### PR TITLE
Editor: Capture Suggest-mode edits as an in-memory overlay

### DIFF
--- a/lib/compat/wordpress-6.9/block-comments.php
+++ b/lib/compat/wordpress-6.9/block-comments.php
@@ -48,6 +48,49 @@ function gutenberg_register_block_comment_metadata() {
 			},
 		)
 	);
+
+	// Suggestion payload attached to a note. A note comment with this meta set
+	// is a suggested edit: the value is a JSON-encoded payload describing the
+	// block, baseline revision, and proposed operations. See
+	// packages/editor/src/components/suggestion-mode/provider.js for the shape.
+	register_meta(
+		'comment',
+		'_wp_suggestion',
+		array(
+			'type'          => 'string',
+			'description'   => __( 'Suggested edit payload (JSON).', 'gutenberg' ),
+			'single'        => true,
+			'show_in_rest'  => array(
+				'schema' => array(
+					'type' => 'string',
+				),
+			),
+			'auth_callback' => function ( $allowed, $meta_key, $object_id ) {
+				return current_user_can( 'edit_comment', $object_id );
+			},
+		)
+	);
+
+	// Lifecycle status for a suggestion. `pending` on creation; moved to
+	// `applied` or `rejected` by Phase 3's apply/reject actions.
+	register_meta(
+		'comment',
+		'_wp_suggestion_status',
+		array(
+			'type'          => 'string',
+			'description'   => __( 'Suggestion lifecycle status.', 'gutenberg' ),
+			'single'        => true,
+			'show_in_rest'  => array(
+				'schema' => array(
+					'type' => 'string',
+					'enum' => array( 'pending', 'applied', 'rejected' ),
+				),
+			),
+			'auth_callback' => function ( $allowed, $meta_key, $object_id ) {
+				return current_user_can( 'edit_comment', $object_id );
+			},
+		)
+	);
 }
 add_action( 'init', 'gutenberg_register_block_comment_metadata' );
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 -   Added an `editorIntent` preference (`edit`, `suggest`, `view`) with a matching `setEditorIntent` action and `getEditorIntent` selector. Surfaced as an Edit / Suggest / View menu in the editor options for post types that support notes. The `view` intent puts the block editor into a read-only preview.
+-   Added a suggestion-overlay subsystem that powers the `suggest` intent. When active, an `editor.BlockEdit` filter diverts `setAttributes` into an in-memory overlay keyed by `clientId`; the block renders with the pending change merged on top of its real attributes, but the block-editor store stays at the baseline. A toolbar button on the selected block submits the overlay as a note comment with a `_wp_suggestion` meta payload (`schemaVersion`, `blockName`, `baseRevision`, `operations`) or discards it. Phase 2: capture only; Apply/Reject and diff rendering follow.
 
 ## 14.43.0 (2026-04-01)
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -45,6 +45,16 @@ import EditorKeyboardShortcuts from '../global-keyboard-shortcuts';
 import PatternRenameModal from '../pattern-rename-modal';
 import PatternDuplicateModal from '../pattern-duplicate-modal';
 import TemplatePartMenuItems from '../template-part-menu-items';
+import {
+	SuggestionOverlayProvider,
+	SuggestionCommitBar,
+	registerSuggestionOverlayFilter,
+} from '../suggestion-mode';
+
+// Register the `editor.BlockEdit` filter once when the editor provider module
+// loads. The filter is a no-op outside of the `suggest` intent, so it's safe
+// to register globally.
+registerSuggestionOverlayFilter();
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
@@ -447,26 +457,29 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 							settings={ blockEditorSettings }
 							useSubRegistry={ false }
 						>
-							{ children }
-							{ ! settings.isPreviewMode && (
-								<>
-									<PatternsMenuItems />
-									<TemplatePartMenuItems />
-									{ mode === 'template-locked' && (
-										<DisableNonPageContentBlocks />
-									) }
-									{ type === 'wp_navigation' && (
-										<NavigationBlockEditingMode />
-									) }
-									<EditorKeyboardShortcuts />
-									<KeyboardShortcutHelpModal />
-									<BlockRemovalWarnings />
-									<StartPageOptions />
-									<StartTemplateOptions />
-									<PatternRenameModal />
-									<PatternDuplicateModal />
-								</>
-							) }
+							<SuggestionOverlayProvider>
+								{ children }
+								{ ! settings.isPreviewMode && (
+									<>
+										<PatternsMenuItems />
+										<TemplatePartMenuItems />
+										{ mode === 'template-locked' && (
+											<DisableNonPageContentBlocks />
+										) }
+										{ type === 'wp_navigation' && (
+											<NavigationBlockEditingMode />
+										) }
+										<EditorKeyboardShortcuts />
+										<KeyboardShortcutHelpModal />
+										<BlockRemovalWarnings />
+										<StartPageOptions />
+										<StartTemplateOptions />
+										<PatternRenameModal />
+										<PatternDuplicateModal />
+										<SuggestionCommitBar />
+									</>
+								) }
+							</SuggestionOverlayProvider>
 						</BlockEditorProviderComponent>
 					</BlockContextProvider>
 				</EntityProvider>

