### PR TITLE
[Accidental PR creation, please ignore]

### DIFF
--- a/packages/sync/src/providers/http-polling/config.ts
+++ b/packages/sync/src/providers/http-polling/config.ts
@@ -24,7 +24,13 @@ export const DISCONNECT_DIALOG_RETRY_MS = 30000;
 // until the next automatic retry attempt.
 export const MANUAL_RETRY_INTERVAL_MS = 15000;
 
-export const MAX_UPDATE_SIZE_IN_BYTES = 1 * 1024 * 1024; // 1 MB
+const MAX_ENCODED_UPDATE_SIZE_IN_BYTES = 1 * 1024 * 1024; // 1 MB
+
+// The server validates the base64-encoded `data` string against a 1 MB
+// maxLength. Base64 encodes three raw bytes as four characters, so cap the raw
+// Yjs update size to the largest value that cannot exceed the server limit.
+export const MAX_UPDATE_SIZE_IN_BYTES =
+	Math.floor( MAX_ENCODED_UPDATE_SIZE_IN_BYTES / 4 ) * 3;
 
 // Corresponds with server-side
 // WP_HTTP_Polling_Sync_Server::MAX_ROOMS_PER_REQUEST.

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -77,7 +77,7 @@ interface RegisterRoomOptions {
 
 interface RoomState {
 	clientId: number;
-	createCompactionUpdate: () => SyncUpdate;
+	createCompactionUpdate: () => SyncUpdate | void;
 	endCursor: number;
 	isPrimaryRoom: boolean;
 	localAwarenessState: LocalAwarenessState;
@@ -210,6 +210,40 @@ function handleForbiddenError(
 
 const roomStates: Map< string, RoomState > = new Map();
 
+function disconnectForDocumentSizeLimit(
+	roomState: RoomState,
+	updateSizeInBytes: number
+): void {
+	roomState.log( 'Document size limit exceeded', {
+		maxUpdateSizeInBytes: MAX_UPDATE_SIZE_IN_BYTES,
+		updateSizeInBytes,
+	} );
+
+	roomState.onStatusChange( {
+		status: 'disconnected',
+		error: new ConnectionError(
+			ConnectionErrorCode.DOCUMENT_SIZE_LIMIT_EXCEEDED,
+			'Document size limit exceeded'
+		),
+	} );
+
+	// This is an unrecoverable error. Unregister the room to prevent syncing.
+	unregisterRoom( roomState.room );
+}
+
+function createSyncUpdateIfWithinSizeLimit(
+	roomState: RoomState,
+	data: Uint8Array,
+	type: SyncUpdateType
+): SyncUpdate | void {
+	if ( data.byteLength > MAX_UPDATE_SIZE_IN_BYTES ) {
+		disconnectForDocumentSizeLimit( roomState, data.byteLength );
+		return;
+	}
+
+	return createSyncUpdate( data, type );
+}
+
 /**
  * Create a compaction update by merging existing updates. This preserves
  * the original operation metadata (client IDs, logical clocks) so that
@@ -219,7 +253,7 @@ const roomStates: Map< string, RoomState > = new Map();
  *
  * @param updates The updates to merge
  */
-function createDeprecatedCompactionUpdate( updates: SyncUpdate[] ): SyncUpdate {
+function createDeprecatedCompactionUpdate( updates: SyncUpdate[] ): Uint8Array {
 	// Extract only compaction and update types for merging (skip sync-step updates).
 	// Decode base64 updates to Uint8Array for merging.
 	const mergeable = updates
@@ -230,11 +264,7 @@ function createDeprecatedCompactionUpdate( updates: SyncUpdate[] ): SyncUpdate {
 		)
 		.map( ( u ) => base64ToUint8Array( u.data ) );
 
-	// Merge all updates while preserving operation metadata.
-	return createSyncUpdate(
-		Y.mergeUpdatesV2( mergeable ),
-		SyncUpdateType.COMPACTION
-	);
+	return Y.mergeUpdatesV2( mergeable );
 }
 
 /**
@@ -683,17 +713,23 @@ function poll(): void {
 				if ( room.should_compact ) {
 					roomState.log( 'Server requested compaction update' );
 					roomState.updateQueue.clear();
-					roomState.updateQueue.add(
-						roomState.createCompactionUpdate()
-					);
+					const compactionUpdate = roomState.createCompactionUpdate();
+					if ( compactionUpdate ) {
+						roomState.updateQueue.add( compactionUpdate );
+					}
 				} else if ( room.compaction_request ) {
 					// Deprecated
 					roomState.log( 'Server requested (old) compaction update' );
-					roomState.updateQueue.add(
+					const compactionUpdate = createSyncUpdateIfWithinSizeLimit(
+						roomState,
 						createDeprecatedCompactionUpdate(
 							room.compaction_request
-						)
+						),
+						SyncUpdateType.COMPACTION
 					);
+					if ( compactionUpdate ) {
+						roomState.updateQueue.add( compactionUpdate );
+					}
 				}
 			} );
 
@@ -756,9 +792,16 @@ function poll(): void {
 
 					if ( room.updates.length > 0 && state.endCursor > 0 ) {
 						state.updateQueue.clear();
-						state.updateQueue.add( state.createCompactionUpdate() );
+						const compactionUpdate = state.createCompactionUpdate();
+						if ( compactionUpdate ) {
+							state.updateQueue.add( compactionUpdate );
+						}
 					} else if ( room.updates.length > 0 ) {
 						state.updateQueue.restore( room.updates );
+					}
+
+					if ( roomStates.get( room.room ) !== state ) {
+						continue;
 					}
 
 					state.log(
@@ -864,22 +907,8 @@ function registerRoom( {
 			if ( ! state ) {
 				return;
 			}
-
-			state.log( 'Document size limit exceeded', {
-				maxUpdateSizeInBytes: MAX_UPDATE_SIZE_IN_BYTES,
-				updateSizeInBytes: update.byteLength,
-			} );
-
-			state.onStatusChange( {
-				status: 'disconnected',
-				error: new ConnectionError(
-					ConnectionErrorCode.DOCUMENT_SIZE_LIMIT_EXCEEDED,
-					'Document size limit exceeded'
-				),
-			} );
-
-			// This is an unrecoverable error. Unregister the room to prevent syncing.
-			unregisterRoom( room );
+			disconnectForDocumentSizeLimit( state, update.byteLength );
+			return;
 		}
 
 		// Tag local document changes as 'update' type.
@@ -895,7 +924,8 @@ function registerRoom( {
 	const roomState: RoomState = {
 		clientId: doc.clientID,
 		createCompactionUpdate: () =>
-			createSyncUpdate(
+			createSyncUpdateIfWithinSizeLimit(
+				roomState,
 				Y.encodeStateAsUpdateV2( doc ),
 				SyncUpdateType.COMPACTION
 			),

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -151,12 +151,14 @@ function identifyForbiddenRoom(
  * rooms, and restores pending updates for the remaining rooms so they retry on
  * the next poll cycle.
  *
- * @param error          The forbidden error, narrowed via isForbiddenError.
- * @param requestedRooms The rooms that were in the failing request.
+ * @param error               The forbidden error, narrowed via isForbiddenError.
+ * @param requestedRooms      The rooms that were in the failing request.
+ * @param requestedRoomStates The room states that created the failing request.
  */
 function handleForbiddenError(
 	error: WPRestError,
-	requestedRooms: SyncPayload[ 'rooms' ]
+	requestedRooms: SyncPayload[ 'rooms' ],
+	requestedRoomStates: Map< string, RoomState >
 ): void {
 	const forbiddenRoom = identifyForbiddenRoom(
 		error,
@@ -165,8 +167,8 @@ function handleForbiddenError(
 
 	if ( forbiddenRoom ) {
 		// A specific room was denied — unregister only that room.
-		const state = roomStates.get( forbiddenRoom );
-		if ( state ) {
+		const state = requestedRoomStates.get( forbiddenRoom );
+		if ( state && roomStates.get( forbiddenRoom ) === state ) {
 			state.log(
 				'Permission denied, unregistering room',
 				{ error },
@@ -179,13 +181,14 @@ function handleForbiddenError(
 		// Restore updates for remaining rooms so they can be retried on
 		// the next poll cycle.
 		for ( const room of requestedRooms ) {
+			const remainingState = requestedRoomStates.get( room.room );
 			if (
 				room.room === forbiddenRoom ||
-				! roomStates.has( room.room )
+				! remainingState ||
+				roomStates.get( room.room ) !== remainingState
 			) {
 				continue;
 			}
-			const remainingState = roomStates.get( room.room )!;
 			if ( room.updates.length > 0 ) {
 				remainingState.updateQueue.restore( room.updates );
 			}
@@ -620,6 +623,9 @@ function poll(): void {
 				updates: state.updateQueue.get(),
 			} ) ),
 		};
+		const requestedRoomStates = new Map(
+			roomsInRequest.map( ( state ) => [ state.room, state ] )
+		);
 
 		// Emit 'connecting' status only for rooms in this request. Rooms
 		// rotated out of this poll keep their prior status.
@@ -648,11 +654,14 @@ function poll(): void {
 			hasCollaborators = false;
 
 			rooms.forEach( ( room ) => {
-				if ( ! roomStates.has( room.room ) ) {
+				const roomState = requestedRoomStates.get( room.room );
+				if (
+					! roomState ||
+					roomStates.get( room.room ) !== roomState
+				) {
 					return;
 				}
 
-				const roomState = roomStates.get( room.room )!;
 				roomState.endCursor = room.end_cursor;
 
 				// If a limit is exceeded, disconnect immediately without processing updates.
@@ -746,7 +755,11 @@ function poll(): void {
 			// sync a specific entity. Silently unregister the affected
 			// room(s) and let polling continue for the rest.
 			if ( isForbiddenError( error ) ) {
-				handleForbiddenError( error, payload.rooms );
+				handleForbiddenError(
+					error,
+					payload.rooms,
+					requestedRoomStates
+				);
 
 				// If every room was unregistered, stop the poll loop
 				// instead of scheduling another tick. Reset isPolling
@@ -784,11 +797,10 @@ function poll(): void {
 				// them; if it didn't, the compaction includes them. Updates not seen by
 				// this client are preserved in both cases.
 				for ( const room of payload.rooms ) {
-					if ( ! roomStates.has( room.room ) ) {
+					const state = requestedRoomStates.get( room.room );
+					if ( ! state || roomStates.get( room.room ) !== state ) {
 						continue;
 					}
-
-					const state = roomStates.get( room.room )!;
 
 					if ( room.updates.length > 0 && state.endCursor > 0 ) {
 						state.updateQueue.clear();
@@ -836,6 +848,11 @@ function poll(): void {
 					} );
 				}
 			}
+		}
+
+		if ( roomStates.size === 0 ) {
+			isPolling = false;
+			return;
 		}
 
 		pollingTimeoutId = setTimeout( poll, pollInterval );
@@ -986,6 +1003,12 @@ function unregisterRoom(
 	}
 
 	if ( 0 === roomStates.size && areListenersRegistered ) {
+		if ( pollingTimeoutId ) {
+			clearTimeout( pollingTimeoutId );
+			pollingTimeoutId = null;
+			isPolling = false;
+		}
+
 		window.removeEventListener( 'beforeunload', handleBeforeUnload );
 		window.removeEventListener( 'pagehide', handlePageHide );
 		document.removeEventListener(

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -133,6 +133,7 @@ describe( 'polling-manager', () => {
 	let mockPostSyncUpdateNonBlocking: jest.Mock<
 		typeof import('../utils').postSyncUpdateNonBlocking
 	>;
+	let mockEncodeStateAsUpdateV2: jest.Mock;
 	let mockApplyFilters: jest.Mock;
 
 	beforeEach( () => {
@@ -145,6 +146,7 @@ describe( 'polling-manager', () => {
 			mockPostSyncUpdate = require( '../utils' ).postSyncUpdate;
 			mockPostSyncUpdateNonBlocking =
 				require( '../utils' ).postSyncUpdateNonBlocking;
+			mockEncodeStateAsUpdateV2 = require( 'yjs' ).encodeStateAsUpdateV2;
 			mockApplyFilters = require( '@wordpress/hooks' ).applyFilters;
 		} );
 	} );
@@ -252,6 +254,75 @@ describe( 'polling-manager', () => {
 						code: 'document-size-limit-exceeded',
 					} ),
 				} )
+			);
+		} );
+
+		it( 'does not send an oversized server-requested compaction update', async () => {
+			const responseWithCollaborator = {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 1,
+						awareness: { 1: {}, 2: {} },
+						updates: [],
+					},
+				],
+			};
+			const responseWithCompactionRequest = {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 2,
+						awareness: { 1: {}, 2: {} },
+						updates: [],
+						should_compact: true,
+					},
+				],
+			};
+			mockPostSyncUpdate
+				.mockResolvedValueOnce( responseWithCollaborator )
+				.mockResolvedValueOnce( responseWithCompactionRequest )
+				.mockResolvedValueOnce( responseWithCollaborator );
+			mockEncodeStateAsUpdateV2.mockReturnValueOnce(
+				new Uint8Array( 11 )
+			);
+
+			const onStatusChange = jest.fn();
+			const doc = createMockDoc( 1 );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc,
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange,
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			await jest.advanceTimersByTimeAsync( 1000 );
+			await jest.advanceTimersByTimeAsync( 1000 );
+
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+			expect( onStatusChange ).toHaveBeenCalledWith( {
+				status: 'disconnected',
+				error: expect.objectContaining( {
+					code: 'document-size-limit-exceeded',
+				} ),
+			} );
+			expect( mockPostSyncUpdateNonBlocking ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					rooms: expect.arrayContaining( [
+						expect.objectContaining( {
+							room: 'test-room',
+							awareness: null,
+						} ),
+					] ),
+				} )
+			);
+			expect( doc.off ).toHaveBeenCalledWith(
+				'updateV2',
+				expect.any( Function )
 			);
 		} );
 	} );
@@ -880,6 +951,70 @@ describe( 'polling-manager', () => {
 			const retryUpdates = thirdCallPayload.rooms[ 0 ].updates;
 			expect( retryUpdates ).toHaveLength( 1 );
 			expect( retryUpdates[ 0 ].type ).toBe( 'compaction' );
+		} );
+
+		it( 'does not retry a failed poll with an oversized compaction update', async () => {
+			const responseWithCollaborator = {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 1,
+						awareness: { 1: {}, 2: {} },
+						updates: [],
+					},
+				],
+			};
+			mockPostSyncUpdate.mockResolvedValueOnce(
+				responseWithCollaborator
+			);
+			mockEncodeStateAsUpdateV2.mockReturnValueOnce(
+				new Uint8Array( 11 )
+			);
+
+			const onStatusChange = jest.fn();
+			const doc = createMockDoc( 1 );
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc,
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange,
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			const onDocUpdate = getOnDocUpdate( doc );
+			onDocUpdate( new Uint8Array( [ 1, 2, 3 ] ), 'user' );
+
+			mockPostSyncUpdate.mockRejectedValueOnce( new Error( 'timeout' ) );
+			await jest.advanceTimersByTimeAsync( 1000 );
+
+			mockPostSyncUpdate.mockResolvedValueOnce(
+				responseWithCollaborator
+			);
+			await jest.advanceTimersByTimeAsync( 1000 );
+
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+			expect( onStatusChange ).toHaveBeenCalledWith( {
+				status: 'disconnected',
+				error: expect.objectContaining( {
+					code: 'document-size-limit-exceeded',
+				} ),
+			} );
+			expect( mockPostSyncUpdateNonBlocking ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					rooms: expect.arrayContaining( [
+						expect.objectContaining( {
+							room: 'test-room',
+							awareness: null,
+						} ),
+					] ),
+				} )
+			);
+			expect( doc.off ).toHaveBeenCalledWith(
+				'updateV2',
+				expect.any( Function )
+			);
 		} );
 
 		it( 'does not queue a compaction for rooms with no outgoing updates', async () => {

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -9,7 +9,7 @@ import {
 	it,
 	jest,
 } from '@jest/globals';
-import { type SyncResponse } from '../types';
+import { SyncUpdateType, type SyncResponse } from '../types';
 
 // Mock all external dependencies before imports.
 jest.mock( 'yjs', () => ( {
@@ -74,10 +74,12 @@ interface PollingManager {
 
 function createDeferred< T >() {
 	let resolve!: ( value: T ) => void;
-	const promise = new Promise< T >( ( res ) => {
+	let reject!: ( reason?: unknown ) => void;
+	const promise = new Promise< T >( ( res, rej ) => {
 		resolve = res;
+		reject = rej;
 	} );
-	return { promise, resolve };
+	return { promise, reject, resolve };
 }
 
 function createMockDoc( clientID = 1 ) {
@@ -133,7 +135,9 @@ describe( 'polling-manager', () => {
 	let mockPostSyncUpdateNonBlocking: jest.Mock<
 		typeof import('../utils').postSyncUpdateNonBlocking
 	>;
+	let mockApplyUpdateV2: jest.Mock;
 	let mockEncodeStateAsUpdateV2: jest.Mock;
+	let mockMergeUpdatesV2: jest.Mock;
 	let mockApplyFilters: jest.Mock;
 
 	beforeEach( () => {
@@ -146,7 +150,9 @@ describe( 'polling-manager', () => {
 			mockPostSyncUpdate = require( '../utils' ).postSyncUpdate;
 			mockPostSyncUpdateNonBlocking =
 				require( '../utils' ).postSyncUpdateNonBlocking;
+			mockApplyUpdateV2 = require( 'yjs' ).applyUpdateV2;
 			mockEncodeStateAsUpdateV2 = require( 'yjs' ).encodeStateAsUpdateV2;
+			mockMergeUpdatesV2 = require( 'yjs' ).mergeUpdatesV2;
 			mockApplyFilters = require( '@wordpress/hooks' ).applyFilters;
 		} );
 	} );
@@ -257,6 +263,56 @@ describe( 'polling-manager', () => {
 			);
 		} );
 
+		it( 'polls immediately for a new room after a local size-limit disconnect clears the last room', async () => {
+			mockPostSyncUpdate
+				.mockResolvedValueOnce( syncResponse )
+				.mockResolvedValueOnce( {
+					rooms: [
+						{
+							room: 'new-room',
+							end_cursor: 1,
+							awareness: {},
+							updates: [],
+						},
+					],
+				} );
+
+			const doc = createMockDoc( 1 );
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc,
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			const onDocUpdate = getOnDocUpdate( doc );
+			onDocUpdate( new Uint8Array( 11 ), 'some-origin' );
+
+			pollingManager.registerRoom( {
+				room: 'new-room',
+				doc: createMockDoc( 2 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+			expect( mockPostSyncUpdate.mock.calls[ 1 ][ 0 ] ).toEqual(
+				expect.objectContaining( {
+					rooms: expect.arrayContaining( [
+						expect.objectContaining( { room: 'new-room' } ),
+					] ),
+				} )
+			);
+		} );
+
 		it( 'does not send an oversized server-requested compaction update', async () => {
 			const responseWithCollaborator = {
 				rooms: [
@@ -324,6 +380,84 @@ describe( 'polling-manager', () => {
 				'updateV2',
 				expect.any( Function )
 			);
+		} );
+
+		it( 'does not send an oversized deprecated server-requested compaction update', async () => {
+			mockPostSyncUpdate.mockResolvedValueOnce( {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 1,
+						awareness: {},
+						updates: [],
+						compaction_request: [
+							{
+								data: 'AA==',
+								type: SyncUpdateType.UPDATE,
+							},
+						],
+					},
+				],
+			} );
+			mockMergeUpdatesV2.mockReturnValueOnce( new Uint8Array( 11 ) );
+
+			const onStatusChange = jest.fn();
+			const doc = createMockDoc( 1 );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc,
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange,
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+			expect( onStatusChange ).toHaveBeenCalledWith( {
+				status: 'disconnected',
+				error: expect.objectContaining( {
+					code: 'document-size-limit-exceeded',
+				} ),
+			} );
+			expect( mockPostSyncUpdateNonBlocking ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					rooms: expect.arrayContaining( [
+						expect.objectContaining( {
+							room: 'test-room',
+							awareness: null,
+						} ),
+					] ),
+				} )
+			);
+			expect( doc.off ).toHaveBeenCalledWith(
+				'updateV2',
+				expect.any( Function )
+			);
+
+			mockPostSyncUpdate.mockResolvedValueOnce( {
+				rooms: [
+					{
+						room: 'new-room',
+						end_cursor: 1,
+						awareness: {},
+						updates: [],
+					},
+				],
+			} );
+			pollingManager.registerRoom( {
+				room: 'new-room',
+				doc: createMockDoc( 2 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 		} );
 	} );
 
@@ -1060,6 +1194,106 @@ describe( 'polling-manager', () => {
 				} >;
 			};
 			expect( thirdCallPayload.rooms[ 0 ].updates ).toHaveLength( 0 );
+		} );
+	} );
+
+	describe( 'stale in-flight requests', () => {
+		it( 'ignores a success response for a re-registered room with the same name', async () => {
+			const deferred = createDeferred< SyncResponse >();
+			mockPostSyncUpdate.mockReturnValueOnce( deferred.promise );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			pollingManager.unregisterRoom( 'test-room', {
+				sendDisconnectSignal: false,
+			} );
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc( 2 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			deferred.resolve( {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 1,
+						awareness: {},
+						updates: [
+							{
+								data: 'AA==',
+								type: SyncUpdateType.UPDATE,
+							},
+						],
+					},
+				],
+			} );
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			expect( mockApplyUpdateV2 ).not.toHaveBeenCalled();
+		} );
+
+		it( 'ignores an error response for a re-registered room with the same name', async () => {
+			const responseWithCollaborator = {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 1,
+						awareness: { 1: {}, 2: {} },
+						updates: [],
+					},
+				],
+			};
+			mockPostSyncUpdate.mockResolvedValueOnce(
+				responseWithCollaborator
+			);
+
+			const doc = createMockDoc( 1 );
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc,
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			const onDocUpdate = getOnDocUpdate( doc );
+			onDocUpdate( new Uint8Array( [ 1, 2, 3 ] ), 'user' );
+
+			const deferred = createDeferred< SyncResponse >();
+			mockPostSyncUpdate.mockReturnValueOnce( deferred.promise );
+			await jest.advanceTimersByTimeAsync( 1000 );
+
+			const newRoomLog = jest.fn();
+			pollingManager.unregisterRoom( 'test-room', {
+				sendDisconnectSignal: false,
+			} );
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc( 2 ),
+				awareness: createMockAwareness(),
+				log: newRoomLog,
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			deferred.reject( new Error( 'timeout' ) );
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			expect( newRoomLog ).not.toHaveBeenCalled();
 		} );
 	} );
 


### PR DESCRIPTION
## What?\nGuard HTTP polling RTC update creation so local and compaction updates cannot exceed the server per-update data limit. Also harden poll response handling so stale in-flight responses cannot mutate a room that was unregistered and re-registered with the same name.\n\n## Why?\nThe server validates the base64-encoded update data string with a 1 MiB maxLength. The client previously used a 1 MiB raw-byte cap and compaction updates bypassed the size guard, so large but ordinary collaborative edits could lead to repeated 400 responses and a generic Connection lost modal.\n\nA follow-up audit also found provider lifecycle bugs around terminal unregister and stale in-flight responses.\n\n## Testing\n- npm run test:unit packages/sync/src/providers/http-polling/test/polling-manager.test.ts -- --runInBand\n- npm run lint:js -- packages/sync/src/providers/http-polling/polling-manager.ts packages/sync/src/providers/http-polling/test/polling-manager.test.ts packages/sync/src/providers/http-polling/config.ts\n- git diff --check origin/trunk...HEAD\n\nRepro/evidence branch: https://github.com/danluu/gutenberg/tree/danluu/rtc-issue-05-oversized-update-repro