### PR TITLE
Tooltip, Menu, CustomSelectControl v2: Render inside the overlay legacy slot

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -22,6 +22,7 @@
 -   Add `getOverlayLegacySlot()` helper and matching `.wp-overlay-legacy` styles. Lazily mounts a body-level container at `z-index: 99997` with `isolation: isolate` to be used as the portal target for legacy overlays in a follow-up. No runtime behavior change yet.
 -   `Popover`: Render the fallback container inside the new overlay legacy slot. The popover's per-class z-index is preserved and now stacks relative to the slot.
 -   `Modal`: Portal modals into the overlay legacy slot. Update the aria-helper to walk up from the modal so siblings of the slot wrapper (and outer modals when nested) continue to be aria-hidden.
+-   `Tooltip`, `Menu`, `CustomSelectControl` v2: Pass `portalElement={ getOverlayLegacySlot }` so each Ariakit-backed overlay portals into the overlay legacy slot. Per-overlay z-indexes are unchanged.
 -   `NavigableContainer`: Refactor from class component to function component with hooks ([#77171](https://github.com/WordPress/gutenberg/pull/77171)).
 -   `Menu`: Refactor `Menu.Popover` to use Ariakit’s `render` prop, wrapping content in `MenuMotionRoot` (motion styles) and `MenuSurface` (panel layout and `variant` chrome) ([#77460](https://github.com/WordPress/gutenberg/pull/77460)).
 -   Fix types for TypeScript 7.0 ([#77177](https://github.com/WordPress/gutenberg/pull/77177)).

--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -25,6 +25,7 @@ import type {
 import InputBase from '../input-control/input-base';
 import SelectControlChevronDown from '../select-control/chevron-down';
 import BaseControl from '../base-control';
+import { getOverlayLegacySlot } from '../utils/overlay-legacy-slot';
 
 export const CustomSelectContext =
 	createContext< CustomSelectContextType >( undefined );
@@ -151,6 +152,7 @@ function CustomSelect(
 					onKeyDown={ onSelectPopoverKeyDown }
 					// Match legacy behavior
 					flip={ ! isLegacy }
+					portalElement={ getOverlayLegacySlot }
 				>
 					<CustomSelectContext.Provider value={ contextValue }>
 						{ children }

--- a/packages/components/src/menu/popover.tsx
+++ b/packages/components/src/menu/popover.tsx
@@ -19,6 +19,7 @@ import {
 import type { WordPressComponentProps } from '../context';
 import type { PopoverProps } from './types';
 import * as Styled from './styles';
+import { getOverlayLegacySlot } from '../utils/overlay-legacy-slot';
 import { Context } from './context';
 
 export const Popover = forwardRef<
@@ -96,6 +97,7 @@ export const Popover = forwardRef<
 			data-submenu={ !! menuContext.store.parent || undefined }
 			wrapperProps={ wrapperProps }
 			hideOnEscape={ hideOnEscape }
+			portalElement={ getOverlayLegacySlot }
 			unmountOnHide
 			render={ renderMenu }
 		/>

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -11,6 +11,7 @@ import deprecated from '@wordpress/deprecated';
 import type { TooltipProps } from './types';
 import Shortcut from '../shortcut';
 import { positionToPlacement } from '../popover/utils';
+import { getOverlayLegacySlot } from '../utils/overlay-legacy-slot';
 import { TooltipInternalContext } from './context';
 
 /**
@@ -122,6 +123,7 @@ function UnforwardedTooltip(
 					gutter={ 4 }
 					id={ describedById }
 					overflowPadding={ 0.5 }
+					portalElement={ getOverlayLegacySlot }
 					store={ tooltipStore }
 				>
 					{ text }


### PR DESCRIPTION
## What?

Stacked on top of #77757.

Pass `portalElement={ getOverlayLegacySlot }` to each Ariakit-backed `@wordpress/components` overlay (Tooltip, Menu, CustomSelectControl v2) so they portal into `.wp-overlay-legacy` instead of Ariakit's default container under the document body.

## Why?

Continuation of the legacy-slot migration. With these leaf overlays in the slot, they share the same stacking context as Modal and Popover and stack correctly against `@wordpress/ui` overlays (which will render in the overlay prime slot in a later PR).

These leaf-shaped overlays land in the **legacy** slot rather than the prime slot to avoid coupling `@wordpress/components` to `@wordpress/ui`. Their per-class z-indexes within the legacy slot's stacking context (Tooltip 1,000,002, Menu 1,000,000) preserve the existing Tooltip-above-Popover and Menu-above-Modal ordering against the other `@wordpress/components` overlays.

## How?

`portalElement` accepts a function `(defaultElement: HTMLElement) => HTMLElement | null`, so passing `getOverlayLegacySlot` as the resolver is enough — Ariakit calls it lazily when the overlay needs a portal target.

-   `packages/components/src/tooltip/index.tsx`: add `portalElement={ getOverlayLegacySlot }` to `<Ariakit.Tooltip>`.
-   `packages/components/src/menu/popover.tsx`: add `portalElement={ getOverlayLegacySlot }` to `<Styled.Menu>` (Ariakit menu primitive).
-   `packages/components/src/custom-select-control-v2/custom-select.tsx`: add `portalElement={ getOverlayLegacySlot }` to `<Styled.SelectPopover>`.

No prop API changes; consumers can still pass their own `portalElement` to override (the prop is exposed by Ariakit, just not by `@wordpress/components`'s wrappers — but if a consumer drops down to the underlying Ariakit primitive, their value still wins).

## Testing Instructions

1.  Open the post editor. Hover any control with a tooltip. The `.components-tooltip` element should be inside `<div class="wp-overlay-legacy">`.
2.  Open a Menu (e.g. the kebab "More options" menu on a block). The menu surface should be inside `.wp-overlay-legacy`.
3.  Open a CustomSelectControl v2 dropdown (e.g. typography or border controls in some inspector panels). The popover should be inside `.wp-overlay-legacy`.
4.  Verify cross-overlay stacking: hover a tooltip-bearing control inside an open Modal. The tooltip should still appear above the modal (z-indexes preserved within the slot).
5.  Run the unit suite:

    ```sh
    npm run test:unit -- packages/components/src/tooltip packages/components/src/menu packages/components/src/custom-select-control-v2
    ```

### Testing Instructions for Keyboard

Open a Menu via its trigger button (`Enter` or `Space`). Use arrow keys to navigate, `Escape` to close. Hover focus into a control with a tooltip via `Tab` and verify the tooltip appears.

## Use of AI Tools

This PR was authored with assistance from AI tooling (Claude). All code, copy, and structural decisions were reviewed by a human contributor.