### PR TITLE
wp-env: fix stale urls.development after --auto-port reassigns port

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `wp-env status` now reports the development URL based on the live Docker port mapping instead of the configured `WP_SITEURL`. This fixes a stale URL when `--auto-port` reassigns the port; consumers reading `urls.development` from `wp-env status --json` no longer have to fall back to constructing the URL from `ports.development` themselves.
+
 ## 11.5.0 (2026-04-29)
 
 ## 11.4.0 (2026-04-15)

--- a/packages/env/lib/runtime/docker/index.js
+++ b/packages/env/lib/runtime/docker/index.js
@@ -44,6 +44,48 @@ const retry = require( '../../retry' );
 const CONFIG_CACHE_KEY = 'config_checksum';
 
 /**
+ * Build the development URL reported by `getStatus()` from the live Docker
+ * port mapping rather than the configured `WP_SITEURL`. After
+ * `--auto-port` reassigns the port, the configured value goes stale.
+ * If the configured site URL has a custom host or path, that shape is
+ * preserved — only the port is rebased onto the live mapping.
+ *
+ * @param {string|undefined} configuredSiteUrl `WP_SITEURL` from config.
+ * @param {number|null}      livePort          Live Docker port for the dev
+ *                                             container, or null when the
+ *                                             environment is not running.
+ * @return {string|null} The development URL, or null when not running.
+ */
+function rebaseSiteUrlPort( configuredSiteUrl, livePort ) {
+	if ( ! livePort ) {
+		return null;
+	}
+	if ( ! configuredSiteUrl ) {
+		return `http://localhost:${ livePort }`;
+	}
+	let url;
+	try {
+		url = new URL( configuredSiteUrl );
+	} catch {
+		return `http://localhost:${ livePort }`;
+	}
+	// If the user's WP_SITEURL has no port, they explicitly want the URL
+	// as-configured (e.g. `http://example.com`). Don't append a port.
+	if ( ! url.port ) {
+		return configuredSiteUrl;
+	}
+	url.port = String( livePort );
+	let result = url.toString();
+	// `URL.toString()` emits a trailing slash for empty paths. Match the
+	// shape of the input so existing consumers that string-compare don't
+	// see a spurious change.
+	if ( ! configuredSiteUrl.endsWith( '/' ) && result.endsWith( '/' ) ) {
+		result = result.slice( 0, -1 );
+	}
+	return result;
+}
+
+/**
  * Docker runtime implementation for wp-env.
  *
  * This runtime uses Docker Compose for container orchestration.
@@ -718,7 +760,16 @@ class DockerRuntime {
 			// Containers are not running.
 		}
 
-		const siteUrl = config.env.development.config.WP_SITEURL;
+		// Derive the development URL from the live Docker port mapping.
+		// Reading `config.env.development.config.WP_SITEURL` directly goes
+		// stale after `--auto-port` reassigns the port, since WP_SITEURL is
+		// computed once at config-load time from the configured port.
+		// Replace the port in the configured site URL so a custom
+		// WP_SITEURL (different host or path) is preserved.
+		const developmentUrl = rebaseSiteUrlPort(
+			config.env.development.config.WP_SITEURL,
+			isRunning ? developmentPort : null
+		);
 
 		const testsEnabled = config.testsEnvironment !== false;
 
@@ -726,7 +777,7 @@ class DockerRuntime {
 			status: isRunning ? 'running' : 'stopped',
 			runtime: 'docker',
 			urls: {
-				development: isRunning ? siteUrl : null,
+				development: developmentUrl,
 				phpmyadmin:
 					isRunning && phpmyadminPort
 						? `http://localhost:${ phpmyadminPort }`
@@ -842,3 +893,4 @@ class DockerRuntime {
 }
 
 module.exports = DockerRuntime;
+module.exports.rebaseSiteUrlPort = rebaseSiteUrlPort;

--- a/packages/env/lib/runtime/docker/test/rebase-site-url-port.js
+++ b/packages/env/lib/runtime/docker/test/rebase-site-url-port.js
@@ -1,0 +1,63 @@
+'use strict';
+/**
+ * Internal dependencies
+ */
+const { rebaseSiteUrlPort } = require( '../index' );
+
+describe( 'rebaseSiteUrlPort', () => {
+	it( 'returns null when the live port is missing', () => {
+		expect( rebaseSiteUrlPort( 'http://localhost:8888', null ) ).toBeNull();
+		expect( rebaseSiteUrlPort( 'http://localhost:8888', 0 ) ).toBeNull();
+	} );
+
+	it( 'falls back to localhost when the configured site URL is empty', () => {
+		expect( rebaseSiteUrlPort( '', 8889 ) ).toBe( 'http://localhost:8889' );
+		expect( rebaseSiteUrlPort( undefined, 8889 ) ).toBe(
+			'http://localhost:8889'
+		);
+	} );
+
+	it( 'replaces the port in the configured site URL with the live port', () => {
+		expect( rebaseSiteUrlPort( 'http://localhost:8888', 8889 ) ).toBe(
+			'http://localhost:8889'
+		);
+	} );
+
+	it( 'preserves a custom host when rebasing the port', () => {
+		expect( rebaseSiteUrlPort( 'http://my.local:8888', 8889 ) ).toBe(
+			'http://my.local:8889'
+		);
+	} );
+
+	it( 'preserves a custom path and scheme when rebasing the port', () => {
+		expect( rebaseSiteUrlPort( 'https://my.local:8888/wp', 8889 ) ).toBe(
+			'https://my.local:8889/wp'
+		);
+	} );
+
+	it( 'returns the configured site URL unchanged when it has no port', () => {
+		// A user who explicitly set WP_SITEURL without a port wants exactly
+		// that URL — don't synthesize one onto it.
+		expect( rebaseSiteUrlPort( 'http://example.com', 8889 ) ).toBe(
+			'http://example.com'
+		);
+	} );
+
+	it( 'falls back to localhost when the configured site URL is invalid', () => {
+		expect( rebaseSiteUrlPort( 'not a url', 8889 ) ).toBe(
+			'http://localhost:8889'
+		);
+	} );
+
+	it( 'preserves a trailing slash when present in the configured URL', () => {
+		expect( rebaseSiteUrlPort( 'http://localhost:8888/', 8889 ) ).toBe(
+			'http://localhost:8889/'
+		);
+	} );
+
+	it( 'does not introduce a trailing slash that the configured URL lacked', () => {
+		expect( rebaseSiteUrlPort( 'http://localhost:8888', 8889 ) ).toBe(
+			'http://localhost:8889'
+		);
+	} );
+} );


