### PR TITLE
EditSite: Use `--wpds-cursor-control` design token for interactive controls

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- `EditSite`: Use `--wpds-cursor-control` for interactive cursor styling. [#77362](https://github.com/WordPress/gutenberg/pull/77362)
+
 ## 6.43.0 (2026-04-01)
 
 ## 6.42.0 (2026-03-18)

--- a/packages/edit-site/src/components/post-list/style.scss
+++ b/packages/edit-site/src/components/post-list/style.scss
@@ -44,7 +44,7 @@
 	padding: 0;
 	background-color: unset;
 	box-sizing: border-box;
-	cursor: pointer;
+	cursor: var(--wpds-cursor-control);
 	overflow: hidden;
 	height: 100%;
 	width: 100%;


### PR DESCRIPTION
## What?
Part of #76221

Replaces a hardcoded `cursor: pointer` declaration in `@wordpress/edit-site` with `cursor: var(--wpds-cursor-control)`.

## Why?
- Update instances of `cursor: pointer` to use the design token for better maintenance.


## How?
- Removed `cursor: pointer` and used `cursor: var(--wpds-cursor-control)`.

> **Note**: While working on the PR, I noticed that `.edit-site-post-list__featured-image-button` does not appear to be used anywhere in the codebase and seems to be unused CSS. I still applied the token replacement.

## Testing Instructions
Since `.edit-site-post-list__featured-image-button` appears to be unused in the codebase, there is no frontend element to visually verify.

## Use of AI Tools
Use Claude Code to review code and create pull request description.