### PR TITLE
Links: ensure custom links show invalid state in editor

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -671,6 +671,25 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inspector-controls/README.md>
 
+### isURLLike
+
+Determines whether a given value could be a URL or valid href value (like relative paths or hash links). Note this does not guarantee the value is a URL only that it looks like something that should be treated as direct entry rather than a search term. For example, just because a string has `www.` in it doesn't make it a URL, but it does make it highly likely that it will be so in the context of creating a link it makes sense to treat it like one.
+
+Examples of "URL-like" values:
+
+-   URLs with protocols: `https://wordpress.org`, `mailto:test@example.com`
+-   Domain-like strings: `www.wordpress.org`, `wordpress.org`
+-   Relative paths: `/handbook`, `./page`, `../parent`
+-   Hash links: `#section`
+
+_Parameters_
+
+-   _val_ `string`: the candidate for being URL-like (or not).
+
+_Returns_
+
+-   `boolean`: whether or not the value is potentially a URL.
+
 ### isValueSpacingPreset
 
 Checks is given value is a spacing preset.

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -169,6 +169,7 @@ export { default as __experimentalPublishDateTimePicker } from './publish-date-t
 export { default as __experimentalInspectorPopoverHeader } from './inspector-popover-header';
 export { default as BlockPopover } from './block-popover';
 export { useBlockEditingMode } from './block-editing-mode';
+export { default as isURLLike } from './link-control/is-url-like';
 
 /*
  * State Related Components

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -160,6 +160,11 @@ export default function NavigationLinkEdit( {
 		[ clientId, maxNestingLevel ]
 	);
 
+	const selectedBlockClientId = useSelect(
+		( select ) => select( blockEditorStore ).getSelectedBlockClientId(),
+		[]
+	);
+
 	const validateLinkStatus = useEnableLinkStatusValidation( clientId );
 	const { getBlocks } = useSelect( blockEditorStore );
 
@@ -176,11 +181,16 @@ export default function NavigationLinkEdit( {
 		setAttributes,
 	} );
 
+	const isEditingContext =
+		isSelected || selectedBlockClientId === parentBlockClientId;
+
 	const [ isInvalid, isDraft ] = useIsInvalidLink(
 		kind,
 		type,
 		id,
-		validateLinkStatus
+		validateLinkStatus,
+		url,
+		isEditingContext
 	);
 
 	/**
@@ -394,6 +404,8 @@ export default function NavigationLinkEdit( {
 					attributes={ attributes }
 					setAttributes={ setAttributes }
 					clientId={ clientId }
+					isSelected={ isSelected }
+					isParentOfSelectedBlock={ isParentOfSelectedBlock }
 				/>
 			</InspectorControls>
 			<div { ...blockProps }>

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -138,6 +138,25 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		return '';
 	}
 
+	// Don't render custom links with invalid or missing URLs.
+	$kind = isset( $attributes['kind'] ) ? $attributes['kind'] : '';
+	$url  = isset( $attributes['url'] ) ? trim( $attributes['url'] ) : '';
+
+	if ( 'post-type' !== $kind ) {
+		$is_valid_url =
+			! empty( $url ) && (
+				filter_var( $url, FILTER_VALIDATE_URL ) !== false ||
+				str_starts_with( $url, '/' ) ||
+				str_starts_with( $url, '#' ) ||
+				str_starts_with( $url, 'mailto:' ) ||
+				str_starts_with( $url, 'tel:' )
+			);
+
+		if ( ! $is_valid_url ) {
+			return '';
+		}
+	}
+
 	// The build system prefixes this function with "gutenberg_" to avoid
 	// collisions with the core version. Until this function is backported to
 	// core, we need to guard its use and only call the prefixed name in

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -71,17 +71,21 @@ function getEntityTypeName( type, kind ) {
  * This component provides the inspector controls (ToolsPanel) that are identical
  * between both navigation blocks.
  *
- * @param {Object}   props                - Component props
- * @param {Object}   props.attributes     - Block attributes
- * @param {Function} props.setAttributes  - Function to update block attributes
- * @param {string}   props.clientId       - Block client ID
- * @param {boolean}  props.isLinkEditable - Whether link editing should be allowed
+ * @param {Object}   props                         - Component props
+ * @param {Object}   props.attributes              - Block attributes
+ * @param {Function} props.setAttributes           - Function to update block attributes
+ * @param {string}   props.clientId                - Block client ID
+ * @param {boolean}  props.isLinkEditable          - Whether link editing should be allowed
+ * @param {boolean}  props.isSelected
+ * @param {boolean}  props.isParentOfSelectedBlock
  */
 export function Controls( {
 	attributes,
 	setAttributes,
 	clientId,
 	isLinkEditable = true,
+	isSelected = false,
+	isParentOfSelectedBlock = false,
 } ) {
 	const { label, url, description, rel, opensInNewTab } = attributes;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
@@ -93,11 +97,15 @@ export function Controls( {
 			attributes,
 		} );
 
+	const isEditingContext = isSelected || isParentOfSelectedBlock;
+
 	const [ isInvalid, isDraft ] = useIsInvalidLink(
 		attributes.kind,
 		attributes.type,
 		entityRecord?.id,
-		hasUrlBinding
+		hasUrlBinding,
+		url,
+		isEditingContext
 	);
 
 	let helpText = '';

--- a/packages/block-library/src/navigation-link/shared/use-is-invalid-link.js
+++ b/packages/block-library/src/navigation-link/shared/use-is-invalid-link.js
@@ -3,19 +3,27 @@
  */
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useBlockEditingMode } from '@wordpress/block-editor';
+import { useBlockEditingMode, isURLLike } from '@wordpress/block-editor';
 
 /**
  * A React hook to determine if a navigation link or submenu's parent link is invalid.
  *
- * @param {string}  kind    The kind of link (post-type, custom, taxonomy, etc).
- * @param {string}  type    The type of post (post, page, etc).
- * @param {number}  id      The post or term id.
- * @param {boolean} enabled Whether to enable the validation check.
- *
+ * @param {string}  kind             The kind of link (post-type, custom, taxonomy, etc).
+ * @param {string}  type             The type of post (post, page, etc).
+ * @param {number}  id               The post or term id.
+ * @param {boolean} enabled          Whether to enable the entity validation check.
+ * @param {string}  url              The URL attribute (for custom link validation).
+ * @param {boolean} isEditingContext Whether the block (or parent block) is selected.
  * @return {Array} Array containing [isInvalid, isDraft] booleans.
  */
