### PR TITLE
Fix: block-mover horizontal tooltip position

### DIFF
--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -138,7 +138,11 @@ const BlockMoverButton = forwardRef(
 						direction,
 						orientation
 					) }
-					tooltipPosition={ direction === 'down' ? 'bottom' : 'top' }
+					tooltipPosition={
+						direction === 'down' && orientation === 'vertical'
+							? 'bottom'
+							: 'top'
+					}
 					aria-describedby={ descriptionId }
 					{ ...props }
 					onClick={ isDisabled ? null : onClick }

--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -8,7 +8,7 @@ import clsx from 'clsx';
  */
 import { getBlockType } from '@wordpress/blocks';
 import { Button, VisuallyHidden } from '@wordpress/components';
-import { useInstanceId } from '@wordpress/compose';
+import { useInstanceId, useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
@@ -66,6 +66,7 @@ const BlockMoverButton = forwardRef(
 			? clientIds
 			: [ clientIds ];
 		const blocksCount = normalizedClientIds.length;
+		const isMobileViewport = useViewportMatch( 'small', '<' );
 
 		const {
 			blockType,
@@ -139,7 +140,9 @@ const BlockMoverButton = forwardRef(
 						orientation
 					) }
 					tooltipPosition={
-						direction === 'down' && orientation === 'vertical'
+						! isMobileViewport &&
+						direction === 'down' &&
+						orientation === 'vertical'
 							? 'bottom'
 							: 'top'
 					}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73785
Fix regression from #77588

This PR refines the tooltip positioning for block mover buttons to only apply the `bottom` position when the mover orientation is `vertical`.

## Why?
As pointed out in the [previous PR](https://github.com/WordPress/gutenberg/pull/77588#issuecomment-4302719801), forcing a bottom tooltip on the "Down" button looks unnatural when the movers are arranged horizontally (where the "Down" button actually moves items right/left). In horizontal layouts, the tooltip should remain in its default top position for consistency and better visibility.

## How?
Updated the logic in `BlockMoverButton` to check both the direction and the orientation.

## Testing Instructions

1. Open a post or page.
2. **Test Vertical**: Insert two Paragraph blocks. Hover over the "Move Down" button. The tooltip should appear at the bottom. Hover over the "Move Up" button. The tooltip should appear at the top.
3. **Test Horizontal**: Insert a Buttons block or a Navigation block. Select an individual item so the horizontal movers appear.
4. Hover over both mover buttons (Left/Right).
5. Verify that both tooltips now appear at the top, rather than one being forced to the bottom.

## Screenshots or screencast 

### Before

https://github.com/user-attachments/assets/2a62d18a-d7fb-4ad2-ae0c-30967aa576b4

### After

https://github.com/user-attachments/assets/e11db8c3-0598-45a0-a64a-126a85d8a9f4


## Use of AI Tools
I used Gemini 3 Flash to help format this PR description and summarize the logic implementation based on my git diff.

cc: @ciampo, @t-hamano