### PR TITLE
Experiment: Fix console errors/warnings  for taxonomies

### DIFF
--- a/routes/taxonomies/fields.tsx
+++ b/routes/taxonomies/fields.tsx
@@ -1,13 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { Notice } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { resolveSelect, useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import type { Field, Form } from '@wordpress/dataviews';
-import { Stack } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components -- Used here because it supports rendering as a `span` via the `render` prop to avoid invalid HTML.
+import { Notice, Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -114,13 +114,15 @@ export function useSlugField(
 			type: 'text',
 			enableGlobalSearch: true,
 			description: (
-				<Stack direction="column" gap="sm">
+				<Stack direction="column" gap="sm" render={ <span /> }>
 					{ showRenameWarning && (
-						<Notice status="warning" isDismissible={ false }>
-							{ __(
-								'Changing the key renames the taxonomy — existing terms may become inaccessible until a migration updates the database.'
-							) }
-						</Notice>
+						<Notice.Root intent="warning" render={ <span /> }>
+							<Notice.Description>
+								{ __(
+									'Changing the key renames the taxonomy — existing terms may become inaccessible until a migration updates the database.'
+								) }
+							</Notice.Description>
+						</Notice.Root>
 					) }
 					<span>
 						{ __(
@@ -131,7 +133,7 @@ export function useSlugField(
 			),
 			isValid: {
 				required: true,
-				pattern: '^[a-z0-9_-]{1,32}$',
+				pattern: '^[a-z0-9_\\-]{1,32}$',
 				custom: async ( value: TaxonomyFormData ) => {
 					const slug = value.slug;
 					if ( originalSlug !== undefined && slug === originalSlug ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes some console errors/warnings  for taxonomies.





## Testing instructions
1. Enable the Content types: manage custom taxonomies experiment
2. Go to Settings/Taxonomies and observe no related console errors/warnings in dev tools
3. `edit` a taxonomy and change the `taxonomy-key` which will render the notice. Observe no related console errors/warnings in dev tools