-export const useIsInvalidLink = ( kind, type, id, enabled ) => {
+export const useIsInvalidLink = (
+	kind,
+	type,
+	id,
+	enabled,
+	url,
+	isEditingContext
+) => {
 	const isPostType =
 		kind === 'post-type' || type === 'post' || type === 'page';
 	const hasId = Number.isInteger( id );
@@ -62,11 +70,25 @@ export const useIsInvalidLink = ( kind, type, id, enabled ) => {
 	// 1. The post status is trash (trashed).
 	// 2. The entity doesn't exist (deleted).
 	// If either of those is true, invalidate.
-	const isInvalid =
+	const isInvalidEntity =
 		isPostType &&
 		hasId &&
 		( isDeleted || ( postStatus && 'trash' === postStatus ) );
 	const isDraft = 'draft' === postStatus;
 
-	return [ isInvalid, isDraft ];
+	// URL-based invalidity check for custom links.
+	//
+	// A custom link is any link that is NOT a post-type entity binding.
+	// We check it when:
+	//   1. It is not a post-type link (kind !== 'post-type').
+	//   2. The block is in an editable mode (not disabled/template context).
+	const shouldCheckUrl =
+		! isPostType && blockEditingMode !== 'disabled' && isEditingContext;
+
+	// A custom link is invalid when:
+	//   - It has no URL at all, OR
+	//   - Its URL fails isURL() (e.g. "not a url")
+	const isInvalidUrl = shouldCheckUrl && ( ! url || ! isURLLike( url ) );
+
+	return [ isInvalidEntity || isInvalidUrl, isDraft ];
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72621 <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->
Adds URL validation for custom navigation links. The existing useIsInvalidLink hook only checked entity status, leaving custom links entirely unvalidated.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Previously only entity-based links (trashed/deleted posts) were flagged as invalid — custom links with bad or missing URLs were silently ignored. Now they show the existing (Invalid) indicator and are suppressed on the frontend.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Extended `useIsInvalidLink` to accept two new parameters: `url` and `isEditingContext`. When the link is not a post-type entity and the block is in an editing context, it checks whether the URL passes `isURLLike()`. If it doesn't (or is empty), `isInvalid` is returned as `true`.
- Exported `isURLLike` from `@wordpress/block-editor` so it can be consumed by the navigation-link package.
- Updated call sites in both edit.js and controls.js to pass the new parameters.
- Added a PHP-side guard in index.php to suppress rendering of custom links with invalid/missing URLs on the frontend.

Note: Consistent display of the invalid state in the List View sidebar (canvas + sidebar parity) is tracked separately in #73304, which also has a needs-design label. That work is out of scope for this PR.

## Testing Instructions

1. Open a post or page in the editor.
2. Insert a Navigation block and add a Custom Link item.
3. Set the URL to something invalid, e.g. not a url, hello, or leave it empty.
4. Select the navigation link block.
5. Verify that the (Invalid) indicator appears next to the label in the canvas.
6. Deselect the block — verify the indicator is not shown (check is only performed when selected, to avoid performance regressions).
7. Save and preview the page — verify the invalid custom link is not rendered on the frontend.
8. Repeat with a valid URL (e.g. https://wordpress.org, /relative-path, #hash) — verify no invalid indicator appears.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


Before | After
-- | --
Custom link with invalid URL renders normally | (Invalid) indicator shown when block is selected
<img width="900" height="200" alt="Screenshot 2026-04-24 at 12 15 59 PM" src="https://github.com/user-attachments/assets/640f52bd-379d-41a6-9d29-c2d97de0b80e" /> | <img width="900" height="200" alt="Screenshot 2026-04-24 at 12 30 12 PM" src="https://github.com/user-attachments/assets/03fae10e-b777-4360-9839-f77490f32ab2" />

## Use of AI Tools
Claude (Anthropic) was used to help with drafting this PR and it's description. All code changes were reviewed manually.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
