### PR TITLE
Jest setup: remove unneeded rAF and URL polyfills

### DIFF
--- a/packages/jest-preset-default/scripts/setup-globals.js
+++ b/packages/jest-preset-default/scripts/setup-globals.js
@@ -3,7 +3,6 @@
 globalThis.SCRIPT_DEBUG = true;
 
 // These are necessary to load TinyMCE successfully.
-global.URL = window.URL;
 global.window.tinyMCEPreInit = {
 	// Without this, TinyMCE tries to determine its URL by looking at the
 	// <script> tag where it was loaded from, which of course fails here.
@@ -12,18 +11,6 @@ global.window.tinyMCEPreInit = {
 
 global.window.setImmediate = function ( callback ) {
 	return setTimeout( callback, 0 );
-};
-
-global.window.requestAnimationFrame = function requestAnimationFrame(
-	callback
-) {
-	const randomDelay = Math.round( ( Math.random() * 1_000 ) / 60 );
-
-	return setTimeout( () => callback( Date.now() ), randomDelay );
-};
-
-global.window.cancelAnimationFrame = function cancelAnimationFrame( handle ) {
-	return clearTimeout( handle );
 };
 
 // Ignoring `options` argument since we unconditionally schedule this ASAP.


### PR DESCRIPTION
When testing #77319 I noticed that our Jest setup has unnecessary polyfills for `requestAnimationFrame` and `URL`. Maybe they were needed in the past, but at some time Jest and JSDOM added support.

This PR removes the unneeded polyfills. We need to keep `setImmediate` and `requestIdleCallback` because they are not implemented by JSDOM.

The JSDOM implementation is a simple `setTimeout` with 16ms timeout. That's simpler than our random timeout between 0 and 16ms.

The HTML standard specifies that the animation frames are triggered by some external source, often dictated by hardware, e.g., a screen refresh rate. That means we have almost complete freedom about when we trigger rAF.