### PR DESCRIPTION
## What?

`wp-env status --json` reports a stale `urls.development` after `--auto-port` reassigns the WordPress dev container to a different port. Build the URL from the live Docker port mapping instead of the configured `WP_SITEURL` so consumers reading the JSON output see the actual reachable URL.

## Why?

`wp-env status --json` exposes both `urls.development` (a string like `http://localhost:8888`) and `ports.development` (the integer port). The port field is read from the live Docker mapping (`docker compose port wordpress 80`), but the URL field was read from `config.env.development.config.WP_SITEURL`, which is computed once at config-load time from the configured port.

When the user starts wp-env with `--auto-port` and 8888 is busy, wp-env falls back to e.g. 8889 and the WordPress install is correctly reachable there. But `urls.development` keeps reporting `http://localhost:8888`, so consumers (CI configs, IDE integrations, Playwright setups) that trust that field route to the wrong (or non-existent) port.

Repro:

1. Bind port 8888 with anything (`docker run --rm -p 8888:80 nginx:alpine`).
2. `wp-env start --auto-port` — wp-env lands on 8889.
3. `wp-env status --json` returns `urls.development: "http://localhost:8888"` while `ports.development: "8889"`.

The Playground runtime already constructs `urls.development` from the resolved port (`packages/env/lib/runtime/playground/index.js`); this brings the Docker runtime in line.

## How?

A small `rebaseSiteUrlPort` helper replaces the port in the configured `WP_SITEURL` with the live port from Docker. Custom-host or custom-path WP_SITEURLs are preserved verbatim; only the port number changes. A WP_SITEURL without a port is returned exactly as-configured (the user explicitly chose that shape — don't synthesize a port onto it). Falls back to `http://localhost:${ port }` for empty / malformed configured URLs.

Includes a unit test covering the matrix of inputs.

## Testing Instructions

1. Bind port 8888: `docker run --rm -d --name port-blocker -p 8888:80 nginx:alpine`
2. From any wp-env-enabled project: `npx wp-env start --auto-port`. wp-env should land on 8889/8890.
3. `npx wp-env status --json | jq` — `urls.development` should now match `http://localhost:8889` (with this fix) instead of `http://localhost:8888` (without).
4. `docker stop port-blocker` to clean up.

Unit test: `npx jest --config=test/unit/jest.config.js --testPathPattern=rebase-site-url-port` — 9 tests pass.

### Testing Instructions for Keyboard

N/A — this is a CLI / status command change, no UI surface.

## Screenshots or screencast

N/A.

## Use of AI Tools

<!-- Author will fill in -->

## Changelog

### Changed

- `wp-env status` now derives `urls.development` from the live Docker port mapping instead of the configured `WP_SITEURL`. ([packages/env/CHANGELOG.md](../tree/packages/env/CHANGELOG.md))