### PR TITLE
Media Editor: add zoom control and hide fine rotation on narrow viewports

### DIFF
--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -1,15 +1,22 @@
 /**
  * WordPress dependencies
  */
-import { SelectControl, ToggleControl } from '@wordpress/components';
+import {
+	RangeControl,
+	SelectControl,
+	ToggleControl,
+} from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { useCropper } from '../../image-editor';
 import {
 	DEFAULT_ASPECT_RATIOS,
+	MAX_ZOOM,
+	MIN_ZOOM,
 	ORIGINAL_ASPECT_RATIO,
 } from '../../image-editor/core/constants';
 
@@ -69,8 +76,30 @@ export default function MediaEditorCropPanel( {
 	freeformCrop,
 	onFreeformChange,
 }: MediaEditorCropPanelProps ) {
+	const { state, setZoom } = useCropper();
+
 	return (
 		<Stack direction="column" gap="md">
+			<RangeControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ __( 'Zoom' ) }
+				min={ MIN_ZOOM }
+				max={ MAX_ZOOM }
+				step={ 0.1 }
+				value={ state.zoom }
+				onChange={ ( value ) =>
+					setZoom( typeof value === 'number' ? value : MIN_ZOOM )
+				}
+				renderTooltipContent={ ( value ) => {
+					const zoom = typeof value === 'number' ? value : MIN_ZOOM;
+					return sprintf(
+						/* translators: %d: zoom level as a percentage. */
+						__( '%d%%' ),
+						Math.round( zoom * 100 )
+					);
+				} }
+			/>
 			<SelectControl
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom

--- a/packages/media-editor/src/components/media-editor-toolbar/style.scss
+++ b/packages/media-editor/src/components/media-editor-toolbar/style.scss
@@ -1,4 +1,5 @@
 @use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/breakpoints" as *;
 
 .media-editor-toolbar {
 	width: 100%;
@@ -10,5 +11,11 @@
 	.media-editor-toolbar__rotation-slider {
 		flex: 1 1 auto;
 		max-width: 240px;
+
+		// At narrow widths the slider is too cramped to aim precisely;
+		// the 90° rotate buttons cover the essential need.
+		@media (max-width: #{ $break-mobile }) {
+			display: none;
+		}
 	}
 }


### PR DESCRIPTION
Follow-up to #77540.

Part of:

* https://github.com/WordPress/gutenberg/issues/73771

## Summary

- Add a Zoom `RangeControl` to the Crop sidebar tab (1×–10×, step 0.1, tooltip as a percentage). Reset still handled by the toolbar's Reset button.
- Hide the fine-rotation slider in the bottom toolbar at viewports ≤ 480px so the remaining controls (90° rotate, flip, Reset) have room to breathe. The slider is too cramped to aim precisely at that width.

Thanks to @andrewserong for the suggestions

## Test plan

- [ ] Open the media editor modal. Crop sidebar tab shows a Zoom slider above Aspect ratio. Dragging it scales the image inside the cropper viewport; tooltip reads as `100%`–`1000%`.
- [ ] Click Reset in the bottom toolbar — zoom returns to 100% along with rotation/flip/crop.
- [ ] Resize the window below 480px wide — the fine-rotation slider disappears; rotate/flip/Reset remain usable.
- [ ] Resize back above 480px — slider reappears.
- [ ] Keyboard: Zoom slider is reachable via Tab and adjustable with arrow keys.


https://github.com/user-attachments/assets/336d9e49-b8fa-4f61-9757-10727a98de4a

