### PR TITLE
[WP 7.0] Fix failing 'WP_HTTP_Polling_Sync_Server' unit test

### DIFF
--- a/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
@@ -222,7 +222,7 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 				foreach ( $existing_awareness as $entry ) {
 					if ( $client_id === $entry['client_id'] && $wp_user_id !== $entry['wp_user_id'] ) {
 						return new WP_Error(
-							'forbidden',
+							'rest_cannot_edit',
 							__( 'Client ID is already in use by another user.', 'gutenberg' ),
 							array( 'status' => 403 )
 						);


### PR DESCRIPTION
## What?
Backport of #77025 to the `wp/7.0` branch.

## Why?

Since #76987 was merged into the `wp/7.0` branch, unit tests have been failing.

```
There was 1 failure:

1) Tests_Collaboration_WpHttpPollingSyncServer::test_sync_awareness_client_id_cannot_be_used_by_another_user
The expected error code does not match.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'rest_cannot_edit'
+'forbidden'
```

I believe we need to backport #77025, which resolved this issue, as well.

## Testing Instructions

All unit tests should be ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)