### PR TITLE
RTC: Tag persisted-doc init with dedicated origin to prevent false dirty state on load

### DIFF
--- a/packages/sync/src/config.ts
+++ b/packages/sync/src/config.ts
@@ -58,3 +58,15 @@ export const LOCAL_SYNC_MANAGER_ORIGIN = 'syncManager';
  * the CRDT document (and synced to peers) without creating undo levels.
  */
 export const LOCAL_UNDO_IGNORED_ORIGIN = 'gutenberg-undo-ignored';
+
+/**
+ * Origin string for applying a persisted CRDT document to a live Y.Doc at
+ * initial load. Transactions tagged with this origin are treated as
+ * initialization data rather than peer-originated edits, so the record
+ * observer in the sync manager skips dispatching `editRecord` for them.
+ *
+ * Reserved for internal sync-manager use. Providers must not tag their own
+ * transactions with this origin; doing so would cause the record observer
+ * to silently drop legitimate peer updates.
+ */
+export const PERSISTED_DOC_INIT_ORIGIN = 'persistedDocInit';

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -12,6 +12,7 @@ import {
 	CRDT_STATE_MAP_KEY,
 	CRDT_STATE_MAP_SAVED_AT_KEY as SAVED_AT_KEY,
 	LOCAL_SYNC_MANAGER_ORIGIN,
+	PERSISTED_DOC_INIT_ORIGIN,
 } from './config';
 import {
 	logPerformanceTiming,
@@ -212,6 +213,22 @@ export function createSyncManager( debug = false ): SyncManager {
 			_events: Y.YEvent< any >[],
 			transaction: Y.Transaction
 		): void => {
+			// Skip transactions that apply the persisted CRDT document at initial
+			// load. These are initialization data, not peer-originated edits — the
+			// reconciliation path in _applyPersistedCrdtDoc heals any drift between
+			// the persisted doc and the REST record without routing through the
+			// edit store, so we must not dispatch editRecord here or the editor
+			// would be falsely marked dirty on load / after publish.
+			if ( transaction.origin === PERSISTED_DOC_INIT_ORIGIN ) {
+				return;
+			}
+
+			// PERSISTED_DOC_INIT_ORIGIN transactions are also local and would
+			// be caught by the guard below, but we filter them explicitly
+			// above so the intent is clear and the suppression is preserved
+			// even if the locality semantics of the apply change in Yjs.
+			// This guard covers all other local non-undo origins (e.g.
+			// LOCAL_SYNC_MANAGER_ORIGIN from the reconciliation transact).
 			if (
 				transaction.local &&
 				! ( transaction.origin instanceof Y.UndoManager )
@@ -495,8 +512,13 @@ export function createSyncManager( debug = false ): SyncManager {
 		// IMPORTANT: Do not wrap this in a transaction with the local origin. It
 		// effectively advances the state vector for the current client, which causes
 		// Yjs to think that another client is using this client ID.
+		//
+		// Tag the apply with PERSISTED_DOC_INIT_ORIGIN so that the record observer
+		// above recognizes this as initialization data rather than a peer edit and
+		// does not dispatch editRecord for it. The reconciliation below still heals
+		// any drift between persisted doc and REST record.
 		const update = Y.encodeStateAsUpdateV2( tempDoc );
-		Y.applyUpdateV2( targetDoc, update );
+		Y.applyUpdateV2( targetDoc, update, PERSISTED_DOC_INIT_ORIGIN );
 
 		// Compute the differences between the persisted doc and the current
 		// record. This can happen when:

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -354,6 +354,58 @@ describe( 'SyncManager', () => {
 					1
 				);
 			} );
+
+			it( 'does not dispatch editRecord from the record observer when applying the persisted CRDT doc', async () => {
+				// Persisted CRDT doc has drifted from the REST record. Before
+				// PERSISTED_DOC_INIT_ORIGIN was introduced, the Y.Doc observer
+				// treated the apply as a peer update and dispatched editRecord
+				// with the drifted value, falsely dirtying the editor on load.
+				mockSyncConfig = {
+					...mockSyncConfig,
+					getPersistedCRDTDoc: jest.fn( () =>
+						createPersistedCRDTDoc( {
+							...mockRecord,
+							title: 'Drifted title from persisted CRDT doc',
+						} )
+					),
+				};
+
+				const manager = createSyncManager();
+
+				await manager.load(
+					mockSyncConfig,
+					'post',
+					'123',
+					mockRecord,
+					mockHandlers
+				);
+
+				// Flush microtasks so any async observer side effects would
+				// have had a chance to run.
+				await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+				// Negative: observer must not have dispatched editRecord for
+				// the persisted-doc init transaction.
+				expect( mockHandlers.editRecord ).not.toHaveBeenCalled();
+
+				// Positive: confirm the reconciliation path still ran, so
+				// this test cannot pass vacuously (e.g. if _applyPersistedCrdtDoc
+				// became a no-op, only the negative assertion above would hold).
+				expect(
+					mockSyncConfig.getChangesFromCRDTDoc
+				).toHaveBeenCalledTimes( 1 );
+				expect(
+					mockSyncConfig.applyChangesToCRDTDoc
+				).toHaveBeenCalledTimes( 1 );
+				expect(
+					mockSyncConfig.applyChangesToCRDTDoc
+				).toHaveBeenCalledWith( expect.any( Y.Doc ), {
+					title: mockRecord.title,
+				} );
+				expect( mockHandlers.persistCRDTDoc ).toHaveBeenCalledTimes(
+					1
+				);
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
## What?

See #76402 — related to RTC's sticky unsaved-changes behavior.

Adds a dedicated transaction origin (`PERSISTED_DOC_INIT_ORIGIN`) for the initial `Y.applyUpdateV2` call that hydrates a post's live Y.Doc from its persisted `_crdt_document` post_meta. The record observer (`onRecordUpdate`) now skips `editRecord` dispatch for transactions carrying that origin, so hydration of the persisted doc no longer masquerades as a peer edit. The reconciliation path that heals any drift between the persisted doc and the REST record is unchanged.

## Why?

With RTC enabled, opening a post whose persisted CRDT document has drifted from the REST record (e.g. after publish, when the server mutates `status` / `slug` / `link`, or after an out-of-band edit like WP-CLI) falsely puts the editor into a dirty state:

- Save button is active on load with no user edits.
- The browser's `beforeunload` warning fires when navigating away.
- On drafts, the primary action flips from **Publish** to **Save**, requiring users to "save" before they can publish.

This has been surfacing via customer reports on WordPress.com Atomic sites running Gutenberg ≥ 22.8 (when RTC became enabled by default in #75739).

Root cause: `_applyPersistedCrdtDoc` calls `Y.applyUpdateV2(targetDoc, update)` without an origin. The record observer then treats the resulting transaction as a peer update and dispatches `editRecord` with whatever fields differ between persisted CRDT and REST record. Those diffs land in the editor's non-transient edit bucket (since `status`, `slug`, `link` are not marked transient), and `hasEditsForEntityRecord` flips to `true`.

#75975 closed an adjacent staleness path (pending Y.Doc updates at save time) but did not cover server-side mutations that arrive *after* the CRDT doc is persisted — that's the window this PR addresses.

## How?

Three changes in `@wordpress/sync`, one additive test:

1. **`packages/sync/src/config.ts`** — export a new `PERSISTED_DOC_INIT_ORIGIN` string constant, documented as internal sync-manager use only.

2. **`packages/sync/src/manager.ts`** —
   - Import the new constant.
   - In `_applyPersistedCrdtDoc`, pass the origin as the third argument to `Y.applyUpdateV2`. Leaves the existing warning comment about not wrapping in a local-origin `transact()` intact; the third-arg origin doesn't advance the state vector as a local client (the polling provider already uses the same pattern for its own origin tagging).
   - In `onRecordUpdate`, add an early return when `transaction.origin === PERSISTED_DOC_INIT_ORIGIN`, placed before the existing `transaction.local && !(origin instanceof Y.UndoManager)` guard. An inline comment explains why the explicit guard is kept even though the subsequent one would also catch it — the intent needs to be clear and the suppression must survive any future change to Yjs locality semantics on the apply.

3. **`packages/sync/src/test/manager.ts`** — new regression test in the "persisted CRDT doc behavior" suite: sets up a drifted persisted doc, loads the entity, flushes the microtask queue, asserts `editRecord` was **not** called, and asserts positively that the reconciliation path still ran (`getChangesFromCRDTDoc` / `applyChangesToCRDTDoc` / `persistCRDTDoc` each invoked once with the expected drift-healing payload). The positive assertions are there specifically to prevent the test from passing vacuously if a future refactor short-circuits `_applyPersistedCrdtDoc`.

Peer-originated updates from providers continue to dispatch `editRecord` normally — provider transactions carry their own origins, not this one — so real-time collaborative typing is unaffected.

## Testing Instructions

Prerequisite: RTC enabled (Settings → Writing → "Enable real-time collaboration" is on).

**False dirty state on load**
- [ ] Open any previously-published post in the block editor.
- [ ] Save button is disabled on load.
- [ ] Closing the tab does not trigger a `beforeunload` warning.

**Post-publish state**
- [ ] Create a new draft, add a title and a paragraph block.
- [ ] Click Publish and confirm.
- [ ] Save button stays disabled immediately after the publish completes (no reload needed).
- [ ] Save button remains disabled after reloading the page.

**Publish button on drafts**
- [ ] Create a new draft with content.
- [ ] The top-right primary action reads **Publish** (not Save).

**Collaboration still works (regression)**
- [ ] Open the same post in two browsers signed in as different users.
- [ ] Type in browser A.
- [ ] Browser B receives the updates.
- [ ] Browser B's Save button becomes active (correct — there are real unsaved edits from the peer).

**Reconciliation still heals drift (regression)**
- [ ] With RTC off, publish a post (creates divergence between its `_crdt_document` and the row).
- [ ] Re-enable RTC and reload the editor.
- [ ] No false dirty state appears.
- [ ] The next save/load cycle brings `_crdt_document` back in sync with the REST record.

### Testing Instructions for Keyboard

No UI-visible changes; existing keyboard interactions are unchanged. Keyboard testing is not required.

## Screenshots or screencast

| Before | After |
| - | - |
| ![Before fix — Save button active and beforeunload warning firing on reload with no changes](https://raw.githubusercontent.com/Gustavo-Hilario/gutenberg/pr-77503-screenshots/before-fix.png) | ![After fix — Save button disabled on reload with no changes](https://raw.githubusercontent.com/Gustavo-Hilario/gutenberg/pr-77503-screenshots/after-fix.png) |
| Loading or reloading a published post with no user changes still shows the Save button as active, and the browser warning appears when trying to reload or exit the editor. | Loading or reloading the same post shows the Save button as inactive. No spurious beforeunload warning. |

## Use of AI Tools

This PR was developed with Anthropic's Claude as a pair-programming assistant, under my review. The root-cause analysis, code changes, and regression test were reviewed manually and through an additional automated code review pass (Claude + OpenAI Codex) before committing. All code has been read, understood, and tested by me.
