### PR TITLE
Media editor modal: name landmark regions and add panel headings

### DIFF
--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -99,7 +99,7 @@ export default function MediaEditorCropPanel( {
 
 	return (
 		<Stack direction="column" gap="md">
-			<VisuallyHidden render={ <h3 /> }>
+			<VisuallyHidden render={ <h2 /> }>
 				{ __( 'Crop options' ) }
 			</VisuallyHidden>
 			<div role="presentation" { ...zoomGestureHandlers }>

--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -6,7 +6,7 @@ import {
 	SelectControl,
 	ToggleControl,
 } from '@wordpress/components';
-import { Stack } from '@wordpress/ui';
+import { Stack, VisuallyHidden } from '@wordpress/ui';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -99,6 +99,9 @@ export default function MediaEditorCropPanel( {
 
 	return (
 		<Stack direction="column" gap="md">
+			<VisuallyHidden render={ <h3 /> }>
+				{ __( 'Crop options' ) }
+			</VisuallyHidden>
 			<div role="presentation" { ...zoomGestureHandlers }>
 				<RangeControl
 					__next40pxDefaultSize

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -537,6 +537,13 @@ function MediaEditorModalContent( {
 						</Tabs>
 						<InterfaceSkeleton
 							className="media-editor-modal__skeleton"
+							labels={ {
+								body: isImage
+									? __( 'Image editor' )
+									: __( 'Media preview' ),
+								sidebar: __( 'Media details' ),
+								footer: __( 'Image editing tools' ),
+							} }
 							content={
 								<div className="media-editor-modal__canvas">
 									{ isImage ? (

--- a/packages/media-editor/src/components/media-form/index.tsx
+++ b/packages/media-editor/src/components/media-form/index.tsx
@@ -76,7 +76,7 @@ export default function MediaForm( {
 	return (
 		<div className="media-editor-form">
 			<VStack spacing={ 4 }>
-				<VisuallyHidden render={ <h3 /> }>
+				<VisuallyHidden render={ <h2 /> }>
 					{ __( 'Media details' ) }
 				</VisuallyHidden>
 				{ header }

--- a/packages/media-editor/src/components/media-form/index.tsx
+++ b/packages/media-editor/src/components/media-form/index.tsx
@@ -4,6 +4,8 @@
 import { DataForm } from '@wordpress/dataviews';
 import type { Form, Field } from '@wordpress/dataviews';
 import { Spinner, __experimentalVStack as VStack } from '@wordpress/components';
+import { VisuallyHidden } from '@wordpress/ui';
+import { __ } from '@wordpress/i18n';
 import type { ReactNode } from 'react';
 
 /**
@@ -74,6 +76,9 @@ export default function MediaForm( {
 	return (
 		<div className="media-editor-form">
 			<VStack spacing={ 4 }>
+				<VisuallyHidden render={ <h3 /> }>
+					{ __( 'Media details' ) }
+				</VisuallyHidden>
 				{ header }
 				<DataForm
 					data={ media }


### PR DESCRIPTION
## Summary

The media editor modal already exposes three landmark regions through `InterfaceSkeleton`, but they use the post editor's default names — "Content", "Settings", "Footer" — which don't match this dialog. The sidebar's heading is also fixed at "Details" even when the Crop tab is open.

This PR:

- Passes a `labels` prop to `InterfaceSkeleton` so the regions are named "Image editor" (or "Media preview" for non-image media), "Media details", and "Image editing tools".
- Adds a hidden `<h3>` to each sidebar panel ("Crop options", "Media details") so the heading outline matches the active tab.

`VisuallyHidden` is imported from `@wordpress/ui` per the `use-recommended-components` rule. No new dependencies.

A possible follow-up: the cropper canvas uses `role="group"`, which isn't a landmark. Promoting it to `role="region"` would expose it directly to landmark navigation, but that file is shared with the standalone image editor, so it's worth deciding on separately.

## Test plan

- [ ] Open the modal on an image. Confirm the regions are named "Image editor", "Media details", and "Image editing tools".
- [ ] Confirm the active panel's `<h3>` ("Crop options" or "Media details") shows under "Edit media".
- [ ] Open a non-image attachment. Confirm the canvas region is named "Media preview".
- [ ] Confirm the sidebar layout looks unchanged.