### PR TITLE
Site Editor: Add "Root" template wrapper and template-content block

### DIFF
--- a/docs/how-to-guides/themes/README.md
+++ b/docs/how-to-guides/themes/README.md
@@ -20,3 +20,4 @@ There isn't an FSE specific theme type. In WordPress > 5.9 FSE is enabled for an
 
 - [Global Settings (theme.json)](/docs/how-to-guides/themes/global-settings-and-styles.md)
 - [Theme Support](/docs/how-to-guides/themes/theme-support.md)
+- [Root template](/docs/how-to-guides/themes/root-template.md)

--- a/docs/how-to-guides/themes/root-template.md
+++ b/docs/how-to-guides/themes/root-template.md
@@ -1,0 +1,61 @@
+# Root template
+
+A block theme can opt into a single `root.html` template that defines
+site-wide chrome (header, footer, sidebars) once. When `root.html` is
+present, every other template in the theme renders inside it on the
+frontend and in the Site Editor — so theme authors no longer need to
+repeat the same header/footer template parts in every template.
+
+## How it works
+
+Add a `root.html` file to your theme's `templates/` directory. Anywhere
+inside it, drop the `core/template-content` block:
+
+```html
+<!-- wp:group {"tagName":"main"} -->
+<div class="wp-block-group">
+    <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+    <!-- wp:template-content /-->
+    <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+</div>
+<!-- /wp:group -->
+```
+
+`core/template-content` is the slot the WordPress template hierarchy
+fills at render time. On the frontend, when WordPress would normally
+serve `archive.html`, `single.html`, `index.html`, etc., it serves
+`root.html` instead and renders the originally-resolved template's
+blocks inside `core/template-content`.
+
+`core/template-content` may only be inserted inside `root.html` and may
+only appear once per template.
+
+## Authoring inside the Site Editor
+
+Two flows in the editor:
+
+-   **Editing `root.html` directly.** `core/template-content` shows a
+    non-interactive preview of the home-hierarchy fallback (front-page →
+    home → index) so you can see how the chrome looks around real
+    content. A dropdown in the block's inspector switches the preview to
+    a different template, and an "Edit template" toolbar action opens
+    the previewed template in the regular editor.
+-   **Editing any other template** (e.g. archive, single). The Site
+    Editor wraps that template inside `root.html`. The inner template's
+    blocks are fully editable inside `core/template-content`; the
+    surrounding chrome is locked but selectable. Clicking any chrome
+    block surfaces an "Edit root template" toolbar action that switches
+    you to editing `root.html` itself.
+
+## When to use it
+
+Use `root.html` when your templates are mostly chrome + a single content
+slot. Skip it when templates differ in structure beyond their content —
+the wrap forces every template through the same outer markup.
+
+## Compatibility
+
+Themes without a `root.html` continue to work exactly as before:
+WordPress resolves the template hierarchy normally and serves the
+matching template directly. Adding a `root.html` is a strictly opt-in
+change.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -312,6 +312,12 @@
 		"parent": "themes"
 	},
 	{
+		"title": "Root template",
+		"slug": "root-template",
+		"markdown_source": "../docs/how-to-guides/themes/root-template.md",
+		"parent": "themes"
+	},
+	{
 		"title": "Thunks in Core-Data",
 		"slug": "thunks",
 		"markdown_source": "../docs/how-to-guides/thunks.md",

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -1070,6 +1070,14 @@ A cloud of popular keywords, each sized by how often it appears. ([Source](https
 -	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding), typography (lineHeight), ~~html~~
 -	**Attributes:** largestFontSize, numberOfTags, showTagCounts, smallestFontSize, taxonomy
 
+## Template Content
+
+Renders the template selected by the WordPress template hierarchy. Use inside a root.html template to control the shared scaffolding around every page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/template-content))
+
+-	**Name:** core/template-content
+-	**Category:** theme
+-	**Supports:** inserter, ~~html~~, ~~multiple~~, ~~renaming~~, ~~reusable~~
+
 ## Template Part
 
 Edit the different global regions of your site, like the header, footer, sidebar, or create your own. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/template-part))

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -133,7 +133,8 @@
 					{
 						"docs/how-to-guides/themes/global-settings-and-styles.md": []
 					},
-					{ "docs/how-to-guides/themes/theme-support.md": [] }
+					{ "docs/how-to-guides/themes/theme-support.md": [] },
+					{ "docs/how-to-guides/themes/root-template.md": [] }
 				]
 			},
 			{ "docs/how-to-guides/thunks.md": [] },

