### PR TITLE
Writing Flow: fix arrow keys skipping paragraph containing link

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -120,6 +120,9 @@ export function getClosestTabbable(
 		// candidates. We must not skip contenteditable nodes that happen to
 		// contain links or other focusable inline elements, since those are the
 		// correct navigation targets.
+		//
+		// See https://github.com/WordPress/gutenberg/pull/77474
+		// TODO: Consider fixing focus.tabbable
 		if (
 			node.contentEditable !== 'true' &&
 			getBlockClientId( node ) &&

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -115,9 +115,13 @@ export function getClosestTabbable(
 	}
 
 	function isTabCandidate( node ) {
-		// If it's a block and there are nested focusable nodes, skip because
-		// there are better candidates.
+		// If it's a block wrapper (not itself a contenteditable editing surface)
+		// and there are nested focusable nodes, skip because there are better
+		// candidates. We must not skip contenteditable nodes that happen to
+		// contain links or other focusable inline elements, since those are the
+		// correct navigation targets.
 		if (
+			node.contentEditable !== 'true' &&
 			getBlockClientId( node ) &&
 			focus.focusable
 				.find( node )

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1233,6 +1233,41 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 				.getByRole( 'button', { name: 'Bold' } )
 		).toBeVisible();
 	} );
+
+	// Regression test: ArrowDown should not skip over a paragraph that contains
+	// a link. See https://github.com/WordPress/gutenberg/issues/77473.
+	test( 'should not skip paragraph with link when navigating down with ArrowDown', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'a' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: '<a href="#">a</a>' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'a' },
+		} );
+
+		// Position cursor at the start of the first paragraph.
+		await editor.canvas
+			.locator( 'role=document[name="Block: Paragraph"i]' )
+			.first()
+			.click();
+		await page.keyboard.press( 'Home' );
+
+		// ArrowDown should move to the second paragraph (with the link),
+		// not skip over it to the third.
+		await page.keyboard.press( 'ArrowDown' );
+
+		// The focused element should be the second paragraph, which contains a link.
+		const focusedElement = editor.canvas.locator( ':focus' );
+		await expect( focusedElement.locator( 'a[href="#"]' ) ).toBeVisible();
+	} );
 } );
 
 class WritingFlowUtils {


### PR DESCRIPTION
Fixes #77473.

## What

When the cursor was in a paragraph and the next paragraph contained a link (or any focusable inline element wrapping the full content), pressing `ArrowDown` would skip over it and land in the paragraph after. The same happened in the opposite direction with `ArrowUp`, or indeed with the horizontal arrows at the edges of the paragraphs.

## Why

_I'd like this to be vetted by @ellatrix_

Commit #75141 added a check in `isTabCandidate` to skip any node that (a) has a block client ID and (b) contains nested focusable elements — intended to skip block wrapper divs in favour of their inner contenteditable children.

However, `getBlockClientId()` returns a truthy value for *any* node inside a block, not just the wrapper. So a `<p contenteditable="true">` containing an `<a href>` was also skipped: the `<p>` was rejected because it had a nested focusable (the link), and the `<a>` was subsequently rejected by the existing contenteditable guard. Navigation fell through to the next plain paragraph.

## Fix

Add `node.contentEditable !== 'true'` to the skip condition so that actual editing surfaces are never bypassed regardless of what inline elements they contain. Only non-contenteditable wrappers are subject to the "skip in favour of children" logic.

## Testing

```
npm run test:e2e -- test/e2e/specs/editor/various/writing-flow.spec.js
```

All 126 tests pass across Chromium, Firefox, and WebKit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)