### PR TITLE
Draggable: Render the clone inside the overlay legacy slot

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,7 @@
 -   `Modal`: Portal modals into the overlay legacy slot. Update the aria-helper to walk up from the modal so siblings of the slot wrapper (and outer modals when nested) continue to be aria-hidden.
 -   `Tooltip`, `Menu`, `CustomSelectControl` v2: Pass `portalElement={ getOverlayLegacySlot }` so each Ariakit-backed overlay portals into the overlay legacy slot. Per-overlay z-indexes are unchanged.
 -   `SnackbarList`: Bake the previously-mixin-only positioning (`position: fixed; bottom; padding-inline; pointer-events: none;`) into `.components-snackbar-list` directly so the list self-positions whether portaled or rendered inline.
+-   `Draggable`: Append the drag clone wrapper to the overlay legacy slot instead of the document body. The clone's z-index is unchanged; it stacks relative to the slot.
 -   `NavigableContainer`: Refactor from class component to function component with hooks ([#77171](https://github.com/WordPress/gutenberg/pull/77171)).
 -   `Menu`: Refactor `Menu.Popover` to use Ariakit’s `render` prop, wrapping content in `MenuMotionRoot` (motion styles) and `MenuSurface` (panel layout and `variant` chrome) ([#77460](https://github.com/WordPress/gutenberg/pull/77460)).
 -   Fix types for TypeScript 7.0 ([#77177](https://github.com/WordPress/gutenberg/pull/77177)).

--- a/packages/components/src/draggable/index.tsx
+++ b/packages/components/src/draggable/index.tsx
@@ -13,6 +13,7 @@ import { useEffect, useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import type { DraggableProps } from './types';
+import { getOverlayLegacySlot } from '../utils/overlay-legacy-slot';
 
 const dragImageClass = 'components-draggable__invisible-drag-image';
 const cloneWrapperClass = 'components-draggable__clone';
@@ -141,8 +142,8 @@ export function Draggable( {
 			clonedDragComponent.innerHTML = dragComponentRef.current.innerHTML;
 			cloneWrapper.appendChild( clonedDragComponent );
 
-			// Inject the cloneWrapper into the DOM.
-			ownerDocument.body.appendChild( cloneWrapper );
+			// Inject the cloneWrapper into the overlay legacy slot.
+			getOverlayLegacySlot().appendChild( cloneWrapper );
 		} else {
 			const element = ownerDocument.getElementById(
 				elementId
@@ -175,7 +176,7 @@ export function Draggable( {
 
 			// Inject the cloneWrapper into the DOM.
 			if ( appendToOwnerDocument ) {
-				ownerDocument.body.appendChild( cloneWrapper );
+				getOverlayLegacySlot().appendChild( cloneWrapper );
 			} else {
 				elementWrapper?.appendChild( cloneWrapper );
 			}


### PR DESCRIPTION
## What?

Stacked on top of #77760.

Replace `ownerDocument.body.appendChild( cloneWrapper )` with `getOverlayLegacySlot().appendChild( cloneWrapper )` in `Draggable`. Both clone branches are covered (`__experimentalDragComponent` and the `appendToOwnerDocument` branch).

## Why?

Final step of the legacy-slot migration. With the drag clone in `.wp-overlay-legacy`, every legacy `@wordpress/components` overlay now shares the same stacking context.

The drag clone uses `position: fixed` and `transform` to follow the cursor, so its positioning is independent of where in the DOM it lives. The `.components-draggable__clone` z-index (1,000,000,000 — the billion) is unchanged; it now stacks relative to the legacy slot. A future cleanup PR can revisit whether the billion is still needed once the slot architecture is fully in place.

## How?

`packages/components/src/draggable/index.tsx`:

-   Import `getOverlayLegacySlot`.
-   The two body-appendChild calls (one in the `dragComponent`-defined branch, one in the `appendToOwnerDocument === true` branch) become `getOverlayLegacySlot().appendChild( cloneWrapper )`.
-   The `appendToOwnerDocument === false` branch (default) is unchanged — it still appends the clone next to the source element's wrapper.
-   The fake invisible drag image (used for `event.dataTransfer.setDragImage` and immediately removed) and the body class for cursor styling stay on `ownerDocument.body`.

The cleanup path (`cloneWrapper.parentNode.removeChild( cloneWrapper )`) is unchanged and works regardless of where the clone was attached.

## Testing Instructions

1.  Open the post editor. Drag a block by its drag handle. The drag clone (preview that follows the cursor) should appear and reposition smoothly.
2.  Inspect during drag: the `.components-draggable__clone` element should be inside `<div class="wp-overlay-legacy">` rather than directly under `<body>`.
3.  Open List View. Drag a block from List View to a new position. Same DOM check.
4.  Drag from inside the iframed canvas (Site Editor / Post Editor with iframe). The default path (`appendToOwnerDocument: false`) attaches the clone next to the dragged element — unchanged. Verify drag-and-drop still works.
5.  Cancel a drag with `Escape`. Verify the clone is removed.

### Testing Instructions for Keyboard

Drag-and-drop is a pointer-based interaction. Verify keyboard-equivalent block movement (the up/down arrow shortcuts in List View, `Ctrl+Shift+D` for duplicate, etc.) still works — no changes are expected here.

## Use of AI Tools

This PR was authored with assistance from AI tooling (Claude). All code, copy, and structural decisions were reviewed by a human contributor.