### PR TITLE
[Dataviews]: Add comments count field with sorting and filtering

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -25,6 +25,9 @@ import {
 	OPERATOR_BEFORE,
 	OPERATOR_AFTER,
 	LAYOUT_LIST,
+	OPERATOR_IS,
+	OPERATOR_GREATER_THAN,
+	OPERATOR_LESS_THAN,
 } from '../../utils/constants';
 
 import AddNewPostModal from '../add-new-post';
@@ -36,6 +39,7 @@ import {
 
 import useNotesCount from './use-notes-count';
 import { QuickEditModal } from './quick-edit-modal';
+import useCommentsCount from './use-comments-count';
 
 const { usePostActions, usePostFields } = unlock( editorPrivateApis );
 const { useLocation, useHistory } = unlock( routerPrivateApis );
@@ -43,6 +47,8 @@ const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
 const EMPTY_ARRAY = [];
 
 const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All but 'trash'.
+
+const COMPUTED_SORT_FIELDS = new Set( [ 'author', 'commentsCount' ] );
 
 function getItemId( item ) {
 	return item.id.toString();
@@ -119,6 +125,8 @@ export default function PostList( { postType } ) {
 		postType,
 	} );
 
+	const isComputedSort = COMPUTED_SORT_FIELDS.has( view.sort?.field );
+
 	const queryArgs = useMemo( () => {
 		const filters = {};
 		view.filters?.forEach( ( filter ) => {
@@ -163,12 +171,12 @@ export default function PostList( { postType } ) {
 			page: view.page,
 			_embed: 'author,wp:featuredmedia',
 			order: view.sort?.direction,
-			orderby: view.sort?.field,
+			orderby: isComputedSort ? undefined : view.sort?.field,
 			orderby_hierarchy: !! view.showLevels,
 			search: view.search,
 			...filters,
 		};
-	}, [ view ] );
+	}, [ view, isComputedSort ] );
 	const {
 		records,
 		isResolving: isLoadingData,
@@ -183,28 +191,70 @@ export default function PostList( { postType } ) {
 	);
 	const { notesCount, isLoading: isLoadingNotesCount } =
 		useNotesCount( postIds );
+	const { commentsCount, isLoading: isLoadingCommentsCount } =
+		useCommentsCount( postIds );
 
 	// The REST API sort the authors by ID, but we want to sort them by name.
 	const data = useMemo( () => {
-		let processedRecords = records;
+		const commentsFilters =
+			view.filters?.filter(
+				( filter ) => filter.field === 'commentsCount'
+			) ?? [];
 
-		if ( view?.sort?.field === 'author' ) {
+		if ( ! records ) {
+			return records;
+		}
+
+		let processedRecords = records.map( ( record ) => ( {
+			...record,
+			notesCount: notesCount[ record.id ] ?? 0,
+			commentsCount: commentsCount[ record.id ] ?? 0,
+		} ) );
+
+		if ( commentsFilters.length ) {
+			processedRecords = processedRecords.filter( ( record ) =>
+				commentsFilters.every( ( filter ) => {
+					if ( filter.value === '' || filter.value === null ) {
+						return true;
+					}
+
+					const value = Number( filter.value );
+					const count = Number( record.commentsCount );
+
+					switch ( filter.operator ) {
+						case OPERATOR_IS:
+							return count === value;
+						case OPERATOR_LESS_THAN:
+							return count < value;
+						case OPERATOR_GREATER_THAN:
+							return count > value;
+						default:
+							return true;
+					}
+				} )
+			);
+		}
+
+		if (
+			view?.sort?.field === 'author' ||
+			view?.sort?.field === 'commentsCount'
+		) {
 			processedRecords = filterSortAndPaginate(
-				records,
+				processedRecords,
 				{ sort: { ...view.sort } },
 				fields
 			).data;
 		}
 
-		if ( processedRecords ) {
-			return processedRecords.map( ( record ) => ( {
-				...record,
-				notesCount: notesCount[ record.id ] ?? 0,
-			} ) );
-		}
-
 		return processedRecords;
-	}, [ records, fields, view?.sort, notesCount ] );
+	}, [
+		view.filters,
+		view?.sort,
+		records,
+		notesCount,
+		commentsCount,
+		fields,
+	] );
 
 	const ids = data?.map( ( record ) => getItemId( record ) ) ?? [];
 	const prevIds = usePrevious( ids ) ?? [];
@@ -309,7 +359,10 @@ export default function PostList( { postType } ) {
 				actions={ actions }
 				data={ data || EMPTY_ARRAY }
 				isLoading={
-					isLoadingData || isLoadingNotesCount || ! hasResolved
+					isLoadingData ||
+					isLoadingNotesCount ||
+					isLoadingCommentsCount ||
+					! hasResolved
 				}
 				view={ view }
 				onChangeView={ onChangeView }

--- a/packages/edit-site/src/components/post-list/use-comments-count.js
+++ b/packages/edit-site/src/components/post-list/use-comments-count.js
@@ -1,0 +1,52 @@
+import { useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Hook to fetch comments counts for a list of post IDs.
+ *
+ * This hook fetches all comments for the given posts and returns
+ * a map of post ID to comments count.
+ *
+ * @param {number[]} postIds - Array of post IDs to fetch comments for.
+ * @return {{ commentsCount: Object, isLoading: boolean }} Object with commentsCount map and loading state.
+ */
+export default function useCommentsCount( postIds ) {
+	const { comments, isLoading } = useSelect(
+		( select ) => {
+			if ( ! postIds.length ) {
+				return { comments: [], isLoading: false };
+			}
+
+			const { getEntityRecords } = select( coreStore );
+			const records = getEntityRecords( 'root', 'comment', {
+				// Using -1 may crash the REST API if there are too many comments, so we use a high number instead.
+				// For posts with >100 comments, this count may be incomplete.
+				per_page: 100,
+				post: postIds,
+				context: 'view',
+			} );
+
+			return {
+				comments: records,
+				isLoading: records === null,
+			};
+		},
+		[ postIds ]
+	);
+
+	const commentsCount = useMemo( () => {
+		const counts = {};
+
+		for ( const comment of comments || [] ) {
+			const postId = comment.post;
+			if ( postId ) {
+				counts[ postId ] = ( counts[ postId ] || 0 ) + 1;
+			}
+		}
+
+		return counts;
+	}, [ comments ] );
+
+	return { commentsCount, isLoading };
+}

--- a/packages/edit-site/src/utils/constants.js
+++ b/packages/edit-site/src/utils/constants.js
@@ -60,3 +60,5 @@ export const OPERATOR_IS_ANY = 'isAny';
 export const OPERATOR_IS_NONE = 'isNone';
 export const OPERATOR_BEFORE = 'before';
 export const OPERATOR_AFTER = 'after';
+export const OPERATOR_GREATER_THAN = 'greaterThan';
+export const OPERATOR_LESS_THAN = 'lessThan';

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -39,6 +39,7 @@ import {
 	scheduledDateField,
 	formatField,
 	postContentInfoField,
+	commentsField,
 } from '@wordpress/fields';
 import {
 	altTextField,
@@ -273,6 +274,7 @@ export const registerPostTypeSchema =
 					excerptField,
 				postTypeConfig.supports?.[ 'page-attributes' ] && parentField,
 				postTypeConfig.supports?.comments && commentStatusField,
+				postTypeConfig.supports?.comments && commentsField,
 				postTypeConfig.supports?.trackbacks && pingStatusField,
 				( postTypeConfig.supports?.comments ||
 					postTypeConfig.supports?.trackbacks ) &&

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -26,6 +26,10 @@ Undocumented declaration.
 
 Undocumented declaration.
 
+### commentsField
+
+Comments count field for post types that support comments.
+
 ### commentStatusField
 
 Comment status field for BasePost.

--- a/packages/fields/src/fields/comments/index.tsx
+++ b/packages/fields/src/fields/comments/index.tsx
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import type { Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+
+import type { BasePost } from '../../types';
+
+interface PostWithCommentsCount extends BasePost {
+	commentsCount?: number;
+}
+
+const commentsField: Field< PostWithCommentsCount > = {
+	id: 'commentsCount',
+	label: __( 'Comments' ),
+	type: 'integer',
+	filterBy: {
+		operators: [ 'is', 'lessThan', 'greaterThan' ],
+	},
+};
+
+/**
+ * Comments count field for post types that support comments.
+ */
+export default commentsField;

--- a/packages/fields/src/fields/index.ts
+++ b/packages/fields/src/fields/index.ts
@@ -19,3 +19,4 @@ export { default as notesField } from './notes';
 export { default as excerptField } from './excerpt';
 export { default as formatField } from './format';
 export { default as postContentInfoField } from './post-content-info';
+export { default as commentsField } from './comments';


### PR DESCRIPTION
## What?
Closes #73299

Adds a new `commentsCount` field to Pages DataView, including:

1. Display of comment counts per page
2. Client-side sorting support for the field
3. Filtering support with operators: 
i. Is
ii. Less than
iii. Greater than

## Why?
This PR addresses that gap by introducing a comments count field, as discussed in the issue, while keeping it hidden by default (since Pages don’t commonly use comments).

## How?
This PR introduces a `commentsCount` field in `@wordpress/fields`, registered for post types that support comments. A custom `useCommentsCount` hook fetches comments via core-data. Filtering is handled client-side, supporting "is", "less than", and "greater than" operators.

## Testing Instructions
1. Go to Site Editor → Pages
2. Ensure you have pages with 0, 1, and multiple comments
3. Enable the Comments column in DataViews (if hidden)
5. Verify that each page shows the correct comment count
6. Sort by Comments and confirm correct order (ascending and descending)
7. Apply filters:
a. Comments is 1
b. Comments greater than 0
c. Comments less than 2
8. Verify results update correctly without refresh
9. Clear filters and confirm all pages are shown again

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Is filter|Greater than filter|Config dropdown|
|-|-|-|
|<img width="752" height="484" alt="image" src="https://github.com/user-attachments/assets/f718a89c-3d38-4308-82c3-a7ef2e3d23e4" />|<img width="760" height="786" alt="image" src="https://github.com/user-attachments/assets/508f47c6-23a9-4a15-8d03-daa93b46b3cf" />|<img width="754" height="1368" alt="image" src="https://github.com/user-attachments/assets/a94c9d06-a3ed-4a97-8598-6734ca5f0156" />|