### PR TITLE
Feature/embed youtube seek

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -312,7 +312,7 @@ Add a block that displays content pulled from other sites, like Twitter or YouTu
 -	**Name:** core/embed
 -	**Category:** embed
 -	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin)
--	**Attributes:** allowResponsive, caption, previewable, providerNameSlug, responsive, type, url
+-	**Attributes:** allowResponsive, caption, enableYouTubeSeek, previewable, providerNameSlug, responsive, type, url
 
 ## File
 

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -47,6 +47,7 @@
 	"wpScript": true,
 	"wpScriptModuleExports": {
 		"./accordion/view": "./build-module/accordion/view.mjs",
+		"./embed/view": "./build-module/embed/view.mjs",
 		"./file/view": "./build-module/file/view.mjs",
 		"./form/view": "./build-module/form/view.mjs",
 		"./image/view": "./build-module/image/view.mjs",

--- a/packages/block-library/src/embed/block.json
+++ b/packages/block-library/src/embed/block.json
@@ -38,6 +38,10 @@
 			"type": "boolean",
 			"default": true,
 			"role": "content"
+		},
+		"enableYouTubeSeek": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {
@@ -51,5 +55,6 @@
 		}
 	},
 	"editorStyle": "wp-block-embed-editor",
-	"style": "wp-block-embed"
+	"style": "wp-block-embed",
+	"viewScriptModule": "@wordpress/block-library/embed/view"
 }

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -1,19 +1,6 @@
 /**
  * Internal dependencies
  */
