### PR TITLE
Gutenberg Experiments: Ensure the experiment is active before outputting flags

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -9,20 +9,19 @@
  * Sets a global JS variable used to trigger the availability of each Gutenberg Experiment.
  */
 function gutenberg_enable_experiments() {
-	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-color-randomizer', $gutenberg_experiments ) ) {
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-color-randomizer' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableColorRandomizer = true', 'before' );
 	}
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-grid-interactivity', $gutenberg_experiments ) ) {
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-grid-interactivity' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableGridInteractivity = true', 'before' );
 	}
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-no-tinymce' ) ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalDisableTinymce = true', 'before' );
 	}
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-dataviews-media-modal', $gutenberg_experiments ) ) {
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-dataviews-media-modal' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalDataViewsMediaModal = true', 'before' );
 	}
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-content-only-inspector-fields', $gutenberg_experiments ) ) {
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-content-only-inspector-fields' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalContentOnlyInspectorFields = true', 'before' );
 	}
 	if ( gutenberg_is_experiment_enabled( 'active_templates' ) ) {
@@ -61,15 +60,13 @@ function gutenberg_enable_form_input_blocks() {
  * Sets global JS variables used to enable various block experiments.
  */
 function gutenberg_enable_block_experiments() {
-	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
-
 	// Experimental form blocks.
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-form-blocks', $gutenberg_experiments ) ) {
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-form-blocks' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableFormBlocks = true', 'before' );
 	}
 
 	// General experimental blocks that are not in the default block library.
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-block-experiments', $gutenberg_experiments ) ) {
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-block-experiments' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableBlockExperiments = true', 'before' );
 	}
 }


### PR DESCRIPTION
## What?

Follows:

* https://github.com/WordPress/gutenberg/pull/77443

Ensure that Gutenberg experiments are actually active and truthy before outputting their JS global flags.

## Why?

In #77443 where the experiments page was redesigned, switching an experiment to be off now means that the flag is set to `false` explicitly. Many of the experiments only checked to see if the array key exists, and so if the key existed but was set to `false` the experiment would unexpectedly be active 😱 

This change updates all the experiments that were doing that to use the `gutenberg_is_experiment_enabled` utility function that performs a `! empty()` check which means explicit false values will be treated as the experiment not being enabled.

## How?

* Update the enable experiments code to use the `gutenberg_is_experiment_enabled` check instead of an array key exists check

## Testing Instructions

* In `trunk` try toggling the Media Upload Modal on and off and notice that after activating it's impossible to switch off
* With this PR applied, toggling should work as expected
* Double-check each of the experiments updated here to make sure they're all toggling as expected

## Screenshots or screencast <!-- if applicable -->

To show what I mean, toggle this experiment on and off at http://localhost:8888/wp-admin/admin.php?page=experiments-wp-admin:

<img width="701" height="106" alt="image" src="https://github.com/user-attachments/assets/acbc449a-1c08-4f21-87a4-76335062a0e7" />

Then go to the post editor and go to add a featured image, and you should see the core media modal:

<img width="1272" height="715" alt="image" src="https://github.com/user-attachments/assets/7f8c2acf-789d-4c1a-b9c8-2dede013d3c8" />

And not this one, which should only show if the experiment is on:

<img width="1272" height="716" alt="image" src="https://github.com/user-attachments/assets/65d06011-03b2-4795-b2c7-b46901b3fc74" />

## Use of AI Tools

Claude Code