### PR TITLE
CI: Flag issue mentions that are not linked in the Development field

### DIFF
--- a/.github/workflows/check-linked-issues.yml
+++ b/.github/workflows/check-linked-issues.yml
@@ -19,19 +19,33 @@ jobs:
               uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
               with:
                   script: |
+                      // -----------------------------------------------------------------
+                      // Step 1: Gather basic context about the pull request being checked.
+                      // -----------------------------------------------------------------
                       const { owner, repo } = context.repo;
                       const pr = context.payload.pull_request;
                       const prNumber = pr.number;
                       const body = pr.body || '';
 
-                      // Strip HTML comments so template placeholders like
-                      // "Closes <!-- #ISSUE-NUMBER -->" are ignored.
+                      // -----------------------------------------------------------------
+                      // Step 2: Normalise the PR body before parsing.
+                      //
+                      // HTML comments are stripped so placeholders like
+                      // `Closes <!-- #ISSUE-NUMBER -->` in the PR template don't match
+                      // as real issue references.
+                      // -----------------------------------------------------------------
                       const visibleBody = body.replace( /<!--[\s\S]*?-->/g, '' );
 
-                      // Collect referenced issue numbers from:
-                      //   - bare `#123`
-                      //   - `GH-123`
-                      //   - full URLs to issues in this repo
+                      // -----------------------------------------------------------------
+                      // Step 3: Extract every issue number mentioned in the description.
+                      //
+                      // Three forms are recognised:
+                      //   - `#1234`              (short reference)
+                      //   - `GH-1234`            (alternative short form)
+                      //   - Full URLs to issues or pulls in this repo
+                      //
+                      // Numbers are collected into a Set so duplicates collapse.
+                      // -----------------------------------------------------------------
                       const referenced = new Set();
 
                       const shortRefRegex = /(?:^|[^&\w])(?:GH-|#)(\d+)\b/gi;
@@ -48,9 +62,17 @@ jobs:
                           referenced.add( Number( m[ 1 ] ) );
                       }
 
-                      // The PR's own number isn't an "issue mention".
+                      // The PR's own number can appear in URLs (e.g. a screenshot link)
+                      // and is never an "issue mention" of itself.
                       referenced.delete( prNumber );
 
+                      // -----------------------------------------------------------------
+                      // Step 4: Look for an existing bot comment so we can update or
+                      // remove it rather than posting a fresh comment on every run.
+                      //
+                      // A hidden HTML-comment marker uniquely identifies comments left
+                      // by this workflow.
+                      // -----------------------------------------------------------------
                       const marker = '<!-- check-linked-issues-bot -->';
 
                       const comments = await github.paginate(
@@ -76,13 +98,26 @@ jobs:
                           }
                       };
 
+                      // -----------------------------------------------------------------
+                      // Step 5: Early-exit when the description mentions no issues.
+                      //
+                      // If a previous run left a comment, clear it now so the thread
+                      // reflects the current state of the PR body.
+                      // -----------------------------------------------------------------
                       if ( referenced.size === 0 ) {
                           core.info( 'No issue references detected in PR body.' );
                           await clearExistingComment();
                           return;
                       }
 
-                      // Fetch linked issues (the "Development" relationship) via GraphQL.
+                      // -----------------------------------------------------------------
+                      // Step 6: Ask GraphQL which issues GitHub considers "linked".
+                      //
+                      // `closingIssuesReferences` is the exact set of issues that power
+                      // the *Development* section of the right sidebar — populated
+                      // either by closing keywords in the body or by manual linking
+                      // via the UI.
+                      // -----------------------------------------------------------------
                       const query = `
                           query($owner: String!, $repo: String!, $number: Int!) {
                               repository(owner: $owner, name: $repo) {
@@ -105,9 +140,17 @@ jobs:
                           )
                       );
 
-                      // Verify each referenced number is actually an issue in this repo
-                      // (filters out PR-number references, cross-repo refs that happened
-                      // to match, and stale numbers).
+                      // -----------------------------------------------------------------
+                      // Step 7: Reduce `referenced` to the set that is truly unlinked
+                      // and is a real issue in this repository.
+                      //
+                      // `issues.get` is also used to filter out:
+                      //   - references that are actually pull requests (data.pull_request
+                      //     is set for PRs),
+                      //   - numbers that don't exist (404), which can happen for
+                      //     cross-repo or stale references that happened to match the
+                      //     `#N` pattern.
+                      // -----------------------------------------------------------------
                       const unlinked = [];
                       for ( const number of referenced ) {
                           if ( linked.has( number ) ) {
@@ -119,7 +162,6 @@ jobs:
                                   repo,
                                   issue_number: number,
                               } );
