### PR TITLE
Tabs: Fix missing keyboard focus ring on the panel in Windows High Contrast mode when rendered inside wp-admin

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   `Link`: Fix text decoration on the `unstyled` variant when `openInNewTab` is enabled, and simplify new-tab icon markup ([#77420](https://github.com/WordPress/gutenberg/pull/77420)).
 -   `Dialog`, `AlertDialog`, `Popover`, `Tooltip`, `Select`: Fix broken focus-trap caused by ThemeProvider's `display: contents` and Base UI's `checkVisibility()` ([#77381](https://github.com/WordPress/gutenberg/pull/77381)).
+-   `Tabs`: Fix missing keyboard focus ring on the panel in Windows High Contrast mode when rendered inside wp-admin ([#77469](https://github.com/WordPress/gutenberg/pull/77469)).
 
 ### Enhancements
 

--- a/packages/ui/src/tabs/panel.tsx
+++ b/packages/ui/src/tabs/panel.tsx
@@ -2,6 +2,7 @@ import { forwardRef } from '@wordpress/element';
 import clsx from 'clsx';
 import { Tabs as _Tabs } from '@base-ui/react/tabs';
 import { useRegisterPanel } from './context';
+import defenseStyles from '../utils/css/global-css-defense.module.css';
 import styles from './style.module.css';
 import type { TabPanelProps } from './types';
 
@@ -18,7 +19,11 @@ export const Panel = forwardRef< HTMLDivElement, TabPanelProps >(
 		return (
 			<_Tabs.Panel
 				ref={ forwardedRef }
-				className={ clsx( styles.tabpanel, className ) }
+				className={ clsx(
+					defenseStyles.div,
+					styles.tabpanel,
+					className
+				) }
 				{ ...otherProps }
 			/>
 		);

--- a/packages/ui/src/tabs/panel.tsx
+++ b/packages/ui/src/tabs/panel.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import { Tabs as _Tabs } from '@base-ui/react/tabs';
 import { useRegisterPanel } from './context';
 import defenseStyles from '../utils/css/global-css-defense.module.css';
-import styles from './style.module.css';
+import focusStyles from '../utils/css/focus.module.css';
 import type { TabPanelProps } from './types';
 
 /**
@@ -21,7 +21,7 @@ export const Panel = forwardRef< HTMLDivElement, TabPanelProps >(
 				ref={ forwardedRef }
 				className={ clsx(
 					defenseStyles.div,
-					styles.tabpanel,
+					focusStyles[ 'outset-ring--focus-visible' ],
 					className
 				) }
 				{ ...otherProps }

--- a/packages/ui/src/tabs/style.module.css
+++ b/packages/ui/src/tabs/style.module.css
@@ -249,21 +249,4 @@
 			rotate: 180deg;
 		}
 	}
-
-	.tabpanel {
-		&:focus {
-			box-shadow: none;
-			outline: none;
-		}
-
-		&:focus-visible {
-			box-shadow:
-				0 0 0 var(--wpds-border-width-focus)
-				var(--wpds-color-stroke-focus-brand);
-
-			/* Windows high contrast mode. */
-			outline: 2px solid transparent;
-			outline-offset: 0;
-		}
-	}
 }


### PR DESCRIPTION
- Related to #77467

## What?

Add defensive styling to the `Tabs.Panel` component so that its focus indicator remains visible under Windows high contrast / `forced-colors` mode when the component is rendered inside wp-admin.

## Why?

The WordPress core applies `outline: none` to the `div` element, so the focus ring is not displayed.

## How?

Unlike issue #77467, this problem cannot be solved by simply introducing a defensive style because `--_gcd-div-outline` is undefined. To make this defensive style work, this PR introduces a focus utility to this component and draws the focus ring with an outline instead of box-shadow.

## Testing Instructions

1. Access the following URL: http://localhost:50240/?path=/story/design-system-components-tabs--default&globals=css:wordpress
2. In this story, WordPress-derived CSS is enabled.
3. Open Chrome DevTools → `Rendering` panel → set `Emulate CSS media feature forced-colors` to `active`.
4. Tab through the component until focus reaches the tab panel body.
5. Ensure that a visual focus outline (using the system highlight color) is displayed around the panel.

## Screenshots or screencast

### Before

<img width="1204" height="633" alt="before" src="https://github.com/user-attachments/assets/fc29d5cd-61d7-46f9-b28b-c0a370265c6d" />

### After

<img width="1138" height="632" alt="after" src="https://github.com/user-attachments/assets/d86c570e-87a9-4237-9af0-f969f2c264fb" />

## Use of AI Tools

Authored with assistance from Claude Code; reviewed and validated by the author.
