### PR TITLE
Feat: Add support for styling inline <code> element

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -99,6 +99,7 @@ Settings related to colors.
 | heading | Allow users to set heading colors in a block. | `boolean` | `true` |
 | button | Allow users to set button colors in a block. | `boolean` | `true` |
 | caption | Allow users to set caption colors in a block. | `boolean` | `true` |
+| code | Allow users to set code colors in a block. | `boolean` | `true` |
 
 ---
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -656,6 +656,7 @@ class WP_Theme_JSON_Gutenberg {
 		// The block classes are necessary to target older content that won't use the new class names.
 		'caption'   => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
 		'cite'      => 'cite',
+		'code'   => 'code:where(:not(pre code))',
 		'select'    => 'select',
 		'textInput' => 'textarea, input:where([type=email],[type=number],[type=password],[type=search],[type=text],[type=tel],[type=url])',
 	);

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -299,6 +299,7 @@ export const __EXPERIMENTAL_ELEMENTS = {
 	caption:
 		'.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
 	cite: 'cite',
+	code: 'code:where(:not(pre code))',
 	select: 'select',
 	textInput:
 		'textarea, input:where([type=email],[type=number],[type=password],[type=search],[type=tel],[type=text],[type=url])',

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -242,6 +242,11 @@
 							"description": "Allow users to set caption colors in a block.",
 							"type": "boolean",
 							"default": true
+						},
+						"code": {
+							"description": "Allow users to set code colors in a block.",
+							"type": "boolean",
+							"default": true
 						}
 					},
 					"additionalProperties": false
@@ -1973,6 +1978,9 @@
 				},
 				"caption": {
 					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"code": {
+					"$ref": "#/definitions/stylesProperties"
 				},
 				"cite": {
 					"$ref": "#/definitions/stylesPropertiesComplete"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #73323

Adds support for styling inline `<code>` elements via `theme.json` by registering `code` as a valid element under styles.elements and enabling related color settings.

## Why?
Currently, theme.json does not support styling inline `<code>` tags (e.g., backticks inside paragraphs), even though they are commonly used in content.

## How?
This PR introduces code as a supported element across the theme.json system.

## Testing Instructions
1. Add the following to theme.json:
```
{
  "styles": {
		"elements": {
			"code": {
				"color": {
					"text": "green",
					"background": "black"
				},
				"typography": {
					"fontFamily": "var(--wp--preset--font-family--fira-code)",
					 "textTransform": "uppercase",
					"letterSpacing": "0.1em",
					"textDecoration": "underline"
				}
			}
		}
	},
}
```
2. Add an `inline code` using backticks.
3. View frontend and confirm:
    1. Inline `<code>` is styled
    2. Styles match theme.json

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1463" height="708" alt="Screenshot 2026-04-20 at 6 54 44 PM" src="https://github.com/user-attachments/assets/0b80113f-7e34-4916-866d-0d7b880900e1" />|<img width="1468" height="715" alt="Screenshot 2026-04-20 at 6 55 21 PM" src="https://github.com/user-attachments/assets/297cb9c0-969b-43c8-bdcf-31706b03b62a" />|