### PR TITLE
Externalize react-dom/client

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -41,6 +41,7 @@ function defaultRequestToExternal( request ) {
 			return 'React';
 
 		case 'react-dom':
+		case 'react-dom/client':
 			return 'ReactDOM';
 
 		case 'react/jsx-runtime':
@@ -122,6 +123,9 @@ function defaultRequestToHandle( request ) {
 
 		case 'lodash-es':
 			return 'lodash';
+
+		case 'react-dom/client':
+			return 'react-dom';
 
 		case 'react/jsx-runtime':
 			return 'react-jsx-runtime';

--- a/packages/dependency-extraction-webpack-plugin/test/util.js
+++ b/packages/dependency-extraction-webpack-plugin/test/util.js
@@ -47,6 +47,20 @@ describe( 'defaultRequestToExternal', () => {
 			defaultRequestToExternal( '@wordpress/some-future-package' )
 		).toEqual( [ 'wp', 'someFuturePackage' ] );
 	} );
+
+	test( 'Handles react request', () => {
+		expect( defaultRequestToExternal( 'react' ) ).toBe( 'React' );
+	} );
+
+	test( 'Handles react-dom request', () => {
+		expect( defaultRequestToExternal( 'react-dom' ) ).toBe( 'ReactDOM' );
+	} );
+
+	test( 'Handles react-dom/client request', () => {
+		expect( defaultRequestToExternal( 'react-dom/client' ) ).toBe(
+			'ReactDOM'
+		);
+	} );
 } );
 
 describe( 'defaultRequestToHandle', () => {
@@ -62,5 +76,19 @@ describe( 'defaultRequestToHandle', () => {
 		expect(
 			defaultRequestToHandle( '@wordpress/some-future-package' )
 		).toBe( 'wp-some-future-package' );
+	} );
+
+	test( 'Handles react request', () => {
+		expect( defaultRequestToHandle( 'react' ) ).toBeUndefined();
+	} );
+
+	test( 'Handles react-dom request', () => {
+		expect( defaultRequestToHandle( 'react-dom' ) ).toBeUndefined();
+	} );
+
+	test( 'Handles react-dom/client request', () => {
+		expect( defaultRequestToHandle( 'react-dom/client' ) ).toBe(
+			'react-dom'
+		);
 	} );
 } );

--- a/packages/wp-build/lib/wordpress-externals-plugin.mjs
+++ b/packages/wp-build/lib/wordpress-externals-plugin.mjs
@@ -125,6 +125,10 @@ export function createWordpressExternalsPlugin(
 				const vendorExternals = {
 					react: { global: 'React', handle: 'react' },
 					'react-dom': { global: 'ReactDOM', handle: 'react-dom' },
+					'react-dom/client': {
+						global: 'ReactDOM',
+						handle: 'react-dom',
+					},
 					'react/jsx-runtime': {
 						global: 'ReactJSXRuntime',
 						handle: 'react-jsx-runtime',


### PR DESCRIPTION
Updates the externalization code (both webpack and esbuild) to also externalize `react-dom/client` imports to refer to the `react-dom` script handle, i.e., the `window.ReactDOM` global.

This continues the work done in #76825, streamlining the `react-dom` library and preparing it for React 19 upgrade. In React 18 and older, `react-dom` always exported `createRoot` and `hydrateRoot` and the `react-dom/client` was just a trivial re-export handler. In React 19, `react-dom/client` is a big standalone library which would be directly bundled inside `wp-element` if we didn't do this externalization. And `react-dom` is a tiny library of univeral (both server and client) helpers.

**How to test:** verify that:
- in dev mode, the "You are importing `createRoot` from `react-dom`" console warnings are still not there, i.e., we're not regressing the fixes from #76825.
- the `wp-element` script is smaller, because it no longer bundles the `react-dom/client` code. In `trunk` with React 18 the size difference is small, in React 19 it would be massive (try with #61521 if you're really curious).
