### PR TITLE
CollapsibleCard: Prevent focus ring clipping by content overflow

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -24,6 +24,7 @@
 -   Remove the transitive peer dependency on `date-fns` / `@date-fns/tz` ([#77520](https://github.com/WordPress/gutenberg/pull/77520)), resolving [#77395](https://github.com/WordPress/gutenberg/issues/77395).
 -   `Text`: Apply both heading and paragraph CSS defenses regardless of variant, so the correct defense kicks in based on the rendered element rather than the typographic variant ([#77461](https://github.com/WordPress/gutenberg/pull/77461)).
 -   `CollapsibleCard`: Fix missing keyboard focus ring on the header chevron icon when rendered inside wp-admin ([#77468](https://github.com/WordPress/gutenberg/pull/77468)).
+-   `CollapsibleCard`: Prevent the focus ring of focusable descendants from being clipped by the panel's overflow once the panel is fully expanded ([#77667](https://github.com/WordPress/gutenberg/pull/77667)).
 -   `Tabs`: Fix missing keyboard focus ring on the panel in Windows High Contrast mode when rendered inside wp-admin ([#77469](https://github.com/WordPress/gutenberg/pull/77469)).
 
 ### Enhancements

--- a/packages/ui/src/collapsible-card/content.tsx
+++ b/packages/ui/src/collapsible-card/content.tsx
@@ -1,4 +1,5 @@
-import { forwardRef } from '@wordpress/element';
+import { useMergeRefs } from '@wordpress/compose';
+import { forwardRef, useEffect, useRef, useState } from '@wordpress/element';
 import clsx from 'clsx';
 import * as Card from '../card';
 import * as Collapsible from '../collapsible';
@@ -14,10 +15,70 @@ export const Content = forwardRef< HTMLDivElement, ContentProps >(
 		{ className, render, children, hiddenUntilFound = true, ...restProps },
 		ref
 	) {
+		const panelRef = useRef< HTMLDivElement >( null );
+		const mergedRef = useMergeRefs( [ ref, panelRef ] );
+		// True only when the panel is fully expanded — open AND any
+		// open/close transition has settled. While true, the overflow
+		// clip is dropped so descendant focus rings aren't cut off.
+		const [ isExpanded, setIsExpanded ] = useState( false );
+
+		useEffect( () => {
+			const panel = panelRef.current;
+			if ( ! panel ) {
+				return;
+			}
+
+			const sync = () => {
+				if ( ! panel.hasAttribute( 'data-open' ) ) {
+					setIsExpanded( false );
+					return;
+				}
+				// No active animation? Treat as already settled.
+				// Covers `prefers-reduced-motion`, where the height
+				// change is instantaneous and `transitionend` never
+				// fires.
+				if ( panel.getAnimations().length === 0 ) {
+					setIsExpanded( true );
+				}
+				// Otherwise wait for `transitionend`.
+			};
+
+			const handleTransitionEnd = ( event: TransitionEvent ) => {
+				if (
+					event.target !== panel ||
+					event.propertyName !== 'height'
+				) {
+					return;
+				}
+				setIsExpanded( panel.hasAttribute( 'data-open' ) );
+			};
+
+			sync();
+
+			const observer = new MutationObserver( sync );
+			observer.observe( panel, {
+				attributes: true,
+				attributeFilter: [ 'data-open' ],
+			} );
+			panel.addEventListener( 'transitionend', handleTransitionEnd );
+
+			return () => {
+				observer.disconnect();
+				panel.removeEventListener(
+					'transitionend',
+					handleTransitionEnd
+				);
+			};
+		}, [] );
+
 		return (
 			<Collapsible.Panel
-				ref={ ref }
-				className={ clsx( styles.content, className ) }
+				ref={ mergedRef }
+				className={ clsx(
+					styles.content,
+					isExpanded && styles[ 'is-expanded' ],
+					className
+				) }
 				hiddenUntilFound={ hiddenUntilFound }
 				{ ...restProps }
 			>

--- a/packages/ui/src/collapsible-card/content.tsx
+++ b/packages/ui/src/collapsible-card/content.tsx
@@ -1,5 +1,4 @@
-import { useMergeRefs } from '@wordpress/compose';
-import { forwardRef, useEffect, useRef, useState } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 import clsx from 'clsx';
 import * as Card from '../card';
 import * as Collapsible from '../collapsible';
@@ -15,70 +14,21 @@ export const Content = forwardRef< HTMLDivElement, ContentProps >(
 		{ className, render, children, hiddenUntilFound = true, ...restProps },
 		ref
 	) {
-		const panelRef = useRef< HTMLDivElement >( null );
-		const mergedRef = useMergeRefs( [ ref, panelRef ] );
-		// True only when the panel is fully expanded — open AND any
-		// open/close transition has settled. While true, the overflow
-		// clip is dropped so descendant focus rings aren't cut off.
-		const [ isExpanded, setIsExpanded ] = useState( false );
-
-		useEffect( () => {
-			const panel = panelRef.current;
-			if ( ! panel ) {
-				return;
-			}
-
-			const sync = () => {
-				if ( ! panel.hasAttribute( 'data-open' ) ) {
-					setIsExpanded( false );
-					return;
-				}
-				// No active animation? Treat as already settled.
-				// Covers `prefers-reduced-motion`, where the height
-				// change is instantaneous and `transitionend` never
-				// fires.
-				if ( panel.getAnimations().length === 0 ) {
-					setIsExpanded( true );
-				}
-				// Otherwise wait for `transitionend`.
-			};
-
-			const handleTransitionEnd = ( event: TransitionEvent ) => {
-				if (
-					event.target !== panel ||
-					event.propertyName !== 'height'
-				) {
-					return;
-				}
-				setIsExpanded( panel.hasAttribute( 'data-open' ) );
-			};
-
-			sync();
-
-			const observer = new MutationObserver( sync );
-			observer.observe( panel, {
-				attributes: true,
-				attributeFilter: [ 'data-open' ],
-			} );
-			panel.addEventListener( 'transitionend', handleTransitionEnd );
-
-			return () => {
-				observer.disconnect();
-				panel.removeEventListener(
-					'transitionend',
-					handleTransitionEnd
-				);
-			};
-		}, [] );
-
 		return (
 			<Collapsible.Panel
-				ref={ mergedRef }
-				className={ clsx(
-					styles.content,
-					isExpanded && styles[ 'is-expanded' ],
-					className
-				) }
+				ref={ ref }
+				// @ts-expect-error Base UI supports the callback-style
+				// version of the `className` prop, but we're purposefully
+				// not advertising it in our `@wordpress/ui` re-export.
+				className={ ( state ) =>
+					clsx(
+						styles.content,
+						state.open &&
+							state.transitionStatus === 'idle' &&
+							styles.overflowVisible,
+						className
+					)
+				}
 				hiddenUntilFound={ hiddenUntilFound }
 				{ ...restProps }
 			>

--- a/packages/ui/src/collapsible-card/style.module.css
+++ b/packages/ui/src/collapsible-card/style.module.css
@@ -47,12 +47,12 @@
 		margin-block-start: var(--wp-ui-card-header-content-margin);
 
 		/* Clip while collapsed or transitioning so the panel collapses
-		   cleanly. The `is-expanded` class is set once the open
+		   cleanly. The `overflowVisible` class is set once the open
 		   transition has settled, dropping the clip so descendant
 		   focus rings aren't cut off. */
 		overflow: hidden;
 
-		&.is-expanded {
+		&.overflowVisible {
 			overflow: visible;
 		}
 

--- a/packages/ui/src/collapsible-card/style.module.css
+++ b/packages/ui/src/collapsible-card/style.module.css
@@ -28,7 +28,7 @@
 	}
 
 	.header-trigger {
-		@media not (prefers-reduced-motion) {
+		@media not ( prefers-reduced-motion ) {
 			transition: rotate 0.15s ease-out;
 		}
 	}
@@ -44,8 +44,17 @@
 
 	.content {
 		height: var(--collapsible-panel-height);
-		overflow: hidden;
 		margin-block-start: var(--wp-ui-card-header-content-margin);
+
+		/* Clip while collapsed or transitioning so the panel collapses
+		   cleanly. The `is-expanded` class is set once the open
+		   transition has settled, dropping the clip so descendant
+		   focus rings aren't cut off. */
+		overflow: hidden;
+
+		&.is-expanded {
+			overflow: visible;
+		}
 
 		&[hidden]:not([hidden="until-found"]) {
 			display: none;
@@ -56,15 +65,18 @@
 			height: 0;
 		}
 
-		@media not (prefers-reduced-motion) {
+		@media not ( prefers-reduced-motion ) {
 			transition: all 150ms ease-out;
 		}
 	}
-
 }
 
 @layer wp-ui-compositions {
 	.content-inner {
+		/* Card.Content's `.header + .content` selector doesn't match here
+		   because Collapsible.Panel sits between Card.Header and Card.Content.
+		   Re-apply the zero top padding manually so the header/content gap
+		   matches Card. */
 		padding-block-start: 0;
 	}
 

--- a/routes/experiments-home/style.scss
+++ b/routes/experiments-home/style.scss
@@ -4,9 +4,4 @@
 	padding: $grid-unit-30;
 	max-width: 680px;
 	margin: 0 auto;
-
-	// Avoid clipping the first toggle's focus ring by the card's overflow.
-	.dataforms-layouts-regular__field:first-child {
-		padding-top: $grid-unit-05;
-	}
 }


### PR DESCRIPTION
- See https://github.com/WordPress/gutenberg/pull/77443#discussion_r3098492280
- Similar to https://github.com/WordPress/gutenberg/pull/51829

## What?

Prevent the focus ring of focusable descendants of `CollapsibleCard.Content` from being clipped by the panel's overflow once the card is fully expanded. The first child is the worst case — its ring extends into the gap above the content area and was being cut off.

## Why?

The panel needs `overflow: hidden` while collapsed and during the open/close height animation, otherwise its content escapes the card during the transition. But once the panel has settled open, that clip cuts off the focus ring of any focusable descendant whose ring extends past the panel's edge. Consumers were working around this in their own stylesheets (e.g. the Experiments screen).

## How?

Toggle the clip on a class instead of always applying it:

- `overflow: hidden` while collapsed or transitioning.
- `overflow: visible` (`overflowVisible` class) once the panel is fully expanded.

The class is gated on Base UI's panel state via the `className` callback — `state.open && state.transitionStatus === 'idle'` — which is the public way to read "open and settled" without subscribing to DOM events. The callback form is documented Base UI API; `@wordpress/ui`'s `ComponentProps` re-types `className` as `string` only, so the function form needs a one-line `@ts-expect-error` at the call site.

No public API change. The per-route padding workaround in the Experiments screen is no longer needed and is removed.

## Testing Instructions

1. Open the new `WithFocusableContent` story under `Design System / Components / CollapsibleCard` in Storybook.
2. Tab into the card. The first focusable child's focus ring should be fully visible above the panel boundary.
3. Toggle the card open/closed several times — the height animation should still clip cleanly (no content peeking out below the card edge).
4. Repeat with `prefers-reduced-motion` enabled (DevTools → Rendering → Emulate CSS media feature `prefers-reduced-motion: reduce`). The first child's focus ring should still be fully visible when the card is open.
5. In wp-admin, visit the Experiments screen. The first toggle's focus ring should not be clipped.

### Testing Instructions for Keyboard

Same as above — drive the toggle and field interactions purely with `Tab`, `Shift+Tab`, `Space`, and `Enter`.

## Screenshots or screencast

| Before | After |
| - | - |
| ![Before](https://github.com/user-attachments/assets/0d173ed9-6230-49b6-9cf7-5965defc290f) | ![After](https://github.com/user-attachments/assets/e693c28a-3507-40cd-a349-1622598283ee) |

## Use of AI Tools

The original approach was explored with Claude. Subsequent rounds (including this revision and PR description) were drafted with Claude in Cursor and reviewed by the author.