--- a/packages/editor/src/components/suggestion-mode/commit-bar.js
+++ b/packages/editor/src/components/suggestion-mode/commit-bar.js
@@ -1,0 +1,110 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	BlockControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useCallback, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useSuggestionOverlay } from './overlay-context';
+import { operationsFromOverlay, useSuggestionsProvider } from './provider';
+
+const EDITOR_STORE_NAME = 'core/editor';
+
+/**
+ * Block toolbar group that surfaces Submit / Discard controls whenever the
+ * currently selected block has a pending suggestion overlay.
+ *
+ * The bar is a shared singleton — mounted once per editor provider rather
+ * than once per block — because the block-editor's `BlockControls` fill
+ * automatically targets the selected block's toolbar slot.
+ *
+ * @return {React.ReactNode|null} Toolbar markup, or null if nothing pending.
+ */
+export default function SuggestionCommitBar() {
+	const { entries, clearOverlay } = useSuggestionOverlay();
+	const { createSuggestion } = useSuggestionsProvider();
+
+	const { selectedClientId, isSuggestMode } = useSelect( ( select ) => {
+		return {
+			selectedClientId:
+				select( blockEditorStore ).getSelectedBlockClientId(),
+			isSuggestMode:
+				select( EDITOR_STORE_NAME ).getEditorIntent?.() === 'suggest',
+		};
+	}, [] );
+
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const entry = selectedClientId ? entries[ selectedClientId ] : null;
+	const hasOverlay =
+		!! entry && Object.keys( entry.overlayAttributes ).length > 0;
+
+	const onSubmit = useCallback( async () => {
+		if ( ! entry || isSubmitting ) {
+			return;
+		}
+		const operations = operationsFromOverlay(
+			entry.baselineAttributes,
+			entry.overlayAttributes
+		);
+		if ( operations.length === 0 ) {
+			clearOverlay( selectedClientId );
+			return;
+		}
+		setIsSubmitting( true );
+		try {
+			await createSuggestion( {
+				clientId: selectedClientId,
+				blockName: entry.blockName,
+				operations,
+			} );
+			clearOverlay( selectedClientId );
+		} catch {
+			// Notice surfaced by the provider.
+		} finally {
+			setIsSubmitting( false );
+		}
+	}, [
+		entry,
+		isSubmitting,
+		selectedClientId,
+		clearOverlay,
+		createSuggestion,
+	] );
+
+	const onDiscard = useCallback( () => {
+		if ( selectedClientId ) {
+			clearOverlay( selectedClientId );
+		}
+	}, [ selectedClientId, clearOverlay ] );
+
+	if ( ! isSuggestMode || ! hasOverlay ) {
+		return null;
+	}
+
+	return (
+		<BlockControls group="other">
+			<ToolbarGroup>
+				<ToolbarButton
+					variant="primary"
+					onClick={ onSubmit }
+					disabled={ isSubmitting }
+				>
+					{ isSubmitting
+						? __( 'Submitting…' )
+						: __( 'Submit suggestion' ) }
+				</ToolbarButton>
+				<ToolbarButton onClick={ onDiscard } disabled={ isSubmitting }>
+					{ __( 'Discard' ) }
+				</ToolbarButton>
+			</ToolbarGroup>
+		</BlockControls>
+	);
+}

--- a/packages/editor/src/components/suggestion-mode/index.js
+++ b/packages/editor/src/components/suggestion-mode/index.js
@@ -1,0 +1,15 @@
+export {
+	SuggestionOverlayProvider,
+	useSuggestionOverlay,
+	overlayReducer,
+} from './overlay-context';
+export {
+	default as withSuggestionOverlay,
+	registerSuggestionOverlayFilter,
+} from './with-suggestion-overlay';
+export { default as SuggestionCommitBar } from './commit-bar';
+export {
+	useSuggestionsProvider,
+	operationsFromOverlay,
+	SCHEMA_VERSION,
+} from './provider';

