### PR TITLE
Revisions Slider: Add aria-valuetext for screen reader accessibility

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -4,7 +4,7 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { RangeControl, Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 
 /**
@@ -94,6 +94,17 @@ function RevisionsSlider() {
 		return dateI18n( dateSettings.formats.datetime, revision.date );
 	};
 
+	const selectedRevision = revisions?.[ selectedIndex ];
+	const ariaValueText = selectedRevision
+		? sprintf(
+				/* translators: 1: current revision number, 2: total number of revisions, 3: revision date */
+				__( 'Revision %1$s of %2$s: %3$s' ),
+				selectedIndex + 1,
+				revisions.length,
+				dateI18n( dateSettings.formats.datetime, selectedRevision.date )
+		  )
+		: undefined;
+
 	if ( isLoading ) {
 		return <Spinner />;
 	}
@@ -117,6 +128,7 @@ function RevisionsSlider() {
 	return (
 		<RangeControl
 			__next40pxDefaultSize
+			aria-valuetext={ ariaValueText }
 			className="editor-revisions-header__slider"
 			hideLabelFromVision
 			label={ __( 'Revision' ) }


### PR DESCRIPTION
## What?
Part of #77530

> Slider: Visual label not available to screen readers. Use aria-valuetext to allow screen readers to get the text interpretation of the numeric revision value.

Adds `aria-valuetext` to the revisions slider so screen readers announce a meaningful string instead of a bare numeric index.

## Why?
The revisions slider uses a 0-based index as its value. Screen readers would announce "3" with no context, giving users no useful information about which revision they're on. 

## How?
Computes a human-readable string from the currently selected revision, e.g. _"Revision 3 of 7: January 15, 2025 at 2:30 pm"_  and passes it as `aria-valuetext` on the `RangeControl`. 

## Testing Instructions
1. Open a post or page that has **at least two saved revisions**.
2. Click the **Revisions** button in the right side toolbar.
3. Inspect the slider element in DevTools — the `<input type="range">` should have an `aria-valuetext` attribute.
4. Move the slider left/right and confirm `aria-valuetext` updates to reflect the newly selected revision's number and date.

### Testing Instructions for Keyboard
1. Open a post with multiple revisions and navigate to the Revisions panel.
2. Tab to the revisions slider.
3. Enable a screen reader (e.g. VoiceOver on macOS: `Cmd+F5`).
4. Press the left/right arrow keys to move through revisions and the screen reader should announce the full revision label (e.g. _"Revision 3 of 7: April 21, 2026 at 3:45 pm"_) instead of just a number.

## Screenshots or screencast 

### Before
https://github.com/user-attachments/assets/8b660100-d79c-42d4-a141-279f1850c2cc

### After
https://github.com/user-attachments/assets/912280ae-64ff-4753-94f3-2cabe5c52804

## Use of AI Tools
I used Claude Code to review the code.
