### PR TITLE
Block Editor: Remove unused reducer action types

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -422,45 +422,35 @@ function withPersistentBlockChange( reducer ) {
 	let markNextChangeAsNotPersistent = false;
 
 	return ( state, action ) => {
-		let nextState = reducer( state, action );
+		const nextState = reducer( state, action );
 
-		let nextIsPersistentChange;
+		const wasMarkedAsNotPersistent = markNextChangeAsNotPersistent;
+		markNextChangeAsNotPersistent =
+			action.type === 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT';
+
 		const isExplicitPersistentChange =
 			action.type === 'MARK_LAST_CHANGE_AS_PERSISTENT' ||
-			markNextChangeAsNotPersistent;
+			wasMarkedAsNotPersistent;
 
 		// Defer to previous state value (or default) unless changing or
 		// explicitly marking as persistent.
 		if ( state === nextState && ! isExplicitPersistentChange ) {
-			markNextChangeAsNotPersistent =
-				action.type === 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT';
-
-			nextIsPersistentChange = state?.isPersistentChange ?? true;
-			if ( state.isPersistentChange === nextIsPersistentChange ) {
+			if ( state.isPersistentChange !== undefined ) {
 				return state;
 			}
-
-			return {
-				...nextState,
-				isPersistentChange: nextIsPersistentChange,
-			};
+			return { ...nextState, isPersistentChange: true };
 		}
 
-		nextState = {
-			...nextState,
-			isPersistentChange: isExplicitPersistentChange
-				? ! markNextChangeAsNotPersistent
-				: ! isUpdatingSameBlockAttribute( action, lastAction ),
-		};
+		const isPersistentChange = isExplicitPersistentChange
+			? ! wasMarkedAsNotPersistent
+			: ! isUpdatingSameBlockAttribute( action, lastAction );
 
 		// In comparing against the previous action, consider only those which
 		// would have qualified as one which would have been ignored or not
 		// have resulted in a changed state.
 		lastAction = action;
-		markNextChangeAsNotPersistent =
-			action.type === 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT';
 
-		return nextState;
+		return { ...nextState, isPersistentChange };
 	};
 }
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -292,7 +292,6 @@ const withBlockTree =
 					false
 				);
 				break;
-			case 'SYNC_DERIVED_BLOCK_ATTRIBUTES':
 			case 'UPDATE_BLOCK_ATTRIBUTES': {
 				newState.tree = new Map( newState.tree );
 				action.clientIds.forEach( ( clientId ) => {
@@ -421,27 +420,11 @@ const withBlockTree =
 function withPersistentBlockChange( reducer ) {
 	let lastAction;
 	let markNextChangeAsNotPersistent = false;
-	let explicitPersistent;
 
 	return ( state, action ) => {
 		let nextState = reducer( state, action );
 
 		let nextIsPersistentChange;
-		if ( action.type === 'SET_EXPLICIT_PERSISTENT' ) {
-			explicitPersistent = action.isPersistentChange;
-			nextIsPersistentChange = state.isPersistentChange ?? true;
-		}
-
-		if ( explicitPersistent !== undefined ) {
-			nextIsPersistentChange = explicitPersistent;
-			return nextIsPersistentChange === nextState.isPersistentChange
-				? nextState
-				: {
-						...nextState,
-						isPersistentChange: nextIsPersistentChange,
-				  };
-		}
-
 		const isExplicitPersistentChange =
 			action.type === 'MARK_LAST_CHANGE_AS_PERSISTENT' ||
 			markNextChangeAsNotPersistent;
@@ -897,7 +880,6 @@ export const blocks = pipe(
 				return newState;
 			}
 
-			case 'SYNC_DERIVED_BLOCK_ATTRIBUTES':
 			case 'UPDATE_BLOCK_ATTRIBUTES': {
 				// Avoid a state change if none of the block IDs are known.
 				if ( action.clientIds.every( ( id ) => ! state.get( id ) ) ) {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2196,7 +2196,7 @@ describe( 'state', () => {
 					expect( state.isPersistentChange ).toBe( true );
 				} );
 
-				it( 'should flag the next change as not persistent', () => {
+				it( 'should flag only the next change as not persistent', () => {
 					let original = deepFreeze(
 						blocks( undefined, {
 							type: 'RESET_BLOCKS',
@@ -2213,7 +2213,7 @@ describe( 'state', () => {
 						type: 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT',
 					} );
 
-					const state = blocks( original, {
+					const nextState = blocks( original, {
 						type: 'UPDATE_BLOCK_ATTRIBUTES',
 						clientIds: [ 'kumquat' ],
 						attributes: {
@@ -2221,7 +2221,18 @@ describe( 'state', () => {
 						},
 					} );
 
-					expect( state.isPersistentChange ).toBe( false );
+					expect( nextState.isPersistentChange ).toBe( false );
+
+					// A subsequent change should revert to persistent.
+					const subsequentState = blocks( nextState, {
+						type: 'UPDATE_BLOCK_ATTRIBUTES',
+						clientIds: [ 'kumquat' ],
+						attributes: {
+							other: true,
+						},
+					} );
+
+					expect( subsequentState.isPersistentChange ).toBe( true );
 				} );
 
 				it( 'should retain reference for same state, same persistence', () => {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2196,6 +2196,34 @@ describe( 'state', () => {
 					expect( state.isPersistentChange ).toBe( true );
 				} );
 
+				it( 'should flag the next change as not persistent', () => {
+					let original = deepFreeze(
+						blocks( undefined, {
+							type: 'RESET_BLOCKS',
+							blocks: [
+								{
+									clientId: 'kumquat',
+									attributes: {},
+									innerBlocks: [],
+								},
+							],
+						} )
+					);
+					original = blocks( original, {
+						type: 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT',
+					} );
+
+					const state = blocks( original, {
+						type: 'UPDATE_BLOCK_ATTRIBUTES',
+						clientIds: [ 'kumquat' ],
+						attributes: {
+							updated: true,
+						},
+					} );
+
+					expect( state.isPersistentChange ).toBe( false );
+				} );
+
 				it( 'should retain reference for same state, same persistence', () => {
 					const original = deepFreeze(
 						blocks( undefined, {


### PR DESCRIPTION
## What?
PR removes dead code in the blocks reducer: `SYNC_DERIVED_BLOCK_ATTRIBUTES` (two fall-through cases into `UPDATE_BLOCK_ATTRIBUTES`) and `SET_EXPLICIT_PERSISTENT` (with its `explicitPersistent` branch in `withPersistentBlockChange`). Neither action is dispatched anywhere in the codebase. Introduced via #56235 and #57088.

I've also simplified `withPersistentBlockChange,` and Claude added a unit test for the missing case.

## Testing Instructions
* This should have good test coverage, so just smoke test typing and coalesced text undos.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Claude for review.