### PR TITLE
Revise README for FocalPointPicker component to use object-position

### DIFF
--- a/packages/components/src/focal-point-picker/README.md
+++ b/packages/components/src/focal-point-picker/README.md
@@ -1,9 +1,9 @@
 # FocalPointPicker
 
-Focal Point Picker is a component which creates a UI for identifying the most important visual point of an image. This component addresses a specific problem: with large background images it is common to see undesirable crops, especially when viewing on smaller viewports such as mobile phones. This component allows the selection of the point with the most important visual information and returns it as a pair of numbers between 0 and 1. This value can be easily converted into the CSS `background-position` attribute, and will ensure that the focal point is never cropped out, regardless of viewport.
+Focal Point Picker is a component which creates a UI for identifying the most important visual point of an image. It addresses two common issues in responsive image rendering. First, large background images are often cropped in undesirable ways, especially on smaller viewports such as mobile devices. Second, the CSS aspect-ratio property can inadvertently crop out the area of highest visual interest. This component allows the selection of the point with the most important visual information and returns it as a pair of numbers between 0 and 1. This value can be easily converted into the CSS `object-position` attribute, and will ensure that the focal point is never cropped out, regardless of viewport.
 
 - Example focal point picker value: `{ x: 0.5, y: 0.1 }`
-- Corresponding CSS: `background-position: 50% 10%;`
+- Corresponding CSS: `object-position: 50% 10%`
 
 ## Usage
 