--- a/packages/editor/src/components/suggestion-mode/overlay-context.js
+++ b/packages/editor/src/components/suggestion-mode/overlay-context.js
@@ -1,0 +1,178 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+	useReducer,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+
+/**
+ * @typedef {Object} OverlayEntry
+ * @property {string} blockName          The block name at the time the
+ *                                       overlay was opened.
+ * @property {Object} baselineAttributes The attributes captured when
+ *                                       Suggest mode first began editing
+ *                                       this block.
+ * @property {Object} overlayAttributes  Pending attribute changes that
+ *                                       have not yet been committed.
+ */
+
+/**
+ * @typedef {Object} OverlayContextValue
+ * @property {Object.<string,OverlayEntry>} entries              Per-clientId entries.
+ * @property {Function}                     captureBaseline      Store a baseline for a
+ *                                                               block if one isn't set.
+ * @property {Function}                     setOverlayAttributes Merge overlay attributes
+ *                                                               onto an entry.
+ * @property {Function}                     clearOverlay         Remove the entry.
+ * @property {Function}                     hasOverlay           Check if an entry has any
+ *                                                               overlay attributes.
+ */
+
+const EMPTY_ENTRIES = Object.freeze( {} );
+
+const OverlayContext = createContext( {
+	entries: EMPTY_ENTRIES,
+	captureBaseline: () => {},
+	setOverlayAttributes: () => {},
+	clearOverlay: () => {},
+	hasOverlay: () => false,
+} );
+
+/**
+ * Reducer managing the map of pending block overlays.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Action.
+ * @return {Object} Next state.
+ */
+export function overlayReducer( state, action ) {
+	switch ( action.type ) {
+		case 'CAPTURE_BASELINE': {
+			if ( state[ action.clientId ] ) {
+				return state;
+			}
+			return {
+				...state,
+				[ action.clientId ]: {
+					blockName: action.blockName,
+					baselineAttributes: action.attributes,
+					overlayAttributes: {},
+				},
+			};
+		}
+		case 'SET_OVERLAY_ATTRIBUTES': {
+			const entry = state[ action.clientId ];
+			if ( ! entry ) {
+				return state;
+			}
+			return {
+				...state,
+				[ action.clientId ]: {
+					...entry,
+					overlayAttributes: {
+						...entry.overlayAttributes,
+						...action.attributes,
+					},
+				},
+			};
+		}
+		case 'CLEAR_OVERLAY': {
+			if ( ! state[ action.clientId ] ) {
+				return state;
+			}
+			const { [ action.clientId ]: _removed, ...rest } = state;
+			return rest;
+		}
+		default:
+			return state;
+	}
+}
+
+/**
+ * Provider exposing the suggestion overlay to descendant blocks.
+ *
+ * The overlay is intentionally in-memory only. It stores pending attribute
+ * changes per `clientId` so a block can render the user's in-progress
+ * suggestion without mutating the real block-editor state.
+ *
+ * @param {{ children: React.ReactNode }} props
+ */
+export function SuggestionOverlayProvider( { children } ) {
+	const [ entries, dispatch ] = useReducer( overlayReducer, EMPTY_ENTRIES );
+
+	const captureBaseline = useCallback(
+		( clientId, blockName, attributes ) =>
+			dispatch( {
+				type: 'CAPTURE_BASELINE',
+				clientId,
+				blockName,
+				attributes,
+			} ),
+		[]
+	);
+
+	const setOverlayAttributes = useCallback(
+		( clientId, attributes ) =>
+			dispatch( {
+				type: 'SET_OVERLAY_ATTRIBUTES',
+				clientId,
+				attributes,
+			} ),
+		[]
+	);
+
+	const clearOverlay = useCallback(
+		( clientId ) => dispatch( { type: 'CLEAR_OVERLAY', clientId } ),
+		[]
+	);
+
+	const hasOverlay = useCallback(
+		( clientId ) => {
+			const entry = entries[ clientId ];
+			return (
+				!! entry && Object.keys( entry.overlayAttributes ).length > 0
+			);
+		},
+		[ entries ]
+	);
+
+	const value = useMemo(
+		() => ( {
+			entries,
+			captureBaseline,
+			setOverlayAttributes,
+			clearOverlay,
+			hasOverlay,
+		} ),
+		[
+			entries,
+			captureBaseline,
+			setOverlayAttributes,
+			clearOverlay,
+			hasOverlay,
+		]
+	);
+
+	return (
+		<OverlayContext.Provider value={ value }>
+			{ children }
+		</OverlayContext.Provider>
+	);
+}
+
+/**
+ * Hook returning the suggestion overlay API.
+ *
+ * @return {OverlayContextValue} Overlay API.
+ */
+export function useSuggestionOverlay() {
+	return useContext( OverlayContext );
+}

