### PR TITLE
Image Editor experiment: Pass theme aspect ratios to media editor

### DIFF
--- a/packages/editor/src/components/media/media-editor-modal.js
+++ b/packages/editor/src/components/media/media-editor-modal.js
@@ -77,6 +77,8 @@ export default function MediaEditorModalMount() {
 			.map( aspectRatioPresetFromSettings )
 			.filter( Boolean );
 
+		// Passing `undefined` lets the media editor use its fallback presets.
+		// Passing `[]` explicitly removes fixed presets when defaults are off.
 		if ( presets.length || showDefaultRatios === false ) {
 			return presets;
 		}

--- a/packages/editor/src/components/media/media-editor-modal.js
+++ b/packages/editor/src/components/media/media-editor-modal.js
@@ -67,14 +67,21 @@ export default function MediaEditorModalMount() {
 			return undefined;
 		}
 
-		return [
+		const candidateRatios = [
 			...( showDefaultRatios && Array.isArray( defaultRatios )
 				? defaultRatios
 				: [] ),
 			...( Array.isArray( themeRatios ) ? themeRatios : [] ),
-		]
+		];
+		const presets = candidateRatios
 			.map( aspectRatioPresetFromSettings )
 			.filter( Boolean );
+
+		if ( presets.length || showDefaultRatios === false ) {
+			return presets;
+		}
+
+		return undefined;
 	}, [ defaultRatios, themeRatios, showDefaultRatios ] );
 
 	return (

--- a/packages/editor/src/components/media/media-editor-modal.js
+++ b/packages/editor/src/components/media/media-editor-modal.js
@@ -1,6 +1,8 @@
 /**
  * WordPress dependencies
  */
+import { useSettings } from '@wordpress/block-editor';
+import { useMemo } from '@wordpress/element';
 import { privateApis as mediaEditorPrivateApis } from '@wordpress/media-editor';
 
 /**
@@ -10,6 +12,34 @@ import { unlock } from '../../lock-unlock';
 import usePostFields from '../post-fields';
 
 const { MediaEditorModal } = unlock( mediaEditorPrivateApis );
+
+function ratioToNumber( ratio ) {
+	if ( ratio === undefined || ratio === null ) {
+		return NaN;
+	}
+	const [ a, b, ...rest ] = String( ratio ).split( '/' ).map( Number );
+	if (
+		a <= 0 ||
+		b <= 0 ||
+		Number.isNaN( a ) ||
+		Number.isNaN( b ) ||
+		rest.length
+	) {
+		return NaN;
+	}
+	return b ? a / b : a;
+}
+
+function aspectRatioPresetFromSettings( { name, ratio } = {} ) {
+	const value = ratioToNumber( ratio );
+	if ( ! name || ! Number.isFinite( value ) || value <= 0 ) {
+		return null;
+	}
+	return {
+		label: name,
+		value,
+	};
+}
 
 /**
  * Mounts the MediaEditorModal alongside existing editor modals.
@@ -22,5 +52,35 @@ const { MediaEditorModal } = unlock( mediaEditorPrivateApis );
  */
 export default function MediaEditorModalMount() {
 	const fields = usePostFields( { postType: 'attachment' } );
-	return <MediaEditorModal fields={ fields } />;
+	const [ defaultRatios, themeRatios, showDefaultRatios ] = useSettings(
+		'dimensions.aspectRatios.default',
+		'dimensions.aspectRatios.theme',
+		'dimensions.defaultAspectRatios'
+	);
+	const aspectRatioPresets = useMemo( () => {
+		const hasAspectRatioSettings =
+			Array.isArray( defaultRatios ) ||
+			Array.isArray( themeRatios ) ||
+			typeof showDefaultRatios === 'boolean';
+
+		if ( ! hasAspectRatioSettings ) {
+			return undefined;
+		}
+
+		return [
+			...( showDefaultRatios && Array.isArray( defaultRatios )
+				? defaultRatios
+				: [] ),
+			...( Array.isArray( themeRatios ) ? themeRatios : [] ),
+		]
+			.map( aspectRatioPresetFromSettings )
+			.filter( Boolean );
+	}, [ defaultRatios, themeRatios, showDefaultRatios ] );
+
+	return (
+		<MediaEditorModal
+			fields={ fields }
+			aspectRatioPresets={ aspectRatioPresets }
+		/>
+	);
 }

--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -19,6 +19,7 @@ import {
 	MIN_ZOOM,
 	ORIGINAL_ASPECT_RATIO,
 } from '../../image-editor/core/constants';
+import type { AspectRatioPreset } from '../../image-editor/core/constants';
 
 export interface MediaEditorCropPanelProps {
 	/**
@@ -33,6 +34,11 @@ export interface MediaEditorCropPanelProps {
 	freeformCrop: boolean;
 	/** Setter for freeform mode. */
 	onFreeformChange: ( value: boolean ) => void;
+	/**
+	 * Fixed aspect-ratio presets to display after Free and Original. When
+	 * omitted, the media editor's default fixed-ratio presets are used.
+	 */
+	aspectRatioPresets?: AspectRatioPreset[];
 }
 
 /**
@@ -69,14 +75,21 @@ export function resolveAspectRatio(
  * @param props.onAspectRatioChange
  * @param props.freeformCrop
  * @param props.onFreeformChange
+ * @param props.aspectRatioPresets
  */
 export default function MediaEditorCropPanel( {
 	aspectRatioValue,
 	onAspectRatioChange,
 	freeformCrop,
 	onFreeformChange,
+	aspectRatioPresets,
 }: MediaEditorCropPanelProps ) {
 	const { state, setZoom } = useCropper();
+	const aspectRatioOptions = [
+		...DEFAULT_ASPECT_RATIOS.filter( ( preset ) => preset.value <= 0 ),
+		...( aspectRatioPresets ??
+			DEFAULT_ASPECT_RATIOS.filter( ( preset ) => preset.value > 0 ) ),
+	];
 
 	return (
 		<Stack direction="column" gap="md">
@@ -106,7 +119,7 @@ export default function MediaEditorCropPanel( {
 				label={ __( 'Aspect ratio' ) }
 				value={ aspectRatioValue }
 				onChange={ onAspectRatioChange }
-				options={ DEFAULT_ASPECT_RATIOS.map( ( preset ) => ( {
+				options={ aspectRatioOptions.map( ( preset ) => ( {
 					label: preset.label,
 					value: preset.value.toString(),
 				} ) ) }

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -45,6 +45,7 @@ import { store as mediaEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import { getMediaTypeFromMimeType } from '../../utils';
 import { CropperProvider, useCropper } from '../../image-editor';
+import type { AspectRatioPreset } from '../../image-editor/core/constants';
 
 const { Tabs } = unlock( componentsPrivateApis );
 
@@ -56,6 +57,11 @@ interface MediaEditorModalProps {
 	 * since `@wordpress/media-editor` cannot depend on `@wordpress/editor`.
 	 */
 	fields?: Field< Media >[];
+	/**
+	 * Fixed aspect-ratio presets for image cropping. Free and Original are
+	 * always provided by the modal.
+	 */
+	aspectRatioPresets?: AspectRatioPreset[];
 }
 
 interface ModalTab {
@@ -158,7 +164,10 @@ function HeaderActions( {
 	);
 }
 
-export function MediaEditorModal( { fields = [] }: MediaEditorModalProps ) {
+export function MediaEditorModal( {
+	fields = [],
+	aspectRatioPresets,
+}: MediaEditorModalProps ) {
 	const { isModalOpen, id, onUpdate } = useSelect( ( select ) => {
 		const { isOpen, getId, getOnUpdate } = select( mediaEditorStore );
 		return {
@@ -279,13 +288,14 @@ export function MediaEditorModal( { fields = [] }: MediaEditorModalProps ) {
 							onAspectRatioChange={ setAspectRatioValue }
 							freeformCrop={ freeformCrop }
 							onFreeformChange={ setFreeformCrop }
+							aspectRatioPresets={ aspectRatioPresets }
 						/>
 					</Stack>
 				),
 			},
 			detailsTab,
 		];
-	}, [ isImage, aspectRatioValue, freeformCrop ] );
+	}, [ isImage, aspectRatioValue, freeformCrop, aspectRatioPresets ] );
 
 	if ( ! isModalOpen || ! id ) {
 		return null;


### PR DESCRIPTION
## What
Passes editor-provided aspect ratio presets into the media editor crop panel.

The editor modal mount now reads `dimensions.aspectRatios.default`, `dimensions.aspectRatios.theme`, and `dimensions.defaultAspectRatios`, converts those settings to numeric presets, and passes them to `MediaEditorModal`. 

The media editor keeps `Free` and `Original`, then uses the provided fixed-ratio presets instead of its package defaults.

If there are no consumer-fed aspect rations, the croppers internal defaults will apply.

Here are the combined aspect ratios from the block editor:

<img width="473" height="143" alt="Screenshot 2026-04-25 at 12 27 58 pm" src="https://github.com/user-attachments/assets/ba23ac39-61ee-4713-80d5-c2058a17798c" />

Here they are in the cropper dropdown:

<img width="591" height="496" alt="Screenshot 2026-04-25 at 12 26 37 pm" src="https://github.com/user-attachments/assets/3cd8f448-9b97-47b7-bce3-ad109049352d" />


## Testing
1. Enable the Gutenberg experiments for Media editor and Media editor modal.
2. Use a theme with custom `settings.dimensions.aspectRatios` in `theme.json`. Optionally set `settings.dimensions.defaultAspectRatios` to `false`.
3. Add/select an Image block with an uploaded image.
4. Open the crop flow that uses the media editor modal.
5. Confirm the Aspect ratio select shows `Free`, `Original`, and the ratios from theme settings.
6. Confirm package default fixed ratios are not shown when theme/editor presets are supplied.
7. Confirm selecting a custom ratio locks the cropper to that ratio.

