### PR TITLE
Taxonomies: warn when editing an existing taxonomy's slug

### DIFF
--- a/routes/taxonomies/actions/edit.tsx
+++ b/routes/taxonomies/actions/edit.tsx
@@ -58,7 +58,7 @@ function EditTaxonomyModal( {
 
 	const [ data, setData ] = useState< TaxonomyFormData >( initialData );
 	const [ isSaving, setIsSaving ] = useState( false );
-	const slugField = useSlugField( item.slug );
+	const slugField = useSlugField( item.slug, data.slug );
 	const objectTypeField = useObjectTypeField();
 
 	const fields = useMemo< Field< TaxonomyFormData >[] >(

--- a/routes/taxonomies/fields.tsx
+++ b/routes/taxonomies/fields.tsx
@@ -1,9 +1,11 @@
 /**
  * WordPress dependencies
  */
+import { Notice } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import type { Field, Form } from '@wordpress/dataviews';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -97,17 +99,33 @@ export const statusField: Field< TaxonomyFormData > = {
 };
 
 export function useSlugField(
-	currentSlug?: string
+	originalSlug?: string,
+	currentValue?: string
 ): Field< TaxonomyFormData > {
-	const takenSlugs = useTakenTaxonomySlugs( currentSlug );
+	const takenSlugs = useTakenTaxonomySlugs( originalSlug );
+	const showRenameWarning =
+		originalSlug !== undefined && currentValue !== originalSlug;
 	return useMemo< Field< TaxonomyFormData > >(
 		() => ( {
 			id: 'slug',
 			label: __( 'Slug' ),
 			type: 'text',
 			enableGlobalSearch: true,
-			description: __(
-				'Lower case letters, numbers, underscores, and dashes only. Maximum length: 32 characters. Changing the key renames the taxonomy — existing terms may become inaccessible until a migration updates the database.'
+			description: (
+				<Stack direction="column" gap="sm">
+					{ showRenameWarning && (
+						<Notice status="warning" isDismissible={ false }>
+							{ __(
+								'Changing the key renames the taxonomy — existing terms may become inaccessible until a migration updates the database.'
+							) }
+						</Notice>
+					) }
+					<span>
+						{ __(
+							'Lower case letters, numbers, underscores, and dashes only. Maximum length: 32 characters.'
+						) }
+					</span>
+				</Stack>
 			),
 			isValid: {
 				required: true,
@@ -120,7 +138,7 @@ export function useSlugField(
 			filterBy: false,
 			enableSorting: false,
 		} ),
-		[ takenSlugs ]
+		[ takenSlugs, showRenameWarning ]
 	);
 }
 


### PR DESCRIPTION
## What?
Follow-up to #77497. Adds a warning Notice under the Slug field in the Edit Taxonomy modal (Settings > Taxonomies > Edit) when the user changes the slug of an existing custom taxonomy.

## Why?
The taxonomy slug is effectively its identity key — it's what `register_taxonomy()` is called with and what terms reference in the database. If a user edits an existing taxonomy's slug, existing terms can become inaccessible until a migration renames them. Previously, this caveat was buried in the field's always-on description next to the formatting rules; users creating new taxonomies were reading irrelevant scary text, and users editing existing ones could miss it. This PR scopes the warning to the only flow where it matters, and surfaces it as a proper warning Notice.

## How?
Displays a warning if the user attempts to edit the slug of an existing custom taxonomy.

## Testing Instructions
  1. Enable the Content types: manage custom taxonomies experiment.
  2. Go to Settings > Taxonomies and create a taxonomy (e.g. Genre). Verify no warning appears in the Add modal under the
   Slug field.
  3. From the row actions menu, pick Edit. Verify the slug field shows only the formatting help text — no warning yet.
  4. Edit the slug (e.g. genre > genres). Verify the warning Notice appears above the help text, with sm gap between
  them.
  5. Change the slug back to the original value. Verify the warning disappears.
  6. Save and re-open Edit. Verify the warning is absent again until the slug is modified.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="378" height="167" alt="Screenshot 2026-04-21 at 19 12 20" src="https://github.com/user-attachments/assets/9e4f27c5-0c74-4ef0-bebb-0f7e71fa95d5" />

After - before editing slug
<img width="385" height="130" alt="Screenshot 2026-04-21 at 19 01 31" src="https://github.com/user-attachments/assets/91331fed-db8d-481e-b832-707171dfd80f" />

After - after editing slug
<img width="377" height="219" alt="Screenshot 2026-04-21 at 19 01 22" src="https://github.com/user-attachments/assets/d29493e1-d17b-4a05-b13a-22a66d2888cb" />

## Use of AI Tools

Opus 4.7