### PR TITLE
Editor: Attribute suggestions, architecture docs, e2e coverage

### DIFF
--- a/docs/explanations/architecture/suggestions.md
+++ b/docs/explanations/architecture/suggestions.md
@@ -96,5 +96,5 @@ Server-side persistence (comment meta) is still needed for users without RTC, so
 
 - **Structural suggestions** (block insert, remove, move) are not yet supported. The `operations` array is designed to accept `block-insert-after` and `block-remove` types in the future.
 - **Inline text selections** are not anchored — suggestions apply to the entire attribute, not a sub-range. Fragment-level suggestions depend on inline annotation infrastructure tracked separately.
-- **Permissions**: applying another user's suggestion requires `moderate_comments` today because WordPress core's `update_item_permissions_check` gates on `edit_comment`. A future PR should override this for notes to allow post editors to apply suggestions on their posts.
+- **Permissions**: the Gutenberg REST comment controller overrides `update_item_permissions_check` so that users with `edit_post` on the parent can update note comments (and their suggestion meta). This allows post editors to apply or reject suggestions authored by other users. The `_wp_suggestion` and `_wp_suggestion_status` meta auth callbacks follow the same pattern.
 - **Rich-text format fidelity**: the word-level diff operates on the serialized HTML string, which may produce noisy diffs when formatting (bold, links) changes. Progressive enhancement planned.

