### PR TITLE
Fix: Accessibility issues in admin Font Library

### DIFF
--- a/routes/font-list/stage.tsx
+++ b/routes/font-list/stage.tsx
@@ -73,7 +73,7 @@ function FontLibraryPage() {
 	}
 
 	return (
-		<Page title={ __( 'Fonts' ) }>
+		<Page headingLevel={ 1 } title={ __( 'Fonts' ) }>
 			<Tabs
 				selectedTabId={ activeTab }
 				onSelect={ ( tabId: string ) => setActiveTab( tabId ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes - https://github.com/WordPress/gutenberg/issues/77481
Core Trac - https://core.trac.wordpress.org/ticket/65100

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
1. PR adds the heading level to be `1` for the font-library admin UI page.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. Add prop `headingLevel={ 1 }` to `Page` for the fonts page in admin UI.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Checkout to the PR.
2. Build and use the PR version of Gutenberg plugin.
3. Add the plugin to WordPress core with latest trunk branch.
4. Visit - `wp-admin/font-library.php?p=%2Ffont-list` and inspect the heading, It should be `h1`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1440" height="709" alt="Screenshot 2026-04-20 at 12 01 25 PM" src="https://github.com/user-attachments/assets/14d406eb-f9b3-4fcd-8228-cc70091ce21f" /> | <img width="1440" height="709" alt="Screenshot 2026-04-20 at 12 19 05 PM" src="https://github.com/user-attachments/assets/5fb055bd-e37a-48b9-ad65-fde4db54fa20" /> |

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
- None
