### PR TITLE
Connectors a11y list structure

### DIFF
--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -30,6 +30,13 @@ const { store } = unlock( connectorsPrivateApis );
 // Register built-in connectors
 registerDefaultConnectors();
 
+type RenderableConnectorConfig = ConnectorConfig &
+	Required< Pick< ConnectorConfig, 'render' > >;
+
+const isRenderableConnector = (
+	connector: ConnectorConfig
+): connector is RenderableConnectorConfig => !! connector.render;
+
 function ConnectorsPage() {
 	const { connectors, canInstallPlugins } = useSelect(
 		( select ) => ( {
@@ -42,9 +49,7 @@ function ConnectorsPage() {
 		[]
 	);
 
-	const renderableConnectors = connectors.filter(
-		( connector: ConnectorConfig ) => connector.render
-	);
+	const renderableConnectors = connectors.filter( isRenderableConnector );
 	const isEmpty = renderableConnectors.length === 0;
 
 	return (
@@ -82,28 +87,31 @@ function ConnectorsPage() {
 				) : (
 					<VStack spacing={ 3 }>
 						<AiPluginCallout />
-						<VStack spacing={ 3 } role="list">
-							{ connectors.map(
+						<VStack
+							spacing={ 3 }
+							role="list"
+							aria-label={ __( 'Available connectors' ) }
+						>
+							{ renderableConnectors.map(
 								( connector: ConnectorConfig ) => {
-									if ( connector.render ) {
-										return (
-											<connector.render
-												key={ connector.slug }
-												slug={ connector.slug }
-												name={ connector.name }
-												description={
-													connector.description
-												}
-												type={ connector.type }
-												logo={ connector.logo }
-												authentication={
-													connector.authentication
-												}
-												plugin={ connector.plugin }
-											/>
-										);
-									}
-									return null;
+									const Connector = connector.render;
+
+									return (
+										<Connector
+											key={ connector.slug }
+											slug={ connector.slug }
+											name={ connector.name }
+											description={
+												connector.description
+											}
+											type={ connector.type }
+											logo={ connector.logo }
+											authentication={
+												connector.authentication
+											}
+											plugin={ connector.plugin }
+										/>
+									);
 								}
 							) }
 						</VStack>

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -92,6 +92,20 @@ test.describe( 'Connectors', () => {
 			await expect( button ).not.toHaveAttribute( 'aria-expanded' );
 		}
 
+		const connectorsList = page.getByRole( 'list', {
+			name: 'Available connectors',
+		} );
+		await expect( connectorsList ).toBeVisible();
+		await expect( connectorsList.getByRole( 'listitem' ) ).toHaveCount(
+			CONNECTORS.length
+		);
+
+		// The callout is not a connector card and should remain outside
+		// the list used to group connector list items.
+		await expect(
+			connectorsList.locator( '.ai-plugin-callout' )
+		).toHaveCount( 0 );
+
 		// Verify the plugin directory search link is present.
 		await expect(
 			page.getByRole( 'link', {


### PR DESCRIPTION
## What?
Closes #77650

Adds an accessible list wrapper around connector cards on the Settings > Connectors screen.

## Why?
Connector cards render as `role="listitem"`, so they need a valid `role="list"` parent for correct ARIA structure.

## How?
Filters renderable connectors first, renders them inside a named `role="list"` container, and keeps the AI plugin callout outside the list.

## Testing Instructions
1. Go to Settings > Connectors.
2. Inspect the connector cards in DevTools.
3. Confirm the cards are `listitem`s inside the “Available connectors” list.

### Testing Instructions for Keyboard
No keyboard interaction changes.

## Screenshots or screencast
N/A

## Use of AI Tools
Used ChatGPT/Codex to help implement and test the change. Reviewed before submission.