### PR TITLE
Tabs: Remove redundant version field from block.json

### DIFF
--- a/packages/block-library/src/tab-panel/block.json
+++ b/packages/block-library/src/tab-panel/block.json
@@ -5,7 +5,6 @@
 	"name": "core/tab-panel",
 	"title": "Tab Panel",
 	"description": "Container for tab panel content in a tabbed interface.",
-	"version": "1.0.0",
 	"category": "design",
 	"textdomain": "default",
 	"parent": [ "core/tabs" ],

--- a/packages/block-library/src/tab/block.json
+++ b/packages/block-library/src/tab/block.json
@@ -5,7 +5,6 @@
 	"name": "core/tab",
 	"title": "Tab",
 	"description": "Content for a tab in a tabbed interface.",
-	"version": "1.0.0",
 	"category": "design",
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/tabs-menu-item/block.json
+++ b/packages/block-library/src/tabs-menu-item/block.json
@@ -5,7 +5,6 @@
 	"name": "core/tabs-menu-item",
 	"title": "Tab Menu Item",
 	"description": "A single tab button in the tabs menu.",
-	"version": "1.0.0",
 	"category": "design",
 	"textdomain": "default",
 	"parent": [ "core/tabs-menu" ],

--- a/packages/block-library/src/tabs-menu/block.json
+++ b/packages/block-library/src/tabs-menu/block.json
@@ -5,7 +5,6 @@
 	"name": "core/tabs-menu",
 	"title": "Tabs Menu",
 	"description": "Display the tab buttons for a tabbed interface.",
-	"version": "1.0.0",
 	"category": "design",
 	"textdomain": "default",
 	"parent": [ "core/tabs" ],

--- a/packages/block-library/src/tabs/block.json
+++ b/packages/block-library/src/tabs/block.json
@@ -5,7 +5,6 @@
 	"name": "core/tabs",
 	"title": "Tabs",
 	"description": "Display content in a tabbed interface to help users navigate detailed content with ease.",
-	"version": "1.0.0",
 	"category": "design",
 	"textdomain": "default",
 	"allowedBlocks": [ "core/tabs-menu", "core/tab-panel" ],


### PR DESCRIPTION
## What?
Remove the `version` field from all five Tabs-family `block.json` files.

## Why?

No other core block declares a `version` in its `block.json`.

## Testing Instructions

N/A

## Use of AI Tools

N/A