### PR TITLE
Block Editor: Add useBlockStyle hook and refactor style panels to use it

### DIFF
--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -16,6 +16,7 @@ import { useCallback } from '@wordpress/element';
 import InspectorControls from '../components/inspector-controls';
 import { cleanEmptyObject } from './utils';
 import { store as blockEditorStore } from '../store';
+import { useBlockStyle } from './use-block-style';
 import {
 	default as StylesBackgroundPanel,
 	useHasBackgroundPanel,
@@ -164,14 +165,13 @@ export function BackgroundImagePanel( {
 	setAttributes,
 	settings,
 } ) {
-	const { style, className, inheritedValue } = useSelect(
+	const { className, inheritedValue } = useSelect(
 		( select ) => {
 			const { getBlockAttributes, getSettings } =
 				select( blockEditorStore );
 			const _settings = getSettings();
 			const blockAttributes = getBlockAttributes( clientId );
 			return {
-				style: blockAttributes?.style,
 				className: blockAttributes?.className,
 				/*
 				 * To ensure we pass down the right inherited values:
@@ -186,6 +186,7 @@ export function BackgroundImagePanel( {
 		},
 		[ clientId, name ]
 	);
+	const [ style ] = useBlockStyle( null );
 
 	const backgroundGradientSupported = hasBackgroundSupport(
 		name,

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -30,6 +30,7 @@ import {
 } from '../components/global-styles';
 import { store as blockEditorStore } from '../store';
 import { __ } from '@wordpress/i18n';
+import { useBlockStyle } from './use-block-style';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
 export const SHADOW_SUPPORT_KEY = 'shadow';
@@ -142,18 +143,19 @@ function BordersInspectorControl( { label, children, resetAllFilter } ) {
 
 export function BorderPanel( { clientId, name, setAttributes, settings } ) {
 	const isEnabled = useHasBorderPanel( settings );
-	const { style, borderColor } = useSelect(
+	const { borderColor } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
 			if ( ! isEnabled ) {
 				return {};
 			}
-			const { style: _style, borderColor: _borderColor } =
+			const { borderColor: _borderColor } =
 				select( blockEditorStore ).getBlockAttributes( clientId ) || {};
-			return { style: _style, borderColor: _borderColor };
+			return { borderColor: _borderColor };
 		},
 		[ clientId, isEnabled ]
 	);
+	const [ style ] = useBlockStyle( null );
 	const value = useMemo( () => {
 		return attributesToStyle( { style, borderColor } );
 	}, [ style, borderColor ] );

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -33,6 +33,7 @@ import {
 } from '../components/global-styles/color-panel';
 import BlockColorContrastChecker from './contrast-checker';
 import { store as blockEditorStore } from '../store';
+import { useBlockStyle } from './use-block-style';
 
 export const COLOR_SUPPORT_KEY = 'color';
 
@@ -271,20 +272,18 @@ export function ColorEdit( {
 } ) {
 	const isEnabled = useHasColorPanel( settings );
 
-	const { style, textColor, backgroundColor, gradient } = useSelect(
+	const { textColor, backgroundColor, gradient } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
 			if ( ! isEnabled ) {
 				return {};
 			}
 			const {
-				style: _style,
 				textColor: _textColor,
 				backgroundColor: _backgroundColor,
 				gradient: _gradient,
 			} = select( blockEditorStore ).getBlockAttributes( clientId ) || {};
 			return {
-				style: _style,
 				textColor: _textColor,
 				backgroundColor: _backgroundColor,
 				gradient: _gradient,
@@ -292,6 +291,7 @@ export function ColorEdit( {
 		},
 		[ clientId, isEnabled ]
 	);
+	const [ style ] = useBlockStyle( null );
 	const value = useMemo( () => {
 		return attributesToStyle( {
 			style,

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { Platform, useState, useEffect, useCallback } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { getBlockSupport } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
 
@@ -22,7 +22,8 @@ import {
 import { MarginVisualizer, PaddingVisualizer } from './spacing-visualizer';
 import { store as blockEditorStore } from '../store';
 import { unlock } from '../lock-unlock';
-import { cleanEmptyObject, shouldSkipSerialization } from './utils';
+import { shouldSkipSerialization } from './utils';
+import { useBlockStyle } from './use-block-style';
 
 export const DIMENSIONS_SUPPORT_KEY = 'dimensions';
 export const SPACING_SUPPORT_KEY = 'spacing';
@@ -68,26 +69,10 @@ function DimensionsInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
+export function DimensionsPanel( { clientId, name, settings } ) {
 	const isEnabled = useHasDimensionsPanel( settings );
-	const value = useSelect(
-		( select ) => {
-			// Early return to avoid subscription when disabled
-			if ( ! isEnabled ) {
-				return undefined;
-			}
-			return select( blockEditorStore ).getBlockAttributes( clientId )
-				?.style;
-		},
-		[ clientId, isEnabled ]
-	);
-
 	const [ visualizedProperty, setVisualizedProperty ] = useVisualizer();
-	const onChange = ( newStyle ) => {
-		setAttributes( {
-			style: cleanEmptyObject( newStyle ),
-		} );
-	};
+	const [ value, onChange ] = useBlockStyle( null );
 
 	if ( ! isEnabled ) {
 		return null;

--- a/packages/block-editor/src/hooks/test/use-block-style.js
+++ b/packages/block-editor/src/hooks/test/use-block-style.js
@@ -1,0 +1,198 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { createElement } from '@wordpress/element';
+import {
+	createBlock,
+	registerBlockType,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+import { dispatch, select } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { useBlockStyle } from '../use-block-style';
+import { BlockEditContextProvider } from '../../components/block-edit/context';
+
+describe( 'useBlockStyle', () => {
+	beforeAll( () => {
+		registerBlockType( 'test/style-block', {
+			apiVersion: 3,
+			title: 'Style Block',
+			category: 'text',
+			attributes: {
+				style: { type: 'object' },
+			},
+			edit: () => null,
+			save: () => null,
+		} );
+	} );
+
+	afterAll( async () => {
+		unregisterBlockType( 'test/style-block' );
+		await act( async () => {
+			await dispatch( blockEditorStore ).resetBlocks( [] );
+		} );
+	} );
+
+	let clientId;
+	beforeEach( async () => {
+		const block = createBlock( 'test/style-block', {
+			style: {
+				color: { text: '#000000' },
+				':hover': { color: { text: '#ff0000' } },
+			},
+		} );
+		await act( async () => {
+			await dispatch( blockEditorStore ).resetBlocks( [ block ] );
+		} );
+		clientId = block.clientId;
+	} );
+
+	afterEach( async () => {
+		await act( async () => {
+			await dispatch( blockEditorStore ).resetBlocks( [] );
+		} );
+	} );
+
+	function makeWrapper( id ) {
+		return function Wrapper( { children } ) {
+			return createElement(
+				BlockEditContextProvider,
+				{
+					value: {
+						clientId: id,
+						name: 'test/style-block',
+						isSelected: true,
+					},
+				},
+				children
+			);
+		};
+	}
+
+	describe( 'reading values', () => {
+		it( 'reads a value from the default state via dot-notation path', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toBe( '#000000' );
+		} );
+
+		it( 'reads a value from the default state via array path', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( [ 'color', 'text' ] ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toBe( '#000000' );
+		} );
+
+		it( 'treats state "default" the same as no state', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', 'default' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toBe( '#000000' );
+		} );
+
+		it( 'reads a value scoped to a pseudo-state via dot-notation path', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', ':hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toBe( '#ff0000' );
+		} );
+
+		it( 'reads the full state sub-object when path is null', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( null, ':hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toEqual( {
+				color: { text: '#ff0000' },
+			} );
+		} );
+	} );
+
+	describe( 'writing values', () => {
+		it( 'writes a value to the default state without affecting pseudo-state styles', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			act( () => {
+				result.current[ 1 ]( '#ffffff' );
+			} );
+
+			const { style } =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			expect( style.color.text ).toBe( '#ffffff' );
+			expect( style[ ':hover' ].color.text ).toBe( '#ff0000' );
+		} );
+
+		it( 'writes a value to a pseudo-state without affecting the default state', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', ':hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			act( () => {
+				result.current[ 1 ]( '#0000ff' );
+			} );
+
+			const { style } =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			expect( style[ ':hover' ].color.text ).toBe( '#0000ff' );
+			expect( style.color.text ).toBe( '#000000' );
+		} );
+
+		it( 'replaces the full state sub-object when path is null', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( null, ':hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			act( () => {
+				result.current[ 1 ]( { color: { text: '#0000ff' } } );
+			} );
+
+			const { style } =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			expect( style[ ':hover' ] ).toEqual( {
+				color: { text: '#0000ff' },
+			} );
+			expect( style.color.text ).toBe( '#000000' );
+		} );
+
+		it( 'removes the state key when the last value inside it is cleared', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', ':hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			act( () => {
+				result.current[ 1 ]( undefined );
+			} );
+
+			const { style } =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			expect( style[ ':hover' ] ).toBeUndefined();
+			// Default-state styles must be left intact.
+			expect( style.color.text ).toBe( '#000000' );
+		} );
+	} );
+} );

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -21,6 +21,7 @@ import { TEXT_ALIGN_SUPPORT_KEY } from './text-align';
 import { FIT_TEXT_SUPPORT_KEY } from './fit-text';
 import { cleanEmptyObject } from './utils';
 import { store as blockEditorStore } from '../store';
+import { useBlockStyle } from './use-block-style';
 
 function omit( object, keys ) {
 	return Object.fromEntries(
@@ -119,20 +120,18 @@ function TypographyInspectorControl( { children, resetAllFilter } ) {
 export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
 	const isEnabled = useHasTypographyPanel( settings );
 
-	const { style, fontFamily, fontSize, fitText } = useSelect(
+	const { fontFamily, fontSize, fitText } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled.
 			if ( ! isEnabled ) {
 				return {};
 			}
 			const {
-				style: _style,
 				fontFamily: _fontFamily,
 				fontSize: _fontSize,
 				fitText: _fitText,
 			} = select( blockEditorStore ).getBlockAttributes( clientId ) || {};
 			return {
-				style: _style,
 				fontFamily: _fontFamily,
 				fontSize: _fontSize,
 				fitText: _fitText,
@@ -140,6 +139,7 @@ export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
 		},
 		[ clientId, isEnabled ]
 	);
+	const [ style ] = useBlockStyle( null );
 	const value = useMemo(
 		() => attributesToStyle( { style, fontFamily, fontSize } ),
 		[ style, fontSize, fontFamily ]

--- a/packages/block-editor/src/hooks/use-block-style.js
+++ b/packages/block-editor/src/hooks/use-block-style.js
@@ -1,0 +1,85 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useMemo } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useBlockEditContext } from '../components/block-edit/context';
+import { store as blockEditorStore } from '../store';
+import { getValueFromObjectPath, setImmutably } from '../utils/object';
+import { cleanEmptyObject } from './utils';
+
+/**
+ * Returns a `[value, setter]` pair for a path within a block's `style`
+ * attribute. Works like `useStyle` in Global Styles but reads from the
+ * current block instance's attributes instead of `theme.json`.
+ *
+ * Path uses dot notation into the style object, e.g. `'color'` or
+ * `'typography.fontSize'`. Pass a separate `state` argument to scope to a
+ * pseudo-state or custom state — the state key becomes the first segment of
+ * the storage path:
+ *
+ *   `useBlockStyle( 'color', ':hover' )`       — `style[':hover'].color`
+ *   `useBlockStyle( 'color', '@current' )`     — `style['@current'].color`
+ *   `useBlockStyle( 'color', ':hover:focus' )` — compound state
+ *
+ * Omit `path` (or pass `null`) to read and write the full style object for
+ * that state context, e.g. `useBlockStyle( null, ':hover' )` returns the
+ * entire `style[':hover']` sub-object.
+ *
+ * Keeping state separate from the path means no heuristic is needed to
+ * distinguish state keys from style property names, regardless of the
+ * state format convention used.
+ *
+ * @param {string|string[]|null} path  Dot-separated path into the `style` object, or `null` for the root.
+ * @param {string}               state Optional state key, e.g. `':hover'` or `'@current'`. Omit or pass `'default'` for base styles.
+ * @return {[*, Function]} Tuple of `[currentValue, setValue]`.
+ */
+export function useBlockStyle( path, state ) {
+	const { clientId } = useBlockEditContext();
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const style = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockAttributes( clientId )?.style,
+		[ clientId ]
+	);
+
+	const pathArray = useMemo( () => {
+		let stylePath;
+		if ( ! path ) {
+			stylePath = [];
+		} else if ( Array.isArray( path ) ) {
+			stylePath = path;
+		} else {
+			stylePath = path.split( '.' );
+		}
+		return state && state !== 'default'
+			? [ state, ...stylePath ]
+			: stylePath;
+	}, [ path, state ] );
+
+	const value = useMemo(
+		() => getValueFromObjectPath( style, pathArray ),
+		[ style, pathArray ]
+	);
+
+	const setValue = useCallback(
+		( newValue ) => {
+			// Empty path means the caller wants to replace the style root (or
+			// the full state sub-object) wholesale rather than a nested key.
+			const newStyle = pathArray.length
+				? setImmutably( style ?? {}, pathArray, newValue )
+				: newValue;
+			updateBlockAttributes( clientId, {
+				style: cleanEmptyObject( newStyle ),
+			} );
+		},
+		[ updateBlockAttributes, clientId, style, pathArray ]
+	);
+
+	return [ value, setValue ];
+}


### PR DESCRIPTION
## Summary
- Introduces a `useBlockStyle(path, state)` hook that provides a `[value, setter]` pair for reading/writing a block's `style` attribute, centralizing a pattern currently duplicated across all style panels
- Refactors `ColorEdit`, `TypographyPanel`, `BorderPanel`, `DimensionsPanel`, and `BackgroundImagePanel` to read `style` via `useBlockStyle(null)` instead of inline `useSelect` calls

This is a pure refactor with no behavioral change — all panels still operate on the default state. The hook's `state` parameter lays groundwork for per-instance interactive state support (e.g. `:hover`).

Based on @MaggieCabrera's work in https://github.com/WordPress/gutenberg/pull/76491

## Test plan
- [ ] Verify all style panels (Color, Typography, Border, Dimensions, Background) continue to work as before
- [ ] Run JS unit tests: `npx wp-scripts test-unit-js --no-coverage --testPathPattern='use-block-style'`
- [ ] Confirm no regressions in block style editing across block types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>