### PR TITLE
CollapsibleCard: Fix missing keyboard focus ring on the header chevron icon when rendered inside wp-admin

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   `Link`: Fix text decoration on the `unstyled` variant when `openInNewTab` is enabled, and simplify new-tab icon markup ([#77420](https://github.com/WordPress/gutenberg/pull/77420)).
 -   `Dialog`, `AlertDialog`, `Popover`, `Tooltip`, `Select`: Fix broken focus-trap caused by ThemeProvider's `display: contents` and Base UI's `checkVisibility()` ([#77381](https://github.com/WordPress/gutenberg/pull/77381)).
+-   `CollapsibleCard`: Fix missing keyboard focus ring on the header chevron icon when rendered inside wp-admin ([#77468](https://github.com/WordPress/gutenberg/pull/77468)).
 
 ### Enhancements
 

--- a/packages/ui/src/collapsible-card/header.tsx
+++ b/packages/ui/src/collapsible-card/header.tsx
@@ -5,6 +5,7 @@ import * as Card from '../card';
 import * as Collapsible from '../collapsible';
 import { Icon } from '../icon';
 import styles from './style.module.css';
+import defenseStyles from '../utils/css/global-css-defense.module.css';
 import focusStyles from '../utils/css/focus.module.css';
 import { HeaderDescriptionIdContext } from './context';
 import type { HeaderProps } from './types';
@@ -55,6 +56,7 @@ export const Header = forwardRef< HTMLDivElement, HeaderProps >(
 						<div
 							className={ clsx(
 								styles[ 'header-trigger-wrapper' ],
+								defenseStyles.div,
 								// While the interactive trigger element is the whole header,
 								// the focus ring will be displayed only on the icon to visually
 								// emulate it being the button.


### PR DESCRIPTION
- Closes: #77467
- Follow up to #76783

## What?

Add defensive styling to the header of the `CollapsibleCard` component so that the focus ring is displayed correctly when the header is focused.

## Why?

See #77467

## Testing Instructions

- Access the following URL: https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-collapsiblecard--docs&globals=css:wordpress
- In this story, WordPress-derived CSS is enabled.
- Press the Tab key on your keyboard to focus on the header.
- Ensure that a visual focus ring is displayed.

## Screenshots or screencast

<img width="1155" height="573" alt="outline" src="https://github.com/user-attachments/assets/db8281a2-4d45-4044-915f-a0eec7327a8f" />


## Use of AI Tools

Authored with assistance from Claude Code; reviewed and validated by the author.
