### PR TITLE
Grid: render resize handle as component

### DIFF
--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -110,7 +110,7 @@ interface DashboardGridLayoutItem {
 | `editMode` | `boolean` | `false` | Enables drag-to-reorder and resize handles. |
 | `onChangeLayout` | `( layout ) => void` | — | Fired when the user commits a drag or resize. |
 | `onPreviewLayout` | `( layout ) => void` | — | Fired continuously during a drag or resize with the in-progress layout. Use for live feedback; `onChangeLayout` still emits the committed result. |
-| `renderResizeHandle` | `( props ) => ReactNode` | — | Override the default corner-triangle resize handle with a custom element. Receives gesture wiring (`ref`, `listeners`, `attributes`) plus `disabled`, `verticalResizable`, and `itemId`. The grid keeps ownership of the `<DndContext>` and the throttled delta loop. |
+| `renderResizeHandle` | `ComponentType< ResizeHandleRenderProps >` | — | Override the default corner-triangle resize handle with a custom component. Receives gesture wiring (`ref`, `listeners`, `attributes`) plus `verticalResizable`, `isResizing`, and `itemId`. The grid keeps ownership of the `<DndContext>` and the throttled delta loop. |
 | `className` | `string` | — | Extra class on the grid root. |
 
 `DashboardGrid` forwards refs to its root `<div>`, and standard `<div>`
@@ -211,9 +211,9 @@ Resize handles are currently pointer-only.
 
 The default handle is a small corner triangle on the bottom-right of
 each tile. To swap it for a custom element (icon, button, branded
-shape…), pass `renderResizeHandle`. The grid still owns the gesture
-— `<DndContext>`, throttled delta loop, step-to-grid logic — and
-passes the wiring to your render prop. Spread `listeners` and
+shape…), pass a component to `renderResizeHandle`. The grid still
+owns the gesture — `<DndContext>`, throttled delta loop, step-to-grid
+logic — and passes the wiring as props. Spread `listeners` and
 `attributes` and assign `ref` on the element that should receive
 pointer events.
 
@@ -221,15 +221,13 @@ pointer events.
 import { Icon } from '@wordpress/ui';
 import { resizeCornerNE } from '@wordpress/icons';
 