--- a/packages/editor/src/components/suggestion-mode/provider.js
+++ b/packages/editor/src/components/suggestion-mode/provider.js
@@ -1,0 +1,195 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as noticesStore } from '@wordpress/notices';
+import { __ } from '@wordpress/i18n';
+
+// The editor store is referenced by its registered name to avoid a module
+// cycle between this file, the editor store (which transitively re-imports
+// the editor provider), and the suggestion-mode barrel.
+const EDITOR_STORE_NAME = 'core/editor';
+
+/**
+ * @typedef {Object} SuggestionOperation
+ * @property {'attribute-set'} type      Operation type. Only `attribute-set`
+ *                                       is implemented in Phase 2.
+ * @property {string}          attribute The attribute being changed.
+ * @property {*}               before    The baseline value.
+ * @property {*}               after     The proposed value.
+ */
+
+/**
+ * @typedef {Object} SuggestionPayload
+ * @property {number}                schemaVersion Payload schema version.
+ * @property {string}                blockName     Block name at capture time.
+ * @property {string|null}           baseRevision  Post `modified_gmt` at
+ *                                                 capture, used by Phase 3 to
+ *                                                 detect stale suggestions.
+ * @property {SuggestionOperation[]} operations    Ordered operations.
+ */
+
+const SCHEMA_VERSION = 1;
+
+/**
+ * Build attribute-set operations by diffing an overlay entry against its
+ * captured baseline. Attributes whose value differs are emitted; unchanged
+ * or absent keys are skipped.
+ *
+ * @param {Object} baselineAttributes Attributes captured on first edit.
+ * @param {Object} overlayAttributes  Pending attribute changes.
+ * @return {SuggestionOperation[]} Operations describing the suggestion.
+ */
+export function operationsFromOverlay( baselineAttributes, overlayAttributes ) {
+	const operations = [];
+	for ( const [ attribute, after ] of Object.entries(
+		overlayAttributes || {}
+	) ) {
+		const before = baselineAttributes?.[ attribute ];
+		if ( ! isAttributeEqual( before, after ) ) {
+			operations.push( {
+				type: 'attribute-set',
+				attribute,
+				before: before ?? null,
+				after,
+			} );
+		}
+	}
+	return operations;
+}
+
+function isAttributeEqual( a, b ) {
+	if ( a === b ) {
+		return true;
+	}
+	if ( a === null || a === undefined || b === null || b === undefined ) {
+		return false;
+	}
+	if ( typeof a !== 'object' || typeof b !== 'object' ) {
+		return false;
+	}
+	try {
+		return JSON.stringify( a ) === JSON.stringify( b );
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Comment-meta backed suggestions provider. Phase 2 implements only
+ * `createSuggestion`. Apply and reject are stubbed and will be implemented
+ * alongside the diff preview in Phase 3. The provider shape is stable so
+ * Phase 3 / a future Yjs-backed provider can swap in without touching the
+ * UI.
+ *
+ * Storage: a new `note` comment with the suggestion payload serialized to
+ * the `_wp_suggestion` comment meta. Linkage to a block reuses the existing
+ * `metadata.noteId` block attribute.
+ *
+ * @return {{
+ *   createSuggestion: Function,
+ *   applySuggestion:  Function,
+ *   rejectSuggestion: Function,
+ * }} Suggestions API.
+ */
+export function useSuggestionsProvider() {
+	const { postId, postModified } = useSelect( ( select ) => {
+		const editor = select( EDITOR_STORE_NAME );
+		const id = editor?.getCurrentPostId?.() ?? null;
+		const postType = editor?.getCurrentPostType?.() ?? null;
+		const record =
+			id && postType
+				? select( coreStore ).getEditedEntityRecord(
+						'postType',
+						postType,
+						id
+				  )
+				: null;
+		return {
+			postId: id,
+			postModified: record?.modified_gmt ?? null,
+		};
+	}, [] );
+
+	const { saveEntityRecord } = useDispatch( coreStore );
+	const { createNotice } = useDispatch( noticesStore );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const createSuggestion = useCallback(
+		async ( { clientId, blockName, operations } ) => {
+			if ( ! postId ) {
+				throw new Error( 'No post id available for suggestion.' );
+			}
+			if ( ! operations || operations.length === 0 ) {
+				return null;
+			}
+
+			const payload = /** @type {SuggestionPayload} */ ( {
+				schemaVersion: SCHEMA_VERSION,
+				blockName,
+				baseRevision: postModified,
+				operations,
+			} );
+
+			try {
+				const savedRecord = await saveEntityRecord(
+					'root',
+					'comment',
+					{
+						post: postId,
+						content: '',
+						status: 'hold',
+						type: 'note',
+						parent: 0,
+						meta: {
+							_wp_suggestion: JSON.stringify( payload ),
+						},
+					},
+					{ throwOnError: true }
+				);
+
+				if ( savedRecord?.id ) {
+					updateBlockAttributes( clientId, {
+						metadata: {
+							noteId: savedRecord.id,
+						},
+					} );
+				}
+
+				createNotice( 'snackbar', __( 'Suggestion submitted.' ), {
+					type: 'snackbar',
+					isDismissible: true,
+				} );
+				return savedRecord;
+			} catch ( error ) {
+				createNotice(
+					'error',
+					error?.message || __( 'Unable to submit suggestion.' ),
+					{ type: 'snackbar', isDismissible: true }
+				);
+				throw error;
+			}
+		},
+		[
+			postId,
+			postModified,
+			saveEntityRecord,
+			updateBlockAttributes,
+			createNotice,
+		]
+	);
+
+	const applySuggestion = useCallback( async () => {
+		throw new Error( 'applySuggestion is not implemented in Phase 2.' );
+	}, [] );
+	const rejectSuggestion = useCallback( async () => {
+		throw new Error( 'rejectSuggestion is not implemented in Phase 2.' );
+	}, [] );
+
+	return { createSuggestion, applySuggestion, rejectSuggestion };
+}
+
+export { SCHEMA_VERSION };

--- a/packages/editor/src/components/suggestion-mode/test/overlay-context.js
+++ b/packages/editor/src/components/suggestion-mode/test/overlay-context.js
@@ -1,0 +1,91 @@
+/**
+ * Internal dependencies
+ */
+import { overlayReducer } from '../overlay-context';
+
+describe( 'overlayReducer', () => {
+	const CLIENT_ID = 'abc-123';
+	const INITIAL = Object.freeze( {} );
+
+	it( 'captures a baseline once per client id', () => {
+		const afterFirst = overlayReducer( INITIAL, {
+			type: 'CAPTURE_BASELINE',
+			clientId: CLIENT_ID,
+			blockName: 'core/paragraph',
+			attributes: { content: 'Hello' },
+		} );
+		expect( afterFirst[ CLIENT_ID ] ).toEqual( {
+			blockName: 'core/paragraph',
+			baselineAttributes: { content: 'Hello' },
+			overlayAttributes: {},
+		} );
+
+		const afterSecond = overlayReducer( afterFirst, {
+			type: 'CAPTURE_BASELINE',
+			clientId: CLIENT_ID,
+			blockName: 'core/paragraph',
+			attributes: { content: 'CHANGED' },
+		} );
+		expect( afterSecond ).toBe( afterFirst );
+	} );
+
+	it( 'merges overlay attributes over an existing entry', () => {
+		const withBaseline = overlayReducer( INITIAL, {
+			type: 'CAPTURE_BASELINE',
+			clientId: CLIENT_ID,
+			blockName: 'core/paragraph',
+			attributes: { content: 'A', level: 2 },
+		} );
+		const withOverlay = overlayReducer( withBaseline, {
+			type: 'SET_OVERLAY_ATTRIBUTES',
+			clientId: CLIENT_ID,
+			attributes: { content: 'B' },
+		} );
+		expect( withOverlay[ CLIENT_ID ].overlayAttributes ).toEqual( {
+			content: 'B',
+		} );
+		expect( withOverlay[ CLIENT_ID ].baselineAttributes ).toEqual( {
+			content: 'A',
+			level: 2,
+		} );
+
+		const updated = overlayReducer( withOverlay, {
+			type: 'SET_OVERLAY_ATTRIBUTES',
+			clientId: CLIENT_ID,
+			attributes: { level: 3 },
+		} );
+		expect( updated[ CLIENT_ID ].overlayAttributes ).toEqual( {
+			content: 'B',
+			level: 3,
+		} );
+	} );
+
+	it( 'ignores overlay writes without a captured baseline', () => {
+		const next = overlayReducer( INITIAL, {
+			type: 'SET_OVERLAY_ATTRIBUTES',
+			clientId: CLIENT_ID,
+			attributes: { content: 'Nope' },
+		} );
+		expect( next ).toBe( INITIAL );
+	} );
+
+	it( 'removes an entry on clear', () => {
+		const withEntry = overlayReducer( INITIAL, {
+			type: 'CAPTURE_BASELINE',
+			clientId: CLIENT_ID,
+			blockName: 'core/paragraph',
+			attributes: {},
+		} );
+		const cleared = overlayReducer( withEntry, {
+			type: 'CLEAR_OVERLAY',
+			clientId: CLIENT_ID,
+		} );
+		expect( cleared ).toEqual( {} );
+		expect( cleared ).not.toBe( withEntry );
+	} );
+
+	it( 'returns the same reference for unknown actions', () => {
+		const next = overlayReducer( INITIAL, { type: 'UNKNOWN' } );
+		expect( next ).toBe( INITIAL );
+	} );
+} );

--- a/packages/editor/src/components/suggestion-mode/test/provider.js
+++ b/packages/editor/src/components/suggestion-mode/test/provider.js
@@ -1,0 +1,67 @@
+/**
+ * Internal dependencies
+ */
+import { operationsFromOverlay } from '../provider';
+
+describe( 'operationsFromOverlay', () => {
+	it( 'emits one attribute-set op per changed key', () => {
+		const ops = operationsFromOverlay(
+			{ content: 'Hello', level: 2 },
+			{ content: 'Hi', level: 3 }
+		);
+		expect( ops ).toEqual( [
+			{
+				type: 'attribute-set',
+				attribute: 'content',
+				before: 'Hello',
+				after: 'Hi',
+			},
+			{
+				type: 'attribute-set',
+				attribute: 'level',
+				before: 2,
+				after: 3,
+			},
+		] );
+	} );
+
+	it( 'skips attributes that equal their baseline', () => {
+		const ops = operationsFromOverlay(
+			{ content: 'Same', level: 2 },
+			{ content: 'Same', level: 3 }
+		);
+		expect( ops ).toEqual( [
+			{
+				type: 'attribute-set',
+				attribute: 'level',
+				before: 2,
+				after: 3,
+			},
+		] );
+	} );
+
+	it( 'deep-compares object-valued attributes', () => {
+		const ops = operationsFromOverlay(
+			{ style: { typography: { fontSize: '16px' } } },
+			{ style: { typography: { fontSize: '16px' } } }
+		);
+		expect( ops ).toEqual( [] );
+	} );
+
+	it( 'captures a null baseline when the attribute is new', () => {
+		const ops = operationsFromOverlay( {}, { url: 'https://x.test' } );
+		expect( ops ).toEqual( [
+			{
+				type: 'attribute-set',
+				attribute: 'url',
+				before: null,
+				after: 'https://x.test',
+			},
+		] );
+	} );
+
+	it( 'returns an empty array for an empty overlay', () => {
+		expect( operationsFromOverlay( { a: 1 }, {} ) ).toEqual( [] );
+		expect( operationsFromOverlay( { a: 1 }, null ) ).toEqual( [] );
+	} );
+} );

--- a/packages/editor/src/components/suggestion-mode/test/with-suggestion-overlay.js
+++ b/packages/editor/src/components/suggestion-mode/test/with-suggestion-overlay.js
@@ -1,0 +1,134 @@
+/**
+ * External dependencies
+ */
+import { render, screen, act } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import withSuggestionOverlay from '../with-suggestion-overlay';
+import { SuggestionOverlayProvider } from '../overlay-context';
+import { store as editorStore } from '../../../store';
+
+function renderWithProviders( ui, { intent = 'edit' } = {} ) {
+	const registry = createRegistry();
+	registry.register( preferencesStore );
+	registry.register( editorStore );
+	registry.dispatch( preferencesStore ).set( 'core', 'editorIntent', intent );
+
+	const wrapper = ( { children } ) => (
+		<RegistryProvider value={ registry }>
+			<SuggestionOverlayProvider>{ children }</SuggestionOverlayProvider>
+		</RegistryProvider>
+	);
+
+	return {
+		registry,
+		...render( ui, { wrapper } ),
+	};
+}
+
+// Minimal block component that exposes its received attributes and
+// calls setAttributes when its button is clicked.
+function FakeBlock( { attributes, setAttributes } ) {
+	return (
+		<>
+			<div data-testid="content">{ attributes?.content ?? '' }</div>
+			<button
+				type="button"
+				onClick={ () => setAttributes( { content: 'proposed' } ) }
+			>
+				edit
+			</button>
+		</>
+	);
+}
+
+const Wrapped = withSuggestionOverlay( FakeBlock );
+
+describe( 'withSuggestionOverlay', () => {
+	it( 'passes through unchanged in Edit intent', () => {
+		const setAttributes = jest.fn();
+		renderWithProviders(
+			<Wrapped
+				clientId="a"
+				name="core/paragraph"
+				attributes={ { content: 'Hello' } }
+				setAttributes={ setAttributes }
+			/>
+		);
+
+		expect( screen.getByTestId( 'content' ) ).toHaveTextContent( 'Hello' );
+
+		act( () => {
+			screen.getByRole( 'button', { name: 'edit' } ).click();
+		} );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			content: 'proposed',
+		} );
+	} );
+
+	it( 'diverts setAttributes into the overlay in Suggest intent', () => {
+		const setAttributes = jest.fn();
+		renderWithProviders(
+			<Wrapped
+				clientId="a"
+				name="core/paragraph"
+				attributes={ { content: 'Hello' } }
+				setAttributes={ setAttributes }
+			/>,
+			{ intent: 'suggest' }
+		);
+
+		act( () => {
+			screen.getByRole( 'button', { name: 'edit' } ).click();
+		} );
+
+		// Real setAttributes is never called; block renders merged value.
+		expect( setAttributes ).not.toHaveBeenCalled();
+		expect( screen.getByTestId( 'content' ) ).toHaveTextContent(
+			'proposed'
+		);
+	} );
+
+	it( 'merges overlay on top of real attributes for rendering', () => {
+		const setAttributes = jest.fn();
+		const { rerender } = renderWithProviders(
+			<Wrapped
+				clientId="a"
+				name="core/paragraph"
+				attributes={ { content: 'Hello', level: 2 } }
+				setAttributes={ setAttributes }
+			/>,
+			{ intent: 'suggest' }
+		);
+
+		act( () => {
+			screen.getByRole( 'button', { name: 'edit' } ).click();
+		} );
+		expect( screen.getByTestId( 'content' ) ).toHaveTextContent(
+			'proposed'
+		);
+
+		// Real attributes update (e.g., from RTC sync). Overlay wins on
+		// overlapping keys; non-overlapping keys reflect the new real value.
+		rerender(
+			<Wrapped
+				clientId="a"
+				name="core/paragraph"
+				attributes={ { content: 'UPSTREAM', level: 3 } }
+				setAttributes={ setAttributes }
+			/>
+		);
+		expect( screen.getByTestId( 'content' ) ).toHaveTextContent(
+			'proposed'
+		);
+	} );
+} );

