### PR TITLE
wp-build: Add menuSlug and menuSlugAdmin options for admin page URLs

### DIFF
--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- Add a `menuSlug` option to `wpPlugin.pages` entries, letting admin page URLs be customized independently from the page `id`.
+- Add `menuSlug` and `menuSlugAdmin` options to `wpPlugin.pages` entries, letting admin page URLs be customized independently from the page `id` (including overriding the default `-wp-admin` suffix for WP-Admin mode).
 
 ## 0.12.0 (2026-04-15)
 

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Add a `menuSlug` option to `wpPlugin.pages` entries, letting admin page URLs be customized independently from the page `id`.
+
 ## 0.12.0 (2026-04-15)
 
 ## 0.11.0 (2026-04-01)

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -280,7 +280,7 @@ Pages can be defined as simple strings or as objects with initialization modules
 - **Object format**: `{ "id": "page-slug", "init": ["@scope/package"], "menuSlug": "custom-url" }` - Page with optional init modules and a custom menu slug
   - **`id`** (required): The page identifier. Used for generated PHP function names, action hook names, and generated file paths.
   - **`init`** (optional): Array of script module IDs to execute during page initialization
-  - **`menuSlug`** (optional): The menu slug passed to `add_submenu_page()` / `add_menu_page()`, which controls the admin URL (`admin.php?page={menuSlug}`). Defaults to `{id}-wp-admin`. Set this to customize the URL independently from `id`.
+  - **`menuSlug`** (optional): The menu slug passed to `add_menu_page()` (full-page mode) or `add_submenu_page()` (WP-Admin mode), which controls the admin URL (`admin.php?page={menuSlug}`). When set, it applies to both modes. When omitted, full-page mode falls back to `{id}` and WP-Admin mode to `{id}-wp-admin`. Set this to customize the URL independently from `id`.
 
 **Generated Files:**
 

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -280,8 +280,8 @@ Pages can be defined as simple strings or as objects with initialization modules
 - **Object format**: `{ "id": "page-slug", "init": ["@scope/package"], "menuSlug": "custom-url" }` - Page with optional init modules and a custom menu slug
   - **`id`** (required): The page identifier. Used for generated PHP function names, action hook names, and generated file paths.
   - **`init`** (optional): Array of script module IDs to execute during page initialization
-  - **`menuSlug`** (optional): The menu slug for full-page mode (`admin.php?page={menuSlug}`). Defaults to `{id}`.
-  - **`menuSlugAdmin`** (optional): The menu slug for WP-Admin mode (`admin.php?page={menuSlugAdmin}`). Defaults to `{menuSlug}-wp-admin`. Set this to use an arbitrary URL (without the `-wp-admin` suffix). `menuSlug` and `menuSlugAdmin` must not resolve to the same value or the build will fail, because both templates listen on `$_GET['page']` and would collide.
+  - **`menuSlug`** (optional): The menu slug for full-page mode (`admin.php?page={menuSlug}`). Defaults to `{id}`. Must only contain lowercase alphanumerics, dashes, and underscores (compatible with WordPress `sanitize_key()`).
+  - **`menuSlugAdmin`** (optional): The menu slug for WP-Admin mode (`admin.php?page={menuSlugAdmin}`). Defaults to `{menuSlug}-wp-admin`. Set this to use an arbitrary URL (without the `-wp-admin` suffix). Same character restrictions as `menuSlug`. `menuSlug` and `menuSlugAdmin` must not resolve to the same value or the build will fail, because both templates listen on `$_GET['page']` and would collide.
 
 **Generated Files:**
 

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -280,7 +280,7 @@ Pages can be defined as simple strings or as objects with initialization modules
 - **Object format**: `{ "id": "page-slug", "init": ["@scope/package"], "menuSlug": "custom-url" }` - Page with optional init modules and a custom menu slug
   - **`id`** (required): The page identifier. Used for generated PHP function names, action hook names, and generated file paths.
   - **`init`** (optional): Array of script module IDs to execute during page initialization
