### PR TITLE
Site Logo Block: Enable the media editor modal experiment for the crop button

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -51,7 +51,9 @@ import { unlock } from '../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
-const { mediaEditKey } = unlock( blockEditorPrivateApis );
+const { mediaEditKey, openMediaEditorModalKey } = unlock(
+	blockEditorPrivateApis
+);
 
 const SiteLogo = ( {
 	alt,
@@ -78,22 +80,26 @@ const SiteLogo = ( {
 	const blockEditingMode = useBlockEditingMode();
 	const isContentOnlyMode = blockEditingMode === 'contentOnly';
 
-	const { imageEditing, maxWidth, title, editMediaEntity } = useSelect(
-		( select ) => {
-			const settings = select( blockEditorStore ).getSettings();
-			const siteEntities = select( coreStore ).getEntityRecord(
-				'root',
-				'__unstableBase'
-			);
-			return {
-				title: siteEntities?.name,
-				imageEditing: settings.imageEditing,
-				maxWidth: settings.maxWidth,
-				editMediaEntity: settings?.[ mediaEditKey ],
-			};
-		},
-		[]
-	);
+	const {
+		imageEditing,
+		maxWidth,
+		title,
+		editMediaEntity,
+		openMediaEditorModal,
+	} = useSelect( ( select ) => {
+		const settings = select( blockEditorStore ).getSettings();
+		const siteEntities = select( coreStore ).getEntityRecord(
+			'root',
+			'__unstableBase'
+		);
+		return {
+			title: siteEntities?.name,
+			imageEditing: settings.imageEditing,
+			maxWidth: settings.maxWidth,
+			editMediaEntity: settings?.[ mediaEditKey ],
+			openMediaEditorModal: settings?.[ openMediaEditorModalKey ],
+		};
+	}, [] );
 
 	useEffect( () => {
 		// Turn the `Use as site icon` toggle off if it is on but the logo and icon have
@@ -109,6 +115,12 @@ const SiteLogo = ( {
 			setIsEditingImage( false );
 		}
 	}, [ isSelected ] );
+
+	const handleMediaUpdate = ( { id: newId } ) => {
+		if ( typeof newId === 'number' && newId !== logoId ) {
+			setLogo( newId );
+		}
+	};
 
 	function onResizeStart() {
 		toggleSelection( false );
@@ -388,7 +400,15 @@ const SiteLogo = ( {
 				shouldShowCropAndDimensions && (
 					<BlockControls group="block">
 						<ToolbarButton
-							onClick={ () => setIsEditingImage( true ) }
+							onClick={
+								openMediaEditorModal && logoId
+									? () =>
+											openMediaEditorModal( {
+												id: logoId,
+												onUpdate: handleMediaUpdate,
+											} )
+									: () => setIsEditingImage( true )
+							}
 							icon={ crop }
 							label={ __( 'Crop' ) }
 						/>


### PR DESCRIPTION
## What?

Follows #77480 

Part of:

* #73771 

Now that there's a Media Editor Modal experiment (originally just hooked into the Image block), also add it in to the Site Logo block, connected to the crop button in the block toolbar.

## Why?

As some of us experiment with a media editor modal to enable cropping of media items, this will help ensure that all places we're using cropping tools for blocks are working and doing the same thing. As it stands, I think it's just the Image and Site Logo blocks that use cropping tools, so this is the only other one that needed to be added in.

## How?

* Follow what we did for the Image block and use `openMediaEditorModal` and pass it a callback to update the attachment id when the modal performs an update

## Testing Instructions

Enable the Media Editor Modal experiment:

<img width="2118" height="152" alt="image" src="https://github.com/user-attachments/assets/be9ec5fe-74eb-4fdf-a42c-780b1e77639c" />

Clicking the Crop button in the Site Logo block's toolbar should invoke the media editor modal.
With the experiment switched off, it should use the inline cropper as in trunk.

Note: actual cropping tools have not yet been wired up. This just preps the block to be compatible with it when that happens.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/64ad5df5-8a07-4216-afc0-464e67ec535d

## Use of AI Tools

Claude Code (Opus 4.7)