### PR TITLE
Experiment: Follow up improvements on taxonomies(77497)

### DIFF
--- a/routes/taxonomies/actions/edit.tsx
+++ b/routes/taxonomies/actions/edit.tsx
@@ -30,12 +30,8 @@ import {
 	useObjectTypeField,
 	useSlugField,
 } from '../fields';
-import {
-	serializeForSave,
-	toFormData,
-	type TaxonomyFormData,
-	type TaxonomyRecord,
-} from '../utils';
+import { serializeForSave, toFormData } from '../utils';
+import type { TaxonomyFormData, TaxonomyRecord } from '../types';
 
 function EditTaxonomyModal( {
 	items,
@@ -48,7 +44,7 @@ function EditTaxonomyModal( {
 	const { record, hasResolved } = useEntityRecord< TaxonomyRecord >(
 		'postType',
 		'wp_user_taxonomy',
-		item.id ?? 0
+		item.id as number
 	);
 
 	const initialData = useMemo< TaxonomyFormData >(

--- a/routes/taxonomies/actions/edit.tsx
+++ b/routes/taxonomies/actions/edit.tsx
@@ -109,7 +109,7 @@ function EditTaxonomyModal( {
 	}
 
 	if ( ! hasResolved ) {
-		return <></>;
+		return null;
 	}
 
 	return (

--- a/routes/taxonomies/actions/toggle-active.ts
+++ b/routes/taxonomies/actions/toggle-active.ts
@@ -21,7 +21,7 @@ const toggleActiveAction: Action< TaxonomyFormData > = {
 		const { saveEntityRecord } = registry.dispatch( coreStore );
 		const { createSuccessNotice, createErrorNotice } =
 			registry.dispatch( noticesStore );
-		const next = items.every( ( i ) => i.status === 'publish' )
+		const nextStatus = items.every( ( i ) => i.status === 'publish' )
 			? 'draft'
 			: 'publish';
 		try {
@@ -32,12 +32,12 @@ const toggleActiveAction: Action< TaxonomyFormData > = {
 				await saveEntityRecord(
 					'postType',
 					'wp_user_taxonomy',
-					{ id: item.id, status: next },
+					{ id: item.id, status: nextStatus },
 					{ throwOnError: true }
 				);
 			}
 			createSuccessNotice(
-				next === 'publish'
+				nextStatus === 'publish'
 					? __( 'Taxonomy activated.' )
 					: __( 'Taxonomy deactivated.' ),
 				{ type: 'snackbar' }

--- a/routes/taxonomies/actions/toggle-active.ts
+++ b/routes/taxonomies/actions/toggle-active.ts
@@ -9,7 +9,7 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
-import type { TaxonomyFormData } from '../utils';
+import type { TaxonomyFormData } from '../types';
 
 const toggleActiveAction: Action< TaxonomyFormData > = {
 	id: 'toggle-active',

--- a/routes/taxonomies/add-taxonomy.tsx
+++ b/routes/taxonomies/add-taxonomy.tsx
@@ -23,7 +23,8 @@ import {
 	useObjectTypeField,
 	useSlugField,
 } from './fields';
-import { serializeForSave, type TaxonomyFormData } from './utils';
+import { serializeForSave } from './utils';
+import type { TaxonomyFormData } from './types';
 
 const BLANK_RECORD: TaxonomyFormData = {
 	slug: '',

--- a/routes/taxonomies/fields.tsx
+++ b/routes/taxonomies/fields.tsx
@@ -110,7 +110,7 @@ export function useSlugField(
 	return useMemo< Field< TaxonomyFormData > >(
 		() => ( {
 			id: 'slug',
-			label: __( 'Slug' ),
+			label: __( 'Taxonomy key' ),
 			type: 'text',
 			enableGlobalSearch: true,
 			description: (

--- a/routes/taxonomies/fields.tsx
+++ b/routes/taxonomies/fields.tsx
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { Notice } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { resolveSelect, useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import type { Field, Form } from '@wordpress/dataviews';
@@ -10,7 +12,7 @@ import { Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
-import { usePublicPostTypes, useTakenTaxonomySlugs } from './utils';
+import { usePublicPostTypes } from './utils';
 import type { TaxonomyFormData } from './types';
 
 export const titleField: Field< TaxonomyFormData > = {
@@ -99,7 +101,10 @@ export function useSlugField(
 	originalSlug?: string,
 	currentValue?: string
 ): Field< TaxonomyFormData > {
-	const takenSlugs = useTakenTaxonomySlugs( originalSlug );
+	const registeredTaxonomies = useSelect(
+		( select ) => select( coreStore ).getTaxonomies( { per_page: -1 } ),
+		[]
+	);
 	const showRenameWarning =
 		originalSlug !== undefined && currentValue !== originalSlug;
 	return useMemo< Field< TaxonomyFormData > >(
@@ -127,15 +132,35 @@ export function useSlugField(
 			isValid: {
 				required: true,
 				pattern: '^[a-z0-9_-]{1,32}$',
-				custom: ( value: TaxonomyFormData ) =>
-					takenSlugs.has( value.slug )
+				custom: async ( value: TaxonomyFormData ) => {
+					const slug = value.slug;
+					if ( originalSlug !== undefined && slug === originalSlug ) {
+						return null;
+					}
+					const slugTaken = ( registeredTaxonomies ?? [] ).some(
+						( t: any ) => t.slug === slug
+					);
+					if ( slugTaken ) {
+						return __( 'This taxonomy key is already in use.' );
+					}
+					// We only need to query for `drafts` because published taxonomies are checked through `registeredTaxonomies` above.
+					const drafts = await resolveSelect(
+						coreStore
+					).getEntityRecords( 'postType', 'wp_user_taxonomy', {
+						slug,
+						status: 'draft',
+						_fields: 'id,name',
+						per_page: 1,
+					} );
+					return !! drafts?.length
 						? __( 'This taxonomy key is already in use.' )
-						: null,
+						: null;
+				},
 			},
 			filterBy: false,
 			enableSorting: false,
 		} ),
-		[ takenSlugs, showRenameWarning ]
+		[ registeredTaxonomies, originalSlug, showRenameWarning ]
 	);
 }
 

--- a/routes/taxonomies/fields.tsx
+++ b/routes/taxonomies/fields.tsx
@@ -10,11 +10,8 @@ import { Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
-import {
-	usePublicPostTypes,
-	useTakenTaxonomySlugs,
-	type TaxonomyFormData,
-} from './utils';
+import { usePublicPostTypes, useTakenTaxonomySlugs } from './utils';
+import type { TaxonomyFormData } from './types';
 
 export const titleField: Field< TaxonomyFormData > = {
 	id: 'title',

--- a/routes/taxonomies/fields.tsx
+++ b/routes/taxonomies/fields.tsx
@@ -102,7 +102,7 @@ export function useSlugField(
 	currentValue?: string
 ): Field< TaxonomyFormData > {
 	const registeredTaxonomies = useSelect(
-		( select ) => select( coreStore ).getTaxonomies( { per_page: -1 } ),
+		( select ) => select( coreStore ).getTaxonomies(),
 		[]
 	);
 	const showRenameWarning =

--- a/routes/taxonomies/stage.tsx
+++ b/routes/taxonomies/stage.tsx
@@ -20,7 +20,8 @@ import {
 	useSlugField,
 	useObjectTypeField,
 } from './fields';
-import { toFormData, type TaxonomyRecord } from './utils';
+import { toFormData } from './utils';
+import type { TaxonomyRecord } from './types';
 
 const defaultLayouts = {
 	table: {},

--- a/routes/taxonomies/types.ts
+++ b/routes/taxonomies/types.ts
@@ -1,0 +1,33 @@
+export interface TaxonomyRecord {
+	id: number;
+	type: 'wp_user_taxonomy';
+	slug: string;
+	status: 'publish' | 'draft';
+	title: { raw: string; rendered: string };
+	content: { raw: string; rendered: string };
+}
+
+export interface StoredConfig {
+	labels?: { singular_name?: string };
+	object_type?: string[];
+	public?: boolean;
+	hierarchical?: boolean;
+}
+
+/**
+ * Normalized in-memory shape used by the Add/Edit forms and the DataViews
+ * table. REST rows are converted to this shape via `toFormData`, and back to
+ * the save payload via `serializeForSave`, so fields never have to JSON
+ * round-trip `content.raw` on every keystroke.
+ */
+export interface TaxonomyFormData {
+	id?: number;
+	slug: string;
+	status: 'publish' | 'draft';
+	title: { raw: string };
+	config: Required<
+		Pick< StoredConfig, 'object_type' | 'public' | 'hierarchical' >
+	> & {
+		labels: { singular_name: string };
+	};
+}

--- a/routes/taxonomies/utils.ts
+++ b/routes/taxonomies/utils.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 
@@ -73,25 +73,4 @@ export function usePublicPostTypes() {
 				return a.name.localeCompare( b.name );
 			} );
 	}, [ postTypes ] );
-}
-
-export function useTakenTaxonomySlugs( excludeSlug?: string ): Set< string > {
-	const registered = useSelect(
-		( select ) => select( coreStore ).getTaxonomies(),
-		[]
-	);
-	const { records: drafts } = useEntityRecords< { slug: string } >(
-		'postType',
-		'wp_user_taxonomy',
-		{ per_page: 100, status: 'draft', context: 'edit' }
-	);
-	return useMemo( () => {
-		const set = new Set< string >();
-		( registered ?? [] ).forEach( ( t: any ) => set.add( t.slug ) );
-		( drafts ?? [] ).forEach( ( r ) => set.add( r.slug ) );
-		if ( excludeSlug ) {
-			set.delete( excludeSlug );
-		}
-		return set;
-	}, [ registered, drafts, excludeSlug ] );
 }

--- a/routes/taxonomies/utils.ts
+++ b/routes/taxonomies/utils.ts
@@ -5,38 +5,10 @@ import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 
-export type TaxonomyRecord = {
-	id?: number;
-	slug: string;
-	status: 'publish' | 'draft';
-	title: { raw?: string; rendered: string };
-	content: { raw?: string; rendered: string };
-};
-
-export type StoredConfig = {
-	labels?: { singular_name?: string };
-	object_type?: string[];
-	public?: boolean;
-	hierarchical?: boolean;
-};
-
 /**
- * Normalized in-memory shape used by all three consumers. REST rows are
- * converted to this shape on load via `toFormData`, and back to the save
- * payload via `serializeForSave`, so fields never have to JSON round-trip
- * `content.raw` on every keystroke.
+ * Internal dependencies
  */
-export type TaxonomyFormData = {
-	id?: number;
-	slug: string;
-	status: 'publish' | 'draft';
-	title: { raw: string };
-	config: Required<
-		Pick< StoredConfig, 'object_type' | 'public' | 'hierarchical' >
-	> & {
-		labels: { singular_name: string };
-	};
-};
+import type { StoredConfig, TaxonomyFormData, TaxonomyRecord } from './types';
 
 export function parseConfig( raw?: string ): StoredConfig {
 	if ( ! raw ) {
@@ -51,12 +23,12 @@ export function parseConfig( raw?: string ): StoredConfig {
 }
 
 export function toFormData( row: TaxonomyRecord ): TaxonomyFormData {
-	const parsed = parseConfig( row.content?.raw );
+	const parsed = parseConfig( row.content.raw );
 	return {
 		id: row.id,
 		slug: row.slug,
 		status: row.status,
-		title: { raw: row.title.raw ?? '' },
+		title: { raw: row.title.raw },
 		config: {
 			labels: {
 				singular_name: parsed.labels?.singular_name ?? '',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/77497

Addresses some of the feedback:
1. Improve types and adds a separate file for them
2. Improve `taxonomy key` validation

## Testing instructions
1. Enable the Content types: manage custom taxonomies experiment
2. Go to `Settings/Taxonomies` and play around with adding and editing taxonomies by changing the `taxonomy key` field to existing taxonomies (e.g. `category`).