### PR TITLE
Guidelines: Drop default_term from wp_guideline_type taxonomy

### DIFF
--- a/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
@@ -173,7 +173,7 @@ class Gutenberg_Guidelines_Post_Type {
 			return;
 		}
 
-		$terms = wp_get_object_terms( $post_id, self::TAXONOMY, array( 'fields' => 'ids' ) );
+		$terms = get_the_terms( $post_id, self::TAXONOMY );
 		if ( is_wp_error( $terms ) || ! empty( $terms ) ) {
 			return;
 		}

--- a/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
@@ -149,12 +149,39 @@ class Gutenberg_Guidelines_Post_Type {
 				'show_admin_column'  => true,
 				'show_in_nav_menus'  => false,
 				'show_in_rest'       => true,
-				'default_term'       => array(
-					'name' => __( 'Artifact', 'gutenberg' ),
-					'slug' => self::TERM_ARTIFACT,
-				),
 			)
 		);
+	}
+
+	/**
+	 * Ensures a guideline post always has a type term.
+	 *
+	 * Assigns the `artifact` fallback when the post was saved without one.
+	 * The REST controller sets `content` explicitly for the singleton, so
+	 * this only applies to posts inserted through other paths.
+	 *
+	 * The taxonomy intentionally does not use `default_term` at registration
+	 * time: on multisite installations with many sites, that triggers cache
+	 * clearing work across sites even for taxonomies with zero posts.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public static function ensure_default_type_term( $post_id ) {
+		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return;
+		}
+
+		$terms = wp_get_object_terms( $post_id, self::TAXONOMY, array( 'fields' => 'ids' ) );
+		if ( is_wp_error( $terms ) || ! empty( $terms ) ) {
+			return;
+		}
+
+		$term_id = self::get_or_create_term_id( self::TERM_ARTIFACT, __( 'Artifact', 'gutenberg' ) );
+		if ( is_wp_error( $term_id ) ) {
+			return;
+		}
+
+		wp_set_object_terms( $post_id, array( $term_id ), self::TAXONOMY );
 	}
 
 	/**

--- a/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
@@ -151,6 +151,8 @@ class Gutenberg_Guidelines_Post_Type {
 				'show_in_rest'       => true,
 			)
 		);
+
+		add_action( 'save_post_' . self::POST_TYPE, array( __CLASS__, 'ensure_default_type_term' ) );
 	}
 
 	/**

--- a/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
@@ -169,7 +169,7 @@ class Gutenberg_Guidelines_Post_Type {
 	 * @param int $post_id Post ID.
 	 */
 	public static function ensure_default_type_term( $post_id ) {
-		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+		if ( wp_is_post_revision( $post_id ) ) {
 			return;
 		}
 

--- a/lib/experimental/guidelines/index.php
+++ b/lib/experimental/guidelines/index.php
@@ -20,11 +20,6 @@ add_action( 'init', array( 'Gutenberg_Guidelines_Post_Type', 'register' ) );
 add_action( 'rest_api_init', array( 'Gutenberg_Guidelines_Post_Type', 'register_post_meta' ) );
 
 add_action(
-	'save_post_' . Gutenberg_Guidelines_Post_Type::POST_TYPE,
-	array( 'Gutenberg_Guidelines_Post_Type', 'ensure_default_type_term' )
-);
-
-add_action(
 	'current_screen',
 	function ( $screen ) {
 		if ( Gutenberg_Guidelines_Post_Type::POST_TYPE !== $screen->post_type ) {

--- a/lib/experimental/guidelines/index.php
+++ b/lib/experimental/guidelines/index.php
@@ -20,6 +20,11 @@ add_action( 'init', array( 'Gutenberg_Guidelines_Post_Type', 'register' ) );
 add_action( 'rest_api_init', array( 'Gutenberg_Guidelines_Post_Type', 'register_post_meta' ) );
 
 add_action(
+	'save_post_' . Gutenberg_Guidelines_Post_Type::POST_TYPE,
+	array( 'Gutenberg_Guidelines_Post_Type', 'ensure_default_type_term' )
+);
+
+add_action(
 	'current_screen',
 	function ( $screen ) {
 		if ( Gutenberg_Guidelines_Post_Type::POST_TYPE !== $screen->post_type ) {

--- a/phpunit/experimental/guidelines/class-gutenberg-guidelines-post-type-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-guidelines-post-type-test.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Tests for the Guidelines Post Type registration and type-term behavior.
+ *
+ * @package gutenberg
+ */
+class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var int Administrator user ID.
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Set up class fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * Clean up class fixtures.
+	 */
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
+	}
+
+	/**
+	 * Clean up guidelines posts and taxonomy terms after each test.
+	 */
+	public function tear_down() {
+		$posts = get_posts(
+			array(
+				'post_type'      => Gutenberg_Guidelines_Post_Type::POST_TYPE,
+				'post_status'    => array( 'publish', 'draft' ),
+				'posts_per_page' => -1,
+			)
+		);
+		foreach ( $posts as $post ) {
+			wp_delete_post( $post->ID, true );
+		}
+
+		$terms = get_terms(
+			array(
+				'taxonomy'   => Gutenberg_Guidelines_Post_Type::TAXONOMY,
+				'hide_empty' => false,
+			)
+		);
+		if ( ! is_wp_error( $terms ) ) {
+			foreach ( $terms as $term ) {
+				wp_delete_term( $term->term_id, Gutenberg_Guidelines_Post_Type::TAXONOMY );
+			}
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * The taxonomy is registered for the guidelines post type.
+	 */
+	public function test_taxonomy_is_registered() {
+		$this->assertTrue( taxonomy_exists( Gutenberg_Guidelines_Post_Type::TAXONOMY ) );
+	}
+
+	/**
+	 * Regression test: the taxonomy must not be registered with `default_term`.
+	 *
+	 * Using `default_term` triggers cross-site `clean_term_cache` work on
+	 * multisite installs and is the root cause this fix addresses.
+	 */
+	public function test_taxonomy_does_not_use_default_term() {
+		$taxonomy = get_taxonomy( Gutenberg_Guidelines_Post_Type::TAXONOMY );
+
+		$this->assertNotFalse( $taxonomy );
+		$this->assertEmpty( $taxonomy->default_term );
+	}
+
+	/**
+	 * A post inserted without an explicit type gets the artifact fallback.
+	 */
+	public function test_artifact_assigned_when_no_term_set() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => Gutenberg_Guidelines_Post_Type::POST_TYPE,
+				'post_status' => 'draft',
+				'post_title'  => 'No-type guideline',
+			)
+		);
+
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+
+		$terms = wp_get_object_terms( $post_id, Gutenberg_Guidelines_Post_Type::TAXONOMY, array( 'fields' => 'slugs' ) );
+
+		$this->assertSame( array( Gutenberg_Guidelines_Post_Type::TERM_ARTIFACT ), $terms );
+	}
+
+	/**
+	 * A post inserted with an explicit type keeps that type.
+	 */
+	public function test_explicit_term_is_preserved() {
+		wp_set_current_user( self::$admin_id );
+
+		$content_term_id = Gutenberg_Guidelines_Post_Type::get_or_create_term_id(
+			Gutenberg_Guidelines_Post_Type::TERM_CONTENT,
+			'Content'
+		);
+		$this->assertIsInt( $content_term_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => Gutenberg_Guidelines_Post_Type::POST_TYPE,
+				'post_status' => 'draft',
+				'post_title'  => 'Content guideline',
+				'tax_input'   => array(
+					Gutenberg_Guidelines_Post_Type::TAXONOMY => array( $content_term_id ),
+				),
+			),
+			true
+		);
+
+		$this->assertIsInt( $post_id );
+		$this->assertNotWPError( $post_id );
+
+		$terms = wp_get_object_terms( $post_id, Gutenberg_Guidelines_Post_Type::TAXONOMY, array( 'fields' => 'slugs' ) );
+
+		$this->assertSame( array( Gutenberg_Guidelines_Post_Type::TERM_CONTENT ), $terms );
+	}
+
+	/**
+	 * Updates to an existing post do not overwrite an already-assigned term.
+	 */
+	public function test_term_is_not_overwritten_on_update() {
+		wp_set_current_user( self::$admin_id );
+
+		$content_term_id = Gutenberg_Guidelines_Post_Type::get_or_create_term_id(
+			Gutenberg_Guidelines_Post_Type::TERM_CONTENT,
+			'Content'
+		);
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => Gutenberg_Guidelines_Post_Type::POST_TYPE,
+				'post_status' => 'draft',
+				'post_title'  => 'Content guideline',
+				'tax_input'   => array(
+					Gutenberg_Guidelines_Post_Type::TAXONOMY => array( $content_term_id ),
+				),
+			),
+			true
+		);
+
+		wp_update_post(
+			array(
+				'ID'         => $post_id,
+				'post_title' => 'Updated title',
+			)
+		);
+
+		$terms = wp_get_object_terms( $post_id, Gutenberg_Guidelines_Post_Type::TAXONOMY, array( 'fields' => 'slugs' ) );
+
+		$this->assertSame( array( Gutenberg_Guidelines_Post_Type::TERM_CONTENT ), $terms );
+	}
+
+	/**
+	 * The hook does not fire for other post types.
+	 */
+	public function test_other_post_types_are_unaffected() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'draft',
+			)
+		);
+
+		$terms = wp_get_object_terms( $post_id, Gutenberg_Guidelines_Post_Type::TAXONOMY );
+
+		$this->assertSame( array(), $terms );
+	}
+}

