### PR TITLE
Common CSS: avoid false-positive border-style on custom properties

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -240,7 +240,7 @@ html :where(.is-position-sticky) {
 // To support sticky positioning, reset the admin bar offset to 0px on mobile devices,
 // within the scope of the position classname. This is required because the admin bar
 // is not fixed to the top on mobile devices, but is fixed on viewports larger than 600px.
-@media screen and ( max-width: 600px ) {
+@media screen and (max-width: 600px) {
 	html :where(.is-position-sticky) {
 		/* stylelint-disable length-zero-no-unit -- 0px is set explicitly so that it can be used in a calc value. */
 		--wp-admin--admin-bar--position-offset: 0px;

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -125,38 +125,91 @@
 html :where(.has-border-color) {
 	border-style: solid;
 }
-html :where([style*="border-color"]) {
+// Use ^= and *=; selectors so custom properties like --my-border-color
+// don't accidentally match. Only real declarations at the start of
+// the style string or after a semicolon should trigger these rules.
+html
+:where(
+	[style^="border-color"],
+	[style*=";border-color"],
+	[style*="; border-color"]
+) {
 	border-style: solid;
 }
-html :where([style*="border-top-color"]) {
+html
+:where(
+	[style^="border-top-color"],
+	[style*=";border-top-color"],
+	[style*="; border-top-color"]
+) {
 	border-top-style: solid;
 }
-html :where([style*="border-right-color"]) {
+html
+:where(
+	[style^="border-right-color"],
+	[style*=";border-right-color"],
+	[style*="; border-right-color"]
+) {
 	/*rtl:ignore*/
 	border-right-style: solid;
 }
-html :where([style*="border-bottom-color"]) {
+html
+:where(
+	[style^="border-bottom-color"],
+	[style*=";border-bottom-color"],
+	[style*="; border-bottom-color"]
+) {
 	border-bottom-style: solid;
 }
-html :where([style*="border-left-color"]) {
+html
+:where(
+	[style^="border-left-color"],
+	[style*=";border-left-color"],
+	[style*="; border-left-color"]
+) {
 	/*rtl:ignore*/
 	border-left-style: solid;
 }
 
-html :where([style*="border-width"]) {
+html
+:where(
+	[style^="border-width"],
+	[style*=";border-width"],
+	[style*="; border-width"]
+) {
 	border-style: solid;
 }
-html :where([style*="border-top-width"]) {
+html
+:where(
+	[style^="border-top-width"],
+	[style*=";border-top-width"],
+	[style*="; border-top-width"]
+) {
 	border-top-style: solid;
 }
-html :where([style*="border-right-width"]) {
+html
+:where(
+	[style^="border-right-width"],
+	[style*=";border-right-width"],
+	[style*="; border-right-width"]
+) {
 	/*rtl:ignore*/
 	border-right-style: solid;
 }
-html :where([style*="border-bottom-width"]) {
+html
+:where(
+	[style^="border-bottom-width"],
+	[style*=";border-bottom-width"],
+	[style*="; border-bottom-width"]
+) {
 	border-bottom-style: solid;
 }
-html :where([style*="border-left-width"]) {
+html
+:where(
+	[style^="border-left-width"],
+	[style*=";border-left-width"],
+	[style*="; border-left-width"]
+) {
 	/*rtl:ignore*/
 	border-left-style: solid;
 }
@@ -187,7 +240,7 @@ html :where(.is-position-sticky) {
 // To support sticky positioning, reset the admin bar offset to 0px on mobile devices,
 // within the scope of the position classname. This is required because the admin bar
 // is not fixed to the top on mobile devices, but is fixed on viewports larger than 600px.
-@media screen and (max-width: 600px) {
+@media screen and ( max-width: 600px ) {
 	html :where(.is-position-sticky) {
 		/* stylelint-disable length-zero-no-unit -- 0px is set explicitly so that it can be used in a calc value. */
 		--wp-admin--admin-bar--position-offset: 0px;


### PR DESCRIPTION
## What?

Tightens the CSS attribute selectors in `common.scss` that apply default `border-style: solid` when border properties are detected in inline styles.

## Why?

Fixes #70211.

The selectors `[style*="border-width"]` and `[style*="border-color"]` use substring matching (`*=`), which matches **any** inline style containing those strings — including CSS custom properties like `--my-border-width: 1px` or `--fir-list-border-color: red`.

This causes `border-style: solid` to be applied to elements that have no actual border set, producing unwanted visible borders on custom blocks and themes that use custom properties with "border" in their name.

## How?

Implements suggested fix in https://github.com/WordPress/gutenberg/pull/75546#issuecomment-3970212891.

Replaced each `[style*="prop"]` selector with three more precise selectors:

| Selector | Matches when... |
|----------|----------------|
| `[style^="prop"]` | `prop` is the first declaration in the style |
| `[style*=";prop"]` | `prop` follows a semicolon (no space) |
| `[style*="; prop"]` | `prop` follows a semicolon and space |

CSS custom property names always begin with `--`, so they can never appear directly after a semicolon or at the start of the style attribute without that prefix. Real CSS property declarations can.

All selectors remain inside `:where()` so specificity is unchanged.

## Testing Instructions

1. Add a block or HTML with a custom property containing "border-width" or "border-color":
   ```html
   <div style="--my-border-width: 1px; padding: 10px;">Should have no border</div>
   <div style="--fir-list-border-color: red; padding: 10px;">Should have no border</div>
   ```
2. **Before**: Both divs get `border-style: solid` applied (unwanted border visible)
3. **After**: No border appears on either div

4. Verify real borders still work:
   ```html
   <div style="border-width: 2px; border-color: red;">Should have a red border</div>
   ```
5. Confirm the red border is still applied correctly