### PR TITLE
try responsive states for block instances 

### DIFF
--- a/docs/how-to-guides/themes/global-settings-and-styles.md
+++ b/docs/how-to-guides/themes/global-settings-and-styles.md
@@ -1058,6 +1058,83 @@ Pseudo selectors `:hover`, `:focus`, `:focus-visible`, `:visited`, `:active`, `:
 	}
 ```
 
+#### Responsive styles
+
+Block styles can be scoped to two named breakpoints: `mobile` and `tablet`. Any style property that is valid at the block or element level can be nested under one of these keys.
+
+| Key | Media query applied |
+| --- | --- |
+| `mobile` | `@media (width <= 480px)` |
+| `tablet` | `@media (480px < width <= 782px)` |
+
+Responsive overrides can be placed directly on a block node:
+
+```json
+{
+	"version": 3,
+	"styles": {
+		"blocks": {
+			"core/group": {
+				"color": {
+					"text": "black"
+				},
+				"mobile": {
+					"color": {
+						"text": "hotpink"
+					}
+				}
+			}
+		}
+	}
+}
+```
+
+```css
+:root :where(.wp-block-group) { color: black; }
+@media (width <= 480px) { :root :where(.wp-block-group) { color: hotpink; } }
+```
+
+They can also be placed on element nodes within a block:
+
+```json
+{
+	"version": 3,
+	"styles": {
+		"blocks": {
+			"core/group": {
+				"elements": {
+					"link": {
+						"color": { "text": "blue" },
+						":hover": {
+							"color": { "text": "navy" }
+						}
+					}
+				},
+				"mobile": {
+					"elements": {
+						"link": {
+							"color": { "text": "red" },
+							":hover": {
+								"color": { "text": "darkred" }
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+```
+
+```css
+:root :where(.wp-block-group a)        { color: blue; }
+@media (width <= 480px) { :root :where(.wp-block-group a)       { color: red; } }
+:root :where(.wp-block-group a:hover)  { color: navy; }
+@media (width <= 480px) { :root :where(.wp-block-group a:hover) { color: darkred; } }
+```
+
+Responsive overrides are always output after the default styles they override, so the cascade order is preserved without needing to increase specificity.
+
 #### Variations
 
 A block can have a "style variation," as defined in the [block.json specification](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/#styles-optional). Theme authors can define the style attributes for an existing style variation using the `theme.json` file. Styles for unregistered style variations will be ignored.

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -101,7 +101,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 -	**Name:** core/button
 -	**Category:** design
 -	**Parent:** core/buttons
--	**Supports:** anchor, color (background, gradients, text), dimensions (width), interactivity (clientNavigation), shadow, spacing (padding), splitting, typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
+-	**Supports:** anchor, color (background, gradients, text), dimensions (width), interactivity (clientNavigation), shadow, spacing (padding), splitting, states (:active, :focus, :hover), typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
 -	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textColor, title, type, url
 
 ## Buttons

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -31,7 +31,7 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$style = $block['attrs']['style'] ?? array();
+	$style     = $block['attrs']['style'] ?? array();
 	$css_rules = array();
 
 	foreach ( $supported_states as $state ) {

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Block states support for frontend CSS generation.
+ *
+ * Generates scoped CSS for per-instance pseudo-state styles (e.g., :hover, :focus)
+ * declared in block attributes under `style[':hover']`, `style[':focus']`, etc.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders per-instance state styles on the frontend for blocks that declare
+ * `__experimentalStates` support.
+ *
+ * @param string $block_content The block's rendered HTML.
+ * @param array  $block         The block data including blockName and attrs.
+ * @return string Modified block content with injected state styles.
+ */
+function gutenberg_render_block_states_support( $block_content, $block ) {
+	if ( empty( $block['blockName'] ) || empty( $block_content ) ) {
+		return $block_content;
+	}
+
+	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	if ( ! $block_type ) {
+		return $block_content;
+	}
+
+	$supported_states = $block_type->supports['__experimentalStates'] ?? null;
+	if ( empty( $supported_states ) || ! is_array( $supported_states ) ) {
+		return $block_content;
+	}
+
+	$style = $block['attrs']['style'] ?? array();
+	$css_rules = array();
+
+	foreach ( $supported_states as $state ) {
+		if ( empty( $style[ $state ] ) || ! is_array( $style[ $state ] ) ) {
+			continue;
+		}
+
+		$compiled = wp_style_engine_get_styles( $style[ $state ] );
+		if ( ! empty( $compiled['css'] ) ) {
+			$css_rules[] = array(
+				'state' => $state,
+				'css'   => $compiled['css'],
+			);
+		}
+	}
+
+	if ( empty( $css_rules ) ) {
+		return $block_content;
+	}
+
+	$unique_class = 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 );
+	$css          = '';
+
+	foreach ( $css_rules as $rule ) {
+		$css .= ".$unique_class$rule[state] { $rule[css] }\n";
+	}
+
+	// Inject the unique class into the first element of the block content.
+	$processor = new WP_HTML_Tag_Processor( $block_content );
+	if ( $processor->next_tag() ) {
+		$processor->add_class( $unique_class );
+		$block_content = $processor->get_updated_html();
+	}
+
+	return '<style>' . $css . '</style>' . $block_content;
+}
+add_filter( 'render_block', 'gutenberg_render_block_states_support', 10, 2 );

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -52,11 +52,35 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		return $block_content;
 	}
 
+	// Map __experimentalStatesElement values to their CSS element selectors.
+	$element_selectors = array(
+		'button' => '.wp-element-button, .wp-block-button__link',
+		'link'   => 'a:where(:not(.wp-element-button))',
+	);
+
+	$states_element  = $block_type->supports['__experimentalStatesElement'] ?? null;
+	$element_css_sel = isset( $states_element ) ? ( $element_selectors[ $states_element ] ?? null ) : null;
+
 	$unique_class = 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 );
 	$css          = '';
 
 	foreach ( $css_rules as $rule ) {
-		$css .= ".$unique_class$rule[state] { $rule[css] }\n";
+		if ( $element_css_sel ) {
+			// Append pseudo-class to each comma-separated element selector part
+			// and scope them to the unique wrapper class.
+			$parts    = explode( ',', $element_css_sel );
+			$scoped   = array();
+			foreach ( $parts as $part ) {
+				$scoped[] = '.' . $unique_class . ' ' . trim( $part ) . $rule['state'];
+			}
+			$selector = implode( ', ', $scoped );
+		} else {
+			$selector = '.' . $unique_class . $rule['state'];
+		}
+		// Use !important to override utility classes like
+		// .has-accent-3-background-color which are generated with !important.
+		$declarations = str_replace( ';', ' !important;', $rule['css'] );
+		$css         .= "$selector { $declarations }\n";
 	}
 
 	// Inject the unique class into the first element of the block content.

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -60,20 +60,24 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 	 * state styles share the same hash class and therefore the same selector, so
 	 * only one CSS rule is emitted. The store is flushed to the page by
 	 * gutenberg_enqueue_stored_styles() rather than injected inline here.
+	 *
+	 * Preset utility classes (e.g. .has-accent-3-background-color) are generated
+	 * with !important, so state styles targeting the same properties must also use
+	 * !important to win. Properties without preset utility classes don't need it.
 	 */
+	$preset_class_properties = array( 'color', 'background-color', 'border-color', 'background', 'font-size', 'font-family' );
+
 	$style_rules = array();
 	foreach ( $css_rules as $rule ) {
-		// Use !important to override utility classes like
-		// .has-accent-3-background-color which are generated with !important.
-		$declarations_with_important = array_map(
-			static function ( $value ) {
-				return rtrim( $value ) . ' !important';
-			},
-			$rule['declarations']
-		);
-		$style_rules[]               = array(
+		$declarations = array();
+		foreach ( $rule['declarations'] as $property => $value ) {
+			$declarations[ $property ] = in_array( $property, $preset_class_properties, true )
+				? $value . ' !important'
+				: $value;
+		}
+		$style_rules[] = array(
 			'selector'     => ".$unique_class{$rule['state']}",
-			'declarations' => $declarations_with_important,
+			'declarations' => $declarations,
 		);
 	}
 

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -52,43 +52,46 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	// Map __experimentalStatesElement values to their CSS element selectors.
-	$element_selectors = array(
-		'button' => '.wp-element-button, .wp-block-button__link',
-		'link'   => 'a:where(:not(.wp-element-button))',
-	);
-
-	$states_element  = $block_type->supports['__experimentalStatesElement'] ?? null;
-	$element_css_sel = isset( $states_element ) ? ( $element_selectors[ $states_element ] ?? null ) : null;
-
 	$unique_class = 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 );
 	$css          = '';
 
 	foreach ( $css_rules as $rule ) {
-		if ( $element_css_sel ) {
-			// Append pseudo-class to each comma-separated element selector part
-			// and scope them to the unique wrapper class.
-			$parts    = explode( ',', $element_css_sel );
-			$scoped   = array();
-			foreach ( $parts as $part ) {
-				$scoped[] = '.' . $unique_class . ' ' . trim( $part ) . $rule['state'];
-			}
-			$selector = implode( ', ', $scoped );
-		} else {
-			$selector = '.' . $unique_class . $rule['state'];
-		}
 		// Use !important to override utility classes like
 		// .has-accent-3-background-color which are generated with !important.
 		$declarations = str_replace( ';', ' !important;', $rule['css'] );
-		$css         .= "$selector { $declarations }\n";
+		$css         .= ".$unique_class$rule[state] { $declarations }\n";
 	}
 
-	// Inject the unique class into the first element of the block content.
-	$processor = new WP_HTML_Tag_Processor( $block_content );
-	if ( $processor->next_tag() ) {
-		$processor->add_class( $unique_class );
-		$block_content = $processor->get_updated_html();
+	// Add the unique class to the interactive element so that state selectors
+	// like `.$unique_class:hover` match directly without needing a descendant.
+	// If the block declares selectors.root with a descendant (e.g. the button
+	// block's ".wp-block-button .wp-block-button__link"), we extract the last
+	// class and walk to that element. Otherwise we fall back to the wrapper.
+	$root_selector = $block_type->selectors['root'] ?? null;
+	$target_class  = null;
+	if ( $root_selector && preg_match( '/\.([a-zA-Z0-9_-]+)\s*$/', $root_selector, $matches ) ) {
+		$target_class = $matches[1];
 	}
+
+	$processor = new WP_HTML_Tag_Processor( $block_content );
+	$found     = false;
+	if ( $target_class ) {
+		while ( $processor->next_tag() ) {
+			if ( $processor->has_class( $target_class ) ) {
+				$processor->add_class( $unique_class );
+				$found = true;
+				break;
+			}
+		}
+	}
+	if ( ! $found ) {
+		// No target class found or no selectors.root — add to the wrapper.
+		$processor = new WP_HTML_Tag_Processor( $block_content );
+		if ( $processor->next_tag() ) {
+			$processor->add_class( $unique_class );
+		}
+	}
+	$block_content = $processor->get_updated_html();
 
 	return '<style>' . $css . '</style>' . $block_content;
 }

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -40,10 +40,10 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		}
 
 		$compiled = wp_style_engine_get_styles( $style[ $state ] );
-		if ( ! empty( $compiled['css'] ) ) {
+		if ( ! empty( $compiled['declarations'] ) ) {
 			$css_rules[] = array(
-				'state' => $state,
-				'css'   => $compiled['css'],
+				'state'        => $state,
+				'declarations' => $compiled['declarations'],
 			);
 		}
 	}
@@ -53,14 +53,37 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 	}
 
 	$unique_class = 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 );
-	$css          = '';
 
+	/*
+	 * Register each state's CSS rules with the block-supports style engine store.
+	 * The store deduplicates rules by selector — two block instances with identical
+	 * state styles share the same hash class and therefore the same selector, so
+	 * only one CSS rule is emitted. The store is flushed to the page by
+	 * gutenberg_enqueue_stored_styles() rather than injected inline here.
+	 */
+	$style_rules = array();
 	foreach ( $css_rules as $rule ) {
 		// Use !important to override utility classes like
 		// .has-accent-3-background-color which are generated with !important.
-		$declarations = str_replace( ';', ' !important;', $rule['css'] );
-		$css         .= ".$unique_class$rule[state] { $declarations }\n";
+		$declarations_with_important = array_map(
+			static function ( $value ) {
+				return rtrim( $value ) . ' !important';
+			},
+			$rule['declarations']
+		);
+		$style_rules[]               = array(
+			'selector'     => ".$unique_class{$rule['state']}",
+			'declarations' => $declarations_with_important,
+		);
 	}
+
+	gutenberg_style_engine_get_stylesheet_from_css_rules(
+		$style_rules,
+		array(
+			'context'  => 'block-supports',
+			'prettify' => false,
+		)
+	);
 
 	// Add the unique class to the interactive element so that state selectors
 	// like `.$unique_class:hover` match directly without needing a descendant.
@@ -84,8 +107,6 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 	} elseif ( $processor->next_tag() ) {
 		$processor->add_class( $unique_class );
 	}
-	$block_content = $processor->get_updated_html();
-
-	return '<style>' . $css . '</style>' . $block_content;
+	return $processor->get_updated_html();
 }
 add_filter( 'render_block', 'gutenberg_render_block_states_support', 10, 2 );

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -74,22 +74,15 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 	}
 
 	$processor = new WP_HTML_Tag_Processor( $block_content );
-	$found     = false;
 	if ( $target_class ) {
 		while ( $processor->next_tag() ) {
 			if ( $processor->has_class( $target_class ) ) {
 				$processor->add_class( $unique_class );
-				$found = true;
 				break;
 			}
 		}
-	}
-	if ( ! $found ) {
-		// No target class found or no selectors.root — add to the wrapper.
-		$processor = new WP_HTML_Tag_Processor( $block_content );
-		if ( $processor->next_tag() ) {
-			$processor->add_class( $unique_class );
-		}
+	} elseif ( $processor->next_tag() ) {
+		$processor->add_class( $unique_class );
 	}
 	$block_content = $processor->get_updated_html();
 

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -10,7 +10,7 @@
 
 /**
  * Renders per-instance state styles on the frontend for blocks that declare
- * `__experimentalStates` support.
+ * `states` support.
  *
  * @param string $block_content The block's rendered HTML.
  * @param array  $block         The block data including blockName and attrs.
@@ -26,7 +26,7 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$supported_states = $block_type->supports['__experimentalStates'] ?? null;
+	$supported_states = $block_type->supports['states'] ?? null;
 	if ( empty( $supported_states ) || ! is_array( $supported_states ) ) {
 		return $block_content;
 	}

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -2,15 +2,34 @@
 /**
  * Block states support for frontend CSS generation.
  *
- * Generates scoped CSS for per-instance pseudo-state styles (e.g., :hover, :focus)
- * declared in block attributes under `style[':hover']`, `style[':focus']`, etc.
+ * Generates scoped CSS for per-instance state styles:
+ * - Pseudo-states (e.g., :hover, :focus) for blocks that declare `states` support in block.json.
+ * - Responsive states (mobile, tablet) for all blocks.
  *
  * @package WordPress
  */
 
 /**
- * Renders per-instance state styles on the frontend for blocks that declare
- * `states` support.
+ * Responsive breakpoints for per-block responsive states.
+ * Keep in sync with RESPONSIVE_BREAKPOINTS in packages/global-styles-engine/src/core/render.tsx
+ * and WP_Theme_JSON_Gutenberg::RESPONSIVE_BREAKPOINTS.
+ */
+const BLOCK_STATES_RESPONSIVE_BREAKPOINTS = array(
+	'mobile' => '@media (width <= 480px)',
+	'tablet' => '@media (480px < width <= 782px)',
+);
+
+/**
+ * Renders per-instance state styles on the frontend.
+ *
+ * Handles two categories of states:
+ * - Pseudo-states (:hover, :focus, :active): only for blocks that declare `states` support
+ *   in block.json. Output as `.wp-states-{hash}:hover { ... }`.
+ * - Responsive states (mobile, tablet): available for all blocks automatically.
+ *   Output as `@media (...) { .wp-states-{hash} { ... } }`.
+ *
+ * A single unique class is added to the block's interactive element and shared
+ * across both state types so rules from both categories apply to the same element.
  *
  * @param string $block_content The block's rendered HTML.
  * @param array  $block         The block data including blockName and attrs.
@@ -26,63 +45,86 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		return $block_content;
 	}
 
+	$style     = $block['attrs']['style'] ?? array();
+	$all_rules = array();
+
+	// --- Pseudo-states (only for blocks that declare `states` support) ---
 	$supported_states = $block_type->supports['states'] ?? null;
-	if ( empty( $supported_states ) || ! is_array( $supported_states ) ) {
-		return $block_content;
+	if ( ! empty( $supported_states ) && is_array( $supported_states ) ) {
+		/*
+		 * Preset utility classes (e.g. .has-accent-3-background-color) are generated
+		 * with !important, so state styles targeting the same properties must also use
+		 * !important to win specificity.
+		 */
+		$preset_class_properties = array( 'color', 'background-color', 'border-color', 'background', 'font-size', 'font-family' );
+
+		foreach ( $supported_states as $state ) {
+			if ( empty( $style[ $state ] ) || ! is_array( $style[ $state ] ) ) {
+				continue;
+			}
+
+			$compiled = wp_style_engine_get_styles( $style[ $state ] );
+			if ( ! empty( $compiled['declarations'] ) ) {
+				$declarations = array();
+				foreach ( $compiled['declarations'] as $property => $value ) {
+					$declarations[ $property ] = in_array( $property, $preset_class_properties, true )
+						? $value . ' !important'
+						: $value;
+				}
+				$all_rules[] = array(
+					'type'         => 'pseudo',
+					'state'        => $state,
+					'declarations' => $declarations,
+				);
+			}
+		}
 	}
 
