### PR TITLE
Gallery Block: Add masonry style variation

### DIFF
--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -9,6 +9,10 @@
 	"description": "Display multiple images in a rich gallery.",
 	"keywords": [ "images", "photos" ],
 	"textdomain": "default",
+	"styles": [
+		{ "name": "default", "label": "Default", "isDefault": true },
+		{ "name": "masonry", "label": "Masonry" }
+	],
 	"attributes": {
 		"images": {
 			"type": "array",

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -160,6 +160,12 @@ export default function GalleryEdit( props ) {
 		aspectRatio,
 	} = attributes;
 
+	// The Masonry style variation replaces the flex layout with CSS columns,
+	// where the shared `imageCrop` and `aspectRatio` options cannot be honoured
+	// without breaking the column flow. Hide those controls when the variation
+	// is active and show a notice pointing users at the Default style.
+	const isMasonry = !! attributes.className?.includes( 'is-style-masonry' );
+
 	const {
 		__unstableMarkNextChangeAsNotPersistent,
 		replaceInnerBlocks,
@@ -744,20 +750,35 @@ export default function GalleryEdit( props ) {
 								/>
 							</ToolsPanelItem>
 						) }
-						<ToolsPanelItem
-							isShownByDefault
-							label={ __( 'Crop images to fit' ) }
-							hasValue={ () => ! imageCrop }
-							onDeselect={ () =>
-								setAttributes( { imageCrop: true } )
-							}
-						>
-							<ToggleControl
+						{ isMasonry && (
+							<ToolsPanelItem
+								isShownByDefault
+								label={ __( 'Layout notice' ) }
+								hasValue={ () => false }
+							>
+								<p className="wp-block-gallery__masonry-notice">
+									{ __(
+										'The Masonry style manages image cropping and aspect ratio automatically. Switch to the Default style to change these options.'
+									) }
+								</p>
+							</ToolsPanelItem>
+						) }
+						{ ! isMasonry && (
+							<ToolsPanelItem
+								isShownByDefault
 								label={ __( 'Crop images to fit' ) }
-								checked={ !! imageCrop }
-								onChange={ toggleImageCrop }
-							/>
-						</ToolsPanelItem>
+								hasValue={ () => ! imageCrop }
+								onDeselect={ () =>
+									setAttributes( { imageCrop: true } )
+								}
+							>
+								<ToggleControl
+									label={ __( 'Crop images to fit' ) }
+									checked={ !! imageCrop }
+									onChange={ toggleImageCrop }
+								/>
+							</ToolsPanelItem>
+						) }
 						<ToolsPanelItem
 							isShownByDefault
 							label={ __( 'Randomize order' ) }
@@ -786,7 +807,7 @@ export default function GalleryEdit( props ) {
 								/>
 							</ToolsPanelItem>
 						) }
-						{ aspectRatioOptions.length > 1 && (
+						{ ! isMasonry && aspectRatioOptions.length > 1 && (
 							<ToolsPanelItem
 								hasValue={ () =>
 									!! aspectRatio && aspectRatio !== 'auto'

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -73,6 +73,15 @@
 	}
 }
 
+// Inline notice shown in the Settings panel when the Masonry style variation
+// is active, explaining why the crop and aspect-ratio controls are hidden.
+.wp-block-gallery__masonry-notice {
+	margin: 0;
+	color: $gray-700;
+	font-size: 12px;
+	line-height: 1.4;
+}
+
 /**
  * Deprecated css past this point. This can be removed once all galleries are migrated
  * to V2.

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -193,4 +193,57 @@ figure.wp-block-gallery.has-nested-images {
 	&.aligncenter {
 		justify-content: center;
 	}
+
+	// Masonry block style variation (#28247).
+	// Uses CSS columns so images flow top-to-bottom and keep their natural
+	// aspect ratios. Images keep the same figure markup used by the default
+	// flex layout so gallery features (caption, lightbox, linkTo, random
+	// order, resolution) continue to work unchanged.
+	&.is-style-masonry {
+		display: block;
+		column-gap: var(--wp--style--unstable-gallery-gap, #{$grid-unit-20});
+		column-count: 2;
+
+		// Map the columns attribute onto CSS column-count.
+		&.columns-1 {
+			column-count: 1;
+		}
+
+		@include break-small {
+			column-count: 3;
+
+			@for $i from 2 through 8 {
+				&.columns-#{ $i } {
+					column-count: $i;
+				}
+			}
+
+			&.columns-default {
+				column-count: 3;
+			}
+		}
+
+		// Each image spans its column; masonry relies on natural heights.
+		// `break-inside: avoid` keeps the figure together when columns
+		// reflow. The `aspect-ratio` override neutralises the gallery's
+		// shared aspect-ratio option, which applies an inline style to each
+		// figure and would otherwise force every tile to the same shape.
+		figure.wp-block-image:not(#individual-image) {
+			width: 100%;
+			margin: 0 0 var(--wp--style--unstable-gallery-gap, #{$grid-unit-20});
+			break-inside: avoid;
+			display: block;
+			aspect-ratio: auto !important;
+
+			// The `is-cropped` rules above force a fixed height and
+			// `object-fit: cover` on the image. That collapses masonry into
+			// a grid, so neutralise them here — `!important` is required
+			// because `is-cropped` sets the same properties.
+			a,
+			img {
+				height: auto !important;
+				object-fit: initial !important;
+			}
+		}
+	}
 }


### PR DESCRIPTION
## What?

Adds a `Masonry` block style variation to the Gallery block. When active, the gallery lays out inner Image blocks with CSS columns and `break-inside: avoid`, so images flow top-to-bottom preserving their natural aspect ratios. The existing flex layout remains the default, and the new variation is opt-in via the block's Styles panel.

<img width="1116" height="721" alt="masonry" src="https://github.com/user-attachments/assets/695f2e7b-5f87-4182-9fd7-5a91bb9d9b4e" />

---

https://github.com/user-attachments/assets/2ad2dbdd-b282-4758-9329-23d60c91d005

## Why?

Fixes #28247.

The Gallery block currently supports a single flex layout with fixed rows and `object-fit: cover` cropping. With mixed aspect ratios this either crops aggressively (distracting authored composition) or, when cropping is off, leaves large vertical gaps between rows. @melchoyce opened this issue back in January 2021 asking for a proper masonry option; five years later it is still the most-requested Gallery layout change that did not make it into core (see also #42240 for the related CSS-grid effort).

Beyond core, this is the second phase of a wider effort to replace the wordpress.org Plugin Directory's legacy React screenshot gallery with native blocks (see meta#8083, meta#2273, WordPress/wordpress.org#524). Plugin authors upload screenshots in very different formats — tall, wide, square — and the current flex Gallery cannot present them well without either cropping away intent or leaving awkward empty rows. Phase 1 (#77477, captions in the lightbox) is already on review; this PR is the companion change that makes the underlying layout suitable for that content.

## How?

Four files, +101 / -14. All changes scoped to the Gallery block. No PHP changes, no changes to the static save output, no new block attributes.

### `packages/block-library/src/gallery/block.json`

Registers a `styles` array with two entries: `default` (marked `isDefault: true` so existing posts are unaffected) and `masonry`. That is the whole opt-in surface — the variation adds no new attributes and relies on the standard `is-style-masonry` class that block style variations generate.

### `packages/block-library/src/gallery/style.scss`

Adds a single nested rule block under the existing `.wp-block-gallery.has-nested-images`:

- `&.is-style-masonry` switches `display: block`, sets `column-gap: var(--wp--style--unstable-gallery-gap)` (the same variable the flex layout already uses, so theme gap settings carry over unchanged), and maps `columns-1` through `columns-8` onto `column-count`, including the mobile default of `2` and the desktop default of `3` behind the existing `break-small` mixin.
- Inner `figure.wp-block-image` gets `width: 100%`, `break-inside: avoid`, `display: block`, and `aspect-ratio: auto !important`. The `!important` is needed to neutralise the inline `aspect-ratio` that the shared Aspect ratio control sets on each figure — see the UI note in `edit.js` below.
- The nested `a, img` rule overrides the `is-cropped` rules' `height: 100%` and `object-fit: cover` back to `height: auto` and `object-fit: initial`, again because `is-cropped` is a sibling class that can co-exist with `is-style-masonry` on the wrapper.

### `packages/block-library/src/gallery/edit.js`

One line detects the variation from the attribute (not the className prop, which can be filtered by other APIs before reaching this component):

```js
const isMasonry = !! attributes.className?.includes( 'is-style-masonry' );
```

`isMasonry` is used to hide two `ToolsPanelItem`s (`Crop images to fit` and `Aspect ratio`) whose flex-based behaviour the CSS columns layout cannot honour. In their place a small inline notice renders:

> The Masonry style manages image cropping and aspect ratio automatically. Switch to the Default style to change these options.

Everything else in the inspector (Columns, Resolution, Randomize order, Open images in new tab, Navigation button type, LinkTo toolbar, border / spacing / colour supports) is untouched.

### `packages/block-library/src/gallery/editor.scss`

Adds the `.wp-block-gallery__masonry-notice` rule: neutral grey help text styled to match the surrounding ToolsPanel help copy.

## Backward compatibility

- No block attributes added, removed, or renamed.
- Existing galleries render byte-identical HTML — the new `styles` array marks `default` as `isDefault: true`, so posts without an explicit `className` keep the current flex layout.
- All CSS additions are scoped under `&.is-style-masonry`, so nothing leaks into default galleries.
- Inside the masonry variation, all other Gallery options (crop toggled on, aspect ratio forced to 1:1 / 16:9, random order, different image resolutions, lightbox, linkTo media/attachment, alignments wide/full) continue to work: aspect ratios turn the gallery into a squared / widescreen grid, crop decides whether those tiles get `object-fit: cover` or stay natural, etc. The notice in the sidebar tells authors which pair is managed by the layout rather than removing them from their mental model.
- No changes to `save.js` / deprecations required: the `className` attribute already round-trips through the block's existing `supports.anchor` / default className handling.
- `*.native.js` mirrors were not touched — the variation is additive and the native UI simply does not render a Styles tab, so behaviour on React Native remains exactly as it was.

## Testing Instructions

1. Start Gutenberg locally (`npm run dev` + `wp-env start`) or use the built plugin on a WordPress install.
2. Create a new page and add a Gallery block with 6–10 images of mixed aspect ratios (tall portraits, wide landscapes, a square or two).
3. Click the gallery once to select the block. If the right-hand block sidebar is not visible, toggle it via the top-bar **Settings** button (the icon showing two vertical panels, top right of the editor, or `Ctrl+Shift+,` / `Cmd+Shift+,`).
4. With the Gallery selected, look just below the block's name (`Gallery — Display multiple images in a rich gallery.`) in the sidebar. There are three tab icons in a row:
   - **List View** (horizontal lines icon) — inner block tree.
   - **Settings** (gear / cog icon) — Columns, Resolution, Crop, Aspect ratio, etc.
   - **Styles** (two-tone circle, half-filled) — **this is the new tab to use.**
5. Open the **Styles** tab. Two preview cards are shown:
   - **Default** — current flex layout, selected by default.
   - **Masonry** — new CSS-columns layout added by this PR.
   Click the **Masonry** card. The preview card becomes the active style, `is-style-masonry` is added to the block's wrapper in the canvas, and the layout updates immediately.
6. Open the **Settings** tab (gear icon). Confirm that `Crop images to fit` and `Aspect ratio` are replaced by a short inline notice reading: _"The Masonry style manages image cropping and aspect ratio automatically. Switch to the Default style to change these options."_

**Expected default state after step 5:** the gallery switches to a three-column masonry layout on desktop, two columns on mobile. Images keep their natural aspect ratios, there are no gaps between rows.

Variations to cover:

- **Columns slider 1 → 8** — the column count maps one-to-one onto CSS `column-count`, including the mobile breakpoint. At 1 column the gallery reads as a single-column stack. The slider's max is clamped to the number of images in the gallery (standard Gallery behaviour), so seven or eight columns require seven or eight images.
- **Resolution `Large` → `Thumbnail`** — inner images reload at the smaller size and masonry adjusts to the new natural heights without any layout shift in the wrapper.
- **LinkTo: Media file / Attachment page** — each figure gains an anchor tag; the masonry layout is preserved and clicking an image opens the expected destination.
- **LinkTo: Enlarge on click (lightbox)** — the lightbox opens the full-size image and honours Phase 1 (#77477) captions if that PR has landed.
- **Randomize order** — every front-end load reshuffles the inner images; the column flow adapts.
- **Alignment `Wide` / `Full`** — the gallery widens, the masonry keeps its column structure, no overflow.
- **Captions** — `<figcaption>` renders over the bottom of each figure using the existing gallery caption styling; `break-inside: avoid` keeps the caption tied to its image.
- **Switch back to Default** — the inline notice disappears, `Crop images to fit` and `Aspect ratio` return, and the gallery reverts to the flex layout with no leftover masonry classes on the wrapper.
- **Existing galleries** — load a post authored before this PR with a regular Gallery block. No visual or HTML diff should be visible.
- **Mobile** — resize the viewport below the `break-small` breakpoint; the gallery falls back to two columns.
- **RTL** — the column flow should mirror correctly in right-to-left locales (CSS columns follow `direction`).

## Related work

This PR is phase 2 of the effort to replace the wordpress.org Plugin Directory's React screenshot gallery with core blocks:

- Phase 1: #77477 — captions in the lightbox.
- Phase 3 (Meta): meta#8083, meta#2273, WordPress/wordpress.org#524.

Related Gutenberg issues that this PR does not close but is adjacent to:

- #42240 — Gallery: CSS Grid masonry tracking issue. If the CSS Working Group finalises `grid-template-rows: masonry` and it ships beyond Firefox, `&.is-style-masonry` can be upgraded to Grid masonry without touching any authored content.
- #29244 — 2021 attempt by @aaronrobertshaw to expose a filter for alternative inner layouts. Closed; the style-variation approach in this PR covers the same user-facing need without a new extension point.

cc @melchoyce (original issue author), @jameskoster, @mtias, @ryelle (WordPress/wordpress.org#524), @dd32 (Meta committer who confirmed the overall direction).

Fixes #28247.
