### PR TITLE
UI/Dialog: add explicit `margin-inline-end` rule to Title

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Enhancements
 
--   `Dialog`: Update `Header` layout to support multiple trailing elements alongside the title ([#77161](https://github.com/WordPress/gutenberg/pull/77161)).
+-   `Dialog`: Update `Header` layout to support multiple trailing elements alongside the title ([#77161](https://github.com/WordPress/gutenberg/pull/77161), [#77334](https://github.com/WordPress/gutenberg/pull/77334)).
 -   `Dialog`: Use `Text` internally for `Dialog.Title`, adopting the `heading-xl` variant for consistent typography ([#77161](https://github.com/WordPress/gutenberg/pull/77161)).
 -   `Dialog`, `AlertDialog`, `Tooltip`, `Select`: Add `container` prop to `Popup` for custom portal targets ([#77163](https://github.com/WordPress/gutenberg/pull/77163)).
 -   Add defensive styles against global WordPress stylesheets like common.css and forms.css ([#76783](https://github.com/WordPress/gutenberg/pull/76783)).

--- a/packages/ui/src/dialog/style.module.css
+++ b/packages/ui/src/dialog/style.module.css
@@ -98,7 +98,10 @@
 	}
 
 	.title {
-		/* Workaround the higher specificity of the global CSS defense styles */
+		margin-inline-end: auto;
+
+		/* Workaround: the GCD shorthand `margin` overrides the longhand above.
+		 * Keep both so the layout survives GCD removal. */
 		--_gcd-heading-margin: 0 auto 0 0;
 
 		&:dir(rtl) {


### PR DESCRIPTION
## What?

Follow-up to #77161, addressing [review feedback](https://github.com/WordPress/gutenberg/pull/77161#discussion_r2043660282).

Adds a direct `margin-inline-end: auto` CSS rule to `Dialog.Title` so the header flex layout works independently of global CSS defense (GCD) styles.

## Why?

The `.title` class currently relies solely on the `--_gcd-heading-margin` CSS variable to push trailing header elements to the end. Once the GCD layer is eventually removed, there would be no `margin-inline-end` rule, breaking the header layout.

## How?

Adds `margin-inline-end: auto` alongside the existing `--_gcd-heading-margin` workaround. While GCD is active, its shorthand `margin` overrides the longhand — so the variable is still needed. Once GCD is removed, the direct rule takes over.

## Testing Instructions

1. Open a story or test page that renders a `Dialog` with a title and a close button (or other trailing elements) in the header.
2. Verify the title is pushed to the start and trailing elements sit at the end of the header row.
3. Verify the same in RTL mode.

## Use of AI Tools

Cursor + Claude Opus 4.6