### PR TITLE
Fix: Add Missing Dimension Controls & Limited Customization in Accordion Block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -36,7 +36,7 @@ Wraps the heading and panel in one unit. ([Source](https://github.com/WordPress/
 -	**Category:** design
 -	**Parent:** core/accordion
 -	**Allowed Blocks:** core/accordion-heading, core/accordion-panel
--	**Supports:** color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, margin), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** openByDefault
 
 ## Accordion Panel

--- a/packages/block-library/src/accordion-item/block.json
+++ b/packages/block-library/src/accordion-item/block.json
@@ -16,6 +16,7 @@
 		"interactivity": true,
 		"spacing": {
 			"margin": [ "top", "bottom" ],
+			"padding": [ "top", "bottom" ],
 			"blockGap": true
 		},
 		"__experimentalBorder": {

--- a/packages/block-library/src/accordion-item/block.json
+++ b/packages/block-library/src/accordion-item/block.json
@@ -16,7 +16,7 @@
 		"interactivity": true,
 		"spacing": {
 			"margin": [ "top", "bottom" ],
-			"padding": [ "top", "bottom" ],
+			"padding": true,
 			"blockGap": true
 		},
 		"__experimentalBorder": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/77729

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Add the support for padding on all sides for accordion item.
- See - https://github.com/WordPress/gutenberg/issues/77729, Point 1.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Add `padding: true` to spacing in supports to enable padding dimensions for all sides.
- Resolves point 1 in the issue.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open post/page.
2. Add accordion block.
3. Check accordion item styles -> dimension -> padding.
4. The padding should be present and it should allow to set it for all 4 direction.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1440" height="709" alt="Screenshot 2026-04-29 at 10 31 02 AM" src="https://github.com/user-attachments/assets/035ebfca-0eeb-4afb-b39c-1e8454d03ed9" /> | <img width="1440" height="709" alt="Screenshot 2026-04-29 at 10 30 14 AM" src="https://github.com/user-attachments/assets/e247df36-2e71-4c24-81be-14e04a0c3cb4" /> |

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
- None
