### PR TITLE
Tabs: remove sequential numbering from new tab labels

### DIFF
--- a/packages/block-library/src/tab/add-tab-toolbar-control.js
+++ b/packages/block-library/src/tab/add-tab-toolbar-control.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { sprintf, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 import {
 	BlockControls,
@@ -22,13 +22,12 @@ import { useDispatch, useSelect } from '@wordpress/data';
 export default function AddTabToolbarControl( { tabsClientId } ) {
 	const { insertBlock } = useDispatch( blockEditorStore );
 
-	const { tabPanelClientId, tabsMenuClientId, tabCount } = useSelect(
+	const { tabPanelClientId, tabsMenuClientId } = useSelect(
 		( select ) => {
 			if ( ! tabsClientId ) {
 				return {
 					tabPanelClientId: null,
 					tabsMenuClientId: null,
-					tabCount: 0,
 				};
 			}
 			const { getBlocks } = select( blockEditorStore );
@@ -42,7 +41,6 @@ export default function AddTabToolbarControl( { tabsClientId } ) {
 			return {
 				tabPanelClientId: tabPanel?.clientId || null,
 				tabsMenuClientId: tabsMenu?.clientId || null,
-				tabCount: tabPanel?.innerBlocks?.length || 0,
 			};
 		},
 		[ tabsClientId ]
@@ -53,11 +51,7 @@ export default function AddTabToolbarControl( { tabsClientId } ) {
 			return;
 		}
 
-		const newTabBlock = createBlock( 'core/tab', {
-			/* translators: %d: tab number */
-			label: sprintf( __( 'Tab %d' ), tabCount + 1 ),
-		} );
-		insertBlock( newTabBlock, undefined, tabPanelClientId );
+		insertBlock( createBlock( 'core/tab' ), undefined, tabPanelClientId );
 
 		// Insert a corresponding menu item into the tabs-menu.
 		if ( tabsMenuClientId ) {

--- a/packages/block-library/src/tab/add-tab-toolbar-control.js
+++ b/packages/block-library/src/tab/add-tab-toolbar-control.js
@@ -51,7 +51,10 @@ export default function AddTabToolbarControl( { tabsClientId } ) {
 			return;
 		}
 
-		insertBlock( createBlock( 'core/tab' ), undefined, tabPanelClientId );
+		const newTabBlock = createBlock( 'core/tab', {
+			label: __( 'Tab' ),
+		} );
+		insertBlock( newTabBlock, undefined, tabPanelClientId );
 
 		// Insert a corresponding menu item into the tabs-menu.
 		if ( tabsMenuClientId ) {

--- a/packages/block-library/src/tabs-menu-item/edit.js
+++ b/packages/block-library/src/tabs-menu-item/edit.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	useBlockProps,
 	store as blockEditorStore,
@@ -138,11 +138,7 @@ function Edit( {
 				<RichText
 					tagName="span"
 					withoutInteractiveFormatting
-					placeholder={ sprintf(
-						/* translators: %d is the tab index + 1 */
-						__( 'Tab title %d' ),
-						menuItemIndex + 1
-					) }
+					placeholder={ __( 'Tab title' ) }
 					value={ label }
 					onChange={ handleLabelChange }
 				/>

--- a/packages/block-library/src/tabs/edit.js
+++ b/packages/block-library/src/tabs/edit.js
@@ -9,6 +9,7 @@ import {
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo, useEffect, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -41,14 +42,14 @@ const TABS_TEMPLATE = [
 			[
 				'core/tab',
 				{
-					label: 'Tab 1',
+					label: __( 'Tab' ),
 				},
 				[ [ 'core/paragraph' ] ],
 			],
 			[
 				'core/tab',
 				{
-					label: 'Tab 2',
+					label: __( 'Tab' ),
 				},
 				[ [ 'core/paragraph' ] ],
 			],


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/77189#issuecomment-4238290330

## What?

Removes the logic that auto-assigns sequential numbers (e.g. `Tab 1`, `Tab 2`) when new tabs are added to the Tabs block, including the numbered placeholder on the tabs-menu-item.

## Why?

Unfortunately, the current tab number increment does not work in several scenarios. For example,

1. Inset a Tabs block: `Tab 1` and `Tab 2`
2. Add a new Tab: `Tab 1`, `Tab 2`, and `Tab 3`
3. Remove the second tab: `Tab 1` and `Tab 3`
4. Insert a new Tab: `Tab 1`, `Tab 3`, and `Tab 3`

To solve this problem, I will avoid adding the number itself to the tab. The tab text can be freely modified by the user, and it is unlikely that many users will use the automatically generated tab text.

## Testing Instructions

1. Insert a Tabs block into a new post.
6. Confirm the two initial tabs are labelled `Tab`.
7. Use the block toolbar's "Add tab" button several times and confirm each newly added tab is labelled `Tab`
8. If you clear the tab text, the placeholder "Tab title" will be displayed.

## Screenshots or screencast

| Before | After |
|--------|--------|
| <img width="534" height="221" alt="image" src="https://github.com/user-attachments/assets/666551d7-5f9c-4848-a5d0-c510c752e2bd" /> | <img width="487" height="220" alt="image" src="https://github.com/user-attachments/assets/fa534a44-e35c-4536-ab53-b31090d553bb" /> | 


## Use of AI Tools

This PR was drafted with the assistance of Claude Code (Anthropic). All changes were reviewed and verified by the author before submission.