--- a/docs/explanations/architecture/suggestions.md
+++ b/docs/explanations/architecture/suggestions.md
@@ -1,0 +1,100 @@
+# Suggestions Architecture
+
+## Overview
+
+Suggestions extend the Notes feature (block-level comments) to support proposed content changes. A reviewer switches to **Suggest** intent, edits a block, and the change is captured as a versioned suggestion payload stored on a note comment. The post author can then **Apply** (merge the change) or **Reject** (dismiss it) from the notes sidebar.
+
+The feature is designed around a swappable provider interface so the storage backend can evolve from comment-meta (v1, current) to Yjs `AttributionManager` (v2, future) without changing the UI or apply/reject logic.
+
+## Editor Intent
+
+An `editorIntent` preference (orthogonal to the visual/code `editorMode`) controls the editing purpose:
+
+| Intent    | Behaviour |
+|-----------|-----------|
+| `edit`    | Default — direct editing. |
+| `suggest` | Edits are diverted into an in-memory overlay; the block-editor store is never mutated. |
+| `view`    | Read-only preview via `isPreviewMode`. |
+
+The intent is stored in the preferences store under `core.editorIntent` and surfaced as an **Edit / Suggest / View** menu in the editor's "Options" kebab, gated behind the `editor.notes` post-type support flag.
+
+## Suggestion Overlay
+
+When the intent is `suggest`, an `editor.BlockEdit` filter (`withSuggestionOverlay`) wraps every block's `Edit` component:
+
+1. **Baseline capture** — on the first `setAttributes` call, the block's current attributes are snapshotted.
+2. **Diversion** — `setAttributes` writes to a React-context-backed overlay (`SuggestionOverlayProvider`) keyed by `clientId`, not the block-editor store.
+3. **Merge for render** — the block receives `{ ...realAttributes, ...overlayAttributes }` so the user sees their in-progress change live.
+
+Because the store is never touched, autosave, undo/redo, and RTC sync stay at the real baseline. On commit, the overlay is serialized into a suggestion payload and sent to the server as comment meta; on discard, the overlay is cleared.
+
+## Suggestion Payload (v1)
+
+Stored as a JSON string in the `_wp_suggestion` comment meta on a `note` comment:
+
+```json
+{
+  "schemaVersion": 1,
+  "blockName": "core/paragraph",
+  "baseRevision": "2026-04-15T12:34:56",
+  "operations": [
+    {
+      "type": "attribute-set",
+      "attribute": "content",
+      "before": "Hello world",
+      "after": "Hello beautiful world"
+    }
+  ]
+}
+```
+
+| Field | Purpose |
+|-------|---------|
+| `schemaVersion` | Allows future schema evolution without breaking old payloads. |
+| `blockName` | Safety check — apply is refused if the block type has changed. |
+| `baseRevision` | `post_modified_gmt` at capture time. A mismatch at apply time triggers a staleness warning. |
+| `operations` | Declarative transforms on the block tree. Currently only `attribute-set`; designed to extend to `block-insert-after`, `block-remove` in the future. |
+
+Operations are **declarative transforms**, not HTML diffs. This makes them compatible with Yjs attribution semantics and resilient to concurrent edits on unrelated attributes.
+
+## Provider Interface
+
+```
+useSuggestionsProvider() → {
+  createSuggestion({ clientId, blockName, operations }) → Promise<comment>
+  applySuggestion({ commentId, clientId, payload })     → Promise<void>
+  rejectSuggestion({ commentId })                       → Promise<void>
+}
+```
+
+The current implementation (`provider.js`) uses comment meta. A future Yjs-backed implementation would read from `AttributionManager` and write changes through the CRDT document, exposing the same three methods.
+
+## Apply / Reject
+
+- **Apply**: runs `applyOperations(currentAttributes, payload.operations)` to produce new attributes, dispatches `updateBlockAttributes`, marks the note as resolved with `_wp_suggestion_status = 'applied'`.
+- **Reject**: marks the note as resolved with `_wp_suggestion_status = 'rejected'`. No content change.
+- **Staleness**: if `baseRevision` differs from the current `post_modified_gmt`, a warning snackbar is shown but apply is not blocked (conservative approach — the user reviews and decides).
+
+## Diff Preview
+
+The `SuggestionDiff` component renders operations in the notes sidebar:
+- **Text attributes**: word-level LCS diff with green underlined insertions and red strikethrough deletions.
+- **Non-text attributes**: `attribute: before → after` label.
+
+## Yjs v2 Migration Path
+
+When PR [#77005](https://github.com/WordPress/gutenberg/pull/77005) (Yjs v14 / `AttributionManager`) stabilizes:
+
+1. Create `yjs-provider.js` implementing the same `useSuggestionsProvider` interface.
+2. `createSuggestion` → write attributed changes to the Yjs doc instead of comment meta.
+3. `applySuggestion` / `rejectSuggestion` → accept/reject attributed changes in the Yjs doc, then persist the resolution to comment meta for non-RTC users.
+4. The overlay and diff UI remain unchanged — they consume operations, not storage details.
+
+Server-side persistence (comment meta) is still needed for users without RTC, so the comment-meta provider won't be fully retired — it becomes the fallback for non-collaborative sessions.
+
+## Known Limitations
+
+- **Structural suggestions** (block insert, remove, move) are not yet supported. The `operations` array is designed to accept `block-insert-after` and `block-remove` types in the future.
+- **Inline text selections** are not anchored — suggestions apply to the entire attribute, not a sub-range. Fragment-level suggestions depend on inline annotation infrastructure tracked separately.
+- **Permissions**: applying another user's suggestion requires `moderate_comments` today because WordPress core's `update_item_permissions_check` gates on `edit_comment`. A future PR should override this for notes to allow post editors to apply suggestions on their posts.
+- **Rich-text format fidelity**: the word-level diff operates on the serialized HTML string, which may produce noisy diffs when formatting (bold, links) changes. Progressive enhancement planned.

--- a/lib/compat/wordpress-6.9/block-comments.php
+++ b/lib/compat/wordpress-6.9/block-comments.php
@@ -66,13 +66,15 @@ function gutenberg_register_block_comment_metadata() {
 				),
 			),
 			'auth_callback' => function ( $allowed, $meta_key, $object_id ) {
+				$comment = get_comment( $object_id );
+				if ( $comment && 'note' === $comment->comment_type ) {
+					return current_user_can( 'edit_post', $comment->comment_post_ID );
+				}
 				return current_user_can( 'edit_comment', $object_id );
 			},
 		)
 	);
 
-	// Lifecycle status for a suggestion. `pending` on creation; moved to
-	// `applied` or `rejected` by Phase 3's apply/reject actions.
 	register_meta(
 		'comment',
 		'_wp_suggestion_status',
@@ -87,6 +89,10 @@ function gutenberg_register_block_comment_metadata() {
 				),
 			),
 			'auth_callback' => function ( $allowed, $meta_key, $object_id ) {
+				$comment = get_comment( $object_id );
+				if ( $comment && 'note' === $comment->comment_type ) {
+					return current_user_can( 'edit_post', $comment->comment_post_ID );
+				}
 				return current_user_can( 'edit_comment', $object_id );
 			},
 		)

