### PR TITLE
Backport: Writing Flow: fix arrow keys skipping paragraph containing link

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -115,9 +115,16 @@ export function getClosestTabbable(
 	}
 
 	function isTabCandidate( node ) {
-		// If it's a block and there are nested focusable nodes, skip because
-		// there are better candidates.
+		// If it's a block wrapper (not itself a contenteditable editing surface)
+		// and there are nested focusable nodes, skip because there are better
+		// candidates. We must not skip contenteditable nodes that happen to
+		// contain links or other focusable inline elements, since those are the
+		// correct navigation targets.
+		//
+		// See https://github.com/WordPress/gutenberg/pull/77474
+		// TODO: Consider fixing focus.tabbable
 		if (
+			node.contentEditable !== 'true' &&
 			getBlockClientId( node ) &&
 			focus.focusable
 				.find( node )

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1194,6 +1194,80 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
 		).not.toBeFocused();
 	} );
+
+	test( 'should show format toolbar when selecting text from the left edge of a block', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello world' },
+		} );
+
+		// Deselect the block.
+		await page.evaluate( () =>
+			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock()
+		);
+
+		const paragraphBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		const box = await paragraphBlock.boundingBox();
+
+		// Start the drag from just before the left edge of the paragraph
+		// (on the block wrapper padding) and drag into the text.
+		const startX = box.x - 5;
+		const startY = box.y + box.height / 2;
+		const endX = box.x + box.width / 2;
+		const endY = startY;
+
+		await page.mouse.move( startX, startY );
+		await page.mouse.down();
+		await page.mouse.move( endX, endY, { steps: 10 } );
+		await page.mouse.up();
+
+		// The Bold button should be visible in the inline block toolbar.
+		await expect(
+			page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Bold' } )
+		).toBeVisible();
+	} );
+
+	// Regression test: ArrowDown should not skip over a paragraph that contains
+	// a link. See https://github.com/WordPress/gutenberg/issues/77473.
+	test( 'should not skip paragraph with link when navigating down with ArrowDown', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'a' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: '<a href="#">a</a>' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'a' },
+		} );
+
+		// Position cursor at the start of the first paragraph.
+		await editor.canvas
+			.locator( 'role=document[name="Block: Paragraph"i]' )
+			.first()
+			.click();
+		await page.keyboard.press( 'Home' );
+
+		// ArrowDown should move to the second paragraph (with the link),
+		// not skip over it to the third.
+		await page.keyboard.press( 'ArrowDown' );
+
+		// The focused element should be the second paragraph, which contains a link.
+		const focusedElement = editor.canvas.locator( ':focus' );
+		await expect( focusedElement.locator( 'a[href="#"]' ) ).toBeVisible();
+	} );
 } );
 
 class WritingFlowUtils {

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1195,45 +1195,6 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		).not.toBeFocused();
 	} );
 
-	test( 'should show format toolbar when selecting text from the left edge of a block', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( {
-			name: 'core/paragraph',
-			attributes: { content: 'Hello world' },
-		} );
-
-		// Deselect the block.
-		await page.evaluate( () =>
-			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock()
-		);
-
-		const paragraphBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Paragraph',
-		} );
-		const box = await paragraphBlock.boundingBox();
-
-		// Start the drag from just before the left edge of the paragraph
-		// (on the block wrapper padding) and drag into the text.
-		const startX = box.x - 5;
-		const startY = box.y + box.height / 2;
-		const endX = box.x + box.width / 2;
-		const endY = startY;
-
-		await page.mouse.move( startX, startY );
-		await page.mouse.down();
-		await page.mouse.move( endX, endY, { steps: 10 } );
-		await page.mouse.up();
-
-		// The Bold button should be visible in the inline block toolbar.
-		await expect(
-			page
-				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: 'Bold' } )
-		).toBeVisible();
-	} );
-
 	// Regression test: ArrowDown should not skip over a paragraph that contains
 	// a link. See https://github.com/WordPress/gutenberg/issues/77473.
 	test( 'should not skip paragraph with link when navigating down with ArrowDown', async ( {


### PR DESCRIPTION
Manual backport (due to merge conflict) of #77474 to wp/7.0