### PR TITLE
Migrate __experimentalHeading to @wordpress/ui Text in Shadow Panel

### DIFF
--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import {
 	__experimentalVStack as VStack,
-	__experimentalHeading as Heading,
 	__experimentalHStack as HStack,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
 	Button,
@@ -15,6 +14,7 @@ import {
 } from '@wordpress/components';
 import { useMemo, useRef } from '@wordpress/element';
 import { shadow as shadowIcon, Icon, check, reset } from '@wordpress/icons';
+import { Text } from '@wordpress/ui';
 
 /**
  * External dependencies
@@ -35,7 +35,9 @@ export function ShadowPopoverContainer( { shadow, onShadowChange, settings } ) {
 	return (
 		<div className="block-editor-global-styles__shadow-popover-container">
 			<VStack spacing={ 4 }>
-				<Heading level={ 5 }>{ __( 'Drop shadow' ) }</Heading>
+				<Text variant="heading-sm" render={ <h5 /> }>
+					{ __( 'Drop shadow' ) }
+				</Text>
 				<ShadowPresets
 					presets={ shadows }
 					activeShadow={ shadow }

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -121,7 +121,7 @@
 	},
 	"packages/block-editor/src/components/global-styles/shadow-panel-components.js": {
 		"@wordpress/use-recommended-components": {
-			"count": 3
+			"count": 2
 		}
 	},
 	"packages/block-editor/src/components/html-element-control/index.js": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: #77265

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

> Now that the required tooling is in place, we can start applying consistent text styling across the site and block editor. This can be done by replacing instances of __experimentalText and __experimentalHeading, as well as any ad hoc styled text, with the [Text](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-text--docs) component from the UI package.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Replaced the __experimentalHeading with @wordpress/ui Text in Shadow Panel

### Testing Instructions

1. Open Site Editor (Appearance → Editor).
2. Open Styles.
3. Go to Blocks.
4. Select Button block.
5. In the styles sidebar, find Drop shadow and click it to open the shadow popover.
6. Verify the popover heading shows "Drop shadow" (this is the migrated heading).

|Before|After|
|-|-|
|<img width="1886" height="491" alt="image" src="https://github.com/user-attachments/assets/e5e6be43-a9df-4060-96eb-c16e6a5ec594" />|<img width="1882" height="484" alt="Screenshot 2026-05-09 at 6 17 14 PM" src="https://github.com/user-attachments/assets/978435c3-d3c3-4444-8da7-c7089d95002a" />|