### PR TITLE
User Taxonomies: show Public field in create/edit form

### DIFF
--- a/packages/user-taxonomies/src/fields/general.tsx
+++ b/packages/user-taxonomies/src/fields/general.tsx
@@ -256,6 +256,7 @@ export const generalForm: Form = {
 		'slug',
 		'description',
 		'object_type',
+		'public',
 		'hierarchical',
 		'status',
 	],


### PR DESCRIPTION
## What?
Adds the Public toggle to the General section of the user-taxonomy form. The field was already defined and listed in the quick edit form, but was missing from the create/edit form.

## Why?
Filling a field gap in the create/edit form.

## How?
Just listing the field on the create/edit form.

## Testing Instructions
* Enable the Content Types experiment
* Go to Settings > Taxonomies and click Add New
* Confirm a Public toggle now appears in the form.
* Insert a taxonomy and go to its edit screen
* Verify you can see a Public toggle and it works as expected.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="613" height="702" alt="Screenshot 2026-04-29 at 16 18 13" src="https://github.com/user-attachments/assets/2a296ac0-c986-4305-ba8c-8b2ef9145100" />|<img width="612" height="777" alt="Screenshot 2026-04-29 at 16 21 31" src="https://github.com/user-attachments/assets/14479077-199c-46cd-bbee-92fb1d12fd44" />|

## Use of AI Tools

Opus 4.7