### PR TITLE
Revert tsgo update as it breaks trunk

### DIFF
--- a/bin/build.mjs
+++ b/bin/build.mjs
@@ -114,7 +114,7 @@ async function build() {
 			// Step 4: Build TypeScript types
 			console.log( '\n📘 Building TypeScript types...\n' );
 			const tsStartTime = Date.now();
-			await exec( 'tsgo', [ '--build' ] ).catch( () => {
+			await exec( 'tsc', [ '--build' ] ).catch( () => {
 				console.error(
 					'\n❌ TypeScript compilation failed. Try cleaning up first: `npm run clean:package-types`'
 				);

--- a/bin/dev.mjs
+++ b/bin/dev.mjs
@@ -150,7 +150,7 @@ async function dev() {
 		// Step 4: Build TypeScript types
 		console.log( '\n📘 Building TypeScript types...\n' );
 		const tsStartTime = Date.now();
-		await exec( 'tsgo', [ '--build' ] ).catch( () => {
+		await exec( 'tsc', [ '--build' ] ).catch( () => {
 			console.error(
 				'\n❌ TypeScript compilation failed. Try cleaning up first: `npm run clean:package-types`'
 			);
@@ -182,7 +182,7 @@ async function dev() {
 		console.log( '   - Package builder watching for source changes\n' );
 
 		// Start TypeScript watch
-		const tscWatch = execAsync( 'tsgo', [
+		const tscWatch = execAsync( 'tsc', [
 			'--build',
 			'--watch',
 			'--preserveWatchOutput',

--- a/bin/packages/check-build-type-declaration-files.js
+++ b/bin/packages/check-build-type-declaration-files.js
@@ -70,7 +70,7 @@ async function getDecFile( packagePath ) {
 async function typecheckDeclarations( file ) {
 	return new Promise( ( resolve, reject ) => {
 		exec(
-			`npx tsgo --ignoreConfig --target esnext --moduleResolution bundler --noEmit --skipLibCheck "${ file }"`,
+			`npx tsc --ignoreConfig --target esnext --moduleResolution bundler --noEmit --skipLibCheck "${ file }"`,
 			( error, stdout, stderr ) => {
 				if ( error ) {
 					reject( { file, error, stderr, stdout } );

--- a/package.json
+++ b/package.json
@@ -118,9 +118,9 @@
 	},
 	"scripts": {
 		"build": "node ./bin/build.mjs",
-		"build:profile-types": "rimraf ./ts-traces && npm run clean:package-types && node ./bin/packages/validate-typescript-version.js && ( tsgo --build --extendedDiagnostics --generateTrace ./ts-traces || ( echo 'tsc failed.'; exit 1 ) ) && node ./bin/packages/check-build-type-declaration-files.js && npx --yes @typescript/analyze-trace ts-traces > ts-traces/analysis.txt && node -p \"'\\n\\nDone! Build traces saved to ts-traces/ directory.\\nTrace analysis saved to ts-traces/analysis.txt.'\"",
+		"build:profile-types": "rimraf ./ts-traces && npm run clean:package-types && node ./bin/packages/validate-typescript-version.js && ( tsc --build --extendedDiagnostics --generateTrace ./ts-traces || ( echo 'tsc failed.'; exit 1 ) ) && node ./bin/packages/check-build-type-declaration-files.js && npx --yes @typescript/analyze-trace ts-traces > ts-traces/analysis.txt && node -p \"'\\n\\nDone! Build traces saved to ts-traces/ directory.\\nTrace analysis saved to ts-traces/analysis.txt.'\"",
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",
-		"clean:package-types": "tsgo --build --clean && rimraf --glob \"./packages/*/build-types\"",
+		"clean:package-types": "tsc --build --clean && rimraf --glob \"./packages/*/build-types\"",
 		"clean:packages": "rimraf --glob \"./packages/*/{build,build-module,build-wp,build-style}\" \"./build\"",
 		"component-usage-stats": "node ./node_modules/react-scanner/bin/react-scanner -c ./react-scanner.config.js",
 		"dev": "node ./bin/dev.mjs",

--- a/packages/preferences/src/components/preferences-modal-tabs/index.tsx
+++ b/packages/preferences/src/components/preferences-modal-tabs/index.tsx
@@ -110,10 +110,10 @@ export default function PreferencesModalTabs( {
 							<ItemGroup>
 								{ tabs.map( ( tab ) => {
 									return (
+										// @ts-expect-error: Navigator.Button is currently typed in a way that prevents Item from being passed in
 										<Navigator.Button
 											key={ tab.name }
 											path={ `/${ tab.name }` }
-											// @ts-expect-error: Navigator.Button is currently typed in a way that prevents Item from being passed in
 											as={ Item }
 											isAction
 										>


### PR DESCRIPTION
The `tsgo` update in #77177 broke `trunk`, for reasons I don't understand yet, so let's revert it until we figure it out.

This is a minimal revert, turns out that there was only one type error fix that's not compatible between 6.0 and 7.0 and must be reverted.