### PR TITLE
Taxonomies: Declare `@wordpress/base-styles` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63200,6 +63200,7 @@
 			"dependencies": {
 				"@wordpress/admin-ui": "file:../../packages/admin-ui",
 				"@wordpress/api-fetch": "file:../../packages/api-fetch",
+				"@wordpress/base-styles": "file:../../packages/base-styles",
 				"@wordpress/components": "file:../../packages/components",
 				"@wordpress/core-data": "file:../../packages/core-data",
 				"@wordpress/data": "file:../../packages/data",

--- a/routes/taxonomies/package.json
+++ b/routes/taxonomies/package.json
@@ -11,6 +11,7 @@
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",
 		"@wordpress/api-fetch": "file:../../packages/api-fetch",
+		"@wordpress/base-styles": "file:../../packages/base-styles",
 		"@wordpress/components": "file:../../packages/components",
 		"@wordpress/core-data": "file:../../packages/core-data",
 		"@wordpress/data": "file:../../packages/data",


### PR DESCRIPTION
## What?
Adds `@wordpress/base-styles` to the dependencies list in `routes/taxonomies/package.json`.

## Why?
`routes/taxonomies/style.scss` imports from `@wordpress/base-styles` but the package was not declared as a dependency of the route. This was flagged in post-merge review of #77497.

Ref: https://github.com/WordPress/gutenberg/pull/77497#discussion_r3118017614

## How?
Just added the dependency.

## Testing Instructions
  - npm install succeeds without warnings about the missing dep.
  - npm run build completes successfully.
  - The taxonomies route styles still render correctly in the editor (modal animations, spacing, borders).

### Testing Instructions for Keyboard
Same

## Use of AI Tools

Opus 4.7
