### PR TITLE
ESLint Plugin: Recommend `EmptyState` from `@wordpress/ui`

### DIFF
--- a/packages/eslint-plugin/rules/use-recommended-components.js
+++ b/packages/eslint-plugin/rules/use-recommended-components.js
@@ -13,6 +13,7 @@ const ALLOWLIST = {
 			'Card',
 			'Collapsible',
 			'CollapsibleCard',
+			'EmptyState',
 			'Link',
 			'Stack',
 			'Text',


### PR DESCRIPTION
## What?

Adds `EmptyState` to the `@wordpress/ui` allowlist in `packages/eslint-plugin/rules/use-recommended-components.js`.

## Why?

`EmptyState` is shipped, fully tested, and ready for production use, but a direct import still triggers `@wordpress/use-recommended-components`. Adding the component to the allowlist matches the framing that the allowlist itself is the readiness signal. See [#76135](https://github.com/WordPress/gutenberg/issues/76135) for the broader readiness discussion.

## How?

Single-line addition to the `'@wordpress/ui'` allowlist array, alphabetized.

## Testing

- `packages/eslint-plugin/rules/__tests__/use-recommended-components.js` passes unchanged.
- After this change, `import { EmptyState } from '@wordpress/ui';` no longer triggers `@wordpress/use-recommended-components`.
