### PR TITLE
View Config: Serve supported action IDs from the REST controller

### DIFF
--- a/backport-changelog/7.1/11272.md
+++ b/backport-changelog/7.1/11272.md
@@ -7,3 +7,4 @@ https://github.com/WordPress/wordpress-develop/pull/11272
 * https://github.com/WordPress/gutenberg/pull/76953
 * https://github.com/WordPress/gutenberg/pull/76903
 * https://github.com/WordPress/gutenberg/pull/77290
+* https://github.com/WordPress/gutenberg/pull/77343

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -134,6 +134,17 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			$view_list       = $this->get_view_list_for_wp_template();
 		}
 
+		/**
+		 * Filters the list of supported action identifiers for a given entity type.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param string[] $actions Array of action identifiers.
+		 * @param string   $kind    Entity kind.
+		 * @param string   $name    Entity name.
+		 */
+		$actions = apply_filters( 'gutenberg_view_config_actions', $this->get_actions( $kind, $name ), $kind, $name );
+
 		$response = array(
 			'kind'            => $kind,
 			'name'            => $name,
@@ -141,6 +152,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			'default_layouts' => $default_layouts,
 			'view_list'       => $view_list,
 			'form'            => $form,
+			'actions'         => $actions,
 		);
 
 		return rest_ensure_response( $response );
@@ -280,6 +292,14 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 					'type'        => 'object',
 					'readonly'    => true,
 					'properties'  => $this->get_form_schema(),
+				),
+				'actions'         => array(
+					'description' => __( 'Supported action identifiers.', 'gutenberg' ),
+					'type'        => 'array',
+					'readonly'    => true,
+					'items'       => array(
+						'type' => 'string',
+					),
 				),
 			),
 		);
@@ -1268,5 +1288,62 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		$view_list = array_merge( $view_list, $registered_authors, $user_authors );
 
 		return $view_list;
+	}
+
+	/**
+	 * Returns the list of supported action identifiers for a given entity type.
+	 *
+	 * @param string $kind Entity kind.
+	 * @param string $name Entity name.
+	 * @return string[] Array of action identifiers.
+	 */
+	private function get_actions( $kind, $name ) {
+		// Actions available for all entity types.
+		$actions = array( 'restore', 'reset-post', 'delete-post', 'move-to-trash', 'permanently-delete' );
+
+		if ( 'postType' !== $kind ) {
+			return $actions;
+		}
+
+		$post_type_object = get_post_type_object( $name );
+		if ( ! $post_type_object ) {
+			return $actions;
+		}
+
+		if ( $post_type_object->viewable ) {
+			$actions[] = 'view-post';
+		}
+
+		if ( post_type_supports( $name, 'revisions' ) ) {
+			$actions[] = 'view-post-revisions';
+		}
+
+		if ( post_type_supports( $name, 'title' ) ) {
+			$actions[] = 'rename-post';
+		}
+
+		if ( post_type_supports( $name, 'page-attributes' ) ) {
+			$actions[] = 'order-pages';
+		}
+
+		$can_create = current_user_can( $post_type_object->cap->create_posts );
+
+		if ( $can_create && ! in_array( $name, array( 'wp_block', 'wp_template_part' ), true ) ) {
+			$actions[] = 'duplicate-post';
+		}
+
+		if ( $can_create && 'wp_template_part' === $name && wp_is_block_theme() ) {
+			$actions[] = 'duplicate-template-part';
+		}
+
+		if ( $can_create && 'wp_block' === $name ) {
+			$actions[] = 'duplicate-pattern';
+		}
+
+		if ( 'wp_block' === $name ) {
+			$actions[] = 'export-pattern';
+		}
+
+		return $actions;
 	}
 }

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -344,6 +344,7 @@ export function getViewConfig(
 			default_layouts: undefined,
 			view_list: undefined,
 			form: undefined,
+			actions: undefined,
 		}
 	);
 }

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -168,6 +168,25 @@ const ORDERED_MEDIA_FIELDS = [
 	descriptionField,
 ];
 
+/**
+ * Maps server-provided action IDs to their client-side implementations.
+ */
+const ACTION_MAP: Record< string, Action< any > > = {
+	'view-post': viewPost,
+	'view-post-revisions': viewPostRevisions,
+	'duplicate-post': duplicatePost,
+	'duplicate-pattern': duplicatePattern,
+	'duplicate-template-part': duplicateTemplatePart,
+	'order-pages': reorderPage,
+	'export-pattern': exportPattern,
+	'permanently-delete': permanentlyDeletePost,
+	restore: restorePost,
+	'move-to-trash': trashPost,
+	'rename-post': renamePost,
+	'reset-post': resetPost,
+	'delete-post': deletePost,
+};
+
 export const registerPostTypeSchema =
 	( postType: string ) =>
 	async ( { registry }: { registry: any } ) => {
@@ -184,16 +203,15 @@ export const registerPostTypeSchema =
 			postType
 		);
 
+		// Fetch view config (includes server-provided action IDs).
+		const viewConfig = await unlock(
+			registry.resolveSelect( coreStore )
+		).getViewConfig( 'postType', postType );
+
 		const postTypeConfig = ( await registry
 			.resolveSelect( coreStore )
 			.getPostType( postType ) ) as PostType;
 
-		const canCreate = await registry
-			.resolveSelect( coreStore )
-			.canUser( 'create', {
-				kind: 'postType',
-				name: postType,
-			} );
 		const currentTheme = await registry
 			.resolveSelect( coreStore )
 			.getCurrentTheme();
@@ -201,56 +219,30 @@ export const registerPostTypeSchema =
 			.select( editorStore )
 			.getEditorSettings();
 