-                              // `issues.get` also returns PRs; skip those.
                               if ( data.pull_request ) {
                                   continue;
                               }
@@ -132,6 +174,9 @@ jobs:
                           }
                       }
 
+                      // -----------------------------------------------------------------
+                      // Step 8: Everything is linked — clean up and finish.
+                      // -----------------------------------------------------------------
                       if ( unlinked.length === 0 ) {
                           core.info(
                               'All referenced issues are linked via the Development field.'
@@ -140,6 +185,10 @@ jobs:
                           return;
                       }
 
+                      // -----------------------------------------------------------------
+                      // Step 9: Build the advisory comment body listing unlinked issues
+                      // and explaining the two ways to resolve the notice.
+                      // -----------------------------------------------------------------
                       const list = unlinked
                           .sort( ( a, b ) => a - b )
                           .map( ( n ) => `- #${ n }` )
@@ -161,6 +210,11 @@ jobs:
                           'If a reference is intentionally informational (e.g. *Follow up to #1234*, *See #1234*), no action is needed. This check is advisory and will not block the PR.',
                       ].join( '\n' );
 
+                      // -----------------------------------------------------------------
+                      // Step 10: Post a new comment or update the existing one in place.
+                      // An update is skipped when the body hasn't changed to avoid
+                      // needless notifications on every PR edit.
+                      // -----------------------------------------------------------------
                       if ( existing ) {
                           if ( existing.body !== message ) {
                               await github.rest.issues.updateComment( {
@@ -179,6 +233,8 @@ jobs:
                           } );
                       }
 
+                      // Surface the detection in the Actions log as a warning so it's
+                      // visible in the checks UI without failing the run.
                       core.warning(
                           `Unlinked issue mentions detected: ${ unlinked
                               .map( ( n ) => `#${ n }` )

--- a/.github/workflows/check-linked-issues.yml
+++ b/.github/workflows/check-linked-issues.yml
@@ -1,0 +1,186 @@
+name: Check linked issues on Pull Request
+on:
+    pull_request_target:
+        types: [opened, edited, reopened, synchronize, ready_for_review]
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+    check-linked-issues:
+        name: Flag issue mentions that are not linked
+        runs-on: 'ubuntu-24.04'
+        if: ${{ github.event.pull_request.state == 'open' && github.repository == 'WordPress/gutenberg' }}
+        permissions:
+            pull-requests: write
+        steps:
+            - name: Detect unlinked issue mentions
+              uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+              with:
+                  script: |
+                      const { owner, repo } = context.repo;
+                      const pr = context.payload.pull_request;
+                      const prNumber = pr.number;
+                      const body = pr.body || '';
+
+                      // Strip HTML comments so template placeholders like
+                      // "Closes <!-- #ISSUE-NUMBER -->" are ignored.
+                      const visibleBody = body.replace( /<!--[\s\S]*?-->/g, '' );
+
+                      // Collect referenced issue numbers from:
+                      //   - bare `#123`
+                      //   - `GH-123`
+                      //   - full URLs to issues in this repo
+                      const referenced = new Set();
+
+                      const shortRefRegex = /(?:^|[^&\w])(?:GH-|#)(\d+)\b/gi;
+                      let m;
+                      while ( ( m = shortRefRegex.exec( visibleBody ) ) ) {
+                          referenced.add( Number( m[ 1 ] ) );
+                      }
+
+                      const urlRegex = new RegExp(
+                          `https?://github\\.com/${ owner }/${ repo }/(?:issues|pull)/(\\d+)`,
+                          'gi'
+                      );
+                      while ( ( m = urlRegex.exec( visibleBody ) ) ) {
+                          referenced.add( Number( m[ 1 ] ) );
+                      }
+
+                      // The PR's own number isn't an "issue mention".
+                      referenced.delete( prNumber );
+
+                      const marker = '<!-- check-linked-issues-bot -->';
+
+                      const comments = await github.paginate(
+                          github.rest.issues.listComments,
+                          {
+                              owner,
+                              repo,
+                              issue_number: prNumber,
+                              per_page: 100,
+                          }
+                      );
+                      const existing = comments.find(
+                          ( c ) => c.body && c.body.includes( marker )
+                      );
+
+                      const clearExistingComment = async () => {
+                          if ( existing ) {
+                              await github.rest.issues.deleteComment( {
+                                  owner,
+                                  repo,
+                                  comment_id: existing.id,
+                              } );
+                          }
+                      };
+
+                      if ( referenced.size === 0 ) {
+                          core.info( 'No issue references detected in PR body.' );
+                          await clearExistingComment();
+                          return;
+                      }
+
+                      // Fetch linked issues (the "Development" relationship) via GraphQL.
+                      const query = `
+                          query($owner: String!, $repo: String!, $number: Int!) {
+                              repository(owner: $owner, name: $repo) {
+                                  pullRequest(number: $number) {
+                                      closingIssuesReferences(first: 50) {
+                                          nodes { number }
+                                      }
+                                  }
+                              }
+                          }
+                      `;
+                      const result = await github.graphql( query, {
+                          owner,
+                          repo,
+                          number: prNumber,
+                      } );
+                      const linked = new Set(
+                          ( result.repository.pullRequest.closingIssuesReferences.nodes || [] ).map(
+                              ( n ) => n.number
+                          )
+                      );
+
+                      // Verify each referenced number is actually an issue in this repo
+                      // (filters out PR-number references, cross-repo refs that happened
+                      // to match, and stale numbers).
+                      const unlinked = [];
+                      for ( const number of referenced ) {
+                          if ( linked.has( number ) ) {
+                              continue;
+                          }
+                          try {
+                              const { data } = await github.rest.issues.get( {
+                                  owner,
+                                  repo,
+                                  issue_number: number,
+                              } );
+                              // `issues.get` also returns PRs; skip those.
+                              if ( data.pull_request ) {
+                                  continue;
+                              }
+                              unlinked.push( number );
+                          } catch ( err ) {
+                              if ( err.status === 404 ) {
+                                  continue;
+                              }
+                              throw err;
+                          }
+                      }
+
+                      if ( unlinked.length === 0 ) {
+                          core.info(
+                              'All referenced issues are linked via the Development field.'
+                          );
+                          await clearExistingComment();
+                          return;
+                      }
+
+                      const list = unlinked
+                          .sort( ( a, b ) => a - b )
+                          .map( ( n ) => `- #${ n }` )
+                          .join( '\n' );
+
+                      const message = [
+                          marker,
+                          '### Linked issues check',
+                          '',
+                          "The following issue(s) are mentioned in this PR's description but are **not linked** in the *Development* section of the right sidebar:",
+                          '',
+                          list,
+                          '',
+                          'Release leads and folks writing release notes rely on the *Development* relationship to find every PR associated with a ticket. To link an issue, please either:',
+                          '',
+                          '- Replace the mention with a closing keyword in the PR description (e.g. `Closes #1234`, `Fixes #1234`, or `Resolves #1234`), **or**',
+                          '- Manually link the issue from the *Development* section on the right sidebar of this PR.',
+                          '',
+                          'If a reference is intentionally informational (e.g. *Follow up to #1234*, *See #1234*), no action is needed. This check is advisory and will not block the PR.',
+                      ].join( '\n' );
+
+                      if ( existing ) {
+                          if ( existing.body !== message ) {
+                              await github.rest.issues.updateComment( {
+                                  owner,
+                                  repo,
+                                  comment_id: existing.id,
+                                  body: message,
+                              } );
+                          }
+                      } else {
+                          await github.rest.issues.createComment( {
+                              owner,
+                              repo,
+                              issue_number: prNumber,
+                              body: message,
+                          } );
+                      }
+
+                      core.warning(
+                          `Unlinked issue mentions detected: ${ unlinked
+                              .map( ( n ) => `#${ n }` )
+                              .join( ', ' ) }`
+                      );


### PR DESCRIPTION
## What?

Closes #77397

Adds a new advisory CI workflow, `check-linked-issues.yml`, that scans every open PR's description for issue references (`#1234`, `GH-1234`, or full issue URLs) and compares them against the PR's *Development* relationship (GraphQL `closingIssuesReferences`). If any referenced issue isn't linked, the workflow posts or updates a sticky comment explaining how to link it.

## Why?

Based on Amy's feedback: anything included in a release should be **linked** (not just mentioned) in the PR description so that it shows up in the *Development* section on the right sidebar of the related ticket. Today, tracking tickets like the per-release editor tasks ticket rely on release leads manually following every comment and every PR mentioned in every tracker to figure out what belongs in the release — and things still slip through. Surfacing the relationship in the sidebar lets release leads and release-note writers find every PR attached to a ticket at a glance.

The check is intentionally **non-invasive**:

- It does not edit the PR body.
- It does not fail the PR — it's advisory.
- It only comments when unlinked mentions are detected; it clears its own comment once they're linked.
- Informational mentions (e.g. *Follow up to #1234*, *See #1234*) can be left as-is if intentional.

A more aggressive variant (auto-appending a bot-managed `Closes #N` block to the PR body) was considered but not chosen, because closing keywords also auto-close the referenced issue on merge — which is wrong for informational references. A future iteration can layer automatic linking on top of this check if desired.

## How?

- New workflow: `.github/workflows/check-linked-issues.yml`.
- Runs on `pull_request_target` (`opened`, `edited`, `reopened`, `synchronize`, `ready_for_review`) so it reacts to description edits.
- Uses `actions/github-script` to:
    1. Strip HTML comments from the body (avoids matching the `Closes <!-- #ISSUE-NUMBER -->` placeholder in the PR template).
    2. Extract referenced numbers from bare `#N`, `GH-N`, and in-repo issue/pull URLs.
    3. Query `closingIssuesReferences` to determine which are already linked via the *Development* field.
    4. Verify each remaining number resolves to an issue (not a PR and not 404) to filter cross-repo and stale references.
    5. Post or update a single sticky comment (marked with an HTML-comment tag) listing unlinked references; delete the comment once everything is linked.
- Uses the default `GITHUB_TOKEN` with scoped `pull-requests: write` permission. No additional secrets required.
- Gated to `WordPress/gutenberg` and open PRs only.
- The script itself is annotated with step-by-step block comments (Step 1–10) to make the flow easy to follow for future maintainers.

## Testing Instructions

1. Open or edit a test PR that mentions an issue in the body without a closing keyword (e.g. `See #100`).
2. Confirm the workflow runs and posts a comment listing the unlinked issue.
3. Update the PR body to use `Closes #100` (or manually link the issue from the *Development* sidebar).
4. Re-trigger the workflow (edit the body or push) and confirm the comment is removed.
5. Verify a PR description with no issue mentions produces no comment.
6. Verify a PR description that only mentions PR numbers (not issue numbers) produces no comment.

## Follow-ups

- If this approach works well, consider tightening to a required check (`exit_type: failure`) after a grace period.
- Could be extended to enforce the relationship for PRs labeled with a release milestone only.
- Optional: layer in automatic linking for references that clearly use closing verbs in prose (e.g. *fixes issue #123*) but aren't formatted correctly.