### PR TITLE
Prevent false iframe warning from global styles custom properties

### DIFF
--- a/packages/block-editor/src/components/iframe/get-compatibility-styles.js
+++ b/packages/block-editor/src/components/iframe/get-compatibility-styles.js
@@ -44,6 +44,15 @@ export function getCompatibilityStyles() {
 				return accumulator;
 			}
 
+			// Don't treat global styles custom properties as compatibility styles.
+			// They contain `.wp-block-*` selectors but are not editor canvas styles.
+			if (
+				ownerNode.id ===
+				'global-styles-css-custom-properties-inline-css'
+			) {
+				return accumulator;
+			}
+
 			// Don't try to add styles without ID. Styles enqueued via the WP dependency system will always have IDs.
 			if ( ! ownerNode.id ) {
 				return accumulator;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #76082

Prevents the editor from incorrectly treating global styles custom properties as iframe compatibility styles, which removes the unnecessary console warning.

## Why?
When block-level presets are defined, Gutenberg generates CSS using `.wp-block-*` selectors. The current detection logic assumes any style containing `.wp-block` is meant for the editor iframe, which is not always true.

This causes global styles to be misclassified and triggers a misleading console warning, even though everything is working correctly.

## How?
Added a guard in `getCompatibilityStyles()` to skip the `global-styles-css-custom-properties-inline-css` style block during detection.

This ensures global styles are not incorrectly treated as iframe styles, without changing how styles are enqueued or affecting existing behavior.

## Testing Instructions

1. Add a block-level preset in theme.json.
2. Go to Posts → Add New.
3. Open browser dev tools → Console tab.
4. Confirm the warning is gone.
5. Confirm block styles still work as expected.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1374" height="464" alt="image" src="https://github.com/user-attachments/assets/423fee2c-3fe9-47a6-ae30-819850c60153" />|<img width="1374" height="464" alt="image" src="https://github.com/user-attachments/assets/57ce04fe-f3cd-436e-8b8c-ff4561cdaa97" />|