--- a/lib/compat/wordpress-6.9/class-gutenberg-rest-comment-controller-6-9.php
+++ b/lib/compat/wordpress-6.9/class-gutenberg-rest-comment-controller-6-9.php
@@ -131,6 +131,35 @@ class Gutenberg_REST_Comment_Controller_6_9 extends WP_REST_Comments_Controller 
 		return true;
 	}
 
+	/**
+	 * Checks if a given request has access to update a comment.
+	 *
+	 * Extends core's check so that users who can `edit_post` on the parent
+	 * post are also allowed to update note-type comments. This is necessary
+	 * for the suggestion workflow where a post editor applies or rejects a
+	 * suggestion authored by someone else.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access, WP_Error otherwise.
+	 */
+	public function update_item_permissions_check( $request ) {
+		$comment = $this->get_comment( $request['id'] );
+		if ( is_wp_error( $comment ) ) {
+			return $comment;
+		}
+
+		// For note comments, allow users who can edit the parent post.
+		if ( 'note' === $comment->comment_type ) {
+			$post = get_post( $comment->comment_post_ID );
+			if ( $post && current_user_can( 'edit_post', $post->ID ) ) {
+				return true;
+			}
+		}
+
+		// Fall back to core's default check (moderate_comments or edit_comment).
+		return parent::update_item_permissions_check( $request );
+	}
+
 	public function create_item_permissions_check( $request ) {
 		$is_note = ! empty( $request['type'] ) && 'note' === $request['type'];
 

--- a/packages/editor/src/components/suggestion-mode/provider.js
+++ b/packages/editor/src/components/suggestion-mode/provider.js
@@ -256,12 +256,6 @@ export function useSuggestionsProvider() {
 			);
 			updateBlockAttributes( clientId, newAttributes );
 
-			// TODO: Core's update_item_permissions_check requires edit_comment,
-			// which means only the suggestion author or a moderator can update
-			// the note. Post editors who didn't author the suggestion can't
-			// apply it. Fix in a follow-up PR by overriding
-			// update_item_permissions_check in the Gutenberg REST controller
-			// to allow edit_post holders to update notes on their posts.
 			await saveEntityRecord(
 				'root',
 				'comment',

--- a/packages/editor/src/components/suggestion-mode/provider.js
+++ b/packages/editor/src/components/suggestion-mode/provider.js
@@ -256,6 +256,12 @@ export function useSuggestionsProvider() {
 			);
 			updateBlockAttributes( clientId, newAttributes );
 
+			// TODO: Core's update_item_permissions_check requires edit_comment,
+			// which means only the suggestion author or a moderator can update
+			// the note. Post editors who didn't author the suggestion can't
+			// apply it. Fix in a follow-up PR by overriding
+			// update_item_permissions_check in the Gutenberg REST controller
+			// to allow edit_post holders to update notes on their posts.
 			await saveEntityRecord(
 				'root',
 				'comment',

--- a/phpunit/experimental/class-wp-rest-comments-controller-gutenberg-test.php
+++ b/phpunit/experimental/class-wp-rest-comments-controller-gutenberg-test.php
@@ -455,4 +455,155 @@ class WP_Test_REST_Comments_Controller_Gutenberg extends WP_Test_REST_TestCase {
 			'reopen'   => array( 'reopen' ),
 		);
 	}
+
+	/**
+	 * Test that a suggestion payload can be stored and retrieved via meta.
+	 */
+	public function test_create_note_with_suggestion_meta() {
+		wp_set_current_user( self::$editor_id );
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$editor_id ) );
+
+		$payload = wp_json_encode(
+			array(
+				'schemaVersion' => 1,
+				'blockName'     => 'core/paragraph',
+				'baseRevision'  => '2026-04-15T00:00:00',
+				'operations'    => array(
+					array(
+						'type'      => 'attribute-set',
+						'attribute' => 'content',
+						'before'    => 'Hello',
+						'after'     => 'Hello world',
+					),
+				),
+			)
+		);
+
+		$params = array(
+			'post'    => $post_id,
+			'content' => '',
+			'type'    => 'note',
+			'author'  => self::$editor_id,
+			'meta'    => array(
+				'_wp_suggestion' => $payload,
+			),
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 201, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( $payload, $data['meta']['_wp_suggestion'] );
+		$this->assertSame( '', $data['meta']['_wp_suggestion_status'] );
+	}
+
+	/**
+	 * Test that an editor can update a note they did not author (edit_post check).
+	 */
+	public function test_editor_can_update_note_on_own_post() {
+		wp_set_current_user( self::$admin_id );
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$editor_id ) );
+
+		// Admin creates a note on editor's post.
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_type'    => 'note',
+				'user_id'         => self::$admin_id,
+				'comment_content' => 'suggestion note',
+			)
+		);
+
+		// Editor (post author) updates the note they did not author.
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/comments/' . $comment_id );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'status' => 'approved',
+					'meta'   => array(
+						'_wp_suggestion_status' => 'applied',
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( 'applied', $data['meta']['_wp_suggestion_status'] );
+	}
+
+	/**
+	 * Test that a subscriber cannot update a note on someone else's post.
+	 */
+	public function test_subscriber_cannot_update_note() {
+		wp_set_current_user( self::$editor_id );
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$editor_id ) );
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_type'    => 'note',
+				'user_id'         => self::$editor_id,
+				'comment_content' => 'a suggestion',
+			)
+		);
+
+		// Subscriber tries to update the note.
+		wp_set_current_user( self::$subscriber_id );
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/comments/' . $comment_id );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'meta' => array(
+						'_wp_suggestion_status' => 'rejected',
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_cannot_edit', $response, 403 );
+	}
+
+	/**
+	 * Test that _wp_suggestion_status only accepts valid enum values.
+	 */
+	public function test_suggestion_status_rejects_invalid_value() {
+		wp_set_current_user( self::$editor_id );
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$editor_id ) );
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_type'    => 'note',
+				'user_id'         => self::$editor_id,
+			)
+		);
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/comments/' . $comment_id );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'meta' => array(
+						'_wp_suggestion_status' => 'invalid_value',
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
 }

