### PR TITLE
Block editor: Remove stale reusable block z-index styles

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### Breaking Changes
 
--   Remove the following entries from the `z-index()` helper ([#77619](https://github.com/WordPress/gutenberg/pull/77619), [#77620](https://github.com/WordPress/gutenberg/pull/77620), [#77621](https://github.com/WordPress/gutenberg/pull/77621), [#77714](https://github.com/WordPress/gutenberg/pull/77714), [#77715](https://github.com/WordPress/gutenberg/pull/77715), [#77717](https://github.com/WordPress/gutenberg/pull/77717)):
+-   Remove the following entries from the `z-index()` helper ([#77619](https://github.com/WordPress/gutenberg/pull/77619), [#77620](https://github.com/WordPress/gutenberg/pull/77620), [#77621](https://github.com/WordPress/gutenberg/pull/77621), [#77714](https://github.com/WordPress/gutenberg/pull/77714), [#77715](https://github.com/WordPress/gutenberg/pull/77715), [#77717](https://github.com/WordPress/gutenberg/pull/77717), [#77774](https://github.com/WordPress/gutenberg/pull/77774)):
     -   `.block-editor-block-contextual-toolbar`
     -   `.block-editor-block-list__block {core/image aligned wide or fullwide}`
     -   `.block-editor-block-list__block::before`
     -   `.block-editor-block-list__block.has-block-overlay`
+    -   `.block-editor-block-list__block .reusable-block-edit-panel *`
     -   `.block-editor-block-list__insertion-point`
     -   `.block-editor-block-switcher__arrow`
     -   `.block-editor-url-input__suggestions`

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -38,8 +38,6 @@ $z-layers: (
 	// The draggable element should show up above the entire UI
 	".components-draggable__clone": 1000000000,
 
-	".block-editor-block-list__block .reusable-block-edit-panel *": 1,
-
 	// Show drop zone above most standard content, but below any overlays
 	".components-drop-zone": 40,
 	".components-drop-zone__content": 50,

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -154,7 +154,7 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 	}
 
 	.reusable-block-edit-panel * {
-		z-index: z-index(".block-editor-block-list__block .reusable-block-edit-panel *");
+		z-index: 1;
 	}
 
 	/**

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -153,10 +153,6 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 		}
 	}
 
-	.reusable-block-edit-panel * {
-		z-index: 1;
-	}
-
 	/**
 	 * Notices
 	 */


### PR DESCRIPTION
## What?

Removes stale `reusable-block-edit-panel` z-index styles from the block editor.

## Why?

The `reusable-block-edit-panel` class no longer appears to be used in the repo. The selector and its shared `z-index()` helper entry can be removed instead of inlining the value locally.

## How?

Removes the unused nested selector from `packages/block-editor/src/components/block-list/content.scss` and removes the corresponding key from `packages/base-styles/_z-index.scss`.

## Testing Instructions

1. Run `npm run lint:css -- packages/base-styles/_z-index.scss packages/block-editor/src/components/block-list/content.scss`.
2. Search for `reusable-block-edit-panel` and confirm there are no remaining references.
3. Open a post or page in the editor.
4. Insert and select a synced pattern/reusable block, and confirm the block editor still behaves as expected.