### PR TITLE
Notes: Refactor to use new '@wordpress/ui' components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59812,6 +59812,7 @@
 				"@wordpress/reusable-blocks": "file:../reusable-blocks",
 				"@wordpress/rich-text": "file:../rich-text",
 				"@wordpress/server-side-render": "file:../server-side-render",
+				"@wordpress/ui": "file:../ui",
 				"@wordpress/upload-media": "file:../upload-media",
 				"@wordpress/url": "file:../url",
 				"@wordpress/views": "file:../views",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -98,6 +98,7 @@
 		"@wordpress/reusable-blocks": "file:../reusable-blocks",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/server-side-render": "file:../server-side-render",
+		"@wordpress/ui": "file:../ui",
 		"@wordpress/upload-media": "file:../upload-media",
 		"@wordpress/url": "file:../url",
 		"@wordpress/views": "file:../views",

--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { __experimentalHStack as HStack } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import {
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
@@ -50,7 +50,7 @@ export function AddComment( { onSubmit, commentSidebarRef, floating } ) {
 		<FloatingContainer
 			floating={ floating }
 			className="editor-collab-sidebar-panel__thread is-selected"
-			spacing="3"
+			gap="md"
 			tabIndex={ 0 }
 			aria-label={ __( 'New note' ) }
 			role="treeitem"
@@ -69,9 +69,9 @@ export function AddComment( { onSubmit, commentSidebarRef, floating } ) {
 				selectNote( undefined );
 			} }
 		>
-			<HStack alignment="left" spacing="3">
+			<Stack direction="row" align="center" justify="flex-start" gap="md">
 				<CommentAuthorInfo />
-			</HStack>
+			</Stack>
 			<CommentForm
 				onSubmit={ async ( inputComment ) => {
 					const { id } = await onSubmit( { content: inputComment } );

--- a/packages/editor/src/components/collab-sidebar/comment-author-info.js
+++ b/packages/editor/src/components/collab-sidebar/comment-author-info.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Tooltip, __experimentalVStack as VStack } from '@wordpress/components';
+import { Tooltip } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { __, _x } from '@wordpress/i18n';
 import {
 	dateI18n,
@@ -89,7 +90,7 @@ function CommentAuthorInfo( { avatar, name, date, userId } ) {
 					),
 				} }
 			/>
-			<VStack spacing="0">
+			<Stack direction="column">
 				<span className="editor-collab-sidebar-panel__user-name">
 					{ name ?? currentUserName }
 				</span>
@@ -103,7 +104,7 @@ function CommentAuthorInfo( { avatar, name, date, userId } ) {
 						</time>
 					</Tooltip>
 				) }
