### PR TITLE
Paragraph: Refactor replacement logic in 'useOnEnter' hook

### DIFF
--- a/packages/block-library/src/paragraph/use-enter.js
+++ b/packages/block-library/src/paragraph/use-enter.js
@@ -9,24 +9,20 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import {
 	hasBlockSupport,
 	createBlock,
+	cloneBlock,
 	getDefaultBlockName,
 } from '@wordpress/blocks';
 
 export function useOnEnter( props ) {
 	const { batch } = useRegistry();
-	const {
-		moveBlocksToPosition,
-		replaceInnerBlocks,
-		duplicateBlocks,
-		insertBlock,
-	} = useDispatch( blockEditorStore );
+	const { moveBlocksToPosition, replaceBlocks, selectionChange } =
+		useDispatch( blockEditorStore );
 	const {
 		getBlockRootClientId,
 		getBlockIndex,
 		getBlockOrder,
 		getBlockName,
 		getBlock,
-		getNextBlockClientId,
 		canInsertBlockType,
 	} = useSelect( blockEditorStore );
 	const propsRef = useRef( props );
@@ -104,24 +100,22 @@ export function useOnEnter( props ) {
 
 			// If it is in the middle, split the block in two.
 			const wrapperBlock = getBlock( wrapperClientId );
-			batch( () => {
-				duplicateBlocks( [ wrapperClientId ] );
-				const blockIndex = getBlockIndex( wrapperClientId );
+			const head = cloneBlock( {
+				...wrapperBlock,
+				innerBlocks: wrapperBlock.innerBlocks.slice( 0, position ),
+			} );
+			const middle = createBlock( defaultBlockName );
+			const tail = cloneBlock( {
+				...wrapperBlock,
+				innerBlocks: wrapperBlock.innerBlocks.slice( position + 1 ),
+			} );
 
-				replaceInnerBlocks(
-					wrapperClientId,
-					wrapperBlock.innerBlocks.slice( 0, position )
-				);
-				replaceInnerBlocks(
-					getNextBlockClientId( wrapperClientId ),
-					wrapperBlock.innerBlocks.slice( position + 1 )
-				);
-				insertBlock(
-					createBlock( defaultBlockName ),
-					blockIndex + 1,
-					grandparentClientId,
-					true
-				);
+			batch( () => {
+				replaceBlocks( wrapperClientId, [ head, middle, tail ] );
+				// The selected paragraph is a descendant of the replaced
+				// wrapper, so `replaceBlocks` leaves the selection stale.
+				// Move it to the new default block explicitly.
+				selectionChange( middle.clientId );
 			} );
 		}
 


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/77291#issuecomment-4242550875.

PR refactors `useOnEnter` hook's split in the middle logic to use`replaceBlocks` + `selectionChange` action combo. This matches implementations for List Item and Button blocks.

## Why?
Simplifies the logic and reduces the failure rate with a single `replaceBlocks` call.

## Testing Instructions
1. Open a post or page.
2. Add a group with an empty paragraph, followed by an image.
3. Move selection back to paragraph and press <kbd>Enter</kbd>
4. Paragraph should be placed in the middle of the two Group blocks, and the image should be in the last one.

Behavior has good test coverage via `test/e2e/specs/editor/various/splitting-merging.spec.js.`

### Testing Instructions for Keyboard
Same.
