### PR TITLE
Image editor: hold Shift while resizing to lock current aspect ratio

### DIFF
--- a/packages/media-editor/src/image-editor/core/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/stencil-math.ts
@@ -282,8 +282,18 @@ export function computeShiftLockedResizeRect(
 			newWidth = maxWidth;
 			newHeight = newWidth / normalizedRatio;
 		}
-		newWidth = Math.max( newWidth, MIN_CROP_SIZE );
-		newHeight = Math.max( newHeight, MIN_CROP_SIZE );
+		// Enforce the minimum on the driving axis, then derive the
+		// other axis from the ratio so it stays consistent. The
+		// effective minimum height has to satisfy MIN_CROP_SIZE on
+		// both axes simultaneously.
+		const minHeight = Math.max(
+			MIN_CROP_SIZE,
+			MIN_CROP_SIZE / normalizedRatio
+		);
+		if ( newHeight < minHeight ) {
+			newHeight = minHeight;
+			newWidth = newHeight * normalizedRatio;
+		}
 		// Re-anchor the dragged axis to the opposite edge so the
 		// height adjustment after clamping keeps that edge fixed.
 		const newY = handle === 'n' ? s.y + s.height - newHeight : s.y;
@@ -305,8 +315,11 @@ export function computeShiftLockedResizeRect(
 		newHeight = maxHeight;
 		newWidth = newHeight * normalizedRatio;
 	}
