### PR TITLE
Interactivity API: Fix popover bind hydration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60864,7 +60864,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@preact/signals": "^1.3.0",
-				"preact": "10.29.1"
+				"preact": "^10.29.1"
 			},
 			"devDependencies": {
 				"@types/jest": "^29.5.14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -46538,9 +46538,9 @@
 			}
 		},
 		"node_modules/preact": {
-			"version": "10.24.2",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.24.2.tgz",
-			"integrity": "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==",
+			"version": "10.29.1",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+			"integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -60864,7 +60864,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@preact/signals": "^1.3.0",
-				"preact": "^10.24.2"
+				"preact": "10.29.1"
 			},
 			"devDependencies": {
 				"@types/jest": "^29.5.14"

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-bind/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-bind/render.php
@@ -66,6 +66,9 @@
 		'emptyString' => '{ "value": "" }',
 		'anyString'   => '{ "value": "any" }',
 		'number'      => '{ "value": 10 }',
+		'auto'        => '{ "value": "auto" }',
+		'manual'      => '{ "value": "manual" }',
+		'hint'        => '{ "value": "hint" }',
 	);
 	?>
 
@@ -90,31 +93,6 @@
 			data-wp-bind--disabled="context.value"
 			data-wp-bind--aria-disabled="context.value"
 		>
-		<button
-			data-testid="toggle value"
-			data-wp-on--click="actions.toggleValue"
-			data-wp-bind--data-toggle-count="context.count"
-		>Toggle</button>
-	</div>
-	<?php endforeach; ?>
-
-	<?php
-	$popover_cases = array(
-		'true'   => '{ "value": true }',
-		'false'  => '{ "value": false }',
-		'null'   => '{ "value": null }',
-		'undef'  => '{ "__any": "any" }',
-		'auto'   => '{ "value": "auto" }',
-		'manual' => '{ "value": "manual" }',
-		'hint'   => '{ "value": "hint" }',
-	);
-	?>
-
-	<?php foreach ( $popover_cases as $type => $context ) : ?>
-	<div
-		data-testid='hydrating popover <?php echo $type; ?>'
-		data-wp-context='<?php echo $context; ?>'
-	>
 		<div
 			data-testid="popover"
 			data-wp-bind--popover="context.value"

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-bind/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-bind/render.php
@@ -98,6 +98,35 @@
 	</div>
 	<?php endforeach; ?>
 
