### PR TITLE
Menu: Fix flaky submenu focus test

### DIFF
--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -359,32 +359,49 @@ describe( 'Menu', () => {
 			// Arrow up/down selects menu items
 			// The selection wraps around from last to first and viceversa
 			await press.ArrowDown();
-			await waitForFocusedMenuItem( 'Menu item 1' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Menu item 1' } )
+			).toHaveFocus();
 
 			await press.ArrowDown();
-			await waitForFocusedMenuItem( 'Menu item 2' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Menu item 2' } )
+			).toHaveFocus();
 
 			await press.ArrowDown();
-			await waitForFocusedMenuItem( 'Submenu trigger item' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Submenu trigger item' } )
+			).toHaveFocus();
 
 			await press.ArrowDown();
-			await waitForFocusedMenuItem( 'Menu item 3' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Menu item 3' } )
+			).toHaveFocus();
 
 			await press.ArrowDown();
-			await waitForFocusedMenuItem( 'Menu item 1' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Menu item 1' } )
+			).toHaveFocus();
 
 			await press.ArrowUp();
-			await waitForFocusedMenuItem( 'Menu item 3' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Menu item 3' } )
+			).toHaveFocus();
 
 			await press.ArrowUp();
-			await waitForFocusedMenuItem( 'Submenu trigger item' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Submenu trigger item' } )
+			).toHaveFocus();
 
 			// Arrow right/left can be used to enter/leave submenus
+			// (focus crosses menu contexts, so wait for it to settle)
 			await press.ArrowRight();
 			await waitForFocusedMenuItem( 'Submenu item 1' );
 
 			await press.ArrowDown();
-			await waitForFocusedMenuItem( 'Submenu item 2' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Submenu item 2' } )
+			).toHaveFocus();
 
 			await press.ArrowLeft();
 			await waitForFocusedMenuItem( 'Submenu trigger item' );
@@ -881,17 +898,17 @@ describe( 'Menu', () => {
 
 			// Menu is not modal, therefore the outer button is part of the
 			// accessibility tree and can be found.
-			const outerButton = screen.getByRole( 'button', {
-				name: 'Button outside of dropdown',
-			} );
+			expect(
+				screen.getByRole( 'button', {
+					name: 'Button outside of dropdown',
+				} )
+			).toBeVisible();
 
 			// The outer button can be focused by pressing tab. Doing so will cause
 			// the Menu to close.
 			await press.Tab();
-			await waitFor( () => {
-				expect( outerButton ).toHaveFocus();
-				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
-			} );
+			await waitForFocusedButton( 'Button outside of dropdown' );
+			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -353,6 +353,15 @@ describe( 'Menu', () => {
 				expect( screen.getByRole( 'menu' ) ).toHaveFocus()
 			);
 
+			const expectFocusedMenuItem = ( name: string ) =>
+				waitFor( () =>
+					expect(
+						screen.getByRole( 'menuitem', {
+							name,
+						} )
+					).toHaveFocus()
+				);
+
 			// Arrow up/down selects menu items
 			// The selection wraps around from last to first and viceversa
 			await press.ArrowDown();
@@ -392,11 +401,7 @@ describe( 'Menu', () => {
 
 			// Arrow right/left can be used to enter/leave submenus
 			await press.ArrowRight();
-			expect(
-				screen.getByRole( 'menuitem', {
-					name: 'Submenu item 1',
-				} )
-			).toHaveFocus();
+			await expectFocusedMenuItem( 'Submenu item 1' );
 
 			await press.ArrowDown();
 			expect(
@@ -406,40 +411,20 @@ describe( 'Menu', () => {
 			).toHaveFocus();
 
 			await press.ArrowLeft();
-			expect(
-				screen.getByRole( 'menuitem', {
-					name: 'Submenu trigger item',
-				} )
-			).toHaveFocus();
+			await expectFocusedMenuItem( 'Submenu trigger item' );
 
 			// Spacebar or enter key can also be used to enter a submenu
 			await press.Enter();
-			expect(
-				screen.getByRole( 'menuitem', {
-					name: 'Submenu item 1',
-				} )
-			).toHaveFocus();
+			await expectFocusedMenuItem( 'Submenu item 1' );
 
 			await press.ArrowLeft();
-			expect(
-				screen.getByRole( 'menuitem', {
-					name: 'Submenu trigger item',
-				} )
-			).toHaveFocus();
+			await expectFocusedMenuItem( 'Submenu trigger item' );
 
 			await press.Space();
-			expect(
-				screen.getByRole( 'menuitem', {
-					name: 'Submenu item 1',
-				} )
-			).toHaveFocus();
+			await expectFocusedMenuItem( 'Submenu item 1' );
 
 			await press.ArrowLeft();
-			expect(
-				screen.getByRole( 'menuitem', {
-					name: 'Submenu trigger item',
-				} )
-			).toHaveFocus();
+			await expectFocusedMenuItem( 'Submenu trigger item' );
 		} );
 
 		it( 'should check radio items and keep the menu open when clicking (controlled)', async () => {

--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -26,11 +26,6 @@ const waitForFocusedMenuItem = ( name: string ) =>
 		expect( screen.getByRole( 'menuitem', { name } ) ).toHaveFocus()
 	);
 
-const waitForFocusedButton = ( name: string ) =>
-	waitFor( () =>
-		expect( screen.getByRole( 'button', { name } ) ).toHaveFocus()
-	);
-
 // Open dropdown => open menu
 // Submenu trigger item => open submenu
 
@@ -217,7 +212,11 @@ describe( 'Menu', () => {
 
 			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
 
-			await waitForFocusedButton( 'Open dropdown' );
+			await waitFor( () =>
+				expect(
+					screen.getByRole( 'button', { name: 'Open dropdown' } )
+				).toHaveFocus()
+			);
 		} );
 
 		it( 'should close when clicking outside of the content', async () => {
@@ -404,20 +403,32 @@ describe( 'Menu', () => {
 			).toHaveFocus();
 
 			await press.ArrowLeft();
-			await waitForFocusedMenuItem( 'Submenu trigger item' );
+			expect(
+				screen.getByRole( 'menuitem', {
+					name: 'Submenu trigger item',
+				} )
+			).toHaveFocus();
 
 			// Spacebar or enter key can also be used to enter a submenu
 			await press.Enter();
 			await waitForFocusedMenuItem( 'Submenu item 1' );
 
 			await press.ArrowLeft();
-			await waitForFocusedMenuItem( 'Submenu trigger item' );
+			expect(
+				screen.getByRole( 'menuitem', {
+					name: 'Submenu trigger item',
+				} )
+			).toHaveFocus();
 
 			await press.Space();
 			await waitForFocusedMenuItem( 'Submenu item 1' );
 
 			await press.ArrowLeft();
-			await waitForFocusedMenuItem( 'Submenu trigger item' );
+			expect(
+				screen.getByRole( 'menuitem', {
+					name: 'Submenu trigger item',
+				} )
+			).toHaveFocus();
 		} );
 
 		it( 'should check radio items and keep the menu open when clicking (controlled)', async () => {
@@ -898,16 +909,15 @@ describe( 'Menu', () => {
 
 			// Menu is not modal, therefore the outer button is part of the
 			// accessibility tree and can be found.
-			expect(
-				screen.getByRole( 'button', {
-					name: 'Button outside of dropdown',
-				} )
-			).toBeVisible();
+			const outerButton = screen.getByRole( 'button', {
+				name: 'Button outside of dropdown',
+			} );
+			expect( outerButton ).toBeVisible();
 
 			// The outer button can be focused by pressing tab. Doing so will cause
 			// the Menu to close.
 			await press.Tab();
-			await waitForFocusedButton( 'Button outside of dropdown' );
+			expect( outerButton ).toBeVisible();
 			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
 		} );
 	} );
@@ -1052,7 +1062,9 @@ describe( 'Menu', () => {
 
 			// Type "tw", it should match and focus the item with content "Two"
 			await type( 'tw' );
-			await waitForFocusedMenuItem( 'Two' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Two' } )
+			).toHaveFocus();
 
 			// Wait for the typeahead timer to reset and interpret
 			// the next keystrokes as a new search
@@ -1060,7 +1072,9 @@ describe( 'Menu', () => {
 
 			// Type "on", it should match and focus the item with content "One"
 			await type( 'on' );
-			await waitForFocusedMenuItem( 'One' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'One' } )
+			).toHaveFocus();
 		} );
 
 		it( 'should keep previous focus when no matches are found', async () => {
@@ -1084,7 +1098,7 @@ describe( 'Menu', () => {
 
 			// Type a string that doesn't match any items. Focus shouldn't move.
 			await type( 'abc' );
-			await waitForFocusedMenu();
+			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
 
 			// Wait for the typeahead timer to reset and interpret
 			// the next keystrokes as a new search
@@ -1092,7 +1106,9 @@ describe( 'Menu', () => {
 
 			// Type "on", it should match and focus the item with content "One"
 			await type( 'on' );
-			await waitForFocusedMenuItem( 'One' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'One' } )
+			).toHaveFocus();
 
 			// Wait for the typeahead timer to reset and interpret
 			// the next keystrokes as a new search
@@ -1100,7 +1116,9 @@ describe( 'Menu', () => {
 
 			// Type a string that doesn't match any items. Focus shouldn't move.
 			await type( 'abc' );
-			await waitForFocusedMenuItem( 'One' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'One' } )
+			).toHaveFocus();
 
 			// Wait for the typeahead timer to reset and interpret
 			// the next keystrokes as a new search
@@ -1108,7 +1126,9 @@ describe( 'Menu', () => {
 
 			// Type "tw", it should match and focus the item with content "Two"
 			await type( 'tw' );
-			await waitForFocusedMenuItem( 'Two' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Two' } )
+			).toHaveFocus();
 		} );
 	} );
 } );

--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -18,6 +18,19 @@ const delay = ( delayInMs: number ) => {
 	return new Promise( ( resolve ) => setTimeout( resolve, delayInMs ) );
 };
 
+const waitForFocusedMenu = () =>
+	waitFor( () => expect( screen.getByRole( 'menu' ) ).toHaveFocus() );
+
+const waitForFocusedMenuItem = ( name: string ) =>
+	waitFor( () =>
+		expect( screen.getByRole( 'menuitem', { name } ) ).toHaveFocus()
+	);
+
+const waitForFocusedButton = ( name: string ) =>
+	waitFor( () =>
+		expect( screen.getByRole( 'button', { name } ) ).toHaveFocus()
+	);
+
 // Open dropdown => open menu
 // Submenu trigger item => open submenu
 
@@ -114,7 +127,7 @@ describe( 'Menu', () => {
 			await click( toggleButton );
 
 			// Menu open, focus is on the menu wrapper
-			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
+			await waitForFocusedMenu();
 		} );
 
 		it( 'should open and focus the first item when pressing the arrow down key on the trigger', async () => {
@@ -145,9 +158,7 @@ describe( 'Menu', () => {
 
 			// Menu open, focus is on the first focusable item
 			// (disabled items are still focusable and accessible)
-			expect(
-				screen.getByRole( 'menuitem', { name: 'First item' } )
-			).toHaveFocus();
+			await waitForFocusedMenuItem( 'First item' );
 		} );
 
 		it( 'should open and focus the first item when pressing the space key on the trigger', async () => {
@@ -178,9 +189,7 @@ describe( 'Menu', () => {
 
 			// Menu open, focus is on the first focusable item
 			// (disabled items are still focusable and accessible
-			expect(
-				screen.getByRole( 'menuitem', { name: 'First item' } )
-			).toHaveFocus();
+			await waitForFocusedMenuItem( 'First item' );
 		} );
 
 		it( 'should close when pressing the escape key', async () => {
@@ -201,18 +210,14 @@ describe( 'Menu', () => {
 
 			// Focuses menu on mouse click, focuses first item on keyboard press
 			// Can be changed with a custom useEffect
-			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
+			await waitForFocusedMenu();
 
 			// Pressing esc will close the menu and move focus to the toggle
 			await press.Escape();
 
 			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
 
-			await waitFor( () =>
-				expect(
-					screen.getByRole( 'button', { name: 'Open dropdown' } )
-				).toHaveFocus()
-			);
+			await waitForFocusedButton( 'Open dropdown' );
 		} );
 
 		it( 'should close when clicking outside of the content', async () => {
@@ -348,17 +353,8 @@ describe( 'Menu', () => {
 				</Menu>
 			);
 
-			const waitForFocusedMenuItem = ( name: string ) =>
-				waitFor( () =>
-					expect(
-						screen.getByRole( 'menuitem', { name } )
-					).toHaveFocus()
-				);
-
 			// The menu is focused automatically when `defaultOpen` is set.
-			await waitFor( () =>
-				expect( screen.getByRole( 'menu' ) ).toHaveFocus()
-			);
+			await waitForFocusedMenu();
 
 			// Arrow up/down selects menu items
 			// The selection wraps around from last to first and viceversa
@@ -851,7 +847,7 @@ describe( 'Menu', () => {
 			);
 
 			// Menu open, focus is on the menu wrapper
-			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
+			await waitForFocusedMenu();
 
 			expect(
 				screen.queryByRole( 'button', {
@@ -881,7 +877,7 @@ describe( 'Menu', () => {
 			);
 
 			// Menu open, focus is on the menu wrapper
-			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
+			await waitForFocusedMenu();
 
 			// Menu is not modal, therefore the outer button is part of the
 			// accessibility tree and can be found.
@@ -892,8 +888,10 @@ describe( 'Menu', () => {
 			// The outer button can be focused by pressing tab. Doing so will cause
 			// the Menu to close.
 			await press.Tab();
-			expect( outerButton ).toBeInTheDocument();
-			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
+			await waitFor( () => {
+				expect( outerButton ).toHaveFocus();
+				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
+			} );
 		} );
 	} );
 
@@ -1033,13 +1031,11 @@ describe( 'Menu', () => {
 					name: 'Open dropdown',
 				} )
 			);
-			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
+			await waitForFocusedMenu();
 
 			// Type "tw", it should match and focus the item with content "Two"
 			await type( 'tw' );
-			expect(
-				screen.getByRole( 'menuitem', { name: 'Two' } )
-			).toHaveFocus();
+			await waitForFocusedMenuItem( 'Two' );
 
 			// Wait for the typeahead timer to reset and interpret
 			// the next keystrokes as a new search
@@ -1047,9 +1043,7 @@ describe( 'Menu', () => {
 
 			// Type "on", it should match and focus the item with content "One"
 			await type( 'on' );
-			expect(
-				screen.getByRole( 'menuitem', { name: 'One' } )
-			).toHaveFocus();
+			await waitForFocusedMenuItem( 'One' );
 		} );
 
 		it( 'should keep previous focus when no matches are found', async () => {
@@ -1069,11 +1063,11 @@ describe( 'Menu', () => {
 					name: 'Open dropdown',
 				} )
 			);
-			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
+			await waitForFocusedMenu();
 
 			// Type a string that doesn't match any items. Focus shouldn't move.
 			await type( 'abc' );
-			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
+			await waitForFocusedMenu();
 
 			// Wait for the typeahead timer to reset and interpret
 			// the next keystrokes as a new search
@@ -1081,9 +1075,7 @@ describe( 'Menu', () => {
 
 			// Type "on", it should match and focus the item with content "One"
 			await type( 'on' );
-			expect(
-				screen.getByRole( 'menuitem', { name: 'One' } )
-			).toHaveFocus();
+			await waitForFocusedMenuItem( 'One' );
 
 			// Wait for the typeahead timer to reset and interpret
 			// the next keystrokes as a new search
@@ -1091,9 +1083,7 @@ describe( 'Menu', () => {
 
 			// Type a string that doesn't match any items. Focus shouldn't move.
 			await type( 'abc' );
-			expect(
-				screen.getByRole( 'menuitem', { name: 'One' } )
-			).toHaveFocus();
+			await waitForFocusedMenuItem( 'One' );
 
 			// Wait for the typeahead timer to reset and interpret
 			// the next keystrokes as a new search
@@ -1101,9 +1091,7 @@ describe( 'Menu', () => {
 
 			// Type "tw", it should match and focus the item with content "Two"
 			await type( 'tw' );
-			expect(
-				screen.getByRole( 'menuitem', { name: 'Two' } )
-			).toHaveFocus();
+			await waitForFocusedMenuItem( 'Two' );
 		} );
 	} );
 } );

--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -348,83 +348,63 @@ describe( 'Menu', () => {
 				</Menu>
 			);
 
+			const waitForFocusedMenuItem = ( name: string ) =>
+				waitFor( () =>
+					expect(
+						screen.getByRole( 'menuitem', { name } )
+					).toHaveFocus()
+				);
+
 			// The menu is focused automatically when `defaultOpen` is set.
 			await waitFor( () =>
 				expect( screen.getByRole( 'menu' ) ).toHaveFocus()
 			);
 
-			const expectFocusedMenuItem = ( name: string ) =>
-				waitFor( () =>
-					expect(
-						screen.getByRole( 'menuitem', {
-							name,
-						} )
-					).toHaveFocus()
-				);
-
 			// Arrow up/down selects menu items
 			// The selection wraps around from last to first and viceversa
 			await press.ArrowDown();
-			expect(
-				screen.getByRole( 'menuitem', { name: 'Menu item 1' } )
-			).toHaveFocus();
+			await waitForFocusedMenuItem( 'Menu item 1' );
 
 			await press.ArrowDown();
-			expect(
-				screen.getByRole( 'menuitem', { name: 'Menu item 2' } )
-			).toHaveFocus();
+			await waitForFocusedMenuItem( 'Menu item 2' );
 
 			await press.ArrowDown();
-			expect(
-				screen.getByRole( 'menuitem', { name: 'Submenu trigger item' } )
-			).toHaveFocus();
+			await waitForFocusedMenuItem( 'Submenu trigger item' );
 
 			await press.ArrowDown();
-			expect(
-				screen.getByRole( 'menuitem', { name: 'Menu item 3' } )
-			).toHaveFocus();
+			await waitForFocusedMenuItem( 'Menu item 3' );
 
 			await press.ArrowDown();
-			expect(
-				screen.getByRole( 'menuitem', { name: 'Menu item 1' } )
-			).toHaveFocus();
+			await waitForFocusedMenuItem( 'Menu item 1' );
 
 			await press.ArrowUp();
-			expect(
-				screen.getByRole( 'menuitem', { name: 'Menu item 3' } )
-			).toHaveFocus();
+			await waitForFocusedMenuItem( 'Menu item 3' );
 
 			await press.ArrowUp();
-			expect(
-				screen.getByRole( 'menuitem', { name: 'Submenu trigger item' } )
-			).toHaveFocus();
+			await waitForFocusedMenuItem( 'Submenu trigger item' );
 
 			// Arrow right/left can be used to enter/leave submenus
 			await press.ArrowRight();
-			await expectFocusedMenuItem( 'Submenu item 1' );
+			await waitForFocusedMenuItem( 'Submenu item 1' );
 
 			await press.ArrowDown();
-			expect(
-				screen.getByRole( 'menuitem', {
-					name: 'Submenu item 2',
-				} )
-			).toHaveFocus();
+			await waitForFocusedMenuItem( 'Submenu item 2' );
 
 			await press.ArrowLeft();
-			await expectFocusedMenuItem( 'Submenu trigger item' );
+			await waitForFocusedMenuItem( 'Submenu trigger item' );
 
 			// Spacebar or enter key can also be used to enter a submenu
 			await press.Enter();
-			await expectFocusedMenuItem( 'Submenu item 1' );
+			await waitForFocusedMenuItem( 'Submenu item 1' );
 
 			await press.ArrowLeft();
-			await expectFocusedMenuItem( 'Submenu trigger item' );
+			await waitForFocusedMenuItem( 'Submenu trigger item' );
 
 			await press.Space();
-			await expectFocusedMenuItem( 'Submenu item 1' );
+			await waitForFocusedMenuItem( 'Submenu item 1' );
 
 			await press.ArrowLeft();
-			await expectFocusedMenuItem( 'Submenu trigger item' );
+			await waitForFocusedMenuItem( 'Submenu trigger item' );
 		} );
 
 		it( 'should check radio items and keep the menu open when clicking (controlled)', async () => {


### PR DESCRIPTION
## What?

This updates `packages/components/src/menu/test/index.tsx` to stabilize focus assertions across the `Menu` test file, by adding shared async focus helpers and uses them for the focus transitions that were failing intermittently in CI.

## Why?

The common pattern in recent unit test failures on CI is that focus sometimes lands on an intermediate element first, then settles on the expected target a moment later.

That showed up in recent logs as:
- [24518371811](https://github.com/WordPress/gutenberg/actions/runs/24518371811): submenu keyboard navigation expected `Submenu item 1`, but focus was still on the submenu `role="menu"` container.
- [24504507390](https://github.com/WordPress/gutenberg/actions/runs/24504507390): same submenu keyboard-navigation failure at the same assertion.
- [24507074091](https://github.com/WordPress/gutenberg/actions/runs/24507074091): non-modal menu test expected the menu wrapper to keep focus, but focus was on the trigger button.
- [24503608390](https://github.com/WordPress/gutenberg/actions/runs/24503608390) and [24474029279](https://github.com/WordPress/gutenberg/actions/runs/24474029279): close-on-escape path expected menu focus, but focus had already returned to the trigger.
- [24500109772](https://github.com/WordPress/gutenberg/actions/runs/24500109772), [24495170722](https://github.com/WordPress/gutenberg/actions/runs/24495170722), [24494820779](https://github.com/WordPress/gutenberg/actions/runs/24494820779), and [24468416091](https://github.com/WordPress/gutenberg/actions/runs/24468416091): open-with-space path expected the first item to be focused, but focus was still on the menu wrapper.
- [24470376929](https://github.com/WordPress/gutenberg/actions/runs/24470376929): click-open path expected the menu wrapper to be focused, but focus was still on the trigger.

Taken together, those runs suggest a broader focus-settling race in this test file rather than a single isolated flaky assertion.

## How?

- Adds shared helpers for waiting on menu, menu item, and trigger focus.
- Reuses those helpers for focus-transition boundaries in the file.
- Leaves the synchronous assertions in place for stable in-menu navigation where focus is already inside the same menu context.

## Testing Instructions

1. Run `npm run test:unit -- packages/components/src/menu/test/index.tsx --runInBand`.
2. Confirm `packages/components/src/menu/test/index.tsx` passes.
3. Repeat the file a few times to check for stability, for example: `npm run test:unit -- packages/components/src/menu/test/index.tsx --runInBand`.