-	newWidth = Math.max( newWidth, MIN_CROP_SIZE );
-	newHeight = Math.max( newHeight, MIN_CROP_SIZE );
+	const minWidth = Math.max( MIN_CROP_SIZE, MIN_CROP_SIZE * normalizedRatio );
+	if ( newWidth < minWidth ) {
+		newWidth = minWidth;
+		newHeight = newWidth / normalizedRatio;
+	}
 	const newX = handle === 'w' ? s.x + s.width - newWidth : s.x;
 	return {
 		x: newX,

--- a/packages/media-editor/src/image-editor/core/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/stencil-math.ts
@@ -204,3 +204,114 @@ export function computeLockedResizeRect(
 
 	return { x: newX, y: newY, width: distW, height: distH };
 }
+
+/**
+ * Compute the new crop rect for a resize that temporarily locks the
+ * aspect ratio to `drag.startRect`'s ratio (e.g. while Shift is held).
+ *
+ * Corner handles delegate to {@link computeLockedResizeRect}. Edge
+ * handles size the dragged axis freely, then expand the perpendicular
+ * axis symmetrically around the rect's center to preserve the ratio,
+ * clamping symmetrically so the rect stays within bounds.
+ *
+ * @param drag      The current drag state.
+ * @param clientX   Current mouse/touch X position in pixels.
+ * @param clientY   Current mouse/touch Y position in pixels.
+ * @param imageSize The rendered image dimensions in pixels.
+ * @param bounds    The allowed crop area bounds.
+ * @return The new crop rect in normalized coordinates.
+ */
+export function computeShiftLockedResizeRect(
+	drag: ResizeDragState,
+	clientX: number,
+	clientY: number,
+	imageSize: Size,
+	bounds: CropBounds
+): NormalizedRect {
+	const s = drag.startRect;
+	const pixelW = s.width * imageSize.width;
+	const pixelH = s.height * imageSize.height;
+	if ( pixelH <= 0 || pixelW <= 0 ) {
+		return computeFreeResizeRect(
+			drag,
+			clientX,
+			clientY,
+			imageSize,
+			bounds
+		);
+	}
+	const normalizedRatio = s.width / s.height;
+
+	const handle = drag.handle;
+	if (
+		handle === 'nw' ||
+		handle === 'ne' ||
+		handle === 'sw' ||
+		handle === 'se'
+	) {
+		return computeLockedResizeRect(
+			drag,
+			clientX,
+			clientY,
+			imageSize,
+			bounds,
+			normalizedRatio
+		);
+	}
+
+	// Edge handle: size the dragged axis with free-resize logic, then
+	// expand the perpendicular axis symmetrically around the rect's center.
+	const free = computeFreeResizeRect(
+		drag,
+		clientX,
+		clientY,
+		imageSize,
+		bounds
+	);
+
+	if ( handle === 'n' || handle === 's' ) {
+		// Height is the driver; derive width from ratio.
+		let newHeight = free.height;
+		let newWidth = newHeight * normalizedRatio;
+		const centerX = s.x + s.width / 2;
+		// Symmetric clamp: limit by the smaller of the two side gaps so
+		// the rect stays centered around centerX.
+		const maxWidth =
+			Math.min( centerX - bounds.minX, bounds.maxX - centerX ) * 2;
+		if ( newWidth > maxWidth ) {
+			newWidth = maxWidth;
+			newHeight = newWidth / normalizedRatio;
+		}
+		newWidth = Math.max( newWidth, MIN_CROP_SIZE );
+		newHeight = Math.max( newHeight, MIN_CROP_SIZE );
+		// Re-anchor the dragged axis to the opposite edge so the
+		// height adjustment after clamping keeps that edge fixed.
+		const newY = handle === 'n' ? s.y + s.height - newHeight : s.y;
+		return {
+			x: centerX - newWidth / 2,
+			y: newY,
+			width: newWidth,
+			height: newHeight,
+		};
+	}
+
+	// 'e' or 'w': width is the driver; derive height from ratio.
+	let newWidth = free.width;
+	let newHeight = newWidth / normalizedRatio;
+	const centerY = s.y + s.height / 2;
+	const maxHeight =
+		Math.min( centerY - bounds.minY, bounds.maxY - centerY ) * 2;
+	if ( newHeight > maxHeight ) {
+		newHeight = maxHeight;
+		newWidth = newHeight * normalizedRatio;
+	}
+	newWidth = Math.max( newWidth, MIN_CROP_SIZE );
+	newHeight = Math.max( newHeight, MIN_CROP_SIZE );
+	const newX = handle === 'w' ? s.x + s.width - newWidth : s.x;
+	return {
+		x: newX,
+		y: centerY - newHeight / 2,
+		width: newWidth,
+		height: newHeight,
+	};
+}

--- a/packages/media-editor/src/image-editor/core/test/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/test/stencil-math.ts
@@ -235,6 +235,58 @@ describe( 'computeShiftLockedResizeRect', () => {
 		} );
 	} );
 
