### PR TITLE
Media Editor Modal: interactive grid mode

### DIFF
--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -44,6 +44,7 @@ export default function MediaEditorCanvas( {
 				controller={ controller }
 				aspectRatio={ aspectRatio }
 				freeformCrop={ freeformCrop }
+				showGrid="interactive"
 			/>
 		</div>
 	);

--- a/packages/media-editor/src/image-editor/react/components/cropper.scss
+++ b/packages/media-editor/src/image-editor/react/components/cropper.scss
@@ -58,6 +58,7 @@ $handle-touch-target-size: 44px;
 		position: absolute;
 		pointer-events: none;
 		overflow: hidden;
+		transition: opacity 0.2s ease;
 	}
 
 	&__grid-line {

--- a/packages/media-editor/src/image-editor/react/components/cropper.scss
+++ b/packages/media-editor/src/image-editor/react/components/cropper.scss
@@ -58,7 +58,7 @@ $handle-touch-target-size: 44px;
 		position: absolute;
 		pointer-events: none;
 		overflow: hidden;
-		transition: opacity 0.2s ease;
+		transition: opacity 0.15s ease;
 	}
 
 	&__grid-line {

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -40,6 +40,9 @@ import './cropper.scss';
 /** Threshold for comparing normalized crop rect values. */
 const CROP_RECT_EPSILON = 1e-6;
 
+/** How long to wait after the last placement change before fading the grid out. */
+const GRID_FADE_DELAY_MS = 100;
+
 // Largest rect of the given pixel aspect ratio that fits inside the visual
 // bounds, centered in [0,1] × [0,1] normalized space. Returns a full-frame
 // rect (1×1) if `aspectRatio` is unset or non-positive.
@@ -81,8 +84,13 @@ export interface CropperProps {
 	controller: UseCropperStateReturn;
 	/** Stencil component for the crop area. Defaults to RectangleStencil. */
 	stencil?: React.ComponentType< StencilProps >;
-	/** Show the rule-of-thirds grid overlay. */
-	showGrid?: boolean;
+	/**
+	 * Controls the rule-of-thirds grid overlay.
+	 * - `false` (default): grid is never shown.
+	 * - `true`: grid is always shown.
+	 * - `'interactive'`: grid is shown for placement interactions.
+	 */
+	showGrid?: boolean | 'interactive';
 	/** Show the dimming overlay outside the crop area. */
 	showDimming?: boolean;
 	/** Minimum zoom level. */
@@ -132,7 +140,7 @@ export interface CropperProps {
  * @param root0.src            Image source URL.
  * @param root0.controller     The full state/setter object from `useCropperState`.
  * @param root0.stencil        Custom stencil component.
- * @param root0.showGrid       Show rule-of-thirds grid overlay.
+ * @param root0.showGrid       Grid overlay mode: false | true | 'interactive'.
  * @param root0.showDimming    Show dimming overlay outside crop.
  * @param root0.minZoom        Minimum zoom level.
  * @param root0.maxZoom        Maximum zoom level.
@@ -164,7 +172,7 @@ function CropperInner(
 	}: CropperProps,
 	ref: React.ForwardedRef< HTMLDivElement >
 ) {
-	const { state, setImage, setCropRect, settleCrop } = controller;
+	const { state, setImage, setCropRect, settleCrop, isDirty } = controller;
 	// Canvas measurement via ResizeObserver. The canvas is the inner
 	// positioning context for image/stencil/handles — inset from the root
 	// by the handle gutter, so crop math operates on the reduced box.
@@ -274,18 +282,18 @@ function CropperInner(
 	}, [ state, elementSize, visualSize, canvasSize ] );
 
 	// Use the interaction hook for mouse, touch, and keyboard events.
-	const { handlers, onWheelNative, isDragging, isZooming } = useInteraction(
-		state,
-		controller,
-		canvasSize,
-		visualSize,
-		{
-			minZoom,
-			maxZoom,
-			onGestureStart,
-			onGestureEnd,
-		}
-	);
+	const {
+		handlers,
+		onWheelNative,
+		isDragging,
+		isZooming,
+		isPlacementInteracting,
+	} = useInteraction( state, controller, canvasSize, visualSize, {
+		minZoom,
+		maxZoom,
+		onGestureStart,
+		onGestureEnd,
+	} );
 
 	// Register wheel handler natively with { passive: false } so
 	// preventDefault works. React's onWheel registers as passive. Bound
@@ -351,6 +359,144 @@ function CropperInner(
 		};
 	}, [] );
 
