### PR TITLE
Content Types: Add Duplicate action to post type management

### DIFF
--- a/packages/user-post-types/src/actions/duplicate.tsx
+++ b/packages/user-post-types/src/actions/duplicate.tsx
@@ -36,9 +36,13 @@ const duplicateForm: Form = {
 };
 
 function buildCopySlug( slug: string ): string {
-	const suffix = '_copy';
-	const base = slug.slice( 0, SLUG_MAX_LENGTH - suffix.length );
-	return `${ base }${ suffix }`;
+	const match = slug.match( /^(.*?)(\d+)$/ );
+	const base = match ? match[ 1 ] : slug;
+	const nextNumber = String( match ? parseInt( match[ 2 ], 10 ) + 1 : 2 );
+	return `${ base.slice(
+		0,
+		SLUG_MAX_LENGTH - nextNumber.length
+	) }${ nextNumber }`;
 }
 
 function DuplicatePostTypeModal( {

--- a/packages/user-post-types/src/actions/duplicate.tsx
+++ b/packages/user-post-types/src/actions/duplicate.tsx
@@ -1,0 +1,167 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import {
+	DataForm,
+	useFormValidity,
+	type Action,
+	type Field,
+	type Form,
+} from '@wordpress/dataviews';
+import { useMemo, useState } from '@wordpress/element';
+import { __, _x, sprintf } from '@wordpress/i18n';
+import { copy } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { Stack } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import {
+	pluralLabelField,
+	singularLabelField,
+	useSlugField,
+} from '../fields/general';
+import { serializeForSave } from '../utils';
+import type { CoreDataError, PostTypeFormData } from '../types';
+
+const SLUG_MAX_LENGTH = 20;
+
+const duplicateForm: Form = {
+	layout: { type: 'regular' },
+	fields: [ 'plural_name', 'singular_name', 'slug' ],
+};
+
+function buildCopySlug( slug: string ): string {
+	const suffix = '_copy';
+	const base = slug.slice( 0, SLUG_MAX_LENGTH - suffix.length );
+	return `${ base }${ suffix }`;
+}
+
+function DuplicatePostTypeModal( {
+	items,
+	closeModal,
+	onActionPerformed,
+}: {
+	items: PostTypeFormData[];
+	closeModal?: () => void;
+	onActionPerformed?: ( items: PostTypeFormData[] ) => void;
+} ) {
+	const source = items[ 0 ];
+	const [ data, setData ] = useState< PostTypeFormData >( () => ( {
+		...source,
+		id: undefined,
+		status: 'draft',
+		title: {
+			raw: sprintf(
+				/* translators: %s: existing post type title. */
+				_x( '%s (Copy)', 'post type' ),
+				source.title.raw
+			),
+		},
+		slug: buildCopySlug( source.slug ),
+	} ) );
+	const [ isDuplicating, setIsDuplicating ] = useState( false );
+	const slugField = useSlugField( undefined, data.slug );
+
+	const fields = useMemo< Field< PostTypeFormData >[] >(
+		() => [ pluralLabelField, singularLabelField, slugField ],
+		[ slugField ]
+	);
+
+	const { validity, isValid } = useFormValidity(
+		data,
+		fields,
+		duplicateForm
+	);
+	const { saveEntityRecord } = useDispatch( coreStore );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	async function onDuplicate() {
+		if ( isDuplicating || ! isValid ) {
+			return;
+		}
+		setIsDuplicating( true );
+		try {
+			await saveEntityRecord(
+				'postType',
+				'wp_user_post_type',
+				serializeForSave( data ),
+				{ throwOnError: true }
+			);
+			createSuccessNotice(
+				sprintf(
+					/* translators: %s: post type plural label. */
+					__( '"%s" post type created.' ),
+					data.title.raw
+				),
+				{ type: 'snackbar' }
+			);
+			onActionPerformed?.( items );
+			closeModal?.();
+		} catch ( error ) {
+			const typedError = error as CoreDataError;
+			createErrorNotice(
+				typedError?.message && typedError.code !== 'unknown_error'
+					? typedError.message
+					: __( 'Failed to duplicate post type.' ),
+				{ type: 'snackbar' }
+			);
+		} finally {
+			setIsDuplicating( false );
+		}
+	}
+
+	return (
+		<Stack direction="column" gap="md">
+			<DataForm< PostTypeFormData >
+				data={ data }
+				fields={ fields }
+				form={ duplicateForm }
+				validity={ validity }
+				onChange={ ( edits ) =>
+					setData(
+						( prev ) =>
+							( { ...prev, ...edits } ) as PostTypeFormData
+					)
+				}
+			/>
+			<Stack direction="row" justify="flex-end" gap="sm">
+				<Button
+					__next40pxDefaultSize
+					variant="tertiary"
+					onClick={ closeModal }
+					disabled={ isDuplicating }
+					accessibleWhenDisabled
+				>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					isBusy={ isDuplicating }
+					disabled={ isDuplicating || ! isValid }
+					accessibleWhenDisabled
+					onClick={ onDuplicate }
+				>
+					{ _x( 'Duplicate', 'action label' ) }
+				</Button>
+			</Stack>
+		</Stack>
+	);
+}
+
+const duplicatePostTypeAction: Action< PostTypeFormData > = {
+	id: 'duplicate-post-type',
+	label: _x( 'Duplicate', 'action label' ),
+	icon: copy,
+	modalHeader: __( 'Duplicate post type' ),
+	modalFocusOnMount: 'firstContentElement',
+	RenderModal: DuplicatePostTypeModal,
+};
+
+export default duplicatePostTypeAction;

--- a/packages/user-post-types/src/index.ts
+++ b/packages/user-post-types/src/index.ts
@@ -22,4 +22,5 @@ export * from './fields';
 export { default as activateAction } from './actions/activate';
 export { default as deactivateAction } from './actions/deactivate';
 export { default as deletePostTypeAction } from './actions/delete';
+export { default as duplicatePostTypeAction } from './actions/duplicate';
 export { createStatusAction, type StatusActionConfig } from './actions/utils';

--- a/routes/post-types/stage.tsx
+++ b/routes/post-types/stage.tsx
@@ -21,6 +21,7 @@ import {
 	activateAction,
 	deactivateAction,
 	deletePostTypeAction,
+	duplicatePostTypeAction,
 	type PostTypeRecord,
 } from '@wordpress/user-post-types';
 
@@ -51,6 +52,7 @@ function PostTypesPage() {
 		() => [
 			editAction,
 			quickEditPostTypeAction,
+			duplicatePostTypeAction,
 			activateAction,
 			deactivateAction,
 			deletePostTypeAction,


### PR DESCRIPTION
## What?
Adds a "Duplicate" action to the post type management screen added in #77754.

## Why?
When a user wants a new post type that is similar to an existing one, today they have to recreate every option from scratch. Duplicating is the obvious shortcut.

## How?
Adding a new action that opens a modal for adding details and then duplicates the post type based on the passed data. 

## Testing Instructions
  1. Enable the Content Types experiment (Gutenberg > Experiments).
  2. Visit the Post Types screen and create or pick an existing custom post type.
  3. From the row's actions menu, choose Duplicate.
  4. Verify the modal pre-fills:
      - Plural label: `<original> (Copy)`
      - Singular label: same as the source
      - Post type key: `<original-slug>_copy` (truncated if needed)
  5. Submit. Verify:
      - A success snackbar appears.
      - A new row shows up with status "Inactive".
      - Editing the new row shows the same data as the source.
  6. Try to duplicate again without changing the key — confirm the slug field reports "This post type key is already in use." and the primary button stays disabled.
  7. Try entering an invalid key (uppercase, spaces, > 20 chars) — confirm the same field reports a validation error.
  8. Activate the duplicate, confirm it registers as a new post type.
  9. Delete the duplicate, confirm it goes away cleanly.

### Testing Instructions for Keyboard
  1. Tab to a post type row's actions menu trigger and open it with Enter / Space.
  2. Arrow to Duplicate and activate it.
  3. Confirm focus lands inside the modal (Plural label input).
  4. Tab through Plural label > Singular label > Post type key > Cancel > Duplicate.
  5. Submit with Enter on the Duplicate button; confirm the modal closes and focus returns to a sensible place in the table.
  6. Re-open via keyboard, press Esc; confirm the modal closes without saving.

## Screenshots or screencast <!-- if applicable -->

<img width="200" height="240" alt="Screenshot 2026-04-30 at 16 47 49" src="https://github.com/user-attachments/assets/aa1d2173-6c65-4948-b292-844117f2cf28" />

<img width="577" height="442" alt="Screenshot 2026-04-30 at 16 47 57" src="https://github.com/user-attachments/assets/8d46967f-3a33-49d7-aae9-c16173eff781" />

## Use of AI Tools

Opus 4.7
