### PR TITLE
Docs: Update parameter type from `number` to `int`

### DIFF
--- a/packages/style-engine/src/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/src/class-wp-style-engine-css-declarations.php
@@ -135,8 +135,8 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 		/**
 		 * Filters and compiles the CSS declarations.
 		 *
-		 * @param bool   $should_prettify Whether to add spacing, new lines and indents.
-		 * @param number $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
+		 * @param bool $should_prettify Whether to add spacing, new lines and indents.
+		 * @param int  $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
 		 *
 		 * @return string The CSS declarations.
 		 */

--- a/packages/style-engine/src/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/src/class-wp-style-engine-css-rule.php
@@ -132,8 +132,8 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		/**
 		 * Gets the CSS.
 		 *
-		 * @param bool   $should_prettify Whether to add spacing, new lines and indents.
-		 * @param number $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
+		 * @param bool $should_prettify Whether to add spacing, new lines and indents.
+		 * @param int  $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
 		 *
 		 * @return string
 		 */


### PR DESCRIPTION
## What?
This pull request makes a minor documentation update to the PHPDoc comments in the Style Engine package. We should change the type of the `$indent_count` parameter in two methods, updating it from the non-existent `number` type to the correct `int` type.



