### PR TITLE
Card: Remove unused CardContext

### DIFF
--- a/packages/components/src/card/context.ts
+++ b/packages/components/src/card/context.ts
@@ -1,9 +1,0 @@
-/**
- * WordPress dependencies
- */
-import { createContext, useContext } from '@wordpress/element';
-
-export const CardContext = createContext( {} );
-CardContext.displayName = 'CardContext';
-
-export const useCardContext = () => useContext( CardContext );


### PR DESCRIPTION
## What?

Removes `packages/components/src/card/context.ts`, which exports `CardContext` and `useCardContext`. Neither is used anywhere in the codebase.

## Why?

Dead code. The context was likely intended to share state across `Card` subcomponents but was never wired up. Removing it reduces noise and surface area in the `Card` directory.

> [!NOTE]
> This PR removes only the unused `packages/components/src/card/context.ts` helper export. It does not change the documented `Card` subcomponent behavior: props like `size` and `isBorderless` are still inherited by `CardBody`, `CardHeader`, and `CardFooter` through the [components context system](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/CONTRIBUTING.md#context-system).
 
## How?

- Deleted `packages/components/src/card/context.ts`.
- Added an `Internal` changelog entry.

The file isn't re-exported from any `index.ts`, so this isn't a public API change for consumers of `@wordpress/components`.

## Testing Instructions

1. `git grep CardContext` and `git grep useCardContext` should return no results.
2. The `Card` Storybook stories should continue to work as before.

## Use of AI Tools

Authored with the assistance of Cursor (Claude).