### PR TITLE
CI: Skip End-to-End and Performance tests on non-impactful PRs

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -36,6 +36,11 @@ jobs:
               id: filter
               if: github.event_name == 'pull_request'
               with:
+                  # `every` is required for the `!`-prefixed exclusion rules below
+                  # to actually exclude. The default `some` quantifier would treat
+                  # each rule as an independent OR predicate, which means `**`
+                  # alone would always match.
+                  predicate-quantifier: 'every'
                   filters: |
                       impactful:
                           - '**'

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -20,12 +20,63 @@ concurrency:
 permissions: {}
 
 jobs:
+    # Detects whether a PR touches any "impactful" paths. On non-PR events,
+    # always emits should_run=true so push/release/workflow_dispatch keep
+    # their existing behavior.
+    # NOTE: Keep the filter list in sync with .github/workflows/performance.yml.
+    changes:
+        name: Detect impactful changes
+        runs-on: 'ubuntu-24.04'
+        permissions:
+            pull-requests: read
+        outputs:
+            should_run: ${{ steps.filter.outputs.impactful || steps.force-run.outputs.impactful }}
+        steps:
+            - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+              id: filter
+              if: github.event_name == 'pull_request'
+              with:
+                  filters: |
+                      impactful:
+                          - '**'
+                          - '!**/*.md'
+                          - '!docs/**'
+                          - '!**/stories/**'
+                          - '!**/*.story.{js,jsx,ts,tsx}'
+                          - '!**/*.stories.{js,jsx,ts,tsx}'
+                          - '!.storybook/**'
+                          - '!storybook/**'
+                          - '!.github/ISSUE_TEMPLATE/**'
+                          - '!.github/PULL_REQUEST_TEMPLATE.md'
+                          - '!.cursor/**'
+                          - '!.husky/**'
+                          - '!CODEOWNERS'
+                          - '!packages/eslint-plugin/**'
+                          - '!packages/stylelint-config/**'
+                          - '!packages/prettier-config/**'
+                          - '!packages/npm-package-json-lint-config/**'
+                          - '!packages/jest-console/**'
+                          - '!packages/jest-preset-default/**'
+                          - '!packages/jest-puppeteer-axe/**'
+                          - '!packages/docgen/**'
+                          - '!packages/project-management-automation/**'
+                          - '!eslint.config.mjs'
+                          - '!.stylelintrc*'
+                          - '!.prettierrc*'
+                          - '!.editorconfig'
+                          - '!.markdownlint*'
+            - name: Default to run outside pull requests
+              id: force-run
+              if: github.event_name != 'pull_request'
+              run: echo "impactful=true" >> "$GITHUB_OUTPUT"
+
     e2e-playwright:
         name: Playwright - ${{ matrix.part }}
         runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
-        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+        needs: changes
+        if: ${{ (github.event_name != 'pull_request' || needs.changes.outputs.should_run == 'true') && (github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request') }}
         strategy:
             fail-fast: false
             matrix:
@@ -76,8 +127,11 @@ jobs:
 
     merge-artifacts:
         name: Merge Artifacts
-        if: ${{ !cancelled() }}
-        needs: [e2e-playwright]
+        # Gate on `changes` as well: GitHub treats a skipped `needs:` as success,
+        # so without this guard merge-artifacts would still run after a fully
+        # skipped matrix and try to merge nonexistent artifacts.
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.should_run == 'true') }}
+        needs: [changes, e2e-playwright]
         runs-on: 'ubuntu-24.04'
         permissions:
             contents: read

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -44,6 +44,11 @@ jobs:
               id: filter
               if: github.event_name == 'pull_request'
               with:
+                  # `every` is required for the `!`-prefixed exclusion rules below
+                  # to actually exclude. The default `some` quantifier would treat
+                  # each rule as an independent OR predicate, which means `**`
+                  # alone would always match.
+                  predicate-quantifier: 'every'
                   filters: |
                       impactful:
                           - '**'

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -28,13 +28,64 @@ concurrency:
 permissions: {}
 
 jobs:
