### PR TITLE
LinkControl: Add "No results found" state in search results

### DIFF
--- a/packages/block-editor/src/components/link-control/search-results.js
+++ b/packages/block-editor/src/components/link-control/search-results.js
@@ -12,10 +12,10 @@ import clsx from 'clsx';
 /**
  * Internal dependencies
  */
-import LinkControlSearchCreate from './search-create-button';
+import deprecated from '@wordpress/deprecated';
 import LinkControlSearchItem from './search-item';
 import { CREATE_TYPE, LINK_ENTRY_TYPES } from './constants';
-import deprecated from '@wordpress/deprecated';
+import LinkControlSearchCreate from './search-create-button';
 
 function LinkControlSearchResults( {
 	withCreateSuggestion,
@@ -47,6 +47,10 @@ function LinkControlSearchResults( {
 	// If the query has a specified type, then we can skip showing them in the result. See #24839.
 	const shouldShowSuggestionsTypes = ! suggestionsQuery?.type;
 
+	// If there are no suggestions and we're not currently loading or showing initial suggestions, then we can show the "No results" state.
+	const hasNoResults =
+		suggestions.length === 0 && ! isLoading && ! isInitialSuggestions;
+
 	const labelText = isInitialSuggestions
 		? __( 'Suggestions' )
 		: sprintf(
@@ -63,60 +67,72 @@ function LinkControlSearchResults( {
 				aria-label={ labelText }
 			>
 				<MenuGroup>
-					{ suggestions.map( ( suggestion, index ) => {
-						if (
-							shouldShowCreateSuggestion &&
-							CREATE_TYPE === suggestion.type
-						) {
+					{ hasNoResults ? (
+						<div className="block-editor-link-control__search-no-results">
+							{ __( 'No results found.' ) }
+						</div>
+					) : (
+						suggestions.map( ( suggestion, index ) => {
+							if (
+								shouldShowCreateSuggestion &&
+								CREATE_TYPE === suggestion.type
+							) {
+								return (
+									<LinkControlSearchCreate
+										searchTerm={ currentInputValue }
+										buttonText={
+											createSuggestionButtonText
+										}
+										onClick={ () =>
+											handleSuggestionClick( suggestion )
+										}
+										// Intentionally only using `type` here as
+										// the constant is enough to uniquely
+										// identify the single "CREATE" suggestion.
+										key={ suggestion.type }
+										itemProps={ buildSuggestionItemProps(
+											suggestion,
+											index
+										) }
+										isSelected={
+											index === selectedSuggestion
+										}
+									/>
+								);
+							}
+
+							// If we're not handling "Create" suggestions above then
+							// we don't want them in the main results so exit early.
+							if ( CREATE_TYPE === suggestion.type ) {
+								return null;
+							}
+
 							return (
-								<LinkControlSearchCreate
-									searchTerm={ currentInputValue }
-									buttonText={ createSuggestionButtonText }
-									onClick={ () =>
-										handleSuggestionClick( suggestion )
-									}
-									// Intentionally only using `type` here as
-									// the constant is enough to uniquely
-									// identify the single "CREATE" suggestion.
-									key={ suggestion.type }
+								<LinkControlSearchItem
+									key={ `${ suggestion.id }-${ suggestion.type }` }
 									itemProps={ buildSuggestionItemProps(
 										suggestion,
 										index
 									) }
+									suggestion={ suggestion }
+									index={ index }
+									onClick={ () => {
+										handleSuggestionClick( suggestion );
+									} }
 									isSelected={ index === selectedSuggestion }
+									isURL={ LINK_ENTRY_TYPES.includes(
+										suggestion.type
+									) }
+									searchTerm={ currentInputValue }
+									shouldShowType={
+										shouldShowSuggestionsTypes
+									}
+									isFrontPage={ suggestion?.isFrontPage }
+									isBlogHome={ suggestion?.isBlogHome }
 								/>
 							);
-						}
-
-						// If we're not handling "Create" suggestions above then
-						// we don't want them in the main results so exit early.
-						if ( CREATE_TYPE === suggestion.type ) {
-							return null;
-						}
-
-						return (
-							<LinkControlSearchItem
-								key={ `${ suggestion.id }-${ suggestion.type }` }
-								itemProps={ buildSuggestionItemProps(
-									suggestion,
-									index
-								) }
-								suggestion={ suggestion }
-								index={ index }
-								onClick={ () => {
-									handleSuggestionClick( suggestion );
-								} }
-								isSelected={ index === selectedSuggestion }
-								isURL={ LINK_ENTRY_TYPES.includes(
-									suggestion.type
-								) }
-								searchTerm={ currentInputValue }
-								shouldShowType={ shouldShowSuggestionsTypes }
-								isFrontPage={ suggestion?.isFrontPage }
-								isBlogHome={ suggestion?.isBlogHome }
-							/>
-						);
-					} ) }
+						} )
+					) }
 				</MenuGroup>
 			</div>
 		</div>

--- a/packages/block-editor/src/components/link-control/search-results.js
+++ b/packages/block-editor/src/components/link-control/search-results.js
@@ -49,7 +49,9 @@ function LinkControlSearchResults( {
 
 	// If there are no suggestions and we're not currently loading or showing initial suggestions, then we can show the "No results" state.
 	const hasNoResults =
-		suggestions.length === 0 && ! isLoading && ! isInitialSuggestions;
+		suggestions.filter( ( s ) => s.type !== CREATE_TYPE ).length === 0 &&
+		! isLoading &&
+		! isInitialSuggestions;
 
 	const labelText = isInitialSuggestions
 		? __( 'Suggestions' )
@@ -67,11 +69,12 @@ function LinkControlSearchResults( {
 				aria-label={ labelText }
 			>
 				<MenuGroup>
-					{ hasNoResults ? (
+					{ hasNoResults && (
 						<div className="block-editor-link-control__search-no-results">
 							{ __( 'No results found.' ) }
 						</div>
-					) : (
+					) }
+					{ ! hasNoResults &&
 						suggestions.map( ( suggestion, index ) => {
 							if (
 								shouldShowCreateSuggestion &&
@@ -131,8 +134,26 @@ function LinkControlSearchResults( {
 									isBlogHome={ suggestion?.isBlogHome }
 								/>
 							);
-						} )
-					) }
+						} ) }
+					{ hasNoResults &&
+						shouldShowCreateSuggestion &&
+						suggestions
+							.filter( ( s ) => s.type === CREATE_TYPE )
+							.map( ( suggestion, index ) => (
+								<LinkControlSearchCreate
+									key={ suggestion.type }
+									searchTerm={ currentInputValue }
+									buttonText={ createSuggestionButtonText }
+									onClick={ () =>
+										handleSuggestionClick( suggestion )
+									}
+									itemProps={ buildSuggestionItemProps(
+										suggestion,
+										index
+									) }
+									isSelected={ index === selectedSuggestion }
+								/>
+							) ) }
 				</MenuGroup>
 			</div>
 		</div>

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -405,3 +405,9 @@ $block-editor-link-control-number-of-actions: 1;
 	top: calc(50% + #{$spinner-size} / 4); // Add top spacing because this input has a visual label.
 	right: $grid-unit-15;
 }
+
+.block-editor-link-control__search-no-results {
+	padding: $grid-unit-30;
+	text-align: center;
+	color: $gray-700;
+}

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -820,6 +820,117 @@ describe( 'Manual link entry', () => {
 		);
 	} );
 
+	describe( 'Displaying no results found message', () => {
+		it( 'should display "No results found" when search returns no suggestions', async () => {
+			const user = userEvent.setup();
+
+			mockFetchSearchSuggestions.mockImplementation( () =>
+				Promise.resolve( [] )
+			);
+
+			render( <LinkControl showSuggestions /> );
+
+			const searchInput = screen.getByRole( 'combobox', {
+				name: 'Search or type URL',
+			} );
+
+			await user.type( searchInput, 'nonexistent' );
+
+			const noResultsMessage = await screen.findByText(
+				'No results found.',
+				{},
+				{ timeout: 2000 }
+			);
+
+			expect( noResultsMessage ).toBeVisible();
+			expect( noResultsMessage ).toHaveClass(
+				'block-editor-link-control__search-no-results'
+			);
+		} );
+
+		it( 'should not display "No results found" for initial suggestions', async () => {
+			mockFetchSearchSuggestions.mockImplementation( () =>
+				Promise.resolve( [] )
+			);
+
+			render( <LinkControl showInitialSuggestions /> );
+
+			const searchInput = screen.getByRole( 'combobox', {
+				name: 'Search or type URL',
+			} );
+
+			expect( searchInput ).toHaveAttribute( 'aria-expanded', 'false' );
+
+			const noResultsMessage = screen.queryByText( 'No results found.' );
+			expect( noResultsMessage ).not.toBeInTheDocument();
+		} );
+
+		it( 'should hide "No results found" when results are available', async () => {
+			const user = userEvent.setup();
+
+			mockFetchSearchSuggestions.mockImplementation( async () => [] );
+
+			render( <LinkControl showSuggestions /> );
+
+			const searchInput = screen.getByRole( 'combobox', {
+				name: 'Search or type URL',
+			} );
+
+			await user.type( searchInput, 'nonexistent' );
+
+			const noResultsMessage =
+				await screen.findByText( 'No results found.' );
+			expect( noResultsMessage ).toBeVisible();
+
+			mockFetchSearchSuggestions.mockImplementation( () =>
+				Promise.resolve( fauxEntitySuggestions )
+			);
+
+			await user.clear( searchInput );
+			await user.type( searchInput, 'hello' );
+
+			const searchResults = await screen.findByRole( 'listbox', {
+				name: /Search results for/,
+			} );
+
+			expect(
+				screen.queryByText( 'No results found.' )
+			).not.toBeInTheDocument();
+			expect( searchResults ).toBeVisible();
+			expect(
+				within( searchResults ).getAllByRole( 'option' ).length
+			).toBeGreaterThan( 0 );
+		} );
+
+		it( 'should display "No results found" alongside CREATE option when withCreateSuggestion is enabled', async () => {
+			const user = userEvent.setup();
+
+			mockFetchSearchSuggestions.mockImplementation( () =>
+				Promise.resolve( [] )
+			);
+
+			render( <LinkControl showSuggestions withCreateSuggestion /> );
+
+			const searchInput = screen.getByRole( 'combobox', {
+				name: 'Search or type URL',
+			} );
+
+			await user.type( searchInput, 'newpage' );
+
+			const searchResults = await screen.findByRole( 'listbox', {
+				name: /Search results for/,
+			} );
+
+			// Both "No results found." and CREATE option should be present
+			expect( screen.getByText( 'No results found.' ) ).toBeVisible();
+			expect(
+				within( searchResults ).getByRole( 'option', {
+					name: /^Create:/,
+				} )
+			).toBeVisible();
+		} );
+	} );
+
 	describe( 'Handling cancellation', () => {
 		it( 'should not show cancellation button during link creation', async () => {
 			const mockOnRemove = jest.fn();

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -191,11 +191,22 @@ class URLInput extends Component {
 					return;
 				}
 
+				// Determine whether or not to show suggestions.
+				// Suggestions should be shown if there are any results,
+				// or if the renderSuggestions prop is a function and we're not showing initial
+				// suggestions (which means we're showing search results).
+				const shouldShowSuggestions =
+					!! suggestions.length ||
+					( isFunction(
+						this.props.__experimentalRenderSuggestions
+					) &&
+						! isInitialSuggestions );
+
 				this.setState( {
 					suggestions,
 					suggestionsValue: value,
 					loading: false,
-					showSuggestions: !! suggestions.length,
+					showSuggestions: shouldShowSuggestions,
 				} );
 
 				if ( !! suggestions.length ) {
@@ -211,7 +222,7 @@ class URLInput extends Component {
 						),
 						'assertive'
 					);
-				} else {
+				} else if ( ! isInitialSuggestions ) {
 					this.props.debouncedSpeak(
 						__( 'No results.' ),
 						'assertive'
@@ -533,7 +544,7 @@ class URLInput extends Component {
 			loading,
 		} = this.state;
 
-		if ( ! showSuggestions || suggestions.length === 0 ) {
+		if ( ! showSuggestions ) {
 			return null;
 		}
 


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73290

## Why?
Currently, when users search inside LinkControl and no results are returned, the UI provides no feedback — the dropdown silently disappears. This creates confusion about whether the search is still loading, failed, or simply found nothing.

A simple notice significantly improves clarity and reduces user uncertainty, especially for new or less technical users.

## Testing Instructions
1. Open a post or page in the editor.
2. Insert a **Navigation** block (or any block with a Link setting).
3. Click the link input to open LinkControl.
4. Type a search term that is unlikely to match any content (e.g., `xyzabc123notreal`).
5. Verify that `"No results found."` appears in the dropdown.
6. Clear the input and type a term that matches existing content.
7. Verify that the `"No results found."` message disappears and suggestions appear normally.
8. Open LinkControl without typing anything (initial state).
9. Verify that `"No results found."` does **not** appear on initial open.

**Inline link format (Paragraph block and Buttons block):**

1. Add a **Paragraph** block and type some text.
2. Select the text and open the inline link UI via the toolbar.
3. Type a search term with no results.
4. Verify `"No results found."` appears and does not interfere with the link flow.
5. Type a term with results and verify suggestions appear normally.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/78f9f010-57de-4bf7-bd2e-da091f18365a

## Use of AI Tools
Claude Code was used to assist with code exploration, implementation planning, and test authoring. All generated code has been reviewed and verified.
