### PR TITLE
Show dropdown icons for submenu in overlay menu on mobile devices

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -615,21 +615,8 @@ button.wp-block-navigation-item__content {
 					justify-content: flex-start;
 				}
 
-				.wp-block-navigation__submenu-icon {
-					display: none;
-				}
-
-				// Always expand/unfold submenus inside the modal.
+				// Keep overlay submenus stacked vertically, but leave them collapsed until toggled open.
 				.has-child .wp-block-navigation__submenu-container {
-					// Unset CSS that hides dropdown menus.
-					opacity: 1;
-					visibility: visible;
-					height: auto;
-					width: auto;
-					overflow: initial;
-					min-width: 200px;
-
-					// Position and style.
 					position: static;
 					border: none;
 					padding-left: 2rem;
@@ -660,6 +647,10 @@ button.wp-block-navigation-item__content {
 					flex-direction: column;
 					// Inherit alignment settings from container.
 					align-items: var(--navigation-layout-justification-setting, initial);
+				}
+				.wp-block-navigation__submenu-icon {
+					align-self: flex-start;
+					transform: scale(2);
 				}
 			}
 


### PR DESCRIPTION
## What?
Closes #73089

This PR updates the Navigation block overlay menu to keep submenus collapsed by default on small screens while showing submenu toggle icons so users can expand and collapse nested items as needed.

## Why?
Currently, overlay menus expand all submenu items by default and hide submenu icons, which makes large mobile menus difficult to navigate.

## How?
Updates the overlay menu styles in `packages/block-library/src/navigation/style.scss` to:

- show submenu toggle icons in the overlay menu
- stop forcing submenu containers to stay expanded by default
- preserve the existing vertical mobile submenu layout

The existing submenu toggle behavior in view.js is reused without additional changes.

## Testing Instructions

1. Add a Navigation block with nested submenu items.
2. Enable the responsive overlay menu.
3. Open the frontend on a mobile-sized viewport.
4. Open the overlay menu.
5. Verify submenu items are collapsed by default.
6. Verify submenu toggle icons are visible.
7. Expand and collapse submenu items using the toggle buttons.
8. Verify nested items still display in a vertical stacked layout.

## Screenshots or screencast <!-- if applicable -->
<img width="229" height="331" alt="image" src="https://github.com/user-attachments/assets/dc0a4704-29ed-447f-8bd0-9c5478b489eb" />