### PR TITLE
Disable Classic block: Always register, hide from inserter conditionally

### DIFF
--- a/packages/block-library/src/freeform/index.js
+++ b/packages/block-library/src/freeform/index.js
@@ -21,4 +21,14 @@ export const settings = {
 	save,
 };
 
-export const init = () => initBlock( { name, metadata, settings } );
+export const init = () => {
+	// When the "Disable Classic block" experiment is enabled, only expose the
+	// block in the inserter if the current post actually needs a classic block.
+	const supports = {
+		...metadata.supports,
+		inserter:
+			! window?.__experimentalDisableTinymce ||
+			!! window?.wp?.needsClassicBlock,
+	};
+	return initBlock( { name, metadata, settings: { ...settings, supports } } );
+};

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -296,14 +296,9 @@ const getAllBlocks = () => {
 		blocks.push( playlistTrack );
 	}
 
-	// Register the classic block if it's needed or the experiment to disable TinyMCE is not active
-	if (
-		window?.wp?.oldEditor &&
-		( window?.wp?.needsClassicBlock ||
-			! window?.__experimentalDisableTinymce )
-	) {
-		blocks.push( classic );
-	}
+	// Always register the classic block. Inserter availability is controlled
+	// by the block's `supports.inserter` value in `freeform/init`.
+	blocks.push( classic );
 
 	return blocks.filter( Boolean );
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Always register the `core/freeform` (Classic) block. Its inserter availability is now controlled by `supports.inserter` instead of conditionally skipping registration.

## Why?
Trying a different approach for the experiment - instead of skipping registration, we always register the block but hide it from the inserter. This preserves support for existing posts that already contain a Classic block, while preventing new ones from being added.

The exact condition for hiding the block in the inserter will be tweaked in follow-up PRs.

## How?
The Classic block is now always included in the list of registered core blocks. When the experiment is enabled, its visibility in the inserter is controlled via `supports.inserter` based on the `window.wp.needsClassicBlock` flag.

## Testing Instructions
1. Open a post that does not contain a classic block.
2. Confirm the Classic block is not in the inserter when the "Disable Classic block" experiment is enabled.
3. Disable the experiment and confirm the Classic block appears in the inserter.
4. Open a post that contains a classic block and confirm it still renders/edits correctly in both cases.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

N/A

## Use of AI Tools

Opus 4.7