### PR TITLE
Fix: use node_modules/.bin/stylelint to avoid npm warnings on Node 24

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -37,7 +37,7 @@ jobs:
                 node: ['20', '22', '24']
                 shard: ['1/4', '2/4', '3/4', '4/4']
                 exclude:
-                    # On PRs: Only test Node 20 and 24 (temporarily including 24 to verify Node 24 failures)
+                    # On PRs: Only test Node 20 and 24 (temporarily including 24 to verify Node 24 fix)
                     - event: 'pull_request'
                       node: '22'
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -37,11 +37,9 @@ jobs:
                 node: ['20', '22', '24']
                 shard: ['1/4', '2/4', '3/4', '4/4']
                 exclude:
-                    # On PRs: Only test Node 20
+                    # On PRs: Only test Node 20 and 24 (temporarily including 24 to verify Node 24 failures)
                     - event: 'pull_request'
                       node: '22'
-                    - event: 'pull_request'
-                      node: '24'
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -37,9 +37,11 @@ jobs:
                 node: ['20', '22', '24']
                 shard: ['1/4', '2/4', '3/4', '4/4']
                 exclude:
-                    # On PRs: Only test Node 20 and 24 (temporarily including 24 to verify Node 24 fix)
+                    # On PRs: Only test Node 20
                     - event: 'pull_request'
                       node: '22'
+                    - event: 'pull_request'
+                      node: '24'
 
         steps:
             - name: Checkout repository

--- a/packages/stylelint-config/test/utils/index.js
+++ b/packages/stylelint-config/test/utils/index.js
@@ -8,7 +8,7 @@ const util = require( 'node:util' ),
 const execute = util.promisify( childProcess.exec );
 
 const generateStylelintCommand = ( filename ) =>
-	'npx stylelint ' +
+	'node_modules/.bin/stylelint ' +
 	path.resolve( __dirname, '../', filename ) +
 	' -c' +
 	path.resolve( __dirname, '../', './.stylelintrc.tests.json' ) +

--- a/packages/theme/src/stylelint-plugins/test/utils/index.ts
+++ b/packages/theme/src/stylelint-plugins/test/utils/index.ts
@@ -8,7 +8,7 @@ const generateStylelintCommand = (
 	filename: string,
 	configFile: string
 ): string =>
-	'npx stylelint ' +
+	'node_modules/.bin/stylelint ' +
 	path.resolve( __dirname, '../', filename ) +
 	' -c ' +
 	path.resolve( __dirname, '../', configFile ) +


### PR DESCRIPTION
## Problem

After #77063 merged, all Node.js 24 CI shards fail with:

```
SyntaxError: Unexpected token 'p', "npm warn Un"... is not valid JSON
```

The test utility in `packages/theme/src/stylelint-plugins/test/utils/index.ts` runs `npx stylelint --formatter json` and parses the output from `stderr`. On Node 24 / npm 10, running the test suite via `npm run test:unit -- --shard --cacheDirectory` causes npm to emit `npm warn Unknown cli config "--shard"` / `npm warn Unknown cli config "--cacheDirectory"` warnings to stderr. These warnings bleed into every `npx` invocation's stderr, corrupting the stylelint JSON output.

Reported in: https://github.com/WordPress/gutenberg/pull/77063#issuecomment-4286228156

## Fix

Replace `npx stylelint` with `node_modules/.bin/stylelint`. This invokes the binary directly, bypassing npm entirely, so no npm warnings can pollute stderr.

## Verification

This PR temporarily enables Node.js 24 in the PR unit test matrix (first commit) to confirm the failure, then applies the fix (second commit, to be pushed once CI shows the failure on the first commit).

The Node 24 workflow exclusion will be restored to its original state in this PR.