### PR TITLE
[ui] Add internal wp compat overlay slot helper

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -15,11 +15,19 @@
 -   `Drawer`: Restore the slide-out animation when the popup closes ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).
 -   `Drawer`: Forward the `render` prop on `Drawer.Content` to the scroll container instead of leaking it as a DOM attribute, matching `Dialog.Content` ([#77941](https://github.com/WordPress/gutenberg/pull/77941)).
 
+### New Features
+
+-   Add `useEnableWpCompatOverlaySlot()` hook to opt into a body-level overlay container that stacks `@wordpress/ui` overlays above `@wordpress/components` overlays in mixed-library compositions. The slot auto-enables wherever `window.wp.components` is on the global (the typical script-loader setup for WordPress plugins and admin screens), so the hook is mostly relevant for hosts that bundle `@wordpress/components` (or only `@wordpress/ui`) directly — apps that aren't built with standard WordPress build tooling. Per-component support will be added incrementally ([#77851](https://github.com/WordPress/gutenberg/pull/77851)).
+
 ### Enhancements
 
 -   `Select`: Add a `placeholder` prop to `Select.Trigger`, and support `null` item values for clearable placeholder options ([#78076](https://github.com/WordPress/gutenberg/pull/78076)).
 -   `Drawer`: Fade the popup elevation shadow alongside the slide ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).
 -   `Drawer`: Allow mouse-drag swipe-dismiss in the popup-edge padding gutter ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).
+
+### Internal
+
+-   Add internal `getWpCompatOverlaySlot()` helper and a co-located unlayered CSS module that lazily provide a body-level `[data-wp-compat-overlay-slot]` container at z-index `1000000003`, gated by `useEnableWpCompatOverlaySlot()` and by auto-detection of `window.wp.components` ([#77851](https://github.com/WordPress/gutenberg/pull/77851)).
 
 ## 0.12.0 (2026-04-29)
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -17,4 +17,5 @@ export * from './stack';
 export * as Tabs from './tabs';
 export * from './text';
 export * as Tooltip from './tooltip';
+export { useEnableWpCompatOverlaySlot } from './utils/use-enable-wp-compat-overlay-slot';
 export * from './visually-hidden';

--- a/packages/ui/src/utils/css/wp-compat-overlay-slot.module.css
+++ b/packages/ui/src/utils/css/wp-compat-overlay-slot.module.css
@@ -25,8 +25,8 @@
  *   1. `z-index` is ignored on `position: static` elements. The slot needs
  *      to be positioned for the `1000000003` value to apply at all.
  *   2. Any non-static position makes the slot a containing block for its
- *      absolute-positioned descendants. Base UI overlay positioners use
- *      `positionMethod: 'absolute'` by default, and floating-ui writes
+ *      absolute-positioned descendants. Overlay positioners in this
+ *      package position popups absolutely, and floating-ui writes
  *      physical viewport-relative `top` / `left` coordinates onto the
  *      floating element. For those coordinates to land correctly, the
  *      containing block must sit at viewport `(0, 0)`. `position: fixed`

--- a/packages/ui/src/utils/css/wp-compat-overlay-slot.module.css
+++ b/packages/ui/src/utils/css/wp-compat-overlay-slot.module.css
@@ -1,0 +1,63 @@
+/*
+ * WP compat overlay slot — body-level positioned container that hosts
+ * `@wordpress/ui` overlays so they reliably stack in mixed-library
+ * compositions.
+ *
+ * The `data-wp-compat-overlay-slot` attribute is the architectural identifier
+ * for the slot (see `getWpCompatOverlaySlot()`); the `.slot` class is the
+ * styling vehicle.
+ *
+ * Authored unlayered — outside `@layer wp-ui-*` — so the slot's z-index and
+ * positioning win against any `@layer`-scoped rule that might otherwise try
+ * to redefine them. CSS cascade layers always lose to unlayered styles, so
+ * unlayering is the ceiling.
+ *
+ * Why each declaration is what it is:
+ *
+ * - `z-index: 1000000003` — sits in a separate, reserved billion-scale band
+ *   above the legacy z-index map in `packages/base-styles/_z-index.scss`.
+ *   The literal value lives here as a transitional compromise: the z-index
+ *   list is conceptually a legacy concern that the broader migration aims
+ *   to eliminate, and this slot is itself a workaround on top of it.
+ *
+ * - `position: fixed` — load-bearing for two independent reasons:
+ *
+ *   1. `z-index` is ignored on `position: static` elements. The slot needs
+ *      to be positioned for the `1000000003` value to apply at all.
+ *   2. Any non-static position makes the slot a containing block for its
+ *      absolute-positioned descendants. Base UI overlay positioners use
+ *      `positionMethod: 'absolute'` by default, and floating-ui writes
+ *      physical viewport-relative `top` / `left` coordinates onto the
+ *      floating element. For those coordinates to land correctly, the
+ *      containing block must sit at viewport `(0, 0)`. `position: fixed`
+ *      (with `top: 0; left: 0`) pins the slot there regardless of scroll;
+ *      `position: relative` would anchor at body's flow position (offset
+ *      by body's margin/padding) and silently break popover positioning.
+ *
+ * - `top: 0; left: 0` — physical, intentionally not logical. Floating-ui
+ *   writes physical viewport pixels onto the floating element, so the
+ *   containing block has to sit at the *physical* viewport origin.
+ *   `inset-inline-start: 0` would resolve to `right: 0` in RTL, anchoring
+ *   the (zero-width) slot at the viewport's top-right corner; an absolute
+ *   child with `left: 200px` would then resolve at viewport-width + 200px,
+ *   off the right edge of the screen. Same hazard for `inset-block-start`
+ *   under vertical writing modes.
+ *
+ * - `isolation: isolate` — strictly redundant once `position: fixed` and
+ *   `z-index` are set (a positioned element with a non-`auto` z-index
+ *   already establishes a stacking context). Kept as an explicit
+ *   declaration of intent: this element is a stacking-context boundary,
+ *   independent of how it happens to be positioned.
+ *
+ * The slot has zero content size, so it never intercepts pointer events on
+ * its own.
+ */
+
+.slot {
+	position: fixed;
+	top: 0;
+	/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical anchoring required so floating-ui's viewport-relative coordinates resolve correctly; see file header for reasoning. */
+	left: 0;
+	z-index: 1000000003;
+	isolation: isolate;
+}

--- a/packages/ui/src/utils/css/wp-compat-overlay-slot.module.css
+++ b/packages/ui/src/utils/css/wp-compat-overlay-slot.module.css
@@ -1,62 +1,45 @@
 /*
  * WP compat overlay slot — body-level positioned container that hosts
  * `@wordpress/ui` overlays so they reliably stack in mixed-library
- * compositions.
+ * compositions. The `data-wp-compat-overlay-slot` attribute is the
+ * architectural identifier (see `getWpCompatOverlaySlot()`); `.slot` is
+ * the styling vehicle.
  *
- * The `data-wp-compat-overlay-slot` attribute is the architectural identifier
- * for the slot (see `getWpCompatOverlaySlot()`); the `.slot` class is the
- * styling vehicle.
- *
- * Authored unlayered — outside `@layer wp-ui-*` — so the slot's z-index and
- * positioning win against any `@layer`-scoped rule that might otherwise try
- * to redefine them. CSS cascade layers always lose to unlayered styles, so
- * unlayering is the ceiling.
+ * Authored unlayered — outside `@layer wp-ui-*` — so the slot's z-index
+ * and positioning win against any `@layer`-scoped rule. CSS cascade
+ * layers always lose to unlayered styles, so unlayering is the ceiling.
  *
  * Why each declaration is what it is:
  *
- * - `z-index: 1000000003` — sits in a separate, reserved billion-scale band
- *   above the legacy z-index map in `packages/base-styles/_z-index.scss`.
- *   The literal value lives here as a transitional compromise: the z-index
- *   list is conceptually a legacy concern that the broader migration aims
- *   to eliminate, and this slot is itself a workaround on top of it.
+ * - `z-index: 1000000003` — sits in a reserved billion-scale band above
+ *   the legacy z-index map in `packages/base-styles/_z-index.scss`.
  *
- * - `position: fixed` — load-bearing for two independent reasons:
+ * - `position: fixed` — load-bearing for two reasons. (1) `z-index` is
+ *   ignored on `position: static`. (2) A non-static position makes the
+ *   slot a containing block for absolute-positioned descendants;
+ *   floating-ui writes physical viewport-relative `top` / `left` onto
+ *   the floating element, so the containing block must sit at viewport
+ *   `(0, 0)`. `position: fixed` (with `top: 0; left: 0`) pins it there
+ *   regardless of scroll; `position: relative` would anchor at body's
+ *   flow position and silently break popover positioning.
  *
- *   1. `z-index` is ignored on `position: static` elements. The slot needs
- *      to be positioned for the `1000000003` value to apply at all.
- *   2. Any non-static position makes the slot a containing block for its
- *      absolute-positioned descendants. Overlay positioners in this
- *      package position popups absolutely, and floating-ui writes
- *      physical viewport-relative `top` / `left` coordinates onto the
- *      floating element. For those coordinates to land correctly, the
- *      containing block must sit at viewport `(0, 0)`. `position: fixed`
- *      (with `top: 0; left: 0`) pins the slot there regardless of scroll;
- *      `position: relative` would anchor at body's flow position (offset
- *      by body's margin/padding) and silently break popover positioning.
+ * - `top: 0; left: 0` — physical, not logical. `inset-inline-start: 0`
+ *   would resolve to `right: 0` in RTL, anchoring the (zero-width) slot
+ *   at the viewport's top-right corner; an absolute child with
+ *   `left: 200px` would then resolve off the right edge of the screen.
+ *   Same hazard for `inset-block-start` under vertical writing modes.
  *
- * - `top: 0; left: 0` — physical, intentionally not logical. Floating-ui
- *   writes physical viewport pixels onto the floating element, so the
- *   containing block has to sit at the *physical* viewport origin.
- *   `inset-inline-start: 0` would resolve to `right: 0` in RTL, anchoring
- *   the (zero-width) slot at the viewport's top-right corner; an absolute
- *   child with `left: 200px` would then resolve at viewport-width + 200px,
- *   off the right edge of the screen. Same hazard for `inset-block-start`
- *   under vertical writing modes.
+ * - `isolation: isolate` — redundant once `position: fixed` and
+ *   `z-index` are set (the slot is already a stacking context). Kept as
+ *   an explicit declaration of intent.
  *
- * - `isolation: isolate` — strictly redundant once `position: fixed` and
- *   `z-index` are set (a positioned element with a non-`auto` z-index
- *   already establishes a stacking context). Kept as an explicit
- *   declaration of intent: this element is a stacking-context boundary,
- *   independent of how it happens to be positioned.
- *
- * The slot has zero content size, so it never intercepts pointer events on
- * its own.
+ * The slot has zero content size, so it never intercepts pointer events.
  */
 
 .slot {
 	position: fixed;
 	top: 0;
-	/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical anchoring required so floating-ui's viewport-relative coordinates resolve correctly; see file header for reasoning. */
+	/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical anchoring required so floating-ui's viewport-relative coordinates resolve correctly; see file header. */
 	left: 0;
 	z-index: 1000000003;
 	isolation: isolate;

--- a/packages/ui/src/utils/test/use-enable-wp-compat-overlay-slot.test.tsx
+++ b/packages/ui/src/utils/test/use-enable-wp-compat-overlay-slot.test.tsx
@@ -1,0 +1,79 @@
+import { render } from '@testing-library/react';
+import {
+	WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE,
+	getWpCompatOverlaySlot,
+	__resetWpCompatOverlaySlotCacheForTests,
+} from '../wp-compat-overlay-slot';
+import { useEnableWpCompatOverlaySlot } from '../use-enable-wp-compat-overlay-slot';
+
+const internalWindow = window as unknown as {
+	__wpUiCompatOverlaySlotEnabled?: boolean;
+};
+
+// The slot is identified by a data attribute (cross-tooling marker, not a
+// user-facing role/text), so direct DOM queries are appropriate here —
+// Testing Library's role/text accessors don't apply.
+/* eslint-disable testing-library/no-node-access */
+
+function findSlots(): HTMLElement[] {
+	return Array.from(
+		document.querySelectorAll< HTMLElement >(
+			`[${ WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE }]`
+		)
+	);
+}
+
+function HookHost() {
+	useEnableWpCompatOverlaySlot();
+	return null;
+}
+
+describe( 'useEnableWpCompatOverlaySlot', () => {
+	afterEach( () => {
+		__resetWpCompatOverlaySlotCacheForTests();
+		findSlots().forEach( ( el ) => el.remove() );
+		delete internalWindow.__wpUiCompatOverlaySlotEnabled;
+	} );
+
+	it( 'enables the slot once mounted, so getWpCompatOverlaySlot() returns the slot', () => {
+		expect( getWpCompatOverlaySlot() ).toBeNull();
+
+		render( <HookHost /> );
+
+		const slot = getWpCompatOverlaySlot();
+		expect( slot ).not.toBeNull();
+		expect( slot?.parentElement ).toBe( document.body );
+		expect( findSlots() ).toHaveLength( 1 );
+	} );
+
+	it( 'is idempotent across multiple components calling the hook', () => {
+		render(
+			<>
+				<HookHost />
+				<HookHost />
+				<HookHost />
+			</>
+		);
+
+		expect( getWpCompatOverlaySlot() ).not.toBeNull();
+		expect( findSlots() ).toHaveLength( 1 );
+	} );
+
+	it( 'leaves the slot enabled after the hook caller unmounts (one-way opt-in)', () => {
+		// The slot is shared infrastructure across all `@wordpress/ui`
+		// consumers in the document; a single component shouldn't be
+		// able to disable it for everyone else once enabled. This test
+		// pins that one-way behavior — unmounting the hook caller does
+		// not flip the gate back off.
+		const { unmount } = render( <HookHost /> );
+
+		expect( getWpCompatOverlaySlot() ).not.toBeNull();
+
+		unmount();
+
+		expect( internalWindow.__wpUiCompatOverlaySlotEnabled ).toBe( true );
+		expect( getWpCompatOverlaySlot() ).not.toBeNull();
+	} );
+} );
+
+/* eslint-enable testing-library/no-node-access */

--- a/packages/ui/src/utils/test/wp-compat-overlay-slot.test.ts
+++ b/packages/ui/src/utils/test/wp-compat-overlay-slot.test.ts
@@ -191,6 +191,42 @@ describe( 'getWpCompatOverlaySlot', () => {
 
 			expect( getWpCompatOverlaySlot() ).toBeNull();
 		} );
+
+		it( 'invalidates the cache and detaches the stale slot when the cached element belongs to a different document', () => {
+			// Drives the `cachedSlot.ownerDocument !== ownerDocument` branch
+			// and the subsequent `if ( cachedSlot?.isConnected )
+			// cachedSlot.remove();` cleanup. Triggered in real environments
+			// by a runtime-detected switch in the owning document (e.g. a
+			// jsdom test teardown that tears down the realm, or a host
+			// swapping the active document). Simulated here by moving the
+			// cached slot into a foreign parsed document so its
+			// `ownerDocument` differs from the helper's local `document`
+			// while staying `isConnected` to that foreign document — the
+			// exact shape the cleanup branch was written to handle.
+			const first = getWpCompatOverlaySlot();
+			expect( first ).not.toBeNull();
+
+			const foreignDocument = new DOMParser().parseFromString(
+				'<!DOCTYPE html><html><body></body></html>',
+				'text/html'
+			);
+			foreignDocument.body.appendChild(
+				foreignDocument.adoptNode( first! )
+			);
+			expect( first?.ownerDocument ).toBe( foreignDocument );
+			expect( first?.isConnected ).toBe( true );
+			expect( findSlots() ).toHaveLength( 0 );
+
+			const second = getWpCompatOverlaySlot();
+
+			expect( second ).not.toBeNull();
+			expect( second ).not.toBe( first );
+			expect( second?.ownerDocument ).toBe( document );
+			expect( second?.parentElement ).toBe( document.body );
+			expect( first?.isConnected ).toBe( false );
+			expect( foreignDocument.body.children ).toHaveLength( 0 );
+			expect( findSlots() ).toHaveLength( 1 );
+		} );
 	} );
 
 	describe( 'DOM-level singleton (cross-instance coordination)', () => {

--- a/packages/ui/src/utils/test/wp-compat-overlay-slot.test.ts
+++ b/packages/ui/src/utils/test/wp-compat-overlay-slot.test.ts
@@ -1,0 +1,293 @@
+import {
+	getWpCompatOverlaySlot,
+	WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE,
+	__resetWpCompatOverlaySlotCacheForTests,
+} from '../wp-compat-overlay-slot';
+
+/**
+ * Typed accessor for the internal opt-in flag the helper reads. The flag
+ * is intentionally undeclared on the global `Window` interface — the
+ * public API is `useEnableWpCompatOverlaySlot()` (tested separately) — so
+ * tests that exercise the gating mechanism directly stay behind this
+ * cast, mirroring how the helper itself reads the flag.
+ */
+const internalWindow = window as unknown as {
+	__wpUiCompatOverlaySlotEnabled?: unknown;
+};
+
+/**
+ * Typed accessor for the WordPress runtime global the auto-detect heuristic
+ * reads. Mirrors the helper's local `WpEnvironmentWindow` cast pattern (kept
+ * off the global `Window` interface to avoid leaking a `Window.wp`
+ * augmentation into downstream TS consumers via the package's published
+ * types). Tests use this accessor to plant / observe the runtime shape the
+ * heuristic inspects.
+ */
+const wpEnvWindow = window as unknown as {
+	wp?: { components?: unknown };
+};
+
+function findSlots(): HTMLElement[] {
+	return Array.from(
+		document.querySelectorAll< HTMLElement >(
+			`[${ WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE }]`
+		)
+	);
+}
+
+describe( 'getWpCompatOverlaySlot', () => {
+	afterEach( () => {
+		__resetWpCompatOverlaySlotCacheForTests();
+		findSlots().forEach( ( el ) => el.remove() );
+		delete internalWindow.__wpUiCompatOverlaySlotEnabled;
+		delete wpEnvWindow.wp;
+	} );
+
+	describe( 'explicit opt-in via internal flag', () => {
+		it( 'returns null when no gate is open', () => {
+			expect( getWpCompatOverlaySlot() ).toBeNull();
+			expect( findSlots() ).toHaveLength( 0 );
+		} );
+
+		it( 'returns null when the flag is explicitly false', () => {
+			internalWindow.__wpUiCompatOverlaySlotEnabled = false;
+
+			expect( getWpCompatOverlaySlot() ).toBeNull();
+			expect( findSlots() ).toHaveLength( 0 );
+		} );
+
+		it.each( [
+			[ '1', 1 ],
+			[ "'yes'", 'yes' ],
+			[ 'null', null ],
+			[ 'undefined', undefined ],
+		] )(
+			'returns null when the flag is %s (strict-equality gate)',
+			( _label, value ) => {
+				internalWindow.__wpUiCompatOverlaySlotEnabled = value;
+
+				expect( getWpCompatOverlaySlot() ).toBeNull();
+				expect( findSlots() ).toHaveLength( 0 );
+			}
+		);
+
+		it( 'creates and returns the slot when the flag is true', () => {
+			internalWindow.__wpUiCompatOverlaySlotEnabled = true;
+
+			const slot = getWpCompatOverlaySlot();
+
+			expect( slot ).not.toBeNull();
+			expect( slot ).toBeInstanceOf( HTMLDivElement );
+			expect( slot?.parentElement ).toBe( document.body );
+			expect(
+				slot?.hasAttribute( WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE )
+			).toBe( true );
+			expect( findSlots() ).toHaveLength( 1 );
+		} );
+	} );
+
+	describe( 'WordPress environment auto-detection', () => {
+		it( 'auto-enables when window.wp.components is an object', () => {
+			wpEnvWindow.wp = { components: {} };
+
+			const slot = getWpCompatOverlaySlot();
+
+			expect( slot ).not.toBeNull();
+			expect( findSlots() ).toHaveLength( 1 );
+		} );
+
+		it.each( [
+			[ 'a string', 'something' ],
+			[ 'a number', 42 ],
+			[ 'a boolean', true ],
+			[ 'undefined', undefined ],
+		] )(
+			'does not auto-enable when window.wp.components is %s',
+			( _label, value ) => {
+				wpEnvWindow.wp = { components: value };
+
+				expect( getWpCompatOverlaySlot() ).toBeNull();
+				expect( findSlots() ).toHaveLength( 0 );
+			}
+		);
+
+		it( 'does not auto-enable when window.wp.components is null', () => {
+			// `typeof null === 'object'` so the check needs an explicit null
+			// guard. This test pins that behavior.
+			wpEnvWindow.wp = { components: null };
+
+			expect( getWpCompatOverlaySlot() ).toBeNull();
+			expect( findSlots() ).toHaveLength( 0 );
+		} );
+
+		it( 'does not auto-enable when window.wp itself is missing', () => {
+			expect( getWpCompatOverlaySlot() ).toBeNull();
+			expect( findSlots() ).toHaveLength( 0 );
+		} );
+
+		it( 'opens the gate even with the explicit flag absent', () => {
+			wpEnvWindow.wp = { components: {} };
+			expect(
+				internalWindow.__wpUiCompatOverlaySlotEnabled
+			).toBeUndefined();
+
+			expect( getWpCompatOverlaySlot() ).not.toBeNull();
+		} );
+
+		// The cross-origin `window.top` throw path (where `.wp` access
+		// throws because the top window is in another origin) isn't unit-
+		// tested: jsdom defines `window.top` as a non-configurable, non-
+		// writable getter, so neither `Object.defineProperty` nor
+		// `jest.spyOn(window, 'top', 'get')` nor `jest.replaceProperty`
+		// can simulate the throw. The helper's `try/catch` is readable in
+		// place and the same-origin happy path (`window.top === window` in
+		// jsdom, exercised by every other auto-detect test in this suite)
+		// covers the no-throw branch. Real cross-origin embeddings are
+		// validated via manual smoke testing.
+	} );
+
+	describe( 'singleton caching', () => {
+		beforeEach( () => {
+			internalWindow.__wpUiCompatOverlaySlotEnabled = true;
+		} );
+
+		it( 'returns the same element on repeated calls', () => {
+			const first = getWpCompatOverlaySlot();
+			const second = getWpCompatOverlaySlot();
+			const third = getWpCompatOverlaySlot();
+
+			expect( first ).not.toBeNull();
+			expect( second ).toBe( first );
+			expect( third ).toBe( first );
+			expect( findSlots() ).toHaveLength( 1 );
+		} );
+
+		it( 'creates a fresh element when the previous one was removed from the DOM, and re-caches it', () => {
+			const first = getWpCompatOverlaySlot();
+			expect( first ).not.toBeNull();
+
+			first?.remove();
+			expect( findSlots() ).toHaveLength( 0 );
+
+			const second = getWpCompatOverlaySlot();
+
+			expect( second ).not.toBeNull();
+			expect( second ).not.toBe( first );
+			expect( second?.isConnected ).toBe( true );
+			expect( findSlots() ).toHaveLength( 1 );
+
+			// The recreated element should now be cached: a third call must
+			// return it directly without creating a third slot.
+			const third = getWpCompatOverlaySlot();
+			expect( third ).toBe( second );
+			expect( findSlots() ).toHaveLength( 1 );
+		} );
+
+		it( 'returns null after the gate is closed, even if a slot was previously created', () => {
+			const slot = getWpCompatOverlaySlot();
+			expect( slot ).not.toBeNull();
+
+			delete internalWindow.__wpUiCompatOverlaySlotEnabled;
+
+			expect( getWpCompatOverlaySlot() ).toBeNull();
+		} );
+	} );
+
+	describe( 'DOM-level singleton (cross-instance coordination)', () => {
+		beforeEach( () => {
+			internalWindow.__wpUiCompatOverlaySlotEnabled = true;
+		} );
+
+		it( 'adopts a pre-existing slot element rather than appending a duplicate', () => {
+			// Simulate a second `@wordpress/ui` package instance having
+			// already created the slot before this instance's call. The
+			// module-level `cachedSlot` is null, but the DOM has the slot.
+			const preExisting = document.createElement( 'div' );
+			preExisting.setAttribute( WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE, '' );
+			document.body.appendChild( preExisting );
+
+			const slot = getWpCompatOverlaySlot();
+
+			expect( slot ).toBe( preExisting );
+			expect( findSlots() ).toHaveLength( 1 );
+		} );
+
+		it( 'caches the adopted slot for subsequent calls', () => {
+			const preExisting = document.createElement( 'div' );
+			preExisting.setAttribute( WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE, '' );
+			document.body.appendChild( preExisting );
+
+			const first = getWpCompatOverlaySlot();
+			const second = getWpCompatOverlaySlot();
+
+			expect( first ).toBe( preExisting );
+			expect( second ).toBe( preExisting );
+			expect( findSlots() ).toHaveLength( 1 );
+		} );
+	} );
+
+	describe( 'document.body unavailable', () => {
+		beforeEach( () => {
+			internalWindow.__wpUiCompatOverlaySlotEnabled = true;
+		} );
+
+		it( 'returns null without throwing when document.body is missing', () => {
+			const realBody = document.body;
+			const bodyDescriptor = Object.getOwnPropertyDescriptor(
+				Document.prototype,
+				'body'
+			);
+
+			Object.defineProperty( document, 'body', {
+				configurable: true,
+				get: () => null,
+			} );
+
+			try {
+				expect( () => getWpCompatOverlaySlot() ).not.toThrow();
+				expect( getWpCompatOverlaySlot() ).toBeNull();
+			} finally {
+				if ( bodyDescriptor ) {
+					Object.defineProperty( document, 'body', bodyDescriptor );
+				} else {
+					// jsdom typically defines `body` on Document.prototype; if
+					// it isn't present, fall back to deleting the override so
+					// `document.body` resolves to the live element again.
+					delete ( document as unknown as { body: unknown } ).body;
+				}
+				expect( document.body ).toBe( realBody );
+			}
+		} );
+	} );
+
+	describe( 'DOM identification', () => {
+		beforeEach( () => {
+			internalWindow.__wpUiCompatOverlaySlotEnabled = true;
+		} );
+
+		it( 'tags the element with the data-wp-compat-overlay-slot attribute (no value)', () => {
+			const slot = getWpCompatOverlaySlot();
+
+			expect(
+				slot?.getAttribute( WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE )
+			).toBe( '' );
+		} );
+
+		it( 'is discoverable via [data-wp-compat-overlay-slot] selector', () => {
+			const slot = getWpCompatOverlaySlot();
+
+			expect(
+				document.querySelector(
+					`[${ WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE }]`
+				)
+			).toBe( slot );
+		} );
+
+		it( 'appends the slot to the local document body', () => {
+			const slot = getWpCompatOverlaySlot();
+
+			expect( slot?.ownerDocument ).toBe( document );
+			expect( slot?.parentElement ).toBe( document.body );
+		} );
+	} );
+} );

--- a/packages/ui/src/utils/use-enable-wp-compat-overlay-slot.ts
+++ b/packages/ui/src/utils/use-enable-wp-compat-overlay-slot.ts
@@ -22,11 +22,14 @@
  * the same component.
  *
  * Timing: the opt-in is applied during the calling component's render so
- * that descendants in the same render pass — Tooltip's `Portal`, etc. —
- * synchronously read it through `getWpCompatOverlaySlot()` and pick up
- * the slot on first mount. The set is a single boolean assignment to a
- * cross-instance shared store; it is idempotent and safe to repeat,
- * including under React.StrictMode's double-render.
+ * that descendants of the hook caller in the same render pass — Tooltip's
+ * `Portal`, etc. — read it through `getWpCompatOverlaySlot()` and pick up
+ * the slot on first mount. Siblings rendered *before* the hook caller in
+ * the same pass won't see the flag until their next render — call the
+ * hook from a top-level component so every consumer is a descendant. The
+ * set is a single boolean assignment to a cross-instance shared store; it
+ * is idempotent and safe to repeat, including under React.StrictMode's
+ * double-render.
  */
 export function useEnableWpCompatOverlaySlot(): void {
 	if ( typeof window === 'undefined' ) {
@@ -43,10 +46,14 @@ export function useEnableWpCompatOverlaySlot(): void {
 	// time descendants that resolve the gate during render (Tooltip's
 	// `Portal` reads `getWpCompatOverlaySlot()` on every render to pick
 	// its container) have already seen the slot disabled and rendered
-	// against Base UI's default container. A pure idempotent boolean
-	// write is the kind of side effect render is allowed to emit:
-	// repeated calls (re-renders, StrictMode double-renders, multiple
-	// hook callers) all collapse to the same final state.
+	// against Base UI's default container. Render-phase visibility
+	// extends only to components rendered *after* this hook in the same
+	// pass — i.e. descendants of the caller. The "call from a top-level
+	// component" guidance in the JSDoc keeps that invariant trivially
+	// satisfied. A pure idempotent boolean write is the kind of side
+	// effect render is allowed to emit: repeated calls (re-renders,
+	// StrictMode double-renders, multiple hook callers) all collapse to
+	// the same final state.
 	const internalWindow = window as {
 		__wpUiCompatOverlaySlotEnabled?: boolean;
 	};

--- a/packages/ui/src/utils/use-enable-wp-compat-overlay-slot.ts
+++ b/packages/ui/src/utils/use-enable-wp-compat-overlay-slot.ts
@@ -46,7 +46,7 @@ export function useEnableWpCompatOverlaySlot(): void {
 	// time descendants that resolve the gate during render (Tooltip's
 	// `Portal` reads `getWpCompatOverlaySlot()` on every render to pick
 	// its container) have already seen the slot disabled and rendered
-	// against Base UI's default container. Render-phase visibility
+	// against the default portal container. Render-phase visibility
 	// extends only to components rendered *after* this hook in the same
 	// pass — i.e. descendants of the caller. The "call from a top-level
 	// component" guidance in the JSDoc keeps that invariant trivially

--- a/packages/ui/src/utils/use-enable-wp-compat-overlay-slot.ts
+++ b/packages/ui/src/utils/use-enable-wp-compat-overlay-slot.ts
@@ -1,0 +1,56 @@
+/**
+ * Opts the host application into the `@wordpress/ui` compat overlay slot —
+ * a body-level positioned container into which `@wordpress/ui` overlays
+ * portal so they reliably stack above `@wordpress/components` overlays in
+ * mixed-library compositions.
+ *
+ * Call once from a component that mounts for the lifetime of the app
+ * (typically the root). The opt-in is intentionally one-way: the slot is
+ * shared infrastructure across every `@wordpress/ui` consumer in the same
+ * document, and a single component shouldn't be able to turn it off for
+ * everyone else. If the slot isn't wanted, simply don't call this hook.
+ *
+ * Anywhere `window.wp.components` is exposed on the global — the typical
+ * setup for plugins enqueueing `wp-components` through WordPress's
+ * script-loader — the slot auto-enables, so calling this hook is a no-op
+ * (and unnecessary). The hook exists for hosts that bundle
+ * `@wordpress/components` (or only `@wordpress/ui`) directly into their
+ * app rather than relying on the global — apps that aren't built with
+ * standard WordPress build tooling.
+ *
+ * Idempotent: safe to call from multiple components or multiple times in
+ * the same component.
+ *
+ * Timing: the opt-in is applied during the calling component's render so
+ * that descendants in the same render pass — Tooltip's `Portal`, etc. —
+ * synchronously read it through `getWpCompatOverlaySlot()` and pick up
+ * the slot on first mount. The set is a single boolean assignment to a
+ * cross-instance shared store; it is idempotent and safe to repeat,
+ * including under React.StrictMode's double-render.
+ */
+export function useEnableWpCompatOverlaySlot(): void {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	// The window flag is the cross-`@wordpress/ui`-instance shared store
+	// the helper reads. It is intentionally undeclared on the global
+	// `Window` interface — the hook is the public API; any direct access
+	// is internal and stays behind a local cast.
+	//
+	// The set is performed during render, not in a `useLayoutEffect`,
+	// because effects fire *after* the initial render commits — by which
+	// time descendants that resolve the gate during render (Tooltip's
+	// `Portal` reads `getWpCompatOverlaySlot()` on every render to pick
+	// its container) have already seen the slot disabled and rendered
+	// against Base UI's default container. A pure idempotent boolean
+	// write is the kind of side effect render is allowed to emit:
+	// repeated calls (re-renders, StrictMode double-renders, multiple
+	// hook callers) all collapse to the same final state.
+	const internalWindow = window as {
+		__wpUiCompatOverlaySlotEnabled?: boolean;
+	};
+	if ( internalWindow.__wpUiCompatOverlaySlotEnabled !== true ) {
+		internalWindow.__wpUiCompatOverlaySlotEnabled = true;
+	}
+}

--- a/packages/ui/src/utils/use-enable-wp-compat-overlay-slot.ts
+++ b/packages/ui/src/utils/use-enable-wp-compat-overlay-slot.ts
@@ -10,50 +10,28 @@
  * document, and a single component shouldn't be able to turn it off for
  * everyone else. If the slot isn't wanted, simply don't call this hook.
  *
- * Anywhere `window.wp.components` is exposed on the global — the typical
- * setup for plugins enqueueing `wp-components` through WordPress's
- * script-loader — the slot auto-enables, so calling this hook is a no-op
- * (and unnecessary). The hook exists for hosts that bundle
- * `@wordpress/components` (or only `@wordpress/ui`) directly into their
- * app rather than relying on the global — apps that aren't built with
- * standard WordPress build tooling.
+ * Anywhere `window.wp.components` is on the global — the typical setup
+ * for plugins enqueueing `wp-components` through WordPress's script-
+ * loader — the slot auto-enables and this hook is a no-op. The hook
+ * exists for apps that aren't built with standard WordPress build
+ * tooling.
  *
- * Idempotent: safe to call from multiple components or multiple times in
- * the same component.
- *
- * Timing: the opt-in is applied during the calling component's render so
- * that descendants of the hook caller in the same render pass — Tooltip's
- * `Portal`, etc. — read it through `getWpCompatOverlaySlot()` and pick up
- * the slot on first mount. Siblings rendered *before* the hook caller in
- * the same pass won't see the flag until their next render — call the
- * hook from a top-level component so every consumer is a descendant. The
- * set is a single boolean assignment to a cross-instance shared store; it
- * is idempotent and safe to repeat, including under React.StrictMode's
- * double-render.
+ * Idempotent and safe to call from multiple components.
  */
 export function useEnableWpCompatOverlaySlot(): void {
 	if ( typeof window === 'undefined' ) {
 		return;
 	}
 
-	// The window flag is the cross-`@wordpress/ui`-instance shared store
-	// the helper reads. It is intentionally undeclared on the global
-	// `Window` interface — the hook is the public API; any direct access
-	// is internal and stays behind a local cast.
-	//
-	// The set is performed during render, not in a `useLayoutEffect`,
-	// because effects fire *after* the initial render commits — by which
-	// time descendants that resolve the gate during render (Tooltip's
-	// `Portal` reads `getWpCompatOverlaySlot()` on every render to pick
-	// its container) have already seen the slot disabled and rendered
-	// against the default portal container. Render-phase visibility
-	// extends only to components rendered *after* this hook in the same
-	// pass — i.e. descendants of the caller. The "call from a top-level
-	// component" guidance in the JSDoc keeps that invariant trivially
-	// satisfied. A pure idempotent boolean write is the kind of side
-	// effect render is allowed to emit: repeated calls (re-renders,
-	// StrictMode double-renders, multiple hook callers) all collapse to
-	// the same final state.
+	// The opt-in is applied during render (not in `useLayoutEffect`) so
+	// descendants in the same render pass — e.g. `Tooltip.Portal`, which
+	// reads `getWpCompatOverlaySlot()` on every render — see the gate
+	// open on first mount. Render-phase visibility extends only to
+	// components rendered *after* this hook in the same pass; calling
+	// from a top-level component keeps that invariant trivially
+	// satisfied. An idempotent boolean write is the kind of side effect
+	// render is allowed to emit: re-renders, StrictMode double-renders,
+	// and multiple hook callers all collapse to the same final state.
 	const internalWindow = window as {
 		__wpUiCompatOverlaySlotEnabled?: boolean;
 	};

--- a/packages/ui/src/utils/wp-compat-overlay-slot.ts
+++ b/packages/ui/src/utils/wp-compat-overlay-slot.ts
@@ -114,6 +114,15 @@ function isInWordPressEnvironment(): boolean {
  */
 let cachedSlot: HTMLDivElement | null = null;
 
+/**
+ * Creates the slot element, tags it with the cross-instance singleton
+ * attribute, applies the co-located CSS-module class, and appends it to
+ * the given document's body. Callers are expected to have already
+ * verified that the opt-in gate is open and that `ownerDocument.body`
+ * exists; this helper performs no validation of its own.
+ *
+ * @param ownerDocument The document that should own and host the slot.
+ */
 function createSlot( ownerDocument: Document ): HTMLDivElement {
 	const element = ownerDocument.createElement( 'div' );
 	element.setAttribute( WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE, '' );

--- a/packages/ui/src/utils/wp-compat-overlay-slot.ts
+++ b/packages/ui/src/utils/wp-compat-overlay-slot.ts
@@ -1,12 +1,9 @@
 import styles from './css/wp-compat-overlay-slot.module.css';
 
 /**
- * Minimal shape of the WordPress runtime global, applied as a local cast
- * inside `isInWordPressEnvironment()` so the auto-detect heuristic
- * (`typeof wp.components === 'object'`) type-checks without leaking a
- * `Window.wp` augmentation into downstream TS consumers via this package's
- * published `.d.ts`. The real `wp.components` namespace is far richer; we
- * only care whether it exists.
+ * Minimal shape of the WordPress runtime global. Local cast so the auto-
+ * detect heuristic type-checks without leaking a `Window.wp` augmentation
+ * into downstream TS consumers via this package's published `.d.ts`.
  */
 type WpEnvironmentWindow = {
 	wp?: {
@@ -15,56 +12,31 @@ type WpEnvironmentWindow = {
 };
 
 /**
- * Internal cross-`@wordpress/ui`-instance shared store for the explicit
- * opt-in. Set by `useEnableWpCompatOverlaySlot()`; read here. Deliberately
- * not declared on the global `Window` interface so consumers don't see it
- * as part of the public API surface — direct access is for in-package
- * callers only and stays behind a local cast.
+ * Cross-`@wordpress/ui`-instance shared store for the explicit opt-in.
+ * Set by `useEnableWpCompatOverlaySlot()`; read here. Intentionally not
+ * declared on the global `Window` interface — direct access is in-package
+ * only and stays behind a local cast.
  */
 type CompatOverlaySlotInternalWindow = {
 	__wpUiCompatOverlaySlotEnabled?: boolean;
 };
 
 /**
- * Attribute that identifies the compat overlay slot DOM element. Used as the
- * architectural marker for cross-tooling discovery and, crucially, for
- * cross-`@wordpress/ui`-instance singleton coordination (see
- * `getWpCompatOverlaySlot()`); styling is delivered via the CSS-module class
- * on the same element.
- *
- * Exported for tests and other in-package callers; not re-exported from the
- * package entry point.
+ * Identifies the compat overlay slot DOM element. Used as the cross-
+ * `@wordpress/ui`-instance singleton marker (see `getWpCompatOverlaySlot()`);
+ * styling is delivered via the CSS-module class on the same element.
  */
 export const WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE = 'data-wp-compat-overlay-slot';
 
 /**
  * Resolves the document that should own the slot — always the local
  * document, i.e., the one the JS realm calling this helper sees as
- * `globalThis.document`.
- *
- * This rule pairs cleanly with the two iframe patterns we care about:
- *
- * - An iframe that is a React `createPortal` boundary, not a script
- *   boundary (e.g. Gutenberg's editor canvas, or any `StyleProvider`-style
- *   embed). Components rendered inside the iframe keep running in the
- *   parent's JS realm; only their DOM lands in the iframe document. So a
- *   `@wordpress/ui` overlay inside that iframe calls this helper from the
- *   parent's realm, gets the parent's document, and its popup portals out
- *   to the parent's body — naturally escaping the iframe and stacking
- *   above any parent-document overlays. No cross-frame traversal needed.
- * - True script-boundary iframes (Storybook's preview iframe, embedded
- *   standalone apps, etc.) load their own bundle and run their own JS
- *   realm. The helper resolves to that iframe's document, the slot lives
- *   alongside the bundle that created it, and the bundle's CSS modules
- *   apply to the slot's classname.
- *
- * Why local-only and not `window.top?.document`: traversing up to the top
- * window would put the slot in a document where this bundle's CSS modules
- * aren't loaded (Storybook's preview iframe is the canonical example), so
- * the slot's classname would have nothing to match. "Is this a WordPress
- * environment?" (auto-detect) and "which document should host the slot?"
- * (frame placement) are orthogonal questions; the helper answers the
- * second by always using the local realm's document.
+ * `globalThis.document`. Not `window.top?.document`, which would put the
+ * slot in a document where this bundle's CSS modules aren't loaded
+ * (Storybook's preview iframe being the canonical example). "Is this a
+ * WordPress environment?" (auto-detect) and "which document hosts the
+ * slot?" (placement) are orthogonal; the helper always answers the
+ * second with the local realm.
  */
 function resolveOwnerDocument(): Document | null {
 	if ( typeof document === 'undefined' ) {
@@ -75,19 +47,12 @@ function resolveOwnerDocument(): Document | null {
 
 /**
  * Detects whether the runtime is a WordPress-flavored environment by
- * checking for `window.wp.components`. In WordPress (admin, plugins
- * enqueueing `wp-components`, etc.) the `@wordpress/components` package is
- * exposed as a global object, which the script-loader system sets up before
- * any consumer of `@wordpress/ui` runs. This is the dominant case — it lets
- * the slot auto-enable without any developer intervention.
- *
- * Tries the top window first so an iframe (e.g., the editor canvas) inherits
- * the parent's WP environment when its own window doesn't have `wp` set up.
- * Falls back to the local window. The `typeof === 'object'` check is
- * deliberately stricter than `!== undefined` so a stray `window.wp` global
- * with a non-object `components` (e.g., a string) doesn't trigger
- * auto-enable. `null` is rejected by the explicit null comparison because
- * `typeof null === 'object'`.
+ * checking for `window.wp.components`. Tries the top window first so an
+ * iframe (e.g., the editor canvas) inherits the parent's WP environment;
+ * falls back to the local window. The `typeof === 'object'` check is
+ * deliberately stricter than `!== undefined` so a stray non-object
+ * `components` doesn't trigger auto-enable, and the explicit null
+ * comparison covers `typeof null === 'object'`.
  */
 function isInWordPressEnvironment(): boolean {
 	let topWp: WpEnvironmentWindow[ 'wp' ];
@@ -101,15 +66,11 @@ function isInWordPressEnvironment(): boolean {
 }
 
 /**
- * Cached reference to the slot. Revalidated on each call against the current
- * owner document and the slot's connection state, so a stale reference from
- * a previous owner document (e.g. test cleanup tearing down jsdom, or a
- * runtime-detected switch between cross-frame and local-doc placement) or
- * an externally-detached element doesn't get returned. A missed cache falls
- * through to a DOM query for an existing slot in the document before
- * creating a new one — that handles the case of multiple `@wordpress/ui`
- * package instances loaded on the same page (each with its own module-level
- * cache), letting them share a single DOM-level singleton via the
+ * Module-level cache. Revalidated on each call against the current owner
+ * document and the slot's connection state. On miss, the helper falls
+ * back to a DOM query for an existing slot before creating one — that's
+ * what coordinates multiple `@wordpress/ui` package instances loaded on
+ * the same page around a single DOM-level singleton via the
  * `[data-wp-compat-overlay-slot]` attribute.
  */
 let cachedSlot: HTMLDivElement | null = null;
@@ -117,9 +78,8 @@ let cachedSlot: HTMLDivElement | null = null;
 /**
  * Creates the slot element, tags it with the cross-instance singleton
  * attribute, applies the co-located CSS-module class, and appends it to
- * the given document's body. Callers are expected to have already
- * verified that the opt-in gate is open and that `ownerDocument.body`
- * exists; this helper performs no validation of its own.
+ * the given document's body. Callers must have already verified the gate
+ * is open and `ownerDocument.body` exists.
  *
  * @param ownerDocument The document that should own and host the slot.
  */
@@ -134,53 +94,27 @@ function createSlot( ownerDocument: Document ): HTMLDivElement {
 }
 
 /**
- * Returns the body-level compat overlay slot element when the runtime opts
- * in, lazily creating it on first call. Returns `null` otherwise, leaving
- * the underlying overlay primitives' default portal container in effect.
+ * Returns the body-level compat overlay slot element when the runtime
+ * opts in, lazily creating it on first call. Returns `null` otherwise,
+ * leaving the underlying overlay primitives' default portal container
+ * in effect.
  *
  * Two opt-in paths:
- * - Auto-enabled by detecting `window.wp.components` on the global. This
- *   is the dominant case for plugins and admin screens that get
- *   `wp-components` enqueued through WordPress's script-loader, and it
- *   requires no developer intervention.
- * - Explicitly enabled by calling `useEnableWpCompatOverlaySlot()` from a
- *   top-level component — the public API for hosts that bundle
- *   `@wordpress/components` (or only `@wordpress/ui`) directly rather
- *   than relying on the global, e.g. standalone apps built on Vite,
- *   Next, etc.
  *
- * The slot is a single `<div data-wp-compat-overlay-slot>` appended to a
- * document body, with special styles (see the co-located CSS module for
- * details and reasoning). It exists so that `@wordpress/ui` overlays
- * reliably stack above `@wordpress/components` overlays in mixed-library
- * compositions without per-instance plumbing.
+ * - Auto-detected when `window.wp.components` is on the global — the
+ *   typical script-loader setup for WordPress plugins and admin
+ *   screens. Zero developer intervention required.
+ * - Explicit, via `useEnableWpCompatOverlaySlot()` from a top-level
+ *   component — for hosts that bundle `@wordpress/components` (or only
+ *   `@wordpress/ui`) directly rather than relying on the global.
  *
- * Document placement: the slot lives in the document the helper is
- * called from — see `resolveOwnerDocument` for why a single, predictable
- * rule covers both Gutenberg's editor canvas iframe (which is a React
- * portal boundary, not a script boundary) and true script-boundary
- * iframes like Storybook's preview.
- *
- * Subsequent calls return the same element. If the element has been removed
- * from the DOM (e.g. by an unrelated script or a test teardown) it is
- * recreated transparently on the next call. If a different `@wordpress/ui`
- * package instance has already created a slot in the same document (e.g. on
- * a page that bundles multiple copies), this call adopts the existing
- * element rather than appending a duplicate — the
- * `[data-wp-compat-overlay-slot]` attribute is the cross-instance
- * coordination marker.
- *
- * A plain function — rather than a React hook — is appropriate here because
- * this is the consumer-side read API for `@wordpress/ui` overlays:
- * - The gating signals (auto-detect, internal opt-in flag) don't change at
- *   runtime, so there's no React state to subscribe to.
- * - The slot creation is synchronous DOM manipulation
- *   (`document.body.appendChild`), so no `useLayoutEffect` timing is needed.
- * - The same function shape works in any context (render or non-render).
- *
- * The opt-in side is a hook (`useEnableWpCompatOverlaySlot`) because writing
- * to global state from a render path is the kind of side effect that wants
- * effect-phase scheduling.
+ * The slot is a single `<div data-wp-compat-overlay-slot>` appended to
+ * the local document's body (see `resolveOwnerDocument`) with styles
+ * pinned via the co-located CSS module. Subsequent calls return the
+ * same element; if it's been removed from the DOM it's recreated, and
+ * if a different `@wordpress/ui` instance already created a slot in
+ * the same document this call adopts it rather than appending a
+ * duplicate.
  */
 export function getWpCompatOverlaySlot(): HTMLDivElement | null {
 	if ( typeof window === 'undefined' ) {
@@ -196,11 +130,9 @@ export function getWpCompatOverlaySlot(): HTMLDivElement | null {
 	}
 
 	const ownerDocument = resolveOwnerDocument();
-	// `document.body` can be null if the helper is called before `<body>` has
-	// been parsed (e.g. from a `<script>` placed in `<head>` ahead of body).
-	// Bail in that case rather than throwing in `createSlot`'s `appendChild`;
-	// callers fall through to the default portal container, which is the
-	// same no-op behavior as when neither gate fires.
+	// `document.body` can be null if the helper runs before `<body>` is
+	// parsed (e.g. a `<script>` in `<head>`). Bail rather than throw in
+	// `createSlot`; callers fall through to the default portal container.
 	if ( ! ownerDocument || ! ownerDocument.body ) {
 		return null;
 	}
@@ -213,10 +145,9 @@ export function getWpCompatOverlaySlot(): HTMLDivElement | null {
 		return cachedSlot;
 	}
 
-	// Look for a slot already in the document before creating a new one. This
-	// handles the multiple-package-instances case: each instance has its own
-	// module-level `cachedSlot`, but the DOM is the shared source of truth.
-	// The attribute is the cross-instance singleton marker.
+	// DOM-level singleton: prefer an existing slot in the document over
+	// creating a duplicate. Coordinates multiple `@wordpress/ui` package
+	// instances around one slot via the attribute marker.
 	const existing = ownerDocument.querySelector< HTMLDivElement >(
 		`[${ WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE }]`
 	);
@@ -225,11 +156,8 @@ export function getWpCompatOverlaySlot(): HTMLDivElement | null {
 		return existing;
 	}
 
-	// If the cached slot still belongs to a (different) document that owns
-	// it, detach it before replacing the cache so we don't leave an orphaned
-	// slot in a document we no longer manage. Slots that are already
-	// disconnected (e.g. removed by a test or by external code in the same
-	// document) need no cleanup here.
+	// Detach any cached slot still attached to a foreign document, so we
+	// don't orphan a slot in a document we no longer manage.
 	if ( cachedSlot?.isConnected ) {
 		cachedSlot.remove();
 	}
@@ -239,8 +167,8 @@ export function getWpCompatOverlaySlot(): HTMLDivElement | null {
 }
 
 /**
- * Test-only escape hatch that drops the cached singleton so a fresh element
- * is created on the next `getWpCompatOverlaySlot()` call.
+ * Test-only escape hatch that drops the cached singleton so a fresh
+ * element is created on the next `getWpCompatOverlaySlot()` call.
  */
 export function __resetWpCompatOverlaySlotCacheForTests(): void {
 	cachedSlot = null;

--- a/packages/ui/src/utils/wp-compat-overlay-slot.ts
+++ b/packages/ui/src/utils/wp-compat-overlay-slot.ts
@@ -136,7 +136,7 @@ function createSlot( ownerDocument: Document ): HTMLDivElement {
 /**
  * Returns the body-level compat overlay slot element when the runtime opts
  * in, lazily creating it on first call. Returns `null` otherwise, leaving
- * Base UI's default portal container in effect.
+ * the underlying overlay primitives' default portal container in effect.
  *
  * Two opt-in paths:
  * - Auto-enabled by detecting `window.wp.components` on the global. This
@@ -199,8 +199,8 @@ export function getWpCompatOverlaySlot(): HTMLDivElement | null {
 	// `document.body` can be null if the helper is called before `<body>` has
 	// been parsed (e.g. from a `<script>` placed in `<head>` ahead of body).
 	// Bail in that case rather than throwing in `createSlot`'s `appendChild`;
-	// callers fall through to Base UI's default container, which is the same
-	// no-op behavior as when neither gate fires.
+	// callers fall through to the default portal container, which is the
+	// same no-op behavior as when neither gate fires.
 	if ( ! ownerDocument || ! ownerDocument.body ) {
 		return null;
 	}

--- a/packages/ui/src/utils/wp-compat-overlay-slot.ts
+++ b/packages/ui/src/utils/wp-compat-overlay-slot.ts
@@ -1,0 +1,238 @@
+import styles from './css/wp-compat-overlay-slot.module.css';
+
+/**
+ * Minimal shape of the WordPress runtime global, applied as a local cast
+ * inside `isInWordPressEnvironment()` so the auto-detect heuristic
+ * (`typeof wp.components === 'object'`) type-checks without leaking a
+ * `Window.wp` augmentation into downstream TS consumers via this package's
+ * published `.d.ts`. The real `wp.components` namespace is far richer; we
+ * only care whether it exists.
+ */
+type WpEnvironmentWindow = {
+	wp?: {
+		components?: unknown;
+	};
+};
+
+/**
+ * Internal cross-`@wordpress/ui`-instance shared store for the explicit
+ * opt-in. Set by `useEnableWpCompatOverlaySlot()`; read here. Deliberately
+ * not declared on the global `Window` interface so consumers don't see it
+ * as part of the public API surface — direct access is for in-package
+ * callers only and stays behind a local cast.
+ */
+type CompatOverlaySlotInternalWindow = {
+	__wpUiCompatOverlaySlotEnabled?: boolean;
+};
+
+/**
+ * Attribute that identifies the compat overlay slot DOM element. Used as the
+ * architectural marker for cross-tooling discovery and, crucially, for
+ * cross-`@wordpress/ui`-instance singleton coordination (see
+ * `getWpCompatOverlaySlot()`); styling is delivered via the CSS-module class
+ * on the same element.
+ *
+ * Exported for tests and other in-package callers; not re-exported from the
+ * package entry point.
+ */
+export const WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE = 'data-wp-compat-overlay-slot';
+
+/**
+ * Resolves the document that should own the slot — always the local
+ * document, i.e., the one the JS realm calling this helper sees as
+ * `globalThis.document`.
+ *
+ * This rule pairs cleanly with the two iframe patterns we care about:
+ *
+ * - An iframe that is a React `createPortal` boundary, not a script
+ *   boundary (e.g. Gutenberg's editor canvas, or any `StyleProvider`-style
+ *   embed). Components rendered inside the iframe keep running in the
+ *   parent's JS realm; only their DOM lands in the iframe document. So a
+ *   `@wordpress/ui` overlay inside that iframe calls this helper from the
+ *   parent's realm, gets the parent's document, and its popup portals out
+ *   to the parent's body — naturally escaping the iframe and stacking
+ *   above any parent-document overlays. No cross-frame traversal needed.
+ * - True script-boundary iframes (Storybook's preview iframe, embedded
+ *   standalone apps, etc.) load their own bundle and run their own JS
+ *   realm. The helper resolves to that iframe's document, the slot lives
+ *   alongside the bundle that created it, and the bundle's CSS modules
+ *   apply to the slot's classname.
+ *
+ * Why local-only and not `window.top?.document`: traversing up to the top
+ * window would put the slot in a document where this bundle's CSS modules
+ * aren't loaded (Storybook's preview iframe is the canonical example), so
+ * the slot's classname would have nothing to match. "Is this a WordPress
+ * environment?" (auto-detect) and "which document should host the slot?"
+ * (frame placement) are orthogonal questions; the helper answers the
+ * second by always using the local realm's document.
+ */
+function resolveOwnerDocument(): Document | null {
+	if ( typeof document === 'undefined' ) {
+		return null;
+	}
+	return document;
+}
+
+/**
+ * Detects whether the runtime is a WordPress-flavored environment by
+ * checking for `window.wp.components`. In WordPress (admin, plugins
+ * enqueueing `wp-components`, etc.) the `@wordpress/components` package is
+ * exposed as a global object, which the script-loader system sets up before
+ * any consumer of `@wordpress/ui` runs. This is the dominant case — it lets
+ * the slot auto-enable without any developer intervention.
+ *
+ * Tries the top window first so an iframe (e.g., the editor canvas) inherits
+ * the parent's WP environment when its own window doesn't have `wp` set up.
+ * Falls back to the local window. The `typeof === 'object'` check is
+ * deliberately stricter than `!== undefined` so a stray `window.wp` global
+ * with a non-object `components` (e.g., a string) doesn't trigger
+ * auto-enable. `null` is rejected by the explicit null comparison because
+ * `typeof null === 'object'`.
+ */
+function isInWordPressEnvironment(): boolean {
+	let topWp: WpEnvironmentWindow[ 'wp' ];
+	try {
+		topWp = ( window.top as WpEnvironmentWindow | undefined )?.wp;
+	} catch {
+		// Cross-origin top window — fall through to the local window.
+	}
+	const wp = topWp ?? ( window as WpEnvironmentWindow ).wp;
+	return typeof wp?.components === 'object' && wp.components !== null;
+}
+
+/**
+ * Cached reference to the slot. Revalidated on each call against the current
+ * owner document and the slot's connection state, so a stale reference from
+ * a previous owner document (e.g. test cleanup tearing down jsdom, or a
+ * runtime-detected switch between cross-frame and local-doc placement) or
+ * an externally-detached element doesn't get returned. A missed cache falls
+ * through to a DOM query for an existing slot in the document before
+ * creating a new one — that handles the case of multiple `@wordpress/ui`
+ * package instances loaded on the same page (each with its own module-level
+ * cache), letting them share a single DOM-level singleton via the
+ * `[data-wp-compat-overlay-slot]` attribute.
+ */
+let cachedSlot: HTMLDivElement | null = null;
+
+function createSlot( ownerDocument: Document ): HTMLDivElement {
+	const element = ownerDocument.createElement( 'div' );
+	element.setAttribute( WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE, '' );
+	if ( styles.slot ) {
+		element.classList.add( styles.slot );
+	}
+	ownerDocument.body.appendChild( element );
+	return element;
+}
+
+/**
+ * Returns the body-level compat overlay slot element when the runtime opts
+ * in, lazily creating it on first call. Returns `null` otherwise, leaving
+ * Base UI's default portal container in effect.
+ *
+ * Two opt-in paths:
+ * - Auto-enabled by detecting `window.wp.components` on the global. This
+ *   is the dominant case for plugins and admin screens that get
+ *   `wp-components` enqueued through WordPress's script-loader, and it
+ *   requires no developer intervention.
+ * - Explicitly enabled by calling `useEnableWpCompatOverlaySlot()` from a
+ *   top-level component — the public API for hosts that bundle
+ *   `@wordpress/components` (or only `@wordpress/ui`) directly rather
+ *   than relying on the global, e.g. standalone apps built on Vite,
+ *   Next, etc.
+ *
+ * The slot is a single `<div data-wp-compat-overlay-slot>` appended to a
+ * document body, with special styles (see the co-located CSS module for
+ * details and reasoning). It exists so that `@wordpress/ui` overlays
+ * reliably stack above `@wordpress/components` overlays in mixed-library
+ * compositions without per-instance plumbing.
+ *
+ * Document placement: the slot lives in the document the helper is
+ * called from — see `resolveOwnerDocument` for why a single, predictable
+ * rule covers both Gutenberg's editor canvas iframe (which is a React
+ * portal boundary, not a script boundary) and true script-boundary
+ * iframes like Storybook's preview.
+ *
+ * Subsequent calls return the same element. If the element has been removed
+ * from the DOM (e.g. by an unrelated script or a test teardown) it is
+ * recreated transparently on the next call. If a different `@wordpress/ui`
+ * package instance has already created a slot in the same document (e.g. on
+ * a page that bundles multiple copies), this call adopts the existing
+ * element rather than appending a duplicate — the
+ * `[data-wp-compat-overlay-slot]` attribute is the cross-instance
+ * coordination marker.
+ *
+ * A plain function — rather than a React hook — is appropriate here because
+ * this is the consumer-side read API for `@wordpress/ui` overlays:
+ * - The gating signals (auto-detect, internal opt-in flag) don't change at
+ *   runtime, so there's no React state to subscribe to.
+ * - The slot creation is synchronous DOM manipulation
+ *   (`document.body.appendChild`), so no `useLayoutEffect` timing is needed.
+ * - The same function shape works in any context (render or non-render).
+ *
+ * The opt-in side is a hook (`useEnableWpCompatOverlaySlot`) because writing
+ * to global state from a render path is the kind of side effect that wants
+ * effect-phase scheduling.
+ */
+export function getWpCompatOverlaySlot(): HTMLDivElement | null {
+	if ( typeof window === 'undefined' ) {
+		return null;
+	}
+
+	if (
+		! isInWordPressEnvironment() &&
+		( window as CompatOverlaySlotInternalWindow )
+			.__wpUiCompatOverlaySlotEnabled !== true
+	) {
+		return null;
+	}
+
+	const ownerDocument = resolveOwnerDocument();
+	// `document.body` can be null if the helper is called before `<body>` has
+	// been parsed (e.g. from a `<script>` placed in `<head>` ahead of body).
+	// Bail in that case rather than throwing in `createSlot`'s `appendChild`;
+	// callers fall through to Base UI's default container, which is the same
+	// no-op behavior as when neither gate fires.
+	if ( ! ownerDocument || ! ownerDocument.body ) {
+		return null;
+	}
+
+	if (
+		cachedSlot &&
+		cachedSlot.ownerDocument === ownerDocument &&
+		cachedSlot.isConnected
+	) {
+		return cachedSlot;
+	}
+
+	// Look for a slot already in the document before creating a new one. This
+	// handles the multiple-package-instances case: each instance has its own
+	// module-level `cachedSlot`, but the DOM is the shared source of truth.
+	// The attribute is the cross-instance singleton marker.
+	const existing = ownerDocument.querySelector< HTMLDivElement >(
+		`[${ WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE }]`
+	);
+	if ( existing instanceof HTMLDivElement ) {
+		cachedSlot = existing;
+		return existing;
+	}
+
+	// If the cached slot still belongs to a (different) document that owns
+	// it, detach it before replacing the cache so we don't leave an orphaned
+	// slot in a document we no longer manage. Slots that are already
+	// disconnected (e.g. removed by a test or by external code in the same
+	// document) need no cleanup here.
+	if ( cachedSlot?.isConnected ) {
+		cachedSlot.remove();
+	}
+
+	cachedSlot = createSlot( ownerDocument );
+	return cachedSlot;
+}
+
+/**
+ * Test-only escape hatch that drops the cached singleton so a fresh element
+ * is created on the next `getWpCompatOverlaySlot()` call.
+ */
+export function __resetWpCompatOverlaySlotCacheForTests(): void {
+	cachedSlot = null;
+}


### PR DESCRIPTION
## What?

Adds a dormant body-level overlay slot to `@wordpress/ui`. Once a leaf overlay portals into it, that overlay stacks above `@wordpress/components` overlays in mixed-library compositions. No consumers in this PR.

## Why?

Reliable cross-library stacking, without per-instance plumbing on every `@wordpress/ui` overlay. The first leaf-overlay wiring (Tooltip) lands in #78095 and validates the slot end-to-end; this PR ships the infrastructure on its own so it can land independently.

## How?

Two opt-in paths, both lazy:

-   **Auto-detect** wherever `window.wp.components` is on the global — the typical script-loader setup for plugins and admin screens, so most consumers do nothing.
-   **`useEnableWpCompatOverlaySlot()`** hook for hosts that bundle `@wordpress/components` (or only `@wordpress/ui`) directly rather than relying on the global — apps that aren't built with standard WordPress build tooling.

When opted in, the helper lazy-creates a single `<div data-wp-compat-overlay-slot>` on `document.body` at z-index `1000000003`. Otherwise it returns `null` and the default portal container the overlay primitives ship with stays in effect.

<details>
<summary>Implementation notes</summary>

-   Co-located unlayered CSS module: `position: fixed; top: 0; left: 0; z-index: 1000000003; isolation: isolate`. Full reasoning lives in the file's header comment.
-   The hook writes its internal flag synchronously during render so descendants that resolve the gate during the same render pass (e.g. Tooltip's `Portal`, which calls the helper on every render) pick up the slot on first mount. The enable is one-way by design — a single component shouldn't be able to turn off shared infrastructure for everyone else.
-   The internal flag is undeclared on the global `Window` interface; the hook is the only documented opt-in surface.
-   The slot lives in the document the helper is called from (`document`), with no cross-frame traversal. This gives the right placement for both common iframe patterns: Gutenberg's editor canvas iframe is a `createPortal` boundary, not a script boundary, so `@wordpress/ui` components rendered inside the canvas keep running in the parent's JS realm and the slot lands in the parent body — escaping the iframe naturally. True script-boundary iframes (Storybook's preview, embedded standalone apps) load their own bundle, run their own JS realm, and get a slot in their own document, alongside the bundle's CSS modules.
-   Multiple `@wordpress/ui` package instances on the same page coordinate through the DOM via the `[data-wp-compat-overlay-slot]` attribute — one slot regardless of bundle count. Cache self-heals when the element is removed externally.
-   `document.body` is null-guarded.

</details>

## Testing Instructions

```sh
npx jest --config=test/unit/jest.config.js --testPathPattern='packages/ui/src/utils/test/(wp-compat-overlay-slot|use-enable-wp-compat-overlay-slot)'
```

Expected: 28 passing tests. The helper is dormant, so there's no user-facing surface to verify in this PR; end-to-end validation lands in #78095.

## Next steps

-   Wire `@wordpress/ui` overlays through the slot, starting with Tooltip (#78095) and continuing incrementally.
-   Address `.components-draggable__clone` so an active drag stays above the slot — likely by migrating it onto the slot rather than bumping its z-index.

## Use of AI Tools

Authored with Cursor (Claude). Author reviewed all changes.