### PR TITLE
UI/Docs: Clarify package setup for custom WP Admin pages

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Documentation
+
+-   Restructure setup docs into "Within standard WordPress editor screens" and "Elsewhere" for clarity ([#77338](https://github.com/WordPress/gutenberg/pull/77338)).
+
 ### Bug Fixes
 
 -   `Dialog`, `AlertDialog`, `Popover`, `Tooltip`, `Select`: Fix broken focus-trap caused by ThemeProvider's `display: contents` and Base UI's `checkVisibility()` ([#77381](https://github.com/WordPress/gutenberg/pull/77381)).

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -28,13 +28,13 @@ npm install @wordpress/ui
 
 As an implementation of the design system and companion to the `@wordpress/theme` package, these components depend on CSS custom properties defined by the theme package. What you need to set up depends on whether you're building for a WordPress context, and how much of the theming features you want to use.
 
-### Within WordPress
+### Within standard WordPress editor screens
 
-Stylesheets are managed on your behalf in a WordPress context, so you don't need to worry about loading them yourself.
+In standard WordPress editor screens (such as the post editor or the site editor), stylesheets, isolation styles, and layout styles are managed centrally by Gutenberg. You don't need to add any setup yourself — and you should avoid doing so in this shared context to prevent conflicts.
 
-### Outside WordPress
+### Elsewhere
 
-While the components ship with basic fallbacks for every CSS custom property, it's recommended that you install and load the design tokens stylesheet to support the full range of theming capabilities:
+The components ship with built-in fallback values for all CSS custom properties, so they work out of the box without any theme setup. For full theming capabilities, it's recommended that you install and load the design tokens stylesheet:
 
 ```
 npm install @wordpress/theme


### PR DESCRIPTION
## What?

See https://github.com/Automattic/jetpack/pull/47992#discussion_r3078543310

Restructures the Setup section in the `@wordpress/ui` README into clearer groupings: "Within standard WordPress editor screens" and "Elsewhere".

## Why?

The previous documentation grouped setup as "Within WordPress" vs "Outside WordPress", which was misleading in two ways:

- It implied that **all** WordPress contexts automatically handle setup, when in practice only standard editor screens (post editor, site editor) do so — managed centrally by Gutenberg.
- It didn't mention that components ship with built-in fallback values for all CSS custom properties, so they work out of the box without any theme setup. The design tokens stylesheet is only needed for full theming capabilities.

This was originally flagged via a [Jetpack PR discussion](https://github.com/Automattic/jetpack/pull/47992#discussion_r3078543310).

## How?

- Renamed "Within WordPress" to "Within standard WordPress editor screens" — clarifies scope and notes that consumers should avoid adding setup themselves in this shared context.
- Renamed "Outside WordPress" to "Elsewhere" — notes that components work out of the box with fallbacks, and the design tokens stylesheet is only needed for full theming.
- Added a CHANGELOG entry.

## Testing Instructions

1. Read the updated [Setup section in packages/ui/README.md](https://github.com/WordPress/gutenberg/blob/docs/ui-readme-clarify-wp-setup/packages/ui/README.md#setup).
2. Verify the guidance is clear and accurate.

## Use of AI Tools

Cursor + Claude Opus 4.6
