### PR TITLE
Latest Comments: Fix uneven padding issue causing mis-alignment

### DIFF
--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -2,7 +2,7 @@
 // Using `:where` keeps specificity at 0 so global styles, theme.json,
 // and inspector controls can override it without difficulty.
 :where(.wp-block-latest-comments) {
-	padding: 0;
+	padding-left: 0;
 }
 
 // Lower specificity - target list element.

--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -33,13 +33,6 @@ ol.wp-block-latest-comments {
 	}
 }
 
-// Higher specificity - target list via wrapper.
-.wp-block-latest-comments .wp-block-latest-comments {
-	// Remove left spacing. Higher specificity required to
-	// override default wp-block layout styles in the Post/Site editor.
-	padding-left: 0;
-}
-
 .wp-block-latest-comments__comment {
 	list-style: none;
 	margin-bottom: 1em;

--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -1,3 +1,10 @@
+// Reset the browser's default `padding-inline-start: 40px` on `<ol>`.
+// Using `:where` keeps specificity at 0 so global styles, theme.json,
+// and inspector controls can override it without difficulty.
+:where(.wp-block-latest-comments) {
+	padding: 0;
+}
+
 // Lower specificity - target list element.
 ol.wp-block-latest-comments {
 	// Removes left spacing in Customizer Widgets screen.


### PR DESCRIPTION
## What?

Closes #66043

This PR resets the padding for Latest Comments blocks because only left padding is added via user-agent-stylesheet which looks uneven and creates visually uneven layout compared to other blocks.

## Why?

Due to only one side padding for Latest Comments block added via user-agent-stylesheet, it looks visually mis-aligned. While Latest Comments block is technically **list block** but we don't need **bullet points** etc so **extra left indentation** seems unnecessary and creates uneven layout

## How?

This PR updates the Latest Comments block to reset the padding for Latest Comments block. The **key point** here is reset for padding is added using `:where()` which has zero specificity, so it only overrides the user agent stylesheet's padding and Any **global styles, theme.json overrides, or inspector padding** controls will naturally take precedence without needing !important or higher specificity selectors and can be overridden easily.

## Testing Instructions

1. Open any demo or testing Post.
2. Add Latest Comments block.
3. Verify no uneven padding is added.
4. Try to give padding via theme.json and Inspector Styling.
5. Verify those styles are overridden and applied correctly.

## Screenshots or screencast

### Before Fix

<img width="1191" height="474" alt="Before fix" src="https://github.com/user-attachments/assets/d7d2d0f2-cdb4-4e50-9768-35c0a4a98992" />

### After Fix

<img width="1192" height="503" alt="After Fix" src="https://github.com/user-attachments/assets/68343e4a-be2d-4435-9b36-ec11d625f2fa" />

## Use of AI Tools

N/A