### PR TITLE
Grid: add auto-fit layout option

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -549,12 +549,14 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$responsive_gap_value = '0px';
 		}
 
+		$auto_placement = ! empty( $layout['autoFit'] ) ? 'auto-fit' : 'auto-fill';
+
 		if ( ! empty( $layout['columnCount'] ) && ! empty( $layout['minimumColumnWidth'] ) ) {
 			$max_value       = 'max(min(' . $layout['minimumColumnWidth'] . ', 100%), (100% - (' . $responsive_gap_value . ' * (' . $layout['columnCount'] . ' - 1))) /' . $layout['columnCount'] . ')';
 			$layout_styles[] = array(
 				'selector'     => $selector,
 				'declarations' => array(
-					'grid-template-columns' => 'repeat(auto-fill, minmax(' . $max_value . ', 1fr))',
+					'grid-template-columns' => 'repeat(' . $auto_placement . ', minmax(' . $max_value . ', 1fr))',
 					'container-type'        => 'inline-size',
 				),
 			);
@@ -581,7 +583,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$layout_styles[] = array(
 				'selector'     => $selector,
 				'declarations' => array(
-					'grid-template-columns' => 'repeat(auto-fill, minmax(min(' . $minimum_column_width . ', 100%), 1fr))',
+					'grid-template-columns' => 'repeat(' . $auto_placement . ', minmax(min(' . $minimum_column_width . ', 100%), 1fr))',
 					'container-type'        => 'inline-size',
 				),
 			);

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -8,6 +8,7 @@ import {
 	Flex,
 	FlexItem,
 	RangeControl,
+	ToggleControl,
 	__experimentalNumberControl as NumberControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
@@ -120,7 +121,10 @@ export default {
 			minimumColumnWidth = null,
 			columnCount = null,
 			rowCount = null,
+			autoFit = false,
 		} = layout;
+
+		const autoPlacement = autoFit ? 'auto-fit' : 'auto-fill';
 
 		// Check that the grid layout attributes are of the correct type, so that we don't accidentally
 		// write code that stores a string attribute instead of a number.
@@ -170,7 +174,7 @@ export default {
 				columnCount - 1
 			}) ) / ${ columnCount })`;
 			rules.push(
-				`grid-template-columns: repeat(auto-fill, minmax(${ maxValue }, 1fr))`,
+				`grid-template-columns: repeat(${ autoPlacement }, minmax(${ maxValue }, 1fr))`,
 				`container-type: inline-size`
 			);
 			if ( rowCount ) {
@@ -189,7 +193,7 @@ export default {
 			}
 		} else {
 			rules.push(
-				`grid-template-columns: repeat(auto-fill, minmax(min(${
+				`grid-template-columns: repeat(${ autoPlacement }, minmax(min(${
 					minimumColumnWidth || '12rem'
 				}, 100%), 1fr))`,
 				'container-type: inline-size'
@@ -223,7 +227,8 @@ export default {
 
 // Enables setting minimum width of grid items.
 function GridLayoutMinimumWidthControl( { layout, onChange } ) {
-	const { minimumColumnWidth, columnCount, isManualPlacement } = layout;
+	const { minimumColumnWidth, columnCount, isManualPlacement, autoFit } =
+		layout;
 	const defaultValue = isManualPlacement || columnCount ? null : '12rem';
 	const value = minimumColumnWidth || defaultValue;
 	const [ quantity, unit = 'rem' ] =
@@ -298,6 +303,16 @@ function GridLayoutMinimumWidthControl( { layout, onChange } ) {
 					'Columns will wrap to fewer per row when they can no longer maintain the minimum width.'
 				) }
 			</p>
+			<ToggleControl
+				label={ __( 'Fill available space' ) }
+				checked={ !! autoFit }
+				onChange={ ( autoFitValue ) =>
+					onChange( {
+						...layout,
+						autoFit: autoFitValue || undefined,
+					} )
+				}
+			/>
 		</fieldset>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #57186 <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->
Adds an "Fill available space" toggle to the Grid layout inspector controls. When enabled, switches auto-fill to auto-fit in the generated grid-template-columns CSS, both in the editor and on the frontend for the grid block

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
auto-fill keeps empty column tracks, leaving visible gaps when the number of items doesn't divide evenly into the grid. auto-fit collapses those empty tracks so items stretch to fill the full row. There's no one-size-fits-all default — both behaviours are valid depending on the design — so this exposes it as a user-configurable option rather than changing the default.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Added autoFit to the layout object, read in getLayoutStyle in packages/block-editor/src/layouts/grid.js
- Added a ToggleControl ("Fill available space") in GridLayoutMinimumWidthControl
- Updated lib/block-supports/layout.php to read $layout['autoFit'] and output auto-fit or auto-fill accordingly, so the frontend matches the editor

> Note: will open a backport PR to core once reviews are addressed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert a Group block, set layout to Grid
2. Add 3 items, set a min column width (e.g. 2rem) and max columns to 6
3. View on a wide viewport — notice the empty gap on the right
4. In inspector controls, toggle "Fill available space" on
5. Verify items stretch to fill the row in the editor canvas
6. Save and preview — verify the same behaviour on the frontend

## Screenshots

  | Editor | Frontend
-- | -- | --
Before (auto-fill) | <img width="2406" height="1052" alt="autofill editor" src="https://github.com/user-attachments/assets/5ee73add-70c4-4c0a-a5da-3c80c662c546" /> | <img width="1370" height="728" alt="autofill site" src="https://github.com/user-attachments/assets/316fba0e-be42-4aa1-bc91-efc435996e56" />
After (auto-fit toggle on) | <img width="2438" height="1046" alt="autofit editor" src="https://github.com/user-attachments/assets/8e780c34-376e-4829-aca3-5482b551c7a4" /> | <img width="1482" height="722" alt="autofit site" src="https://github.com/user-attachments/assets/d3b2a9fe-f6cd-4307-88c5-0abe2a3c78bc" />

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Claude (Anthropic) was used to help draft this PR. All code changes were authored and reviewed manually.
