### PR TITLE
Background image control: Add unit controls for focal point

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -294,7 +294,7 @@ Add an image or video with a text overlay. ([Source](https://github.com/WordPres
 -	**Name:** core/cover
 -	**Category:** media
 -	**Supports:** align, allowedBlocks, anchor, color (heading, text, ~~background~~, ~~enableContrastChecker~~), dimensions (aspectRatio), filter (duotone), interactivity (clientNavigation), layout (~~allowJustification~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, isUserOverlayColor, minHeight, minHeightUnit, overlayColor, poster, sizeSlug, tagName, templateLock, url, useFeaturedImage
+-	**Attributes:** alt, backgroundType, contentPosition, customGradient, customOverlayColor, customPosition, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, isUserOverlayColor, minHeight, minHeightUnit, overlayColor, poster, sizeSlug, tagName, templateLock, url, useFeaturedImage
 
 ## Details
 

--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -50,6 +50,32 @@ import {
 
 const IMAGE_BACKGROUND_TYPE = 'image';
 
+const BACKGROUND_POSITION_UNITS = [
+	{ value: '%', label: '%', default: 50 },
+	{ value: 'px', label: 'px', default: 0 },
+	{ value: 'em', label: 'em', default: 0 },
+	{ value: 'rem', label: 'rem', default: 0 },
+	{ value: 'vw', label: 'vw', default: 0 },
+	{ value: 'vh', label: 'vh', default: 0 },
+];
+
+/**
+ * Parses a CSS background-position string into X and Y components.
+ *
+ * @param {string} value CSS background-position value.
+ * @return {{ x: string|undefined, y: string|undefined }} Parsed X and Y components.
+ */
+const parseBackgroundPosition = ( value ) => {
+	if ( ! value ) {
+		return { x: undefined, y: undefined };
+	}
+	const parts = value.split( ' ' ).filter( Boolean );
+	return {
+		x: parts[ 0 ] ?? undefined,
+		y: parts.length > 1 ? parts[ 1 ] : parts[ 0 ],
+	};
+};
+
 const BACKGROUND_POPOVER_PROPS = {
 	placement: 'left-start',
 	offset: 36,
@@ -451,6 +477,12 @@ function BackgroundSizeControls( {
 		style?.background?.backgroundAttachment ||
 		inheritedValue?.background?.backgroundAttachment;
 
+	// Set a default background position for non-site-wide, uploaded images with a size of 'contain'.
+	const backgroundPositionValue =
+		! positionValue && isUploadedImage && 'contain' === sizeValue
+			? defaultValues?.backgroundPosition
+			: positionValue;
+
 	/*
 	 * Set default values for uploaded images.
 	 * The default values are passed by the consumer.
@@ -541,6 +573,52 @@ function BackgroundSizeControls( {
 		);
 	};
 
+	const { x: posX, y: posY } = parseBackgroundPosition(
+		backgroundPositionValue ?? ''
+	);
+	const positionXValue = posX ?? '50%';
+	const positionYValue = posY ?? '50%';
+
+	const updateBackgroundPositionX = ( next ) => {
+		if ( next === undefined ) {
+			onChange(
+				setImmutably(
+					style,
+					[ 'background', 'backgroundPosition' ],
+					undefined
+				)
+			);
+			return;
+		}
+		onChange(
+			setImmutably(
+				style,
+				[ 'background', 'backgroundPosition' ],
+				`${ next } ${ positionYValue }`
+			)
+		);
+	};
+
+	const updateBackgroundPositionY = ( next ) => {
+		if ( next === undefined ) {
+			onChange(
+				setImmutably(
+					style,
+					[ 'background', 'backgroundPosition' ],
+					undefined
+				)
+			);
+			return;
+		}
+		onChange(
+			setImmutably(
+				style,
+				[ 'background', 'backgroundPosition' ],
+				`${ positionXValue } ${ next }`
+			)
+		);
+	};
+
 	const toggleIsRepeated = () =>
 		onChange(
 			setImmutably(
@@ -559,20 +637,31 @@ function BackgroundSizeControls( {
 			)
 		);
 
-	// Set a default background position for non-site-wide, uploaded images with a size of 'contain'.
-	const backgroundPositionValue =
-		! positionValue && isUploadedImage && 'contain' === sizeValue
-			? defaultValues?.backgroundPosition
-			: positionValue;
-
 	return (
 		<VStack spacing={ 3 } className="single-column">
 			<FocalPointPicker
 				label={ __( 'Focal point' ) }
+				__experimentalHideControls
 				url={ imageValue }
 				value={ backgroundPositionToCoords( backgroundPositionValue ) }
 				onChange={ updateBackgroundPosition }
 			/>
+			<HStack spacing={ 2 }>
+				<UnitControl
+					label={ __( 'X position' ) }
+					value={ positionXValue }
+					onChange={ updateBackgroundPositionX }
+					units={ BACKGROUND_POSITION_UNITS }
+					size="__unstable-large"
+				/>
+				<UnitControl
+					label={ __( 'Y position' ) }
+					value={ positionYValue }
+					onChange={ updateBackgroundPositionY }
+					units={ BACKGROUND_POSITION_UNITS }
+					size="__unstable-large"
+				/>
+			</HStack>
 			<ToggleControl
 				label={ __( 'Fixed background' ) }
 				checked={ attachmentValue === 'fixed' }

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -50,6 +50,9 @@
 		"focalPoint": {
 			"type": "object"
 		},
+		"customPosition": {
+			"type": "string"
+		},
 		"minHeight": {
 			"type": "number"
 		},

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -102,6 +102,7 @@ function CoverEdit( {
 		useFeaturedImage,
 		dimRatio,
 		focalPoint,
+		customPosition,
 		hasParallax,
 		isDark,
 		isRepeated,
@@ -445,13 +446,13 @@ function CoverEdit( {
 
 	const backgroundImage = url ? `url(${ url })` : undefined;
 
-	const backgroundPosition = mediaPosition( focalPoint );
+	const backgroundPosition = customPosition ?? mediaPosition( focalPoint );
 
 	const bgStyle = { backgroundColor: overlayColor.color };
 	const mediaStyle = {
 		objectPosition:
-			focalPoint && isImgElement
-				? mediaPosition( focalPoint )
+			( focalPoint || customPosition ) && isImgElement
+				? customPosition ?? mediaPosition( focalPoint )
 				: undefined,
 	};
 

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -41,6 +41,26 @@ const { cleanEmptyObject, ResolutionTool, HTMLElementControl } = unlock(
 	blockEditorPrivateApis
 );
 
+const BACKGROUND_POSITION_UNITS = [
+	{ value: '%', label: '%', default: 50 },
+	{ value: 'px', label: 'px', default: 0 },
+	{ value: 'em', label: 'em', default: 0 },
+	{ value: 'rem', label: 'rem', default: 0 },
+	{ value: 'vw', label: 'vw', default: 0 },
+	{ value: 'vh', label: 'vh', default: 0 },
+];
+
+const parseBackgroundPosition = ( value ) => {
+	if ( ! value ) {
+		return { x: undefined, y: undefined };
+	}
+	const parts = value.split( ' ' ).filter( Boolean );
+	return {
+		x: parts[ 0 ] ?? undefined,
+		y: parts.length > 1 ? parts[ 1 ] : parts[ 0 ],
+	};
+};
+
 function CoverHeightInput( {
 	onChange,
 	onUnitChange,
@@ -105,6 +125,7 @@ export default function CoverInspectorControls( {
 		id,
 		dimRatio,
 		focalPoint,
+		customPosition,
 		hasParallax,
 		isRepeated,
 		minHeight,
@@ -180,6 +201,38 @@ export default function CoverInspectorControls( {
 
 	const showFocalPointPicker = isVideoBackground || isImageBackground;
 
+	// Effective CSS position string: customPosition takes precedence over focalPoint.
+	const effectivePositionStr =
+		customPosition ??
+		( focalPoint ? mediaPosition( focalPoint ) : undefined );
+	const { x: posX, y: posY } = parseBackgroundPosition(
+		effectivePositionStr ?? ''
+	);
+	const positionXValue = posX ?? '50%';
+	const positionYValue = posY ?? '50%';
+
+	const updateBackgroundPositionX = ( next ) => {
+		if ( next === undefined ) {
+			setAttributes( { customPosition: undefined } );
+			return;
+		}
+		setAttributes( {
+			customPosition: `${ next } ${ positionYValue }`,
+			focalPoint: undefined,
+		} );
+	};
+
+	const updateBackgroundPositionY = ( next ) => {
+		if ( next === undefined ) {
+			setAttributes( { customPosition: undefined } );
+			return;
+		}
+		setAttributes( {
+			customPosition: `${ positionXValue } ${ next }`,
+			focalPoint: undefined,
+		} );
+	};
+
 	const imperativeFocalPointPreview = ( value ) => {
 		const [ styleOfRef, property ] = mediaElement.current
 			? [ mediaElement.current.style, 'objectPosition' ]
@@ -201,6 +254,7 @@ export default function CoverInspectorControls( {
 							setAttributes( {
 								hasParallax: false,
 								focalPoint: undefined,
+								customPosition: undefined,
 								isRepeated: false,
 								alt: '',
 								poster: undefined,
@@ -251,15 +305,19 @@ export default function CoverInspectorControls( {
 							<ToolsPanelItem
 								label={ __( 'Focal point' ) }
 								isShownByDefault
-								hasValue={ () => !! focalPoint }
+								hasValue={ () =>
+									!! focalPoint || !! customPosition
+								}
 								onDeselect={ () =>
 									setAttributes( {
 										focalPoint: undefined,
+										customPosition: undefined,
 									} )
 								}
 							>
 								<FocalPointPicker
 									label={ __( 'Focal point' ) }
+									__experimentalHideControls
 									url={ url }
 									value={ focalPoint }
 									onDragStart={ imperativeFocalPointPreview }
@@ -267,9 +325,31 @@ export default function CoverInspectorControls( {
 									onChange={ ( newFocalPoint ) =>
 										setAttributes( {
 											focalPoint: newFocalPoint,
+											customPosition: undefined,
 										} )
 									}
 								/>
+								<div
+									style={ {
+										display: 'flex',
+										gap: '8px',
+									} }
+								>
+									<UnitControl
+										__next40pxDefaultSize
+										label={ __( 'X position' ) }
+										value={ positionXValue }
+										onChange={ updateBackgroundPositionX }
+										units={ BACKGROUND_POSITION_UNITS }
+									/>
+									<UnitControl
+										__next40pxDefaultSize
+										label={ __( 'Y position' ) }
+										value={ positionYValue }
+										onChange={ updateBackgroundPositionY }
+										units={ BACKGROUND_POSITION_UNITS }
+									/>
+								</div>
 							</ToolsPanelItem>
 						) }
 						{ isVideoBackground && (

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -35,6 +35,7 @@ export default function save( { attributes } ) {
 		customOverlayColor,
 		dimRatio,
 		focalPoint,
+		customPosition,
 		useFeaturedImage,
 		hasParallax,
 		isDark,
@@ -77,13 +78,13 @@ export default function save( { attributes } ) {
 
 	const objectPosition =
 		// prettier-ignore
-		focalPoint && isImgElement
-			  ? mediaPosition(focalPoint)
+		( focalPoint || customPosition ) && isImgElement
+			  ? ( customPosition ?? mediaPosition(focalPoint) )
 			  : undefined;
 
 	const backgroundImage = url ? `url(${ url })` : undefined;
 
-	const backgroundPosition = mediaPosition( focalPoint );
+	const backgroundPosition = customPosition ?? mediaPosition( focalPoint );
 
 	const classes = clsx(
 		{

--- a/packages/components/src/focal-point-picker/index.tsx
+++ b/packages/components/src/focal-point-picker/index.tsx
@@ -89,6 +89,7 @@ const GRID_OVERLAY_TIMEOUT = 600;
 export function FocalPointPicker( {
 	// Prevent passing to internal component.
 	__nextHasNoMarginBottom: _,
+	__experimentalHideControls = false,
 	autoPlay = true,
 	className,
 	help,
@@ -279,13 +280,15 @@ export function FocalPointPicker( {
 					/>
 				</MediaContainer>
 			</MediaWrapper>
-			<Controls
-				hasHelpText={ !! help }
-				point={ { x, y } }
-				onChange={ ( value ) => {
-					onChange?.( getFinalValue( value ) );
-				} }
-			/>
+			{ ! __experimentalHideControls && (
+				<Controls
+					hasHelpText={ !! help }
+					point={ { x, y } }
+					onChange={ ( value ) => {
+						onChange?.( getFinalValue( value ) );
+					} }
+				/>
+			) }
 			{ !! help && <StyledHelp>{ help }</StyledHelp> }
 		</Container>
 	);

--- a/packages/components/src/focal-point-picker/types.ts
+++ b/packages/components/src/focal-point-picker/types.ts
@@ -28,6 +28,14 @@ export type FocalPointPickerProps = Pick<
 	 */
 	__next40pxDefaultSize?: boolean;
 	/**
+	 * If true, the built-in X/Y position text inputs are not rendered.
+	 * Useful when replacing them with custom controls (e.g. ones that
+	 * support additional CSS units beyond percentages).
+	 *
+	 * @default false
+	 */
+	__experimentalHideControls?: boolean;
+	/**
 	 * Autoplays HTML5 video. This only applies to video sources (`url`).
 	 *
 	 * @default true


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/54336

## What?
Add support for non-percent CSS units (rem, em, px, vw, vh) for background image position in BackgroundImagePanel (Poetry block) and Cover block focal point controls.

## Why?
Previously, background image positioning was limited to percent-based values via the FocalPointPicker. Users needed the flexibility to use other CSS units for positioning backgrounds in different scenarios (e.g., `2rem 3em` or `10px 20px`).

## Testing Instructions
1. Open a page/post and add a Poetry block (or any block with background image support)
2. Open "Settings" → "Background" panel
3. Add a background image
4. Locate the "Focal point" section with X/Y position controls
5. Test with different unit controls.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/a924f605-6908-4db9-91eb-dd5211dca11c

## Use of AI Tools
This implementation was developed with assistance from Claude. AI was used for:
- Code exploration and architecture understanding
- Debugging layout and positioning issues