### PR TITLE
Image Block: Restore captions in lightbox overlay with Gallery-level toggles

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -390,7 +390,7 @@ Display multiple images in a rich gallery. ([Source](https://github.com/WordPres
 -	**Category:** media
 -	**Allowed Blocks:** core/image
 -	**Supports:** align, anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), listView, spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
--	**Attributes:** allowResize, aspectRatio, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, navigationButtonType, randomOrder, shortCodeTransforms, sizeSlug
+-	**Attributes:** allowResize, aspectRatio, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, navigationButtonType, randomOrder, shortCodeTransforms, showCaptionInGallery, showCaptionInLightbox, sizeSlug
 
 ## Group
 

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -115,10 +115,12 @@
 			"default": "auto"
 		},
 		"showCaptionInGallery": {
-			"type": "boolean"
+			"type": "boolean",
+			"default": true
 		},
 		"showCaptionInLightbox": {
-			"type": "boolean"
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -113,13 +113,21 @@
 		"aspectRatio": {
 			"type": "string",
 			"default": "auto"
+		},
+		"showCaptionInGallery": {
+			"type": "boolean"
+		},
+		"showCaptionInLightbox": {
+			"type": "boolean"
 		}
 	},
 	"providesContext": {
 		"allowResize": "allowResize",
 		"imageCrop": "imageCrop",
 		"fixedHeight": "fixedHeight",
-		"navigationButtonType": "navigationButtonType"
+		"navigationButtonType": "navigationButtonType",
+		"showCaptionInGallery": "showCaptionInGallery",
+		"showCaptionInLightbox": "showCaptionInLightbox"
 	},
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -7,6 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import {
+	BaseControl,
 	SelectControl,
 	ToggleControl,
 	RangeControl,
@@ -16,6 +17,7 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalVStack as VStack,
 	ToolbarDropdownMenu,
 	PanelBody,
 } from '@wordpress/components';
@@ -29,6 +31,7 @@ import {
 	MediaReplaceFlow,
 	useSettings,
 } from '@wordpress/block-editor';
