### PR TITLE
Migrate __experimentalText to @wordpress/ui Text in viewport visibility info

### DIFF
--- a/packages/block-editor/src/components/block-visibility/viewport-visibility-info.js
+++ b/packages/block-editor/src/components/block-visibility/viewport-visibility-info.js
@@ -3,13 +3,13 @@
  */
 import {
 	Icon,
-	__experimentalText as WCText,
 	__experimentalHStack as HStack,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { unseen } from '@wordpress/icons';
+import { Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -131,7 +131,7 @@ export default function ViewportVisibilityInfo( { clientId } ) {
 		<WCBadge className="block-editor-block-visibility-info">
 			<HStack spacing={ 2 } justify="start">
 				<Icon icon={ unseen } />
-				<WCText>{ label }</WCText>
+				<Text>{ label }</Text>
 			</HStack>
 		</WCBadge>
 	);

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -76,7 +76,7 @@
 	},
 	"packages/block-editor/src/components/block-visibility/viewport-visibility-info.js": {
 		"@wordpress/use-recommended-components": {
-			"count": 2
+			"count": 1
 		}
 	},
 	"packages/block-editor/src/components/border-radius-control/index.js": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: #77265

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

> Now that the required tooling is in place, we can start applying consistent text styling across the site and block editor. This can be done by replacing instances of __experimentalText and __experimentalHeading, as well as any ad hoc styled text, with the [Text](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-text--docs) component from the UI package.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Replaced the __experimentalText to @wordpress/ui Text in viewport visibility info

### Testing Instructions

1. Open the post editor and add a block
2. Select that block and open the block options menu (from block toolbar) and click Hide.
3. In the Hide block modal, check at least one viewport (for example Hide on Desktop), then apply.
4. Keep the same block selected and look at the right sidebar Block settings.
5. Verify the visibility badge appears with the hidden icon and label text: "Block is hidden on Desktop", this is the migrated text.


|Before|After|
|-|-|
|<img width="1892" height="475" alt="image" src="https://github.com/user-attachments/assets/0da322b7-b3a6-4b86-84cd-45f90cb5e263" />|<img width="1883" height="539" alt="Screenshot 2026-05-09 at 7 13 52 PM" src="https://github.com/user-attachments/assets/72f75c08-63e4-460a-a4b1-fdc37435d019" />|