### PR TITLE
Fix import order in block-editor `custom-css.js`

### DIFF
--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -1,18 +1,11 @@
-/**
- * WordPress dependencies
- */
 import { useEffect, useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
 import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
 import { processCSSNesting } from '@wordpress/global-styles-engine';
-import { useBlockEditingMode } from '../components/block-editing-mode';
 import { store as noticesStore } from '@wordpress/notices';
-
-/**
- * Internal dependencies
- */
+import { useBlockEditingMode } from '../components/block-editing-mode';
 import InspectorControls from '../components/inspector-controls';
 import AdvancedPanel, {
 	validateCSS,


### PR DESCRIPTION
## What?

Fixes an import order lint rule violation in `packages/block-editor/src/hooks/custom-css.js` that is causing strict checks in local lint-staged commit hooks to fail for trunk merge commits.

## Why?

I think this file was last committed with `--no-verify` or something.

## Testing Instructions

No functional changes. Just passes the `tools/eslint/config.strict.mjs` linting.