### PR TITLE
Improve wording clarity in Image block placeholder text

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -437,7 +437,7 @@ export function ImageEdit( {
 					! lockUrlControls &&
 					! isSmallContainer &&
 					__(
-						'Drag and drop an image, upload, or choose from your library.'
+						'Drag and drop an image, upload it, or choose from your library.'
 					)
 				}
 				style={ {


### PR DESCRIPTION
This PR updates the wording of the Image block placeholder text for improved readability.

Changed:
"upload" → "upload it"