### PR TITLE
Command Palette: Fix macOs label for sites unable to determine UA via PHP

### DIFF
--- a/backport-changelog/7.0/11636.md
+++ b/backport-changelog/7.0/11636.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11636
+
+* https://github.com/WordPress/gutenberg/pull/77638

--- a/lib/compat/wordpress-7.0/command-palette.php
+++ b/lib/compat/wordpress-7.0/command-palette.php
@@ -79,3 +79,31 @@ CSS;
 	wp_add_inline_style( 'admin-bar', $css );
 }
 add_action( 'admin_bar_init', 'gutenberg_add_admin_bar_styles' );
+
+function gutenberg_add_admin_bar_script() {
+	if ( ! is_admin_bar_showing() ) {
+		return;
+	}
+	$labels = array(
+		'appleOS' => _x( '⌘K', 'keyboard shortcut to open the command palette' ),
+		'default' => _x( 'Ctrl+K', 'keyboard shortcut to open the command palette' ),
+	);
+	$script = <<<JS
+		(( shortCutLabels ) => {
+			let userAgent = '';
+			// Assigning agent may error if the HTTP header is blocked at the browser level.
+			try {
+				userAgent = navigator.userAgent;
+			} catch (error) {}
+			const isAppleOS = /Macintosh|Mac OS X|Mac_PowerPC/i.test( userAgent );
+			const shortcutLabel = isAppleOS ? shortCutLabels.appleOS : shortCutLabels.default;
+			const commandPaletteNode = document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' );
+			if ( commandPaletteNode ) {
+				commandPaletteNode.textContent = shortcutLabel;
+			}
+		})
+JS;
+	$script .= '(' . wp_json_encode( $labels ) . ');';
+	wp_add_inline_script( 'admin-bar', $script );
+}
+add_action( 'admin_bar_init', 'gutenberg_add_admin_bar_script' );

--- a/lib/compat/wordpress-7.0/command-palette.php
+++ b/lib/compat/wordpress-7.0/command-palette.php
@@ -88,7 +88,7 @@ function gutenberg_add_admin_bar_script() {
 		'appleOS' => _x( '⌘K', 'keyboard shortcut to open the command palette' ),
 		'default' => _x( 'Ctrl+K', 'keyboard shortcut to open the command palette' ),
 	);
-	$script  = <<<JS
+	$script  = <<<'JS'
 		(( shortCutLabels ) => {
 			let userAgent = '';
 			// Assigning agent may error if the HTTP header is blocked at the browser level.
@@ -105,7 +105,7 @@ function gutenberg_add_admin_bar_script() {
 				commandPaletteNode.textContent = shortcutLabel;
 			}
 		})
-JS;
+	JS;
 	$script .= '(' . wp_json_encode( $labels ) . ');';
 	wp_add_inline_script( 'admin-bar', $script );
 }

--- a/lib/compat/wordpress-7.0/command-palette.php
+++ b/lib/compat/wordpress-7.0/command-palette.php
@@ -9,16 +9,38 @@ function gutenberg_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ):
 		return;
 	}
 
