### PR TITLE
Experiment: Taxonomies implement `auto-fill labels`

### DIFF
--- a/packages/user-taxonomies/src/fields/labels.tsx
+++ b/packages/user-taxonomies/src/fields/labels.tsx
@@ -166,7 +166,7 @@ function LabelsActionsEdit( {
 }: DataFormControlProps< TaxonomyFormData > ) {
 	const plural = data.title.raw.trim();
 	const singular = data.config.labels.singular_name.trim();
-	const canAutoFill = plural !== '' && singular !== '';
+	const canAutoFill = !! plural.length && !! singular.length;
 	const hasOverrides = STRING_LABEL_KEYS.some(
 		( key ) =>
 			key !== 'singular_name' &&
@@ -176,7 +176,7 @@ function LabelsActionsEdit( {
 		<Stack direction="column" gap="md">
 			<Text variant="body-md" className="taxonomy-form__help-text">
 				{ __(
-					'Override the text WordPress shows in admin lists, menus, and forms. Auto-fill replaces every label below with values derived from the current plural and singular names — including any you have already customized. Clear empties them all so WordPress falls back to its defaults. If you rename the taxonomy after auto-filling, click Auto-fill again to keep them in sync.'
+					'Override the text WordPress shows in admin lists, menus, and forms. Auto-fill replaces every label below with values derived from the current plural and singular names — including any you have already customized. Clearing removes all overrides so WordPress falls back to its defaults. If you rename the taxonomy after auto-filling, click Auto-fill again to keep them in sync.'
 				) }
 			</Text>
 			<Stack direction="row" justify="flex-end" gap="sm">
@@ -204,6 +204,7 @@ function LabelsActionsEdit( {
 					__next40pxDefaultSize
 					size="compact"
 					icon={ trash }
+					isDestructive
 					label={ __( 'Clear labels' ) }
 					accessibleWhenDisabled
 					disabled={ ! hasOverrides }
@@ -226,11 +227,10 @@ function LabelsActionsEdit( {
 	);
 }
 
-// Phantom field: a no-value Field used solely to render the Labels card's
-// description and action buttons. DataForm card layouts have no first-class
-// slot for header actions or arbitrary React among children, so we register
-// this as a "field" and suppress its label via labelPosition: 'none'. Worth
-// revisiting if DataForm gains native per-card actions — this hack can go.
+// TODO: Replace this phantom field once DataForm supports per-card header
+// actions or arbitrary React among children. We register a no-value Field
+// solely to render the Labels card's description and action buttons,
+// suppressing its label via labelPosition: 'none'.
 export const labelsActionsField: Field< TaxonomyFormData > = {
 	id: '__labels_actions',
 	label: '',

--- a/packages/user-taxonomies/src/fields/labels.tsx
+++ b/packages/user-taxonomies/src/fields/labels.tsx
@@ -1,14 +1,18 @@
 /**
  * WordPress dependencies
  */
+import { Button } from '@wordpress/components';
+import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import type { Field, Form } from '@wordpress/dataviews';
+import { trash } from '@wordpress/icons';
+
+import { Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
  */
 import type { StoredLabels, TaxonomyFormData } from '../types';
-import { STRING_LABEL_KEYS } from '../utils';
+import { deriveLabels, STRING_LABEL_KEYS } from '../utils';
 
 type LabelFieldOptions = {
 	placeholder?: string;
@@ -156,8 +160,95 @@ export const chooseFromMostUsedField = labelField(
 	}
 );
 
+function LabelsActionsEdit( {
+	data,
+	onChange,
+}: DataFormControlProps< TaxonomyFormData > ) {
+	const plural = data.title.raw.trim();
+	const singular = data.config.labels.singular_name.trim();
+	const canAutoFill = plural !== '' && singular !== '';
+	const hasOverrides = STRING_LABEL_KEYS.some(
+		( key ) =>
+			key !== 'singular_name' &&
+			( data.config.labels[ key ] ?? '' ) !== ''
+	);
+	return (
+		<Stack direction="column" gap="md">
+			<Text variant="body-md" className="taxonomy-form__help-text">
+				{ __(
+					'Override the text WordPress shows in admin lists, menus, and forms. Auto-fill replaces every label below with values derived from the current plural and singular names — including any you have already customized. Clear empties them all so WordPress falls back to its defaults. If you rename the taxonomy after auto-filling, click Auto-fill again to keep them in sync.'
+				) }
+			</Text>
+			<Stack direction="row" justify="flex-end" gap="sm">
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					size="compact"
+					accessibleWhenDisabled
+					disabled={ ! canAutoFill }
+					onClick={ () =>
+						onChange( {
+							config: {
+								...data.config,
+								labels: {
+									...data.config.labels,
+									...deriveLabels( plural, singular ),
+								},
+							},
+						} )
+					}
+				>
+					{ __( 'Auto-fill labels' ) }
+				</Button>
+				<Button
+					__next40pxDefaultSize
+					size="compact"
+					icon={ trash }
+					label={ __( 'Clear labels' ) }
+					accessibleWhenDisabled
+					disabled={ ! hasOverrides }
+					onClick={ () => {
+						const cleared: StoredLabels = {
+							singular_name: data.config.labels.singular_name,
+						};
+						for ( const key of STRING_LABEL_KEYS ) {
+							if ( key !== 'singular_name' ) {
+								cleared[ key ] = '';
+							}
+						}
+						onChange( {
+							config: { ...data.config, labels: cleared },
+						} );
+					} }
+				/>
+			</Stack>
+		</Stack>
+	);
+}
+
+// Phantom field: a no-value Field used solely to render the Labels card's
+// description and action buttons. DataForm card layouts have no first-class
+// slot for header actions or arbitrary React among children, so we register
+// this as a "field" and suppress its label via labelPosition: 'none'. Worth
+// revisiting if DataForm gains native per-card actions — this hack can go.
+export const labelsActionsField: Field< TaxonomyFormData > = {
+	id: '__labels_actions',
+	label: '',
+	getValue: () => '',
+	setValue: () => ( {} ),
+	Edit: LabelsActionsEdit,
+	enableSorting: false,
+	filterBy: false,
+};
+
 export const labelsForm: Form = {
 	layout: { type: 'regular' },
 	// singular_name lives in the General card, so exclude it here.
-	fields: STRING_LABEL_KEYS.filter( ( key ) => key !== 'singular_name' ),
+	fields: [
+		{
+			id: '__labels_actions',
+			layout: { type: 'regular', labelPosition: 'none' },
+		},
+		...STRING_LABEL_KEYS.filter( ( key ) => key !== 'singular_name' ),
+	],
 };

--- a/packages/user-taxonomies/src/utils.ts
+++ b/packages/user-taxonomies/src/utils.ts
@@ -4,6 +4,7 @@
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -59,6 +60,91 @@ export const STRING_LABEL_KEYS: ( keyof StoredLabels )[] = [
 	'add_or_remove_items',
 	'choose_from_most_used',
 ];
+
+export function deriveLabels(
+	plural: string,
+	singular: string
+): Omit< StoredLabels, 'singular_name' > {
+	const lcPlural = plural.toLowerCase();
+	return {
+		menu_name: plural,
+		all_items: sprintf(
+			/* translators: %s: Plural taxonomy label. */
+			__( 'All %s' ),
+			plural
+		),
+		edit_item: sprintf(
+			/* translators: %s: Singular taxonomy label. */
+			__( 'Edit %s' ),
+			singular
+		),
+		view_item: sprintf(
+			/* translators: %s: Singular taxonomy label. */
+			__( 'View %s' ),
+			singular
+		),
+		update_item: sprintf(
+			/* translators: %s: Singular taxonomy label. */
+			__( 'Update %s' ),
+			singular
+		),
+		add_new_item: sprintf(
+			/* translators: %s: Singular taxonomy label. */
+			__( 'Add New %s' ),
+			singular
+		),
+		new_item_name: sprintf(
+			/* translators: %s: Singular taxonomy label. */
+			__( 'New %s Name' ),
+			singular
+		),
+		search_items: sprintf(
+			/* translators: %s: Plural taxonomy label. */
+			__( 'Search %s' ),
+			plural
+		),
+		not_found: sprintf(
+			/* translators: %s: Plural taxonomy label, lowercase. */
+			__( 'No %s found.' ),
+			lcPlural
+		),
+		back_to_items: sprintf(
+			/* translators: %s: Plural taxonomy label. */
+			__( '← Back to %s' ),
+			plural
+		),
+		parent_item: sprintf(
+			/* translators: %s: Singular taxonomy label. */
+			__( 'Parent %s' ),
+			singular
+		),
+		popular_items: sprintf(
+			/* translators: %s: Plural taxonomy label. */
+			__( 'Popular %s' ),
+			plural
+		),
+		separate_items_with_commas: sprintf(
+			/* translators: %s: Plural taxonomy label, lowercase. */
+			__( 'Separate %s with commas' ),
+			lcPlural
+		),
+		parent_item_colon: sprintf(
+			/* translators: %s: Singular taxonomy label. */
+			__( 'Parent %s:' ),
+			singular
+		),
+		add_or_remove_items: sprintf(
+			/* translators: %s: Plural taxonomy label, lowercase. */
+			__( 'Add or remove %s' ),
+			lcPlural
+		),
+		choose_from_most_used: sprintf(
+			/* translators: %s: Plural taxonomy label, lowercase. */
+			__( 'Choose from the most used %s' ),
+			lcPlural
+		),
+	};
+}
 
 export function toFormData( row: TaxonomyRecord ): TaxonomyFormData {
 	const parsed = parseConfig( row.content.raw );

--- a/routes/taxonomies/stage.tsx
+++ b/routes/taxonomies/stage.tsx
@@ -125,6 +125,10 @@ function TaxonomiesPage() {
 				paginationInfo={ paginationInfo }
 				defaultLayouts={ defaultLayouts }
 				getItemId={ ( item ) => String( item.id ) }
+				isItemClickable={ () => true }
+				onClickItem={ ( item ) =>
+					navigate( { to: `/edit/${ item.id }` } )
+				}
 			/>
 		</Page>
 	);

--- a/routes/taxonomy-edit/stage.tsx
+++ b/routes/taxonomy-edit/stage.tsx
@@ -28,6 +28,7 @@ import {
 	editItemField,
 	generalForm,
 	hierarchicalField,
+	labelsActionsField,
 	labelsForm,
 	menuNameField,
 	newItemNameField,
@@ -142,6 +143,7 @@ function TaxonomyPage( {
 			hierarchicalField,
 			statusField,
 			// Labels
+			labelsActionsField,
 			menuNameField,
 			allItemsField,
 			editItemField,
@@ -182,9 +184,6 @@ function TaxonomyPage( {
 				{
 					id: 'labels',
 					label: __( 'Labels' ),
-					description: __(
-						'Override the text WordPress shows in admin lists, menus, and forms. Leave blank to use defaults derived from the plural and singular names.'
-					),
 					layout: {
 						type: 'card',
 						isCollapsible: true,

--- a/routes/taxonomy-edit/taxonomy-form.scss
+++ b/routes/taxonomy-edit/taxonomy-form.scss
@@ -1,7 +1,13 @@
+@use "@wordpress/base-styles/colors" as *;
+
 .taxonomy-form {
 	box-sizing: border-box;
 	width: 100%;
 	max-width: 680px;
 	margin: 0 auto;
 	padding: 24px;
+}
+
+.taxonomy-form__help-text {
+	color: $gray-700;
 }


### PR DESCRIPTION
## Summary

Part of: https://github.com/WordPress/gutenberg/issues/77600

Adds two actions inside the taxonomy edit form's **Labels** card to make the labels section less manual:

- **Auto-fill labels** — populates every label field from the current Plural/Singular names using the same patterns the existing field placeholders encode (`All %s`, `Edit %s`, `← Back to %s`, `No %s found.`, etc.). Disabled until both Plural and Singular are set.
- **Clear labels** — empties every label override (icon-only trash button, "Clear labels" tooltip). Disabled when there's nothing to clear. Cleared values are dropped at serialize time, so WP falls back to its registration-time defaults.

The Labels card's previous prose description is consolidated into a single help paragraph rendered above the buttons, with an extra sentence reminding users to re-run Auto-fill after a rename.

Also: rows in the taxonomies list are now `isItemClickable` and route to the edit page on click.

## How it's wired

The two buttons are rendered inside the Labels card via a small "phantom field" — a `Field` with no value (no-op `getValue`/`setValue`) whose custom `Edit` renders the help paragraph and the button row. It's the first child of `labelsForm.fields` and uses `labelPosition: 'none'` so the regular layout suppresses the auto-rendered field label.

This is a workaround for `DataForm` card layouts having no first-class slot for header actions or arbitrary React among children. The hack is annotated with a comment in `packages/user-taxonomies/src/fields/labels.tsx` noting that adding native per-card action support to `DataForm` would let us drop it.

## Translation note (read this if you test locale switching)

The auto-fill localizes labels at click-time using `sprintf(__('All %s'), plural)`. This relies on the standard WP JS-translation pipeline (`.pot` extraction → translate.wordpress.org → JSON language packs → `wp_set_script_translations()`). Local `wp-env` does **not** auto-load the JS catalog for newly-added strings, so switching the admin locale (e.g. to Greek) currently produces English prefixes alongside the translated noun (e.g. "All Σκυλιά"). That's expected pre-shipping behavior and will resolve once translations land in the package's catalog.

## Testing instructions

1. Enable the *Content types: manage custom taxonomies* experiment.
2. Go to **Settings → Taxonomies**
3. In create/edit form `labels` card play around with the `auto-fill/clear` action buttons.

## Use of AI Tools

Opus 4.7 with steering, changes and review