### PR TITLE
LinkControl: Allow filtering custom post type icons in search results

### DIFF
--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -18,18 +18,7 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { safeDecodeURI, filterURLForDisplay, getPath } from '@wordpress/url';
 import { pipe } from '@wordpress/compose';
 import deprecated from '@wordpress/deprecated';
-import { applyFilters, addFilter } from '@wordpress/hooks';
-
-addFilter(
-	'blockEditor.linkControl.searchItemIcon',
-	'block-editor/link-control',
-	( icon, suggestionType ) => {
-		if ( suggestionType === 'rt-movie' ) {
-			return verse; // @wordpress/icons SVG — no dashicon string needed
-		}
-		return icon;
-	}
-);
+import { applyFilters } from '@wordpress/hooks';
 
 const TYPES = {
 	post: {

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -18,6 +18,18 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { safeDecodeURI, filterURLForDisplay, getPath } from '@wordpress/url';
 import { pipe } from '@wordpress/compose';
 import deprecated from '@wordpress/deprecated';
+import { applyFilters, addFilter } from '@wordpress/hooks';
+
+addFilter(
+	'blockEditor.linkControl.searchItemIcon',
+	'block-editor/link-control',
+	( icon, suggestionType ) => {
+		if ( suggestionType === 'rt-movie' ) {
+			return verse; // @wordpress/icons SVG — no dashicon string needed
+		}
+		return icon;
+	}
+);
 
 const TYPES = {
 	post: {
@@ -58,6 +70,21 @@ function SearchItemIcon( { isURL, suggestion } ) {
 			}
 		}
 	}
+
+	/**
+	 * Filters the icon used in the Link Control search item.
+	 *
+	 * Useful for providing icons for custom post types not covered by the
+	 * built-in TYPES map. Return a @wordpress/icons SVG component, a null to render nothing.
+	 *
+	 * @param {string} icon     The resolved icon, or null.
+	 * @param {string} postType The post type of the suggestion.
+	 */
+	icon = applyFilters(
+		'blockEditor.linkControl.searchItemIcon',
+		icon,
+		suggestion.type
+	);
 
 	if ( icon ) {
 		return (


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/71491

Adds a JavaScript filter `blockEditor.linkControl.searchItemIcon` to the `<SearchItemIcon />` component to allow customizing the icon displayed in Link Control search suggestions.

## Why?
Currently, custom post types cannot display their registered icons within the Link Control search results. This PR solves this by exposing a filter, allowing developers to inject custom SVG icons for specific custom post types or suggestion types (custom tax).

## How?
Wraps the resolved icon variable in the `SearchItemIcon` component with `applyFilters`. This passes the default icon and the `suggestion.type` (post type) to the filter before rendering the final `@wordpress/icons` component.

## Testing Instructions
1. Enqueue a custom script in the editor, or open your browser console in the Block Editor.
2. Add a filter to replace an icon for a specific post type (e.g., overriding pages or targeting a CPT):

```JavaScript
import { verse } from '@wordpress/icons';
import { addFilter } from '@wordpress/hooks';

addFilter(
	'blockEditor.linkControl.searchItemIcon',
	'test-plugin',
	( icon, suggestionType ) => {
		if ( suggestionType === 'rt-movie' ) {
			return verse;
		}
		return icon;
	}
);
```
3. Insert a Paragraph block and type some text.
4. Highlight the text and press Cmd/Ctrl + K to open the Link Control.
5. Search for the targeted post type.
6. Verify that your custom icon appears next to the search result.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="702" height="228" alt="image" src="https://github.com/user-attachments/assets/f048e762-d373-43e6-9ccc-d800c670a1b9" />|<img width="700" height="238" alt="image" src="https://github.com/user-attachments/assets/1b3e2db9-3b3e-4ae2-b761-ae2feb061d52" />|
