### PR TITLE
Media editor modal: add interactive grid

### DIFF
--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -10,8 +10,8 @@ export interface MediaEditorCanvasProps {
 	aspectRatio?: number;
 	/** Enable freeform crop mode (resize handles). */
 	freeformCrop?: boolean;
-	/** Whether an external placement control should reveal the grid. */
-	isPlacementControlActive?: boolean;
+	/** Whether external placement activity should reveal the grid. */
+	isPlacementActive?: boolean;
 }
 
 /**
@@ -24,12 +24,12 @@ export interface MediaEditorCanvasProps {
  * @param props
  * @param props.aspectRatio
  * @param props.freeformCrop
- * @param props.isPlacementControlActive
+ * @param props.isPlacementActive
  */
 export default function MediaEditorCanvas( {
 	aspectRatio,
 	freeformCrop,
-	isPlacementControlActive = false,
+	isPlacementActive = false,
 }: MediaEditorCanvasProps ) {
 	const { media } = useMediaEditorContext();
 	const controller = useCropper();
@@ -49,7 +49,7 @@ export default function MediaEditorCanvas( {
 				aspectRatio={ aspectRatio }
 				freeformCrop={ freeformCrop }
 				showGrid="interactive"
-				isPlacementControlActive={ isPlacementControlActive }
+				isPlacementActive={ isPlacementActive }
 			/>
 		</div>
 	);

--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -44,6 +44,7 @@ export default function MediaEditorCanvas( {
 				controller={ controller }
 				aspectRatio={ aspectRatio }
 				freeformCrop={ freeformCrop }
+				showGrid="interactive"
 			/>
 		</div>
 	);

--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -10,6 +10,8 @@ export interface MediaEditorCanvasProps {
 	aspectRatio?: number;
 	/** Enable freeform crop mode (resize handles). */
 	freeformCrop?: boolean;
+	/** Whether an external placement control should reveal the grid. */
+	isPlacementControlActive?: boolean;
 }
 
 /**
@@ -22,10 +24,12 @@ export interface MediaEditorCanvasProps {
  * @param props
  * @param props.aspectRatio
  * @param props.freeformCrop
+ * @param props.isPlacementControlActive
  */
 export default function MediaEditorCanvas( {
 	aspectRatio,
 	freeformCrop,
+	isPlacementControlActive = false,
 }: MediaEditorCanvasProps ) {
 	const { media } = useMediaEditorContext();
 	const controller = useCropper();
@@ -45,6 +49,7 @@ export default function MediaEditorCanvas( {
 				aspectRatio={ aspectRatio }
 				freeformCrop={ freeformCrop }
 				showGrid="interactive"
+				isPlacementControlActive={ isPlacementControlActive }
 			/>
 		</div>
 	);

--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -34,6 +34,8 @@ export interface MediaEditorCropPanelProps {
 	freeformCrop: boolean;
 	/** Setter for freeform mode. */
 	onFreeformChange: ( value: boolean ) => void;
+	/** Signal that a placement-oriented control is being adjusted. */
+	onPlacementControlInteraction?: () => void;
 	/**
 	 * Fixed aspect-ratio presets to display after Free and Original. When
 	 * omitted, the media editor's default fixed-ratio presets are used.
@@ -75,6 +77,7 @@ export function resolveAspectRatio(
  * @param props.onAspectRatioChange
  * @param props.freeformCrop
  * @param props.onFreeformChange
+ * @param props.onPlacementControlInteraction
  * @param props.aspectRatioPresets
  */
 export default function MediaEditorCropPanel( {
@@ -82,6 +85,7 @@ export default function MediaEditorCropPanel( {
 	onAspectRatioChange,
 	freeformCrop,
 	onFreeformChange,
+	onPlacementControlInteraction,
 	aspectRatioPresets,
 }: MediaEditorCropPanelProps ) {
 	const { state, setZoom } = useCropper();
@@ -101,9 +105,10 @@ export default function MediaEditorCropPanel( {
 				max={ MAX_ZOOM }
 				step={ 0.1 }
 				value={ state.zoom }
-				onChange={ ( value ) =>
-					setZoom( typeof value === 'number' ? value : MIN_ZOOM )
-				}
+				onChange={ ( value ) => {
+					onPlacementControlInteraction?.();
+					setZoom( typeof value === 'number' ? value : MIN_ZOOM );
+				} }
 				renderTooltipContent={ ( value ) => {
 					const zoom = typeof value === 'number' ? value : MIN_ZOOM;
 					return sprintf(

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -233,8 +233,7 @@ function MediaEditorModalContent( {
 
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ isDiscardDialogOpen, setIsDiscardDialogOpen ] = useState( false );
-	const [ isPlacementControlActive, setIsPlacementControlActive ] =
-		useState( false );
+	const [ isPlacementActive, setIsPlacementActive ] = useState( false );
 	const placementControlTimerRef =
 		useRef< ReturnType< typeof setTimeout > >();
 
@@ -242,10 +241,10 @@ function MediaEditorModalContent( {
 	const [ freeformCrop, setFreeformCrop ] = useState( true );
 
 	const signalPlacementControlInteraction = useCallback( () => {
-		setIsPlacementControlActive( true );
+		setIsPlacementActive( true );
 		clearTimeout( placementControlTimerRef.current );
 		placementControlTimerRef.current = setTimeout( () => {
-			setIsPlacementControlActive( false );
+			setIsPlacementActive( false );
 		}, PLACEMENT_CONTROL_IDLE_MS );
 	}, [] );
 
@@ -516,8 +515,8 @@ function MediaEditorModalContent( {
 												imageAspectRatio
 											) }
 											freeformCrop={ freeformCrop }
-											isPlacementControlActive={
-												isPlacementControlActive
+											isPlacementActive={
+												isPlacementActive
 											}
 										/>
 									) : (

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -15,9 +15,11 @@ import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
 	createPortal,
+	useCallback,
 	useContext,
 	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -70,6 +72,7 @@ const METADATA_EDIT_KEYS = [
 // Scope save-failure snackbars to this modal so they don't leak into the
 // host editor's notices tray (and vice versa).
 const NOTICES_CONTEXT = 'media-editor';
+const PLACEMENT_CONTROL_IDLE_MS = 300;
 
 const { Tabs } = unlock( componentsPrivateApis );
 
@@ -230,9 +233,27 @@ function MediaEditorModalContent( {
 
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ isDiscardDialogOpen, setIsDiscardDialogOpen ] = useState( false );
+	const [ isPlacementControlActive, setIsPlacementControlActive ] =
+		useState( false );
+	const placementControlTimerRef =
+		useRef< ReturnType< typeof setTimeout > >();
 
 	const [ aspectRatioValue, setAspectRatioValue ] = useState( '0' );
 	const [ freeformCrop, setFreeformCrop ] = useState( true );
+
+	const signalPlacementControlInteraction = useCallback( () => {
+		setIsPlacementControlActive( true );
+		clearTimeout( placementControlTimerRef.current );
+		placementControlTimerRef.current = setTimeout( () => {
+			setIsPlacementControlActive( false );
+		}, PLACEMENT_CONTROL_IDLE_MS );
+	}, [] );
+
+	useEffect( () => {
+		return () => {
+			clearTimeout( placementControlTimerRef.current );
+		};
+	}, [] );
 
 	// Reset aspect-ratio / freeform state when the media changes, so the
 	// next image starts from the defaults.
@@ -292,6 +313,9 @@ function MediaEditorModalContent( {
 							onAspectRatioChange={ setAspectRatioValue }
 							freeformCrop={ freeformCrop }
 							onFreeformChange={ setFreeformCrop }
+							onPlacementControlInteraction={
+								signalPlacementControlInteraction
+							}
 							aspectRatioPresets={ aspectRatioPresets }
 						/>
 					</Stack>
@@ -299,7 +323,13 @@ function MediaEditorModalContent( {
 			},
 			detailsTab,
 		];
-	}, [ isImage, aspectRatioValue, freeformCrop, aspectRatioPresets ] );
+	}, [
+		isImage,
+		aspectRatioValue,
+		freeformCrop,
+		aspectRatioPresets,
+		signalPlacementControlInteraction,
+	] );
 
 	const handleChange = ( updates: Partial< Media > ) => {
 		editEntityRecord( 'postType', 'attachment', id, updates );
@@ -486,6 +516,9 @@ function MediaEditorModalContent( {
 												imageAspectRatio
 											) }
 											freeformCrop={ freeformCrop }
+											isPlacementControlActive={
+												isPlacementControlActive
+											}
 										/>
 									) : (
 										<MediaPreview />
@@ -499,6 +532,9 @@ function MediaEditorModalContent( {
 											setAspectRatioValue( '0' );
 											setFreeformCrop( true );
 										} }
+										onPlacementControlInteraction={
+											signalPlacementControlInteraction
+										}
 									/>
 								) : undefined
 							}

--- a/packages/media-editor/src/components/media-editor-toolbar/index.tsx
+++ b/packages/media-editor/src/components/media-editor-toolbar/index.tsx
@@ -24,6 +24,8 @@ export interface MediaEditorToolbarProps {
 	 * controller.
 	 */
 	onReset?: () => void;
+	/** Signal that a placement-oriented control is being adjusted. */
+	onPlacementControlInteraction?: () => void;
 }
 
 /**
@@ -33,9 +35,11 @@ export interface MediaEditorToolbarProps {
  * and freeform toggle live in the Crop sidebar tab instead.
  * @param props
  * @param props.onReset
+ * @param props.onPlacementControlInteraction
  */
 export default function MediaEditorToolbar( {
 	onReset,
+	onPlacementControlInteraction,
 }: MediaEditorToolbarProps ) {
 	const { state, setRotation, setFlip, snapRotate90, reset, isDirty } =
 		useCropper();
@@ -65,6 +69,7 @@ export default function MediaEditorToolbar( {
 			-MAX_ROTATION_OFFSET + EPS,
 			Math.min( MAX_ROTATION_OFFSET - EPS, value )
 		);
+		onPlacementControlInteraction?.();
 		setRotation( baseAngle + clamped * visualDir );
 	};
 

--- a/packages/media-editor/src/image-editor/react/components/cropper.scss
+++ b/packages/media-editor/src/image-editor/react/components/cropper.scss
@@ -58,6 +58,17 @@ $handle-touch-target-size: 44px;
 		position: absolute;
 		pointer-events: none;
 		overflow: hidden;
+		transition: opacity 0.15s ease;
+	}
+
+	&__canvas--grid-interactive &__grid {
+		opacity: 0;
+		transition-delay: 0.1s;
+	}
+
+	&__canvas--show-grid &__grid {
+		opacity: 1;
+		transition-delay: 0s;
 	}
 
 	&__grid-line {

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -135,7 +135,7 @@ export interface CropperProps {
  * @param root0.controller               The full state/setter object from `useCropperState`.
  * @param root0.stencil                  Custom stencil component.
  * @param root0.showGrid                 Grid overlay mode: false | true | 'interactive'.
- * @param root0.isPlacementControlActive
+ * @param root0.isPlacementControlActive Whether external placement controls are active, keeping the grid visible in interactive mode.
  * @param root0.showDimming              Show dimming overlay outside crop.
  * @param root0.minZoom                  Minimum zoom level.
  * @param root0.maxZoom                  Maximum zoom level.

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -81,8 +81,8 @@ export interface CropperProps {
 	controller: UseCropperStateReturn;
 	/** Stencil component for the crop area. Defaults to RectangleStencil. */
 	stencil?: React.ComponentType< StencilProps >;
-	/** Show the rule-of-thirds grid overlay. */
-	showGrid?: boolean;
+	/** Show the rule-of-thirds grid overlay, or only during interactions. */
+	showGrid?: boolean | 'interactive';
 	/** Show the dimming overlay outside the crop area. */
 	showDimming?: boolean;
 	/** Minimum zoom level. */
@@ -132,7 +132,7 @@ export interface CropperProps {
  * @param root0.src            Image source URL.
  * @param root0.controller     The full state/setter object from `useCropperState`.
  * @param root0.stencil        Custom stencil component.
- * @param root0.showGrid       Show rule-of-thirds grid overlay.
+ * @param root0.showGrid       Grid overlay mode: false | true | 'interactive'.
  * @param root0.showDimming    Show dimming overlay outside crop.
  * @param root0.minZoom        Minimum zoom level.
  * @param root0.maxZoom        Maximum zoom level.
@@ -274,18 +274,18 @@ function CropperInner(
 	}, [ state, elementSize, visualSize, canvasSize ] );
 
 	// Use the interaction hook for mouse, touch, and keyboard events.
-	const { handlers, onWheelNative, isDragging, isZooming } = useInteraction(
-		state,
-		controller,
-		canvasSize,
-		visualSize,
-		{
-			minZoom,
-			maxZoom,
-			onGestureStart,
-			onGestureEnd,
-		}
-	);
+	const {
+		handlers,
+		onWheelNative,
+		isDragging,
+		isZooming,
+		isPlacementInteracting,
+	} = useInteraction( state, controller, canvasSize, visualSize, {
+		minZoom,
+		maxZoom,
+		onGestureStart,
+		onGestureEnd,
+	} );
 
 	// Register wheel handler natively with { passive: false } so
 	// preventDefault works. React's onWheel registers as passive. Bound
@@ -351,6 +351,11 @@ function CropperInner(
 		};
 	}, [] );
 
+	const [ isResizing, setIsResizing ] = useState( false );
+	const isInteractiveGrid = showGrid === 'interactive';
+	const showInteractiveGrid =
+		isInteractiveGrid && ( isPlacementInteracting || isResizing );
+
 	/**
 	 * Handle Escape on a resize handle — return focus to the canvas so
 	 * arrow keys pan the image rather than resize.
@@ -359,10 +364,16 @@ function CropperInner(
 		canvasRef.current?.focus( { preventScroll: true } );
 	}, [] );
 
+	const handleResizeStart = useCallback( () => {
+		setIsResizing( true );
+		onGestureStart?.();
+	}, [ onGestureStart ] );
+
 	/**
 	 * Handle resize end — settle the crop rect (re-center, fill height).
 	 */
 	const handleResizeEnd = useCallback( () => {
+		setIsResizing( false );
 		setSettling( true );
 		settleCrop();
 		onGestureEnd?.();
@@ -434,7 +445,13 @@ function CropperInner(
 			 */ }
 			<div
 				ref={ canvasRef }
-				className="wp-media-editor-image-editor__canvas"
+				className={ clsx(
+					'wp-media-editor-image-editor__canvas',
+					isInteractiveGrid &&
+						'wp-media-editor-image-editor__canvas--grid-interactive',
+					showInteractiveGrid &&
+						'wp-media-editor-image-editor__canvas--show-grid'
+				) }
 				tabIndex={ 0 }
 				role="group"
 				aria-label={ __( 'Image editor' ) }
@@ -465,7 +482,7 @@ function CropperInner(
 					containerSize={ canvasSize }
 					imageSize={ visualSize }
 					onCropChange={ handleCropChange }
-					onResizeStart={ onGestureStart }
+					onResizeStart={ handleResizeStart }
 					onResizeEnd={ handleResizeEnd }
 					onEscape={ handleEscape }
 					aspectRatio={ aspectRatio }
@@ -475,7 +492,7 @@ function CropperInner(
 				/>
 
 				{ /* Rule-of-thirds grid */ }
-				{ showGrid && (
+				{ ( showGrid === true || isInteractiveGrid ) && (
 					<GridOverlay
 						cropRect={ state.cropRect }
 						containerSize={ canvasSize }

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -83,6 +83,8 @@ export interface CropperProps {
 	stencil?: React.ComponentType< StencilProps >;
 	/** Show the rule-of-thirds grid overlay, or only during interactions. */
 	showGrid?: boolean | 'interactive';
+	/** Whether an external placement control, such as a zoom slider, is active. */
+	isPlacementControlActive?: boolean;
 	/** Show the dimming overlay outside the crop area. */
 	showDimming?: boolean;
 	/** Minimum zoom level. */
@@ -128,22 +130,23 @@ export interface CropperProps {
  * The component fills its parent container (100% width and height).
  * Wrap it in a sized container to control its dimensions.
  *
- * @param root0                Component props implementing CropperProps.
- * @param root0.src            Image source URL.
- * @param root0.controller     The full state/setter object from `useCropperState`.
- * @param root0.stencil        Custom stencil component.
- * @param root0.showGrid       Grid overlay mode: false | true | 'interactive'.
- * @param root0.showDimming    Show dimming overlay outside crop.
- * @param root0.minZoom        Minimum zoom level.
- * @param root0.maxZoom        Maximum zoom level.
- * @param root0.aspectRatio    Fixed aspect ratio (width/height).
- * @param root0.freeformCrop   Enable resize handles.
- * @param root0.onImageLoaded  Image load callback.
- * @param root0.onStateChange  Every-frame state callback.
- * @param root0.onGestureStart Gesture boundary start.
- * @param root0.onGestureEnd   Gesture boundary end.
- * @param root0.className      Additional CSS class.
- * @param ref                  Forwarded ref for the container div.
+ * @param root0                          Component props implementing CropperProps.
+ * @param root0.src                      Image source URL.
+ * @param root0.controller               The full state/setter object from `useCropperState`.
+ * @param root0.stencil                  Custom stencil component.
+ * @param root0.showGrid                 Grid overlay mode: false | true | 'interactive'.
+ * @param root0.isPlacementControlActive
+ * @param root0.showDimming              Show dimming overlay outside crop.
+ * @param root0.minZoom                  Minimum zoom level.
+ * @param root0.maxZoom                  Maximum zoom level.
+ * @param root0.aspectRatio              Fixed aspect ratio (width/height).
+ * @param root0.freeformCrop             Enable resize handles.
+ * @param root0.onImageLoaded            Image load callback.
+ * @param root0.onStateChange            Every-frame state callback.
+ * @param root0.onGestureStart           Gesture boundary start.
+ * @param root0.onGestureEnd             Gesture boundary end.
+ * @param root0.className                Additional CSS class.
+ * @param ref                            Forwarded ref for the container div.
  */
 function CropperInner(
 	{
@@ -151,6 +154,7 @@ function CropperInner(
 		controller,
 		stencil: StencilComponent = RectangleStencil,
 		showGrid = false,
+		isPlacementControlActive = false,
 		showDimming = true,
 		minZoom,
 		maxZoom,
@@ -354,7 +358,8 @@ function CropperInner(
 	const [ isResizing, setIsResizing ] = useState( false );
 	const isInteractiveGrid = showGrid === 'interactive';
 	const showInteractiveGrid =
-		isInteractiveGrid && ( isPlacementInteracting || isResizing );
+		isInteractiveGrid &&
+		( isPlacementInteracting || isResizing || isPlacementControlActive );
 
 	/**
 	 * Handle Escape on a resize handle — return focus to the canvas so

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -83,8 +83,8 @@ export interface CropperProps {
 	stencil?: React.ComponentType< StencilProps >;
 	/** Show the rule-of-thirds grid overlay, or only during interactions. */
 	showGrid?: boolean | 'interactive';
-	/** Whether an external placement control, such as a zoom slider, is active. */
-	isPlacementControlActive?: boolean;
+	/** Whether external placement activity should keep the grid visible. */
+	isPlacementActive?: boolean;
 	/** Show the dimming overlay outside the crop area. */
 	showDimming?: boolean;
 	/** Minimum zoom level. */
@@ -130,23 +130,23 @@ export interface CropperProps {
  * The component fills its parent container (100% width and height).
  * Wrap it in a sized container to control its dimensions.
  *
- * @param root0                          Component props implementing CropperProps.
- * @param root0.src                      Image source URL.
- * @param root0.controller               The full state/setter object from `useCropperState`.
- * @param root0.stencil                  Custom stencil component.
- * @param root0.showGrid                 Grid overlay mode: false | true | 'interactive'.
- * @param root0.isPlacementControlActive Whether external placement controls are active, keeping the grid visible in interactive mode.
- * @param root0.showDimming              Show dimming overlay outside crop.
- * @param root0.minZoom                  Minimum zoom level.
- * @param root0.maxZoom                  Maximum zoom level.
- * @param root0.aspectRatio              Fixed aspect ratio (width/height).
- * @param root0.freeformCrop             Enable resize handles.
- * @param root0.onImageLoaded            Image load callback.
- * @param root0.onStateChange            Every-frame state callback.
- * @param root0.onGestureStart           Gesture boundary start.
- * @param root0.onGestureEnd             Gesture boundary end.
- * @param root0.className                Additional CSS class.
- * @param ref                            Forwarded ref for the container div.
+ * @param root0                   Component props implementing CropperProps.
+ * @param root0.src               Image source URL.
+ * @param root0.controller        The full state/setter object from `useCropperState`.
+ * @param root0.stencil           Custom stencil component.
+ * @param root0.showGrid          Grid overlay mode: false | true | 'interactive'.
+ * @param root0.isPlacementActive Keep grid visible during external placement activity.
+ * @param root0.showDimming       Show dimming overlay outside crop.
+ * @param root0.minZoom           Minimum zoom level.
+ * @param root0.maxZoom           Maximum zoom level.
+ * @param root0.aspectRatio       Fixed aspect ratio (width/height).
+ * @param root0.freeformCrop      Enable resize handles.
+ * @param root0.onImageLoaded     Image load callback.
+ * @param root0.onStateChange     Every-frame state callback.
+ * @param root0.onGestureStart    Gesture boundary start.
+ * @param root0.onGestureEnd      Gesture boundary end.
+ * @param root0.className         Additional CSS class.
+ * @param ref                     Forwarded ref for the container div.
  */
 function CropperInner(
 	{
@@ -154,7 +154,7 @@ function CropperInner(
 		controller,
 		stencil: StencilComponent = RectangleStencil,
 		showGrid = false,
-		isPlacementControlActive = false,
+		isPlacementActive = false,
 		showDimming = true,
 		minZoom,
 		maxZoom,
@@ -283,7 +283,7 @@ function CropperInner(
 		onWheelNative,
 		isDragging,
 		isZooming,
-		isPlacementInteracting,
+		isPlacementActive: isInteractionPlacementActive,
 	} = useInteraction( state, controller, canvasSize, visualSize, {
 		minZoom,
 		maxZoom,
@@ -359,7 +359,7 @@ function CropperInner(
 	const isInteractiveGrid = showGrid === 'interactive';
 	const showInteractiveGrid =
 		isInteractiveGrid &&
-		( isPlacementInteracting || isResizing || isPlacementControlActive );
+		( isInteractionPlacementActive || isResizing || isPlacementActive );
 
 	/**
 	 * Handle Escape on a resize handle — return focus to the canvas so

--- a/packages/media-editor/src/image-editor/react/components/overlays/grid-overlay.tsx
+++ b/packages/media-editor/src/image-editor/react/components/overlays/grid-overlay.tsx
@@ -49,6 +49,7 @@ export function GridOverlay( {
 	return (
 		<div
 			className="wp-media-editor-image-editor__grid"
+			data-testid="cropper-grid"
 			style={ {
 				left,
 				top,

--- a/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
@@ -128,6 +128,7 @@ export function RectangleStencil( {
 		[ boundsMinX, boundsMinY, boundsMaxX, boundsMaxY ]
 	);
 	const keyboardSettleTimerRef = useRef< ReturnType< typeof setTimeout > >();
+	const keyboardResizeActiveRef = useRef( false );
 	const hasLockedRatio = !! ( aspectRatio && aspectRatio > 0 );
 
 	// Clear the pending keyboard settle timer on unmount so it can't
@@ -135,6 +136,7 @@ export function RectangleStencil( {
 	useEffect( () => {
 		return () => {
 			clearTimeout( keyboardSettleTimerRef.current );
+			keyboardResizeActiveRef.current = false;
 		};
 	}, [] );
 
@@ -281,6 +283,11 @@ export function RectangleStencil( {
 			el.addEventListener( 'lostpointercapture', onEnd );
 
 			onResizeStart?.();
+			// Cancel any pending keyboard settle so it can't fire onResizeEnd
+			// mid-drag if the user switches from keyboard to pointer within
+			// the settle window.
+			clearTimeout( keyboardSettleTimerRef.current );
+			keyboardResizeActiveRef.current = false;
 		},
 		[ cropRect, onResizeStart ]
 	);
@@ -377,6 +384,19 @@ export function RectangleStencil( {
 			event.preventDefault();
 			event.stopPropagation();
 
+			if ( ! keyboardResizeActiveRef.current ) {
+				keyboardResizeActiveRef.current = true;
+				onResizeStart?.();
+			}
+
+			const scheduleKeyboardResizeEnd = () => {
+				clearTimeout( keyboardSettleTimerRef.current );
+				keyboardSettleTimerRef.current = setTimeout( () => {
+					keyboardResizeActiveRef.current = false;
+					onResizeEnd?.();
+				}, KEYBOARD_SETTLE_DELAY );
+			};
+
 			const step = event.shiftKey ? KEYBOARD_STEP_SHIFT : KEYBOARD_STEP;
 
 			// Determine the normalized delta from the arrow key.
@@ -409,10 +429,7 @@ export function RectangleStencil( {
 				onCropChange(
 					computeLockedRect( syntheticDrag, clientX, clientY )
 				);
-				clearTimeout( keyboardSettleTimerRef.current );
-				keyboardSettleTimerRef.current = setTimeout( () => {
-					onResizeEnd?.();
-				}, KEYBOARD_SETTLE_DELAY );
+				scheduleKeyboardResizeEnd();
 			} else {
 				// For freeform resize, synthesize a drag via computeFreeRect.
 				const syntheticDrag: ResizeDragState = {
@@ -426,10 +443,7 @@ export function RectangleStencil( {
 				onCropChange(
 					computeFreeRect( syntheticDrag, clientX, clientY )
 				);
-				clearTimeout( keyboardSettleTimerRef.current );
-				keyboardSettleTimerRef.current = setTimeout( () => {
-					onResizeEnd?.();
-				}, KEYBOARD_SETTLE_DELAY );
+				scheduleKeyboardResizeEnd();
 			}
 		},
 		[
@@ -440,6 +454,7 @@ export function RectangleStencil( {
 			computeLockedRect,
 			computeFreeRect,
 			onCropChange,
+			onResizeStart,
 			onResizeEnd,
 			onEscape,
 		]

--- a/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -29,6 +29,7 @@ function renderStencil(
 	overrides: Partial< React.ComponentProps< typeof RectangleStencil > > = {}
 ) {
 	const onCropChange = jest.fn();
+	const onResizeStart = jest.fn();
 	const onResizeEnd = jest.fn();
 	const onEscape = jest.fn();
 
@@ -38,6 +39,7 @@ function renderStencil(
 			containerSize={ CONTAINER_SIZE }
 			imageSize={ IMAGE_SIZE }
 			onCropChange={ onCropChange }
+			onResizeStart={ onResizeStart }
 			onResizeEnd={ onResizeEnd }
 			onEscape={ onEscape }
 			freeformCrop
@@ -46,7 +48,7 @@ function renderStencil(
 		/>
 	);
 
-	return { onCropChange, onResizeEnd, onEscape };
+	return { onCropChange, onResizeStart, onResizeEnd, onEscape };
 }
 
 describe( 'RectangleStencil', () => {
@@ -132,6 +134,25 @@ describe( 'RectangleStencil', () => {
 	} );
 
 	describe( 'keyboard — arrow keys (fine step)', () => {
+		it( 'calls onResizeStart once and onResizeEnd after keyboard resize settles', () => {
+			jest.useFakeTimers();
+			const { onResizeStart, onResizeEnd } = renderStencil();
+			const eHandle = screen.getAllByRole( 'button' )[ 3 ];
+
+			fireEvent.keyDown( eHandle, { key: 'ArrowRight' } );
+			fireEvent.keyDown( eHandle, { key: 'ArrowRight' } );
+
+			expect( onResizeStart ).toHaveBeenCalledTimes( 1 );
+			expect( onResizeEnd ).not.toHaveBeenCalled();
+
+			act( () => {
+				jest.advanceTimersByTime( 500 );
+			} );
+
+			expect( onResizeEnd ).toHaveBeenCalledTimes( 1 );
+			jest.useRealTimers();
+		} );
+
 		it( 'moves the right edge right by KEYBOARD_STEP on ArrowRight (no Shift)', () => {
 			const { onCropChange } = renderStencil();
 			// 'e' handle is the 4th button in clockwise order (nw, n, ne, e).
@@ -203,6 +224,25 @@ describe( 'RectangleStencil', () => {
 	} );
 
 	describe( 'pointer drag — focus after release', () => {
+		it( 'calls onResizeStart on pointerdown and onResizeEnd on pointerup', () => {
+			const { onResizeStart, onResizeEnd } = renderStencil();
+			const [ firstHandle ] = screen.getAllByRole( 'button' );
+
+			fireEvent.pointerDown( firstHandle, {
+				button: 0,
+				clientX: 100,
+				clientY: 100,
+				pointerId: 1,
+			} );
+
+			expect( onResizeStart ).toHaveBeenCalledTimes( 1 );
+			expect( onResizeEnd ).not.toHaveBeenCalled();
+
+			fireEvent.pointerUp( firstHandle, { pointerId: 1 } );
+
+			expect( onResizeEnd ).toHaveBeenCalledTimes( 1 );
+		} );
+
 		it( 'focuses the handle button after a pointer drag ends', () => {
 			renderStencil();
 			const [ firstHandle ] = screen.getAllByRole( 'button' );

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { Cropper } from '../cropper';
+import type { UseCropperStateReturn } from '../../hooks/use-cropper-state';
+import { DEFAULT_STATE } from '../../../core/constants';
+
+const GRID_TEST_ID = 'cropper-grid';
+const GRID_INTERACTIVE_CLASS =
+	'wp-media-editor-image-editor__canvas--grid-interactive';
+const SHOW_GRID_CLASS = 'wp-media-editor-image-editor__canvas--show-grid';
+
+function createController(): UseCropperStateReturn {
+	return {
+		state: {
+			...DEFAULT_STATE,
+			image: {
+				src: 'test.jpg',
+				naturalWidth: 600,
+				naturalHeight: 400,
+			},
+		},
+		setImage: jest.fn(),
+		setPan: jest.fn(),
+		setZoom: jest.fn(),
+		setZoomAtPoint: jest.fn(),
+		setRotation: jest.fn(),
+		setFlip: jest.fn(),
+		snapRotate90: jest.fn(),
+		setCropRect: jest.fn(),
+		settleCrop: jest.fn(),
+		applyOperation: jest.fn(),
+		reset: jest.fn(),
+		isDirty: false,
+		getCroppedImage: jest.fn(),
+	};
+}
+
+describe( 'Cropper grid visibility classes', () => {
+	const originalResizeObserver = globalThis.ResizeObserver;
+
+	beforeAll( () => {
+		globalThis.ResizeObserver = class ResizeObserver {
+			private callback: ResizeObserverCallback;
+
+			constructor( callback: ResizeObserverCallback ) {
+				this.callback = callback;
+			}
+
+			observe() {
+				this.callback(
+					[
+						{
+							contentRect: { width: 600, height: 400 },
+						} as ResizeObserverEntry,
+					],
+					this
+				);
+			}
+
+			unobserve() {}
+
+			disconnect() {}
+		} as typeof ResizeObserver;
+	} );
+
+	afterAll( () => {
+		globalThis.ResizeObserver = originalResizeObserver;
+	} );
+
+	it( 'does not render the grid when showGrid is false', () => {
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ createController() }
+				showGrid={ false }
+				showDimming={ false }
+			/>
+		);
+
+		expect( screen.queryByTestId( GRID_TEST_ID ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the grid always visible when showGrid is true', async () => {
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ createController() }
+				showGrid
+				showDimming={ false }
+			/>
+		);
+
+		await screen.findByTestId( GRID_TEST_ID );
+
+		const canvas = screen.getByRole( 'group', { name: 'Image editor' } );
+		expect( canvas ).not.toHaveClass( GRID_INTERACTIVE_CLASS );
+		expect( canvas ).not.toHaveClass( SHOW_GRID_CLASS );
+	} );
+
+	it( 'renders the grid hidden by default in interactive mode', async () => {
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ createController() }
+				showGrid="interactive"
+				showDimming={ false }
+			/>
+		);
+
+		await screen.findByTestId( GRID_TEST_ID );
+
+		const canvas = screen.getByRole( 'group', { name: 'Image editor' } );
+		expect( canvas ).toHaveClass( GRID_INTERACTIVE_CLASS );
+		expect( canvas ).not.toHaveClass( SHOW_GRID_CLASS );
+	} );
+
+	it( 'shows the interactive grid when a placement control is active', async () => {
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ createController() }
+				showGrid="interactive"
+				showDimming={ false }
+				isPlacementControlActive
+			/>
+		);
+
+		await screen.findByTestId( GRID_TEST_ID );
+
+		const canvas = screen.getByRole( 'group', { name: 'Image editor' } );
+		expect( canvas ).toHaveClass( GRID_INTERACTIVE_CLASS );
+		expect( canvas ).toHaveClass( SHOW_GRID_CLASS );
+	} );
+} );

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -127,7 +127,7 @@ describe( 'Cropper grid visibility classes', () => {
 				controller={ createController() }
 				showGrid="interactive"
 				showDimming={ false }
-				isPlacementControlActive
+				isPlacementActive
 			/>
 		);
 

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-interaction.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-interaction.ts
@@ -1,0 +1,218 @@
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { useInteraction } from '../use-interaction';
+import type { CropperInteractionActions } from '../../../core/interaction-controller';
+import type { CropperState, Size } from '../../../core/types';
+import { DEFAULT_STATE } from '../../../core/constants';
+
+const CONTAINER_SIZE: Size = { width: 500, height: 300 };
+const IMAGE_SIZE: Size = { width: 500, height: 300 };
+
+function makeState( overrides: Partial< CropperState > = {} ): CropperState {
+	return {
+		...DEFAULT_STATE,
+		image: {
+			src: 'test.jpg',
+			naturalWidth: 1000,
+			naturalHeight: 600,
+		},
+		zoom: 2,
+		...overrides,
+	};
+}
+
+function createActions(): jest.Mocked< CropperInteractionActions > {
+	return {
+		setPan: jest.fn(),
+		setZoom: jest.fn(),
+		setZoomAtPoint: jest.fn(),
+		snapRotate90: jest.fn(),
+	};
+}
+
+function createWheelEvent(
+	overrides: Partial< WheelEvent > & { currentTarget?: unknown } = {}
+): WheelEvent {
+	return {
+		preventDefault: jest.fn(),
+		deltaY: -100,
+		clientX: 0,
+		clientY: 0,
+		currentTarget: null,
+		...overrides,
+	} as unknown as WheelEvent;
+}
+
+function createKeyboardEvent( key: string ): React.KeyboardEvent {
+	return {
+		key,
+		nativeEvent: {
+			key,
+			preventDefault: jest.fn(),
+		},
+	} as unknown as React.KeyboardEvent;
+}
+
+function createTouchEvent(
+	touches: Array< { clientX: number; clientY: number } >
+): TouchEvent {
+	return {
+		preventDefault: jest.fn(),
+		touches,
+	} as unknown as TouchEvent;
+}
+
+function createTouchDocument(): Document & {
+	_fire: ( type: string, event: unknown ) => void;
+} {
+	const listeners: Record< string, EventListener[] > = {};
+	return {
+		addEventListener: jest.fn( ( type: string, fn: EventListener ) => {
+			if ( ! listeners[ type ] ) {
+				listeners[ type ] = [];
+			}
+			listeners[ type ].push( fn );
+		} ),
+		removeEventListener: jest.fn( ( type: string, fn: EventListener ) => {
+			if ( listeners[ type ] ) {
+				listeners[ type ] = listeners[ type ].filter(
+					( listener ) => listener !== fn
+				);
+			}
+		} ),
+		_fire( type: string, event: unknown ) {
+			listeners[ type ]?.forEach( ( fn ) =>
+				fn( event as unknown as Event )
+			);
+		},
+	} as unknown as Document & {
+		_fire: ( type: string, event: unknown ) => void;
+	};
+}
+
+function createTouchTarget( ownerDocument: Document ) {
+	return {
+		getBoundingClientRect: () => ( {
+			left: 0,
+			top: 0,
+			width: 500,
+			height: 300,
+		} ),
+		ownerDocument,
+	};
+}
+
+describe( 'useInteraction grid placement signal', () => {
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'sets isPlacementInteracting during keyboard pan, then clears it after idle', () => {
+		jest.useFakeTimers();
+		const { result } = renderHook( () =>
+			useInteraction(
+				makeState(),
+				createActions(),
+				CONTAINER_SIZE,
+				IMAGE_SIZE
+			)
+		);
+
+		act( () => {
+			result.current.handlers.onKeyDown(
+				createKeyboardEvent( 'ArrowRight' )
+			);
+		} );
+
+		expect( result.current.isPlacementInteracting ).toBe( true );
+
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
+
+		expect( result.current.isPlacementInteracting ).toBe( false );
+	} );
+
+	it.each( [ '+', '-', 'r' ] )(
+		'does not set isPlacementInteracting for non-placement key %s',
+		( key ) => {
+			const { result } = renderHook( () =>
+				useInteraction(
+					makeState(),
+					createActions(),
+					CONTAINER_SIZE,
+					IMAGE_SIZE
+				)
+			);
+
+			act( () => {
+				result.current.handlers.onKeyDown( createKeyboardEvent( key ) );
+			} );
+
+			expect( result.current.isPlacementInteracting ).toBe( false );
+		}
+	);
+
+	it( 'sets isPlacementInteracting during wheel zoom, then clears it after the wheel debounce', () => {
+		jest.useFakeTimers();
+		const { result } = renderHook( () =>
+			useInteraction(
+				makeState(),
+				createActions(),
+				CONTAINER_SIZE,
+				IMAGE_SIZE
+			)
+		);
+
+		act( () => {
+			result.current.onWheelNative(
+				createWheelEvent( { deltaY: -100, currentTarget: null } )
+			);
+		} );
+
+		expect( result.current.isPlacementInteracting ).toBe( true );
+
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
+
+		expect( result.current.isPlacementInteracting ).toBe( false );
+	} );
+
+	it( 'sets isPlacementInteracting during pinch zoom, then clears it on touch end', () => {
+		const doc = createTouchDocument();
+		const target = createTouchTarget( doc );
+		const { result } = renderHook( () =>
+			useInteraction(
+				makeState(),
+				createActions(),
+				CONTAINER_SIZE,
+				IMAGE_SIZE
+			)
+		);
+
+		act( () => {
+			result.current.handlers.onTouchStart( {
+				currentTarget: target,
+				nativeEvent: createTouchEvent( [
+					{ clientX: 200, clientY: 150 },
+					{ clientX: 300, clientY: 150 },
+				] ),
+			} as unknown as React.TouchEvent );
+		} );
+
+		expect( result.current.isPlacementInteracting ).toBe( true );
+
+		act( () => {
+			doc._fire( 'touchend', createTouchEvent( [] ) );
+		} );
+
+		expect( result.current.isPlacementInteracting ).toBe( false );
+	} );
+} );

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-interaction.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-interaction.ts
@@ -113,7 +113,7 @@ describe( 'useInteraction grid placement signal', () => {
 		jest.useRealTimers();
 	} );
 
-	it( 'sets isPlacementInteracting during keyboard pan, then clears it after idle', () => {
+	it( 'sets isPlacementActive during keyboard pan, then clears it after idle', () => {
 		jest.useFakeTimers();
 		const { result } = renderHook( () =>
 			useInteraction(
@@ -130,17 +130,17 @@ describe( 'useInteraction grid placement signal', () => {
 			);
 		} );
 
-		expect( result.current.isPlacementInteracting ).toBe( true );
+		expect( result.current.isPlacementActive ).toBe( true );
 
 		act( () => {
 			jest.advanceTimersByTime( 300 );
 		} );
 
-		expect( result.current.isPlacementInteracting ).toBe( false );
+		expect( result.current.isPlacementActive ).toBe( false );
 	} );
 
 	it.each( [ '+', '-', 'r' ] )(
-		'does not set isPlacementInteracting for non-placement key %s',
+		'does not set isPlacementActive for non-placement key %s',
 		( key ) => {
 			const { result } = renderHook( () =>
 				useInteraction(
@@ -155,11 +155,11 @@ describe( 'useInteraction grid placement signal', () => {
 				result.current.handlers.onKeyDown( createKeyboardEvent( key ) );
 			} );
 
-			expect( result.current.isPlacementInteracting ).toBe( false );
+			expect( result.current.isPlacementActive ).toBe( false );
 		}
 	);
 
-	it( 'sets isPlacementInteracting during wheel zoom, then clears it after the wheel debounce', () => {
+	it( 'sets isPlacementActive during wheel zoom, then clears it after the wheel debounce', () => {
 		jest.useFakeTimers();
 		const { result } = renderHook( () =>
 			useInteraction(
@@ -176,16 +176,16 @@ describe( 'useInteraction grid placement signal', () => {
 			);
 		} );
 
-		expect( result.current.isPlacementInteracting ).toBe( true );
+		expect( result.current.isPlacementActive ).toBe( true );
 
 		act( () => {
 			jest.advanceTimersByTime( 300 );
 		} );
 
-		expect( result.current.isPlacementInteracting ).toBe( false );
+		expect( result.current.isPlacementActive ).toBe( false );
 	} );
 
-	it( 'sets isPlacementInteracting during pinch zoom, then clears it on touch end', () => {
+	it( 'sets isPlacementActive during pinch zoom, then clears it on touch end', () => {
 		const doc = createTouchDocument();
 		const target = createTouchTarget( doc );
 		const { result } = renderHook( () =>
@@ -207,12 +207,12 @@ describe( 'useInteraction grid placement signal', () => {
 			} as unknown as React.TouchEvent );
 		} );
 
-		expect( result.current.isPlacementInteracting ).toBe( true );
+		expect( result.current.isPlacementActive ).toBe( true );
 
 		act( () => {
 			doc._fire( 'touchend', createTouchEvent( [] ) );
 		} );
 
-		expect( result.current.isPlacementInteracting ).toBe( false );
+		expect( result.current.isPlacementActive ).toBe( false );
 	} );
 } );

--- a/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
@@ -28,7 +28,7 @@ export interface UseInteractionReturn {
 	isDragging: boolean;
 	/** Whether a double-tap zoom animation is in progress. */
 	isZooming: boolean;
-	/** Whether the user is currently panning the image for placement. */
+	/** Whether the user is currently performing a placement interaction. */
 	isPlacementInteracting: boolean;
 }
 
@@ -91,6 +91,7 @@ export function useInteraction(
 ): UseInteractionReturn {
 	const [ isDragging, setIsDragging ] = useState( false );
 	const [ isZooming, setIsZooming ] = useState( false );
+	const [ isGestureInteracting, setIsGestureInteracting ] = useState( false );
 	const [ isKeyboardPanning, setIsKeyboardPanning ] = useState( false );
 	const keyboardInteractionTimerRef =
 		useRef< ReturnType< typeof setTimeout > >();
@@ -109,6 +110,12 @@ export function useInteraction(
 	actionsRef.current = actions;
 
 	const controllerRef = useRef< InteractionController | null >( null );
+	const startPlacementGesture = useCallback( () => {
+		setIsGestureInteracting( true );
+	}, [] );
+	const stopPlacementGesture = useCallback( () => {
+		setIsGestureInteracting( false );
+	}, [] );
 	const signalKeyboardPlacement = useCallback( () => {
 		setIsKeyboardPanning( true );
 		clearTimeout( keyboardInteractionTimerRef.current );
@@ -153,8 +160,14 @@ export function useInteraction(
 			get doubleTapZoom() {
 				return optionsRef.current?.doubleTapZoom;
 			},
-			onGestureStart: () => optionsRef.current?.onGestureStart?.(),
-			onGestureEnd: () => optionsRef.current?.onGestureEnd?.(),
+			onGestureStart: () => {
+				startPlacementGesture();
+				optionsRef.current?.onGestureStart?.();
+			},
+			onGestureEnd: () => {
+				stopPlacementGesture();
+				optionsRef.current?.onGestureEnd?.();
+			},
 			onStatusChange: ( status ) => {
 				setIsDragging( status.isDragging );
 				setIsZooming( status.isZooming );
@@ -165,7 +178,7 @@ export function useInteraction(
 			controller.destroy();
 			controllerRef.current = null;
 		};
-	}, [] );
+	}, [ startPlacementGesture, stopPlacementGesture ] );
 
 	const onPointerDown = useCallback( ( e: React.PointerEvent ) => {
 		const el = e.currentTarget as HTMLElement;
@@ -205,6 +218,7 @@ export function useInteraction(
 		onWheelNative,
 		isDragging,
 		isZooming,
-		isPlacementInteracting: isDragging || isKeyboardPanning,
+		isPlacementInteracting:
+			isGestureInteracting || isKeyboardPanning || isZooming,
 	};
 }

--- a/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
@@ -29,7 +29,7 @@ export interface UseInteractionReturn {
 	/** Whether a double-tap zoom animation is in progress. */
 	isZooming: boolean;
 	/** Whether the user is currently performing a placement interaction. */
-	isPlacementInteracting: boolean;
+	isPlacementActive: boolean;
 }
 
 /**
@@ -91,7 +91,7 @@ export function useInteraction(
 ): UseInteractionReturn {
 	const [ isDragging, setIsDragging ] = useState( false );
 	const [ isZooming, setIsZooming ] = useState( false );
-	const [ isGestureInteracting, setIsGestureInteracting ] = useState( false );
+	const [ isGestureActive, setIsGestureActive ] = useState( false );
 	const [ isKeyboardPanning, setIsKeyboardPanning ] = useState( false );
 	const keyboardInteractionTimerRef =
 		useRef< ReturnType< typeof setTimeout > >();
@@ -111,10 +111,10 @@ export function useInteraction(
 
 	const controllerRef = useRef< InteractionController | null >( null );
 	const startPlacementGesture = useCallback( () => {
-		setIsGestureInteracting( true );
+		setIsGestureActive( true );
 	}, [] );
 	const stopPlacementGesture = useCallback( () => {
-		setIsGestureInteracting( false );
+		setIsGestureActive( false );
 	}, [] );
 	const signalKeyboardPlacement = useCallback( () => {
 		setIsKeyboardPanning( true );
@@ -218,7 +218,6 @@ export function useInteraction(
 		onWheelNative,
 		isDragging,
 		isZooming,
-		isPlacementInteracting:
-			isGestureInteracting || isKeyboardPanning || isZooming,
+		isPlacementActive: isGestureActive || isKeyboardPanning || isZooming,
 	};
 }

--- a/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
@@ -28,6 +28,8 @@ export interface UseInteractionReturn {
 	isDragging: boolean;
 	/** Whether a double-tap zoom animation is in progress. */
 	isZooming: boolean;
+	/** Whether the user is currently panning the image for placement. */
+	isPlacementInteracting: boolean;
 }
 
 /**
@@ -48,6 +50,21 @@ export interface UseInteractionOptions {
 	onGestureStart?: () => void;
 	/** Fires when a continuous gesture ends (pointer release). */
 	onGestureEnd?: () => void;
+}
+
+/** How long keyboard placement stays active after the latest handled key. */
+const KEYBOARD_INTERACTION_IDLE_MS = 300;
+
+function isHandledKeyboardPan( event: KeyboardEvent ): boolean {
+	switch ( event.key ) {
+		case 'ArrowUp':
+		case 'ArrowDown':
+		case 'ArrowLeft':
+		case 'ArrowRight':
+			return true;
+		default:
+			return false;
+	}
 }
 
 /**
@@ -74,6 +91,9 @@ export function useInteraction(
 ): UseInteractionReturn {
 	const [ isDragging, setIsDragging ] = useState( false );
 	const [ isZooming, setIsZooming ] = useState( false );
+	const [ isKeyboardPanning, setIsKeyboardPanning ] = useState( false );
+	const keyboardInteractionTimerRef =
+		useRef< ReturnType< typeof setTimeout > >();
 
 	// Keep mutable refs so the controller always reads fresh values
 	// without needing to be recreated.
@@ -89,6 +109,19 @@ export function useInteraction(
 	actionsRef.current = actions;
 
 	const controllerRef = useRef< InteractionController | null >( null );
+	const signalKeyboardPlacement = useCallback( () => {
+		setIsKeyboardPanning( true );
+		clearTimeout( keyboardInteractionTimerRef.current );
+		keyboardInteractionTimerRef.current = setTimeout( () => {
+			setIsKeyboardPanning( false );
+		}, KEYBOARD_INTERACTION_IDLE_MS );
+	}, [] );
+
+	useEffect( () => {
+		return () => {
+			clearTimeout( keyboardInteractionTimerRef.current );
+		};
+	}, [] );
 
 	// Create / destroy the controller. The controller reads all volatile
 	// values through refs, so it can stay mounted across render updates.
@@ -149,9 +182,15 @@ export function useInteraction(
 		);
 	}, [] );
 
-	const onKeyDown = useCallback( ( e: React.KeyboardEvent ) => {
-		controllerRef.current?.handleKeyDown( e.nativeEvent );
-	}, [] );
+	const onKeyDown = useCallback(
+		( e: React.KeyboardEvent ) => {
+			if ( isHandledKeyboardPan( e.nativeEvent ) ) {
+				signalKeyboardPlacement();
+			}
+			controllerRef.current?.handleKeyDown( e.nativeEvent );
+		},
+		[ signalKeyboardPlacement ]
+	);
 
 	const onWheelNative = useCallback( ( e: WheelEvent ) => {
 		controllerRef.current?.handleWheel( e );
@@ -166,5 +205,6 @@ export function useInteraction(
 		onWheelNative,
 		isDragging,
 		isZooming,
+		isPlacementInteracting: isDragging || isKeyboardPanning,
 	};
 }

--- a/packages/media-editor/src/image-editor/stories/rectangle-crop.story.tsx
+++ b/packages/media-editor/src/image-editor/stories/rectangle-crop.story.tsx
@@ -56,6 +56,14 @@ import './style.css';
 
 const SAMPLE_IMAGE = 'image-editor-demo.jpeg';
 
+const GRID_MODES = {
+	off: false,
+	on: true,
+	interactive: 'interactive',
+} as const;
+
+type GridMode = keyof typeof GRID_MODES;
+
 const IMAGE_CREDIT = (
 	<p style={ { fontSize: 10, color: '#aaa', margin: '4px 0 0' } }>
 		{ '"A fashionable melange of English words (1887)" ' }
@@ -173,6 +181,7 @@ const WithControlsComponent = () => {
 
 	const [ aspectRatioValue, setAspectRatioValue ] = useState( '0' );
 	const [ freeformCrop, setFreeformCrop ] = useState( false );
+	const [ gridMode, setGridMode ] = useState< GridMode >( 'interactive' );
 	const { src, isCustom, handleFileChange, resetToSample } =
 		useUploadableImage();
 	const fileInputRef = useRef< HTMLInputElement >( null );
@@ -409,6 +418,26 @@ const WithControlsComponent = () => {
 							onChange={ setFreeformCrop }
 						/>
 					</FlexItem>
+					<FlexItem>
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label="Grid"
+							hideLabelFromVision
+							value={ gridMode }
+							onChange={ ( value ) =>
+								setGridMode( value as GridMode )
+							}
+							options={ [
+								{ label: 'Grid: off', value: 'off' },
+								{ label: 'Grid: always on', value: 'on' },
+								{
+									label: 'Grid: interactive',
+									value: 'interactive',
+								},
+							] }
+						/>
+					</FlexItem>
 					<FlexItem isBlock />
 					<FlexItem>
 						<Button
@@ -451,7 +480,7 @@ const WithControlsComponent = () => {
 				<Cropper
 					src={ src }
 					controller={ controller }
-					showGrid
+					showGrid={ GRID_MODES[ gridMode ] }
 					showDimming
 					freeformCrop={ freeformCrop }
 					aspectRatio={ resolveAspectRatio(


### PR DESCRIPTION
## What?

Adds a simpler interactive grid mode for the media editor image cropper.

This is intended as a smaller alternative to #77739. Instead of inferring grid visibility from cropper state value changes, this approach shows the grid with CSS classes while the user is actively performing placement-oriented interactions.

https://github.com/user-attachments/assets/313f36b5-3fce-40ec-9d7d-54657beeb3b1

<img width="931" height="584" alt="Screenshot 2026-04-29 at 10 05 03 am" src="https://github.com/user-attachments/assets/fe09663c-0a1e-4d34-85ef-cfb0c7e8bf9a" />



## Why?

The grid is most useful while positioning the crop, not for every transform.

This keeps the grid visible for:

- dragging/panning the image
- mouse wheel zoom
- pinch zoom
- crop handle resizing
- keyboard nudging
- keyboard crop resizing
- explicit placement controls, such as the zoom control

It avoids showing the grid for unrelated discrete actions like flip, reset, 90-degree rotate, and aspect ratio changes.

## How?

- Extends `showGrid` to support `true`, `false`, and `"interactive"`.
- Always renders the grid in interactive mode, but hides/shows it with canvas classes.
- Reuses interaction lifecycle signals instead of diffing cropper state values.
- Tracks crop-handle resize activity, including keyboard resize.
- Lets external placement controls opt into showing the grid.
- Enables `showGrid="interactive"` in the media editor canvas.

## Testing


You can test with `npm run storybook:dev` as well if you like.

Or the experiment:

<img width="683" height="92" alt="Screenshot 2026-04-28 at 1 51 13 pm" src="https://github.com/user-attachments/assets/fd0fc8e6-1408-400e-a826-040592baade5" />


1. Add an image block to a post. Open the crop/image editor modal.
2. Confirm the grid is hidden when the cropper is idle.
3. Drag/pan the image inside the crop area.
   - Expected: the grid appears while dragging and fades shortly after release.
4. Use the mouse wheel/trackpad scroll to zoom.
   - Expected: the grid appears during zoom and fades shortly after scrolling stops.
5. On a touch device or responsive simulator, pinch zoom the image.
   - Expected: the grid appears during the pinch and hides after touch ends.
6. Enable freeform crop.
7. Drag a crop handle.
   - Expected: the grid appears while resizing and hides after release.
8. Focus the cropper canvas and use arrow keys to nudge the image.
   - Expected: the grid appears while nudging and fades after key input stops.
9. Focus a crop handle and use arrow keys to resize the crop.
   - Expected: the grid appears while resizing and fades after key input stops.
10. Use the zoom control in the crop sidebar.
   - Expected: the grid appears while changing zoom and fades after input stops.
11. Try flip, reset, 90-degree rotate, and aspect ratio changes.
   - Expected: these actions do not show the grid unless another placement interaction is active.






