### PR TITLE
Revisions: Add tooltip to diff marker buttons 

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/diff-markers.js
+++ b/packages/editor/src/components/post-revisions-preview/diff-markers.js
@@ -15,6 +15,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -97,7 +98,7 @@ function DiffMarkerButton( { clientId, status, subscribe } ) {
 	}
 
 	return (
-		<button
+		<Button
 			className={ `revision-diff-marker is-${ status }` }
 			style={ {
 				top: `${ position.top }%`,

--- a/packages/editor/src/components/post-revisions-preview/diff-markers.js
+++ b/packages/editor/src/components/post-revisions-preview/diff-markers.js
@@ -99,6 +99,7 @@ function DiffMarkerButton( { clientId, status, subscribe } ) {
 
 	return (
 		<Button
+			__next40pxDefaultSize
 			className={ `revision-diff-marker is-${ status }` }
 			style={ {
 				top: `${ position.top }%`,
@@ -106,6 +107,7 @@ function DiffMarkerButton( { clientId, status, subscribe } ) {
 			} }
 			onClick={ () => blockRef.current?.focus() }
 			aria-label={ STATUS_LABELS[ status ] }
+			showTooltip
 		/>
 	);
 }

--- a/packages/editor/src/components/post-revisions-preview/diff-markers.js
+++ b/packages/editor/src/components/post-revisions-preview/diff-markers.js
@@ -15,7 +15,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Tooltip } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -98,17 +98,17 @@ function DiffMarkerButton( { clientId, status, subscribe } ) {
 	}
 
 	return (
-		<Button
-			__next40pxDefaultSize
-			className={ `revision-diff-marker is-${ status }` }
-			style={ {
-				top: `${ position.top }%`,
-				height: `${ Math.max( position.height, 0.5 ) }%`,
-			} }
-			onClick={ () => blockRef.current?.focus() }
-			label={ STATUS_LABELS[ status ] }
-			showTooltip
-		/>
+		<Tooltip text={ STATUS_LABELS[ status ] }>
+			<button
+				className={ `revision-diff-marker is-${ status }` }
+				style={ {
+					top: `${ position.top }%`,
+					height: `${ Math.max( position.height, 0.5 ) }%`,
+				} }
+				onClick={ () => blockRef.current?.focus() }
+				aria-label={ STATUS_LABELS[ status ] }
+			/>
+		</Tooltip>
 	);
 }
 

--- a/packages/editor/src/components/post-revisions-preview/diff-markers.js
+++ b/packages/editor/src/components/post-revisions-preview/diff-markers.js
@@ -106,7 +106,7 @@ function DiffMarkerButton( { clientId, status, subscribe } ) {
 				height: `${ Math.max( position.height, 0.5 ) }%`,
 			} }
 			onClick={ () => blockRef.current?.focus() }
-			aria-label={ STATUS_LABELS[ status ] }
+			label={ STATUS_LABELS[ status ] }
 			showTooltip
 		/>
 	);


### PR DESCRIPTION

## What?

Part of https://github.com/WordPress/gutenberg/issues/77530

Replaces the raw `<button>` elements in the diff markers minimap with the `<Button>` component, adding label and `showTooltip` props.

## Why?

Diff marker buttons had no visible tooltip, and sighted users hovering the minimap received no textual information about what the coloured bar represents.

## How?

`label` on `<Button>` sets aria-label and renders visible text when the user has "text only buttons" enabled. `showTooltip` ensures the Gutenberg `<Tooltip>` always appears on hover with the same label text ("Go to added block", "Go to removed block", "Go to modified block").

## Testing Instructions

1. Create a post with multiple revisions and enter the visual revisions view.
2. Enable Show changes (eye icon). Coloured bars appear in the right-hand minimap.
3. Hover any bar, and a tooltip should appear with the text "Go to added block", "Go to removed block", or "Go to modified block".
4. Verfiy the aria-labels stay intact and as expected.

## Screenshots or screencast 

### Before


https://github.com/user-attachments/assets/6b09dec3-93a4-48c6-a7d8-a0439c8abf32



### After

https://github.com/user-attachments/assets/0b3f5ddf-8ad4-406d-a843-7460c189c4e5



