### PR TITLE
Connectors: keep focus on action Button during install

### DIFF
--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -195,6 +195,7 @@ function ApiKeyConnector( {
 							onClick={ handleActionClick }
 							disabled={ pluginStatus === 'checking' || isBusy }
 							isBusy={ isBusy }
+							accessibleWhenDisabled
 						>
 							{ getButtonLabel() }
 						</Button>

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __experimentalHStack as HStack, Button } from '@wordpress/components';
+import { useEffect, useRef } from '@wordpress/element';
 import {
 	__experimentalRegisterConnector as registerConnector,
 	__experimentalConnectorItem as ConnectorItem,
@@ -152,6 +153,18 @@ function ApiKeyConnector( {
 		( pluginStatus === 'inactive' && canActivatePlugins === false );
 	const showActionButton = ! showUnavailableBadge;
 
+	const actionButtonRef = useRef< HTMLButtonElement >( null );
+	const pendingFocusRef = useRef( false );
+
+	// Restore focus to the action button after the API key form closes,
+	// since the focused element inside the form is removed from the DOM.
+	useEffect( () => {
+		if ( pendingFocusRef.current && ! isBusy ) {
+			pendingFocusRef.current = false;
+			actionButtonRef.current?.focus();
+		}
+	}, [ isBusy, isExpanded, isConnected ] );
+
 	return (
 		<ConnectorItem
 			className={
@@ -166,6 +179,7 @@ function ApiKeyConnector( {
 					{ showUnavailableBadge && <UnavailableActionBadge /> }
 					{ showActionButton && (
 						<Button
+							ref={ actionButtonRef }
 							variant={
 								isExpanded || isConnected
 									? 'tertiary'
@@ -196,10 +210,20 @@ function ApiKeyConnector( {
 					readOnly={ isConnected || isExternallyConfigured }
 					keySource={ keySource }
 					onRemove={
-						isExternallyConfigured ? undefined : removeApiKey
+						isExternallyConfigured
+							? undefined
+							: async () => {
+									pendingFocusRef.current = true;
+									try {
+										await removeApiKey();
+									} catch {
+										pendingFocusRef.current = false;
+									}
+							  }
 					}
 					onSave={ async ( apiKey: string ) => {
 						await saveApiKey( apiKey );
+						pendingFocusRef.current = true;
 						setIsExpanded( false );
 					} }
 				/>

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __experimentalHStack as HStack, Button } from '@wordpress/components';
-import { useEffect, useRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import {
 	__experimentalRegisterConnector as registerConnector,
 	__experimentalConnectorItem as ConnectorItem,
@@ -154,16 +154,6 @@ function ApiKeyConnector( {
 	const showActionButton = ! showUnavailableBadge;
 
 	const actionButtonRef = useRef< HTMLButtonElement >( null );
-	const pendingFocusRef = useRef( false );
-
-	// Restore focus to the action button after the API key form closes,
-	// since the focused element inside the form is removed from the DOM.
-	useEffect( () => {
-		if ( pendingFocusRef.current && ! isBusy ) {
-			pendingFocusRef.current = false;
-			actionButtonRef.current?.focus();
-		}
-	}, [ isBusy, isExpanded, isConnected ] );
 
 	return (
 		<ConnectorItem
@@ -213,18 +203,14 @@ function ApiKeyConnector( {
 						isExternallyConfigured
 							? undefined
 							: async () => {
-									pendingFocusRef.current = true;
-									try {
-										await removeApiKey();
-									} catch {
-										pendingFocusRef.current = false;
-									}
+									await removeApiKey();
+									actionButtonRef.current?.focus();
 							  }
 					}
 					onSave={ async ( apiKey: string ) => {
 						await saveApiKey( apiKey );
-						pendingFocusRef.current = true;
 						setIsExpanded( false );
+						actionButtonRef.current?.focus();
 					} }
 				/>
 			) }

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __experimentalHStack as HStack, Button } from '@wordpress/components';
-import { useEffect, useRef } from '@wordpress/element';
 import {
 	__experimentalRegisterConnector as registerConnector,
 	__experimentalConnectorItem as ConnectorItem,
@@ -153,24 +152,6 @@ function ApiKeyConnector( {
 		( pluginStatus === 'inactive' && canActivatePlugins === false );
 	const showActionButton = ! showUnavailableBadge;
 
-	const actionButtonRef = useRef< HTMLButtonElement >( null );
-	const pendingFocusRef = useRef( false );
-
-	// Restore focus to the action button after async actions complete.
-	useEffect( () => {
-		if ( pendingFocusRef.current && ! isBusy ) {
-			pendingFocusRef.current = false;
-			actionButtonRef.current?.focus();
-		}
-	}, [ isBusy, isExpanded, isConnected ] );
-
-	const handleActionClick = () => {
-		if ( pluginStatus === 'not-installed' || pluginStatus === 'inactive' ) {
-			pendingFocusRef.current = true;
-		}
-		handleButtonClick();
-	};
-
 	return (
 		<ConnectorItem
 			className={
@@ -185,14 +166,13 @@ function ApiKeyConnector( {
 					{ showUnavailableBadge && <UnavailableActionBadge /> }
 					{ showActionButton && (
 						<Button
-							ref={ actionButtonRef }
 							variant={
 								isExpanded || isConnected
 									? 'tertiary'
 									: 'secondary'
 							}
 							size="compact"
-							onClick={ handleActionClick }
+							onClick={ handleButtonClick }
 							disabled={ pluginStatus === 'checking' || isBusy }
 							isBusy={ isBusy }
 							accessibleWhenDisabled
@@ -216,20 +196,10 @@ function ApiKeyConnector( {
 					readOnly={ isConnected || isExternallyConfigured }
 					keySource={ keySource }
 					onRemove={
-						isExternallyConfigured
-							? undefined
-							: async () => {
-									pendingFocusRef.current = true;
-									try {
-										await removeApiKey();
-									} catch {
-										pendingFocusRef.current = false;
-									}
-							  }
+						isExternallyConfigured ? undefined : removeApiKey
 					}
 					onSave={ async ( apiKey: string ) => {
 						await saveApiKey( apiKey );
-						pendingFocusRef.current = true;
 						setIsExpanded( false );
 					} }
 				/>


### PR DESCRIPTION
Follow-up on #76456

## What?

This PR fixes an issue where focus is temporarily lost on the connector screen during plugin installation. As a result, the screen reader's narration when the install button is pressed is refined.

Before:

```
Install  button
Connectors ‹ gutenberg — WordPress  document   
Plugin for Anthropic installed and activated successfully. 
main landmark
Connectors  region
Anthropic  grouping
Cancel  button
```

After

```
Install  button
unavailable
Plugin for Anthropic installed and activated successfully.
```

## Why?

When a plugin is installing, the button changes to a disabled state, causing focus to be lost. Although focus is restored via `useEffect` afterward, redundant information is conveyed to screen readers.

## How?

- Add the `accessibleWhenDisabled` prop to ensure that the button never loses focus.
- The button only needs to be explicitly focused when saving or deleting the API key. Therefore, this PR focuses the button as an onClick trigger instead of useEffect.

## Testing Instructions

1. Launch your screen reader.
2. Go to the Connectors screen.
3. Using only keyboard operations, install, enable, register, and delete plugins and API keys.
4. The screen reader should function properly, and focus should never be lost.

## Screenshots or screencast

https://github.com/user-attachments/assets/7236fc8c-e4a1-4430-bab0-27a6b7ade045

## Use of AI Tools

Authored with assistance from Claude Code. All changes were reviewed and tested by the author.