### PR TITLE
PoC: Basic entity management

### DIFF
--- a/lib/experimental/entities/class-gutenberg-entity-manager.php
+++ b/lib/experimental/entities/class-gutenberg-entity-manager.php
@@ -73,6 +73,30 @@ class Gutenberg_Entity_Manager {
 			}
 		}
 
+		// Clean up uncustomized orphans: stored plugin entities that are no
+		// longer registered and were never customized have no reason to
+		// linger in the option.
+		foreach ( $configs['post_types'] as $slug => $config ) {
+			if (
+				empty( $config['_user_created'] ) &&
+				empty( $config['_customized'] ) &&
+				! post_type_exists( $slug )
+			) {
+				unset( $configs['post_types'][ $slug ] );
+				$dirty = true;
+			}
+		}
+		foreach ( $configs['taxonomies'] as $slug => $config ) {
+			if (
+				empty( $config['_user_created'] ) &&
+				empty( $config['_customized'] ) &&
+				! taxonomy_exists( $slug )
+			) {
+				unset( $configs['taxonomies'][ $slug ] );
+				$dirty = true;
+			}
+		}
+
 		// Apply post type configs.
 		foreach ( $configs['post_types'] as $slug => $config ) {
 			if ( empty( $config['_user_created'] ) && post_type_exists( $slug ) ) {

--- a/lib/experimental/entities/class-gutenberg-entity-manager.php
+++ b/lib/experimental/entities/class-gutenberg-entity-manager.php
@@ -102,7 +102,6 @@ class Gutenberg_Entity_Manager {
 
 		return array(
 			'_user_created' => false,
-			'_source'       => ! empty( $type_object->_builtin ) ? 'core' : 'plugin',
 			'labels'        => $labels,
 			'description'   => $type_object->description ?? '',
 			'public'        => (bool) ( $type_object->public ?? false ),
@@ -142,7 +141,6 @@ class Gutenberg_Entity_Manager {
 
 		return array(
 			'_user_created' => false,
-			'_source'       => ! empty( $taxonomy_object->_builtin ) ? 'core' : 'plugin',
 			'labels'        => $labels,
 			'description'   => $taxonomy_object->description ?? '',
 			'public'        => (bool) ( $taxonomy_object->public ?? false ),
@@ -223,7 +221,6 @@ class Gutenberg_Entity_Manager {
 				}
 			}
 		}
-
 	}
 
 	/**

--- a/lib/experimental/entities/class-gutenberg-entity-manager.php
+++ b/lib/experimental/entities/class-gutenberg-entity-manager.php
@@ -245,6 +245,7 @@ class Gutenberg_Entity_Manager {
 				}
 			}
 		}
+
 	}
 
 	/**
@@ -323,6 +324,27 @@ class Gutenberg_Entity_Manager {
 
 		if ( isset( $config['show_in_rest'] ) ) {
 			$taxonomy_object->show_in_rest = (bool) $config['show_in_rest'];
+		}
+
+		if ( isset( $config['object_type'] ) ) {
+			$current_object_types = (array) $taxonomy_object->object_type;
+			$desired_object_types = (array) $config['object_type'];
+
+			// Unregister from post types that are no longer assigned.
+			foreach ( $current_object_types as $post_type ) {
+				if ( ! in_array( $post_type, $desired_object_types, true ) ) {
+					unregister_taxonomy_for_object_type( $slug, $post_type );
+				}
+			}
+
+			// Register for newly assigned post types.
+			foreach ( $desired_object_types as $post_type ) {
+				if ( ! in_array( $post_type, $current_object_types, true ) ) {
+					register_taxonomy_for_object_type( $slug, $post_type );
+				}
+			}
+
+			$taxonomy_object->object_type = $desired_object_types;
 		}
 	}
 

--- a/lib/experimental/entities/class-gutenberg-entity-manager.php
+++ b/lib/experimental/entities/class-gutenberg-entity-manager.php
@@ -1,0 +1,352 @@
+<?php
+/**
+ * Entity Manager.
+ *
+ * Manages the lifecycle of post types and taxonomies, storing their
+ * configurations in a database option and re-registering them on init.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Entity configuration manager.
+ */
+class Gutenberg_Entity_Manager {
+
+	/**
+	 * Option name for storing entity configurations.
+	 *
+	 * @var string
+	 */
+	const OPTION_NAME = 'gutenberg_entity_configs';
+
+	/**
+	 * Initializes the entity manager hooks.
+	 */
+	public static function init() {
+		add_action( 'init', array( __CLASS__, 'apply_entity_configs' ), 99 );
+	}
+
+	/**
+	 * Applies stored entity configurations.
+	 *
+	 * On first run, seeds the option from currently registered types.
+	 * On subsequent runs, modifies existing types and registers user-created ones.
+	 */
+	public static function apply_entity_configs() {
+		$configs = get_option( self::OPTION_NAME, null );
+
+		// First activation: seed from current state.
+		if ( null === $configs || false === $configs ) {
+			$configs = self::seed_from_current_state();
+			update_option( self::OPTION_NAME, $configs, false );
+			return;
+		}
+
+		// Apply post type configs.
+		if ( ! empty( $configs['post_types'] ) ) {
+			foreach ( $configs['post_types'] as $slug => $config ) {
+				if ( empty( $config['_user_created'] ) && post_type_exists( $slug ) ) {
+					self::modify_post_type( $slug, $config );
+				} elseif ( ! empty( $config['_user_created'] ) && ! post_type_exists( $slug ) ) {
+					self::register_custom_post_type( $slug, $config );
+				}
+			}
+		}
+
+		// Apply taxonomy configs.
+		if ( ! empty( $configs['taxonomies'] ) ) {
+			foreach ( $configs['taxonomies'] as $slug => $config ) {
+				if ( empty( $config['_user_created'] ) && taxonomy_exists( $slug ) ) {
+					self::modify_taxonomy( $slug, $config );
+				} elseif ( ! empty( $config['_user_created'] ) && ! taxonomy_exists( $slug ) ) {
+					self::register_custom_taxonomy( $slug, $config );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Seeds the entity configs option from currently registered types and taxonomies.
+	 *
+	 * @return array The seeded configuration array.
+	 */
+	public static function seed_from_current_state() {
+		$configs = array(
+			'post_types' => array(),
+			'taxonomies' => array(),
+		);
+
+		// Capture all registered post types.
+		$post_types = get_post_types( array(), 'objects' );
+		foreach ( $post_types as $slug => $type_object ) {
+			$configs['post_types'][ $slug ] = self::extract_post_type_config( $slug, $type_object );
+		}
+
+		// Capture all registered taxonomies.
+		$taxonomies = get_taxonomies( array(), 'objects' );
+		foreach ( $taxonomies as $slug => $taxonomy_object ) {
+			$configs['taxonomies'][ $slug ] = self::extract_taxonomy_config( $slug, $taxonomy_object );
+		}
+
+		return $configs;
+	}
+
+	/**
+	 * Extracts a storable configuration from a WP_Post_Type object.
+	 *
+	 * @param string       $slug        The post type slug.
+	 * @param WP_Post_Type $type_object The post type object.
+	 * @return array The extracted configuration.
+	 */
+	private static function extract_post_type_config( $slug, $type_object ) {
+		$labels = array();
+		if ( isset( $type_object->labels ) ) {
+			$labels = (array) $type_object->labels;
+		}
+
+		$supports = get_all_post_type_supports( $slug );
+
+		// Normalize supports to boolean values.
+		$normalized_supports = array();
+		foreach ( $supports as $feature => $value ) {
+			$normalized_supports[ $feature ] = (bool) $value;
+		}
+
+		$rewrite = false;
+		if ( is_array( $type_object->rewrite ) ) {
+			$rewrite = $type_object->rewrite;
+		} elseif ( true === $type_object->rewrite ) {
+			$rewrite = array( 'slug' => $slug );
+		}
+
+		return array(
+			'_user_created' => false,
+			'labels'        => $labels,
+			'description'   => $type_object->description ?? '',
+			'public'        => (bool) ( $type_object->public ?? false ),
+			'hierarchical'  => (bool) ( $type_object->hierarchical ?? false ),
+			'supports'      => $normalized_supports,
+			'has_archive'   => $type_object->has_archive ?? false,
+			'rewrite'       => $rewrite,
+			'show_in_rest'  => (bool) ( $type_object->show_in_rest ?? false ),
+			'rest_base'     => $type_object->rest_base ?? $slug,
+			'menu_icon'     => $type_object->menu_icon ?? null,
+			'menu_position' => $type_object->menu_position ?? null,
+			'show_ui'       => (bool) ( $type_object->show_ui ?? false ),
+			'show_in_menu'  => $type_object->show_in_menu ?? false,
+			'taxonomies'    => (array) get_object_taxonomies( $slug ),
+		);
+	}
+
+	/**
+	 * Extracts a storable configuration from a WP_Taxonomy object.
+	 *
+	 * @param string      $slug            The taxonomy slug.
+	 * @param WP_Taxonomy $taxonomy_object The taxonomy object.
+	 * @return array The extracted configuration.
+	 */
+	private static function extract_taxonomy_config( $slug, $taxonomy_object ) {
+		$labels = array();
+		if ( isset( $taxonomy_object->labels ) ) {
+			$labels = (array) $taxonomy_object->labels;
+		}
+
+		$rewrite = false;
+		if ( is_array( $taxonomy_object->rewrite ) ) {
+			$rewrite = $taxonomy_object->rewrite;
+		} elseif ( true === $taxonomy_object->rewrite ) {
+			$rewrite = array( 'slug' => $slug );
+		}
+
+		return array(
+			'_user_created' => false,
+			'labels'        => $labels,
+			'description'   => $taxonomy_object->description ?? '',
+			'public'        => (bool) ( $taxonomy_object->public ?? false ),
+			'hierarchical'  => (bool) ( $taxonomy_object->hierarchical ?? false ),
+			'show_in_rest'  => (bool) ( $taxonomy_object->show_in_rest ?? false ),
+			'rest_base'     => $taxonomy_object->rest_base ?? $slug,
+			'show_ui'       => (bool) ( $taxonomy_object->show_ui ?? false ),
+			'show_in_menu'  => $taxonomy_object->show_in_menu ?? false,
+			'rewrite'       => $rewrite,
+			'object_type'   => (array) ( $taxonomy_object->object_type ?? array() ),
+		);
+	}
+
+	/**
+	 * Modifies an existing post type in place using global $wp_post_types.
+	 *
+	 * @param string $slug   The post type slug.
+	 * @param array  $config The stored configuration.
+	 */
+	private static function modify_post_type( $slug, $config ) {
+		global $wp_post_types;
+
+		if ( ! isset( $wp_post_types[ $slug ] ) ) {
+			return;
+		}
+
+		$type_object = $wp_post_types[ $slug ];
+
+		if ( ! empty( $config['labels'] ) ) {
+			$type_object->labels = (object) array_merge(
+				(array) $type_object->labels,
+				$config['labels']
+			);
+			$type_object->label = $type_object->labels->name ?? $type_object->label;
+		}
+
+		if ( isset( $config['description'] ) ) {
+			$type_object->description = $config['description'];
+		}
+
+		if ( isset( $config['public'] ) ) {
+			$type_object->public = (bool) $config['public'];
+		}
+
+		if ( isset( $config['show_ui'] ) ) {
+			$type_object->show_ui = (bool) $config['show_ui'];
+		}
+
+		if ( isset( $config['show_in_menu'] ) ) {
+			$type_object->show_in_menu = $config['show_in_menu'];
+		}
+
+		if ( isset( $config['show_in_rest'] ) ) {
+			$type_object->show_in_rest = (bool) $config['show_in_rest'];
+		}
+
+		if ( isset( $config['menu_icon'] ) ) {
+			$type_object->menu_icon = $config['menu_icon'];
+		}
+
+		if ( isset( $config['menu_position'] ) ) {
+			$type_object->menu_position = $config['menu_position'];
+		}
+
+		if ( isset( $config['has_archive'] ) ) {
+			$type_object->has_archive = $config['has_archive'];
+		}
+
+		if ( isset( $config['supports'] ) ) {
+			// Clear and re-add supports.
+			$existing_supports = get_all_post_type_supports( $slug );
+			foreach ( array_keys( $existing_supports ) as $feature ) {
+				remove_post_type_support( $slug, $feature );
+			}
+			foreach ( $config['supports'] as $feature => $enabled ) {
+				if ( $enabled ) {
+					add_post_type_support( $slug, $feature );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Registers a user-created post type.
+	 *
+	 * @param string $slug   The post type slug.
+	 * @param array  $config The stored configuration.
+	 */
+	private static function register_custom_post_type( $slug, $config ) {
+		$supports = array();
+		if ( ! empty( $config['supports'] ) ) {
+			$supports = array_keys( array_filter( $config['supports'] ) );
+		}
+		if ( empty( $supports ) ) {
+			$supports = array( 'title', 'editor' );
+		}
+
+		$args = array(
+			'labels'        => $config['labels'] ?? array(),
+			'description'   => $config['description'] ?? '',
+			'public'        => $config['public'] ?? true,
+			'hierarchical'  => $config['hierarchical'] ?? false,
+			'supports'      => $supports,
+			'has_archive'   => $config['has_archive'] ?? false,
+			'rewrite'       => $config['rewrite'] ?? true,
+			'show_in_rest'  => $config['show_in_rest'] ?? true,
+			'rest_base'     => $config['rest_base'] ?? $slug,
+			'menu_icon'     => $config['menu_icon'] ?? 'dashicons-admin-post',
+			'menu_position' => $config['menu_position'] ?? null,
+			'show_ui'       => $config['show_ui'] ?? true,
+			'show_in_menu'  => $config['show_in_menu'] ?? true,
+			'taxonomies'    => $config['taxonomies'] ?? array(),
+		);
+
+		register_post_type( $slug, $args );
+	}
+
+	/**
+	 * Modifies an existing taxonomy in place using global $wp_taxonomies.
+	 *
+	 * @param string $slug   The taxonomy slug.
+	 * @param array  $config The stored configuration.
+	 */
+	private static function modify_taxonomy( $slug, $config ) {
+		global $wp_taxonomies;
+
+		if ( ! isset( $wp_taxonomies[ $slug ] ) ) {
+			return;
+		}
+
+		$taxonomy_object = $wp_taxonomies[ $slug ];
+
+		if ( ! empty( $config['labels'] ) ) {
+			$taxonomy_object->labels = (object) array_merge(
+				(array) $taxonomy_object->labels,
+				$config['labels']
+			);
+			$taxonomy_object->label = $taxonomy_object->labels->name ?? $taxonomy_object->label;
+		}
+
+		if ( isset( $config['description'] ) ) {
+			$taxonomy_object->description = $config['description'];
+		}
+
+		if ( isset( $config['public'] ) ) {
+			$taxonomy_object->public = (bool) $config['public'];
+		}
+
+		if ( isset( $config['show_ui'] ) ) {
+			$taxonomy_object->show_ui = (bool) $config['show_ui'];
+		}
+
+		if ( isset( $config['show_in_menu'] ) ) {
+			$taxonomy_object->show_in_menu = $config['show_in_menu'];
+		}
+
+		if ( isset( $config['show_in_rest'] ) ) {
+			$taxonomy_object->show_in_rest = (bool) $config['show_in_rest'];
+		}
+	}
+
+	/**
+	 * Registers a user-created taxonomy.
+	 *
+	 * @param string $slug   The taxonomy slug.
+	 * @param array  $config The stored configuration.
+	 */
+	private static function register_custom_taxonomy( $slug, $config ) {
+		$args = array(
+			'labels'        => $config['labels'] ?? array(),
+			'description'   => $config['description'] ?? '',
+			'public'        => $config['public'] ?? true,
+			'hierarchical'  => $config['hierarchical'] ?? false,
+			'show_in_rest'  => $config['show_in_rest'] ?? true,
+			'rest_base'     => $config['rest_base'] ?? $slug,
+			'show_ui'       => $config['show_ui'] ?? true,
+			'show_in_menu'  => $config['show_in_menu'] ?? true,
+			'rewrite'       => $config['rewrite'] ?? true,
+		);
+
+		$object_type = $config['object_type'] ?? array( 'post' );
+
+		register_taxonomy( $slug, $object_type, $args );
+	}
+}

--- a/lib/experimental/entities/class-gutenberg-entity-manager.php
+++ b/lib/experimental/entities/class-gutenberg-entity-manager.php
@@ -39,6 +39,7 @@ class Gutenberg_Entity_Manager {
 	 */
 	public static function apply_entity_configs() {
 		$configs = get_option( self::OPTION_NAME, null );
+		$dirty   = false;
 
 		// First activation: seed from current state.
 		if ( null === $configs || false === $configs ) {
@@ -47,26 +48,53 @@ class Gutenberg_Entity_Manager {
 			return;
 		}
 
-		// Apply post type configs.
-		if ( ! empty( $configs['post_types'] ) ) {
-			foreach ( $configs['post_types'] as $slug => $config ) {
-				if ( empty( $config['_user_created'] ) && post_type_exists( $slug ) ) {
-					self::modify_post_type( $slug, $config );
-				} elseif ( ! empty( $config['_user_created'] ) && ! post_type_exists( $slug ) ) {
-					self::register_custom_post_type( $slug, $config );
-				}
+		if ( ! isset( $configs['post_types'] ) ) {
+			$configs['post_types'] = array();
+		}
+		if ( ! isset( $configs['taxonomies'] ) ) {
+			$configs['taxonomies'] = array();
+		}
+
+		// Auto-detect new post types registered by plugins since last run.
+		$post_types = get_post_types( array(), 'objects' );
+		foreach ( $post_types as $slug => $type_object ) {
+			if ( ! isset( $configs['post_types'][ $slug ] ) ) {
+				$configs['post_types'][ $slug ] = self::extract_post_type_config( $slug, $type_object );
+				$dirty                          = true;
 			}
 		}
 
-		// Apply taxonomy configs.
-		if ( ! empty( $configs['taxonomies'] ) ) {
-			foreach ( $configs['taxonomies'] as $slug => $config ) {
-				if ( empty( $config['_user_created'] ) && taxonomy_exists( $slug ) ) {
-					self::modify_taxonomy( $slug, $config );
-				} elseif ( ! empty( $config['_user_created'] ) && ! taxonomy_exists( $slug ) ) {
-					self::register_custom_taxonomy( $slug, $config );
-				}
+		// Auto-detect new taxonomies registered by plugins since last run.
+		$taxonomies = get_taxonomies( array(), 'objects' );
+		foreach ( $taxonomies as $slug => $taxonomy_object ) {
+			if ( ! isset( $configs['taxonomies'][ $slug ] ) ) {
+				$configs['taxonomies'][ $slug ] = self::extract_taxonomy_config( $slug, $taxonomy_object );
+				$dirty                          = true;
 			}
+		}
+
+		// Apply post type configs.
+		foreach ( $configs['post_types'] as $slug => $config ) {
+			if ( empty( $config['_user_created'] ) && post_type_exists( $slug ) ) {
+				self::modify_post_type( $slug, $config );
+			} elseif ( ! empty( $config['_user_created'] ) && ! post_type_exists( $slug ) ) {
+				self::register_custom_post_type( $slug, $config );
+			}
+			// If not user-created and doesn't exist, it's an orphan — skip silently.
+		}
+
+		// Apply taxonomy configs.
+		foreach ( $configs['taxonomies'] as $slug => $config ) {
+			if ( empty( $config['_user_created'] ) && taxonomy_exists( $slug ) ) {
+				self::modify_taxonomy( $slug, $config );
+			} elseif ( ! empty( $config['_user_created'] ) && ! taxonomy_exists( $slug ) ) {
+				self::register_custom_taxonomy( $slug, $config );
+			}
+			// If not user-created and doesn't exist, it's an orphan — skip silently.
+		}
+
+		if ( $dirty ) {
+			update_option( self::OPTION_NAME, $configs, false );
 		}
 	}
 
@@ -126,6 +154,7 @@ class Gutenberg_Entity_Manager {
 
 		return array(
 			'_user_created' => false,
+			'_source'       => ! empty( $type_object->_builtin ) ? 'core' : 'plugin',
 			'labels'        => $labels,
 			'description'   => $type_object->description ?? '',
 			'public'        => (bool) ( $type_object->public ?? false ),
@@ -165,6 +194,7 @@ class Gutenberg_Entity_Manager {
 
 		return array(
 			'_user_created' => false,
+			'_source'       => ! empty( $taxonomy_object->_builtin ) ? 'core' : 'plugin',
 			'labels'        => $labels,
 			'description'   => $taxonomy_object->description ?? '',
 			'public'        => (bool) ( $taxonomy_object->public ?? false ),

--- a/lib/experimental/entities/class-gutenberg-entity-manager.php
+++ b/lib/experimental/entities/class-gutenberg-entity-manager.php
@@ -34,128 +34,52 @@ class Gutenberg_Entity_Manager {
 	/**
 	 * Applies stored entity configurations.
 	 *
-	 * On first run, seeds the option from currently registered types.
-	 * On subsequent runs, modifies existing types and registers user-created ones.
+	 * The stored option only contains user-created entities and
+	 * customizations on top of otherwise-registered entities. Everything
+	 * else is left untouched so it behaves exactly as core/plugins register
+	 * it.
 	 */
 	public static function apply_entity_configs() {
-		$configs = get_option( self::OPTION_NAME, null );
-		$dirty   = false;
+		$configs = get_option( self::OPTION_NAME, array() );
 
-		// First activation: seed from current state.
-		if ( null === $configs || false === $configs ) {
-			$configs = self::seed_from_current_state();
-			update_option( self::OPTION_NAME, $configs, false );
-			return;
-		}
-
-		if ( ! isset( $configs['post_types'] ) ) {
-			$configs['post_types'] = array();
-		}
-		if ( ! isset( $configs['taxonomies'] ) ) {
-			$configs['taxonomies'] = array();
-		}
-
-		// Auto-detect new post types registered by plugins since last run.
-		$post_types = get_post_types( array(), 'objects' );
-		foreach ( $post_types as $slug => $type_object ) {
-			if ( ! isset( $configs['post_types'][ $slug ] ) ) {
-				$configs['post_types'][ $slug ] = self::extract_post_type_config( $slug, $type_object );
-				$dirty                          = true;
+		if ( ! empty( $configs['post_types'] ) ) {
+			foreach ( $configs['post_types'] as $slug => $config ) {
+				if ( ! empty( $config['_user_created'] ) ) {
+					if ( ! post_type_exists( $slug ) ) {
+						self::register_custom_post_type( $slug, $config );
+					}
+				} elseif ( post_type_exists( $slug ) ) {
+					// Customized core/plugin entity — apply overrides.
+					self::modify_post_type( $slug, $config );
+				}
+				// If not user-created and doesn't exist, it's an orphan — skip silently.
 			}
 		}
 
-		// Auto-detect new taxonomies registered by plugins since last run.
-		$taxonomies = get_taxonomies( array(), 'objects' );
-		foreach ( $taxonomies as $slug => $taxonomy_object ) {
-			if ( ! isset( $configs['taxonomies'][ $slug ] ) ) {
-				$configs['taxonomies'][ $slug ] = self::extract_taxonomy_config( $slug, $taxonomy_object );
-				$dirty                          = true;
+		if ( ! empty( $configs['taxonomies'] ) ) {
+			foreach ( $configs['taxonomies'] as $slug => $config ) {
+				if ( ! empty( $config['_user_created'] ) ) {
+					if ( ! taxonomy_exists( $slug ) ) {
+						self::register_custom_taxonomy( $slug, $config );
+					}
+				} elseif ( taxonomy_exists( $slug ) ) {
+					self::modify_taxonomy( $slug, $config );
+				}
 			}
 		}
-
-		// Clean up uncustomized orphans: stored plugin entities that are no
-		// longer registered and were never customized have no reason to
-		// linger in the option.
-		foreach ( $configs['post_types'] as $slug => $config ) {
-			if (
-				empty( $config['_user_created'] ) &&
-				empty( $config['_customized'] ) &&
-				! post_type_exists( $slug )
-			) {
-				unset( $configs['post_types'][ $slug ] );
-				$dirty = true;
-			}
-		}
-		foreach ( $configs['taxonomies'] as $slug => $config ) {
-			if (
-				empty( $config['_user_created'] ) &&
-				empty( $config['_customized'] ) &&
-				! taxonomy_exists( $slug )
-			) {
-				unset( $configs['taxonomies'][ $slug ] );
-				$dirty = true;
-			}
-		}
-
-		// Apply post type configs.
-		foreach ( $configs['post_types'] as $slug => $config ) {
-			if ( empty( $config['_user_created'] ) && post_type_exists( $slug ) ) {
-				self::modify_post_type( $slug, $config );
-			} elseif ( ! empty( $config['_user_created'] ) && ! post_type_exists( $slug ) ) {
-				self::register_custom_post_type( $slug, $config );
-			}
-			// If not user-created and doesn't exist, it's an orphan — skip silently.
-		}
-
-		// Apply taxonomy configs.
-		foreach ( $configs['taxonomies'] as $slug => $config ) {
-			if ( empty( $config['_user_created'] ) && taxonomy_exists( $slug ) ) {
-				self::modify_taxonomy( $slug, $config );
-			} elseif ( ! empty( $config['_user_created'] ) && ! taxonomy_exists( $slug ) ) {
-				self::register_custom_taxonomy( $slug, $config );
-			}
-			// If not user-created and doesn't exist, it's an orphan — skip silently.
-		}
-
-		if ( $dirty ) {
-			update_option( self::OPTION_NAME, $configs, false );
-		}
-	}
-
-	/**
-	 * Seeds the entity configs option from currently registered types and taxonomies.
-	 *
-	 * @return array The seeded configuration array.
-	 */
-	public static function seed_from_current_state() {
-		$configs = array(
-			'post_types' => array(),
-			'taxonomies' => array(),
-		);
-
-		// Capture all registered post types.
-		$post_types = get_post_types( array(), 'objects' );
-		foreach ( $post_types as $slug => $type_object ) {
-			$configs['post_types'][ $slug ] = self::extract_post_type_config( $slug, $type_object );
-		}
-
-		// Capture all registered taxonomies.
-		$taxonomies = get_taxonomies( array(), 'objects' );
-		foreach ( $taxonomies as $slug => $taxonomy_object ) {
-			$configs['taxonomies'][ $slug ] = self::extract_taxonomy_config( $slug, $taxonomy_object );
-		}
-
-		return $configs;
 	}
 
 	/**
 	 * Extracts a storable configuration from a WP_Post_Type object.
 	 *
+	 * Used by the REST controller to build a "default" representation of
+	 * an entity that isn't stored in the option.
+	 *
 	 * @param string       $slug        The post type slug.
 	 * @param WP_Post_Type $type_object The post type object.
 	 * @return array The extracted configuration.
 	 */
-	private static function extract_post_type_config( $slug, $type_object ) {
+	public static function extract_post_type_config( $slug, $type_object ) {
 		$labels = array();
 		if ( isset( $type_object->labels ) ) {
 			$labels = (array) $type_object->labels;
@@ -203,7 +127,7 @@ class Gutenberg_Entity_Manager {
 	 * @param WP_Taxonomy $taxonomy_object The taxonomy object.
 	 * @return array The extracted configuration.
 	 */
-	private static function extract_taxonomy_config( $slug, $taxonomy_object ) {
+	public static function extract_taxonomy_config( $slug, $taxonomy_object ) {
 		$labels = array();
 		if ( isset( $taxonomy_object->labels ) ) {
 			$labels = (array) $taxonomy_object->labels;

--- a/lib/experimental/entities/class-gutenberg-rest-entity-configs-controller.php
+++ b/lib/experimental/entities/class-gutenberg-rest-entity-configs-controller.php
@@ -322,18 +322,13 @@ class Gutenberg_REST_Entity_Configs_Controller extends WP_REST_Controller {
 
 		$updated = $this->prepare_config_from_request( $request, $entity_type );
 
-		// Merge updated fields into existing config.
-		$config                   = array_merge( $existing, $updated );
-		$config['_user_created']  = ! empty( $existing['_user_created'] );
-		$config['_customized']    = true;
+		// Merge updated fields into existing config. _customized is only
+		// meaningful for non-user-created entities (it gates the Revert UI).
+		$config = array_merge( $existing, $updated );
+		if ( empty( $config['_user_created'] ) ) {
+			$config['_customized'] = true;
+		}
 		$configs[ $key ][ $slug ] = $config;
-
-		if ( ! isset( $configs['post_types'] ) ) {
-			$configs['post_types'] = array();
-		}
-		if ( ! isset( $configs['taxonomies'] ) ) {
-			$configs['taxonomies'] = array();
-		}
 
 		update_option( Gutenberg_Entity_Manager::OPTION_NAME, $configs, false );
 
@@ -346,7 +341,11 @@ class Gutenberg_REST_Entity_Configs_Controller extends WP_REST_Controller {
 	/**
 	 * Deletes an entity configuration.
 	 *
-	 * Only user-created entities can be deleted.
+	 * For user-created entities this is a real deletion (stored config
+	 * removed and the type unregistered). For customized core/plugin
+	 * entities it is a "revert": the stored overrides are removed, and the
+	 * live registration is left alone so the type reverts to whatever core
+	 * or the plugin registered.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object or error.
@@ -394,10 +393,9 @@ class Gutenberg_REST_Entity_Configs_Controller extends WP_REST_Controller {
 		}
 
 		// For user-created entities, unregister so the type/taxonomy is
-		// fully removed. For plugin-registered entities (revert), leave the
-		// live registration alone — the plugin re-registers it on every
-		// request, and auto-detection will re-seed the config with default
-		// values on the next page load.
+		// fully removed. For core/plugin entities (revert), leave the live
+		// registration alone — core or the plugin re-registers it on every
+		// request, restoring the original defaults.
 		if ( ! empty( $config['_user_created'] ) ) {
 			if ( 'post_type' === $entity_type && post_type_exists( $slug ) ) {
 				unregister_post_type( $slug );
@@ -432,20 +430,20 @@ class Gutenberg_REST_Entity_Configs_Controller extends WP_REST_Controller {
 		// (e.g., the plugin that created it was deactivated).
 		$is_orphaned = ! $is_registered && empty( $config['_user_created'] );
 
-		// Compute _source from the live type object when possible so the
-		// classification self-heals even if the stored config predates the
-		// _source field or the entity's source has changed.
+		// Compute _source from the live type object. Orphans fall back to
+		// 'plugin' since the original registrant is gone.
 		if ( ! empty( $config['_user_created'] ) ) {
 			$source = 'user';
 		} elseif ( 'post_type' === $entity_type && $is_registered ) {
-			$type_object = get_post_type_object( $slug );
-			$source      = ! empty( $type_object->_builtin ) ? 'core' : 'plugin';
+			$source = ! empty( get_post_type_object( $slug )->_builtin )
+				? 'core'
+				: 'plugin';
 		} elseif ( 'taxonomy' === $entity_type && $is_registered ) {
-			$taxonomy_object = get_taxonomy( $slug );
-			$source          = ! empty( $taxonomy_object->_builtin ) ? 'core' : 'plugin';
+			$source = ! empty( get_taxonomy( $slug )->_builtin )
+				? 'core'
+				: 'plugin';
 		} else {
-			// Orphaned and unknown: fall back to stored value or 'plugin'.
-			$source = $config['_source'] ?? 'plugin';
+			$source = 'plugin';
 		}
 
 		return array_merge(

--- a/lib/experimental/entities/class-gutenberg-rest-entity-configs-controller.php
+++ b/lib/experimental/entities/class-gutenberg-rest-entity-configs-controller.php
@@ -97,16 +97,42 @@ class Gutenberg_REST_Entity_Configs_Controller extends WP_REST_Controller {
 	 */
 	public function get_items( $request ) {
 		$configs = get_option( Gutenberg_Entity_Manager::OPTION_NAME, array() );
-		$result  = array();
+		$stored_post_types = $configs['post_types'] ?? array();
+		$stored_taxonomies = $configs['taxonomies'] ?? array();
+		$result            = array();
+		$seen_post_types   = array();
+		$seen_taxonomies   = array();
 
-		if ( ! empty( $configs['post_types'] ) ) {
-			foreach ( $configs['post_types'] as $slug => $config ) {
+		// Live-registered post types: merge with stored config if any.
+		$post_types = get_post_types( array(), 'objects' );
+		foreach ( $post_types as $slug => $type_object ) {
+			$config = isset( $stored_post_types[ $slug ] )
+				? $stored_post_types[ $slug ]
+				: Gutenberg_Entity_Manager::extract_post_type_config( $slug, $type_object );
+			$result[]                   = $this->prepare_config_for_response( $slug, 'post_type', $config );
+			$seen_post_types[ $slug ] = true;
+		}
+
+		// Stored-but-not-registered post types (orphans and user-created
+		// whose registration failed).
+		foreach ( $stored_post_types as $slug => $config ) {
+			if ( ! isset( $seen_post_types[ $slug ] ) ) {
 				$result[] = $this->prepare_config_for_response( $slug, 'post_type', $config );
 			}
 		}
 
-		if ( ! empty( $configs['taxonomies'] ) ) {
-			foreach ( $configs['taxonomies'] as $slug => $config ) {
+		// Live-registered taxonomies: merge with stored config if any.
+		$taxonomies = get_taxonomies( array(), 'objects' );
+		foreach ( $taxonomies as $slug => $taxonomy_object ) {
+			$config = isset( $stored_taxonomies[ $slug ] )
+				? $stored_taxonomies[ $slug ]
+				: Gutenberg_Entity_Manager::extract_taxonomy_config( $slug, $taxonomy_object );
+			$result[]                 = $this->prepare_config_for_response( $slug, 'taxonomy', $config );
+			$seen_taxonomies[ $slug ] = true;
+		}
+
+		foreach ( $stored_taxonomies as $slug => $config ) {
+			if ( ! isset( $seen_taxonomies[ $slug ] ) ) {
 				$result[] = $this->prepare_config_for_response( $slug, 'taxonomy', $config );
 			}
 		}
@@ -125,16 +151,28 @@ class Gutenberg_REST_Entity_Configs_Controller extends WP_REST_Controller {
 		$slug        = $request['slug'];
 		$configs     = get_option( Gutenberg_Entity_Manager::OPTION_NAME, array() );
 		$key         = 'post_type' === $entity_type ? 'post_types' : 'taxonomies';
+		$config      = $configs[ $key ][ $slug ] ?? null;
 
-		if ( empty( $configs[ $key ][ $slug ] ) ) {
-			return new WP_Error(
-				'rest_entity_config_not_found',
-				__( 'Entity configuration not found.', 'gutenberg' ),
-				array( 'status' => 404 )
-			);
+		// No stored config — fall back to the live registration.
+		if ( null === $config ) {
+			if ( 'post_type' === $entity_type && post_type_exists( $slug ) ) {
+				$config = Gutenberg_Entity_Manager::extract_post_type_config(
+					$slug,
+					get_post_type_object( $slug )
+				);
+			} elseif ( 'taxonomy' === $entity_type && taxonomy_exists( $slug ) ) {
+				$config = Gutenberg_Entity_Manager::extract_taxonomy_config(
+					$slug,
+					get_taxonomy( $slug )
+				);
+			} else {
+				return new WP_Error(
+					'rest_entity_config_not_found',
+					__( 'Entity configuration not found.', 'gutenberg' ),
+					array( 'status' => 404 )
+				);
+			}
 		}
-
-		$config = $configs[ $key ][ $slug ];
 
 		return rest_ensure_response( $this->prepare_config_for_response( $slug, $entity_type, $config ) );
 	}
@@ -258,22 +296,44 @@ class Gutenberg_REST_Entity_Configs_Controller extends WP_REST_Controller {
 		$configs     = get_option( Gutenberg_Entity_Manager::OPTION_NAME, array() );
 		$key         = 'post_type' === $entity_type ? 'post_types' : 'taxonomies';
 
+		// If no stored config yet, seed it from the live registration so
+		// customizations can be applied on top of the defaults.
 		if ( empty( $configs[ $key ][ $slug ] ) ) {
-			return new WP_Error(
-				'rest_entity_config_not_found',
-				__( 'Entity configuration not found.', 'gutenberg' ),
-				array( 'status' => 404 )
-			);
+			if ( 'post_type' === $entity_type && post_type_exists( $slug ) ) {
+				$existing = Gutenberg_Entity_Manager::extract_post_type_config(
+					$slug,
+					get_post_type_object( $slug )
+				);
+			} elseif ( 'taxonomy' === $entity_type && taxonomy_exists( $slug ) ) {
+				$existing = Gutenberg_Entity_Manager::extract_taxonomy_config(
+					$slug,
+					get_taxonomy( $slug )
+				);
+			} else {
+				return new WP_Error(
+					'rest_entity_config_not_found',
+					__( 'Entity configuration not found.', 'gutenberg' ),
+					array( 'status' => 404 )
+				);
+			}
+		} else {
+			$existing = $configs[ $key ][ $slug ];
 		}
 
-		$existing = $configs[ $key ][ $slug ];
-		$updated  = $this->prepare_config_from_request( $request, $entity_type );
+		$updated = $this->prepare_config_from_request( $request, $entity_type );
 
 		// Merge updated fields into existing config.
 		$config                   = array_merge( $existing, $updated );
-		$config['_user_created']  = $existing['_user_created'];
+		$config['_user_created']  = ! empty( $existing['_user_created'] );
 		$config['_customized']    = true;
 		$configs[ $key ][ $slug ] = $config;
+
+		if ( ! isset( $configs['post_types'] ) ) {
+			$configs['post_types'] = array();
+		}
+		if ( ! isset( $configs['taxonomies'] ) ) {
+			$configs['taxonomies'] = array();
+		}
 
 		update_option( Gutenberg_Entity_Manager::OPTION_NAME, $configs, false );
 

--- a/lib/experimental/entities/class-gutenberg-rest-entity-configs-controller.php
+++ b/lib/experimental/entities/class-gutenberg-rest-entity-configs-controller.php
@@ -272,6 +272,7 @@ class Gutenberg_REST_Entity_Configs_Controller extends WP_REST_Controller {
 		// Merge updated fields into existing config.
 		$config                   = array_merge( $existing, $updated );
 		$config['_user_created']  = $existing['_user_created'];
+		$config['_customized']    = true;
 		$configs[ $key ][ $slug ] = $config;
 
 		update_option( Gutenberg_Entity_Manager::OPTION_NAME, $configs, false );
@@ -308,24 +309,39 @@ class Gutenberg_REST_Entity_Configs_Controller extends WP_REST_Controller {
 		$is_registered = 'post_type' === $entity_type
 			? post_type_exists( $slug )
 			: taxonomy_exists( $slug );
-		$is_orphaned   = ! $is_registered && empty( $config['_user_created'] );
 
-		// Only user-created entities and orphans (stored but no longer
-		// registered) can be deleted. Actively registered non-user entities
-		// belong to core/plugins/themes and must not be deleted here.
-		if ( empty( $config['_user_created'] ) && ! $is_orphaned ) {
+		// Determine if this is a core-registered entity (not user-created).
+		$is_core = false;
+		if ( empty( $config['_user_created'] ) && $is_registered ) {
+			if ( 'post_type' === $entity_type ) {
+				$object  = get_post_type_object( $slug );
+				$is_core = ! empty( $object->_builtin );
+			} else {
+				$object  = get_taxonomy( $slug );
+				$is_core = ! empty( $object->_builtin );
+			}
+		}
+
+		// Core entities cannot be deleted or reverted via this endpoint.
+		if ( $is_core ) {
 			return new WP_Error(
 				'rest_entity_config_not_deletable',
-				__( 'This entity is registered by core, a plugin, or a theme and cannot be deleted.', 'gutenberg' ),
+				__( 'Core entities cannot be deleted.', 'gutenberg' ),
 				array( 'status' => 403 )
 			);
 		}
 
-		// Unregister the entity.
-		if ( 'post_type' === $entity_type && post_type_exists( $slug ) ) {
-			unregister_post_type( $slug );
-		} elseif ( 'taxonomy' === $entity_type && taxonomy_exists( $slug ) ) {
-			unregister_taxonomy( $slug );
+		// For user-created entities, unregister so the type/taxonomy is
+		// fully removed. For plugin-registered entities (revert), leave the
+		// live registration alone — the plugin re-registers it on every
+		// request, and auto-detection will re-seed the config with default
+		// values on the next page load.
+		if ( ! empty( $config['_user_created'] ) ) {
+			if ( 'post_type' === $entity_type && post_type_exists( $slug ) ) {
+				unregister_post_type( $slug );
+			} elseif ( 'taxonomy' === $entity_type && taxonomy_exists( $slug ) ) {
+				unregister_taxonomy( $slug );
+			}
 		}
 
 		unset( $configs[ $key ][ $slug ] );
@@ -377,6 +393,7 @@ class Gutenberg_REST_Entity_Configs_Controller extends WP_REST_Controller {
 				'entity_type' => $entity_type,
 				'_source'     => $source,
 				'_orphaned'   => $is_orphaned,
+				'_customized' => ! empty( $config['_customized'] ),
 			)
 		);
 	}

--- a/lib/experimental/entities/class-gutenberg-rest-entity-configs-controller.php
+++ b/lib/experimental/entities/class-gutenberg-rest-entity-configs-controller.php
@@ -322,8 +322,10 @@ class Gutenberg_REST_Entity_Configs_Controller extends WP_REST_Controller {
 			}
 		}
 
-		// Core entities cannot be deleted or reverted via this endpoint.
-		if ( $is_core ) {
+		// Core entities can only be reverted (when they have been customized),
+		// never deleted. An uncustomized core entity has no stored deviations
+		// to remove, so blocking prevents accidental no-op churn.
+		if ( $is_core && empty( $config['_customized'] ) ) {
 			return new WP_Error(
 				'rest_entity_config_not_deletable',
 				__( 'Core entities cannot be deleted.', 'gutenberg' ),

--- a/lib/experimental/entities/class-gutenberg-rest-entity-configs-controller.php
+++ b/lib/experimental/entities/class-gutenberg-rest-entity-configs-controller.php
@@ -1,0 +1,574 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Entity_Configs_Controller class
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API controller for entity configurations.
+ */
+class Gutenberg_REST_Entity_Configs_Controller extends WP_REST_Controller {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'gutenberg/v1';
+		$this->rest_base = 'entity-configs';
+	}
+
+	/**
+	 * Registers the routes for entity configs.
+	 */
+	public function register_routes() {
+		// Collection route: list all and create new.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => $this->get_create_item_args(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		// Single item route: get, update, delete.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<entity_type>post_type|taxonomy)/(?P<slug>[a-z0-9_-]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => $this->get_update_item_args(),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Checks if the current user has permission to manage entity configs.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access, WP_Error otherwise.
+	 */
+	public function permissions_check( $request ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to manage entity configurations.', 'gutenberg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves all entity configurations.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function get_items( $request ) {
+		$configs = get_option( Gutenberg_Entity_Manager::OPTION_NAME, array() );
+		$result  = array();
+
+		if ( ! empty( $configs['post_types'] ) ) {
+			foreach ( $configs['post_types'] as $slug => $config ) {
+				$result[] = $this->prepare_config_for_response( $slug, 'post_type', $config );
+			}
+		}
+
+		if ( ! empty( $configs['taxonomies'] ) ) {
+			foreach ( $configs['taxonomies'] as $slug => $config ) {
+				$result[] = $this->prepare_config_for_response( $slug, 'taxonomy', $config );
+			}
+		}
+
+		return rest_ensure_response( $result );
+	}
+
+	/**
+	 * Retrieves a single entity configuration.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object or error.
+	 */
+	public function get_item( $request ) {
+		$entity_type = $request['entity_type'];
+		$slug        = $request['slug'];
+		$configs     = get_option( Gutenberg_Entity_Manager::OPTION_NAME, array() );
+		$key         = 'post_type' === $entity_type ? 'post_types' : 'taxonomies';
+
+		if ( empty( $configs[ $key ][ $slug ] ) ) {
+			return new WP_Error(
+				'rest_entity_config_not_found',
+				__( 'Entity configuration not found.', 'gutenberg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$config = $configs[ $key ][ $slug ];
+
+		return rest_ensure_response( $this->prepare_config_for_response( $slug, $entity_type, $config ) );
+	}
+
+	/**
+	 * Creates a new entity configuration.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object or error.
+	 */
+	public function create_item( $request ) {
+		$entity_type = $request['entity_type'];
+		$slug        = sanitize_key( $request['slug'] );
+		$configs     = get_option( Gutenberg_Entity_Manager::OPTION_NAME, array() );
+		$key         = 'post_type' === $entity_type ? 'post_types' : 'taxonomies';
+
+		if ( empty( $slug ) ) {
+			return new WP_Error(
+				'rest_invalid_slug',
+				__( 'Entity slug is required.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Check for slug conflicts.
+		if ( ! empty( $configs[ $key ][ $slug ] ) ) {
+			return new WP_Error(
+				'rest_entity_config_exists',
+				__( 'An entity with this slug already exists.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( 'post_type' === $entity_type && post_type_exists( $slug ) ) {
+			return new WP_Error(
+				'rest_entity_config_exists',
+				__( 'A post type with this slug is already registered.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( 'taxonomy' === $entity_type && taxonomy_exists( $slug ) ) {
+			return new WP_Error(
+				'rest_entity_config_exists',
+				__( 'A taxonomy with this slug is already registered.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$config                   = $this->prepare_config_from_request( $request, $entity_type );
+		$config['_user_created']  = true;
+		$configs[ $key ][ $slug ] = $config;
+
+		update_option( Gutenberg_Entity_Manager::OPTION_NAME, $configs, false );
+
+		// Register immediately so it's available in the current request.
+		if ( 'post_type' === $entity_type ) {
+			$supports = array();
+			if ( ! empty( $config['supports'] ) ) {
+				$supports = array_keys( array_filter( $config['supports'] ) );
+			}
+			if ( empty( $supports ) ) {
+				$supports = array( 'title', 'editor' );
+			}
+
+			register_post_type(
+				$slug,
+				array(
+					'labels'        => $config['labels'] ?? array(),
+					'description'   => $config['description'] ?? '',
+					'public'        => $config['public'] ?? true,
+					'hierarchical'  => $config['hierarchical'] ?? false,
+					'supports'      => $supports,
+					'has_archive'   => $config['has_archive'] ?? false,
+					'rewrite'       => $config['rewrite'] ?? true,
+					'show_in_rest'  => $config['show_in_rest'] ?? true,
+					'rest_base'     => $config['rest_base'] ?? $slug,
+					'menu_icon'     => $config['menu_icon'] ?? 'dashicons-admin-post',
+					'menu_position' => $config['menu_position'] ?? null,
+					'show_ui'       => $config['show_ui'] ?? true,
+					'show_in_menu'  => $config['show_in_menu'] ?? true,
+					'taxonomies'    => $config['taxonomies'] ?? array(),
+				)
+			);
+		} else {
+			register_taxonomy(
+				$slug,
+				$config['object_type'] ?? array( 'post' ),
+				array(
+					'labels'       => $config['labels'] ?? array(),
+					'description'  => $config['description'] ?? '',
+					'public'       => $config['public'] ?? true,
+					'hierarchical' => $config['hierarchical'] ?? false,
+					'show_in_rest' => $config['show_in_rest'] ?? true,
+					'rest_base'    => $config['rest_base'] ?? $slug,
+					'show_ui'      => $config['show_ui'] ?? true,
+					'show_in_menu' => $config['show_in_menu'] ?? true,
+					'rewrite'      => $config['rewrite'] ?? true,
+				)
+			);
+		}
+
+		// Flag that rewrite rules need flushing.
+		set_transient( 'gutenberg_entity_configs_flush_rewrite', true, 60 );
+
+		$response = rest_ensure_response( $this->prepare_config_for_response( $slug, $entity_type, $config ) );
+		$response->set_status( 201 );
+
+		return $response;
+	}
+
+	/**
+	 * Updates an existing entity configuration.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object or error.
+	 */
+	public function update_item( $request ) {
+		$entity_type = $request['entity_type'];
+		$slug        = $request['slug'];
+		$configs     = get_option( Gutenberg_Entity_Manager::OPTION_NAME, array() );
+		$key         = 'post_type' === $entity_type ? 'post_types' : 'taxonomies';
+
+		if ( empty( $configs[ $key ][ $slug ] ) ) {
+			return new WP_Error(
+				'rest_entity_config_not_found',
+				__( 'Entity configuration not found.', 'gutenberg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$existing = $configs[ $key ][ $slug ];
+		$updated  = $this->prepare_config_from_request( $request, $entity_type );
+
+		// Merge updated fields into existing config.
+		$config                   = array_merge( $existing, $updated );
+		$config['_user_created']  = $existing['_user_created'];
+		$configs[ $key ][ $slug ] = $config;
+
+		update_option( Gutenberg_Entity_Manager::OPTION_NAME, $configs, false );
+
+		// Flag that rewrite rules need flushing.
+		set_transient( 'gutenberg_entity_configs_flush_rewrite', true, 60 );
+
+		return rest_ensure_response( $this->prepare_config_for_response( $slug, $entity_type, $config ) );
+	}
+
+	/**
+	 * Deletes an entity configuration.
+	 *
+	 * Only user-created entities can be deleted.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object or error.
+	 */
+	public function delete_item( $request ) {
+		$entity_type = $request['entity_type'];
+		$slug        = $request['slug'];
+		$configs     = get_option( Gutenberg_Entity_Manager::OPTION_NAME, array() );
+		$key         = 'post_type' === $entity_type ? 'post_types' : 'taxonomies';
+
+		if ( empty( $configs[ $key ][ $slug ] ) ) {
+			return new WP_Error(
+				'rest_entity_config_not_found',
+				__( 'Entity configuration not found.', 'gutenberg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$config = $configs[ $key ][ $slug ];
+
+		if ( empty( $config['_user_created'] ) ) {
+			return new WP_Error(
+				'rest_entity_config_not_deletable',
+				__( 'Built-in entities cannot be deleted.', 'gutenberg' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// Unregister the entity.
+		if ( 'post_type' === $entity_type && post_type_exists( $slug ) ) {
+			unregister_post_type( $slug );
+		} elseif ( 'taxonomy' === $entity_type && taxonomy_exists( $slug ) ) {
+			unregister_taxonomy( $slug );
+		}
+
+		unset( $configs[ $key ][ $slug ] );
+		update_option( Gutenberg_Entity_Manager::OPTION_NAME, $configs, false );
+
+		// Flag that rewrite rules need flushing.
+		set_transient( 'gutenberg_entity_configs_flush_rewrite', true, 60 );
+
+		return rest_ensure_response( array( 'deleted' => true ) );
+	}
+
+	/**
+	 * Prepares an entity config for the REST response.
+	 *
+	 * @param string $slug        The entity slug.
+	 * @param string $entity_type The entity type (post_type or taxonomy).
+	 * @param array  $config      The stored configuration.
+	 * @return array The response data.
+	 */
+	private function prepare_config_for_response( $slug, $entity_type, $config ) {
+		return array_merge(
+			$config,
+			array(
+				'slug'        => $slug,
+				'entity_type' => $entity_type,
+			)
+		);
+	}
+
+	/**
+	 * Builds a configuration array from the REST request.
+	 *
+	 * @param WP_REST_Request $request     Full details about the request.
+	 * @param string          $entity_type The entity type (post_type or taxonomy).
+	 * @return array The configuration data.
+	 */
+	private function prepare_config_from_request( $request, $entity_type ) {
+		$config = array();
+
+		$common_fields = array(
+			'labels',
+			'description',
+			'public',
+			'hierarchical',
+			'show_in_rest',
+			'rest_base',
+			'show_ui',
+			'show_in_menu',
+			'rewrite',
+		);
+
+		foreach ( $common_fields as $field ) {
+			if ( isset( $request[ $field ] ) ) {
+				$config[ $field ] = $request[ $field ];
+			}
+		}
+
+		if ( 'post_type' === $entity_type ) {
+			$post_type_fields = array(
+				'supports',
+				'has_archive',
+				'menu_icon',
+				'menu_position',
+				'taxonomies',
+			);
+			foreach ( $post_type_fields as $field ) {
+				if ( isset( $request[ $field ] ) ) {
+					$config[ $field ] = $request[ $field ];
+				}
+			}
+		}
+
+		if ( 'taxonomy' === $entity_type ) {
+			if ( isset( $request['object_type'] ) ) {
+				$config['object_type'] = $request['object_type'];
+			}
+		}
+
+		return $config;
+	}
+
+	/**
+	 * Gets the arguments for creating an entity config.
+	 *
+	 * @return array The create arguments.
+	 */
+	private function get_create_item_args() {
+		return array(
+			'entity_type' => array(
+				'description' => __( 'The entity type.', 'gutenberg' ),
+				'type'        => 'string',
+				'enum'        => array( 'post_type', 'taxonomy' ),
+				'required'    => true,
+			),
+			'slug'        => array(
+				'description'       => __( 'The entity slug.', 'gutenberg' ),
+				'type'              => 'string',
+				'required'          => true,
+				'sanitize_callback' => 'sanitize_key',
+			),
+			'labels'      => array(
+				'description' => __( 'The entity labels.', 'gutenberg' ),
+				'type'        => 'object',
+			),
+			'description' => array(
+				'description' => __( 'A description of the entity.', 'gutenberg' ),
+				'type'        => 'string',
+			),
+			'public'      => array(
+				'description' => __( 'Whether the entity is public.', 'gutenberg' ),
+				'type'        => 'boolean',
+			),
+			'hierarchical' => array(
+				'description' => __( 'Whether the entity is hierarchical.', 'gutenberg' ),
+				'type'        => 'boolean',
+			),
+			'show_in_rest' => array(
+				'description' => __( 'Whether to expose via REST API.', 'gutenberg' ),
+				'type'        => 'boolean',
+			),
+			'rest_base'    => array(
+				'description' => __( 'The REST API base slug.', 'gutenberg' ),
+				'type'        => 'string',
+			),
+			'show_ui'      => array(
+				'description' => __( 'Whether to show a UI for the entity.', 'gutenberg' ),
+				'type'        => 'boolean',
+			),
+			'show_in_menu' => array(
+				'description' => __( 'Whether to show in the admin menu.', 'gutenberg' ),
+				'type'        => array( 'boolean', 'string' ),
+			),
+			'rewrite'      => array(
+				'description' => __( 'Rewrite configuration.', 'gutenberg' ),
+				'type'        => array( 'object', 'boolean' ),
+			),
+			'supports'     => array(
+				'description' => __( 'Post type features (post types only).', 'gutenberg' ),
+				'type'        => 'object',
+			),
+			'has_archive'  => array(
+				'description' => __( 'Whether the post type has an archive (post types only).', 'gutenberg' ),
+				'type'        => array( 'boolean', 'string' ),
+			),
+			'menu_icon'    => array(
+				'description' => __( 'The dashicon or URL for the menu icon (post types only).', 'gutenberg' ),
+				'type'        => array( 'string', 'null' ),
+			),
+			'menu_position' => array(
+				'description' => __( 'The menu position (post types only).', 'gutenberg' ),
+				'type'        => array( 'integer', 'null' ),
+			),
+			'taxonomies'   => array(
+				'description' => __( 'Taxonomies associated with the post type (post types only).', 'gutenberg' ),
+				'type'        => 'array',
+				'items'       => array( 'type' => 'string' ),
+			),
+			'object_type'  => array(
+				'description' => __( 'Post types this taxonomy is associated with (taxonomies only).', 'gutenberg' ),
+				'type'        => 'array',
+				'items'       => array( 'type' => 'string' ),
+			),
+		);
+	}
+
+	/**
+	 * Gets the arguments for updating an entity config.
+	 *
+	 * Same as create except slug and entity_type are not required (they come from the URL).
+	 *
+	 * @return array The update arguments.
+	 */
+	private function get_update_item_args() {
+		$args = $this->get_create_item_args();
+		unset( $args['entity_type'] );
+		unset( $args['slug'] );
+
+		// Nothing is required for updates.
+		foreach ( $args as &$arg ) {
+			unset( $arg['required'] );
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Retrieves the entity config schema.
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$this->schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'entity-config',
+			'type'       => 'object',
+			'properties' => array(
+				'slug'          => array(
+					'description' => __( 'The entity slug.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'entity_type'   => array(
+					'description' => __( 'The entity type (post_type or taxonomy).', 'gutenberg' ),
+					'type'        => 'string',
+					'enum'        => array( 'post_type', 'taxonomy' ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'_user_created' => array(
+					'description' => __( 'Whether this entity was created by a user.', 'gutenberg' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'labels'        => array(
+					'description' => __( 'The entity labels.', 'gutenberg' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'description'   => array(
+					'description' => __( 'A description of the entity.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'public'        => array(
+					'description' => __( 'Whether the entity is public.', 'gutenberg' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'hierarchical'  => array(
+					'description' => __( 'Whether the entity is hierarchical.', 'gutenberg' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'show_in_rest'  => array(
+					'description' => __( 'Whether the entity is exposed via REST API.', 'gutenberg' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'show_ui'       => array(
+					'description' => __( 'Whether the entity has a UI.', 'gutenberg' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+}

--- a/lib/experimental/entities/class-gutenberg-rest-entity-configs-controller.php
+++ b/lib/experimental/entities/class-gutenberg-rest-entity-configs-controller.php
@@ -304,12 +304,19 @@ class Gutenberg_REST_Entity_Configs_Controller extends WP_REST_Controller {
 			);
 		}
 
-		$config = $configs[ $key ][ $slug ];
+		$config        = $configs[ $key ][ $slug ];
+		$is_registered = 'post_type' === $entity_type
+			? post_type_exists( $slug )
+			: taxonomy_exists( $slug );
+		$is_orphaned   = ! $is_registered && empty( $config['_user_created'] );
 
-		if ( empty( $config['_user_created'] ) ) {
+		// Only user-created entities and orphans (stored but no longer
+		// registered) can be deleted. Actively registered non-user entities
+		// belong to core/plugins/themes and must not be deleted here.
+		if ( empty( $config['_user_created'] ) && ! $is_orphaned ) {
 			return new WP_Error(
 				'rest_entity_config_not_deletable',
-				__( 'Built-in entities cannot be deleted.', 'gutenberg' ),
+				__( 'This entity is registered by core, a plugin, or a theme and cannot be deleted.', 'gutenberg' ),
 				array( 'status' => 403 )
 			);
 		}
@@ -339,11 +346,37 @@ class Gutenberg_REST_Entity_Configs_Controller extends WP_REST_Controller {
 	 * @return array The response data.
 	 */
 	private function prepare_config_for_response( $slug, $entity_type, $config ) {
+		$is_registered = 'post_type' === $entity_type
+			? post_type_exists( $slug )
+			: taxonomy_exists( $slug );
+
+		// An entity is orphaned when it's stored but no longer registered
+		// (e.g., the plugin that created it was deactivated).
+		$is_orphaned = ! $is_registered && empty( $config['_user_created'] );
+
+		// Compute _source from the live type object when possible so the
+		// classification self-heals even if the stored config predates the
+		// _source field or the entity's source has changed.
+		if ( ! empty( $config['_user_created'] ) ) {
+			$source = 'user';
+		} elseif ( 'post_type' === $entity_type && $is_registered ) {
+			$type_object = get_post_type_object( $slug );
+			$source      = ! empty( $type_object->_builtin ) ? 'core' : 'plugin';
+		} elseif ( 'taxonomy' === $entity_type && $is_registered ) {
+			$taxonomy_object = get_taxonomy( $slug );
+			$source          = ! empty( $taxonomy_object->_builtin ) ? 'core' : 'plugin';
+		} else {
+			// Orphaned and unknown: fall back to stored value or 'plugin'.
+			$source = $config['_source'] ?? 'plugin';
+		}
+
 		return array_merge(
 			$config,
 			array(
 				'slug'        => $slug,
 				'entity_type' => $entity_type,
+				'_source'     => $source,
+				'_orphaned'   => $is_orphaned,
 			)
 		);
 	}
@@ -441,7 +474,7 @@ class Gutenberg_REST_Entity_Configs_Controller extends WP_REST_Controller {
 			),
 			'rest_base'    => array(
 				'description' => __( 'The REST API base slug.', 'gutenberg' ),
-				'type'        => 'string',
+				'type'        => array( 'string', 'boolean', 'null' ),
 			),
 			'show_ui'      => array(
 				'description' => __( 'Whether to show a UI for the entity.', 'gutenberg' ),

--- a/lib/experimental/entities/load.php
+++ b/lib/experimental/entities/load.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Bootstraps the Entities page in wp-admin.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once __DIR__ . '/class-gutenberg-entity-manager.php';
+require_once __DIR__ . '/class-gutenberg-rest-entity-configs-controller.php';
+
+// Initialize the entity manager (hooks into init at priority 99).
+Gutenberg_Entity_Manager::init();
+
+// Register REST API routes.
+add_action(
+	'rest_api_init',
+	function () {
+		$controller = new Gutenberg_REST_Entity_Configs_Controller();
+		$controller->register_routes();
+	}
+);
+
+// Register admin menu item under Appearance at priority 11 (after Core's menu setup).
+add_action( 'admin_menu', 'gutenberg_register_entities_admin_submenu', 11 );
+
+/**
+ * Registers the Entities submenu item under Appearance.
+ */
+function gutenberg_register_entities_admin_submenu() {
+	add_submenu_page(
+		'themes.php',
+		__( 'Entities', 'gutenberg' ),
+		__( 'Entities', 'gutenberg' ),
+		'manage_options',
+		'entities-wp-admin',
+		'gutenberg_entities_wp_admin_render_page'
+	);
+}
+
+// Flush rewrite rules when entity configs have changed.
+add_action( 'init', 'gutenberg_entity_configs_maybe_flush_rewrite_rules', 100 );
+
+/**
+ * Flushes rewrite rules if entity configurations have been modified.
+ */
+function gutenberg_entity_configs_maybe_flush_rewrite_rules() {
+	if ( get_transient( 'gutenberg_entity_configs_flush_rewrite' ) ) {
+		delete_transient( 'gutenberg_entity_configs_flush_rewrite' );
+		flush_rewrite_rules( false );
+	}
+}

--- a/lib/experimental/entities/load.php
+++ b/lib/experimental/entities/load.php
@@ -28,11 +28,11 @@ add_action(
 add_action( 'admin_menu', 'gutenberg_register_entities_admin_submenu', 11 );
 
 /**
- * Registers the Entities submenu item under Appearance.
+ * Registers the Entities submenu item under Settings.
  */
 function gutenberg_register_entities_admin_submenu() {
 	add_submenu_page(
-		'themes.php',
+		'options-general.php',
 		__( 'Entities', 'gutenberg' ),
 		__( 'Entities', 'gutenberg' ),
 		'manage_options',

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -221,6 +221,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-entities',
+		__( 'Entities', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enables the Entities page for managing post types and taxonomies from the admin UI.', 'gutenberg' ),
+			'id'    => 'gutenberg-entities',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/lib/load.php
+++ b/lib/load.php
@@ -220,3 +220,8 @@ if ( gutenberg_is_experiment_enabled( 'gutenberg-guidelines' ) ) {
 	require __DIR__ . '/experimental/guidelines/load.php';
 	require __DIR__ . '/experimental/guidelines/index.php';
 }
+
+// Entities (only load when experiment is enabled).
+if ( gutenberg_is_experiment_enabled( 'gutenberg-entities' ) ) {
+	require __DIR__ . '/experimental/entities/load.php';
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20550,6 +20550,18 @@
 			"resolved": "packages/element",
 			"link": true
 		},
+		"node_modules/@wordpress/entity-edit-route": {
+			"resolved": "routes/entity-edit",
+			"link": true
+		},
+		"node_modules/@wordpress/entity-list-route": {
+			"resolved": "routes/entity-list",
+			"link": true
+		},
+		"node_modules/@wordpress/entity-new-route": {
+			"resolved": "routes/entity-new",
+			"link": true
+		},
 		"node_modules/@wordpress/env": {
 			"resolved": "packages/env",
 			"link": true
@@ -62926,6 +62938,52 @@
 				"@wordpress/notices": "file:../../packages/notices",
 				"@wordpress/ui": "file:../../packages/ui",
 				"@wordpress/url": "file:../../packages/url"
+			}
+		},
+		"routes/entity-edit": {
+			"name": "@wordpress/entity-edit-route",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/api-fetch": "file:../../packages/api-fetch",
+				"@wordpress/components": "file:../../packages/components",
+				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/element": "file:../../packages/element",
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/notices": "file:../../packages/notices",
+				"@wordpress/private-apis": "file:../../packages/private-apis",
+				"@wordpress/route": "file:../../packages/route"
+			}
+		},
+		"routes/entity-list": {
+			"name": "@wordpress/entity-list-route",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/api-fetch": "file:../../packages/api-fetch",
+				"@wordpress/components": "file:../../packages/components",
+				"@wordpress/dataviews": "file:../../packages/dataviews",
+				"@wordpress/element": "file:../../packages/element",
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/icons": "file:../../packages/icons",
+				"@wordpress/notices": "file:../../packages/notices",
+				"@wordpress/private-apis": "file:../../packages/private-apis",
+				"@wordpress/route": "file:../../packages/route"
+			}
+		},
+		"routes/entity-new": {
+			"name": "@wordpress/entity-new-route",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/api-fetch": "file:../../packages/api-fetch",
+				"@wordpress/components": "file:../../packages/components",
+				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/element": "file:../../packages/element",
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/notices": "file:../../packages/notices",
+				"@wordpress/private-apis": "file:../../packages/private-apis",
+				"@wordpress/route": "file:../../packages/route"
 			}
 		},
 		"routes/font-list": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62950,6 +62950,7 @@
 				"@wordpress/data": "file:../../packages/data",
 				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/notices": "file:../../packages/notices",
 				"@wordpress/private-apis": "file:../../packages/private-apis",
 				"@wordpress/route": "file:../../packages/route"
@@ -62962,6 +62963,7 @@
 				"@wordpress/admin-ui": "file:../../packages/admin-ui",
 				"@wordpress/api-fetch": "file:../../packages/api-fetch",
 				"@wordpress/components": "file:../../packages/components",
+				"@wordpress/data": "file:../../packages/data",
 				"@wordpress/dataviews": "file:../../packages/dataviews",
 				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/i18n": "file:../../packages/i18n",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 			},
 			"font-library",
 			"options-connectors",
-			"guidelines"
+			"guidelines",
+			"entities"
 		]
 	},
 	"config": {

--- a/routes/entity-edit/package.json
+++ b/routes/entity-edit/package.json
@@ -13,6 +13,7 @@
 		"@wordpress/data": "file:../../packages/data",
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/notices": "file:../../packages/notices",
 		"@wordpress/private-apis": "file:../../packages/private-apis",
 		"@wordpress/route": "file:../../packages/route"

--- a/routes/entity-edit/package.json
+++ b/routes/entity-edit/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "@wordpress/entity-edit-route",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/edit/$entityType/$slug",
+		"page": "entities"
+	},
+	"dependencies": {
+		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/api-fetch": "file:../../packages/api-fetch",
+		"@wordpress/components": "file:../../packages/components",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/notices": "file:../../packages/notices",
+		"@wordpress/private-apis": "file:../../packages/private-apis",
+		"@wordpress/route": "file:../../packages/route"
+	}
+}

--- a/routes/entity-edit/route.ts
+++ b/routes/entity-edit/route.ts
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const route = {
+	title: () => __( 'Edit Entity' ),
+};

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -14,6 +14,8 @@ import {
 	PanelRow,
 	Spinner,
 	// @ts-ignore
+	__experimentalConfirmDialog as ConfirmDialog,
+	// @ts-ignore
 	__experimentalVStack as VStack,
 	// @ts-ignore
 	__experimentalHStack as HStack,
@@ -25,10 +27,11 @@ import {
 	useMemo,
 	useRef,
 } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { store as noticesStore } from '@wordpress/notices';
 import { useDispatch } from '@wordpress/data';
+import { trash } from '@wordpress/icons';
 
 interface EntityConfig {
 	slug: string;
@@ -86,6 +89,8 @@ function EntityEdit() {
 
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ isSaving, setIsSaving ] = useState( false );
+	const [ isDeleting, setIsDeleting ] = useState( false );
+	const [ showDeleteConfirm, setShowDeleteConfirm ] = useState( false );
 	const [ config, setConfig ] = useState< EntityConfig | null >( null );
 	const [ allConfigs, setAllConfigs ] = useState< EntityConfig[] >( [] );
 	const originalConfigRef = useRef< EntityConfig | null >( null );
@@ -245,6 +250,32 @@ function EntityEdit() {
 		setIsSaving( false );
 	}, [ config, entityType, slug, createSuccessNotice, createErrorNotice ] );
 
+	const handleDelete = useCallback( async () => {
+		setIsDeleting( true );
+		try {
+			await apiFetch( {
+				path: `/gutenberg/v1/entity-configs/${ entityType }/${ slug }`,
+				method: 'DELETE',
+			} );
+			sessionStorage.setItem(
+				'gutenberg_entity_saved',
+				__( 'Entity deleted successfully.' )
+			);
+			// Always reload — a deleted entity affects the admin menu.
+			const url = new URL( window.location.href );
+			url.searchParams.set( 'p', '/' );
+			url.searchParams.set( 'tab', entityType );
+			window.location.href = url.toString();
+		} catch {
+			createErrorNotice( __( 'Failed to delete entity.' ), {
+				type: 'snackbar',
+				id: 'entity-delete-error',
+			} );
+			setIsDeleting( false );
+			setShowDeleteConfirm( false );
+		}
+	}, [ entityType, slug, createErrorNotice ] );
+
 	if ( isLoading ) {
 		return (
 			<Page title={ __( 'Edit Entity' ) }>
@@ -267,302 +298,354 @@ function EntityEdit() {
 	}`;
 
 	return (
-		<Page
-			title={ pageTitle }
-			actions={
-				<HStack spacing={ 3 }>
-					<Button
-						variant="tertiary"
-						onClick={ () =>
-							navigate( {
-								to: '/',
-								search: { tab: entityType },
-							} )
-						}
-						size="compact"
-					>
-						{ __( 'Back' ) }
-					</Button>
-					<Button
-						variant="primary"
-						onClick={ handleSave }
-						isBusy={ isSaving }
-						disabled={ isSaving }
-						size="compact"
-					>
-						{ __( 'Save' ) }
-					</Button>
-				</HStack>
-			}
-		>
-			<div style={ { maxWidth: 800, padding: '0 16px' } }>
-				<VStack spacing={ 4 }>
-					<Panel>
-						<PanelBody title={ __( 'General' ) } initialOpen>
-							<PanelRow>
-								<TextControl
-									__nextHasNoMarginBottom
-									label={ __( 'Name (Plural)' ) }
-									value={ config.labels?.name || '' }
-									onChange={ ( value: string ) =>
-										updateLabel( 'name', value )
-									}
-								/>
-							</PanelRow>
-							<PanelRow>
-								<TextControl
-									__nextHasNoMarginBottom
-									label={ __( 'Singular Name' ) }
-									value={ config.labels?.singular_name || '' }
-									onChange={ ( value: string ) =>
-										updateLabel( 'singular_name', value )
-									}
-								/>
-							</PanelRow>
-							<PanelRow>
-								<TextControl
-									__nextHasNoMarginBottom
-									label={ __( 'Slug' ) }
-									value={ config.slug }
-									disabled
-									readOnly
-								/>
-							</PanelRow>
-							<PanelRow>
-								<TextareaControl
-									__nextHasNoMarginBottom
-									label={ __( 'Description' ) }
-									value={ config.description || '' }
-									onChange={ ( value: string ) =>
-										updateField( 'description', value )
-									}
-								/>
-							</PanelRow>
-						</PanelBody>
-					</Panel>
-
-					<Panel>
-						<PanelBody title={ __( 'Visibility' ) } initialOpen>
-							<PanelRow>
-								<ToggleControl
-									__nextHasNoMarginBottom
-									label={ __( 'Public' ) }
-									checked={ config.public }
-									onChange={ ( value: boolean ) =>
-										updateField( 'public', value )
-									}
-								/>
-							</PanelRow>
-							<PanelRow>
-								<ToggleControl
-									__nextHasNoMarginBottom
-									label={ __( 'Hierarchical' ) }
-									checked={ config.hierarchical }
-									onChange={ ( value: boolean ) =>
-										updateField( 'hierarchical', value )
-									}
-								/>
-							</PanelRow>
-							<PanelRow>
-								<ToggleControl
-									__nextHasNoMarginBottom
-									label={ __( 'Show UI' ) }
-									checked={ config.show_ui }
-									onChange={ ( value: boolean ) =>
-										updateField( 'show_ui', value )
-									}
-								/>
-							</PanelRow>
-							<PanelRow>
-								<ToggleControl
-									__nextHasNoMarginBottom
-									label={ __( 'Show in Menu' ) }
-									checked={ !! config.show_in_menu }
-									onChange={ ( value: boolean ) =>
-										updateField( 'show_in_menu', value )
-									}
-								/>
-							</PanelRow>
-							{ isPostType && (
+		<>
+			<Page
+				title={ pageTitle }
+				actions={
+					<HStack spacing={ 3 }>
+						<Button
+							variant="tertiary"
+							onClick={ () =>
+								navigate( {
+									to: '/',
+									search: { tab: entityType },
+								} )
+							}
+							size="compact"
+						>
+							{ __( 'Back' ) }
+						</Button>
+						{ config._user_created && (
+							<Button
+								icon={ trash }
+								label={ __( 'Delete' ) }
+								isDestructive
+								onClick={ () => setShowDeleteConfirm( true ) }
+								disabled={ isDeleting }
+								size="compact"
+							/>
+						) }
+						<Button
+							variant="primary"
+							onClick={ handleSave }
+							isBusy={ isSaving }
+							disabled={ isSaving }
+							size="compact"
+						>
+							{ __( 'Save' ) }
+						</Button>
+					</HStack>
+				}
+			>
+				<div style={ { maxWidth: 800, padding: '0 16px' } }>
+					<VStack spacing={ 4 }>
+						<Panel>
+							<PanelBody title={ __( 'General' ) } initialOpen>
 								<PanelRow>
-									<ToggleControl
+									<TextControl
 										__nextHasNoMarginBottom
-										label={ __( 'Has Archive' ) }
-										checked={ !! config.has_archive }
-										onChange={ ( value: boolean ) =>
-											updateField( 'has_archive', value )
+										label={ __( 'Name (Plural)' ) }
+										value={ config.labels?.name || '' }
+										onChange={ ( value: string ) =>
+											updateLabel( 'name', value )
 										}
 									/>
 								</PanelRow>
-							) }
-						</PanelBody>
-					</Panel>
+								<PanelRow>
+									<TextControl
+										__nextHasNoMarginBottom
+										label={ __( 'Singular Name' ) }
+										value={
+											config.labels?.singular_name || ''
+										}
+										onChange={ ( value: string ) =>
+											updateLabel(
+												'singular_name',
+												value
+											)
+										}
+									/>
+								</PanelRow>
+								<PanelRow>
+									<TextControl
+										__nextHasNoMarginBottom
+										label={ __( 'Slug' ) }
+										value={ config.slug }
+										disabled
+										readOnly
+									/>
+								</PanelRow>
+								<PanelRow>
+									<TextareaControl
+										__nextHasNoMarginBottom
+										label={ __( 'Description' ) }
+										value={ config.description || '' }
+										onChange={ ( value: string ) =>
+											updateField( 'description', value )
+										}
+									/>
+								</PanelRow>
+							</PanelBody>
+						</Panel>
 
-					<Panel>
-						<PanelBody
-							title={ __( 'REST API' ) }
-							initialOpen={ false }
-						>
-							<PanelRow>
-								<ToggleControl
-									__nextHasNoMarginBottom
-									label={ __( 'Show in REST' ) }
-									checked={ config.show_in_rest }
-									onChange={ ( value: boolean ) =>
-										updateField( 'show_in_rest', value )
-									}
-								/>
-							</PanelRow>
-							<PanelRow>
-								<TextControl
-									__nextHasNoMarginBottom
-									label={ __( 'REST Base' ) }
-									value={ config.rest_base || '' }
-									onChange={ ( value: string ) =>
-										updateField( 'rest_base', value )
-									}
-								/>
-							</PanelRow>
-						</PanelBody>
-					</Panel>
-
-					{ ! isPostType && (
 						<Panel>
-							<PanelBody title={ __( 'Post Types' ) } initialOpen>
-								{ availablePostTypes.map( ( pt ) => (
-									<PanelRow key={ pt.slug }>
-										<CheckboxControl
+							<PanelBody title={ __( 'Visibility' ) } initialOpen>
+								<PanelRow>
+									<ToggleControl
+										__nextHasNoMarginBottom
+										label={ __( 'Public' ) }
+										checked={ config.public }
+										onChange={ ( value: boolean ) =>
+											updateField( 'public', value )
+										}
+									/>
+								</PanelRow>
+								<PanelRow>
+									<ToggleControl
+										__nextHasNoMarginBottom
+										label={ __( 'Hierarchical' ) }
+										checked={ config.hierarchical }
+										onChange={ ( value: boolean ) =>
+											updateField( 'hierarchical', value )
+										}
+									/>
+								</PanelRow>
+								<PanelRow>
+									<ToggleControl
+										__nextHasNoMarginBottom
+										label={ __( 'Show UI' ) }
+										checked={ config.show_ui }
+										onChange={ ( value: boolean ) =>
+											updateField( 'show_ui', value )
+										}
+									/>
+								</PanelRow>
+								<PanelRow>
+									<ToggleControl
+										__nextHasNoMarginBottom
+										label={ __( 'Show in Menu' ) }
+										checked={ !! config.show_in_menu }
+										onChange={ ( value: boolean ) =>
+											updateField( 'show_in_menu', value )
+										}
+									/>
+								</PanelRow>
+								{ isPostType && (
+									<PanelRow>
+										<ToggleControl
 											__nextHasNoMarginBottom
-											label={ pt.labels?.name || pt.slug }
-											checked={
-												config.object_type?.includes(
-													pt.slug
-												) ?? false
-											}
+											label={ __( 'Has Archive' ) }
+											checked={ !! config.has_archive }
 											onChange={ ( value: boolean ) =>
-												toggleObjectType(
-													pt.slug,
+												updateField(
+													'has_archive',
 													value
 												)
 											}
 										/>
 									</PanelRow>
-								) ) }
-								{ availablePostTypes.length === 0 && (
-									<PanelRow>
-										<p>
-											{ __( 'No post types available.' ) }
-										</p>
-									</PanelRow>
 								) }
 							</PanelBody>
 						</Panel>
-					) }
 
-					{ isPostType && (
 						<Panel>
 							<PanelBody
-								title={ __( 'Menu' ) }
+								title={ __( 'REST API' ) }
 								initialOpen={ false }
 							>
 								<PanelRow>
-									<TextControl
+									<ToggleControl
 										__nextHasNoMarginBottom
-										label={ __( 'Menu Icon' ) }
-										help={ __(
-											'A dashicon class name or URL to an icon image.'
-										) }
-										value={ config.menu_icon || '' }
-										onChange={ ( value: string ) =>
-											updateField(
-												'menu_icon',
-												value || null
-											)
+										label={ __( 'Show in REST' ) }
+										checked={ config.show_in_rest }
+										onChange={ ( value: boolean ) =>
+											updateField( 'show_in_rest', value )
 										}
 									/>
 								</PanelRow>
 								<PanelRow>
 									<TextControl
 										__nextHasNoMarginBottom
-										label={ __( 'Menu Position' ) }
-										type="number"
-										value={
-											config.menu_position !== null
-												? String( config.menu_position )
-												: ''
-										}
+										label={ __( 'REST Base' ) }
+										value={ config.rest_base || '' }
 										onChange={ ( value: string ) =>
-											updateField(
-												'menu_position',
-												value ? Number( value ) : null
-											)
+											updateField( 'rest_base', value )
 										}
 									/>
 								</PanelRow>
 							</PanelBody>
 						</Panel>
-					) }
 
-					{ isPostType && (
+						{ ! isPostType && (
+							<Panel>
+								<PanelBody
+									title={ __( 'Post Types' ) }
+									initialOpen
+								>
+									{ availablePostTypes.map( ( pt ) => (
+										<PanelRow key={ pt.slug }>
+											<CheckboxControl
+												__nextHasNoMarginBottom
+												label={
+													pt.labels?.name || pt.slug
+												}
+												checked={
+													config.object_type?.includes(
+														pt.slug
+													) ?? false
+												}
+												onChange={ ( value: boolean ) =>
+													toggleObjectType(
+														pt.slug,
+														value
+													)
+												}
+											/>
+										</PanelRow>
+									) ) }
+									{ availablePostTypes.length === 0 && (
+										<PanelRow>
+											<p>
+												{ __(
+													'No post types available.'
+												) }
+											</p>
+										</PanelRow>
+									) }
+								</PanelBody>
+							</Panel>
+						) }
+
+						{ isPostType && (
+							<Panel>
+								<PanelBody
+									title={ __( 'Menu' ) }
+									initialOpen={ false }
+								>
+									<PanelRow>
+										<TextControl
+											__nextHasNoMarginBottom
+											label={ __( 'Menu Icon' ) }
+											help={ __(
+												'A dashicon class name or URL to an icon image.'
+											) }
+											value={ config.menu_icon || '' }
+											onChange={ ( value: string ) =>
+												updateField(
+													'menu_icon',
+													value || null
+												)
+											}
+										/>
+									</PanelRow>
+									<PanelRow>
+										<TextControl
+											__nextHasNoMarginBottom
+											label={ __( 'Menu Position' ) }
+											type="number"
+											value={
+												config.menu_position !== null
+													? String(
+															config.menu_position
+													  )
+													: ''
+											}
+											onChange={ ( value: string ) =>
+												updateField(
+													'menu_position',
+													value
+														? Number( value )
+														: null
+												)
+											}
+										/>
+									</PanelRow>
+								</PanelBody>
+							</Panel>
+						) }
+
+						{ isPostType && (
+							<Panel>
+								<PanelBody
+									title={ __( 'Supports' ) }
+									initialOpen={ false }
+								>
+									{ POST_TYPE_SUPPORTS.map( ( feature ) => (
+										<PanelRow key={ feature }>
+											<CheckboxControl
+												__nextHasNoMarginBottom
+												label={ feature }
+												checked={
+													!! config.supports?.[
+														feature
+													]
+												}
+												onChange={ ( value: boolean ) =>
+													updateSupport(
+														feature,
+														value
+													)
+												}
+											/>
+										</PanelRow>
+									) ) }
+								</PanelBody>
+							</Panel>
+						) }
+
 						<Panel>
 							<PanelBody
-								title={ __( 'Supports' ) }
+								title={ __( 'Labels' ) }
 								initialOpen={ false }
 							>
-								{ POST_TYPE_SUPPORTS.map( ( feature ) => (
-									<PanelRow key={ feature }>
-										<CheckboxControl
+								{ [
+									'add_new',
+									'add_new_item',
+									'edit_item',
+									'new_item',
+									'view_item',
+									'view_items',
+									'search_items',
+									'not_found',
+									'not_found_in_trash',
+									'all_items',
+									'menu_name',
+								].map( ( labelKey ) => (
+									<PanelRow key={ labelKey }>
+										<TextControl
 											__nextHasNoMarginBottom
-											label={ feature }
-											checked={
-												!! config.supports?.[ feature ]
+											label={ labelKey }
+											value={
+												config.labels?.[ labelKey ] ||
+												''
 											}
-											onChange={ ( value: boolean ) =>
-												updateSupport( feature, value )
+											onChange={ ( value: string ) =>
+												updateLabel( labelKey, value )
 											}
 										/>
 									</PanelRow>
 								) ) }
 							</PanelBody>
 						</Panel>
+					</VStack>
+				</div>
+			</Page>
+			{ showDeleteConfirm && (
+				<ConfirmDialog
+					isOpen
+					onConfirm={ handleDelete }
+					onCancel={ () => setShowDeleteConfirm( false ) }
+					confirmButtonText={ __( 'Delete' ) }
+					isBusy={ isDeleting }
+				>
+					{ sprintf(
+						/* translators: %s: entity name */
+						__( 'Are you sure you want to delete "%s"?' ),
+						config.labels?.name || config.slug
 					) }
-
-					<Panel>
-						<PanelBody
-							title={ __( 'Labels' ) }
-							initialOpen={ false }
-						>
-							{ [
-								'add_new',
-								'add_new_item',
-								'edit_item',
-								'new_item',
-								'view_item',
-								'view_items',
-								'search_items',
-								'not_found',
-								'not_found_in_trash',
-								'all_items',
-								'menu_name',
-							].map( ( labelKey ) => (
-								<PanelRow key={ labelKey }>
-									<TextControl
-										__nextHasNoMarginBottom
-										label={ labelKey }
-										value={
-											config.labels?.[ labelKey ] || ''
-										}
-										onChange={ ( value: string ) =>
-											updateLabel( labelKey, value )
-										}
-									/>
-								</PanelRow>
-							) ) }
-						</PanelBody>
-					</Panel>
-				</VStack>
-			</div>
-		</Page>
+				</ConfirmDialog>
+			) }
+		</>
 	);
 }
 

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -18,7 +18,7 @@ import {
 	// @ts-ignore
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { store as noticesStore } from '@wordpress/notices';
@@ -41,7 +41,6 @@ interface EntityConfig {
 	menu_position?: number | null;
 	show_ui: boolean;
 	show_in_menu: boolean | string;
-	taxonomies?: string[];
 	object_type?: string[];
 }
 
@@ -70,21 +69,34 @@ function EntityEdit() {
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ config, setConfig ] = useState< EntityConfig | null >( null );
+	const [ allConfigs, setAllConfigs ] = useState< EntityConfig[] >( [] );
 
-	// Fetch the entity config.
+	// Fetch the entity config and all configs (for taxonomy/post type lists).
 	useEffect( () => {
 		setIsLoading( true );
-		apiFetch< EntityConfig >( {
-			path: `/gutenberg/v1/entity-configs/${ entityType }/${ slug }`,
-		} )
-			.then( ( response ) => {
-				setConfig( response );
+		Promise.all( [
+			apiFetch< EntityConfig >( {
+				path: `/gutenberg/v1/entity-configs/${ entityType }/${ slug }`,
+			} ),
+			apiFetch< EntityConfig[] >( {
+				path: '/gutenberg/v1/entity-configs',
+			} ),
+		] )
+			.then( ( [ entityResponse, allResponse ] ) => {
+				setConfig( entityResponse );
+				setAllConfigs( allResponse );
 				setIsLoading( false );
 			} )
 			.catch( () => {
 				setIsLoading( false );
 			} );
 	}, [ entityType, slug ] );
+
+	// Available post types for taxonomy assignment panel.
+	const availablePostTypes = useMemo(
+		() => allConfigs.filter( ( c ) => c.entity_type === 'post_type' ),
+		[ allConfigs ]
+	);
 
 	const updateField = useCallback(
 		< K extends keyof EntityConfig >(
@@ -131,6 +143,19 @@ function EntityEdit() {
 		[]
 	);
 
+	const toggleObjectType = useCallback(
+		( postTypeSlug: string, assigned: boolean ) => {
+			setConfig( ( prev ) => {
+				const current = prev!.object_type ?? [];
+				const updated = assigned
+					? [ ...current, postTypeSlug ]
+					: current.filter( ( t ) => t !== postTypeSlug );
+				return { ...prev!, object_type: updated } as EntityConfig;
+			} );
+		},
+		[]
+	);
+
 	const handleSave = useCallback( async () => {
 		if ( ! config ) {
 			return;
@@ -158,7 +183,6 @@ function EntityEdit() {
 								has_archive: config.has_archive,
 								menu_icon: config.menu_icon,
 								menu_position: config.menu_position,
-								taxonomies: config.taxonomies,
 						  }
 						: {
 								object_type: config.object_type,
@@ -352,6 +376,39 @@ function EntityEdit() {
 							</PanelRow>
 						</PanelBody>
 					</Panel>
+
+					{ ! isPostType && (
+						<Panel>
+							<PanelBody title={ __( 'Post Types' ) } initialOpen>
+								{ availablePostTypes.map( ( pt ) => (
+									<PanelRow key={ pt.slug }>
+										<CheckboxControl
+											__nextHasNoMarginBottom
+											label={ pt.labels?.name || pt.slug }
+											checked={
+												config.object_type?.includes(
+													pt.slug
+												) ?? false
+											}
+											onChange={ ( value: boolean ) =>
+												toggleObjectType(
+													pt.slug,
+													value
+												)
+											}
+										/>
+									</PanelRow>
+								) ) }
+								{ availablePostTypes.length === 0 && (
+									<PanelRow>
+										<p>
+											{ __( 'No post types available.' ) }
+										</p>
+									</PanelRow>
+								) }
+							</PanelBody>
+						</Panel>
+					) }
 
 					{ isPostType && (
 						<Panel>

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -5,6 +5,7 @@ import { useParams, useNavigate } from '@wordpress/route';
 import { Page } from '@wordpress/admin-ui';
 import {
 	Button,
+	Notice,
 	TextControl,
 	TextareaControl,
 	ToggleControl,
@@ -339,6 +340,13 @@ function EntityEdit() {
 			>
 				<div style={ { maxWidth: 800, padding: 16 } }>
 					<VStack spacing={ 4 }>
+						{ ! config._user_created && (
+							<Notice status="warning" isDismissible={ false }>
+								{ __(
+									'Warning: you are editing a built-in entity, which might have unexpected consequences.'
+								) }
+							</Notice>
+						) }
 						<Panel>
 							<PanelBody title={ __( 'General' ) } initialOpen>
 								<PanelRow>

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -78,6 +78,7 @@ function EntityEdit() {
 			sessionStorage.removeItem( 'gutenberg_entity_saved' );
 			createSuccessNotice( __( 'Entity updated successfully.' ), {
 				type: 'snackbar',
+				id: 'entity-save-success',
 			} );
 		}
 	}, [ createSuccessNotice ] );
@@ -228,6 +229,7 @@ function EntityEdit() {
 			originalConfigRef.current = config;
 			createSuccessNotice( __( 'Entity updated successfully.' ), {
 				type: 'snackbar',
+				id: 'entity-save-success',
 			} );
 		} catch {
 			createErrorNotice( __( 'Failed to update entity.' ), {

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -349,7 +349,7 @@ function EntityEdit() {
 						) }
 						<Panel>
 							<PanelBody title={ __( 'General' ) } initialOpen>
-								<PanelRow>
+								<VStack spacing={ 4 }>
 									<TextControl
 										__nextHasNoMarginBottom
 										label={ __( 'Name (Plural)' ) }
@@ -358,8 +358,6 @@ function EntityEdit() {
 											updateLabel( 'name', value )
 										}
 									/>
-								</PanelRow>
-								<PanelRow>
 									<TextControl
 										__nextHasNoMarginBottom
 										label={ __( 'Singular Name' ) }
@@ -373,8 +371,6 @@ function EntityEdit() {
 											)
 										}
 									/>
-								</PanelRow>
-								<PanelRow>
 									<TextControl
 										__nextHasNoMarginBottom
 										label={ __( 'Slug' ) }
@@ -382,8 +378,6 @@ function EntityEdit() {
 										disabled
 										readOnly
 									/>
-								</PanelRow>
-								<PanelRow>
 									<TextareaControl
 										__nextHasNoMarginBottom
 										label={ __( 'Description' ) }
@@ -392,7 +386,7 @@ function EntityEdit() {
 											updateField( 'description', value )
 										}
 									/>
-								</PanelRow>
+								</VStack>
 							</PanelBody>
 						</Panel>
 
@@ -461,17 +455,20 @@ function EntityEdit() {
 								title={ __( 'REST API' ) }
 								initialOpen={ false }
 							>
-								<PanelRow>
-									<ToggleControl
-										__nextHasNoMarginBottom
-										label={ __( 'Show in REST' ) }
-										checked={ config.show_in_rest }
-										onChange={ ( value: boolean ) =>
-											updateField( 'show_in_rest', value )
-										}
-									/>
-								</PanelRow>
-								<PanelRow>
+								<VStack spacing={ 4 }>
+									<PanelRow>
+										<ToggleControl
+											__nextHasNoMarginBottom
+											label={ __( 'Show in REST' ) }
+											checked={ config.show_in_rest }
+											onChange={ ( value: boolean ) =>
+												updateField(
+													'show_in_rest',
+													value
+												)
+											}
+										/>
+									</PanelRow>
 									<TextControl
 										__nextHasNoMarginBottom
 										label={ __( 'REST Base' ) }
@@ -480,7 +477,7 @@ function EntityEdit() {
 											updateField( 'rest_base', value )
 										}
 									/>
-								</PanelRow>
+								</VStack>
 							</PanelBody>
 						</Panel>
 
@@ -530,7 +527,7 @@ function EntityEdit() {
 									title={ __( 'Menu' ) }
 									initialOpen={ false }
 								>
-									<PanelRow>
+									<VStack spacing={ 4 }>
 										<TextControl
 											__nextHasNoMarginBottom
 											label={ __( 'Menu Icon' ) }
@@ -545,8 +542,6 @@ function EntityEdit() {
 												)
 											}
 										/>
-									</PanelRow>
-									<PanelRow>
 										<TextControl
 											__nextHasNoMarginBottom
 											label={ __( 'Menu Position' ) }
@@ -567,7 +562,7 @@ function EntityEdit() {
 												)
 											}
 										/>
-									</PanelRow>
+									</VStack>
 								</PanelBody>
 							</Panel>
 						) }
@@ -606,21 +601,22 @@ function EntityEdit() {
 								title={ __( 'Labels' ) }
 								initialOpen={ false }
 							>
-								{ [
-									'add_new',
-									'add_new_item',
-									'edit_item',
-									'new_item',
-									'view_item',
-									'view_items',
-									'search_items',
-									'not_found',
-									'not_found_in_trash',
-									'all_items',
-									'menu_name',
-								].map( ( labelKey ) => (
-									<PanelRow key={ labelKey }>
+								<VStack spacing={ 4 }>
+									{ [
+										'add_new',
+										'add_new_item',
+										'edit_item',
+										'new_item',
+										'view_item',
+										'view_items',
+										'search_items',
+										'not_found',
+										'not_found_in_trash',
+										'all_items',
+										'menu_name',
+									].map( ( labelKey ) => (
 										<TextControl
+											key={ labelKey }
 											__nextHasNoMarginBottom
 											label={ labelKey }
 											value={
@@ -631,8 +627,8 @@ function EntityEdit() {
 												updateLabel( labelKey, value )
 											}
 										/>
-									</PanelRow>
-								) ) }
+									) ) }
+								</VStack>
 							</PanelBody>
 						</Panel>
 					</VStack>

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -38,6 +38,8 @@ interface EntityConfig {
 	slug: string;
 	entity_type: 'post_type' | 'taxonomy';
 	_user_created: boolean;
+	_source: 'core' | 'plugin' | 'user';
+	_orphaned: boolean;
 	labels: Record< string, string >;
 	description: string;
 	public: boolean;
@@ -241,11 +243,14 @@ function EntityEdit() {
 				type: 'snackbar',
 				id: 'entity-save-success',
 			} );
-		} catch {
-			createErrorNotice( __( 'Failed to update entity.' ), {
-				type: 'snackbar',
-				id: 'entity-save-error',
-			} );
+		} catch ( error: any ) {
+			createErrorNotice(
+				error?.message || __( 'Failed to update entity.' ),
+				{
+					type: 'snackbar',
+					id: 'entity-save-error',
+				}
+			);
 		}
 
 		setIsSaving( false );
@@ -316,7 +321,7 @@ function EntityEdit() {
 						>
 							{ __( 'Back' ) }
 						</Button>
-						{ config._user_created && (
+						{ ( config._user_created || config._orphaned ) && (
 							<Button
 								icon={ trash }
 								label={ __( 'Delete' ) }
@@ -340,10 +345,24 @@ function EntityEdit() {
 			>
 				<div style={ { padding: 16 } }>
 					<VStack spacing={ 4 }>
-						{ ! config._user_created && (
+						{ config._orphaned && (
 							<Notice status="warning" isDismissible={ false }>
 								{ __(
-									'Warning: you are editing a built-in entity, which might have unexpected consequences.'
+									'This entity is no longer registered. The plugin or theme that created it may be deactivated. Saving changes will have no effect until it is registered again.'
+								) }
+							</Notice>
+						) }
+						{ ! config._orphaned && config._source === 'core' && (
+							<Notice status="warning" isDismissible={ false }>
+								{ __(
+									'Warning: you are editing a core WordPress entity. Changes might have unexpected consequences.'
+								) }
+							</Notice>
+						) }
+						{ ! config._orphaned && config._source === 'plugin' && (
+							<Notice status="warning" isDismissible={ false }>
+								{ __(
+									'Warning: you are editing an entity registered by a plugin or theme. If it is updated or deactivated, your changes may be lost.'
 								) }
 							</Notice>
 						) }

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -10,10 +10,8 @@ import {
 	TextareaControl,
 	ToggleControl,
 	CheckboxControl,
-	Panel,
-	PanelBody,
-	PanelRow,
 	Spinner,
+	privateApis as componentsPrivateApis,
 	// @ts-ignore
 	__experimentalConfirmDialog as ConfirmDialog,
 	// @ts-ignore
@@ -33,6 +31,13 @@ import apiFetch from '@wordpress/api-fetch';
 import { store as noticesStore } from '@wordpress/notices';
 import { useDispatch } from '@wordpress/data';
 import { trash, undo } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
+const { Tabs } = unlock( componentsPrivateApis );
 
 interface EntityConfig {
 	slug: string;
@@ -389,8 +394,38 @@ function EntityEdit() {
 								) }
 							</Notice>
 						) }
-						<Panel>
-							<PanelBody title={ __( 'General' ) } initialOpen>
+						<Tabs>
+							<Tabs.TabList>
+								<Tabs.Tab tabId="general">
+									{ __( 'General' ) }
+								</Tabs.Tab>
+								<Tabs.Tab tabId="visibility">
+									{ __( 'Visibility' ) }
+								</Tabs.Tab>
+								<Tabs.Tab tabId="rest-api">
+									{ __( 'REST API' ) }
+								</Tabs.Tab>
+								{ ! isPostType && (
+									<Tabs.Tab tabId="post-types">
+										{ __( 'Post Types' ) }
+									</Tabs.Tab>
+								) }
+								{ isPostType && (
+									<Tabs.Tab tabId="menu">
+										{ __( 'Menu' ) }
+									</Tabs.Tab>
+								) }
+								{ isPostType && (
+									<Tabs.Tab tabId="supports">
+										{ __( 'Supports' ) }
+									</Tabs.Tab>
+								) }
+								<Tabs.Tab tabId="labels">
+									{ __( 'Labels' ) }
+								</Tabs.Tab>
+							</Tabs.TabList>
+
+							<Tabs.TabPanel tabId="general" focusable={ false }>
 								<VStack spacing={ 4 }>
 									<TextControl
 										__next40pxDefaultSize
@@ -433,12 +468,13 @@ function EntityEdit() {
 										}
 									/>
 								</VStack>
-							</PanelBody>
-						</Panel>
+							</Tabs.TabPanel>
 
-						<Panel>
-							<PanelBody title={ __( 'Visibility' ) } initialOpen>
-								<PanelRow>
+							<Tabs.TabPanel
+								tabId="visibility"
+								focusable={ false }
+							>
+								<VStack spacing={ 3 }>
 									<ToggleControl
 										__nextHasNoMarginBottom
 										label={ __( 'Public' ) }
@@ -447,8 +483,6 @@ function EntityEdit() {
 											updateField( 'public', value )
 										}
 									/>
-								</PanelRow>
-								<PanelRow>
 									<ToggleControl
 										__nextHasNoMarginBottom
 										label={ __( 'Hierarchical' ) }
@@ -457,8 +491,6 @@ function EntityEdit() {
 											updateField( 'hierarchical', value )
 										}
 									/>
-								</PanelRow>
-								<PanelRow>
 									<ToggleControl
 										__nextHasNoMarginBottom
 										label={ __( 'Show UI' ) }
@@ -467,8 +499,6 @@ function EntityEdit() {
 											updateField( 'show_ui', value )
 										}
 									/>
-								</PanelRow>
-								<PanelRow>
 									<ToggleControl
 										__nextHasNoMarginBottom
 										label={ __( 'Show in Menu' ) }
@@ -477,9 +507,7 @@ function EntityEdit() {
 											updateField( 'show_in_menu', value )
 										}
 									/>
-								</PanelRow>
-								{ isPostType && (
-									<PanelRow>
+									{ isPostType && (
 										<ToggleControl
 											__nextHasNoMarginBottom
 											label={ __( 'Has Archive' ) }
@@ -491,30 +519,20 @@ function EntityEdit() {
 												)
 											}
 										/>
-									</PanelRow>
-								) }
-							</PanelBody>
-						</Panel>
+									) }
+								</VStack>
+							</Tabs.TabPanel>
 
-						<Panel>
-							<PanelBody
-								title={ __( 'REST API' ) }
-								initialOpen={ false }
-							>
+							<Tabs.TabPanel tabId="rest-api" focusable={ false }>
 								<VStack spacing={ 4 }>
-									<PanelRow>
-										<ToggleControl
-											__nextHasNoMarginBottom
-											label={ __( 'Show in REST' ) }
-											checked={ config.show_in_rest }
-											onChange={ ( value: boolean ) =>
-												updateField(
-													'show_in_rest',
-													value
-												)
-											}
-										/>
-									</PanelRow>
+									<ToggleControl
+										__nextHasNoMarginBottom
+										label={ __( 'Show in REST' ) }
+										checked={ config.show_in_rest }
+										onChange={ ( value: boolean ) =>
+											updateField( 'show_in_rest', value )
+										}
+									/>
 									<TextControl
 										__next40pxDefaultSize
 										__nextHasNoMarginBottom
@@ -525,18 +543,17 @@ function EntityEdit() {
 										}
 									/>
 								</VStack>
-							</PanelBody>
-						</Panel>
+							</Tabs.TabPanel>
 
-						{ ! isPostType && (
-							<Panel>
-								<PanelBody
-									title={ __( 'Post Types' ) }
-									initialOpen
+							{ ! isPostType && (
+								<Tabs.TabPanel
+									tabId="post-types"
+									focusable={ false }
 								>
-									{ availablePostTypes.map( ( pt ) => (
-										<PanelRow key={ pt.slug }>
+									<VStack spacing={ 3 }>
+										{ availablePostTypes.map( ( pt ) => (
 											<CheckboxControl
+												key={ pt.slug }
 												__nextHasNoMarginBottom
 												label={
 													pt.labels?.name || pt.slug
@@ -553,27 +570,20 @@ function EntityEdit() {
 													)
 												}
 											/>
-										</PanelRow>
-									) ) }
-									{ availablePostTypes.length === 0 && (
-										<PanelRow>
+										) ) }
+										{ availablePostTypes.length === 0 && (
 											<p>
 												{ __(
 													'No post types available.'
 												) }
 											</p>
-										</PanelRow>
-									) }
-								</PanelBody>
-							</Panel>
-						) }
+										) }
+									</VStack>
+								</Tabs.TabPanel>
+							) }
 
-						{ isPostType && (
-							<Panel>
-								<PanelBody
-									title={ __( 'Menu' ) }
-									initialOpen={ false }
-								>
+							{ isPostType && (
+								<Tabs.TabPanel tabId="menu" focusable={ false }>
 									<VStack spacing={ 4 }>
 										<TextControl
 											__next40pxDefaultSize
@@ -612,44 +622,42 @@ function EntityEdit() {
 											}
 										/>
 									</VStack>
-								</PanelBody>
-							</Panel>
-						) }
+								</Tabs.TabPanel>
+							) }
 
-						{ isPostType && (
-							<Panel>
-								<PanelBody
-									title={ __( 'Supports' ) }
-									initialOpen={ false }
+							{ isPostType && (
+								<Tabs.TabPanel
+									tabId="supports"
+									focusable={ false }
 								>
-									{ POST_TYPE_SUPPORTS.map( ( feature ) => (
-										<PanelRow key={ feature }>
-											<CheckboxControl
-												__nextHasNoMarginBottom
-												label={ feature }
-												checked={
-													!! config.supports?.[
-														feature
-													]
-												}
-												onChange={ ( value: boolean ) =>
-													updateSupport(
-														feature,
-														value
-													)
-												}
-											/>
-										</PanelRow>
-									) ) }
-								</PanelBody>
-							</Panel>
-						) }
+									<VStack spacing={ 3 }>
+										{ POST_TYPE_SUPPORTS.map(
+											( feature ) => (
+												<CheckboxControl
+													key={ feature }
+													__nextHasNoMarginBottom
+													label={ feature }
+													checked={
+														!! config.supports?.[
+															feature
+														]
+													}
+													onChange={ (
+														value: boolean
+													) =>
+														updateSupport(
+															feature,
+															value
+														)
+													}
+												/>
+											)
+										) }
+									</VStack>
+								</Tabs.TabPanel>
+							) }
 
-						<Panel>
-							<PanelBody
-								title={ __( 'Labels' ) }
-								initialOpen={ false }
-							>
+							<Tabs.TabPanel tabId="labels" focusable={ false }>
 								<VStack spacing={ 4 }>
 									{ [
 										'add_new',
@@ -679,8 +687,8 @@ function EntityEdit() {
 										/>
 									) ) }
 								</VStack>
-							</PanelBody>
-						</Panel>
+							</Tabs.TabPanel>
+						</Tabs>
 					</VStack>
 				</div>
 			</Page>

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -257,12 +257,12 @@ function EntityEdit() {
 		setIsSaving( false );
 	}, [ config, entityType, slug, createSuccessNotice, createErrorNotice ] );
 
-	// Plugin-registered entities that are still active are "reverted" (overrides
-	// cleared; plugin re-registers it on next request). User-created and
-	// orphaned entities are "deleted" (stored config removed). Revert is only
-	// available when the entity has actually been customized.
+	// Core and active plugin entities are "reverted" (overrides cleared;
+	// core/plugin re-registers them on next request). User-created and orphaned
+	// entities are "deleted" (stored config removed). Revert is only available
+	// when the entity has actually been customized.
 	const isRevert =
-		config?._source === 'plugin' &&
+		( config?._source === 'plugin' || config?._source === 'core' ) &&
 		! config?._orphaned &&
 		!! config?._customized;
 

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -338,7 +338,7 @@ function EntityEdit() {
 					</HStack>
 				}
 			>
-				<div style={ { maxWidth: 800, padding: 16 } }>
+				<div style={ { padding: 16 } }>
 					<VStack spacing={ 4 }>
 						{ ! config._user_created && (
 							<Notice status="warning" isDismissible={ false }>

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -74,9 +74,10 @@ function EntityEdit() {
 
 	// Show a success notice if we just reloaded after a menu-affecting save.
 	useEffect( () => {
-		if ( sessionStorage.getItem( 'gutenberg_entity_saved' ) ) {
+		const message = sessionStorage.getItem( 'gutenberg_entity_saved' );
+		if ( message ) {
 			sessionStorage.removeItem( 'gutenberg_entity_saved' );
-			createSuccessNotice( __( 'Entity updated successfully.' ), {
+			createSuccessNotice( message, {
 				type: 'snackbar',
 				id: 'entity-save-success',
 			} );
@@ -221,7 +222,10 @@ function EntityEdit() {
 					JSON.stringify( config.object_type );
 
 			if ( menuChanged ) {
-				sessionStorage.setItem( 'gutenberg_entity_saved', '1' );
+				sessionStorage.setItem(
+					'gutenberg_entity_saved',
+					__( 'Entity updated successfully.' )
+				);
 				window.location.reload();
 				return;
 			}

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -234,6 +234,7 @@ function EntityEdit() {
 		} catch {
 			createErrorNotice( __( 'Failed to update entity.' ), {
 				type: 'snackbar',
+				id: 'entity-save-error',
 			} );
 		}
 

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -268,7 +268,12 @@ function EntityEdit() {
 				<HStack spacing={ 3 }>
 					<Button
 						variant="tertiary"
-						onClick={ () => navigate( { to: '/' } ) }
+						onClick={ () =>
+							navigate( {
+								to: '/',
+								search: { tab: entityType },
+							} )
+						}
 						size="compact"
 					>
 						{ __( 'Back' ) }

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -393,6 +393,7 @@ function EntityEdit() {
 							<PanelBody title={ __( 'General' ) } initialOpen>
 								<VStack spacing={ 4 }>
 									<TextControl
+										__next40pxDefaultSize
 										__nextHasNoMarginBottom
 										label={ __( 'Name (Plural)' ) }
 										value={ config.labels?.name || '' }
@@ -401,6 +402,7 @@ function EntityEdit() {
 										}
 									/>
 									<TextControl
+										__next40pxDefaultSize
 										__nextHasNoMarginBottom
 										label={ __( 'Singular Name' ) }
 										value={
@@ -414,6 +416,7 @@ function EntityEdit() {
 										}
 									/>
 									<TextControl
+										__next40pxDefaultSize
 										__nextHasNoMarginBottom
 										label={ __( 'Slug' ) }
 										value={ config.slug }
@@ -421,6 +424,7 @@ function EntityEdit() {
 										readOnly
 									/>
 									<TextareaControl
+										__next40pxDefaultSize
 										__nextHasNoMarginBottom
 										label={ __( 'Description' ) }
 										value={ config.description || '' }
@@ -512,6 +516,7 @@ function EntityEdit() {
 										/>
 									</PanelRow>
 									<TextControl
+										__next40pxDefaultSize
 										__nextHasNoMarginBottom
 										label={ __( 'REST Base' ) }
 										value={ config.rest_base || '' }
@@ -571,6 +576,7 @@ function EntityEdit() {
 								>
 									<VStack spacing={ 4 }>
 										<TextControl
+											__next40pxDefaultSize
 											__nextHasNoMarginBottom
 											label={ __( 'Menu Icon' ) }
 											help={ __(
@@ -585,6 +591,7 @@ function EntityEdit() {
 											}
 										/>
 										<TextControl
+											__next40pxDefaultSize
 											__nextHasNoMarginBottom
 											label={ __( 'Menu Position' ) }
 											type="number"
@@ -658,6 +665,7 @@ function EntityEdit() {
 										'menu_name',
 									].map( ( labelKey ) => (
 										<TextControl
+											__next40pxDefaultSize
 											key={ labelKey }
 											__nextHasNoMarginBottom
 											label={ labelKey }

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -72,6 +72,16 @@ function EntityEdit() {
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 
+	// Show a success notice if we just reloaded after a menu-affecting save.
+	useEffect( () => {
+		if ( sessionStorage.getItem( 'gutenberg_entity_saved' ) ) {
+			sessionStorage.removeItem( 'gutenberg_entity_saved' );
+			createSuccessNotice( __( 'Entity updated successfully.' ), {
+				type: 'snackbar',
+			} );
+		}
+	}, [ createSuccessNotice ] );
+
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ config, setConfig ] = useState< EntityConfig | null >( null );
@@ -210,6 +220,7 @@ function EntityEdit() {
 					JSON.stringify( config.object_type );
 
 			if ( menuChanged ) {
+				sessionStorage.setItem( 'gutenberg_entity_saved', '1' );
 				window.location.reload();
 				return;
 			}

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -337,7 +337,7 @@ function EntityEdit() {
 					</HStack>
 				}
 			>
-				<div style={ { maxWidth: 800, padding: '0 16px' } }>
+				<div style={ { maxWidth: 800, padding: 16 } }>
 					<VStack spacing={ 4 }>
 						<Panel>
 							<PanelBody title={ __( 'General' ) } initialOpen>

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -1,0 +1,463 @@
+/**
+ * WordPress dependencies
+ */
+import { useParams, useNavigate } from '@wordpress/route';
+import { Page } from '@wordpress/admin-ui';
+import {
+	Button,
+	TextControl,
+	TextareaControl,
+	ToggleControl,
+	CheckboxControl,
+	Panel,
+	PanelBody,
+	PanelRow,
+	Spinner,
+	// @ts-ignore
+	__experimentalVStack as VStack,
+	// @ts-ignore
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { useState, useEffect, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { store as noticesStore } from '@wordpress/notices';
+import { useDispatch } from '@wordpress/data';
+
+interface EntityConfig {
+	slug: string;
+	entity_type: 'post_type' | 'taxonomy';
+	_user_created: boolean;
+	labels: Record< string, string >;
+	description: string;
+	public: boolean;
+	hierarchical: boolean;
+	supports?: Record< string, boolean >;
+	has_archive?: boolean | string;
+	rewrite?: { slug?: string } | boolean;
+	show_in_rest: boolean;
+	rest_base: string;
+	menu_icon?: string | null;
+	menu_position?: number | null;
+	show_ui: boolean;
+	show_in_menu: boolean | string;
+	taxonomies?: string[];
+	object_type?: string[];
+}
+
+const POST_TYPE_SUPPORTS = [
+	'title',
+	'editor',
+	'author',
+	'thumbnail',
+	'excerpt',
+	'trackbacks',
+	'custom-fields',
+	'comments',
+	'revisions',
+	'page-attributes',
+	'post-formats',
+];
+
+function EntityEdit() {
+	const { entityType, slug } = useParams( {
+		from: '/edit/$entityType/$slug',
+	} );
+	const navigate = useNavigate();
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ config, setConfig ] = useState< EntityConfig | null >( null );
+
+	// Fetch the entity config.
+	useEffect( () => {
+		setIsLoading( true );
+		apiFetch< EntityConfig >( {
+			path: `/gutenberg/v1/entity-configs/${ entityType }/${ slug }`,
+		} )
+			.then( ( response ) => {
+				setConfig( response );
+				setIsLoading( false );
+			} )
+			.catch( () => {
+				setIsLoading( false );
+			} );
+	}, [ entityType, slug ] );
+
+	const updateField = useCallback(
+		< K extends keyof EntityConfig >(
+			field: K,
+			value: EntityConfig[ K ]
+		) => {
+			setConfig(
+				( prev ) =>
+					( {
+						...prev!,
+						[ field ]: value,
+					} ) as EntityConfig
+			);
+		},
+		[]
+	);
+
+	const updateLabel = useCallback( ( key: string, value: string ) => {
+		setConfig(
+			( prev ) =>
+				( {
+					...prev!,
+					labels: {
+						...prev!.labels,
+						[ key ]: value,
+					},
+				} ) as EntityConfig
+		);
+	}, [] );
+
+	const updateSupport = useCallback(
+		( feature: string, enabled: boolean ) => {
+			setConfig(
+				( prev ) =>
+					( {
+						...prev!,
+						supports: {
+							...prev!.supports,
+							[ feature ]: enabled,
+						},
+					} ) as EntityConfig
+			);
+		},
+		[]
+	);
+
+	const handleSave = useCallback( async () => {
+		if ( ! config ) {
+			return;
+		}
+
+		setIsSaving( true );
+
+		try {
+			await apiFetch( {
+				path: `/gutenberg/v1/entity-configs/${ entityType }/${ slug }`,
+				method: 'PUT',
+				data: {
+					labels: config.labels,
+					description: config.description,
+					public: config.public,
+					hierarchical: config.hierarchical,
+					show_in_rest: config.show_in_rest,
+					rest_base: config.rest_base,
+					show_ui: config.show_ui,
+					show_in_menu: config.show_in_menu,
+					rewrite: config.rewrite,
+					...( entityType === 'post_type'
+						? {
+								supports: config.supports,
+								has_archive: config.has_archive,
+								menu_icon: config.menu_icon,
+								menu_position: config.menu_position,
+								taxonomies: config.taxonomies,
+						  }
+						: {
+								object_type: config.object_type,
+						  } ),
+				},
+			} );
+			createSuccessNotice( __( 'Entity updated successfully.' ), {
+				type: 'snackbar',
+			} );
+		} catch {
+			createErrorNotice( __( 'Failed to update entity.' ), {
+				type: 'snackbar',
+			} );
+		}
+
+		setIsSaving( false );
+	}, [ config, entityType, slug, createSuccessNotice, createErrorNotice ] );
+
+	if ( isLoading ) {
+		return (
+			<Page title={ __( 'Edit Entity' ) }>
+				<Spinner />
+			</Page>
+		);
+	}
+
+	if ( ! config ) {
+		return (
+			<Page title={ __( 'Edit Entity' ) }>
+				<p>{ __( 'Entity not found.' ) }</p>
+			</Page>
+		);
+	}
+
+	const isPostType = entityType === 'post_type';
+	const pageTitle = `${ __( 'Edit' ) }: ${
+		config.labels?.name || config.slug
+	}`;
+
+	return (
+		<Page
+			title={ pageTitle }
+			actions={
+				<HStack spacing={ 3 }>
+					<Button
+						variant="tertiary"
+						onClick={ () => navigate( { to: '/' } ) }
+						size="compact"
+					>
+						{ __( 'Back' ) }
+					</Button>
+					<Button
+						variant="primary"
+						onClick={ handleSave }
+						isBusy={ isSaving }
+						disabled={ isSaving }
+						size="compact"
+					>
+						{ __( 'Save' ) }
+					</Button>
+				</HStack>
+			}
+		>
+			<div style={ { maxWidth: 800, padding: '0 16px' } }>
+				<VStack spacing={ 4 }>
+					<Panel>
+						<PanelBody title={ __( 'General' ) } initialOpen>
+							<PanelRow>
+								<TextControl
+									__nextHasNoMarginBottom
+									label={ __( 'Name (Plural)' ) }
+									value={ config.labels?.name || '' }
+									onChange={ ( value: string ) =>
+										updateLabel( 'name', value )
+									}
+								/>
+							</PanelRow>
+							<PanelRow>
+								<TextControl
+									__nextHasNoMarginBottom
+									label={ __( 'Singular Name' ) }
+									value={ config.labels?.singular_name || '' }
+									onChange={ ( value: string ) =>
+										updateLabel( 'singular_name', value )
+									}
+								/>
+							</PanelRow>
+							<PanelRow>
+								<TextControl
+									__nextHasNoMarginBottom
+									label={ __( 'Slug' ) }
+									value={ config.slug }
+									disabled
+									readOnly
+								/>
+							</PanelRow>
+							<PanelRow>
+								<TextareaControl
+									__nextHasNoMarginBottom
+									label={ __( 'Description' ) }
+									value={ config.description || '' }
+									onChange={ ( value: string ) =>
+										updateField( 'description', value )
+									}
+								/>
+							</PanelRow>
+						</PanelBody>
+					</Panel>
+
+					<Panel>
+						<PanelBody title={ __( 'Visibility' ) } initialOpen>
+							<PanelRow>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Public' ) }
+									checked={ config.public }
+									onChange={ ( value: boolean ) =>
+										updateField( 'public', value )
+									}
+								/>
+							</PanelRow>
+							<PanelRow>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Hierarchical' ) }
+									checked={ config.hierarchical }
+									onChange={ ( value: boolean ) =>
+										updateField( 'hierarchical', value )
+									}
+								/>
+							</PanelRow>
+							<PanelRow>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Show UI' ) }
+									checked={ config.show_ui }
+									onChange={ ( value: boolean ) =>
+										updateField( 'show_ui', value )
+									}
+								/>
+							</PanelRow>
+							<PanelRow>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Show in Menu' ) }
+									checked={ !! config.show_in_menu }
+									onChange={ ( value: boolean ) =>
+										updateField( 'show_in_menu', value )
+									}
+								/>
+							</PanelRow>
+							{ isPostType && (
+								<PanelRow>
+									<ToggleControl
+										__nextHasNoMarginBottom
+										label={ __( 'Has Archive' ) }
+										checked={ !! config.has_archive }
+										onChange={ ( value: boolean ) =>
+											updateField( 'has_archive', value )
+										}
+									/>
+								</PanelRow>
+							) }
+						</PanelBody>
+					</Panel>
+
+					<Panel>
+						<PanelBody
+							title={ __( 'REST API' ) }
+							initialOpen={ false }
+						>
+							<PanelRow>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Show in REST' ) }
+									checked={ config.show_in_rest }
+									onChange={ ( value: boolean ) =>
+										updateField( 'show_in_rest', value )
+									}
+								/>
+							</PanelRow>
+							<PanelRow>
+								<TextControl
+									__nextHasNoMarginBottom
+									label={ __( 'REST Base' ) }
+									value={ config.rest_base || '' }
+									onChange={ ( value: string ) =>
+										updateField( 'rest_base', value )
+									}
+								/>
+							</PanelRow>
+						</PanelBody>
+					</Panel>
+
+					{ isPostType && (
+						<Panel>
+							<PanelBody
+								title={ __( 'Menu' ) }
+								initialOpen={ false }
+							>
+								<PanelRow>
+									<TextControl
+										__nextHasNoMarginBottom
+										label={ __( 'Menu Icon' ) }
+										help={ __(
+											'A dashicon class name or URL to an icon image.'
+										) }
+										value={ config.menu_icon || '' }
+										onChange={ ( value: string ) =>
+											updateField(
+												'menu_icon',
+												value || null
+											)
+										}
+									/>
+								</PanelRow>
+								<PanelRow>
+									<TextControl
+										__nextHasNoMarginBottom
+										label={ __( 'Menu Position' ) }
+										type="number"
+										value={
+											config.menu_position !== null
+												? String( config.menu_position )
+												: ''
+										}
+										onChange={ ( value: string ) =>
+											updateField(
+												'menu_position',
+												value ? Number( value ) : null
+											)
+										}
+									/>
+								</PanelRow>
+							</PanelBody>
+						</Panel>
+					) }
+
+					{ isPostType && (
+						<Panel>
+							<PanelBody
+								title={ __( 'Supports' ) }
+								initialOpen={ false }
+							>
+								{ POST_TYPE_SUPPORTS.map( ( feature ) => (
+									<PanelRow key={ feature }>
+										<CheckboxControl
+											__nextHasNoMarginBottom
+											label={ feature }
+											checked={
+												!! config.supports?.[ feature ]
+											}
+											onChange={ ( value: boolean ) =>
+												updateSupport( feature, value )
+											}
+										/>
+									</PanelRow>
+								) ) }
+							</PanelBody>
+						</Panel>
+					) }
+
+					<Panel>
+						<PanelBody
+							title={ __( 'Labels' ) }
+							initialOpen={ false }
+						>
+							{ [
+								'add_new',
+								'add_new_item',
+								'edit_item',
+								'new_item',
+								'view_item',
+								'view_items',
+								'search_items',
+								'not_found',
+								'not_found_in_trash',
+								'all_items',
+								'menu_name',
+							].map( ( labelKey ) => (
+								<PanelRow key={ labelKey }>
+									<TextControl
+										__nextHasNoMarginBottom
+										label={ labelKey }
+										value={
+											config.labels?.[ labelKey ] || ''
+										}
+										onChange={ ( value: string ) =>
+											updateLabel( labelKey, value )
+										}
+									/>
+								</PanelRow>
+							) ) }
+						</PanelBody>
+					</Panel>
+				</VStack>
+			</div>
+		</Page>
+	);
+}
+
+export const stage = EntityEdit;

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -32,7 +32,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { store as noticesStore } from '@wordpress/notices';
 import { useDispatch } from '@wordpress/data';
-import { trash } from '@wordpress/icons';
+import { trash, undo } from '@wordpress/icons';
 
 interface EntityConfig {
 	slug: string;
@@ -40,6 +40,7 @@ interface EntityConfig {
 	_user_created: boolean;
 	_source: 'core' | 'plugin' | 'user';
 	_orphaned: boolean;
+	_customized: boolean;
 	labels: Record< string, string >;
 	description: string;
 	public: boolean;
@@ -256,6 +257,15 @@ function EntityEdit() {
 		setIsSaving( false );
 	}, [ config, entityType, slug, createSuccessNotice, createErrorNotice ] );
 
+	// Plugin-registered entities that are still active are "reverted" (overrides
+	// cleared; plugin re-registers it on next request). User-created and
+	// orphaned entities are "deleted" (stored config removed). Revert is only
+	// available when the entity has actually been customized.
+	const isRevert =
+		config?._source === 'plugin' &&
+		! config?._orphaned &&
+		!! config?._customized;
+
 	const handleDelete = useCallback( async () => {
 		setIsDeleting( true );
 		try {
@@ -265,22 +275,29 @@ function EntityEdit() {
 			} );
 			sessionStorage.setItem(
 				'gutenberg_entity_saved',
-				__( 'Entity deleted successfully.' )
+				isRevert
+					? __( 'Entity reverted successfully.' )
+					: __( 'Entity deleted successfully.' )
 			);
-			// Always reload — a deleted entity affects the admin menu.
+			// Always reload — a deleted/reverted entity affects the admin menu.
 			const url = new URL( window.location.href );
 			url.searchParams.set( 'p', '/' );
 			url.searchParams.set( 'tab', entityType );
 			window.location.href = url.toString();
 		} catch {
-			createErrorNotice( __( 'Failed to delete entity.' ), {
-				type: 'snackbar',
-				id: 'entity-delete-error',
-			} );
+			createErrorNotice(
+				isRevert
+					? __( 'Failed to revert entity.' )
+					: __( 'Failed to delete entity.' ),
+				{
+					type: 'snackbar',
+					id: 'entity-delete-error',
+				}
+			);
 			setIsDeleting( false );
 			setShowDeleteConfirm( false );
 		}
-	}, [ entityType, slug, createErrorNotice ] );
+	}, [ entityType, slug, isRevert, createErrorNotice ] );
 
 	if ( isLoading ) {
 		return (
@@ -321,11 +338,17 @@ function EntityEdit() {
 						>
 							{ __( 'Back' ) }
 						</Button>
-						{ ( config._user_created || config._orphaned ) && (
+						{ ( config._user_created ||
+							config._orphaned ||
+							isRevert ) && (
 							<Button
-								icon={ trash }
-								label={ __( 'Delete' ) }
-								isDestructive
+								icon={ isRevert ? undo : trash }
+								label={
+									isRevert
+										? __( 'Revert to default' )
+										: __( 'Delete' )
+								}
+								isDestructive={ ! isRevert }
 								onClick={ () => setShowDeleteConfirm( true ) }
 								disabled={ isDeleting }
 								size="compact"
@@ -658,14 +681,24 @@ function EntityEdit() {
 					isOpen
 					onConfirm={ handleDelete }
 					onCancel={ () => setShowDeleteConfirm( false ) }
-					confirmButtonText={ __( 'Delete' ) }
+					confirmButtonText={
+						isRevert ? __( 'Revert' ) : __( 'Delete' )
+					}
 					isBusy={ isDeleting }
 				>
-					{ sprintf(
-						/* translators: %s: entity name */
-						__( 'Are you sure you want to delete "%s"?' ),
-						config.labels?.name || config.slug
-					) }
+					{ isRevert
+						? sprintf(
+								/* translators: %s: entity name */
+								__(
+									'Are you sure you want to revert "%s" to its default state? All your customizations will be lost.'
+								),
+								config.labels?.name || config.slug
+						  )
+						: sprintf(
+								/* translators: %s: entity name */
+								__( 'Are you sure you want to delete "%s"?' ),
+								config.labels?.name || config.slug
+						  ) }
 				</ConfirmDialog>
 			) }
 		</>

--- a/routes/entity-edit/stage.tsx
+++ b/routes/entity-edit/stage.tsx
@@ -18,7 +18,13 @@ import {
 	// @ts-ignore
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
+import {
+	useState,
+	useEffect,
+	useCallback,
+	useMemo,
+	useRef,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { store as noticesStore } from '@wordpress/notices';
@@ -70,6 +76,7 @@ function EntityEdit() {
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ config, setConfig ] = useState< EntityConfig | null >( null );
 	const [ allConfigs, setAllConfigs ] = useState< EntityConfig[] >( [] );
+	const originalConfigRef = useRef< EntityConfig | null >( null );
 
 	// Fetch the entity config and all configs (for taxonomy/post type lists).
 	useEffect( () => {
@@ -84,6 +91,7 @@ function EntityEdit() {
 		] )
 			.then( ( [ entityResponse, allResponse ] ) => {
 				setConfig( entityResponse );
+				originalConfigRef.current = entityResponse;
 				setAllConfigs( allResponse );
 				setIsLoading( false );
 			} )
@@ -189,6 +197,24 @@ function EntityEdit() {
 						  } ),
 				},
 			} );
+
+			const prev = originalConfigRef.current;
+			const menuChanged =
+				prev?.labels?.name !== config.labels?.name ||
+				prev?.labels?.menu_name !== config.labels?.menu_name ||
+				prev?.show_ui !== config.show_ui ||
+				prev?.show_in_menu !== config.show_in_menu ||
+				prev?.menu_icon !== config.menu_icon ||
+				prev?.menu_position !== config.menu_position ||
+				JSON.stringify( prev?.object_type ) !==
+					JSON.stringify( config.object_type );
+
+			if ( menuChanged ) {
+				window.location.reload();
+				return;
+			}
+
+			originalConfigRef.current = config;
 			createSuccessNotice( __( 'Entity updated successfully.' ), {
 				type: 'snackbar',
 			} );

--- a/routes/entity-list/package.json
+++ b/routes/entity-list/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "@wordpress/entity-list-route",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/",
+		"page": "entities"
+	},
+	"dependencies": {
+		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/api-fetch": "file:../../packages/api-fetch",
+		"@wordpress/components": "file:../../packages/components",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/dataviews": "file:../../packages/dataviews",
+		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/icons": "file:../../packages/icons",
+		"@wordpress/notices": "file:../../packages/notices",
+		"@wordpress/private-apis": "file:../../packages/private-apis",
+		"@wordpress/route": "file:../../packages/route"
+	}
+}

--- a/routes/entity-list/route.ts
+++ b/routes/entity-list/route.ts
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const route = {
+	title: () => __( 'Entities' ),
+};

--- a/routes/entity-list/stage.tsx
+++ b/routes/entity-list/stage.tsx
@@ -33,6 +33,7 @@ interface EntityConfig {
 	_user_created: boolean;
 	_source: 'core' | 'plugin' | 'user';
 	_orphaned: boolean;
+	_customized: boolean;
 	labels?: Record< string, string >;
 	description?: string;
 	public?: boolean;
@@ -217,19 +218,11 @@ function EntityList() {
 					method: 'DELETE',
 				} )
 					.then( () => {
-						setAllConfigs( ( prev ) =>
-							prev.filter(
-								( c ) =>
-									! (
-										c.slug === item.slug &&
-										c.entity_type === item.entity_type
-									)
-							)
+						sessionStorage.setItem(
+							'gutenberg_entity_saved',
+							__( 'Entity deleted successfully.' )
 						);
-						createSuccessNotice(
-							__( 'Entity deleted successfully.' ),
-							{ type: 'snackbar', id: 'entity-delete-success' }
-						);
+						window.location.reload();
 					} )
 					.catch( () => {
 						createErrorNotice( __( 'Failed to delete entity.' ), {
@@ -239,10 +232,49 @@ function EntityList() {
 					} );
 			},
 		} ),
-		[ createSuccessNotice, createErrorNotice ]
+		[ createErrorNotice ]
 	);
 
-	const actions = useMemo( () => [ deleteAction ], [ deleteAction ] );
+	const revertAction: Action< EntityConfig > = useMemo(
+		() => ( {
+			id: 'revert',
+			label: __( 'Revert to default' ),
+			isPrimary: false,
+			isEligible( item: EntityConfig ) {
+				return (
+					item._source === 'plugin' &&
+					! item._orphaned &&
+					item._customized
+				);
+			},
+			callback( items: EntityConfig[] ) {
+				const item = items[ 0 ];
+				apiFetch( {
+					path: `/gutenberg/v1/entity-configs/${ item.entity_type }/${ item.slug }`,
+					method: 'DELETE',
+				} )
+					.then( () => {
+						sessionStorage.setItem(
+							'gutenberg_entity_saved',
+							__( 'Entity reverted successfully.' )
+						);
+						window.location.reload();
+					} )
+					.catch( () => {
+						createErrorNotice( __( 'Failed to revert entity.' ), {
+							type: 'snackbar',
+							id: 'entity-revert-error',
+						} );
+					} );
+			},
+		} ),
+		[ createErrorNotice ]
+	);
+
+	const actions = useMemo(
+		() => [ deleteAction, revertAction ],
+		[ deleteAction, revertAction ]
+	);
 
 	return (
 		<Page title={ __( 'Entities' ) }>

--- a/routes/entity-list/stage.tsx
+++ b/routes/entity-list/stage.tsx
@@ -132,9 +132,10 @@ function EntityList() {
 		useDispatch( noticesStore );
 	// Show a success notice if we just reloaded after a save.
 	useEffect( () => {
-		if ( sessionStorage.getItem( 'gutenberg_entity_saved' ) ) {
+		const message = sessionStorage.getItem( 'gutenberg_entity_saved' );
+		if ( message ) {
 			sessionStorage.removeItem( 'gutenberg_entity_saved' );
-			createSuccessNotice( __( 'Entity saved successfully.' ), {
+			createSuccessNotice( message, {
 				type: 'snackbar',
 				id: 'entity-save-success',
 			} );

--- a/routes/entity-list/stage.tsx
+++ b/routes/entity-list/stage.tsx
@@ -229,7 +229,7 @@ function EntityList() {
 
 	return (
 		<Page title={ __( 'Entities' ) }>
-			<div style={ { padding: '0 16px' } }>
+			<div style={ { padding: '16px' } }>
 				<Tabs selectedTabId={ activeTab } onSelect={ handleTabChange }>
 					<Tabs.TabList>
 						{ TABS.map( ( tab ) => (

--- a/routes/entity-list/stage.tsx
+++ b/routes/entity-list/stage.tsx
@@ -141,13 +141,21 @@ const fields: Field< EntityConfig >[] = [
 		id: 'modified',
 		label: __( 'Modified' ),
 		render: ( { item }: { item: EntityConfig } ) => {
+			if ( item._user_created ) {
+				return <>{ __( 'N/A' ) }</>;
+			}
 			return <>{ item._customized ? __( 'Yes' ) : __( 'No' ) }</>;
 		},
-		getValue: ( { item }: { item: EntityConfig } ) =>
-			item._customized ? 'yes' : 'no',
+		getValue: ( { item }: { item: EntityConfig } ) => {
+			if ( item._user_created ) {
+				return 'n/a';
+			}
+			return item._customized ? 'yes' : 'no';
+		},
 		elements: [
 			{ value: 'yes', label: __( 'Yes' ) },
 			{ value: 'no', label: __( 'No' ) },
+			{ value: 'n/a', label: __( 'N/A' ) },
 		],
 		filterBy: {
 			operators: [ 'is' as const ],

--- a/routes/entity-list/stage.tsx
+++ b/routes/entity-list/stage.tsx
@@ -31,6 +31,8 @@ interface EntityConfig {
 	slug: string;
 	entity_type: 'post_type' | 'taxonomy';
 	_user_created: boolean;
+	_source: 'core' | 'plugin' | 'user';
+	_orphaned: boolean;
 	labels?: Record< string, string >;
 	description?: string;
 	public?: boolean;
@@ -46,7 +48,7 @@ const DEFAULT_VIEW: View = {
 		field: 'slug',
 		direction: 'asc' as const,
 	},
-	fields: [ 'slug', 'description', 'public', 'user_created' ],
+	fields: [ 'slug', 'description', 'public', 'source' ],
 	titleField: 'name',
 };
 
@@ -102,18 +104,33 @@ const fields: Field< EntityConfig >[] = [
 		},
 	},
 	{
-		id: 'user_created',
-		label: __( 'Custom' ),
+		id: 'source',
+		label: __( 'Source' ),
 		render: ( { item }: { item: EntityConfig } ) => {
-			return (
-				<>{ item._user_created ? __( 'Custom' ) : __( 'Built-in' ) }</>
-			);
+			if ( item._orphaned ) {
+				return <>{ __( 'Orphaned' ) }</>;
+			}
+			switch ( item._source ) {
+				case 'core':
+					return <>{ __( 'Core' ) }</>;
+				case 'user':
+					return <>{ __( 'Custom' ) }</>;
+				case 'plugin':
+				default:
+					return <>{ __( 'Plugin' ) }</>;
+			}
 		},
-		getValue: ( { item }: { item: EntityConfig } ) =>
-			item._user_created ? 'custom' : 'built-in',
+		getValue: ( { item }: { item: EntityConfig } ) => {
+			if ( item._orphaned ) {
+				return 'orphaned';
+			}
+			return item._source ?? 'plugin';
+		},
 		elements: [
-			{ value: 'custom', label: __( 'Custom' ) },
-			{ value: 'built-in', label: __( 'Built-in' ) },
+			{ value: 'core', label: __( 'Core' ) },
+			{ value: 'plugin', label: __( 'Plugin' ) },
+			{ value: 'user', label: __( 'Custom' ) },
+			{ value: 'orphaned', label: __( 'Orphaned' ) },
 		],
 		filterBy: {
 			operators: [ 'is' as const ],
@@ -191,7 +208,7 @@ function EntityList() {
 			label: __( 'Delete' ),
 			isPrimary: false,
 			isEligible( item: EntityConfig ) {
-				return item._user_created;
+				return item._user_created || item._orphaned;
 			},
 			callback( items: EntityConfig[] ) {
 				const item = items[ 0 ];

--- a/routes/entity-list/stage.tsx
+++ b/routes/entity-list/stage.tsx
@@ -129,6 +129,16 @@ function EntityList() {
 	const navigate = useNavigate();
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
+	// Show a success notice if we just reloaded after a save.
+	useEffect( () => {
+		if ( sessionStorage.getItem( 'gutenberg_entity_saved' ) ) {
+			sessionStorage.removeItem( 'gutenberg_entity_saved' );
+			createSuccessNotice( __( 'Entity saved successfully.' ), {
+				type: 'snackbar',
+			} );
+		}
+	}, [ createSuccessNotice ] );
+
 	const [ allConfigs, setAllConfigs ] = useState< EntityConfig[] >( [] );
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ activeTab, setActiveTab ] = useState< string >( 'post_type' );

--- a/routes/entity-list/stage.tsx
+++ b/routes/entity-list/stage.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useNavigate, Link } from '@wordpress/route';
+import { useNavigate, useSearch, Link } from '@wordpress/route';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { Page } from '@wordpress/admin-ui';
 import type {
@@ -127,6 +127,7 @@ function getItemId( item: EntityConfig ) {
 
 function EntityList() {
 	const navigate = useNavigate();
+	const searchParams = useSearch( { from: '/' } );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 	// Show a success notice if we just reloaded after a save.
@@ -142,7 +143,9 @@ function EntityList() {
 
 	const [ allConfigs, setAllConfigs ] = useState< EntityConfig[] >( [] );
 	const [ isLoading, setIsLoading ] = useState( true );
-	const [ activeTab, setActiveTab ] = useState< string >( 'post_type' );
+	const initialTab =
+		searchParams.tab === 'taxonomy' ? 'taxonomy' : 'post_type';
+	const [ activeTab, setActiveTab ] = useState< string >( initialTab );
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 
 	// Fetch entity configs from REST API.
@@ -172,10 +175,14 @@ function EntityList() {
 		return filterSortAndPaginate( filteredConfigs, view, fields );
 	}, [ filteredConfigs, view ] );
 
-	const handleTabChange = useCallback( ( tab: string ) => {
-		setActiveTab( tab );
-		setView( DEFAULT_VIEW );
-	}, [] );
+	const handleTabChange = useCallback(
+		( tab: string ) => {
+			setActiveTab( tab );
+			setView( DEFAULT_VIEW );
+			navigate( { search: { tab } } );
+		},
+		[ navigate ]
+	);
 
 	const deleteAction: Action< EntityConfig > = useMemo(
 		() => ( {

--- a/routes/entity-list/stage.tsx
+++ b/routes/entity-list/stage.tsx
@@ -1,0 +1,268 @@
+/**
+ * WordPress dependencies
+ */
+import { useNavigate, Link } from '@wordpress/route';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { Page } from '@wordpress/admin-ui';
+import type {
+	View,
+	Field,
+	Action,
+	SupportedLayouts,
+} from '@wordpress/dataviews';
+import {
+	Button,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
+import { useMemo, useState, useEffect, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { store as noticesStore } from '@wordpress/notices';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
+const { Tabs } = unlock( componentsPrivateApis );
+
+interface EntityConfig {
+	slug: string;
+	entity_type: 'post_type' | 'taxonomy';
+	_user_created: boolean;
+	labels?: Record< string, string >;
+	description?: string;
+	public?: boolean;
+	hierarchical?: boolean;
+	show_in_rest?: boolean;
+	show_ui?: boolean;
+}
+
+const DEFAULT_VIEW: View = {
+	type: 'table' as const,
+	search: '',
+	sort: {
+		field: 'slug',
+		direction: 'asc' as const,
+	},
+	fields: [ 'slug', 'description', 'public', 'user_created' ],
+	titleField: 'name',
+};
+
+const DEFAULT_LAYOUTS: SupportedLayouts = {
+	table: true,
+};
+
+const TABS = [
+	{ slug: 'post_type', label: __( 'Post Types' ) },
+	{ slug: 'taxonomy', label: __( 'Taxonomies' ) },
+];
+
+const fields: Field< EntityConfig >[] = [
+	{
+		id: 'name',
+		label: __( 'Name' ),
+		enableGlobalSearch: true,
+		enableHiding: false,
+		render: ( { item }: { item: EntityConfig } ) => {
+			return <>{ item.labels?.name || item.slug }</>;
+		},
+		getValue: ( { item }: { item: EntityConfig } ) => {
+			return item.labels?.name || item.slug;
+		},
+	},
+	{
+		id: 'slug',
+		label: __( 'Slug' ),
+		enableGlobalSearch: true,
+		getValue: ( { item }: { item: EntityConfig } ) => item.slug,
+	},
+	{
+		id: 'description',
+		label: __( 'Description' ),
+		getValue: ( { item }: { item: EntityConfig } ) =>
+			item.description || '',
+		enableSorting: false,
+	},
+	{
+		id: 'public',
+		label: __( 'Public' ),
+		render: ( { item }: { item: EntityConfig } ) => {
+			return <>{ item.public ? __( 'Yes' ) : __( 'No' ) }</>;
+		},
+		getValue: ( { item }: { item: EntityConfig } ) =>
+			item.public ? 'yes' : 'no',
+		elements: [
+			{ value: 'yes', label: __( 'Yes' ) },
+			{ value: 'no', label: __( 'No' ) },
+		],
+		filterBy: {
+			operators: [ 'is' as const ],
+		},
+	},
+	{
+		id: 'user_created',
+		label: __( 'Custom' ),
+		render: ( { item }: { item: EntityConfig } ) => {
+			return (
+				<>{ item._user_created ? __( 'Custom' ) : __( 'Built-in' ) }</>
+			);
+		},
+		getValue: ( { item }: { item: EntityConfig } ) =>
+			item._user_created ? 'custom' : 'built-in',
+		elements: [
+			{ value: 'custom', label: __( 'Custom' ) },
+			{ value: 'built-in', label: __( 'Built-in' ) },
+		],
+		filterBy: {
+			operators: [ 'is' as const ],
+		},
+	},
+];
+
+function getItemId( item: EntityConfig ) {
+	return `${ item.entity_type }:${ item.slug }`;
+}
+
+function EntityList() {
+	const navigate = useNavigate();
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+	const [ allConfigs, setAllConfigs ] = useState< EntityConfig[] >( [] );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ activeTab, setActiveTab ] = useState< string >( 'post_type' );
+	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+
+	// Fetch entity configs from REST API.
+	useEffect( () => {
+		setIsLoading( true );
+		apiFetch< EntityConfig[] >( {
+			path: '/gutenberg/v1/entity-configs',
+		} )
+			.then( ( response ) => {
+				setAllConfigs( response );
+				setIsLoading( false );
+			} )
+			.catch( () => {
+				setIsLoading( false );
+			} );
+	}, [] );
+
+	// Filter configs by the active tab.
+	const filteredConfigs = useMemo( () => {
+		return allConfigs.filter(
+			( config ) => config.entity_type === activeTab
+		);
+	}, [ allConfigs, activeTab ] );
+
+	// Apply client-side sorting, filtering, and pagination.
+	const { data, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( filteredConfigs, view, fields );
+	}, [ filteredConfigs, view ] );
+
+	const handleTabChange = useCallback( ( tab: string ) => {
+		setActiveTab( tab );
+		setView( DEFAULT_VIEW );
+	}, [] );
+
+	const deleteAction: Action< EntityConfig > = useMemo(
+		() => ( {
+			id: 'delete',
+			label: __( 'Delete' ),
+			isPrimary: false,
+			isEligible( item: EntityConfig ) {
+				return item._user_created;
+			},
+			callback( items: EntityConfig[] ) {
+				const item = items[ 0 ];
+				apiFetch( {
+					path: `/gutenberg/v1/entity-configs/${ item.entity_type }/${ item.slug }`,
+					method: 'DELETE',
+				} )
+					.then( () => {
+						setAllConfigs( ( prev ) =>
+							prev.filter(
+								( c ) =>
+									! (
+										c.slug === item.slug &&
+										c.entity_type === item.entity_type
+									)
+							)
+						);
+						createSuccessNotice(
+							__( 'Entity deleted successfully.' ),
+							{ type: 'snackbar' }
+						);
+					} )
+					.catch( () => {
+						createErrorNotice( __( 'Failed to delete entity.' ), {
+							type: 'snackbar',
+						} );
+					} );
+			},
+		} ),
+		[ createSuccessNotice, createErrorNotice ]
+	);
+
+	const actions = useMemo( () => [ deleteAction ], [ deleteAction ] );
+
+	return (
+		<Page title={ __( 'Entities' ) }>
+			<div style={ { padding: '0 16px' } }>
+				<Tabs selectedTabId={ activeTab } onSelect={ handleTabChange }>
+					<Tabs.TabList>
+						{ TABS.map( ( tab ) => (
+							<Tabs.Tab key={ tab.slug } tabId={ tab.slug }>
+								{ tab.label }
+							</Tabs.Tab>
+						) ) }
+					</Tabs.TabList>
+				</Tabs>
+			</div>
+			<DataViews
+				data={ data }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				actions={ actions }
+				isLoading={ isLoading }
+				paginationInfo={ paginationInfo }
+				defaultLayouts={ DEFAULT_LAYOUTS }
+				getItemId={ getItemId }
+				isItemClickable={ () => true }
+				renderItemLink={ ( {
+					item,
+					...props
+				}: {
+					item: EntityConfig;
+				} ) => (
+					<Link
+						to={ `/edit/${ item.entity_type }/${ item.slug }` }
+						{ ...props }
+						onClick={ ( event: React.MouseEvent ) => {
+							event.stopPropagation();
+						} }
+					/>
+				) }
+				header={
+					<Button
+						variant="primary"
+						onClick={ () => {
+							navigate( {
+								to: `/new/${ activeTab }`,
+							} );
+						} }
+						size="compact"
+					>
+						{ activeTab === 'post_type'
+							? __( 'Add Post Type' )
+							: __( 'Add Taxonomy' ) }
+					</Button>
+				}
+			/>
+		</Page>
+	);
+}
+
+export const stage = EntityList;

--- a/routes/entity-list/stage.tsx
+++ b/routes/entity-list/stage.tsx
@@ -135,6 +135,7 @@ function EntityList() {
 			sessionStorage.removeItem( 'gutenberg_entity_saved' );
 			createSuccessNotice( __( 'Entity saved successfully.' ), {
 				type: 'snackbar',
+				id: 'entity-save-success',
 			} );
 		}
 	}, [ createSuccessNotice ] );

--- a/routes/entity-list/stage.tsx
+++ b/routes/entity-list/stage.tsx
@@ -210,12 +210,13 @@ function EntityList() {
 						);
 						createSuccessNotice(
 							__( 'Entity deleted successfully.' ),
-							{ type: 'snackbar' }
+							{ type: 'snackbar', id: 'entity-delete-success' }
 						);
 					} )
 					.catch( () => {
 						createErrorNotice( __( 'Failed to delete entity.' ), {
 							type: 'snackbar',
+							id: 'entity-delete-error',
 						} );
 					} );
 			},

--- a/routes/entity-list/stage.tsx
+++ b/routes/entity-list/stage.tsx
@@ -242,7 +242,7 @@ function EntityList() {
 			isPrimary: false,
 			isEligible( item: EntityConfig ) {
 				return (
-					item._source === 'plugin' &&
+					( item._source === 'plugin' || item._source === 'core' ) &&
 					! item._orphaned &&
 					item._customized
 				);

--- a/routes/entity-list/stage.tsx
+++ b/routes/entity-list/stage.tsx
@@ -49,7 +49,7 @@ const DEFAULT_VIEW: View = {
 		field: 'slug',
 		direction: 'asc' as const,
 	},
-	fields: [ 'slug', 'description', 'public', 'source' ],
+	fields: [ 'slug', 'description', 'public', 'source', 'modified' ],
 	titleField: 'name',
 };
 
@@ -132,6 +132,22 @@ const fields: Field< EntityConfig >[] = [
 			{ value: 'plugin', label: __( 'Plugin' ) },
 			{ value: 'user', label: __( 'Custom' ) },
 			{ value: 'orphaned', label: __( 'Orphaned' ) },
+		],
+		filterBy: {
+			operators: [ 'is' as const ],
+		},
+	},
+	{
+		id: 'modified',
+		label: __( 'Modified' ),
+		render: ( { item }: { item: EntityConfig } ) => {
+			return <>{ item._customized ? __( 'Yes' ) : __( 'No' ) }</>;
+		},
+		getValue: ( { item }: { item: EntityConfig } ) =>
+			item._customized ? 'yes' : 'no',
+		elements: [
+			{ value: 'yes', label: __( 'Yes' ) },
+			{ value: 'no', label: __( 'No' ) },
 		],
 		filterBy: {
 			operators: [ 'is' as const ],

--- a/routes/entity-new/package.json
+++ b/routes/entity-new/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "@wordpress/entity-new-route",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/new/$entityType",
+		"page": "entities"
+	},
+	"dependencies": {
+		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/api-fetch": "file:../../packages/api-fetch",
+		"@wordpress/components": "file:../../packages/components",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/notices": "file:../../packages/notices",
+		"@wordpress/private-apis": "file:../../packages/private-apis",
+		"@wordpress/route": "file:../../packages/route"
+	}
+}

--- a/routes/entity-new/route.ts
+++ b/routes/entity-new/route.ts
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const route = {
+	title: () => __( 'New Entity' ),
+};

--- a/routes/entity-new/stage.tsx
+++ b/routes/entity-new/stage.tsx
@@ -1,0 +1,458 @@
+/**
+ * WordPress dependencies
+ */
+import { useParams, useNavigate } from '@wordpress/route';
+import { Page } from '@wordpress/admin-ui';
+import {
+	Button,
+	TextControl,
+	TextareaControl,
+	ToggleControl,
+	CheckboxControl,
+	Panel,
+	PanelBody,
+	PanelRow,
+	// @ts-ignore
+	__experimentalVStack as VStack,
+	// @ts-ignore
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { useState, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { store as noticesStore } from '@wordpress/notices';
+import { useDispatch } from '@wordpress/data';
+
+const POST_TYPE_SUPPORTS = [
+	'title',
+	'editor',
+	'author',
+	'thumbnail',
+	'excerpt',
+	'trackbacks',
+	'custom-fields',
+	'comments',
+	'revisions',
+	'page-attributes',
+	'post-formats',
+];
+
+const DEFAULT_POST_TYPE_SUPPORTS: Record< string, boolean > = {
+	title: true,
+	editor: true,
+};
+
+interface NewEntityConfig {
+	slug: string;
+	labels: Record< string, string >;
+	description: string;
+	public: boolean;
+	hierarchical: boolean;
+	supports: Record< string, boolean >;
+	has_archive: boolean;
+	show_in_rest: boolean;
+	rest_base: string;
+	menu_icon: string;
+	menu_position: number | null;
+	show_ui: boolean;
+	show_in_menu: boolean;
+	object_type: string[];
+}
+
+function getDefaultConfig(): NewEntityConfig {
+	return {
+		slug: '',
+		labels: {
+			name: '',
+			singular_name: '',
+		},
+		description: '',
+		public: true,
+		hierarchical: false,
+		supports: { ...DEFAULT_POST_TYPE_SUPPORTS },
+		has_archive: false,
+		show_in_rest: true,
+		rest_base: '',
+		menu_icon: 'dashicons-admin-post',
+		menu_position: null,
+		show_ui: true,
+		show_in_menu: true,
+		object_type: [ 'post' ],
+	};
+}
+
+function EntityNew() {
+	const { entityType } = useParams( {
+		from: '/new/$entityType',
+	} );
+	const navigate = useNavigate();
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ config, setConfig ] =
+		useState< NewEntityConfig >( getDefaultConfig );
+
+	const isPostType = entityType === 'post_type';
+
+	const updateField = useCallback(
+		< K extends keyof NewEntityConfig >(
+			field: K,
+			value: NewEntityConfig[ K ]
+		) => {
+			setConfig( ( prev ) => ( { ...prev, [ field ]: value } ) );
+		},
+		[]
+	);
+
+	const updateLabel = useCallback( ( key: string, value: string ) => {
+		setConfig( ( prev ) => ( {
+			...prev,
+			labels: { ...prev.labels, [ key ]: value },
+		} ) );
+	}, [] );
+
+	const updateSupport = useCallback(
+		( feature: string, enabled: boolean ) => {
+			setConfig( ( prev ) => ( {
+				...prev,
+				supports: { ...prev.supports, [ feature ]: enabled },
+			} ) );
+		},
+		[]
+	);
+
+	const handleSave = useCallback( async () => {
+		if ( ! config.slug ) {
+			createErrorNotice( __( 'Slug is required.' ), {
+				type: 'snackbar',
+			} );
+			return;
+		}
+
+		if ( ! config.labels.name ) {
+			createErrorNotice( __( 'Name is required.' ), {
+				type: 'snackbar',
+			} );
+			return;
+		}
+
+		setIsSaving( true );
+
+		try {
+			await apiFetch( {
+				path: '/gutenberg/v1/entity-configs',
+				method: 'POST',
+				data: {
+					entity_type: entityType,
+					slug: config.slug,
+					labels: config.labels,
+					description: config.description,
+					public: config.public,
+					hierarchical: config.hierarchical,
+					show_in_rest: config.show_in_rest,
+					rest_base: config.rest_base || config.slug,
+					show_ui: config.show_ui,
+					show_in_menu: config.show_in_menu,
+					...( isPostType
+						? {
+								supports: config.supports,
+								has_archive: config.has_archive,
+								menu_icon: config.menu_icon || null,
+								menu_position: config.menu_position,
+						  }
+						: {
+								object_type: config.object_type,
+						  } ),
+				},
+			} );
+			createSuccessNotice( __( 'Entity created successfully.' ), {
+				type: 'snackbar',
+			} );
+			navigate( { to: '/' } );
+		} catch ( error: any ) {
+			createErrorNotice(
+				error?.message || __( 'Failed to create entity.' ),
+				{ type: 'snackbar' }
+			);
+		}
+
+		setIsSaving( false );
+	}, [
+		config,
+		entityType,
+		isPostType,
+		navigate,
+		createSuccessNotice,
+		createErrorNotice,
+	] );
+
+	const pageTitle = isPostType ? __( 'New Post Type' ) : __( 'New Taxonomy' );
+
+	return (
+		<Page
+			title={ pageTitle }
+			actions={
+				<HStack spacing={ 3 }>
+					<Button
+						variant="tertiary"
+						onClick={ () => navigate( { to: '/' } ) }
+						size="compact"
+					>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						variant="primary"
+						onClick={ handleSave }
+						isBusy={ isSaving }
+						disabled={ isSaving }
+						size="compact"
+					>
+						{ __( 'Create' ) }
+					</Button>
+				</HStack>
+			}
+		>
+			<div style={ { maxWidth: 800, padding: '0 16px' } }>
+				<VStack spacing={ 4 }>
+					<Panel>
+						<PanelBody title={ __( 'General' ) } initialOpen>
+							<PanelRow>
+								<TextControl
+									__nextHasNoMarginBottom
+									label={ __( 'Slug' ) }
+									help={ __(
+										'A unique identifier. Lowercase letters, numbers, and hyphens only.'
+									) }
+									value={ config.slug }
+									onChange={ ( value: string ) =>
+										updateField(
+											'slug',
+											value
+												.toLowerCase()
+												.replace( /[^a-z0-9_-]/g, '' )
+										)
+									}
+								/>
+							</PanelRow>
+							<PanelRow>
+								<TextControl
+									__nextHasNoMarginBottom
+									label={ __( 'Name (Plural)' ) }
+									value={ config.labels.name || '' }
+									onChange={ ( value: string ) =>
+										updateLabel( 'name', value )
+									}
+								/>
+							</PanelRow>
+							<PanelRow>
+								<TextControl
+									__nextHasNoMarginBottom
+									label={ __( 'Singular Name' ) }
+									value={ config.labels.singular_name || '' }
+									onChange={ ( value: string ) =>
+										updateLabel( 'singular_name', value )
+									}
+								/>
+							</PanelRow>
+							<PanelRow>
+								<TextareaControl
+									__nextHasNoMarginBottom
+									label={ __( 'Description' ) }
+									value={ config.description }
+									onChange={ ( value: string ) =>
+										updateField( 'description', value )
+									}
+								/>
+							</PanelRow>
+						</PanelBody>
+					</Panel>
+
+					<Panel>
+						<PanelBody title={ __( 'Visibility' ) } initialOpen>
+							<PanelRow>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Public' ) }
+									checked={ config.public }
+									onChange={ ( value: boolean ) =>
+										updateField( 'public', value )
+									}
+								/>
+							</PanelRow>
+							<PanelRow>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Hierarchical' ) }
+									checked={ config.hierarchical }
+									onChange={ ( value: boolean ) =>
+										updateField( 'hierarchical', value )
+									}
+								/>
+							</PanelRow>
+							<PanelRow>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Show UI' ) }
+									checked={ config.show_ui }
+									onChange={ ( value: boolean ) =>
+										updateField( 'show_ui', value )
+									}
+								/>
+							</PanelRow>
+							<PanelRow>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Show in Menu' ) }
+									checked={ config.show_in_menu }
+									onChange={ ( value: boolean ) =>
+										updateField( 'show_in_menu', value )
+									}
+								/>
+							</PanelRow>
+							{ isPostType && (
+								<PanelRow>
+									<ToggleControl
+										__nextHasNoMarginBottom
+										label={ __( 'Has Archive' ) }
+										checked={ !! config.has_archive }
+										onChange={ ( value: boolean ) =>
+											updateField( 'has_archive', value )
+										}
+									/>
+								</PanelRow>
+							) }
+						</PanelBody>
+					</Panel>
+
+					<Panel>
+						<PanelBody
+							title={ __( 'REST API' ) }
+							initialOpen={ false }
+						>
+							<PanelRow>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Show in REST' ) }
+									checked={ config.show_in_rest }
+									onChange={ ( value: boolean ) =>
+										updateField( 'show_in_rest', value )
+									}
+								/>
+							</PanelRow>
+							<PanelRow>
+								<TextControl
+									__nextHasNoMarginBottom
+									label={ __( 'REST Base' ) }
+									value={ config.rest_base }
+									onChange={ ( value: string ) =>
+										updateField( 'rest_base', value )
+									}
+								/>
+							</PanelRow>
+						</PanelBody>
+					</Panel>
+
+					{ isPostType && (
+						<Panel>
+							<PanelBody
+								title={ __( 'Menu' ) }
+								initialOpen={ false }
+							>
+								<PanelRow>
+									<TextControl
+										__nextHasNoMarginBottom
+										label={ __( 'Menu Icon' ) }
+										help={ __(
+											'A dashicon class name or URL to an icon image.'
+										) }
+										value={ config.menu_icon || '' }
+										onChange={ ( value: string ) =>
+											updateField( 'menu_icon', value )
+										}
+									/>
+								</PanelRow>
+								<PanelRow>
+									<TextControl
+										__nextHasNoMarginBottom
+										label={ __( 'Menu Position' ) }
+										type="number"
+										value={
+											config.menu_position !== null
+												? String( config.menu_position )
+												: ''
+										}
+										onChange={ ( value: string ) =>
+											updateField(
+												'menu_position',
+												value ? Number( value ) : null
+											)
+										}
+									/>
+								</PanelRow>
+							</PanelBody>
+						</Panel>
+					) }
+
+					{ isPostType && (
+						<Panel>
+							<PanelBody
+								title={ __( 'Supports' ) }
+								initialOpen={ false }
+							>
+								{ POST_TYPE_SUPPORTS.map( ( feature ) => (
+									<PanelRow key={ feature }>
+										<CheckboxControl
+											__nextHasNoMarginBottom
+											label={ feature }
+											checked={
+												!! config.supports[ feature ]
+											}
+											onChange={ ( value: boolean ) =>
+												updateSupport( feature, value )
+											}
+										/>
+									</PanelRow>
+								) ) }
+							</PanelBody>
+						</Panel>
+					) }
+
+					{ ! isPostType && (
+						<Panel>
+							<PanelBody
+								title={ __( 'Associated Post Types' ) }
+								initialOpen={ false }
+							>
+								<PanelRow>
+									<TextControl
+										__nextHasNoMarginBottom
+										label={ __( 'Object Types' ) }
+										help={ __(
+											'Comma-separated list of post type slugs.'
+										) }
+										value={
+											config.object_type?.join( ', ' ) ||
+											''
+										}
+										onChange={ ( value: string ) =>
+											updateField(
+												'object_type',
+												value
+													.split( ',' )
+													.map( ( s ) => s.trim() )
+													.filter( Boolean )
+											)
+										}
+									/>
+								</PanelRow>
+							</PanelBody>
+						</Panel>
+					) }
+				</VStack>
+			</div>
+		</Page>
+	);
+}
+
+export const stage = EntityNew;

--- a/routes/entity-new/stage.tsx
+++ b/routes/entity-new/stage.tsx
@@ -264,6 +264,7 @@ function EntityNew() {
 						<PanelBody title={ __( 'General' ) } initialOpen>
 							<VStack spacing={ 4 }>
 								<TextControl
+									__next40pxDefaultSize
 									__nextHasNoMarginBottom
 									label={ __( 'Slug' ) }
 									help={ __(
@@ -280,6 +281,7 @@ function EntityNew() {
 									}
 								/>
 								<TextControl
+									__next40pxDefaultSize
 									__nextHasNoMarginBottom
 									label={ __( 'Name (Plural)' ) }
 									value={ config.labels.name || '' }
@@ -288,6 +290,7 @@ function EntityNew() {
 									}
 								/>
 								<TextControl
+									__next40pxDefaultSize
 									__nextHasNoMarginBottom
 									label={ __( 'Singular Name' ) }
 									value={ config.labels.singular_name || '' }
@@ -296,6 +299,7 @@ function EntityNew() {
 									}
 								/>
 								<TextareaControl
+									__next40pxDefaultSize
 									__nextHasNoMarginBottom
 									label={ __( 'Description' ) }
 									value={ config.description }
@@ -381,6 +385,7 @@ function EntityNew() {
 									/>
 								</PanelRow>
 								<TextControl
+									__next40pxDefaultSize
 									__nextHasNoMarginBottom
 									label={ __( 'REST Base' ) }
 									value={ config.rest_base }
@@ -431,6 +436,7 @@ function EntityNew() {
 							>
 								<VStack spacing={ 4 }>
 									<TextControl
+										__next40pxDefaultSize
 										__nextHasNoMarginBottom
 										label={ __( 'Menu Icon' ) }
 										help={ __(
@@ -442,6 +448,7 @@ function EntityNew() {
 										}
 									/>
 									<TextControl
+										__next40pxDefaultSize
 										__nextHasNoMarginBottom
 										label={ __( 'Menu Position' ) }
 										type="number"

--- a/routes/entity-new/stage.tsx
+++ b/routes/entity-new/stage.tsx
@@ -200,6 +200,11 @@ function EntityNew() {
 						  } ),
 				},
 			} );
+			if ( config.show_in_menu || config.show_ui ) {
+				window.location.reload();
+				return;
+			}
+
 			createSuccessNotice( __( 'Entity created successfully.' ), {
 				type: 'snackbar',
 			} );

--- a/routes/entity-new/stage.tsx
+++ b/routes/entity-new/stage.tsx
@@ -262,7 +262,7 @@ function EntityNew() {
 				<VStack spacing={ 4 }>
 					<Panel>
 						<PanelBody title={ __( 'General' ) } initialOpen>
-							<PanelRow>
+							<VStack spacing={ 4 }>
 								<TextControl
 									__nextHasNoMarginBottom
 									label={ __( 'Slug' ) }
@@ -279,8 +279,6 @@ function EntityNew() {
 										)
 									}
 								/>
-							</PanelRow>
-							<PanelRow>
 								<TextControl
 									__nextHasNoMarginBottom
 									label={ __( 'Name (Plural)' ) }
@@ -289,8 +287,6 @@ function EntityNew() {
 										updateLabel( 'name', value )
 									}
 								/>
-							</PanelRow>
-							<PanelRow>
 								<TextControl
 									__nextHasNoMarginBottom
 									label={ __( 'Singular Name' ) }
@@ -299,8 +295,6 @@ function EntityNew() {
 										updateLabel( 'singular_name', value )
 									}
 								/>
-							</PanelRow>
-							<PanelRow>
 								<TextareaControl
 									__nextHasNoMarginBottom
 									label={ __( 'Description' ) }
@@ -309,7 +303,7 @@ function EntityNew() {
 										updateField( 'description', value )
 									}
 								/>
-							</PanelRow>
+							</VStack>
 						</PanelBody>
 					</Panel>
 
@@ -375,17 +369,17 @@ function EntityNew() {
 							title={ __( 'REST API' ) }
 							initialOpen={ false }
 						>
-							<PanelRow>
-								<ToggleControl
-									__nextHasNoMarginBottom
-									label={ __( 'Show in REST' ) }
-									checked={ config.show_in_rest }
-									onChange={ ( value: boolean ) =>
-										updateField( 'show_in_rest', value )
-									}
-								/>
-							</PanelRow>
-							<PanelRow>
+							<VStack spacing={ 4 }>
+								<PanelRow>
+									<ToggleControl
+										__nextHasNoMarginBottom
+										label={ __( 'Show in REST' ) }
+										checked={ config.show_in_rest }
+										onChange={ ( value: boolean ) =>
+											updateField( 'show_in_rest', value )
+										}
+									/>
+								</PanelRow>
 								<TextControl
 									__nextHasNoMarginBottom
 									label={ __( 'REST Base' ) }
@@ -394,7 +388,7 @@ function EntityNew() {
 										updateField( 'rest_base', value )
 									}
 								/>
-							</PanelRow>
+							</VStack>
 						</PanelBody>
 					</Panel>
 
@@ -435,7 +429,7 @@ function EntityNew() {
 								title={ __( 'Menu' ) }
 								initialOpen={ false }
 							>
-								<PanelRow>
+								<VStack spacing={ 4 }>
 									<TextControl
 										__nextHasNoMarginBottom
 										label={ __( 'Menu Icon' ) }
@@ -447,8 +441,6 @@ function EntityNew() {
 											updateField( 'menu_icon', value )
 										}
 									/>
-								</PanelRow>
-								<PanelRow>
 									<TextControl
 										__nextHasNoMarginBottom
 										label={ __( 'Menu Position' ) }
@@ -465,7 +457,7 @@ function EntityNew() {
 											)
 										}
 									/>
-								</PanelRow>
+								</VStack>
 							</PanelBody>
 						</Panel>
 					) }

--- a/routes/entity-new/stage.tsx
+++ b/routes/entity-new/stage.tsx
@@ -201,6 +201,7 @@ function EntityNew() {
 				},
 			} );
 			if ( config.show_in_menu || config.show_ui ) {
+				sessionStorage.setItem( 'gutenberg_entity_saved', '1' );
 				window.location.reload();
 				return;
 			}

--- a/routes/entity-new/stage.tsx
+++ b/routes/entity-new/stage.tsx
@@ -208,6 +208,7 @@ function EntityNew() {
 
 			createSuccessNotice( __( 'Entity created successfully.' ), {
 				type: 'snackbar',
+				id: 'entity-save-success',
 			} );
 			navigate( { to: '/' } );
 		} catch ( error: any ) {

--- a/routes/entity-new/stage.tsx
+++ b/routes/entity-new/stage.tsx
@@ -93,8 +93,7 @@ function EntityNew() {
 		from: '/new/$entityType',
 	} );
 	const navigate = useNavigate();
-	const { createSuccessNotice, createErrorNotice } =
-		useDispatch( noticesStore );
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ config, setConfig ] =
@@ -202,17 +201,25 @@ function EntityNew() {
 						  } ),
 				},
 			} );
+			sessionStorage.setItem(
+				'gutenberg_entity_saved',
+				__( 'Entity created successfully.' )
+			);
+
 			if ( config.show_in_menu || config.show_ui ) {
-				sessionStorage.setItem( 'gutenberg_entity_saved', '1' );
-				window.location.reload();
+				// Navigate to the edit screen via full reload so the admin menu updates.
+				const url = new URL( window.location.href );
+				url.searchParams.set(
+					'p',
+					`/edit/${ entityType }/${ config.slug }`
+				);
+				window.location.href = url.toString();
 				return;
 			}
 
-			createSuccessNotice( __( 'Entity created successfully.' ), {
-				type: 'snackbar',
-				id: 'entity-save-success',
+			navigate( {
+				to: `/edit/${ entityType }/${ config.slug }`,
 			} );
-			navigate( { to: '/', search: { tab: entityType } } );
 		} catch ( error: any ) {
 			createErrorNotice(
 				error?.message || __( 'Failed to create entity.' ),
@@ -221,14 +228,7 @@ function EntityNew() {
 		}
 
 		setIsSaving( false );
-	}, [
-		config,
-		entityType,
-		isPostType,
-		navigate,
-		createSuccessNotice,
-		createErrorNotice,
-	] );
+	}, [ config, entityType, isPostType, navigate, createErrorNotice ] );
 
 	const pageTitle = isPostType ? __( 'New Post Type' ) : __( 'New Taxonomy' );
 

--- a/routes/entity-new/stage.tsx
+++ b/routes/entity-new/stage.tsx
@@ -17,11 +17,18 @@ import {
 	// @ts-ignore
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { useState, useCallback } from '@wordpress/element';
+import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { store as noticesStore } from '@wordpress/notices';
 import { useDispatch } from '@wordpress/data';
+
+interface EntityConfig {
+	slug: string;
+	entity_type: 'post_type' | 'taxonomy';
+	_user_created: boolean;
+	labels?: Record< string, string >;
+}
 
 const POST_TYPE_SUPPORTS = [
 	'title',
@@ -92,8 +99,23 @@ function EntityNew() {
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ config, setConfig ] =
 		useState< NewEntityConfig >( getDefaultConfig );
+	const [ allConfigs, setAllConfigs ] = useState< EntityConfig[] >( [] );
 
 	const isPostType = entityType === 'post_type';
+
+	// Fetch all configs for taxonomy/post type assignment lists.
+	useEffect( () => {
+		apiFetch< EntityConfig[] >( {
+			path: '/gutenberg/v1/entity-configs',
+		} ).then( ( response ) => {
+			setAllConfigs( response );
+		} );
+	}, [] );
+
+	const availablePostTypes = useMemo(
+		() => allConfigs.filter( ( c ) => c.entity_type === 'post_type' ),
+		[ allConfigs ]
+	);
 
 	const updateField = useCallback(
 		< K extends keyof NewEntityConfig >(
@@ -118,6 +140,18 @@ function EntityNew() {
 				...prev,
 				supports: { ...prev.supports, [ feature ]: enabled },
 			} ) );
+		},
+		[]
+	);
+
+	const toggleObjectType = useCallback(
+		( postTypeSlug: string, assigned: boolean ) => {
+			setConfig( ( prev ) => {
+				const updated = assigned
+					? [ ...prev.object_type, postTypeSlug ]
+					: prev.object_type.filter( ( t ) => t !== postTypeSlug );
+				return { ...prev, object_type: updated };
+			} );
 		},
 		[]
 	);
@@ -353,6 +387,37 @@ function EntityNew() {
 						</PanelBody>
 					</Panel>
 
+					{ ! isPostType && (
+						<Panel>
+							<PanelBody title={ __( 'Post Types' ) } initialOpen>
+								{ availablePostTypes.map( ( pt ) => (
+									<PanelRow key={ pt.slug }>
+										<CheckboxControl
+											__nextHasNoMarginBottom
+											label={ pt.labels?.name || pt.slug }
+											checked={ config.object_type.includes(
+												pt.slug
+											) }
+											onChange={ ( value: boolean ) =>
+												toggleObjectType(
+													pt.slug,
+													value
+												)
+											}
+										/>
+									</PanelRow>
+								) ) }
+								{ availablePostTypes.length === 0 && (
+									<PanelRow>
+										<p>
+											{ __( 'No post types available.' ) }
+										</p>
+									</PanelRow>
+								) }
+							</PanelBody>
+						</Panel>
+					) }
+
 					{ isPostType && (
 						<Panel>
 							<PanelBody
@@ -414,38 +479,6 @@ function EntityNew() {
 										/>
 									</PanelRow>
 								) ) }
-							</PanelBody>
-						</Panel>
-					) }
-
-					{ ! isPostType && (
-						<Panel>
-							<PanelBody
-								title={ __( 'Associated Post Types' ) }
-								initialOpen={ false }
-							>
-								<PanelRow>
-									<TextControl
-										__nextHasNoMarginBottom
-										label={ __( 'Object Types' ) }
-										help={ __(
-											'Comma-separated list of post type slugs.'
-										) }
-										value={
-											config.object_type?.join( ', ' ) ||
-											''
-										}
-										onChange={ ( value: string ) =>
-											updateField(
-												'object_type',
-												value
-													.split( ',' )
-													.map( ( s ) => s.trim() )
-													.filter( Boolean )
-											)
-										}
-									/>
-								</PanelRow>
 							</PanelBody>
 						</Panel>
 					) }

--- a/routes/entity-new/stage.tsx
+++ b/routes/entity-new/stage.tsx
@@ -210,7 +210,7 @@ function EntityNew() {
 				type: 'snackbar',
 				id: 'entity-save-success',
 			} );
-			navigate( { to: '/' } );
+			navigate( { to: '/', search: { tab: entityType } } );
 		} catch ( error: any ) {
 			createErrorNotice(
 				error?.message || __( 'Failed to create entity.' ),
@@ -237,7 +237,9 @@ function EntityNew() {
 				<HStack spacing={ 3 }>
 					<Button
 						variant="tertiary"
-						onClick={ () => navigate( { to: '/' } ) }
+						onClick={ () =>
+							navigate( { to: '/', search: { tab: entityType } } )
+						}
 						size="compact"
 					>
 						{ __( 'Cancel' ) }

--- a/routes/entity-new/stage.tsx
+++ b/routes/entity-new/stage.tsx
@@ -9,9 +9,7 @@ import {
 	TextareaControl,
 	ToggleControl,
 	CheckboxControl,
-	Panel,
-	PanelBody,
-	PanelRow,
+	privateApis as componentsPrivateApis,
 	// @ts-ignore
 	__experimentalVStack as VStack,
 	// @ts-ignore
@@ -22,6 +20,13 @@ import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { store as noticesStore } from '@wordpress/notices';
 import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
+const { Tabs } = unlock( componentsPrivateApis );
 
 interface EntityConfig {
 	slug: string;
@@ -259,240 +264,227 @@ function EntityNew() {
 			}
 		>
 			<div style={ { padding: 16 } }>
-				<VStack spacing={ 4 }>
-					<Panel>
-						<PanelBody title={ __( 'General' ) } initialOpen>
+				<Tabs>
+					<Tabs.TabList>
+						<Tabs.Tab tabId="general">{ __( 'General' ) }</Tabs.Tab>
+						<Tabs.Tab tabId="visibility">
+							{ __( 'Visibility' ) }
+						</Tabs.Tab>
+						<Tabs.Tab tabId="rest-api">
+							{ __( 'REST API' ) }
+						</Tabs.Tab>
+						{ ! isPostType && (
+							<Tabs.Tab tabId="post-types">
+								{ __( 'Post Types' ) }
+							</Tabs.Tab>
+						) }
+						{ isPostType && (
+							<Tabs.Tab tabId="menu">{ __( 'Menu' ) }</Tabs.Tab>
+						) }
+						{ isPostType && (
+							<Tabs.Tab tabId="supports">
+								{ __( 'Supports' ) }
+							</Tabs.Tab>
+						) }
+					</Tabs.TabList>
+
+					<Tabs.TabPanel tabId="general" focusable={ false }>
+						<VStack spacing={ 4 }>
+							<TextControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								label={ __( 'Slug' ) }
+								help={ __(
+									'A unique identifier. Lowercase letters, numbers, and hyphens only.'
+								) }
+								value={ config.slug }
+								onChange={ ( value: string ) =>
+									updateField(
+										'slug',
+										value
+											.toLowerCase()
+											.replace( /[^a-z0-9_-]/g, '' )
+									)
+								}
+							/>
+							<TextControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								label={ __( 'Name (Plural)' ) }
+								value={ config.labels.name || '' }
+								onChange={ ( value: string ) =>
+									updateLabel( 'name', value )
+								}
+							/>
+							<TextControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								label={ __( 'Singular Name' ) }
+								value={ config.labels.singular_name || '' }
+								onChange={ ( value: string ) =>
+									updateLabel( 'singular_name', value )
+								}
+							/>
+							<TextareaControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								label={ __( 'Description' ) }
+								value={ config.description }
+								onChange={ ( value: string ) =>
+									updateField( 'description', value )
+								}
+							/>
+						</VStack>
+					</Tabs.TabPanel>
+
+					<Tabs.TabPanel tabId="visibility" focusable={ false }>
+						<VStack spacing={ 3 }>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Public' ) }
+								checked={ config.public }
+								onChange={ ( value: boolean ) =>
+									updateField( 'public', value )
+								}
+							/>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Hierarchical' ) }
+								checked={ config.hierarchical }
+								onChange={ ( value: boolean ) =>
+									updateField( 'hierarchical', value )
+								}
+							/>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Show UI' ) }
+								checked={ config.show_ui }
+								onChange={ ( value: boolean ) =>
+									updateField( 'show_ui', value )
+								}
+							/>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Show in Menu' ) }
+								checked={ config.show_in_menu }
+								onChange={ ( value: boolean ) =>
+									updateField( 'show_in_menu', value )
+								}
+							/>
+							{ isPostType && (
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Has Archive' ) }
+									checked={ !! config.has_archive }
+									onChange={ ( value: boolean ) =>
+										updateField( 'has_archive', value )
+									}
+								/>
+							) }
+						</VStack>
+					</Tabs.TabPanel>
+
+					<Tabs.TabPanel tabId="rest-api" focusable={ false }>
+						<VStack spacing={ 4 }>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Show in REST' ) }
+								checked={ config.show_in_rest }
+								onChange={ ( value: boolean ) =>
+									updateField( 'show_in_rest', value )
+								}
+							/>
+							<TextControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								label={ __( 'REST Base' ) }
+								value={ config.rest_base }
+								onChange={ ( value: string ) =>
+									updateField( 'rest_base', value )
+								}
+							/>
+						</VStack>
+					</Tabs.TabPanel>
+
+					{ ! isPostType && (
+						<Tabs.TabPanel tabId="post-types" focusable={ false }>
+							<VStack spacing={ 3 }>
+								{ availablePostTypes.map( ( pt ) => (
+									<CheckboxControl
+										key={ pt.slug }
+										__nextHasNoMarginBottom
+										label={ pt.labels?.name || pt.slug }
+										checked={ config.object_type.includes(
+											pt.slug
+										) }
+										onChange={ ( value: boolean ) =>
+											toggleObjectType( pt.slug, value )
+										}
+									/>
+								) ) }
+								{ availablePostTypes.length === 0 && (
+									<p>{ __( 'No post types available.' ) }</p>
+								) }
+							</VStack>
+						</Tabs.TabPanel>
+					) }
+
+					{ isPostType && (
+						<Tabs.TabPanel tabId="menu" focusable={ false }>
 							<VStack spacing={ 4 }>
 								<TextControl
 									__next40pxDefaultSize
 									__nextHasNoMarginBottom
-									label={ __( 'Slug' ) }
+									label={ __( 'Menu Icon' ) }
 									help={ __(
-										'A unique identifier. Lowercase letters, numbers, and hyphens only.'
+										'A dashicon class name or URL to an icon image.'
 									) }
-									value={ config.slug }
+									value={ config.menu_icon || '' }
+									onChange={ ( value: string ) =>
+										updateField( 'menu_icon', value )
+									}
+								/>
+								<TextControl
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+									label={ __( 'Menu Position' ) }
+									type="number"
+									value={
+										config.menu_position !== null
+											? String( config.menu_position )
+											: ''
+									}
 									onChange={ ( value: string ) =>
 										updateField(
-											'slug',
-											value
-												.toLowerCase()
-												.replace( /[^a-z0-9_-]/g, '' )
+											'menu_position',
+											value ? Number( value ) : null
 										)
 									}
 								/>
-								<TextControl
-									__next40pxDefaultSize
-									__nextHasNoMarginBottom
-									label={ __( 'Name (Plural)' ) }
-									value={ config.labels.name || '' }
-									onChange={ ( value: string ) =>
-										updateLabel( 'name', value )
-									}
-								/>
-								<TextControl
-									__next40pxDefaultSize
-									__nextHasNoMarginBottom
-									label={ __( 'Singular Name' ) }
-									value={ config.labels.singular_name || '' }
-									onChange={ ( value: string ) =>
-										updateLabel( 'singular_name', value )
-									}
-								/>
-								<TextareaControl
-									__next40pxDefaultSize
-									__nextHasNoMarginBottom
-									label={ __( 'Description' ) }
-									value={ config.description }
-									onChange={ ( value: string ) =>
-										updateField( 'description', value )
-									}
-								/>
 							</VStack>
-						</PanelBody>
-					</Panel>
-
-					<Panel>
-						<PanelBody title={ __( 'Visibility' ) } initialOpen>
-							<PanelRow>
-								<ToggleControl
-									__nextHasNoMarginBottom
-									label={ __( 'Public' ) }
-									checked={ config.public }
-									onChange={ ( value: boolean ) =>
-										updateField( 'public', value )
-									}
-								/>
-							</PanelRow>
-							<PanelRow>
-								<ToggleControl
-									__nextHasNoMarginBottom
-									label={ __( 'Hierarchical' ) }
-									checked={ config.hierarchical }
-									onChange={ ( value: boolean ) =>
-										updateField( 'hierarchical', value )
-									}
-								/>
-							</PanelRow>
-							<PanelRow>
-								<ToggleControl
-									__nextHasNoMarginBottom
-									label={ __( 'Show UI' ) }
-									checked={ config.show_ui }
-									onChange={ ( value: boolean ) =>
-										updateField( 'show_ui', value )
-									}
-								/>
-							</PanelRow>
-							<PanelRow>
-								<ToggleControl
-									__nextHasNoMarginBottom
-									label={ __( 'Show in Menu' ) }
-									checked={ config.show_in_menu }
-									onChange={ ( value: boolean ) =>
-										updateField( 'show_in_menu', value )
-									}
-								/>
-							</PanelRow>
-							{ isPostType && (
-								<PanelRow>
-									<ToggleControl
-										__nextHasNoMarginBottom
-										label={ __( 'Has Archive' ) }
-										checked={ !! config.has_archive }
-										onChange={ ( value: boolean ) =>
-											updateField( 'has_archive', value )
-										}
-									/>
-								</PanelRow>
-							) }
-						</PanelBody>
-					</Panel>
-
-					<Panel>
-						<PanelBody
-							title={ __( 'REST API' ) }
-							initialOpen={ false }
-						>
-							<VStack spacing={ 4 }>
-								<PanelRow>
-									<ToggleControl
-										__nextHasNoMarginBottom
-										label={ __( 'Show in REST' ) }
-										checked={ config.show_in_rest }
-										onChange={ ( value: boolean ) =>
-											updateField( 'show_in_rest', value )
-										}
-									/>
-								</PanelRow>
-								<TextControl
-									__next40pxDefaultSize
-									__nextHasNoMarginBottom
-									label={ __( 'REST Base' ) }
-									value={ config.rest_base }
-									onChange={ ( value: string ) =>
-										updateField( 'rest_base', value )
-									}
-								/>
-							</VStack>
-						</PanelBody>
-					</Panel>
-
-					{ ! isPostType && (
-						<Panel>
-							<PanelBody title={ __( 'Post Types' ) } initialOpen>
-								{ availablePostTypes.map( ( pt ) => (
-									<PanelRow key={ pt.slug }>
-										<CheckboxControl
-											__nextHasNoMarginBottom
-											label={ pt.labels?.name || pt.slug }
-											checked={ config.object_type.includes(
-												pt.slug
-											) }
-											onChange={ ( value: boolean ) =>
-												toggleObjectType(
-													pt.slug,
-													value
-												)
-											}
-										/>
-									</PanelRow>
-								) ) }
-								{ availablePostTypes.length === 0 && (
-									<PanelRow>
-										<p>
-											{ __( 'No post types available.' ) }
-										</p>
-									</PanelRow>
-								) }
-							</PanelBody>
-						</Panel>
+						</Tabs.TabPanel>
 					) }
 
 					{ isPostType && (
-						<Panel>
-							<PanelBody
-								title={ __( 'Menu' ) }
-								initialOpen={ false }
-							>
-								<VStack spacing={ 4 }>
-									<TextControl
-										__next40pxDefaultSize
-										__nextHasNoMarginBottom
-										label={ __( 'Menu Icon' ) }
-										help={ __(
-											'A dashicon class name or URL to an icon image.'
-										) }
-										value={ config.menu_icon || '' }
-										onChange={ ( value: string ) =>
-											updateField( 'menu_icon', value )
-										}
-									/>
-									<TextControl
-										__next40pxDefaultSize
-										__nextHasNoMarginBottom
-										label={ __( 'Menu Position' ) }
-										type="number"
-										value={
-											config.menu_position !== null
-												? String( config.menu_position )
-												: ''
-										}
-										onChange={ ( value: string ) =>
-											updateField(
-												'menu_position',
-												value ? Number( value ) : null
-											)
-										}
-									/>
-								</VStack>
-							</PanelBody>
-						</Panel>
-					) }
-
-					{ isPostType && (
-						<Panel>
-							<PanelBody
-								title={ __( 'Supports' ) }
-								initialOpen={ false }
-							>
+						<Tabs.TabPanel tabId="supports" focusable={ false }>
+							<VStack spacing={ 3 }>
 								{ POST_TYPE_SUPPORTS.map( ( feature ) => (
-									<PanelRow key={ feature }>
-										<CheckboxControl
-											__nextHasNoMarginBottom
-											label={ feature }
-											checked={
-												!! config.supports[ feature ]
-											}
-											onChange={ ( value: boolean ) =>
-												updateSupport( feature, value )
-											}
-										/>
-									</PanelRow>
+									<CheckboxControl
+										key={ feature }
+										__nextHasNoMarginBottom
+										label={ feature }
+										checked={
+											!! config.supports[ feature ]
+										}
+										onChange={ ( value: boolean ) =>
+											updateSupport( feature, value )
+										}
+									/>
 								) ) }
-							</PanelBody>
-						</Panel>
+							</VStack>
+						</Tabs.TabPanel>
 					) }
-				</VStack>
+				</Tabs>
 			</div>
 		</Page>
 	);

--- a/routes/entity-new/stage.tsx
+++ b/routes/entity-new/stage.tsx
@@ -160,6 +160,7 @@ function EntityNew() {
 		if ( ! config.slug ) {
 			createErrorNotice( __( 'Slug is required.' ), {
 				type: 'snackbar',
+				id: 'entity-validation-error',
 			} );
 			return;
 		}
@@ -167,6 +168,7 @@ function EntityNew() {
 		if ( ! config.labels.name ) {
 			createErrorNotice( __( 'Name is required.' ), {
 				type: 'snackbar',
+				id: 'entity-validation-error',
 			} );
 			return;
 		}
@@ -214,7 +216,7 @@ function EntityNew() {
 		} catch ( error: any ) {
 			createErrorNotice(
 				error?.message || __( 'Failed to create entity.' ),
-				{ type: 'snackbar' }
+				{ type: 'snackbar', id: 'entity-save-error' }
 			);
 		}
 

--- a/routes/entity-new/stage.tsx
+++ b/routes/entity-new/stage.tsx
@@ -258,7 +258,7 @@ function EntityNew() {
 				</HStack>
 			}
 		>
-			<div style={ { maxWidth: 800, padding: 16 } }>
+			<div style={ { padding: 16 } }>
 				<VStack spacing={ 4 }>
 					<Panel>
 						<PanelBody title={ __( 'General' ) } initialOpen>

--- a/routes/entity-new/stage.tsx
+++ b/routes/entity-new/stage.tsx
@@ -258,7 +258,7 @@ function EntityNew() {
 				</HStack>
 			}
 		>
-			<div style={ { maxWidth: 800, padding: '0 16px' } }>
+			<div style={ { maxWidth: 800, padding: 16 } }>
 				<VStack spacing={ 4 }>
 					<Panel>
 						<PanelBody title={ __( 'General' ) } initialOpen>


### PR DESCRIPTION
## What?
This PR experiments with introducing a basic entity management interface.

This is just a PoC, not intended to be landed.

## Why?
To allow managing post types and taxonomies through the UI.

## How?
It currently stores the modified entities in an option. 

It allows you to manage existing entities (coming from core or plugins) and create new ones.

It's very opinionated, and suggests a few debatable things - like changing existing entities could break a bunch of things. 

## Testing Instructions
Go to Settings > Entities and start playing with the existing post types and taxonomies, or create new ones.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

TBD

## Use of AI Tools

Used Claude for prototyping this. 