### PR TITLE
Media Editor Modal: Try a Photoshop-style navigator to pan and zoom freely

### DIFF
--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -14,6 +14,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import { useCropper } from '../../image-editor';
 import { useCropGestureHandlers } from '../../hooks/use-crop-gesture-handlers';
+import MediaEditorNavigator from '../media-editor-navigator';
 import {
 	DEFAULT_ASPECT_RATIOS,
 	MAX_ZOOM,
@@ -99,11 +100,12 @@ export default function MediaEditorCropPanel( {
 
 	return (
 		<Stack direction="column" gap="md">
+			<MediaEditorNavigator />
 			<div role="presentation" { ...zoomGestureHandlers }>
 				<RangeControl
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
-					label={ __( 'Zoom' ) }
+					label={ __( 'Image zoom' ) }
 					min={ MIN_ZOOM }
 					max={ MAX_ZOOM }
 					step={ 0.1 }

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -52,6 +52,7 @@ import type { MediaEditorModalUpdate } from '../../store/actions';
 import { unlock } from '../../lock-unlock';
 import { getMediaTypeFromMimeType } from '../../utils';
 import { CropperProvider, useCropper } from '../../image-editor';
+import { ViewportProvider } from '../../image-editor/react/components/viewport-provider';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
 import { CROP_CONTROL_ATTR } from '../../hooks/use-crop-gesture-handlers';
 import { buildModifiers } from './build-modifiers';
@@ -666,14 +667,16 @@ export function MediaEditorModal( {
 	// modal's entry animation and cause a visible flicker.
 	return (
 		<CropperProvider key={ id }>
-			<MediaEditorModalContent
-				fields={ fields }
-				id={ id }
-				media={ media }
-				hasEdits={ hasEdits }
-				aspectRatioPresets={ aspectRatioPresets }
-				onUpdate={ onUpdate }
-			/>
+			<ViewportProvider>
+				<MediaEditorModalContent
+					fields={ fields }
+					id={ id }
+					media={ media }
+					hasEdits={ hasEdits }
+					aspectRatioPresets={ aspectRatioPresets }
+					onUpdate={ onUpdate }
+				/>
+			</ViewportProvider>
 		</CropperProvider>
 	);
 }

--- a/packages/media-editor/src/components/media-editor-navigator/index.tsx
+++ b/packages/media-editor/src/components/media-editor-navigator/index.tsx
@@ -24,48 +24,78 @@ import {
 import { useMediaEditorContext } from '../media-editor-provider';
 import './style.scss';
 
-/**
- * Returns CSS position/size style for the viewport rect indicator
- * within the navigator thumbnail.
- *
- * @param vpZoom            Current viewport zoom level (> 1 = zoomed in).
- * @param vpPan             Current viewport pan offset in canvas CSS pixels.
- * @param vpPan.x           Pan offset on the X axis.
- * @param vpPan.y           Pan offset on the Y axis.
- * @param thumbSize         Navigator thumbnail dimensions in pixels.
- * @param thumbSize.width   Thumbnail width.
- * @param thumbSize.height  Thumbnail height.
- * @param canvasSize        Estimated canvas dimensions in pixels.
- * @param canvasSize.width  Canvas width.
- * @param canvasSize.height Canvas height.
- * @return Inline style for the viewport rect overlay element.
- */
 function getViewportRectStyle(
 	vpZoom: number,
 	vpPan: { x: number; y: number },
 	thumbSize: { width: number; height: number },
-	canvasSize: { width: number; height: number }
+	actualCanvasSize: { width: number; height: number },
+	imageNaturalSize: { width: number; height: number }
 ): React.CSSProperties {
-	if ( canvasSize.width === 0 || canvasSize.height === 0 ) {
+	if (
+		actualCanvasSize.width === 0 ||
+		actualCanvasSize.height === 0 ||
+		thumbSize.width === 0 ||
+		thumbSize.height === 0 ||
+		imageNaturalSize.width === 0 ||
+		imageNaturalSize.height === 0
+	) {
 		return {};
 	}
 
-	// At viewport zoom `vz`, the visible canvas region is (W/vz) × (H/vz).
-	const visibleW = canvasSize.width / vpZoom;
-	const visibleH = canvasSize.height / vpZoom;
+	const imageRatio = imageNaturalSize.width / imageNaturalSize.height;
+	const canvasRatio = actualCanvasSize.width / actualCanvasSize.height;
 
-	// Viewport pan shifts the canvas; visible region top-left in canvas pixels:
-	const visibleX = canvasSize.width / 2 - visibleW / 2 - vpPan.x / vpZoom;
-	const visibleY = canvasSize.height / 2 - visibleH / 2 - vpPan.y / vpZoom;
+	// Image size fitted into canvas space (aspect-ratio preserving).
+	let imageInCanvasW: number;
+	let imageInCanvasH: number;
+	if ( imageRatio > canvasRatio ) {
+		imageInCanvasW = actualCanvasSize.width;
+		imageInCanvasH = actualCanvasSize.width / imageRatio;
+	} else {
+		imageInCanvasH = actualCanvasSize.height;
+		imageInCanvasW = actualCanvasSize.height * imageRatio;
+	}
 
-	// Map canvas coords to thumbnail coords.
-	const scaleX = thumbSize.width / canvasSize.width;
-	const scaleY = thumbSize.height / canvasSize.height;
+	// Image size fitted into thumbnail space (same logic — matches the <img>
+	// element's object-fit:contain rendering).
+	const thumbRatio = thumbSize.width / thumbSize.height;
+	let thumbImageW: number;
+	let thumbImageH: number;
+	if ( imageRatio > thumbRatio ) {
+		thumbImageW = thumbSize.width;
+		thumbImageH = thumbSize.width / imageRatio;
+	} else {
+		thumbImageH = thumbSize.height;
+		thumbImageW = thumbSize.height * imageRatio;
+	}
 
-	const left = Math.max( 0, visibleX * scaleX );
-	const top = Math.max( 0, visibleY * scaleY );
-	const width = Math.min( thumbSize.width - left, visibleW * scaleX );
-	const height = Math.min( thumbSize.height - top, visibleH * scaleY );
+	// Scale from canvas pixels to thumbnail pixels (via image dimensions).
+	const canvasToThumb = thumbImageW / imageInCanvasW;
+
+	// Visible canvas region in canvas pixels.
+	const visW = actualCanvasSize.width / vpZoom;
+	const visH = actualCanvasSize.height / vpZoom;
+	const visLeft = actualCanvasSize.width / 2 - vpPan.x / vpZoom - visW / 2;
+	const visTop = actualCanvasSize.height / 2 - vpPan.y / vpZoom - visH / 2;
+
+	// Image top-left offset within canvas space.
+	const imageLeft = ( actualCanvasSize.width - imageInCanvasW ) / 2;
+	const imageTop = ( actualCanvasSize.height - imageInCanvasH ) / 2;
+
+	// Image top-left offset within thumbnail space (letterbox offset).
+	const thumbImageLeft = ( thumbSize.width - thumbImageW ) / 2;
+	const thumbImageTop = ( thumbSize.height - thumbImageH ) / 2;
+
+	// Map visible canvas region into thumbnail coordinates.
+	const rawLeft = thumbImageLeft + ( visLeft - imageLeft ) * canvasToThumb;
+	const rawTop = thumbImageTop + ( visTop - imageTop ) * canvasToThumb;
+	const rawRight = rawLeft + visW * canvasToThumb;
+	const rawBottom = rawTop + visH * canvasToThumb;
+
+	const left = Math.max( 0, Math.min( rawLeft, thumbSize.width ) );
+	const top = Math.max( 0, Math.min( rawTop, thumbSize.height ) );
+	const width = Math.max( 0, Math.min( rawRight, thumbSize.width ) - left );
+	const height = Math.max( 0, Math.min( rawBottom, thumbSize.height ) - top );
 
 	return { left, top, width, height };
 }
@@ -80,7 +110,7 @@ function getViewportRectStyle(
  */
 export default function MediaEditorNavigator() {
 	const { state } = useCropper();
-	const { viewport, setViewportZoom, setViewportPan } = useViewport();
+	const { viewport, setViewportZoomAtCenter, setViewportPan } = useViewport();
 	const { media } = useMediaEditorContext();
 
 	const src = media?.source_url ?? state.image?.src ?? '';
@@ -110,26 +140,10 @@ export default function MediaEditorNavigator() {
 		};
 	}, [] );
 
-	// Estimate canvas size from the image aspect ratio fitted into the thumbnail.
 	const naturalW = state.image?.naturalWidth ?? 1;
 	const naturalH = state.image?.naturalHeight ?? 1;
-	const canvasSize = useMemo( () => {
-		if ( thumbSize.width === 0 || thumbSize.height === 0 ) {
-			return { width: naturalW, height: naturalH };
-		}
-		const ratio = naturalW / naturalH;
-		const thumbRatio = thumbSize.width / thumbSize.height;
-		if ( ratio > thumbRatio ) {
-			return {
-				width: thumbSize.width,
-				height: thumbSize.width / ratio,
-			};
-		}
-		return {
-			width: thumbSize.height * ratio,
-			height: thumbSize.height,
-		};
-	}, [ naturalW, naturalH, thumbSize ] );
+	const actualCanvasW = viewport.canvasSize?.width ?? 0;
+	const actualCanvasH = viewport.canvasSize?.height ?? 0;
 
 	const viewportRectStyle = useMemo(
 		() =>
@@ -137,9 +151,18 @@ export default function MediaEditorNavigator() {
 				viewport.zoom,
 				viewport.pan,
 				thumbSize,
-				canvasSize
+				{ width: actualCanvasW, height: actualCanvasH },
+				{ width: naturalW, height: naturalH }
 			),
-		[ viewport.zoom, viewport.pan, thumbSize, canvasSize ]
+		[
+			viewport.zoom,
+			viewport.pan,
+			thumbSize,
+			actualCanvasW,
+			actualCanvasH,
+			naturalW,
+			naturalH,
+		]
 	);
 
 	// Drag-to-pan: dragging the thumbnail moves the viewport.
@@ -167,19 +190,19 @@ export default function MediaEditorNavigator() {
 	const handleThumbPointerMove = useCallback(
 		( e: React.PointerEvent< HTMLDivElement > ) => {
 			const drag = dragRef.current;
-			if ( ! drag || thumbSize.width === 0 ) {
+			if ( ! drag || thumbSize.width === 0 || actualCanvasW === 0 ) {
 				return;
 			}
 			// Thumbnail scale: thumb px → canvas px. Dragging left in the
 			// thumbnail pans the viewport left (negate the delta).
-			const scaleX = canvasSize.width / thumbSize.width;
-			const scaleY = canvasSize.height / thumbSize.height;
+			const scaleX = actualCanvasW / thumbSize.width;
+			const scaleY = actualCanvasH / thumbSize.height;
 			setViewportPan( {
 				x: drag.startPanX - ( e.clientX - drag.startX ) * scaleX,
 				y: drag.startPanY - ( e.clientY - drag.startY ) * scaleY,
 			} );
 		},
-		[ canvasSize, thumbSize, setViewportPan ]
+		[ actualCanvasW, actualCanvasH, thumbSize, setViewportPan ]
 	);
 
 	const handleThumbPointerUp = useCallback( () => {
@@ -199,6 +222,8 @@ export default function MediaEditorNavigator() {
 				onPointerDown={ handleThumbPointerDown }
 				onPointerMove={ handleThumbPointerMove }
 				onPointerUp={ handleThumbPointerUp }
+				onPointerCancel={ handleThumbPointerUp }
+				onLostPointerCapture={ handleThumbPointerUp }
 			>
 				<img
 					className="media-editor-navigator__thumbnail-img"
@@ -224,7 +249,9 @@ export default function MediaEditorNavigator() {
 				step={ 0.05 }
 				value={ viewport.zoom }
 				onChange={ ( value ) => {
-					setViewportZoom( typeof value === 'number' ? value : 1 );
+					setViewportZoomAtCenter(
+						typeof value === 'number' ? value : 1
+					);
 				} }
 				renderTooltipContent={ ( value ) => {
 					const zoom = typeof value === 'number' ? value : 1;

--- a/packages/media-editor/src/components/media-editor-navigator/index.tsx
+++ b/packages/media-editor/src/components/media-editor-navigator/index.tsx
@@ -1,0 +1,240 @@
+/**
+ * WordPress dependencies
+ */
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	useCallback,
+	useRef,
+	useState,
+	useMemo,
+	useEffect,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useCropper } from '../../image-editor';
+import { useViewport } from '../../image-editor/react/components/viewport-provider';
+import {
+	MIN_VIEWPORT_ZOOM,
+	MAX_VIEWPORT_ZOOM,
+} from '../../image-editor/core/constants';
+import { useMediaEditorContext } from '../media-editor-provider';
+import './style.scss';
+
+/**
+ * Returns CSS position/size style for the viewport rect indicator
+ * within the navigator thumbnail.
+ *
+ * @param vpZoom            Current viewport zoom level (> 1 = zoomed in).
+ * @param vpPan             Current viewport pan offset in canvas CSS pixels.
+ * @param vpPan.x           Pan offset on the X axis.
+ * @param vpPan.y           Pan offset on the Y axis.
+ * @param thumbSize         Navigator thumbnail dimensions in pixels.
+ * @param thumbSize.width   Thumbnail width.
+ * @param thumbSize.height  Thumbnail height.
+ * @param canvasSize        Estimated canvas dimensions in pixels.
+ * @param canvasSize.width  Canvas width.
+ * @param canvasSize.height Canvas height.
+ * @return Inline style for the viewport rect overlay element.
+ */
+function getViewportRectStyle(
+	vpZoom: number,
+	vpPan: { x: number; y: number },
+	thumbSize: { width: number; height: number },
+	canvasSize: { width: number; height: number }
+): React.CSSProperties {
+	if ( canvasSize.width === 0 || canvasSize.height === 0 ) {
+		return {};
+	}
+
+	// At viewport zoom `vz`, the visible canvas region is (W/vz) × (H/vz).
+	const visibleW = canvasSize.width / vpZoom;
+	const visibleH = canvasSize.height / vpZoom;
+
+	// Viewport pan shifts the canvas; visible region top-left in canvas pixels:
+	const visibleX = canvasSize.width / 2 - visibleW / 2 - vpPan.x / vpZoom;
+	const visibleY = canvasSize.height / 2 - visibleH / 2 - vpPan.y / vpZoom;
+
+	// Map canvas coords to thumbnail coords.
+	const scaleX = thumbSize.width / canvasSize.width;
+	const scaleY = thumbSize.height / canvasSize.height;
+
+	const left = Math.max( 0, visibleX * scaleX );
+	const top = Math.max( 0, visibleY * scaleY );
+	const width = Math.min( thumbSize.width - left, visibleW * scaleX );
+	const height = Math.min( thumbSize.height - top, visibleH * scaleY );
+
+	return { left, top, width, height };
+}
+
+/**
+ * Navigator panel — a Photoshop-style minimap for the image editor viewport.
+ *
+ * Shows a thumbnail of the source image with a rectangle indicating the
+ * currently visible portion of the canvas. Users can drag the thumbnail to
+ * pan the viewport, and use the zoom slider to change the viewport zoom
+ * without affecting the crop area.
+ */
+export default function MediaEditorNavigator() {
+	const { state } = useCropper();
+	const { viewport, setViewportZoom, setViewportPan } = useViewport();
+	const { media } = useMediaEditorContext();
+
+	const src = media?.source_url ?? state.image?.src ?? '';
+
+	// Thumbnail container ref for measuring its layout size.
+	const thumbContainerRef = useRef< HTMLDivElement >( null );
+	const [ thumbSize, setThumbSize ] = useState( { width: 0, height: 0 } );
+
+	useEffect( () => {
+		const el = thumbContainerRef.current;
+		if ( ! el ) {
+			return;
+		}
+		const observer = new ResizeObserver( ( entries ) => {
+			for ( const entry of entries ) {
+				const { width, height } = entry.contentRect;
+				setThumbSize( ( prev ) =>
+					prev.width === width && prev.height === height
+						? prev
+						: { width, height }
+				);
+			}
+		} );
+		observer.observe( el );
+		return () => {
+			observer.disconnect();
+		};
+	}, [] );
+
+	// Estimate canvas size from the image aspect ratio fitted into the thumbnail.
+	const naturalW = state.image?.naturalWidth ?? 1;
+	const naturalH = state.image?.naturalHeight ?? 1;
+	const canvasSize = useMemo( () => {
+		if ( thumbSize.width === 0 || thumbSize.height === 0 ) {
+			return { width: naturalW, height: naturalH };
+		}
+		const ratio = naturalW / naturalH;
+		const thumbRatio = thumbSize.width / thumbSize.height;
+		if ( ratio > thumbRatio ) {
+			return {
+				width: thumbSize.width,
+				height: thumbSize.width / ratio,
+			};
+		}
+		return {
+			width: thumbSize.height * ratio,
+			height: thumbSize.height,
+		};
+	}, [ naturalW, naturalH, thumbSize ] );
+
+	const viewportRectStyle = useMemo(
+		() =>
+			getViewportRectStyle(
+				viewport.zoom,
+				viewport.pan,
+				thumbSize,
+				canvasSize
+			),
+		[ viewport.zoom, viewport.pan, thumbSize, canvasSize ]
+	);
+
+	// Drag-to-pan: dragging the thumbnail moves the viewport.
+	const dragRef = useRef< {
+		startX: number;
+		startY: number;
+		startPanX: number;
+		startPanY: number;
+	} | null >( null );
+
+	const handleThumbPointerDown = useCallback(
+		( e: React.PointerEvent< HTMLDivElement > ) => {
+			e.preventDefault();
+			e.currentTarget.setPointerCapture( e.pointerId );
+			dragRef.current = {
+				startX: e.clientX,
+				startY: e.clientY,
+				startPanX: viewport.pan.x,
+				startPanY: viewport.pan.y,
+			};
+		},
+		[ viewport.pan ]
+	);
+
+	const handleThumbPointerMove = useCallback(
+		( e: React.PointerEvent< HTMLDivElement > ) => {
+			const drag = dragRef.current;
+			if ( ! drag || thumbSize.width === 0 ) {
+				return;
+			}
+			// Thumbnail scale: thumb px → canvas px. Dragging left in the
+			// thumbnail pans the viewport left (negate the delta).
+			const scaleX = canvasSize.width / thumbSize.width;
+			const scaleY = canvasSize.height / thumbSize.height;
+			setViewportPan( {
+				x: drag.startPanX - ( e.clientX - drag.startX ) * scaleX,
+				y: drag.startPanY - ( e.clientY - drag.startY ) * scaleY,
+			} );
+		},
+		[ canvasSize, thumbSize, setViewportPan ]
+	);
+
+	const handleThumbPointerUp = useCallback( () => {
+		dragRef.current = null;
+	}, [] );
+
+	if ( ! src ) {
+		return null;
+	}
+
+	return (
+		<Stack direction="column" gap="sm">
+			{ /* Thumbnail with viewport rect overlay */ }
+			<div
+				ref={ thumbContainerRef }
+				className="media-editor-navigator__thumbnail"
+				onPointerDown={ handleThumbPointerDown }
+				onPointerMove={ handleThumbPointerMove }
+				onPointerUp={ handleThumbPointerUp }
+			>
+				<img
+					className="media-editor-navigator__thumbnail-img"
+					src={ src }
+					alt=""
+					draggable={ false }
+				/>
+				{ thumbSize.width > 0 && (
+					<div
+						className="media-editor-navigator__viewport-rect"
+						style={ viewportRectStyle }
+					/>
+				) }
+			</div>
+
+			{ /* Viewport zoom slider */ }
+			<RangeControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ __( 'View zoom' ) }
+				min={ MIN_VIEWPORT_ZOOM }
+				max={ MAX_VIEWPORT_ZOOM }
+				step={ 0.05 }
+				value={ viewport.zoom }
+				onChange={ ( value ) => {
+					setViewportZoom( typeof value === 'number' ? value : 1 );
+				} }
+				renderTooltipContent={ ( value ) => {
+					const zoom = typeof value === 'number' ? value : 1;
+					return sprintf(
+						/* translators: %d: view zoom level as a percentage. */
+						__( '%d%%' ),
+						Math.round( zoom * 100 )
+					);
+				} }
+			/>
+		</Stack>
+	);
+}

--- a/packages/media-editor/src/components/media-editor-navigator/style.scss
+++ b/packages/media-editor/src/components/media-editor-navigator/style.scss
@@ -1,0 +1,33 @@
+.media-editor-navigator {
+	&__thumbnail {
+		position: relative;
+		width: 100%;
+		overflow: hidden;
+		background: #1e1e1e;
+		border-radius: 2px;
+		cursor: grab;
+		user-select: none;
+		touch-action: none;
+		aspect-ratio: 16 / 9;
+
+		&:active {
+			cursor: grabbing;
+		}
+	}
+
+	&__thumbnail-img {
+		display: block;
+		width: 100%;
+		height: 100%;
+		object-fit: contain;
+		pointer-events: none;
+	}
+
+	&__viewport-rect {
+		position: absolute;
+		border: 1px solid rgba(255, 255, 255, 0.8);
+		box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.4);
+		box-sizing: border-box;
+		pointer-events: none;
+	}
+}

--- a/packages/media-editor/src/image-editor/core/constants.ts
+++ b/packages/media-editor/src/image-editor/core/constants.ts
@@ -11,6 +11,9 @@ import type { NormalizedRect, Flip, CropperState } from './types';
 export const MIN_ZOOM = 1;
 export const MAX_ZOOM = 10;
 
+export const MIN_VIEWPORT_ZOOM = 0.1;
+export const MAX_VIEWPORT_ZOOM = 4;
+
 /**
  * Wheel zoom sensitivity. A deltaY of 100 changes zoom by 0.25.
  * This could be made configurable as a prop to the Cropper component.

--- a/packages/media-editor/src/image-editor/core/containment.ts
+++ b/packages/media-editor/src/image-editor/core/containment.ts
@@ -88,23 +88,21 @@ function getMinZoomForCover(
 /**
  * Compute the crop handle bounds in normalized visual space by finding the
  * axis-aligned bounding box (AABB) of the actual image footprint at the
- * current pan/zoom/rotation, then intersecting with the container viewport.
+ * current pan/zoom/rotation.
  *
  * Unlike a static centerline-based calculation, this accounts for the
  * current pan position — if the user pans right, the left bound tightens
  * because the image's left edge has moved right.
  *
- * @param state         The current cropper state (crop, zoom, rotation, flip).
- * @param elementSize   The fitted (unrotated) image element dimensions in pixels.
- * @param visualSize    The visual (rotated) image bounding box in pixels.
- * @param containerSize The container dimensions in pixels.
+ * @param state       The current cropper state (crop, zoom, rotation, flip).
+ * @param elementSize The fitted (unrotated) image element dimensions in pixels.
+ * @param visualSize  The visual (rotated) image bounding box in pixels.
  * @return The min/max x and y that a crop rect edge can reach in normalized space.
  */
 export function getCropBounds(
 	state: CropperState,
 	elementSize: Size,
-	visualSize: Size,
-	containerSize: Size
+	visualSize: Size
 ): { minX: number; minY: number; maxX: number; maxY: number } {
 	if (
 		elementSize.width === 0 ||
@@ -140,13 +138,6 @@ export function getCropBounds(
 		[ -hw, hh ],
 	];
 
-	// Transform corners through CSS matrix → screen offsets from element center.
-	// Screen position = element_center + transformed_offset.
-	// Element center is at (containerW/2, containerH/2) after CSS centering.
-	// But we want normalized coords, so work relative to the visual image origin.
-	const offsetX = ( containerSize.width - visualSize.width ) / 2;
-	const offsetY = ( containerSize.height - visualSize.height ) / 2;
-
 	let imgMinX = Infinity;
 	let imgMaxX = -Infinity;
 	let imgMinY = Infinity;
@@ -167,19 +158,11 @@ export function getCropBounds(
 		imgMaxY = Math.max( imgMaxY, ny );
 	}
 
-	// Container bounds in normalized space.
-	const containerMinX = -offsetX / visualSize.width;
-	const containerMaxX = ( containerSize.width - offsetX ) / visualSize.width;
-	const containerMinY = -offsetY / visualSize.height;
-	const containerMaxY =
-		( containerSize.height - offsetY ) / visualSize.height;
-
-	// Crop bounds = intersection of image AABB and container bounds.
 	return {
-		minX: Math.max( imgMinX, containerMinX ),
-		minY: Math.max( imgMinY, containerMinY ),
-		maxX: Math.min( imgMaxX, containerMaxX ),
-		maxY: Math.min( imgMaxY, containerMaxY ),
+		minX: imgMinX,
+		minY: imgMinY,
+		maxX: imgMaxX,
+		maxY: imgMaxY,
 	};
 }
 

--- a/packages/media-editor/src/image-editor/core/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/interaction-controller.ts
@@ -64,6 +64,8 @@ export interface CropperInteractionActions {
 	snapRotate90: ( direction: 1 | -1 ) => void;
 	/** Toggle flip on the given axis. */
 	toggleFlip?: ( direction: 'horizontal' | 'vertical' ) => void;
+	/** Set the viewport pan offset in CSS pixels (display-only, does not affect crop). */
+	setViewportPan?: ( pan: { x: number; y: number } ) => void;
 }
 
 /**
@@ -86,6 +88,22 @@ export interface InteractionControllerOptions {
 	minZoom?: number;
 	/** Maximum zoom level. Defaults to MAX_ZOOM. Read lazily. */
 	maxZoom?: number;
+	/**
+	 * Returns the current viewport zoom level. Used to de-scale pointer
+	 * deltas so a drag of N screen pixels moves N/viewportZoom canvas pixels.
+	 * Defaults to 1 (no viewport zoom). Read lazily.
+	 */
+	getViewportZoom?: () => number;
+	/**
+	 * Returns the current viewport pan offset in CSS pixels.
+	 * Snapshotted at drag start for viewport pan mode.
+	 */
+	getViewportPan?: () => { x: number; y: number };
+	/**
+	 * Returns true if a pointer event originates outside the crop stencil.
+	 * When true, pointer drags pan the viewport instead of the image.
+	 */
+	isOutsideCrop?: ( e: PointerEvent ) => boolean;
 	/** Zoom speed multiplier for wheel events. Defaults to 0.0025. Read lazily. */
 	zoomSpeed?: number;
 	/** Pan step size in normalized coords for keyboard events. Defaults to 0.05. Read lazily. */
@@ -131,6 +149,11 @@ export class InteractionController {
 		startY: number;
 		startPanX: number;
 		startPanY: number;
+		/** Whether this drag is panning the viewport (outside crop area). */
+		isViewportPan: boolean;
+		/** Viewport pan at drag start (for viewport pan mode). */
+		startViewportPanX: number;
+		startViewportPanY: number;
 	} | null = null;
 
 	/** Active touch state during touch interactions. */
@@ -215,6 +238,11 @@ export class InteractionController {
 		return this.options.doubleTapZoom ?? 2;
 	}
 
+	/** Read viewport zoom lazily so option changes take effect immediately. */
+	private get viewportZoom(): number {
+		return this.options.getViewportZoom?.() ?? 1;
+	}
+
 	/**
 	 * Update the drag/zoom status and notify via callback if changed.
 	 *
@@ -282,11 +310,21 @@ export class InteractionController {
 		this.options.onGestureStart?.();
 
 		const currentState = this.options.getState();
+		const isViewportPan =
+			!! this.options.isOutsideCrop?.( e ) &&
+			!! this.options.actions.setViewportPan;
+		const currentViewportPan = this.options.getViewportPan?.() ?? {
+			x: 0,
+			y: 0,
+		};
 		this.drag = {
 			startX: e.clientX,
 			startY: e.clientY,
 			startPanX: currentState.pan.x,
 			startPanY: currentState.pan.y,
+			isViewportPan,
+			startViewportPanX: currentViewportPan.x,
+			startViewportPanY: currentViewportPan.y,
 		};
 
 		const onPointerMove = ( moveEvent: Event ) => {
@@ -298,17 +336,33 @@ export class InteractionController {
 
 			cancelAnimationFrame( this.rafId );
 			this.rafId = requestAnimationFrame( () => {
+				if ( drag.isViewportPan ) {
+					// Panning the viewport: screen deltas map 1:1 to CSS px offsets.
+					this.options.actions.setViewportPan?.( {
+						x:
+							drag.startViewportPanX +
+							( pe.clientX - drag.startX ),
+						y:
+							drag.startViewportPanY +
+							( pe.clientY - drag.startY ),
+					} );
+					return;
+				}
+
 				const s = this.options.getState();
+				const vz = this.viewportZoom;
 				const imgSize = this.options.getImageSize();
 				const containerSize = this.options.getContainerSize();
 				const panSize = imgSize ?? containerSize;
+				// Divide by viewport zoom so a screen drag of N px moves
+				// N/vz canvas-space px.
 				const deltaX =
 					panSize.width > 0
-						? ( pe.clientX - drag.startX ) / panSize.width
+						? ( pe.clientX - drag.startX ) / ( panSize.width * vz )
 						: 0;
 				const deltaY =
 					panSize.height > 0
-						? ( pe.clientY - drag.startY ) / panSize.height
+						? ( pe.clientY - drag.startY ) / ( panSize.height * vz )
 						: 0;
 
 				const { pan: newCrop } = restrictPanZoom(
@@ -400,8 +454,13 @@ export class InteractionController {
 				? target.getBoundingClientRect()
 				: undefined;
 		if ( visSize.width > 0 && visSize.height > 0 && rect ) {
-			const fx = e.clientX - rect.left - containerSize.width / 2;
-			const fy = e.clientY - rect.top - containerSize.height / 2;
+			// Use the visual centre of the (possibly viewport-zoomed) canvas
+			// as the reference point, then de-scale to canvas space.
+			const vz = this.viewportZoom;
+			const cx = rect.left + rect.width / 2;
+			const cy = rect.top + rect.height / 2;
+			const fx = ( e.clientX - cx ) / vz;
+			const fy = ( e.clientY - cy ) / vz;
 
 			const zoomRatio = 1 - newZoom / s.zoom;
 			const focalNormX = fx / visSize.width;

--- a/packages/media-editor/src/image-editor/core/test/camera.ts
+++ b/packages/media-editor/src/image-editor/core/test/camera.ts
@@ -548,12 +548,11 @@ describe( 'getSourceRegionPercent', () => {
 } );
 
 describe( 'getCropBounds', () => {
-	it( 'allows crop handle to reach container edge when 4:3 image is zoomed in 3:2 container', () => {
-		// MtBlanc1.jpg is 500×375 (4:3) in a 600×400 container (3:2).
-		// At zoom=1, the image is 533×400 — 33px padding on each side.
-		// At zoom=1.75, the image fills the container. The crop handle
-		// should be able to reach the container left edge (pixel 0),
-		// which is at normalized x = -0.0625.
+	it( 'returns the image AABB — not clipped to the container — when 4:3 image is zoomed in 3:2 container', () => {
+		// 500×375 (4:3) in a 600×400 container (3:2).
+		// At zoom=1 the fitted element is 533×400 (letterboxed horizontally).
+		// At zoom=1.75 the image overflows the container on all sides; bounds
+		// should track the image corners, not the container edges.
 		const nat: Size = { width: 500, height: 375 };
 		const container: Size = { width: 600, height: 400 };
 		const { elementSize, visualSize } = getImageFit( container, nat, 0 );
@@ -571,23 +570,14 @@ describe( 'getCropBounds', () => {
 			rotation: 0,
 		} );
 
-		const bounds = getCropBounds(
-			state,
-			elementSize,
-			visualSize,
-			container
-		);
+		const bounds = getCropBounds( state, elementSize, visualSize );
 
-		// boundsMinX should be negative (crop can extend left of visual image origin).
-		expect( bounds.minX ).toBeLessThan( 0 );
-		// The pixel position of boundsMinX should be the container left edge (pixel 0).
-		const offsetX = ( container.width - visualSize.width ) / 2;
-		const pixelLeft = offsetX + bounds.minX * visualSize.width;
-		expect( pixelLeft ).toBeCloseTo( 0, 0 );
-
-		// boundsMaxX should be > 1 (crop can extend right of visual image).
-		expect( bounds.maxX ).toBeGreaterThan( 1 );
-		const pixelRight = offsetX + bounds.maxX * visualSize.width;
-		expect( pixelRight ).toBeCloseTo( container.width, 0 );
+		// With zoom=1.75 the image extends well outside the container, so
+		// the bounds should be the image corners in normalized space (≈ ±0.375),
+		// not clipped to the container edges (which would be ≈ ±0.0625).
+		expect( bounds.minX ).toBeLessThan( -0.3 );
+		expect( bounds.maxX ).toBeGreaterThan( 1.3 );
+		expect( bounds.minY ).toBeLessThan( -0.3 );
+		expect( bounds.maxY ).toBeGreaterThan( 1.3 );
 	} );
 } );

--- a/packages/media-editor/src/image-editor/core/types.ts
+++ b/packages/media-editor/src/image-editor/core/types.ts
@@ -154,11 +154,23 @@ export interface ViewportState {
 	zoom: number;
 	/** Pan offset in CSS pixels from the canvas centre. */
 	pan: { x: number; y: number };
+	/**
+	 * Measured canvas element size in CSS pixels. Set by the Cropper
+	 * component; used by the navigator to compute an accurate viewport rect.
+	 */
+	canvasSize: Size | null;
 }
 
 export type ViewportAction =
 	| { type: 'SET_VIEWPORT_ZOOM'; payload: number }
+	/**
+	 * Zooms to a new level while keeping the current view centre stationary.
+	 * Pan is scaled by (newZoom / oldZoom) so the canvas point visible at the
+	 * root centre does not jump.
+	 */
+	| { type: 'SET_VIEWPORT_ZOOM_AT_CENTER'; payload: number }
 	| { type: 'SET_VIEWPORT_PAN'; payload: { x: number; y: number } }
+	| { type: 'SET_CANVAS_SIZE'; payload: Size }
 	| { type: 'RESET_VIEWPORT' };
 
 /**
@@ -193,4 +205,9 @@ export interface StencilProps {
 	};
 	/** Called when Escape is pressed on a resize handle. */
 	onEscape?: () => void;
+	/**
+	 * Current viewport zoom level. Used to counter-scale handles so they
+	 * remain the same visual size regardless of viewport zoom.
+	 */
+	viewportZoom?: number;
 }

--- a/packages/media-editor/src/image-editor/core/types.ts
+++ b/packages/media-editor/src/image-editor/core/types.ts
@@ -143,6 +143,25 @@ export type CropperAction =
 	| { type: 'RESET'; payload?: Partial< CropperState > };
 
 /**
+ * Viewport (navigator) camera state.
+ *
+ * Controls how the canvas is displayed in the container without
+ * affecting the crop area or the exported image. Zoom > 1 magnifies
+ * the canvas; pan shifts it in CSS pixels from the canvas centre.
+ */
+export interface ViewportState {
+	/** Viewport zoom level. 1 = canvas fills container normally. */
+	zoom: number;
+	/** Pan offset in CSS pixels from the canvas centre. */
+	pan: { x: number; y: number };
+}
+
+export type ViewportAction =
+	| { type: 'SET_VIEWPORT_ZOOM'; payload: number }
+	| { type: 'SET_VIEWPORT_PAN'; payload: { x: number; y: number } }
+	| { type: 'RESET_VIEWPORT' };
+
+/**
  * The contract for a pluggable stencil component.
  * Stencils render the crop area overlay and handle resize interactions.
  */

--- a/packages/media-editor/src/image-editor/core/viewport-state.ts
+++ b/packages/media-editor/src/image-editor/core/viewport-state.ts
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import type { ViewportState, ViewportAction } from './types';
+import { MIN_VIEWPORT_ZOOM, MAX_VIEWPORT_ZOOM } from './constants';
+
+export const DEFAULT_VIEWPORT_STATE: ViewportState = {
+	zoom: 1,
+	pan: { x: 0, y: 0 },
+};
+
+function clampViewportZoom( zoom: number ): number {
+	return Math.min( MAX_VIEWPORT_ZOOM, Math.max( MIN_VIEWPORT_ZOOM, zoom ) );
+}
+
+export function viewportReducer(
+	state: ViewportState,
+	action: ViewportAction
+): ViewportState {
+	switch ( action.type ) {
+		case 'SET_VIEWPORT_ZOOM':
+			return { ...state, zoom: clampViewportZoom( action.payload ) };
+		case 'SET_VIEWPORT_PAN':
+			return { ...state, pan: action.payload };
+		case 'RESET_VIEWPORT':
+			return DEFAULT_VIEWPORT_STATE;
+	}
+}

--- a/packages/media-editor/src/image-editor/core/viewport-state.ts
+++ b/packages/media-editor/src/image-editor/core/viewport-state.ts
@@ -7,6 +7,7 @@ import { MIN_VIEWPORT_ZOOM, MAX_VIEWPORT_ZOOM } from './constants';
 export const DEFAULT_VIEWPORT_STATE: ViewportState = {
 	zoom: 1,
 	pan: { x: 0, y: 0 },
+	canvasSize: null,
 };
 
 function clampViewportZoom( zoom: number ): number {
@@ -20,8 +21,22 @@ export function viewportReducer(
 	switch ( action.type ) {
 		case 'SET_VIEWPORT_ZOOM':
 			return { ...state, zoom: clampViewportZoom( action.payload ) };
+		case 'SET_VIEWPORT_ZOOM_AT_CENTER': {
+			const newZoom = clampViewportZoom( action.payload );
+			if ( newZoom === state.zoom ) {
+				return state;
+			}
+			const ratio = newZoom / state.zoom;
+			return {
+				...state,
+				zoom: newZoom,
+				pan: { x: state.pan.x * ratio, y: state.pan.y * ratio },
+			};
+		}
 		case 'SET_VIEWPORT_PAN':
 			return { ...state, pan: action.payload };
+		case 'SET_CANVAS_SIZE':
+			return { ...state, canvasSize: action.payload };
 		case 'RESET_VIEWPORT':
 			return DEFAULT_VIEWPORT_STATE;
 	}

--- a/packages/media-editor/src/image-editor/react/components/cropper.scss
+++ b/packages/media-editor/src/image-editor/react/components/cropper.scss
@@ -12,6 +12,19 @@ $handle-touch-target-size: 44px;
 	user-select: none;
 	cursor: grab;
 
+	// Transparent overlay that sits behind the canvas and catches pointer
+	// events in empty root areas that the canvas no longer covers after a
+	// viewport pan/zoom transform. Enables pan-from-anywhere UX.
+	&__pan-backdrop {
+		position: absolute;
+		inset: 0;
+		cursor: grab;
+
+		&:active {
+			cursor: grabbing;
+		}
+	}
+
 	// Inner gutter for resize handles. Handles use negative offsets and a
 	// touch target that extends past the crop edge; the root clips overflow
 	// (required for the dimming overlay's box-shadow trick), so a flush

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -286,8 +286,8 @@ function CropperInner(
 		if ( ! state.image || elementSize.width === 0 ) {
 			return undefined;
 		}
-		return getCropBounds( state, elementSize, visualSize, canvasSize );
-	}, [ state, elementSize, visualSize, canvasSize ] );
+		return getCropBounds( state, elementSize, visualSize );
+	}, [ state, elementSize, visualSize ] );
 	const [ isResizing, setIsResizing ] = useState( false );
 	const isResizingRef = useRef( false );
 

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -177,7 +177,7 @@ function CropperInner(
 	// positioning context for image/stencil/handles — inset from the root
 	// by the handle gutter, so crop math operates on the reduced box.
 	const canvasRef = useRef< HTMLDivElement >( null );
-	const [ canvasSize, setCanvasSize ] = useState< Size >( {
+	const [ canvasSize, setCanvasSizeLocal ] = useState< Size >( {
 		width: 0,
 		height: 0,
 	} );
@@ -190,7 +190,7 @@ function CropperInner(
 		const observer = new ResizeObserver( ( entries ) => {
 			for ( const entry of entries ) {
 				const { width, height } = entry.contentRect;
-				setCanvasSize( ( prev ) => {
+				setCanvasSizeLocal( ( prev ) => {
 					if ( prev.width === width && prev.height === height ) {
 						return prev;
 					}
@@ -203,6 +203,14 @@ function CropperInner(
 			observer.disconnect();
 		};
 	}, [] );
+
+	// Report canvas size to the viewport context so the navigator can
+	// compute an accurate viewport rect.
+	useEffect( () => {
+		if ( viewport && canvasSize.width > 0 && canvasSize.height > 0 ) {
+			viewport.setCanvasSize( canvasSize );
+		}
+	}, [ viewport, canvasSize ] );
 
 	// Notify consumer of state changes.
 	useEffect( () => {
@@ -444,6 +452,50 @@ function CropperInner(
 		[ ref ]
 	);
 
+	// Backdrop viewport-pan drag: captures pointer events in empty areas
+	// of the root that are not covered by the canvas after transform.
+	const backdropDragRef = useRef< {
+		startX: number;
+		startY: number;
+		startPanX: number;
+		startPanY: number;
+	} | null >( null );
+
+	const handleBackdropPointerDown = useCallback(
+		( e: React.PointerEvent< HTMLDivElement > ) => {
+			if ( ! viewport ) {
+				return;
+			}
+			e.preventDefault();
+			e.currentTarget.setPointerCapture( e.pointerId );
+			backdropDragRef.current = {
+				startX: e.clientX,
+				startY: e.clientY,
+				startPanX: viewport.viewport.pan.x,
+				startPanY: viewport.viewport.pan.y,
+			};
+		},
+		[ viewport ]
+	);
+
+	const handleBackdropPointerMove = useCallback(
+		( e: React.PointerEvent< HTMLDivElement > ) => {
+			const drag = backdropDragRef.current;
+			if ( ! drag || ! viewport ) {
+				return;
+			}
+			viewport.setViewportPan( {
+				x: drag.startPanX + ( e.clientX - drag.startX ),
+				y: drag.startPanY + ( e.clientY - drag.startY ),
+			} );
+		},
+		[ viewport ]
+	);
+
+	const handleBackdropPointerUp = useCallback( () => {
+		backdropDragRef.current = null;
+	}, [] );
+
 	return (
 		<div
 			ref={ setContainerRef }
@@ -453,6 +505,22 @@ function CropperInner(
 				className
 			) }
 		>
+			{ /*
+			 * Transparent backdrop, below the canvas in stacking order. It
+			 * catches pointer events in empty areas of the root that the
+			 * canvas no longer covers when panned or zoomed, enabling the
+			 * user to start a viewport pan drag from anywhere in the editor.
+			 */ }
+			{ viewport && (
+				<div
+					className="wp-media-editor-image-editor__pan-backdrop"
+					onPointerDown={ handleBackdropPointerDown }
+					onPointerMove={ handleBackdropPointerMove }
+					onPointerUp={ handleBackdropPointerUp }
+					onPointerCancel={ handleBackdropPointerUp }
+					onLostPointerCapture={ handleBackdropPointerUp }
+				/>
+			) }
 			{ /*
 			 * The canvas is the interactive, inset surface. Handles and
 			 * the ARIA role/tabIndex live here so pointer geometry
@@ -522,6 +590,7 @@ function CropperInner(
 					freeformCrop={ freeformCrop }
 					stencilTransition={ settleStencilTransition }
 					cropBounds={ cropBounds }
+					viewportZoom={ viewport?.viewport.zoom ?? 1 }
 				/>
 
 				{ /* Rule-of-thirds grid */ }

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -35,6 +35,7 @@ import { useAriaAnnouncer } from '../hooks/use-aria-announcer';
 import { RectangleStencil } from './stencils/rectangle-stencil';
 import { DimmingOverlay } from './overlays/dimming-overlay';
 import { GridOverlay } from './overlays/grid-overlay';
+import { useViewportOptional } from './viewport-provider';
 import './cropper.scss';
 
 /** Threshold for comparing normalized crop rect values. */
@@ -169,6 +170,9 @@ function CropperInner(
 	ref: React.ForwardedRef< HTMLDivElement >
 ) {
 	const { state, setImage, setCropRect, settleCrop } = controller;
+	// Viewport camera — null when used outside a ViewportProvider.
+	const viewport = useViewportOptional();
+
 	// Canvas measurement via ResizeObserver. The canvas is the inner
 	// positioning context for image/stencil/handles — inset from the root
 	// by the handle gutter, so crop math operates on the reduced box.
@@ -291,6 +295,9 @@ function CropperInner(
 		maxZoom,
 		onGestureStart,
 		onGestureEnd,
+		viewportZoom: viewport?.viewport.zoom,
+		viewportPan: viewport?.viewport.pan,
+		setViewportPan: viewport?.setViewportPan,
 	} );
 
 	// Register wheel handler natively with { passive: false } so
@@ -467,6 +474,17 @@ function CropperInner(
 					showInteractiveGrid &&
 						'wp-media-editor-image-editor__canvas--show-grid'
 				) }
+				style={
+					viewport &&
+					( viewport.viewport.zoom !== 1 ||
+						viewport.viewport.pan.x !== 0 ||
+						viewport.viewport.pan.y !== 0 )
+						? {
+								transform: `translate(${ viewport.viewport.pan.x }px, ${ viewport.viewport.pan.y }px) scale(${ viewport.viewport.zoom })`,
+								transformOrigin: 'center center',
+						  }
+						: undefined
+				}
 				tabIndex={ 0 }
 				role="group"
 				aria-label={ __( 'Image editor' ) }

--- a/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
@@ -79,27 +79,6 @@ const KEYBOARD_SETTLE_DELAY = 500;
  */
 type RectangleStencilProps = StencilProps;
 
-/**
- * A rectangular crop stencil with resize handles.
- *
- * In freeform mode, handles resize the crop area. Clicks inside the
- * crop pass through to the container for image panning. The crop
- * auto-centers after resize via SETTLE_CROP.
- *
- * @param props                   Component props implementing StencilProps.
- * @param props.cropRect          The crop rectangle in normalized coordinates.
- * @param props.containerSize     The container element dimensions in pixels.
- * @param props.imageSize         The rendered image dimensions in pixels.
- * @param props.onCropChange      Callback fired when the crop rect changes.
- * @param props.onResizeStart     Callback fired when a resize drag starts.
- * @param props.onResizeEnd       Callback fired when a resize drag ends (mouseup).
- * @param props.aspectRatio       Optional fixed aspect ratio (width / height).
- * @param props.freeformCrop      Whether resize handles are shown.
- * @param props.stencilTransition CSS transition string for settle animation.
- * @param props.cropBounds        Maximum crop rect bounds from camera (zoom/rotation-aware).
- * @param props.onEscape          Called when Escape is pressed on a resize handle.
- * @return The rectangle stencil element.
- */
 export function RectangleStencil( {
 	cropRect,
 	containerSize,
@@ -112,6 +91,7 @@ export function RectangleStencil( {
 	stencilTransition,
 	cropBounds,
 	onEscape,
+	viewportZoom = 1,
 }: RectangleStencilProps ) {
 	// Use cropBounds from the camera if available, otherwise default to [0,1].
 	const boundsMinX = cropBounds?.minX ?? 0;
@@ -478,7 +458,9 @@ export function RectangleStencil( {
 			} }
 		>
 			{ /* The crop rectangle border. pointer-events: none is set in
-				   CSS so clicks pass through to the container for panning. */ }
+				   CSS so clicks pass through to the container for panning.
+				   Counter-scale the border width so it stays 1px regardless
+				   of viewport zoom. */ }
 			<div
 				className="wp-media-editor-image-editor__stencil-rect"
 				style={ {
@@ -486,9 +468,18 @@ export function RectangleStencil( {
 					height: '100%',
 					top: 0,
 					left: 0,
+					borderWidth:
+						viewportZoom !== 1
+							? `${ 1 / viewportZoom }px`
+							: undefined,
 				} }
 			/>
 			{ /* Resize handles — only in freeform mode.
+				   Counter-scale each handle so its visual size stays constant
+				   regardless of viewport zoom. The transform-origin is 50%/50%
+				   (the handle centre), which sits on the crop edge corner, so
+				   the handle stays correctly positioned while shrinking to its
+				   intended 12 px visual size.
 				   Semantics: role="button" with aria-label describing
 				   which edge/corner. Arrow keys resize (onKeyDown).
 				   role="slider" would be more precise but requires
@@ -500,6 +491,11 @@ export function RectangleStencil( {
 						key={ pos }
 						type="button"
 						className={ `wp-media-editor-image-editor__handle wp-media-editor-image-editor__handle--${ pos }` }
+						style={
+							viewportZoom !== 1
+								? { transform: `scale(${ 1 / viewportZoom })` }
+								: undefined
+						}
 						onPointerDown={ ( event ) =>
 							handlePointerDown( pos, event )
 						}

--- a/packages/media-editor/src/image-editor/react/components/viewport-provider.tsx
+++ b/packages/media-editor/src/image-editor/react/components/viewport-provider.tsx
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	useViewportState,
+	type UseViewportStateReturn,
+} from '../hooks/use-viewport-state';
+
+type ViewportContextValue = UseViewportStateReturn | null;
+
+const ViewportContext = createContext< ViewportContextValue >( null );
+
+export function ViewportProvider( {
+	children,
+}: {
+	children: React.ReactNode;
+} ) {
+	const viewportState = useViewportState();
+	return (
+		<ViewportContext.Provider value={ viewportState }>
+			{ children }
+		</ViewportContext.Provider>
+	);
+}
+
+export function useViewport(): UseViewportStateReturn {
+	const context = useContext( ViewportContext );
+	if ( ! context ) {
+		throw new Error(
+			'useViewport must be used within a ViewportProvider.'
+		);
+	}
+	return context;
+}
+
+/**
+ * Like `useViewport` but returns null when used outside a ViewportProvider.
+ * Use this in components that work with or without a viewport context.
+ */
+export function useViewportOptional(): UseViewportStateReturn | null {
+	return useContext( ViewportContext );
+}

--- a/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
@@ -50,6 +50,19 @@ export interface UseInteractionOptions {
 	onGestureStart?: () => void;
 	/** Fires when a continuous gesture ends (pointer release). */
 	onGestureEnd?: () => void;
+	/**
+	 * Current viewport zoom level. Used to de-scale pointer deltas so
+	 * a screen drag of N px moves N/viewportZoom canvas-space px.
+	 */
+	viewportZoom?: number;
+	/** Current viewport pan offset in CSS pixels (for snapshot at drag start). */
+	viewportPan?: { x: number; y: number };
+	/**
+	 * Callback to pan the viewport camera (display-only, does not affect crop).
+	 * When provided, dragging outside the crop area pans the viewport instead
+	 * of the image.
+	 */
+	setViewportPan?: ( pan: { x: number; y: number } ) => void;
 }
 
 /** How long keyboard placement stays active after the latest handled key. */
@@ -124,6 +137,10 @@ export function useInteraction(
 	const actionsRef = useRef( actions );
 	actionsRef.current = actions;
 
+	// Snapshot of the canvas element — captured on every pointerdown so
+	// isOutsideCrop can call getBoundingClientRect() in the same frame.
+	const canvasElRef = useRef< HTMLElement | null >( null );
+
 	const controllerRef = useRef< InteractionController | null >( null );
 	const startPlacementGesture = useCallback( () => {
 		setIsGestureActive( true );
@@ -166,6 +183,8 @@ export function useInteraction(
 					actionsRef.current.snapRotate90( direction ),
 				toggleFlip: ( direction ) =>
 					actionsRef.current.toggleFlip?.( direction ),
+				setViewportPan: ( pan ) =>
+					optionsRef.current?.setViewportPan?.( pan ),
 			},
 			getContainerSize: () => containerSizeRef.current,
 			getImageSize: () => imageSizeRef.current,
@@ -183,6 +202,54 @@ export function useInteraction(
 			},
 			get doubleTapZoom() {
 				return optionsRef.current?.doubleTapZoom;
+			},
+			getViewportZoom: () => optionsRef.current?.viewportZoom ?? 1,
+			getViewportPan: () =>
+				optionsRef.current?.viewportPan ?? { x: 0, y: 0 },
+			isOutsideCrop: ( e: PointerEvent ) => {
+				// Only route to viewport pan when a setViewportPan handler is
+				// available — otherwise there's nothing to pan.
+				if ( ! optionsRef.current?.setViewportPan ) {
+					return false;
+				}
+				const el = canvasElRef.current;
+				if ( ! el ) {
+					return false;
+				}
+				const imgSize = imageSizeRef.current;
+				if ( ! imgSize ) {
+					return false;
+				}
+				const rect = el.getBoundingClientRect();
+				const s = stateRef.current;
+				const vz = optionsRef.current?.viewportZoom ?? 1;
+				// Canvas centre in screen space (getBoundingClientRect
+				// already accounts for the viewport CSS transform).
+				const cx = rect.left + rect.width / 2;
+				const cy = rect.top + rect.height / 2;
+				// Stencil bounds in screen space.
+				const left =
+					cx +
+					( s.cropRect.x * imgSize.width - imgSize.width / 2 ) * vz;
+				const right =
+					cx +
+					( ( s.cropRect.x + s.cropRect.width ) * imgSize.width -
+						imgSize.width / 2 ) *
+						vz;
+				const top =
+					cy +
+					( s.cropRect.y * imgSize.height - imgSize.height / 2 ) * vz;
+				const bottom =
+					cy +
+					( ( s.cropRect.y + s.cropRect.height ) * imgSize.height -
+						imgSize.height / 2 ) *
+						vz;
+				return (
+					e.clientX < left ||
+					e.clientX > right ||
+					e.clientY < top ||
+					e.clientY > bottom
+				);
 			},
 			onGestureStart: () => {
 				startPlacementGesture();
@@ -206,6 +273,9 @@ export function useInteraction(
 
 	const onPointerDown = useCallback( ( e: React.PointerEvent ) => {
 		const el = e.currentTarget as HTMLElement;
+		// Snapshot the canvas element so isOutsideCrop can call
+		// getBoundingClientRect() synchronously during the same event.
+		canvasElRef.current = el;
 		controllerRef.current?.handlePointerDown( e.nativeEvent, el );
 	}, [] );
 

--- a/packages/media-editor/src/image-editor/react/hooks/use-viewport-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-viewport-state.ts
@@ -6,7 +6,7 @@ import { useReducer, useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import type { ViewportState } from '../../core/types';
+import type { ViewportState, Size } from '../../core/types';
 import {
 	viewportReducer,
 	DEFAULT_VIEWPORT_STATE,
@@ -15,7 +15,10 @@ import {
 export interface UseViewportStateReturn {
 	viewport: ViewportState;
 	setViewportZoom: ( zoom: number ) => void;
+	/** Zooms to a new level while keeping the current view centre stationary. */
+	setViewportZoomAtCenter: ( zoom: number ) => void;
 	setViewportPan: ( pan: { x: number; y: number } ) => void;
+	setCanvasSize: ( size: Size ) => void;
 	resetViewport: () => void;
 }
 
@@ -29,13 +32,28 @@ export function useViewportState(): UseViewportStateReturn {
 		dispatch( { type: 'SET_VIEWPORT_ZOOM', payload: zoom } );
 	}, [] );
 
+	const setViewportZoomAtCenter = useCallback( ( zoom: number ) => {
+		dispatch( { type: 'SET_VIEWPORT_ZOOM_AT_CENTER', payload: zoom } );
+	}, [] );
+
 	const setViewportPan = useCallback( ( pan: { x: number; y: number } ) => {
 		dispatch( { type: 'SET_VIEWPORT_PAN', payload: pan } );
+	}, [] );
+
+	const setCanvasSize = useCallback( ( size: Size ) => {
+		dispatch( { type: 'SET_CANVAS_SIZE', payload: size } );
 	}, [] );
 
 	const resetViewport = useCallback( () => {
 		dispatch( { type: 'RESET_VIEWPORT' } );
 	}, [] );
 
-	return { viewport, setViewportZoom, setViewportPan, resetViewport };
+	return {
+		viewport,
+		setViewportZoom,
+		setViewportZoomAtCenter,
+		setViewportPan,
+		setCanvasSize,
+		resetViewport,
+	};
 }

--- a/packages/media-editor/src/image-editor/react/hooks/use-viewport-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-viewport-state.ts
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { useReducer, useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { ViewportState } from '../../core/types';
+import {
+	viewportReducer,
+	DEFAULT_VIEWPORT_STATE,
+} from '../../core/viewport-state';
+
+export interface UseViewportStateReturn {
+	viewport: ViewportState;
+	setViewportZoom: ( zoom: number ) => void;
+	setViewportPan: ( pan: { x: number; y: number } ) => void;
+	resetViewport: () => void;
+}
+
+export function useViewportState(): UseViewportStateReturn {
+	const [ viewport, dispatch ] = useReducer(
+		viewportReducer,
+		DEFAULT_VIEWPORT_STATE
+	);
+
+	const setViewportZoom = useCallback( ( zoom: number ) => {
+		dispatch( { type: 'SET_VIEWPORT_ZOOM', payload: zoom } );
+	}, [] );
+
+	const setViewportPan = useCallback( ( pan: { x: number; y: number } ) => {
+		dispatch( { type: 'SET_VIEWPORT_PAN', payload: pan } );
+	}, [] );
+
+	const resetViewport = useCallback( () => {
+		dispatch( { type: 'RESET_VIEWPORT' } );
+	}, [] );
+
+	return { viewport, setViewportZoom, setViewportPan, resetViewport };
+}


### PR DESCRIPTION
## What?

🚧 🚧 🚧 Just an experiment for now 🚧 🚧 🚧

For the experimental Media Editor Modal, try out a Photoshop-style navigator that's separate from zooming the crop area. It should also allow folks to pan the viewport separately from moving the crop area.

## Why?

To allow more freedom around the cropping area. It's a balancing act as it also might make things feel more complex or hard to use! For now this is just something I'm playing around with, and thought I'd save my progress.

## How?

TBC

## Testing Instructions

TBC

## Screenshots or screencast <!-- if applicable -->

<img width="1266" height="834" alt="image" src="https://github.com/user-attachments/assets/4785c181-829f-4d28-82dd-25ceb6468d8e" />

https://github.com/user-attachments/assets/91578d30-ab89-4b53-bc38-af3242f30329

## Use of AI Tools

Claude Code
