### PR TITLE
Allow enabling RTC when encountering a locked post

### DIFF
--- a/lib/compat/wordpress-7.0/post-lock-rtc-compat.php
+++ b/lib/compat/wordpress-7.0/post-lock-rtc-compat.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Adds support for users with sufficient permissions to be able to enable
+ * RTC whenever they encounter a locked post.
+ *
+ * The user who enables the RTC updates the setting directly
+ * through their client. All the other clients are informed through
+ * the heartbeat that RTC has been enabled in settings which prompts
+ * them to save and reload their client so that RTC is enabled for
+ * their client as well.
+ *
+ * @package gutenberg
+ */
+if ( ! function_exists( 'gutenberg_rtc_heartbeat_post_lock' ) ) {
+	/**
+	 * Intercepts the heartbeat request to echo the RTC status based on the global option.
+	 *
+	 * @param array  $response  The Heartbeat response array.
+	 * @param array  $data      The data sent by the client.
+	 * @param string $screen_id The screen ID.
+	 * @return array The modified Heartbeat response.
+	 */
+	function gutenberg_rtc_heartbeat_post_lock( $response, $data, $screen_id ) {
+		if ( ! isset( $data['wp-refresh-post-lock'] ) ) {
+			return $response;
+		}
+
+		$post_id = absint( $data['wp-refresh-post-lock']['post_id'] );
+		if ( ! $post_id ) {
+			return $response;
+		}
+
+		$is_rtc_enabled = get_option( 'wp_collaboration_enabled', false );
+
+		if ( $is_rtc_enabled ) {
+			if ( ! isset( $response['wp-refresh-post-lock'] ) ) {
+				$response['wp-refresh-post-lock'] = array();
+			}
+			$response['wp-refresh-post-lock']['real_time_collaboration'] = true;
+		}
+
+		return $response;
+	}
+
+	add_filter( 'heartbeat_received', 'gutenberg_rtc_heartbeat_post_lock', 20, 3 );
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -120,6 +120,7 @@ require __DIR__ . '/compat/wordpress-7.0/kses.php';
 require __DIR__ . '/compat/wordpress-7.0/media.php';
 require __DIR__ . '/compat/wordpress-7.0/command-palette.php';
 require __DIR__ . '/compat/wordpress-7.0/meta-box-rtc-compat.php';
+require __DIR__ . '/compat/wordpress-7.0/post-lock-rtc-compat.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -11,7 +11,11 @@ import {
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
-import { useEffect, createInterpolateElement } from '@wordpress/element';
+import {
+	useEffect,
+	useState,
+	createInterpolateElement,
+} from '@wordpress/element';
 import { addAction, removeAction } from '@wordpress/hooks';
 import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
@@ -61,7 +65,11 @@ function CollaborationContext() {
 function PostLockedModal() {
 	const instanceId = useInstanceId( PostLockedModal );
 	const hookName = 'core/editor/post-locked-modal-' + instanceId;
-	const { autosave, updatePostLock } = useDispatch( editorStore );
+	const { autosave, savePost, updatePostLock } = useDispatch( editorStore );
+	const { editEntityRecord, saveEditedEntityRecord } =
+		useDispatch( coreStore );
+	const [ showRTCReloadModal, setShowRTCReloadModal ] = useState( false );
+
 	const {
 		isCollaborationEnabled,
 		isLocked,
@@ -72,6 +80,7 @@ function PostLockedModal() {
 		activePostLock,
 		postType,
 		previewLink,
+		canUserEnableRTC,
 	} = useSelect( ( select ) => {
 		const {
 			isCollaborationEnabledForCurrentPost,
@@ -84,7 +93,7 @@ function PostLockedModal() {
 			getEditedPostPreviewLink,
 			getEditorSettings,
 		} = select( editorStore );
-		const { getPostType } = select( coreStore );
+		const { getPostType, canUser } = select( coreStore );
 		return {
 			isCollaborationEnabled: isCollaborationEnabledForCurrentPost(),
 			isLocked: isPostLocked(),
@@ -95,6 +104,7 @@ function PostLockedModal() {
 			activePostLock: getActivePostLock(),
 			postType: getPostType( getEditedPostAttribute( 'type' ) ),
 			previewLink: getEditedPostPreviewLink(),
+			canUserEnableRTC: canUser( 'update', 'settings' ),
 		};
 	}, [] );
 
@@ -115,6 +125,7 @@ function PostLockedModal() {
 			data[ 'wp-refresh-post-lock' ] = {
 				lock: activePostLock,
 				post_id: postId,
+				real_time_collaboration: isCollaborationEnabled,
 			};
 		}
 
@@ -129,6 +140,7 @@ function PostLockedModal() {
 			}
 
 			const received = data[ 'wp-refresh-post-lock' ];
+
 			if ( received.lock_error ) {
 				// Auto save and display the takeover modal.
 				autosave();
@@ -145,6 +157,16 @@ function PostLockedModal() {
 					isLocked: false,
 					activePostLock: received.new_lock,
 				} );
+			}
+
+			// If another user enabled RTC through the modal, we send this through the
+			// heartbeat. If we receive that RTC is enabled in the heartbeat, but it is not in the current state,
+			// we save and reload the page to enable RTC state for the current user.
+			if (
+				received.real_time_collaboration &&
+				! isCollaborationEnabled
+			) {
+				setShowRTCReloadModal( true );
 			}
 		}
 
@@ -183,6 +205,45 @@ function PostLockedModal() {
 			window.removeEventListener( 'beforeunload', releasePostLock );
 		};
 	}, [] );
+
+	if ( showRTCReloadModal ) {
+		return (
+			<Modal
+				title={ __( 'Real-Time Collaboration Enabled' ) }
+				focusOnMount
+				shouldCloseOnClickOutside={ false }
+				shouldCloseOnEsc={ false }
+				isDismissible={ false }
+				className="editor-post-locked-modal"
+				size="medium"
+			>
+				<HStack alignment="top" spacing={ 6 }>
+					<div>
+						<p>
+							{ __(
+								'Another user has just enabled real-time collaboration. To join them and avoid losing your recent changes, please save and reload the editor.'
+							) }
+						</p>
+						<HStack
+							className="editor-post-locked-modal__buttons"
+							justify="flex-end"
+						>
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								onClick={ async () => {
+									await savePost();
+									window.location.reload();
+								} }
+							>
+								{ __( 'Save and Reload' ) }
+							</Button>
+						</HStack>
+					</div>
+				</HStack>
+			</Modal>
+		);
+	}
 
 	if ( ! isLocked ) {
 		return null;
@@ -299,6 +360,29 @@ function PostLockedModal() {
 						className="editor-post-locked-modal__buttons"
 						justify="flex-end"
 					>
+						{ ! isTakeover && canUserEnableRTC && (
+							<Button
+								__next40pxDefaultSize
+								variant="tertiary"
+								onClick={ async () => {
+									await editEntityRecord(
+										'root',
+										'site',
+										undefined,
+										{
+											wp_collaboration_enabled: true,
+										}
+									);
+									await saveEditedEntityRecord(
+										'root',
+										'site'
+									);
+									window.location.reload();
+								} }
+							>
+								{ __( 'Enable real-time collaboration' ) }
+							</Button>
+						) }
 						{ ! isTakeover && (
 							<Button
 								__next40pxDefaultSize


### PR DESCRIPTION
## What?
When a user who can enable RTC encounters a locked post being edited by someone else, they are provided with an option to enable RTC in the Post Locked modal.

This patch implements this using the heartbeats that are sent from the server to the clients.

The user who enables the RTC updates the setting directly through their client. All the other clients are informed through the heartbeat that RTC has been enabled in settings which prompts them to save and reload their client so that RTC is enable for their client as well.

This change also requires to update the [heartbeat processing logic in Core](https://github.com/WordPress/wordpress-develop/blob/5044e953df6e6bc058f8c6bf2eb9e81e4889a9b1/src/wp-admin/includes/misc.php#L1198) to send `real_time_collaboration` state as in [this branch](https://github.com/JDeepD/gutenberg/blob/feat/allow-rtc-on-locked-post/lib/compat/wordpress-7.0/post-lock-rtc-compat.php).

Closes https://github.com/WordPress/gutenberg/issues/76666


## Why?
This change is necessary so that we do not have to ask the client editing the post to exit out of the editor and edit again after we have enabled RTC.

## How?
- Consider that RTC is disabled on the site.
- User A is editing a post
- User B wants to edit that same post but receives a popup that the post is being edited by User A. If they have necessary permissions, they are given the option to enable RTC in the modal itself.
- When they click on the button to enable RTC, the admin setting is updated through the REST API and User B's screen reloads to update the window with the appropriate RTC states.
- To notify User A that RTC has been enabled, we modify the heartbeat messages to include `real_time_collaboration` state. This state is taken from the admin options and always reflects the state as it is in the backend. When User A's client finds that  `real_time_collaboration` is true in the heartbeat but it is false in the window, it informs the user that RTC has been enabled by someone else and asks them to save and reload the page to update the window state with appropriate RTC states.

## Testing Instructions
Here are the complete testing instructions to add to your PR. They cover the happy path, the heartbeat sync, and the security permissions check we implemented.

## Testing Instructions

1. Ensure RTC is disabled (Settings > Writing > Collaboration).
2. Create 2 Users who have permissions for editing admin settings (e.g., two Administrators).
3. Log in as **User A** in one browser (or a standard window) and create or edit a post. Add some text to the post, but do not save or exit. Leave the editor open.
4. Log in as **User B** in a different browser (or an incognito window) and navigate to edit the exact same post.
5. Verify that User B sees the "Post Locked" modal ("This post is already being edited").
6. Verify that the **"Enable real-time collaboration"** button is visible in this modal for User B.
7. Click the **"Enable real-time collaboration"** button as User B.
8. Verify that User B's page automatically reloads and successfully enters the editor.
9. Switch back to **User A**'s browser. Wait for the next heartbeat tick (heartbeat in editor happens in interval of 10 seconds so there might be a bit of delay).
10. Verify that a new modal appears for User A stating: *"Another user has just enabled real-time collaboration. To join them and avoid losing your recent changes, please save and reload the editor."*
11. Click the **"Save and Reload"** button as User A.
12. Verify that User A's page saves the unsaved text, reloads without triggering a native browser "leave site" warning, and successfully joins the editor alongside User B.
13. **Test Permissions Check:** Go to Settings and disable RTC again. 
14. Log in as a user *without* permissions to edit global settings (e.g., a standard Author or Contributor). 
15. Have User A lock a post again, and have the Author open it.
16. Verify that the Author sees the locked post modal, but **does not** see the "Enable real-time collaboration" button.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/aa939005-c588-4a83-8a5b-6866bac9361e

## Use of AI Tools
- Used Claude Sonnet 4.5, Gemini 3.1 Pro and Minimax2.5 for research, editor code suggestions and code review.