### PR TITLE
Block Toolbar: Prevent position shifts when using mover control

### DIFF
--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -10,6 +10,7 @@ import { useMergeRefs } from '@wordpress/compose';
 import { Popover } from '@wordpress/components';
 import {
 	forwardRef,
+	useCallback,
 	useMemo,
 	useReducer,
 	useLayoutEffect,
@@ -52,6 +53,10 @@ function BlockPopover(
 		0
 	);
 
+	const debouncedRecompute = useCallback( () => {
+		window.requestAnimationFrame( () => forceRecomputePopoverDimensions() );
+	}, [ forceRecomputePopoverDimensions ] );
+
 	// When blocks are moved up/down, they are animated to their new position by
 	// updating the `transform` property manually (i.e. without using CSS
 	// transitions or animations). The animation, which can also scroll the block
@@ -64,15 +69,13 @@ function BlockPopover(
 			return;
 		}
 
-		const observer = new window.MutationObserver(
-			forceRecomputePopoverDimensions
-		);
+		const observer = new window.MutationObserver( debouncedRecompute );
 		observer.observe( selectedElement, { attributes: true } );
 
 		return () => {
 			observer.disconnect();
 		};
-	}, [ selectedElement ] );
+	}, [ selectedElement, debouncedRecompute ] );
 
 	const popoverAnchor = useMemo( () => {
 		if (

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -10,7 +10,6 @@ import { useMergeRefs } from '@wordpress/compose';
 import { Popover } from '@wordpress/components';
 import {
 	forwardRef,
-	useCallback,
 	useMemo,
 	useReducer,
 	useLayoutEffect,
@@ -53,10 +52,6 @@ function BlockPopover(
 		0
 	);
 
-	const debouncedRecompute = useCallback( () => {
-		window.requestAnimationFrame( () => forceRecomputePopoverDimensions() );
-	}, [ forceRecomputePopoverDimensions ] );
-
 	// When blocks are moved up/down, they are animated to their new position by
 	// updating the `transform` property manually (i.e. without using CSS
 	// transitions or animations). The animation, which can also scroll the block
@@ -69,13 +64,17 @@ function BlockPopover(
 			return;
 		}
 
-		const observer = new window.MutationObserver( debouncedRecompute );
+		const observer = new window.MutationObserver( () =>
+			window.requestAnimationFrame( () =>
+				forceRecomputePopoverDimensions()
+			)
+		);
 		observer.observe( selectedElement, { attributes: true } );
 
 		return () => {
 			observer.disconnect();
 		};
-	}, [ selectedElement, debouncedRecompute ] );
+	}, [ selectedElement ] );
 
 	const popoverAnchor = useMemo( () => {
 		if (

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -52,27 +52,35 @@ function BlockPopover(
 		0
 	);
 
-	// When blocks are moved up/down, they are animated to their new position by
-	// updating the `transform` property manually (i.e. without using CSS
-	// transitions or animations). The animation, which can also scroll the block
-	// editor, can sometimes cause the position of the Popover to get out of sync.
-	// A MutationObserver is therefore used to make sure that changes to the
-	// selectedElement's attribute (i.e. `transform`) can be tracked and used to
-	// trigger the Popover to rerender.
+	// `useMovingAnimation` writes the block's `transform` on every spring tick.
+	// Reacting synchronously to each mutation would race with Floating UI's own
+	// autoUpdate frame loop and cause the toolbar to visibly jump. Coalescing
+	// to one recompute per animation frame avoids that. The observer can't
+	// simply be removed: with autoUpdate's animationFrame mode alone, the
+	// toolbar trails the block by ~1 frame because the spring's rAF and
+	// autoUpdate's rAF are independently scheduled.
 	useLayoutEffect( () => {
 		if ( ! selectedElement ) {
 			return;
 		}
 
-		const observer = new window.MutationObserver( () =>
-			window.requestAnimationFrame( () =>
-				forceRecomputePopoverDimensions()
-			)
-		);
+		let rafId;
+		const observer = new window.MutationObserver( () => {
+			if ( rafId ) {
+				return;
+			}
+			rafId = window.requestAnimationFrame( () => {
+				rafId = null;
+				forceRecomputePopoverDimensions();
+			} );
+		} );
 		observer.observe( selectedElement, { attributes: true } );
 
 		return () => {
 			observer.disconnect();
+			if ( rafId ) {
+				window.cancelAnimationFrame( rafId );
+			}
 		};
 	}, [ selectedElement ] );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #61435<!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->
Stops the block toolbar from jumping around when using the mover controls.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When a block is moved, useMovingAnimation writes transform on every spring tick. The MutationObserver was firing synchronously on each mutation, racing with Floating UI's own autoUpdate frame loop — causing the toolbar to visibly jump mid-animation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Coalesced the MutationObserver callbacks via requestAnimationFrame so at most one recompute is triggered per frame, matching the cadence of the spring animation. Also added proper cleanup via cancelAnimationFrame on unmount to prevent stale updates.
The observer itself can't simply be removed: without it, Floating UI's animationFrame mode alone causes the toolbar to trail the block by ~1 frame throughout the animation because the spring's rAF and autoUpdate's rAF are independently scheduled.

## Testing Instructions

1. Open a post with many blocks
2. Select a block and scroll upwards till it is partially in view then use the mover arrows up and down
3. Verify the toolbar doesn't jump during animation (Also check for regressions in [#44220](https://github.com/WordPress/gutenberg/issues/44220), [#44281](https://github.com/WordPress/gutenberg/issues/44281))
4. Click the mover arrows rapidly (overlapping animations) and verify no jump
5. Test in the Site Editor (Appearance → Editor) with a template containing many blocks
6. Enable prefers-reduced-motion in OS accessibility settings and repeat

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
https://github.com/user-attachments/assets/43627b69-63ce-4642-bf2b-7621c648f6f6

### After (Post editor)
https://github.com/user-attachments/assets/2e778066-412f-4c4d-b673-2eb3e536a559

### After (Site editor)
https://github.com/user-attachments/assets/f0798212-ecf8-4278-8c00-1fd506ebdac4

### After (reduced-motion enabled)
https://github.com/user-attachments/assets/1141cdf4-3ef7-444d-a1c5-d70b2c1f7532

## Use of AI Tools
Claude (Anthropic) was used to help draft this PR. All changes were reviewed manually.

note: please check [this](https://github.com/WordPress/gutenberg/pull/77798#issuecomment-4379039771) for further explanation

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
