### PR TITLE
Widgets: Use `--wpds-cursor-control` design token

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -95,7 +95,7 @@
 
 .wp-block-legacy-widget__edit-preview,
 .wp-block-legacy-widget__edit-no-preview {
-	cursor: pointer;
+	cursor: var(--wpds-cursor-control);
 
 	&:hover::after {
 		border-radius: $radius-small;


### PR DESCRIPTION


## What?
Part of https://github.com/WordPress/gutenberg/issues/76221


## Why?

Update the instance of `cursor: pointer` to use the `--wpds-cursor-control` design token so interactive control cursor behavior can be centrally configured.


## How?

Replaced hardcoded `cursor: pointer` with `cursor: var(--wpds-cursor-control)` in the Legacy Widget block's editor stylesheet.


## Testing Instructions

1. Open the Widgets editor and add a Legacy Widget block in the block editor.
2. Hover over the widget preview/no-preview area.
3. Inspect the element and verify `cursor: var(--wpds-cursor-control)` is applied.
4. Confirm cursor behavior is unchanged (still shows pointer via build-time fallback).


## Screenshots or screencast

#### Before

<img width="2516" height="1028" alt="image" src="https://github.com/user-attachments/assets/2217d910-cada-49d3-897d-bdb9859c5762" />

#### After

<img width="2518" height="1130" alt="image" src="https://github.com/user-attachments/assets/38b9a18c-911f-4f2e-9167-52f4469ee1e7" />




