### PR TITLE
Fix: Buttons block shows inserter picker when multiple allowed blocks are registered

### DIFF
--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -6,13 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	useBlockProps,
-	useInnerBlocksProps,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
-import { store as blocksStore } from '@wordpress/blocks';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
 const DEFAULT_BLOCK = {
 	name: 'core/button',
@@ -29,7 +23,7 @@ const DEFAULT_BLOCK = {
 	],
 };
 
-function ButtonsEdit( { attributes, className, clientId } ) {
+function ButtonsEdit( { attributes, className } ) {
 	const { fontSize, layout, style } = attributes;
 	const blockProps = useBlockProps( {
 		className: clsx( className, {
@@ -37,26 +31,8 @@ function ButtonsEdit( { attributes, className, clientId } ) {
 		} ),
 	} );
 
-	const { hasButtonVariations, hasMultipleAllowedBlocks } = useSelect(
-		( select ) => {
-			const buttonVariations = select( blocksStore ).getBlockVariations(
-				'core/button',
-				'inserter'
-			);
-			const allowedBlocks =
-				select( blockEditorStore ).getAllowedBlocks( clientId );
-			return {
-				hasButtonVariations: buttonVariations.length > 0,
-				hasMultipleAllowedBlocks:
-					allowedBlocks && allowedBlocks.length > 1,
-			};
-		},
-		[ clientId ]
-	);
-
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		defaultBlock: DEFAULT_BLOCK,
-		directInsert: ! hasButtonVariations && ! hasMultipleAllowedBlocks,
 		template: [ [ 'core/button' ] ],
 		templateInsertUpdatesSelection: true,
 		orientation: layout?.orientation ?? 'horizontal',

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -6,7 +6,11 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
 
@@ -25,27 +29,34 @@ const DEFAULT_BLOCK = {
 	],
 };
 
-function ButtonsEdit( { attributes, className } ) {
+function ButtonsEdit( { attributes, className, clientId } ) {
 	const { fontSize, layout, style } = attributes;
 	const blockProps = useBlockProps( {
 		className: clsx( className, {
 			'has-custom-font-size': fontSize || style?.typography?.fontSize,
 		} ),
 	} );
-	const { hasButtonVariations } = useSelect( ( select ) => {
-		const buttonVariations = select( blocksStore ).getBlockVariations(
-			'core/button',
-			'inserter'
-		);
-		return {
-			hasButtonVariations: buttonVariations.length > 0,
-		};
-	}, [] );
+
+	const { hasButtonVariations, hasMultipleAllowedBlocks } = useSelect(
+		( select ) => {
+			const buttonVariations = select( blocksStore ).getBlockVariations(
+				'core/button',
+				'inserter'
+			);
+			const allowedBlocks =
+				select( blockEditorStore ).getAllowedBlocks( clientId );
+			return {
+				hasButtonVariations: buttonVariations.length > 0,
+				hasMultipleAllowedBlocks:
+					allowedBlocks && allowedBlocks.length > 1,
+			};
+		},
+		[ clientId ]
+	);
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		defaultBlock: DEFAULT_BLOCK,
-		// This check should be handled by the `Inserter` internally to be consistent across all blocks that use it.
-		directInsert: ! hasButtonVariations,
+		directInsert: ! hasButtonVariations && ! hasMultipleAllowedBlocks,
 		template: [ [ 'core/button' ] ],
 		templateInsertUpdatesSelection: true,
 		orientation: layout?.orientation ?? 'horizontal',


### PR DESCRIPTION
## What

Fixes Buttons block not showing inserter picker when multiple allowed blocks are registered.

## Why

The current logic only checks for `core/button` variations and ignores multiple allowed block types, so it always inserts the default button.

## How

Update `directInsert` logic:

```
directInsert: !hasButtonVariations && !hasMultipleAllowedBlocks;
```

## Result

* Single block → direct insert (no change)
* Multiple blocks → shows inserter picker
<img width="1911" height="960" alt="image" src="https://github.com/user-attachments/assets/b7df4573-2055-4c44-a5d9-4cbeaa7c5fe3" />


## Testing

1. Add a custom button block
2. Allow it inside `core/buttons`
3. Click ➕ inside Buttons block

Picker should appear.

## Issue

Fixes #77839