-  - **`menuSlug`** (optional): The menu slug passed to `add_menu_page()` (full-page mode) or `add_submenu_page()` (WP-Admin mode), which controls the admin URL (`admin.php?page={menuSlug}`). When set, it applies to both modes. When omitted, full-page mode falls back to `{id}` and WP-Admin mode to `{id}-wp-admin`. Set this to customize the URL independently from `id`.
+  - **`menuSlug`** (optional): The base menu slug used to build the admin URL (`admin.php?page=...`). Full-page mode uses `{menuSlug}` as-is. WP-Admin mode appends `-wp-admin` by convention, producing `{menuSlug}-wp-admin`. Defaults to `{id}`. Set this to customize the URL independently from `id`.
 
 **Generated Files:**
 

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -280,7 +280,8 @@ Pages can be defined as simple strings or as objects with initialization modules
 - **Object format**: `{ "id": "page-slug", "init": ["@scope/package"], "menuSlug": "custom-url" }` - Page with optional init modules and a custom menu slug
   - **`id`** (required): The page identifier. Used for generated PHP function names, action hook names, and generated file paths.
   - **`init`** (optional): Array of script module IDs to execute during page initialization
-  - **`menuSlug`** (optional): The base menu slug used to build the admin URL (`admin.php?page=...`). Full-page mode uses `{menuSlug}` as-is. WP-Admin mode appends `-wp-admin` by convention, producing `{menuSlug}-wp-admin`. Defaults to `{id}`. Set this to customize the URL independently from `id`.
+  - **`menuSlug`** (optional): The menu slug for full-page mode (`admin.php?page={menuSlug}`). Defaults to `{id}`.
+  - **`menuSlugAdmin`** (optional): The menu slug for WP-Admin mode (`admin.php?page={menuSlugAdmin}`). Defaults to `{menuSlug}-wp-admin`. Set this to use an arbitrary URL (without the `-wp-admin` suffix). `menuSlug` and `menuSlugAdmin` must not resolve to the same value or the build will fail, because both templates listen on `$_GET['page']` and would collide.
 
 **Generated Files:**
 

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -277,9 +277,10 @@ Pages can be defined as simple strings or as objects with initialization modules
 
 **Page Configuration:**
 - **String format**: `"my-admin-page"` - Simple page with no init modules
-- **Object format**: `{ "id": "page-slug", "init": ["@scope/package"] }` - Page with optional init modules
-  - **`id`** (required): The page slug used in WordPress admin URLs
+- **Object format**: `{ "id": "page-slug", "init": ["@scope/package"], "menuSlug": "custom-url" }` - Page with optional init modules and a custom menu slug
+  - **`id`** (required): The page identifier. Used for generated PHP function names, action hook names, and generated file paths.
   - **`init`** (optional): Array of script module IDs to execute during page initialization
+  - **`menuSlug`** (optional): The menu slug passed to `add_submenu_page()` / `add_menu_page()`, which controls the admin URL (`admin.php?page={menuSlug}`). Defaults to `{id}-wp-admin`. Set this to customize the URL independently from `id`.
 
 **Generated Files:**
 