+    # Detects whether a PR touches any "impactful" paths. On non-PR events,
+    # always emits should_run=true so push/release/workflow_dispatch keep
+    # their existing behavior.
+    # NOTE: Keep the filter list in sync with .github/workflows/end2end-test.yml.
+    changes:
+        name: Detect impactful changes
+        runs-on: 'ubuntu-24.04'
+        permissions:
+            pull-requests: read
+        outputs:
+            should_run: ${{ steps.filter.outputs.impactful || steps.force-run.outputs.impactful }}
+        steps:
+            - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+              id: filter
+              if: github.event_name == 'pull_request'
+              with:
+                  filters: |
+                      impactful:
+                          - '**'
+                          - '!**/*.md'
+                          - '!docs/**'
+                          - '!**/stories/**'
+                          - '!**/*.story.{js,jsx,ts,tsx}'
+                          - '!**/*.stories.{js,jsx,ts,tsx}'
+                          - '!.storybook/**'
+                          - '!storybook/**'
+                          - '!.github/ISSUE_TEMPLATE/**'
+                          - '!.github/PULL_REQUEST_TEMPLATE.md'
+                          - '!.cursor/**'
+                          - '!.husky/**'
+                          - '!CODEOWNERS'
+                          - '!packages/eslint-plugin/**'
+                          - '!packages/stylelint-config/**'
+                          - '!packages/prettier-config/**'
+                          - '!packages/npm-package-json-lint-config/**'
+                          - '!packages/jest-console/**'
+                          - '!packages/jest-preset-default/**'
+                          - '!packages/jest-puppeteer-axe/**'
+                          - '!packages/docgen/**'
+                          - '!packages/project-management-automation/**'
+                          - '!eslint.config.mjs'
+                          - '!.stylelintrc*'
+                          - '!.prettierrc*'
+                          - '!.editorconfig'
+                          - '!.markdownlint*'
+            - name: Default to run outside pull requests
+              id: force-run
+              if: github.event_name != 'pull_request'
+              run: echo "impactful=true" >> "$GITHUB_OUTPUT"
+
     performance:
         timeout-minutes: 60
         name: Run performance tests
         runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
-        if: ${{ github.repository == 'WordPress/gutenberg' }}
+        needs: changes
+        if: ${{ (github.event_name != 'pull_request' || needs.changes.outputs.should_run == 'true') && github.repository == 'WordPress/gutenberg' }}
         env:
             WP_ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
 


### PR DESCRIPTION
## What?

