### PR TITLE
Fix: CSS nesting deeper than one level

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1582,9 +1582,9 @@ class WP_Theme_JSON_Gutenberg {
 				$nested_selector    = $has_pseudo_element
 					? str_replace( $pseudo_part, '', $nested_selector )
 					: $nested_selector;
-				$trimmed_nested = trim( $nested_selector );
+				$trimmed_nested     = trim( $nested_selector );
 				// Build the composed selector for this nesting level.
-				$part_selector  = ( ! empty( $trimmed_nested ) && str_starts_with( $nested_selector, ' ' ) )
+				$part_selector = ( ! empty( $trimmed_nested ) && str_starts_with( $nested_selector, ' ' ) )
 					? static::scope_selector( $selector, $nested_selector )
 					: static::append_to_selector( $selector, $nested_selector );
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1564,7 +1564,7 @@ class WP_Theme_JSON_Gutenberg {
 				$nested_selector = trim( substr( $part, 0, $brace_pos ) );
 
 				// Find the body: everything after the first `{` up to the last `}`.
-				$body = substr( $part, $brace_pos + 1 );
+				$body       = substr( $part, $brace_pos + 1 );
 				$last_brace = strrpos( $body, '}' );
 				if ( false !== $last_brace ) {
 					$body = substr( $body, 0, $last_brace );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1524,6 +1524,11 @@ class WP_Theme_JSON_Gutenberg {
 	/**
 	 * Processes the CSS, to apply nesting.
 	 *
+	 * Supports arbitrarily deep native CSS nesting using the `&` selector.
+	 * Each `&` rule is flattened into an explicit `:root :where(...)` selector
+	 * so that specificity is controlled correctly. Nested `&` rules are handled
+	 * recursively, so nesting deeper than one level works as expected.
+	 *
 	 * @since 6.2.0
 	 *
 	 * @param string $css      The CSS to process.
@@ -1533,49 +1538,121 @@ class WP_Theme_JSON_Gutenberg {
 	public static function process_blocks_custom_css( $css, $selector ) {
 		$processed_css = '';
 
-		if ( empty( $css ) ) {
-			return $processed_css;
-		}
+		/*
+		* Split only on `&` tokens that appear at brace-depth 0, i.e. the
+		* top-level nesting operators so that inner `&` tokens inside a
+		* nested rule body are NOT split off prematurely.
+		*/
+		$parts = static::split_css_at_top_level_ampersand( $css );
 
-		// Split CSS nested rules.
-		$parts = explode( '&', $css );
 		foreach ( $parts as $part ) {
-			if ( empty( $part ) ) {
+			if ( empty( trim( $part ) ) ) {
 				continue;
 			}
-			$is_root_css = ( ! str_contains( $part, '{' ) );
+
+			$is_root_css = ! str_contains( $part, '{' );
 			if ( $is_root_css ) {
 				// If the part doesn't contain braces, it applies to the root level.
 				$processed_css .= ':root :where(' . trim( $selector ) . '){' . trim( $part ) . '}';
 			} else {
 				// If the part contains braces, it's a nested CSS rule.
-				$part = explode( '{', str_replace( '}', '', $part ) );
-				if ( count( $part ) !== 2 ) {
+				$brace_pos = strpos( $part, '{' );
+				if ( false === $brace_pos ) {
 					continue;
 				}
-				$nested_selector = $part[0];
-				$css_value       = $part[1];
+
+				$nested_selector = trim( substr( $part, 0, $brace_pos ) );
+
+				// Find the body: everything after the first `{` up to the last `}`.
+				$body = substr( $part, $brace_pos + 1 );
+				$last_brace = strrpos( $body, '}' );
+				if ( false !== $last_brace ) {
+					$body = substr( $body, 0, $last_brace );
+				}
+				$body = trim( $body );
 
 				/*
-				 * Handle pseudo elements such as ::before, ::after etc. Regex will also
-				 * capture any leading combinator such as >, +, or ~, as well as spaces.
-				 * This allows pseudo elements as descendants e.g. `.parent ::before`.
-				 */
+				* Handle pseudo elements such as ::before, ::after etc.  The regex
+				* also captures any leading combinator (>, +, ~) or whitespace, so
+				* descendant pseudo elements like `.parent ::before` are supported.
+				*/
 				$matches            = array();
 				$has_pseudo_element = preg_match( '/([>+~\s]*::[a-zA-Z-]+)/', $nested_selector, $matches );
 				$pseudo_part        = $has_pseudo_element ? $matches[1] : '';
-				$nested_selector    = $has_pseudo_element ? str_replace( $pseudo_part, '', $nested_selector ) : $nested_selector;
+				$nested_selector    = $has_pseudo_element
+					? str_replace( $pseudo_part, '', $nested_selector )
+					: $nested_selector;
 
-				// Finalize selector and re-append pseudo element if required.
-				$part_selector  = str_starts_with( $nested_selector, ' ' )
+				// Build the composed selector for this nesting level.
+				$part_selector = str_starts_with( $nested_selector, ' ' )
 					? static::scope_selector( $selector, $nested_selector )
 					: static::append_to_selector( $selector, $nested_selector );
-				$final_selector = ":root :where($part_selector)$pseudo_part";
 
-				$processed_css .= $final_selector . '{' . trim( $css_value ) . '}';
+				if ( str_contains( $body, '&' ) ) {
+					/*
+					* The rule body itself contains further `&` nesting.
+					* Recurse so that each deeper level is handled correctly,
+					* passing the composed selector as the new context.
+					* The pseudo element (if any) is appended to the selector
+					* so it is carried through to every descendant rule.
+					*/
+					$processed_css .= static::process_blocks_custom_css(
+						$body,
+						$part_selector . $pseudo_part
+					);
+				} else {
+					// No further nesting, emit the final flattened rule.
+					$final_selector = ':root :where(' . $part_selector . ')' . $pseudo_part;
+					$processed_css .= $final_selector . '{' . trim( $body ) . '}';
+				}
 			}
 		}
+
 		return $processed_css;
+	}
+
+	/**
+	 * Splits a CSS string at `&` characters that appear at brace depth 0.
+	 *
+	 * Unlike a naive `explode( '&', $css )`, this method only splits on `&`
+	 * tokens that are NOT inside a `{ ... }` block, so inner ampersands used
+	 * in nested CSS rules are preserved intact inside their surrounding part.
+	 *
+	 * @since 23.0.0
+	 *
+	 * @param string $css The raw CSS to split.
+	 * @return string[] Parts of the CSS split at top level `&` characters.
+	 *                  The first element is everything before the first `&`,
+	 *                  which may be an empty string.
+	 */
+	private static function split_css_at_top_level_ampersand( $css ) {
+		$parts   = array();
+		$depth   = 0;
+		$current = '';
+		$length  = strlen( $css );
+
+		for ( $i = 0; $i < $length; $i++ ) {
+			$char = $css[ $i ];
+
+			if ( '{' === $char ) {
+				++$depth;
+				$current .= $char;
+			} elseif ( '}' === $char ) {
+				--$depth;
+				$current .= $char;
+			} elseif ( '&' === $char && 0 === $depth ) {
+				// Top-level ampersand: start a new part.
+				$parts[] = $current;
+				$current = '';
+			} else {
+				$current .= $char;
+			}
+		}
+
+		// Append whatever remains after the last top level `&`.
+		$parts[] = $current;
+
+		return $parts;
 	}
 
 	/**

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1561,7 +1561,7 @@ class WP_Theme_JSON_Gutenberg {
 					continue;
 				}
 
-				$nested_selector = trim( substr( $part, 0, $brace_pos ) );
+				$nested_selector = substr( $part, 0, $brace_pos );
 
 				// Find the body: everything after the first `{` up to the last `}`.
 				$body       = substr( $part, $brace_pos + 1 );
@@ -1582,9 +1582,9 @@ class WP_Theme_JSON_Gutenberg {
 				$nested_selector    = $has_pseudo_element
 					? str_replace( $pseudo_part, '', $nested_selector )
 					: $nested_selector;
-
+				$trimmed_nested = trim( $nested_selector );
 				// Build the composed selector for this nesting level.
-				$part_selector = str_starts_with( $nested_selector, ' ' )
+				$part_selector  = ( ! empty( $trimmed_nested ) && str_starts_with( $nested_selector, ' ' ) )
 					? static::scope_selector( $selector, $nested_selector )
 					: static::append_to_selector( $selector, $nested_selector );
 

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1883,7 +1883,7 @@ export function processCSSNesting( css: string, blockSelector: string ) {
 				return;
 			}
 
-			const nestedSelector = part.slice( 0, braceIndex ).trim();
+			const nestedSelector = part.slice( 0, braceIndex );
 
 			// Body is everything after the first `{` up to the last `}`.
 			let body = part.slice( braceIndex + 1 );
@@ -1907,11 +1907,12 @@ export function processCSSNesting( css: string, blockSelector: string ) {
 			const cleanNestedSelector = pseudoPart
 				? nestedSelector.replace( pseudoPart, '' )
 				: nestedSelector;
-
+			const trimmedClean = cleanNestedSelector.trim();
 			// Build the composed selector for this nesting level.
-			const partSelector = cleanNestedSelector.startsWith( ' ' )
-				? `${ blockSelector } ${ cleanNestedSelector.trim() }`
-				: `${ blockSelector }${ cleanNestedSelector.trim() }`;
+			const partSelector =
+				trimmedClean && cleanNestedSelector.startsWith( ' ' )
+					? `${ blockSelector } ${ cleanNestedSelector.trim() }`
+					: `${ blockSelector }${ cleanNestedSelector.trim() }`;
 
 			if ( body.includes( '&' ) ) {
 				/*

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -21,7 +21,6 @@ import {
 	ROOT_CSS_PROPERTIES_SELECTOR,
 	scopeSelector,
 	scopeFeatureSelectors,
-	appendToSelector,
 	getBlockStyleVariationSelector,
 	getResolvedValue,
 } from '../utils/common';
@@ -1813,6 +1812,45 @@ function updateConfigWithSeparator(
 	return config;
 }
 
+/**
+ * Splits a CSS string at `&` characters that appear at brace depth 0 only.
+ *
+ * This preserves inner `&` tokens that are
+ * already inside a `{ ... }` block so that nested CSS nesting operators are
+ * not accidentally split off from their containing rule.
+ *
+ * @param {string} css The raw CSS string to split.
+ * @return {string[]} Parts split at top-level `&` characters.
+ */
+function splitCSSAtTopLevelAmpersand( css: string ) {
+	const parts = [];
+	let depth = 0;
+	let current = '';
+
+	for ( let i = 0; i < css.length; i++ ) {
+		const char = css[ i ];
+
+		if ( char === '{' ) {
+			depth++;
+			current += char;
+		} else if ( char === '}' ) {
+			depth--;
+			current += char;
+		} else if ( char === '&' && depth === 0 ) {
+			// Top-level ampersand, start a new part.
+			parts.push( current );
+			current = '';
+		} else {
+			current += char;
+		}
+	}
+
+	// Push whatever remains after the last top-level `&`.
+	parts.push( current );
+
+	return parts;
+}
+
 export function processCSSNesting( css: string, blockSelector: string ) {
 	let processedCSS = '';
 
@@ -1820,8 +1858,11 @@ export function processCSSNesting( css: string, blockSelector: string ) {
 		return processedCSS;
 	}
 
-	// Split CSS nested rules.
-	const parts = css.split( '&' );
+	/*
+	 * Split only on `&` tokens that appear at brace depth 0 so that inner
+	 * `&` tokens inside a nested rule body are NOT split off prematurely.
+	 */
+	const parts = splitCSSAtTopLevelAmpersand( css );
 	parts.forEach( ( part: string ) => {
 		if ( ! part || part.trim() === '' ) {
 			return;
@@ -1832,41 +1873,64 @@ export function processCSSNesting( css: string, blockSelector: string ) {
 			// If the part doesn't contain braces, it applies to the root level.
 			processedCSS += `:root :where(${ blockSelector }){${ part.trim() }}`;
 		} else {
-			// If the part contains braces, it's a nested CSS rule.
-			const splitPart = part.replace( '}', '' ).split( '{' );
-			if ( splitPart.length !== 2 ) {
+			/*
+			 * A nested `&` rule.  Locate the first `{` to split the selector
+			 * fragment from the rule body, then find the matching `}` to
+			 * extract the body content.
+			 */
+			const braceIndex = part.indexOf( '{' );
+			if ( braceIndex === -1 ) {
 				return;
 			}
 
-			const [ nestedSelector, cssValue ] = splitPart;
+			const nestedSelector = part.slice( 0, braceIndex ).trim();
 
-			// Handle pseudo elements such as ::before, ::after, etc. Regex will also
-			// capture any leading combinator such as >, +, or ~, as well as spaces.
-			// This allows pseudo elements as descendants e.g. `.parent ::before`.
-			const matches = nestedSelector.match( /([>+~\s]*::[a-zA-Z-]+)/ );
-			const pseudoPart = matches ? matches[ 1 ] : '';
-			const withoutPseudoElement = matches
-				? nestedSelector.replace( pseudoPart, '' ).trim()
-				: nestedSelector.trim();
-
-			let combinedSelector;
-			if ( withoutPseudoElement === '' ) {
-				// Only contained a pseudo element to use the block selector to form
-				// the final `:root :where()` selector.
-				combinedSelector = blockSelector;
-			} else {
-				// If the nested selector is a descendant of the block scope it with the
-				// block selector. Otherwise append it to the block selector.
-				combinedSelector = nestedSelector.startsWith( ' ' )
-					? scopeSelector( blockSelector, withoutPseudoElement )
-					: appendToSelector( blockSelector, withoutPseudoElement );
+			// Body is everything after the first `{` up to the last `}`.
+			let body = part.slice( braceIndex + 1 );
+			const lastBrace = body.lastIndexOf( '}' );
+			if ( lastBrace !== -1 ) {
+				body = body.slice( 0, lastBrace );
 			}
+			body = body.trim();
 
-			// Build final rule, re-adding any pseudo element outside the `:where()`
-			// to maintain valid CSS selector.
-			processedCSS += `:root :where(${ combinedSelector })${ pseudoPart }{${ cssValue.trim() }}`;
+			/*
+			 * Handle pseudo elements such as ::before, ::after, etc.
+			 * The regex also captures leading combinators (>, +, ~) and
+			 * spaces, so descendants like `.parent ::before` are supported.
+			 */
+			const pseudoElementMatch = nestedSelector.match(
+				/([>+~\s]*::[a-zA-Z-]+)/
+			);
+			const pseudoPart = pseudoElementMatch
+				? pseudoElementMatch[ 1 ]
+				: '';
+			const cleanNestedSelector = pseudoPart
+				? nestedSelector.replace( pseudoPart, '' )
+				: nestedSelector;
+
+			// Build the composed selector for this nesting level.
+			const partSelector = cleanNestedSelector.startsWith( ' ' )
+				? `${ blockSelector } ${ cleanNestedSelector.trim() }`
+				: `${ blockSelector }${ cleanNestedSelector.trim() }`;
+
+			if ( body.includes( '&' ) ) {
+				/*
+				 * The rule body contains further `&` nesting recurse so
+				 * that each deeper level is handled correctly, passing the
+				 * composed selector (+ any pseudo element) as the new context.
+				 */
+				processedCSS += processCSSNesting(
+					body,
+					`${ partSelector }${ pseudoPart }`
+				);
+			} else {
+				// No further nesting, emit the final flattened rule.
+				const finalSelector = `:root :where(${ partSelector })${ pseudoPart }`;
+				processedCSS += `${ finalSelector }{${ body }}`;
+			}
 		}
 	} );
+
 	return processedCSS;
 }
 

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -21,6 +21,9 @@ import {
 	ROOT_CSS_PROPERTIES_SELECTOR,
 	scopeSelector,
 	scopeFeatureSelectors,
+	// Unit tests rely on this function being exported, even though it's not used internally.
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	appendToSelector,
 	getBlockStyleVariationSelector,
 	getResolvedValue,
 } from '../utils/common';
@@ -863,7 +866,6 @@ function pickStyleKeys( treeToPickFrom: any ): any {
 	const pickedEntries = entries.filter( ( [ key ] ) =>
 		STYLE_KEYS.includes( key )
 	);
-	// clone the style objects so that `getFeatureDeclarations` can remove consumed keys from it
 	const clonedEntries = pickedEntries.map( ( [ key, style ] ) => [
 		key,
 		JSON.parse( JSON.stringify( style ) ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73217

Fixes CSS nesting parsing so only top-level & selectors are split, preventing nested rules from being parsed incorrectly.

## Why?
The previous implementation split on every `&`, including nested ones inside rule bodies. This broke nested selectors and caused valid CSS to fail or generate incorrect output.

## How?
Adds a depth aware parser that only splits `&` at brace depth `0`. Nested rules are then processed recursively while preserving pseudo-elements and selector scoping.

The logic is implemented in both the `JS` and `PHP`, CSS nesting processors to keep behavior consistent.

## Testing Instructions

1. Open the Site Editor.
2. Add a block with custom CSS & verify nested rules work.
3. Add:
```
&.is-layout-flex > *:has(+ *) {
	display: flex;
	flex-flow: row nowrap;
	column-gap: 5px;

	/* 2nd level nesting: not working as it should */
	&::after { 
		content: '•' 
	}
}
```
4. Save and verify the styles apply correctly on the frontend.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:

https://github.com/user-attachments/assets/0089482d-25f4-42be-9527-ddd8957ce4f7

After:

https://github.com/user-attachments/assets/b9be5347-e290-4088-aa72-8d45ed8721b6
