### PR TITLE
wp-build: Widen optional peer dependency ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62960,10 +62960,10 @@
 				"npm": ">=10.2.3"
 			},
 			"peerDependencies": {
-				"@wordpress/boot": "^0.3.0",
+				"@wordpress/boot": ">=0.3.0 <1.0.0",
 				"@wordpress/private-apis": "^1.0.0",
-				"@wordpress/route": "^0.2.0",
-				"@wordpress/theme": "^0.3.0"
+				"@wordpress/route": ">=0.2.0 <1.0.0",
+				"@wordpress/theme": ">=0.8.0 <1.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@wordpress/boot": {

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Update the optional `@wordpress/theme` peer dependency range to match the versions that provide the design token fallback build plugins.
+
 ## 0.12.0 (2026-04-15)
 
 ## 0.11.0 (2026-04-01)

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Update the optional `@wordpress/boot`, `@wordpress/route`, and `@wordpress/theme` peer dependency ranges to avoid blocking newer compatible package versions.
+-   Update the optional `@wordpress/boot`, `@wordpress/route`, and `@wordpress/theme` peer dependency ranges to avoid blocking newer compatible package versions ([#77568](https://github.com/WordPress/gutenberg/pull/77568)).
 
 ## 0.12.0 (2026-04-15)
 

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Update the optional `@wordpress/theme` peer dependency range to match the versions that provide the design token fallback build plugins.
+-   Update the optional `@wordpress/boot`, `@wordpress/route`, and `@wordpress/theme` peer dependency ranges to avoid blocking newer compatible package versions.
 
 ## 0.12.0 (2026-04-15)
 

--- a/packages/wp-build/package.json
+++ b/packages/wp-build/package.json
@@ -58,7 +58,7 @@
 		"@wordpress/boot": "^0.3.0",
 		"@wordpress/private-apis": "^1.0.0",
 		"@wordpress/route": "^0.2.0",
-		"@wordpress/theme": "^0.3.0"
+		"@wordpress/theme": ">=0.8.0 <1.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@wordpress/boot": {

--- a/packages/wp-build/package.json
+++ b/packages/wp-build/package.json
@@ -55,9 +55,9 @@
 		"@types/node": "^20.17.10"
 	},
 	"peerDependencies": {
-		"@wordpress/boot": "^0.3.0",
+		"@wordpress/boot": ">=0.3.0 <1.0.0",
 		"@wordpress/private-apis": "^1.0.0",
-		"@wordpress/route": "^0.2.0",
+		"@wordpress/route": ">=0.2.0 <1.0.0",
 		"@wordpress/theme": ">=0.8.0 <1.0.0"
 	},
 	"peerDependenciesMeta": {


### PR DESCRIPTION
## What?

Reported in https://github.com/WordPress/ai/issues/451#issuecomment-4292690102

Updates the optional `@wordpress/boot`, `@wordpress/route`, and `@wordpress/theme` peer dependency ranges in `@wordpress/build` to avoid blocking newer compatible package versions.

Also the floor for `@wordpress/theme` was 0.3.0 when it actually required the build plugins added in 0.8.0. This is also fixed.

## Why?

The published peer dependency metadata was still capped to older `0.x` ranges, which can cause npm dependency resolution failures when consumers install newer compatible versions alongside `@wordpress/build`.

> [!IMPORTANT]
>  The gotcha here is that semver for `0.x` ranges (i.e. before a 1.0.0 release) means that every minor release is considered potentially breaking. So `^0.1.0` actually only goes up to `0.1.x`, not `0.x.x`.

## How?
This widens the optional peer dependency ranges for `@wordpress/boot`, `@wordpress/route`, and `@wordpress/theme` to `<1.0.0`, while preserving their existing minimum supported versions.

## Testing Instructions
1. Create a packed tarball from this branch's `@wordpress/build` package.
2. In a fresh temporary directory, run `npm install <packed-tarball> @wordpress/ui@0.11.0 @wordpress/boot@0.11.0 @wordpress/route@0.10.0 --ignore-scripts`.
3. Confirm the install succeeds without `@wordpress/build` peer dependency resolution errors for those packages.

(Might be worth having a CI check similar to this to prevent issues moving forward… Out of scope for this PR though.)