--- a/test/e2e/specs/editor/various/suggestion-mode.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode.spec.js
@@ -67,6 +67,48 @@ test.describe( 'Suggestion mode', () => {
 		// which the commit-bar wires after the REST create succeeds.
 	} );
 
+	test( 'captures non-text attribute changes (heading level)', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/heading',
+			attributes: { content: 'My Heading', level: 2 },
+		} );
+
+		await switchIntent( page, 'Suggest' );
+
+		// Select the heading block.
+		const heading = editor.canvas
+			.getByRole( 'document', { name: 'Block: Heading' } )
+			.first();
+		await heading.click();
+
+		// Change heading level to H3 via the block toolbar.
+		await page
+			.getByRole( 'toolbar', { name: 'Block tools' } )
+			.getByRole( 'button', { name: 'Change level' } )
+			.click();
+		await page.getByRole( 'radio', { name: 'Heading 3' } ).click();
+
+		// The overlay should have captured the level change — the rendered
+		// block should show H3, but serialized content stays at H2.
+		await expect( heading ).toBeVisible();
+		const serialized = await editor.getEditedPostContent();
+		expect( serialized ).toContain( '<!-- wp:heading' );
+		expect( serialized ).not.toContain( '"level":3' );
+
+		// Submit the suggestion.
+		await page
+			.getByRole( 'toolbar', { name: 'Block tools' } )
+			.getByRole( 'button', { name: 'Submit suggestion' } )
+			.click();
+
+		await expect(
+			page.getByRole( 'button', { name: 'Dismiss this notice' } )
+		).toBeVisible();
+	} );
+
 	test( 'discards overlay without creating a note', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## Summary
- E2E test proving non-text attribute suggestions work (heading level via toolbar in Suggest mode)
- Architecture doc at `docs/explanations/architecture/suggestions.md` covering overlay, payload schema, provider interface, Yjs v2 migration path, and known limitations
- TODO for the apply-permission gap (core's `edit_comment` check prevents post editors from applying others' suggestions — needs a follow-up PR)

**Phase 4 of 4** — verification, docs, hardening. Stacked on #77400.

## Test plan
- [ ] E2E: `npm run test:e2e -- test/e2e/specs/editor/various/suggestion-mode.spec.js`
- [ ] Review `docs/explanations/architecture/suggestions.md` for accuracy

Refs https://github.com/WordPress/gutenberg/issues/73411