### PR TITLE
Visual Revisions: Improve diff for Classic Block instead of marking entire block as changed

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/block-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/block-diff.js
@@ -69,6 +69,25 @@ function textSimilarity( text1, text2 ) {
 }
 
 /**
+ * Gets comparable text for a raw block.
+ * Prefers innerHTML, but falls back to common content attributes.
+ *
+ * @param {Object} rawBlock Raw block.
+ * @return {string} Text used for similarity comparisons.
+ */
+function getRawBlockText( rawBlock ) {
+	if ( rawBlock?.innerHTML ) {
+		return rawBlock.innerHTML;
+	}
+
+	if ( typeof rawBlock?.attrs?.content === 'string' ) {
+		return rawBlock.attrs.content;
+	}
+
+	return '';
+}
+
+/**
  * Post-process diff result to pair similar removed/added blocks as modifications.
  * This catches modifications that LCS missed due to content changes.
  *
@@ -112,8 +131,8 @@ function pairSimilarBlocks( blocks ) {
 			}
 
 			const score = textSimilarity(
-				rem.block.innerHTML || '',
-				add.block.innerHTML || ''
+				getRawBlockText( rem.block ),
+				getRawBlockText( add.block )
 			);
 			// If content is identical (score=1), only pair if attrs differ.
 			// Otherwise identical blocks are just position swaps, not modifications.

--- a/packages/editor/src/components/post-revisions-preview/test/block-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/test/block-diff.js
@@ -11,6 +11,7 @@ import {
 import { RichTextData } from '@wordpress/rich-text';
 import * as paragraphBlock from '@wordpress/block-library/src/paragraph';
 import * as groupBlock from '@wordpress/block-library/src/group';
+import * as freeformBlock from '@wordpress/block-library/src/freeform';
 
 /**
  * Internal dependencies
@@ -65,6 +66,12 @@ describe( 'diffRevisionContent', () => {
 				groupBlock.settings
 			);
 		}
+		if ( ! getBlockType( 'core/freeform' ) ) {
+			registerBlockType(
+				{ name: freeformBlock.name, ...freeformBlock.metadata },
+				freeformBlock.settings
+			);
+		}
 
 		registerDiffFormatTypes();
 	} );
@@ -75,6 +82,9 @@ describe( 'diffRevisionContent', () => {
 		}
 		if ( getBlockType( 'core/group' ) ) {
 			unregisterBlockType( 'core/group' );
+		}
+		if ( getBlockType( 'core/freeform' ) ) {
+			unregisterBlockType( 'core/freeform' );
 		}
 
 		unregisterDiffFormatTypes();
@@ -146,6 +156,34 @@ describe( 'diffRevisionContent', () => {
 				attributes: {
 					__revisionDiffStatus: {
 						status: 'modified',
+					},
+				},
+			},
+		] );
+	} );
+
+	it( 'pairs changed classic block content as modified', () => {
+		const previous = serialize( [
+			createBlock( 'core/freeform', {
+				content: '<p>Original classic block content</p>',
+			} ),
+		] );
+		const current = serialize( [
+			createBlock( 'core/freeform', {
+				content: '<p>Updated classic block content with edits</p>',
+			} ),
+		] );
+		const blocks = diffRevisionContent( current, previous );
+
+		expect( normalizeBlockTree( blocks ) ).toMatchObject( [
+			{
+				name: 'core/freeform',
+				attributes: {
+					__revisionDiffStatus: {
+						status: 'modified',
+						changedAttributes: {
+							content: expect.any( Array ),
+						},
 					},
 				},
 			},

--- a/packages/editor/src/components/revision-block-diff/index.js
+++ b/packages/editor/src/components/revision-block-diff/index.js
@@ -2,23 +2,30 @@
  * WordPress dependencies
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { Notice } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
 import RevisionDiffPanel from '../revision-diff-panel';
+import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 /**
  * Panel that shows changed block attributes for the selected block
  * when viewing revisions.
  */
 export default function RevisionBlockDiffPanel() {
-	const { block } = useSelect( ( select ) => {
+	const { block, currentRevisionId } = useSelect( ( select ) => {
 		const { getSelectedBlock } = select( blockEditorStore );
+		const { getCurrentRevisionId } = unlock( select( editorStore ) );
+
 		return {
 			block: getSelectedBlock(),
+			currentRevisionId: getCurrentRevisionId(),
 		};
 	}, [] );
 
@@ -26,14 +33,34 @@ export default function RevisionBlockDiffPanel() {
 		return null;
 	}
 
+	const diffStatus = block.attributes?.__revisionDiffStatus?.status;
 	const changedAttributes =
 		block.attributes?.__revisionDiffStatus?.changedAttributes;
+	const isClassicBlockWithDiff =
+		block.name === 'core/freeform' && !! diffStatus;
+	const classicRevisionsUrl = currentRevisionId
+		? addQueryArgs( 'revision.php', { revision: currentRevisionId } )
+		: null;
 
 	return (
-		<RevisionDiffPanel
-			title={ __( 'Changed attributes' ) }
-			entries={ changedAttributes }
-			initialOpen
-		/>
+		<>
+			{ isClassicBlockWithDiff && (
+				<Notice isDismissible={ false } status="warning">
+					{ __(
+						'Detailed inline changes are not available for Classic Block content in visual revisions. Use classic revisions for a full text diff.'
+					) }{ ' ' }
+					{ classicRevisionsUrl && (
+						<a href={ classicRevisionsUrl }>
+							{ __( 'Open classic revisions' ) }
+						</a>
+					) }
+				</Notice>
+			) }
+			<RevisionDiffPanel
+				title={ __( 'Changed attributes' ) }
+				entries={ changedAttributes }
+				initialOpen
+			/>
+		</>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/76689

Improve how Classic Block (core/freeform) content changes are detected and displayed in visual revisions. The diff algorithm now correctly pairs changed Classic Block versions as modifications instead of separate remove/add events, and displays a helpful warning when viewing Classic Block changes in the block inspector.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Classic Blocks store their content in attrs.content instead of innerHTML, which caused the similarity matching algorithm to treat any edit as a block deletion + insertion rather than a modification. This resulted in poor diff visualization and confusion about what actually changed.

Additionally, while visual revisions work well for modern blocks, they have limitations for Classic Blocks because inline HTML diffs aren't meaningful in the block editor context. Users need a way to discover the classic revision.php screen where they can see a proper text-level diff.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Added getRawBlockText() helper function that extracts comparable text from raw blocks, preferring innerHTML but falling back to attrs.content for blocks like Classic Block that store content in attributes.

2. Updated pairSimilarBlocks() algorithm to use getRawBlockText() when computing text similarity scores, so Classic Block content changes are now properly detected and paired as modifications.

3. Enhanced revision block diff panel to detect when a Classic Block has changes and display a warning notice with a direct link to the classic revision.php screen for that revision ID, guiding users to the appropriate tool for detailed text-level diffs.

4. Added comprehensive test coverage including a new test case that verifies Classic Block content changes are correctly identified as modifications.

## Testing Instructions

1. Create a post with a Classic Block containing some content.
2. Edit the Classic Block content.
3. Save the post as a new revision.
4. Open the Revisions panel in the editor.
5. Click to view the revision where you edited the Classic Block.
6. Enable "Show changes" (eye icon in revisions header).
7. Click on the Classic Block in the editor to select it.
8. In the Block tab of the sidebar, you should see a warning notice stating:
"Detailed inline changes are not available for Classic Block content in visual revisions. Use classic revisions for a full text diff."
9. A clickable link "Open classic revisions" that opens revision.php for that revision

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1467" height="828" alt="image" src="https://github.com/user-attachments/assets/ab265130-8dd0-4a98-9d4e-01e9d723bfd8" />|<img width="1470" height="825" alt="image" src="https://github.com/user-attachments/assets/ada230e3-597f-4a9d-937b-33ce04cf8af4" />|