### PR TITLE
ExternalLink: Align appearance with Link from @wordpress/ui

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   `ExternalLink`: Align appearance with `Link` from `@wordpress/ui` (brand color, underline thickness/offset, focus ring, and external-link icon spacing) ([#77790](https://github.com/WordPress/gutenberg/pull/77790)).
 -   `Menu`: Remove `cursor: not-allowed` and added pointer styles to menu ([#70412](https://github.com/WordPress/gutenberg/pull/70412))
 -   `FormToggle`: Add stacking context isolation ([#77619](https://github.com/WordPress/gutenberg/pull/77619)).
 -   `CircularOptionPicker`: Add stacking context isolation ([#77715](https://github.com/WordPress/gutenberg/pull/77715)).

--- a/packages/components/src/external-link/style.scss
+++ b/packages/components/src/external-link/style.scss
@@ -2,7 +2,7 @@
 	color: var(--wpds-color-fg-interactive-brand);
 	text-decoration: none;
 
-	// Match the focus ring used by `Link` in `@wordpress/ui`.
+	// Match the `outset-ring--focus` utility used by `Link` in `@wordpress/ui`.
 	@media not ( prefers-reduced-motion ) {
 		transition: outline 0.1s ease-out;
 	}

--- a/packages/components/src/external-link/style.scss
+++ b/packages/components/src/external-link/style.scss
@@ -30,7 +30,7 @@
 .components-external-link__contents {
 	text-decoration: underline;
 	text-underline-offset: 0.2em;
-	text-decoration-thickness: 0.5px;
+	text-decoration-thickness: from-font;
 }
 
 .components-external-link__icon {

--- a/packages/components/src/external-link/style.scss
+++ b/packages/components/src/external-link/style.scss
@@ -37,5 +37,4 @@
 	display: inline-block;
 	margin-inline-start: var(--wpds-dimension-padding-xs);
 	font-weight: var(--wpds-typography-font-weight-regular);
-	text-decoration: none;
 }

--- a/packages/components/src/external-link/style.scss
+++ b/packages/components/src/external-link/style.scss
@@ -1,5 +1,32 @@
 .components-external-link {
+	color: var(--wpds-color-fg-interactive-brand);
 	text-decoration: none;
+	text-underline-offset: 0.2em;
+	text-decoration-thickness: 0.5px;
+
+	// Match the focus ring used by `Link` in `@wordpress/ui`.
+	@media not ( prefers-reduced-motion ) {
+		transition: outline 0.1s ease-out;
+	}
+	// Outline width must be kept at 0 even with a transparent color,
+	// or else the outline will be visible in forced-colors mode.
+	outline: 0 solid transparent;
+	outline-offset: 1px;
+
+	&:visited {
+		color: var(--wpds-color-fg-interactive-brand);
+	}
+
+	&:hover,
+	&:active {
+		color: var(--wpds-color-fg-interactive-brand-active);
+	}
+
+	&:focus {
+		outline:
+			var(--wpds-border-width-focus) solid
+			var(--wpds-color-stroke-focus-brand);
+	}
 }
 
 .components-external-link__contents {
@@ -7,6 +34,8 @@
 }
 
 .components-external-link__icon {
-	margin-left: 0.5ch;
-	font-weight: 400;
+	display: inline-block;
+	margin-inline-start: var(--wpds-dimension-padding-xs);
+	font-weight: var(--wpds-typography-font-weight-regular);
+	text-decoration: none;
 }

--- a/packages/components/src/external-link/style.scss
+++ b/packages/components/src/external-link/style.scss
@@ -1,8 +1,6 @@
 .components-external-link {
 	color: var(--wpds-color-fg-interactive-brand);
 	text-decoration: none;
-	text-underline-offset: 0.2em;
-	text-decoration-thickness: 0.5px;
 
 	// Match the focus ring used by `Link` in `@wordpress/ui`.
 	@media not ( prefers-reduced-motion ) {
@@ -31,6 +29,8 @@
 
 .components-external-link__contents {
 	text-decoration: underline;
+	text-underline-offset: 0.2em;
+	text-decoration-thickness: 0.5px;
 }
 
 .components-external-link__icon {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -36,6 +36,7 @@
 -   `Select`: Tighten spacing after checkmark when `Select.Item` is `size="small"` ([#77642](https://github.com/WordPress/gutenberg/pull/77642)).
 -   `Dialog`, `Drawer`, `Popover`: Align title and description colors across all three overlay primitives. Title color is now authored explicitly (resilient to global CSS defenses), and description color now inherits from the popup foreground token instead of overriding to the weak variant ([#77692](https://github.com/WordPress/gutenberg/pull/77692)).
 -   `Dialog`, `AlertDialog`, `Drawer`, `Popover`, `Select`, `Tooltip`: Unify the hairline border across overlay popups. Popups without a backdrop show a token-colored border in regular mode; popups with a backdrop hide the border (which would be redundant with the backdrop's containment); all popups show a `CanvasText` border in forced-colors mode ([#77691](https://github.com/WordPress/gutenberg/pull/77691)).
+-   `Link`: Use `text-decoration-thickness: from-font` so the underline honors the font's metrics, instead of a fixed sub-pixel value that renders inconsistently across device pixel ratios ([#77790](https://github.com/WordPress/gutenberg/pull/77790)).
 
 ### Internal
 

--- a/packages/ui/src/link/style.module.css
+++ b/packages/ui/src/link/style.module.css
@@ -3,7 +3,7 @@
 @layer wp-ui-components {
 	.link {
 		text-underline-offset: 0.2em;
-		text-decoration-thickness: 0.5px;
+		text-decoration-thickness: from-font;
 	}
 
 	/* Brand tone */


### PR DESCRIPTION
## What

Aligns the appearance of `ExternalLink` (`@wordpress/components`) with `Link` (`@wordpress/ui`), so the two components look visually consistent when used side-by-side.

## Why

`ExternalLink` and `Link` were drifting visually: different colors, underline thickness/offset, focus ring treatment, and external-link icon spacing. Now that `Link` from `@wordpress/ui` is the recommended primitive (and `ExternalLink` is on the path to being redirected to it — see [#77012 review](https://github.com/WordPress/gutenberg/pull/77012#discussion_r3029572766)), it's worth bringing the legacy component up to visual parity in the meantime so the two don't look mismatched in the same UI.

This addresses the appearance differences flagged in [#77012 (comment)](https://github.com/WordPress/gutenberg/pull/77012#discussion_r3113374128).

## How

Primarily updates `packages/components/src/external-link/style.scss` — no JSX or API changes. Also makes one small tweak to `packages/ui/src/link/style.module.css` to keep the two components in lockstep.

- **Color**: Uses `--wpds-color-fg-interactive-brand` (and `…-active` on hover/active), matching `Link`'s default `tone="brand"`.
- **Underline**: Adds `text-underline-offset: 0.2em` and `text-decoration-thickness: from-font` (kept on the `__contents` span so the icon stays clean). `from-font` honors the font's underline metrics rather than hard-coding a sub-pixel value, which renders inconsistently across device pixel ratios. Applied to both `ExternalLink` and `Link` so they stay aligned.
- **Focus ring**: Mirrors the `outset-ring--focus` treatment from `@wordpress/ui` — transparent `0 solid` outline at rest (so the `outline` transition animates in, and forced-colors mode doesn't render a permanent ring) plus `outline-offset: 1px`, swapping to `var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus-brand)` on `:focus`.
- **Icon spacing**: Switches to `margin-inline-start: var(--wpds-dimension-padding-xs)` (was `margin-left: 0.5ch`) and `font-weight: var(--wpds-typography-font-weight-regular)` (was `400`).
- **Cleanup**: Drops a redundant `text-decoration: none` from `.components-external-link__icon` — the parent anchor already sets `text-decoration: none`, and the icon span never opts into an underline, so the declaration had no effect.

### Out of scope / notes

- No new props (e.g. `tone`, `variant`). `ExternalLink` is slated to redirect to `Link` + `openInNewTab`; consumers needing tone variants should reach for `Link` directly. Keeping the API minimal keeps the eventual migration mechanical.
- Uses `:focus` (not `:focus-visible`) to match `Link`'s current behavior. The open question raised in [#77744](https://github.com/WordPress/gutenberg/issues/77744) — should links use `:focus-visible`? — is best resolved across **both** components in a follow-up.
- The arrow icon JSX is unchanged. `Link` uses a `::after` pseudo-element to dodge text-selection / Twemoji issues; `ExternalLink` already mitigates Twemoji via `wp-exclude-emoji`. Reworking it to a pseudo-element would be a JSX-level change with potential consumer impact, so it's deferred.

## Testing instructions

1. Open Storybook and visit **Components/Navigation/ExternalLink → Default**.
2. Confirm the link uses the brand color, has a thin underline with offset, and shows the brand-colored focus ring on tab focus.
3. In a separate tab, open **Design System/Components/Link → Default** and visually compare — the two should look near-identical aside from the trailing arrow. Underline thickness should match in both.
4. Verify in forced-colors mode (Windows High Contrast / Chrome devtools "Emulate forced-colors: active") that no permanent outline is visible at rest.
5. Verify hover/active states transition smoothly to the brand-active color.

## Use of AI Tools

Created with Cursor & Claude Opus 4.7