### PR TITLE
Modal: Render inside the overlay legacy slot

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 -   Add `getOverlayLegacySlot()` helper and matching `.wp-overlay-legacy` styles. Lazily mounts a body-level container at `z-index: 99997` with `isolation: isolate` to be used as the portal target for legacy overlays in a follow-up. No runtime behavior change yet.
 -   `Popover`: Render the fallback container inside the new overlay legacy slot. The popover's per-class z-index is preserved and now stacks relative to the slot.
+-   `Modal`: Portal modals into the overlay legacy slot. Update the aria-helper to walk up from the modal so siblings of the slot wrapper (and outer modals when nested) continue to be aria-hidden.
 -   `NavigableContainer`: Refactor from class component to function component with hooks ([#77171](https://github.com/WordPress/gutenberg/pull/77171)).
 -   `Menu`: Refactor `Menu.Popover` to use Ariakit’s `render` prop, wrapping content in `MenuMotionRoot` (motion styles) and `MenuSurface` (panel layout and `variant` chrome) ([#77460](https://github.com/WordPress/gutenberg/pull/77460)).
 -   Fix types for TypeScript 7.0 ([#77177](https://github.com/WordPress/gutenberg/pull/77177)).

--- a/packages/components/src/modal/aria-helper.ts
+++ b/packages/components/src/modal/aria-helper.ts
@@ -21,18 +21,42 @@ const hiddenElementsByDepth: Element[][] = [];
  * @param modalElement The element that should not be hidden.
  */
 export function modalize( modalElement?: HTMLDivElement ) {
-	const elements = Array.from( document.body.children );
 	const hiddenElements: Element[] = [];
 	hiddenElementsByDepth.push( hiddenElements );
-	for ( const element of elements ) {
-		if ( element === modalElement ) {
-			continue;
-		}
 
-		if ( elementShouldBeHidden( element ) ) {
-			element.setAttribute( 'aria-hidden', 'true' );
-			hiddenElements.push( element );
+	if ( ! modalElement ) {
+		// Fallback (no modal element provided): hide all body children. Kept
+		// for backwards compatibility with legacy callers.
+		for ( const element of Array.from( document.body.children ) ) {
+			if ( elementShouldBeHidden( element ) ) {
+				element.setAttribute( 'aria-hidden', 'true' );
+				hiddenElements.push( element );
+			}
 		}
+		return;
+	}
+
+	// Walk up from the modal to <body>, hiding non-modal siblings at each
+	// level. This preserves correct screen-reader semantics when the modal
+	// is portaled into a wrapper (e.g. the overlay legacy slot): siblings
+	// inside the wrapper — including an outer modal when nested — get
+	// hidden, and so do siblings of the wrapper at the body level.
+	let current: Element = modalElement;
+	while ( current.parentElement ) {
+		const parent = current.parentElement;
+		for ( const sibling of Array.from( parent.children ) ) {
+			if ( sibling === current ) {
+				continue;
+			}
+			if ( elementShouldBeHidden( sibling ) ) {
+				sibling.setAttribute( 'aria-hidden', 'true' );
+				hiddenElements.push( sibling );
+			}
+		}
+		if ( parent === document.body ) {
+			break;
+		}
+		current = parent;
 	}
 }
 

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -23,6 +23,7 @@ import * as ariaHelper from './aria-helper';
 import Button from '../button';
 import StyleProvider from '../style-provider';
 import type { ModalProps } from './types';
+import { getOverlayLegacySlot } from '../utils/overlay-legacy-slot';
 import { withIgnoreIMEEvents } from '../utils/with-ignore-ime-events';
 import { Spacer } from '../spacer';
 import { useModalExitAnimation } from './use-modal-exit-animation';
@@ -363,7 +364,7 @@ function UnforwardedModal(
 		<ModalContext.Provider value={ nestedDismissers }>
 			{ modal }
 		</ModalContext.Provider>,
-		document.body
+		getOverlayLegacySlot()
 	);
 }
 


### PR DESCRIPTION
## What?

Stacked on top of #77756.

Move the `@wordpress/components` Modal portal from `document.body` to `getOverlayLegacySlot()`, and update the aria-hide algorithm so it remains correct after the wrapper is introduced.

## Why?

Continuation of the legacy-slot migration. With the Modal inside `.wp-overlay-legacy`, every legacy `@wordpress/components` overlay shares the same stacking context, so a future `@wordpress/ui` Tooltip rendered inside a `@wordpress/components` Modal will stack above the modal by virtue of its slot being above the legacy slot — without any per-instance plumbing.

The `.components-modal__screen-overlay` z-index (100,000) and the 14 sibling overlay z-indexes at 1,000,001 (e.g. `.components-confirm-dialog`) are unchanged. They now stack relative to the legacy slot's stacking context, preserving the existing modal-above-popover ordering.

## How?

-   `packages/components/src/modal/index.tsx`: change `createPortal(modal, document.body)` to `createPortal(modal, getOverlayLegacySlot())`.
-   `packages/components/src/modal/aria-helper.ts`: rewrite `modalize()` to walk up from `modalElement` to `<body>` and hide non-modal siblings at each level. The previous algorithm only inspected direct body children — once the modal is portaled into a body-level wrapper (the slot), the wrapper itself would have been hidden, taking the modal subtree with it. The new algorithm:
    -   Walks up from the modal to body, hiding siblings at each level.
    -   Preserves the existing nested-modal semantics: when an inner modal opens, the outer modal (a sibling inside the slot) gets aria-hidden, and at the body level the rest of the editor still gets aria-hidden via the slot's siblings.
    -   Keeps the legacy fallback when called without a `modalElement`.

## Testing Instructions

1.  Open the post editor. Trigger any modal (e.g. block-editor Rename Block, Duplicate, Block Visibility). Verify the modal opens, traps focus, and dismisses with `Escape` and the close button.
2.  In DevTools, walk up from `.components-modal__screen-overlay`. The modal should be inside `<div class="wp-overlay-legacy">` rather than directly under `<body>`.
3.  Open a confirm dialog (e.g. confirm a destructive operation). Verify it stacks above the modal as before.
4.  Nested modal (e.g. Block Manager inside Preferences). Verify the outer modal becomes aria-hidden when the inner opens, and is restored on inner close.
5.  Run the unit suite:

    ```sh
    npm run test:unit -- packages/components/src/modal
    ```

### Testing Instructions for Keyboard

Open any modal. `Tab` and `Shift+Tab` should cycle within the modal (focus trap). `Escape` should close it and return focus to the trigger.

## Use of AI Tools

This PR was authored with assistance from AI tooling (Claude). All code, copy, and structural decisions were reviewed by a human contributor.