### PR TITLE
TypeScript: Share React CSS custom properties typing

### DIFF
--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -190,9 +190,9 @@ export function DefaultConnectorSettings( {
 			className="connector-settings"
 			style={
 				readOnly
-					? ( {
+					? {
 							'--wp-components-color-background': '#f0f0f0',
-					  } as React.CSSProperties )
+					  }
 					: undefined
 			}
 		>

--- a/packages/connectors/tsconfig.json
+++ b/packages/connectors/tsconfig.json
@@ -1,6 +1,9 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"types": [ "react-css-custom-properties" ]
+	},
 	"references": [
 		{ "path": "../components" },
 		{ "path": "../data" },

--- a/packages/dataviews/src/dataviews/stories/layout-activity.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-activity.tsx
@@ -640,13 +640,11 @@ const LayoutActivityComponent = ( {
 
 	return (
 		<div
-			style={
-				{
-					height: '100%',
-					maxWidth: fullWidth ? undefined : '400px',
-					'--wp-dataviews-color-background': backgroundColor,
-				} as React.CSSProperties
-			}
+			style={ {
+				height: '100%',
+				maxWidth: fullWidth ? undefined : '400px',
+				'--wp-dataviews-color-background': backgroundColor,
+			} }
 		>
 			<DataViews
 				getItemId={ ( item ) => item.id.toString() }

--- a/packages/dataviews/src/dataviews/stories/layout-grid.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-grid.tsx
@@ -61,12 +61,10 @@ export const LayoutTableComponent = ( {
 	}, [ view ] );
 	return (
 		<div
-			style={
-				{
-					height: '100%',
-					'--wp-dataviews-color-background': backgroundColor,
-				} as React.CSSProperties
-			}
+			style={ {
+				height: '100%',
+				'--wp-dataviews-color-background': backgroundColor,
+			} }
 		>
 			<DataViews
 				getItemId={ ( item ) => item.id.toString() }

--- a/packages/dataviews/src/dataviews/stories/layout-list.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-list.tsx
@@ -63,13 +63,11 @@ export const LayoutTableComponent = ( {
 	}, [ view ] );
 	return (
 		<div
-			style={
-				{
-					height: '100%',
-					maxWidth: fullWidth ? undefined : '400px',
-					'--wp-dataviews-color-background': backgroundColor,
-				} as React.CSSProperties
-			}
+			style={ {
+				height: '100%',
+				maxWidth: fullWidth ? undefined : '400px',
+				'--wp-dataviews-color-background': backgroundColor,
+			} }
 		>
 			<DataViews
 				getItemId={ ( item ) => item.id.toString() }

--- a/packages/dataviews/src/dataviews/stories/layout-table.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-table.tsx
@@ -62,12 +62,10 @@ export const LayoutTableComponent = ( {
 	}, [ view ] );
 	return (
 		<div
-			style={
-				{
-					height: '100%',
-					'--wp-dataviews-color-background': backgroundColor,
-				} as React.CSSProperties
-			}
+			style={ {
+				height: '100%',
+				'--wp-dataviews-color-background': backgroundColor,
+			} }
 		>
 			<DataViews
 				getItemId={ ( item ) => item.id.toString() }

--- a/packages/dataviews/tsconfig.json
+++ b/packages/dataviews/tsconfig.json
@@ -6,7 +6,8 @@
 			"gutenberg-env",
 			"gutenberg-test-env",
 			"jest",
-			"style-imports"
+			"style-imports",
+			"react-css-custom-properties"
 		]
 	},
 	"references": [

--- a/packages/editor/src/components/collaborators-presence/avatar/component.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar/component.tsx
@@ -73,7 +73,7 @@ function Avatar( {
 					'--editor-avatar-name-color': nameColor,
 			  }
 			: {} ),
-	} as React.CSSProperties;
+	};
 
 	const avatar = (
 		<div

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"types": [ "style-imports" ],
+		"types": [ "style-imports", "react-css-custom-properties" ],
 		"checkJs": false
 	},
 	"references": [

--- a/packages/theme/src/color-ramps/stories/brand-fallbacks.story.tsx
+++ b/packages/theme/src/color-ramps/stories/brand-fallbacks.story.tsx
@@ -72,12 +72,10 @@ export default meta;
 export const Default: StoryObj< typeof Verifier > = {
 	render: ( { adminThemeColor } ) => (
 		<div
-			style={
-				{
-					'--wp-admin-theme-color': adminThemeColor,
-					fontSize: 13,
-				} as React.CSSProperties
-			}
+			style={ {
+				'--wp-admin-theme-color': adminThemeColor,
+				fontSize: 13,
+			} }
 		>
 			<p
 				style={ {

--- a/packages/theme/src/use-theme-provider-styles.ts
+++ b/packages/theme/src/use-theme-provider-styles.ts
@@ -228,7 +228,7 @@ export function useThemeProviderStyles( {
 		} );
 	}, [ primary, bg ] );
 
-	const themeProviderStyles = useMemo(
+	const themeProviderStyles: CSSProperties = useMemo(
 		() => ( {
 			...colorStyles,
 			...( cursorControl && {

--- a/packages/theme/tsconfig.src.json
+++ b/packages/theme/tsconfig.src.json
@@ -3,7 +3,7 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"moduleResolution": "bundler",
-		"types": [ "jest", "style-imports" ]
+		"types": [ "jest", "style-imports", "react-css-custom-properties" ]
 	},
 	"exclude": [],
 	"files": [ "global.d.ts" ],

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -2,7 +2,12 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"types": [ "node", "jest", "style-imports" ]
+		"types": [
+			"node",
+			"jest",
+			"style-imports",
+			"react-css-custom-properties"
+		]
 	},
 	"references": [
 		{ "path": "../a11y" },

--- a/typings/react-css-custom-properties/index.d.ts
+++ b/typings/react-css-custom-properties/index.d.ts
@@ -1,4 +1,4 @@
-import 'react';
+export {};
 
 declare module 'react' {
 	interface CSSProperties {


### PR DESCRIPTION
## What?
Follow up to #77388 by moving the React CSS custom properties augmentation into a shared typing that other packages can opt into.

## Why?
`@wordpress/ui` currently owns a package-local `React.CSSProperties` augmentation even though the same CSS custom properties pattern is already used in other packages. Sharing the typing removes that duplication and lets the affected packages drop a few redundant casts.

## How?
- add `typings/react-css-custom-properties`
- switch `@wordpress/ui` to the shared typing and remove its local declaration file
- opt `dataviews`, `editor`, `theme`, and `connectors` into the shared typing
- remove the affected `as React.CSSProperties` casts
- add an explicit `CSSProperties` annotation in `theme` to keep the exported type portable

## Testing Instructions
1. Run `./node_modules/.bin/tsc -p packages/ui/tsconfig.json --pretty false --noEmit`.
2. Run `./node_modules/.bin/tsc -p packages/dataviews/tsconfig.json --pretty false --noEmit`.
3. Run `./node_modules/.bin/tsc -p packages/theme/tsconfig.src.json --pretty false --noEmit`.
4. Run `./node_modules/.bin/tsc -p packages/connectors/tsconfig.json --pretty false --noEmit`.
5. Confirm each command passes without React CSS custom property typing errors.

## Use of AI Tools
Cursor was used to help prepare the change and draft this pull request.