### PR TITLE
e2e: shorten visit-site-editor canvas-loader visible wait

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -67,8 +67,12 @@ export async function visitSiteEditor(
 
 		try {
 			// Wait for the canvas loader to appear first, so that the locator that
-			// waits for the hidden state doesn't resolve prematurely.
-			await canvasLoader.waitFor( { state: 'visible', timeout: 60_000 } );
+			// waits for the hidden state doesn't resolve prematurely. The loader
+			// either renders within a tick or it is skipped entirely (when the
+			// editor finishes resolving inside the artificial-delay window in
+			// `useIsSiteEditorLoading`), so a long visible-state timeout is just
+			// wasted wall clock when the loader never shows up.
+			await canvasLoader.waitFor( { state: 'visible', timeout: 3_000 } );
 			await canvasLoader.waitFor( {
 				state: 'hidden',
 				// Bigger timeout is needed for larger entities, like the Large Post


### PR DESCRIPTION
## Test branch — not for merge

Investigating the perf-tests workflow regression that started at #77443. See https://github.com/WordPress/gutenberg/pull/77443 for context.

## What

`visitSiteEditor` waits up to 60s for `.edit-site-canvas-loader` to become visible, then up to 60s for it to hide. The visible wait is wrapped in `try/catch` so a missed render is non-fatal — but it still burns the full 60s before the catch fires.

Since #77443 the site-editor `firstBlock` perf metric jumped from ~4 200 ms to ~65 300 ms with samples clustered within ~100 ms — the signature of a fixed timeout. The site-editor suite added ~13 min to the workflow as a result; other suites unchanged.

Hypothesis: with the new experiments REST schema in place, the site editor finishes resolving inside the 100 ms artificial-delay in `useIsSiteEditorLoading`, so React never commits a loading render and the loader element is skipped entirely.

This change drops the visible-state timeout to 3 s. The loader either renders within a tick or doesn't render at all — a 60 s wait is wasted wall clock either way. The hidden-state timeout stays at 60 s for the cases where the loader does appear.

## Test plan

- [ ] Compare `firstBlock` q50 in the perf workflow artifacts vs trunk; expect ~4 000 ms instead of ~65 000 ms on the site-editor suite
- [ ] Compare overall workflow duration vs recent trunk runs; expect ~10–13 min reduction
- [ ] Verify other site-editor specs that legitimately wait for the loader still pass