### PR TITLE
Media Upload Modal: Fix pagination and search

### DIFF
--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -70,14 +70,19 @@ const NOTICES_CONTEXT = 'media-modal';
 // Notice ID - reused for all upload-related notices to prevent flooding
 const NOTICE_ID_UPLOAD_PROGRESS = 'media-modal-upload-progress';
 
+type ViewQueryParams = Pick< View, 'page' | 'search' >;
+
+const defaultQueryParams: ViewQueryParams = {
+	page: 1,
+	search: '',
+};
+
 const defaultView: View = {
 	type: LAYOUT_PICKER_GRID,
 	fields: [],
 	showTitle: false,
 	titleField: 'title',
 	mediaField: 'media_thumbnail',
-	search: '',
-	page: 1,
 	perPage: 50,
 	filters: [],
 	layout: {
@@ -230,6 +235,9 @@ export function MediaUploadModal( {
 		useDispatch( noticesStore );
 	const invalidateAttachmentResolutions =
 		useInvalidateAttachmentResolutions();
+	const [ queryParams, setQueryParams ] = useState< ViewQueryParams >(
+		() => defaultQueryParams
+	);
 
 	// Persist view configuration across sessions via the preferences store.
 	const { view, updateView, isModified, resetToDefault } = useView( {
@@ -237,7 +245,21 @@ export function MediaUploadModal( {
 		name: 'attachment',
 		slug: 'media-modal',
 		defaultView,
+		queryParams,
+		onChangeQueryParams: setQueryParams,
 	} );
+
+	// Normalize undefined transient DataViews values so they do not persist as modified modal preferences.
+	const handleChangeView = useCallback(
+		( nextView: View ) => {
+			const normalizedView = { ...nextView };
+			if ( normalizedView.startPosition === undefined ) {
+				delete normalizedView.startPosition;
+			}
+			updateView( normalizedView );
+		},
+		[ updateView ]
+	);
 
 	// Build query args based on view properties, similar to PostList
 	const queryArgs = useMemo( () => {
@@ -581,7 +603,7 @@ export function MediaUploadModal( {
 				data={ mediaRecords || [] }
 				fields={ fields }
 				view={ view }
-				onChangeView={ updateView }
+				onChangeView={ handleChangeView }
 				actions={ actions }
 				selection={ selection }
 				onChangeSelection={ setSelection }

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -466,6 +466,12 @@ export function MediaUploadModal( {
 		onClose?.();
 	}, [ removeAllNotices, onClose ] );
 
+	useEffect( () => {
+		if ( ! isOpen ) {
+			setQueryParams( defaultQueryParams );
+		}
+	}, [ isOpen ] );
+
 	// Use onUpload if provided, otherwise fall back to uploadMedia
 	const handleUpload = onUpload || uploadMedia;
 

--- a/packages/media-utils/src/components/media-upload-modal/test/index.test.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/test/index.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+import { privateApis as coreDataPrivateApis } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import { MediaUploadModal } from '../index';
+import { unlock } from '../../../lock-unlock';
+
+const preferenceKey = 'dataviews-postType-attachment-media-modal';
+
+jest.mock( '@wordpress/core-data', () => {
+	const { __dangerousOptInToUnstableAPIsOnlyForCoreModules } =
+		jest.requireActual( '@wordpress/private-apis' );
+	const { lock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+		'@wordpress/core-data'
+	);
+	// Keep the private API contract real while replacing only the data hook.
+	const privateApis = {};
+	lock( privateApis, {
+		useEntityRecordsWithPermissions: jest.fn(),
+	} );
+
+	return {
+		privateApis,
+		store: {
+			name: 'core',
+		},
+	};
+} );
+
+const mockUseEntityRecordsWithPermissions = unlock( coreDataPrivateApis )
+	.useEntityRecordsWithPermissions as jest.Mock;
+
+function renderModal() {
+	const registry = createRegistry();
+	registry.register( noticesStore );
+	registry.register( preferencesStore );
+
+	const view = render(
+		<RegistryProvider value={ registry }>
+			<MediaUploadModal
+				isOpen
+				onSelect={ jest.fn() }
+				onClose={ jest.fn() }
+			/>
+		</RegistryProvider>
+	);
+
+	return { ...view, registry };
+}
+
+describe( 'MediaUploadModal', () => {
+	beforeEach( () => {
+		mockUseEntityRecordsWithPermissions.mockReturnValue( {
+			records: [],
+			isResolving: false,
+			totalItems: 100,
+			totalPages: 2,
+		} );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'updates the media query when the picker changes page', async () => {
+		const user = userEvent.setup();
+		const { registry } = renderModal();
+
+		expect( mockUseEntityRecordsWithPermissions ).toHaveBeenLastCalledWith(
+			'postType',
+			'attachment',
+			expect.objectContaining( {
+				page: 1,
+			} )
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Next page' } ) );
+
+		await waitFor( () => {
+			expect(
+				mockUseEntityRecordsWithPermissions
+			).toHaveBeenLastCalledWith(
+				'postType',
+				'attachment',
+				expect.objectContaining( {
+					page: 2,
+				} )
+			);
+		} );
+		expect(
+			registry
+				.select( preferencesStore )
+				.get( 'core/views', preferenceKey )
+		).toBeUndefined();
+	} );
+
+	it( 'updates the media query when the picker changes search', async () => {
+		const user = userEvent.setup();
+		const { registry } = renderModal();
+
+		await user.type(
+			screen.getByRole( 'searchbox', { name: 'Search media' } ),
+			'cat'
+		);
+
+		await waitFor( () => {
+			expect(
+				mockUseEntityRecordsWithPermissions
+			).toHaveBeenLastCalledWith(
+				'postType',
+				'attachment',
+				expect.objectContaining( {
+					page: 1,
+					search: 'cat',
+				} )
+			);
+		} );
+		expect(
+			registry
+				.select( preferencesStore )
+				.get( 'core/views', preferenceKey )
+		).toBeUndefined();
+	} );
+} );

--- a/packages/media-utils/src/components/media-upload-modal/test/index.test.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/test/index.test.tsx
@@ -44,22 +44,37 @@ jest.mock( '@wordpress/core-data', () => {
 const mockUseEntityRecordsWithPermissions = unlock( coreDataPrivateApis )
 	.useEntityRecordsWithPermissions as jest.Mock;
 
-function renderModal() {
+function renderModal( { isOpen = true } = {} ) {
 	const registry = createRegistry();
 	registry.register( noticesStore );
 	registry.register( preferencesStore );
 
+	const onSelect = jest.fn();
+	const onClose = jest.fn();
+
 	const view = render(
 		<RegistryProvider value={ registry }>
 			<MediaUploadModal
-				isOpen
-				onSelect={ jest.fn() }
-				onClose={ jest.fn() }
+				isOpen={ isOpen }
+				onSelect={ onSelect }
+				onClose={ onClose }
 			/>
 		</RegistryProvider>
 	);
 
-	return { ...view, registry };
+	const rerender = ( props: { isOpen: boolean } ) => {
+		view.rerender(
+			<RegistryProvider value={ registry }>
+				<MediaUploadModal
+					{ ...props }
+					onSelect={ onSelect }
+					onClose={ onClose }
+				/>
+			</RegistryProvider>
+		);
+	};
+
+	return { ...view, registry, rerender };
 }
 
 describe( 'MediaUploadModal', () => {
@@ -74,6 +89,39 @@ describe( 'MediaUploadModal', () => {
 
 	afterEach( () => {
 		jest.clearAllMocks();
+	} );
+
+	it( 'resets page and search when the modal is closed and reopened', async () => {
+		const user = userEvent.setup();
+		const { rerender } = renderModal();
+
+		await user.click( screen.getByRole( 'button', { name: 'Next page' } ) );
+
+		await waitFor( () => {
+			expect(
+				mockUseEntityRecordsWithPermissions
+			).toHaveBeenLastCalledWith(
+				'postType',
+				'attachment',
+				expect.objectContaining( { page: 2 } )
+			);
+		} );
+
+		// Close the modal.
+		rerender( { isOpen: false } );
+
+		// Reopen the modal.
+		rerender( { isOpen: true } );
+
+		await waitFor( () => {
+			expect(
+				mockUseEntityRecordsWithPermissions
+			).toHaveBeenLastCalledWith(
+				'postType',
+				'attachment',
+				expect.objectContaining( { page: 1, search: '' } )
+			);
+		} );
 	} );
 
 	it( 'updates the media query when the picker changes page', async () => {


### PR DESCRIPTION
## What?

Follows:

* #77288

In the media modal experiment, fix pagination and search. In #77288 we added view persistence, but seemed to have broken pagination and search in the process.

The reason is that `useView` expects to handle `queryParams` (and specifically `page` and `search`) separately so that they're not included with the persistent view config. Since we weren't passing in `queryParams`, the values were being stripped, which meant that the Next / Prev buttons, etc weren't working in the modal.

## How?

* Use local state to track non-persisted query state and pass this in to `useView` along with a callback setter.
* Add some minimal tests to cover pagination and search that these actions result in updating the call to get entity records with the expected value. This isn't as thorough as real e2es but means we're at least adding regression tests for this part of the behaviour.

## Testing Instructions

Enable the media upload modal experiment:

<img width="642" height="82" alt="image" src="https://github.com/user-attachments/assets/47cd7c8e-68e1-4935-800f-72b3eaeaec32" />

* On a site with enough media items to result in pagination, go to edit a post or page and add a featured image.
* Try paginating or searching and it should work without affecting the persisted view config (i.e. there should be no blue dot on the cog icon at the top right)
* Change other config like density or number of items, and it _should_ add the blue dot / make the Reset button available
* Close the modal and open it again and it should remember the persisted values

## Screenshots or screencast <!-- if applicable -->

This should work:

https://github.com/user-attachments/assets/44240f27-bee2-4602-b5fa-e9b68b5a00b7

## Use of AI Tools

Codex and Claude Code to verify Codex's fix and tests