+	<?php
+	$popover_cases = array(
+		'true'   => '{ "value": true }',
+		'false'  => '{ "value": false }',
+		'null'   => '{ "value": null }',
+		'undef'  => '{ "__any": "any" }',
+		'auto'   => '{ "value": "auto" }',
+		'manual' => '{ "value": "manual" }',
+		'hint'   => '{ "value": "hint" }',
+	);
+	?>
+
+	<?php foreach ( $popover_cases as $type => $context ) : ?>
+	<div
+		data-testid='hydrating popover <?php echo $type; ?>'
+		data-wp-context='<?php echo $context; ?>'
+	>
+		<div
+			data-testid="popover"
+			data-wp-bind--popover="context.value"
+		></div>
+		<button
+			data-testid="toggle value"
+			data-wp-on--click="actions.toggleValue"
+			data-wp-bind--data-toggle-count="context.count"
+		>Toggle</button>
+	</div>
+	<?php endforeach; ?>
+
 	<div data-wp-context='{"test": true}'>
 		<div
 			data-testid="without-unique-id"

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -35,7 +35,7 @@
 	"types": "build-types",
 	"dependencies": {
 		"@preact/signals": "^1.3.0",
-		"preact": "10.29.1"
+		"preact": "^10.29.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^29.5.14"

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -35,7 +35,7 @@
 	"types": "build-types",
 	"dependencies": {
 		"@preact/signals": "^1.3.0",
-		"preact": "^10.24.2"
+		"preact": "10.29.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^29.5.14"

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -745,7 +745,7 @@ export default () => {
 				/*
 				 * We set the value directly to the corresponding HTMLElement instance
 				 * property excluding the following special cases. We follow Preact's
-				 * logic: https://github.com/preactjs/preact/blob/ea49f7a0f9d1ff2c98c0bdd66aa0cbc583055246/src/diff/props.js#L110-L129
+				 * logic: https://github.com/preactjs/preact/blob/10.29.1/src/diff/props.js#L115-L129
 				 */
 				if ( attribute === 'style' ) {
 					if ( typeof result === 'string' ) {
@@ -774,6 +774,7 @@ export default () => {
 					attribute !== 'rowSpan' &&
 					attribute !== 'colSpan' &&
 					attribute !== 'role' &&
+					attribute !== 'popover' &&
 					attribute in el
 				) {
 					try {
@@ -788,14 +789,21 @@ export default () => {
 				 * aria- and data- attributes have no boolean representation.
 				 * A `false` value is different from the attribute not being
 				 * present, so we can't remove it.
-				 * We follow Preact's logic: https://github.com/preactjs/preact/blob/ea49f7a0f9d1ff2c98c0bdd66aa0cbc583055246/src/diff/props.js#L131C24-L136
+				 * We follow Preact's logic: https://github.com/preactjs/preact/blob/10.29.1/src/diff/props.js#L138-L150
 				 */
+				if ( typeof result === 'function' ) {
+					return;
+				}
+
 				if (
 					result !== null &&
 					result !== undefined &&
 					( result !== false || attribute[ 4 ] === '-' )
 				) {
-					el.setAttribute( attribute, result );
+					el.setAttribute(
+						attribute,
+						attribute === 'popover' && result === true ? '' : result
+					);
 				} else {
 					el.removeAttribute( attribute );
 				}

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -791,10 +791,6 @@ export default () => {
 				 * present, so we can't remove it.
 				 * We follow Preact's logic: https://github.com/preactjs/preact/blob/10.29.1/src/diff/props.js#L138-L150
 				 */
-				if ( typeof result === 'function' ) {
-					return;
-				}
-
 				if (
 					result !== null &&
 					result !== undefined &&

--- a/test/e2e/specs/interactivity/directive-bind.spec.ts
+++ b/test/e2e/specs/interactivity/directive-bind.spec.ts
@@ -176,7 +176,7 @@ test.describe( 'data-wp-bind', () => {
 				values: {
 					false: [ null, 'false' ],
 					true: [ null, 'true' ],
-					null: [ null, '', null, 'tacocat' ],
+					null: [ null, '' ],
 					undef: [ null, '', null, 'tacocat' ],
 					emptyString: [ null, '' ],
 					anyString: [ null, 'any' ],
@@ -263,7 +263,12 @@ test.describe( 'data-wp-bind', () => {
 						propValue,
 					] );
 
-					await toggle.click( { clickCount: 2 } );
+					await toggle.click();
+					await expect( toggle ).toHaveAttribute(
+						'data-toggle-count',
+						'1'
+					);
+					await toggle.click();
 
 					// Ensure values have been updated after toggling.
 					await expect( toggle ).toHaveAttribute(

--- a/test/e2e/specs/interactivity/directive-bind.spec.ts
+++ b/test/e2e/specs/interactivity/directive-bind.spec.ts
@@ -127,6 +127,18 @@ test.describe( 'data-wp-bind', () => {
 					 * contain after hydration.
 					 */
 					entityPropValue: any,
+					/**
+					 * Value that the attribute should contain after Preact
+					 * renders the same value. If omitted, the hydration value
+					 * is used.
+					 */
+					renderedAttributeValue?: any,
+					/**
+					 * Value that the HTMLElement instance property should
+					 * contain after Preact renders the same value. If omitted,
+					 * the hydration value is used.
+					 */
+					renderedEntityPropValue?: any,
 				]
 			>;
 		};
@@ -164,8 +176,8 @@ test.describe( 'data-wp-bind', () => {
 				values: {
 					false: [ null, 'false' ],
 					true: [ null, 'true' ],
-					null: [ null, '' ],
-					undef: [ null, '' ],
+					null: [ null, '', null, 'tacocat' ],
+					undef: [ null, '', null, 'tacocat' ],
 					emptyString: [ null, '' ],
 					anyString: [ null, 'any' ],
 					number: [ null, '10' ],
@@ -204,7 +216,12 @@ test.describe( 'data-wp-bind', () => {
 				page,
 			} ) => {
 				for ( const type in values ) {
-					const [ attrValue, propValue ] = values[ type ];
+					const [
+						attrValue,
+						propValue,
+						renderedAttrValue = attrValue,
+						renderedPropValue = propValue,
+					] = values[ type ];
 
 					const container = page.getByTestId( `hydrating ${ type }` );
 					const el = container.getByTestId( testid );
@@ -230,18 +247,6 @@ test.describe( 'data-wp-bind', () => {
 						propValue,
 					] );
 
-					// Only check the rendered value if the new value is not
-					// `undefined` and the attribute is neither `value` nor
-					// `disabled` because Preact doesn't update the attribute
-					// for those cases.
-					// See https://github.com/preactjs/preact/blob/099c38c6ef92055428afbc116d18a6b9e0c2ea2c/src/diff/index.js#L471-L494
-					if (
-						type === 'undef' &&
-						( name === 'value' || name === 'undefined' )
-					) {
-						return;
-					}
-
 					await toggle.click( { clickCount: 2 } );
 
 					// Ensure values have been updated after toggling.
@@ -250,7 +255,6 @@ test.describe( 'data-wp-bind', () => {
 						'2'
 					);
 
-					// Values should be the same as before.
 					const renderedAttr = await el.getAttribute( name );
 					const renderedProp = await el.evaluate(
 						( node, propName ) => ( node as any )[ propName ],
@@ -258,15 +262,58 @@ test.describe( 'data-wp-bind', () => {
 					);
 					expect( [ type, renderedAttr ] ).toEqual( [
 						type,
-						attrValue,
+						renderedAttrValue,
 					] );
 					expect( [ type, renderedProp ] ).toEqual( [
 						type,
-						propValue,
+						renderedPropValue,
 					] );
 				}
 			} );
 		}
+
+		test( 'popover is correctly hydrated for different values', async ( {
+			page,
+		} ) => {
+			const values: Record< string, string | null > = {
+				true: '',
+				false: null,
+				null: null,
+				undef: null,
+				auto: 'auto',
+				manual: 'manual',
+				hint: 'hint',
+			};
+
+			// Ensure hydration has happened.
+			const checkbox = page.getByTestId(
+				'add missing checked at hydration'
+			);
+			await expect( checkbox ).toBeChecked();
+
+			for ( const type in values ) {
+				const attrValue = values[ type ];
+				const container = page.getByTestId(
+					`hydrating popover ${ type }`
+				);
+				const el = container.getByTestId( 'popover' );
+				const toggle = container.getByTestId( 'toggle value' );
+
+				const hydratedAttr = await el.getAttribute( 'popover' );
+				expect( [ type, hydratedAttr ] ).toEqual( [ type, attrValue ] );
+
+				await toggle.click( { clickCount: 2 } );
+
+				// Ensure values have been updated after toggling.
+				await expect( toggle ).toHaveAttribute(
+					'data-toggle-count',
+					'2'
+				);
+
+				const renderedAttr = await el.getAttribute( 'popover' );
+				expect( [ type, renderedAttr ] ).toEqual( [ type, attrValue ] );
+			}
+		} );
 	} );
 
 	test( 'should ignore unique ids', async ( { page } ) => {

--- a/test/e2e/specs/interactivity/directive-bind.spec.ts
+++ b/test/e2e/specs/interactivity/directive-bind.spec.ts
@@ -176,7 +176,7 @@ test.describe( 'data-wp-bind', () => {
 				values: {
 					false: [ null, 'false' ],
 					true: [ null, 'true' ],
-					null: [ null, '' ],
+					null: [ null, '', null, 'tacocat' ],
 					undef: [ null, '', null, 'tacocat' ],
 					emptyString: [ null, '' ],
 					anyString: [ null, 'any' ],

--- a/test/e2e/specs/interactivity/directive-bind.spec.ts
+++ b/test/e2e/specs/interactivity/directive-bind.spec.ts
@@ -209,6 +209,22 @@ test.describe( 'data-wp-bind', () => {
 					number: [ '10', undefined ],
 				},
 			},
+			{
+				testid: 'popover',
+				name: 'popover',
+				values: {
+					false: [ null, null ],
+					true: [ '', 'auto' ],
+					null: [ null, null ],
+					undef: [ null, null ],
+					emptyString: [ '', 'auto' ],
+					anyString: [ 'any', 'manual' ],
+					number: [ '10', 'manual' ],
+					auto: [ 'auto', 'auto' ],
+					manual: [ 'manual', 'manual' ],
+					hint: [ 'hint', 'hint' ],
+				},
+			},
 		];
 
 		for ( const { testid, name, values } of matrix ) {
@@ -271,49 +287,6 @@ test.describe( 'data-wp-bind', () => {
 				}
 			} );
 		}
-
-		test( 'popover is correctly hydrated for different values', async ( {
-			page,
-		} ) => {
-			const values: Record< string, string | null > = {
-				true: '',
-				false: null,
-				null: null,
-				undef: null,
-				auto: 'auto',
-				manual: 'manual',
-				hint: 'hint',
-			};
-
-			// Ensure hydration has happened.
-			const checkbox = page.getByTestId(
-				'add missing checked at hydration'
-			);
-			await expect( checkbox ).toBeChecked();
-
-			for ( const type in values ) {
-				const attrValue = values[ type ];
-				const container = page.getByTestId(
-					`hydrating popover ${ type }`
-				);
-				const el = container.getByTestId( 'popover' );
-				const toggle = container.getByTestId( 'toggle value' );
-
-				const hydratedAttr = await el.getAttribute( 'popover' );
-				expect( [ type, hydratedAttr ] ).toEqual( [ type, attrValue ] );
-
-				await toggle.click( { clickCount: 2 } );
-
-				// Ensure values have been updated after toggling.
-				await expect( toggle ).toHaveAttribute(
-					'data-toggle-count',
-					'2'
-				);
-
-				const renderedAttr = await el.getAttribute( 'popover' );
-				expect( [ type, renderedAttr ] ).toEqual( [ type, attrValue ] );
-			}
-		} );
 	} );
 
 	test( 'should ignore unique ids', async ( { page } ) => {


### PR DESCRIPTION
## What?
Closes #77766

Updates `@wordpress/interactivity` to Preact `10.29.1` and aligns Interactivity API hydration-time `wp-bind` attribute handling with current Preact behavior, including support for `data-wp-bind--popover`.

## Why?

`data-wp-bind--popover` was not setting the `popover` attribute correctly during hydration because the Interactivity API mirrors Preact's DOM attribute handling for hydration, and that mirrored logic did not include Preact's newer special handling for `popover`.

The lockfile also kept Gutenberg on an older Preact release even though the existing dependency range allowed newer versions, so the dependency and related test expectations needed to be updated together.

## How?

- Pins the `preact` dependency for `@wordpress/interactivity` to `10.29.1` and updates `package-lock.json`.
- Updates the directive bind E2E expectations to match current Preact behavior for `input.value` when rerendering `null` / `undefined`.
- Updates `packages/interactivity/src/directives.tsx` so hydration excludes `popover` from the DOM property assignment path, removes it for `false`, `null`, and `undefined`, preserves string values, and serializes `true` as a present empty attribute.
- Adds E2E coverage for `data-wp-bind--popover` values: `true`, `false`, `null`, `undefined`, `auto`, `manual`, and `hint`.

## Testing Instructions

1. Run the directive bind E2E test:
   ```bash
   npm run test:e2e -- test/e2e/specs/interactivity/directive-bind.spec.ts
   ```
2. Confirm the `data-wp-bind › attribute hydration › value is correctly hydrated for different values` test passes.
3. Confirm the `data-wp-bind › attribute hydration › popover is correctly hydrated for different values` test passes.

### Testing Instructions for Keyboard

Not applicable. This does not change user-facing UI or keyboard interactions.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

This PR was prepared with assistance from AI coding agents in Pi. The generated code, tests, documentation review, and PR description were reviewed by the contributor.
