### PR TITLE
Storybook: add global preview styles for @wordpress/ui overlays

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -17,7 +17,6 @@
 
 ### Internal
 
--   Storybook: add global preview iframe styles on the shared monorepo canvas (`body` positioning and `#storybook-root` isolation) so portaled `@wordpress/ui` overlays stack predictably in local development; does not affect published package assets ([#77451](https://github.com/WordPress/gutenberg/pull/77451)).
 -   Extract shared `useScheduleValidation` hook; refactor `Dialog`, `Popover`, and `Tabs` validation contexts to use it ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
 -   `Tabs`: Wrap two validation timeout waits in `act(...)` to avoid intermittent test warnings ([#77319](https://github.com/WordPress/gutenberg/pull/77319)).
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Internal
 
--   Storybook: add global preview head styles (`body` positioning and `#storybook-root` isolation) so layered `@wordpress/ui` overlays render predictably in the dev preview ([#77451](https://github.com/WordPress/gutenberg/pull/77451)).
+-   Storybook: add global preview iframe styles on the shared monorepo canvas (`body` positioning and `#storybook-root` isolation) so portaled `@wordpress/ui` overlays stack predictably in local development; does not affect published package assets ([#77451](https://github.com/WordPress/gutenberg/pull/77451)).
 -   Extract shared `useScheduleValidation` hook; refactor `Dialog`, `Popover`, and `Tabs` validation contexts to use it ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
 -   `Tabs`: Wrap two validation timeout waits in `act(...)` to avoid intermittent test warnings ([#77319](https://github.com/WordPress/gutenberg/pull/77319)).
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Internal
 
+-   Storybook: add global preview head styles (`body` positioning and `#storybook-root` isolation) so layered `@wordpress/ui` overlays render predictably in the dev preview ([#77451](https://github.com/WordPress/gutenberg/pull/77451)).
 -   Extract shared `useScheduleValidation` hook; refactor `Dialog`, `Popover`, and `Tabs` validation contexts to use it ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
 -   `Tabs`: Wrap two validation timeout waits in `act(...)` to avoid intermittent test warnings ([#77319](https://github.com/WordPress/gutenberg/pull/77319)).
 

--- a/storybook/preview-head.html
+++ b/storybook/preview-head.html
@@ -7,9 +7,6 @@
 	on the preview root. Matches @wordpress/ui README guidance for using the
 	library outside the standard editor ("Elsewhere").
 
-	Extracted from https://github.com/WordPress/gutenberg/pull/76837 for
-	https://github.com/WordPress/gutenberg/pull/77451
-
 	#storybook-root is Storybook's preview mount target; if a future Storybook major
 	changes the DOM, update this selector. isolation: isolate creates a stacking
 	context (z-index / compositing) for descendants and portaled layers.

--- a/storybook/preview-head.html
+++ b/storybook/preview-head.html
@@ -1,0 +1,9 @@
+<style>
+	body {
+		position: relative;
+	}
+
+	#storybook-root {
+		isolation: isolate;
+	}
+</style>

--- a/storybook/preview-head.html
+++ b/storybook/preview-head.html
@@ -3,7 +3,7 @@
 
 	Intentional blast radius: styles apply to the whole monorepo canvas (see
 	storybook/main.ts), not only @wordpress/ui, so any package's portaled overlays
-	get a predictable host: relative positioning on body and a stacking boundary
+	get predictable layout: relative positioning on body and a stacking boundary
 	on the preview root. Matches @wordpress/ui README guidance for using the
 	library outside the standard editor ("Elsewhere").
 

--- a/storybook/preview-head.html
+++ b/storybook/preview-head.html
@@ -1,5 +1,5 @@
 <!--
-	Global preview iframe CSS for Storybook 10.x (this file is injected for every story).
+	Global preview iframe CSS (this file is injected for every story).
 
 	Intentional blast radius: styles apply to the whole monorepo canvas (see
 	storybook/main.ts), not only @wordpress/ui, so any package's portaled overlays

--- a/storybook/preview-head.html
+++ b/storybook/preview-head.html
@@ -1,3 +1,19 @@
+<!--
+	Global preview iframe CSS for Storybook 10.x (this file is injected for every story).
+
+	Intentional blast radius: styles apply to the whole monorepo canvas (see
+	storybook/main.ts), not only @wordpress/ui, so any package's portaled overlays
+	get a predictable host: relative positioning on body and a stacking boundary
+	on the preview root. Matches @wordpress/ui README guidance for using the
+	library outside the standard editor ("Elsewhere").
+
+	Extracted from https://github.com/WordPress/gutenberg/pull/76837 for
+	https://github.com/WordPress/gutenberg/pull/77451
+
+	#storybook-root is Storybook's preview mount target; if a future Storybook major
+	changes the DOM, update this selector. isolation: isolate creates a stacking
+	context (z-index / compositing) for descendants and portaled layers.
+-->
 <style>
 	body {
 		position: relative;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related: [#76837](https://github.com/WordPress/gutenberg/pull/76837) (source PR this was extracted from)

## What?

Adds global styles in `storybook/preview-head.html` so the Storybook preview iframe gives portaled `@wordpress/ui` overlays (dialogs, popovers, etc.) a predictable positioning and stacking context. Records the change under `@wordpress/ui` **Internal** changelog as dev-preview documentation.

## Why?

[#76837](https://github.com/WordPress/gutenberg/pull/76837) introduced the same rules while migrating modals. Splitting them out lets the Storybook canvas fix land without the rest of that PR, and keeps overlay stories closer to the documented “host” setup for `@wordpress/ui`.

## How?

- `body { position: relative; }` — positioning context for portaled layers.
- `#storybook-root { isolation: isolate; }` — stacking boundary at the Storybook preview root (SB 10.x convention in this repo).

<details>
<summary>Implementation notes (optional read)</summary>

These rules apply to **every** story in the monorepo Storybook build (see `storybook/main.ts` globs), not only `packages/ui`. That is intentional for a single shared canvas: the same stacking behavior benefits any story using portaled overlays. If we ever need package-specific behavior, a narrower approach (e.g. decorators) would be a follow-up.

</details>

## Testing Instructions

1. From the repo root: `npm install` (if needed), then run `npm run storybook:dev` (watches packages and starts `@wordpress/storybook`; see `CONTRIBUTING.md` for alternatives).

**Which stories to prioritize:** in the Storybook sidebar, open **`Design System/Components/Dialog`**, **`Design System/Components/AlertDialog`**, and **`Design System/Components/Popover`**. Then optionally **`Components/Overlays/Modal`** (or another overlay-heavy story outside `@wordpress/ui`).

2. Confirm backdrops and layered content stack and cover the canvas as expected (no “bleed” behind the wrong ancestor).

3. **Accessibility smoke:** with **Dialog** or **AlertDialog** open, tab through focusable controls and confirm focus rings stay visible and usable (no overlay hiding focus unexpectedly).

**CI:** the repository **Storybook build and Smoke Tests** workflow covers Storybook build smoke; stacking and focus still need the manual steps above before merge.

### Testing Instructions for Keyboard

Use step 3 above in Storybook only (focus visibility inside open overlays). This PR does not change WordPress editor UI or production keyboard behavior.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| - | - |
| (empty / default Storybook canvas stacking) | (optional) attach a screenshot of a `@wordpress/ui` Dialog story showing correct backdrop coverage after merge |

## Use of AI Tools

Pull request description drafted with assistance from Cursor (GPT-based agent). Commits were authored with Cursor for the extraction; changes were reviewed locally before opening the draft PR.
