### PR TITLE
feat: Enhance Connectors page on read-only file system

### DIFF
--- a/backport-changelog/7.0/11779.md
+++ b/backport-changelog/7.0/11779.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11779
+
+* https://github.com/WordPress/gutenberg/pull/77521

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -554,14 +554,8 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 		$connectors[ $connector_id ] = $connector_out;
 	}
 	ksort( $connectors );
-
-	$is_file_mods_disabled = defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS;
-	if ( function_exists( 'wp_is_file_mod_allowed' ) ) {
-		$is_file_mods_disabled = ! wp_is_file_mod_allowed( 'install_plugins' );
-	}
-
 	$data['connectors']         = $connectors;
-	$data['isFileModsDisabled'] = $is_file_mods_disabled;
+	$data['isFileModsDisabled'] = ! wp_is_file_mod_allowed( 'install_plugins' );
 	return $data;
 }
 remove_filter( 'script_module_data_options-connectors-wp-admin', '_wp_connectors_get_connector_script_module_data' );

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -555,7 +555,7 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 	}
 	ksort( $connectors );
 	$data['connectors']         = $connectors;
-	$data['isFileModsDisabled'] = ! wp_is_file_mod_allowed( 'install_plugins' );
+	$data['isFileModDisabled'] = ! wp_is_file_mod_allowed( 'install_plugins' );
 	return $data;
 }
 remove_filter( 'script_module_data_options-connectors-wp-admin', '_wp_connectors_get_connector_script_module_data' );

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -554,7 +554,14 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 		$connectors[ $connector_id ] = $connector_out;
 	}
 	ksort( $connectors );
-	$data['connectors'] = $connectors;
+
+	$is_file_mods_disabled = defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS;
+	if ( function_exists( 'wp_is_file_mod_allowed' ) ) {
+		$is_file_mods_disabled = ! wp_is_file_mod_allowed( 'install_plugins' );
+	}
+
+	$data['connectors']         = $connectors;
+	$data['isFileModsDisabled'] = $is_file_mods_disabled;
 	return $data;
 }
 remove_filter( 'script_module_data_options-connectors-wp-admin', '_wp_connectors_get_connector_script_module_data' );

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -554,7 +554,7 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 		$connectors[ $connector_id ] = $connector_out;
 	}
 	ksort( $connectors );
-	$data['connectors']         = $connectors;
+	$data['connectors']        = $connectors;
 	$data['isFileModDisabled'] = ! wp_is_file_mod_allowed( 'install_plugins' );
 	return $data;
 }

--- a/routes/connectors-home/ai-plugin-callout.tsx
+++ b/routes/connectors-home/ai-plugin-callout.tsx
@@ -197,11 +197,6 @@ export function AiPluginCallout() {
 		return null;
 	}
 
