### PR TITLE
RTC: Fix "Connection Lost" dialog when too many entities are loaded

### DIFF
--- a/packages/sync/src/providers/http-polling/config.ts
+++ b/packages/sync/src/providers/http-polling/config.ts
@@ -26,6 +26,10 @@ export const MANUAL_RETRY_INTERVAL_MS = 15000;
 
 export const MAX_UPDATE_SIZE_IN_BYTES = 1 * 1024 * 1024; // 1 MB
 
+// Corresponds with server-side
+// WP_HTTP_Polling_Sync_Server::MAX_ROOMS_PER_REQUEST.
+export const MAX_ROOMS_PER_REQUEST = 50;
+
 export const POLLING_INTERVAL_IN_MS = applyFilters(
 	'sync.pollingManager.pollingInterval',
 	4000 // 4 seconds

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -576,11 +576,6 @@ function poll(): void {
 		// cancels a beforeunload dialog.
 		isUnloadPending = false;
 
-		// Emit 'connecting' status.
-		roomStates.forEach( ( state ) => {
-			state.onStatusChange( { status: 'connecting' } );
-		} );
-
 		// Create a payload with all queued updates. We include rooms even if they
 		// have no updates to ensure we receive any incoming updates. Note that we
 		// withhold our own updates until we detect another collaborator using the
@@ -596,13 +591,19 @@ function poll(): void {
 			} ) ),
 		};
 