Adds a lightweight `changes` filter job to [`end2end-test.yml`](https://github.com/WordPress/gutenberg/blob/trunk/.github/workflows/end2end-test.yml) and [`performance.yml`](https://github.com/WordPress/gutenberg/blob/trunk/.github/workflows/performance.yml) so that PRs touching only non-impactful files (Markdown, Storybook story files, dev-only packages, etc.) skip those long-running jobs. Behavior on `push`, `release`, and `workflow_dispatch` events is unchanged.

## Why?

The full Playwright matrix (8 shards) and the 60-minute Performance job currently run on every PR, including PRs that only touch documentation, Storybook stories, or development-only configs (lint plugins, Prettier config, etc.). Those changes cannot affect e2e or performance test outcomes, so the runs are pure overhead.

## How?

A new `changes` job at the top of each workflow uses [`dorny/paths-filter@v4.0.1`](https://github.com/dorny/paths-filter) to compute a single boolean output `should_run`:

- On `pull_request`, the filter returns `true` if any changed file falls outside the ignore list (Markdown, `docs/**`, `**/stories/**`, `.storybook/**`, dev-only packages like `eslint-plugin`, `prettier-config`, etc.).
- On all other events, a fallback step echoes `should_run=true` so push/release/dispatch keep their current behavior.

The filter is configured with `predicate-quantifier: 'every'`. This is load-bearing: `dorny/paths-filter` defaults to `some`, under which each rule (including the `**` baseline) is an independent OR predicate, so `!`-prefixed exclusions never have a chance to exclude anything. Under `every`, all rules must match — `**` AND `!**/*.md` AND ... AND ... — which produces the intended "everything except these paths" semantics. Anyone editing the filter list later needs to keep this constraint in mind.

Downstream jobs gate on the output via `if:`. Skipped-via-`if:` jobs are treated as success by branch protection, so the required check names (`Playwright - 1` … `Playwright - 8`, `Run performance tests`) remain satisfied without any branch-protection changes.

The `merge-artifacts` job in `end2end-test.yml` also gains the `changes` gate. This is required, not optional: GitHub treats a skipped `needs:` job as success, so without the additional guard `merge-artifacts` would still run after a fully skipped matrix and try to merge nonexistent artifacts.

### File pattern set

Ignored on PRs (skip e2e/perf if these are the only changes):

- All Markdown (`**/*.md`) and the `docs/` tree
- Storybook stories (`**/stories/**`, `**/*.story.*`, `**/*.stories.*`) and config (`.storybook/**`, `storybook/**`)
- GitHub templates and meta files (`.github/ISSUE_TEMPLATE/**`, `.github/PULL_REQUEST_TEMPLATE.md`, `CODEOWNERS`)
- Editor/agent metadata (`.cursor/**`, `.husky/**`)
- Dev-only packages whose contents never load in the editor or perf/e2e harness: `eslint-plugin`, `stylelint-config`, `prettier-config`, `npm-package-json-lint-config`, `jest-console`, `jest-preset-default`, `jest-puppeteer-axe`, `docgen`, `project-management-automation`
- Root lint/format configs (`eslint.config.mjs`, `.stylelintrc*`, `.prettierrc*`, `.editorconfig`, `.markdownlint*`)

Deliberately not ignored (look dev-only but actually affect e2e or perf):

- `packages/babel-*`, `packages/postcss-*`, `packages/*-webpack-plugin`, `packages/wp-build`, `packages/scripts`, `packages/browserslist-config`: feed into the build of the plugin code that e2e and perf load
- `packages/e2e-tests/`, `packages/e2e-test-utils-playwright/`, `packages/report-flaky-tests/`: directly part of the e2e pipeline
- `packages/env/`: drives `wp-env-test start` in both workflows
- The workflow files themselves, so changes to either workflow always trigger a real run

The filter list is intentionally duplicated between the two workflows for review clarity. Both blocks carry a `NOTE: Keep in sync with the other workflow` comment. Extracting into a shared composite action is a possible follow-up.

### New external action

This introduces `dorny/paths-filter` as a new third-party action for this repo, pinned to a full commit SHA (`fbd0ab8f3e69293af611ebaee6363fc25e6d187d`, `v4.0.1`). It is widely used and only needs `pull-requests: read` for the change-detection step.

## Testing Instructions

Validated via a stacked PR (#77535) that touches only `README.md` and a `*.story.tsx` file. With this PR's changes applied, both workflows produce a passing `Detect impactful changes` job and the `Playwright - N`, `Merge Artifacts`, and `Run performance tests` jobs all complete with conclusion `skipped`. The first attempt incorrectly ran them; that revealed the `predicate-quantifier` requirement noted above, which the latest commit on this branch fixes.

After merge, worth watching the first few PRs in each category:

1. A PR that only touches Markdown or Storybook stories: confirm both `Playwright - N` and `Run performance tests` checks appear as skipped (and are still considered passing for branch protection).
2. A PR that touches `packages/components/src/**/*.tsx` (or any non-ignored source file): confirm both workflows run as today.
3. A push to `trunk` after merge: confirm both workflows run as today (the `changes` job emits `should_run=true` for non-PR events).

Locally, [`actionlint 1.7.11`](https://github.com/rhysd/actionlint) was run against both modified files and reported no issues.

## Notes for reviewers

- A doc-only PR will see e2e and performance show up as skipped checks. This is the intended outcome and is treated as success by branch protection. To force a real run, re-run the workflow.
- This PR relies on each `Playwright - N` matrix child being a required check (or covered by a ruleset). If only some matrix legs are required, skip-vs-run is invisible for the others, which is the same behavior as today.

## Use of AI Tools

The plan, the workflow edits, and this PR description were drafted with assistance from AI tooling (Cursor agents). All output was reviewed and validated locally.