--- a/lib/compat/wordpress-7.1/root-template.php
+++ b/lib/compat/wordpress-7.1/root-template.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Root template feature.
+ *
+ * If the active theme provides a `root.html` template, every block template
+ * resolved by the WordPress template hierarchy is wrapped inside it. The
+ * originally-resolved template id is stashed in a global so the
+ * `core/template-content` block can resolve and render it.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Returns the active theme's root block template, or null if none exists.
+ *
+ * Caches the result for the duration of the request. `get_block_template()`
+ * checks both the `wp_template` post type (user customizations) and theme
+ * files, so this works for either source.
+ *
+ * Pass `true` to reset the cache. Useful when root has been created, deleted,
+ * or saved during the same request and a subsequent render needs the fresh
+ * value (e.g. previewing edits made in the Site Editor without a full page
+ * reload). Cleared automatically when any `wp_template` post is saved.
+ *
+ * @param bool $reset Whether to discard the cached value before returning.
+ * @return WP_Block_Template|null
+ */
+function gutenberg_get_root_block_template( $reset = false ) {
+	static $resolved = false;
+	static $cached   = null;
+
+	if ( $reset ) {
+		$resolved = false;
+		$cached   = null;
+	}
+
+	if ( $resolved ) {
+		return $cached;
+	}
+	$resolved = true;
+
+	$id     = get_stylesheet() . '//root';
+	$cached = get_block_template( $id, 'wp_template' );
+	return $cached;
+}
+
+/**
+ * Invalidates the cached root block template after any `wp_template` post is
+ * saved, so subsequent renders in the same request pick up the fresh content.
+ * Cheap (just resets two PHP statics).
+ */
+add_action( 'save_post_wp_template', 'gutenberg_clear_root_block_template_cache' );
+function gutenberg_clear_root_block_template_cache() {
+	gutenberg_get_root_block_template( true );
+}
+
+/**
+ * Swaps the resolved template content for the root template, stashing the
+ * inner template id so `core/template-content` can render the original.
+ *
+ * Hooked on `template_include`, which fires after the `*_template` filter
+ * chain has populated `$_wp_current_template_id` and
+ * `$_wp_current_template_content`.
+ *
+ * @global string $_wp_current_template_id
+ * @global string $_wp_current_template_content
+ *
+ * @param string $template Resolved template path (unchanged by this filter).
+ * @return string
+ */
+function gutenberg_root_template_swap( $template ) {
+	global $_wp_current_template_id, $_wp_current_template_content;
+
+	if ( empty( $_wp_current_template_id ) ) {
+		return $template;
+	}
+
+	// If we are already rendering root (e.g. directly visiting it via the editor preview), skip.
+	$separator = strpos( $_wp_current_template_id, '//' );
+	$slug      = false === $separator ? $_wp_current_template_id : substr( $_wp_current_template_id, $separator + 2 );
+	if ( 'root' === $slug ) {
+		return $template;
+	}
+
+	$root = gutenberg_get_root_block_template();
+	if ( ! $root ) {
+		return $template;
+	}
+
+	// Stash the inner template id for `core/template-content`.
+	$GLOBALS['_wp_current_inner_template_id'] = $_wp_current_template_id;
+
+	$_wp_current_template_id      = $root->id;
+	$_wp_current_template_content = $root->content;
+
+	return $template;
+}
+// `template_include` fires after the `*_template` filter chain, so by the
+// time this runs, `$_wp_current_template_id` / `$_wp_current_template_content`
+// are already populated. Default priority is sufficient.
+add_filter( 'template_include', 'gutenberg_root_template_swap' );
+
+/**
+ * Registers the `root` template type with the standard hierarchy types so it
+ * gets a proper title and description in the Site Editor's templates list.
+ *
+ * Only adds the entry when the active theme actually provides a `root.html`,
+ * so themes that don't use the wrapping pattern don't see "Root" as an
+ * available template type in the "Add new" UI.
+ *
+ * @param array $template_types Map of template slug to type metadata.
+ * @return array
+ */
+function gutenberg_register_root_template_type( $template_types ) {
+	if ( isset( $template_types['root'] ) ) {
+		return $template_types;
+	}
+	if ( ! gutenberg_get_root_block_template() ) {
+		return $template_types;
+	}
+	$template_types['root'] = array(
+		'title'       => _x( 'Root', 'Template name' ),
+		'description' => __( 'This template wraps every page. Use it to define site-wide scaffolding (header, footer, navigation, sidebars) once. Requires a Template Content block inside which renders the correct template in the WordPress hierarchy.' ),
+	);
+	return $template_types;
+}
+add_filter( 'default_template_types', 'gutenberg_register_root_template_type' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -82,6 +82,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	// WordPress 7.1 compat.
 	require __DIR__ . '/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php';
 	require __DIR__ . '/compat/wordpress-7.1/rest-api.php';
+	require __DIR__ . '/compat/wordpress-7.1/root-template.php';
 
 	// Plugin specific code.
 	require_once __DIR__ . '/class-wp-rest-global-styles-controller-gutenberg.php';

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   New `core/template-content` block — renders, on the frontend, whichever template the WordPress hierarchy selects. Intended for use inside an opt-in `root.html` template that wraps every page. The block has two editor modes: when the user is wrapping a non-root template (e.g. `archive`) inside `root.html`, the inner template's blocks render here and edits round-trip to that entity; when the user edits `root.html` directly, the slot shows a non-interactive preview of the home-hierarchy fallback (front-page → home → index) with a dropdown to pick a different template to preview, plus an "Edit template" toolbar button to open it in the regular editor.
+
 ## 9.45.0 (2026-04-29)
 
 ## 9.44.0 (2026-04-15)

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -51,6 +51,7 @@
 @use "./table/editor.scss" as *;
 @use "./tab-list/editor.scss" as *;
 @use "./tab/editor.scss" as *;
+@use "./template-content/editor.scss" as *;
 @use "./template-part/editor.scss" as *;
 @use "./term-template/editor.scss" as *;
 @use "./text-columns/editor.scss" as *;

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -143,6 +143,7 @@ import * as tableOfContents from './table-of-contents';
 import * as tabList from './tab-list';
 import * as tabs from './tabs';
 import * as tagCloud from './tag-cloud';
+import * as templateContent from './template-content';
 import * as templatePart from './template-part';
 import * as termCount from './term-count';
 import * as termDescription from './term-description';
@@ -228,6 +229,7 @@ const getAllBlocks = () => {
 		siteTitle,
 		siteTagline,
 		query,
+		templateContent,
 		templatePart,
 		avatar,
 		postTitle,

--- a/packages/block-library/src/template-content/block.json
+++ b/packages/block-library/src/template-content/block.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/template-content",
+	"title": "Template Content",
+	"category": "theme",
+	"description": "Renders the template selected by the WordPress template hierarchy. Use inside a root.html template to control the shared scaffolding around every page.",
+	"textdomain": "default",
+	"supports": {
+		"html": false,
+		"multiple": false,
+		"reusable": false,
+		"renaming": false,
+		"inserter": true
+	},
+	"editorStyle": "wp-block-template-content-editor"
+}

--- a/packages/block-library/src/template-content/edit.js
+++ b/packages/block-library/src/template-content/edit.js
@@ -1,0 +1,488 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	BlockControls,
+	InspectorControls,
+	store as blockEditorStore,
+	__experimentalUseBlockPreview as useBlockPreview,
+} from '@wordpress/block-editor';
+import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
+import { parse } from '@wordpress/blocks';
+import { useSelect, useRegistry } from '@wordpress/data';
+import { useLayoutEffect, useMemo, useState } from '@wordpress/element';
+import {
+	Placeholder,
+	Spinner,
+	ToolbarButton,
+	PanelBody,
+	SelectControl,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import icon from './icon';
+import { selectWrapModeClientIds } from './select-wrap-mode-client-ids';
+
+/**
+ * Hierarchy used to find a default preview template when the user is editing
+ * `root.html` directly and hasn't picked one explicitly. Walks the same
+ * precedence WordPress uses to resolve the home page on the frontend.
+ */
+const HOMEPAGE_FALLBACKS = [ 'front-page', 'home', 'index' ];
+
+/**
+ * Stabilises the array reference returned from selectors so it only changes
+ * when contents change. `getBlockOrder` returns a fresh array per state
+ * mutation; without this every dispatch would invalidate dependent effects
+ * and re-trigger the dispatches that caused the state mutation, looping.
+ *
+ * @param {string[]} clientIds Array of client ids to memoise by content.
+ * @return {string[]} Memoised reference to `clientIds`.
+ */
+function useStableClientIds( clientIds ) {
+	return useMemo(
+		() => clientIds,
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[ clientIds.join( ',' ) ]
+	);
+}
+
+/**
+ * Locks the canvas to "edit only the inner template's blocks" when the Site
+ * Editor wraps a non-root template inside `root.html`.
+ *
+ * `core/template-content` can be nested at any depth in `root.html`, so we
+ * categorise blocks relative to it rather than relative to the canvas root:
+ *
+ *   - `core/template-content` itself stays `'contentOnly'` (visible in List
+ *     View, not directly editable).
+ *   - Its descendants stay `'default'` so the inner template is editable.
+ *   - Its ancestors become `'contentOnly'`. They contain template-content as
+ *     a descendant, so they can't be marked `'disabled'` (that would
+ *     propagate to template-content). `'contentOnly'` keeps them clickable.
+ *   - Every other block (lateral chrome — siblings of an ancestor or of
+ *     template-content itself, plus those siblings' descendants):
+ *     - The "chrome top" (sibling whose parent is an ancestor or the canvas
+ *       root) becomes `'contentOnly'` so users can select it for the
+ *       "Edit root template" affordance.
+ *     - Everything beneath a chrome top becomes `'disabled'` (inert), so
+ *       clicks on internals bubble up to the chrome top.
+ *
+ * We do NOT lock the canvas root (`''`) here. Setting `''` to `'disabled'`
+ * would propagate `inert` to every chrome top via derivation, swallowing
+ * the very clicks the affordance needs to react to.
+ *
+ * Each effect uses a stabilised dep array + read-before-dispatch guard.
+ * `setBlockEditingMode` writes to a Map even on no-op writes, which would
+ * otherwise loop: dispatch → state mutates → selector returns new array →
+ * effect re-runs → dispatch → … .
+ *
+ * @param {string|null} clientId The `core/template-content` block's id.
+ */
+export function useWrapModeLocking( clientId ) {
+	const {
+		ancestorClientIds,
+		innerChildClientIds,
+		chromeTopClientIds,
+		chromeDescendantClientIds,
+	} = useSelect(
+		( select ) =>
+			selectWrapModeClientIds( select( blockEditorStore ), clientId ),
+		[ clientId ]
+	);
+
+	const registry = useRegistry();
+	const stableAncestorClientIds = useStableClientIds( ancestorClientIds );
+	const stableInnerChildClientIds = useStableClientIds( innerChildClientIds );
+	const stableChromeTopClientIds = useStableClientIds( chromeTopClientIds );
+	const stableChromeDescendantClientIds = useStableClientIds(
+		chromeDescendantClientIds
+	);
+
+	useLayoutEffect( () => {
+		if ( ! clientId ) {
+			return;
+		}
+		const { getBlockEditingMode } = registry.select( blockEditorStore );
+		const { setBlockEditingMode, unsetBlockEditingMode } =
+			registry.dispatch( blockEditorStore );
+		if ( getBlockEditingMode( clientId ) !== 'contentOnly' ) {
+			setBlockEditingMode( clientId, 'contentOnly' );
+		}
+		return () => {
+			unsetBlockEditingMode( clientId );
+		};
+	}, [ clientId, registry ] );
+
+	useLayoutEffect( () => {
+		if ( stableAncestorClientIds.length === 0 ) {
+			return;
+		}
+		const { getBlockEditingMode } = registry.select( blockEditorStore );
+		const { setBlockEditingMode, unsetBlockEditingMode } =
+			registry.dispatch( blockEditorStore );
+		const toSet = stableAncestorClientIds.filter(
+			( id ) => getBlockEditingMode( id ) !== 'contentOnly'
+		);
+		if ( toSet.length > 0 ) {
+			registry.batch( () => {
+				for ( const id of toSet ) {
+					setBlockEditingMode( id, 'contentOnly' );
+				}
+			} );
+		}
+		return () => {
+			registry.batch( () => {
+				for ( const id of stableAncestorClientIds ) {
+					unsetBlockEditingMode( id );
+				}
+			} );
+		};
+	}, [ stableAncestorClientIds, registry ] );
+
+	useLayoutEffect( () => {
+		if ( stableInnerChildClientIds.length === 0 ) {
+			return;
+		}
+		const { getBlockEditingMode } = registry.select( blockEditorStore );
+		const { setBlockEditingMode, unsetBlockEditingMode } =
+			registry.dispatch( blockEditorStore );
+		const toSet = stableInnerChildClientIds.filter(
+			( id ) => getBlockEditingMode( id ) !== 'default'
+		);
+		if ( toSet.length > 0 ) {
+			registry.batch( () => {
+				for ( const id of toSet ) {
+					setBlockEditingMode( id, 'default' );
+				}
+			} );
+		}
+		return () => {
+			registry.batch( () => {
+				for ( const id of stableInnerChildClientIds ) {
+					unsetBlockEditingMode( id );
+				}
+			} );
+		};
+	}, [ stableInnerChildClientIds, registry ] );
+
+	useLayoutEffect( () => {
+		if ( stableChromeTopClientIds.length === 0 ) {
+			return;
+		}
+		const { getBlockEditingMode } = registry.select( blockEditorStore );
+		const { setBlockEditingMode, unsetBlockEditingMode } =
+			registry.dispatch( blockEditorStore );
+		const toSet = stableChromeTopClientIds.filter(
+			( id ) => getBlockEditingMode( id ) !== 'contentOnly'
+		);
+		if ( toSet.length > 0 ) {
+			registry.batch( () => {
+				for ( const id of toSet ) {
+					setBlockEditingMode( id, 'contentOnly' );
+				}
+			} );
+		}
+		return () => {
+			registry.batch( () => {
+				for ( const id of stableChromeTopClientIds ) {
+					unsetBlockEditingMode( id );
+				}
+			} );
+		};
+	}, [ stableChromeTopClientIds, registry ] );
+
+	useLayoutEffect( () => {
+		if ( stableChromeDescendantClientIds.length === 0 ) {
+			return;
+		}
+		const { getBlockEditingMode } = registry.select( blockEditorStore );
+		const { setBlockEditingMode, unsetBlockEditingMode } =
+			registry.dispatch( blockEditorStore );
+		const toSet = stableChromeDescendantClientIds.filter(
+			( id ) => getBlockEditingMode( id ) !== 'disabled'
+		);
+		if ( toSet.length > 0 ) {
+			registry.batch( () => {
+				for ( const id of toSet ) {
+					setBlockEditingMode( id, 'disabled' );
+				}
+			} );
+		}
+		return () => {
+			registry.batch( () => {
+				for ( const id of stableChromeDescendantClientIds ) {
+					unsetBlockEditingMode( id );
+				}
+			} );
+		};
+	}, [ stableChromeDescendantClientIds, registry ] );
+}
+
+/**
+ * Wrap-mode rendering: the user navigated to a non-root template (e.g.
+ * `archive`) but the Site Editor is wrapping it in `root.html`. The inner
+ * template's blocks render here as fully editable inner blocks; their edits
+ * round-trip to the inner template's entity. Root chrome around us is
+ * locked via `useWrapModeLocking`.
+ *
+ * @param {Object} props                 Component props.
+ * @param {string} props.innerTemplateId The inner template entity id (e.g.
+ *                                       `theme//archive`).
+ * @param {Object} props.blockProps      Props returned by `useBlockProps`.
+ * @param {string} props.clientId        The current block's client id.
+ */
+function WrapModeEdit( { innerTemplateId, blockProps, clientId } ) {
+	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
+		'postType',
+		'wp_template',
+		{ id: innerTemplateId }
+	);
+
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		value: blocks,
+		onInput,
+		onChange,
+		templateLock: false,
+	} );
+
+	useWrapModeLocking( clientId );
+
+	if ( ! blocks ) {
+		return (
+			<div { ...blockProps }>
+				<Placeholder
+					icon={ icon }
+					label={ __( 'Template Content' ) }
+					instructions={ __( 'Loading template…' ) }
+				>
+					<Spinner />
+				</Placeholder>
+			</div>
+		);
+	}
+
+	return <div { ...innerBlocksProps } />;
+}
+
+/**
+ * Direct-edit-root rendering: the user is editing `root.html`. Show a
+ * non-editable preview of the active theme's home-hierarchy fallback (or a
+ * user-picked template) inside this slot, with an "Edit template" button to
+ * open the previewed template in the regular template editor.
+ *
+ * @param {Object} props            Component props.
+ * @param {Object} props.blockProps Props returned by `useBlockProps`.
+ */
+function PreviewModeEdit( { blockProps } ) {
+	// Per-session local state — the previewed template is an editor-only
+	// convenience, not data the theme author wants persisted into the saved
+	// root template's HTML.
+	const [ previewedTemplate, setPreviewedTemplate ] = useState( undefined );
+
+	const { stylesheet, themeTemplates } = useSelect( ( select ) => {
+		const { getCurrentTheme, getEntityRecords } = select( coreStore );
+		const sheet = getCurrentTheme()?.stylesheet;
+		const records = getEntityRecords( 'postType', 'wp_template', {
+			per_page: -1,
+		} );
+		return {
+			stylesheet: sheet ?? null,
+			themeTemplates:
+				records && sheet
+					? records.filter( ( t ) => t.theme === sheet )
+					: null,
+		};
+	}, [] );
+
+	// 1. The user's session-local pick, if any.
+	// 2. Else the first of `front-page` / `home` / `index` that exists.
+	const templateId = useMemo( () => {
+		if ( ! stylesheet ) {
+			return null;
+		}
+		if ( previewedTemplate ) {
+			return `${ stylesheet }//${ previewedTemplate }`;
+		}
+		if ( ! themeTemplates ) {
+			return null;
+		}
+		const availableSlugs = new Set( themeTemplates.map( ( t ) => t.slug ) );
+		for ( const slug of HOMEPAGE_FALLBACKS ) {
+			if ( availableSlugs.has( slug ) ) {
+				return `${ stylesheet }//${ slug }`;
+			}
+		}
+		return null;
+	}, [ stylesheet, previewedTemplate, themeTemplates ] );
+
+	// Read the previewed template's content directly. We deliberately avoid
+	// `useEntityBlockEditor` here because its `_id ?? providerId` fallback
+	// would resolve to the surrounding entity (the root template itself)
+	// when `templateId` is null, causing recursive preview.
+	const content = useSelect(
+		( select ) => {
+			if ( ! templateId ) {
+				return null;
+			}
+			// `getEntityRecord` triggers the resolver on first call.
+			const record = select( coreStore ).getEntityRecord(
+				'postType',
+				'wp_template',
+				templateId
+			);
+			return record?.content?.raw ?? null;
+		},
+		[ templateId ]
+	);
+
+	const previewBlocks = useMemo( () => {
+		return content ? parse( content ) : [];
+	}, [ content ] );
+
+	const blockPreviewProps = useBlockPreview( {
+		blocks: previewBlocks,
+		props: blockProps,
+	} );
+
+	const onNavigateToEntityRecord = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings().onNavigateToEntityRecord,
+		[]
+	);
+
+	const canEditPreviewedTemplate = useSelect(
+		( select ) =>
+			!! templateId &&
+			!! select( coreStore ).canUser( 'update', {
+				kind: 'postType',
+				name: 'wp_template',
+				id: templateId,
+			} ),
+		[ templateId ]
+	);
+
+	const previewOptions = useMemo( () => {
+		const fallbackOption = {
+			label: __( 'Default (home page)' ),
+			value: '',
+		};
+		if ( ! themeTemplates ) {
+			return [ fallbackOption ];
+		}
+		return [
+			fallbackOption,
+			...themeTemplates
+				.filter( ( t ) => t.slug !== 'root' )
+				.map( ( t ) => ( {
+					label: t.title?.rendered || t.slug,
+					value: t.slug,
+				} ) ),
+		];
+	}, [ themeTemplates ] );
+
+	const inspector = (
+		<InspectorControls>
+			<PanelBody title={ __( 'Preview' ) }>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Preview template' ) }
+					help={ __(
+						'Pick which template to render inside this block while editing. The frontend always uses the WordPress hierarchy regardless of this setting; the choice is not saved.'
+					) }
+					value={ previewedTemplate ?? '' }
+					options={ previewOptions }
+					onChange={ ( value ) =>
+						setPreviewedTemplate( value || undefined )
+					}
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+
+	const editTemplateToolbar = templateId &&
+		canEditPreviewedTemplate &&
+		onNavigateToEntityRecord && (
+			<BlockControls group="other">
+				<ToolbarButton
+					onClick={ () =>
+						onNavigateToEntityRecord( {
+							postId: templateId,
+							postType: 'wp_template',
+							focusMode: false,
+						} )
+					}
+				>
+					{ __( 'Edit template' ) }
+				</ToolbarButton>
+			</BlockControls>
+		);
+
+	const isLoaded = templateId !== null && content !== null;
+	const hasContent = isLoaded && previewBlocks.length > 0;
+
+	if ( hasContent ) {
+		return (
+			<>
+				{ editTemplateToolbar }
+				{ inspector }
+				<div { ...blockPreviewProps } />
+			</>
+		);
+	}
+
+	return (
+		<>
+			{ editTemplateToolbar }
+			{ inspector }
+			<div { ...blockProps }>
+				<Placeholder
+					icon={ icon }
+					label={ __( 'Template Content' ) }
+					instructions={
+						isLoaded
+							? __(
+									'On the frontend, this block renders whichever template the WordPress hierarchy selects (front-page, archive, single, 404, etc.).'
+							  )
+							: __( 'Loading template preview…' )
+					}
+				>
+					{ ! isLoaded && <Spinner /> }
+				</Placeholder>
+			</div>
+		</>
+	);
+}
+
+export default function TemplateContentEdit( { clientId } ) {
+	const blockProps = useBlockProps();
+
+	// `__experimentalRootInnerTemplateId` is set by edit-site when wrapping
+	// a non-root template inside `root.html`. When set, this block's
+	// children are the inner template's blocks; when not, we're being
+	// rendered inside `root.html` itself and show a non-editable preview.
+	const innerTemplateId = useSelect( ( select ) => {
+		return (
+			select( blockEditorStore ).getSettings()
+				.__experimentalRootInnerTemplateId ?? null
+		);
+	}, [] );
+
+	if ( innerTemplateId ) {
+		return (
+			<WrapModeEdit
+				innerTemplateId={ innerTemplateId }
+				blockProps={ blockProps }
+				clientId={ clientId }
+			/>
+		);
+	}
+
+	return <PreviewModeEdit blockProps={ blockProps } />;
+}

