### PR TITLE
Media Editor Modal: render cropper in canvas for images

### DIFF
--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -1,0 +1,56 @@
+/**
+ * Internal dependencies
+ */
+import { useMediaEditorContext } from '../media-editor-provider';
+import { getMediaTypeFromMimeType } from '../../utils';
+import { Cropper, useCropperState } from '../../image-editor';
+
+/**
+ * Props for MediaEditorCanvas.
+ */
+export interface MediaEditorCanvasProps {
+	/**
+	 * Called on each cropper gesture end with the current dirty state.
+	 *
+	 * The modal captures this so a later save-path PR can react without
+	 * re-plumbing. Not used to drive UI in this PR.
+	 */
+	onDirtyChange?: ( isDirty: boolean ) => void;
+}
+
+/**
+ * Editing surface for image media in the media editor modal.
+ *
+ * Sibling to `MediaPreview`: `MediaPreview` is a passive viewer, this is the
+ * interactive editor. The modal decides which to render based on media type.
+ *
+ * Returns `null` for missing or non-image media so the modal's outer guards
+ * can render a spinner or fall through to `<MediaPreview>` respectively.
+ *
+ * @param props               Component props.
+ * @param props.onDirtyChange Called on each cropper gesture end with the
+ *                            current dirty state.
+ */
+export default function MediaEditorCanvas( {
+	onDirtyChange,
+}: MediaEditorCanvasProps ) {
+	const { media } = useMediaEditorContext();
+	const controller = useCropperState();
+
+	const mediaUrl = media?.source_url;
+	const mediaType = getMediaTypeFromMimeType( media?.mime_type );
+
+	if ( ! mediaUrl || mediaType.type !== 'image' ) {
+		return null;
+	}
+
+	return (
+		<div className="media-editor-canvas">
+			<Cropper
+				src={ mediaUrl }
+				controller={ controller }
+				onGestureEnd={ () => onDirtyChange?.( controller.isDirty ) }
+			/>
+		</div>
+	);
+}

--- a/packages/media-editor/src/components/media-editor-canvas/style.scss
+++ b/packages/media-editor/src/components/media-editor-canvas/style.scss
@@ -1,0 +1,9 @@
+// The canvas wrapper fills the modal's canvas area so the cropper has a
+// sized parent (the cropper uses 100% width/height of its container).
+// `position: relative` establishes a stacking context for any future
+// overlays rendered inside the canvas.
+.media-editor-canvas {
+	position: relative;
+	width: 100%;
+	height: 100%;
+}

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -35,9 +35,11 @@ import {
 import { MediaEditorProvider } from '../media-editor-provider';
 import type { Media } from '../media-editor-provider';
 import MediaPreview from '../media-preview';
+import MediaEditorCanvas from '../media-editor-canvas';
 import MediaForm from '../media-form';
 import { store as mediaEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import { getMediaTypeFromMimeType } from '../../utils';
 
 const { Tabs } = unlock( componentsPrivateApis );
 
@@ -130,6 +132,12 @@ export function MediaEditorModal( { fields = [] }: MediaEditorModalProps ) {
 	const { closeMediaEditorModal } = useDispatch( mediaEditorStore );
 
 	const [ isSaving, setIsSaving ] = useState( false );
+
+	// Captured from the cropper via MediaEditorCanvas. Unused in this PR —
+	// a follow-up will wire this to the Save button so save is enabled only
+	// when the cropper has edits.
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const [ isDirty, setIsDirty ] = useState( false );
 
 	// Snapshot the original values for fields the modal edits, so Cancel can
 	// restore them. Captured once per open.
@@ -262,7 +270,18 @@ export function MediaEditorModal( { fields = [] }: MediaEditorModalProps ) {
 					className="media-editor-modal__skeleton"
 					content={
 						<div className="media-editor-modal__canvas">
-							{ media ? <MediaPreview /> : <Spinner /> }
+							{ ! media && <Spinner /> }
+							{ media &&
+								getMediaTypeFromMimeType( media.mime_type )
+									.type === 'image' && (
+									<MediaEditorCanvas
+										key={ media.id }
+										onDirtyChange={ setIsDirty }
+									/>
+								) }
+							{ media &&
+								getMediaTypeFromMimeType( media.mime_type )
+									.type !== 'image' && <MediaPreview /> }
 						</div>
 					}
 					sidebar={ <ComplementaryArea.Slot scope="media-editor" /> }

--- a/packages/media-editor/src/style.scss
+++ b/packages/media-editor/src/style.scss
@@ -2,3 +2,4 @@
 @use "./components/media-preview/style.scss" as *;
 @use "./image-editor/style.scss" as *;
 @use "./components/media-editor-modal/style.scss" as *;
+@use "./components/media-editor-canvas/style.scss" as *;


### PR DESCRIPTION
## What?

Mount the internal image editor (`<Cropper>` + `useCropperState()`, from #77479) inside the media editor modal (from #77480) when the edited attachment is an image. Non-image media (video/audio/file) continues to render through `<MediaPreview>` unchanged.

Part of:

* https://github.com/WordPress/gutenberg/issues/73771
* https://github.com/WordPress/gutenberg/issues/72734

## Why?

Now that the modal scaffold and the cropper are both merged, this is the minimum wiring to get the cropper rendering inside the modal. Keeps the PR small so follow-ups (tools UI, save path) can be reviewed on their own merits.

## How?

* New internal component `MediaEditorCanvas` wraps `useCropperState()` + `<Cropper>`. Sibling to `MediaPreview`: `MediaPreview` stays a passive viewer, `MediaEditorCanvas` is the interactive editor.
* `MediaEditorModal` routes to `MediaEditorCanvas` for images, `MediaPreview` otherwise. A `key={ media.id }` on the canvas guarantees a clean remount if the attachment changes while the modal is open.
* `MediaEditorCanvas` bubbles `controller.isDirty` up via `onDirtyChange` on gesture end. The modal captures it in local state — unused for now, ready for a future PR to gate the Save button on edits.
* No public API changes. `MediaEditorCanvas` is internal to `@wordpress/media-editor`.

## What's explicitly *not* in this PR

* No toolbar (rotate / flip / aspect-ratio presets / zoom slider). That's the next PR, along with decisions about sidebar placement.
* No save path. Save still only persists attachment metadata; cropper state is discarded on close.
* No unit tests — the wrapper is too thin to test meaningfully, and the cropper itself already has 254 tests.

## Testing Instructions

1. Activate the **Media Editor Modal** experiment at `wp-admin/admin.php?page=gutenberg-experiments`.
2. In a post or page, add an image block and upload an image.
3. Click the Crop icon in the block toolbar. The modal should open with the cropper mounted in the canvas.
4. Verify pan (drag) and zoom (mouse wheel / pinch) work.
5. Cancel closes the modal. Re-open → Save closes the modal (metadata save path unchanged).
6. Insert an audio/video/file block. The modal (when reached through any existing flow) continues to use `<MediaPreview>`.

## Screenshots

<!-- todo: add before/after of the modal showing the cropper canvas -->