-	$is_apple_os    = (bool) preg_match( '/Macintosh|Mac OS X|Mac_PowerPC/i', $_SERVER['HTTP_USER_AGENT'] ?? '' );
-	$shortcut_label = $is_apple_os
-		? _x( '⌘K', 'keyboard shortcut to open the command palette' )
-		: _x( 'Ctrl+K', 'keyboard shortcut to open the command palette' );
-	$title          = sprintf(
+	$shortcut_labels = array(
+		'appleOS' => _x( '⌘K', 'keyboard shortcut to open the command palette' ),
+		'default' => _x( 'Ctrl+K', 'keyboard shortcut to open the command palette' ),
+	);
+	$is_apple_os     = (bool) preg_match( '/Macintosh|Mac OS X|Mac_PowerPC/i', $_SERVER['HTTP_USER_AGENT'] ?? '' );
+	$shortcut_label  = $is_apple_os ? $shortcut_labels['appleOS'] : $shortcut_labels['default'];
+	$title           = sprintf(
 		'<span class="ab-icon" aria-hidden="true"></span><span class="ab-label"><kbd>%s</kbd><span class="screen-reader-text"> %s</span></span>',
 		$shortcut_label,
 		/* translators: Hidden accessibility text. */
 		__( 'Open command palette' ),
 	);
+
+	/*
+	 * Detect Apple OS via JavaScript for users behind a CDN blocking the UA header.
+	 *
+	 * Running the script as the admin bar is rendered avoids a flash of incorrect content
+	 * for users with Apple OS when the UA header is blocked. It also prevents the need for
+	 * wp-i18n to be loaded as a dependency as it is most likely not included on the front
+	 * end of a site.
+	 */
+	$script  = <<<'JS'
+		(( shortcutLabels ) => {
+			const isAppleOS = navigator.platform.startsWith("Mac") || navigator.platform === "iPhone" || navigator.platform === "iPad";
+			if ( ! isAppleOS ) {
+				return;
+			}
+			document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' ).textContent = shortcutLabels.appleOS;
+		})
+	JS;
+	$script .= '(' . wp_json_encode( $shortcut_labels, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ');';
+	$script .= "\n//# sourceURL=gutenberg_admin_bar_command_palette_menu";
 	$wp_admin_bar->add_node(
 		array(
 			'id'    => 'command-palette',
@@ -27,6 +49,7 @@ function gutenberg_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ):
 			'meta'  => array(
 				'class'   => 'hide-if-no-js',
 				'onclick' => 'wp.data.dispatch( "core/commands" ).open(); return false;',
+				'html'    => "<script>{$script}</script>",
 			),
 		)
 	);
@@ -79,34 +102,3 @@ CSS;
 	wp_add_inline_style( 'admin-bar', $css );
 }
 add_action( 'admin_bar_init', 'gutenberg_add_admin_bar_styles' );
-
-function gutenberg_add_admin_bar_script() {
-	if ( ! is_admin_bar_showing() ) {
-		return;
-	}
-	$labels  = array(
-		'appleOS' => _x( '⌘K', 'keyboard shortcut to open the command palette' ),
-		'default' => _x( 'Ctrl+K', 'keyboard shortcut to open the command palette' ),
-	);
-	$script  = <<<'JS'
-		(( shortcutLabels ) => {
-			let userAgent = '';
-			// Assigning agent may error if the HTTP header is blocked at the browser level.
-			try {
-				userAgent = navigator.userAgent;
-			} catch (error) {
-				// Make no change to the default shortcut label.
-				return;
-			}
-			const isAppleOS = /Macintosh|Mac OS X|Mac_PowerPC/i.test( userAgent );
-			const shortcutLabel = isAppleOS ? shortcutLabels.appleOS : shortcutLabels.default;
-			const commandPaletteNode = document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' );
-			if ( commandPaletteNode ) {
-				commandPaletteNode.textContent = shortcutLabel;
-			}
-		})
-	JS;
-	$script .= '(' . wp_json_encode( $labels ) . ');';
-	wp_add_inline_script( 'admin-bar', $script );
-}
-add_action( 'admin_bar_init', 'gutenberg_add_admin_bar_script' );

--- a/lib/compat/wordpress-7.0/command-palette.php
+++ b/lib/compat/wordpress-7.0/command-palette.php
@@ -27,20 +27,21 @@ function gutenberg_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ):
 	 *
 	 * Running the script as the admin bar is rendered avoids a flash of incorrect content
 	 * for users with Apple OS when the UA header is blocked. It also prevents the need for
-	 * wp-i18n to be loaded as a dependency as it is most likely not included on the front
-	 * end of a site.
+	 * wp-i18n to be loaded as a dependency.
 	 */
 	$function = <<<'JS'
