### PR TITLE
Experiments Page: Update labels for media experiments to better clarify what they do

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -126,18 +126,6 @@ function gutenberg_initialize_experiments_settings() {
 	);
 
 	add_settings_field(
-		'gutenberg-dataviews-media-modal',
-		__( 'Data Views: new media modal', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Enables a new media modal experience powered by Data Views for improved media library management.', 'gutenberg' ),
-			'id'    => 'gutenberg-dataviews-media-modal',
-		)
-	);
-
-	add_settings_field(
 		'gutenberg-full-page-client-side-navigation',
 		__( 'Interactivity API: Full-page client-side navigation', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
@@ -204,7 +192,7 @@ function gutenberg_initialize_experiments_settings() {
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Enables editing media items (attachments) directly in the block editor with a dedicated media preview and metadata panel.', 'gutenberg' ),
+			'label' => __( 'Adds an "Edit media" action on image blocks for editing the attached media item (metadata and content) in the editor.', 'gutenberg' ),
 			'id'    => 'gutenberg-media-editor',
 		)
 	);
@@ -216,8 +204,20 @@ function gutenberg_initialize_experiments_settings() {
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Enables the in-place Media Editor modal for editing attachments (e.g. from the image block) without navigating to the attachment post type.', 'gutenberg' ),
+			'label' => __( 'Enables an in-place modal for image editing — cropping, adjustments, and metadata — opened from blocks like the image block without navigating away from the current post.', 'gutenberg' ),
 			'id'    => 'gutenberg-media-editor-modal',
+		)
+	);
+
+	add_settings_field(
+		'gutenberg-dataviews-media-modal',
+		__( 'Media Upload Modal', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Replaces the existing WordPress media modal with a new modal powered by Data Views, supporting browsing, selecting, and uploading media.', 'gutenberg' ),
+			'id'    => 'gutenberg-dataviews-media-modal',
 		)
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of:

* https://github.com/WordPress/gutenberg/issues/73771
* https://github.com/WordPress/gutenberg/issues/72734
* https://github.com/WordPress/gutenberg/issues/73085

In the Gutenberg Experiments page, group together the media-related experiments and better clarify what each does. There are currently three:

* Media Editor (being able to edit a media item in a different state of the editor itself)
* Media Editor Modal (being able to edit a media item in a modal — invoked from the image block, and it'll eventually allow cropping and metadata editing)
* Media Upload Modal — the DataViews-powered alternative to the WP media library, used when selecting or uploading images

The Media Editor Modal experiment is very new, and I expect that it'll replace the Media Editor experiment entirely. I'm not removing that experiment _just_ yet as I'd like to see how far we get with the modal approach first. But my hunch is that we'll remove `Media Editor` and just have the two modals as experiments. Until then, we've got three.

## Why?

A colleague asked which experiments did what, which made me think we should clarify the labels on these as the experiments have shifted slightly from their original labels / intentions, and grouping them together will hopefully make them easier to find in the list.

## How?

Just changing the wording of the labels, but not the actual experiment keys in use.

## Testing Instructions

Open up: http://localhost:8888/wp-admin/admin.php?page=gutenberg-experiments and give the experiments a read. Do they make sense?

You can also smoke testing enabling them and seeing that the flags still work as expected

## Screenshots or screencast <!-- if applicable -->

### Before

They were in different sections and possibly a bit ambiguous:

<img width="2196" height="1416" alt="image" src="https://github.com/user-attachments/assets/0f6bb0fc-beb7-4b89-abc9-4ae70584b15b" />

### After

Grouped together, and hopefully a bit clearer (happy to tweak if it still feels off!)

<img width="2194" height="426" alt="image" src="https://github.com/user-attachments/assets/3c611e4a-886c-45cd-87ec-00e3d5e05870" />

## Use of AI Tools

Claude Code (Opus 4.7) used to perform the changes.