-import {
-	createUpgradedEmbedBlock,
-	getClassNames,
-	removeAspectRatioClasses,
-	fallback,
-	getEmbedInfoByProvider,
-	getMergedAttributesWithPreview,
-} from './util';
-import EmbedControls from './embed-controls';
-import { embedContentIcon } from './icons';
-import EmbedLoading from './embed-loading';
-import EmbedPlaceholder from './embed-placeholder';
-import EmbedPreview from './embed-preview';
 
 /**
  * External dependencies
@@ -30,6 +17,19 @@ import { useBlockProps } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { View } from '@wordpress/primitives';
 import { getAuthority } from '@wordpress/url';
+import EmbedPreview from './embed-preview';
+import EmbedPlaceholder from './embed-placeholder';
+import EmbedLoading from './embed-loading';
+import { embedContentIcon } from './icons';
+import EmbedControls from './embed-controls';
+import {
+	createUpgradedEmbedBlock,
+	getClassNames,
+	removeAspectRatioClasses,
+	fallback,
+	getEmbedInfoByProvider,
+	getMergedAttributesWithPreview,
+} from './util';
 import { Caption } from '../utils/caption';
 
 const EmbedEdit = ( props ) => {
@@ -39,6 +39,7 @@ const EmbedEdit = ( props ) => {
 			previewable,
 			responsive,
 			url: attributesUrl,
+			enableYouTubeSeek,
 		},
 		attributes,
 		isSelected,
@@ -117,6 +118,10 @@ const EmbedEdit = ( props ) => {
 			title,
 			responsive
 		);
+
+	function toggleYouTubeSeek( value ) {
+		setAttributes( { enableYouTubeSeek: value } );
+	}
 
 	function toggleResponsive( newAllowResponsive ) {
 		const { className } = attributes;
@@ -265,6 +270,9 @@ const EmbedEdit = ( props ) => {
 				allowResponsive={ allowResponsive }
 				toggleResponsive={ toggleResponsive }
 				switchBackToURLInput={ () => setIsEditingURL( true ) }
+				providerNameSlug={ providerNameSlug }
+				enableYouTubeSeek={ enableYouTubeSeek }
+				toggleYouTubeSeek={ toggleYouTubeSeek }
 			/>
 			<figure
 				{ ...blockProps }

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -34,6 +34,9 @@ const EmbedControls = ( {
 	allowResponsive,
 	toggleResponsive,
 	switchBackToURLInput,
+	providerNameSlug,
+	enableYouTubeSeek,
+	toggleYouTubeSeek,
 } ) => {
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
@@ -73,6 +76,33 @@ const EmbedControls = ( {
 								checked={ allowResponsive }
 								help={ getResponsiveHelp }
 								onChange={ toggleResponsive }
+							/>
+						</ToolsPanelItem>
+					</ToolsPanel>
+				</InspectorControls>
+			) }
+			{ providerNameSlug === 'youtube' && (
+				<InspectorControls>
+					<ToolsPanel
+						label={ __( 'Player settings' ) }
+						resetAll={ () => {
+							toggleYouTubeSeek( false );
+						} }
+						dropdownMenuProps={ dropdownMenuProps }
+					>
+						<ToolsPanelItem
+							label={ __( 'Enable timestamp seeking' ) }
+							isShownByDefault
+							hasValue={ () => enableYouTubeSeek }
+							onDeselect={ () => toggleYouTubeSeek( false ) }
+						>
+							<ToggleControl
+								label={ __( 'Enable timestamp seeking' ) }
+								checked={ enableYouTubeSeek }
+								help={ __(
+									'Allows links with data-yt-seek="SECONDS" to jump to a timestamp in this video.'
+								) }
+								onChange={ toggleYouTubeSeek }
 							/>
 						</ToolsPanelItem>
 					</ToolsPanel>

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -6,6 +6,7 @@ import {
 	ToolbarButton,
 	ToggleControl,
 	ToolbarGroup,
+	PanelBody,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
@@ -83,29 +84,16 @@ const EmbedControls = ( {
 			) }
 			{ providerNameSlug === 'youtube' && (
 				<InspectorControls>
-					<ToolsPanel
-						label={ __( 'Player settings' ) }
-						resetAll={ () => {
-							toggleYouTubeSeek( false );
-						} }
-						dropdownMenuProps={ dropdownMenuProps }
-					>
-						<ToolsPanelItem
+					<PanelBody title={ __( 'Player settings' ) }>
+						<ToggleControl
 							label={ __( 'Enable timestamp seeking' ) }
-							isShownByDefault
-							hasValue={ () => enableYouTubeSeek }
-							onDeselect={ () => toggleYouTubeSeek( false ) }
-						>
-							<ToggleControl
-								label={ __( 'Enable timestamp seeking' ) }
-								checked={ enableYouTubeSeek }
-								help={ __(
-									'Allows links with data-yt-seek="SECONDS" to jump to a timestamp in this video.'
-								) }
-								onChange={ toggleYouTubeSeek }
-							/>
-						</ToolsPanelItem>
-					</ToolsPanel>
+							checked={ !! enableYouTubeSeek }
+							help={ __(
+								'Allows links with data-yt-seek="SECONDS" to jump to a timestamp in this video.'
+							) }
+							onChange={ toggleYouTubeSeek }
+						/>
+					</PanelBody>
 				</InspectorControls>
 			) }
 		</>

--- a/packages/block-library/src/embed/save.js
+++ b/packages/block-library/src/embed/save.js
@@ -13,7 +13,8 @@ import {
 } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { url, caption, type, providerNameSlug } = attributes;
+	const { url, caption, type, providerNameSlug, enableYouTubeSeek } =
+		attributes;
 
 	if ( ! url ) {
 		return null;
@@ -26,7 +27,12 @@ export default function save( { attributes } ) {
 	} );
 
 	return (
-		<figure { ...useBlockProps.save( { className } ) }>
+		<figure
+			{ ...useBlockProps.save( { className } ) }
+			{ ...( enableYouTubeSeek
+				? { 'data-enable-youtube-seek': '' }
+				: {} ) }
+		>
 			<div className="wp-block-embed__wrapper">
 				{ `\n${ url }\n` /* URL needs to be on its own line. */ }
 			</div>

