### PR TITLE
ui: Unify hairline border across overlay popups

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -35,7 +35,7 @@
 -   `Link`: Honor `openInNewTab` consistently instead of treating hash links as a special case ([#77422](https://github.com/WordPress/gutenberg/pull/77422)).
 -   `Select`: Tighten spacing after checkmark when `Select.Item` is `size="small"` ([#77642](https://github.com/WordPress/gutenberg/pull/77642)).
 -   `Dialog`, `Drawer`, `Popover`: Align title and description colors across all three overlay primitives. Title color is now authored explicitly (resilient to global CSS defenses), and description color now inherits from the popup foreground token instead of overriding to the weak variant ([#77692](https://github.com/WordPress/gutenberg/pull/77692)).
--   `Dialog`, `AlertDialog`, `Drawer`, `Popover`, `Select`, `Tooltip`: Unify the hairline border across overlay popups so the edge stays visible in both regular and forced-colors mode ([#77691](https://github.com/WordPress/gutenberg/pull/77691)).
+-   `Dialog`, `AlertDialog`, `Drawer`, `Popover`, `Select`, `Tooltip`: Unify the hairline border across overlay popups. Popups without a backdrop show a token-colored border in regular mode; popups with a backdrop hide the border (which would be redundant with the backdrop's containment); all popups show a `CanvasText` border in forced-colors mode ([#77691](https://github.com/WordPress/gutenberg/pull/77691)).
 
 ### Internal
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -35,6 +35,7 @@
 -   `Link`: Honor `openInNewTab` consistently instead of treating hash links as a special case ([#77422](https://github.com/WordPress/gutenberg/pull/77422)).
 -   `Select`: Tighten spacing after checkmark when `Select.Item` is `size="small"` ([#77642](https://github.com/WordPress/gutenberg/pull/77642)).
 -   `Dialog`, `Drawer`, `Popover`: Align title and description colors across all three overlay primitives. Title color is now authored explicitly (resilient to global CSS defenses), and description color now inherits from the popup foreground token instead of overriding to the weak variant ([#77692](https://github.com/WordPress/gutenberg/pull/77692)).
+-   `Dialog`, `AlertDialog`, `Drawer`, `Popover`, `Select`, `Tooltip`: Unify the hairline border across overlay popups so the edge stays visible in both regular and forced-colors mode ([#77691](https://github.com/WordPress/gutenberg/pull/77691)).
 
 ### Internal
 

--- a/packages/ui/src/dialog/style.module.css
+++ b/packages/ui/src/dialog/style.module.css
@@ -97,6 +97,19 @@
 			 */
 			height: 100dvh;
 		}
+
+		/*
+		 * Forced-colors mode strips `box-shadow` and replaces the popup's
+		 * `background-color` with `Canvas`, which is also the color the UA
+		 * uses for the backdrop — the popup boundary would otherwise
+		 * disappear. A 1px `CanvasText` border restores the edge. The
+		 * popup uses `box-sizing: border-box`, so the border is absorbed
+		 * into the existing box and doesn't shift any layout in non-FC
+		 * mode (where the declaration is inert).
+		 */
+		@media (forced-colors: active) {
+			border: 1px solid CanvasText;
+		}
 	}
 
 	/*

--- a/packages/ui/src/dialog/style.module.css
+++ b/packages/ui/src/dialog/style.module.css
@@ -44,6 +44,7 @@
 		max-height: calc(100dvh - 2 * var(--viewport-inset));
 		background-color: var(--wpds-color-bg-surface-neutral-strong);
 		border-radius: var(--wpds-border-radius-lg);
+		border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
 		box-shadow: var(--wpds-elevation-lg);
 		overflow: hidden;
 		font-family: var(--wpds-typography-font-family-body);
@@ -96,19 +97,6 @@
 			 * The max-{width,height} properties will make sure some padding is shown.
 			 */
 			height: 100dvh;
-		}
-
-		/*
-		 * Forced-colors mode strips `box-shadow` and replaces the popup's
-		 * `background-color` with `Canvas`, which is also the color the UA
-		 * uses for the backdrop — the popup boundary would otherwise
-		 * disappear. A 1px `CanvasText` border restores the edge. The
-		 * popup uses `box-sizing: border-box`, so the border is absorbed
-		 * into the existing box and doesn't shift any layout in non-FC
-		 * mode (where the declaration is inert).
-		 */
-		@media (forced-colors: active) {
-			border: 1px solid CanvasText;
 		}
 	}
 

--- a/packages/ui/src/dialog/style.module.css
+++ b/packages/ui/src/dialog/style.module.css
@@ -101,6 +101,34 @@
 	}
 
 	/*
+	 * When a backdrop is rendered alongside the popup (modal mode),
+	 * hide the regular-mode border. The backdrop already provides
+	 * visual containment, so the border becomes redundant noise.
+	 * `transparent` (not `none`) keeps popup geometry identical
+	 * across modal/non-modal — `box-sizing: border-box` absorbs the
+	 * 1px into the existing box.
+	 */
+	.backdrop ~ * .popup {
+		border-color: transparent;
+	}
+
+	/*
+	 * Forced-colors mode strips `box-shadow` and substitutes
+	 * `background-color` with `Canvas` (the page background), so the
+	 * boundary depends entirely on the border. Set `CanvasText`
+	 * explicitly for both modal and non-modal popups: `transparent`
+	 * is not substituted by the UA, and being explicit also removes
+	 * any reliance on UA color-substitution behavior for the
+	 * non-modal case.
+	 */
+	@media (forced-colors: active) {
+		.popup,
+		.backdrop ~ * .popup {
+			border-color: CanvasText;
+		}
+	}
+
+	/*
 	 * Chrome + content primitives are centralized in
 	 * `overlay-chrome.module.css` and shared with `drawer/style.module.css`
 	 * and `alert-dialog/popup.tsx`. Separator coloring and the modal

--- a/packages/ui/src/drawer/style.module.css
+++ b/packages/ui/src/drawer/style.module.css
@@ -218,6 +218,34 @@
 	}
 
 	/*
+	 * When a backdrop is rendered alongside the popup (modal mode),
+	 * hide the regular-mode border. The backdrop already provides
+	 * visual containment, so the border becomes redundant noise.
+	 * `transparent` (not `none`) keeps popup geometry identical
+	 * across modal/non-modal — `box-sizing: border-box` absorbs the
+	 * 1px into the existing box.
+	 */
+	.backdrop ~ * .popup {
+		border-color: transparent;
+	}
+
+	/*
+	 * Forced-colors mode strips `box-shadow` and substitutes
+	 * `background-color` with `Canvas` (the page background), so the
+	 * boundary depends entirely on the border. Set `CanvasText`
+	 * explicitly for both modal and non-modal popups: `transparent`
+	 * is not substituted by the UA, and being explicit also removes
+	 * any reliance on UA color-substitution behavior for the
+	 * non-modal case.
+	 */
+	@media (forced-colors: active) {
+		.popup,
+		.backdrop ~ * .popup {
+			border-color: CanvasText;
+		}
+	}
+
+	/*
 	 * Chrome + content primitives are centralized in
 	 * `overlay-chrome.module.css` and shared with `dialog/style.module.css`
 	 * and `alert-dialog/popup.tsx`. Separator coloring and the modal

--- a/packages/ui/src/drawer/style.module.css
+++ b/packages/ui/src/drawer/style.module.css
@@ -135,6 +135,19 @@
 			user-select: none;
 		}
 
+		/*
+		 * Forced-colors mode strips `box-shadow` and replaces the popup's
+		 * `background-color` with `Canvas`, which is also the color the UA
+		 * uses for the backdrop — the popup boundary would otherwise
+		 * disappear. A 1px `CanvasText` border restores the edge. The
+		 * popup uses `box-sizing: border-box`, so the border is absorbed
+		 * into the existing box and doesn't shift any layout in non-FC
+		 * mode (where the declaration is inert).
+		 */
+		@media (forced-colors: active) {
+			border: 1px solid CanvasText;
+		}
+
 		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
 		&[data-swipe-direction="left"] {
 			--stretch-size: calc(100vw - var(--viewport-inset));

--- a/packages/ui/src/drawer/style.module.css
+++ b/packages/ui/src/drawer/style.module.css
@@ -83,6 +83,7 @@
 		overflow: hidden;
 		pointer-events: auto;
 		background-color: var(--wpds-color-bg-surface-neutral-strong);
+		border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
 		box-shadow: var(--wpds-elevation-lg);
 		font-family: var(--wpds-typography-font-family-body);
 		font-size: var(--wpds-typography-font-size-md);
@@ -133,19 +134,6 @@
 
 		&[data-swiping] {
 			user-select: none;
-		}
-
-		/*
-		 * Forced-colors mode strips `box-shadow` and replaces the popup's
-		 * `background-color` with `Canvas`, which is also the color the UA
-		 * uses for the backdrop — the popup boundary would otherwise
-		 * disappear. A 1px `CanvasText` border restores the edge. The
-		 * popup uses `box-sizing: border-box`, so the border is absorbed
-		 * into the existing box and doesn't shift any layout in non-FC
-		 * mode (where the declaration is inert).
-		 */
-		@media (forced-colors: active) {
-			border: 1px solid CanvasText;
 		}
 
 		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */

--- a/packages/ui/src/popover/style.module.css
+++ b/packages/ui/src/popover/style.module.css
@@ -18,6 +18,34 @@
 		outline: 0;
 	}
 
+	/*
+	 * When a backdrop is rendered alongside the popup, hide the
+	 * regular-mode border. The backdrop already provides visual
+	 * containment, so the border becomes redundant noise.
+	 * `transparent` (not `none`) keeps popup geometry identical
+	 * regardless of the `backdrop` prop — `box-sizing: border-box`
+	 * absorbs the 1px into the existing box.
+	 */
+	.backdrop ~ * .popup {
+		border-color: transparent;
+	}
+
+	/*
+	 * Forced-colors mode strips `box-shadow` and substitutes
+	 * `background-color` with `Canvas` (the page background), so the
+	 * boundary depends entirely on the border. Set `CanvasText`
+	 * explicitly for both backdrop and non-backdrop popups:
+	 * `transparent` is not substituted by the UA, and being
+	 * explicit also removes any reliance on UA color-substitution
+	 * behavior for the non-backdrop case.
+	 */
+	@media (forced-colors: active) {
+		.popup,
+		.backdrop ~ * .popup {
+			border-color: CanvasText;
+		}
+	}
+
 	.arrow {
 		display: flex;
 

--- a/packages/ui/src/popover/style.module.css
+++ b/packages/ui/src/popover/style.module.css
@@ -9,7 +9,7 @@
 		background-color: var(--wpds-color-bg-surface-neutral-strong);
 		padding: var(--wpds-dimension-padding-lg);
 		border-radius: var(--wpds-border-radius-md);
-		border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
+		border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
 		box-shadow: var(--wpds-elevation-md);
 		font-family: var(--wpds-typography-font-family-body);
 		font-size: var(--wpds-typography-font-size-md);
@@ -47,7 +47,7 @@
 	}
 
 	.arrow-stroke {
-		fill: var(--wpds-color-stroke-surface-neutral-weak);
+		fill: var(--wpds-color-stroke-surface-neutral);
 	}
 
 	.title {

--- a/packages/ui/src/tooltip/style.module.css
+++ b/packages/ui/src/tooltip/style.module.css
@@ -6,6 +6,7 @@
 	}
 
 	.popup {
+		box-sizing: border-box;
 		background-color: var(--wpds-color-bg-surface-neutral-strong);
 		padding:
 			var(--wpds-dimension-padding-xs)
@@ -16,5 +17,16 @@
 		line-height: 1.4; /* TODO: use DS token for line height */
 		color: var(--wpds-color-fg-content-neutral);
 		box-shadow: var(--wpds-elevation-sm);
+
+		/*
+		 * Forced-colors mode strips `box-shadow` and replaces the
+		 * `background-color` with `Canvas`, so the tooltip would merge
+		 * into the page. A 1px `CanvasText` border restores the edge,
+		 * and `box-sizing: border-box` keeps the non-FC layout exactly
+		 * as before (the 1px is absorbed).
+		 */
+		@media (forced-colors: active) {
+			border: 1px solid CanvasText;
+		}
 	}
 }

--- a/packages/ui/src/tooltip/style.module.css
+++ b/packages/ui/src/tooltip/style.module.css
@@ -6,7 +6,6 @@
 	}
 
 	.popup {
-		box-sizing: border-box;
 		background-color: var(--wpds-color-bg-surface-neutral-strong);
 		padding:
 			var(--wpds-dimension-padding-xs)
@@ -21,9 +20,10 @@
 		/*
 		 * Forced-colors mode strips `box-shadow` and replaces the
 		 * `background-color` with `Canvas`, so the tooltip would merge
-		 * into the page. A 1px `CanvasText` border restores the edge,
-		 * and `box-sizing: border-box` keeps the non-FC layout exactly
-		 * as before (the 1px is absorbed).
+		 * into the page. A 1px `CanvasText` border restores the edge.
+		 * The popup inherits `box-sizing: border-box` from the
+		 * positioner (via the shared `.box-sizing` reset utility), so
+		 * the 1px is absorbed and non-FC layout is unchanged.
 		 */
 		@media (forced-colors: active) {
 			border: 1px solid CanvasText;

--- a/packages/ui/src/utils/css/item-popup.module.css
+++ b/packages/ui/src/utils/css/item-popup.module.css
@@ -13,7 +13,7 @@
 		min-width: var(--anchor-width);
 		max-width: var(--available-width);
 		border-radius: var(--wpds-border-radius-md);
-		border: 1px solid var(--wpds-color-stroke-surface-neutral);
+		border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
 		box-shadow: var(--wpds-elevation-md);
 		background-color: var(--wpds-color-bg-surface-neutral-strong);
 		font-family: var(--wpds-typography-font-family-body);
@@ -45,7 +45,7 @@
 		padding-block: var(--wp-ui-popup-padding);
 
 		.list-scrollable-container:not(:empty) + & {
-			border-block-start: 1px solid var(--wpds-color-stroke-surface-neutral);
+			border-block-start: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
 		}
 	}
 


### PR DESCRIPTION
## What?

Unify the hairline border story across overlay popups (`Dialog`, `AlertDialog`, `Drawer`, `Popover`, `Select`, `Tooltip`):

- Popups **without a backdrop** show a token-colored 1px border in regular mode.
- Popups **with a backdrop** hide the border in regular mode (the backdrop already provides visual containment).
- **All** popups show a `CanvasText` border in forced-colors mode.

## Why?

The popup boundary used to depend on a mix of `box-shadow` and per-component `border` declarations, with diverging tokens and no consistent forced-colors story. In particular, modal `Dialog`/`Drawer` and `AlertDialog` had no border at all in regular mode but disappeared into the page in forced-colors mode (where `box-shadow` is stripped and the popup background becomes `Canvas`).

Tying the regular-mode border to "is there a backdrop alongside this popup?" matches the visual intent — when there's a backdrop, the popup is already isolated; when there isn't, the popup needs its own edge — and yields the same forced-colors behavior across every overlay.

## How?

| Component | regular (no backdrop) | regular (backdrop) | forced-colors (any) |
|---|---|---|---|
| `Tooltip` | n/a | n/a | `1px solid CanvasText` *(unchanged)* |
| `Popover` | `border-width-xs` solid `stroke-surface-neutral` | `transparent` border | `CanvasText` border |
| `Select` popup | `border-width-xs` solid `stroke-surface-neutral` | n/a | `CanvasText` border (UA substitution) |
| `Dialog` (non-modal) | `border-width-xs` solid `stroke-surface-neutral` | — | `CanvasText` border |
| `Dialog` (modal, default) | — | `transparent` border | `CanvasText` border |
| `Drawer` (non-modal) | `border-width-xs` solid `stroke-surface-neutral` | — | `CanvasText` border |
| `Drawer` (modal, default) | — | `transparent` border | `CanvasText` border |
| `AlertDialog` (always modal) | — | `transparent` border | `CanvasText` border |

`AlertDialog` reuses `Dialog`'s popup classes, so it inherits the change.

The "transparent when a backdrop is rendered" rule is a CSS-only sibling selector inside each component's CSS module:

```css
.popup {
	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
}

.backdrop ~ * .popup {
	border-color: transparent;
}

@media (forced-colors: active) {
	.popup,
	.backdrop ~ * .popup {
		border-color: CanvasText;
	}
}
```

No JSX changes needed — the rule keys off the presence of the `.backdrop` element that components already conditionally render based on their own `modal` / `backdrop` props.

<details>
<summary>Implementation notes</summary>

- `transparent` (not `none`) is used for the modal-mode border so popup geometry stays identical regardless of mode — `box-sizing: border-box` absorbs the 1px into the existing box, and `transparent` reduces the forced-colors override to a single `border-color` declaration.
- The forced-colors override sets `CanvasText` explicitly for both the base `.popup` and `.backdrop ~ * .popup` selectors. The second selector is needed because `.backdrop ~ * .popup` is more specific (0,2,0) than `.popup` (0,1,0) — without it, the regular-mode `transparent` rule would still win in forced-colors mode for modal popups.
- Sibling-and-descendant selector `.backdrop ~ * .popup` matches all four affected DOM structures (`Dialog`, `Drawer`, `Popover`, `AlertDialog`), where the popup always sits inside a wrapper element rendered as a sibling-after of the backdrop (`ThemeProvider` for `Dialog`/`AlertDialog`, `Viewport` for `Drawer`, `Positioner` for `Popover`).
- `Popover.arrow-stroke` was updated to `--wpds-color-stroke-surface-neutral` so the arrow's edge stays flush with the new popup border color (was `-neutral-weak`).
- `Drawer` gets the border on all four sides — including the side flush with the viewport. Per-direction `border-*-radius` matching would be more precise but adds noticeable CSS for a flush edge that's effectively invisible against the viewport.
- `Select` popup's internal list-footer divider was bumped from raw `1px` to `--wpds-border-width-xs` for parity with the popup border above it.
- Elevation tiers (`sm` / `md` / `lg`) match the WPDS guidance in `packages/theme/docs/tokens.md` (tooltips → `sm`, menus/popovers → `md`, modals → `lg`) and are unchanged.

</details>

## Testing Instructions

1. `npm install`
2. `cd packages/ui && npm run storybook`
3. **Regular mode**: open the default story for `Tooltip`, `Popover`, `Dialog`, `Drawer`, `AlertDialog`, and the form `Select`.
   - `Tooltip` should look unchanged from `trunk` (no border).
   - `Select` and `Popover` (default, no backdrop) should show a 1px hairline border.
   - `Dialog`, `Drawer`, `AlertDialog` (modal by default) should have a backdrop and **no** visible border.
4. **Non-modal `Dialog`/`Drawer`**: open the non-modal stories. They should show a 1px hairline border and **no** backdrop.
5. **`Popover` with backdrop**: open the story that sets `backdrop={ true }`. The popup should show no border in regular mode.
6. **Arrow alignment**: open `Popover` with an arrow. The arrow stroke should sit flush with the popup border (no color seam).
7. Enable forced-colors emulation:
   - Chrome / Edge: DevTools → Rendering → "Emulate CSS media feature `forced-colors: active`"
   - Firefox: DevTools → Inspector → Rules → `forced-colors`
8. Re-open every story. Every popup should show a visible system-color border around its edge.
9. Disable the emulation. Layouts and spacing should match step 3 — no shifted content.

## Follow-ups

- Consider extracting a shared "overlay surface" CSS utility under `utils/css/` (alongside `dropdown-motion.module.css`) so future overlays pick up `background-color`, hairline border, and the backdrop/forced-colors story by composition. Out of scope here.

## Use of AI Tools

Cursor + Claude Opus 4.7.

Made with [Cursor](https://cursor.com)
