### PR TITLE
Design System: Add missing packages to Storybook introduction

### DIFF
--- a/storybook/stories/design-system/introduction.mdx
+++ b/storybook/stories/design-system/introduction.mdx
@@ -61,6 +61,8 @@ A curated library of SVG icons for use throughout WordPress interfaces:
 -   **Composable**: Each icon is exported as a React component and can be rendered directly or through the `<Icon>` wrapper with adjustable size.
 -   **Consistent visual language**: Drawn to a shared style so icons feel coherent wherever they appear across WordPress.
 
+See the [`@wordpress/icons` README](https://github.com/WordPress/gutenberg/tree/trunk/packages/icons) for usage details.
+
 ### Compositional Packages
 
 Higher-level compositional packages use the design system to provide solutions for common UI patterns:
@@ -73,9 +75,13 @@ A set of components and utilities for displaying, filtering, and editing lists o
 -   **Selection and editing**: `DataViewsPicker` optimizes the same experience for selecting items from a dataset, while `DataForm` handles creating and editing individual records.
 -   **Declarative fields**: Drive rendering and behavior through field definitions rather than bespoke markup for each column or form.
 
+See the [`@wordpress/dataviews` README](https://github.com/WordPress/gutenberg/tree/trunk/packages/dataviews) for API reference and usage guidance.
+
 #### Admin UI (`@wordpress/admin-ui`)
 
 High-level building blocks for consistent WordPress admin page layouts:
 
 -   **Page structure**: Abstractions for pages, sidebars, headers, and navigation that encode the expected shape of an admin screen.
 -   **Consistency by default**: Enforces a predictable admin experience across features without each team re-deriving the same layout patterns.
+
+See the [`@wordpress/admin-ui` README](https://github.com/WordPress/gutenberg/tree/trunk/packages/admin-ui) for API reference and usage guidance.

--- a/storybook/stories/design-system/introduction.mdx
+++ b/storybook/stories/design-system/introduction.mdx
@@ -23,9 +23,18 @@ For more context on the motivations and goals behind this work, see the [Design 
 
 ## What are the parts of the design system?
 
-The WordPress Design System consists of two complementary packages:
+Describing the parts of a design system can be challenging, because ideally every part of the application inherits and builds from the design system fundamentals in some way.
 
-### Theming (`@wordpress/theme`)
+In WordPress, when talking about the design system, we usually think of its scope including:
+
+- **Foundational packages** establish the fundamental components and theming behaviors. As a low-level implementation, they are meant to be highly flexible, but this flexibility can make them difficult to work with.
+- **Compositional packages** operate at a higher-level, providing developer conveniences for composing the foundational elements of the design system into common solutions. These components optimize for predictable user experiences, sometimes intentionally limiting configurability in service of consistency.
+
+### Foundational Packages
+
+The WordPress Design System consists of a few core packages:
+
+#### Theming (`@wordpress/theme`)
 
 The foundational layer that provides:
 
@@ -34,7 +43,7 @@ The foundational layer that provides:
 
 Explore the [Theme documentation](/story/design-system-theme-introduction--docs) to learn more about design tokens, the token architecture, and how to use `ThemeProvider`.
 
-### Components (`@wordpress/ui`)
+#### Components (`@wordpress/ui`)
 
 A library of React UI components built on the theme foundation:
 
@@ -43,3 +52,30 @@ A library of React UI components built on the theme foundation:
 -   **Accessible by default**: Built with WordPress accessibility coding standards in mind, including semantic markup, keyboard navigation, and proper color contrast.
 
 Explore the [Components documentation](/story/design-system-components-introduction--docs) to learn more about the component library and usage patterns.
+
+#### Icons (`@wordpress/icons`)
+
+A curated library of SVG icons for use throughout WordPress interfaces:
+
+-   **Comprehensive coverage**: A broad set of icons spanning common editor and admin actions.
+-   **Composable**: Each icon is exported as a React component and can be rendered directly or through the `<Icon>` wrapper with adjustable size.
+-   **Consistent visual language**: Drawn to a shared style so icons feel coherent wherever they appear across WordPress.
+
+### Compositional Packages
+
+Higher-level compositional packages use the design system to provide solutions for common UI patterns:
+
+#### DataViews (`@wordpress/dataviews`)
+
+A set of components and utilities for displaying, filtering, and editing lists of data:
+
+-   **Multiple layouts**: Render the same dataset as a table, grid, or list, with built-in search, filters, sorting, and pagination.
+-   **Selection and editing**: `DataViewsPicker` optimizes the same experience for selecting items from a dataset, while `DataForm` handles creating and editing individual records.
+-   **Declarative fields**: Drive rendering and behavior through field definitions rather than bespoke markup for each column or form.
+
+#### Admin UI (`@wordpress/admin-ui`)
+
+High-level building blocks for consistent WordPress admin page layouts:
+
+-   **Page structure**: Abstractions for pages, sidebars, headers, and navigation that encode the expected shape of an admin screen.
+-   **Consistency by default**: Enforces a predictable admin experience across features without each team re-deriving the same layout patterns.


### PR DESCRIPTION
## What?

Updates the [Design System "Introduction" page](https://wordpress.github.io/gutenberg/?path=/docs/design-system-introduction--docs) in Storybook to include all packages considered as part of the scope of the design system.

Already present:

- `@wordpress/ui`
- `@wordpress/theme`

Missing:

- `@wordpress/icons`
- `@wordpress/dataviews`
- `@wordpress/admin-ui`

While `@wordpress/ui` and `@wordpress/theme` are considered the essential core of the design system, it's an incomplete picture. Those low-level primitives are composed into packages like `@wordpress/dataviews`, which provide an improved developer experience for implementing common UI patterns _using design system building blocks_, and are themselves considered part of the design system, albeit operating at a higher level of abstraction.

## Why?

Clarifies scope and break-down of the design system, which in turn can help understand what belongs where, and who might be responsible for certain types of changes.

## How?

I added two new sub-sections to the existing "What are the parts of the design system" to differentiate "Foundational packages" and "Composite packages". I'm not fixed to these names; suggestions welcome 😄 

## Testing Instructions

Review updated documentation for accuracy.

## Use of AI Tools

I used Opus 4.7 for research into understanding how these packages describe themselves and common industry terminology for these types of layered abstractions. Content in specific package sections (e.g. `@wordpress/icons`) is AI-generated with human review and edit. All other content (new "What are the parts of the design system?" and "Foundational/Composite packages" intros) is authored by me.