### PR TITLE
Block Library: Use ServerSideRender for Classic block preview

### DIFF
--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -14,7 +14,8 @@ import {
 	ToolbarGroup,
 	ToolbarButton,
 } from '@wordpress/components';
-import { useState, useRef, RawHTML } from '@wordpress/element';
+import ServerSideRender from '@wordpress/server-side-render';
+import { useState, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { classic } from '@wordpress/icons';
 
@@ -59,7 +60,11 @@ export default function FreeformEdit( {
 			</BlockControls>
 			<div { ...useBlockProps() }>
 				{ content ? (
-					<RawHTML>{ content }</RawHTML>
+					<ServerSideRender
+						block="core/freeform"
+						attributes={ attributes }
+						httpMethod="POST"
+					/>
 				) : (
 					<Placeholder
 						icon={ <BlockIcon icon={ classic } /> }

--- a/packages/block-library/src/freeform/index.php
+++ b/packages/block-library/src/freeform/index.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Server-side rendering of the `core/freeform` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/freeform` block on server.
+ *
+ * @param array  $attributes The block attributes.
+ * @param string $content    The block content.
+ *
+ * @return string Returns the block content with shortcodes processed.
+ */
+function render_block_core_freeform( $attributes, $content ) {
+	return do_shortcode( $attributes['content'] ?? $content );
+}
+
+/**
+ * Registers the `core/freeform` block on server.
+ */
+function register_block_core_freeform() {
+	register_block_type_from_metadata(
+		__DIR__ . '/freeform',
+		array(
+			'render_callback' => 'render_block_core_freeform',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_freeform' );


### PR DESCRIPTION

## What?

Fixes an issue where the Classic block (`core/freeform`) displays raw shortcodes (e.g. `[caption]`) in the editor preview instead of rendered output.
Closes https://github.com/WordPress/gutenberg/issues/53698

## Why?

The Classic block currently renders its preview using `RawHTML`, which does not process shortcodes.
As a result, the editor preview does not match:

* the frontend rendering
* the Classic editor (TinyMCE modal) output

This creates an inconsistent editing experience.

## How?

* Replaced `RawHTML` with `ServerSideRender` in the Classic block preview.
* Added a minimal `render_callback` to process content using `do_shortcode()`.

This follows the standard Gutenberg approach for dynamic rendering and ensures shortcode handling is consistent with WordPress core behavior.

## Testing Instructions

1. Add a Classic block.
2. Open the Classic editor (modal).
3. Insert an image with a caption.
4. Save and return to the block editor.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


#### Before

* `[caption]` shortcode is shown as raw text.


https://github.com/user-attachments/assets/7d1f2cc6-3af9-46c1-b673-d7879719bcc9


#### After

* Caption is rendered correctly in the preview.

https://github.com/user-attachments/assets/26751192-51ca-463c-af92-d769da174481


