### PR TITLE
RTC: fix table edit loss and associated revision loss when an old or externally-created post has no persisted CRDT document and contains duplicate table rows

### DIFF
--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -94,6 +94,7 @@ export function updateSelectedCell( state, selection, updateCell ) {
 					}
 
 					return {
+						...row,
 						cells: row.cells.map(
 							( cellAttributes, columnIndex ) => {
 								const cellLocation = {
@@ -248,6 +249,7 @@ export function insertColumn( state, { columnIndex } ) {
 					}
 
 					return {
+						...row,
 						cells: [
 							...row.cells.slice( 0, columnIndex ),
 							{
@@ -290,6 +292,7 @@ export function deleteColumn( state, { columnIndex } ) {
 				sectionName,
 				section
 					.map( ( row ) => ( {
+						...row,
 						cells:
 							row.cells.length >= columnIndex
 								? row.cells.filter(

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -81,6 +81,8 @@ interface MergeCrdtBlocksOptions {
  */
 export type MergeCursorPosition = WPBlockSelection | null;
 
+const ARRAY_ELEMENT_ID_KEY = '__unstableSyncId';
+const ARRAY_ELEMENT_ID_SYMBOL = Symbol( 'wpSyncArrayElementId' );
 const serializableBlocksCache = new WeakMap< WeakKey, Block[] >();
 
 /**
@@ -104,10 +106,20 @@ function serializeAttributeValue( value: unknown ): unknown {
 	// e.g. a single row inside core/table `body`: { cells: [ ... ] }
 	if ( value && typeof value === 'object' ) {
 		const result: Record< string, unknown > = {};
+		const arrayElementId = getArrayElementId( value );
 
 		for ( const [ k, v ] of Object.entries( value ) ) {
+			if ( k === ARRAY_ELEMENT_ID_KEY ) {
+				continue;
+			}
+
 			result[ k ] = serializeAttributeValue( v );
 		}
+
+		if ( arrayElementId ) {
+			result[ ARRAY_ELEMENT_ID_KEY ] = arrayElementId;
+		}
+
 		return result;
 	}
 
@@ -188,14 +200,23 @@ function deserializeAttributeValue(
 	// e.g. a single row inside core/table `body`: { cells: [ ... ] }
 	if ( value && typeof value === 'object' ) {
 		const result: Record< string, unknown > = {};
+		const arrayElementId = getArrayElementId( value );
 
 		for ( const [ key, innerValue ] of Object.entries(
 			value as Record< string, unknown >
 		) ) {
+			if ( key === ARRAY_ELEMENT_ID_KEY ) {
+				continue;
+			}
+
 			result[ key ] = deserializeAttributeValue(
 				schema?.query?.[ key ],
 				innerValue
 			);
+		}
+
+		if ( arrayElementId ) {
+			defineArrayElementId( result, arrayElementId );
 		}
 
 		return result;
@@ -270,7 +291,8 @@ function areBlocksEqual( gblock: Block, yblock: YBlock ): boolean {
 
 function createNewYAttributeMap(
 	blockName: string,
-	attributes: BlockAttributes
+	attributes: BlockAttributes,
+	blockPath?: string
 ): YBlockAttributes {
 	return new Y.Map(
 		Object.entries( attributes ).map(
@@ -280,7 +302,10 @@ function createNewYAttributeMap(
 					createNewYAttributeValue(
 						blockName,
 						attributeName,
-						attributeValue
+						attributeValue,
+						blockPath
+							? `${ blockPath }/attributes/${ attributeName }`
+							: undefined
 					),
 				];
 			}
@@ -291,10 +316,11 @@ function createNewYAttributeMap(
 function createNewYAttributeValue(
 	blockName: string,
 	attributeName: string,
-	attributeValue: unknown
+	attributeValue: unknown,
+	attributePath?: string
 ): Y.Text | Y.Array< unknown > | Y.Map< unknown > | unknown {
 	const schema = getBlockAttributeSchema( blockName, attributeName );
-	return createYValueFromSchema( schema, attributeValue );
+	return createYValueFromSchema( schema, attributeValue, attributePath );
 }
 
 /**
@@ -306,13 +332,15 @@ function createNewYAttributeValue(
  * - `object` with query  -> Y.Map
  * - anything else        -> plain value (unchanged)
  *
- * @param schema The attribute type definition.
- * @param value  The plain JS value to convert.
+ * @param schema           The attribute type definition.
+ * @param value            The plain JS value to convert.
+ * @param arrayElementPath Optional stable path used to seed array element IDs.
  * @return A Y.js type or the original value.
  */
 function createYValueFromSchema(
 	schema: BlockAttributeSchema | undefined,
-	value: unknown
+	value: unknown,
+	arrayElementPath?: string
 ): Y.Text | Y.Array< unknown > | Y.Map< unknown > | unknown {
 	if ( ! schema ) {
 		return value;
@@ -328,14 +356,22 @@ function createYValueFromSchema(
 
 		yArray.insert(
 			0,
-			value.map( ( item ) => createYMapFromQuery( query, item ) )
+			value.map( ( item, index ) =>
+				createYMapFromQuery(
+					query,
+					item,
+					arrayElementPath
+						? `${ arrayElementPath }/${ index }`
+						: undefined
+				)
+			)
 		);
 
 		return yArray;
 	}
 
 	if ( schema.type === 'object' && schema.query && isRecord( value ) ) {
-		return createYMapFromQuery( schema.query, value );
+		return createYMapFromQuery( schema.query, value, arrayElementPath );
 	}
 
 	return value;
@@ -355,29 +391,42 @@ function isRecord( value: unknown ): value is Record< string, unknown > {
  * Create a Y.Map from a plain object, using a query schema to decide which
  * properties should become nested Y.js types (Y.Text, Y.Array, Y.Map).
  *
- * @param query The query schema defining the properties.
- * @param obj   The plain object to convert.
+ * @param query          The query schema defining the properties.
+ * @param obj            The plain object to convert.
+ * @param arrayElementId Optional stable ID for this array element.
  * @return A Y.Map with typed values.
  */
 function createYMapFromQuery(
 	query: Record< string, BlockAttributeSchema >,
-	obj: unknown
+	obj: unknown,
+	arrayElementId?: string
 ): Y.Map< unknown > {
 	if ( ! isRecord( obj ) ) {
 		return new Y.Map();
 	}
 
-	const entries: [ string, unknown ][] = Object.entries( obj ).map(
-		( [ key, val ] ): [ string, unknown ] => {
+	const resolvedArrayElementId =
+		getArrayElementId( obj ) ?? arrayElementId ?? uuidv4();
+	const entries: [ string, unknown ][] = Object.entries( obj )
+		.filter( ( [ key ] ) => key !== ARRAY_ELEMENT_ID_KEY )
+		.map( ( [ key, val ] ): [ string, unknown ] => {
 			const subSchema = query[ key ];
-			return [ key, createYValueFromSchema( subSchema, val ) ];
-		}
-	);
+			return [
+				key,
+				createYValueFromSchema(
+					subSchema,
+					val,
+					`${ resolvedArrayElementId }/${ key }`
+				),
+			];
+		} );
+
+	entries.push( [ ARRAY_ELEMENT_ID_KEY, resolvedArrayElementId ] );
 
 	return new Y.Map( entries );
 }
 
-function createNewYBlock( block: Block ): YBlock {
+function createNewYBlock( block: Block, blockPath?: string ): YBlock {
 	return createYMap< YBlockRecord >(
 		Object.fromEntries(
 			Object.entries( block ).map( ( [ key, value ] ) => {
@@ -385,7 +434,11 @@ function createNewYBlock( block: Block ): YBlock {
 					case 'attributes': {
 						return [
 							key,
-							createNewYAttributeMap( block.name, value ),
+							createNewYAttributeMap(
+								block.name,
+								value,
+								blockPath
+							),
 						];
 					}
 
@@ -399,8 +452,13 @@ function createNewYBlock( block: Block ): YBlock {
 
 						innerBlocks.insert(
 							0,
-							value.map( ( innerBlock: Block ) =>
-								createNewYBlock( innerBlock )
+							value.map( ( innerBlock: Block, index: number ) =>
+								createNewYBlock(
+									innerBlock,
+									blockPath
+										? `${ blockPath }/innerBlocks/${ index }`
+										: undefined
+								)
 							)
 						);
 
@@ -655,7 +713,9 @@ export function mergeCrdtBlocks(
 
 	// inserts
 	for ( let i = 0; i < numOfInsertionsNeeded; i++, left++ ) {
-		const newBlock = [ createNewYBlock( incomingBlocksToSync[ left ] ) ];
+		const newBlock = [
+			createNewYBlock( incomingBlocksToSync[ left ], String( left ) ),
+		];
 
 		yblocks.insert( left, newBlock );
 	}
@@ -692,10 +752,124 @@ function areArrayElementsEqual(
 	yElement: unknown
 ): boolean {
 	if ( yElement instanceof Y.Map && isRecord( newElement ) ) {
-		return fastDeepEqual( newElement, yElement.toJSON() );
+		return fastDeepEqual(
+			stripArrayElementIds( newElement ),
+			stripArrayElementIds( yElement.toJSON() )
+		);
 	}
 
-	return fastDeepEqual( newElement, yElement );
+	return fastDeepEqual(
+		stripArrayElementIds( newElement ),
+		stripArrayElementIds( yElement )
+	);
+}
+
+function getArrayElementId( value: unknown ): string | undefined {
+	if ( value instanceof Y.Map ) {
+		const id = value.get( ARRAY_ELEMENT_ID_KEY );
+		return typeof id === 'string' ? id : undefined;
+	}
+
+	if ( isRecord( value ) ) {
+		const id = value[ ARRAY_ELEMENT_ID_KEY ];
+		if ( typeof id === 'string' ) {
+			return id;
+		}
+
+		const symbolId = ( value as Record< symbol, unknown > )[
+			ARRAY_ELEMENT_ID_SYMBOL
+		];
+		return typeof symbolId === 'string' ? symbolId : undefined;
+	}
+
+	return undefined;
+}
+
+function defineArrayElementId(
+	value: Record< string, unknown >,
+	id: string
+): void {
+	Object.defineProperty( value, ARRAY_ELEMENT_ID_SYMBOL, {
+		configurable: true,
+		enumerable: true,
+		value: id,
+	} );
+}
+
+function stripArrayElementIds( value: unknown ): unknown {
+	if ( Array.isArray( value ) ) {
+		return value.map( stripArrayElementIds );
+	}
+
+	if ( isRecord( value ) ) {
+		return Object.fromEntries(
+			Object.entries( value )
+				.filter( ( [ key ] ) => key !== ARRAY_ELEMENT_ID_KEY )
+				.map( ( [ key, innerValue ] ) => [
+					key,
+					stripArrayElementIds( innerValue ),
+				] )
+		);
+	}
+
+	return value;
+}
+
+function mergeYArrayByElementIds(
+	yArray: Y.Array< unknown >,
+	newValue: unknown[],
+	query: Record< string, BlockAttributeSchema >,
+	cursorPosition: MergeCursorPosition,
+	cursorScope: RichTextCursorScope
+): boolean {
+	if ( ! newValue.some( getArrayElementId ) ) {
+		return false;
+	}
+
+	let index = 0;
+
+	for ( const newElement of newValue ) {
+		const newId = getArrayElementId( newElement );
+		let currentIndex = -1;
+
+		if ( newId ) {
+			for ( let i = index; i < yArray.length; i++ ) {
+				if ( getArrayElementId( yArray.get( i ) ) === newId ) {
+					currentIndex = i;
+					break;
+				}
+			}
+		}
+
+		if ( currentIndex > index ) {
+			yArray.delete( index, currentIndex - index );
+		}
+
+		if ( currentIndex >= index ) {
+			const currentElement = yArray.get( index );
+			if ( currentElement instanceof Y.Map && isRecord( newElement ) ) {
+				mergeYMapValues(
+					currentElement,
+					newElement,
+					query,
+					cursorPosition,
+					cursorScope
+				);
+			}
+		} else {
+			yArray.insert( index, [
+				createYMapFromQuery( query, newElement ),
+			] );
+		}
+
+		index++;
+	}
+
+	if ( yArray.length > index ) {
+		yArray.delete( index, yArray.length - index );
+	}
+
+	return true;
 }
 
 /**
@@ -725,6 +899,19 @@ function mergeYArray(
 	}
 
 	const query = schema.query;
+
+	if (
+		mergeYArrayByElementIds(
+			yArray,
+			newValue,
+			query,
+			cursorPosition,
+			cursorScope
+		)
+	) {
+		return;
+	}
+
 	const numOfCommonEntries = Math.min( newValue.length, yArray.length );
 
 	let left = 0;
@@ -909,7 +1096,7 @@ function mergeYMapValues(
 
 	// Delete properties absent from the incoming object.
 	for ( const key of yMap.keys() ) {
-		if ( ! Object.hasOwn( newObj, key ) ) {
+		if ( key !== ARRAY_ELEMENT_ID_KEY && ! Object.hasOwn( newObj, key ) ) {
 			yMap.delete( key );
 		}
 	}

--- a/packages/core-data/src/utils/test/rtc-table-duplicate-body-revision-loss.test.ts
+++ b/packages/core-data/src/utils/test/rtc-table-duplicate-body-revision-loss.test.ts
@@ -1,0 +1,345 @@
+/**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	type CRDTDoc,
+	type ObjectData,
+	type SyncConfig,
+	Y,
+} from '@wordpress/sync';
+
+/**
+ * Mock sync providers so the SyncManager test can deterministically deliver
+ * normal Yjs updates after both collaborators make local table edits.
+ */
+jest.mock( '../../../../sync/src/providers', () => ( {
+	getProviderCreators: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/blocks', () => ( {
+	getBlockTypes: () => [
+		{
+			name: 'core/table',
+			attributes: {
+				body: {
+					type: 'array',
+					query: {
+						cells: {
+							type: 'array',
+							query: {
+								content: { type: 'rich-text' },
+								tag: { type: 'string' },
+							},
+						},
+					},
+				},
+			},
+		},
+	],
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import { createSyncManager } from '../../../../sync/src/manager';
+import { getProviderCreators } from '../../../../sync/src/providers';
+import { CRDT_RECORD_MAP_KEY } from '../../sync';
+import {
+	deserializeBlockAttributes,
+	mergeCrdtBlocks,
+	type Block,
+	type YBlock,
+} from '../crdt-blocks';
+
+const OBJECT_TYPE = 'postType/post';
+const OBJECT_ID = '1';
+const EDITED_MARKER = 'edited-second-duplicate-body-marker';
+const INITIAL_ROWS = [ 'anchor', 'same', 'same' ];
+const mockGetProviderCreators = jest.mocked( getProviderCreators );
+
+type TableCell = {
+	content?: unknown;
+	tag?: string;
+	[ key: string ]: unknown;
+};
+
+type TableRow = {
+	cells: TableCell[];
+	[ key: string ]: unknown;
+};
+
+function createTableBlock( values: string[] ): Block {
+	return {
+		name: 'core/table',
+		clientId: 'table',
+		attributes: {
+			body: values.map( ( value ) => ( {
+				cells: [
+					{
+						content: value,
+						tag: 'td',
+					},
+				],
+			} ) ),
+		},
+		innerBlocks: [],
+	};
+}
+
+function createTableBlockFromRows(
+	sourceBlock: Block,
+	rows: TableRow[]
+): Block {
+	return {
+		...sourceBlock,
+		attributes: {
+			...sourceBlock.attributes,
+			body: rows,
+		},
+	};
+}
+
+function cloneBlocks( blocks: Block[] ): Block[] {
+	return JSON.parse( JSON.stringify( blocks ) ) as Block[];
+}
+
+function getBlocksArray( ydoc: CRDTDoc ): Y.Array< YBlock > {
+	const recordMap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+	let blocks = recordMap.get( 'blocks' );
+
+	if ( ! ( blocks instanceof Y.Array ) ) {
+		blocks = new Y.Array< YBlock >();
+		recordMap.set( 'blocks', blocks );
+	}
+
+	return blocks as Y.Array< YBlock >;
+}
+
+function applyTableRows( ydoc: CRDTDoc, values: string[] ) {
+	mergeCrdtBlocks(
+		getBlocksArray( ydoc ),
+		[ createTableBlock( values ) ],
+		null
+	);
+}
+
+function getSerializableBlocks( ydoc: CRDTDoc ): Block[] {
+	return getBlocksArray( ydoc ).toJSON() as Block[];
+}
+
+function getTableRowsFromBlocks( blocks: Block[] ): TableRow[] {
+	return ( blocks[ 0 ]?.attributes.body ?? [] ) as TableRow[];
+}
+
+function createBlocksWithEditedTableRow(
+	ydoc: CRDTDoc,
+	index: number,
+	content: string
+): Block[] {
+	const blocks = getSerializableBlocks( ydoc );
+	const rows = getTableRowsFromBlocks( blocks ).map( ( row, rowIndex ) => {
+		if ( rowIndex !== index ) {
+			return row;
+		}
+
+		return {
+			...row,
+			cells: row.cells.map( ( cell, cellIndex ) =>
+				cellIndex === 0 ? { ...cell, content } : cell
+			),
+		};
+	} );
+
+	return [ createTableBlockFromRows( blocks[ 0 ], rows ) ];
+}
+
+function createBlocksWithDeletedTableRow(
+	ydoc: CRDTDoc,
+	index: number
+): Block[] {
+	const blocks = getSerializableBlocks( ydoc );
+	const rows = getTableRowsFromBlocks( blocks ).filter(
+		( _row, rowIndex ) => rowIndex !== index
+	);
+
+	return [ createTableBlockFromRows( blocks[ 0 ], rows ) ];
+}
+
+function getTableCellContents( ydoc: CRDTDoc ): string[] {
+	const body = getTableRowsFromBlocks( getSerializableBlocks( ydoc ) );
+
+	return ( body ?? [] ).map( ( row ) => String( row.cells[ 0 ].content ) );
+}
+
+function syncDocs( first: CRDTDoc, second: CRDTDoc ) {
+	Y.applyUpdateV2( second, Y.encodeStateAsUpdateV2( first ) );
+	Y.applyUpdateV2( first, Y.encodeStateAsUpdateV2( second ) );
+}
+
+function createBlocksSyncConfig(
+	onApply?: ( ydoc: CRDTDoc ) => void
+): SyncConfig {
+	return {
+		applyChangesToCRDTDoc: ( ydoc: CRDTDoc, changes: ObjectData ) => {
+			onApply?.( ydoc );
+			const blocks = changes.blocks as Block[] | undefined;
+
+			if ( blocks ) {
+				mergeCrdtBlocks( getBlocksArray( ydoc ), blocks, null );
+			}
+		},
+		getChangesFromCRDTDoc: ( ydoc: CRDTDoc, editedRecord: ObjectData ) => {
+			const blocks = deserializeBlockAttributes(
+				getBlocksArray( ydoc ).toJSON() as Block[]
+			);
+
+			return JSON.stringify( blocks ) ===
+				JSON.stringify( editedRecord.blocks )
+				? {}
+				: { blocks };
+		},
+		getPersistedCRDTDoc: () => null,
+	};
+}
+
+function createHandlers( blocks: Block[] ) {
+	let editedBlocks = cloneBlocks( blocks );
+
+	return {
+		addUndoMeta: jest.fn(),
+		editRecord: jest.fn( ( changes: { blocks?: Block[] } ) => {
+			if ( changes.blocks ) {
+				editedBlocks = cloneBlocks( changes.blocks );
+			}
+		} ),
+		getEditedRecord: jest.fn( async () => ( {
+			id: 1,
+			blocks: cloneBlocks( editedBlocks ),
+		} ) ),
+		onStatusChange: jest.fn(),
+		persistCRDTDoc: jest.fn(),
+		refetchRecord: jest.fn( async () => {} ),
+		restoreUndoMeta: jest.fn(),
+	};
+}
+
+function waitForDeferredUpdate() {
+	return new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+}
+
+describe( 'duplicate table body revision loss', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockGetProviderCreators.mockReturnValue( [
+			jest.fn( async () => ( {
+				destroy: jest.fn(),
+				on: jest.fn(),
+			} ) ),
+		] );
+	} );
+
+	it( 'does not lose a later duplicate table row edit when another session deletes the earlier duplicate row', () => {
+		const editorDoc = new Y.Doc();
+		const deleterDoc = new Y.Doc();
+
+		try {
+			// Old/no-CRDT posts can be independently bootstrapped from the same
+			// serialized table body in two browser sessions.
+			applyTableRows( editorDoc, INITIAL_ROWS );
+			applyTableRows( deleterDoc, INITIAL_ROWS );
+			syncDocs( editorDoc, deleterDoc );
+
+			mergeCrdtBlocks(
+				getBlocksArray( editorDoc ),
+				createBlocksWithEditedTableRow( editorDoc, 2, EDITED_MARKER ),
+				null
+			);
+			mergeCrdtBlocks(
+				getBlocksArray( deleterDoc ),
+				createBlocksWithDeletedTableRow( deleterDoc, 1 ),
+				null
+			);
+			syncDocs( editorDoc, deleterDoc );
+
+			expect( getTableCellContents( editorDoc ) ).toContain(
+				EDITED_MARKER
+			);
+			expect( getTableCellContents( deleterDoc ) ).toContain(
+				EDITED_MARKER
+			);
+		} finally {
+			editorDoc.destroy();
+			deleterDoc.destroy();
+		}
+	} );
+
+	it( 'does not let SyncManager lose a duplicate table row edit after independent no-CRDT bootstraps', async () => {
+		let editorDoc: CRDTDoc | undefined;
+		let deleterDoc: CRDTDoc | undefined;
+		const editorManager = createSyncManager();
+		const deleterManager = createSyncManager();
+		const initialBlocks = [ createTableBlock( INITIAL_ROWS ) ];
+
+		await editorManager.load(
+			createBlocksSyncConfig( ( ydoc ) => {
+				editorDoc = ydoc;
+			} ),
+			OBJECT_TYPE,
+			OBJECT_ID,
+			{ id: 1, blocks: initialBlocks },
+			createHandlers( initialBlocks )
+		);
+		await deleterManager.load(
+			createBlocksSyncConfig( ( ydoc ) => {
+				deleterDoc = ydoc;
+			} ),
+			OBJECT_TYPE,
+			OBJECT_ID,
+			{ id: 1, blocks: initialBlocks },
+			createHandlers( initialBlocks )
+		);
+
+		expect( editorDoc ).toBeDefined();
+		expect( deleterDoc ).toBeDefined();
+		syncDocs( editorDoc as CRDTDoc, deleterDoc as CRDTDoc );
+
+		editorManager.update(
+			OBJECT_TYPE,
+			OBJECT_ID,
+			{
+				blocks: createBlocksWithEditedTableRow(
+					editorDoc as CRDTDoc,
+					2,
+					EDITED_MARKER
+				),
+			},
+			'LOCAL_EDITOR_ORIGIN'
+		);
+		deleterManager.update(
+			OBJECT_TYPE,
+			OBJECT_ID,
+			{
+				blocks: createBlocksWithDeletedTableRow(
+					deleterDoc as CRDTDoc,
+					1
+				),
+			},
+			'LOCAL_EDITOR_ORIGIN'
+		);
+		await waitForDeferredUpdate();
+		syncDocs( editorDoc as CRDTDoc, deleterDoc as CRDTDoc );
+		await waitForDeferredUpdate();
+
+		expect( getTableCellContents( editorDoc as CRDTDoc ) ).toContain(
+			EDITED_MARKER
+		);
+		expect( getTableCellContents( deleterDoc as CRDTDoc ) ).toContain(
+			EDITED_MARKER
+		);
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/collaboration-table-duplicates.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-table-duplicates.spec.ts
@@ -1,0 +1,292 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+type Editor = import('@wordpress/e2e-test-utils-playwright').Editor;
+type Page = import('@playwright/test').Page;
+
+const TABLE_POST_CONTENT = `<!-- wp:table -->
+<figure class="wp-block-table"><table><tbody><tr><td>anchor</td></tr><tr><td>same</td></tr><tr><td>same</td></tr></tbody></table></figure>
+<!-- /wp:table -->`;
+const EDITED_SECOND_DUPLICATE = 'edited-second-duplicate';
+
+async function getPersistedContent(
+	requestUtils: {
+		rest: < T >( options: {
+			path: string;
+			params?: Record< string, string >;
+		} ) => Promise< T >;
+	},
+	postId: number
+): Promise< string > {
+	const post = await requestUtils.rest< {
+		content: string | { raw?: string; rendered?: string };
+	} >( {
+		path: `/wp/v2/posts/${ postId }`,
+		params: { context: 'edit' },
+	} );
+
+	return typeof post.content === 'string'
+		? post.content
+		: post.content.raw ?? post.content.rendered ?? '';
+}
+
+async function getRevisionContents(
+	requestUtils: {
+		rest: < T >( options: {
+			path: string;
+			params?: Record< string, string >;
+		} ) => Promise< T >;
+	},
+	postId: number
+): Promise< string[] > {
+	const revisions = await requestUtils.rest<
+		Array< { content?: string | { raw?: string; rendered?: string } } >
+	>( {
+		path: `/wp/v2/posts/${ postId }/revisions`,
+		params: { context: 'edit' },
+	} );
+
+	return revisions.map( ( revision ) => {
+		if ( typeof revision.content === 'string' ) {
+			return revision.content;
+		}
+
+		return revision.content?.raw ?? revision.content?.rendered ?? '';
+	} );
+}
+
+async function getTableBodyCellContents( editor: Editor ) {
+	return editor.canvas
+		.getByRole( 'textbox', { name: 'Body cell text' } )
+		.evaluateAll( ( cells ) =>
+			cells.map( ( cell ) => cell.textContent?.trim() )
+		);
+}
+
+async function editTableCell( {
+	editor,
+	page,
+	index,
+	content,
+}: {
+	editor: Editor;
+	page: Page;
+	index: number;
+	content: string;
+} ) {
+	await editor.canvas
+		.getByRole( 'textbox', { name: 'Body cell text' } )
+		.nth( index )
+		.click();
+	await page.keyboard.press( 'ControlOrMeta+a' );
+	await page.keyboard.type( content );
+}
+
+async function deleteTableRow( {
+	editor,
+	page,
+	index,
+}: {
+	editor: Editor;
+	page: Page;
+	index: number;
+} ) {
+	await editor.canvas
+		.getByRole( 'textbox', { name: 'Body cell text' } )
+		.nth( index )
+		.click();
+	await editor.clickBlockToolbarButton( 'Edit table' );
+	await page.getByRole( 'menuitem', { name: 'Delete row' } ).click();
+}
+
+async function selectTableCellText( {
+	editor,
+	page,
+	index,
+}: {
+	editor: Editor;
+	page: Page;
+	index: number;
+} ) {
+	await editor.canvas
+		.getByRole( 'textbox', { name: 'Body cell text' } )
+		.nth( index )
+		.click();
+	await page.keyboard.press( 'ControlOrMeta+a' );
+}
+
+async function openDeleteRowMenu( {
+	editor,
+	page,
+	index,
+}: {
+	editor: Editor;
+	page: Page;
+	index: number;
+} ) {
+	await editor.canvas
+		.getByRole( 'textbox', { name: 'Body cell text' } )
+		.nth( index )
+		.click();
+	await editor.clickBlockToolbarButton( 'Edit table' );
+	await expect(
+		page.getByRole( 'menuitem', { name: 'Delete row' } )
+	).toBeVisible();
+}
+
+test.describe( 'Collaboration - duplicate table rows', () => {
+	test( 'preserves a later duplicate row edit when the earlier duplicate row is deleted', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		test.setTimeout( 45_000 );
+
+		const post = await requestUtils.createPost( {
+			title: 'Duplicate table row collaboration repro',
+			status: 'draft',
+			content: TABLE_POST_CONTENT,
+			date_gmt: new Date().toISOString(),
+		} );
+
+		await collaborationUtils.openCollaborativeSession( post.id );
+		const { editor2, page2 } = collaborationUtils;
+
+		await expect
+			.poll( () => getTableBodyCellContents( editor ), {
+				timeout: 10_000,
+			} )
+			.toEqual( [ 'anchor', 'same', 'same' ] );
+		await expect
+			.poll( () => getTableBodyCellContents( editor2 ), {
+				timeout: 10_000,
+			} )
+			.toEqual( [ 'anchor', 'same', 'same' ] );
+
+		await Promise.all( [
+			editTableCell( {
+				content: EDITED_SECOND_DUPLICATE,
+				editor,
+				index: 2,
+				page,
+			} ),
+			deleteTableRow( {
+				editor: editor2,
+				index: 1,
+				page: page2,
+			} ),
+		] );
+
+		await Promise.all( [
+			collaborationUtils.waitForSyncCycle( page, 5 ),
+			collaborationUtils.waitForSyncCycle( page2, 5 ),
+		] );
+
+		await expect
+			.poll( () => getTableBodyCellContents( editor ), {
+				timeout: 10_000,
+			} )
+			.toEqual( [ 'anchor', EDITED_SECOND_DUPLICATE ] );
+		await expect
+			.poll( () => getTableBodyCellContents( editor2 ), {
+				timeout: 10_000,
+			} )
+			.toEqual( [ 'anchor', EDITED_SECOND_DUPLICATE ] );
+	} );
+
+	test( 'saves the later duplicate row edit into revisions when another user deletes the earlier duplicate row', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		test.setTimeout( 60_000 );
+
+		const post = await requestUtils.createPost( {
+			title: 'Duplicate table row body revision loss',
+			status: 'draft',
+			content: TABLE_POST_CONTENT,
+			date_gmt: new Date().toISOString(),
+		} );
+
+		await collaborationUtils.openCollaborativeSession( post.id );
+		const { editor2, page2 } = collaborationUtils;
+
+		await expect
+			.poll( () => getTableBodyCellContents( editor ), {
+				timeout: 10_000,
+			} )
+			.toEqual( [ 'anchor', 'same', 'same' ] );
+		await expect
+			.poll( () => getTableBodyCellContents( editor2 ), {
+				timeout: 10_000,
+			} )
+			.toEqual( [ 'anchor', 'same', 'same' ] );
+
+		await selectTableCellText( {
+			editor,
+			index: 2,
+			page,
+		} );
+		await openDeleteRowMenu( {
+			editor: editor2,
+			index: 1,
+			page: page2,
+		} );
+
+		await page.keyboard.type( EDITED_SECOND_DUPLICATE );
+		await expect
+			.poll( () => getTableBodyCellContents( editor ), {
+				timeout: 5_000,
+			} )
+			.toContain( EDITED_SECOND_DUPLICATE );
+		await page2.getByRole( 'menuitem', { name: 'Delete row' } ).click();
+
+		await Promise.all( [
+			collaborationUtils.waitForSyncCycle( page, 5, {
+				timeout: 20_000,
+			} ),
+			collaborationUtils.waitForSyncCycle( page2, 5, {
+				timeout: 20_000,
+			} ),
+		] );
+		await expect
+			.poll( () => getTableBodyCellContents( editor ), {
+				timeout: 10_000,
+			} )
+			.toEqual( [ 'anchor', EDITED_SECOND_DUPLICATE ] );
+		await expect
+			.poll( () => getTableBodyCellContents( editor2 ), {
+				timeout: 10_000,
+			} )
+			.toEqual( [ 'anchor', EDITED_SECOND_DUPLICATE ] );
+
+		const editorCellsBeforeSave = await getTableBodyCellContents( editor );
+		await editor.saveDraft();
+
+		expect( {
+			editorCellsBeforeSave,
+			persistedContent: await getPersistedContent(
+				requestUtils,
+				post.id
+			),
+			revisionContents: await getRevisionContents(
+				requestUtils,
+				post.id
+			),
+		} ).toEqual( {
+			editorCellsBeforeSave: expect.arrayContaining( [
+				EDITED_SECOND_DUPLICATE,
+			] ),
+			persistedContent: expect.stringContaining(
+				EDITED_SECOND_DUPLICATE
+			),
+			revisionContents: expect.arrayContaining( [
+				expect.stringContaining( EDITED_SECOND_DUPLICATE ),
+			] ),
+		} );
+	} );
+} );


### PR DESCRIPTION
This is part of an AI fuzzing project, where an AI wrote a fuzzer and then triages bugs from the fuzzer and creates fixes. See #77716 for the tracking issue. As of this writing, there have been no known false positives from this project, but there have been some issues, which are documented in #77716. I expect we’ll see false positives at some point (and may even have one that’s been filed in a PR that hasn’t been inspected by a code owner yet).

## What?

https://github.com/user-attachments/assets/ed4efe62-2059-4be6-a7a4-1abc9e6547a6

Note that while the symptoms of this bug are very similar to #77723, the tests here fail with the fix for #77723, so this looks like a distinct bug that looks like the same bug superficially.

## BEGIN AI GENERATED TEXT

Two collaborators can lose a table-body edit when an old or externally-created
post has no persisted CRDT document and contains duplicate table rows.

The browser repro starts with serialized post content containing a table body
with three one-cell rows:

```text
anchor
same
same
```

One user edits the later duplicate row to `edited-second-duplicate`. Another
user deletes the earlier duplicate row through the normal table toolbar. The
edit marker is visible in the editing user's browser before the delete is
clicked. After normal RTC convergence, both editors show only:

```text
anchor
same
```

When the user performs a normal Save draft, the saved post body contains the
lost two-row table and the post revisions do not contain
`edited-second-duplicate`.

This is a body-content loss bug, not a title-loss bug.

## Reproduction Levels

-   CRDT merge repro:
    `packages/core-data/src/utils/test/rtc-table-duplicate-body-revision-loss.test.ts`
    (`does not lose a later duplicate table row edit when another session deletes
the earlier duplicate row`).
-   SyncManager repro:
    `packages/core-data/src/utils/test/rtc-table-duplicate-body-revision-loss.test.ts`
    (`does not let SyncManager lose a duplicate table row edit after independent
no-CRDT bootstraps`).
-   Browser Playwright repro:
    `test/e2e/specs/editor/collaboration/collaboration-table-duplicates.spec.ts`
    (`saves the later duplicate row edit into revisions when another user deletes
the earlier duplicate row`).
-   Fuzzer coverage:
    `packages/core-data/src/utils/test/crdt-table-duplicates.fuzz.test.ts`.

The focused lower-level command is:

```sh
npm run test:unit -- packages/core-data/src/utils/test/rtc-table-duplicate-body-revision-loss.test.ts --maxWorkers=1
```

The browser command is:

```sh
npm run test:e2e -- test/e2e/specs/editor/collaboration/collaboration-table-duplicates.spec.ts -g "saves the later duplicate row edit into revisions" --workers=1
```

Expected failure on the buggy code:

-   The editor body after convergence and before save is `["anchor", "same"]`.
-   The persisted post content is the two-row table.
-   The revisions contain the two-row table and the original three-row table.
-   No revision contains `edited-second-duplicate`.

## Relationship To Known RTC Table And Revision Bugs

### Duplicate Table Row Divergence: #77723

[WordPress/gutenberg#77723](https://github.com/WordPress/gutenberg/pull/77723)
is the closest known bug. It was about ambiguous value matching for duplicate
query-array entries. Dan's stable table query-array identity work fixed the
shared-CRDT case by carrying an internal `__unstableSyncId` through runtime
table attributes without serializing it into post content.

That fix is present on this base, and the existing control repro passes:

```sh
npm run test:unit -- packages/core-data/src/utils/test/crdt-table-duplicates-repro.test.ts --maxWorkers=1
```

That control initializes document B from document A's CRDT state, so both
sessions share row identities before editing. The remaining bug is different:
old/no-CRDT serialized post content can be independently bootstrapped in two
browser sessions. Each session parses the same duplicate rows from HTML and
creates its own internal identities. Because the rows have the same visible
content and no shared persisted identity, "delete the earlier `same` row" and
"edit the later `same` row" are still ambiguous after the two independent CRDT
states meet.

I checked the browser repro on Dan's hardened duplicate-table branch
`try/rtc-duplicate-table-rows-stock-repro-pr-trunk` (`2e153b32280`, containing
`Harden table query identity sync`). The stock table-body repro still fails
there, and the revision-level browser repro still saves a two-row table whose
revisions omit `edited-second-duplicate`. This is therefore not just a re-find
of the earlier shared-CRDT duplicate-table fix.

### Stale Local Table Snapshot Loss: #77775

[WordPress/gutenberg#77775](https://github.com/WordPress/gutenberg/pull/77775)
is related because it also touches the RTC table/query-array merge path, but it
is a different invariant. That bug is about a client applying a stale full local
block snapshot after it has already received a remote CRDT update. The stale
snapshot can overwrite, delete, or resurrect remote table data even when the row
or cell identity is already known.

This duplicate-body revision-loss bug does not require a stale local snapshot.
It starts earlier: two no-CRDT sessions independently bootstrap from the same
serialized table HTML and therefore assign incompatible internal identities to
the same visible duplicate rows. The lower-level CRDT and SyncManager repros
fail before the PHP autosave path and before any browser stale-snapshot recovery
logic is relevant.

The fixes are complementary. #77775 changes when a local snapshot is allowed to
write into the current Y.Doc. This bug changes how independently bootstrapped
old/no-CRDT table rows get a shared logical identity in the first place.

### Auto-Draft Autosave Retention: #77865

[WordPress/gutenberg#77865](https://github.com/WordPress/gutenberg/pull/77865)
is a revision/data-loss bug, but it is not the same bug. That PR changes the
PHP autosave controller so a new `auto-draft` is promoted to a visible `draft`
when RTC is enabled. This table-body repro creates a normal draft fixture with
serialized table content, opens two collaborative editor sessions, loses the
body edit during RTC convergence, and then performs a normal Save draft. It does
not rely on `post-new.php`, automatic autosave, or auto-draft promotion.

There is an indirect interaction: #77865 can create another normal user path to
a visible draft whose content came from serialized HTML and may not yet have a
matching persisted CRDT document. If that draft contains duplicate table rows,
it can satisfy the independent-bootstrap precondition for this bug. But #77865
does not touch `mergeCrdtBlocks()`, table query-array identity, or table state
helpers, so it does not fix this table-body loss.

## Root Cause

`core/table` stores rows and cells as nested query-array attributes. The RTC
merge code represents those arrays as Yjs arrays of maps and uses
`__unstableSyncId` as the preferred stable identity for array elements.

That identity is intentionally not serialized into post HTML. For old posts,
REST-created posts, imported posts, or any post that has no persisted CRDT
document yet, two sessions can therefore construct different internal identities
for the same visible duplicate rows.

When the two sessions later converge:

1. The editing session has `anchor`, `same`, `edited-second-duplicate`.
2. The deleting session has `anchor`, `same`.
3. The merge sees duplicate visible values and incompatible internal row IDs.
4. `mergeYArrayLocalChanges()` / `findYArrayElementIndex()` can match the local
   edit against the wrong duplicate row.
5. The edited Yjs text is removed or overwritten, leaving only `anchor`, `same`.
6. A normal save persists that converged lost state, so revisions cannot restore
   the body edit.

The important invariant violation is:

> A user-visible body edit to one duplicate query-array element must not be lost
> merely because another collaborator deletes a different duplicate element.

## False-Positive Analysis

The browser repro does not inject faults, drop messages, modify application
state directly, or use a test-only collaboration provider. It uses the stock
editor flow:

1. Create a draft fixture with normal serialized post content and no persisted
   CRDT metadata.
2. Open two collaborative editor sessions.
3. Select and type into a table cell.
4. Open the table toolbar menu and click `Delete row`.
5. Wait for normal convergence.
6. Click Save draft.
7. Read persisted content and revisions through the normal REST API.

The only setup shortcut is creating the initial old/no-CRDT post fixture, which
represents real content created before RTC metadata existed, imported content,
or content created through APIs outside the editor.

The marker is explicitly observed in the editor before the second user clicks
Delete row. The failure is also reproduced below the browser layer in direct
CRDT and SyncManager tests. That rules out a Playwright-only race or a test
assertion that never made a real body edit.

The loss does happen before the final save: after convergence, the editor body
is already `["anchor", "same"]`. The revision-loss part is that the user's
subsequent normal save records only the lost body, leaving no revision that can
restore the marker.

## Fix Plan

1. Keep internal query-array IDs for live editor objects, but treat independently
   bootstrapped IDs from the same old/no-CRDT serialized content as provisional.
2. During first live convergence for no-persisted-CRDT records, reconcile
   identical parsed array elements so that sessions agree on one identity per
   logical element before local structural edits are allowed to collapse
   duplicates.
3. If duplicate elements cannot be unambiguously matched, prefer preserving both
   user-visible edits over deleting one. A visible duplicate row is less bad than
   silent body data loss.
4. Add a deterministic regression for the independent-bootstrap case, not only
   the shared-CRDT case.
5. Keep the browser revision test because the bug is user-impacting only after a
   normal save proves that the body edit is absent from revisions.

## END AI GENERATED TEXT
