### PR TITLE
Media Editor Modal: save via Core's /edit modifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60929,6 +60929,7 @@
 			"version": "0.7.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/components": "file:../components",
 				"@wordpress/core-data": "file:../core-data",
 				"@wordpress/data": "file:../data",

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -44,6 +44,7 @@
 		"build-module/store/index.mjs"
 	],
 	"dependencies": {
+		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/components": "file:../components",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",

--- a/packages/media-editor/src/components/media-editor-modal/build-modifiers.ts
+++ b/packages/media-editor/src/components/media-editor-modal/build-modifiers.ts
@@ -1,0 +1,164 @@
+/**
+ * Internal dependencies
+ */
+import type { CropperState, Size } from '../../image-editor';
+import { getRotatedBBox } from '../../image-editor/core/camera';
+
+/**
+ * A single modifier in the Core REST `/edit` payload. Order is
+ * significant — the server applies modifiers sequentially (see
+ * `WP_REST_Attachments_Controller::edit_media_item`).
+ *
+ * Shape/units:
+ *   - `flip`:   booleans per axis. Applied first in this module's output.
+ *   - `rotate`: `angle` in degrees, clockwise-positive (matches the
+ *     cropper's own convention; Core negates it internally for
+ *     `WP_Image_Editor::rotate`, which is counterclockwise-positive).
+ *   - `crop`:   percentages (0–100) of the image's dimensions **at the
+ *     moment the crop is applied**. Because modifiers are applied in
+ *     order, after a preceding `rotate` the server's
+ *     `WP_Image_Editor::get_size()` reports the full post-rotate AABB,
+ *     so the percentages are of that AABB. Origin is top-left.
+ */
+export type Modifier =
+	| {
+			type: 'flip';
+			args: { flip: { horizontal: boolean; vertical: boolean } };
+	  }
+	| { type: 'rotate'; args: { angle: number } }
+	| {
+			type: 'crop';
+			args: { left: number; top: number; width: number; height: number };
+	  };
+
+/**
+ * Tolerance (percent) used to decide whether a crop rect is effectively
+ * full-frame. Sub-pixel / float-ulp deltas below this value are treated
+ * as no crop. Matches the historical threshold used by the legacy
+ * `use-save-image.js` (which compared against `99.9`).
+ */
+const CROP_TOLERANCE = 0.1;
+
+/**
+ * Build a Core-compatible modifiers array from the cropper state.
+ *
+ * Emits `[flip, rotate, crop]` in that order. Identity operations are
+ * pruned — an absent flip, a rotation that normalizes to 0°, and a crop
+ * rect that covers (within tolerance) the full post-rotate AABB each
+ * produce no modifier. An identity state (fresh image, no edits) returns
+ * an empty array; callers can use that to skip the `/edit` call.
+ *
+ * Frames and math:
+ *
+ * The cropper's `cropRect` is stored as fractions of the **snap-rotation**
+ * bounding box (the stencil-reference frame — see `createCamera` /
+ * `createExportCamera`). Pan is in that frame; zoom scales the image
+ * beneath a fixed stencil. Two conversions are needed to reach the frame
+ * Core's crop modifier applies against:
+ *
+ *   1. Express the stencil rect in snap-AABB **pixels**:
+ *      Image screen-normalized top-left with zoom/pan is
+ *      `(0.5 + pan - zoom/2)`; the stencil's pixel footprint is the
+ *      inverse of that transform applied to `cropRect`.
+ *
+ *   2. Translate from snap-AABB coords to full-AABB coords. Both AABBs
+ *      share the source-image center, so the conversion is a pure
+ *      translation by `(fullCenter - snapCenter)`. Finally, express the
+ *      translated rect as percentages of the full AABB.
+ *
+ * Rotation sign: the cropper composes `flip · R(θ)` on the source (see
+ * `createExportCamera` — rotate then flip). Core's `[flip, rotate]`
+ * applies the opposite order: `R(θ') · flip`. For both to land on the
+ * same pixels we invert the rotation sign when exactly one flip axis
+ * is set (`flip_h · R(θ) = R(-θ) · flip_h`). Both-or-neither flips
+ * leave the sign alone because `flip_h · flip_v = -I` commutes with
+ * rotation.
+ *
+ * @param state     Current cropper state.
+ * @param imageSize Natural dimensions of the source image.
+ * @return Ordered modifier array; empty when nothing is server-relevant.
+ */
+export function buildModifiers(
+	state: CropperState,
+	imageSize: Size
+): Modifier[] {
+	const modifiers: Modifier[] = [];
+
+	if ( imageSize.width === 0 || imageSize.height === 0 ) {
+		return modifiers;
+	}
+
+	const { cropRect, pan, zoom, flip } = state;
+	const hasFlipH = flip.horizontal;
+	const hasFlipV = flip.vertical;
+
+	if ( hasFlipH || hasFlipV ) {
+		modifiers.push( {
+			type: 'flip',
+			args: { flip: { horizontal: hasFlipH, vertical: hasFlipV } },
+		} );
+	}
+
+	const rawAngle = ( ( state.rotation % 360 ) + 360 ) % 360;
+	// Invert the sign for single-axis flips so Core's `flip → rotate`
+	// pipeline matches the cropper's `rotate → flip` composition.
+	const singleAxisFlip = hasFlipH !== hasFlipV;
+	const signedAngle = singleAxisFlip ? ( 360 - rawAngle ) % 360 : rawAngle;
+	if ( signedAngle !== 0 ) {
+		modifiers.push( { type: 'rotate', args: { angle: signedAngle } } );
+	}
+
+	const snapRotation = Math.round( state.rotation / 90 ) * 90;
+	const { width: snapW, height: snapH } = getRotatedBBox(
+		imageSize.width,
+		imageSize.height,
+		snapRotation
+	);
+	const { width: fullW, height: fullH } = getRotatedBBox(
+		imageSize.width,
+		imageSize.height,
+		state.rotation
+	);
+
+	// Stencil rect in snap-AABB pixels. Inverts `createExportCamera`'s
+	// pan/zoom composition to recover the pixel rectangle the stencil
+	// framed in that frame.
+	const imgLeft = 0.5 + pan.x - zoom / 2;
+	const imgTop = 0.5 + pan.y - zoom / 2;
+	const snapX = ( ( cropRect.x - imgLeft ) / zoom ) * snapW;
+	const snapY = ( ( cropRect.y - imgTop ) / zoom ) * snapH;
+	const widthPx = ( cropRect.width / zoom ) * snapW;
+	const heightPx = ( cropRect.height / zoom ) * snapH;
+
+	// Translate to the full AABB (both centered on source).
+	const offsetX = ( fullW - snapW ) / 2;
+	const offsetY = ( fullH - snapH ) / 2;
+	const fullX = snapX + offsetX;
+	const fullY = snapY + offsetY;
+
+	// Percentages of the full AABB — Core's crop frame after rotate.
+	const leftPct = ( fullX / fullW ) * 100;
+	const topPct = ( fullY / fullH ) * 100;
+	const widthPct = ( widthPx / fullW ) * 100;
+	const heightPct = ( heightPx / fullH ) * 100;
+
+	const coversFullFrame =
+		leftPct <= CROP_TOLERANCE &&
+		topPct <= CROP_TOLERANCE &&
+		widthPct >= 100 - CROP_TOLERANCE &&
+		heightPct >= 100 - CROP_TOLERANCE;
+
+	if ( ! coversFullFrame ) {
+		modifiers.push( {
+			type: 'crop',
+			args: {
+				left: leftPct,
+				top: topPct,
+				width: widthPct,
+				height: heightPct,
+			},
+		} );
+	}
+
+	return modifiers;
+}

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import {
 	Button,
 	Flex,
@@ -9,7 +10,7 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
 	useContext,
@@ -44,8 +45,25 @@ import MediaForm from '../media-form';
 import { store as mediaEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import { getMediaTypeFromMimeType } from '../../utils';
-import { CropperProvider, useCropper } from '../../image-editor';
+import {
+	CropperProvider,
+	useCropper,
+	type UseCropperStateReturn,
+} from '../../image-editor';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
+import { buildModifiers } from './build-modifiers';
+
+// Details-tab edits the modal bundles into a transformed `/edit` request.
+// These are the same fields Core's `edit_media_item` reads from the
+// request body via `prepare_item_for_database` / `alt_text` — forwarding
+// them preserves any staged changes across the attachment-duplicating
+// save.
+const METADATA_EDIT_KEYS = [
+	'title',
+	'caption',
+	'description',
+	'alt_text',
+] as const;
 
 const { Tabs } = unlock( componentsPrivateApis );
 
@@ -121,7 +139,7 @@ interface HeaderActionsProps {
 	hasMedia: boolean;
 	hasEdits: boolean;
 	onCancel: () => void;
-	onSave: () => void;
+	onSave: ( controller: UseCropperStateReturn ) => void;
 }
 
 function HeaderActions( {
@@ -131,7 +149,8 @@ function HeaderActions( {
 	onCancel,
 	onSave,
 }: HeaderActionsProps ) {
-	const { isDirty } = useCropper();
+	const controller = useCropper();
+	const { isDirty } = controller;
 	const saveDisabled = isSaving || ! hasMedia || ( ! isDirty && ! hasEdits );
 	return (
 		<Flex
@@ -153,7 +172,7 @@ function HeaderActions( {
 			<Button
 				size="compact"
 				variant="primary"
-				onClick={ onSave }
+				onClick={ () => onSave( controller ) }
 				isBusy={ isSaving }
 				disabled={ saveDisabled }
 				accessibleWhenDisabled
@@ -200,7 +219,8 @@ export function MediaEditorModal( {
 		[ id ]
 	);
 
-	const { editEntityRecord, saveEditedEntityRecord } =
+	const registry = useRegistry();
+	const { editEntityRecord, receiveEntityRecords, saveEditedEntityRecord } =
 		useDispatch( coreStore );
 	const { closeMediaEditorModal } = useDispatch( mediaEditorStore );
 
@@ -317,16 +337,86 @@ export function MediaEditorModal( {
 		closeMediaEditorModal();
 	};
 
-	const handleSave = async () => {
+	const handleSave = async ( controller: UseCropperStateReturn ) => {
 		setIsSaving( true );
 		try {
-			const saved = ( await saveEditedEntityRecord(
-				'postType',
-				'attachment',
-				id
-			) ) as Media | undefined;
+			let saved: Media | null | undefined;
+
+			const modifiers =
+				controller.isDirty && controller.state.image
+					? buildModifiers( controller.state, {
+							width: controller.state.image.naturalWidth,
+							height: controller.state.image.naturalHeight,
+					  } )
+					: [];
+
+			if ( modifiers.length > 0 ) {
+				// Bundle staged Details-tab edits into the same /edit
+				// request. Transformed saves duplicate the attachment,
+				// and the prior core-data edits were staged against the
+				// old id — if we don't forward them here they'd be
+				// silently lost. Core's `edit_media_item` honors these
+				// keys via `prepare_item_for_database` and `alt_text`.
+				const pendingEdits = registry
+					.select( coreStore )
+					.getEntityRecordNonTransientEdits(
+						'postType',
+						'attachment',
+						id
+					) as Record< string, unknown > | undefined;
+				const metadataEdits: Record< string, unknown > = {};
+				for ( const key of METADATA_EDIT_KEYS ) {
+					if ( pendingEdits && key in pendingEdits ) {
+						metadataEdits[ key ] = pendingEdits[ key ];
+					}
+				}
+
+				saved = ( await apiFetch( {
+					path: `/wp/v2/media/${ id }/edit`,
+					method: 'POST',
+					data: {
+						src: media?.source_url,
+						modifiers,
+						...metadataEdits,
+					},
+				} ) ) as Media;
+
+				if ( saved ) {
+					// Put the newly-created attachment into the core-data
+					// cache so downstream consumers see it without an
+					// extra fetch round-trip.
+					receiveEntityRecords(
+						'postType',
+						'attachment',
+						saved,
+						undefined,
+						true
+					);
+				}
+			} else {
+				saved = ( await saveEditedEntityRecord(
+					'postType',
+					'attachment',
+					id
+				) ) as Media | undefined;
+			}
 
 			const next = ( saved ?? media ) as Media | null;
+
+			// A transformed save creates a new attachment; the Details
+			// edits now live on the new record (sent in the /edit
+			// payload). Reset the old record's staged edits back to its
+			// original values so it doesn't appear dirty in the Media
+			// Library afterwards.
+			if ( next && next.id !== id && originalFieldValuesRef.current ) {
+				editEntityRecord(
+					'postType',
+					'attachment',
+					id,
+					originalFieldValuesRef.current
+				);
+			}
+
 			if ( next && next.id && onUpdate ) {
 				// Normalize to the public callback shape — see
 				// `MediaEditorModalUpdate` in `../../store/actions.ts`.

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -12,13 +12,7 @@ import {
 import { Stack } from '@wordpress/ui';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import {
-	useContext,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from '@wordpress/element';
+import { useContext, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { drawerRight } from '@wordpress/icons';
 import type { Field } from '@wordpress/dataviews';
@@ -223,32 +217,15 @@ export function MediaEditorModal( {
 	);
 
 	const registry = useRegistry();
-	const { editEntityRecord, receiveEntityRecords, saveEditedEntityRecord } =
-		useDispatch( coreStore );
+	const {
+		clearEntityRecordEdits,
+		editEntityRecord,
+		receiveEntityRecords,
+		saveEditedEntityRecord,
+	} = useDispatch( coreStore );
 	const { closeMediaEditorModal } = useDispatch( mediaEditorStore );
 
 	const [ isSaving, setIsSaving ] = useState( false );
-
-	// Snapshot the original values for fields the modal edits, so Cancel can
-	// restore them. Captured once per open.
-	const originalFieldValuesRef = useRef< Record< string, unknown > | null >(
-		null
-	);
-	useEffect( () => {
-		if ( ! isModalOpen ) {
-			originalFieldValuesRef.current = null;
-			return;
-		}
-		if ( ! originalFieldValuesRef.current && media ) {
-			const snapshot: Record< string, unknown > = {};
-			fields.forEach( ( field ) => {
-				snapshot[ field.id ] = ( media as Record< string, unknown > )[
-					field.id
-				];
-			} );
-			originalFieldValuesRef.current = snapshot;
-		}
-	}, [ isModalOpen, media, fields ] );
 
 	const [ aspectRatioValue, setAspectRatioValue ] = useState( '0' );
 	const [ freeformCrop, setFreeformCrop ] = useState( true );
@@ -329,14 +306,7 @@ export function MediaEditorModal( {
 	};
 
 	const handleCancel = () => {
-		if ( originalFieldValuesRef.current ) {
-			editEntityRecord(
-				'postType',
-				'attachment',
-				id,
-				originalFieldValuesRef.current
-			);
-		}
+		clearEntityRecordEdits( 'postType', 'attachment', id );
 		closeMediaEditorModal();
 	};
 
@@ -406,18 +376,11 @@ export function MediaEditorModal( {
 
 			const next = ( saved ?? media ) as Media | null;
 
-			// A transformed save creates a new attachment; the Details
-			// edits now live on the new record (sent in the /edit
-			// payload). Reset the old record's staged edits back to its
-			// original values so it doesn't appear dirty in the Media
-			// Library afterwards.
-			if ( next && next.id !== id && originalFieldValuesRef.current ) {
-				editEntityRecord(
-					'postType',
-					'attachment',
-					id,
-					originalFieldValuesRef.current
-				);
+			// A transformed save creates a new attachment; clear staged
+			// edits on the old record so it doesn't appear dirty in the
+			// Media Library afterwards.
+			if ( next && next.id !== id ) {
+				clearEntityRecordEdits( 'postType', 'attachment', id );
 			}
 
 			if ( next && next.id && onUpdate ) {

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -54,15 +54,18 @@ import type { AspectRatioPreset } from '../../image-editor/core/constants';
 import { buildModifiers } from './build-modifiers';
 
 // Details-tab edits the modal bundles into a transformed `/edit` request.
-// These are the same fields Core's `edit_media_item` reads from the
-// request body via `prepare_item_for_database` / `alt_text` — forwarding
-// them preserves any staged changes across the attachment-duplicating
-// save.
+// Matches Core's `WP_REST_Attachments_Controller::get_edit_media_item_args`
+// — that endpoint's arg schema explicitly whitelists only these fields
+// (title / caption / description / alt_text / post), so forwarding any
+// others would fail REST validation with `rest_invalid_param`. Staged
+// edits to fields outside this list are not forwarded; a follow-up could
+// persist them via a separate `saveEditedEntityRecord` call.
 const METADATA_EDIT_KEYS = [
 	'title',
 	'caption',
 	'description',
 	'alt_text',
+	'post',
 ] as const;
 
 const { Tabs } = unlock( componentsPrivateApis );

--- a/packages/media-editor/src/components/media-editor-modal/test/build-modifiers.test.ts
+++ b/packages/media-editor/src/components/media-editor-modal/test/build-modifiers.test.ts
@@ -1,0 +1,343 @@
+/**
+ * buildModifiers ↔ Export-camera parity.
+ *
+ * WHAT THIS TEST GUARANTEES
+ *
+ * "What the user framed in the stencil is what the server crops from the
+ * source." The cropper shows the user a live preview via the *export
+ * camera* (`createExportCamera`); the server receives a `modifiers` array
+ * from `buildModifiers` and applies them sequentially in the order
+ * `[flip, rotate, crop]` (Core's `WP_REST_Attachments_Controller
+ * ::edit_media_item`). Both paths must land on the same source pixel for
+ * the same spot in the output, otherwise the saved image drifts from
+ * what the user framed.
+ *
+ * This test asserts that invariant holds for every combination of
+ * rotation, zoom, pan, flip, and crop rect the cropper can produce.
+ *
+ * STRATEGY
+ *
+ * For each cropper state and each probe point (u, v) ∈ [0, 1]² inside
+ * the cropped output:
+ *
+ *   1. `exportSourcePixel` — inverts the export-camera matrix to find
+ *      the source pixel the cropper draws at (u, v). Ground truth:
+ *      it's literally what the user sees on screen.
+ *   2. `serverSourcePixel` — simulates the Core pipeline
+ *      (`flip → rotate → crop`) in reverse to find the source pixel the
+ *      server would place at (u, v).
+ *   3. Assert both answers agree to within 1 source pixel (float slop).
+ *
+ * A wrong crop rect, frame, or rotation sign makes the two paths
+ * diverge and pinpoints the offending (state, probe) pair.
+ *
+ * ORDER / SIGN NOTES
+ *
+ * The cropper's export camera composes the source-to-screen chain as
+ * `flip · R(θ)` on the (centered) source — rotate first, then flip.
+ * Core's `modifiers` pipeline applies `flip` first, then `R(θ')`. For
+ * these two chains to land on the same pixel, when exactly one flip
+ * axis is set we must send `θ' = -θ` (since `flip_h · R(θ) = R(-θ) ·
+ * flip_h`). Both-or-neither flips leave `θ' = θ` because `flip_h · flip_v
+ * = -I` commutes with rotation.
+ *
+ * MAINTENANCE NOTES
+ *
+ * - If you change `buildModifiers`, this test is the primary safety net.
+ *   Run it after any edit to that file or to `createExportCamera`.
+ * - If Core's pipeline operation order ever changes, update
+ *   `serverSourcePixel` to match — it mirrors the server exactly.
+ * - Adding a new cropper operation (e.g. skew) means: extend
+ *   `CropperState`, teach `buildModifiers` to emit it, extend
+ *   `serverSourcePixel` to undo it, and add values to the grid in
+ *   `buildRows`. The probes don't need to change.
+ */
+
+/**
+ * External dependencies
+ */
+import { mat2d, vec2 } from 'gl-matrix';
+
+/**
+ * Internal dependencies
+ */
+import { buildModifiers } from '../build-modifiers';
+import type { Modifier } from '../build-modifiers';
+import {
+	createExportCamera,
+	getRotatedBBox,
+} from '../../../image-editor/core/camera';
+import { DEFAULT_STATE } from '../../../image-editor/core/constants';
+import type { CropperState, Size } from '../../../image-editor/core/types';
+
+const IMAGE: Size = { width: 1600, height: 900 };
+
+function makeState( overrides: Partial< CropperState > = {} ): CropperState {
+	return {
+		...DEFAULT_STATE,
+		image: {
+			src: 'test.jpg',
+			naturalWidth: IMAGE.width,
+			naturalHeight: IMAGE.height,
+		},
+		...overrides,
+	};
+}
+
+/**
+ * Source pixel the cropper draws at output position (u, v). Inverts the
+ * export-camera matrix — the same one the preview uses — so whatever the
+ * user sees on-screen is exactly what this returns.
+ *
+ * @param state      Cropper state (rotation/zoom/pan/flip/cropRect).
+ * @param imageSize  Natural dimensions of the source image.
+ * @param outputSize Output canvas dimensions the camera renders into.
+ * @param u          Horizontal probe in [0, 1] across the output.
+ * @param v          Vertical probe in [0, 1] across the output.
+ */
+function exportSourcePixel(
+	state: CropperState,
+	imageSize: Size,
+	outputSize: Size,
+	u: number,
+	v: number
+): { x: number; y: number } {
+	const camera = createExportCamera( state, imageSize, outputSize );
+	const inv = mat2d.create();
+	mat2d.invert( inv, camera );
+	const out = vec2.create();
+	vec2.transformMat2d(
+		out,
+		[ u * outputSize.width, v * outputSize.height ],
+		inv
+	);
+	return { x: out[ 0 ], y: out[ 1 ] };
+}
+
+/**
+ * Extract the pieces of the server pipeline we need to simulate from a
+ * modifier array. `flip` and `rotate` may be absent (identity-pruned),
+ * `crop` may also be absent when the full-frame is framed; in that case
+ * the output canvas equals the full rotated AABB.
+ *
+ * @param modifiers Ordered modifier array as emitted by `buildModifiers`.
+ */
+function readModifiers( modifiers: Modifier[] ): {
+	flip: { horizontal: boolean; vertical: boolean };
+	rotation: number;
+	crop: { left: number; top: number; width: number; height: number } | null;
+} {
+	const flip = { horizontal: false, vertical: false };
+	let rotation = 0;
+	let crop: {
+		left: number;
+		top: number;
+		width: number;
+		height: number;
+	} | null = null;
+
+	for ( const m of modifiers ) {
+		if ( m.type === 'flip' ) {
+			flip.horizontal = m.args.flip.horizontal;
+			flip.vertical = m.args.flip.vertical;
+		} else if ( m.type === 'rotate' ) {
+			rotation = m.args.angle;
+		} else if ( m.type === 'crop' ) {
+			crop = {
+				left: m.args.left,
+				top: m.args.top,
+				width: m.args.width,
+				height: m.args.height,
+			};
+		}
+	}
+
+	return { flip, rotation, crop };
+}
+
+/**
+ * Source pixel the server lands on for output point (u, v). Simulates
+ * Core's `[flip, rotate, crop]` pipeline in reverse:
+ *   1. Output point o = (u · outW, v · outH).
+ *   2. Canvas point c = o + (cropX, cropY) in the post-rotate full AABB.
+ *   3. Undo rotation about the source center to reach the flipped frame.
+ *   4. Undo flip about the source center.
+ *
+ * @param modifiers Ordered modifier array the client sends.
+ * @param imageSize Natural dimensions of the source image.
+ * @param u         Horizontal probe in [0, 1] across the output.
+ * @param v         Vertical probe in [0, 1] across the output.
+ */
+function serverSourcePixel(
+	modifiers: Modifier[],
+	imageSize: Size,
+	u: number,
+	v: number
+): { x: number; y: number } {
+	const { flip, rotation, crop } = readModifiers( modifiers );
+
+	const fullBBox = getRotatedBBox(
+		imageSize.width,
+		imageSize.height,
+		rotation
+	);
+
+	// Percent → pixels in the full-AABB frame. When crop is absent the
+	// output canvas is the full AABB itself.
+	const cropW = crop ? ( crop.width * fullBBox.width ) / 100 : fullBBox.width;
+	const cropH = crop
+		? ( crop.height * fullBBox.height ) / 100
+		: fullBBox.height;
+	const cropX = crop ? ( crop.left * fullBBox.width ) / 100 : 0;
+	const cropY = crop ? ( crop.top * fullBBox.height ) / 100 : 0;
+
+	// Undo crop translation.
+	const cx = u * cropW + cropX;
+	const cy = v * cropH + cropY;
+
+	// Undo rotation about source center. Core applies rotation to the
+	// flipped source, so inverting rotation brings us back to the flipped
+	// frame (source center at full-AABB center).
+	const rad = ( rotation * Math.PI ) / 180;
+	const cos = Math.cos( rad );
+	const sin = Math.sin( rad );
+	const dx = cx - fullBBox.width / 2;
+	const dy = cy - fullBBox.height / 2;
+	// gl-matrix mat2d.rotate: (x, y) → (x·cos - y·sin, x·sin + y·cos).
+	// Inverse is the transpose: (x, y) → (x·cos + y·sin, -x·sin + y·cos).
+	let fx = dx * cos + dy * sin + imageSize.width / 2;
+	let fy = -dx * sin + dy * cos + imageSize.height / 2;
+
+	// Undo flip about source center (flip is its own inverse).
+	if ( flip.horizontal ) {
+		fx = imageSize.width - fx;
+	}
+	if ( flip.vertical ) {
+		fy = imageSize.height - fy;
+	}
+
+	return { x: fx, y: fy };
+}
+
+// Seven probe points — corners catch offset/scale drift, center catches
+// uniform bugs, two asymmetric interior points catch cross-axis bugs
+// that a center probe would miss.
+const PROBES: { label: string; u: number; v: number }[] = [
+	{ label: 'top-left', u: 0, v: 0 },
+	{ label: 'top-right', u: 1, v: 0 },
+	{ label: 'bottom-right', u: 1, v: 1 },
+	{ label: 'bottom-left', u: 0, v: 1 },
+	{ label: 'center', u: 0.5, v: 0.5 },
+	{ label: 'interior-1', u: 0.3, v: 0.7 },
+	{ label: 'interior-2', u: 0.8, v: 0.25 },
+];
+
+interface ParityRow {
+	label: string;
+	state: CropperState;
+	probeLabel: string;
+	u: number;
+	v: number;
+}
+
+function buildRows(): ParityRow[] {
+	const rotations = [ 0, 15, 45, 60, 90, 135, 201, 270 ];
+	const zooms = [ 1, 1.5, 2.5 ];
+	const pans = [
+		{ x: 0, y: 0 },
+		{ x: 0.08, y: -0.05 },
+		{ x: -0.1, y: 0.12 },
+	];
+	const flips = [
+		{ horizontal: false, vertical: false },
+		{ horizontal: true, vertical: false },
+		{ horizontal: false, vertical: true },
+		{ horizontal: true, vertical: true },
+	];
+	const cropRects = [
+		{ label: 'full', rect: { x: 0, y: 0, width: 1, height: 1 } },
+		{
+			label: 'centered',
+			rect: { x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+		},
+		{
+			label: 'off-center',
+			rect: { x: 0.1, y: 0.2, width: 0.45, height: 0.55 },
+		},
+	];
+
+	const rows: ParityRow[] = [];
+	for ( const rotation of rotations ) {
+		for ( const zoom of zooms ) {
+			for ( const pan of pans ) {
+				for ( const flip of flips ) {
+					for ( const { label: cropLabel, rect } of cropRects ) {
+						const flipLabel = `${ flip.horizontal ? 'H' : '-' }${
+							flip.vertical ? 'V' : '-'
+						}`;
+						const stateLabel = `rot=${ rotation } zoom=${ zoom } pan=(${ pan.x },${ pan.y }) flip=${ flipLabel } crop=${ cropLabel }`;
+						const state = makeState( {
+							rotation,
+							zoom,
+							pan,
+							flip,
+							cropRect: rect,
+						} );
+						for ( const { label: probeLabel, u, v } of PROBES ) {
+							rows.push( {
+								label: `${ stateLabel } probe=${ probeLabel }`,
+								state,
+								probeLabel,
+								u,
+								v,
+							} );
+						}
+					}
+				}
+			}
+		}
+	}
+	return rows;
+}
+
+/**
+ * Output size the server would produce, computed from the modifier list.
+ * With a crop: the crop's pixel dims in the full-AABB frame. Without a
+ * crop: the full rotated AABB.
+ *
+ * @param modifiers Modifier array the server will apply.
+ * @param imageSize Natural dimensions of the source image.
+ */
+function outputSizeFor( modifiers: Modifier[], imageSize: Size ): Size {
+	const { rotation, crop } = readModifiers( modifiers );
+	const full = getRotatedBBox( imageSize.width, imageSize.height, rotation );
+	if ( ! crop ) {
+		return { width: full.width, height: full.height };
+	}
+	return {
+		width: ( crop.width * full.width ) / 100,
+		height: ( crop.height * full.height ) / 100,
+	};
+}
+
+describe( 'buildModifiers ↔ Export-camera parity', () => {
+	const rows = buildRows();
+
+	it.each( rows )( '$label', ( { state, u, v } ) => {
+		const modifiers = buildModifiers( state, IMAGE );
+
+		// Output canvas is whatever the server would emit: the crop rect
+		// if present, otherwise the full rotated AABB. This makes (u, v)
+		// map to the same *output* pixel on both paths.
+		const outputSize = outputSizeFor( modifiers, IMAGE );
+
+		const exported = exportSourcePixel( state, IMAGE, outputSize, u, v );
+		const server = serverSourcePixel( modifiers, IMAGE, u, v );
+
+		// Tolerance of 1 source pixel. The two paths compose rotations
+		// and scales in different orders, so sub-pixel disagreement is
+		// expected from floating-point. Anything larger is a real bug.
+		expect( server.x ).toBeCloseTo( exported.x, 0 );
+		expect( server.y ).toBeCloseTo( exported.y, 0 );
+	} );
+} );

--- a/packages/media-editor/tsconfig.json
+++ b/packages/media-editor/tsconfig.json
@@ -6,6 +6,7 @@
 		"checkJs": false
 	},
 	"references": [
+		{ "path": "../api-fetch" },
 		{ "path": "../components" },
 		{ "path": "../core-data" },
 		{ "path": "../data" },


### PR DESCRIPTION
Related to:

- https://github.com/WordPress/gutenberg/issues/73771

Alternative to #77583. Wires the media-editor modal's Save button to `POST /wp/v2/media/{id}/edit` using Core's existing `modifiers` contract — no new REST handler or experimental PHP.


https://github.com/user-attachments/assets/fa021319-2c49-4a77-ae5d-4f84f5f5686b



Key bit is a purely client-side snap-AABB → full-AABB translation in `buildModifiers`, so fine rotations crop accurately against the post-rotate canvas that Core's `WP_Image_Editor::rotate` produces.

Staged Details-tab edits (`title`, `caption`, `description`, `alt_text`) are bundled into the same `/edit` request, so metadata survives the attachment-duplicating save. Identity states (Details-only) fall through to `saveEditedEntityRecord`.

Uses `apiFetch` directly + the public `receiveEntityRecords` action to keep `@wordpress/media-editor` off private core-data APIs.

## Test plan

- [x] `npm run test:unit -- packages/media-editor` (18525 tests, includes 6048-case WYSIWYG parity grid across 8 rotations × 3 zooms × 3 pans × 4 flips × 3 crops × 7 probes)
- [ ] Manual: snap rotations (0/90/180/270), fine rotations (15/45/60/135), zoom/pan-only framing, each flip axis, Details-only save, Details + crop save