### PR TITLE
Typography: Fix link font-size inheritance when block typography is customized

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -194,3 +194,10 @@ html :where(.is-position-sticky) {
 		/* stylelint-enable length-zero-no-unit */
 	}
 }
+
+/**
+ * Prevent global link font sizes from overriding block level font sizes.
+ */
+html :where(.has-custom-font-size, [class*="-font-size"], [style*="font-size"]) a:where(:not(.wp-element-button)) {
+	font-size: inherit;
+}


### PR DESCRIPTION
## What?

Closes #64976 

This PR resolves an issue where custom typography font sizes applied to a block (via Inspector Controls) are ignored by the block's inner links if a global link font size has been defined in the Site Editor.

## Why?

When a site-wide link font size is defined in Global Styles (Editor > Styles > Typography > Elements > Links), WordPress outputs an explicit styling rule: `a:where(:not(.wp-element-button)) { font-size: ... }` which carries a specificity of `0-0-1`.

When a custom typography size is applied to a block, Gutenberg targets the block's wrapper (e.g., via a `.has-large-font-size` class or an inline `style="..."` attribute). Because the inner `<a>` element has a dedicated CSS rule targeting it via Global Styles, it fails to inherit the font size from its parent wrapper, creating visual inconsistencies where links don't match the surrounding block text.

## How?

* **Global Cascade Reset (`packages/block-library/src/common.scss`)**: Added a targeted `:where()` selector to capture wrappers containing custom typography features (`.has-custom-font-size`, `[class*="-font-size"]`, and `[style*="font-size"]`). This rule forces inner anchor tags to `font-size: inherit;`. Wrapping it in `html :where(...)` provides exactly `0-0-2` specificity—strong enough to override the global `0-0-1` link rule, but weak enough to not disrupt any utility classes applied directly to the anchor elements themselves.

## Testing Instructions

1. Using a block theme (e.g., Twenty Twenty-Five), go to Site Editor > Styles > Typography > Elements > Links, and set the Font Size to **Large**. 
2. Edit a page or template, create a **Paragraph** block, and insert a hyperlink into the body text.
3. Select the Paragraph block and change its typography Font Size to **Small** via the Inspector Controls.
4. Verify that the link text shrinks to properly match the **Small** size of the paragraph instead of staying stubbornly **Large**.

## Screenshots or screencast 

### Before Fix

https://github.com/user-attachments/assets/e7af16a8-981c-409a-b586-fe3dde794bf9

### After Fix

https://github.com/user-attachments/assets/95ecb8e1-c6fa-479c-bde0-cdc34d32a447

## Use of AI Tools

AI was used to investigate the exact CSS specificity clash causing the inheritance breakdown and draft this PR description.