### PR TITLE
LinkControl: Show URL suggestion for custom links in Navigation block across all link variations

### DIFF
--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -33,7 +33,8 @@ const handleEntitySearch = async (
 	fetchSearchSuggestions,
 	withCreateSuggestion,
 	pageOnFront,
-	pageForPosts
+	pageForPosts,
+	withURLSuggestion = true
 ) => {
 	const { isInitialSuggestions } = suggestionsQuery;
 
@@ -57,6 +58,20 @@ const handleEntitySearch = async (
 		return results;
 	}
 
+	// When a URL-like value is entered and URL suggestions are enabled,
+	// append a URL suggestion to entity results. This allows users to create
+	// custom links from any link variation even when direct entry is disabled.
+	if ( isURLLike( val ) && withURLSuggestion ) {
+		const { url, type } = normalizeUrl( val );
+		results.push( {
+			id: val,
+			title: val,
+			url,
+			type,
+		} );
+		return results;
+	}
+
 	// Here we append a faux suggestion to represent a "CREATE" option. This
 	// is detected in the rendering of the search results and handled as a
 	// special case. This is currently necessary because the suggestions
@@ -71,7 +86,7 @@ const handleEntitySearch = async (
 	// to the text value of the `<input>`. This is because `title` is used
 	// when creating the suggestion. Similarly `url` is used when using keyboard to select
 	// the suggestion (the <form> `onSubmit` handler falls-back to `url`).
-	return isURLLike( val ) || ! withCreateSuggestion
+	return ! withCreateSuggestion
 		? results
 		: results.concat( {
 				// the `id` prop is intentionally omitted here because it
@@ -86,7 +101,8 @@ const handleEntitySearch = async (
 export default function useSearchHandler(
 	suggestionsQuery,
 	allowDirectEntry,
-	withCreateSuggestion
+	withCreateSuggestion,
+	withURLSuggestion = true
 ) {
 	const { fetchSearchSuggestions, pageOnFront, pageForPosts } = useSelect(
 		( select ) => {
@@ -108,24 +124,35 @@ export default function useSearchHandler(
 
 	return useCallback(
 		( val, { isInitialSuggestions } ) => {
-			return isURLLike( val )
-				? directEntryHandler( val, { isInitialSuggestions } )
-				: handleEntitySearch(
-						val,
-						{ ...suggestionsQuery, isInitialSuggestions },
-						fetchSearchSuggestions,
-						withCreateSuggestion,
-						pageOnFront,
-						pageForPosts
-				  );
+			// Show URL suggestion when:
+			// 1. Value is URL-like AND
+			// 2. Either direct entry is allowed OR URL suggestions are enabled
+			const shouldShowURLSuggestion =
+				isURLLike( val ) && ( allowDirectEntry || withURLSuggestion );
+
+			if ( shouldShowURLSuggestion && allowDirectEntry ) {
+				return directEntryHandler( val, { isInitialSuggestions } );
+			}
+
+			return handleEntitySearch(
+				val,
+				{ ...suggestionsQuery, isInitialSuggestions },
+				fetchSearchSuggestions,
+				withCreateSuggestion,
+				pageOnFront,
+				pageForPosts,
+				withURLSuggestion
+			);
 		},
 		[
+			allowDirectEntry,
 			directEntryHandler,
 			fetchSearchSuggestions,
 			pageOnFront,
 			pageForPosts,
 			suggestionsQuery,
 			withCreateSuggestion,
+			withURLSuggestion,
 		]
 	);
 }

--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -218,7 +218,7 @@ function UnforwardedLinkUI( props, ref ) {
 						showInitialSuggestions
 						withCreateSuggestion={ false }
 						noDirectEntry={ !! type }
-						noURLSuggestion={ !! type }
+						noURLSuggestion={ false }
 						suggestionsQuery={ getSuggestionsQuery( type, kind ) }
 						onChange={ props.onChange }
 						onInputChange={ ( value ) => {


### PR DESCRIPTION
## What?
Closes #73292

Enable URL suggestions (showing "Press ENTER to add this link") in the Navigation block's link control when typing a URL-like value, matching the behavior already available in button, paragraph, and other blocks.

## Why?
Previously, URL suggestions were only shown in the Custom Link variation of the Navigation block. When users selected a different link variation (Page, Post, Taxonomy) and typed a URL-like value, they received no feedback. This caused confusion and made it unclear whether they could create a custom link from other variations.

The feature already works correctly in button blocks, paragraph blocks (inline links), and other contexts. It was just missing in the Navigation block.

## Testing Instructions
1. In the block editor, add or edit a Navigation block
2. Click on a Navigation Link block
3. Open the link control popup
4. Switch to the **Page** variation (or Post, Taxonomy)
5. Type a URL-like value (e.g., `wordpress.org` or `https://www.example.com`)
6. Verify that a URL suggestion appears with the info text "Press ENTER to add this link"
7. Press ENTER or click the suggestion
8. Verify the custom URL is created as the link

## Screenshots or screencast
https://github.com/user-attachments/assets/56c86f91-24a9-47ec-9dee-fe9cba73688d

