### PR TITLE
Env: Bypass Composer 2.8 audit.block-insecure for PHPUnit install

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Disable Composer 2.8+ `audit.block-insecure` before installing PHPUnit in the tests-cli image so that advisories on abandoned PHPUnit majors don't block the image build. ([#77470](https://github.com/WordPress/gutenberg/issues/77470))
+
 ## 11.4.0 (2026-04-15)
 
 ### Bug Fixes

--- a/packages/env/lib/runtime/docker/docker-config.js
+++ b/packages/env/lib/runtime/docker/docker-config.js
@@ -230,7 +230,7 @@ RUN rm /tmp/composer-setup.php`;
 	dockerFileContent += `
 USER $HOST_UID:$HOST_GID
 ENV PATH="\${PATH}:/home/$HOST_USERNAME/.composer/vendor/bin"
-RUN composer global require --dev phpunit/phpunit:"^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+RUN composer config --global audit.block-insecure false && composer global require --dev phpunit/phpunit:"^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
 USER root`;
 
 	return dockerFileContent;


### PR DESCRIPTION
## What

Prefixes the `tests-cli` image's global PHPUnit install with
`composer config --global audit.block-insecure false &&` so Composer 2.8+
will resolve the PHPUnit dependency tree instead of aborting with exit 2.

## Why

Composer 2.8 enables `audit.block-insecure` by default. Every version in the
PHPUnit range wp-env installs (`^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0`)
pulls in transitive deps flagged by advisories `PKSA-5jz8-6tcw-pbk4` and
`PKSA-z3gr-8qht-p93v`. As a result, **every fresh `wp-env start` on CI (and
many local installs) fails** with Composer refusing to install anything at
all during the image build.

Composer's own error output points at the fix:

> To turn the feature off entirely, you can set 'block-insecure' to false in your 'audit' config.

`--no-audit` / `COMPOSER_NO_AUDIT=1` look similar but **do not** help here —
they only suppress the post-install audit report, not the resolution-time
advisory filter. `audit.block-insecure` is the only toggle that lets
resolution proceed.

Fixes #77470.

## Scope

Deliberately narrow:

- One-line change in the Dockerfile template.
- A CHANGELOG entry under `## Unreleased`.

Explicitly **out of scope**:

- Tightening the PHPUnit version range. Older PHPUnit majors are still
  needed for older-PHP matrix jobs, so that is a separate conversation.
- The PHP 8.2 pin floated in
  [#77470 (comment)](https://github.com/WordPress/gutenberg/issues/77470#issuecomment-4273452673) —
  that is a user-side workaround, not something to bake into wp-env.

## Evidence that downstream workarounds are fragile

I was shipping a sed-based patch of the generated `docker-config.js` in
[apermo/reusable-workflows#24](https://github.com/apermo/reusable-workflows/pull/24)
(released as v0.4.3) to keep our CI green. It works, but it is brittle: any
edit to this line upstream breaks the sed. A one-line upstream fix removes
the need for that patch entirely.

## Test plan

- [ ] `npm install && npm run build` completes.
- [ ] `wp-env start --update` produces a `tests-cli` image that builds
      cleanly (no Composer exit 2).
- [ ] `wp-env run tests-cli phpunit --version` prints a PHPUnit version.

## Disclosure

This PR was prepared with the help of Claude (Anthropic's Claude Code, Opus 4.7)
acting as pair-programmer. Christoph Daum reviewed the change and is
responsible for the contribution.