### PR TITLE
Feat: Alow disabling block inspector tab via supports.inspector

### DIFF
--- a/packages/editor/src/components/sidebar/header.js
+++ b/packages/editor/src/components/sidebar/header.js
@@ -17,7 +17,8 @@ import { sidebars } from './constants';
 
 const { Tabs } = unlock( componentsPrivateApis );
 
-const SidebarHeader = ( _, ref ) => {
+const SidebarHeader = ( props, ref ) => {
+	const { hasInspector } = props;
 	const { postTypeLabel, isAttachment, isRevisionsMode } = useSelect(
 		( select ) => {
 			const { getPostTypeLabel, getCurrentPostType } =
@@ -55,7 +56,7 @@ const SidebarHeader = ( _, ref ) => {
 			>
 				{ documentLabel }
 			</Tabs.Tab>
-			{ ! isAttachment && (
+			{ ! isAttachment && hasInspector && (
 				<Tabs.Tab
 					tabId={ sidebars.block }
 					// Used for focus management in the SettingsSidebar component.

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -18,6 +18,7 @@ import { drawerLeft, drawerRight } from '@wordpress/icons';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { store as interfaceStore } from '@wordpress/interface';
+import { store as blocksStore } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -60,6 +61,7 @@ const SidebarContent = ( {
 	onActionPerformed,
 	extraPanels,
 	postType,
+	hasInspector,
 } ) => {
 	const tabListRef = useRef( null );
 	// Because `PluginSidebar` renders a `ComplementaryArea`, we
@@ -132,7 +134,10 @@ const SidebarContent = ( {
 			identifier={ tabName }
 			header={
 				<Tabs.Context.Provider value={ tabsContextValue }>
-					<SidebarHeader ref={ tabListRef } />
+					<SidebarHeader
+						ref={ tabListRef }
+						hasInspector={ hasInspector }
+					/>
 				</Tabs.Context.Provider>
 			}
 			closeLabel={ __( 'Close Settings' ) }
@@ -214,9 +219,26 @@ const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 		[ enableComplementaryArea ]
 	);
 
+	const hasInspector = useSelect( ( select ) => {
+		const clientId = select( blockEditorStore ).getBlockSelectionStart();
+
+		if ( ! clientId ) {
+			return true;
+		}
+
+		const block = select( blockEditorStore ).getBlock( clientId );
+		const blockType = select( blocksStore ).getBlockType( block?.name );
+
+		return blockType?.supports?.inspector !== false;
+	}, [] );
+
 	return (
 		<Tabs
-			selectedTabId={ tabName }
+			selectedTabId={
+				tabName === sidebars.block && ! hasInspector
+					? sidebars.document
+					: tabName
+			}
 			onSelect={ onTabSelect }
 			selectOnMove={ false }
 		>
@@ -227,6 +249,7 @@ const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 				onActionPerformed={ onActionPerformed }
 				extraPanels={ extraPanels }
 				postType={ postType }
+				hasInspector={ hasInspector }
 			/>
 		</Tabs>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #75363

Adds support for disabling the Block Inspector tab via a new `supports.inspector` flag. When set to false, the "Block" tab is not shown and the editor no longer switches to it.

## Why?
Some blocks (e.g. meta-style UI blocks used in locked templates) do not provide meaningful inspector controls. Automatically switching to an empty "Block" tab creates a confusing UX and forces users to manually switch back to the "Document" tab (Post tab).

This change allows such custom blocks to opt out of the Block Inspector entirely, improving usability and consistency.

## How?

- Introduces support for `supports.inspector`
- Prevents rendering of "Block" tab button in `SidebarHeader`
- Ensures fallback to "Document" tab when "Block" tab is unavailable

## Testing Instructions

- Register a test block with:
```
supports: {
	inspector: false,
}
```
- Open the editor
- Insert the block
- Select the block
- Sidebar remains on "Document" tab & no "Block" tab is visible

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="2940" height="1420" alt="image" src="https://github.com/user-attachments/assets/71cb7d34-60aa-411c-8309-26ff348d7744" />|<img width="2940" height="1420" alt="image" src="https://github.com/user-attachments/assets/3be0a389-12c7-4b53-acad-60f13f052b98" />|