### PR TITLE
Experiment: Split status action to two actions, make them bulk-capable

### DIFF
--- a/routes/taxonomies/actions/activate.ts
+++ b/routes/taxonomies/actions/activate.ts
@@ -1,0 +1,109 @@
+/**
+ * WordPress dependencies
+ */
+import { store as coreStore } from '@wordpress/core-data';
+import type { Action } from '@wordpress/dataviews';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import type { CoreDataError, TaxonomyFormData } from '../types';
+
+const activateAction: Action< TaxonomyFormData > = {
+	id: 'activate',
+	label: __( 'Activate' ),
+	supportsBulk: true,
+	isEligible: ( item ) => item.status !== 'publish',
+	async callback( items, { registry } ) {
+		const itemsToUpdate = items.filter(
+			( item ) => item.id !== undefined && item.status !== 'publish'
+		);
+		if ( itemsToUpdate.length === 0 ) {
+			return;
+		}
+		const { saveEntityRecord } = registry.dispatch( coreStore );
+		const { createSuccessNotice, createErrorNotice } =
+			registry.dispatch( noticesStore );
+		const promiseResult = await Promise.allSettled(
+			itemsToUpdate.map( ( item ) =>
+				saveEntityRecord(
+					'postType',
+					'wp_user_taxonomy',
+					{ id: item.id, status: 'publish' },
+					{ throwOnError: true }
+				)
+			)
+		);
+		if ( promiseResult.every( ( { status } ) => status === 'fulfilled' ) ) {
+			createSuccessNotice(
+				itemsToUpdate.length === 1
+					? __( 'Taxonomy activated.' )
+					: sprintf(
+							/* translators: %d: The number of taxonomies. */
+							_n(
+								'%d taxonomy activated.',
+								'%d taxonomies activated.',
+								itemsToUpdate.length
+							),
+							itemsToUpdate.length
+					  ),
+				{ type: 'snackbar' }
+			);
+		} else {
+			let errorMessage;
+			if ( promiseResult.length === 1 ) {
+				const typedError = promiseResult[ 0 ] as {
+					reason?: CoreDataError;
+				};
+				if (
+					typedError.reason?.message &&
+					typedError.reason.code !== 'unknown_error'
+				) {
+					errorMessage = typedError.reason.message;
+				} else {
+					errorMessage = __( 'Failed to activate taxonomy.' );
+				}
+			} else {
+				const errorMessages = new Set< string >();
+				const failedPromises = promiseResult.filter(
+					( { status } ) => status === 'rejected'
+				);
+				for ( const failedPromise of failedPromises ) {
+					const typedError = failedPromise as {
+						reason?: CoreDataError;
+					};
+					if (
+						typedError.reason?.message &&
+						typedError.reason.code !== 'unknown_error'
+					) {
+						errorMessages.add( typedError.reason.message );
+					}
+				}
+				if ( errorMessages.size === 0 ) {
+					errorMessage = __( 'Failed to activate taxonomies.' );
+				} else if ( errorMessages.size === 1 ) {
+					errorMessage = sprintf(
+						/* translators: %s: an error message */
+						__(
+							'An error occurred while activating the taxonomy: %s'
+						),
+						[ ...errorMessages ][ 0 ]
+					);
+				} else {
+					errorMessage = sprintf(
+						/* translators: %s: a list of comma separated error messages */
+						__(
+							'Some errors occurred while activating the taxonomies: %s'
+						),
+						[ ...errorMessages ].join( ',' )
+					);
+				}
+			}
+			createErrorNotice( errorMessage, { type: 'snackbar' } );
+		}
+	},
+};
+
+export default activateAction;

--- a/routes/taxonomies/actions/activate.ts
+++ b/routes/taxonomies/actions/activate.ts
@@ -1,109 +1,46 @@
 /**
  * WordPress dependencies
  */
-import { store as coreStore } from '@wordpress/core-data';
-import type { Action } from '@wordpress/dataviews';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
  */
-import type { CoreDataError, TaxonomyFormData } from '../types';
+import { createStatusAction } from './utils';
 
