### PR TITLE
Build: Add page dependencies filter to wp-build page templates

### DIFF
--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -366,6 +366,41 @@ export async function init() {
 
 The `init()` function is **mandatory** - all init modules must export this named function. Init modules are loaded as static dependencies and executed sequentially before the boot system registers menu items and routes.
 
+**Extending Page Dependencies:**
+
+Generated page templates expose a PHP filter that lets extensions append script modules to the page's dependency tree. This is useful for plugins that want modules available in the browser import map — for eager or lazy loading — without re-registering the page itself.
+
+Two filter names are available, one per page mode:
+
+```php
+// Full-page mode
+apply_filters( '{page-slug}_script_module_dependencies', $boot_dependencies );
+
+// WP-admin mode
+apply_filters( '{page-slug}-wp-admin_script_module_dependencies', $boot_dependencies );
+```
+
+The callback receives the current `$boot_dependencies` array and must return it. Each entry is an array with `id` (script module ID) and `import` (`'static'` or `'dynamic'`):
+
+```php
+add_filter( 'my-page_script_module_dependencies', function ( $deps ) {
+	$deps[] = array(
+		'import' => 'dynamic',
+		'id'     => '@my-plugin/settings',
+	);
+	return $deps;
+} );
+```
+
+- **`static`** imports are loaded immediately when the page boots.
+- **`dynamic`** imports appear in the browser import map but are only fetched on demand via `import( id )`. Good for code paths that may or may not be rendered.
+
+**Example use cases:**
+
+- **Lazy-loaded components**: Declare feature modules as dynamic deps so `lazy( () => import( id ) )` resolves at render time without eagerly loading everything.
+- **Conditional feature modules**: Register modules only when certain capabilities, settings, or feature flags are met — the page module sees them, but the browser only fetches them when needed.
+- **Third-party extensions**: Other plugins can hook the filter to inject their own modules into a page owned by someone else, without touching the original page's registration code.
+
 ### Example: WordPress Core (Gutenberg)
 
 ```json

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -196,6 +196,17 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suf
 			}
 		}
 
+		/**
+		 * Filters the script module dependencies for the page module.
+		 *
+		 * Allows extensions to add script modules (static or dynamic) to the
+		 * page's dependency tree. Dynamic dependencies appear in the browser
+		 * import map without being eagerly loaded.
+		 *
+		 * @param array $boot_dependencies Array of dependency arrays with 'id' and 'import' keys.
+		 */
+		$boot_dependencies = apply_filters( '{{PAGE_SLUG}}-wp-admin_script_module_dependencies', $boot_dependencies );
+
 		// Dummy script module to ensure dependencies are loaded
 		wp_register_script_module(
 			'{{PAGE_SLUG}}-wp-admin',

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -209,6 +209,17 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
 			}
 		}
 
+		/**
+		 * Filters the script module dependencies for the page module.
+		 *
+		 * Allows extensions to add script modules (static or dynamic) to the
+		 * page's dependency tree. Dynamic dependencies appear in the browser
+		 * import map without being eagerly loaded.
+		 *
+		 * @param array $boot_dependencies Array of dependency arrays with 'id' and 'import' keys.
+		 */
+		$boot_dependencies = apply_filters( '{{PAGE_SLUG}}_script_module_dependencies', $boot_dependencies );
+
 		// Dummy script module to ensure dependencies are loaded
 		wp_register_script_module(
 			'{{PAGE_SLUG}}',


### PR DESCRIPTION
# Build: Add page dependencies filter to wp-build page templates

## What?

Adds a PHP filter to the generated page templates in `@wordpress/build` so extensions can append script modules to a page's dependency tree without re-registering existing modules.

Two filter names are exposed, one per page mode:

- `{page-slug}_script_module_dependencies` — full-page mode (`page.php.template`)
- `{page-slug}-wp-admin_script_module_dependencies` — wp-admin mode (`page-wp-admin.php.template`)

The filter fires right before the page's dummy script module is registered, receiving the `$boot_dependencies` array. Callbacks can append entries with `id` (script module ID) and `import` (`'static'` or `'dynamic'`).

## Why?

Page templates currently assemble `$boot_dependencies` from a fixed set of sources (init modules, routes). Extensions that need to surface additional modules in the browser import map have no clean extension point — they either have to deregister/re-register the page module (fragile, timing-dependent, breaks with future additions) or re-register `@wordpress/*` modules (pollutes unrelated state).

A plain filter is the least invasive, most composable option:

- **Lazy-loaded components** — declare feature modules as `'dynamic'` deps so `lazy( () => import( id ) )` resolves at render time without eagerly loading everything.
- **Conditional feature modules** — register modules only when a capability, setting, or feature flag is met.
- **Third-party extensions** — other plugins can inject modules into a page owned by someone else, without touching that page's registration code.

## How?

Two commits:

1. **`73dbd04`** — adds `apply_filters()` in `page.php.template` (line 221) and `page-wp-admin.php.template` (line 206), right after `$boot_dependencies` is assembled and before `wp_register_script_module()`. No behavior change for existing consumers: unhooked filter is a no-op.

2. **`11f8a71`** — documents the filter in `packages/wp-build/README.md` under the `wpPlugin.pages` section. Includes the filter signature, a generic `add_filter` example, the `static` vs `dynamic` distinction, and three example use cases.

## Testing Instructions

1. Build a plugin that uses `@wordpress/build` with an admin page defined in `wpPlugin.pages`.
2. Run `wp-build`.
3. Inspect the generated page PHP (`build/pages/{page-slug}/page.php` or `page-wp-admin.php`) — confirm the `apply_filters()` call appears between the foreach loop that adds routes and the `wp_register_script_module()` call.
4. Hook the filter:
   ```php
   add_filter( 'my-page_script_module_dependencies', function ( $deps ) {
       $deps[] = array(
           'import' => 'dynamic',
           'id'     => '@my-plugin/lazy-feature',
       );
       return $deps;
   } );
   ```
5. Load the page, open DevTools → Network. Confirm `@my-plugin/lazy-feature` is present in the import map (`<script type="importmap">`) but **not** fetched eagerly.
6. Trigger a code path that calls `import( '@my-plugin/lazy-feature' )` and confirm it resolves.

## Follow-ups

- [ ] Explore a non-page variant for surfaces that don't use the `page.php.template` (e.g., modules loaded outside the admin page template chain).
