### PR TITLE
Disable Classic block: Control inserter support via filter

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -87,23 +87,15 @@ function gutenberg_override_translation_file( $file, $handle ) {
 add_filter( 'load_script_translation_file', 'gutenberg_override_translation_file', 10, 2 );
 
 /**
- * Handle special case dependencies for wp-block-library that depend on runtime conditions.
- *
- * This adds the 'editor' dependency conditionally based on experiments and classic block requirements.
- * All other script registrations are handled by the auto-generated build/scripts.php file.
+ * Adds the 'editor' dependency to wp-block-library, required by the Classic block.
  *
  * @param WP_Scripts $scripts WP_Scripts instance.
  */
 function gutenberg_register_block_library_script_special_case( $scripts ) {
 	$handle = 'wp-block-library';
 	$script = $scripts->query( $handle, 'registered' );
-	if (
-		! gutenberg_is_experiment_enabled( 'gutenberg-no-tinymce' ) ||
-		gutenberg_classic_block_supports_inserter()
-	) {
-		if ( ! in_array( 'editor', $script->deps, true ) ) {
-			$script->deps[] = 'editor';
-		}
+	if ( ! in_array( 'editor', $script->deps, true ) ) {
+		$script->deps[] = 'editor';
 	}
 }
 add_action( 'wp_default_scripts', 'gutenberg_register_block_library_script_special_case', 11 );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -99,7 +99,7 @@ function gutenberg_register_block_library_script_special_case( $scripts ) {
 	$script = $scripts->query( $handle, 'registered' );
 	if (
 		! gutenberg_is_experiment_enabled( 'gutenberg-no-tinymce' ) ||
-		gutenberg_post_being_edited_requires_classic_block()
+		gutenberg_classic_block_supports_inserter()
 	) {
 		if ( ! in_array( 'editor', $script->deps, true ) ) {
 			$script->deps[] = 'editor';

--- a/lib/experimental/disable-tinymce.php
+++ b/lib/experimental/disable-tinymce.php
@@ -9,7 +9,7 @@
  * Render a variable that we'll use to declare that the editor will need the classic block.
  */
 function gutenberg_declare_classic_block_necessary() {
-	if ( ! gutenberg_post_being_edited_requires_classic_block() ) {
+	if ( ! gutenberg_classic_block_supports_inserter() ) {
 		return;
 	}
 	echo '<script type="text/javascript">window.wp.needsClassicBlock = true;</script>';
@@ -17,46 +17,28 @@ function gutenberg_declare_classic_block_necessary() {
 add_action( 'admin_print_footer_scripts', 'gutenberg_declare_classic_block_necessary', 20 );
 
 /**
- * Whether the current editor contains a classic block instance.
+ * Whether the Classic block should be available in the inserter.
  *
- * @return bool True if the editor contains a classic block, false otherwise.
+ * @return bool True if the Classic block should be in the inserter.
  */
-function gutenberg_post_being_edited_requires_classic_block() {
-	if ( ! is_admin() ) {
-		return false;
-	}
-
-	// Continue only if we're in the post editor.
-	if ( empty( $_GET['post'] ) || empty( $_GET['action'] ) || 'edit' !== $_GET['action'] ) {
-		return false;
-	}
-
-	// Bail if for some reason the post isn't found.
-	$current_post = get_post( absint( $_GET['post'] ) );
-	if ( ! $current_post ) {
-		return false;
-	}
-
-	// Check if block editor is disabled by "Classic Editor" or another plugin.
+function gutenberg_classic_block_supports_inserter() {
+	$post = null;
 	if (
-		function_exists( 'use_block_editor_for_post_type' ) &&
-		! use_block_editor_for_post_type( $current_post->post_type )
+		is_admin() &&
+		! empty( $_GET['post'] ) &&
+		! empty( $_GET['action'] ) &&
+		'edit' === $_GET['action']
 	) {
-		return true;
+		$post = get_post( absint( $_GET['post'] ) ) ?: null;
 	}
 
-	$content = $current_post->post_content;
-	if ( empty( $content ) ) {
-		return false;
-	}
-
-	$parsed_blocks = parse_blocks( $content );
-	foreach ( $parsed_blocks as $block ) {
-		$is_freeform_block = empty( $block['blockName'] ) || 'core/freeform' === $block['blockName'];
-		if ( $is_freeform_block && strlen( trim( $block['innerHTML'] ) ) > 0 ) {
-			return true;
-		}
-	}
-
-	return false;
+	/**
+	 * Filters whether the Classic block should be available in the inserter.
+	 *
+	 * Defaults to false. Use this filter to opt in (globally or per post).
+	 *
+	 * @param bool         $supports_inserter Whether the Classic block is available in the inserter.
+	 * @param WP_Post|null $post              The post being edited, or null if not in the post editor.
+	 */
+	return (bool) apply_filters( 'gutenberg_classic_block_supports_inserter', false, $post );
 }

--- a/lib/experimental/disable-tinymce.php
+++ b/lib/experimental/disable-tinymce.php
@@ -29,7 +29,7 @@ function gutenberg_classic_block_supports_inserter() {
 		! empty( $_GET['action'] ) &&
 		'edit' === $_GET['action']
 	) {
-		$post = get_post( absint( $_GET['post'] ) ) ?: null;
+		$post = get_post( absint( $_GET['post'] ) );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add a `gutenberg_classic_block_supports_inserter` filter to control whether the Classic block is available in the inserter. Defaults to `false`.

The previous post-content check is no longer necessary. Since we switched to registering the Classic block unconditionally in https://github.com/WordPress/gutenberg/pull/77840, existing posts that use the Classic block will continue to work - we just don't allow new instances to be inserted.

## Why?
Previously, the Classic block was made available in the inserter when the post being edited already contained one. For the experiment, we want a stricter default - hide the Classic block from the inserter, and let developers opt in explicitly.

## How?
The Classic block's inserter visibility is now driven by a single PHP filter. The result is exposed to JS through the existing `window.wp.needsClassicBlock` flag, which the block reads via `supports.inserter`. The filter receives the post being edited (or null) so callbacks can decide based on context.

## Testing Instructions
1. Open a post in the block editor with the "Disable Classic block" experiment enabled.
2. Confirm the Classic block is not in the inserter, even on posts that already contain a Classic block.
3. Add this snippet to a plugin or `mu-plugins`:
```php
add_filter( 'gutenberg_classic_block_supports_inserter', '__return_true' );
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

N/A

## Use of AI Tools

Cursor with Opus 4.7