+	// Interactive grid: keep it visible for direct placement gestures
+	// (pan/crop-resize), and briefly flash it for zoom changes.
+	const [ gridVisible, setGridVisible ] = useState( false );
+	const [ isResizing, setIsResizing ] = useState( false );
+	const gridFadeTimerRef = useRef< ReturnType< typeof setTimeout > >();
+	const gridInteractionReadyRef = useRef( false );
+	const isCropperInteracting = isPlacementInteracting || isResizing;
+	const previousPlacementValuesRef = useRef( {
+		zoom: state.zoom,
+		panX: state.pan.x,
+		panY: state.pan.y,
+		rotation: state.rotation,
+		flipHorizontal: state.flip.horizontal,
+		flipVertical: state.flip.vertical,
+		cropX: state.cropRect.x,
+		cropY: state.cropRect.y,
+		cropWidth: state.cropRect.width,
+		cropHeight: state.cropRect.height,
+	} );
+
+	const showInteractiveGrid = useCallback( () => {
+		if ( showGrid !== 'interactive' || ! gridInteractionReadyRef.current ) {
+			return;
+		}
+		clearTimeout( gridFadeTimerRef.current );
+		setGridVisible( true );
+	}, [ showGrid ] );
+
+	const fadeInteractiveGridSoon = useCallback( () => {
+		if ( showGrid !== 'interactive' || ! gridInteractionReadyRef.current ) {
+			return;
+		}
+		clearTimeout( gridFadeTimerRef.current );
+		gridFadeTimerRef.current = setTimeout( () => {
+			setGridVisible( false );
+		}, GRID_FADE_DELAY_MS );
+	}, [ showGrid ] );
+
+	// Defer readiness until after image load and its dependent effects settle,
+	// so automatic initialisation changes don't trigger the interactive grid.
+	useEffect( () => {
+		gridInteractionReadyRef.current = false;
+		if ( ! state.image ) {
+			return;
+		}
+		const id = setTimeout( () => {
+			gridInteractionReadyRef.current = true;
+		}, 0 );
+		return () => clearTimeout( id );
+	}, [ state.image ] );
+
+	useEffect( () => {
+		if ( showGrid !== 'interactive' ) {
+			return;
+		}
+		if ( isCropperInteracting ) {
+			showInteractiveGrid();
+			return;
+		}
+		if ( gridVisible ) {
+			fadeInteractiveGridSoon();
+		}
+		return () => {
+			clearTimeout( gridFadeTimerRef.current );
+		};
+	}, [
+		isCropperInteracting,
+		gridVisible,
+		showGrid,
+		showInteractiveGrid,
+		fadeInteractiveGridSoon,
+	] );
+
+	useEffect( () => {
+		const previous = previousPlacementValuesRef.current;
+		const current = {
+			zoom: state.zoom,
+			panX: state.pan.x,
+			panY: state.pan.y,
+			rotation: state.rotation,
+			flipHorizontal: state.flip.horizontal,
+			flipVertical: state.flip.vertical,
+			cropX: state.cropRect.x,
+			cropY: state.cropRect.y,
+			cropWidth: state.cropRect.width,
+			cropHeight: state.cropRect.height,
+		};
+		previousPlacementValuesRef.current = current;
+
+		if (
+			showGrid !== 'interactive' ||
+			isCropperInteracting ||
+			! gridInteractionReadyRef.current ||
+			! isDirty
+		) {
+			return;
+		}
+
+		const zoomOrPanChanged =
+			previous.zoom !== current.zoom ||
+			previous.panX !== current.panX ||
+			previous.panY !== current.panY;
+		const cropRectChanged =
+			previous.cropX !== current.cropX ||
+			previous.cropY !== current.cropY ||
+			previous.cropWidth !== current.cropWidth ||
+			previous.cropHeight !== current.cropHeight;
+		const orientationChanged =
+			previous.rotation !== current.rotation ||
+			previous.flipHorizontal !== current.flipHorizontal ||
+			previous.flipVertical !== current.flipVertical;
+
+		if ( zoomOrPanChanged && ! cropRectChanged && ! orientationChanged ) {
+			showInteractiveGrid();
+			fadeInteractiveGridSoon();
+		}
+	}, [
+		state.zoom,
+		state.pan.x,
+		state.pan.y,
+		state.rotation,
+		state.flip.horizontal,
+		state.flip.vertical,
+		state.cropRect.x,
+		state.cropRect.y,
+		state.cropRect.width,
+		state.cropRect.height,
+		showGrid,
+		isCropperInteracting,
+		isDirty,
+		showInteractiveGrid,
+		fadeInteractiveGridSoon,
+	] );
+
+	useEffect( () => {
+		return () => clearTimeout( gridFadeTimerRef.current );
+	}, [] );
+
 	/**
 	 * Handle Escape on a resize handle — return focus to the canvas so
 	 * arrow keys pan the image rather than resize.
@@ -360,9 +506,20 @@ function CropperInner(
 	}, [] );
 
 	/**
+	 * Handle resize start — resize handles live outside useInteraction, so
+	 * they provide their own interaction signal for the interactive grid.
+	 */
+	const handleResizeStart = useCallback( () => {
+		setIsResizing( true );
+		showInteractiveGrid();
+		onGestureStart?.();
+	}, [ showInteractiveGrid, onGestureStart ] );
+
+	/**
 	 * Handle resize end — settle the crop rect (re-center, fill height).
 	 */
 	const handleResizeEnd = useCallback( () => {
+		setIsResizing( false );
 		setSettling( true );
 		settleCrop();
 		onGestureEnd?.();
@@ -465,7 +622,7 @@ function CropperInner(
 					containerSize={ canvasSize }
 					imageSize={ visualSize }
 					onCropChange={ handleCropChange }
-					onResizeStart={ onGestureStart }
+					onResizeStart={ handleResizeStart }
 					onResizeEnd={ handleResizeEnd }
 					onEscape={ handleEscape }
 					aspectRatio={ aspectRatio }
@@ -475,11 +632,14 @@ function CropperInner(
 				/>
 
 				{ /* Rule-of-thirds grid */ }
-				{ showGrid && (
+				{ ( showGrid === true || showGrid === 'interactive' ) && (
 					<GridOverlay
 						cropRect={ state.cropRect }
 						containerSize={ canvasSize }
 						imageSize={ visualSize }
+						opacity={
+							showGrid === 'interactive' && ! gridVisible ? 0 : 1
+						}
 					/>
 				) }
 

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -357,13 +357,15 @@ function CropperInner(
 		};
 	}, [] );
 
-	const { gridVisible, notifyResizeStart, notifyResizeEnd } =
-		useInteractiveGrid( {
-			showGrid,
-			isPlacementInteracting,
-			isDirty,
-			state,
-		} );
+	const [ isResizing, setIsResizing ] = useState( false );
+	const isCropperInteracting = isPlacementInteracting || isResizing;
+
+	const { gridVisible } = useInteractiveGrid( {
+		showGrid,
+		isCropperInteracting,
+		isDirty,
+		state,
+	} );
 
 	/**
 	 * Handle Escape on a resize handle — return focus to the canvas so
@@ -374,15 +376,15 @@ function CropperInner(
 	}, [] );
 
 	const handleResizeStart = useCallback( () => {
-		notifyResizeStart();
+		setIsResizing( true );
 		onGestureStart?.();
-	}, [ notifyResizeStart, onGestureStart ] );
+	}, [ onGestureStart ] );
 
 	/**
 	 * Handle resize end — settle the crop rect (re-center, fill height).
 	 */
 	const handleResizeEnd = useCallback( () => {
-		notifyResizeEnd();
+		setIsResizing( false );
 		setSettling( true );
 		settleCrop();
 		onGestureEnd?.();
@@ -390,7 +392,7 @@ function CropperInner(
 		settleTimerRef.current = setTimeout( () => {
 			setSettling( false );
 		}, 200 );
-	}, [ notifyResizeEnd, settleCrop, onGestureEnd ] );
+	}, [ settleCrop, onGestureEnd ] );
 
 	const imageTransition =
 		settling || isZooming ? 'transform 150ms linear' : undefined;

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -30,6 +30,7 @@ import type { UseCropperStateReturn } from '../hooks/use-cropper-state';
 import { getImageFit } from '../../core/camera';
 import { getCropBounds } from '../../core/containment';
 import { useInteraction } from '../hooks/use-interaction';
+import { useInteractiveGrid } from '../hooks/use-interactive-grid';
 import { useTransformStyle } from '../hooks/use-transform-style';
 import { useAriaAnnouncer } from '../hooks/use-aria-announcer';
 import { RectangleStencil } from './stencils/rectangle-stencil';
@@ -39,9 +40,6 @@ import './cropper.scss';
 
 /** Threshold for comparing normalized crop rect values. */
 const CROP_RECT_EPSILON = 1e-6;
-
-/** How long to wait after the last placement change before fading the grid out. */
-const GRID_FADE_DELAY_MS = 100;
 
 // Largest rect of the given pixel aspect ratio that fits inside the visual
 // bounds, centered in [0,1] × [0,1] normalized space. Returns a full-frame
@@ -359,143 +357,13 @@ function CropperInner(
 		};
 	}, [] );
 
-	// Interactive grid: keep it visible for direct placement gestures
-	// (pan/crop-resize), and briefly flash it for zoom changes.
-	const [ gridVisible, setGridVisible ] = useState( false );
-	const [ isResizing, setIsResizing ] = useState( false );
-	const gridFadeTimerRef = useRef< ReturnType< typeof setTimeout > >();
-	const gridInteractionReadyRef = useRef( false );
-	const isCropperInteracting = isPlacementInteracting || isResizing;
-	const previousPlacementValuesRef = useRef( {
-		zoom: state.zoom,
-		panX: state.pan.x,
-		panY: state.pan.y,
-		rotation: state.rotation,
-		flipHorizontal: state.flip.horizontal,
-		flipVertical: state.flip.vertical,
-		cropX: state.cropRect.x,
-		cropY: state.cropRect.y,
-		cropWidth: state.cropRect.width,
-		cropHeight: state.cropRect.height,
-	} );
-
-	const showInteractiveGrid = useCallback( () => {
-		if ( showGrid !== 'interactive' || ! gridInteractionReadyRef.current ) {
-			return;
-		}
-		clearTimeout( gridFadeTimerRef.current );
-		setGridVisible( true );
-	}, [ showGrid ] );
-
-	const fadeInteractiveGridSoon = useCallback( () => {
-		if ( showGrid !== 'interactive' || ! gridInteractionReadyRef.current ) {
-			return;
-		}
-		clearTimeout( gridFadeTimerRef.current );
-		gridFadeTimerRef.current = setTimeout( () => {
-			setGridVisible( false );
-		}, GRID_FADE_DELAY_MS );
-	}, [ showGrid ] );
-
-	// Defer readiness until after image load and its dependent effects settle,
-	// so automatic initialisation changes don't trigger the interactive grid.
-	useEffect( () => {
-		gridInteractionReadyRef.current = false;
-		if ( ! state.image ) {
-			return;
-		}
-		const id = setTimeout( () => {
-			gridInteractionReadyRef.current = true;
-		}, 0 );
-		return () => clearTimeout( id );
-	}, [ state.image ] );
-
-	useEffect( () => {
-		if ( showGrid !== 'interactive' ) {
-			return;
-		}
-		if ( isCropperInteracting ) {
-			showInteractiveGrid();
-			return;
-		}
-		if ( gridVisible ) {
-			fadeInteractiveGridSoon();
-		}
-		return () => {
-			clearTimeout( gridFadeTimerRef.current );
-		};
-	}, [
-		isCropperInteracting,
-		gridVisible,
-		showGrid,
-		showInteractiveGrid,
-		fadeInteractiveGridSoon,
-	] );
-
-	useEffect( () => {
-		const previous = previousPlacementValuesRef.current;
-		const current = {
-			zoom: state.zoom,
-			panX: state.pan.x,
-			panY: state.pan.y,
-			rotation: state.rotation,
-			flipHorizontal: state.flip.horizontal,
-			flipVertical: state.flip.vertical,
-			cropX: state.cropRect.x,
-			cropY: state.cropRect.y,
-			cropWidth: state.cropRect.width,
-			cropHeight: state.cropRect.height,
-		};
-		previousPlacementValuesRef.current = current;
-
-		if (
-			showGrid !== 'interactive' ||
-			isCropperInteracting ||
-			! gridInteractionReadyRef.current ||
-			! isDirty
-		) {
-			return;
-		}
-
-		const zoomOrPanChanged =
-			previous.zoom !== current.zoom ||
-			previous.panX !== current.panX ||
-			previous.panY !== current.panY;
-		const cropRectChanged =
-			previous.cropX !== current.cropX ||
-			previous.cropY !== current.cropY ||
-			previous.cropWidth !== current.cropWidth ||
-			previous.cropHeight !== current.cropHeight;
-		const orientationChanged =
-			previous.rotation !== current.rotation ||
-			previous.flipHorizontal !== current.flipHorizontal ||
-			previous.flipVertical !== current.flipVertical;
-
-		if ( zoomOrPanChanged && ! cropRectChanged && ! orientationChanged ) {
-			showInteractiveGrid();
-			fadeInteractiveGridSoon();
-		}
-	}, [
-		state.zoom,
-		state.pan.x,
-		state.pan.y,
-		state.rotation,
-		state.flip.horizontal,
-		state.flip.vertical,
-		state.cropRect.x,
-		state.cropRect.y,
-		state.cropRect.width,
-		state.cropRect.height,
-		showGrid,
-		isCropperInteracting,
-		isDirty,
-		showInteractiveGrid,
-		fadeInteractiveGridSoon,
-	] );
-
-	useEffect( () => {
-		return () => clearTimeout( gridFadeTimerRef.current );
-	}, [] );
+	const { gridVisible, notifyResizeStart, notifyResizeEnd } =
+		useInteractiveGrid( {
+			showGrid,
+			isPlacementInteracting,
+			isDirty,
+			state,
+		} );
 
 	/**
 	 * Handle Escape on a resize handle — return focus to the canvas so
@@ -505,21 +373,16 @@ function CropperInner(
 		canvasRef.current?.focus( { preventScroll: true } );
 	}, [] );
 
-	/**
-	 * Handle resize start — resize handles live outside useInteraction, so
-	 * they provide their own interaction signal for the interactive grid.
-	 */
 	const handleResizeStart = useCallback( () => {
-		setIsResizing( true );
-		showInteractiveGrid();
+		notifyResizeStart();
 		onGestureStart?.();
-	}, [ showInteractiveGrid, onGestureStart ] );
+	}, [ notifyResizeStart, onGestureStart ] );
 
 	/**
 	 * Handle resize end — settle the crop rect (re-center, fill height).
 	 */
 	const handleResizeEnd = useCallback( () => {
-		setIsResizing( false );
+		notifyResizeEnd();
 		setSettling( true );
 		settleCrop();
 		onGestureEnd?.();
@@ -527,7 +390,7 @@ function CropperInner(
 		settleTimerRef.current = setTimeout( () => {
 			setSettling( false );
 		}, 200 );
-	}, [ settleCrop, onGestureEnd ] );
+	}, [ notifyResizeEnd, settleCrop, onGestureEnd ] );
 
 	const imageTransition =
 		settling || isZooming ? 'transform 150ms linear' : undefined;

