### PR TITLE
Fix block level feature selectors for style variations in global styles

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3276,8 +3276,8 @@ class WP_Theme_JSON_Gutenberg {
 						 * Feature selector is block-level (e.g. `.wp-block-button` for
 						 * dimensions/width) — apply the variation class directly to it.
 						 */
-						$feature_element_selector = str_replace( $shortened_selector, '', $clean_style_variation_selector );
-						$combined_selectors       = str_replace( $feature_element_selector, '', $clean_style_variation_selector );
+						$combined_selectors = explode( ' ', $clean_style_variation_selector )[0];
+
 					} else {
 						// Prepend the variation selector to the current selector.
 						$split_selectors    = explode( ',', $shortened_selector );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3269,17 +3269,26 @@ class WP_Theme_JSON_Gutenberg {
 					 * - `.wp-block-image img, .wp-block-image.my-class img`
 					 */
 					$clean_current_selector = preg_replace( '/,\s+/', ',', $current_selector );
-					$shortened_selector     = str_replace( $block_metadata['selector'], '', $clean_current_selector );
+					$shortened_selector     = str_replace( $selector, '', $clean_current_selector );
 
-					// Prepend the variation selector to the current selector.
-					$split_selectors    = explode( ',', $shortened_selector );
-					$updated_selectors  = array_map(
-						static function ( $split_selector ) use ( $clean_style_variation_selector ) {
-							return $clean_style_variation_selector . $split_selector;
-						},
-						$split_selectors
-					);
-					$combined_selectors = implode( ',', $updated_selectors );
+					if ( $selector && ! str_contains( $clean_current_selector, $selector ) ) {
+						/*
+						 * Feature selector is block-level (e.g. `.wp-block-button` for
+						 * dimensions/width) — apply the variation class directly to it.
+						 */
+						$feature_element_selector = str_replace( $shortened_selector, '', $clean_style_variation_selector );
+						$combined_selectors       = str_replace( $feature_element_selector, '', $clean_style_variation_selector );
+					} else {
+						// Prepend the variation selector to the current selector.
+						$split_selectors    = explode( ',', $shortened_selector );
+						$updated_selectors  = array_map(
+							static function ( $split_selector ) use ( $clean_style_variation_selector ) {
+								return $clean_style_variation_selector . $split_selector;
+							},
+							$split_selectors
+						);
+						$combined_selectors = implode( ',', $updated_selectors );
+					}
 
 					// Add the new declarations to the overall results under the modified selector.
 					$style_variation_declarations[ $combined_selectors ] = $new_declarations;

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1640,10 +1640,18 @@ export const transformToStyles = (
 										] ) => {
 											if ( declarations.length ) {
 												const cssSelector =
-													concatFeatureVariationSelectorString(
-														baseSelector,
-														styleVariationSelector as string
-													);
+													! selector ||
+													baseSelector.includes(
+														selector
+													)
+														? concatFeatureVariationSelectorString(
+																baseSelector,
+																styleVariationSelector as string
+														  )
+														: getBlockStyleVariationSelector(
+																styleVariationName,
+																baseSelector
+														  );
 												const rules =
 													declarations.join( ';' );
 												ruleset += `:root :where(${ cssSelector }){${ rules };}`;

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -652,6 +652,127 @@ describe( 'global styles renderer', () => {
 			);
 		} );
 
+		it( 'should scope block-level feature selector to variation class when root selector is a compound selector', () => {
+			/*
+			 * Mirrors the PHP test test_block_style_variation_support_styles_scope_button_feature_selector.
+			 * core/button has a compound root selector (.wp-block-button .wp-block-button__link)
+			 * but its spacing feature targets only the outer wrapper (.wp-block-button).
+			 * The fix ensures the variation CSS uses .wp-block-button.is-style-outline
+			 * rather than incorrectly concatenating the full compound variation selector
+			 * onto the block-level feature selector.
+			 */
+			const tree: GlobalStylesConfig = {
+				styles: {
+					blocks: {
+						'core/button': {
+							variations: {
+								outline: {
+									spacing: {
+										padding: '10px',
+									},
+								},
+							},
+						},
+					},
+				},
+			};
+
+			const blockSelectors = {
+				'core/button': {
+					selector: '.wp-block-button .wp-block-button__link',
+					featureSelectors: {
+						spacing: '.wp-block-button',
+					},
+					styleVariationSelectors: {
+						outline:
+							'.wp-block-button.is-style-outline .wp-block-button__link',
+					},
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors,
+				false,
+				false,
+				true,
+				true,
+				{
+					blockGap: false,
+					blockStyles: true,
+					layoutStyles: false,
+					marginReset: false,
+					presets: false,
+					rootPadding: false,
+					variationStyles: true,
+				}
+			);
+
+			expect( result ).toEqual(
+				':root :where(.wp-block-button.is-style-outline){padding: 10px;}'
+			);
+		} );
+
+		it( 'should scope block-level feature selector to variation class when root selector uses a child combinator', () => {
+			/*
+			 * Mirrors the PHP test test_block_style_variation_support_styles_scope_table_feature_selector.
+			 * core/table has a child-combinator root selector (.wp-block-table > table)
+			 * but its spacing feature targets only the block wrapper (.wp-block-table).
+			 * The fix ensures the variation CSS uses .wp-block-table.is-style-stripes
+			 * rather than incorrectly appending the block wrapper selector to the
+			 * compound variation selector.
+			 */
+			const tree: GlobalStylesConfig = {
+				styles: {
+					blocks: {
+						'core/table': {
+							variations: {
+								stripes: {
+									spacing: {
+										padding: '40px',
+									},
+								},
+							},
+						},
+					},
+				},
+			};
+
+			const blockSelectors = {
+				'core/table': {
+					selector: '.wp-block-table > table',
+					featureSelectors: {
+						spacing: '.wp-block-table',
+					},
+					styleVariationSelectors: {
+						stripes: '.wp-block-table.is-style-stripes > table',
+					},
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors,
+				false,
+				false,
+				true,
+				true,
+				{
+					blockGap: false,
+					blockStyles: true,
+					layoutStyles: false,
+					marginReset: false,
+					presets: false,
+					rootPadding: false,
+					variationStyles: true,
+				}
+			);
+
+			expect( result ).toEqual(
+				':root :where(.wp-block-table.is-style-stripes){padding: 40px;}'
+			);
+		} );
+
 		it( 'should handle block pseudo selectors', () => {
 			const tree = {
 				styles: {

--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -77,6 +77,8 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
+		wp_deregister_style( 'block-style-variation-styles' );
+
 		$GLOBALS['wp_theme_directories'] = $this->orig_theme_dir;
 		wp_clean_themes_cache();
 		unset( $GLOBALS['wp_themes'] );
@@ -260,5 +262,111 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertSameSetsWithIndex( $expected, $variation_data, 'Variation data with resolved ref values does not match' );
+	}
+
+	/**
+	 * Tests that block-level feature selectors for Button style variations use the
+	 * generated variation instance class.
+	 */
+	public function test_block_style_variation_support_styles_scope_button_feature_selector() {
+		$filter = function ( $theme_json ) {
+			return $theme_json->update_with(
+				array(
+					'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+					'styles'  => array(
+						'blocks' => array(
+							'core/button' => array(
+								'variations' => array(
+									'outline' => array(
+										'dimensions' => array(
+											'width' => '25%',
+										),
+									),
+								),
+							),
+						),
+					),
+				)
+			);
+		};
+
+		add_filter( 'wp_theme_json_data_user', $filter );
+		_gutenberg_clean_theme_json_caches();
+
+		$parsed_block = array(
+			'blockName'    => 'core/button',
+			'attrs'        => array(
+				'className' => 'is-style-outline',
+			),
+			'innerBlocks'  => array(),
+			'innerHTML'    => '<div class="wp-block-button is-style-outline"><a class="wp-block-button__link">Text</a></div>',
+			'innerContent' => array(),
+		);
+
+		$parsed_block = gutenberg_render_block_style_variation_support_styles( $parsed_block );
+		$styles       = implode( '', wp_styles()->registered['block-style-variation-styles']->extra['after'] ?? array() );
+
+		remove_filter( 'wp_theme_json_data_user', $filter );
+		_gutenberg_clean_theme_json_caches();
+
+		preg_match( '/is-style-outline--\d+/', $parsed_block['attrs']['className'], $matches );
+		$variation_instance_class = $matches[0] ?? '';
+
+		$this->assertNotEmpty( $variation_instance_class );
+		$this->assertMatchesRegularExpression( "/:root :where\\(\\.wp-block-button\\.$variation_instance_class\\s*\\)\\{width: 25%;\\}/", $styles );
+		$this->assertStringNotContainsString( ':root :where(){', $styles );
+	}
+
+	/**
+	 * Tests that block-level feature selectors for Table style variations use the
+	 * generated variation instance class.
+	 */
+	public function test_block_style_variation_support_styles_scope_table_feature_selector() {
+		$filter = function ( $theme_json ) {
+			return $theme_json->update_with(
+				array(
+					'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+					'styles'  => array(
+						'blocks' => array(
+							'core/table' => array(
+								'variations' => array(
+									'stripes' => array(
+										'spacing' => array(
+											'padding' => '40px',
+										),
+									),
+								),
+							),
+						),
+					),
+				)
+			);
+		};
+
+		add_filter( 'wp_theme_json_data_user', $filter );
+		_gutenberg_clean_theme_json_caches();
+
+		$parsed_block = array(
+			'blockName'    => 'core/table',
+			'attrs'        => array(
+				'className' => 'is-style-stripes',
+			),
+			'innerBlocks'  => array(),
+			'innerHTML'    => '<figure class="wp-block-table is-style-stripes"><table></table></figure>',
+			'innerContent' => array(),
+		);
+
+		$parsed_block = gutenberg_render_block_style_variation_support_styles( $parsed_block );
+		$styles       = implode( '', wp_styles()->registered['block-style-variation-styles']->extra['after'] ?? array() );
+
+		remove_filter( 'wp_theme_json_data_user', $filter );
+		_gutenberg_clean_theme_json_caches();
+
+		preg_match( '/is-style-stripes--\d+/', $parsed_block['attrs']['className'], $matches );
+		$variation_instance_class = $matches[0] ?? '';
+
+		$this->assertNotEmpty( $variation_instance_class );
+		$this->assertStringContainsString( ":root :where(.wp-block-table.$variation_instance_class){padding: 40px;}", $styles );
+		$this->assertStringNotContainsString( ':root :where(){', $styles );
 	}
 }

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -4545,6 +4545,47 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual_styles );
 	}
 
+	public function test_get_styles_for_block_with_table_style_variation_spacing_selector() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/table' => array(
+							'variations' => array(
+								'stripes' => array(
+									'spacing' => array(
+										'padding' => '40px',
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$metadata = array(
+			'name'       => 'core/table',
+			'path'       => array( 'styles', 'blocks', 'core/table' ),
+			'selector'   => '.wp-block-table > table',
+			'selectors'  => array(
+				'spacing' => '.wp-block-table',
+			),
+			'variations' => array(
+				array(
+					'path'     => array( 'styles', 'blocks', 'core/table', 'variations', 'stripes' ),
+					'selector' => '.wp-block-table.is-style-stripes > table',
+				),
+			),
+		);
+
+		$actual_styles = $theme_json->get_styles_for_block( $metadata );
+		$expected      = ':root :where(.wp-block-table.is-style-stripes){padding: 40px;}';
+
+		$this->assertSameCSS( $expected, $actual_styles );
+	}
+
 	public function test_get_styles_for_block_with_style_variations_and_block_gap() {
 		register_block_style(
 			'core/group',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Extracted from https://github.com/WordPress/gutenberg/pull/77513/changes#r3136201572

When a selector for a block support is block level _but_ the default selector for that block is some inner element, such as happens with the Button block, supports using the block level selector don't work on style variations in global styles.

This PR corrects the output selector so those supports can work as expected.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In Global styles, go to Blocks > Button.
2. Click through to the "Outline" variation and change its width.
3. Add a Button set to Outline in a post, save and check it has the set width in the front end.