### PR TITLE
[Video Block]: Update z-index for tracks popover to ensure proper stacking context

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -145,6 +145,7 @@ $z-layers: (
 	// Show media replace flow and similar popovers beneath the media modal when its open.
 	".components-popover.block-editor-media-replace-flow__options": 99999,
 	".components-popover.block-editor-inspector-list-view-content-popover": 99999,
+	".components-popover.block-library-video-tracks-editor": 99999,
 
 	// ...Except for popovers immediately beneath wp-admin menu on large breakpoints
 	".components-popover.block-editor-inserter__popover": 99999,

--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -27,6 +27,11 @@
 	z-index: z-index("{core/video track editor popover}");
 }
 
+// Use a lower z-index for the popover when a modal is open to prevent it appearing atop the modal.
+.modal-open .block-library-video-tracks-editor {
+	z-index: z-index(".components-popover.block-library-video-tracks-editor");
+}
+
 .block-library-video-tracks-editor__track-list-track {
 	padding-left: $grid-unit-15;
 }


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/issues/77515

Fixes an issue where the Text Tracks popover appears above the Media Modal. The change ensures the popover is rendered beneath the modal by correcting the stacking order (`z-index`).

## Why?

The current behaviour breaks the expected modal layering, making the UI confusing and harder to interact with. Since modals should take visual and interaction priority, any underlying popovers must not overlay them. This fix restores proper hierarchy and improves overall user experience.

## How?

Related issues have been referenced for the approach in this PR:
https://github.com/WordPress/gutenberg/blob/d6e6997efd7f2867a91ebd4cdaeab9b7f721fbc8/packages/block-editor/src/components/inspector-controls/styles.scss#L4-L7

## Testing Instructions
1. Enable, `Gutenberg > Experiments > Data Views: new media modal` to enable new media modal.
2. Insert a Video block.
3. Upload or select a video.
4. In the block toolbar, click Text Tracks.
5. Under Add Tracks, click Open Media Library.
6. Verify the media library modal is fully visible.

## Screenshots

|Before|After|
|-|-|
|<img width="1916" height="991" alt="bug-1" src="https://github.com/user-attachments/assets/9db8c696-79eb-4b60-a662-1e104a36220a" />|<img width="1573" height="991" alt="after" src="https://github.com/user-attachments/assets/9fc10da1-058c-4f1d-8067-395e485341e0" />|

## Use of AI Tools

ChatGPT Web to write the PR description.