### PR TITLE
Admin UI: use UI Text component in header

### DIFF
--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Enhancements
 
--   Admin UI: use UI Text component in header.
+-   Admin UI: use UI Text component in header. [#77372](https://github.com/WordPress/gutenberg/pull/77372)
 
 ## 1.12.0 (2026-04-15)
 

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 -   Convert styles to CSS modules with logical properties, removing previously exposed class names. [#77088](https://github.com/WordPress/gutenberg/pull/77088).
 
+### Enhancements
+
+-   Admin UI: use UI Text component in header.
+
 ## 1.12.0 (2026-04-15)
 
 ### Enhancements

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Admin UI: use UI Text component in header.
+
 ## 1.12.0 (2026-04-15)
 
 ### Enhancements

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
--   Admin UI: use UI Text component in header.
+-   Admin UI: use UI Text component in header. [#77372](https://github.com/WordPress/gutenberg/pull/77372)
 
 ## 1.12.0 (2026-04-15)
 

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -51,15 +51,15 @@ export default function Header( {
 							{ visual }
 						</div>
 					) }
-				{ title && (
-					<Text
-						className={ styles[ 'header-title' ] }
-						render={ <HeadingTag /> }
-						variant="heading-lg"
-					>
-						{ title }
-					</Text>
-				) }
+					{ title && (
+						<Text
+							className={ styles[ 'header-title' ] }
+							render={ <HeadingTag /> }
+							variant="body-lg"
+						>
+							{ title }
+						</Text>
+					) }
 					{ breadcrumbs }
 					{ badges }
 				</Stack>
@@ -73,15 +73,15 @@ export default function Header( {
 					{ actions }
 				</Stack>
 			</Stack>
-		{ subTitle && (
-			<Text
-				render={ <p /> }
-				variant="body-md"
-				className={ styles[ 'header-subtitle' ] }
-			>
-				{ subTitle }
-			</Text>
-		) }
+			{ subTitle && (
+				<Text
+					render={ <p /> }
+					variant="body-md"
+					className={ styles[ 'header-subtitle' ] }
+				>
+					{ subTitle }
+				</Text>
+			) }
 		</Stack>
 	);
 }

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Stack } from '@wordpress/ui';
+import { Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -51,11 +51,15 @@ export default function Header( {
 							{ visual }
 						</div>
 					) }
-					{ title && (
-						<HeadingTag className={ styles[ 'header-title' ] }>
-							{ title }
-						</HeadingTag>
-					) }
+				{ title && (
+					<Text
+						className={ styles[ 'header-title' ] }
+						render={ <HeadingTag /> }
+						variant="heading-lg"
+					>
+						{ title }
+					</Text>
+				) }
 					{ breadcrumbs }
 					{ badges }
 				</Stack>
@@ -69,9 +73,15 @@ export default function Header( {
 					{ actions }
 				</Stack>
 			</Stack>
-			{ subTitle && (
-				<p className={ styles[ 'header-subtitle' ] }>{ subTitle }</p>
-			) }
+		{ subTitle && (
+			<Text
+				render={ <p /> }
+				variant="body-md"
+				className={ styles[ 'header-subtitle' ] }
+			>
+				{ subTitle }
+			</Text>
+		) }
 		</Stack>
 	);
 }

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -55,7 +55,7 @@ export default function Header( {
 						<Text
 							className={ styles[ 'header-title' ] }
 							render={ <HeadingTag /> }
-							variant="body-lg"
+							variant="heading-lg"
 						>
 							{ title }
 						</Text>

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -44,7 +44,7 @@ export default function Header( {
 						<Text
 							className="admin-ui-page__header-title"
 							render={ <HeadingTag /> }
-							variant="body-lg"
+							variant="heading-lg"
 						>
 							{ title }
 						</Text>

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Stack } from '@wordpress/ui';
+import { Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -41,9 +41,13 @@ export default function Header( {
 						/>
 					) }
 					{ title && (
-						<HeadingTag className="admin-ui-page__header-title">
+						<Text
+							className="admin-ui-page__header-title"
+							render={ <HeadingTag /> }
+							variant="heading-lg"
+						>
 							{ title }
-						</HeadingTag>
+						</Text>
 					) }
 					{ breadcrumbs }
 					{ badges }
@@ -59,7 +63,13 @@ export default function Header( {
 				</Stack>
 			</Stack>
 			{ subTitle && (
-				<p className="admin-ui-page__header-subtitle">{ subTitle }</p>
+				<Text
+					render={ <p /> }
+					variant="body-md"
+					className="admin-ui-page__header-subtitle"
+				>
+					{ subTitle }
+				</Text>
 			) }
 		</Stack>
 	);

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -44,7 +44,7 @@ export default function Header( {
 						<Text
 							className="admin-ui-page__header-title"
 							render={ <HeadingTag /> }
-							variant="heading-lg"
+							variant="body-lg"
 						>
 							{ title }
 						</Text>

--- a/packages/admin-ui/src/page/style.module.css
+++ b/packages/admin-ui/src/page/style.module.css
@@ -18,7 +18,7 @@
 	z-index: 1;
 }
 
-/* @TODO: Remove truncation styles once `Text` supports truncation natively. */
+/* @TODO: Remove truncation styles once `Text` supports truncation natively. See https://github.com/WordPress/gutenberg/issues/77391 */
 .header-title {
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/packages/admin-ui/src/page/style.module.css
+++ b/packages/admin-ui/src/page/style.module.css
@@ -19,7 +19,6 @@
 }
 
 .header-title {
-	margin: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
@@ -49,7 +48,6 @@
 .header-subtitle {
 	padding-block-end: var(--wpds-dimension-padding-xs);
 	color: var(--wpds-color-fg-content-neutral-weak);
-	margin: 0;
 }
 
 .content {

--- a/packages/admin-ui/src/page/style.module.css
+++ b/packages/admin-ui/src/page/style.module.css
@@ -19,11 +19,6 @@
 }
 
 .header-title {
-	/* @TODO: use Text component from UI when available. */
-	font-family: var(--wpds-typography-font-family-heading);
-	font-size: var(--wpds-typography-font-size-lg);
-	font-weight: var(--wpds-typography-font-weight-medium);
-	line-height: var(--wpds-typography-line-height-lg);
 	margin: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -54,8 +49,6 @@
 .header-subtitle {
 	padding-block-end: var(--wpds-dimension-padding-xs);
 	color: var(--wpds-color-fg-content-neutral-weak);
-	font-size: var(--wpds-typography-font-size-md);
-	line-height: var(--wpds-typography-line-height-md);
 	margin: 0;
 }
 

--- a/packages/admin-ui/src/page/style.module.css
+++ b/packages/admin-ui/src/page/style.module.css
@@ -18,6 +18,7 @@
 	z-index: 1;
 }
 
+/* @TODO: Remove truncation styles once `Text` supports truncation natively. */
 .header-title {
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -18,6 +18,7 @@
 	z-index: 1;
 }
 
+// @TODO: Remove truncation styles once `Text` supports truncation natively.
 .admin-ui-page__header-title {
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -19,7 +19,6 @@
 }
 
 .admin-ui-page__header-title {
-	margin: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
@@ -32,7 +31,6 @@
 .admin-ui-page__header-subtitle {
 	padding-block-end: var(--wpds-dimension-padding-xs);
 	color: var(--wpds-color-fg-content-neutral-weak);
-	margin: 0;
 }
 
 .admin-ui-page__content {

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -19,11 +19,6 @@
 }
 
 .admin-ui-page__header-title {
-	// @TODO: use Text component from UI when available.
-	font-family: var(--wpds-typography-font-family-heading);
-	font-size: var(--wpds-typography-font-size-lg);
-	font-weight: var(--wpds-typography-font-weight-medium);
-	line-height: var(--wpds-typography-line-height-lg);
 	margin: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -37,8 +32,6 @@
 .admin-ui-page__header-subtitle {
 	padding-block-end: var(--wpds-dimension-padding-xs);
 	color: var(--wpds-color-fg-content-neutral-weak);
-	font-size: var(--wpds-typography-font-size-md);
-	line-height: var(--wpds-typography-line-height-md);
 	margin: 0;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Follow-up to https://github.com/WordPress/gutenberg/pull/76452#discussion_r2930913207
- Adjacent to similar work in breadcrumbs https://github.com/WordPress/gutenberg/pull/77012#discussion_r3046128561

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Using `Text` UI component directly instead of design tokens via CSS.
- Removes `typography-*` styles and margin reset, which [also isn't needed now](https://github.com/WordPress/gutenberg/pull/76970).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Test all pages using Admin UI:
   - Appearance → Fonts
   - Appearance → Editor sub pages

You should not notice any visual differences.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