-<DashboardGrid
-	layout={ layout }
-	editMode
-	renderResizeHandle={ ( {
-		ref,
-		listeners,
-		attributes,
-		verticalResizable,
-	} ) => (
+function CustomResizeHandle( {
+	ref,
+	listeners,
+	attributes,
+	verticalResizable,
+} ) {
+	return (
 		<div
 			ref={ ref }
 			{ ...listeners }
@@ -243,16 +241,22 @@ import { resizeCornerNE } from '@wordpress/icons';
 		>
 			<Icon icon={ resizeCornerNE } size={ 16 } />
 		</div>
-	) }
+	);
+}
+
+<DashboardGrid
+	layout={ layout }
+	editMode
+	renderResizeHandle={ CustomResizeHandle }
 >
 	{ tiles }
 </DashboardGrid>;
 ```
 
-The render prop receives:
+The component receives:
 
-| Field | Type | Description |
-|-------|------|-------------|
+| Prop | Type | Description |
+|------|------|-------------|
 | `ref` | `( node ) => void` | dnd-kit ref; assign on the gesture-bearing element. |
 | `listeners` | `SyntheticListenerMap \| undefined` | Pointer/keyboard listeners; spread on the same element. |
 | `attributes` | `DraggableAttributes` | Accessibility/dnd-kit attributes; spread alongside `listeners`. |
@@ -261,7 +265,7 @@ The render prop receives:
 | `itemId` | `string` | Owning tile's `key`. |
 
 The handle is only mounted while the grid is in edit mode (`editMode={ true }`),
-so the consumer's render prop never has to short-circuit on a disabled state.
+so the custom component never has to short-circuit on a disabled state.
 
 ## Contributing to this package
 

--- a/packages/grid/src/resize-handle.tsx
+++ b/packages/grid/src/resize-handle.tsx
@@ -52,14 +52,17 @@ function ResizeHandle( {
 	}, [ isDragging, verticalResizable ] );
 
 	if ( renderResizeHandle ) {
-		return renderResizeHandle( {
-			ref: mergedRef,
-			listeners,
-			attributes,
-			verticalResizable,
-			isResizing: isDragging,
-			itemId,
-		} );
+		const RenderResizeHandle = renderResizeHandle;
+		return (
+			<RenderResizeHandle
+				ref={ mergedRef }
+				listeners={ listeners }
+				attributes={ attributes }
+				verticalResizable={ verticalResizable }
+				isResizing={ isDragging }
+				itemId={ itemId }
+			/>
+		);
 	}
 
 	return (

--- a/packages/grid/src/stories/index.story.tsx
+++ b/packages/grid/src/stories/index.story.tsx
@@ -766,9 +766,7 @@ export const CustomResizeHandleStory: Story = {
 				{ ...args }
 				layout={ layout }
 				onChangeLayout={ setLayout }
-				renderResizeHandle={ ( props ) => (
-					<CustomResizeHandle { ...props } />
-				) }
+				renderResizeHandle={ CustomResizeHandle }
 			>
 				{ tiles }
 			</DashboardGrid>

--- a/packages/grid/src/types.ts
+++ b/packages/grid/src/types.ts
@@ -53,7 +53,7 @@ export type DashboardGridLayoutItem = {
 };
 
 /**
- * Props passed to a `renderResizeHandle` callback. Spread `listeners`
+ * Props received by a custom resize handle component. Spread `listeners`
  * and `attributes` onto the element that should respond to the gesture,
  * and assign `ref` to the same element so dnd-kit can track it.
  */
@@ -124,13 +124,13 @@ export interface ResizeHandleProps {
 	onResizeEnd?: () => void;
 
 	/**
-	 * Render prop to override the default corner triangle with a
+	 * Component that overrides the default corner triangle with a
 	 * custom element. Receives gesture wiring (`ref`, `listeners`,
 	 * `attributes`) plus context. The grid keeps ownership of the
 	 * `<DndContext>` and the throttled delta loop; consumers are only
 	 * responsible for the visual.
 	 */
-	renderResizeHandle?: ( props: ResizeHandleRenderProps ) => React.ReactNode;
+	renderResizeHandle?: React.ComponentType< ResizeHandleRenderProps >;
 }
 
 /**
@@ -199,10 +199,10 @@ export type GridItemProps = {
 	onResizeEnd: () => void;
 
 	/**
-	 * Render prop forwarded to `<ResizeHandle />` to override the
-	 * default corner triangle. See `DashboardGridProps.renderResizeHandle`.
+	 * Component forwarded to `<ResizeHandle />` to override the default
+	 * corner triangle. See `DashboardGridProps.renderResizeHandle`.
 	 */
-	renderResizeHandle?: ( props: ResizeHandleRenderProps ) => React.ReactNode;
+	renderResizeHandle?: React.ComponentType< ResizeHandleRenderProps >;
 };
 
 /**
@@ -279,13 +279,13 @@ interface BaseDashboardGridProps
 
 	/**
 	 * Override the default corner-triangle resize handle with a custom
-	 * element. The grid still owns the gesture (dnd-kit `<DndContext>`,
+	 * component. The grid still owns the gesture (dnd-kit `<DndContext>`,
 	 * throttled delta loop) and passes the wiring to the consumer:
 	 * spread `listeners` and `attributes` and assign `ref` on the
 	 * element that should receive the gesture. Use `disabled` and
 	 * `verticalResizable` to adapt the visual to context.
 	 */
-	renderResizeHandle?: ( props: ResizeHandleRenderProps ) => React.ReactNode;
+	renderResizeHandle?: React.ComponentType< ResizeHandleRenderProps >;
 }
 
 interface FixedDashboardGridProps extends BaseDashboardGridProps {


### PR DESCRIPTION
## What?

Convert `renderResizeHandle` on `<DashboardGrid>` (and the internal `<ResizeHandle>` / `<GridItem>` shapes) from a function render prop to a `React.ComponentType< ResizeHandleRenderProps >`. The internal invocation now passes the merged ref via a JSX prop (`<RenderResizeHandle ref={ ... } />`) instead of as an argument to a function call.

This unblocks lint on `trunk`. PR #77811 introduced the render-prop function, and the recent `eslint-plugin-react-hooks` v7 upgrade (#69962) activated `react-hooks/refs`, which flags passing a ref to a function during render.

## Why?

CI is currently red on trunk because `packages/grid/src/resize-handle.tsx:55` violates the new `react-hooks/refs` rule:

> Passing a ref to a function may read its value during render (react-hooks/refs)

Adding the file to `tools/eslint/suppressions.json` would match the convention used by the v7 upgrade for pre-existing violations, but the underlying issue is that passing a callback ref as a function argument during render is exactly the pattern the rule is designed to discourage. Refs propagated via JSX `ref={ ... }` go through React's commit phase, which is the supported path; refs read inside a function call during render can tear.

The render-prop function shape also forced consumers to wrap their handle in an inline arrow (`( props ) => <X { ...props } />`). A `ComponentType` prop accepts the component directly.

## How?

- `packages/grid/src/types.ts`: change the type of `renderResizeHandle` from `( props: ResizeHandleRenderProps ) => React.ReactNode` to `React.ComponentType< ResizeHandleRenderProps >` in `ResizeHandleProps`, `GridItemProps`, and `BaseDashboardGridProps`. Update the surrounding JSDoc.
- `packages/grid/src/resize-handle.tsx`: replace the function call with a JSX render. A local PascalCase alias (`RenderResizeHandle`) is needed because JSX requires the component identifier to start with an uppercase letter.
- `packages/grid/src/stories/index.story.tsx`: pass the `CustomResizeHandle` component directly instead of wrapping it in an arrow function.
- `packages/grid/README.md`: update the props table, the "Custom resize handle" example, and the props-received table to reflect the component-based API.

`tools/eslint/suppressions.json` is intentionally untouched; the fix removes the violation at the source.

## Testing

1. `npm install`
2. `npx eslint --suppressions-location tools/eslint/suppressions.json packages/grid/src/`. Expect exit code 0; the previous `react-hooks/refs` failure on `resize-handle.tsx:55` is gone and no new suppression was added.
3. `npx tsc --noEmit -p packages/grid/tsconfig.json`. Expect exit code 0.
4. Storybook: `npm run storybook:dev`, navigate to **Grid / Custom Resize Handle**. The custom corner-stroke SVG handle should render at the bottom-right of each tile, drag-resizing should commit a new layout via `onChangeLayout`, and `isResizing` should flip the handle's opacity during the gesture.
5. Confirm `git diff trunk -- tools/eslint/suppressions.json` is empty.

## Follow-ups

- [ ] None. The change is self-contained and unblocks trunk CI.