### PR TITLE
Fix missing custom duotone creation menu in duotone controls

### DIFF
--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -66,6 +66,23 @@ function useHasDuotoneControl( settings ) {
 	);
 }
 
+export function getCustomDuotoneFlags(
+	settings,
+	colorPalette,
+	enableCustomDuotone = true
+) {
+	const disableCustomColors = ! settings?.color?.custom;
+	const disableCustomDuotone =
+		! enableCustomDuotone ||
+		! settings?.color?.customDuotone ||
+		( colorPalette?.length === 0 && disableCustomColors );
+
+	return {
+		disableCustomColors,
+		disableCustomDuotone,
+	};
+}
+
 function FiltersToolsPanel( {
 	resetAllFilter,
 	onChange,
@@ -172,6 +189,7 @@ export default function FiltersPanel( {
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
+	enableCustomDuotone = true,
 } ) {
 	const decodeValue = ( rawValue ) =>
 		getValueFromVariable( { settings }, '', rawValue );
@@ -186,6 +204,11 @@ export default function FiltersPanel( {
 		presetSetting: 'palette',
 		defaultSetting: 'defaultPalette',
 	} );
+	const { disableCustomColors, disableCustomDuotone } = getCustomDuotoneFlags(
+		settings,
+		colorPalette,
+		enableCustomDuotone
+	);
 	const duotone = decodeValue( inheritedValue?.filter?.duotone );
 	const setDuotone = ( newValue ) => {
 		const duotonePreset = duotonePalette.find( ( { colors } ) => {
@@ -241,9 +264,12 @@ export default function FiltersPanel( {
 									<DuotonePicker
 										colorPalette={ colorPalette }
 										duotonePalette={ duotonePalette }
-										// TODO: Re-enable both when custom colors are supported for block-level styles.
-										disableCustomColors
-										disableCustomDuotone
+										disableCustomColors={
+											disableCustomColors
+										}
+										disableCustomDuotone={
+											disableCustomDuotone
+										}
 										value={ duotone }
 										onChange={ setDuotone }
 									/>

--- a/packages/block-editor/src/components/global-styles/test/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/filters-panel.js
@@ -1,0 +1,82 @@
+/**
+ * Internal dependencies
+ */
+import { getCustomDuotoneFlags } from '../filters-panel';
+
+describe( 'getCustomDuotoneFlags', () => {
+	it( 'enables custom duotone when custom color and duotone are enabled', () => {
+		const settings = {
+			color: {
+				custom: true,
+				customDuotone: true,
+			},
+		};
+
+		expect( getCustomDuotoneFlags( settings, [] ) ).toEqual( {
+			disableCustomColors: false,
+			disableCustomDuotone: false,
+		} );
+	} );
+
+	it( 'disables custom duotone when custom duotone is disabled', () => {
+		const settings = {
+			color: {
+				custom: true,
+				customDuotone: false,
+			},
+		};
+
+		expect(
+			getCustomDuotoneFlags( settings, [ { slug: 'blue' } ] )
+		).toEqual( {
+			disableCustomColors: false,
+			disableCustomDuotone: true,
+		} );
+	} );
+
+	it( 'disables custom duotone when both custom colors and palette are unavailable', () => {
+		const settings = {
+			color: {
+				custom: false,
+				customDuotone: true,
+			},
+		};
+
+		expect( getCustomDuotoneFlags( settings, [] ) ).toEqual( {
+			disableCustomColors: true,
+			disableCustomDuotone: true,
+		} );
+	} );
+
+	it( 'allows custom duotone when custom colors are disabled but palette exists', () => {
+		const settings = {
+			color: {
+				custom: false,
+				customDuotone: true,
+			},
+		};
+
+		expect(
+			getCustomDuotoneFlags( settings, [ { slug: 'brand' } ] )
+		).toEqual( {
+			disableCustomColors: true,
+			disableCustomDuotone: false,
+		} );
+	} );
+
+	it( 'disables custom duotone when explicitly disabled by the caller', () => {
+		const settings = {
+			color: {
+				custom: true,
+				customDuotone: true,
+			},
+		};
+
+		expect(
+			getCustomDuotoneFlags( settings, [ { slug: 'brand' } ], false )
+		).toEqual( {
+			disableCustomColors: false,
+			disableCustomDuotone: true,
+		} );
+	} );
+} );

--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -393,6 +393,7 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 					onChange={ setStyle }
 					settings={ settings }
 					includeLayoutControls
+					enableCustomDuotone={ false }
 				/>
 			) }
 			{ hasImageSettingsPanel && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/58548

Fixes the missing custom duotone creator in the block sidebar by making FiltersPanel read customDuotone and custom (color) settings instead of always passing hardcoded disableCustomColors and disableCustomDuotone to DuotonePicker.

Removed the custom duotone creator at Global block settings level as per the comment: https://github.com/WordPress/gutenberg/issues/58548#issuecomment-1945402681

## Why?
When editing an Image or Cover block, the custom duotone creator (the color picker that lets you build a two-tone filter from scratch) appeared in the block toolbar but was completely absent from the block sidebar. This was a regression caused by a hardcoded disableCustomColors and disableCustomDuotone in FiltersPanel, originally added with a TODO comment noting it should be re-enabled when block-level custom colors were supported. 

## How?
In filters-panel.js:

Extracted a getCustomDuotoneFlags( settings, colorPalette, enableCustomDuotone ) helper that derives disableCustomColors and disableCustomDuotone from the actual block settings, matching the logic already used in the toolbar path (DuotonePanelPure in duotone.js).

Added an enableCustomDuotone prop on FiltersPanel (defaults to true) to allow callers to opt out if needed.

Removed the hardcoded disableCustomColors and disableCustomDuotone from DuotonePicker, replacing them with the values computed from settings.

## Testing Instructions
1. Activate a block theme.
2. Open a post in the Editor.
3. Insert an Image block and upload or select an image.
4. Open the block sidebar (Inspector Controls).
5. Scroll to the Filters panel and click the Duotone toggle.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|Sidebar shows only preset swatches, no custom creator|Sidebar shows custom duotone color picker|
| <img width="521" height="302" alt="image" src="https://github.com/user-attachments/assets/c7d23ec9-ffd3-4457-b7d5-ff4d0a20411f" /> |<img width="521" height="572" alt="image" src="https://github.com/user-attachments/assets/2487eb55-717a-4ed0-9cce-0186c4ac371d" />|
|Custom creator present in global site editor settings| Disabled custom creator in global editor settings |
|<img width="493" height="402" alt="image" src="https://github.com/user-attachments/assets/361a5e9c-bc81-435a-b9e4-ae3e3253fc6c" />| <img width="493" height="362" alt="image" src="https://github.com/user-attachments/assets/213e4e42-72f7-4411-8982-880d78db708f" />|


## Use of AI Tools
This PR was developed with assistance from Claude for code generation and iteration. All changes were reviewed and verified manually.
