### PR TITLE
ui/Tabs: Fix `act()` warnings in tests

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Internal
 
 -   Extract shared `useScheduleValidation` hook; refactor `Dialog`, `Popover`, and `Tabs` validation contexts to use it ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
+-   `Tabs`: Fix non-deterministic `act()` test warnings by wrapping two 50ms validation waits in `act(...)` so Base UI transition updates settle inside React's act boundary ([#77319](https://github.com/WordPress/gutenberg/pull/77319)).
 
 ## 0.11.0 (2026-04-15)
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Internal
 
 -   Extract shared `useScheduleValidation` hook; refactor `Dialog`, `Popover`, and `Tabs` validation contexts to use it ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
--   `Tabs`: Fix non-deterministic `act()` test warnings by wrapping two 50ms validation waits in `act(...)` so Base UI transition updates settle inside React's act boundary ([#77319](https://github.com/WordPress/gutenberg/pull/77319)).
+-   `Tabs`: Wrap two validation timeout waits in `act(...)` to avoid intermittent test warnings ([#77319](https://github.com/WordPress/gutenberg/pull/77319)).
 
 ## 0.11.0 (2026-04-15)
 

--- a/packages/ui/src/tabs/test/index.test.tsx
+++ b/packages/ui/src/tabs/test/index.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jest/no-conditional-expect */
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { useEffect, useState, createRef } from '@wordpress/element';
@@ -2344,7 +2344,9 @@ describe( 'Tabs', () => {
 			await waitForComponentToBeInitializedWithSelectedTab( 'One' );
 
 			// Wait a bit to ensure validation has run
-			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			await act(
+				() => new Promise( ( resolve ) => setTimeout( resolve, 50 ) )
+			);
 
 			expect( errors ).toHaveLength( 0 );
 
@@ -2391,7 +2393,9 @@ describe( 'Tabs', () => {
 			await waitForComponentToBeInitializedWithSelectedTab( 'One' );
 
 			// Wait for validation
-			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			await act(
+				() => new Promise( ( resolve ) => setTimeout( resolve, 50 ) )
+			);
 
 			// No errors since counts match
 			expect( errors ).toHaveLength( 0 );


### PR DESCRIPTION
## What?

Fixes non-deterministic `act()` warnings in the `@wordpress/ui` Tabs test suite.

## Why?

The warnings were caused by two validation tests that waited `50ms` via `setTimeout` outside of `act(...)`:

```js
await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
```

During those waits, Base UI transition updates scheduled via `requestAnimationFrame` could fire outside React's act boundary, intermittently producing warnings.

## How?

Use a targeted fix by wrapping only those two validation waits in `act(...)`:

```js
await act( () => new Promise( ( resolve ) => setTimeout( resolve, 50 ) ) );
```

This keeps the existing test structure intact, avoids suite-wide act-environment suppression, and removes warnings where they actually originate.

Also updates `packages/ui/CHANGELOG.md` in the current Unreleased section.

## Testing Instructions

```bash
npm run test:unit -- --testPathPattern='packages/ui/src/tabs' --no-coverage
```

Verify:
1. All 55 tests pass
2. No `act()` warnings in output

## Use of AI Tools

This PR was authored with the assistance of an AI coding agent (Claude) in Cursor IDE.

Made with [Cursor](https://cursor.com)