### PR TITLE
Experimental: Take a radical approach to deprecating `core/freeform`

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -99,7 +99,8 @@ function gutenberg_register_block_library_script_special_case( $scripts ) {
 	$script = $scripts->query( $handle, 'registered' );
 	if (
 		! gutenberg_is_experiment_enabled( 'gutenberg-no-tinymce' ) ||
-		! empty( $_GET['requiresTinymce'] )
+		! empty( $_GET['requiresTinymce'] ) ||
+		gutenberg_post_being_edited_requires_classic_block()
 	) {
 		if ( ! in_array( 'editor', $script->deps, true ) ) {
 			$script->deps[] = 'editor';

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -99,8 +99,7 @@ function gutenberg_register_block_library_script_special_case( $scripts ) {
 	$script = $scripts->query( $handle, 'registered' );
 	if (
 		! gutenberg_is_experiment_enabled( 'gutenberg-no-tinymce' ) ||
-		! empty( $_GET['requiresTinymce'] ) ||
-		gutenberg_post_being_edited_requires_classic_block()
+		! empty( $_GET['requiresTinymce'] )
 	) {
 		if ( ! in_array( 'editor', $script->deps, true ) ) {
 			$script->deps[] = 'editor';

--- a/lib/experimental/disable-tinymce.php
+++ b/lib/experimental/disable-tinymce.php
@@ -7,22 +7,10 @@
 
 // add_action( 'admin_footer', 'gutenberg_test_tinymce_access' ); // Uncomment the following line to force an external TinyMCE usage.
 
-/**
- * Render a variable that we'll use to declare that the editor will need the classic block.
- */
-function gutenberg_declare_classic_block_necessary() {
-	if ( ! gutenberg_post_being_edited_requires_classic_block() ) {
-		return;
-	}
-	echo '<script type="text/javascript">window.wp.needsClassicBlock = true;</script>';
-}
-add_action( 'admin_print_footer_scripts', 'gutenberg_declare_classic_block_necessary', 20 );
-
 // If user has already requested TinyMCE, we're ending the experiment.
-if ( ! empty( $_GET['requiresTinymce'] ) || gutenberg_post_being_edited_requires_classic_block() ) {
+if ( ! empty( $_GET['requiresTinymce'] ) ) {
 	return;
 }
-
 
 /**
  * Disable TinyMCE by introducing a placeholder `_WP_Editors` class.
@@ -58,49 +46,4 @@ add_action( 'wp_enqueue_media', 'gutenberg_wp_enqueue_media' );
  */
 function gutenberg_test_tinymce_access() {
 	echo '<script type="text/javascript">const a = window.tinymce.$;</script>';
-}
-
-/**
- * Whether the current editor contains a classic block instance.
- *
- * @return bool True if the editor contains a classic block, false otherwise.
- */
-function gutenberg_post_being_edited_requires_classic_block() {
-	if ( ! is_admin() ) {
-		return false;
-	}
-
-	// Continue only if we're in the post editor.
-	if ( empty( $_GET['post'] ) || empty( $_GET['action'] ) || 'edit' !== $_GET['action'] ) {
-		return false;
-	}
-
-	// Bail if for some reason the post isn't found.
-	$current_post = get_post( absint( $_GET['post'] ) );
-	if ( ! $current_post ) {
-		return false;
-	}
-
-	// Check if block editor is disabled by "Classic Editor" or another plugin.
-	if (
-		function_exists( 'use_block_editor_for_post_type' ) &&
-		! use_block_editor_for_post_type( $current_post->post_type )
-	) {
-		return true;
-	}
-
-	$content = $current_post->post_content;
-	if ( empty( $content ) ) {
-		return false;
-	}
-
-	$parsed_blocks = parse_blocks( $content );
-	foreach ( $parsed_blocks as $block ) {
-		$is_freeform_block = empty( $block['blockName'] ) || 'core/freeform' === $block['blockName'];
-		if ( $is_freeform_block && strlen( trim( $block['innerHTML'] ) ) > 0 ) {
-			return true;
-		}
-	}
-
-	return false;
 }

--- a/lib/experimental/disable-tinymce.php
+++ b/lib/experimental/disable-tinymce.php
@@ -7,6 +7,17 @@
 
 // add_action( 'admin_footer', 'gutenberg_test_tinymce_access' ); // Uncomment the following line to force an external TinyMCE usage.
 
+/**
+ * Render a variable that we'll use to declare that the editor will need the classic block.
+ */
+function gutenberg_declare_classic_block_necessary() {
+	if ( ! gutenberg_post_being_edited_requires_classic_block() ) {
+		return;
+	}
+	echo '<script type="text/javascript">window.wp.needsClassicBlock = true;</script>';
+}
+add_action( 'admin_print_footer_scripts', 'gutenberg_declare_classic_block_necessary', 20 );
+
 // If user has already requested TinyMCE, we're ending the experiment.
 if ( ! empty( $_GET['requiresTinymce'] ) || gutenberg_post_being_edited_requires_classic_block() ) {
 	return;

--- a/lib/experimental/disable-tinymce.php
+++ b/lib/experimental/disable-tinymce.php
@@ -8,7 +8,7 @@
 // add_action( 'admin_footer', 'gutenberg_test_tinymce_access' ); // Uncomment the following line to force an external TinyMCE usage.
 
 // If user has already requested TinyMCE, we're ending the experiment.
-if ( ! empty( $_GET['requiresTinymce'] ) ) {
+if ( ! empty( $_GET['requiresTinymce'] ) || gutenberg_post_being_edited_requires_classic_block() ) {
 	return;
 }
 
@@ -46,4 +46,41 @@ add_action( 'wp_enqueue_media', 'gutenberg_wp_enqueue_media' );
  */
 function gutenberg_test_tinymce_access() {
 	echo '<script type="text/javascript">const a = window.tinymce.$;</script>';
+}
+
+/**
+ * Whether the current editor contains a classic block instance.
+ *
+ * @return bool True if the editor contains a classic block, false otherwise.
+ */
+function gutenberg_post_being_edited_requires_classic_block() {
+	if ( ! is_admin() ) {
+		return false;
+	}
+
+	// Continue only if we're in the post editor.
+	if ( empty( $_GET['post'] ) || empty( $_GET['action'] ) || 'edit' !== $_GET['action'] ) {
+		return false;
+	}
+
+	// Bail if for some reason the post isn't found.
+	$current_post = get_post( absint( $_GET['post'] ) );
+	if ( ! $current_post ) {
+		return false;
+	}
+
+	// Check if block editor is disabled by "Classic Editor" or another plugin.
+	if (
+		function_exists( 'use_block_editor_for_post_type' ) &&
+		! use_block_editor_for_post_type( $current_post->post_type )
+	) {
+		return true;
+	}
+
+	$content = $current_post->post_content;
+	if ( empty( $content ) ) {
+		return false;
+	}
+
+	return false;
 }

--- a/lib/experimental/disable-tinymce.php
+++ b/lib/experimental/disable-tinymce.php
@@ -69,18 +69,25 @@ function gutenberg_post_being_edited_requires_classic_block() {
 		return false;
 	}
 
-	// Check if block editor is disabled by "Classic Editor" or another plugin.
-	if (
-		function_exists( 'use_block_editor_for_post_type' ) &&
-		! use_block_editor_for_post_type( $current_post->post_type )
-	) {
+	/**
+	 * Filters whether the Classic block should be enabled site-wide,
+	 * regardless of the post being edited.
+	 *
+	 * @param bool $enabled Whether to enable the Classic block. Default false.
+	 */
+	if ( apply_filters( 'gutenberg_classic_block_enabled', false ) ) {
 		return true;
 	}
 
-	$content = $current_post->post_content;
-	if ( empty( $content ) ) {
-		return false;
-	}
+	// Check if block editor is disabled by "Classic Editor" or another plugin.
+	$requires_classic_block = function_exists( 'use_block_editor_for_post_type' ) &&
+		! use_block_editor_for_post_type( $current_post->post_type );
 
-	return false;
+	/**
+	 * Filters whether the current post being edited requires the Classic block.
+	 *
+	 * @param bool    $requires_classic_block Whether the current post requires the Classic block.
+	 * @param WP_Post $current_post           The post being edited.
+	 */
+	return (bool) apply_filters( 'gutenberg_post_requires_classic_block', $requires_classic_block, $current_post );
 }

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -303,7 +303,8 @@ const getAllBlocks = () => {
 	//   - a query argument specifies that TinyMCE should be loaded
 	if (
 		window?.wp?.oldEditor &&
-		( ! window?.__experimentalDisableTinymce ||
+		( window?.wp?.needsClassicBlock ||
+			! window?.__experimentalDisableTinymce ||
 			!! new URLSearchParams( window?.location?.search ).get(
 				'requiresTinymce'
 			) )

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -299,13 +299,11 @@ const getAllBlocks = () => {
 	// When in a WordPress context, conditionally
 	// add the classic block and TinyMCE editor
 	// under any of the following conditions:
-	//   - the current post contains a classic block
 	//   - the experiment to disable TinyMCE isn't active.
 	//   - a query argument specifies that TinyMCE should be loaded
 	if (
 		window?.wp?.oldEditor &&
-		( window?.wp?.needsClassicBlock ||
-			! window?.__experimentalDisableTinymce ||
+		( ! window?.__experimentalDisableTinymce ||
 			!! new URLSearchParams( window?.location?.search ).get(
 				'requiresTinymce'
 			) )

--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -4,7 +4,8 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
 import { Button } from '@wordpress/components';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, rawHandler } from '@wordpress/blocks';
+import { autop } from '@wordpress/autop';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	Warning,
@@ -34,7 +35,7 @@ export default function MissingEdit( { attributes, clientId } ) {
 		},
 		[ clientId ]
 	);
-	const { replaceBlock } = useDispatch( blockEditorStore );
+	const { replaceBlock, replaceBlocks } = useDispatch( blockEditorStore );
 
 	function convertToHTML() {
 		replaceBlock(
@@ -45,15 +46,35 @@ export default function MissingEdit( { attributes, clientId } ) {
 		);
 	}
 
+	function convertToBlocks() {
+		replaceBlocks(
+			clientId,
+			rawHandler( {
+				HTML: autop( originalUndelimitedContent ).trim(),
+			} )
+		);
+	}
+
 	const actions = [];
 	let messageHTML;
+
+	const convertToBlocksButton = (
+		<Button
+			__next40pxDefaultSize
+			key="convert-to-blocks"
+			onClick={ convertToBlocks }
+			variant="primary"
+		>
+			{ __( 'Convert to blocks' ) }
+		</Button>
+	);
 
 	const convertToHtmlButton = (
 		<Button
 			__next40pxDefaultSize
-			key="convert"
+			key="keep-as-html"
 			onClick={ convertToHTML }
-			variant="primary"
+			variant="secondary"
 		>
 			{ __( 'Keep as HTML' ) }
 		</Button>
@@ -64,14 +85,15 @@ export default function MissingEdit( { attributes, clientId } ) {
 		! hasFreeformBlock &&
 		( ! originalName || originalName === 'core/freeform' )
 	) {
+		actions.push( convertToBlocksButton );
 		if ( hasHTMLBlock ) {
 			messageHTML = __(
-				'It appears you are trying to use the deprecated Classic block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely. Alternatively, if you have unsaved changes, you can save them and refresh to use the Classic block.'
+				'It appears you are trying to use the deprecated Classic block. You can leave this block intact, convert its content to blocks, convert it to a Custom HTML block, or remove it entirely.'
 			);
 			actions.push( convertToHtmlButton );
 		} else {
 			messageHTML = __(
-				'It appears you are trying to use the deprecated Classic block. You can leave this block intact, or remove it entirely. Alternatively, if you have unsaved changes, you can save them and refresh to use the Classic block.'
+				'It appears you are trying to use the deprecated Classic block. You can leave this block intact, convert its content to blocks, or remove it entirely.'
 			);
 		}
 	} else if ( hasContent && hasHTMLBlock ) {

--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -69,12 +69,12 @@ export default function MissingEdit( { attributes, clientId } ) {
 		</Button>
 	);
 
-	const convertToHtmlButton = (
+	const getConvertToHtmlButton = ( variant ) => (
 		<Button
 			__next40pxDefaultSize
 			key="keep-as-html"
 			onClick={ convertToHTML }
-			variant="secondary"
+			variant={ variant }
 		>
 			{ __( 'Keep as HTML' ) }
 		</Button>
@@ -90,7 +90,7 @@ export default function MissingEdit( { attributes, clientId } ) {
 			messageHTML = __(
 				'It appears you are trying to use the deprecated Classic block. You can leave this block intact, convert its content to blocks, convert it to a Custom HTML block, or remove it entirely.'
 			);
-			actions.push( convertToHtmlButton );
+			actions.push( getConvertToHtmlButton( 'secondary' ) );
 		} else {
 			messageHTML = __(
 				'It appears you are trying to use the deprecated Classic block. You can leave this block intact, convert its content to blocks, or remove it entirely.'
@@ -104,7 +104,7 @@ export default function MissingEdit( { attributes, clientId } ) {
 			),
 			originalName
 		);
-		actions.push( convertToHtmlButton );
+		actions.push( getConvertToHtmlButton( 'primary' ) );
 	} else {
 		messageHTML = sprintf(
 			/* translators: %s: block name */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
