### PR TITLE
Notes: Compute note positions centrally in useFloatingBoard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59778,7 +59778,6 @@
 			"version": "14.44.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@floating-ui/react-dom": "2.0.8",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -60,7 +60,6 @@
 		"build-module/bindings/**"
 	],
 	"dependencies": {
-		"@floating-ui/react-dom": "2.0.8",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",

--- a/packages/editor/src/components/collab-sidebar/board-store.js
+++ b/packages/editor/src/components/collab-sidebar/board-store.js
@@ -45,7 +45,6 @@ export function createBoardStore() {
 
 		registerThread( id, blockEl, floatingEl ) {
 			blockRefs.set( id, blockEl );
-
 			const prev = floatingRefs.get( id );
 			if ( prev && prev !== floatingEl ) {
 				observer.unobserve( prev );
@@ -56,7 +55,6 @@ export function createBoardStore() {
 				idByElement.set( floatingEl, id );
 				observer.observe( floatingEl );
 			}
-
 			emit();
 		},
 
@@ -78,6 +76,10 @@ export function createBoardStore() {
 					el ? [ [ id, el.getBoundingClientRect() ] ] : []
 				)
 			);
+		},
+
+		getFirstBlockElement() {
+			return blockRefs.values().next().value ?? null;
 		},
 	};
 }

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -40,7 +40,7 @@ import { unlock } from '../../lock-unlock';
 import CommentAuthorInfo from './comment-author-info';
 import CommentForm from './comment-form';
 import { focusCommentThread, getCommentExcerpt } from './utils';
-import { useFloatingBoard, useFloatingThread } from './hooks';
+import { useFloatingBoard } from './hooks';
 import { FloatingContainer } from './floating-container';
 import { AddComment } from './add-comment';
 import { store as editorStore } from '../../store';
@@ -174,13 +174,13 @@ export function Comments( {
 		}
 	}, [ noteFocused, selectedNote, selectNote, commentSidebarRef ] );
 
