### PR TITLE
Navigation: Fixes `aria-expanded` not updating on hover submenu inside overlay

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1250,7 +1250,7 @@ function block_core_navigation_add_directives_to_submenu( $tags, $block_attribut
 			)
 		) ) {
 			$tags->set_attribute( 'data-wp-on--click', 'actions.toggleMenuOnClick' );
-			$tags->set_attribute( 'data-wp-bind--aria-expanded', 'state.isMenuOpen' );
+			$tags->set_attribute( 'data-wp-bind--aria-expanded', 'state.isSubmenuOpen' );
 			// The `aria-expanded` attribute for SSR is already added in the submenu block.
 		}
 		// Add directives to the submenu.

--- a/packages/block-library/src/navigation/test/view.js
+++ b/packages/block-library/src/navigation/test/view.js
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+
+let mockRegisteredStore;
+let mockCurrentContext;
+
+jest.mock( '@wordpress/interactivity', () => ( {
+	store: ( name, config ) => {
+		mockRegisteredStore = config;
+		return config;
+	},
+	getContext: () => mockCurrentContext,
+	getElement: () => ( { ref: {} } ),
+	withSyncEvent: ( fn ) => fn,
+} ) );
+
+describe( 'Navigation view script', () => {
+	beforeEach( async () => {
+		jest.resetModules();
+		mockRegisteredStore = null;
+		mockCurrentContext = null;
+		// Import the view.js script to register the store
+		await import( '../view.js' );
+	} );
+
+	it( 'updates submenuOpenedBy.hover when hovering a submenu inside an open overlay', () => {
+		// Mock the context for a submenu inside an open overlay
+		mockCurrentContext = {
+			type: 'submenu',
+			submenuOpenedBy: { click: false, hover: false, focus: false },
+			overlayOpenedBy: { click: true, hover: false, focus: false },
+		};
+
+		const { state, actions } = mockRegisteredStore;
+
+		// Verify initial state
+		expect( state.isSubmenuOpen ).toBe( true ); // because overlay is open
+		expect( mockCurrentContext.submenuOpenedBy.hover ).toBe( false );
+
+		// Simulate hover enter
+		actions.openMenuOnHover( { pointerType: 'mouse' } );
+
+		// Verify that hover state is tracked even though submenu is already "open" visually
+		expect( mockCurrentContext.submenuOpenedBy.hover ).toBe( true );
+		expect( state.isSubmenuOpen ).toBe( true ); // remains true
+
+		// Simulate hover leave
+		actions.closeMenuOnHover( { pointerType: 'mouse' } );
+
+		// Verify hover state is cleared
+		expect( mockCurrentContext.submenuOpenedBy.hover ).toBe( false );
+		expect( state.isSubmenuOpen ).toBe( true ); // remains true because overlay is still open
+	} );
+} );

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -88,13 +88,8 @@ const { state, actions } = store(
 				if ( event?.pointerType === 'touch' ) {
 					return;
 				}
-				const { type, overlayOpenedBy } = getContext();
-				if (
-					type === 'submenu' &&
-					// Only open on hover if the overlay is closed.
-					Object.values( overlayOpenedBy || {} ).filter( Boolean )
-						.length === 0
-				) {
+				const { type } = getContext();
+				if ( type === 'submenu' ) {
 					actions.openMenu( 'hover' );
 				}
 			},
@@ -102,13 +97,8 @@ const { state, actions } = store(
 				if ( event?.pointerType === 'touch' ) {
 					return;
 				}
-				const { type, overlayOpenedBy } = getContext();
-				if (
-					type === 'submenu' &&
-					// Only close on hover if the overlay is closed.
-					Object.values( overlayOpenedBy || {} ).filter( Boolean )
-						.length === 0
-				) {
+				const { type } = getContext();
+				if ( type === 'submenu' ) {
 					actions.closeMenu( 'hover' );
 				}
 			},

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -80,6 +80,17 @@ const { state, actions } = store(
 					? ctx.overlayOpenedBy
 					: ctx.submenuOpenedBy;
 			},
+			get isSubmenuOpen() {
+				const ctx = getContext();
+				// Once the overlay itself is open, its styles always expand
+				// every submenu regardless of hover/click/focus state, so the
+				// toggle's `aria-expanded` should reflect that immediately
+				// instead of waiting for a hover/click/focus interaction.
+				const isOverlayOpen =
+					Object.values( ctx.overlayOpenedBy || {} ).filter( Boolean )
+						.length > 0;
+				return isOverlayOpen || state.isMenuOpen;
+			},
 		},
 		actions: {
 			openMenuOnHover( event ) {


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/76658

When `Submenu Visibility` is set to `Hover`, the toggle button's `aria-expanded` attribute does not update to `true` when hovering over a submenu inside a Navigation Overlay. The submenu was visually shown, but `aria-expanded` remained `false`, creating a mismatch that screen readers would report as "closed" for a visible submenu.

## Why?

The `openMenuOnHover` and `closeMenuOnHover` action handlers contained a guard that prevented them from running when the parent overlay was already open because `overlayOpenedBy` had a truthy value.

Since `pointerenter` directives are only added to `<li>` elements when `submenuVisibility === 'hover'`, removing the guard is safe since those events can only fire inside an already-open overlay, which is exactly when the state should be updated.

## How?
Removed the `overlayOpenedBy` guard from `openMenuOnHover` and `closeMenuOnHover` in
`packages/block-library/src/navigation/view.js`.

## Testing Instructions

1. Go to **Appearance → Editor → Templates**.
2. Edit a template that has a navigation in an overlay (or set `Overlay Menu` to `Always`).
3. Add a Navigation block with a **Submenu** item and set **Submenu Visibility** to **Hover**.
4. Save and view the frontend.
5. Click **Open menu** to open the overlay.
6. Hover over the submenu parent item.
7. Inspect the toggle `<button>` — `aria-expanded` should now be `"true"` while hovered.
8. Hover away — `aria-expanded` should return to `"false"`.
9. Confirm **Click** mode submenus, keyboard navigation, and Escape/focus-trap behaviour
   are unaffected.


## Screenshots or screencast

### Before

https://github.com/user-attachments/assets/894e5aec-373b-4482-99f4-593aaa7a7454




### After


https://github.com/user-attachments/assets/07d07836-23d1-4a87-a88f-4ad530a03304


