### PR TITLE
Experiment: Improve taxonomy `edit` action

### DIFF
--- a/routes/taxonomies/actions/edit.tsx
+++ b/routes/taxonomies/actions/edit.tsx
@@ -3,7 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { closeSmall, pencil } from '@wordpress/icons';
-import { store as coreStore, useEntityRecord } from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import {
 	DataForm,
@@ -30,8 +30,8 @@ import {
 	useObjectTypeField,
 	useSlugField,
 } from '../fields';
-import { serializeForSave, toFormData } from '../utils';
-import type { TaxonomyFormData, TaxonomyRecord } from '../types';
+import { serializeForSave } from '../utils';
+import type { TaxonomyFormData } from '../types';
 
 function EditTaxonomyModal( {
 	items,
@@ -41,18 +41,7 @@ function EditTaxonomyModal( {
 	closeModal?: () => void;
 } ) {
 	const item = items[ 0 ];
-	const { record, hasResolved } = useEntityRecord< TaxonomyRecord >(
-		'postType',
-		'wp_user_taxonomy',
-		item.id as number
-	);
-
-	const initialData = useMemo< TaxonomyFormData >(
-		() => ( record ? toFormData( record ) : item ),
-		[ record, item ]
-	);
-
-	const [ data, setData ] = useState< TaxonomyFormData >( initialData );
+	const [ data, setData ] = useState< TaxonomyFormData >( item );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const slugField = useSlugField( item.slug, data.slug );
 	const objectTypeField = useObjectTypeField();
@@ -108,23 +97,18 @@ function EditTaxonomyModal( {
 		}
 	}
 
-	if ( ! hasResolved ) {
-		return null;
-	}
-
 	return (
-		<>
+		<Stack
+			className="dataviews-action-modal__edit-taxonomy-body"
+			direction="column"
+		>
 			<Stack
 				className="dataviews-action-modal__edit-taxonomy-header"
 				direction="row"
 				justify="space-between"
 				align="center"
 			>
-				<Text
-					variant="heading-sm"
-					render={ <h2 /> }
-					className="dataviews-action-modal__edit-taxonomy-title"
-				>
+				<Text variant="heading-sm" render={ <h2 /> }>
 					{ __( 'Edit taxonomy' ) }
 				</Text>
 				<Button
@@ -171,7 +155,7 @@ function EditTaxonomyModal( {
 					{ __( 'Done' ) }
 				</Button>
 			</Stack>
-		</>
+		</Stack>
 	);
 }
 

--- a/routes/taxonomies/style.scss
+++ b/routes/taxonomies/style.scss
@@ -32,38 +32,28 @@
 	}
 
 	.components-modal__content {
-		display: flex;
-		flex-direction: column;
-		height: 100%;
 		padding: 0;
+		overflow-y: auto;
 	}
 
 	.dataviews-action-modal__edit-taxonomy-header {
-		flex: 0 0 auto;
-		padding: $grid-unit-15 $grid-unit-20 $grid-unit-15 $grid-unit-30;
-		border-bottom: 1px solid $gray-200;
-		background: #fff;
-	}
-
-	.dataviews-action-modal__edit-taxonomy-title {
-		margin: 0;
-		font-size: 13px;
-		font-weight: 600;
-		line-height: 1.4;
+		position: sticky;
+		top: 0;
+		z-index: 1;
+		background: $white;
+		padding: $grid-unit-20 $grid-unit-30;
 	}
 
 	.dataviews-action-modal__edit-taxonomy-content {
-		flex: 1 1 auto;
-		min-height: 0;
-		overflow-y: auto;
-		padding: $grid-unit-20 $grid-unit-30;
+		padding: 0 $grid-unit-30;
 	}
 
 	.dataviews-action-modal__edit-taxonomy-footer {
-		flex: 0 0 auto;
+		position: sticky;
+		bottom: 0;
+		z-index: 1;
+		background: $white;
 		padding: $grid-unit-20 $grid-unit-30;
-		border-top: 1px solid $gray-200;
-		background: #fff;
 
 		.components-button {
 			flex: 1;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/77600

Improve taxonomy `edit`action:
1. Sticky header/footer in UI
2. Simplify action by using the selected item. Initially the implementation was inspired by `quick edit modal` but the main difference there is that the quick edit modal is not part of the action itself, therefore didn't have access to the selected item.

## Testing instructions
1. Enable the Content types: manage custom taxonomies experiment
3. Go to Settings/Taxonomies and edit taxonomies.
4. Edits should work properly and UI should include the sticky header/footer.
