### PR TITLE
Experimental Image Cropper: Tweak the keyboard interactions with drag handles and canvas

### DIFF
--- a/packages/media-editor/src/image-editor/core/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/interaction-controller.ts
@@ -883,6 +883,9 @@ export class InteractionController {
 			}
 			case 'r':
 			case 'R': {
+				if ( e.metaKey || e.ctrlKey || e.altKey || e.shiftKey ) {
+					break;
+				}
 				e.preventDefault();
 				this.options.dispatch( {
 					type: 'SNAP_ROTATE_90',

--- a/packages/media-editor/src/image-editor/core/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/interaction-controller.ts
@@ -786,7 +786,7 @@ export class InteractionController {
 						...currentState,
 						pan: {
 							x: currentState.pan.x,
-							y: currentState.pan.y - this.keyboardStep,
+							y: currentState.pan.y + this.keyboardStep,
 						},
 					},
 					getImageSizeFromState( currentState ),
@@ -805,7 +805,7 @@ export class InteractionController {
 						...currentState,
 						pan: {
 							x: currentState.pan.x,
-							y: currentState.pan.y + this.keyboardStep,
+							y: currentState.pan.y - this.keyboardStep,
 						},
 					},
 					getImageSizeFromState( currentState ),
@@ -823,7 +823,7 @@ export class InteractionController {
 					{
 						...currentState,
 						pan: {
-							x: currentState.pan.x - this.keyboardStep,
+							x: currentState.pan.x + this.keyboardStep,
 							y: currentState.pan.y,
 						},
 					},
@@ -842,7 +842,7 @@ export class InteractionController {
 					{
 						...currentState,
 						pan: {
-							x: currentState.pan.x + this.keyboardStep,
+							x: currentState.pan.x - this.keyboardStep,
 							y: currentState.pan.y,
 						},
 					},

--- a/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
@@ -520,10 +520,10 @@ describe( 'InteractionController', () => {
 			const call = dispatchMock.mock.calls.find(
 				( c ) => c[ 0 ].type === 'SET_PAN'
 			);
-			// ArrowUp decreases y by keyboardStep (0.05 default).
+			// ArrowUp scrolls the viewport up — image moves down, so y increases.
 			expect(
 				( call![ 0 ].payload as { y: number } ).y
-			).toBeLessThanOrEqual( 0 );
+			).toBeGreaterThanOrEqual( 0 );
 		} );
 
 		it( 'dispatches SET_CROP on ArrowDown', () => {
@@ -550,10 +550,10 @@ describe( 'InteractionController', () => {
 			const call = dispatchMock.mock.calls.find(
 				( c ) => c[ 0 ].type === 'SET_PAN'
 			);
-			// ArrowLeft decreases x by keyboardStep.
+			// ArrowLeft scrolls the viewport left — image moves right, so x increases.
 			expect(
 				( call![ 0 ].payload as { x: number } ).x
-			).toBeLessThanOrEqual( 0 );
+			).toBeGreaterThanOrEqual( 0 );
 		} );
 
 		it( 'dispatches SET_CROP on ArrowRight', () => {
@@ -635,10 +635,10 @@ describe( 'InteractionController', () => {
 			const call = dispatchMock.mock.calls.find(
 				( c ) => c[ 0 ].type === 'SET_PAN'
 			);
-			// At zoom=2 with full crop rect, maxX = 0.25.
-			// 0 + 0.1 = 0.1, within bounds.
+			// ArrowRight scrolls the viewport right — image moves left, so x decreases.
+			// 0 - 0.1 = -0.1, within bounds.
 			expect( ( call![ 0 ].payload as { x: number } ).x ).toBeCloseTo(
-				0.1
+				-0.1
 			);
 		} );
 

--- a/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
@@ -621,6 +621,20 @@ describe( 'InteractionController', () => {
 			} );
 		} );
 
+		it.each( [ 'metaKey', 'ctrlKey', 'altKey', 'shiftKey' ] )(
+			'does not rotate when %s is held with r',
+			( modifier ) => {
+				const state = makeState( { rotation: 0 } );
+				const { controller } = createController( state );
+
+				controller.handleKeyDown(
+					createKeyboardEvent( 'r', { [ modifier ]: true } )
+				);
+
+				expect( dispatchMock ).not.toHaveBeenCalled();
+			}
+		);
+
 		it( 'respects custom keyboardStep (read lazily)', () => {
 			const state = makeState( { zoom: 2 } );
 			const { controller, opts } = createController( state, {

--- a/packages/media-editor/src/image-editor/core/types.ts
+++ b/packages/media-editor/src/image-editor/core/types.ts
@@ -168,4 +168,6 @@ export interface StencilProps {
 		maxX: number;
 		maxY: number;
 	};
+	/** Called when Escape is pressed on a resize handle. */
+	onEscape?: () => void;
 }

--- a/packages/media-editor/src/image-editor/react/components/cropper.scss
+++ b/packages/media-editor/src/image-editor/react/components/cropper.scss
@@ -87,7 +87,7 @@ $handle-touch-target-size: 44px;
 	&__handle {
 		// Reset native <button> UA styles — the handle is a button for
 		// accessibility (native keyboard focus, button semantics), but
-		// it's styled as a small draggable square.
+		// it's styled as a small draggable circle.
 		appearance: none;
 		margin: 0;
 		padding: 0;
@@ -99,8 +99,22 @@ $handle-touch-target-size: 44px;
 		height: 12px;
 		background: rgba(255, 255, 255, 0.6);
 		border: 1px solid rgba(255, 255, 255, 0.9);
+		border-radius: 50%;
 		box-sizing: border-box;
 		pointer-events: auto;
+		transition: background-color 0.15s ease, box-shadow 0.15s ease;
+
+		&:focus {
+			outline: none;
+		}
+
+		// Double ring (white inner + theme-color outer) for legibility
+		// over the dark dimming overlay.
+		&:focus-visible {
+			background: var(--wp-admin-theme-color, #007cba);
+			border-color: transparent;
+			box-shadow: 0 0 0 2px #fff, 0 0 0 4px var(--wp-admin-theme-color, #007cba);
+		}
 
 		// Extend touch target to the minimum accessible hit area.
 		&::before {

--- a/packages/media-editor/src/image-editor/react/components/cropper.scss
+++ b/packages/media-editor/src/image-editor/react/components/cropper.scss
@@ -111,9 +111,9 @@ $handle-touch-target-size: 44px;
 		// Double ring (white inner + theme-color outer) for legibility
 		// over the dark dimming overlay.
 		&:focus-visible {
-			background: var(--wp-admin-theme-color, #007cba);
+			background: var(--wp-image-editor-focus-color, var(--wp-admin-theme-color, #007cba));
 			border-color: transparent;
-			box-shadow: 0 0 0 2px #fff, 0 0 0 4px var(--wp-admin-theme-color, #007cba);
+			box-shadow: 0 0 0 2px #fff, 0 0 0 4px var(--wp-image-editor-focus-color, var(--wp-admin-theme-color, #007cba));
 		}
 
 		// Extend touch target to the minimum accessible hit area.

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -358,6 +358,14 @@ function CropperInner(
 	}, [] );
 
 	/**
+	 * Handle Escape on a resize handle — return focus to the canvas so
+	 * arrow keys pan the image rather than resize.
+	 */
+	const handleEscape = useCallback( () => {
+		canvasRef.current?.focus( { preventScroll: true } );
+	}, [] );
+
+	/**
 	 * Handle resize end — settle the crop rect (re-center, fill height).
 	 */
 	const handleResizeEnd = useCallback( () => {
@@ -465,6 +473,7 @@ function CropperInner(
 					onCropChange={ handleCropChange }
 					onResizeStart={ onGestureStart }
 					onResizeEnd={ handleResizeEnd }
+					onEscape={ handleEscape }
 					aspectRatio={ aspectRatio }
 					freeformCrop={ freeformCrop }
 					stencilTransition={ settleStencilTransition }

--- a/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
@@ -18,21 +18,23 @@ import {
 
 /**
  * Corner handle positions only — used when aspect ratio is locked.
+ * Ordered clockwise from top-left for logical tab order.
  */
-const CORNER_POSITIONS: HandlePosition[] = [ 'nw', 'ne', 'sw', 'se' ];
+const CORNER_POSITIONS: HandlePosition[] = [ 'nw', 'ne', 'se', 'sw' ];
 
 /**
  * All handle positions rendered by the stencil.
+ * Ordered clockwise from top-left for logical tab order.
  */
 const ALL_POSITIONS: HandlePosition[] = [
-	'n',
-	's',
-	'e',
-	'w',
 	'nw',
+	'n',
 	'ne',
-	'sw',
+	'e',
 	'se',
+	's',
+	'sw',
+	'w',
 ];
 
 /**
@@ -62,10 +64,11 @@ function getHandleLabel( pos: HandlePosition ): string {
 	}
 }
 
-/**
- * Step size for keyboard-driven handle resize, in normalized coordinates.
- */
-const KEYBOARD_STEP = 0.02;
+/** Fine step for keyboard-driven handle resize, in normalized coordinates. */
+const KEYBOARD_STEP = 0.01;
+
+/** Coarse step when Shift is held — 10× the fine step. */
+const KEYBOARD_STEP_SHIFT = 0.1;
 
 /** Delay before keyboard resize triggers settle (ms). */
 const KEYBOARD_SETTLE_DELAY = 500;
@@ -93,6 +96,7 @@ type RectangleStencilProps = StencilProps;
  * @param props.freeformCrop      Whether resize handles are shown.
  * @param props.stencilTransition CSS transition string for settle animation.
  * @param props.cropBounds        Maximum crop rect bounds from camera (zoom/rotation-aware).
+ * @param props.onEscape          Called when Escape is pressed on a resize handle.
  * @return The rectangle stencil element.
  */
 export function RectangleStencil( {
@@ -106,6 +110,7 @@ export function RectangleStencil( {
 	freeformCrop = false,
 	stencilTransition,
 	cropBounds,
+	onEscape,
 }: RectangleStencilProps ) {
 	// Use cropBounds from the camera if available, otherwise default to [0,1].
 	const boundsMinX = cropBounds?.minX ?? 0;
@@ -192,7 +197,7 @@ export function RectangleStencil( {
 				ownerDoc.activeElement.blur();
 			}
 			// Capture pointer so drag works across iframe boundaries.
-			const el = event.currentTarget;
+			const el = event.currentTarget as HTMLButtonElement;
 			el.setPointerCapture( event.pointerId );
 
 			const drag: ResizeDragState = {
@@ -247,6 +252,11 @@ export function RectangleStencil( {
 				el.removeEventListener( 'pointerup', onEnd );
 				el.removeEventListener( 'lostpointercapture', onEnd );
 				latestHandlersRef.current?.onResizeEnd?.();
+				// Restore focus to the handle so arrow keys work
+				// immediately after a mouse drag. Browsers suppress
+				// :focus-visible after pointer interactions, so the
+				// focus ring stays hidden until the user presses a key.
+				el.focus( { preventScroll: true } );
 			};
 
 			el.addEventListener( 'pointermove', onMove );
@@ -302,12 +312,21 @@ export function RectangleStencil( {
 	};
 
 	/**
-	 * Handle keyboard arrow keys on a resize handle.
-	 * Moves the corresponding edge(s) by KEYBOARD_STEP in normalized space.
+	 * Handle keyboard events on a resize handle.
+	 * Arrow keys resize; Escape returns focus to the canvas.
+	 * Shift multiplies the step size by 10 for coarser movement.
 	 */
 	const handleKeyDown = useCallback(
 		( handle: HandlePosition, event: React.KeyboardEvent ) => {
 			const key = event.key;
+
+			if ( key === 'Escape' ) {
+				event.preventDefault();
+				event.stopPropagation();
+				onEscape?.();
+				return;
+			}
+
 			if (
 				key !== 'ArrowUp' &&
 				key !== 'ArrowDown' &&
@@ -320,20 +339,22 @@ export function RectangleStencil( {
 			event.preventDefault();
 			event.stopPropagation();
 
+			const step = event.shiftKey ? KEYBOARD_STEP_SHIFT : KEYBOARD_STEP;
+
 			// Determine the normalized delta from the arrow key.
 			let dx = 0;
 			let dy = 0;
 			if ( key === 'ArrowLeft' ) {
-				dx = -KEYBOARD_STEP;
+				dx = -step;
 			}
 			if ( key === 'ArrowRight' ) {
-				dx = KEYBOARD_STEP;
+				dx = step;
 			}
 			if ( key === 'ArrowUp' ) {
-				dy = -KEYBOARD_STEP;
+				dy = -step;
 			}
 			if ( key === 'ArrowDown' ) {
-				dy = KEYBOARD_STEP;
+				dy = step;
 			}
 
 			if ( hasLockedRatio ) {
@@ -382,6 +403,7 @@ export function RectangleStencil( {
 			computeFreeRect,
 			onCropChange,
 			onResizeEnd,
+			onEscape,
 		]
 	);
 

--- a/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.tsx
@@ -1,0 +1,225 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { RectangleStencil } from '../rectangle-stencil';
+import type { NormalizedRect, Size } from '../../../../core/types';
+
+const DEFAULT_CROP_RECT: NormalizedRect = {
+	x: 0.1,
+	y: 0.1,
+	width: 0.8,
+	height: 0.8,
+};
+const CONTAINER_SIZE: Size = { width: 600, height: 400 };
+const IMAGE_SIZE: Size = { width: 500, height: 300 };
+const CROP_BOUNDS = { minX: 0, minY: 0, maxX: 1, maxY: 1 };
+
+/**
+ * Render a RectangleStencil in freeform mode with sensible defaults.
+ * Returns the mock callbacks; use `screen` for DOM queries.
+ *
+ * @param overrides Props to override on the rendered stencil.
+ */
+function renderStencil(
+	overrides: Partial< React.ComponentProps< typeof RectangleStencil > > = {}
+) {
+	const onCropChange = jest.fn();
+	const onResizeEnd = jest.fn();
+	const onEscape = jest.fn();
+
+	render(
+		<RectangleStencil
+			cropRect={ DEFAULT_CROP_RECT }
+			containerSize={ CONTAINER_SIZE }
+			imageSize={ IMAGE_SIZE }
+			onCropChange={ onCropChange }
+			onResizeEnd={ onResizeEnd }
+			onEscape={ onEscape }
+			freeformCrop
+			cropBounds={ CROP_BOUNDS }
+			{ ...overrides }
+		/>
+	);
+
+	return { onCropChange, onResizeEnd, onEscape };
+}
+
+describe( 'RectangleStencil', () => {
+	// jsdom does not implement PointerEvent or pointer capture — stub both so
+	// handle drag tests work. Same pattern as core/test/interaction-controller.ts.
+	beforeAll( () => {
+		if ( ! HTMLElement.prototype.setPointerCapture ) {
+			HTMLElement.prototype.setPointerCapture = jest.fn();
+		}
+		if ( ! HTMLElement.prototype.releasePointerCapture ) {
+			HTMLElement.prototype.releasePointerCapture = jest.fn();
+		}
+		// Without a PointerEvent constructor, fireEvent.pointerDown falls back to
+		// the base Event class which has no `button` property. The stencil's
+		// handler guards on `event.button !== 0` and returns early, so no native
+		// listeners are ever registered. Providing a minimal stub (extending
+		// MouseEvent so `button` comes from MouseEventInit) fixes this.
+		if ( typeof ( globalThis as any ).PointerEvent === 'undefined' ) {
+			( globalThis as any ).PointerEvent = class PointerEvent extends (
+				MouseEvent
+			) {
+				pointerId: number;
+				constructor( type: string, init: PointerEventInit = {} ) {
+					super( type, init );
+					this.pointerId = init.pointerId ?? 0;
+				}
+			};
+		}
+	} );
+
+	describe( 'tab order', () => {
+		it( 'renders handles clockwise from top-left in freeform mode', () => {
+			renderStencil();
+			const labels = screen
+				.getAllByRole( 'button' )
+				.map( ( b ) => b.getAttribute( 'aria-label' ) );
+
+			expect( labels ).toEqual( [
+				'Resize top-left corner',
+				'Resize top edge',
+				'Resize top-right corner',
+				'Resize right edge',
+				'Resize bottom-right corner',
+				'Resize bottom edge',
+				'Resize bottom-left corner',
+				'Resize left edge',
+			] );
+		} );
+
+		it( 'renders corner handles clockwise from top-left when aspect ratio is locked', () => {
+			renderStencil( { aspectRatio: 16 / 9 } );
+			const labels = screen
+				.getAllByRole( 'button' )
+				.map( ( b ) => b.getAttribute( 'aria-label' ) );
+
+			expect( labels ).toEqual( [
+				'Resize top-left corner',
+				'Resize top-right corner',
+				'Resize bottom-right corner',
+				'Resize bottom-left corner',
+			] );
+		} );
+	} );
+
+	describe( 'keyboard — Escape', () => {
+		it( 'calls onEscape when Escape is pressed on a handle', () => {
+			const { onEscape } = renderStencil();
+			const [ firstHandle ] = screen.getAllByRole( 'button' );
+
+			fireEvent.keyDown( firstHandle, { key: 'Escape' } );
+
+			expect( onEscape ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'does not call onCropChange when Escape is pressed', () => {
+			const { onCropChange } = renderStencil();
+			const [ firstHandle ] = screen.getAllByRole( 'button' );
+
+			fireEvent.keyDown( firstHandle, { key: 'Escape' } );
+
+			expect( onCropChange ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'keyboard — arrow keys (fine step)', () => {
+		it( 'moves the right edge right by KEYBOARD_STEP on ArrowRight (no Shift)', () => {
+			const { onCropChange } = renderStencil();
+			// 'e' handle is the 4th button in clockwise order (nw, n, ne, e).
+			const eHandle = screen.getAllByRole( 'button' )[ 3 ];
+
+			fireEvent.keyDown( eHandle, {
+				key: 'ArrowRight',
+				shiftKey: false,
+			} );
+
+			expect( onCropChange ).toHaveBeenCalledTimes( 1 );
+			const newRect: NormalizedRect = onCropChange.mock.calls[ 0 ][ 0 ];
+			// dx = 0.01, edgeRight = 0.1 + 0.8 + 0.01 = 0.91, width = 0.81.
+			expect( newRect.width ).toBeCloseTo( 0.81, 5 );
+			expect( newRect.x ).toBeCloseTo( 0.1, 5 );
+		} );
+
+		it( 'moves the bottom edge down by KEYBOARD_STEP on ArrowDown (no Shift)', () => {
+			const { onCropChange } = renderStencil();
+			// 's' handle is the 6th button (nw, n, ne, e, se, s).
+			const sHandle = screen.getAllByRole( 'button' )[ 5 ];
+
+			fireEvent.keyDown( sHandle, {
+				key: 'ArrowDown',
+				shiftKey: false,
+			} );
+
+			expect( onCropChange ).toHaveBeenCalledTimes( 1 );
+			const newRect: NormalizedRect = onCropChange.mock.calls[ 0 ][ 0 ];
+			// dy = 0.01, edgeBottom = 0.1 + 0.8 + 0.01 = 0.91, height = 0.81.
+			expect( newRect.height ).toBeCloseTo( 0.81, 5 );
+			expect( newRect.y ).toBeCloseTo( 0.1, 5 );
+		} );
+	} );
+
+	describe( 'keyboard — arrow keys (coarse step with Shift)', () => {
+		it( 'moves the right edge right by KEYBOARD_STEP_SHIFT on Shift+ArrowRight', () => {
+			const { onCropChange } = renderStencil();
+			const eHandle = screen.getAllByRole( 'button' )[ 3 ];
+
+			fireEvent.keyDown( eHandle, { key: 'ArrowRight', shiftKey: true } );
+
+			expect( onCropChange ).toHaveBeenCalledTimes( 1 );
+			const newRect: NormalizedRect = onCropChange.mock.calls[ 0 ][ 0 ];
+			// dx = 0.1, edgeRight = 0.1 + 0.8 + 0.1 = 1.0 (clamped to boundsMaxX=1), width = 0.9.
+			expect( newRect.width ).toBeCloseTo( 0.9, 5 );
+		} );
+
+		it( 'step is 10x larger with Shift than without', () => {
+			const { onCropChange } = renderStencil();
+			const eHandle = screen.getAllByRole( 'button' )[ 3 ];
+
+			fireEvent.keyDown( eHandle, {
+				key: 'ArrowRight',
+				shiftKey: false,
+			} );
+			const fineRect: NormalizedRect = onCropChange.mock.calls[ 0 ][ 0 ];
+			const fineDelta = fineRect.width - DEFAULT_CROP_RECT.width;
+
+			onCropChange.mockClear();
+
+			fireEvent.keyDown( eHandle, { key: 'ArrowRight', shiftKey: true } );
+			const coarseRect: NormalizedRect =
+				onCropChange.mock.calls[ 0 ][ 0 ];
+			const coarseDelta = coarseRect.width - DEFAULT_CROP_RECT.width;
+
+			expect( coarseDelta / fineDelta ).toBeCloseTo( 10, 0 );
+		} );
+	} );
+
+	describe( 'pointer drag — focus after release', () => {
+		it( 'focuses the handle button after a pointer drag ends', () => {
+			renderStencil();
+			const [ firstHandle ] = screen.getAllByRole( 'button' );
+
+			jest.spyOn( firstHandle, 'focus' );
+
+			fireEvent.pointerDown( firstHandle, {
+				button: 0,
+				clientX: 100,
+				clientY: 100,
+				pointerId: 1,
+			} );
+			fireEvent.pointerUp( firstHandle, {
+				pointerId: 1,
+			} );
+
+			expect( firstHandle.focus ).toHaveBeenCalled();
+		} );
+	} );
+} );


### PR DESCRIPTION
## What?

Follows / part of:

* https://github.com/WordPress/gutenberg/pull/77591
* https://github.com/WordPress/gutenberg/issues/73771

Tweak the keyboard interactions for the experimental image cropper in the media editor:

* Re-order the drag handles so that they go clockwise from top-left, to make tabbing feel a bit more natural
* When dragging a drag handle, place focus on the drag handle afterwards so that users can tweak via keyboard immediately
* For keyboard interactions allow a shift modifier to create a 10x jump in movement (this kind of matches behaviour in apps like Photoshop and Affinity), to make it easier to make either small or large adjustments
* Allow the Escape key to go to the canvas
* When using cursor keys on the canvas, invert the directions as when you're using the keyboard it feels more natural (to me at least) for it to be moving the crop area, rather than the image underneath
* For rotation, only allow it when pressing "r" if a modifier key isn't in use, so that we don't block reloading the page
* Visual change: Use circles for the drag handles, and add a focused state that clearly shows what's focused

These are admittedly opinionated changes, but they're weakly held ideas! Based on some chatter with @ramonjd from #77591, and I'm happy to scale this back / split things out if anything feels off.

## Why?

Oftentimes folks might switch between keyboard and mouse while interacting with cropping tools and the overall idea here is to try to make that handoff feel as smooth as possible, while also feeling consistent with some other apps that do cropping.

## How?

* Hopefully self-explanatory, but these are mostly minor code tweaks, re-ordering items, adjusting logic in small places where possible
* The main API change is adding an `onEscape` callback to the stencil so that we can move focus back to the canvas
* An opinionated styling change to the drag handles. Happy to change this if the circles etc look off!

## Testing Instructions

* Activate the media editor modal experiment in Gutenberg, and add an image to a post or page.
* Click the Crop icon in the block toolbar to open the media editor
* Dragging by mouse should be much the same as on trunk. However! If you drag a drag handle and then use the cursor keys, it should immediately allow you to use the keyboard to move the drag handles
* Using shift should apply a 10x modifier to how far you can move
* Try tabbing forwards and backwards between the drag handles and see how it feels
* Use Escape key to go back up to the canvas
* Use the cursor keys to move around — does the inverted direction feel more natural?
* Also a question for the reviewer: how does the styling look on the focused drag handles? Is it too much?

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/0ba807c6-ca1a-4809-a44c-aecb26bda8d1

## Use of AI Tools

Mostly Claude Code with Sonnet 4.6, with a little tweaking by hand.