### PR TITLE
Update the AI plugin settings page slug we link to after activation

### DIFF
--- a/routes/connectors-home/ai-plugin-callout.tsx
+++ b/routes/connectors-home/ai-plugin-callout.tsx
@@ -23,6 +23,7 @@ import { WpLogoDecoration } from './wp-logo-decoration';
 import type { PluginStatus } from './use-connector-plugin';
 
 const AI_PLUGIN_SLUG = 'ai';
+const AI_PLUGIN_PAGE_SLUG = 'ai-wp-admin';
 const AI_PLUGIN_ID = 'ai/ai';
 const AI_PLUGIN_URL = 'https://wordpress.org/plugins/ai/';
 
@@ -278,7 +279,7 @@ export function AiPluginCallout() {
 						variant="secondary"
 						size="compact"
 						href={ addQueryArgs( 'options-general.php', {
-							page: AI_PLUGIN_SLUG,
+							page: AI_PLUGIN_PAGE_SLUG,
 						} ) }
 					>
 						{ __( 'Control features in the AI plugin' ) }


### PR DESCRIPTION
## What?

Closes #77337
See also https://core.trac.wordpress.org/ticket/65073

Ensure that the button we show after the AI plugin is installed links to the correct settings page.

## Why?

Previously the AI plugin used the slug `ai` for it's settings page. This was updated in https://github.com/WordPress/ai/pull/340 as part of switching to using `wp-build` for that settings page. The slug is now `ai-wp-admin`. We did recently [add a redirect](https://github.com/WordPress/ai/pull/424) from `ai` to `ai-wp-admin` but ideally we update this link so we aren't relying on that redirect.

## How?

- Adds a new constant, `AI_PLUGIN_PAGE_SLUG`, that stores the slug for the AI plugin settings page
- Use this constant instead of the `AI_PLUGIN_SLUG` constant when rendering the settings button

## Testing Instructions

1. Go to the new Connectors settings page, `Settings > Connectors`
2. Ensure you don't have the AI plugin installed / activated
3. You should see a callout at the top of the page prompting you to install the plugin
4. Click the button in this callout
5. Once complete, the callout should update and provide a button to `Control features in the AI plugin`
6. Ensure the URL of this button points to the correct settings page, `ai-wp-admin`
7. Click the button and ensure it works correctly

## Use of AI Tools

None
