### PR TITLE
Add configurable link separators with responsive visibility controls for Navigation including page list items

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -539,7 +539,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 -	**Category:** theme
 -	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/icon, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
 -	**Supports:** align (full, wide), anchor, ariaLabel, contentRole, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, overlay, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, submenuVisibility, templateLock, textColor
+-	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, linkSeparator, linkSeparatorVisibility, maxNestingLevel, overlay, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, submenuVisibility, templateLock, textColor
 
 ## Custom Link
 

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -89,6 +89,16 @@
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", "contentOnly", false ]
+		},
+		"linkSeparator": {
+			"type": "string",
+			"enum": [ "none", "pipe", "slash", "dash", "bullet", "cross" ],
+			"default": "none"
+		},
+		"linkSeparatorVisibility": {
+			"type": "string",
+			"enum": [ "desktop", "desktop-tablet", "all" ],
+			"default": "desktop"
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -690,7 +690,7 @@ function Navigation( {
 			'--wp-navigation-link-separator': hasLinkSeparator
 				? `"${ separatorChar }"`
 				: undefined,
-			'--wp-navigation-link-separator-gap': separatorGap,
+			'--wp-navigation-link-separator-gap': separatorGap || '1em',
 		},
 	} );
 
@@ -971,9 +971,7 @@ function Navigation( {
 							isShownByDefault
 						>
 							<ToggleGroupControl
-								label={
-									__( 'Separator' ) + ': ' + linkSeparator
-								}
+								label={ __( 'Separator' ) }
 								value={ linkSeparator }
 								onChange={ ( value ) =>
 									setAttributes( { linkSeparator: value } )

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -297,6 +297,8 @@ function Navigation( {
 		} = {},
 		hasIcon,
 		icon = 'handle',
+		linkSeparator,
+		linkSeparatorVisibility,
 	} = attributes;
 
 	const ref = attributes.ref;
@@ -616,6 +618,41 @@ function Navigation( {
 
 	const isResponsive = 'never' !== overlayMenu && ! editorDisabledResponsive;
 
+	const LINK_SEPARATOR_OPTIONS = [
+		{ value: 'none', label: __( 'None' ) },
+		{ value: 'pipe', label: '|' },
+		{ value: 'slash', label: '/' },
+		{ value: 'dash', label: '—' },
+		{ value: 'bullet', label: '•' },
+		{ value: 'cross', label: 'X' },
+	];
+
+	const LINK_SEPARATOR_VISIBILITY_OPTIONS = [
+		{ value: 'desktop', label: __( 'Desktop only' ) },
+		{ value: 'desktop-tablet', label: __( 'Desktop + Tablet' ) },
+		{ value: 'all', label: __( 'All devices' ) },
+	];
+
+	const LINK_SEPARATOR_CHARS = {
+		pipe: '|',
+		slash: '/',
+		dash: '—',
+		bullet: '•',
+		cross: 'X',
+	};
+
+	const hasLinkSeparator = linkSeparator !== 'none';
+	const separatorChar = LINK_SEPARATOR_CHARS[ linkSeparator ] || '';
+
+	const blockGap = attributes?.style?.spacing?.blockGap;
+
+	let separatorGap;
+
+	if ( blockGap?.startsWith( 'var:preset|spacing|' ) ) {
+		const slug = blockGap.replace( 'var:preset|spacing|', '' );
+		separatorGap = `var(--wp--preset--spacing--${ slug })`;
+	}
+
 	const blockProps = useBlockProps( {
 		ref: navRef,
 		className: clsx(
@@ -640,12 +677,20 @@ function Navigation( {
 				) ]: !! backgroundColor?.slug,
 				[ `has-text-decoration-${ textDecoration }` ]: textDecoration,
 				'block-editor-block-content-overlay': hasBlockOverlay,
+				'has-link-separator': hasLinkSeparator,
+				[ `has-link-separator-${ linkSeparator }` ]: hasLinkSeparator,
+				[ `has-link-separator-visibility-${ linkSeparatorVisibility }` ]:
+					hasLinkSeparator,
 			},
 			layoutClassNames
 		),
 		style: {
 			color: ! textColor?.slug && textColor?.color,
 			backgroundColor: ! backgroundColor?.slug && backgroundColor?.color,
+			'--wp-navigation-link-separator': hasLinkSeparator
+				? `"${ separatorChar }"`
+				: undefined,
+			'--wp-navigation-link-separator-gap': separatorGap,
 		},
 	} );
 
@@ -799,7 +844,7 @@ function Navigation( {
 	const stylingInspectorControls = (
 		<>
 			<InspectorControls>
-				{ hasSubmenus && (
+				{
 					<ToolsPanel
 						label={ __( 'Display' ) }
 						resetAll={ () => {
@@ -914,8 +959,61 @@ function Navigation( {
 								) }
 							</>
 						) }
+						<ToolsPanelItem
+							hasValue={ () => hasLinkSeparator }
+							label={ __( 'Link separators' ) }
+							onDeselect={ () =>
+								setAttributes( {
+									linkSeparator: 'none',
+									linkSeparatorVisibility: 'desktop',
+								} )
+							}
+							isShownByDefault
+						>
+							<ToggleGroupControl
+								label={
+									__( 'Separator' ) + ': ' + linkSeparator
+								}
+								value={ linkSeparator }
+								onChange={ ( value ) =>
+									setAttributes( { linkSeparator: value } )
+								}
+								__next40pxDefaultSize
+							>
+								{ LINK_SEPARATOR_OPTIONS.map( ( option ) => (
+									<ToggleGroupControlOption
+										key={ option.value }
+										value={ option.value }
+										label={ option.label }
+									/>
+								) ) }
+							</ToggleGroupControl>
+
+							{ hasLinkSeparator && (
+								<ToggleGroupControl
+									label={ __( 'Show on' ) }
+									value={ linkSeparatorVisibility }
+									onChange={ ( value ) =>
+										setAttributes( {
+											linkSeparatorVisibility: value,
+										} )
+									}
+									__next40pxDefaultSize
+								>
+									{ LINK_SEPARATOR_VISIBILITY_OPTIONS.map(
+										( option ) => (
+											<ToggleGroupControlOption
+												key={ option.value }
+												value={ option.value }
+												label={ option.label }
+											/>
+										)
+									) }
+								</ToggleGroupControl>
+							) }
+						</ToolsPanelItem>
 					</ToolsPanel>
-				) }
+				}
 			</InspectorControls>
 			{ ! isWithinOverlay && (
 				<InspectorControls>

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -721,3 +721,42 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 .wp-block-navigation__overlay-help-text-wrapper {
 	margin-top: $grid-unit-10;
 }
+
+.wp-block-navigation {
+	&.has-link-separator {
+		.wp-block-navigation__container .wp-block-navigation-item {
+			& + .wp-block-navigation-item::before,
+			& + .wp-block-page-list::before {
+				content: var(--wp-navigation-link-separator);
+				display: inline-block;
+				color: currentColor;
+				font-weight: 400;
+				white-space: nowrap;
+				position: absolute;
+				margin-inline-start: calc(var(--wp-navigation-link-separator-gap, 0px) / (-2) - 0.5ch);
+			}
+		}
+
+		&.has-link-separator-visibility-desktop {
+			@media (max-width: 800px) {
+				.wp-block-navigation__container .wp-block-navigation-item {
+					& + .wp-block-navigation-item::before,
+					& + .wp-block-page-list::before {
+						content: none;
+					}
+				}
+			}
+		}
+
+		&.has-link-separator-visibility-desktop-tablet {
+			@media (max-width: 599px) {
+				.wp-block-navigation__container .wp-block-navigation-item {
+					& + .wp-block-navigation-item::before,
+					& + .wp-block-page-list::before {
+						content: none;
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1824,7 +1824,7 @@ function block_core_navigation_get_most_recently_published_navigation() {
  * @param array $attributes Navigation block attributes.
  * @return str Block gap preset css variable.
  */
-function block_core_get_navigation_block_gap( $attributes ) {
+function block_core_navigation_get_block_gap( $attributes ) {
 	$block_gap = $attributes['style']['spacing']['blockGap'] ?? '';
 
 	if ( empty( $block_gap ) ) {
@@ -1878,7 +1878,7 @@ function block_core_navigation_build_css_separators( $attributes ) {
 		sanitize_html_class( $visibility )
 	);
 
-	$block_gap = block_core_get_navigation_block_gap( $attributes );
+	$block_gap = block_core_navigation_get_block_gap( $attributes );
 	if ( $block_gap ) {
 		$separators['inline_styles'] .= sprintf(
 			'--wp-navigation-link-separator-gap: %s;',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -601,13 +601,15 @@ class WP_Navigation_Block_Renderer {
 		// Manually add block support text decoration as CSS class.
 		$text_decoration       = $attributes['style']['typography']['textDecoration'] ?? null;
 		$text_decoration_class = sprintf( 'has-text-decoration-%s', $text_decoration );
+		$separators            = block_core_navigation_build_css_separators( $attributes );
 
 		$classes = array_merge(
 			$colors['css_classes'],
 			$font_sizes['css_classes'],
 			$is_responsive_menu ? array( 'is-responsive' ) : array(),
 			$layout_class ? array( $layout_class ) : array(),
-			$text_decoration ? array( $text_decoration_class ) : array()
+			$text_decoration ? array( $text_decoration_class ) : array(),
+			$separators['css_classes'],
 		);
 		return implode( ' ', $classes );
 	}
@@ -623,8 +625,9 @@ class WP_Navigation_Block_Renderer {
 	private static function get_styles( $attributes ) {
 		$colors       = block_core_navigation_build_css_colors( $attributes );
 		$font_sizes   = block_core_navigation_build_css_font_sizes( $attributes );
+		$separators   = block_core_navigation_build_css_separators( $attributes );
 		$block_styles = $attributes['styles'] ?? '';
-		return $block_styles . $colors['inline_styles'] . $font_sizes['inline_styles'];
+		return $block_styles . $colors['inline_styles'] . $font_sizes['inline_styles'] . $separators['inline_styles'];
 	}
 
 	/**
@@ -1808,4 +1811,85 @@ function block_core_navigation_get_most_recently_published_navigation() {
 	}
 
 	return null;
+}
+
+/**
+ * Retrieves the block gap CSS variable value from navigation block attributes.
+ *
+ * Processes the block gap spacing attribute and converts preset references
+ * into CSS custom property syntax.
+ *
+ * @since 23.0.0
+ *
+ * @param array $attributes Navigation block attributes.
+ * @return str Block gap preset css variable.
+ */
+function block_core_get_navigation_block_gap( $attributes ) {
+	$block_gap = $attributes['style']['spacing']['blockGap'] ?? '';
+
+	if ( empty( $block_gap ) ) {
+		return '';
+	}
+
+	if ( 0 === strpos( $block_gap, 'var:preset|spacing|' ) ) {
+		$preset_slug = substr( $block_gap, strlen( 'var:preset|spacing|' ) );
+		$block_gap   = sprintf(
+			'var(--wp--preset--spacing--%s)',
+			sanitize_key( $preset_slug )
+		);
+	}
+
+	return $block_gap;
+}
+
+/**
+ * Build CSS classes and styles for link separators.
+ *
+ * @since 23.0.0
+ *
+ * @param array $attributes Navigation block attributes.
+ * @return array Separator CSS classes and inline styles.
+ */
+function block_core_navigation_build_css_separators( $attributes ) {
+	$separator_map = array(
+		'dot'    => '·',
+		'pipe'   => '|',
+		'slash'  => '/',
+		'dash'   => '—',
+		'bullet' => '•',
+		'cross'  => 'X',
+	);
+
+	$separator  = $attributes['linkSeparator'] ?? 'none';
+	$visibility = $attributes['linkSeparatorVisibility'] ?? 'desktop';
+	$separators = array(
+		'css_classes'   => array(),
+		'inline_styles' => '',
+	);
+
+	if ( 'none' === $separator || ! isset( $separator_map[ $separator ] ) ) {
+		return $separators;
+	}
+
+	$separators['css_classes'][] = 'has-link-separator';
+	$separators['css_classes'][] = sprintf( 'has-link-separator-%s', sanitize_html_class( $separator ) );
+	$separators['css_classes'][] = sprintf(
+		'has-link-separator-visibility-%s',
+		sanitize_html_class( $visibility )
+	);
+
+	$block_gap = block_core_get_navigation_block_gap( $attributes );
+	if ( $block_gap ) {
+		$separators['inline_styles'] .= sprintf(
+			'--wp-navigation-link-separator-gap: %s;',
+			esc_attr( $block_gap )
+		);
+	}
+
+	$separators['inline_styles'] .= sprintf(
+		'--wp-navigation-link-separator: "%s";',
+		esc_attr( $separator_map[ $separator ] )
+	);
+
+	return $separators;
 }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1884,6 +1884,8 @@ function block_core_navigation_build_css_separators( $attributes ) {
 			'--wp-navigation-link-separator-gap: %s;',
 			esc_attr( $block_gap )
 		);
+	} else {
+		$separators['inline_styles'] .= '--wp-navigation-link-separator-gap: 1em;';
 	}
 
 	$separators['inline_styles'] .= sprintf(

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -151,6 +151,42 @@ $navigation-icon-size: 24px;
 		--navigation-layout-justification-setting: space-between;
 		--navigation-layout-justify: space-between;
 	}
+	&.has-link-separator {
+		.wp-block-navigation__container .wp-block-navigation-item {
+			& + .wp-block-navigation-item::before,
+			& + .wp-block-page-list::before {
+				content: var(--wp-navigation-link-separator);
+				display: inline-block;
+				color: currentColor;
+				font-weight: 400;
+				white-space: nowrap;
+				position: absolute;
+				margin-inline-start: calc(var(--wp-navigation-link-separator-gap, 0px) / (-2) - 0.5ch);
+			}
+		}
+
+		&.has-link-separator-visibility-desktop {
+			@media (max-width: 800px) {
+				.wp-block-navigation__container .wp-block-navigation-item {
+					& + .wp-block-navigation-item::before,
+					& + .wp-block-page-list::before {
+						content: none;
+					}
+				}
+			}
+		}
+
+		&.has-link-separator-visibility-desktop-tablet {
+			@media (max-width: 599px) {
+				.wp-block-navigation__container .wp-block-navigation-item {
+					& + .wp-block-navigation-item::before,
+					& + .wp-block-page-list::before {
+						content: none;
+					}
+				}
+			}
+		}
+	}
 }
 
 // Low specificity padding to not override global styles.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes https://github.com/WordPress/gutenberg/issues/75201

Adds support for configurable link separators in the Navigation block, along with options to control their visibility across devices.

## Why?
Designers often need separators between navigation links for better readability and visual structure, especially in horizontal menus and footers. Currently, this requires custom CSS, which is not user-friendly or consistent across themes. This PR introduces a built-in solution that works out of the box and adapts to responsive layouts.

## How?

- Introduced new block attributes for separator type and visibility settings
- Extended block wrapper classes and inline styles to pass separator configuration
- Implemented logic to convert spacing presets into CSS variables for accurate separator alignment when the block spacing is changed.
- Used CSS pseudo-elements to render separators and position them precisely between items using the computed gap
- Ensured compatibility with both Navigation items and Page List items

## Testing Instructions

1. Open a post or page
2. Insert a Navigation block
3. Add multiple Navigation Link items or use a Page List block inside it
4. Open the block settings in the sidebar
5. Select a separator style (e.g. dot, pipe, dash, etc.)
6. Change the “Show on” option (Desktop only / Desktop + Tablet / All)
7. Adjust the block spacing from the Dimensions panel
8. Verify that:
    1. Separators appear between items
    2. Separators stay centered regardless of spacing changes
    3. Visibility settings correctly hide/show separators on different screen sizes
9. Preview the page and verify the same behavior on the frontend

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/19c2d09f-5e1a-4ea7-b389-c30aa5bc5861


## Use of AI Tools
Used AI assistance to help refine code and for documentation.
