### PR TITLE
Editor: Use `--wpds-cursor-control` design token

### DIFF
--- a/packages/editor/src/components/collaborators-presence/styles/collaborators-list.scss
+++ b/packages/editor/src/components/collaborators-presence/styles/collaborators-list.scss
@@ -63,7 +63,7 @@
 		padding: $grid-unit-15 $grid-unit-20;
 		gap: $grid-unit-10;
 		width: 100%;
-		cursor: pointer;
+		cursor: var(--wpds-cursor-control);
 		transition: background-color 0.2s ease;
 
 		&:hover:not(:disabled) {

--- a/packages/editor/src/components/collaborators-presence/styles/collaborators-presence.scss
+++ b/packages/editor/src/components/collaborators-presence/styles/collaborators-presence.scss
@@ -22,7 +22,7 @@
 .editor-collaborators-presence__button.editor-collaborators-presence__button.components-button {
 	display: flex;
 	align-items: center;
-	cursor: pointer;
+	cursor: var(--wpds-cursor-control);
 	position: relative;
 	padding: $grid-unit-05;
 	border-radius: $grid-unit-05;

--- a/packages/editor/src/components/document-outline/style.scss
+++ b/packages/editor/src/components/document-outline/style.scss
@@ -43,7 +43,7 @@
 }
 
 .document-outline__button {
-	cursor: pointer;
+	cursor: var(--wpds-cursor-control);
 	background: none;
 	border: none;
 	display: flex;

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -102,7 +102,7 @@ function Image( { clientId, alt, url } ) {
 				height: '32px',
 				objectFit: 'cover',
 				borderRadius: '2px',
-				cursor: 'pointer',
+				cursor: 'var(--wpds-cursor-control)',
 			} }
 			whileHover={ { scale: 1.08 } }
 		/>

--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -44,7 +44,7 @@
 		min-height: 4px;
 		border: none;
 		padding: 0;
-		cursor: pointer;
+		cursor: var(--wpds-cursor-control);
 		transition: opacity 0.1s ease;
 
 		&.is-added {

--- a/packages/editor/src/components/style-book/constants.ts
+++ b/packages/editor/src/components/style-book/constants.ts
@@ -227,7 +227,7 @@ export const STYLE_BOOK_IFRAME_STYLES = `
 	.editor-style-book__example {
 	    max-width: 900px;
 		border-radius: 2px;
-		cursor: pointer;
+		cursor: var(--wpds-cursor-control);
 		display: flex;
 		flex-direction: column;
 		gap: 40px;

--- a/packages/editor/src/components/style-book/index.js
+++ b/packages/editor/src/components/style-book/index.js
@@ -620,7 +620,7 @@ export const StyleBookBody = ( {
 			<style>
 				{ STYLE_BOOK_IFRAME_STYLES }
 				{ !! onClick &&
-					'body { cursor: pointer; } body * { pointer-events: none; }' }
+					'body { cursor: var(--wpds-cursor-control); } body * { pointer-events: none; }' }
 			</style>
 			<Examples
 				className="editor-style-book__examples"

--- a/packages/editor/src/components/template-actions-panel/style.scss
+++ b/packages/editor/src/components/template-actions-panel/style.scss
@@ -19,7 +19,7 @@
 	}
 
 	&[role="button"] {
-		cursor: pointer;
+		cursor: var(--wpds-cursor-control);
 
 		&:hover .block-editor-block-preview__container::after {
 			outline-color: rgba($black, 0.3);


### PR DESCRIPTION
## What?

Part of https://github.com/WordPress/gutenberg/issues/76221


## Why?

Update instances of `cursor: pointer` to use the `--wpds-cursor-control` design token so interactive control cursor behavior can be centrally configured.

## How?


Replaced hardcoded `cursor: pointer` with `cursor: var(--wpds-cursor-control)` in:
- Document outline button (`document-outline/style.scss`)
- Collaborators presence button (`collaborators-presence/styles/collaborators-presence.scss`)
- Collaborators list item (`collaborators-presence/styles/collaborators-list.scss`)
- Template actions panel role="button" (`template-actions-panel/style.scss`)
- Post revisions preview diff marker (`post-revisions-preview/style.scss`)
- Style book example card (`style-book/constants.ts`)



## Testing Instructions


### Document Outline
1. Open a post with multiple outline elements (like Headings)
2. Open the sidebar → Document tab → Document Outline
3. Inspect a heading button and verify `cursor: var(--wpds-cursor-control, pointer)`

### Collaborators Presence and list items 
1. Open a post being edited by multiple users (or inspect the collaborators button in the top bar)
2. Inspect `.editor-collaborators-presence__button` and `collaborators-presence__list-item` and verify the token

### Template Actions Panel
1. Make sure to enable the experiment - `Editor Inspector: Use DataForm`
2. Edit a page and inspect the sidebar element in `Template: Pages`
3. Inspect the template preview area with `role="button"` and verify the token

### Post Revisions Preview
1. Open a post with revisions, open the revisions panel
2. Inspect the diff markers and verify the token

### Style Book
1. Go to **Appearance → Editor → Styles → Style Book**
2. Inspect any example card and verify `cursor: var(--wpds-cursor-control, pointer)` on `.editor-style-book__example`
## Screenshots or screencast 

### Document Outline



| Before | After |
|--------|-------|
| <img width="1470" height="732" alt="Before" src="https://github.com/user-attachments/assets/62ffe295-3add-43c2-ac52-0fbf77e621b6" /> | <img width="1470" height="671" alt="After" src="https://github.com/user-attachments/assets/897b7454-d24a-488a-953d-5052e969a4f5" /> |

---

### Collaborators Presence and List Items


| Before | After |
|--------|-------|
| <img width="1470" height="719" alt="Before" src="https://github.com/user-attachments/assets/87485256-2dac-4ae8-9e45-c8e42cf6e091" /> | <img width="1470" height="726" alt="After" src="https://github.com/user-attachments/assets/c4341f48-8443-41a9-b668-2d5c611e1089" /> |
| <img width="1470" height="732" alt="Before" src="https://github.com/user-attachments/assets/7ac8295c-c822-4a55-9347-83c2a2f556d6" /> | <img width="1470" height="703" alt="After" src="https://github.com/user-attachments/assets/9e5dbac2-1c6d-40f6-932b-9f6800456fa9" /> |

---

### Template Actions Panel


| Before | After |
|--------|-------|
| <img width="1470" height="730" alt="Before" src="https://github.com/user-attachments/assets/c5bd6041-8d43-4aab-995e-9098ef2e7ed2" /> | <img width="1470" height="689" alt="After" src="https://github.com/user-attachments/assets/994bc04b-800a-419f-89c1-f3d955bfa021" /> |

---

### Post Revisions Preview

| Before | After |
|--------|-------|
| <img width="1470" height="653" alt="Before" src="https://github.com/user-attachments/assets/83439033-0896-43ba-9da8-0efe720aeff5" /> | <img width="1470" height="675" alt="After" src="https://github.com/user-attachments/assets/a41b35ec-992a-41d2-b0a7-7f8795e4cd05" /> |

---

### Style Book


| Before | After |
|--------|-------|
| <img width="1470" height="714" alt="Before" src="https://github.com/user-attachments/assets/f58227fe-a230-4ba0-82aa-671629d9425f" /> | <img width="1470" height="734" alt="After" src="https://github.com/user-attachments/assets/9631642d-b681-476d-9364-b43122421762" /> |


---

### Maybe Upload Media


| Before | After |
|--------|-------|
| <img width="1470" height="639" alt="Screenshot 2026-04-17 at 11 45 24" src="https://github.com/user-attachments/assets/f39e2e89-655b-4e0f-89a7-29496ffd8844" /> | <img width="1470" height="635" alt="Screenshot 2026-04-17 at 11 39 50" src="https://github.com/user-attachments/assets/0be13d34-abeb-4d4e-bd48-1dbbb5051cee" /> |



