### PR TITLE
Testing: Remove condition from 'autosave' e2e test

### DIFF
--- a/test/e2e/specs/editor/various/autosave.spec.js
+++ b/test/e2e/specs/editor/various/autosave.spec.js
@@ -327,21 +327,6 @@ test.describe( 'Autosave', () => {
 		await page.reload();
 		await page.waitForFunction( () => window?.wp?.data );
 
-		// FIXME: Occasionally, upon reload, there is no server-provided
-		// autosave value available, despite our having previously explicitly
-		// autosaved. The reasons for this are still unknown. Since this is
-		// unrelated to *local* autosave, until we can understand them, we'll
-		// drop this test's expectations if we don't have an autosave object
-		// available.
-		const stillHasRemoteAutosave = await page.evaluate(
-			() =>
-				window.wp.data.select( 'core/editor' ).getEditorSettings()
-					.autosave
-		);
-		if ( ! stillHasRemoteAutosave ) {
-			return;
-		}
-
 		// Only remote autosave notice should be applied.
 		await expect(
 			page.locator( '.components-notice__content' )


### PR DESCRIPTION
## What?
Closes #58959

Removes the conditional assertion and early return from the "**shouldn't conflict with server-side autosave**" e2e test.

## Why?
- The test contained a FIXME workaround that masked an intermittent issue where server-provided autosave values were occasionally unavailable after reload. 
- By removing the conditional escape hatch, the test is now deterministic and properly validates autosave behavior without hiding potential problems.

## How?
Removed the `stillHasRemoteAutosave` variable check.

## Testing Instructions
1. Run the autosave e2e tests: `npm run test:e2e -- test/e2e/specs/editor/various/autosave.spec.js`
2. All tests should pass without errors

## Result
- All tests pass without errors. 
- While the root cause of the original intermittent issue remains unknown, removing the conditional has not introduced any failures, which indicates the issue was either rare or has been resolved in the current codebase. 