--- a/phpunit/experimental/guidelines/class-gutenberg-guidelines-post-type-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-guidelines-post-type-test.php
@@ -165,18 +165,27 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The hook does not fire for other post types.
+	 * The fallback is skipped for revisions (including autosaves, which are
+	 * stored as revisions).
 	 */
-	public function test_other_post_types_are_unaffected() {
-		$post_id = self::factory()->post->create(
+	public function test_revision_is_ignored() {
+		wp_set_current_user( self::$admin_id );
+
+		$post_id = wp_insert_post(
 			array(
-				'post_type'   => 'post',
+				'post_type'   => Gutenberg_Guidelines_Post_Type::POST_TYPE,
 				'post_status' => 'draft',
+				'post_title'  => 'Guideline with revision',
 			)
 		);
 
-		$terms = wp_get_object_terms( $post_id, Gutenberg_Guidelines_Post_Type::TAXONOMY );
+		$revision_id = wp_save_post_revision( $post_id );
+		$this->assertIsInt( $revision_id );
+		$this->assertGreaterThan( 0, $revision_id );
 
+		Gutenberg_Guidelines_Post_Type::ensure_default_type_term( $revision_id );
+
+		$terms = wp_get_object_terms( $revision_id, Gutenberg_Guidelines_Post_Type::TAXONOMY );
 		$this->assertSame( array(), $terms );
 	}
 }


### PR DESCRIPTION
## What

Stop passing `default_term` when registering the `wp_guideline_type` taxonomy. Assign the `artifact` fallback from a `save_post_wp_guideline` hook instead, and only when the saved post has no type term yet.

## Why

Registering the taxonomy with `default_term` routes through core paths that trigger cross-site `clean_term_cache` work. On multisite installations with a large number of sites (reported on WordPress.com after v23.0.0), this caused significant load even for sites with zero guidelines posts. The `default_term` registration argument also has limited precedent in core and is not well-tested under caching/invalidation scenarios.

## How

- Remove the `default_term` argument from `register_taxonomy()`.
- Add `Gutenberg_Guidelines_Post_Type::ensure_default_type_term()` that runs on `save_post_wp_guideline`. Because that action fires after `wp_insert_post()` processes `tax_input`, any explicit term is already attached when the callback runs. The callback queries attached terms and only assigns `artifact` when none are present.
- The REST controller's singleton creation already sets `content` via `tax_input`, so that path is a no-op for this new hook.

## Behavior

- REST singleton create → `content` attached → hook is a no-op.
- Manual `/wp-admin` create with a type chosen → user term attached → hook is a no-op.
- Manual create with no type chosen → `artifact` assigned.
- Subsequent updates → post already has a term → hook is a no-op.

## Test plan

- [ ] Existing `Gutenberg_Guidelines_REST_Controller_Test` suite passes (31 tests).
- [ ] Verify on a fresh install that no guidelines posts exist and no taxonomy-related DB writes occur on `init`.
- [ ] Create a `wp_guideline` post via `wp-admin` without picking a type → confirm it gets the `artifact` term.
- [ ] Create a `wp_guideline` post via `wp-admin` with a type picked → confirm the picked term is preserved.
- [ ] Exercise the REST create endpoint → confirm the `content` term is assigned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)