### PR TITLE
Accordion: Remove invalid `isBlock` prop from `ToggleControl`

### DIFF
--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -140,7 +140,6 @@ export default function Edit( {
 						}
 					>
 						<ToggleControl
-							isBlock
 							label={ __( 'Auto-close' ) }
 							onChange={ ( value ) => {
 								setAttributes( {
@@ -160,7 +159,6 @@ export default function Edit( {
 						onDeselect={ () => setAttributes( { showIcon: true } ) }
 					>
 						<ToggleControl
-							isBlock
 							label={ __( 'Show icon' ) }
 							onChange={ ( value ) => {
 								setAttributes( {


### PR DESCRIPTION
## What?
Removes the invalid `isBlock` prop from two `ToggleControl` instances in the Accordion block's Edit component.

## Why?
`ToggleControl` does not support the `isBlock` prop. It has no effect and produces a noisy React warning.

<img width="1089" height="724" alt="accordion" src="https://github.com/user-attachments/assets/f032799e-6fe5-4d7e-9af1-72840cb01cbc" />

## Testing Instructions
1. Insert an Accordion block.
2. Open the block's Settings panel.
3. Confirm the "Auto-close" and "Show icon" toggles render and behave as before.
4. Check the browser console for the absence of the unknown-prop warning.

## Screenshots or screencast
N/A

## Use of AI Tools
Authored with assistance from Claude Code; reviewed by the contributor.
