### PR TITLE
DataForm: Render field `description` as help text in the `array` control

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- DataForm: Render field `description` as help text in the `array` control.[#77554](https://github.com/WordPress/gutenberg/pull/77554)
+
 ## 14.1.0 (2026-04-15)
 
 ### Enhancements

--- a/packages/dataviews/src/components/dataform-controls/array.tsx
+++ b/packages/dataviews/src/components/dataform-controls/array.tsx
@@ -74,7 +74,6 @@ export default function ArrayControl< Item >( {
 			value={ arrayValueAsElements }
 			onChange={ onChangeControl }
 			placeholder={ placeholder }
-			help={ description }
 			suggestions={ elements?.map( ( element ) => element.value ) }
 			disabled={ disabled }
 			__experimentalValidateInput={ ( token: string ) => {
@@ -90,7 +89,7 @@ export default function ArrayControl< Item >( {
 				return true;
 			} }
 			__experimentalExpandOnFocus={ elements && elements.length > 0 }
-			help={ field.isValid?.elements ? '' : undefined }
+			help={ description ?? ( field.isValid?.elements ? '' : undefined ) }
 			displayTransform={ ( token: any ) => {
 				// For existing tokens (element objects), display their label
 				if ( typeof token === 'object' && 'label' in token ) {

--- a/packages/dataviews/src/components/dataform-controls/array.tsx
+++ b/packages/dataviews/src/components/dataform-controls/array.tsx
@@ -22,7 +22,8 @@ export default function ArrayControl< Item >( {
 	markWhenOptional,
 	validity,
 }: DataFormControlProps< Item > ) {
-	const { label, placeholder, getValue, setValue, isValid } = field;
+	const { label, placeholder, description, getValue, setValue, isValid } =
+		field;
 	const value = getValue( { item: data } );
 	const disabled = field.isDisabled( { item: data, field } );
 
@@ -73,6 +74,7 @@ export default function ArrayControl< Item >( {
 			value={ arrayValueAsElements }
 			onChange={ onChangeControl }
 			placeholder={ placeholder }
+			help={ description }
 			suggestions={ elements?.map( ( element ) => element.value ) }
 			disabled={ disabled }
 			__experimentalValidateInput={ ( token: string ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR builds up upon the work of: https://github.com/WordPress/gutenberg/pull/77552.

It can be tested properly when the above PR is merged and allows the DataForm `array` control to use the `field's` description as a `help` text, similarly to the other controls we have.

## Testing Instructions (after merging `#77552`)
1. In storybook (`npm run storybook:dev`) `?path=/story/dataviews-fieldtypes--array-component`
2. select the item and observe the `help` text being rendered