### PR TITLE
Embed: Restore paragraph with URL when undoing paste-to-embed transform

### DIFF
--- a/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
@@ -126,9 +126,9 @@ export default ( props ) => ( element ) => {
 		}
 
 		// Record an intermediate paragraph-with-URL state so a single undo
-		// after the URL → block transformation restores the pasted text.
+		// after the URL → block transformation restores the pasted link.
 		if ( mode === 'BLOCKS' ) {
-			onChange( insert( value, create( { text: trimmedPlainText } ) ) );
+			pasteInline( html );
 			registry
 				.dispatch( blockEditorStore )
 				.__unstableMarkLastChangeAsPersistent();

--- a/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
@@ -8,6 +8,7 @@ import { isURL } from '@wordpress/url';
 /**
  * Internal dependencies
  */
+import { store as blockEditorStore } from '../../../store';
 import { addActiveFormats } from '../utils';
 import { getPasteEventData } from '../../../utils/pasting';
 
@@ -25,6 +26,7 @@ export default ( props ) => ( element ) => {
 			__unstableEmbedURLOnPaste,
 			preserveWhiteSpace,
 			pastePlainText,
+			registry,
 		} = props.current;
 
 		// The event listener is attached to the window, so we need to check if
@@ -116,11 +118,23 @@ export default ( props ) => ( element ) => {
 
 		if ( typeof content === 'string' ) {
 			pasteInline( content );
-		} else if ( content.length > 0 ) {
-			if ( onReplace && isEmpty( value ) ) {
-				onReplace( content, content.length - 1, -1 );
-			}
+			return;
 		}
+
+		if ( ! content.length || ! onReplace || ! isEmpty( value ) ) {
+			return;
+		}
+
+		// Record an intermediate paragraph-with-URL state so a single undo
+		// after the URL → block transformation restores the pasted text.
+		if ( mode === 'BLOCKS' ) {
+			onChange( insert( value, create( { text: trimmedPlainText } ) ) );
+			registry
+				.dispatch( blockEditorStore )
+				.__unstableMarkLastChangeAsPersistent();
+		}
+
+		onReplace( content, content.length - 1, -1 );
 	}
 
 	const { defaultView } = element.ownerDocument;

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -702,7 +702,8 @@ test.describe( 'Copy/cut/paste', () => {
 			{
 				name: 'core/paragraph',
 				attributes: {
-					content: 'https://www.youtube.com/watch?v=FcTLMTyD2DU',
+					content:
+						'<a href="https://www.youtube.com/watch?v=FcTLMTyD2DU">https://www.youtube.com/watch?v=FcTLMTyD2DU</a>',
 				},
 			},
 		] );

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -686,6 +686,28 @@ test.describe( 'Copy/cut/paste', () => {
 		] );
 	} );
 
+	test( 'should undo embed on paste', async ( { pageUtils, editor } ) => {
+		await editor.insertBlock( { name: 'core/paragraph' } );
+		pageUtils.setClipboardData( {
+			plainText: 'https://www.youtube.com/watch?v=FcTLMTyD2DU',
+			html: 'https://www.youtube.com/watch?v=FcTLMTyD2DU',
+		} );
+		await pageUtils.pressKeys( 'primary+v' );
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{ name: 'core/embed' },
+		] );
+
+		await pageUtils.pressKeys( 'primary+z' );
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: 'https://www.youtube.com/watch?v=FcTLMTyD2DU',
+				},
+			},
+		] );
+	} );
+
 	test( 'should not link selection for non http(s) protocol', async ( {
 		pageUtils,
 		editor,


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/11245.
Requires #77546. Rebased, all tests are passing now.
Somewhat related #21789.

PR makes it easier to paste and retain links into empty paragraph blocks. See: https://github.com/WordPress/gutenberg/issues/15102.

Pasting a plain URL into an empty paragraph auto-replaces it with an embed block in a single `REPLACE_BLOCKS`, so `⌘Z` jumped straight back to the empty paragraph and the pasted URL was lost.

Before calling `onReplace` in the BLOCKS-mode paste path, insert the URL into the paragraph and mark that change as persistent. One undo now lands on "paragraph containing URL"; a second undo removes it.

## Testing Instructions
1. Open a post or page. 
2. Paste a YouTube (or any other embeddable) into a paragraph block.
3. Undo the change.
4. Confirm that it reverts to a paragraph with a URL in it.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/6586a80b-c86b-436a-a070-98e0d4ff6a38

## Use of AI Tools

Claude as an assistant, for running the ideas.