### PR TITLE
Media editor modal: disable scroll wheel zoom while a pan/drag is active

### DIFF
--- a/packages/media-editor/src/image-editor/core/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/interaction-controller.ts
@@ -361,6 +361,10 @@ export class InteractionController {
 	handleWheel( e: WheelEvent ): void {
 		e.preventDefault();
 
+		if ( this.drag ) {
+			return;
+		}
+
 		// Debounced gesture boundaries for wheel zoom.
 		// Start on first wheel event, end after 300ms of no events.
 		if ( ! this.wheelGestureActive ) {

--- a/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
@@ -465,6 +465,31 @@ describe( 'InteractionController', () => {
 			expect( setZoomCall![ 0 ] ).toBe( 4 );
 		} );
 
+		it( 'does not zoom while pointer pan is active', () => {
+			const state = makeState( { zoom: 2 } );
+			const { controller } = createController( state );
+			const el = createMockElement();
+
+			controller.handlePointerDown(
+				createPointerEvent( { clientX: 100, clientY: 100 } ),
+				el
+			);
+
+			jest.clearAllMocks();
+
+			const wheelEvent = createWheelEvent( {
+				deltaY: -100,
+				currentTarget: null,
+			} );
+			controller.handleWheel( wheelEvent );
+
+			expect( wheelEvent.preventDefault ).toHaveBeenCalled();
+			expect( actionMocks.setZoom ).not.toHaveBeenCalled();
+			expect( actionMocks.setZoomAtPoint ).not.toHaveBeenCalled();
+
+			el._fire( 'pointerup', createPointerEvent() );
+		} );
+
 		it( 'calls onGestureStart on first wheel, onGestureEnd after debounce', () => {
 			jest.useFakeTimers( {
 				doNotFake: [ 'requestAnimationFrame', 'cancelAnimationFrame' ],


### PR DESCRIPTION
## What?

Follow up to 

- https://github.com/WordPress/gutenberg/pull/77826

Part of:

* https://github.com/WordPress/gutenberg/issues/73771

Prevents wheel zooming in the media editor cropper while a pointer pan gesture is active.

Thanks @andrewserong for the suggestion.

## Why?

When using high-resolution scroll devices, wheel events can fire during pointer interactions. If that happens while panning the image, the cropper can zoom and pan at the same time, making the canvas feel unstable.

This follows the same interaction model as crop handle resizing: while one placement gesture is active, wheel zoom is ignored.

## Testing

You shouldn't be able to do this!


https://github.com/user-attachments/assets/1dc24473-dcea-4a8d-a1e5-53824a8f1faa