-	const { boardOffsets, registerThread, unregisterThread } = useFloatingBoard(
-		{
+	const { notePositions, contentHeight, registerThread, unregisterThread } =
+		useFloatingBoard( {
 			threads,
 			selectedNoteId: selectedNote,
 			isFloating,
-		}
-	);
+			commentSidebarRef,
+		} );
 
 	const handleThreadNavigation = ( event, thread, isSelected ) => {
 		if ( event.defaultPrevented ) {
@@ -260,6 +260,9 @@ export function Comments( {
 
 	return (
 		<>
+			{ isFloating && contentHeight > 0 && (
+				<div style={ { height: contentHeight } } aria-hidden="true" />
+			) }
 			{ ! isFloating && selectedNote === 'new' && (
 				<AddComment
 					onSubmit={ onAddReply }
@@ -278,8 +281,7 @@ export function Comments( {
 					floating={
 						isFloating
 							? {
-									calculatedOffset:
-										boardOffsets[ thread.id ] ?? 0,
+									y: notePositions[ thread.id ],
 									registerThread,
 									unregisterThread,
 							  }
@@ -318,13 +320,21 @@ function Thread( {
 		toggleBlockHighlight,
 		50
 	);
-	const { y, refs } = useFloatingThread( {
-		thread,
-		calculatedOffset: floating?.calculatedOffset ?? 0,
-		registerThread: floating?.registerThread,
-		unregisterThread: floating?.unregisterThread,
-	} );
+	const floatingRef = useRef( null );
 	const isKeyboardTabbingRef = useRef( false );
+
+	const registerThread = floating?.registerThread;
+	const unregisterThread = floating?.unregisterThread;
+
+	// Register block + floating elements with the board.
+	// The board's ResizeObserver and autoUpdate track changes automatically.
+	useEffect( () => {
+		const floatingEl = floatingRef.current;
+		if ( floatingEl && registerThread ) {
+			registerThread( thread.id, relatedBlockElement, floatingEl );
+		}
+		return () => unregisterThread?.( thread.id );
+	}, [ relatedBlockElement, thread.id, registerThread, unregisterThread ] );
 
 	const onMouseEnter = () => {
 		debouncedToggleBlockHighlight( thread.blockClientId, true );
@@ -414,14 +424,16 @@ function Thread( {
 			<AddComment
 				onSubmit={ onAddReply }
 				commentSidebarRef={ commentSidebarRef }
-				floating={ { y, refs } }
+				floating={ { y: floating.y, ref: floatingRef } }
 			/>
 		);
 	}
 
 	return (
 		<FloatingContainer
-			floating={ isFloating ? { y, refs } : undefined }
+			floating={
+				isFloating ? { y: floating.y, ref: floatingRef } : undefined
+			}
 			className={ clsx( 'editor-collab-sidebar-panel__thread', {
 				'is-selected': isSelected,
 			} ) }

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -174,7 +174,7 @@ export function Comments( {
 		}
 	}, [ noteFocused, selectedNote, selectNote, commentSidebarRef ] );
 
-	const { notePositions, contentHeight, registerThread, unregisterThread } =
+	const { notePositions, registerThread, unregisterThread } =
 		useFloatingBoard( {
 			threads,
 			selectedNoteId: selectedNote,
@@ -260,9 +260,6 @@ export function Comments( {
 
 	return (
 		<>
-			{ isFloating && contentHeight > 0 && (
-				<div style={ { height: contentHeight } } aria-hidden="true" />
-			) }
 			{ ! isFloating && selectedNote === 'new' && (
 				<AddComment
 					onSubmit={ onAddReply }

--- a/packages/editor/src/components/collab-sidebar/floating-container.js
+++ b/packages/editor/src/components/collab-sidebar/floating-container.js
@@ -19,7 +19,7 @@ export function FloatingContainer( {
 	return (
 		<VStack
 			className={ clsx( className, { 'is-floating': isFloating } ) }
-			ref={ isFloating ? floating.refs.setFloating : undefined }
+			ref={ isFloating ? floating.ref : undefined }
 			style={ isFloating ? { top: floating.y, ...style } : style }
 			{ ...props }
 		>

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -332,13 +332,12 @@ export function useFloatingBoard( {
 	commentSidebarRef,
 } ) {
 	const [ notePositions, setNotePositions ] = useState( {} );
-	const [ contentHeight, setContentHeight ] = useState( 0 );
 	const [ store ] = useState( createBoardStore );
 
 	const heights = useSyncExternalStore( store.subscribe, store.getSnapshot );
 
-	// Positions are computed with scrollTop baked in; the panel mirrors the
-	// editor's scroll so notes track their blocks without per-frame recalc.
+	// Notes are positioned in canvas content-space; CSS inherits
+	// `--canvas-scroll` to translate each thread in sync with the canvas.
 	useEffect( () => {
 		if ( ! isFloating || ! commentSidebarRef?.current ) {
 			return;
@@ -351,6 +350,13 @@ export function useFloatingBoard( {
 		const rootEl = blockEl?.closest( '.is-root-container' ) ?? blockEl;
 		const canvas = rootEl ? getScrollContainer( rootEl ) : null;
 
+		const applyScroll = () => {
+			panel.style.setProperty(
+				'--canvas-scroll',
+				`${ -( canvas?.scrollTop ?? 0 ) }px`
+			);
+		};
+
 		// Recalc is deferred to a rAF; back-to-back updates collapse into one paint.
 		const rafId = window.requestAnimationFrame( () => {
 			const result = calculateNotePositions( {
@@ -362,30 +368,18 @@ export function useFloatingBoard( {
 			} );
 
 			setNotePositions( result.positions );
-			setContentHeight( result.contentHeight );
-
-			if ( canvas ) {
-				panel.scrollTop = canvas.scrollTop;
-			}
+			applyScroll();
 		} );
-
-		const onScroll = () => {
-			panel.scrollTop = canvas.scrollTop;
-		};
 
 		// Root scrolling elements (documentElement/body) don't fire scroll
 		// on themselves; capture on the window catches them in either canvas.
 		const view = canvas?.ownerDocument?.defaultView;
-		view?.addEventListener( 'scroll', onScroll, {
-			passive: true,
-			capture: true,
-		} );
+		const listenerOptions = { passive: true, capture: true };
+		view?.addEventListener( 'scroll', applyScroll, listenerOptions );
 
 		return () => {
 			window.cancelAnimationFrame( rafId );
-			view?.removeEventListener( 'scroll', onScroll, {
-				capture: true,
-			} );
+			view?.removeEventListener( 'scroll', applyScroll, listenerOptions );
 		};
 	}, [
 		commentSidebarRef,
@@ -398,7 +392,6 @@ export function useFloatingBoard( {
 
 	return {
 		notePositions,
-		contentHeight,
 		registerThread: store.registerThread,
 		unregisterThread: store.unregisterThread,
 	};

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -1,13 +1,4 @@
 /**
- * External dependencies
- */
-import {
-	useFloating,
-	offset as offsetMiddleware,
-	autoUpdate,
-} from '@floating-ui/react-dom';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -24,6 +15,7 @@ import {
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { store as noticesStore } from '@wordpress/notices';
+import { getScrollContainer } from '@wordpress/dom';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as interfaceStore } from '@wordpress/interface';
 
@@ -34,9 +26,9 @@ import { store as editorStore } from '../../store';
 import { FLOATING_NOTES_SIDEBAR } from './constants';
 import { unlock } from '../../lock-unlock';
 import { createBoardStore } from './board-store';
-import { calculateAllOffsets } from './utils';
+import { calculateNotePositions } from './utils';
 
-const { useBlockElement, cleanEmptyObject } = unlock( blockEditorPrivateApis );
+const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
 
 export function useBlockComments( postId ) {
 	const queryArgs = {
@@ -333,92 +325,81 @@ export function useEnableFloatingSidebar( enabled = false ) {
 	}, [ enabled, registry ] );
 }
 
-export function useFloatingBoard( { threads, selectedNoteId, isFloating } ) {
-	const [ boardOffsets, setBoardOffsets ] = useState( {} );
+export function useFloatingBoard( {
+	threads,
+	selectedNoteId,
+	isFloating,
+	commentSidebarRef,
+} ) {
+	const [ notePositions, setNotePositions ] = useState( {} );
+	const [ contentHeight, setContentHeight ] = useState( 0 );
 	const [ store ] = useState( createBoardStore );
-	const { setCanvasMinHeight } = unlock( useDispatch( editorStore ) );
 
 	const heights = useSyncExternalStore( store.subscribe, store.getSnapshot );
 
-	// Recalc is deferred to a rAF; the cleanup cancels the pending frame
-	// when deps change, so back-to-back updates collapse into one paint.
+	// Positions are computed with scrollTop baked in; the panel mirrors the
+	// editor's scroll so notes track their blocks without per-frame recalc.
 	useEffect( () => {
-		if ( ! isFloating ) {
+		if ( ! isFloating || ! commentSidebarRef?.current ) {
 			return;
 		}
 
+		const panel = commentSidebarRef.current;
+		const blockEl = store.getFirstBlockElement();
+		// Climb to the block-list root so nested scroll containers
+		// (e.g. a Group with overflow:auto) don't shadow the canvas.
+		const rootEl = blockEl?.closest( '.is-root-container' ) ?? blockEl;
+		const canvas = rootEl ? getScrollContainer( rootEl ) : null;
+
+		// Recalc is deferred to a rAF; back-to-back updates collapse into one paint.
 		const rafId = window.requestAnimationFrame( () => {
-			const { offsets, minHeight } = calculateAllOffsets( {
+			const result = calculateNotePositions( {
 				threads,
 				selectedNoteId,
 				blockRects: store.getBlockRects(),
 				heights,
+				scrollTop: canvas?.scrollTop ?? 0,
 			} );
-			setBoardOffsets( offsets );
-			setCanvasMinHeight( minHeight );
+
+			setNotePositions( result.positions );
+			setContentHeight( result.contentHeight );
+
+			if ( canvas ) {
+				panel.scrollTop = canvas.scrollTop;
+			}
 		} );
 
-		return () => window.cancelAnimationFrame( rafId );
+		const onScroll = () => {
+			panel.scrollTop = canvas.scrollTop;
+		};
+
+		// Root scrolling elements (documentElement/body) don't fire scroll
+		// on themselves; capture on the window catches them in either canvas.
+		const view = canvas?.ownerDocument?.defaultView;
+		view?.addEventListener( 'scroll', onScroll, {
+			passive: true,
+			capture: true,
+		} );
+
+		return () => {
+			window.cancelAnimationFrame( rafId );
+			view?.removeEventListener( 'scroll', onScroll, {
+				capture: true,
+			} );
+		};
 	}, [
+		commentSidebarRef,
 		heights,
 		isFloating,
 		selectedNoteId,
-		setCanvasMinHeight,
 		store,
 		threads,
 	] );
 
 	return {
-		boardOffsets,
+		notePositions,
+		contentHeight,
 		registerThread: store.registerThread,
 		unregisterThread: store.unregisterThread,
-	};
-}
-
-export function useFloatingThread( {
-	thread,
-	calculatedOffset,
-	registerThread,
-	unregisterThread,
-} ) {
-	const blockElement = useBlockElement( thread.blockClientId );
-
-	// Use floating-ui to track the block element's position with the calculated offset.
-	const { y, refs } = useFloating( {
-		placement: 'right-start',
-		middleware: [
-			offsetMiddleware( {
-				crossAxis: calculatedOffset || -16,
-			} ),
-		],
-		whileElementsMounted: autoUpdate,
-	} );
-
-	// Set the floating-ui reference element.
-	useEffect( () => {
-		if ( blockElement ) {
-			refs.setReference( blockElement );
-		}
-	}, [ blockElement, refs ] );
-
-	// Register block + floating elements with the board.
-	// The board's ResizeObserver tracks height changes automatically.
-	useEffect( () => {
-		const floatingEl = refs.floating?.current;
-		if ( floatingEl && registerThread ) {
-			registerThread( thread.id, blockElement, floatingEl );
-		}
-		return () => unregisterThread?.( thread.id );
-	}, [
-		blockElement,
-		thread.id,
-		refs.floating,
-		registerThread,
-		unregisterThread,
-	] );
-
-	return {
-		y,
-		refs,
 	};
 }

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -19,13 +19,7 @@
 	position: relative;
 	padding: $grid-unit-20 $grid-unit-20 $grid-unit-30;
 	height: 100%;
-	overflow-y: auto;
-	overflow-x: hidden;
-	scrollbar-width: none; // Firefox
-
-	&::-webkit-scrollbar {
-		display: none; // Chrome/Safari
-	}
+	overflow: hidden;
 }
 
 .editor-collab-sidebar-panel__thread {
@@ -53,6 +47,10 @@
 		right: $grid-unit-20;
 		position: absolute;
 		margin-top: $grid-unit-20;
+		// Inherits `--canvas-scroll` from the panel (set by `useFloatingBoard`)
+		// so each thread tracks the canvas scroll.
+		transform: translateY(var(--canvas-scroll, 0));
+		will-change: transform;
 	}
 }
 

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -16,9 +16,16 @@
 }
 
 .editor-collab-sidebar-panel {
+	position: relative;
 	padding: $grid-unit-20 $grid-unit-20 $grid-unit-30;
 	height: 100%;
-	overflow: hidden;
+	overflow-y: auto;
+	overflow-x: hidden;
+	scrollbar-width: none; // Firefox
+
+	&::-webkit-scrollbar {
+		display: none; // Chrome/Safari
+	}
 }
 
 .editor-collab-sidebar-panel__thread {

--- a/packages/editor/src/components/collab-sidebar/test/utils.js
+++ b/packages/editor/src/components/collab-sidebar/test/utils.js
@@ -162,24 +162,4 @@ describe( 'calculateNotePositions', () => {
 		// Thread 2: 300 + 500 + (-16) = 784.
 		expect( positions[ 2 ] ).toBe( 784 );
 	} );
-
-	it( 'computes contentHeight from the last note bottom', () => {
-		const threads = [ { id: 1 }, { id: 2 } ];
-		const blockRects = {
-			1: makeRect( 100 ),
-			2: makeRect( 300 ),
-		};
-		const heights = { 1: 50, 2: 60 };
-
-		const { contentHeight } = calculateNotePositions( {
-			threads,
-			selectedNoteId: 1,
-			blockRects,
-			heights,
-			scrollTop: 0,
-		} );
-
-		// Last note bottom = position(284) + height(60) = 344, + padding(32) = 376.
-		expect( contentHeight ).toBe( 376 );
-	} );
 } );

--- a/packages/editor/src/components/collab-sidebar/test/utils.js
+++ b/packages/editor/src/components/collab-sidebar/test/utils.js
@@ -8,7 +8,7 @@ function makeRect( top ) {
 }
 
 describe( 'calculateNotePositions', () => {
-	it( 'returns empty positions when no threads match blockRects', () => {
+	it( 'returns empty positions when the anchor thread has no blockRect', () => {
 		const { positions } = calculateNotePositions( {
 			threads: [ { id: 1 } ],
 			selectedNoteId: undefined,
@@ -19,7 +19,7 @@ describe( 'calculateNotePositions', () => {
 		expect( positions ).toEqual( {} );
 	} );
 
-	it( 'assigns default position when there is no selected thread', () => {
+	it( 'falls back to the first thread as anchor when none is selected', () => {
 		const threads = [ { id: 1 }, { id: 2 }, { id: 3 } ];
 		const blockRects = {
 			1: makeRect( 100 ),
@@ -36,41 +36,14 @@ describe( 'calculateNotePositions', () => {
 			scrollTop: 0,
 		} );
 
-		// With no selected thread, anchorIndex falls back to 0 (first thread).
-		// position = blockTop + scrollTop + offset = blockTop + (-16).
-		expect( positions[ 1 ] ).toBe( 84 );
-		expect( positions[ 2 ] ).toBe( 284 );
-		expect( positions[ 3 ] ).toBe( 484 );
+		// 1: 100 - 16 = 84
+		// 2: 300 - 16 = 284
+		// 3: 500 - 16 = 484
+		expect( positions ).toEqual( { 1: 84, 2: 284, 3: 484 } );
 	} );
 
-	it( 'pushes neighbors below the selected thread downward when overlapping', () => {
-		const threads = [ { id: 1 }, { id: 2 }, { id: 3 } ];
-		// Thread 2 selected; thread 3 starts inside thread 2's space.
-		const blockRects = {
-			1: makeRect( 100 ),
-			2: makeRect( 200 ),
-			3: makeRect( 220 ),
-		};
-		const heights = { 1: 50, 2: 80, 3: 50 };
-
-		const { positions } = calculateNotePositions( {
-			threads,
-			selectedNoteId: 2,
-			blockRects,
-			heights,
-			scrollTop: 0,
-		} );
-
-		// Anchor: position = 200 + (-16) = 184.
-		expect( positions[ 2 ] ).toBe( 184 );
-		// Thread 3 overlaps thread 2: previous bottom = (200-16)+80 = 264.
-		// 220 < 264+16 = 280, so offset = 264-220+20 = 64. Position = 220+64 = 284.
-		expect( positions[ 3 ] ).toBe( 284 );
-	} );
-
-	it( 'pushes neighbors above the selected thread upward when overlapping', () => {
+	it( 'pushes an overlapping thread above the anchor upward', () => {
 		const threads = [ { id: 1 }, { id: 2 } ];
-		// Thread 1 is tall and overlaps where thread 2 sits.
 		const blockRects = {
 			1: makeRect( 150 ),
 			2: makeRect( 180 ),
@@ -85,16 +58,13 @@ describe( 'calculateNotePositions', () => {
 			scrollTop: 0,
 		} );
 
-		// Anchor: position = 180 + (-16) = 164.
-		expect( positions[ 2 ] ).toBe( 164 );
-		// Thread 1 bottom = 150+60 = 210, belowAdjustedTop = 180-16 = 164.
-		// 210 > 164, so offset = 164-150-60-20 = -66. Position = 150+(-66) = 84.
-		expect( positions[ 1 ] ).toBe( 84 );
+		// 2 (anchor): 180 - 16 = 164
+		// 1 (upward):  164 - 60 - 20 = 84
+		expect( positions ).toEqual( { 1: 84, 2: 164 } );
 	} );
 
-	it( 'cascades overlap adjustment across multiple threads below', () => {
+	it( 'cascades downward offsets through consecutive overlapping threads', () => {
 		const threads = [ { id: 1 }, { id: 2 }, { id: 3 } ];
-		// All three threads are tightly packed.
 		const blockRects = {
 			1: makeRect( 100 ),
 			2: makeRect( 110 ),
@@ -110,19 +80,16 @@ describe( 'calculateNotePositions', () => {
 			scrollTop: 0,
 		} );
 
-		// Anchor: position = 100 + (-16) = 84.
-		expect( positions[ 1 ] ).toBe( 84 );
-		// Thread 2: prev bottom = (100-16)+80 = 164. 110 < 164+16, offset = 164-110+20 = 74. Position = 110+74 = 184.
-		expect( positions[ 2 ] ).toBe( 184 );
-		// Thread 3: prev bottom = (110+74)+80 = 264. 120 < 264+16, offset = 264-120+20 = 164. Position = 120+164 = 284.
-		expect( positions[ 3 ] ).toBe( 284 );
+		// 1 (anchor):    100 - 16 = 84
+		// 2 (downward):   84 + 80 + 20 = 184
+		// 3 (downward):  184 + 80 + 20 = 284
+		expect( positions ).toEqual( { 1: 84, 2: 184, 3: 284 } );
 	} );
 
-	it( 'skips threads with missing blockRects', () => {
+	it( 'omits threads that have no blockRect', () => {
 		const threads = [ { id: 1 }, { id: 2 }, { id: 3 } ];
 		const blockRects = {
 			1: makeRect( 100 ),
-			// id 2 is missing
 			3: makeRect( 500 ),
 		};
 		const heights = { 1: 50, 3: 50 };
@@ -135,12 +102,37 @@ describe( 'calculateNotePositions', () => {
 			scrollTop: 0,
 		} );
 
-		expect( positions[ 1 ] ).toBe( 84 );
-		expect( positions[ 2 ] ).toBeUndefined();
-		expect( positions[ 3 ] ).toBe( 484 );
+		// 1: 100 - 16 = 84
+		// 3: 500 - 16 = 484
+		expect( positions ).toEqual( { 1: 84, 3: 484 } );
 	} );
 
-	it( 'incorporates scrollTop into positions', () => {
+	it( 'allows upward cascade to produce negative positions', () => {
+		const threads = [ { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 } ];
+		const blockRects = {
+			1: makeRect( 150 ),
+			2: makeRect( 200 ),
+			3: makeRect( 250 ),
+			4: makeRect( 300 ),
+		};
+		const heights = { 1: 90, 2: 90, 3: 90, 4: 230 };
+
+		const { positions } = calculateNotePositions( {
+			threads,
+			selectedNoteId: 4,
+			blockRects,
+			heights,
+			scrollTop: 0,
+		} );
+
+		// 4 (anchor):  300 - 16 = 284
+		// 3 (upward):  284 - 90 - 20 = 174
+		// 2 (upward):  174 - 90 - 20 = 64
+		// 1 (upward):   64 - 90 - 20 = -46
+		expect( positions ).toEqual( { 1: -46, 2: 64, 3: 174, 4: 284 } );
+	} );
+
+	it( 'adds scrollTop to the final positions', () => {
 		const threads = [ { id: 1 }, { id: 2 } ];
 		const blockRects = {
 			1: makeRect( 100 ),
@@ -156,10 +148,8 @@ describe( 'calculateNotePositions', () => {
 			scrollTop: 500,
 		} );
 
-		// position = blockTop + scrollTop + offset.
-		// Thread 1: 100 + 500 + (-16) = 584.
-		expect( positions[ 1 ] ).toBe( 584 );
-		// Thread 2: 300 + 500 + (-16) = 784.
-		expect( positions[ 2 ] ).toBe( 784 );
+		// 1: 100 + 500 - 16 = 584
+		// 2: 300 + 500 - 16 = 784
+		expect( positions ).toEqual( { 1: 584, 2: 784 } );
 	} );
 } );

--- a/packages/editor/src/components/collab-sidebar/test/utils.js
+++ b/packages/editor/src/components/collab-sidebar/test/utils.js
@@ -1,25 +1,25 @@
 /**
  * Internal dependencies
  */
-import { calculateAllOffsets } from '../utils';
+import { calculateNotePositions } from '../utils';
 
 function makeRect( top ) {
 	return { top };
 }
 
-describe( 'calculateAllOffsets', () => {
-	it( 'returns empty offsets when no threads match blockRects', () => {
-		const { offsets, minHeight } = calculateAllOffsets( {
+describe( 'calculateNotePositions', () => {
+	it( 'returns empty positions when no threads match blockRects', () => {
+		const { positions } = calculateNotePositions( {
 			threads: [ { id: 1 } ],
 			selectedNoteId: undefined,
 			blockRects: {},
 			heights: {},
+			scrollTop: 0,
 		} );
-		expect( offsets ).toEqual( {} );
-		expect( minHeight ).toBe( 0 );
+		expect( positions ).toEqual( {} );
 	} );
 
-	it( 'assigns default offset when there is no selected thread', () => {
+	it( 'assigns default position when there is no selected thread', () => {
 		const threads = [ { id: 1 }, { id: 2 }, { id: 3 } ];
 		const blockRects = {
 			1: makeRect( 100 ),
@@ -28,18 +28,19 @@ describe( 'calculateAllOffsets', () => {
 		};
 		const heights = { 1: 50, 2: 50, 3: 50 };
 
-		const { offsets } = calculateAllOffsets( {
+		const { positions } = calculateNotePositions( {
 			threads,
 			selectedNoteId: undefined,
 			blockRects,
 			heights,
+			scrollTop: 0,
 		} );
 
-		// With no selected thread, breakIndex falls back to 0 (first thread).
-		expect( offsets[ 1 ] ).toBe( -16 );
-		// Non-overlapping threads get the default offset.
-		expect( offsets[ 2 ] ).toBe( -16 );
-		expect( offsets[ 3 ] ).toBe( -16 );
+		// With no selected thread, anchorIndex falls back to 0 (first thread).
+		// position = blockTop + scrollTop + offset = blockTop + (-16).
+		expect( positions[ 1 ] ).toBe( 84 );
+		expect( positions[ 2 ] ).toBe( 284 );
+		expect( positions[ 3 ] ).toBe( 484 );
 	} );
 
 	it( 'pushes neighbors below the selected thread downward when overlapping', () => {
@@ -52,17 +53,19 @@ describe( 'calculateAllOffsets', () => {
 		};
 		const heights = { 1: 50, 2: 80, 3: 50 };
 
-		const { offsets } = calculateAllOffsets( {
+		const { positions } = calculateNotePositions( {
 			threads,
 			selectedNoteId: 2,
 			blockRects,
 			heights,
+			scrollTop: 0,
 		} );
 
-		expect( offsets[ 2 ] ).toBe( -16 );
-		// thread 3 overlaps thread 2: previous bottom = (200-16)+80 = 264.
-		// 220 < 264+16 = 280, so offset = 264 - 220 + 20 = 64.
-		expect( offsets[ 3 ] ).toBe( 64 );
+		// Anchor: position = 200 + (-16) = 184.
+		expect( positions[ 2 ] ).toBe( 184 );
+		// Thread 3 overlaps thread 2: previous bottom = (200-16)+80 = 264.
+		// 220 < 264+16 = 280, so offset = 264-220+20 = 64. Position = 220+64 = 284.
+		expect( positions[ 3 ] ).toBe( 284 );
 	} );
 
 	it( 'pushes neighbors above the selected thread upward when overlapping', () => {
@@ -74,17 +77,19 @@ describe( 'calculateAllOffsets', () => {
 		};
 		const heights = { 1: 60, 2: 50 };
 
-		const { offsets } = calculateAllOffsets( {
+		const { positions } = calculateNotePositions( {
 			threads,
 			selectedNoteId: 2,
 			blockRects,
 			heights,
+			scrollTop: 0,
 		} );
 
-		expect( offsets[ 2 ] ).toBe( -16 );
-		// Thread 1 bottom = 150 + 60 = 210, next threadTop = 180 - 16 = 164.
-		// 210 > 164, so offset = 164 - 150 - 60 - 20 = -66.
-		expect( offsets[ 1 ] ).toBe( -66 );
+		// Anchor: position = 180 + (-16) = 164.
+		expect( positions[ 2 ] ).toBe( 164 );
+		// Thread 1 bottom = 150+60 = 210, belowAdjustedTop = 180-16 = 164.
+		// 210 > 164, so offset = 164-150-60-20 = -66. Position = 150+(-66) = 84.
+		expect( positions[ 1 ] ).toBe( 84 );
 	} );
 
 	it( 'cascades overlap adjustment across multiple threads below', () => {
@@ -97,18 +102,20 @@ describe( 'calculateAllOffsets', () => {
 		};
 		const heights = { 1: 80, 2: 80, 3: 80 };
 
-		const { offsets } = calculateAllOffsets( {
+		const { positions } = calculateNotePositions( {
 			threads,
 			selectedNoteId: 1,
 			blockRects,
 			heights,
+			scrollTop: 0,
 		} );
 
-		expect( offsets[ 1 ] ).toBe( -16 );
-		// Thread 2: previous bottom = (100-16)+80 = 164. 110 < 164+16, offset = 164-110+20 = 74.
-		expect( offsets[ 2 ] ).toBe( 74 );
-		// Thread 3: previous bottom = (110+74)+80 = 264. 120 < 264+16, offset = 264-120+20 = 164.
-		expect( offsets[ 3 ] ).toBe( 164 );
+		// Anchor: position = 100 + (-16) = 84.
+		expect( positions[ 1 ] ).toBe( 84 );
+		// Thread 2: prev bottom = (100-16)+80 = 164. 110 < 164+16, offset = 164-110+20 = 74. Position = 110+74 = 184.
+		expect( positions[ 2 ] ).toBe( 184 );
+		// Thread 3: prev bottom = (110+74)+80 = 264. 120 < 264+16, offset = 264-120+20 = 164. Position = 120+164 = 284.
+		expect( positions[ 3 ] ).toBe( 284 );
 	} );
 
 	it( 'skips threads with missing blockRects', () => {
@@ -120,34 +127,59 @@ describe( 'calculateAllOffsets', () => {
 		};
 		const heights = { 1: 50, 3: 50 };
 
-		const { offsets } = calculateAllOffsets( {
+		const { positions } = calculateNotePositions( {
 			threads,
 			selectedNoteId: 1,
 			blockRects,
 			heights,
+			scrollTop: 0,
 		} );
 
-		expect( offsets[ 1 ] ).toBe( -16 );
-		expect( offsets[ 2 ] ).toBeUndefined();
-		expect( offsets[ 3 ] ).toBe( -16 );
+		expect( positions[ 1 ] ).toBe( 84 );
+		expect( positions[ 2 ] ).toBeUndefined();
+		expect( positions[ 3 ] ).toBe( 484 );
 	} );
 
-	it( 'computes minHeight from the last thread position', () => {
+	it( 'incorporates scrollTop into positions', () => {
 		const threads = [ { id: 1 }, { id: 2 } ];
 		const blockRects = {
 			1: makeRect( 100 ),
-			2: makeRect( 400 ),
+			2: makeRect( 300 ),
 		};
-		const heights = { 1: 50, 2: 60 };
+		const heights = { 1: 50, 2: 50 };
 
-		const { minHeight } = calculateAllOffsets( {
+		const { positions } = calculateNotePositions( {
 			threads,
 			selectedNoteId: 1,
 			blockRects,
 			heights,
+			scrollTop: 500,
 		} );
 
-		// Last thread: top=400, height=60, offset=-16, + 32 = 476.
-		expect( minHeight ).toBe( 476 );
+		// position = blockTop + scrollTop + offset.
+		// Thread 1: 100 + 500 + (-16) = 584.
+		expect( positions[ 1 ] ).toBe( 584 );
+		// Thread 2: 300 + 500 + (-16) = 784.
+		expect( positions[ 2 ] ).toBe( 784 );
+	} );
+
+	it( 'computes contentHeight from the last note bottom', () => {
+		const threads = [ { id: 1 }, { id: 2 } ];
+		const blockRects = {
+			1: makeRect( 100 ),
+			2: makeRect( 300 ),
+		};
+		const heights = { 1: 50, 2: 60 };
+
+		const { contentHeight } = calculateNotePositions( {
+			threads,
+			selectedNoteId: 1,
+			blockRects,
+			heights,
+			scrollTop: 0,
+		} );
+
+		// Last note bottom = position(284) + height(60) = 344, + padding(32) = 376.
+		expect( contentHeight ).toBe( 376 );
 	} );
 } );

--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -92,22 +92,24 @@ export function getCommentExcerpt( text, excerptLength = 10 ) {
 }
 
 /**
- * Calculate y offsets for all floating comment threads. Adjusts positions
- * to prevent overlapping by pushing threads above the selected one upward
- * and threads below it downward.
+ * Calculate final top positions for all floating comment threads in the
+ * editor's content coordinate space. Adjusts positions to prevent overlapping
+ * by pushing threads above the selected one upward and threads below it downward.
  *
  * @param {Object}                  params
  * @param {Array}                   params.threads        Ordered list of thread objects.
  * @param {string|number|undefined} params.selectedNoteId ID of the currently selected thread.
  * @param {Object<string,DOMRect>}  params.blockRects     Pre-read bounding rects keyed by thread ID.
  * @param {Object<string,number>}   params.heights        Rendered heights keyed by thread ID.
- * @return {{ offsets: Object<string,number>, minHeight: number }} Computed offsets and minimum editor height.
+ * @param {number}                  params.scrollTop      Current scroll offset of the editor content.
+ * @return {{ positions: Object<string,number>, contentHeight: number }} Computed top positions and content height.
  */
-export function calculateAllOffsets( {
+export function calculateNotePositions( {
 	threads,
 	selectedNoteId,
 	blockRects,
 	heights,
+	scrollTop = 0,
 } ) {
 	const offsets = {};
 
@@ -119,7 +121,7 @@ export function calculateAllOffsets( {
 	const anchorThread = threads[ anchorIndex ];
 
 	if ( ! anchorThread || ! blockRects[ anchorThread.id ] ) {
-		return { offsets, minHeight: 0 };
+		return { positions: {}, contentHeight: 0 };
 	}
 
 	const anchorRect = blockRects[ anchorThread.id ];
@@ -182,21 +184,26 @@ export function calculateAllOffsets( {
 		belowAdjustedTop = threadTop + offset;
 	}
 
-	let editorMinHeight = 0;
-	const lastThread = threads[ threads.length - 1 ];
-	const lastBlockRect = blockRects[ lastThread.id ];
-	if ( lastBlockRect ) {
-		const lastThreadTop = lastBlockRect.top || 0;
-		const lastThreadHeight = heights[ lastThread.id ] || 0;
-		const lastThreadOffset = offsets[ lastThread.id ] || 0;
-		editorMinHeight =
-			lastThreadTop +
-			lastThreadHeight +
-			lastThreadOffset +
-			BOARD_BOTTOM_PADDING;
+	// blockRect.top + scrollTop is the block's absolute y within the editor's
+	// scroll content. The sidebar mirrors that scroll, so positions stay valid
+	// without per-frame recalculation.
+	const positions = {};
+	let contentHeight = 0;
+	for ( const thread of threads ) {
+		const blockRect = blockRects[ thread.id ];
+		if ( blockRect && offsets[ thread.id ] !== undefined ) {
+			positions[ thread.id ] =
+				blockRect.top + scrollTop + offsets[ thread.id ];
+			const bottom =
+				positions[ thread.id ] + ( heights[ thread.id ] || 0 );
+			if ( bottom > contentHeight ) {
+				contentHeight = bottom;
+			}
+		}
 	}
+	contentHeight += BOARD_BOTTOM_PADDING;
 
-	return { offsets, minHeight: editorMinHeight };
+	return { positions, contentHeight };
 }
 
 /**

--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -16,7 +16,6 @@ export function sanitizeCommentString( str ) {
 const THREAD_ALIGN_OFFSET = -16;
 const THREAD_GAP = 16;
 const OVERLAP_MARGIN = 20;
-const BOARD_BOTTOM_PADDING = 32;
 
 /**
  * Avatar border colors chosen to be visually distinct from each other and from
@@ -102,7 +101,7 @@ export function getCommentExcerpt( text, excerptLength = 10 ) {
  * @param {Object<string,DOMRect>}  params.blockRects     Pre-read bounding rects keyed by thread ID.
  * @param {Object<string,number>}   params.heights        Rendered heights keyed by thread ID.
  * @param {number}                  params.scrollTop      Current scroll offset of the editor content.
- * @return {{ positions: Object<string,number>, contentHeight: number }} Computed top positions and content height.
+ * @return {{ positions: Object<string,number> }} Computed top positions.
  */
 export function calculateNotePositions( {
 	threads,
@@ -121,7 +120,7 @@ export function calculateNotePositions( {
 	const anchorThread = threads[ anchorIndex ];
 
 	if ( ! anchorThread || ! blockRects[ anchorThread.id ] ) {
-		return { positions: {}, contentHeight: 0 };
+		return { positions: {} };
 	}
 
 	const anchorRect = blockRects[ anchorThread.id ];
@@ -185,25 +184,17 @@ export function calculateNotePositions( {
 	}
 
 	// blockRect.top + scrollTop is the block's absolute y within the editor's
-	// scroll content. The sidebar mirrors that scroll, so positions stay valid
-	// without per-frame recalculation.
+	// scroll content; CSS translates each thread by -scrollTop at render time.
 	const positions = {};
-	let contentHeight = 0;
 	for ( const thread of threads ) {
 		const blockRect = blockRects[ thread.id ];
 		if ( blockRect && offsets[ thread.id ] !== undefined ) {
 			positions[ thread.id ] =
 				blockRect.top + scrollTop + offsets[ thread.id ];
-			const bottom =
-				positions[ thread.id ] + ( heights[ thread.id ] || 0 );
-			if ( bottom > contentHeight ) {
-				contentHeight = bottom;
-			}
 		}
 	}
-	contentHeight += BOARD_BOTTOM_PADDING;
 
-	return { positions, contentHeight };
+	return { positions };
 }
 
 /**

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -112,7 +112,6 @@ function VisualEditor( {
 		postType,
 		isPreview,
 		styles,
-		canvasMinHeight,
 	} = useSelect( ( select ) => {
 		const {
 			getCurrentPostId,
@@ -121,7 +120,6 @@ function VisualEditor( {
 			getEditorSettings,
 			getRenderingMode,
 			getDeviceType,
-			getCanvasMinHeight,
 		} = unlock( select( editorStore ) );
 		const { getPostType, getEditedEntityRecord } = select( coreStore );
 		const postTypeSlug = getCurrentPostType();
@@ -163,7 +161,6 @@ function VisualEditor( {
 			postType: postTypeSlug,
 			isPreview: editorSettings.isPreviewMode,
 			styles: editorSettings.styles,
-			canvasMinHeight: getCanvasMinHeight(),
 		};
 	}, [] );
 	const { isCleanNewPost } = useSelect( editorStore );
@@ -336,20 +333,6 @@ function VisualEditor( {
 
 	const isNavigationPreview = postType === NAVIGATION_POST_TYPE && isPreview;
 
-	// Calculate the minimum height including scroll offset to fit all notes.
-	const calculatedMinHeight = useMemo( () => {
-		if ( ! localRef.current ) {
-			return canvasMinHeight;
-		}
-
-		const { ownerDocument } = localRef.current;
-		const scrollTop =
-			ownerDocument.documentElement.scrollTop ||
-			ownerDocument.body.scrollTop;
-
-		return canvasMinHeight + scrollTop;
-	}, [ canvasMinHeight ] );
-
 	const [ paddingAppenderRef, paddingStyle ] = usePaddingAppender(
 		! isPreview && renderingMode === 'post-only' && ! isDesignPostType
 	);
@@ -363,11 +346,7 @@ function VisualEditor( {
 				// Ensures margins of children are contained so that the body background paints behind them.
 				// Otherwise, the background of html (when zoomed out) would show there and appear broken. It's
 				// important mostly for post-only views yet conceivably an issue in templated views too.
-				css: `:where(.block-editor-iframe__body){display:flow-root;${
-					calculatedMinHeight
-						? `min-height:${ calculatedMinHeight }px;`
-						: ''
-				}}.is-root-container{display:flow-root;${
+				css: `:where(.block-editor-iframe__body){display:flow-root;}.is-root-container{display:flow-root;${
 					// Some themes will have `min-height: 100vh` for the root container,
 					// which isn't a requirement in auto resize mode.
 					enableResizing || isNavigationPreview
@@ -389,13 +368,7 @@ function VisualEditor( {
 				// The CSS for isNavigationPreview centers the body content vertically and horizontally when the navigation is in preview mode.
 			},
 		];
-	}, [
-		styles,
-		enableResizing,
-		isNavigationPreview,
-		calculatedMinHeight,
-		paddingStyle,
-	] );
+	}, [ styles, enableResizing, isNavigationPreview, paddingStyle ] );
 
 	const typewriterRef = useTypewriter();
 	contentRef = useMergeRefs( [

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -576,19 +576,6 @@ export function resetStylesNavigation() {
 }
 
 /**
- * Set the minimum height of the canvas.
- *
- * @param {number} minHeight
- * @return {Object} Action object.
- */
-export function setCanvasMinHeight( minHeight ) {
-	return {
-		type: 'SET_CANVAS_MIN_HEIGHT',
-		minHeight,
-	};
-}
-
-/**
  * Set the current revision ID for revisions preview mode.
  * Pass a revision ID to enter revisions mode, or null to exit.
  *

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -337,16 +337,6 @@ export function getShowStylebook( state ) {
 }
 
 /**
- * Get the canvas minimum height.
- *
- * @param {Object} state Global application state.
- * @return {number} The canvas minimum height.
- */
-export function getCanvasMinHeight( state ) {
-	return state.canvasMinHeight;
-}
-
-/**
  * Returns whether the editor is in revisions preview mode.
  *
  * @param {Object} state Global application state.

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -419,21 +419,6 @@ export function showStylebook( state = false, action ) {
 }
 
 /**
- * Reducer for the canvas minimum height.
- *
- * @param {number} state  Current state.
- * @param {Object} action Dispatched action.
- * @return {number} Updated state.
- */
-export function canvasMinHeight( state = 0, action ) {
-	switch ( action.type ) {
-		case 'SET_CANVAS_MIN_HEIGHT':
-			return action.minHeight;
-	}
-	return state;
-}
-
-/**
  * Reducer for the revisions preview mode.
  * Stores the current revision ID, or null if not in revisions mode.
  *
@@ -504,7 +489,6 @@ export default combineReducers( {
 	publishSidebarActive,
 	stylesPath,
 	showStylebook,
-	canvasMinHeight,
 	revisionId,
 	showRevisionDiff,
 	selectedNote,


### PR DESCRIPTION
## What?
Closes #73653.
Partially solves https://github.com/WordPress/gutenberg/issues/73565.

Replaces the floating-UI `autoUpdate` dependency with a CSS-driven scroll-sync approach. Note positions are computed once in canvas content-space; a single CSS custom property (`--canvas-scroll`) on the sidebar panel drives the visual sync on every scroll event.

- Removed `@floating-ui/dom` from `@wordpress/editor` dependencies.
- Removed the global `canvasMinHeight` editor state (action, selector, reducer). The canvas no longer grows to fit the sidebar.
- Notes are positioned using `blockRect.top + scrollTop` (the block's absolute y within the editor's scroll content).
- A scroll listener on the canvas's window (capture mode) writes `-canvas.scrollTop` into `--canvas-scroll` on the panel. CSS inherits the variable and each floating thread applies `transform: translateY(var(--canvas-scroll))`.
- Scroll-container discovery starts from `.is-root-container` so nested-block scroll containers (e.g. a Group with `overflow: auto`) don't shadow the editor canvas.
- Works in both iframe and non-iframe canvas modes.

## Why?

- No external dependency.
- A single place to manage note positions and improved recalculations.
- Canvas doesn't need to know or care about sidebar height.
- No per-frame recalculation — positions update only when notes/blocks change (registration, heights, selection). Scroll tracking is a single DOM write per scroll event.

## Testing Instructions
Stress test floating notes.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Used Claude to brainstorm my ideas, tested and reviewed personally.
