### PR TITLE
Block Editor: Fix blockGap fallback handling for nested var() fallback values

### DIFF
--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -23,7 +23,8 @@ import {
  * Internal dependencies
  */
 import { appendSelectors, getBlockGapCSS } from './utils';
-import { getGapCSSValue } from '../hooks/gap';
+import { getGapCSSValue, getGapBoxControlValueFromStyle } from '../hooks/gap';
+import { getSpacingPresetCssVar } from '../components/spacing-sizes-control/utils';
 import {
 	BlockControls,
 	JustifyContentControl,
@@ -147,15 +148,12 @@ export default {
 		// falling back to '0.5em' for backwards compatibility.
 		let fallbackGapValue = '0.5em';
 		if ( globalBlockGapValue ) {
-			// Process the global gap value to handle preset values
-			const processedGlobalGap = getGapCSSValue(
-				globalBlockGapValue,
-				'0.5em'
-			);
-			// Use the column gap value (second value if two values exist)
-			const gapParts = processedGlobalGap.split( ' ' );
+			const gapBox =
+				getGapBoxControlValueFromStyle( globalBlockGapValue );
 			fallbackGapValue =
-				gapParts.length > 1 ? gapParts[ 1 ] : gapParts[ 0 ];
+				getSpacingPresetCssVar( gapBox?.left ) ||
+				getSpacingPresetCssVar( gapBox?.top ) ||
+				'0.5em';
 		}
 
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -21,7 +21,8 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { appendSelectors, getBlockGapCSS } from './utils';
-import { getGapCSSValue } from '../hooks/gap';
+import { getGapCSSValue, getGapBoxControlValueFromStyle } from '../hooks/gap';
+import { getSpacingPresetCssVar } from '../components/spacing-sizes-control/utils';
 import { shouldSkipSerialization } from '../hooks/utils';
 import { LAYOUT_DEFINITIONS } from './definitions';
 
@@ -143,10 +144,12 @@ export default {
 		// If the gap value has both top and left (separated by space), use the left value for horizontal calculations.
 		let fallbackGapValue = '1.2rem';
 		if ( globalBlockGapValue ) {
-			const processedGap = getGapCSSValue( globalBlockGapValue, '0.5em' );
-			const gapParts = processedGap.split( ' ' );
+			const gapBox =
+				getGapBoxControlValueFromStyle( globalBlockGapValue );
 			fallbackGapValue =
-				gapParts.length > 1 ? gapParts[ 1 ] : gapParts[ 0 ];
+				getSpacingPresetCssVar( gapBox?.left ) ||
+				getSpacingPresetCssVar( gapBox?.top ) ||
+				'1.2rem';
 		}
 
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,


### PR DESCRIPTION
## What?
This PR fixes invalid gap CSS generation when `styles.spacing.blockGap` in `theme.json` uses nested `var()` fallbacks, and the user updates row/column gap controls in the editor.
Closes https://github.com/WordPress/gutenberg/issues/76896

## Why?
The previous fallback logic split processed gap strings by whitespace. That approach breaks values like:

```json
"blockGap": "var(--a, var(--b, 1.2rem))"
```

because whitespace inside nested `var()` expressions is not a safe delimiter.

## How?
Use existing gap helpers to read row/column values directly instead of string splitting:
- `getGapBoxControlValueFromStyle(...)`
- `getSpacingPresetCssVar(...)`

This keeps the fix minimal and scoped to fallback resolution.

## Testing Instructions
1. Use a block theme with:
   ```json
   {
     "styles": {
       "spacing": {
         "blockGap": "var(--a, var(--b, 1.2rem))"
       }
     }
   }
   ```
2. Insert a Columns block.
3. Confirm initial gap is valid.
4. Update only column-gap (and then row-gap) from block settings.
5. Verify generated CSS remains valid and parentheses stay balanced.

