### PR TITLE
`defaultRenderingMode` value not respected when changed using `block_editor_settings_all`

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -472,7 +472,6 @@ function Layout( {
 			styles,
 			onNavigateToEntityRecord,
 			onNavigateToPreviousEntityRecord,
-			defaultRenderingMode: 'post-only',
 		} ),
 		[
 			settings,

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -21,7 +21,11 @@ import { store as preferencesStore } from '@wordpress/preferences';
 /**
  * Internal dependencies
  */
-import { getRenderingMode, getCurrentPost } from './selectors';
+import {
+	getRenderingMode,
+	getCurrentPost,
+	getEditorSettings,
+} from './selectors';
 import {
 	getEntityActions as _getEntityActions,
 	getEntityFields as _getEntityFields,
@@ -305,7 +309,10 @@ export const getDefaultRenderingMode = createRegistrySelector(
 			  )?.[ 'default-mode' ]
 			: undefined;
 
-		const defaultMode = defaultModePreference || postTypeDefaultMode;
+		const settingsDefaultMode =
+			getEditorSettings( state ).defaultRenderingMode;
+		const defaultMode =
+			defaultModePreference || postTypeDefaultMode || settingsDefaultMode;
 
 		// Fallback gracefully to 'post-only' when rendering mode is not supported.
 		if ( ! RENDERING_MODES.includes( defaultMode ) ) {

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -301,6 +301,11 @@ export const getDefaultRenderingMode = createRegistrySelector(
 			'core',
 			'renderingModes'
 		)?.[ theme ]?.[ postType ];
+
+		if ( RENDERING_MODES.includes( defaultModePreference ) ) {
+			return defaultModePreference;
+		}
+
 		const postTypeDefaultMode = Array.isArray(
 			postTypeEntity?.supports?.editor
 		)
@@ -309,17 +314,18 @@ export const getDefaultRenderingMode = createRegistrySelector(
 			  )?.[ 'default-mode' ]
 			: undefined;
 
-		const settingsDefaultMode =
-			getEditorSettings( state ).defaultRenderingMode;
-		const defaultMode =
-			defaultModePreference || postTypeDefaultMode || settingsDefaultMode;
-
-		// Fallback gracefully to 'post-only' when rendering mode is not supported.
-		if ( ! RENDERING_MODES.includes( defaultMode ) ) {
-			return 'post-only';
+		if ( RENDERING_MODES.includes( postTypeDefaultMode ) ) {
+			return postTypeDefaultMode;
 		}
 
-		return defaultMode;
+		const settingsDefaultMode =
+			getEditorSettings( state ).defaultRenderingMode;
+
+		if ( RENDERING_MODES.includes( settingsDefaultMode ) ) {
+			return settingsDefaultMode;
+		}
+
+		return 'post-only';
 	}
 );
 

--- a/packages/editor/src/store/test/private-selectors.js
+++ b/packages/editor/src/store/test/private-selectors.js
@@ -1,7 +1,16 @@
 /**
+ * WordPress dependencies
+ */
+import { store as coreStore } from '@wordpress/core-data';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
  * Internal dependencies
  */
-import { getPostBlocksByName } from '../private-selectors';
+import {
+	getDefaultRenderingMode,
+	getPostBlocksByName,
+} from '../private-selectors';
 
 describe( 'getPostBlocksByName', () => {
 	const state = {
@@ -74,5 +83,72 @@ describe( 'getPostBlocksByName', () => {
 			'core/heading',
 		] );
 		expect( result ).toEqual( [ 'block1', 'block2', 'block3' ] );
+	} );
+} );
+
+describe( 'getDefaultRenderingMode', () => {
+	function setupRegistry( {
+		supportsEditor = true,
+		theme = 'twentytwentyfive',
+		renderingModes = null,
+	} = {} ) {
+		getDefaultRenderingMode.registry = {
+			select: ( store ) => {
+				if ( store === coreStore ) {
+					return {
+						getPostType: () => ( {
+							supports: { editor: supportsEditor },
+						} ),
+						getCurrentTheme: () => ( { stylesheet: theme } ),
+						hasFinishedResolution: () => true,
+					};
+				}
+				if ( store === preferencesStore ) {
+					return {
+						get: () => renderingModes,
+					};
+				}
+			},
+		};
+	}
+
+	describe( 'defaultRenderingMode from editor settings', () => {
+		it( 'uses defaultRenderingMode from editor settings when no user preference is saved', () => {
+			setupRegistry( { renderingModes: null } );
+			const state = {
+				editorSettings: { defaultRenderingMode: 'template-locked' },
+			};
+
+			expect( getDefaultRenderingMode( state, 'post' ) ).toBe(
+				'template-locked'
+			);
+		} );
+
+		it( 'user preference takes priority over defaultRenderingMode from editor settings', () => {
+			setupRegistry( {
+				theme: 'twentytwentyfive',
+				renderingModes: {
+					twentytwentyfive: { post: 'template-locked' },
+				},
+			} );
+			const state = {
+				editorSettings: { defaultRenderingMode: 'post-only' },
+			};
+
+			expect( getDefaultRenderingMode( state, 'post' ) ).toBe(
+				'template-locked'
+			);
+		} );
+
+		it( 'falls back to post-only when defaultRenderingMode in settings is the default', () => {
+			setupRegistry( { renderingModes: null } );
+			const state = {
+				editorSettings: { defaultRenderingMode: 'post-only' },
+			};
+
+			expect( getDefaultRenderingMode( state, 'post' ) ).toBe(
+				'post-only'
+			);
+		} );
 	} );
 } );

--- a/packages/editor/src/store/test/private-selectors.js
+++ b/packages/editor/src/store/test/private-selectors.js
@@ -112,6 +112,36 @@ describe( 'getDefaultRenderingMode', () => {
 		};
 	}
 
+	describe( 'editor.default-mode post type support', () => {
+		it( 'default-mode from post type support should be respected when no user preference is saved', () => {
+			setupRegistry( {
+				supportsEditor: [ { 'default-mode': 'template-locked' } ],
+			} );
+			const state = {
+				editorSettings: { defaultRenderingMode: 'post-only' },
+			};
+
+			expect( getDefaultRenderingMode( state, 'post' ) ).toBe(
+				'template-locked'
+			);
+		} );
+
+		it( 'user preference should take priority over post type supports registered default-mode support', () => {
+			setupRegistry( {
+				theme: 'twentytwentyfive',
+				supportsEditor: [ { 'default-mode': 'template-locked' } ],
+				renderingModes: { twentytwentyfive: { post: 'post-only' } },
+			} );
+			const state = {
+				editorSettings: { defaultRenderingMode: 'post-only' },
+			};
+
+			expect( getDefaultRenderingMode( state, 'post' ) ).toBe(
+				'post-only'
+			);
+		} );
+	} );
+
 	describe( 'defaultRenderingMode from editor settings', () => {
 		it( 'uses defaultRenderingMode from editor settings when no user preference is saved', () => {
 			setupRegistry( { renderingModes: null } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The `defaultRenderingMode` editor setting (filterable via `block_editor_settings_all`) is never consulted by `getDefaultRenderingMode`,  making it impossible to control the initial rendering mode from PHP.

The selector only checks user preferences and post type supports, then fell back to the hardcoded `'post-only'`.

<!-- In a few words, what is the PR actually doing? -->

## Why?
There's no way for a plugin, theme, or custom code to control the default behavior. In my case, I was trying to specify `template-locked` as the default for all users on a site as it's easier for them to edit the content when it's shown in the context of the template with the site's full layout.

`defaultRenderinMode` implies that the value specified will be used as the default, but it's actually ignored (with the exception of the "Go back" snackbar.

## How?
This adds `editorSettings.defaultRenderingMode` as a third tier in the fallback chain: user preference, post type supports, settings, `'post-only'`.

User-saved preferences (set when clicking the "Show template" toggle) are still respected and take priority.

Additional tests are included to cover the scenarios where `add_post_type_support( 'post_type', 'editor', [ 'default-mode' => 'template-locked' ] )` was used to register a default mode for a specific post type.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Sonnet 4.6
Used for: Analyzing the problem and creating the initial draft of the PR.