### PR TITLE
Admin UI: change default heading level from h2 to h1

### DIFF
--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   Change default `headingLevel` for the `Page` component's header from `2` to `1`, meaning from `h2` to `h1`. If you need to keep previous behaviour, use `<Page title="Example" headingLevel={ 2 }>`
+-   Change default `headingLevel` for the `Page` component's header from `2` to `1`, meaning from `h2` to `h1`. If you need to keep previous behaviour, use `<Page title="Example" headingLevel={ 2 }>` [#77617](https://github.com/WordPress/gutenberg/pull/77617)
 
 ### New Features
 

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   `Page`: The default `headingLevel` for the page header has changed from `2` to `1`.
+-   Change default `headingLevel` for the `Page` component's header from `2` to `1`, meaning from `h2` to `h1`. If you need to keep previous behaviour, use `<Page title="Example" headingLevel={ 2 }>`
 
 ### New Features
 

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   `Page`: The default `headingLevel` for the page header has changed from `2` to `1`.
+
 ### New Features
 
 -   `Page`: Add `visual` prop to render a decorative-only icon or image alongside the header title or breadcrumbs. [#76469](https://github.com/WordPress/gutenberg/pull/76469)

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -10,7 +10,7 @@ import { SidebarToggleSlot } from './sidebar-toggle-slot';
 import styles from './style.module.css';
 
 export default function Header( {
-	headingLevel = 2,
+	headingLevel = 1,
 	breadcrumbs,
 	badges,
 	visual,

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -181,6 +181,7 @@ export default function DataviewsPatterns() {
 			<Page
 				className="edit-site-page-patterns-dataviews"
 				title={ title }
+				headingLevel={ 2 }
 				subTitle={ description }
 				actions={
 					<PatternsActions

--- a/packages/edit-site/src/components/page-templates/index-legacy.js
+++ b/packages/edit-site/src/components/page-templates/index-legacy.js
@@ -136,6 +136,7 @@ export default function PageTemplates() {
 		<Page
 			className="edit-site-page-templates"
 			title={ __( 'Templates' ) }
+			headingLevel={ 2 }
 			actions={ <AddNewTemplate /> }
 		>
 			<DataViews

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -325,6 +325,7 @@ export default function PageTemplates() {
 		<Page
 			className="edit-site-page-templates"
 			title={ __( 'Templates' ) }
+			headingLevel={ 2 }
 			actions={ <AddNewTemplate /> }
 		>
 			<DataViews

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -279,6 +279,7 @@ export default function PostList( { postType } ) {
 	return (
 		<Page
 			title={ labels?.name }
+			headingLevel={ 2 }
 			actions={
 				<>
 					{ labels?.add_new_item && canCreateRecord && (

--- a/packages/edit-site/src/components/sidebar-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-global-styles/index.js
@@ -103,6 +103,7 @@ export default function SidebarGlobalStyles() {
 			}
 			className="edit-site-styles"
 			title={ __( 'Styles' ) }
+			headingLevel={ 2 }
 		>
 			<GlobalStylesUIWrapper
 				path={ section }

--- a/packages/edit-site/src/components/sidebar-identity/index.js
+++ b/packages/edit-site/src/components/sidebar-identity/index.js
@@ -74,7 +74,7 @@ export default function SidebarIdentity() {
 	};
 
 	return (
-		<Page title={ __( 'Identity' ) } hasPadding>
+		<Page title={ __( 'Identity' ) } headingLevel={ 2 } hasPadding>
 			<DataForm
 				data={ data }
 				fields={ fields }

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -50,7 +50,6 @@ function ConnectorsPage() {
 	return (
 		<Page
 			title={ __( 'Connectors' ) }
-			headingLevel={ 1 }
 			subTitle={ __(
 				'All of your API keys and credentials are stored here and shared across plugins. Configure once and use everywhere.'
 			) }

--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 
 function Dashboard() {
 	return (
-		<Page title={ __( 'Dashboard' ) } headingLevel={ 1 }>
+		<Page title={ __( 'Dashboard' ) }>
 			<div className="dashboard-widgets" />
 		</Page>
 	);

--- a/routes/font-list/stage.tsx
+++ b/routes/font-list/stage.tsx
@@ -73,11 +73,7 @@ function FontLibraryPage() {
 	}
 
 	return (
-		<Page
-			headingLevel={ 1 }
-			title={ __( 'Fonts' ) }
-			className="font-library-page"
-		>
+		<Page title={ __( 'Fonts' ) } className="font-library-page">
 			<Tabs
 				selectedTabId={ activeTab }
 				onSelect={ ( tabId: string ) => setActiveTab( tabId ) }

--- a/routes/navigation-edit/stage.tsx
+++ b/routes/navigation-edit/stage.tsx
@@ -44,6 +44,7 @@ function NavigationEditStage() {
 	return (
 		<Page
 			ariaLabel={ decodeEntities( menuTitle ) }
+			headingLevel={ 2 }
 			breadcrumbs={
 				<Breadcrumbs
 					items={ [

--- a/routes/navigation-list/stage.tsx
+++ b/routes/navigation-list/stage.tsx
@@ -131,6 +131,7 @@ function NavigationList() {
 		<>
 			<Page
 				title={ __( 'Navigation' ) }
+				headingLevel={ 2 }
 				className="navigation-page"
 				hasPadding={ false }
 				actions={

--- a/routes/pattern-list/stage.tsx
+++ b/routes/pattern-list/stage.tsx
@@ -258,6 +258,7 @@ function PatternList() {
 	return (
 		<Page
 			title={ __( 'Patterns' ) }
+			headingLevel={ 2 }
 			subTitle={ __(
 				'Reusable design elements for your site. Create once, use everywhere.'
 			) }

--- a/routes/post-list/stage.tsx
+++ b/routes/post-list/stage.tsx
@@ -320,6 +320,7 @@ function PostList() {
 	return (
 		<Page
 			title={ postTypeObject.labels?.name }
+			headingLevel={ 2 }
 			subTitle={ postTypeObject.labels?.description }
 			className={ `${ postTypeObject.name.toLowerCase() }-page` }
 			actions={

--- a/routes/styles/stage.tsx
+++ b/routes/styles/stage.tsx
@@ -53,6 +53,7 @@ function Stage() {
 
 	return (
 		<Page
+			headingLevel={ 2 }
 			actions={
 				! isMobileViewport ? (
 					<HStack>

--- a/routes/template-part-list/stage.tsx
+++ b/routes/template-part-list/stage.tsx
@@ -249,6 +249,7 @@ function TemplatePartList() {
 	return (
 		<Page
 			title={ postTypeObject.labels?.name }
+			headingLevel={ 2 }
 			subTitle={ postTypeObject.labels?.description }
 			className="template-part-page"
 			actions={

--- a/test/e2e/specs/admin/guidelines.spec.js
+++ b/test/e2e/specs/admin/guidelines.spec.js
@@ -121,11 +121,10 @@ test.describe( 'Guidelines', () => {
 			.getByRole( 'link', { name: 'Guidelines' } )
 			.click();
 
-		// The page layout renders the "Guidelines" title as an h2 (the
-		// Page component defaults headingLevel to 2) and the category
-		// accordions load once the initial fetch resolves.
+		// The page layout renders the "Guidelines" title as an h1 and
+		// the category accordions load once the initial fetch resolves.
 		await expect(
-			page.getByRole( 'heading', { name: 'Guidelines', level: 2 } )
+			page.getByRole( 'heading', { name: 'Guidelines', level: 1 } )
 		).toBeVisible();
 		await expect(
 			page.getByRole( 'button', { name: 'Expand Copy guidelines' } )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Default to heading level h1 for the Page component for better accessibility, instead of the previous h2.
- Update current pages to h2 where needed.
- Update pages with the previous H1 exception to use the default.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Use of h1 is important for accessibility on pages where the title heading is clearly the main heading of the page. That's not the case in all site-editor pages, where the navigation sidebar includes "page heading" outside the actual `Page` component.

Currently, we're manually switching to h1 on "top level pages" like on [Fonts](https://github.com/WordPress/gutenberg/pull/77482) and [Connectors](https://github.com/WordPress/gutenberg/pull/76456), which is when `headingLevel` was initially added.

Since many of the default use cases by plugin developers and also within Gutenberg are "classic sidebar + Page", it's reasonable to default to h1 so that consumers (especially plugin developers) don't need to worry about this.

In future, I'd expect WP Build to just handle the semantics depending on what we're building, so that nobody needs to think about the right accessible heading level.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Default to h1 instead of h2 in the page header.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

See affected screens:

### Standalone admin pages
| Route | URL |
|---|---|
| `connectors-home` | `/wp-admin/options-general.php?page=options-connectors-wp-admin` |
| `guidelines` | `/wp-admin/options-general.php?page=guidelines-wp-admin` |
| `taxonomies` | `/wp-admin/options-general.php?page=taxonomies-wp-admin` |
| `font-list` | `/wp-admin/themes.php?page=font-library-wp-admin&p=%2Ffont-list` |

### Site Editor
| Route | URL |
|---|---|
| `navigation-list` | `/wp-admin/admin.php?page=site-editor-v2&p=%2Fnavigation%2Flist` |
| `navigation-edit` | `/wp-admin/admin.php?page=site-editor-v2&p=%2Fnavigation%2Fedit%2F{id}` |
| `pattern-list` | `/wp-admin/admin.php?page=site-editor-v2&p=%2Fpatterns%2Flist%2F{type}` |
| `post-list` | `/wp-admin/admin.php?page=site-editor-v2&p=%2Ftypes%2F{type}%2Flist%2F{slug}` |
| `styles` | `/wp-admin/admin.php?page=site-editor-v2&p=%2Fstyles` |
| `template-part-list` | `/wp-admin/admin.php?page=site-editor-v2&p=%2Ftemplate-parts%2Flist%2F{area}` |


Make sure to test both versions of the site editor (see Gutenberg→Experiments):
<img width="688" height="71" alt="image" src="https://github.com/user-attachments/assets/fd45a345-9ca6-4583-b365-d36c13627b03" />


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Examples of pages that should remain h1:
<img width="1316" height="899" alt="image" src="https://github.com/user-attachments/assets/34e8df59-ece8-4f32-a831-7328d7a76ae8" />
<img width="1660" height="1088" alt="Screenshot 2026-04-23 at 16 28 24" src="https://github.com/user-attachments/assets/4ed4505b-f344-4b15-9467-b7befc957fde" />
<img width="1658" height="1089" alt="Screenshot 2026-04-23 at 16 28 17" src="https://github.com/user-attachments/assets/2e7b3600-d0c9-4329-b5e0-2719382b189e" />

Examples of pages that should remain h2:

<img width="1656" height="1090" alt="Screenshot 2026-04-23 at 16 13 40" src="https://github.com/user-attachments/assets/a344b755-4a83-4b56-85a7-522a0b0773fe" />
<img width="1657" height="1092" alt="Screenshot 2026-04-23 at 16 13 32" src="https://github.com/user-attachments/assets/256a66a8-4f85-4001-a6f7-da59b98a2847" />



## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Created by using Cursor.