### PR TITLE
Media: Skip Document-Isolation-Policy in WordPress Playground

### DIFF
--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -304,6 +304,29 @@ function gutenberg_filter_mod_rewrite_rules( string $rules ): string {
 add_filter( 'mod_rewrite_rules', 'gutenberg_filter_mod_rewrite_rules' );
 
 /**
+ * Detects whether the current request is running in WordPress Playground.
+ *
+ * Playground runs PHP via WebAssembly (PHP.wasm) and serves WordPress inside a
+ * cross-origin-isolated iframe controlled by a ServiceWorker that already sets
+ * Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy. Injecting a
+ * Document-Isolation-Policy header on top of that would move the document into
+ * a separate agent cluster and break Playground's parent/iframe messaging.
+ *
+ * @return bool True if running inside Playground.
+ */
+function gutenberg_is_playground(): bool {
+	if ( ! empty( $_SERVER['SERVER_SOFTWARE'] ) && false !== stripos( (string) $_SERVER['SERVER_SOFTWARE'], 'wasm' ) ) {
+		return true;
+	}
+
+	if ( defined( 'WP_ENVIRONMENT_TYPE' ) && 'playground' === WP_ENVIRONMENT_TYPE ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
  * Returns the major Chromium version from the current request's User-Agent.
  *
  * Matches all Chromium-based browsers (Chrome, Edge, Opera, Brave).
@@ -331,6 +354,14 @@ function gutenberg_set_up_cross_origin_isolation() {
 	// Re-check the filter at action time, since other plugins (loaded after Gutenberg)
 	// may have added a filter to disable client-side media processing.
 	if ( ! gutenberg_is_client_side_media_processing_enabled() ) {
+		return;
+	}
+
+	// WordPress Playground is already cross-origin isolated via its ServiceWorker's
+	// COOP/COEP headers, so SharedArrayBuffer is available without DIP. Sending DIP
+	// would isolate the document into its own agent cluster and break Playground's
+	// parent/iframe communication.
+	if ( gutenberg_is_playground() ) {
 		return;
 	}
 
@@ -484,6 +515,13 @@ function gutenberg_add_crossorigin_attributes( string $html ): string {
  * could have assets loaded from a different domain.
  */
 function gutenberg_override_media_templates(): void {
+	// Playground does not need DIP, so the crossorigin attribute rewrite is
+	// unnecessary and would be skipped anyway — bail early to avoid the
+	// output buffer cost.
+	if ( gutenberg_is_playground() ) {
+		return;
+	}
+
 	remove_action( 'admin_footer', 'wp_print_media_templates' );
 	add_action(
 		'admin_footer',


### PR DESCRIPTION
## What?

Prevents the **Client-side media processing** experiment from crashing the editor UI when run inside WordPress Playground, by skipping Gutenberg's `Document-Isolation-Policy` header in that environment.

Fixes #75941. Related: [WordPress/wordpress-playground#2954](https://github.com/WordPress/wordpress-playground/issues/2954).

## Why?

Gutenberg's client-side media pipeline sends `Document-Isolation-Policy: isolate-and-credentialless` on block-editor screens so `wasm-vips` can use `SharedArrayBuffer`. DIP moves the document into its own agent cluster, which severs the synchronous `window.parent` access Playground's parent/iframe architecture depends on — the editor UI blows up the moment the experiment is enabled.

### Honest framing of what this PR does (and doesn't do)

This PR only **stops the crash**. It does **not** by itself make client-side media functional in Playground.

Why: Playground does not currently provide any form of cross-origin isolation (no COOP/COEP/DIP on any of its responses — I verified with direct `fetch()` against `/`, `/remote.html`, and `/scope:*/wp-admin/*`). Without isolation, `crossOriginIsolated` is `false` and `SharedArrayBuffer` is `undefined`, and Gutenberg's JS-side feature-detection (`packages/upload-media/src/feature-detection.ts`) correctly short-circuits with the message *"SharedArrayBuffer is not available. This may be due to missing cross-origin isolation headers."*

So the state of play is:

| | Editor crashes? | Client-side media works? |
|---|---|---|
| Trunk (pre-PR) | 💥 | — |
| This PR | ✓ no crash | ✗ graceful runtime disable (no SAB) |
| Goal | ✓ | ✓ — **needs a Playground-side change** to enable cross-origin isolation |

There is also already a `__return_false` filter for `wp_client_side_media_processing_enabled` in Playground's mu-plugin that was added during an earlier DIP+COEP conflict (`packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php`). With this PR landed, the original reason for that filter (DIP crashing the iframe) no longer applies, but Playground still needs to provide isolation for the feature to actually light up. A companion Playground issue is being filed to track that work.

## How?

- Adds a `gutenberg_is_playground()` helper in `lib/media/load.php` that detects the runtime via `$_SERVER['SERVER_SOFTWARE']` containing `wasm` (Playground reports `PHP.wasm`, verified against its Site Health debug output), with a `WP_ENVIRONMENT_TYPE === 'playground'` fallback.
- Early-returns from `gutenberg_set_up_cross_origin_isolation()` in Playground, so no DIP header is sent.
- Early-returns from `gutenberg_override_media_templates()` in Playground, so the `crossorigin="anonymous"` template rewrite (only meaningful under DIP) is skipped.

Gutenberg's JS-side feature-detection handles the rest: with no SAB, the client-side media path silently defers to server-side processing.

## Testing Instructions

1. Open the Playground preview for this PR: [playground.wordpress.net/?gutenberg-pr=77507](https://playground.wordpress.net/?gutenberg-pr=77507#%7B%22landingPage%22%3A%22%2Fwp-admin%2Fpost-new.php%22%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%5D%7D).
2. Navigate to Add New Post. Confirm the editor loads (does not crash).
3. Verify no `Document-Isolation-Policy` header is sent for `/wp-admin/*` responses (DevTools → Network).
4. Verify `crossOriginIsolated` is `false` inside the iframe (DevTools console) — this is expected; it's why client-side media remains runtime-disabled in Playground.
5. Uploads still work via server-side processing.

Outside of Playground, behavior is unchanged — DIP is still sent on Chromium ≥137 and client-side media works as before.

### Testing Instructions for Keyboard

N/A — server-side header change, no keyboard-facing UI.

## Types of changes

Bug fix.

## Checklist

- [x] My code is tested.
- [x] My code follows the WordPress Coding Standards.
- [x] My code has proper inline documentation.
- [ ] I've included developer documentation if appropriate.
- [ ] I've updated all React Native files affected by the changes. (N/A)
- [ ] I've tested my changes with keyboard and screen readers. (N/A)