### PR TITLE
fix: auto-save alert link to the correct revision screen

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -22,6 +22,7 @@ import {
 import { store as noticesStore } from '@wordpress/notices';
 import { privateApis as editPatternsPrivateApis } from '@wordpress/patterns';
 import { createBlock } from '@wordpress/blocks';
+import { getQueryArg } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -308,6 +309,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			setCurrentTemplateId,
 			setEditedPost,
 			setRenderingMode,
+			setCurrentRevisionId,
 		} = unlock( useDispatch( editorStore ) );
 		const { editEntityRecord } = useDispatch( coreStore );
 
@@ -336,6 +338,10 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			updatePostLock( settings.postLock );
 			setupEditor( post, initialEdits, settings.template );
 			if ( settings.autosave ) {
+				const autosaveId = parseInt(
+					getQueryArg( settings.autosave.editLink, 'revision' ),
+					10
+				);
 				createWarningNotice(
 					__(
 						'There is an autosave of this post that is more recent than the version below.'
@@ -345,7 +351,8 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 						actions: [
 							{
 								label: __( 'View the autosave' ),
-								url: settings.autosave.editLink,
+								onClick: () =>
+									setCurrentRevisionId( autosaveId ),
 							},
 						],
 					}


### PR DESCRIPTION
## What?
Closes #75868

## Why?
When a user returns to a post and the editor discovers that there is a more recent auto-save version than the version the user is on, the block editor displayes a warning on top of the screen with the link
"View the autosave". The URL points to the old screens at /wp-admin/revision.php?revision=xxxx

## How?
`setCurrentRevisionId()` is used instead of using the url from `settings.autosave.editLink`

## Testing Instructions

1. Open a post in browser window.
2. Make changes to the post.
3. Don't save.
4. Open a different browser
5. open the same post in the block editor.
6. That should display the autosave warning.

## Use of AI Tools
Claude code