### PR TITLE
Tabs: Add classic theme styles to reset button defaults

### DIFF
--- a/packages/block-library/src/classic.scss
+++ b/packages/block-library/src/classic.scss
@@ -69,8 +69,8 @@
 	&:hover,
 	&:focus {
 		// Sometimes styles are applied when the button element is
-		// hovered over or focused. This isn't expected for accordion
-		// toggle buttons, so reset those styles here.
+		// hovered over or focused. This isn't expected for tab
+		// buttons, so reset those styles here.
 		text-decoration: none;
 	}
 

--- a/packages/block-library/src/classic.scss
+++ b/packages/block-library/src/classic.scss
@@ -58,3 +58,24 @@
 		outline: auto;
 	}
 }
+
+.wp-block-tab {
+	// Button elements can have colors applied with high CSS specificity,
+	// and since this specificity is impossible to predict, we use
+	// `!important` to reset the color.
+	background-color: inherit !important;
+	color: inherit !important;
+
+	&:hover,
+	&:focus {
+		// Sometimes styles are applied when the button element is
+		// hovered over or focused. This isn't expected for accordion
+		// toggle buttons, so reset those styles here.
+		text-decoration: none;
+	}
+
+	&:focus-visible {
+		outline-offset: 0;
+		outline: auto;
+	}
+}

--- a/packages/block-library/src/classic.scss
+++ b/packages/block-library/src/classic.scss
@@ -63,8 +63,12 @@
 	// Button elements can have colors applied with high CSS specificity,
 	// and since this specificity is impossible to predict, we use
 	// `!important` to reset the color.
-	background-color: inherit !important;
-	color: inherit !important;
+	&:not(.has-text-color) {
+		color: inherit !important;
+	}
+	&:not(.has-background) {
+		background-color: inherit !important;
+	}
 
 	&:hover,
 	&:focus {


### PR DESCRIPTION
Related to: #73454
See: https://github.com/WordPress/gutenberg/issues/75402#issuecomment-3997675066

## What?

This PR provides a default tab button style for the classic theme.

## Why?

Many classic themes apply styles to the button element. Due to the influence of these styles, active tabs may not be displayed correctly or may result in an unnatural design.

## How?

To ensure that the default style is displayed appropriately in all themes, we will add minimal styles.

- No background color, default text color
- Border below the active tab
- Outline appears when the tab is focused

## Testing Instructions

Enable any theme to check the tab styles.



## Screenshots or screencast <!-- if applicable -->

| Theme | Before | After |
|--------|--------|--------|
| Twenty Twenty-One | <img width="269" height="134" alt="image" src="https://github.com/user-attachments/assets/6c79ae42-2fb2-4077-ad71-9438fa2d7014" />| <img width="290" height="123" alt="image" src="https://github.com/user-attachments/assets/208e7074-00c3-4f6a-8327-f937f0295963" /> |
| Twenty Twenty | <img width="294" height="187" alt="image" src="https://github.com/user-attachments/assets/5d8274a4-034a-4e98-8af8-3c91dad1a470" />| <img width="289" height="199" alt="image" src="https://github.com/user-attachments/assets/d5792b9c-ef0d-4481-8820-f1524f2d84e2" />|
| Twenty Nineteen | <img width="291" height="119" alt="image" src="https://github.com/user-attachments/assets/c539a9ac-0fae-4a36-afb9-169bc0824b23" />| <img width="285" height="143" alt="image" src="https://github.com/user-attachments/assets/bb369251-3175-4417-80b0-05d839df09d4" />|
| Twenty Seventeen | <img width="222" height="91" alt="image" src="https://github.com/user-attachments/assets/ba91d735-a229-4235-885a-c0a774281e31" />| <img width="222" height="85" alt="image" src="https://github.com/user-attachments/assets/9117da22-7e90-4d4d-b179-376731b9111d" />|
| Twenty Sixteen | <img width="235" height="97" alt="image" src="https://github.com/user-attachments/assets/94e7f49f-1a87-49bb-a3ac-ef903c6ca329" />| <img width="229" height="97" alt="image" src="https://github.com/user-attachments/assets/cbd3a0a6-2595-4eb4-87af-1507cabb2ae9" />| 

## Use of AI Tools

N/A