### PR TITLE
Image: add support for text and background color in caption elements

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -444,7 +444,7 @@ Insert an image to make a visual statement. ([Source](https://github.com/WordPre
 
 -	**Name:** core/image
 -	**Category:** media
--	**Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity, shadow, spacing (margin)
+-	**Supports:** align (center, full, left, right, wide), anchor, color (caption, ~~background~~, ~~text~~), filter (duotone), interactivity, shadow, spacing (margin)
 -	**Attributes:** alt, aspectRatio, blob, caption, focalPoint, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
 
 ## Latest Comments

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -73,6 +73,14 @@ function gutenberg_should_add_elements_class_name( $block, $options ) {
 				array( 'h6', 'color', 'gradient' ),
 			),
 		),
+		'caption' => array(
+			'skip'  => $options['caption']['skip'] ?? false,
+			'paths' => array(
+				array( 'caption', 'color', 'text' ),
+				array( 'caption', 'color', 'background' ),
+				array( 'caption', 'color', 'gradient' ),
+			),
+		),
 	);
 
 	$elements_style_attributes = $block['attrs']['style']['elements'];
@@ -134,9 +142,11 @@ function gutenberg_render_elements_support_styles( $parsed_block ) {
 	$skip_link_color_serialization         = wp_should_skip_block_supports_serialization( $block_type, 'color', 'link' );
 	$skip_heading_color_serialization      = wp_should_skip_block_supports_serialization( $block_type, 'color', 'heading' );
 	$skip_button_color_serialization       = wp_should_skip_block_supports_serialization( $block_type, 'color', 'button' );
+	$skip_caption_color_serialization      = wp_should_skip_block_supports_serialization( $block_type, 'color', 'caption' );
 	$skips_all_element_color_serialization = $skip_link_color_serialization &&
 		$skip_heading_color_serialization &&
-		$skip_button_color_serialization;
+		$skip_button_color_serialization &&
+		$skip_caption_color_serialization;
 
 	if ( $skips_all_element_color_serialization ) {
 		return $parsed_block;
@@ -146,6 +156,7 @@ function gutenberg_render_elements_support_styles( $parsed_block ) {
 		'button'  => array( 'skip' => $skip_button_color_serialization ),
 		'link'    => array( 'skip' => $skip_link_color_serialization ),
 		'heading' => array( 'skip' => $skip_heading_color_serialization ),
+		'caption' => array( 'skip' => $skip_caption_color_serialization ),
 	);
 
 	if ( ! gutenberg_should_add_elements_class_name( $parsed_block, $options ) ) {
@@ -173,6 +184,10 @@ function gutenberg_render_elements_support_styles( $parsed_block ) {
 			'selector' => ".$class_name h1, .$class_name h2, .$class_name h3, .$class_name h4, .$class_name h5, .$class_name h6",
 			'skip'     => $skip_heading_color_serialization,
 			'elements' => array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ),
+		),
+		'caption' => array(
+			'selector' => ".$class_name .wp-element-caption, .$class_name figcaption",
+			'skip'     => $skip_caption_color_serialization,
 		),
 	);
 

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -693,9 +693,7 @@ export default function ColorPanel( {
 			onChange( newValue );
 		};
 		const supportsTextColor = true;
-		// Background color is not supported for `caption`
-		// as there isn't yet a way to set padding for the element.
-		const supportsBackground = name !== 'caption';
+		const supportsBackground = true;
 
 		items.push( {
 			key: name,

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -377,6 +377,7 @@ const elementTypes = [
 		elementType: 'heading',
 		elements: [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],
 	},
+	{ elementType: 'caption' },
 ];
 
 // Used for generating the instance ID

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -298,6 +298,7 @@ export function useBlockSettings( name, parentLayout ) {
 		isTextEnabled,
 		isHeadingEnabled,
 		isButtonEnabled,
+		isCaptionEnabled,
 		shadow,
 	] = useSettings(
 		'background.backgroundImage',
@@ -362,6 +363,7 @@ export function useBlockSettings( name, parentLayout ) {
 		'color.text',
 		'color.heading',
 		'color.button',
+		'color.caption',
 		'shadow'
 	);
 
@@ -398,6 +400,7 @@ export function useBlockSettings( name, parentLayout ) {
 				link: isLinkEnabled,
 				heading: isHeadingEnabled,
 				button: isButtonEnabled,
+				caption: isCaptionEnabled,
 				text: isTextEnabled,
 			},
 			typography: {
@@ -520,6 +523,7 @@ export function useBlockSettings( name, parentLayout ) {
 		isTextEnabled,
 		isHeadingEnabled,
 		isButtonEnabled,
+		isCaptionEnabled,
 		shadow,
 	] );
 

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -113,7 +113,8 @@
 		"anchor": true,
 		"color": {
 			"text": false,
-			"background": false
+			"background": false,
+			"caption": true
 		},
 		"filter": {
 			"duotone": true

--- a/packages/blocks/src/api/constants.ts
+++ b/packages/blocks/src/api/constants.ts
@@ -168,6 +168,10 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		value: [ 'elements', 'caption', 'color', 'text' ],
 		support: [ 'color', 'caption' ],
 	},
+	captionBackgroundColor: {
+		value: [ 'elements', 'caption', 'color', 'background' ],
+		support: [ 'color', 'caption' ],
+	},
 	buttonColor: {
 		value: [ 'elements', 'button', 'color', 'text' ],
 		support: [ 'color', 'button' ],

--- a/packages/blocks/src/store/private-selectors.ts
+++ b/packages/blocks/src/store/private-selectors.ts
@@ -19,6 +19,7 @@ const ROOT_BLOCK_SUPPORTS: string[] = [
 	'color',
 	'linkColor',
 	'captionColor',
+	'captionBackgroundColor',
 	'buttonColor',
 	'headingColor',
 	'fontFamily',


### PR DESCRIPTION
Closes #67249

## What?
Add background color and text color customization options for image captions in the Styles panel.

## Why?
The image caption background styling was introduced in PR #63471, but users have no way to customize this background to fit their images without using custom CSS. This PR expands the Styles options for captions to allow both background color and text color customization directly from the block inspector, following the same pattern used for button and heading element styles.

## Testing Instructions
1. Open or create a post/page in the editor
2. Insert an **Image block**
3. Upload or select an image
4. Add a caption to the image
5. With the image block selected, open the **Styles** panel in the block inspector sidebar
6. Look for the **Captions** section (should now be visible)
7. Test text color:
   - Click the **Text** tab in the Captions section
   - Select a color from the palette or set a custom color
   - Verify the caption text color changes in the editor
8. Test background color:
   - Click the **Background** tab in the Captions section
   - Select a color from the palette or set a custom color
   - Verify the caption background color changes in the editor
9. Save the post and verify styles are preserved on the frontend

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/83b6bf20-789d-4271-b927-fb12e63fa29e


## Use of AI Tools
This PR was authored with assistance from Claude (AI code assistant). The implementation strategy, code changes, and testing approach were guided by AI analysis of the Gutenberg codebase, but all code has been manually reviewed and verified to follow Gutenberg's patterns and conventions.