-		( shortcutLabels ) => {
-			const isAppleOS = navigator.platform.startsWith("Mac") || navigator.platform === "iPhone" || navigator.platform === "iPad";
-			if ( ! isAppleOS ) {
-				return;
+		( appleOSLabel ) => {
+			if ( navigator.platform.startsWith("Mac") || navigator.platform === "iPhone" || navigator.platform === "iPad" ) {
+				document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' ).textContent = appleOSLabel;
 			}
-			document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' ).textContent = shortcutLabels.appleOS;
 		}
 	JS;
-	$script   = sprintf( '( %s )( %s );', $function, wp_json_encode( $shortcut_labels, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) );
-	$script  .= "\n//# sourceURL=gutenberg_admin_bar_command_palette_menu";
+	$script   = sprintf(
+		'( %s )( %s );',
+		$function,
+		wp_json_encode( $shortcut_labels['appleOS'], JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+	);
+	$script  .= "\n//# sourceURL=" . rawurlencode( __FUNCTION__ );
 	$wp_admin_bar->add_node(
 		array(
 			'id'    => 'command-palette',
@@ -49,7 +50,7 @@ function gutenberg_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ):
 			'meta'  => array(
 				'class'   => 'hide-if-no-js',
 				'onclick' => 'wp.data.dispatch( "core/commands" ).open(); return false;',
-				'html'    => "<script>{$script}</script>",
+				'html'    => wp_get_inline_script_tag( $script ),
 			),
 		)
 	);

--- a/lib/compat/wordpress-7.0/command-palette.php
+++ b/lib/compat/wordpress-7.0/command-palette.php
@@ -30,17 +30,17 @@ function gutenberg_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ):
 	 * wp-i18n to be loaded as a dependency as it is most likely not included on the front
 	 * end of a site.
 	 */
-	$script  = <<<'JS'
-		(( shortcutLabels ) => {
+	$function = <<<'JS'
+		( shortcutLabels ) => {
 			const isAppleOS = navigator.platform.startsWith("Mac") || navigator.platform === "iPhone" || navigator.platform === "iPad";
 			if ( ! isAppleOS ) {
 				return;
 			}
 			document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' ).textContent = shortcutLabels.appleOS;
-		})
+		}
 	JS;
-	$script .= '(' . wp_json_encode( $shortcut_labels, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ');';
-	$script .= "\n//# sourceURL=gutenberg_admin_bar_command_palette_menu";
+	$script   = sprintf( '( %s )( %s );', $function, wp_json_encode( $shortcut_labels, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) );
+	$script  .= "\n//# sourceURL=gutenberg_admin_bar_command_palette_menu";
 	$wp_admin_bar->add_node(
 		array(
 			'id'    => 'command-palette',

--- a/lib/compat/wordpress-7.0/command-palette.php
+++ b/lib/compat/wordpress-7.0/command-palette.php
@@ -23,7 +23,7 @@ function gutenberg_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ):
 	);
 
 	/*
-	 * Detect Apple OS via JavaScript for users behind a CDN blocking the UA header.
+	 * Detect Apple OS via JavaScript for sites behind a CDN blocking the UA header.
 	 *
 	 * Running the script as the admin bar is rendered avoids a flash of incorrect content
 	 * for users with Apple OS when the UA header is blocked. It also prevents the need for

--- a/lib/compat/wordpress-7.0/command-palette.php
+++ b/lib/compat/wordpress-7.0/command-palette.php
@@ -84,11 +84,11 @@ function gutenberg_add_admin_bar_script() {
 	if ( ! is_admin_bar_showing() ) {
 		return;
 	}
-	$labels = array(
+	$labels  = array(
 		'appleOS' => _x( '⌘K', 'keyboard shortcut to open the command palette' ),
 		'default' => _x( 'Ctrl+K', 'keyboard shortcut to open the command palette' ),
 	);
-	$script = <<<JS
+	$script  = <<<JS
 		(( shortCutLabels ) => {
 			let userAgent = '';
 			// Assigning agent may error if the HTTP header is blocked at the browser level.

--- a/lib/compat/wordpress-7.0/command-palette.php
+++ b/lib/compat/wordpress-7.0/command-palette.php
@@ -94,7 +94,10 @@ function gutenberg_add_admin_bar_script() {
 			// Assigning agent may error if the HTTP header is blocked at the browser level.
 			try {
 				userAgent = navigator.userAgent;
-			} catch (error) {}
+			} catch (error) {
+				// Make no change to the default shortcut label.
+				return;
+			}
 			const isAppleOS = /Macintosh|Mac OS X|Mac_PowerPC/i.test( userAgent );
 			const shortcutLabel = isAppleOS ? shortCutLabels.appleOS : shortCutLabels.default;
 			const commandPaletteNode = document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' );

--- a/lib/compat/wordpress-7.0/command-palette.php
+++ b/lib/compat/wordpress-7.0/command-palette.php
@@ -89,7 +89,7 @@ function gutenberg_add_admin_bar_script() {
 		'default' => _x( 'Ctrl+K', 'keyboard shortcut to open the command palette' ),
 	);
 	$script  = <<<'JS'
-		(( shortCutLabels ) => {
+		(( shortcutLabels ) => {
 			let userAgent = '';
 			// Assigning agent may error if the HTTP header is blocked at the browser level.
 			try {
@@ -99,7 +99,7 @@ function gutenberg_add_admin_bar_script() {
 				return;
 			}
 			const isAppleOS = /Macintosh|Mac OS X|Mac_PowerPC/i.test( userAgent );
-			const shortcutLabel = isAppleOS ? shortCutLabels.appleOS : shortCutLabels.default;
+			const shortcutLabel = isAppleOS ? shortcutLabels.appleOS : shortcutLabels.default;
 			const commandPaletteNode = document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' );
 			if ( commandPaletteNode ) {
 				commandPaletteNode.textContent = shortcutLabel;

--- a/lib/compat/wordpress-7.0/command-palette.php
+++ b/lib/compat/wordpress-7.0/command-palette.php
@@ -13,7 +13,8 @@ function gutenberg_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ):
 		'appleOS' => _x( '⌘K', 'keyboard shortcut to open the command palette' ),
 		'default' => _x( 'Ctrl+K', 'keyboard shortcut to open the command palette' ),
 	);
-	$is_apple_os     = (bool) preg_match( '/Macintosh|Mac OS X|Mac_PowerPC/i', $_SERVER['HTTP_USER_AGENT'] ?? '' );
+	$apple_pattern   = 'Macintosh|Mac OS X|Mac_PowerPC';
+	$is_apple_os     = (bool) preg_match( "/{$apple_pattern}/i", $_SERVER['HTTP_USER_AGENT'] ?? '' );
 	$shortcut_label  = $is_apple_os ? $shortcut_labels['appleOS'] : $shortcut_labels['default'];
 	$title           = sprintf(
 		'<span class="ab-icon" aria-hidden="true"></span><span class="ab-label"><kbd>%s</kbd><span class="screen-reader-text"> %s</span></span>',
@@ -30,15 +31,16 @@ function gutenberg_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ):
 	 * wp-i18n to be loaded as a dependency.
 	 */
 	$function = <<<'JS'
-		( appleOSLabel ) => {
-			if ( navigator.platform.startsWith("Mac") || navigator.platform === "iPhone" || navigator.platform === "iPad" ) {
+		( applePattern, appleOSLabel ) => {
+			if ( ( new RegExp( applePattern ) ).test( navigator.userAgent ) ) {
 				document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' ).textContent = appleOSLabel;
 			}
 		}
 	JS;
 	$script   = sprintf(
-		'( %s )( %s );',
+		'( %s )( %s, %s );',
 		$function,
+		wp_json_encode( $apple_pattern, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 		wp_json_encode( $shortcut_labels['appleOS'], JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 	);
 	$script  .= "\n//# sourceURL=" . rawurlencode( __FUNCTION__ );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds a JavaScript check of the User-Agent for displaying the text in the admin bar.

Closes #77636.
See Core-65121

## Why?

On sites served over a CDN is it relatively common for the CDN to strip the `User-Agent` HTTP header, on macOS systems this causes the incorrect label to be displayed.

## How?

Adds a JavaScript fallback to test the UA and determine the best label to use.

## Testing Instructions
1. Buy a macOS computer/use BrowserStack on macOS.
2. In your `wp-config.php` file, add the code `$_SERVER['HTTP_USER_AGENT'] = '';` to emulate a site behind a CDN stripping the header
3. Visit `/wp-admin`
4. Ensure the label is correct on this branch.
5. Ensure the label is incorrect on trunk
6. Remove the code added to the wp-config file to avoid confusion later.


### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="1006" height="414" alt="Screenshot 2026-04-24 at 11 26 31 am" src="https://github.com/user-attachments/assets/147bda79-39e0-4ff9-8356-9ed77d4612bc" />|<img width="1080" height="399" alt="Screenshot 2026-04-24 at 11 25 14 am" src="https://github.com/user-attachments/assets/fdde0ca0-6943-4dd5-ad8e-3ac19d1523d5" />|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

N/A