### PR TITLE
Media editor modal: add Shift+R for counter-clockwise rotation

### DIFF
--- a/packages/media-editor/src/components/media-editor-keyboard-shortcuts-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-keyboard-shortcuts-modal/index.tsx
@@ -58,6 +58,10 @@ const SHORTCUTS: ShortcutEntry[] = [
 		keyCombination: { character: 'R' },
 	},
 	{
+		description: __( 'Rotate 90° counter-clockwise' ),
+		keyCombination: { modifier: 'shift', character: 'R' },
+	},
+	{
 		description: __( 'Flip horizontal' ),
 		keyCombination: { character: 'H' },
 	},

--- a/packages/media-editor/src/image-editor/core/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/interaction-controller.ts
@@ -896,11 +896,11 @@ export class InteractionController {
 			}
 			case 'r':
 			case 'R': {
-				if ( e.metaKey || e.ctrlKey || e.altKey || e.shiftKey ) {
+				if ( e.metaKey || e.ctrlKey || e.altKey ) {
 					break;
 				}
 				e.preventDefault();
-				this.options.actions.snapRotate90( 1 );
+				this.options.actions.snapRotate90( e.shiftKey ? -1 : 1 );
 				break;
 			}
 			case 'h':

--- a/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
@@ -612,7 +612,18 @@ describe( 'InteractionController', () => {
 			expect( actionMocks.snapRotate90 ).toHaveBeenCalledWith( 1 );
 		} );
 
-		it.each( [ 'metaKey', 'ctrlKey', 'altKey', 'shiftKey' ] )(
+		it( 'calls snapRotate90 counter-clockwise on shift+r', () => {
+			const state = makeState( { rotation: 0 } );
+			const { controller } = createController( state );
+
+			controller.handleKeyDown(
+				createKeyboardEvent( 'r', { shiftKey: true } )
+			);
+
+			expect( actionMocks.snapRotate90 ).toHaveBeenCalledWith( -1 );
+		} );
+
+		it.each( [ 'metaKey', 'ctrlKey', 'altKey' ] )(
 			'does not rotate when %s is held with r',
 			( modifier ) => {
 				const state = makeState( { rotation: 0 } );


### PR DESCRIPTION
## What?

Part of:

- https://github.com/WordPress/gutenberg/issues/73771

Follow-up to #77871. Adds `Shift+R` as a keyboard shortcut to rotate 90° counter-clockwise, complementing the existing `R` shortcut for clockwise rotation.

Props to @andrewserong for the idea

## Changes

- `R` → rotate 90° clockwise (unchanged)
- `Shift+R` → rotate 90° counter-clockwise (new)
- `Meta`/`Ctrl`/`Alt` continue to suppress the shortcut
- Listed in the keyboard shortcuts modal

## Testing

- Open the media editor modal and focus the canvas
- Press `R` — image rotates clockwise
- Press `Shift+R` — image rotates counter-clockwise
- Open the shortcuts modal (keyboard icon in header) — confirm both entries are listed with the correct modifier keys

<img width="382" height="518" alt="Screenshot 2026-05-04 at 12 57 35 pm" src="https://github.com/user-attachments/assets/69b37bad-df2a-4324-9512-13aa91b12bfb" />


https://github.com/user-attachments/assets/d1858bb5-f0e1-4dcd-a242-2f4d0d8afe7c


