### PR TITLE
Document how to ignore VSCode Workplace Settings.

### DIFF
--- a/docs/contributors/code/getting-started-with-code-contribution.md
+++ b/docs/contributors/code/getting-started-with-code-contribution.md
@@ -243,7 +243,9 @@ To use Prettier with Visual Studio Code, you should install the [Prettier - Code
 
 This will use the `.prettierrc.js` file included in the root of the Gutenberg repository. The config is included from the [@wordpress/prettier-config](/packages/prettier-config/README.md) package.
 
-If you only want to use this configuration with the Gutenberg project, create a directory called .vscode at the top-level of Gutenberg, and place your settings in a settings.json there. Visual Studio Code refers to this as Workplace Settings, and only apply to the project.
+If you only want to use this configuration with the Gutenberg project, create a directory called `.vscode` at the top-level of Gutenberg (if it doesn't exist yet), and place your settings in a `settings.json` there. Visual Studio Code refers to this as Workplace Settings, and only apply to the project.
+
+After you create a `.vscode/settings.json` file in your repository, you probably want to add it to your [global gitignore file](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer) so that it stays private for you and is not committed to the repository.
 
 For other editors, see [Prettier's Editor Integration docs](https://prettier.io/docs/en/editors.html)
 

--- a/docs/contributors/code/getting-started-with-code-contribution.md
+++ b/docs/contributors/code/getting-started-with-code-contribution.md
@@ -243,7 +243,7 @@ To use Prettier with Visual Studio Code, you should install the [Prettier - Code
 
 This will use the `.prettierrc.js` file included in the root of the Gutenberg repository. The config is included from the [@wordpress/prettier-config](/packages/prettier-config/README.md) package.
 
-If you only want to use this configuration with the Gutenberg project, create a directory called `.vscode` at the top-level of Gutenberg (if it doesn't exist yet), and place your settings in a `settings.json` there. Visual Studio Code refers to this as Workplace Settings, and only apply to the project.
+If you only want to use this configuration with the Gutenberg project, create a directory called `.vscode` at the top-level of Gutenberg (if it doesn't exist yet), and place your settings in a `settings.json` there. Visual Studio Code refers to this as Workspace Settings, and only apply to the project.
 
 After you create a `.vscode/settings.json` file in your repository, you probably want to add it to your [global gitignore file](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer) so that it stays private for you and is not committed to the repository.
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

Tiny PR to improve documentation.

The documentation about configuring Prettier with VSCode suggests to create a 
`.vscode` directory and place there a `settings.json` file if contributors want to use the configuration only with the Gutenberg project:

https://github.com/WordPress/gutenberg/blob/a91510eeec84b317be39b89526772b0f00abe5d2/docs/contributors/code/getting-started-with-code-contribution.md?plain=1#L246

However, by doing so, Git will detect a new untracked file with the risk contributors may commit it.
Also, the `.vscode` directory already exists so the wording 'create a directory ...` should be improved.

I initially considered to add it to the `.gitignore` file. Then, based on the  discussion on https://github.com/WordPress/gutenberg/pull/31622 I realized it's best for the `.gitignore` file to not contain any IDE/editor specific entry.

As such, I'd like to propose to add to the doc the same recommendation already in use for the env `launch.json` file. See:

https://github.com/WordPress/gutenberg/blob/d173a16785b0bc95d04a71c582a5e8c4d6e5a3a0/packages/env/README.md?plain=1#L281

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- Contributors may inadvertently commit the file.
- Documentation consistnecy.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Improves the docs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Observe whether the amended documentation makes sense.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
None