+		// Emit 'connecting' status only for rooms in this request. Rooms
+		// rotated out of this poll keep their prior status.
+		roomsInRequest.forEach( ( state ) => {
+			state.onStatusChange( { status: 'connecting' } );
+		} );
+
 		try {
 			const { rooms } = await postSyncUpdate( payload );
 
 			// Emit 'connected' status.
 			consecutiveFailures = 0;
 			isManualRetry = false;
-			roomStates.forEach( ( state ) => {
+			roomsInRequest.forEach( ( state ) => {
 				state.onStatusChange( { status: 'connected' } );
 			} );
 
@@ -768,7 +769,7 @@ function poll(): void {
 					const backgroundRetriesFailed =
 						consecutiveFailures > retrySchedule.length;
 
-					roomStates.forEach( ( state ) => {
+					roomsInRequest.forEach( ( state ) => {
 						state.onStatusChange( {
 							status: 'disconnected',
 							canManuallyRetry: true,

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -604,6 +604,13 @@ function poll(): void {
 			consecutiveFailures = 0;
 			isManualRetry = false;
 			roomsInRequest.forEach( ( state ) => {
+				// Skip rooms unregistered during the await (e.g. the
+				// size-limit handler in onDocUpdate). Their terminal
+				// status was already set by whatever unregistered them.
+				if ( roomStates.get( state.room ) !== state ) {
+					return;
+				}
+
 				state.onStatusChange( { status: 'connected' } );
 			} );
 
@@ -770,6 +777,12 @@ function poll(): void {
 						consecutiveFailures > retrySchedule.length;
 
 					roomsInRequest.forEach( ( state ) => {
+						// Skip rooms unregistered during the await so
+						// their terminal status isn't overwritten.
+						if ( roomStates.get( state.room ) !== state ) {
+							return;
+						}
+
 						state.onStatusChange( {
 							status: 'disconnected',
 							canManuallyRetry: true,

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -20,6 +20,7 @@ import {
 	DEFAULT_CLIENT_LIMIT_PER_ROOM,
 	ERROR_RETRY_DELAYS_SOLO_MS,
 	ERROR_RETRY_DELAYS_WITH_COLLABORATORS_MS,
+	MAX_ROOMS_PER_REQUEST,
 	MAX_UPDATE_SIZE_IN_BYTES,
 	POLLING_INTERVAL_IN_MS,
 	POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS,
@@ -44,6 +45,7 @@ import {
 	intValueOrDefault,
 	postSyncUpdate,
 	postSyncUpdateNonBlocking,
+	rotateWindow,
 } from './utils';
 
 const POLLING_MANAGER_ORIGIN = 'polling-manager';
@@ -439,6 +441,12 @@ let isUnloadPending = false;
 let pollInterval = POLLING_INTERVAL_IN_MS;
 let pollingTimeoutId: ReturnType< typeof setTimeout > | null = null;
 
+// When more rooms are registered than the server allows per request
+// (MAX_ROOMS_PER_REQUEST), the primary room is sent every poll and the
+// remaining "overflow" rooms are rotated across polls. This offset
+// points into the overflow list at the next room to include.
+let roomOverflowOffset = 0;
+
 /**
  * Mark that a page unload has been requested. This fires on
  * `beforeunload` which happens before the browser aborts in-flight
@@ -468,7 +476,11 @@ function handlePageHide(): void {
 		} )
 	);
 
-	postSyncUpdateNonBlocking( { rooms } );
+	for ( let i = 0; i < rooms.length; i += MAX_ROOMS_PER_REQUEST ) {
+		postSyncUpdateNonBlocking( {
+			rooms: rooms.slice( i, i + MAX_ROOMS_PER_REQUEST ),
+		} );
+	}
 }
 
 /**
@@ -506,6 +518,49 @@ function handleVisibilityChange() {
 	}
 }
 
+/**
+ * Select which rooms to include in the next sync request.
+ *
+ * The server caps requests at MAX_ROOMS_PER_REQUEST rooms. When fewer rooms are
+ * registered than the cap, every room is included on every poll. When the cap
+ * is exceeded, the primary room is sent on every poll (so the main document
+ * stays fully synced) and the remaining overflow rooms are rotated across
+ * successive polls so each one is included (at a reduced frequency).
+ *
+ * Rooms that are skipped on a given poll keep their queued updates; the updates
+ * are drained on the next poll that includes them.
+ *
+ * @return The RoomStates to include in this request, in send order.
+ */
+function selectRoomsForRequest(): RoomState[] {
+	const allRooms = Array.from( roomStates.values() );
+
+	// Fast path: everything fits in a single request.
+	if ( allRooms.length <= MAX_ROOMS_PER_REQUEST ) {
+		return allRooms;
+	}
+
+	// Rotation path: pin the primary room to every request (if one exists)
+	// and rotate the remaining overflow rooms across successive polls.
+	const primaryRoom = allRooms.find( ( state ) => state.isPrimaryRoom );
+	const overflowRooms = allRooms.filter( ( state ) => state !== primaryRoom );
+	const overflowSlotsPerRequest =
+		MAX_ROOMS_PER_REQUEST - ( primaryRoom ? 1 : 0 );
+
+	const { window: overflowSlice, nextOffset } = rotateWindow(
+		overflowRooms,
+		roomOverflowOffset,
+		overflowSlotsPerRequest
+	);
+	roomOverflowOffset = nextOffset;
+
+	if ( primaryRoom ) {
+		return [ primaryRoom, ...overflowSlice ];
+	}
+
+	return overflowSlice;
+}
+
 function poll(): void {
 	isPolling = true;
 	pollingTimeoutId = null;
@@ -530,16 +585,15 @@ function poll(): void {
 		// have no updates to ensure we receive any incoming updates. Note that we
 		// withhold our own updates until we detect another collaborator using the
 		// queue's pause / resume mechanism.
+		const roomsInRequest = selectRoomsForRequest();
 		const payload: SyncPayload = {
-			rooms: Array.from( roomStates.entries() ).map(
-				( [ room, state ] ) => ( {
-					after: state.endCursor ?? 0,
-					awareness: state.localAwarenessState,
-					client_id: state.clientId,
-					room,
-					updates: state.updateQueue.get(),
-				} )
-			),
+			rooms: roomsInRequest.map( ( state ) => ( {
+				after: state.endCursor ?? 0,
+				awareness: state.localAwarenessState,
+				client_id: state.clientId,
+				room: state.room,
+				updates: state.updateQueue.get(),
+			} ) ),
 		};
 
 		try {
@@ -897,6 +951,7 @@ function unregisterRoom(
 		areListenersRegistered = false;
 		hasCheckedConnectionLimit = false;
 		consecutiveFailures = 0;
+		roomOverflowOffset = 0;
 	}
 }
 

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -45,6 +45,10 @@ jest.mock( '@wordpress/hooks', () => ( {
 jest.mock( '../config', () => ( {
 	...( jest.requireActual( '../config' ) as object ),
 	MAX_UPDATE_SIZE_IN_BYTES: 10,
+	// Shrink the per-request room cap so rotation tests don't need 50+
+	// registered rooms. Existing tests register at most 2 rooms and
+	// stay well under this cap.
+	MAX_ROOMS_PER_REQUEST: 10,
 } ) );
 
 jest.mock( '../utils', () => ( {
@@ -1278,6 +1282,165 @@ describe( 'polling-manager', () => {
 
 			await jest.advanceTimersByTimeAsync( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+		} );
+	} );
+
+	describe( 'room overflow rotation', () => {
+		// The outer mock sets MAX_ROOMS_PER_REQUEST to 10. Tests in this
+		// block register a primary room plus additional "overflow" rooms
+		// to exercise the rotation behavior. With cap=10 and the primary
+		// pinned, each request carries 9 overflow slots.
+
+		function registerRoom( pollingMgr: PollingManager, room: string ) {
+			pollingMgr.registerRoom( {
+				room,
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+		}
+
+		function registerPrimaryAndOverflow(
+			pollingMgr: PollingManager,
+			overflowCount: number
+		): string[] {
+			registerRoom( pollingMgr, 'primary' );
+			const overflowNames: string[] = [];
+			for ( let i = 1; i <= overflowCount; i++ ) {
+				const name = `o${ i }`;
+				overflowNames.push( name );
+				registerRoom( pollingMgr, name );
+			}
+			return overflowNames;
+		}
+
+		function getRoomNames( callIndex: number ): string[] {
+			const payload = mockPostSyncUpdate.mock.calls[ callIndex ][ 0 ] as {
+				rooms: { room: string }[];
+			};
+			return payload.rooms.map( ( r ) => r.room );
+		}
+
+		it( 'sends every room in a single request when the count is at or under the cap', async () => {
+			mockPostSyncUpdate.mockResolvedValue( { rooms: [] } );
+
+			// Primary + 9 overflow = 10 rooms, exactly at the cap.
+			const overflow = registerPrimaryAndOverflow( pollingManager, 9 );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+			expect( getRoomNames( 0 ) ).toEqual( [ 'primary', ...overflow ] );
+		} );
+
+		it( 'caps each request at MAX_ROOMS_PER_REQUEST and always includes the primary room', async () => {
+			mockPostSyncUpdate.mockResolvedValue( { rooms: [] } );
+
+			// Primary + 11 overflow = 12 rooms, over the cap of 10.
+			registerPrimaryAndOverflow( pollingManager, 11 );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			await jest.advanceTimersByTimeAsync( 4000 );
+			await jest.advanceTimersByTimeAsync( 4000 );
+
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			for ( let i = 0; i < 3; i++ ) {
+				const names = getRoomNames( i );
+				expect( names ).toHaveLength( 10 );
+				expect( names[ 0 ] ).toBe( 'primary' );
+			}
+		} );
+
+		it( 'rotates overflow rooms across successive polls until all are covered', async () => {
+			mockPostSyncUpdate.mockResolvedValue( { rooms: [] } );
+
+			// Primary + 15 overflow = 16 rooms. With 9 overflow slots per
+			// request, two polls send 18 slots — enough to cover every
+			// overflow room at least once.
+			const overflow = registerPrimaryAndOverflow( pollingManager, 15 );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			await jest.advanceTimersByTimeAsync( 4000 );
+
+			const overflowSeen = new Set< string >();
+			for ( let i = 0; i < 2; i++ ) {
+				for ( const name of getRoomNames( i ) ) {
+					if ( name !== 'primary' ) {
+						overflowSeen.add( name );
+					}
+				}
+			}
+
+			expect( overflowSeen ).toEqual( new Set( overflow ) );
+		} );
+
+		it( 'advances the rotation window so successive polls send different overflow rooms', async () => {
+			mockPostSyncUpdate.mockResolvedValue( { rooms: [] } );
+
+			// Primary + 11 overflow rooms, 9 slots per request.
+			registerPrimaryAndOverflow( pollingManager, 11 );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			await jest.advanceTimersByTimeAsync( 4000 );
+
+			const first = getRoomNames( 0 ).slice( 1 );
+			const second = getRoomNames( 1 ).slice( 1 );
+
+			expect( first ).not.toEqual( second );
+			// Two polls of 9 slots against 11 overflow rooms cover the
+			// entire set.
+			expect( new Set( [ ...first, ...second ] ).size ).toBe( 11 );
+		} );
+
+		it( 'advances the rotation window even when a poll fails', async () => {
+			// Primary + 11 overflow rooms, 9 slots per request.
+			registerPrimaryAndOverflow( pollingManager, 11 );
+
+			// First poll fails. It should have sent primary + 9 overflow.
+			mockPostSyncUpdate.mockRejectedValueOnce( new Error( 'network' ) );
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			const firstSent = getRoomNames( 0 );
+			expect( firstSent ).toHaveLength( 10 );
+			expect( firstSent[ 0 ] ).toBe( 'primary' );
+
+			// Second poll should rotate past the failed window, still
+			// pinning primary but with a different overflow slice.
+			mockPostSyncUpdate.mockResolvedValueOnce( { rooms: [] } );
+			await jest.advanceTimersByTimeAsync( 2000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			const secondSent = getRoomNames( 1 );
+			expect( secondSent ).toHaveLength( 10 );
+			expect( secondSent[ 0 ] ).toBe( 'primary' );
+			expect( secondSent ).not.toEqual( firstSent );
+		} );
+
+		it( 'chunks the page-hide disconnect beacon so each request stays under the cap', async () => {
+			mockPostSyncUpdate.mockResolvedValue( { rooms: [] } );
+
+			// 21 rooms at cap=10 => three beacons (10 + 10 + 1).
+			registerPrimaryAndOverflow( pollingManager, 20 );
+
+			// Flush the initial poll so the pagehide test observes
+			// postSyncUpdateNonBlocking calls from the page-hide handler only.
+			await jest.advanceTimersByTimeAsync( 0 );
+			mockPostSyncUpdateNonBlocking.mockClear();
+
+			window.dispatchEvent( new Event( 'pagehide' ) );
+
+			expect( mockPostSyncUpdateNonBlocking ).toHaveBeenCalledTimes( 3 );
+
+			const beaconsSent = mockPostSyncUpdateNonBlocking.mock.calls.map(
+				( call ) =>
+					( call[ 0 ] as { rooms: { room: string }[] } ).rooms.length
+			);
+			expect( beaconsSent.every( ( n ) => n <= 10 ) ).toBe( true );
+			expect( beaconsSent.reduce( ( a, b ) => a + b, 0 ) ).toBe( 21 );
 		} );
 	} );
 } );

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -1290,6 +1290,11 @@ describe( 'polling-manager', () => {
 		// block register a primary room plus additional "overflow" rooms
 		// to exercise the rotation behavior. With cap=10 and the primary
 		// pinned, each request carries 9 overflow slots.
+		//
+		// Note: the first registerRoom call triggers poll() synchronously,
+		// so the first poll's payload contains only the primary room.
+		// Overflow rooms registered in the same tick are picked up starting
+		// with the second poll, which is when rotation behavior kicks in.
 
 		function registerRoom( pollingMgr: PollingManager, room: string ) {
 			pollingMgr.registerRoom( {
@@ -1330,9 +1335,16 @@ describe( 'polling-manager', () => {
 			const overflow = registerPrimaryAndOverflow( pollingManager, 9 );
 
 			await jest.advanceTimersByTimeAsync( 0 );
+			await jest.advanceTimersByTimeAsync( 4000 );
 
-			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
-			expect( getRoomNames( 0 ) ).toEqual( [ 'primary', ...overflow ] );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			// First poll fires synchronously with only the primary room.
+			expect( getRoomNames( 0 ) ).toEqual( [ 'primary' ] );
+
+			// Second poll includes every registered room in a single
+			// request (fast path since total rooms === cap).
+			expect( getRoomNames( 1 ) ).toEqual( [ 'primary', ...overflow ] );
 		} );
 
 		it( 'caps each request at MAX_ROOMS_PER_REQUEST and always includes the primary room', async () => {
@@ -1347,7 +1359,11 @@ describe( 'polling-manager', () => {
 
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 
-			for ( let i = 0; i < 3; i++ ) {
+			// First poll: only the primary room was registered yet.
+			expect( getRoomNames( 0 ) ).toEqual( [ 'primary' ] );
+
+			// Subsequent polls cap at MAX_ROOMS_PER_REQUEST and pin primary.
+			for ( let i = 1; i < 3; i++ ) {
 				const names = getRoomNames( i );
 				expect( names ).toHaveLength( 10 );
 				expect( names[ 0 ] ).toBe( 'primary' );
@@ -1357,16 +1373,18 @@ describe( 'polling-manager', () => {
 		it( 'rotates overflow rooms across successive polls until all are covered', async () => {
 			mockPostSyncUpdate.mockResolvedValue( { rooms: [] } );
 
-			// Primary + 15 overflow = 16 rooms. With 9 overflow slots per
-			// request, two polls send 18 slots — enough to cover every
-			// overflow room at least once.
+			// Primary + 15 overflow = 16 rooms. Skipping the primary-only
+			// first poll, two subsequent rotation polls send 18 slots —
+			// enough to cover every overflow room at least once.
 			const overflow = registerPrimaryAndOverflow( pollingManager, 15 );
 
 			await jest.advanceTimersByTimeAsync( 0 );
 			await jest.advanceTimersByTimeAsync( 4000 );
+			await jest.advanceTimersByTimeAsync( 4000 );
 
 			const overflowSeen = new Set< string >();
-			for ( let i = 0; i < 2; i++ ) {
+			// Skip poll 0 (primary only); inspect rotation polls.
+			for ( let i = 1; i < 3; i++ ) {
 				for ( const name of getRoomNames( i ) ) {
 					if ( name !== 'primary' ) {
 						overflowSeen.add( name );
@@ -1385,13 +1403,15 @@ describe( 'polling-manager', () => {
 
 			await jest.advanceTimersByTimeAsync( 0 );
 			await jest.advanceTimersByTimeAsync( 4000 );
+			await jest.advanceTimersByTimeAsync( 4000 );
 
-			const first = getRoomNames( 0 ).slice( 1 );
-			const second = getRoomNames( 1 ).slice( 1 );
+			// Compare the two rotation polls (poll 0 is primary-only).
+			const first = getRoomNames( 1 ).slice( 1 );
+			const second = getRoomNames( 2 ).slice( 1 );
 
 			expect( first ).not.toEqual( second );
-			// Two polls of 9 slots against 11 overflow rooms cover the
-			// entire set.
+			// Two rotation polls of 9 slots against 11 overflow rooms
+			// cover the entire set.
 			expect( new Set( [ ...first, ...second ] ).size ).toBe( 11 );
 		} );
 
@@ -1399,25 +1419,32 @@ describe( 'polling-manager', () => {
 			// Primary + 11 overflow rooms, 9 slots per request.
 			registerPrimaryAndOverflow( pollingManager, 11 );
 
-			// First poll fails. It should have sent primary + 9 overflow.
-			mockPostSyncUpdate.mockRejectedValueOnce( new Error( 'network' ) );
+			// Poll 1: primary only (fires synchronously at registration).
+			mockPostSyncUpdate.mockResolvedValueOnce( { rooms: [] } );
 			await jest.advanceTimersByTimeAsync( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+			expect( getRoomNames( 0 ) ).toEqual( [ 'primary' ] );
 
-			const firstSent = getRoomNames( 0 );
-			expect( firstSent ).toHaveLength( 10 );
-			expect( firstSent[ 0 ] ).toBe( 'primary' );
-
-			// Second poll should rotate past the failed window, still
-			// pinning primary but with a different overflow slice.
-			mockPostSyncUpdate.mockResolvedValueOnce( { rooms: [] } );
-			await jest.advanceTimersByTimeAsync( 2000 );
+			// Poll 2 fails while sending primary + 9 overflow. The
+			// rotation offset should still advance past this window.
+			mockPostSyncUpdate.mockRejectedValueOnce( new Error( 'network' ) );
+			await jest.advanceTimersByTimeAsync( 4000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 
-			const secondSent = getRoomNames( 1 );
-			expect( secondSent ).toHaveLength( 10 );
-			expect( secondSent[ 0 ] ).toBe( 'primary' );
-			expect( secondSent ).not.toEqual( firstSent );
+			const failedSent = getRoomNames( 1 );
+			expect( failedSent ).toHaveLength( 10 );
+			expect( failedSent[ 0 ] ).toBe( 'primary' );
+
+			// Poll 3 retries after the failure and should send a different
+			// overflow slice, proving the offset advanced despite the error.
+			mockPostSyncUpdate.mockResolvedValueOnce( { rooms: [] } );
+			await jest.advanceTimersByTimeAsync( 2000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			const retrySent = getRoomNames( 2 );
+			expect( retrySent ).toHaveLength( 10 );
+			expect( retrySent[ 0 ] ).toBe( 'primary' );
+			expect( retrySent ).not.toEqual( failedSent );
 		} );
 
 		it( 'chunks the page-hide disconnect beacon so each request stays under the cap', async () => {

--- a/packages/sync/src/providers/http-polling/test/utils.test.ts
+++ b/packages/sync/src/providers/http-polling/test/utils.test.ts
@@ -24,6 +24,7 @@ import {
 	createUpdateQueue,
 	intValueOrDefault,
 	postSyncUpdate,
+	rotateWindow,
 	uint8ArrayToBase64,
 } from '../utils';
 
@@ -658,6 +659,130 @@ describe( 'http-polling utils', () => {
 		it( 'handles edge cases', () => {
 			expect( intValueOrDefault( '   15   ', 0 ) ).toBe( 15 ); // whitespace
 			expect( intValueOrDefault( '08', 0 ) ).toBe( 8 ); // leading zero
+		} );
+	} );
+
+	describe( 'rotateWindow', () => {
+		it( 'returns an empty window for an empty list', () => {
+			expect( rotateWindow( [], 0, 3 ) ).toEqual( {
+				window: [],
+				nextOffset: 0,
+			} );
+		} );
+
+		it( 'returns an empty window for any offset when the list is empty', () => {
+			expect( rotateWindow( [], 42, 10 ) ).toEqual( {
+				window: [],
+				nextOffset: 0,
+			} );
+		} );
+
+		it( 'returns every item and advances the offset when size fits', () => {
+			const items = [ 'a', 'b', 'c', 'd' ];
+
+			expect( rotateWindow( items, 0, 4 ) ).toEqual( {
+				window: [ 'a', 'b', 'c', 'd' ],
+				nextOffset: 0,
+			} );
+		} );
+
+		it( 'returns a prefix window when size is smaller than the list', () => {
+			const items = [ 'a', 'b', 'c', 'd', 'e' ];
+
+			expect( rotateWindow( items, 0, 2 ) ).toEqual( {
+				window: [ 'a', 'b' ],
+				nextOffset: 2,
+			} );
+		} );
+
+		it( 'starts the window at the given offset', () => {
+			const items = [ 'a', 'b', 'c', 'd', 'e' ];
+
+			expect( rotateWindow( items, 2, 2 ) ).toEqual( {
+				window: [ 'c', 'd' ],
+				nextOffset: 4,
+			} );
+		} );
+
+		it( 'wraps around the end of the list', () => {
+			const items = [ 'a', 'b', 'c', 'd', 'e' ];
+
+			expect( rotateWindow( items, 4, 3 ) ).toEqual( {
+				window: [ 'e', 'a', 'b' ],
+				nextOffset: 2,
+			} );
+		} );
+
+		it( 'normalizes offsets larger than the list length', () => {
+			const items = [ 'a', 'b', 'c' ];
+
+			// offset 7 mod 3 === 1, so the window starts at 'b'.
+			expect( rotateWindow( items, 7, 2 ) ).toEqual( {
+				window: [ 'b', 'c' ],
+				nextOffset: 0,
+			} );
+		} );
+
+		it( 'normalizes negative offsets into the valid range', () => {
+			const items = [ 'a', 'b', 'c' ];
+
+			// -1 should resolve to the last element.
+			expect( rotateWindow( items, -1, 2 ) ).toEqual( {
+				window: [ 'c', 'a' ],
+				nextOffset: 1,
+			} );
+		} );
+
+		it( 'clamps the window when size exceeds the list length', () => {
+			const items = [ 'a', 'b', 'c' ];
+
+			expect( rotateWindow( items, 0, 10 ) ).toEqual( {
+				window: [ 'a', 'b', 'c' ],
+				nextOffset: 1,
+			} );
+		} );
+
+		it( 'returns an empty window and leaves offset unchanged for size 0', () => {
+			const items = [ 'a', 'b', 'c' ];
+
+			expect( rotateWindow( items, 2, 0 ) ).toEqual( {
+				window: [],
+				nextOffset: 2,
+			} );
+		} );
+
+		it( 'treats negative sizes as zero', () => {
+			const items = [ 'a', 'b', 'c' ];
+
+			expect( rotateWindow( items, 1, -5 ) ).toEqual( {
+				window: [],
+				nextOffset: 1,
+			} );
+		} );
+
+		it( 'does not mutate the input list', () => {
+			const items = [ 'a', 'b', 'c', 'd' ];
+			const snapshot = [ ...items ];
+
+			rotateWindow( items, 2, 3 );
+
+			expect( items ).toEqual( snapshot );
+		} );
+
+		it( 'supports successive calls that cover every item exactly once', () => {
+			const items = [ 'a', 'b', 'c', 'd', 'e' ];
+			const seen: string[] = [];
+			let offset = 0;
+
+			for ( let i = 0; i < 3; i++ ) {
+				const { window, nextOffset } = rotateWindow( items, offset, 2 );
+				seen.push( ...window );
+				offset = nextOffset;
+			}
+
+			// Three rotations of size 2 => 6 slots; across 5 items that means
+			// each item is seen at least once.
+			expect( new Set( seen ) ).toEqual( new Set( items ) );
 		} );
 	} );
 } );

--- a/packages/sync/src/providers/http-polling/utils.ts
+++ b/packages/sync/src/providers/http-polling/utils.ts
@@ -149,3 +149,32 @@ export function intValueOrDefault(
 
 	return isNaN( intValue ) ? defaultValue : intValue;
 }
+
+/**
+ * Take `size` items from `items` starting at `offset`, wrapping around the
+ * end of the list. Returns the selected window and the offset to use on the
+ * next call (advanced by `size`).
+ *
+ * @param items  The list to rotate through.
+ * @param offset The starting index. Values larger than `items.length` are
+ *               wrapped (modulo).
+ * @param size   The maximum number of items to include in the window. The
+ *               window may be shorter if `size` exceeds `items.length`.
+ */
+export function rotateWindow< T >(
+	items: T[],
+	offset: number,
+	size: number
+): { window: T[]; nextOffset: number } {
+	if ( items.length === 0 ) {
+		return { window: [], nextOffset: 0 };
+	}
+
+	const start = ( ( offset % items.length ) + items.length ) % items.length;
+	const wrapped = [ ...items.slice( start ), ...items.slice( 0, start ) ];
+
+	return {
+		window: wrapped.slice( 0, Math.max( 0, size ) ),
+		nextOffset: ( start + Math.max( 0, size ) ) % items.length,
+	};
+}


### PR DESCRIPTION
## What?

When too many entities are loaded onto a page with real-time collaboration, the REST endpoint's [maximum room limit](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php#L54) returns an error, which results in the "Connection Lost" dialog:

<img width="1438" height="675" alt="connection-lost-request" src="https://github.com/user-attachments/assets/24d2828f-a58c-4946-b634-9fa3515d2b82" />

---

Change the HTTP polling sync provider to rotate room subscriptions across polls when a single page registers more sync rooms than the server will accept in one request.

## Why?

[`WP_HTTP_Polling_Sync_Server` enforces `MAX_ROOMS_PER_REQUEST = 50`](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php#L54) via a `maxItems` schema constraint on the `rooms` parameter. The client didn't know about this cap and put every registered room into one request. When too many entities are registered, the poll is rejected before any of them can sync and the "Connection Lost" dialog appears.

## How?

The poll loop now picks a subset of rooms that fit inside `MAX_ROOMS_PER_REQUEST` on each poll. When the total room count is at or below the cap, behavior is unchanged (every room in every request). When it's over, the function pins the "primary" room to every request so the main document keeps syncing at full cadence, and rotates the remaining "overflow" rooms through the remaining 49 slots across successive polls. Skipped rooms keep their queued updates, so nothing is lost, just synced at a slower cadence.

Primary-room identification reuses the existing `isPrimaryRoom` flag set at `registerRoom()` time (first room to register wins). That's already the signal we use for connection-limit enforcement. If the editor's post is loaded first, it gets pinned, and in any case where the primary is unregistered mid-session the rotation falls back to covering everything evenly.

## Testing Instructions

It's fairly difficult in normal circumstances to request 50+ individual entities in normal editor use. I've added a script below that will generate a post with 100 file blocks, which registers each as an entity.

To use the reproduction script, download `rtc-repro-many-files.php` below to the root of your Gutenberg repository, and add any image called `image.jpg` also in the root of the repository. The script uses that file to create 100 attachments for the reproduction.

---

<details>
<summary>📄 Expand rtc-repro-many-files.php:</summary>

```
<?php
/**
 * RTC disconnect reproduction.
 *
 * Uploads image.jpg (co-located in the Gutenberg plugin root) N times, then
 * creates a draft page with one File block per uploaded attachment. Opening
 * the page in the block editor subscribes N attachment sync rooms. When N
 * exceeds WP_HTTP_Polling_Sync_Server::MAX_ROOMS_PER_REQUEST (50), the next
 * poll is rejected with a 400 rest_too_many_items and the
 * sync-connection-error modal fires.
 *
 * Prerequisite: wp-env is running, RTC is enabled in Settings > Writing,
 * and image.jpg exists next to this script.
 *
 * Run from the repo root:
 *   npx wp-env run --env-cwd='wp-content/plugins/gutenberg' cli \
 *       wp eval-file rtc-repro-many-files.php [count]
 *
 * Arguments (optional):
 *   $args[0]  count   Number of File blocks to create. Default 100.
 */

if ( ! defined( 'WP_CLI' ) ) {
	die( "This script must be run via WP-CLI.\n" );
}

$count  = isset( $args[0] ) ? max( 1, (int) $args[0] ) : 100;
$source = __DIR__ . '/image.jpg';

if ( ! file_exists( $source ) ) {
	WP_CLI::error( "Source file not found: $source" );
}

require_once ABSPATH . 'wp-admin/includes/image.php';

// Reuse attachments from previous runs. We tag them with a meta key so we
// can re-find them cheaply by number, without relying on titles (which the
// user might change) or filenames (which WordPress might dedupe).
$meta_key = '_rtc_repro_seed_index';

$existing_query = new WP_Query(
	array(
		'post_type'      => 'attachment',
		'post_status'    => 'inherit',
		'posts_per_page' => -1,
		'fields'         => 'ids',
		'meta_key'       => $meta_key, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
		'orderby'        => 'meta_value_num',
		'order'          => 'ASC',
		'no_found_rows'  => true,
	)
);

// Map existing seed index => attachment ID.
$existing = array();
foreach ( $existing_query->posts as $existing_id ) {
	$idx = (int) get_post_meta( $existing_id, $meta_key, true );
	if ( $idx > 0 ) {
		$existing[ $idx ] = $existing_id;
	}
}

WP_CLI::log(
	sprintf(
		'Found %d existing seeded attachments; need %d total.',
		count( $existing ),
		$count
	)
);

$bytes = null; // Lazy-load; avoid reading the file if no new uploads needed.
$ids   = array();

for ( $i = 1; $i <= $count; $i++ ) {
	if ( isset( $existing[ $i ] ) ) {
		$ids[] = $existing[ $i ];
		continue;
	}

	if ( null === $bytes ) {
		$bytes = file_get_contents( $source );
	}

	$filename = sprintf( 'rtc-repro-%03d.jpg', $i );
	$upload   = wp_upload_bits( $filename, null, $bytes );

	if ( ! empty( $upload['error'] ) ) {
		WP_CLI::warning( "Upload $i failed: {$upload['error']}" );
		continue;
	}

	$attach_id = wp_insert_attachment(
		array(
			'post_mime_type' => 'image/jpeg',
			'post_title'     => "RTC Repro $i",
			'post_status'    => 'inherit',
		),
		$upload['file']
	);

	if ( is_wp_error( $attach_id ) || ! $attach_id ) {
		WP_CLI::warning( "Attachment insert $i failed." );
		continue;
	}

	wp_update_attachment_metadata(
		$attach_id,
		wp_generate_attachment_metadata( $attach_id, $upload['file'] )
	);

	update_post_meta( $attach_id, $meta_key, $i );

	$ids[] = $attach_id;

	if ( 0 === $i % 10 ) {
		WP_CLI::log( "Seeded $i / $count attachments..." );
	}
}

if ( empty( $ids ) ) {
	WP_CLI::error( 'No attachments available; aborting.' );
}

$blocks = '';
foreach ( $ids as $id ) {
	$url      = wp_get_attachment_url( $id );
	$file_id  = "wp-block-file--media-$id";
	// Match the exact shape produced by the core/file save function so block
	// validation doesn't flag every block. The two <a> tags are:
	//   1. The text link, id'd for `fileId` + aria-describedby, filename as rich-text.
	//   2. The download button, class'd as the save function emits it.
	$blocks .= sprintf(
		"<!-- wp:file {\"id\":%d,\"href\":\"%s\"} -->\n<div class=\"wp-block-file\"><a id=\"%s\" href=\"%s\">File %d</a><a href=\"%s\" class=\"wp-block-file__button wp-element-button\" download aria-describedby=\"%s\">Download</a></div>\n<!-- /wp:file -->\n\n",
		$id,
		esc_attr( $url ),
		esc_attr( $file_id ),
		esc_url( $url ),
		$id,
		esc_url( $url ),
		esc_attr( $file_id )
	);
}

$page_id = wp_insert_post(
	array(
		'post_type'    => 'page',
		'post_status'  => 'draft',
		'post_title'   => sprintf( 'RTC File Block Repro (%d files)', count( $ids ) ),
		'post_content' => $blocks,
	),
	true
);

if ( is_wp_error( $page_id ) ) {
	WP_CLI::error( 'Page creation failed: ' . $page_id->get_error_message() );
}

WP_CLI::success(
	sprintf( 'Created page %d with %d File blocks.', $page_id, count( $ids ) )
);
WP_CLI::log(
	'Edit URL: ' . home_url( "/wp-admin/post.php?post=$page_id&action=edit" )
);
```

</details>

---

1. Ensure RTC is enabled via Settings -> Writing -> "Enable real-time collaboration" checkbox.
2. Seed a page with 100 File blocks using the included repro script (requires `image.jpg` next to the script at the Gutenberg plugin root):

    ```bash
    # With rtc-repro-many-files.php downloaded (from above) and a image.jpg file:
    
    wp-env run --env-cwd='wp-content/plugins/gutenberg' cli wp eval-file rtc-repro-many-files.php 100
    ```

    It prints the edit URL of the generated page when it finishes.
3. Open that page in the block editor. On `trunk`, the "Connection lost" dialog appears within a few seconds of load (see screenshot in top of description). After this PR, the editor stays connected:

    <img width="1438" height="676" alt="room-rotate-example" src="https://github.com/user-attachments/assets/42dc03fb-dd45-46ab-b82e-55ac213fa628" />

4. Open DevTools -> Network and filter for `updates`. Verify that:
    - Each `POST /wp-sync/v1/updates` body has `rooms.length <= 50`.
    - Every request has the page's `postType/page:<id>` room at index 0.
    - Over several polls, the union of `postType/attachment:*` rooms eventually covers all 100 attachments (they rotate).
5. Edit the page content, save, reload the editor. Nothing about the save flow should have changed; verify the disconnect modal does not fire.
6. As a regression check, open a normal page with a handful of attachments (well under 50). The network tab should show a single request per poll containing every room, same as today.

To run the unit tests:

```bash
npm run test:unit -- --testPathPattern='packages/sync/src/providers/http-polling/test'
```

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Used for: The whole process.