@@ -307,7 +308,7 @@ add_submenu_page(
 
 Note: The callback function name is prefixed with your plugin name (from `wpPlugin.name` in root `package.json`). For example, if your plugin name is `my-plugin`, the function will be `my_plugin_my_admin_page_wp_admin_render_page`.
 
-The page slug is `my-admin-page-wp-admin` (your page ID + `-wp-admin`). WordPress routes all requests to this callback, and the JavaScript router handles internal navigation.
+The menu slug defaults to `my-admin-page-wp-admin` (your page `id` + `-wp-admin`) and can be overridden via the `menuSlug` option in `wpPlugin.pages`. WordPress routes all requests to this callback, and the JavaScript router handles internal navigation.
 
 **Deep linking with the `p` query parameter:**
 

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1161,6 +1161,13 @@ async function generatePagesPhp( pageData, replacements ) {
 						.join( '\n' )
 				: '\t\t\t// No init modules configured';
 
+		// The menuSlug option (single value) customizes the admin URL for both
+		// page modes. When unset, each mode falls back to its conventional
+		// default: full-page mode uses the page id, WP-Admin mode appends
+		// `-wp-admin`.
+		const fullPageMenuSlug = page.menuSlug || page.slug;
+		const wpAdminMenuSlug = page.menuSlug || `${ page.slug }-wp-admin`;
+
 		const templateReplacements = {
 			...replacements,
 			'{{PAGE_SLUG}}': page.slug,
@@ -1168,7 +1175,8 @@ async function generatePagesPhp( pageData, replacements ) {
 			'{{PREFIX}}': prefixUnderscore,
 			'{{INIT_MODULES_PHP_ARRAY}}': initModulesPhp,
 			'{{INIT_MODULES_JSON}}': JSON.stringify( page.initModules ),
-			'{{MENU_SLUG}}': page.menuSlug,
+			'{{FULL_PAGE_MENU_SLUG}}': fullPageMenuSlug,
+			'{{WP_ADMIN_MENU_SLUG}}': wpAdminMenuSlug,
 		};
 
 		// Generate both page.php and page-wp-admin.php
@@ -1819,7 +1827,7 @@ async function buildAll( baseUrlExpression ) {
 				id: page,
 				init: [],
 				title: undefined,
-				menuSlug: `${ page }-wp-admin`,
+				menuSlug: undefined,
 			};
 		}
 		return {
@@ -1827,7 +1835,7 @@ async function buildAll( baseUrlExpression ) {
 			init: page.init || [],
 			title: page.title || undefined,
 			experimental: page.experimental || false,
-			menuSlug: page.menuSlug || `${ page.id }-wp-admin`,
+			menuSlug: page.menuSlug || undefined,
 		};
 	} );
 

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1161,10 +1161,20 @@ async function generatePagesPhp( pageData, replacements ) {
 						.join( '\n' )
 				: '\t\t\t// No init modules configured';
 
-		// The menuSlug option controls the admin URL base. Full-page mode uses
-		// it as-is; WP-Admin mode appends `-wp-admin` by convention. When
-		// unset, it falls back to the page id.
+		// Full-page mode uses `menuSlug` (defaults to the page id).
+		// WP-Admin mode uses `menuSlugAdmin` (defaults to `{menuSlug}-wp-admin`).
+		// Both templates are always generated and register hooks on every
+		// request, so the two slugs must differ to avoid the full-page
+		// `admin_init` hook intercepting WP-Admin mode requests.
 		const menuSlug = page.menuSlug || page.slug;
+		const menuSlugAdmin = page.menuSlugAdmin || `${ menuSlug }-wp-admin`;
+		if ( menuSlug === menuSlugAdmin ) {
+			throw new Error(
+				`Page "${ page.slug }": menuSlug and menuSlugAdmin must differ ` +
+					`(both resolved to "${ menuSlug }"). The full-page and ` +
+					`WP-Admin templates both listen on $_GET['page'] and would collide.`
+			);
+		}
 
 		const templateReplacements = {
 			...replacements,
@@ -1174,6 +1184,7 @@ async function generatePagesPhp( pageData, replacements ) {
 			'{{INIT_MODULES_PHP_ARRAY}}': initModulesPhp,
 			'{{INIT_MODULES_JSON}}': JSON.stringify( page.initModules ),
 			'{{MENU_SLUG}}': menuSlug,
+			'{{MENU_SLUG_ADMIN}}': menuSlugAdmin,
 		};
 
 		// Generate both page.php and page-wp-admin.php
@@ -1825,6 +1836,7 @@ async function buildAll( baseUrlExpression ) {
 				init: [],
 				title: undefined,
 				menuSlug: undefined,
+				menuSlugAdmin: undefined,
 			};
 		}
 		return {
@@ -1833,6 +1845,7 @@ async function buildAll( baseUrlExpression ) {
 			title: page.title || undefined,
 			experimental: page.experimental || false,
 			menuSlug: page.menuSlug || undefined,
+			menuSlugAdmin: page.menuSlugAdmin || undefined,
 		};
 	} );
 
@@ -1855,6 +1868,7 @@ async function buildAll( baseUrlExpression ) {
 			initModules: page.init,
 			title: page.title,
 			menuSlug: page.menuSlug,
+			menuSlugAdmin: page.menuSlugAdmin,
 		};
 	} );
 

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1161,12 +1161,10 @@ async function generatePagesPhp( pageData, replacements ) {
 						.join( '\n' )
 				: '\t\t\t// No init modules configured';
 
-		// The menuSlug option (single value) customizes the admin URL for both
-		// page modes. When unset, each mode falls back to its conventional
-		// default: full-page mode uses the page id, WP-Admin mode appends
-		// `-wp-admin`.
-		const fullPageMenuSlug = page.menuSlug || page.slug;
-		const wpAdminMenuSlug = page.menuSlug || `${ page.slug }-wp-admin`;
+		// The menuSlug option controls the admin URL base. Full-page mode uses
+		// it as-is; WP-Admin mode appends `-wp-admin` by convention. When
+		// unset, it falls back to the page id.
+		const menuSlug = page.menuSlug || page.slug;
 
 		const templateReplacements = {
 			...replacements,
@@ -1175,8 +1173,7 @@ async function generatePagesPhp( pageData, replacements ) {
 			'{{PREFIX}}': prefixUnderscore,
 			'{{INIT_MODULES_PHP_ARRAY}}': initModulesPhp,
 			'{{INIT_MODULES_JSON}}': JSON.stringify( page.initModules ),
-			'{{FULL_PAGE_MENU_SLUG}}': fullPageMenuSlug,
-			'{{WP_ADMIN_MENU_SLUG}}': wpAdminMenuSlug,
+			'{{MENU_SLUG}}': menuSlug,
 		};
 
 		// Generate both page.php and page-wp-admin.php

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1171,6 +1171,18 @@ async function generatePagesPhp( pageData, replacements ) {
 				`Page "${ page.slug }": menuSlug and menuSlugAdmin must differ (both resolved to "${ menuSlug }").`
 			);
 		}
+		// Match WordPress `sanitize_key()`: lowercase alphanumerics, dashes, underscores.
+		const sanitizeKeyPattern = /^[a-z0-9_-]+$/;
+		for ( const [ key, value ] of [
+			[ 'menuSlug', menuSlug ],
+			[ 'menuSlugAdmin', menuSlugAdmin ],
+		] ) {
+			if ( ! sanitizeKeyPattern.test( value ) ) {
+				throw new Error(
+					`Page "${ page.slug }": ${ key } "${ value }" must only contain lowercase alphanumerics, dashes, and underscores.`
+				);
+			}
+		}
 
 		const templateReplacements = {
 			...replacements,

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1168,6 +1168,7 @@ async function generatePagesPhp( pageData, replacements ) {
 			'{{PREFIX}}': prefixUnderscore,
 			'{{INIT_MODULES_PHP_ARRAY}}': initModulesPhp,
 			'{{INIT_MODULES_JSON}}': JSON.stringify( page.initModules ),
+			'{{MENU_SLUG}}': page.menuSlug,
 		};
 
 		// Generate both page.php and page-wp-admin.php
@@ -1814,13 +1815,19 @@ async function buildAll( baseUrlExpression ) {
 	// Normalize PAGES config to support both string and object formats
 	const normalizedPages = PAGES.map( ( page ) => {
 		if ( typeof page === 'string' ) {
-			return { id: page, init: [], title: undefined };
+			return {
+				id: page,
+				init: [],
+				title: undefined,
+				menuSlug: `${ page }-wp-admin`,
+			};
 		}
 		return {
 			id: page.id,
 			init: page.init || [],
 			title: page.title || undefined,
 			experimental: page.experimental || false,
+			menuSlug: page.menuSlug || `${ page.id }-wp-admin`,
 		};
 	} );
 
@@ -1842,6 +1849,7 @@ async function buildAll( baseUrlExpression ) {
 			routes: pageRoutes,
 			initModules: page.init,
 			title: page.title,
+			menuSlug: page.menuSlug,
 		};
 	} );
 

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1161,18 +1161,14 @@ async function generatePagesPhp( pageData, replacements ) {
 						.join( '\n' )
 				: '\t\t\t// No init modules configured';
 
-		// Full-page mode uses `menuSlug` (defaults to the page id).
-		// WP-Admin mode uses `menuSlugAdmin` (defaults to `{menuSlug}-wp-admin`).
-		// Both templates are always generated and register hooks on every
-		// request, so the two slugs must differ to avoid the full-page
-		// `admin_init` hook intercepting WP-Admin mode requests.
+		// Both templates register hooks on every request, so `menuSlug`
+		// (full-page) and `menuSlugAdmin` (WP-Admin) must differ to avoid
+		// the full-page `admin_init` hook intercepting WP-Admin requests.
 		const menuSlug = page.menuSlug || page.slug;
 		const menuSlugAdmin = page.menuSlugAdmin || `${ menuSlug }-wp-admin`;
 		if ( menuSlug === menuSlugAdmin ) {
 			throw new Error(
-				`Page "${ page.slug }": menuSlug and menuSlugAdmin must differ ` +
-					`(both resolved to "${ menuSlug }"). The full-page and ` +
-					`WP-Admin templates both listen on $_GET['page'] and would collide.`
+				`Page "${ page.slug }": menuSlug and menuSlugAdmin must differ (both resolved to "${ menuSlug }").`
 			);
 		}
 

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -119,11 +119,11 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_preload_data() {
  */
 function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suffix ) {
 	// Check all possible ways this page can be accessed:
-	// 1. Menu page via admin.php?page={{MENU_SLUG}}-wp-admin (plugin)
+	// 1. Menu page via admin.php?page={{MENU_SLUG_ADMIN}} (plugin)
 	// 2. Direct file via {{PAGE_SLUG}}.php (Core) - screen ID will be '{{PAGE_SLUG}}'
 	$current_screen = get_current_screen();
 	$is_our_page = (
-		( isset( $_GET['page'] ) && '{{MENU_SLUG}}-wp-admin' === $_GET['page'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		( isset( $_GET['page'] ) && '{{MENU_SLUG_ADMIN}}' === $_GET['page'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		( $current_screen && '{{PAGE_SLUG}}' === $current_screen->id )
 	);
 

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -119,11 +119,11 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_preload_data() {
  */
 function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suffix ) {
 	// Check all possible ways this page can be accessed:
-	// 1. Menu page via admin.php?page={{WP_ADMIN_MENU_SLUG}} (plugin)
+	// 1. Menu page via admin.php?page={{MENU_SLUG}}-wp-admin (plugin)
 	// 2. Direct file via {{PAGE_SLUG}}.php (Core) - screen ID will be '{{PAGE_SLUG}}'
 	$current_screen = get_current_screen();
 	$is_our_page = (
-		( isset( $_GET['page'] ) && '{{WP_ADMIN_MENU_SLUG}}' === $_GET['page'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		( isset( $_GET['page'] ) && '{{MENU_SLUG}}-wp-admin' === $_GET['page'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		( $current_screen && '{{PAGE_SLUG}}' === $current_screen->id )
 	);
 

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -119,11 +119,11 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_preload_data() {
  */
 function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suffix ) {
 	// Check all possible ways this page can be accessed:
-	// 1. Menu page via admin.php?page={{MENU_SLUG}} (plugin)
+	// 1. Menu page via admin.php?page={{WP_ADMIN_MENU_SLUG}} (plugin)
 	// 2. Direct file via {{PAGE_SLUG}}.php (Core) - screen ID will be '{{PAGE_SLUG}}'
 	$current_screen = get_current_screen();
 	$is_our_page = (
-		( isset( $_GET['page'] ) && '{{MENU_SLUG}}' === $_GET['page'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		( isset( $_GET['page'] ) && '{{WP_ADMIN_MENU_SLUG}}' === $_GET['page'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		( $current_screen && '{{PAGE_SLUG}}' === $current_screen->id )
 	);
 

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -119,11 +119,11 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_preload_data() {
  */
 function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suffix ) {
 	// Check all possible ways this page can be accessed:
-	// 1. Menu page via admin.php?page={{PAGE_SLUG}}-wp-admin (plugin)
+	// 1. Menu page via admin.php?page={{MENU_SLUG}} (plugin)
 	// 2. Direct file via {{PAGE_SLUG}}.php (Core) - screen ID will be '{{PAGE_SLUG}}'
 	$current_screen = get_current_screen();
 	$is_our_page = (
-		( isset( $_GET['page'] ) && '{{PAGE_SLUG}}-wp-admin' === $_GET['page'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		( isset( $_GET['page'] ) && '{{MENU_SLUG}}' === $_GET['page'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		( $current_screen && '{{PAGE_SLUG}}' === $current_screen->id )
 	);
 

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -307,7 +307,7 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
  */
 function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_intercept_render() {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	if ( isset( $_GET['page'] ) && '{{FULL_PAGE_MENU_SLUG}}' === $_GET['page'] ) {
+	if ( isset( $_GET['page'] ) && '{{MENU_SLUG}}' === $_GET['page'] ) {
 		{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page();
 		exit;
 	}

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -307,7 +307,7 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
  */
 function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_intercept_render() {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	if ( isset( $_GET['page'] ) && '{{PAGE_SLUG}}' === $_GET['page'] ) {
+	if ( isset( $_GET['page'] ) && '{{FULL_PAGE_MENU_SLUG}}' === $_GET['page'] ) {
 		{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page();
 		exit;
 	}


### PR DESCRIPTION
## What?

This PR enables manual setting of menu slugs in wp-build, allowing pages to be exposed at arbitrary URLs in both wp-admin and full-page modes.

## Why?

The reason for submitting this PR is #77443. We found that when rebuilding the Gutenberg experimental settings page with wp-build, the URL is forced to change as follows:

- Before: http://localhost:8888/wp-admin/admin.php?page=gutenberg-experiments
- After: http://localhost:8888/wp-admin/admin.php?page=experiments-wp-admin

We need to implement redirect processing for users who may have bookmarked old URLs. I believe this could be a barrier for many developers when we recommend page development based on wp-build.

## How?

Add options `menuSlug` and `menuSlugAdmin` to allow changing the menu slug for each of the two modes. Each menu slug must be unique.

## Testing Instructions

The following is an example of changing the URL of the Connectors page from `?page=options-connectors-wp-admin` to `?page=options-connectors`.

```diff
diff --git a/lib/experimental/connectors/load.php b/lib/experimental/connectors/load.php
index 7e60135edb4..65fbf2e9b44 100644
--- a/lib/experimental/connectors/load.php
+++ b/lib/experimental/connectors/load.php
@@ -28,7 +28,7 @@ function _gutenberg_connectors_add_settings_menu_item(): void {
                __( 'Connectors', 'gutenberg' ),
                __( 'Connectors', 'gutenberg' ),
                'manage_options',
-               'options-connectors-wp-admin',
+               'options-connectors',
                'gutenberg_options_connectors_wp_admin_render_page',
                1
        );
diff --git a/package.json b/package.json
index ca046fbfa0d..3ad3380cd52 100644
--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
                                "experimental": true
                        },
                        "font-library",
-                       "options-connectors",
+                       {
+                               "id": "options-connectors",
+                               "menuSlug": "options-connectors-single",
+                               "menuSlugAdmin": "options-connectors"
+                       },
                        "guidelines",
                        "taxonomies"
                ]
```

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Claude Code was used to investigate the existing template code paths (plugin vs. Core build modes from #75844), work through the design tradeoffs, draft the implementation, and author the documentation and commit messages. All changes were reviewed by the author before committing.
