### PR TITLE
[Do not merge] CI validation: doc-only PR should skip e2e and performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- CI validation: temporary edit to verify the doc-only skip behavior in PR #77533. Do not merge. -->
+
 # Gutenberg
 
 [![End-to-End Tests](https://github.com/WordPress/gutenberg/workflows/End-to-End%20Tests/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22End-to-End+Tests%22+branch%3Atrunk)

--- a/packages/components/src/card/stories/index.story.tsx
+++ b/packages/components/src/card/stories/index.story.tsx
@@ -1,3 +1,4 @@
+// CI validation: temporary edit to verify the stories-only skip behavior in PR #77533. Do not merge.
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import {
 	Card,


### PR DESCRIPTION
## What?

Temporary stacked validation PR for [#77533](https://github.com/WordPress/gutenberg/pull/77533). **Do not merge.**

This PR's only changes are:

- A no-op HTML comment at the top of `README.md` (exercises the `**/*.md` ignore pattern).
- A no-op JS comment at the top of a Storybook story file (exercises the `**/stories/**` ignore pattern).

## Why?

To verify, with a real CI run, that the new `changes` filter job in [#77533](https://github.com/WordPress/gutenberg/pull/77533) correctly skips the End-to-End and Performance workflows when a PR touches only ignored paths.

## Expected CI behavior

- `Playwright - 1` … `Playwright - 8`: **skipped** (gray dash).
- `Run performance tests`: **skipped** (gray dash).
- All other checks (unit tests, lint, etc.): run normally.
- Despite the e2e and performance checks being skipped, branch protection should consider them passing for required-status purposes.

If any of the e2e or performance jobs actually run, the filter is over-eager and #77533 needs adjustment. If they all skip cleanly, the filter is working as designed.

## How?

Branched off `ci/skip-e2e-perf-on-non-impactful-changes` (the head of #77533) and added a single doc-only commit. The PR base is the feature branch, so `dorny/paths-filter` only sees the doc-only diff.

## Cleanup

Once observed, this PR will be closed without merging and the branch deleted.

## Use of AI Tools

This PR was created with assistance from AI tooling (Cursor agents) for validation purposes only. It will not be merged.