@@ -14,15 +14,14 @@ import { FocalPointPicker } from '@wordpress/components';
 const Example = () => {
 	const [ focalPoint, setFocalPoint ] = useState( {
 		x: 0.5,
-		y: 0.5,
+		y: 0.1,
 	} );
 
 	const url = '/path/to/image';
 
 	/* Example function to render the CSS styles based on Focal Point Picker value */
 	const style = {
-		backgroundImage: `url(${ url })`,
-		backgroundPosition: `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`,
+		objectPosition: `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`,
 	};
 
 	return (
@@ -34,7 +33,7 @@ const Example = () => {
 				onDrag={ setFocalPoint }
 				onChange={ setFocalPoint }
 			/>
-			<div style={ style } />
+			<img src={ url } style={ style }  />
 		</>
 	);
 };

--- a/packages/components/src/focal-point-picker/README.md
+++ b/packages/components/src/focal-point-picker/README.md
@@ -1,15 +1,15 @@
 # FocalPointPicker
 
-Focal Point Picker is a component which creates a UI for identifying the most important visual point of an image. It addresses two common issues in responsive image rendering. First, large background images are often cropped in undesirable ways, especially on smaller viewports such as mobile devices. Second, the CSS aspect-ratio property can inadvertently crop out the area of highest visual interest. This component allows the selection of the point with the most important visual information and returns it as a pair of numbers between 0 and 1. This value can be easily converted into the CSS `object-position` attribute, and will ensure that the focal point is never cropped out, regardless of viewport.
+Focal Point Picker is a component which creates a UI for identifying the most important visual point of an image. It addresses two common issues in responsive image rendering. First, large background images are often cropped in undesirable ways, especially on smaller viewports such as mobile devices. Second, the CSS aspect-ratio property can inadvertently crop out the area of highest visual interest. This component allows the selection of the point with the most important visual information and returns it as a pair of numbers between 0 and 1. The output value can be applied to either CSS `background-position` (for elements with `background-image`) or `object-position` (for `<img>` / `<video>` elements rendered with `object-fit: cover`).
 
-- Example focal point picker value: `{ x: 0.5, y: 0.1 }`
-- Corresponding CSS: `object-position: 50% 10%`
+-   Example focal point picker value: `{ x: 0.5, y: 0.1 };`
+-   Corresponding CSS: `object-position: 50% 10%;`
 
 ## Usage
 
 ```jsx
-import { useState } from 'react';
 import { FocalPointPicker } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 
 const Example = () => {
 	const [ focalPoint, setFocalPoint ] = useState( {
@@ -21,6 +21,9 @@ const Example = () => {
 
 	/* Example function to render the CSS styles based on Focal Point Picker value */
 	const style = {
+		width: '100%',
+		aspectRatio: '16 / 9',
+		objectFit: 'cover',
 		objectPosition: `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`,
 	};
 
@@ -33,10 +36,9 @@ const Example = () => {
 				onDrag={ setFocalPoint }
 				onChange={ setFocalPoint }
 			/>
-			<img src={ url } style={ style }  />
+			<img src={ url } alt="" style={ style } />
 		</>
 	);
-};
 ```
 
 ## Props

--- a/packages/components/src/focal-point-picker/README.md
+++ b/packages/components/src/focal-point-picker/README.md
@@ -39,6 +39,7 @@ const Example = () => {
 			<img src={ url } alt="" style={ style } />
 		</>
 	);
+};
 ```
 
 ## Props

--- a/packages/components/src/focal-point-picker/README.md
+++ b/packages/components/src/focal-point-picker/README.md
@@ -1,9 +1,11 @@
 # FocalPointPicker
 
-Focal Point Picker is a component which creates a UI for identifying the most important visual point of an image. It addresses two common issues in responsive image rendering. First, large background images are often cropped in undesirable ways, especially on smaller viewports such as mobile devices. Second, the CSS aspect-ratio property can inadvertently crop out the area of highest visual interest. This component allows the selection of the point with the most important visual information and returns it as a pair of numbers between 0 and 1. The output value can be applied to either CSS `background-position` (for elements with `background-image`) or `object-position` (for `<img>` / `<video>` elements rendered with `object-fit: cover`).
+Focal Point Picker is a component which creates a UI for identifying the most important visual point of an image.
 
--   Example focal point picker value: `{ x: 0.5, y: 0.1 };`
--   Corresponding CSS: `object-position: 50% 10%;`
+It addresses two common issues when displaying images in cropped containers. First, large background images can be cropped in undesirable ways, especially on smaller viewports such as mobile devices. Second, the CSS aspect-ratio property can inadvertently crop out the area of highest visual interest. This component allows the selection of the point with the most important visual information and returns it as a pair of numbers between 0 and 1. The output value can be applied to either CSS `background-position` (for elements with `background-image`) or `object-position` (for `<img>` / `<video>` elements rendered with `object-fit: cover`).
+
+-   Example focal point picker value: `{ x: 0.5, y: 0.1 }`;
+-   Corresponding CSS: `object-position: 50% 10%`;
 
 ## Usage
 

--- a/packages/components/src/focal-point-picker/index.tsx
+++ b/packages/components/src/focal-point-picker/index.tsx
@@ -44,14 +44,15 @@ const GRID_OVERLAY_TIMEOUT = 600;
 /**
  * Focal Point Picker is a component which creates a UI for identifying the most important visual point of an image.
  *
- * This component addresses a specific problem: with large background images it is common to see undesirable crops,
- * especially when viewing on smaller viewports such as mobile phones. This component allows the selection of
- * the point with the most important visual information and returns it as a pair of numbers between 0 and 1.
- * This value can be easily converted into the CSS `background-position` attribute, and will ensure that the
- * focal point is never cropped out, regardless of viewport.
+ * It addresses two common issues in responsive image rendering. First, large background images are often cropped in
+ * undesirable ways, especially on smaller viewports such as mobile devices. Second, the CSS aspect-ratio property can
+ * inadvertently crop out the area of highest visual interest. This component allows the selection of the point with the
+ * most important visual information and returns it as a pair of numbers between 0 and 1. The output value can be
+ * applied to either CSS `background-position` (for elements with `background-image`) or `object-position`
+ * (for `<img>` / `<video>` elements rendered with `object-fit: cover`).
  *
- * - Example focal point picker value: `{ x: 0.5, y: 0.1 }`
- * - Corresponding CSS: `background-position: 50% 10%;`
+ * - Example focal point picker value: `{ x: 0.5, y: 0.1 };`
+ * - Corresponding CSS: `object-position: 50% 10%;`
  *
  * ```jsx
  * import { FocalPointPicker } from '@wordpress/components';
