### PR TITLE
Navigation Link: Hide “Create page” option for URL-like input

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -29,6 +29,22 @@ import { LinkUIPageCreator } from './page-creator';
 import LinkUIBlockInserter from './block-inserter';
 import { useEntityBinding, useLinkPreview } from '../shared';
 
+function isURLLikeInput( value = '' ) {
+	const input = value.trim();
+
+	if ( ! input || input.includes( ' ' ) ) {
+		return false;
+	}
+
+	return (
+		isURL( input ) ||
+		/^\/\//.test( input ) ||
+		/^www\./i.test( input ) ||
+		/^(?:\/|\.\/|\.\.\/)/.test( input ) ||
+		/^[a-z0-9-]+\.[a-z]{2,}(?:[/?#].*)?$/i.test( input )
+	);
+}
+
 /**
  * Given the Link block's type attribute, return the query params to give to
  * /wp/v2/search.
@@ -176,6 +192,13 @@ function UnforwardedLinkUI( props, ref ) {
 
 	const blockEditingMode = useBlockEditingMode();
 
+	const currentSearchValue = initialSearchValue || initialSearchValue || '';
+
+	const canAddPage =
+		permissions?.canCreate &&
+		type === 'page' &&
+		! isURLLikeInput( currentSearchValue );
+
 	return (
 		<Popover
 			ref={ ref }
@@ -206,15 +229,11 @@ function UnforwardedLinkUI( props, ref ) {
 						value={ link }
 						showInitialSuggestions
 						withCreateSuggestion={ false }
-						noDirectEntry={ !! type }
-						noURLSuggestion={ !! type }
+						noDirectEntry={ false }
+						noURLSuggestion={ false }
 						suggestionsQuery={ getSuggestionsQuery( type, kind ) }
 						onChange={ props.onChange }
-						onInputChange={ ( value ) => {
-							// Observe the input value so we can pass the value to the page creator
-							// and restore it on back button click
-							searchInputValueRef.current = value;
-						} }
+						onInputChange={ updateSearchValue }
 						inputValue={ initialSearchValue }
 						onRemove={ props.onRemove }
 						onCancel={ props.onCancel }
@@ -236,10 +255,7 @@ function UnforwardedLinkUI( props, ref ) {
 									setAddingPage={ () => {
 										setAddingPage( true );
 									} }
-									canAddPage={
-										permissions?.canCreate &&
-										type === 'page'
-									}
+									canAddPage={ canAddPage }
 									canAddBlock={
 										blockEditingMode === 'default'
 									}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #73295

Updates the Navigation block link UI to hide the “Create page” option when the user enters a URL-like value. The URL-like input now shows the “Press ENTER to add this link” option instead.

## Why?
Currently, the Navigation block continues to show the “Create page” action even when users clearly enter a URL-like value such as `https://example.com`, `www.wordpress.org`, or `/contact`.

This is misleading because the input indicates the user intends to add a link rather than create a new page. Hiding the page creation action for URL-like input improves clarity and aligns the UI with user intent.

## How?
This PR updates the Navigation block link UI logic to detect URL-like input values and conditionally hide the “Create page” action when such values are entered.

It also enables direct URL entry suggestions in the Navigation link popover so users sees the “Press ENTER to add this link” option for URL-like input, matching behavior already used in other link flows such as the Button block.

## Testing Instructions
1. Open the Site Editor or Post Editor.
2. Insert a Navigation block.
3. Add a Navigation Link.
4. Type "Page name" into the link search field.
5. Verify that the “Create page” option is visible.
6. Clear the input and type https://example.com.
7. Verify that the “Create page” option is hidden.
8. Verify that the “Press ENTER to add this link” option is shown.
9. Test with a few examples like:
a. www.wordpress.org
b. /contact
c. example.com

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="704" height="254" alt="image" src="https://github.com/user-attachments/assets/f5d1e6ab-3e86-4ec7-a409-be47b0543421" />|<img width="704" height="254" alt="image" src="https://github.com/user-attachments/assets/b003c67c-ccd1-4cda-80cd-26e0c01bc36f" />|
