### PR TITLE
Grid: fix `width: 'fill'` when tiles span multiple rows

### DIFF
--- a/packages/grid/src/resolve-fill-widths.ts
+++ b/packages/grid/src/resolve-fill-widths.ts
@@ -13,7 +13,10 @@ import type { DashboardGridLayoutItem } from './types';
  *   Each fixed item between two fills is visited at most once by a fill's
  *   look-ahead.
  * - Multi-row path (any item with `height > 1`): per-column skyline that
- *   tracks shadow occupation of tall tiles, O(n · maxColumns).
+ *   tracks shadow occupation of tall tiles. Placement scans rows in
+ *   row-major order, so worst-case cost depends on both columns and rows
+ *   scanned (rows bounded by the sum of item heights), not only on
+ *   `maxColumns`.
  *
  * @param sortedKeys - Item keys in display order.
  * @param layoutMap  - Map of key to DashboardGridLayoutItem.
@@ -28,9 +31,10 @@ export function resolveFillWidths(
 	const resolved = new Map< string, number >();
 	const n = sortedKeys.length;
 
-	// Pre-extract items, clamp widths, and detect which path to take.
+	// Pre-extract items, clamp widths and heights, detect which path to take.
 	const items = new Array< DashboardGridLayoutItem | undefined >( n );
 	const widths = new Array< number >( n );
+	const heights = new Array< number >( n );
 	let hasFill = false;
 	let hasMultiRow = false;
 	let totalRows = 0;
@@ -42,10 +46,13 @@ export function resolveFillWidths(
 			item && typeof item.width === 'number'
 				? Math.min( item.width, maxColumns )
 				: 1;
+		// Clamp to a positive integer so `0`, fractional, or negative
+		// values match the `|| 1` defaulting used in GridItem styles.
+		const h = Math.max( 1, Math.floor( item?.height ?? 1 ) );
+		heights[ i ] = h;
 		if ( item?.width === 'fill' ) {
 			hasFill = true;
 		}
-		const h = item?.height ?? 1;
 		if ( h > 1 ) {
 			hasMultiRow = true;
 		}
@@ -123,7 +130,7 @@ export function resolveFillWidths(
 			continue;
 		}
 
-		const h = item.height ?? 1;
+		const h = heights[ i ];
 
 		if ( item.width === 'full' ) {
 			let r = cursorRow;

--- a/packages/grid/src/resolve-fill-widths.ts
+++ b/packages/grid/src/resolve-fill-widths.ts
@@ -5,12 +5,15 @@ import type { DashboardGridLayoutItem } from './types';
 
 /**
  * Resolves items with `width: 'fill'` by computing how many columns they
- * should span. Simulates CSS Grid row packing to determine remaining space
- * in each row, then assigns that space to fill items.
+ * should span. Simulates CSS Grid's row-sparse auto-flow placement so the
+ * resolved span matches the free run that CSS Grid will actually use.
  *
- * Complexity: O(n). The inner look-ahead breaks at the next fill or full
- * item, so the fixed items between two fills are scanned exactly once —
- * each fixed item is visited by at most one fill's look-ahead.
+ * Two paths:
+ * - Fast path (no `height > 1` items): single-row column tracker, O(n).
+ *   Each fixed item between two fills is visited at most once by a fill's
+ *   look-ahead.
+ * - Multi-row path (any item with `height > 1`): per-column skyline that
+ *   tracks shadow occupation of tall tiles, O(n · maxColumns).
  *
  * @param sortedKeys - Item keys in display order.
  * @param layoutMap  - Map of key to DashboardGridLayoutItem.
@@ -25,11 +28,12 @@ export function resolveFillWidths(
 	const resolved = new Map< string, number >();
 	const n = sortedKeys.length;
 
-	// Pre-extract items into a flat array and pre-compute clamped widths.
-	// This avoids repeated Map.get() and Math.min() calls in the hot loops.
+	// Pre-extract items, clamp widths, and detect which path to take.
 	const items = new Array< DashboardGridLayoutItem | undefined >( n );
 	const widths = new Array< number >( n );
 	let hasFill = false;
+	let hasMultiRow = false;
+	let totalRows = 0;
 
 	for ( let i = 0; i < n; i++ ) {
 		const item = layoutMap.get( sortedKeys[ i ] );
@@ -41,13 +45,77 @@ export function resolveFillWidths(
 		if ( item?.width === 'fill' ) {
 			hasFill = true;
 		}
+		const h = item?.height ?? 1;
+		if ( h > 1 ) {
+			hasMultiRow = true;
+		}
+		totalRows += h;
 	}
 
 	if ( ! hasFill ) {
 		return resolved;
 	}
 
-	let currentCol = 0;
+	if ( ! hasMultiRow ) {
+		let currentCol = 0;
+
+		for ( let i = 0; i < n; i++ ) {
+			const item = items[ i ];
+			if ( ! item ) {
+				continue;
+			}
+
+			if ( item.width === 'full' ) {
+				currentCol = 0;
+				continue;
+			}
+
+			if ( item.width === 'fill' ) {
+				let reserved = 0;
+				for ( let j = i + 1; j < n; j++ ) {
+					const next = items[ j ];
+					if (
+						! next ||
+						next.width === 'full' ||
+						next.width === 'fill'
+					) {
+						break;
+					}
+					const nextW = widths[ j ];
+					if ( currentCol + 1 + reserved + nextW <= maxColumns ) {
+						reserved += nextW;
+					} else {
+						break;
+					}
+				}
+				const fillCols = Math.max(
+					1,
+					maxColumns - currentCol - reserved
+				);
+				resolved.set( item.key, fillCols );
+				currentCol += fillCols;
+			} else {
+				const w = widths[ i ];
+				if ( currentCol + w > maxColumns ) {
+					currentCol = 0;
+				}
+				currentCol += w;
+			}
+
+			if ( currentCol >= maxColumns ) {
+				currentCol = 0;
+			}
+		}
+
+		return resolved;
+	}
+
+	// `rowOccupancy[ col ]` is the index of the next free row at that
+	// column; rows below it are taken by previously placed items. This
+	// captures the "shadow" of tall tiles into the rows they span.
+	const rowOccupancy = new Array< number >( maxColumns ).fill( 0 );
+	let cursorRow = 0;
+	let cursorCol = 0;
 
 	for ( let i = 0; i < n; i++ ) {
 		const item = items[ i ];
@@ -55,14 +123,43 @@ export function resolveFillWidths(
 			continue;
 		}
 
+		const h = item.height ?? 1;
+
 		if ( item.width === 'full' ) {
-			currentCol = 0;
+			let r = cursorRow;
+			for ( let c = 0; c < maxColumns; c++ ) {
+				if ( rowOccupancy[ c ] > r ) {
+					r = rowOccupancy[ c ];
+				}
+			}
+			for ( let c = 0; c < maxColumns; c++ ) {
+				rowOccupancy[ c ] = r + h;
+			}
+			cursorRow = r + h;
+			cursorCol = 0;
 			continue;
 		}
 
 		if ( item.width === 'fill' ) {
-			// Look ahead: reserve columns for subsequent
-			// non-fill items that fit in this row.
+			let r = cursorRow;
+			let c = cursorCol;
+			scan: for ( ; r <= totalRows; r++ ) {
+				const start = r === cursorRow ? cursorCol : 0;
+				for ( c = start; c < maxColumns; c++ ) {
+					if ( rowOccupancy[ c ] <= r ) {
+						break scan;
+					}
+				}
+			}
+			const fillStartRow = r;
+			const fillStartCol = c;
+			let runLength = 0;
+			while (
+				fillStartCol + runLength < maxColumns &&
+				rowOccupancy[ fillStartCol + runLength ] <= fillStartRow
+			) {
+				runLength++;
+			}
 			let reserved = 0;
 			for ( let j = i + 1; j < n; j++ ) {
 				const next = items[ j ];
@@ -74,28 +171,46 @@ export function resolveFillWidths(
 					break;
 				}
 				const nextW = widths[ j ];
-				// 1 = minimum span for the fill item itself
-				if ( currentCol + 1 + reserved + nextW <= maxColumns ) {
+				if ( 1 + reserved + nextW <= runLength ) {
 					reserved += nextW;
 				} else {
 					break;
 				}
 			}
-
-			const fillCols = Math.max( 1, maxColumns - currentCol - reserved );
+			const fillCols = Math.max( 1, runLength - reserved );
 			resolved.set( item.key, fillCols );
-			currentCol += fillCols;
-		} else {
-			const w = widths[ i ];
-			if ( currentCol + w > maxColumns ) {
-				currentCol = 0;
+			for ( let k = 0; k < fillCols; k++ ) {
+				rowOccupancy[ fillStartCol + k ] = fillStartRow + h;
 			}
-			currentCol += w;
+			cursorRow = fillStartRow;
+			cursorCol = fillStartCol + fillCols;
+			continue;
 		}
 
-		if ( currentCol >= maxColumns ) {
-			currentCol = 0;
+		const w = widths[ i ];
+		let r = cursorRow;
+		let c = cursorCol;
+		place: for ( ; r <= totalRows; r++ ) {
+			c = r === cursorRow ? cursorCol : 0;
+			while ( c + w <= maxColumns ) {
+				let blocked = -1;
+				for ( let k = 0; k < w; k++ ) {
+					if ( rowOccupancy[ c + k ] > r ) {
+						blocked = c + k;
+						break;
+					}
+				}
+				if ( blocked === -1 ) {
+					break place;
+				}
+				c = blocked + 1;
+			}
 		}
+		for ( let k = 0; k < w; k++ ) {
+			rowOccupancy[ c + k ] = r + h;
+		}
+		cursorRow = r;
+		cursorCol = c + w;
 	}
 
 	return resolved;

--- a/packages/grid/src/test/resolve-fill-widths.test.ts
+++ b/packages/grid/src/test/resolve-fill-widths.test.ts
@@ -183,4 +183,68 @@ describe( 'resolveFillWidths', () => {
 		const result = resolveFillWidths( [], new Map(), 6 );
 		expect( result.size ).toBe( 0 );
 	} );
+
+	describe( 'with multi-row items (height > 1)', () => {
+		it( 'accounts for the shadow of a tall tile on the left', () => {
+			const items: DashboardGridLayoutItem[] = [
+				{ key: 'tall', width: 3, height: 2 },
+				{ key: 'header', width: 9, height: 1 },
+				{ key: 'sub', width: 3, height: 1 },
+				{ key: 'fill', width: 'fill', height: 1 },
+			];
+			const result = resolveFillWidths(
+				keys( items ),
+				makeMap( items ),
+				12
+			);
+			expect( result.get( 'fill' ) ).toBe( 6 );
+		} );
+
+		it( 'accounts for the shadow of a tall tile in the middle', () => {
+			const items: DashboardGridLayoutItem[] = [
+				{ key: 'a', width: 3, height: 1 },
+				{ key: 'b', width: 3, height: 2 },
+				{ key: 'c', width: 6, height: 1 },
+				{ key: 'd', width: 3, height: 1 },
+				{ key: 'fill', width: 'fill', height: 1 },
+			];
+			const result = resolveFillWidths(
+				keys( items ),
+				makeMap( items ),
+				12
+			);
+			expect( result.get( 'fill' ) ).toBe( 6 );
+		} );
+
+		it( 'accounts for the shadow of a tall tile on the right', () => {
+			const items: DashboardGridLayoutItem[] = [
+				{ key: 'a', width: 3, height: 1 },
+				{ key: 'b', width: 6, height: 1 },
+				{ key: 'c', width: 3, height: 2 },
+				{ key: 'd', width: 6, height: 1 },
+				{ key: 'fill', width: 'fill', height: 1 },
+			];
+			const result = resolveFillWidths(
+				keys( items ),
+				makeMap( items ),
+				12
+			);
+			expect( result.get( 'fill' ) ).toBe( 3 );
+		} );
+
+		it( 'tracks shadow across multiple rows for height > 2', () => {
+			const items: DashboardGridLayoutItem[] = [
+				{ key: 'tall', width: 3, height: 3 },
+				{ key: 'a', width: 9, height: 1 },
+				{ key: 'b', width: 9, height: 1 },
+				{ key: 'fill', width: 'fill', height: 1 },
+			];
+			const result = resolveFillWidths(
+				keys( items ),
+				makeMap( items ),
+				12
+			);
+			expect( result.get( 'fill' ) ).toBe( 9 );
+		} );
+	} );
 } );


### PR DESCRIPTION
## What?

Fixes the `resolveFillWidths` computation in `@wordpress/grid` so it accounts for the columns occupied by tiles with `height > 1` in the rows they span.

Closes #77768.

## Why?

`resolveFillWidths` tracked position with a single `currentCol`, never reading the `height` property. When a tile had `height > 1`, its "shadow" occupation in the rows below was invisible to the algorithm. Any later `fill` item placed in those rows got the wrong span — typically too wide — and CSS Grid wrapped it to a new row.

Concrete repro (12-col grid):

```js
const layout = [
	{ key: 'fixed-1', width: 3, height: 2, order: 1 },
	{ key: 'fixed-1-1', width: 9, height: 1, order: 2 },
	{ key: 'fixed-2', width: 3, height: 1, order: 3 },
	{ key: 'fixed-3', width: 'fill', height: 1, order: 5 },
];
```

Before this PR `fixed-3` is computed as `span 9` and wraps to row 3. With the fix it is computed as `span 6` and lands in row 2 cols 7–12, right after `fixed-2`.

## How?

Replace the single column tracker with a per-column skyline when the layout contains any `height > 1` item. `rowOccupancy[ col ]` stores the index of the next free row at each column, so tall tiles correctly mark their columns as taken across every row they span.

Two paths:

- **Fast path (no tall tiles):** the original 1D tracker, preserved verbatim. `O(n)` with the same look-ahead amortization.
- **Multi-row path:** per-column skyline with row-sparse auto-flow placement, `O(n · maxColumns)`.

The fast path means layouts that don't use `height > 1` keep the previous performance. `resolveFillWidths` is invoked from a `useMemo` keyed on `[ items, layoutMap, effectiveColumns ]`, so it only re-runs on layout changes (not on every render).

## Testing instructions

Unit tests:

```sh
npx jest packages/grid/src/test/resolve-fill-widths.test.ts
```

20/20 should pass — the 16 existing tests plus 4 new cases covering tall tiles on the left, in the middle, on the right, and with `height > 1` greater than 2.

Manual:

1. Open the `Grid > EditMode` story in Storybook.
2. Build the layout from the repro above.
3. Confirm the `fill` tile lands on row 2 next to `fixed-2`, not on row 3.


https://github.com/user-attachments/assets/70874f38-de4e-4189-97c3-6bcf338c777c

