### PR TITLE
ButtonGroup: Inline z-index

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Remove the shared Button Group z-index entry from the `$z-layers` map ([#77621](https://github.com/WordPress/gutenberg/pull/77621)).
+
 ## 6.20.0 (2026-04-15)
 
 ## 6.19.0 (2026-04-01)

--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-### Internal
+### Breaking Changes
 
--   Remove the shared Button Group z-index entry from the `$z-layers` map ([#77621](https://github.com/WordPress/gutenberg/pull/77621)).
+-   Remove `.components-button {:focus or .is-primary}` from the `z-index()` helper ([#77621](https://github.com/WordPress/gutenberg/pull/77621)).
 
 ## 6.20.0 (2026-04-15)
 

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -50,9 +50,6 @@ $z-layers: (
 	".has-child .wp-block-navigation__submenu-container": 28,
 	".has-child:hover .wp-block-navigation__submenu-container": 29,
 
-	// Active pill button
-	".components-button {:focus or .is-primary}": 1,
-
 	// The draggable element should show up above the entire UI
 	".components-draggable__clone": 1000000000,
 

--- a/packages/components/src/button-group/style.scss
+++ b/packages/components/src/button-group/style.scss
@@ -1,6 +1,5 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
-@use "@wordpress/base-styles/z-index" as *;
 
 .components-button-group {
 	display: inline-block;
@@ -28,7 +27,7 @@
 		&:focus,
 		&.is-primary {
 			position: relative;
-			z-index: z-index(".components-button {:focus or .is-primary}");
+			z-index: 1;
 		}
 
 		// The active button should look pressed.


### PR DESCRIPTION
## What?

Removes `.components-button {:focus or .is-primary}` from the shared `$z-layers` map in `packages/base-styles/_z-index.scss` and sets `z-index: 1` directly on the focused or active button in `packages/components/src/button-group/style.scss`.

## Why?

The Button Group button only needs a local stacking value of `1` so its focus ring and active border can render above adjacent buttons. Keeping it in the global z-index map added indirection without coordinating with any broader stacking context, so this inlines the value and removes the unused registry entry.

## Testing Instructions

1. Run Storybook for `@wordpress/components` (or open a screen that uses Button Group).
2. Open the Button Group story at `Components/Deprecated/ButtonGroup`, or any screen that uses grouped buttons.
3. Confirm the focused button still renders its focus ring cleanly above adjacent buttons, and the active button still appears above neighboring borders.
4. Optionally inspect the focused or active button in dev tools and confirm `z-index: 1` is applied.

### Testing Instructions for Keyboard

1. Tab to a Button Group.
2. Move focus onto a grouped button.
3. Confirm the focus ring remains visible and is not cropped by adjacent buttons.

## Use of AI Tools

Used Cursor to review the diff and draft the PR description. I reviewed the resulting code and text.