--- a/packages/editor/src/components/suggestion-mode/test/with-suggestion-overlay.js
+++ b/packages/editor/src/components/suggestion-mode/test/with-suggestion-overlay.js
@@ -131,4 +131,31 @@ describe( 'withSuggestionOverlay', () => {
 			'proposed'
 		);
 	} );
+
+	it( 'passes through in View intent — no overlay, no diversion', () => {
+		const setAttributes = jest.fn();
+		renderWithProviders(
+			<Wrapped
+				clientId="a"
+				name="core/paragraph"
+				attributes={ { content: 'Untouched' } }
+				setAttributes={ setAttributes }
+			/>,
+			{ intent: 'view' }
+		);
+
+		expect( screen.getByTestId( 'content' ) ).toHaveTextContent(
+			'Untouched'
+		);
+
+		act( () => {
+			screen.getByRole( 'button', { name: 'edit' } ).click();
+		} );
+
+		// In view intent the HOC is a pass-through, so the real
+		// setAttributes is invoked and the overlay is never used.
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			content: 'proposed',
+		} );
+	} );
 } );

--- a/packages/editor/src/components/suggestion-mode/with-suggestion-overlay.js
+++ b/packages/editor/src/components/suggestion-mode/with-suggestion-overlay.js
@@ -1,0 +1,97 @@
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+import { useCallback, useMemo, useRef } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { useSuggestionOverlay } from './overlay-context';
+
+// The editor store is referenced by its registered name rather than being
+// imported directly to avoid a module cycle between this file, the editor
+// store, and the provider (which mounts `SuggestionOverlayProvider`).
+const EDITOR_STORE_NAME = 'core/editor';
+
+/**
+ * HOC that diverts block edits to the suggestion overlay when the editor is
+ * in the `suggest` intent. The block's real attributes are never mutated;
+ * overlay attributes are merged into the `attributes` prop for rendering so
+ * the user sees their in-progress change, but the block-editor store stays
+ * at the baseline until the suggestion is committed.
+ *
+ * In any other intent the HOC is a pass-through.
+ */
+const withSuggestionOverlay = createHigherOrderComponent(
+	( BlockEdit ) =>
+		function BlockEditWithSuggestionOverlay( props ) {
+			// `setAttributes` is intentionally ignored when the intent is
+			// `suggest` — edits are captured in the overlay instead of being
+			// written back to the block-editor store.
+			const { clientId, name, attributes } = props;
+			const isSuggestMode = useSelect(
+				( select ) =>
+					select( EDITOR_STORE_NAME ).getEditorIntent?.() ===
+					'suggest',
+				[]
+			);
+
+			const { entries, captureBaseline, setOverlayAttributes } =
+				useSuggestionOverlay();
+
+			// Track the latest attributes via a ref so the wrapped
+			// `setAttributes` callback remains stable. Blocks sometimes
+			// invoke `setAttributes` from effects keyed on this reference.
+			const attributesRef = useRef( attributes );
+			attributesRef.current = attributes;
+
+			const overlayAttributes =
+				entries[ clientId ]?.overlayAttributes ?? null;
+
+			const wrappedSetAttributes = useCallback(
+				( nextAttributes ) => {
+					// Lazily capture the baseline on first edit so we only
+					// track blocks the user actually touched.
+					captureBaseline( clientId, name, attributesRef.current );
+					setOverlayAttributes( clientId, nextAttributes );
+				},
+				[ clientId, name, captureBaseline, setOverlayAttributes ]
+			);
+
+			const mergedAttributes = useMemo( () => {
+				if ( ! overlayAttributes ) {
+					return attributes;
+				}
+				return { ...attributes, ...overlayAttributes };
+			}, [ attributes, overlayAttributes ] );
+
+			if ( ! isSuggestMode ) {
+				return <BlockEdit { ...props } />;
+			}
+
+			return (
+				<BlockEdit
+					{ ...props }
+					attributes={ mergedAttributes }
+					setAttributes={ wrappedSetAttributes }
+				/>
+			);
+		},
+	'withSuggestionOverlay'
+);
+
+/**
+ * Register the overlay filter. Idempotent — safe to import multiple times.
+ */
+export function registerSuggestionOverlayFilter() {
+	addFilter(
+		'editor.BlockEdit',
+		'core/editor/suggestion-mode-overlay',
+		withSuggestionOverlay
+	);
+}
+
+export default withSuggestionOverlay;

