### PR TITLE
Core Data: Remove redundant memoization wrapper from 'getQueriedItems'

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Remove redundant `createSelector` wrapper from `getQueriedItems`; the inner deep-equality cache already handles inlined query objects.
+
 ## 7.44.0 (2026-04-15)
 
 ### Bug Fixes

--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -4,11 +4,6 @@
 import EquivalentKeyMap from 'equivalent-key-map';
 
 /**
- * WordPress dependencies
- */
-import { createSelector } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
 import getQueryParts from './get-query-parts';
@@ -114,11 +109,9 @@ function getQueriedItemsUncached( state, query, options = {} ) {
 
 /**
  * Returns items for a given query, or null if the items are not known. Caches
- * result both per state (by reference) and per query (by deep equality).
- * The caching approach is intended to be durable to query objects which are
- * deeply but not referentially equal, since otherwise:
+ * result per state (by reference) and per query (by deep equality), so that:
  *
- * `getQueriedItems( state, {} ) !== getQueriedItems( state, {} )`
+ * `getQueriedItems( state, {} ) === getQueriedItems( state, {} )`
  *
  * @param {Object}  state                      State object.
  * @param {?Object} query                      Optional query.
@@ -127,24 +120,22 @@ function getQueriedItemsUncached( state, query, options = {} ) {
  *
  * @return {?Array} Query items.
  */
-export const getQueriedItems = createSelector(
-	( state, query = {}, options = {} ) => {
-		let queriedItemsCache = queriedItemsCacheByState.get( state );
-		if ( queriedItemsCache ) {
-			const queriedItems = queriedItemsCache.get( query );
-			if ( queriedItems !== undefined ) {
-				return queriedItems;
-			}
-		} else {
-			queriedItemsCache = new EquivalentKeyMap();
-			queriedItemsCacheByState.set( state, queriedItemsCache );
+export function getQueriedItems( state, query = {}, options = {} ) {
+	let queriedItemsCache = queriedItemsCacheByState.get( state );
+	if ( queriedItemsCache ) {
+		const queriedItems = queriedItemsCache.get( query );
+		if ( queriedItems !== undefined ) {
+			return queriedItems;
 		}
-
-		const items = getQueriedItemsUncached( state, query, options );
-		queriedItemsCache.set( query, items );
-		return items;
+	} else {
+		queriedItemsCache = new EquivalentKeyMap();
+		queriedItemsCacheByState.set( state, queriedItemsCache );
 	}
-);
+
+	const items = getQueriedItemsUncached( state, query, options );
+	queriedItemsCache.set( query, items );
+	return items;
+}
 
 export function getQueriedTotalItems( state, query = {} ) {
 	const { stableKey, context } = getQueryParts( query );


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/76406#discussion_r3021647145.

Drop the `createSelector` (rememo) wrapper around `getQueriedItems`; keep the existing inner `EquivalentKeyMap`-based cache.

## Why?
Rememo caches by reference equality on arguments. Callers inline query objects (`getEntityRecords(state, 'postType', 'post', { per_page: 10 })`), so the query is a new reference every call and rememo's cache never hits - every call fell through to the inner function.

The inner `EquivalentKeyMap` caches by deep equality, which is how queries are actually passed. Removing the wrapper keeps behavior identical and drops per-call overhead (arg copy, WeakMap walk, linked-list scan).

## Testing Instructions
1. Smoke test editors and DataViews.
2. Confirm there are no warnings from the `useSelect` hook, which tests unstable references in dev mode.

### Testing Instructions for Keyboard
Same.
