### PR TITLE
Guidelines CPT: Skip registration when post type already exists

### DIFF
--- a/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
@@ -76,6 +76,10 @@ class Gutenberg_Guidelines_Post_Type {
 	 * Register the custom post type.
 	 */
 	public static function register() {
+		if ( post_type_exists( self::POST_TYPE ) ) {
+			return;
+		}
+
 		$args = array(
 			'labels'                          => array(
 				'name'          => __( 'Guidelines', 'gutenberg' ),


### PR DESCRIPTION
## Summary

Adds an early return in `Gutenberg_Guidelines_Post_Type::register()` so that if the `wp_guideline` post type is already registered (for example by WordPress core once the CPT lands there), the Gutenberg plugin does not re-register it — and by extension skips the `wp_guideline_type` taxonomy registration too.

Forward-compatibility preparation for #77230 (Phase 1). No behavior change for current users running the plugin against WP core that doesn't ship the CPT.

## Test plan

- [ ] Unit tests still pass: `composer test`
- [ ] With a WP core build that does not register `wp_guideline`, the CPT and taxonomy are registered as before (verify via `wp post-type list` / `wp taxonomy list`).
- [ ] With a stub that pre-registers `wp_guideline`, Gutenberg's `register()` exits early and does not override the existing registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)