### PR TITLE
UI: use Text in Notice.ActionLink typography

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -36,6 +36,7 @@
 -   `AlertDialog`: Rewrite internals to use Base UI's `AlertDialog` primitives directly instead of `Dialog` wrappers. Introduces an internal state machine for async confirm flows ([#76937](https://github.com/WordPress/gutenberg/pull/76937)).
 -   `Field.Label`, `Fieldset.Legend`, `Field.Details`: Refactor `VisuallyHidden` composition to preserve semantic HTML elements when visually hiding content.
 -   `Badge`: Use `Text` component for typography ([#77295](https://github.com/WordPress/gutenberg/pull/77295)).
+-   `Notice.ActionLink`: Use `Text` component for typography ([#77332](https://github.com/WordPress/gutenberg/pull/77332)).
 -   Update `@base-ui/react` from `1.3.0` to `1.4.0` ([#77308](https://github.com/WordPress/gutenberg/pull/77308)).
 
 ## 0.10.0 (2026-04-01)

--- a/packages/ui/src/notice/action-link.tsx
+++ b/packages/ui/src/notice/action-link.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { Link } from '../link';
+import { Text } from '../text';
 import type { ActionLinkProps } from './types';
 import styles from './style.module.css';
 
@@ -10,12 +11,12 @@ import styles from './style.module.css';
 export const ActionLink = forwardRef< HTMLAnchorElement, ActionLinkProps >(
 	function NoticeActionLink( { className, ...props }, ref ) {
 		return (
-			<Link
+			<Text
+				variant="body-md"
+				render={ <Link tone="neutral" variant="default" /> }
 				ref={ ref }
 				className={ clsx( styles[ 'action-link' ], className ) }
 				{ ...props }
-				tone="neutral"
-				variant="default"
 			/>
 		);
 	}

--- a/packages/ui/src/notice/action-link.tsx
+++ b/packages/ui/src/notice/action-link.tsx
@@ -12,11 +12,11 @@ export const ActionLink = forwardRef< HTMLAnchorElement, ActionLinkProps >(
 	function NoticeActionLink( { className, ...props }, ref ) {
 		return (
 			<Text
-				variant="body-md"
-				render={ <Link tone="neutral" variant="default" /> }
 				ref={ ref }
 				className={ clsx( styles[ 'action-link' ], className ) }
 				{ ...props }
+				variant="body-md"
+				render={ <Link tone="neutral" variant="default" /> }
 			/>
 		);
 	}

--- a/packages/ui/src/notice/action-link.tsx
+++ b/packages/ui/src/notice/action-link.tsx
@@ -9,14 +9,16 @@ import styles from './style.module.css';
  * An action link for use within Notice.Actions.
  */
 export const ActionLink = forwardRef< HTMLAnchorElement, ActionLinkProps >(
-	function NoticeActionLink( { className, ...props }, ref ) {
+	function NoticeActionLink( { className, render, ...props }, ref ) {
 		return (
 			<Text
 				ref={ ref }
 				className={ clsx( styles[ 'action-link' ], className ) }
 				{ ...props }
 				variant="body-md"
-				render={ <Link tone="neutral" variant="default" /> }
+				render={
+					<Link tone="neutral" variant="default" render={ render } />
+				}
 			/>
 		);
 	}

--- a/packages/ui/src/notice/style.module.css
+++ b/packages/ui/src/notice/style.module.css
@@ -64,7 +64,6 @@
 
 	.action-link {
 		flex-shrink: 0;
-		margin-block: auto;
 
 		/* Add more horizontal space when following another action link/button */
 		&:not(:first-child) {
@@ -121,6 +120,11 @@
 }
 
 @layer wp-ui-compositions {
+	/* Override `Text` margin */
+	.action-link {
+		margin-block: auto;
+	}
+
 	/* Add partial transparency to CloseIcon and outline/minimal ActionButton
 	 * for a better look over tinted backgrounds */
 	.close-icon,

--- a/packages/ui/src/notice/style.module.css
+++ b/packages/ui/src/notice/style.module.css
@@ -64,10 +64,6 @@
 
 	.action-link {
 		flex-shrink: 0;
-		font-family: var(--wpds-typography-font-family-body);
-		font-size: var(--wpds-typography-font-size-md);
-		font-weight: var(--wpds-typography-font-weight-regular);
-		line-height: var(--wpds-typography-line-height-sm);
 		margin-block: auto;
 
 		/* Add more horizontal space when following another action link/button */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #76929

Updates `Notice.ActionLink` in `@wordpress/ui` to use the 'Text` component for typography instead of ad hoc typography CSS tokens.

## Why?
This follows the design system direction in #76929 to standardize typography via `Text` variants. For `Notice.ActionLink`, the target pairing is an exact match to `body-md`.

## How?
Refactored `Notice.ActionLink` to compose:
- `Text` with `variant="body-md"`
- `render={ <Link tone="neutral" variant="default" /> }`

Removed direct typography declarations from `.action-link` styles in `style.module.css`


## Testing Instructions
1. Run focused unit tests: `npm run test:unit -- packages/ui/src/notice/test/index.test.tsx`
2. Verify in Storybook: `npm run storybook:dev`.


## Use of AI Tools
Used Claude AI to help draft the PR description and assist with review.