### PR TITLE
Add icon type selection and styles for accordion heading

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -16,7 +16,7 @@ Displays a foldable layout that groups content in collapsible sections. ([Source
 -	**Category:** design
 -	**Allowed Blocks:** core/accordion-item
 -	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), contentRole, interactivity, layout, listView, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** autoclose, headingLevel, iconPosition, levelOptions, showIcon
+-	**Attributes:** autoclose, headingLevel, iconPosition, iconType, levelOptions, showIcon
 
 ## Accordion Heading
 
@@ -26,7 +26,7 @@ Displays a heading that toggles the accordion panel. ([Source](https://github.co
 -	**Category:** design
 -	**Parent:** core/accordion-item
 -	**Supports:** anchor, color (background, gradients, text), interactivity, shadow, spacing (padding), typography (fontSize), ~~align~~, ~~lock~~, ~~visibility~~
--	**Attributes:** iconPosition, level, openByDefault, showIcon, title
+-	**Attributes:** iconPosition, iconType, level, openByDefault, showIcon, title
 
 ## Accordion Item
 

--- a/packages/block-library/src/accordion-heading/block.json
+++ b/packages/block-library/src/accordion-heading/block.json
@@ -8,6 +8,7 @@
 	"parent": [ "core/accordion-item" ],
 	"usesContext": [
 		"core/accordion-icon-position",
+		"core/accordion-icon-type",
 		"core/accordion-show-icon",
 		"core/accordion-heading-level"
 	],
@@ -88,6 +89,11 @@
 		"showIcon": {
 			"type": "boolean",
 			"default": true
+		},
+		"iconType": {
+			"type": "string",
+			"default": "plus",
+			"enum": [ "plus", "chevron", "arrow" ]
 		}
 	},
 	"textdomain": "default"

--- a/packages/block-library/src/accordion-heading/edit.js
+++ b/packages/block-library/src/accordion-heading/edit.js
@@ -13,10 +13,16 @@ import {
 } from '@wordpress/block-editor';
 import { useDispatch } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import getIconContent from './get-icon-content';
+
 export default function Edit( { attributes, setAttributes, context } ) {
 	const { title } = attributes;
 	const {
 		'core/accordion-icon-position': iconPosition,
+		'core/accordion-icon-type': iconType,
 		'core/accordion-show-icon': showIcon,
 		'core/accordion-heading-level': headingLevel,
 	} = context;
@@ -31,10 +37,12 @@ export default function Edit( { attributes, setAttributes, context } ) {
 			setAttributes( {
 				iconPosition,
 				showIcon,
+				iconType: iconType || 'plus',
 			} );
 		}
 	}, [
 		iconPosition,
+		iconType,
 		showIcon,
 		setAttributes,
 		__unstableMarkNextChangeAsNotPersistent,
@@ -56,6 +64,8 @@ export default function Edit( { attributes, setAttributes, context } ) {
 	const blockProps = useBlockProps();
 	const spacingProps = useSpacingProps( attributes );
 
+	const iconContent = getIconContent( iconType );
+
 	return (
 		<TagName { ...blockProps }>
 			<button
@@ -65,10 +75,12 @@ export default function Edit( { attributes, setAttributes, context } ) {
 			>
 				{ showIcon && iconPosition === 'left' && (
 					<span
-						className="wp-block-accordion-heading__toggle-icon"
+						className={ `wp-block-accordion-heading__toggle-icon is-icon-${
+							iconType || 'plus'
+						}` }
 						aria-hidden="true"
 					>
-						+
+						{ iconContent }
 					</span>
 				) }
 				<RichText
@@ -88,10 +100,12 @@ export default function Edit( { attributes, setAttributes, context } ) {
 				/>
 				{ showIcon && iconPosition === 'right' && (
 					<span
-						className="wp-block-accordion-heading__toggle-icon"
+						className={ `wp-block-accordion-heading__toggle-icon is-icon-${
+							iconType || 'plus'
+						}` }
 						aria-hidden="true"
 					>
-						+
+						{ iconContent }
 					</span>
 				) }
 			</button>

--- a/packages/block-library/src/accordion-heading/get-icon-content.js
+++ b/packages/block-library/src/accordion-heading/get-icon-content.js
@@ -1,0 +1,38 @@
+import { SVG } from '@wordpress/primitives';
+
+export default function getIconContent( iconType ) {
+	switch ( iconType ) {
+		case 'chevron':
+			return (
+				<SVG
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 24 24"
+					width="24"
+					height="24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+				>
+					<polyline points="9 6 15 12 9 18" />
+				</SVG>
+			);
+		case 'arrow':
+			return (
+				<SVG
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 24 24"
+					width="24"
+					height="24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+				>
+					<line x1="12" y1="5" x2="12" y2="19" />
+					<polyline points="19 12 12 19 5 12" />
+				</SVG>
+			);
+		case 'plus':
+		default:
+			return '+';
+	}
+}

--- a/packages/block-library/src/accordion-heading/save.js
+++ b/packages/block-library/src/accordion-heading/save.js
@@ -8,13 +8,20 @@ import {
 	getTypographyClassesAndStyles,
 } from '@wordpress/block-editor';
 
+/**
+ * Internal dependencies
+ */
+import getIconContent from './get-icon-content';
+
 export default function save( { attributes } ) {
-	const { level, title, iconPosition, showIcon } = attributes;
+	const { level, title, iconPosition, iconType, showIcon } = attributes;
 	const TagName = 'h' + ( level || 3 );
 	const typographyProps = getTypographyClassesAndStyles( attributes );
 
 	const blockProps = useBlockProps.save();
 	const spacingProps = getSpacingClassesAndStyles( attributes );
+
+	const iconContent = getIconContent( iconType );
 
 	return (
 		<TagName { ...blockProps }>
@@ -25,10 +32,12 @@ export default function save( { attributes } ) {
 			>
 				{ showIcon && iconPosition === 'left' && (
 					<span
-						className="wp-block-accordion-heading__toggle-icon"
+						className={ `wp-block-accordion-heading__toggle-icon is-icon-${
+							iconType || 'plus'
+						}` }
 						aria-hidden="true"
 					>
-						+
+						{ iconContent }
 					</span>
 				) }
 				<RichText.Content
@@ -42,10 +51,12 @@ export default function save( { attributes } ) {
 				/>
 				{ showIcon && iconPosition === 'right' && (
 					<span
-						className="wp-block-accordion-heading__toggle-icon"
+						className={ `wp-block-accordion-heading__toggle-icon is-icon-${
+							iconType || 'plus'
+						}` }
 						aria-hidden="true"
 					>
-						+
+						{ iconContent }
 					</span>
 				) }
 			</button>

--- a/packages/block-library/src/accordion-heading/style.scss
+++ b/packages/block-library/src/accordion-heading/style.scss
@@ -38,4 +38,9 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+
+	svg {
+		width: 1em;
+		height: 1em;
+	}
 }

--- a/packages/block-library/src/accordion-item/style.scss
+++ b/packages/block-library/src/accordion-item/style.scss
@@ -1,6 +1,17 @@
 .wp-block-accordion-item {
-	&.is-open > .wp-block-accordion-heading .wp-block-accordion-heading__toggle-icon {
+	// Plus icon: rotates 45deg to become ×
+	&.is-open > .wp-block-accordion-heading .wp-block-accordion-heading__toggle-icon.is-icon-plus {
 		transform: rotate(45deg);
+	}
+
+	// Chevron icon: rotates 90deg to point down
+	&.is-open > .wp-block-accordion-heading .wp-block-accordion-heading__toggle-icon.is-icon-chevron {
+		transform: rotate(90deg);
+	}
+
+	// Arrow icon: rotates 180deg to point up
+	&.is-open > .wp-block-accordion-heading .wp-block-accordion-heading__toggle-icon.is-icon-arrow {
+		transform: rotate(180deg);
 	}
 
 	/* Add transitions only for users who do not prefer reduced motion */

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -63,6 +63,11 @@
 			"type": "string",
 			"default": "right"
 		},
+		"iconType": {
+			"type": "string",
+			"default": "plus",
+			"enum": [ "plus", "chevron", "arrow" ]
+		},
 		"showIcon": {
 			"type": "boolean",
 			"default": true
@@ -81,6 +86,7 @@
 	},
 	"providesContext": {
 		"core/accordion-icon-position": "iconPosition",
+		"core/accordion-icon-type": "iconType",
 		"core/accordion-show-icon": "showIcon",
 		"core/accordion-heading-level": "headingLevel"
 	},

--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -38,6 +38,7 @@ export default function Edit( {
 	attributes: {
 		autoclose,
 		iconPosition,
+		iconType,
 		showIcon,
 		headingLevel,
 		levelOptions,
@@ -127,6 +128,7 @@ export default function Edit( {
 							autoclose: false,
 							showIcon: true,
 							iconPosition: 'right',
+							iconType: 'plus',
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
@@ -199,6 +201,39 @@ export default function Edit( {
 								<ToggleGroupControlOption
 									label={ __( 'Right' ) }
 									value="right"
+								/>
+							</ToggleGroupControl>
+						</ToolsPanelItem>
+					) }
+					{ showIcon && (
+						<ToolsPanelItem
+							label={ __( 'Icon style' ) }
+							isShownByDefault
+							hasValue={ () => iconType !== 'plus' }
+							onDeselect={ () =>
+								setAttributes( { iconType: 'plus' } )
+							}
+						>
+							<ToggleGroupControl
+								__next40pxDefaultSize
+								isBlock
+								label={ __( 'Icon style' ) }
+								value={ iconType }
+								onChange={ ( value ) => {
+									setAttributes( { iconType: value } );
+								} }
+							>
+								<ToggleGroupControlOption
+									label={ __( 'Plus' ) }
+									value="plus"
+								/>
+								<ToggleGroupControlOption
+									label={ __( 'Chevron' ) }
+									value="chevron"
+								/>
+								<ToggleGroupControlOption
+									label={ __( 'Arrow' ) }
+									value="arrow"
 								/>
 							</ToggleGroupControl>
 						</ToolsPanelItem>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #77819

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
