### PR TITLE
Grid: add @types/jest devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60689,6 +60689,7 @@
 				"clsx": "^2.1.1"
 			},
 			"devDependencies": {
+				"@types/jest": "^29.5.14",
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/ui": "file:../ui"
 			},

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -55,6 +55,7 @@
 		"clsx": "^2.1.1"
 	},
 	"devDependencies": {
+		"@types/jest": "^29.5.14",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/ui": "file:../ui"
 	},


### PR DESCRIPTION
## What?

Declares `@types/jest` as a `devDependency` of `@wordpress/grid`. The package's `tsconfig.json` already lists `"jest"` in `compilerOptions.types`, but the type-definitions package was not declared as a dependency of the workspace.

Follows up on review feedback in #77562: https://github.com/WordPress/gutenberg/pull/77562#pullrequestreview-4195021738

## Why?

`compilerOptions.types: [ "jest" ]` instructs TypeScript to load global type declarations from `@types/jest` (so `describe`, `it`, `expect`, `jest.*` are typed). Today the package only typechecks because `@types/jest` is hoisted from another workspace's `node_modules`. That makes the dependency implicit and brittle: it breaks the moment the package is built in isolation or hoisting changes.

Every other Gutenberg package that uses `"jest"` in `tsconfig` types declares this dependency explicitly (`components`, `dataviews`, `ui`, `core-data`, `media-fields`, `global-styles-engine` — all on `^29.5.14`).

## How?

Adds a single entry to `packages/grid/package.json`:

```json
"devDependencies": {
    "@types/jest": "^29.5.14",
    ...
}
```

Version pinned to match the rest of the monorepo. `package-lock.json` regenerated by `npm install`.

## Testing

```bash
npx tsc --build packages/grid
```

Expected: clean exit, no errors.