--- a/packages/block-library/src/template-content/editor.scss
+++ b/packages/block-library/src/template-content/editor.scss
@@ -1,0 +1,31 @@
+// Mirrors `core/template-part`'s outline treatment: highlight the block in
+// the canvas with the synced-pattern purple so authors can see the boundary
+// of the area whose contents come from another template.
+.block-editor-block-list__block:not(.remove-outline).wp-block-template-content {
+
+	&.is-highlighted::after,
+	&.is-selected::after {
+		outline-color: var(--wp-block-synced-color);
+	}
+
+	&.block-editor-block-list__block:not([contenteditable]):focus {
+		&::after {
+			outline-color: var(--wp-block-synced-color);
+		}
+	}
+}
+
+.is-outline-mode .block-editor-block-list__block:not(.remove-outline).wp-block-template-content {
+
+	&.is-hovered::after,
+	&.is-selected::after,
+	&.is-highlighted::after {
+		outline-color: var(--wp-block-synced-color);
+	}
+
+	&.block-editor-block-list__block:not([contenteditable]):focus {
+		&::after {
+			outline-color: var(--wp-block-synced-color);
+		}
+	}
+}

--- a/packages/block-library/src/template-content/icon.js
+++ b/packages/block-library/src/template-content/icon.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/primitives';
+
+/**
+ * Layout-style icon with the bottom-right cell rendered solid to evoke
+ * "the active page slot inside a wrapper".
+ */
+const icon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M18 5.5H6a.5.5 0 00-.5.5v3h13V6a.5.5 0 00-.5-.5zm-10 5H5.5V18a.5.5 0 00.5.5h2.5v-8zM6 4h12a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2z" />
+		<Path d="M10 10.5h8.5V18a.5.5 0 01-.5.5h-8z" />
+	</SVG>
+);
+
+export default icon;

--- a/packages/block-library/src/template-content/index.js
+++ b/packages/block-library/src/template-content/index.js
@@ -1,0 +1,68 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { select } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import metadata from './block.json';
+import edit from './edit';
+import icon from './icon';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	// Just `src` — letting CSS colour the icon. The `is-synced` class on the
+	// List View row (added because `isTemplatePart()` now returns `true` for
+	// this block) already paints the icon purple when not selected and white
+	// when selected. Setting `foreground` here would apply an inline style
+	// that overrides the selected-state colour.
+	icon,
+	edit,
+};
+
+/**
+ * Returns true when the editor is currently editing the `root` wp_template
+ * entity. Reads selectors via `select()` to avoid a hard dependency on
+ * `@wordpress/editor` (which isn't available in every editor context).
+ */
+function isEditingRootTemplate() {
+	// Importing the editor store would create a circular dep
+	// (block-library is a lower layer than @wordpress/editor), so we look
+	// it up by name at runtime instead.
+	// eslint-disable-next-line @wordpress/data-no-store-string-literals
+	const editor = select( 'core/editor' );
+	if ( editor?.getCurrentPostType?.() !== 'wp_template' ) {
+		return false;
+	}
+	const postId = editor?.getCurrentPostId?.();
+	if ( ! postId ) {
+		return false;
+	}
+	const record = select( coreStore ).getEditedEntityRecord(
+		'postType',
+		'wp_template',
+		postId
+	);
+	return record?.slug === 'root';
+}
+
+export const init = () => {
+	addFilter(
+		'blockEditor.__unstableCanInsertBlockType',
+		'core/template-content/restrict-to-root-template',
+		( canInsert, blockType ) => {
+			if ( blockType.name !== 'core/template-content' ) {
+				return canInsert;
+			}
+			return isEditingRootTemplate();
+		}
+	);
+
+	return initBlock( { name, metadata, settings } );
+};