+import { useInstanceId } from '@wordpress/compose';
 import { Platform, useEffect, useMemo } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -158,6 +161,8 @@ export default function GalleryEdit( props ) {
 		linkTo,
 		sizeSlug,
 		aspectRatio,
+		showCaptionInGallery,
+		showCaptionInLightbox,
 	} = attributes;
 
 	const {
@@ -231,6 +236,11 @@ export default function GalleryEdit( props ) {
 		  ).length > 0
 		: images.filter( ( image ) => image.attributes.lightbox?.enabled )
 				.length > 0;
+
+	const captionsGroupId = useInstanceId(
+		GalleryEdit,
+		'gallery-captions-group'
+	);
 
 	const themeOptions = themeRatios?.map( ( { name, ratio } ) => ( {
 		label: name,
@@ -844,6 +854,62 @@ export default function GalleryEdit( props ) {
 								</ToggleGroupControl>
 							) }
 						</ToolsPanelItem>
+						{ hasLightboxImages && (
+							<ToolsPanelItem
+								label={ __( 'Captions' ) }
+								isShownByDefault
+								hasValue={ () =>
+									showCaptionInGallery === false ||
+									showCaptionInLightbox === false
+								}
+								onDeselect={ () =>
+									setAttributes( {
+										showCaptionInGallery: undefined,
+										showCaptionInLightbox: undefined,
+									} )
+								}
+							>
+								<BaseControl
+									__nextHasNoMarginBottom
+									id={ captionsGroupId }
+									label={ __( 'Captions' ) }
+								>
+									<VStack spacing={ 4 }>
+										<ToggleControl
+											__nextHasNoMarginBottom
+											label={ __( 'Show in gallery' ) }
+											checked={
+												showCaptionInGallery !== false
+											}
+											onChange={ ( value ) =>
+												setAttributes( {
+													showCaptionInGallery: value,
+												} )
+											}
+											help={ __(
+												'Display image captions beneath each image on the page.'
+											) }
+										/>
+										<ToggleControl
+											__nextHasNoMarginBottom
+											label={ __( 'Show in lightbox' ) }
+											checked={
+												showCaptionInLightbox !== false
+											}
+											onChange={ ( value ) =>
+												setAttributes( {
+													showCaptionInLightbox:
+														value,
+												} )
+											}
+											help={ __(
+												'Display image captions at the bottom of the lightbox overlay.'
+											) }
+										/>
+									</VStack>
+								</BaseControl>
+							</ToolsPanelItem>
+						) }
 					</ToolsPanel>
 				) }
 				{ Platform.isNative && (

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -12,7 +12,9 @@
 		"postId",
 		"postType",
 		"queryId",
-		"galleryId"
+		"galleryId",
+		"showCaptionInGallery",
+		"showCaptionInLightbox"
 	],
 	"description": "Insert an image to make a visual statement.",
 	"keywords": [ "img", "photo", "picture" ],

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -311,7 +311,7 @@ export default function Image( {
 		setOffsetTop( imageElement?.offsetTop ?? 0 );
 	}, [ imageElement ] );
 	const setRefs = useMergeRefs( [ setImageElement, setResizeObserved ] );
-	const { allowResize = true } = context;
+	const { allowResize = true, showCaptionInGallery } = context;
 
 	const { image, canUserEdit, attachmentResolutionError } = useSelect(
 		( select ) => {
@@ -1333,18 +1333,20 @@ export default function Image( {
 			{ img }
 			{ resizableBox }
 
-			<Caption
-				attributes={ attributes }
-				setAttributes={ setAttributes }
-				isSelected={ isSingleSelected }
-				insertBlocksAfter={ insertBlocksAfter }
-				label={ __( 'Image caption text' ) }
-				showToolbarButton={
-					isSingleSelected &&
-					( hasNonContentControls || isContentOnlyMode ) &&
-					! hideCaptionControls
-				}
-			/>
+			{ showCaptionInGallery !== false && (
+				<Caption
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+					isSelected={ isSingleSelected }
+					insertBlocksAfter={ insertBlocksAfter }
+					label={ __( 'Image caption text' ) }
+					showToolbarButton={
+						isSingleSelected &&
+						( hasNonContentControls || isContentOnlyMode ) &&
+						! hideCaptionControls
+					}
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -230,6 +230,16 @@ function block_core_image_render_lightbox( $block_content, $block, $block_instan
 	$figure_class_names = $processor->get_attribute( 'class' );
 	$figure_styles      = $processor->get_attribute( 'style' );
 
+	// Caption. The caption is rendered as plain text via the Interactivity API's
+	// `data-wp-text` directive, so strip any markup preserved in the inline caption.
+	// When the image lives inside a Gallery block that opted out of lightbox
+	// captions, skip extraction so the overlay stays empty for those images.
+	$caption                  = '';
+	$show_caption_in_lightbox = $block_instance->context['showCaptionInLightbox'] ?? true;
+	if ( $show_caption_in_lightbox && preg_match( '/<figcaption[^>]*>(.*?)<\/figcaption>/is', $block_content, $caption_match ) ) {
+		$caption = trim( wp_strip_all_tags( $caption_match[1] ) );
+	}
+
 	// Create unique id and set the image metadata in the state.
 	$unique_image_id = uniqid();
 	wp_interactivity_state(
@@ -247,6 +257,7 @@ function block_core_image_render_lightbox( $block_content, $block, $block_instan
 					'targetHeight'           => $img_height,
 					'scaleAttr'              => $block['attrs']['scale'] ?? false,
 					'alt'                    => $alt,
+					'caption'                => $caption,
 					'galleryId'              => $block_instance->context['galleryId'] ?? null,
 					'customAriaLabel'        => $custom_aria_label ?? null,
 					'navigationButtonType'   => $block_instance->context['navigationButtonType'] ?? 'icon',
@@ -318,6 +329,29 @@ function block_core_image_render_lightbox( $block_content, $block, $block_instan
 }
 
 /**
+ * Removes the figcaption from the rendered Image block when the parent Gallery
+ * block opted out of showing captions inline (while still keeping them
+ * available in the lightbox overlay). The Gallery block exposes
+ * `showCaptionInGallery` via its provided context; when it is explicitly
+ * `false`, the figcaption is stripped from the block output.
+ *
+ * @since 23.0.0
+ *
+ * @param string   $block_content Rendered block content.
+ * @param array    $block         Block attributes and metadata.
+ * @param WP_Block $block_instance The block instance.
+ * @return string Filtered block content.
+ */
+function block_core_image_apply_gallery_caption_visibility( $block_content, $block, $block_instance ) {
+	$show_in_gallery = $block_instance->context['showCaptionInGallery'] ?? true;
+	if ( false !== $show_in_gallery ) {
+		return $block_content;
+	}
+	return preg_replace( '/<figcaption\b[^>]*>.*?<\/figcaption>/is', '', $block_content );
+}
+add_filter( 'render_block_core/image', 'block_core_image_apply_gallery_caption_visibility', 20, 3 );
+
+/**
  * @since 6.5.0
  */
 function block_core_image_print_lightbox_overlay() {
@@ -380,6 +414,7 @@ function block_core_image_print_lightbox_overlay() {
 				<div class="lightbox-image-container">
 					<figure data-wp-bind--class="state.selectedImage.figureClassNames" data-wp-bind--style="state.figureStyles">
 						<img data-wp-bind--alt="state.selectedImage.alt" data-wp-bind--class="state.selectedImage.imgClassNames" data-wp-bind--style="state.imgStyles" data-wp-bind--src="state.selectedImage.currentSrc">
+						<figcaption class="wp-lightbox-caption" data-wp-class--has-caption="!!state.selectedImage.caption" data-wp-text="state.selectedImage.caption"></figcaption>
 					</figure>
 				</div>
 				<div class="lightbox-image-container">
@@ -393,6 +428,7 @@ function block_core_image_print_lightbox_overlay() {
 							data-wp-bind--srcset="state.enlargedSrcset"
 							sizes="100vw"
 						>
+						<figcaption class="wp-lightbox-caption" data-wp-class--has-caption="!!state.selectedImage.caption" data-wp-text="state.selectedImage.caption"></figcaption>
 					</figure>
 				</div>
 				<button type="button" style="fill:{$close_button_color}" class="wp-lightbox-navigation-button wp-lightbox-navigation-button-next" data-wp-bind--hidden="!state.hasNavigation" data-wp-on--click="actions.showNextImage" data-wp-bind--aria-label="state.nextButtonAriaLabel">

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -326,8 +326,51 @@
 			height: var(--wp--lightbox-image-height);
 		}
 
-		figcaption {
+		// Hide any legacy inline figcaption inside the overlay, but keep our
+		// explicit `.wp-lightbox-caption` element visible so it can fade in.
+		figcaption:not(.wp-lightbox-caption) {
 			display: none;
+		}
+	}
+
+	// Caption inside the lightbox overlay. Uses the explicit
+	// `wp-lightbox-caption` class so the rules apply regardless of the figure's
+	// runtime class (which is bound dynamically via the Interactivity API).
+	// Visibility is driven by `:empty` rather than a hidden attribute so the
+	// fade transition is not interrupted by `display: none`.
+	.wp-lightbox-caption {
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		z-index: 3000001;
+		margin: 0;
+		padding: 3em 1em 1em;
+		color: #fff;
+		text-align: center;
+		font-size: 0.875rem;
+		line-height: 1.4;
+		background: linear-gradient(to top, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0));
+		pointer-events: none;
+		opacity: 0;
+		transition: opacity 120ms ease-in;
+
+		@media (prefers-reduced-motion: reduce) {
+			transition: none;
+		}
+	}
+
+	// Fade the caption in only after the zoom animation has had a chance to
+	// settle. `.active` is toggled on the overlay wrapper itself. The
+	// `has-caption` class is bound via the Interactivity API when the current
+	// image has a non-empty caption, which keeps the empty caption element
+	// visually hidden for images without a caption.
+	&.active .wp-lightbox-caption.has-caption {
+		opacity: 1;
+		transition: opacity 200ms ease-out 200ms;
+
+		@media (prefers-reduced-motion: reduce) {
+			transition: none;
 		}
 	}
 


### PR DESCRIPTION
## What?

Restores `figcaption` rendering inside the Image block lightbox overlay so captions authored via the inline caption field become visible when an image is enlarged via the core lightbox. Adds two Gallery-level toggles (`Show captions in gallery` / `Show captions in lightbox`) so authors can choose where captions are displayed without editing each image individually.

https://github.com/user-attachments/assets/de1356a7-8872-4a7a-b143-312eb1022e12

<img width="1036" height="678" alt="image" src="https://github.com/user-attachments/assets/8e0b5685-5417-44f9-89b6-23d6da28d030" />

## Why?

Fixes #60469.

Captions have been hidden in the lightbox overlay since #58835 shipped in WordPress 6.5. Since then, users who enable **Expand on click** on an Image block — or **Enlarge on click** on a Gallery block — lose the contextual information their caption provides exactly when users most need it: when the image is enlarged and isolated from its surrounding content.

The two Gallery toggles solve the separate-but-related problem that the inline caption is overloaded: it renders both under the image on the page and inside the lightbox. Sometimes authors want both; sometimes they want a compact grid with descriptions surfacing only on enlarge. The toggles cover the full matrix without introducing a separate caption field.

This also unblocks an effort to replace the wordpress.org Plugin Directory's legacy React screenshot gallery with native Gallery + core lightbox (see meta#8083 and WordPress/wordpress.org#524). Plugin screenshot captions typically explain what the screenshot shows, which is only useful when the screenshot is actually enlarged — and plugin pages work best when the grid itself stays compact.

## How?

Five files, ~157 lines. All changes scoped to the Image and Gallery blocks.

### `packages/block-library/src/gallery/block.json`
Adds two optional boolean attributes (`showCaptionInGallery`, `showCaptionInLightbox`) and exposes them through `providesContext`, so inner Image blocks can honour them without having to read the parent's state directly.

### `packages/block-library/src/gallery/edit.js`
Adds a single `ToolsPanelItem` labelled **Captions** under the existing _Navigation button type_ control, rendered only when the gallery has images with the lightbox enabled. Inside a `BaseControl` heading (to match the visual weight of the other sections) it renders a `VStack` of two `ToggleControl`s:

- **Show in gallery** — default `on`
- **Show in lightbox** — default `on`

Resetting the panel item clears both attributes back to `undefined` (treated as `true` in PHP), so the default behaviour is full backward compatibility.

### `packages/block-library/src/image/block.json`
Adds `showCaptionInGallery` and `showCaptionInLightbox` to `usesContext`.

### `packages/block-library/src/image/index.php`
Two small additions:

- `block_core_image_render_lightbox()` now extracts the caption from the already-rendered block content and stores it in `wp_interactivity_state()`. When the parent Gallery's context reports `showCaptionInLightbox === false`, the stored caption is an empty string so the overlay stays empty for those images. The caption is passed through `wp_strip_all_tags()` because the Interactivity API renders it via `data-wp-text`, which outputs plain text.
- `block_core_image_print_lightbox_overlay()` adds a `<figcaption class="wp-lightbox-caption">` inside each of the two overlay `<figure>` elements, bound via `data-wp-text="state.selectedImage.caption"` and `data-wp-class--has-caption="!!state.selectedImage.caption"`.
- A new `block_core_image_apply_gallery_caption_visibility()` filter (priority 20, after the lightbox filter) strips the `<figcaption>` from the rendered Image block when the Gallery context reports `showCaptionInGallery === false`. Running after the lightbox filter means the caption is still captured for the overlay before it is removed from the on-page output.

### `packages/block-library/src/image/style.scss`
- The legacy `.wp-lightbox-overlay .wp-block-image figcaption { display: none }` rule is narrowed to `figcaption:not(.wp-lightbox-caption)` so it keeps hiding any stray inline figcaption nested inside the overlay but leaves our explicit caption element alone.
- A new `.wp-lightbox-caption` rule positions the caption as a bottom-aligned bar over the image with a top-fading dark gradient for legibility; `pointer-events: none` lets clicks on the empty gradient area still close the overlay.
- A `.wp-lightbox-overlay.active .wp-lightbox-caption.has-caption` rule fades the caption in once the zoom animation has had a chance to settle (`transition: opacity 200ms ease-out 200ms`). The inverse fade-out uses a faster `120ms ease-in` declared on the base rule.
- `@media (prefers-reduced-motion: reduce)` clears the transition on both rules so users opted into reduced motion see the caption appear and disappear instantly.

No JavaScript (`view.js`) changes were required — `setButtonStyles()` already accounts for caption height when measuring the figure, so overlay sizing calculations remain intact.

## Backward compatibility

- No existing block attributes were modified; the two new attributes default to `undefined`, which is treated as `true` in PHP, so existing posts behave as before — plus they now actually show captions in the lightbox (the behaviour that existed before #58835).
- The legacy `figcaption { display: none }` rule inside the overlay is preserved, just narrowed via `:not(.wp-lightbox-caption)`.
- Gallery and Image native editor mirrors (`*.native.js`) were not modified — the new attributes are optional and the native UI simply ignores them.

### A note on rich-text captions

The inline caption attribute is a `rich-text`, so authored markup like `<strong>` and `<a>` is preserved at the block level and still renders on the front-end figure. Inside the lightbox overlay the markup is stripped to plain text because the Interactivity API currently has no safe way to bind HTML from state — `data-wp-text` is the only text-rendering directive. Keeping links live inside the overlay (plus the focus/escape interactions that requires) is worth a separate design discussion.

## Testing Instructions

1. Create a new page.
2. Add a Gallery block with several images; upload each one with a caption.
3. From the block toolbar's **Link** menu pick **Enlarge on click**.
4. In the Gallery block sidebar, below **Navigation button type**, find the new **Captions** section with two toggles.

**Expected default state:** both toggles on, captions visible both in the grid and in the lightbox (the pre-#58835 behaviour). Click an image — the lightbox opens and the caption fades in at the bottom once the zoom settles.

Variations to cover:

- **Show in gallery: off, Show in lightbox: on** — captions disappear from the grid but remain in the lightbox. This is the main use case this PR is meant to unblock.
- **Show in gallery: on, Show in lightbox: off** — captions stay under the thumbnails but the lightbox overlay shows no caption.
- **Both off** — captions are authored but never shown (useful for accessibility or migration scenarios).
- **Reduced motion** — with `prefers-reduced-motion: reduce` set in the OS, captions should appear and disappear without a fade.
- **No caption** — an image without a caption should render no caption area in the overlay.
- **Long caption** — a caption long enough to wrap should wrap inside the image width instead of overflowing.
- **Single Image block outside a gallery** — the lightbox should show the caption with default styling; the new Gallery-level toggles do not apply to standalone Image blocks (they're scoped to the Gallery context).
- **Keyboard navigation** — the caption should update correctly as you navigate between images with left/right arrow keys.
- **Screen reader** — the `<figcaption>` inside the overlay is still read as the image's caption when the overlay is open.

### Screenshots or screencast

Before: caption hidden in the lightbox.
After: caption fades in at the bottom of the lightbox overlay, with Gallery-level controls for where captions should be displayed.

## Related work

This PR unblocks the first phase of a longer effort to replace the wordpress.org Plugin Directory's screenshot gallery with core blocks:

- meta#8083 — Add lightbox to plugin screenshots
- WordPress/wordpress.org#524 — Gallery block for screenshots

A follow-up Gutenberg PR is planned to add per-image overrides for these settings (so an individual image inside a gallery can opt out of the gallery-wide default) and to look at richer caption options in the lightbox (e.g. link support, fixed positions). Those are not required to close this issue and are kept out of this PR to keep the scope focused.

Fixes #60469