### PR TITLE
RTC: fix stale local snapshots overwriting object+query map operations

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -62,6 +62,7 @@ export type YBlocks = Y.Array< YBlock >;
 export type YBlockAttributes = Y.Map< Y.Text | unknown >;
 
 const serializableBlocksCache = new WeakMap< WeakKey, Block[] >();
+const previousLocalBlocksCache = new WeakMap< YBlocks, Block[] >();
 
 /**
  * Recursively walk an attribute value and convert any RichTextData instances
@@ -398,7 +399,23 @@ export function mergeCrdtBlocks(
 		);
 	}
 	const blocksToSync = serializableBlocksCache.get( incomingBlocks ) ?? [];
+	const previousBlocks = previousLocalBlocksCache.get( yblocks );
 
+	mergeCrdtBlocksIntoYBlocks(
+		yblocks,
+		blocksToSync,
+		cursorPosition,
+		previousBlocks
+	);
+	previousLocalBlocksCache.set( yblocks, blocksToSync );
+}
+
+function mergeCrdtBlocksIntoYBlocks(
+	yblocks: YBlocks,
+	blocksToSync: Block[],
+	cursorPosition: number | null,
+	previousBlocks?: Block[]
+): void {
 	// This is a rudimentary diff implementation similar to the y-prosemirror diffing
 	// approach.
 	// A better implementation would also diff the textual content and represent it
@@ -457,11 +474,13 @@ export function mergeCrdtBlocks(
 	for ( let i = 0; i < numOfUpdatesNeeded; i++, left++ ) {
 		const block = blocksToSync[ left ];
 		const yblock = yblocks.get( left );
+		const previousBlock = previousBlocks?.[ left ];
 
 		Object.entries( block ).forEach( ( [ key, value ] ) => {
 			switch ( key ) {
 				case 'attributes': {
 					const currentAttributes = yblock.get( key );
+					const previousAttributes = previousBlock?.attributes;
 
 					// If attributes are not set on the yblock, use the new values.
 					if ( ! currentAttributes ) {
@@ -476,12 +495,29 @@ export function mergeCrdtBlocks(
 						( [ attributeName, attributeValue ] ) => {
 							const currentAttribute =
 								currentAttributes?.get( attributeName );
+							const previousAttributeValue =
+								previousAttributes?.[ attributeName ];
 
 							const isExpectedType = isExpectedAttributeType(
 								block.name,
 								attributeName,
 								currentAttribute
 							);
+
+							if (
+								previousAttributes &&
+								Object.hasOwn(
+									previousAttributes,
+									attributeName
+								) &&
+								arePlainValuesEqual(
+									previousAttributeValue,
+									attributeValue
+								) &&
+								isExpectedType
+							) {
+								return;
+							}
 
 							// Y types (Y.Text, Y.Array, Y.Map) cannot be
 							// compared with fastDeepEqual against plain values.
@@ -504,7 +540,8 @@ export function mergeCrdtBlocks(
 									attributeName,
 									attributeValue,
 									currentAttributes,
-									cursorPosition
+									cursorPosition,
+									previousAttributeValue
 								);
 							}
 						}
@@ -513,7 +550,14 @@ export function mergeCrdtBlocks(
 					// Delete any attributes that are no longer present.
 					currentAttributes.forEach(
 						( _attrValue: unknown, attrName: string ) => {
-							if ( ! value.hasOwnProperty( attrName ) ) {
+							if (
+								! value.hasOwnProperty( attrName ) &&
+								( ! previousAttributes ||
+									Object.hasOwn(
+										previousAttributes,
+										attrName
+									) )
+							) {
 								currentAttributes.delete( attrName );
 							}
 						}
@@ -531,22 +575,36 @@ export function mergeCrdtBlocks(
 						yblock.set( key, yInnerBlocks );
 					}
 
-					mergeCrdtBlocks(
+					mergeCrdtBlocksIntoYBlocks(
 						yInnerBlocks,
 						value ?? [],
-						cursorPosition
+						cursorPosition,
+						previousBlock?.innerBlocks
 					);
 					break;
 				}
 
 				default:
+					if (
+						previousBlock &&
+						arePlainValuesEqual(
+							block[ key ],
+							previousBlock[ key ]
+						)
+					) {
+						break;
+					}
+
 					if ( ! fastDeepEqual( block[ key ], yblock.get( key ) ) ) {
 						yblock.set( key, value );
 					}
 			}
 		} );
 		yblock.forEach( ( _v, k ) => {
-			if ( ! block.hasOwnProperty( k ) ) {
+			if (
+				! block.hasOwnProperty( k ) &&
+				( ! previousBlock || previousBlock.hasOwnProperty( k ) )
+			) {
 				yblock.delete( k );
 			}
 		} );
@@ -600,6 +658,115 @@ function areArrayElementsEqual(
 	return fastDeepEqual( newElement, yElement );
 }
 
+function arePlainValuesEqual( a: unknown, b: unknown ): boolean {
+	return fastDeepEqual( a, b );
+}
+
+function isExpectedYValueTypeForSchema(
+	schema: BlockAttributeSchema | undefined,
+	newVal: unknown,
+	currentVal: unknown
+): boolean {
+	if ( schema?.type === 'rich-text' ) {
+		return currentVal instanceof Y.Text;
+	}
+
+	if ( schema?.type === 'array' && schema.query && Array.isArray( newVal ) ) {
+		return currentVal instanceof Y.Array;
+	}
+
+	if ( schema?.type === 'object' && schema.query && isRecord( newVal ) ) {
+		return currentVal instanceof Y.Map;
+	}
+
+	return true;
+}
+
+function isYArrayEqualToPlainArray(
+	yArray: Y.Array< unknown >,
+	value: unknown[]
+): boolean {
+	return (
+		yArray.length === value.length &&
+		value.every( ( element, index ) =>
+			areArrayElementsEqual( element, yArray.get( index ) )
+		)
+	);
+}
+
+function findYArrayElementIndex(
+	yArray: Y.Array< unknown >,
+	previousElement: unknown,
+	preferredIndex: number,
+	previousLength: number
+): number {
+	for ( let i = 0; i < yArray.length; i++ ) {
+		if ( areArrayElementsEqual( previousElement, yArray.get( i ) ) ) {
+			return i;
+		}
+	}
+
+	if ( yArray.length === previousLength && preferredIndex < yArray.length ) {
+		return preferredIndex;
+	}
+
+	return preferredIndex < yArray.length ? preferredIndex : -1;
+}
+
+function mergeYArrayLocalChanges(
+	yArray: Y.Array< unknown >,
+	newValue: unknown[],
+	previousValue: unknown[],
+	query: Record< string, BlockAttributeSchema >,
+	cursorPosition: number | null
+): boolean {
+	if ( arePlainValuesEqual( newValue, previousValue ) ) {
+		return true;
+	}
+
+	// No remote divergence: preserve existing behavior for ordinary local
+	// inserts/deletes/reorders.
+	if ( isYArrayEqualToPlainArray( yArray, previousValue ) ) {
+		return false;
+	}
+
+	const sharedLength = Math.min( previousValue.length, newValue.length );
+
+	for ( let i = 0; i < sharedLength; i++ ) {
+		const previousElement = previousValue[ i ];
+		const newElement = newValue[ i ];
+
+		if ( arePlainValuesEqual( previousElement, newElement ) ) {
+			continue;
+		}
+
+		const currentIndex = findYArrayElementIndex(
+			yArray,
+			previousElement,
+			i,
+			previousValue.length
+		);
+
+		if ( currentIndex === -1 ) {
+			continue;
+		}
+
+		const currentElement = yArray.get( currentIndex );
+
+		if ( currentElement instanceof Y.Map && isRecord( newElement ) ) {
+			mergeYMapValues(
+				currentElement,
+				newElement,
+				query,
+				cursorPosition,
+				isRecord( previousElement ) ? previousElement : undefined
+			);
+		}
+	}
+
+	return true;
+}
+
 /**
  * Merge an incoming plain array into an existing Y.Array in-place.
  *
@@ -613,18 +780,34 @@ function areArrayElementsEqual(
  * @param newValue       The new plain array to merge into the Y.Array.
  * @param schema         The attribute schema (must have `query`).
  * @param cursorPosition The local cursor position for rich-text delta merges.
+ * @param previousValue  The previous plain local array value.
  */
 function mergeYArray(
 	yArray: Y.Array< unknown >,
 	newValue: unknown[],
 	schema: BlockAttributeSchema,
-	cursorPosition: number | null
+	cursorPosition: number | null,
+	previousValue?: unknown[]
 ): void {
 	if ( ! schema.query ) {
 		return;
 	}
 
 	const query = schema.query;
+
+	if (
+		previousValue &&
+		mergeYArrayLocalChanges(
+			yArray,
+			newValue,
+			previousValue,
+			query,
+			cursorPosition
+		)
+	) {
+		return;
+	}
+
 	const numOfCommonEntries = Math.min( newValue.length, yArray.length );
 
 	let left = 0;
@@ -722,15 +905,26 @@ function mergeYArray(
  * @param yMap           The Y.Map that owns this entry.
  * @param key            The key of this entry in the Y.Map.
  * @param cursorPosition The local cursor position for rich-text delta merges.
+ * @param previousVal    The previous plain local value for this entry.
  */
 function mergeYValue(
 	schema: BlockAttributeSchema | undefined,
 	newVal: unknown,
 	yMap: Y.Map< unknown >,
 	key: string,
-	cursorPosition: number | null
+	cursorPosition: number | null,
+	previousVal?: unknown
 ): void {
 	const currentVal = yMap.get( key );
+
+	if (
+		previousVal !== undefined &&
+		arePlainValuesEqual( previousVal, newVal ) &&
+		isExpectedYValueTypeForSchema( schema, newVal, currentVal )
+	) {
+		return;
+	}
+
 	if (
 		schema?.type === 'rich-text' &&
 		typeof newVal === 'string' &&
@@ -743,14 +937,26 @@ function mergeYValue(
 		Array.isArray( newVal ) &&
 		currentVal instanceof Y.Array
 	) {
-		mergeYArray( currentVal, newVal, schema, cursorPosition );
+		mergeYArray(
+			currentVal,
+			newVal,
+			schema,
+			cursorPosition,
+			Array.isArray( previousVal ) ? previousVal : undefined
+		);
 	} else if (
 		schema?.type === 'object' &&
 		schema.query &&
 		isRecord( newVal ) &&
 		currentVal instanceof Y.Map
 	) {
-		mergeYMapValues( currentVal, newVal, schema.query, cursorPosition );
+		mergeYMapValues(
+			currentVal,
+			newVal,
+			schema.query,
+			cursorPosition,
+			isRecord( previousVal ) ? previousVal : undefined
+		);
 	} else {
 		const newYValue = createYValueFromSchema( schema, newVal );
 
@@ -773,20 +979,47 @@ function mergeYValue(
  * @param newObj         The new plain object to merge into the Y.Map.
  * @param query          The query schema defining property types.
  * @param cursorPosition The local cursor position for rich-text delta merges.
+ * @param previousObj    The previous plain local object value.
  */
 function mergeYMapValues(
 	yMap: Y.Map< unknown >,
 	newObj: Record< string, unknown >,
 	query: Record< string, BlockAttributeSchema >,
-	cursorPosition: number | null
+	cursorPosition: number | null,
+	previousObj?: Record< string, unknown >
 ): void {
 	for ( const [ key, newVal ] of Object.entries( newObj ) ) {
-		mergeYValue( query[ key ], newVal, yMap, key, cursorPosition );
+		const previousVal = previousObj?.[ key ];
+
+		if (
+			previousObj &&
+			Object.hasOwn( previousObj, key ) &&
+			arePlainValuesEqual( previousVal, newVal ) &&
+			isExpectedYValueTypeForSchema(
+				query[ key ],
+				newVal,
+				yMap.get( key )
+			)
+		) {
+			continue;
+		}
+
+		mergeYValue(
+			query[ key ],
+			newVal,
+			yMap,
+			key,
+			cursorPosition,
+			previousVal
+		);
 	}
 
 	// Delete properties absent from the incoming object.
 	for ( const key of yMap.keys() ) {
-		if ( ! Object.hasOwn( newObj, key ) ) {
+		if (
+			! Object.hasOwn( newObj, key ) &&
+			( ! previousObj || Object.hasOwn( previousObj, key ) )
+		) {
 			yMap.delete( key );
 		}
 	}
@@ -795,18 +1028,20 @@ function mergeYMapValues(
 /**
  * Update a single attribute on a Yjs block attributes map (currentAttributes).
  *
- * @param blockName         The block type name, e.g. 'core/paragraph'.
- * @param attributeName     The name of the attribute to update, e.g. 'content'.
- * @param attributeValue    The new value for the attribute.
- * @param currentAttributes The Y.Map holding the block's current attributes.
- * @param cursorPosition    The local cursor position, used when merging rich-text deltas.
+ * @param blockName              The block type name, e.g. 'core/paragraph'.
+ * @param attributeName          The name of the attribute to update, e.g. 'content'.
+ * @param attributeValue         The new value for the attribute.
+ * @param currentAttributes      The Y.Map holding the block's current attributes.
+ * @param cursorPosition         The local cursor position, used when merging rich-text deltas.
+ * @param previousAttributeValue The previous plain local value for the attribute.
  */
 function updateYBlockAttribute(
 	blockName: string,
 	attributeName: string,
 	attributeValue: unknown,
 	currentAttributes: YBlockAttributes,
-	cursorPosition: number | null
+	cursorPosition: number | null,
+	previousAttributeValue?: unknown
 ): void {
 	const schema = getBlockAttributeSchema( blockName, attributeName );
 
@@ -815,7 +1050,8 @@ function updateYBlockAttribute(
 		attributeValue,
 		currentAttributes,
 		attributeName,
-		cursorPosition
+		cursorPosition,
+		previousAttributeValue
 	);
 }
 

--- a/packages/core-data/src/utils/test/crdt-object-query-stale-snapshot-repro.test.ts
+++ b/packages/core-data/src/utils/test/crdt-object-query-stale-snapshot-repro.test.ts
@@ -1,0 +1,234 @@
+/**
+ * WordPress dependencies
+ */
+import { Y } from '@wordpress/sync';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+
+jest.mock( 'uuid', () => ( {
+	v4: () => 'mocked-uuid',
+} ) );
+
+jest.mock( '@wordpress/blocks', () => {
+	const actual = jest.requireActual( '@wordpress/blocks' ) as Record<
+		string,
+		unknown
+	>;
+
+	return {
+		...actual,
+		__unstableSerializeAndClean: ( blocks: unknown ) =>
+			JSON.stringify( blocks ),
+		getBlockTypes: () => [
+			{
+				name: 'test/object-query-card',
+				attributes: {
+					hero: {
+						type: 'object',
+						query: {
+							headline: { type: 'string' },
+							caption: { type: 'string' },
+						},
+					},
+				},
+			},
+		],
+	};
+} );
+
+/**
+ * Internal dependencies
+ */
+import { applyPostChangesToCRDTDoc, getPostChangesFromCRDTDoc } from '../crdt';
+import {
+	mergeCrdtBlocks,
+	type Block,
+	type YBlock,
+	type YBlockAttributes,
+} from '../crdt-blocks';
+import { getRootMap } from '../crdt-utils';
+import { CRDT_RECORD_MAP_KEY } from '../../sync';
+import type { Post } from '../../entity-types/post';
+
+const syncedProperties = new Set( [ 'blocks' ] );
+
+function objectQueryBlock( hero: {
+	headline?: string;
+	caption?: string;
+} ): Block {
+	return {
+		name: 'test/object-query-card',
+		attributes: {
+			hero,
+		},
+		innerBlocks: [],
+		clientId: 'object-query-card-1',
+	};
+}
+
+function getHeroFromBlocks( yblocks: Y.Array< YBlock > ) {
+	const attributes = yblocks.get( 0 ).get( 'attributes' ) as YBlockAttributes;
+
+	return attributes.get( 'hero' ) as Y.Map< unknown >;
+}
+
+function getHeroFromDoc( doc: Y.Doc ) {
+	const record = getRootMap< { blocks: Y.Array< YBlock > } >(
+		doc,
+		CRDT_RECORD_MAP_KEY
+	);
+	const yblocks = record.get( 'blocks' );
+
+	if ( ! ( yblocks instanceof Y.Array ) ) {
+		throw new Error( 'Expected CRDT doc to contain blocks.' );
+	}
+
+	return getHeroFromBlocks( yblocks );
+}
+
+function applyRemoteUpdate( receiver: Y.Doc, sender: Y.Doc ) {
+	Y.applyUpdate( receiver, Y.encodeStateAsUpdate( sender ) );
+}
+
+describe( 'object+query stale snapshot repro', () => {
+	it( 'mergeCrdtBlocks preserves a remote sibling object property update', () => {
+		const docA = new Y.Doc();
+		const docB = new Y.Doc();
+		const blocksA = docA.getArray< YBlock >();
+		const blocksB = docB.getArray< YBlock >();
+		const initialBlocks = [
+			objectQueryBlock( {
+				headline: 'headline before',
+				caption: 'caption before',
+			} ),
+		];
+
+		mergeCrdtBlocks( blocksA, initialBlocks, null );
+		applyRemoteUpdate( docB, docA );
+
+		const staleLocalSnapshot = [
+			objectQueryBlock( {
+				headline: 'headline from user A',
+				caption: 'caption before',
+			} ),
+		];
+		const remoteCaptionUpdate = [
+			objectQueryBlock( {
+				headline: 'headline before',
+				caption: 'caption from user B',
+			} ),
+		];
+
+		mergeCrdtBlocks( blocksB, remoteCaptionUpdate, null );
+		applyRemoteUpdate( docA, docB );
+		expect( getHeroFromBlocks( blocksA ).get( 'caption' ) ).toBe(
+			'caption from user B'
+		);
+
+		mergeCrdtBlocks( blocksA, staleLocalSnapshot, null );
+
+		expect( getHeroFromBlocks( blocksA ).toJSON() ).toEqual( {
+			headline: 'headline from user A',
+			caption: 'caption from user B',
+		} );
+	} );
+
+	it( 'mergeCrdtBlocks preserves a remote sibling object property delete', () => {
+		const docA = new Y.Doc();
+		const docB = new Y.Doc();
+		const blocksA = docA.getArray< YBlock >();
+		const blocksB = docB.getArray< YBlock >();
+		const initialBlocks = [
+			objectQueryBlock( {
+				headline: 'headline before',
+				caption: 'caption before',
+			} ),
+		];
+
+		mergeCrdtBlocks( blocksA, initialBlocks, null );
+		applyRemoteUpdate( docB, docA );
+
+		const staleLocalSnapshot = [
+			objectQueryBlock( {
+				headline: 'headline from user A',
+				caption: 'caption before',
+			} ),
+		];
+		const remoteCaptionDelete = [
+			objectQueryBlock( {
+				headline: 'headline before',
+			} ),
+		];
+
+		mergeCrdtBlocks( blocksB, remoteCaptionDelete, null );
+		applyRemoteUpdate( docA, docB );
+		expect( getHeroFromBlocks( blocksA ).has( 'caption' ) ).toBe( false );
+
+		mergeCrdtBlocks( blocksA, staleLocalSnapshot, null );
+
+		expect( getHeroFromBlocks( blocksA ).toJSON() ).toEqual( {
+			headline: 'headline from user A',
+		} );
+	} );
+
+	it( 'post CRDT adapter preserves remote object+query sibling changes', () => {
+		const docA = new Y.Doc();
+		const docB = new Y.Doc();
+		const initialBlocks = [
+			objectQueryBlock( {
+				headline: 'headline before',
+				caption: 'caption before',
+			} ),
+		];
+
+		applyPostChangesToCRDTDoc(
+			docA,
+			{ blocks: initialBlocks },
+			syncedProperties
+		);
+		applyRemoteUpdate( docB, docA );
+
+		const staleLocalSnapshot = [
+			objectQueryBlock( {
+				headline: 'headline from user A',
+				caption: 'caption before',
+			} ),
+		];
+		const remoteCaptionUpdate = [
+			objectQueryBlock( {
+				headline: 'headline before',
+				caption: 'caption from user B',
+			} ),
+		];
+
+		applyPostChangesToCRDTDoc(
+			docB,
+			{ blocks: remoteCaptionUpdate },
+			syncedProperties
+		);
+		applyRemoteUpdate( docA, docB );
+		expect( getHeroFromDoc( docA ).get( 'caption' ) ).toBe(
+			'caption from user B'
+		);
+
+		applyPostChangesToCRDTDoc(
+			docA,
+			{ blocks: staleLocalSnapshot },
+			syncedProperties
+		);
+
+		const changes = getPostChangesFromCRDTDoc(
+			docA,
+			{ blocks: initialBlocks } as unknown as Post,
+			syncedProperties
+		);
+
+		expect( ( changes.blocks as Block[] )[ 0 ].attributes.hero ).toEqual( {
+			headline: 'headline from user A',
+			caption: 'caption from user B',
+		} );
+	} );
+} );

--- a/packages/core-data/src/utils/test/crdt-stale-query-array-post.test.ts
+++ b/packages/core-data/src/utils/test/crdt-stale-query-array-post.test.ts
@@ -1,0 +1,260 @@
+/**
+ * WordPress dependencies
+ */
+import { RichTextData } from '@wordpress/rich-text';
+import { Y } from '@wordpress/sync';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest, afterEach } from '@jest/globals';
+
+jest.mock( '@wordpress/blocks', () => {
+	const actual = jest.requireActual( '@wordpress/blocks' ) as Record<
+		string,
+		unknown
+	>;
+	return {
+		...actual,
+		getBlockTypes: () => [
+			{
+				name: 'core/table',
+				attributes: {
+					body: {
+						type: 'array',
+						query: {
+							cells: {
+								type: 'array',
+								query: {
+									content: { type: 'rich-text' },
+									tag: { type: 'string' },
+								},
+							},
+						},
+					},
+				},
+			},
+		],
+	};
+} );
+
+/**
+ * Internal dependencies
+ */
+import {
+	applyPostChangesToCRDTDoc,
+	getPostChangesFromCRDTDoc,
+	type PostChanges,
+} from '../crdt';
+import type { Block } from '../crdt-blocks';
+import type { Post } from '../../entity-types';
+
+const syncedProperties = new Set( [ 'blocks' ] );
+const RANDOM_SEEDS = Array.from(
+	{ length: 24 },
+	( _value, index ) => index + 1
+);
+
+function tableBlock( rows: string[][] ): Block {
+	return {
+		name: 'core/table',
+		clientId: 'table-1',
+		attributes: {
+			body: rows.map( ( cells ) => ( {
+				cells: cells.map( ( content ) => ( { content, tag: 'td' } ) ),
+			} ) ),
+		},
+		innerBlocks: [],
+	};
+}
+
+function applyBlocks( doc: Y.Doc, blocks: Block[] ) {
+	applyPostChangesToCRDTDoc(
+		doc,
+		{ blocks } as PostChanges,
+		syncedProperties
+	);
+}
+
+function syncDocs( from: Y.Doc, to: Y.Doc ) {
+	Y.applyUpdate( to, Y.encodeStateAsUpdate( from ) );
+}
+
+function textValue( value: unknown ): string {
+	if ( value instanceof RichTextData ) {
+		return value.text;
+	}
+	return String( value );
+}
+
+function getBody( doc: Y.Doc ): string[][] {
+	const changes = getPostChangesFromCRDTDoc(
+		doc,
+		{ blocks: [] } as unknown as Post,
+		syncedProperties
+	);
+	const block = ( changes.blocks as Block[] )[ 0 ];
+	const body = block.attributes.body as {
+		cells: { content: unknown }[];
+	}[];
+
+	return body.map( ( row ) =>
+		row.cells.map( ( cell ) => textValue( cell.content ) )
+	);
+}
+
+function cloneRows( rows: string[][] ): string[][] {
+	return rows.map( ( cells ) => [ ...cells ] );
+}
+
+/* eslint-disable no-bitwise */
+function createSeededRandom( seed: number ) {
+	let state = seed >>> 0;
+
+	function next() {
+		state += 0x6d2b79f5;
+		let value = state;
+		value = Math.imul( value ^ ( value >>> 15 ), value | 1 );
+		value ^= value + Math.imul( value ^ ( value >>> 7 ), value | 61 );
+		return ( ( value ^ ( value >>> 14 ) ) >>> 0 ) / 0x100000000;
+	}
+
+	return {
+		int( maxExclusive: number ) {
+			return Math.floor( next() * maxExclusive );
+		},
+		pick< T >( values: readonly T[] ): T {
+			return values[ this.int( values.length ) ];
+		},
+	};
+}
+/* eslint-enable no-bitwise */
+
+function rowsContain( rows: string[][], value: string ): boolean {
+	return rows.some( ( row ) => row.includes( value ) );
+}
+
+function runRandomStaleTableScenario( seed: number ) {
+	const random = createSeededRandom( seed );
+	const docA = new Y.Doc();
+	const docB = new Y.Doc();
+	const initialRows = [
+		[ `seed-${ seed }-A1`, `seed-${ seed }-B1` ],
+		[ `seed-${ seed }-A2`, `seed-${ seed }-B2` ],
+		[ `seed-${ seed }-A3`, `seed-${ seed }-B3` ],
+	];
+	const staleLocalRows = cloneRows( initialRows );
+	const remoteRows = cloneRows( initialRows );
+	const localMarker = `local-${ seed }`;
+	const remoteMarker = `remote-${ seed }`;
+	const scenario = random.pick( [
+		'remote-cell-edit',
+		'remote-append-row',
+		'remote-prepend-row',
+		'remote-delete-row',
+	] as const );
+
+	try {
+		applyBlocks( docA, [ tableBlock( initialRows ) ] );
+		syncDocs( docA, docB );
+
+		switch ( scenario ) {
+			case 'remote-cell-edit':
+				remoteRows[ 1 ][ 1 ] = remoteMarker;
+				break;
+
+			case 'remote-append-row':
+				remoteRows.push( [ remoteMarker, `remote-tail-${ seed }` ] );
+				break;
+
+			case 'remote-prepend-row':
+				remoteRows.unshift( [ remoteMarker, `remote-head-${ seed }` ] );
+				break;
+
+			case 'remote-delete-row':
+				remoteRows[ 2 ][ 0 ] = remoteMarker;
+				applyBlocks( docA, [ tableBlock( remoteRows ) ] );
+				syncDocs( docA, docB );
+				remoteRows.splice( 2, 1 );
+				break;
+		}
+
+		applyBlocks( docB, [ tableBlock( remoteRows ) ] );
+		syncDocs( docB, docA );
+
+		staleLocalRows[ 0 ][ 0 ] = localMarker;
+		applyBlocks( docA, [ tableBlock( staleLocalRows ) ] );
+
+		const body = getBody( docA );
+		expect( rowsContain( body, localMarker ) ).toBe( true );
+
+		if ( scenario === 'remote-delete-row' ) {
+			expect( rowsContain( body, remoteMarker ) ).toBe( false );
+		} else {
+			expect( rowsContain( body, remoteMarker ) ).toBe( true );
+		}
+	} catch ( error ) {
+		throw new Error(
+			`Stale table scenario failed for seed ${ seed } (${ scenario }): ${
+				error instanceof Error ? error.message : String( error )
+			}`
+		);
+	} finally {
+		docA.destroy();
+		docB.destroy();
+	}
+}
+
+describe( 'post CRDT stale query-array snapshots', () => {
+	const docs: Y.Doc[] = [];
+
+	afterEach( () => {
+		for ( const doc of docs ) {
+			doc.destroy();
+		}
+		docs.length = 0;
+	} );
+
+	it( 'preserves a remote table cell edit through the post changes adapter', () => {
+		const docA = new Y.Doc();
+		const docB = new Y.Doc();
+		docs.push( docA, docB );
+
+		applyBlocks( docA, [
+			tableBlock( [
+				[ 'A1', 'B1' ],
+				[ 'A2', 'B2' ],
+			] ),
+		] );
+		syncDocs( docA, docB );
+
+		applyBlocks( docB, [
+			tableBlock( [
+				[ 'A1', 'B1' ],
+				[ 'A2', 'remote-B2' ],
+			] ),
+		] );
+		syncDocs( docB, docA );
+		expect( getBody( docA )[ 1 ][ 1 ] ).toBe( 'remote-B2' );
+
+		applyBlocks( docA, [
+			tableBlock( [
+				[ 'local-A1', 'B1' ],
+				[ 'A2', 'B2' ],
+			] ),
+		] );
+
+		expect( getBody( docA ) ).toEqual( [
+			[ 'local-A1', 'B1' ],
+			[ 'A2', 'remote-B2' ],
+		] );
+	} );
+
+	it.each( RANDOM_SEEDS )(
+		'preserves acknowledged remote table operations after a stale local snapshot (seed %i)',
+		( seed ) => {
+			expect.hasAssertions();
+			runRandomStaleTableScenario( seed );
+		}
+	);
+} );

--- a/packages/core-data/src/utils/test/crdt-stale-query-array.test.ts
+++ b/packages/core-data/src/utils/test/crdt-stale-query-array.test.ts
@@ -1,0 +1,176 @@
+/**
+ * WordPress dependencies
+ */
+import { Y } from '@wordpress/sync';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest, afterEach } from '@jest/globals';
+
+jest.mock( '@wordpress/blocks', () => ( {
+	getBlockTypes: () => [
+		{
+			name: 'core/table',
+			attributes: {
+				body: {
+					type: 'array',
+					query: {
+						cells: {
+							type: 'array',
+							query: {
+								content: { type: 'rich-text' },
+								tag: { type: 'string' },
+							},
+						},
+					},
+				},
+			},
+		},
+	],
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import { mergeCrdtBlocks, type Block, type YBlock } from '../crdt-blocks';
+
+function tableBlock( rows: string[][] ): Block {
+	return {
+		name: 'core/table',
+		clientId: 'table-1',
+		attributes: {
+			body: rows.map( ( cells ) => ( {
+				cells: cells.map( ( content ) => ( { content, tag: 'td' } ) ),
+			} ) ),
+		},
+		innerBlocks: [],
+	};
+}
+
+function syncDocs( from: Y.Doc, to: Y.Doc ) {
+	Y.applyUpdate( to, Y.encodeStateAsUpdate( from ) );
+}
+
+function getTableBody( yblocks: Y.Array< YBlock > ) {
+	return yblocks.toJSON()[ 0 ].attributes.body as {
+		cells: { content: string }[];
+	}[];
+}
+
+describe( 'stale query-array block snapshots', () => {
+	const docs: Y.Doc[] = [];
+
+	afterEach( () => {
+		for ( const doc of docs ) {
+			doc.destroy();
+		}
+		docs.length = 0;
+	} );
+
+	function createSyncedDocs( initialRows: string[][] ) {
+		const docA = new Y.Doc();
+		const docB = new Y.Doc();
+		docs.push( docA, docB );
+
+		const yblocksA = docA.getArray< YBlock >();
+		const yblocksB = docB.getArray< YBlock >();
+
+		mergeCrdtBlocks( yblocksA, [ tableBlock( initialRows ) ], null );
+		syncDocs( docA, docB );
+
+		return { docA, docB, yblocksA, yblocksB };
+	}
+
+	it( 'preserves a remote nested cell edit after a stale local cell edit', () => {
+		const { docA, docB, yblocksA, yblocksB } = createSyncedDocs( [
+			[ 'A1', 'B1' ],
+			[ 'A2', 'B2' ],
+		] );
+
+		mergeCrdtBlocks(
+			yblocksB,
+			[
+				tableBlock( [
+					[ 'A1', 'B1' ],
+					[ 'A2', 'remote-B2' ],
+				] ),
+			],
+			null
+		);
+		syncDocs( docB, docA );
+		expect( getTableBody( yblocksA )[ 1 ].cells[ 1 ].content ).toBe(
+			'remote-B2'
+		);
+
+		mergeCrdtBlocks(
+			yblocksA,
+			[
+				tableBlock( [
+					[ 'local-A1', 'B1' ],
+					[ 'A2', 'B2' ],
+				] ),
+			],
+			null
+		);
+
+		const body = getTableBody( yblocksA );
+		expect( body[ 0 ].cells[ 0 ].content ).toBe( 'local-A1' );
+		expect( body[ 1 ].cells[ 1 ].content ).toBe( 'remote-B2' );
+	} );
+
+	it( 'preserves a remote appended row after a stale local cell edit', () => {
+		const { docA, docB, yblocksA, yblocksB } = createSyncedDocs( [
+			[ 'A1' ],
+			[ 'A2' ],
+		] );
+
+		mergeCrdtBlocks(
+			yblocksB,
+			[ tableBlock( [ [ 'A1' ], [ 'A2' ], [ 'remote-A3' ] ] ) ],
+			null
+		);
+		syncDocs( docB, docA );
+		expect( getTableBody( yblocksA ) ).toHaveLength( 3 );
+
+		mergeCrdtBlocks(
+			yblocksA,
+			[ tableBlock( [ [ 'local-A1' ], [ 'A2' ] ] ) ],
+			null
+		);
+
+		const body = getTableBody( yblocksA );
+		expect( body ).toHaveLength( 3 );
+		expect( body[ 0 ].cells[ 0 ].content ).toBe( 'local-A1' );
+		expect( body[ 2 ].cells[ 0 ].content ).toBe( 'remote-A3' );
+	} );
+
+	it( 'does not resurrect a remotely deleted row from a stale local snapshot', () => {
+		const { docA, docB, yblocksA, yblocksB } = createSyncedDocs( [
+			[ 'A1' ],
+			[ 'A2' ],
+			[ 'A3' ],
+		] );
+
+		mergeCrdtBlocks(
+			yblocksB,
+			[ tableBlock( [ [ 'A1' ], [ 'A2' ] ] ) ],
+			null
+		);
+		syncDocs( docB, docA );
+		expect( getTableBody( yblocksA ) ).toHaveLength( 2 );
+
+		mergeCrdtBlocks(
+			yblocksA,
+			[ tableBlock( [ [ 'local-A1' ], [ 'A2' ], [ 'A3' ] ] ) ],
+			null
+		);
+
+		const body = getTableBody( yblocksA );
+		expect( body ).toHaveLength( 2 );
+		expect( body[ 0 ].cells[ 0 ].content ).toBe( 'local-A1' );
+		expect( body.map( ( row ) => row.cells[ 0 ].content ) ).not.toContain(
+			'A3'
+		);
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/collaboration-table-stale-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-table-stale-snapshot.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+const ONE_COLUMN_TABLE = `<!-- wp:table -->
+<figure class="wp-block-table"><table><tbody><tr><td></td></tr><tr><td></td></tr></tbody></table></figure>
+<!-- /wp:table -->`;
+
+const TWO_COLUMN_TABLE = `<!-- wp:table -->
+<figure class="wp-block-table"><table><tbody><tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></tbody></table></figure>
+<!-- /wp:table -->`;
+
+async function getBodyCellTexts( editor: any ): Promise< string[] > {
+	const texts = await editor.canvas
+		.locator( 'role=textbox[name="Body cell text"i]' )
+		.allTextContents();
+	return texts.map( ( text: string ) => text.replace( /\uFEFF/g, '' ) );
+}
+
+async function typeInBodyCell(
+	page: any,
+	editor: any,
+	index: number,
+	text: string
+) {
+	const cell = editor.canvas
+		.locator( 'role=textbox[name="Body cell text"i]' )
+		.nth( index );
+	await cell.click();
+	await page.keyboard.type( text );
+}
+
+async function replaceHtmlModeText( editor: any, text: string ) {
+	const htmlEditor = editor.canvas.locator(
+		'textarea.block-editor-block-list__block-html-textarea'
+	);
+	await htmlEditor.click();
+	await htmlEditor.fill( text );
+}
+
+test.describe( 'Collaboration - table stale snapshots', () => {
+	test( 'preserves a remotely inserted table row when another user edits a stale HTML snapshot', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'RTC table stale HTML snapshot',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+			content: TWO_COLUMN_TABLE,
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { page2, editor2 } = collaborationUtils;
+
+		await expect
+			.poll( () => getBodyCellTexts( editor ), { timeout: 10_000 } )
+			.toEqual( [ 'A1', 'B1', 'A2', 'B2' ] );
+		await expect
+			.poll( () => getBodyCellTexts( editor2 ), { timeout: 10_000 } )
+			.toEqual( [ 'A1', 'B1', 'A2', 'B2' ] );
+
+		await editor.canvas
+			.locator( 'role=textbox[name="Body cell text"i]' )
+			.nth( 0 )
+			.click();
+		await editor.clickBlockOptionsMenuItem( 'Edit as HTML' );
+		const userAHtml = editor.canvas.locator(
+			'textarea.block-editor-block-list__block-html-textarea'
+		);
+		await expect( userAHtml ).toHaveValue( /A1/ );
+
+		await editor2.canvas
+			.locator( 'role=textbox[name="Body cell text"i]' )
+			.nth( 0 )
+			.click();
+		await editor2.clickBlockToolbarButton( 'Edit table' );
+		await page2
+			.getByRole( 'menuitem', { name: 'Insert row after' } )
+			.click();
+		await typeInBodyCell( page2, editor2, 2, 'A-new' );
+		await typeInBodyCell( page2, editor2, 3, 'B-new' );
+
+		await expect
+			.poll( () => getBodyCellTexts( editor2 ), { timeout: 10_000 } )
+			.toEqual( [ 'A1', 'B1', 'A-new', 'B-new', 'A2', 'B2' ] );
+
+		const staleHtml = await userAHtml.inputValue();
+		await replaceHtmlModeText(
+			editor,
+			staleHtml.replace( 'A1', 'A1 local HTML edit' )
+		);
+		await expect( userAHtml ).toHaveValue( /A1 local HTML edit/ );
+		await editor.clickBlockOptionsMenuItem( 'Edit visually' );
+
+		const expectedCells = [
+			'A1 local HTML edit',
+			'B1',
+			'A-new',
+			'B-new',
+			'A2',
+			'B2',
+		];
+
+		await expect
+			.poll( () => getBodyCellTexts( editor ), { timeout: 15_000 } )
+			.toEqual( expectedCells );
+		await expect
+			.poll( () => getBodyCellTexts( editor2 ), { timeout: 15_000 } )
+			.toEqual( expectedCells );
+	} );
+
+	test( 'preserves a remotely appended table row when another user edits a different cell', async ( {
+		collaborationUtils,
+		requestUtils,
+		page,
+		editor,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'RTC table stale append',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+			content: ONE_COLUMN_TABLE,
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { page2, editor2 } = collaborationUtils;
+
+		await expect
+			.poll( () => getBodyCellTexts( editor ), { timeout: 10_000 } )
+			.toEqual( [ '', '' ] );
+		await expect
+			.poll( () => getBodyCellTexts( editor2 ), { timeout: 10_000 } )
+			.toEqual( [ '', '' ] );
+
+		const userAReceivesSync = page.waitForResponse(
+			( response ) =>
+				response.url().includes( 'wp-sync' ) &&
+				response.status() === 200,
+			{ timeout: 15_000 }
+		);
+
+		await editor2.canvas
+			.locator( 'role=textbox[name="Body cell text"i]' )
+			.nth( 1 )
+			.click();
+		await editor2.clickBlockToolbarButton( 'Edit table' );
+		await page2
+			.getByRole( 'menuitem', { name: 'Insert row after' } )
+			.click();
+
+		await userAReceivesSync;
+		await typeInBodyCell( page, editor, 0, 'local-A1' );
+
+		await expect
+			.poll( () => getBodyCellTexts( editor ), { timeout: 15_000 } )
+			.toEqual( [ 'local-A1', '', '' ] );
+		await expect
+			.poll( () => getBodyCellTexts( editor2 ), { timeout: 15_000 } )
+			.toEqual( [ 'local-A1', '', '' ] );
+	} );
+} );


### PR DESCRIPTION
This is part of an AI fuzzing project, where an AI wrote a fuzzer and then triages bugs from the fuzzer and creates fixes. See #77716 for the tracking issue. As of this writing, there have been no known false positives from this project, but there have been some issues, which are documented in #77716. I expect we’ll see false positives at some point (and may even have one that’s been filed in a PR that hasn’t been inspected by a code owner yet).

## What?

Here's a video demonstrating a repro for this issue (specifically, italicizing some text causes HTML to get corrupted):

https://github.com/user-attachments/assets/3212e992-67d8-4a85-ac81-b136975e56c0

Unlike a lot of PRs in the #77716 series of PRs, this makes a moderately large change to the code. For a lot of the tiny tactical fixes, I think there's a very strong case for putting the fix in even if the approach should change because real users are running into issues frequently (or, that's my experience when using RTC, anyway), but if you prefer a different approach here it's possible the fix should be something fairly different. Please note the "open questions" at the bottom of the AI description for the issue and PR here.

## AI TEXT

Object-backed `query` attributes are stored as nested `Y.Map` values, but the
current local merge path treats every incoming plain object snapshot as the full
desired value. If user A has a stale local editor snapshot of
`attributes.hero`, receives user B's remote update to `hero.caption`, and then
changes only `hero.headline`, the stale local snapshot writes the old
`hero.caption` back into the CRDT document. The same path resurrects a remote
delete when the stale object still contains the deleted key.

The focused example uses a custom block with this attribute schema:

```js
hero: {
	type: 'object',
	query: {
		headline: { type: 'string' },
		caption: { type: 'string' },
	},
}
```

## Status against known fixes

Base tested for the issue branch:
`5ddf4ad1b34bb0798185a663437955e7f10da01b` (`origin/trunk`), which already
contains the merged large-update fix from
[#77669](https://github.com/WordPress/gutenberg/pull/77669) and the merged
follow-up listed in the fuzz tracking issue,
[#77681](https://github.com/WordPress/gutenberg/pull/77681).

I reviewed the tracking issue
[#77716](https://github.com/WordPress/gutenberg/issues/77716), its listed PRs,
comments, and related open RTC fixes. Most listed fixes are not on the
object+query map merge path: the title reload fix
[#77666](https://github.com/WordPress/gutenberg/pull/77666), awareness fixes
[#77673](https://github.com/WordPress/gutenberg/pull/77673) and
[#77678](https://github.com/WordPress/gutenberg/issues/77678), room storage work
[#77675](https://github.com/WordPress/gutenberg/pull/77675), and the test-only
cursor scope PR [#77662](https://github.com/WordPress/gutenberg/pull/77662).

I applied the focused repros to the relevant branches that do touch nearby RTC
merge code:

| Ref tested | Result |
| --- | --- |
| `origin/trunk` at `5ddf4ad1b34` | Fails the unit/model, post-adapter, and Playwright repros. |
| `danluu/try/offset-space-bug-pr` at `cfcfe75228f` ([#77658](https://github.com/WordPress/gutenberg/pull/77658)) | Fails all three focused unit tests. |
| `danluu/try/rtc-duplicate-table-rows-stock-repro-pr-trunk` at `2e153b32280` ([#77723](https://github.com/WordPress/gutenberg/pull/77723)) | Fails the focused object+query map tests. That branch adds stable IDs for query-array elements, but the object map stale-snapshot overwrite remains. |
| `danluu/try/fuzz-known-issues-fixed-campaign` at `220392e83e9` | The direct `mergeCrdtBlocks()` update and delete repros still fail with the stale caption restored. The post-adapter helper diverges on that campaign branch, so the merge-level result is the useful signal there. |

### Current trunk and newer danluu branch revalidation

I re-fetched current refs on 2026-05-01:

```bash
git fetch origin trunk
git fetch danluu '+refs/heads/*:refs/remotes/danluu/*'
```

Current `origin/trunk` was `68484244df2d`. The proposed PR branch
`danluu/try/stale-query-object-map-pr` is rebased on that trunk and has this
three-commit structure:

```text
eb4c6383612 Add RTC stale snapshot merge repros
7fa898389e0 Add RTC stale table Playwright repro
17f5c915e93 Preserve remote CRDT edits from stale local snapshots
```

| Ref tested | Why tested | Command/result |
| --- | --- | --- |
| `7fa898389e0` (`origin/trunk` plus repro tests, no fix) | Current trunk baseline for the stock Table browser repro. | `WP_ENV_PORT=8922 WP_BASE_URL=http://localhost:8922 WP_ARTIFACTS_PATH=/Users/danluu/dev/fuzz/gutenberg-stale-query-object-map-baseline-rebased-check/artifacts/repeat-baseline-post-rebase-8922 npm run test:e2e -- test/e2e/specs/editor/collaboration/collaboration-table-stale-snapshot.spec.ts --project=chromium --grep "stale HTML snapshot" --repeat-each=5 --retries=0` failed 5/5 on user-visible table preservation assertions. |
| `17f5c915e93` (`danluu/try/stale-query-object-map-pr`) | Proposed fix branch after rebase onto current trunk. | Same Playwright command on `WP_ENV_PORT=8921`, with artifacts under `/Users/danluu/dev/fuzz/gutenberg-stale-query-object-map-pr/artifacts/repeat-fix-post-rebase-8921`, passed 5/5. The full file also passed 2/2. |
| `17f5c915e93` (`danluu/try/stale-query-object-map-pr`) | Targeted CI checks for changed files. | `npm run lint:js -- packages/core-data/src/utils/crdt-blocks.ts packages/core-data/src/utils/test/crdt-object-query-stale-snapshot-repro.test.ts packages/core-data/src/utils/test/crdt-stale-query-array.test.ts packages/core-data/src/utils/test/crdt-stale-query-array-post.test.ts test/e2e/specs/editor/collaboration/collaboration-table-stale-snapshot.spec.ts` passed. `npm run test:unit -- packages/core-data/src/utils/test/crdt-object-query-stale-snapshot-repro.test.ts packages/core-data/src/utils/test/crdt-stale-query-array.test.ts packages/core-data/src/utils/test/crdt-stale-query-array-post.test.ts --runInBand` passed 31 tests. `npm run build -- --skip-types` passed. |
| `danluu/try/stale-top-level-blocks-pr` at `d4f43fbf6954` | Recent stale-snapshot fix touching block CRDT merge code. | Scratch minimal object+query unit repro failed 2/2. |
| `danluu/try/stale-rich-text-sibling-pr` at `1455411c8049` | Recent stale-snapshot fix touching block CRDT merge code and rich-text siblings. | Scratch minimal object+query unit repro failed 2/2. |
| `danluu/try/stale-content-overwrite-pr` at `54ff99db2227` | Recent RTC stale content overwrite fix touching `crdt-blocks.ts` and post sync plumbing. | Scratch minimal object+query unit repro failed 2/2. |
| `danluu/try/form-content-overwrite-pr` at `cd6822b89c95` | Recent stale form overwrite fix touching `crdt-blocks.ts` and post sync plumbing. | Scratch minimal object+query unit repro failed 2/2. |
| `danluu/try/rtc-duplicate-table-body-revision-loss-pr` at `c7ef8332801b` | Recent table/CRDT fix touching table identity and merge code. | Scratch minimal object+query unit repro failed 2/2. |
| `danluu/try/rtc-table-stale-snapshot-pr` at `876398df67b8` | Directly overlapping stock Table stale-snapshot fix branch. | Scratch minimal object+query unit repro failed 2/2. I also copied the current HTML-mode Playwright repro into a fresh detached scratch worktree and ran it on `WP_ENV_PORT=8923`; it failed 3/3. Two repeats failed on visible data loss (`A-new/B-new` missing or A's HTML edit missing), and one repeat hit an old-branch harness timeout after the textarea left HTML mode. Artifacts: `/Users/danluu/dev/fuzz/issue2-table-candidate-e2e/artifacts/rtc-table-stale-snapshot-pr-html-repro-8923/`. |
| `danluu/try/offset-space-bug-pr` at `f136c427533b` | Recent rich-text/CRDT fix touching `crdt-blocks.ts`. | Scratch minimal object+query unit repro failed 2/2. |
| `danluu/try/draft-reopens-blank-pr` at `a3e4dbc6e81a` | Recent sync bootstrap fix that could affect stale editor state. | Scratch minimal object+query unit repro failed 2/2. |
| `danluu/try/nav-menu-stale-save-pr` at `82c7692768c4` | Recent stale-save fix; inspected because it is stale-state related, though it is on navigation entities rather than block CRDT maps. | Scratch minimal object+query unit repro failed 2/2. |
| `danluu/fix/rtc-autodraft-autosave-loss-pr` at `b677576fbfe8` | Recent RTC autosave fix. | Scratch minimal object+query unit repro failed 2/2. |
| `danluu/try/rich-text-html-corruption` at `0e3f72522e2` | Recent rich-text branch by committer date. | Inspected only: diff is documentation for rich-text HTML corruption and does not include a product-code fix for block CRDT maps. |
| `danluu/try/stale-query-array` at `97b9e88e363` | Recent stale query-array branch by committer date. | Inspected only: branch contains repros/analysis and no product-code fix commit. |

The scratch minimal candidate command was:

```bash
npm run test:unit -- packages/core-data/src/utils/test/crdt-object-query-stale-snapshot-minimal.test.ts --runInBand
```

The copied scratch test keeps only the two `mergeCrdtBlocks()` object+query
update/delete histories to avoid unrelated old-branch post-adapter and editor
dependency drift. Its result summary and per-branch logs are under:

```text
/Users/danluu/dev/fuzz/issue2-danluu-checks-20260501-minimal-results-20260501-005833/
```

Conclusion: this issue is still active after the relevant known fixes I could
identify from #77716 and related open branches.

## Reproductions

New focused repro file:
`packages/core-data/src/utils/test/crdt-object-query-stale-snapshot-repro.test.ts`.

Focused merge-level repro:

```bash
npm run test:unit -- packages/core-data/src/utils/test/crdt-object-query-stale-snapshot-repro.test.ts --runInBand --testNamePattern="mergeCrdtBlocks preserves a remote sibling object property update"
```

Expected: after user B changes `hero.caption` and user A later changes only
`hero.headline` from a stale local snapshot, the final object is:

```js
{ headline: 'headline from user A', caption: 'caption from user B' }
```

Actual on `5ddf4ad1b34`: `caption` is restored to `caption before`.

Focused delete repro:

```bash
npm run test:unit -- packages/core-data/src/utils/test/crdt-object-query-stale-snapshot-repro.test.ts --runInBand --testNamePattern="mergeCrdtBlocks preserves a remote sibling object property delete"
```

Expected: after user B deletes `hero.caption`, user A's later stale headline
edit must not bring it back.

Actual on `5ddf4ad1b34`: `caption before` is resurrected.

Post CRDT adapter repro:

```bash
npm run test:unit -- packages/core-data/src/utils/test/crdt-object-query-stale-snapshot-repro.test.ts --runInBand --testNamePattern="post CRDT adapter preserves remote object\\+query sibling changes"
```

Expected: `applyPostChangesToCRDTDoc()` and `getPostChangesFromCRDTDoc()`
preserve B's caption update after A's stale headline snapshot is applied.

Actual on `5ddf4ad1b34`: the adapter returns `caption before`.

Run all lower-level repros:

```bash
npm run test:unit -- packages/core-data/src/utils/test/crdt-object-query-stale-snapshot-repro.test.ts --runInBand
```

Actual on `5ddf4ad1b34`: all 3 tests fail.

Playwright repro:
`test/e2e/specs/editor/collaboration/collaboration-object-query-stale-snapshot.spec.ts`.

```bash
WP_ENV_PORT=8894 WP_BASE_URL=http://localhost:8894 npm run test:e2e -- test/e2e/specs/editor/collaboration/collaboration-object-query-stale-snapshot.spec.ts --project=chromium
```

The test creates a draft post, opens it in two collaborative editor sessions,
registers a custom block with the object+query schema, inserts the block through
the block inserter, and edits visible textboxes with normal keyboard actions.
The custom block keeps a local draft after the user has edited the form, which
is a realistic block UI pattern and creates the stale local object snapshot
without direct Y.Doc mutation, fault injection, clock changes, or network hacks.

Expected: after B edits the caption and A edits the headline, both editors show:

```js
{ headline: 'headline from user A', caption: 'caption from user B' }
```

Actual on `5ddf4ad1b34`: A's final attributes are:

```js
{ headline: 'headline from user A', caption: 'caption before' }
```

I first tried a simpler Playwright flow where both editors edited the shared
fields directly without a local draft held by the block. That passed because the
block UI immediately consumed the remote prop update and did not retain a stale
object snapshot. The retained local draft variant is still natural for a block
form and exercises the real editor data path.

### Stock Table browser repro evidence

The proposed fix branch also carries a browser-level repro using only the stock
`core/table` block and ordinary editor controls:
`test/e2e/specs/editor/collaboration/collaboration-table-stale-snapshot.spec.ts`.
This is the realistic browser repro used for PR-readiness because it does not
register a custom block, mutate a Y.Doc directly, mutate editor stores, pause
clocks or networks, or use fault injection.

Minimal user flow:

1. Create a draft containing a normal two-row Table block with cells
   `A1/B1` and `A2/B2`.
2. User A opens the stock Table block's built-in **Edit as HTML** mode,
   retaining a local HTML snapshot.
3. User B uses the stock Table toolbar's **Insert row after** action and types
   `A-new/B-new` into the inserted row.
4. User A edits only `A1` in the stock HTML textarea to
   `A1 local HTML edit`, then switches the block back to visual mode.

Expected final visible table on both editors:

```js
[ 'A1 local HTML edit', 'B1', 'A-new', 'B-new', 'A2', 'B2' ]
```

Repeated baseline command, run from a detached baseline worktree at
`7fa898389e0` (`trunk` plus the repro tests, without the fix):

```bash
WP_ENV_PORT=8922 WP_BASE_URL=http://localhost:8922 \
WP_ARTIFACTS_PATH=/Users/danluu/dev/fuzz/gutenberg-stale-query-object-map-baseline-rebased-check/artifacts/repeat-baseline-post-rebase-8922 \
npm run test:e2e -- test/e2e/specs/editor/collaboration/collaboration-table-stale-snapshot.spec.ts --project=chromium --grep "stale HTML snapshot" --repeat-each=5 --retries=0
```

Result on the unfixed baseline: 5/5 repeats failed the user-visible preservation
assertion. In 3/5 repeats the remotely inserted `A-new/B-new` row disappeared
and the final visible table was:

```js
[ 'A1 local HTML edit', 'B1', 'A2', 'B2' ]
```

In 2/5 repeats the stale HTML handoff lost User A's local `A1` edit while
retaining User B's row:

```js
[ 'A1', 'B1', 'A-new', 'B-new', 'A2', 'B2' ]
```

Both outcomes are visible editor data loss from the same normal stock Table
workflow; the first is the stale-snapshot overwrite symptom this fix targets,
and the second is the same workflow failing the preservation invariant in the
other direction. The repeated baseline artifacts are under:

```text
/Users/danluu/dev/fuzz/gutenberg-stale-query-object-map-baseline-rebased-check/artifacts/repeat-baseline-post-rebase-8922/
```

Repeated fix-branch command, run from
`/Users/danluu/dev/fuzz/gutenberg-stale-query-object-map-pr` at
`17f5c915e93`:

```bash
WP_ENV_PORT=8921 WP_BASE_URL=http://localhost:8921 \
WP_ARTIFACTS_PATH=/Users/danluu/dev/fuzz/gutenberg-stale-query-object-map-pr/artifacts/repeat-fix-post-rebase-8921 \
npm run test:e2e -- test/e2e/specs/editor/collaboration/collaboration-table-stale-snapshot.spec.ts --project=chromium --grep "stale HTML snapshot" --repeat-each=5 --retries=0
```

Result on the fix branch: 5/5 repeats passed. The repeated fix artifacts are
under:

```text
/Users/danluu/dev/fuzz/gutenberg-stale-query-object-map-pr/artifacts/repeat-fix-post-rebase-8921/
```

I also tried a keyboard-typing variant of the HTML textarea edit. It was less
useful as evidence because it sometimes failed before the final preservation
assertion when the textarea had already left HTML mode. The committed repro uses
Playwright's normal form-control `fill()` action on the stock HTML textarea,
which produced a clean 5/5 baseline-fails and 5/5 fix-passes split.

Verification commands that passed before writing this handoff:

```bash
npm run lint:js -- packages/core-data/src/utils/test/crdt-object-query-stale-snapshot-repro.test.ts test/e2e/specs/editor/collaboration/collaboration-object-query-stale-snapshot.spec.ts
npm run build -- --skip-types
```

## Failure mechanism

`mergeCrdtBlocks()` iterates the incoming block snapshot and compares each
incoming attribute against the current value in the local Y.Doc. For nested Yjs
values, including object+query attributes stored as `Y.Map`, it always delegates
to `mergeYValue()` because `fastDeepEqual()` cannot compare a Y type with a plain
object.

For `schema.type === 'object' && schema.query`, `mergeYValue()` calls
`mergeYMapValues()`. `mergeYMapValues()` then:

1. iterates every key in the incoming plain object and calls `mergeYValue()` for
   that key;
2. deletes every key currently in the `Y.Map` that is absent from the incoming
   object.

That is correct only if the incoming object is causally the latest intended
state of the whole object. In the stale-snapshot history, it is not. The
incoming object is a local UI snapshot that only proves user A changed
`hero.headline`; it says nothing reliable about `hero.caption`. Because the
merge diffs against the current Y.Doc instead of against user A's previous local
snapshot, the old caption is misclassified as a local write, and missing keys
are misclassified as local deletes.

## How this was introduced

The exact introducing PR is uncertain because this is a semantic bug in the
snapshot merge model, not a crash introduced by one isolated line.

Evidence from `packages/core-data/src/utils/crdt-blocks.ts` history:

- [#72262](https://github.com/WordPress/gutenberg/pull/72262) introduced the
  post/block CRDT merge infrastructure (`84019935998`). That established the
  broad pattern of merging incoming editor snapshots into the CRDT document.
- [#76913](https://github.com/WordPress/gutenberg/pull/76913) added the
  schema-aware nested Yjs representation for table/query attributes
  (`09a21c64b5b`). That commit added the relevant `object` with `query` handling
  through `Y.Map` and `mergeYMapValues()`, which is the active failure path for
  this issue.
- [#77164](https://github.com/WordPress/gutenberg/pull/77164) changed query
  array stability (`a6bfd3e5543`). It is related to stale snapshots for nested
  arrays, but this object+query map repro fails without needing array structural
  matching.

My best supported attribution is that the stale full-snapshot model originates
with the initial block CRDT merge design, while the object+query map-specific
failure became observable through the nested Y.Map handling added in #76913.

## Initial fix plan

Track the previous local editor snapshot for each local merge stream and derive
local operations by diffing:

```text
previous local snapshot -> next local snapshot
```

Then apply only those local operations to the current Y.Doc. For object+query
maps:

- update a key only if that key changed locally between the previous and next
  local snapshots;
- delete a key only if it existed in the previous local snapshot and is absent
  from the next local snapshot;
- preserve remote sibling keys already present in the Y.Doc when the local diff
  has no operation for that key.

The implementation should be schema-driven and not special-case
`test/object-query-card` or `hero`.

## Fix plan audit

### Linus Torvalds lens

The bug is an invariant failure: a stale snapshot is being treated as a set of
operations. Patching `mergeYMapValues()` with heuristics such as "do not replace
if the Y.Doc value differs" would hide one symptom while breaking legitimate
local overwrites. The fix needs an explicit local-base invariant: writes must be
derived from a known prior local state, and the merge code must be small enough
that updates and deletes follow the same rule.

### Kyle Kingsbury / Jepsen lens

The property to preserve is operation causality and convergence, not just final
deep equality for a happy path. The stale local snapshot has not observed B's
caption operation, so it cannot safely overwrite or delete that field. Tests
must include histories for remote update, remote add, remote delete, replayed
updates, late join, and both application orders. Deletes need special attention:
a missing field is only a delete if there is local-base evidence that the field
was removed locally.

### Dan Luu lens

The Playwright repro matters because this is not just an artificial model test.
Stateful block UIs commonly keep draft form objects, debounce updates, or stage
multi-field edits before committing them. A fix that only handles the exact unit
shape may still fail under real editor interleavings. The tests should leave a
debuggable trail with ordinary block attributes and should avoid hidden metadata
that leaks into serialized content or plugin-visible block data.

## Revised fix plan

1. Add local-base snapshot plumbing at the RTC adapter boundary, likely around
   `applyPostChangesToCRDTDoc()` or its caller, so `mergeCrdtBlocks()` can
   receive both the previous local blocks and the next local blocks for local
   writes.
2. Keep the existing full merge path only for initialization, loading a fresh
   CRDT document, or explicitly trusted full-state replacement.
3. Add recursive schema-aware diff application for object+query maps. The diff
   should emit key update/delete operations from previous-local to next-local
   and apply those operations to the current Y.Map. For nested Y.Text and
   Y.Array values, delegate to the corresponding operation-aware merge path.
4. When there is no previous local snapshot for an already-synced record, prefer
   preserving remote data and forcing an editor resync over applying a
   destructive full-object overwrite.
5. Extend tests:
   - keep the focused update/delete tests in
     `crdt-object-query-stale-snapshot-repro.test.ts`;
   - add remote add and replay-order cases;
   - add a late-join or reload assertion once the local-base plumbing exists;
   - keep the Playwright repro as the browser-level guard for realistic
     stateful block UI behavior.

## Open questions

- Where should the previous local snapshot live so it is per entity, per local
  editor stream, and not confused with remote state received from Yjs?
- How should full-state replacement be represented explicitly so initialization
  and migrations do not accidentally use the delta-only path?
- Should local-base diffing also become the shared fix for rich-text siblings,
  query arrays, and top-level block arrays, or should object maps land as the
  first narrow slice behind a common operation interface?

## END AI TEXT