### PR TITLE
Migrate text component to UI package for block editor control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58190,6 +58190,7 @@
 				"@wordpress/rich-text": "file:../rich-text",
 				"@wordpress/style-engine": "file:../style-engine",
 				"@wordpress/token-list": "file:../token-list",
+				"@wordpress/ui": "file:../ui",
 				"@wordpress/upload-media": "file:../upload-media",
 				"@wordpress/url": "file:../url",
 				"@wordpress/warning": "file:../warning",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -93,6 +93,7 @@
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/style-engine": "file:../style-engine",
 		"@wordpress/token-list": "file:../token-list",
+		"@wordpress/ui": "file:../ui",
 		"@wordpress/upload-media": "file:../upload-media",
 		"@wordpress/url": "file:../url",
 		"@wordpress/warning": "file:../warning",

--- a/packages/block-editor/src/components/block-bindings/attribute-control.js
+++ b/packages/block-editor/src/components/block-bindings/attribute-control.js
@@ -13,11 +13,11 @@ import {
 } from '@wordpress/blocks';
 import {
 	__experimentalItem as Item,
-	__experimentalText as Text,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalVStack as VStack,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { Text } from '@wordpress/ui';
 import { useSelect } from '@wordpress/data';
 import { useContext } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -32,6 +32,7 @@
 		{ "path": "../style-engine" },
 		{ "path": "../token-list" },
 		{ "path": "../url" },
+		{ "path": "../ui" },
 		{ "path": "../upload-media" },
 		{ "path": "../warning" },
 		{ "path": "../wordcount" }


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of:  https://github.com/wordPress/gutenberg/issues/77265
`Attribute control — block-bindings/attribute-control.js uses Text truncate / variant="muted"`

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Migrate existing `__experimentalText` to `@wordpress/ui Text`

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added `@wordpress/ui` to dependency. 


## Use of AI Tools
- Used Copilot for PR description and commit messages
