### PR TITLE
Fix Post Featured Image overflow in Group flex layouts with aspect ratio

### DIFF
--- a/packages/block-library/src/post-featured-image/style.scss
+++ b/packages/block-library/src/post-featured-image/style.scss
@@ -15,6 +15,10 @@
 		box-sizing: border-box;
 	}
 
+	@at-root .wp-block-group.is-layout-flex & {
+		max-width: 100%;
+	}
+
 	&.alignwide img,
 	&.alignfull img {
 		width: 100%;


### PR DESCRIPTION
## What?
Closes #67430

Fixes an overflow issue where Post Featured Image can exceed its container width in Group flex layouts (Stack/Row) when an aspect ratio is set (for example 4/3 or 16/9).

## Why?
The issue has been reproducible across multiple environments and browsers when Query Loop items include featured images with mixed source proportions and a wide aspect ratio. This breaks expected layout behavior in Stack/Row contexts.

## How?
Adds a minimal, scoped style rule for Post Featured Image only when it is inside a Group flex layout:

- Apply `max-width: 100%` in `.wp-block-group.is-layout-flex` context

This keeps the fix targeted to the problematic layout context and avoids broader style impact.

## Testing Instructions
1. Create or edit a post/page.
2. Insert a Query Loop block.
3. In Post Template, insert a Group block and set layout to Stack (or Row).
4. Add Post Featured Image and set aspect ratio to `4/3` or `16/9`.
5. Use posts with varied featured image proportions (portrait, landscape, square).
6. Confirm the featured image does not overflow in the editor.
7. Preview on frontend and confirm no overflow there either.
8. Verify Post Featured Image behavior outside Group flex layouts is unchanged.

## Screenshots or screencast
Before: Featured image overflows in Stack/Row with wide aspect ratio

https://github.com/user-attachments/assets/84a50b1b-609a-44a2-83a1-097ba9828864



After: Featured image remains constrained within container

https://github.com/user-attachments/assets/87c00dd9-83c3-4f25-baaf-5a1c7d1b5fb7


