### PR TITLE
Fix: selection and deletion for the nested list

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -267,6 +267,59 @@ export default function useSelectionObserver() {
 					];
 					const depth = findDepth( startPath, endPath );
 
+					// When one block is an ancestor of the other (its path
+					// ends before the divergence point), treat this as a
+					// cross-level RichText selection so the merge/delete path
+					// can handle it (e.g. parent list-item + nested list-item).
+					if (
+						depth >= startPath.length ||
+						depth >= endPath.length
+					) {
+						const richTextElementStart =
+							getRichTextElement( startNode );
+						const richTextElementEnd =
+							getRichTextElement( endNode );
+
+						if ( richTextElementStart && richTextElementEnd ) {
+							const range = selection.getRangeAt( 0 );
+							const richTextDataStart = create( {
+								element: richTextElementStart,
+								range,
+								__unstableIsEditableTree: true,
+							} );
+							const richTextDataEnd = create( {
+								element: richTextElementEnd,
+								range,
+								__unstableIsEditableTree: true,
+							} );
+							selectionChange( {
+								start: {
+									clientId: startClientId,
+									attributeKey:
+										richTextElementStart.dataset
+											.wpBlockAttributeKey,
+									offset:
+										richTextDataStart.start ??
+										richTextDataStart.end,
+								},
+								end: {
+									clientId: endClientId,
+									attributeKey:
+										richTextElementEnd.dataset
+											.wpBlockAttributeKey,
+									offset:
+										richTextDataEnd.start ??
+										richTextDataEnd.end,
+								},
+							} );
+						} else if ( depth >= startPath.length ) {
+							multiSelect( startClientId, startClientId );
+						} else {
+							multiSelect( endClientId, endClientId );
+						}
+						return;
+					}
+
 					if (
 						startPath[ depth ] !== startClientId ||
 						endPath[ depth ] !== endClientId

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -683,6 +683,40 @@ export const synchronizeTemplate =
 	};
 
 /**
+ * Removes a block (by clientId) from a nested innerBlocks structure. If
+ * removing the block leaves its immediate parent container empty, the empty
+ * container is also removed. Siblings of the removed block are preserved.
+ *
+ * @param {Array}  innerBlocks      The innerBlocks array to process.
+ * @param {string} clientIdToRemove The clientId of the block to remove.
+ * @return {Array} Updated innerBlocks with the specified block removed.
+ */
+function removeFromInnerBlocks( innerBlocks, clientIdToRemove ) {
+	const result = [];
+	for ( const block of innerBlocks ) {
+		if ( block.clientId === clientIdToRemove ) {
+			continue;
+		}
+		const newInnerBlocks = removeFromInnerBlocks(
+			block.innerBlocks || [],
+			clientIdToRemove
+		);
+		const didRemove =
+			newInnerBlocks.length < ( block.innerBlocks || [] ).length;
+		// If this container became empty after removal, drop it too.
+		if ( didRemove && newInnerBlocks.length === 0 ) {
+			continue;
+		}
+		result.push(
+			newInnerBlocks === block.innerBlocks
+				? block
+				: { ...block, innerBlocks: newInnerBlocks }
+		);
+	}
+	return result;
+}
+
+/**
  * Delete the current selection.
  *
  * @param {boolean} isForward
@@ -714,25 +748,56 @@ export const __unstableDeleteSelection =
 			selectionFocus.clientId
 		);
 
-		// It's not mergeable if the selection doesn't start and end in the same
-		// block list. Maybe in the future it should be allowed.
+		// Allow cross-level selections when one block is an ancestor of the
+		// other (e.g. parent list-item + nested list-item). In that case the
+		// outer block is the merge target and we remove the nested structure.
+		let isCrossLevel = false;
+		let outerSelection, innerSelection;
+
 		if ( anchorRootClientId !== focusRootClientId ) {
-			return;
+			const anchorParents = select.getBlockParents(
+				selectionAnchor.clientId
+			);
+			const focusParents = select.getBlockParents(
+				selectionFocus.clientId
+			);
+
+			if ( focusParents.includes( selectionAnchor.clientId ) ) {
+				isCrossLevel = true;
+				outerSelection = selectionAnchor;
+				innerSelection = selectionFocus;
+			} else if ( anchorParents.includes( selectionFocus.clientId ) ) {
+				isCrossLevel = true;
+				outerSelection = selectionFocus;
+				innerSelection = selectionAnchor;
+			}
+
+			// It's not mergeable if the selection doesn't start and end in
+			// the same block list. Maybe in the future it should be allowed.
+			if ( ! isCrossLevel ) {
+				return;
+			}
 		}
 
-		const blockOrder = select.getBlockOrder( anchorRootClientId );
-		const anchorIndex = blockOrder.indexOf( selectionAnchor.clientId );
-		const focusIndex = blockOrder.indexOf( selectionFocus.clientId );
-
-		// Reassign selection start and end based on order.
 		let selectionStart, selectionEnd;
 
-		if ( anchorIndex > focusIndex ) {
-			selectionStart = selectionFocus;
-			selectionEnd = selectionAnchor;
+		if ( isCrossLevel ) {
+			// For cross-level, the outer (ancestor) block is always the merge
+			// target. Order: outer block's content start, inner block's content end.
+			selectionStart = outerSelection;
+			selectionEnd = innerSelection;
 		} else {
-			selectionStart = selectionAnchor;
-			selectionEnd = selectionFocus;
+			const blockOrder = select.getBlockOrder( anchorRootClientId );
+			const anchorIndex = blockOrder.indexOf( selectionAnchor.clientId );
+			const focusIndex = blockOrder.indexOf( selectionFocus.clientId );
+
+			if ( anchorIndex > focusIndex ) {
+				selectionStart = selectionFocus;
+				selectionEnd = selectionAnchor;
+			} else {
+				selectionStart = selectionAnchor;
+				selectionEnd = selectionFocus;
+			}
 		}
 
 		const targetSelection = isForward ? selectionEnd : selectionStart;
@@ -807,6 +872,15 @@ export const __unstableDeleteSelection =
 		updatedAttributes[ newAttributeKey ] = newHtml;
 
 		const selectedBlockClientIds = select.getSelectedBlockClientIds();
+
+		// For cross-level selections getSelectedBlockClientIds() returns an
+		// empty or incomplete list because the two blocks share no common
+		// block-order list. Instead, replace the outer (ancestor) block and
+		// strip its innerBlocks so the nested content is removed.
+		const blocksToReplace = isCrossLevel
+			? [ outerSelection.clientId ]
+			: selectedBlockClientIds;
+
 		const replacement = [
 			...( isForward ? blocksWithTheSameType : [] ),
 			{
@@ -816,6 +890,17 @@ export const __unstableDeleteSelection =
 					...targetBlock.attributes,
 					...updatedAttributes,
 				},
+				// For cross-level merges, surgically remove only the selected
+				// inner block (and its container if it becomes empty). Sibling
+				// blocks that were not part of the selection are preserved.
+				...( isCrossLevel
+					? {
+							innerBlocks: removeFromInnerBlocks(
+								targetBlock.innerBlocks || [],
+								innerSelection.clientId
+							),
+					  }
+					: {} ),
 			},
 			...( isForward ? [] : blocksWithTheSameType ),
 		];
@@ -829,7 +914,7 @@ export const __unstableDeleteSelection =
 			);
 
 			dispatch.replaceBlocks(
-				selectedBlockClientIds,
+				blocksToReplace,
 				replacement,
 				0, // If we don't pass the `indexToSelect` it will default to the last block.
 				select.getSelectedBlocksInitialCaretPosition()

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1100,9 +1100,49 @@ export function __unstableIsSelectionMergeable( state, isForward ) {
 	);
 
 	// It's not mergeable if the selection doesn't start and end in the same
-	// block list. Maybe in the future it should be allowed.
+	// block list. Allow cross-level selections when one block is an ancestor
+	// of the other (e.g. parent list-item + nested list-item).
 	if ( anchorRootClientId !== focusRootClientId ) {
-		return false;
+		const anchorParents = getBlockParents(
+			state,
+			selectionAnchor.clientId
+		);
+		const focusParents = getBlockParents( state, selectionFocus.clientId );
+		const isCrossLevel =
+			focusParents.includes( selectionAnchor.clientId ) ||
+			anchorParents.includes( selectionFocus.clientId );
+
+		if ( ! isCrossLevel ) {
+			return false;
+		}
+
+		// For cross-level, the "target" is always the outer/ancestor block.
+		const outerClientId = focusParents.includes( selectionAnchor.clientId )
+			? selectionAnchor.clientId
+			: selectionFocus.clientId;
+		const innerClientId =
+			outerClientId === selectionAnchor.clientId
+				? selectionFocus.clientId
+				: selectionAnchor.clientId;
+
+		const targetBlockName = getBlockName( state, outerClientId );
+		const targetBlockType = getBlockType( targetBlockName );
+
+		if ( ! targetBlockType.merge ) {
+			return false;
+		}
+
+		const blockToMerge = getBlock( state, innerClientId );
+
+		if ( blockToMerge.name === targetBlockName ) {
+			return true;
+		}
+
+		const blocksToMerge = switchToBlockType(
+			blockToMerge,
+			targetBlockName
+		);
+		return !! ( blocksToMerge && blocksToMerge.length );
 	}
 
 	const blockOrder = getBlockOrder( state, anchorRootClientId );

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -1446,4 +1446,348 @@ describe( 'actions', () => {
 			} );
 		} );
 	} );
+
+	describe( '__unstableDeleteSelection', () => {
+		const { __unstableDeleteSelection } = actions;
+
+		beforeEach( () => {
+			registerBlockType( 'core/list-item', {
+				apiVersion: 3,
+				save: () => null,
+				category: 'text',
+				title: 'List Item',
+				attributes: {
+					content: { type: 'string' },
+				},
+				merge( attributes, attributesToMerge ) {
+					return {
+						content: attributes.content + attributesToMerge.content,
+					};
+				},
+			} );
+		} );
+
+		afterEach( () => {
+			unregisterBlockType( 'core/list-item' );
+		} );
+
+		it( 'does nothing when anchor and focus are in the same block', () => {
+			const select = {
+				getSelectionStart: () => ( {
+					clientId: 'item-a',
+					attributeKey: 'content',
+					offset: 0,
+				} ),
+				getSelectionEnd: () => ( {
+					clientId: 'item-a',
+					attributeKey: 'content',
+					offset: 3,
+				} ),
+			};
+			const dispatch = Object.assign( jest.fn(), {
+				selectionChange: jest.fn(),
+				replaceBlocks: jest.fn(),
+			} );
+			const registry = { batch: ( cb ) => cb() };
+
+			__unstableDeleteSelection( false )( {
+				select,
+				dispatch,
+				registry,
+			} );
+
+			expect( dispatch.replaceBlocks ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does nothing when cross-root blocks are not ancestor/descendant of each other', () => {
+			const select = {
+				getSelectionStart: () => ( {
+					clientId: 'item-a',
+					attributeKey: 'content',
+					offset: 0,
+				} ),
+				getSelectionEnd: () => ( {
+					clientId: 'item-b',
+					attributeKey: 'content',
+					offset: 3,
+				} ),
+				getBlockRootClientId: ( clientId ) =>
+					clientId === 'item-a' ? 'list-a' : 'list-b',
+				getBlockParents: ( clientId ) =>
+					clientId === 'item-a' ? [ 'list-a' ] : [ 'list-b' ],
+			};
+			const dispatch = Object.assign( jest.fn(), {
+				selectionChange: jest.fn(),
+				replaceBlocks: jest.fn(),
+			} );
+			const registry = { batch: ( cb ) => cb() };
+
+			__unstableDeleteSelection( false )( {
+				select,
+				dispatch,
+				registry,
+			} );
+
+			expect( dispatch.replaceBlocks ).not.toHaveBeenCalled();
+		} );
+
+		it( 'merges cross-level parent→child selection by replacing the outer block', () => {
+			const parentBlock = deepFreeze( {
+				clientId: 'parent-item',
+				name: 'core/list-item',
+				attributes: { content: 'list 1' },
+				// Nested list has only one child so it will be emptied and removed.
+				innerBlocks: [
+					{
+						clientId: 'nested-list',
+						name: 'core/list',
+						attributes: {},
+						innerBlocks: [
+							{
+								clientId: 'child-item',
+								name: 'core/list-item',
+								attributes: { content: 'nested' },
+								innerBlocks: [],
+							},
+						],
+					},
+				],
+			} );
+			const childBlock = deepFreeze( {
+				clientId: 'child-item',
+				name: 'core/list-item',
+				attributes: { content: 'nested' },
+				innerBlocks: [],
+			} );
+
+			// Simulate: anchor at offset 4 in parent ("list"), focus at offset 6 in child ("nested").
+			const select = {
+				getSelectionStart: () => ( {
+					clientId: 'parent-item',
+					attributeKey: 'content',
+					offset: 4,
+				} ),
+				getSelectionEnd: () => ( {
+					clientId: 'child-item',
+					attributeKey: 'content',
+					offset: 6,
+				} ),
+				getBlockRootClientId: ( clientId ) =>
+					clientId === 'parent-item' ? 'list-1' : 'nested-list',
+				getBlockParents: ( clientId ) =>
+					clientId === 'child-item'
+						? [ 'list-1', 'parent-item', 'nested-list' ]
+						: [ 'list-1' ],
+				getBlockOrder: () => [ 'parent-item' ],
+				getBlock: ( clientId ) =>
+					clientId === 'parent-item' ? parentBlock : childBlock,
+				getSelectedBlockClientIds: () => [],
+				getSelectedBlocksInitialCaretPosition: () => 0,
+			};
+
+			const dispatch = Object.assign( jest.fn(), {
+				selectionChange: jest.fn(),
+				replaceBlocks: jest.fn(),
+			} );
+			const registry = { batch: ( cb ) => cb() };
+
+			__unstableDeleteSelection( false )( {
+				select,
+				dispatch,
+				registry,
+			} );
+
+			// replaceBlocks should have been called with the outer (parent) block's clientId.
+			// The nested list had only one child, so it is empty after removal and is dropped.
+			expect( dispatch.replaceBlocks ).toHaveBeenCalledWith(
+				[ 'parent-item' ],
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						clientId: 'parent-item',
+						name: 'core/list-item',
+						innerBlocks: [],
+					} ),
+				] ),
+				0,
+				0
+			);
+		} );
+
+		it( 'merges cross-level child→parent selection (selection started from child side)', () => {
+			const parentBlock = deepFreeze( {
+				clientId: 'parent-item',
+				name: 'core/list-item',
+				attributes: { content: 'list 1' },
+				innerBlocks: [
+					{
+						clientId: 'nested-list',
+						name: 'core/list',
+						attributes: {},
+						innerBlocks: [
+							{
+								clientId: 'child-item',
+								name: 'core/list-item',
+								attributes: { content: 'nested' },
+								innerBlocks: [],
+							},
+						],
+					},
+				],
+			} );
+			const childBlock = deepFreeze( {
+				clientId: 'child-item',
+				name: 'core/list-item',
+				attributes: { content: 'nested' },
+				innerBlocks: [],
+			} );
+
+			// Anchor is child, focus is parent (user selected from child upward).
+			const select = {
+				getSelectionStart: () => ( {
+					clientId: 'child-item',
+					attributeKey: 'content',
+					offset: 3,
+				} ),
+				getSelectionEnd: () => ( {
+					clientId: 'parent-item',
+					attributeKey: 'content',
+					offset: 2,
+				} ),
+				getBlockRootClientId: ( clientId ) =>
+					clientId === 'parent-item' ? 'list-1' : 'nested-list',
+				getBlockParents: ( clientId ) =>
+					clientId === 'child-item'
+						? [ 'list-1', 'parent-item', 'nested-list' ]
+						: [ 'list-1' ],
+				getBlockOrder: () => [ 'parent-item' ],
+				getBlock: ( clientId ) =>
+					clientId === 'parent-item' ? parentBlock : childBlock,
+				getSelectedBlockClientIds: () => [],
+				getSelectedBlocksInitialCaretPosition: () => 0,
+			};
+
+			const dispatch = Object.assign( jest.fn(), {
+				selectionChange: jest.fn(),
+				replaceBlocks: jest.fn(),
+			} );
+			const registry = { batch: ( cb ) => cb() };
+
+			__unstableDeleteSelection( false )( {
+				select,
+				dispatch,
+				registry,
+			} );
+
+			// Should replace the outer (parent) block even though anchor was child.
+			expect( dispatch.replaceBlocks ).toHaveBeenCalledWith(
+				[ 'parent-item' ],
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						clientId: 'parent-item',
+						name: 'core/list-item',
+						innerBlocks: [],
+					} ),
+				] ),
+				0,
+				0
+			);
+		} );
+
+		it( 'preserves sibling children when only one child is selected for deletion', () => {
+			const siblingBlock = deepFreeze( {
+				clientId: 'child-item-2',
+				name: 'core/list-item',
+				attributes: { content: 'sublist 2' },
+				innerBlocks: [],
+			} );
+			const parentBlock = deepFreeze( {
+				clientId: 'parent-item',
+				name: 'core/list-item',
+				attributes: { content: 'list 1' },
+				// Two children: child-item-1 (selected for deletion) and child-item-2 (sibling, keep).
+				innerBlocks: [
+					{
+						clientId: 'nested-list',
+						name: 'core/list',
+						attributes: {},
+						innerBlocks: [
+							{
+								clientId: 'child-item-1',
+								name: 'core/list-item',
+								attributes: { content: 'sublist 1' },
+								innerBlocks: [],
+							},
+							siblingBlock,
+						],
+					},
+				],
+			} );
+			const childBlock = deepFreeze( {
+				clientId: 'child-item-1',
+				name: 'core/list-item',
+				attributes: { content: 'sublist 1' },
+				innerBlocks: [],
+			} );
+
+			const select = {
+				getSelectionStart: () => ( {
+					clientId: 'parent-item',
+					attributeKey: 'content',
+					offset: 4,
+				} ),
+				getSelectionEnd: () => ( {
+					clientId: 'child-item-1',
+					attributeKey: 'content',
+					offset: 7,
+				} ),
+				getBlockRootClientId: ( clientId ) =>
+					clientId === 'parent-item' ? 'list-1' : 'nested-list',
+				getBlockParents: ( clientId ) =>
+					clientId === 'child-item-1'
+						? [ 'list-1', 'parent-item', 'nested-list' ]
+						: [ 'list-1' ],
+				getBlockOrder: () => [ 'parent-item' ],
+				getBlock: ( clientId ) =>
+					clientId === 'parent-item' ? parentBlock : childBlock,
+				getSelectedBlockClientIds: () => [],
+				getSelectedBlocksInitialCaretPosition: () => 0,
+			};
+
+			const dispatch = Object.assign( jest.fn(), {
+				selectionChange: jest.fn(),
+				replaceBlocks: jest.fn(),
+			} );
+			const registry = { batch: ( cb ) => cb() };
+
+			__unstableDeleteSelection( false )( {
+				select,
+				dispatch,
+				registry,
+			} );
+
+			// The nested list still has child-item-2, so it should be preserved.
+			expect( dispatch.replaceBlocks ).toHaveBeenCalledWith(
+				[ 'parent-item' ],
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						clientId: 'parent-item',
+						name: 'core/list-item',
+						// nested-list kept because child-item-2 remains.
+						innerBlocks: [
+							expect.objectContaining( {
+								clientId: 'nested-list',
+								innerBlocks: [
+									expect.objectContaining( {
+										clientId: 'child-item-2',
+									} ),
+								],
+							} ),
+						],
+					} ),
+				] ),
+				0,
+				0
+			);
+		} );
+	} );
 } );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -5160,4 +5160,281 @@ describe( 'getBlockEditingMode', () => {
 			).toBe( 'contentOnly' );
 		} );
 	} );
+
+	describe( '__unstableIsSelectionMergeable', () => {
+		const { __unstableIsSelectionMergeable } = selectors;
+
+		// Builds block state for a nested list:
+		//   core/list (list-1)
+		//     core/list-item (parent-item)  ← "list 1"
+		//       core/list (nested-list)
+		//         core/list-item (child-item)  ← "nested"
+		function buildNestedListState( {
+			anchorClientId,
+			anchorAttributeKey,
+			anchorOffset,
+			focusClientId,
+			focusAttributeKey,
+			focusOffset,
+		} ) {
+			return {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							'list-1': { clientId: 'list-1', name: 'core/list' },
+							'parent-item': {
+								clientId: 'parent-item',
+								name: 'core/list-item',
+							},
+							'nested-list': {
+								clientId: 'nested-list',
+								name: 'core/list',
+							},
+							'child-item': {
+								clientId: 'child-item',
+								name: 'core/list-item',
+							},
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							'list-1': {},
+							'parent-item': { content: 'list 1' },
+							'nested-list': {},
+							'child-item': { content: 'nested' },
+						} )
+					),
+					order: new Map(
+						Object.entries( {
+							'': [ 'list-1' ],
+							'list-1': [ 'parent-item' ],
+							'parent-item': [ 'nested-list' ],
+							'nested-list': [ 'child-item' ],
+							'child-item': [],
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							'list-1': '',
+							'parent-item': 'list-1',
+							'nested-list': 'parent-item',
+							'child-item': 'nested-list',
+						} )
+					),
+					tree: new Map(
+						Object.entries( {
+							'child-item': {
+								clientId: 'child-item',
+								name: 'core/list-item',
+								attributes: { content: 'nested' },
+								innerBlocks: [],
+							},
+							'nested-list': {
+								clientId: 'nested-list',
+								name: 'core/list',
+								attributes: {},
+								innerBlocks: [],
+							},
+							'parent-item': {
+								clientId: 'parent-item',
+								name: 'core/list-item',
+								attributes: { content: 'list 1' },
+								innerBlocks: [],
+							},
+							'list-1': {
+								clientId: 'list-1',
+								name: 'core/list',
+								attributes: {},
+								innerBlocks: [],
+							},
+						} )
+					),
+					controlledInnerBlocks: new Set(),
+					cache: {
+						'list-1': {},
+						'parent-item': {},
+						'nested-list': {},
+						'child-item': {},
+					},
+				},
+				selection: {
+					selectionStart: {
+						clientId: anchorClientId,
+						attributeKey: anchorAttributeKey,
+						offset: anchorOffset,
+					},
+					selectionEnd: {
+						clientId: focusClientId,
+						attributeKey: focusAttributeKey,
+						offset: focusOffset,
+					},
+				},
+			};
+		}
+
+		beforeEach( () => {
+			registerBlockType( 'core/list-item', {
+				apiVersion: 3,
+				save: () => null,
+				category: 'text',
+				title: 'List Item',
+				attributes: {
+					content: { type: 'string' },
+				},
+				merge( attributes, attributesToMerge ) {
+					return {
+						content: attributes.content + attributesToMerge.content,
+					};
+				},
+			} );
+
+			registerBlockType( 'core/list', {
+				apiVersion: 3,
+				save: () => null,
+				category: 'text',
+				title: 'List',
+				attributes: {},
+			} );
+		} );
+
+		afterEach( () => {
+			unregisterBlockType( 'core/list-item' );
+			unregisterBlockType( 'core/list' );
+		} );
+
+		it( 'returns true when anchor is ancestor of focus (parent list-item selecting into child list-item)', () => {
+			const state = buildNestedListState( {
+				anchorClientId: 'parent-item',
+				anchorAttributeKey: 'content',
+				anchorOffset: 2,
+				focusClientId: 'child-item',
+				focusAttributeKey: 'content',
+				focusOffset: 4,
+			} );
+
+			expect( __unstableIsSelectionMergeable( state, false ) ).toBe(
+				true
+			);
+		} );
+
+		it( 'returns true when focus is ancestor of anchor (child list-item selecting back into parent list-item)', () => {
+			const state = buildNestedListState( {
+				anchorClientId: 'child-item',
+				anchorAttributeKey: 'content',
+				anchorOffset: 4,
+				focusClientId: 'parent-item',
+				focusAttributeKey: 'content',
+				focusOffset: 2,
+			} );
+
+			expect( __unstableIsSelectionMergeable( state, false ) ).toBe(
+				true
+			);
+		} );
+
+		it( 'returns false when the anchor block type has no merge function', () => {
+			// Temporarily re-register core/list-item without a merge function.
+			unregisterBlockType( 'core/list-item' );
+			registerBlockType( 'core/list-item', {
+				apiVersion: 3,
+				save: () => null,
+				category: 'text',
+				title: 'List Item (no merge)',
+				attributes: {
+					content: { type: 'string' },
+				},
+				// No merge function.
+			} );
+
+			const state = buildNestedListState( {
+				anchorClientId: 'parent-item',
+				anchorAttributeKey: 'content',
+				anchorOffset: 0,
+				focusClientId: 'child-item',
+				focusAttributeKey: 'content',
+				focusOffset: 3,
+			} );
+
+			expect( __unstableIsSelectionMergeable( state, false ) ).toBe(
+				false
+			);
+		} );
+
+		it( 'returns false when the two blocks are in completely different branch (not ancestor/descendant)', () => {
+			// Build a flat two-list-item state where neither is a parent of the other.
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							'list-a': {
+								clientId: 'list-a',
+								name: 'core/list',
+							},
+							'item-a': {
+								clientId: 'item-a',
+								name: 'core/list-item',
+							},
+							'list-b': {
+								clientId: 'list-b',
+								name: 'core/list',
+							},
+							'item-b': {
+								clientId: 'item-b',
+								name: 'core/list-item',
+							},
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							'list-a': {},
+							'item-a': { content: 'A' },
+							'list-b': {},
+							'item-b': { content: 'B' },
+						} )
+					),
+					order: new Map(
+						Object.entries( {
+							'': [ 'list-a', 'list-b' ],
+							'list-a': [ 'item-a' ],
+							'item-a': [],
+							'list-b': [ 'item-b' ],
+							'item-b': [],
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							'list-a': '',
+							'item-a': 'list-a',
+							'list-b': '',
+							'item-b': 'list-b',
+						} )
+					),
+					tree: new Map(),
+					controlledInnerBlocks: new Set(),
+					cache: {
+						'list-a': {},
+						'item-a': {},
+						'list-b': {},
+						'item-b': {},
+					},
+				},
+				selection: {
+					selectionStart: {
+						clientId: 'item-a',
+						attributeKey: 'content',
+						offset: 0,
+					},
+					selectionEnd: {
+						clientId: 'item-b',
+						attributeKey: 'content',
+						offset: 1,
+					},
+				},
+			};
+
+			expect( __unstableIsSelectionMergeable( state, false ) ).toBe(
+				false
+			);
+		} );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #76233

<!-- In a few words, what is the PR actually doing? -->
Fix nested parent/child list-item selection and deletion handling when selecting across hierarchy levels.

This PR enables proper multi-block selection, mergeability detection, and deletion behavior when a selection spans from a parent block into a nested descendant block.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Cross-level selections between ancestor/descendant list items were broken due to multiple assumptions in the selection/merge logic that both selected blocks existed at the same nesting depth.

As a result:
- Parent → child nested selections failed to become mergeable
- Backspace/Delete did not properly merge/delete the selected content
- Nested multi-selection could silently fail due to invalid `multiSelect(undefined, ...)`

This prevented expected editor behavior when selecting content across nested list structures.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
### 1. Updated `use-selection-observer.js`
- Added handling for ancestor/descendant cross-level selections
- When one selection path is a prefix of the other:
  - Dispatch `selectionChange` with rich text start/end metadata
  - Avoid broken `multiSelect(undefined, ...)` flow

### 2. Updated `selectors.js`
- Enhanced `__unstableIsSelectionMergeable`
- Detect ancestor/descendant relationships when root client IDs differ
- Return mergeable if block types support merging

### 3. Updated `actions.js`
- Fixed `__unstableDeleteSelection` for cross-level selections
- Resolve ancestor block as merge target
- Replace outer block with merged content
- Clear nested `innerBlocks` from absorbed descendant structure

## Testing Instructions
1. Open the block editor.
2. Insert a List block.
3. Create nested list items:
   - Parent item
   - Nested child item inside parent
4. Select text starting in the parent list item and ending in the nested child list item or vice-verca.
5. Press Backspace/Delete.

### Verify:
- Selection is treated as mergeable
- Selected content is deleted/merged correctly
- Nested child structure is absorbed as expected

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Navigate to a nested list block using keyboard only.
2. Use Shift + Arrow Keys to create a text selection spanning parent and nested child list items.
3. Press Backspace/Delete.

### Verify:
- Selection merges/deletes correctly
- No keyboard accessibility regressions occur


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
https://github.com/user-attachments/assets/774b17e5-9727-4ca3-a8ae-b2bbaf002624

### After

https://github.com/user-attachments/assets/05d59aee-2bb5-4e69-a8a1-a0df2943a823