### PR TITLE
Content types: Make post type titles clickable to open edit page

### DIFF
--- a/routes/post-types/stage.tsx
+++ b/routes/post-types/stage.tsx
@@ -129,6 +129,10 @@ function PostTypesPage() {
 				paginationInfo={ paginationInfo }
 				defaultLayouts={ defaultLayouts }
 				getItemId={ ( item ) => String( item.id ) }
+				isItemClickable={ () => true }
+				onClickItem={ ( item ) =>
+					navigate( { to: `/edit/${ item.id }` } )
+				}
 			/>
 		</Page>
 	);


### PR DESCRIPTION
## What?
In the content types experiment, makes the post type titles clickable and leading to the edit page.

## Why?
QoL improvement. Also consistency - we recently did it in the taxonomies page.

## How?
Adding `onClickItem` and `isItemClickable`.

## Testing Instructions
* Enable the Content types experiment
* Add a post type
* Go to /wp-admin/options-general.php?page=post-types-wp-admin
* Verify the title is clickable and it leads to the edit page

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

None

## Use of AI Tools

Opus 4.7
