### PR TITLE
ui: Uniform title and description styles across overlays

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -29,6 +29,7 @@
 -   `Dialog`: `Dialog.Header` and `Dialog.Footer` now default to `<header>` and `<footer>` elements for richer landmark semantics. Their `ref` type widens from `HTMLDivElement` to `HTMLElement`; pass `render` to opt out of the default tag ([#76690](https://github.com/WordPress/gutenberg/pull/76690)).
 -   `Dialog`, `Popover`: Upgrade dev-only title validation from mount-only to cleanup-based re-validation, catching conditionally rendered titles ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
 -   `Link`: Honor `openInNewTab` consistently instead of treating hash links as a special case ([#77422](https://github.com/WordPress/gutenberg/pull/77422)).
+-   `Dialog`, `Drawer`, `Popover`: Align title and description colors across all three overlay primitives. Title color is now authored explicitly (resilient to global CSS defenses), and description color now inherits from the popup foreground token instead of overriding to the weak variant ([#77692](https://github.com/WordPress/gutenberg/pull/77692)).
 
 ### Internal
 

--- a/packages/ui/src/dialog/description.tsx
+++ b/packages/ui/src/dialog/description.tsx
@@ -1,6 +1,7 @@
 import { Dialog as _Dialog } from '@base-ui/react/dialog';
 import { forwardRef } from '@wordpress/element';
 import { Text } from '../text';
+import styles from './style.module.css';
 import type { DescriptionProps } from './types';
 
 /**
@@ -15,6 +16,7 @@ const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
 				ref={ ref }
 				variant="body-md"
 				render={ <_Dialog.Description { ...props } /> }
+				className={ styles.description }
 			>
 				{ children }
 			</Text>

--- a/packages/ui/src/dialog/description.tsx
+++ b/packages/ui/src/dialog/description.tsx
@@ -1,7 +1,6 @@
 import { Dialog as _Dialog } from '@base-ui/react/dialog';
 import { forwardRef } from '@wordpress/element';
 import { Text } from '../text';
-import styles from './style.module.css';
 import type { DescriptionProps } from './types';
 
 /**
@@ -16,7 +15,6 @@ const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
 				ref={ ref }
 				variant="body-md"
 				render={ <_Dialog.Description { ...props } /> }
-				className={ styles.description }
 			>
 				{ children }
 			</Text>

--- a/packages/ui/src/dialog/style.module.css
+++ b/packages/ui/src/dialog/style.module.css
@@ -100,8 +100,10 @@
 	}
 
 	.title {
-		margin-inline-end: auto;
+		color: var(--wpds-color-fg-content-neutral);
+		--_gcd-heading-color: var(--wpds-color-fg-content-neutral);
 
+		margin-inline-end: auto;
 		/* Workaround: the GCD shorthand `margin` overrides the longhand above.
 		 * Keep both so the layout survives GCD removal. */
 		--_gcd-heading-margin: 0 auto 0 0;

--- a/packages/ui/src/dialog/style.module.css
+++ b/packages/ui/src/dialog/style.module.css
@@ -115,7 +115,6 @@
 
 	.description {
 		margin-bottom: var(--wpds-dimension-gap-lg);
-		color: var(--wpds-color-fg-content-neutral-weak);
 	}
 
 	.footer {

--- a/packages/ui/src/drawer/description.tsx
+++ b/packages/ui/src/drawer/description.tsx
@@ -1,7 +1,6 @@
 import { Drawer as _Drawer } from '@base-ui/react/drawer';
 import { forwardRef } from '@wordpress/element';
 import { Text } from '../text';
-import styles from './style.module.css';
 import type { DescriptionProps } from './types';
 
 /**
@@ -16,7 +15,6 @@ const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
 				ref={ ref }
 				variant="body-md"
 				render={ <_Drawer.Description { ...props } /> }
-				className={ styles.description }
 			>
 				{ children }
 			</Text>

--- a/packages/ui/src/drawer/style.module.css
+++ b/packages/ui/src/drawer/style.module.css
@@ -249,8 +249,10 @@
 	}
 
 	.title {
-		margin-inline-end: auto;
+		color: var(--wpds-color-fg-content-neutral);
+		--_gcd-heading-color: var(--wpds-color-fg-content-neutral);
 
+		margin-inline-end: auto;
 		/* Workaround: the GCD shorthand `margin` overrides the longhand above.
 		 * Keep both so the layout survives GCD removal. */
 		--_gcd-heading-margin: 0 auto 0 0;
@@ -258,10 +260,6 @@
 		&:dir(rtl) {
 			--_gcd-heading-margin: 0 0 0 auto;
 		}
-	}
-
-	.description {
-		color: var(--wpds-color-fg-content-neutral-weak);
 	}
 
 	.footer {

--- a/packages/ui/src/popover/description.tsx
+++ b/packages/ui/src/popover/description.tsx
@@ -1,7 +1,6 @@
 import { Popover as _Popover } from '@base-ui/react/popover';
 import { forwardRef } from '@wordpress/element';
 import { Text } from '../text';
-import styles from './style.module.css';
 import type { DescriptionProps } from './types';
 
 /**
@@ -16,7 +15,6 @@ const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
 				ref={ ref }
 				variant="body-md"
 				render={ <_Popover.Description { ...props } /> }
-				className={ styles.description }
 			>
 				{ children }
 			</Text>

--- a/packages/ui/src/popover/style.module.css
+++ b/packages/ui/src/popover/style.module.css
@@ -50,8 +50,9 @@
 		fill: var(--wpds-color-stroke-surface-neutral-weak);
 	}
 
-	.description {
-		color: var(--wpds-color-fg-content-neutral-weak);
+	.title {
+		color: var(--wpds-color-fg-content-neutral);
+		--_gcd-heading-color: var(--wpds-color-fg-content-neutral);
 	}
 
 	.backdrop {

--- a/packages/ui/src/popover/title.tsx
+++ b/packages/ui/src/popover/title.tsx
@@ -3,6 +3,7 @@ import { useMergeRefs } from '@wordpress/compose';
 import { forwardRef, useEffect, useRef } from '@wordpress/element';
 import { Text } from '../text';
 import { usePopoverValidationContext } from './context';
+import styles from './style.module.css';
 import type { TitleProps } from './types';
 
 /**
@@ -39,6 +40,7 @@ const Title = forwardRef< HTMLHeadingElement, TitleProps >(
 				ref={ mergedRef }
 				variant="heading-xl"
 				render={ <_Popover.Title { ...props } /> }
+				className={ styles.title }
 			>
 				{ children }
 			</Text>


### PR DESCRIPTION
Extracted from https://github.com/WordPress/gutenberg/pull/77559


## What?

Align `.Title` and `.Description` styles across `Dialog`, `Drawer`, and `Popover`.

- Each overlay's `.title` now sets `color` explicitly (plus the matching `--_gcd-heading-color` workaround).
- Each overlay's `.description` no longer hard-codes a color — it now inherits from `.popup`.
- `Popover.Title` adopts the shared `.title` class to match the other two overlays.
- `Popover.Description` drops the now-orphan `styles.description` className; `Dialog.Description` keeps its className, which now only carries the `margin-bottom` layout rule.

## Why?

Each overlay was setting (or not setting) heading + description colors independently, with subtle drift. This makes the three overlays describe their title/description colors the same way, so future token changes propagate uniformly.

**Title.** `.popup` already sets `color: var(--wpds-color-fg-content-neutral)`, but `global-css-defense.module.css` paints headings via `:is(h1…h6).heading { color: var(--_gcd-heading-color, var(--wpds-color-fg-content-neutral)); }`, which defeats inheritance. Authoring `color` (and `--_gcd-heading-color`) directly on `.title` keeps the title color consistent across overlays and resilient to GCD changes/removal.

**Description.** Each overlay was overriding the description color to `--wpds-color-fg-content-neutral-weak`. Removing that override lets the description inherit `--wpds-color-fg-content-neutral` from `.popup`, matching the title and aligning all three overlays on a single source of truth.

## How?

- `dialog/style.module.css` + `drawer/style.module.css`: add `color` + `--_gcd-heading-color` on `.title`; drop the description color override (Dialog `.description` keeps its `margin-bottom`).
- `drawer/description.tsx` + `popover/description.tsx`: drop the now-redundant `className={ styles.description }` and the `styles` import (the rule no longer exists for them).
- `popover/style.module.css`: add `.title { color: …; --_gcd-heading-color: …; }` and remove the `.description` color override.
- `popover/title.tsx`: apply `styles.title` to match the new rule.

No prop / public-API changes.

<details>
<summary>Visual delta</summary>

- Title: no visible change (same token, just authored directly on `.title` instead of inherited).
- Description: changes from `--wpds-color-fg-content-neutral-weak` to `--wpds-color-fg-content-neutral` (slightly stronger). Intentional: aligns description color with the popup's foreground token across overlays.

</details>

## Testing Instructions

1. `npm install`
2. `cd packages/ui && npm run storybook`
3. Open the default story for each of `Dialog`, `Drawer`, and `Popover` — title color matches across overlays.
4. Open any "with description" story — description color matches across overlays (slightly darker than `trunk` by design, see Visual delta above).

## Use of AI Tools

Cursor + Claude Opus 4.7.

Made with [Cursor](https://cursor.com)
