### PR TITLE
Image: Fix non-local image ID removal undo trap

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -362,27 +362,6 @@ export default function Image( {
 		[ id, isSingleSelected ]
 	);
 
-	// If the image has an id but the attachment doesn't exist on this site,
-	// clear the id so Gutenberg treats the image as external.
-	// This handles content copied between WordPress sites.
-	//
-	// Known limitation: if a different attachment with the same id happens to
-	// exist on the destination site, the lookup will succeed and the wrong
-	// local image will be used. URL matching could address this in a follow-up.
-	// See: https://github.com/WordPress/gutenberg/issues/74156
-	useEffect( () => {
-		if ( ! id || ! isSingleSelected ) {
-			return;
-		}
-		// Only clear for confirmed 404s. apiFetch throws the Response object
-		// for HTTP errors, so checking .status === 404 avoids incorrectly
-		// clearing the id on 403, 500, or network failures, which would
-		// cause data loss for valid local attachments.
-		if ( attachmentResolutionError?.status === 404 ) {
-			setAttributes( { id: undefined } );
-		}
-	}, [ id, isSingleSelected, attachmentResolutionError, setAttributes ] );
-
 	const {
 		canInsertCover,
 		imageEditing,
@@ -413,7 +392,11 @@ export default function Image( {
 	const { getBlock, getSettings } = useSelect( blockEditorStore );
 	const onNavigateToEntityRecord = getSettings().onNavigateToEntityRecord;
 
-	const { replaceBlocks, toggleSelection } = useDispatch( blockEditorStore );
+	const {
+		replaceBlocks,
+		toggleSelection,
+		__unstableMarkNextChangeAsNotPersistent,
+	} = useDispatch( blockEditorStore );
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
 	const { editEntityRecord } = useDispatch( coreStore );
@@ -443,6 +426,34 @@ export default function Image( {
 			( { slug } ) => image?.media_details?.sizes?.[ slug ]?.source_url
 		)
 		.map( ( { name, slug } ) => ( { value: slug, label: name } ) );
+
+	// If the image has an id but the attachment doesn't exist on this site,
+	// clear the id so Gutenberg treats the image as external.
+	// This handles content copied between WordPress sites.
+	//
+	// Known limitation: if a different attachment with the same id happens to
+	// exist on the destination site, the lookup will succeed and the wrong
+	// local image will be used. URL matching could address this in a follow-up.
+	// See: https://github.com/WordPress/gutenberg/issues/74156
+	useEffect( () => {
+		if ( ! id || ! isSingleSelected ) {
+			return;
+		}
+		// Only clear for confirmed 404s. apiFetch throws the Response object
+		// for HTTP errors, so checking .status === 404 avoids incorrectly
+		// clearing the id on 403, 500, or network failures, which would
+		// cause data loss for valid local attachments.
+		if ( attachmentResolutionError?.status === 404 ) {
+			__unstableMarkNextChangeAsNotPersistent();
+			setAttributes( { id: undefined } );
+		}
+	}, [
+		id,
+		isSingleSelected,
+		attachmentResolutionError,
+		setAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
+	] );
 
 	// If an image is externally hosted, try to fetch the image data. This may
 	// fail if the image host doesn't allow CORS with the domain. If it works,


### PR DESCRIPTION
## What?
This is a follow-up to #77178.

PR prevents "undo trap" for the Image block when attachment is missing from the site. Similar effects should mark attribute changes as non-persistent.

## Testing Instructions
* See testing instructions for #77178.
* Repeat the steps.
* Confirm there's no undo level created after the `id` attribute is removed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f80027e2-43d4-443c-ac4b-d36babb12ff4