-const activateAction: Action< TaxonomyFormData > = {
+const activateAction = createStatusAction( {
 	id: 'activate',
 	label: __( 'Activate' ),
-	supportsBulk: true,
-	isEligible: ( item ) => item.status !== 'publish',
-	async callback( items, { registry } ) {
-		const itemsToUpdate = items.filter(
-			( item ) => item.id !== undefined && item.status !== 'publish'
-		);
-		if ( itemsToUpdate.length === 0 ) {
-			return;
-		}
-		const { saveEntityRecord } = registry.dispatch( coreStore );
-		const { createSuccessNotice, createErrorNotice } =
-			registry.dispatch( noticesStore );
-		const promiseResult = await Promise.allSettled(
-			itemsToUpdate.map( ( item ) =>
-				saveEntityRecord(
-					'postType',
-					'wp_user_taxonomy',
-					{ id: item.id, status: 'publish' },
-					{ throwOnError: true }
-				)
-			)
-		);
-		if ( promiseResult.every( ( { status } ) => status === 'fulfilled' ) ) {
-			createSuccessNotice(
-				itemsToUpdate.length === 1
-					? __( 'Taxonomy activated.' )
-					: sprintf(
-							/* translators: %d: The number of taxonomies. */
-							_n(
-								'%d taxonomy activated.',
-								'%d taxonomies activated.',
-								itemsToUpdate.length
-							),
-							itemsToUpdate.length
-					  ),
-				{ type: 'snackbar' }
-			);
-		} else {
-			let errorMessage;
-			if ( promiseResult.length === 1 ) {
-				const typedError = promiseResult[ 0 ] as {
-					reason?: CoreDataError;
-				};
-				if (
-					typedError.reason?.message &&
-					typedError.reason.code !== 'unknown_error'
-				) {
-					errorMessage = typedError.reason.message;
-				} else {
-					errorMessage = __( 'Failed to activate taxonomy.' );
-				}
-			} else {
-				const errorMessages = new Set< string >();
-				const failedPromises = promiseResult.filter(
-					( { status } ) => status === 'rejected'
-				);
-				for ( const failedPromise of failedPromises ) {
-					const typedError = failedPromise as {
-						reason?: CoreDataError;
-					};
-					if (
-						typedError.reason?.message &&
-						typedError.reason.code !== 'unknown_error'
-					) {
-						errorMessages.add( typedError.reason.message );
-					}
-				}
-				if ( errorMessages.size === 0 ) {
-					errorMessage = __( 'Failed to activate taxonomies.' );
-				} else if ( errorMessages.size === 1 ) {
-					errorMessage = sprintf(
-						/* translators: %s: an error message */
-						__(
-							'An error occurred while activating the taxonomy: %s'
-						),
-						[ ...errorMessages ][ 0 ]
-					);
-				} else {
-					errorMessage = sprintf(
-						/* translators: %s: a list of comma separated error messages */
-						__(
-							'Some errors occurred while activating the taxonomies: %s'
-						),
-						[ ...errorMessages ].join( ',' )
-					);
-				}
-			}
-			createErrorNotice( errorMessage, { type: 'snackbar' } );
-		}
+	targetStatus: 'publish',
+	messages: {
+		successSingle: __( 'Taxonomy activated.' ),
+		successMany: ( count: number ) =>
+			sprintf(
+				/* translators: %d: The number of taxonomies. */
+				_n(
+					'%d taxonomy activated.',
+					'%d taxonomies activated.',
+					count
+				),
+				count
+			),
+		failSingle: __( 'Failed to activate taxonomy.' ),
+		failMany: __( 'Failed to activate taxonomies.' ),
+		errorSingle: ( message: string ) =>
+			sprintf(
+				/* translators: %s: an error message */
+				__( 'An error occurred while activating the taxonomy: %s' ),
+				message
+			),
+		errorMany: ( messages: string ) =>
+			sprintf(
+				/* translators: %s: a list of comma separated error messages */
+				__(
+					'Some errors occurred while activating the taxonomies: %s'
+				),
+				messages
+			),
 	},
-};
+} );
 
 export default activateAction;

--- a/routes/taxonomies/actions/deactivate.ts
+++ b/routes/taxonomies/actions/deactivate.ts
@@ -11,54 +11,44 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import type { CoreDataError, TaxonomyFormData } from '../types';
 
-function getSuccessMessage( count: number, nextStatus: 'publish' | 'draft' ) {
-	if ( count === 1 ) {
-		return nextStatus === 'publish'
-			? __( 'Taxonomy activated.' )
-			: __( 'Taxonomy deactivated.' );
-	}
-	if ( nextStatus === 'publish' ) {
-		return sprintf(
-			/* translators: %d: The number of taxonomies. */
-			_n( '%d taxonomy activated.', '%d taxonomies activated.', count ),
-			count
-		);
-	}
-	return sprintf(
-		/* translators: %d: The number of taxonomies. */
-		_n( '%d taxonomy deactivated.', '%d taxonomies deactivated.', count ),
-		count
-	);
-}
-
-const toggleActiveAction: Action< TaxonomyFormData > = {
-	id: 'toggle-active',
-	label: ( items: TaxonomyFormData[] ) =>
-		items.every( ( i ) => i.status === 'publish' )
-			? __( 'Deactivate' )
-			: __( 'Activate' ),
+const deactivateAction: Action< TaxonomyFormData > = {
+	id: 'deactivate',
+	label: __( 'Deactivate' ),
 	supportsBulk: true,
+	isEligible: ( item ) => item.status === 'publish',
 	async callback( items, { registry } ) {
+		const itemsToUpdate = items.filter(
+			( item ) => item.id !== undefined && item.status === 'publish'
+		);
+		if ( itemsToUpdate.length === 0 ) {
+			return;
+		}
 		const { saveEntityRecord } = registry.dispatch( coreStore );
 		const { createSuccessNotice, createErrorNotice } =
 			registry.dispatch( noticesStore );
-		const nextStatus = items.every( ( i ) => i.status === 'publish' )
-			? 'draft'
-			: 'publish';
-		const itemsToUpdate = items.filter( ( item ) => item.id !== undefined );
 		const promiseResult = await Promise.allSettled(
 			itemsToUpdate.map( ( item ) =>
 				saveEntityRecord(
 					'postType',
 					'wp_user_taxonomy',
-					{ id: item.id, status: nextStatus },
+					{ id: item.id, status: 'draft' },
 					{ throwOnError: true }
 				)
 			)
 		);
 		if ( promiseResult.every( ( { status } ) => status === 'fulfilled' ) ) {
 			createSuccessNotice(
-				getSuccessMessage( itemsToUpdate.length, nextStatus ),
+				itemsToUpdate.length === 1
+					? __( 'Taxonomy deactivated.' )
+					: sprintf(
+							/* translators: %d: The number of taxonomies. */
+							_n(
+								'%d taxonomy deactivated.',
+								'%d taxonomies deactivated.',
+								itemsToUpdate.length
+							),
+							itemsToUpdate.length
+					  ),
 				{ type: 'snackbar' }
 			);
 		} else {
@@ -73,7 +63,7 @@ const toggleActiveAction: Action< TaxonomyFormData > = {
 				) {
 					errorMessage = typedError.reason.message;
 				} else {
-					errorMessage = __( 'Failed to update taxonomy status.' );
+					errorMessage = __( 'Failed to deactivate taxonomy.' );
 				}
 			} else {
 				const errorMessages = new Set< string >();
@@ -92,12 +82,12 @@ const toggleActiveAction: Action< TaxonomyFormData > = {
 					}
 				}
 				if ( errorMessages.size === 0 ) {
-					errorMessage = __( 'Failed to update taxonomies status.' );
+					errorMessage = __( 'Failed to deactivate taxonomies.' );
 				} else if ( errorMessages.size === 1 ) {
 					errorMessage = sprintf(
 						/* translators: %s: an error message */
 						__(
-							'An error occurred while updating the taxonomy status: %s'
+							'An error occurred while deactivating the taxonomy: %s'
 						),
 						[ ...errorMessages ][ 0 ]
 					);
@@ -105,7 +95,7 @@ const toggleActiveAction: Action< TaxonomyFormData > = {
 					errorMessage = sprintf(
 						/* translators: %s: a list of comma separated error messages */
 						__(
-							'Some errors occurred while updating the taxonomies status: %s'
+							'Some errors occurred while deactivating the taxonomies: %s'
 						),
 						[ ...errorMessages ].join( ',' )
 					);
@@ -116,4 +106,4 @@ const toggleActiveAction: Action< TaxonomyFormData > = {
 	},
 };
 
-export default toggleActiveAction;
+export default deactivateAction;

--- a/routes/taxonomies/actions/deactivate.ts
+++ b/routes/taxonomies/actions/deactivate.ts
@@ -1,109 +1,46 @@
 /**
  * WordPress dependencies
  */
-import { store as coreStore } from '@wordpress/core-data';
-import type { Action } from '@wordpress/dataviews';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
  */
-import type { CoreDataError, TaxonomyFormData } from '../types';
+import { createStatusAction } from './utils';
 
-const deactivateAction: Action< TaxonomyFormData > = {
+const deactivateAction = createStatusAction( {
 	id: 'deactivate',
 	label: __( 'Deactivate' ),
-	supportsBulk: true,
-	isEligible: ( item ) => item.status === 'publish',
-	async callback( items, { registry } ) {
-		const itemsToUpdate = items.filter(
-			( item ) => item.id !== undefined && item.status === 'publish'
-		);
-		if ( itemsToUpdate.length === 0 ) {
-			return;
-		}
-		const { saveEntityRecord } = registry.dispatch( coreStore );
-		const { createSuccessNotice, createErrorNotice } =
-			registry.dispatch( noticesStore );
-		const promiseResult = await Promise.allSettled(
-			itemsToUpdate.map( ( item ) =>
-				saveEntityRecord(
-					'postType',
-					'wp_user_taxonomy',
-					{ id: item.id, status: 'draft' },
-					{ throwOnError: true }
-				)
-			)
-		);
-		if ( promiseResult.every( ( { status } ) => status === 'fulfilled' ) ) {
-			createSuccessNotice(
-				itemsToUpdate.length === 1
-					? __( 'Taxonomy deactivated.' )
-					: sprintf(
-							/* translators: %d: The number of taxonomies. */
-							_n(
-								'%d taxonomy deactivated.',
-								'%d taxonomies deactivated.',
-								itemsToUpdate.length
-							),
-							itemsToUpdate.length
-					  ),
-				{ type: 'snackbar' }
-			);
-		} else {
-			let errorMessage;
-			if ( promiseResult.length === 1 ) {
-				const typedError = promiseResult[ 0 ] as {
-					reason?: CoreDataError;
-				};
-				if (
-					typedError.reason?.message &&
-					typedError.reason.code !== 'unknown_error'
-				) {
-					errorMessage = typedError.reason.message;
-				} else {
-					errorMessage = __( 'Failed to deactivate taxonomy.' );
-				}
-			} else {
-				const errorMessages = new Set< string >();
-				const failedPromises = promiseResult.filter(
-					( { status } ) => status === 'rejected'
-				);
-				for ( const failedPromise of failedPromises ) {
-					const typedError = failedPromise as {
-						reason?: CoreDataError;
-					};
-					if (
-						typedError.reason?.message &&
-						typedError.reason.code !== 'unknown_error'
-					) {
-						errorMessages.add( typedError.reason.message );
-					}
-				}
-				if ( errorMessages.size === 0 ) {
-					errorMessage = __( 'Failed to deactivate taxonomies.' );
-				} else if ( errorMessages.size === 1 ) {
-					errorMessage = sprintf(
-						/* translators: %s: an error message */
-						__(
-							'An error occurred while deactivating the taxonomy: %s'
-						),
-						[ ...errorMessages ][ 0 ]
-					);
-				} else {
-					errorMessage = sprintf(
-						/* translators: %s: a list of comma separated error messages */
-						__(
-							'Some errors occurred while deactivating the taxonomies: %s'
-						),
-						[ ...errorMessages ].join( ',' )
-					);
-				}
-			}
-			createErrorNotice( errorMessage, { type: 'snackbar' } );
-		}
+	targetStatus: 'draft',
+	messages: {
+		successSingle: __( 'Taxonomy deactivated.' ),
+		successMany: ( count: number ) =>
+			sprintf(
+				/* translators: %d: The number of taxonomies. */
+				_n(
+					'%d taxonomy deactivated.',
+					'%d taxonomies deactivated.',
+					count
+				),
+				count
+			),
+		failSingle: __( 'Failed to deactivate taxonomy.' ),
+		failMany: __( 'Failed to deactivate taxonomies.' ),
+		errorSingle: ( message: string ) =>
+			sprintf(
+				/* translators: %s: an error message */
+				__( 'An error occurred while deactivating the taxonomy: %s' ),
+				message
+			),
+		errorMany: ( messages: string ) =>
+			sprintf(
+				/* translators: %s: a list of comma separated error messages */
+				__(
+					'Some errors occurred while deactivating the taxonomies: %s'
+				),
+				messages
+			),
 	},
-};
+} );
 
 export default deactivateAction;

--- a/routes/taxonomies/actions/index.ts
+++ b/routes/taxonomies/actions/index.ts
@@ -1,3 +1,4 @@
+export { default as activateAction } from './activate';
+export { default as deactivateAction } from './deactivate';
 export { default as deleteTaxonomyAction } from './delete';
 export { default as editTaxonomyAction } from './edit';
-export { default as toggleActiveAction } from './toggle-active';

--- a/routes/taxonomies/actions/toggle-active.ts
+++ b/routes/taxonomies/actions/toggle-active.ts
@@ -3,13 +3,33 @@
  */
 import { store as coreStore } from '@wordpress/core-data';
 import type { Action } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
  */
-import type { TaxonomyFormData } from '../types';
+import type { CoreDataError, TaxonomyFormData } from '../types';
+
+function getSuccessMessage( count: number, nextStatus: 'publish' | 'draft' ) {
+	if ( count === 1 ) {
+		return nextStatus === 'publish'
+			? __( 'Taxonomy activated.' )
+			: __( 'Taxonomy deactivated.' );
+	}
+	if ( nextStatus === 'publish' ) {
+		return sprintf(
+			/* translators: %d: The number of taxonomies. */
+			_n( '%d taxonomy activated.', '%d taxonomies activated.', count ),
+			count
+		);
+	}
+	return sprintf(
+		/* translators: %d: The number of taxonomies. */
+		_n( '%d taxonomy deactivated.', '%d taxonomies deactivated.', count ),
+		count
+	);
+}
 
 const toggleActiveAction: Action< TaxonomyFormData > = {
 	id: 'toggle-active',
@@ -17,6 +37,7 @@ const toggleActiveAction: Action< TaxonomyFormData > = {
 		items.every( ( i ) => i.status === 'publish' )
 			? __( 'Deactivate' )
 			: __( 'Activate' ),
+	supportsBulk: true,
 	async callback( items, { registry } ) {
 		const { saveEntityRecord } = registry.dispatch( coreStore );
 		const { createSuccessNotice, createErrorNotice } =
@@ -24,31 +45,73 @@ const toggleActiveAction: Action< TaxonomyFormData > = {
 		const nextStatus = items.every( ( i ) => i.status === 'publish' )
 			? 'draft'
 			: 'publish';
-		try {
-			for ( const item of items ) {
-				if ( item.id === undefined ) {
-					continue;
-				}
-				await saveEntityRecord(
+		const itemsToUpdate = items.filter( ( item ) => item.id !== undefined );
+		const promiseResult = await Promise.allSettled(
+			itemsToUpdate.map( ( item ) =>
+				saveEntityRecord(
 					'postType',
 					'wp_user_taxonomy',
 					{ id: item.id, status: nextStatus },
 					{ throwOnError: true }
-				);
-			}
+				)
+			)
+		);
+		if ( promiseResult.every( ( { status } ) => status === 'fulfilled' ) ) {
 			createSuccessNotice(
-				nextStatus === 'publish'
-					? __( 'Taxonomy activated.' )
-					: __( 'Taxonomy deactivated.' ),
+				getSuccessMessage( itemsToUpdate.length, nextStatus ),
 				{ type: 'snackbar' }
 			);
-		} catch ( error: any ) {
-			createErrorNotice(
-				error?.message && error?.code !== 'unknown_error'
-					? error.message
-					: __( 'Failed to update taxonomy status.' ),
-				{ type: 'snackbar' }
-			);
+		} else {
+			let errorMessage;
+			if ( promiseResult.length === 1 ) {
+				const typedError = promiseResult[ 0 ] as {
+					reason?: CoreDataError;
+				};
+				if (
+					typedError.reason?.message &&
+					typedError.reason.code !== 'unknown_error'
+				) {
+					errorMessage = typedError.reason.message;
+				} else {
+					errorMessage = __( 'Failed to update taxonomy status.' );
+				}
+			} else {
+				const errorMessages = new Set< string >();
+				const failedPromises = promiseResult.filter(
+					( { status } ) => status === 'rejected'
+				);
+				for ( const failedPromise of failedPromises ) {
+					const typedError = failedPromise as {
+						reason?: CoreDataError;
+					};
+					if (
+						typedError.reason?.message &&
+						typedError.reason.code !== 'unknown_error'
+					) {
+						errorMessages.add( typedError.reason.message );
+					}
+				}
+				if ( errorMessages.size === 0 ) {
+					errorMessage = __( 'Failed to update taxonomies status.' );
+				} else if ( errorMessages.size === 1 ) {
+					errorMessage = sprintf(
+						/* translators: %s: an error message */
+						__(
+							'An error occurred while updating the taxonomy status: %s'
+						),
+						[ ...errorMessages ][ 0 ]
+					);
+				} else {
+					errorMessage = sprintf(
+						/* translators: %s: a list of comma separated error messages */
+						__(
+							'Some errors occurred while updating the taxonomies status: %s'
+						),
+						[ ...errorMessages ].join( ',' )
+					);
+				}
+			}
+			createErrorNotice( errorMessage, { type: 'snackbar' } );
 		}
 	},
 };

--- a/routes/taxonomies/actions/utils.ts
+++ b/routes/taxonomies/actions/utils.ts
@@ -1,0 +1,114 @@
+/**
+ * WordPress dependencies
+ */
+import { store as coreStore } from '@wordpress/core-data';
+import type { Action } from '@wordpress/dataviews';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import type { CoreDataError, TaxonomyFormData } from '../types';
+
+type Status = TaxonomyFormData[ 'status' ];
+
+export interface StatusActionConfig {
+	id: string;
+	label: string;
+	targetStatus: Status;
+	messages: {
+		successSingle: string;
+		successMany: ( count: number ) => string;
+		failSingle: string;
+		failMany: string;
+		errorSingle: ( message: string ) => string;
+		errorMany: ( messages: string ) => string;
+	};
+}
+
+export function createStatusAction(
+	config: StatusActionConfig
+): Action< TaxonomyFormData > {
+	const isEligible = ( item: TaxonomyFormData ) =>
+		item.status !== config.targetStatus;
+	return {
+		id: config.id,
+		label: config.label,
+		supportsBulk: true,
+		isEligible,
+		async callback( items, { registry } ) {
+			const itemsToUpdate = items.filter(
+				( item ) => item.id !== undefined && isEligible( item )
+			);
+			if ( itemsToUpdate.length === 0 ) {
+				return;
+			}
+			const { saveEntityRecord } = registry.dispatch( coreStore );
+			const { createSuccessNotice, createErrorNotice } =
+				registry.dispatch( noticesStore );
+			const promiseResult = await Promise.allSettled(
+				itemsToUpdate.map( ( item ) =>
+					saveEntityRecord(
+						'postType',
+						'wp_user_taxonomy',
+						{ id: item.id, status: config.targetStatus },
+						{ throwOnError: true }
+					)
+				)
+			);
+			if (
+				promiseResult.every( ( { status } ) => status === 'fulfilled' )
+			) {
+				createSuccessNotice(
+					itemsToUpdate.length === 1
+						? config.messages.successSingle
+						: config.messages.successMany( itemsToUpdate.length ),
+					{ type: 'snackbar' }
+				);
+				return;
+			}
+			let errorMessage;
+			if ( promiseResult.length === 1 ) {
+				const typedError = promiseResult[ 0 ] as {
+					reason?: CoreDataError;
+				};
+				if (
+					typedError.reason?.message &&
+					typedError.reason.code !== 'unknown_error'
+				) {
+					errorMessage = typedError.reason.message;
+				} else {
+					errorMessage = config.messages.failSingle;
+				}
+			} else {
+				const errorMessages = new Set< string >();
+				const failedPromises = promiseResult.filter(
+					( { status } ) => status === 'rejected'
+				);
+				for ( const failedPromise of failedPromises ) {
+					const typedError = failedPromise as {
+						reason?: CoreDataError;
+					};
+					if (
+						typedError.reason?.message &&
+						typedError.reason.code !== 'unknown_error'
+					) {
+						errorMessages.add( typedError.reason.message );
+					}
+				}
+				if ( errorMessages.size === 0 ) {
+					errorMessage = config.messages.failMany;
+				} else if ( errorMessages.size === 1 ) {
+					errorMessage = config.messages.errorSingle(
+						[ ...errorMessages ][ 0 ]
+					);
+				} else {
+					errorMessage = config.messages.errorMany(
+						[ ...errorMessages ].join( ',' )
+					);
+				}
+			}
+			createErrorNotice( errorMessage, { type: 'snackbar' } );
+		},
+	};
+}

--- a/routes/taxonomies/actions/utils.ts
+++ b/routes/taxonomies/actions/utils.ts
@@ -37,9 +37,7 @@ export function createStatusAction(
 		supportsBulk: true,
 		isEligible,
 		async callback( items, { registry } ) {
-			const itemsToUpdate = items.filter(
-				( item ) => item.id !== undefined && isEligible( item )
-			);
+			const itemsToUpdate = items.filter( isEligible );
 			if ( itemsToUpdate.length === 0 ) {
 				return;
 			}

--- a/routes/taxonomies/stage.tsx
+++ b/routes/taxonomies/stage.tsx
@@ -12,9 +12,10 @@ import { __ } from '@wordpress/i18n';
  */
 import AddTaxonomy from './add-taxonomy';
 import {
+	activateAction,
+	deactivateAction,
 	deleteTaxonomyAction,
 	editTaxonomyAction,
-	toggleActiveAction,
 } from './actions';
 import {
 	titleField,
@@ -44,7 +45,12 @@ const DEFAULT_VIEW: View = {
 function TaxonomiesPage() {
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const taxonomyActions = useMemo(
-		() => [ editTaxonomyAction, toggleActiveAction, deleteTaxonomyAction ],
+		() => [
+			editTaxonomyAction,
+			activateAction,
+			deactivateAction,
+			deleteTaxonomyAction,
+		],
 		[]
 	);
 	const slugField = useSlugField();


### PR DESCRIPTION
## What?

Follow-up to https://github.com/WordPress/gutenberg/pull/77497. Part of https://github.com/WordPress/gutenberg/issues/77600.

## Why?
To allow bulk activation/deactivation of taxonomies.

## How?
  - Enables bulk activate/deactivate on the taxonomies
  - Swaps the sequential `for…of + await` loop for `Promise.allSettled`, so a single failure no longer aborts the rest of the
  batch and updates run in parallel.
  - Aligns success/error notices with how we do it in the delete action.

## Testing Instructions
* Enable the manage taxonomies experiment
* Go to Settings > Taxonomies
* Insert a few taxonomies
* Select multiple taxonomies.
* Bulk activate/deactivate them from the footer
* Verify bulk activation/deactivation works correctly. 

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

<img width="351" height="47" alt="Screenshot 2026-04-24 at 1 04 04" src="https://github.com/user-attachments/assets/e3845046-b723-4240-9751-9e3d3d233898" />


## Use of AI Tools

Opus 4.7
