### PR TITLE
Experimental Image Cropper: Ensure focus is on canvas when dragging

### DIFF
--- a/packages/media-editor/src/image-editor/core/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/interaction-controller.ts
@@ -247,11 +247,17 @@ export class InteractionController {
 		}
 		e.preventDefault();
 
-		// Blur any focused handle so its focus ring doesn't linger.
+		// Blur any focused handle so its focus ring doesn't linger,
+		// but leave the canvas itself alone so keyboard control works after drag.
 		const ownerDoc = el.ownerDocument;
-		if ( ownerDoc?.activeElement instanceof HTMLElement ) {
+		if (
+			ownerDoc?.activeElement instanceof HTMLElement &&
+			ownerDoc.activeElement !== el
+		) {
 			ownerDoc.activeElement.blur();
 		}
+
+		el.focus();
 
 		// Capture pointer so drag works across iframe boundaries.
 		el.setPointerCapture( e.pointerId );

--- a/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
@@ -62,6 +62,7 @@ function createMockElement(): HTMLElement & {
 } {
 	const listeners: Record< string, EventListener[] > = {};
 	return {
+		focus: jest.fn(),
 		setPointerCapture: jest.fn(),
 		releasePointerCapture: jest.fn(),
 		addEventListener: jest.fn( ( type: string, fn: EventListener ) => {
@@ -329,6 +330,16 @@ describe( 'InteractionController', () => {
 			el._fire( 'pointerup', createPointerEvent() );
 
 			expect( onGestureEnd ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'focuses the element on pointerdown', () => {
+			const state = makeState( { zoom: 2 } );
+			const { controller } = createController( state );
+			const el = createMockElement();
+
+			controller.handlePointerDown( createPointerEvent(), el );
+
+			expect( el.focus ).toHaveBeenCalled();
 		} );
 
 		it( 'reports isDragging via onStatusChange', () => {


### PR DESCRIPTION
Part of:

* #73771 

## What?

Update the experimental image cropper so that focus is on the canvas when clicking to interact.

## Why?

I noticed that if I click to move the crop area, if I then go to make adjustments via the keyboard, nothing happened. So my hunch is that if we move focus there, it'll feel a little more intuitive moving from mouse to keyboard.

It's just a small change, but thought I'd try it out. If it proves okay, we might do a similar thing with the drag handles themselves. But I've kept this PR small in case it's not really viable.

## How?

* Only blur if we're not focused on the canvas.
* Focus the canvas when panning.

## Testing Instructions

Enable the MediaEditorModal experiment, and go to make a crop. Set the crop area, and drag the middle area of the crop. Then use keyboard arrows, and it should work.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/4bb98c99-8a1b-4768-83c7-39285c383b6c

### After

https://github.com/user-attachments/assets/eae143f3-cf95-464b-9256-8a2988276c0b

## Use of AI Tools

Claude Code