### PR TITLE
Connectors: Stop e2e capability restriction from leaking across specs

### DIFF
--- a/packages/e2e-tests/plugins/connectors-capability-restriction.php
+++ b/packages/e2e-tests/plugins/connectors-capability-restriction.php
@@ -39,12 +39,8 @@ register_deactivation_hook(
 add_filter(
 	'map_meta_cap',
 	static function ( $caps, $cap ) {
-		// Skip the restriction during REST requests to the plugins endpoint.
-		// The Connectors page checks capabilities via PHP `current_user_can`,
-		// not via `/wp/v2/plugins`, so the test assertions remain valid. But
-		// the test runner uses that endpoint to activate/deactivate plugins,
-		// and a leaked restriction blocking `activate_plugins` would prevent
-		// cleanup, persisting the option and breaking unrelated specs.
+		// Always allow /wp/v2/plugins so the e2e cleanup can deactivate
+		// this plugin even when the restriction would otherwise block it.
 		if ( defined( 'REST_REQUEST' ) && REST_REQUEST && isset( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
 			$route = (string) $GLOBALS['wp']->query_vars['rest_route'];
 			if ( 0 === strpos( $route, '/wp/v2/plugins' ) ) {

--- a/packages/e2e-tests/plugins/connectors-capability-restriction.php
+++ b/packages/e2e-tests/plugins/connectors-capability-restriction.php
@@ -39,15 +39,6 @@ register_deactivation_hook(
 add_filter(
 	'map_meta_cap',
 	static function ( $caps, $cap ) {
-		// Always allow /wp/v2/plugins so the e2e cleanup can deactivate
-		// this plugin even when the restriction would otherwise block it.
-		if ( defined( 'REST_REQUEST' ) && REST_REQUEST && isset( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
-			$route = (string) $GLOBALS['wp']->query_vars['rest_route'];
-			if ( 0 === strpos( $route, '/wp/v2/plugins' ) ) {
-				return $caps;
-			}
-		}
-
 		$restriction = get_option( 'gutenberg_test_cap_restriction', '' );
 
 		if ( empty( $restriction ) ) {

--- a/packages/e2e-tests/plugins/connectors-capability-restriction.php
+++ b/packages/e2e-tests/plugins/connectors-capability-restriction.php
@@ -22,6 +22,13 @@ add_action(
 	}
 );
 
+register_activation_hook(
+	__FILE__,
+	static function () {
+		delete_option( 'gutenberg_test_cap_restriction' );
+	}
+);
+
 register_deactivation_hook(
 	__FILE__,
 	static function () {
@@ -32,6 +39,19 @@ register_deactivation_hook(
 add_filter(
 	'map_meta_cap',
 	static function ( $caps, $cap ) {
+		// Skip the restriction during REST requests to the plugins endpoint.
+		// The Connectors page checks capabilities via PHP `current_user_can`,
+		// not via `/wp/v2/plugins`, so the test assertions remain valid. But
+		// the test runner uses that endpoint to activate/deactivate plugins,
+		// and a leaked restriction blocking `activate_plugins` would prevent
+		// cleanup, persisting the option and breaking unrelated specs.
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST && isset( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
+			$route = (string) $GLOBALS['wp']->query_vars['rest_route'];
+			if ( 0 === strpos( $route, '/wp/v2/plugins' ) ) {
+				return $caps;
+			}
+		}
+
 		$restriction = get_option( 'gutenberg_test_cap_restriction', '' );
 
 		if ( empty( $restriction ) ) {

--- a/packages/e2e-tests/plugins/connectors-capability-restriction.php
+++ b/packages/e2e-tests/plugins/connectors-capability-restriction.php
@@ -36,6 +36,45 @@ register_deactivation_hook(
 	}
 );
 
+add_action(
+	'wp_connectors_init',
+	static function ( WP_Connector_Registry $registry ) {
+		$registry->register(
+			'test_install_required_connector',
+			array(
+				'name'           => 'Test Install Required Connector',
+				'description'    => 'A connector backed by a plugin that is not installed.',
+				'type'           => 'ai_provider',
+				'plugin'         => array(
+					'file'      => 'gutenberg-test-connectors-never-installed/plugin.php',
+					'is_active' => '__return_false',
+				),
+				'authentication' => array(
+					'method'       => 'api_key',
+					'setting_name' => 'gutenberg_test_install_required_connector_api_key',
+				),
+			)
+		);
+
+		$registry->register(
+			'test_activate_required_connector',
+			array(
+				'name'           => 'Test Activate Required Connector',
+				'description'    => 'A connector backed by an installed inactive plugin.',
+				'type'           => 'ai_provider',
+				'plugin'         => array(
+					'file'      => 'hello/hello.php',
+					'is_active' => '__return_false',
+				),
+				'authentication' => array(
+					'method'       => 'api_key',
+					'setting_name' => 'gutenberg_test_activate_required_connector_api_key',
+				),
+			)
+		);
+	}
+);
+
 add_filter(
 	'map_meta_cap',
 	static function ( $caps, $cap ) {

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -53,7 +53,7 @@ test.describe( 'Connectors', () => {
 		);
 	} );
 
-	test( 'should display default providers with install buttons', async ( {
+	test( 'should display default providers with setup buttons', async ( {
 		page,
 		admin,
 	} ) => {
@@ -66,7 +66,7 @@ test.describe( 'Connectors', () => {
 		} );
 		await expect( pageTitle ).toBeVisible();
 
-		// Verify each connector card shows name as heading, description, and Install button.
+		// Verify each connector card shows name as heading, description, and Set up button.
 		for ( const { slug, name, description } of CONNECTORS ) {
 			const card = page.locator( `.connector-item--${ slug }` );
 			await expect( card ).toBeVisible();
@@ -86,9 +86,9 @@ test.describe( 'Connectors', () => {
 				headingId
 			);
 
-			const button = card.getByRole( 'button', { name: 'Install' } );
+			const button = card.getByRole( 'button', { name: 'Set up' } );
 			await expect( button ).toBeVisible();
-			// Install button should not have aria-expanded.
+			// Set up button should not have aria-expanded until expanded.
 			await expect( button ).not.toHaveAttribute( 'aria-expanded' );
 		}
 
@@ -457,6 +457,16 @@ test.describe( 'Connectors', () => {
 
 	test.describe( 'Connectors page capability checks', () => {
 		const PLUGIN_SLUG = 'gutenberg-test-connectors-capability-restriction';
+		const installRequiredConnector = {
+			slug: 'gutenberg-test-connectors-never-installed',
+			name: 'Test Install Required Connector',
+			action: 'Install',
+		};
+		const activateRequiredConnector = {
+			slug: 'hello',
+			name: 'Test Activate Required Connector',
+			action: 'Activate',
+		};
 		const clearCapabilityRestriction = async ( requestUtils ) => {
 			await requestUtils.rest( {
 				path: '/wp/v2/settings',
@@ -491,7 +501,7 @@ test.describe( 'Connectors', () => {
 		];
 
 		capabilities.forEach( ( [ restriction, label ] ) => {
-			test( `should show "Not available" when ${ label }`, async ( {
+			test( `should show unavailable connector actions when ${ label }`, async ( {
 				page,
 				admin,
 				requestUtils,
@@ -509,23 +519,23 @@ test.describe( 'Connectors', () => {
 					CONNECTORS_PAGE_QUERY
 				);
 
-				// AI plugin callout banner should be hidden when user lacks permissions.
-				await expect(
-					page.locator( '.ai-plugin-callout' )
-				).toBeHidden();
-
-				for ( const { slug } of CONNECTORS ) {
+				for ( const { slug, name, action } of [
+					installRequiredConnector,
+					activateRequiredConnector,
+				] ) {
 					const card = page.locator( `.connector-item--${ slug }` );
 					await expect( card ).toBeVisible();
+					await expect(
+						card.getByRole( 'heading', { name, level: 2 } )
+					).toBeVisible();
 					await expect(
 						card.getByText( 'Not available' )
 					).toBeVisible();
 					await expect(
-						card.getByRole( 'button', { name: 'Install' } )
+						card.getByRole( 'button', { name: action } )
 					).toBeHidden();
 				}
 
-				// Plugin directory link should be hidden.
 				await expect(
 					page.getByRole( 'link', {
 						name: 'search the plugin directory',

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -457,12 +457,26 @@ test.describe( 'Connectors', () => {
 
 	test.describe( 'Connectors page capability checks', () => {
 		const PLUGIN_SLUG = 'gutenberg-test-connectors-capability-restriction';
+		const clearCapabilityRestriction = async ( requestUtils ) => {
+			await requestUtils.rest( {
+				path: '/wp/v2/settings',
+				method: 'POST',
+				data: {
+					gutenberg_test_cap_restriction: '',
+				},
+			} );
+		};
 
 		test.beforeAll( async ( { requestUtils } ) => {
 			await requestUtils.activatePlugin( PLUGIN_SLUG );
 		} );
 
+		test.afterEach( async ( { requestUtils } ) => {
+			await clearCapabilityRestriction( requestUtils );
+		} );
+
 		test.afterAll( async ( { requestUtils } ) => {
+			await clearCapabilityRestriction( requestUtils );
 			await requestUtils.deactivatePlugin( PLUGIN_SLUG );
 		} );
 


### PR DESCRIPTION
## What?

Fixes a leak in the e2e test plugin `packages/e2e-tests/plugins/connectors-capability-restriction.php` that has been breaking the `Playwright - 1` job on trunk continuously since 2026-04-30 ~12:18 UTC. Refs #75980 (the PR that introduced this test plugin).

## Why?

The plugin registers a `map_meta_cap` filter that blocks capabilities like `install_plugins`, `activate_plugins`, `delete_plugins`, etc., based on the value of the `gutenberg_test_cap_restriction` option.

When a test in `test/e2e/specs/admin/connectors.spec.js` sets a restriction that blocks plugin capabilities, the `afterAll` hook calling `requestUtils.deactivatePlugin()` can fail because the `/wp/v2/plugins` endpoint requires those same capabilities. If that happens, the plugin stays active, the option stays set, and subsequent specs that touch `requestUtils.activatePlugin/deactivatePlugin` can fail with `rest_cannot_view_plugins` (HTTP 403), even when they are unrelated to Connectors capability checks.

After removing that leak, the same Connectors spec also needed an expectation update: the built-in AI providers are now available for setup, so they render `Set up` rather than `Install`. Capability assertions now use dedicated test connectors with controlled plugin states instead of depending on the current state of built-in providers.

## How?

- Clear `gutenberg_test_cap_restriction` after each capability case and before deactivating the helper plugin, so cleanup cannot inherit the restricted capability state.
- Clear `gutenberg_test_cap_restriction` on helper plugin activation as a defensive reset for dirty prior runs.
- Add two controlled connector fixtures to the helper plugin: one backed by a never-installed plugin and one backed by an installed inactive plugin. The capability tests assert `Not available` against those fixtures.
- Update the default provider test to expect `Set up`, matching the current built-in provider state.

This keeps `/wp/v2/plugins` subject to the real capability restrictions during assertions while making cleanup deterministic.

## Testing

- `ReadLints` on the touched files: no errors.
- `git diff --check -- packages/e2e-tests/plugins/connectors-capability-restriction.php test/e2e/specs/admin/connectors.spec.js`: passes.
- `npm run test:e2e -- test/e2e/specs/admin/connectors.spec.js`: 18 passed.
- CI is re-running against commit `aaa88605e6b`.

## Refs

- #75980 — original PR that introduced the test plugin