--- a/packages/media-editor/src/image-editor/react/components/overlays/grid-overlay.tsx
+++ b/packages/media-editor/src/image-editor/react/components/overlays/grid-overlay.tsx
@@ -13,6 +13,8 @@ interface GridOverlayProps {
 	containerSize: Size;
 	/** The rendered image dimensions in pixels within the container. */
 	imageSize: Size;
+	/** Opacity of the grid overlay (0-1). Defaults to 1. */
+	opacity?: number;
 }
 
 /**
@@ -25,12 +27,14 @@ interface GridOverlayProps {
  * @param props.cropRect      The crop rectangle in normalized coordinates.
  * @param props.containerSize The container element dimensions in pixels.
  * @param props.imageSize     The rendered image dimensions in pixels.
+ * @param props.opacity       Opacity of the overlay (0-1).
  * @return The grid overlay element.
  */
 export function GridOverlay( {
 	cropRect,
 	containerSize,
 	imageSize,
+	opacity = 1,
 }: GridOverlayProps ) {
 	if ( containerSize.width === 0 || containerSize.height === 0 ) {
 		return null;
@@ -54,6 +58,7 @@ export function GridOverlay( {
 				top,
 				width,
 				height,
+				opacity,
 			} }
 		>
 			{ /* Horizontal lines at 1/3 and 2/3 */ }

--- a/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
@@ -128,6 +128,7 @@ export function RectangleStencil( {
 		[ boundsMinX, boundsMinY, boundsMaxX, boundsMaxY ]
 	);
 	const keyboardSettleTimerRef = useRef< ReturnType< typeof setTimeout > >();
+	const keyboardResizeActiveRef = useRef( false );
 	const hasLockedRatio = !! ( aspectRatio && aspectRatio > 0 );
 
 	// Clear the pending keyboard settle timer on unmount so it can't
@@ -135,6 +136,7 @@ export function RectangleStencil( {
 	useEffect( () => {
 		return () => {
 			clearTimeout( keyboardSettleTimerRef.current );
+			keyboardResizeActiveRef.current = false;
 		};
 	}, [] );
 
@@ -377,6 +379,19 @@ export function RectangleStencil( {
 			event.preventDefault();
 			event.stopPropagation();
 
+			if ( ! keyboardResizeActiveRef.current ) {
+				keyboardResizeActiveRef.current = true;
+				onResizeStart?.();
+			}
+
+			const scheduleKeyboardResizeEnd = () => {
+				clearTimeout( keyboardSettleTimerRef.current );
+				keyboardSettleTimerRef.current = setTimeout( () => {
+					keyboardResizeActiveRef.current = false;
+					onResizeEnd?.();
+				}, KEYBOARD_SETTLE_DELAY );
+			};
+
 			const step = event.shiftKey ? KEYBOARD_STEP_SHIFT : KEYBOARD_STEP;
 
 			// Determine the normalized delta from the arrow key.
@@ -409,10 +424,7 @@ export function RectangleStencil( {
 				onCropChange(
 					computeLockedRect( syntheticDrag, clientX, clientY )
 				);
-				clearTimeout( keyboardSettleTimerRef.current );
-				keyboardSettleTimerRef.current = setTimeout( () => {
-					onResizeEnd?.();
-				}, KEYBOARD_SETTLE_DELAY );
+				scheduleKeyboardResizeEnd();
 			} else {
 				// For freeform resize, synthesize a drag via computeFreeRect.
 				const syntheticDrag: ResizeDragState = {
@@ -426,10 +438,7 @@ export function RectangleStencil( {
 				onCropChange(
 					computeFreeRect( syntheticDrag, clientX, clientY )
 				);
-				clearTimeout( keyboardSettleTimerRef.current );
-				keyboardSettleTimerRef.current = setTimeout( () => {
-					onResizeEnd?.();
-				}, KEYBOARD_SETTLE_DELAY );
+				scheduleKeyboardResizeEnd();
 			}
 		},
 		[
@@ -440,6 +449,7 @@ export function RectangleStencil( {
 			computeLockedRect,
 			computeFreeRect,
 			onCropChange,
+			onResizeStart,
 			onResizeEnd,
 			onEscape,
 		]

--- a/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
@@ -28,6 +28,8 @@ export interface UseInteractionReturn {
 	isDragging: boolean;
 	/** Whether a double-tap zoom animation is in progress. */
 	isZooming: boolean;
+	/** Whether the user is currently performing a placement interaction. */
+	isPlacementInteracting: boolean;
 }
 
 /**
@@ -48,6 +50,21 @@ export interface UseInteractionOptions {
 	onGestureStart?: () => void;
 	/** Fires when a continuous gesture ends (pointer release). */
 	onGestureEnd?: () => void;
+}
+
+/** How long keyboard placement stays active after the latest handled key. */
+const KEYBOARD_INTERACTION_IDLE_MS = 300;
+
+function isHandledKeyboardPan( event: KeyboardEvent ): boolean {
+	switch ( event.key ) {
+		case 'ArrowUp':
+		case 'ArrowDown':
+		case 'ArrowLeft':
+		case 'ArrowRight':
+			return true;
+		default:
+			return false;
+	}
 }
 
 /**
@@ -74,6 +91,10 @@ export function useInteraction(
 ): UseInteractionReturn {
 	const [ isDragging, setIsDragging ] = useState( false );
 	const [ isZooming, setIsZooming ] = useState( false );
+	const [ isPlacementInteracting, setIsPlacementInteracting ] =
+		useState( false );
+	const keyboardInteractionTimerRef =
+		useRef< ReturnType< typeof setTimeout > >();
 
 	// Keep mutable refs so the controller always reads fresh values
 	// without needing to be recreated.
@@ -89,6 +110,30 @@ export function useInteraction(
 	actionsRef.current = actions;
 
 	const controllerRef = useRef< InteractionController | null >( null );
+
+	const startPlacementInteracting = useCallback( () => {
+		clearTimeout( keyboardInteractionTimerRef.current );
+		setIsPlacementInteracting( true );
+	}, [] );
+
+	const stopPlacementInteracting = useCallback( () => {
+		clearTimeout( keyboardInteractionTimerRef.current );
+		setIsPlacementInteracting( false );
+	}, [] );
+
+	const signalKeyboardPlacement = useCallback( () => {
+		setIsPlacementInteracting( true );
+		clearTimeout( keyboardInteractionTimerRef.current );
+		keyboardInteractionTimerRef.current = setTimeout( () => {
+			setIsPlacementInteracting( false );
+		}, KEYBOARD_INTERACTION_IDLE_MS );
+	}, [] );
+
+	useEffect( () => {
+		return () => {
+			clearTimeout( keyboardInteractionTimerRef.current );
+		};
+	}, [] );
 
 	// Create / destroy the controller. The controller reads all volatile
 	// values through refs, so it can stay mounted across render updates.
@@ -125,6 +170,11 @@ export function useInteraction(
 			onStatusChange: ( status ) => {
 				setIsDragging( status.isDragging );
 				setIsZooming( status.isZooming );
+				if ( status.isDragging ) {
+					startPlacementInteracting();
+				} else {
+					stopPlacementInteracting();
+				}
 			},
 		} );
 		controllerRef.current = controller;
@@ -132,7 +182,7 @@ export function useInteraction(
 			controller.destroy();
 			controllerRef.current = null;
 		};
-	}, [] );
+	}, [ startPlacementInteracting, stopPlacementInteracting ] );
 
 	const onPointerDown = useCallback( ( e: React.PointerEvent ) => {
 		const el = e.currentTarget as HTMLElement;
@@ -149,9 +199,15 @@ export function useInteraction(
 		);
 	}, [] );
 
-	const onKeyDown = useCallback( ( e: React.KeyboardEvent ) => {
-		controllerRef.current?.handleKeyDown( e.nativeEvent );
-	}, [] );
+	const onKeyDown = useCallback(
+		( e: React.KeyboardEvent ) => {
+			if ( isHandledKeyboardPan( e.nativeEvent ) ) {
+				signalKeyboardPlacement();
+			}
+			controllerRef.current?.handleKeyDown( e.nativeEvent );
+		},
+		[ signalKeyboardPlacement ]
+	);
 
 	const onWheelNative = useCallback( ( e: WheelEvent ) => {
 		controllerRef.current?.handleWheel( e );
@@ -166,5 +222,6 @@ export function useInteraction(
 		onWheelNative,
 		isDragging,
 		isZooming,
+		isPlacementInteracting,
 	};
 }

--- a/packages/media-editor/src/image-editor/react/hooks/use-interactive-grid.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-interactive-grid.ts
@@ -1,0 +1,177 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useCallback, useRef, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { CropperState } from '../../core/types';
+
+/** How long to wait after the last placement change before fading the grid out. */
+const GRID_FADE_DELAY_MS = 100;
+
+type PlacementSnapshot = {
+	zoom: number;
+	panX: number;
+	panY: number;
+	rotation: number;
+	flipHorizontal: boolean;
+	flipVertical: boolean;
+	cropX: number;
+	cropY: number;
+	cropWidth: number;
+	cropHeight: number;
+};
+
+function snapshotPlacement( state: CropperState ): PlacementSnapshot {
+	return {
+		zoom: state.zoom,
+		panX: state.pan.x,
+		panY: state.pan.y,
+		rotation: state.rotation,
+		flipHorizontal: state.flip.horizontal,
+		flipVertical: state.flip.vertical,
+		cropX: state.cropRect.x,
+		cropY: state.cropRect.y,
+		cropWidth: state.cropRect.width,
+		cropHeight: state.cropRect.height,
+	};
+}
+
+/**
+ * Manages the rule-of-thirds grid visibility for interactive mode.
+ *
+ * In `'interactive'` mode the grid is shown while the user is performing a
+ * placement gesture (pan, drag, crop-resize) and briefly flashes when zoom or
+ * pan changes without a direct gesture (e.g. slider input). It fades out
+ * shortly after the interaction ends.
+ *
+ * Returns `gridVisible` (whether to show the grid at full opacity), plus
+ * `notifyResizeStart` / `notifyResizeEnd` — call these from the host component
+ * when a crop-handle resize begins and ends, since resize events live outside
+ * `useInteraction`.
+ *
+ * When `showGrid` is not `'interactive'`, all returned values are inert and no
+ * timers are scheduled.
+ *
+ * @param root0                        Destructured options.
+ * @param root0.showGrid               Grid mode prop from the Cropper.
+ * @param root0.isPlacementInteracting Whether a drag/pan is in progress (from useInteraction).
+ * @param root0.isDirty                Whether the user has made any edits.
+ * @param root0.state                  Current cropper state (read for placement values).
+ * @return gridVisible, notifyResizeStart, notifyResizeEnd.
+ */
+export function useInteractiveGrid( {
+	showGrid,
+	isPlacementInteracting,
+	isDirty,
+	state,
+}: {
+	showGrid: boolean | 'interactive';
+	isPlacementInteracting: boolean;
+	isDirty: boolean;
+	state: CropperState;
+} ): {
+	gridVisible: boolean;
+	notifyResizeStart: () => void;
+	notifyResizeEnd: () => void;
+} {
+	const [ gridVisible, setGridVisible ] = useState( false );
+	const [ isResizing, setIsResizing ] = useState( false );
+	const gridFadeTimerRef = useRef< ReturnType< typeof setTimeout > >();
+	const previousSnapshotRef = useRef( snapshotPlacement( state ) );
+	const isCropperInteracting = isPlacementInteracting || isResizing;
+
+	useEffect( () => {
+		if ( showGrid !== 'interactive' ) {
+			return;
+		}
+
+		const previous = previousSnapshotRef.current;
+		const current: PlacementSnapshot = {
+			zoom: state.zoom,
+			panX: state.pan.x,
+			panY: state.pan.y,
+			rotation: state.rotation,
+			flipHorizontal: state.flip.horizontal,
+			flipVertical: state.flip.vertical,
+			cropX: state.cropRect.x,
+			cropY: state.cropRect.y,
+			cropWidth: state.cropRect.width,
+			cropHeight: state.cropRect.height,
+		};
+		previousSnapshotRef.current = current;
+
+		// Always cancel any pending fade before deciding what to do next.
+		clearTimeout( gridFadeTimerRef.current );
+
+		// Keep the grid visible for the full duration of any placement gesture.
+		if ( isCropperInteracting ) {
+			setGridVisible( true );
+			return () => clearTimeout( gridFadeTimerRef.current );
+		}
+
+		// Flash briefly when zoom or pan changes via a non-gesture (e.g. slider).
+		// Skips flips, rotations, and aspect-ratio-driven crop changes.
+		if ( isDirty ) {
+			const zoomOrPanChanged =
+				previous.zoom !== current.zoom ||
+				previous.panX !== current.panX ||
+				previous.panY !== current.panY;
+			const cropRectChanged =
+				previous.cropX !== current.cropX ||
+				previous.cropY !== current.cropY ||
+				previous.cropWidth !== current.cropWidth ||
+				previous.cropHeight !== current.cropHeight;
+			const orientationChanged =
+				previous.rotation !== current.rotation ||
+				previous.flipHorizontal !== current.flipHorizontal ||
+				previous.flipVertical !== current.flipVertical;
+
+			if (
+				zoomOrPanChanged &&
+				! cropRectChanged &&
+				! orientationChanged
+			) {
+				setGridVisible( true );
+				return () => clearTimeout( gridFadeTimerRef.current );
+			}
+		}
+
+		// Schedule fade-out if the grid is currently visible (interaction or
+		// flash just ended and this effect re-ran with gridVisible = true).
+		if ( gridVisible ) {
+			gridFadeTimerRef.current = setTimeout( () => {
+				setGridVisible( false );
+			}, GRID_FADE_DELAY_MS );
+		}
+
+		return () => clearTimeout( gridFadeTimerRef.current );
+	}, [
+		showGrid,
+		isCropperInteracting,
+		gridVisible,
+		isDirty,
+		state.zoom,
+		state.pan.x,
+		state.pan.y,
+		state.rotation,
+		state.flip.horizontal,
+		state.flip.vertical,
+		state.cropRect.x,
+		state.cropRect.y,
+		state.cropRect.width,
+		state.cropRect.height,
+	] );
+
+	const notifyResizeStart = useCallback( () => {
+		setIsResizing( true );
+	}, [] );
+
+	const notifyResizeEnd = useCallback( () => {
+		setIsResizing( false );
+	}, [] );
+
+	return { gridVisible, notifyResizeStart, notifyResizeEnd };
+}

--- a/packages/media-editor/src/image-editor/react/hooks/use-interactive-grid.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-interactive-grid.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useCallback, useRef, useEffect } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -47,48 +47,50 @@ function snapshotPlacement( state: CropperState ): PlacementSnapshot {
  * pan changes without a direct gesture (e.g. slider input). It fades out
  * shortly after the interaction ends.
  *
- * Returns `gridVisible` (whether to show the grid at full opacity), plus
- * `notifyResizeStart` / `notifyResizeEnd` — call these from the host component
- * when a crop-handle resize begins and ends, since resize events live outside
- * `useInteraction`.
+ * Returns `gridVisible` — whether the grid should be shown at full opacity.
+ * When `showGrid` is not `'interactive'`, the effect exits immediately and
+ * `gridVisible` stays `false`.
  *
- * When `showGrid` is not `'interactive'`, all returned values are inert and no
- * timers are scheduled.
+ * Design note — single merged effect: the interaction path and the zoom-flash
+ * path share one fade timer. They must both be able to cancel each other's
+ * pending fade (e.g. a zoom change while the drag-end timer is counting down
+ * should reset the delay). A single effect with one timer ref is the only way
+ * to guarantee that without introducing shared mutable state across effects.
  *
- * @param root0                        Destructured options.
- * @param root0.showGrid               Grid mode prop from the Cropper.
- * @param root0.isPlacementInteracting Whether a drag/pan is in progress (from useInteraction).
- * @param root0.isDirty                Whether the user has made any edits.
- * @param root0.state                  Current cropper state (read for placement values).
- * @return gridVisible, notifyResizeStart, notifyResizeEnd.
+ * @param root0                      Destructured options.
+ * @param root0.showGrid             Grid mode prop from the Cropper.
+ * @param root0.isCropperInteracting True while any placement gesture is active.
+ * @param root0.isDirty              Whether the user has made any edits.
+ * @param root0.state                Current cropper state (read for placement values).
+ * @return gridVisible.
  */
 export function useInteractiveGrid( {
 	showGrid,
-	isPlacementInteracting,
+	isCropperInteracting,
 	isDirty,
 	state,
 }: {
 	showGrid: boolean | 'interactive';
-	isPlacementInteracting: boolean;
+	isCropperInteracting: boolean;
 	isDirty: boolean;
 	state: CropperState;
 } ): {
 	gridVisible: boolean;
-	notifyResizeStart: () => void;
-	notifyResizeEnd: () => void;
 } {
 	const [ gridVisible, setGridVisible ] = useState( false );
-	const [ isResizing, setIsResizing ] = useState( false );
 	const gridFadeTimerRef = useRef< ReturnType< typeof setTimeout > >();
 	const previousSnapshotRef = useRef( snapshotPlacement( state ) );
-	const isCropperInteracting = isPlacementInteracting || isResizing;
 
 	useEffect( () => {
+		// All paths other than 'interactive' are intentional no-ops.
 		if ( showGrid !== 'interactive' ) {
 			return;
 		}
 
 		const previous = previousSnapshotRef.current;
+		// Inline field reads rather than snapshotPlacement(state) so the
+		// exhaustive-deps rule can confirm every accessed field is in the
+		// deps array below.
 		const current: PlacementSnapshot = {
 			zoom: state.zoom,
 			panX: state.pan.x,
@@ -103,17 +105,21 @@ export function useInteractiveGrid( {
 		};
 		previousSnapshotRef.current = current;
 
-		// Always cancel any pending fade before deciding what to do next.
-		clearTimeout( gridFadeTimerRef.current );
-
 		// Keep the grid visible for the full duration of any placement gesture.
+		// Cancel any pending fade so the timer resets if the user re-engages.
 		if ( isCropperInteracting ) {
+			clearTimeout( gridFadeTimerRef.current );
 			setGridVisible( true );
 			return () => clearTimeout( gridFadeTimerRef.current );
 		}
 
 		// Flash briefly when zoom or pan changes via a non-gesture (e.g. slider).
-		// Skips flips, rotations, and aspect-ratio-driven crop changes.
+		// Skips flips, rotations, and aspect-ratio-driven crop-rect changes.
+		//
+		// The timer is scheduled here directly rather than relying on a
+		// subsequent effect re-run, because if gridVisible is already true,
+		// setGridVisible(true) is a no-op — React won't re-render, the
+		// fade-scheduling branch below is never reached, and the grid gets stuck.
 		if ( isDirty ) {
 			const zoomOrPanChanged =
 				previous.zoom !== current.zoom ||
@@ -134,13 +140,18 @@ export function useInteractiveGrid( {
 				! cropRectChanged &&
 				! orientationChanged
 			) {
+				clearTimeout( gridFadeTimerRef.current );
 				setGridVisible( true );
+				gridFadeTimerRef.current = setTimeout( () => {
+					setGridVisible( false );
+				}, GRID_FADE_DELAY_MS );
 				return () => clearTimeout( gridFadeTimerRef.current );
 			}
 		}
 
-		// Schedule fade-out if the grid is currently visible (interaction or
-		// flash just ended and this effect re-ran with gridVisible = true).
+		// Schedule fade-out if the grid is visible and nothing above is keeping
+		// it open. Reached when interaction ends (isCropperInteracting → false)
+		// or when gridVisible flips true (causing a re-run with no new trigger).
 		if ( gridVisible ) {
 			gridFadeTimerRef.current = setTimeout( () => {
 				setGridVisible( false );
@@ -153,6 +164,9 @@ export function useInteractiveGrid( {
 		isCropperInteracting,
 		gridVisible,
 		isDirty,
+		// Placement values — needed for zoom-flash detection only, but must
+		// always be in the deps array because the snapshot is updated on every
+		// run (including during interaction) to keep it current.
 		state.zoom,
 		state.pan.x,
 		state.pan.y,
@@ -165,13 +179,5 @@ export function useInteractiveGrid( {
 		state.cropRect.height,
 	] );
 
-	const notifyResizeStart = useCallback( () => {
-		setIsResizing( true );
-	}, [] );
-
-	const notifyResizeEnd = useCallback( () => {
-		setIsResizing( false );
-	}, [] );
-
-	return { gridVisible, notifyResizeStart, notifyResizeEnd };
+	return { gridVisible };
 }

--- a/packages/media-editor/src/image-editor/stories/rectangle-crop.story.tsx
+++ b/packages/media-editor/src/image-editor/stories/rectangle-crop.story.tsx
@@ -173,6 +173,9 @@ const WithControlsComponent = () => {
 
 	const [ aspectRatioValue, setAspectRatioValue ] = useState( '0' );
 	const [ freeformCrop, setFreeformCrop ] = useState( false );
+	const [ gridMode, setGridMode ] = useState< 'off' | 'on' | 'interactive' >(
+		'interactive'
+	);
 	const { src, isCustom, handleFileChange, resetToSample } =
 		useUploadableImage();
 	const fileInputRef = useRef< HTMLInputElement >( null );
@@ -409,6 +412,28 @@ const WithControlsComponent = () => {
 							onChange={ setFreeformCrop }
 						/>
 					</FlexItem>
+					<FlexItem>
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label="Grid"
+							hideLabelFromVision
+							value={ gridMode }
+							onChange={ ( value ) =>
+								setGridMode(
+									value as 'off' | 'on' | 'interactive'
+								)
+							}
+							options={ [
+								{ label: 'Grid: off', value: 'off' },
+								{ label: 'Grid: always on', value: 'on' },
+								{
+									label: 'Grid: interactive',
+									value: 'interactive',
+								},
+							] }
+						/>
+					</FlexItem>
 					<FlexItem isBlock />
 					<FlexItem>
 						<Button
@@ -451,7 +476,15 @@ const WithControlsComponent = () => {
 				<Cropper
 					src={ src }
 					controller={ controller }
-					showGrid
+					showGrid={
+						(
+							{
+								off: false,
+								on: true,
+								interactive: 'interactive',
+							} as const
+						 )[ gridMode ]
+					}
 					showDimming
 					freeformCrop={ freeformCrop }
 					aspectRatio={ resolveAspectRatio(


### PR DESCRIPTION
The grid appears for placement-oriented interactions like crop, pan, zoom, and keyboard nudging, then fades out. 

It avoids showing for non-placement actions such as flip, reset, rotate, and aspect ratio changes. Fine rotate was left out for now, but that's debatable?

Keeps the grid visible for the full duration of drag/resize gestures instead of tying visibility only to value changes.


https://github.com/user-attachments/assets/845f9e18-ac5c-4f0c-99e1-d7c0cd3a16dc


