### PR TITLE
viewport visibility: use 'key' instead of 'value' for device type 

### DIFF
--- a/packages/block-editor/src/components/block-visibility/viewport-visibility-info.js
+++ b/packages/block-editor/src/components/block-visibility/viewport-visibility-info.js
@@ -25,7 +25,7 @@ const { Badge } = unlock( componentsPrivateApis );
 const DEFAULT_VISIBILITY_STATE = {
 	currentBlockVisibility: undefined,
 	hasParentHiddenEverywhere: false,
-	selectedDeviceType: BLOCK_VISIBILITY_VIEWPORTS.desktop.value,
+	selectedDeviceType: BLOCK_VISIBILITY_VIEWPORTS.desktop.key,
 };
 
 export default function ViewportVisibilityInfo( { clientId } ) {
@@ -49,7 +49,7 @@ export default function ViewportVisibilityInfo( { clientId } ) {
 					getBlockAttributes( clientId )?.metadata?.blockVisibility,
 				selectedDeviceType:
 					getSettings()?.[ deviceTypeKey ]?.toLowerCase() ||
-					BLOCK_VISIBILITY_VIEWPORTS.desktop.value,
+					BLOCK_VISIBILITY_VIEWPORTS.desktop.key,
 				hasParentHiddenEverywhere:
 					isBlockParentHiddenEverywhere( clientId ),
 			};

--- a/packages/block-editor/src/hooks/grid-visualizer.js
+++ b/packages/block-editor/src/hooks/grid-visualizer.js
@@ -54,7 +54,7 @@ function GridTools( { clientId, layout } ) {
 				const settings = getSettings();
 				const currentDeviceType =
 					settings?.[ deviceTypeKey ]?.toLowerCase() ||
-					BLOCK_VISIBILITY_VIEWPORTS.desktop.value;
+					BLOCK_VISIBILITY_VIEWPORTS.desktop.key;
 
 				return {
 					isVisible: true,

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -244,7 +244,7 @@ function GridTools( {
 					blockAttributes?.metadata?.blockVisibility,
 				deviceType:
 					settings?.[ deviceTypeKey ]?.toLowerCase() ||
-					BLOCK_VISIBILITY_VIEWPORTS.desktop.value,
+					BLOCK_VISIBILITY_VIEWPORTS.desktop.key,
 				// Check if the selected child block is itself a grid.
 				isChildBlockAGrid: blockAttributes?.layout?.type === 'grid',
 			};


### PR DESCRIPTION
## What?

Fixes an invalid fallback when reading the editor preview device type from block editor settings.

`BLOCK_VISIBILITY_VIEWPORTS` only defines `key`, `label`, and `icon` — there is no `value` property. Code that used `BLOCK_VISIBILITY_VIEWPORTS.desktop.value` therefore always fell through to **`undefined`**, so expressions like:

`getSettings()?.[ deviceTypeKey ]?.toLowerCase() || BLOCK_VISIBILITY_VIEWPORTS.desktop.value`

could resolve to **`undefined`** whenever the device type was not yet present in settings. Downstream visibility logic then behaved as if the preview were **desktop**, which could hide the block visibility inspector notice and cause inconsistent UI (including flaky or failing E2E around the “Block is hidden on Mobile” badge).

## Why?

- Aligns the fallback with the real shape of `BLOCK_VISIBILITY_VIEWPORTS` (`desktop.key` → `'desktop'`).
- Restores a meaningful default instead of `undefined`.

## How?

Replace `BLOCK_VISIBILITY_VIEWPORTS.desktop.value` with `BLOCK_VISIBILITY_VIEWPORTS.desktop.key` in:

- `packages/block-editor/src/components/block-visibility/viewport-visibility-info.js`
- `packages/block-editor/src/hooks/grid-visualizer.js`
- `packages/block-editor/src/hooks/layout-child.js`

### Testing


#### Manual

Smoke test the block inspector block visibility label: 

hide a block on mobile only, keep it selected, switch the editor View preview between Desktop and Mobile, and confirm the settings sidebar still shows the block-hidden-at-viewport notice when the block is hidden at the current preview.

Smoke test grid: 

on a post, add a grid layout, hide the grid or a parent on Mobile only, select the grid container, toggle View between Desktop and Mobile, and confirm the grid visualizer overlay appears when the grid is visible at that preview and stays hidden when it is hidden at that preview.

#### Automated 
- `npm run test:unit -- packages/block-editor/src/components/block-visibility/test/use-block-visibility.js`
- With wp-env running: `npm run test:e2e -- test/e2e/specs/editor/various/block-hiding.spec.js`


https://github.com/user-attachments/assets/5883cf9f-f4cd-4376-8153-be502c1beae3

