### PR TITLE
Update uuid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
 				"@types/react-dom": "^18.3.1",
 				"@types/semver": "7.3.8",
 				"@types/sprintf-js": "1.1.2",
-				"@types/uuid": "8.3.1",
 				"@typescript/native-preview": "7.0.0-dev.20260423.1",
 				"@wordpress/build": "file:./packages/wp-build",
 				"@wordpress/eslint-tools": "file:./tools/eslint",
@@ -87,7 +86,7 @@
 				"style-loader": "3.2.1",
 				"stylelint-plugin-logical-css": "^1.2.3",
 				"typescript": "6.0.2",
-				"uuid": "9.0.1",
+				"uuid": "11.1.1",
 				"wait-on": "8.0.1"
 			},
 			"engines": {
@@ -1231,6 +1230,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@appium/support/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@appium/support/node_modules/which": {
@@ -18601,12 +18615,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
 			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
-		},
-		"node_modules/@types/uuid": {
-			"version": "8.3.1",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
-			"integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
-			"dev": true
 		},
 		"node_modules/@types/vfile": {
 			"version": "3.0.2",
@@ -54723,15 +54731,17 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
+			"license": "MIT",
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"node_modules/v8-to-istanbul": {
@@ -57763,7 +57773,7 @@
 				"@wordpress/hooks": "file:../hooks",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/rich-text": "file:../rich-text",
-				"uuid": "^9.0.1"
+				"uuid": "^14.0.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -57771,6 +57781,19 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
+			}
+		},
+		"packages/annotations/node_modules/uuid": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"packages/api-fetch": {
@@ -58242,7 +58265,7 @@
 				"html-react-parser": "5.2.11",
 				"memize": "^2.1.0",
 				"remove-accents": "^0.5.0",
-				"uuid": "^9.0.1"
+				"uuid": "^14.0.0"
 			},
 			"devDependencies": {
 				"deep-freeze": "0.0.1"
@@ -58267,6 +58290,19 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/arraypress"
+			}
+		},
+		"packages/block-library/node_modules/uuid": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"packages/block-serialization-default-parser": {
@@ -58324,7 +58360,7 @@
 				"remove-accents": "^0.5.0",
 				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
-				"uuid": "^9.0.1"
+				"uuid": "^14.0.0"
 			},
 			"devDependencies": {
 				"deep-freeze": "0.0.1"
@@ -58341,6 +58377,19 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+		},
+		"packages/blocks/node_modules/uuid": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
 		},
 		"packages/boot": {
 			"name": "@wordpress/boot",
@@ -58469,7 +58518,7 @@
 				"react-colorful": "^5.6.1",
 				"react-day-picker": "^9.7.0",
 				"remove-accents": "^0.5.0",
-				"uuid": "^9.0.1"
+				"uuid": "^14.0.0"
 			},
 			"devDependencies": {
 				"@ariakit/test": "^0.4.13",
@@ -58576,6 +58625,19 @@
 			"peerDependencies": {
 				"react": ">=16.8.0",
 				"react-dom": ">=16.8.0"
+			}
+		},
+		"packages/components/node_modules/uuid": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"packages/compose": {
@@ -58686,7 +58748,7 @@
 				"equivalent-key-map": "^0.2.2",
 				"fast-deep-equal": "^3.1.3",
 				"memize": "^2.1.0",
-				"uuid": "^9.0.1"
+				"uuid": "^14.0.0"
 			},
 			"devDependencies": {
 				"@jest/globals": "^30.2.0",
@@ -59416,6 +59478,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"packages/core-data/node_modules/uuid": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
 		"packages/core-data/node_modules/write-file-atomic": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
@@ -60064,7 +60139,7 @@
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"remove-accents": "^0.5.0",
-				"uuid": "^9.0.1"
+				"uuid": "^14.0.0"
 			},
 			"devDependencies": {
 				"deep-freeze": "0.0.1"
@@ -60076,6 +60151,19 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"packages/editor/node_modules/uuid": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"packages/element": {
@@ -63029,7 +63117,7 @@
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/url": "file:../url",
 				"@wordpress/vips": "file:../vips",
-				"uuid": "^9.0.1"
+				"uuid": "^14.0.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -63038,6 +63126,19 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"packages/upload-media/node_modules/uuid": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"packages/url": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
 		"@types/react-dom": "^18.3.1",
 		"@types/semver": "7.3.8",
 		"@types/sprintf-js": "1.1.2",
-		"@types/uuid": "8.3.1",
 		"@typescript/native-preview": "7.0.0-dev.20260423.1",
 		"@wordpress/build": "file:./packages/wp-build",
 		"@wordpress/eslint-tools": "file:./tools/eslint",
@@ -110,7 +109,7 @@
 		"style-loader": "3.2.1",
 		"stylelint-plugin-logical-css": "^1.2.3",
 		"typescript": "6.0.2",
-		"uuid": "9.0.1",
+		"uuid": "11.1.1",
 		"wait-on": "8.0.1"
 	},
 	"overrides": {

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -47,7 +47,7 @@
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/rich-text": "file:../rich-text",
-		"uuid": "^9.0.1"
+		"uuid": "^14.0.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0"

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -140,7 +140,7 @@
 		"html-react-parser": "5.2.11",
 		"memize": "^2.1.0",
 		"remove-accents": "^0.5.0",
-		"uuid": "^9.0.1"
+		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
 		"deep-freeze": "0.0.1"

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -76,7 +76,7 @@
 		"remove-accents": "^0.5.0",
 		"showdown": "^1.9.1",
 		"simple-html-tokenizer": "^0.5.7",
-		"uuid": "^9.0.1"
+		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
 		"deep-freeze": "0.0.1"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -99,7 +99,7 @@
 		"react-colorful": "^5.6.1",
 		"react-day-picker": "^9.7.0",
 		"remove-accents": "^0.5.0",
-		"uuid": "^9.0.1"
+		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
 		"@ariakit/test": "^0.4.13",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -69,7 +69,7 @@
 		"equivalent-key-map": "^0.2.2",
 		"fast-deep-equal": "^3.1.3",
 		"memize": "^2.1.0",
-		"uuid": "^9.0.1"
+		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
 		"@jest/globals": "^30.2.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -114,7 +114,7 @@
 		"memize": "^2.1.0",
 		"react-autosize-textarea": "^7.1.0",
 		"remove-accents": "^0.5.0",
-		"uuid": "^9.0.1"
+		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
 		"deep-freeze": "0.0.1"

--- a/packages/upload-media/package.json
+++ b/packages/upload-media/package.json
@@ -58,7 +58,7 @@
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/url": "file:../url",
 		"@wordpress/vips": "file:../vips",
-		"uuid": "^9.0.1"
+		"uuid": "^14.0.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->
Packages are updated to the latest version, 14.0.0. The monorepo root is updated to 11.1.1, which is the latest version that still supports CommonJS.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Upstream has deprecated all versions of `uuid` before 11, and notes that 11 will likely be deprecated in 2028.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
... By updating the version numbers in package.json files.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
There should be no functional changes due to this PR.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

N/A

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
None