-	$style     = $block['attrs']['style'] ?? array();
-	$css_rules = array();
-
-	foreach ( $supported_states as $state ) {
-		if ( empty( $style[ $state ] ) || ! is_array( $style[ $state ] ) ) {
+	// --- Responsive states (available for all blocks) ---
+	foreach ( BLOCK_STATES_RESPONSIVE_BREAKPOINTS as $breakpoint => $media_query ) {
+		if ( empty( $style[ $breakpoint ] ) || ! is_array( $style[ $breakpoint ] ) ) {
 			continue;
 		}
 
-		$compiled = wp_style_engine_get_styles( $style[ $state ] );
+		$compiled = wp_style_engine_get_styles( $style[ $breakpoint ] );
 		if ( ! empty( $compiled['declarations'] ) ) {
-			$css_rules[] = array(
-				'state'        => $state,
+			$all_rules[] = array(
+				'type'         => 'responsive',
+				'media_query'  => $media_query,
 				'declarations' => $compiled['declarations'],
 			);
 		}
 	}
 
-	if ( empty( $css_rules ) ) {
+	if ( empty( $all_rules ) ) {
 		return $block_content;
 	}
 
-	$unique_class = 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 );
-
 	/*
-	 * Register each state's CSS rules with the block-supports style engine store.
-	 * The store deduplicates rules by selector — two block instances with identical
-	 * state styles share the same hash class and therefore the same selector, so
-	 * only one CSS rule is emitted. The store is flushed to the page by
-	 * gutenberg_enqueue_stored_styles() rather than injected inline here.
-	 *
-	 * Preset utility classes (e.g. .has-accent-3-background-color) are generated
-	 * with !important, so state styles targeting the same properties must also use
-	 * !important to win. Properties without preset utility classes don't need it.
+	 * Build a unique class from all state rules so that two block instances with
+	 * identical state styles share the same hash class and therefore the same CSS
+	 * (the style engine store deduplicates by selector).
 	 */
-	$preset_class_properties = array( 'color', 'background-color', 'border-color', 'background', 'font-size', 'font-family' );
+	$unique_class = 'wp-states-' . substr( md5( wp_json_encode( $all_rules ) ), 0, 8 );
 
-	$style_rules = array();
-	foreach ( $css_rules as $rule ) {
-		$declarations = array();
-		foreach ( $rule['declarations'] as $property => $value ) {
-			$declarations[ $property ] = in_array( $property, $preset_class_properties, true )
-				? $value . ' !important'
-				: $value;
+	$style_engine_rules = array();
+	foreach ( $all_rules as $rule ) {
+		if ( 'pseudo' === $rule['type'] ) {
+			$style_engine_rules[] = array(
+				'selector'     => ".$unique_class{$rule['state']}",
+				'declarations' => $rule['declarations'],
+			);
+		} else {
+			$style_engine_rules[] = array(
+				'selector'     => ".$unique_class",
+				'declarations' => $rule['declarations'],
+				'rules_group'  => $rule['media_query'],
+			);
 		}
-		$style_rules[] = array(
-			'selector'     => ".$unique_class{$rule['state']}",
-			'declarations' => $declarations,
-		);
 	}
 
 	gutenberg_style_engine_get_stylesheet_from_css_rules(
-		$style_rules,
+		$style_engine_rules,
 		array(
 			'context'  => 'block-supports',
 			'prettify' => false,
@@ -90,7 +132,7 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 	);
 
 	// Add the unique class to the interactive element so that state selectors
-	// like `.$unique_class:hover` match directly without needing a descendant.
+	// like `.$unique_class:hover` or responsive `.$unique_class` match it directly.
 	// If the block declares selectors.root with a descendant (e.g. the button
 	// block's ".wp-block-button .wp-block-button__link"), we extract the last
 	// class and walk to that element. Otherwise we fall back to the wrapper.

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1998,6 +1998,11 @@ class WP_Theme_JSON_Gutenberg {
 				}
 			}
 		}
+
+		if ( ! empty( $options['media_query'] ) && ! empty( $block_rules ) ) {
+			$block_rules = $options['media_query'] . '{' . $block_rules . '}';
+		}
+
 		return $block_rules;
 	}
 
@@ -3408,6 +3413,19 @@ class WP_Theme_JSON_Gutenberg {
 						$variation_responsive_css .= $breakpoint_media . '{' . $breakpoint_custom_css . '}';
 					}
 
+					// Process blockGap responsive layout styles for this variation.
+					if ( isset( $breakpoint_node['spacing']['blockGap'] ) ) {
+						$variation_layout_metadata             = $style_variation;
+						$variation_layout_metadata['selector'] = $style_variation['selector'] . $block_metadata['css'];
+						$variation_responsive_css             .= $this->get_layout_styles(
+							$variation_layout_metadata,
+							array(
+								'node'        => $breakpoint_node,
+								'media_query' => $breakpoint_media,
+							)
+						);
+					}
+
 					// Process nested element styles for this breakpoint state.
 					if ( isset( $breakpoint_node['elements'] ) && ! empty( $block_elements ) ) {
 						foreach ( $breakpoint_node['elements'] as $element_name => $element_node ) {
@@ -3664,6 +3682,17 @@ class WP_Theme_JSON_Gutenberg {
 				if ( isset( $breakpoint_node['css'] ) ) {
 					$breakpoint_custom_css   = static::process_blocks_custom_css( $breakpoint_node['css'], $css_selector );
 					$responsive_feature_css .= $breakpoint_media . '{' . $breakpoint_custom_css . '}';
+				}
+
+				// Process blockGap responsive layout styles.
+				if ( ! empty( $block_metadata['name'] ) ) {
+					$responsive_feature_css .= $this->get_layout_styles(
+						$block_metadata,
+						array(
+							'node'        => $breakpoint_node,
+							'media_query' => $breakpoint_media,
+						)
+					);
 				}
 			}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -773,37 +773,6 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
-	 * Returns CSS rules for responsive breakpoint states stored in a block node.
-	 * Unlike pseudo-selectors, breakpoint styles are available for all blocks and
-	 * are wrapped in CSS media queries rather than appended to the selector.
-	 *
-	 * @param array  $node          The block's styles node from theme.json.
-	 * @param string $base_selector The base CSS selector for the block.
-	 * @param array  $settings      The theme.json settings.
-	 * @return string CSS rules string with media query wrappers.
-	 */
-	private static function process_responsive_selectors( $node, $base_selector, $settings ) {
-		$responsive_css = '';
-
-		foreach ( static::RESPONSIVE_BREAKPOINTS as $breakpoint_key => $media_query ) {
-			if ( ! isset( $node[ $breakpoint_key ] ) ) {
-				continue;
-			}
-
-			$declarations = static::compute_style_properties( $node[ $breakpoint_key ], $settings, null, null );
-
-			if ( empty( $declarations ) ) {
-				continue;
-			}
-
-			$inner_rule      = static::to_ruleset( ":root :where($base_selector)", $declarations );
-			$responsive_css .= $media_query . '{' . $inner_rule . '}';
-		}
-
-		return $responsive_css;
-	}
-
-	/**
 	 * Returns a class name by an element name.
 	 *
 	 * @since 6.1.0

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -621,6 +621,19 @@ class WP_Theme_JSON_Gutenberg {
 	);
 
 	/**
+	 * Responsive breakpoint state keys and their corresponding CSS media queries.
+	 * These are available for all blocks and wrap their styles in the given media query.
+	 * Keep in sync with RESPONSIVE_BREAKPOINTS in packages/global-styles-engine/src/core/render.tsx.
+	 *
+	 * @since 7.1.0
+	 * @var array
+	 */
+	const RESPONSIVE_BREAKPOINTS = array(
+		'mobile' => '@media (width <= 480px)',
+		'tablet' => '@media (480px < width <= 782px)',
+	);
+
+	/**
 	 * Custom states for blocks that map to CSS class selectors rather than
 	 * CSS pseudo-selectors. Values use the '@' prefix (e.g. '@current') to
 	 * distinguish them from real CSS pseudo-selectors.
@@ -757,6 +770,37 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		return $pseudo_declarations;
+	}
+
+	/**
+	 * Returns CSS rules for responsive breakpoint states stored in a block node.
+	 * Unlike pseudo-selectors, breakpoint styles are available for all blocks and
+	 * are wrapped in CSS media queries rather than appended to the selector.
+	 *
+	 * @param array  $node          The block's styles node from theme.json.
+	 * @param string $base_selector The base CSS selector for the block.
+	 * @param array  $settings      The theme.json settings.
+	 * @return string CSS rules string with media query wrappers.
+	 */
+	private static function process_responsive_selectors( $node, $base_selector, $settings ) {
+		$responsive_css = '';
+
+		foreach ( static::RESPONSIVE_BREAKPOINTS as $breakpoint_key => $media_query ) {
+			if ( ! isset( $node[ $breakpoint_key ] ) ) {
+				continue;
+			}
+
+			$declarations = static::compute_style_properties( $node[ $breakpoint_key ], $settings, null, null );
+
+			if ( empty( $declarations ) ) {
+				continue;
+			}
+
+			$inner_rule      = static::to_ruleset( ":root :where($base_selector)", $declarations );
+			$responsive_css .= $media_query . '{' . $inner_rule . '}';
+		}
+
+		return $responsive_css;
 	}
 
 	/**
@@ -1087,6 +1131,11 @@ class WP_Theme_JSON_Gutenberg {
 			$schema_styles_blocks[ $block ]             = $styles_non_top_level;
 			$schema_styles_blocks[ $block ]['elements'] = $schema_styles_elements;
 
+			// Add responsive breakpoint states for all blocks.
+			foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint_state ) {
+				$schema_styles_blocks[ $block ][ $breakpoint_state ] = $styles_non_top_level;
+			}
+
 			// Add pseudo-selectors for blocks that support them.
 			if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
 				foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] as $pseudo_selector ) {
@@ -1132,6 +1181,11 @@ class WP_Theme_JSON_Gutenberg {
 			if ( ! empty( $style_variation_names ) ) {
 				foreach ( $style_variation_names as $variation_name ) {
 					$variation_schema = $block_style_variation_styles;
+
+					// Add responsive breakpoint states to block style variations.
+					foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint_state ) {
+						$variation_schema[ $breakpoint_state ] = $styles_non_top_level;
+					}
 
 					// Add pseudo-selectors to variations for blocks that support them.
 					if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
@@ -3245,6 +3299,7 @@ class WP_Theme_JSON_Gutenberg {
 		// If there are style variations, generate the declarations for them, including any feature selectors the block may have.
 		$style_variation_declarations    = array();
 		$style_variation_custom_css      = array();
+		$style_variation_responsive_css  = array();
 		$style_variation_layout_metadata = array();
 		if ( ! empty( $block_metadata['variations'] ) ) {
 			foreach ( $block_metadata['variations'] as $style_variation ) {
@@ -3295,6 +3350,12 @@ class WP_Theme_JSON_Gutenberg {
 				// Store custom CSS for the style variation.
 				if ( isset( $style_variation_node['css'] ) ) {
 					$style_variation_custom_css[ $style_variation['selector'] ] = $this->process_blocks_custom_css( $style_variation_node['css'], $style_variation['selector'] );
+				}
+
+				// Store responsive breakpoint CSS for the style variation.
+				$variation_responsive_css = static::process_responsive_selectors( $style_variation_node, $style_variation['selector'], $settings );
+				if ( ! empty( $variation_responsive_css ) ) {
+					$style_variation_responsive_css[ $style_variation['selector'] ] = $variation_responsive_css;
 				}
 
 				// Store variation metadata and node for layout styles generation.
@@ -3474,6 +3535,9 @@ class WP_Theme_JSON_Gutenberg {
 			if ( isset( $style_variation_custom_css[ $style_variation_selector ] ) ) {
 				$block_rules .= $style_variation_custom_css[ $style_variation_selector ];
 			}
+			if ( isset( $style_variation_responsive_css[ $style_variation_selector ] ) ) {
+				$block_rules .= $style_variation_responsive_css[ $style_variation_selector ];
+			}
 		}
 
 		// 7. Generate and append any custom CSS rules.
@@ -3484,6 +3548,11 @@ class WP_Theme_JSON_Gutenberg {
 			}
 			$css_selector = is_string( $css_feature_selector ) ? $css_feature_selector : $selector;
 			$block_rules .= $this->process_blocks_custom_css( $node['css'], $css_selector );
+		}
+
+		// 8. Generate and append responsive breakpoint rules.
+		if ( ! $is_root_selector ) {
+			$block_rules .= static::process_responsive_selectors( $node, $selector, $settings );
 		}
 
 		return $block_rules;
@@ -4006,6 +4075,13 @@ class WP_Theme_JSON_Gutenberg {
 				}
 			}
 
+			// Re-add and process responsive breakpoint styles.
+			foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint ) {
+				if ( isset( $input[ $breakpoint ] ) ) {
+					$output[ $breakpoint ] = static::remove_insecure_styles( $input[ $breakpoint ] );
+				}
+			}
+
 			if ( ! empty( $output ) ) {
 				_wp_array_set( $sanitized, $metadata['path'], $output );
 			}
@@ -4025,6 +4101,13 @@ class WP_Theme_JSON_Gutenberg {
 
 					if ( isset( $variation_input['elements'] ) ) {
 						$variation_output['elements'] = static::remove_insecure_element_styles( $variation_input['elements'] );
+					}
+
+					// Re-add and process responsive breakpoint styles for variations.
+					foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint ) {
+						if ( isset( $variation_input[ $breakpoint ] ) ) {
+							$variation_output[ $breakpoint ] = static::remove_insecure_styles( $variation_input[ $breakpoint ] );
+						}
 					}
 
 					if ( ! empty( $variation_output ) ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3391,6 +3391,12 @@ class WP_Theme_JSON_Gutenberg {
 						$base_ruleset              = static::to_ruleset( ':root :where(' . $style_variation['selector'] . ')', $breakpoint_declarations );
 						$variation_responsive_css .= $breakpoint_media . '{' . $base_ruleset . '}';
 					}
+
+					// Process custom CSS for this breakpoint.
+					if ( isset( $breakpoint_node['css'] ) ) {
+						$breakpoint_custom_css     = static::process_blocks_custom_css( $breakpoint_node['css'], $style_variation['selector'] );
+						$variation_responsive_css .= $breakpoint_media . '{' . $breakpoint_custom_css . '}';
+					}
 				}
 
 				if ( ! empty( $variation_responsive_css ) ) {
@@ -3566,13 +3572,15 @@ class WP_Theme_JSON_Gutenberg {
 			}
 		}
 
+		// Compute selector for block custom CSS.
+		$css_feature_selector = $block_metadata['selectors']['css'] ?? null;
+		if ( is_array( $css_feature_selector ) ) {
+			$css_feature_selector = $css_feature_selector['root'] ?? null;
+		}
+		$css_selector = is_string( $css_feature_selector ) ? $css_feature_selector : $selector;
+
 		// 7. Generate and append any custom CSS rules.
 		if ( isset( $node['css'] ) && ! $is_root_selector ) {
-			$css_feature_selector = $block_metadata['selectors']['css'] ?? null;
-			if ( is_array( $css_feature_selector ) ) {
-				$css_feature_selector = $css_feature_selector['root'] ?? null;
-			}
-			$css_selector = is_string( $css_feature_selector ) ? $css_feature_selector : $selector;
 			$block_rules .= $this->process_blocks_custom_css( $node['css'], $css_selector );
 		}
 
@@ -3594,6 +3602,11 @@ class WP_Theme_JSON_Gutenberg {
 				foreach ( $breakpoint_feature_declarations as $feature_selector => $individual_feature_declarations ) {
 					$feature_ruleset         = static::to_ruleset( ":root :where($feature_selector)", $individual_feature_declarations );
 					$responsive_feature_css .= $breakpoint_media . '{' . $feature_ruleset . '}';
+				}
+
+				if ( isset( $breakpoint_node['css'] ) ) {
+					$breakpoint_custom_css   = static::process_blocks_custom_css( $breakpoint_node['css'], $css_selector );
+					$responsive_feature_css .= $breakpoint_media . '{' . $breakpoint_custom_css . '}';
 				}
 			}
 
@@ -4125,6 +4138,11 @@ class WP_Theme_JSON_Gutenberg {
 			foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint ) {
 				if ( isset( $input[ $breakpoint ] ) ) {
 					$output[ $breakpoint ] = static::remove_insecure_styles( $input[ $breakpoint ] );
+
+					// Responsive custom CSS is allowed for users with 'edit_css' capability.
+					if ( isset( $input[ $breakpoint ]['css'] ) && current_user_can( 'edit_css' ) ) {
+						$output[ $breakpoint ]['css'] = $input[ $breakpoint ]['css'];
+					}
 				}
 			}
 
@@ -4153,6 +4171,11 @@ class WP_Theme_JSON_Gutenberg {
 					foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint ) {
 						if ( isset( $variation_input[ $breakpoint ] ) ) {
 							$variation_output[ $breakpoint ] = static::remove_insecure_styles( $variation_input[ $breakpoint ] );
+
+							// Responsive custom CSS is allowed for users with 'edit_css' capability.
+							if ( isset( $variation_input[ $breakpoint ]['css'] ) && current_user_can( 'edit_css' ) ) {
+								$variation_output[ $breakpoint ]['css'] = $variation_input[ $breakpoint ]['css'];
+							}
 						}
 					}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3132,6 +3132,7 @@ class WP_Theme_JSON_Gutenberg {
 					'path'       => $node_path,
 					'selector'   => $selector,
 					'selectors'  => $feature_selectors,
+					'elements'   => $selectors[ $name ]['elements'] ?? array(),
 					'duotone'    => $duotone_selector,
 					'variations' => $variation_selectors,
 					'css'        => $selector,
@@ -3164,6 +3165,7 @@ class WP_Theme_JSON_Gutenberg {
 								'path'       => array( 'styles', 'blocks', $name, $pseudo_selector ),
 								'selector'   => static::append_to_selector( $selector, $pseudo_selector ),
 								'selectors'  => $pseudo_feature_selectors,
+								'elements'   => $selectors[ $name ]['elements'] ?? array(),
 								'duotone'    => $duotone_selector,
 								'variations' => $variation_selectors,
 								'css'        => static::append_to_selector( $selector, $pseudo_selector ),
@@ -3185,6 +3187,7 @@ class WP_Theme_JSON_Gutenberg {
 								'path'       => array( 'styles', 'blocks', $name, $custom_state ),
 								'selector'   => $custom_css_selector,
 								'selectors'  => $feature_selectors,
+								'elements'   => $selectors[ $name ]['elements'] ?? array(),
 								'duotone'    => $duotone_selector,
 								'variations' => $variation_selectors,
 								'css'        => $custom_css_selector,
@@ -3200,6 +3203,7 @@ class WP_Theme_JSON_Gutenberg {
 											'path'       => array( 'styles', 'blocks', $name, $custom_state, $pseudo ),
 											'selector'   => $compound_css_selector,
 											'selectors'  => $feature_selectors,
+											'elements'   => $selectors[ $name ]['elements'] ?? array(),
 											'duotone'    => $duotone_selector,
 											'variations' => $variation_selectors,
 											'css'        => $compound_css_selector,
@@ -3274,8 +3278,7 @@ class WP_Theme_JSON_Gutenberg {
 		// Update text indent selector for paragraph blocks based on the textIndent setting.
 		$block_name           = $block_metadata['name'] ?? null;
 		$feature_declarations = static::update_paragraph_text_indent_selector( $feature_declarations, $settings, $block_name );
-		$blocks_metadata      = static::get_blocks_metadata();
-		$block_elements       = $block_name && isset( $blocks_metadata[ $block_name ]['elements'] ) ? $blocks_metadata[ $block_name ]['elements'] : array();
+		$block_elements       = $block_metadata['elements'] ?? array();
 
 		// Update button width declarations for percentage values to use calc() with block gap.
 		$feature_declarations = static::update_button_width_declarations( $feature_declarations, $settings );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3700,9 +3700,16 @@ class WP_Theme_JSON_Gutenberg {
 			$block_rules .= static::process_responsive_selectors( $node, $selector, $settings );
 		}
 
-		// 9. When processing a block element node, emit responsive breakpoint overrides for
-		// that element immediately after its default styles. This ensures media queries always
-		// follow the default rules they are meant to override.
+		// 9. When processing a block element node, emit responsive breakpoint overrides
+		// immediately after that node's default styles so media queries always follow the
+		// non-media rules they override.
+		//
+		// Each element has two node passes in the style_nodes list:
+		//   (a) base node  (selector = "a")       → emits base responsive styles only
+		//   (b) pseudo node (selector = "a:hover") → emits that pseudo's responsive styles only
+		//
+		// Splitting the work this way preserves cascade order:
+		//   a {}  →  @media{ a{} }  →  a:hover {}  →  @media{ a:hover{} }
 		$path       = $block_metadata['path'];
 		$path_count = count( $path );
 
@@ -3722,32 +3729,36 @@ class WP_Theme_JSON_Gutenberg {
 					continue;
 				}
 
-				$breakpoint_media     = static::RESPONSIVE_BREAKPOINTS[ $breakpoint ];
-				$element_declarations = static::compute_style_properties( $responsive_element_node, $settings, null, $this->theme_json );
+				$breakpoint_media = static::RESPONSIVE_BREAKPOINTS[ $breakpoint ];
 
-				if ( ! empty( $element_declarations ) ) {
-					$element_ruleset = static::to_ruleset( ':root :where(' . $selector . ')', $element_declarations );
-					$block_rules    .= $breakpoint_media . '{' . $element_ruleset . '}';
-				}
+				if ( $pseudo_selector ) {
+					// Pseudo-selector node: only emit styles for this specific pseudo-state.
+					if ( ! isset( $responsive_element_node[ $pseudo_selector ] ) ) {
+						continue;
+					}
 
-				if ( isset( $responsive_element_node['css'] ) ) {
-					$element_custom_css = static::process_blocks_custom_css( $responsive_element_node['css'], $selector );
-					$block_rules       .= $breakpoint_media . '{' . $element_custom_css . '}';
-				}
-
-				if ( isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ] ) ) {
-					foreach ( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ] as $pseudo_sel ) {
-						if ( ! isset( $responsive_element_node[ $pseudo_sel ] ) ) {
-							continue;
-						}
-
-						$pseudo_declarations = static::compute_style_properties( $responsive_element_node[ $pseudo_sel ], $settings, null, $this->theme_json );
-						if ( empty( $pseudo_declarations ) ) {
-							continue;
-						}
-
-						$pseudo_ruleset = static::to_ruleset( ':root :where(' . static::append_to_selector( $selector, $pseudo_sel ) . ')', $pseudo_declarations );
+					$pseudo_declarations = static::compute_style_properties( $responsive_element_node[ $pseudo_selector ], $settings, null, $this->theme_json );
+					if ( ! empty( $pseudo_declarations ) ) {
+						$pseudo_ruleset = static::to_ruleset( ':root :where(' . $selector . ')', $pseudo_declarations );
 						$block_rules   .= $breakpoint_media . '{' . $pseudo_ruleset . '}';
+					}
+
+					if ( isset( $responsive_element_node[ $pseudo_selector ]['css'] ) ) {
+						$pseudo_css   = static::process_blocks_custom_css( $responsive_element_node[ $pseudo_selector ]['css'], $selector );
+						$block_rules .= $breakpoint_media . '{' . $pseudo_css . '}';
+					}
+				} else {
+					// Base element node: only emit base responsive styles.
+					// Pseudo-selector responsive styles are handled by their own node pass above.
+					$element_declarations = static::compute_style_properties( $responsive_element_node, $settings, null, $this->theme_json );
+					if ( ! empty( $element_declarations ) ) {
+						$element_ruleset = static::to_ruleset( ':root :where(' . $selector . ')', $element_declarations );
+						$block_rules    .= $breakpoint_media . '{' . $element_ruleset . '}';
+					}
+
+					if ( isset( $responsive_element_node['css'] ) ) {
+						$element_custom_css = static::process_blocks_custom_css( $responsive_element_node['css'], $selector );
+						$block_rules       .= $breakpoint_media . '{' . $element_custom_css . '}';
 					}
 				}
 			}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1111,6 +1111,11 @@ class WP_Theme_JSON_Gutenberg {
 					$schema_styles_elements[ $element ][ $pseudo_selector ] = $styles_non_top_level;
 				}
 			}
+
+			// Add responsive breakpoint states for elements.
+			foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint_state ) {
+				$schema_styles_elements[ $element ][ $breakpoint_state ] = $styles_non_top_level;
+			}
 		}
 
 		$schema_styles_blocks   = array();
@@ -1133,7 +1138,8 @@ class WP_Theme_JSON_Gutenberg {
 
 			// Add responsive breakpoint states for all blocks.
 			foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint_state ) {
-				$schema_styles_blocks[ $block ][ $breakpoint_state ] = $styles_non_top_level;
+				$schema_styles_blocks[ $block ][ $breakpoint_state ]             = $styles_non_top_level;
+				$schema_styles_blocks[ $block ][ $breakpoint_state ]['elements'] = $schema_styles_elements;
 			}
 
 			// Add pseudo-selectors for blocks that support them.
@@ -1184,7 +1190,9 @@ class WP_Theme_JSON_Gutenberg {
 
 					// Add responsive breakpoint states to block style variations.
 					foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint_state ) {
-						$variation_schema[ $breakpoint_state ] = $styles_non_top_level;
+						$variation_schema[ $breakpoint_state ]             = $styles_non_top_level;
+						$variation_schema[ $breakpoint_state ]['elements'] = $schema_styles_elements;
+						$variation_schema[ $breakpoint_state ]['blocks']   = $schema_styles_blocks;
 					}
 
 					// Add pseudo-selectors to variations for blocks that support them.
@@ -3292,6 +3300,8 @@ class WP_Theme_JSON_Gutenberg {
 		// Update text indent selector for paragraph blocks based on the textIndent setting.
 		$block_name           = $block_metadata['name'] ?? null;
 		$feature_declarations = static::update_paragraph_text_indent_selector( $feature_declarations, $settings, $block_name );
+		$blocks_metadata      = static::get_blocks_metadata();
+		$block_elements       = $block_name && isset( $blocks_metadata[ $block_name ]['elements'] ) ? $blocks_metadata[ $block_name ]['elements'] : array();
 
 		// Update button width declarations for percentage values to use calc() with block gap.
 		$feature_declarations = static::update_button_width_declarations( $feature_declarations, $settings );
@@ -3396,6 +3406,53 @@ class WP_Theme_JSON_Gutenberg {
 					if ( isset( $breakpoint_node['css'] ) ) {
 						$breakpoint_custom_css     = static::process_blocks_custom_css( $breakpoint_node['css'], $style_variation['selector'] );
 						$variation_responsive_css .= $breakpoint_media . '{' . $breakpoint_custom_css . '}';
+					}
+
+					// Process nested element styles for this breakpoint state.
+					if ( isset( $breakpoint_node['elements'] ) && ! empty( $block_elements ) ) {
+						foreach ( $breakpoint_node['elements'] as $element_name => $element_node ) {
+							if ( ! isset( $block_elements[ $element_name ] ) ) {
+								continue;
+							}
+
+							$clean_element_selector     = preg_replace( '/,\s+/', ',', $block_elements[ $element_name ] );
+							$shortened_selector         = str_replace( $block_metadata['selector'], '', $clean_element_selector );
+							$split_selectors            = explode( ',', $shortened_selector );
+							$updated_selectors          = array_map(
+								static function ( $split_selector ) use ( $clean_style_variation_selector ) {
+									return $clean_style_variation_selector . $split_selector;
+								},
+								$split_selectors
+							);
+							$variation_element_selector = implode( ',', $updated_selectors );
+
+							$element_declarations = static::compute_style_properties( $element_node, $settings, null, $this->theme_json );
+							if ( ! empty( $element_declarations ) ) {
+								$element_ruleset           = static::to_ruleset( ':root :where(' . $variation_element_selector . ')', $element_declarations );
+								$variation_responsive_css .= $breakpoint_media . '{' . $element_ruleset . '}';
+							}
+
+							if ( isset( $element_node['css'] ) ) {
+								$element_custom_css        = static::process_blocks_custom_css( $element_node['css'], $variation_element_selector );
+								$variation_responsive_css .= $breakpoint_media . '{' . $element_custom_css . '}';
+							}
+
+							if ( isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element_name ] ) ) {
+								foreach ( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element_name ] as $pseudo_selector ) {
+									if ( ! isset( $element_node[ $pseudo_selector ] ) ) {
+										continue;
+									}
+
+									$pseudo_declarations = static::compute_style_properties( $element_node[ $pseudo_selector ], $settings, null, $this->theme_json );
+									if ( empty( $pseudo_declarations ) ) {
+										continue;
+									}
+
+									$pseudo_selector_ruleset   = static::to_ruleset( ':root :where(' . static::append_to_selector( $variation_element_selector, $pseudo_selector ) . ')', $pseudo_declarations );
+									$variation_responsive_css .= $breakpoint_media . '{' . $pseudo_selector_ruleset . '}';
+								}
+							}
+						}
 					}
 				}
 
@@ -3612,6 +3669,59 @@ class WP_Theme_JSON_Gutenberg {
 
 			$block_rules .= $responsive_feature_css;
 			$block_rules .= static::process_responsive_selectors( $node, $selector, $settings );
+		}
+
+		// 9. When processing a block element node, emit responsive breakpoint overrides for
+		// that element immediately after its default styles. This ensures media queries always
+		// follow the default rules they are meant to override.
+		$path       = $block_metadata['path'];
+		$path_count = count( $path );
+
+		$is_block_element_node = $is_processing_element
+			&& $path_count >= 5
+			&& 'elements' === $path[ $path_count - 2 ]
+			&& in_array( 'blocks', $path, true );
+
+		if ( $is_block_element_node ) {
+			$parent_block_path = array_slice( $path, 0, $path_count - 2 );
+
+			foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint ) {
+				$responsive_element_path = array_merge( $parent_block_path, array( $breakpoint, 'elements', $current_element ) );
+				$responsive_element_node = _wp_array_get( $this->theme_json, $responsive_element_path, null );
+
+				if ( empty( $responsive_element_node ) ) {
+					continue;
+				}
+
+				$breakpoint_media     = static::RESPONSIVE_BREAKPOINTS[ $breakpoint ];
+				$element_declarations = static::compute_style_properties( $responsive_element_node, $settings, null, $this->theme_json );
+
+				if ( ! empty( $element_declarations ) ) {
+					$element_ruleset = static::to_ruleset( ':root :where(' . $selector . ')', $element_declarations );
+					$block_rules    .= $breakpoint_media . '{' . $element_ruleset . '}';
+				}
+
+				if ( isset( $responsive_element_node['css'] ) ) {
+					$element_custom_css = static::process_blocks_custom_css( $responsive_element_node['css'], $selector );
+					$block_rules       .= $breakpoint_media . '{' . $element_custom_css . '}';
+				}
+
+				if ( isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ] ) ) {
+					foreach ( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ] as $pseudo_sel ) {
+						if ( ! isset( $responsive_element_node[ $pseudo_sel ] ) ) {
+							continue;
+						}
+
+						$pseudo_declarations = static::compute_style_properties( $responsive_element_node[ $pseudo_sel ], $settings, null, $this->theme_json );
+						if ( empty( $pseudo_declarations ) ) {
+							continue;
+						}
+
+						$pseudo_ruleset = static::to_ruleset( ':root :where(' . static::append_to_selector( $selector, $pseudo_sel ) . ')', $pseudo_declarations );
+						$block_rules   .= $breakpoint_media . '{' . $pseudo_ruleset . '}';
+					}
+				}
+			}
 		}
 
 		return $block_rules;
@@ -4139,6 +4249,14 @@ class WP_Theme_JSON_Gutenberg {
 				if ( isset( $input[ $breakpoint ] ) ) {
 					$output[ $breakpoint ] = static::remove_insecure_styles( $input[ $breakpoint ] );
 
+					if ( isset( $input[ $breakpoint ]['elements'] ) ) {
+						$output[ $breakpoint ]['elements'] = static::remove_insecure_element_styles( $input[ $breakpoint ]['elements'] );
+					}
+
+					if ( isset( $input[ $breakpoint ]['blocks'] ) ) {
+						$output[ $breakpoint ]['blocks'] = static::remove_insecure_inner_block_styles( $input[ $breakpoint ]['blocks'] );
+					}
+
 					// Responsive custom CSS is allowed for users with 'edit_css' capability.
 					if ( isset( $input[ $breakpoint ]['css'] ) && current_user_can( 'edit_css' ) ) {
 						$output[ $breakpoint ]['css'] = $input[ $breakpoint ]['css'];
@@ -4171,6 +4289,14 @@ class WP_Theme_JSON_Gutenberg {
 					foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint ) {
 						if ( isset( $variation_input[ $breakpoint ] ) ) {
 							$variation_output[ $breakpoint ] = static::remove_insecure_styles( $variation_input[ $breakpoint ] );
+
+							if ( isset( $variation_input[ $breakpoint ]['elements'] ) ) {
+								$variation_output[ $breakpoint ]['elements'] = static::remove_insecure_element_styles( $variation_input[ $breakpoint ]['elements'] );
+							}
+
+							if ( isset( $variation_input[ $breakpoint ]['blocks'] ) ) {
+								$variation_output[ $breakpoint ]['blocks'] = static::remove_insecure_inner_block_styles( $variation_input[ $breakpoint ]['blocks'] );
+							}
 
 							// Responsive custom CSS is allowed for users with 'edit_css' capability.
 							if ( isset( $variation_input[ $breakpoint ]['css'] ) && current_user_can( 'edit_css' ) ) {
@@ -4239,6 +4365,13 @@ class WP_Theme_JSON_Gutenberg {
 					}
 				}
 
+				// Re-add and process responsive breakpoint styles for elements.
+				foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint ) {
+					if ( isset( $element_input[ $breakpoint ] ) ) {
+						$element_output[ $breakpoint ] = static::remove_insecure_styles( $element_input[ $breakpoint ] );
+					}
+				}
+
 				$sanitized[ $element_name ] = $element_output;
 			}
 		}
@@ -4260,6 +4393,13 @@ class WP_Theme_JSON_Gutenberg {
 
 			if ( isset( $block_input['elements'] ) ) {
 				$block_output['elements'] = static::remove_insecure_element_styles( $block_input['elements'] );
+			}
+
+			// Re-add and process responsive breakpoint styles for inner blocks.
+			foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint ) {
+				if ( isset( $block_input[ $breakpoint ] ) ) {
+					$block_output[ $breakpoint ] = static::remove_insecure_styles( $block_input[ $breakpoint ] );
+				}
 			}
 
 			$sanitized[ $block_type ] = $block_output;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3352,12 +3352,6 @@ class WP_Theme_JSON_Gutenberg {
 					$style_variation_custom_css[ $style_variation['selector'] ] = $this->process_blocks_custom_css( $style_variation_node['css'], $style_variation['selector'] );
 				}
 
-				// Store responsive breakpoint CSS for the style variation.
-				$variation_responsive_css = static::process_responsive_selectors( $style_variation_node, $style_variation['selector'], $settings );
-				if ( ! empty( $variation_responsive_css ) ) {
-					$style_variation_responsive_css[ $style_variation['selector'] ] = $variation_responsive_css;
-				}
-
 				// Store variation metadata and node for layout styles generation.
 				// Only store if the variation has blockGap defined.
 				if ( isset( $style_variation_node['spacing']['blockGap'] ) ) {
@@ -3369,9 +3363,41 @@ class WP_Theme_JSON_Gutenberg {
 						'node'     => $style_variation_node,
 					);
 				}
+
+				// Store responsive breakpoint CSS for the style variation.
+				// This includes both base properties and feature-level selectors.
+				$variation_responsive_css = '';
+
+				foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint ) {
+					if ( ! isset( $style_variation_node[ $breakpoint ] ) ) {
+						continue;
+					}
+
+					$breakpoint_node  = $style_variation_node[ $breakpoint ];
+					$breakpoint_media = static::RESPONSIVE_BREAKPOINTS[ $breakpoint ];
+
+					// Process feature-level declarations for this breakpoint.
+					$breakpoint_feature_declarations = static::get_feature_declarations_for_node( $block_metadata, $breakpoint_node );
+					$breakpoint_feature_declarations = static::update_paragraph_text_indent_selector( $breakpoint_feature_declarations, $settings, $block_name );
+					$breakpoint_feature_declarations = static::update_button_width_declarations( $breakpoint_feature_declarations, $settings );
+					foreach ( $breakpoint_feature_declarations as $feature_selector => $feature_decl ) {
+						$feature_ruleset           = static::to_ruleset( ':root :where(' . $feature_selector . ')', $feature_decl );
+						$variation_responsive_css .= $breakpoint_media . '{' . $feature_ruleset . '}';
+					}
+
+					// Process base properties for this breakpoint.
+					$breakpoint_declarations = static::compute_style_properties( $breakpoint_node, $settings, null, $this->theme_json );
+					if ( ! empty( $breakpoint_declarations ) ) {
+						$base_ruleset              = static::to_ruleset( ':root :where(' . $style_variation['selector'] . ')', $breakpoint_declarations );
+						$variation_responsive_css .= $breakpoint_media . '{' . $base_ruleset . '}';
+					}
+				}
+
+				if ( ! empty( $variation_responsive_css ) ) {
+					$style_variation_responsive_css[ $style_variation['selector'] ] = $variation_responsive_css;
+				}
 			}
 		}
-
 		/*
 		 * Get a reference to element name from path.
 		 * $block_metadata['path'] = array( 'styles','elements','link' );
@@ -3552,6 +3578,26 @@ class WP_Theme_JSON_Gutenberg {
 
 		// 8. Generate and append responsive breakpoint rules.
 		if ( ! $is_root_selector ) {
+			$responsive_feature_css = '';
+
+			foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint ) {
+				if ( ! isset( $node[ $breakpoint ] ) ) {
+					continue;
+				}
+
+				$breakpoint_node                 = $node[ $breakpoint ];
+				$breakpoint_media                = static::RESPONSIVE_BREAKPOINTS[ $breakpoint ];
+				$breakpoint_feature_declarations = static::get_feature_declarations_for_node( $block_metadata, $breakpoint_node );
+				$breakpoint_feature_declarations = static::update_paragraph_text_indent_selector( $breakpoint_feature_declarations, $settings, $block_name );
+				$breakpoint_feature_declarations = static::update_button_width_declarations( $breakpoint_feature_declarations, $settings );
+
+				foreach ( $breakpoint_feature_declarations as $feature_selector => $individual_feature_declarations ) {
+					$feature_ruleset         = static::to_ruleset( ":root :where($feature_selector)", $individual_feature_declarations );
+					$responsive_feature_css .= $breakpoint_media . '{' . $feature_ruleset . '}';
+				}
+			}
+
+			$block_rules .= $responsive_feature_css;
 			$block_rules .= static::process_responsive_selectors( $node, $selector, $settings );
 		}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3679,6 +3679,14 @@ class WP_Theme_JSON_Gutenberg {
 					$responsive_feature_css .= $breakpoint_media . '{' . $feature_ruleset . '}';
 				}
 
+				// Emit base responsive declarations using the already-stripped $breakpoint_node
+				// (get_feature_declarations_for_node removes feature props by reference, so only
+				// non-feature properties remain here, matching non-responsive cascade behaviour).
+				$breakpoint_declarations = static::compute_style_properties( $breakpoint_node, $settings, null, null );
+				if ( ! empty( $breakpoint_declarations ) ) {
+					$responsive_feature_css .= $breakpoint_media . '{' . static::to_ruleset( ":root :where($selector)", $breakpoint_declarations ) . '}';
+				}
+
 				if ( isset( $breakpoint_node['css'] ) ) {
 					$breakpoint_custom_css   = static::process_blocks_custom_css( $breakpoint_node['css'], $css_selector );
 					$responsive_feature_css .= $breakpoint_media . '{' . $breakpoint_custom_css . '}';
@@ -3697,7 +3705,6 @@ class WP_Theme_JSON_Gutenberg {
 			}
 
 			$block_rules .= $responsive_feature_css;
-			$block_rules .= static::process_responsive_selectors( $node, $selector, $settings );
 		}
 
 		// 9. When processing a block element node, emit responsive breakpoint overrides

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3313,15 +3313,24 @@ class WP_Theme_JSON_Gutenberg {
 					$clean_current_selector = preg_replace( '/,\s+/', ',', $current_selector );
 					$shortened_selector     = str_replace( $block_metadata['selector'], '', $clean_current_selector );
 
-					// Prepend the variation selector to the current selector.
-					$split_selectors    = explode( ',', $shortened_selector );
-					$updated_selectors  = array_map(
-						static function ( $split_selector ) use ( $clean_style_variation_selector ) {
-							return $clean_style_variation_selector . $split_selector;
-						},
-						$split_selectors
-					);
-					$combined_selectors = implode( ',', $updated_selectors );
+					if ( $block_metadata['selector'] && ! str_contains( $clean_current_selector, $block_metadata['selector'] ) ) {
+						/*
+						 * Feature selector is block-level (e.g. `.wp-block-button` for
+						 * dimensions/width) — apply the variation class directly to it.
+						 */
+						$feature_element_selector = str_replace( $shortened_selector, '', $clean_style_variation_selector );
+						$combined_selectors       = str_replace( $feature_element_selector, '', $clean_style_variation_selector );
+					} else {
+						// Prepend the variation selector to the current selector.
+						$split_selectors    = explode( ',', $shortened_selector );
+						$updated_selectors  = array_map(
+							static function ( $split_selector ) use ( $clean_style_variation_selector ) {
+								return $clean_style_variation_selector . $split_selector;
+							},
+							$split_selectors
+						);
+						$combined_selectors = implode( ',', $updated_selectors );
+					}
 
 					// Add the new declarations to the overall results under the modified selector.
 					$style_variation_declarations[ $combined_selectors ] = $new_declarations;
@@ -3362,13 +3371,34 @@ class WP_Theme_JSON_Gutenberg {
 
 					$breakpoint_node  = $style_variation_node[ $breakpoint ];
 					$breakpoint_media = static::RESPONSIVE_BREAKPOINTS[ $breakpoint ];
-
 					// Process feature-level declarations for this breakpoint.
 					$breakpoint_feature_declarations = static::get_feature_declarations_for_node( $block_metadata, $breakpoint_node );
 					$breakpoint_feature_declarations = static::update_paragraph_text_indent_selector( $breakpoint_feature_declarations, $settings, $block_name );
 					$breakpoint_feature_declarations = static::update_button_width_declarations( $breakpoint_feature_declarations, $settings );
 					foreach ( $breakpoint_feature_declarations as $feature_selector => $feature_decl ) {
-						$feature_ruleset           = static::to_ruleset( ':root :where(' . $feature_selector . ')', $feature_decl );
+						$clean_feature_selector = preg_replace( '/,\s+/', ',', $feature_selector );
+						$shortened_selector     = str_replace( $block_metadata['selector'], '', $clean_feature_selector );
+
+						if ( $block_metadata['selector'] && ! str_contains( $clean_feature_selector, $block_metadata['selector'] ) ) {
+							/*
+							 * Feature selector is block-level (e.g. `.wp-block-button` for
+							 * dimensions/width) — apply the variation class directly to it.
+							 */
+							$feature_element_selector = str_replace( $shortened_selector, '', $clean_style_variation_selector );
+							$combined_selectors       = str_replace( $feature_element_selector, '', $clean_style_variation_selector );
+						} else {
+							// Prepend the variation selector to the current selector.
+							$split_selectors    = explode( ',', $shortened_selector );
+							$updated_selectors  = array_map(
+								static function ( $split_selector ) use ( $clean_style_variation_selector ) {
+									return $clean_style_variation_selector . $split_selector;
+								},
+								$split_selectors
+							);
+							$combined_selectors = implode( ',', $updated_selectors );
+						}
+
+						$feature_ruleset           = static::to_ruleset( ':root :where(' . $combined_selectors . ')', $feature_decl );
 						$variation_responsive_css .= $breakpoint_media . '{' . $feature_ruleset . '}';
 					}
 

--- a/lib/load.php
+++ b/lib/load.php
@@ -202,6 +202,7 @@ require __DIR__ . '/block-supports/aria-label.php';
 require __DIR__ . '/block-supports/anchor.php';
 require __DIR__ . '/block-supports/block-visibility.php';
 require __DIR__ . '/block-supports/custom-css.php';
+require __DIR__ . '/block-supports/states.php';
 
 // Client-side media processing.
 require_once __DIR__ . '/media/load.php';

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -12,6 +12,7 @@ import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
+	createSlotFill,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -33,6 +34,9 @@ import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
 
 const { Badge } = unlock( componentsPrivateApis );
+
+export const { Fill: BlockCardControlsFill, Slot: BlockCardControlsSlot } =
+	createSlotFill( 'BlockCardControls' );
 
 function OptionalParentSelectButton( { children, onClick } ) {
 	if ( ! onClick ) {
@@ -151,58 +155,65 @@ function BlockCard( {
 			) }
 		>
 			<VStack>
-				<HStack justify="flex-start" spacing={ 0 }>
-					{ parentBlockClientId && (
-						<Button
-							onClick={ () => selectBlock( parentBlockClientId ) }
-							label={
-								parentBlockName
-									? sprintf(
-											/* translators: %s: The name of the parent block. */
-											__( 'Go to "%s" block' ),
-											getBlockType( parentBlockName )
-												?.title
-									  )
-									: __( 'Go to parent block' )
+				<HStack justify="space-between" spacing={ 0 }>
+					<HStack justify="flex-start" spacing={ 0 }>
+						{ parentBlockClientId && (
+							<Button
+								onClick={ () =>
+									selectBlock( parentBlockClientId )
+								}
+								label={
+									parentBlockName
+										? sprintf(
+												/* translators: %s: The name of the parent block. */
+												__( 'Go to "%s" block' ),
+												getBlockType( parentBlockName )
+													?.title
+										  )
+										: __( 'Go to parent block' )
+								}
+								style={
+									// TODO: This style override is also used in ToolsPanelHeader.
+									// It should be supported out-of-the-box by Button.
+									{ minWidth: 24, padding: 0 }
+								}
+								icon={ isRTL() ? chevronRight : chevronLeft }
+								size="small"
+							/>
+						) }
+						{ isChild && (
+							<span className="block-editor-block-card__child-indicator-icon">
+								<Icon
+									icon={ isRTL() ? arrowLeft : arrowRight }
+								/>
+							</span>
+						) }
+						<OptionalParentSelectButton
+							onClick={
+								parentClientId
+									? () => {
+											selectBlock( parentClientId );
+									  }
+									: undefined
 							}
-							style={
-								// TODO: This style override is also used in ToolsPanelHeader.
-								// It should be supported out-of-the-box by Button.
-								{ minWidth: 24, padding: 0 }
-							}
-							icon={ isRTL() ? chevronRight : chevronLeft }
-							size="small"
-						/>
-					) }
-					{ isChild && (
-						<span className="block-editor-block-card__child-indicator-icon">
-							<Icon icon={ isRTL() ? arrowLeft : arrowRight } />
-						</span>
-					) }
-					<OptionalParentSelectButton
-						onClick={
-							parentClientId
-								? () => {
-										selectBlock( parentClientId );
-								  }
-								: undefined
-						}
-					>
-						<BlockIcon icon={ icon } showColors />
-						<VStack spacing={ 1 }>
-							<TitleElement className="block-editor-block-card__title">
-								<span className="block-editor-block-card__name">
-									{ !! name?.length ? name : title }
-								</span>
-								{ ! parentClientId &&
-									! isChild &&
-									!! name?.length && (
-										<Badge>{ title }</Badge>
-									) }
-							</TitleElement>
-							{ children }
-						</VStack>
-					</OptionalParentSelectButton>
+						>
+							<BlockIcon icon={ icon } showColors />
+							<VStack spacing={ 1 }>
+								<TitleElement className="block-editor-block-card__title">
+									<span className="block-editor-block-card__name">
+										{ !! name?.length ? name : title }
+									</span>
+									{ ! parentClientId &&
+										! isChild &&
+										!! name?.length && (
+											<Badge>{ title }</Badge>
+										) }
+								</TitleElement>
+								{ children }
+							</VStack>
+						</OptionalParentSelectButton>
+					</HStack>
+					<BlockCardControlsSlot />
 				</HStack>
 				{ ! parentClientId && ! isChild && description && (
 					<Text className="block-editor-block-card__description">

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -35,8 +35,9 @@ import BlockIcon from '../block-icon';
 
 const { Badge } = unlock( componentsPrivateApis );
 
+const BlockCardControlsKey = Symbol( 'BlockCardControls' );
 export const { Fill: BlockCardControlsFill, Slot: BlockCardControlsSlot } =
-	createSlotFill( 'BlockCardControls' );
+	createSlotFill( BlockCardControlsKey );
 
 function OptionalParentSelectButton( { children, onClick } ) {
 	if ( ! onClick ) {

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -25,6 +25,7 @@ import { store as blockEditorStore } from '../../store';
 import BlockStyles from '../block-styles';
 import { ListViewContentPopover } from '../inspector-controls/list-view-content-popover';
 import InspectorControls from '../inspector-controls';
+import { BlockInspectorPreTabsSlot } from './inspector-pre-tabs-slot-fill';
 import { default as InspectorControlsTabs } from '../inspector-controls-tabs';
 import useInspectorControlsTabs from '../inspector-controls-tabs/use-inspector-controls-tabs';
 import InspectorControlsLastItem from '../inspector-controls/last-item';
@@ -351,6 +352,7 @@ const BlockInspectorSingleBlock = ( {
 			<ViewportVisibilityInfo clientId={ renderedBlockClientId } />
 			<EditContents clientId={ renderedBlockClientId } />
 			<BlockVariationTransforms blockClientId={ renderedBlockClientId } />
+			<BlockInspectorPreTabsSlot />
 			{ hasMultipleTabs && (
 				<>
 					<InspectorControlsTabs

--- a/packages/block-editor/src/components/block-inspector/inspector-pre-tabs-slot-fill.js
+++ b/packages/block-editor/src/components/block-inspector/inspector-pre-tabs-slot-fill.js
@@ -1,0 +1,9 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+export const {
+	Fill: BlockInspectorPreTabsFill,
+	Slot: BlockInspectorPreTabsSlot,
+} = createSlotFill( 'BlockInspectorPreTabs' );

--- a/packages/block-editor/src/components/block-inspector/inspector-pre-tabs-slot-fill.js
+++ b/packages/block-editor/src/components/block-inspector/inspector-pre-tabs-slot-fill.js
@@ -3,7 +3,9 @@
  */
 import { createSlotFill } from '@wordpress/components';
 
+const BlockInspectorPreTabsKey = Symbol( 'BlockInspectorPreTabs' );
+
 export const {
 	Fill: BlockInspectorPreTabsFill,
 	Slot: BlockInspectorPreTabsSlot,
-} = createSlotFill( 'BlockInspectorPreTabs' );
+} = createSlotFill( BlockInspectorPreTabsKey );

--- a/packages/block-editor/src/components/global-styles/state-control.js
+++ b/packages/block-editor/src/components/global-styles/state-control.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { check, chevronDown } from '@wordpress/icons';
+import { check, chevronDown, moreVertical } from '@wordpress/icons';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 
 /**
@@ -13,12 +13,14 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
  * @param {Array}    props.states   Array of available states with value and label.
  * @param {string}   props.value    Currently selected state value.
  * @param {Function} props.onChange Callback when selection changes.
+ * @param {boolean}  props.showText Whether to show text label on the toggle. Default true.
  * @return {Element|null} State control component.
  */
 export default function StateControl( {
 	states = [],
 	value = 'default',
 	onChange,
+	showText = true,
 } ) {
 	if ( ! states || states.length === 0 ) {
 		return null;
@@ -39,20 +41,21 @@ export default function StateControl( {
 		return currentOption?.label || __( 'Default' );
 	};
 
+	const icon = showText ? chevronDown : moreVertical;
+	const toggleProps = showText
+		? { size: 'compact', variant: 'tertiary', iconPosition: 'right' }
+		: { size: 'compact', variant: 'tertiary' };
+
 	return (
 		<DropdownMenu
-			icon={ chevronDown }
+			icon={ icon }
 			label={ sprintf(
 				/* translators: %s: Current state (e.g. "Hover", "Focus") */
 				__( 'State: %s' ),
 				getCurrentStateLabel()
 			) }
-			text={ getCurrentStateLabel() }
-			toggleProps={ {
-				size: 'compact',
-				variant: 'tertiary',
-				iconPosition: 'right',
-			} }
+			text={ showText ? getCurrentStateLabel() : undefined }
+			toggleProps={ toggleProps }
 		>
 			{ ( { onClose } ) => (
 				<MenuGroup label={ __( 'State' ) }>

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -123,9 +123,23 @@ export function getBackgroundImageClasses( style ) {
 function BackgroundInspectorControl( {
 	children,
 	backgroundGradientSupported = false,
+	selectedState = 'default',
 } ) {
+	const isStateSelected = selectedState !== 'default';
 	const resetAllFilter = useCallback(
 		( attributes ) => {
+			if ( isStateSelected ) {
+				return {
+					...attributes,
+					style: cleanEmptyObject( {
+						...attributes.style,
+						[ selectedState ]: {
+							...attributes.style?.[ selectedState ],
+							background: undefined,
+						},
+					} ),
+				};
+			}
 			const updatedClassName = attributes.className?.includes(
 				'has-background'
 			)
@@ -149,7 +163,7 @@ function BackgroundInspectorControl( {
 				} ),
 			};
 		},
-		[ backgroundGradientSupported ]
+		[ backgroundGradientSupported, isStateSelected, selectedState ]
 	);
 	return (
 		<InspectorControls group="background" resetAllFilter={ resetAllFilter }>
@@ -200,11 +214,12 @@ export function BackgroundImagePanel( {
 		( { children } ) => (
 			<BackgroundInspectorControl
 				backgroundGradientSupported={ backgroundGradientSupported }
+				selectedState={ selectedState }
 			>
 				{ children }
 			</BackgroundInspectorControl>
 		),
-		[ backgroundGradientSupported ]
+		[ backgroundGradientSupported, selectedState ]
 	);
 
 	if (
@@ -214,9 +229,9 @@ export function BackgroundImagePanel( {
 		return null;
 	}
 
-	const isStateMode = selectedState && selectedState !== 'default';
-	const value = isStateMode ? style?.[ selectedState ] : style;
-	const onChange = isStateMode
+	const isStateSelected = selectedState && selectedState !== 'default';
+	const value = isStateSelected ? style?.[ selectedState ] : style;
+	const onChange = isStateSelected
 		? ( newStateStyle ) =>
 				setAttributes( {
 					style: cleanEmptyObject( {

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -23,6 +23,7 @@ import {
 	hasBackgroundGradientValue,
 } from '../components/global-styles/background-panel';
 import { globalStylesDataKey } from '../store/private-keys';
+import { useBlockStateProps } from './state-utils';
 
 export const BACKGROUND_SUPPORT_KEY = 'background';
 
@@ -222,6 +223,13 @@ export function BackgroundImagePanel( {
 		[ backgroundGradientSupported, selectedState ]
 	);
 
+	// Must be declared before the early return to follow Rules of Hooks.
+	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
+		selectedState,
+		style,
+		setAttributes,
+	} );
+
 	if (
 		! useHasBackgroundPanel( settings ) ||
 		! hasBackgroundSupport( name )
@@ -229,16 +237,8 @@ export function BackgroundImagePanel( {
 		return null;
 	}
 
-	const isStateSelected = selectedState && selectedState !== 'default';
-	const value = isStateSelected ? style?.[ selectedState ] : style;
 	const onChange = isStateSelected
-		? ( newStateStyle ) =>
-				setAttributes( {
-					style: cleanEmptyObject( {
-						...style,
-						[ selectedState ]: newStateStyle,
-					} ),
-				} )
+		? stateOnChange
 		: ( newStyle ) => {
 				const isMigrating =
 					backgroundGradientSupported && !! style?.color?.gradient;
@@ -263,7 +263,10 @@ export function BackgroundImagePanel( {
 				// Conversely, if the gradient is cleared and has-background was added
 				// during a previous migration, remove it so it does not linger.
 				if ( isMigrating && !! newStyle?.background?.gradient ) {
-					newAttributes.className = clsx( className, 'has-background' );
+					newAttributes.className = clsx(
+						className,
+						'has-background'
+					);
 				} else if (
 					! newStyle?.background?.gradient &&
 					className?.includes( 'has-background' )
@@ -276,7 +279,7 @@ export function BackgroundImagePanel( {
 				}
 
 				setAttributes( newAttributes );
-			};
+		  };
 
 	// When background.gradient is supported but not yet explicitly set, fall
 	// back to color.gradient for display. Any write from this panel migrates
@@ -318,7 +321,7 @@ export function BackgroundImagePanel( {
 			settings={ updatedSettings }
 			onChange={ onChange }
 			defaultControls={ defaultControls }
-			value={ isStateMode ? value : styleValue }
+			value={ isStateSelected ? stateValue : styleValue }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -14,6 +14,7 @@ import { useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import InspectorControls from '../components/inspector-controls';
+import { useBlockEditContext } from '../components/block-edit/context';
 import { cleanEmptyObject } from './utils';
 import { store as blockEditorStore } from '../store';
 import {
@@ -23,7 +24,7 @@ import {
 	hasBackgroundGradientValue,
 } from '../components/global-styles/background-panel';
 import { globalStylesDataKey } from '../store/private-keys';
-import { useBlockStateProps } from './state-utils';
+import { useBlockStyle } from './use-block-style';
 
 export const BACKGROUND_SUPPORT_KEY = 'background';
 
@@ -176,18 +177,16 @@ function BackgroundInspectorControl( {
 export function BackgroundImagePanel( {
 	clientId,
 	name,
-	setAttributes,
 	settings,
 	selectedState = 'default',
 } ) {
-	const { style, className, inheritedValue } = useSelect(
+	const { className, inheritedValue } = useSelect(
 		( select ) => {
 			const { getBlockAttributes, getSettings } =
 				select( blockEditorStore );
 			const _settings = getSettings();
 			const blockAttributes = getBlockAttributes( clientId );
 			return {
-				style: blockAttributes?.style,
 				className: blockAttributes?.className,
 				/*
 				 * To ensure we pass down the right inherited values:
@@ -202,6 +201,10 @@ export function BackgroundImagePanel( {
 		},
 		[ clientId, name ]
 	);
+
+	const { setAttributes } = useBlockEditContext();
+	const [ style, setStyle ] = useBlockStyle( null, selectedState );
+	const isStateSelected = selectedState !== 'default';
 
 	const backgroundGradientSupported = hasBackgroundSupport(
 		name,
@@ -223,13 +226,6 @@ export function BackgroundImagePanel( {
 		[ backgroundGradientSupported, selectedState ]
 	);
 
-	// Must be declared before the early return to follow Rules of Hooks.
-	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
-		selectedState,
-		style,
-		setAttributes,
-	} );
-
 	if (
 		! useHasBackgroundPanel( settings ) ||
 		! hasBackgroundSupport( name )
@@ -238,7 +234,7 @@ export function BackgroundImagePanel( {
 	}
 
 	const onChange = isStateSelected
-		? stateOnChange
+		? setStyle
 		: ( newStyle ) => {
 				const isMigrating =
 					backgroundGradientSupported && !! style?.color?.gradient;
@@ -321,7 +317,7 @@ export function BackgroundImagePanel( {
 			settings={ updatedSettings }
 			onChange={ onChange }
 			defaultControls={ defaultControls }
-			value={ isStateSelected ? stateValue : styleValue }
+			value={ isStateSelected ? style : styleValue }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -163,6 +163,7 @@ export function BackgroundImagePanel( {
 	name,
 	setAttributes,
 	settings,
+	selectedState = 'default',
 } ) {
 	const { style, className, inheritedValue } = useSelect(
 		( select ) => {
@@ -213,44 +214,54 @@ export function BackgroundImagePanel( {
 		return null;
 	}
 
-	const onChange = ( newStyle ) => {
-		const isMigrating =
-			backgroundGradientSupported && !! style?.color?.gradient;
-		const newAttributes = {
-			style: cleanEmptyObject(
-				backgroundGradientSupported
-					? {
-							...newStyle,
-							color: {
-								...newStyle?.color,
-								gradient: undefined,
-							},
-					  }
-					: newStyle
-			),
-		};
+	const isStateMode = selectedState && selectedState !== 'default';
+	const value = isStateMode ? style?.[ selectedState ] : style;
+	const onChange = isStateMode
+		? ( newStateStyle ) =>
+				setAttributes( {
+					style: cleanEmptyObject( {
+						...style,
+						[ selectedState ]: newStateStyle,
+					} ),
+				} )
+		: ( newStyle ) => {
+				const isMigrating =
+					backgroundGradientSupported && !! style?.color?.gradient;
+				const newAttributes = {
+					style: cleanEmptyObject(
+						backgroundGradientSupported
+							? {
+									...newStyle,
+									color: {
+										...newStyle?.color,
+										gradient: undefined,
+									},
+							  }
+							: newStyle
+					),
+				};
 
-		// When migrating from color.gradient to background.gradient, preserve
-		// the has-background class so existing styles relying on it (e.g.
-		// theme padding) are not silently broken. Only add the class when a
-		// gradient value is being set — not when it is being cleared/reset.
-		// Conversely, if the gradient is cleared and has-background was added
-		// during a previous migration, remove it so it does not linger.
-		if ( isMigrating && !! newStyle?.background?.gradient ) {
-			newAttributes.className = clsx( className, 'has-background' );
-		} else if (
-			! newStyle?.background?.gradient &&
-			className?.includes( 'has-background' )
-		) {
-			newAttributes.className =
-				className
-					.split( ' ' )
-					.filter( ( c ) => c !== 'has-background' )
-					.join( ' ' ) || undefined;
-		}
+				// When migrating from color.gradient to background.gradient, preserve
+				// the has-background class so existing styles relying on it (e.g.
+				// theme padding) are not silently broken. Only add the class when a
+				// gradient value is being set — not when it is being cleared/reset.
+				// Conversely, if the gradient is cleared and has-background was added
+				// during a previous migration, remove it so it does not linger.
+				if ( isMigrating && !! newStyle?.background?.gradient ) {
+					newAttributes.className = clsx( className, 'has-background' );
+				} else if (
+					! newStyle?.background?.gradient &&
+					className?.includes( 'has-background' )
+				) {
+					newAttributes.className =
+						className
+							.split( ' ' )
+							.filter( ( c ) => c !== 'has-background' )
+							.join( ' ' ) || undefined;
+				}
 
-		setAttributes( newAttributes );
-	};
+				setAttributes( newAttributes );
+			};
 
 	// When background.gradient is supported but not yet explicitly set, fall
 	// back to color.gradient for display. Any write from this panel migrates
@@ -292,7 +303,7 @@ export function BackgroundImagePanel( {
 			settings={ updatedSettings }
 			onChange={ onChange }
 			defaultControls={ defaultControls }
-			value={ styleValue }
+			value={ isStateMode ? value : styleValue }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -14,7 +14,7 @@ import { useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import InspectorControls from '../components/inspector-controls';
-import { cleanEmptyObject } from './utils';
+import { cleanEmptyObject, buildStateResetAllFilter } from './utils';
 import { store as blockEditorStore } from '../store';
 import {
 	default as StylesBackgroundPanel,
@@ -130,16 +130,10 @@ function BackgroundInspectorControl( {
 	const resetAllFilter = useCallback(
 		( attributes ) => {
 			if ( isStateSelected ) {
-				return {
-					...attributes,
-					style: cleanEmptyObject( {
-						...attributes.style,
-						[ selectedState ]: {
-							...attributes.style?.[ selectedState ],
-							background: undefined,
-						},
-					} ),
-				};
+				return buildStateResetAllFilter( selectedState, ( style ) => ( {
+					...style,
+					background: undefined,
+				} ) )( attributes );
 			}
 			const updatedClassName = attributes.className?.includes(
 				'has-background'

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -14,7 +14,6 @@ import { useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import InspectorControls from '../components/inspector-controls';
-import { useBlockEditContext } from '../components/block-edit/context';
 import { cleanEmptyObject } from './utils';
 import { store as blockEditorStore } from '../store';
 import {
@@ -177,6 +176,7 @@ function BackgroundInspectorControl( {
 export function BackgroundImagePanel( {
 	clientId,
 	name,
+	setAttributes,
 	settings,
 	selectedState = 'default',
 } ) {
@@ -202,7 +202,6 @@ export function BackgroundImagePanel( {
 		[ clientId, name ]
 	);
 
-	const { setAttributes } = useBlockEditContext();
 	const [ style, setStyle ] = useBlockStyle( null, selectedState );
 	const isStateSelected = selectedState !== 'default';
 

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -31,7 +31,8 @@ import {
 	BorderPanel as StylesBorderPanel,
 } from '../components/global-styles';
 import { store as blockEditorStore } from '../store';
-import { useBlockStateProps } from './state-utils';
+import { useBlockEditContext } from '../components/block-edit/context';
+import { useBlockStyle } from './use-block-style';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
 export const SHADOW_SUPPORT_KEY = 'shadow';
@@ -157,39 +158,36 @@ function BordersInspectorControl( {
 export function BorderPanel( {
 	clientId,
 	name,
-	setAttributes,
 	settings,
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasBorderPanel( settings );
-	const { style, borderColor } = useSelect(
+	const { borderColor } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
 			if ( ! isEnabled ) {
 				return {};
 			}
-			const { style: _style, borderColor: _borderColor } =
+			const { borderColor: _borderColor } =
 				select( blockEditorStore ).getBlockAttributes( clientId ) || {};
-			return { style: _style, borderColor: _borderColor };
+			return { borderColor: _borderColor };
 		},
 		[ clientId, isEnabled ]
 	);
 
-	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
-		selectedState,
-		style,
-		setAttributes,
-	} );
+	const { setAttributes } = useBlockEditContext();
+	const [ style, setStyle ] = useBlockStyle( null, selectedState );
+	const isStateSelected = selectedState !== 'default';
 
 	const value = useMemo( () => {
 		if ( isStateSelected ) {
-			return stateValue;
+			return style;
 		}
 		return attributesToStyle( { style, borderColor } );
-	}, [ isStateSelected, stateValue, style, borderColor ] );
+	}, [ isStateSelected, style, borderColor ] );
 
 	const onChange = isStateSelected
-		? stateOnChange
+		? setStyle
 		: ( newStyle ) => {
 				setAttributes( styleToAttributes( newStyle ) );
 		  };

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -31,7 +31,6 @@ import {
 	BorderPanel as StylesBorderPanel,
 } from '../components/global-styles';
 import { store as blockEditorStore } from '../store';
-import { useBlockEditContext } from '../components/block-edit/context';
 import { useBlockStyle } from './use-block-style';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
@@ -158,6 +157,7 @@ function BordersInspectorControl( {
 export function BorderPanel( {
 	clientId,
 	name,
+	setAttributes,
 	settings,
 	selectedState = 'default',
 } ) {
@@ -175,7 +175,6 @@ export function BorderPanel( {
 		[ clientId, isEnabled ]
 	);
 
-	const { setAttributes } = useBlockEditContext();
 	const [ style, setStyle ] = useBlockStyle( null, selectedState );
 	const isStateSelected = selectedState !== 'default';
 

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -31,6 +31,7 @@ import {
 	BorderPanel as StylesBorderPanel,
 } from '../components/global-styles';
 import { store as blockEditorStore } from '../store';
+import { useBlockStateProps } from './state-utils';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
 export const SHADOW_SUPPORT_KEY = 'shadow';
@@ -161,7 +162,6 @@ export function BorderPanel( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasBorderPanel( settings );
-	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 	const { style, borderColor } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
@@ -174,21 +174,22 @@ export function BorderPanel( {
 		},
 		[ clientId, isEnabled ]
 	);
+
+	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
+		selectedState,
+		style,
+		setAttributes,
+	} );
+
 	const value = useMemo( () => {
 		if ( isStateSelected ) {
-			return style?.[ selectedState ];
+			return stateValue;
 		}
 		return attributesToStyle( { style, borderColor } );
-	}, [ isStateSelected, selectedState, style, borderColor ] );
+	}, [ isStateSelected, stateValue, style, borderColor ] );
 
 	const onChange = isStateSelected
-		? ( newStateStyle ) =>
-				setAttributes( {
-					style: cleanEmptyObject( {
-						...style,
-						[ selectedState ]: newStateStyle,
-					} ),
-				} )
+		? stateOnChange
 		: ( newStyle ) => {
 				setAttributes( styleToAttributes( newStyle ) );
 		  };

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -11,6 +11,7 @@ import { __experimentalHasSplitBorders as hasSplitBorders } from '@wordpress/com
 import { Platform, useCallback, useMemo } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -29,7 +30,6 @@ import {
 	BorderPanel as StylesBorderPanel,
 } from '../components/global-styles';
 import { store as blockEditorStore } from '../store';
-import { __ } from '@wordpress/i18n';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
 export const SHADOW_SUPPORT_KEY = 'shadow';
@@ -140,8 +140,15 @@ function BordersInspectorControl( { label, children, resetAllFilter } ) {
 	);
 }
 
-export function BorderPanel( { clientId, name, setAttributes, settings } ) {
+export function BorderPanel( {
+	clientId,
+	name,
+	setAttributes,
+	settings,
+	selectedState = 'default',
+} ) {
 	const isEnabled = useHasBorderPanel( settings );
+	const isStateMode = !! ( selectedState && selectedState !== 'default' );
 	const { style, borderColor } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
@@ -155,12 +162,23 @@ export function BorderPanel( { clientId, name, setAttributes, settings } ) {
 		[ clientId, isEnabled ]
 	);
 	const value = useMemo( () => {
+		if ( isStateMode ) {
+			return style?.[ selectedState ];
+		}
 		return attributesToStyle( { style, borderColor } );
-	}, [ style, borderColor ] );
+	}, [ isStateMode, selectedState, style, borderColor ] );
 
-	const onChange = ( newStyle ) => {
-		setAttributes( styleToAttributes( newStyle ) );
-	};
+	const onChange = isStateMode
+		? ( newStateStyle ) =>
+				setAttributes( {
+					style: cleanEmptyObject( {
+						...style,
+						[ selectedState ]: newStateStyle,
+					} ),
+				} )
+		: ( newStyle ) => {
+				setAttributes( styleToAttributes( newStyle ) );
+		  };
 
 	if ( ! isEnabled ) {
 		return null;

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -23,6 +23,7 @@ import {
 	cleanEmptyObject,
 	shouldSkipSerialization,
 	useBlockSettings,
+	buildStateResetAllFilter,
 } from './utils';
 import {
 	useHasBorderPanel,
@@ -116,9 +117,21 @@ function attributesToStyle( attributes ) {
 	};
 }
 
-function BordersInspectorControl( { label, children, resetAllFilter } ) {
+function BordersInspectorControl( {
+	label,
+	children,
+	resetAllFilter,
+	selectedState = 'default',
+} ) {
+	const isStateSelected = selectedState !== 'default';
 	const attributesResetAllFilter = useCallback(
 		( attributes ) => {
+			if ( isStateSelected ) {
+				return buildStateResetAllFilter(
+					selectedState,
+					resetAllFilter
+				)( attributes );
+			}
 			const existingStyle = attributesToStyle( attributes );
 			const updatedStyle = resetAllFilter( existingStyle );
 			return {
@@ -126,7 +139,7 @@ function BordersInspectorControl( { label, children, resetAllFilter } ) {
 				...styleToAttributes( updatedStyle ),
 			};
 		},
-		[ resetAllFilter ]
+		[ isStateSelected, selectedState, resetAllFilter ]
 	);
 
 	return (
@@ -148,7 +161,7 @@ export function BorderPanel( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasBorderPanel( settings );
-	const isStateMode = !! ( selectedState && selectedState !== 'default' );
+	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 	const { style, borderColor } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
@@ -162,13 +175,13 @@ export function BorderPanel( {
 		[ clientId, isEnabled ]
 	);
 	const value = useMemo( () => {
-		if ( isStateMode ) {
+		if ( isStateSelected ) {
 			return style?.[ selectedState ];
 		}
 		return attributesToStyle( { style, borderColor } );
-	}, [ isStateMode, selectedState, style, borderColor ] );
+	}, [ isStateSelected, selectedState, style, borderColor ] );
 
-	const onChange = isStateMode
+	const onChange = isStateSelected
 		? ( newStateStyle ) =>
 				setAttributes( {
 					style: cleanEmptyObject( {
@@ -179,6 +192,19 @@ export function BorderPanel( {
 		: ( newStyle ) => {
 				setAttributes( styleToAttributes( newStyle ) );
 		  };
+
+	const BorderWrapper = useMemo(
+		() =>
+			function BorderWrapperComponent( props ) {
+				return (
+					<BordersInspectorControl
+						{ ...props }
+						selectedState={ selectedState }
+					/>
+				);
+			},
+		[ selectedState ]
+	);
 
 	if ( ! isEnabled ) {
 		return null;
@@ -197,7 +223,7 @@ export function BorderPanel( {
 
 	return (
 		<StylesBorderPanel
-			as={ BordersInspectorControl }
+			as={ BorderWrapper }
 			panelId={ clientId }
 			settings={ settings }
 			value={ value }

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -34,7 +34,7 @@ import {
 } from '../components/global-styles/color-panel';
 import BlockColorContrastChecker from './contrast-checker';
 import { store as blockEditorStore } from '../store';
-import { useBlockStateProps } from './state-utils';
+import { useBlockStyle } from './use-block-style';
 
 export const COLOR_SUPPORT_KEY = 'color';
 
@@ -285,20 +285,18 @@ export function ColorEdit( {
 } ) {
 	const isEnabled = useHasColorPanel( settings );
 
-	const { style, textColor, backgroundColor, gradient } = useSelect(
+	const { textColor, backgroundColor, gradient } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
 			if ( ! isEnabled ) {
 				return {};
 			}
 			const {
-				style: _style,
 				textColor: _textColor,
 				backgroundColor: _backgroundColor,
 				gradient: _gradient,
 			} = select( blockEditorStore ).getBlockAttributes( clientId ) || {};
 			return {
-				style: _style,
 				textColor: _textColor,
 				backgroundColor: _backgroundColor,
 				gradient: _gradient,
@@ -307,15 +305,12 @@ export function ColorEdit( {
 		[ clientId, isEnabled ]
 	);
 
-	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
-		selectedState,
-		style,
-		setAttributes,
-	} );
+	const [ style, setStyle ] = useBlockStyle( null, selectedState );
+	const isStateSelected = selectedState !== 'default';
 
 	const value = useMemo( () => {
 		if ( isStateSelected ) {
-			return stateValue;
+			return style;
 		}
 		return attributesToStyle( {
 			style,
@@ -323,17 +318,10 @@ export function ColorEdit( {
 			backgroundColor,
 			gradient,
 		} );
-	}, [
-		isStateSelected,
-		stateValue,
-		style,
-		textColor,
-		backgroundColor,
-		gradient,
-	] );
+	}, [ isStateSelected, style, textColor, backgroundColor, gradient ] );
 
 	const onChange = isStateSelected
-		? stateOnChange
+		? setStyle
 		: ( newStyle ) => {
 				setAttributes( styleToAttributes( newStyle ) );
 		  };

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -268,8 +268,10 @@ export function ColorEdit( {
 	asWrapper,
 	label,
 	defaultControls,
+	selectedState = 'default',
 } ) {
 	const isEnabled = useHasColorPanel( settings );
+	const isStateMode = !! ( selectedState && selectedState !== 'default' );
 
 	const { style, textColor, backgroundColor, gradient } = useSelect(
 		( select ) => {
@@ -293,17 +295,35 @@ export function ColorEdit( {
 		[ clientId, isEnabled ]
 	);
 	const value = useMemo( () => {
+		if ( isStateMode ) {
+			return style?.[ selectedState ];
+		}
 		return attributesToStyle( {
 			style,
 			textColor,
 			backgroundColor,
 			gradient,
 		} );
-	}, [ style, textColor, backgroundColor, gradient ] );
+	}, [
+		isStateMode,
+		selectedState,
+		style,
+		textColor,
+		backgroundColor,
+		gradient,
+	] );
 
-	const onChange = ( newStyle ) => {
-		setAttributes( styleToAttributes( newStyle ) );
-	};
+	const onChange = isStateMode
+		? ( newStateStyle ) =>
+				setAttributes( {
+					style: cleanEmptyObject( {
+						...style,
+						[ selectedState ]: newStateStyle,
+					} ),
+				} )
+		: ( newStyle ) => {
+				setAttributes( styleToAttributes( newStyle ) );
+		  };
 
 	if ( ! isEnabled ) {
 		return null;
@@ -317,6 +337,7 @@ export function ColorEdit( {
 		  ] );
 
 	const enableContrastChecking =
+		! isStateMode &&
 		Platform.OS === 'web' &&
 		! value?.color?.gradient &&
 		( settings?.color?.text || settings?.color?.link ) &&

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -23,6 +23,7 @@ import {
 	cleanEmptyObject,
 	transformStyles,
 	shouldSkipSerialization,
+	buildStateResetAllFilter,
 } from './utils';
 import { getBackgroundImageClasses } from './background';
 import { useSettings } from '../components/use-settings';
@@ -237,9 +238,20 @@ function attributesToStyle( attributes ) {
 	};
 }
 
-function ColorInspectorControl( { children, resetAllFilter } ) {
+function ColorInspectorControl( {
+	children,
+	resetAllFilter,
+	selectedState = 'default',
+} ) {
+	const isStateSelected = selectedState !== 'default';
 	const attributesResetAllFilter = useCallback(
 		( attributes ) => {
+			if ( isStateSelected ) {
+				return buildStateResetAllFilter(
+					selectedState,
+					resetAllFilter
+				)( attributes );
+			}
 			const existingStyle = attributesToStyle( attributes );
 			const updatedStyle = resetAllFilter( existingStyle );
 			return {
@@ -247,7 +259,7 @@ function ColorInspectorControl( { children, resetAllFilter } ) {
 				...styleToAttributes( updatedStyle ),
 			};
 		},
-		[ resetAllFilter ]
+		[ isStateSelected, selectedState, resetAllFilter ]
 	);
 
 	return (
@@ -271,7 +283,7 @@ export function ColorEdit( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasColorPanel( settings );
-	const isStateMode = !! ( selectedState && selectedState !== 'default' );
+	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 
 	const { style, textColor, backgroundColor, gradient } = useSelect(
 		( select ) => {
@@ -295,7 +307,7 @@ export function ColorEdit( {
 		[ clientId, isEnabled ]
 	);
 	const value = useMemo( () => {
-		if ( isStateMode ) {
+		if ( isStateSelected ) {
 			return style?.[ selectedState ];
 		}
 		return attributesToStyle( {
@@ -305,7 +317,7 @@ export function ColorEdit( {
 			gradient,
 		} );
 	}, [
-		isStateMode,
+		isStateSelected,
 		selectedState,
 		style,
 		textColor,
@@ -313,7 +325,7 @@ export function ColorEdit( {
 		gradient,
 	] );
 
-	const onChange = isStateMode
+	const onChange = isStateSelected
 		? ( newStateStyle ) =>
 				setAttributes( {
 					style: cleanEmptyObject( {
@@ -324,6 +336,14 @@ export function ColorEdit( {
 		: ( newStyle ) => {
 				setAttributes( styleToAttributes( newStyle ) );
 		  };
+
+	const Wrapper = useMemo( () => {
+		const Base = asWrapper || ColorInspectorControl;
+		function ColorWrapper( props ) {
+			return <Base { ...props } selectedState={ selectedState } />;
+		}
+		return ColorWrapper;
+	}, [ asWrapper, selectedState ] );
 
 	if ( ! isEnabled ) {
 		return null;
@@ -337,7 +357,7 @@ export function ColorEdit( {
 		  ] );
 
 	const enableContrastChecking =
-		! isStateMode &&
+		! isStateSelected &&
 		Platform.OS === 'web' &&
 		! value?.color?.gradient &&
 		( settings?.color?.text || settings?.color?.link ) &&
@@ -349,9 +369,6 @@ export function ColorEdit( {
 				COLOR_SUPPORT_KEY,
 				'enableContrastChecker',
 			] );
-
-	// Use provided wrapper or default to ColorInspectorControl
-	const Wrapper = asWrapper || ColorInspectorControl;
 
 	return (
 		<StylesColorPanel

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -34,6 +34,7 @@ import {
 } from '../components/global-styles/color-panel';
 import BlockColorContrastChecker from './contrast-checker';
 import { store as blockEditorStore } from '../store';
+import { useBlockStateProps } from './state-utils';
 
 export const COLOR_SUPPORT_KEY = 'color';
 
@@ -283,7 +284,6 @@ export function ColorEdit( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasColorPanel( settings );
-	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 
 	const { style, textColor, backgroundColor, gradient } = useSelect(
 		( select ) => {
@@ -306,9 +306,16 @@ export function ColorEdit( {
 		},
 		[ clientId, isEnabled ]
 	);
+
+	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
+		selectedState,
+		style,
+		setAttributes,
+	} );
+
 	const value = useMemo( () => {
 		if ( isStateSelected ) {
-			return style?.[ selectedState ];
+			return stateValue;
 		}
 		return attributesToStyle( {
 			style,
@@ -318,7 +325,7 @@ export function ColorEdit( {
 		} );
 	}, [
 		isStateSelected,
-		selectedState,
+		stateValue,
 		style,
 		textColor,
 		backgroundColor,
@@ -326,13 +333,7 @@ export function ColorEdit( {
 	] );
 
 	const onChange = isStateSelected
-		? ( newStateStyle ) =>
-				setAttributes( {
-					style: cleanEmptyObject( {
-						...style,
-						[ selectedState ]: newStateStyle,
-					} ),
-				} )
+		? stateOnChange
 		: ( newStyle ) => {
 				setAttributes( styleToAttributes( newStyle ) );
 		  };

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -6,7 +6,13 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { Platform, useState, useEffect, useCallback } from '@wordpress/element';
+import {
+	Platform,
+	useState,
+	useEffect,
+	useCallback,
+	useMemo,
+} from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { getBlockSupport } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
@@ -22,7 +28,11 @@ import {
 import { MarginVisualizer, PaddingVisualizer } from './spacing-visualizer';
 import { store as blockEditorStore } from '../store';
 import { unlock } from '../lock-unlock';
-import { cleanEmptyObject, shouldSkipSerialization } from './utils';
+import {
+	cleanEmptyObject,
+	shouldSkipSerialization,
+	buildStateResetAllFilter,
+} from './utils';
 
 export const DIMENSIONS_SUPPORT_KEY = 'dimensions';
 export const SPACING_SUPPORT_KEY = 'spacing';
@@ -45,9 +55,20 @@ function useVisualizer() {
 	return [ property, setProperty ];
 }
 
-function DimensionsInspectorControl( { children, resetAllFilter } ) {
+function DimensionsInspectorControl( {
+	children,
+	resetAllFilter,
+	selectedState = 'default',
+} ) {
+	const isStateSelected = selectedState !== 'default';
 	const attributesResetAllFilter = useCallback(
 		( attributes ) => {
+			if ( isStateSelected ) {
+				return buildStateResetAllFilter(
+					selectedState,
+					resetAllFilter
+				)( attributes );
+			}
 			const existingStyle = attributes.style;
 			const updatedStyle = resetAllFilter( existingStyle );
 			return {
@@ -55,7 +76,7 @@ function DimensionsInspectorControl( { children, resetAllFilter } ) {
 				style: updatedStyle,
 			};
 		},
-		[ resetAllFilter ]
+		[ isStateSelected, selectedState, resetAllFilter ]
 	);
 
 	return (
@@ -76,7 +97,7 @@ export function DimensionsPanel( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasDimensionsPanel( settings );
-	const isStateMode = !! ( selectedState && selectedState !== 'default' );
+	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 	const style = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
@@ -91,8 +112,8 @@ export function DimensionsPanel( {
 
 	const [ visualizedProperty, setVisualizedProperty ] = useVisualizer();
 
-	const value = isStateMode ? style?.[ selectedState ] : style;
-	const onChange = isStateMode
+	const value = isStateSelected ? style?.[ selectedState ] : style;
+	const onChange = isStateSelected
 		? ( newStateStyle ) =>
 				setAttributes( {
 					style: cleanEmptyObject( {
@@ -104,6 +125,19 @@ export function DimensionsPanel( {
 				setAttributes( {
 					style: cleanEmptyObject( newStyle ),
 				} );
+
+	const DimensionsWrapper = useMemo(
+		() =>
+			function DimensionsWrapperComponent( props ) {
+				return (
+					<DimensionsInspectorControl
+						{ ...props }
+						selectedState={ selectedState }
+					/>
+				);
+			},
+		[ selectedState ]
+	);
 
 	if ( ! isEnabled ) {
 		return null;
@@ -125,15 +159,17 @@ export function DimensionsPanel( {
 	return (
 		<>
 			<StylesDimensionsPanel
-				as={ DimensionsInspectorControl }
+				as={ DimensionsWrapper }
 				panelId={ clientId }
 				settings={ settings }
 				value={ value }
 				onChange={ onChange }
 				defaultControls={ defaultControls }
-				onVisualize={ isStateMode ? undefined : setVisualizedProperty }
+				onVisualize={
+					isStateSelected ? undefined : setVisualizedProperty
+				}
 			/>
-			{ ! isStateMode &&
+			{ ! isStateSelected &&
 				!! settings?.spacing?.padding &&
 				visualizedProperty === 'padding' && (
 					<PaddingVisualizer
@@ -142,7 +178,7 @@ export function DimensionsPanel( {
 						value={ value }
 					/>
 				) }
-			{ ! isStateMode &&
+			{ ! isStateSelected &&
 				!! settings?.spacing?.margin &&
 				visualizedProperty === 'margin' && (
 					<MarginVisualizer

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -33,6 +33,7 @@ import {
 	shouldSkipSerialization,
 	buildStateResetAllFilter,
 } from './utils';
+import { useBlockStateProps } from './state-utils';
 
 export const DIMENSIONS_SUPPORT_KEY = 'dimensions';
 export const SPACING_SUPPORT_KEY = 'spacing';
@@ -97,7 +98,6 @@ export function DimensionsPanel( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasDimensionsPanel( settings );
-	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 	const style = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
@@ -112,15 +112,15 @@ export function DimensionsPanel( {
 
 	const [ visualizedProperty, setVisualizedProperty ] = useVisualizer();
 
-	const value = isStateSelected ? style?.[ selectedState ] : style;
+	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
+		selectedState,
+		style,
+		setAttributes,
+	} );
+
+	const value = isStateSelected ? stateValue : style;
 	const onChange = isStateSelected
-		? ( newStateStyle ) =>
-				setAttributes( {
-					style: cleanEmptyObject( {
-						...style,
-						[ selectedState ]: newStateStyle,
-					} ),
-				} )
+		? stateOnChange
 		: ( newStyle ) =>
 				setAttributes( {
 					style: cleanEmptyObject( newStyle ),

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -13,7 +13,7 @@ import {
 	useCallback,
 	useMemo,
 } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { getBlockSupport } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
 
@@ -28,12 +28,8 @@ import {
 import { MarginVisualizer, PaddingVisualizer } from './spacing-visualizer';
 import { store as blockEditorStore } from '../store';
 import { unlock } from '../lock-unlock';
-import {
-	cleanEmptyObject,
-	shouldSkipSerialization,
-	buildStateResetAllFilter,
-} from './utils';
-import { useBlockStateProps } from './state-utils';
+import { shouldSkipSerialization, buildStateResetAllFilter } from './utils';
+import { useBlockStyle } from './use-block-style';
 
 export const DIMENSIONS_SUPPORT_KEY = 'dimensions';
 export const SPACING_SUPPORT_KEY = 'spacing';
@@ -93,38 +89,13 @@ function DimensionsInspectorControl( {
 export function DimensionsPanel( {
 	clientId,
 	name,
-	setAttributes,
 	settings,
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasDimensionsPanel( settings );
-	const style = useSelect(
-		( select ) => {
-			// Early return to avoid subscription when disabled
-			if ( ! isEnabled ) {
-				return undefined;
-			}
-			return select( blockEditorStore ).getBlockAttributes( clientId )
-				?.style;
-		},
-		[ clientId, isEnabled ]
-	);
-
+	const isStateSelected = selectedState !== 'default';
 	const [ visualizedProperty, setVisualizedProperty ] = useVisualizer();
-
-	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
-		selectedState,
-		style,
-		setAttributes,
-	} );
-
-	const value = isStateSelected ? stateValue : style;
-	const onChange = isStateSelected
-		? stateOnChange
-		: ( newStyle ) =>
-				setAttributes( {
-					style: cleanEmptyObject( newStyle ),
-				} );
+	const [ value, onChange ] = useBlockStyle( null, selectedState );
 
 	const DimensionsWrapper = useMemo(
 		() =>

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -68,9 +68,16 @@ function DimensionsInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
+export function DimensionsPanel( {
+	clientId,
+	name,
+	setAttributes,
+	settings,
+	selectedState = 'default',
+} ) {
 	const isEnabled = useHasDimensionsPanel( settings );
-	const value = useSelect(
+	const isStateMode = !! ( selectedState && selectedState !== 'default' );
+	const style = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
 			if ( ! isEnabled ) {
@@ -83,11 +90,20 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 	);
 
 	const [ visualizedProperty, setVisualizedProperty ] = useVisualizer();
-	const onChange = ( newStyle ) => {
-		setAttributes( {
-			style: cleanEmptyObject( newStyle ),
-		} );
-	};
+
+	const value = isStateMode ? style?.[ selectedState ] : style;
+	const onChange = isStateMode
+		? ( newStateStyle ) =>
+				setAttributes( {
+					style: cleanEmptyObject( {
+						...style,
+						[ selectedState ]: newStateStyle,
+					} ),
+				} )
+		: ( newStyle ) =>
+				setAttributes( {
+					style: cleanEmptyObject( newStyle ),
+				} );
 
 	if ( ! isEnabled ) {
 		return null;
@@ -115,9 +131,10 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 				value={ value }
 				onChange={ onChange }
 				defaultControls={ defaultControls }
-				onVisualize={ setVisualizedProperty }
+				onVisualize={ isStateMode ? undefined : setVisualizedProperty }
 			/>
-			{ !! settings?.spacing?.padding &&
+			{ ! isStateMode &&
+				!! settings?.spacing?.padding &&
 				visualizedProperty === 'padding' && (
 					<PaddingVisualizer
 						forceShow={ visualizedProperty === 'padding' }
@@ -125,7 +142,8 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 						value={ value }
 					/>
 				) }
-			{ !! settings?.spacing?.margin &&
+			{ ! isStateMode &&
+				!! settings?.spacing?.margin &&
 				visualizedProperty === 'margin' && (
 					<MarginVisualizer
 						forceShow={ visualizedProperty === 'margin' }

--- a/packages/block-editor/src/hooks/state-utils.js
+++ b/packages/block-editor/src/hooks/state-utils.js
@@ -2,11 +2,35 @@
  * WordPress dependencies
  */
 import { getBlockType } from '@wordpress/blocks';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { scopeSelector } from '../components/global-styles/utils';
+
+/**
+ * Recursively removes undefined and empty-object values.
+ * Duplicated here to avoid a circular dependency with ./utils.
+ *
+ * @param {*} object
+ * @return {*} Cleaned value.
+ */
+function cleanEmptyObject( object ) {
+	if (
+		object === null ||
+		typeof object !== 'object' ||
+		Array.isArray( object )
+	) {
+		return object;
+	}
+	const cleanedNestedObjects = Object.entries( object )
+		.map( ( [ key, value ] ) => [ key, cleanEmptyObject( value ) ] )
+		.filter( ( [ , value ] ) => value !== undefined );
+	return ! cleanedNestedObjects.length
+		? undefined
+		: Object.fromEntries( cleanedNestedObjects );
+}
 
 /**
  * Given a block's `selectors.root` value, returns the part of the selector
@@ -82,4 +106,37 @@ export function buildCanvasStateSelector( clientId, name ) {
 		}
 	}
 	return `[data-block="${ clientId }"]`;
+}
+
+/**
+ * Shared hook for block style panels that support interactive states
+ * (hover, focus, active). Encapsulates the repeated boilerplate for
+ * determining whether a state is selected, reading the scoped style value,
+ * and building the state-scoped onChange handler.
+ *
+ * @param {Object}   options
+ * @param {string}   options.selectedState Currently selected state, e.g. ':hover'. Defaults to 'default'.
+ * @param {Object}   options.style         The block's `style` attribute.
+ * @param {Function} options.setAttributes The block's setAttributes function.
+ * @return {{ isStateSelected: boolean, stateValue: Object|undefined, stateOnChange: Function }} State props.
+ */
+export function useBlockStateProps( { selectedState, style, setAttributes } ) {
+	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
+
+	const stateOnChange = useCallback(
+		( newStateStyle ) =>
+			setAttributes( {
+				style: cleanEmptyObject( {
+					...style,
+					[ selectedState ]: newStateStyle,
+				} ),
+			} ),
+		[ setAttributes, style, selectedState ]
+	);
+
+	return {
+		isStateSelected,
+		stateValue: isStateSelected ? style?.[ selectedState ] : undefined,
+		stateOnChange,
+	};
 }

--- a/packages/block-editor/src/hooks/state-utils.js
+++ b/packages/block-editor/src/hooks/state-utils.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { __EXPERIMENTAL_ELEMENTS as ELEMENTS } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { scopeSelector } from '../components/global-styles/utils';
+
+export const STATES_ELEMENT_SUPPORT_KEY = '__experimentalStatesElement';
+
+/**
+ * Builds the scoped CSS selector for a block state (e.g. :hover, :focus).
+ *
+ * When the block declares `__experimentalStatesElement` pointing to a known
+ * ELEMENTS key (e.g. "button"), the pseudo-class is appended to each
+ * comma-separated element selector part and the result is scoped under
+ * `baseSelector`. Otherwise falls back to appending the state directly to
+ * `baseSelector` (i.e. the block wrapper).
+ *
+ * @param {string}      baseSelector  The block-instance scoping class selector.
+ * @param {string|null} statesElement Value of `__experimentalStatesElement` support, or null.
+ * @param {string}      state         The pseudo-class string, e.g. ":hover".
+ * @return {string} The fully-scoped CSS selector for this state.
+ */
+export function buildStateSelector( baseSelector, statesElement, state ) {
+	if ( statesElement && ELEMENTS[ statesElement ] ) {
+		const elementParts = ELEMENTS[ statesElement ]
+			.split( ',' )
+			.map( ( part ) => part.trim() + state )
+			.join( ', ' );
+		return scopeSelector( baseSelector, elementParts );
+	}
+	return `${ baseSelector }${ state }`;
+}

--- a/packages/block-editor/src/hooks/state-utils.js
+++ b/packages/block-editor/src/hooks/state-utils.js
@@ -2,35 +2,11 @@
  * WordPress dependencies
  */
 import { getBlockType } from '@wordpress/blocks';
-import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { scopeSelector } from '../components/global-styles/utils';
-
-/**
- * Recursively removes undefined and empty-object values.
- * Duplicated here to avoid a circular dependency with ./utils.
- *
- * @param {*} object
- * @return {*} Cleaned value.
- */
-function cleanEmptyObject( object ) {
-	if (
-		object === null ||
-		typeof object !== 'object' ||
-		Array.isArray( object )
-	) {
-		return object;
-	}
-	const cleanedNestedObjects = Object.entries( object )
-		.map( ( [ key, value ] ) => [ key, cleanEmptyObject( value ) ] )
-		.filter( ( [ , value ] ) => value !== undefined );
-	return ! cleanedNestedObjects.length
-		? undefined
-		: Object.fromEntries( cleanedNestedObjects );
-}
 
 /**
  * Given a block's `selectors.root` value, returns the part of the selector
@@ -106,37 +82,4 @@ export function buildCanvasStateSelector( clientId, name ) {
 		}
 	}
 	return `[data-block="${ clientId }"]`;
-}
-
-/**
- * Shared hook for block style panels that support interactive states
- * (hover, focus, active). Encapsulates the repeated boilerplate for
- * determining whether a state is selected, reading the scoped style value,
- * and building the state-scoped onChange handler.
- *
- * @param {Object}   options
- * @param {string}   options.selectedState Currently selected state, e.g. ':hover'. Defaults to 'default'.
- * @param {Object}   options.style         The block's `style` attribute.
- * @param {Function} options.setAttributes The block's setAttributes function.
- * @return {{ isStateSelected: boolean, stateValue: Object|undefined, stateOnChange: Function }} State props.
- */
-export function useBlockStateProps( { selectedState, style, setAttributes } ) {
-	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
-
-	const stateOnChange = useCallback(
-		( newStateStyle ) =>
-			setAttributes( {
-				style: cleanEmptyObject( {
-					...style,
-					[ selectedState ]: newStateStyle,
-				} ),
-			} ),
-		[ setAttributes, style, selectedState ]
-	);
-
-	return {
-		isStateSelected,
-		stateValue: isStateSelected ? style?.[ selectedState ] : undefined,
-		stateOnChange,
-	};
 }

--- a/packages/block-editor/src/hooks/state-utils.js
+++ b/packages/block-editor/src/hooks/state-utils.js
@@ -1,36 +1,61 @@
 /**
  * WordPress dependencies
  */
-import { __EXPERIMENTAL_ELEMENTS as ELEMENTS } from '@wordpress/blocks';
+import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import { scopeSelector } from '../components/global-styles/utils';
 
-export const STATES_ELEMENT_SUPPORT_KEY = '__experimentalStatesElement';
+/**
+ * Given a block's `selectors.root` value, returns the part of the selector
+ * that is relative to the block wrapper — i.e., everything after the first
+ * compound selector segment.
+ *
+ * Examples:
+ *   ".wp-block-button .wp-block-button__link" → ".wp-block-button__link"
+ *   ".wp-block-foo > .inner"                 → "> .inner"
+ *   ".wp-block-foo"                          → null (no descendant)
+ *
+ * @param {string} rootSelector The block's `selectors.root` value.
+ * @return {string|null} Relative selector, or null if rootSelector targets the wrapper itself.
+ */
+export function getRelativeRootSelector( rootSelector ) {
+	// Match everything after the first compound selector (up to the first
+	// whitespace or combinator character).
+	// Require at least one combinator character (space, >, +, ~) between the
+	// first compound selector and the rest. Without this anchor, a greedy
+	// quantifier would backtrack into the first token and produce false matches.
+	const match = rootSelector.trim().match( /^[^ >+~]+[ >+~](.*)$/ );
+	if ( ! match ) {
+		return null;
+	}
+	const rest = match[ 1 ].trim();
+	return rest || null;
+}
 
 /**
  * Builds the scoped CSS selector for a block state (e.g. :hover, :focus).
  *
- * When the block declares `__experimentalStatesElement` pointing to a known
- * ELEMENTS key (e.g. "button"), the pseudo-class is appended to each
- * comma-separated element selector part and the result is scoped under
- * `baseSelector`. Otherwise falls back to appending the state directly to
- * `baseSelector` (i.e. the block wrapper).
+ * Uses the block's `selectors.root` to determine which element the state
+ * pseudo-class should apply to. If `selectors.root` describes a descendant
+ * element (e.g. ".wp-block-button .wp-block-button__link"), the relative
+ * portion (".wp-block-button__link") is scoped under `baseSelector`. If no
+ * descendant is present, falls back to appending the state to `baseSelector`.
  *
- * @param {string}      baseSelector  The block-instance scoping class selector.
- * @param {string|null} statesElement Value of `__experimentalStatesElement` support, or null.
- * @param {string}      state         The pseudo-class string, e.g. ":hover".
+ * @param {string} baseSelector The block-instance scoping class selector.
+ * @param {string} name         The block name, used to look up selectors.
+ * @param {string} state        The pseudo-class string, e.g. ":hover".
  * @return {string} The fully-scoped CSS selector for this state.
  */
-export function buildStateSelector( baseSelector, statesElement, state ) {
-	if ( statesElement && ELEMENTS[ statesElement ] ) {
-		const elementParts = ELEMENTS[ statesElement ]
-			.split( ',' )
-			.map( ( part ) => part.trim() + state )
-			.join( ', ' );
-		return scopeSelector( baseSelector, elementParts );
+export function buildStateSelector( baseSelector, name, state ) {
+	const rootSelector = getBlockType( name )?.selectors?.root;
+	if ( rootSelector ) {
+		const relativeSelector = getRelativeRootSelector( rootSelector );
+		if ( relativeSelector ) {
+			return scopeSelector( baseSelector, relativeSelector + state );
+		}
 	}
 	return `${ baseSelector }${ state }`;
 }

--- a/packages/block-editor/src/hooks/state-utils.js
+++ b/packages/block-editor/src/hooks/state-utils.js
@@ -59,3 +59,27 @@ export function buildStateSelector( baseSelector, name, state ) {
 	}
 	return `${ baseSelector }${ state }`;
 }
+
+/**
+ * Builds the CSS selector used to preview a state on the editor canvas,
+ * scoped to a specific block instance via its `data-block` attribute.
+ *
+ * For blocks whose `selectors.root` targets a descendant element
+ * (e.g. ".wp-block-button .wp-block-button__link"), the selector targets
+ * that descendant inside the block wrapper. Otherwise it targets the wrapper
+ * itself.
+ *
+ * @param {string} clientId The block's clientId.
+ * @param {string} name     The block name, used to look up selectors.
+ * @return {string} CSS selector scoped to this block instance.
+ */
+export function buildCanvasStateSelector( clientId, name ) {
+	const rootSelector = getBlockType( name )?.selectors?.root;
+	if ( rootSelector ) {
+		const relativeSelector = getRelativeRootSelector( rootSelector );
+		if ( relativeSelector ) {
+			return `[data-block="${ clientId }"] ${ relativeSelector }`;
+		}
+	}
+	return `[data-block="${ clientId }"]`;
+}

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 import StateControl from '../components/global-styles/state-control';
 import { BlockCardControlsFill } from '../components/block-card';
 
-export const STATES_SUPPORT_KEY = '__experimentalStates';
+export const STATES_SUPPORT_KEY = 'states';
 
 export const STATE_LABELS = {
 	':hover': __( 'Hover' ),
@@ -20,7 +20,7 @@ export const STATE_LABELS = {
 
 /**
  * Renders a state selector (hover, focus, active) in the block card header.
- * Only shown for blocks that declare `__experimentalStates` support.
+ * Only shown for blocks that declare `states` support.
  *
  * @param {Object}   props          Component props.
  * @param {string}   props.name     Block name.

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -7,8 +7,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { unlock } from '../lock-unlock';
-import { privateApis as blockEditorPrivateApis } from '../private-apis';
+import StateControl from '../components/global-styles/state-control';
+import { BlockCardControlsFill } from '../components/block-card';
 
 export const STATES_SUPPORT_KEY = '__experimentalStates';
 
@@ -17,10 +17,6 @@ export const STATE_LABELS = {
 	':focus': __( 'Focus' ),
 	':active': __( 'Active' ),
 };
-
-const { StateControl, BlockCardControlsFill } = unlock(
-	blockEditorPrivateApis
-);
 
 /**
  * Renders a state selector (hover, focus, active) in the block card header.

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlockSupport } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+import { privateApis as blockEditorPrivateApis } from '../private-apis';
+
+export const STATES_SUPPORT_KEY = '__experimentalStates';
+
+export const STATE_LABELS = {
+	':hover': __( 'Hover' ),
+	':focus': __( 'Focus' ),
+	':active': __( 'Active' ),
+};
+
+const { StateControl, BlockCardControlsFill } = unlock(
+	blockEditorPrivateApis
+);
+
+/**
+ * Renders a state selector (hover, focus, active) in the block card header.
+ * Only shown for blocks that declare `__experimentalStates` support.
+ *
+ * @param {Object}   props          Component props.
+ * @param {string}   props.name     Block name.
+ * @param {string}   props.value    Currently selected state value.
+ * @param {Function} props.onChange Callback when selection changes.
+ * @return {Element|null} State control component, or null if not applicable.
+ */
+export function BlockStatesControl( { name, value, onChange } ) {
+	const validStates = getBlockSupport( name, STATES_SUPPORT_KEY ) ?? [];
+	const stateOptions = validStates
+		.filter( ( state ) => STATE_LABELS[ state ] )
+		.map( ( state ) => ( { value: state, label: STATE_LABELS[ state ] } ) );
+
+	if ( ! stateOptions.length ) {
+		return null;
+	}
+
+	return (
+		<BlockCardControlsFill>
+			<StateControl
+				states={ stateOptions }
+				value={ value }
+				onChange={ onChange }
+				showText={ false }
+			/>
+		</BlockCardControlsFill>
+	);
+}

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -19,24 +19,37 @@ export const STATE_LABELS = {
 };
 
 /**
- * Renders a state selector (hover, focus, active) in the block card header.
- * Only shown for blocks that declare `states` support.
+ * Responsive state labels — available on all blocks without any block.json support declaration.
+ * Keep in sync with RESPONSIVE_BREAKPOINTS in lib/class-wp-theme-json-gutenberg.php.
+ */
+export const RESPONSIVE_STATE_LABELS = {
+	mobile: __( 'Mobile' ),
+	tablet: __( 'Tablet' ),
+};
+
+/**
+ * Renders a state selector in the block card header.
+ * Always includes responsive states (Mobile, Tablet) for all blocks.
+ * Also includes pseudo-states (:hover, :focus, :active) for blocks that
+ * declare `states` support in block.json.
  *
  * @param {Object}   props          Component props.
  * @param {string}   props.name     Block name.
  * @param {string}   props.value    Currently selected state value.
  * @param {Function} props.onChange Callback when selection changes.
- * @return {Element|null} State control component, or null if not applicable.
+ * @return {Element} State control component.
  */
 export function BlockStatesControl( { name, value, onChange } ) {
-	const validStates = getBlockSupport( name, STATES_SUPPORT_KEY ) ?? [];
-	const stateOptions = validStates
+	const pseudoStates = getBlockSupport( name, STATES_SUPPORT_KEY ) ?? [];
+	const pseudoStateOptions = pseudoStates
 		.filter( ( state ) => STATE_LABELS[ state ] )
 		.map( ( state ) => ( { value: state, label: STATE_LABELS[ state ] } ) );
 
-	if ( ! stateOptions.length ) {
-		return null;
-	}
+	const responsiveStateOptions = Object.entries(
+		RESPONSIVE_STATE_LABELS
+	).map( ( [ key, label ] ) => ( { value: key, label } ) );
+
+	const stateOptions = [ ...pseudoStateOptions, ...responsiveStateOptions ];
 
 	return (
 		<BlockCardControlsFill>

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -43,6 +43,13 @@ import { BlockInspectorPreTabsFill } from '../components/block-inspector/inspect
 import { scopeSelector } from '../components/global-styles/utils';
 import { useBlockEditingMode } from '../components/block-editing-mode';
 
+// Keep in sync with RESPONSIVE_BREAKPOINTS in
+// lib/class-wp-theme-json-gutenberg.php.
+const RESPONSIVE_STATE_MEDIA_QUERIES = {
+	mobile: '@media (width <= 480px)',
+	tablet: '@media (480px < width <= 782px)',
+};
+
 const styleSupportKeys = [
 	...TYPOGRAPHY_SUPPORT_KEYS,
 	BORDER_SUPPORT_KEY,
@@ -342,13 +349,13 @@ function BlockStyleControls( {
 	const blockEditingMode = useBlockEditingMode();
 	const [ selectedState, setSelectedState ] = useState( 'default' );
 	const [ showStateOnCanvas, setShowStateOnCanvas ] = useState( true );
+	const isPseudoSelectorState = selectedState?.startsWith( ':' );
 
-	// Inject state styles onto the editor canvas so the selected state is
+	// Inject pseudo-state styles onto the editor canvas so the selected state is
 	// visible while editing. Scoped to this block instance via data-block so
-	// other blocks of the same type are not affected. Must be called before
-	// any early returns because it is a hook.
+	// other blocks of the same type are not affected.
 	const canvasStateCSS = useMemo( () => {
-		if ( ! showStateOnCanvas || selectedState === 'default' ) {
+		if ( ! showStateOnCanvas || ! isPseudoSelectorState ) {
 			return undefined;
 		}
 		const stateValue = style?.[ selectedState ];
@@ -360,8 +367,46 @@ function BlockStyleControls( {
 		// Use !important to override utility classes (e.g. has-accent-3-color)
 		// that the block's default color support generates with !important.
 		return css ? css.replace( /;/g, ' !important;' ) : undefined;
-	}, [ showStateOnCanvas, selectedState, style, clientId, name ] );
-	useStyleOverride( { css: canvasStateCSS } );
+	}, [
+		showStateOnCanvas,
+		isPseudoSelectorState,
+		selectedState,
+		style,
+		clientId,
+		name,
+	] );
+
+	// Always emit responsive-state styles with media queries in the editor so
+	// responsive preview (or viewport resizing) displays responsive styles as
+	// on the frontend.
+	const canvasResponsiveCSS = useMemo( () => {
+		const selector = buildCanvasStateSelector( clientId, name );
+		const responsiveCSSRules = [];
+
+		Object.entries( RESPONSIVE_STATE_MEDIA_QUERIES ).forEach(
+			( [ state, mediaQuery ] ) => {
+				const responsiveStyles = style?.[ state ];
+				if ( ! responsiveStyles ) {
+					return;
+				}
+				const css = compileCSS( responsiveStyles, { selector } );
+				if ( css ) {
+					responsiveCSSRules.push( `${ mediaQuery }{${ css }}` );
+				}
+			}
+		);
+
+		return responsiveCSSRules.length > 0
+			? responsiveCSSRules.join( '' )
+			: undefined;
+	}, [ style, clientId, name ] );
+
+	useStyleOverride( {
+		css:
+			canvasStateCSS || canvasResponsiveCSS
+				? `${ canvasStateCSS || '' }${ canvasResponsiveCSS || '' }`
+				: undefined,
+	} );
 
 	if ( blockEditingMode !== 'default' ) {
 		return null;
@@ -392,7 +437,7 @@ function BlockStyleControls( {
 				value={ selectedState }
 				onChange={ setSelectedState }
 			/>
-			{ selectedState !== 'default' && (
+			{ isPseudoSelectorState && (
 				<BlockInspectorPreTabsFill>
 					<Spacer paddingX={ 4 } paddingY={ 2 }>
 						<ToggleControl
@@ -558,6 +603,25 @@ function useBlockProps( { name, style } ) {
 				}
 			} );
 		}
+
+		Object.entries( RESPONSIVE_STATE_MEDIA_QUERIES ).forEach(
+			( [ state, mediaQuery ] ) => {
+				const responsiveStyles = style?.[ state ];
+				if ( responsiveStyles ) {
+					const selector = buildStateSelector(
+						baseElementSelector,
+						name,
+						''
+					);
+					const css = compileCSS( responsiveStyles, {
+						selector,
+					} );
+					if ( css ) {
+						cssRules.push( `${ mediaQuery }{${ css }}` );
+					}
+				}
+			}
+		);
 
 		return cssRules.length > 0 ? cssRules.join( '' ) : undefined;
 	}, [ baseElementSelector, blockElementStyles, name, style ] );

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { useMemo, useState } from '@wordpress/element';
+import { ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import {
 	getBlockSupport,
@@ -34,7 +36,11 @@ import {
 	useBlockSettings,
 } from './utils';
 import { BlockStatesControl, STATES_SUPPORT_KEY } from './states';
-import { buildStateSelector } from './state-utils';
+import { buildStateSelector, buildCanvasStateSelector } from './state-utils';
+import { unlock } from '../lock-unlock';
+import { privateApis as blockEditorPrivateApis } from '../private-apis';
+
+const { BlockInspectorPreTabsFill } = unlock( blockEditorPrivateApis );
 import StylesColorPanel from '../components/global-styles/color-panel';
 import StylesTypographyPanel from '../components/global-styles/typography-panel';
 import StylesBorderPanel from '../components/global-styles/border-panel';
@@ -340,6 +346,27 @@ function BlockStyleControls( {
 	const settings = useBlockSettings( name, __unstableParentLayout );
 	const blockEditingMode = useBlockEditingMode();
 	const [ selectedState, setSelectedState ] = useState( 'default' );
+	const [ showStateOnCanvas, setShowStateOnCanvas ] = useState( true );
+
+	// Inject state styles onto the editor canvas so the selected state is
+	// visible while editing. Scoped to this block instance via data-block so
+	// other blocks of the same type are not affected. Must be called before
+	// any early returns because it is a hook.
+	const canvasStateCSS = useMemo( () => {
+		if ( ! showStateOnCanvas || selectedState === 'default' ) {
+			return undefined;
+		}
+		const stateValue = style?.[ selectedState ];
+		if ( ! stateValue ) {
+			return undefined;
+		}
+		const selector = buildCanvasStateSelector( clientId, name );
+		const css = compileCSS( stateValue, { selector } );
+		// Use !important to override utility classes (e.g. has-accent-3-color)
+		// that the block's default color support generates with !important.
+		return css ? css.replace( /;/g, ' !important;' ) : undefined;
+	}, [ showStateOnCanvas, selectedState, style, clientId, name ] );
+	useStyleOverride( { css: canvasStateCSS } );
 
 	if ( blockEditingMode !== 'default' ) {
 		return null;
@@ -378,6 +405,16 @@ function BlockStyleControls( {
 		return (
 			<>
 				{ statesControl }
+				<BlockInspectorPreTabsFill>
+					<div style={ { padding: '8px 16px' } }>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Show state on canvas' ) }
+							checked={ showStateOnCanvas }
+							onChange={ setShowStateOnCanvas }
+						/>
+					</div>
+				</BlockInspectorPreTabsFill>
 				<InspectorControls>
 					<StylesColorPanel
 						value={ stateValue }

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -30,7 +30,6 @@ import {
 	DimensionsPanel,
 } from './dimensions';
 import {
-	cleanEmptyObject,
 	shouldSkipSerialization,
 	useStyleOverride,
 	useBlockSettings,
@@ -38,14 +37,8 @@ import {
 import { BlockStatesControl, STATES_SUPPORT_KEY } from './states';
 import { buildStateSelector, buildCanvasStateSelector } from './state-utils';
 import { BlockInspectorPreTabsFill } from '../components/block-inspector/inspector-pre-tabs-slot-fill';
-import StylesColorPanel from '../components/global-styles/color-panel';
-import StylesTypographyPanel from '../components/global-styles/typography-panel';
-import StylesBorderPanel from '../components/global-styles/border-panel';
-import StylesDimensionsPanel from '../components/global-styles/dimensions-panel';
-import StylesBackgroundPanel from '../components/global-styles/background-panel';
 import { scopeSelector } from '../components/global-styles/utils';
 import { useBlockEditingMode } from '../components/block-editing-mode';
-import InspectorControls from '../components/inspector-controls';
 
 const styleSupportKeys = [
 	...TYPOGRAPHY_SUPPORT_KEYS,
@@ -389,18 +382,7 @@ function BlockStyleControls( {
 		/>
 	);
 
-	// For non-default states, use Global Styles panels which accept explicit
-	// value/onChange props so we can route saves to the state-specific sub-key.
 	if ( selectedState !== 'default' ) {
-		const stateValue = style?.[ selectedState ] || {};
-		const setStateStyle = ( newStyle ) =>
-			setAttributes( {
-				style: cleanEmptyObject( {
-					...style,
-					[ selectedState ]: newStyle,
-				} ),
-			} );
-
 		return (
 			<>
 				{ statesControl }
@@ -414,44 +396,41 @@ function BlockStyleControls( {
 						/>
 					</div>
 				</BlockInspectorPreTabsFill>
-				<InspectorControls>
-					<StylesColorPanel
-						value={ stateValue }
-						inheritedValue={ stateValue }
-						onChange={ setStateStyle }
-						settings={ panelSettings }
-						panelId={ clientId }
-					/>
-					<StylesBackgroundPanel
-						value={ stateValue }
-						inheritedValue={ stateValue }
-						onChange={ setStateStyle }
-						settings={ panelSettings }
-						panelId={ clientId }
-					/>
-					<StylesTypographyPanel
-						value={ stateValue }
-						inheritedValue={ stateValue }
-						onChange={ setStateStyle }
-						settings={ panelSettings }
-						panelId={ clientId }
-					/>
-					<StylesBorderPanel
-						value={ stateValue }
-						inheritedValue={ stateValue }
-						onChange={ setStateStyle }
-						settings={ panelSettings }
-						panelId={ clientId }
-						name={ name }
-					/>
-					<StylesDimensionsPanel
-						value={ stateValue }
-						inheritedValue={ stateValue }
-						onChange={ setStateStyle }
-						settings={ panelSettings }
-						panelId={ clientId }
-					/>
-				</InspectorControls>
+				<ColorEdit
+					clientId={ clientId }
+					name={ name }
+					setAttributes={ setAttributes }
+					settings={ panelSettings }
+					selectedState={ selectedState }
+				/>
+				<BackgroundImagePanel
+					clientId={ clientId }
+					name={ name }
+					setAttributes={ setAttributes }
+					settings={ panelSettings }
+					selectedState={ selectedState }
+				/>
+				<TypographyPanel
+					clientId={ clientId }
+					name={ name }
+					setAttributes={ setAttributes }
+					settings={ panelSettings }
+					selectedState={ selectedState }
+				/>
+				<BorderPanel
+					clientId={ clientId }
+					name={ name }
+					setAttributes={ setAttributes }
+					settings={ panelSettings }
+					selectedState={ selectedState }
+				/>
+				<DimensionsPanel
+					clientId={ clientId }
+					name={ name }
+					setAttributes={ setAttributes }
+					settings={ panelSettings }
+					selectedState={ selectedState }
+				/>
 			</>
 		);
 	}

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { useMemo, useState } from '@wordpress/element';
-import { ToggleControl } from '@wordpress/components';
+import {
+	ToggleControl,
+	__experimentalSpacer as Spacer,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import {
@@ -387,14 +390,13 @@ function BlockStyleControls( {
 			<>
 				{ statesControl }
 				<BlockInspectorPreTabsFill>
-					<div style={ { padding: '8px 16px' } }>
+					<Spacer paddingX={ 4 } paddingY={ 2 }>
 						<ToggleControl
-							__nextHasNoMarginBottom
 							label={ __( 'Show state on canvas' ) }
 							checked={ showStateOnCanvas }
 							onChange={ setShowStateOnCanvas }
 						/>
-					</div>
+					</Spacer>
 				</BlockInspectorPreTabsFill>
 				<ColorEdit
 					clientId={ clientId }

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import {
 	getBlockSupport,
@@ -28,12 +28,18 @@ import {
 	DimensionsPanel,
 } from './dimensions';
 import {
+	cleanEmptyObject,
 	shouldSkipSerialization,
 	useStyleOverride,
 	useBlockSettings,
 } from './utils';
+import { BlockStatesControl, STATES_SUPPORT_KEY } from './states';
+import StylesColorPanel from '../components/global-styles/color-panel';
+import StylesTypographyPanel from '../components/global-styles/typography-panel';
+import StylesBorderPanel from '../components/global-styles/border-panel';
 import { scopeSelector } from '../components/global-styles/utils';
 import { useBlockEditingMode } from '../components/block-editing-mode';
+import InspectorControls from '../components/inspector-controls';
 
 const styleSupportKeys = [
 	...TYPOGRAPHY_SUPPORT_KEYS,
@@ -327,29 +333,88 @@ function BlockStyleControls( {
 	clientId,
 	name,
 	setAttributes,
+	style,
 	__unstableParentLayout,
 } ) {
 	const settings = useBlockSettings( name, __unstableParentLayout );
 	const blockEditingMode = useBlockEditingMode();
+	const [ selectedState, setSelectedState ] = useState( 'default' );
+
+	if ( blockEditingMode !== 'default' ) {
+		return null;
+	}
+
+	const panelSettings = {
+		...settings,
+		typography: {
+			...settings.typography,
+			// The text alignment UI for individual blocks is rendered in
+			// the block toolbar, so disable it here.
+			textAlign: false,
+		},
+	};
+
+	const statesControl = (
+		<BlockStatesControl
+			name={ name }
+			value={ selectedState }
+			onChange={ setSelectedState }
+		/>
+	);
+
+	// For non-default states, use Global Styles panels which accept explicit
+	// value/onChange props so we can route saves to the state-specific sub-key.
+	if ( selectedState !== 'default' ) {
+		const stateValue = style?.[ selectedState ] || {};
+		const setStateStyle = ( newStyle ) =>
+			setAttributes( {
+				style: cleanEmptyObject( {
+					...style,
+					[ selectedState ]: newStyle,
+				} ),
+			} );
+
+		return (
+			<>
+				{ statesControl }
+				<InspectorControls>
+					<StylesColorPanel
+						value={ stateValue }
+						inheritedValue={ stateValue }
+						onChange={ setStateStyle }
+						settings={ panelSettings }
+						panelId={ clientId }
+					/>
+					<StylesTypographyPanel
+						value={ stateValue }
+						inheritedValue={ stateValue }
+						onChange={ setStateStyle }
+						settings={ panelSettings }
+						panelId={ clientId }
+					/>
+					<StylesBorderPanel
+						value={ stateValue }
+						inheritedValue={ stateValue }
+						onChange={ setStateStyle }
+						settings={ panelSettings }
+						panelId={ clientId }
+						name={ name }
+					/>
+				</InspectorControls>
+			</>
+		);
+	}
+
 	const passedProps = {
 		clientId,
 		name,
 		setAttributes,
-		settings: {
-			...settings,
-			typography: {
-				...settings.typography,
-				// The text alignment UI for individual blocks is rendered in
-				// the block toolbar, so disable it here.
-				textAlign: false,
-			},
-		},
+		settings: panelSettings,
 	};
-	if ( blockEditingMode !== 'default' ) {
-		return null;
-	}
+
 	return (
 		<>
+			{ statesControl }
 			<ColorEdit { ...passedProps } />
 			<BackgroundImagePanel { ...passedProps } />
 			<TypographyPanel { ...passedProps } />
@@ -469,11 +534,36 @@ function useBlockProps( { name, style } ) {
 	const baseElementSelector = `.${ blockElementsContainerIdentifier }`;
 	const blockElementStyles = style?.elements;
 
-	const styles = useMemo(
-		() =>
-			getElementCSSRules( blockElementStyles, name, baseElementSelector ),
-		[ baseElementSelector, blockElementStyles, name ]
-	);
+	const styles = useMemo( () => {
+		const cssRules = [];
+
+		const elementCSS = getElementCSSRules(
+			blockElementStyles,
+			name,
+			baseElementSelector
+		);
+		if ( elementCSS ) {
+			cssRules.push( elementCSS );
+		}
+
+		// Generate per-instance state CSS (e.g., :hover, :focus).
+		const validStates = getBlockSupport( name, STATES_SUPPORT_KEY );
+		if ( validStates ) {
+			validStates.forEach( ( state ) => {
+				const stateStyles = style?.[ state ];
+				if ( stateStyles ) {
+					const css = compileCSS( stateStyles, {
+						selector: `${ baseElementSelector }${ state }`,
+					} );
+					if ( css ) {
+						cssRules.push( css );
+					}
+				}
+			} );
+		}
+
+		return cssRules.length > 0 ? cssRules.join( '' ) : undefined;
+	}, [ baseElementSelector, blockElementStyles, name, style ] );
 
 	useStyleOverride( { css: styles } );
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -41,6 +41,8 @@ import { BlockInspectorPreTabsFill } from '../components/block-inspector/inspect
 import StylesColorPanel from '../components/global-styles/color-panel';
 import StylesTypographyPanel from '../components/global-styles/typography-panel';
 import StylesBorderPanel from '../components/global-styles/border-panel';
+import StylesDimensionsPanel from '../components/global-styles/dimensions-panel';
+import StylesBackgroundPanel from '../components/global-styles/background-panel';
 import { scopeSelector } from '../components/global-styles/utils';
 import { useBlockEditingMode } from '../components/block-editing-mode';
 import InspectorControls from '../components/inspector-controls';
@@ -420,6 +422,13 @@ function BlockStyleControls( {
 						settings={ panelSettings }
 						panelId={ clientId }
 					/>
+					<StylesBackgroundPanel
+						value={ stateValue }
+						inheritedValue={ stateValue }
+						onChange={ setStateStyle }
+						settings={ panelSettings }
+						panelId={ clientId }
+					/>
 					<StylesTypographyPanel
 						value={ stateValue }
 						inheritedValue={ stateValue }
@@ -434,6 +443,13 @@ function BlockStyleControls( {
 						settings={ panelSettings }
 						panelId={ clientId }
 						name={ name }
+					/>
+					<StylesDimensionsPanel
+						value={ stateValue }
+						inheritedValue={ stateValue }
+						onChange={ setStateStyle }
+						settings={ panelSettings }
+						panelId={ clientId }
 					/>
 				</InspectorControls>
 			</>

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -37,10 +37,7 @@ import {
 } from './utils';
 import { BlockStatesControl, STATES_SUPPORT_KEY } from './states';
 import { buildStateSelector, buildCanvasStateSelector } from './state-utils';
-import { unlock } from '../lock-unlock';
-import { privateApis as blockEditorPrivateApis } from '../private-apis';
-
-const { BlockInspectorPreTabsFill } = unlock( blockEditorPrivateApis );
+import { BlockInspectorPreTabsFill } from '../components/block-inspector/inspector-pre-tabs-slot-fill';
 import StylesColorPanel from '../components/global-styles/color-panel';
 import StylesTypographyPanel from '../components/global-styles/typography-panel';
 import StylesBorderPanel from '../components/global-styles/border-panel';

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -34,6 +34,7 @@ import {
 	useBlockSettings,
 } from './utils';
 import { BlockStatesControl, STATES_SUPPORT_KEY } from './states';
+import { buildStateSelector, STATES_ELEMENT_SUPPORT_KEY } from './state-utils';
 import StylesColorPanel from '../components/global-styles/color-panel';
 import StylesTypographyPanel from '../components/global-styles/typography-panel';
 import StylesBorderPanel from '../components/global-styles/border-panel';
@@ -549,12 +550,25 @@ function useBlockProps( { name, style } ) {
 		// Generate per-instance state CSS (e.g., :hover, :focus).
 		const validStates = getBlockSupport( name, STATES_SUPPORT_KEY );
 		if ( validStates ) {
+			const statesElement = getBlockSupport(
+				name,
+				STATES_ELEMENT_SUPPORT_KEY
+			);
 			validStates.forEach( ( state ) => {
 				const stateStyles = style?.[ state ];
 				if ( stateStyles ) {
-					const css = compileCSS( stateStyles, {
-						selector: `${ baseElementSelector }${ state }`,
-					} );
+					const selector = buildStateSelector(
+						baseElementSelector,
+						statesElement,
+						state
+					);
+					// State styles use !important to override utility classes
+					// like .has-accent-3-background-color which the block's
+					// default color support generates with !important.
+					const css = compileCSS( stateStyles, { selector } ).replace(
+						/;/g,
+						' !important;'
+					);
 					if ( css ) {
 						cssRules.push( css );
 					}

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -377,18 +377,22 @@ function BlockStyleControls( {
 		},
 	};
 
-	const statesControl = (
-		<BlockStatesControl
-			name={ name }
-			value={ selectedState }
-			onChange={ setSelectedState }
-		/>
-	);
+	const passedProps = {
+		clientId,
+		name,
+		setAttributes,
+		settings: panelSettings,
+		selectedState,
+	};
 
-	if ( selectedState !== 'default' ) {
-		return (
-			<>
-				{ statesControl }
+	return (
+		<>
+			<BlockStatesControl
+				name={ name }
+				value={ selectedState }
+				onChange={ setSelectedState }
+			/>
+			{ selectedState !== 'default' && (
 				<BlockInspectorPreTabsFill>
 					<Spacer paddingX={ 4 } paddingY={ 2 }>
 						<ToggleControl
@@ -398,55 +402,7 @@ function BlockStyleControls( {
 						/>
 					</Spacer>
 				</BlockInspectorPreTabsFill>
-				<ColorEdit
-					clientId={ clientId }
-					name={ name }
-					setAttributes={ setAttributes }
-					settings={ panelSettings }
-					selectedState={ selectedState }
-				/>
-				<BackgroundImagePanel
-					clientId={ clientId }
-					name={ name }
-					setAttributes={ setAttributes }
-					settings={ panelSettings }
-					selectedState={ selectedState }
-				/>
-				<TypographyPanel
-					clientId={ clientId }
-					name={ name }
-					setAttributes={ setAttributes }
-					settings={ panelSettings }
-					selectedState={ selectedState }
-				/>
-				<BorderPanel
-					clientId={ clientId }
-					name={ name }
-					setAttributes={ setAttributes }
-					settings={ panelSettings }
-					selectedState={ selectedState }
-				/>
-				<DimensionsPanel
-					clientId={ clientId }
-					name={ name }
-					setAttributes={ setAttributes }
-					settings={ panelSettings }
-					selectedState={ selectedState }
-				/>
-			</>
-		);
-	}
-
-	const passedProps = {
-		clientId,
-		name,
-		setAttributes,
-		settings: panelSettings,
-	};
-
-	return (
-		<>
-			{ statesControl }
+			) }
 			<ColorEdit { ...passedProps } />
 			<BackgroundImagePanel { ...passedProps } />
 			<TypographyPanel { ...passedProps } />

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -34,7 +34,7 @@ import {
 	useBlockSettings,
 } from './utils';
 import { BlockStatesControl, STATES_SUPPORT_KEY } from './states';
-import { buildStateSelector, STATES_ELEMENT_SUPPORT_KEY } from './state-utils';
+import { buildStateSelector } from './state-utils';
 import StylesColorPanel from '../components/global-styles/color-panel';
 import StylesTypographyPanel from '../components/global-styles/typography-panel';
 import StylesBorderPanel from '../components/global-styles/border-panel';
@@ -550,16 +550,12 @@ function useBlockProps( { name, style } ) {
 		// Generate per-instance state CSS (e.g., :hover, :focus).
 		const validStates = getBlockSupport( name, STATES_SUPPORT_KEY );
 		if ( validStates ) {
-			const statesElement = getBlockSupport(
-				name,
-				STATES_ELEMENT_SUPPORT_KEY
-			);
 			validStates.forEach( ( state ) => {
 				const stateStyles = style?.[ state ];
 				if ( stateStyles ) {
 					const selector = buildStateSelector(
 						baseElementSelector,
-						statesElement,
+						name,
 						state
 					);
 					// State styles use !important to override utility classes

--- a/packages/block-editor/src/hooks/test/state-utils.js
+++ b/packages/block-editor/src/hooks/test/state-utils.js
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import { buildStateSelector } from '../state-utils';
+
+describe( 'buildStateSelector', () => {
+	const BASE = '.wp-elements-abc123';
+
+	it( 'scopes state to each element selector part when statesElement is "button"', () => {
+		// ELEMENTS['button'] = '.wp-element-button, .wp-block-button__link'
+		expect( buildStateSelector( BASE, 'button', ':hover' ) ).toBe(
+			`${ BASE } .wp-element-button:hover, ${ BASE } .wp-block-button__link:hover`
+		);
+	} );
+
+	it( 'works for :focus and :active states', () => {
+		expect( buildStateSelector( BASE, 'button', ':focus' ) ).toBe(
+			`${ BASE } .wp-element-button:focus, ${ BASE } .wp-block-button__link:focus`
+		);
+		expect( buildStateSelector( BASE, 'button', ':active' ) ).toBe(
+			`${ BASE } .wp-element-button:active, ${ BASE } .wp-block-button__link:active`
+		);
+	} );
+
+	it( 'scopes state to the single element selector when statesElement is "link"', () => {
+		// ELEMENTS['link'] = 'a:where(:not(.wp-element-button))'
+		expect( buildStateSelector( BASE, 'link', ':hover' ) ).toBe(
+			`${ BASE } a:where(:not(.wp-element-button)):hover`
+		);
+	} );
+
+	it( 'falls back to appending state to the base selector when statesElement is null', () => {
+		expect( buildStateSelector( BASE, null, ':hover' ) ).toBe(
+			`${ BASE }:hover`
+		);
+	} );
+
+	it( 'falls back to appending state to the base selector when statesElement is undefined', () => {
+		expect( buildStateSelector( BASE, undefined, ':hover' ) ).toBe(
+			`${ BASE }:hover`
+		);
+	} );
+
+	it( 'falls back to appending state to the base selector when statesElement has no matching ELEMENTS entry', () => {
+		expect( buildStateSelector( BASE, 'unknown-element', ':hover' ) ).toBe(
+			`${ BASE }:hover`
+		);
+	} );
+} );

--- a/packages/block-editor/src/hooks/test/state-utils.js
+++ b/packages/block-editor/src/hooks/test/state-utils.js
@@ -1,48 +1,90 @@
 /**
+ * WordPress dependencies
+ */
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
-import { buildStateSelector } from '../state-utils';
+import { getRelativeRootSelector, buildStateSelector } from '../state-utils';
+
+describe( 'getRelativeRootSelector', () => {
+	it( 'returns the descendant part of a space-combinator selector', () => {
+		expect(
+			getRelativeRootSelector( '.wp-block-button .wp-block-button__link' )
+		).toBe( '.wp-block-button__link' );
+	} );
+
+	it( 'preserves explicit child combinators', () => {
+		expect( getRelativeRootSelector( '.wp-block-foo > .inner' ) ).toBe(
+			'> .inner'
+		);
+	} );
+
+	it( 'preserves multi-level descendants', () => {
+		expect( getRelativeRootSelector( '.wp-block-foo .bar .baz' ) ).toBe(
+			'.bar .baz'
+		);
+	} );
+
+	it( 'returns null for a single-class selector', () => {
+		expect( getRelativeRootSelector( '.wp-block-foo' ) ).toBeNull();
+	} );
+} );
 
 describe( 'buildStateSelector', () => {
 	const BASE = '.wp-elements-abc123';
 
-	it( 'scopes state to each element selector part when statesElement is "button"', () => {
-		// ELEMENTS['button'] = '.wp-element-button, .wp-block-button__link'
-		expect( buildStateSelector( BASE, 'button', ':hover' ) ).toBe(
-			`${ BASE } .wp-element-button:hover, ${ BASE } .wp-block-button__link:hover`
+	beforeEach( () => {
+		registerBlockType( 'test/button', {
+			apiVersion: 3,
+			title: 'Button',
+			category: 'text',
+			attributes: {},
+			edit: () => null,
+			save: () => null,
+			selectors: {
+				root: '.wp-block-button .wp-block-button__link',
+			},
+		} );
+		registerBlockType( 'test/plain', {
+			apiVersion: 3,
+			title: 'Plain',
+			category: 'text',
+			attributes: {},
+			edit: () => null,
+			save: () => null,
+		} );
+	} );
+
+	afterEach( () => {
+		unregisterBlockType( 'test/button' );
+		unregisterBlockType( 'test/plain' );
+	} );
+
+	it( 'scopes state to the descendant element from selectors.root', () => {
+		expect( buildStateSelector( BASE, 'test/button', ':hover' ) ).toBe(
+			`${ BASE } .wp-block-button__link:hover`
 		);
 	} );
 
 	it( 'works for :focus and :active states', () => {
-		expect( buildStateSelector( BASE, 'button', ':focus' ) ).toBe(
-			`${ BASE } .wp-element-button:focus, ${ BASE } .wp-block-button__link:focus`
+		expect( buildStateSelector( BASE, 'test/button', ':focus' ) ).toBe(
+			`${ BASE } .wp-block-button__link:focus`
 		);
-		expect( buildStateSelector( BASE, 'button', ':active' ) ).toBe(
-			`${ BASE } .wp-element-button:active, ${ BASE } .wp-block-button__link:active`
-		);
-	} );
-
-	it( 'scopes state to the single element selector when statesElement is "link"', () => {
-		// ELEMENTS['link'] = 'a:where(:not(.wp-element-button))'
-		expect( buildStateSelector( BASE, 'link', ':hover' ) ).toBe(
-			`${ BASE } a:where(:not(.wp-element-button)):hover`
+		expect( buildStateSelector( BASE, 'test/button', ':active' ) ).toBe(
+			`${ BASE } .wp-block-button__link:active`
 		);
 	} );
 
-	it( 'falls back to appending state to the base selector when statesElement is null', () => {
-		expect( buildStateSelector( BASE, null, ':hover' ) ).toBe(
+	it( 'falls back to appending state to the base selector when block has no selectors.root', () => {
+		expect( buildStateSelector( BASE, 'test/plain', ':hover' ) ).toBe(
 			`${ BASE }:hover`
 		);
 	} );
 
-	it( 'falls back to appending state to the base selector when statesElement is undefined', () => {
-		expect( buildStateSelector( BASE, undefined, ':hover' ) ).toBe(
-			`${ BASE }:hover`
-		);
-	} );
-
-	it( 'falls back to appending state to the base selector when statesElement has no matching ELEMENTS entry', () => {
-		expect( buildStateSelector( BASE, 'unknown-element', ':hover' ) ).toBe(
+	it( 'falls back to appending state to the base selector for an unknown block name', () => {
+		expect( buildStateSelector( BASE, 'test/unknown', ':hover' ) ).toBe(
 			`${ BASE }:hover`
 		);
 	} );

--- a/packages/block-editor/src/hooks/test/use-block-style.js
+++ b/packages/block-editor/src/hooks/test/use-block-style.js
@@ -35,9 +35,11 @@ describe( 'useBlockStyle', () => {
 		} );
 	} );
 
-	afterAll( () => {
+	afterAll( async () => {
 		unregisterBlockType( 'test/style-block' );
-		dispatch( blockEditorStore ).resetBlocks( [] );
+		await act( async () => {
+			await dispatch( blockEditorStore ).resetBlocks( [] );
+		} );
 	} );
 
 	let clientId;
@@ -48,12 +50,16 @@ describe( 'useBlockStyle', () => {
 				':hover': { color: { text: '#ff0000' } },
 			},
 		} );
-		await dispatch( blockEditorStore ).resetBlocks( [ block ] );
+		await act( async () => {
+			await dispatch( blockEditorStore ).resetBlocks( [ block ] );
+		} );
 		clientId = block.clientId;
 	} );
 
-	afterEach( () => {
-		dispatch( blockEditorStore ).resetBlocks( [] );
+	afterEach( async () => {
+		await act( async () => {
+			await dispatch( blockEditorStore ).resetBlocks( [] );
+		} );
 	} );
 
 	function makeWrapper( id ) {

--- a/packages/block-editor/src/hooks/test/use-block-style.js
+++ b/packages/block-editor/src/hooks/test/use-block-style.js
@@ -1,0 +1,192 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { createElement } from '@wordpress/element';
+import {
+	createBlock,
+	registerBlockType,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+import { dispatch, select } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { useBlockStyle } from '../use-block-style';
+import { BlockEditContextProvider } from '../../components/block-edit/context';
+
+describe( 'useBlockStyle', () => {
+	beforeAll( () => {
+		registerBlockType( 'test/style-block', {
+			apiVersion: 3,
+			title: 'Style Block',
+			category: 'text',
+			attributes: {
+				style: { type: 'object' },
+			},
+			edit: () => null,
+			save: () => null,
+		} );
+	} );
+
+	afterAll( () => {
+		unregisterBlockType( 'test/style-block' );
+		dispatch( blockEditorStore ).resetBlocks( [] );
+	} );
+
+	let clientId;
+	beforeEach( async () => {
+		const block = createBlock( 'test/style-block', {
+			style: {
+				color: { text: '#000000' },
+				':hover': { color: { text: '#ff0000' } },
+			},
+		} );
+		await dispatch( blockEditorStore ).resetBlocks( [ block ] );
+		clientId = block.clientId;
+	} );
+
+	afterEach( () => {
+		dispatch( blockEditorStore ).resetBlocks( [] );
+	} );
+
+	function makeWrapper( id ) {
+		return function Wrapper( { children } ) {
+			return createElement(
+				BlockEditContextProvider,
+				{
+					value: {
+						clientId: id,
+						name: 'test/style-block',
+						isSelected: true,
+					},
+				},
+				children
+			);
+		};
+	}
+
+	describe( 'reading values', () => {
+		it( 'reads a value from the default state via dot-notation path', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toBe( '#000000' );
+		} );
+
+		it( 'reads a value from the default state via array path', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( [ 'color', 'text' ] ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toBe( '#000000' );
+		} );
+
+		it( 'treats state "default" the same as no state', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', 'default' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toBe( '#000000' );
+		} );
+
+		it( 'reads a value scoped to a pseudo-state via dot-notation path', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', ':hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toBe( '#ff0000' );
+		} );
+
+		it( 'reads the full state sub-object when path is null', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( null, ':hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toEqual( {
+				color: { text: '#ff0000' },
+			} );
+		} );
+	} );
+
+	describe( 'writing values', () => {
+		it( 'writes a value to the default state without affecting pseudo-state styles', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			act( () => {
+				result.current[ 1 ]( '#ffffff' );
+			} );
+
+			const { style } =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			expect( style.color.text ).toBe( '#ffffff' );
+			expect( style[ ':hover' ].color.text ).toBe( '#ff0000' );
+		} );
+
+		it( 'writes a value to a pseudo-state without affecting the default state', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', ':hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			act( () => {
+				result.current[ 1 ]( '#0000ff' );
+			} );
+
+			const { style } =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			expect( style[ ':hover' ].color.text ).toBe( '#0000ff' );
+			expect( style.color.text ).toBe( '#000000' );
+		} );
+
+		it( 'replaces the full state sub-object when path is null', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( null, ':hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			act( () => {
+				result.current[ 1 ]( { color: { text: '#0000ff' } } );
+			} );
+
+			const { style } =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			expect( style[ ':hover' ] ).toEqual( {
+				color: { text: '#0000ff' },
+			} );
+			expect( style.color.text ).toBe( '#000000' );
+		} );
+
+		it( 'removes the state key when the last value inside it is cleared', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', ':hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			act( () => {
+				result.current[ 1 ]( undefined );
+			} );
+
+			const { style } =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			expect( style[ ':hover' ] ).toBeUndefined();
+			// Default-state styles must be left intact.
+			expect( style.color.text ).toBe( '#000000' );
+		} );
+	} );
+} );

--- a/packages/block-editor/src/hooks/test/utils.js
+++ b/packages/block-editor/src/hooks/test/utils.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { cleanEmptyObject } from '../utils';
+import { cleanEmptyObject, buildStateResetAllFilter } from '../utils';
 
 describe( 'cleanEmptyObject', () => {
 	it( 'should remove nested keys', () => {
@@ -28,5 +28,72 @@ describe( 'cleanEmptyObject', () => {
 		expect( cleanEmptyObject( { color: { text: '' } } ) ).not.toEqual(
 			undefined
 		);
+	} );
+} );
+
+describe( 'buildStateResetAllFilter', () => {
+	it( 'should clear only the selected state styles and leave default styles intact', () => {
+		const innerReset = ( style ) => ( { ...style, color: undefined } );
+		const attributes = {
+			style: {
+				color: { text: '#000000' },
+				':hover': { color: { text: '#ff0000' } },
+			},
+		};
+
+		const result = buildStateResetAllFilter(
+			':hover',
+			innerReset
+		)( attributes );
+
+		expect( result.style[ ':hover' ] ).toBeUndefined();
+		expect( result.style.color ).toEqual( { text: '#000000' } );
+	} );
+
+	it( 'should not affect other state keys', () => {
+		const innerReset = () => ( {} );
+		const attributes = {
+			style: {
+				':hover': { color: { text: '#ff0000' } },
+				':focus': { color: { text: '#0000ff' } },
+			},
+		};
+
+		const result = buildStateResetAllFilter(
+			':hover',
+			innerReset
+		)( attributes );
+
+		expect( result.style[ ':hover' ] ).toBeUndefined();
+		expect( result.style[ ':focus' ] ).toEqual( {
+			color: { text: '#0000ff' },
+		} );
+	} );
+
+	it( 'should remove the state key entirely when inner reset returns an empty object', () => {
+		const innerReset = () => ( {} );
+		const attributes = {
+			style: {
+				':hover': { color: { text: '#ff0000' } },
+			},
+		};
+
+		const result = buildStateResetAllFilter(
+			':hover',
+			innerReset
+		)( attributes );
+
+		expect( result.style ).toBeUndefined();
+	} );
+
+	it( 'should call the inner reset with an empty object when no state styles exist', () => {
+		const innerReset = jest.fn( ( style ) => style );
+		const attributes = {
+			style: { color: { text: '#000000' } },
+		};
+
+		buildStateResetAllFilter( ':hover', innerReset )( attributes );
+
+		expect( innerReset ).toHaveBeenCalledWith( {} );
 	} );
 } );

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -21,6 +21,7 @@ import { TEXT_ALIGN_SUPPORT_KEY } from './text-align';
 import { FIT_TEXT_SUPPORT_KEY } from './fit-text';
 import { cleanEmptyObject, buildStateResetAllFilter } from './utils';
 import { store as blockEditorStore } from '../store';
+import { useBlockStateProps } from './state-utils';
 
 function omit( object, keys ) {
 	return Object.fromEntries(
@@ -135,7 +136,6 @@ export function TypographyPanel( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasTypographyPanel( settings );
-	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 
 	const { style, fontFamily, fontSize, fitText } = useSelect(
 		( select ) => {
@@ -158,21 +158,22 @@ export function TypographyPanel( {
 		},
 		[ clientId, isEnabled ]
 	);
+
+	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
+		selectedState,
+		style,
+		setAttributes,
+	} );
+
 	const value = useMemo( () => {
 		if ( isStateSelected ) {
-			return style?.[ selectedState ];
+			return stateValue;
 		}
 		return attributesToStyle( { style, fontFamily, fontSize } );
-	}, [ isStateSelected, selectedState, style, fontSize, fontFamily ] );
+	}, [ isStateSelected, stateValue, style, fontSize, fontFamily ] );
 
 	const onChange = isStateSelected
-		? ( newStateStyle ) =>
-				setAttributes( {
-					style: cleanEmptyObject( {
-						...style,
-						[ selectedState ]: newStateStyle,
-					} ),
-				} )
+		? stateOnChange
 		: ( newStyle ) => {
 				const newAttributes = styleToAttributes( newStyle );
 

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -19,7 +19,7 @@ import { FONT_FAMILY_SUPPORT_KEY } from './font-family';
 import { FONT_SIZE_SUPPORT_KEY } from './font-size';
 import { TEXT_ALIGN_SUPPORT_KEY } from './text-align';
 import { FIT_TEXT_SUPPORT_KEY } from './fit-text';
-import { cleanEmptyObject } from './utils';
+import { cleanEmptyObject, buildStateResetAllFilter } from './utils';
 import { store as blockEditorStore } from '../store';
 
 function omit( object, keys ) {
@@ -93,9 +93,20 @@ function attributesToStyle( attributes ) {
 	};
 }
 
-function TypographyInspectorControl( { children, resetAllFilter } ) {
+function TypographyInspectorControl( {
+	children,
+	resetAllFilter,
+	selectedState = 'default',
+} ) {
+	const isStateSelected = selectedState !== 'default';
 	const attributesResetAllFilter = useCallback(
 		( attributes ) => {
+			if ( isStateSelected ) {
+				return buildStateResetAllFilter(
+					selectedState,
+					resetAllFilter
+				)( attributes );
+			}
 			const existingStyle = attributesToStyle( attributes );
 			const updatedStyle = resetAllFilter( existingStyle );
 			return {
@@ -103,7 +114,7 @@ function TypographyInspectorControl( { children, resetAllFilter } ) {
 				...styleToAttributes( updatedStyle ),
 			};
 		},
-		[ resetAllFilter ]
+		[ isStateSelected, selectedState, resetAllFilter ]
 	);
 
 	return (
@@ -124,7 +135,7 @@ export function TypographyPanel( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasTypographyPanel( settings );
-	const isStateMode = !! ( selectedState && selectedState !== 'default' );
+	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 
 	const { style, fontFamily, fontSize, fitText } = useSelect(
 		( select ) => {
@@ -148,13 +159,13 @@ export function TypographyPanel( {
 		[ clientId, isEnabled ]
 	);
 	const value = useMemo( () => {
-		if ( isStateMode ) {
+		if ( isStateSelected ) {
 			return style?.[ selectedState ];
 		}
 		return attributesToStyle( { style, fontFamily, fontSize } );
-	}, [ isStateMode, selectedState, style, fontSize, fontFamily ] );
+	}, [ isStateSelected, selectedState, style, fontSize, fontFamily ] );
 
-	const onChange = isStateMode
+	const onChange = isStateSelected
 		? ( newStateStyle ) =>
 				setAttributes( {
 					style: cleanEmptyObject( {
@@ -176,6 +187,19 @@ export function TypographyPanel( {
 				setAttributes( newAttributes );
 		  };
 
+	const TypographyWrapper = useMemo(
+		() =>
+			function TypographyWrapperComponent( props ) {
+				return (
+					<TypographyInspectorControl
+						{ ...props }
+						selectedState={ selectedState }
+					/>
+				);
+			},
+		[ selectedState ]
+	);
+
 	if ( ! isEnabled ) {
 		return null;
 	}
@@ -187,7 +211,7 @@ export function TypographyPanel( {
 
 	return (
 		<StylesTypographyPanel
-			as={ TypographyInspectorControl }
+			as={ TypographyWrapper }
 			panelId={ clientId }
 			settings={ settings }
 			value={ value }

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -21,7 +21,8 @@ import { TEXT_ALIGN_SUPPORT_KEY } from './text-align';
 import { FIT_TEXT_SUPPORT_KEY } from './fit-text';
 import { cleanEmptyObject, buildStateResetAllFilter } from './utils';
 import { store as blockEditorStore } from '../store';
-import { useBlockStateProps } from './state-utils';
+import { useBlockEditContext } from '../components/block-edit/context';
+import { useBlockStyle } from './use-block-style';
 
 function omit( object, keys ) {
 	return Object.fromEntries(
@@ -131,26 +132,23 @@ function TypographyInspectorControl( {
 export function TypographyPanel( {
 	clientId,
 	name,
-	setAttributes,
 	settings,
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasTypographyPanel( settings );
 
-	const { style, fontFamily, fontSize, fitText } = useSelect(
+	const { fontFamily, fontSize, fitText } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled.
 			if ( ! isEnabled ) {
 				return {};
 			}
 			const {
-				style: _style,
 				fontFamily: _fontFamily,
 				fontSize: _fontSize,
 				fitText: _fitText,
 			} = select( blockEditorStore ).getBlockAttributes( clientId ) || {};
 			return {
-				style: _style,
 				fontFamily: _fontFamily,
 				fontSize: _fontSize,
 				fitText: _fitText,
@@ -159,25 +157,23 @@ export function TypographyPanel( {
 		[ clientId, isEnabled ]
 	);
 
-	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
-		selectedState,
-		style,
-		setAttributes,
-	} );
+	const { setAttributes } = useBlockEditContext();
+	const [ style, setStyle ] = useBlockStyle( null, selectedState );
+	const isStateSelected = selectedState !== 'default';
 
 	const value = useMemo( () => {
 		if ( isStateSelected ) {
-			return stateValue;
+			return style;
 		}
 		return attributesToStyle( { style, fontFamily, fontSize } );
-	}, [ isStateSelected, stateValue, style, fontSize, fontFamily ] );
+	}, [ isStateSelected, style, fontSize, fontFamily ] );
 
 	const onChange = isStateSelected
-		? stateOnChange
+		? setStyle
 		: ( newStyle ) => {
 				const newAttributes = styleToAttributes( newStyle );
 
-				// If setting a font size and fitText is currently enabled, disable it
+				// If setting a font size and fitText is currently enabled, disable it.
 				const hasFontSize =
 					newAttributes.fontSize ||
 					newAttributes.style?.typography?.fontSize;

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -116,8 +116,15 @@ function TypographyInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
+export function TypographyPanel( {
+	clientId,
+	name,
+	setAttributes,
+	settings,
+	selectedState = 'default',
+} ) {
 	const isEnabled = useHasTypographyPanel( settings );
+	const isStateMode = !! ( selectedState && selectedState !== 'default' );
 
 	const { style, fontFamily, fontSize, fitText } = useSelect(
 		( select ) => {
@@ -140,23 +147,34 @@ export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
 		},
 		[ clientId, isEnabled ]
 	);
-	const value = useMemo(
-		() => attributesToStyle( { style, fontFamily, fontSize } ),
-		[ style, fontSize, fontFamily ]
-	);
-
-	const onChange = ( newStyle ) => {
-		const newAttributes = styleToAttributes( newStyle );
-
-		// If setting a font size and fitText is currently enabled, disable it
-		const hasFontSize =
-			newAttributes.fontSize || newAttributes.style?.typography?.fontSize;
-		if ( hasFontSize && fitText ) {
-			newAttributes.fitText = undefined;
+	const value = useMemo( () => {
+		if ( isStateMode ) {
+			return style?.[ selectedState ];
 		}
+		return attributesToStyle( { style, fontFamily, fontSize } );
+	}, [ isStateMode, selectedState, style, fontSize, fontFamily ] );
 
-		setAttributes( newAttributes );
-	};
+	const onChange = isStateMode
+		? ( newStateStyle ) =>
+				setAttributes( {
+					style: cleanEmptyObject( {
+						...style,
+						[ selectedState ]: newStateStyle,
+					} ),
+				} )
+		: ( newStyle ) => {
+				const newAttributes = styleToAttributes( newStyle );
+
+				// If setting a font size and fitText is currently enabled, disable it
+				const hasFontSize =
+					newAttributes.fontSize ||
+					newAttributes.style?.typography?.fontSize;
+				if ( hasFontSize && fitText ) {
+					newAttributes.fitText = undefined;
+				}
+
+				setAttributes( newAttributes );
+		  };
 
 	if ( ! isEnabled ) {
 		return null;

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -21,7 +21,6 @@ import { TEXT_ALIGN_SUPPORT_KEY } from './text-align';
 import { FIT_TEXT_SUPPORT_KEY } from './fit-text';
 import { cleanEmptyObject, buildStateResetAllFilter } from './utils';
 import { store as blockEditorStore } from '../store';
-import { useBlockEditContext } from '../components/block-edit/context';
 import { useBlockStyle } from './use-block-style';
 
 function omit( object, keys ) {
@@ -132,6 +131,7 @@ function TypographyInspectorControl( {
 export function TypographyPanel( {
 	clientId,
 	name,
+	setAttributes,
 	settings,
 	selectedState = 'default',
 } ) {
@@ -157,7 +157,6 @@ export function TypographyPanel( {
 		[ clientId, isEnabled ]
 	);
 
-	const { setAttributes } = useBlockEditContext();
 	const [ style, setStyle ] = useBlockStyle( null, selectedState );
 	const isStateSelected = selectedState !== 'default';
 

--- a/packages/block-editor/src/hooks/use-block-style.js
+++ b/packages/block-editor/src/hooks/use-block-style.js
@@ -26,12 +26,16 @@ import { cleanEmptyObject } from './utils';
  *   `useBlockStyle( 'color', '@current' )`     — `style['@current'].color`
  *   `useBlockStyle( 'color', ':hover:focus' )` — compound state
  *
+ * Omit `path` (or pass `null`) to read and write the full style object for
+ * that state context, e.g. `useBlockStyle( null, ':hover' )` returns the
+ * entire `style[':hover']` sub-object.
+ *
  * Keeping state separate from the path means no heuristic is needed to
  * distinguish state keys from style property names, regardless of the
  * state format convention used.
  *
- * @param {string|string[]} path  Dot-separated path into the `style` object.
- * @param {string}          state Optional state key, e.g. `':hover'` or `'@current'`. Omit for default styles.
+ * @param {string|string[]|null} path  Dot-separated path into the `style` object, or `null` for the root.
+ * @param {string}               state Optional state key, e.g. `':hover'` or `'@current'`. Omit or pass `'default'` for base styles.
  * @return {[*, Function]} Tuple of `[currentValue, setValue]`.
  */
 export function useBlockStyle( path, state ) {
@@ -44,7 +48,14 @@ export function useBlockStyle( path, state ) {
 	);
 
 	const pathArray = useMemo( () => {
-		const stylePath = Array.isArray( path ) ? path : path.split( '.' );
+		let stylePath;
+		if ( ! path ) {
+			stylePath = [];
+		} else if ( Array.isArray( path ) ) {
+			stylePath = path;
+		} else {
+			stylePath = path.split( '.' );
+		}
 		return state && state !== 'default'
 			? [ state, ...stylePath ]
 			: stylePath;
@@ -57,10 +68,13 @@ export function useBlockStyle( path, state ) {
 
 	const setValue = useCallback(
 		( newValue ) => {
+			// Empty path means the caller wants to replace the style root (or
+			// the full state sub-object) wholesale rather than a nested key.
+			const newStyle = pathArray.length
+				? setImmutably( style ?? {}, pathArray, newValue )
+				: newValue;
 			setAttributes( {
-				style: cleanEmptyObject(
-					setImmutably( style ?? {}, pathArray, newValue )
-				),
+				style: cleanEmptyObject( newStyle ),
 			} );
 		},
 		[ setAttributes, style, pathArray ]

--- a/packages/block-editor/src/hooks/use-block-style.js
+++ b/packages/block-editor/src/hooks/use-block-style.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback, useMemo } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -39,7 +39,8 @@ import { cleanEmptyObject } from './utils';
  * @return {[*, Function]} Tuple of `[currentValue, setValue]`.
  */
 export function useBlockStyle( path, state ) {
-	const { clientId, setAttributes } = useBlockEditContext();
+	const { clientId } = useBlockEditContext();
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	const style = useSelect(
 		( select ) =>
@@ -73,11 +74,11 @@ export function useBlockStyle( path, state ) {
 			const newStyle = pathArray.length
 				? setImmutably( style ?? {}, pathArray, newValue )
 				: newValue;
-			setAttributes( {
+			updateBlockAttributes( clientId, {
 				style: cleanEmptyObject( newStyle ),
 			} );
 		},
-		[ setAttributes, style, pathArray ]
+		[ updateBlockAttributes, clientId, style, pathArray ]
 	);
 
 	return [ value, setValue ];

--- a/packages/block-editor/src/hooks/use-block-style.js
+++ b/packages/block-editor/src/hooks/use-block-style.js
@@ -1,0 +1,70 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useBlockEditContext } from '../components/block-edit/context';
+import { store as blockEditorStore } from '../store';
+import { getValueFromObjectPath, setImmutably } from '../utils/object';
+import { cleanEmptyObject } from './utils';
+
+/**
+ * Returns a `[value, setter]` pair for a path within a block's `style`
+ * attribute. Works like `useStyle` in Global Styles but reads from the
+ * current block instance's attributes instead of `theme.json`.
+ *
+ * Path uses dot notation into the style object, e.g. `'color'` or
+ * `'typography.fontSize'`. Pass a separate `state` argument to scope to a
+ * pseudo-state or custom state — the state key becomes the first segment of
+ * the storage path:
+ *
+ *   `useBlockStyle( 'color', ':hover' )`       — `style[':hover'].color`
+ *   `useBlockStyle( 'color', '@current' )`     — `style['@current'].color`
+ *   `useBlockStyle( 'color', ':hover:focus' )` — compound state
+ *
+ * Keeping state separate from the path means no heuristic is needed to
+ * distinguish state keys from style property names, regardless of the
+ * state format convention used.
+ *
+ * @param {string|string[]} path  Dot-separated path into the `style` object.
+ * @param {string}          state Optional state key, e.g. `':hover'` or `'@current'`. Omit for default styles.
+ * @return {[*, Function]} Tuple of `[currentValue, setValue]`.
+ */
+export function useBlockStyle( path, state ) {
+	const { clientId, setAttributes } = useBlockEditContext();
+
+	const style = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockAttributes( clientId )?.style,
+		[ clientId ]
+	);
+
+	const pathArray = useMemo( () => {
+		const stylePath = Array.isArray( path ) ? path : path.split( '.' );
+		return state && state !== 'default'
+			? [ state, ...stylePath ]
+			: stylePath;
+	}, [ path, state ] );
+
+	const value = useMemo(
+		() => getValueFromObjectPath( style, pathArray ),
+		[ style, pathArray ]
+	);
+
+	const setValue = useCallback(
+		( newValue ) => {
+			setAttributes( {
+				style: cleanEmptyObject(
+					setImmutably( style ?? {}, pathArray, newValue )
+				),
+			} );
+		},
+		[ setAttributes, style, pathArray ]
+	);
+
+	return [ value, setValue ];
+}

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -50,6 +50,30 @@ export const cleanEmptyObject = ( object ) => {
 		: Object.fromEntries( cleanedNestedObjects );
 };
 
+/**
+ * Builds a `resetAllFilter` for use with `<InspectorControls>` when a
+ * non-default interactive state (e.g. `:hover`) is active. Rather than
+ * resetting the whole block style object, it scopes the reset to the
+ * sub-key that stores styles for that state, leaving default styles intact.
+ *
+ * @param {string}   selectedState    The active state key, e.g. ':hover'.
+ * @param {Function} innerResetFilter The panel's own resetAllFilter callback.
+ * @return {Function} A filter that takes block `attributes` and returns updated attributes.
+ */
+export function buildStateResetAllFilter( selectedState, innerResetFilter ) {
+	return ( attributes ) => {
+		const existingStateStyle = attributes.style?.[ selectedState ] || {};
+		const updatedStateStyle = innerResetFilter( existingStateStyle );
+		return {
+			...attributes,
+			style: cleanEmptyObject( {
+				...attributes.style,
+				[ selectedState ]: updatedStateStyle,
+			} ),
+		};
+	};
+}
+
 export function transformStyles(
 	activeSupports,
 	migrationPaths,

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -75,6 +75,7 @@ import {
 	isRelativePath,
 } from './components/link-control/is-url-like';
 import { BlockCardControlsFill } from './components/block-card';
+import { BlockInspectorPreTabsFill } from './components/block-inspector/inspector-pre-tabs-slot-fill';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -143,4 +144,5 @@ lock( privateApis, {
 	isHashLink,
 	isRelativePath,
 	BlockCardControlsFill,
+	BlockInspectorPreTabsFill,
 } );

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -74,8 +74,6 @@ import {
 	isHashLink,
 	isRelativePath,
 } from './components/link-control/is-url-like';
-import { BlockCardControlsFill } from './components/block-card';
-import { BlockInspectorPreTabsFill } from './components/block-inspector/inspector-pre-tabs-slot-fill';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -143,6 +141,4 @@ lock( privateApis, {
 	useListViewPanelState,
 	isHashLink,
 	isRelativePath,
-	BlockCardControlsFill,
-	BlockInspectorPreTabsFill,
 } );

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -74,6 +74,7 @@ import {
 	isHashLink,
 	isRelativePath,
 } from './components/link-control/is-url-like';
+import { BlockCardControlsFill } from './components/block-card';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -141,4 +142,5 @@ lock( privateApis, {
 	useListViewPanelState,
 	isHashLink,
 	isRelativePath,
+	BlockCardControlsFill,
 } );

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -138,8 +138,7 @@
 		"interactivity": {
 			"clientNavigation": true
 		},
-		"__experimentalStates": [ ":hover", ":focus", ":active" ],
-		"__experimentalStatesElement": "button"
+		"__experimentalStates": [ ":hover", ":focus", ":active" ]
 	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -138,7 +138,8 @@
 		"interactivity": {
 			"clientNavigation": true
 		},
-		"__experimentalStates": [ ":hover", ":focus", ":active" ]
+		"__experimentalStates": [ ":hover", ":focus", ":active" ],
+		"__experimentalStatesElement": "button"
 	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -138,7 +138,7 @@
 		"interactivity": {
 			"clientNavigation": true
 		},
-		"__experimentalStates": [ ":hover", ":focus", ":active" ]
+		"states": [ ":hover", ":focus", ":active" ]
 	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -137,7 +137,8 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
-		}
+		},
+		"__experimentalStates": [ ":hover", ":focus", ":active" ]
 	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1001,6 +1001,8 @@ function appendPseudoSelectorStyles(
  * @param featureSelectors       Optional feature-level selectors for the block.
  * @param treeSettings           Global styles settings tree.
  * @param styleVariationSelector Optional style variation selector.
+ * @param blockRootSelector      Optional block root selector used to detect block-level feature selectors.
+ * @param styleVariationName     Optional variation name used when applying variation class to block-level feature selectors.
  * @return Updated ruleset string with responsive CSS rules appended.
  */
 function appendResponsiveStyles(
@@ -1012,7 +1014,9 @@ function appendResponsiveStyles(
 		| Record< string, string | Record< string, string > >
 		| undefined,
 	treeSettings: Record< string, any > | undefined,
-	styleVariationSelector?: string
+	styleVariationSelector?: string,
+	blockRootSelector?: string,
+	styleVariationName?: string
 ): string {
 	const responsiveStyles = Object.entries( styles ).filter( ( [ key ] ) =>
 		Object.prototype.hasOwnProperty.call( RESPONSIVE_BREAKPOINTS, key )
@@ -1054,12 +1058,28 @@ function appendResponsiveStyles(
 					if ( ! declarations.length ) {
 						return;
 					}
-					const cssSelector = styleVariationSelector
-						? concatFeatureVariationSelectorString(
-								baseSelector,
-								styleVariationSelector
-						  )
-						: baseSelector;
+					let cssSelector: string;
+					if ( ! styleVariationSelector ) {
+						cssSelector = baseSelector;
+					} else if (
+						blockRootSelector &&
+						styleVariationName &&
+						! baseSelector.includes( blockRootSelector )
+					) {
+						/*
+						 * Feature selector is block-level (e.g. `.wp-block-button` for
+						 * dimensions/width) — apply the variation class directly to it.
+						 */
+						cssSelector = getBlockStyleVariationSelector(
+							styleVariationName,
+							baseSelector
+						);
+					} else {
+						cssSelector = concatFeatureVariationSelectorString(
+							baseSelector,
+							styleVariationSelector
+						);
+					}
 					const rules = declarations.join( ';' );
 					ruleset += `${ mediaQuery }{:root :where(${ cssSelector }){${ rules };}}`;
 				}
@@ -1754,11 +1774,26 @@ export const transformToStyles = (
 											string[],
 										] ) => {
 											if ( declarations.length ) {
+												/*
+												 * If the feature selector does not include the block's
+												 * root selector (e.g. core/button dimensions width uses
+												 * `.wp-block-button` while root is
+												 * `.wp-block-button .wp-block-button__link`), apply the
+												 * variation class directly to the feature selector.
+												 */
 												const cssSelector =
-													concatFeatureVariationSelectorString(
-														baseSelector,
-														styleVariationSelector as string
-													);
+													! selector ||
+													baseSelector.includes(
+														selector
+													)
+														? concatFeatureVariationSelectorString(
+																baseSelector,
+																styleVariationSelector as string
+														  )
+														: getBlockStyleVariationSelector(
+																styleVariationName,
+																baseSelector
+														  );
 												const rules =
 													declarations.join( ';' );
 												ruleset += `:root :where(${ cssSelector }){${ rules };}`;
@@ -1803,7 +1838,9 @@ export const transformToStyles = (
 									ruleset,
 									featureSelectors,
 									tree.settings,
-									styleVariationSelector as string
+									styleVariationSelector as string,
+									selector,
+									styleVariationName
 								);
 
 								// Generate layout styles for the variation if it supports layout and has blockGap defined.

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -164,6 +164,15 @@ const VALID_BLOCK_PSEUDO_SELECTORS: Record< string, string[] > = {
 };
 
 /**
+ * Responsive breakpoint state keys and their corresponding CSS media queries.
+ * Keep in sync with WP_Theme_JSON_Gutenberg::RESPONSIVE_BREAKPOINTS.
+ */
+const RESPONSIVE_BREAKPOINTS: Record< string, string > = {
+	mobile: '@media (width <= 480px)',
+	tablet: '@media (480px < width <= 782px)',
+};
+
+/**
  * Transform given preset tree into a set of preset class declarations.
  *
  * @param blockSelector Block selector string
@@ -875,9 +884,17 @@ function pickStyleAndPseudoKeys(
 	const allowedPseudoSelectors = blockName
 		? VALID_BLOCK_PSEUDO_SELECTORS[ blockName ] ?? []
 		: [];
+	// Responsive breakpoint keys are available for all blocks (blockName contains '/').
+	const includeResponsive = blockName?.includes( '/' ) ?? false;
 	const pickedEntries = entries.filter(
 		( [ key ] ) =>
-			STYLE_KEYS.includes( key ) || allowedPseudoSelectors.includes( key )
+			STYLE_KEYS.includes( key ) ||
+			allowedPseudoSelectors.includes( key ) ||
+			( includeResponsive &&
+				Object.prototype.hasOwnProperty.call(
+					RESPONSIVE_BREAKPOINTS,
+					key
+				) )
 	);
 	// clone the style objects so that `getFeatureDeclarations` can remove consumed keys from it
 	const clonedEntries = pickedEntries.map( ( [ key, style ] ) => [
@@ -968,6 +985,104 @@ function appendPseudoSelectorStyles(
 		) };}`;
 
 		ruleset += pseudoRule;
+	} );
+
+	return ruleset;
+}
+
+/**
+ * Appends CSS rules for responsive breakpoint states to a ruleset string.
+ * Block styles stored under 'mobile' or 'tablet' keys are wrapped in the
+ * corresponding media queries instead of being appended to the selector.
+ *
+ * @param styles                 The styles object potentially containing responsive keys.
+ * @param selector               The base CSS selector for the block.
+ * @param ruleset                The accumulating CSS ruleset string.
+ * @param featureSelectors       Optional feature-level selectors for the block.
+ * @param treeSettings           Global styles settings tree.
+ * @param styleVariationSelector Optional style variation selector.
+ * @return Updated ruleset string with responsive CSS rules appended.
+ */
+function appendResponsiveStyles(
+	styles: Record< string, any >,
+	selector: string,
+	ruleset: string,
+	featureSelectors:
+		| string
+		| Record< string, string | Record< string, string > >
+		| undefined,
+	treeSettings: Record< string, any > | undefined,
+	styleVariationSelector?: string
+): string {
+	const responsiveStyles = Object.entries( styles ).filter( ( [ key ] ) =>
+		Object.prototype.hasOwnProperty.call( RESPONSIVE_BREAKPOINTS, key )
+	);
+
+	if ( ! responsiveStyles.length ) {
+		return ruleset;
+	}
+
+	responsiveStyles.forEach( ( [ breakpointKey, breakpointStyle ] ) => {
+		if ( ! breakpointStyle || typeof breakpointStyle !== 'object' ) {
+			return;
+		}
+
+		const mediaQuery = RESPONSIVE_BREAKPOINTS[ breakpointKey ];
+		const remainingBreakpointStyles = JSON.parse(
+			JSON.stringify( breakpointStyle )
+		);
+
+		if ( featureSelectors && typeof featureSelectors !== 'string' ) {
+			let breakpointFeatureDeclarations = getFeatureDeclarations(
+				featureSelectors,
+				remainingBreakpointStyles
+			);
+
+			breakpointFeatureDeclarations = updateParagraphTextIndentSelector(
+				breakpointFeatureDeclarations,
+				treeSettings,
+				undefined
+			);
+
+			breakpointFeatureDeclarations = updateButtonWidthDeclarations(
+				breakpointFeatureDeclarations,
+				treeSettings
+			);
+
+			Object.entries( breakpointFeatureDeclarations ).forEach(
+				( [ baseSelector, declarations ] ) => {
+					if ( ! declarations.length ) {
+						return;
+					}
+					const cssSelector = styleVariationSelector
+						? concatFeatureVariationSelectorString(
+								baseSelector,
+								styleVariationSelector
+						  )
+						: baseSelector;
+					const rules = declarations.join( ';' );
+					ruleset += `${ mediaQuery }{:root :where(${ cssSelector }){${ rules };}}`;
+				}
+			);
+		}
+
+		const breakpointDeclarations = getStylesDeclarations(
+			remainingBreakpointStyles
+		);
+
+		if ( ! breakpointDeclarations.length ) {
+			return;
+		}
+
+		const cssSelector = styleVariationSelector
+			? concatFeatureVariationSelectorString(
+					selector,
+					styleVariationSelector
+			  )
+			: selector;
+		ruleset += `${ mediaQuery }{:root :where(${ cssSelector }){${ breakpointDeclarations.join(
+			';'
+		) };}}`;
 	} );
 
 	return ruleset;
@@ -1682,6 +1797,15 @@ export const transformToStyles = (
 									styleVariationSelector as string
 								);
 
+								ruleset = appendResponsiveStyles(
+									styleVariations,
+									styleVariationSelector as string,
+									ruleset,
+									featureSelectors,
+									tree.settings,
+									styleVariationSelector as string
+								);
+
 								// Generate layout styles for the variation if it supports layout and has blockGap defined.
 								if (
 									hasLayoutSupport &&
@@ -1710,6 +1834,14 @@ export const transformToStyles = (
 					featureSelectors,
 					tree.settings,
 					name
+				);
+
+				ruleset = appendResponsiveStyles(
+					styles,
+					selector,
+					ruleset,
+					featureSelectors,
+					tree.settings
 				);
 			}
 		);

--- a/packages/global-styles-ui/src/hooks.ts
+++ b/packages/global-styles-ui/src/hooks.ts
@@ -53,6 +53,12 @@ export function useStyle< T = any >(
 	state?: string
 ) {
 	const { user, base, merged, onChange } = useContext( GlobalStylesContext );
+	const isPseudoSelectorState = state?.startsWith( ':' );
+	const pseudoSelectorState = isPseudoSelectorState ? state : undefined;
+	const stylePath =
+		state && ! isPseudoSelectorState
+			? [ path, state ].filter( Boolean ).join( '.' )
+			: path;
 
 	let sourceValue = merged;
 	if ( readFrom === 'base' ) {
@@ -61,23 +67,33 @@ export function useStyle< T = any >(
 		sourceValue = user;
 	}
 
-	const styleValue = useMemo( () => {
+	const styleValue = useMemo< T | undefined >( () => {
 		const rawValue = getStyle< T >(
 			sourceValue,
-			path,
+			stylePath,
 			blockName,
 			shouldDecodeEncode
 		);
-		if ( state ) {
-			return ( rawValue as any )?.[ state ] ?? {};
+		if ( pseudoSelectorState ) {
+			return (
+				( rawValue as Record< string, T | undefined > )?.[
+					pseudoSelectorState
+				] ?? ( {} as T )
+			);
 		}
 		return rawValue;
-	}, [ sourceValue, path, blockName, shouldDecodeEncode, state ] );
+	}, [
+		sourceValue,
+		stylePath,
+		blockName,
+		shouldDecodeEncode,
+		pseudoSelectorState,
+	] );
 
 	const setStyleValue = useCallback(
 		( newValue: T | undefined ) => {
 			let valueToSet: any = newValue;
-			if ( state ) {
+			if ( pseudoSelectorState ) {
 				const fullCurrentValue = getStyle(
 					user,
 					path,
@@ -86,18 +102,18 @@ export function useStyle< T = any >(
 				);
 				valueToSet = {
 					...( fullCurrentValue as object ),
-					[ state ]: newValue,
+					[ pseudoSelectorState ]: newValue,
 				};
 			}
 			const newGlobalStyles = setStyle< any >(
 				user,
-				path,
+				stylePath,
 				valueToSet,
 				blockName
 			);
 			onChange( newGlobalStyles );
 		},
-		[ user, onChange, path, blockName, state ]
+		[ user, onChange, path, stylePath, blockName, pseudoSelectorState ]
 	);
 
 	return [ styleValue, setStyleValue ] as const;

--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -263,9 +263,14 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 		// If there are settings changes, we need to update both styles and
 		// settings atomically to avoid race conditions.
 		if ( newSettings?.typography ) {
+			// Build the state-aware path so that breakpoint styles (e.g. mobile)
+			// are written to the correct sub-path and do not overwrite the default.
+			const stylePathForBreakpoint = [ prefix, stateParam ]
+				.filter( Boolean )
+				.join( '.' );
 			let updatedConfig = setStyleHelper(
 				userConfig,
-				prefix,
+				stylePathForBreakpoint,
 				styleWithoutSettings,
 				name
 			);
@@ -366,7 +371,10 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 					value={ style }
 					onChange={ onChangeTypography }
 					settings={ settings }
-					isGlobalStyles
+					// Only expose global-settings controls (e.g. "Indent all
+					// paragraphs") when not editing a breakpoint-specific state,
+					// because those settings are global and cannot be per-breakpoint.
+					isGlobalStyles={ selectedState === 'default' }
 				/>
 			) }
 			{ hasDimensionsPanel && (
@@ -395,7 +403,7 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 					includeLayoutControls
 				/>
 			) }
-			{ hasImageSettingsPanel && (
+			{ hasImageSettingsPanel && selectedState === 'default' && (
 				<ImageSettingsPanel
 					onChange={ onChangeLightbox }
 					value={ userSettings }

--- a/packages/global-styles-ui/src/utils.ts
+++ b/packages/global-styles-ui/src/utils.ts
@@ -52,15 +52,26 @@ export const VALID_BLOCK_STATES: Record< string, StateDefinition[] > = {
 };
 
 /**
+ * Responsive breakpoint states available for all blocks.
+ * These map to CSS media queries wrapping the block's styles.
+ */
+export const RESPONSIVE_STATES: StateDefinition[] = [
+	{ value: 'mobile', label: __( 'Mobile' ) },
+	{ value: 'tablet', label: __( 'Tablet' ) },
+];
+
+/**
  * Get the valid states for a given block or element.
  *
  * @param name The block name (e.g., 'core/button') or element name (e.g., 'button')
  * @return Array of valid state definitions, or empty array if none
  */
 export function getValidStates( name: string ): StateDefinition[] {
-	// Check if it's a block
-	if ( VALID_BLOCK_STATES[ name ] ) {
-		return VALID_BLOCK_STATES[ name ];
+	// Check if it's a block (contains a slash, e.g. 'core/button').
+	// All blocks receive responsive states by default.
+	if ( name.includes( '/' ) ) {
+		const blockPseudoStates = VALID_BLOCK_STATES[ name ] ?? [];
+		return [ ...blockPseudoStates, ...RESPONSIVE_STATES ];
 	}
 
 	// Check if it's an element

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -25,7 +25,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Registers a block with `__experimentalStates` support.
+	 * Registers a block with `states` support.
 	 *
 	 * @param string $block_name Block name.
 	 * @param array  $selectors  Optional block selectors (e.g. `['root' => '.foo .bar']`).
@@ -39,7 +39,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 				'style' => array( 'type' => 'object' ),
 			),
 			'supports'    => array(
-				'__experimentalStates' => array( ':hover', ':focus', ':active' ),
+				'states' => array( ':hover', ':focus', ':active' ),
 			),
 		);
 		if ( ! empty( $selectors ) ) {
@@ -123,7 +123,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that block content is returned unchanged when `__experimentalStates` support is not declared.
+	 * Tests that block content is returned unchanged when `states` support is not declared.
 	 *
 	 * @covers ::gutenberg_render_block_states_support
 	 */

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -1,0 +1,532 @@
+<?php
+/**
+ * Tests the states block support.
+ *
+ * @package gutenberg
+ */
+
+class WP_Block_Supports_States_Test extends WP_UnitTestCase {
+	/**
+	 * @var string|null
+	 */
+	private $test_block_name;
+
+	public function set_up() {
+		parent::set_up();
+		$this->test_block_name = null;
+	}
+
+	public function tear_down() {
+		if ( $this->test_block_name ) {
+			unregister_block_type( $this->test_block_name );
+		}
+		$this->test_block_name = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Registers a block with `__experimentalStates` support.
+	 *
+	 * @param string $block_name Block name.
+	 * @param array  $selectors  Optional block selectors (e.g. `['root' => '.foo .bar']`).
+	 * @return WP_Block_Type
+	 */
+	private function register_block_with_states( $block_name, $selectors = array() ) {
+		$this->test_block_name = $block_name;
+		$args                  = array(
+			'api_version' => 3,
+			'attributes'  => array(
+				'style' => array( 'type' => 'object' ),
+			),
+			'supports'    => array(
+				'__experimentalStates' => array( ':hover', ':focus', ':active' ),
+			),
+		);
+		if ( ! empty( $selectors ) ) {
+			$args['selectors'] = $selectors;
+		}
+		register_block_type( $block_name, $args );
+
+		return WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
+	}
+
+	/**
+	 * Mirrors the CSS-building logic in gutenberg_render_block_states_support()
+	 * to produce the expected `<style>` tag and unique scoped class name for a
+	 * given map of state => style arrays.
+	 *
+	 * @param array $state_styles Map of state to style array (e.g. `[':hover' => ['color' => [...]]]`).
+	 * @return array { style_tag: string, unique_class: string }
+	 */
+	private function build_expected_state_output( $state_styles ) {
+		$css_rules = array();
+		foreach ( $state_styles as $state => $style ) {
+			$compiled = wp_style_engine_get_styles( $style );
+			if ( ! empty( $compiled['css'] ) ) {
+				$css_rules[] = array(
+					'state' => $state,
+					'css'   => $compiled['css'],
+				);
+			}
+		}
+
+		$unique_class = 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 );
+		$css          = '';
+		foreach ( $css_rules as $rule ) {
+			$declarations = str_replace( ';', ' !important;', $rule['css'] );
+			$css         .= ".$unique_class$rule[state] { $declarations }\n";
+		}
+
+		return array(
+			'style_tag'    => '<style>' . $css . '</style>',
+			'unique_class' => $unique_class,
+		);
+	}
+
+	/**
+	 * Tests that block content is returned unchanged when the block name is missing.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_returns_unchanged_when_block_name_missing() {
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$block         = array(
+			'blockName' => '',
+			'attrs'     => array(),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $block_content, $actual );
+	}
+
+	/**
+	 * Tests that block content is returned unchanged when content is empty.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_returns_unchanged_when_block_content_empty() {
+		$this->register_block_with_states( 'test/states-empty-content' );
+
+		$block = array(
+			'blockName' => 'test/states-empty-content',
+			'attrs'     => array(
+				'style' => array(
+					':hover' => array( 'color' => array( 'text' => '#ff0000' ) ),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_block_states_support( '', $block );
+
+		$this->assertSame( '', $actual );
+	}
+
+	/**
+	 * Tests that block content is returned unchanged when `__experimentalStates` support is not declared.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_returns_unchanged_when_states_support_not_declared() {
+		$this->test_block_name = 'test/no-states-support';
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'style' => array( 'type' => 'object' ),
+				),
+				'supports'    => array(),
+			)
+		);
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$block         = array(
+			'blockName' => 'test/no-states-support',
+			'attrs'     => array(
+				'style' => array(
+					':hover' => array( 'color' => array( 'text' => '#ff0000' ) ),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $block_content, $actual );
+	}
+
+	/**
+	 * Tests that block content is returned unchanged when no state styles are set.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_returns_unchanged_when_no_state_styles_set() {
+		$this->register_block_with_states( 'test/states-no-state-style' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$block         = array(
+			'blockName' => 'test/states-no-state-style',
+			'attrs'     => array(
+				'style' => array(
+					'color' => array( 'text' => '#000000' ),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $block_content, $actual );
+	}
+
+	/**
+	 * Tests that block content is returned unchanged when the state key is an empty array.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_returns_unchanged_when_state_style_is_empty_array() {
+		$this->register_block_with_states( 'test/states-empty-hover' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$block         = array(
+			'blockName' => 'test/states-empty-hover',
+			'attrs'     => array(
+				'style' => array(
+					':hover' => array(),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $block_content, $actual );
+	}
+
+	/**
+	 * Tests that hover text color generates a scoped style tag with !important.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_hover_text_color_generates_scoped_css() {
+		$this->register_block_with_states( 'test/states-hover-text-color' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array( ':hover' => array( 'color' => array( 'text' => '#e6ffe8' ) ) );
+		$block         = array(
+			'blockName' => 'test/states-hover-text-color',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that hover background color generates a scoped style tag.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_hover_background_color_generates_scoped_css() {
+		$this->register_block_with_states( 'test/states-hover-bg-color' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array( ':hover' => array( 'color' => array( 'background' => '#ff00d0' ) ) );
+		$block         = array(
+			'blockName' => 'test/states-hover-bg-color',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that hover text and background color both appear in a single rule.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_hover_text_and_background_color_in_same_rule() {
+		$this->register_block_with_states( 'test/states-hover-both-colors' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array(
+			':hover' => array(
+				'color' => array(
+					'background' => '#ff00d0',
+					'text'       => '#e6ffe8',
+				),
+			),
+		);
+		$block         = array(
+			'blockName' => 'test/states-hover-both-colors',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that a font family stored as a preset reference is resolved to a CSS
+	 * custom property in the generated style tag.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_hover_font_family_preset_reference_generates_css_custom_property() {
+		$this->register_block_with_states( 'test/states-hover-font-family' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array(
+			':hover' => array(
+				'typography' => array( 'fontFamily' => 'var:preset|font-family|heading' ),
+			),
+		);
+		$block         = array(
+			'blockName' => 'test/states-hover-font-family',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that hover font size generates a scoped style tag.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_hover_font_size_generates_scoped_css() {
+		$this->register_block_with_states( 'test/states-hover-font-size' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array(
+			':hover' => array(
+				'typography' => array( 'fontSize' => '1.5rem' ),
+			),
+		);
+		$block         = array(
+			'blockName' => 'test/states-hover-font-size',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that hover border width and color generate a scoped style tag.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_hover_border_width_and_color_generate_scoped_css() {
+		$this->register_block_with_states( 'test/states-hover-border' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array(
+			':hover' => array(
+				'border' => array(
+					'width' => '2px',
+					'color' => '#000000',
+				),
+			),
+		);
+		$block         = array(
+			'blockName' => 'test/states-hover-border',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that hover border radius generates a scoped style tag.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_hover_border_radius_generates_scoped_css() {
+		$this->register_block_with_states( 'test/states-hover-border-radius' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array(
+			':hover' => array(
+				'border' => array( 'radius' => '8px' ),
+			),
+		);
+		$block         = array(
+			'blockName' => 'test/states-hover-border-radius',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that multiple states each generate a separate scoped CSS rule.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_multiple_states_generate_separate_css_rules() {
+		$this->register_block_with_states( 'test/states-multiple' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array(
+			':hover' => array( 'color' => array( 'text' => '#ff0000' ) ),
+			':focus' => array( 'color' => array( 'text' => '#00ff00' ) ),
+		);
+		$block         = array(
+			'blockName' => 'test/states-multiple',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that the unique scoped class is added to the wrapper element for a
+	 * block with no descendant root selector.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_unique_class_is_added_to_wrapper_when_no_root_selector() {
+		$this->register_block_with_states( 'test/states-wrapper' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array( ':hover' => array( 'color' => array( 'text' => '#ff0000' ) ) );
+		$block         = array(
+			'blockName' => 'test/states-wrapper',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that the unique scoped class is added to the descendant element (not
+	 * the wrapper) for a block whose `selectors.root` targets a descendant, so
+	 * that `.wp-states-XXXX:hover` matches correctly.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_unique_class_is_added_to_descendant_not_wrapper_when_root_selector_has_descendant() {
+		$this->register_block_with_states(
+			'test/states-descendant',
+			array( 'root' => '.wp-block-button .wp-block-button__link' )
+		);
+
+		$block_content = '<div class="wp-block-button"><a class="wp-block-button__link">Click me</a></div>';
+		$state_styles  = array( ':hover' => array( 'color' => array( 'background' => '#ff00d0' ) ) );
+		$block         = array(
+			'blockName' => 'test/states-descendant',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-button"><a class="wp-block-button__link ' . $parts['unique_class'] . '">Click me</a></div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Integration test using the exact block markup and style attribute captured
+	 * from a core/button block in the editor with Twenty Twenty-Four theme.
+	 * Covers color, typography (preset font family reference), and class injection
+	 * onto the descendant element.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_button_like_block_with_hover_color_and_font_family_preset() {
+		$this->register_block_with_states(
+			'test/states-button-full',
+			array( 'root' => '.wp-block-button .wp-block-button__link' )
+		);
+
+		$block_content = '<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-accent-4-background-color has-text-color has-background has-link-color wp-element-button" style="color:#bdfffb">Button 2 outline</a></div>';
+		$state_styles  = array(
+			':hover' => array(
+				'color'      => array(
+					'background' => '#ff00d0',
+					'text'       => '#e6ffe8',
+				),
+				// Font family is stored as a preset reference by the editor.
+				'typography' => array(
+					'fontFamily' => 'var:preset|font-family|heading',
+				),
+			),
+		);
+		$block         = array(
+			'blockName' => 'test/states-button-full',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-accent-4-background-color has-text-color has-background has-link-color wp-element-button ' . $parts['unique_class'] . '" style="color:#bdfffb">Button 2 outline</a></div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that hover border styles on a button-like block are scoped to the
+	 * descendant element.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_button_like_block_with_hover_border() {
+		$this->register_block_with_states(
+			'test/states-button-border',
+			array( 'root' => '.wp-block-button .wp-block-button__link' )
+		);
+
+		$block_content = '<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Click</a></div>';
+		$state_styles  = array(
+			':hover' => array(
+				'border' => array(
+					'color' => '#0000ff',
+					'width' => '3px',
+					'style' => 'dashed',
+				),
+			),
+		);
+		$block         = array(
+			'blockName' => 'test/states-button-border',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-button"><a class="wp-block-button__link wp-element-button ' . $parts['unique_class'] . '">Click</a></div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+}

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -484,7 +484,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 				),
 			),
 		);
-		$block         = array(
+		$block = array(
 			'blockName' => 'test/states-button-full',
 			'attrs'     => array( 'style' => $state_styles ),
 		);

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -52,34 +52,26 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 
 	/**
 	 * Mirrors the CSS-building logic in gutenberg_render_block_states_support()
-	 * to produce the expected `<style>` tag and unique scoped class name for a
-	 * given map of state => style arrays.
+	 * to produce the unique scoped class name for a given map of state => style arrays.
+	 * CSS is now registered with the style engine store rather than injected inline.
 	 *
 	 * @param array $state_styles Map of state to style array (e.g. `[':hover' => ['color' => [...]]]`).
-	 * @return array { style_tag: string, unique_class: string }
+	 * @return array { unique_class: string }
 	 */
 	private function build_expected_state_output( $state_styles ) {
 		$css_rules = array();
 		foreach ( $state_styles as $state => $style ) {
 			$compiled = wp_style_engine_get_styles( $style );
-			if ( ! empty( $compiled['css'] ) ) {
+			if ( ! empty( $compiled['declarations'] ) ) {
 				$css_rules[] = array(
-					'state' => $state,
-					'css'   => $compiled['css'],
+					'state'        => $state,
+					'declarations' => $compiled['declarations'],
 				);
 			}
 		}
 
-		$unique_class = 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 );
-		$css          = '';
-		foreach ( $css_rules as $rule ) {
-			$declarations = str_replace( ';', ' !important;', $rule['css'] );
-			$css         .= ".$unique_class$rule[state] { $declarations }\n";
-		}
-
 		return array(
-			'style_tag'    => '<style>' . $css . '</style>',
-			'unique_class' => $unique_class,
+			'unique_class' => 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 ),
 		);
 	}
 
@@ -202,7 +194,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that hover text color generates a scoped style tag with !important.
+	 * Tests that hover text color generates scoped CSS with !important.
 	 *
 	 * @covers ::gutenberg_render_block_states_support
 	 */
@@ -217,14 +209,14 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
 	}
 
 	/**
-	 * Tests that hover background color generates a scoped style tag.
+	 * Tests that hover background color generates scoped CSS.
 	 *
 	 * @covers ::gutenberg_render_block_states_support
 	 */
@@ -239,7 +231,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -268,7 +260,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -295,14 +287,14 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
 	}
 
 	/**
-	 * Tests that hover font size generates a scoped style tag.
+	 * Tests that hover font size generates scoped CSS.
 	 *
 	 * @covers ::gutenberg_render_block_states_support
 	 */
@@ -321,7 +313,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -350,14 +342,14 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
 	}
 
 	/**
-	 * Tests that hover border radius generates a scoped style tag.
+	 * Tests that hover border radius generates scoped CSS.
 	 *
 	 * @covers ::gutenberg_render_block_states_support
 	 */
@@ -376,7 +368,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -401,7 +393,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -424,7 +416,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -451,7 +443,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-button"><a class="wp-block-button__link ' . $parts['unique_class'] . '">Click me</a></div>';
+		$expected = '<div class="wp-block-button"><a class="wp-block-button__link ' . $parts['unique_class'] . '">Click me</a></div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -490,7 +482,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-accent-4-background-color has-text-color has-background has-link-color wp-element-button ' . $parts['unique_class'] . '" style="color:#bdfffb">Button 2 outline</a></div>';
+		$expected = '<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-accent-4-background-color has-text-color has-background has-link-color wp-element-button ' . $parts['unique_class'] . '" style="color:#bdfffb">Button 2 outline</a></div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -524,7 +516,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-button"><a class="wp-block-button__link wp-element-button ' . $parts['unique_class'] . '">Click</a></div>';
+		$expected = '<div class="wp-block-button"><a class="wp-block-button__link wp-element-button ' . $parts['unique_class'] . '">Click</a></div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2736,6 +2736,116 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
+	/**
+	 * @covers WP_Theme_JSON_Gutenberg::remove_insecure_properties
+	 */
+	public function test_remove_insecure_properties_preserves_responsive_block_element_styles() {
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/group' => array(
+							'elements' => array(
+								'link' => array(
+									'color'  => array(
+										'text' => 'var:preset|color|dark-gray',
+									),
+									'mobile' => array(
+										'color' => array(
+											'text' => 'var:preset|color|dark-pink',
+										),
+									),
+									'tablet' => array(
+										'color' => array(
+											'text' => 'var:preset|color|dark-red',
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = array(
+			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'styles'  => array(
+				'blocks' => array(
+					'core/group' => array(
+						'elements' => array(
+							'link' => array(
+								'color'  => array(
+									'text' => 'var(--wp--preset--color--dark-gray)',
+								),
+								'mobile' => array(
+									'color' => array(
+										'text' => 'var(--wp--preset--color--dark-pink)',
+									),
+								),
+								'tablet' => array(
+									'color' => array(
+										'text' => 'var(--wp--preset--color--dark-red)',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Gutenberg::remove_insecure_properties
+	 */
+	public function test_remove_insecure_properties_preserves_responsive_elements_within_block_state() {
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/group' => array(
+							'mobile' => array(
+								'elements' => array(
+									'link' => array(
+										'color' => array(
+											'text' => 'var:preset|color|dark-pink',
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = array(
+			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'styles'  => array(
+				'blocks' => array(
+					'core/group' => array(
+						'mobile' => array(
+							'elements' => array(
+								'link' => array(
+									'color' => array(
+										'text' => 'var(--wp--preset--color--dark-pink)',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
 	public function test_remove_insecure_properties_removes_non_preset_settings() {
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -957,28 +957,273 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSameCSS( $focus_style, $theme_json->get_styles_for_block( $focus_node ) );
 	}
 
-	public function test_process_responsive_selectors_outputs_media_wrapped_css() {
-		$node = array(
-			'mobile' => array(
-				'color' => array(
-					'text' => 'red',
+	public function test_get_styles_for_block_responsive_feature_selector_not_duplicated_on_base_selector() {
+		register_block_type(
+			'test/responsive-feature',
+			array(
+				'api_version' => 3,
+				'selectors'   => array(
+					'root'  => '.wp-block-test-responsive-feature',
+					'color' => '.wp-block-test-responsive-feature .color-target',
 				),
+			)
+		);
+
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'test/responsive-feature' => array(
+							'mobile' => array(
+								'color' => array(
+									'text' => 'red',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$metadata = array(
+			'name'      => 'test/responsive-feature',
+			'path'      => array( 'styles', 'blocks', 'test/responsive-feature' ),
+			'selector'  => '.wp-block-test-responsive-feature',
+			'selectors' => array(
+				'color' => '.wp-block-test-responsive-feature .color-target',
 			),
-			'tablet' => array(
-				'spacing' => array(
-					'margin' => '1rem',
+		);
+
+		$actual_styles = $theme_json->get_styles_for_block( $metadata );
+
+		unregister_block_type( 'test/responsive-feature' );
+
+		$this->assertStringContainsString(
+			'@media (width <= 480px){:root :where(.wp-block-test-responsive-feature .color-target){color: red;}}',
+			$actual_styles
+		);
+		$this->assertStringNotContainsString(
+			'@media (width <= 480px){:root :where(.wp-block-test-responsive-feature){color: red;}}',
+			$actual_styles
+		);
+	}
+
+	public function test_get_styles_for_block_outputs_responsive_block_gap_after_default_gap() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'spacing' => array(
+						'blockGap' => true,
+					),
+				),
+				'styles'   => array(
+					'blocks' => array(
+						'core/group' => array(
+							'spacing' => array(
+								'blockGap' => '5rem',
+							),
+							'mobile'  => array(
+								'spacing' => array(
+									'blockGap' => '2rem',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$metadata = array(
+			'name'     => 'core/group',
+			'path'     => array( 'styles', 'blocks', 'core/group' ),
+			'selector' => '.wp-block-group',
+			'css'      => '.wp-block-group',
+		);
+
+		$actual_styles = $theme_json->get_styles_for_block( $metadata );
+
+		$default_gap = ':root :where(.wp-block-group-is-layout-flex){gap: 5rem;}';
+		$mobile_gap  = ':root :where(.wp-block-group-is-layout-flex){gap: 2rem;}';
+
+		$this->assertStringContainsString( $default_gap, $actual_styles );
+		$this->assertStringContainsString( '@media (width <= 480px)', $actual_styles );
+		$this->assertStringContainsString( $mobile_gap, $actual_styles );
+		$this->assertLessThan( strpos( $actual_styles, $mobile_gap ), strpos( $actual_styles, $default_gap ) );
+	}
+
+	public function test_get_styles_for_block_responsive_element_pseudo_styles_preserve_order_and_do_not_duplicate_pseudo() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/group' => array(
+							'elements' => array(
+								'link' => array(
+									'color'  => array(
+										'text' => 'blue',
+									),
+									':hover' => array(
+										'color' => array(
+											'text' => 'navy',
+										),
+									),
+								),
+							),
+							'mobile'   => array(
+								'elements' => array(
+									'link' => array(
+										'color'  => array(
+											'text' => 'red',
+										),
+										':hover' => array(
+											'color' => array(
+												'text' => 'darkred',
+											),
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$link_node = array(
+			'path'     => array( 'styles', 'blocks', 'core/group', 'elements', 'link' ),
+			'selector' => '.wp-block-group a:where(:not(.wp-element-button))',
+		);
+
+		$hover_node = array(
+			'path'     => array( 'styles', 'blocks', 'core/group', 'elements', 'link' ),
+			'selector' => '.wp-block-group a:where(:not(.wp-element-button)):hover',
+		);
+
+		$actual_styles = $theme_json->get_styles_for_block( $link_node ) . $theme_json->get_styles_for_block( $hover_node );
+
+		$default_link = ':root :where(.wp-block-group a:where(:not(.wp-element-button))){color: blue;}';
+		$mobile_link  = '@media (width <= 480px){:root :where(.wp-block-group a:where(:not(.wp-element-button))){color: red;}}';
+		$default_hov  = ':root :where(.wp-block-group a:where(:not(.wp-element-button)):hover){color: navy;}';
+		$mobile_hov   = '@media (width <= 480px){:root :where(.wp-block-group a:where(:not(.wp-element-button)):hover){color: darkred;}}';
+
+		$this->assertStringContainsString( $default_link, $actual_styles );
+		$this->assertStringContainsString( $mobile_link, $actual_styles );
+		$this->assertStringContainsString( $default_hov, $actual_styles );
+		$this->assertStringContainsString( $mobile_hov, $actual_styles );
+
+		$this->assertLessThan( strpos( $actual_styles, $mobile_link ), strpos( $actual_styles, $default_link ) );
+		$this->assertLessThan( strpos( $actual_styles, $default_hov ), strpos( $actual_styles, $mobile_link ) );
+		$this->assertLessThan( strpos( $actual_styles, $mobile_hov ), strpos( $actual_styles, $default_hov ) );
+		$this->assertStringNotContainsString( ':hover:hover', $actual_styles );
+	}
+
+	public function test_get_styles_for_block_with_style_variations_and_responsive_block_gap() {
+		register_block_style(
+			'core/group',
+			array(
+				'name'  => 'withGap',
+				'label' => 'With Gap',
+			)
+		);
+
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'spacing' => array(
+						'blockGap' => true,
+					),
+				),
+				'styles'   => array(
+					'blocks' => array(
+						'core/group' => array(
+							'variations' => array(
+								'withGap' => array(
+									'spacing' => array(
+										'blockGap' => '5rem',
+									),
+									'mobile'  => array(
+										'spacing' => array(
+											'blockGap' => '2rem',
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$metadata = array(
+			'name'       => 'core/group',
+			'path'       => array( 'styles', 'blocks', 'core/group' ),
+			'selector'   => '.wp-block-group',
+			'css'        => '.wp-block-group',
+			'variations' => array(
+				array(
+					'path'     => array( 'styles', 'blocks', 'core/group', 'variations', 'withGap' ),
+					'selector' => '.is-style-withGap.wp-block-group',
 				),
 			),
 		);
 
-		$reflection = new ReflectionMethod( WP_Theme_JSON_Gutenberg::class, 'process_responsive_selectors' );
-		$reflection->setAccessible( true );
+		$actual_styles = $theme_json->get_styles_for_block( $metadata );
 
-		$actual = $reflection->invoke( null, $node, '.wp-block-group', array() );
+		unregister_block_style( 'core/group', 'withGap' );
 
-		$expected = '@media (width <= 480px){:root :where(.wp-block-group){color: red;}}@media (480px < width <= 782px){:root :where(.wp-block-group){margin: 1rem;}}';
+		$default_gap = ':root :where(.is-style-withGap.wp-block-group.wp-block-group-is-layout-flex){gap: 5rem;}';
+		$mobile_gap  = ':root :where(.is-style-withGap.wp-block-group.wp-block-group-is-layout-flex){gap: 2rem;}';
 
-		$this->assertSameCSS( $expected, $actual );
+		$this->assertStringContainsString( $default_gap, $actual_styles );
+		$this->assertStringContainsString( '@media (width <= 480px)', $actual_styles );
+		$this->assertStringContainsString( $mobile_gap, $actual_styles );
+		$this->assertLessThan( strpos( $actual_styles, $mobile_gap ), strpos( $actual_styles, $default_gap ) );
+	}
+
+	public function test_get_styles_for_block_outputs_tablet_responsive_styles_only() {
+		register_block_type(
+			'test/tablet-only',
+			array(
+				'api_version' => 3,
+			)
+		);
+
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'test/tablet-only' => array(
+							'tablet' => array(
+								'color' => array(
+									'text' => 'purple',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$metadata = array(
+			'name'     => 'test/tablet-only',
+			'path'     => array( 'styles', 'blocks', 'test/tablet-only' ),
+			'selector' => '.wp-block-test-tablet-only',
+		);
+
+		$actual_styles = $theme_json->get_styles_for_block( $metadata );
+
+		unregister_block_type( 'test/tablet-only' );
+
+		$this->assertStringContainsString(
+			'@media (480px < width <= 782px){:root :where(.wp-block-test-tablet-only){color: purple;}}',
+			$actual_styles
+		);
+		$this->assertStringNotContainsString( '@media (width <= 480px)', $actual_styles );
 	}
 
 	/**

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -957,6 +957,30 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSameCSS( $focus_style, $theme_json->get_styles_for_block( $focus_node ) );
 	}
 
+	public function test_process_responsive_selectors_outputs_media_wrapped_css() {
+		$node = array(
+			'mobile' => array(
+				'color' => array(
+					'text' => 'red',
+				),
+			),
+			'tablet' => array(
+				'spacing' => array(
+					'margin' => '1rem',
+				),
+			),
+		);
+
+		$reflection = new ReflectionMethod( WP_Theme_JSON_Gutenberg::class, 'process_responsive_selectors' );
+		$reflection->setAccessible( true );
+
+		$actual = $reflection->invoke( null, $node, '.wp-block-group', array() );
+
+		$expected = '@media (width <= 480px){:root :where(.wp-block-group){color: red;}}@media (480px < width <= 782px){:root :where(.wp-block-group){margin: 1rem;}}';
+
+		$this->assertSameCSS( $expected, $actual );
+	}
+
 	/**
 	 * Tests that if an element has nothing but pseudo selector styles, they are still output by get_stylesheet.
 	 */

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -608,6 +608,13 @@
 						}
 					}
 				},
+				"states": {
+					"description": "An array of interactive pseudo-states (e.g. \":hover\", \":focus\", \":active\") for which the block supports per-instance style overrides. Custom state keys are also supported for future extensibility.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
 				"shadow": {
 					"description": "Allow blocks to define a box shadow.",
 					"oneOf": [

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1863,6 +1863,21 @@
 		"stylesBlocksPseudoSelectorsPropertyNames": {
 			"enum": [ ":hover", ":focus", ":focus-visible", ":active" ]
 		},
+		"stylesBlocksResponsiveSelectorsProperties": {
+			"description": "Responsive block states keyed by breakpoint name. Each breakpoint supports the same style properties as the default block state.",
+			"type": "object",
+			"properties": {
+				"mobile": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"tablet": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				}
+			}
+		},
+		"stylesBlocksResponsiveSelectorsPropertyNames": {
+			"enum": [ "mobile", "tablet" ]
+		},
 		"stylesElementsPseudoSelectorsProperties": {
 			"type": "object",
 			"properties": {
@@ -2040,6 +2055,9 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
+							"$ref": "#/definitions/stylesBlocksResponsiveSelectorsProperties"
+						},
+						{
 							"type": "object",
 							"properties": {
 								"variations": {
@@ -2051,6 +2069,9 @@
 													"$ref": "#/definitions/stylesProperties"
 												},
 												{
+													"$ref": "#/definitions/stylesBlocksResponsiveSelectorsProperties"
+												},
+												{
 													"$ref": "#/definitions/stylesBlocksPseudoSelectorsProperties"
 												},
 												{
@@ -2059,6 +2080,9 @@
 														"anyOf": [
 															{
 																"$ref": "#/definitions/stylesPropertyNames"
+															},
+															{
+																"$ref": "#/definitions/stylesBlocksResponsiveSelectorsPropertyNames"
 															},
 															{
 																"$ref": "#/definitions/stylesBlocksPseudoSelectorsPropertyNames"
@@ -2084,6 +2108,9 @@
 									},
 									{
 										"enum": [ "variations" ]
+									},
+									{
+										"$ref": "#/definitions/stylesBlocksResponsiveSelectorsPropertyNames"
 									},
 									{
 										"$ref": "#/definitions/stylesBlocksPseudoSelectorsPropertyNames"
@@ -2223,6 +2250,9 @@
 					"allOf": [
 						{
 							"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+						},
+						{
+							"$ref": "#/definitions/stylesBlocksResponsiveSelectorsProperties"
 						},
 						{
 							"$ref": "#/definitions/stylesBlocksPseudoSelectorsProperties"
@@ -2417,6 +2447,9 @@
 					"$ref": "#/definitions/stylesProperties"
 				},
 				{
+					"$ref": "#/definitions/stylesBlocksResponsiveSelectorsProperties"
+				},
+				{
 					"type": "object",
 					"properties": {
 						"elements": {
@@ -2433,6 +2466,9 @@
 						"anyOf": [
 							{
 								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"$ref": "#/definitions/stylesBlocksResponsiveSelectorsPropertyNames"
 							},
 							{
 								"enum": [ "elements", "variations" ]
@@ -2556,6 +2592,9 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
+							"$ref": "#/definitions/stylesBlocksResponsiveSelectorsProperties"
+						},
+						{
 							"$ref": "#/definitions/stylesBlocksPseudoSelectorsProperties"
 						},
 						{
@@ -2564,6 +2603,9 @@
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesBlocksResponsiveSelectorsPropertyNames"
 									},
 									{
 										"$ref": "#/definitions/stylesBlocksPseudoSelectorsPropertyNames"
@@ -2887,6 +2929,9 @@
 					"$ref": "#/definitions/stylesProperties"
 				},
 				{
+					"$ref": "#/definitions/stylesBlocksResponsiveSelectorsProperties"
+				},
+				{
 					"type": "object",
 					"properties": {
 						"elements": {
@@ -2900,6 +2945,9 @@
 						"anyOf": [
 							{
 								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"$ref": "#/definitions/stylesBlocksResponsiveSelectorsPropertyNames"
 							},
 							{
 								"enum": [ "elements" ]

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1932,6 +1932,21 @@
 				":visited"
 			]
 		},
+		"stylesElementsResponsiveSelectorsProperties": {
+			"description": "Responsive element states keyed by breakpoint name. Each breakpoint supports the same style properties as the default element state.",
+			"type": "object",
+			"properties": {
+				"mobile": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"tablet": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				}
+			}
+		},
+		"stylesElementsResponsiveSelectorsPropertyNames": {
+			"enum": [ "mobile", "tablet" ]
+		},
 		"stylesElementsPropertiesComplete": {
 			"description": "Styles defined on a per-element basis using the element's selector.",
 			"type": "object",
@@ -1942,6 +1957,9 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
+							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
+						},
+						{
 							"$ref": "#/definitions/stylesElementsPseudoSelectorsProperties"
 						},
 						{
@@ -1950,6 +1968,9 @@
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
 									},
 									{
 										"$ref": "#/definitions/stylesElementsPseudoSelectorsPropertyNames"
@@ -1965,6 +1986,9 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
+							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
+						},
+						{
 							"$ref": "#/definitions/stylesElementsPseudoSelectorsProperties"
 						},
 						{
@@ -1975,6 +1999,9 @@
 										"$ref": "#/definitions/stylesPropertyNames"
 									},
 									{
+										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
+									},
+									{
 										"$ref": "#/definitions/stylesElementsPseudoSelectorsPropertyNames"
 									}
 								]
@@ -1983,37 +2010,257 @@
 					]
 				},
 				"heading": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
+									}
+								]
+							}
+						}
+					]
 				},
 				"h1": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
+									}
+								]
+							}
+						}
+					]
 				},
 				"h2": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
+									}
+								]
+							}
+						}
+					]
 				},
 				"h3": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
+									}
+								]
+							}
+						}
+					]
 				},
 				"h4": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
+									}
+								]
+							}
+						}
+					]
 				},
 				"h5": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
+									}
+								]
+							}
+						}
+					]
 				},
 				"h6": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
+									}
+								]
+							}
+						}
+					]
 				},
 				"caption": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
+									}
+								]
+							}
+						}
+					]
 				},
 				"cite": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
+									}
+								]
+							}
+						}
+					]
 				},
 				"select": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
+									}
+								]
+							}
+						}
+					]
 				},
 				"textInput": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
+									}
+								]
+							}
+						}
+					]
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Very dodgy WIP glueing together #77513 and #76491 and adding support for responsive states on block instances.

This is just so we can have a play and see what is needed here.

## Problems revealed in testing

* the "Show state on canvas" toggle that #76491 adds for pseudo selectors doesn't really make sense for responsive states, so instead we're outputting the styles in the editor and users can view them by either resizing the window or using the device previews.

* currently we're only outputting responsive styles for block supports, but we'll need to support a bunch of custom settings like column numbers on Columns block (or at least reflowing to a given amount of columns - not actually changing the markup) so I'm guessing these will require individual, per-block adjustments.

* layout doesn't work out of the box, neither does child layout. this is probably due to all the custom logic in layout to output multiple styles. Spacing styles seem to be saved per breakpoint but no CSS is output.

* all the block supports that output inline styles don't work because the responsive styles are overridden by the inline ones. We could change them to output regular CSS or we could override them with `!important`. Changing them to regular CSS is the preferred option if at all possible.

* Switching to a different style variation on a breakpoint doesn't work (should it? probably not. but then we should ensure we only show the controls that work when a breakpoint is set)


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
