### PR TITLE
Image Cropper: Try a simpler alternative for showing interactive grid lines

### DIFF
--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -44,6 +44,7 @@ export default function MediaEditorCanvas( {
 				controller={ controller }
 				aspectRatio={ aspectRatio }
 				freeformCrop={ freeformCrop }
+				showGrid="interactive"
 			/>
 		</div>
 	);

--- a/packages/media-editor/src/image-editor/react/components/cropper.scss
+++ b/packages/media-editor/src/image-editor/react/components/cropper.scss
@@ -58,6 +58,7 @@ $handle-touch-target-size: 44px;
 		position: absolute;
 		pointer-events: none;
 		overflow: hidden;
+		transition: opacity 0.2s ease;
 	}
 
 	&__grid-line {

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -40,6 +40,9 @@ import './cropper.scss';
 /** Threshold for comparing normalized crop rect values. */
 const CROP_RECT_EPSILON = 1e-6;
 
+/** How long to wait after the last interaction before fading the grid out. */
+const GRID_FADE_DELAY_MS = 200;
+
 // Largest rect of the given pixel aspect ratio that fits inside the visual
 // bounds, centered in [0,1] × [0,1] normalized space. Returns a full-frame
 // rect (1×1) if `aspectRatio` is unset or non-positive.
@@ -81,8 +84,12 @@ export interface CropperProps {
 	controller: UseCropperStateReturn;
 	/** Stencil component for the crop area. Defaults to RectangleStencil. */
 	stencil?: React.ComponentType< StencilProps >;
-	/** Show the rule-of-thirds grid overlay. */
-	showGrid?: boolean;
+	/**
+	 * Show the rule-of-thirds grid overlay.
+	 * - `true`: always shown
+	 * - `'interactive'`: shown while the user is interacting, fades out after
+	 */
+	showGrid?: boolean | 'interactive';
 	/** Show the dimming overlay outside the crop area. */
 	showDimming?: boolean;
 	/** Minimum zoom level. */
@@ -132,7 +139,7 @@ export interface CropperProps {
  * @param root0.src            Image source URL.
  * @param root0.controller     The full state/setter object from `useCropperState`.
  * @param root0.stencil        Custom stencil component.
- * @param root0.showGrid       Show rule-of-thirds grid overlay.
+ * @param root0.showGrid       Show rule-of-thirds grid overlay (`true` | `'interactive'`).
  * @param root0.showDimming    Show dimming overlay outside crop.
  * @param root0.minZoom        Minimum zoom level.
  * @param root0.maxZoom        Maximum zoom level.
@@ -351,6 +358,64 @@ function CropperInner(
 		};
 	}, [] );
 
+	// Interactive grid: visible while the user is interacting, fades out
+	// after GRID_FADE_DELAY_MS of inactivity.
+	const [ gridVisible, setGridVisible ] = useState( false );
+	const gridFadeTimerRef = useRef< ReturnType< typeof setTimeout > >();
+	const gridInteractionReadyRef = useRef( false );
+
+	// Defer readiness until after image load and its dependent effects settle,
+	// so automatic initialisation changes don't trigger the interactive grid.
+	useEffect( () => {
+		gridInteractionReadyRef.current = false;
+		if ( ! state.image ) {
+			return;
+		}
+		const id = setTimeout( () => {
+			gridInteractionReadyRef.current = true;
+		}, 0 );
+		return () => clearTimeout( id );
+	}, [ state.image ] );
+
+	// Show the grid when pan, zoom, rotation, or crop rect changes — the
+	// interactions that affect image placement and composition. Flip changes
+	// are deliberately excluded (discrete button tap, not a drag interaction).
+	// Guard against reset by detecting the isDirty true→false transition.
+	const prevIsDirtyRef = useRef( controller.isDirty );
+	useEffect( () => {
+		const wasJustReset = prevIsDirtyRef.current && ! controller.isDirty;
+		prevIsDirtyRef.current = controller.isDirty;
+
+		if (
+			showGrid !== 'interactive' ||
+			! gridInteractionReadyRef.current ||
+			wasJustReset
+		) {
+			return;
+		}
+		setGridVisible( true );
+		clearTimeout( gridFadeTimerRef.current );
+		gridFadeTimerRef.current = setTimeout( () => {
+			setGridVisible( false );
+		}, GRID_FADE_DELAY_MS );
+		return () => clearTimeout( gridFadeTimerRef.current );
+	}, [
+		state.pan.x,
+		state.pan.y,
+		state.zoom,
+		state.rotation,
+		state.cropRect.x,
+		state.cropRect.y,
+		state.cropRect.width,
+		state.cropRect.height,
+		controller.isDirty,
+		showGrid,
+	] );
+
+	useEffect( () => {
+		return () => clearTimeout( gridFadeTimerRef.current );
+	}, [] );
+
 	/**
 	 * Handle Escape on a resize handle — return focus to the canvas so
 	 * arrow keys pan the image rather than resize.
@@ -475,11 +540,14 @@ function CropperInner(
 				/>
 
 				{ /* Rule-of-thirds grid */ }
