### PR TITLE
Tighten [style*="border-color"] selector to avoid matching URLs in inline styles

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -125,38 +125,38 @@
 html :where(.has-border-color) {
 	border-style: solid;
 }
-html :where([style*="border-color"]) {
+html :where([style*="border-color:"]) {
 	border-style: solid;
 }
-html :where([style*="border-top-color"]) {
+html :where([style*="border-top-color:"]) {
 	border-top-style: solid;
 }
-html :where([style*="border-right-color"]) {
+html :where([style*="border-right-color:"]) {
 	/*rtl:ignore*/
 	border-right-style: solid;
 }
-html :where([style*="border-bottom-color"]) {
+html :where([style*="border-bottom-color:"]) {
 	border-bottom-style: solid;
 }
-html :where([style*="border-left-color"]) {
+html :where([style*="border-left-color:"]) {
 	/*rtl:ignore*/
 	border-left-style: solid;
 }
 
-html :where([style*="border-width"]) {
+html :where([style*="border-width:"]) {
 	border-style: solid;
 }
-html :where([style*="border-top-width"]) {
+html :where([style*="border-top-width:"]) {
 	border-top-style: solid;
 }
-html :where([style*="border-right-width"]) {
+html :where([style*="border-right-width:"]) {
 	/*rtl:ignore*/
 	border-right-style: solid;
 }
-html :where([style*="border-bottom-width"]) {
+html :where([style*="border-bottom-width:"]) {
 	border-bottom-style: solid;
 }
-html :where([style*="border-left-width"]) {
+html :where([style*="border-left-width:"]) {
 	/*rtl:ignore*/
 	border-left-style: solid;
 }


### PR DESCRIPTION
This change fixes an issue where the selector [style*="border-color"] was too broad and matched unintended cases.

On the WordCamp Europe site, an inline style contained a background image URL with border-color in the filename. This caused the rule to incorrectly apply borders, resulting in random borders appearing across the site.

The selector is now tightened to [style*="border-color:"] to ensure it only targets actual CSS declarations, not substrings inside URLs.


Related #75546 
@aaronrobertshaw 
AI Note: PR Title and Description written by AI