### PR TITLE
Experiment: Render taxonomy status as a Badge

### DIFF
--- a/routes/taxonomies/fields.tsx
+++ b/routes/taxonomies/fields.tsx
@@ -7,7 +7,7 @@ import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import type { Field, Form } from '@wordpress/dataviews';
 // eslint-disable-next-line @wordpress/use-recommended-components -- Used here because it supports rendering as a `span` via the `render` prop to avoid invalid HTML.
-import { Notice, Stack } from '@wordpress/ui';
+import { Badge, Notice, Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -94,6 +94,14 @@ export const statusField: Field< TaxonomyFormData > = {
 		{ value: 'publish', label: __( 'Active' ) },
 		{ value: 'draft', label: __( 'Inactive' ) },
 	],
+	render: ( { item } ) => {
+		const isActive = item.status === 'publish';
+		return (
+			<Badge intent={ isActive ? 'stable' : 'draft' }>
+				{ isActive ? __( 'Active' ) : __( 'Inactive' ) }
+			</Badge>
+		);
+	},
 	enableSorting: false,
 };
 


### PR DESCRIPTION
## What?
Render the Status column in the Taxonomies experiment DataView as a `Badge` instead of the plain element label text.

Follow-up to #77497. Part of #77600.

## Why?
The Status column currently renders the raw elements label — plain "Active" / "Inactive" text — which is easy to miss when scanning the table and doesn't visually distinguish between the two states. The design system ships a purpose-built Badge component with a documented plugin-status example that maps neatly onto this column, so we should use it for visual consistency with other DataViews in the dashboard and to give users a clearer at-a-glance read of the row's state.

## How?
Custom rendering for the status field, using the existing `Badge` component. 

## Testing Instructions
* Enable the taxonomies experiment
* Navigate to Settings > Taxonomies
* Create a couple of taxonomies, one inactive, one active
* Verify the Status columns and the badges in there look good.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

<img width="889" height="237" alt="Screenshot 2026-04-24 at 0 44 33" src="https://github.com/user-attachments/assets/07ca93ea-129f-4335-9826-6d66cfc9134b" />

## Use of AI Tools

Opus 4.7