### PR TITLE
Image editor: reserve inner gutter so crop handles stay accessible

### DIFF
--- a/packages/media-editor/src/components/media-editor-modal/style.scss
+++ b/packages/media-editor/src/components/media-editor-modal/style.scss
@@ -59,7 +59,6 @@
 		justify-content: center;
 		background: $gray-100;
 		overflow: auto;
-		padding: $grid-unit-20;
 		height: 100%;
 
 		// MediaPreview uses `min-height: 100%` so it can grow when needed in

--- a/packages/media-editor/src/image-editor/react/components/cropper.scss
+++ b/packages/media-editor/src/image-editor/react/components/cropper.scss
@@ -1,3 +1,8 @@
+// Handle touch target size — used both for the handle ::before hit area and
+// for the inner canvas inset (half the touch target on each side so the full
+// reach extends to the crop edge).
+$handle-touch-target-size: 44px;
+
 .wp-media-editor-image-editor {
 	position: relative;
 	overflow: hidden;
@@ -8,14 +13,14 @@
 	cursor: grab;
 
 	// Inner gutter for resize handles. Handles use negative offsets and a
-	// 44×44 touch target that extends past the crop edge; the root clips
-	// overflow (required for the dimming overlay's box-shadow trick), so a
-	// flush handle would be clipped. The inner `__canvas` wrapper is inset
-	// by half the touch target, reserving reach room on all sides while
-	// keeping the root as the clipping boundary.
+	// touch target that extends past the crop edge; the root clips overflow
+	// (required for the dimming overlay's box-shadow trick), so a flush
+	// handle would be clipped. The inner `__canvas` wrapper is inset by half
+	// the touch target, reserving reach room on all sides while keeping the
+	// root as the clipping boundary.
 	&__canvas {
 		position: absolute;
-		inset: 22px;
+		inset: calc($handle-touch-target-size / 2);
 	}
 
 	&--dragging {
@@ -97,14 +102,14 @@
 		box-sizing: border-box;
 		pointer-events: auto;
 
-		// Extend touch target to 44px minimum for accessibility.
+		// Extend touch target to the minimum accessible hit area.
 		&::before {
 			content: "";
 			position: absolute;
 			top: 50%;
 			left: 50%;
-			width: 44px;
-			height: 44px;
+			width: $handle-touch-target-size;
+			height: $handle-touch-target-size;
 			transform: translate(-50%, -50%);
 		}
 

--- a/packages/media-editor/src/image-editor/react/components/cropper.scss
+++ b/packages/media-editor/src/image-editor/react/components/cropper.scss
@@ -7,6 +7,17 @@
 	user-select: none;
 	cursor: grab;
 
+	// Inner gutter for resize handles. Handles use negative offsets and a
+	// 44×44 touch target that extends past the crop edge; the root clips
+	// overflow (required for the dimming overlay's box-shadow trick), so a
+	// flush handle would be clipped. The inner `__canvas` wrapper is inset
+	// by half the touch target, reserving reach room on all sides while
+	// keeping the root as the clipping boundary.
+	&__canvas {
+		position: absolute;
+		inset: 22px;
+	}
+
 	&--dragging {
 		cursor: grabbing;
 	}

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -175,7 +175,7 @@ function CropperInner(
 	// positioning context for image/stencil/handles — inset from the root
 	// by the handle gutter, so crop math operates on the reduced box.
 	const canvasRef = useRef< HTMLDivElement >( null );
-	const [ containerSize, setContainerSize ] = useState< Size >( {
+	const [ canvasSize, setCanvasSize ] = useState< Size >( {
 		width: 0,
 		height: 0,
 	} );
@@ -188,7 +188,7 @@ function CropperInner(
 		const observer = new ResizeObserver( ( entries ) => {
 			for ( const entry of entries ) {
 				const { width, height } = entry.contentRect;
-				setContainerSize( ( prev ) => {
+				setCanvasSize( ( prev ) => {
 					if ( prev.width === width && prev.height === height ) {
 						return prev;
 					}
@@ -216,11 +216,11 @@ function CropperInner(
 	const { elementSize, visualSize } = useMemo(
 		() =>
 			getImageFit(
-				containerSize,
+				canvasSize,
 				{ width: naturalWidth, height: naturalHeight },
 				state.rotation
 			),
-		[ containerSize, naturalWidth, naturalHeight, state.rotation ]
+		[ canvasSize, naturalWidth, naturalHeight, state.rotation ]
 	);
 
 	// In fixed-crop mode, auto-size the crop rect to fill the visual area
@@ -276,14 +276,14 @@ function CropperInner(
 		if ( ! state.image || elementSize.width === 0 ) {
 			return undefined;
 		}
-		return getCropBounds( state, elementSize, visualSize, containerSize );
-	}, [ state, elementSize, visualSize, containerSize ] );
+		return getCropBounds( state, elementSize, visualSize, canvasSize );
+	}, [ state, elementSize, visualSize, canvasSize ] );
 
 	// Use the interaction hook for mouse, touch, and keyboard events.
 	const { handlers, onWheelNative, isDragging, isZooming } = useInteraction(
 		state,
 		dispatch,
-		containerSize,
+		canvasSize,
 		visualSize,
 		{
 			minZoom,
@@ -381,8 +381,8 @@ function CropperInner(
 		if ( elementSize.width === 0 || elementSize.height === 0 ) {
 			return {};
 		}
-		const centerX = ( containerSize.width - elementSize.width ) / 2;
-		const centerY = ( containerSize.height - elementSize.height ) / 2;
+		const centerX = ( canvasSize.width - elementSize.width ) / 2;
+		const centerY = ( canvasSize.height - elementSize.height ) / 2;
 		return {
 			width: elementSize.width,
 			height: elementSize.height,
@@ -393,7 +393,7 @@ function CropperInner(
 			transform: transformString,
 			transition: imageTransition,
 		};
-	}, [ containerSize, elementSize, transformString, imageTransition ] );
+	}, [ canvasSize, elementSize, transformString, imageTransition ] );
 
 	// Forward the root element to the consumer's ref.
 	const setContainerRef = useCallback(
@@ -452,7 +452,7 @@ function CropperInner(
 				{ showDimming && (
 					<DimmingOverlay
 						cropRect={ state.cropRect }
-						containerSize={ containerSize }
+						containerSize={ canvasSize }
 						imageSize={ visualSize }
 					/>
 				) }
@@ -460,7 +460,7 @@ function CropperInner(
 				{ /* The stencil (crop area with handles) */ }
 				<StencilComponent
 					cropRect={ state.cropRect }
-					containerSize={ containerSize }
+					containerSize={ canvasSize }
 					imageSize={ visualSize }
 					onCropChange={ handleCropChange }
 					onResizeStart={ onGestureStart }
@@ -475,7 +475,7 @@ function CropperInner(
 				{ showGrid && (
 					<GridOverlay
 						cropRect={ state.cropRect }
-						containerSize={ containerSize }
+						containerSize={ canvasSize }
 						imageSize={ visualSize }
 					/>
 				) }

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -171,15 +171,17 @@ function CropperInner(
 		settleCrop,
 		__dispatch: dispatch,
 	} = controller;
-	// Container measurement via ResizeObserver.
-	const containerRef = useRef< HTMLDivElement >( null );
+	// Canvas measurement via ResizeObserver. The canvas is the inner
+	// positioning context for image/stencil/handles — inset from the root
+	// by the handle gutter, so crop math operates on the reduced box.
+	const canvasRef = useRef< HTMLDivElement >( null );
 	const [ containerSize, setContainerSize ] = useState< Size >( {
 		width: 0,
 		height: 0,
 	} );
 
 	useEffect( () => {
-		const element = containerRef.current;
+		const element = canvasRef.current;
 		if ( ! element ) {
 			return;
 		}
@@ -292,9 +294,11 @@ function CropperInner(
 	);
 
 	// Register wheel handler natively with { passive: false } so
-	// preventDefault works. React's onWheel registers as passive.
+	// preventDefault works. React's onWheel registers as passive. Bound
+	// to the canvas (not the root) so pointer geometry inside the handler
+	// resolves against the canvas box.
 	useEffect( () => {
-		const el = containerRef.current;
+		const el = canvasRef.current;
 		if ( ! el ) {
 			return;
 		}
@@ -391,12 +395,9 @@ function CropperInner(
 		};
 	}, [ containerSize, elementSize, transformString, imageTransition ] );
 
-	// Merge the forwarded ref with the internal container ref.
+	// Forward the root element to the consumer's ref.
 	const setContainerRef = useCallback(
 		( element: HTMLDivElement | null ) => {
-			(
-				containerRef as React.MutableRefObject< HTMLDivElement | null >
-			 ).current = element;
 			if ( typeof ref === 'function' ) {
 				ref( element );
 			} else if ( ref ) {
@@ -416,77 +417,88 @@ function CropperInner(
 				isDragging && 'wp-media-editor-image-editor--dragging',
 				className
 			) }
-			// The container is focusable so keyboard users can pan/zoom
-			// with arrow keys and +/−. We deliberately do NOT use
-			// role="application" — it disables the screen reader's
-			// normal keyboard interception, which is too heavy-handed
-			// for a single widget in a page. Screen reader users get
-			// the ARIA live region (below) as the announcement channel.
-			tabIndex={ 0 }
-			role="group"
-			aria-label={ __( 'Image editor' ) }
-			{ ...handlers }
 		>
-			{ /* The image layer */ }
-			<img
-				className="wp-media-editor-image-editor__image"
-				src={ src }
-				alt=""
-				onLoad={ handleImageLoad }
-				style={ imageStyle }
-				draggable={ false }
-			/>
-
-			{ /* Dimming overlay outside the crop area */ }
-			{ showDimming && (
-				<DimmingOverlay
-					cropRect={ state.cropRect }
-					containerSize={ containerSize }
-					imageSize={ visualSize }
-				/>
-			) }
-
-			{ /* The stencil (crop area with handles) */ }
-			<StencilComponent
-				cropRect={ state.cropRect }
-				containerSize={ containerSize }
-				imageSize={ visualSize }
-				onCropChange={ handleCropChange }
-				onResizeStart={ onGestureStart }
-				onResizeEnd={ handleResizeEnd }
-				aspectRatio={ aspectRatio }
-				freeformCrop={ freeformCrop }
-				stencilTransition={ settleStencilTransition }
-				cropBounds={ cropBounds }
-			/>
-
-			{ /* Rule-of-thirds grid */ }
-			{ showGrid && (
-				<GridOverlay
-					cropRect={ state.cropRect }
-					containerSize={ containerSize }
-					imageSize={ visualSize }
-				/>
-			) }
-
-			{ /* ARIA live region for screen reader announcements */ }
+			{ /*
+			 * The canvas is the interactive, inset surface. Handles and
+			 * the ARIA role/tabIndex live here so pointer geometry
+			 * (getBoundingClientRect on e.currentTarget) resolves against
+			 * the same box that crop math uses. The root stays as the
+			 * clipping shell for the dimming overlay's box-shadow.
+			 *
+			 * Not role="application" — that disables the screen reader's
+			 * normal keyboard interception, too heavy-handed for a single
+			 * widget. Screen reader users get the ARIA live region below
+			 * as the announcement channel.
+			 */ }
 			<div
-				aria-live="polite"
-				aria-atomic="true"
-				className="wp-media-editor-image-editor__aria-live"
-				style={ {
-					position: 'absolute',
-					width: 1,
-					height: 1,
-					padding: 0,
-					margin: -1,
-					overflow: 'hidden',
-					clip: 'rect(0, 0, 0, 0)',
-					whiteSpace: 'nowrap',
-					border: 0,
-				} }
+				ref={ canvasRef }
+				className="wp-media-editor-image-editor__canvas"
+				tabIndex={ 0 }
+				role="group"
+				aria-label={ __( 'Image editor' ) }
+				{ ...handlers }
 			>
-				{ ariaMessage }
+				{ /* The image layer */ }
+				<img
+					className="wp-media-editor-image-editor__image"
+					src={ src }
+					alt=""
+					onLoad={ handleImageLoad }
+					style={ imageStyle }
+					draggable={ false }
+				/>
+
+				{ /* Dimming overlay outside the crop area */ }
+				{ showDimming && (
+					<DimmingOverlay
+						cropRect={ state.cropRect }
+						containerSize={ containerSize }
+						imageSize={ visualSize }
+					/>
+				) }
+
+				{ /* The stencil (crop area with handles) */ }
+				<StencilComponent
+					cropRect={ state.cropRect }
+					containerSize={ containerSize }
+					imageSize={ visualSize }
+					onCropChange={ handleCropChange }
+					onResizeStart={ onGestureStart }
+					onResizeEnd={ handleResizeEnd }
+					aspectRatio={ aspectRatio }
+					freeformCrop={ freeformCrop }
+					stencilTransition={ settleStencilTransition }
+					cropBounds={ cropBounds }
+				/>
+
+				{ /* Rule-of-thirds grid */ }
+				{ showGrid && (
+					<GridOverlay
+						cropRect={ state.cropRect }
+						containerSize={ containerSize }
+						imageSize={ visualSize }
+					/>
+				) }
+
+				{ /* ARIA live region for screen reader announcements */ }
+				<div
+					aria-live="polite"
+					aria-atomic="true"
+					className="wp-media-editor-image-editor__aria-live"
+					style={ {
+						position: 'absolute',
+						width: 1,
+						height: 1,
+						padding: 0,
+						margin: -1,
+						overflow: 'hidden',
+						clip: 'rect(0, 0, 0, 0)',
+						whiteSpace: 'nowrap',
+						border: 0,
+					} }
+				>
+					{ ariaMessage }
+				</div>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Description

Part of:

* https://github.com/WordPress/gutenberg/issues/73771

Follow up to https://github.com/WordPress/gutenberg/pull/77479

Crop handles on the image editor use negative offsets and a 44×44 touch target that extends past the crop edge. The cropper root is `overflow: hidden` (required for the dimming overlay's `box-shadow` trick), so when the crop sits flush against the root, the handle rim and most of its touch target get clipped.

### After

https://github.com/user-attachments/assets/4d811d79-ece6-401b-ba84-a090e654a785


### Before


https://github.com/user-attachments/assets/fb0ab5ea-310e-4a57-b64e-5460564addc0



- Added an inner `__canvas` wrapper inset by 22px (half the touch target). Absolutely-positioned children (image, dimming, stencil, grid, handles, aria-live) now render inside the wrapper; the root stays as the clipping boundary for the dimming shadow.
- Moved event handlers, `tabIndex`, `role`, and `aria-label` onto the wrapper so pointer geometry (`e.currentTarget.getBoundingClientRect()`) resolves against the same box crop math uses — no changes needed in `interaction-controller.ts`.
- Removed the now-redundant `padding: $grid-unit-20` from `.media-editor-modal__canvas`; the gutter lives in the cropper where it belongs.

## Test steps

- [ ] Open the media editor modal on an image attachment.
- [ ] Enable freeform crop, drag the crop area against each edge of the canvas. All 8 handles remain fully visible — no clipped rims.
- [ ] Click/tap handles near the canvas edge. The 44×44 touch target is reachable beyond the visible square.
- [ ] Wheel-zoom with the cursor near the canvas edge. Focal-point zoom still keeps the point under the cursor stationary.
- [ ] Keyboard-focus the cropper, pan with arrow keys, zoom with `+/-`.
- [ ] Storybook `MediaEditor/ImageEditor → Rectangle Crop` story: toggle freeform, confirm handles stay on-canvas.
- [ ] Dimming overlay still darkens everything outside the crop, including the gutter.


