### PR TITLE
Fields: Use `--wpds-cursor-control` design token

### DIFF
--- a/packages/fields/src/components/create-template-part-modal/style.scss
+++ b/packages/fields/src/components/create-template-part-modal/style.scss
@@ -64,7 +64,7 @@
 	}
 
 	input[type="radio"]:not(:checked) ~ &::before {
-		cursor: pointer;
+		cursor: var(--wpds-cursor-control);
 	}
 
 	input[type="radio"]:focus-visible ~ &::before {

--- a/packages/fields/src/components/media-edit/style.scss
+++ b/packages/fields/src/components/media-edit/style.scss
@@ -103,7 +103,7 @@ fieldset.fields__media-edit {
 		border-radius: $radius-small;
 		padding: $grid-unit-05 $grid-unit-10;
 		min-height: $grid-unit-50;
-		cursor: pointer;
+		cursor: var(--wpds-cursor-control);
 		min-width: 0;
 
 		&:not(.has-attachment) {


### PR DESCRIPTION

## What?

Part of https://github.com/WordPress/gutenberg/issues/76221


## Why?

Update instances of `cursor: pointer` to use the `--wpds-cursor-control` design token so interactive control cursor behavior can be centrally configured.



## How?

Replaced hardcoded `cursor: pointer` with `cursor: var(--wpds-cursor-control)` in:
- Media edit upload area (`media-edit/style.scss`)
- Create template part modal radio labels (`create-template-part-modal/style.scss`)


## Testing Instructions



### Media Edit
1. Open `http://localhost:8888/wp-admin/`
2. Go to **Appearance → Editor → Templates** (or Pages)
3. Edit any template/page that has a media field (e.g., Featured Image area)
4. Inspect the media upload dropzone — verify `cursor: var(--wpds-cursor-control, pointer)` is applied
5. Hover to confirm the pointer cursor still works

### Create Template Part Modal
1. In the Site Editor, go to **Patterns → Template Parts**
2. Click "Add New Template Part"
3. In the modal, inspect the area radio options (General / Header / Footer)
4. Hover over an unchecked radio label — verify `cursor: var(--wpds-cursor-control, pointer)` on the `::before` pseudo-element
5. Confirm clicking still selects the radio


## Screenshots or screencast <!-- if applicable -->

### Media Edit Before

<img width="1522" height="1344" alt="image" src="https://github.com/user-attachments/assets/0a44d0d7-bb80-49e9-b5ea-caf471a71f68" />


### Media Edit After

<img width="1534" height="1348" alt="image" src="https://github.com/user-attachments/assets/03e0fb5e-81b0-4054-b628-d463673afc6a" />


### Create Template Part Modal Before

<img width="2940" height="1236" alt="image" src="https://github.com/user-attachments/assets/2846a534-fa7a-4934-a342-5720f734a2ea" />


### Create Template Part Modal After

<img width="2940" height="1266" alt="image" src="https://github.com/user-attachments/assets/eeff3d0d-380c-496a-9cfe-86720dbdc2f6" />
