### PR TITLE
Block Editor: Clarify logic for 'directInsert' inner blocks setting

### DIFF
--- a/docs/how-to-guides/block-tutorial/nested-blocks-inner-blocks.md
+++ b/docs/how-to-guides/block-tutorial/nested-blocks-inner-blocks.md
@@ -71,7 +71,9 @@ By default `InnerBlocks` opens a list of permitted blocks via `allowedBlocks` wh
 />
 ```
 
-This behavior is disabled until the `directInsert` prop is set to `true`. This allows you to specify conditions for when the default block should or should not be inserted.
+Set `directInsert` to `true` to force the appender to insert the `defaultBlock` immediately, bypassing the inserter dropdown, including any registered inserter variations of that block type. Leave it unset (or `false`) to let the appender open the inserter so users can pick a variation.
+
+Note: redundant when `allowedBlocks` resolves to a single block type with no variations, the appender already inserts directly.
 
 ## Template
 

--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -205,4 +205,8 @@ const DEFAULT_BLOCK = { name: 'core/paragraph', attributes: { content: 'Lorem ip
 ### `directInsert`
 
 - **Type:** `Boolean`
-- **Default:** - `undefined`. Determines whether the default block should be inserted directly into the InnerBlocks area by the block appender.
+- **Default:** `undefined`.
+
+When `true`, the appender inserts `defaultBlock` directly and skips the inserter dropdown, **including any registered inserter variations** of that block type. Use this to opt out of the variation picker; otherwise leave unset.
+
+Note: redundant when `allowedBlocks` resolves to a single block type with no variations, the appender already inserts directly.


### PR DESCRIPTION
## What?
Related #77858.

PR clarifies docs for `directInsert` inner blocks setting and how it works based on other block configs.

## Testing Instructions
Confirm updated docs make sense.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Grammarly, I'm bad at grammar.
