### PR TITLE
Editor: Add Edit / Suggest / View intent mode scaffolding

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -381,6 +381,20 @@ _Returns_
 
 -   `Array`: Block list.
 
+### getEditorIntent
+
+Returns the current editor intent. The intent represents the user's editing purpose — directly editing content (`edit`), suggesting changes that the author can apply or reject (`suggest`), or viewing the post in a read-only mode (`view`).
+
+The intent is orthogonal to the `editorMode` preference (visual vs. code).
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `string`: The current editor intent. One of `edit`, `suggest`, `view`.
+
 ### getEditorMode
 
 Returns the current editing mode.
@@ -1502,6 +1516,16 @@ _Parameters_
 _Returns_
 
 -   `Object`: Action object.
+
+### setEditorIntent
+
+Sets the current editor intent.
+
+The intent represents the user's editing purpose: directly editing content (`edit`), suggesting changes that the author can apply or reject (`suggest`), or viewing the post in a read-only mode (`view`). It is orthogonal to the `editorMode` preference (visual vs. code).
+
+_Parameters_
+
+-   _intent_ `'edit'|'suggest'|'view'`: The editor intent to set.
 
 ### setIsInserterOpened
 

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -61,6 +61,7 @@ export function initializeEditor(
 
 	dispatch( preferencesStore ).setDefaults( 'core', {
 		allowRightClickOverrides: true,
+		editorIntent: 'edit',
 		editorMode: 'visual',
 		editorTool: 'edit',
 		fixedToolbar: false,

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -63,6 +63,7 @@ export function initializeEditor( id, settings ) {
 	dispatch( preferencesStore ).setDefaults( 'core', {
 		allowRightClickOverrides: true,
 		distractionFree: false,
+		editorIntent: 'edit',
 		editorMode: 'visual',
 		editorTool: 'edit',
 		fixedToolbar: false,

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Added an `editorIntent` preference (`edit`, `suggest`, `view`) with a matching `setEditorIntent` action and `getEditorIntent` selector. Surfaced as an Edit / Suggest / View menu in the editor options for post types that support notes. The `view` intent puts the block editor into a read-only preview.
+
 ## 14.43.0 (2026-04-01)
 
 ## 14.42.0 (2026-03-18)

--- a/packages/editor/src/components/intent-switcher/index.js
+++ b/packages/editor/src/components/intent-switcher/index.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { MenuItemsChoice, MenuGroup } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import PostTypeSupportCheck from '../post-type-support-check';
+
+/**
+ * Set of available editor intent options.
+ *
+ * @type {Array}
+ */
+const INTENTS = [
+	{
+		value: 'edit',
+		label: __( 'Edit' ),
+		info: __( 'Edit content directly.' ),
+	},
+	{
+		value: 'suggest',
+		label: __( 'Suggest' ),
+		info: __( 'Propose changes the author can apply or reject.' ),
+	},
+	{
+		value: 'view',
+		label: __( 'View' ),
+		info: __( 'Read-only preview of the content.' ),
+	},
+];
+
+/**
+ * Editor intent switcher. Lets the user pick between direct editing,
+ * suggesting changes, or viewing in read-only. Only rendered for post
+ * types that declare the `editor.notes` support.
+ */
+function IntentSwitcher() {
+	const intent = useSelect(
+		( select ) => select( editorStore ).getEditorIntent(),
+		[]
+	);
+	const { setEditorIntent } = useDispatch( editorStore );
+
+	return (
+		<PostTypeSupportCheck supportKeys="editor.notes">
+			<MenuGroup label={ __( 'Mode' ) }>
+				<MenuItemsChoice
+					choices={ INTENTS }
+					value={ intent }
+					onSelect={ setEditorIntent }
+				/>
+			</MenuGroup>
+		</PostTypeSupportCheck>
+	);
+}
+
+export default IntentSwitcher;

--- a/packages/editor/src/components/more-menu/index.js
+++ b/packages/editor/src/components/more-menu/index.js
@@ -21,6 +21,7 @@ import { store as interfaceStore, ActionItem } from '@wordpress/interface';
  * Internal dependencies
  */
 import CopyContentMenuItem from './copy-content-menu-item';
+import IntentSwitcher from '../intent-switcher';
 import ModeSwitcher from '../mode-switcher';
 import ToolsMoreMenuGroup from './tools-more-menu-group';
 import ViewMoreMenuGroup from './view-more-menu-group';
@@ -110,6 +111,7 @@ export default function MoreMenu( { disabled = false } ) {
 							/>
 							<ViewMoreMenuGroup.Slot fillProps={ { onClose } } />
 						</MenuGroup>
+						<IntentSwitcher />
 						<ModeSwitcher />
 						<ActionItem.Slot
 							name="core/plugin-more-menu"

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -129,6 +129,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		focusMode,
 		hasFixedToolbar,
 		isDistractionFree,
+		isViewIntent,
 		keepCaretInsideBlock,
 		hasUploadPermissions,
 		hiddenBlockTypes,
@@ -199,6 +200,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 					get( 'core', 'fixedToolbar' ) || ! isLargeViewport,
 				hiddenBlockTypes: get( 'core', 'hiddenBlockTypes' ),
 				isDistractionFree: get( 'core', 'distractionFree' ),
+				isViewIntent: get( 'core', 'editorIntent' ) === 'view',
 				keepCaretInsideBlock: get( 'core', 'keepCaretInsideBlock' ),
 				hasUploadPermissions:
 					canUser( 'create', {
@@ -403,13 +405,14 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			[ isNavigationOverlayContextKey ]: isNavigationOverlayContext,
 		};
 
-		if ( isRevisionsMode ) {
+		if ( isRevisionsMode || isViewIntent ) {
 			blockEditorSettings.isPreviewMode = true;
 		}
 
 		return blockEditorSettings;
 	}, [
 		isRevisionsMode,
+		isViewIntent,
 		allowedBlockTypes,
 		allowRightClickOverrides,
 		focusMode,

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -1065,6 +1065,36 @@ export const switchEditorMode =
 	};
 
 /**
+ * Sets the current editor intent.
+ *
+ * The intent represents the user's editing purpose: directly editing content
+ * (`edit`), suggesting changes that the author can apply or reject
+ * (`suggest`), or viewing the post in a read-only mode (`view`). It is
+ * orthogonal to the `editorMode` preference (visual vs. code).
+ *
+ * @param {'edit'|'suggest'|'view'} intent The editor intent to set.
+ */
+export const setEditorIntent =
+	( intent ) =>
+	( { registry } ) => {
+		if ( intent !== 'edit' && intent !== 'suggest' && intent !== 'view' ) {
+			return;
+		}
+
+		registry
+			.dispatch( preferencesStore )
+			.set( 'core', 'editorIntent', intent );
+
+		if ( intent === 'edit' ) {
+			speak( __( 'Edit mode selected' ), 'assertive' );
+		} else if ( intent === 'suggest' ) {
+			speak( __( 'Suggest mode selected' ), 'assertive' );
+		} else if ( intent === 'view' ) {
+			speak( __( 'View mode selected' ), 'assertive' );
+		}
+	};
+
+/**
  * Returns an action object used in signalling that the user opened the publish
  * sidebar.
  *

--- a/packages/editor/src/store/constants.ts
+++ b/packages/editor/src/store/constants.ts
@@ -37,3 +37,18 @@ export const DESIGN_POST_TYPES = [
 	PATTERN_POST_TYPE,
 	NAVIGATION_POST_TYPE,
 ];
+
+/**
+ * Editor intent values. The intent represents the user's current editing
+ * purpose (edit the post directly, suggest changes, or view in read-only).
+ * It is orthogonal to the `editorMode` preference (visual vs. code).
+ */
+export const EDITOR_INTENT_EDIT = 'edit';
+export const EDITOR_INTENT_SUGGEST = 'suggest';
+export const EDITOR_INTENT_VIEW = 'view';
+export const EDITOR_INTENTS = [
+	EDITOR_INTENT_EDIT,
+	EDITOR_INTENT_SUGGEST,
+	EDITOR_INTENT_VIEW,
+] as const;
+export type EditorIntent = ( typeof EDITOR_INTENTS )[ number ];

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1386,6 +1386,23 @@ export const getEditorMode = createRegistrySelector(
 		select( preferencesStore ).get( 'core', 'editorMode' ) ?? 'visual'
 );
 
+/**
+ * Returns the current editor intent. The intent represents the user's
+ * editing purpose — directly editing content (`edit`), suggesting changes
+ * that the author can apply or reject (`suggest`), or viewing the post in
+ * a read-only mode (`view`).
+ *
+ * The intent is orthogonal to the `editorMode` preference (visual vs. code).
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {string} The current editor intent. One of `edit`, `suggest`, `view`.
+ */
+export const getEditorIntent = createRegistrySelector(
+	( select ) => () =>
+		select( preferencesStore ).get( 'core', 'editorIntent' ) ?? 'edit'
+);
+
 /*
  * Backward compatibility
  */

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -547,6 +547,54 @@ describe( 'Editor actions', () => {
 		} );
 	} );
 
+	describe( 'setEditorIntent', () => {
+		let registry;
+
+		beforeEach( () => {
+			registry = createRegistryWithStores();
+		} );
+
+		it( 'defaults to edit', () => {
+			expect( registry.select( editorStore ).getEditorIntent() ).toEqual(
+				'edit'
+			);
+		} );
+
+		it( 'switches between edit, suggest, and view', () => {
+			registry.dispatch( editorStore ).setEditorIntent( 'suggest' );
+			expect( registry.select( editorStore ).getEditorIntent() ).toEqual(
+				'suggest'
+			);
+
+			registry.dispatch( editorStore ).setEditorIntent( 'view' );
+			expect( registry.select( editorStore ).getEditorIntent() ).toEqual(
+				'view'
+			);
+
+			registry.dispatch( editorStore ).setEditorIntent( 'edit' );
+			expect( registry.select( editorStore ).getEditorIntent() ).toEqual(
+				'edit'
+			);
+		} );
+
+		it( 'ignores unknown intents', () => {
+			registry.dispatch( editorStore ).setEditorIntent( 'suggest' );
+			registry.dispatch( editorStore ).setEditorIntent( 'bogus' );
+			expect( registry.select( editorStore ).getEditorIntent() ).toEqual(
+				'suggest'
+			);
+		} );
+
+		it( 'persists to the preferences store', () => {
+			registry.dispatch( editorStore ).setEditorIntent( 'view' );
+			expect(
+				registry
+					.select( preferencesStore )
+					.get( 'core', 'editorIntent' )
+			).toEqual( 'view' );
+		} );
+	} );
+
 	describe( 'toggleDistractionFree', () => {
 		it( 'should properly update settings to prevent layout corruption when enabling distraction free mode', () => {
 			const registry = createRegistryWithStores();

--- a/test/e2e/specs/editor/various/editor-intent-switcher.spec.js
+++ b/test/e2e/specs/editor/various/editor-intent-switcher.spec.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+async function openIntentSwitcher( page ) {
+	await page.click(
+		'role=region[name="Editor top bar"i] >> role=button[name="Options"i]'
+	);
+}
+
+test.describe( 'Editor intent switcher', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'defaults to Edit intent and persists across reload', async ( {
+		page,
+		editor,
+	} ) => {
+		await openIntentSwitcher( page );
+
+		const editChoice = page.getByRole( 'menuitemradio', { name: 'Edit' } );
+		const suggestChoice = page.getByRole( 'menuitemradio', {
+			name: 'Suggest',
+		} );
+		const viewChoice = page.getByRole( 'menuitemradio', { name: 'View' } );
+
+		await expect( editChoice ).toBeVisible();
+		await expect( suggestChoice ).toBeVisible();
+		await expect( viewChoice ).toBeVisible();
+		await expect( editChoice ).toHaveAttribute( 'aria-checked', 'true' );
+
+		// Select Suggest and confirm selection persists across reload.
+		await suggestChoice.click();
+		await page.reload();
+		await editor.canvas.locator( 'body' ).waitFor();
+		await openIntentSwitcher( page );
+		await expect(
+			page.getByRole( 'menuitemradio', { name: 'Suggest' } )
+		).toHaveAttribute( 'aria-checked', 'true' );
+	} );
+
+	test( 'View intent makes blocks read-only', async ( { editor, page } ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Initial content' },
+		} );
+
+		await openIntentSwitcher( page );
+		await page.getByRole( 'menuitemradio', { name: 'View' } ).click();
+
+		// In preview mode, block content is not editable — the paragraph
+		// should render but clicking and typing should not change it.
+		const paragraph = editor.canvas.getByText( 'Initial content' );
+		await expect( paragraph ).toBeVisible();
+		await expect( paragraph ).not.toHaveAttribute(
+			'contenteditable',
+			'true'
+		);
+	} );
+} );


### PR DESCRIPTION
## Summary
- Introduces an `editorIntent` preference (`edit`, `suggest`, `view`) orthogonal to the visual/code `editorMode`
- Adds `setEditorIntent` action and `getEditorIntent` selector in the editor store
- Surfaces as an Edit / Suggest / View menu in the Options kebab, gated on `editor.notes` post type support
- `view` intent reuses `isPreviewMode` for read-only block rendering

**Phase 1 of 4** for Suggest mode ([stacked PR series](#73411)).

## Test plan
- [ ] Open post editor → Options kebab → confirm Edit/Suggest/View menu appears
- [ ] Select Suggest → reload → confirm Suggest is persisted
- [ ] Select View → confirm blocks are non-editable (contenteditable=false)
- [ ] Unit tests: `npm run test:unit -- packages/editor/src/store/test/actions.js --testNamePattern=setEditorIntent`
- [ ] E2E: `npm run test:e2e -- test/e2e/specs/editor/various/editor-intent-switcher.spec.js`

Refs https://github.com/WordPress/gutenberg/issues/73411
Refs https://github.com/WordPress/gutenberg/issues/73410