### PR TITLE
Block Editor: Fix target block for copying direct insert block attributes

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -230,6 +230,7 @@ export default compose( [
 				hasInserterItems,
 				getAllowedBlocks,
 				getDirectInsertBlock,
+				getBlockListSettings,
 			} = select( blockEditorStore );
 
 			const { getBlockVariations, getBlockType } = select( blocksStore );
@@ -238,9 +239,9 @@ export default compose( [
 				rootClientId || getBlockRootClientId( clientId ) || undefined;
 
 			const allowedBlocks = getAllowedBlocks( rootClientId );
-
 			const directInsertBlock =
 				shouldDirectInsert && getDirectInsertBlock( rootClientId );
+			const { defaultBlock } = getBlockListSettings( rootClientId ) ?? {};
 
 			const hasSingleBlockType =
 				allowedBlocks?.length === 1 &&
@@ -250,6 +251,17 @@ export default compose( [
 			let allowedBlockType = false;
 			if ( hasSingleBlockType ) {
 				allowedBlockType = allowedBlocks[ 0 ];
+			}
+
+			// The block this appender will insert when in single-click mode.
+			// Prefer the registered `defaultBlock`; fall back to the only allowed
+			// block when the parent restricts inner blocks to a single type.
+			let blockToInsert = directInsertBlock || null;
+			if ( ! blockToInsert && hasSingleBlockType ) {
+				blockToInsert =
+					defaultBlock?.name === allowedBlockType.name
+						? defaultBlock
+						: { name: allowedBlockType.name };
 			}
 
 			const defaultBlockType = directInsertBlock
@@ -266,6 +278,7 @@ export default compose( [
 				blockTitle: allowedBlockType ? allowedBlockType.title : '',
 				allowedBlockType,
 				directInsertBlock,
+				blockToInsert,
 				appenderLabel,
 				rootClientId,
 			};
@@ -278,14 +291,13 @@ export default compose( [
 					rootClientId,
 					clientId,
 					isAppender,
-					hasSingleBlockType,
 					allowedBlockType,
-					directInsertBlock,
+					blockToInsert,
 					onSelectOrClose,
 					selectBlockOnInsert,
 				} = ownProps;
 
-				if ( ! hasSingleBlockType && ! directInsertBlock ) {
+				if ( ! blockToInsert ) {
 					return;
 				}
 
@@ -314,10 +326,7 @@ export default compose( [
 									parentBlock.innerBlocks.length - 1
 								];
 
-							if (
-								directInsertBlock &&
-								directInsertBlock?.name === lastInnerBlock.name
-							) {
+							if ( blockToInsert.name === lastInnerBlock.name ) {
 								adjacentAttributes = lastInnerBlock.attributes;
 							}
 						}
@@ -375,33 +384,27 @@ export default compose( [
 
 				const { insertBlock } = dispatch( blockEditorStore );
 
-				let blockToInsert;
-
-				// Attempt to augment the directInsertBlock with attributes from an adjacent block.
+				// Attempt to augment the inserted block with attributes from an adjacent block.
 				// This ensures styling from nearby blocks is preserved in the newly inserted block.
 				// See: https://github.com/WordPress/gutenberg/issues/37904
-				if ( directInsertBlock ) {
-					const newAttributes = getAdjacentBlockAttributes(
-						directInsertBlock.attributesToCopy
-					);
+				const newAttributes = getAdjacentBlockAttributes(
+					blockToInsert.attributesToCopy
+				);
 
-					blockToInsert = createBlock( directInsertBlock.name, {
-						...( directInsertBlock.attributes || {} ),
-						...newAttributes,
-					} );
-				} else {
-					blockToInsert = createBlock( allowedBlockType.name );
-				}
+				const newBlock = createBlock( blockToInsert.name, {
+					...( blockToInsert.attributes || {} ),
+					...newAttributes,
+				} );
 
 				insertBlock(
-					blockToInsert,
+					newBlock,
 					getInsertionIndex(),
 					rootClientId,
 					selectBlockOnInsert
 				);
 
 				if ( onSelectOrClose ) {
-					onSelectOrClose( blockToInsert );
+					onSelectOrClose( newBlock );
 				}
 
 				const message = sprintf(

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -144,7 +144,6 @@ class Inserter extends Component {
 			clientId,
 			isAppender,
 			showInserterHelpPanel,
-
 			// This prop is experimental to give some time for the quick inserter to mature
 			// Feel free to make them stable after a few releases.
 			__experimentalIsQuick: isQuick,
@@ -194,13 +193,13 @@ class Inserter extends Component {
 		const {
 			position,
 			hasSingleBlockType,
-			directInsertBlock,
+			blockToInsert,
 			insertOnlyAllowedBlock,
 			__experimentalIsQuick: isQuick,
 			onSelectOrClose,
 		} = this.props;
 
-		if ( hasSingleBlockType || directInsertBlock ) {
+		if ( hasSingleBlockType || blockToInsert ) {
 			return this.renderToggle( { onToggle: insertOnlyAllowedBlock } );
 		}
 
@@ -232,7 +231,6 @@ export default compose( [
 				getDirectInsertBlock,
 				getBlockListSettings,
 			} = select( blockEditorStore );
-
 			const { getBlockVariations, getBlockType } = select( blocksStore );
 
 			rootClientId =
@@ -247,21 +245,19 @@ export default compose( [
 				allowedBlocks?.length === 1 &&
 				getBlockVariations( allowedBlocks[ 0 ].name, 'inserter' )
 					?.length === 0;
+			const allowedBlockType = hasSingleBlockType
+				? allowedBlocks[ 0 ]
+				: null;
 
-			let allowedBlockType = false;
-			if ( hasSingleBlockType ) {
-				allowedBlockType = allowedBlocks[ 0 ];
-			}
-
-			// The block this appender will insert when in single-click mode.
-			// Prefer the registered `defaultBlock`; fall back to the only allowed
-			// block when the parent restricts inner blocks to a single type.
+			// Single-block-type parents get adjacent-attribute copying
+			// without needing to set `directInsert: true`.
 			let blockToInsert = directInsertBlock || null;
-			if ( ! blockToInsert && hasSingleBlockType ) {
-				blockToInsert =
-					defaultBlock?.name === allowedBlockType.name
-						? defaultBlock
-						: { name: allowedBlockType.name };
+			if (
+				! blockToInsert &&
+				hasSingleBlockType &&
+				defaultBlock?.name === allowedBlockType.name
+			) {
+				blockToInsert = defaultBlock;
 			}
 
 			const defaultBlockType = directInsertBlock
@@ -277,7 +273,6 @@ export default compose( [
 				hasSingleBlockType,
 				blockTitle: allowedBlockType ? allowedBlockType.title : '',
 				allowedBlockType,
-				directInsertBlock,
 				blockToInsert,
 				appenderLabel,
 				rootClientId,
@@ -291,68 +286,59 @@ export default compose( [
 					rootClientId,
 					clientId,
 					isAppender,
+					hasSingleBlockType,
 					allowedBlockType,
 					blockToInsert,
 					onSelectOrClose,
 					selectBlockOnInsert,
 				} = ownProps;
 
-				if ( ! blockToInsert ) {
+				if ( ! hasSingleBlockType && ! blockToInsert ) {
 					return;
 				}
 
-				function getAdjacentBlockAttributes( attributesToCopy ) {
-					const { getBlock, getPreviousBlockClientId } =
-						select( blockEditorStore );
+				const blockName = blockToInsert?.name ?? allowedBlockType.name;
 
-					if (
-						! attributesToCopy ||
-						( ! clientId && ! rootClientId )
-					) {
+				function getAdjacentBlockAttributes( attributesToCopy ) {
+					if ( ! attributesToCopy?.length ) {
 						return {};
 					}
 
-					const result = {};
-					let adjacentAttributes = {};
+					const { getBlock, getPreviousBlockClientId } =
+						select( blockEditorStore );
 
-					// If there is no clientId, then attempt to get attributes
-					// from the last block within innerBlocks of the root block.
-					if ( ! clientId ) {
-						const parentBlock = getBlock( rootClientId );
-
-						if ( parentBlock?.innerBlocks?.length ) {
-							const lastInnerBlock =
-								parentBlock.innerBlocks[
-									parentBlock.innerBlocks.length - 1
-								];
-
-							if ( blockToInsert.name === lastInnerBlock.name ) {
-								adjacentAttributes = lastInnerBlock.attributes;
-							}
-						}
-					} else {
-						// Otherwise, attempt to get attributes from the
-						// previous block relative to the current clientId.
+					// Find the adjacent block of the same type whose attributes
+					// should be copied: previous sibling when inserting next to
+					// an existing block, otherwise the last child of the root.
+					let adjacentAttributes;
+					if ( clientId ) {
 						const currentBlock = getBlock( clientId );
 						const previousBlock = getBlock(
 							getPreviousBlockClientId( clientId )
 						);
-
 						if ( currentBlock?.name === previousBlock?.name ) {
-							adjacentAttributes =
-								previousBlock?.attributes || {};
+							adjacentAttributes = previousBlock?.attributes;
+						}
+					} else if ( rootClientId ) {
+						const lastInnerBlock =
+							getBlock( rootClientId )?.innerBlocks?.at( -1 );
+						if ( lastInnerBlock?.name === blockName ) {
+							adjacentAttributes = lastInnerBlock.attributes;
 						}
 					}
 
-					// Copy over only those attributes flagged to be copied.
-					attributesToCopy.forEach( ( attribute ) => {
-						if ( adjacentAttributes.hasOwnProperty( attribute ) ) {
-							result[ attribute ] =
-								adjacentAttributes[ attribute ];
-						}
-					} );
+					if ( ! adjacentAttributes ) {
+						return {};
+					}
 
-					return result;
+					return Object.fromEntries(
+						attributesToCopy
+							.filter( ( attr ) => attr in adjacentAttributes )
+							.map( ( attr ) => [
+								attr,
+								adjacentAttributes[ attr ],
+							] )
+					);
 				}
 
 				function getInsertionIndex() {
@@ -388,11 +374,11 @@ export default compose( [
 				// This ensures styling from nearby blocks is preserved in the newly inserted block.
 				// See: https://github.com/WordPress/gutenberg/issues/37904
 				const newAttributes = getAdjacentBlockAttributes(
-					blockToInsert.attributesToCopy
+					blockToInsert?.attributesToCopy
 				);
 
-				const newBlock = createBlock( blockToInsert.name, {
-					...( blockToInsert.attributes || {} ),
+				const newBlock = createBlock( blockName, {
+					...( blockToInsert?.attributes || {} ),
 					...newAttributes,
 				} );
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1776,9 +1776,9 @@ export const insertBeforeBlock =
 		const rootClientId = select.getBlockRootClientId( clientId );
 
 		const blockIndex = select.getBlockIndex( clientId );
-		const directInsertBlock = rootClientId
-			? select.getDirectInsertBlock( rootClientId )
-			: null;
+		const { defaultBlock: directInsertBlock } = rootClientId
+			? select.getBlockListSettings( rootClientId ) ?? {}
+			: {};
 
 		if ( ! directInsertBlock ) {
 			return dispatch.insertDefaultBlock( {}, rootClientId, blockIndex );
@@ -1815,9 +1815,9 @@ export const insertAfterBlock =
 		const rootClientId = select.getBlockRootClientId( clientId );
 
 		const blockIndex = select.getBlockIndex( clientId );
-		const directInsertBlock = rootClientId
-			? select.getDirectInsertBlock( rootClientId )
-			: null;
+		const { defaultBlock: directInsertBlock } = rootClientId
+			? select.getBlockListSettings( rootClientId ) ?? {}
+			: {};
 
 		if ( ! directInsertBlock ) {
 			return dispatch.insertDefaultBlock(

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -266,79 +266,6 @@ test.describe( 'Buttons', () => {
 		] );
 	} );
 
-	test.describe( 'Width support', () => {
-		test.beforeAll( async ( { requestUtils } ) => {
-			await requestUtils.activateTheme( 'emptytheme' );
-		} );
-
-		test.beforeEach( async ( { admin } ) => {
-			await admin.createNewPost();
-		} );
-
-		test.afterAll( async ( { requestUtils } ) => {
-			await requestUtils.activateTheme( 'twentytwentyone' );
-		} );
-
-		test( 'can resize width', async ( { editor, page } ) => {
-			// Mock spacing units to include % for the width control
-			await page.waitForFunction( () => window?.wp?.data );
-			await page.evaluate( () => {
-				const settings = window.wp.data
-					.select( 'core/block-editor' )
-					.getSettings();
-				window.wp.data.dispatch( 'core/block-editor' ).updateSettings( {
-					...settings,
-					spacing: { units: [ 'px', '%', 'em', 'rem', 'vh', 'vw' ] },
-				} );
-			} );
-
-			await editor.insertBlock( { name: 'core/buttons' } );
-			await page.keyboard.type( 'Content' );
-
-			// Select the inner Button block (not the outer Buttons container)
-			const buttonBlock = editor.canvas
-				.getByRole( 'document', {
-					name: 'Block: Button',
-					exact: true,
-				} )
-				.filter( { hasText: 'Content' } );
-			await editor.selectBlocks( buttonBlock );
-
-			await editor.openDocumentSettingsSidebar();
-
-			const settingsPanel = page.getByRole( 'region', {
-				name: 'Editor settings',
-			} );
-
-			// Switch from preset slider to custom value input
-			await settingsPanel
-				.getByRole( 'group', { name: 'Width' } )
-				.getByLabel( 'Set custom value' )
-				.click();
-
-			// Change the unit from px to % using the combobox
-			await settingsPanel
-				.getByRole( 'combobox', { name: 'Select unit' } )
-				.first()
-				.selectOption( '%' );
-
-			// Set the width value
-			await settingsPanel
-				.getByRole( 'spinbutton', { name: 'Width', exact: true } )
-				.fill( '25' );
-
-			// Check the content.
-			const content = await editor.getEditedPostContent();
-			expect( content ).toBe(
-				`<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"style":{"dimensions":{"width":"25%"}}} -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Content</a></div>
-<!-- /wp:button --></div>
-<!-- /wp:buttons -->`
-			);
-		} );
-	} );
-
 	test( 'can apply named colors', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'core/buttons' } );
 		await page.keyboard.type( 'Content' );
@@ -448,6 +375,131 @@ test.describe( 'Buttons', () => {
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`
 		);
+	} );
+
+	test( 'copies attributes when inserting a sibling via the appender', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/buttons' } );
+		await page.keyboard.type( 'Content' );
+		await editor.openDocumentSettingsSidebar();
+
+		// Apply named colors to the first button.
+		const settings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settings.getByRole( 'button', { name: 'Text' } ).click();
+		await page.getByRole( 'option', { name: 'Cyan bluish gray' } ).click();
+		await settings.getByRole( 'button', { name: 'Background' } ).click();
+		await page.getByRole( 'option', { name: 'Vivid red' } ).click();
+
+		// Select the parent Buttons block so the appender is visible.
+		await editor.selectBlocks(
+			editor.canvas.getByRole( 'document', { name: 'Block: Buttons' } )
+		);
+
+		// Insert a sibling via the appender; should auto-insert a button.
+		await editor.canvas
+			.getByRole( 'button', { name: 'Add button' } )
+			.click();
+
+		// The new button should inherit color attributes from its sibling.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/buttons',
+				innerBlocks: [
+					{
+						name: 'core/button',
+						attributes: {
+							text: 'Content',
+							backgroundColor: 'vivid-red',
+							textColor: 'cyan-bluish-gray',
+						},
+					},
+					{
+						name: 'core/button',
+						attributes: {
+							backgroundColor: 'vivid-red',
+							textColor: 'cyan-bluish-gray',
+						},
+					},
+				],
+			},
+		] );
+	} );
+
+	test.describe( 'Width support', () => {
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activateTheme( 'emptytheme' );
+		} );
+
+		test.beforeEach( async ( { admin } ) => {
+			await admin.createNewPost();
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.activateTheme( 'twentytwentyone' );
+		} );
+
+		test( 'can resize width', async ( { editor, page } ) => {
+			// Mock spacing units to include % for the width control
+			await page.waitForFunction( () => window?.wp?.data );
+			await page.evaluate( () => {
+				const settings = window.wp.data
+					.select( 'core/block-editor' )
+					.getSettings();
+				window.wp.data.dispatch( 'core/block-editor' ).updateSettings( {
+					...settings,
+					spacing: { units: [ 'px', '%', 'em', 'rem', 'vh', 'vw' ] },
+				} );
+			} );
+
+			await editor.insertBlock( { name: 'core/buttons' } );
+			await page.keyboard.type( 'Content' );
+
+			// Select the inner Button block (not the outer Buttons container)
+			const buttonBlock = editor.canvas
+				.getByRole( 'document', {
+					name: 'Block: Button',
+					exact: true,
+				} )
+				.filter( { hasText: 'Content' } );
+			await editor.selectBlocks( buttonBlock );
+
+			await editor.openDocumentSettingsSidebar();
+
+			const settingsPanel = page.getByRole( 'region', {
+				name: 'Editor settings',
+			} );
+
+			// Switch from preset slider to custom value input
+			await settingsPanel
+				.getByRole( 'group', { name: 'Width' } )
+				.getByLabel( 'Set custom value' )
+				.click();
+
+			// Change the unit from px to % using the combobox
+			await settingsPanel
+				.getByRole( 'combobox', { name: 'Select unit' } )
+				.first()
+				.selectOption( '%' );
+
+			// Set the width value
+			await settingsPanel
+				.getByRole( 'spinbutton', { name: 'Width', exact: true } )
+				.fill( '25' );
+
+			// Check the content.
+			const content = await editor.getEditedPostContent();
+			expect( content ).toBe(
+				`<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"style":{"dimensions":{"width":"25%"}}} -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Content</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->`
+			);
+		} );
 	} );
 
 	test.describe( 'Block transforms', () => {


### PR DESCRIPTION
## What?
Related #77858.
Improves https://github.com/WordPress/gutenberg/pull/53783#discussion_r1322326730.
Supersedes https://github.com/WordPress/gutenberg/pull/54409.

The Inserter now automatically copies the attributes of adjacent blocks (as specified in `defaultBlock.attributesToCopy`) when direct insertion is enabled for a specific allowed block type. This change means that the parent no longer needs to set `directInsert: true` to enable this functionality. 

Previously, direct insertion would skip transferring attributes such as color and font from the previous block, requiring manual checks for `directInsert` to work properly. Now, all validation and checks are managed internally by the Inserter.

`insertBeforeBlock` / `insertAfterBlock` now read `defaultBlock` from `getBlockListSettings` directly instead of going through `getDirectInsertBlock`. This means attribute copying (e.g. color, font from the reference block) happens whenever the parent declares a `defaultBlock` - the explicit `directInsert: true` opt-in is no longer required, matching the inserter's behavior.

The code is easier to review with [white space disabled](https://github.com/WordPress/gutenberg/pull/77877/changes?w=0).

## Testing Instructions
1. Comment out `directInsert` for the Buttons block.
2. Create a post and add buttons.
3. Set some styling for a button.
4. Select the parent block, so the inserter is visible.
5. Insert new sibling blocks.
6. Confirm their styles are the same.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/811a44f0-f155-4874-aa37-b399cda66eb1

## Use of AI Tools

Claude for some final cleanups.
