### PR TITLE
Fix: block-mover button tooltip position

### DIFF
--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -138,6 +138,7 @@ const BlockMoverButton = forwardRef(
 						direction,
 						orientation
 					) }
+					tooltipPosition={ direction === 'down' ? 'bottom' : 'top' }
 					aria-describedby={ descriptionId }
 					{ ...props }
 					onClick={ isDisabled ? null : onClick }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #73785

This PR adjusts the tooltip positioning for the block mover buttons. It ensures the "Move Down" button displays its tooltip below the button, while the "Move Up" button (and any others) displays its tooltip above.

## Why?
Previously, the tooltips for the block mover controls could overlap other UI elements or the buttons themselves depending on the context. By explicitly setting the tooltip position to 'top' for the up button and 'bottom' for the down button, we provide better visual clarity and prevent the tooltip from obscuring the adjacent mover control.

## How?
Modified the `BlockMoverButton` component to dynamically set the `tooltipPosition` prop based on the `direction` prop.

## Testing Instructions

1. Open a post or page.
2. Insert at least two blocks (e.g., two Paragraph blocks).
3. Select the bottom block to reveal the block toolbar.
4. Hover over the Move Up (chevron up) icon. Verify the tooltip appears above the icon.
5. Hover over the Move Down (chevron down) icon. Verify the tooltip appears below the icon.
6. Switch to a block layout that uses horizontal movers (like buttons in a Row block) and verify the tooltips still behave predictably.

## Screenshots or screencast <!-- if applicable -->

### Before:

https://github.com/user-attachments/assets/7cf59cfa-7e8e-45e2-88eb-7f7fabb9cfa8


### After:

https://github.com/user-attachments/assets/95e759f0-d2c0-487f-a3c9-2aaa0cd424bc


## Use of AI Tools
I used Gemini 3 Flash to help format this PR description and summarize the logic implementation based on my git diff.

cc: @ciampo, @mirka