### PR TITLE
Template parts: make 'Detach' context menu item consistent across patterns and template parts

### DIFF
--- a/packages/editor/src/components/template-part-menu-items/convert-to-regular.js
+++ b/packages/editor/src/components/template-part-menu-items/convert-to-regular.js
@@ -3,15 +3,46 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { MenuItem } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
+import {
+	MenuItem,
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+import { useState } from '@wordpress/element';
 
 export default function ConvertToRegularBlocks( { clientId, onClose } ) {
+	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
+
 	const { getBlocks } = useSelect( blockEditorStore );
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 
-	const canRemove = useSelect(
-		( select ) => select( blockEditorStore ).canRemoveBlock( clientId ),
+	const { canRemove, templatePartTitle } = useSelect(
+		( select ) => {
+			const { canRemoveBlock, getBlock } = select( blockEditorStore );
+			const { getEntityRecord, getCurrentTheme } = select( coreStore );
+
+			const block = getBlock( clientId );
+			const { slug, theme } = block?.attributes ?? {};
+			const themeSlug = theme || getCurrentTheme()?.stylesheet;
+			const templatePartId =
+				themeSlug && slug ? `${ themeSlug }//${ slug }` : null;
+			const entity = templatePartId
+				? getEntityRecord(
+						'postType',
+						'wp_template_part',
+						templatePartId
+				  )
+				: null;
+
+			return {
+				canRemove: canRemoveBlock( clientId ),
+				templatePartTitle: entity?.title?.rendered
+					? decodeEntities( entity.title.rendered )
+					: null,
+			};
+		},
 		[ clientId ]
 	);
 
@@ -19,14 +50,45 @@ export default function ConvertToRegularBlocks( { clientId, onClose } ) {
 		return null;
 	}
 
+	const title = templatePartTitle
+		? sprintf(
+				/* translators: %s: template part title, e.g. "Header" */
+				__( 'Detach %s?' ),
+				templatePartTitle
+		  )
+		: __( 'Detach template part?' );
+
+	const message = templatePartTitle
+		? sprintf(
+				/* translators: %s: template part title, e.g. "Header" */
+				__(
+					'The blocks will be separated from the original template part and will be fully editable. Future changes to the %s template part will not apply here.'
+				),
+				templatePartTitle
+		  )
+		: __(
+				'The blocks will be separated from the original template part and will be fully editable. Future changes to the template part will not apply here.'
+		  );
+
 	return (
-		<MenuItem
-			onClick={ () => {
-				replaceBlocks( clientId, getBlocks( clientId ) );
-				onClose();
-			} }
-		>
-			{ __( 'Disconnect' ) }
-		</MenuItem>
+		<>
+			<MenuItem onClick={ () => setShowConfirmDialog( true ) }>
+				{ __( 'Detach' ) }
+			</MenuItem>
+			<ConfirmDialog
+				isOpen={ showConfirmDialog }
+				onConfirm={ () => {
+					replaceBlocks( clientId, getBlocks( clientId ) );
+					onClose();
+				} }
+				onCancel={ () => setShowConfirmDialog( false ) }
+				confirmButtonText={ __( 'Detach' ) }
+				size="medium"
+				title={ title }
+				__experimentalHideHeader={ false }
+			>
+				{ message }
+			</ConfirmDialog>
+		</>
 	);
 }

--- a/packages/editor/src/components/template-part-menu-items/convert-to-regular.js
+++ b/packages/editor/src/components/template-part-menu-items/convert-to-regular.js
@@ -26,7 +26,7 @@ export default function ConvertToRegularBlocks( { clientId, onClose } ) {
 				onClose();
 			} }
 		>
-			{ __( 'Detach' ) }
+			{ __( 'Disconnect' ) }
 		</MenuItem>
 	);
 }

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -112,7 +112,7 @@ function PatternsManageButton( { clientId, onClose } ) {
 			{ canDetach && (
 				<>
 					<MenuItem onClick={ () => setShowConfirmDialog( true ) }>
-						{ __( 'Detach pattern' ) }
+						{ __( 'Detach' ) }
 					</MenuItem>
 					<ConfirmDialog
 						isOpen={ showConfirmDialog }

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -112,25 +112,15 @@ function PatternsManageButton( { clientId, onClose } ) {
 			{ canDetach && (
 				<>
 					<MenuItem onClick={ () => setShowConfirmDialog( true ) }>
-						{ isSyncedPattern
-							? __( 'Disconnect pattern' )
-							: __( 'Detach pattern' ) }
+						{ __( 'Detach pattern' ) }
 					</MenuItem>
 					<ConfirmDialog
 						isOpen={ showConfirmDialog }
 						onConfirm={ handleDetach }
 						onCancel={ () => setShowConfirmDialog( false ) }
-						confirmButtonText={
-							isSyncedPattern
-								? __( 'Disconnect' )
-								: __( 'Detach' )
-						}
+						confirmButtonText={ __( 'Detach' ) }
 						size="medium"
-						title={
-							isSyncedPattern
-								? __( 'Disconnect pattern?' )
-								: __( 'Detach pattern?' )
-						}
+						title={ __( 'Detach pattern?' ) }
 						__experimentalHideHeader={ false }
 					>
 						{ isSyncedPattern

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -691,10 +691,10 @@ test.describe( 'Pattern Overrides', () => {
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
 		await editor.showBlockToolbar();
-		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
 		await page
 			.getByRole( 'dialog' )
-			.getByRole( 'button', { name: 'Disconnect' } )
+			.getByRole( 'button', { name: 'Detach' } )
 			.click();
 
 		// Check that the overrides remain.
@@ -737,10 +737,10 @@ test.describe( 'Pattern Overrides', () => {
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
 		await editor.showBlockToolbar();
-		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
 		await page
 			.getByRole( 'dialog' )
-			.getByRole( 'button', { name: 'Disconnect' } )
+			.getByRole( 'button', { name: 'Detach' } )
 			.click();
 
 		// Check that the overrides remain.

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -691,7 +691,7 @@ test.describe( 'Pattern Overrides', () => {
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
 		await editor.showBlockToolbar();
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach' );
 		await page
 			.getByRole( 'dialog' )
 			.getByRole( 'button', { name: 'Detach' } )
@@ -737,7 +737,7 @@ test.describe( 'Pattern Overrides', () => {
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
 		await editor.showBlockToolbar();
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach' );
 		await page
 			.getByRole( 'dialog' )
 			.getByRole( 'button', { name: 'Detach' } )

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -479,8 +479,8 @@ test.describe( 'Unsynced pattern', () => {
 			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
 		);
 
-		// Open the block options menu and click "Detach pattern".
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		// Open the block options menu and click "Detach".
+		await editor.clickBlockOptionsMenuItem( 'Detach' );
 		await page
 			.getByRole( 'dialog' )
 			.getByRole( 'button', { name: 'Detach' } )
@@ -838,7 +838,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach' );
 		await page
 			.getByRole( 'dialog' )
 			.getByRole( 'button', { name: 'Detach' } )
@@ -878,7 +878,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach' );
 		await page
 			.getByRole( 'dialog' )
 			.getByRole( 'button', { name: 'Detach' } )
@@ -984,7 +984,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach' );
 		await page
 			.getByRole( 'dialog' )
 			.getByRole( 'button', { name: 'Detach' } )

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -838,10 +838,10 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
 		await page
 			.getByRole( 'dialog' )
-			.getByRole( 'button', { name: 'Disconnect' } )
+			.getByRole( 'button', { name: 'Detach' } )
 			.click();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -878,10 +878,10 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
 		await page
 			.getByRole( 'dialog' )
-			.getByRole( 'button', { name: 'Disconnect' } )
+			.getByRole( 'button', { name: 'Detach' } )
 			.click();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -984,10 +984,10 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
 		await page
 			.getByRole( 'dialog' )
-			.getByRole( 'button', { name: 'Disconnect' } )
+			.getByRole( 'button', { name: 'Detach' } )
 			.click();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -176,6 +176,7 @@ test.describe( 'Template Part', () => {
 	test( 'can detach blocks from a template part', async ( {
 		admin,
 		editor,
+		page,
 	} ) => {
 		const paragraphText = 'Test 3';
 
@@ -210,6 +211,10 @@ test.describe( 'Template Part', () => {
 		// Detach the paragraph from the header template part.
 		await editor.selectBlocks( templatePartWithParagraph );
 		await editor.clickBlockOptionsMenuItem( 'Detach' );
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Detach' } )
+			.click();
 
 		// There should be a paragraph but no header template part.
 		await expect( paragraph ).toBeVisible();

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -173,7 +173,7 @@ test.describe( 'Template Part', () => {
 		);
 	} );
 
-	test( 'can detach blocks from a template part', async ( {
+	test( 'can disconnect blocks from a template part', async ( {
 		admin,
 		editor,
 	} ) => {
@@ -207,9 +207,9 @@ test.describe( 'Template Part', () => {
 		);
 		await expect( templatePartWithParagraph ).toBeVisible();
 
-		// Detach the paragraph from the header template part.
+		// Disconnect the paragraph from the header template part.
 		await editor.selectBlocks( templatePartWithParagraph );
-		await editor.clickBlockOptionsMenuItem( 'Detach' );
+		await editor.clickBlockOptionsMenuItem( 'Disconnect' );
 
 		// There should be a paragraph but no header template part.
 		await expect( paragraph ).toBeVisible();

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -173,7 +173,7 @@ test.describe( 'Template Part', () => {
 		);
 	} );
 
-	test( 'can disconnect blocks from a template part', async ( {
+	test( 'can detach blocks from a template part', async ( {
 		admin,
 		editor,
 	} ) => {
@@ -207,9 +207,9 @@ test.describe( 'Template Part', () => {
 		);
 		await expect( templatePartWithParagraph ).toBeVisible();
 
-		// Disconnect the paragraph from the header template part.
+		// Detach the paragraph from the header template part.
 		await editor.selectBlocks( templatePartWithParagraph );
-		await editor.clickBlockOptionsMenuItem( 'Disconnect' );
+		await editor.clickBlockOptionsMenuItem( 'Detach' );
 
 		// There should be a paragraph but no header template part.
 		await expect( paragraph ).toBeVisible();


### PR DESCRIPTION


## What?

Follow up to https://github.com/WordPress/gutenberg/pull/75713

Template parts used "Detach" while synced patterns used "Disconnect". This PR normalises the label to **Detach** across both patterns and template parts, and adds a confirmation modal to template parts (already present for patterns).


## Why 

Make things consistent. Reduce blast radius of confusion!

## How


- `convert-to-regular.js`: adds confirmation modal before detaching a template part, with a dynamic title using the template part name (e.g. "Detach Header?") when available
- `patterns-manage-button.js`: removes the synced/unsynced conditional — both now use "Detach" 
- E2E tests updated to match new labels and modal flow

## Testing


1. Open the Site Editor, edit a template containing a Template Part (e.g. header)
2. Select the Template Part block, open block options (⋮)
3. Click **Detach** — confirm a modal appears with the template part name in the title
4. Confirm — template part is replaced with its inner blocks
5. In the post editor, insert a synced pattern, open block options
6. Confirm the item reads **Detach** (previously "Disconnect pattern")
7. Confirm the modal title reads **Detach pattern?** and the confirm button reads **Detach**



https://github.com/user-attachments/assets/3ad2cb15-c2c2-4442-9f14-e66bcf893f43






## Use of AI Tools

A bit. Not much.