### PR TITLE
Media Editor Modal: Use shift modifier to adjust keyboard pan speed

### DIFF
--- a/packages/media-editor/src/components/media-editor-keyboard-shortcuts-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-keyboard-shortcuts-modal/index.tsx
@@ -66,7 +66,7 @@ const SHORTCUTS: ShortcutEntry[] = [
 		keyCombination: { character: 'V' },
 	},
 	{
-		description: __( 'Resize crop (large step)' ),
+		description: __( 'Pan or resize crop (large step)' ),
 		keyCombination: {
 			modifier: 'shift',
 			character: [ '↑', '↓', '←', '→' ],

--- a/packages/media-editor/src/image-editor/core/constants.ts
+++ b/packages/media-editor/src/image-editor/core/constants.ts
@@ -17,6 +17,12 @@ export const MAX_ZOOM = 10;
  */
 export const DEFAULT_WHEEL_ZOOM_SPEED = 0.0025;
 
+/** Fine step for keyboard-driven cropper movement, in normalized coordinates. */
+export const DEFAULT_KEYBOARD_STEP = 0.01;
+
+/** Coarse keyboard movement multiplier when Shift is held. */
+export const KEYBOARD_SHIFT_STEP_MULTIPLIER = 10;
+
 /**
  * Maximum free-rotation offset in degrees from the nearest 90° step.
  * The rotation slider allows ±45° around the current cardinal angle.

--- a/packages/media-editor/src/image-editor/core/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/interaction-controller.ts
@@ -2,7 +2,13 @@
  * Internal dependencies
  */
 import type { CropperState, NormalizedPoint, Size } from './types';
-import { DEFAULT_WHEEL_ZOOM_SPEED, MIN_ZOOM, MAX_ZOOM } from './constants';
+import {
+	DEFAULT_KEYBOARD_STEP,
+	DEFAULT_WHEEL_ZOOM_SPEED,
+	KEYBOARD_SHIFT_STEP_MULTIPLIER,
+	MIN_ZOOM,
+	MAX_ZOOM,
+} from './constants';
 import { restrictPanZoom } from './containment';
 
 /** Time window for detecting a double-tap gesture (ms). */
@@ -88,7 +94,10 @@ export interface InteractionControllerOptions {
 	maxZoom?: number;
 	/** Zoom speed multiplier for wheel events. Defaults to 0.0025. Read lazily. */
 	zoomSpeed?: number;
-	/** Pan step size in normalized coords for keyboard events. Defaults to 0.05. Read lazily. */
+	/**
+	 * Pan step size in normalized coords for keyboard events.
+	 * Defaults to 0.01. Read lazily. Shift multiplies it by 10.
+	 */
 	keyboardStep?: number;
 	/** Zoom level for double-tap zoom. Defaults to 2. Read lazily. */
 	doubleTapZoom?: number;
@@ -207,7 +216,19 @@ export class InteractionController {
 
 	/** Read keyboardStep lazily so option changes take effect immediately. */
 	private get keyboardStep(): number {
-		return this.options.keyboardStep ?? 0.05;
+		return this.options.keyboardStep ?? DEFAULT_KEYBOARD_STEP;
+	}
+
+	/**
+	 * Get the keyboard pan step, including modifier-based coarse movement.
+	 *
+	 * @param event The native KeyboardEvent.
+	 * @return The normalized pan step.
+	 */
+	private getKeyboardStep( event: KeyboardEvent ): number {
+		return event.shiftKey
+			? this.keyboardStep * KEYBOARD_SHIFT_STEP_MULTIPLIER
+			: this.keyboardStep;
 	}
 
 	/** Read doubleTapZoom lazily so option changes take effect immediately. */
@@ -787,12 +808,13 @@ export class InteractionController {
 		switch ( e.key ) {
 			case 'ArrowUp': {
 				e.preventDefault();
+				const keyboardStep = this.getKeyboardStep( e );
 				const { pan: newCrop } = restrictPanZoom(
 					{
 						...currentState,
 						pan: {
 							x: currentState.pan.x,
-							y: currentState.pan.y + this.keyboardStep,
+							y: currentState.pan.y + keyboardStep,
 						},
 					},
 					getImageSizeFromState( currentState ),
@@ -803,12 +825,13 @@ export class InteractionController {
 			}
 			case 'ArrowDown': {
 				e.preventDefault();
+				const keyboardStep = this.getKeyboardStep( e );
 				const { pan: newCrop } = restrictPanZoom(
 					{
 						...currentState,
 						pan: {
 							x: currentState.pan.x,
-							y: currentState.pan.y - this.keyboardStep,
+							y: currentState.pan.y - keyboardStep,
 						},
 					},
 					getImageSizeFromState( currentState ),
@@ -819,11 +842,12 @@ export class InteractionController {
 			}
 			case 'ArrowLeft': {
 				e.preventDefault();
+				const keyboardStep = this.getKeyboardStep( e );
 				const { pan: newCrop } = restrictPanZoom(
 					{
 						...currentState,
 						pan: {
-							x: currentState.pan.x + this.keyboardStep,
+							x: currentState.pan.x + keyboardStep,
 							y: currentState.pan.y,
 						},
 					},
@@ -835,11 +859,12 @@ export class InteractionController {
 			}
 			case 'ArrowRight': {
 				e.preventDefault();
+				const keyboardStep = this.getKeyboardStep( e );
 				const { pan: newCrop } = restrictPanZoom(
 					{
 						...currentState,
 						pan: {
-							x: currentState.pan.x - this.keyboardStep,
+							x: currentState.pan.x - keyboardStep,
 							y: currentState.pan.y,
 						},
 					},

--- a/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
@@ -714,6 +714,42 @@ describe( 'InteractionController', () => {
 			expect( call![ 0 ].x ).toBeCloseTo( -0.1 );
 		} );
 
+		it( 'uses fine keyboardStep by default for arrow key panning', () => {
+			const state = makeState( { zoom: 2 } );
+			const { controller } = createController( state );
+
+			controller.handleKeyDown( createKeyboardEvent( 'ArrowRight' ) );
+
+			const call = actionMocks.setPan.mock.calls[ 0 ];
+			expect( call![ 0 ].x ).toBeCloseTo( -0.01 );
+		} );
+
+		it( 'uses a 10x larger keyboardStep when Shift is held while panning', () => {
+			const state = makeState( { zoom: 2 } );
+			const { controller } = createController( state );
+
+			controller.handleKeyDown(
+				createKeyboardEvent( 'ArrowRight', { shiftKey: true } )
+			);
+
+			const call = actionMocks.setPan.mock.calls[ 0 ];
+			expect( call![ 0 ].x ).toBeCloseTo( -0.1 );
+		} );
+
+		it( 'applies the Shift multiplier to custom keyboardStep while panning', () => {
+			const state = makeState( { zoom: 2 } );
+			const { controller } = createController( state, {
+				keyboardStep: 0.02,
+			} );
+
+			controller.handleKeyDown(
+				createKeyboardEvent( 'ArrowRight', { shiftKey: true } )
+			);
+
+			const call = actionMocks.setPan.mock.calls[ 0 ];
+			expect( call![ 0 ].x ).toBeCloseTo( -0.2 );
+		} );
+
 		it( 'does not dispatch on unhandled keys', () => {
 			const state = makeState();
 			const { controller } = createController( state );

--- a/packages/media-editor/src/image-editor/docs/recipes.md
+++ b/packages/media-editor/src/image-editor/docs/recipes.md
@@ -647,10 +647,10 @@ function ImageEditorWithUndo( { src }: { src: string } ) {
 The cropper is keyboard-accessible and screen-reader friendly:
 
 **Keyboard controls:**
-- **Arrow keys** on the container: pan the image
+- **Arrow keys** on the container: pan the image (Shift for larger jumps)
 - **+/-** on the container: zoom in/out
 - **R** on the container: snap rotate 90°
-- **Tab** to crop handles, then **arrow keys** to resize (0.02 step per keypress)
+- **Tab** to crop handles, then **arrow keys** to resize (Shift for larger jumps)
 - Aspect ratio lock is respected during keyboard resize
 
 **Screen reader support:**

--- a/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
@@ -9,6 +9,10 @@ import { __ } from '@wordpress/i18n';
  */
 import type { StencilProps, NormalizedRect } from '../../../core/types';
 import {
+	DEFAULT_KEYBOARD_STEP,
+	KEYBOARD_SHIFT_STEP_MULTIPLIER,
+} from '../../../core/constants';
+import {
 	computeFreeResizeRect,
 	computeLockedResizeRect,
 	computeShiftLockedResizeRect,
@@ -64,12 +68,6 @@ function getHandleLabel( pos: HandlePosition ): string {
 			return __( 'Resize bottom-right corner' );
 	}
 }
-
-/** Fine step for keyboard-driven handle resize, in normalized coordinates. */
-const KEYBOARD_STEP = 0.01;
-
-/** Coarse step when Shift is held — 10× the fine step. */
-const KEYBOARD_STEP_SHIFT = 0.1;
 
 /** Delay before keyboard resize triggers settle (ms). */
 const KEYBOARD_SETTLE_DELAY = 500;
@@ -397,7 +395,9 @@ export function RectangleStencil( {
 				}, KEYBOARD_SETTLE_DELAY );
 			};
 
-			const step = event.shiftKey ? KEYBOARD_STEP_SHIFT : KEYBOARD_STEP;
+			const step = event.shiftKey
+				? DEFAULT_KEYBOARD_STEP * KEYBOARD_SHIFT_STEP_MULTIPLIER
+				: DEFAULT_KEYBOARD_STEP;
 
 			// Determine the normalized delta from the arrow key.
 			let dx = 0;

--- a/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
@@ -42,7 +42,10 @@ export interface UseInteractionOptions {
 	maxZoom?: number;
 	/** Zoom speed multiplier for wheel events. Defaults to 0.0025. */
 	zoomSpeed?: number;
-	/** Pan step size in normalized coords for keyboard events. Defaults to 0.05. */
+	/**
+	 * Pan step size in normalized coords for keyboard events.
+	 * Defaults to 0.01. Shift multiplies it by 10.
+	 */
 	keyboardStep?: number;
 	/** Zoom level for double-tap zoom. Defaults to 2. */
 	doubleTapZoom?: number;


### PR DESCRIPTION
## What?

Part of: 

* https://github.com/WordPress/gutenberg/issues/73771

Just like we do for keyboard handling of the resize handles, this PR adds in a shift modifier to adjust the speed of keyboard panning for the cropper.

## Why?

Sometimes you want a little more precision when moving the crop area by keyboard, and sometimes you want to go a little faster. Also, it's more consistent if it works the same for panning as for the crop drag handles.

## How?

* Add a tiny `getKeyboardStep` function to handle the swift
* Consolidate the constants
* Update the docs and references to these controls
* Add some tests

## Testing Instructions

Enable the Media Upload Modal experiment

Add an image to a post or page and click the crop icon in the block toolbar to invoke the modal.

Reduce the size of the crop area, and either tab to the cropper or drag it to ensure it's focused. Then, use the cursor keys on the keyboard to interact with it. Then, hold the Shift key while doing the same. Does it work as expected?

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/0a6333af-b6df-490d-85b6-f1eb1e81527d

## Use of AI Tools

Codex