### PR TITLE
Cover: Enable background image controls

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -293,7 +293,7 @@ Add an image or video with a text overlay. ([Source](https://github.com/WordPres
 
 -	**Name:** core/cover
 -	**Category:** media
--	**Supports:** align, allowedBlocks, anchor, color (heading, text, ~~background~~, ~~enableContrastChecker~~), dimensions (aspectRatio), filter (duotone), interactivity (clientNavigation), layout (~~allowJustification~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align, allowedBlocks, anchor, background (backgroundImage, backgroundSize), color (heading, text, ~~background~~, ~~enableContrastChecker~~), dimensions (aspectRatio), filter (duotone), interactivity (clientNavigation), layout (~~allowJustification~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, isUserOverlayColor, minHeight, minHeightUnit, overlayColor, poster, sizeSlug, tagName, templateLock, url, useFeaturedImage
 
 ## Details

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -93,6 +93,13 @@
 		"align": true,
 		"html": false,
 		"shadow": true,
+		"background": {
+			"backgroundImage": true,
+			"backgroundSize": true,
+			"__experimentalDefaultControls": {
+				"backgroundImage": true
+			}
+		},
 		"spacing": {
 			"padding": true,
 			"margin": [ "top", "bottom" ],


### PR DESCRIPTION
## What?
Closes #64703

Add Background Image panel support to the Cover block by enabling the `backgroundImage` support flag, matching the UI pattern used in the Group block.

## Why?
Issue #64703 proposes adding a Background Image panel to the Cover block's Inspector, similar to the Group block's existing Background Image panel. Adds consistency among blocks. 

## How?
- Implemented as per the Group block's patterns.


## Testing Instructions
1. Create or open a post/page
2. Insert a Cover block
3. Select the Cover block
4. Go to the **Styles** tab in the Inspector panel
5. You should see a **Background image** button
6. Click it to open the media picker and select or upload an image
7. The image should be applied to the cover block background 
8. Verify focal point and other background controls are accessible
