### PR TITLE
[Dataviews] Add discussion filter support to Pages

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -206,7 +206,7 @@ export default function PostList( { postType } ) {
 
 		if ( view?.sort?.field === 'author' ) {
 			processedRecords = filterSortAndPaginate(
-				records,
+				processedRecords,
 				{ sort: { ...view.sort } },
 				fields
 			).data;

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -150,6 +150,12 @@ export default function PostList( { postType } ) {
 					filters.after = filter.value;
 				}
 			}
+			if ( filter.field === 'discussion' ) {
+				if ( filter.value === undefined ) {
+					return;
+				}
+				filters.comment_status = filter.value;
+			}
 		} );
 
 		// We want to provide a different default item for the status filter
@@ -188,6 +194,16 @@ export default function PostList( { postType } ) {
 	const data = useMemo( () => {
 		let processedRecords = records;
 
+		const discussionFilter = view.filters?.find(
+			( filter ) => filter.field === 'discussion'
+		);
+
+		if ( discussionFilter?.value ) {
+			processedRecords = processedRecords?.filter(
+				( record ) => record.comment_status === discussionFilter.value
+			);
+		}
+
 		if ( view?.sort?.field === 'author' ) {
 			processedRecords = filterSortAndPaginate(
 				records,
@@ -204,7 +220,7 @@ export default function PostList( { postType } ) {
 		}
 
 		return processedRecords;
-	}, [ records, fields, view?.sort, notesCount ] );
+	}, [ records, fields, view.filters, view?.sort, notesCount ] );
 
 	const ids = data?.map( ( record ) => getItemId( record ) ) ?? [];
 	const prevIds = usePrevious( ids ) ?? [];

--- a/packages/fields/src/fields/discussion/index.tsx
+++ b/packages/fields/src/fields/discussion/index.tsx
@@ -28,7 +28,21 @@ const discussionField: Field< BasePost > = {
 		}
 		return __( 'Closed' );
 	},
-	filterBy: false,
+	elements: [
+		{
+			value: 'open',
+			label: __( 'Open' ),
+			description: __( 'Discussion is open.' ),
+		},
+		{
+			value: 'closed',
+			label: __( 'Closed' ),
+			description: __( 'Discussion is closed.' ),
+		},
+	],
+	filterBy: {
+		operators: [ 'is' ],
+	},
 };
 
 /**


### PR DESCRIPTION
## What?
Closes #73298

Adds support for filtering the Pages Data View by discussion status. Users can filter pages based on whether comments are open or closed.

## Why?
The Pages Data View already exposes discussion information through the discussion field, but filtering was disabled. This made it difficult to quickly find pages with comments enabled or disabled, especially on larger sites.

## How?
This PR enables filtering for the existing discussion field and applies the filter client-side in the Pages Data View by filtering records based on their `comment_status`.

## Testing Instructions
1. Go to Site Editor → Pages.
2. Create or edit a few pages with different discussion settings:
i. One page with discussions enabled.
ii. One page with discussions disabled.
3. Open the Pages Data View filters.
4. Add the “Discussion” filter.
5. Select open and verify only pages with `discussions: open` are shown.
6. Change the filter to closed and verify only pages with `discussions: closed` are shown.
7. Remove the filter and verify all pages appear again.

## Screenshots or screencast <!-- if applicable -->

<img width="379" height="340" alt="image" src="https://github.com/user-attachments/assets/3603b57a-0a61-45a2-98bf-a1068a3bb6d2" />