-			</VStack>
+			</Stack>
 		</>
 	);
 }

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -8,12 +8,11 @@ import TextareaAutosize from 'react-autosize-textarea';
  */
 import { useState } from '@wordpress/element';
 import {
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
 	Button,
 	VisuallyHidden,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { isKeyboardEvent } from '@wordpress/keycodes';
@@ -40,10 +39,11 @@ function CommentForm( {
 		! sanitizeCommentString( inputComment ).length;
 
 	return (
-		<VStack
+		<Stack
 			className="editor-collab-sidebar-panel__comment-form"
-			spacing="4"
-			as="form"
+			direction="column"
+			gap="lg"
+			render={ <form /> }
 			onSubmit={ ( event ) => {
 				event.preventDefault();
 				onSubmit( inputComment );
@@ -76,7 +76,13 @@ function CommentForm( {
 					}
 				} }
 			/>
-			<HStack spacing="2" justify="flex-end" wrap>
+			<Stack
+				direction="row"
+				align="center"
+				justify="flex-end"
+				gap="sm"
+				wrap="wrap"
+			>
 				<Button size="compact" variant="tertiary" onClick={ onCancel }>
 					<Truncate>{ __( 'Cancel' ) }</Truncate>
 				</Button>
@@ -89,8 +95,8 @@ function CommentForm( {
 				>
 					<Truncate>{ submitButtonText }</Truncate>
 				</Button>
-			</HStack>
-		</VStack>
+			</Stack>
+		</Stack>
 	);
 }
 

--- a/packages/editor/src/components/collab-sidebar/comment-indicator-toolbar.js
+++ b/packages/editor/src/components/collab-sidebar/comment-indicator-toolbar.js
@@ -1,11 +1,8 @@
 /**
  * WordPress dependencies
  */
-import {
-	ToolbarButton,
-	__experimentalText as Text,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { ToolbarButton } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
@@ -83,7 +80,7 @@ const CommentAvatarIndicator = ( { onClick, thread } ) => {
 				onClick={ () => onClick() }
 				showTooltip
 			>
-				<HStack spacing="1">
+				<Stack direction="row" align="center" gap="xs">
 					{ visibleParticipants.map( ( participant ) => (
 						<img
 							key={ participant.id }
@@ -98,9 +95,11 @@ const CommentAvatarIndicator = ( { onClick, thread } ) => {
 						/>
 					) ) }
 					{ overflowCount > 0 && (
-						<Text weight={ 500 }>{ overflowText }</Text>
+						<span className="editor-collab-sidebar-panel__participant-overflow">
+							{ overflowText }
+						</span>
 					) }
-				</HStack>
+				</Stack>
 			</ToolbarButton>
 		</CommentIconToolbarSlotFill.Fill>
 	);

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -14,16 +14,13 @@ import {
 	useRef,
 } from '@wordpress/element';
 import {
-	__experimentalText as Text,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	__experimentalConfirmDialog as ConfirmDialog,
 	Button,
 	FlexItem,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useDebounce } from '@wordpress/compose';
-
 import { published, moreVertical } from '@wordpress/icons';
 import { __, _x, sprintf, _n } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -435,7 +432,7 @@ function Thread( {
 				'is-selected': isSelected,
 			} ) }
 			id={ `comment-thread-${ thread.id }` }
-			spacing="3"
+			gap="md"
 			onClick={ handleCommentSelect }
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }
@@ -473,9 +470,9 @@ function Thread( {
 				{ __( 'Add new reply' ) }
 			</Button>
 			{ ! thread.blockClientId && (
-				<Text as="p" weight={ 500 } variant="muted">
+				<p className="editor-collab-sidebar-panel__deleted-block-notice">
 					{ __( 'Original block deleted.' ) }
-				</Text>
+				</p>
 			) }
 			<CommentBoard
 				thread={ thread }
@@ -508,7 +505,12 @@ function Thread( {
 					/>
 				) ) }
 			{ ! isSelected && restReplies.length > 0 && (
-				<HStack className="editor-collab-sidebar-panel__more-reply-separator">
+				<Stack
+					direction="row"
+					align="center"
+					justify="space-between"
+					className="editor-collab-sidebar-panel__more-reply-separator"
+				>
 					<Button
 						size="compact"
 						variant="tertiary"
@@ -531,7 +533,7 @@ function Thread( {
 							restReplies.length
 						) }
 					</Button>
-				</HStack>
+				</Stack>
 			) }
 			{ ! isSelected && lastReply && (
 				<CommentBoard
@@ -543,11 +545,16 @@ function Thread( {
 				/>
 			) }
 			{ isSelected && (
-				<VStack spacing="2" role="treeitem">
-					<HStack alignment="left" spacing="3" justify="flex-start">
+				<Stack direction="column" gap="sm" role="treeitem">
+					<Stack
+						direction="row"
+						align="center"
+						justify="flex-start"
+						gap="md"
+					>
 						<CommentAuthorInfo />
-					</HStack>
-					<VStack spacing="2">
+					</Stack>
+					<Stack direction="column" gap="sm">
 						<CommentForm
 							onSubmit={ ( inputComment ) => {
 								if ( 'approved' === thread.status ) {
@@ -587,8 +594,8 @@ function Thread( {
 								thread.author_name
 							) }
 						/>
-					</VStack>
-				</VStack>
+					</Stack>
+				</Stack>
 			) }
 			{ !! thread.blockClientId && (
 				<Button
@@ -673,11 +680,12 @@ const CommentBoard = ( { thread, parent, isExpanded, onEdit, onDelete } ) => {
 			: __( 'Are you sure you want to delete this reply?' );
 
 	return (
-		<VStack
-			spacing="2"
+		<Stack
+			direction="column"
+			gap="sm"
 			role={ thread.parent !== 0 ? 'treeitem' : undefined }
 		>
-			<HStack alignment="left" spacing="3" justify="flex-start">
+			<Stack direction="row" align="center" justify="flex-start" gap="md">
 				<CommentAuthorInfo
 					avatar={ thread?.author_avatar_urls?.[ 48 ] }
 					name={ thread?.author_name }
@@ -692,7 +700,7 @@ const CommentBoard = ( { thread, parent, isExpanded, onEdit, onDelete } ) => {
 							event.stopPropagation();
 						} }
 					>
-						<HStack spacing="0">
+						<Stack direction="row" align="center">
 							{ canResolve && (
 								<Button
 									label={ _x(
@@ -744,10 +752,10 @@ const CommentBoard = ( { thread, parent, isExpanded, onEdit, onDelete } ) => {
 									) ) }
 								</Menu.Popover>
 							</Menu>
-						</HStack>
+						</Stack>
 					</FlexItem>
 				) }
-			</HStack>
+			</Stack>
 			{ 'edit' === actionState ? (
 				<CommentForm
 					onSubmit={ ( value ) => {
@@ -814,7 +822,7 @@ const CommentBoard = ( { thread, parent, isExpanded, onEdit, onDelete } ) => {
 					{ deleteConfirmMessage }
 				</ConfirmDialog>
 			) }
-		</VStack>
+		</Stack>
 	);
 };
 

--- a/packages/editor/src/components/collab-sidebar/floating-container.js
+++ b/packages/editor/src/components/collab-sidebar/floating-container.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 export function FloatingContainer( {
 	floating,
@@ -17,13 +17,14 @@ export function FloatingContainer( {
 } ) {
 	const isFloating = !! floating;
 	return (
-		<VStack
+		<Stack
+			direction="column"
 			className={ clsx( className, { 'is-floating': isFloating } ) }
 			ref={ isFloating ? floating.ref : undefined }
 			style={ isFloating ? { top: floating.y, ...style } : style }
 			{ ...props }
 		>
 			{ children }
-		</VStack>
+		</Stack>
 	);
 }

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
@@ -43,11 +43,12 @@ function NotesSidebarContent( {
 	const { onCreate, onEdit, onDelete } = useBlockCommentsActions();
 
 	return (
-		<VStack
+		<Stack
 			className="editor-collab-sidebar-panel"
 			style={ styles }
 			role="tree"
-			spacing="3"
+			direction="column"
+			gap="md"
 			justify="flex-start"
 			ref={ ( node ) => {
 				// Sometimes previous sidebar unmounts after the new one mounts.
@@ -69,7 +70,7 @@ function NotesSidebarContent( {
 				commentSidebarRef={ commentSidebarRef }
 				isFloating={ isFloating }
 			/>
-		</VStack>
+		</Stack>
 	);
 }
 

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -120,6 +120,15 @@
 	font-weight: $font-weight-medium;
 }
 
+.editor-collab-sidebar-panel__deleted-block-notice {
+	font-weight: $font-weight-medium;
+	color: $gray-700;
+}
+
+.editor-collab-sidebar-panel__participant-overflow {
+	font-weight: $font-weight-medium;
+}
+
 .editor-collab-sidebar-panel__resolution-text {
 	font-style: italic;
 }

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -38,6 +38,7 @@
 		{ "path": "../preferences" },
 		{ "path": "../private-apis" },
 		{ "path": "../rich-text" },
+		{ "path": "../ui" },
 		{ "path": "../url" },
 		{ "path": "../upload-media" },
 		{ "path": "../views" },

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -514,41 +514,6 @@
 			"count": 1
 		}
 	},
-	"packages/editor/src/components/collab-sidebar/add-comment.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
-	"packages/editor/src/components/collab-sidebar/comment-author-info.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
-	"packages/editor/src/components/collab-sidebar/comment-form.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 2
-		}
-	},
-	"packages/editor/src/components/collab-sidebar/comment-indicator-toolbar.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 2
-		}
-	},
-	"packages/editor/src/components/collab-sidebar/comments.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 3
-		}
-	},
-	"packages/editor/src/components/collab-sidebar/floating-container.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
-	"packages/editor/src/components/collab-sidebar/index.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/editor/src/components/document-bar/index.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION
## What?
PR migrates Notes internals to use new recommended components from the `@wordpress/ui` package. This fixes suppressed ESLint errors in the directory.

Had to remove some `Text` component uses. The new one has no `muted` variant.

## Testing Instructions
1. Open a post notes.
2. Smoke tests them for any visual regressions.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Claude with some hand-holding. It still had a couple of problems remapping the props.
