### PR TITLE
Experiment: Add delete action to taxonomy management

### DIFF
--- a/routes/taxonomies/actions/delete.tsx
+++ b/routes/taxonomies/actions/delete.tsx
@@ -35,41 +35,84 @@ function DeleteTaxonomyModal( {
 			return;
 		}
 		setIsDeleting( true );
-		try {
-			for ( const item of items ) {
-				if ( item.id === undefined ) {
-					continue;
-				}
-				await deleteEntityRecord(
+		const itemsToDelete = items.filter( ( item ) => item.id !== undefined );
+		const promiseResult = await Promise.allSettled(
+			itemsToDelete.map( ( item ) =>
+				deleteEntityRecord(
 					'postType',
 					'wp_user_taxonomy',
-					item.id,
+					item.id as number,
 					{ force: true },
 					{ throwOnError: true }
-				);
-			}
+				)
+			)
+		);
+		if ( promiseResult.every( ( { status } ) => status === 'fulfilled' ) ) {
 			createSuccessNotice(
-				items.length === 1
+				itemsToDelete.length === 1
 					? sprintf(
 							/* translators: %s: taxonomy plural label. */
 							__( '"%s" taxonomy deleted.' ),
-							items[ 0 ].title.raw
+							itemsToDelete[ 0 ].title.raw
 					  )
 					: __( 'Taxonomies deleted.' ),
 				{ type: 'snackbar' }
 			);
-			onActionPerformed?.( items );
-			closeModal?.();
-		} catch ( error: any ) {
-			createErrorNotice(
-				error?.message && error?.code !== 'unknown_error'
-					? error.message
-					: __( 'Failed to delete taxonomy.' ),
-				{ type: 'snackbar' }
-			);
-		} finally {
-			setIsDeleting( false );
+		} else {
+			let errorMessage;
+			if ( promiseResult.length === 1 ) {
+				const typedError = promiseResult[ 0 ] as {
+					reason?: { message?: string; code?: string };
+				};
+				if (
+					typedError.reason?.message &&
+					typedError.reason.code !== 'unknown_error'
+				) {
+					errorMessage = typedError.reason.message;
+				} else {
+					errorMessage = __( 'Failed to delete taxonomy.' );
+				}
+			} else {
+				const errorMessages = new Set< string >();
+				const failedPromises = promiseResult.filter(
+					( { status } ) => status === 'rejected'
+				);
+				for ( const failedPromise of failedPromises ) {
+					const typedError = failedPromise as {
+						reason?: { message?: string; code?: string };
+					};
+					if (
+						typedError.reason?.message &&
+						typedError.reason.code !== 'unknown_error'
+					) {
+						errorMessages.add( typedError.reason.message );
+					}
+				}
+				if ( errorMessages.size === 0 ) {
+					errorMessage = __( 'Failed to delete taxonomies.' );
+				} else if ( errorMessages.size === 1 ) {
+					errorMessage = sprintf(
+						/* translators: %s: an error message */
+						__(
+							'An error occurred while deleting the taxonomy: %s'
+						),
+						[ ...errorMessages ][ 0 ]
+					);
+				} else {
+					errorMessage = sprintf(
+						/* translators: %s: a list of comma separated error messages */
+						__(
+							'Some errors occurred while deleting the taxonomies: %s'
+						),
+						[ ...errorMessages ].join( ',' )
+					);
+				}
+			}
+			createErrorNotice( errorMessage, { type: 'snackbar' } );
 		}
+		onActionPerformed?.( itemsToDelete );
+		setIsDeleting( false );
+		closeModal?.();
 	}
 
 	return (

--- a/routes/taxonomies/actions/delete.tsx
+++ b/routes/taxonomies/actions/delete.tsx
@@ -1,0 +1,131 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import type { Action } from '@wordpress/dataviews';
+import { useState } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { trash } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { Stack, Text } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import type { TaxonomyFormData } from '../utils';
+
+function DeleteTaxonomyModal( {
+	items,
+	closeModal,
+	onActionPerformed,
+}: {
+	items: TaxonomyFormData[];
+	closeModal?: () => void;
+	onActionPerformed?: ( items: TaxonomyFormData[] ) => void;
+} ) {
+	const [ isDeleting, setIsDeleting ] = useState( false );
+	const { deleteEntityRecord } = useDispatch( coreStore );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	async function onDelete() {
+		if ( isDeleting ) {
+			return;
+		}
+		setIsDeleting( true );
+		try {
+			for ( const item of items ) {
+				if ( item.id === undefined ) {
+					continue;
+				}
+				await deleteEntityRecord(
+					'postType',
+					'wp_user_taxonomy',
+					item.id,
+					{ force: true },
+					{ throwOnError: true }
+				);
+			}
+			createSuccessNotice(
+				items.length === 1
+					? sprintf(
+							/* translators: %s: taxonomy plural label. */
+							__( '"%s" taxonomy deleted.' ),
+							items[ 0 ].title.raw
+					  )
+					: __( 'Taxonomies deleted.' ),
+				{ type: 'snackbar' }
+			);
+			onActionPerformed?.( items );
+			closeModal?.();
+		} catch ( error: any ) {
+			createErrorNotice(
+				error?.message && error?.code !== 'unknown_error'
+					? error.message
+					: __( 'Failed to delete taxonomy.' ),
+				{ type: 'snackbar' }
+			);
+		} finally {
+			setIsDeleting( false );
+		}
+	}
+
+	return (
+		<Stack direction="column" gap="md">
+			<Text>
+				{ items.length > 1
+					? sprintf(
+							/* translators: %d: number of taxonomies to delete. */
+							_n(
+								'Are you sure you want to delete %d taxonomy?',
+								'Are you sure you want to delete %d taxonomies?',
+								items.length
+							),
+							items.length
+					  )
+					: sprintf(
+							/* translators: %s: taxonomy plural label. */
+							__( 'Are you sure you want to delete "%s"?' ),
+							items[ 0 ].title.raw
+					  ) }
+			</Text>
+			<Stack direction="row" justify="flex-end" gap="sm">
+				<Button
+					__next40pxDefaultSize
+					variant="tertiary"
+					onClick={ closeModal }
+					disabled={ isDeleting }
+					accessibleWhenDisabled
+				>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					isDestructive
+					isBusy={ isDeleting }
+					disabled={ isDeleting }
+					accessibleWhenDisabled
+					onClick={ onDelete }
+				>
+					{ __( 'Delete' ) }
+				</Button>
+			</Stack>
+		</Stack>
+	);
+}
+
+const deleteTaxonomyAction: Action< TaxonomyFormData > = {
+	id: 'delete-taxonomy',
+	label: __( 'Delete' ),
+	icon: trash,
+	supportsBulk: true,
+	modalHeader: ( items ) =>
+		items.length > 1 ? __( 'Delete taxonomies' ) : __( 'Delete taxonomy' ),
+	modalSize: 'small',
+	RenderModal: DeleteTaxonomyModal,
+};
+
+export default deleteTaxonomyAction;

--- a/routes/taxonomies/actions/delete.tsx
+++ b/routes/taxonomies/actions/delete.tsx
@@ -122,8 +122,8 @@ const deleteTaxonomyAction: Action< TaxonomyFormData > = {
 	label: __( 'Delete' ),
 	icon: trash,
 	supportsBulk: true,
-	modalHeader: ( items ) =>
-		items.length > 1 ? __( 'Delete taxonomies' ) : __( 'Delete taxonomy' ),
+	hideModalHeader: true,
+	modalFocusOnMount: 'firstContentElement',
 	modalSize: 'small',
 	RenderModal: DeleteTaxonomyModal,
 };

--- a/routes/taxonomies/actions/delete.tsx
+++ b/routes/taxonomies/actions/delete.tsx
@@ -6,7 +6,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import type { Action } from '@wordpress/dataviews';
 import { useState } from '@wordpress/element';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { Stack, Text } from '@wordpress/ui';
@@ -14,7 +14,7 @@ import { Stack, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
-import type { TaxonomyFormData } from '../utils';
+import type { CoreDataError, TaxonomyFormData } from '../types';
 
 function DeleteTaxonomyModal( {
 	items,
@@ -51,18 +51,26 @@ function DeleteTaxonomyModal( {
 			createSuccessNotice(
 				itemsToDelete.length === 1
 					? sprintf(
-							/* translators: %s: taxonomy plural label. */
+							/* translators: %s: The taxonomy's plural label. */
 							__( '"%s" taxonomy deleted.' ),
 							itemsToDelete[ 0 ].title.raw
 					  )
-					: __( 'Taxonomies deleted.' ),
+					: sprintf(
+							/* translators: %d: The number of taxonomies. */
+							_n(
+								'%d taxonomy deleted.',
+								'%d taxonomies deleted.',
+								itemsToDelete.length
+							),
+							itemsToDelete.length
+					  ),
 				{ type: 'snackbar' }
 			);
 		} else {
 			let errorMessage;
 			if ( promiseResult.length === 1 ) {
 				const typedError = promiseResult[ 0 ] as {
-					reason?: { message?: string; code?: string };
+					reason?: CoreDataError;
 				};
 				if (
 					typedError.reason?.message &&
@@ -79,7 +87,7 @@ function DeleteTaxonomyModal( {
 				);
 				for ( const failedPromise of failedPromises ) {
 					const typedError = failedPromise as {
-						reason?: { message?: string; code?: string };
+						reason?: CoreDataError;
 					};
 					if (
 						typedError.reason?.message &&
@@ -129,7 +137,7 @@ function DeleteTaxonomyModal( {
 							items.length
 					  )
 					: sprintf(
-							/* translators: %s: taxonomy plural label. */
+							/* translators: %s: The taxonomy's plural label. */
 							__( 'Are you sure you want to delete "%s"?' ),
 							items[ 0 ].title.raw
 					  ) }
@@ -153,7 +161,7 @@ function DeleteTaxonomyModal( {
 					accessibleWhenDisabled
 					onClick={ onDelete }
 				>
-					{ __( 'Delete' ) }
+					{ _x( 'Delete', 'verb' ) }
 				</Button>
 			</Stack>
 		</Stack>
@@ -162,7 +170,7 @@ function DeleteTaxonomyModal( {
 
 const deleteTaxonomyAction: Action< TaxonomyFormData > = {
 	id: 'delete-taxonomy',
-	label: __( 'Delete' ),
+	label: _x( 'Delete', 'verb' ),
 	icon: trash,
 	supportsBulk: true,
 	hideModalHeader: true,

--- a/routes/taxonomies/actions/index.ts
+++ b/routes/taxonomies/actions/index.ts
@@ -1,2 +1,3 @@
+export { default as deleteTaxonomyAction } from './delete';
 export { default as editTaxonomyAction } from './edit';
 export { default as toggleActiveAction } from './toggle-active';

--- a/routes/taxonomies/stage.tsx
+++ b/routes/taxonomies/stage.tsx
@@ -11,7 +11,11 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import AddTaxonomy from './add-taxonomy';
-import { editTaxonomyAction, toggleActiveAction } from './actions';
+import {
+	deleteTaxonomyAction,
+	editTaxonomyAction,
+	toggleActiveAction,
+} from './actions';
 import {
 	titleField,
 	statusField,
@@ -39,7 +43,7 @@ const DEFAULT_VIEW: View = {
 function TaxonomiesPage() {
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const taxonomyActions = useMemo(
-		() => [ editTaxonomyAction, toggleActiveAction ],
+		() => [ editTaxonomyAction, toggleActiveAction, deleteTaxonomyAction ],
 		[]
 	);
 	const slugField = useSlugField();

--- a/routes/taxonomies/types.ts
+++ b/routes/taxonomies/types.ts
@@ -31,3 +31,5 @@ export interface TaxonomyFormData {
 		labels: { singular_name: string };
 	};
 }
+
+export type CoreDataError = { message?: string; code?: string };


### PR DESCRIPTION
## What?
Adds a Delete action to the Taxonomies experiment (Settings > Taxonomies), alongside the existing Edit and Activate/Deactivate actions.

Follow-up to #77497. 

## What we're not doing

* Not handling any trash functionality (which seems unnecessary with the activation mechanism).
* Not handling cleanup or migration of existing terms - we might want to offer that to the user upon deletion of a taxonomy.

## Why?
The Taxonomies experiment lets users create custom taxonomies, but has no way to remove them. Users could only deactivate.

## How?
Mirrors the pattern of the existing `editTaxonomyAction`:

  - new action with a `RenderModal` confirmation
  - `supportsBulk: true` so multi-select works from the DataViews bulk actions bar.
  - per the destructive-actions design pattern, uses a `Modal` + `isDestructive` primary button.
  - wires it into the rest of the `taxonomyActions` array
  - success/error snackbars follow the same phrasing as the Edit and Toggle actions.

## Testing Instructions
 1. Enable the Content types: manage custom taxonomies experiment.
  2. Go to Settings > Taxonomies and create a couple of taxonomies.
  3. From the row actions menu, pick Delete > confirm > the taxonomy is removed (might need a refresh with the current setup) and a snackbar confirms.
  4. Select multiple rows > use the bulk Delete action > confirmation message pluralizes correctly.
  5. Cancel in the confirmation dialog > nothing is deleted.
  6. Trigger an error (e.g. network offline) > error snackbar is shown, the modal stays open.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

<img width="252" height="236" alt="Screenshot 2026-04-21 at 16 33 16" src="https://github.com/user-attachments/assets/881de800-0f50-4d19-b8f1-e65a35cbf36b" />

## Use of AI Tools

Opus 4.7