### PR TITLE
Fix PHP multisite tests

### DIFF
--- a/phpunit/experimental/content-types/user-taxonomy-content-filter-test.php
+++ b/phpunit/experimental/content-types/user-taxonomy-content-filter-test.php
@@ -21,6 +21,13 @@ class User_Taxonomy_Content_Filter_Test extends WP_UnitTestCase {
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+		// On multisite, `unfiltered_html` belongs to super admins only; the
+		// single-site administrator role doesn't carry it. Promote so the
+		// kses pre-filter is bypassed in both environments and the test
+		// exercises our sanitizer as the sole line of defense.
+		if ( is_multisite() ) {
+			grant_super_admin( self::$admin_id );
+		}
 	}
 
 	public static function wpTearDownAfterClass() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Follow up of: https://github.com/WordPress/gutenberg/pull/77697

It seems multisite PHP tests are failing because of the original PR. The pattern used here is seems to be used in many other places.