### PR TITLE
Popover: Render inside the overlay legacy slot

### DIFF
--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -8,9 +8,12 @@ import clsx from 'clsx';
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { isTextField } from '@wordpress/dom';
-import { Popover } from '@wordpress/components';
+import {
+	Popover,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
-import { useRef, useState } from '@wordpress/element';
+import { useRef, useState, createPortal } from '@wordpress/element';
 import {
 	switchToBlockType,
 	hasBlockSupport,
@@ -33,6 +36,10 @@ import usePopoverScroll from '../block-popover/use-popover-scroll';
 import ZoomOutModeInserters from './zoom-out-mode-inserters';
 import { useShowBlockTools } from './use-show-block-tools';
 import { unlock } from '../../lock-unlock';
+
+const { __experimentalGetOverlayLegacySlot: getOverlayLegacySlot } = unlock(
+	componentsPrivateApis
+);
 import usePasteStyles from '../use-paste-styles';
 import { BlockRenameModal, useBlockRename } from '../block-rename';
 import { BlockVisibilityModal } from '../block-visibility';
@@ -322,18 +329,24 @@ export default function BlockTools( {
 				) }
 
 				{ /* Used for the inline rich text toolbar. Until this toolbar is combined into BlockToolbar, someone implementing their own BlockToolbar will also need to use this to see the image caption toolbar. */ }
-				{ ! isZoomOutMode && ! hasFixedToolbar && (
-					<Popover.Slot
-						name="block-toolbar"
-						ref={ blockToolbarRef }
-					/>
-				) }
+				{ ! isZoomOutMode &&
+					! hasFixedToolbar &&
+					createPortal(
+						<Popover.Slot
+							name="block-toolbar"
+							ref={ blockToolbarRef }
+						/>,
+						getOverlayLegacySlot()
+					) }
 				{ children }
 				{ /* Used for inline rich text popovers. */ }
-				<Popover.Slot
-					name="__unstable-block-tools-after"
-					ref={ blockToolbarAfterRef }
-				/>
+				{ createPortal(
+					<Popover.Slot
+						name="__unstable-block-tools-after"
+						ref={ blockToolbarAfterRef }
+					/>,
+					getOverlayLegacySlot()
+				) }
 				{ isZoomOutMode && ! isDragging && (
 					<ZoomOutModeInserters
 						__unstableContentRef={ __unstableContentRef }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Internal
 
 -   Add `getOverlayLegacySlot()` helper and matching `.wp-overlay-legacy` styles. Lazily mounts a body-level container at `z-index: 99997` with `isolation: isolate` to be used as the portal target for legacy overlays in a follow-up. No runtime behavior change yet.
+-   `Popover`: Render the fallback container inside the new overlay legacy slot. The popover's per-class z-index is preserved and now stacks relative to the slot.
 -   `NavigableContainer`: Refactor from class component to function component with hooks ([#77171](https://github.com/WordPress/gutenberg/pull/77171)).
 -   `Menu`: Refactor `Menu.Popover` to use Ariakit’s `render` prop, wrapping content in `MenuMotionRoot` (motion styles) and `MenuSurface` (panel layout and `variant` chrome) ([#77460](https://github.com/WordPress/gutenberg/pull/77460)).
 -   Fix types for TypeScript 7.0 ([#77177](https://github.com/WordPress/gutenberg/pull/77177)).

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -35,6 +35,7 @@ import { __ } from '@wordpress/i18n';
 import Button from '../button';
 import ScrollLock from '../scroll-lock';
 import { Slot, Fill, useSlot } from '../slot-fill';
+import { getOverlayLegacySlot } from '../utils/overlay-legacy-slot';
 import {
 	computePopoverPosition,
 	positionToPlacement,
@@ -93,13 +94,14 @@ import { slotNameContext } from './context';
 
 const fallbackContainerClassname = 'components-popover__fallback-container';
 const getPopoverFallbackContainer = () => {
-	let container = document.body.querySelector(
+	const legacySlot = getOverlayLegacySlot();
+	let container = legacySlot.querySelector(
 		'.' + fallbackContainerClassname
 	);
 	if ( ! container ) {
 		container = document.createElement( 'div' );
 		container.className = fallbackContainerClassname;
-		document.body.append( container );
+		legacySlot.append( container );
 	}
 
 	return container;

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -11,6 +11,7 @@ import { Menu } from './menu';
 import { ComponentsContext } from './context/context-system-provider';
 import Theme from './theme';
 import { Tabs } from './tabs';
+import { getOverlayLegacySlot } from './utils/overlay-legacy-slot';
 import { kebabCase, normalizeTextString } from './utils/strings';
 import { withIgnoreIMEEvents } from './utils/with-ignore-ime-events';
 import { lock } from './lock-unlock';
@@ -34,6 +35,7 @@ import { ValidatedFormTokenField } from './validated-form-controls/components/fo
 export const privateApis = {};
 lock( privateApis, {
 	__experimentalPopoverLegacyPositionToPlacement,
+	__experimentalGetOverlayLegacySlot: getOverlayLegacySlot,
 	ComponentsContext,
 	Tabs,
 	Theme,

--- a/packages/customize-widgets/src/components/customize-widgets/index.js
+++ b/packages/customize-widgets/src/components/customize-widgets/index.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { useState, useEffect, useRef, createPortal } from '@wordpress/element';
-import { SlotFillProvider, Popover } from '@wordpress/components';
+import {
+	SlotFillProvider,
+	Popover,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -12,6 +16,11 @@ import SidebarBlockEditor from '../sidebar-block-editor';
 import FocusControl from '../focus-control';
 import SidebarControls from '../sidebar-controls';
 import useClearSelectedBlock from './use-clear-selected-block';
+import { unlock } from '../../lock-unlock';
+
+const { __experimentalGetOverlayLegacySlot: getOverlayLegacySlot } = unlock(
+	componentsPrivateApis
+);
 
 export default function CustomizeWidgets( {
 	api,
@@ -19,9 +28,6 @@ export default function CustomizeWidgets( {
 	blockEditorSettings,
 } ) {
 	const [ activeSidebarControl, setActiveSidebarControl ] = useState( null );
-	const parentContainer = document.getElementById(
-		'customize-theme-controls'
-	);
 	const popoverRef = useRef();
 
 	useClearSelectedBlock( activeSidebarControl, popoverRef );
@@ -55,16 +61,15 @@ export default function CustomizeWidgets( {
 			activeSidebarControl.container[ 0 ]
 		);
 
-	// We have to portal this to the parent of both the editor and the inspector,
-	// so that the popovers will appear above both of them.
-	const popover =
-		parentContainer &&
-		createPortal(
-			<div className="customize-widgets-popover" ref={ popoverRef }>
-				<Popover.Slot />
-			</div>,
-			parentContainer
-		);
+	// Portal this into the overlay legacy slot so popovers appear above both
+	// the editor and the inspector. The slot's stacking context (above the
+	// customizer panes, below the WP admin bar) handles the layering.
+	const popover = createPortal(
+		<div className="customize-widgets-popover" ref={ popoverRef }>
+			<Popover.Slot />
+		</div>,
+		getOverlayLegacySlot()
+	);
 
 	return (
 		<SlotFillProvider>

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -3,9 +3,12 @@
  */
 import { BlockToolbar } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { useRef } from '@wordpress/element';
+import { createPortal, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Popover } from '@wordpress/components';
+import {
+	Popover,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { PinnedItems } from '@wordpress/interface';
 import { useViewportMatch } from '@wordpress/compose';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -17,6 +20,11 @@ import { VisuallyHidden } from '@wordpress/ui';
 import DocumentTools from './document-tools';
 import SaveButton from '../save-button';
 import MoreMenu from '../more-menu';
+import { unlock } from '../../lock-unlock';
+
+const { __experimentalGetOverlayLegacySlot: getOverlayLegacySlot } = unlock(
+	componentsPrivateApis
+);
 
 function Header() {
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -54,10 +62,13 @@ function Header() {
 							<div className="selected-block-tools-wrapper">
 								<BlockToolbar hideDragHandle />
 							</div>
-							<Popover.Slot
-								ref={ blockToolbarRef }
-								name="block-toolbar"
-							/>
+							{ createPortal(
+								<Popover.Slot
+									ref={ blockToolbarRef }
+									name="block-toolbar"
+								/>,
+								getOverlayLegacySlot()
+							) }
 						</>
 					) }
 				</div>

--- a/packages/editor/src/components/collapsible-block-toolbar/index.js
+++ b/packages/editor/src/components/collapsible-block-toolbar/index.js
@@ -11,8 +11,12 @@ import {
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { useEffect } from '@wordpress/element';
-import { Button, Popover } from '@wordpress/components';
+import { createPortal, useEffect } from '@wordpress/element';
+import {
+	Button,
+	Popover,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { next, previous } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
@@ -23,6 +27,9 @@ import { useSelect } from '@wordpress/data';
 import { unlock } from '../../lock-unlock';
 
 const { useHasBlockToolbar } = unlock( blockEditorPrivateApis );
+const { __experimentalGetOverlayLegacySlot: getOverlayLegacySlot } = unlock(
+	componentsPrivateApis
+);
 
 export default function CollapsibleBlockToolbar( { isCollapsed, onToggle } ) {
 	const { blockSelectionStart } = useSelect( ( select ) => {
@@ -55,7 +62,10 @@ export default function CollapsibleBlockToolbar( { isCollapsed, onToggle } ) {
 			>
 				<BlockToolbar hideDragHandle />
 			</div>
-			<Popover.Slot name="block-toolbar" />
+			{ createPortal(
+				<Popover.Slot name="block-toolbar" />,
+				getOverlayLegacySlot()
+			) }
 
 			<Button
 				className="editor-collapsible-block-toolbar__toggle"


### PR DESCRIPTION
## What?

Stacked on top of #77755.

Move the `@wordpress/components` Popover into the overlay legacy slot introduced in the previous PR. Two paths are migrated:

-   The popover **fallback container** (\`.components-popover__fallback-container\`) is now created inside \`.wp-overlay-legacy\` rather than directly under the document body.
-   Gutenberg's internal \`Popover.Slot\` declarations (\`block-toolbar\`, \`__unstable-block-tools-after\`, and the default slot in customize-widgets) are wrapped in \`createPortal(<Popover.Slot …>, getOverlayLegacySlot())\` so the slot DOM lives inside the legacy slot.

## Why?

This is the second step in the two-slot overlay architecture: every \`@wordpress/components\` overlay needs to land inside \`.wp-overlay-legacy\` so that, once \`@wordpress/ui\` leaf overlays start rendering inside \`.wp-overlay-prime\` in a later PR, mixed-library composition (e.g. a \`@wordpress/ui\` Tooltip rendered inside a \`@wordpress/components\` Popover) stacks correctly without per-instance plumbing.

The \`.components-popover\` z-index (1,000,000) is unchanged. It now stacks relative to the legacy slot's stacking context rather than the document body, preserving the existing Tooltip > Popover > Modal ordering.

Plugin-registered \`Popover.Slot\` declarations (any slot whose name doesn't appear in Gutenberg's own packages) are **not** relocated.

## How?

-   \`packages/components/src/popover/index.tsx\`: \`getPopoverFallbackContainer()\` now creates the container as a child of \`getOverlayLegacySlot()\` and queries within it for an existing one.
-   \`packages/components/src/private-apis.ts\`: expose \`getOverlayLegacySlot\` as \`__experimentalGetOverlayLegacySlot\` so editor packages can target the slot without hardcoded selectors.
-   \`packages/block-editor/src/components/block-tools/index.js\`: wrap both \`Popover.Slot\` declarations in \`createPortal(..., getOverlayLegacySlot())\`. Refs (used by \`usePopoverScroll\`) and slot names are unchanged.
-   \`packages/editor/src/components/collapsible-block-toolbar/index.js\`: same wrap for the \`block-toolbar\` slot.
-   \`packages/edit-widgets/src/components/header/index.js\`: same wrap for the \`block-toolbar\` slot.
-   \`packages/customize-widgets/src/components/customize-widgets/index.js\`: change the existing portal target from \`#customize-theme-controls\` to \`getOverlayLegacySlot()\`. The wrapping \`.customize-widgets-popover\` div and \`popoverRef\` are preserved (the latter is still used by \`useClearSelectedBlock\`).

\`createPortal\` only changes DOM bubbling, not the React tree, so SlotFill context propagation, \`usePopoverScroll\`'s wheel-forwarding, and ref-based focus checks (e.g. \`useClearSelectedBlock\`) all continue to work.

## Testing Instructions

After this PR is loaded, the popover fallback container and Gutenberg's slot-routed popovers should be inside \`<div class=\"wp-overlay-legacy\">\` rather than directly under \`<body>\`.

1.  Open the post editor. Select a block. The block toolbar popover should appear and behave as before; in DevTools, walk up from \`.components-popover\` and you should reach \`<div class=\"wp-overlay-legacy\"></div>\` before \`<body>\`.
2.  Open a popover that doesn't use a slot (e.g. the inserter, Settings sidebar dropdown). Same DOM check.
3.  In Site Editor / Post Editor with iframed canvas, open a popover from a block inside the iframe. The popover should still position correctly relative to its trigger.
4.  In the customizer (Appearance → Customize → Widgets), open a widget editor and verify popovers float over the customizer panes.
5.  In \`edit-widgets\`, switch to fixed toolbar and confirm the block toolbar popover renders correctly.

Unit tests:

\`\`\`sh
npm run test:unit -- packages/components/src/popover packages/customize-widgets packages/edit-widgets packages/editor/src/components/collapsible-block-toolbar packages/block-editor/src/components/block-tools
\`\`\`

### Testing Instructions for Keyboard

Keyboard interaction with popovers is unchanged. Open the post editor, select a block, press \`Alt+F10\` to focus the block toolbar, navigate inside it. Open the inserter with \`/\` and verify it can be navigated and dismissed with \`Escape\`.

## Use of AI Tools

This PR was authored with assistance from AI tooling (Claude). All code, copy, and structural decisions were reviewed by a human contributor.