### PR TITLE
Enhance accordion block editing experience with contextual outlines

### DIFF
--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -86,5 +86,6 @@
 	},
 	"allowedBlocks": [ "core/accordion-item" ],
 	"textdomain": "default",
+	"editorStyle": "wp-block-accordion-editor",
 	"viewScriptModule": "@wordpress/block-library/accordion/view"
 }

--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -24,6 +24,11 @@ import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
@@ -48,8 +53,42 @@ export default function Edit( {
 } ) {
 	const registry = useRegistry();
 	const { getBlockOrder } = useSelect( blockEditorStore );
+
+	const isInnermostActive = useSelect(
+		( select ) => {
+			const {
+				hasSelectedInnerBlock,
+				getSelectedBlockClientId,
+				getBlockParentsByBlockName,
+			} = select( blockEditorStore );
+
+			if ( ! hasSelectedInnerBlock( clientId, true ) ) {
+				return false;
+			}
+
+			const selectedId = getSelectedBlockClientId();
+			if ( ! selectedId ) {
+				return false;
+			}
+
+			const accordionAncestors = getBlockParentsByBlockName(
+				selectedId,
+				'core/accordion'
+			);
+
+			return (
+				accordionAncestors.length > 0 &&
+				accordionAncestors[ accordionAncestors.length - 1 ] === clientId
+			);
+		},
+		[ clientId ]
+	);
+
 	const blockProps = useBlockProps( {
 		role: 'group',
+		className: clsx( {
+			'is-accordion-editing-active': isInnermostActive,
+		} ),
 	} );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const { updateBlockAttributes, insertBlock } =

--- a/packages/block-library/src/accordion/editor.scss
+++ b/packages/block-library/src/accordion/editor.scss
@@ -1,0 +1,31 @@
+// Editor-only outlines for accordion blocks.
+// Shows contextual sibling awareness when editing inside an accordion.
+
+// Color tokens matching the grid visualizer approach:
+// Uses currentColor with color-mix so outlines adapt to theme context.
+$accordion-outline-color: color-mix(in srgb, currentColor 20%, #0000);
+$accordion-outline-color-faint: color-mix(in srgb, currentColor 10%, #0000);
+
+// When the accordion is the innermost active editing level,
+// show outlines on all accordion items for spatial orientation.
+.wp-block-accordion.is-accordion-editing-active {
+	// All sibling items get a subtle dashed outline.
+	> [data-type="core/accordion-item"]:not(.is-selected) {
+		outline: 1px dashed $accordion-outline-color;
+		outline-offset: -1px;
+	}
+
+	// The item containing the active selection gets a solid outline.
+	> [data-type="core/accordion-item"].has-child-selected {
+		outline: 1px solid $accordion-outline-color;
+		outline-offset: -1px;
+	}
+
+	// Nested structure hint: when the active item contains a nested accordion,
+	// show a faint outline around the nested accordion boundary.
+	> [data-type="core/accordion-item"]:is(.has-child-selected, .is-selected)
+	[data-type="core/accordion"] {
+		outline: 1px dashed $accordion-outline-color-faint;
+		outline-offset: -1px;
+	}
+}

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -1,5 +1,6 @@
 @use "@wordpress/base-styles/mixins" as *;
 @use "./utils/media-control.scss" as *;
+@use "./accordion/editor.scss" as *;
 @use "./audio/editor.scss" as *;
 @use "./avatar/editor.scss" as *;
 @use "./button/editor.scss" as *;


### PR DESCRIPTION
## What?

Adds editor-only outlines to the Accordion block so users can orient within the accordion structure directly on the canvas, without relying on the List View sidebar.

See https://github.com/WordPress/gutenberg/issues/77299

## Why?

When editing inside an Accordion with multiple items, there is no visual indication of the block hierarchy on the canvas. It's difficult to tell which item you're in, or how many siblings exist at the current level. This is especially disorienting with nested accordions. The Grid variation of the Group block already solves this problem for grid layouts with its grid visualizer outlines — the Accordion should offer a similar level of spatial awareness.

## How?

A lightweight "contextual sibling awareness" model using one new CSS class and a small `editor.scss` file:

**JS (`accordion/edit.js`):** A `useSelect` hook determines whether this accordion instance is the *innermost active* one — meaning it contains the selected block and no nested accordion also contains it. Uses the existing `getBlockParentsByBlockName` selector. When active, applies the class `is-accordion-editing-active` to the container.

**CSS (`accordion/editor.scss`):** Three outline layers, all editor-only:
1. **Sibling items** — subtle dashed outline on all items at the active level
2. **Active item** — solid outline on the item containing the selection
3. **Nested hint** — fainter dashed outline around any nested accordion container inside the active item

Colors use `color-mix(in srgb, currentColor %, #0000)` to match the grid visualizer pattern and adapt to theme context.

**Nested accordion behavior:** Only the innermost level the user is working in shows outlines. When clicking deeper into a nested accordion, the outlines shift to that level. Parent levels go quiet.

## Testing Instructions

1. Create a new post or page.
2. Insert an **Accordion** block with 3–4 items. Add some content (paragraphs, headings) to the panels.
3. Click into different items' headings and panel content. Verify:
  - All sibling items show a subtle dashed outline.
  - The item you're editing in shows a solid outline.
  - The selected block itself has the standard blue Gutenberg outline.
4. Select an accordion-item directly (via List View or breadcrumb). Verify:
  - Sibling items show dashed outlines.
  - The selected item shows the blue Gutenberg outline (no doubled outline).
5. Click outside the accordion or select the accordion container itself. Verify all custom outlines disappear.
6. **Nested test:** Inside one item's panel, insert another Accordion block with 2+ items.
  - Edit content at the outer level → the nested accordion shows a faint dashed hint outline.
  - Click into the nested accordion's content → outlines shift to the inner level; outer outlines disappear.
  - Click back to the outer level → outlines shift back.
7. Verify the frontend (View Post) shows no outlines — these are editor-only.

### Testing Instructions for Keyboard

1. Use Tab/Arrow keys to navigate into an accordion item's heading or panel.
2. Verify outlines appear on sibling items as described above.
3. Use the breadcrumb or List View to move between nesting levels and verify outlines shift accordingly.
4. Outlines are purely visual and do not affect focus order or ARIA attributes.

## Screenshots

|Before|After|
|-|-|
|<img width="1465" height="897" alt="accordion-before-1" src="https://github.com/user-attachments/assets/016f9ed1-c89a-4333-8137-16dd68de516a" />|<img width="1465" height="897" alt="accordion-after-1" src="https://github.com/user-attachments/assets/79d4f2bb-5fee-4155-af72-d576f49eb66e" />|
|<img width="1465" height="897" alt="accordion-before-2" src="https://github.com/user-attachments/assets/f94561bf-fa98-41f7-a467-e5ee2d3073da" />|<img width="1465" height="897" alt="accordion-after-2" src="https://github.com/user-attachments/assets/703ab31d-7f7d-436e-baaf-a10102510174" />|
|<img width="1465" height="897" alt="accordion-before-3" src="https://github.com/user-attachments/assets/2fee2276-c35b-4740-906b-172f3c943e7d" />|<img width="1465" height="897" alt="accordion-after-3" src="https://github.com/user-attachments/assets/7a025228-4ead-4236-bc31-e84c43e4a99a" />|
|<img width="1465" height="897" alt="accordion-before-4-sub" src="https://github.com/user-attachments/assets/0fdf2fad-6214-4ff1-a37f-6d4319af7cc3" />|<img width="1465" height="897" alt="accordion-after-4-sub" src="https://github.com/user-attachments/assets/2b5642c1-e011-46aa-85d1-83e7b0b4e1bc" />|

## Use of AI Tools

This PR was authored with assistance from Claude Code (Claude Opus). The implementation plan, code review, and all code changes were reviewed and validated by myself.