### PR TITLE
Notes: Reduce passes in useBlockComments memo and rename outputs

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -67,94 +67,73 @@ export function useBlockComments( postId ) {
 			return { resultComments: [], unresolvedSortedThreads: [] };
 		}
 
-		const blocksWithComments = clientIds.reduce( ( results, clientId ) => {
-			const commentId = getBlockAttributes( clientId )?.metadata?.noteId;
-			if ( commentId ) {
-				results[ clientId ] = commentId;
+		// Single pass over clientIds: build clientId->noteId map AND reverse lookup.
+		const blocksWithComments = {};
+		const clientIdByNoteId = new Map();
+		for ( const clientId of clientIds ) {
+			const noteId = getBlockAttributes( clientId )?.metadata?.noteId;
+			if ( noteId ) {
+				const key = String( noteId );
+				blocksWithComments[ clientId ] = key;
+				clientIdByNoteId.set( key, clientId );
 			}
-			return results;
-		}, {} );
+		}
 
-		// Create a compare to store the references to all objects by id.
-		const compare = {};
-		const result = [];
-
-		// Create a reverse map for faster lookup.
-		const commentIdToBlockClientId = Object.keys(
-			blocksWithComments
-		).reduce( ( mapping, clientId ) => {
-			mapping[ blocksWithComments[ clientId ] ] = clientId;
-			return mapping;
-		}, {} );
-
-		// Initialize each object with an empty `reply` array and map blockClientId.
-		threads.forEach( ( item ) => {
-			const itemBlock = commentIdToBlockClientId[ item.id ];
-
-			compare[ item.id ] = {
+		// Materialize threads; collect roots; replies linked in a second pass
+		// via unshift to invert order (matches prior reverse semantics).
+		const threadsById = new Map();
+		const rootThreads = [];
+		for ( const item of threads ) {
+			const thread = {
 				...item,
 				reply: [],
-				blockClientId: item.parent === 0 ? itemBlock : null,
+				blockClientId:
+					item.parent === 0
+						? clientIdByNoteId.get( String( item.id ) ) ?? null
+						: null,
 			};
-		} );
-
-		// Iterate over the data to build the tree structure.
-		threads.forEach( ( item ) => {
+			threadsById.set( item.id, thread );
 			if ( item.parent === 0 ) {
-				// If parent is 0, it's a root item, push it to the result array.
-				result.push( compare[ item.id ] );
-			} else if ( compare[ item.parent ] ) {
-				// Otherwise, find its parent and push it to the parent's `reply` array.
-				compare[ item.parent ].reply.push( compare[ item.id ] );
+				rootThreads.push( thread );
 			}
-		} );
+		}
+		for ( const item of threads ) {
+			if ( item.parent !== 0 ) {
+				threadsById
+					.get( item.parent )
+					?.reply.unshift( threadsById.get( item.id ) );
+			}
+		}
 
-		if ( 0 === result?.length ) {
+		if ( rootThreads.length === 0 ) {
 			return { resultComments: [], unresolvedSortedThreads: [] };
 		}
 
-		const updatedResult = result.map( ( item ) => ( {
-			...item,
-			reply: [ ...item.reply ].reverse(),
-		} ) );
+		// Single partition over notes-in-block-order.
+		const unresolved = [];
+		const resolved = [];
+		for ( const noteId of Object.values( blocksWithComments ) ) {
+			const thread =
+				threadsById.get( Number( noteId ) ) ??
+				threadsById.get( noteId );
+			if ( ! thread ) {
+				continue;
+			}
+			if ( thread.status === 'hold' ) {
+				unresolved.push( thread );
+			} else if ( thread.status === 'approved' ) {
+				resolved.push( thread );
+			}
+		}
 
-		const threadIdMap = new Map(
-			updatedResult.map( ( thread ) => [ String( thread.id ), thread ] )
+		// Orphans: root threads without a linked block. They only need to come last.
+		const orphans = rootThreads.filter(
+			( thread ) => ! thread.blockClientId
 		);
-
-		// Prepare sets to determine which threads are linked to existing blocks.
-		const mappedIds = new Set(
-			Object.values( blocksWithComments ).map( ( id ) => String( id ) )
-		);
-
-		// Get comments by block order, first unresolved, then resolved.
-		const unresolvedSortedComments = Object.values( blocksWithComments )
-			.map( ( commentId ) => threadIdMap.get( String( commentId ) ) )
-			.filter(
-				( thread ) => thread !== undefined && thread.status === 'hold'
-			);
-
-		const resolvedSortedComments = Object.values( blocksWithComments )
-			.map( ( commentId ) => threadIdMap.get( String( commentId ) ) )
-			.filter(
-				( thread ) =>
-					thread !== undefined && thread.status === 'approved'
-			);
-
-		// Append orphaned notes (whose related block was deleted or missing).
-		const orphanedComments = updatedResult.filter(
-			( thread ) => ! mappedIds.has( String( thread.id ) )
-		);
-
-		const allSortedComments = [
-			...unresolvedSortedComments,
-			...resolvedSortedComments,
-			...orphanedComments,
-		];
 
 		return {
-			resultComments: allSortedComments,
-			unresolvedSortedThreads: unresolvedSortedComments,
+			resultComments: [ ...unresolved, ...resolved, ...orphans ],
+			unresolvedSortedThreads: unresolved,
 		};
 	}, [ clientIds, threads, getBlockAttributes ] );
 

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -62,9 +62,9 @@ export function useBlockComments( postId ) {
 	}, [] );
 
 	// Process comments to build the tree structure.
-	const { resultComments, unresolvedSortedThreads } = useMemo( () => {
+	const { notes, unresolvedNotes } = useMemo( () => {
 		if ( ! threads || threads.length === 0 ) {
-			return { resultComments: [], unresolvedSortedThreads: [] };
+			return { notes: [], unresolvedNotes: [] };
 		}
 
 		// Single pass over clientIds: build clientId->noteId map AND reverse lookup.
@@ -106,7 +106,7 @@ export function useBlockComments( postId ) {
 		}
 
 		if ( rootThreads.length === 0 ) {
-			return { resultComments: [], unresolvedSortedThreads: [] };
+			return { notes: [], unresolvedNotes: [] };
 		}
 
 		// Single partition over notes-in-block-order.
@@ -132,14 +132,14 @@ export function useBlockComments( postId ) {
 		);
 
 		return {
-			resultComments: [ ...unresolved, ...resolved, ...orphans ],
-			unresolvedSortedThreads: unresolved,
+			notes: [ ...unresolved, ...resolved, ...orphans ],
+			unresolvedNotes: unresolved,
 		};
 	}, [ clientIds, threads, getBlockAttributes ] );
 
 	return {
-		resultComments,
-		unresolvedSortedThreads,
+		notes,
+		unresolvedNotes,
 	};
 }
 

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -114,17 +114,15 @@ function NotesSidebar( { postId } ) {
 		[]
 	);
 
-	const { resultComments, unresolvedSortedThreads } =
-		useBlockComments( postId );
+	const { notes, unresolvedNotes } = useBlockComments( postId );
 
 	// Only enable the floating sidebar for large viewports.
 	const showFloatingSidebar = isLargeViewport;
 	// Fallback to "All notes" sidebar on smaller viewports.
-	const showAllNotesSidebar =
-		resultComments.length > 0 || ! showFloatingSidebar;
+	const showAllNotesSidebar = notes.length > 0 || ! showFloatingSidebar;
 	useEnableFloatingSidebar(
 		showFloatingSidebar &&
-			( unresolvedSortedThreads.length > 0 || selectedNote !== undefined )
+			( unresolvedNotes.length > 0 || selectedNote !== undefined )
 	);
 
 	useShortcut(
@@ -150,7 +148,7 @@ function NotesSidebar( { postId } ) {
 
 	// Find the current thread for the selected block.
 	const currentThread = blockCommentId
-		? resultComments.find( ( thread ) => thread.id === blockCommentId )
+		? notes.find( ( thread ) => thread.id === blockCommentId )
 		: null;
 
 	async function openTheSidebar( selectedClientId ) {
@@ -160,7 +158,7 @@ function NotesSidebar( { postId } ) {
 			selectedClientId && selectedClientId !== clientId
 				? selectedClientId
 				: clientId;
-		const targetNote = resultComments.find(
+		const targetNote = notes.find(
 			( note ) => note.blockClientId === targetClientId
 		);
 
@@ -213,7 +211,7 @@ function NotesSidebar( { postId } ) {
 					closeLabel={ __( 'Close Notes' ) }
 				>
 					<NotesSidebarContent
-						comments={ resultComments }
+						comments={ notes }
 						commentSidebarRef={ commentSidebarRef }
 					/>
 				</PluginSidebar>
@@ -228,7 +226,7 @@ function NotesSidebar( { postId } ) {
 					backgroundColor={ backgroundColor }
 				>
 					<NotesSidebarContent
-						comments={ unresolvedSortedThreads }
+						comments={ unresolvedNotes }
 						commentSidebarRef={ commentSidebarRef }
 						styles={ {
 							backgroundColor,


### PR DESCRIPTION
## What?

PR makes the following changes to data aggregation in the `useBlockComments` hook:

* Collapse the `useBlockComments` tree-build memo into fewer passes: build the clientId↔noteId maps in one loop, drop the post-hoc `[ ...reply ].reverse()` clone (use `unshift` while linking)
* partition unresolved/resolved/orphan notes in a single iteration instead of three.
* Orphan detection now uses the already-computed `blockClientId` instead of rebuilding a `mappedIds` Set.
* Rename hook outputs to match domain vocabulary: `resultComments` → `notes`, `unresolvedSortedThreads` → `unresolvedNotes`. 

Changes are easier to review with [hidden whitespace](https://github.com/WordPress/gutenberg/pull/77440/changes?w=0).

## Testing Instructions
1. CI checks are passing.
2. Smoke test notes order, they should be displayed by block order as before.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Claude. Reviewed by a human.