### PR TITLE
Media Editor Modal: Try adding undo/redo for the image cropper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61032,6 +61032,7 @@
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/interface": "file:../interface",
+				"@wordpress/keycodes": "file:../keycodes",
 				"@wordpress/notices": "file:../notices",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/ui": "file:../ui",

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -54,6 +54,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/interface": "file:../interface",
+		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/ui": "file:../ui",

--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -50,6 +50,8 @@ export default function MediaEditorCanvas( {
 				freeformCrop={ freeformCrop }
 				showGrid="interactive"
 				isPlacementActive={ isPlacementActive }
+				onGestureStart={ controller.beginGesture }
+				onGestureEnd={ controller.commitHistory }
 			/>
 		</div>
 	);

--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -50,7 +50,6 @@ export default function MediaEditorCanvas( {
 				freeformCrop={ freeformCrop }
 				showGrid="interactive"
 				isPlacementActive={ isPlacementActive }
-				onGestureStart={ controller.beginGesture }
 				onGestureEnd={ controller.commitHistory }
 			/>
 		</div>

--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -50,6 +50,7 @@ export default function MediaEditorCanvas( {
 				freeformCrop={ freeformCrop }
 				showGrid="interactive"
 				isPlacementActive={ isPlacementActive }
+				onGestureStart={ controller.commitHistory }
 				onGestureEnd={ controller.commitHistory }
 			/>
 		</div>

--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -50,6 +50,9 @@ export default function MediaEditorCanvas( {
 				freeformCrop={ freeformCrop }
 				showGrid="interactive"
 				isPlacementActive={ isPlacementActive }
+				// Flush on gesture start so any pending sidebar interaction
+				// (e.g. zoom slider debounce) is committed as its own undo
+				// step before the canvas gesture begins.
 				onGestureStart={ controller.commitHistory }
 				onGestureEnd={ controller.commitHistory }
 			/>

--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -13,6 +13,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useCropper } from '../../image-editor';
+import { useCropGestureHandlers } from '../../hooks/use-crop-gesture-handlers';
 import {
 	DEFAULT_ASPECT_RATIOS,
 	MAX_ZOOM,
@@ -89,6 +90,7 @@ export default function MediaEditorCropPanel( {
 	aspectRatioPresets,
 }: MediaEditorCropPanelProps ) {
 	const { state, setZoom } = useCropper();
+	const zoomGestureHandlers = useCropGestureHandlers();
 	const aspectRatioOptions = [
 		...DEFAULT_ASPECT_RATIOS.filter( ( preset ) => preset.value <= 0 ),
 		...( aspectRatioPresets ??
@@ -97,27 +99,30 @@ export default function MediaEditorCropPanel( {
 
 	return (
 		<Stack direction="column" gap="md">
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ __( 'Zoom' ) }
-				min={ MIN_ZOOM }
-				max={ MAX_ZOOM }
-				step={ 0.1 }
-				value={ state.zoom }
-				onChange={ ( value ) => {
-					onPlacementControlInteraction?.();
-					setZoom( typeof value === 'number' ? value : MIN_ZOOM );
-				} }
-				renderTooltipContent={ ( value ) => {
-					const zoom = typeof value === 'number' ? value : MIN_ZOOM;
-					return sprintf(
-						/* translators: %d: zoom level as a percentage. */
-						__( '%d%%' ),
-						Math.round( zoom * 100 )
-					);
-				} }
-			/>
+			<div role="presentation" { ...zoomGestureHandlers }>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Zoom' ) }
+					min={ MIN_ZOOM }
+					max={ MAX_ZOOM }
+					step={ 0.1 }
+					value={ state.zoom }
+					onChange={ ( value ) => {
+						onPlacementControlInteraction?.();
+						setZoom( typeof value === 'number' ? value : MIN_ZOOM );
+					} }
+					renderTooltipContent={ ( value ) => {
+						const zoom =
+							typeof value === 'number' ? value : MIN_ZOOM;
+						return sprintf(
+							/* translators: %d: zoom level as a percentage. */
+							__( '%d%%' ),
+							Math.round( zoom * 100 )
+						);
+					} }
+				/>
+			</div>
 			<SelectControl
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -462,6 +462,29 @@ function MediaEditorModalContent( {
 			isDismissible={ false }
 			shouldCloseOnClickOutside={ ! hasChanges && ! isSaving }
 			onKeyDown={ ( event ) => {
+				// Undo / Redo — only when a text input is not focused so
+				// browser-native field undo (Details tab) is preserved.
+				if (
+					( event.metaKey || event.ctrlKey ) &&
+					event.key === 'z' &&
+					isImage
+				) {
+					const target = event.target as HTMLElement;
+					const isTextField =
+						target.tagName === 'INPUT' ||
+						target.tagName === 'TEXTAREA' ||
+						target.isContentEditable;
+					if ( ! isTextField ) {
+						event.preventDefault();
+						if ( event.shiftKey ) {
+							cropper.redo();
+						} else {
+							cropper.undo();
+						}
+						return;
+					}
+				}
+
 				if ( event.code !== 'Escape' && event.key !== 'Escape' ) {
 					return;
 				}

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -24,6 +24,7 @@ import {
 } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { close, drawerRight } from '@wordpress/icons';
+import { isAppleOS, isKeyboardEvent } from '@wordpress/keycodes';
 import { SnackbarNotices, store as noticesStore } from '@wordpress/notices';
 import type { Field } from '@wordpress/dataviews';
 import {
@@ -464,15 +465,15 @@ function MediaEditorModalContent( {
 			shouldCloseOnClickOutside={ ! hasChanges && ! isSaving }
 			onKeyDown={ ( event ) => {
 				// Undo / Redo — skip when a metadata text field is focused
-				// so the browser's native field undo (Details tab) is
+				// so the browser's native field undo/redo (Details tab) is
 				// preserved. Inputs inside a crop control wrapper are
 				// intentionally included — the wrapper's data attribute
 				// signals that custom undo/redo should handle them.
-				if (
-					( event.metaKey || event.ctrlKey ) &&
-					event.key.toLowerCase() === 'z' &&
-					isImage
-				) {
+				const isUndoShortcut = isKeyboardEvent.primary( event, 'z' );
+				const isRedoShortcut =
+					isKeyboardEvent.primaryShift( event, 'z' ) ||
+					( ! isAppleOS() && isKeyboardEvent.primary( event, 'y' ) );
+				if ( ( isUndoShortcut || isRedoShortcut ) && isImage ) {
 					const target = event.target as HTMLElement;
 					const isMetadataField =
 						( target.tagName === 'INPUT' ||
@@ -481,7 +482,7 @@ function MediaEditorModalContent( {
 						! target.closest( `[${ CROP_CONTROL_ATTR }]` );
 					if ( ! isMetadataField ) {
 						event.preventDefault();
-						if ( event.shiftKey ) {
+						if ( isRedoShortcut ) {
 							cropper.redo();
 						} else {
 							cropper.undo();

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -52,6 +52,7 @@ import { unlock } from '../../lock-unlock';
 import { getMediaTypeFromMimeType } from '../../utils';
 import { CropperProvider, useCropper } from '../../image-editor';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
+import { CROP_CONTROL_ATTR } from '../../hooks/use-crop-gesture-handlers';
 import { buildModifiers } from './build-modifiers';
 
 // Details-tab edits the modal bundles into a transformed `/edit` request.
@@ -462,19 +463,23 @@ function MediaEditorModalContent( {
 			isDismissible={ false }
 			shouldCloseOnClickOutside={ ! hasChanges && ! isSaving }
 			onKeyDown={ ( event ) => {
-				// Undo / Redo — only when a text input is not focused so
-				// browser-native field undo (Details tab) is preserved.
+				// Undo / Redo — skip when a metadata text field is focused
+				// so the browser's native field undo (Details tab) is
+				// preserved. Inputs inside a crop control wrapper are
+				// intentionally included — the wrapper's data attribute
+				// signals that custom undo/redo should handle them.
 				if (
 					( event.metaKey || event.ctrlKey ) &&
-					event.key === 'z' &&
+					event.key.toLowerCase() === 'z' &&
 					isImage
 				) {
 					const target = event.target as HTMLElement;
-					const isTextField =
-						target.tagName === 'INPUT' ||
-						target.tagName === 'TEXTAREA' ||
-						target.isContentEditable;
-					if ( ! isTextField ) {
+					const isMetadataField =
+						( target.tagName === 'INPUT' ||
+							target.tagName === 'TEXTAREA' ||
+							target.isContentEditable ) &&
+						! target.closest( `[${ CROP_CONTROL_ATTR }]` );
+					if ( ! isMetadataField ) {
 						event.preventDefault();
 						if ( event.shiftKey ) {
 							cropper.redo();

--- a/packages/media-editor/src/components/media-editor-toolbar/index.tsx
+++ b/packages/media-editor/src/components/media-editor-toolbar/index.tsx
@@ -9,6 +9,8 @@ import {
 	rotateRight,
 	flipHorizontal,
 	flipVertical,
+	undo,
+	redo,
 } from '@wordpress/icons';
 
 /**
@@ -41,8 +43,19 @@ export default function MediaEditorToolbar( {
 	onReset,
 	onPlacementControlInteraction,
 }: MediaEditorToolbarProps ) {
-	const { state, setRotation, setFlip, snapRotate90, reset, isDirty } =
-		useCropper();
+	const {
+		state,
+		setRotation,
+		setFlip,
+		snapRotate90,
+		reset,
+		isDirty,
+		hasUndo,
+		hasRedo,
+		undo: undoCrop,
+		redo: redoCrop,
+		commitHistory,
+	} = useCropper();
 
 	const handleReset = () => {
 		reset();
@@ -84,6 +97,24 @@ export default function MediaEditorToolbar( {
 		>
 			<Button
 				size="compact"
+				icon={ undo }
+				label={ __( 'Undo' ) }
+				showTooltip
+				disabled={ ! hasUndo }
+				accessibleWhenDisabled
+				onClick={ undoCrop }
+			/>
+			<Button
+				size="compact"
+				icon={ redo }
+				label={ __( 'Redo' ) }
+				showTooltip
+				disabled={ ! hasRedo }
+				accessibleWhenDisabled
+				onClick={ redoCrop }
+			/>
+			<Button
+				size="compact"
 				icon={ rotateLeft }
 				label={ __( 'Rotate 90° counter-clockwise' ) }
 				showTooltip
@@ -122,7 +153,13 @@ export default function MediaEditorToolbar( {
 					} )
 				}
 			/>
-			<div className="media-editor-toolbar__rotation-slider">
+			{ /* onPointerUp / onKeyUp reset the gesture flag so the next
+			     drag or keyboard interaction creates a fresh undo entry. */ }
+			<div
+				className="media-editor-toolbar__rotation-slider"
+				onPointerUp={ commitHistory }
+				onKeyUp={ commitHistory }
+			>
 				<RangeControl
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom

--- a/packages/media-editor/src/components/media-editor-toolbar/index.tsx
+++ b/packages/media-editor/src/components/media-editor-toolbar/index.tsx
@@ -4,6 +4,7 @@
 import { Button, RangeControl } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
+import { displayShortcut, isAppleOS } from '@wordpress/keycodes';
 import {
 	rotateLeft,
 	rotateRight,
@@ -101,6 +102,7 @@ export default function MediaEditorToolbar( {
 				icon={ undo }
 				label={ __( 'Undo' ) }
 				showTooltip
+				shortcut={ displayShortcut.primary( 'z' ) }
 				disabled={ ! hasUndo }
 				accessibleWhenDisabled
 				onClick={ undoCrop }
@@ -110,6 +112,11 @@ export default function MediaEditorToolbar( {
 				icon={ redo }
 				label={ __( 'Redo' ) }
 				showTooltip
+				shortcut={
+					isAppleOS()
+						? displayShortcut.primaryShift( 'z' )
+						: displayShortcut.primary( 'y' )
+				}
 				disabled={ ! hasRedo }
 				accessibleWhenDisabled
 				onClick={ redoCrop }

--- a/packages/media-editor/src/components/media-editor-toolbar/index.tsx
+++ b/packages/media-editor/src/components/media-editor-toolbar/index.tsx
@@ -17,6 +17,7 @@ import {
  * Internal dependencies
  */
 import { useCropper } from '../../image-editor';
+import { useCropGestureHandlers } from '../../hooks/use-crop-gesture-handlers';
 import { MAX_ROTATION_OFFSET } from '../../image-editor/core/constants';
 
 export interface MediaEditorToolbarProps {
@@ -54,8 +55,8 @@ export default function MediaEditorToolbar( {
 		hasRedo,
 		undo: undoCrop,
 		redo: redoCrop,
-		commitHistory,
 	} = useCropper();
+	const rotationGestureHandlers = useCropGestureHandlers();
 
 	const handleReset = () => {
 		reset();
@@ -153,13 +154,10 @@ export default function MediaEditorToolbar( {
 					} )
 				}
 			/>
-			{ /* onPointerUp / onKeyUp reset the gesture flag so the next
-			     drag or keyboard interaction creates a fresh undo entry. */ }
 			<div
 				role="presentation"
 				className="media-editor-toolbar__rotation-slider"
-				onPointerUp={ commitHistory }
-				onKeyUp={ commitHistory }
+				{ ...rotationGestureHandlers }
 			>
 				<RangeControl
 					__next40pxDefaultSize

--- a/packages/media-editor/src/components/media-editor-toolbar/index.tsx
+++ b/packages/media-editor/src/components/media-editor-toolbar/index.tsx
@@ -156,6 +156,7 @@ export default function MediaEditorToolbar( {
 			{ /* onPointerUp / onKeyUp reset the gesture flag so the next
 			     drag or keyboard interaction creates a fresh undo entry. */ }
 			<div
+				role="presentation"
 				className="media-editor-toolbar__rotation-slider"
 				onPointerUp={ commitHistory }
 				onKeyUp={ commitHistory }

--- a/packages/media-editor/src/hooks/use-crop-gesture-handlers.ts
+++ b/packages/media-editor/src/hooks/use-crop-gesture-handlers.ts
@@ -14,11 +14,12 @@ export const CROP_CONTROL_ATTR = 'data-crop-control';
 /**
  * Returns event handler props to spread onto a wrapper element around a
  * crop control. Marks the wrapper as a crop control (via `data-crop-control`)
- * and wires up gesture boundaries so each interaction produces a single
- * undo history entry.
+ * so the modal's Cmd+Z handler can identify it, and wires up immediate-flush
+ * signals on pointer-up and key-up so history is committed as soon as the
+ * user releases rather than waiting for the debounce window to expire.
  *
- * `beginGesture` is idempotent — safe to call on every pointerdown/keydown
- * repeat without double-pushing history.
+ * The history entry itself is recorded by the state-change debounce in
+ * `useCropperState` — no explicit gesture-start signal is needed.
  *
  * Usage:
  *   const gestureHandlers = useCropGestureHandlers();
@@ -27,21 +28,10 @@ export const CROP_CONTROL_ATTR = 'data-crop-control';
  *   </div>
  */
 export function useCropGestureHandlers() {
-	const { beginGesture, commitHistory } = useCropper();
+	const { commitHistory } = useCropper();
 	return {
 		[ CROP_CONTROL_ATTR ]: true,
-		onPointerDown: beginGesture,
 		onPointerUp: commitHistory,
-		// Only begin a gesture for keys that change the control value
-		// (arrow keys, etc.). Modifier-only keys and shortcuts like Cmd+Z
-		// must not trigger beginGesture — doing so would push the current
-		// state to history and corrupt the undo stack before the modal's
-		// undo handler has a chance to fire.
-		onKeyDown: ( event: React.KeyboardEvent ) => {
-			if ( ! event.metaKey && ! event.ctrlKey && ! event.altKey ) {
-				beginGesture();
-			}
-		},
 		onKeyUp: commitHistory,
 	};
 }

--- a/packages/media-editor/src/hooks/use-crop-gesture-handlers.ts
+++ b/packages/media-editor/src/hooks/use-crop-gesture-handlers.ts
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies
+ */
+import { useCropper } from '../image-editor';
+
+/**
+ * Data attribute applied to crop control wrappers. The modal's keyboard
+ * shortcut handler uses this to distinguish crop controls (where custom
+ * undo/redo should fire) from metadata text fields (where the browser's
+ * native undo should be preserved).
+ */
+export const CROP_CONTROL_ATTR = 'data-crop-control';
+
+/**
+ * Returns event handler props to spread onto a wrapper element around a
+ * crop control. Marks the wrapper as a crop control (via `data-crop-control`)
+ * and wires up gesture boundaries so each interaction produces a single
+ * undo history entry.
+ *
+ * `beginGesture` is idempotent — safe to call on every pointerdown/keydown
+ * repeat without double-pushing history.
+ *
+ * Usage:
+ *   const gestureHandlers = useCropGestureHandlers();
+ *   <div role="presentation" { ...gestureHandlers }>
+ *     <RangeControl ... />
+ *   </div>
+ */
+export function useCropGestureHandlers() {
+	const { beginGesture, commitHistory } = useCropper();
+	return {
+		[ CROP_CONTROL_ATTR ]: true,
+		onPointerDown: beginGesture,
+		onPointerUp: commitHistory,
+		// Only begin a gesture for keys that change the control value
+		// (arrow keys, etc.). Modifier-only keys and shortcuts like Cmd+Z
+		// must not trigger beginGesture — doing so would push the current
+		// state to history and corrupt the undo stack before the modal's
+		// undo handler has a chance to fire.
+		onKeyDown: ( event: React.KeyboardEvent ) => {
+			if ( ! event.metaKey && ! event.ctrlKey && ! event.altKey ) {
+				beginGesture();
+			}
+		},
+		onKeyUp: commitHistory,
+	};
+}

--- a/packages/media-editor/src/image-editor/core/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/interaction-controller.ts
@@ -731,6 +731,11 @@ export class InteractionController {
 			this.setStatus( { isZooming: false } );
 		}, ZOOM_ANIMATION_DURATION );
 
+		// Double-tap bypasses the normal handleTouchStart gesture path so
+		// onGestureStart/End are never called — fire them here so undo
+		// receives a proper boundary around this discrete zoom action.
+		this.options.onGestureStart?.();
+
 		if ( visSize.width > 0 && visSize.height > 0 ) {
 			const fx = tapX - containerRect.left - containerSize.width / 2;
 			const fy = tapY - containerRect.top - containerSize.height / 2;
@@ -758,6 +763,8 @@ export class InteractionController {
 		} else {
 			this.options.actions.setZoom( targetZoom );
 		}
+
+		this.options.onGestureEnd?.();
 		return true;
 	}
 

--- a/packages/media-editor/src/image-editor/core/state.ts
+++ b/packages/media-editor/src/image-editor/core/state.ts
@@ -6,6 +6,13 @@ import { DEFAULT_STATE, MAX_ZOOM } from './constants';
 import { normalizeRotation, degreesToRadians } from './math/rotation';
 import { restrictPanZoom, restrictCropRect } from './containment';
 
+/** Small tolerance for cropper floating-point comparisons. */
+const STATE_EPSILON = 1e-6;
+
+function nearlyEqual( a: number, b: number ): boolean {
+	return Math.abs( a - b ) < STATE_EPSILON;
+}
+
 /**
  * Translate a pipeline transform operation into the equivalent
  * reducer action. Pipeline ops aren't 1:1 with reducer actions —
@@ -414,15 +421,15 @@ export function isStateDirty(
 	initial: CropperState
 ): boolean {
 	return (
-		current.pan.x !== initial.pan.x ||
-		current.pan.y !== initial.pan.y ||
-		current.zoom !== initial.zoom ||
-		current.rotation !== initial.rotation ||
+		! nearlyEqual( current.pan.x, initial.pan.x ) ||
+		! nearlyEqual( current.pan.y, initial.pan.y ) ||
+		! nearlyEqual( current.zoom, initial.zoom ) ||
+		! nearlyEqual( current.rotation, initial.rotation ) ||
 		current.flip.horizontal !== initial.flip.horizontal ||
 		current.flip.vertical !== initial.flip.vertical ||
-		current.cropRect.x !== initial.cropRect.x ||
-		current.cropRect.y !== initial.cropRect.y ||
-		current.cropRect.width !== initial.cropRect.width ||
-		current.cropRect.height !== initial.cropRect.height
+		! nearlyEqual( current.cropRect.x, initial.cropRect.x ) ||
+		! nearlyEqual( current.cropRect.y, initial.cropRect.y ) ||
+		! nearlyEqual( current.cropRect.width, initial.cropRect.width ) ||
+		! nearlyEqual( current.cropRect.height, initial.cropRect.height )
 	);
 }

--- a/packages/media-editor/src/image-editor/core/test/state.ts
+++ b/packages/media-editor/src/image-editor/core/test/state.ts
@@ -1,6 +1,6 @@
 import type { CropperState, Size } from '../types';
 import { DEFAULT_STATE } from '../constants';
-import { cropperReducer, enforceContainment } from '../state';
+import { cropperReducer, enforceContainment, isStateDirty } from '../state';
 import {
 	createCamera,
 	screenToWorld,
@@ -123,6 +123,26 @@ describe( 'enforceContainment', () => {
 		const enforced = enforceContainment( state );
 		const enforced2 = enforceContainment( enforced );
 		expect( enforced2 ).toBe( enforced );
+	} );
+} );
+
+describe( 'isStateDirty', () => {
+	it( 'ignores floating-point noise from containment math', () => {
+		const initial = makeState();
+		const current = makeState( {
+			pan: { x: initial.pan.x, y: initial.pan.y + 2e-8 },
+		} );
+
+		expect( isStateDirty( current, initial ) ).toBe( false );
+	} );
+
+	it( 'detects visible cropper state changes', () => {
+		const initial = makeState();
+		const current = makeState( {
+			pan: { x: initial.pan.x, y: initial.pan.y + 0.01 },
+		} );
+
+		expect( isStateDirty( current, initial ) ).toBe( true );
 	} );
 } );
 

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
@@ -934,6 +934,29 @@ describe( 'useCropperState', () => {
 			expect( result.current.hasRedo ).toBe( false );
 		} );
 
+		it( 'undo after redo returns to a clean initial state', () => {
+			const { result } = renderHook( () => useCropperState() );
+			act( () => {
+				result.current.setImage( {
+					src: 'test.jpg',
+					naturalWidth: 1000,
+					naturalHeight: 500,
+				} );
+			} );
+			act( () => result.current.snapRotate90( 1 ) );
+			expect( result.current.isDirty ).toBe( true );
+
+			act( () => result.current.undo() );
+			expect( result.current.isDirty ).toBe( false );
+
+			act( () => result.current.redo() );
+			expect( result.current.isDirty ).toBe( true );
+
+			act( () => result.current.undo() );
+			expect( result.current.state.rotation ).toBe( 0 );
+			expect( result.current.isDirty ).toBe( false );
+		} );
+
 		// --- undo/redo with a pending gesture ---
 
 		it( 'undo flushes a pending gesture before undoing', () => {

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
@@ -908,10 +908,8 @@ describe( 'useCropperState', () => {
 
 		it( 'undo restores the previous state and enables redo', () => {
 			const { result } = renderHook( () => useCropperState() );
-			act( () => {
-				result.current.setZoom( 3 );
-				result.current.commitHistory();
-			} );
+			act( () => result.current.setZoom( 3 ) );
+			act( () => result.current.commitHistory() );
 			act( () => result.current.undo() );
 			expect( result.current.state.zoom ).toBe( 1 );
 			expect( result.current.hasUndo ).toBe( false );
@@ -920,10 +918,8 @@ describe( 'useCropperState', () => {
 
 		it( 'redo re-applies the undone state', () => {
 			const { result } = renderHook( () => useCropperState() );
-			act( () => {
-				result.current.setZoom( 3 );
-				result.current.commitHistory();
-			} );
+			act( () => result.current.setZoom( 3 ) );
+			act( () => result.current.commitHistory() );
 			act( () => result.current.undo() );
 			act( () => result.current.redo() );
 			expect( result.current.state.zoom ).toBe( 3 );

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
@@ -857,6 +857,14 @@ describe( 'useCropperState', () => {
 			expect( result.current.hasUndo ).toBe( false );
 		} );
 
+		it( 'does not create a history entry for a no-op round trip', () => {
+			const { result } = renderHook( () => useCropperState() );
+			act( () => result.current.setZoom( 2 ) );
+			act( () => result.current.setZoom( 1 ) );
+			act( () => jest.advanceTimersByTime( DEBOUNCE_MS ) );
+			expect( result.current.hasUndo ).toBe( false );
+		} );
+
 		// --- commitHistory flush ---
 
 		it( 'commitHistory flushes the pending entry immediately', () => {
@@ -966,11 +974,21 @@ describe( 'useCropperState', () => {
 			expect( result.current.hasUndo ).toBe( false );
 		} );
 
-		it( 'reset clears the undo history', () => {
+		it( 'reset is undoable and restores a clean current state', () => {
 			const { result } = renderHook( () => useCropperState() );
 			act( () => result.current.setZoom( 3 ) );
 			act( () => result.current.commitHistory() );
 			expect( result.current.hasUndo ).toBe( true );
+			act( () => result.current.reset() );
+			expect( result.current.state.zoom ).toBe( 1 );
+			expect( result.current.isDirty ).toBe( false );
+			expect( result.current.hasUndo ).toBe( true );
+			act( () => result.current.undo() );
+			expect( result.current.state.zoom ).toBe( 3 );
+		} );
+
+		it( 'reset does not create a history entry when already clean', () => {
+			const { result } = renderHook( () => useCropperState() );
 			act( () => result.current.reset() );
 			expect( result.current.hasUndo ).toBe( false );
 		} );
@@ -992,6 +1010,40 @@ describe( 'useCropperState', () => {
 			// Second undo removes the zoom gesture.
 			act( () => result.current.undo() );
 			expect( result.current.state.zoom ).toBe( 1 );
+		} );
+
+		it( 'settleCrop is grouped into the resize undo step', () => {
+			const { result } = renderHook( () => useCropperState() );
+			act( () => {
+				result.current.setImage( {
+					src: 'test.jpg',
+					naturalWidth: 1000,
+					naturalHeight: 500,
+				} );
+			} );
+			const initialCropRect = result.current.state.cropRect;
+
+			act( () => {
+				result.current.setCropRect( {
+					x: 0.25,
+					y: 0.25,
+					width: 0.5,
+					height: 0.5,
+				} );
+			} );
+			act( () => result.current.settleCrop() );
+			const settledState = result.current.state;
+
+			expect( result.current.hasUndo ).toBe( true );
+			act( () => result.current.undo() );
+			expect( result.current.state.cropRect ).toEqual( initialCropRect );
+			expect( result.current.hasUndo ).toBe( false );
+
+			act( () => result.current.redo() );
+			expect( result.current.state.cropRect ).toEqual(
+				settledState.cropRect
+			);
+			expect( result.current.state.zoom ).toBe( settledState.zoom );
 		} );
 	} );
 

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
@@ -827,6 +827,178 @@ describe( 'useCropperState', () => {
 		} );
 	} );
 
+	describe( 'undo/redo history', () => {
+		const DEBOUNCE_MS = 300;
+
+		beforeEach( () => jest.useFakeTimers() );
+		afterEach( () => jest.useRealTimers() );
+
+		// --- debounce batching ---
+
+		it( 'does not create a history entry before the debounce fires', () => {
+			const { result } = renderHook( () => useCropperState() );
+			act( () => {
+				result.current.setZoom( 3 );
+			} );
+			expect( result.current.hasUndo ).toBe( false );
+		} );
+
+		it( 'creates one history entry after the debounce settles', () => {
+			const { result } = renderHook( () => useCropperState() );
+			act( () => {
+				result.current.setZoom( 2 );
+				result.current.setZoom( 3 );
+				result.current.setZoom( 4 );
+			} );
+			act( () => jest.advanceTimersByTime( DEBOUNCE_MS ) );
+			expect( result.current.hasUndo ).toBe( true );
+			act( () => result.current.undo() );
+			expect( result.current.state.zoom ).toBe( 1 );
+			expect( result.current.hasUndo ).toBe( false );
+		} );
+
+		// --- commitHistory flush ---
+
+		it( 'commitHistory flushes the pending entry immediately', () => {
+			const { result } = renderHook( () => useCropperState() );
+			// Separate act() calls are required: setZoom dispatches a reducer
+			// action that React processes when act() flushes. If commitHistory
+			// runs in the same act(), stateRef.current hasn't updated yet and
+			// the flush sees no change.
+			act( () => result.current.setZoom( 3 ) );
+			act( () => result.current.commitHistory() );
+			expect( result.current.hasUndo ).toBe( true );
+		} );
+
+		it( 'commitHistory is a no-op when state has not changed', () => {
+			const { result } = renderHook( () => useCropperState() );
+			act( () => {
+				result.current.commitHistory();
+			} );
+			expect( result.current.hasUndo ).toBe( false );
+		} );
+
+		// --- discrete actions ---
+
+		it( 'setFlip creates a history entry immediately', () => {
+			const { result } = renderHook( () => useCropperState() );
+			act( () => {
+				result.current.setFlip( { horizontal: true, vertical: false } );
+			} );
+			expect( result.current.hasUndo ).toBe( true );
+		} );
+
+		it( 'snapRotate90 creates a history entry immediately', () => {
+			const { result } = renderHook( () => useCropperState() );
+			act( () => {
+				result.current.snapRotate90( 1 );
+			} );
+			expect( result.current.hasUndo ).toBe( true );
+		} );
+
+		it( 'applyOperation creates a history entry immediately', () => {
+			const { result } = renderHook( () => useCropperState() );
+			act( () => {
+				result.current.applyOperation( { type: 'zoom', factor: 3 } );
+			} );
+			expect( result.current.hasUndo ).toBe( true );
+		} );
+
+		// --- undo / redo round-trip ---
+
+		it( 'undo restores the previous state and enables redo', () => {
+			const { result } = renderHook( () => useCropperState() );
+			act( () => {
+				result.current.setZoom( 3 );
+				result.current.commitHistory();
+			} );
+			act( () => result.current.undo() );
+			expect( result.current.state.zoom ).toBe( 1 );
+			expect( result.current.hasUndo ).toBe( false );
+			expect( result.current.hasRedo ).toBe( true );
+		} );
+
+		it( 'redo re-applies the undone state', () => {
+			const { result } = renderHook( () => useCropperState() );
+			act( () => {
+				result.current.setZoom( 3 );
+				result.current.commitHistory();
+			} );
+			act( () => result.current.undo() );
+			act( () => result.current.redo() );
+			expect( result.current.state.zoom ).toBe( 3 );
+			expect( result.current.hasRedo ).toBe( false );
+		} );
+
+		// --- undo/redo with a pending gesture ---
+
+		it( 'undo flushes a pending gesture before undoing', () => {
+			const { result } = renderHook( () => useCropperState() );
+			// Commit one step, then start a second change without committing.
+			act( () => result.current.setZoom( 3 ) );
+			act( () => result.current.commitHistory() );
+			act( () => result.current.setZoom( 5 ) );
+			// Undo should flush zoom=5 first, then undo back to zoom=3.
+			act( () => result.current.undo() );
+			expect( result.current.state.zoom ).toBe( 3 );
+			expect( result.current.hasRedo ).toBe( true );
+		} );
+
+		it( 'undo with no prior history flushes and undoes the pending gesture', () => {
+			const { result } = renderHook( () => useCropperState() );
+			act( () => {
+				result.current.setZoom( 3 );
+			} );
+			// Undo before the debounce fires — flush saves the change, then
+			// immediately undoes it.
+			act( () => result.current.undo() );
+			expect( result.current.state.zoom ).toBe( 1 );
+		} );
+
+		// --- setImage and reset do not pollute history ---
+
+		it( 'setImage does not create a history entry', () => {
+			const { result } = renderHook( () => useCropperState() );
+			act( () => {
+				result.current.setImage( {
+					src: 'test.jpg',
+					naturalWidth: 100,
+					naturalHeight: 100,
+				} );
+			} );
+			act( () => jest.advanceTimersByTime( DEBOUNCE_MS ) );
+			expect( result.current.hasUndo ).toBe( false );
+		} );
+
+		it( 'reset clears the undo history', () => {
+			const { result } = renderHook( () => useCropperState() );
+			act( () => result.current.setZoom( 3 ) );
+			act( () => result.current.commitHistory() );
+			expect( result.current.hasUndo ).toBe( true );
+			act( () => result.current.reset() );
+			expect( result.current.hasUndo ).toBe( false );
+		} );
+
+		// --- discrete action flushes a concurrent continuous gesture ---
+
+		it( 'discrete action saves the pending gesture as a separate undo step', () => {
+			const { result } = renderHook( () => useCropperState() );
+			act( () => {
+				result.current.setZoom( 3 );
+			} );
+			act( () => {
+				result.current.setFlip( { horizontal: true, vertical: false } );
+			} );
+			// First undo removes the flip.
+			act( () => result.current.undo() );
+			expect( result.current.state.flip.horizontal ).toBe( false );
+			expect( result.current.state.zoom ).toBe( 3 );
+			// Second undo removes the zoom gesture.
+			act( () => result.current.undo() );
+			expect( result.current.state.zoom ).toBe( 1 );
+		} );
+	} );
+
 	describe( 'public controller contract', () => {
 		it( 'does not expose the raw reducer dispatch', () => {
 			const { result } = renderHook( () => useCropperState() );

--- a/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useReducer, useCallback, useRef } from '@wordpress/element';
+import { useReducer, useCallback, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -64,6 +64,26 @@ export interface UseCropperStateReturn {
 	reset: ( resetState?: Partial< CropperState > ) => void;
 	/** Whether the current state differs from the initial state. */
 	isDirty: boolean;
+	/** Whether there is a cropper state to undo. */
+	hasUndo: boolean;
+	/** Whether there is a cropper state to redo. */
+	hasRedo: boolean;
+	/** Undo the last committed cropper operation. */
+	undo: () => void;
+	/** Redo the last undone cropper operation. */
+	redo: () => void;
+	/**
+	 * Mark the start of a continuous gesture (pan drag, pinch zoom, wheel
+	 * zoom). Pushes the current state onto the undo stack the first time it
+	 * is called within a gesture sequence; subsequent calls within the same
+	 * gesture are no-ops. Call `commitHistory` when the gesture ends.
+	 */
+	beginGesture: () => void;
+	/**
+	 * Mark the end of a continuous gesture (e.g. fine-rotation slider
+	 * release) so the next gesture creates a fresh history entry.
+	 */
+	commitHistory: () => void;
 	/**
 	 * Export the cropped image as a Blob. Throws on failure — see
 	 * `exportCroppedImage` in core for the error semantics (image
@@ -100,6 +120,75 @@ export function useCropperState(
 	// (reset, setImage) can read fresh state without re-creating themselves.
 	const stateRef = useRef( state );
 	stateRef.current = state;
+
+	// History stack for undo/redo. Using refs for the arrays avoids
+	// unnecessary re-renders on every push; a pair of boolean state values
+	// drives the enabled/disabled state of the undo/redo buttons.
+	const historyRef = useRef< CropperState[] >( [] );
+	const redoStackRef = useRef< CropperState[] >( [] );
+	const [ hasUndo, setHasUndo ] = useState( false );
+	const [ hasRedo, setHasRedo ] = useState( false );
+
+	// Tracks whether a continuous gesture (e.g. rotation slider drag) is
+	// in progress so we only push one history entry per gesture.
+	const isGestureRef = useRef( false );
+
+	const pushToHistory = useCallback( () => {
+		const current = stateRef.current;
+		// Skip duplicate pushes (e.g. rapid discrete action on unchanged state).
+		if ( historyRef.current[ historyRef.current.length - 1 ] === current ) {
+			return;
+		}
+		historyRef.current = [ ...historyRef.current, current ];
+		redoStackRef.current = [];
+		setHasUndo( true );
+		setHasRedo( false );
+	}, [] );
+
+	const undo = useCallback( () => {
+		const prev = historyRef.current[ historyRef.current.length - 1 ];
+		if ( ! prev ) {
+			return;
+		}
+		redoStackRef.current = [ stateRef.current, ...redoStackRef.current ];
+		historyRef.current = historyRef.current.slice( 0, -1 );
+		isGestureRef.current = false;
+		setHasUndo( historyRef.current.length > 0 );
+		setHasRedo( true );
+		dispatch( { type: 'RESET', payload: prev } );
+	}, [ dispatch ] );
+
+	const redo = useCallback( () => {
+		const next = redoStackRef.current[ 0 ];
+		if ( ! next ) {
+			return;
+		}
+		historyRef.current = [ ...historyRef.current, stateRef.current ];
+		redoStackRef.current = redoStackRef.current.slice( 1 );
+		isGestureRef.current = false;
+		setHasUndo( true );
+		setHasRedo( redoStackRef.current.length > 0 );
+		dispatch( { type: 'RESET', payload: next } );
+	}, [ dispatch ] );
+
+	const beginGesture = useCallback( () => {
+		if ( ! isGestureRef.current ) {
+			isGestureRef.current = true;
+			pushToHistory();
+		}
+	}, [ pushToHistory ] );
+
+	const commitHistory = useCallback( () => {
+		isGestureRef.current = false;
+	}, [] );
+
+	const clearHistory = useCallback( () => {
+		historyRef.current = [];
+		redoStackRef.current = [];
+		isGestureRef.current = false;
+		setHasUndo( false );
+		setHasRedo( false );
+	}, [] );
 
 	const setImage = useCallback(
 		( image: CropperState[ 'image' ] ) => {
@@ -142,26 +231,35 @@ export function useCropperState(
 
 	const setRotation = useCallback(
 		( rotation: number ) => {
+			// The rotation slider fires many onChange events during a single
+			// drag gesture. Only push one history entry at the start of each
+			// gesture; commitHistory() resets the flag on pointer/key release.
+			if ( ! isGestureRef.current ) {
+				isGestureRef.current = true;
+				pushToHistory();
+			}
 			dispatch( { type: 'SET_ROTATION', payload: rotation } );
 		},
-		[ dispatch ]
+		[ dispatch, pushToHistory ]
 	);
 
 	const setFlip = useCallback(
 		( flip: Flip ) => {
+			pushToHistory();
 			dispatch( { type: 'SET_FLIP', payload: flip } );
 		},
-		[ dispatch ]
+		[ dispatch, pushToHistory ]
 	);
 
 	const snapRotate90 = useCallback(
 		( direction: 1 | -1 ) => {
+			pushToHistory();
 			dispatch( {
 				type: 'SNAP_ROTATE_90',
 				payload: { direction },
 			} );
 		},
-		[ dispatch ]
+		[ dispatch, pushToHistory ]
 	);
 
 	const setCropRect = useCallback(
@@ -172,18 +270,21 @@ export function useCropperState(
 	);
 
 	const settleCrop = useCallback( () => {
+		pushToHistory();
 		dispatch( { type: 'SETTLE_CROP' } );
-	}, [ dispatch ] );
+	}, [ dispatch, pushToHistory ] );
 
 	const applyOperation = useCallback(
 		( op: TransformOperation ) => {
+			pushToHistory();
 			dispatch( { type: 'APPLY_OPERATION', payload: op } );
 		},
-		[ dispatch ]
+		[ dispatch, pushToHistory ]
 	);
 
 	const reset = useCallback(
 		( resetState?: Partial< CropperState > ) => {
+			clearHistory();
 			dispatch( { type: 'RESET', payload: resetState } );
 			// Mirror the reducer's RESET exactly so isDirty stays in
 			// sync. RESET preserves the currently-loaded image; the
@@ -196,7 +297,7 @@ export function useCropperState(
 				...resetState,
 			} );
 		},
-		[ dispatch ]
+		[ dispatch, clearHistory ]
 	);
 
 	const isDirty = isStateDirty( state, initialRef.current );
@@ -233,6 +334,12 @@ export function useCropperState(
 		reset,
 		isDirty,
 		getCroppedImage,
+		hasUndo,
+		hasRedo,
+		undo,
+		redo,
+		beginGesture,
+		commitHistory,
 	};
 	return controller;
 }

--- a/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
@@ -104,6 +104,13 @@ export interface UseCropperStateReturn {
 /** Milliseconds of inactivity after which a continuous interaction is committed to history. */
 const HISTORY_DEBOUNCE_MS = 300;
 
+/** Small tolerance for cropper floating-point comparisons. */
+const HISTORY_EPSILON = 1e-6;
+
+function nearlyEqual( a: number, b: number ): boolean {
+	return Math.abs( a - b ) < HISTORY_EPSILON;
+}
+
 function areHistoryStatesEqual( a: CropperState, b: CropperState ): boolean {
 	const aImage = a.image;
 	const bImage = b.image;
@@ -111,16 +118,16 @@ function areHistoryStatesEqual( a: CropperState, b: CropperState ): boolean {
 		aImage?.src === bImage?.src &&
 		aImage?.naturalWidth === bImage?.naturalWidth &&
 		aImage?.naturalHeight === bImage?.naturalHeight &&
-		a.pan.x === b.pan.x &&
-		a.pan.y === b.pan.y &&
-		a.zoom === b.zoom &&
-		a.rotation === b.rotation &&
+		nearlyEqual( a.pan.x, b.pan.x ) &&
+		nearlyEqual( a.pan.y, b.pan.y ) &&
+		nearlyEqual( a.zoom, b.zoom ) &&
+		nearlyEqual( a.rotation, b.rotation ) &&
 		a.flip.horizontal === b.flip.horizontal &&
 		a.flip.vertical === b.flip.vertical &&
-		a.cropRect.x === b.cropRect.x &&
-		a.cropRect.y === b.cropRect.y &&
-		a.cropRect.width === b.cropRect.width &&
-		a.cropRect.height === b.cropRect.height
+		nearlyEqual( a.cropRect.x, b.cropRect.x ) &&
+		nearlyEqual( a.cropRect.y, b.cropRect.y ) &&
+		nearlyEqual( a.cropRect.width, b.cropRect.width ) &&
+		nearlyEqual( a.cropRect.height, b.cropRect.height )
 	);
 }
 

--- a/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
@@ -63,9 +63,8 @@ export interface UseCropperStateReturn {
 	 * available visual area while preserving the framed image region.
 	 * Typically called from a stencil's `onResizeEnd` callback.
 	 *
-	 * History is recorded automatically by the state-change debounce.
-	 * For programmatic crop changes that need an immediate history entry,
-	 * call `commitHistory()` afterwards or use `applyOperation` instead.
+	 * Flushes the pending resize history before dispatching, then suppresses
+	 * the settle dispatch itself so resizing and settling undo as one step.
 	 */
 	settleCrop: () => void;
 	/** Apply a transform operation through the pipeline. */
@@ -104,6 +103,26 @@ export interface UseCropperStateReturn {
 
 /** Milliseconds of inactivity after which a continuous interaction is committed to history. */
 const HISTORY_DEBOUNCE_MS = 300;
+
+function areHistoryStatesEqual( a: CropperState, b: CropperState ): boolean {
+	const aImage = a.image;
+	const bImage = b.image;
+	return (
+		aImage?.src === bImage?.src &&
+		aImage?.naturalWidth === bImage?.naturalWidth &&
+		aImage?.naturalHeight === bImage?.naturalHeight &&
+		a.pan.x === b.pan.x &&
+		a.pan.y === b.pan.y &&
+		a.zoom === b.zoom &&
+		a.rotation === b.rotation &&
+		a.flip.horizontal === b.flip.horizontal &&
+		a.flip.vertical === b.flip.vertical &&
+		a.cropRect.x === b.cropRect.x &&
+		a.cropRect.y === b.cropRect.y &&
+		a.cropRect.width === b.cropRect.width &&
+		a.cropRect.height === b.cropRect.height
+	);
+}
 
 /**
  * Reducer-based state management hook for the image editor.
@@ -149,21 +168,20 @@ export function useCropperState(
 	// Debounce-based history: tracks the last committed state and a pending
 	// timer. Any state change resets the timer; when it expires the
 	// pre-change state is pushed to history.
-	const lastCommittedStateRef = useRef< CropperState | null >( null );
+	const lastCommittedStateRef = useRef< CropperState | null >( state );
 	const debounceTimerRef = useRef< ReturnType< typeof setTimeout > >();
 	// Set to true before dispatching actions that must not produce a debounce
 	// history entry (undo, redo, reset, setImage, discrete actions).
 	const suppressDebounceRef = useRef( false );
-	// Used to sync lastCommittedStateRef to the actual initial state on the
-	// first useEffect run, before any user interaction.
-	const isMountedRef = useRef( false );
 
 	// Pushes `entry` (defaults to current state) onto the undo stack and
 	// clears the redo stack. Skips if `entry` is already the last item,
 	// so rapid discrete actions on unchanged state don't create duplicates.
 	const pushToHistory = useCallback( ( entry?: CropperState ) => {
 		const target = entry ?? stateRef.current;
-		if ( historyRef.current[ historyRef.current.length - 1 ] === target ) {
+		const previousEntry =
+			historyRef.current[ historyRef.current.length - 1 ];
+		if ( previousEntry && areHistoryStatesEqual( previousEntry, target ) ) {
 			return;
 		}
 		historyRef.current = [ ...historyRef.current, target ];
@@ -176,14 +194,6 @@ export function useCropperState(
 	// timer; once the state has settled for HISTORY_DEBOUNCE_MS the
 	// pre-change snapshot is pushed to the undo stack.
 	useEffect( () => {
-		// First run: capture the actual initial state reference from
-		// useReducer (a separate enforceContainment call would give a
-		// different object reference) so the first real change is detected.
-		if ( ! isMountedRef.current ) {
-			isMountedRef.current = true;
-			lastCommittedStateRef.current = stateRef.current;
-			return;
-		}
 		// Suppress flag: undo/redo/reset/setImage/discrete actions set this
 		// to opt out of the debounce for their own state changes.
 		if ( suppressDebounceRef.current ) {
@@ -191,13 +201,26 @@ export function useCropperState(
 			lastCommittedStateRef.current = stateRef.current;
 			return;
 		}
+		if (
+			lastCommittedStateRef.current !== null &&
+			areHistoryStatesEqual(
+				lastCommittedStateRef.current,
+				stateRef.current
+			)
+		) {
+			lastCommittedStateRef.current = stateRef.current;
+			return;
+		}
 		clearTimeout( debounceTimerRef.current );
 		debounceTimerRef.current = setTimeout( () => {
 			const snapshot = lastCommittedStateRef.current;
-			if ( snapshot !== null && snapshot !== stateRef.current ) {
+			if (
+				snapshot !== null &&
+				! areHistoryStatesEqual( snapshot, stateRef.current )
+			) {
 				pushToHistory( snapshot );
-				lastCommittedStateRef.current = stateRef.current;
 			}
+			lastCommittedStateRef.current = stateRef.current;
 		}, HISTORY_DEBOUNCE_MS );
 		return () => clearTimeout( debounceTimerRef.current );
 	}, [ state, pushToHistory ] );
@@ -209,10 +232,13 @@ export function useCropperState(
 	const commitHistory = useCallback( () => {
 		clearTimeout( debounceTimerRef.current );
 		const snapshot = lastCommittedStateRef.current;
-		if ( snapshot !== null && snapshot !== stateRef.current ) {
+		if (
+			snapshot !== null &&
+			! areHistoryStatesEqual( snapshot, stateRef.current )
+		) {
 			pushToHistory( snapshot );
-			lastCommittedStateRef.current = stateRef.current;
 		}
+		lastCommittedStateRef.current = stateRef.current;
 	}, [ pushToHistory ] );
 
 	const undo = useCallback( () => {
@@ -247,14 +273,6 @@ export function useCropperState(
 		setHasRedo( redoStackRef.current.length > 0 );
 		dispatch( { type: 'RESET', payload: next } );
 	}, [ dispatch, commitHistory ] );
-
-	const clearHistory = useCallback( () => {
-		historyRef.current = [];
-		redoStackRef.current = [];
-		clearTimeout( debounceTimerRef.current );
-		setHasUndo( false );
-		setHasRedo( false );
-	}, [] );
 
 	const setImage = useCallback(
 		( image: CropperState[ 'image' ] ) => {
@@ -335,8 +353,10 @@ export function useCropperState(
 	);
 
 	const settleCrop = useCallback( () => {
+		commitHistory();
+		suppressDebounceRef.current = true;
 		dispatch( { type: 'SETTLE_CROP' } );
-	}, [ dispatch ] );
+	}, [ dispatch, commitHistory ] );
 
 	const applyOperation = useCallback(
 		( op: TransformOperation ) => {
@@ -350,7 +370,17 @@ export function useCropperState(
 
 	const reset = useCallback(
 		( resetState?: Partial< CropperState > ) => {
-			clearHistory();
+			commitHistory();
+			const nextInitialState = enforceContainment( {
+				...DEFAULT_STATE,
+				image: stateRef.current.image,
+				...resetState,
+			} );
+			if (
+				! areHistoryStatesEqual( stateRef.current, nextInitialState )
+			) {
+				pushToHistory();
+			}
 			suppressDebounceRef.current = true;
 			dispatch( { type: 'RESET', payload: resetState } );
 			// Mirror the reducer's RESET exactly so isDirty stays in
@@ -358,13 +388,9 @@ export function useCropperState(
 			// containment step can tweak pan/zoom/cropRect by float ulp,
 			// which we must fold into the "initial" snapshot or isDirty
 			// would report true after a reset.
-			initialRef.current = enforceContainment( {
-				...DEFAULT_STATE,
-				image: stateRef.current.image,
-				...resetState,
-			} );
+			initialRef.current = nextInitialState;
 		},
-		[ dispatch, clearHistory ]
+		[ dispatch, pushToHistory, commitHistory ]
 	);
 
 	const isDirty = isStateDirty( state, initialRef.current );

--- a/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
@@ -1,7 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { useReducer, useCallback, useRef, useState } from '@wordpress/element';
+import {
+	useReducer,
+	useCallback,
+	useRef,
+	useState,
+	useEffect,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -56,6 +62,10 @@ export interface UseCropperStateReturn {
 	 * Settle the crop rect after a resize drag: expand to fill the
 	 * available visual area while preserving the framed image region.
 	 * Typically called from a stencil's `onResizeEnd` callback.
+	 *
+	 * History is recorded automatically by the state-change debounce.
+	 * For programmatic crop changes that need an immediate history entry,
+	 * call `commitHistory()` afterwards or use `applyOperation` instead.
 	 */
 	settleCrop: () => void;
 	/** Apply a transform operation through the pipeline. */
@@ -73,15 +83,9 @@ export interface UseCropperStateReturn {
 	/** Redo the last undone cropper operation. */
 	redo: () => void;
 	/**
-	 * Mark the start of a continuous gesture (pan drag, pinch zoom, wheel
-	 * zoom). Pushes the current state onto the undo stack the first time it
-	 * is called within a gesture sequence; subsequent calls within the same
-	 * gesture are no-ops. Call `commitHistory` when the gesture ends.
-	 */
-	beginGesture: () => void;
-	/**
-	 * Mark the end of a continuous gesture (e.g. fine-rotation slider
-	 * release) so the next gesture creates a fresh history entry.
+	 * Flush the pending history entry immediately, bypassing the debounce
+	 * timer. Call this on pointer-up or key-up to give an instant commit
+	 * rather than waiting for the debounce window to expire.
 	 */
 	commitHistory: () => void;
 	/**
@@ -93,6 +97,9 @@ export interface UseCropperStateReturn {
 	getCroppedImage: ( mimeType?: string, quality?: number ) => Promise< Blob >;
 }
 
+/** Milliseconds of inactivity after which a continuous interaction is committed to history. */
+const HISTORY_DEBOUNCE_MS = 300;
+
 /**
  * Reducer-based state management hook for the image editor.
  *
@@ -100,6 +107,11 @@ export interface UseCropperStateReturn {
  * every supported transition. The reducer and containment logic
  * live in core/state.ts (framework-agnostic); this hook is a thin
  * React wrapper around that pure reducer, with memoized callbacks.
+ *
+ * History is recorded via a state-change debounce: any state change
+ * starts a 300 ms timer; when it fires the pre-change state is pushed
+ * onto the undo stack. `commitHistory` flushes the timer immediately
+ * (useful on pointer-up / key-up for a crisp commit feel).
  *
  * @param initialState Optional partial state to merge with DEFAULT_STATE.
  * @return The cropper state, setters, and utilities.
@@ -129,11 +141,17 @@ export function useCropperState(
 	const [ hasUndo, setHasUndo ] = useState( false );
 	const [ hasRedo, setHasRedo ] = useState( false );
 
-	// Tracks whether a continuous gesture (e.g. rotation slider drag) is
-	// in progress so we only push one history entry per gesture.
-	const isGestureRef = useRef( false );
-	// Snapshot of state at gesture start for lazy history push.
-	const gestureSnapshotRef = useRef< CropperState | null >( null );
+	// Debounce-based history: tracks the last committed state and a pending
+	// timer. Any state change resets the timer; when it expires the
+	// pre-change state is pushed to history.
+	const lastCommittedStateRef = useRef< CropperState | null >( null );
+	const debounceTimerRef = useRef< ReturnType< typeof setTimeout > >();
+	// Set to true before dispatching actions that must not produce a debounce
+	// history entry (undo, redo, reset, setImage, discrete actions).
+	const suppressDebounceRef = useRef( false );
+	// Used to sync lastCommittedStateRef to the actual initial state on the
+	// first useEffect run, before any user interaction.
+	const isMountedRef = useRef( false );
 
 	// Pushes `entry` (defaults to current state) onto the undo stack and
 	// clears the redo stack. Skips if `entry` is already the last item,
@@ -149,64 +167,94 @@ export function useCropperState(
 		setHasRedo( false );
 	}, [] );
 
+	// Watch state and debounce history commits. Any dispatch resets the
+	// timer; once the state has settled for HISTORY_DEBOUNCE_MS the
+	// pre-change snapshot is pushed to the undo stack.
+	useEffect( () => {
+		// First run: capture the actual initial state reference from
+		// useReducer (a separate enforceContainment call would give a
+		// different object reference) so the first real change is detected.
+		if ( ! isMountedRef.current ) {
+			isMountedRef.current = true;
+			lastCommittedStateRef.current = stateRef.current;
+			return;
+		}
+		// Suppress flag: undo/redo/reset/setImage/discrete actions set this
+		// to opt out of the debounce for their own state changes.
+		if ( suppressDebounceRef.current ) {
+			suppressDebounceRef.current = false;
+			lastCommittedStateRef.current = stateRef.current;
+			return;
+		}
+		clearTimeout( debounceTimerRef.current );
+		debounceTimerRef.current = setTimeout( () => {
+			const snapshot = lastCommittedStateRef.current;
+			if ( snapshot !== null && snapshot !== stateRef.current ) {
+				pushToHistory( snapshot );
+				lastCommittedStateRef.current = stateRef.current;
+			}
+		}, HISTORY_DEBOUNCE_MS );
+		return () => clearTimeout( debounceTimerRef.current );
+	}, [ state, pushToHistory ] );
+
+	// Flush the pending debounce immediately: cancel the timer and push the
+	// pre-change snapshot if the state has actually changed. Used by
+	// pointer-up / key-up handlers for an instant commit feel, and by
+	// undo/redo/discrete actions before recording their own history entry.
+	const commitHistory = useCallback( () => {
+		clearTimeout( debounceTimerRef.current );
+		const snapshot = lastCommittedStateRef.current;
+		if ( snapshot !== null && snapshot !== stateRef.current ) {
+			pushToHistory( snapshot );
+			lastCommittedStateRef.current = stateRef.current;
+		}
+	}, [ pushToHistory ] );
+
 	const undo = useCallback( () => {
+		// Flush any pending gesture so it becomes a distinct undo step
+		// before we pop history. This ensures mid-gesture undo undoes the
+		// pending change rather than silently discarding it.
+		commitHistory();
 		const prev = historyRef.current[ historyRef.current.length - 1 ];
 		if ( ! prev ) {
 			return;
 		}
 		redoStackRef.current = [ stateRef.current, ...redoStackRef.current ];
 		historyRef.current = historyRef.current.slice( 0, -1 );
-		gestureSnapshotRef.current = null;
-		isGestureRef.current = false;
+		suppressDebounceRef.current = true;
 		setHasUndo( historyRef.current.length > 0 );
 		setHasRedo( true );
 		dispatch( { type: 'RESET', payload: prev } );
-	}, [ dispatch ] );
+	}, [ dispatch, commitHistory ] );
 
 	const redo = useCallback( () => {
+		// Flush any pending gesture before redoing so the in-flight change
+		// is saved and the redo target lands on top of it.
+		commitHistory();
 		const next = redoStackRef.current[ 0 ];
 		if ( ! next ) {
 			return;
 		}
 		historyRef.current = [ ...historyRef.current, stateRef.current ];
 		redoStackRef.current = redoStackRef.current.slice( 1 );
-		gestureSnapshotRef.current = null;
-		isGestureRef.current = false;
+		suppressDebounceRef.current = true;
 		setHasUndo( true );
 		setHasRedo( redoStackRef.current.length > 0 );
 		dispatch( { type: 'RESET', payload: next } );
-	}, [ dispatch ] );
-
-	const beginGesture = useCallback( () => {
-		if ( ! isGestureRef.current ) {
-			isGestureRef.current = true;
-			// Capture state now but defer the history push until commitHistory
-			// so we only record an entry when something actually changed.
-			gestureSnapshotRef.current = stateRef.current;
-		}
-	}, [] );
-
-	const commitHistory = useCallback( () => {
-		const snapshot = gestureSnapshotRef.current;
-		// Only push if the gesture produced a real state change.
-		if ( snapshot !== null && snapshot !== stateRef.current ) {
-			pushToHistory( snapshot );
-		}
-		gestureSnapshotRef.current = null;
-		isGestureRef.current = false;
-	}, [ pushToHistory ] );
+	}, [ dispatch, commitHistory ] );
 
 	const clearHistory = useCallback( () => {
 		historyRef.current = [];
 		redoStackRef.current = [];
-		gestureSnapshotRef.current = null;
-		isGestureRef.current = false;
+		clearTimeout( debounceTimerRef.current );
 		setHasUndo( false );
 		setHasRedo( false );
 	}, [] );
 
 	const setImage = useCallback(
 		( image: CropperState[ 'image' ] ) => {
+			clearTimeout( debounceTimerRef.current );
+			suppressDebounceRef.current = true;
 			dispatch( { type: 'SET_IMAGE', payload: image } );
 			// Refresh the "clean" snapshot to match the post-load state
 			// produced by the reducer. Otherwise containment can nudge
@@ -253,21 +301,25 @@ export function useCropperState(
 
 	const setFlip = useCallback(
 		( flip: Flip ) => {
-			pushToHistory();
+			commitHistory(); // flush any pending continuous gesture first
+			pushToHistory(); // record current state as the undo point
+			suppressDebounceRef.current = true;
 			dispatch( { type: 'SET_FLIP', payload: flip } );
 		},
-		[ dispatch, pushToHistory ]
+		[ dispatch, pushToHistory, commitHistory ]
 	);
 
 	const snapRotate90 = useCallback(
 		( direction: 1 | -1 ) => {
+			commitHistory();
 			pushToHistory();
+			suppressDebounceRef.current = true;
 			dispatch( {
 				type: 'SNAP_ROTATE_90',
 				payload: { direction },
 			} );
 		},
-		[ dispatch, pushToHistory ]
+		[ dispatch, pushToHistory, commitHistory ]
 	);
 
 	const setCropRect = useCallback(
@@ -278,21 +330,23 @@ export function useCropperState(
 	);
 
 	const settleCrop = useCallback( () => {
-		pushToHistory();
 		dispatch( { type: 'SETTLE_CROP' } );
-	}, [ dispatch, pushToHistory ] );
+	}, [ dispatch ] );
 
 	const applyOperation = useCallback(
 		( op: TransformOperation ) => {
+			commitHistory();
 			pushToHistory();
+			suppressDebounceRef.current = true;
 			dispatch( { type: 'APPLY_OPERATION', payload: op } );
 		},
-		[ dispatch, pushToHistory ]
+		[ dispatch, pushToHistory, commitHistory ]
 	);
 
 	const reset = useCallback(
 		( resetState?: Partial< CropperState > ) => {
 			clearHistory();
+			suppressDebounceRef.current = true;
 			dispatch( { type: 'RESET', payload: resetState } );
 			// Mirror the reducer's RESET exactly so isDirty stays in
 			// sync. RESET preserves the currently-loaded image; the
@@ -346,7 +400,6 @@ export function useCropperState(
 		hasRedo,
 		undo,
 		redo,
-		beginGesture,
 		commitHistory,
 	};
 	return controller;

--- a/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
@@ -84,8 +84,13 @@ export interface UseCropperStateReturn {
 	redo: () => void;
 	/**
 	 * Flush the pending history entry immediately, bypassing the debounce
-	 * timer. Call this on pointer-up or key-up to give an instant commit
-	 * rather than waiting for the debounce window to expire.
+	 * timer. Useful in two situations:
+	 *
+	 * - **Pointer-up / key-up**: commit as soon as the user releases so the
+	 *   undo button lights up without waiting for the debounce window.
+	 * - **Gesture start**: pass to `onGestureStart` on the `Cropper` so any
+	 *   pending sidebar interaction is committed before a new canvas gesture
+	 *   begins, keeping the two interactions as separate undo steps.
 	 */
 	commitHistory: () => void;
 	/**

--- a/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
@@ -132,14 +132,18 @@ export function useCropperState(
 	// Tracks whether a continuous gesture (e.g. rotation slider drag) is
 	// in progress so we only push one history entry per gesture.
 	const isGestureRef = useRef( false );
+	// Snapshot of state at gesture start for lazy history push.
+	const gestureSnapshotRef = useRef< CropperState | null >( null );
 
-	const pushToHistory = useCallback( () => {
-		const current = stateRef.current;
-		// Skip duplicate pushes (e.g. rapid discrete action on unchanged state).
-		if ( historyRef.current[ historyRef.current.length - 1 ] === current ) {
+	// Pushes `entry` (defaults to current state) onto the undo stack and
+	// clears the redo stack. Skips if `entry` is already the last item,
+	// so rapid discrete actions on unchanged state don't create duplicates.
+	const pushToHistory = useCallback( ( entry?: CropperState ) => {
+		const target = entry ?? stateRef.current;
+		if ( historyRef.current[ historyRef.current.length - 1 ] === target ) {
 			return;
 		}
-		historyRef.current = [ ...historyRef.current, current ];
+		historyRef.current = [ ...historyRef.current, target ];
 		redoStackRef.current = [];
 		setHasUndo( true );
 		setHasRedo( false );
@@ -152,6 +156,7 @@ export function useCropperState(
 		}
 		redoStackRef.current = [ stateRef.current, ...redoStackRef.current ];
 		historyRef.current = historyRef.current.slice( 0, -1 );
+		gestureSnapshotRef.current = null;
 		isGestureRef.current = false;
 		setHasUndo( historyRef.current.length > 0 );
 		setHasRedo( true );
@@ -165,6 +170,7 @@ export function useCropperState(
 		}
 		historyRef.current = [ ...historyRef.current, stateRef.current ];
 		redoStackRef.current = redoStackRef.current.slice( 1 );
+		gestureSnapshotRef.current = null;
 		isGestureRef.current = false;
 		setHasUndo( true );
 		setHasRedo( redoStackRef.current.length > 0 );
@@ -174,17 +180,26 @@ export function useCropperState(
 	const beginGesture = useCallback( () => {
 		if ( ! isGestureRef.current ) {
 			isGestureRef.current = true;
-			pushToHistory();
+			// Capture state now but defer the history push until commitHistory
+			// so we only record an entry when something actually changed.
+			gestureSnapshotRef.current = stateRef.current;
 		}
-	}, [ pushToHistory ] );
+	}, [] );
 
 	const commitHistory = useCallback( () => {
+		const snapshot = gestureSnapshotRef.current;
+		// Only push if the gesture produced a real state change.
+		if ( snapshot !== null && snapshot !== stateRef.current ) {
+			pushToHistory( snapshot );
+		}
+		gestureSnapshotRef.current = null;
 		isGestureRef.current = false;
-	}, [] );
+	}, [ pushToHistory ] );
 
 	const clearHistory = useCallback( () => {
 		historyRef.current = [];
 		redoStackRef.current = [];
+		gestureSnapshotRef.current = null;
 		isGestureRef.current = false;
 		setHasUndo( false );
 		setHasRedo( false );
@@ -231,16 +246,9 @@ export function useCropperState(
 
 	const setRotation = useCallback(
 		( rotation: number ) => {
-			// The rotation slider fires many onChange events during a single
-			// drag gesture. Only push one history entry at the start of each
-			// gesture; commitHistory() resets the flag on pointer/key release.
-			if ( ! isGestureRef.current ) {
-				isGestureRef.current = true;
-				pushToHistory();
-			}
 			dispatch( { type: 'SET_ROTATION', payload: rotation } );
 		},
-		[ dispatch, pushToHistory ]
+		[ dispatch ]
 	);
 
 	const setFlip = useCallback(

--- a/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
@@ -55,12 +55,16 @@ export interface UseInteractionOptions {
 /** How long keyboard placement stays active after the latest handled key. */
 const KEYBOARD_INTERACTION_IDLE_MS = 300;
 
-function isHandledKeyboardPan( event: KeyboardEvent ): boolean {
+function isHandledKeyboardInteraction( event: KeyboardEvent ): boolean {
 	switch ( event.key ) {
 		case 'ArrowUp':
 		case 'ArrowDown':
 		case 'ArrowLeft':
 		case 'ArrowRight':
+		case '+':
+		case '=':
+		case '-':
+		case '_':
 			return true;
 		default:
 			return false;
@@ -95,6 +99,9 @@ export function useInteraction(
 	const [ isKeyboardPanning, setIsKeyboardPanning ] = useState( false );
 	const keyboardInteractionTimerRef =
 		useRef< ReturnType< typeof setTimeout > >();
+	// Tracks whether a keyboard gesture (pan or zoom) is currently active so
+	// onGestureStart is only fired once per gesture, not on every key repeat.
+	const isKeyboardGestureActiveRef = useRef( false );
 
 	// Keep mutable refs so the controller always reads fresh values
 	// without needing to be recreated.
@@ -117,10 +124,18 @@ export function useInteraction(
 		setIsGestureActive( false );
 	}, [] );
 	const signalKeyboardPlacement = useCallback( () => {
+		// Fire onGestureStart once at the beginning of each keyboard gesture
+		// so the undo system captures a history entry for the whole sequence.
+		if ( ! isKeyboardGestureActiveRef.current ) {
+			isKeyboardGestureActiveRef.current = true;
+			optionsRef.current?.onGestureStart?.();
+		}
 		setIsKeyboardPanning( true );
 		clearTimeout( keyboardInteractionTimerRef.current );
 		keyboardInteractionTimerRef.current = setTimeout( () => {
+			isKeyboardGestureActiveRef.current = false;
 			setIsKeyboardPanning( false );
+			optionsRef.current?.onGestureEnd?.();
 		}, KEYBOARD_INTERACTION_IDLE_MS );
 	}, [] );
 
@@ -197,7 +212,7 @@ export function useInteraction(
 
 	const onKeyDown = useCallback(
 		( e: React.KeyboardEvent ) => {
-			if ( isHandledKeyboardPan( e.nativeEvent ) ) {
+			if ( isHandledKeyboardInteraction( e.nativeEvent ) ) {
 				signalKeyboardPlacement();
 			}
 			controllerRef.current?.handleKeyDown( e.nativeEvent );

--- a/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
@@ -55,12 +55,20 @@ export interface UseInteractionOptions {
 /** How long keyboard placement stays active after the latest handled key. */
 const KEYBOARD_INTERACTION_IDLE_MS = 300;
 
-function isHandledKeyboardInteraction( event: KeyboardEvent ): boolean {
+function isHandledKeyboardPan( event: KeyboardEvent ): boolean {
 	switch ( event.key ) {
 		case 'ArrowUp':
 		case 'ArrowDown':
 		case 'ArrowLeft':
 		case 'ArrowRight':
+			return true;
+		default:
+			return false;
+	}
+}
+
+function isHandledKeyboardZoom( event: KeyboardEvent ): boolean {
+	switch ( event.key ) {
 		case '+':
 		case '=':
 		case '-':
@@ -123,14 +131,13 @@ export function useInteraction(
 	const stopPlacementGesture = useCallback( () => {
 		setIsGestureActive( false );
 	}, [] );
-	const signalKeyboardPlacement = useCallback( () => {
-		// Fire onGestureStart once at the beginning of each keyboard gesture
-		// so the undo system captures a history entry for the whole sequence.
+	// Shared timer logic for any keyboard gesture (pan or zoom): fires
+	// onGestureStart once per burst and onGestureEnd after the idle window.
+	const signalKeyboardGesture = useCallback( () => {
 		if ( ! isKeyboardGestureActiveRef.current ) {
 			isKeyboardGestureActiveRef.current = true;
 			optionsRef.current?.onGestureStart?.();
 		}
-		setIsKeyboardPanning( true );
 		clearTimeout( keyboardInteractionTimerRef.current );
 		keyboardInteractionTimerRef.current = setTimeout( () => {
 			isKeyboardGestureActiveRef.current = false;
@@ -212,12 +219,15 @@ export function useInteraction(
 
 	const onKeyDown = useCallback(
 		( e: React.KeyboardEvent ) => {
-			if ( isHandledKeyboardInteraction( e.nativeEvent ) ) {
-				signalKeyboardPlacement();
+			if ( isHandledKeyboardPan( e.nativeEvent ) ) {
+				setIsKeyboardPanning( true );
+				signalKeyboardGesture();
+			} else if ( isHandledKeyboardZoom( e.nativeEvent ) ) {
+				signalKeyboardGesture();
 			}
 			controllerRef.current?.handleKeyDown( e.nativeEvent );
 		},
-		[ signalKeyboardPlacement ]
+		[ signalKeyboardGesture ]
 	);
 
 	const onWheelNative = useCallback( ( e: WheelEvent ) => {

--- a/packages/media-editor/tsconfig.json
+++ b/packages/media-editor/tsconfig.json
@@ -14,6 +14,7 @@
 		{ "path": "../element" },
 		{ "path": "../i18n" },
 		{ "path": "../icons" },
+		{ "path": "../keycodes" },
 		{ "path": "../notices" },
 		{ "path": "../private-apis" },
 		{ "path": "../ui" }


### PR DESCRIPTION
## What?

Part of:

* https://github.com/WordPress/gutenberg/issues/73771

Add undo/redo to the image cropper as part of the experimental media editor modal.

## Why?

The particular way of doing undo/redo here is just tied to the image cropper, and doesn't include metadata. The reasoning here is that the metadata fields are already covered by browser undo behaviour for editing text fields, and shouldn't really be mixed in with the flow of editing crops in the canvas.

Also, the local approach to undo/redo means we don't muddy any entity state and everything can be tossed out when we close the modal.

If we need a more integrated approach further down the track, we can pursue it, but for now this seemed expedient.

## How?

* Add undo, redo, hasUndo, hasRedo, and commitHistory to `useCropperState`.
* Expose controls for it in the media editor toolbar.
* Add a hook to allow controls to flag that they're intended to be covered by the undo/redo state (`useCropGestureHandlers`)
* In most cases, attempt to create undo stack entries based on debounced state changes
* But also commit to history early when a key is released or a mouse button is released, in order to make the undo state feel snappy
* Avoid the undo/redo state when editing other fields like metadata so that we scope this to just cropper changes (for now at least)

## Testing Instructions

* Enable the media editor modal experiment
* Add an image to a post or page
* Make a bunch of cropping, rotation, flip changes etc
* Try the undo and redo buttons and see if they work as expected

Note: the buttons are currently in the footer, but I think they'd feel a bit more "canonical" somewhere in the header? Might look a bit awkward next to the "Edit media" title, so happy for any ideas there.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/c68a5e5c-45b7-4cd2-b960-d35303590368

## Use of AI Tools

Claude Code