### PR TITLE
Post Editor: Store metaboxes RTC-compatible flag on location entries

### DIFF
--- a/backport-changelog/7.0/11566.md
+++ b/backport-changelog/7.0/11566.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/11566
 
 * https://github.com/WordPress/gutenberg/pull/76939
+* https://github.com/WordPress/gutenberg/pull/77361

--- a/docs/reference-guides/data/data-core-edit-post.md
+++ b/docs/reference-guides/data/data-core-edit-post.md
@@ -124,18 +124,6 @@ _Returns_
 
 -   `Object`: Preferences Object.
 
-### getRtcCompatibleMetaBoxIds
-
-Returns the list of meta box IDs marked as compatible with real-time collaboration via the add_meta_box() \_\_rtc_compatible_meta_box compatibility flag.
-
-_Parameters_
-
--   _state_ `Object`: Global application state.
-
-_Returns_
-
--   `string[]`: List of RTC-compatible meta box IDs.
-
 ### hasMetaBoxes
 
 Returns true if the post is using Meta Boxes
@@ -483,14 +471,6 @@ Returns an action object used to open/close the list view.
 _Parameters_
 
 -   _isOpen_ `boolean`: A boolean representing whether the list view should be opened or closed.
-
-### setRtcCompatibleMetaBoxIds
-
-Stores the IDs of meta boxes marked as compatible with real-time collaboration via the \_\_rtc_compatible_meta_box flag on the server.
-
-_Parameters_
-
--   _ids_ `string[]`: Meta box IDs that are RTC-compatible.
 
 ### showBlockTypes
 

--- a/lib/compat/wordpress-7.0/meta-box-rtc-compat.php
+++ b/lib/compat/wordpress-7.0/meta-box-rtc-compat.php
@@ -34,33 +34,42 @@ if ( ! function_exists( 'gutenberg_inject_rtc_compatible_meta_boxes' ) ) {
 			return $wp_meta_boxes;
 		}
 
-		$rtc_compatible_ids = array();
+		$meta_boxes_per_location = array();
 
