### PR TITLE
Classic Block: Copy/paste broken for empty Classic Block

### DIFF
--- a/packages/blocks/src/api/parser/index.ts
+++ b/packages/blocks/src/api/parser/index.ts
@@ -190,10 +190,18 @@ export function parseRawBlock(
 	// It might be a good idea to throw a warning here.
 	// TODO: I'm unsure about the unregisteredFallbackBlock check,
 	// it might ignore some dynamic unregistered third party blocks wrongly.
-	const isFallbackBlock =
-		normalizedBlock.blockName === getFreeformContentHandlerName() ||
+	const isUnregisteredBlock =
 		normalizedBlock.blockName === getUnregisteredTypeHandlerName();
-	if ( ! blockType || ( ! normalizedBlock.innerHTML && isFallbackBlock ) ) {
+
+	const isImplicitFreeformBlock =
+		normalizedBlock.blockName === getFreeformContentHandlerName() &&
+		rawBlock.blockName !== getFreeformContentHandlerName();
+
+	if (
+		! blockType ||
+		( ! normalizedBlock.innerHTML &&
+			( isUnregisteredBlock || isImplicitFreeformBlock ) )
+	) {
 		return;
 	}
 

--- a/packages/blocks/src/api/raw-handling/paste-handler.ts
+++ b/packages/blocks/src/api/raw-handling/paste-handler.ts
@@ -118,10 +118,11 @@ export function pasteHandler( {
 
 		if ( content.indexOf( '<!-- wp:' ) !== -1 ) {
 			const parseResult = parse( content );
-			const isSingleFreeFormBlock =
+			const isSingleNonEmptyFreeFormBlock =
 				parseResult.length === 1 &&
-				parseResult[ 0 ].name === 'core/freeform';
-			if ( ! isSingleFreeFormBlock ) {
+				parseResult[ 0 ].name === 'core/freeform' &&
+				parseResult[ 0 ].attributes?.content;
+			if ( ! isSingleNonEmptyFreeFormBlock ) {
 				return parseResult;
 			}
 		}

--- a/packages/blocks/src/api/serializer.tsx
+++ b/packages/blocks/src/api/serializer.tsx
@@ -415,11 +415,16 @@ export function serializeBlock(
 	const blockName = block.name;
 	const saveContent = getBlockInnerHTML( block );
 
-	if (
-		blockName === getUnregisteredTypeHandlerName() ||
-		( ! isInnerBlocks && blockName === getFreeformContentHandlerName() )
-	) {
+	if ( blockName === getUnregisteredTypeHandlerName() ) {
 		return saveContent;
+	}
+
+	if ( ! isInnerBlocks && blockName === getFreeformContentHandlerName() ) {
+		if ( saveContent ) {
+			return saveContent;
+		}
+
+		return getCommentDelimitedContent( blockName, {}, saveContent );
 	}
 
 	const blockType = getBlockType( blockName );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #75798

<!-- In a few words, what is the PR actually doing? -->
Copy/paste from the block options menu does nothing for an empty Classic Block because it is invisible in the code editor when empty, unlike other block types (Image, Audio, Custom HTML, etc.).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
An empty Classic Block serializes to empty HTML instead of a block comment delimiter. As a result, the clipboard receives no data when the block is copied or cut, so pasting produces no output.

By emitting a block comment when the Classic Block is empty and ensuring it is properly parsed (without being ignored), we allow empty Classic Blocks to be copied/cut and pasted correctly, while preserving the existing HTML parsing behavior when the block contains content.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Emit `<!-- wp:freeform /-->` when the Classic Block’s `saveContent` is empty.
- Only ignore implicit freeform blocks during parsing (`rawBlock.blockName !== getFreeformContentHandlerName()`)
- Use `attributes?.content` in the paste handler to distinguish and empty Classic Blocks from the legacy freeform blocks containing raw HTML

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Insert an empty Classic Block
2. Copy or cut it using the block options menu, then paste
    - An empty Classic Block should be inserted
3. Switch to the code editor and confirm `<!-- wp:freeform /-->` is present
4. Repeat with a non-empty Classic Block
    - Content should copy and paste correctly
5. (Optional) Paste raw HTML directly into the code editor
    - Legacy content handling should continue to work as before


<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/2abc9091-d276-4bf2-aaf0-d1e1e449f5c6


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Code assistance with GitHub Copilot and ChatGPT for rephrasing PR description.