### PR TITLE
Button: Align link variant underline with Link and ExternalLink

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `Button`: Align `link` variant underline (offset and thickness) with `ExternalLink` and `Link` from `@wordpress/ui` ([#77842](https://github.com/WordPress/gutenberg/pull/77842)).
+
 ### Bug Fixes
 
 -   `TabPanel`: Fix tab indicator animation while switching tabs ([#77812](https://github.com/WordPress/gutenberg/pull/77812)).

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -252,6 +252,8 @@
 		font-weight: $font-weight-regular;
 		color: $components-color-accent;
 		text-decoration: underline;
+		text-underline-offset: 0.2em;
+		text-decoration-thickness: from-font;
 
 		@media not (prefers-reduced-motion) {
 			transition-property: border, background, color;


### PR DESCRIPTION
## What

Brings the `link` variant of `Button` (`@wordpress/components`) in line with the underline styling shared by `ExternalLink` and `Link` (`@wordpress/ui`). Specifically, sets `text-underline-offset: 0.2em` and `text-decoration-thickness: from-font` on `.is-link`.

Follow-up to #77790.

## Why

#77790 aligned `ExternalLink` with `Link` so the two render consistently when used side-by-side. Buttons rendered with `variant="link"` were left out and now look mismatched next to the other two — heavier, browser-default underline sitting tight to the baseline. Since `Button` with `variant="link"` is widely used in toolbars, sidebars, and inline UI alongside actual links, it should share the same underline metrics for visual coherence.

## How

- Adds `text-underline-offset: 0.2em` to match the offset used by `Link`/`ExternalLink`.
- Adds `text-decoration-thickness: from-font` so the underline honors the font's own underline metrics rather than a hard-coded sub-pixel value (consistent with the change made in #77790, which moved away from `0.5px` for the same reason — it rendered inconsistently across device pixel ratios).
- No JS, API, or markup changes; purely a CSS tweak scoped to the `&.is-link` rule in `packages/components/src/button/style.scss`.

## Testing instructions

1. Open Storybook and visit **Components/Actions/Button**.
2. Switch the `variant` control to `link`.
3. Confirm the underline is thinner and sits slightly below the baseline (no longer hugging it).
4. Place a `Button variant="link"` next to an `ExternalLink` and a `Link` from `@wordpress/ui` — underline thickness and offset should now match across all three.