### PR TITLE
[ LinkControl ] Implement enhanced inline page creation flow

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -181,6 +181,7 @@ function LinkControl( {
 	hasTextControl = false,
 	renderControlBottom = null,
 	handleEntities = false,
+	showCreateSuggestionInDropdown,
 } ) {
 	if ( withCreateSuggestion === undefined && createSuggestion ) {
 		withCreateSuggestion = true;
@@ -710,6 +711,9 @@ function LinkControl( {
 									onSubmit={ handleSubmit }
 									helpTextId={ helpTextId }
 								/>
+							}
+							showCreateSuggestionInDropdown={
+								showCreateSuggestionInDropdown
 							}
 						/>
 						{ isEntity && helpTextId && (

--- a/packages/block-editor/src/components/link-control/page-creator.js
+++ b/packages/block-editor/src/components/link-control/page-creator.js
@@ -1,0 +1,169 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useRef, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	TextControl,
+	Notice,
+	CheckboxControl,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { chevronLeftSmall } from '@wordpress/icons';
+
+function generateSlug( text ) {
+	const cleanSlug = text
+		.toLowerCase()
+		.replace( /[^a-z0-9\s-]/g, '' )
+		.replace( /\s+/g, '-' )
+		.replace( /-+/g, '-' )
+		.trim();
+
+	return cleanSlug ? '/' + cleanSlug : '';
+}
+
+/**
+ * Inline page creation form for LinkControl.
+ *
+ * Page creation is delegated to the consumer via onCreateSuggestion, which
+ * already carries the saveEntityRecord call.
+ *
+ * @param {Object}   props
+ * @param {string}   props.initialTitle       Pre-populated from the search input value.
+ * @param {Function} props.onCreateSuggestion Consumer-provided async creator: (title) => suggestion.
+ * @param {Function} props.onPageCreated      Called with the resulting link object on success.
+ * @param {Function} props.onCancel           Called when the user cancels.
+ */
+export function LinkControlPageCreator( {
+	initialTitle = '',
+	onCreateSuggestion,
+	onPageCreated,
+	onCancel,
+} ) {
+	const [ title, setTitle ] = useState( initialTitle );
+	const [ isCreating, setIsCreating ] = useState( false );
+	const [ errorMessage, setErrorMessage ] = useState( null );
+	const [ publishImmediately, setPublishImmediately ] = useState( true );
+	const [ slug, setSlug ] = useState( generateSlug( initialTitle ) );
+	const [ isSlugDirty, setIsSlugDirty ] = useState( false );
+	const backButtonRef = useRef();
+
+	useEffect( () => {
+		backButtonRef.current?.focus();
+	}, [] );
+
+	const handleTitleChange = ( newTitle ) => {
+		setTitle( newTitle );
+		if ( ! isSlugDirty ) {
+			setSlug( generateSlug( newTitle ) );
+		}
+	};
+
+	const handleSlugChange = ( newSlug ) => {
+		setSlug( newSlug );
+		setIsSlugDirty( true );
+	};
+
+	const handleCreate = async () => {
+		if ( ! title?.trim() ) {
+			return;
+		}
+
+		setIsCreating( true );
+		setErrorMessage( null );
+		try {
+			const suggestion = await onCreateSuggestion(
+				title.trim(),
+				publishImmediately,
+				slug.trim()
+			);
+			if ( suggestion?.url ) {
+				onPageCreated( suggestion );
+			}
+		} catch ( _e ) {
+			setErrorMessage(
+				__( 'There was an error creating the page. Please try again.' )
+			);
+			setIsCreating( false );
+		}
+	};
+
+	return (
+		<div className="block-editor-link-control__page-creator">
+			<Button
+				ref={ backButtonRef }
+				className="block-editor-link-control__page-creator__back"
+				icon={ chevronLeftSmall }
+				onClick={ onCancel }
+				size="small"
+			>
+				{ __( 'Back' ) }
+			</Button>
+			<div className="block-editor-link-control__page-creator__inner">
+				{ errorMessage && (
+					<Notice status="error" isDismissible={ false }>
+						{ errorMessage }
+					</Notice>
+				) }
+				<VStack spacing={ 4 }>
+					<TextControl
+						__next40pxDefaultSize
+						label={ __( 'Page title' ) }
+						value={ title }
+						onChange={ handleTitleChange }
+						placeholder={ __( 'Enter page title' ) }
+						onKeyDown={ ( event ) => {
+							if ( event.key === 'Enter' ) {
+								event.preventDefault();
+								handleCreate();
+							}
+						} }
+						disabled={ isCreating }
+					/>
+					<TextControl
+						__next40pxDefaultSize
+						label={ __( 'URL slug' ) }
+						value={ slug }
+						onChange={ handleSlugChange }
+						help={ __(
+							'Auto-generated from the title. Edit to customise.'
+						) }
+						disabled={ isCreating }
+					/>
+					<CheckboxControl
+						label={ __( 'Publish immediately' ) }
+						help={ __(
+							'If unchecked, the page will be created as a draft.'
+						) }
+						checked={ publishImmediately }
+						onChange={ setPublishImmediately }
+						disabled={ isCreating }
+					/>
+					<HStack justify="right" spacing={ 2 }>
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ onCancel }
+							disabled={ isCreating }
+							accessibleWhenDisabled
+						>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							onClick={ handleCreate }
+							isBusy={ isCreating }
+							disabled={ ! title?.trim() || isCreating }
+							accessibleWhenDisabled
+						>
+							{ isCreating ? __( 'Creating…' ) : __( 'Create' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</div>
+		</div>
+	);
+}

--- a/packages/block-editor/src/components/link-control/page-creator.js
+++ b/packages/block-editor/src/components/link-control/page-creator.js
@@ -32,7 +32,7 @@ function generateSlug( text ) {
  *
  * @param {Object}   props
  * @param {string}   props.initialTitle       Pre-populated from the search input value.
- * @param {Function} props.onCreateSuggestion Consumer-provided async creator: (title) => suggestion.
+ * @param {Function} props.onCreateSuggestion Consumer-provided async creator.
  * @param {Function} props.onPageCreated      Called with the resulting link object on success.
  * @param {Function} props.onCancel           Called when the user cancels.
  */

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -3,7 +3,10 @@
  */
 import { forwardRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { plus } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
 import deprecated from '@wordpress/deprecated';
+import { LinkControlPageCreator } from './page-creator';
 
 /**
  * Internal dependencies
@@ -46,13 +49,14 @@ const LinkControlSearchInput = forwardRef(
 			suffix,
 			isEntity = false,
 			customValidity: customValidityProp,
+			showCreateSuggestionInDropdown = false,
 		},
 		ref
 	) => {
 		const genericSearchHandler = useSearchHandler(
 			suggestionsQuery,
 			allowDirectEntry,
-			withCreateSuggestion,
+			withCreateSuggestion && showCreateSuggestionInDropdown,
 			withURLSuggestion
 		);
 
@@ -61,6 +65,7 @@ const LinkControlSearchInput = forwardRef(
 			: noopSearchHandler;
 
 		const [ focusedSuggestion, setFocusedSuggestion ] = useState();
+		const [ isCreatingPage, setIsCreatingPage ] = useState( false );
 
 		/**
 		 * Handles the user moving between different suggestions. Does not handle
@@ -129,6 +134,17 @@ const LinkControlSearchInput = forwardRef(
 				? _placeholder
 				: __( 'Link' );
 
+		if ( withCreateSuggestion && isCreatingPage ) {
+			return (
+				<LinkControlPageCreator
+					initialTitle={ value || '' }
+					onCreateSuggestion={ onCreateSuggestion }
+					onPageCreated={ () => setIsCreatingPage( false ) }
+					onCancel={ () => setIsCreatingPage( false ) }
+				/>
+			);
+		}
+
 		return (
 			<div className="block-editor-link-control__search-input-container">
 				<URLInput
@@ -169,6 +185,18 @@ const LinkControlSearchInput = forwardRef(
 					suffix={ suffix }
 					disabled={ isEntity }
 				/>
+				{ withCreateSuggestion && ! showCreateSuggestionInDropdown && (
+					<Button
+						className="block-editor-link-control__search-create has-text"
+						icon={ plus }
+						onClick={ () => setIsCreatingPage( true ) }
+						__next40pxDefaultSize
+					>
+						{ value
+							? createSuggestionButtonText( value )
+							: __( 'Create page' ) }
+					</Button>
+				) }
 				{ children }
 			</div>
 		);

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -56,6 +56,22 @@ $block-editor-link-control-number-of-actions: 1;
 			}
 		}
 	}
+
+	&__page-creator {
+		max-width: 350px;
+		min-width: auto;
+		width: 90vw;
+		padding-top: $grid-unit-10;
+
+		&__back {
+			margin-left: $grid-unit-10;
+			text-transform: uppercase;
+		}
+
+		&__inner {
+			padding: $grid-unit-20;
+		}
+	}
 }
 
 // Provides positioning context for reset button. Without this then when an
@@ -276,7 +292,7 @@ $block-editor-link-control-number-of-actions: 1;
 }
 
 .block-editor-link-control__loading {
-	margin: $grid-unit-20; // when only loading control is shown it requires it's own spacing.
+	margin: $grid-unit-20;
 	display: flex;
 	align-items: center;
 
@@ -304,6 +320,21 @@ $block-editor-link-control-number-of-actions: 1;
 
 .block-editor-link-control__search-create {
 	align-items: center; // align text with icon.
+	width: 100%;
+	border-top: 1px solid $gray-200;
+	padding: $grid-unit-10 $grid-unit-15;
+	color: $gray-900;
+
+	&:hover,
+	&:focus {
+		background-color: $gray-100;
+	}
+
+	mark {
+		font-weight: 600;
+		color: inherit;
+		background-color: transparent;
+	}
 
 	.block-editor-link-control__preview-title {
 		margin-bottom: 0;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -292,7 +292,7 @@ $block-editor-link-control-number-of-actions: 1;
 }
 
 .block-editor-link-control__loading {
-	margin: $grid-unit-20;
+	margin: $grid-unit-20; // when only loading control is shown it requires it's own spacing.
 	display: flex;
 	align-items: center;
 

--- a/packages/block-editor/src/components/link-control/use-create-page.js
+++ b/packages/block-editor/src/components/link-control/use-create-page.js
@@ -9,7 +9,11 @@ export default function useCreatePage( handleCreatePage ) {
 	const [ isCreatingPage, setIsCreatingPage ] = useState( false );
 	const [ errorMessage, setErrorMessage ] = useState( null );
 
-	const createPage = async function ( suggestionTitle ) {
+	const createPage = async function (
+		suggestionTitle,
+		publishImmediately,
+		Slug
+	) {
 		setIsCreatingPage( true );
 		setErrorMessage( null );
 
@@ -19,7 +23,13 @@ export default function useCreatePage( handleCreatePage ) {
 			cancelableCreateSuggestion.current = makeCancelable(
 				// Using Promise.resolve to allow createSuggestion to return a
 				// non-Promise based value.
-				Promise.resolve( handleCreatePage( suggestionTitle ) )
+				Promise.resolve(
+					handleCreatePage(
+						suggestionTitle,
+						publishImmediately,
+						Slug
+					)
+				)
 			);
 
 			return await cancelableCreateSuggestion.current.promise;

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -204,11 +204,16 @@ function ButtonEdit( props ) {
 		[ context, isSelected, metadata?.bindings?.url ]
 	);
 
-	async function handleCreate( pageTitle ) {
-		const page = await createPageEntity( {
+	async function handleCreate( pageTitle, publishImmediately, Slug ) {
+		const payload = {
 			title: pageTitle,
-			status: 'draft',
-		} );
+			status: publishImmediately ? 'publish' : 'draft',
+		};
+
+		if ( Slug ) {
+			payload.slug = Slug;
+		}
+		const page = await createPageEntity( payload );
 
 		return {
 			id: page.id,

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -251,11 +251,16 @@ function InlineLinkUI( {
 		},
 	} );
 
-	async function handleCreate( pageTitle ) {
-		const page = await createPageEntity( {
+	async function handleCreate( pageTitle, publishImmediately, Slug ) {
+		const payload = {
 			title: pageTitle,
-			status: 'draft',
-		} );
+			status: publishImmediately ? 'publish' : 'draft',
+		};
+
+		if ( Slug ) {
+			payload.slug = Slug;
+		}
+		const page = await createPageEntity( payload );
 
 		return {
 			id: page.id,


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #72626

Adds the enhanced page creation flow (previously exclusive to the Navigation block) to the global `LinkControl` component with additional improvements.

## Why?
The previous inline creation flow was confusing, it instantly created a draft page without confirmation and offered no control over the title or status. This aligns the default `LinkControl` with the superior UX currently found in the Navigation Link block.

## How?

- Added `LinkControlPageCreator` which asks the user for the "holy trinity" of quick page creation: Title, URL Slug (dynamically auto-populated as you type), and Status (Publish/Draft).
- Delegated the actual `saveEntityRecord` database call back up to the block consumers (e.g., `Button/Edit.js`, `inline.js`) via `onCreateSuggestion`.
- Disabled the old inline creation dropdown item when the new dedicated bottom button is active to prevent duplicate UI elements.
- The old legacy controls can be still used by passing `showCreateSuggestionInDropdown` as `true`.

## Testing Instructions
1. Open a post or page in the editor.
2. Add a Button block, or highlight text in a Paragraph and press `Cmd/Ctrl + K`.
3. Type a non-existent page name in the link search box.
4. Click the new `+ Create page` button at the bottom of the popover.
5. Verify the new sub-view that opens and the Title is pre-populated.
6. Verify the URL Slug auto-populates with a leading slash (e.g., `/my-page`) as you type, unless manually edited.
7. Toggle the "Publish immediately" checkbox, click "Create", and verify the link is applied and the page was created in the backend with the correct status and slug.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="352" height="220" alt="Screenshot 2026-04-27 at 7 19 26 PM" src="https://github.com/user-attachments/assets/144bbb0f-a448-4586-b168-029393dd62e5" />|<img width="350" height="256" alt="Screenshot 2026-04-27 at 7 20 54 PM" src="https://github.com/user-attachments/assets/3986aa21-7623-4f38-9c24-7c8fa4ef2fac" />
<img width="351" height="119" alt="Screenshot 2026-04-27 at 7 20 13 PM" src="https://github.com/user-attachments/assets/e92d1eba-b056-48aa-aa0a-1356386335c8" />|<img width="352" height="357" alt="Screenshot 2026-04-27 at 7 21 22 PM" src="https://github.com/user-attachments/assets/63fe581e-b943-425b-b9cd-8a81a30c1423" />|