### PR TITLE
Media editor: avoid double-mount flicker on open

### DIFF
--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -498,7 +498,9 @@ function MediaEditorModalContent( {
 				settings={ { fields } }
 			>
 				{ ! media ? (
-					<Spinner />
+					<div className="media-editor-modal__loading">
+						<Spinner />
+					</div>
 				) : (
 					<>
 						<Tabs>
@@ -616,11 +618,12 @@ export function MediaEditorModal( {
 	// just a `useReducer` with no side effects — so the inner component
 	// can read `isDirty` for images without forking on media type. The
 	// `key` remounts the provider when the edited attachment changes,
-	// discarding the previous cropper state. Today the modal always
-	// closes between edits so this is belt-and-braces, but it guards
-	// against future flows that swap `id` in the store without closing.
+	// discarding the previous cropper state. Keying on `id` (rather than
+	// `media?.id`) avoids a remount when `media` resolves from `null` to
+	// the loaded record on open — that flip would otherwise re-run the
+	// modal's entry animation and cause a visible flicker.
 	return (
-		<CropperProvider key={ media?.id ?? 'none' }>
+		<CropperProvider key={ id }>
 			<MediaEditorModalContent
 				fields={ fields }
 				id={ id }

--- a/packages/media-editor/src/components/media-editor-modal/style.scss
+++ b/packages/media-editor/src/components/media-editor-modal/style.scss
@@ -16,6 +16,18 @@
 	display: flex;
 	flex-direction: column;
 
+	// Center the loading spinner in the modal body while media data is
+	// resolving, before the InterfaceSkeleton mounts. The wrapper sits
+	// inside `.components-modal__children-container`, which isn't a flex
+	// container — `height: 100%` (rather than `flex: 1`) makes it fill
+	// the body so the inner flex can center the spinner.
+	.media-editor-modal__loading {
+		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
 	// InterfaceSkeleton defaults to position: fixed for full-viewport usage.
 	// Reset it so the skeleton flows inside the modal's content area. Stack
 	// children vertically (header/body/footer) since the default row layout


### PR DESCRIPTION
## What

- Avoid double-mount flicker: `<CropperProvider key={ media?.id ?? 'none' }>` remounted when `media` resolved from `null` to the loaded record on open, dragging `<Modal>` with it. The modal's entry animation ran twice — once with the spinner, once with the cropper. Key on `id` from the store instead, which is set atomically with `isModalOpen` and stays stable across the load. Should have listened to @andrewserong over at https://github.com/WordPress/gutenberg/pull/77540#discussion_r3122815174 😄 
- Center the loading spinner in the modal body while media data resolves.




The animation bug is actually very subtle and hard to test without just eyeballing it. 
I used the Animations inspector to slow things down in the video:

<img width="491" height="210" alt="Screenshot 2026-04-28 at 3 10 15 pm" src="https://github.com/user-attachments/assets/7647959e-571d-4824-9dcc-a93dd1a7b713" />


### Before


https://github.com/user-attachments/assets/a09bd4d3-7ed4-4e3d-8dcd-b2ce032af42b


<img width="1333" height="764" alt="Screenshot 2026-04-28 at 3 03 07 pm" src="https://github.com/user-attachments/assets/a57ebe8d-d5dc-44b9-81d2-796a67847975" />



### After



https://github.com/user-attachments/assets/b7a35543-797c-4f84-9111-30e1164b593e


<img width="1345" height="769" alt="Screenshot 2026-04-28 at 3 25 32 pm" src="https://github.com/user-attachments/assets/478911dc-1681-412a-b154-0e8d1ce89dc2" />




## Testing

Enable the experiment:

<img width="683" height="92" alt="Screenshot 2026-04-28 at 1 51 13 pm" src="https://github.com/user-attachments/assets/a550a74f-203d-45c9-bc4b-2e2ae56b9476" />


For the animation:

1. Hard-refresh the post editor.
2. Open the media editor modal on an Image block — single, smooth entry animation.
3. Close and reopen — still smooth.
4. (If reachable) Switch attachments while the modal is open — cropper state resets.


For the loader:

1. Fire up the editor, add an image block.
2. Kill your connection in dev tools
3. Open the edit modal

