### PR TITLE
Media Editor: auto zoom-out during freeform crop handle drag

### DIFF
--- a/packages/media-editor/src/image-editor/core/camera.ts
+++ b/packages/media-editor/src/image-editor/core/camera.ts
@@ -101,6 +101,10 @@ export function getImageFit(
  * are viewport-relative: the image mirrors across the viewport's vertical /
  * horizontal axis regardless of current rotation.
  *
+ * `state.zoom` below 1 is supported — the matrix simply renders the image
+ * smaller than its contain-fit. This is only reachable while `isResizing`
+ * is true; `SETTLE_CROP` restores the invariant.
+ *
  * @param state         The current cropper state (zoom, rotation, flip, crop).
  * @param containerSize The size of the container in pixels.
  * @param imageSize     The natural size of the image in pixels.

--- a/packages/media-editor/src/image-editor/core/constants.ts
+++ b/packages/media-editor/src/image-editor/core/constants.ts
@@ -39,6 +39,7 @@ export const DEFAULT_STATE: CropperState = {
 	baseRotation: 0,
 	flip: { ...DEFAULT_FLIP },
 	cropRect: { ...DEFAULT_CROP_RECT },
+	isResizing: false,
 };
 
 /**

--- a/packages/media-editor/src/image-editor/core/constants.ts
+++ b/packages/media-editor/src/image-editor/core/constants.ts
@@ -7,6 +7,16 @@ export const MIN_ZOOM = 1;
 export const MAX_ZOOM = 10;
 
 /**
+ * Minimum zoom while a handle-driven resize is in progress.
+ *
+ * Below 1, the image renders smaller than its classic contain-fit so
+ * the growing crop rect can still frame it. 0.1 is an arbitrary lower
+ * bound — far below anything the UX would reach, but finite to avoid
+ * divide-by-zero in coverage math.
+ */
+export const MIN_ZOOM_RESIZING = 0.1;
+
+/**
  * Maximum free-rotation offset in degrees from the nearest 90° step.
  * The rotation slider allows ±45° around the current cardinal angle.
  */

--- a/packages/media-editor/src/image-editor/core/containment.ts
+++ b/packages/media-editor/src/image-editor/core/containment.ts
@@ -297,7 +297,13 @@ export function restrictPanZoom(
 			? imageSize.width / imageSize.height
 			: 1;
 	const minZoom = getMinZoomForCover( state.rotation, aspectRatio, cropRect );
-	const zoom = Math.max( state.zoom, minZoom );
+	// While a handle drag is in progress, the caller is intentionally
+	// shrinking zoom below the cover floor so the image can recede as
+	// the crop grows. Don't fight it — just keep the candidate zoom as-is.
+	// End-of-drag (`END_RESIZE` + `SETTLE_CROP`) restores the invariant.
+	const zoom = state.isResizing
+		? state.zoom
+		: Math.max( state.zoom, minZoom );
 
 	// Step 2: build camera with candidate pan and corrected zoom.
 	const candidateState = { ...state, zoom };

--- a/packages/media-editor/src/image-editor/core/state.ts
+++ b/packages/media-editor/src/image-editor/core/state.ts
@@ -377,6 +377,11 @@ export function cropperReducer(
 			return commitBase(
 				enforceContainment( {
 					...state,
+					// Clear the resize flag so a caller that forgot to
+					// dispatch END_RESIZE first still lands in a coherent
+					// post-drag state — otherwise `commitBase` would leave
+					// `base*` pinned while live fields moved on.
+					isResizing: false,
 					zoom: state.zoom * s,
 					pan: {
 						x: ( state.pan.x - oldCx + 0.5 ) * s,

--- a/packages/media-editor/src/image-editor/core/state.ts
+++ b/packages/media-editor/src/image-editor/core/state.ts
@@ -390,6 +390,18 @@ export function cropperReducer(
 				operationToAction( state, action.payload )
 			);
 
+		case 'BEGIN_RESIZE':
+			if ( state.isResizing ) {
+				return state;
+			}
+			return { ...state, isResizing: true };
+
+		case 'END_RESIZE':
+			if ( ! state.isResizing ) {
+				return state;
+			}
+			return { ...state, isResizing: false };
+
 		case 'RESET':
 			return commitBase(
 				enforceContainment( {

--- a/packages/media-editor/src/image-editor/core/state.ts
+++ b/packages/media-editor/src/image-editor/core/state.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import type { CropperState, CropperAction, TransformOperation } from './types';
-import { DEFAULT_STATE, MAX_ZOOM } from './constants';
+import { DEFAULT_STATE, MAX_ZOOM, MIN_ZOOM_RESIZING } from './constants';
 import { normalizeRotation, degreesToRadians } from './math/rotation';
 import { restrictPanZoom, restrictCropRect } from './containment';
 
@@ -128,6 +128,13 @@ export function enforceContainment( state: CropperState ): CropperState {
  * @return The state with base fields synced to current.
  */
 function commitBase( next: CropperState ): CropperState {
+	// Any action dispatched while `isResizing` leaves `base*` pinned —
+	// the user has not yet committed the new pose. The pin is cleared
+	// by `END_RESIZE` followed by `SETTLE_CROP`, which relies on the
+	// pre-drag base to snap back to a coherent post-drag state.
+	if ( next.isResizing ) {
+		return next;
+	}
 	if (
 		next.basePan.x === next.pan.x &&
 		next.basePan.y === next.pan.y &&
@@ -185,7 +192,8 @@ export function cropperReducer(
 			);
 
 		case 'SET_ZOOM': {
-			const z = Math.min( MAX_ZOOM, Math.max( 1, action.payload ) );
+			const floor = state.isResizing ? MIN_ZOOM_RESIZING : 1;
+			const z = Math.min( MAX_ZOOM, Math.max( floor, action.payload ) );
 			return commitBase(
 				enforceContainment( {
 					...state,
@@ -195,7 +203,11 @@ export function cropperReducer(
 		}
 
 		case 'SET_ZOOM_AT_POINT': {
-			const z = Math.min( MAX_ZOOM, Math.max( 1, action.payload.zoom ) );
+			const floor = state.isResizing ? MIN_ZOOM_RESIZING : 1;
+			const z = Math.min(
+				MAX_ZOOM,
+				Math.max( floor, action.payload.zoom )
+			);
 			return commitBase(
 				enforceContainment( {
 					...state,

--- a/packages/media-editor/src/image-editor/core/test/sub-unit-zoom.ts
+++ b/packages/media-editor/src/image-editor/core/test/sub-unit-zoom.ts
@@ -52,3 +52,54 @@ describe( 'BEGIN_RESIZE / END_RESIZE', () => {
 		expect( next.cropRect ).toEqual( state.cropRect );
 	} );
 } );
+
+describe( 'SET_ZOOM during resize', () => {
+	it( 'allows zoom < 1 while isResizing', () => {
+		const state = makeState( { isResizing: true } );
+		const next = cropperReducer( state, {
+			type: 'SET_ZOOM',
+			payload: 0.6,
+		} );
+		expect( next.zoom ).toBeCloseTo( 0.6, 5 );
+	} );
+
+	it( 'clamps zoom to MIN_ZOOM when not resizing', () => {
+		const state = makeState();
+		const next = cropperReducer( state, {
+			type: 'SET_ZOOM',
+			payload: 0.6,
+		} );
+		expect( next.zoom ).toBe( 1 );
+	} );
+
+	it( 'does not overwrite baseZoom while isResizing', () => {
+		const state = makeState( {
+			isResizing: true,
+			zoom: 1.5,
+			baseZoom: 1.5,
+		} );
+		const next = cropperReducer( state, {
+			type: 'SET_ZOOM',
+			payload: 0.7,
+		} );
+		expect( next.zoom ).toBeCloseTo( 0.7, 5 );
+		expect( next.baseZoom ).toBe( 1.5 );
+	} );
+
+	it( 'preserves sub-unit zoom through enforceContainment at a rotation where cover floor > payload', () => {
+		// With rotation 45° and a centered square crop, the cover
+		// floor (minZoom for restrictPanZoom) is well above 1. If the
+		// containment skip in `restrictPanZoom` were missing, the
+		// 0.4 payload would be bumped back up to that floor.
+		const state = makeState( {
+			isResizing: true,
+			rotation: 45,
+			cropRect: { x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+		} );
+		const next = cropperReducer( state, {
+			type: 'SET_ZOOM',
+			payload: 0.4,
+		} );
+		expect( next.zoom ).toBeCloseTo( 0.4, 5 );
+	} );
+} );

--- a/packages/media-editor/src/image-editor/core/test/sub-unit-zoom.ts
+++ b/packages/media-editor/src/image-editor/core/test/sub-unit-zoom.ts
@@ -6,6 +6,7 @@
  * `preview-export-parity.ts`. This file covers only the sub-unit path:
  * begin → grow crop past 1.0 → end → settle → back in the normal domain.
  */
+import { createCamera, screenToWorld, worldToScreen } from '../camera';
 import { DEFAULT_STATE } from '../constants';
 import { cropperReducer } from '../state';
 import type { CropperState, Size } from '../types';
@@ -127,5 +128,27 @@ describe( 'SETTLE_CROP after sub-unit zoom', () => {
 		const cy = rect.y + rect.height / 2;
 		expect( cx ).toBeCloseTo( 0.5, 2 );
 		expect( cy ).toBeCloseTo( 0.5, 2 );
+	} );
+} );
+
+/**
+ * Camera math is linear, so `zoom < 1` is mathematically safe — but
+ * this test pins it down explicitly. A world point at the image center
+ * should map to the container center regardless of zoom, and round-trip
+ * through worldToScreen → screenToWorld.
+ */
+describe( 'camera at zoom < 1', () => {
+	it( 'round-trips a world point through createCamera at zoom=0.5', () => {
+		const state = makeState( { isResizing: true, zoom: 0.5 } );
+		const container: Size = { width: 800, height: 600 };
+		const camera = createCamera( state, container, IMAGE );
+		const worldIn = { x: 0.5, y: 0.5 };
+		const screen = worldToScreen( camera, worldIn );
+		const worldOut = screenToWorld( camera, screen );
+		expect( worldOut.x ).toBeCloseTo( worldIn.x, 5 );
+		expect( worldOut.y ).toBeCloseTo( worldIn.y, 5 );
+		// Image center should map to container center.
+		expect( screen.x ).toBeCloseTo( container.width / 2, 1 );
+		expect( screen.y ).toBeCloseTo( container.height / 2, 1 );
 	} );
 } );

--- a/packages/media-editor/src/image-editor/core/test/sub-unit-zoom.ts
+++ b/packages/media-editor/src/image-editor/core/test/sub-unit-zoom.ts
@@ -103,3 +103,29 @@ describe( 'SET_ZOOM during resize', () => {
 		expect( next.zoom ).toBeCloseTo( 0.4, 5 );
 	} );
 } );
+
+describe( 'SETTLE_CROP after sub-unit zoom', () => {
+	it( 'snaps zoom back to >= 1 after settle', () => {
+		// Simulate an in-progress drag that left zoom below 1 with a
+		// crop rect expanded to fill the new, smaller image footprint.
+		const state = makeState( {
+			isResizing: true,
+			zoom: 0.7,
+			cropRect: { x: 0.05, y: 0.05, width: 0.9, height: 0.9 },
+		} );
+
+		// End-of-drag: clear flag, then settle.
+		const ended = cropperReducer( state, { type: 'END_RESIZE' } );
+		expect( ended.isResizing ).toBe( false );
+
+		const settled = cropperReducer( ended, { type: 'SETTLE_CROP' } );
+		expect( settled.zoom ).toBeGreaterThanOrEqual( 1 );
+		// Crop should be centered and fill at least one axis.
+		const rect = settled.cropRect;
+		expect( Math.max( rect.width, rect.height ) ).toBeCloseTo( 1, 2 );
+		const cx = rect.x + rect.width / 2;
+		const cy = rect.y + rect.height / 2;
+		expect( cx ).toBeCloseTo( 0.5, 2 );
+		expect( cy ).toBeCloseTo( 0.5, 2 );
+	} );
+} );

--- a/packages/media-editor/src/image-editor/core/test/sub-unit-zoom.ts
+++ b/packages/media-editor/src/image-editor/core/test/sub-unit-zoom.ts
@@ -106,6 +106,21 @@ describe( 'SET_ZOOM during resize', () => {
 } );
 
 describe( 'SETTLE_CROP after sub-unit zoom', () => {
+	it( 'self-heals isResizing if a caller forgot END_RESIZE', () => {
+		// Defensive: SETTLE_CROP must leave `isResizing` false regardless
+		// of input so `commitBase` can re-snapshot the pose. A caller who
+		// dispatches SETTLE_CROP without first dispatching END_RESIZE
+		// should still land in a coherent state.
+		const state = makeState( {
+			isResizing: true,
+			zoom: 0.8,
+			cropRect: { x: 0.1, y: 0.1, width: 0.8, height: 0.8 },
+		} );
+		const next = cropperReducer( state, { type: 'SETTLE_CROP' } );
+		expect( next.isResizing ).toBe( false );
+		expect( next.baseZoom ).toBe( next.zoom );
+	} );
+
 	it( 'snaps zoom back to >= 1 after settle', () => {
 		// Simulate an in-progress drag that left zoom below 1 with a
 		// crop rect expanded to fill the new, smaller image footprint.

--- a/packages/media-editor/src/image-editor/core/test/sub-unit-zoom.ts
+++ b/packages/media-editor/src/image-editor/core/test/sub-unit-zoom.ts
@@ -1,0 +1,54 @@
+/**
+ * Sub-unit zoom regime — the transient state entered during a handle-driven
+ * resize drag where the image can render below classic contain-fit.
+ *
+ * Parity with the committed-state domain (zoom ≥ 1) is covered by
+ * `preview-export-parity.ts`. This file covers only the sub-unit path:
+ * begin → grow crop past 1.0 → end → settle → back in the normal domain.
+ */
+import { DEFAULT_STATE } from '../constants';
+import { cropperReducer } from '../state';
+import type { CropperState, Size } from '../types';
+
+const IMAGE: Size = { width: 1600, height: 900 };
+
+function makeState( overrides: Partial< CropperState > = {} ): CropperState {
+	return {
+		...DEFAULT_STATE,
+		image: {
+			src: 'test.jpg',
+			naturalWidth: IMAGE.width,
+			naturalHeight: IMAGE.height,
+		},
+		...overrides,
+	};
+}
+
+describe( 'BEGIN_RESIZE / END_RESIZE', () => {
+	it( 'BEGIN_RESIZE sets isResizing without touching pan/zoom/crop', () => {
+		const state = makeState( {
+			zoom: 1.5,
+			pan: { x: 0.1, y: -0.2 },
+			cropRect: { x: 0.2, y: 0.2, width: 0.5, height: 0.5 },
+		} );
+		const next = cropperReducer( state, { type: 'BEGIN_RESIZE' } );
+		expect( next.isResizing ).toBe( true );
+		expect( next.zoom ).toBe( state.zoom );
+		expect( next.pan ).toEqual( state.pan );
+		expect( next.cropRect ).toEqual( state.cropRect );
+	} );
+
+	it( 'END_RESIZE clears isResizing without touching pan/zoom/crop', () => {
+		const state = makeState( {
+			isResizing: true,
+			zoom: 0.75,
+			pan: { x: 0.1, y: -0.2 },
+			cropRect: { x: 0.2, y: 0.2, width: 0.5, height: 0.5 },
+		} );
+		const next = cropperReducer( state, { type: 'END_RESIZE' } );
+		expect( next.isResizing ).toBe( false );
+		expect( next.zoom ).toBe( 0.75 );
+		expect( next.pan ).toEqual( state.pan );
+		expect( next.cropRect ).toEqual( state.cropRect );
+	} );
+} );

--- a/packages/media-editor/src/image-editor/core/types.ts
+++ b/packages/media-editor/src/image-editor/core/types.ts
@@ -102,6 +102,11 @@ export interface CropperState {
 	flip: Flip;
 	/** The crop rectangle in normalized coordinates. */
 	cropRect: NormalizedRect;
+	/**
+	 * True while a handle-driven resize drag is in progress.
+	 * Always false in committed state.
+	 */
+	isResizing: boolean;
 }
 
 /**
@@ -136,7 +141,19 @@ export type CropperAction =
 	/** Applies a single pipeline transform via the reducer. */
 	| { type: 'APPLY_OPERATION'; payload: TransformOperation }
 	/** Resets to DEFAULT_STATE, optionally merging a partial override. */
-	| { type: 'RESET'; payload?: Partial< CropperState > };
+	| { type: 'RESET'; payload?: Partial< CropperState > }
+	/**
+	 * Begin a handle-driven resize. Sets `isResizing: true` so subsequent
+	 * `SET_CROP_RECT` dispatches can scale zoom below 1. No other state
+	 * changes — pan/zoom/rotation/crop are preserved.
+	 */
+	| { type: 'BEGIN_RESIZE' }
+	/**
+	 * End a handle-driven resize. Clears `isResizing`. Does NOT re-run
+	 * containment or settle — the caller is expected to follow with
+	 * `SETTLE_CROP`, which snaps zoom back to ≥ 1.
+	 */
+	| { type: 'END_RESIZE' };
 
 /**
  * The contract for a pluggable stencil component.

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -40,6 +40,13 @@ import './cropper.scss';
 /** Threshold for comparing normalized crop rect values. */
 const CROP_RECT_EPSILON = 1e-6;
 
+/**
+ * Leaves a small margin around the crop during handle-driven resize
+ * so the handles stay a little inside the container edge — easier to
+ * grab outward than if they sat flush against it.
+ */
+const RESIZE_FIT_MARGIN = 0.95;
+
 // Largest rect of the given pixel aspect ratio that fits inside the visual
 // bounds, centered in [0,1] × [0,1] normalized space. Returns a full-frame
 // rect (1×1) if `aspectRatio` is unset or non-positive.
@@ -336,9 +343,17 @@ function CropperInner(
 	 */
 	const handleCropChange = useCallback(
 		( rect: NormalizedRect ) => {
-			setCropRect( rect );
+			if ( ! state.isResizing || ! freeformCrop ) {
+				setCropRect( rect );
+				return;
+			}
+			const largest = Math.max( rect.width, rect.height );
+			const fit =
+				largest > 0 ? Math.min( 1, RESIZE_FIT_MARGIN / largest ) : 1;
+			dispatch( { type: 'SET_CROP_RECT', payload: rect } );
+			dispatch( { type: 'SET_ZOOM', payload: fit } );
 		},
-		[ setCropRect ]
+		[ state.isResizing, freeformCrop, setCropRect, dispatch ]
 	);
 
 	// Settling animation: brief linear transition after resize end.
@@ -354,17 +369,27 @@ function CropperInner(
 	}, [] );
 
 	/**
+	 * Handle resize start — switch the reducer into resize mode so
+	 * zoom can drop below 1 while the handles are being dragged.
+	 */
+	const handleResizeStart = useCallback( () => {
+		dispatch( { type: 'BEGIN_RESIZE' } );
+		onGestureStart?.();
+	}, [ dispatch, onGestureStart ] );
+
+	/**
 	 * Handle resize end — settle the crop rect (re-center, fill height).
 	 */
 	const handleResizeEnd = useCallback( () => {
 		setSettling( true );
+		dispatch( { type: 'END_RESIZE' } );
 		settleCrop();
 		onGestureEnd?.();
 		clearTimeout( settleTimerRef.current );
 		settleTimerRef.current = setTimeout( () => {
 			setSettling( false );
 		}, 200 );
-	}, [ settleCrop, onGestureEnd ] );
+	}, [ dispatch, settleCrop, onGestureEnd ] );
 
 	const imageTransition =
 		settling || isZooming ? 'transform 150ms linear' : undefined;
@@ -452,7 +477,7 @@ function CropperInner(
 				containerSize={ containerSize }
 				imageSize={ visualSize }
 				onCropChange={ handleCropChange }
-				onResizeStart={ onGestureStart }
+				onResizeStart={ handleResizeStart }
 				onResizeEnd={ handleResizeEnd }
 				aspectRatio={ aspectRatio }
 				freeformCrop={ freeformCrop }

--- a/packages/media-editor/src/image-editor/react/hooks/test/resize-zoom-out.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/resize-zoom-out.ts
@@ -1,0 +1,84 @@
+/**
+ * Integration: the full dispatch chain through `useCropperState` when
+ * the user drags a freeform crop handle outward.
+ *
+ * Covers what the unit tests in `core/test/sub-unit-zoom.ts` cannot —
+ * that dispatching BEGIN_RESIZE followed by successive SET_CROP_RECT +
+ * SET_ZOOM pairs via the hook's `__dispatch` yields a sub-unit zoom,
+ * and that END_RESIZE + `settleCrop` restores `zoom >= 1` and clears
+ * the flag.
+ */
+
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { useCropperState } from '../use-cropper-state';
+
+describe( 'handle-driven zoom-out integration', () => {
+	it( 'drops zoom below 1 as the east edge grows past the image', () => {
+		const { result } = renderHook( () => useCropperState() );
+
+		act( () => {
+			result.current.setImage( {
+				src: 'test.jpg',
+				naturalWidth: 1600,
+				naturalHeight: 900,
+			} );
+		} );
+
+		// Start from a centered crop.
+		act( () => {
+			result.current.setCropRect( {
+				x: 0.25,
+				y: 0.25,
+				width: 0.5,
+				height: 0.5,
+			} );
+		} );
+
+		act( () => {
+			result.current.__dispatch( { type: 'BEGIN_RESIZE' } );
+		} );
+
+		// Simulate the cropper's handleCropChange path: combined crop +
+		// zoom dispatch via `__dispatch`. This isolates reducer behavior
+		// from the component.
+		act( () => {
+			result.current.__dispatch( {
+				type: 'SET_CROP_RECT',
+				payload: { x: 0.1, y: 0.25, width: 0.9, height: 0.5 },
+			} );
+			result.current.__dispatch( {
+				type: 'SET_ZOOM',
+				payload: 0.95 / 0.9,
+			} );
+		} );
+		// Grown further — past the point where zoom must go below 1.
+		act( () => {
+			result.current.__dispatch( {
+				type: 'SET_CROP_RECT',
+				payload: { x: 0.0, y: 0.2, width: 1.0, height: 0.6 },
+			} );
+			result.current.__dispatch( {
+				type: 'SET_ZOOM',
+				payload: 0.95 / 1.0,
+			} );
+		} );
+
+		expect( result.current.state.zoom ).toBeLessThan( 1 );
+		expect( result.current.state.isResizing ).toBe( true );
+
+		// Release: settle should restore the invariant.
+		act( () => {
+			result.current.__dispatch( { type: 'END_RESIZE' } );
+			result.current.settleCrop();
+		} );
+		expect( result.current.state.zoom ).toBeGreaterThanOrEqual( 1 );
+		expect( result.current.state.isResizing ).toBe( false );
+	} );
+} );

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
@@ -902,11 +902,13 @@ describe( 'useCropperState', () => {
 			// committed pose and are redundant for dirty tracking — if
 			// any base field differs from initial, the corresponding
 			// live field (crop/zoom/rotation) will also differ.
+			// 'isResizing' is a transient UI flag, not a user edit.
 			const excludedFields = [
 				'image',
 				'basePan',
 				'baseZoom',
 				'baseRotation',
+				'isResizing',
 			];
 
 			const stateKeys = flattenKeys(


### PR DESCRIPTION
## Summary

- When dragging a freeform crop handle outward toward (or past) the image edge, the image now auto-scales down so the crop can keep growing past its original footprint.
- On release, the view settles back to a normal fit with the new crop centered and `zoom >= 1` restored.
- Addresses the follow-up from https://github.com/WordPress/gutenberg/pull/77479#issuecomment-4285653857.

## How it works

A transient `isResizing` flag gates a sub-unit-zoom regime in the cropper reducer:

- `BEGIN_RESIZE` on handle pointerdown relaxes the `zoom >= 1` floor and pins `base*` fields.
- During drag, `handleCropChange` dispatches a combined `SET_CROP_RECT` + `SET_ZOOM` where zoom is computed so the growing crop fits the container with a small margin (`RESIZE_FIT_MARGIN = 0.95`).
- `restrictPanZoom` in containment skips the cover-floor bump while the flag is set — the camera math is linear and handles `zoom < 1` without modification (verified by test + JSDoc in `createCamera`).
- `END_RESIZE` clears the flag; `SETTLE_CROP` then re-expands the crop, recenters, and `enforceContainment` restores the cover invariant. `SETTLE_CROP` also self-heals the flag so a caller that forgets `END_RESIZE` still lands in a coherent state.

Behavior is gated to freeform crops — fixed aspect-ratio presets are untouched.

## Tests

- New focused suite `core/test/sub-unit-zoom.ts` covers the sub-unit regime: flag transitions, sub-unit zoom through `SET_ZOOM` and `enforceContainment`, settle self-heal, zoom-back-to-≥1, and camera round-trip at `zoom=0.5`.
- New integration test `react/hooks/test/resize-zoom-out.ts` exercises the full dispatch chain through the state hook.
- The 12k-assertion `preview-export-parity.ts` suite is deliberately untouched and still green — the sub-unit regime is transient and never escapes into committed state.

## Test plan

- [ ] Drag the east/west/north/south handles outward on a 16:9 image — image scales down, handles keep tracking.
- [ ] Drag the nw/ne/sw/se corners outward — same behavior.
- [ ] Release — crop re-centers, zoom snaps to >= 1.
- [ ] Drag a handle inward — image stays put until release.
- [ ] With a fixed aspect ratio preset active — zoom-out does NOT engage; clamp behavior matches trunk.
- [ ] Rotate (15 degrees) + drag — still works.
- [ ] Flip + drag — still works.
- [ ] Existing 12k preview-export parity suite still passes.

## Follow-ups (not in this PR)

- v4 smoother settle transition (width/height/left/top animation).
- Approach-driven zoom-out (start shrinking before the handle reaches the edge).
- `createCamera` -> `getImageFit` delegation refactor.