### PR TITLE
Experiment: Improve `taxonomies` DataViews height

### DIFF
--- a/routes/taxonomies/stage.tsx
+++ b/routes/taxonomies/stage.tsx
@@ -26,6 +26,7 @@ import {
 } from './fields';
 import { toFormData } from './utils';
 import type { TaxonomyRecord } from './types';
+import './style.scss';
 
 const defaultLayouts = {
 	table: {},
@@ -91,7 +92,12 @@ function TaxonomiesPage() {
 		[ totalItems, totalPages ]
 	);
 	return (
-		<Page title={ __( 'Taxonomies' ) } actions={ <AddTaxonomy /> }>
+		<Page
+			title={ __( 'Taxonomies' ) }
+			className="taxonomies-page"
+			hasPadding={ false }
+			actions={ <AddTaxonomy /> }
+		>
 			<DataViews
 				data={ data }
 				fields={ fields }

--- a/routes/taxonomies/style.scss
+++ b/routes/taxonomies/style.scss
@@ -1,5 +1,18 @@
 @use "@wordpress/base-styles/variables" as *;
 @use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/mixins" as *;
+
+// Size the stage to the viewport so DataViews owns its own scroll and
+// the sticky footer stays visible. Note: when the wp-admin sidebar
+// (#adminmenu) is taller than the viewport, #wpwrap still grows to
+// fit it, so empty space may appear below DataViews.
+.boot-layout__stage:has(.taxonomies-page) {
+	height: calc(100vh - #{$admin-bar-height-big});
+
+	@include break-medium {
+		height: calc(100vh - #{$admin-bar-height});
+	}
+}
 
 .dataviews-action-modal__edit-taxonomy {
 	justify-content: flex-end;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/77600


This PR improves `taxonomies` DataViews height so the sticky footer is visible at the bottom of the visible viewport.

There are some more nuances to this because there can still be empty space below the DataViews component if the wp-admin sidebar is taller than the viewport. In site editor this is handled by having the sidebar as a separate scrolling container, but trying something like that for the main sidebar is out of scope of this experiment and might be impactful.

## Testing instructions
1. Enable the Content types: manage custom taxonomies experiment
2. Go to Settings/Taxonomies and observe that the footer is properly positioned and visible.
