### PR TITLE
Taxonomies: add spacing above Add Taxonomy modal actions

### DIFF
--- a/routes/taxonomies/add-taxonomy.tsx
+++ b/routes/taxonomies/add-taxonomy.tsx
@@ -110,11 +110,17 @@ function AddTaxonomyModal( {
 			focusOnMount="firstContentElement"
 			size="small"
 		>
-			<form
-				onSubmit={ ( event ) => {
-					event.preventDefault();
-					onSubmit();
-				} }
+			<Stack
+				direction="column"
+				gap="md"
+				render={
+					<form
+						onSubmit={ ( event ) => {
+							event.preventDefault();
+							onSubmit();
+						} }
+					/>
+				}
 			>
 				<DataForm< TaxonomyFormData >
 					data={ data }
@@ -128,12 +134,7 @@ function AddTaxonomyModal( {
 						)
 					}
 				/>
-				<Stack
-					className="dataviews-action-modal__add-taxonomy-footer"
-					direction="row"
-					gap="sm"
-					justify="end"
-				>
+				<Stack direction="row" gap="sm" justify="end">
 					<Button
 						__next40pxDefaultSize
 						variant="tertiary"
@@ -151,7 +152,7 @@ function AddTaxonomyModal( {
 						{ __( 'Create' ) }
 					</Button>
 				</Stack>
-			</form>
+			</Stack>
 		</Modal>
 	);
 }

--- a/routes/taxonomies/add-taxonomy.tsx
+++ b/routes/taxonomies/add-taxonomy.tsx
@@ -128,7 +128,12 @@ function AddTaxonomyModal( {
 						)
 					}
 				/>
-				<Stack direction="row" gap="sm" justify="end">
+				<Stack
+					className="dataviews-action-modal__add-taxonomy-footer"
+					direction="row"
+					gap="sm"
+					justify="end"
+				>
 					<Button
 						__next40pxDefaultSize
 						variant="tertiary"

--- a/routes/taxonomies/style.scss
+++ b/routes/taxonomies/style.scss
@@ -72,10 +72,6 @@
 	}
 }
 
-.dataviews-action-modal__add-taxonomy-footer {
-	margin-top: $grid-unit-15;
-}
-
 @keyframes edit-taxonomy-slide-in-right {
 	from {
 		transform: translateX(100%);

--- a/routes/taxonomies/style.scss
+++ b/routes/taxonomies/style.scss
@@ -72,6 +72,10 @@
 	}
 }
 
+.dataviews-action-modal__add-taxonomy-footer {
+	margin-top: $grid-unit-15;
+}
+
 @keyframes edit-taxonomy-slide-in-right {
 	from {
 		transform: translateX(100%);


### PR DESCRIPTION
## What?
Closes #77518.

Adds missing space above the action buttons in the "Add taxonomy" modal in the Taxonomies experimental flow.

## Why?
The Add Taxonomy modal currently places the footer actions too close to the form content, which hurts visual separation and consistency with the related Edit Taxonomy modal.

This is a follow-up UI polish fix related to #77497, as noted in the issue report.

## How?
- Updated the footer `Stack` in the Add Taxonomy modal to use a class name instead of inline styling.
- Added a dedicated SCSS rule to apply top spacing above the button row.
- Kept the change small and scoped to taxonomy route UI styles.

Implementation details:
- Added class in `routes/taxonomies/add-taxonomy.tsx`:
  - `dataviews-action-modal__add-taxonomy-footer`
- Added style in `routes/taxonomies/style.scss`:
  - `.dataviews-action-modal__add-taxonomy-footer { margin-top: $grid-unit-15; }`

## Testing Instructions
1. Enable the "Content types: manage custom taxonomies" experiment.
2. Open the Settings -> Taxonomies screen.
3. Click "Add taxonomy".
4. Observe the action button row at the bottom (Cancel/Create).
5. Confirm there is visible spacing above the buttons and they are no longer too close to the form fields.
6. Confirm no layout regressions in the same modal.

### Testing Instructions for Keyboard
1. Navigate to Settings -> Taxonomies using keyboard only.
2. Tab to "Add taxonomy" and press Enter/Space.
3. Use Tab / Shift+Tab through fields and reach Cancel/Create buttons.
4. Verify focus order remains logical and unchanged.
5. Press Enter on Cancel to close modal.
6. Reopen modal and submit via keyboard to verify Create button behavior is unchanged.

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="1615" height="878" alt="image" src="https://github.com/user-attachments/assets/3d0c7dcd-d780-43fb-99b6-7701dd4b8366" />|<img width="1615" height="878" alt="image" src="https://github.com/user-attachments/assets/10a7f1c4-84d2-4253-8cce-0ba49aaaa959" />|

## Use of AI Tools
Not use