### PR TITLE
Make Block Inserter search input sticky while scrolling

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -168,6 +168,18 @@ function InserterMenu(
 
 	const showMediaPanel = selectedTab === 'media' && !! selectedMediaCategory;
 
+	const [ isScrolled, setIsScrolled ] = useState( false );
+
+	const handleScroll = useCallback( ( event ) => {
+		const hasScrolled = event.target.scrollTop > 0;
+		setIsScrolled( ( prevIsScrolled ) => {
+			if ( hasScrolled !== prevIsScrolled ) {
+				return hasScrolled;
+			}
+			return prevIsScrolled;
+		} );
+	}, [] );
+
 	const inserterSearch = useMemo( () => {
 		if ( selectedTab === 'media' ) {
 			return null;
@@ -176,7 +188,9 @@ function InserterMenu(
 		return (
 			<>
 				<SearchControl
-					className="block-editor-inserter__search"
+					className={ clsx( 'block-editor-inserter__search', {
+						'is-scrolled': isScrolled,
+					} ) }
 					onChange={ ( value ) => {
 						if ( hoveredItem ) {
 							setHoveredItem( null );
@@ -219,6 +233,7 @@ function InserterMenu(
 		rootClientId,
 		__experimentalInsertionIndex,
 		isAppender,
+		isScrolled,
 	] );
 
 	const blocksTab = useMemo( () => {
@@ -332,7 +347,10 @@ function InserterMenu(
 			} ) }
 			ref={ ref }
 		>
-			<div className="block-editor-inserter__main-area">
+			<div
+				className="block-editor-inserter__main-area"
+				onScrollCapture={ handleScroll }
+			>
 				<TabbedSidebar
 					ref={ tabsRef }
 					onSelect={ handleSetSelectedTab }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -10,6 +10,7 @@ import {
 	forwardRef,
 	useState,
 	useCallback,
+	useEffect,
 	useMemo,
 	useRef,
 	useLayoutEffect,
@@ -169,16 +170,27 @@ function InserterMenu(
 	const showMediaPanel = selectedTab === 'media' && !! selectedMediaCategory;
 
 	const [ isScrolled, setIsScrolled ] = useState( false );
+	const blocksPanelRef = useRef( null );
+	const patternsPanelRef = useRef( null );
+	const mediaPanelRef = useRef( null );
+	useEffect( () => {
+		const handleScroll = ( event ) => {
+			setIsScrolled( event.currentTarget.scrollTop > 0 );
+		};
+		const panels = [
+			blocksPanelRef.current,
+			patternsPanelRef.current,
+			mediaPanelRef.current,
+		].filter( Boolean );
+		panels.forEach( ( panel ) =>
+			panel.addEventListener( 'scroll', handleScroll )
+		);
 
-	const handleScroll = useCallback( ( event ) => {
-		if (
-			! event.target.classList.contains(
-				'block-editor-tabbed-sidebar__tabpanel'
-			)
-		) {
-			return;
-		}
-		setIsScrolled( event.target.scrollTop > 0 );
+		return () => {
+			panels.forEach( ( panel ) =>
+				panel.removeEventListener( 'scroll', handleScroll )
+			);
+		};
 	}, [] );
 
 	const inserterSearch = useMemo( () => {
@@ -348,10 +360,7 @@ function InserterMenu(
 			} ) }
 			ref={ ref }
 		>
-			<div
-				className="block-editor-inserter__main-area"
-				onScrollCapture={ handleScroll }
-			>
+			<div className="block-editor-inserter__main-area">
 				<TabbedSidebar
 					ref={ tabsRef }
 					onSelect={ handleSetSelectedTab }
@@ -362,6 +371,7 @@ function InserterMenu(
 						{
 							name: 'blocks',
 							title: __( 'Blocks' ),
+							panelRef: blocksPanelRef,
 							panel: (
 								<>
 									{ inserterSearch }
@@ -374,6 +384,7 @@ function InserterMenu(
 						{
 							name: 'patterns',
 							title: __( 'Patterns' ),
+							panelRef: patternsPanelRef,
 							panel: (
 								<>
 									{ inserterSearch }
@@ -386,6 +397,7 @@ function InserterMenu(
 						{
 							name: 'media',
 							title: __( 'Media' ),
+							panelRef: mediaPanelRef,
 							panel: (
 								<>
 									{ inserterSearch }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -171,13 +171,14 @@ function InserterMenu(
 	const [ isScrolled, setIsScrolled ] = useState( false );
 
 	const handleScroll = useCallback( ( event ) => {
-		const hasScrolled = event.target.scrollTop > 0;
-		setIsScrolled( ( prevIsScrolled ) => {
-			if ( hasScrolled !== prevIsScrolled ) {
-				return hasScrolled;
-			}
-			return prevIsScrolled;
-		} );
+		if (
+			! event.target.classList.contains(
+				'block-editor-tabbed-sidebar__tabpanel'
+			)
+		) {
+			return;
+		}
+		setIsScrolled( event.target.scrollTop > 0 );
 	}, [] );
 
 	const inserterSearch = useMemo( () => {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -120,6 +120,9 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__search {
 	padding: $grid-unit-20 $grid-unit-20 0 $grid-unit-20;
+	position: sticky;
+	top: 0;
+	z-index: 2;
 }
 
 .block-editor-inserter__no-tab-container {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -123,6 +123,13 @@ $block-inserter-tabs-height: 44px;
 	position: sticky;
 	top: 0;
 	z-index: 2;
+	background-color: $white;
+	border-bottom: 1px solid transparent;
+	transition: border-bottom-color 0 linear;
+	padding-bottom: $grid-unit-20;
+	&.is-scrolled {
+		border-bottom-color: $gray-200;
+	}
 }
 
 .block-editor-inserter__no-tab-container {
@@ -141,7 +148,7 @@ $block-inserter-tabs-height: 44px;
 
 	display: inline-flex;
 	align-items: center;
-	padding: $grid-unit-20 $grid-unit-20 0;
+	padding: 0 $grid-unit-20;
 }
 
 .block-editor-inserter__panel-content {
@@ -227,7 +234,7 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__media-tabs-container,
 .block-editor-inserter__block-patterns-tabs-container {
 	flex-grow: 1;
-	padding: $grid-unit-20;
+	padding: 0 $grid-unit-20 $grid-unit-20 $grid-unit-20;
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -125,7 +125,9 @@ $block-inserter-tabs-height: 44px;
 	z-index: 2;
 	background-color: $white;
 	border-bottom: 1px solid transparent;
-	transition: border-bottom-color 0 linear;
+	@media not ( prefers-reduced-motion ) {
+		transition: border-bottom-color 0 linear;
+	}
 	padding-bottom: $grid-unit-20;
 	&.is-scrolled {
 		border-bottom-color: $gray-200;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -119,16 +119,15 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__search {
-	padding: $grid-unit-20 $grid-unit-20 0 $grid-unit-20;
+	padding: $grid-unit-20;
 	position: sticky;
 	top: 0;
 	z-index: 2;
 	background-color: $white;
 	border-bottom: 1px solid transparent;
 	@media not ( prefers-reduced-motion ) {
-		transition: border-bottom-color 0 linear;
+		transition: border-bottom-color 0.1s linear;
 	}
-	padding-bottom: $grid-unit-20;
 	&.is-scrolled {
 		border-bottom-color: $gray-200;
 	}
@@ -236,7 +235,7 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__media-tabs-container,
 .block-editor-inserter__block-patterns-tabs-container {
 	flex-grow: 1;
-	padding: 0 $grid-unit-20 $grid-unit-20 $grid-unit-20;
+	padding: 0 $grid-unit-20 $grid-unit-20;
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -242,6 +242,10 @@ $block-inserter-tabs-height: 44px;
 	justify-content: space-between;
 }
 
+.block-editor-inserter__media-tabs-container {
+	padding-top: $grid-unit-20;
+}
+
 .block-editor-inserter__category-tablist {
 	margin-bottom: $grid-unit-10;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #71995

Makes the search input inside the block inserter panel sticky so it remains visible while scrolling through blocks.

## Why?
Currently, the search bar scrolls out of view when browsing long lists of blocks. This change prevents users from having to unnecessarily scroll back to the top just to access the search functionality, improving overall workflow and usability.

## How?
Updated the `.block-editor-inserter__search` SCSS to use `position: sticky` and `top: 0`. Added a `z-index` to ensure the scrolled blocks slide cleanly underneath the search input. Intentionally omitted the background color to allow the blocks to remain visible as they slide past the search area, creating a nice visual effect.

## Testing Instructions

1. Open a post or page in the editor.
2. Click the + (Toggle block inserter) button in the top-left toolbar to open the inserter panel.
3. Scroll down through the list of available blocks.
4. Verify that the search input remains fixed at the top of the panel and that blocks scroll cleanly underneath it.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="700" height="600" alt="image" src="https://github.com/user-attachments/assets/1de21bd9-2b3d-40da-8c53-9aae66efd2cd" />|<img width="700" height="600" alt="image" src="https://github.com/user-attachments/assets/fc120d69-f5de-44fd-b4e8-6cf5cc5fa376" />|