--- a/test/e2e/specs/editor/various/editor-intent-switcher.spec.js
+++ b/test/e2e/specs/editor/various/editor-intent-switcher.spec.js
@@ -59,4 +59,44 @@ test.describe( 'Editor intent switcher', () => {
 			'true'
 		);
 	} );
+
+	test( 'View intent prevents suggestion overlay and commit bar', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Protected content' },
+		} );
+
+		// First enter Suggest mode and type to create an overlay.
+		await openIntentSwitcher( page );
+		await page.getByRole( 'menuitemradio', { name: 'Suggest' } ).click();
+
+		const paragraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+		await paragraph.click();
+		await page.keyboard.press( 'End' );
+		await page.keyboard.type( ' added' );
+		await expect( paragraph ).toContainText( 'Protected content added' );
+
+		// Submit suggestion button should be visible in Suggest mode.
+		const submitButton = page
+			.getByRole( 'toolbar', { name: 'Block tools' } )
+			.getByRole( 'button', { name: 'Submit suggestion' } );
+		await expect( submitButton ).toBeVisible();
+
+		// Switch to View — the editor becomes read-only and the commit
+		// bar should disappear because isSuggestMode === false.
+		await openIntentSwitcher( page );
+		await page.getByRole( 'menuitemradio', { name: 'View' } ).click();
+
+		await expect( submitButton ).toBeHidden();
+
+		// The serialized content is unchanged — no suggestion leaked.
+		const serialized = await editor.getEditedPostContent();
+		expect( serialized ).toContain( 'Protected content' );
+		expect( serialized ).not.toContain( 'added' );
+	} );
 } );

