### PR TITLE
Migrate __experimentalHeading to @wordpress/ui Text in Mobile tab navigation

### DIFF
--- a/packages/block-editor/src/components/inserter/mobile-tab-navigation.js
+++ b/packages/block-editor/src/components/inserter/mobile-tab-navigation.js
@@ -8,12 +8,12 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalSpacer as Spacer,
-	__experimentalHeading as Heading,
 	__experimentalView as View,
 	Navigator,
 	FlexBlock,
 } from '@wordpress/components';
 import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
+import { Text } from '@wordpress/ui';
 
 function ScreenHeader( { title } ) {
 	return (
@@ -32,7 +32,9 @@ function ScreenHeader( { title } ) {
 							label={ __( 'Back' ) }
 						/>
 						<Spacer>
-							<Heading level={ 5 }>{ title }</Heading>
+							<Text variant="heading-sm" render={ <h5 /> }>
+								{ title }
+							</Text>
 						</Spacer>
 					</HStack>
 				</Spacer>

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -151,7 +151,7 @@
 	},
 	"packages/block-editor/src/components/inserter/mobile-tab-navigation.js": {
 		"@wordpress/use-recommended-components": {
-			"count": 3
+			"count": 2
 		}
 	},
 	"packages/block-editor/src/components/inspector-popover-header/index.js": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: #77265

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

> Now that the required tooling is in place, we can start applying consistent text styling across the site and block editor. This can be done by replacing instances of __experimentalText and __experimentalHeading, as well as any ad hoc styled text, with the [Text](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-text--docs) component from the UI package.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Replaced the __experimentalHeading with @wordpress/ui Text in Mobile tab navigation

### Testing Instructions

1. Open the post editor.
2. Switch to a mobile viewport (responsive mode in browser devtools, e.g. iPhone width).
3. Open the block inserter (+).
4. In the mobile inserter, click Browse all to expand.
5. Switch to Patterns tab, select any from the list (ex: Banners).
6. The heading "Back" with the chevron icon is the migrated heading.

|Before|After|
|-|-|
|<img width="1511" height="537" alt="image" src="https://github.com/user-attachments/assets/8ec85caa-6c2f-420a-9e46-89b419769128" />|<img width="1425" height="514" alt="image" src="https://github.com/user-attachments/assets/6ce809d9-e0dd-4a75-9bbc-bdb91bb2d071" />|