### PR TITLE
Notes: Extract floating notes state into a dedicated store

### DIFF
--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -16,17 +16,12 @@ import { unlock } from '../../lock-unlock';
 import CommentAuthorInfo from './comment-author-info';
 import CommentForm from './comment-form';
 import { FloatingContainer } from './floating-container';
-import { focusCommentThread, noop } from './utils';
+import { focusCommentThread } from './utils';
 import { store as editorStore } from '../../store';
 
 const { useBlockElement } = unlock( blockEditorPrivateApis );
 
-export function AddComment( {
-	onSubmit,
-	commentSidebarRef,
-	reflowComments = noop,
-	floating,
-} ) {
+export function AddComment( { onSubmit, commentSidebarRef, floating } ) {
 	const { clientId } = useSelect( ( select ) => {
 		const { getSelectedBlockClientId } = select( blockEditorStore );
 		return {
@@ -84,7 +79,6 @@ export function AddComment( {
 					focusCommentThread( id, commentSidebarRef.current );
 				} }
 				onCancel={ unselectThread }
-				reflowComments={ reflowComments }
 				submitButtonText={ __( 'Add note' ) }
 				labelText={ __( 'New note' ) }
 			/>

--- a/packages/editor/src/components/collab-sidebar/board-store.js
+++ b/packages/editor/src/components/collab-sidebar/board-store.js
@@ -17,12 +17,10 @@ export function createBoardStore() {
 		let changed = false;
 		for ( const entry of entries ) {
 			const id = idByElement.get( entry.target );
-			if ( id !== undefined ) {
-				const newHeight = entry.target.scrollHeight;
-				if ( heights[ id ] !== newHeight ) {
-					heights[ id ] = newHeight;
-					changed = true;
-				}
+			const newHeight = entry.borderBoxSize[ 0 ].blockSize;
+			if ( heights[ id ] !== newHeight ) {
+				heights[ id ] = newHeight;
+				changed = true;
 			}
 		}
 		if ( changed ) {

--- a/packages/editor/src/components/collab-sidebar/board-store.js
+++ b/packages/editor/src/components/collab-sidebar/board-store.js
@@ -1,0 +1,85 @@
+export function createBoardStore() {
+	const listeners = new Set();
+	const blockRefs = new Map();
+	const floatingRefs = new Map();
+	const idByElement = new WeakMap();
+	const heights = {};
+	let snapshot = {};
+
+	function emit() {
+		snapshot = { ...heights };
+		for ( const listener of listeners ) {
+			listener();
+		}
+	}
+
+	const observer = new window.ResizeObserver( ( entries ) => {
+		let changed = false;
+		for ( const entry of entries ) {
+			const id = idByElement.get( entry.target );
+			if ( id !== undefined ) {
+				const newHeight = entry.target.scrollHeight;
+				if ( heights[ id ] !== newHeight ) {
+					heights[ id ] = newHeight;
+					changed = true;
+				}
+			}
+		}
+		if ( changed ) {
+			emit();
+		}
+	} );
+
+	return {
+		subscribe( listener ) {
+			listeners.add( listener );
+			return () => {
+				listeners.delete( listener );
+				if ( listeners.size === 0 ) {
+					observer.disconnect();
+				}
+			};
+		},
+
+		getSnapshot() {
+			return snapshot;
+		},
+
+		registerThread( id, blockEl, floatingEl ) {
+			blockRefs.set( id, blockEl );
+
+			const prev = floatingRefs.get( id );
+			if ( prev && prev !== floatingEl ) {
+				observer.unobserve( prev );
+				idByElement.delete( prev );
+			}
+			if ( floatingEl ) {
+				floatingRefs.set( id, floatingEl );
+				idByElement.set( floatingEl, id );
+				observer.observe( floatingEl );
+			}
+
+			emit();
+		},
+
+		unregisterThread( id ) {
+			blockRefs.delete( id );
+			const prev = floatingRefs.get( id );
+			if ( prev ) {
+				observer.unobserve( prev );
+				idByElement.delete( prev );
+				floatingRefs.delete( id );
+			}
+			delete heights[ id ];
+		},
+
+		getBlockRects() {
+			// Batch all rect reads before any writes to avoid layout thrashing.
+			return Object.fromEntries(
+				Array.from( blockRefs ).flatMap( ( [ id, el ] ) =>
+					el ? [ [ id, el.getBoundingClientRect() ] ] : []
+				)
+			);
+		},
+	};
+}

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -15,13 +15,13 @@ import {
 	VisuallyHidden,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useInstanceId, useDebounce } from '@wordpress/compose';
+import { useInstanceId } from '@wordpress/compose';
 import { isKeyboardEvent } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
-import { sanitizeCommentString, noop } from './utils';
+import { sanitizeCommentString } from './utils';
 
 function CommentForm( {
 	onSubmit,
@@ -29,18 +29,10 @@ function CommentForm( {
 	thread,
 	submitButtonText,
 	labelText,
-	reflowComments = noop,
 } ) {
 	const [ inputComment, setInputComment ] = useState(
 		thread?.content?.raw ?? ''
 	);
-
-	// Regularly trigger a reflow as the user types since the textarea may grow or shrink.
-	const debouncedCommentUpdated = useDebounce( reflowComments, 100 );
-
-	const updateComment = ( value ) => {
-		setInputComment( value );
-	};
 
 	const inputId = useInstanceId( CommentForm, 'comment-input' );
 	const isDisabled =
@@ -64,10 +56,9 @@ function CommentForm( {
 			<TextareaAutosize
 				id={ inputId }
 				value={ inputComment ?? '' }
-				onChange={ ( comment ) => {
-					updateComment( comment.target.value );
-					debouncedCommentUpdated();
-				} }
+				onChange={ ( comment ) =>
+					setInputComment( comment.target.value )
+				}
 				rows={ 1 }
 				maxRows={ 20 }
 				onKeyDown={ ( event ) => {

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -176,11 +176,13 @@ export function Comments( {
 		}
 	}, [ noteFocused, selectedNote, selectNote, commentSidebarRef ] );
 
-	const { boardOffsets, registerThread, reportHeight } = useFloatingBoard( {
-		threads,
-		selectedNoteId: selectedNote,
-		isFloating,
-	} );
+	const { boardOffsets, registerThread, unregisterThread } = useFloatingBoard(
+		{
+			threads,
+			selectedNoteId: selectedNote,
+			isFloating,
+		}
+	);
 
 	const handleThreadNavigation = ( event, thread, isSelected ) => {
 		if ( event.defaultPrevented ) {
@@ -281,8 +283,8 @@ export function Comments( {
 							? {
 									calculatedOffset:
 										boardOffsets[ thread.id ] ?? 0,
-									reportHeight,
 									registerThread,
+									unregisterThread,
 									commentLastUpdated,
 							  }
 							: undefined
@@ -316,10 +318,6 @@ function Thread( {
 		useDispatch( blockEditorStore )
 	);
 	const { selectNote } = unlock( useDispatch( editorStore ) );
-	const selectedNote = useSelect(
-		( select ) => unlock( select( editorStore ) ).getSelectedNote(),
-		[]
-	);
 	const relatedBlockElement = useBlockElement( thread.blockClientId );
 	const debouncedToggleBlockHighlight = useDebounce(
 		toggleBlockHighlight,
@@ -328,9 +326,8 @@ function Thread( {
 	const { y, refs } = useFloatingThread( {
 		thread,
 		calculatedOffset: floating?.calculatedOffset ?? 0,
-		reportHeight: floating?.reportHeight,
 		registerThread: floating?.registerThread,
-		selectedThread: selectedNote,
+		unregisterThread: floating?.unregisterThread,
 		commentLastUpdated: floating?.commentLastUpdated,
 	} );
 	const isKeyboardTabbingRef = useRef( false );

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -54,9 +54,7 @@ export function Comments( {
 	onAddReply,
 	onCommentDelete,
 	commentSidebarRef,
-	reflowComments,
 	isFloating = false,
-	commentLastUpdated,
 } ) {
 	const { selectNote } = unlock( useDispatch( editorStore ) );
 	const { selectBlock, toggleBlockSpotlight } = unlock(
@@ -277,7 +275,6 @@ export function Comments( {
 					onEditComment={ onEditComment }
 					isSelected={ selectedNote === thread.id }
 					commentSidebarRef={ commentSidebarRef }
-					reflowComments={ reflowComments }
 					floating={
 						isFloating
 							? {
@@ -285,7 +282,6 @@ export function Comments( {
 										boardOffsets[ thread.id ] ?? 0,
 									registerThread,
 									unregisterThread,
-									commentLastUpdated,
 							  }
 							: undefined
 					}
@@ -309,7 +305,6 @@ function Thread( {
 	onCommentDelete,
 	isSelected,
 	commentSidebarRef,
-	reflowComments,
 	floating,
 	onKeyDown,
 } ) {
@@ -328,7 +323,6 @@ function Thread( {
 		calculatedOffset: floating?.calculatedOffset ?? 0,
 		registerThread: floating?.registerThread,
 		unregisterThread: floating?.unregisterThread,
-		commentLastUpdated: floating?.commentLastUpdated,
 	} );
 	const isKeyboardTabbingRef = useRef( false );
 
@@ -420,7 +414,6 @@ function Thread( {
 			<AddComment
 				onSubmit={ onAddReply }
 				commentSidebarRef={ commentSidebarRef }
-				reflowComments={ reflowComments }
 				floating={ { y, refs } }
 			/>
 		);
@@ -493,7 +486,6 @@ function Thread( {
 					}
 				} }
 				onDelete={ onCommentDelete }
-				reflowComments={ reflowComments }
 			/>
 			{ isSelected &&
 				allReplies.map( ( reply ) => (
@@ -504,7 +496,6 @@ function Thread( {
 						isExpanded={ isSelected }
 						onEdit={ onEditComment }
 						onDelete={ onCommentDelete }
-						reflowComments={ reflowComments }
 					/>
 				) ) }
 			{ ! isSelected && restReplies.length > 0 && (
@@ -540,7 +531,6 @@ function Thread( {
 					isExpanded={ isSelected }
 					onEdit={ onEditComment }
 					onDelete={ onCommentDelete }
-					reflowComments={ reflowComments }
 				/>
 			) }
 			{ isSelected && (
@@ -587,7 +577,6 @@ function Thread( {
 								thread.id,
 								thread.author_name
 							) }
-							reflowComments={ reflowComments }
 						/>
 					</VStack>
 				</VStack>
@@ -609,14 +598,7 @@ function Thread( {
 	);
 }
 
-const CommentBoard = ( {
-	thread,
-	parent,
-	isExpanded,
-	onEdit,
-	onDelete,
-	reflowComments,
-} ) => {
+const CommentBoard = ( { thread, parent, isExpanded, onEdit, onDelete } ) => {
 	const [ actionState, setActionState ] = useState( false );
 	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
 	const actionButtonRef = useRef( null );
@@ -776,7 +758,6 @@ const CommentBoard = ( {
 						thread.id,
 						thread.author_name
 					) }
-					reflowComments={ reflowComments }
 				/>
 			) : (
 				<RawHTML

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -15,8 +15,8 @@ import {
 	useState,
 	useEffect,
 	useMemo,
-	useCallback,
 	useReducer,
+	useSyncExternalStore,
 } from '@wordpress/element';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
@@ -34,6 +34,7 @@ import { store as interfaceStore } from '@wordpress/interface';
 import { store as editorStore } from '../../store';
 import { FLOATING_NOTES_SIDEBAR } from './constants';
 import { unlock } from '../../lock-unlock';
+import { createBoardStore } from './board-store';
 import { calculateAllOffsets, noop } from './utils';
 
 const { useBlockElement, cleanEmptyObject } = unlock( blockEditorPrivateApis );
@@ -368,41 +369,21 @@ export function useEnableFloatingSidebar( enabled = false ) {
 }
 
 export function useFloatingBoard( { threads, selectedNoteId, isFloating } ) {
-	const [ heights, setHeights ] = useState( {} );
 	const [ boardOffsets, setBoardOffsets ] = useState( {} );
-	const [ blockRefs, setBlockRefs ] = useState( {} );
-
+	const [ store ] = useState( createBoardStore );
 	const { setCanvasMinHeight } = unlock( useDispatch( editorStore ) );
 
-	const registerThread = useCallback( ( id, el ) => {
-		setBlockRefs( ( prev ) => ( { ...prev, [ id ]: el } ) );
-	}, [] );
-
-	const reportHeight = useCallback( ( id, newHeight ) => {
-		setHeights( ( prev ) => {
-			if ( prev[ id ] !== newHeight ) {
-				return { ...prev, [ id ]: newHeight };
-			}
-			return prev;
-		} );
-	}, [] );
+	const heights = useSyncExternalStore( store.subscribe, store.getSnapshot );
 
 	useEffect( () => {
 		if ( ! isFloating ) {
 			return;
 		}
 
-		// Batch all rect reads before any writes to avoid layout thrashing.
-		const blockRects = Object.fromEntries(
-			Object.entries( blockRefs ).flatMap( ( [ id, el ] ) =>
-				el ? [ [ id, el.getBoundingClientRect() ] ] : []
-			)
-		);
-
 		const { offsets: newOffsets, minHeight } = calculateAllOffsets( {
 			threads,
 			selectedNoteId,
-			blockRects,
+			blockRects: store.getBlockRects(),
 			heights,
 		} );
 		if ( Object.keys( newOffsets ).length > 0 ) {
@@ -411,22 +392,25 @@ export function useFloatingBoard( { threads, selectedNoteId, isFloating } ) {
 		setCanvasMinHeight( minHeight );
 	}, [
 		heights,
-		blockRefs,
 		isFloating,
 		threads,
 		selectedNoteId,
 		setCanvasMinHeight,
+		store,
 	] );
 
-	return { boardOffsets, registerThread, reportHeight };
+	return {
+		boardOffsets,
+		registerThread: store.registerThread,
+		unregisterThread: store.unregisterThread,
+	};
 }
 
 export function useFloatingThread( {
 	thread,
 	calculatedOffset,
-	reportHeight,
-	selectedThread,
 	registerThread,
+	unregisterThread,
 	commentLastUpdated,
 } ) {
 	const blockElement = useBlockElement( thread.blockClientId );
@@ -442,32 +426,27 @@ export function useFloatingThread( {
 		whileElementsMounted: autoUpdate,
 	} );
 
-	// Store the block reference for each thread.
+	// Set the floating-ui reference element.
 	useEffect( () => {
 		if ( blockElement ) {
 			refs.setReference( blockElement );
 		}
 	}, [ blockElement, refs, commentLastUpdated ] );
 
-	// Register the block element so the board can read its rect.
+	// Register block + floating elements with the board.
+	// The board's ResizeObserver tracks height changes automatically.
 	useEffect( () => {
-		if ( refs.floating?.current ) {
-			registerThread( thread.id, blockElement );
+		const floatingEl = refs.floating?.current;
+		if ( floatingEl && registerThread ) {
+			registerThread( thread.id, blockElement, floatingEl );
 		}
-	}, [ blockElement, thread.id, refs.floating, registerThread ] );
-
-	// When the selected thread changes, report height to trigger offset recalculation.
-	useEffect( () => {
-		if ( refs.floating?.current ) {
-			const newHeight = refs.floating.current.scrollHeight;
-			reportHeight( thread.id, newHeight );
-		}
+		return () => unregisterThread?.( thread.id );
 	}, [
+		blockElement,
 		thread.id,
-		reportHeight,
 		refs.floating,
-		selectedThread,
-		commentLastUpdated,
+		registerThread,
+		unregisterThread,
 	] );
 
 	return {

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -375,28 +375,34 @@ export function useFloatingBoard( { threads, selectedNoteId, isFloating } ) {
 
 	const heights = useSyncExternalStore( store.subscribe, store.getSnapshot );
 
+	// Defer rect reads + offset calculation to a rAF so rapid-fire
+	// changes (ResizeObserver, selection, threads) coalesce into one recalc.
 	useEffect( () => {
 		if ( ! isFloating ) {
 			return;
 		}
 
-		const { offsets: newOffsets, minHeight } = calculateAllOffsets( {
-			threads,
-			selectedNoteId,
-			blockRects: store.getBlockRects(),
-			heights,
+		const rafId = window.requestAnimationFrame( () => {
+			const { offsets: newOffsets, minHeight } = calculateAllOffsets( {
+				threads,
+				selectedNoteId,
+				blockRects: store.getBlockRects(),
+				heights,
+			} );
+			if ( Object.keys( newOffsets ).length > 0 ) {
+				setBoardOffsets( newOffsets );
+			}
+			setCanvasMinHeight( minHeight );
 		} );
-		if ( Object.keys( newOffsets ).length > 0 ) {
-			setBoardOffsets( newOffsets );
-		}
-		setCanvasMinHeight( minHeight );
+
+		return () => window.cancelAnimationFrame( rafId );
 	}, [
 		heights,
 		isFloating,
-		threads,
 		selectedNoteId,
 		setCanvasMinHeight,
 		store,
+		threads,
 	] );
 
 	return {

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -361,23 +361,21 @@ export function useFloatingBoard( { threads, selectedNoteId, isFloating } ) {
 
 	const heights = useSyncExternalStore( store.subscribe, store.getSnapshot );
 
-	// Defer rect reads + offset calculation to a rAF so rapid-fire
-	// changes (ResizeObserver, selection, threads) coalesce into one recalc.
+	// Recalc is deferred to a rAF; the cleanup cancels the pending frame
+	// when deps change, so back-to-back updates collapse into one paint.
 	useEffect( () => {
 		if ( ! isFloating ) {
 			return;
 		}
 
 		const rafId = window.requestAnimationFrame( () => {
-			const { offsets: newOffsets, minHeight } = calculateAllOffsets( {
+			const { offsets, minHeight } = calculateAllOffsets( {
 				threads,
 				selectedNoteId,
 				blockRects: store.getBlockRects(),
 				heights,
 			} );
-			if ( Object.keys( newOffsets ).length > 0 ) {
-				setBoardOffsets( newOffsets );
-			}
+			setBoardOffsets( offsets );
 			setCanvasMinHeight( minHeight );
 		} );
 

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -15,7 +15,6 @@ import {
 	useState,
 	useEffect,
 	useMemo,
-	useReducer,
 	useSyncExternalStore,
 } from '@wordpress/element';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
@@ -35,16 +34,11 @@ import { store as editorStore } from '../../store';
 import { FLOATING_NOTES_SIDEBAR } from './constants';
 import { unlock } from '../../lock-unlock';
 import { createBoardStore } from './board-store';
-import { calculateAllOffsets, noop } from './utils';
+import { calculateAllOffsets } from './utils';
 
 const { useBlockElement, cleanEmptyObject } = unlock( blockEditorPrivateApis );
 
 export function useBlockComments( postId ) {
-	const [ commentLastUpdated, reflowComments ] = useReducer(
-		() => Date.now(),
-		0
-	);
-
 	const queryArgs = {
 		post: postId,
 		type: 'note',
@@ -167,12 +161,10 @@ export function useBlockComments( postId ) {
 	return {
 		resultComments,
 		unresolvedSortedThreads,
-		reflowComments,
-		commentLastUpdated,
 	};
 }
 
-export function useBlockCommentsActions( reflowComments = noop ) {
+export function useBlockCommentsActions() {
 	const { createNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
 	const { getCurrentPostId } = useSelect( editorStore );
@@ -226,10 +218,8 @@ export function useBlockCommentsActions( reflowComments = noop ) {
 					isDismissible: true,
 				}
 			);
-			setTimeout( reflowComments, 300 );
 			return savedRecord;
 		} catch ( error ) {
-			reflowComments();
 			onError( error );
 		}
 	};
@@ -294,9 +284,7 @@ export function useBlockCommentsActions( reflowComments = noop ) {
 					isDismissible: true,
 				}
 			);
-			reflowComments();
 		} catch ( error ) {
-			reflowComments();
 			onError( error );
 		}
 	};
@@ -328,9 +316,7 @@ export function useBlockCommentsActions( reflowComments = noop ) {
 				type: 'snackbar',
 				isDismissible: true,
 			} );
-			reflowComments();
 		} catch ( error ) {
-			reflowComments();
 			onError( error );
 		}
 	};
@@ -417,7 +403,6 @@ export function useFloatingThread( {
 	calculatedOffset,
 	registerThread,
 	unregisterThread,
-	commentLastUpdated,
 } ) {
 	const blockElement = useBlockElement( thread.blockClientId );
 
@@ -437,7 +422,7 @@ export function useFloatingThread( {
 		if ( blockElement ) {
 			refs.setReference( blockElement );
 		}
-	}, [ blockElement, refs, commentLastUpdated ] );
+	}, [ blockElement, refs ] );
 
 	// Register block + floating elements with the board.
 	// The board's ResizeObserver tracks height changes automatically.

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -38,12 +38,9 @@ function NotesSidebarContent( {
 	styles,
 	comments,
 	commentSidebarRef,
-	reflowComments,
-	commentLastUpdated,
 	isFloating = false,
 } ) {
-	const { onCreate, onEdit, onDelete } =
-		useBlockCommentsActions( reflowComments );
+	const { onCreate, onEdit, onDelete } = useBlockCommentsActions();
 
 	return (
 		<VStack
@@ -70,8 +67,6 @@ function NotesSidebarContent( {
 				onAddReply={ onCreate }
 				onCommentDelete={ onDelete }
 				commentSidebarRef={ commentSidebarRef }
-				reflowComments={ reflowComments }
-				commentLastUpdated={ commentLastUpdated }
 				isFloating={ isFloating }
 			/>
 		</VStack>
@@ -119,12 +114,8 @@ function NotesSidebar( { postId } ) {
 		[]
 	);
 
-	const {
-		resultComments,
-		unresolvedSortedThreads,
-		reflowComments,
-		commentLastUpdated,
-	} = useBlockComments( postId );
+	const { resultComments, unresolvedSortedThreads } =
+		useBlockComments( postId );
 
 	// Only enable the floating sidebar for large viewports.
 	const showFloatingSidebar = isLargeViewport;
@@ -239,8 +230,6 @@ function NotesSidebar( { postId } ) {
 					<NotesSidebarContent
 						comments={ unresolvedSortedThreads }
 						commentSidebarRef={ commentSidebarRef }
-						reflowComments={ reflowComments }
-						commentLastUpdated={ commentLastUpdated }
 						styles={ {
 							backgroundColor,
 						} }

--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -13,11 +13,6 @@ export function sanitizeCommentString( str ) {
 	return str.trim();
 }
 
-/**
- * A no-operation function that does nothing.
- */
-export function noop() {}
-
 const THREAD_ALIGN_OFFSET = -16;
 const THREAD_GAP = 16;
 const OVERLAP_MARGIN = 20;


### PR DESCRIPTION
## What?
This is a follow-up to #77414.

Extract the floating notes board state into a dedicated store and remove the manual `reflowComments` reflow mechanism.

## Why?
1. **Layout thrashing** -  the board state (`blockRefs`, `heights`) used React `useState`, causing full re-renders and synchronous `getBoundingClientRect` reads in `useEffect`. Rapid state updates (typing, resizing, CRUD) across N threads resulted in redundant recalculations on each render cycle.
2. **Manual reflows** - `reflowComments` (a `useReducer`-based `Date.now()` counter) was used in about 15 places across 6 files to trigger layout recalculation after comment CRUD and textarea resizing. This approach was fragile and triggered more times than needed. Now it's redundant, the `ResizeObserver` monitors panel heights.


## How?
**Board store**: A plain JS store (compatible with `useSyncExternalStore`) that holds `blockRefs`, `floatingRefs`, and `heights` outside React state. A single `ResizeObserver` watches all floating panel elements and emits only when heights actually change. `getBlockRects()` batches all `getBoundingClientRect` reads in one pass.

## Testing Instructions
1. Existing e2e tests are passing.
4. Smoke tests the floating notes feature. It should work as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before - every keystroke triggers reflow**

https://github.com/user-attachments/assets/d950c462-8e86-4c70-bdac-9ab4f6d49fe5

**After - only actual height changes trigger reflow**

https://github.com/user-attachments/assets/6d4f2fc2-83de-4204-94ac-b42fdd87ba15

## Use of AI Tools

Used Claude to brainstorm my ideas, tested and reviewed personally.
