### PR TITLE
Experiment: Add custom taxonomies

### DIFF
--- a/lib/experimental/content-types/index.php
+++ b/lib/experimental/content-types/index.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Registers the private CPTs that store user-defined content types:
+ *   - wp_user_taxonomy     (user-defined taxonomies)
+ *
+ * Each record holds the registration intent for one taxonomy;
+ * the `register_taxonomy` calls that materialize
+ * these records into the live registry come in a follow-up step.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Capability map: every write operation requires `manage_options`.
+ * Read is allowed for any authenticated user that can `edit_posts` so the
+ * REST endpoint can be consumed by the Settings pages without exposing the
+ * records to unauthenticated visitors.
+ *
+ * @return array
+ */
+function _gutenberg_content_types_admin_only_capabilities() {
+	return array(
+		'read'                   => 'edit_posts',
+		'create_posts'           => 'manage_options',
+		'edit_posts'             => 'manage_options',
+		'edit_published_posts'   => 'manage_options',
+		'delete_posts'           => 'manage_options',
+		'delete_published_posts' => 'manage_options',
+		'edit_others_posts'      => 'manage_options',
+		'delete_others_posts'    => 'manage_options',
+		'publish_posts'          => 'manage_options',
+	);
+}
+
+/**
+ * Registers the wp_user_taxonomy CPT.
+ */
+function gutenberg_register_user_taxonomy_cpt() {
+	register_post_type(
+		'wp_user_taxonomy',
+		array(
+			'labels'             => array(
+				'name'          => __( 'User taxonomies', 'gutenberg' ),
+				'singular_name' => __( 'User taxonomy', 'gutenberg' ),
+				'add_new_item'  => __( 'Add taxonomy', 'gutenberg' ),
+			),
+			'public'             => false,
+			'publicly_queryable' => false,
+			'show_ui'            => false,
+			'show_in_menu'       => false,
+			'show_in_rest'       => true,
+			'rest_base'          => 'user-taxonomies',
+			'capability_type'    => 'post',
+			'capabilities'       => _gutenberg_content_types_admin_only_capabilities(),
+			'map_meta_cap'       => true,
+			'supports'           => array( 'title', 'editor' ),
+			'hierarchical'       => false,
+			'has_archive'        => false,
+			'rewrite'            => false,
+			'query_var'          => false,
+		)
+	);
+}
+
+add_action( 'init', 'gutenberg_register_user_taxonomy_cpt' );
+
+/**
+ * Builds register_taxonomy() arguments from a wp_user_taxonomy record.
+ * Returns null for invalid records so callers can skip them uniformly.
+ *
+ * @param WP_Post $record Stored taxonomy record.
+ * @return array{0: string, 1: string[], 2: array}|null [ $slug, $object_type, $args ].
+ */
+function gutenberg_build_user_taxonomy_args( WP_Post $record ) {
+	$slug = $record->post_name;
+	if ( ! is_string( $slug ) || ! preg_match( '/^[a-z0-9_-]{1,32}$/', $slug ) ) {
+		return null;
+	}
+
+	$config = json_decode( (string) $record->post_content, true, 8 );
+	if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $config ) ) {
+		return null;
+	}
+
+	$object_type = array();
+	if ( isset( $config['object_type'] ) && is_array( $config['object_type'] ) ) {
+		foreach ( $config['object_type'] as $pt_slug ) {
+			if ( is_string( $pt_slug ) && post_type_exists( $pt_slug ) ) {
+				$object_type[] = $pt_slug;
+			}
+		}
+	}
+
+	$title    = sanitize_text_field( $record->post_title );
+	$singular = isset( $config['labels']['singular_name'] )
+		? sanitize_text_field( (string) $config['labels']['singular_name'] )
+		: '';
+	$labels   = array(
+		'name'          => $title,
+		'singular_name' => '' !== $singular ? $singular : $title,
+	);
+
+	$args = array(
+		'labels'       => $labels,
+		'public'       => ! empty( $config['public'] ),
+		'hierarchical' => ! empty( $config['hierarchical'] ),
+		'show_in_rest' => true,
+	);
+
+	return array( $slug, $object_type, $args );
+}
+
+/**
+ * Materializes stored wp_user_taxonomy records into live registered
+ * taxonomies by reading each published record and calling register_taxonomy()
+ * with a tightly-validated subset of its stored config.
+ *
+ * Drafts (post_status != 'publish') are skipped, so Edit's Active toggle
+ * gates whether a record is actually registered.
+ */
+function gutenberg_register_user_defined_taxonomies() {
+	$records = get_posts(
+		array(
+			'post_type'        => 'wp_user_taxonomy',
+			'post_status'      => 'publish',
+			'posts_per_page'   => -1,
+			'no_found_rows'    => true,
+			'suppress_filters' => true,
+		)
+	);
+
+	foreach ( $records as $record ) {
+		$built = gutenberg_build_user_taxonomy_args( $record );
+		if ( null === $built ) {
+			continue;
+		}
+		list( $slug, $object_type, $args ) = $built;
+
+		// Defense-in-depth: never overwrite an existing taxonomy registration,
+		// even if a bad record slipped past server-side slug validation.
+		if ( taxonomy_exists( $slug ) ) {
+			continue;
+		}
+
+		register_taxonomy( $slug, $object_type, $args );
+	}
+}
+add_action( 'init', 'gutenberg_register_user_defined_taxonomies', 20 );
+
+/**
+ * Rejects a wp_user_taxonomy save when its slug collides with an existing
+ * taxonomy or another wp_user_taxonomy post. Primary server-side defense —
+ * the Add/Edit modals do the same check client-side for UX, but the server
+ * enforces the invariant.
+ *
+ * @param stdClass        $prepared_post Post object prepared for insertion.
+ * @param WP_REST_Request $request       The REST request.
+ * @return stdClass|WP_Error Filtered post object, or WP_Error to abort.
+ */
+function gutenberg_validate_user_taxonomy_slug( $prepared_post, $request ) {
+	$slug = ! empty( $prepared_post->post_name )
+		? (string) $prepared_post->post_name
+		: '';
+	if ( '' === $slug ) {
+		return $prepared_post;
+	}
+
+	$editing_id = isset( $prepared_post->ID ) ? (int) $prepared_post->ID : 0;
+
+	// Unchanged slug on an existing record — allow.
+	if ( $editing_id > 0 ) {
+		$existing = get_post( $editing_id );
+		if ( $existing && $existing->post_name === $slug ) {
+			return $prepared_post;
+		}
+	}
+
+	// Another wp_user_taxonomy post already owns this slug → reject.
+	$other_posts = get_posts(
+		array(
+			'post_type'        => 'wp_user_taxonomy',
+			'post_status'      => 'any',
+			'name'             => $slug,
+			'posts_per_page'   => 1,
+			'no_found_rows'    => true,
+			'suppress_filters' => true,
+			'post__not_in'     => $editing_id > 0 ? array( $editing_id ) : array(),
+		)
+	);
+	if ( ! empty( $other_posts ) ) {
+		return new WP_Error(
+			'gutenberg_user_taxonomy_slug_taken',
+			__( 'Another user-defined taxonomy already uses this key.', 'gutenberg' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	// Registered taxonomy owns this slug (core / plugin) → reject. Our own
+	// materializer runs at init priority 20 and skips colliding slugs, so a
+	// taxonomy_exists() hit here means a non-user-taxonomy registration.
+	if ( taxonomy_exists( $slug ) ) {
+		return new WP_Error(
+			'gutenberg_user_taxonomy_slug_reserved',
+			sprintf(
+				/* translators: %s: taxonomy slug */
+				__( 'The taxonomy key "%s" is reserved by an existing taxonomy.', 'gutenberg' ),
+				$slug
+			),
+			array( 'status' => 400 )
+		);
+	}
+
+	return $prepared_post;
+}
+add_filter( 'rest_pre_insert_wp_user_taxonomy', 'gutenberg_validate_user_taxonomy_slug', 10, 2 );

--- a/lib/experimental/content-types/index.php
+++ b/lib/experimental/content-types/index.php
@@ -161,7 +161,7 @@ add_action( 'init', 'gutenberg_register_user_defined_taxonomies', 20 );
  * @param WP_REST_Request $request       The REST request.
  * @return stdClass|WP_Error Filtered post object, or WP_Error to abort.
  */
-function gutenberg_validate_user_taxonomy_slug( $prepared_post, $request ) {
+function gutenberg_validate_user_taxonomy_slug( $prepared_post, $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	$slug = ! empty( $prepared_post->post_name )
 		? (string) $prepared_post->post_name
 		: '';

--- a/lib/experimental/content-types/index.php
+++ b/lib/experimental/content-types/index.php
@@ -15,28 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Capability map: every write operation requires `manage_options`.
- * Read is allowed for any authenticated user that can `edit_posts` so the
- * REST endpoint can be consumed by the Settings pages without exposing the
- * records to unauthenticated visitors.
- *
- * @return array
- */
-function _gutenberg_content_types_admin_only_capabilities() {
-	return array(
-		'read'                   => 'edit_posts',
-		'create_posts'           => 'manage_options',
-		'edit_posts'             => 'manage_options',
-		'edit_published_posts'   => 'manage_options',
-		'delete_posts'           => 'manage_options',
-		'delete_published_posts' => 'manage_options',
-		'edit_others_posts'      => 'manage_options',
-		'delete_others_posts'    => 'manage_options',
-		'publish_posts'          => 'manage_options',
-	);
-}
-
-/**
  * Registers the wp_user_taxonomy CPT.
  */
 function gutenberg_register_user_taxonomy_cpt() {
@@ -55,7 +33,23 @@ function gutenberg_register_user_taxonomy_cpt() {
 			'show_in_rest'       => true,
 			'rest_base'          => 'user-taxonomies',
 			'capability_type'    => 'post',
-			'capabilities'       => _gutenberg_content_types_admin_only_capabilities(),
+			'capabilities'       => array(
+				/**
+				 * Capability map: every write operation requires `manage_options`.
+				 * Read is allowed for any authenticated user that can `edit_posts` so the
+				 * REST endpoint can be consumed by the Settings pages without exposing the
+				 * records to unauthenticated visitors.
+				 */
+				'read'                   => 'edit_posts',
+				'create_posts'           => 'manage_options',
+				'edit_posts'             => 'manage_options',
+				'edit_published_posts'   => 'manage_options',
+				'delete_posts'           => 'manage_options',
+				'delete_published_posts' => 'manage_options',
+				'edit_others_posts'      => 'manage_options',
+				'delete_others_posts'    => 'manage_options',
+				'publish_posts'          => 'manage_options',
+			),
 			'map_meta_cap'       => true,
 			'supports'           => array( 'title', 'editor' ),
 			'hierarchical'       => false,

--- a/lib/experimental/content-types/index.php
+++ b/lib/experimental/content-types/index.php
@@ -155,7 +155,7 @@ add_action( 'init', 'gutenberg_register_user_defined_taxonomies', 20 );
  * @param WP_REST_Request $request       The REST request.
  * @return stdClass|WP_Error Filtered post object, or WP_Error to abort.
  */
-function gutenberg_validate_user_taxonomy_slug( $prepared_post, $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+function gutenberg_validate_user_taxonomy_slug( $prepared_post ) {
 	$slug = ! empty( $prepared_post->post_name )
 		? (string) $prepared_post->post_name
 		: '';
@@ -210,4 +210,4 @@ function gutenberg_validate_user_taxonomy_slug( $prepared_post, $request ) { // 
 
 	return $prepared_post;
 }
-add_filter( 'rest_pre_insert_wp_user_taxonomy', 'gutenberg_validate_user_taxonomy_slug', 10, 2 );
+add_filter( 'rest_pre_insert_wp_user_taxonomy', 'gutenberg_validate_user_taxonomy_slug' );

--- a/lib/experimental/content-types/load.php
+++ b/lib/experimental/content-types/load.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Bootstraps the Content Types pages (Taxonomies) in wp-admin under Settings.
+ *
+ * @package gutenberg
+ */
+
+add_action( 'admin_menu', '_gutenberg_content_types_add_settings_menu_items', 11 );
+
+/**
+ * Registers "Taxonomies" submenu items under Settings.
+ *
+ * @access private
+ */
+function _gutenberg_content_types_add_settings_menu_items() {
+	if ( function_exists( 'gutenberg_taxonomies_wp_admin_render_page' ) ) {
+		add_submenu_page(
+			'options-general.php',
+			__( 'Taxonomies', 'gutenberg' ),
+			__( 'Taxonomies', 'gutenberg' ),
+			'manage_options',
+			'taxonomies-wp-admin',
+			'gutenberg_taxonomies_wp_admin_render_page'
+		);
+	}
+}

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -221,6 +221,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-content-types',
+		__( 'Content types: manage custom taxonomies', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enables a UI for creating and managing custom taxonomies. Custom post types will be explored soon.', 'gutenberg' ),
+			'id'    => 'gutenberg-content-types',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/lib/load.php
+++ b/lib/load.php
@@ -220,3 +220,9 @@ if ( gutenberg_is_experiment_enabled( 'gutenberg-guidelines' ) ) {
 	require __DIR__ . '/experimental/guidelines/load.php';
 	require __DIR__ . '/experimental/guidelines/index.php';
 }
+
+// Content types (only load when experiment is enabled).
+if ( gutenberg_is_experiment_enabled( 'gutenberg-content-types' ) ) {
+	require __DIR__ . '/experimental/content-types/load.php';
+	require __DIR__ . '/experimental/content-types/index.php';
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20893,6 +20893,10 @@
 			"resolved": "packages/sync",
 			"link": true
 		},
+		"node_modules/@wordpress/taxonomies-route": {
+			"resolved": "routes/taxonomies",
+			"link": true
+		},
 		"node_modules/@wordpress/template": {
 			"resolved": "routes/template",
 			"link": true
@@ -63191,6 +63195,24 @@
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
 				"@wordpress/route": "file:../../packages/route",
+				"@wordpress/url": "file:../../packages/url"
+			}
+		},
+		"routes/taxonomies": {
+			"name": "@wordpress/taxonomies-route",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/api-fetch": "file:../../packages/api-fetch",
+				"@wordpress/components": "file:../../packages/components",
+				"@wordpress/core-data": "file:../../packages/core-data",
+				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/dataviews": "file:../../packages/dataviews",
+				"@wordpress/element": "file:../../packages/element",
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/icons": "file:../../packages/icons",
+				"@wordpress/notices": "file:../../packages/notices",
+				"@wordpress/ui": "file:../../packages/ui",
 				"@wordpress/url": "file:../../packages/url"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 			},
 			"font-library",
 			"options-connectors",
-			"guidelines"
+			"guidelines",
+			"taxonomies"
 		]
 	},
 	"config": {

--- a/routes/taxonomies/actions/edit.tsx
+++ b/routes/taxonomies/actions/edit.tsx
@@ -1,0 +1,191 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { closeSmall, pencil } from '@wordpress/icons';
+import { store as coreStore, useEntityRecord } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import {
+	DataForm,
+	useFormValidity,
+	type Action,
+	type Field,
+} from '@wordpress/dataviews';
+import { useMemo, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { Stack, Text } from '@wordpress/ui';
+import '../style.scss';
+
+/**
+ * Internal dependencies
+ */
+import {
+	defaultForm,
+	hierarchicalField,
+	pluralLabelField,
+	publicField,
+	singularLabelField,
+	statusField,
+	useObjectTypeField,
+	useSlugField,
+} from '../fields';
+import {
+	serializeForSave,
+	toFormData,
+	type TaxonomyFormData,
+	type TaxonomyRecord,
+} from '../utils';
+
+function EditTaxonomyModal( {
+	items,
+	closeModal,
+}: {
+	items: TaxonomyFormData[];
+	closeModal?: () => void;
+} ) {
+	const item = items[ 0 ];
+	const { record, hasResolved } = useEntityRecord< TaxonomyRecord >(
+		'postType',
+		'wp_user_taxonomy',
+		item.id ?? 0
+	);
+
+	const initialData = useMemo< TaxonomyFormData >(
+		() => ( record ? toFormData( record ) : item ),
+		[ record, item ]
+	);
+
+	const [ data, setData ] = useState< TaxonomyFormData >( initialData );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const slugField = useSlugField( item.slug );
+	const objectTypeField = useObjectTypeField();
+
+	const fields = useMemo< Field< TaxonomyFormData >[] >(
+		() => [
+			pluralLabelField,
+			singularLabelField,
+			slugField,
+			objectTypeField,
+			publicField,
+			hierarchicalField,
+			statusField,
+		],
+		[ slugField, objectTypeField ]
+	);
+
+	const { validity, isValid } = useFormValidity( data, fields, defaultForm );
+	const { saveEntityRecord } = useDispatch( coreStore );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	async function onSave() {
+		if ( isSaving || ! isValid ) {
+			return;
+		}
+		setIsSaving( true );
+		try {
+			await saveEntityRecord(
+				'postType',
+				'wp_user_taxonomy',
+				serializeForSave( { ...data, id: item.id } ),
+				{ throwOnError: true }
+			);
+			createSuccessNotice(
+				sprintf(
+					/* translators: %s: taxonomy plural label. */
+					__( '"%s" taxonomy updated.' ),
+					data.title.raw
+				),
+				{ type: 'snackbar' }
+			);
+			closeModal?.();
+		} catch ( error: any ) {
+			createErrorNotice(
+				error?.message && error?.code !== 'unknown_error'
+					? error.message
+					: __( 'Failed to update taxonomy.' ),
+				{ type: 'snackbar' }
+			);
+		} finally {
+			setIsSaving( false );
+		}
+	}
+
+	if ( ! hasResolved ) {
+		return <></>;
+	}
+
+	return (
+		<>
+			<Stack
+				className="dataviews-action-modal__edit-taxonomy-header"
+				direction="row"
+				justify="space-between"
+				align="center"
+			>
+				<Text
+					variant="heading-sm"
+					render={ <h2 /> }
+					className="dataviews-action-modal__edit-taxonomy-title"
+				>
+					{ __( 'Edit taxonomy' ) }
+				</Text>
+				<Button
+					size="small"
+					icon={ closeSmall }
+					label={ __( 'Close' ) }
+					onClick={ closeModal }
+				/>
+			</Stack>
+			<div className="dataviews-action-modal__edit-taxonomy-content">
+				<DataForm< TaxonomyFormData >
+					data={ data }
+					fields={ fields }
+					form={ defaultForm }
+					validity={ validity }
+					onChange={ ( edits ) =>
+						setData(
+							( prev ) =>
+								( { ...prev, ...edits } ) as TaxonomyFormData
+						)
+					}
+				/>
+			</div>
+			<Stack
+				className="dataviews-action-modal__edit-taxonomy-footer"
+				direction="row"
+				gap="sm"
+			>
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					onClick={ closeModal }
+				>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					isBusy={ isSaving }
+					disabled={ isSaving }
+					accessibleWhenDisabled
+					onClick={ onSave }
+				>
+					{ __( 'Done' ) }
+				</Button>
+			</Stack>
+		</>
+	);
+}
+
+const editTaxonomyAction: Action< TaxonomyFormData > = {
+	id: 'edit-taxonomy',
+	label: __( 'Edit' ),
+	icon: pencil,
+	isPrimary: true,
+	hideModalHeader: true,
+	RenderModal: EditTaxonomyModal,
+};
+
+export default editTaxonomyAction;

--- a/routes/taxonomies/actions/index.ts
+++ b/routes/taxonomies/actions/index.ts
@@ -1,0 +1,2 @@
+export { default as editTaxonomyAction } from './edit';
+export { default as toggleActiveAction } from './toggle-active';

--- a/routes/taxonomies/actions/toggle-active.ts
+++ b/routes/taxonomies/actions/toggle-active.ts
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { store as coreStore } from '@wordpress/core-data';
+import type { Action } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import type { TaxonomyFormData } from '../utils';
+
+const toggleActiveAction: Action< TaxonomyFormData > = {
+	id: 'toggle-active',
+	label: ( items: TaxonomyFormData[] ) =>
+		items.every( ( i ) => i.status === 'publish' )
+			? __( 'Deactivate' )
+			: __( 'Activate' ),
+	async callback( items, { registry } ) {
+		const { saveEntityRecord } = registry.dispatch( coreStore );
+		const { createSuccessNotice, createErrorNotice } =
+			registry.dispatch( noticesStore );
+		const next = items.every( ( i ) => i.status === 'publish' )
+			? 'draft'
+			: 'publish';
+		try {
+			for ( const item of items ) {
+				if ( item.id === undefined ) {
+					continue;
+				}
+				await saveEntityRecord(
+					'postType',
+					'wp_user_taxonomy',
+					{ id: item.id, status: next },
+					{ throwOnError: true }
+				);
+			}
+			createSuccessNotice(
+				next === 'publish'
+					? __( 'Taxonomy activated.' )
+					: __( 'Taxonomy deactivated.' ),
+				{ type: 'snackbar' }
+			);
+		} catch ( error: any ) {
+			createErrorNotice(
+				error?.message && error?.code !== 'unknown_error'
+					? error.message
+					: __( 'Failed to update taxonomy status.' ),
+				{ type: 'snackbar' }
+			);
+		}
+	},
+};
+
+export default toggleActiveAction;

--- a/routes/taxonomies/add-taxonomy.tsx
+++ b/routes/taxonomies/add-taxonomy.tsx
@@ -1,0 +1,180 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { DataForm, useFormValidity, type Field } from '@wordpress/dataviews';
+import { useMemo, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { Stack } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import {
+	defaultForm,
+	hierarchicalField,
+	pluralLabelField,
+	publicField,
+	singularLabelField,
+	statusField,
+	useObjectTypeField,
+	useSlugField,
+} from './fields';
+import { serializeForSave, type TaxonomyFormData } from './utils';
+
+const BLANK_RECORD: TaxonomyFormData = {
+	slug: '',
+	status: 'publish',
+	title: { raw: '' },
+	config: {
+		labels: { singular_name: '' },
+		object_type: [],
+		public: true,
+		hierarchical: false,
+	},
+};
+
+function AddTaxonomyModal( {
+	addNewLabel,
+	onClose,
+}: {
+	addNewLabel: string;
+	onClose: () => void;
+} ) {
+	const slugField = useSlugField();
+	const objectTypeField = useObjectTypeField();
+
+	const fields = useMemo< Field< TaxonomyFormData >[] >(
+		() => [
+			pluralLabelField,
+			singularLabelField,
+			slugField,
+			objectTypeField,
+			publicField,
+			hierarchicalField,
+			statusField,
+		],
+		[ slugField, objectTypeField ]
+	);
+
+	const [ data, setData ] = useState< TaxonomyFormData >( {
+		...BLANK_RECORD,
+	} );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const { validity, isValid } = useFormValidity( data, fields, defaultForm );
+
+	const { saveEntityRecord } = useDispatch( coreStore );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	async function onSubmit() {
+		if ( isSaving || ! isValid ) {
+			return;
+		}
+		setIsSaving( true );
+		try {
+			await saveEntityRecord(
+				'postType',
+				'wp_user_taxonomy',
+				serializeForSave( data ),
+				{ throwOnError: true }
+			);
+			createSuccessNotice(
+				sprintf(
+					/* translators: %s: taxonomy plural label. */
+					__( '"%s" taxonomy created.' ),
+					data.title.raw
+				),
+				{ type: 'snackbar' }
+			);
+			onClose();
+		} catch ( error: any ) {
+			createErrorNotice(
+				error?.message && error?.code !== 'unknown_error'
+					? error.message
+					: __( 'Failed to create taxonomy.' ),
+				{ type: 'snackbar' }
+			);
+		} finally {
+			setIsSaving( false );
+		}
+	}
+
+	return (
+		<Modal
+			title={ addNewLabel }
+			onRequestClose={ onClose }
+			focusOnMount="firstContentElement"
+			size="small"
+		>
+			<form
+				onSubmit={ ( event ) => {
+					event.preventDefault();
+					onSubmit();
+				} }
+			>
+				<DataForm< TaxonomyFormData >
+					data={ data }
+					fields={ fields }
+					form={ defaultForm }
+					validity={ validity }
+					onChange={ ( edits ) =>
+						setData(
+							( prev ) =>
+								( { ...prev, ...edits } ) as TaxonomyFormData
+						)
+					}
+				/>
+				<Stack direction="row" gap="sm" justify="end">
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						onClick={ onClose }
+					>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						type="submit"
+						isBusy={ isSaving }
+						accessibleWhenDisabled
+					>
+						{ __( 'Create' ) }
+					</Button>
+				</Stack>
+			</form>
+		</Modal>
+	);
+}
+
+export default function AddTaxonomy() {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const addNewLabel = useSelect(
+		( select ) =>
+			select( coreStore ).getPostType( 'wp_user_taxonomy' )?.labels
+				?.add_new_item ?? __( 'Add taxonomy' ),
+		[]
+	);
+	return (
+		<>
+			<Button
+				variant="primary"
+				size="compact"
+				__next40pxDefaultSize
+				onClick={ () => setIsOpen( true ) }
+			>
+				{ addNewLabel }
+			</Button>
+			{ isOpen && (
+				<AddTaxonomyModal
+					addNewLabel={ addNewLabel }
+					onClose={ () => setIsOpen( false ) }
+				/>
+			) }
+		</>
+	);
+}

--- a/routes/taxonomies/fields.tsx
+++ b/routes/taxonomies/fields.tsx
@@ -1,0 +1,185 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import type { Field, Form } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import {
+	usePublicPostTypes,
+	useTakenTaxonomySlugs,
+	type TaxonomyFormData,
+} from './utils';
+
+export const titleField: Field< TaxonomyFormData > = {
+	id: 'title',
+	label: __( 'Title' ),
+	type: 'text',
+	enableGlobalSearch: true,
+	getValue: ( { item } ) => item.title.raw,
+	setValue: ( { value } ) => ( { title: { raw: String( value ?? '' ) } } ),
+	isValid: { required: true },
+	filterBy: false,
+	enableHiding: false,
+};
+
+export const pluralLabelField: Field< TaxonomyFormData > = {
+	id: 'plural_name',
+	label: __( 'Plural label' ),
+	type: 'text',
+	getValue: ( { item } ) => item.title.raw,
+	setValue: ( { value } ) => ( { title: { raw: String( value ?? '' ) } } ),
+	isValid: { required: true },
+};
+
+export const singularLabelField: Field< TaxonomyFormData > = {
+	id: 'singular_name',
+	label: __( 'Singular label' ),
+	type: 'text',
+	getValue: ( { item } ) => item.config.labels.singular_name,
+	setValue: ( { item, value } ) => ( {
+		config: {
+			...item.config,
+			labels: {
+				...item.config.labels,
+				singular_name: String( value ?? '' ),
+			},
+		},
+	} ),
+	isValid: { required: true },
+	enableSorting: false,
+};
+
+export const publicField: Field< TaxonomyFormData > = {
+	id: 'public',
+	label: __( 'Public' ),
+	type: 'boolean',
+	description: __(
+		'Whether a taxonomy is intended for use publicly either via the admin interface or by front-end users.'
+	),
+	getValue: ( { item } ) => item.config.public,
+	setValue: ( { item, value } ) => ( {
+		config: { ...item.config, public: !! value },
+	} ),
+	filterBy: false,
+	enableSorting: false,
+};
+
+export const hierarchicalField: Field< TaxonomyFormData > = {
+	id: 'hierarchical',
+	label: __( 'Hierarchical' ),
+	type: 'boolean',
+	description: __(
+		'When on, terms behave like categories with parent-child relationships. When off, terms behave like tags.'
+	),
+	getValue: ( { item } ) => item.config.hierarchical,
+	setValue: ( { item, value } ) => ( {
+		config: { ...item.config, hierarchical: !! value },
+	} ),
+	filterBy: false,
+	enableSorting: false,
+};
+
+export const statusField: Field< TaxonomyFormData > = {
+	id: 'status',
+	label: __( 'Status' ),
+	description: __(
+		'Active taxonomies are enabled and registered with WordPress.'
+	),
+	elements: [
+		{ value: 'publish', label: __( 'Active' ) },
+		{ value: 'draft', label: __( 'Inactive' ) },
+	],
+	enableSorting: false,
+};
+
+export function useSlugField(
+	currentSlug?: string
+): Field< TaxonomyFormData > {
+	const takenSlugs = useTakenTaxonomySlugs( currentSlug );
+	return useMemo< Field< TaxonomyFormData > >(
+		() => ( {
+			id: 'slug',
+			label: __( 'Slug' ),
+			type: 'text',
+			enableGlobalSearch: true,
+			description: __(
+				'Lower case letters, underscores and dashes only. Changing the key renames the taxonomy — existing terms may become inaccessible until a migration updates the database.'
+			),
+			isValid: {
+				required: true,
+				pattern: '^[a-z0-9_-]{1,32}$',
+				custom: ( value: TaxonomyFormData ) =>
+					takenSlugs.has( value.slug )
+						? __( 'This taxonomy key is already in use.' )
+						: null,
+			},
+			filterBy: false,
+			enableSorting: false,
+		} ),
+		[ takenSlugs ]
+	);
+}
+
+export function useObjectTypeField(): Field< TaxonomyFormData > {
+	const publicPostTypes = usePublicPostTypes();
+	return useMemo< Field< TaxonomyFormData > >( () => {
+		const elements = ( publicPostTypes ?? [] ).map( ( pt: any ) => ( {
+			value: pt.slug as string,
+			label: pt.name as string,
+		} ) );
+		const labelMap: Record< string, string > = Object.fromEntries(
+			elements.map( ( e ) => [ e.value, e.label ] )
+		);
+		return {
+			id: 'object_type',
+			label: __( 'Post types' ),
+			type: 'array',
+			description: __(
+				'One or more post types with which the taxonomy should be associated.'
+			),
+			elements,
+			enableSorting: false,
+			getValue: ( { item } ) => item.config.object_type,
+			setValue: ( { item, value } ) => ( {
+				config: {
+					...item.config,
+					object_type: Array.isArray( value ) ? value : [],
+				},
+			} ),
+			render: ( { item } ) => {
+				const slugs = item.config.object_type;
+				if ( ! slugs || slugs.length === 0 ) {
+					return <span aria-hidden="true">—</span>;
+				}
+				return (
+					<>
+						{ slugs
+							.map( ( s ) => labelMap[ s ] ?? s )
+							.join( ', ' ) }
+					</>
+				);
+			},
+			isValid: { required: true },
+			filterBy: false,
+		};
+	}, [ publicPostTypes ] );
+}
+
+// --- Form layout ---------------------------------------------------------
+
+export const defaultForm: Form = {
+	layout: { type: 'regular' },
+	fields: [
+		'plural_name',
+		'singular_name',
+		'slug',
+		'object_type',
+		'public',
+		'hierarchical',
+		'status',
+	],
+};

--- a/routes/taxonomies/fields.tsx
+++ b/routes/taxonomies/fields.tsx
@@ -107,7 +107,7 @@ export function useSlugField(
 			type: 'text',
 			enableGlobalSearch: true,
 			description: __(
-				'Lower case letters, underscores and dashes only. Changing the key renames the taxonomy — existing terms may become inaccessible until a migration updates the database.'
+				'Lower case letters, numbers, underscores, and dashes only. Maximum length: 32 characters. Changing the key renames the taxonomy — existing terms may become inaccessible until a migration updates the database.'
 			),
 			isValid: {
 				required: true,

--- a/routes/taxonomies/package.json
+++ b/routes/taxonomies/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "@wordpress/taxonomies-route",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/",
+		"page": [
+			"taxonomies"
+		]
+	},
+	"dependencies": {
+		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/api-fetch": "file:../../packages/api-fetch",
+		"@wordpress/components": "file:../../packages/components",
+		"@wordpress/core-data": "file:../../packages/core-data",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/dataviews": "file:../../packages/dataviews",
+		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/icons": "file:../../packages/icons",
+		"@wordpress/notices": "file:../../packages/notices",
+		"@wordpress/ui": "file:../../packages/ui",
+		"@wordpress/url": "file:../../packages/url"
+	}
+}

--- a/routes/taxonomies/route.ts
+++ b/routes/taxonomies/route.ts
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const route = {
+	title: () => __( 'Taxonomies' ),
+};

--- a/routes/taxonomies/stage.tsx
+++ b/routes/taxonomies/stage.tsx
@@ -1,0 +1,109 @@
+/**
+ * WordPress dependencies
+ */
+import { Page } from '@wordpress/admin-ui';
+import { DataViews, type View } from '@wordpress/dataviews';
+import { useEntityRecords } from '@wordpress/core-data';
+import { useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import AddTaxonomy from './add-taxonomy';
+import { editTaxonomyAction, toggleActiveAction } from './actions';
+import {
+	titleField,
+	statusField,
+	publicField,
+	hierarchicalField,
+	useSlugField,
+	useObjectTypeField,
+} from './fields';
+import { toFormData, type TaxonomyRecord } from './utils';
+
+const defaultLayouts = {
+	table: {},
+};
+
+const DEFAULT_VIEW: View = {
+	type: 'table',
+	perPage: 20,
+	page: 1,
+	fields: [ 'object_type', 'status', 'public' ],
+	titleField: 'title',
+	layout: {},
+};
+
+function TaxonomiesPage() {
+	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const taxonomyActions = useMemo(
+		() => [ editTaxonomyAction, toggleActiveAction ],
+		[]
+	);
+	const slugField = useSlugField();
+	const objectTypeField = useObjectTypeField();
+	const fields = useMemo(
+		() => [
+			titleField,
+			objectTypeField,
+			statusField,
+			publicField,
+			slugField,
+			hierarchicalField,
+		],
+		[ slugField, objectTypeField ]
+	);
+	const queryArgs = useMemo( () => {
+		const statusFilter = view.filters?.find(
+			( filter ) => filter.field === 'status'
+		);
+		return {
+			per_page: view.perPage,
+			page: view.page,
+			context: 'edit',
+			order: view.sort?.direction,
+			orderby: view.sort?.field,
+			search: view.search,
+			status: statusFilter?.value ?? [ 'publish', 'draft' ],
+		};
+	}, [ view ] );
+	const { records, isResolving, hasResolved, totalItems, totalPages } =
+		useEntityRecords< TaxonomyRecord >(
+			'postType',
+			'wp_user_taxonomy',
+			queryArgs
+		);
+	const data = useMemo(
+		() => ( records ?? [] ).map( toFormData ),
+		[ records ]
+	);
+	const paginationInfo = useMemo(
+		() => ( {
+			totalItems: totalItems ?? 0,
+			totalPages: totalPages ?? 0,
+		} ),
+		[ totalItems, totalPages ]
+	);
+	return (
+		<Page title={ __( 'Taxonomies' ) } actions={ <AddTaxonomy /> }>
+			<DataViews
+				data={ data }
+				fields={ fields }
+				actions={ taxonomyActions }
+				view={ view }
+				onChangeView={ setView }
+				isLoading={ isResolving || ! hasResolved }
+				paginationInfo={ paginationInfo }
+				defaultLayouts={ defaultLayouts }
+				getItemId={ ( item ) => String( item.id ) }
+			/>
+		</Page>
+	);
+}
+
+function Stage() {
+	return <TaxonomiesPage />;
+}
+
+export const stage = Stage;

--- a/routes/taxonomies/stage.tsx
+++ b/routes/taxonomies/stage.tsx
@@ -102,8 +102,4 @@ function TaxonomiesPage() {
 	);
 }
 
-function Stage() {
-	return <TaxonomiesPage />;
-}
-
-export const stage = Stage;
+export const stage = TaxonomiesPage;

--- a/routes/taxonomies/style.scss
+++ b/routes/taxonomies/style.scss
@@ -1,0 +1,91 @@
+@use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
+
+.dataviews-action-modal__edit-taxonomy {
+	justify-content: flex-end;
+	align-items: stretch;
+
+	.components-modal__frame {
+		margin: $grid-unit-20 $grid-unit-20 $grid-unit-20 0;
+		height: calc(100% - #{$grid-unit-20 * 2});
+		max-height: calc(100% - #{$grid-unit-20 * 2});
+		max-width: 400px;
+		border-radius: $radius-large;
+		position: relative;
+		animation-name: none;
+
+		@media (prefers-reduced-motion: no-preference) {
+			animation-name: edit-taxonomy-slide-in-right;
+			animation-duration: 0.2s;
+			animation-timing-function: ease-out;
+		}
+	}
+
+	&.is-animating-out .components-modal__frame {
+		animation-name: none;
+
+		@media (prefers-reduced-motion: no-preference) {
+			animation-name: edit-taxonomy-slide-out-right;
+			animation-duration: 0.2s;
+			animation-timing-function: ease-out;
+		}
+	}
+
+	.components-modal__content {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		padding: 0;
+	}
+
+	.dataviews-action-modal__edit-taxonomy-header {
+		flex: 0 0 auto;
+		padding: $grid-unit-15 $grid-unit-20 $grid-unit-15 $grid-unit-30;
+		border-bottom: 1px solid $gray-200;
+		background: #fff;
+	}
+
+	.dataviews-action-modal__edit-taxonomy-title {
+		margin: 0;
+		font-size: 13px;
+		font-weight: 600;
+		line-height: 1.4;
+	}
+
+	.dataviews-action-modal__edit-taxonomy-content {
+		flex: 1 1 auto;
+		min-height: 0;
+		overflow-y: auto;
+		padding: $grid-unit-20 $grid-unit-30;
+	}
+
+	.dataviews-action-modal__edit-taxonomy-footer {
+		flex: 0 0 auto;
+		padding: $grid-unit-20 $grid-unit-30;
+		border-top: 1px solid $gray-200;
+		background: #fff;
+
+		.components-button {
+			flex: 1;
+			justify-content: center;
+		}
+	}
+}
+
+@keyframes edit-taxonomy-slide-in-right {
+	from {
+		transform: translateX(100%);
+	}
+	to {
+		transform: translateX(0);
+	}
+}
+
+@keyframes edit-taxonomy-slide-out-right {
+	from {
+		transform: translateX(0);
+	}
+	to {
+		transform: translateX(100%);
+	}
+}

--- a/routes/taxonomies/utils.ts
+++ b/routes/taxonomies/utils.ts
@@ -1,0 +1,125 @@
+/**
+ * WordPress dependencies
+ */
+import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+
+export type TaxonomyRecord = {
+	id?: number;
+	slug: string;
+	status: 'publish' | 'draft';
+	title: { raw?: string; rendered: string };
+	content: { raw?: string; rendered: string };
+};
+
+export type StoredConfig = {
+	labels?: { singular_name?: string };
+	object_type?: string[];
+	public?: boolean;
+	hierarchical?: boolean;
+};
+
+/**
+ * Normalized in-memory shape used by all three consumers. REST rows are
+ * converted to this shape on load via `toFormData`, and back to the save
+ * payload via `serializeForSave`, so fields never have to JSON round-trip
+ * `content.raw` on every keystroke.
+ */
+export type TaxonomyFormData = {
+	id?: number;
+	slug: string;
+	status: 'publish' | 'draft';
+	title: { raw: string };
+	config: Required<
+		Pick< StoredConfig, 'object_type' | 'public' | 'hierarchical' >
+	> & {
+		labels: { singular_name: string };
+	};
+};
+
+export function parseConfig( raw?: string ): StoredConfig {
+	if ( ! raw ) {
+		return {};
+	}
+	try {
+		const parsed = JSON.parse( raw );
+		return typeof parsed === 'object' && parsed !== null ? parsed : {};
+	} catch {
+		return {};
+	}
+}
+
+export function toFormData( row: TaxonomyRecord ): TaxonomyFormData {
+	const parsed = parseConfig( row.content?.raw );
+	return {
+		id: row.id,
+		slug: row.slug,
+		status: row.status,
+		title: { raw: row.title.raw ?? '' },
+		config: {
+			labels: {
+				singular_name: parsed.labels?.singular_name ?? '',
+			},
+			object_type: Array.isArray( parsed.object_type )
+				? parsed.object_type
+				: [],
+			public: parsed.public ?? true,
+			hierarchical: parsed.hierarchical ?? false,
+		},
+	};
+}
+
+export function serializeForSave( data: TaxonomyFormData ) {
+	return {
+		...( data.id !== undefined ? { id: data.id } : {} ),
+		slug: data.slug,
+		status: data.status,
+		title: data.title.raw,
+		content: JSON.stringify( {
+			labels: { singular_name: data.config.labels.singular_name },
+			object_type: data.config.object_type,
+			public: data.config.public,
+			hierarchical: data.config.hierarchical,
+		} ),
+	};
+}
+
+export function usePublicPostTypes() {
+	const postTypes = useSelect(
+		( select ) => select( coreStore ).getPostTypes( { per_page: -1 } ),
+		[]
+	);
+	return useMemo( () => {
+		return postTypes
+			?.filter( ( { viewable }: any ) => viewable )
+			.sort( ( a: any, b: any ) => {
+				// Keep the built-in 'post' type at the top; sort the rest alphabetically.
+				if ( a.slug === 'post' || b.slug === 'post' ) {
+					return 0;
+				}
+				return a.name.localeCompare( b.name );
+			} );
+	}, [ postTypes ] );
+}
+
+export function useTakenTaxonomySlugs( excludeSlug?: string ): Set< string > {
+	const registered = useSelect(
+		( select ) => select( coreStore ).getTaxonomies(),
+		[]
+	);
+	const { records: drafts } = useEntityRecords< { slug: string } >(
+		'postType',
+		'wp_user_taxonomy',
+		{ per_page: 100, status: 'draft', context: 'edit' }
+	);
+	return useMemo( () => {
+		const set = new Set< string >();
+		( registered ?? [] ).forEach( ( t: any ) => set.add( t.slug ) );
+		( drafts ?? [] ).forEach( ( r ) => set.add( r.slug ) );
+		if ( excludeSlug ) {
+			set.delete( excludeSlug );
+		}
+		return set;
+	}, [ registered, drafts, excludeSlug ] );
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In the same spirit with: https://github.com/WordPress/gutenberg/pull/77487

This PR adds under a Gutenberg experiment the ability to add and edit custom taxonomies. For now you can manage only a few necessary fields and not all of them - we will iterate.

Let's see how far we can get with the current APIs and how possible it can be to support the majority of use cases for custom taxonomies (and later for post types), where it's assumed that the majority of the cases are the simpler ones.

## How
1. Just to start I used a CPT to get so much for free. This is implementation detail though and can be changed later. 
2. UI follows a bit what we have in site editor for other entities. Create/edit flows and UI will be revisited when more fields will be added.


## Testing Instructions
1. Enable the `Content types: manage custom taxonomies` experiment
3. Go to `Settings/Taxonomies` and play around with adding and editing taxonomies. 

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/2f0c7423-1551-45fd-92a8-01d904d638ff




## Use of AI Tools
Opus 4.7


