### PR TITLE
Navigation block: Add Invalid Link Status Indicators in Editable List View

### DIFF
--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -40,13 +40,6 @@ const ListViewBlockContents = forwardRef(
 
 		return (
 			<>
-				{ AdditionalBlockContent && (
-					<AdditionalBlockContent
-						block={ block }
-						insertedBlock={ insertedBlock }
-						setInsertedBlock={ setInsertedBlock }
-					/>
-				) }
 				<BlockDraggable
 					appendToOwnerDocument
 					clientIds={ draggableClientIds }
@@ -71,6 +64,13 @@ const ListViewBlockContents = forwardRef(
 						/>
 					) }
 				</BlockDraggable>
+				{ AdditionalBlockContent && (
+					<AdditionalBlockContent
+						block={ block }
+						insertedBlock={ insertedBlock }
+						setInsertedBlock={ setInsertedBlock }
+					/>
+				) }
 			</>
 		);
 	}

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -19,7 +19,7 @@ import { unlock } from '../../lock-unlock';
 import DeletedNavigationWarning from './deleted-navigation-warning';
 import useNavigationMenu from '../use-navigation-menu';
 import LeafMoreMenu from './leaf-more-menu';
-import { NavigationLinkUI } from './navigation-link-ui';
+import { NavigationListViewAdditionalContent } from './navigation-list-view-additional-content';
 import NavigationListViewHeader from './navigation-list-view-header';
 
 const actionLabel =
@@ -86,7 +86,7 @@ const MainContent = ( {
 				description={ description }
 				showAppender
 				blockSettingsMenu={ LeafMoreMenu }
-				additionalBlockContent={ NavigationLinkUI }
+				additionalBlockContent={ NavigationListViewAdditionalContent }
 				onSelect={ openListViewContentPanel }
 			/>
 		</div>

--- a/packages/block-library/src/navigation/edit/navigation-list-view-additional-content.js
+++ b/packages/block-library/src/navigation/edit/navigation-list-view-additional-content.js
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { NavigationLinkUI } from './navigation-link-ui';
+import {
+	useIsInvalidLink,
+	useEnableLinkStatusValidation,
+} from '../../navigation-link/shared';
+
+const BLOCKS_WITH_STATUS_INDICATORS = [
+	'core/navigation-link',
+	'core/navigation-submenu',
+];
+
+/**
+ * Renders a status badge for invalid/draft navigation links in the list view.
+ * Mirrors the in-canvas "(Invalid)" / "(Draft)" indicators shown in the
+ * Navigation block's canvas representation.
+ *
+ * @param {Object} props       Component props.
+ * @param {Object} props.block The block object, including clientId, name, and attributes.
+ * @return {Element|null} The status indicator, or null if no status to display.
+ */
+function NavigationLinkListViewStatus( { block } ) {
+	const { clientId, name, attributes } = block;
+	const { kind, type, id } = attributes;
+
+	const validateLinkStatus = useEnableLinkStatusValidation( clientId );
+
+	const [ isInvalid, isDraft ] = useIsInvalidLink(
+		kind,
+		type,
+		id,
+		validateLinkStatus
+	);
+
+	if ( ! BLOCKS_WITH_STATUS_INDICATORS.includes( name ) ) {
+		return null;
+	}
+
+	if ( ! isInvalid && ! isDraft ) {
+		return null;
+	}
+
+	const statusText = isInvalid
+		? /* translators: Indicating that the navigation link is Invalid. */
+		  __( 'Invalid' )
+		: /* translators: Indicating that the navigation link is a Draft. */
+		  __( 'Draft' );
+
+	return (
+		<span
+			className={ clsx( 'wp-block-navigation-link__list-view-status', {
+				'is-invalid': isInvalid,
+				'is-draft': isDraft,
+			} ) }
+			aria-label={ sprintf(
+				/* translators: %s: The link status e.g. "Invalid" or "Draft". */
+				__( 'Link status: %s' ),
+				statusText
+			) }
+		>
+			{ /* Visible status text — hidden from screen readers since aria-label above provides the accessible name. */ }
+			<span aria-hidden="true">{ `(${ statusText })` }</span>
+		</span>
+	);
+}
+
+/**
+ * Combined additional block content for the navigation list view.
+ *
+ * Renders both:
+ * 1. The link insertion UI for newly inserted navigation link blocks.
+ * 2. A status indicator for existing navigation link blocks that are
+ *    invalid (deleted/trashed) or in draft status.
+ *
+ * This matches the in-canvas indicators already shown in the Navigation block's
+ * canvas representation, ensuring consistent feedback in both editing modes.
+ *
+ * @param {Object}   props                  Component props (passed through from PrivateListView).
+ * @param {Object}   props.block            The block object.
+ * @param {Object}   props.insertedBlock    The most recently inserted block, if any.
+ * @param {Function} props.setInsertedBlock Setter for the inserted block state.
+ * @return {Element} The combined additional block content.
+ */
+export function NavigationListViewAdditionalContent( props ) {
+	return (
+		<>
+			<NavigationLinkUI { ...props } />
+			<NavigationLinkListViewStatus block={ props.block } />
+		</>
+	);
+}

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -635,6 +635,33 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	margin-left: 24px;
 }
 
+/**
+ * Invalid/Draft status indicators in the navigation list view.
+ *
+ * These mirror the in-canvas indicators shown in the Navigation block's
+ * canvas representation, ensuring consistent feedback in both editing modes.
+ */
+.wp-block-navigation-link__list-view-status {
+	display: inline-flex;
+	align-items: center;
+	flex-shrink: 0;
+	font-size: $default-font-size;
+	font-style: italic;
+	color: $gray-700;
+	white-space: nowrap;
+	margin-left: $grid-unit-05;
+
+	span {
+		text-decoration: wavy underline;
+		text-decoration-skip-ink: none;
+		text-underline-offset: 0.25rem;
+	}
+
+	&.is-invalid span {
+		color: $alert-red;
+	}
+}
+
 .editor-sidebar__panel .wp-block-navigation__submenu-header {
 	margin-top: 0;
 	margin-bottom: 0;


### PR DESCRIPTION
Closes #73304

## What?
Adds link status indicators (Invalid, Draft) to the Navigation block's Editable List View, matching the indicators already shown in the in-canvas representation. Users now see consistent feedback about broken or problematic links whether they edit in the canvas or sidebar.

## Why?
Previously, invalid link indicators were only visible in the in-canvas view of the Navigation block. In List View (sidebar), there was no equivalent feedback, making it harder for users to audit and repair navigation issues—especially in large menus or when primarily working from the sidebar. Aligning List View with in-canvas status indicators ensures broken or problematic items are consistently discoverable, regardless of how users choose to edit their menus.

## Testing Instructions
1. Create or open a Navigation block with menu items.
2. In the block canvas, create draft post.
3. Open the Navigation block's List View (in the sidebar inspector panel).
4. Verify that the same navigation link now shows (draft) in the list view with matching wavy underline styling.
5. Verify that only invalid/draft items show indicators; valid links remain unmarked.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/5762515b-73d4-43f8-88e8-2b55783d5ed2

