### PR TITLE
Navigation: fix deprecated function call in get_inner_blocks_from_unstable_location. 

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1085,7 +1085,7 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		}
 
 		$menu_items_by_parent_id = block_core_navigation_sort_menu_items_by_parent_id( $menu_items );
-		$parsed_blocks           = block_core_navigation_parse_blocks_from_menu_items( $menu_items_by_parent_id[0], $menu_items_by_parent_id );
+		$parsed_blocks           = block_core_navigation_convert_menu_items_to_blocks( $menu_items_by_parent_id[0] ?? array(), $menu_items_by_parent_id );
 		return new WP_Block_List( $parsed_blocks, $attributes );
 	}
 }
@@ -1584,11 +1584,14 @@ function block_core_navigation_typographic_presets_backcompatibility( $parsed_bl
 add_filter( 'render_block_data', 'block_core_navigation_typographic_presets_backcompatibility' );
 
 /**
- * Turns menu item data into a nested array of parsed blocks
+ * Turns menu item data into a nested array of parsed blocks.
  *
- * @since 5.9.0
+ * Internal (non-deprecated) implementation used by
+ * block_core_navigation_get_inner_blocks_from_unstable_location() and the
+ * deprecated block_core_navigation_parse_blocks_from_menu_items().
  *
- * @deprecated 6.3.0 Use WP_Navigation_Fallback::parse_blocks_from_menu_items() instead.
+ * @since 6.8.0
+ * @access private
  *
  * @param array $menu_items               An array of menu items that represent
  *                                        an individual level of a menu.
@@ -1598,10 +1601,7 @@ add_filter( 'render_block_data', 'block_core_navigation_typographic_presets_back
  *                                        that parent.
  * @return array An array of parsed block data.
  */
-function block_core_navigation_parse_blocks_from_menu_items( $menu_items, $menu_items_by_parent_id ) {
-
-	_deprecated_function( __FUNCTION__, '6.3.0', 'WP_Navigation_Fallback::parse_blocks_from_menu_items' );
-
+function block_core_navigation_convert_menu_items_to_blocks( $menu_items, $menu_items_by_parent_id ) {
 	if ( empty( $menu_items ) ) {
 		return array();
 	}
@@ -1632,7 +1632,7 @@ function block_core_navigation_parse_blocks_from_menu_items( $menu_items, $menu_
 		);
 
 		$block['innerBlocks']  = isset( $menu_items_by_parent_id[ $menu_item->ID ] )
-			? block_core_navigation_parse_blocks_from_menu_items( $menu_items_by_parent_id[ $menu_item->ID ], $menu_items_by_parent_id )
+			? block_core_navigation_convert_menu_items_to_blocks( $menu_items_by_parent_id[ $menu_item->ID ], $menu_items_by_parent_id )
 			: array();
 		$block['innerContent'] = array_map( 'serialize_block', $block['innerBlocks'] );
 
@@ -1640,6 +1640,26 @@ function block_core_navigation_parse_blocks_from_menu_items( $menu_items, $menu_
 	}
 
 	return $blocks;
+}
+
+/**
+ * Turns menu item data into a nested array of parsed blocks
+ *
+ * @since 5.9.0
+ *
+ * @deprecated 6.3.0 Use WP_Classic_To_Block_Menu_Converter::to_blocks() instead.
+ *
+ * @param array $menu_items               An array of menu items that represent
+ *                                        an individual level of a menu.
+ * @param array $menu_items_by_parent_id  An array keyed by the id of the
+ *                                        parent menu where each element is an
+ *                                        array of menu items that belong to
+ *                                        that parent.
+ * @return array An array of parsed block data.
+ */
+function block_core_navigation_parse_blocks_from_menu_items( $menu_items, $menu_items_by_parent_id ) {
+	_deprecated_function( __FUNCTION__, '6.3.0', 'WP_Classic_To_Block_Menu_Converter::to_blocks' );
+	return block_core_navigation_convert_menu_items_to_blocks( $menu_items, $menu_items_by_parent_id );
 }
 
 /**


### PR DESCRIPTION
- Replace call to deprecated block_core_navigation_parse_blocks_from_menu_items()
    with a new private helper block_core_navigation_convert_menu_items_to_blocks()                                                                                                                                
  - Add missing null-coalescing guard on $menu_items_by_parent_id[0]                                                                                                                                              
  - Fix incorrect @deprecated docblock referencing non-existent     
    WP_Navigation_Fallback::parse_blocks_from_menu_items()                                                                                                                                                        
  - As a bonus, recursive calls inside the helper no longer fire the deprecation                                                                                                                                  
    notice on every submenu level.                                              
                                                                                                                                                                                                                  
  Fixes #77442                                              
                                                                                                                                                                                                                  
  ## What?
                                                                                                                                                                                                                  
  Closes #77442                                             
               
  Fixes three bugs in `packages/block-library/src/navigation/index.php` introduced when `block_core_navigation_get_inner_blocks_from_unstable_location()` was added in 6.5.0.
                                                                                                                                                                                                                  
  ## Why?
                                                                                                                                                                                                                  
  1. `block_core_navigation_get_inner_blocks_from_unstable_location()` (added 6.5.0) was calling `block_core_navigation_parse_blocks_from_menu_items()` which was deprecated in 6.3.0. On any site using a
  Navigation block with the `__unstableLocation` attribute (classic menu location fallback), this triggered a `_deprecated_function()` notice on every page render when `WP_DEBUG` is enabled.                    
                                                                                                                                                                                              
  2. The deprecated function's `@deprecated` docblock referenced `WP_Navigation_Fallback::parse_blocks_from_menu_items()` as the replacement, but that method does not exist. The correct replacement in Core is  
  `WP_Classic_To_Block_Menu_Converter::to_blocks()`.                                                                                                                                                              
                                                    
  3. The same call site accessed `$menu_items_by_parent_id[0]` directly without a `?? array()` guard. If all menu items carry a non-zero parent ID (e.g. due to data corruption), the `0` key is absent and PHP   
  8.x raises an undefined array key notice. The equivalent call in the already-deprecated `block_core_navigation_get_classic_menu_fallback_blocks()` correctly used `?? array()`.                                 
                                                                                                                                                                                 
  ## How?                                                                                                                                                                                                         
                                                                                                                                                                                                                  
  - Extracted the conversion logic into a new private helper `block_core_navigation_convert_menu_items_to_blocks()`. Its recursive calls reference itself rather than the deprecated wrapper, so the deprecation
  notice no longer fires once per submenu level.                                                                                                                                                                  
  - Updated `block_core_navigation_get_inner_blocks_from_unstable_location()` to call the helper directly with the `?? array()` guard.
  - Reduced `block_core_navigation_parse_blocks_from_menu_items()` to a thin shim: fires `_deprecated_function()` once, then delegates to the helper. Corrected its `@deprecated` docblock to reference           
  `WP_Classic_To_Block_Menu_Converter::to_blocks()`.                                                                                                                                                              
                                                                                                                                                                                                                  
  ## Testing Instructions                                                                                                                                                                                         
                                                                                                                                                                                                                  
  1. Set up a classic WordPress theme that registers a nav menu location.
  2. Assign a classic menu to that location via **Appearance → Menus**, including at least one item with sub-items.                                                                                               
  3. Add a Navigation block to a page/template and configure it to use `__unstableLocation` (the classic menu location fallback).
  4. Enable `WP_DEBUG` and `WP_DEBUG_LOG` in `wp-config.php`.                                                                                                                                                     
  5. Load a front-end page that renders the Navigation block.                                                                                                                                                     
  6. Check `wp-content/debug.log`.                                                                                                                                                                                
                                                                                                                                                                                                                  
  **Before this fix:** a `_deprecated_function` notice for `block_core_navigation_parse_blocks_from_menu_items` appears — once per submenu level per request.                                                     
  **After this fix:** no deprecation notices appear; the Navigation block renders identically.                                                                                                                    
                                                                                              
  ### Testing Instructions for Keyboard                                                                                                                                                                           
                                                            
  No UI changes — this is a PHP-only fix. Keyboard behaviour of the Navigation block is unaffected.                                                                                                               
                                                                                                                                                                                                                  
  ## Use of AI Tools
                                                                                                                                                                                                                  
  This PR was authored with the assistance of Claude (Anthropic) for code analysis and implementation. The changes have been reviewed and verified manually.