### PR TITLE
Base styles: update changelog to be clearer

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -20,7 +20,7 @@
     -   `.components-circular-option-picker__option.is-pressed`
     -   `.components-circular-option-picker__option.is-pressed + svg`
     -   `.components-circular-option-picker__swatches`
-    -   `.components-circular-option-picker__swatches > *:not(.components-circular-option-picker__swatches)`
+    -   `> *:not(.components-circular-option-picker__swatches)`
     -   `.components-form-toggle__input`
     -   `.components-popover.block-editor-inspector-list-view-content-popover`
     -   `.components-popover.interface-more-menu__content`

--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -4,12 +4,7 @@
 
 ### Breaking Changes
 
--   Remove `.components-circular-option-picker__option-wrapper::before`, `.components-circular-option-picker__option.is-pressed`, `.components-circular-option-picker__option.is-pressed + svg`, `.components-circular-option-picker__swatches`, and `> *:not(.components-circular-option-picker__swatches)` from the `z-index()` helper ([#77715](https://github.com/WordPress/gutenberg/pull/77715)).
--   Remove `.components-resizable-box__handle`, `.components-resizable-box__side-handle`, and `.components-resizable-box__corner-handle` from the `z-index()` helper ([#77620](https://github.com/WordPress/gutenberg/pull/77620)).
--   Remove `.components-form-toggle__input` from the `z-index()` helper ([#77619](https://github.com/WordPress/gutenberg/pull/77619)).
--   Remove `.interface-complementary-area .components-panel` and `.interface-complementary-area .components-panel__header` from the `z-index()` helper ([#77717](https://github.com/WordPress/gutenberg/pull/77717)).
--   Remove `.components-button {:focus or .is-primary}` from the `z-index()` helper ([#77621](https://github.com/WordPress/gutenberg/pull/77621)).
--   Remove the following stale entries from the `z-index()` helper ([#77714](https://github.com/WordPress/gutenberg/pull/77714)):
+-   Remove the following entries from the `z-index()` helper ([#77619](https://github.com/WordPress/gutenberg/pull/77619), [#77620](https://github.com/WordPress/gutenberg/pull/77620), [#77621](https://github.com/WordPress/gutenberg/pull/77621), [#77714](https://github.com/WordPress/gutenberg/pull/77714), [#77715](https://github.com/WordPress/gutenberg/pull/77715), [#77717](https://github.com/WordPress/gutenberg/pull/77717)):
     -   `.block-editor-block-contextual-toolbar`
     -   `.block-editor-block-list__block {core/image aligned wide or fullwide}`
     -   `.block-editor-block-list__block::before`
@@ -20,13 +15,25 @@
     -   `.block-editor-warning`
     -   `.block-library-classic__toolbar`
     -   `.components-autocomplete__results`
+    -   `.components-button {:focus or .is-primary}`
+    -   `.components-circular-option-picker__option-wrapper::before`
+    -   `.components-circular-option-picker__option.is-pressed`
+    -   `.components-circular-option-picker__option.is-pressed + svg`
+    -   `.components-circular-option-picker__swatches`
+    -   `.components-circular-option-picker__swatches > *:not(.components-circular-option-picker__swatches)`
+    -   `.components-form-toggle__input`
     -   `.components-popover.block-editor-inspector-list-view-content-popover`
     -   `.components-popover.interface-more-menu__content`
+    -   `.components-resizable-box__handle`
+    -   `.components-resizable-box__side-handle`
+    -   `.components-resizable-box__corner-handle`
     -   `.dataviews-action-modal__quick-edit`
     -   `.edit-site-editor__toggle-save-panel`
     -   `.edit-site-template-panel__replace-template-modal`
     -   `.edit-widgets-header`
     -   `.edit-widgets-sidebar {greater than small}`
+    -   `.interface-complementary-area .components-panel`
+    -   `.interface-complementary-area .components-panel__header`
     -   `.wp-block-template-part__placeholder-preview-filter-input`
 
 ## 6.20.0 (2026-04-15)


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Simple cleanup of changelog. 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It makes sense to have a line per PR, but this time the change as one big line felt clearer for anyone updating their dependencies outside Gutenberg in future. Changes are breaking, so clarity is important.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
None
### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
Before
<img width="1105" height="835" alt="image" src="https://github.com/user-attachments/assets/5336e019-dbe6-4dac-822b-a63dfdc4283b" />

After
<img width="1156" height="943" alt="image" src="https://github.com/user-attachments/assets/6cb228ad-f825-413c-bc0c-5df56be3f955" />

## Use of AI Tools
yes
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
