### PR TITLE
RTC: Fix issue where undo acts on the wrong synced entity

### DIFF
--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -22,6 +22,7 @@ import {
 	CRDT_STATE_MAP_KEY,
 	CRDT_STATE_MAP_SAVED_AT_KEY as SAVED_AT_KEY,
 	CRDT_STATE_MAP_SAVED_BY_KEY as SAVED_BY_KEY,
+	LOCAL_EDITOR_ORIGIN,
 } from '../config';
 import { getProviderCreators } from '../providers';
 import type {
@@ -224,6 +225,69 @@ describe( 'SyncManager', () => {
 				mockSyncConfig.applyChangesToCRDTDoc
 			).toHaveBeenCalledTimes( 2 );
 			expect( mockProviderCreator ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		it( 'only adds undo metadata for the entity that changed', async () => {
+			mockSyncConfig.applyChangesToCRDTDoc = jest.fn(
+				( ydoc: CRDTDoc, changes: Partial< ObjectData > ) => {
+					const recordMap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+					Object.entries( changes ).forEach( ( [ key, value ] ) => {
+						recordMap.set( key, value );
+					} );
+				}
+			);
+
+			const recordA = { id: '123', title: 'Post A', meta: {} };
+			const recordB = { id: '456', title: 'Post B', meta: {} };
+			const handlersA = {
+				...mockHandlers,
+				addUndoMeta: jest.fn(),
+				getEditedRecord: jest.fn( async () =>
+					Promise.resolve( recordA )
+				),
+				restoreUndoMeta: jest.fn(),
+			};
+			const handlersB = {
+				...mockHandlers,
+				addUndoMeta: jest.fn(),
+				getEditedRecord: jest.fn( async () =>
+					Promise.resolve( recordB )
+				),
+				restoreUndoMeta: jest.fn(),
+			};
+
+			const manager = createSyncManager();
+
+			await manager.load(
+				mockSyncConfig,
+				'post',
+				'123',
+				recordA,
+				handlersA
+			);
+			await manager.load(
+				mockSyncConfig,
+				'post',
+				'456',
+				recordB,
+				handlersB
+			);
+
+			handlersA.addUndoMeta.mockClear();
+			handlersB.addUndoMeta.mockClear();
+
+			manager.update(
+				'post',
+				'123',
+				{ title: 'Post A updated' },
+				LOCAL_EDITOR_ORIGIN,
+				{ isNewUndoLevel: true }
+			);
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+			expect( handlersA.addUndoMeta ).toHaveBeenCalledTimes( 1 );
+			expect( handlersB.addUndoMeta ).not.toHaveBeenCalled();
 		} );
 
 		describe( 'persisted CRDT doc behavior', () => {

--- a/packages/sync/src/test/undo-manager.test.ts
+++ b/packages/sync/src/test/undo-manager.test.ts
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import * as Y from 'yjs';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+/**
+ * Internal dependencies
+ */
+import { LOCAL_EDITOR_ORIGIN } from '../config';
+import { createUndoManager } from '../undo-manager';
+
+describe( 'SyncUndoManager', () => {
+	const docs: Y.Doc[] = [];
+
+	afterEach( () => {
+		docs.splice( 0 ).forEach( ( doc ) => doc.destroy() );
+	} );
+
+	function createScopedMap() {
+		const doc = new Y.Doc();
+		docs.push( doc );
+		return {
+			doc,
+			map: doc.getMap( 'record' ),
+			handlers: {
+				addUndoMeta: jest.fn(),
+				restoreUndoMeta: jest.fn(),
+			},
+		};
+	}
+
+	it( 'only runs metadata handlers for the document that created the stack item', () => {
+		const undoManager = createUndoManager();
+		const first = createScopedMap();
+		const second = createScopedMap();
+
+		undoManager.addToScope( first.map, first.handlers );
+		undoManager.addToScope( second.map, second.handlers );
+
+		first.doc.transact( () => {
+			first.map.set( 'title', 'First changed' );
+		}, LOCAL_EDITOR_ORIGIN );
+
+		expect( first.map.get( 'title' ) ).toBe( 'First changed' );
+		expect( second.map.get( 'title' ) ).toBeUndefined();
+		expect( first.handlers.addUndoMeta ).toHaveBeenCalledTimes( 1 );
+		expect( second.handlers.addUndoMeta ).not.toHaveBeenCalled();
+
+		undoManager.undo();
+
+		expect( first.map.get( 'title' ) ).toBeUndefined();
+		expect( second.map.get( 'title' ) ).toBeUndefined();
+		// Undoing creates a redo stack item, so metadata must also be
+		// captured for redo selection restoration.
+		expect( first.handlers.addUndoMeta ).toHaveBeenCalledTimes( 2 );
+		expect( second.handlers.addUndoMeta ).not.toHaveBeenCalled();
+		expect( first.handlers.restoreUndoMeta ).toHaveBeenCalledTimes( 1 );
+		expect( second.handlers.restoreUndoMeta ).not.toHaveBeenCalled();
+
+		first.handlers.addUndoMeta.mockClear();
+		first.handlers.restoreUndoMeta.mockClear();
+		second.handlers.addUndoMeta.mockClear();
+		second.handlers.restoreUndoMeta.mockClear();
+
+		first.doc.transact( () => {
+			first.map.set( 'title', 'First changed again' );
+		}, LOCAL_EDITOR_ORIGIN );
+
+		second.doc.transact( () => {
+			second.map.set( 'title', 'Second changed' );
+		}, LOCAL_EDITOR_ORIGIN );
+
+		expect( first.map.get( 'title' ) ).toBe( 'First changed again' );
+		expect( second.map.get( 'title' ) ).toBe( 'Second changed' );
+		expect( first.handlers.addUndoMeta ).toHaveBeenCalledTimes( 1 );
+		expect( second.handlers.addUndoMeta ).toHaveBeenCalledTimes( 1 );
+
+		undoManager.undo();
+
+		expect( first.map.get( 'title' ) ).toBe( 'First changed again' );
+		expect( second.map.get( 'title' ) ).toBeUndefined();
+		expect( first.handlers.addUndoMeta ).toHaveBeenCalledTimes( 1 );
+		expect( second.handlers.addUndoMeta ).toHaveBeenCalledTimes( 2 );
+		expect( first.handlers.restoreUndoMeta ).not.toHaveBeenCalled();
+		expect( second.handlers.restoreUndoMeta ).toHaveBeenCalledTimes( 1 );
+
+		undoManager.redo();
+
+		expect( first.map.get( 'title' ) ).toBe( 'First changed again' );
+		expect( second.map.get( 'title' ) ).toBe( 'Second changed' );
+		expect( first.handlers.addUndoMeta ).toHaveBeenCalledTimes( 1 );
+		expect( second.handlers.addUndoMeta ).toHaveBeenCalledTimes( 3 );
+		expect( first.handlers.restoreUndoMeta ).not.toHaveBeenCalled();
+		expect( second.handlers.restoreUndoMeta ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/packages/sync/src/undo-manager.ts
+++ b/packages/sync/src/undo-manager.ts
@@ -15,6 +15,11 @@ import { LOCAL_EDITOR_ORIGIN } from './config';
 import { YMultiDocUndoManager } from './y-utilities/y-multidoc-undomanager';
 import type { ObjectData, RecordHandlers, SyncUndoManager } from './types';
 
+type UndoMetaHandlers = Pick<
+	RecordHandlers,
+	'addUndoMeta' | 'restoreUndoMeta'
+>;
+
 interface StackItemEvent {
 	stackItem: { meta: Map< any, any > };
 	origin: any;
@@ -30,6 +35,7 @@ interface StackItemEvent {
  * without conflicts.
  */
 export function createUndoManager(): SyncUndoManager {
+	const undoMetaHandlers = new Map< Y.Doc, UndoMetaHandlers >();
 	const yUndoManager = new YMultiDocUndoManager( [], {
 		// Throttle undo/redo captures after 500ms of inactivity.
 		// 500 was selected from subjective local UX testing, shorter timeouts
@@ -38,6 +44,24 @@ export function createUndoManager(): SyncUndoManager {
 		// Ensure that we only scope the undo/redo to the current editor.
 		// The yjs document's clientID is added once it's available.
 		trackedOrigins: new Set( [ LOCAL_EDITOR_ORIGIN ] ),
+	} );
+
+	yUndoManager.on( 'stack-item-added', ( event: StackItemEvent ) => {
+		const handlers = undoMetaHandlers.get( event.ydoc );
+		if ( ! handlers ) {
+			return;
+		}
+
+		handlers.addUndoMeta( event.ydoc, event.stackItem.meta );
+	} );
+
+	yUndoManager.on( 'stack-item-popped', ( event: StackItemEvent ) => {
+		const handlers = undoMetaHandlers.get( event.ydoc );
+		if ( ! handlers ) {
+			return;
+		}
+
+		handlers.restoreUndoMeta( event.ydoc, event.stackItem.meta );
 	} );
 
 	return {
@@ -65,10 +89,7 @@ export function createUndoManager(): SyncUndoManager {
 		 * @param                handlers.addUndoMeta
 		 * @param                handlers.restoreUndoMeta
 		 */
-		addToScope(
-			ymap: Y.Map< any >,
-			handlers: Pick< RecordHandlers, 'addUndoMeta' | 'restoreUndoMeta' >
-		): void {
+		addToScope( ymap: Y.Map< any >, handlers: UndoMetaHandlers ): void {
 			if ( ymap.doc === null ) {
 				// Necessary for a type check, but this shouldn't happen.
 				return;
@@ -77,15 +98,10 @@ export function createUndoManager(): SyncUndoManager {
 			const ydoc = ymap.doc;
 			yUndoManager.addToScope( ymap );
 
-			const { addUndoMeta, restoreUndoMeta } = handlers;
-
-			yUndoManager.on( 'stack-item-added', ( event: StackItemEvent ) => {
-				addUndoMeta( ydoc, event.stackItem.meta );
-			} );
-
-			yUndoManager.on( 'stack-item-popped', ( event: StackItemEvent ) => {
-				restoreUndoMeta( ydoc, event.stackItem.meta );
-			} );
+			if ( ! undoMetaHandlers.has( ydoc ) ) {
+				ydoc.on( 'destroy', () => undoMetaHandlers.delete( ydoc ) );
+			}
+			undoMetaHandlers.set( ydoc, handlers );
 		},
 
 		/**

--- a/test/e2e/specs/editor/collaboration/collaboration-undo-redo.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-undo-redo.spec.ts
@@ -1,7 +1,70 @@
 /**
+ * External dependencies
+ */
+import type { Page } from '@playwright/test';
+
+/**
  * Internal dependencies
  */
 import { test, expect } from './fixtures';
+import { pressKey, LINE_START_KEY } from './fixtures/keyboard-utils';
+
+async function loadDefaultCategoryViaPublishPanel( page: Page ) {
+	await page
+		.getByRole( 'region', { name: 'Editor top bar' } )
+		.getByRole( 'button', { name: 'Publish', exact: true } )
+		.click();
+
+	await page.waitForFunction(
+		() => {
+			const core = window.wp?.data?.select( 'core' );
+			if ( ! core ) {
+				return false;
+			}
+			const defaultCategoryId = core.getEntityRecord( 'root', 'site' )
+				?.default_category;
+
+			return (
+				!! defaultCategoryId &&
+				core.hasFinishedResolution( 'getEntityRecord', [
+					'taxonomy',
+					'category',
+					defaultCategoryId,
+				] )
+			);
+		},
+		undefined,
+		{ timeout: 15000 }
+	);
+
+	await page
+		.getByRole( 'region', { name: 'Editor publish' } )
+		.getByRole( 'button', { name: 'Cancel' } )
+		.click();
+}
+
+async function getSelectionSnapshot( page: Page ) {
+	return page.evaluate( () => {
+		const blockEditor = window.wp.data.select( 'core/block-editor' );
+		const selectionStart = blockEditor.getSelectionStart();
+		const selectionEnd = blockEditor.getSelectionEnd();
+		const blocks = blockEditor.getBlocks();
+		const selectedBlock = selectionStart?.clientId
+			? blockEditor.getBlock( selectionStart.clientId )
+			: null;
+
+		return {
+			attributeKey: selectionStart?.attributeKey,
+			blockIndex: blocks.findIndex(
+				( block: { clientId: string } ) =>
+					block.clientId === selectionStart?.clientId
+			),
+			content: selectedBlock?.attributes?.content,
+			endOffset: selectionEnd?.offset,
+			offset: selectionStart?.offset,
+		};
+	} );
+}
 
 test.describe( 'Collaboration - Undo/Redo', () => {
 	test( 'User A undo only affects their own changes, not User B changes', async ( {
@@ -128,5 +191,76 @@ test.describe( 'Collaboration - Undo/Redo', () => {
 					attributes: { content: 'Undoable content' },
 				},
 			] );
+	} );
+
+	test( 'Undo restores the post selection when another synced entity is loaded', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Undo Selection Metadata Test',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+		} );
+		await collaborationUtils.openPost( post.id );
+
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'Undo Selection Metadata Test' );
+
+		// Opening the normal pre-publish panel loads the default category
+		// entity, adding a second synced Yjs document to the page.
+		await loadDefaultCategoryViaPublishPanel( page );
+
+		await editor.canvas
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click();
+		await page.keyboard.type( 'abcdef' );
+		await page.keyboard.press( LINE_START_KEY );
+		await pressKey( page, 'ArrowRight', 3 );
+
+		await expect
+			.poll( () => getSelectionSnapshot( page ), { timeout: 5000 } )
+			.toMatchObject( {
+				blockIndex: 0,
+				content: 'abcdef',
+				offset: 3,
+			} );
+
+		await page.keyboard.press( 'Enter' );
+		await expect
+			.poll( () => editor.getBlocks(), { timeout: 5000 } )
+			.toMatchObject( [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'abc' },
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'def' },
+				},
+			] );
+
+		await page.keyboard.press( 'ControlOrMeta+z' );
+		await expect
+			.poll( () => editor.getBlocks(), { timeout: 5000 } )
+			.toMatchObject( [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'abcdef' },
+				},
+			] );
+
+		await expect
+			.poll( () => getSelectionSnapshot( page ), { timeout: 5000 } )
+			.toMatchObject( {
+				attributeKey: 'content',
+				blockIndex: 0,
+				content: 'abcdef',
+				endOffset: 3,
+				offset: 3,
+			} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This is part of a series of bug reports and PRs from an AI fuzzing project. See #77532 for more details on that. I filing a few more of these after a discussion with @alecgeatches on how the fuzzer found a bug that I hadn't file that ended up taking some developer time to chase down and repro.


https://github.com/user-attachments/assets/5cedb606-5a98-44fe-8d77-5a5125dbd3c5


## BEGIN AI GENERATED TEXT

The
stock repro uses only normal editor actions: open the publish panel so the
default category entity is synced, type into the post, and press undo. The text
undo is applied, but the selection metadata that should be restored with the
undo stack item is missing or comes from the wrong entity scope.

This is a cross-entity scoping bug in `packages/sync/src/undo-manager.ts`. Each
synced entity adds metadata handlers to the shared Yjs `UndoManager`, but the
event listeners installed for those handlers are global to the undo manager
rather than scoped to the document/entity that produced the undo event.

## Stock repro

- Browser repro:
  https://github.com/danluu/gutenberg/blob/try/rtc-undo-cross-entity-stock-repro-pr-trunk/test/e2e/specs/editor/collaboration/collaboration-undo-redo.spec.ts
- Video:
  https://github.com/danluu/gutenberg/blob/try/rtc-undo-cross-entity-stock-repro/docs/explanations/architecture/rtc-stock-repros/videos/undo-metadata-cross-entity.mp4
- Video provenance: regenerated on April 26, 2026 from the Playwright trace
  emitted by the checked-in browser repro. In this current worktree run, after
  moving the undo environment from Playground to Docker, the real fixture fails
  earlier than the historical selection assertion: the normal undo shortcut
  leaves the split `abc` / `def` paragraphs in place, so the selection snapshot
  assertion is not reached. The MP4 intentionally shows that actual e2e run
  rather than a hand-written undo flow.
- Normal user actions:
  1. Editor A opens a collaborative post.
  2. Editor A opens the pre-publish panel, which loads and syncs the default
     category entity.
  3. Editor A closes the panel and types into the post title/body.
  4. Editor A presses undo.
  5. The content undo happens, but selection metadata for the post is not
     restored correctly.

## Observed vs expected

Expected: undo restores both the post content and the post selection metadata
that was recorded for the stack item.

Observed: after a second synced entity has been added, the undo stack item can be
handled through metadata callbacks for the wrong entity. The visible symptom is
that the post content changes but the selection metadata is unset or incorrect.

## How it was introduced

Undo support for RTC was added in #72407, `Real-time collaboration: Add
UndoManager support for collaborative editing`.

The cross-entity metadata bug was introduced by #74878, `Real-time
collaboration: Use relative positions in undo stack`. That PR added per-entity
`addUndoMeta` and `restoreUndoMeta` handlers inside `addToScope()`. The handlers
close over the entity-specific document state, but the listeners are registered
on the shared `UndoManager` events `stack-item-added` and `stack-item-popped`.
Those events are not filtered before calling each entity's handlers.

When a second synced entity is added, one undo manager has multiple sets of
entity-specific metadata listeners. A post undo event can therefore run category
metadata logic, or the category listener can overwrite/omit metadata that should
belong to the post.

## Root cause

The undo manager is shared across synced entities, but undo metadata handlers are
registered as if each entity has a private undo manager. Listener lifetime and
listener dispatch are both too broad:

- each scope registration adds another global listener pair;
- listeners close over entity-local metadata functions;
- dispatch does not first prove that the stack item belongs to that entity's
  Yjs document or tracked type;
- cleanup is easy to get wrong because listener ownership is duplicated per
  scope.

The issue is not specific to categories. Categories are just the stock UI path
that makes the editor sync a second entity without custom setup.

## Fix plan

1. Keep the shared undo stack so user-facing undo ordering across synced
   entities does not change.
2. Use the `ydoc` already emitted by `YMultiDocUndoManager` stack-item events to
   identify the document that produced the stack item.
3. In each metadata listener installed by `addToScope()`, return early unless
   `event.ydoc` is the Yjs document for that scope.
4. Invoke only the metadata handlers for the owning entity. If ownership cannot
   be determined, do not run unrelated entity handlers as a fallback.
5. Add regression coverage at the direct undo-wrapper level and the
   `SyncManager` integration level so the fix cannot regress back to global
   metadata dispatch.

The fix should not split the editor into independent undo managers per entity
unless product behavior explicitly wants separate undo stacks. Splitting stacks
would avoid this bug but would also change user-facing undo ordering across
entities. The safer fix is to keep the shared stack and scope only the metadata
dispatch.

## Repro coverage in the PR branch

PR branch:
https://github.com/danluu/gutenberg/tree/try/rtc-undo-cross-entity-stock-repro-pr-trunk

- Browser-level normal-user repro:
  https://github.com/danluu/gutenberg/blob/try/rtc-undo-cross-entity-stock-repro-pr-trunk/test/e2e/specs/editor/collaboration/collaboration-undo-redo.spec.ts
- `SyncManager` integration repro:
  https://github.com/danluu/gutenberg/blob/try/rtc-undo-cross-entity-stock-repro-pr-trunk/packages/sync/src/test/manager.ts
- Direct `SyncUndoManager` wrapper repro:
  https://github.com/danluu/gutenberg/blob/try/rtc-undo-cross-entity-stock-repro-pr-trunk/packages/sync/src/test/undo-manager.test.ts

There is no lower Gutenberg repro below `SyncUndoManager` for this bug. The
underlying `YMultiDocUndoManager` already emits the owning `ydoc`; the bug is in
Gutenberg's wrapper ignoring that ownership information when dispatching
metadata handlers.

## Verification

The failing stock repro is:

```bash
WP_BASE_URL=http://localhost:8990 npm run test:e2e -- test/e2e/specs/editor/collaboration/collaboration-undo-redo.spec.ts --grep "Undo restores the post selection"
```

Known-fixes-base status, checked on `try/fuzz-known-issues-fixed-campaign`
after the previously found RTC fixes were applied:

-   **Fails:** browser stock repro
    `Undo restores the post selection when another synced entity is loaded`.
    Content undo still happens, but the selection snapshot has
    `attributeKey: undefined`, `blockIndex: -1`, and no offsets/content instead
    of the expected post paragraph selection.
-   **Passes:** baseline undo/redo collaboration tests in the same spec:
    `User A undo only affects their own changes, not User B changes` and
    `Redo restores the undone change`.

The pass/fail split matters: the previously fixed RTC write-path and ordinary
undo behavior remain functional, but the multi-entity undo metadata scoping bug
is still present.

Lower-level coverage should assert that a stack item created from one Yjs
document never invokes metadata handlers registered for a different synced
entity.

Current PR-branch verification:

- Tests-only commit fails against trunk:
  `packages/sync/src/test/undo-manager.test.ts` fails because a stack item from
  one Yjs document invokes `addUndoMeta` for a different document.
- Tests-only commit fails against trunk:
  `packages/sync/src/test/manager.ts` fails because an update to one synced
  entity invokes undo metadata handlers for another synced entity.
- Branch head passes:
  `npm run test:unit -- packages/sync/src/test/undo-manager.test.ts packages/sync/src/test/manager.ts`


## END AI GENERATED TEXT


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
As noted above, the code here was AI generated and the bug came out of an AI fuzzing project.