### PR TITLE
Fix: Correct nested list markers in Latest Posts and Post Content

### DIFF
--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -65,6 +65,19 @@
 	margin-bottom: 1em;
 }
 
+.wp-block-latest-posts__post-full-content {
+	// Apply list styles only to unordered lists to prevent overriding ordered list styles.
+	ul > li {
+		list-style-type: disc;
+		> ul > li {
+			list-style-type: circle;
+			> ul > li {
+				list-style-type: square;
+			}
+		}
+	}
+}
+
 .wp-block-latest-posts__featured-image {
 	a {
 		display: inline-block;

--- a/packages/block-library/src/post-content/style.scss
+++ b/packages/block-library/src/post-content/style.scss
@@ -1,3 +1,14 @@
 .wp-block-post-content {
 	display: flow-root;
+
+	// Apply list styles only to unordered lists to prevent overriding ordered list styles.
+	ul > li {
+		list-style-type: disc;
+		> ul > li {
+			list-style-type: circle;
+			> ul > li {
+				list-style-type: square;
+			}
+		}
+	}
 }


### PR DESCRIPTION
## What?
Closes #63604 

Fixes an issue where unordered lists nested inside the Latest Posts block and the Post Content block displayed the incorrect sequence of list item markers.

## Why?

Browsers natively track list nesting to sequence markers (`disc` -> `circle` -> `square`). However, because blocks like Latest Posts and Post Template use `<ul>` or `<li>` wrappers for their outer structure, any List Block placed inside them is interpreted by the browser as an *already nested* list, immediately applying `circle` to the first level.

A previous fix attempted this by explicitly applying `list-style-type` to all `<li>` elements within these block wrappers. But selecting the `<li>` also overrode the inherited styles and defaults of ordered lists (`<ol>`), which meant that user-selected list styles like `upper-roman` or `lower-alpha` didn't work.

## How?

The CSS rules for `.wp-block-latest-posts__post-full-content` and `.wp-block-post-content` have been updated to target `ul > li` rather than just `li` or `ul`. 

By strictly targeting list items that are direct children of unordered lists (`ul > li`), we explicitly reset the marker sequence ( as mentioned above ) for unordered lists and forcefully override the browser's User Agent styles. Importantly, this syntax completely ignores `<ol>` list items. Ordered lists will now correctly preserve their browser defaults (`decimal`) or user-defined inline styles.

## Testing Instructions

1. Create a new post.
2. Add a list block. Example:
```html
<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>One: disc<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>nested: circle<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>two levels: square<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>three levels: square</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item --></ul>
<!-- /wp:list -->
```
3. Add a latest posts block.
4. Enable the post content option, and select "show full post".
5. Set the number of items to 1.
6. **Verify**: The first level of the unordered list should display a solid `disc`, the second level an open `circle`, and the third a `square`.
7. **Verify**: The ordered list should preserve its custom numbering sequence (e.g., I, II, III) and not be incorrectly forced to `disc`.

## Screenshots or screencast

### Before

<img width="1191" height="505" alt="Screenshot 2026-04-23 at 5 54 07 PM" src="https://github.com/user-attachments/assets/cc6b6a50-ec3c-4b7d-9f80-05044fc315aa" />

### After

<img width="1190" height="496" alt="Screenshot 2026-04-23 at 5 50 22 PM" src="https://github.com/user-attachments/assets/daa4f58d-411b-4f91-9946-04f71e47df92" />

## Use of AI Tools

AI used to draft PR description.