### PR TITLE
Media Editor Modal: surface save failures as scoped snackbar notices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60946,6 +60946,7 @@
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/interface": "file:../interface",
+				"@wordpress/notices": "file:../notices",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/ui": "file:../ui",
 				"clsx": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60938,6 +60938,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
+				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
 				"@wordpress/core-data": "file:../core-data",
 				"@wordpress/data": "file:../data",

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -111,12 +111,6 @@ $z-layers: (
 	// Show snackbars above everything (similar to popovers)
 	".components-snackbar-list": 100000,
 
-	// Snackbars portaled inside a Modal need to clear the modal overlay
-	// (".components-modal__screen-overlay" at 100000) and any popovers
-	// that may open inside the modal (".components-popover" at 1000000).
-	// Sits at the same tier as the in-modal action modals below.
-	".components-snackbar-list.media-editor-modal__snackbar": 1000001,
-
 	// Show modal under the wp-admin menus and the popover
 	".components-modal__screen-overlay": 100000,
 
@@ -140,6 +134,7 @@ $z-layers: (
 	".editor-post-template__create-template-modal": 1000001,
 	".edit-site-template-panel__replace-template-modal": 1000001,
 	".editor-sync-connection-error-modal": 1000001,
+	".components-snackbar-list.media-editor-modal__snackbar": 1000001,
 
 	// Note: The ConfirmDialog component's z-index is being set to 1000001 in packages/components/src/confirm-dialog/styles.ts
 	// because it uses emotion and not sass. We need it to render on top its parent popover.

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -111,6 +111,12 @@ $z-layers: (
 	// Show snackbars above everything (similar to popovers)
 	".components-snackbar-list": 100000,
 
+	// Snackbars portaled inside a Modal need to clear the modal overlay
+	// (".components-modal__screen-overlay" at 100000) and any popovers
+	// that may open inside the modal (".components-popover" at 1000000).
+	// Sits at the same tier as the in-modal action modals below.
+	".components-snackbar-list.media-editor-modal__snackbar": 1000001,
+
 	// Show modal under the wp-admin menus and the popover
 	".components-modal__screen-overlay": 100000,
 

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -45,6 +45,7 @@
 	],
 	"dependencies": {
 		"@wordpress/api-fetch": "file:../api-fetch",
+		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -53,6 +53,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/interface": "file:../interface",
+		"@wordpress/notices": "file:../notices",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/ui": "file:../ui",
 		"clsx": "^2.1.1",

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -13,9 +13,16 @@ import {
 import { Stack } from '@wordpress/ui';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useContext, useEffect, useMemo, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import {
+	createPortal,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+} from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { close, drawerRight } from '@wordpress/icons';
+import { SnackbarNotices, store as noticesStore } from '@wordpress/notices';
 import type { Field } from '@wordpress/dataviews';
 import {
 	ComplementaryArea,
@@ -59,6 +66,10 @@ const METADATA_EDIT_KEYS = [
 	'alt_text',
 	'post',
 ] as const;
+
+// Scope save-failure snackbars to this modal so they don't leak into the
+// host editor's notices tray (and vice versa).
+const NOTICES_CONTEXT = 'media-editor';
 
 const { Tabs } = unlock( componentsPrivateApis );
 
@@ -215,6 +226,7 @@ function MediaEditorModalContent( {
 		saveEditedEntityRecord,
 	} = useDispatch( coreStore );
 	const { closeMediaEditorModal } = useDispatch( mediaEditorStore );
+	const { createErrorNotice, removeAllNotices } = useDispatch( noticesStore );
 
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ isDiscardDialogOpen, setIsDiscardDialogOpen ] = useState( false );
@@ -294,6 +306,7 @@ function MediaEditorModalContent( {
 	};
 
 	const discardAndClose = () => {
+		removeAllNotices( 'snackbar', NOTICES_CONTEXT );
 		clearEntityRecordEdits( 'postType', 'attachment', id );
 		closeMediaEditorModal();
 	};
@@ -312,6 +325,9 @@ function MediaEditorModalContent( {
 	};
 
 	const handleSave = async () => {
+		// Clear any prior failure snackbar so a successful retry doesn't
+		// leave a stale "Could not save image" hovering.
+		removeAllNotices( 'snackbar', NOTICES_CONTEXT );
 		setIsSaving( true );
 		try {
 			let saved: Media | null | undefined;
@@ -390,6 +406,20 @@ function MediaEditorModalContent( {
 				onUpdate( { id: next.id, url: next.source_url } );
 			}
 			closeMediaEditorModal();
+		} catch ( error ) {
+			const message =
+				error instanceof Error
+					? error.message
+					: ( error as { message?: string } )?.message ??
+					  __( 'An unknown error occurred.' );
+			createErrorNotice(
+				sprintf(
+					/* translators: %s: Error message. */
+					__( 'Could not save image. %s' ),
+					message
+				),
+				{ type: 'snackbar', context: NOTICES_CONTEXT }
+			);
 		} finally {
 			setIsSaving( false );
 		}
@@ -496,6 +526,13 @@ function MediaEditorModalContent( {
 					) }
 				</ConfirmDialog>
 			</MediaEditorProvider>
+			{ createPortal(
+				<SnackbarNotices
+					className="media-editor-modal__snackbar"
+					context={ NOTICES_CONTEXT }
+				/>,
+				document.body
+			) }
 		</Modal>
 	);
 }

--- a/packages/media-editor/src/components/media-editor-modal/style.scss
+++ b/packages/media-editor/src/components/media-editor-modal/style.scss
@@ -1,6 +1,7 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/z-index" as *;
 
 // `className` on `<Modal>` is applied to `.components-modal__frame`, so the
 // compound selector below bumps specificity over the shipped rule at
@@ -113,14 +114,14 @@
 }
 
 // `<SnackbarNotices>` renders `.components-snackbar-list` with
-// `position: absolute; width: 100%; z-index: 100000`. Portaled to
-// `<body>` it has no positioned ancestor, so it collapses to a 0-size
-// box at the document origin; even when laid out, the modal overlay
-// (also z-index 100000) paints on top of it. `snackbar-container`
-// fixes-positions the list at the viewport bottom; the elevated
-// z-index lifts it above the modal overlay. Mirrors the
-// `media-upload-modal__snackbar` precedent.
+// `position: absolute; width: 100%`. Portaled to `<body>` it has no
+// positioned ancestor, so it collapses to a 0-size box at the document
+// origin and would also be painted under the modal overlay since both
+// share the default snackbar z-index. `snackbar-container` fixes the
+// list to the viewport bottom; the elevated z-index (registered in
+// base-styles) lifts it above the modal overlay and any popovers that
+// may open inside the modal.
 .media-editor-modal__snackbar {
 	@include snackbar-container();
-	z-index: 200000;
+	z-index: z-index(".components-snackbar-list.media-editor-modal__snackbar");
 }

--- a/packages/media-editor/src/components/media-editor-modal/style.scss
+++ b/packages/media-editor/src/components/media-editor-modal/style.scss
@@ -111,3 +111,16 @@
 		}
 	}
 }
+
+// `<SnackbarNotices>` renders `.components-snackbar-list` with
+// `position: absolute; width: 100%; z-index: 100000`. Portaled to
+// `<body>` it has no positioned ancestor, so it collapses to a 0-size
+// box at the document origin; even when laid out, the modal overlay
+// (also z-index 100000) paints on top of it. `snackbar-container`
+// fixes-positions the list at the viewport bottom; the elevated
+// z-index lifts it above the modal overlay. Mirrors the
+// `media-upload-modal__snackbar` precedent.
+.media-editor-modal__snackbar {
+	@include snackbar-container();
+	z-index: 200000;
+}

--- a/packages/media-editor/tsconfig.json
+++ b/packages/media-editor/tsconfig.json
@@ -14,6 +14,7 @@
 		{ "path": "../element" },
 		{ "path": "../i18n" },
 		{ "path": "../icons" },
+		{ "path": "../notices" },
 		{ "path": "../private-apis" },
 		{ "path": "../ui" }
 	]


### PR DESCRIPTION
## What


Adds a snackbar notice when a save in the Media Editor modal fails. Previously a failed `/wp/v2/media/{id}/edit` POST or `saveEditedEntityRecord` rejection produced an unhandled promise rejection — the Save button just popped out of its busy state with no UI feedback.


https://github.com/user-attachments/assets/518e802a-7170-4856-9466-d5d5d5434189



## Why

Follow-up to #77641. Andrew flagged the missing error handling in [his review](https://github.com/WordPress/gutenberg/pull/77641#pullrequestreview-4185781463) and pointed at the existing `media-utils/src/components/media-upload-modal` snackbar pattern as a precedent.

## How

- New `media-editor` notices context isolates failure snackbars to the modal — they don't leak into the host editor's tray, and host-editor notices don't bleed into the modal.
- `<SnackbarNotices>` is portaled to `document.body` so the list isn't trapped inside the Modal's stacking context.
- `.media-editor-modal__snackbar` uses `@include snackbar-container()` (fixed-position bottom strip) plus `z-index: 200000` to clear the modal overlay. Without this the list collapses to a 0-size box and would be painted under the overlay anyway.
- Stale failure snackbars are cleared at the start of each save attempt and on cancel, so a successful retry doesn't leave a dead message hovering.

Mirrors the established pattern in `packages/media-utils/src/components/media-upload-modal/`.

## Test plan

- [ ] Edit an image, hit Save with the network offline (or temporarily throw inside `handleSave`) → snackbar "Could not save image. <message>" appears at the bottom of the modal, above the overlay.
- [ ] Force a server-side validation error (e.g. set alt_text to something Core's REST args reject) → REST error `message` appears verbatim after "Could not save image.".
- [ ] Save successfully after a prior failure → stale snackbar from the failed attempt is gone before the modal closes.
- [ ] Cancel after a failure → snackbar dismissed, no leak into the host editor's tray after the modal closes.
- [ ] Open the modal from the host editor while the host editor itself has a snackbar showing → host snackbar stays in its own tray; opening/closing the modal does not affect it.