### PR TITLE
UI: Portal prop and Portal subcomponents for overlay Popups

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   `Dialog`, `AlertDialog`, `Popover`, `Tooltip`, `Select`: **`Popup` portal API** ([#77452](https://github.com/WordPress/gutenberg/pull/77452)). Add `Portal` subcomponents and an optional `portal` prop on `Popup` (when omitted, the default `Portal` is used). Remove `container` from every `Popup` and `portalClassName` from `Dialog.Popup` / `AlertDialog.Popup`; pass `portal={ <Matching.Portal … /> }` for `container`, `className`, `style`, and other portal options.
+
 ### Documentation
 
 -   Restructure setup docs into "Within standard WordPress editor screens" and "Elsewhere" for clarity ([#77338](https://github.com/WordPress/gutenberg/pull/77338)).

--- a/packages/ui/src/alert-dialog/index.ts
+++ b/packages/ui/src/alert-dialog/index.ts
@@ -1,4 +1,4 @@
-export type { PortalProps } from './portal';
+export type { PortalProps } from './types';
 export { Root } from './root';
 export { Trigger } from './trigger';
 export { Popup } from './popup';

--- a/packages/ui/src/alert-dialog/index.ts
+++ b/packages/ui/src/alert-dialog/index.ts
@@ -1,4 +1,3 @@
-export type { PortalProps } from './types';
 export { Root } from './root';
 export { Trigger } from './trigger';
 export { Popup } from './popup';

--- a/packages/ui/src/alert-dialog/index.ts
+++ b/packages/ui/src/alert-dialog/index.ts
@@ -1,3 +1,5 @@
+export type { PortalProps } from './portal';
 export { Root } from './root';
 export { Trigger } from './trigger';
 export { Popup } from './popup';
+export { Portal } from './portal';

--- a/packages/ui/src/alert-dialog/popup.tsx
+++ b/packages/ui/src/alert-dialog/popup.tsx
@@ -1,6 +1,11 @@
 import { AlertDialog as _AlertDialog } from '@base-ui/react/alert-dialog';
 import clsx from 'clsx';
-import { forwardRef, useContext } from '@wordpress/element';
+import {
+	cloneElement,
+	forwardRef,
+	isValidElement,
+	useContext,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	type ThemeProvider as ThemeProviderType,
@@ -13,6 +18,7 @@ import { unlock } from '../lock-unlock';
 import { Stack } from '../stack';
 import { Text } from '../text';
 import { AlertDialogContext } from './context';
+import { Portal } from './portal';
 import alertDialogStyles from './style.module.css';
 import type { PopupProps } from './types';
 
@@ -23,7 +29,7 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >(
 	function AlertDialogPopup(
 		{
 			className,
-			container,
+			portal,
 			intent = 'default',
 			title,
 			description,
@@ -44,8 +50,9 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >(
 
 		const buttonsDisabled = phase !== 'idle' || undefined;
 
-		return (
-			<_AlertDialog.Portal container={ container }>
+		const rootPortal = portal ?? <Portal />;
+		const portalChildren = (
+			<>
 				<_AlertDialog.Backdrop className={ dialogStyles.backdrop } />
 				<ThemeProvider>
 					<_AlertDialog.Popup
@@ -108,8 +115,14 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >(
 						</Stack>
 					</_AlertDialog.Popup>
 				</ThemeProvider>
-			</_AlertDialog.Portal>
+			</>
 		);
+
+		if ( isValidElement( rootPortal ) ) {
+			return cloneElement( rootPortal, { children: portalChildren } );
+		}
+
+		return <Portal>{ portalChildren }</Portal>;
 	}
 );
 

--- a/packages/ui/src/alert-dialog/popup.tsx
+++ b/packages/ui/src/alert-dialog/popup.tsx
@@ -1,17 +1,13 @@
 import { AlertDialog as _AlertDialog } from '@base-ui/react/alert-dialog';
 import clsx from 'clsx';
-import {
-	cloneElement,
-	forwardRef,
-	isValidElement,
-	useContext,
-} from '@wordpress/element';
+import { forwardRef, useContext } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	type ThemeProvider as ThemeProviderType,
 	privateApis as themePrivateApis,
 } from '@wordpress/theme';
 
+import { renderPortalChildren } from '../utils/render-portal-children';
 import { Button } from '../button';
 import dialogStyles from '../dialog/style.module.css';
 import { unlock } from '../lock-unlock';
@@ -50,7 +46,6 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >(
 
 		const buttonsDisabled = phase !== 'idle' || undefined;
 
-		const rootPortal = portal ?? <Portal />;
 		const portalChildren = (
 			<>
 				<_AlertDialog.Backdrop className={ dialogStyles.backdrop } />
@@ -118,11 +113,7 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >(
 			</>
 		);
 
-		if ( isValidElement( rootPortal ) ) {
-			return cloneElement( rootPortal, { children: portalChildren } );
-		}
-
-		return <Portal>{ portalChildren }</Portal>;
+		return renderPortalChildren( portal, <Portal />, portalChildren );
 	}
 );
 

--- a/packages/ui/src/alert-dialog/popup.tsx
+++ b/packages/ui/src/alert-dialog/popup.tsx
@@ -7,7 +7,7 @@ import {
 	privateApis as themePrivateApis,
 } from '@wordpress/theme';
 
-import { renderPortalChildren } from '../utils/render-portal-children';
+import { renderPortalWithChildren } from '../utils/render-portal-with-children';
 import { Button } from '../button';
 import dialogStyles from '../dialog/style.module.css';
 import { unlock } from '../lock-unlock';
@@ -113,7 +113,7 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >(
 			</>
 		);
 
-		return renderPortalChildren( portal, <Portal />, portalChildren );
+		return renderPortalWithChildren( portal, <Portal />, portalChildren );
 	}
 );
 

--- a/packages/ui/src/alert-dialog/portal.tsx
+++ b/packages/ui/src/alert-dialog/portal.tsx
@@ -1,10 +1,6 @@
 import { AlertDialog as _AlertDialog } from '@base-ui/react/alert-dialog';
 import { forwardRef } from '@wordpress/element';
-import type { ComponentPropsWithoutRef } from 'react';
-
-export type PortalProps = ComponentPropsWithoutRef<
-	typeof _AlertDialog.Portal
->;
+import type { PortalProps } from './types';
 
 /**
  * Root element that portals `AlertDialog` overlay content. Pass to

--- a/packages/ui/src/alert-dialog/portal.tsx
+++ b/packages/ui/src/alert-dialog/portal.tsx
@@ -1,0 +1,21 @@
+import { AlertDialog as _AlertDialog } from '@base-ui/react/alert-dialog';
+import { forwardRef } from '@wordpress/element';
+import type { ComponentPropsWithoutRef } from 'react';
+
+export type PortalProps = ComponentPropsWithoutRef<
+	typeof _AlertDialog.Portal
+>;
+
+/**
+ * Root element that portals `AlertDialog` overlay content. Pass to
+ * `AlertDialog.Popup`'s `portal` prop to customize the portal target and
+ * wrapper. When `portal` is omitted, `AlertDialog.Popup` uses this component
+ * with default props.
+ */
+const Portal = forwardRef< HTMLDivElement, PortalProps >(
+	function AlertDialogPortal( props, ref ) {
+		return <_AlertDialog.Portal ref={ ref } { ...props } />;
+	}
+);
+
+export { Portal };

--- a/packages/ui/src/alert-dialog/test/index.test.tsx
+++ b/packages/ui/src/alert-dialog/test/index.test.tsx
@@ -1453,8 +1453,8 @@ describe( 'AlertDialog', () => {
 		} );
 	} );
 
-	describe( 'container', () => {
-		it( 'should render inside the container when provided', async () => {
+	describe( 'portal', () => {
+		it( 'should render inside the portal container when a custom target is provided', async () => {
 			const user = userEvent.setup();
 			const containerRef = createRef< HTMLDivElement >();
 
@@ -1468,7 +1468,11 @@ describe( 'AlertDialog', () => {
 						/>
 						<AlertDialog.Popup
 							title="Confirm"
-							container={ containerRef }
+							portal={
+								<AlertDialog.Portal
+									container={ containerRef }
+								/>
+							}
 						/>
 					</AlertDialog.Root>
 				</div>

--- a/packages/ui/src/alert-dialog/types.ts
+++ b/packages/ui/src/alert-dialog/types.ts
@@ -66,12 +66,13 @@ export interface PopupProps
 	/**
 	 * Optional portal element, typically `<AlertDialog.Portal />` with
 	 * custom `container`, `className`, or `style`. Overlay content is
-	 * rendered as this portal's children.
+	 * rendered as this portal's children (do not pass `children` on the portal
+	 * element; they would be ignored).
 	 *
 	 * When omitted, `AlertDialog.Popup` uses `AlertDialog.Portal` with default
 	 * props.
 	 */
-	portal?: ReactElement< PortalProps >;
+	portal?: ReactElement< Omit< PortalProps, 'children' > >;
 
 	/**
 	 * The semantic intent of the dialog, which determines its styling.

--- a/packages/ui/src/alert-dialog/types.ts
+++ b/packages/ui/src/alert-dialog/types.ts
@@ -1,8 +1,11 @@
 import type { AlertDialog as _AlertDialog } from '@base-ui/react/alert-dialog';
-import type { ReactElement, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ReactElement, ReactNode } from 'react';
 
 import type { ComponentProps } from '../utils/types';
-import type { PortalProps } from './portal';
+
+export type PortalProps = ComponentPropsWithoutRef<
+	typeof _AlertDialog.Portal
+>;
 
 /**
  * The return type of `onConfirm`. Return `void` (or nothing) to auto-close

--- a/packages/ui/src/alert-dialog/types.ts
+++ b/packages/ui/src/alert-dialog/types.ts
@@ -1,7 +1,8 @@
 import type { AlertDialog as _AlertDialog } from '@base-ui/react/alert-dialog';
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import type { ComponentProps } from '../utils/types';
+import type { PortalProps } from './portal';
 
 /**
  * The return type of `onConfirm`. Return `void` (or nothing) to auto-close
@@ -63,9 +64,14 @@ export interface PopupProps
 	extends ComponentProps< 'div' >,
 		Pick< _AlertDialog.Popup.Props, 'initialFocus' | 'finalFocus' > {
 	/**
-	 * A parent element to render the portal into.
+	 * Optional portal element, typically `<AlertDialog.Portal />` with
+	 * custom `container`, `className`, or `style`. Overlay content is
+	 * rendered as this portal's children.
+	 *
+	 * When omitted, `AlertDialog.Popup` uses `AlertDialog.Portal` with default
+	 * props.
 	 */
-	container?: _AlertDialog.Portal.Props[ 'container' ];
+	portal?: ReactElement< PortalProps >;
 
 	/**
 	 * The semantic intent of the dialog, which determines its styling.

--- a/packages/ui/src/dialog/index.ts
+++ b/packages/ui/src/dialog/index.ts
@@ -8,7 +8,6 @@ import { Root } from './root';
 import { Title } from './title';
 import { Trigger } from './trigger';
 
-export type { PortalProps } from './types';
 export {
 	Action,
 	CloseIcon,

--- a/packages/ui/src/dialog/index.ts
+++ b/packages/ui/src/dialog/index.ts
@@ -8,7 +8,7 @@ import { Root } from './root';
 import { Title } from './title';
 import { Trigger } from './trigger';
 
-export type { PortalProps } from './portal';
+export type { PortalProps } from './types';
 export {
 	Action,
 	CloseIcon,

--- a/packages/ui/src/dialog/index.ts
+++ b/packages/ui/src/dialog/index.ts
@@ -3,8 +3,20 @@ import { CloseIcon } from './close-icon';
 import { Footer } from './footer';
 import { Header } from './header';
 import { Popup } from './popup';
+import { Portal } from './portal';
 import { Root } from './root';
 import { Title } from './title';
 import { Trigger } from './trigger';
 
-export { Action, CloseIcon, Footer, Header, Popup, Root, Title, Trigger };
+export type { PortalProps } from './portal';
+export {
+	Action,
+	CloseIcon,
+	Footer,
+	Header,
+	Popup,
+	Portal,
+	Root,
+	Title,
+	Trigger,
+};

--- a/packages/ui/src/dialog/popup.tsx
+++ b/packages/ui/src/dialog/popup.tsx
@@ -1,6 +1,6 @@
 import { Dialog as _Dialog } from '@base-ui/react/dialog';
 import clsx from 'clsx';
-import { cloneElement, forwardRef, isValidElement } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 import {
 	type ThemeProvider as ThemeProviderType,
@@ -8,6 +8,7 @@ import {
 } from '@wordpress/theme';
 import { unlock } from '../lock-unlock';
 import { useDeprioritizedInitialFocus } from '../utils/use-deprioritized-initial-focus';
+import { renderPortalChildren } from '../utils/render-portal-children';
 import { DialogValidationProvider } from './context';
 import { Portal } from './portal';
 import styles from './style.module.css';
@@ -22,10 +23,8 @@ const CLOSE_ICON_ATTR = 'data-wp-ui-dialog-close-icon';
  * Renders the dialog popup element that contains the dialog content.
  * Uses a portal to render outside the DOM hierarchy.
  *
- * When `portal` is omitted, defaults to `Dialog.Portal`. The
- * `cloneElement` / `isValidElement` portal wiring matches the other overlay
- * `Popup` implementations on purpose so each component stays explicit rather
- * than sharing a cross-package helper.
+ * When `portal` is omitted, defaults to `Dialog.Portal`. Portal merging is
+ * handled by `renderPortalChildren` (shared with other overlay `Popup`s).
  */
 const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 	{
@@ -45,7 +44,6 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 	} );
 	const mergedRef = useMergeRefs( [ ref, popupRef ] );
 
-	const rootPortal = portal ?? <Portal />;
 	const portalChildren = (
 		<>
 			<_Dialog.Backdrop className={ styles.backdrop } />
@@ -69,11 +67,7 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 		</>
 	);
 
-	if ( isValidElement( rootPortal ) ) {
-		return cloneElement( rootPortal, { children: portalChildren } );
-	}
-
-	return <Portal>{ portalChildren }</Portal>;
+	return renderPortalChildren( portal, <Portal />, portalChildren );
 } );
 
 export { Popup };

--- a/packages/ui/src/dialog/popup.tsx
+++ b/packages/ui/src/dialog/popup.tsx
@@ -1,6 +1,6 @@
 import { Dialog as _Dialog } from '@base-ui/react/dialog';
 import clsx from 'clsx';
-import { forwardRef } from '@wordpress/element';
+import { cloneElement, forwardRef, isValidElement } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 import {
 	type ThemeProvider as ThemeProviderType,
@@ -9,6 +9,7 @@ import {
 import { unlock } from '../lock-unlock';
 import { useDeprioritizedInitialFocus } from '../utils/use-deprioritized-initial-focus';
 import { DialogValidationProvider } from './context';
+import { Portal } from './portal';
 import styles from './style.module.css';
 import type { PopupProps } from './types';
 
@@ -20,11 +21,16 @@ const CLOSE_ICON_ATTR = 'data-wp-ui-dialog-close-icon';
 /**
  * Renders the dialog popup element that contains the dialog content.
  * Uses a portal to render outside the DOM hierarchy.
+ *
+ * When `portal` is omitted, defaults to `Dialog.Portal`. The
+ * `cloneElement` / `isValidElement` portal wiring matches the other overlay
+ * `Popup` implementations on purpose so each component stays explicit rather
+ * than sharing a cross-package helper.
  */
 const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 	{
 		className,
-		container,
+		portal,
 		size = 'medium',
 		initialFocus,
 		finalFocus,
@@ -39,8 +45,9 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 	} );
 	const mergedRef = useMergeRefs( [ ref, popupRef ] );
 
-	return (
-		<_Dialog.Portal container={ container }>
+	const rootPortal = portal ?? <Portal />;
+	const portalChildren = (
+		<>
 			<_Dialog.Backdrop className={ styles.backdrop } />
 			<ThemeProvider>
 				<_Dialog.Popup
@@ -59,8 +66,14 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 					</DialogValidationProvider>
 				</_Dialog.Popup>
 			</ThemeProvider>
-		</_Dialog.Portal>
+		</>
 	);
+
+	if ( isValidElement( rootPortal ) ) {
+		return cloneElement( rootPortal, { children: portalChildren } );
+	}
+
+	return <Portal>{ portalChildren }</Portal>;
 } );
 
 export { Popup };

--- a/packages/ui/src/dialog/popup.tsx
+++ b/packages/ui/src/dialog/popup.tsx
@@ -8,7 +8,7 @@ import {
 } from '@wordpress/theme';
 import { unlock } from '../lock-unlock';
 import { useDeprioritizedInitialFocus } from '../utils/use-deprioritized-initial-focus';
-import { renderPortalChildren } from '../utils/render-portal-children';
+import { renderPortalWithChildren } from '../utils/render-portal-with-children';
 import { DialogValidationProvider } from './context';
 import { Portal } from './portal';
 import styles from './style.module.css';
@@ -24,7 +24,7 @@ const CLOSE_ICON_ATTR = 'data-wp-ui-dialog-close-icon';
  * Uses a portal to render outside the DOM hierarchy.
  *
  * When `portal` is omitted, defaults to `Dialog.Portal`. Portal merging is
- * handled by `renderPortalChildren` (shared with other overlay `Popup`s).
+ * handled by `renderPortalWithChildren` (shared with other overlay `Popup`s).
  */
 const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 	{
@@ -67,7 +67,7 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 		</>
 	);
 
-	return renderPortalChildren( portal, <Portal />, portalChildren );
+	return renderPortalWithChildren( portal, <Portal />, portalChildren );
 } );
 
 export { Popup };

--- a/packages/ui/src/dialog/portal.tsx
+++ b/packages/ui/src/dialog/portal.tsx
@@ -1,8 +1,6 @@
 import { Dialog as _Dialog } from '@base-ui/react/dialog';
 import { forwardRef } from '@wordpress/element';
-import type { ComponentPropsWithoutRef } from 'react';
-
-export type PortalProps = ComponentPropsWithoutRef< typeof _Dialog.Portal >;
+import type { PortalProps } from './types';
 
 /**
  * Root element that portals `Dialog` overlay content (`Backdrop`, inner

--- a/packages/ui/src/dialog/portal.tsx
+++ b/packages/ui/src/dialog/portal.tsx
@@ -1,0 +1,20 @@
+import { Dialog as _Dialog } from '@base-ui/react/dialog';
+import { forwardRef } from '@wordpress/element';
+import type { ComponentPropsWithoutRef } from 'react';
+
+export type PortalProps = ComponentPropsWithoutRef< typeof _Dialog.Portal >;
+
+/**
+ * Root element that portals `Dialog` overlay content (`Backdrop`, inner
+ * `Popup`, etc.) outside the DOM hierarchy. Pass to `Dialog.Popup`'s
+ * `portal` prop to customize `container`, `className`, `style`, and other
+ * Base UI portal options. When `portal` is omitted, `Dialog.Popup` uses this
+ * component with default props.
+ */
+const Portal = forwardRef< HTMLDivElement, PortalProps >(
+	function DialogPortal( props, ref ) {
+		return <_Dialog.Portal ref={ ref } { ...props } />;
+	}
+);
+
+export { Portal };

--- a/packages/ui/src/dialog/test/index.test.tsx
+++ b/packages/ui/src/dialog/test/index.test.tsx
@@ -502,8 +502,8 @@ describe( 'Dialog', () => {
 		} );
 	} );
 
-	describe( 'container', () => {
-		it( 'should render inside the container when provided', async () => {
+	describe( 'portal', () => {
+		it( 'should render inside the portal container when a custom target is provided', async () => {
 			const user = userEvent.setup();
 			const containerRef = createRef< HTMLDivElement >();
 
@@ -515,7 +515,11 @@ describe( 'Dialog', () => {
 							ref={ containerRef }
 							data-testid="custom-container"
 						/>
-						<Dialog.Popup container={ containerRef }>
+						<Dialog.Popup
+							portal={
+								<Dialog.Portal container={ containerRef } />
+							}
+						>
 							<Dialog.Header>
 								<Dialog.Title>Title</Dialog.Title>
 							</Dialog.Header>

--- a/packages/ui/src/dialog/types.ts
+++ b/packages/ui/src/dialog/types.ts
@@ -39,11 +39,12 @@ export interface PopupProps
 	/**
 	 * Optional portal element, typically `<Dialog.Portal />` with custom
 	 * `container`, `className`, or `style`. The popup and backdrop are
-	 * rendered as this portal's children.
+	 * rendered as this portal's children (do not pass `children` on the portal
+	 * element; they would be ignored).
 	 *
 	 * When omitted, `Dialog.Popup` uses `Dialog.Portal` with default props.
 	 */
-	portal?: ReactElement< PortalProps >;
+	portal?: ReactElement< Omit< PortalProps, 'children' > >;
 
 	/**
 	 * Renders the dialog at a preset width (excluding additional padding from

--- a/packages/ui/src/dialog/types.ts
+++ b/packages/ui/src/dialog/types.ts
@@ -1,6 +1,8 @@
 import type { Dialog as _Dialog } from '@base-ui/react/dialog';
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
+
 import type { Button } from '../button';
+import type { PortalProps } from './portal';
 import type { IconButton } from '../icon-button';
 import type { ComponentProps } from '../utils/types';
 
@@ -35,9 +37,13 @@ export interface PopupProps
 	children?: ReactNode;
 
 	/**
-	 * A parent element to render the portal into.
+	 * Optional portal element, typically `<Dialog.Portal />` with custom
+	 * `container`, `className`, or `style`. The popup and backdrop are
+	 * rendered as this portal's children.
+	 *
+	 * When omitted, `Dialog.Popup` uses `Dialog.Portal` with default props.
 	 */
-	container?: _Dialog.Portal.Props[ 'container' ];
+	portal?: ReactElement< PortalProps >;
 
 	/**
 	 * Renders the dialog at a preset width (excluding additional padding from

--- a/packages/ui/src/dialog/types.ts
+++ b/packages/ui/src/dialog/types.ts
@@ -1,10 +1,11 @@
 import type { Dialog as _Dialog } from '@base-ui/react/dialog';
-import type { ReactElement, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ReactElement, ReactNode } from 'react';
 
 import type { Button } from '../button';
-import type { PortalProps } from './portal';
 import type { IconButton } from '../icon-button';
 import type { ComponentProps } from '../utils/types';
+
+export type PortalProps = ComponentPropsWithoutRef< typeof _Dialog.Portal >;
 
 export interface RootProps
 	extends Pick<

--- a/packages/ui/src/form/primitives/select/index.ts
+++ b/packages/ui/src/form/primitives/select/index.ts
@@ -1,5 +1,4 @@
 export { Item } from './item';
-export type { PortalProps } from './types';
 export { Portal } from './portal';
 export { Popup } from './popup';
 export { Root } from './root';

--- a/packages/ui/src/form/primitives/select/index.ts
+++ b/packages/ui/src/form/primitives/select/index.ts
@@ -1,5 +1,5 @@
 export { Item } from './item';
-export type { PortalProps } from './portal';
+export type { PortalProps } from './types';
 export { Portal } from './portal';
 export { Popup } from './popup';
 export { Root } from './root';

--- a/packages/ui/src/form/primitives/select/index.ts
+++ b/packages/ui/src/form/primitives/select/index.ts
@@ -1,4 +1,6 @@
 export { Item } from './item';
+export type { PortalProps } from './portal';
+export { Portal } from './portal';
 export { Popup } from './popup';
 export { Root } from './root';
 export { Trigger } from './trigger';

--- a/packages/ui/src/form/primitives/select/popup.tsx
+++ b/packages/ui/src/form/primitives/select/popup.tsx
@@ -1,12 +1,13 @@
 import { Select as _Select } from '@base-ui/react/select';
 import clsx from 'clsx';
-import { cloneElement, forwardRef, isValidElement } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 import {
 	type ThemeProvider as ThemeProviderType,
 	privateApis as themePrivateApis,
 } from '@wordpress/theme';
 import { unlock } from '../../../lock-unlock';
 import { Portal } from './portal';
+import { renderPortalChildren } from '../../../utils/render-portal-children';
 import itemPopupStyles from '../../../utils/css/item-popup.module.css';
 import resetStyles from '../../../utils/css/resets.module.css';
 import styles from './style.module.css';
@@ -21,7 +22,6 @@ export const Popup = forwardRef< HTMLDivElement, SelectPopupProps >(
 		{ className, portal, children, style, ...restProps },
 		ref
 	) {
-		const rootPortal = portal ?? <Portal />;
 		const portalChildren = (
 			<_Select.Positioner
 				{ ...ITEM_POPUP_POSITIONER_PROPS }
@@ -55,10 +55,6 @@ export const Popup = forwardRef< HTMLDivElement, SelectPopupProps >(
 			</_Select.Positioner>
 		);
 
-		if ( isValidElement( rootPortal ) ) {
-			return cloneElement( rootPortal, { children: portalChildren } );
-		}
-
-		return <Portal>{ portalChildren }</Portal>;
+		return renderPortalChildren( portal, <Portal />, portalChildren );
 	}
 );

--- a/packages/ui/src/form/primitives/select/popup.tsx
+++ b/packages/ui/src/form/primitives/select/popup.tsx
@@ -1,11 +1,12 @@
 import { Select as _Select } from '@base-ui/react/select';
 import clsx from 'clsx';
-import { forwardRef } from '@wordpress/element';
+import { cloneElement, forwardRef, isValidElement } from '@wordpress/element';
 import {
 	type ThemeProvider as ThemeProviderType,
 	privateApis as themePrivateApis,
 } from '@wordpress/theme';
 import { unlock } from '../../../lock-unlock';
+import { Portal } from './portal';
 import itemPopupStyles from '../../../utils/css/item-popup.module.css';
 import resetStyles from '../../../utils/css/resets.module.css';
 import styles from './style.module.css';
@@ -17,42 +18,47 @@ const ThemeProvider: typeof ThemeProviderType =
 
 export const Popup = forwardRef< HTMLDivElement, SelectPopupProps >(
 	function Popup(
-		{ className, container, children, style, ...restProps },
+		{ className, portal, children, style, ...restProps },
 		ref
 	) {
-		return (
-			<_Select.Portal container={ container }>
-				<_Select.Positioner
-					{ ...ITEM_POPUP_POSITIONER_PROPS }
-					alignItemWithTrigger={ false }
-					style={ style }
-					className={ clsx(
-						resetStyles[ 'box-sizing' ],
-						styles.positioner,
-						className
-					) }
-				>
-					<ThemeProvider>
-						<_Select.Popup
-							ref={ ref }
-							className={ itemPopupStyles.popup }
-							{ ...restProps }
-						>
-							<_Select.List className={ itemPopupStyles.list }>
-								<div
-									className={
-										itemPopupStyles[
-											'list-scrollable-container'
-										]
-									}
-								>
-									{ children }
-								</div>
-							</_Select.List>
-						</_Select.Popup>
-					</ThemeProvider>
-				</_Select.Positioner>
-			</_Select.Portal>
+		const rootPortal = portal ?? <Portal />;
+		const portalChildren = (
+			<_Select.Positioner
+				{ ...ITEM_POPUP_POSITIONER_PROPS }
+				alignItemWithTrigger={ false }
+				style={ style }
+				className={ clsx(
+					resetStyles[ 'box-sizing' ],
+					styles.positioner,
+					className
+				) }
+			>
+				<ThemeProvider>
+					<_Select.Popup
+						ref={ ref }
+						className={ itemPopupStyles.popup }
+						{ ...restProps }
+					>
+						<_Select.List className={ itemPopupStyles.list }>
+							<div
+								className={
+									itemPopupStyles[
+										'list-scrollable-container'
+									]
+								}
+							>
+								{ children }
+							</div>
+						</_Select.List>
+					</_Select.Popup>
+				</ThemeProvider>
+			</_Select.Positioner>
 		);
+
+		if ( isValidElement( rootPortal ) ) {
+			return cloneElement( rootPortal, { children: portalChildren } );
+		}
+
+		return <Portal>{ portalChildren }</Portal>;
 	}
 );

--- a/packages/ui/src/form/primitives/select/popup.tsx
+++ b/packages/ui/src/form/primitives/select/popup.tsx
@@ -7,7 +7,7 @@ import {
 } from '@wordpress/theme';
 import { unlock } from '../../../lock-unlock';
 import { Portal } from './portal';
-import { renderPortalChildren } from '../../../utils/render-portal-children';
+import { renderPortalWithChildren } from '../../../utils/render-portal-with-children';
 import itemPopupStyles from '../../../utils/css/item-popup.module.css';
 import resetStyles from '../../../utils/css/resets.module.css';
 import styles from './style.module.css';
@@ -55,6 +55,6 @@ export const Popup = forwardRef< HTMLDivElement, SelectPopupProps >(
 			</_Select.Positioner>
 		);
 
-		return renderPortalChildren( portal, <Portal />, portalChildren );
+		return renderPortalWithChildren( portal, <Portal />, portalChildren );
 	}
 );

--- a/packages/ui/src/form/primitives/select/portal.tsx
+++ b/packages/ui/src/form/primitives/select/portal.tsx
@@ -1,0 +1,18 @@
+import { Select as _Select } from '@base-ui/react/select';
+import { forwardRef } from '@wordpress/element';
+import type { ComponentPropsWithoutRef } from 'react';
+
+export type PortalProps = ComponentPropsWithoutRef< typeof _Select.Portal >;
+
+/**
+ * Root element that portals `Select` listbox content. Pass to
+ * `Select.Popup`'s `portal` prop. When `portal` is omitted, `Select.Popup`
+ * uses this component with default props.
+ */
+const Portal = forwardRef< HTMLDivElement, PortalProps >(
+	function SelectPortal( props, ref ) {
+		return <_Select.Portal ref={ ref } { ...props } />;
+	}
+);
+
+export { Portal };

--- a/packages/ui/src/form/primitives/select/portal.tsx
+++ b/packages/ui/src/form/primitives/select/portal.tsx
@@ -1,8 +1,6 @@
 import { Select as _Select } from '@base-ui/react/select';
 import { forwardRef } from '@wordpress/element';
-import type { ComponentPropsWithoutRef } from 'react';
-
-export type PortalProps = ComponentPropsWithoutRef< typeof _Select.Portal >;
+import type { PortalProps } from './types';
 
 /**
  * Root element that portals `Select` listbox content. Pass to

--- a/packages/ui/src/form/primitives/select/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/select/test/index.test.tsx
@@ -31,8 +31,8 @@ describe( 'Select', () => {
 		expect( itemRef.current ).toBeInstanceOf( HTMLDivElement );
 	} );
 
-	describe( 'container', () => {
-		it( 'should render inside the container when provided', async () => {
+	describe( 'portal', () => {
+		it( 'should render inside the portal container when a custom target is provided', async () => {
 			const user = userEvent.setup();
 			const containerRef = createRef< HTMLDivElement >();
 
@@ -44,7 +44,11 @@ describe( 'Select', () => {
 							ref={ containerRef }
 							data-testid="custom-container"
 						/>
-						<Select.Popup container={ containerRef }>
+						<Select.Popup
+							portal={
+								<Select.Portal container={ containerRef } />
+							}
+						>
 							<Select.Item value="Item 1" />
 						</Select.Popup>
 					</Select.Root>

--- a/packages/ui/src/form/primitives/select/types.ts
+++ b/packages/ui/src/form/primitives/select/types.ts
@@ -1,6 +1,9 @@
 import type { Select as _Select } from '@base-ui/react/select';
+import type { ReactElement } from 'react';
+
 import type { ComponentProps } from '../../../utils/types';
 import type { InputLayoutProps } from '../input-layout/types';
+import type { PortalProps } from './portal';
 
 // The second type parameter is the `multiple` flag (currently disabled).
 export type SelectRootProps = Omit<
@@ -34,9 +37,11 @@ export type SelectPopupProps = ComponentProps< typeof _Select.Popup > & {
 	 */
 	children?: React.ReactNode;
 	/**
-	 * A parent element to render the portal into.
+	 * Optional portal element, typically `<Select.Portal />` with custom
+	 * `container`. When omitted, `Select.Popup` uses `Select.Portal` with
+	 * default props.
 	 */
-	container?: _Select.Portal.Props[ 'container' ];
+	portal?: ReactElement< PortalProps >;
 };
 
 export type SelectItemProps = Omit<

--- a/packages/ui/src/form/primitives/select/types.ts
+++ b/packages/ui/src/form/primitives/select/types.ts
@@ -1,9 +1,10 @@
 import type { Select as _Select } from '@base-ui/react/select';
-import type { ReactElement } from 'react';
+import type { ComponentPropsWithoutRef, ReactElement } from 'react';
 
 import type { ComponentProps } from '../../../utils/types';
 import type { InputLayoutProps } from '../input-layout/types';
-import type { PortalProps } from './portal';
+
+export type PortalProps = ComponentPropsWithoutRef< typeof _Select.Portal >;
 
 // The second type parameter is the `multiple` flag (currently disabled).
 export type SelectRootProps = Omit<

--- a/packages/ui/src/form/primitives/select/types.ts
+++ b/packages/ui/src/form/primitives/select/types.ts
@@ -39,9 +39,10 @@ export type SelectPopupProps = ComponentProps< typeof _Select.Popup > & {
 	/**
 	 * Optional portal element, typically `<Select.Portal />` with custom
 	 * `container`. When omitted, `Select.Popup` uses `Select.Portal` with
-	 * default props.
+	 * default props. Do not pass `children` on the portal element; they would
+	 * be ignored.
 	 */
-	portal?: ReactElement< PortalProps >;
+	portal?: ReactElement< Omit< PortalProps, 'children' > >;
 };
 
 export type SelectItemProps = Omit<

--- a/packages/ui/src/popover/index.ts
+++ b/packages/ui/src/popover/index.ts
@@ -7,5 +7,4 @@ import { Root } from './root';
 import { Title } from './title';
 import { Trigger } from './trigger';
 
-export type { PortalProps } from './types';
 export { Arrow, Close, Description, Portal, Popup, Root, Title, Trigger };

--- a/packages/ui/src/popover/index.ts
+++ b/packages/ui/src/popover/index.ts
@@ -7,5 +7,5 @@ import { Root } from './root';
 import { Title } from './title';
 import { Trigger } from './trigger';
 
-export type { PortalProps } from './portal';
+export type { PortalProps } from './types';
 export { Arrow, Close, Description, Portal, Popup, Root, Title, Trigger };

--- a/packages/ui/src/popover/index.ts
+++ b/packages/ui/src/popover/index.ts
@@ -2,8 +2,10 @@ import { Arrow } from './arrow';
 import { Close } from './close';
 import { Description } from './description';
 import { Popup } from './popup';
+import { Portal } from './portal';
 import { Root } from './root';
 import { Title } from './title';
 import { Trigger } from './trigger';
 
-export { Arrow, Close, Description, Popup, Root, Title, Trigger };
+export type { PortalProps } from './portal';
+export { Arrow, Close, Description, Portal, Popup, Root, Title, Trigger };

--- a/packages/ui/src/popover/popup.tsx
+++ b/packages/ui/src/popover/popup.tsx
@@ -1,6 +1,6 @@
 import { Popover as _Popover } from '@base-ui/react/popover';
 import clsx from 'clsx';
-import { cloneElement, forwardRef, isValidElement } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 import {
 	type ThemeProvider as ThemeProviderType,
@@ -9,6 +9,7 @@ import {
 import { unlock } from '../lock-unlock';
 import resetStyles from '../utils/css/resets.module.css';
 import { useDeprioritizedInitialFocus } from '../utils/use-deprioritized-initial-focus';
+import { renderPortalChildren } from '../utils/render-portal-children';
 import { PopoverValidationProvider } from './context';
 import { Portal } from './portal';
 import styles from './style.module.css';
@@ -100,7 +101,6 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function PopoverPopup(
 		</_Popover.Positioner>
 	);
 
-	const rootPortal = portal ?? <Portal />;
 	const portalChildren = (
 		<>
 			{ backdropElement }
@@ -108,11 +108,7 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function PopoverPopup(
 		</>
 	);
 
-	if ( isValidElement( rootPortal ) ) {
-		return cloneElement( rootPortal, { children: portalChildren } );
-	}
-
-	return <Portal>{ portalChildren }</Portal>;
+	return renderPortalChildren( portal, <Portal />, portalChildren );
 } );
 
 export { Popup };

--- a/packages/ui/src/popover/popup.tsx
+++ b/packages/ui/src/popover/popup.tsx
@@ -9,7 +9,7 @@ import {
 import { unlock } from '../lock-unlock';
 import resetStyles from '../utils/css/resets.module.css';
 import { useDeprioritizedInitialFocus } from '../utils/use-deprioritized-initial-focus';
-import { renderPortalChildren } from '../utils/render-portal-children';
+import { renderPortalWithChildren } from '../utils/render-portal-with-children';
 import { PopoverValidationProvider } from './context';
 import { Portal } from './portal';
 import styles from './style.module.css';
@@ -108,7 +108,7 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function PopoverPopup(
 		</>
 	);
 
-	return renderPortalChildren( portal, <Portal />, portalChildren );
+	return renderPortalWithChildren( portal, <Portal />, portalChildren );
 } );
 
 export { Popup };

--- a/packages/ui/src/popover/popup.tsx
+++ b/packages/ui/src/popover/popup.tsx
@@ -1,6 +1,6 @@
 import { Popover as _Popover } from '@base-ui/react/popover';
 import clsx from 'clsx';
-import { forwardRef } from '@wordpress/element';
+import { cloneElement, forwardRef, isValidElement } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 import {
 	type ThemeProvider as ThemeProviderType,
@@ -10,6 +10,7 @@ import { unlock } from '../lock-unlock';
 import resetStyles from '../utils/css/resets.module.css';
 import { useDeprioritizedInitialFocus } from '../utils/use-deprioritized-initial-focus';
 import { PopoverValidationProvider } from './context';
+import { Portal } from './portal';
 import styles from './style.module.css';
 import type { PopupProps } from './types';
 
@@ -22,8 +23,9 @@ const CLOSE_ATTR = 'data-wp-ui-popover-close';
  * Renders the floating popup container for the popover content.
  *
  * Handles portal rendering, positioning relative to the anchor, collision
- * avoidance, focus management, and optional backdrop. Supply a `container`
- * element for cross-document scenarios such as iframes.
+ * avoidance, focus management, and optional backdrop. Use
+ * `portal={ <Popover.Portal container={ ... } /> }` for cross-document
+ * scenarios such as iframes.
  */
 const Popup = forwardRef< HTMLDivElement, PopupProps >( function PopoverPopup(
 	{
@@ -38,7 +40,7 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function PopoverPopup(
 		collisionAvoidance,
 		collisionBoundary,
 		collisionPadding,
-		container,
+		portal,
 		finalFocus,
 		initialFocus,
 		side = 'bottom',
@@ -98,12 +100,19 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function PopoverPopup(
 		</_Popover.Positioner>
 	);
 
-	return (
-		<_Popover.Portal container={ container }>
+	const rootPortal = portal ?? <Portal />;
+	const portalChildren = (
+		<>
 			{ backdropElement }
 			{ positioner }
-		</_Popover.Portal>
+		</>
 	);
+
+	if ( isValidElement( rootPortal ) ) {
+		return cloneElement( rootPortal, { children: portalChildren } );
+	}
+
+	return <Portal>{ portalChildren }</Portal>;
 } );
 
 export { Popup };

--- a/packages/ui/src/popover/portal.tsx
+++ b/packages/ui/src/popover/portal.tsx
@@ -1,0 +1,19 @@
+import { Popover as _Popover } from '@base-ui/react/popover';
+import { forwardRef } from '@wordpress/element';
+import type { ComponentPropsWithoutRef } from 'react';
+
+export type PortalProps = ComponentPropsWithoutRef< typeof _Popover.Portal >;
+
+/**
+ * Root element that portals `Popover` floating content. Pass to
+ * `Popover.Popup`'s `portal` prop (for example `container` for
+ * cross-document rendering). When `portal` is omitted, `Popover.Popup` uses
+ * this component with default props.
+ */
+const Portal = forwardRef< HTMLDivElement, PortalProps >(
+	function PopoverPortal( props, ref ) {
+		return <_Popover.Portal ref={ ref } { ...props } />;
+	}
+);
+
+export { Portal };

--- a/packages/ui/src/popover/portal.tsx
+++ b/packages/ui/src/popover/portal.tsx
@@ -1,8 +1,6 @@
 import { Popover as _Popover } from '@base-ui/react/popover';
 import { forwardRef } from '@wordpress/element';
-import type { ComponentPropsWithoutRef } from 'react';
-
-export type PortalProps = ComponentPropsWithoutRef< typeof _Popover.Portal >;
+import type { PortalProps } from './types';
 
 /**
  * Root element that portals `Popover` floating content. Pass to

--- a/packages/ui/src/popover/root.tsx
+++ b/packages/ui/src/popover/root.tsx
@@ -12,8 +12,8 @@ import type { RootProps } from './types';
  *
  * - `Popover.Root` — provides open state and context to all sub-components.
  * - `Popover.Trigger` — the button that toggles the popup.
- * - `Popover.Popup` — the floating container (portal, positioning, collision
- *   avoidance).
+ * - `Popover.Popup` — the floating container (positioning, collision
+ *   avoidance); portals by default or via `portal={ <Popover.Portal /> }`.
  * - `Popover.Arrow` — an optional arrow pointing toward the anchor.
  * - `Popover.Title` — **required** heading that labels the popover for
  *   accessibility (can be visually hidden).

--- a/packages/ui/src/popover/stories/index.story.tsx
+++ b/packages/ui/src/popover/stories/index.story.tsx
@@ -13,6 +13,7 @@ const meta: Meta< typeof Popover.Root > = {
 	component: Popover.Root,
 	subcomponents: {
 		'Popover.Trigger': Popover.Trigger,
+		'Popover.Portal': Popover.Portal,
 		'Popover.Popup': Popover.Popup,
 		'Popover.Arrow': Popover.Arrow,
 		'Popover.Title': Popover.Title,
@@ -443,10 +444,11 @@ export const OverlayPlacement: Story = {
 };
 
 /**
- * To render the popup inline (without a portal), create a local ref to a
- * `<span>` with `display: contents` and pass it as the `container` prop.
- * The popup will render inside the span rather than being portaled to
- * `document.body`, while retaining all positioning behavior.
+ * To keep the floating layer **in page flow** next to surrounding layout,
+ * create a local ref to a `<span>` with `display: contents` and pass
+ * `portal={ <Popover.Portal container={ ref } /> }`. The popup still uses a
+ * portal, but the portal **mounts** into that subtree instead of
+ * `document.body`, while retaining positioning behavior.
  *
  * **Note:** `backdrop` will not cover the full viewport in this mode.
  */
@@ -463,7 +465,11 @@ export const Inline: Story = {
 						ref={ inlineContainerRef }
 						style={ { display: 'contents' } }
 					/>
-					<Popover.Popup container={ inlineContainerRef }>
+					<Popover.Popup
+						portal={
+							<Popover.Portal container={ inlineContainerRef } />
+						}
+					>
 						<Popover.Arrow />
 						<Popover.Title
 							style={ {
@@ -473,8 +479,10 @@ export const Inline: Story = {
 							Inline Popover
 						</Popover.Title>
 						<Popover.Description>
-							This popup is rendered in place — no portal is used.
-							Inspect the DOM to see it lives inside its parent.
+							This example still uses `Popover.Portal`, but the
+							portal `container` is the in-tree span above, so the
+							portal node mounts inside the wrapper instead of
+							`document.body`.
 						</Popover.Description>
 					</Popover.Popup>
 				</Popover.Root>
@@ -624,8 +632,12 @@ export const CrossIframe: Story = {
 									Popover&apos;s anchor (inside iframe)
 								</Popover.Trigger>
 								<Popover.Popup
-									container={
-										portalContainerRef as React.RefObject< HTMLElement >
+									portal={
+										<Popover.Portal
+											container={
+												portalContainerRef as React.RefObject< HTMLElement >
+											}
+										/>
 									}
 									collisionBoundary={
 										iframeBoundary ?? undefined
@@ -661,9 +673,9 @@ export const CrossIframe: Story = {
  * `@wordpress/components` as the render target.
  *
  * The `Slot` renders a `div` in the parent document, and its forwarded ref
- * is passed to `Popover.Popup`'s `container` prop so the popup portals into
- * the slot element. This mirrors the legacy Popover's `WithSlotOutsideIframe`
- * pattern.
+ * is passed to `Popover.Portal`'s `container` prop (via `Popover.Popup`'s
+ * `portal` prop) so the popup portals into the slot element. This mirrors the
+ * legacy Popover's `WithSlotOutsideIframe` pattern.
  */
 export const CrossIframeWithSlotFill: Story = {
 	name: 'Cross-Iframe (SlotFill)',
@@ -713,8 +725,12 @@ export const CrossIframeWithSlotFill: Story = {
 									Popover&apos;s anchor (inside iframe)
 								</Popover.Trigger>
 								<Popover.Popup
-									container={
-										slotRef as React.RefObject< HTMLElement >
+									portal={
+										<Popover.Portal
+											container={
+												slotRef as React.RefObject< HTMLElement >
+											}
+										/>
 									}
 									collisionBoundary={
 										iframeBoundary ?? undefined

--- a/packages/ui/src/popover/stories/index.story.tsx
+++ b/packages/ui/src/popover/stories/index.story.tsx
@@ -580,8 +580,8 @@ export const CollisionAvoidance: Story = {
 
 /**
  * When the popover's trigger lives inside an iframe but the popover should
- * render in the parent document, pass a parent-document element to the
- * `container` prop on `Popover.Popup`.
+ * render in the parent document, pass a parent-document element through
+ * `portal={ <Popover.Portal container={ ... } /> }` on `Popover.Popup`.
  *
  * This technique is used in Gutenberg where the block editor canvas is an
  * iframe but toolbars and menus must appear outside it.

--- a/packages/ui/src/popover/stories/index.story.tsx
+++ b/packages/ui/src/popover/stories/index.story.tsx
@@ -12,6 +12,7 @@ const meta: Meta< typeof Popover.Root > = {
 	component: Popover.Root,
 	subcomponents: {
 		'Popover.Trigger': Popover.Trigger,
+		'Popover.Portal': Popover.Portal,
 		'Popover.Popup': Popover.Popup,
 		'Popover.Arrow': Popover.Arrow,
 		'Popover.Title': Popover.Title,
@@ -442,10 +443,11 @@ export const OverlayPlacement: Story = {
 };
 
 /**
- * To render the popup inline (without a portal), create a local ref to a
- * `<span>` with `display: contents` and pass it as the `container` prop.
- * The popup will render inside the span rather than being portaled to
- * `document.body`, while retaining all positioning behavior.
+ * To keep the floating layer **in page flow** next to surrounding layout,
+ * create a local ref to a `<span>` with `display: contents` and pass
+ * `portal={ <Popover.Portal container={ ref } /> }`. The popup still uses a
+ * portal, but the portal **mounts** into that subtree instead of
+ * `document.body`, while retaining positioning behavior.
  *
  * **Note:** `backdrop` will not cover the full viewport in this mode.
  */
@@ -462,7 +464,11 @@ export const Inline: Story = {
 						ref={ inlineContainerRef }
 						style={ { display: 'contents' } }
 					/>
-					<Popover.Popup container={ inlineContainerRef }>
+					<Popover.Popup
+						portal={
+							<Popover.Portal container={ inlineContainerRef } />
+						}
+					>
 						<Popover.Arrow />
 						<Popover.Title
 							style={ {
@@ -472,8 +478,10 @@ export const Inline: Story = {
 							Inline Popover
 						</Popover.Title>
 						<Popover.Description>
-							This popup is rendered in place — no portal is used.
-							Inspect the DOM to see it lives inside its parent.
+							This example still uses `Popover.Portal`, but the
+							portal `container` is the in-tree span above, so the
+							portal node mounts inside the wrapper instead of
+							`document.body`.
 						</Popover.Description>
 					</Popover.Popup>
 				</Popover.Root>
@@ -623,8 +631,12 @@ export const CrossIframe: Story = {
 									Popover&apos;s anchor (inside iframe)
 								</Popover.Trigger>
 								<Popover.Popup
-									container={
-										portalContainerRef as React.RefObject< HTMLElement >
+									portal={
+										<Popover.Portal
+											container={
+												portalContainerRef as React.RefObject< HTMLElement >
+											}
+										/>
 									}
 									collisionBoundary={
 										iframeBoundary ?? undefined
@@ -660,9 +672,9 @@ export const CrossIframe: Story = {
  * `@wordpress/components` as the render target.
  *
  * The `Slot` renders a `div` in the parent document, and its forwarded ref
- * is passed to `Popover.Popup`'s `container` prop so the popup portals into
- * the slot element. This mirrors the legacy Popover's `WithSlotOutsideIframe`
- * pattern.
+ * is passed to `Popover.Portal`'s `container` prop (via `Popover.Popup`'s
+ * `portal` prop) so the popup portals into the slot element. This mirrors the
+ * legacy Popover's `WithSlotOutsideIframe` pattern.
  */
 export const CrossIframeWithSlotFill: Story = {
 	name: 'Cross-Iframe (SlotFill)',
@@ -712,8 +724,12 @@ export const CrossIframeWithSlotFill: Story = {
 									Popover&apos;s anchor (inside iframe)
 								</Popover.Trigger>
 								<Popover.Popup
-									container={
-										slotRef as React.RefObject< HTMLElement >
+									portal={
+										<Popover.Portal
+											container={
+												slotRef as React.RefObject< HTMLElement >
+											}
+										/>
 									}
 									collisionBoundary={
 										iframeBoundary ?? undefined

--- a/packages/ui/src/popover/test/index.test.tsx
+++ b/packages/ui/src/popover/test/index.test.tsx
@@ -447,9 +447,7 @@ describe( 'Popover', () => {
 						/>
 						<Popover.Popup
 							portal={
-								<Popover.Portal
-									container={ containerRef }
-								/>
+								<Popover.Portal container={ containerRef } />
 							}
 						>
 							<Popover.Title>Title</Popover.Title>

--- a/packages/ui/src/popover/test/index.test.tsx
+++ b/packages/ui/src/popover/test/index.test.tsx
@@ -434,7 +434,7 @@ describe( 'Popover', () => {
 		} );
 	} );
 
-	describe( 'inline (via container)', () => {
+	describe( 'inline via portal (custom container)', () => {
 		function InlinePopover() {
 			const containerRef = createRef< HTMLSpanElement >();
 			return (
@@ -445,7 +445,13 @@ describe( 'Popover', () => {
 							ref={ containerRef }
 							style={ { display: 'contents' } }
 						/>
-						<Popover.Popup container={ containerRef }>
+						<Popover.Popup
+							portal={
+								<Popover.Portal
+									container={ containerRef }
+								/>
+							}
+						>
 							<Popover.Title>Title</Popover.Title>
 							Inline content
 						</Popover.Popup>
@@ -454,7 +460,7 @@ describe( 'Popover', () => {
 			);
 		}
 
-		it( 'should render inside the container when a local ref is used', async () => {
+		it( 'should render inside the portal container when a local ref is used', async () => {
 			const user = userEvent.setup();
 
 			render( <InlinePopover /> );

--- a/packages/ui/src/popover/types.ts
+++ b/packages/ui/src/popover/types.ts
@@ -1,6 +1,8 @@
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import type { Popover as _Popover } from '@base-ui/react/popover';
+
 import type { ComponentProps } from '../utils/types';
+import type { PortalProps } from './portal';
 
 export interface RootProps
 	extends Pick<
@@ -64,12 +66,13 @@ export interface PopupProps
 	children?: ReactNode;
 
 	/**
-	 * A parent element to render the portal into.
+	 * Optional portal element, typically `<Popover.Portal />` with custom
+	 * `container` for cross-document rendering. Floating content is rendered
+	 * as this portal's children.
 	 *
-	 * Useful for cross-document rendering, such as rendering a popover
-	 * in a parent document when the trigger is inside an iframe.
+	 * When omitted, `Popover.Popup` uses `Popover.Portal` with default props.
 	 */
-	container?: _Popover.Portal.Props[ 'container' ];
+	portal?: ReactElement< PortalProps >;
 
 	/**
 	 * The visual style variant of the popup.

--- a/packages/ui/src/popover/types.ts
+++ b/packages/ui/src/popover/types.ts
@@ -1,8 +1,9 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ReactElement, ReactNode } from 'react';
 import type { Popover as _Popover } from '@base-ui/react/popover';
 
 import type { ComponentProps } from '../utils/types';
-import type { PortalProps } from './portal';
+
+export type PortalProps = ComponentPropsWithoutRef< typeof _Popover.Portal >;
 
 export interface RootProps
 	extends Pick<

--- a/packages/ui/src/popover/types.ts
+++ b/packages/ui/src/popover/types.ts
@@ -68,11 +68,12 @@ export interface PopupProps
 	/**
 	 * Optional portal element, typically `<Popover.Portal />` with custom
 	 * `container` for cross-document rendering. Floating content is rendered
-	 * as this portal's children.
+	 * as this portal's children (do not pass `children` on the portal element;
+	 * they would be ignored).
 	 *
 	 * When omitted, `Popover.Popup` uses `Popover.Portal` with default props.
 	 */
-	portal?: ReactElement< PortalProps >;
+	portal?: ReactElement< Omit< PortalProps, 'children' > >;
 
 	/**
 	 * The visual style variant of the popup.

--- a/packages/ui/src/tooltip/index.ts
+++ b/packages/ui/src/tooltip/index.ts
@@ -4,5 +4,4 @@ import { Trigger } from './trigger';
 import { Root } from './root';
 import { Provider } from './provider';
 
-export type { PortalProps } from './types';
 export { Provider, Root, Trigger, Popup, Portal };

--- a/packages/ui/src/tooltip/index.ts
+++ b/packages/ui/src/tooltip/index.ts
@@ -1,6 +1,8 @@
 import { Popup } from './popup';
+import { Portal } from './portal';
 import { Trigger } from './trigger';
 import { Root } from './root';
 import { Provider } from './provider';
 
-export { Provider, Root, Trigger, Popup };
+export type { PortalProps } from './portal';
+export { Provider, Root, Trigger, Popup, Portal };

--- a/packages/ui/src/tooltip/index.ts
+++ b/packages/ui/src/tooltip/index.ts
@@ -4,5 +4,5 @@ import { Trigger } from './trigger';
 import { Root } from './root';
 import { Provider } from './provider';
 
-export type { PortalProps } from './portal';
+export type { PortalProps } from './types';
 export { Provider, Root, Trigger, Popup, Portal };

--- a/packages/ui/src/tooltip/popup.tsx
+++ b/packages/ui/src/tooltip/popup.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { Tooltip } from '@base-ui/react/tooltip';
+import { Tooltip as _Tooltip } from '@base-ui/react/tooltip';
 import { forwardRef } from '@wordpress/element';
 import {
 	type ThemeProvider as ThemeProviderType,
@@ -29,7 +29,7 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function TooltipPopup(
 	ref
 ) {
 	const portalChildren = (
-		<Tooltip.Positioner
+		<_Tooltip.Positioner
 			align={ align }
 			side={ side }
 			sideOffset={ sideOffset }
@@ -50,15 +50,15 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function TooltipPopup(
 				  - remove the hardcoded `bg` setting from the `ThemeProvider` below
 					*/ }
 			<ThemeProvider color={ { bg: '#1e1e1e' } }>
-				<Tooltip.Popup
+				<_Tooltip.Popup
 					ref={ ref }
 					className={ styles.popup }
 					{ ...props }
 				>
 					{ children }
-				</Tooltip.Popup>
+				</_Tooltip.Popup>
 			</ThemeProvider>
-		</Tooltip.Positioner>
+		</_Tooltip.Positioner>
 	);
 
 	return renderPortalWithChildren( portal, <Portal />, portalChildren );

--- a/packages/ui/src/tooltip/popup.tsx
+++ b/packages/ui/src/tooltip/popup.tsx
@@ -8,7 +8,7 @@ import {
 import type { PopupProps } from './types';
 import { unlock } from '../lock-unlock';
 import { Portal } from './portal';
-import { renderPortalChildren } from '../utils/render-portal-children';
+import { renderPortalWithChildren } from '../utils/render-portal-with-children';
 import resetStyles from '../utils/css/resets.module.css';
 import styles from './style.module.css';
 
@@ -61,7 +61,7 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function TooltipPopup(
 		</Tooltip.Positioner>
 	);
 
-	return renderPortalChildren( portal, <Portal />, portalChildren );
+	return renderPortalWithChildren( portal, <Portal />, portalChildren );
 } );
 
 export { Popup };

--- a/packages/ui/src/tooltip/popup.tsx
+++ b/packages/ui/src/tooltip/popup.tsx
@@ -1,12 +1,13 @@
 import clsx from 'clsx';
 import { Tooltip } from '@base-ui/react/tooltip';
-import { forwardRef } from '@wordpress/element';
+import { cloneElement, forwardRef, isValidElement } from '@wordpress/element';
 import {
 	type ThemeProvider as ThemeProviderType,
 	privateApis as themePrivateApis,
 } from '@wordpress/theme';
 import type { PopupProps } from './types';
 import { unlock } from '../lock-unlock';
+import { Portal } from './portal';
 import resetStyles from '../utils/css/resets.module.css';
 import styles from './style.module.css';
 
@@ -16,7 +17,7 @@ const ThemeProvider: typeof ThemeProviderType =
 const Popup = forwardRef< HTMLDivElement, PopupProps >( function TooltipPopup(
 	{
 		align = 'center',
-		container,
+		portal,
 		side = 'top',
 		sideOffset = 4,
 		children,
@@ -26,20 +27,20 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function TooltipPopup(
 	},
 	ref
 ) {
-	return (
-		<Tooltip.Portal container={ container }>
-			<Tooltip.Positioner
-				align={ align }
-				side={ side }
-				sideOffset={ sideOffset }
-				style={ style }
-				className={ clsx(
-					resetStyles[ 'box-sizing' ],
-					className,
-					styles.positioner
-				) }
-			>
-				{ /* This should ideally use whatever dark color makes sense,
+	const rootPortal = portal ?? <Portal />;
+	const portalChildren = (
+		<Tooltip.Positioner
+			align={ align }
+			side={ side }
+			sideOffset={ sideOffset }
+			style={ style }
+			className={ clsx(
+				resetStyles[ 'box-sizing' ],
+				className,
+				styles.positioner
+			) }
+		>
+			{ /* This should ideally use whatever dark color makes sense,
 				and not be hardcoded to #1e1e1e. The solutions would be to:
 				  - review the design of the tooltip, in case we want to stop
 				    hardcoding it to a dark background
@@ -48,18 +49,23 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function TooltipPopup(
 				    them;
 				  - remove the hardcoded `bg` setting from the `ThemeProvider` below
 					*/ }
-				<ThemeProvider color={ { bg: '#1e1e1e' } }>
-					<Tooltip.Popup
-						ref={ ref }
-						className={ styles.popup }
-						{ ...props }
-					>
-						{ children }
-					</Tooltip.Popup>
-				</ThemeProvider>
-			</Tooltip.Positioner>
-		</Tooltip.Portal>
+			<ThemeProvider color={ { bg: '#1e1e1e' } }>
+				<Tooltip.Popup
+					ref={ ref }
+					className={ styles.popup }
+					{ ...props }
+				>
+					{ children }
+				</Tooltip.Popup>
+			</ThemeProvider>
+		</Tooltip.Positioner>
 	);
+
+	if ( isValidElement( rootPortal ) ) {
+		return cloneElement( rootPortal, { children: portalChildren } );
+	}
+
+	return <Portal>{ portalChildren }</Portal>;
 } );
 
 export { Popup };

--- a/packages/ui/src/tooltip/popup.tsx
+++ b/packages/ui/src/tooltip/popup.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { Tooltip } from '@base-ui/react/tooltip';
-import { cloneElement, forwardRef, isValidElement } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 import {
 	type ThemeProvider as ThemeProviderType,
 	privateApis as themePrivateApis,
@@ -8,6 +8,7 @@ import {
 import type { PopupProps } from './types';
 import { unlock } from '../lock-unlock';
 import { Portal } from './portal';
+import { renderPortalChildren } from '../utils/render-portal-children';
 import resetStyles from '../utils/css/resets.module.css';
 import styles from './style.module.css';
 
@@ -27,7 +28,6 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function TooltipPopup(
 	},
 	ref
 ) {
-	const rootPortal = portal ?? <Portal />;
 	const portalChildren = (
 		<Tooltip.Positioner
 			align={ align }
@@ -61,11 +61,7 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function TooltipPopup(
 		</Tooltip.Positioner>
 	);
 
-	if ( isValidElement( rootPortal ) ) {
-		return cloneElement( rootPortal, { children: portalChildren } );
-	}
-
-	return <Portal>{ portalChildren }</Portal>;
+	return renderPortalChildren( portal, <Portal />, portalChildren );
 } );
 
 export { Popup };

--- a/packages/ui/src/tooltip/portal.tsx
+++ b/packages/ui/src/tooltip/portal.tsx
@@ -1,8 +1,6 @@
 import { Tooltip as _Tooltip } from '@base-ui/react/tooltip';
 import { forwardRef } from '@wordpress/element';
-import type { ComponentPropsWithoutRef } from 'react';
-
-export type PortalProps = ComponentPropsWithoutRef< typeof _Tooltip.Portal >;
+import type { PortalProps } from './types';
 
 /**
  * Root element that portals `Tooltip` floating content. Pass to

--- a/packages/ui/src/tooltip/portal.tsx
+++ b/packages/ui/src/tooltip/portal.tsx
@@ -1,0 +1,18 @@
+import { Tooltip } from '@base-ui/react/tooltip';
+import { forwardRef } from '@wordpress/element';
+import type { ComponentPropsWithoutRef } from 'react';
+
+export type PortalProps = ComponentPropsWithoutRef< typeof Tooltip.Portal >;
+
+/**
+ * Root element that portals `Tooltip` floating content. Pass to
+ * `Tooltip.Popup`'s `portal` prop. When `portal` is omitted, `Tooltip.Popup`
+ * uses this component with default props.
+ */
+const Portal = forwardRef< HTMLDivElement, PortalProps >(
+	function TooltipPortal( props, ref ) {
+		return <Tooltip.Portal ref={ ref } { ...props } />;
+	}
+);
+
+export { Portal };

--- a/packages/ui/src/tooltip/portal.tsx
+++ b/packages/ui/src/tooltip/portal.tsx
@@ -1,8 +1,8 @@
-import { Tooltip } from '@base-ui/react/tooltip';
+import { Tooltip as _Tooltip } from '@base-ui/react/tooltip';
 import { forwardRef } from '@wordpress/element';
 import type { ComponentPropsWithoutRef } from 'react';
 
-export type PortalProps = ComponentPropsWithoutRef< typeof Tooltip.Portal >;
+export type PortalProps = ComponentPropsWithoutRef< typeof _Tooltip.Portal >;
 
 /**
  * Root element that portals `Tooltip` floating content. Pass to
@@ -11,7 +11,7 @@ export type PortalProps = ComponentPropsWithoutRef< typeof Tooltip.Portal >;
  */
 const Portal = forwardRef< HTMLDivElement, PortalProps >(
 	function TooltipPortal( props, ref ) {
-		return <Tooltip.Portal ref={ ref } { ...props } />;
+		return <_Tooltip.Portal ref={ ref } { ...props } />;
 	}
 );
 

--- a/packages/ui/src/tooltip/provider.tsx
+++ b/packages/ui/src/tooltip/provider.tsx
@@ -1,8 +1,8 @@
-import { Tooltip } from '@base-ui/react/tooltip';
+import { Tooltip as _Tooltip } from '@base-ui/react/tooltip';
 import type { ProviderProps } from './types';
 
-function Provider( { children, ...props }: ProviderProps ) {
-	return <Tooltip.Provider { ...props }>{ children }</Tooltip.Provider>;
+function Provider( { ...props }: ProviderProps ) {
+	return <_Tooltip.Provider { ...props } />;
 }
 
 export { Provider };

--- a/packages/ui/src/tooltip/root.tsx
+++ b/packages/ui/src/tooltip/root.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from '@base-ui/react/tooltip';
+import { Tooltip as _Tooltip } from '@base-ui/react/tooltip';
 import type { RootProps } from './types';
 
 /**
@@ -15,7 +15,7 @@ import type { RootProps } from './types';
  * @see {@link https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-iconbutton--docs IconButton}
  */
 function Root( props: RootProps ) {
-	return <Tooltip.Root { ...props } />;
+	return <_Tooltip.Root { ...props } />;
 }
 
 export { Root };

--- a/packages/ui/src/tooltip/test/index.test.tsx
+++ b/packages/ui/src/tooltip/test/index.test.tsx
@@ -85,8 +85,8 @@ describe( 'Tooltip', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	describe( 'container', () => {
-		it( 'should render inside the container when provided', async () => {
+	describe( 'portal', () => {
+		it( 'should render inside the portal container when a custom target is provided', async () => {
 			const user = userEvent.setup();
 			const containerRef = createRef< HTMLDivElement >();
 
@@ -99,7 +99,13 @@ describe( 'Tooltip', () => {
 								ref={ containerRef }
 								data-testid="custom-container"
 							/>
-							<Tooltip.Popup container={ containerRef }>
+							<Tooltip.Popup
+								portal={
+									<Tooltip.Portal
+										container={ containerRef }
+									/>
+								}
+							>
 								Tooltip content
 							</Tooltip.Popup>
 						</Tooltip.Root>

--- a/packages/ui/src/tooltip/trigger.tsx
+++ b/packages/ui/src/tooltip/trigger.tsx
@@ -1,14 +1,10 @@
-import { Tooltip } from '@base-ui/react/tooltip';
+import { Tooltip as _Tooltip } from '@base-ui/react/tooltip';
 import { forwardRef } from '@wordpress/element';
 import type { TriggerProps } from './types';
 
 const Trigger = forwardRef< HTMLButtonElement, TriggerProps >(
-	function TooltipTrigger( { children, ...props }, ref ) {
-		return (
-			<Tooltip.Trigger ref={ ref } { ...props }>
-				{ children }
-			</Tooltip.Trigger>
-		);
+	function TooltipTrigger( props, ref ) {
+		return <_Tooltip.Trigger ref={ ref } { ...props } />;
 	}
 );
 

--- a/packages/ui/src/tooltip/types.ts
+++ b/packages/ui/src/tooltip/types.ts
@@ -29,7 +29,8 @@ export interface PopupProps
 	/**
 	 * Optional portal element, typically `<Tooltip.Portal />` with custom
 	 * `container`. When omitted, `Tooltip.Popup` uses `Tooltip.Portal` with
-	 * default props.
+	 * default props. Do not pass `children` on the portal element; they would
+	 * be ignored.
 	 */
-	portal?: ReactElement< PortalProps >;
+	portal?: ReactElement< Omit< PortalProps, 'children' > >;
 }

--- a/packages/ui/src/tooltip/types.ts
+++ b/packages/ui/src/tooltip/types.ts
@@ -1,13 +1,13 @@
 import type { ReactElement, ReactNode } from 'react';
-import type { Tooltip } from '@base-ui/react/tooltip';
+import type { Tooltip as _Tooltip } from '@base-ui/react/tooltip';
 
 import type { ComponentProps } from '../utils/types';
 import type { PortalProps } from './portal';
 
-export type RootProps = Pick< Tooltip.Root.Props, 'disabled' | 'children' >;
+export type RootProps = Pick< _Tooltip.Root.Props, 'disabled' | 'children' >;
 
 export type ProviderProps = Pick<
-	Tooltip.Provider.Props,
+	_Tooltip.Provider.Props,
 	'delay' | 'children'
 >;
 
@@ -20,7 +20,7 @@ export interface TriggerProps extends ComponentProps< 'button' > {
 
 export interface PopupProps
 	extends ComponentProps< 'div' >,
-		Pick< Tooltip.Positioner.Props, 'align' | 'side' | 'sideOffset' > {
+		Pick< _Tooltip.Positioner.Props, 'align' | 'side' | 'sideOffset' > {
 	/**
 	 * The content to be rendered inside the component.
 	 */

--- a/packages/ui/src/tooltip/types.ts
+++ b/packages/ui/src/tooltip/types.ts
@@ -1,6 +1,8 @@
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import type { Tooltip } from '@base-ui/react/tooltip';
+
 import type { ComponentProps } from '../utils/types';
+import type { PortalProps } from './portal';
 
 export type RootProps = Pick< Tooltip.Root.Props, 'disabled' | 'children' >;
 
@@ -25,7 +27,9 @@ export interface PopupProps
 	children?: ReactNode;
 
 	/**
-	 * A parent element to render the portal into.
+	 * Optional portal element, typically `<Tooltip.Portal />` with custom
+	 * `container`. When omitted, `Tooltip.Popup` uses `Tooltip.Portal` with
+	 * default props.
 	 */
-	container?: Tooltip.Portal.Props[ 'container' ];
+	portal?: ReactElement< PortalProps >;
 }

--- a/packages/ui/src/tooltip/types.ts
+++ b/packages/ui/src/tooltip/types.ts
@@ -1,8 +1,9 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ReactElement, ReactNode } from 'react';
 import type { Tooltip as _Tooltip } from '@base-ui/react/tooltip';
 
 import type { ComponentProps } from '../utils/types';
-import type { PortalProps } from './portal';
+
+export type PortalProps = ComponentPropsWithoutRef< typeof _Tooltip.Portal >;
 
 export type RootProps = Pick< _Tooltip.Root.Props, 'disabled' | 'children' >;
 

--- a/packages/ui/src/utils/render-portal-children.ts
+++ b/packages/ui/src/utils/render-portal-children.ts
@@ -1,0 +1,26 @@
+import { cloneElement, isValidElement } from '@wordpress/element';
+import type { ReactElement, ReactNode } from 'react';
+
+/**
+ * Renders overlay markup (`children`) through an optional `portal` element from
+ * `portal={ <Component.Portal … /> }`, or through the package default portal.
+ *
+ * Shared by overlay `Popup` components so portal merge behavior stays consistent.
+ *
+ * @param portal        Optional element from the `portal` prop; when omitted, `defaultPortal` is used.
+ * @param defaultPortal Unpopulated default portal element (e.g. `<Dialog.Portal />`).
+ * @param children      Popup subtree (backdrop, positioner, etc.) to inject as the portal’s children.
+ */
+export function renderPortalChildren(
+	portal: ReactElement | undefined,
+	defaultPortal: ReactElement,
+	children: ReactNode
+): ReactElement {
+	const rootPortal = portal ?? defaultPortal;
+
+	if ( isValidElement( rootPortal ) ) {
+		return cloneElement( rootPortal, { children } );
+	}
+
+	return cloneElement( defaultPortal, { children } );
+}

--- a/packages/ui/src/utils/render-portal-children.ts
+++ b/packages/ui/src/utils/render-portal-children.ts
@@ -13,7 +13,10 @@ type PortalMountElement = ReactElement< { children?: ReactNode } >;
  *
  * Shared by overlay `Popup` components so portal merge behavior stays consistent.
  *
- * @param portal        Optional element from the `portal` prop; when omitted, `defaultPortal` is used.
+ * @param portal        Optional element from the `portal` prop (should have no
+ *                      `children`; callers type this via `Omit<PortalProps,'children'>`).
+ *                      When omitted, `defaultPortal` is used. Injected `children`
+ *                      replace any subtree on the portal element.
  * @param defaultPortal Unpopulated default portal element (e.g. `<Dialog.Portal />`).
  * @param children      Popup subtree (backdrop, positioner, etc.) to inject as the portal’s children.
  */

--- a/packages/ui/src/utils/render-portal-children.ts
+++ b/packages/ui/src/utils/render-portal-children.ts
@@ -2,6 +2,12 @@ import { cloneElement, isValidElement } from '@wordpress/element';
 import type { ReactElement, ReactNode } from 'react';
 
 /**
+ * Portal elements accept injected children; widen `ReactElement` so `cloneElement`
+ * props are not inferred as `unknown` (which breaks package TypeScript builds).
+ */
+type PortalMountElement = ReactElement< { children?: ReactNode } >;
+
+/**
  * Renders overlay markup (`children`) through an optional `portal` element from
  * `portal={ <Component.Portal … /> }`, or through the package default portal.
  *
@@ -19,8 +25,12 @@ export function renderPortalChildren(
 	const rootPortal = portal ?? defaultPortal;
 
 	if ( isValidElement( rootPortal ) ) {
-		return cloneElement( rootPortal, { children } );
+		return cloneElement( rootPortal as PortalMountElement, {
+			children,
+		} );
 	}
 
-	return cloneElement( defaultPortal, { children } );
+	return cloneElement( defaultPortal as PortalMountElement, {
+		children,
+	} );
 }

--- a/packages/ui/src/utils/render-portal-with-children.ts
+++ b/packages/ui/src/utils/render-portal-with-children.ts
@@ -20,7 +20,7 @@ type PortalMountElement = ReactElement< { children?: ReactNode } >;
  * @param defaultPortal Unpopulated default portal element (e.g. `<Dialog.Portal />`).
  * @param children      Popup subtree (backdrop, positioner, etc.) to inject as the portal’s children.
  */
-export function renderPortalChildren(
+export function renderPortalWithChildren(
 	portal: ReactElement | undefined,
 	defaultPortal: ReactElement,
 	children: ReactNode

--- a/packages/ui/src/utils/render-portal-with-children.ts
+++ b/packages/ui/src/utils/render-portal-with-children.ts
@@ -1,4 +1,4 @@
-import { cloneElement, isValidElement } from '@wordpress/element';
+import { cloneElement } from '@wordpress/element';
 import type { ReactElement, ReactNode } from 'react';
 
 /**
@@ -27,13 +27,7 @@ export function renderPortalWithChildren(
 ): ReactElement {
 	const rootPortal = portal ?? defaultPortal;
 
-	if ( isValidElement( rootPortal ) ) {
-		return cloneElement( rootPortal as PortalMountElement, {
-			children,
-		} );
-	}
-
-	return cloneElement( defaultPortal as PortalMountElement, {
+	return cloneElement( rootPortal as PortalMountElement, {
 		children,
 	} );
 }

--- a/packages/ui/src/utils/render-portal-with-children.ts
+++ b/packages/ui/src/utils/render-portal-with-children.ts
@@ -2,12 +2,6 @@ import { cloneElement } from '@wordpress/element';
 import type { ReactElement, ReactNode } from 'react';
 
 /**
- * Portal elements accept injected children; widen `ReactElement` so `cloneElement`
- * props are not inferred as `unknown` (which breaks package TypeScript builds).
- */
-type PortalMountElement = ReactElement< { children?: ReactNode } >;
-
-/**
  * Renders overlay markup (`children`) through an optional `portal` element from
  * `portal={ <Component.Portal … /> }`, or through the package default portal.
  *
@@ -27,7 +21,7 @@ export function renderPortalWithChildren(
 ): ReactElement {
 	const rootPortal = portal ?? defaultPortal;
 
-	return cloneElement( rootPortal as PortalMountElement, {
+	return cloneElement( rootPortal, {
 		children,
 	} );
 }


### PR DESCRIPTION
Follow-up to [#76837 (comment)](https://github.com/WordPress/gutenberg/pull/76837#discussion_r3086772091).

## What?

Adds an optional **`portal`** prop on overlay **`Popup`** components in **`@wordpress/ui`**, plus exported **`Portal`** subcomponents, so callers can pass portal options (`container`, `className`, `style`, …) on `Portal` instead of growing ad hoc props on `Popup`. When **`portal`** is omitted, the default Base UI portal is used.

Covers **`Dialog`**, **`AlertDialog`**, **`Popover`**, **`Tooltip`**, and **`Select`**.

## Why?

Aligns with Mirka's suggestion: compose `portal={ <Dialog.Portal className="…" /> }` rather than forwarding portal-only props through `Popup`.

## How?

<details>
<summary>Details</summary>

- Each overlay **`Popup`** resolves `const rootPortal = portal ?? <Portal />`, builds `portalChildren`, then uses **`cloneElement( rootPortal, { children: portalChildren } )`** when `rootPortal` is a valid element (otherwise falls back to `<Portal>{ portalChildren }</Portal>`). The pattern is intentionally mirrored per component family rather than a shared cross-package helper.
- **`forwardRef`** `portal.tsx` files wrap Base UI `Portal` per family; **`index.ts`** exports `Portal` alongside existing subcomponents.

</details>

<details>
<summary>Migration</summary>

| Component | Removed from `Popup` | Use instead |
|-----------|----------------------|-------------|
| `Dialog` / `AlertDialog` | `container`, `portalClassName` | `portal={ <Dialog.Portal … /> }` |
| `Popover` / `Tooltip` / `Select` | `container` | `portal={ <X.Portal … /> }` |

</details>

## Testing Instructions

1. `npm install` if needed, then `npm run build` so generated packages (e.g. icons) exist.
2. `npm run test:unit -- packages/ui/src/dialog/test packages/ui/src/popover/test packages/ui/src/tooltip/test packages/ui/src/form/primitives/select/test`

### Testing Instructions for Keyboard

No intentional behavior change beyond DOM mount target; run the same unit suites above and spot-check a `Dialog` / `Popover` story in Storybook if desired.

## Screenshots or screencast

Not applicable (API / composition only).

## Use of AI Tools

Developed with assistance from **Cursor**; author reviewed the final diff.
