### PR TITLE
blocks: Port over some of the type information for @wordpress/blocks from DefinitelyTyped

### DIFF
--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- `registerBlockType`: Introduced a slightly modified version of the generics from `@types/wordpress__blocks`
+- `registerBlockVariation`, `unregisterBlockVariation` updated the types to match the dispatch call
+
 ## 15.17.0 (2026-04-15)
 
 ## 15.16.0 (2026-04-01)

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -607,31 +607,7 @@ _Parameters_
 
 ### registerBlockType
 
-Registers a new block provided a unique name and an object defining its behavior. Once registered, the block is made available as an option to any editor interface where blocks are implemented.
-
-For more in-depth information on registering a custom block see the [Create a block tutorial](https://developer.wordpress.org/block-editor/getting-started/create-block/).
-
-_Usage_
-
-```js
-import { __ } from '@wordpress/i18n';
-import { registerBlockType } from '@wordpress/blocks';
-
-registerBlockType( 'namespace/block-name', {
-	title: __( 'My First Block' ),
-	edit: () => <div>{ __( 'Hello from the editor!' ) }</div>,
-	save: () => <div>Hello from the saved content!</div>,
-} );
-```
-
-_Parameters_
-
--   _blockNameOrMetadata_ `string | Record< string, unknown >`: Block type name or its metadata.
--   _settings_ `Partial< BlockType >`: Block settings.
-
-_Returns_
-
--   `BlockType | undefined`: The block, if it has been successfully registered; otherwise `undefined`.
+Undocumented declaration.
 
 ### registerBlockVariation
 
@@ -666,7 +642,7 @@ const ExampleComponent = () => {
 _Parameters_
 
 -   _blockName_ `string`: Name of the block (example: “core/columns”).
--   _variation_ `BlockVariation`: Object describing a block variation.
+-   _variation_ `BlockVariation | BlockVariation[]`: Object describing a block variation.
 
 ### serialize
 
@@ -943,7 +919,7 @@ const ExampleComponent = () => {
 _Parameters_
 
 -   _blockName_ `string`: Name of the block (example: “core/columns”).
--   _variationName_ `string`: Name of the variation defined for the block.
+-   _variationName_ `string | string[]`: Name of the variation defined for the block.
 
 ### updateCategory
 

--- a/packages/blocks/src/api/registration.ts
+++ b/packages/blocks/src/api/registration.ts
@@ -19,6 +19,7 @@ import type {
 	BlockStyle,
 	BlockBindingsSource,
 	Icon,
+	BlockConfiguration,
 } from '../types';
 
 function isObject( object: unknown ): object is Record< string, unknown > {
@@ -125,9 +126,23 @@ function getBlockSettingsFromMetadata( {
  * @return The block, if it has been successfully registered;
  *         otherwise `undefined`.
  */
-export function registerBlockType(
-	blockNameOrMetadata: string | Record< string, unknown >,
-	settings: Partial< BlockType >
+export function registerBlockType<
+	Attributes extends Record< string, unknown > = Record< string, unknown >,
+>(
+	blockNameOrMetadata: BlockConfiguration< Attributes >,
+	settings?: Partial< BlockConfiguration< Attributes > >
+): BlockType | undefined;
+export function registerBlockType<
+	Attributes extends Record< string, unknown > = Record< string, unknown >,
+>(
+	blockNameOrMetadata: string,
+	settings: BlockConfiguration< Attributes >
+): BlockType | undefined;
+export function registerBlockType<
+	Attributes extends Record< string, unknown > = Record< string, unknown >,
+>(
+	blockNameOrMetadata: string | BlockConfiguration< Attributes >,
+	settings?: Partial< BlockConfiguration< Attributes > >
 ): BlockType | undefined {
 	const name = isObject( blockNameOrMetadata )
 		? blockNameOrMetadata.name
@@ -662,9 +677,15 @@ export const getBlockVariations = (
  */
 export const registerBlockVariation = (
 	blockName: string,
-	variation: BlockVariation
+	variation: BlockVariation | BlockVariation[]
 ): void => {
-	if ( typeof variation.name !== 'string' ) {
+	if ( Array.isArray( variation ) ) {
+		for ( const v of variation ) {
+			if ( typeof v.name !== 'string' ) {
+				warning( 'Variation names must be unique strings.' );
+			}
+		}
+	} else if ( typeof variation.name !== 'string' ) {
 		warning( 'Variation names must be unique strings.' );
 	}
 
@@ -698,7 +719,7 @@ export const registerBlockVariation = (
  */
 export const unregisterBlockVariation = (
 	blockName: string,
-	variationName: string
+	variationName: string | string[]
 ): void => {
 	dispatch( blocksStore ).removeBlockVariations( blockName, variationName );
 };


### PR DESCRIPTION
## What?
Closes #77390

This PR adds in the generics that were missing and patches up some differences between the types added in #76312 and the underlying code. It also includes a couple of spots where I patched up mismatches between the types and the underlying logic of the `select` and `dispatch` calls in the process of porting over the types.

## Why?
This PR fixes issues introduced by the differences between the types added in #76312 and the DefinitelyTyped version.

## How?
I ported over the original typedefs where useful and tweaked the ones that didn't match. I didn't rename any of the new types, so there will still be compatibility issues in some cases, but those are fixable via a quick find-and-replace, so I didn't think that the added changes in this PR would be worth it

## Testing Instructions
1. Build the project
2. Try building something that previously relied on `@types/wordpress__blocks` with the built types
   - You may need to do some substitutions for the updated type names, but the key part is the generics