-				{ showGrid && (
+				{ ( showGrid === true || showGrid === 'interactive' ) && (
 					<GridOverlay
 						cropRect={ state.cropRect }
 						containerSize={ canvasSize }
 						imageSize={ visualSize }
+						opacity={
+							showGrid === 'interactive' && ! gridVisible ? 0 : 1
+						}
 					/>
 				) }
 

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -41,7 +41,7 @@ import './cropper.scss';
 const CROP_RECT_EPSILON = 1e-6;
 
 /** How long to wait after the last interaction before fading the grid out. */
-const GRID_FADE_DELAY_MS = 200;
+const GRID_FADE_DELAY_MS = 500;
 
 // Largest rect of the given pixel aspect ratio that fits inside the visual
 // bounds, centered in [0,1] × [0,1] normalized space. Returns a full-frame
@@ -378,18 +378,39 @@ function CropperInner(
 	}, [ state.image ] );
 
 	// Show the grid when pan, zoom, rotation, or crop rect changes — the
-	// interactions that affect image placement and composition. Flip changes
-	// are deliberately excluded (discrete button tap, not a drag interaction).
-	// Guard against reset by detecting the isDirty true→false transition.
+	// interactions that affect image placement and composition.
+	//
+	// Flip is excluded even though SET_FLIP mutates pan and cropRect (it
+	// mirrors them): we track the previous flip state and bail out whenever
+	// flip is the reason the effect fired.
+	//
+	// Reset is excluded by detecting the isDirty true→false transition. isDirty
+	// is read through a ref so it doesn't enter the dep array — adding it
+	// directly would re-fire the effect on flip (flip changes isDirty too).
+	const isDirtyRef = useRef( controller.isDirty );
+	isDirtyRef.current = controller.isDirty;
 	const prevIsDirtyRef = useRef( controller.isDirty );
+	const prevFlipRef = useRef( {
+		horizontal: state.flip.horizontal,
+		vertical: state.flip.vertical,
+	} );
 	useEffect( () => {
-		const wasJustReset = prevIsDirtyRef.current && ! controller.isDirty;
-		prevIsDirtyRef.current = controller.isDirty;
+		const wasJustReset = prevIsDirtyRef.current && ! isDirtyRef.current;
+		prevIsDirtyRef.current = isDirtyRef.current;
+
+		const flipChanged =
+			prevFlipRef.current.horizontal !== state.flip.horizontal ||
+			prevFlipRef.current.vertical !== state.flip.vertical;
+		prevFlipRef.current = {
+			horizontal: state.flip.horizontal,
+			vertical: state.flip.vertical,
+		};
 
 		if (
 			showGrid !== 'interactive' ||
 			! gridInteractionReadyRef.current ||
-			wasJustReset
+			wasJustReset ||
+			flipChanged
 		) {
 			return;
 		}
@@ -408,7 +429,8 @@ function CropperInner(
 		state.cropRect.y,
 		state.cropRect.width,
 		state.cropRect.height,
-		controller.isDirty,
+		state.flip.horizontal,
+		state.flip.vertical,
 		showGrid,
 	] );
 

--- a/packages/media-editor/src/image-editor/react/components/overlays/grid-overlay.tsx
+++ b/packages/media-editor/src/image-editor/react/components/overlays/grid-overlay.tsx
@@ -13,6 +13,8 @@ interface GridOverlayProps {
 	containerSize: Size;
 	/** The rendered image dimensions in pixels within the container. */
 	imageSize: Size;
+	/** Opacity of the grid overlay (0–1). Used for interactive fade. */
+	opacity?: number;
 }
 
 /**
@@ -25,12 +27,14 @@ interface GridOverlayProps {
  * @param props.cropRect      The crop rectangle in normalized coordinates.
  * @param props.containerSize The container element dimensions in pixels.
  * @param props.imageSize     The rendered image dimensions in pixels.
+ * @param props.opacity       Opacity of the grid (0–1). Omit for fully opaque.
  * @return The grid overlay element.
  */
 export function GridOverlay( {
 	cropRect,
 	containerSize,
 	imageSize,
+	opacity,
 }: GridOverlayProps ) {
 	if ( containerSize.width === 0 || containerSize.height === 0 ) {
 		return null;
@@ -54,6 +58,7 @@ export function GridOverlay( {
 				top,
 				width,
 				height,
+				opacity,
 			} }
 		>
 			{ /* Horizontal lines at 1/3 and 2/3 */ }

--- a/packages/media-editor/src/image-editor/stories/rectangle-crop.story.tsx
+++ b/packages/media-editor/src/image-editor/stories/rectangle-crop.story.tsx
@@ -173,6 +173,9 @@ const WithControlsComponent = () => {
 
 	const [ aspectRatioValue, setAspectRatioValue ] = useState( '0' );
 	const [ freeformCrop, setFreeformCrop ] = useState( false );
+	const [ gridMode, setGridMode ] = useState< 'off' | 'on' | 'interactive' >(
+		'interactive'
+	);
 	const { src, isCustom, handleFileChange, resetToSample } =
 		useUploadableImage();
 	const fileInputRef = useRef< HTMLInputElement >( null );
@@ -411,6 +414,28 @@ const WithControlsComponent = () => {
 					</FlexItem>
 					<FlexItem isBlock />
 					<FlexItem>
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label="Grid"
+							hideLabelFromVision
+							value={ gridMode }
+							onChange={ ( value ) =>
+								setGridMode(
+									value as 'off' | 'on' | 'interactive'
+								)
+							}
+							options={ [
+								{ label: 'Grid: off', value: 'off' },
+								{ label: 'Grid: always on', value: 'on' },
+								{
+									label: 'Grid: interactive',
+									value: 'interactive',
+								},
+							] }
+						/>
+					</FlexItem>
+					<FlexItem>
 						<Button
 							__next40pxDefaultSize
 							variant="primary"
@@ -451,7 +476,15 @@ const WithControlsComponent = () => {
 				<Cropper
 					src={ src }
 					controller={ controller }
-					showGrid
+					showGrid={
+						(
+							{
+								off: false,
+								on: true,
+								interactive: 'interactive',
+							} as const
+						 )[ gridMode ]
+					}
 					showDimming
 					freeformCrop={ freeformCrop }
 					aspectRatio={ resolveAspectRatio(


### PR DESCRIPTION
## What?

This is a slightly simpler alternative to #77683 for showing an interactive state for grid lines in the experimental image editor

## Why?

I went down a bit of a rabbithole in #77683 trying to ensure that the grid lines always show while the mouse cursor is down. The approach here tries to be simpler about it and just examine internal state changes, with a (hopefully) comfortable in-between timeout of `500ms`. The sweet spot we want is for the grid lines to be shown long enough to be useful, but not overstay their welcome and feel sluggish.

At the same time, we want to make sure that Reset and Flip actions are excluded from showing grid lines.

## How?

* Add an `interactive` option for the `showGrid` prop
* Show the grid when pan, zoom, rotation, or crop rect changes
* Fade it out after `500ms`
* When a flip or reset occurs, the grid lines should not show

## Testing Instructions

Enable the media editor modal experiment and have a play with all the controls — do the grid lines show when you expect them to, and hide when you expect them to?

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/fbda295b-4406-4594-adf1-bb80abd05171

## Use of AI Tools

Claude Code