### PR TITLE
Fix: Edit-post back button tooltip position

### DIFF
--- a/packages/edit-post/src/components/back-button/fullscreen-mode-close.js
+++ b/packages/edit-post/src/components/back-button/fullscreen-mode-close.js
@@ -134,7 +134,7 @@ function FullscreenModeClose( { showTooltip, icon, href, initialPost } ) {
 				href={ buttonHref }
 				label={ buttonLabel }
 				showTooltip={ showTooltip }
-				tooltipPosition="middle right"
+				tooltipPosition="bottom"
 			>
 				<motion.div variants={ ! disableMotion && siteIconVariants }>
 					<div className="edit-post-fullscreen-mode-close__view-mode-toggle-icon">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of #73785

This PR updates the `tooltipPosition` of the Fullscreen Mode Close button (the "Back" button in the top left of the editor) from `middle right` to `bottom`.

## Why?
The previous `middle right` positioning caused the tooltip to overlap with the block inserter button. Changing the position to bottom ensures the tooltip appears directly beneath the button, which is standard for header-level icons and prevents visual clashing with the other elements.

## How?
Updated the `tooltipPosition` prop for `FullscreenModeClose` component to use the value `bottom`.

## Testing Instructions

1. Open the Block editor.
2. Enable Fullscreen Mode in the editor (Options > View > Fullscreen Mode).
3. Hover over the WordPress (or Site) icon in the top left corner.
4. Verify that the "View Posts" (or similar) tooltip now appears below the button rather than to the right of it.


## Screenshots or screencast <!-- if applicable -->

### Before:

https://github.com/user-attachments/assets/b8a80dc0-4683-4133-a802-f48ca3b02ce2

### After:

https://github.com/user-attachments/assets/271d222c-463c-4903-97ee-73ad1ae0410e


## Use of AI Tools
I used Gemini 3 Flash to help format this PR description and summarize the logic implementation based on my git diff.

cc: @ciampo, @mirka