### PR TITLE
Connectors: Treat network-active plugins as active

### DIFF
--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -114,8 +114,12 @@ export function useConnectorPlugin( {
 
 			// Plugin data resolved — user has API permissions.
 			if ( plugin ) {
+				// Treat both single-site and network-active plugins as active.
+				const isPluginActive =
+					plugin.status === 'active' ||
+					plugin.status === 'network-active';
 				return {
-					derivedPluginStatus: ( plugin.status === 'active'
+					derivedPluginStatus: ( isPluginActive
 						? 'active'
 						: 'inactive' ) as PluginStatus,
 					canManagePlugins: true,


### PR DESCRIPTION
## What?
Closes #77627

Updates the connectors UI plugin status check to recognize the `network-active` plugin status returned by the REST `/wp/v2/plugins/<slug>` endpoint as an active state.

## Why?
On a multisite install, network-activated connector plugins (Akismet and the three AI providers — anthropic, google, openai — are the four that ship with a `plugin.file` today) are displayed on the Connectors screen with an "Activate" button even though they're already running. Clicking the button works, but the state is misreported until the user takes action.

The cause is a strict equality check in `useConnectorPlugin`:

```ts
derivedPluginStatus: ( plugin.status === 'active' ? 'active' : 'inactive' )
```

The REST plugins endpoint can return three values for `status`: `active`, `inactive`, and `network-active`. Gutenberg's own `PluginStatus` type in `packages/core-data/src/entity-types/plugin.ts` declares all three. The connectors hook treats anything other than literally `active` as inactive, so `network-active` falls through to `inactive`.

The server-side `isActivated` flag is reported correctly for network-active plugins, but the client always prefers the REST record once it resolves and ignores the server-provided fallback in that path.

## How?
Accept both `active` and `network-active` as the active state in the derived plugin status. This is a minimal, general fix that resolves the issue for every connector at once rather than a per-plugin patch.

## Testing Instructions
1. Set up a multisite WordPress install with Gutenberg trunk.
2. Network-activate one of the AI provider plugins, e.g. "AI Provider for OpenAI".
3. Visit `/wp-admin/options-connectors.php` on the main site.
4. Verify the connector for the network-active plugin shows "Set up" (not "Activate") and behaves as already active.
5. Repeat with a single-site activated plugin to verify no regression in the standard case.
6. Repeat with the plugin deactivated to verify the "Activate" button still appears for genuinely inactive plugins.

### Testing Instructions for Keyboard
No UI/interaction changes — same buttons, same focus order; only the displayed label/state for network-active plugins changes from "Activate" to "Set up".

## Screenshots or screencast
n/a — only the button label/state changes for the affected scenario.

## Use of AI Tools
Authored with assistance from Claude Code. All code, reasoning, and the issue verification were reviewed by me before submitting.