### PR TITLE
Tooltip: Fix flaky unit test

### DIFF
--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -286,7 +286,7 @@ describe( 'Tooltip', () => {
 
 	describe( 'delay', () => {
 		it( 'should respect custom delay prop when showing tooltip', async () => {
-			const ADDITIONAL_DELAY = 100;
+			const ADDITIONAL_DELAY = 500;
 
 			render(
 				<Tooltip
@@ -304,7 +304,8 @@ describe( 'Tooltip', () => {
 			await hover( anchor );
 			expectTooltipToBeHidden();
 
-			// Advance time by default delay
+			// Advance time by default delay, which is still well before the
+			// custom delay even when CI is slow to resolve the hover event.
 			await sleep( TOOLTIP_DELAY );
 
 			// Tooltip hasn't appeared yet


### PR DESCRIPTION
## What?

Updates the `Tooltip` custom delay unit test to use a larger additional delay buffer.

## Why?

The test has been failing intermittently on trunk CI. Recent Unit Tests workflow failures showed the same assertion failing repeatedly:

`Tooltip › delay › should respect custom delay prop when showing tooltip`

The original test only left a 100ms gap between the default delay and the custom delay, which can be consumed by CI overhead before the "not visible yet" assertion runs.

## How?

This keeps the behavior being tested the same, but increases the arbitrary additional delay from `100ms` to `500ms`. The test still verifies that the tooltip does not appear after the default delay, then appears after the custom delay.

## Testing Instructions

Run the focused Tooltip test:

```sh
npm run test:unit -- packages/components/src/tooltip/test/index.tsx
```

Stress test the previously flaky test:

```sh
for i in $(seq 1 20); do npm run --workspace @wordpress/unit-tests test:unit -- packages/components/src/tooltip/test/index.tsx --testNamePattern='should respect custom delay prop when showing tooltip' || exit 1; done
```

Expected result: all runs pass.