### PR TITLE
Remove ZebulanStanphill from `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,6 @@
 # Blocks
 /packages/block-library                         @ajitbohra @fabiankaegy
 /packages/block-library/src/gallery
-/packages/block-library/src/table-of-contents   @ZebulanStanphill
 
 # Duotone
 /lib/block-supports/duotone.php									@sgomes


### PR DESCRIPTION
## What?
Removes me from the GitHub `CODEOWNERS` file.

## Why?
Trying to clear my inbox of unnecessary notifications. I'm too busy to actively contribute much right now, and I don't want to give the impression that I'm the primary maintainer of the Table of Contents block right now.