--- a/test/e2e/specs/editor/various/suggestion-mode.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode.spec.js
@@ -1,0 +1,102 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+async function switchIntent( page, intentLabel ) {
+	await page.click(
+		'role=region[name="Editor top bar"i] >> role=button[name="Options"i]'
+	);
+	await page
+		.getByRole( 'menuitemradio', { name: intentLabel, exact: true } )
+		.click();
+}
+
+test.describe( 'Suggestion mode', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllComments( 'note' );
+	} );
+
+	test( 'captures edits as an overlay without mutating the block', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Original content' },
+		} );
+
+		await switchIntent( page, 'Suggest' );
+
+		// Focus the paragraph and type additional text.
+		const paragraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+		await paragraph.click();
+		await page.keyboard.press( 'End' );
+		await page.keyboard.type( ' plus suggested' );
+
+		// The rendered block reflects the overlayed suggestion.
+		await expect( paragraph ).toContainText(
+			'Original content plus suggested'
+		);
+
+		// The serialized post content still shows the baseline — the overlay
+		// never touched the block-editor store.
+		const serialized = await editor.getEditedPostContent();
+		expect( serialized ).toContain( 'Original content' );
+		expect( serialized ).not.toContain( 'plus suggested' );
+
+		// Submit suggestion via the block toolbar.
+		await page
+			.getByRole( 'toolbar', { name: 'Block tools' } )
+			.getByRole( 'button', { name: 'Submit suggestion' } )
+			.click();
+
+		// Snackbar confirms.
+		await expect(
+			page.getByRole( 'button', { name: 'Dismiss this notice' } )
+		).toBeVisible();
+
+		// A note comment now exists on this post with a _wp_suggestion meta.
+		// Implementation detail: the block is linked via metadata.noteId,
+		// which the commit-bar wires after the REST create succeeds.
+	} );
+
+	test( 'discards overlay without creating a note', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Keep as is' },
+		} );
+
+		await switchIntent( page, 'Suggest' );
+
+		const paragraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+		await paragraph.click();
+		await page.keyboard.press( 'End' );
+		await page.keyboard.type( '!' );
+		await expect( paragraph ).toContainText( 'Keep as is!' );
+
+		await page
+			.getByRole( 'toolbar', { name: 'Block tools' } )
+			.getByRole( 'button', { name: 'Discard' } )
+			.click();
+
+		await expect( paragraph ).toContainText( 'Keep as is' );
+		// Discard button disappears once the overlay is cleared.
+		await expect(
+			page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Discard' } )
+		).toBeHidden();
+	} );
+} );


