### PR TITLE
Upload Media: Use .jpg extension for HEIC-to-JPEG client conversion

### DIFF
--- a/packages/upload-media/src/canvas-utils.ts
+++ b/packages/upload-media/src/canvas-utils.ts
@@ -46,7 +46,7 @@ export async function canvasConvertToJpeg(
 				quality,
 			} );
 
-			return new File( [ jpegBlob ], `${ baseName }.jpeg`, {
+			return new File( [ jpegBlob ], `${ baseName }.jpg`, {
 				type: 'image/jpeg',
 			} );
 		} finally {
@@ -87,7 +87,7 @@ export async function canvasConvertToJpeg(
 						quality,
 					} );
 
-					return new File( [ jpegBlob ], `${ baseName }.jpeg`, {
+					return new File( [ jpegBlob ], `${ baseName }.jpg`, {
 						type: 'image/jpeg',
 					} );
 				} finally {
@@ -147,7 +147,7 @@ export async function canvasConvertToJpeg(
 					quality,
 				} );
 
-				return new File( [ jpegBlob ], `${ baseName }.jpeg`, {
+				return new File( [ jpegBlob ], `${ baseName }.jpg`, {
 					type: 'image/jpeg',
 				} );
 			}

--- a/packages/upload-media/src/test/canvas-utils.ts
+++ b/packages/upload-media/src/test/canvas-utils.ts
@@ -65,7 +65,7 @@ describe( 'canvasConvertToJpeg', () => {
 			const result = await canvasConvertToJpeg( file );
 
 			expect( result ).toBeInstanceOf( File );
-			expect( result.name ).toBe( 'photo.jpeg' );
+			expect( result.name ).toBe( 'photo.jpg' );
 			expect( result.type ).toBe( 'image/jpeg' );
 			expect( mockBitmap.close ).toHaveBeenCalled();
 			expect( global.createImageBitmap ).toHaveBeenCalledWith( file );
@@ -100,7 +100,7 @@ describe( 'canvasConvertToJpeg', () => {
 			} );
 		} );
 
-		it( 'should strip the extension and use .jpeg', async () => {
+		it( 'should strip the extension and use .jpg', async () => {
 			const jpegBlob = new Blob( [ 'jpeg-data' ], {
 				type: 'image/jpeg',
 			} );
@@ -120,7 +120,7 @@ describe( 'canvasConvertToJpeg', () => {
 				type: 'image/heic',
 			} );
 			const result = await canvasConvertToJpeg( file );
-			expect( result.name ).toBe( 'my-photo.jpeg' );
+			expect( result.name ).toBe( 'my-photo.jpg' );
 		} );
 
 		it( 'should close the bitmap even if canvas context fails', async () => {


### PR DESCRIPTION
## What

Follow-up to #76731. When the client-side HEIC→JPEG converter in `canvasConvertToJpeg()` outputs a file, it now uses the `.jpg` extension instead of `.jpeg`. The MIME type remains `image/jpeg`.

See https://github.com/WordPress/gutenberg/issues/76732

## Why

`.jpg` is the more common and widely-recognized extension for JPEG images. Using it keeps filenames uploaded by the HEIC conversion path consistent with what users expect to see.

## How

- `packages/upload-media/src/canvas-utils.ts`: changed the three `new File( …, \`\${ baseName }.jpeg\`, … )` sites (one per decoding strategy) to `.jpg`.
- `packages/upload-media/src/test/canvas-utils.ts`: updated the two matching test expectations and the affected test title.

## Testing Instructions

1. Enable the client-side media processing feature.
2. Upload a HEIC image.
3. Confirm the resulting JPEG file in the media library uses a `.jpg` extension.

### Automated

- [x] `npm run test:unit -- --testPathPattern="upload-media/src/test/canvas-utils"` passes.