### PR TITLE
Editor: Add suggestion diff preview, Apply, and Reject

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -44,6 +44,11 @@ import { focusCommentThread, getCommentExcerpt } from './utils';
 import { useFloatingThread } from './hooks';
 import { AddComment } from './add-comment';
 import { store as editorStore } from '../../store';
+import {
+	SuggestionDiff,
+	parseSuggestionPayload,
+	useSuggestionsProvider,
+} from '../suggestion-mode';
 
 const { useBlockElement } = unlock( blockEditorPrivateApis );
 const { Menu } = unlock( componentsPrivateApis );
@@ -968,6 +973,7 @@ const CommentBoard = ( {
 						: thread?.content?.rendered }
 				</RawHTML>
 			) }
+			<SuggestionActions thread={ thread } />
 			{ 'delete' === actionState && (
 				<ConfirmDialog
 					isOpen={ showConfirmDialog }
@@ -981,5 +987,80 @@ const CommentBoard = ( {
 		</VStack>
 	);
 };
+
+function SuggestionActions( { thread } ) {
+	const payload = useMemo(
+		() => parseSuggestionPayload( thread?.meta?._wp_suggestion ),
+		[ thread?.meta?._wp_suggestion ]
+	);
+	const suggestionStatus = thread?.meta?._wp_suggestion_status;
+	const { applySuggestion, rejectSuggestion } = useSuggestionsProvider();
+	const [ busy, setBusy ] = useState( false );
+
+	if ( ! payload ) {
+		return null;
+	}
+
+	const isResolved =
+		suggestionStatus === 'applied' || suggestionStatus === 'rejected';
+
+	return (
+		<VStack spacing="2" className="editor-collab-sidebar-panel__suggestion">
+			<SuggestionDiff operations={ payload.operations } />
+			{ isResolved ? (
+				<Text variant="muted" size="12px">
+					{ suggestionStatus === 'applied'
+						? __( 'Applied' )
+						: __( 'Rejected' ) }
+				</Text>
+			) : (
+				<HStack spacing="2" justify="flex-start">
+					<Button
+						variant="primary"
+						size="small"
+						disabled={ busy }
+						accessibleWhenDisabled
+						onClick={ async () => {
+							setBusy( true );
+							try {
+								await applySuggestion( {
+									commentId: thread.id,
+									clientId: thread.blockClientId,
+									payload,
+								} );
+							} catch {
+								// Notice surfaced by the provider.
+							} finally {
+								setBusy( false );
+							}
+						} }
+					>
+						{ __( 'Apply' ) }
+					</Button>
+					<Button
+						variant="secondary"
+						size="small"
+						disabled={ busy }
+						accessibleWhenDisabled
+						onClick={ async () => {
+							setBusy( true );
+							try {
+								await rejectSuggestion( {
+									commentId: thread.id,
+								} );
+							} catch {
+								// Notice surfaced by the provider.
+							} finally {
+								setBusy( false );
+							}
+						} }
+					>
+						{ __( 'Reject' ) }
+					</Button>
+				</HStack>
+			) }
+		</VStack>
+	);
+}
 
 export default Comments;

--- a/packages/editor/src/components/suggestion-mode/index.js
+++ b/packages/editor/src/components/suggestion-mode/index.js
@@ -11,5 +11,8 @@ export { default as SuggestionCommitBar } from './commit-bar';
 export {
 	useSuggestionsProvider,
 	operationsFromOverlay,
+	applyOperations,
+	parseSuggestionPayload,
 	SCHEMA_VERSION,
 } from './provider';
+export { default as SuggestionDiff, wordDiff } from './suggestion-diff';

--- a/packages/editor/src/components/suggestion-mode/provider.js
+++ b/packages/editor/src/components/suggestion-mode/provider.js
@@ -79,13 +79,53 @@ function isAttributeEqual( a, b ) {
 }
 
 /**
- * Comment-meta backed suggestions provider. Phase 2 implements only
- * `createSuggestion`. Apply and reject are stubbed and will be implemented
- * alongside the diff preview in Phase 3. The provider shape is stable so
- * Phase 3 / a future Yjs-backed provider can swap in without touching the
- * UI.
+ * Apply a suggestion payload's operations to a block's current attributes
+ * to produce the new attributes. Pure function — no side effects.
  *
- * Storage: a new `note` comment with the suggestion payload serialized to
+ * @param {Object}                currentAttributes Block's current attributes.
+ * @param {SuggestionOperation[]} operations        Operations from the payload.
+ * @return {Object} Merged attributes with suggestions applied.
+ */
+export function applyOperations( currentAttributes, operations ) {
+	const result = { ...currentAttributes };
+	for ( const op of operations ) {
+		if ( op.type === 'attribute-set' ) {
+			result[ op.attribute ] = op.after;
+		}
+	}
+	return result;
+}
+
+/**
+ * Parse a `_wp_suggestion` meta value into a typed payload.
+ *
+ * @param {string|undefined} raw The raw JSON string from comment meta.
+ * @return {SuggestionPayload|null} Parsed payload, or null if invalid.
+ */
+export function parseSuggestionPayload( raw ) {
+	if ( ! raw ) {
+		return null;
+	}
+	try {
+		const parsed = JSON.parse( raw );
+		if (
+			typeof parsed === 'object' &&
+			parsed !== null &&
+			Array.isArray( parsed.operations )
+		) {
+			return parsed;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Comment-meta backed suggestions provider. The provider shape is stable so
+ * a future Yjs-backed provider can swap in without touching the UI.
+ *
+ * Storage: a `note` comment with the suggestion payload serialized to
  * the `_wp_suggestion` comment meta. Linkage to a block reuses the existing
  * `metadata.noteId` block attribute.
  *
@@ -182,12 +222,85 @@ export function useSuggestionsProvider() {
 		]
 	);
 
-	const applySuggestion = useCallback( async () => {
-		throw new Error( 'applySuggestion is not implemented in Phase 2.' );
-	}, [] );
-	const rejectSuggestion = useCallback( async () => {
-		throw new Error( 'rejectSuggestion is not implemented in Phase 2.' );
-	}, [] );
+	const { getBlockAttributes: selectBlockAttributes } =
+		useSelect( blockEditorStore );
+
+	const applySuggestion = useCallback(
+		async ( { commentId, clientId, payload } ) => {
+			if ( ! payload || ! Array.isArray( payload.operations ) ) {
+				createNotice( 'error', __( 'Invalid suggestion payload.' ), {
+					type: 'snackbar',
+					isDismissible: true,
+				} );
+				return;
+			}
+
+			if (
+				payload.baseRevision &&
+				postModified &&
+				payload.baseRevision !== postModified
+			) {
+				createNotice(
+					'warning',
+					__(
+						'Post content has changed since this suggestion. Review carefully.'
+					),
+					{ type: 'snackbar', isDismissible: true }
+				);
+			}
+
+			const currentAttributes = selectBlockAttributes( clientId );
+			const newAttributes = applyOperations(
+				currentAttributes,
+				payload.operations
+			);
+			updateBlockAttributes( clientId, newAttributes );
+
+			await saveEntityRecord(
+				'root',
+				'comment',
+				{
+					id: commentId,
+					status: 'approved',
+					meta: { _wp_suggestion_status: 'applied' },
+				},
+				{ throwOnError: true }
+			);
+
+			createNotice( 'snackbar', __( 'Suggestion applied.' ), {
+				type: 'snackbar',
+				isDismissible: true,
+			} );
+		},
+		[
+			postModified,
+			saveEntityRecord,
+			updateBlockAttributes,
+			selectBlockAttributes,
+			createNotice,
+		]
+	);
+
+	const rejectSuggestion = useCallback(
+		async ( { commentId } ) => {
+			await saveEntityRecord(
+				'root',
+				'comment',
+				{
+					id: commentId,
+					status: 'approved',
+					meta: { _wp_suggestion_status: 'rejected' },
+				},
+				{ throwOnError: true }
+			);
+
+			createNotice( 'snackbar', __( 'Suggestion rejected.' ), {
+				type: 'snackbar',
+				isDismissible: true,
+			} );
+		},
+		[ saveEntityRecord, createNotice ]
+	);
 
 	return { createSuggestion, applySuggestion, rejectSuggestion };
 }

--- a/packages/editor/src/components/suggestion-mode/suggestion-diff.js
+++ b/packages/editor/src/components/suggestion-mode/suggestion-diff.js
@@ -1,0 +1,187 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+
+/**
+ * Compute a word-level diff between two strings, returning an array of
+ * segments tagged as `equal`, `insert`, or `delete`.
+ *
+ * @param {string} before Original text.
+ * @param {string} after  Proposed text.
+ * @return {Array<{type: string, value: string}>} Diff segments.
+ */
+export function wordDiff( before, after ) {
+	const a = tokenize( before );
+	const b = tokenize( after );
+	const lcs = longestCommonSubsequence( a, b );
+
+	const result = [];
+	let ai = 0;
+	let bi = 0;
+
+	for ( const token of lcs ) {
+		while ( ai < a.length && a[ ai ] !== token ) {
+			result.push( { type: 'delete', value: a[ ai ] } );
+			ai++;
+		}
+		while ( bi < b.length && b[ bi ] !== token ) {
+			result.push( { type: 'insert', value: b[ bi ] } );
+			bi++;
+		}
+		result.push( { type: 'equal', value: token } );
+		ai++;
+		bi++;
+	}
+
+	while ( ai < a.length ) {
+		result.push( { type: 'delete', value: a[ ai ] } );
+		ai++;
+	}
+	while ( bi < b.length ) {
+		result.push( { type: 'insert', value: b[ bi ] } );
+		bi++;
+	}
+
+	return result;
+}
+
+function tokenize( str ) {
+	if ( typeof str !== 'string' ) {
+		return [];
+	}
+	return str.match( /\S+|\s+/g ) || [];
+}
+
+function longestCommonSubsequence( a, b ) {
+	const m = a.length;
+	const n = b.length;
+	const dp = Array.from( { length: m + 1 }, () =>
+		new Array( n + 1 ).fill( 0 )
+	);
+
+	for ( let i = 1; i <= m; i++ ) {
+		for ( let j = 1; j <= n; j++ ) {
+			dp[ i ][ j ] =
+				a[ i - 1 ] === b[ j - 1 ]
+					? dp[ i - 1 ][ j - 1 ] + 1
+					: Math.max( dp[ i - 1 ][ j ], dp[ i ][ j - 1 ] );
+		}
+	}
+
+	const result = [];
+	let i = m;
+	let j = n;
+	while ( i > 0 && j > 0 ) {
+		if ( a[ i - 1 ] === b[ j - 1 ] ) {
+			result.unshift( a[ i - 1 ] );
+			i--;
+			j--;
+		} else if ( dp[ i - 1 ][ j ] > dp[ i ][ j - 1 ] ) {
+			i--;
+		} else {
+			j--;
+		}
+	}
+	return result;
+}
+
+/**
+ * Renders a compact inline diff preview for a suggestion's operations.
+ * Text-valued attributes show word-level insertions (green underline) and
+ * deletions (red strikethrough). Non-text attributes show a before → after
+ * label.
+ *
+ * @param {Object}                                     props
+ * @param {import('./provider').SuggestionOperation[]} props.operations
+ */
+export default function SuggestionDiff( { operations } ) {
+	if ( ! operations || operations.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<VStack
+			className="editor-collab-sidebar-panel__suggestion-diff"
+			spacing="1"
+		>
+			<Text variant="muted" size="11px" upperCase weight={ 600 }>
+				{ __( 'Suggested change' ) }
+			</Text>
+			{ operations.map( ( op, index ) => (
+				<div key={ index }>
+					{ op.type === 'attribute-set' &&
+					isTextValue( op.before ) &&
+					isTextValue( op.after ) ? (
+						<TextDiff
+							before={ op.before ?? '' }
+							after={ op.after }
+						/>
+					) : (
+						<AttributeDiff operation={ op } />
+					) }
+				</div>
+			) ) }
+		</VStack>
+	);
+}
+
+function isTextValue( value ) {
+	return value === null || value === undefined || typeof value === 'string';
+}
+
+function TextDiff( { before, after } ) {
+	const segments = wordDiff( before, after );
+	return (
+		<Text
+			className="editor-collab-sidebar-panel__suggestion-text-diff"
+			size="13px"
+		>
+			{ segments.map( ( seg, i ) => {
+				if ( seg.type === 'delete' ) {
+					return (
+						<del
+							key={ i }
+							style={ {
+								color: 'var(--wp-block-synced-color, #cc1818)',
+								textDecoration: 'line-through',
+							} }
+						>
+							{ seg.value }
+						</del>
+					);
+				}
+				if ( seg.type === 'insert' ) {
+					return (
+						<ins
+							key={ i }
+							style={ {
+								color: 'var(--wp-admin-theme-color, #007017)',
+								textDecoration: 'underline',
+							} }
+						>
+							{ seg.value }
+						</ins>
+					);
+				}
+				return <span key={ i }>{ seg.value }</span>;
+			} ) }
+		</Text>
+	);
+}
+
+function AttributeDiff( { operation } ) {
+	const label =
+		typeof operation.before === 'string'
+			? `${ operation.attribute }: ${ operation.before } → ${ operation.after }`
+			: `${ operation.attribute }: changed`;
+	return (
+		<Text size="12px" variant="muted">
+			{ label }
+		</Text>
+	);
+}

--- a/packages/editor/src/components/suggestion-mode/test/provider.js
+++ b/packages/editor/src/components/suggestion-mode/test/provider.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { operationsFromOverlay } from '../provider';
+import {
+	operationsFromOverlay,
+	applyOperations,
+	parseSuggestionPayload,
+} from '../provider';
 
 describe( 'operationsFromOverlay', () => {
 	it( 'emits one attribute-set op per changed key', () => {
@@ -63,5 +67,71 @@ describe( 'operationsFromOverlay', () => {
 	it( 'returns an empty array for an empty overlay', () => {
 		expect( operationsFromOverlay( { a: 1 }, {} ) ).toEqual( [] );
 		expect( operationsFromOverlay( { a: 1 }, null ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'applyOperations', () => {
+	it( 'applies attribute-set operations to produce new attributes', () => {
+		const result = applyOperations(
+			{ content: 'Hello', level: 2, align: 'left' },
+			[
+				{
+					type: 'attribute-set',
+					attribute: 'content',
+					before: 'Hello',
+					after: 'Hi',
+				},
+				{
+					type: 'attribute-set',
+					attribute: 'level',
+					before: 2,
+					after: 3,
+				},
+			]
+		);
+		expect( result ).toEqual( {
+			content: 'Hi',
+			level: 3,
+			align: 'left',
+		} );
+	} );
+
+	it( 'returns a copy even when operations are empty', () => {
+		const attrs = { content: 'Same' };
+		const result = applyOperations( attrs, [] );
+		expect( result ).toEqual( attrs );
+		expect( result ).not.toBe( attrs );
+	} );
+} );
+
+describe( 'parseSuggestionPayload', () => {
+	it( 'parses a valid JSON payload', () => {
+		const raw = JSON.stringify( {
+			schemaVersion: 1,
+			blockName: 'core/paragraph',
+			baseRevision: '2026-04-15T00:00:00',
+			operations: [
+				{
+					type: 'attribute-set',
+					attribute: 'content',
+					before: 'a',
+					after: 'b',
+				},
+			],
+		} );
+		const result = parseSuggestionPayload( raw );
+		expect( result ).not.toBeNull();
+		expect( result.operations ).toHaveLength( 1 );
+		expect( result.blockName ).toBe( 'core/paragraph' );
+	} );
+
+	it( 'returns null for missing, empty, or invalid input', () => {
+		expect( parseSuggestionPayload( undefined ) ).toBeNull();
+		expect( parseSuggestionPayload( '' ) ).toBeNull();
+		expect( parseSuggestionPayload( 'not json' ) ).toBeNull();
+		expect( parseSuggestionPayload( '42' ) ).toBeNull();
+		expect(
+			parseSuggestionPayload( JSON.stringify( { noOps: true } ) )
+		).toBeNull();
 	} );
 } );

--- a/packages/editor/src/components/suggestion-mode/test/suggestion-diff.js
+++ b/packages/editor/src/components/suggestion-mode/test/suggestion-diff.js
@@ -1,0 +1,61 @@
+/**
+ * Internal dependencies
+ */
+import { wordDiff } from '../suggestion-diff';
+
+describe( 'wordDiff', () => {
+	it( 'returns equal segments for identical strings', () => {
+		expect( wordDiff( 'hello world', 'hello world' ) ).toEqual( [
+			{ type: 'equal', value: 'hello' },
+			{ type: 'equal', value: ' ' },
+			{ type: 'equal', value: 'world' },
+		] );
+	} );
+
+	it( 'detects insertions', () => {
+		const result = wordDiff( 'hello world', 'hello beautiful world' );
+		const types = result.map( ( s ) => s.type );
+		expect( types ).toContain( 'insert' );
+		const inserted = result.filter( ( s ) => s.type === 'insert' );
+		expect( inserted.map( ( s ) => s.value.trim() ) ).toContain(
+			'beautiful'
+		);
+	} );
+
+	it( 'detects deletions', () => {
+		const result = wordDiff( 'hello beautiful world', 'hello world' );
+		const deleted = result.filter( ( s ) => s.type === 'delete' );
+		expect( deleted.map( ( s ) => s.value.trim() ) ).toContain(
+			'beautiful'
+		);
+	} );
+
+	it( 'handles replacement as delete+insert', () => {
+		const result = wordDiff( 'the cat sat', 'the dog sat' );
+		expect( result ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( { type: 'delete', value: 'cat' } ),
+				expect.objectContaining( { type: 'insert', value: 'dog' } ),
+			] )
+		);
+	} );
+
+	it( 'handles empty before (all insertions)', () => {
+		const result = wordDiff( '', 'new text' );
+		expect( result.every( ( s ) => s.type === 'insert' ) ).toBe( true );
+	} );
+
+	it( 'handles empty after (all deletions)', () => {
+		const result = wordDiff( 'old text', '' );
+		expect( result.every( ( s ) => s.type === 'delete' ) ).toBe( true );
+	} );
+
+	it( 'handles null/undefined gracefully', () => {
+		expect( wordDiff( null, 'hello' ) ).toEqual( [
+			{ type: 'insert', value: 'hello' },
+		] );
+		expect( wordDiff( 'hello', null ) ).toEqual( [
+			{ type: 'delete', value: 'hello' },
+		] );
+	} );
+} );


### PR DESCRIPTION
## Summary
- `applySuggestion`: runs operations on block attributes, resolves note as applied. Warns on stale `baseRevision`.
- `rejectSuggestion`: resolves note as rejected, no content change.
- `SuggestionDiff`: word-level LCS diff for text (green insert, red delete), attribute label for non-text.
- `SuggestionActions` in collab sidebar: Apply/Reject buttons on suggestion notes, diff preview, resolved status label.
- `applyOperations` and `parseSuggestionPayload` pure functions for the provider.

**Phase 3 of 4** — builds on Phase 2 overlay capture. Stacked on #77399.

## Test plan
- [ ] Submit a suggestion → open notes sidebar → confirm diff preview renders with insertions/deletions
- [ ] Click Apply → confirm block content updates and note shows "Applied"
- [ ] Click Reject → confirm block content unchanged and note shows "Rejected"
- [ ] Unit tests: `npm run test:unit -- packages/editor/src/components/suggestion-mode/test/`

Refs https://github.com/WordPress/gutenberg/issues/73411