### PR TITLE
Tests: stabilize splitting-merging flaky assertion

### DIFF
--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -135,9 +135,7 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 		await page.keyboard.type( 'Still Second' );
 
 		// Check the content.
-
-		const content = await editor.getEditedPostContent();
-		expect( content ).toBe(
+		await expect.poll( editor.getEditedPostContent ).toBe(
 			`<!-- wp:paragraph -->
 <p>First</p>
 <!-- /wp:paragraph -->


### PR DESCRIPTION
## What?
Related to  #77310

Stabilizes the flaky e2e test `should delete an empty first line` in splitting-merging.spec.js by switching its final content assertion to `expect.poll`.

## Why?
Issue #77310 is an auto-generated flaky test report. The test occasionally fails because editor state updates can be asynchronous right after keyboard interactions (`Enter` / `Shift+Enter` / `Backspace` / typing). A single immediate content read can race with state settling.

Using `expect.poll` makes the assertion resilient to those transient timing differences while preserving the original behavior expectation.

## How?
Updated one assertion in splitting-merging.spec.js:

- Replaced:
`const content = await editor.getEditedPostContent(); expect( content ).toBe( ... )`
- With:
`await expect.poll( editor.getEditedPostContent ).toBe( ... )`

No behavior or expected output was changed; only assertion timing strategy was adjusted.

## Testing Instructions
1. Ensure test environment dependencies are available.
2. Run the targeted spec:
   `npm run test:e2e -- test/e2e/specs/editor/various/splitting-merging.spec.js`
3. Confirm `should delete an empty first line` passes.
4. Re-run the same command a few times to verify improved stability.
5. Optional: run the broader file/group in CI or locally to confirm no regressions.

### Testing Instructions for Keyboard
1. Run:
   `npm run test:e2e -- test/e2e/specs/editor/various/splitting-merging.spec.js`
2. Confirm the keyboard-driven scenario in `should delete an empty first line` passes consistently:
   - `Enter`
   - `Shift+Enter`
   - `Backspace`
   - type `Still Second`
3. Re-run multiple times and verify no intermittent failure in this test.

## Screenshots or screencast

|Before|After|
|-|-|
|Intermittent failure due to immediate assertion after async editor updates.|Assertion waits for settled editor state using `expect.poll`, reducing flakiness.|

## Use of AI Tools
I used GitHub Copilot (GPT-5.3-Codex) to help draft the patch and PR description. I reviewed the code changes and final PR content before submission.