### PR TITLE
Image editor: fix locked-ratio resize driver-axis on non-square images

### DIFF
--- a/packages/media-editor/src/image-editor/core/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/stencil-math.ts
@@ -154,10 +154,18 @@ export function computeLockedResizeRect(
 	distH = Math.max( distH, MIN_CROP_SIZE );
 
 	// Determine which axis "drives" — whichever the user moved more
-	// (in pixel space) determines the size, the other follows.
+	// (in pixel space) determines the size, the other follows. The
+	// `normalizedRatio` is w/h in normalized space; the equivalent
+	// pixel-space ratio is `normalizedRatio * imageW / imageH`. We
+	// compare the pixel motion ratio against that pixel-space ratio
+	// so the units line up (was a unit mismatch on non-square images).
 	const pixelDistW = distW * imageSize.width;
 	const pixelDistH = distH * imageSize.height;
-	if ( pixelDistW / pixelDistH > normalizedRatio ) {
+	const pixelRatio =
+		imageSize.height > 0
+			? ( normalizedRatio * imageSize.width ) / imageSize.height
+			: normalizedRatio;
+	if ( pixelDistW / pixelDistH > pixelRatio ) {
 		// Width is the driver — compute height from ratio.
 		distH = distW / normalizedRatio;
 	} else {

--- a/packages/media-editor/src/image-editor/core/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/stencil-math.ts
@@ -123,10 +123,20 @@ export function computeLockedResizeRect(
 	bounds: CropBounds,
 	normalizedRatio: number
 ): NormalizedRect {
-	const dx =
-		imageSize.width > 0 ? ( clientX - drag.startX ) / imageSize.width : 0;
-	const dy =
-		imageSize.height > 0 ? ( clientY - drag.startY ) / imageSize.height : 0;
+	// The math below divides by `normalizedRatio` and `imageSize`, so
+	// bail out with the start rect when any of them is zero. This can
+	// happen if a resize is triggered (e.g. via keyboard arrows on a
+	// focused handle) before the image has loaded.
+	if (
+		normalizedRatio <= 0 ||
+		imageSize.width <= 0 ||
+		imageSize.height <= 0
+	) {
+		return { ...drag.startRect };
+	}
+
+	const dx = ( clientX - drag.startX ) / imageSize.width;
+	const dy = ( clientY - drag.startY ) / imageSize.height;
 
 	const s = drag.startRect;
 	const handle = drag.handle;
@@ -161,10 +171,7 @@ export function computeLockedResizeRect(
 	// so the units line up (was a unit mismatch on non-square images).
 	const pixelDistW = distW * imageSize.width;
 	const pixelDistH = distH * imageSize.height;
-	const pixelRatio =
-		imageSize.height > 0
-			? ( normalizedRatio * imageSize.width ) / imageSize.height
-			: normalizedRatio;
+	const pixelRatio = ( normalizedRatio * imageSize.width ) / imageSize.height;
 	if ( pixelDistW / pixelDistH > pixelRatio ) {
 		// Width is the driver — compute height from ratio.
 		distH = distW / normalizedRatio;

--- a/packages/media-editor/src/image-editor/core/test/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/test/stencil-math.ts
@@ -1,0 +1,85 @@
+/**
+ * Internal dependencies
+ */
+import {
+	computeLockedResizeRect,
+	type CropBounds,
+	type ResizeDragState,
+} from '../stencil-math';
+import type { Size } from '../types';
+
+const FULL_BOUNDS: CropBounds = { minX: 0, minY: 0, maxX: 1, maxY: 1 };
+
+describe( 'computeLockedResizeRect — driver-axis selection', () => {
+	// On non-square images, the locked-ratio resize must pick the
+	// driving axis based on which the user moved more in *pixel* space,
+	// compared against the *pixel* aspect ratio. Comparing pixel motion
+	// against the normalized w/h ratio is a unit mismatch and produces
+	// the wrong axis on non-square images.
+	//
+	// Setup: a wide 1600×900 image, locked to a square (1:1) crop.
+	// Drag from the NW corner of a (degenerate) start rect, anchored at
+	// (0, 0), so distW/distH after the drag equals the drag offset.
+	const imageSize: Size = { width: 1600, height: 900 };
+	const aspectRatio = 1;
+	// The stencil normalizes the pixel ratio for the math:
+	//   normalizedRatio = aspectRatio * imageH / imageW.
+	const normalizedRatio =
+		( aspectRatio * imageSize.height ) / imageSize.width;
+	const startRect = { x: 0, y: 0, width: 0, height: 0 };
+
+	it( 'lets height drive when the user moves more pixels vertically than horizontally (between normalized and pixel thresholds)', () => {
+		// Drag SE corner to (80px, 100px) from anchor (0, 0).
+		// pixelDistW=80, pixelDistH=100, ratio=0.8.
+		// Pixel ratio test (correct): 0.8 < aspectRatio(1) → height drives.
+		// Result: 100×100 pixels.
+		const drag: ResizeDragState = {
+			handle: 'se',
+			startX: 0,
+			startY: 0,
+			startRect,
+		};
+		const rect = computeLockedResizeRect(
+			drag,
+			80,
+			100,
+			imageSize,
+			FULL_BOUNDS,
+			normalizedRatio
+		);
+
+		const pixelW = rect.width * imageSize.width;
+		const pixelH = rect.height * imageSize.height;
+
+		expect( pixelW / pixelH ).toBeCloseTo( 1, 5 );
+		expect( pixelH ).toBeCloseTo( 100, 5 );
+		expect( pixelW ).toBeCloseTo( 100, 5 );
+	} );
+
+	it( 'lets width drive when the user moves more pixels horizontally than vertically', () => {
+		// Drag SE corner to (200px, 50px) from anchor (0, 0).
+		// pixelDistW=200, pixelDistH=50, ratio=4 > aspectRatio(1).
+		// Width drives. Result: 200×200 pixels.
+		const drag: ResizeDragState = {
+			handle: 'se',
+			startX: 0,
+			startY: 0,
+			startRect,
+		};
+		const rect = computeLockedResizeRect(
+			drag,
+			200,
+			50,
+			imageSize,
+			FULL_BOUNDS,
+			normalizedRatio
+		);
+
+		const pixelW = rect.width * imageSize.width;
+		const pixelH = rect.height * imageSize.height;
+
+		expect( pixelW / pixelH ).toBeCloseTo( 1, 5 );
+		expect( pixelW ).toBeCloseTo( 200, 5 );
+		expect( pixelH ).toBeCloseTo( 200, 5 );
+	} );
+} );

--- a/packages/media-editor/src/image-editor/core/test/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/test/stencil-math.ts
@@ -29,10 +29,14 @@ describe( 'computeLockedResizeRect — driver-axis selection', () => {
 	const startRect = { x: 0, y: 0, width: 0, height: 0 };
 
 	it( 'lets height drive when the user moves more pixels vertically than horizontally (between normalized and pixel thresholds)', () => {
-		// Drag SE corner to (80px, 100px) from anchor (0, 0).
-		// pixelDistW=80, pixelDistH=100, ratio=0.8.
-		// Pixel ratio test (correct): 0.8 < aspectRatio(1) → height drives.
-		// Result: 100×100 pixels.
+		// Drag SE corner to (144px, 160px) from anchor (0, 0).
+		// pixelDistW=144, pixelDistH=160, ratio=0.9 — comfortably above
+		// MIN_CROP_SIZE (0.05 = 80px on a 1600px image), so neither axis
+		// is at the min-clamp boundary. The ratio (0.9) sits between the
+		// old buggy threshold (normalizedRatio=0.5625) and the correct
+		// pixel-space threshold (aspectRatio=1) — that's the gap where
+		// the unit mismatch produced the wrong driver axis.
+		// Correct: 0.9 < aspectRatio(1) → height drives → 160×160 pixels.
 		const drag: ResizeDragState = {
 			handle: 'se',
 			startX: 0,
@@ -41,8 +45,8 @@ describe( 'computeLockedResizeRect — driver-axis selection', () => {
 		};
 		const rect = computeLockedResizeRect(
 			drag,
-			80,
-			100,
+			144,
+			160,
 			imageSize,
 			FULL_BOUNDS,
 			normalizedRatio
@@ -52,8 +56,8 @@ describe( 'computeLockedResizeRect — driver-axis selection', () => {
 		const pixelH = rect.height * imageSize.height;
 
 		expect( pixelW / pixelH ).toBeCloseTo( 1, 5 );
-		expect( pixelH ).toBeCloseTo( 100, 5 );
-		expect( pixelW ).toBeCloseTo( 100, 5 );
+		expect( pixelH ).toBeCloseTo( 160, 5 );
+		expect( pixelW ).toBeCloseTo( 160, 5 );
 	} );
 
 	it( 'lets width drive when the user moves more pixels horizontally than vertically', () => {

--- a/packages/media-editor/src/image-editor/core/test/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/test/stencil-math.ts
@@ -60,6 +60,29 @@ describe( 'computeLockedResizeRect — driver-axis selection', () => {
 		expect( pixelW ).toBeCloseTo( 160, 5 );
 	} );
 
+	it( 'returns the start rect unchanged when normalizedRatio is 0 (image not loaded)', () => {
+		// Reachable in practice: keyboard arrows on a focused resize
+		// handle before the image's natural size is known make the
+		// stencil pass `normalizedRatio === 0`.
+		const preLoadStart = { x: 0.1, y: 0.2, width: 0.3, height: 0.4 };
+		const drag: ResizeDragState = {
+			handle: 'se',
+			startX: 0,
+			startY: 0,
+			startRect: preLoadStart,
+		};
+		const rect = computeLockedResizeRect(
+			drag,
+			100,
+			100,
+			{ width: 0, height: 0 },
+			FULL_BOUNDS,
+			0
+		);
+
+		expect( rect ).toEqual( preLoadStart );
+	} );
+
 	it( 'lets width drive when the user moves more pixels horizontally than vertically', () => {
 		// Drag SE corner to (200px, 50px) from anchor (0, 0).
 		// pixelDistW=200, pixelDistH=50, ratio=4 > aspectRatio(1).


### PR DESCRIPTION
Part of:

- https://github.com/WordPress/gutenberg/issues/73771

## Summary

In `computeLockedResizeRect`, the heuristic that decides which axis "drives" a locked-ratio corner resize compared a pixel-space ratio against a normalized w/h ratio — a unit mismatch. On non-square images the two thresholds differ, so the wrong axis could drive the resize.

**Repro (without this fix):** 1600×900 image, 1:1 locked crop, drag the SE corner with pixel motion (80, 100). Result is 80×80. Expected 100×100 — the user moved further vertically, so height should drive.

**Fix:** convert `normalizedRatio` to its pixel-space equivalent (`normalizedRatio * imageW / imageH`) and compare the pixel motion ratio against that.


https://github.com/user-attachments/assets/200bfc44-692e-4cf7-a244-30a8083c1777



Follow-up to feedback on #77663.

## Test plan

There should be no regressions or weirdness when cropping using aspect ratios.

- [ ] Locked-ratio resize behaves intuitively on a non-square image (e.g. landscape photo, 1:1 crop): the axis with more pixel motion drives.
- [ ] Square images: behavior unchanged (the two thresholds are equal).
- [ ] Existing fixed-aspect-ratio crops (16:9, 4:3 etc.) still resize correctly.

## Use of AI

100% with manual confirmation and testing