### PR TITLE
RTC: Fix merge bug where client applies stale local block snapshot after receiving remote CRDT update

### DIFF
--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -94,6 +94,7 @@ export function updateSelectedCell( state, selection, updateCell ) {
 					}
 
 					return {
+						...row,
 						cells: row.cells.map(
 							( cellAttributes, columnIndex ) => {
 								const cellLocation = {
@@ -248,6 +249,7 @@ export function insertColumn( state, { columnIndex } ) {
 					}
 
 					return {
+						...row,
 						cells: [
 							...row.cells.slice( 0, columnIndex ),
 							{
@@ -290,6 +292,7 @@ export function deleteColumn( state, { columnIndex } ) {
 				sectionName,
 				section
 					.map( ( row ) => ( {
+						...row,
 						cells:
 							row.cells.length >= columnIndex
 								? row.cells.filter(

--- a/packages/block-library/src/table/test/state.js
+++ b/packages/block-library/src/table/test/state.js
@@ -466,6 +466,30 @@ describe( 'insertColumn', () => {
 		expect( state ).toEqual( expected );
 	} );
 
+	it( 'preserves symbol row and cell properties when inserting a column', () => {
+		const syncId = Symbol( 'syncId' );
+		const tableWithSymbolIdentity = deepFreeze( {
+			body: [
+				{
+					[ syncId ]: 'row-1',
+					cells: [
+						{
+							[ syncId ]: 'cell-1',
+							content: 'test',
+							tag: 'td',
+						},
+					],
+				},
+			],
+		} );
+		const state = insertColumn( tableWithSymbolIdentity, {
+			columnIndex: 0,
+		} );
+
+		expect( state.body[ 0 ][ syncId ] ).toBe( 'row-1' );
+		expect( state.body[ 0 ].cells[ 1 ][ syncId ] ).toBe( 'cell-1' );
+	} );
+
 	it( 'adds `th` cells to the head', () => {
 		const state = insertColumn( tableWithHead, {
 			columnIndex: 1,
@@ -772,6 +796,34 @@ describe( 'deleteColumn', () => {
 		};
 
 		expect( state ).toEqual( expected );
+	} );
+
+	it( 'preserves symbol row and cell properties when deleting a column', () => {
+		const syncId = Symbol( 'syncId' );
+		const tableWithSymbolIdentity = deepFreeze( {
+			body: [
+				{
+					[ syncId ]: 'row-1',
+					cells: [
+						{
+							content: 'remove',
+							tag: 'td',
+						},
+						{
+							[ syncId ]: 'cell-2',
+							content: 'keep',
+							tag: 'td',
+						},
+					],
+				},
+			],
+		} );
+		const state = deleteColumn( tableWithSymbolIdentity, {
+			columnIndex: 0,
+		} );
+
+		expect( state.body[ 0 ][ syncId ] ).toBe( 'row-1' );
+		expect( state.body[ 0 ].cells[ 0 ][ syncId ] ).toBe( 'cell-2' );
 	} );
 
 	it( 'should delete all rows when only one column present', () => {
@@ -1304,6 +1356,73 @@ describe( 'updateSelectedCell', () => {
 				table.body[ 1 ],
 			],
 		} );
+	} );
+
+	it( 'preserves unknown row properties when updating a cell', () => {
+		const tableWithRowIdentity = deepFreeze( {
+			body: [
+				{
+					__unstableSyncId: 'row-1',
+					cells: [
+						{
+							content: '',
+							tag: 'td',
+						},
+					],
+				},
+			],
+		} );
+		const cellSelection = {
+			type: 'cell',
+			sectionName: 'body',
+			rowIndex: 0,
+			columnIndex: 0,
+		};
+		const updated = updateSelectedCell(
+			tableWithRowIdentity,
+			cellSelection,
+			( cell ) => ( {
+				...cell,
+				content: 'test',
+			} )
+		);
+
+		expect( updated.body[ 0 ].__unstableSyncId ).toBe( 'row-1' );
+	} );
+
+	it( 'preserves symbol row and cell properties when updating a cell', () => {
+		const syncId = Symbol( 'syncId' );
+		const tableWithSymbolIdentity = deepFreeze( {
+			body: [
+				{
+					[ syncId ]: 'row-1',
+					cells: [
+						{
+							[ syncId ]: 'cell-1',
+							content: '',
+							tag: 'td',
+						},
+					],
+				},
+			],
+		} );
+		const cellSelection = {
+			type: 'cell',
+			sectionName: 'body',
+			rowIndex: 0,
+			columnIndex: 0,
+		};
+		const updated = updateSelectedCell(
+			tableWithSymbolIdentity,
+			cellSelection,
+			( cell ) => ( {
+				...cell,
+				content: 'test',
+			} )
+		);
+
+		expect( updated.body[ 0 ][ syncId ] ).toBe( 'row-1' );
+		expect( updated.body[ 0 ].cells[ 0 ][ syncId ] ).toBe( 'cell-1' );
 	} );
 
 	it( 'updates every cell in the column when the selection type is `column`', () => {

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -61,6 +61,8 @@ export type YBlocks = Y.Array< YBlock >;
 // Attribute values will be typed as the union of `Y.Text` and `unknown`.
 export type YBlockAttributes = Y.Map< Y.Text | unknown >;
 
+const ARRAY_ELEMENT_ID_KEY = '__unstableSyncId';
+const ARRAY_ELEMENT_ID_SYMBOL = Symbol( 'wpSyncArrayElementId' );
 const serializableBlocksCache = new WeakMap< WeakKey, Block[] >();
 
 /**
@@ -84,10 +86,20 @@ function serializeAttributeValue( value: unknown ): unknown {
 	// e.g. a single row inside core/table `body`: { cells: [ ... ] }
 	if ( value && typeof value === 'object' ) {
 		const result: Record< string, unknown > = {};
+		const arrayElementId = getArrayElementId( value );
 
 		for ( const [ k, v ] of Object.entries( value ) ) {
+			if ( k === ARRAY_ELEMENT_ID_KEY ) {
+				continue;
+			}
+
 			result[ k ] = serializeAttributeValue( v );
 		}
+
+		if ( arrayElementId ) {
+			result[ ARRAY_ELEMENT_ID_KEY ] = arrayElementId;
+		}
+
 		return result;
 	}
 
@@ -150,14 +162,23 @@ function deserializeAttributeValue(
 	// e.g. a single row inside core/table `body`: { cells: [ ... ] }
 	if ( value && typeof value === 'object' ) {
 		const result: Record< string, unknown > = {};
+		const arrayElementId = getArrayElementId( value );
 
 		for ( const [ key, innerValue ] of Object.entries(
 			value as Record< string, unknown >
 		) ) {
+			if ( key === ARRAY_ELEMENT_ID_KEY ) {
+				continue;
+			}
+
 			result[ key ] = deserializeAttributeValue(
 				schema?.query?.[ key ],
 				innerValue
 			);
+		}
+
+		if ( arrayElementId ) {
+			defineArrayElementId( result, arrayElementId );
 		}
 
 		return result;
@@ -329,12 +350,15 @@ function createYMapFromQuery(
 		return new Y.Map();
 	}
 
-	const entries: [ string, unknown ][] = Object.entries( obj ).map(
-		( [ key, val ] ): [ string, unknown ] => {
+	const arrayElementId = getArrayElementId( obj ) ?? uuidv4();
+	const entries: [ string, unknown ][] = Object.entries( obj )
+		.filter( ( [ key ] ) => key !== ARRAY_ELEMENT_ID_KEY )
+		.map( ( [ key, val ] ): [ string, unknown ] => {
 			const subSchema = query[ key ];
 			return [ key, createYValueFromSchema( subSchema, val ) ];
-		}
-	);
+		} );
+
+	entries.push( [ ARRAY_ELEMENT_ID_KEY, arrayElementId ] );
 
 	return new Y.Map( entries );
 }
@@ -594,10 +618,122 @@ function areArrayElementsEqual(
 	yElement: unknown
 ): boolean {
 	if ( yElement instanceof Y.Map && isRecord( newElement ) ) {
-		return fastDeepEqual( newElement, yElement.toJSON() );
+		return fastDeepEqual(
+			stripArrayElementIds( newElement ),
+			stripArrayElementIds( yElement.toJSON() )
+		);
 	}
 
-	return fastDeepEqual( newElement, yElement );
+	return fastDeepEqual(
+		stripArrayElementIds( newElement ),
+		stripArrayElementIds( yElement )
+	);
+}
+
+function getArrayElementId( value: unknown ): string | undefined {
+	if ( value instanceof Y.Map ) {
+		const id = value.get( ARRAY_ELEMENT_ID_KEY );
+		return typeof id === 'string' ? id : undefined;
+	}
+
+	if ( isRecord( value ) ) {
+		const id = value[ ARRAY_ELEMENT_ID_KEY ];
+		if ( typeof id === 'string' ) {
+			return id;
+		}
+
+		const symbolId = ( value as Record< symbol, unknown > )[
+			ARRAY_ELEMENT_ID_SYMBOL
+		];
+		return typeof symbolId === 'string' ? symbolId : undefined;
+	}
+
+	return undefined;
+}
+
+function defineArrayElementId(
+	value: Record< string, unknown >,
+	id: string
+): void {
+	Object.defineProperty( value, ARRAY_ELEMENT_ID_SYMBOL, {
+		configurable: true,
+		enumerable: true,
+		value: id,
+	} );
+}
+
+function stripArrayElementIds( value: unknown ): unknown {
+	if ( Array.isArray( value ) ) {
+		return value.map( stripArrayElementIds );
+	}
+
+	if ( isRecord( value ) ) {
+		return Object.fromEntries(
+			Object.entries( value )
+				.filter( ( [ key ] ) => key !== ARRAY_ELEMENT_ID_KEY )
+				.map( ( [ key, innerValue ] ) => [
+					key,
+					stripArrayElementIds( innerValue ),
+				] )
+		);
+	}
+
+	return value;
+}
+
+function mergeYArrayByElementIds(
+	yArray: Y.Array< unknown >,
+	newValue: unknown[],
+	query: Record< string, BlockAttributeSchema >,
+	cursorPosition: number | null
+): boolean {
+	if ( ! newValue.some( getArrayElementId ) ) {
+		return false;
+	}
+
+	let index = 0;
+
+	for ( const newElement of newValue ) {
+		const newId = getArrayElementId( newElement );
+		let currentIndex = -1;
+
+		if ( newId ) {
+			for ( let i = index; i < yArray.length; i++ ) {
+				if ( getArrayElementId( yArray.get( i ) ) === newId ) {
+					currentIndex = i;
+					break;
+				}
+			}
+		}
+
+		if ( currentIndex > index ) {
+			yArray.delete( index, currentIndex - index );
+		}
+
+		if ( currentIndex >= index ) {
+			const currentElement = yArray.get( index );
+			if ( currentElement instanceof Y.Map && isRecord( newElement ) ) {
+				mergeYMapValues(
+					currentElement,
+					newElement,
+					query,
+					cursorPosition
+				);
+			}
+		} else {
+			yArray.insert( index, [
+				createYMapFromQuery( query, newElement ),
+			] );
+		}
+
+		index++;
+	}
+
+	if ( yArray.length > index ) {
+		yArray.delete( index, yArray.length - index );
+	}
+
+	return true;
 }
 
 /**
@@ -625,6 +761,11 @@ function mergeYArray(
 	}
 
 	const query = schema.query;
+
+	if ( mergeYArrayByElementIds( yArray, newValue, query, cursorPosition ) ) {
+		return;
+	}
+
 	const numOfCommonEntries = Math.min( newValue.length, yArray.length );
 
 	let left = 0;
@@ -786,7 +927,7 @@ function mergeYMapValues(
 
 	// Delete properties absent from the incoming object.
 	for ( const key of yMap.keys() ) {
-		if ( ! Object.hasOwn( newObj, key ) ) {
+		if ( key !== ARRAY_ELEMENT_ID_KEY && ! Object.hasOwn( newObj, key ) ) {
 			yMap.delete( key );
 		}
 	}

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -64,6 +64,7 @@ export type YBlockAttributes = Y.Map< Y.Text | unknown >;
 const ARRAY_ELEMENT_ID_KEY = '__unstableSyncId';
 const ARRAY_ELEMENT_ID_SYMBOL = Symbol( 'wpSyncArrayElementId' );
 const serializableBlocksCache = new WeakMap< WeakKey, Block[] >();
+const previousLocalBlocksCache = new WeakMap< YBlocks, Block[] >();
 
 /**
  * Recursively walk an attribute value and convert any RichTextData instances
@@ -422,7 +423,23 @@ export function mergeCrdtBlocks(
 		);
 	}
 	const blocksToSync = serializableBlocksCache.get( incomingBlocks ) ?? [];
+	const previousBlocks = previousLocalBlocksCache.get( yblocks );
 
+	mergeCrdtBlocksIntoYBlocks(
+		yblocks,
+		blocksToSync,
+		cursorPosition,
+		previousBlocks
+	);
+	previousLocalBlocksCache.set( yblocks, blocksToSync );
+}
+
+function mergeCrdtBlocksIntoYBlocks(
+	yblocks: YBlocks,
+	blocksToSync: Block[],
+	cursorPosition: number | null,
+	previousBlocks?: Block[]
+): void {
 	// This is a rudimentary diff implementation similar to the y-prosemirror diffing
 	// approach.
 	// A better implementation would also diff the textual content and represent it
@@ -481,11 +498,13 @@ export function mergeCrdtBlocks(
 	for ( let i = 0; i < numOfUpdatesNeeded; i++, left++ ) {
 		const block = blocksToSync[ left ];
 		const yblock = yblocks.get( left );
+		const previousBlock = previousBlocks?.[ left ];
 
 		Object.entries( block ).forEach( ( [ key, value ] ) => {
 			switch ( key ) {
 				case 'attributes': {
 					const currentAttributes = yblock.get( key );
+					const previousAttributes = previousBlock?.attributes;
 
 					// If attributes are not set on the yblock, use the new values.
 					if ( ! currentAttributes ) {
@@ -500,12 +519,28 @@ export function mergeCrdtBlocks(
 						( [ attributeName, attributeValue ] ) => {
 							const currentAttribute =
 								currentAttributes?.get( attributeName );
-
+							const previousAttributeValue =
+								previousAttributes?.[ attributeName ];
 							const isExpectedType = isExpectedAttributeType(
 								block.name,
 								attributeName,
 								currentAttribute
 							);
+
+							if (
+								previousAttributes &&
+								Object.hasOwn(
+									previousAttributes,
+									attributeName
+								) &&
+								arePlainValuesEqual(
+									previousAttributeValue,
+									attributeValue
+								) &&
+								isExpectedType
+							) {
+								return;
+							}
 
 							// Y types (Y.Text, Y.Array, Y.Map) cannot be
 							// compared with fastDeepEqual against plain values.
@@ -528,7 +563,8 @@ export function mergeCrdtBlocks(
 									attributeName,
 									attributeValue,
 									currentAttributes,
-									cursorPosition
+									cursorPosition,
+									previousAttributeValue
 								);
 							}
 						}
@@ -537,7 +573,14 @@ export function mergeCrdtBlocks(
 					// Delete any attributes that are no longer present.
 					currentAttributes.forEach(
 						( _attrValue: unknown, attrName: string ) => {
-							if ( ! value.hasOwnProperty( attrName ) ) {
+							if (
+								! value.hasOwnProperty( attrName ) &&
+								( ! previousAttributes ||
+									Object.hasOwn(
+										previousAttributes,
+										attrName
+									) )
+							) {
 								currentAttributes.delete( attrName );
 							}
 						}
@@ -555,22 +598,36 @@ export function mergeCrdtBlocks(
 						yblock.set( key, yInnerBlocks );
 					}
 
-					mergeCrdtBlocks(
+					mergeCrdtBlocksIntoYBlocks(
 						yInnerBlocks,
 						value ?? [],
-						cursorPosition
+						cursorPosition,
+						previousBlock?.innerBlocks
 					);
 					break;
 				}
 
 				default:
+					if (
+						previousBlock &&
+						arePlainValuesEqual(
+							block[ key ],
+							previousBlock[ key ]
+						)
+					) {
+						break;
+					}
+
 					if ( ! fastDeepEqual( block[ key ], yblock.get( key ) ) ) {
 						yblock.set( key, value );
 					}
 			}
 		} );
 		yblock.forEach( ( _v, k ) => {
-			if ( ! block.hasOwnProperty( k ) ) {
+			if (
+				! block.hasOwnProperty( k ) &&
+				( ! previousBlock || previousBlock.hasOwnProperty( k ) )
+			) {
 				yblock.delete( k );
 			}
 		} );
@@ -681,6 +738,33 @@ function stripArrayElementIds( value: unknown ): unknown {
 	return value;
 }
 
+function arePlainValuesEqual( a: unknown, b: unknown ): boolean {
+	return fastDeepEqual(
+		stripArrayElementIds( a ),
+		stripArrayElementIds( b )
+	);
+}
+
+function isExpectedYValueTypeForSchema(
+	schema: BlockAttributeSchema | undefined,
+	newVal: unknown,
+	currentVal: unknown
+): boolean {
+	if ( schema?.type === 'rich-text' ) {
+		return currentVal instanceof Y.Text;
+	}
+
+	if ( schema?.type === 'array' && schema.query && Array.isArray( newVal ) ) {
+		return currentVal instanceof Y.Array;
+	}
+
+	if ( schema?.type === 'object' && schema.query && isRecord( newVal ) ) {
+		return currentVal instanceof Y.Map;
+	}
+
+	return true;
+}
+
 function mergeYArrayByElementIds(
 	yArray: Y.Array< unknown >,
 	newValue: unknown[],
@@ -736,6 +820,101 @@ function mergeYArrayByElementIds(
 	return true;
 }
 
+function isYArrayEqualToPlainArray(
+	yArray: Y.Array< unknown >,
+	value: unknown[]
+): boolean {
+	return (
+		yArray.length === value.length &&
+		value.every( ( element, index ) =>
+			areArrayElementsEqual( element, yArray.get( index ) )
+		)
+	);
+}
+
+function findYArrayElementIndex(
+	yArray: Y.Array< unknown >,
+	previousElement: unknown,
+	preferredIndex: number,
+	previousLength: number
+): number {
+	const previousId = getArrayElementId( previousElement );
+
+	if ( previousId ) {
+		for ( let i = 0; i < yArray.length; i++ ) {
+			if ( getArrayElementId( yArray.get( i ) ) === previousId ) {
+				return i;
+			}
+		}
+	}
+
+	for ( let i = 0; i < yArray.length; i++ ) {
+		if ( areArrayElementsEqual( previousElement, yArray.get( i ) ) ) {
+			return i;
+		}
+	}
+
+	if ( yArray.length === previousLength && preferredIndex < yArray.length ) {
+		return preferredIndex;
+	}
+
+	return preferredIndex < yArray.length ? preferredIndex : -1;
+}
+
+function mergeYArrayLocalChanges(
+	yArray: Y.Array< unknown >,
+	newValue: unknown[],
+	previousValue: unknown[],
+	query: Record< string, BlockAttributeSchema >,
+	cursorPosition: number | null
+): boolean {
+	if ( arePlainValuesEqual( newValue, previousValue ) ) {
+		return true;
+	}
+
+	// No remote divergence: preserve existing behavior for ordinary local
+	// inserts/deletes/reorders.
+	if ( isYArrayEqualToPlainArray( yArray, previousValue ) ) {
+		return false;
+	}
+
+	const sharedLength = Math.min( previousValue.length, newValue.length );
+
+	for ( let i = 0; i < sharedLength; i++ ) {
+		const previousElement = previousValue[ i ];
+		const newElement = newValue[ i ];
+
+		if ( arePlainValuesEqual( previousElement, newElement ) ) {
+			continue;
+		}
+
+		const currentIndex = findYArrayElementIndex(
+			yArray,
+			previousElement,
+			i,
+			previousValue.length
+		);
+
+		if ( currentIndex === -1 ) {
+			continue;
+		}
+
+		const currentElement = yArray.get( currentIndex );
+
+		if ( currentElement instanceof Y.Map && isRecord( newElement ) ) {
+			mergeYMapValues(
+				currentElement,
+				newElement,
+				query,
+				cursorPosition,
+				isRecord( previousElement ) ? previousElement : undefined
+			);
+		}
+	}
+
+	return true;
+}
+
 /**
  * Merge an incoming plain array into an existing Y.Array in-place.
  *
@@ -749,18 +928,33 @@ function mergeYArrayByElementIds(
  * @param newValue       The new plain array to merge into the Y.Array.
  * @param schema         The attribute schema (must have `query`).
  * @param cursorPosition The local cursor position for rich-text delta merges.
+ * @param previousValue  The previous plain local array value.
  */
 function mergeYArray(
 	yArray: Y.Array< unknown >,
 	newValue: unknown[],
 	schema: BlockAttributeSchema,
-	cursorPosition: number | null
+	cursorPosition: number | null,
+	previousValue?: unknown[]
 ): void {
 	if ( ! schema.query ) {
 		return;
 	}
 
 	const query = schema.query;
+
+	if (
+		previousValue &&
+		mergeYArrayLocalChanges(
+			yArray,
+			newValue,
+			previousValue,
+			query,
+			cursorPosition
+		)
+	) {
+		return;
+	}
 
 	if ( mergeYArrayByElementIds( yArray, newValue, query, cursorPosition ) ) {
 		return;
@@ -863,15 +1057,26 @@ function mergeYArray(
  * @param yMap           The Y.Map that owns this entry.
  * @param key            The key of this entry in the Y.Map.
  * @param cursorPosition The local cursor position for rich-text delta merges.
+ * @param previousVal    The previous plain local value for this entry.
  */
 function mergeYValue(
 	schema: BlockAttributeSchema | undefined,
 	newVal: unknown,
 	yMap: Y.Map< unknown >,
 	key: string,
-	cursorPosition: number | null
+	cursorPosition: number | null,
+	previousVal?: unknown
 ): void {
 	const currentVal = yMap.get( key );
+
+	if (
+		previousVal !== undefined &&
+		arePlainValuesEqual( previousVal, newVal ) &&
+		isExpectedYValueTypeForSchema( schema, newVal, currentVal )
+	) {
+		return;
+	}
+
 	if (
 		schema?.type === 'rich-text' &&
 		typeof newVal === 'string' &&
@@ -884,14 +1089,26 @@ function mergeYValue(
 		Array.isArray( newVal ) &&
 		currentVal instanceof Y.Array
 	) {
-		mergeYArray( currentVal, newVal, schema, cursorPosition );
+		mergeYArray(
+			currentVal,
+			newVal,
+			schema,
+			cursorPosition,
+			Array.isArray( previousVal ) ? previousVal : undefined
+		);
 	} else if (
 		schema?.type === 'object' &&
 		schema.query &&
 		isRecord( newVal ) &&
 		currentVal instanceof Y.Map
 	) {
-		mergeYMapValues( currentVal, newVal, schema.query, cursorPosition );
+		mergeYMapValues(
+			currentVal,
+			newVal,
+			schema.query,
+			cursorPosition,
+			isRecord( previousVal ) ? previousVal : undefined
+		);
 	} else {
 		const newYValue = createYValueFromSchema( schema, newVal );
 
@@ -914,20 +1131,48 @@ function mergeYValue(
  * @param newObj         The new plain object to merge into the Y.Map.
  * @param query          The query schema defining property types.
  * @param cursorPosition The local cursor position for rich-text delta merges.
+ * @param previousObj    The previous plain local object value.
  */
 function mergeYMapValues(
 	yMap: Y.Map< unknown >,
 	newObj: Record< string, unknown >,
 	query: Record< string, BlockAttributeSchema >,
-	cursorPosition: number | null
+	cursorPosition: number | null,
+	previousObj?: Record< string, unknown >
 ): void {
 	for ( const [ key, newVal ] of Object.entries( newObj ) ) {
-		mergeYValue( query[ key ], newVal, yMap, key, cursorPosition );
+		const previousVal = previousObj?.[ key ];
+
+		if (
+			previousObj &&
+			Object.hasOwn( previousObj, key ) &&
+			arePlainValuesEqual( previousVal, newVal ) &&
+			isExpectedYValueTypeForSchema(
+				query[ key ],
+				newVal,
+				yMap.get( key )
+			)
+		) {
+			continue;
+		}
+
+		mergeYValue(
+			query[ key ],
+			newVal,
+			yMap,
+			key,
+			cursorPosition,
+			previousVal
+		);
 	}
 
 	// Delete properties absent from the incoming object.
 	for ( const key of yMap.keys() ) {
-		if ( key !== ARRAY_ELEMENT_ID_KEY && ! Object.hasOwn( newObj, key ) ) {
+		if (
+			key !== ARRAY_ELEMENT_ID_KEY &&
+			! Object.hasOwn( newObj, key ) &&
+			( ! previousObj || Object.hasOwn( previousObj, key ) )
+		) {
 			yMap.delete( key );
 		}
 	}
@@ -936,18 +1181,20 @@ function mergeYMapValues(
 /**
  * Update a single attribute on a Yjs block attributes map (currentAttributes).
  *
- * @param blockName         The block type name, e.g. 'core/paragraph'.
- * @param attributeName     The name of the attribute to update, e.g. 'content'.
- * @param attributeValue    The new value for the attribute.
- * @param currentAttributes The Y.Map holding the block's current attributes.
- * @param cursorPosition    The local cursor position, used when merging rich-text deltas.
+ * @param blockName              The block type name, e.g. 'core/paragraph'.
+ * @param attributeName          The name of the attribute to update, e.g. 'content'.
+ * @param attributeValue         The new value for the attribute.
+ * @param currentAttributes      The Y.Map holding the block's current attributes.
+ * @param cursorPosition         The local cursor position, used when merging rich-text deltas.
+ * @param previousAttributeValue The previous plain local value for the attribute.
  */
 function updateYBlockAttribute(
 	blockName: string,
 	attributeName: string,
 	attributeValue: unknown,
 	currentAttributes: YBlockAttributes,
-	cursorPosition: number | null
+	cursorPosition: number | null,
+	previousAttributeValue?: unknown
 ): void {
 	const schema = getBlockAttributeSchema( blockName, attributeName );
 
@@ -956,7 +1203,8 @@ function updateYBlockAttribute(
 		attributeValue,
 		currentAttributes,
 		attributeName,
-		cursorPosition
+		cursorPosition,
+		previousAttributeValue
 	);
 }
 

--- a/packages/core-data/src/utils/test/crdt-stale-query-array-post.test.ts
+++ b/packages/core-data/src/utils/test/crdt-stale-query-array-post.test.ts
@@ -1,0 +1,260 @@
+/**
+ * WordPress dependencies
+ */
+import { RichTextData } from '@wordpress/rich-text';
+import { Y } from '@wordpress/sync';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest, afterEach } from '@jest/globals';
+
+jest.mock( '@wordpress/blocks', () => {
+	const actual = jest.requireActual( '@wordpress/blocks' ) as Record<
+		string,
+		unknown
+	>;
+	return {
+		...actual,
+		getBlockTypes: () => [
+			{
+				name: 'core/table',
+				attributes: {
+					body: {
+						type: 'array',
+						query: {
+							cells: {
+								type: 'array',
+								query: {
+									content: { type: 'rich-text' },
+									tag: { type: 'string' },
+								},
+							},
+						},
+					},
+				},
+			},
+		],
+	};
+} );
+
+/**
+ * Internal dependencies
+ */
+import {
+	applyPostChangesToCRDTDoc,
+	getPostChangesFromCRDTDoc,
+	type PostChanges,
+} from '../crdt';
+import type { Block } from '../crdt-blocks';
+import type { Post } from '../../entity-types';
+
+const syncedProperties = new Set( [ 'blocks' ] );
+const RANDOM_SEEDS = Array.from(
+	{ length: 24 },
+	( _value, index ) => index + 1
+);
+
+function tableBlock( rows: string[][] ): Block {
+	return {
+		name: 'core/table',
+		clientId: 'table-1',
+		attributes: {
+			body: rows.map( ( cells ) => ( {
+				cells: cells.map( ( content ) => ( { content, tag: 'td' } ) ),
+			} ) ),
+		},
+		innerBlocks: [],
+	};
+}
+
+function applyBlocks( doc: Y.Doc, blocks: Block[] ) {
+	applyPostChangesToCRDTDoc(
+		doc,
+		{ blocks } as PostChanges,
+		syncedProperties
+	);
+}
+
+function syncDocs( from: Y.Doc, to: Y.Doc ) {
+	Y.applyUpdate( to, Y.encodeStateAsUpdate( from ) );
+}
+
+function textValue( value: unknown ): string {
+	if ( value instanceof RichTextData ) {
+		return value.text;
+	}
+	return String( value );
+}
+
+function getBody( doc: Y.Doc ): string[][] {
+	const changes = getPostChangesFromCRDTDoc(
+		doc,
+		{ blocks: [] } as unknown as Post,
+		syncedProperties
+	);
+	const block = ( changes.blocks as Block[] )[ 0 ];
+	const body = block.attributes.body as {
+		cells: { content: unknown }[];
+	}[];
+
+	return body.map( ( row ) =>
+		row.cells.map( ( cell ) => textValue( cell.content ) )
+	);
+}
+
+function cloneRows( rows: string[][] ): string[][] {
+	return rows.map( ( cells ) => [ ...cells ] );
+}
+
+/* eslint-disable no-bitwise */
+function createSeededRandom( seed: number ) {
+	let state = seed >>> 0;
+
+	function next() {
+		state += 0x6d2b79f5;
+		let value = state;
+		value = Math.imul( value ^ ( value >>> 15 ), value | 1 );
+		value ^= value + Math.imul( value ^ ( value >>> 7 ), value | 61 );
+		return ( ( value ^ ( value >>> 14 ) ) >>> 0 ) / 0x100000000;
+	}
+
+	return {
+		int( maxExclusive: number ) {
+			return Math.floor( next() * maxExclusive );
+		},
+		pick< T >( values: readonly T[] ): T {
+			return values[ this.int( values.length ) ];
+		},
+	};
+}
+/* eslint-enable no-bitwise */
+
+function rowsContain( rows: string[][], value: string ): boolean {
+	return rows.some( ( row ) => row.includes( value ) );
+}
+
+function runRandomStaleTableScenario( seed: number ) {
+	const random = createSeededRandom( seed );
+	const docA = new Y.Doc();
+	const docB = new Y.Doc();
+	const initialRows = [
+		[ `seed-${ seed }-A1`, `seed-${ seed }-B1` ],
+		[ `seed-${ seed }-A2`, `seed-${ seed }-B2` ],
+		[ `seed-${ seed }-A3`, `seed-${ seed }-B3` ],
+	];
+	const staleLocalRows = cloneRows( initialRows );
+	const remoteRows = cloneRows( initialRows );
+	const localMarker = `local-${ seed }`;
+	const remoteMarker = `remote-${ seed }`;
+	const scenario = random.pick( [
+		'remote-cell-edit',
+		'remote-append-row',
+		'remote-prepend-row',
+		'remote-delete-row',
+	] as const );
+
+	try {
+		applyBlocks( docA, [ tableBlock( initialRows ) ] );
+		syncDocs( docA, docB );
+
+		switch ( scenario ) {
+			case 'remote-cell-edit':
+				remoteRows[ 1 ][ 1 ] = remoteMarker;
+				break;
+
+			case 'remote-append-row':
+				remoteRows.push( [ remoteMarker, `remote-tail-${ seed }` ] );
+				break;
+
+			case 'remote-prepend-row':
+				remoteRows.unshift( [ remoteMarker, `remote-head-${ seed }` ] );
+				break;
+
+			case 'remote-delete-row':
+				remoteRows[ 2 ][ 0 ] = remoteMarker;
+				applyBlocks( docA, [ tableBlock( remoteRows ) ] );
+				syncDocs( docA, docB );
+				remoteRows.splice( 2, 1 );
+				break;
+		}
+
+		applyBlocks( docB, [ tableBlock( remoteRows ) ] );
+		syncDocs( docB, docA );
+
+		staleLocalRows[ 0 ][ 0 ] = localMarker;
+		applyBlocks( docA, [ tableBlock( staleLocalRows ) ] );
+
+		const body = getBody( docA );
+		expect( rowsContain( body, localMarker ) ).toBe( true );
+
+		if ( scenario === 'remote-delete-row' ) {
+			expect( rowsContain( body, remoteMarker ) ).toBe( false );
+		} else {
+			expect( rowsContain( body, remoteMarker ) ).toBe( true );
+		}
+	} catch ( error ) {
+		throw new Error(
+			`Stale table scenario failed for seed ${ seed } (${ scenario }): ${
+				error instanceof Error ? error.message : String( error )
+			}`
+		);
+	} finally {
+		docA.destroy();
+		docB.destroy();
+	}
+}
+
+describe( 'post CRDT stale query-array snapshots', () => {
+	const docs: Y.Doc[] = [];
+
+	afterEach( () => {
+		for ( const doc of docs ) {
+			doc.destroy();
+		}
+		docs.length = 0;
+	} );
+
+	it( 'preserves a remote table cell edit through the post changes adapter', () => {
+		const docA = new Y.Doc();
+		const docB = new Y.Doc();
+		docs.push( docA, docB );
+
+		applyBlocks( docA, [
+			tableBlock( [
+				[ 'A1', 'B1' ],
+				[ 'A2', 'B2' ],
+			] ),
+		] );
+		syncDocs( docA, docB );
+
+		applyBlocks( docB, [
+			tableBlock( [
+				[ 'A1', 'B1' ],
+				[ 'A2', 'remote-B2' ],
+			] ),
+		] );
+		syncDocs( docB, docA );
+		expect( getBody( docA )[ 1 ][ 1 ] ).toBe( 'remote-B2' );
+
+		applyBlocks( docA, [
+			tableBlock( [
+				[ 'local-A1', 'B1' ],
+				[ 'A2', 'B2' ],
+			] ),
+		] );
+
+		expect( getBody( docA ) ).toEqual( [
+			[ 'local-A1', 'B1' ],
+			[ 'A2', 'remote-B2' ],
+		] );
+	} );
+
+	it.each( RANDOM_SEEDS )(
+		'preserves acknowledged remote table operations after a stale local snapshot (seed %i)',
+		( seed ) => {
+			expect.hasAssertions();
+			runRandomStaleTableScenario( seed );
+		}
+	);
+} );

--- a/packages/core-data/src/utils/test/crdt-stale-query-array.test.ts
+++ b/packages/core-data/src/utils/test/crdt-stale-query-array.test.ts
@@ -1,0 +1,176 @@
+/**
+ * WordPress dependencies
+ */
+import { Y } from '@wordpress/sync';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest, afterEach } from '@jest/globals';
+
+jest.mock( '@wordpress/blocks', () => ( {
+	getBlockTypes: () => [
+		{
+			name: 'core/table',
+			attributes: {
+				body: {
+					type: 'array',
+					query: {
+						cells: {
+							type: 'array',
+							query: {
+								content: { type: 'rich-text' },
+								tag: { type: 'string' },
+							},
+						},
+					},
+				},
+			},
+		},
+	],
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import { mergeCrdtBlocks, type Block, type YBlock } from '../crdt-blocks';
+
+function tableBlock( rows: string[][] ): Block {
+	return {
+		name: 'core/table',
+		clientId: 'table-1',
+		attributes: {
+			body: rows.map( ( cells ) => ( {
+				cells: cells.map( ( content ) => ( { content, tag: 'td' } ) ),
+			} ) ),
+		},
+		innerBlocks: [],
+	};
+}
+
+function syncDocs( from: Y.Doc, to: Y.Doc ) {
+	Y.applyUpdate( to, Y.encodeStateAsUpdate( from ) );
+}
+
+function getTableBody( yblocks: Y.Array< YBlock > ) {
+	return yblocks.toJSON()[ 0 ].attributes.body as {
+		cells: { content: string }[];
+	}[];
+}
+
+describe( 'stale query-array block snapshots', () => {
+	const docs: Y.Doc[] = [];
+
+	afterEach( () => {
+		for ( const doc of docs ) {
+			doc.destroy();
+		}
+		docs.length = 0;
+	} );
+
+	function createSyncedDocs( initialRows: string[][] ) {
+		const docA = new Y.Doc();
+		const docB = new Y.Doc();
+		docs.push( docA, docB );
+
+		const yblocksA = docA.getArray< YBlock >();
+		const yblocksB = docB.getArray< YBlock >();
+
+		mergeCrdtBlocks( yblocksA, [ tableBlock( initialRows ) ], null );
+		syncDocs( docA, docB );
+
+		return { docA, docB, yblocksA, yblocksB };
+	}
+
+	it( 'preserves a remote nested cell edit after a stale local cell edit', () => {
+		const { docA, docB, yblocksA, yblocksB } = createSyncedDocs( [
+			[ 'A1', 'B1' ],
+			[ 'A2', 'B2' ],
+		] );
+
+		mergeCrdtBlocks(
+			yblocksB,
+			[
+				tableBlock( [
+					[ 'A1', 'B1' ],
+					[ 'A2', 'remote-B2' ],
+				] ),
+			],
+			null
+		);
+		syncDocs( docB, docA );
+		expect( getTableBody( yblocksA )[ 1 ].cells[ 1 ].content ).toBe(
+			'remote-B2'
+		);
+
+		mergeCrdtBlocks(
+			yblocksA,
+			[
+				tableBlock( [
+					[ 'local-A1', 'B1' ],
+					[ 'A2', 'B2' ],
+				] ),
+			],
+			null
+		);
+
+		const body = getTableBody( yblocksA );
+		expect( body[ 0 ].cells[ 0 ].content ).toBe( 'local-A1' );
+		expect( body[ 1 ].cells[ 1 ].content ).toBe( 'remote-B2' );
+	} );
+
+	it( 'preserves a remote appended row after a stale local cell edit', () => {
+		const { docA, docB, yblocksA, yblocksB } = createSyncedDocs( [
+			[ 'A1' ],
+			[ 'A2' ],
+		] );
+
+		mergeCrdtBlocks(
+			yblocksB,
+			[ tableBlock( [ [ 'A1' ], [ 'A2' ], [ 'remote-A3' ] ] ) ],
+			null
+		);
+		syncDocs( docB, docA );
+		expect( getTableBody( yblocksA ) ).toHaveLength( 3 );
+
+		mergeCrdtBlocks(
+			yblocksA,
+			[ tableBlock( [ [ 'local-A1' ], [ 'A2' ] ] ) ],
+			null
+		);
+
+		const body = getTableBody( yblocksA );
+		expect( body ).toHaveLength( 3 );
+		expect( body[ 0 ].cells[ 0 ].content ).toBe( 'local-A1' );
+		expect( body[ 2 ].cells[ 0 ].content ).toBe( 'remote-A3' );
+	} );
+
+	it( 'does not resurrect a remotely deleted row from a stale local snapshot', () => {
+		const { docA, docB, yblocksA, yblocksB } = createSyncedDocs( [
+			[ 'A1' ],
+			[ 'A2' ],
+			[ 'A3' ],
+		] );
+
+		mergeCrdtBlocks(
+			yblocksB,
+			[ tableBlock( [ [ 'A1' ], [ 'A2' ] ] ) ],
+			null
+		);
+		syncDocs( docB, docA );
+		expect( getTableBody( yblocksA ) ).toHaveLength( 2 );
+
+		mergeCrdtBlocks(
+			yblocksA,
+			[ tableBlock( [ [ 'local-A1' ], [ 'A2' ], [ 'A3' ] ] ) ],
+			null
+		);
+
+		const body = getTableBody( yblocksA );
+		expect( body ).toHaveLength( 2 );
+		expect( body[ 0 ].cells[ 0 ].content ).toBe( 'local-A1' );
+		expect( body.map( ( row ) => row.cells[ 0 ].content ) ).not.toContain(
+			'A3'
+		);
+	} );
+} );

--- a/packages/core-data/src/utils/test/crdt-table-duplicates-repro.test.ts
+++ b/packages/core-data/src/utils/test/crdt-table-duplicates-repro.test.ts
@@ -1,0 +1,124 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+
+/**
+ * WordPress dependencies
+ */
+import { Y } from '@wordpress/sync';
+
+/**
+ * Internal dependencies
+ */
+import {
+	deserializeBlockAttributes,
+	mergeCrdtBlocks,
+	type Block,
+	type YBlock,
+} from '../crdt-blocks';
+
+jest.mock( '@wordpress/blocks', () => ( {
+	getBlockTypes: () => [
+		{
+			name: 'core/table',
+			attributes: {
+				body: {
+					type: 'array',
+					query: {
+						cells: {
+							type: 'array',
+							query: {
+								content: { type: 'rich-text' },
+								tag: { type: 'string' },
+							},
+						},
+					},
+				},
+			},
+		},
+	],
+} ) );
+
+function createTableBlock( values: string[] ): Block {
+	return {
+		name: 'core/table',
+		clientId: 'table',
+		attributes: {
+			body: values.map( ( value ) => ( {
+				cells: [
+					{
+						content: value,
+						tag: 'td',
+					},
+				],
+			} ) ),
+		},
+		innerBlocks: [],
+	};
+}
+
+function getRuntimeTableBody( blocks: Block[] ) {
+	return blocks[ 0 ].attributes.body as Array< {
+		cells: Array< Record< string, unknown > >;
+	} >;
+}
+
+function getCellContentText( content: unknown ) {
+	return typeof content === 'object' && content && 'valueOf' in content
+		? String( content.valueOf() )
+		: content;
+}
+
+function getTableBodyCellContents( yblocks: Y.Array< YBlock > ) {
+	const blocks = deserializeBlockAttributes( yblocks.toJSON() as Block[] );
+	return getRuntimeTableBody( blocks ).map( ( row ) =>
+		getCellContentText( row.cells[ 0 ].content )
+	);
+}
+
+describe( 'CRDT duplicate table row repro', () => {
+	it( 'converges when one user edits the later duplicate row and another deletes the earlier duplicate row', () => {
+		const docA = new Y.Doc();
+		const docB = new Y.Doc();
+		const yblocksA = docA.getArray< YBlock >( 'blocks' );
+		const yblocksB = docB.getArray< YBlock >( 'blocks' );
+
+		mergeCrdtBlocks(
+			yblocksA,
+			[ createTableBlock( [ 'anchor', 'same', 'same' ] ) ],
+			null
+		);
+		Y.applyUpdate( docB, Y.encodeStateAsUpdate( docA ) );
+
+		const stateVectorA = Y.encodeStateVector( docA );
+		const stateVectorB = Y.encodeStateVector( docB );
+		const runtimeBlocksA = deserializeBlockAttributes(
+			yblocksA.toJSON() as Block[]
+		);
+		const runtimeBlocksB = deserializeBlockAttributes(
+			yblocksB.toJSON() as Block[]
+		);
+
+		getRuntimeTableBody( runtimeBlocksA )[ 2 ].cells[ 0 ].content =
+			'edited-second-duplicate';
+		getRuntimeTableBody( runtimeBlocksB ).splice( 1, 1 );
+
+		mergeCrdtBlocks( yblocksA, runtimeBlocksA, null );
+		mergeCrdtBlocks( yblocksB, runtimeBlocksB, null );
+
+		const updateA = Y.encodeStateAsUpdate( docA, stateVectorB );
+		const updateB = Y.encodeStateAsUpdate( docB, stateVectorA );
+		Y.applyUpdate( docA, updateB );
+		Y.applyUpdate( docB, updateA );
+
+		expect( getTableBodyCellContents( yblocksA ) ).toEqual( [
+			'anchor',
+			'edited-second-duplicate',
+		] );
+		expect( getTableBodyCellContents( yblocksB ) ).toEqual( [
+			'anchor',
+			'edited-second-duplicate',
+		] );
+	} );
+} );

--- a/packages/core-data/src/utils/test/crdt-table-query-identity.test.ts
+++ b/packages/core-data/src/utils/test/crdt-table-query-identity.test.ts
@@ -1,0 +1,211 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+
+/**
+ * WordPress dependencies
+ */
+import { Y } from '@wordpress/sync';
+
+/**
+ * Internal dependencies
+ */
+import {
+	deserializeBlockAttributes,
+	mergeCrdtBlocks,
+	type Block,
+	type YBlock,
+} from '../crdt-blocks';
+
+jest.mock( '@wordpress/blocks', () => ( {
+	getBlockTypes: () => [
+		{
+			name: 'core/table',
+			attributes: {
+				body: {
+					type: 'array',
+					query: {
+						cells: {
+							type: 'array',
+							query: {
+								content: { type: 'rich-text' },
+								tag: { type: 'string' },
+							},
+						},
+					},
+				},
+			},
+		},
+	],
+} ) );
+
+const INTERNAL_ID_KEY = '__unstableSyncId';
+
+function createTableBlock( values: string[] ): Block {
+	return {
+		name: 'core/table',
+		clientId: 'table',
+		attributes: {
+			body: values.map( ( value ) => ( {
+				cells: [
+					{
+						content: value,
+						tag: 'td',
+					},
+				],
+			} ) ),
+		},
+		innerBlocks: [],
+	};
+}
+
+describe( 'CRDT table query array identity', () => {
+	function getRuntimeBody( yblocks: Y.Array< YBlock > ) {
+		const [ table ] = deserializeBlockAttributes(
+			yblocks.toJSON() as Block[]
+		);
+		return table.attributes.body as Array<
+			Record< string, unknown > & {
+				cells: Array< Record< string, unknown > >;
+			}
+		>;
+	}
+
+	function getRuntimeCellValues( yblocks: Y.Array< YBlock > ) {
+		return getRuntimeBody( yblocks ).map( ( row ) => {
+			const content = row.cells[ 0 ].content;
+			return typeof content === 'object' &&
+				content &&
+				'valueOf' in content
+				? String( content.valueOf() )
+				: content;
+		} );
+	}
+
+	function getYBody( yblocks: Y.Array< YBlock > ) {
+		const [ table ] = yblocks.toJSON() as Block[];
+		return table.attributes.body as Array<
+			Record< string, unknown > & {
+				cells: Array< Record< string, unknown > >;
+			}
+		>;
+	}
+
+	it( 'stores internal identities in the CRDT document only', () => {
+		const doc = new Y.Doc();
+		const yblocks = doc.getArray< YBlock >( 'blocks' );
+
+		mergeCrdtBlocks(
+			yblocks,
+			[ createTableBlock( [ 'anchor', 'same', 'same' ] ) ],
+			null
+		);
+
+		const yBody = getYBody( yblocks );
+		expect( yBody[ 0 ][ INTERNAL_ID_KEY ] ).toEqual( expect.any( String ) );
+		expect( yBody[ 1 ][ INTERNAL_ID_KEY ] ).toEqual( expect.any( String ) );
+		expect( yBody[ 2 ][ INTERNAL_ID_KEY ] ).toEqual( expect.any( String ) );
+		expect( yBody[ 2 ].cells[ 0 ][ INTERNAL_ID_KEY ] ).toEqual(
+			expect.any( String )
+		);
+
+		const [ table ] = deserializeBlockAttributes(
+			yblocks.toJSON() as Block[]
+		);
+		const body = table.attributes.body as Array<
+			Record< string, unknown > & {
+				cells: Array< Record< string, unknown > >;
+			}
+		>;
+
+		expect( body[ 0 ] ).not.toHaveProperty( INTERNAL_ID_KEY );
+		expect( body[ 1 ] ).not.toHaveProperty( INTERNAL_ID_KEY );
+		expect( body[ 2 ] ).not.toHaveProperty( INTERNAL_ID_KEY );
+		expect( body[ 2 ].cells[ 0 ] ).not.toHaveProperty( INTERNAL_ID_KEY );
+		expect( JSON.stringify( table.attributes ) ).not.toContain(
+			INTERNAL_ID_KEY
+		);
+	} );
+
+	it( 'preserves CRDT identities when deserialized blocks are merged back', () => {
+		const doc = new Y.Doc();
+		const yblocks = doc.getArray< YBlock >( 'blocks' );
+
+		mergeCrdtBlocks(
+			yblocks,
+			[ createTableBlock( [ 'anchor', 'same', 'same' ] ) ],
+			null
+		);
+
+		const beforeIds = getYBody( yblocks ).map(
+			( row ) => row[ INTERNAL_ID_KEY ]
+		);
+		const beforeCellIds = getYBody( yblocks ).map(
+			( row ) => row.cells[ 0 ][ INTERNAL_ID_KEY ]
+		);
+		const runtimeBlocks = deserializeBlockAttributes(
+			yblocks.toJSON() as Block[]
+		);
+
+		mergeCrdtBlocks( yblocks, runtimeBlocks, null );
+
+		expect(
+			getYBody( yblocks ).map( ( row ) => row[ INTERNAL_ID_KEY ] )
+		).toEqual( beforeIds );
+		expect(
+			getYBody( yblocks ).map(
+				( row ) => row.cells[ 0 ][ INTERNAL_ID_KEY ]
+			)
+		).toEqual( beforeCellIds );
+	} );
+
+	it( 'preserves a later duplicate row edit when the earlier duplicate is deleted', () => {
+		const docA = new Y.Doc();
+		const docB = new Y.Doc();
+		const yblocksA = docA.getArray< YBlock >( 'blocks' );
+		const yblocksB = docB.getArray< YBlock >( 'blocks' );
+
+		mergeCrdtBlocks(
+			yblocksA,
+			[ createTableBlock( [ 'anchor', 'same', 'same' ] ) ],
+			null
+		);
+		Y.applyUpdate( docB, Y.encodeStateAsUpdate( docA ) );
+
+		const stateVectorA = Y.encodeStateVector( docA );
+		const stateVectorB = Y.encodeStateVector( docB );
+		const runtimeBlocksA = deserializeBlockAttributes(
+			yblocksA.toJSON() as Block[]
+		);
+		const runtimeBlocksB = deserializeBlockAttributes(
+			yblocksB.toJSON() as Block[]
+		);
+		const bodyA = runtimeBlocksA[ 0 ].attributes.body as Array< {
+			cells: Array< Record< string, unknown > >;
+		} >;
+		const bodyB = runtimeBlocksB[ 0 ].attributes.body as Array< {
+			cells: Array< Record< string, unknown > >;
+		} >;
+
+		bodyA[ 2 ].cells[ 0 ].content = 'edited-second-duplicate';
+		bodyB.splice( 1, 1 );
+
+		mergeCrdtBlocks( yblocksA, runtimeBlocksA, null );
+		mergeCrdtBlocks( yblocksB, runtimeBlocksB, null );
+
+		const updateA = Y.encodeStateAsUpdate( docA, stateVectorB );
+		const updateB = Y.encodeStateAsUpdate( docB, stateVectorA );
+		Y.applyUpdate( docA, updateB );
+		Y.applyUpdate( docB, updateA );
+
+		expect( getRuntimeCellValues( yblocksA ) ).toEqual( [
+			'anchor',
+			'edited-second-duplicate',
+		] );
+		expect( getRuntimeCellValues( yblocksB ) ).toEqual( [
+			'anchor',
+			'edited-second-duplicate',
+		] );
+	} );
+} );

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -63,7 +63,7 @@ import {
 	type PostChanges,
 	type YPostRecord,
 } from '../crdt';
-import type { YBlock, YBlockRecord, YBlocks } from '../crdt-blocks';
+import type { Block, YBlock, YBlockRecord, YBlocks } from '../crdt-blocks';
 import { updateSelectionHistory } from '../crdt-selection';
 import { createYMap, getRootMap, type YMapWrap } from '../crdt-utils';
 import type { Post } from '../../entity-types';
@@ -273,6 +273,59 @@ describe( 'crdt', () => {
 			expect( ( map.get( 'blocks' ) as YBlocks ).toJSON() ).toEqual(
 				changes.blocks
 			);
+		} );
+
+		it( 'converges duplicate table row edit/delete through the post changes wrapper', () => {
+			const docB = new Y.Doc();
+
+			try {
+				applyPostChangesToCRDTDoc(
+					doc,
+					{
+						blocks: [
+							createTableBlock( [ 'anchor', 'same', 'same' ] ),
+						],
+					},
+					defaultSyncedProperties
+				);
+				Y.applyUpdate( docB, Y.encodeStateAsUpdate( doc ) );
+
+				const stateVectorA = Y.encodeStateVector( doc );
+				const stateVectorB = Y.encodeStateVector( docB );
+				const runtimeBlocksA = getRuntimeBlocksFromDoc( doc );
+				const runtimeBlocksB = getRuntimeBlocksFromDoc( docB );
+
+				getRuntimeTableBody( runtimeBlocksA )[ 2 ].cells[ 0 ].content =
+					'edited-second-duplicate';
+				getRuntimeTableBody( runtimeBlocksB ).splice( 1, 1 );
+
+				applyPostChangesToCRDTDoc(
+					doc,
+					{ blocks: runtimeBlocksA },
+					defaultSyncedProperties
+				);
+				applyPostChangesToCRDTDoc(
+					docB,
+					{ blocks: runtimeBlocksB },
+					defaultSyncedProperties
+				);
+
+				const updateA = Y.encodeStateAsUpdate( doc, stateVectorB );
+				const updateB = Y.encodeStateAsUpdate( docB, stateVectorA );
+				Y.applyUpdate( doc, updateB );
+				Y.applyUpdate( docB, updateA );
+
+				expect( getTableBodyCellContentsFromDoc( doc ) ).toEqual( [
+					'anchor',
+					'edited-second-duplicate',
+				] );
+				expect( getTableBodyCellContentsFromDoc( docB ) ).toEqual( [
+					'anchor',
+					'edited-second-duplicate',
+				] );
+			} finally {
+				docB.destroy();
+			}
 		} );
 
 		it( 'initializes blocks as Y.Array when not present', () => {
@@ -993,4 +1046,48 @@ function addBlockToDoc(
 	( blocks as YBlocks ).push( [ block ] );
 
 	return ytext;
+}
+
+function createTableBlock( values: string[] ): Block {
+	return {
+		name: 'core/table',
+		clientId: 'table',
+		attributes: {
+			body: values.map( ( value ) => ( {
+				cells: [
+					{
+						content: value,
+						tag: 'td',
+					},
+				],
+			} ) ),
+		},
+		innerBlocks: [],
+	};
+}
+
+function getRuntimeBlocksFromDoc( ydoc: Y.Doc ): Block[] {
+	return getPostChangesFromCRDTDoc(
+		ydoc,
+		{ blocks: [] } as unknown as Post,
+		defaultSyncedProperties
+	).blocks as Block[];
+}
+
+function getRuntimeTableBody( blocks: Block[] ) {
+	return blocks[ 0 ].attributes.body as Array< {
+		cells: Array< Record< string, unknown > >;
+	} >;
+}
+
+function getCellContentText( content: unknown ) {
+	return typeof content === 'object' && content && 'valueOf' in content
+		? String( content.valueOf() )
+		: content;
+}
+
+function getTableBodyCellContentsFromDoc( ydoc: Y.Doc ) {
+	return getRuntimeTableBody( getRuntimeBlocksFromDoc( ydoc ) ).map(
+		( row ) => getCellContentText( row.cells[ 0 ].content )
+	);
 }

--- a/test/e2e/specs/editor/collaboration/collaboration-table-duplicates.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-table-duplicates.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+type Editor = import('@wordpress/e2e-test-utils-playwright').Editor;
+type Page = import('@playwright/test').Page;
+
+const TABLE_POST_CONTENT = `<!-- wp:table -->
+<figure class="wp-block-table"><table><tbody><tr><td>anchor</td></tr><tr><td>same</td></tr><tr><td>same</td></tr></tbody></table></figure>
+<!-- /wp:table -->`;
+
+async function getTableBodyCellContents( editor: Editor ) {
+	return editor.canvas
+		.getByRole( 'textbox', { name: 'Body cell text' } )
+		.evaluateAll( ( cells ) =>
+			cells.map( ( cell ) => cell.textContent?.trim() )
+		);
+}
+
+async function editTableCell( {
+	editor,
+	page,
+	index,
+	content,
+}: {
+	editor: Editor;
+	page: Page;
+	index: number;
+	content: string;
+} ) {
+	await editor.canvas
+		.getByRole( 'textbox', { name: 'Body cell text' } )
+		.nth( index )
+		.click();
+	await page.keyboard.press( 'ControlOrMeta+a' );
+	await page.keyboard.type( content );
+}
+
+async function deleteTableRow( {
+	editor,
+	page,
+	index,
+}: {
+	editor: Editor;
+	page: Page;
+	index: number;
+} ) {
+	await editor.canvas
+		.getByRole( 'textbox', { name: 'Body cell text' } )
+		.nth( index )
+		.click();
+	await editor.clickBlockToolbarButton( 'Edit table' );
+	await page.getByRole( 'menuitem', { name: 'Delete row' } ).click();
+}
+
+test.describe( 'Collaboration - duplicate table rows', () => {
+	test( 'preserves a later duplicate row edit when the earlier duplicate row is deleted', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		test.setTimeout( 45_000 );
+
+		const post = await requestUtils.createPost( {
+			title: 'Duplicate table row collaboration repro',
+			status: 'draft',
+			content: TABLE_POST_CONTENT,
+			date_gmt: new Date().toISOString(),
+		} );
+
+		await collaborationUtils.openCollaborativeSession( post.id );
+		const { editor2, page2 } = collaborationUtils;
+
+		await expect
+			.poll( () => getTableBodyCellContents( editor ), {
+				timeout: 10_000,
+			} )
+			.toEqual( [ 'anchor', 'same', 'same' ] );
+		await expect
+			.poll( () => getTableBodyCellContents( editor2 ), {
+				timeout: 10_000,
+			} )
+			.toEqual( [ 'anchor', 'same', 'same' ] );
+
+		await Promise.all( [
+			editTableCell( {
+				content: 'edited-second-duplicate',
+				editor,
+				index: 2,
+				page,
+			} ),
+			deleteTableRow( {
+				editor: editor2,
+				index: 1,
+				page: page2,
+			} ),
+		] );
+
+		await Promise.all( [
+			collaborationUtils.waitForSyncCycle( page, 5 ),
+			collaborationUtils.waitForSyncCycle( page2, 5 ),
+		] );
+
+		await expect
+			.poll( () => getTableBodyCellContents( editor ), {
+				timeout: 10_000,
+			} )
+			.toEqual( [ 'anchor', 'edited-second-duplicate' ] );
+		await expect
+			.poll( () => getTableBodyCellContents( editor2 ), {
+				timeout: 10_000,
+			} )
+			.toEqual( [ 'anchor', 'edited-second-duplicate' ] );
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/collaboration-table-stale-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-table-stale-snapshot.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+const ONE_COLUMN_TABLE = `<!-- wp:table -->
+<figure class="wp-block-table"><table><tbody><tr><td></td></tr><tr><td></td></tr></tbody></table></figure>
+<!-- /wp:table -->`;
+
+async function getBodyCellTexts( editor: any ): Promise< string[] > {
+	const texts = await editor.canvas
+		.locator( 'role=textbox[name="Body cell text"i]' )
+		.allTextContents();
+	return texts.map( ( text: string ) => text.replace( /\uFEFF/g, '' ) );
+}
+
+async function typeInBodyCell(
+	page: any,
+	editor: any,
+	index: number,
+	text: string
+) {
+	const cell = editor.canvas
+		.locator( 'role=textbox[name="Body cell text"i]' )
+		.nth( index );
+	await cell.click();
+	await page.keyboard.type( text );
+}
+
+test.describe( 'Collaboration - table stale snapshots', () => {
+	test( 'preserves a remotely appended table row when another user edits a different cell', async ( {
+		collaborationUtils,
+		requestUtils,
+		page,
+		editor,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'RTC table stale append',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+			content: ONE_COLUMN_TABLE,
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { page2, editor2 } = collaborationUtils;
+
+		await expect
+			.poll( () => getBodyCellTexts( editor ), { timeout: 10_000 } )
+			.toEqual( [ '', '' ] );
+		await expect
+			.poll( () => getBodyCellTexts( editor2 ), { timeout: 10_000 } )
+			.toEqual( [ '', '' ] );
+
+		const userAReceivesSync = page.waitForResponse(
+			( response ) =>
+				response.url().includes( 'wp-sync' ) &&
+				response.status() === 200,
+			{ timeout: 15_000 }
+		);
+
+		await editor2.canvas
+			.locator( 'role=textbox[name="Body cell text"i]' )
+			.nth( 1 )
+			.click();
+		await editor2.clickBlockToolbarButton( 'Edit table' );
+		await page2
+			.getByRole( 'menuitem', { name: 'Insert row after' } )
+			.click();
+
+		await userAReceivesSync;
+		await typeInBodyCell( page, editor, 0, 'local-A1' );
+
+		await expect
+			.poll( () => getBodyCellTexts( editor ), { timeout: 15_000 } )
+			.toEqual( [ 'local-A1', '', '' ] );
+		await expect
+			.poll( () => getBodyCellTexts( editor2 ), { timeout: 15_000 } )
+			.toEqual( [ 'local-A1', '', '' ] );
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -149,16 +149,87 @@ export default class CollaborationUtils {
 	async waitForMutualDiscovery( { timeout }: { timeout?: number } = {} ) {
 		const pages = this.allPages;
 		const resolvedTimeout = timeout ?? 10000 + pages.length * 2500;
+		const roomName = await this.getCurrentPostRoomName( this.primaryPage );
 
 		await Promise.all(
 			pages.map( ( pg ) =>
-				pg
-					.getByRole( 'button', { name: /Collaborators list/ } )
-					.waitFor( { timeout: resolvedTimeout } )
+				this.waitForAwarenessPeerCount(
+					pg,
+					pages.length,
+					resolvedTimeout,
+					roomName
+				)
 			)
 		);
 
 		await Promise.all( pages.map( ( pg ) => this.waitForSyncCycle( pg ) ) );
+	}
+
+	/**
+	 * Wait until the sync transport reports the expected number of clients in
+	 * the requested room's awareness payload.
+	 *
+	 * Some repros exercise lower-level sync behavior before the rendered
+	 * collaborator presence UI has enough display metadata to show the
+	 * "Collaborators list" button. The transport-level awareness count is the
+	 * synchronization gate these repros actually need.
+	 *
+	 * @param page              The Playwright page to wait on.
+	 * @param expectedPeerCount Expected number of awareness clients.
+	 * @param timeout           Maximum wait time in ms.
+	 * @param roomName          Optional room name to require.
+	 */
+	async waitForAwarenessPeerCount(
+		page: Page,
+		expectedPeerCount: number,
+		timeout: number,
+		roomName?: string
+	) {
+		await page.waitForResponse(
+			async ( response ) => {
+				if (
+					! response.url().includes( 'wp-sync' ) ||
+					response.status() !== 200
+				) {
+					return false;
+				}
+
+				const body = await response.json().catch( () => null );
+				return (
+					body?.rooms?.some(
+						( room: {
+							room?: string;
+							awareness?: Record< string, unknown >;
+						} ) =>
+							( ! roomName || room.room === roomName ) &&
+							room.awareness &&
+							Object.keys( room.awareness ).length >=
+								expectedPeerCount
+					) ?? false
+				);
+			},
+			{ timeout }
+		);
+	}
+
+	/**
+	 * Return the collaboration room name for the current post.
+	 *
+	 * @param page The Playwright page to read from.
+	 */
+	async getCurrentPostRoomName( page: Page ): Promise< string > {
+		const postId = await page.evaluate(
+			() =>
+				( window as any ).wp?.data
+					?.select( 'core/editor' )
+					?.getCurrentPostId?.()
+		);
+
+		if ( ! postId ) {
+			throw new Error( 'Current post ID is unavailable.' );
+		}
+
+		return `postType/post:${ postId }`;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This is part of an AI fuzzing project, where an AI wrote a fuzzer and then triages bugs from the fuzzer and creates fixes. See #77716 for the tracking issue. As of this writing, there have been no known false positives from this project, but there have been some issues, which are documented in #77716.

This PR depends on #77723. It could, theoretically, be independent but it's cleaner to assume the changes from there and modify that. If #77723 is modified before landing, this PR should probably also be modified.

https://github.com/user-attachments/assets/95748e7f-9722-48fe-b796-fb5a487968ec



## BEGIN AI GENERATED TEXT

The RTC table merge path can lose remote edits when a client applies a stale
local block snapshot after receiving a remote CRDT update.

The problem is not that table cells are stored at the wrong Yjs granularity.
The current code does store table rows, cells, and rich-text cell contents as
nested Yjs types. The problem is that the merge code still treats the incoming
Gutenberg block tree as an authoritative full snapshot. If that snapshot was
created before a remote update was reflected into the editor state, values that
are merely stale are interpreted as local writes, deletes, or structural changes.
Those stale values can overwrite remote table edits already present in the
Y.Doc.

This is a data-loss class bug: both clients can converge, but converge to a
state that has dropped an acknowledged remote edit.

## How the bug was introduced

The relevant RTC table behavior was introduced by
[WordPress/gutenberg#76913](https://github.com/WordPress/gutenberg/pull/76913),
"RTC: Fix core/table cell merging".

That PR fixed an important earlier problem: query-backed attributes like
`core/table` `body` were previously stored as plain arrays, so editing one cell
replaced the whole table body. The PR changed query-backed `array` and `object`
attributes to use nested Yjs structures:

-   table `body` is stored as a `Y.Array`;
-   rows and cells are stored as `Y.Map`;
-   rich-text cell `content` is stored as `Y.Text`.

That makes concurrent edits to different table cells merge correctly when both
local snapshots are based on the current local CRDT state.

[WordPress/gutenberg#77164](https://github.com/WordPress/gutenberg/pull/77164),
"RTC: Improve array attribute stability when structural changes occur", then
changed `mergeYArray()` from rebuilding arrays on every length change to a
left/right sweep that preserves existing Yjs objects for unchanged array
elements. That improved append, prepend, and middle-insert behavior, but it did
not change the deeper assumption: a full block snapshot is still merged as if it
were the desired final state.

The fuzzing work that exposes this bug is on the `try/fuzz` branch. The focused
test is in `packages/core-data/src/utils/test/crdt-blocks.fuzz.test.ts` and is
named:

```text
table query-array merges preserve remote edits after stale local snapshots
```

## Failure example

A minimal randomized failure from seed `910`:

```text
initial table 2x2 synced from A to B
B edit row 1 cell 1 -> remote-910-cell-74epi6
A stale snapshot edit row 0 cell 0 -> local-910-cell-1wfzm7d
Expected remote content "remote-910-cell-74epi6" to be present after stale local merge
```

The observed final table body contains A's local edit, but B's remote edit is
reverted to the old value.

The focused test also finds failures for remote structural changes:

-   remote prepend is removed by a stale local snapshot;
-   remote append is removed by a stale local snapshot;
-   remote row deletion is undone by a stale local snapshot.

## Repro video

The normal-user Playwright repro video is
[rtc-table-stale-snapshot-repro.mp4](./assets/rtc-table-stale-snapshot-repro.mp4).

It shows two real editor sessions side by side:

-   User A inserts a normal table, then types into cell A1.
-   User B uses the table toolbar to insert a row after B1 and types
    `remote inserted row`.
-   The bottom annotation band shows the bug: User A has only two rows and no
    remote inserted row, while User B still has the inserted row.

The video was recorded from `try/fuzz` at
`4c5412d836192fa02523199395334d6245abfc64` with wp-env at
`http://localhost:8888`. The recording adds a bottom annotation band outside the
two editor views; the reproduced editor actions are normal clicks, toolbar menu
selections, and keyboard typing.

## Why this happens

The key path is:

```text
mergeCrdtBlocks()
  updateYBlockAttribute()
    mergeYValue()
      mergeYArray()
        mergeYMapValues()
          mergeYValue()
            mergeRichTextUpdate()
```

`mergeCrdtBlocks()` receives a full Gutenberg block tree. For Yjs-backed
attributes, it delegates to `mergeYValue()` even when the attribute may be
unchanged locally, because Yjs types cannot be compared directly with plain
values.

For table bodies, `mergeYValue()` calls `mergeYArray()`. `mergeYArray()` compares
the incoming plain rows against the current `Y.Array` contents. When it sees a
difference, it treats the incoming row or cell value as a local update to apply
to the Y.Doc.

For rich text, `mergeRichTextUpdate()` computes a delta from the current
`Y.Text` value to the incoming string and applies that delta. If the incoming
string is stale, the computed delta is a revert.

That is correct only if the incoming block tree is known to include all remote
updates already present in the Y.Doc. RTC does not have that guarantee. Remote
Yjs updates and local editor snapshots can be interleaved. A stale editor
snapshot therefore contains two different kinds of data:

-   real local edits;
-   old values for fields the user did not touch.

The current merge algorithm cannot distinguish those cases.

Nested Yjs types reduce the blast radius from "whole table body" to
"row/cell/property paths", but they do not solve stale full-state writes. A stale
cell value is still a write to a `Y.Text`; a stale missing row is still a delete
from a `Y.Array`.

## Relationship to the duplicate-row fix

[WordPress/gutenberg#77723](https://github.com/WordPress/gutenberg/pull/77723)
fixes a related but different table merge bug: duplicate-looking rows are
ambiguous when `mergeYArray()` matches query-array elements by serialized value.
That PR adds stable internal identities for query-array elements so two rows with
the same visible contents are no longer treated as interchangeable.

This stale-snapshot bug is not fixed by stable row identity alone. The stale
snapshot can already refer to the right logical row or cell and still carry an
old value. It can also omit a remotely inserted row because the local editor
snapshot was created before that row existed. With the #77723 ID-based merge, an
incoming stale snapshot can still:

-   delete a remote row whose ID exists in the current Y.Doc but not in the stale
    incoming snapshot;
-   resurrect a remote-deleted row whose ID still exists in the stale incoming
    snapshot;
-   overwrite a remote cell edit on the same cell ID because the incoming cell
    string is old.

The fixes are therefore complementary, not independent. The preferred landing
order is:

1.  Land [#77723](https://github.com/WordPress/gutenberg/pull/77723) first, so
    query-array rows and cells have stable internal identities.
2.  Implement this stale-snapshot fix on top of that identity layer.

If this stale-snapshot fix has to land before #77723, it should not invent a
parallel row-identity system. It should keep structural changes conservative and
expect a follow-up rebase onto the #77723 identity mechanism. A textual clean
merge is not enough; the combined behavior must be tested because both fixes
touch `packages/core-data/src/utils/crdt-blocks.ts` and the same table/query
merge path.

## Fix plan

### 1. Make the invariant explicit

The invariant should be:

> Merging a local editor snapshot must only apply changes that happened locally
> since that client's previous editor snapshot. It must not overwrite remote
> changes merely because the local snapshot is stale.

Convergence alone is not enough. The tests must assert preservation of known
remote operations.

### 2. Use #77723 identity as the array basis

Do not solve row identity twice. Once
[#77723](https://github.com/WordPress/gutenberg/pull/77723) lands, use its
internal query-array IDs to identify rows and cells when deriving and applying
local structural operations.

The stale-snapshot fix should change the authority model, not the identity
model. Stable IDs answer "which row is this?" They do not answer "is this stale
snapshot allowed to delete or overwrite this row?" The second question is the
bug being fixed here.

### 3. Add deterministic regressions before changing code

Keep the randomized test, but add small deterministic tests for the specific
failure modes:

-   remote edit to B1, stale local edit to A1;
-   remote append row, stale local edit to an existing cell;
-   remote prepend row, stale local edit to an existing cell;
-   remote delete row, stale local edit to a different row.

Add at least one test that runs against the #77723-style identity path and shows
that stable IDs alone do not preserve the remote operation. These should fail
before the stale-snapshot fix and pass after it.

### 4. Stop treating local block snapshots as authoritative state

Introduce local-base tracking for the block merge path.

For each local merge stream, keep the last serializable block snapshot that came
from the local editor. When a new local snapshot arrives, compute a local delta:

```text
previous local editor snapshot -> next local editor snapshot
```

Apply only that delta to the current Y.Doc. Do not write fields that are
unchanged between the previous and next local snapshots, even if those fields now
differ from the current Y.Doc because of remote updates.

For table query attributes, this means:

-   if a cell's content is unchanged locally, do not call `mergeRichTextUpdate()`
    for that cell;
-   if a row is unchanged locally, do not merge every property in that row;
-   if a property is absent from the stale local snapshot but was not deleted
    locally, do not delete it from the Y.Map;
-   if an array length differs only because the current Y.Doc has remote
    insertions or deletions, do not try to force it back to the stale local length.

### 5. Handle structural table edits as local operations

For query-backed arrays, derive structural operations from the local base:

```text
base rows -> next local rows
```

Then apply those operations to the current Y.Array using the stable row/cell IDs
from #77723 when available.

Deletion must require positive evidence of a local delete from the local base. A
row being absent from a stale incoming snapshot is not enough, because that same
absence is exactly how a remote insert gets lost. Similarly, insertion must not
resurrect a row that was remotely deleted unless the local delta actually added
that logical row after the local base.

The first safe implementation should support the common unambiguous cases:

-   append;
-   prepend;
-   middle insert with unchanged surrounding rows;
-   delete with unchanged surrounding rows.

If the local base and next local snapshot are ambiguous, preserve remote data and
force the editor to resync from the Y.Doc rather than deleting or moving rows by
heuristic.

### 6. Reconcile editor state after remote updates

The merge layer should make stale snapshots less likely by ensuring that remote
Y.Doc updates are reflected into the editor state before later local snapshots
are treated as merge inputs.

This does not replace local-base delta tracking. It is a second defense. In a
browser/editor pipeline, asynchronous updates can still be reordered or batched
in surprising ways.

### 7. Keep the randomized test as a bug finder

The new fuzz test should remain after the deterministic regressions pass. It
should grow to cover:

-   multi-step stale snapshots;
-   repeated remote edits before a stale local merge;
-   duplicate row contents;
-   nested head/body/foot attributes;
-   row and cell structural edits in the same run;
-   the combined #77723 identity path plus stale local snapshots.

The test should report the seed and operation trace, and the default seed range
should be small enough for normal unit-test runs while allowing larger runs via
environment variables.

## Fix plan audit

This section uses engineering lenses inspired by Linus Torvalds, Kyle Kingsbury,
and Dan Luu. It is not speaking for them.

### Linus Torvalds lens

The core smell is still pretending that a full stale state object is an
operation. Stable row IDs do not change that. They make the object easier to
match, but they do not make stale values safe to write.

The plan should not grow a second identity scheme or a pile of special cases in
`mergeYArray()`. Land or rebase on #77723, then make one narrow semantic change:

```text
If it did not change locally, do not write it.
```

The implementation should make ownership explicit. A caller-owned local merge
context is reviewable. A hidden global cache of previous snapshots is not. If a
structural edit is ambiguous, do not be clever; skip the destructive operation
and resync.

### Kyle Kingsbury / Jepsen lens

The model must distinguish identity from causality. #77723 gives rows and cells
identity, but the stale-snapshot bug is about whether an operation is causally
allowed to overwrite another operation.

The tests need operation-preservation invariants:

-   remote edit acknowledged before stale local merge must remain visible unless a
    causally later local operation overwrites the same logical field;
-   remote insert acknowledged before stale local merge must remain present unless
    a causally later local delete targets that same logical row ID;
-   remote delete acknowledged before stale local merge must not be resurrected by
    an old snapshot containing that same logical row ID.

The dangerous case after #77723 is that the code will look more correct because
it has identities, while still applying stale snapshots as full desired states.
The tests should explicitly run the stale-snapshot cases through the ID-aware
path and show that operation preservation, not just convergence, is the success
criterion.

### Dan Luu lens

This is exactly the kind of bug where "the fixes merge cleanly" can be a false
signal. #77723 and this fix can both be reasonable in isolation while combining
into a system that still deletes remote rows absent from a stale incoming
snapshot.

The plan should optimize for reviewability and future debugging:

-   document the distinction between identity and freshness in the code comment
    next to the merge logic;
-   keep deterministic tests small enough that a reviewer can see the lost
    operation without replaying the fuzzer;
-   keep the fuzz test because it explores schedules humans will not enumerate;
-   make destructive fallback paths observable in tests;
-   avoid a broad "fix all CRDT merges" patch when the current repro is the RTC
    editor-to-Y.Doc path for table query attributes.

The revised plan should explicitly say that #77723 is the preferred base. If it
cannot be the base, the stale-snapshot patch must stay conservative enough that
rebasing onto #77723 does not require redesigning the fix.

## Updated post-audit fix plan

The first fix plan did not fully account for the interaction with #77723. This
plan incorporates the audit comments and treats #77723's stable query-array
identity as the preferred foundation.

### Constraints

-   Prefer landing after [#77723](https://github.com/WordPress/gutenberg/pull/77723).
-   Do not add a second row/cell identity mechanism.
-   Do not replace the block merge system.
-   Do not add more "guess the right row" special cases to `mergeYArray()`.
-   Do not make full block snapshots globally behave like operations without a
    caller-provided base snapshot.
-   Do not use convergence as the success condition. The success condition is
    preserving acknowledged remote operations unless a real later local operation
    targets the same logical value.
-   When a structural table edit is ambiguous, preserve remote data and resync the
    editor instead of inventing a delete or move.

### Phase 0: establish the base

Rebase the stale-snapshot fix on top of #77723 if it has landed. If it has not
landed, either base the work on that branch intentionally or keep the production
change limited to local-delta plumbing and non-structural stale writes. Do not
ship a competing table row identity design.

The PR should say which base it used:

-   "built on #77723 identity path"; or
-   "pre-#77723, intentionally avoids structural identity changes and expects a
    rebase."

### Phase 1: add focused failing tests

Before changing production code, add deterministic tests for the failures the
fuzzer found:

-   remote B1 edit, stale local A1 edit;
-   remote append row, stale local cell edit;
-   remote prepend row, stale local cell edit;
-   remote delete row, stale local cell edit in another row.

Add combined-branch tests that prove #77723 alone is insufficient:

-   current Y.Doc has a remote inserted row ID absent from the stale incoming
    snapshot, and the stale merge must not delete it;
-   stale incoming snapshot contains a row ID that was remotely deleted, and the
    stale merge must not resurrect it;
-   same cell ID has newer remote text in the Y.Doc and stale old text in the
    incoming snapshot, and the stale merge must not revert it.

Keep the randomized test, but make the deterministic tests the primary review
surface.

### Phase 2: add opt-in local merge context

Add a small merge context owned by the caller that merges editor state into a
Y.Doc. The context stores the previous serialized local block snapshot for that
specific stream:

```ts
interface LocalBlockMergeContext {
	previousLocalBlocks?: Block[];
}
```

Thread this context through the RTC editor-to-Y.Doc path. Do not make it a hidden
global keyed only by `Y.Array`, because that would make tests pass while leaving
call order and ownership unclear.

When no context is provided, keep the current behavior. That keeps the change
narrow and avoids breaking unrelated callers that use `mergeCrdtBlocks()` as a
simple state-replacement helper.

### Phase 3: derive local changes before touching Yjs

For context-backed merges, compare:

```text
previousLocalBlocks -> nextLocalBlocks
```

Then apply only paths that changed locally. For table `body`, `head`, and `foot`
query attributes:

-   if a rich-text cell is unchanged between previous and next local snapshots,
    do not call `mergeRichTextUpdate()` for that cell;
-   if a plain property is unchanged locally, do not set it on the `Y.Map`;
-   if a property is absent in both previous and next local snapshots, do not
    delete a remote property from the `Y.Map`;
-   if a row or cell array is unchanged locally, do not merge through it just
    because the current Y.Doc differs.

This directly implements the Linus-style rule from the audit: if it did not
change locally, do not write it.

### Phase 4: apply structural operations by identity when available

For query-backed arrays, derive structural operations from the local base and the
next local snapshot. When #77723 IDs are present, use those IDs to apply
unambiguous local inserts and deletes to the current Y.Array.

Deletion rule:

```text
delete row ID X only if X existed in previousLocalBlocks and is absent from
nextLocalBlocks because of the local delta
```

Insertion rule:

```text
insert row ID X only if X is absent from previousLocalBlocks and present in
nextLocalBlocks because of the local delta
```

Never delete a current Y.Array element merely because it is absent from the
incoming snapshot. Never insert an old incoming element merely because the
current Y.Array no longer has it.

For pre-#77723 code, support only unambiguous prefix/suffix structural edits and
prefer skip-and-resync for duplicates or overlapping changes. After #77723, keep
the same conservative behavior for operations whose IDs or local base evidence
are missing.

### Phase 5: make lossy fallbacks observable

The existing wrong-type migration path that rebuilds an entire Y.Array should
remain available for old data, but it should not silently run during ordinary
collaboration. Add a debug-only or test-visible signal for destructive fallback
paths so tests can assert that the stale-snapshot fix is not passing by
rebuilding more data.

The fix should prefer "skip and resync" over "rebuild and hope" whenever the
input is a stale editor snapshot rather than an explicit migration.

### Phase 6: validate with operation-preservation checks

The tests should check operation preservation, not only final equality:

-   after a remote edit has been applied locally, a stale local snapshot must not
    remove that edit;
-   after a remote insert has been applied locally, a stale local snapshot must
    not remove that inserted row;
-   after a remote delete has been applied locally, a stale local snapshot must
    not resurrect the deleted row;
-   after an ambiguous local structural edit, the current Y.Doc should remain
    unchanged except for clearly local leaf edits;
-   the #77723 duplicate-row edit/delete regression must still pass after this
    fix is applied.

Run the deterministic tests, the table fuzzer, the existing block-tree fuzzer,
and the #77723 duplicate-row regression. Then run a larger seed range locally
before opening the PR.

### Phase 7: rollout discipline

Keep the code change behind the local merge context path at first. Do not
retarget every CRDT merge caller in the same patch. The first PR should only wire
the context into the RTC editor-to-Y.Doc path that can produce stale local
snapshots.

After that lands, separately consider whether other callers need the same
context. Each additional caller should come with a test that demonstrates why it
can receive stale full snapshots.

### Why this should not introduce more issues

The plan reduces writes rather than adding broader writes. Unchanged local data
stops being written to the Y.Doc, which is exactly the class of write that causes
the bug.

Using #77723 as the identity layer reduces the chance of a second,
incompatible table identity scheme. The stale-snapshot fix then has one job:
decide whether the local snapshot has authority to write a path or perform a
structural operation.

The risky part is structural editing. The plan deliberately requires both
identity and local-base evidence before applying deletes or inserts. Everything
else is a no-op plus resync, not a best-effort rewrite. That may temporarily
prefer preserving remote data over applying an ambiguous local structural edit,
but it avoids silent data loss and gives the editor a chance to present the
current document state.

The change is reviewable: a small context object, local-delta derivation,
table-query-specific tests, reuse of #77723 IDs, and conservative handling for
ambiguous arrays. If an implementation needs more machinery than that, it should
be split into a later design change rather than hidden inside this bug fix.

## END AI GENERATED TEXT