@@ -60,30 +61,31 @@ const GRID_OVERLAY_TIMEOUT = 600;
  * const Example = () => {
  * 	const [ focalPoint, setFocalPoint ] = useState( {
  * 		x: 0.5,
- * 		y: 0.5,
+ * 		y: 0.1,
  * 	} );
  *
  * 	const url = '/path/to/image';
  *
  * 	// Example function to render the CSS styles based on Focal Point Picker value
- * 	const style = {
- * 		backgroundImage: `url(${ url })`,
- * 		backgroundPosition: `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`,
- * 	};
+ *	const style = {
+ *		width: '100%',
+ *		aspectRatio: '16 / 9',
+ *		objectFit: 'cover',
+ *		objectPosition: `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`,
+ *	};
  *
- * 	return (
- * 		<>
- * 			<FocalPointPicker
- * 				url={ url }
- * 				value={ focalPoint }
- * 				onDragStart={ setFocalPoint }
- * 				onDrag={ setFocalPoint }
- * 				onChange={ setFocalPoint }
- * 			/>
- * 			<div style={ style } />
- * 		</>
- * 	);
- * };
+ *	return (
+ *		<>
+ *			<FocalPointPicker
+ *				url={ url }
+ *				value={ focalPoint }
+ *				onDragStart={ setFocalPoint }
+ *				onDrag={ setFocalPoint }
+ *				onChange={ setFocalPoint }
+ *			/>
+ *			<img src={ url } alt="" style={ style } />
+ *		</>
+ *	);
  * ```
  */
 export function FocalPointPicker( {

--- a/packages/components/src/focal-point-picker/index.tsx
+++ b/packages/components/src/focal-point-picker/index.tsx
@@ -74,18 +74,19 @@ const GRID_OVERLAY_TIMEOUT = 600;
  *		objectPosition: `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`,
  *	};
  *
- *	return (
- *		<>
- *			<FocalPointPicker
- *				url={ url }
- *				value={ focalPoint }
- *				onDragStart={ setFocalPoint }
- *				onDrag={ setFocalPoint }
- *				onChange={ setFocalPoint }
- *			/>
- *			<img src={ url } alt="" style={ style } />
- *		</>
- *	);
+ * 	return (
+ * 		<>
+ * 			<FocalPointPicker
+ * 				url={ url }
+ * 				value={ focalPoint }
+ * 				onDragStart={ setFocalPoint }
+ * 				onDrag={ setFocalPoint }
+ * 				onChange={ setFocalPoint }
+ * 			/>
+ * 			<img src={ url } alt="" style={ style } />
+ * 		</>
+ * 	);
+ * };
  * ```
  */
 export function FocalPointPicker( {

--- a/packages/components/src/focal-point-picker/index.tsx
+++ b/packages/components/src/focal-point-picker/index.tsx
@@ -44,15 +44,17 @@ const GRID_OVERLAY_TIMEOUT = 600;
 /**
  * Focal Point Picker is a component which creates a UI for identifying the most important visual point of an image.
  *
- * It addresses two common issues in responsive image rendering. First, large background images are often cropped in
- * undesirable ways, especially on smaller viewports such as mobile devices. Second, the CSS aspect-ratio property can
- * inadvertently crop out the area of highest visual interest. This component allows the selection of the point with the
- * most important visual information and returns it as a pair of numbers between 0 and 1. The output value can be
- * applied to either CSS `background-position` (for elements with `background-image`) or `object-position`
- * (for `<img>` / `<video>` elements rendered with `object-fit: cover`).
+ * It addresses two common issues when displaying images in cropped containers. First, large
+ * background images can be cropped in undesirable ways, especially on smaller viewports such as
+ * mobile devices. Second, the CSS aspect-ratio property can inadvertently crop out the area of
+ * highest visual interest. This component allows the selection of the point with the most
+ * important visual information and returns it as a pair of numbers between 0 and 1.
+ * The output value can be applied to either CSS `background-position` (for elements with
+ * `background-image`) or `object-position` (for `<img>` / `<video>` elements rendered with
+ * `object-fit: cover`).
  *
- * - Example focal point picker value: `{ x: 0.5, y: 0.1 };`
- * - Corresponding CSS: `object-position: 50% 10%;`
+ * - Example focal point picker value: `{ x: 0.5, y: 0.1 }`;
+ * - Corresponding CSS: `object-position: 50% 10%`;
  *
  * ```jsx
  * import { FocalPointPicker } from '@wordpress/components';
@@ -67,12 +69,12 @@ const GRID_OVERLAY_TIMEOUT = 600;
  * 	const url = '/path/to/image';
  *
  * 	// Example function to render the CSS styles based on Focal Point Picker value
- *	const style = {
- *		width: '100%',
- *		aspectRatio: '16 / 9',
- *		objectFit: 'cover',
- *		objectPosition: `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`,
- *	};
+ * 	const style = {
+ * 		width: '100%',
+ * 		aspectRatio: '16 / 9',
+ * 		objectFit: 'cover',
+ * 		objectPosition: `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`,
+ * 	};
  *
  * 	return (
  * 		<>


### PR DESCRIPTION
- Update the focal point picker's README to clarify the component's purpose both for background images and aspect ratio cropped images.  
- Update example code to use `object-position`

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The Focal Point Picker's use has expanded beyond background images and the CSS example from this README is no longer in use on core blocks such as the cover block. 