### PR TITLE
Core Data: Replace mutated edits with original record to fix dirty state

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -25,6 +25,7 @@ import {
 	getSyncManager,
 } from './sync';
 import logEntityDeprecation from './utils/log-entity-deprecation';
+import { POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE } from './utils/crdt';
 
 function addTitleToAutoDraft( record ) {
 	return record.status === 'auto-draft' ? { ...record, title: '' } : record;
@@ -779,10 +780,32 @@ export const saveEntityRecord =
 							) ),
 						};
 					}
+
+					let fetchPayload = edits;
+
+					if ( persistedRecord ) {
+						const objectType = `${ kind }/${ name }`;
+						const serializedDoc =
+							await getSyncManager()?.createPersistedCRDTDoc(
+								objectType,
+								persistedRecord[ entityIdKey ]
+							);
+
+						if ( serializedDoc ) {
+							fetchPayload = {
+								...fetchPayload,
+								meta: {
+									...fetchPayload.meta,
+									[ POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE ]:
+										serializedDoc,
+								},
+							};
+						}
+					}
 					updatedRecord = await __unstableFetch( {
 						path,
 						method: recordId ? 'PUT' : 'POST',
-						data: edits,
+						data: fetchPayload,
 					} );
 					dispatch.receiveEntityRecords(
 						kind,
@@ -790,7 +813,7 @@ export const saveEntityRecord =
 						updatedRecord,
 						undefined,
 						true,
-						record
+						edits
 					);
 					if ( entityConfig.syncConfig ) {
 						// Use an untracked origin so that the save

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -790,7 +790,7 @@ export const saveEntityRecord =
 						updatedRecord,
 						undefined,
 						true,
-						edits
+						record
 					);
 					if ( entityConfig.syncConfig ) {
 						// Use an untracked origin so that the save

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -14,7 +14,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { PostEditorAwareness } from './awareness/post-editor-awareness';
-import { getSyncManager } from './sync';
 import {
 	applyPostChangesToCRDTDoc,
 	defaultCollectionSyncConfig,
@@ -303,23 +302,6 @@ export const prePersistPostType = async (
 				persistedRecord?.title === 'Auto Draft' )
 		) {
 			newEdits.title = '';
-		}
-	}
-
-	// Add meta for persisted CRDT document.
-	if ( persistedRecord ) {
-		const objectType = `postType/${ name }`;
-		const objectId = persistedRecord.id;
-		const serializedDoc = await getSyncManager()?.createPersistedCRDTDoc(
-			objectType,
-			objectId
-		);
-
-		if ( serializedDoc ) {
-			newEdits.meta = {
-				...edits.meta,
-				[ POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE ]: serializedDoc,
-			};
 		}
 	}
 

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -22,11 +22,7 @@ import {
 	prePersistPostType,
 	additionalEntityConfigLoaders,
 } from '../entities';
-import { getSyncManager } from '../sync';
-import {
-	applyPostChangesToCRDTDoc,
-	POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
-} from '../utils/crdt';
+import { applyPostChangesToCRDTDoc } from '../utils/crdt';
 
 describe( 'getMethodName', () => {
 	it( 'should return the right method name for an entity with the root kind', () => {
@@ -106,31 +102,6 @@ describe( 'prePersistPostType', () => {
 		expect(
 			await prePersistPostType( record, edits, 'post', true )
 		).toEqual( {} );
-	} );
-
-	it( 'adds meta with serialized CRDT doc when createPersistedCRDTDoc returns a value', async () => {
-		const mockSerializedDoc = 'serialized-crdt-doc-data';
-		getSyncManager.mockReturnValue( {
-			createPersistedCRDTDoc: jest
-				.fn()
-				.mockReturnValue( mockSerializedDoc ),
-		} );
-
-		const record = { id: 123, status: 'publish' };
-		const edits = {};
-		const result = await prePersistPostType( record, edits, 'post', false );
-
-		expect( result.meta ).toEqual( {
-			[ POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE ]: mockSerializedDoc,
-		} );
-
-		expect( getSyncManager ).toHaveBeenCalled();
-		expect( getSyncManager().createPersistedCRDTDoc ).toHaveBeenCalledWith(
-			'postType/post',
-			123
-		);
-
-		getSyncManager.mockReset();
 	} );
 } );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes  #77610 

This PR fixes the issue where the editor gets stuck in a dirty state ("Changes you made may not be saved" warning) after successfully restoring a visual revision or saving a post that contains meta updates (like when using the Footnotes block).

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When `saveEntityRecord` prepares to send meta edits to the server, `__unstablePrePersist()` changes the `edits.meta` payload by injecting an internal [collaborative editing key](https://github.com/WordPress/gutenberg/blob/e94adac7003516fbbbf9c3e0ee686a66baa10a0b/packages/core-data/src/entities.js#L325) (`_crdt_document`). 

After the save succeeds, `saveEntityRecord` dispatches `receiveEntityRecords` to clear the saved edits from the store. Previously, it passed the *mutated* `edits` variable as the `persistedEdits` argument. 

Because the Redux reducer compares the original edits in the store (which lack `_crdt_document`) against this mutated `persistedEdits` object using `fastDeepEqual`, the [comparison fails](https://github.com/WordPress/gutenberg/blob/e94adac7003516fbbbf9c3e0ee686a66baa10a0b/packages/core-data/src/reducer.js#L233). The reducer incorrectly assumes the save was incomplete and leaves the post permanently "dirty".

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR updates `saveEntityRecord` to pass the original, un-mutated `record` to `receiveEntityRecords` as `persistedEdits`. This ensures the equality check succeeds and the editor correctly clears its dirty state.

## Testing Instructions
 Visual Revisions

1. Create a new post and publish it.
2. Make a change to the post to create a new revision, and click "Update".
3. Open the visual revisions interface and restore the previous revision.
4. Attempt to refresh the page or navigate away. You should no longer see the "Changes you made may not be saved" warning.

**Test 2: Meta-updating Blocks**
1. Open a post.
2. Add a Footnote block (which updates post meta).
3.  Save the post.
4. Attempt to refresh the page or navigate away. You should no longer see the "Changes you made may not be saved" warning.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before
- Please check the issue description (#77610 )

After

https://github.com/user-attachments/assets/a7368a54-001f-4a9e-a322-17d1da540395


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

- Yes, Used Gemini CLI to assist with debugging
