### PR TITLE
Site Tagline: Make editable inside content-only locked parents

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -947,7 +947,7 @@ Describe in a few words what this site is about. This is important for search re
 
 -	**Name:** core/site-tagline
 -	**Category:** theme
--	**Supports:** align (full, wide), anchor, color (background, gradients, text), contentRole, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
+-	**Supports:** align (full, wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
 -	**Attributes:** level, levelOptions
 
 ## Site Title

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -10,7 +10,8 @@
 	"attributes": {
 		"level": {
 			"type": "number",
-			"default": 0
+			"default": 0,
+			"role": "content"
 		},
 		"levelOptions": {
 			"type": "array",
@@ -38,7 +39,6 @@
 				"text": true
 			}
 		},
-		"contentRole": true,
 		"spacing": {
 			"margin": true,
 			"padding": true,


### PR DESCRIPTION
## What

Replaces `supports.contentRole: true` on the Site Tagline block with `role: "content"` on its `level` attribute.

## Why

`contentRole: true` is meant for **transparent container blocks** (e.g., `core/buttons`, `core/list`) — blocks that hold content children but aren't themselves directly editable. The reducer recognizes that flag and assigns those blocks an editing mode of `disabled` inside content-only locked sections, surfacing their *children* instead:

```js
// packages/block-editor/src/store/reducer.js
if (
    isContentBlock( blockName ) &&
    ! hasContentRoleSupport( blockName )
) {
    derivedBlockEditingModes.set( clientId, 'contentOnly' );
} else {
    derivedBlockEditingModes.set( clientId, 'disabled' );
}
```

Site Tagline is a leaf block (its text is the content, edited via the `description` entity record), not a container. Flagging it as a content-role container forced it into `disabled` mode in content-only sections, so the `RichText` couldn't be focused or typed into.

This PR aligns Site Tagline with how Site Title and Post Title declare themselves as content blocks: by giving an attribute `role: "content"`. That makes `isContentBlock` return true via the attribute path (not the contentRole-container path), so the reducer assigns `contentOnly` editing mode and the tagline becomes editable inside content-only locked parents — matching Site Title's behavior.

## Test plan

- [ ] Insert a Group block, set its template lock to **Content** (content-only).
- [ ] Add a Site Tagline block inside the Group. Confirm the tagline can be focused and edited.
- [ ] Add a Site Title block inside the Group. Confirm both behave identically (both editable, structural controls hidden).
- [ ] Confirm outside of content-only contexts, Site Tagline still exposes its heading-level dropdown and inspector controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)