### PR TITLE
Guidelines REST: Require read access for standard route

### DIFF
--- a/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
@@ -90,7 +90,7 @@ class Gutenberg_Guidelines_Post_Type {
 		register_post_type(
 			self::POST_TYPE,
 			array(
-				'labels'             => array(
+				'labels'                => array(
 					'name'                     => _x( 'Guidelines', 'post type general name', 'gutenberg' ),
 					'singular_name'            => _x( 'Guideline', 'post type singular name', 'gutenberg' ),
 					'add_new'                  => __( 'Add Guideline', 'gutenberg' ),
@@ -112,15 +112,18 @@ class Gutenberg_Guidelines_Post_Type {
 					'view_item'                => __( 'View Guideline', 'gutenberg' ),
 					'view_items'               => __( 'View Guidelines', 'gutenberg' ),
 				),
-				'public'             => false,
-				'publicly_queryable' => false,
-				'show_ui'            => true,
-				'show_in_menu'       => false,
-				'show_in_rest'       => true,
-				'rest_base'          => 'guidelines',
-				'capability_type'    => 'guideline',
-				'map_meta_cap'       => true,
-				'capabilities'       => array(
+				'public'                => false,
+				'publicly_queryable'    => false,
+				'show_ui'               => true,
+				'show_in_menu'          => false,
+				'show_in_rest'          => true,
+				'rest_base'             => 'guidelines',
+
+				'rest_controller_class' => Gutenberg_Guidelines_REST_Controller::class,
+
+				'capability_type'       => 'guideline',
+				'map_meta_cap'          => true,
+				'capabilities'          => array(
 					'read'                   => 'edit_posts',
 					'create_posts'           => 'publish_posts',
 					'edit_posts'             => 'edit_posts',
@@ -134,12 +137,12 @@ class Gutenberg_Guidelines_Post_Type {
 					'edit_others_posts'      => 'edit_others_posts',
 					'delete_others_posts'    => 'delete_others_posts',
 				),
-				'supports'           => array( 'title', 'editor', 'excerpt', 'author', 'revisions' ),
-				'hierarchical'       => false,
-				'has_archive'        => false,
-				'rewrite'            => false,
-				'query_var'          => false,
-				'can_export'         => true,
+				'supports'              => array( 'title', 'editor', 'excerpt', 'author', 'revisions' ),
+				'hierarchical'          => false,
+				'has_archive'           => false,
+				'rewrite'               => false,
+				'query_var'             => false,
+				'can_export'            => true,
 			)
 		);
 

--- a/lib/experimental/guidelines/class-gutenberg-guidelines-rest-controller.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-rest-controller.php
@@ -37,15 +37,14 @@ class Gutenberg_Guidelines_REST_Controller extends WP_REST_Posts_Controller {
 	 * Checks if a given request has access to read a guideline post.
 	 *
 	 * Guidelines are not public content, so every direct item read must pass
-	 * the guideline read capability before falling through to the standard
-	 * post-specific checks.
+	 * the post-specific read capability before falling through to the standard
+	 * post checks.
 	 *
 	 * @param WP_Post $post Post object.
 	 * @return bool Whether the post can be read.
 	 */
 	public function check_read_permission( $post ) {
-		$post_type = get_post_type_object( $post->post_type );
-		if ( ! current_user_can( $post_type->cap->read ) ) {
+		if ( ! current_user_can( 'read_post', $post->ID ) ) {
 			return false;
 		}
 

--- a/lib/experimental/guidelines/class-gutenberg-guidelines-rest-controller.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-rest-controller.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Guidelines REST API Controller.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API controller for guideline posts.
+ */
+class Gutenberg_Guidelines_REST_Controller extends WP_REST_Posts_Controller {
+
+	/**
+	 * Checks if a given request has access to read guideline posts.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		$post_type = get_post_type_object( $this->post_type );
+		if ( ! current_user_can( $post_type->cap->read ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to view guidelines.', 'gutenberg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return parent::get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Checks if a given request has access to read a guideline post.
+	 *
+	 * Guidelines are not public content, so every direct item read must pass
+	 * the guideline read capability before falling through to the standard
+	 * post-specific checks.
+	 *
+	 * @param WP_Post $post Post object.
+	 * @return bool Whether the post can be read.
+	 */
+	public function check_read_permission( $post ) {
+		$post_type = get_post_type_object( $post->post_type );
+		if ( ! current_user_can( $post_type->cap->read ) ) {
+			return false;
+		}
+
+		return parent::check_read_permission( $post );
+	}
+}

--- a/lib/experimental/guidelines/index.php
+++ b/lib/experimental/guidelines/index.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/guidelines.php';
 require_once __DIR__ . '/class-gutenberg-guidelines-post-type.php';
+require_once __DIR__ . '/class-gutenberg-guidelines-rest-controller.php';
 require_once __DIR__ . '/class-gutenberg-content-guidelines-revisions-controller.php';
 require_once __DIR__ . '/class-gutenberg-content-guidelines-rest-controller.php';
 

--- a/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
@@ -172,6 +172,29 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
+	 * Authors can pass the post type read capability but must still satisfy
+	 * the per-post check for non-public statuses.
+	 */
+	public function test_get_item_author_cannot_read_other_users_private_guideline() {
+		$create_response = $this->create_artifact_guideline( array( 'status' => 'private' ) );
+		$post_id         = $create_response->get_data()['id'];
+
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $author_id );
+
+		$request  = new WP_REST_Request( 'GET', self::REST_BASE . '/' . $post_id );
+		$response = rest_get_server()->dispatch( $request );
+
+		$status = $response->get_status();
+		$code   = $response->get_data()['code'] ?? null;
+
+		self::delete_user( $author_id );
+
+		$this->assertSame( 403, $status );
+		$this->assertSame( 'rest_forbidden', $code );
+	}
+
+	/**
 	 * Artifact guidelines can be updated through the standard item route.
 	 */
 	public function test_update_artifact_guideline() {

--- a/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
@@ -141,6 +141,37 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
+	 * Unauthenticated users cannot list published artifact guidelines.
+	 */
+	public function test_get_items_unauthenticated_cannot_read_published_artifacts() {
+		$this->create_artifact_guideline( array( 'status' => 'publish' ) );
+
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'GET', self::REST_BASE );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Unauthenticated users cannot read a published artifact guideline by ID.
+	 */
+	public function test_get_item_unauthenticated_cannot_read_published_artifact() {
+		$create_response = $this->create_artifact_guideline( array( 'status' => 'publish' ) );
+		$post_id         = $create_response->get_data()['id'];
+
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'GET', self::REST_BASE . '/' . $post_id );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
+
+	/**
 	 * Artifact guidelines can be updated through the standard item route.
 	 */
 	public function test_update_artifact_guideline() {


### PR DESCRIPTION
## What?
Adds a small REST controller for the standard `/wp/v2/guidelines` route so `wp_guideline` posts require the post type read capability before they can be listed or read by ID.

## Why?
`wp_guideline` is not public content, but the default `WP_REST_Posts_Controller` treats posts with `publish` status as readable before checking the post type read capability. That can expose published guideline/artifact posts through `/wp/v2/guidelines`.

## How?
- Registers `Gutenberg_Guidelines_REST_Controller` as the `wp_guideline` REST controller.
- Requires the guideline read capability in collection reads.
- Overrides item read permission so published guidelines do not bypass capability checks.
- Adds regression tests for anonymous collection and item requests.

## Testing Instructions
Run:

```bash
npm run wp-env status
npx wp-env run --env-cwd='wp-content/plugins/gutenberg' cli vendor/bin/phpunit -c phpunit.xml.dist --verbose --test-suffix -test.php --filter Gutenberg_Standard_Guidelines_REST_Controller_Test phpunit/experimental/guidelines
npx wp-env run --env-cwd='wp-content/plugins/gutenberg' cli vendor/bin/phpcs lib/experimental/guidelines/class-gutenberg-guidelines-rest-controller.php lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php lib/experimental/guidelines/index.php phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
```

## Testing Instructions for Keyboard
Not applicable; this PR does not change UI.

## Use of AI Tools
Used Codex to draft the implementation and tests; the changes were reviewed and verified locally.