### PR TITLE
REST: Allow post editors to apply/reject suggestions on their posts

### DIFF
--- a/docs/explanations/architecture/suggestions.md
+++ b/docs/explanations/architecture/suggestions.md
@@ -96,5 +96,5 @@ Server-side persistence (comment meta) is still needed for users without RTC, so
 
 - **Structural suggestions** (block insert, remove, move) are not yet supported. The `operations` array is designed to accept `block-insert-after` and `block-remove` types in the future.
 - **Inline text selections** are not anchored — suggestions apply to the entire attribute, not a sub-range. Fragment-level suggestions depend on inline annotation infrastructure tracked separately.
-- **Permissions**: applying another user's suggestion requires `moderate_comments` today because WordPress core's `update_item_permissions_check` gates on `edit_comment`. A future PR should override this for notes to allow post editors to apply suggestions on their posts.
+- **Permissions**: the Gutenberg REST comment controller overrides `update_item_permissions_check` so that users with `edit_post` on the parent can update note comments (and their suggestion meta). This allows post editors to apply or reject suggestions authored by other users. The `_wp_suggestion` and `_wp_suggestion_status` meta auth callbacks follow the same pattern.
 - **Rich-text format fidelity**: the word-level diff operates on the serialized HTML string, which may produce noisy diffs when formatting (bold, links) changes. Progressive enhancement planned.

--- a/lib/compat/wordpress-6.9/block-comments.php
+++ b/lib/compat/wordpress-6.9/block-comments.php
@@ -66,13 +66,15 @@ function gutenberg_register_block_comment_metadata() {
 				),
 			),
 			'auth_callback' => function ( $allowed, $meta_key, $object_id ) {
+				$comment = get_comment( $object_id );
+				if ( $comment && 'note' === $comment->comment_type ) {
+					return current_user_can( 'edit_post', $comment->comment_post_ID );
+				}
 				return current_user_can( 'edit_comment', $object_id );
 			},
 		)
 	);
 
-	// Lifecycle status for a suggestion. `pending` on creation; moved to
-	// `applied` or `rejected` by Phase 3's apply/reject actions.
 	register_meta(
 		'comment',
 		'_wp_suggestion_status',
@@ -87,6 +89,10 @@ function gutenberg_register_block_comment_metadata() {
 				),
 			),
 			'auth_callback' => function ( $allowed, $meta_key, $object_id ) {
+				$comment = get_comment( $object_id );
+				if ( $comment && 'note' === $comment->comment_type ) {
+					return current_user_can( 'edit_post', $comment->comment_post_ID );
+				}
 				return current_user_can( 'edit_comment', $object_id );
 			},
 		)

--- a/lib/compat/wordpress-6.9/class-gutenberg-rest-comment-controller-6-9.php
+++ b/lib/compat/wordpress-6.9/class-gutenberg-rest-comment-controller-6-9.php
@@ -131,6 +131,35 @@ class Gutenberg_REST_Comment_Controller_6_9 extends WP_REST_Comments_Controller 
 		return true;
 	}
 
