### PR TITLE
Embed block: add lazy-load iframe option

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -312,7 +312,7 @@ Add a block that displays content pulled from other sites, like Twitter or YouTu
 -	**Name:** core/embed
 -	**Category:** embed
 -	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin)
--	**Attributes:** allowResponsive, caption, previewable, providerNameSlug, responsive, type, url
+-	**Attributes:** allowResponsive, caption, lazyLoad, previewable, providerNameSlug, responsive, type, url
 
 ## File
 

--- a/packages/block-library/src/embed/block.json
+++ b/packages/block-library/src/embed/block.json
@@ -38,6 +38,10 @@
 			"type": "boolean",
 			"default": true,
 			"role": "content"
+		},
+		"lazyLoad": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -1,19 +1,6 @@
 /**
  * Internal dependencies
  */
-import {
-	createUpgradedEmbedBlock,
-	getClassNames,
-	removeAspectRatioClasses,
-	fallback,
-	getEmbedInfoByProvider,
-	getMergedAttributesWithPreview,
-} from './util';
-import EmbedControls from './embed-controls';
-import { embedContentIcon } from './icons';
-import EmbedLoading from './embed-loading';
-import EmbedPlaceholder from './embed-placeholder';
-import EmbedPreview from './embed-preview';
 
 /**
  * External dependencies
@@ -30,6 +17,19 @@ import { useBlockProps } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { View } from '@wordpress/primitives';
 import { getAuthority } from '@wordpress/url';
+import EmbedPreview from './embed-preview';
+import EmbedPlaceholder from './embed-placeholder';
+import EmbedLoading from './embed-loading';
+import { embedContentIcon } from './icons';
+import EmbedControls from './embed-controls';
+import {
+	createUpgradedEmbedBlock,
+	getClassNames,
+	removeAspectRatioClasses,
+	fallback,
+	getEmbedInfoByProvider,
+	getMergedAttributesWithPreview,
+} from './util';
 import { Caption } from '../utils/caption';
 
 const EmbedEdit = ( props ) => {
@@ -39,6 +39,7 @@ const EmbedEdit = ( props ) => {
 			previewable,
 			responsive,
 			url: attributesUrl,
+			lazyLoad,
 		},
 		attributes,
 		isSelected,
@@ -117,6 +118,10 @@ const EmbedEdit = ( props ) => {
 			title,
 			responsive
 		);
+
+	function toggleLazyLoad( newLazyLoad ) {
+		setAttributes( { lazyLoad: newLazyLoad } );
+	}
 
 	function toggleResponsive( newAllowResponsive ) {
 		const { className } = attributes;
@@ -265,6 +270,8 @@ const EmbedEdit = ( props ) => {
 				allowResponsive={ allowResponsive }
 				toggleResponsive={ toggleResponsive }
 				switchBackToURLInput={ () => setIsEditingURL( true ) }
+				lazyLoad={ lazyLoad }
+				toggleLazyLoad={ toggleLazyLoad }
 			/>
 			<figure
 				{ ...blockProps }

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -27,6 +27,14 @@ function getResponsiveHelp( checked ) {
 		  );
 }
 
+function getLazyLoadHelp( checked ) {
+	return checked
+		? __(
+				'The iframe will be loaded only when it is visible in the viewport.'
+		  )
+		: __( 'The iframe will be loaded immediately when the page loads.' );
+}
+
 const EmbedControls = ( {
 	blockSupportsResponsive,
 	showEditButton,
@@ -34,6 +42,8 @@ const EmbedControls = ( {
 	allowResponsive,
 	toggleResponsive,
 	switchBackToURLInput,
+	lazyLoad,
+	toggleLazyLoad,
 } ) => {
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
@@ -51,21 +61,27 @@ const EmbedControls = ( {
 					) }
 				</ToolbarGroup>
 			</BlockControls>
-			{ themeSupportsResponsive && blockSupportsResponsive && (
-				<InspectorControls>
-					<ToolsPanel
-						label={ __( 'Media settings' ) }
-						resetAll={ () => {
+			<InspectorControls>
+				<ToolsPanel
+					label={ __( 'Media settings' ) }
+					resetAll={ () => {
+						if (
+							themeSupportsResponsive &&
+							blockSupportsResponsive
+						) {
 							toggleResponsive( true );
-						} }
-						dropdownMenuProps={ dropdownMenuProps }
-					>
+						}
+						toggleLazyLoad( false );
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					{ themeSupportsResponsive && blockSupportsResponsive && (
 						<ToolsPanelItem
-							label={ __( 'Media settings' ) }
+							label={ __( 'Resize for smaller devices' ) }
 							isShownByDefault
 							hasValue={ () => ! allowResponsive }
 							onDeselect={ () => {
-								toggleResponsive( ! allowResponsive );
+								toggleResponsive( true );
 							} }
 						>
 							<ToggleControl
@@ -75,9 +91,22 @@ const EmbedControls = ( {
 								onChange={ toggleResponsive }
 							/>
 						</ToolsPanelItem>
-					</ToolsPanel>
-				</InspectorControls>
-			) }
+					) }
+					<ToolsPanelItem
+						label={ __( 'Lazy-load' ) }
+						isShownByDefault
+						hasValue={ () => lazyLoad }
+						onDeselect={ () => toggleLazyLoad( false ) }
+					>
+						<ToggleControl
+							label={ __( 'Lazy-load' ) }
+							checked={ !! lazyLoad }
+							help={ getLazyLoadHelp }
+							onChange={ toggleLazyLoad }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
+			</InspectorControls>
 		</>
 	);
 };

--- a/packages/block-library/src/embed/index.php
+++ b/packages/block-library/src/embed/index.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Server-side rendering of the `core/embed` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/embed` block on the server, applying loading="lazy" to
+ * the iframe when the lazyLoad attribute is enabled.
+ *
+ * @since 6.9.0
+ *
+ * @param array  $attributes The block attributes.
+ * @param string $content    The block content.
+ * @return string The block content, with loading="lazy" on the iframe if enabled.
+ */
+function render_block_core_embed( array $attributes, string $content ): string {
+	if ( empty( $attributes['lazyLoad'] ) ) {
+		return $content;
+	}
+
+	if ( ! str_contains( $content, '<iframe' ) ) {
+		return $content;
+	}
+
+	$p = new WP_HTML_Tag_Processor( $content );
+	while ( $p->next_tag( array( 'tag_name' => 'IFRAME' ) ) ) {
+		$p->set_attribute( 'loading', 'lazy' );
+	}
+
+	return $p->get_updated_html();
+}
+
+/**
+ * Registers the `core/embed` block on the server.
+ *
+ * @since 6.9.0
+ */
+function register_block_core_embed(): void {
+	register_block_type_from_metadata(
+		__DIR__ . '/embed',
+		array(
+			'render_callback' => 'render_block_core_embed',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_embed' );


### PR DESCRIPTION
<h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">What?</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Closes &lt;!#77594&gt;</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Adds an optional <strong>Lazy-load</strong> toggle to the Embed block's <strong>Media settings</strong> inspector panel. When enabled, the block's iframe is rendered with <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">loading="lazy"</code>, deferring the load of offscreen embeds (e.g. YouTube videos below the fold). The feature is opt-in and off by default, so all existing embeds are unaffected.</p><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Why?</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Pages with multiple video embeds — especially YouTube — can suffer significant performance penalties because all iframes load eagerly on page load, regardless of whether they are visible. Native <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">loading="lazy"</code> on iframes is well-supported and recommended by modern web performance guidelines (Core Web Vitals, Lighthouse). Currently there is no built-in way to enable this in the Embed block without custom code or a third-party plugin.</p><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">How?</h2><ul style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">block.json</code></strong><span> </span>— Registers a new<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">lazyLoad</code><span> </span>boolean attribute (default<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">false</code>).</li><li><strong><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">embed-controls.js</code></strong><span> </span>— Adds a<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Lazy-load</code><span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ToggleControl</code><span> </span>inside the existing<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Media settings</code><span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ToolsPanel</code><span> </span>in the block inspector. The panel now renders for all embeds (not only responsive ones) so the toggle is always accessible.</li><li><strong><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">edit.js</code></strong><span> </span>— Destructures<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">lazyLoad</code><span> </span>from attributes, defines<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">toggleLazyLoad()</code>, and passes both down to<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">EmbedControls</code>.</li><li><strong><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">index.php</code></strong><span> </span>— Introduces a PHP<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">render_callback</code><span> </span>(<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">render_block_core_embed</code>) that uses<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">WP_HTML_Tag_Processor</code><span> </span>to inject<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">loading="lazy"</code><span> </span>on every<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">&lt;iframe&gt;</code><span> </span>in the rendered block HTML when<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">lazyLoad</code><span> </span>is<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">true</code>. When<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">false</code>, content is returned unchanged.</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">No changes to <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">save.js</code> — the attribute is stored only in the block comment delimiter and applied entirely server-side, keeping the feature backward-compatible.</p><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Testing Instructions</h2><ol style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Open a post or page in the block editor.</li><li>Insert a<span> </span><strong>YouTube Embed</strong><span> </span>block (or any Embed block).</li><li>Paste a YouTube URL (e.g.<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">https://www.youtube.com/watch?v=dQw4w9WgXcQ</code>) and click<span> </span><strong>Embed</strong>.</li><li>With the block selected, open the<span> </span><strong>Block</strong><span> </span>tab in the right sidebar.</li><li>Scroll down to the<span> </span><strong>Media settings</strong><span> </span>panel — confirm a new<span> </span><strong>Lazy-load</strong><span> </span>toggle is present and defaults to<span> </span><strong>off</strong>.</li><li>Toggle<span> </span><strong>Lazy-load</strong><span> </span>on and click<span> </span><strong>Save</strong>.</li><li>View the page on the frontend and inspect the embed's<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">&lt;iframe&gt;</code><span> </span>element — it should have<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">loading="lazy"</code>.</li><li>Toggle<span> </span><strong>Lazy-load</strong><span> </span>back off, save, and re-inspect —<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">loading="lazy"</code><span> </span>should be absent.</li><li>Verify existing embeds (with no<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">lazyLoad</code><span> </span>attribute saved) render without<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">loading="lazy"</code><span> </span>(backward compat).</li></ol><h3 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Testing Instructions for Keyboard</h3><ol style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Navigate to the block using<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Tab</code><span> </span>/ arrow keys.</li><li>Open the<span> </span><strong>Block</strong><span> </span>sidebar with<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Ctrl+Shift+,</code><span> </span>(or via the toolbar options menu).</li><li><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Tab</code><span> </span>through the<span> </span><strong>Media settings</strong><span> </span>panel to reach the<span> </span><strong>Lazy-load</strong><span> </span>toggle.</li><li>Press<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Space</code><span> </span>to toggle it on/off — confirm the state changes correctly.</li><li>Save the post with<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Ctrl+S</code><span> </span>and verify the result on the frontend as above.</li></ol><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Screenshots or screencast</h2>
Before | After
-- | --
Media settings panel — only "Resize for smaller devices" shown (when responsive theme) | Media settings panel — "Lazy-load" toggle visible for all embed types