-		let canDuplicate =
-			! [ 'wp_block', 'wp_template_part' ].includes(
-				postTypeConfig.slug
-			) &&
-			canCreate &&
-			duplicatePost;
-
-		// @ts-ignore
-		if ( ! globalThis.IS_GUTENBERG_PLUGIN ) {
-			// Outside Gutenberg, disable duplication except for wp_template.
-			if ( 'wp_template' !== postTypeConfig.slug ) {
-				canDuplicate = undefined;
-			}
-		}
-
-		// When template activation experiment is disabled, templates cannot be duplicated.
-		// @ts-ignore
-		if (
-			postTypeConfig.slug === 'wp_template' &&
-			! window?.__experimentalTemplateActivate
-		) {
-			canDuplicate = undefined;
-		}
-
-		const actions = [
-			postTypeConfig.viewable ? viewPost : undefined,
-			!! postTypeConfig.supports?.revisions
-				? viewPostRevisions
-				: undefined,
-			// @ts-ignore
-			canDuplicate,
-			postTypeConfig.slug === 'wp_template_part' &&
-			canCreate &&
-			currentTheme?.is_block_theme
-				? duplicateTemplatePart
-				: undefined,
-			canCreate && postTypeConfig.slug === 'wp_block'
-				? duplicatePattern
-				: undefined,
-			postTypeConfig.supports?.title ? renamePost : undefined,
-			postTypeConfig.supports?.[ 'page-attributes' ]
-				? reorderPage
-				: undefined,
-			postTypeConfig.slug === 'wp_block' ? exportPattern : undefined,
-			restorePost,
-			resetPost,
-			deletePost,
-			trashPost,
-			permanentlyDeletePost,
-		].filter( Boolean );
+		// Map server-provided action IDs to client implementations.
+		const actions = ( viewConfig?.actions ?? [] )
+			.map( ( id: string ) => {
+				// @ts-ignore
+				if ( ! globalThis.IS_GUTENBERG_PLUGIN ) {
+					// Outside Gutenberg, disable duplication except for wp_template.
+					if (
+						id === 'duplicate-post' &&
+						postTypeConfig.slug !== 'wp_template'
+					) {
+						return undefined;
+					}
+				}
+				// When template activation experiment is disabled, templates cannot be duplicated.
+				if (
+					id === 'duplicate-post' &&
+					postTypeConfig.slug === 'wp_template' &&
+					! window?.__experimentalTemplateActivate
+				) {
+					return undefined;
+				}
+				return ACTION_MAP[ id ];
+			} )
+			.filter( Boolean );
 
 		// Handle attachment post type separately with media-specific fields
 		let fields;

--- a/packages/views/src/use-view-config.ts
+++ b/packages/views/src/use-view-config.ts
@@ -30,6 +30,7 @@ export function useViewConfig( {
 	default_layouts: SupportedLayouts;
 	view_list: Array< any >;
 	form: Form | undefined;
+	actions: string[] | undefined;
 } {
 	return useSelect(
 		( select ) => {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/76544

## Status

**THIS IS AN EXPERIMENT NOT READY TO REVIEW/LAND.**

## What?

Move the "which DataViews actions are supported" decision from the client-side `registerPostTypeSchema` thunk to the PHP view config REST controller.

## Why?

Currently, `registerPostTypeSchema` makes 3 separate async `resolveSelect` calls (`getPostType`, `canUser('create')`, `getCurrentTheme`) to derive the list of supported actions — information the server already has access to. This duplicates server-side knowledge in the client and adds unnecessary round-trips. By having the server return the action list, the client becomes a simple consumer that maps IDs to implementations.

This also opens up PHP extensibility: plugins can now filter the action list via `apply_filters( 'gutenberg_view_config_actions', ... )` without requiring JS.

## How?

**PHP controller** (`class-gutenberg-rest-view-config-controller-7-1.php`):
- New `get_actions( $kind, $name )` method returns an array of action ID strings based on post type capabilities, supports, slug, and theme context.
- The `get_items()` response now includes an `actions` key, wrapped in `apply_filters` for extensibility.
- Schema updated with the `actions` property (array of strings, readonly).

**Client-side** (`packages/editor/src/dataviews/store/private-actions.ts`):
- New `ACTION_MAP` constant maps 13 action IDs (e.g. `'view-post'`, `'duplicate-post'`, `'move-to-trash'`) to their JS implementations.
- `registerPostTypeSchema` now fetches `viewConfig.actions` from the server and maps IDs to implementations, replacing the ~50-line conditional action-building block.
- The `canUser('create')` async call is removed (no longer needed for action resolution).
- `IS_GUTENBERG_PLUGIN` and `__experimentalTemplateActivate` client-side gates for `duplicate-post` are preserved.
- Fields logic is unchanged.

**Supporting changes:**
- `core-data` selector default updated to include `actions: undefined`.
- `useViewConfig` return type updated to include `actions: string[] | undefined`.

## Testing Instructions

1. Start wp-env (`npm run wp-env start`).
2. Navigate to the Site Editor → Pages list.
3. Verify all context menu actions appear (View, Rename, Duplicate, Move to Trash, etc.).
4. Check other DataViews screens: Posts, Patterns (wp_block), Template Parts, Templates.
5. Verify that the REST response at `/wp/v2/view-config?kind=postType&name=page` includes an `actions` array with the expected IDs.
6. Test with a user without `create_posts` capability — duplication actions should not appear.

### Testing Instructions for Keyboard

1. Navigate to Pages list using keyboard.
2. Tab to a page row and use the actions menu (three-dot button or keyboard shortcut).
3. Verify all expected actions are present and navigable via arrow keys.

## Screenshots or screencast

N/A — no visual changes; this is a data-flow refactor.

## Use of AI Tools

This PR was authored with the assistance of Claude Code (claude-opus-4-6). All changes were reviewed for correctness.