+	/**
+	 * Checks if a given request has access to update a comment.
+	 *
+	 * Extends core's check so that users who can `edit_post` on the parent
+	 * post are also allowed to update note-type comments. This is necessary
+	 * for the suggestion workflow where a post editor applies or rejects a
+	 * suggestion authored by someone else.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access, WP_Error otherwise.
+	 */
+	public function update_item_permissions_check( $request ) {
+		$comment = $this->get_comment( $request['id'] );
+		if ( is_wp_error( $comment ) ) {
+			return $comment;
+		}
+
+		// For note comments, allow users who can edit the parent post.
+		if ( 'note' === $comment->comment_type ) {
+			$post = get_post( $comment->comment_post_ID );
+			if ( $post && current_user_can( 'edit_post', $post->ID ) ) {
+				return true;
+			}
+		}
+
+		// Fall back to core's default check (moderate_comments or edit_comment).
+		return parent::update_item_permissions_check( $request );
+	}
+
 	public function create_item_permissions_check( $request ) {
 		$is_note = ! empty( $request['type'] ) && 'note' === $request['type'];
 

--- a/packages/editor/src/components/suggestion-mode/provider.js
+++ b/packages/editor/src/components/suggestion-mode/provider.js
@@ -256,12 +256,6 @@ export function useSuggestionsProvider() {
 			);
 			updateBlockAttributes( clientId, newAttributes );
 
-			// TODO: Core's update_item_permissions_check requires edit_comment,
-			// which means only the suggestion author or a moderator can update
-			// the note. Post editors who didn't author the suggestion can't
-			// apply it. Fix in a follow-up PR by overriding
-			// update_item_permissions_check in the Gutenberg REST controller
-			// to allow edit_post holders to update notes on their posts.
 			await saveEntityRecord(
 				'root',
 				'comment',

--- a/phpunit/experimental/class-wp-rest-comments-controller-gutenberg-test.php
+++ b/phpunit/experimental/class-wp-rest-comments-controller-gutenberg-test.php
@@ -455,4 +455,155 @@ class WP_Test_REST_Comments_Controller_Gutenberg extends WP_Test_REST_TestCase {
 			'reopen'   => array( 'reopen' ),
 		);
 	}
+
+	/**
+	 * Test that a suggestion payload can be stored and retrieved via meta.
+	 */
+	public function test_create_note_with_suggestion_meta() {
+		wp_set_current_user( self::$editor_id );
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$editor_id ) );
+
+		$payload = wp_json_encode(
+			array(
+				'schemaVersion' => 1,
+				'blockName'     => 'core/paragraph',
+				'baseRevision'  => '2026-04-15T00:00:00',
+				'operations'    => array(
+					array(
+						'type'      => 'attribute-set',
+						'attribute' => 'content',
+						'before'    => 'Hello',
+						'after'     => 'Hello world',
+					),
+				),
+			)
+		);
+
+		$params = array(
+			'post'    => $post_id,
+			'content' => '',
+			'type'    => 'note',
+			'author'  => self::$editor_id,
+			'meta'    => array(
+				'_wp_suggestion' => $payload,
+			),
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 201, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( $payload, $data['meta']['_wp_suggestion'] );
+		$this->assertSame( '', $data['meta']['_wp_suggestion_status'] );
+	}
+
+	/**
+	 * Test that an editor can update a note they did not author (edit_post check).
+	 */
+	public function test_editor_can_update_note_on_own_post() {
+		wp_set_current_user( self::$admin_id );
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$editor_id ) );
+
+		// Admin creates a note on editor's post.
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_type'    => 'note',
+				'user_id'         => self::$admin_id,
+				'comment_content' => 'suggestion note',
+			)
+		);
+
+		// Editor (post author) updates the note they did not author.
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/comments/' . $comment_id );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'status' => 'approved',
+					'meta'   => array(
+						'_wp_suggestion_status' => 'applied',
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( 'applied', $data['meta']['_wp_suggestion_status'] );
+	}
+
+	/**
+	 * Test that a subscriber cannot update a note on someone else's post.
+	 */
+	public function test_subscriber_cannot_update_note() {
+		wp_set_current_user( self::$editor_id );
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$editor_id ) );
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_type'    => 'note',
+				'user_id'         => self::$editor_id,
+				'comment_content' => 'a suggestion',
+			)
+		);
+
+		// Subscriber tries to update the note.
+		wp_set_current_user( self::$subscriber_id );
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/comments/' . $comment_id );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'meta' => array(
+						'_wp_suggestion_status' => 'rejected',
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_cannot_edit', $response, 403 );
+	}
+
+	/**
+	 * Test that _wp_suggestion_status only accepts valid enum values.
+	 */
+	public function test_suggestion_status_rejects_invalid_value() {
+		wp_set_current_user( self::$editor_id );
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$editor_id ) );
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_type'    => 'note',
+				'user_id'         => self::$editor_id,
+			)
+		);
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/comments/' . $comment_id );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'meta' => array(
+						'_wp_suggestion_status' => 'invalid_value',
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
 }


### PR DESCRIPTION
## Summary
- Overrides `update_item_permissions_check` in the Gutenberg REST comment controller so `edit_post` holders can update note comments (not just comment authors / moderators)
- Updates `_wp_suggestion` and `_wp_suggestion_status` meta auth_callbacks to use `edit_post` on the parent for notes
- Removes the TODO from provider.js and updates architecture doc

**Phase 5 of 5** — REST permission hardening. Stacked on #77401.

## Test plan
- [ ] As Editor role (not admin), create a post and have another user submit a suggestion
- [ ] Verify the Editor can Apply and Reject the suggestion without `moderate_comments`
- [ ] PHP lint: `vendor/bin/phpcs lib/compat/wordpress-6.9/class-gutenberg-rest-comment-controller-6-9.php lib/compat/wordpress-6.9/block-comments.php`

Refs https://github.com/WordPress/gutenberg/issues/73411