### PR TITLE
UI: Use shared style-imports types

### DIFF
--- a/packages/ui/src/types/css-modules.d.ts
+++ b/packages/ui/src/types/css-modules.d.ts
@@ -1,4 +1,0 @@
-declare module '*.module.css' {
-	const classes: { [ key: string ]: string };
-	export default classes;
-}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"types": [ "node", "jest" ]
+		"types": [ "node", "jest", "style-imports" ]
 	},
 	"references": [
 		{ "path": "../a11y" },


### PR DESCRIPTION
## What?
Follow-up to the shared TypeScript style import typings setup by switching `@wordpress/ui` to the existing `style-imports` definitions.

## Why?
`@wordpress/ui` had a package-local `*.module.css` declaration that duplicated part of the shared typing already available in `typings/style-imports`.

## How?
- add `style-imports` to `packages/ui/tsconfig.json`
- remove the local `packages/ui/src/types/css-modules.d.ts` declaration file

## Testing Instructions
1. Run `./node_modules/.bin/tsc -p packages/ui/tsconfig.json --pretty false`.
2. Confirm the command completes without CSS module import type errors.

## Use of AI Tools
Cursor was used to help prepare the change and draft this pull request. I reviewed the result before submitting it.