-	// Not installed and no permissions to install.
-	if ( pluginStatus === 'not-installed' && canInstallPlugins === false ) {
-		return null;
-	}
-
 	// Installed but can't activate (no manage permissions).
 	if ( pluginStatus === 'inactive' && canManagePlugins === false ) {
 		return null;
@@ -215,6 +210,8 @@ export function AiPluginCallout() {
 		( ! initialHasConnectedProvider || justActivated );
 	const showInstallActivate =
 		pluginStatus === 'not-installed' || pluginStatus === 'inactive';
+	const hideButtons =
+		pluginStatus === 'not-installed' && canInstallPlugins === false;
 
 	const getMessage = () => {
 		if ( isJustConnected ) {
@@ -262,29 +259,30 @@ export function AiPluginCallout() {
 						a: <ExternalLink href={ AI_PLUGIN_URL } />,
 					} ) }
 				</p>
-				{ showInstallActivate ? (
-					<Button
-						variant="primary"
-						size="compact"
-						isBusy={ isBusy }
-						disabled={ getPrimaryButtonProps().disabled }
-						accessibleWhenDisabled
-						onClick={ getPrimaryButtonProps().onClick }
-					>
-						{ getPrimaryButtonProps().label }
-					</Button>
-				) : (
-					<Button
-						ref={ actionButtonRef }
-						variant="secondary"
-						size="compact"
-						href={ addQueryArgs( 'options-general.php', {
-							page: AI_PLUGIN_PAGE_SLUG,
-						} ) }
-					>
-						{ __( 'Control features in the AI plugin' ) }
-					</Button>
-				) }
+				{ ! hideButtons &&
+					( showInstallActivate ? (
+						<Button
+							variant="primary"
+							size="compact"
+							isBusy={ isBusy }
+							disabled={ getPrimaryButtonProps().disabled }
+							accessibleWhenDisabled
+							onClick={ getPrimaryButtonProps().onClick }
+						>
+							{ getPrimaryButtonProps().label }
+						</Button>
+					) : (
+						<Button
+							ref={ actionButtonRef }
+							variant="secondary"
+							size="compact"
+							href={ addQueryArgs( 'options-general.php', {
+								page: AI_PLUGIN_PAGE_SLUG,
+							} ) }
+						>
+							{ __( 'Control features in the AI plugin' ) }
+						</Button>
+					) ) }
 			</div>
 			<WpLogoDecoration />
 		</div>

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalHStack as HStack, Button } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useRef } from '@wordpress/element';
 import {
 	__experimentalRegisterConnector as registerConnector,
@@ -12,8 +12,8 @@ import {
 	type ConnectorRenderProps,
 } from '@wordpress/connectors';
 import { select } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
-import { Badge, Link } from '@wordpress/ui';
+import { __, sprintf } from '@wordpress/i18n';
+import { Badge, Link, Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -189,7 +189,7 @@ function ApiKeyConnector( {
 			name={ name }
 			description={ description }
 			actionArea={
-				<HStack spacing={ 3 } expanded={ false }>
+				<Stack direction="row" gap="md" align="center">
 					{ isConnected && <ConnectedBadge /> }
 					{ showUnavailableBadge &&
 						( pluginSlug ? (
@@ -214,7 +214,7 @@ function ApiKeyConnector( {
 							{ getButtonLabel() }
 						</Button>
 					) }
-				</HStack>
+				</Stack>
 			}
 		>
 			{ isExpanded && pluginStatus === 'active' && (

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/connectors';
 import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { Badge } from '@wordpress/ui';
+import { Badge, Link } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -108,6 +108,12 @@ const ConnectedBadge = () => (
 	</span>
 );
 
+const PluginDirectoryLink = ( { slug }: { slug: string } ) => (
+	<Link href={ `https://wordpress.org/plugins/${ slug }/` } openInNewTab>
+		{ __( 'Learn more' ) }
+	</Link>
+);
+
 const UnavailableActionBadge = () => <Badge>{ __( 'Not available' ) }</Badge>;
 
 function ApiKeyConnector( {
@@ -178,7 +184,12 @@ function ApiKeyConnector( {
 			actionArea={
 				<HStack spacing={ 3 } expanded={ false }>
 					{ isConnected && <ConnectedBadge /> }
-					{ showUnavailableBadge && <UnavailableActionBadge /> }
+					{ showUnavailableBadge &&
+						( pluginSlug ? (
+							<PluginDirectoryLink slug={ pluginSlug } />
+						) : (
+							<UnavailableActionBadge />
+						) ) }
 					{ showActionButton && (
 						<Button
 							ref={ actionButtonRef }

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -109,7 +109,14 @@ const ConnectedBadge = () => (
 );
 
 const PluginDirectoryLink = ( { slug }: { slug: string } ) => (
-	<Link href={ `https://wordpress.org/plugins/${ slug }/` } openInNewTab>
+	<Link
+		href={ sprintf(
+			/* translators: %s: plugin slug. */
+			__( 'https://wordpress.org/plugins/%s/' ),
+			slug
+		) }
+		openInNewTab
+	>
 		{ __( 'Learn more' ) }
 	</Link>
 );

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { __experimentalHStack as HStack, Button } from '@wordpress/components';
 import { useRef } from '@wordpress/element';
 import {
 	__experimentalRegisterConnector as registerConnector,
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/connectors';
 import { select } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
-import { Badge, Link, Stack } from '@wordpress/ui';
+import { Badge, Link } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -189,7 +189,7 @@ function ApiKeyConnector( {
 			name={ name }
 			description={ description }
 			actionArea={
-				<Stack direction="row" gap="md" align="center">
+				<HStack spacing={ 3 } expanded={ false }>
 					{ isConnected && <ConnectedBadge /> }
 					{ showUnavailableBadge &&
 						( pluginSlug ? (
@@ -214,7 +214,7 @@ function ApiKeyConnector( {
 							{ getButtonLabel() }
 						</Button>
 					) }
-				</Stack>
+				</HStack>
 			}
 		>
 			{ isExpanded && pluginStatus === 'active' && (

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -43,20 +43,32 @@ interface ConnectorData {
 	authentication: NonNullable< ConnectorConfig[ 'authentication' ] >;
 }
 
+interface ConnectorScriptModuleData {
+	connectors?: Record< string, ConnectorData >;
+	isFileModsDisabled?: boolean;
+}
+
+function getConnectorScriptModuleData(): ConnectorScriptModuleData {
+	try {
+		return JSON.parse(
+			document.getElementById(
+				'wp-script-module-data-options-connectors-wp-admin'
+			)?.textContent ?? '{}'
+		);
+	} catch {
+		return {};
+	}
+}
+
 /**
  * Reads connector data passed from PHP via the script module data mechanism.
  */
 export function getConnectorData(): Record< string, ConnectorData > {
-	try {
-		const parsed = JSON.parse(
-			document.getElementById(
-				'wp-script-module-data-options-connectors-wp-admin'
-			)?.textContent ?? ''
-		);
-		return parsed?.connectors ?? {};
-	} catch {
-		return {};
-	}
+	return getConnectorScriptModuleData().connectors ?? {};
+}
+
+export function getIsFileModsDisabled(): boolean {
+	return !! getConnectorScriptModuleData().isFileModsDisabled;
 }
 
 const CONNECTOR_LOGOS: Record< string, React.ComponentType > = {

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -45,7 +45,7 @@ interface ConnectorData {
 
 interface ConnectorScriptModuleData {
 	connectors?: Record< string, ConnectorData >;
-	isFileModsDisabled?: boolean;
+	isFileModDisabled?: boolean;
 }
 
 function getConnectorScriptModuleData(): ConnectorScriptModuleData {
@@ -67,8 +67,8 @@ export function getConnectorData(): Record< string, ConnectorData > {
 	return getConnectorScriptModuleData().connectors ?? {};
 }
 
-export function getIsFileModsDisabled(): boolean {
-	return !! getConnectorScriptModuleData().isFileModsDisabled;
+export function getIsFileModDisabled(): boolean {
+	return !! getConnectorScriptModuleData().isFileModDisabled;
 }
 
 const CONNECTOR_LOGOS: Record< string, React.ComponentType > = {

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -121,7 +121,8 @@ function ConnectorsPage() {
 								'Plugins cannot be installed here due to your site configuration. Install them manually using your normal deployment workflow.'
 							) }
 						</p>
-						<p>{ __( 'WP-CLI examples:' ) }</p>
+						<details>
+							<summary>{ __( 'WP-CLI examples' ) }</summary>
 						<ul>
 							{ manualInstallPluginSlugs.map( ( slug ) => {
 								const command = `wp plugin install ${ slug } --activate`;
@@ -137,6 +138,7 @@ function ConnectorsPage() {
 								);
 							} ) }
 						</ul>
+						</details>
 					</Notice>
 				) }
 				{ isEmpty ? (

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -110,21 +110,27 @@ function ConnectorsPage() {
 					isEmpty ? ' connectors-page--empty' : ''
 				}` }
 			>
-				{ isFileModsDisabled && manualInstallPluginSlugs.length > 0 && (
+				{ manualInstallPluginSlugs.length > 0 &&
+					( isFileModsDisabled || ! canInstallPlugins ) && (
 					<Notice
 						status="notice"
 						isDismissible={ false }
 						className="connectors-page__file-mods-notice"
 					>
+							{ isFileModsDisabled ? (
+								<>
 						<p>
 							{ __(
 								'Plugins cannot be installed here due to your site configuration. Install them manually using your normal deployment workflow.'
 							) }
 						</p>
 						<details>
-							<summary>{ __( 'WP-CLI examples' ) }</summary>
+										<summary>
+											{ __( 'WP-CLI examples' ) }
+										</summary>
 						<ul>
-							{ manualInstallPluginSlugs.map( ( slug ) => {
+											{ manualInstallPluginSlugs.map(
+												( slug ) => {
 								const command = `wp plugin install ${ slug } --activate`;
 								return (
 									<li key={ slug }>
@@ -133,12 +139,23 @@ function ConnectorsPage() {
 											__( '%s:' ),
 											slug
 										) }{ ' ' }
-										<code>{ command }</code>
+															<code>
+																{ command }
+															</code>
 									</li>
 								);
-							} ) }
+												}
+											) }
 						</ul>
 						</details>
+								</>
+							) : (
+								<p>
+									{ __(
+										'You do not have permission to install plugins. Please ask a site administrator to install them for you.'
+									) }
+								</p>
+							) }
 					</Notice>
 				) }
 				{ isEmpty ? (

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -37,14 +37,23 @@ registerDefaultConnectors();
 function ConnectorsPage() {
 	const isFileModsDisabled = getIsFileModsDisabled();
 
-	const { connectors, canInstallPlugins } = useSelect(
-		( select ) => ( {
+	const { connectors, canInstallPlugins, isAiPluginActive } = useSelect(
+		( select ) => {
+			const coreSelect = select( coreStore );
+			const aiPlugin = coreSelect.getEntityRecord(
+				'root',
+				'plugin',
+				'ai/ai'
+			) as { status: string } | undefined;
+			return {
 			connectors: unlock( select( store ) ).getConnectors(),
-			canInstallPlugins: select( coreStore ).canUser( 'create', {
+				canInstallPlugins: coreSelect.canUser( 'create', {
 				kind: 'root',
 				name: 'plugin',
 			} ),
-		} ),
+				isAiPluginActive: aiPlugin?.status === 'active',
+			};
+		},
 		[]
 	);
 
@@ -65,7 +74,24 @@ function ConnectorsPage() {
 				.filter( ( slug ): slug is string => !! slug )
 		)
 	).sort();
-	const manualInstallPluginSlugs = [ 'ai', ...aiProviderPluginSlugs ];
+	const activatedPluginSlugs = new Set(
+		connectors
+			.filter(
+				( connector: ConnectorConfig ) => connector.plugin?.isActivated
+			)
+			.map(
+				( connector: ConnectorConfig ) =>
+					connector.plugin?.file?.split( '/' )[ 0 ]
+			)
+			.filter( ( slug: string | undefined ): slug is string => !! slug )
+	);
+	// AI provider connectors are only registered when the 'ai' plugin is active.
+	if ( isAiPluginActive ) {
+		activatedPluginSlugs.add( 'ai' );
+	}
+	const manualInstallPluginSlugs = [ 'ai', ...aiProviderPluginSlugs ].filter(
+		( slug ) => ! activatedPluginSlugs.has( slug )
+	);
 	const isEmpty = renderableConnectors.length === 0;
 	const searchUrl =
 		canInstallPlugins && ! isFileModsDisabled
@@ -84,7 +110,7 @@ function ConnectorsPage() {
 					isEmpty ? ' connectors-page--empty' : ''
 				}` }
 			>
-				{ isFileModsDisabled && (
+				{ isFileModsDisabled && manualInstallPluginSlugs.length > 0 && (
 					<Notice
 						status="notice"
 						isDismissible={ false }

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -38,21 +38,21 @@ registerDefaultConnectors();
 function ConnectorsPage() {
 	const isFileModsDisabled = getIsFileModsDisabled();
 
-	const { connectors, canInstallPlugins, isAiPluginActive } = useSelect(
+	const { connectors, canInstallPlugins, isAiPluginInstalled } = useSelect(
 		( select ) => {
 			const coreSelect = select( coreStore );
 			const aiPlugin = coreSelect.getEntityRecord(
 				'root',
 				'plugin',
 				'ai/ai'
-			) as { status: string } | undefined;
+			);
 			return {
 				connectors: unlock( select( store ) ).getConnectors(),
 				canInstallPlugins: coreSelect.canUser( 'create', {
 					kind: 'root',
 					name: 'plugin',
 				} ),
-				isAiPluginActive: aiPlugin?.status === 'active',
+				isAiPluginInstalled: !! aiPlugin,
 			};
 		},
 		[]
@@ -75,10 +75,10 @@ function ConnectorsPage() {
 				.filter( ( slug ): slug is string => !! slug )
 		)
 	).sort();
-	const activatedPluginSlugs = new Set(
+	const installedPluginSlugs = new Set(
 		connectors
 			.filter(
-				( connector: ConnectorConfig ) => connector.plugin?.isActivated
+				( connector: ConnectorConfig ) => connector.plugin?.isInstalled
 			)
 			.map(
 				( connector: ConnectorConfig ) =>
@@ -86,12 +86,11 @@ function ConnectorsPage() {
 			)
 			.filter( ( slug: string | undefined ): slug is string => !! slug )
 	);
-	// AI provider connectors are only registered when the 'ai' plugin is active.
-	if ( isAiPluginActive ) {
-		activatedPluginSlugs.add( 'ai' );
+	if ( isAiPluginInstalled ) {
+		installedPluginSlugs.add( 'ai' );
 	}
 	const manualInstallPluginSlugs = [ 'ai', ...aiProviderPluginSlugs ].filter(
-		( slug ) => ! activatedPluginSlugs.has( slug )
+		( slug ) => ! installedPluginSlugs.has( slug )
 	);
 	const isEmpty = renderableConnectors.length === 0;
 	const searchUrl =

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -4,7 +4,6 @@
 import { Page } from '@wordpress/admin-ui';
 import {
 	Button,
-	Notice,
 	__experimentalHeading as Heading,
 	__experimentalText as WCText,
 	__experimentalVStack as VStack,
@@ -17,6 +16,8 @@ import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Notice } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -46,11 +47,11 @@ function ConnectorsPage() {
 				'ai/ai'
 			) as { status: string } | undefined;
 			return {
-			connectors: unlock( select( store ) ).getConnectors(),
+				connectors: unlock( select( store ) ).getConnectors(),
 				canInstallPlugins: coreSelect.canUser( 'create', {
-				kind: 'root',
-				name: 'plugin',
-			} ),
+					kind: 'root',
+					name: 'plugin',
+				} ),
 				isAiPluginActive: aiPlugin?.status === 'active',
 			};
 		},
@@ -112,52 +113,53 @@ function ConnectorsPage() {
 			>
 				{ manualInstallPluginSlugs.length > 0 &&
 					( isFileModsDisabled || ! canInstallPlugins ) && (
-					<Notice
-						status="notice"
-						isDismissible={ false }
-						className="connectors-page__file-mods-notice"
-					>
-							{ isFileModsDisabled ? (
-								<>
-						<p>
-							{ __(
-								'Plugins cannot be installed here due to your site configuration. Install them manually using your normal deployment workflow.'
-							) }
-						</p>
-						<details>
-										<summary>
-											{ __( 'WP-CLI examples' ) }
-										</summary>
-						<ul>
-											{ manualInstallPluginSlugs.map(
-												( slug ) => {
-								const command = `wp plugin install ${ slug } --activate`;
-								return (
-									<li key={ slug }>
-										{ sprintf(
-											/* translators: %s: Plugin slug. */
-											__( '%s:' ),
-											slug
-										) }{ ' ' }
-															<code>
-																{ command }
-															</code>
-									</li>
-								);
-												}
+						<Notice.Root
+							intent="info"
+							className="connectors-page__file-mods-notice"
+						>
+							<Notice.Description>
+								{ isFileModsDisabled ? (
+									<>
+										<p>
+											{ __(
+												'Plugins cannot be installed here due to your site configuration. Install them manually using your normal deployment workflow.'
 											) }
-						</ul>
-						</details>
-								</>
-							) : (
-								<p>
-									{ __(
-										'You do not have permission to install plugins. Please ask a site administrator to install them for you.'
-									) }
-								</p>
-							) }
-					</Notice>
-				) }
+										</p>
+										<details>
+											<summary>
+												{ __( 'WP-CLI examples' ) }
+											</summary>
+											<ul>
+												{ manualInstallPluginSlugs.map(
+													( slug ) => {
+														const command = `wp plugin install ${ slug } --activate`;
+														return (
+															<li key={ slug }>
+																{ sprintf(
+																	/* translators: %s: Plugin slug. */
+																	__( '%s:' ),
+																	slug
+																) }{ ' ' }
+																<code>
+																	{ command }
+																</code>
+															</li>
+														);
+													}
+												) }
+											</ul>
+										</details>
+									</>
+								) : (
+									<p>
+										{ __(
+											'You do not have permission to install plugins. Please ask a site administrator to install them for you.'
+										) }
+									</p>
+								) }
+							</Notice.Description>
+						</Notice.Root>
+					) }
 				{ isEmpty ? (
 					<VStack
 						alignment="center"
@@ -208,19 +210,19 @@ function ConnectorsPage() {
 						</VStack>
 					</VStack>
 				) }
-					<p>
-						{ createInterpolateElement(
-							__(
-								'If the connector you need is not listed, <a>search the plugin directory</a> to see if a connector is available.'
-							),
-							{
-								a: (
-									// eslint-disable-next-line jsx-a11y/anchor-has-content
+				<p>
+					{ createInterpolateElement(
+						__(
+							'If the connector you need is not listed, <a>search the plugin directory</a> to see if a connector is available.'
+						),
+						{
+							a: (
+								// eslint-disable-next-line jsx-a11y/anchor-has-content
 								<a href={ searchUrl } />
-								),
-							}
-						) }
-					</p>
+							),
+						}
+					) }
+				</p>
 			</div>
 		</Page>
 	);

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -25,7 +25,7 @@ import { Notice } from '@wordpress/ui';
 import './style.scss';
 import { AiPluginCallout } from './ai-plugin-callout';
 import {
-	getIsFileModsDisabled,
+	getIsFileModDisabled,
 	registerDefaultConnectors,
 } from './default-connectors';
 import { unlock } from '../lock-unlock';
@@ -36,7 +36,7 @@ const { store } = unlock( connectorsPrivateApis );
 registerDefaultConnectors();
 
 function ConnectorsPage() {
-	const isFileModsDisabled = getIsFileModsDisabled();
+	const isFileModDisabled = getIsFileModDisabled();
 
 	const { connectors, canInstallPlugins, isAiPluginInstalled } = useSelect(
 		( select ) => {
@@ -107,13 +107,13 @@ function ConnectorsPage() {
 				}` }
 			>
 				{ manualInstallPluginSlugs.length > 0 &&
-					( isFileModsDisabled || ! canInstallPlugins ) && (
+					( isFileModDisabled || ! canInstallPlugins ) && (
 						<Notice.Root
 							intent="info"
 							className="connectors-page__file-mods-notice"
 						>
 							<Notice.Description>
-								{ isFileModsDisabled
+								{ isFileModDisabled
 									? __(
 											'Plugins cannot be installed here due to your site configuration. Install them manually using your normal deployment workflow.'
 									  )
@@ -173,7 +173,7 @@ function ConnectorsPage() {
 						</VStack>
 					</VStack>
 				) }
-				{ canInstallPlugins && ! isFileModsDisabled && (
+				{ canInstallPlugins && ! isFileModDisabled && (
 					<p>
 						{ createInterpolateElement(
 							__(

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -92,7 +92,7 @@ function ConnectorsPage() {
 					>
 						<p>
 							{ __(
-								'Plugin installation from wp-admin is disabled because DISALLOW_FILE_MODS is enabled. Install the AI plugin and any AI provider plugins manually using your normal deployment workflow.'
+								'Plugins cannot be installed here due to your site configuration. Install them manually using your normal deployment workflow.'
 							) }
 						</p>
 						<p>{ __( 'WP-CLI examples:' ) }</p>

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -70,7 +70,7 @@ function ConnectorsPage() {
 	const searchUrl =
 		canInstallPlugins && ! isFileModsDisabled
 			? 'plugin-install.php?s=connector&tab=search&type=tag'
-			: 'https://wordpress.org/plugins/search/ai-connectors/';
+			: __( 'https://wordpress.org/plugins/search/ai-connectors/' );
 
 	return (
 		<Page

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -135,14 +135,21 @@ function ConnectorsPage() {
 														const command = `wp plugin install ${ slug } --activate`;
 														return (
 															<li key={ slug }>
-																{ sprintf(
-																	/* translators: %s: Plugin slug. */
-																	__( '%s:' ),
-																	slug
-																) }{ ' ' }
-																<code>
-																	{ command }
-																</code>
+																{ createInterpolateElement(
+																	sprintf(
+																		/* translators: 1: Plugin slug. 2: WP-CLI command. */
+																		__(
+																			'%1$s: <code>%2$s</code>'
+																		),
+																		slug,
+																		command
+																	),
+																	{
+																		code: (
+																			<code />
+																		),
+																	}
+																) }
 															</li>
 														);
 													}

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -14,7 +14,7 @@ import {
 } from '@wordpress/connectors';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 // eslint-disable-next-line @wordpress/use-recommended-components
 import { Notice } from '@wordpress/ui';
@@ -118,52 +118,13 @@ function ConnectorsPage() {
 							className="connectors-page__file-mods-notice"
 						>
 							<Notice.Description>
-								{ isFileModsDisabled ? (
-									<>
-										<p>
-											{ __(
-												'Plugins cannot be installed here due to your site configuration. Install them manually using your normal deployment workflow.'
-											) }
-										</p>
-										<details>
-											<summary>
-												{ __( 'WP-CLI examples' ) }
-											</summary>
-											<ul>
-												{ manualInstallPluginSlugs.map(
-													( slug ) => {
-														const command = `wp plugin install ${ slug } --activate`;
-														return (
-															<li key={ slug }>
-																{ createInterpolateElement(
-																	sprintf(
-																		/* translators: 1: Plugin slug. 2: WP-CLI command. */
-																		__(
-																			'%1$s: <code>%2$s</code>'
-																		),
-																		slug,
-																		command
-																	),
-																	{
-																		code: (
-																			<code />
-																		),
-																	}
-																) }
-															</li>
-														);
-													}
-												) }
-											</ul>
-										</details>
-									</>
-								) : (
-									<p>
-										{ __(
+								{ isFileModsDisabled
+									? __(
+											'Plugins cannot be installed here due to your site configuration. Install them manually using your normal deployment workflow.'
+									  )
+									: __(
 											'You do not have permission to install plugins. Please ask a site administrator to install them for you.'
-										) }
-									</p>
-								) }
+									  ) }
 							</Notice.Description>
 						</Notice.Root>
 					) }

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -67,6 +67,10 @@ function ConnectorsPage() {
 	).sort();
 	const manualInstallPluginSlugs = [ 'ai', ...aiProviderPluginSlugs ];
 	const isEmpty = renderableConnectors.length === 0;
+	const searchUrl =
+		canInstallPlugins && ! isFileModsDisabled
+			? 'plugin-install.php?s=connector&tab=search&type=tag'
+			: 'https://wordpress.org/plugins/search/ai-connectors/';
 
 	return (
 		<Page
@@ -159,7 +163,6 @@ function ConnectorsPage() {
 						</VStack>
 					</VStack>
 				) }
-				{ canInstallPlugins && ! isFileModsDisabled && (
 					<p>
 						{ createInterpolateElement(
 							__(
@@ -168,12 +171,11 @@ function ConnectorsPage() {
 							{
 								a: (
 									// eslint-disable-next-line jsx-a11y/anchor-has-content
-									<a href="plugin-install.php?s=connector&tab=search&type=tag" />
+								<a href={ searchUrl } />
 								),
 							}
 						) }
 					</p>
-				) }
 			</div>
 		</Page>
 	);

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -86,7 +86,7 @@ function ConnectorsPage() {
 			>
 				{ isFileModsDisabled && (
 					<Notice
-						status="warning"
+						status="notice"
 						isDismissible={ false }
 						className="connectors-page__file-mods-notice"
 					>

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -93,10 +93,6 @@ function ConnectorsPage() {
 		( slug ) => ! installedPluginSlugs.has( slug )
 	);
 	const isEmpty = renderableConnectors.length === 0;
-	const searchUrl =
-		canInstallPlugins && ! isFileModsDisabled
-			? 'plugin-install.php?s=connector&tab=search&type=tag'
-			: __( 'https://wordpress.org/plugins/search/ai-connectors/' );
 
 	return (
 		<Page
@@ -177,19 +173,21 @@ function ConnectorsPage() {
 						</VStack>
 					</VStack>
 				) }
-				<p>
-					{ createInterpolateElement(
-						__(
-							'If the connector you need is not listed, <a>search the plugin directory</a> to see if a connector is available.'
-						),
-						{
-							a: (
-								// eslint-disable-next-line jsx-a11y/anchor-has-content
-								<a href={ searchUrl } />
+				{ canInstallPlugins && ! isFileModsDisabled && (
+					<p>
+						{ createInterpolateElement(
+							__(
+								'If the connector you need is not listed, <a>search the plugin directory</a> to see if a connector is available.'
 							),
-						}
-					) }
-				</p>
+							{
+								a: (
+									// eslint-disable-next-line jsx-a11y/anchor-has-content
+									<a href="plugin-install.php?s=connector&tab=search&type=tag" />
+								),
+							}
+						) }
+					</p>
+				) }
 			</div>
 		</Page>
 	);

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -4,6 +4,7 @@
 import { Page } from '@wordpress/admin-ui';
 import {
 	Button,
+	Notice,
 	__experimentalHeading as Heading,
 	__experimentalText as WCText,
 	__experimentalVStack as VStack,
@@ -14,7 +15,7 @@ import {
 } from '@wordpress/connectors';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -22,7 +23,10 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import './style.scss';
 import { AiPluginCallout } from './ai-plugin-callout';
-import { registerDefaultConnectors } from './default-connectors';
+import {
+	getIsFileModsDisabled,
+	registerDefaultConnectors,
+} from './default-connectors';
 import { unlock } from '../lock-unlock';
 
 const { store } = unlock( connectorsPrivateApis );
@@ -31,6 +35,8 @@ const { store } = unlock( connectorsPrivateApis );
 registerDefaultConnectors();
 
 function ConnectorsPage() {
+	const isFileModsDisabled = getIsFileModsDisabled();
+
 	const { connectors, canInstallPlugins } = useSelect(
 		( select ) => ( {
 			connectors: unlock( select( store ) ).getConnectors(),
@@ -45,6 +51,21 @@ function ConnectorsPage() {
 	const renderableConnectors = connectors.filter(
 		( connector: ConnectorConfig ) => connector.render
 	);
+	const aiProviderPluginSlugs = Array.from(
+		new Set(
+			connectors
+				.filter(
+					( connector: ConnectorConfig ) =>
+						connector.type === 'ai_provider'
+				)
+				.map(
+					( connector: ConnectorConfig ) =>
+						connector.plugin?.file?.split( '/' )[ 0 ]
+				)
+				.filter( ( slug ): slug is string => !! slug )
+		)
+	).sort();
+	const manualInstallPluginSlugs = [ 'ai', ...aiProviderPluginSlugs ];
 	const isEmpty = renderableConnectors.length === 0;
 
 	return (
@@ -59,6 +80,35 @@ function ConnectorsPage() {
 					isEmpty ? ' connectors-page--empty' : ''
 				}` }
 			>
+				{ isFileModsDisabled && (
+					<Notice
+						status="warning"
+						isDismissible={ false }
+						className="connectors-page__file-mods-notice"
+					>
+						<p>
+							{ __(
+								'Plugin installation from wp-admin is disabled because DISALLOW_FILE_MODS is enabled. Install the AI plugin and any AI provider plugins manually using your normal deployment workflow.'
+							) }
+						</p>
+						<p>{ __( 'WP-CLI examples:' ) }</p>
+						<ul>
+							{ manualInstallPluginSlugs.map( ( slug ) => {
+								const command = `wp plugin install ${ slug } --activate`;
+								return (
+									<li key={ slug }>
+										{ sprintf(
+											/* translators: %s: Plugin slug. */
+											__( '%s:' ),
+											slug
+										) }{ ' ' }
+										<code>{ command }</code>
+									</li>
+								);
+							} ) }
+						</ul>
+					</Notice>
+				) }
 				{ isEmpty ? (
 					<VStack
 						alignment="center"
@@ -109,7 +159,7 @@ function ConnectorsPage() {
 						</VStack>
 					</VStack>
 				) }
-				{ canInstallPlugins && (
+				{ canInstallPlugins && ! isFileModsDisabled && (
 					<p>
 						{ createInterpolateElement(
 							__(

--- a/routes/connectors-home/style.scss
+++ b/routes/connectors-home/style.scss
@@ -30,7 +30,7 @@ $sticky-header-clearance: 120px;
 	}
 
 	&__file-mods-notice {
-		margin: 16px 0;
+		margin-bottom: 16px;
 
 		p {
 			margin: 0;

--- a/routes/connectors-home/style.scss
+++ b/routes/connectors-home/style.scss
@@ -31,19 +31,6 @@ $sticky-header-clearance: 120px;
 
 	&__file-mods-notice {
 		margin-bottom: 16px;
-
-		p {
-			margin: 0;
-		}
-
-		ul {
-			margin: 8px 0 0;
-			padding-inline-start: 20px;
-		}
-
-		code {
-			font-size: 12px;
-		}
 	}
 
 	&--empty {

--- a/routes/connectors-home/style.scss
+++ b/routes/connectors-home/style.scss
@@ -29,6 +29,23 @@ $sticky-header-clearance: 120px;
 		scroll-margin-top: $sticky-header-clearance;
 	}
 
+	&__file-mods-notice {
+		margin: 16px 0;
+
+		p {
+			margin: 0;
+		}
+
+		ul {
+			margin: 8px 0 0;
+			padding-inline-start: 20px;
+		}
+
+		code {
+			font-size: 12px;
+		}
+	}
+
 	&--empty {
 		flex-grow: 1;
 		display: flex;

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -547,7 +547,7 @@ test.describe( 'Connectors', () => {
 					page.getByRole( 'link', {
 						name: 'search the plugin directory',
 					} )
-				).toBeVisible();
+				).toBeHidden();
 			} );
 		} );
 	} );

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -461,11 +461,13 @@ test.describe( 'Connectors', () => {
 			slug: 'gutenberg-test-connectors-never-installed',
 			name: 'Test Install Required Connector',
 			action: 'Install',
+			pluginSlug: 'gutenberg-test-connectors-never-installed',
 		};
 		const activateRequiredConnector = {
 			slug: 'hello',
 			name: 'Test Activate Required Connector',
 			action: 'Activate',
+			pluginSlug: 'hello',
 		};
 		const clearCapabilityRestriction = async ( requestUtils ) => {
 			await requestUtils.rest( {
@@ -519,7 +521,7 @@ test.describe( 'Connectors', () => {
 					CONNECTORS_PAGE_QUERY
 				);
 
-				for ( const { slug, name, action } of [
+				for ( const { slug, name, action, pluginSlug } of [
 					installRequiredConnector,
 					activateRequiredConnector,
 				] ) {
@@ -528,9 +530,14 @@ test.describe( 'Connectors', () => {
 					await expect(
 						card.getByRole( 'heading', { name, level: 2 } )
 					).toBeVisible();
-					await expect(
-						card.getByText( 'Not available' )
-					).toBeVisible();
+					const learnMoreLink = card.getByRole( 'link', {
+						name: 'Learn more',
+					} );
+					await expect( learnMoreLink ).toBeVisible();
+					await expect( learnMoreLink ).toHaveAttribute(
+						'href',
+						`https://wordpress.org/plugins/${ pluginSlug }/`
+					);
 					await expect(
 						card.getByRole( 'button', { name: action } )
 					).toBeHidden();
@@ -540,7 +547,7 @@ test.describe( 'Connectors', () => {
 					page.getByRole( 'link', {
 						name: 'search the plugin directory',
 					} )
-				).toBeHidden();
+				).toBeVisible();
 			} );
 		} );
 	} );

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1621,6 +1621,11 @@
 			"count": 1
 		}
 	},
+	"routes/connectors-home/default-connectors.tsx": {
+		"@wordpress/use-recommended-components": {
+			"count": 1
+		}
+	},
 	"routes/connectors-home/stage.tsx": {
 		"@wordpress/no-non-module-stylesheet-imports": {
 			"count": 1

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1621,11 +1621,6 @@
 			"count": 1
 		}
 	},
-	"routes/connectors-home/default-connectors.tsx": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"routes/connectors-home/stage.tsx": {
 		"@wordpress/no-non-module-stylesheet-imports": {
 			"count": 1


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #77352 

<!-- In a few words, what is the PR actually doing? -->
This PR addresse the following:
- Adds a notice to inform users why connectors are not available on their installation.
- Shows the AI plugin bannerbut without the Install button.
- The paragraph at the bottom remains, with an external link to the tag search on the plugin directory (https://wordpress.org/plugins/search/ai-connectors/) when the `DISALLOW_FILE_MODS` constant is true.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
> ... because a user is completely blocked from knowing how to enable the AI functionality. I know that on Pantheon, for example, all production live environments have a readonly filesystem. This is an issue for any site configured with the DISALLOW_FILE_MODS constant enabled in wp-config.php. Users will have no idea how to proceed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
TODO

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
TODO

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1582" height="778" alt="image" src="https://github.com/user-attachments/assets/141d4038-1848-4a2c-b497-a75e9392f8dc" /> | <img width="694" height="652" alt="image" src="https://github.com/user-attachments/assets/f02f63b4-fdcb-49c6-8a41-aea5dffd891f" /> |

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

GitHub Copilot was used in part for coding purposes. All code has been reviewed by me before pushing it.