### PR TITLE
ui: Align WithCustomZIndex Storybook examples across overlays

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Documentation
 
 -   Restructure setup docs into "Within standard WordPress editor screens" and "Elsewhere" for clarity ([#77338](https://github.com/WordPress/gutenberg/pull/77338)).
+-   `Dialog`, `AlertDialog`, `Drawer`, `Popover`, `Tooltip`, `Select`: Align `WithCustomZIndex` Storybook examples so every overlay demonstrates the portal-based per-instance override with consistent copy and z-index value.
 
 ### Bug Fixes
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,7 +13,6 @@
 ### Documentation
 
 -   Restructure setup docs into "Within standard WordPress editor screens" and "Elsewhere" for clarity ([#77338](https://github.com/WordPress/gutenberg/pull/77338)).
--   `Dialog`, `AlertDialog`, `Drawer`, `Popover`, `Tooltip`, `Select`: Align `WithCustomZIndex` Storybook examples so every overlay demonstrates the portal-based per-instance override with consistent copy and z-index value.
 
 ### Bug Fixes
 

--- a/packages/ui/src/alert-dialog/stories/index.story.tsx
+++ b/packages/ui/src/alert-dialog/stories/index.story.tsx
@@ -117,15 +117,14 @@ export const WithCustomContent: Story = {
  * you want it above.
  *
  * `AlertDialog` reuses `Dialog`'s styles, so the same
- * `--wp-ui-dialog-z-index` CSS variable controls the z-index of both the
- * backdrop and the popup. Override it either:
+ * `--wp-ui-dialog-z-index` CSS variable controls the z-index of the alert
+ * dialog's backdrop and popup. Override it either:
  *
  * - **Globally**, by setting the variable on `:root` or `body` (raises every
  *   dialog and alert dialog in the page), or
  * - **Per instance**, by passing an `AlertDialog.Portal` with a `style` (or
  *   `className`) to `AlertDialog.Popup`'s `portal` prop. The variable
- *   cascades from the portal wrapper to the backdrop and the popup, which
- *   are both rendered inside it.
+ *   cascades from the portal wrapper to everything rendered inside it.
  *
  * This story demonstrates the per-instance approach.
  */

--- a/packages/ui/src/dialog/stories/index.story.tsx
+++ b/packages/ui/src/dialog/stories/index.story.tsx
@@ -136,15 +136,14 @@ export const AllSizes: Story = {
  * create situations where a dialog renders below another popover when you
  * want it above.
  *
- * The `--wp-ui-dialog-z-index` CSS variable controls the z-index of both the
- * backdrop and the popup. Override it either:
+ * The `--wp-ui-dialog-z-index` CSS variable controls the z-index of the
+ * dialog's backdrop and popup. Override it either:
  *
  * - **Globally**, by setting the variable on `:root` or `body` (raises every
  *   dialog in the page), or
  * - **Per instance**, by passing a `Dialog.Portal` with a `style` (or
  *   `className`) to `Dialog.Popup`'s `portal` prop. The variable cascades
- *   from the portal wrapper to the backdrop and the popup, which are both
- *   rendered inside it.
+ *   from the portal wrapper to everything rendered inside it.
  *
  * This story demonstrates the per-instance approach.
  */

--- a/packages/ui/src/drawer/stories/index.story.tsx
+++ b/packages/ui/src/drawer/stories/index.story.tsx
@@ -263,8 +263,7 @@ function DirectionSelector( {
  *   drawer in the page), or
  * - **Per instance**, by passing a `Drawer.Portal` with a `style` (or
  *   `className`) to `Drawer.Popup`'s `portal` prop. The variable cascades
- *   from the portal wrapper to everything rendered inside it (backdrop,
- *   viewport, and popup).
+ *   from the portal wrapper to everything rendered inside it.
  *
  * This story demonstrates the per-instance approach.
  */

--- a/packages/ui/src/form/primitives/select/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/select/stories/index.story.tsx
@@ -252,20 +252,19 @@ export const WithCustomTriggerAndItem: Story = {
 
 /**
  * Popovers in Gutenberg are managed with explicit z-index values, which can
- * create situations where a popover renders below another popover, when you
- * want it to be rendered above.
+ * create situations where a select popup renders below another popover when
+ * you want it above.
  *
- * The `--wp-ui-select-z-index` CSS variable is an escape hatch for that
- * case. Override it either:
+ * The `--wp-ui-select-z-index` CSS variable controls the z-index of the
+ * `Select` positioner. Override it either:
  *
  * - **Globally**, by setting the variable on `:root` or `body` (raises every
- *   `Select` popover in the page),
- * - **Per instance on the popup**, by setting the variable via `style` on
- *   `Select.Popup` (as this story does), or
- * - **Per instance on the portal**, by passing a `Select.Portal` with a
- *   `style` (or `className`) to `Select.Popup`'s `portal` prop. The
- *   variable then cascades from the portal wrapper to everything rendered
- *   inside it.
+ *   `Select` popover in the page), or
+ * - **Per instance**, by passing a `Select.Portal` with a `style` (or
+ *   `className`) to `Select.Popup`'s `portal` prop. The variable cascades
+ *   from the portal wrapper to everything rendered inside it.
+ *
+ * This story demonstrates the per-instance approach.
  */
 export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',
@@ -273,7 +272,13 @@ export const WithCustomZIndex: Story = {
 		children: (
 			<>
 				<Select.Trigger />
-				<Select.Popup style={ { '--wp-ui-select-z-index': '1000001' } }>
+				<Select.Popup
+					portal={
+						<Select.Portal
+							style={ { '--wp-ui-select-z-index': '9999' } }
+						/>
+					}
+				>
 					<Select.Item value="Item 1" />
 					<Select.Item value="Item 2" />
 				</Select.Popup>

--- a/packages/ui/src/popover/stories/index.story.tsx
+++ b/packages/ui/src/popover/stories/index.story.tsx
@@ -762,20 +762,19 @@ export const CrossIframeWithSlotFill: Story = {
 
 /**
  * Popovers in Gutenberg are managed with explicit z-index values, which can
- * create situations where a popover renders below another popover, when you
- * want it to be rendered above.
+ * create situations where a popover renders below another popover when you
+ * want it above.
  *
- * The `--wp-ui-popover-z-index` CSS variable is an escape hatch for that
- * case. Override it either:
+ * The `--wp-ui-popover-z-index` CSS variable controls the z-index of the
+ * popover's positioner (and its optional backdrop). Override it either:
  *
  * - **Globally**, by setting the variable on `:root` or `body` (raises every
- *   popover in the page),
- * - **Per instance on the popup**, by setting the variable via `style` on
- *   `Popover.Popup` (as this story does), or
- * - **Per instance on the portal**, by passing a `Popover.Portal` with a
- *   `style` (or `className`) to `Popover.Popup`'s `portal` prop. The
- *   variable then cascades from the portal wrapper to everything rendered
- *   inside it.
+ *   popover in the page), or
+ * - **Per instance**, by passing a `Popover.Portal` with a `style` (or
+ *   `className`) to `Popover.Popup`'s `portal` prop. The variable cascades
+ *   from the portal wrapper to everything rendered inside it.
+ *
+ * This story demonstrates the per-instance approach.
  */
 export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',
@@ -783,7 +782,13 @@ export const WithCustomZIndex: Story = {
 		children: (
 			<>
 				<Popover.Trigger>Open Popover</Popover.Trigger>
-				<Popover.Popup style={ { '--wp-ui-popover-z-index': '9999' } }>
+				<Popover.Popup
+					portal={
+						<Popover.Portal
+							style={ { '--wp-ui-popover-z-index': '9999' } }
+						/>
+					}
+				>
 					<Popover.Arrow />
 					<Popover.Title
 						style={ {
@@ -793,8 +798,9 @@ export const WithCustomZIndex: Story = {
 						Custom z-index
 					</Popover.Title>
 					<Popover.Description>
-						This popover&apos;s positioner has z-index: 9999 via the
-						`--wp-ui-popover-z-index` CSS custom property.
+						This popover renders at `z-index: 9999` via the
+						`--wp-ui-popover-z-index` CSS custom property, set on
+						`Popover.Portal` through the `portal` prop.
 					</Popover.Description>
 				</Popover.Popup>
 			</>

--- a/packages/ui/src/tooltip/stories/index.story.tsx
+++ b/packages/ui/src/tooltip/stories/index.story.tsx
@@ -81,14 +81,14 @@ export const Positioning: StoryObj< typeof Tooltip.Root > = {
  * create situations where a tooltip renders below another popover when you
  * want it above.
  *
- * The `--wp-ui-tooltip-z-index` CSS variable is an escape hatch for that
- * case. Override it either:
+ * The `--wp-ui-tooltip-z-index` CSS variable controls the z-index of the
+ * tooltip's positioner. Override it either:
  *
  * - **Globally**, by setting the variable on `:root` or `body` (raises every
  *   tooltip in the page), or
  * - **Per instance**, by passing a `Tooltip.Portal` with a `style` (or
  *   `className`) to `Tooltip.Popup`'s `portal` prop. The variable cascades
- *   from the portal wrapper to the popup rendered inside it.
+ *   from the portal wrapper to everything rendered inside it.
  *
  * This story demonstrates the per-instance approach.
  */


### PR DESCRIPTION
## What?

Every overlay (`Dialog`, `AlertDialog`, `Drawer`, `Popover`, `Tooltip`, `Select`) ships a `WithCustomZIndex` Storybook story documenting the `--wp-ui-<overlay>-z-index` CSS-variable escape hatch for Gutenberg's legacy z-index world. Over time they drifted in both what they demonstrate and how they describe it — this PR realigns them so the escape hatch reads the same way across the library.

## Why?

Readers opening more than one overlay story ran into:

- Two subtly different example shapes — Popover / Select used an inline `style` on `<Overlay.Popup>`, the others used `<Overlay.Portal style={ … } />`. The inline-on-Popup form worked only because `style` is silently forwarded to the internal positioner, which isn't obvious from the API.
- Three-option bullet lists vs two-option bullet lists with no explanation for the difference.
- Inconsistent closing sentences ("This story demonstrates the per-instance approach." in some, absent in others).
- "escape hatch" vs "controls the z-index of …" phrasing, used arbitrarily across overlays.
- `Select` demoing \`1000001\` while every other overlay used \`9999\`, with no rationale.

## How?

Standardise all six stories on the portal-based per-instance override:

```jsx
<Overlay.Popup
    portal={
        <Overlay.Portal style={ { '--wp-ui-<overlay>-z-index': '9999' } } />
    }
>
    …
</Overlay.Popup>
```

- Switch `Popover` and `Select` to the portal form. The portal wrapper is an ancestor of every positioner / backdrop / popup, so the variable cascades uniformly regardless of the overlay's internal structure.
- Use \`9999\` as the demonstration value everywhere.
- Collapse the bullet list to the same two options (Global / Per instance via Portal) and end each description with the same "This story demonstrates the per-instance approach." closing line.
- Align problem-statement wording ("…when you want it above." everywhere) and variable-description wording ("controls the z-index of …").

Pure Storybook/docs change — no runtime behaviour changes.

## Testing Instructions

1. \`npm run storybook:dev\`
2. For each overlay (Dialog / AlertDialog / Drawer / Popover / Tooltip / Select), open the \`WithCustomZIndex\` story.
3. Verify the description reads with the same structure and wording (just the overlay name swapped), and the code example uses \`<Overlay.Portal style={ { '--wp-ui-…-z-index': '9999' } } />\`.
4. Trigger each overlay and confirm it still renders on top (z-index 9999 is applied).

## Testing Instructions for Keyboard

Open each \`WithCustomZIndex\` story and verify the overlay can still be opened/closed via keyboard as before.

## Screenshots or screencast

N/A — docs/story-only change.

Made with [Cursor](https://cursor.com)