### PR TITLE
Media editor: confirm before discarding unsaved changes

### DIFF
--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -393,87 +393,101 @@ function MediaEditorModalContent( {
 	};
 
 	return (
-		<>
-			<Modal
-				className="media-editor-modal"
-				title={ __( 'Edit media' ) }
-				size="fill"
-				isDismissible={ false }
-				shouldCloseOnEsc={ ! hasChanges }
-				shouldCloseOnClickOutside={ ! hasChanges }
-				onRequestClose={ handleRequestClose }
-				headerActions={
-					<HeaderActions
-						isSaving={ isSaving }
-						hasMedia={ !! media }
-						hasChanges={ hasChanges }
-						onCancel={ handleRequestClose }
-						onSave={ handleSave }
-					/>
+		<Modal
+			className="media-editor-modal"
+			title={ __( 'Edit media' ) }
+			size="fill"
+			isDismissible={ false }
+			shouldCloseOnClickOutside={ ! hasChanges }
+			onKeyDown={ ( event ) => {
+				// When there are pending changes, intercept ESC and
+				// open the confirm dialog ourselves. `preventDefault`
+				// short-circuits Modal's own ESC-to-close handler on
+				// the overlay so the modal doesn't animate out before
+				// the dialog appears.
+				if (
+					hasChanges &&
+					( event.code === 'Escape' || event.key === 'Escape' )
+				) {
+					event.preventDefault();
+					setIsDiscardDialogOpen( true );
 				}
+			} }
+			onRequestClose={ handleRequestClose }
+			headerActions={
+				<HeaderActions
+					isSaving={ isSaving }
+					hasMedia={ !! media }
+					hasChanges={ hasChanges }
+					onCancel={ handleRequestClose }
+					onSave={ handleSave }
+				/>
+			}
+		>
+			<MediaEditorProvider
+				value={ media ?? undefined }
+				onChange={ handleChange }
+				settings={ { fields } }
 			>
-				<MediaEditorProvider
-					value={ media ?? undefined }
-					onChange={ handleChange }
-					settings={ { fields } }
-				>
-					{ ! media ? (
-						<Spinner />
-					) : (
-						<>
-							<Tabs>
-								<MediaEditorModalSidebar tabs={ tabs } />
-							</Tabs>
-							<InterfaceSkeleton
-								className="media-editor-modal__skeleton"
-								content={
-									<div className="media-editor-modal__canvas">
-										{ isImage ? (
-											<MediaEditorCanvas
-												aspectRatio={ resolveAspectRatio(
-													aspectRatioValue,
-													imageAspectRatio
-												) }
-												freeformCrop={ freeformCrop }
-											/>
-										) : (
-											<MediaPreview />
-										) }
-									</div>
-								}
-								footer={
-									isImage ? (
-										<MediaEditorToolbar
-											onReset={ () => {
-												setAspectRatioValue( '0' );
-												setFreeformCrop( true );
-											} }
+				{ ! media ? (
+					<Spinner />
+				) : (
+					<>
+						<Tabs>
+							<MediaEditorModalSidebar tabs={ tabs } />
+						</Tabs>
+						<InterfaceSkeleton
+							className="media-editor-modal__skeleton"
+							content={
+								<div className="media-editor-modal__canvas">
+									{ isImage ? (
+										<MediaEditorCanvas
+											aspectRatio={ resolveAspectRatio(
+												aspectRatioValue,
+												imageAspectRatio
+											) }
+											freeformCrop={ freeformCrop }
 										/>
-									) : undefined
-								}
-								sidebar={
-									<ComplementaryArea.Slot scope="media-editor" />
-								}
-							/>
-						</>
-					) }
-				</MediaEditorProvider>
-			</Modal>
-			<ConfirmDialog
-				isOpen={ isDiscardDialogOpen }
-				confirmButtonText={ __( 'Discard' ) }
-				cancelButtonText={ __( 'Keep editing' ) }
-				onCancel={ () => setIsDiscardDialogOpen( false ) }
-				onConfirm={ () => {
-					setIsDiscardDialogOpen( false );
-					discardAndClose();
-				} }
-			>
-				{ __(
-					'Are you sure you want to discard your unsaved changes?'
+									) : (
+										<MediaPreview />
+									) }
+								</div>
+							}
+							footer={
+								isImage ? (
+									<MediaEditorToolbar
+										onReset={ () => {
+											setAspectRatioValue( '0' );
+											setFreeformCrop( true );
+										} }
+									/>
+								) : undefined
+							}
+							sidebar={
+								<ComplementaryArea.Slot scope="media-editor" />
+							}
+						/>
+					</>
 				) }
-			</ConfirmDialog>
-		</>
+				{ /* Rendered inside the parent Modal so it's tracked as
+					 a nested dismisser. As a top-level sibling it would,
+					 on mount, request the parent Modal close. */ }
+				<ConfirmDialog
+					isOpen={ isDiscardDialogOpen }
+					confirmButtonText={ __( 'Discard' ) }
+					cancelButtonText={ __( 'Keep editing' ) }
+					onCancel={ () => setIsDiscardDialogOpen( false ) }
+					onConfirm={ () => {
+						setIsDiscardDialogOpen( false );
+						discardAndClose();
+					} }
+				>
+					{ __(
+						'Are you sure you want to discard your unsaved changes?'
+					) }
+				</ConfirmDialog>
+			</MediaEditorProvider>
+		</Modal>
 	);
 }
 

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -15,7 +15,7 @@ import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useContext, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { drawerRight } from '@wordpress/icons';
+import { close, drawerRight } from '@wordpress/icons';
 import type { Field } from '@wordpress/dataviews';
 import {
 	ComplementaryArea,
@@ -172,6 +172,14 @@ function HeaderActions( {
 			>
 				{ __( 'Save' ) }
 			</Button>
+			<Button
+				size="compact"
+				icon={ close }
+				label={ __( 'Close' ) }
+				onClick={ onCancel }
+				disabled={ isSaving }
+				accessibleWhenDisabled
+			/>
 		</Flex>
 	);
 }
@@ -390,6 +398,9 @@ function MediaEditorModalContent( {
 				className="media-editor-modal"
 				title={ __( 'Edit media' ) }
 				size="fill"
+				isDismissible={ false }
+				shouldCloseOnEsc={ ! hasChanges }
+				shouldCloseOnClickOutside={ ! hasChanges }
 				onRequestClose={ handleRequestClose }
 				headerActions={
 					<HeaderActions

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -7,6 +7,7 @@ import {
 	Flex,
 	Modal,
 	Spinner,
+	__experimentalConfirmDialog as ConfirmDialog,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
@@ -37,13 +38,10 @@ import MediaEditorCropPanel, {
 } from '../media-editor-crop-panel';
 import MediaForm from '../media-form';
 import { store as mediaEditorStore } from '../../store';
+import type { MediaEditorModalUpdate } from '../../store/actions';
 import { unlock } from '../../lock-unlock';
 import { getMediaTypeFromMimeType } from '../../utils';
-import {
-	CropperProvider,
-	useCropper,
-	type UseCropperStateReturn,
-} from '../../image-editor';
+import { CropperProvider, useCropper } from '../../image-editor';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
 import { buildModifiers } from './build-modifiers';
 
@@ -134,21 +132,19 @@ function MediaEditorModalSidebar( { tabs }: { tabs: ModalTab[] } ) {
 interface HeaderActionsProps {
 	isSaving: boolean;
 	hasMedia: boolean;
-	hasEdits: boolean;
+	hasChanges: boolean;
 	onCancel: () => void;
-	onSave: ( controller: UseCropperStateReturn ) => void;
+	onSave: () => void;
 }
 
 function HeaderActions( {
 	isSaving,
 	hasMedia,
-	hasEdits,
+	hasChanges,
 	onCancel,
 	onSave,
 }: HeaderActionsProps ) {
-	const controller = useCropper();
-	const { isDirty } = controller;
-	const saveDisabled = isSaving || ! hasMedia || ( ! isDirty && ! hasEdits );
+	const saveDisabled = isSaving || ! hasMedia || ! hasChanges;
 	return (
 		<Flex
 			className="media-editor-modal__header-actions"
@@ -169,7 +165,7 @@ function HeaderActions( {
 			<Button
 				size="compact"
 				variant="primary"
-				onClick={ () => onSave( controller ) }
+				onClick={ onSave }
 				isBusy={ isSaving }
 				disabled={ saveDisabled }
 				accessibleWhenDisabled
@@ -180,41 +176,30 @@ function HeaderActions( {
 	);
 }
 
-export function MediaEditorModal( {
-	fields = [],
-	aspectRatioPresets,
-}: MediaEditorModalProps ) {
-	const { isModalOpen, id, onUpdate } = useSelect( ( select ) => {
-		const { isOpen, getId, getOnUpdate } = select( mediaEditorStore );
-		return {
-			isModalOpen: isOpen(),
-			id: getId(),
-			onUpdate: getOnUpdate(),
-		};
-	}, [] );
+interface MediaEditorModalContentProps {
+	fields: Field< Media >[];
+	id: number;
+	media: Media | null;
+	hasEdits: boolean;
+	isModalOpen: boolean;
+	aspectRatioPresets?: AspectRatioPreset[];
+	onUpdate: ( ( updated: MediaEditorModalUpdate ) => void ) | null;
+}
 
-	const { media, hasEdits } = useSelect(
-		( select ) => {
-			if ( ! id ) {
-				return { media: null, hasEdits: false };
-			}
-			const { getEditedEntityRecord, hasEditsForEntityRecord } =
-				select( coreStore );
-			return {
-				media: getEditedEntityRecord(
-					'postType',
-					'attachment',
-					id
-				) as Media,
-				hasEdits: hasEditsForEntityRecord(
-					'postType',
-					'attachment',
-					id
-				),
-			};
-		},
-		[ id ]
-	);
+// Inner component rendered inside `CropperProvider` so it can read
+// `isDirty` from the cropper. The outer `MediaEditorModal` keeps the
+// store reads and provider tree above this.
+function MediaEditorModalContent( {
+	fields,
+	id,
+	media,
+	hasEdits,
+	isModalOpen,
+	aspectRatioPresets,
+	onUpdate,
+}: MediaEditorModalContentProps ) {
+	const cropper = useCropper();
+	const hasChanges = cropper.isDirty || hasEdits;
 
 	const registry = useRegistry();
 	const {
@@ -226,6 +211,7 @@ export function MediaEditorModal( {
 	const { closeMediaEditorModal } = useDispatch( mediaEditorStore );
 
 	const [ isSaving, setIsSaving ] = useState( false );
+	const [ isDiscardDialogOpen, setIsDiscardDialogOpen ] = useState( false );
 
 	const [ aspectRatioValue, setAspectRatioValue ] = useState( '0' );
 	const [ freeformCrop, setFreeformCrop ] = useState( true );
@@ -297,29 +283,33 @@ export function MediaEditorModal( {
 		];
 	}, [ isImage, aspectRatioValue, freeformCrop, aspectRatioPresets ] );
 
-	if ( ! isModalOpen || ! id ) {
-		return null;
-	}
-
 	const handleChange = ( updates: Partial< Media > ) => {
 		editEntityRecord( 'postType', 'attachment', id, updates );
 	};
 
-	const handleCancel = () => {
+	const discardAndClose = () => {
 		clearEntityRecordEdits( 'postType', 'attachment', id );
 		closeMediaEditorModal();
 	};
 
-	const handleSave = async ( controller: UseCropperStateReturn ) => {
+	const handleRequestClose = () => {
+		if ( hasChanges ) {
+			setIsDiscardDialogOpen( true );
+			return;
+		}
+		discardAndClose();
+	};
+
+	const handleSave = async () => {
 		setIsSaving( true );
 		try {
 			let saved: Media | null | undefined;
 
 			const modifiers =
-				controller.isDirty && controller.state.image
-					? buildModifiers( controller.state, {
-							width: controller.state.image.naturalWidth,
-							height: controller.state.image.naturalHeight,
+				cropper.isDirty && cropper.state.image
+					? buildModifiers( cropper.state, {
+							width: cropper.state.image.naturalWidth,
+							height: cropper.state.image.naturalHeight,
 					  } )
 					: [];
 
@@ -394,28 +384,19 @@ export function MediaEditorModal( {
 		}
 	};
 
-	// `CropperProvider` is always mounted — it's just a `useReducer` with
-	// no side effects — so the header actions can read `isDirty` for
-	// images without the JSX forking on media type. React context flows
-	// through `<Modal>`'s portal to the `headerActions` slot.
-	//
-	// The `key` remounts the provider when the edited attachment changes,
-	// discarding the previous cropper state. Today the modal always
-	// closes between edits so this is belt-and-braces, but it guards
-	// against future flows that swap `id` in the store without closing.
 	return (
-		<CropperProvider key={ media?.id ?? 'none' }>
+		<>
 			<Modal
 				className="media-editor-modal"
 				title={ __( 'Edit media' ) }
 				size="fill"
-				onRequestClose={ handleCancel }
+				onRequestClose={ handleRequestClose }
 				headerActions={
 					<HeaderActions
 						isSaving={ isSaving }
 						hasMedia={ !! media }
-						hasEdits={ hasEdits }
-						onCancel={ handleCancel }
+						hasChanges={ hasChanges }
+						onCancel={ handleRequestClose }
 						onSave={ handleSave }
 					/>
 				}
@@ -467,6 +448,82 @@ export function MediaEditorModal( {
 					) }
 				</MediaEditorProvider>
 			</Modal>
+			<ConfirmDialog
+				isOpen={ isDiscardDialogOpen }
+				confirmButtonText={ __( 'Discard' ) }
+				cancelButtonText={ __( 'Keep editing' ) }
+				onCancel={ () => setIsDiscardDialogOpen( false ) }
+				onConfirm={ () => {
+					setIsDiscardDialogOpen( false );
+					discardAndClose();
+				} }
+			>
+				{ __(
+					'Are you sure you want to discard your unsaved changes?'
+				) }
+			</ConfirmDialog>
+		</>
+	);
+}
+
+export function MediaEditorModal( {
+	fields = [],
+	aspectRatioPresets,
+}: MediaEditorModalProps ) {
+	const { isModalOpen, id, onUpdate } = useSelect( ( select ) => {
+		const { isOpen, getId, getOnUpdate } = select( mediaEditorStore );
+		return {
+			isModalOpen: isOpen(),
+			id: getId(),
+			onUpdate: getOnUpdate(),
+		};
+	}, [] );
+
+	const { media, hasEdits } = useSelect(
+		( select ) => {
+			if ( ! id ) {
+				return { media: null, hasEdits: false };
+			}
+			const { getEditedEntityRecord, hasEditsForEntityRecord } =
+				select( coreStore );
+			return {
+				media: getEditedEntityRecord(
+					'postType',
+					'attachment',
+					id
+				) as Media,
+				hasEdits: hasEditsForEntityRecord(
+					'postType',
+					'attachment',
+					id
+				),
+			};
+		},
+		[ id ]
+	);
+
+	if ( ! isModalOpen || ! id ) {
+		return null;
+	}
+
+	// `CropperProvider` is always mounted while the modal is open — it's
+	// just a `useReducer` with no side effects — so the inner component
+	// can read `isDirty` for images without forking on media type. The
+	// `key` remounts the provider when the edited attachment changes,
+	// discarding the previous cropper state. Today the modal always
+	// closes between edits so this is belt-and-braces, but it guards
+	// against future flows that swap `id` in the store without closing.
+	return (
+		<CropperProvider key={ media?.id ?? 'none' }>
+			<MediaEditorModalContent
+				fields={ fields }
+				id={ id }
+				media={ media }
+				hasEdits={ hasEdits }
+				isModalOpen={ isModalOpen }
+				aspectRatioPresets={ aspectRatioPresets }
+				onUpdate={ onUpdate }
+			/>
 		</CropperProvider>
 	);
 }

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -189,7 +189,6 @@ interface MediaEditorModalContentProps {
 	id: number;
 	media: Media | null;
 	hasEdits: boolean;
-	isModalOpen: boolean;
 	aspectRatioPresets?: AspectRatioPreset[];
 	onUpdate: ( ( updated: MediaEditorModalUpdate ) => void ) | null;
 }
@@ -202,7 +201,6 @@ function MediaEditorModalContent( {
 	id,
 	media,
 	hasEdits,
-	isModalOpen,
 	aspectRatioPresets,
 	onUpdate,
 }: MediaEditorModalContentProps ) {
@@ -301,6 +299,11 @@ function MediaEditorModalContent( {
 	};
 
 	const handleRequestClose = () => {
+		// Disallow closing while a save is in flight so the in-progress
+		// request can settle without the modal unmounting under it.
+		if ( isSaving ) {
+			return;
+		}
 		if ( hasChanges ) {
 			setIsDiscardDialogOpen( true );
 			return;
@@ -398,17 +401,23 @@ function MediaEditorModalContent( {
 			title={ __( 'Edit media' ) }
 			size="fill"
 			isDismissible={ false }
-			shouldCloseOnClickOutside={ ! hasChanges }
+			shouldCloseOnClickOutside={ ! hasChanges && ! isSaving }
 			onKeyDown={ ( event ) => {
+				if ( event.code !== 'Escape' && event.key !== 'Escape' ) {
+					return;
+				}
+				// While saving, swallow ESC so the in-progress request
+				// can settle without the modal closing under it.
+				if ( isSaving ) {
+					event.preventDefault();
+					return;
+				}
 				// When there are pending changes, intercept ESC and
 				// open the confirm dialog ourselves. `preventDefault`
 				// short-circuits Modal's own ESC-to-close handler on
 				// the overlay so the modal doesn't animate out before
 				// the dialog appears.
-				if (
-					hasChanges &&
-					( event.code === 'Escape' || event.key === 'Escape' )
-				) {
+				if ( hasChanges ) {
 					event.preventDefault();
 					setIsDiscardDialogOpen( true );
 				}
@@ -545,7 +554,6 @@ export function MediaEditorModal( {
 				id={ id }
 				media={ media }
 				hasEdits={ hasEdits }
-				isModalOpen={ isModalOpen }
 				aspectRatioPresets={ aspectRatioPresets }
 				onUpdate={ onUpdate }
 			/>


### PR DESCRIPTION
## What

Prompts the user to confirm before discarding pending changes when closing the media editor modal.

If either cropper transforms (`isDirty`) or attachment field edits (`hasEdits`) are pending, clicking Cancel, the close button, ESC, or the backdrop now opens a confirmation dialog. If there's nothing to lose, the modal closes immediately as before.

https://github.com/user-attachments/assets/44f19212-0b59-4318-97be-cb287680cf28




## Why

Today the modal silently throws away any in-progress crop/rotate/flip work and quietly rolls back field edits when the user cancels. There's no warning, so an accidental ESC press loses everything.

## How

- Hoist `useCropper().isDirty` from `HeaderActions` up into a new `MediaEditorModalContent` component rendered inside `CropperProvider`. The close handler can now read both dirty signals (`isDirty || hasEdits`) before deciding whether to confirm.
- Single generic copy ("Are you sure you want to discard your unsaved changes?") — does not enumerate change types. Keeps translation surface small and matches the WP post-editor pattern.
- Uses `__experimentalConfirmDialog` from `@wordpress/components`, following the existing pattern in `global-styles-ui` (the newer `@wordpress/ui` `AlertDialog` is not yet on the recommended-components allowlist).

## Test plan

- [ ] Open media editor modal on an image. Don't change anything. Click Cancel / press ESC / click backdrop / click X — modal closes immediately, no dialog.
- [ ] Open modal, edit an attachment field (e.g. alt text). Try to close — confirmation appears. "Keep editing" leaves modal open with edit intact. "Discard" restores original value and closes.
- [ ] Open modal on an image, perform a crop / rotate / flip. Try to close — confirmation appears. Same Keep editing / Discard behavior.
- [ ] Both kinds of edits at once — same flow.
- [ ] Save still works normally; Save button enabled state unchanged.