### PR DESCRIPTION
## Summary
- Adds a suggestion-overlay subsystem: `editor.BlockEdit` filter diverts `setAttributes` into a React-context-backed overlay keyed by `clientId`
- Blocks render with `{ ...realAttributes, ...overlayAttributes }` — user sees their change live but the block-editor store stays at baseline
- `SuggestionCommitBar` in block toolbar: Submit (creates note with `_wp_suggestion` meta) / Discard (clears overlay)
- PHP: registers `_wp_suggestion` and `_wp_suggestion_status` comment meta with REST exposure
- Validates View intent correctly blocks the overlay and commit bar (unit + e2e)

**Phase 2 of 4** — builds on Phase 1 intent scaffolding. Stacked on #77398.

## Test plan
- [ ] Enter Suggest mode → type in a paragraph → confirm serialized content is unchanged (`getEditedPostContent`)
- [ ] Click "Submit suggestion" → confirm snackbar, note created
- [ ] Click "Discard" → confirm overlay clears, block reverts
- [ ] Switch to View → confirm Submit button is hidden
- [ ] Unit tests: `npm run test:unit -- packages/editor/src/components/suggestion-mode/test/`
- [ ] E2E: `npm run test:e2e -- test/e2e/specs/editor/various/suggestion-mode.spec.js`

Refs https://github.com/WordPress/gutenberg/issues/73411