### PR TITLE
RTC: Fixed orphaned meta causing dirty editor state

### DIFF
--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -340,17 +340,29 @@ export function getPostChangesFromCRDTDoc(
 				}
 
 				case 'meta': {
+					const currentMeta =
+						( currentValue as PostChanges[ 'meta' ] ) ?? {};
+
 					allowedMetaChanges = Object.fromEntries(
 						Object.entries( newValue ?? {} ).filter(
-							( [ metaKey ] ) =>
-								! disallowedPostMetaKeys.has( metaKey )
+							( [ metaKey ] ) => {
+								if ( disallowedPostMetaKeys.has( metaKey ) ) {
+									return false;
+								}
+
+								// Ignore meta keys that are no longer registered
+								// for this post (absent from the REST response).
+								// Without this, orphaned CRDT meta would mark
+								// the post permanently dirty.
+								return metaKey in currentMeta;
+							}
 						)
 					);
 
 					// Merge the allowed meta changes with the current meta values since
 					// not all meta properties are synced.
 					const mergedValue = {
-						...( currentValue as PostChanges[ 'meta' ] ),
+						...currentMeta,
 						...allowedMetaChanges,
 					};
 

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -341,7 +341,7 @@ export function getPostChangesFromCRDTDoc(
 
 				case 'meta': {
 					const currentMeta =
-						( currentValue as PostChanges[ 'meta' ] ) ?? {};
+						( currentValue ?? {} ) as PostChanges[ 'meta' ];
 
 					allowedMetaChanges = Object.fromEntries(
 						Object.entries( newValue ?? {} ).filter(

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -341,7 +341,7 @@ export function getPostChangesFromCRDTDoc(
 
 				case 'meta': {
 					const currentMeta =
-						( currentValue ?? {} ) as PostChanges[ 'meta' ];
+						( currentValue as PostChanges[ 'meta' ] ) ?? {};
 
 					allowedMetaChanges = Object.fromEntries(
 						Object.entries( newValue ?? {} ).filter(

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -773,6 +773,30 @@ describe( 'crdt', () => {
 			} );
 		} );
 
+		it( 'excludes orphaned meta keys not present on the edited record', () => {
+			// If post meta is registered, saved (landing in a CRDT doc),
+			// then unregistered, it can permanently mark the record dirty.
+			// Orphaned values should not show up as a change.
+			const metaMap = createYMap();
+			metaMap.set( 'registered_meta', 'value' );
+			metaMap.set( 'orphaned_meta', 'stale value' );
+			map.set( 'meta', metaMap );
+
+			const editedRecord = {
+				meta: {
+					registered_meta: 'value',
+				},
+			} as unknown as Post;
+
+			const changes = getPostChangesFromCRDTDoc(
+				doc,
+				editedRecord,
+				defaultSyncedProperties
+			);
+
+			expect( changes ).not.toHaveProperty( 'meta' );
+		} );
+
 		it( 'excludes disallowed meta keys in changes', () => {
 			const metaMap = createYMap();
 			metaMap.set( 'public_meta', 'new value' );

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -860,31 +860,6 @@ describe( 'crdt', () => {
 			expect( changes2.tags ).toEqual( [ 3 ] );
 		} );
 
-		it( 'excludes orphaned top-level keys not present on the edited record', () => {
-			// Reproduces the taxonomy version of the orphaned-meta bug.
-			// A custom taxonomy (e.g. `genre`) is registered when the CRDT
-			// doc was populated, but has since been unregistered. The REST
-			// response no longer returns the key, so `editedRecord` lacks
-			// it entirely. Without a filter, the stale CRDT value would be
-			// reported as a change and mark the post permanently dirty.
-			map.set( 'genre', [ 10, 20 ] );
-
-			const customSyncedProperties = new Set( [
-				...defaultSyncedProperties,
-				'genre',
-			] );
-
-			const editedRecord = {} as Post;
-
-			const changes = getPostChangesFromCRDTDoc(
-				doc,
-				editedRecord,
-				customSyncedProperties
-			);
-
-			expect( changes ).not.toHaveProperty( 'genre' );
-		} );
-
 		describe( 'selection recalculation', () => {
 			it( 'includes recalculated selection when text is inserted before cursor', () => {
 				const ytext = addBlockToDoc( map, 'block-1', 'Hello world' );

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -860,6 +860,31 @@ describe( 'crdt', () => {
 			expect( changes2.tags ).toEqual( [ 3 ] );
 		} );
 
+		it( 'excludes orphaned top-level keys not present on the edited record', () => {
+			// Reproduces the taxonomy version of the orphaned-meta bug.
+			// A custom taxonomy (e.g. `genre`) is registered when the CRDT
+			// doc was populated, but has since been unregistered. The REST
+			// response no longer returns the key, so `editedRecord` lacks
+			// it entirely. Without a filter, the stale CRDT value would be
+			// reported as a change and mark the post permanently dirty.
+			map.set( 'genre', [ 10, 20 ] );
+
+			const customSyncedProperties = new Set( [
+				...defaultSyncedProperties,
+				'genre',
+			] );
+
+			const editedRecord = {} as Post;
+
+			const changes = getPostChangesFromCRDTDoc(
+				doc,
+				editedRecord,
+				customSyncedProperties
+			);
+
+			expect( changes ).not.toHaveProperty( 'genre' );
+		} );
+
 		describe( 'selection recalculation', () => {
 			it( 'includes recalculated selection when text is inserted before cursor', () => {
 				const ytext = addBlockToDoc( map, 'block-1', 'Hello world' );


### PR DESCRIPTION
## What?

See discussion in https://github.com/WordPress/gutenberg/pull/77503. Thank you to @mmtr and @Gustavo-Hilario for doing most of the work here. This PR implements [the solution discussed here](https://github.com/WordPress/gutenberg/pull/77503#issuecomment-4289874571). The reproduction in `trunk` looks like this:

https://github.com/user-attachments/assets/8a736b5c-dc59-44ca-b94f-bcdfa55de019

After post meta changes, the "Publish" button turns into "Save" without any local changes. Note that saving the post doesn't fix the issue, as the meta value persists in the CRDT doc after reload.

---

The reproduction instructions are available in https://github.com/WordPress/gutenberg/pull/77503#issuecomment-4289818154:

> - Enable RTC in Settings -> Writing
> - Add this to a mu-plugin:
> ```
> add_action( 'init', function () {
>   register_post_meta( '', 'my_custom_meta', array(
>     'show_in_rest'  => true,
>     'single'        => true,
>     'type'          => 'boolean',
>     'default'       => false,
>     'auth_callback' => '__return_true',
>   ) );
> } );
> ```
> 
> - Go to Posts -> Add New
> - Add a title and a paragraph block
> - Convert the paragraph block to a reusable patten
> - Save the post as draft
> - Remove the mu-plugin
> - Open the draft in the editor
> - ❌ Publish button is missing

## What?

Filter out any missing post meta in `getPostChangesFromCRDTDoc`. Keys that live in the CRDT doc but aren't present on the current edited record are now ignored instead of being reported as a change.

## Why?

Unregistered meta values were flipping the editor into a permanently-dirty state. The "Publish" button turned into "Save" on load, and re-saving didn't clear it.

## How?

For incoming `'meta'` values, change `allowedMetaChanges` to only allow keys that also appear in `editedRecord.meta`. That treats "absent from REST" as "no longer registered here" and skips it for sync.

## Testing Instructions

The unit test for this feature can be run via:

```
npm run --workspace @wordpress/unit-tests test:unit -- --testPathPattern='packages/core-data/src/utils/test/crdt.ts$' --testNamePattern='excludes orphaned meta keys'
```

For manual testing, try the reproduction instructions in **What** above. On trunk it will reproduce, and on this branch the post will not get into a dirty state when the meta value is removed.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Used for: The whole process.