### PR TITLE
Workflow: Use --wpds-cursor-control design token

### DIFF
--- a/packages/workflow/src/components/workflow-menu.scss
+++ b/packages/workflow/src/components/workflow-menu.scss
@@ -69,7 +69,7 @@
 
 	[cmdk-item] {
 		border-radius: $radius-small;
-		cursor: pointer;
+		cursor: var(--wpds-cursor-control);
 		display: flex;
 		align-items: center;
 		color: $gray-900;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of  https://github.com/WordPress/gutenberg/issues/76221

<!-- In a few words, what is the PR actually doing? -->

## Why?
Update the instance of cursor: pointer to use the --wpds-cursor-control design token so interactive control cursor behavior can be centrally configured.

## How?
Replaced hardcoded cursor: pointer with cursor: var(--wpds-cursor-control) in the Workflow menu's command item ([cmdk-item]) stylesheet.

## Testing Instructions

1. Go to WP Admin → Settings → Gutenberg → Experiments and enable "Workflow Palette", then save.
2. On any admin page, press Cmd+J (macOS) or Ctrl+J (Windows/Linux) to open the Workflow Palette.
3. Hover over the command items in the list.
4. Inspect the element and verify cursor: var(--wpds-cursor-control) is applied on [cmdk-item].
5. Confirm cursor behavior is unchanged (still shows pointer).

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="2940" height="1678" alt="image" src="https://github.com/user-attachments/assets/aef57fba-a49b-48e5-9b47-4e6d9f845e03" />|<img width="2930" height="1676" alt="image" src="https://github.com/user-attachments/assets/58f3e8f4-e0da-497a-99a4-add1c86e01af" />|
