### PR TITLE
Rich Text: convert -- to em dash in editor

### DIFF
--- a/packages/rich-text/src/hook/event-listeners/index.js
+++ b/packages/rich-text/src/hook/event-listeners/index.js
@@ -14,6 +14,7 @@ import deleteHandler from './delete';
 import inputAndSelection from './input-and-selection';
 import selectionChangeCompat from './selection-change-compat';
 import { preventFocusCapture } from './prevent-focus-capture';
+import textInputRules from './text-input-rules';
 
 const allEventListeners = [
 	copyHandler,
@@ -23,6 +24,7 @@ const allEventListeners = [
 	inputAndSelection,
 	selectionChangeCompat,
 	preventFocusCapture,
+	textInputRules,
 ];
 
 export function useEventListeners( props ) {

--- a/packages/rich-text/src/hook/event-listeners/text-input-rules.js
+++ b/packages/rich-text/src/hook/event-listeners/text-input-rules.js
@@ -1,0 +1,67 @@
+/**
+ * Applies typographic input rules to the RichText editor,
+ * mirroring wp_texturize() so the editor matches the front end.
+ */
+const INPUT_RULES = [
+	{
+		// "---" is intentionally excluded so the separator transform can fire.
+		pattern: /^--([^-])$/,
+		replacement( match, char ) {
+			return '\u2014' + char;
+		},
+		skip: () => false,
+	},
+	{
+		// Mid-line: any run of 2+ dashes preceded by a non-hyphen character
+		pattern: /(?<=[^-])-{2,}$/,
+		replacement( match ) {
+			const emDashes = '\u2014'.repeat( Math.floor( match.length / 2 ) );
+			const leftover = match.length % 2 === 1 ? '-' : '';
+			return emDashes + leftover;
+		},
+		skip: () => false,
+	},
+];
+
+export default ( props ) => ( element ) => {
+	function onInput() {
+		const { record, createRecord, handleChange } = props.current;
+
+		if ( record.current.start !== record.current.end ) {
+			return;
+		}
+
+		const currentValue = createRecord();
+		const { text, start } = currentValue;
+		const textBefore = text.slice( 0, start );
+
+		for ( const { pattern, replacement, skip } of INPUT_RULES ) {
+			if ( ! pattern.test( textBefore ) ) {
+				continue;
+			}
+
+			if ( skip?.( textBefore ) ) {
+				continue;
+			}
+
+			const newTextBefore = textBefore.replace( pattern, replacement );
+			const newText = newTextBefore + text.slice( start );
+			const newStart = newTextBefore.length;
+
+			handleChange( {
+				...currentValue,
+				text: newText,
+				start: newStart,
+				end: newStart,
+			} );
+
+			return;
+		}
+	}
+
+	element.addEventListener( 'input', onInput );
+
+	return () => {
+		element.removeEventListener( 'input', onInput );
+	};
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73022

<!-- In a few words, what is the PR actually doing? -->
Convert `--` to an em dash (`—`) while typing in the RichText editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The front end converts `--` to `—` via `wp_texturize()` but the editor didn't, breaking the WYSIWYG experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds `text-input-rules.js` to `packages/rich-text/src/hook/event-listeners/` with two rules:

- **Start of line:** `--` + any non-hyphen character → `—`. `---` is excluded so the separator block transform still fires.
- **Mid-line:** any run of 2+ hyphens preceded by a non-hyphen converts immediately, pair by pair.

`__unstableInputRule` was considered but not used as it's designed for format types, not character substitution imo.

## Testing Instructions
1. Insert a Paragraph block.
2. Type `-- ` at the start of a line → `— `.
3. Type `---` at the start of a line → separator block, no em dash.
4. Type `hello--` → `hello—`.
5. Verify front end output matches editor.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

|Editor|Site|
|-|-|
|<img width="378" height="230" alt="Screenshot 2026-04-20 at 4 37 08 PM" src="https://github.com/user-attachments/assets/246b891c-ea49-4c37-b4c7-87ebd31d6438" />|<img width="604" height="448" alt="Screenshot 2026-04-20 at 4 37 14 PM" src="https://github.com/user-attachments/assets/565cb118-2a11-4442-a668-9ed51c00a846" />|

### After

|Editor|Site|
|-|-|
|<img width="952" height="562" alt="Screenshot 2026-04-20 at 5 51 37 PM" src="https://github.com/user-attachments/assets/a30efc76-0b61-4e7d-b0b5-c25267ae0a8f" />|<img width="892" height="648" alt="Screenshot 2026-04-20 at 5 33 54 PM" src="https://github.com/user-attachments/assets/8e93604f-8d36-4ed5-98a7-205d1f631e71" />|

## Use of AI Tools
Claude (Anthropic) was used to assist with code review and PR description drafting. All code was reviewed and tested by the author.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
