### PR TITLE
Revisions diff markers: enforce 24×24px minimum target size (WCAG 2.5.8)

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/diff-markers.js
+++ b/packages/editor/src/components/post-revisions-preview/diff-markers.js
@@ -102,7 +102,6 @@ function DiffMarkerButton( { clientId, status, subscribe } ) {
 			style={ {
 				top: `${ position.top }%`,
 				height: `${ Math.max( position.height, 0.5 ) }%`,
-				minHeight: '24px',
 			} }
 			onClick={ () => blockRef.current?.focus() }
 			aria-label={ STATUS_LABELS[ status ] }

--- a/packages/editor/src/components/post-revisions-preview/diff-markers.js
+++ b/packages/editor/src/components/post-revisions-preview/diff-markers.js
@@ -102,6 +102,7 @@ function DiffMarkerButton( { clientId, status, subscribe } ) {
 			style={ {
 				top: `${ position.top }%`,
 				height: `${ Math.max( position.height, 0.5 ) }%`,
+				minHeight: '24px',
 			} }
 			onClick={ () => blockRef.current?.focus() }
 			aria-label={ STATUS_LABELS[ status ] }

--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -35,7 +35,7 @@
 .revision-diff-markers {
 	position: relative;
 	flex-shrink: 0;
-	width: 12px;
+	width: 24px;
 	background: rgba(0, 0, 0, 0.05);
 
 	.revision-diff-marker {


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/77530

Ensures revision diff marker buttons meet the WCAG 2.5.8 minimum target size of 24×24 CSS pixels.

## Why?
Diff marker buttons in the revisions can shrink to as small as 12px by 4px, which falls well below the WCAG 2.5.8 minimum target size of 24 × 24 pixels.

## How?
1. Increase the width of the `.revision-diff-markers` column from 12px to 24px.
2. Add minHeight: '24px' to the button’s inline style.

## Testing Instructions
1. Open a post or page with at least two saved revisions.
2. Open the Revisions panel from the editor toolbar.
3. Inspect any `.revision-diff-marker` button in DevTools. Computed width should be 24px and computed height should be at least 24px, regardless of how small the corresponding block is in the document.

## Screenshots or screencast 

|Before|After|
|-|-|
|<img width="1470" height="791" alt="Screenshot 2026-04-25 at 8 10 38 PM" src="https://github.com/user-attachments/assets/3dfe811d-e27a-4a07-8cd9-e8c3fb093477" />| <img width="1470" height="799" alt="Screenshot 2026-04-25 at 8 08 32 PM" src="https://github.com/user-attachments/assets/71d33950-4a1c-482a-b41a-4617e16b3233" />|

## Use of AI Tools
None
