### PR TITLE
Media Editor Modal: Add an Advanced Panel with top/left and width/height controls

### DIFF
--- a/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
@@ -22,10 +22,72 @@ interface CropAdvancedPanelProps {
 	onPlacementControlInteraction?: () => void;
 }
 
-type Field = 'x' | 'y' | 'width' | 'height';
-type Drafts = Record< Field, string >;
-
 const pxSuffix = <InputControlSuffixWrapper>px</InputControlSuffixWrapper>;
+
+interface CropInputProps {
+	label: string;
+	'aria-label'?: string;
+	value: number;
+	min: number;
+	max: number;
+	onCommit: ( value: number ) => void;
+}
+
+// Shows a live draft while the user types, then snaps to the committed
+// (enforced) value on blur or Enter — canvas updates in real-time without
+// the input jumping to a clamped value on each keystroke.
+function CropInput( {
+	label,
+	'aria-label': ariaLabel,
+	value,
+	min,
+	max,
+	onCommit,
+}: CropInputProps ) {
+	const [ focused, setFocused ] = useState( false );
+	const [ draft, setDraft ] = useState( '' );
+
+	const handleFocus = () => {
+		setFocused( true );
+		setDraft( String( value ) );
+	};
+
+	const handleChange = ( v: string | undefined ) => {
+		setDraft( v ?? '' );
+		const parsed = parseInt( v ?? '', 10 );
+		if ( ! isNaN( parsed ) ) {
+			onCommit( Math.max( min, Math.min( parsed, max ) ) );
+		}
+	};
+
+	const handleBlur = () => setFocused( false );
+
+	const handleKeyDown = (
+		event: React.KeyboardEvent< HTMLInputElement >
+	) => {
+		if ( event.key === 'Enter' || event.key === 'Escape' ) {
+			setFocused( false );
+			event.currentTarget.blur();
+		}
+	};
+
+	return (
+		<NumberControl
+			__next40pxDefaultSize
+			label={ label }
+			aria-label={ ariaLabel }
+			value={ focused ? draft : String( value ) }
+			min={ min }
+			max={ max }
+			step={ 1 }
+			onChange={ handleChange }
+			onFocus={ handleFocus }
+			onBlur={ handleBlur }
+			onKeyDown={ handleKeyDown }
+			suffix={ pxSuffix }
+		/>
+	);
+}
 
 export default function CropAdvancedPanel( {
 	onPlacementControlInteraction,
@@ -51,94 +113,34 @@ export default function CropAdvancedPanel( {
 		};
 	}, [ state ] );
 
-	// Which field is actively focused. Used to switch between showing the
-	// user's draft (free typing) and the committed pixel value from state.
-	const [ focusedField, setFocusedField ] = useState< Field | null >( null );
-
-	// The typed string value for the focused field. Only consulted when the
-	// field is focused — otherwise the display derives from pixels directly,
-	// so it stays in sync with canvas-driven changes at no extra cost.
-	const [ drafts, setDrafts ] = useState< Drafts >( {
-		x: '',
-		y: '',
-		width: '',
-		height: '',
-	} );
-
 	if ( ! pixels ) {
 		return null;
 	}
 
 	const { snapW, snapH } = pixels;
 
-	// Returns the value to show in each input. While focused: the raw typed
-	// draft. While not focused: the committed pixel value (always current).
-	const displayValue = ( field: Field ): string =>
-		focusedField === field ? drafts[ field ] : String( pixels[ field ] );
-
-	const handleFocus = ( field: Field ) => () => {
-		setFocusedField( field );
-		// Seed the draft with the current committed value so the user sees the
-		// right starting point before they begin typing.
-		setDrafts( ( prev ) => ( {
-			...prev,
-			[ field ]: String( pixels[ field ] ),
-		} ) );
-	};
-
-	const handleChange = ( field: Field ) => ( v: string | undefined ) => {
-		// Always update the draft so the input shows what the user typed.
-		setDrafts( ( prev ) => ( { ...prev, [ field ]: v ?? '' } ) );
-
-		const parsed = parseInt( v ?? '', 10 );
-		if ( isNaN( parsed ) || ! state.image ) {
-			return;
-		}
-
-		// Clamp to valid bounds for a best-effort live update. enforceContainment
-		// in the reducer is the authoritative constraint and will catch anything
-		// we miss here, so the cropper never ends up in an invalid state.
-		const clamped = {
-			x:
-				field === 'x'
-					? Math.max( 0, Math.min( parsed, snapW - pixels.width ) )
-					: pixels.x,
-			y:
-				field === 'y'
-					? Math.max( 0, Math.min( parsed, snapH - pixels.height ) )
-					: pixels.y,
-			width:
-				field === 'width'
-					? Math.max( 1, Math.min( parsed, snapW - pixels.x ) )
-					: pixels.width,
-			height:
-				field === 'height'
-					? Math.max( 1, Math.min( parsed, snapH - pixels.y ) )
-					: pixels.height,
-		};
-
-		const imageSize = {
-			width: state.image.naturalWidth,
-			height: state.image.naturalHeight,
-		};
-
-		setCropRect( pixelsToCropRect( clamped, state, imageSize ) );
-		onPlacementControlInteraction?.();
-	};
-
-	const handleBlur = ( field: Field ) => () => {
-		// Clear the focused field — displayValue switches to pixels[field],
-		// which reflects the enforced value after the last onChange commit.
-		setFocusedField( ( prev ) => ( prev === field ? null : prev ) );
-	};
-
-	const handleKeyDown =
-		( field: Field ) =>
-		( event: React.KeyboardEvent< HTMLInputElement > ) => {
-			if ( event.key === 'Enter' || event.key === 'Escape' ) {
-				setFocusedField( ( prev ) => ( prev === field ? null : prev ) );
-				event.currentTarget.blur();
+	const handleCommit =
+		( field: 'x' | 'y' | 'width' | 'height' ) => ( clamped: number ) => {
+			if ( ! state.image ) {
+				return;
 			}
+			const imageSize = {
+				width: state.image.naturalWidth,
+				height: state.image.naturalHeight,
+			};
+			setCropRect(
+				pixelsToCropRect(
+					{
+						x: field === 'x' ? clamped : pixels.x,
+						y: field === 'y' ? clamped : pixels.y,
+						width: field === 'width' ? clamped : pixels.width,
+						height: field === 'height' ? clamped : pixels.height,
+					},
+					state,
+					imageSize
+				)
+			);
+			onPlacementControlInteraction?.();
 		};
 
 	return (
@@ -150,67 +152,43 @@ export default function CropAdvancedPanel( {
 			<Stack direction="column" gap="sm">
 				<Flex gap={ 2 } align="flex-start">
 					<FlexItem isBlock>
-						<NumberControl
-							__next40pxDefaultSize
+						<CropInput
 							label={ __( 'Left' ) }
 							aria-label={ __( 'Crop left position' ) }
-							value={ displayValue( 'x' ) }
+							value={ pixels.x }
 							min={ 0 }
 							max={ Math.max( 0, snapW - pixels.width ) }
-							step={ 1 }
-							onChange={ handleChange( 'x' ) }
-							onFocus={ handleFocus( 'x' ) }
-							onBlur={ handleBlur( 'x' ) }
-							onKeyDown={ handleKeyDown( 'x' ) }
-							suffix={ pxSuffix }
+							onCommit={ handleCommit( 'x' ) }
 						/>
 					</FlexItem>
 					<FlexItem isBlock>
-						<NumberControl
-							__next40pxDefaultSize
+						<CropInput
 							label={ __( 'Top' ) }
 							aria-label={ __( 'Crop top position' ) }
-							value={ displayValue( 'y' ) }
+							value={ pixels.y }
 							min={ 0 }
 							max={ Math.max( 0, snapH - pixels.height ) }
-							step={ 1 }
-							onChange={ handleChange( 'y' ) }
-							onFocus={ handleFocus( 'y' ) }
-							onBlur={ handleBlur( 'y' ) }
-							onKeyDown={ handleKeyDown( 'y' ) }
-							suffix={ pxSuffix }
+							onCommit={ handleCommit( 'y' ) }
 						/>
 					</FlexItem>
 				</Flex>
 				<Flex gap={ 2 } align="flex-start">
 					<FlexItem isBlock>
-						<NumberControl
-							__next40pxDefaultSize
+						<CropInput
 							label={ __( 'Width' ) }
-							value={ displayValue( 'width' ) }
+							value={ pixels.width }
 							min={ 1 }
 							max={ Math.max( 1, snapW - pixels.x ) }
-							step={ 1 }
-							onChange={ handleChange( 'width' ) }
-							onFocus={ handleFocus( 'width' ) }
-							onBlur={ handleBlur( 'width' ) }
-							onKeyDown={ handleKeyDown( 'width' ) }
-							suffix={ pxSuffix }
+							onCommit={ handleCommit( 'width' ) }
 						/>
 					</FlexItem>
 					<FlexItem isBlock>
-						<NumberControl
-							__next40pxDefaultSize
+						<CropInput
 							label={ __( 'Height' ) }
-							value={ displayValue( 'height' ) }
+							value={ pixels.height }
 							min={ 1 }
 							max={ Math.max( 1, snapH - pixels.y ) }
-							step={ 1 }
-							onChange={ handleChange( 'height' ) }
-							onFocus={ handleFocus( 'height' ) }
-							onBlur={ handleBlur( 'height' ) }
-							onKeyDown={ handleKeyDown( 'height' ) }
-							suffix={ pxSuffix }
+							onCommit={ handleCommit( 'height' ) }
 						/>
 					</FlexItem>
 				</Flex>

--- a/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
@@ -16,9 +16,15 @@ import { Stack } from '@wordpress/ui';
  * Internal dependencies
  */
 import { useCropper } from '../../image-editor';
-import { getCropPixels, pixelsToCropRect } from '../../utils/crop-pixels';
+import {
+	getCropPixels,
+	getReachableCropBoundsInPixels,
+	pixelsToCropRect,
+} from '../../utils/crop-pixels';
 
 interface CropAdvancedPanelProps {
+	/** Resolved aspect ratio (width / height). When set, Width and Height inputs are linked. */
+	aspectRatio?: number;
 	onPlacementControlInteraction?: () => void;
 }
 
@@ -35,7 +41,7 @@ interface CropInputProps {
 
 // Shows a live draft while the user types, then snaps to the committed
 // (enforced) value on blur or Enter — canvas updates in real-time without
-// the input jumping to a clamped value on each keystroke.
+// the input jumping to a constrained value on each keystroke.
 function CropInput( {
 	label,
 	'aria-label': ariaLabel,
@@ -60,12 +66,26 @@ function CropInput( {
 		}
 	};
 
-	const handleBlur = () => setFocused( false );
+	const commit = () => {
+		const parsed = parseInt( draft, 10 );
+		if ( ! isNaN( parsed ) ) {
+			onCommit( Math.max( min, Math.min( parsed, max ) ) );
+		}
+	};
+
+	const handleBlur = () => {
+		setFocused( false );
+		commit();
+	};
 
 	const handleKeyDown = (
 		event: React.KeyboardEvent< HTMLInputElement >
 	) => {
-		if ( event.key === 'Enter' || event.key === 'Escape' ) {
+		if ( event.key === 'Enter' ) {
+			setFocused( false );
+			commit();
+			event.currentTarget.blur();
+		} else if ( event.key === 'Escape' ) {
 			setFocused( false );
 			event.currentTarget.blur();
 		}
@@ -90,6 +110,7 @@ function CropInput( {
 }
 
 export default function CropAdvancedPanel( {
+	aspectRatio,
 	onPlacementControlInteraction,
 }: CropAdvancedPanelProps ) {
 	const { state, setCropRect } = useCropper();
@@ -103,13 +124,16 @@ export default function CropAdvancedPanel( {
 			height: state.image.naturalHeight,
 		};
 		const raw = getCropPixels( state, imageSize );
+		const reach = getReachableCropBoundsInPixels( state, imageSize );
 		return {
 			x: Math.round( raw.x ),
 			y: Math.round( raw.y ),
 			width: Math.round( raw.width ),
 			height: Math.round( raw.height ),
-			snapW: Math.round( raw.snapBBoxWidth ),
-			snapH: Math.round( raw.snapBBoxHeight ),
+			minLeft: Math.ceil( reach.minLeft ),
+			minTop: Math.ceil( reach.minTop ),
+			maxRight: Math.floor( reach.maxRight ),
+			maxBottom: Math.floor( reach.maxBottom ),
 		};
 	}, [ state ] );
 
@@ -117,9 +141,9 @@ export default function CropAdvancedPanel( {
 		return null;
 	}
 
-	const { snapW, snapH } = pixels;
+	const { minLeft, minTop, maxRight, maxBottom } = pixels;
 
-	const handleCommit =
+	const handleApply =
 		( field: 'x' | 'y' | 'width' | 'height' ) => ( clamped: number ) => {
 			if ( ! state.image ) {
 				return;
@@ -128,13 +152,33 @@ export default function CropAdvancedPanel( {
 				width: state.image.naturalWidth,
 				height: state.image.naturalHeight,
 			};
+
+			// When an aspect ratio is locked, derive the paired dimension so
+			// both stay consistent. enforceContainment will clamp the result
+			// if it falls outside the valid crop bounds.
+			let newWidth = field === 'width' ? clamped : pixels.width;
+			let newHeight = field === 'height' ? clamped : pixels.height;
+			if ( aspectRatio && aspectRatio > 0 ) {
+				if ( field === 'width' ) {
+					newHeight = Math.max(
+						1,
+						Math.round( clamped / aspectRatio )
+					);
+				} else if ( field === 'height' ) {
+					newWidth = Math.max(
+						1,
+						Math.round( clamped * aspectRatio )
+					);
+				}
+			}
+
 			setCropRect(
 				pixelsToCropRect(
 					{
 						x: field === 'x' ? clamped : pixels.x,
 						y: field === 'y' ? clamped : pixels.y,
-						width: field === 'width' ? clamped : pixels.width,
-						height: field === 'height' ? clamped : pixels.height,
+						width: newWidth,
+						height: newHeight,
 					},
 					state,
 					imageSize
@@ -156,9 +200,9 @@ export default function CropAdvancedPanel( {
 							label={ __( 'Left' ) }
 							aria-label={ __( 'Crop left position' ) }
 							value={ pixels.x }
-							min={ 0 }
-							max={ Math.max( 0, snapW - pixels.width ) }
-							onCommit={ handleCommit( 'x' ) }
+							min={ minLeft }
+							max={ Math.max( minLeft, maxRight - pixels.width ) }
+							onCommit={ handleApply( 'x' ) }
 						/>
 					</FlexItem>
 					<FlexItem isBlock>
@@ -166,9 +210,12 @@ export default function CropAdvancedPanel( {
 							label={ __( 'Top' ) }
 							aria-label={ __( 'Crop top position' ) }
 							value={ pixels.y }
-							min={ 0 }
-							max={ Math.max( 0, snapH - pixels.height ) }
-							onCommit={ handleCommit( 'y' ) }
+							min={ minTop }
+							max={ Math.max(
+								minTop,
+								maxBottom - pixels.height
+							) }
+							onCommit={ handleApply( 'y' ) }
 						/>
 					</FlexItem>
 				</Flex>
@@ -178,8 +225,8 @@ export default function CropAdvancedPanel( {
 							label={ __( 'Width' ) }
 							value={ pixels.width }
 							min={ 1 }
-							max={ Math.max( 1, snapW - pixels.x ) }
-							onCommit={ handleCommit( 'width' ) }
+							max={ Math.max( 1, maxRight - pixels.x ) }
+							onCommit={ handleApply( 'width' ) }
 						/>
 					</FlexItem>
 					<FlexItem isBlock>
@@ -187,8 +234,8 @@ export default function CropAdvancedPanel( {
 							label={ __( 'Height' ) }
 							value={ pixels.height }
 							min={ 1 }
-							max={ Math.max( 1, snapH - pixels.y ) }
-							onCommit={ handleCommit( 'height' ) }
+							max={ Math.max( 1, maxBottom - pixels.y ) }
+							onCommit={ handleApply( 'height' ) }
 						/>
 					</FlexItem>
 				</Flex>

--- a/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
@@ -8,7 +8,7 @@ import {
 	FlexItem,
 	PanelBody,
 } from '@wordpress/components';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Stack } from '@wordpress/ui';
 
@@ -21,6 +21,9 @@ import { getCropPixels, pixelsToCropRect } from '../../utils/crop-pixels';
 interface CropAdvancedPanelProps {
 	onPlacementControlInteraction?: () => void;
 }
+
+type Field = 'x' | 'y' | 'width' | 'height';
+type Drafts = Record< Field, string >;
 
 const pxSuffix = <InputControlSuffixWrapper>px</InputControlSuffixWrapper>;
 
@@ -48,38 +51,94 @@ export default function CropAdvancedPanel( {
 		};
 	}, [ state ] );
 
+	// Which field is actively focused. Used to switch between showing the
+	// user's draft (free typing) and the committed pixel value from state.
+	const [ focusedField, setFocusedField ] = useState< Field | null >( null );
+
+	// The typed string value for the focused field. Only consulted when the
+	// field is focused — otherwise the display derives from pixels directly,
+	// so it stays in sync with canvas-driven changes at no extra cost.
+	const [ drafts, setDrafts ] = useState< Drafts >( {
+		x: '',
+		y: '',
+		width: '',
+		height: '',
+	} );
+
 	if ( ! pixels ) {
 		return null;
 	}
 
-	const { x, y, width, height, snapW, snapH } = pixels;
+	const { snapW, snapH } = pixels;
 
-	const handleChange =
-		( field: 'x' | 'y' | 'width' | 'height' ) =>
-		( nextValue: string | undefined ) => {
-			const parsed = parseInt( nextValue ?? '', 10 );
-			if ( isNaN( parsed ) || ! state.image ) {
-				return;
+	// Returns the value to show in each input. While focused: the raw typed
+	// draft. While not focused: the committed pixel value (always current).
+	const displayValue = ( field: Field ): string =>
+		focusedField === field ? drafts[ field ] : String( pixels[ field ] );
+
+	const handleFocus = ( field: Field ) => () => {
+		setFocusedField( field );
+		// Seed the draft with the current committed value so the user sees the
+		// right starting point before they begin typing.
+		setDrafts( ( prev ) => ( {
+			...prev,
+			[ field ]: String( pixels[ field ] ),
+		} ) );
+	};
+
+	const handleChange = ( field: Field ) => ( v: string | undefined ) => {
+		// Always update the draft so the input shows what the user typed.
+		setDrafts( ( prev ) => ( { ...prev, [ field ]: v ?? '' } ) );
+
+		const parsed = parseInt( v ?? '', 10 );
+		if ( isNaN( parsed ) || ! state.image ) {
+			return;
+		}
+
+		// Clamp to valid bounds for a best-effort live update. enforceContainment
+		// in the reducer is the authoritative constraint and will catch anything
+		// we miss here, so the cropper never ends up in an invalid state.
+		const clamped = {
+			x:
+				field === 'x'
+					? Math.max( 0, Math.min( parsed, snapW - pixels.width ) )
+					: pixels.x,
+			y:
+				field === 'y'
+					? Math.max( 0, Math.min( parsed, snapH - pixels.height ) )
+					: pixels.y,
+			width:
+				field === 'width'
+					? Math.max( 1, Math.min( parsed, snapW - pixels.x ) )
+					: pixels.width,
+			height:
+				field === 'height'
+					? Math.max( 1, Math.min( parsed, snapH - pixels.y ) )
+					: pixels.height,
+		};
+
+		const imageSize = {
+			width: state.image.naturalWidth,
+			height: state.image.naturalHeight,
+		};
+
+		setCropRect( pixelsToCropRect( clamped, state, imageSize ) );
+		onPlacementControlInteraction?.();
+	};
+
+	const handleBlur = ( field: Field ) => () => {
+		// Clear the focused field — displayValue switches to pixels[field],
+		// which reflects the enforced value after the last onChange commit.
+		setFocusedField( ( prev ) => ( prev === field ? null : prev ) );
+	};
+
+	const handleKeyDown =
+		( field: Field ) =>
+		( event: React.KeyboardEvent< HTMLInputElement > ) => {
+			if ( event.key === 'Enter' || event.key === 'Escape' ) {
+				setFocusedField( ( prev ) => ( prev === field ? null : prev ) );
+				event.currentTarget.blur();
 			}
-
-			const imageSize = {
-				width: state.image.naturalWidth,
-				height: state.image.naturalHeight,
-			};
-
-			const newRect = pixelsToCropRect(
-				{
-					x: field === 'x' ? parsed : x,
-					y: field === 'y' ? parsed : y,
-					width: field === 'width' ? parsed : width,
-					height: field === 'height' ? parsed : height,
-				},
-				state,
-				imageSize
-			);
-
-			setCropRect( newRect );
-			onPlacementControlInteraction?.();
 		};
 
 	return (
@@ -95,11 +154,14 @@ export default function CropAdvancedPanel( {
 							__next40pxDefaultSize
 							label={ __( 'Left' ) }
 							aria-label={ __( 'Crop left position' ) }
-							value={ x }
+							value={ displayValue( 'x' ) }
 							min={ 0 }
-							max={ Math.max( 0, snapW - width ) }
+							max={ Math.max( 0, snapW - pixels.width ) }
 							step={ 1 }
 							onChange={ handleChange( 'x' ) }
+							onFocus={ handleFocus( 'x' ) }
+							onBlur={ handleBlur( 'x' ) }
+							onKeyDown={ handleKeyDown( 'x' ) }
 							suffix={ pxSuffix }
 						/>
 					</FlexItem>
@@ -108,11 +170,14 @@ export default function CropAdvancedPanel( {
 							__next40pxDefaultSize
 							label={ __( 'Top' ) }
 							aria-label={ __( 'Crop top position' ) }
-							value={ y }
+							value={ displayValue( 'y' ) }
 							min={ 0 }
-							max={ Math.max( 0, snapH - height ) }
+							max={ Math.max( 0, snapH - pixels.height ) }
 							step={ 1 }
 							onChange={ handleChange( 'y' ) }
+							onFocus={ handleFocus( 'y' ) }
+							onBlur={ handleBlur( 'y' ) }
+							onKeyDown={ handleKeyDown( 'y' ) }
 							suffix={ pxSuffix }
 						/>
 					</FlexItem>
@@ -122,11 +187,14 @@ export default function CropAdvancedPanel( {
 						<NumberControl
 							__next40pxDefaultSize
 							label={ __( 'Width' ) }
-							value={ width }
+							value={ displayValue( 'width' ) }
 							min={ 1 }
-							max={ Math.max( 1, snapW - x ) }
+							max={ Math.max( 1, snapW - pixels.x ) }
 							step={ 1 }
 							onChange={ handleChange( 'width' ) }
+							onFocus={ handleFocus( 'width' ) }
+							onBlur={ handleBlur( 'width' ) }
+							onKeyDown={ handleKeyDown( 'width' ) }
 							suffix={ pxSuffix }
 						/>
 					</FlexItem>
@@ -134,11 +202,14 @@ export default function CropAdvancedPanel( {
 						<NumberControl
 							__next40pxDefaultSize
 							label={ __( 'Height' ) }
-							value={ height }
+							value={ displayValue( 'height' ) }
 							min={ 1 }
-							max={ Math.max( 1, snapH - y ) }
+							max={ Math.max( 1, snapH - pixels.y ) }
 							step={ 1 }
 							onChange={ handleChange( 'height' ) }
+							onFocus={ handleFocus( 'height' ) }
+							onBlur={ handleBlur( 'height' ) }
+							onKeyDown={ handleKeyDown( 'height' ) }
 							suffix={ pxSuffix }
 						/>
 					</FlexItem>

--- a/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
@@ -130,8 +130,8 @@ export default function CropAdvancedPanel( {
 			y: Math.round( raw.y ),
 			width: Math.round( raw.width ),
 			height: Math.round( raw.height ),
-			minLeft: Math.max( 0, Math.floor( reach.minLeft ) ),
-			minTop: Math.max( 0, Math.floor( reach.minTop ) ),
+			minLeft: Math.max( 0, Math.floor( reach.minLeft - 0.5 ) ),
+			minTop: Math.max( 0, Math.floor( reach.minTop - 0.5 ) ),
 			maxRight: Math.floor( reach.maxRight ),
 			maxBottom: Math.floor( reach.maxBottom ),
 		};

--- a/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
@@ -16,6 +16,7 @@ import { Stack } from '@wordpress/ui';
  * Internal dependencies
  */
 import { useCropper } from '../../image-editor';
+import { useCropGestureHandlers } from '../../hooks/use-crop-gesture-handlers';
 import {
 	getCropPixels,
 	getReachableCropBoundsInPixels,
@@ -114,6 +115,7 @@ export default function CropAdvancedPanel( {
 	onPlacementControlInteraction,
 }: CropAdvancedPanelProps ) {
 	const { state, setCropRect } = useCropper();
+	const gestureHandlers = useCropGestureHandlers();
 
 	const pixels = useMemo( () => {
 		if ( ! state.image ) {
@@ -193,53 +195,58 @@ export default function CropAdvancedPanel( {
 			initialOpen={ false }
 			className="media-editor-crop-advanced-panel"
 		>
-			<Stack direction="column" gap="sm">
-				<Flex gap={ 2 } align="flex-start">
-					<FlexItem isBlock>
-						<CropInput
-							label={ __( 'Left' ) }
-							aria-label={ __( 'Crop left position' ) }
-							value={ pixels.x }
-							min={ minLeft }
-							max={ Math.max( minLeft, maxRight - pixels.width ) }
-							onCommit={ handleApply( 'x' ) }
-						/>
-					</FlexItem>
-					<FlexItem isBlock>
-						<CropInput
-							label={ __( 'Top' ) }
-							aria-label={ __( 'Crop top position' ) }
-							value={ pixels.y }
-							min={ minTop }
-							max={ Math.max(
-								minTop,
-								maxBottom - pixels.height
-							) }
-							onCommit={ handleApply( 'y' ) }
-						/>
-					</FlexItem>
-				</Flex>
-				<Flex gap={ 2 } align="flex-start">
-					<FlexItem isBlock>
-						<CropInput
-							label={ __( 'Width' ) }
-							value={ pixels.width }
-							min={ 1 }
-							max={ Math.max( 1, maxRight - pixels.x ) }
-							onCommit={ handleApply( 'width' ) }
-						/>
-					</FlexItem>
-					<FlexItem isBlock>
-						<CropInput
-							label={ __( 'Height' ) }
-							value={ pixels.height }
-							min={ 1 }
-							max={ Math.max( 1, maxBottom - pixels.y ) }
-							onCommit={ handleApply( 'height' ) }
-						/>
-					</FlexItem>
-				</Flex>
-			</Stack>
+			<div role="presentation" { ...gestureHandlers }>
+				<Stack direction="column" gap="sm">
+					<Flex gap={ 2 } align="flex-start">
+						<FlexItem isBlock>
+							<CropInput
+								label={ __( 'Left' ) }
+								aria-label={ __( 'Crop left position' ) }
+								value={ pixels.x }
+								min={ minLeft }
+								max={ Math.max(
+									minLeft,
+									maxRight - pixels.width
+								) }
+								onCommit={ handleApply( 'x' ) }
+							/>
+						</FlexItem>
+						<FlexItem isBlock>
+							<CropInput
+								label={ __( 'Top' ) }
+								aria-label={ __( 'Crop top position' ) }
+								value={ pixels.y }
+								min={ minTop }
+								max={ Math.max(
+									minTop,
+									maxBottom - pixels.height
+								) }
+								onCommit={ handleApply( 'y' ) }
+							/>
+						</FlexItem>
+					</Flex>
+					<Flex gap={ 2 } align="flex-start">
+						<FlexItem isBlock>
+							<CropInput
+								label={ __( 'Width' ) }
+								value={ pixels.width }
+								min={ 1 }
+								max={ Math.max( 1, maxRight - pixels.x ) }
+								onCommit={ handleApply( 'width' ) }
+							/>
+						</FlexItem>
+						<FlexItem isBlock>
+							<CropInput
+								label={ __( 'Height' ) }
+								value={ pixels.height }
+								min={ 1 }
+								max={ Math.max( 1, maxBottom - pixels.y ) }
+								onCommit={ handleApply( 'height' ) }
+							/>
+						</FlexItem>
+					</Flex>
+				</Stack>
+			</div>
 		</PanelBody>
 	);
 }

--- a/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
@@ -1,0 +1,149 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
+	__experimentalNumberControl as NumberControl,
+	Flex,
+	FlexItem,
+	PanelBody,
+} from '@wordpress/components';
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import { useCropper } from '../../image-editor';
+import { getCropPixels, pixelsToCropRect } from '../../utils/crop-pixels';
+
+interface CropAdvancedPanelProps {
+	onPlacementControlInteraction?: () => void;
+}
+
+const pxSuffix = <InputControlSuffixWrapper>px</InputControlSuffixWrapper>;
+
+export default function CropAdvancedPanel( {
+	onPlacementControlInteraction,
+}: CropAdvancedPanelProps ) {
+	const { state, setCropRect } = useCropper();
+
+	const pixels = useMemo( () => {
+		if ( ! state.image ) {
+			return null;
+		}
+		const imageSize = {
+			width: state.image.naturalWidth,
+			height: state.image.naturalHeight,
+		};
+		const raw = getCropPixels( state, imageSize );
+		return {
+			x: Math.round( raw.x ),
+			y: Math.round( raw.y ),
+			width: Math.round( raw.width ),
+			height: Math.round( raw.height ),
+			snapW: Math.round( raw.snapBBoxWidth ),
+			snapH: Math.round( raw.snapBBoxHeight ),
+		};
+	}, [ state ] );
+
+	if ( ! pixels ) {
+		return null;
+	}
+
+	const { x, y, width, height, snapW, snapH } = pixels;
+
+	const handleChange =
+		( field: 'x' | 'y' | 'width' | 'height' ) =>
+		( nextValue: string | undefined ) => {
+			const parsed = parseInt( nextValue ?? '', 10 );
+			if ( isNaN( parsed ) || ! state.image ) {
+				return;
+			}
+
+			const imageSize = {
+				width: state.image.naturalWidth,
+				height: state.image.naturalHeight,
+			};
+
+			const newRect = pixelsToCropRect(
+				{
+					x: field === 'x' ? parsed : x,
+					y: field === 'y' ? parsed : y,
+					width: field === 'width' ? parsed : width,
+					height: field === 'height' ? parsed : height,
+				},
+				state,
+				imageSize
+			);
+
+			setCropRect( newRect );
+			onPlacementControlInteraction?.();
+		};
+
+	return (
+		<PanelBody
+			title={ __( 'Advanced' ) }
+			initialOpen={ false }
+			className="media-editor-crop-advanced-panel"
+		>
+			<Stack direction="column" gap="sm">
+				<Flex gap={ 2 } align="flex-start">
+					<FlexItem isBlock>
+						<NumberControl
+							__next40pxDefaultSize
+							label="X"
+							aria-label={ __( 'Horizontal position' ) }
+							value={ x }
+							min={ 0 }
+							max={ Math.max( 0, snapW - width ) }
+							step={ 1 }
+							onChange={ handleChange( 'x' ) }
+							suffix={ pxSuffix }
+						/>
+					</FlexItem>
+					<FlexItem isBlock>
+						<NumberControl
+							__next40pxDefaultSize
+							label="Y"
+							aria-label={ __( 'Vertical position' ) }
+							value={ y }
+							min={ 0 }
+							max={ Math.max( 0, snapH - height ) }
+							step={ 1 }
+							onChange={ handleChange( 'y' ) }
+							suffix={ pxSuffix }
+						/>
+					</FlexItem>
+				</Flex>
+				<Flex gap={ 2 } align="flex-start">
+					<FlexItem isBlock>
+						<NumberControl
+							__next40pxDefaultSize
+							label={ __( 'Width' ) }
+							value={ width }
+							min={ 1 }
+							max={ Math.max( 1, snapW - x ) }
+							step={ 1 }
+							onChange={ handleChange( 'width' ) }
+							suffix={ pxSuffix }
+						/>
+					</FlexItem>
+					<FlexItem isBlock>
+						<NumberControl
+							__next40pxDefaultSize
+							label={ __( 'Height' ) }
+							value={ height }
+							min={ 1 }
+							max={ Math.max( 1, snapH - y ) }
+							step={ 1 }
+							onChange={ handleChange( 'height' ) }
+							suffix={ pxSuffix }
+						/>
+					</FlexItem>
+				</Flex>
+			</Stack>
+		</PanelBody>
+	);
+}

--- a/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
@@ -93,8 +93,8 @@ export default function CropAdvancedPanel( {
 					<FlexItem isBlock>
 						<NumberControl
 							__next40pxDefaultSize
-							label="X"
-							aria-label={ __( 'Horizontal position' ) }
+							label={ __( 'Left' ) }
+							aria-label={ __( 'Crop left position' ) }
 							value={ x }
 							min={ 0 }
 							max={ Math.max( 0, snapW - width ) }
@@ -106,8 +106,8 @@ export default function CropAdvancedPanel( {
 					<FlexItem isBlock>
 						<NumberControl
 							__next40pxDefaultSize
-							label="Y"
-							aria-label={ __( 'Vertical position' ) }
+							label={ __( 'Top' ) }
+							aria-label={ __( 'Crop top position' ) }
 							value={ y }
 							min={ 0 }
 							max={ Math.max( 0, snapH - height ) }

--- a/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/crop-advanced-panel.tsx
@@ -130,8 +130,8 @@ export default function CropAdvancedPanel( {
 			y: Math.round( raw.y ),
 			width: Math.round( raw.width ),
 			height: Math.round( raw.height ),
-			minLeft: Math.ceil( reach.minLeft ),
-			minTop: Math.ceil( reach.minTop ),
+			minLeft: Math.max( 0, Math.floor( reach.minLeft ) ),
+			minTop: Math.max( 0, Math.floor( reach.minTop ) ),
 			maxRight: Math.floor( reach.maxRight ),
 			maxBottom: Math.floor( reach.maxBottom ),
 		};

--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -92,6 +92,14 @@ export default function MediaEditorCropPanel( {
 }: MediaEditorCropPanelProps ) {
 	const { state, setZoom } = useCropper();
 	const zoomGestureHandlers = useCropGestureHandlers();
+
+	const imageAspectRatio = state.image
+		? state.image.naturalWidth / state.image.naturalHeight
+		: null;
+	const resolvedAspectRatio = resolveAspectRatio(
+		aspectRatioValue,
+		imageAspectRatio
+	);
 	const aspectRatioOptions = [
 		...DEFAULT_ASPECT_RATIOS.filter( ( preset ) => preset.value <= 0 ),
 		...( aspectRatioPresets ??
@@ -145,6 +153,7 @@ export default function MediaEditorCropPanel( {
 				onChange={ onFreeformChange }
 			/>
 			<CropAdvancedPanel
+				aspectRatio={ resolvedAspectRatio }
 				onPlacementControlInteraction={ onPlacementControlInteraction }
 			/>
 		</Stack>

--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -21,6 +21,7 @@ import {
 	ORIGINAL_ASPECT_RATIO,
 } from '../../image-editor/core/constants';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
+import CropAdvancedPanel from './crop-advanced-panel';
 
 export interface MediaEditorCropPanelProps {
 	/**
@@ -142,6 +143,9 @@ export default function MediaEditorCropPanel( {
 				) }
 				checked={ freeformCrop }
 				onChange={ onFreeformChange }
+			/>
+			<CropAdvancedPanel
+				onPlacementControlInteraction={ onPlacementControlInteraction }
 			/>
 		</Stack>
 	);

--- a/packages/media-editor/src/components/media-editor-modal/build-modifiers.ts
+++ b/packages/media-editor/src/components/media-editor-modal/build-modifiers.ts
@@ -3,6 +3,7 @@
  */
 import type { CropperState, Size } from '../../image-editor';
 import { getRotatedBBox } from '../../image-editor/core/camera';
+import { getCropPixels } from '../../utils/crop-pixels';
 
 /**
  * A single modifier in the Core REST `/edit` payload. Order is
@@ -88,7 +89,7 @@ export function buildModifiers(
 		return modifiers;
 	}
 
-	const { cropRect, pan, zoom, flip } = state;
+	const { flip } = state;
 	const hasFlipH = flip.horizontal;
 	const hasFlipV = flip.vertical;
 
@@ -108,27 +109,23 @@ export function buildModifiers(
 		modifiers.push( { type: 'rotate', args: { angle: signedAngle } } );
 	}
 
-	const snapRotation = Math.round( state.rotation / 90 ) * 90;
-	const { width: snapW, height: snapH } = getRotatedBBox(
-		imageSize.width,
-		imageSize.height,
-		snapRotation
-	);
+	// Stencil rect in snap-AABB pixels. Inverts `createExportCamera`'s
+	// pan/zoom composition to recover the pixel rectangle the stencil
+	// framed in that frame.
+	const {
+		x: snapX,
+		y: snapY,
+		width: widthPx,
+		height: heightPx,
+		snapBBoxWidth: snapW,
+		snapBBoxHeight: snapH,
+	} = getCropPixels( state, imageSize );
+
 	const { width: fullW, height: fullH } = getRotatedBBox(
 		imageSize.width,
 		imageSize.height,
 		state.rotation
 	);
-
-	// Stencil rect in snap-AABB pixels. Inverts `createExportCamera`'s
-	// pan/zoom composition to recover the pixel rectangle the stencil
-	// framed in that frame.
-	const imgLeft = 0.5 + pan.x - zoom / 2;
-	const imgTop = 0.5 + pan.y - zoom / 2;
-	const snapX = ( ( cropRect.x - imgLeft ) / zoom ) * snapW;
-	const snapY = ( ( cropRect.y - imgTop ) / zoom ) * snapH;
-	const widthPx = ( cropRect.width / zoom ) * snapW;
-	const heightPx = ( cropRect.height / zoom ) * snapH;
 
 	// Translate to the full AABB (both centered on source).
 	const offsetX = ( fullW - snapW ) / 2;

--- a/packages/media-editor/src/components/media-editor-modal/style.scss
+++ b/packages/media-editor/src/components/media-editor-modal/style.scss
@@ -125,6 +125,28 @@
 	}
 }
 
+// The Advanced panel is a PanelBody nested inside the already-padded
+// `.media-editor-modal__panel`. Pull it flush to the panel edges so the
+// toggle button spans the full width (matching the block inspector's
+// treatment of PanelBody headers), then re-apply horizontal padding inside
+// the content area only.
+.media-editor-crop-advanced-panel.components-panel__body {
+	margin-left: -$grid-unit-20;
+	margin-right: -$grid-unit-20;
+
+	.components-panel__body-title {
+		button.components-panel__body-toggle {
+			padding-left: $grid-unit-20;
+			padding-right: $grid-unit-20;
+		}
+	}
+
+	.components-panel__body-content {
+		padding-left: $grid-unit-20;
+		padding-right: $grid-unit-20;
+	}
+}
+
 // `<SnackbarNotices>` renders `.components-snackbar-list` with
 // `position: absolute; width: 100%`. Portaled to `<body>` it has no
 // positioned ancestor, so it collapses to a 0-size box at the document

--- a/packages/media-editor/src/image-editor/core/state.ts
+++ b/packages/media-editor/src/image-editor/core/state.ts
@@ -5,6 +5,7 @@ import type { CropperAction, CropperState, TransformOperation } from './types';
 import { DEFAULT_STATE, MAX_ZOOM } from './constants';
 import { normalizeRotation, degreesToRadians } from './math/rotation';
 import { restrictPanZoom, restrictCropRect } from './containment';
+import { getRotatedBBox } from './camera';
 
 /** Small tolerance for cropper floating-point comparisons. */
 const STATE_EPSILON = 1e-6;
@@ -369,14 +370,30 @@ export function cropperReducer(
 			// (0.5, 0.5), the pan must place that same content at
 			// the new center. Both pan and zoom scale by s because
 			// the CSS translate is independent of zoom.
+			const rawPanX = ( state.pan.x - oldCx + 0.5 ) * s;
+			const rawPanY = ( state.pan.y - oldCy + 0.5 ) * s;
+
+			// Snap sub-pixel pan drift to zero. A crop whose center lands
+			// within half a pixel of the visual midpoint produces a raw pan
+			// that is less than half a pixel from zero. Keeping that value
+			// would make the image edge appear to be 1 px inside the
+			// container, blocking the user from setting Left/Top to 0 in
+			// the Advanced panel. The snap is invisible (< 0.5 px) but
+			// prevents the bounds minimum from rising above zero.
+			const snapRotation = Math.round( state.rotation / 90 ) * 90;
+			const { width: snapBBoxW, height: snapBBoxH } = getRotatedBBox(
+				state.image.naturalWidth,
+				state.image.naturalHeight,
+				snapRotation
+			);
+			const panX = Math.abs( rawPanX ) < 0.5 / snapBBoxW ? 0 : rawPanX;
+			const panY = Math.abs( rawPanY ) < 0.5 / snapBBoxH ? 0 : rawPanY;
+
 			return commitBase(
 				enforceContainment( {
 					...state,
 					zoom: state.zoom * s,
-					pan: {
-						x: ( state.pan.x - oldCx + 0.5 ) * s,
-						y: ( state.pan.y - oldCy + 0.5 ) * s,
-					},
+					pan: { x: panX, y: panY },
 					cropRect: {
 						x: ( 1 - newW ) / 2,
 						y: ( 1 - newH ) / 2,

--- a/packages/media-editor/src/image-editor/core/test/state.ts
+++ b/packages/media-editor/src/image-editor/core/test/state.ts
@@ -401,6 +401,33 @@ describe( 'cropperReducer — SETTLE_CROP', () => {
 		expect( regionAfter.minY ).toBeCloseTo( regionBefore.minY, 1 );
 	} );
 
+	it( 'snaps sub-pixel pan drift to zero after settle', () => {
+		// A crop whose centre is within half a pixel of the visual midpoint
+		// produces raw pan values below the snap threshold. Without snapping,
+		// those values would raise minLeft / minTop above 0 in the Advanced
+		// panel even though the image is not intentionally panned.
+		//
+		// subPixelOffset is smaller than the 0.5/IMAGE.width threshold, so
+		// the raw pan produced by settle must be snapped to exactly 0.
+		const subPixelOffset = 0.5 / IMAGE.width / 4; // well within threshold
+		const state = makeState( {
+			cropRect: {
+				// crop centre at (0.5 + subPixelOffset, 0.5)
+				x: 0.5 - 0.25 + subPixelOffset,
+				y: 0.25,
+				width: 0.5,
+				height: 0.5,
+			},
+			zoom: 1,
+			pan: { x: 0, y: 0 },
+		} );
+		const settled = cropperReducer( state, { type: 'SETTLE_CROP' } );
+
+		expect( settled.pan.x ).toBe( 0 );
+		// Framing should still be preserved within tolerance.
+		expectSameVisibleRegion( state, settled );
+	} );
+
 	it( 'diagonal drag to very small crop does not over-zoom', () => {
 		// Extreme case: 10% crop. Zoom should be ~10x (or capped at MAX_ZOOM).
 		const afterDrag = enforceContainment(

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -221,9 +221,16 @@ function CropperInner(
 		[ canvasSize, naturalWidth, naturalHeight, state.rotation ]
 	);
 
-	// In fixed-crop mode, auto-size the crop rect when the aspect ratio or
-	// visual size changes. Skipped when transitioning from freeform to fixed
-	// so that a custom crop set in freeform mode is preserved on toggle.
+	// In fixed-crop mode, re-apply the inscribed rect only when the aspect
+	// ratio or visual size changes (i.e. when the shape constraint changes).
+	// The Advanced panel and pan/zoom gestures can freely update the crop
+	// rect in non-freeform mode without triggering a reset.
+	//
+	// state.cropRect is intentionally not a dep: reading it via a ref for
+	// the epsilon check avoids making every Advanced-panel commit re-fire
+	// the effect and undo the user's change.
+	const cropRectRef = useRef( state.cropRect );
+	cropRectRef.current = state.cropRect;
 	const prevFreeformCropRef = useRef( freeformCrop );
 	useEffect( () => {
 		const prevFreeform = prevFreeformCropRef.current;
@@ -241,7 +248,7 @@ function CropperInner(
 			return;
 		}
 		const rect = computeInscribedRect( aspectRatio, visualSize );
-		const current = state.cropRect;
+		const current = cropRectRef.current;
 		if (
 			Math.abs( current.x - rect.x ) < CROP_RECT_EPSILON &&
 			Math.abs( current.y - rect.y ) < CROP_RECT_EPSILON &&
@@ -251,7 +258,7 @@ function CropperInner(
 			return;
 		}
 		setCropRect( rect );
-	}, [ freeformCrop, aspectRatio, visualSize, setCropRect, state.cropRect ] );
+	}, [ freeformCrop, aspectRatio, visualSize, setCropRect ] );
 
 	// In freeform mode, when aspectRatio changes, reshape the crop to the
 	// largest inscribed rect of the new ratio.

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -221,14 +221,23 @@ function CropperInner(
 		[ canvasSize, naturalWidth, naturalHeight, state.rotation ]
 	);
 
-	// In fixed-crop mode, auto-size the crop rect to fill the visual area
-	// while respecting the aspect ratio. The crop is always centered.
+	// In fixed-crop mode, auto-size the crop rect when the aspect ratio or
+	// visual size changes. Skipped when transitioning from freeform to fixed
+	// so that a custom crop set in freeform mode is preserved on toggle.
+	const prevFreeformCropRef = useRef( freeformCrop );
 	useEffect( () => {
+		const prevFreeform = prevFreeformCropRef.current;
+		prevFreeformCropRef.current = freeformCrop;
+
 		if (
 			freeformCrop ||
 			visualSize.width === 0 ||
 			visualSize.height === 0
 		) {
+			return;
+		}
+		// Preserve the crop when the user toggles freeform off.
+		if ( prevFreeform ) {
 			return;
 		}
 		const rect = computeInscribedRect( aspectRatio, visualSize );
@@ -297,6 +306,11 @@ function CropperInner(
 	// preventDefault works. React's onWheel registers as passive. Bound
 	// to the canvas (not the root) so pointer geometry inside the handler
 	// resolves against the canvas box.
+	//
+	// Skip zoom when an input or textarea has focus. The user may be
+	// editing a value in the Advanced panel while their cursor drifts
+	// over the canvas; zooming would change the coordinate context and
+	// make the in-flight draft value incorrect on commit.
 	useEffect( () => {
 		const el = canvasRef.current;
 		if ( ! el ) {
@@ -305,6 +319,11 @@ function CropperInner(
 		const handleWheel = ( event: WheelEvent ) => {
 			if ( isResizingRef.current ) {
 				event.preventDefault();
+				return;
+			}
+			if (
+				el.ownerDocument.activeElement?.matches( 'input, textarea' )
+			) {
 				return;
 			}
 			onWheelNative( event );

--- a/packages/media-editor/src/utils/crop-pixels.ts
+++ b/packages/media-editor/src/utils/crop-pixels.ts
@@ -46,6 +46,16 @@ export function getCropPixels(
 	state: CropperState,
 	imageSize: Size
 ): CropPixels {
+	if ( imageSize.width === 0 || imageSize.height === 0 ) {
+		return {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0,
+			snapBBoxWidth: 0,
+			snapBBoxHeight: 0,
+		};
+	}
 	const { cropRect, pan, zoom, rotation } = state;
 	const snapRotation = Math.round( rotation / 90 ) * 90;
 	const { width: snapBBoxWidth, height: snapBBoxHeight } = getRotatedBBox(

--- a/packages/media-editor/src/utils/crop-pixels.ts
+++ b/packages/media-editor/src/utils/crop-pixels.ts
@@ -1,0 +1,103 @@
+/**
+ * Internal dependencies
+ */
+import type { CropperState, NormalizedRect, Size } from '../image-editor';
+import { getRotatedBBox } from '../image-editor/core/camera';
+
+/**
+ * The crop rectangle expressed as pixel dimensions in the snap-rotation
+ * bounding-box frame. This is the frame the stencil lives in — the same
+ * one `buildModifiers` uses to construct the server crop payload.
+ *
+ * For 0° (and 180°) rotation the snap-AABB equals the source image, so
+ * these values are source pixels. For 90°/270° the axes swap. For
+ * non-snap rotations (e.g. 45°) the snap-AABB is the nearest 90° AABB,
+ * which is how the stencil is positioned.
+ */
+export interface CropPixels {
+	/** X offset of the crop in the snap-rotation bounding box, in pixels. */
+	x: number;
+	/** Y offset of the crop in the snap-rotation bounding box, in pixels. */
+	y: number;
+	/** Width of the crop, in pixels. */
+	width: number;
+	/** Height of the crop, in pixels. */
+	height: number;
+	/** Width of the snap-rotation bounding box, in pixels. */
+	snapBBoxWidth: number;
+	/** Height of the snap-rotation bounding box, in pixels. */
+	snapBBoxHeight: number;
+}
+
+/**
+ * Convert the cropper's normalized cropRect to pixel dimensions in the
+ * snap-rotation bounding-box frame.
+ *
+ * This is the shared math used by `buildModifiers` (to construct the server
+ * crop payload) and by the Advanced crop panel (to display and accept
+ * pixel-value input). Both callers must stay in sync: if the conversion
+ * changes, the server payload and the UI inputs change together.
+ *
+ * @param state     The current cropper state.
+ * @param imageSize Natural dimensions of the source image.
+ * @return Pixel dimensions of the crop in the snap-rotation frame.
+ */
+export function getCropPixels(
+	state: CropperState,
+	imageSize: Size
+): CropPixels {
+	const { cropRect, pan, zoom, rotation } = state;
+	const snapRotation = Math.round( rotation / 90 ) * 90;
+	const { width: snapBBoxWidth, height: snapBBoxHeight } = getRotatedBBox(
+		imageSize.width,
+		imageSize.height,
+		snapRotation
+	);
+	const imgLeft = 0.5 + pan.x - zoom / 2;
+	const imgTop = 0.5 + pan.y - zoom / 2;
+
+	return {
+		x: ( ( cropRect.x - imgLeft ) / zoom ) * snapBBoxWidth,
+		y: ( ( cropRect.y - imgTop ) / zoom ) * snapBBoxHeight,
+		width: ( cropRect.width / zoom ) * snapBBoxWidth,
+		height: ( cropRect.height / zoom ) * snapBBoxHeight,
+		snapBBoxWidth,
+		snapBBoxHeight,
+	};
+}
+
+/**
+ * Convert pixel dimensions in the snap-rotation bounding-box frame back to
+ * a normalized `NormalizedRect`. Exact inverse of `getCropPixels`.
+ *
+ * @param pixels        Crop position and size in snap-rotation pixels.
+ * @param pixels.x      X offset of the crop.
+ * @param pixels.y      Y offset of the crop.
+ * @param pixels.width  Width of the crop.
+ * @param pixels.height Height of the crop.
+ * @param state         The current cropper state (provides zoom, pan, rotation).
+ * @param imageSize     Natural dimensions of the source image.
+ * @return The normalized crop rectangle.
+ */
+export function pixelsToCropRect(
+	pixels: { x: number; y: number; width: number; height: number },
+	state: CropperState,
+	imageSize: Size
+): NormalizedRect {
+	const { pan, zoom, rotation } = state;
+	const snapRotation = Math.round( rotation / 90 ) * 90;
+	const { width: snapBBoxWidth, height: snapBBoxHeight } = getRotatedBBox(
+		imageSize.width,
+		imageSize.height,
+		snapRotation
+	);
+	const imgLeft = 0.5 + pan.x - zoom / 2;
+	const imgTop = 0.5 + pan.y - zoom / 2;
+
+	return {
+		x: ( pixels.x / snapBBoxWidth ) * zoom + imgLeft,
+		y: ( pixels.y / snapBBoxHeight ) * zoom + imgTop,
+		width: ( pixels.width / snapBBoxWidth ) * zoom,
+		height: ( pixels.height / snapBBoxHeight ) * zoom,
+	};
+}

--- a/packages/media-editor/src/utils/crop-pixels.ts
+++ b/packages/media-editor/src/utils/crop-pixels.ts
@@ -2,7 +2,8 @@
  * Internal dependencies
  */
 import type { CropperState, NormalizedRect, Size } from '../image-editor';
-import { getRotatedBBox } from '../image-editor/core/camera';
+import { getImageFit, getRotatedBBox } from '../image-editor/core/camera';
+import { getCropBounds } from '../image-editor/core/containment';
 
 /**
  * The crop rectangle expressed as pixel dimensions in the snap-rotation
@@ -73,6 +74,83 @@ export function getCropPixels(
 		height: ( cropRect.height / zoom ) * snapBBoxHeight,
 		snapBBoxWidth,
 		snapBBoxHeight,
+	};
+}
+
+/**
+ * The reachable pixel bounds for the crop rectangle given the current
+ * zoom, pan, rotation, and flip. Using these as `min`/`max` on the
+ * Advanced panel inputs prevents values that would require unexpected
+ * zoom or pan adjustments to accommodate.
+ *
+ * All values are in the snap-rotation bounding-box frame (same space as
+ * `CropPixels`).
+ */
+export interface ReachableCropPixelBounds {
+	/** Minimum pixel position for the left (x) edge of the crop. */
+	minLeft: number;
+	/** Minimum pixel position for the top (y) edge of the crop. */
+	minTop: number;
+	/** Maximum pixel position for the right edge of the crop (left + width ≤ maxRight). */
+	maxRight: number;
+	/** Maximum pixel position for the bottom edge of the crop (top + height ≤ maxBottom). */
+	maxBottom: number;
+}
+
+/**
+ * Canonical container used for scale-invariant bounds computation.
+ * Same pattern as `restrictPanZoom` in containment.ts.
+ */
+const CANONICAL_CONTAINER: Size = { width: 1000, height: 1000 };
+
+/**
+ * Compute the reachable crop bounds in snap-rotation pixel space, accounting
+ * for the current zoom, pan, rotation, and flip.
+ *
+ * Uses `getCropBounds` with a canonical container (scale-invariant), then
+ * converts the normalized bounds to pixels using the same formula as
+ * `getCropPixels`. This is the answer to "where are the crop boundaries?"
+ * for the Advanced panel inputs.
+ *
+ * @param state     The current cropper state.
+ * @param imageSize Natural dimensions of the source image.
+ * @return Reachable bounds in snap-rotation pixel space.
+ */
+export function getReachableCropBoundsInPixels(
+	state: CropperState,
+	imageSize: Size
+): ReachableCropPixelBounds {
+	if ( imageSize.width === 0 || imageSize.height === 0 ) {
+		return { minLeft: 0, minTop: 0, maxRight: 0, maxBottom: 0 };
+	}
+
+	const { elementSize, visualSize } = getImageFit(
+		CANONICAL_CONTAINER,
+		imageSize,
+		state.rotation
+	);
+	const bounds = getCropBounds(
+		state,
+		elementSize,
+		visualSize,
+		CANONICAL_CONTAINER
+	);
+
+	// Convert normalized bounds to pixels using the same formula as getCropPixels.
+	const snapRotation = Math.round( state.rotation / 90 ) * 90;
+	const { width: snapBBoxWidth, height: snapBBoxHeight } = getRotatedBBox(
+		imageSize.width,
+		imageSize.height,
+		snapRotation
+	);
+	const imgLeft = 0.5 + state.pan.x - state.zoom / 2;
+	const imgTop = 0.5 + state.pan.y - state.zoom / 2;
+
+	return {
+		minLeft: ( ( bounds.minX - imgLeft ) / state.zoom ) * snapBBoxWidth,
+		minTop: ( ( bounds.minY - imgTop ) / state.zoom ) * snapBBoxHeight,
+		maxRight: ( ( bounds.maxX - imgLeft ) / state.zoom ) * snapBBoxWidth,
+		maxBottom: ( ( bounds.maxY - imgTop ) / state.zoom ) * snapBBoxHeight,
 	};
 }
 

--- a/packages/media-editor/src/utils/index.ts
+++ b/packages/media-editor/src/utils/index.ts
@@ -1,2 +1,5 @@
 export { getMediaTypeFromMimeType } from './get-media-type';
 export type { MediaType } from './get-media-type';
+
+export { getCropPixels, pixelsToCropRect } from './crop-pixels';
+export type { CropPixels } from './crop-pixels';

--- a/packages/media-editor/src/utils/index.ts
+++ b/packages/media-editor/src/utils/index.ts
@@ -1,5 +1,9 @@
 export { getMediaTypeFromMimeType } from './get-media-type';
 export type { MediaType } from './get-media-type';
 
-export { getCropPixels, pixelsToCropRect } from './crop-pixels';
-export type { CropPixels } from './crop-pixels';
+export {
+	getCropPixels,
+	getReachableCropBoundsInPixels,
+	pixelsToCropRect,
+} from './crop-pixels';
+export type { CropPixels, ReachableCropPixelBounds } from './crop-pixels';

--- a/packages/media-editor/src/utils/test/crop-pixels.test.ts
+++ b/packages/media-editor/src/utils/test/crop-pixels.test.ts
@@ -1,0 +1,222 @@
+/**
+ * getCropPixels / pixelsToCropRect
+ *
+ * WHAT THESE TESTS GUARANTEE
+ *
+ * 1. Known-value: for a fully-specified cropper state the pixel values must
+ *    equal the hand-computed expected result (guards against future formula
+ *    drift).
+ *
+ * 2. Round-trip: pixelsToCropRect( getCropPixels( state, img ), state, img )
+ *    must reproduce state.cropRect exactly (within float epsilon). If either
+ *    function drifts, the advanced panel inputs will silently shift the crop
+ *    on commit.
+ *
+ * 3. buildModifiers parity: the widthPx / heightPx that getCropPixels returns
+ *    must equal the pixel dimensions computed by the inline math inside
+ *    buildModifiers for the same state. This keeps the UI inputs and the
+ *    server payload in lock-step — if they disagree the user sees one size
+ *    on-screen but crops to a different size on save.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_STATE } from '../../image-editor/core/constants';
+import type { CropperState, Size } from '../../image-editor/core/types';
+import { buildModifiers } from '../../components/media-editor-modal/build-modifiers';
+import { getCropPixels, pixelsToCropRect } from '../crop-pixels';
+
+const IMAGE: Size = { width: 1600, height: 900 };
+
+function makeState( overrides: Partial< CropperState > = {} ): CropperState {
+	return {
+		...DEFAULT_STATE,
+		image: {
+			src: 'test.jpg',
+			naturalWidth: IMAGE.width,
+			naturalHeight: IMAGE.height,
+		},
+		...overrides,
+	};
+}
+
+// ─── Known-value cases ───────────────────────────────────────────────────────
+
+describe( 'getCropPixels – known values', () => {
+	it( 'identity state: full image at zoom 1', () => {
+		const state = makeState();
+		const px = getCropPixels( state, IMAGE );
+		expect( px.x ).toBeCloseTo( 0 );
+		expect( px.y ).toBeCloseTo( 0 );
+		expect( px.width ).toBeCloseTo( IMAGE.width );
+		expect( px.height ).toBeCloseTo( IMAGE.height );
+		expect( px.snapBBoxWidth ).toBeCloseTo( IMAGE.width );
+		expect( px.snapBBoxHeight ).toBeCloseTo( IMAGE.height );
+	} );
+
+	it( 'centered 50% crop at zoom 1', () => {
+		const state = makeState( {
+			cropRect: { x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+		} );
+		const px = getCropPixels( state, IMAGE );
+		expect( px.x ).toBeCloseTo( IMAGE.width * 0.25 );
+		expect( px.y ).toBeCloseTo( IMAGE.height * 0.25 );
+		expect( px.width ).toBeCloseTo( IMAGE.width * 0.5 );
+		expect( px.height ).toBeCloseTo( IMAGE.height * 0.5 );
+	} );
+
+	it( 'zoom 2 full-crop: snap-AABB is still source size, crop is half the image', () => {
+		const state = makeState( { zoom: 2 } );
+		// imgLeft = 0.5 + 0 - 2/2 = -0.5; cropRect.x = 0 → snapX = (0 - (-0.5)) / 2 * W = W/4
+		const px = getCropPixels( state, IMAGE );
+		expect( px.x ).toBeCloseTo( IMAGE.width * 0.25 );
+		expect( px.y ).toBeCloseTo( IMAGE.height * 0.25 );
+		expect( px.width ).toBeCloseTo( IMAGE.width * 0.5 );
+		expect( px.height ).toBeCloseTo( IMAGE.height * 0.5 );
+		// snapBBox is still the source image at 0° rotation.
+		expect( px.snapBBoxWidth ).toBeCloseTo( IMAGE.width );
+		expect( px.snapBBoxHeight ).toBeCloseTo( IMAGE.height );
+	} );
+
+	it( '90° rotation: snap-AABB axes are swapped', () => {
+		const state = makeState( { rotation: 90 } );
+		const px = getCropPixels( state, IMAGE );
+		// After 90° the snap-AABB is H×W (height becomes width).
+		expect( px.snapBBoxWidth ).toBeCloseTo( IMAGE.height );
+		expect( px.snapBBoxHeight ).toBeCloseTo( IMAGE.width );
+	} );
+
+	it( 'non-zero pan shifts the crop position', () => {
+		// Pan right by 0.1 moves imgLeft right, pushing the crop left in source pixels.
+		const noPan = makeState();
+		const withPan = makeState( { pan: { x: 0.1, y: 0 } } );
+		const pxNoPan = getCropPixels( noPan, IMAGE );
+		const pxWithPan = getCropPixels( withPan, IMAGE );
+		// imgLeft with pan = 0.5 + 0.1 - 0.5 = 0.1; without pan = 0.
+		// snapX = (cropRect.x - imgLeft) / zoom * W = (0 - 0.1) / 1 * W = -0.1 * W (negative = off-image edge, clamped later by setCropRect)
+		// The point is that they differ.
+		expect( pxWithPan.x ).not.toBeCloseTo( pxNoPan.x );
+	} );
+} );
+
+// ─── Round-trip ──────────────────────────────────────────────────────────────
+
+interface RoundTripRow {
+	label: string;
+	state: CropperState;
+}
+
+function buildRoundTripRows(): RoundTripRow[] {
+	const rotations = [ 0, 45, 90, 135, 180, 270 ];
+	const zooms = [ 1, 1.5, 2.5 ];
+	const pans = [
+		{ x: 0, y: 0 },
+		{ x: 0.08, y: -0.05 },
+		{ x: -0.1, y: 0.12 },
+	];
+	const cropRects = [
+		{ x: 0, y: 0, width: 1, height: 1 },
+		{ x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+		{ x: 0.1, y: 0.2, width: 0.45, height: 0.55 },
+	];
+
+	const rows: RoundTripRow[] = [];
+	for ( const rotation of rotations ) {
+		for ( const zoom of zooms ) {
+			for ( const pan of pans ) {
+				for ( const cropRect of cropRects ) {
+					rows.push( {
+						label: `rot=${ rotation } zoom=${ zoom } pan=(${ pan.x },${ pan.y }) crop=(${ cropRect.x },${ cropRect.y },${ cropRect.width },${ cropRect.height })`,
+						state: makeState( { rotation, zoom, pan, cropRect } ),
+					} );
+				}
+			}
+		}
+	}
+	return rows;
+}
+
+describe( 'getCropPixels / pixelsToCropRect round-trip', () => {
+	it.each( buildRoundTripRows() )( '$label', ( { state } ) => {
+		const px = getCropPixels( state, IMAGE );
+		const recovered = pixelsToCropRect( px, state, IMAGE );
+
+		expect( recovered.x ).toBeCloseTo( state.cropRect.x, 10 );
+		expect( recovered.y ).toBeCloseTo( state.cropRect.y, 10 );
+		expect( recovered.width ).toBeCloseTo( state.cropRect.width, 10 );
+		expect( recovered.height ).toBeCloseTo( state.cropRect.height, 10 );
+	} );
+} );
+
+// ─── buildModifiers parity ───────────────────────────────────────────────────
+
+interface ParityRow {
+	label: string;
+	state: CropperState;
+}
+
+function buildParityRows(): ParityRow[] {
+	const rotations = [ 0, 90, 180, 270 ];
+	const zooms = [ 1, 2 ];
+	const cropRects = [
+		{ x: 0, y: 0, width: 1, height: 1 },
+		{ x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+	];
+
+	return rotations.flatMap( ( rotation ) =>
+		zooms.flatMap( ( zoom ) =>
+			cropRects.map( ( cropRect ) => ( {
+				label: `rot=${ rotation } zoom=${ zoom } crop=(${ cropRect.x },${ cropRect.y },${ cropRect.width },${ cropRect.height })`,
+				state: makeState( { rotation, zoom, cropRect } ),
+			} ) )
+		)
+	);
+}
+
+describe( 'getCropPixels / buildModifiers parity', () => {
+	// Full-frame rows produce no crop modifier; split them out so expects
+	// are unconditional (avoids jest/no-conditional-expect).
+	const fullFrameRows = buildParityRows().filter( ( { state } ) => {
+		const mods = buildModifiers( state, IMAGE );
+		return ! mods.find( ( m ) => m.type === 'crop' );
+	} );
+	const croppedRows = buildParityRows().filter( ( { state } ) => {
+		const mods = buildModifiers( state, IMAGE );
+		return !! mods.find( ( m ) => m.type === 'crop' );
+	} );
+
+	it.each( fullFrameRows )( 'full-frame: $label', ( { state } ) => {
+		// No crop modifier means full-frame. getCropPixels should span the
+		// full snap-AABB.
+		const px = getCropPixels( state, IMAGE );
+		expect( px.x ).toBeCloseTo( 0, 5 );
+		expect( px.y ).toBeCloseTo( 0, 5 );
+		expect( px.width ).toBeCloseTo( px.snapBBoxWidth, 5 );
+		expect( px.height ).toBeCloseTo( px.snapBBoxHeight, 5 );
+	} );
+
+	it.each( croppedRows )( 'cropped: $label', ( { state } ) => {
+		const modifiers = buildModifiers( state, IMAGE );
+		const cropModifier = modifiers.find( ( m ) => m.type === 'crop' ) as {
+			type: 'crop';
+			args: { left: number; top: number; width: number; height: number };
+		};
+
+		const px = getCropPixels( state, IMAGE );
+
+		// buildModifiers emits percentages of the *full-rotation* AABB (not
+		// the snap-AABB), so we recover the pixel dimensions it encodes and
+		// compare only width/height — size is frame-independent; position
+		// differs because the two frames have different origins.
+		// At snap-only rotations (0°, 90°, 180°, 270°) snap == full, so
+		// widthPct * snapBBoxWidth / 100 == widthPx directly.
+		const recoveredWidth =
+			( cropModifier.args.width / 100 ) * px.snapBBoxWidth;
+		const recoveredHeight =
+			( cropModifier.args.height / 100 ) * px.snapBBoxHeight;
+
+		expect( px.width ).toBeCloseTo( recoveredWidth, 3 );
+		expect( px.height ).toBeCloseTo( recoveredHeight, 3 );
+	} );
+} );

--- a/packages/media-editor/src/utils/test/crop-pixels.test.ts
+++ b/packages/media-editor/src/utils/test/crop-pixels.test.ts
@@ -25,7 +25,11 @@
 import { DEFAULT_STATE } from '../../image-editor/core/constants';
 import type { CropperState, Size } from '../../image-editor/core/types';
 import { buildModifiers } from '../../components/media-editor-modal/build-modifiers';
-import { getCropPixels, pixelsToCropRect } from '../crop-pixels';
+import {
+	getCropPixels,
+	getReachableCropBoundsInPixels,
+	pixelsToCropRect,
+} from '../crop-pixels';
 
 const IMAGE: Size = { width: 1600, height: 900 };
 
@@ -218,5 +222,127 @@ describe( 'getCropPixels / buildModifiers parity', () => {
 
 		expect( px.width ).toBeCloseTo( recoveredWidth, 3 );
 		expect( px.height ).toBeCloseTo( recoveredHeight, 3 );
+	} );
+} );
+
+// ─── getReachableCropBoundsInPixels ──────────────────────────────────────────
+
+describe( 'getReachableCropBoundsInPixels', () => {
+	it( 'identity state: bounds span the full image', () => {
+		const state = makeState();
+		const bounds = getReachableCropBoundsInPixels( state, IMAGE );
+		// At zoom=1 with no pan, the image fills the stencil exactly.
+		expect( bounds.minLeft ).toBeCloseTo( 0, 0 );
+		expect( bounds.minTop ).toBeCloseTo( 0, 0 );
+		expect( bounds.maxRight ).toBeCloseTo( IMAGE.width, 0 );
+		expect( bounds.maxBottom ).toBeCloseTo( IMAGE.height, 0 );
+	} );
+
+	it( 'zoom=2, pan=0: X bounds cover the centre half of the image width', () => {
+		const state = makeState( { zoom: 2 } );
+		const bounds = getReachableCropBoundsInPixels( state, IMAGE );
+		// The canonical container is square (1000×1000) but the image is landscape
+		// (1600×900), so fitScale is constrained by width. The X axis is exactly
+		// 2× zoomed → centre 50% of the width is reachable.
+		expect( bounds.minLeft ).toBeCloseTo( IMAGE.width * 0.25, 0 );
+		expect( bounds.maxRight ).toBeCloseTo( IMAGE.width * 0.75, 0 );
+		// Y bounds are wider than the centre 50% because the letterbox padding
+		// in a square container extends the reachable range beyond the natural
+		// 25%–75% interval.
+		expect( bounds.minTop ).toBeLessThan( IMAGE.height * 0.25 );
+		expect( bounds.maxBottom ).toBeGreaterThan( IMAGE.height * 0.75 );
+	} );
+
+	it( 'bounds tighten as zoom increases', () => {
+		const z1 = getReachableCropBoundsInPixels(
+			makeState( { zoom: 1 } ),
+			IMAGE
+		);
+		const z2 = getReachableCropBoundsInPixels(
+			makeState( { zoom: 2 } ),
+			IMAGE
+		);
+		const z3 = getReachableCropBoundsInPixels(
+			makeState( { zoom: 3 } ),
+			IMAGE
+		);
+		// Higher zoom → smaller reachable window → tighter bounds.
+		expect( z2.maxRight - z2.minLeft ).toBeLessThan(
+			z1.maxRight - z1.minLeft
+		);
+		expect( z3.maxRight - z3.minLeft ).toBeLessThan(
+			z2.maxRight - z2.minLeft
+		);
+	} );
+
+	it( 'pan shifts the reachable window', () => {
+		const centre = getReachableCropBoundsInPixels(
+			makeState( { zoom: 2 } ),
+			IMAGE
+		);
+		const panRight = getReachableCropBoundsInPixels(
+			makeState( { zoom: 2, pan: { x: 0.1, y: 0 } } ),
+			IMAGE
+		);
+		// Panning right (pan.x > 0) moves the image right in the viewport,
+		// exposing the left portion of the image. The reachable left boundary
+		// therefore shifts to a lower pixel value (closer to the image's left
+		// edge), and the right boundary follows accordingly.
+		expect( panRight.minLeft ).toBeLessThan( centre.minLeft );
+		expect( panRight.maxRight ).toBeLessThan( centre.maxRight );
+	} );
+
+	it( 'current crop pixels always sit within the reachable bounds', () => {
+		const states = [
+			makeState(),
+			makeState( { zoom: 2 } ),
+			makeState( { zoom: 1.5, pan: { x: 0.05, y: -0.05 } } ),
+			makeState( {
+				zoom: 2,
+				cropRect: { x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+			} ),
+		];
+		for ( const state of states ) {
+			const bounds = getReachableCropBoundsInPixels( state, IMAGE );
+			const px = getCropPixels( state, IMAGE );
+			expect( px.x ).toBeGreaterThanOrEqual( bounds.minLeft - 1 );
+			expect( px.y ).toBeGreaterThanOrEqual( bounds.minTop - 1 );
+			expect( px.x + px.width ).toBeLessThanOrEqual(
+				bounds.maxRight + 1
+			);
+			expect( px.y + px.height ).toBeLessThanOrEqual(
+				bounds.maxBottom + 1
+			);
+		}
+	} );
+
+	it( '90° rotation: width and height bounds swap', () => {
+		const state0 = makeState( { rotation: 0 } );
+		const state90 = makeState( { rotation: 90 } );
+		const b0 = getReachableCropBoundsInPixels( state0, IMAGE );
+		const b90 = getReachableCropBoundsInPixels( state90, IMAGE );
+		// After 90° rotation the snap-AABB swaps W and H, so the bounds' ranges swap.
+		expect( b90.maxRight - b90.minLeft ).toBeCloseTo(
+			b0.maxBottom - b0.minTop,
+			0
+		);
+		expect( b90.maxBottom - b90.minTop ).toBeCloseTo(
+			b0.maxRight - b0.minLeft,
+			0
+		);
+	} );
+
+	it( 'returns zero bounds for zero-size image', () => {
+		const state = makeState();
+		const bounds = getReachableCropBoundsInPixels( state, {
+			width: 0,
+			height: 0,
+		} );
+		expect( bounds ).toEqual( {
+			minLeft: 0,
+			minTop: 0,
+			maxRight: 0,
+			maxBottom: 0,
+		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of:

* #73771 

To the Media Editor Modal, add an Advanced Panel with left/top and width/height input fields for granular control over the crop.

## Why?

For both keyboard accessibility and fine-grained technical control over the crop. At the same time, these should be live values (controlled components) that also inform the user of the eventual pixel size of their crop.

## How?

Add the controls, but also add some logic to determine the crop pixels and share it with `buildModifiers`. The reason for consolidation is that we want to make sure that the values we're showing a user match as closely as possible to the actual pixel dimensions of the resulting cropped image.

## Testing Instructions

* Enable the media editor modal experiment
* Add an image to a post and click the Crop button
* Have a play with the cropping tools and the Advanced section, and how changing the crop in the canvas updates the values, and how updating the values affects the canvas. How does it feel?

## Screenshots or screencast <!-- if applicable -->

<img width="1271" height="881" alt="image" src="https://github.com/user-attachments/assets/8f7cdab9-afb6-4fb3-9eb5-04a9aeb2d158" />

## Use of AI Tools

Claude Code