### PR TITLE
Media editor: remove unused dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61022,7 +61022,6 @@
 			"version": "0.7.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "^7.16.0",
 				"@wordpress/components": "file:../components",
 				"@wordpress/dataviews": "file:../dataviews",
 				"@wordpress/element": "file:../element",

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -41,7 +41,6 @@
 		"src/**/*.scss"
 	],
 	"dependencies": {
-		"@babel/runtime": "^7.16.0",
 		"@wordpress/components": "file:../components",
 		"@wordpress/dataviews": "file:../dataviews",
 		"@wordpress/element": "file:../element",


### PR DESCRIPTION

Remove unused @babel/runtime dependency from media-editor package.json



### Testing

The CI should build.


I rebuilt and smoke tested the experiment, by enabling and checking the editor flow:

<img width="1070" height="85" alt="Screenshot 2026-04-17 at 12 44 54 pm" src="https://github.com/user-attachments/assets/95935bf2-e2eb-4606-a0aa-181295d4cbce" />


https://github.com/user-attachments/assets/8d3d7b54-aebc-4c7e-8680-962bf03ddd6d