--- a/packages/block-library/src/template-content/index.php
+++ b/packages/block-library/src/template-content/index.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Server-side rendering of the `core/template-content` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/template-content` block on the server.
+ *
+ * Resolves the template id stashed by the root-template swap and renders its
+ * content via `do_blocks()`. Guards against re-entrant rendering of the same
+ * template id.
+ *
+ * @since 7.1.0
+ *
+ * @return string Rendered template content.
+ */
+function render_block_core_template_content() {
+	static $seen_ids = array();
+
+	$inner_template_id = $GLOBALS['_wp_current_inner_template_id'] ?? null;
+	if ( ! $inner_template_id ) {
+		return '';
+	}
+
+	if ( isset( $seen_ids[ $inner_template_id ] ) ) {
+		return ( WP_DEBUG && WP_DEBUG_DISPLAY )
+			? __( '[block rendering halted]' )
+			: '';
+	}
+
+	$template = get_block_template( $inner_template_id, 'wp_template' );
+	if ( ! $template || empty( $template->content ) ) {
+		return '';
+	}
+
+	$seen_ids[ $inner_template_id ] = true;
+	$content                        = do_blocks( $template->content );
+	unset( $seen_ids[ $inner_template_id ] );
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return "<div $wrapper_attributes>" . str_replace( ']]>', ']]&gt;', $content ) . '</div>';
+}
+
+/**
+ * Registers the `core/template-content` block on the server.
+ *
+ * @since 7.1.0
+ */
+function register_block_core_template_content() {
+	register_block_type_from_metadata(
+		__DIR__ . '/template-content',
+		array(
+			'render_callback' => 'render_block_core_template_content',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_template_content' );

--- a/packages/block-library/src/template-content/select-wrap-mode-client-ids.js
+++ b/packages/block-library/src/template-content/select-wrap-mode-client-ids.js
@@ -1,0 +1,60 @@
+/**
+ * Computes the client-id buckets that wrap-mode locking needs from the
+ * block-editor store, given the client id of the `core/template-content`
+ * block.
+ *
+ * Categorisation is relative to template-content (which can be nested
+ * anywhere inside `root.html`):
+ *
+ *   - `ancestorClientIds` — the chain of containers that wrap template-
+ *     content. They can't be marked `'disabled'` (would propagate to
+ *     template-content) so they're locked to `'contentOnly'`.
+ *   - `innerChildClientIds` — direct children of template-content. The
+ *     inner template's blocks live here and stay editable.
+ *   - `chromeTopClientIds` — siblings of any ancestor (or of template-
+ *     content itself) that aren't part of the ancestor chain. Locked to
+ *     `'contentOnly'` so the user can select them.
+ *   - `chromeDescendantClientIds` — everything beneath a chrome top.
+ *     Locked to `'disabled'` (inert) so clicks bubble up to chrome top.
+ *
+ * Pure: takes selectors as a parameter so it can be unit tested.
+ *
+ * @param {Object}      blockEditorSelectors Object exposing the
+ *                                           `getBlockOrder`,
+ *                                           `getBlockParents`, and
+ *                                           `getClientIdsOfDescendants`
+ *                                           selectors.
+ * @param {string|null} clientId             The template-content block's id.
+ */
+export function selectWrapModeClientIds( blockEditorSelectors, clientId ) {
+	if ( ! clientId ) {
+		return {
+			ancestorClientIds: [],
+			innerChildClientIds: [],
+			chromeTopClientIds: [],
+			chromeDescendantClientIds: [],
+		};
+	}
+	const { getBlockOrder, getBlockParents, getClientIdsOfDescendants } =
+		blockEditorSelectors;
+	const ancestorClientIds = getBlockParents( clientId );
+	const ancestorSet = new Set( [ ...ancestorClientIds, clientId ] );
+	const containerLookups = [ '', ...ancestorClientIds ];
+	const chromeTopClientIds = [];
+	for ( const containerId of containerLookups ) {
+		for ( const childId of getBlockOrder( containerId ) ) {
+			if ( ! ancestorSet.has( childId ) ) {
+				chromeTopClientIds.push( childId );
+			}
+		}
+	}
+	return {
+		ancestorClientIds,
+		innerChildClientIds: getBlockOrder( clientId ),
+		chromeTopClientIds,
+		chromeDescendantClientIds:
+			chromeTopClientIds.length > 0
+				? getClientIdsOfDescendants( chromeTopClientIds )
+				: [],
+	};
+}

--- a/packages/block-library/src/template-content/test/edit.js
+++ b/packages/block-library/src/template-content/test/edit.js
@@ -1,0 +1,117 @@
+/**
+ * Internal dependencies
+ */
+import { selectWrapModeClientIds } from '../select-wrap-mode-client-ids';
+
+/**
+ * Builds a fake `select( blockEditorStore )` from a flat tree map. The map
+ * keys are container client ids (use `''` for the canvas root), values are
+ * the children's client ids.
+ *
+ * @param {Record<string, string[]>} order Block-order map.
+ */
+function makeSelectors( order ) {
+	// Walk children → parents lookup.
+	const parents = new Map();
+	for ( const [ container, children ] of Object.entries( order ) ) {
+		for ( const child of children ) {
+			parents.set( child, container );
+		}
+	}
+	const ancestorsOf = ( id ) => {
+		const out = [];
+		let p = parents.get( id );
+		while ( p !== undefined && p !== '' ) {
+			out.unshift( p );
+			p = parents.get( p );
+		}
+		return out;
+	};
+	const descendantsOf = ( ids ) => {
+		const out = [];
+		const walk = ( id ) => {
+			for ( const child of order[ id ] ?? [] ) {
+				out.push( child );
+				walk( child );
+			}
+		};
+		ids.forEach( walk );
+		return out;
+	};
+	return {
+		getBlockOrder: ( id = '' ) => order[ id ] ?? [],
+		getBlockParents: ancestorsOf,
+		getClientIdsOfDescendants: descendantsOf,
+	};
+}
+
+describe( 'selectWrapModeClientIds', () => {
+	test( 'classifies blocks correctly when template-content is nested', () => {
+		// Mirrors TT5's root.html shape:
+		//
+		//   root
+		//   ├── group (ancestor of TC)
+		//   │   ├── header  (chrome top)
+		//   │   │   └── header-title  (chrome descendant)
+		//   │   ├── tc  (template-content)
+		//   │   │   └── inner-para  (inner child)
+		//   │   └── footer  (chrome top)
+		//   │       └── footer-para  (chrome descendant)
+		//   └── root-para  (chrome top)
+		const selectors = makeSelectors( {
+			'': [ 'group', 'root-para' ],
+			group: [ 'header', 'tc', 'footer' ],
+			header: [ 'header-title' ],
+			tc: [ 'inner-para' ],
+			footer: [ 'footer-para' ],
+		} );
+
+		const result = selectWrapModeClientIds( selectors, 'tc' );
+
+		expect( result.ancestorClientIds ).toEqual( [ 'group' ] );
+		expect( result.innerChildClientIds ).toEqual( [ 'inner-para' ] );
+		expect( new Set( result.chromeTopClientIds ) ).toEqual(
+			new Set( [ 'root-para', 'header', 'footer' ] )
+		);
+		expect( new Set( result.chromeDescendantClientIds ) ).toEqual(
+			new Set( [ 'header-title', 'footer-para' ] )
+		);
+		// template-content itself must NOT appear in any chrome bucket; the
+		// caller sets its mode separately, and lumping it in with chrome
+		// previously caused descendants to clobber template-content's mode.
+		expect( result.chromeTopClientIds ).not.toContain( 'tc' );
+		expect( result.chromeDescendantClientIds ).not.toContain( 'tc' );
+		expect( result.chromeDescendantClientIds ).not.toContain(
+			'inner-para'
+		);
+	} );
+
+	test( 'handles a flat tree with template-content at the canvas root', () => {
+		const selectors = makeSelectors( {
+			'': [ 'header', 'tc', 'footer' ],
+			tc: [ 'inner-para' ],
+		} );
+
+		const result = selectWrapModeClientIds( selectors, 'tc' );
+
+		expect( result.ancestorClientIds ).toEqual( [] );
+		expect( result.innerChildClientIds ).toEqual( [ 'inner-para' ] );
+		expect( new Set( result.chromeTopClientIds ) ).toEqual(
+			new Set( [ 'header', 'footer' ] )
+		);
+		expect( result.chromeDescendantClientIds ).toEqual( [] );
+	} );
+
+	test( 'returns empty buckets when clientId is missing', () => {
+		const selectors = makeSelectors( {} );
+
+		const result = selectWrapModeClientIds( selectors, null );
+
+		expect( result ).toEqual( {
+			ancestorClientIds: [],
+			innerChildClientIds: [],
+			chromeTopClientIds: [],
+			chromeDescendantClientIds: [],
+		} );
+	} );
+} );

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Update `registerBlockType` to accept the attributes type as a generic.
 - Update `registerBlockVariation`, `unregisterBlockVariation` type signature to match the dispatch call.
+- `isTemplatePart()` now also returns `true` for `core/template-content`, so the editor surfaces both blocks with the same "synced" visual treatment (List View row colour, icon colour, outline).
 
 ## 15.17.0 (2026-04-15)
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -372,6 +372,8 @@ _Returns_
 
 Determines whether or not the given block is a template part. This is a special block type that allows composing a page template out of reusable design elements.
 
+Also returns true for `core/template-content`, the root-template wrapper block, so it inherits the same "synced" visual treatment in the editor (List View row colour, icon colour, outline) as a template part.
+
 _Parameters_
 
 -   _blockOrType_ `Block | BlockType | null | undefined`: Block or Block Type to test.

--- a/packages/blocks/src/api/registration.ts
+++ b/packages/blocks/src/api/registration.ts
@@ -508,6 +508,10 @@ export function isReusableBlock(
  * special block type that allows composing a page template out of reusable
  * design elements.
  *
+ * Also returns true for `core/template-content`, the root-template wrapper
+ * block, so it inherits the same "synced" visual treatment in the editor
+ * (List View row colour, icon colour, outline) as a template part.
+ *
  * @param blockOrType Block or Block Type to test.
  *
  * @return Whether the given block is a template part.
@@ -515,7 +519,10 @@ export function isReusableBlock(
 export function isTemplatePart(
 	blockOrType: Block | BlockType | null | undefined
 ): boolean {
-	return blockOrType?.name === 'core/template-part';
+	return (
+		blockOrType?.name === 'core/template-part' ||
+		blockOrType?.name === 'core/template-content'
+	);
 }
 
 /**

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Support for an opt-in `root.html` template: themes that ship one get site-wide chrome (header, footer, sidebars) defined once. Opening a non-root template in the Site Editor renders that template inside `root.html` via `core/template-content`, with the surrounding chrome locked but selectable. A new "Edit root template" toolbar item appears on chrome blocks for switching to editing root.html itself, and the templates browse sidebar surfaces a quick "Root template" link.
+
 ## 6.45.0 (2026-04-29)
 
 ## 6.44.0 (2026-04-15)

--- a/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
+++ b/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
@@ -88,11 +88,14 @@ export default function useNavigateToEntityRecord() {
 				} );
 			}
 
-			// Navigate to the new entity record
-			const queryArgs = {
-				canvas: 'edit',
-				focusMode: true,
-			};
+			// Navigate to the new entity record. Callers can opt out of
+			// focus mode (e.g. `core/template-content` opens the chosen
+			// template in the regular template editor, where root.html
+			// wraps it, instead of an isolated focus view).
+			const queryArgs = { canvas: 'edit' };
+			if ( params.focusMode !== false ) {
+				queryArgs.focusMode = true;
+			}
 			if ( isValidRequestedViewport ) {
 				queryArgs.viewport = requestedViewport;
 			}

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -17,7 +17,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { privateApis as blockLibraryPrivateApis } from '@wordpress/block-library';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -122,7 +122,7 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 	const entity = useResolveEditedEntity();
 	// deprecated sync state with url
 	useSyncDeprecatedEntityIntoState( entity );
-	const { postType, postId, context } = entity;
+	const { postType, postId, context, innerTemplateId } = entity;
 	const { isBlockBasedTheme, hasSiteIcon } = useSelect( ( select ) => {
 		const { getCurrentTheme, getEntityRecord } = select( coreDataStore );
 		const siteData = getEntityRecord( 'root', '__unstableBase', undefined );
@@ -135,7 +135,11 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 	const postWithTemplate = !! context?.postId;
 	useEditorTitle(
 		postWithTemplate ? context.postType : postType,
-		postWithTemplate ? context.postId : postId
+		postWithTemplate ? context.postId : postId,
+		// In wrap mode the entity is root.html but the user navigated to
+		// the inner template — surface that to the title so the browser
+		// tab reflects what's being edited.
+		postWithTemplate ? null : innerTemplateId
 	);
 	const _isPreviewingTheme = isPreviewingTheme();
 	const iframeProps = useEditorIframeProps();
@@ -145,7 +149,14 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 		'edit-site-editor__loading-progress'
 	);
 
-	const editorSettings = useSpecificEditorSettings();
+	const baseEditorSettings = useSpecificEditorSettings();
+	const editorSettings = useMemo(
+		() => ( {
+			...baseEditorSettings,
+			__experimentalRootInnerTemplateId: innerTemplateId,
+		} ),
+		[ baseEditorSettings, innerTemplateId ]
+	);
 	const { resetZoomLevel } = unlock( useDispatch( blockEditorStore ) );
 	const { setCurrentRevisionId } = unlock( useDispatch( editorStore ) );
 	const { createSuccessNotice } = useDispatch( noticesStore );

--- a/packages/edit-site/src/components/editor/use-editor-title.js
+++ b/packages/edit-site/src/components/editor/use-editor-title.js
@@ -16,7 +16,7 @@ import { unlock } from '../../lock-unlock';
 
 const { getTemplateInfo } = unlock( editorPrivateApis );
 
-function useEditorTitle( postType, postId ) {
+function useEditorTitle( postType, postId, innerTemplateId ) {
 	const { title, isLoaded } = useSelect(
 		( select ) => {
 			const {
@@ -29,10 +29,18 @@ function useEditorTitle( postType, postId ) {
 				return { isLoaded: false };
 			}
 
+			// In wrap mode the entity being edited is `root.html`, but the
+			// user navigated to the inner template (e.g. `archive`). Use
+			// the inner template's record for the displayed title so the
+			// browser tab matches the on-screen DocumentBar.
+			const displayedPostType = innerTemplateId
+				? 'wp_template'
+				: postType;
+			const displayedPostId = innerTemplateId ?? postId;
 			const _record = getEditedEntityRecord(
 				'postType',
-				postType,
-				postId
+				displayedPostType,
+				displayedPostId
 			);
 
 			const { default_template_types: templateTypes = [] } =
@@ -45,8 +53,8 @@ function useEditorTitle( postType, postId ) {
 
 			const _isLoaded = hasFinishedResolution( 'getEditedEntityRecord', [
 				'postType',
-				postType,
-				postId,
+				displayedPostType,
+				displayedPostId,
 			] );
 
 			return {
@@ -54,7 +62,7 @@ function useEditorTitle( postType, postId ) {
 				isLoaded: _isLoaded,
 			};
 		},
-		[ postType, postId ]
+		[ postType, postId, innerTemplateId ]
 	);
 
 	let editorTitle;

--- a/packages/edit-site/src/components/editor/use-resolve-edited-entity.js
+++ b/packages/edit-site/src/components/editor/use-resolve-edited-entity.js
@@ -3,7 +3,7 @@
  */
 import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { store as coreDataStore } from '@wordpress/core-data';
+import { store as coreDataStore, useEntityRecord } from '@wordpress/core-data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
@@ -71,6 +71,25 @@ export function useResolveEditedEntity() {
 		const { getHomePage } = unlock( select( coreDataStore ) );
 		return getHomePage();
 	}, [] );
+
+	// Resolve the active theme's `root` template id (if any). This drives the
+	// "root template" wrapping behavior: clicking any other template renders
+	// it inside `root` with `core/template-content` as the editable slot,
+	// matching how the live frontend stacks them.
+	//
+	// `useEntityRecord` (vs. a bare `getEntityRecord` selector) auto-fetches
+	// and reports `hasResolved`, so we can keep the editor in a loading state
+	// until we know whether root exists rather than briefly rendering the
+	// wrap-less version and flickering into wrap mode once root loads.
+	const stylesheet = useSelect(
+		( select ) => select( coreDataStore ).getCurrentTheme()?.stylesheet,
+		[]
+	);
+	const rootTemplateId = stylesheet ? `${ stylesheet }//root` : null;
+	const { record: rootTemplate, hasResolved: hasResolvedRoot } =
+		useEntityRecord( 'postType', TEMPLATE_POST_TYPE, rootTemplateId ?? '', {
+			enabled: !! rootTemplateId,
+		} );
 
 	/**
 	 * This is a hook that recreates the logic to resolve a template for a given WordPress postID postTypeId
@@ -148,6 +167,38 @@ export function useResolveEditedEntity() {
 		};
 	} else {
 		entity = { isReady: false };
+	}
+
+	// Root-template wrap: when the active theme has `root.html` and the user
+	// is editing a different `wp_template`, render `root` as the canvas
+	// entity and expose the requested template id as `innerTemplateId`. The
+	// `core/template-content` block reads it via the editor settings and
+	// renders that template's blocks editably inside the root chrome.
+	//
+	// `?focusMode=true` (added by `onNavigateToEntityRecord`, e.g. from the
+	// "Edit original" toolbar on `core/template-content`) bypasses the wrap
+	// so users can drill in to an isolated single-template canvas.
+	//
+	// We hold off on declaring the entity ready until the root lookup has
+	// resolved — otherwise the canvas first paints with the inner template
+	// directly and then re-renders into wrap mode, which feels like a flash.
+	if (
+		rootTemplateId &&
+		entity.isReady &&
+		entity.postType === TEMPLATE_POST_TYPE &&
+		entity.postId &&
+		entity.postId !== rootTemplateId &&
+		! query?.focusMode
+	) {
+		if ( ! hasResolvedRoot ) {
+			entity = { ...entity, isReady: false };
+		} else if ( rootTemplate ) {
+			entity = {
+				...entity,
+				postId: rootTemplateId,
+				innerTemplateId: entity.postId,
+			};
+		}
 	}
 
 	// Restore selection from URL synchronously, before EditorProvider renders.

--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -58,12 +58,81 @@ function useAllDefaultTemplateTypes() {
 	];
 }
 
+/**
+ * Walks a parsed block tree and substitutes any `core/template-content` it
+ * finds with the supplied inner-template blocks. Used to make preview
+ * thumbnails match the frontend, where root.html wraps every other template.
+ *
+ * @param {Object[]} blocks      Parsed block tree to walk.
+ * @param {Object[]} replacement Blocks to drop in where template-content lives.
+ * @return {[Object[], boolean]} The transformed tree and a flag indicating
+ *                               whether template-content was actually found.
+ */
+function substituteTemplateContent( blocks, replacement ) {
+	let found = false;
+	const walk = ( current ) => {
+		const out = [];
+		for ( const block of current ) {
+			if ( block.name === 'core/template-content' ) {
+				found = true;
+				out.push( ...replacement );
+				continue;
+			}
+			if ( block.innerBlocks?.length ) {
+				out.push( {
+					...block,
+					innerBlocks: walk( block.innerBlocks ),
+				} );
+			} else {
+				out.push( block );
+			}
+		}
+		return out;
+	};
+	return [ walk( blocks ), found ];
+}
+
 function PreviewField( { item } ) {
 	const settings = usePatternSettings();
 	const backgroundColor = useStyle( 'color.background' ) ?? 'white';
+
+	const ownBlocks = useMemo(
+		() => parse( item.content.raw ),
+		[ item.content.raw ]
+	);
+
+	// When the active theme has a root.html template and this item is a
+	// non-root template (not a template part, not root itself), pull in
+	// root's content so the thumbnail matches the wrapped frontend output.
+	const rootContent = useSelect(
+		( select ) => {
+			if (
+				item.type !== 'wp_template' ||
+				item.slug === 'root' ||
+				! item.theme
+			) {
+				return null;
+			}
+			const record = select( coreStore ).getEntityRecord(
+				'postType',
+				'wp_template',
+				`${ item.theme }//root`
+			);
+			return record?.content?.raw ?? null;
+		},
+		[ item.type, item.slug, item.theme ]
+	);
+
 	const blocks = useMemo( () => {
-		return parse( item.content.raw );
-	}, [ item.content.raw ] );
+		if ( ! rootContent ) {
+			return ownBlocks;
+		}
+		const [ wrapped, found ] = substituteTemplateContent(
+			parse( rootContent ),
+			ownBlocks
+		);
+		return found ? wrapped : ownBlocks;
+	}, [ rootContent, ownBlocks ] );
 
 	const isEmpty = ! blocks?.length;
 	// Wrap everything in a block editor provider to ensure 'styles' that are needed

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { Fragment } from '@wordpress/element';
 import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import {
@@ -39,6 +40,7 @@ const defaultResolveIcon = ( view ) => {
 export default function DataViewsSidebarContent( {
 	postType,
 	resolveIcon = defaultResolveIcon,
+	appendItems,
 } ) {
 	const {
 		path,
@@ -55,21 +57,29 @@ export default function DataViewsSidebarContent( {
 	return (
 		<>
 			<ItemGroup className="edit-site-sidebar-dataviews">
-				{ viewList?.map( ( view ) => {
+				{ viewList?.map( ( view, index ) => {
 					const isActive = view.slug === activeView;
 					const slug = view.slug === 'all' ? undefined : view.slug;
 					const icon = resolveIcon( view );
 					return (
-						<SidebarNavigationItem
-							key={ view.slug }
-							icon={ icon }
-							to={ addQueryArgs( path, {
-								activeView: slug,
-							} ) }
-							aria-current={ isActive ? 'true' : undefined }
-						>
-							{ view.title }
-						</SidebarNavigationItem>
+						<Fragment key={ view.slug }>
+							<SidebarNavigationItem
+								icon={ icon }
+								to={ addQueryArgs( path, {
+									activeView: slug,
+								} ) }
+								aria-current={ isActive ? 'true' : undefined }
+							>
+								{ view.title }
+							</SidebarNavigationItem>
+							{ /*
+							 * Render `appendItems` immediately after the first
+							 * view (typically the catch-all "All templates" /
+							 * "All pages" entry). This promotes the extra item
+							 * above the per-source rows that follow.
+							 */ }
+							{ index === 0 && appendItems }
+						</Fragment>
 					);
 				} ) }
 			</ItemGroup>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content-legacy.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content-legacy.js
@@ -1,8 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { store as coreStore } from '@wordpress/core-data';
+import { store as coreStore, useEntityRecord } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
 import {
 	commentAuthorAvatar,
 	layout,
@@ -15,6 +17,11 @@ import {
  */
 import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 import DataViewsSidebarContent from '../sidebar-dataviews';
+import SidebarNavigationItem from '../sidebar-navigation-item';
+import { unlock } from '../../lock-unlock';
+import rootTemplateIcon from './root-template-icon';
+
+const { useLocation } = unlock( routerPrivateApis );
 
 const SOURCE_TO_ICON = {
 	user: commentAuthorAvatar,
@@ -22,7 +29,9 @@ const SOURCE_TO_ICON = {
 	plugin: pluginIcon,
 	site: globe,
 };
+
 export default function DataviewsTemplatesSidebarContent() {
+	const { params } = useLocation();
 	const authorSourceMap = useSelect( ( select ) => {
 		const templates = select( coreStore ).getEntityRecords(
 			'postType',
@@ -50,10 +59,40 @@ export default function DataviewsTemplatesSidebarContent() {
 		return SOURCE_TO_ICON[ source ] ?? layout;
 	};
 
+	// If the active theme provides a `root.html`, append a "Root template"
+	// link inside the same ItemGroup as the per-source views, so it reads
+	// as a peer entry with consistent left-alignment. `useEntityRecord`
+	// (vs. `useSelect`) so the lookup is auto-fetched and we know when it
+	// has resolved.
+	const stylesheet = useSelect(
+		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet,
+		[]
+	);
+	const rootTemplateId = stylesheet ? `${ stylesheet }//root` : null;
+	const { record: rootTemplate, hasResolved: hasResolvedRoot } =
+		useEntityRecord( 'postType', TEMPLATE_POST_TYPE, rootTemplateId ?? '', {
+			enabled: !! rootTemplateId,
+		} );
+	const showRootEntry = hasResolvedRoot && !! rootTemplate;
+	const isEditingRoot =
+		params?.postId &&
+		decodeURIComponent( params.postId ) === rootTemplateId;
+
+	const appendItems = showRootEntry ? (
+		<SidebarNavigationItem
+			to={ `/wp_template/${ rootTemplateId }?canvas=edit` }
+			icon={ rootTemplateIcon }
+			aria-current={ isEditingRoot }
+		>
+			{ __( 'Root template' ) }
+		</SidebarNavigationItem>
+	) : null;
+
 	return (
 		<DataViewsSidebarContent
 			postType={ TEMPLATE_POST_TYPE }
 			resolveIcon={ resolveIcon }
+			appendItems={ appendItems }
 		/>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useEntityRecords } from '@wordpress/core-data';
+import {
+	store as coreStore,
+	useEntityRecord,
+	useEntityRecords,
+} from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -15,6 +20,7 @@ import SidebarNavigationItem from '../sidebar-navigation-item';
 import { useAddedBy } from '../page-templates/hooks';
 import { commentAuthorAvatar, published } from '@wordpress/icons';
 import { unlock } from '../../lock-unlock';
+import rootTemplateIcon from './root-template-icon';
 
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -36,6 +42,7 @@ function TemplateDataviewItem( { template, isActive } ) {
 
 export default function DataviewsTemplatesSidebarContent() {
 	const {
+		params,
 		query: { activeView = 'active' },
 	} = useLocation();
 	const { records } = useEntityRecords( 'root', 'registeredTemplate', {
@@ -58,6 +65,25 @@ export default function DataviewsTemplatesSidebarContent() {
 		);
 	}, [ records ] );
 
+	// If the active theme provides a `root.html`, surface a quick "Root
+	// template" link inside the same ItemGroup as the per-source views so
+	// it reads as a peer entry with consistent left-alignment. Promoted
+	// out of the per-source views because it's the most common thing an
+	// author of a root-template-based theme will want to edit.
+	const stylesheet = useSelect(
+		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet,
+		[]
+	);
+	const rootTemplateId = stylesheet ? `${ stylesheet }//root` : null;
+	const { record: rootTemplate, hasResolved: hasResolvedRoot } =
+		useEntityRecord( 'postType', 'wp_template', rootTemplateId ?? '', {
+			enabled: !! rootTemplateId,
+		} );
+	const showRootEntry = hasResolvedRoot && !! rootTemplate;
+	const isEditingRoot =
+		params?.postId &&
+		decodeURIComponent( params.postId ) === rootTemplateId;
+
 	return (
 		<ItemGroup className="edit-site-sidebar-navigation-screen-templates-browse">
 			<SidebarNavigationItem
@@ -67,6 +93,15 @@ export default function DataviewsTemplatesSidebarContent() {
 			>
 				{ __( 'Active templates' ) }
 			</SidebarNavigationItem>
+			{ showRootEntry && (
+				<SidebarNavigationItem
+					to={ `/wp_template/${ rootTemplateId }?canvas=edit` }
+					icon={ rootTemplateIcon }
+					aria-current={ isEditingRoot }
+				>
+					{ __( 'Root template' ) }
+				</SidebarNavigationItem>
+			) }
 			<SidebarNavigationItem
 				to={ addQueryArgs( '/template', { activeView: 'user' } ) }
 				icon={ commentAuthorAvatar }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/root-template-icon.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/root-template-icon.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/primitives';
+
+/**
+ * Mirror of the `core/template-content` block icon. Lives in `edit-site`
+ * because the block-library copy is private; sharing one source file
+ * between the two sidebar variants (new + legacy) keeps them in sync.
+ */
+const rootTemplateIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M18 5.5H6a.5.5 0 00-.5.5v3h13V6a.5.5 0 00-.5-.5zm-10 5H5.5V18a.5.5 0 00.5.5h2.5v-8zM6 4h12a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2z" />
+		<Path d="M10 10.5h8.5V18a.5.5 0 01-.5.5h-8z" />
+	</SVG>
+);
+
+export default rootTemplateIcon;

--- a/packages/edit-site/src/hooks/wrap-mode-root-edit-toolbar.js
+++ b/packages/edit-site/src/hooks/wrap-mode-root-edit-toolbar.js
@@ -1,0 +1,111 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+import {
+	BlockControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { ToolbarButton } from '@wordpress/components';
+import { store as editorStore } from '@wordpress/editor';
+
+const TEMPLATE_CONTENT_BLOCK = 'core/template-content';
+const TEMPLATE_PART_BLOCK = 'core/template-part';
+
+/**
+ * Adds an "Edit root template" toolbar item to chrome blocks when the Site
+ * Editor is wrapping a non-root template inside `root.html`. A chrome block
+ * is one of the blocks in `root.html` that lives outside `core/template-
+ * content`'s subtree — its editing mode is locked to `'contentOnly'` so it
+ * stays selectable, and the toolbar item gives the user a way to switch
+ * into editing root.html itself.
+ *
+ * Returns the unwrapped `BlockEdit` (no extra controls) for blocks that
+ * aren't chrome — the inner template's blocks, `template-content` itself,
+ * the entire tree when not wrapping, and any post types other than
+ * `wp_template`.
+ */
+const withWrapModeRootEditToolbar = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		const { clientId, name } = props;
+		const {
+			innerTemplateId,
+			editingMode,
+			isInsideInnerTemplate,
+			rootPostId,
+			rootPostType,
+			onNavigateToEntityRecord,
+		} = useSelect(
+			( select ) => {
+				const {
+					getSettings,
+					getBlockEditingMode,
+					getBlockParentsByBlockName,
+				} = select( blockEditorStore );
+				const { getCurrentPostId, getCurrentPostType } =
+					select( editorStore );
+				const settings = getSettings();
+				return {
+					innerTemplateId:
+						settings.__experimentalRootInnerTemplateId ?? null,
+					editingMode: clientId
+						? getBlockEditingMode( clientId )
+						: null,
+					isInsideInnerTemplate:
+						clientId &&
+						getBlockParentsByBlockName(
+							clientId,
+							TEMPLATE_CONTENT_BLOCK
+						).length > 0,
+					rootPostId: getCurrentPostId(),
+					rootPostType: getCurrentPostType(),
+					onNavigateToEntityRecord: settings.onNavigateToEntityRecord,
+				};
+			},
+			[ clientId ]
+		);
+
+		// `core/template-part` already exposes an "Edit" toolbar action that
+		// navigates to the template part entity. Showing "Edit root template"
+		// alongside it would be ambiguous, so skip the filter for that block.
+		const showToolbar =
+			!! innerTemplateId &&
+			editingMode === 'contentOnly' &&
+			name !== TEMPLATE_CONTENT_BLOCK &&
+			name !== TEMPLATE_PART_BLOCK &&
+			! isInsideInnerTemplate &&
+			!! onNavigateToEntityRecord &&
+			!! rootPostId;
+
+		return (
+			<>
+				{ showToolbar && (
+					<BlockControls group="other">
+						<ToolbarButton
+							onClick={ () =>
+								onNavigateToEntityRecord( {
+									postId: rootPostId,
+									postType: rootPostType,
+									focusMode: false,
+								} )
+							}
+						>
+							{ __( 'Edit root template' ) }
+						</ToolbarButton>
+					</BlockControls>
+				) }
+				<BlockEdit { ...props } />
+			</>
+		);
+	},
+	'withWrapModeRootEditToolbar'
+);
+
+addFilter(
+	'editor.BlockEdit',
+	'edit-site/wrap-mode-root-edit-toolbar',
+	withWrapModeRootEditToolbar
+);

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -23,6 +23,7 @@ import {
 import { store as editSiteStore } from './store';
 import { unlock } from './lock-unlock';
 import App from './components/app';
+import './hooks/wrap-mode-root-edit-toolbar';
 
 const { registerCoreBlockBindingsSources } = unlock( editorPrivateApis );
 

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -91,6 +91,19 @@ export default function DocumentBar( props ) {
 		} = select( coreStore );
 		const _postType = getCurrentPostType();
 		const _postId = getCurrentPostId();
+		// When the Site Editor wraps a non-root template inside `root.html`,
+		// the entity being edited is root.html but the user navigated to the
+		// inner template (e.g. "archive"). Surface the inner template's
+		// identity so the title bar reflects what the user is editing.
+		const _innerTemplateId =
+			getEditorSettings().__experimentalRootInnerTemplateId;
+		const _displayedDocument = _innerTemplateId
+			? getEditedEntityRecord(
+					'postType',
+					'wp_template',
+					_innerTemplateId
+			  )
+			: getEditedEntityRecord( 'postType', _postType, _postId );
 		const _document = getEditedEntityRecord(
 			'postType',
 			_postType,
@@ -102,7 +115,7 @@ export default function DocumentBar( props ) {
 
 		const _templateInfo = getTemplateInfo( {
 			templateTypes,
-			template: _document,
+			template: _displayedDocument,
 		} );
 		const _postTypeLabel = getPostType( _postType )?.labels?.singular_name;
 
@@ -121,7 +134,7 @@ export default function DocumentBar( props ) {
 			postId: _postId,
 			postType: _postType,
 			postTypeLabel: _postTypeLabel,
-			documentTitle: _document.title,
+			documentTitle: _displayedDocument.title,
 			isNotFound:
 				! _document &&
 				! isResolvingSelector(

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -50,6 +50,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__experimentalDiscussionSettings',
 	'__experimentalFeatures',
 	'__experimentalGlobalStylesBaseStyles',
+	'__experimentalRootInnerTemplateId',
 	'allImageSizes',
 	'alignWide',
 	'blockInspectorTabs',

--- a/phpunit/root-template-test.php
+++ b/phpunit/root-template-test.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Tests for the root template feature: the `template_include` swap and the
+ * `core/template-content` block's render callback (recursion guard +
+ * stashed-id resolution).
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * @group blocks
+ */
+class Root_Template_Test extends WP_UnitTestCase {
+	/**
+	 * Saved theme to restore after each test, so we can switch into the
+	 * bundled `twentytwentyfive` test theme that ships in `test/`.
+	 */
+	private $original_stylesheet;
+	private $original_template;
+	private $original_globals;
+
+	public function set_up() {
+		parent::set_up();
+		// The render-callback assertions below call the gutenberg-prefixed
+		// function name from the built block file. If a contributor runs
+		// PHPUnit before building, the block isn't registered yet — skip
+		// rather than failing with an opaque "undefined function" error.
+		if (
+			! function_exists( 'gutenberg_render_block_core_template_content' )
+		) {
+			$this->markTestSkipped(
+				'core/template-content block not built. Run `npm run build` first.'
+			);
+		}
+
+		$this->original_stylesheet = get_stylesheet();
+		$this->original_template   = get_template();
+		$this->original_globals    = array(
+			'_wp_current_template_id'       => $GLOBALS['_wp_current_template_id'] ?? null,
+			'_wp_current_template_content'  => $GLOBALS['_wp_current_template_content'] ?? null,
+			'_wp_current_inner_template_id' => $GLOBALS['_wp_current_inner_template_id'] ?? null,
+		);
+		// Reset the static cache between tests so each test sees the current
+		// theme's root template.
+		gutenberg_get_root_block_template( true );
+	}
+
+	public function tear_down() {
+		// Restore globals.
+		foreach ( $this->original_globals as $key => $value ) {
+			if ( null === $value ) {
+				unset( $GLOBALS[ $key ] );
+			} else {
+				$GLOBALS[ $key ] = $value;
+			}
+		}
+		gutenberg_get_root_block_template( true );
+		parent::tear_down();
+	}
+
+	/**
+	 * The swap should not run when no template id is set in the request.
+	 */
+	public function test_swap_noop_when_no_current_template() {
+		$GLOBALS['_wp_current_template_id']      = '';
+		$GLOBALS['_wp_current_template_content'] = '';
+
+		$result = gutenberg_root_template_swap( '/path/to/template-canvas.php' );
+
+		$this->assertSame( '/path/to/template-canvas.php', $result );
+		$this->assertEmpty( $GLOBALS['_wp_current_template_id'] );
+		$this->assertArrayNotHasKey(
+			'_wp_current_inner_template_id',
+			$GLOBALS
+		);
+	}
+
+	/**
+	 * The swap should not run when the resolved template is already root —
+	 * otherwise we'd render root inside root and rely on the recursion guard.
+	 */
+	public function test_swap_noop_when_already_rendering_root() {
+		$GLOBALS['_wp_current_template_id']      = get_stylesheet() . '//root';
+		$GLOBALS['_wp_current_template_content'] = '<!-- wp:paragraph --><p>root</p><!-- /wp:paragraph -->';
+
+		gutenberg_root_template_swap( '/path' );
+
+		$this->assertSame(
+			get_stylesheet() . '//root',
+			$GLOBALS['_wp_current_template_id']
+		);
+		$this->assertArrayNotHasKey(
+			'_wp_current_inner_template_id',
+			$GLOBALS
+		);
+	}
+
+	/**
+	 * When the active theme has no root template, the swap is a no-op even
+	 * if a non-root template is being rendered.
+	 */
+	public function test_swap_noop_when_no_root_template_in_theme() {
+		// `default` theme (used in the unit-test bootstrap) has no root.html.
+		$GLOBALS['_wp_current_template_id']      = get_stylesheet() . '//archive';
+		$GLOBALS['_wp_current_template_content'] = '<!-- wp:paragraph --><p>archive</p><!-- /wp:paragraph -->';
+
+		gutenberg_root_template_swap( '/path' );
+
+		$this->assertSame(
+			get_stylesheet() . '//archive',
+			$GLOBALS['_wp_current_template_id']
+		);
+		$this->assertArrayNotHasKey(
+			'_wp_current_inner_template_id',
+			$GLOBALS
+		);
+	}
+
+	/**
+	 * The render callback returns empty (no markup) when no inner template
+	 * id has been stashed by the swap — i.e. the block was rendered outside
+	 * a wrapped request.
+	 */
+	public function test_render_callback_returns_empty_without_stashed_id() {
+		unset( $GLOBALS['_wp_current_inner_template_id'] );
+
+		$rendered = gutenberg_render_block_core_template_content();
+
+		$this->assertSame( '', $rendered );
+	}
+
+	/**
+	 * The render callback returns empty when the stashed inner template id
+	 * doesn't resolve to a real template (e.g. theme uninstalled, slug
+	 * misspelled in `root.html`).
+	 */
+	public function test_render_callback_returns_empty_for_missing_template() {
+		$GLOBALS['_wp_current_inner_template_id'] = 'nonexistent-theme//does-not-exist';
+
+		$rendered = gutenberg_render_block_core_template_content();
+		$this->assertSame( '', $rendered );
+	}
+
+	// The static `$seen_ids` recursion guard mirrors the same pattern used
+	// by `core/template-part` and `core/post-content`. Exercising the
+	// actual reentry path requires a real `wp_template` registered through
+	// the block-template-utils file/post pipeline — not reliably
+	// reproducible from a unit-test fixture without bundling a test
+	// theme. The guard is covered manually and via the e2e flow that
+	// edits root.html with a template-content block inside.
+}

--- a/test/e2e/specs/site-editor/root-template.spec.js
+++ b/test/e2e/specs/site-editor/root-template.spec.js
@@ -1,0 +1,173 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/**
+ * Token coverage for the root-template feature: when the active theme has a
+ * `root.html`, the Site Editor should wrap non-root templates inside it
+ * (the regular editor stays in wrap mode rather than dropping into focus
+ * mode). Root.html itself opens directly.
+ *
+ * Manually verifying the preview-picker, the chrome locking, and the
+ * frontend `template_include` swap is out of scope here — those are
+ * smoke-test territory. This spec guards the URL routing and that the
+ * editor applies the wrap (via `__experimentalRootInnerTemplateId`).
+ *
+ * The root template is created via a direct REST POST rather than
+ * `requestUtils.createTemplate`, because that helper hardcodes
+ * `is_wp_suggestion: true`, which prevents the entity from showing up via
+ * `useEntityRecord` lookup-by-id in the editor.
+ */
+test.describe( 'Root template: wrap routing', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.beforeEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/templates',
+			params: {
+				slug: 'root',
+				title: 'Root',
+				content:
+					'<!-- wp:group {"tagName":"main"} --><main class="wp-block-group"><!-- wp:paragraph --><p>Root chrome paragraph</p><!-- /wp:paragraph --><!-- wp:template-content /--></main><!-- /wp:group -->',
+				status: 'publish',
+			},
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'wraps non-root templates inside root.html (no focus mode)', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitSiteEditor();
+		await page.click( 'role=button[name="Templates"]' );
+
+		// Click any template other than Root. `Index` is the catch-all that
+		// emptytheme always provides.
+		await page
+			.locator( '.fields-field__title', { hasText: 'Index' } )
+			.click();
+
+		// The user URL points at the inner template …
+		// Path is URL-encoded in the `p=` query param.
+		await expect( page ).toHaveURL( /wp_template%2Femptytheme%2F%2Findex/ );
+		await expect( page ).not.toHaveURL( /focusMode=true/ );
+
+		// … but the editor wraps it in root.html, exposed via the inner
+		// template id setting. The block-editor settings can be polled via
+		// `wp.data` once the editor has booted.
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core/block-editor' )
+							.getSettings().__experimentalRootInnerTemplateId
+				)
+			)
+			.toBe( 'emptytheme//index' );
+	} );
+
+	test( 'opens root.html itself in the regular editor (no focus mode)', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitSiteEditor();
+		await page.click( 'role=button[name="Templates"]' );
+
+		await page
+			.locator( '.fields-field__title', { hasText: 'Root' } )
+			.click();
+
+		// The path is URL-encoded in the `p=` query param.
+		await expect( page ).toHaveURL( /wp_template%2Femptytheme%2F%2Froot/ );
+		await expect( page ).not.toHaveURL( /focusMode=true/ );
+	} );
+
+	test( 'surfaces "Edit root template" only on chrome blocks', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitSiteEditor();
+		await page.click( 'role=button[name="Templates"]' );
+
+		await page
+			.locator( '.fields-field__title', { hasText: 'Index' } )
+			.click();
+
+		// Wait for wrap mode to apply. Chrome blocks should be 'contentOnly'.
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core/block-editor' )
+							.getSettings().__experimentalRootInnerTemplateId
+				)
+			)
+			.toBe( 'emptytheme//index' );
+
+		// Select the root chrome paragraph (a chrome top, not template-part).
+		const chromeParagraphId = await page.evaluate( () => {
+			const sel = window.wp.data.select( 'core/block-editor' );
+			// Walk the tree to find the chrome paragraph by its content.
+			const walk = ( id ) => {
+				const block = sel.getBlock( id );
+				if (
+					block?.name === 'core/paragraph' &&
+					block?.attributes?.content?.includes?.( 'Root chrome' )
+				) {
+					return id;
+				}
+				for ( const child of sel.getBlockOrder( id ) ) {
+					const found = walk( child );
+					if ( found ) {
+						return found;
+					}
+				}
+				return null;
+			};
+			return walk( '' );
+		} );
+		await page.evaluate( ( id ) => {
+			window.wp.data.dispatch( 'core/block-editor' ).selectBlock( id );
+		}, chromeParagraphId );
+
+		// The toolbar item shows up.
+		await expect(
+			page.getByRole( 'button', { name: 'Edit root template' } )
+		).toBeVisible();
+
+		// Now select the template-content block. The button should be gone.
+		await page.evaluate( () => {
+			const sel = window.wp.data.select( 'core/block-editor' );
+			const walk = ( id ) => {
+				if ( sel.getBlockName( id ) === 'core/template-content' ) {
+					return id;
+				}
+				for ( const child of sel.getBlockOrder( id ) ) {
+					const found = walk( child );
+					if ( found ) {
+						return found;
+					}
+				}
+				return null;
+			};
+			const tcId = walk( '' );
+			window.wp.data.dispatch( 'core/block-editor' ).selectBlock( tcId );
+		} );
+
+		await expect(
+			page.getByRole( 'button', { name: 'Edit root template' } )
+		).toBeHidden();
+	} );
+} );

--- a/test/integration/fixtures/blocks/core__template-content.html
+++ b/test/integration/fixtures/blocks/core__template-content.html
@@ -1,0 +1,1 @@
+<!-- wp:template-content /-->

--- a/test/integration/fixtures/blocks/core__template-content.json
+++ b/test/integration/fixtures/blocks/core__template-content.json
@@ -1,0 +1,8 @@
+[
+	{
+		"name": "core/template-content",
+		"isValid": true,
+		"attributes": {},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__template-content.parsed.json
+++ b/test/integration/fixtures/blocks/core__template-content.parsed.json
@@ -1,0 +1,9 @@
+[
+	{
+		"blockName": "core/template-content",
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__template-content.serialized.html
+++ b/test/integration/fixtures/blocks/core__template-content.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:template-content /-->


### PR DESCRIPTION
## What?

Introduces an opt-in `root.html` block template that wraps every page on the frontend, plus a new `core/template-content` block (only insertable inside `root.html`) that renders whichever template the WordPress hierarchy would have selected for the current request. When the active theme provides `root.html`, the Site Editor wraps every other template inside it — the chrome is locked but selectable, and authors can switch between editing the inner template and editing root.html via toolbar actions. Template thumbnails in the templates list also render the wrap so previews match the frontend.

## Why?

In block themes, every template currently has its own implementation of header/footer scaffolding. Updating shared chrome (adding a sidebar, changing the header layout, etc.) means editing every template individually. With `root.html`, authors edit shared scaffolding once and have it apply to every page.

This is a proposal — surfacing the pattern for feedback before deeper polish.

## How?

**Frontend.** `lib/compat/wordpress-7.1/root-template.php` hooks `template_include` at the default priority. After WordPress resolves the template hierarchy, if the active theme has a `root` template and the resolved template isn't already `root`, the original template id is stashed in `$GLOBALS['_wp_current_inner_template_id']` and `$_wp_current_template_content` is swapped to root's content. `core/template-content`'s render callback reads that stashed id and runs `do_blocks()` over the inner template, with a static `$seen_ids` recursion guard mirroring `core/template-part` / `core/post-content`.

**Site Editor — wrap mode.** When the user navigates to a non-root template (e.g. `archive`) and the theme has `root.html`, `useResolveEditedEntity` swaps the edited entity to the root template and stashes the original id under `__experimentalRootInnerTemplateId` in editor settings. `core/template-content` reads that setting and renders `useEntityBlockEditor` against the inner template — the inner template's blocks become its children, and edits round-trip to that entity. Surrounding root chrome is locked via `useWrapModeLocking`:

  - Ancestors of `template-content` → `'contentOnly'` (selectable; can't be `'disabled'` because they contain template-content as a descendant).
  - "Chrome top" (every block whose parent is an ancestor or root, but which itself isn't an ancestor or template-content) → `'contentOnly'`.
  - Chrome descendants → `'disabled'` (inert; clicks bubble up to chrome top).
  - `template-content` → `'contentOnly'`; its descendants stay `'default'`.

The id-bucket computation is extracted to a pure function (`selectWrapModeClientIds`) with unit tests covering nested, flat, and missing-clientId cases.

**Site Editor — preview mode.** When the user is editing `root.html` directly, `core/template-content` renders a non-interactive preview via `useBlockPreview` (separate `BlockEditorProvider`, no inner-blocks reparenting). The preview defaults to the home hierarchy (`front-page` → `home` → `index`); a session-local Inspector dropdown switches it. An "Edit template" toolbar action navigates to the previewed template via `onNavigateToEntityRecord` with `focusMode: false`, which extends the existing site-editor navigation helper to honor an opt-out flag.

**Toolbar affordance.** An `editor.BlockEdit` filter registered from edit-site adds an "Edit root template" toolbar button to chrome blocks (`'contentOnly'` editing mode, not `template-content`, not inside the inner template, not a `template-part` since that already has its own Edit action). Clicking navigates to root.html in the regular template editor.

**Visual treatment.** `isTemplatePart()` is extended to recognise `core/template-content` so the block picks up the purple synced-pattern outline and List View row colour. The block ships with a layout-with-solid-bottom-right icon. Its toolbar items live in `BlockControls group="other"`.

**Title bar.** `DocumentBar` and `useEditorTitle` resolve to the inner template's record when `__experimentalRootInnerTemplateId` is set, so both the on-screen title and the browser tab show the template the user is actually editing rather than "Root".

**Templates list.**

  - The sidebar gets a "Root template" link when the active theme has a root.html (only then). Links open root in the regular editor.
  - Template thumbnails parse `root.html`'s blocks and substitute the inner template's blocks into the `core/template-content` slot, so the preview matches what the frontend renders.

**Other touches.**
  - `default_template_types` filter registers a "Root" entry — only when the active theme provides `root.html`.
  - An insertion-guard filter restricts `core/template-content` to root.html.

## Testing instructions

1. In a block theme, add `templates/root.html` with a header, `<!-- wp:template-content /-->`, and a footer.
2. Visit `/`, an archive page, a single post, and a 404 — each renders root's chrome with the hierarchy-resolved template content inside.
3. In the Site Editor, open the templates list. The thumbnails for non-root templates now show the chrome around the template's content. Clicking any non-root template (e.g. Archive) opens it in the regular editor with root.html wrapping it; the inner template's blocks are editable, the chrome around them is selectable but locked.
4. Click any chrome block — the block toolbar shows an **Edit root template** button. Clicking it navigates to editing root.html.
5. Click a header or footer template-part — the toolbar should show its existing **Edit** action and **not** "Edit root template".
6. Open root.html itself. The Template Content slot shows a read-only preview of the home-hierarchy fallback. The Inspector has a **Preview template** dropdown that switches the preview without saving. The block toolbar shows **Edit template** which navigates to the previewed template.
7. The "Root template" entry in the Templates sidebar appears only when the active theme has `root.html`.

### Keyboard

No new keyboard interactions; existing block editor and Site Editor navigation applies.

## Known concerns / deferred decisions

  - **`isTemplatePart()` semantic creep.** Extending a public-named function to recognise a different block. The alternative is duplicating purple visual styling rules in CSS.
  - **`__experimentalRootInnerTemplateId` setting.** A new private-ish setting on block-editor settings, allowlisted in `BLOCK_EDITOR_SETTINGS`. Could grow into a more general "wrap-mode" capability later.
  - **DB-customised templates can render double chrome.** If a theme adopts `root.html` while the DB still has customised versions of templates that include header/footer template-parts, `get_block_template()` returns the DB version and chrome renders twice. No detection or warning.
  - **File-existence as the only opt-in.** No `theme.json` setting or `add_theme_support()` to opt out without removing the file.
  - **Frontend swap is not e2e tested.** The block-editor wrap behaviour and toolbar affordance are; the PHP `template_include` swap relies on PHPUnit + smoke testing.

## Use of AI Tools

This PR was authored with the assistance of Claude (Opus 4.7) under human direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