-		foreach ( $wp_meta_boxes[ $screen_id ] as $priorities ) {
+		foreach ( $wp_meta_boxes[ $screen_id ] as $location => $priorities ) {
 			foreach ( $priorities as $priority_boxes ) {
 				foreach ( (array) $priority_boxes as $meta_box ) {
 					if ( false === $meta_box || ! $meta_box['title'] ) {
 						continue;
 					}
 
-					if ( isset( $meta_box['args']['__rtc_compatible_meta_box'] )
-						&& $meta_box['args']['__rtc_compatible_meta_box'] ) {
-						$rtc_compatible_ids[] = $meta_box['id'];
+					if ( empty( $meta_box['args']['__rtc_compatible_meta_box'] ) ) {
+						continue;
 					}
+
+					if ( ! isset( $meta_boxes_per_location[ $location ] ) ) {
+						$meta_boxes_per_location[ $location ] = array();
+					}
+
+					$meta_boxes_per_location[ $location ][] = array(
+						'id'                => $meta_box['id'],
+						'title'             => $meta_box['title'],
+						'__rtc_compatible' => true,
+					);
 				}
 			}
 		}
 
-		if ( ! empty( $rtc_compatible_ids ) ) {
+		if ( ! empty( $meta_boxes_per_location ) ) {
 			// Meta boxes are registered during admin_head, which fires after
 			// admin_enqueue_scripts where the editor instance is created. This
 			// means the compatibility data cannot be added to editor settings
 			// directly. Instead, we inject an inline script that dispatches
-			// into the store once the block editor has finished loading.
+			// into the store once the block editor has finished loading. The
+			// existing entries are merged by id, so this re-flags meta boxes
+			// already registered by WordPress core.
 			$script = 'window._wpLoadBlockEditor.then( function() {
-				wp.data.dispatch( \'core/edit-post\' ).setRtcCompatibleMetaBoxIds( '
-				. wp_json_encode( array_values( array_unique( $rtc_compatible_ids ) ) )
-				. ' );
+				wp.data.dispatch( \'core/edit-post\' ).setAvailableMetaBoxesPerLocation( ' . wp_json_encode( $meta_boxes_per_location, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ' );
 			} );';
 
 			wp_add_inline_script( 'wp-edit-post', $script );

--- a/lib/compat/wordpress-7.0/meta-box-rtc-compat.php
+++ b/lib/compat/wordpress-7.0/meta-box-rtc-compat.php
@@ -52,8 +52,8 @@ if ( ! function_exists( 'gutenberg_inject_rtc_compatible_meta_boxes' ) ) {
 					}
 
 					$meta_boxes_per_location[ $location ][] = array(
-						'id'                => $meta_box['id'],
-						'title'             => $meta_box['title'],
+						'id'               => $meta_box['id'],
+						'title'            => $meta_box['title'],
 						'__rtc_compatible' => true,
 					);
 				}

--- a/lib/compat/wordpress-7.0/meta-box-rtc-compat.php
+++ b/lib/compat/wordpress-7.0/meta-box-rtc-compat.php
@@ -10,80 +10,77 @@
  * @package gutenberg
  */
 
-if ( ! function_exists( 'gutenberg_inject_rtc_compatible_meta_boxes' ) ) {
-	/**
-	 * Reads the __rtc_compatible_meta_box flag from registered meta boxes
-	 * and injects the compatibility data into the block editor via inline script.
-	 *
-	 * Hooks into filter_block_editor_meta_boxes at a late priority so that it
-	 * runs after any developer filters that add the flag to third-party meta boxes.
-	 *
-	 * @param array $wp_meta_boxes Global meta box state.
-	 * @return array Unmodified meta box state.
-	 */
-	function gutenberg_inject_rtc_compatible_meta_boxes( $wp_meta_boxes ) {
-		global $current_screen;
+/**
+ * Reads the __rtc_compatible_meta_box flag from registered meta boxes
+ * and injects the compatibility data into the block editor via inline script.
+ *
+ * Hooks into filter_block_editor_meta_boxes at a late priority so that it
+ * runs after any developer filters that add the flag to third-party meta boxes.
+ *
+ * @param array $wp_meta_boxes Global meta box state.
+ * @return array Unmodified meta box state.
+ */
+function gutenberg_inject_rtc_compatible_meta_boxes( $wp_meta_boxes ) {
+	global $current_screen;
 
-		if ( ! $current_screen || ! wp_is_collaboration_enabled() ) {
-			return $wp_meta_boxes;
-		}
-
-		$screen_id = $current_screen->id;
-
-		if ( ! isset( $wp_meta_boxes[ $screen_id ] ) ) {
-			return $wp_meta_boxes;
-		}
-
-		$meta_boxes_per_location = array();
-
-		foreach ( $wp_meta_boxes[ $screen_id ] as $location => $priorities ) {
-			foreach ( $priorities as $priority_boxes ) {
-				foreach ( (array) $priority_boxes as $meta_box ) {
-					if ( false === $meta_box || ! $meta_box['title'] ) {
-						continue;
-					}
-
-					if ( empty( $meta_box['args']['__rtc_compatible_meta_box'] ) ) {
-						continue;
-					}
-
-					if ( ! isset( $meta_boxes_per_location[ $location ] ) ) {
-						$meta_boxes_per_location[ $location ] = array();
-					}
-
-					$meta_boxes_per_location[ $location ][] = array(
-						'id'               => $meta_box['id'],
-						'title'            => $meta_box['title'],
-						'__rtc_compatible' => true,
-					);
-				}
-			}
-		}
-
-		if ( ! empty( $meta_boxes_per_location ) ) {
-			// Meta boxes are registered during admin_head, which fires after
-			// admin_enqueue_scripts where the editor instance is created. This
-			// means the compatibility data cannot be added to editor settings
-			// directly. Instead, we inject an inline script that dispatches
-			// into the store once the block editor has finished loading. The
-			// existing entries are merged by id, so this re-flags meta boxes
-			// already registered by WordPress core.
-			$script = 'window._wpLoadBlockEditor.then( function() {
-				wp.data.dispatch( \'core/edit-post\' ).setAvailableMetaBoxesPerLocation( ' . wp_json_encode( $meta_boxes_per_location, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ' );
-			} );';
-
-			wp_add_inline_script( 'wp-edit-post', $script );
-
-			// If wp-edit-post is output earlier in <head>, the inline script
-			// needs to be manually printed. This mirrors the same fallback
-			// used by WordPress core for setAvailableMetaBoxesPerLocation.
-			if ( wp_script_is( 'wp-edit-post', 'done' ) ) {
-				printf( "<script>\n%s\n</script>\n", trim( $script ) );
-			}
-		}
-
+	if ( ! $current_screen || ! wp_is_collaboration_enabled() ) {
 		return $wp_meta_boxes;
 	}
 
-	add_filter( 'filter_block_editor_meta_boxes', 'gutenberg_inject_rtc_compatible_meta_boxes', 100 );
+	$screen_id = $current_screen->id;
+
+	if ( ! isset( $wp_meta_boxes[ $screen_id ] ) ) {
+		return $wp_meta_boxes;
+	}
+
+	$meta_boxes_per_location = array();
+
+	foreach ( $wp_meta_boxes[ $screen_id ] as $location => $priorities ) {
+		foreach ( $priorities as $priority_boxes ) {
+			foreach ( (array) $priority_boxes as $meta_box ) {
+				if ( false === $meta_box || ! $meta_box['title'] ) {
+					continue;
+				}
+
+				if ( empty( $meta_box['args']['__rtc_compatible_meta_box'] ) ) {
+					continue;
+				}
+
+				if ( ! isset( $meta_boxes_per_location[ $location ] ) ) {
+					$meta_boxes_per_location[ $location ] = array();
+				}
+
+				$meta_boxes_per_location[ $location ][] = array(
+					'id'               => $meta_box['id'],
+					'title'            => $meta_box['title'],
+					'__rtc_compatible' => true,
+				);
+			}
+		}
+	}
+
+	if ( ! empty( $meta_boxes_per_location ) ) {
+		// Meta boxes are registered during admin_head, which fires after
+		// admin_enqueue_scripts where the editor instance is created. This
+		// means the compatibility data cannot be added to editor settings
+		// directly. Instead, we inject an inline script that dispatches
+		// into the store once the block editor has finished loading. The
+		// existing entries are merged by id, so this re-flags meta boxes
+		// already registered by WordPress core.
+		$script = 'window._wpLoadBlockEditor.then( function() {
+			wp.data.dispatch( \'core/edit-post\' ).setAvailableMetaBoxesPerLocation( ' . wp_json_encode( $meta_boxes_per_location, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ' );
+		} );';
+
+		wp_add_inline_script( 'wp-edit-post', $script );
+
+		// If wp-edit-post is output earlier in <head>, the inline script
+		// needs to be manually printed. This mirrors the same fallback
+		// used by WordPress core for setAvailableMetaBoxesPerLocation.
+		if ( wp_script_is( 'wp-edit-post', 'done' ) ) {
+			printf( "<script>\n%s\n</script>\n", trim( $script ) );
+		}
+	}
+
+	return $wp_meta_boxes;
 }
+add_filter( 'filter_block_editor_meta_boxes', 'gutenberg_inject_rtc_compatible_meta_boxes', 100 );

--- a/packages/edit-post/src/components/meta-boxes/test/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/test/use-meta-box-initialization.js
@@ -39,7 +39,6 @@ function createMockStores( {
 	isEditorReady = true,
 	isCollaborationEnabled = true,
 	metaBoxes = [],
-	rtcCompatibleIds = [],
 } = {} ) {
 	return {
 		'core/editor': {
@@ -66,7 +65,6 @@ function createMockStores( {
 			},
 			selectors: {
 				getAllMetaBoxes: jest.fn( () => metaBoxes ),
-				getRtcCompatibleMetaBoxIds: jest.fn( () => rtcCompatibleIds ),
 				hasMetaBoxes: jest.fn( () => metaBoxes.length > 0 ),
 				getActiveMetaBoxLocations: jest.fn( () =>
 					metaBoxes.length > 0 ? [ 'normal' ] : []
@@ -113,10 +111,17 @@ describe( 'useMetaBoxInitialization', () => {
 	it( 'does not disable collaboration when all metaboxes are rtcCompatible', () => {
 		const mockStores = createMockStores( {
 			metaBoxes: [
-				{ id: 'my-metabox', title: 'My Meta Box' },
-				{ id: 'another-metabox', title: 'Another' },
+				{
+					id: 'my-metabox',
+					title: 'My Meta Box',
+					__rtc_compatible: true,
+				},
+				{
+					id: 'another-metabox',
+					title: 'Another',
+					__rtc_compatible: true,
+				},
 			],
-			rtcCompatibleIds: [ 'my-metabox', 'another-metabox' ],
 		} );
 		const registry = createRegistry( mockStores );
 
@@ -129,10 +134,13 @@ describe( 'useMetaBoxInitialization', () => {
 	it( 'disables collaboration when some metaboxes lack rtcCompatible', () => {
 		const mockStores = createMockStores( {
 			metaBoxes: [
-				{ id: 'compatible-metabox', title: 'Compatible' },
+				{
+					id: 'compatible-metabox',
+					title: 'Compatible',
+					__rtc_compatible: true,
+				},
 				{ id: 'incompatible-metabox', title: 'Incompatible' },
 			],
-			rtcCompatibleIds: [ 'compatible-metabox' ],
 		} );
 		const registry = createRegistry( mockStores );
 
@@ -143,8 +151,13 @@ describe( 'useMetaBoxInitialization', () => {
 
 	it( 'does not disable collaboration when the only metabox is rtcCompatible', () => {
 		const mockStores = createMockStores( {
-			metaBoxes: [ { id: 'compatible-metabox', title: 'Compatible' } ],
-			rtcCompatibleIds: [ 'compatible-metabox' ],
+			metaBoxes: [
+				{
+					id: 'compatible-metabox',
+					title: 'Compatible',
+					__rtc_compatible: true,
+				},
+			],
 		} );
 		const registry = createRegistry( mockStores );
 

--- a/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
@@ -21,20 +21,18 @@ export const useMetaBoxInitialization = ( enabled ) => {
 	const {
 		isEnabledAndEditorReady,
 		isCollaborationEnabled,
-		hasMetaBoxes,
-		allMetaBoxes,
+		hasIncompatibleMetaBoxes,
 	} = useSelect(
 		( select ) => ( {
 			isEnabledAndEditorReady:
 				enabled && select( editorStore ).__unstableIsEditorReady(),
 			isCollaborationEnabled:
 				select( editorStore ).isCollaborationEnabledForCurrentPost(),
-			hasMetaBoxes: enabled
-				? select( editPostStore ).hasMetaBoxes()
+			hasIncompatibleMetaBoxes: enabled
+				? select( editPostStore )
+						.getAllMetaBoxes()
+						.some( ( metaBox ) => ! metaBox.__rtc_compatible )
 				: false,
-			allMetaBoxes: enabled
-				? select( editPostStore ).getAllMetaBoxes()
-				: undefined,
 		} ),
 		[ enabled ]
 	);
@@ -47,17 +45,9 @@ export const useMetaBoxInitialization = ( enabled ) => {
 		if ( isEnabledAndEditorReady ) {
 			initializeMetaBoxes();
 
-			// Disable real-time collaboration when legacy meta boxes are detected.
-			// Meta boxes marked with __rtc_compatible_meta_box on the server
-			// carry an `__rtc_compatible` flag on their store entry.
-			if ( isCollaborationEnabled ) {
-				const hasIncompatibleMetaBoxes = allMetaBoxes?.some(
-					( metaBox ) => ! metaBox.__rtc_compatible
-				);
-
-				if ( hasIncompatibleMetaBoxes ) {
-					setCollaborationSupported( false );
-				}
+			// Disable real-time collaboration when incompatible meta boxes are detected.
+			if ( isCollaborationEnabled && hasIncompatibleMetaBoxes ) {
+				setCollaborationSupported( false );
 			}
 		}
 	}, [
@@ -65,7 +55,6 @@ export const useMetaBoxInitialization = ( enabled ) => {
 		initializeMetaBoxes,
 		isCollaborationEnabled,
 		setCollaborationSupported,
-		hasMetaBoxes,
-		allMetaBoxes,
+		hasIncompatibleMetaBoxes,
 	] );
 };

--- a/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
@@ -23,7 +23,6 @@ export const useMetaBoxInitialization = ( enabled ) => {
 		isCollaborationEnabled,
 		hasMetaBoxes,
 		allMetaBoxes,
-		rtcCompatibleIds,
 	} = useSelect(
 		( select ) => ( {
 			isEnabledAndEditorReady:
@@ -36,8 +35,6 @@ export const useMetaBoxInitialization = ( enabled ) => {
 			allMetaBoxes: enabled
 				? select( editPostStore ).getAllMetaBoxes()
 				: undefined,
-			rtcCompatibleIds:
-				select( editPostStore ).getRtcCompatibleMetaBoxIds(),
 		} ),
 		[ enabled ]
 	);
@@ -52,10 +49,10 @@ export const useMetaBoxInitialization = ( enabled ) => {
 
 			// Disable real-time collaboration when legacy meta boxes are detected.
 			// Meta boxes marked with __rtc_compatible_meta_box on the server
-			// have their IDs stored via setRtcCompatibleMetaBoxIds().
+			// carry an `__rtc_compatible` flag on their store entry.
 			if ( isCollaborationEnabled ) {
 				const hasIncompatibleMetaBoxes = allMetaBoxes?.some(
-					( metaBox ) => ! rtcCompatibleIds.includes( metaBox.id )
+					( metaBox ) => ! metaBox.__rtc_compatible
 				);
 
 				if ( hasIncompatibleMetaBoxes ) {
@@ -70,6 +67,5 @@ export const useMetaBoxInitialization = ( enabled ) => {
 		setCollaborationSupported,
 		hasMetaBoxes,
 		allMetaBoxes,
-		rtcCompatibleIds,
 	] );
 };

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -278,19 +278,6 @@ export function setAvailableMetaBoxesPerLocation( metaBoxesPerLocation ) {
 }
 
 /**
- * Stores the IDs of meta boxes marked as compatible with real-time collaboration
- * via the __rtc_compatible_meta_box flag on the server.
- *
- * @param {string[]} ids Meta box IDs that are RTC-compatible.
- */
-export function setRtcCompatibleMetaBoxIds( ids ) {
-	return {
-		type: 'SET_RTC_COMPATIBLE_META_BOX_IDS',
-		ids,
-	};
-}
-
-/**
  * Update a metabox.
  */
 export const requestMetaBoxUpdates =

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -32,7 +32,10 @@ function mergeMetaboxes( metaboxes = [], newMetaboxes ) {
 			( box ) => box.id === metabox.id
 		);
 		if ( existing !== -1 ) {
-			mergedMetaboxes[ existing ] = metabox;
+			mergedMetaboxes[ existing ] = {
+				...mergedMetaboxes[ existing ],
+				...metabox,
+			};
 		} else {
 			mergedMetaboxes.push( metabox );
 		}
@@ -83,28 +86,10 @@ function metaBoxesInitialized( state = false, action ) {
 	return state;
 }
 
-/**
- * Reducer tracking meta box IDs marked as compatible with real-time collaboration
- * via the add_meta_box() __rtc_compatible_meta_box compatibility flag.
- *
- * @param {string[]} state  Previous state.
- * @param {Object}   action Action Object.
- *
- * @return {string[]} Updated state.
- */
-export function rtcCompatibleMetaBoxIds( state = [], action ) {
-	switch ( action.type ) {
-		case 'SET_RTC_COMPATIBLE_META_BOX_IDS':
-			return action.ids;
-	}
-	return state;
-}
-
 const metaBoxes = combineReducers( {
 	isSaving: isSavingMetaBoxes,
 	locations: metaBoxLocations,
 	initialized: metaBoxesInitialized,
-	rtcCompatibleIds: rtcCompatibleMetaBoxIds,
 } );
 
 export default combineReducers( {

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -425,18 +425,6 @@ export const getAllMetaBoxes = createSelector(
 );
 
 /**
- * Returns the list of meta box IDs marked as compatible with real-time
- * collaboration via the add_meta_box() __rtc_compatible_meta_box compatibility flag.
- *
- * @param {Object} state Global application state.
- *
- * @return {string[]} List of RTC-compatible meta box IDs.
- */
-export function getRtcCompatibleMetaBoxIds( state ) {
-	return state.metaBoxes.rtcCompatibleIds;
-}
-
-/**
  * Returns true if the post is using Meta Boxes
  *
  * @param {Object} state Global application state


### PR DESCRIPTION
## What?
This is a follow-up refactoring of #76939.

Replace the `rtcCompatibleIds` store slice with an `__rtc_compatible` flag carried directly on meta box entries in `metaBoxLocations`. Reuses the existing `setAvailableMetaBoxesPerLocation` action as the single entry point for server-provided metabox data.

## How?
PHP dispatches a second `setAvailableMetaBoxesPerLocation` with `{ id, title, __rtc_compatible: true }` entries. `mergeMetaboxes` now spreads by id, so the flag layers onto the core's existing entry. Consumer checks `metaBox.__rtc_compatible` instead of an ID lookup.

The PHP core backport would be a one-line change around here: https://github.com/WordPress/wordpress-develop/blob/5044e953df6e6bc058f8c6bf2eb9e81e4889a9b1/src/wp-admin/includes/post.php#L2432-L2435. The override in the plugin requires much more code.

## Testing Instructions
Use testing instructions from #76939. Results should be the same.

It's easier to review changes with [whitespace hidden](https://github.com/WordPress/gutenberg/pull/77361/changes?w=1).

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="844" height="227" alt="CleanShot 2026-04-15 at 10 43 41" src="https://github.com/user-attachments/assets/5a449595-a6b9-419b-a8c6-3ead5bb2d2da" />


## Use of AI Tools

Used Claude to implement my idea, reviewed and tested it myself.
