### PR TITLE
Ensure layout classnames are applied to the inner blocks wrapper and not to its siblings

### DIFF
--- a/backport-changelog/7.1/11598.md
+++ b/backport-changelog/7.1/11598.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11598
+
+* https://github.com/WordPress/gutenberg/pull/77408

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -1050,10 +1050,30 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$first_chunk                 = $block['innerContent'][0] ?? null;
 	if ( is_string( $first_chunk ) && count( $block['innerContent'] ) > 1 ) {
 		$first_chunk_processor = new WP_HTML_Tag_Processor( $first_chunk );
-		while ( $first_chunk_processor->next_tag() ) {
-			$class_attribute = $first_chunk_processor->get_attribute( 'class' );
+		/*
+		 * Use a stack to track open elements as tags are visited. Void elements
+		 * (those without a matching closing tag) are excluded so they don't
+		 * accumulate on the stack. At the end of the chunk, every element still
+		 * on the stack is unclosed — meaning its closing tag lives in a later
+		 * innerContent entry alongside the inner blocks, which makes it the
+		 * inner-block container. Elements that open and close within this chunk
+		 * are siblings that precede the inner blocks and should be ignored.
+		 * The last unclosed element with a class attribute is the best candidate
+		 * for the inner-block wrapper.
+		 */
+		$tag_stack          = array();
+		$html_void_elements = array( 'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source', 'track', 'wbr' );
+		while ( $first_chunk_processor->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
+			if ( $first_chunk_processor->is_tag_closer() ) {
+				array_pop( $tag_stack );
+			} elseif ( ! in_array( strtolower( $first_chunk_processor->get_tag() ), $html_void_elements, true ) ) {
+				$tag_stack[] = $first_chunk_processor->get_attribute( 'class' );
+			}
+		}
+		foreach ( array_reverse( $tag_stack ) as $class_attribute ) {
 			if ( is_string( $class_attribute ) && ! empty( $class_attribute ) ) {
 				$inner_block_wrapper_classes = $class_attribute;
+				break;
 			}
 		}
 	}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -1061,12 +1061,11 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		 * The last unclosed element with a class attribute is the best candidate
 		 * for the inner-block wrapper.
 		 */
-		$tag_stack          = array();
-		$html_void_elements = array( 'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source', 'track', 'wbr' );
+		$tag_stack = array();
 		while ( $first_chunk_processor->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
 			if ( $first_chunk_processor->is_tag_closer() ) {
 				array_pop( $tag_stack );
-			} elseif ( ! in_array( strtolower( $first_chunk_processor->get_tag() ), $html_void_elements, true ) ) {
+			} elseif ( ! WP_HTML_Processor::is_void( $first_chunk_processor->get_tag() ) ) {
 				$tag_stack[] = $first_chunk_processor->get_attribute( 'class' );
 			}
 		}

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -564,6 +564,33 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => '<div class="wp-block-group is-layout-grid wp-container-core-group-is-layout-9d260ee2 wp-block-group-is-layout-grid"></div>',
 			),
+			/*
+			 * When the first innerContent chunk contains a sibling element (one that fully opens
+			 * and closes before the inner blocks), the layout classes must be added to the outer
+			 * container — not to the sibling. The sibling's class was incorrectly chosen by the
+			 * previous logic because it was the last class encountered while scanning the chunk.
+			 */
+			'outer wrapper targeted when sibling element precedes inner blocks' => array(
+				'args'            => array(
+					'block_content' => '<div class="wp-block-group"><div class="wp-block-group__header">Header</div><p>Inner block</p></div>',
+					'block'         => array(
+						'blockName'    => 'core/group',
+						'attrs'        => array(
+							'layout' => array(
+								'type' => 'default',
+							),
+						),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<div class="wp-block-group"><div class="wp-block-group__header">Header</div><p>Inner block</p></div>',
+						'innerContent' => array(
+							'<div class="wp-block-group"><div class="wp-block-group__header">Header</div>',
+							null,
+							'</div>',
+						),
+					),
+				),
+				'expected_output' => '<div class="wp-block-group is-layout-flow wp-block-group-is-layout-flow"><div class="wp-block-group__header">Header</div><p>Inner block</p></div>',
+			),
 		);
 	}
 


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #57242.

When there's an element inside a block container which is a sibling to its inner blocks, and that element has a classname, and the block has layout support, we need to ensure that the layout classnames are applied to the container and not to the inner block sibling. The logic in trunk finds the last element with a classname in the first chunk of `innerContent`, which is the element right before the inner blocks start. But if this element has a closing tag in that first chunk, it's likely to be a sibling and not the container (it can still be the container if there are no inner blocks, in which case there should only be one chunk of `innerContent`, but in that case we have no way of distinguishing it from a sibling element so it's safer to keep the layout classes in the outer wrapper. I was also looking for a solution to #76235 but can't think of a reliable one that doesn't mess with dynamic content).

This PR tries to check for a closing tag in the first chunk of `innerContent` and not apply the layout classnames if it exists.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

This may be easier to test by checking out the branch locally and making changes to the Details block so that its `summary` element has a classname.

Check that when `summary` has a classname, the layout classes don't get attached to it but stay on the outer wrapper.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Code generated with copilot; reviewed and tested by myself.