### PR TITLE
GlobalStylesUI: Add reset action to Additional CSS screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61728,6 +61728,7 @@
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/keycodes": "file:../keycodes",
 				"@wordpress/private-apis": "file:../private-apis",
+				"@wordpress/ui": "file:../ui",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.0",
 				"colord": "^2.7.0"

--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -37,7 +37,7 @@ export default function AdvancedPanel( {
 } ) {
 	// Custom CSS
 	const [ cssError, setCSSError ] = useState( null );
-	const customCSS = inheritedValue?.css;
+	const customCSS = inheritedValue?.css ?? '';
 	function handleOnChange( newValue ) {
 		onChange( {
 			...value,

--- a/packages/global-styles-ui/package.json
+++ b/packages/global-styles-ui/package.json
@@ -60,6 +60,7 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/private-apis": "file:../private-apis",
+		"@wordpress/ui": "file:../ui",
 		"change-case": "^4.1.2",
 		"clsx": "^2.1.0",
 		"colord": "^2.7.0"

--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -6,9 +6,11 @@ import { getBlockType } from '@wordpress/blocks';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { useContext, useMemo, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { useViewportMatch } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import {
-	PanelBody,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalVStack as VStack,
 	__experimentalHasSplitBorders as hasSplitBorders,
 } from '@wordpress/components';
@@ -138,6 +140,17 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 		false,
 		hasSelectedState ? stateParam : undefined
 	);
+	const [ baseStyle ] = useStyle( prefix, name, 'base', false, stateParam );
+
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const dropdownMenuProps = ! isMobileViewport
+		? {
+				popoverProps: {
+					placement: 'left-start',
+					offset: 259,
+				},
+		  }
+		: {};
 
 	const [ userSettings ] = useSetting( '', name, 'user' );
 	const [ rawSettings, setSettings ] = useSetting( '', name );
@@ -427,20 +440,39 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 			) }
 
 			{ canEditCSS && (
-				<PanelBody title={ __( 'Advanced' ) } initialOpen={ false }>
-					<StylesAdvancedPanel
-						value={ style }
-						onChange={ setStyle }
-						inheritedValue={ inheritedStyle }
-						help={ sprintf(
-							// translators: %s: is the name of a block e.g., 'Image' or 'Table'.
-							__(
-								'Add your own CSS to customize the appearance of the %s block. You do not need to include a CSS selector, just add the property and value.'
-							),
-							blockType?.title!
-						) }
-					/>
-				</PanelBody>
+				<ToolsPanel
+					label={ __( 'Advanced' ) }
+					resetAll={ () => {
+						const { css: _css, ...rest } = style ?? {};
+						setStyle( rest );
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					<ToolsPanelItem
+						label={ __( 'Additional CSS' ) }
+						isShownByDefault
+						hasValue={ () =>
+							inheritedStyle?.css !== baseStyle?.css
+						}
+						onDeselect={ () => {
+							const { css: _css, ...rest } = style ?? {};
+							setStyle( rest );
+						} }
+					>
+						<StylesAdvancedPanel
+							value={ style }
+							onChange={ setStyle }
+							inheritedValue={ inheritedStyle }
+							help={ sprintf(
+								// translators: %s: is the name of a block e.g., 'Image' or 'Table'.
+								__(
+									'Add your own CSS to customize the appearance of the %s block. You do not need to include a CSS selector, just add the property and value.'
+								),
+								blockType?.title!
+							) }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			) }
 		</>
 	);

--- a/packages/global-styles-ui/src/screen-css.tsx
+++ b/packages/global-styles-ui/src/screen-css.tsx
@@ -2,7 +2,16 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ExternalLink } from '@wordpress/components';
+import {
+	ExternalLink,
+	Button,
+	FlexItem,
+	FlexBlock,
+	__experimentalSpacer as Spacer,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+import { moreVertical } from '@wordpress/icons';
 // @ts-expect-error: Not typed yet.
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
@@ -15,6 +24,7 @@ import { unlock } from './lock-unlock';
 
 // Access AdvancedPanel from block-editor private APIs
 const { AdvancedPanel: StylesAdvancedPanel } = unlock( blockEditorPrivateApis );
+const { Menu } = unlock( componentsPrivateApis );
 
 function ScreenCSS() {
 	// Get user-only styles (should not decode/encode to preserve raw CSS)
@@ -29,25 +39,58 @@ function ScreenCSS() {
 
 	return (
 		<>
-			<ScreenHeader
-				title={ __( 'Additional CSS' ) }
-				description={
-					<>
-						{ __(
-							'You can add custom CSS to further customize the appearance and layout of your site.'
-						) }
-						<br />
-						<ExternalLink
-							href={ __(
-								'https://developer.wordpress.org/advanced-administration/wordpress/css/'
-							) }
-							className="global-styles-ui-screen-css-help-link"
-						>
-							{ __( 'Learn more about CSS' ) }
-						</ExternalLink>
-					</>
-				}
-			/>
+			<Stack direction="row" justify="space-between" align="flex-start">
+				<FlexBlock>
+					<ScreenHeader
+						title={ __( 'Additional CSS' ) }
+						description={
+							<>
+								{ __(
+									'You can add custom CSS to further customize the appearance and layout of your site.'
+								) }
+								<br />
+								<ExternalLink
+									href={ __(
+										'https://developer.wordpress.org/advanced-administration/wordpress/css/'
+									) }
+									className="global-styles-ui-screen-css-help-link"
+								>
+									{ __( 'Learn more about CSS' ) }
+								</ExternalLink>
+							</>
+						}
+					/>
+				</FlexBlock>
+				<FlexItem>
+					<Spacer marginTop={ 3 } marginBottom={ 0 } paddingX={ 4 }>
+						<Menu>
+							<Menu.TriggerButton
+								render={
+									<Button
+										size="small"
+										icon={ moreVertical }
+										label={ __( 'CSS options' ) }
+									/>
+								}
+							/>
+							<Menu.Popover>
+								<Menu.Item
+									disabled={ ! style?.css }
+									onClick={ () => {
+										const { css: _css, ...rest } =
+											style ?? {};
+										setStyle( rest );
+									} }
+								>
+									<Menu.ItemLabel>
+										{ __( 'Reset' ) }
+									</Menu.ItemLabel>
+								</Menu.Item>
+							</Menu.Popover>
+						</Menu>
+					</Spacer>
+				</FlexItem>
+			</Stack>
 			<div className="global-styles-ui-screen-css">
 				<StylesAdvancedPanel
 					value={ style }

--- a/packages/global-styles-ui/src/screen-css.tsx
+++ b/packages/global-styles-ui/src/screen-css.tsx
@@ -36,6 +36,10 @@ function ScreenCSS() {
 		'merged',
 		false
 	);
+	// Compare against theme-default CSS so Reset remains available when the
+	// user has cleared CSS to an empty string while the theme provides one.
+	const [ baseStyle ] = useStyle( '', undefined, 'base', false );
+	const canReset = inheritedStyle?.css !== baseStyle?.css;
 
 	return (
 		<>
@@ -75,7 +79,7 @@ function ScreenCSS() {
 							/>
 							<Menu.Popover>
 								<Menu.Item
-									disabled={ ! style?.css }
+									disabled={ ! canReset }
 									onClick={ () => {
 										const { css: _css, ...rest } =
 											style ?? {};

--- a/packages/global-styles-ui/tsconfig.json
+++ b/packages/global-styles-ui/tsconfig.json
@@ -20,7 +20,8 @@
 		{ "path": "../i18n" },
 		{ "path": "../icons" },
 		{ "path": "../keycodes" },
-		{ "path": "../private-apis" }
+		{ "path": "../private-apis" },
+		{ "path": "../ui" }
 	],
 	"include": [ "src/**/*" ],
 	"exclude": [ "src/font-library/lib/**/*" ]


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/60673

## What?

Adds a "Reset" action to the Additional CSS screen in the Global Styles UI.

## Why?

Users can freely modify additional CSS, but if they want to restore the default values provided by the theme, they need to reset all global styles.

## How?

### Root

Add a dropdown to the right of the screen header.

<img width="306" height="319" alt="image" src="https://github.com/user-attachments/assets/9186b1cd-c541-4786-8133-5a3e8cd3819a" />

This is similar to the font size presets and shadow presets.

<img width="288" height="219" alt="image" src="https://github.com/user-attachments/assets/0a09ccaa-1b0d-4ac7-a7c8-dd25d2e592a2" />
<img width="291" height="215" alt="image" src="https://github.com/user-attachments/assets/82a5c5ca-beeb-4336-afe3-609639dd81b3" />

### Per Block

Refactor the Advanced panel using the `ToolsPanel` component. Note that this will only be effective in global styles and will not affect the block's sidebar within the post content.

<img width="571" height="304" alt="image" src="https://github.com/user-attachments/assets/250eabb4-9c3b-45a2-afea-25c1bea57f54" />

## Testing Instructions

1. Activate Twenty Twenty-Four. This theme has custom CSS at both the root and per block.
1. Open the Site Editor and navigate to Styles.
2. Confirm that the "Reset" item is disabled if it has not been customized yet.
3. Add some custom CSS.
4. Reset the styles.
5. Confirm that the default CSS for the theme will be restored.

## Screenshots or screencast

### Root

https://github.com/user-attachments/assets/11b59db8-ad3f-4d51-8269-95d2be1c6c66

### Per Block

https://github.com/user-attachments/assets/d0aec848-4ca2-4558-8208-ed9a728a4970

## Use of AI Tools

Used Claude Code to help draft the implementation and this PR description. All changes were reviewed before submission.