+	describe( 'minimum size clamping preserves ratio', () => {
+		it( 'east edge: clamps a tall crop without breaking ratio when width hits MIN_CROP_SIZE', () => {
+			// Tall start rect — small ratio (0.0625 in normalized space).
+			const tallStart = { x: 0.2, y: 0.1, width: 0.05, height: 0.8 };
+			const drag: ResizeDragState = {
+				handle: 'e',
+				startX: 250,
+				startY: 250,
+				startRect: tallStart,
+			};
+			// Drag the east edge inward — width tries to shrink below MIN.
+			const rect = computeShiftLockedResizeRect(
+				drag,
+				200,
+				250,
+				IMAGE,
+				FULL_BOUNDS
+			);
+
+			const startRatio = tallStart.width / tallStart.height;
+			const newRatio = rect.width / rect.height;
+			expect( newRatio ).toBeCloseTo( startRatio, 5 );
+			expect( rect.width ).toBeGreaterThanOrEqual( 0.05 - 1e-9 );
+			expect( rect.height ).toBeGreaterThanOrEqual( 0.05 - 1e-9 );
+		} );
+
+		it( 'north edge: clamps a wide crop without breaking ratio when height hits MIN_CROP_SIZE', () => {
+			// Wide start rect — large ratio (16 in normalized space).
+			const wideStart = { x: 0.1, y: 0.4, width: 0.8, height: 0.05 };
+			const drag: ResizeDragState = {
+				handle: 'n',
+				startX: 500,
+				startY: 200,
+				startRect: wideStart,
+			};
+			// Drag the north edge down — height tries to shrink below MIN.
+			const rect = computeShiftLockedResizeRect(
+				drag,
+				500,
+				220,
+				IMAGE,
+				FULL_BOUNDS
+			);
+
+			const startRatio = wideStart.width / wideStart.height;
+			const newRatio = rect.width / rect.height;
+			expect( newRatio ).toBeCloseTo( startRatio, 5 );
+			expect( rect.width ).toBeGreaterThanOrEqual( 0.05 - 1e-9 );
+			expect( rect.height ).toBeGreaterThanOrEqual( 0.05 - 1e-9 );
+		} );
+	} );
+
 	describe( 'bounds clamping', () => {
 		it( 'east edge: clamps height to the symmetric bounds limit and shrinks width to keep ratio', () => {
 			// Center-y of START_RECT is 0.5; tightest bounds are bounds.minY=0.4

--- a/packages/media-editor/src/image-editor/core/test/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/test/stencil-math.ts
@@ -3,6 +3,7 @@
  */
 import {
 	computeLockedResizeRect,
+	computeShiftLockedResizeRect,
 	type CropBounds,
 	type ResizeDragState,
 } from '../stencil-math';
@@ -108,5 +109,161 @@ describe( 'computeLockedResizeRect — driver-axis selection', () => {
 		expect( pixelW / pixelH ).toBeCloseTo( 1, 5 );
 		expect( pixelW ).toBeCloseTo( 200, 5 );
 		expect( pixelH ).toBeCloseTo( 200, 5 );
+	} );
+} );
+
+const IMAGE: Size = { width: 1000, height: 500 };
+
+const START_RECT = { x: 0.2, y: 0.2, width: 0.4, height: 0.6 };
+
+function makeDrag(
+	handle: ResizeDragState[ 'handle' ],
+	startX = 500,
+	startY = 250
+): ResizeDragState {
+	return {
+		handle,
+		startX,
+		startY,
+		startRect: { ...START_RECT },
+	};
+}
+
+describe( 'computeShiftLockedResizeRect', () => {
+	describe( 'corner handles', () => {
+		it( 'preserves the start rect ratio when dragging the SE corner outward', () => {
+			const drag = makeDrag( 'se' );
+			// Drag right by 200px and down by 50px — width is the bigger
+			// pixel motion, so it drives.
+			const rect = computeShiftLockedResizeRect(
+				drag,
+				700,
+				300,
+				IMAGE,
+				FULL_BOUNDS
+			);
+
+			const startPixelRatio =
+				( START_RECT.width * IMAGE.width ) /
+				( START_RECT.height * IMAGE.height );
+			const newPixelRatio =
+				( rect.width * IMAGE.width ) / ( rect.height * IMAGE.height );
+
+			expect( newPixelRatio ).toBeCloseTo( startPixelRatio, 5 );
+			// SE drag anchors at the NW corner of the start rect.
+			expect( rect.x ).toBeCloseTo( START_RECT.x, 5 );
+			expect( rect.y ).toBeCloseTo( START_RECT.y, 5 );
+		} );
+
+		it( 'preserves the start rect ratio when dragging the NW corner inward', () => {
+			const drag = makeDrag( 'nw' );
+			const rect = computeShiftLockedResizeRect(
+				drag,
+				600,
+				300,
+				IMAGE,
+				FULL_BOUNDS
+			);
+
+			const startPixelRatio =
+				( START_RECT.width * IMAGE.width ) /
+				( START_RECT.height * IMAGE.height );
+			const newPixelRatio =
+				( rect.width * IMAGE.width ) / ( rect.height * IMAGE.height );
+			expect( newPixelRatio ).toBeCloseTo( startPixelRatio, 5 );
+			// NW drag anchors at the SE corner of the start rect.
+			expect( rect.x + rect.width ).toBeCloseTo(
+				START_RECT.x + START_RECT.width,
+				5
+			);
+			expect( rect.y + rect.height ).toBeCloseTo(
+				START_RECT.y + START_RECT.height,
+				5
+			);
+		} );
+	} );
+
+	describe( 'edge handles — symmetric expansion', () => {
+		it( 'east edge: expands height symmetrically around the start rect center', () => {
+			const drag = makeDrag( 'e' );
+			// Expand width by 100px to the right.
+			const rect = computeShiftLockedResizeRect(
+				drag,
+				600,
+				250,
+				IMAGE,
+				FULL_BOUNDS
+			);
+
+			const startCenterY = START_RECT.y + START_RECT.height / 2;
+			expect( rect.y + rect.height / 2 ).toBeCloseTo( startCenterY, 5 );
+			// x-anchored to start.x.
+			expect( rect.x ).toBeCloseTo( START_RECT.x, 5 );
+			// Ratio preserved.
+			const startPixelRatio =
+				( START_RECT.width * IMAGE.width ) /
+				( START_RECT.height * IMAGE.height );
+			const newPixelRatio =
+				( rect.width * IMAGE.width ) / ( rect.height * IMAGE.height );
+			expect( newPixelRatio ).toBeCloseTo( startPixelRatio, 5 );
+		} );
+
+		it( 'north edge: expands width symmetrically around the start rect center', () => {
+			const drag = makeDrag( 'n' );
+			// Drag the top edge up by 50px (taller crop).
+			const rect = computeShiftLockedResizeRect(
+				drag,
+				500,
+				200,
+				IMAGE,
+				FULL_BOUNDS
+			);
+
+			const startCenterX = START_RECT.x + START_RECT.width / 2;
+			expect( rect.x + rect.width / 2 ).toBeCloseTo( startCenterX, 5 );
+			// Bottom edge stays anchored.
+			expect( rect.y + rect.height ).toBeCloseTo(
+				START_RECT.y + START_RECT.height,
+				5
+			);
+			const startPixelRatio =
+				( START_RECT.width * IMAGE.width ) /
+				( START_RECT.height * IMAGE.height );
+			const newPixelRatio =
+				( rect.width * IMAGE.width ) / ( rect.height * IMAGE.height );
+			expect( newPixelRatio ).toBeCloseTo( startPixelRatio, 5 );
+		} );
+	} );
+
+	describe( 'bounds clamping', () => {
+		it( 'east edge: clamps height to the symmetric bounds limit and shrinks width to keep ratio', () => {
+			// Center-y of START_RECT is 0.5; tightest bounds are bounds.minY=0.4
+			// and bounds.maxY=0.6 → max half-height = 0.1, so max height = 0.2.
+			const tightBounds: CropBounds = {
+				minX: 0,
+				minY: 0.4,
+				maxX: 1,
+				maxY: 0.6,
+			};
+			const drag = makeDrag( 'e' );
+			// Drag far right — height would otherwise exceed the bound.
+			const rect = computeShiftLockedResizeRect(
+				drag,
+				1000,
+				250,
+				IMAGE,
+				tightBounds
+			);
+
+			expect( rect.height ).toBeLessThanOrEqual( 0.2 + 1e-9 );
+			// Centered around 0.5.
+			expect( rect.y + rect.height / 2 ).toBeCloseTo( 0.5, 5 );
+			const startPixelRatio =
+				( START_RECT.width * IMAGE.width ) /
+				( START_RECT.height * IMAGE.height );
+			const newPixelRatio =
+				( rect.width * IMAGE.width ) / ( rect.height * IMAGE.height );
+			expect( newPixelRatio ).toBeCloseTo( startPixelRatio, 5 );
+		} );
 	} );
 } );

--- a/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
@@ -11,6 +11,7 @@ import type { StencilProps, NormalizedRect } from '../../../core/types';
 import {
 	computeFreeResizeRect,
 	computeLockedResizeRect,
+	computeShiftLockedResizeRect,
 	type HandlePosition,
 	type CropBounds,
 	type ResizeDragState,
@@ -155,6 +156,11 @@ export function RectangleStencil( {
 			clientX: number,
 			clientY: number
 		) => NormalizedRect;
+		computeShiftLockedRect: (
+			drag: ResizeDragState,
+			clientX: number,
+			clientY: number
+		) => NormalizedRect;
 		onCropChange: ( rect: NormalizedRect ) => void;
 		onResizeEnd?: () => void;
 	} | null >( null );
@@ -215,11 +221,13 @@ export function RectangleStencil( {
 			let rafId = 0;
 			let latestX = event.clientX;
 			let latestY = event.clientY;
+			let latestShift = event.shiftKey;
 
 			const onMove = ( e: Event ) => {
 				const pe = e as PointerEvent;
 				latestX = pe.clientX;
 				latestY = pe.clientY;
+				latestShift = pe.shiftKey;
 				if ( rafId ) {
 					return;
 				}
@@ -229,9 +237,18 @@ export function RectangleStencil( {
 					if ( ! h ) {
 						return;
 					}
-					const newRect = h.hasLockedRatio
-						? h.computeLockedRect( drag, latestX, latestY )
-						: h.computeFreeRect( drag, latestX, latestY );
+					let newRect: NormalizedRect;
+					if ( h.hasLockedRatio ) {
+						newRect = h.computeLockedRect( drag, latestX, latestY );
+					} else if ( latestShift ) {
+						newRect = h.computeShiftLockedRect(
+							drag,
+							latestX,
+							latestY
+						);
+					} else {
+						newRect = h.computeFreeRect( drag, latestX, latestY );
+					}
 					h.onCropChange( newRect );
 				} );
 			};
@@ -303,10 +320,31 @@ export function RectangleStencil( {
 		[ imageSize, bounds, normalizedRatio ]
 	);
 
+	/**
+	 * Compute the new crop rect when Shift is held during a freeform
+	 * resize — preserves the start rect's aspect ratio.
+	 */
+	const computeShiftLockedRect = useCallback(
+		(
+			drag: ResizeDragState,
+			clientX: number,
+			clientY: number
+		): NormalizedRect =>
+			computeShiftLockedResizeRect(
+				drag,
+				clientX,
+				clientY,
+				imageSize,
+				bounds
+			),
+		[ imageSize, bounds ]
+	);
+
 	latestHandlersRef.current = {
 		hasLockedRatio,
 		computeLockedRect,
 		computeFreeRect,
+		computeShiftLockedRect,
 		onCropChange,
 		onResizeEnd,
 	};


### PR DESCRIPTION
## Summary

Part of:

- https://github.com/WordPress/gutenberg/issues/73771

In the experimental media editor's image cropper, holding **Shift** while dragging a resize handle now locks the aspect ratio to the crop's current ratio. Only applies in freeform mode (when no fixed `aspectRatio` is set); a configured aspect ratio still wins.


https://github.com/user-attachments/assets/11997917-5493-450c-8fad-7223107eb123



- Corner handles: anchor opposite corner, preserve start ratio.
- Edge handles: size the dragged axis freely, expand the perpendicular axis symmetrically around the rect's center.

## Test plan

- [ ] Open the image editor on a crop with no aspect ratio set.
- [ ] Drag a corner handle while holding Shift — ratio matches the rect at drag start.
- [ ] Drag an edge handle while holding Shift — opposite axis grows symmetrically; ratio preserved.
- [ ] Release Shift mid-drag — resize returns to free behavior on the next move.
- [ ] With a fixed aspect ratio set, behavior is unchanged.