--- a/packages/block-library/src/embed/view.js
+++ b/packages/block-library/src/embed/view.js
@@ -1,0 +1,85 @@
+/**
+ * Frontend script for the YouTube timestamp seek feature.
+ *
+ * When an embed block has `data-enable-youtube-seek`, this module:
+ *   1. Appends `enablejsapi=1` to each YouTube iframe's src.
+ *   2. Loads the YouTube IFrame Player API.
+ *   3. Creates YT.Player instances so seek links work.
+ *
+ * Usage in post content (survives wp_kses because it uses data attributes):
+ *   <a href="#" data-yt-seek="754">12:34</a> — seeks the nearest YouTube embed to 12m 34s.
+ */
+
+const blocks = document.querySelectorAll(
+	'.wp-block-embed[data-enable-youtube-seek]'
+);
+
+if ( blocks.length > 0 ) {
+	const playerMap = new Map(); // iframe element -> YT.Player
+	const pendingIframes = []; // { iframe, id }
+	let counter = 0;
+
+	blocks.forEach( ( block ) => {
+		const iframe = block.querySelector( 'iframe' );
+		if ( ! iframe?.src.includes( 'youtube.com/embed' ) ) {
+			return;
+		}
+
+		const id = 'yt-seek-player-' + ++counter;
+		iframe.id = id;
+
+		const url = new URL( iframe.src );
+		if ( ! url.searchParams.has( 'enablejsapi' ) ) {
+			url.searchParams.set( 'enablejsapi', '1' );
+			iframe.src = url.toString();
+		}
+
+		pendingIframes.push( { iframe, id } );
+	} );
+
+	if ( pendingIframes.length > 0 ) {
+		// Wire up all [data-yt-seek] links in the document.
+		document.querySelectorAll( '[data-yt-seek]' ).forEach( ( el ) => {
+			el.addEventListener( 'click', ( e ) => {
+				e.preventDefault();
+				const seconds = parseInt( el.dataset.ytSeek, 10 );
+				if ( isNaN( seconds ) ) {
+					return;
+				}
+
+				// Prefer the YouTube embed in the same block; fall back to the first.
+				const block =
+					el.closest( '.wp-block-embed[data-enable-youtube-seek]' ) ||
+					document.querySelector(
+						'.wp-block-embed[data-enable-youtube-seek]'
+					);
+				const iframe = block?.querySelector( 'iframe' );
+				const player = iframe ? playerMap.get( iframe ) : undefined;
+				if ( player ) {
+					player.seekTo( seconds, true );
+					player.playVideo();
+				}
+			} );
+		} );
+
+		// Chain onto any existing YT API ready callback (e.g. from another plugin).
+		const prevReady = window.onYouTubeIframeAPIReady;
+		window.onYouTubeIframeAPIReady = () => {
+			if ( typeof prevReady === 'function' ) {
+				prevReady();
+			}
+			pendingIframes.forEach( ( { iframe, id } ) => {
+				playerMap.set( iframe, new window.YT.Player( id ) );
+			} );
+		};
+
+		// Load the YouTube IFrame API once, even if several blocks are on the page.
+		if (
+			! document.querySelector( 'script[src*="youtube.com/iframe_api"]' )
+		) {
+			const script = document.createElement( 'script' );
+			script.src = 'https://www.youtube.com/iframe_api';
+			document.head.appendChild( script );
+		}
+	}
+}


### PR DESCRIPTION


Fixes #77578

## What does this PR do?

Adds an optional **"Enable timestamp seeking"** toggle to YouTube embed blocks (Inspector → Player settings).

When enabled:
- `data-enable-youtube-seek` is serialised onto the block's `<figure>` element
- A new `viewScriptModule` (`view.js`) runs on the frontend that:
  1. Appends `enablejsapi=1` to the YouTube iframe src
  2. Loads the YouTube IFrame Player API
  3. Wires up click handlers for any `[data-yt-seek="SECONDS"]` elements on the page

## Usage

After enabling the toggle, add a seek link anywhere in the post using a Custom HTML block:

<a href="#" data-yt-seek="754">12:34</a> there's a skateboard.

Clicking the link seeks the video to that timestamp (754 s = 12m 34s) without opening a new video.

## Notes

- Feature is **opt-in** (defaults to `false`) — existing embeds unaffected
- Works with multiple YouTube embeds on the same page
- Chains onto any existing `onYouTubeIframeAPIReady` callback

## Testing instructions

1. Add a YouTube embed block
2. Inspector → **Player settings** → toggle **Enable timestamp seeking** ON
3. Save the post
4. Add a Custom HTML block: `<a href="#" data-yt-seek="30">Jump to 0:30</a>`
5. View the published post and click the link — video seeks to 30s and plays
<img width="331" height="304" alt="Screenshot 2026-04-24 at 1 06 19 AM" src="https://github.com/user-attachments/assets/ff946224-6520-4bc7-99aa-db1522df41a6" />
