### PR TITLE
Media Editor Modal: In the image cropper, pan when dragging the crop instead of constraining to the visible area

### DIFF
--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -4,6 +4,7 @@
 import { useMediaEditorContext } from '../media-editor-provider';
 import { getMediaTypeFromMimeType } from '../../utils';
 import { Cropper, useCropper } from '../../image-editor';
+import { ViewportProvider } from '../../image-editor/react/components/viewport-provider';
 
 export interface MediaEditorCanvasProps {
 	/** Fixed aspect ratio (width / height). `undefined` means free. */
@@ -43,19 +44,21 @@ export default function MediaEditorCanvas( {
 
 	return (
 		<div className="media-editor-canvas">
-			<Cropper
-				src={ mediaUrl }
-				controller={ controller }
-				aspectRatio={ aspectRatio }
-				freeformCrop={ freeformCrop }
-				showGrid="interactive"
-				isPlacementActive={ isPlacementActive }
-				// Flush on gesture start so any pending sidebar interaction
-				// (e.g. zoom slider debounce) is committed as its own undo
-				// step before the canvas gesture begins.
-				onGestureStart={ controller.commitHistory }
-				onGestureEnd={ controller.commitHistory }
-			/>
+			<ViewportProvider>
+				<Cropper
+					src={ mediaUrl }
+					controller={ controller }
+					aspectRatio={ aspectRatio }
+					freeformCrop={ freeformCrop }
+					showGrid="interactive"
+					isPlacementActive={ isPlacementActive }
+					// Flush on gesture start so any pending sidebar interaction
+					// (e.g. zoom slider debounce) is committed as its own undo
+					// step before the canvas gesture begins.
+					onGestureStart={ controller.commitHistory }
+					onGestureEnd={ controller.commitHistory }
+				/>
+			</ViewportProvider>
 		</div>
 	);
 }

--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -4,7 +4,6 @@
 import { useMediaEditorContext } from '../media-editor-provider';
 import { getMediaTypeFromMimeType } from '../../utils';
 import { Cropper, useCropper } from '../../image-editor';
-import { ViewportProvider } from '../../image-editor/react/components/viewport-provider';
 
 export interface MediaEditorCanvasProps {
 	/** Fixed aspect ratio (width / height). `undefined` means free. */
@@ -44,21 +43,19 @@ export default function MediaEditorCanvas( {
 
 	return (
 		<div className="media-editor-canvas">
-			<ViewportProvider>
-				<Cropper
-					src={ mediaUrl }
-					controller={ controller }
-					aspectRatio={ aspectRatio }
-					freeformCrop={ freeformCrop }
-					showGrid="interactive"
-					isPlacementActive={ isPlacementActive }
-					// Flush on gesture start so any pending sidebar interaction
-					// (e.g. zoom slider debounce) is committed as its own undo
-					// step before the canvas gesture begins.
-					onGestureStart={ controller.commitHistory }
-					onGestureEnd={ controller.commitHistory }
-				/>
-			</ViewportProvider>
+			<Cropper
+				src={ mediaUrl }
+				controller={ controller }
+				aspectRatio={ aspectRatio }
+				freeformCrop={ freeformCrop }
+				showGrid="interactive"
+				isPlacementActive={ isPlacementActive }
+				// Flush on gesture start so any pending sidebar interaction
+				// (e.g. zoom slider debounce) is committed as its own undo
+				// step before the canvas gesture begins.
+				onGestureStart={ controller.commitHistory }
+				onGestureEnd={ controller.commitHistory }
+			/>
 		</div>
 	);
 }

--- a/packages/media-editor/src/image-editor/core/containment.ts
+++ b/packages/media-editor/src/image-editor/core/containment.ts
@@ -86,25 +86,28 @@ function getMinZoomForCover(
 }
 
 /**
- * Compute the crop handle bounds in normalized visual space by finding the
+ * Compute the crop handle bounds in normalized visual space — the
  * axis-aligned bounding box (AABB) of the actual image footprint at the
- * current pan/zoom/rotation, then intersecting with the container viewport.
+ * current pan/zoom/rotation.
+ *
+ * Returns the full image AABB without intersecting with the container
+ * viewport. The viewport pan mechanism in the Cropper component allows
+ * the canvas to scroll so handles can reach the image edge even when it
+ * lies outside the visible canvas area.
  *
  * Unlike a static centerline-based calculation, this accounts for the
  * current pan position — if the user pans right, the left bound tightens
  * because the image's left edge has moved right.
  *
- * @param state         The current cropper state (crop, zoom, rotation, flip).
- * @param elementSize   The fitted (unrotated) image element dimensions in pixels.
- * @param visualSize    The visual (rotated) image bounding box in pixels.
- * @param containerSize The container dimensions in pixels.
+ * @param state       The current cropper state (crop, zoom, rotation, flip).
+ * @param elementSize The fitted (unrotated) image element dimensions in pixels.
+ * @param visualSize  The visual (rotated) image bounding box in pixels.
  * @return The min/max x and y that a crop rect edge can reach in normalized space.
  */
 export function getCropBounds(
 	state: CropperState,
 	elementSize: Size,
-	visualSize: Size,
-	containerSize: Size
+	visualSize: Size
 ): { minX: number; minY: number; maxX: number; maxY: number } {
 	if (
 		elementSize.width === 0 ||
@@ -140,13 +143,6 @@ export function getCropBounds(
 		[ -hw, hh ],
 	];
 
-	// Transform corners through CSS matrix → screen offsets from element center.
-	// Screen position = element_center + transformed_offset.
-	// Element center is at (containerW/2, containerH/2) after CSS centering.
-	// But we want normalized coords, so work relative to the visual image origin.
-	const offsetX = ( containerSize.width - visualSize.width ) / 2;
-	const offsetY = ( containerSize.height - visualSize.height ) / 2;
-
 	let imgMinX = Infinity;
 	let imgMaxX = -Infinity;
 	let imgMinY = Infinity;
@@ -167,19 +163,11 @@ export function getCropBounds(
 		imgMaxY = Math.max( imgMaxY, ny );
 	}
 
-	// Container bounds in normalized space.
-	const containerMinX = -offsetX / visualSize.width;
-	const containerMaxX = ( containerSize.width - offsetX ) / visualSize.width;
-	const containerMinY = -offsetY / visualSize.height;
-	const containerMaxY =
-		( containerSize.height - offsetY ) / visualSize.height;
-
-	// Crop bounds = intersection of image AABB and container bounds.
 	return {
-		minX: Math.max( imgMinX, containerMinX ),
-		minY: Math.max( imgMinY, containerMinY ),
-		maxX: Math.min( imgMaxX, containerMaxX ),
-		maxY: Math.min( imgMaxY, containerMaxY ),
+		minX: imgMinX,
+		minY: imgMinY,
+		maxX: imgMaxX,
+		maxY: imgMaxY,
 	};
 }
 

--- a/packages/media-editor/src/image-editor/core/containment.ts
+++ b/packages/media-editor/src/image-editor/core/containment.ts
@@ -104,7 +104,7 @@ function getMinZoomForCover(
  * @param visualSize  The visual (rotated) image bounding box in pixels.
  * @return The min/max x and y that a crop rect edge can reach in normalized space.
  */
-export function getCropBounds(
+export function getImageCropBounds(
 	state: CropperState,
 	elementSize: Size,
 	visualSize: Size

--- a/packages/media-editor/src/image-editor/core/test/camera.ts
+++ b/packages/media-editor/src/image-editor/core/test/camera.ts
@@ -548,17 +548,15 @@ describe( 'getSourceRegionPercent', () => {
 } );
 
 describe( 'getCropBounds', () => {
-	it( 'allows crop handle to reach container edge when 4:3 image is zoomed in 3:2 container', () => {
-		// MtBlanc1.jpg is 500×375 (4:3) in a 600×400 container (3:2).
-		// At zoom=1, the image is 533×400 — 33px padding on each side.
-		// At zoom=1.75, the image fills the container. The crop handle
-		// should be able to reach the container left edge (pixel 0),
-		// which is at normalized x = -0.0625.
+	it( 'returns the image AABB — handles can reach the image edge regardless of container size', () => {
+		// 500×375 (4:3) in a 600×400 container (3:2).
+		// At zoom=1.75 the image overflows the container. Bounds should reflect
+		// the image footprint, not the container edge, so one drag can reach the
+		// image edge (viewport pan reveals content outside the canvas boundary).
 		const nat: Size = { width: 500, height: 375 };
 		const container: Size = { width: 600, height: 400 };
 		const { elementSize, visualSize } = getImageFit( container, nat, 0 );
 
-		// Verify the image doesn't fill the container at zoom=1.
 		expect( visualSize.width ).toBeLessThan( container.width );
 
 		const state = makeState( {
@@ -571,23 +569,14 @@ describe( 'getCropBounds', () => {
 			rotation: 0,
 		} );
 
-		const bounds = getCropBounds(
-			state,
-			elementSize,
-			visualSize,
-			container
-		);
+		const bounds = getCropBounds( state, elementSize, visualSize );
 
-		// boundsMinX should be negative (crop can extend left of visual image origin).
-		expect( bounds.minX ).toBeLessThan( 0 );
-		// The pixel position of boundsMinX should be the container left edge (pixel 0).
-		const offsetX = ( container.width - visualSize.width ) / 2;
-		const pixelLeft = offsetX + bounds.minX * visualSize.width;
-		expect( pixelLeft ).toBeCloseTo( 0, 0 );
-
-		// boundsMaxX should be > 1 (crop can extend right of visual image).
-		expect( bounds.maxX ).toBeGreaterThan( 1 );
-		const pixelRight = offsetX + bounds.maxX * visualSize.width;
-		expect( pixelRight ).toBeCloseTo( container.width, 0 );
+		// At zoom=1.75 the image extends well beyond the container on all sides.
+		// Bounds should be the image AABB corners (≈ ±0.375), not the container
+		// edges (which would be ≈ ±0.0625).
+		expect( bounds.minX ).toBeLessThan( -0.3 );
+		expect( bounds.maxX ).toBeGreaterThan( 1.3 );
+		expect( bounds.minY ).toBeLessThan( -0.3 );
+		expect( bounds.maxY ).toBeGreaterThan( 1.3 );
 	} );
 } );

--- a/packages/media-editor/src/image-editor/core/test/camera.ts
+++ b/packages/media-editor/src/image-editor/core/test/camera.ts
@@ -9,7 +9,7 @@ import {
 import {
 	restrictPanZoom,
 	restrictCropRect,
-	getCropBounds,
+	getImageCropBounds,
 } from '../containment';
 import { getSourceRegion, getSourceRegionPercent } from '../source-region';
 import { DEFAULT_STATE } from '../constants';
@@ -547,7 +547,7 @@ describe( 'getSourceRegionPercent', () => {
 	} );
 } );
 
-describe( 'getCropBounds', () => {
+describe( 'getImageCropBounds', () => {
 	it( 'returns the image AABB — handles can reach the image edge regardless of container size', () => {
 		// 500×375 (4:3) in a 600×400 container (3:2).
 		// At zoom=1.75 the image overflows the container. Bounds should reflect
@@ -569,7 +569,7 @@ describe( 'getCropBounds', () => {
 			rotation: 0,
 		} );
 
-		const bounds = getCropBounds( state, elementSize, visualSize );
+		const bounds = getImageCropBounds( state, elementSize, visualSize );
 
 		// At zoom=1.75 the image extends well beyond the container on all sides.
 		// Bounds should be the image AABB corners (≈ ±0.375), not the container

--- a/packages/media-editor/src/image-editor/core/transform-style.ts
+++ b/packages/media-editor/src/image-editor/core/transform-style.ts
@@ -12,7 +12,7 @@ import { degreesToRadians } from './math/rotation';
  *
  * Flip is composed outside rotation so it is viewport-relative — horizontal
  * flip mirrors across the viewport's vertical axis regardless of rotation.
- * Must match the matrix order in `createCamera` / `getCropBounds`.
+ * Must match the matrix order in `createCamera` / `getImageCropBounds`.
  *
  * This is a pure function with no framework dependencies. The React hook
  * `useTransformStyle` wraps this in `useMemo` for memoization.

--- a/packages/media-editor/src/image-editor/core/types.ts
+++ b/packages/media-editor/src/image-editor/core/types.ts
@@ -145,8 +145,8 @@ export type CropperAction =
 /**
  * Viewport camera state — display-only, does not affect export or undo.
  *
- * Applied as a CSS transform on the canvas div so the user can scroll the
- * view independently of the crop. zoom > 1 magnifies; pan shifts in CSS px.
+ * Applied as a CSS transform on the inner stage div so the user can scroll
+ * the view independently of the crop. zoom > 1 magnifies; pan shifts in CSS px.
  */
 export interface ViewportState {
 	zoom: number;

--- a/packages/media-editor/src/image-editor/core/types.ts
+++ b/packages/media-editor/src/image-editor/core/types.ts
@@ -143,6 +143,22 @@ export type CropperAction =
 	| { type: 'RESET'; payload?: Partial< CropperState > };
 
 /**
+ * Viewport camera state — display-only, does not affect export or undo.
+ *
+ * Applied as a CSS transform on the canvas div so the user can scroll the
+ * view independently of the crop. zoom > 1 magnifies; pan shifts in CSS px.
+ */
+export interface ViewportState {
+	zoom: number;
+	pan: { x: number; y: number };
+}
+
+export type ViewportAction =
+	| { type: 'SET_VIEWPORT_ZOOM'; payload: number }
+	| { type: 'SET_VIEWPORT_PAN'; payload: { x: number; y: number } }
+	| { type: 'RESET_VIEWPORT' };
+
+/**
  * The contract for a pluggable stencil component.
  * Stencils render the crop area overlay and handle resize interactions.
  */

--- a/packages/media-editor/src/image-editor/core/viewport-state.ts
+++ b/packages/media-editor/src/image-editor/core/viewport-state.ts
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import type { ViewportState, ViewportAction } from './types';
+
+export const DEFAULT_VIEWPORT_STATE: ViewportState = {
+	zoom: 1,
+	pan: { x: 0, y: 0 },
+};
+
+export function viewportReducer(
+	state: ViewportState,
+	action: ViewportAction
+): ViewportState {
+	switch ( action.type ) {
+		case 'SET_VIEWPORT_ZOOM':
+			return {
+				...state,
+				zoom: Math.min( 4, Math.max( 0.1, action.payload ) ),
+			};
+		case 'SET_VIEWPORT_PAN':
+			return { ...state, pan: action.payload };
+		case 'RESET_VIEWPORT':
+			return DEFAULT_VIEWPORT_STATE;
+	}
+}

--- a/packages/media-editor/src/image-editor/core/viewport-state.ts
+++ b/packages/media-editor/src/image-editor/core/viewport-state.ts
@@ -13,14 +13,21 @@ export function viewportReducer(
 	action: ViewportAction
 ): ViewportState {
 	switch ( action.type ) {
-		case 'SET_VIEWPORT_ZOOM':
-			return {
-				...state,
-				zoom: Math.min( 4, Math.max( 0.1, action.payload ) ),
-			};
-		case 'SET_VIEWPORT_PAN':
-			return { ...state, pan: action.payload };
+		case 'SET_VIEWPORT_ZOOM': {
+			const zoom = Math.min( 4, Math.max( 0.1, action.payload ) );
+			return zoom === state.zoom ? state : { ...state, zoom };
+		}
+		case 'SET_VIEWPORT_PAN': {
+			const { x, y } = action.payload;
+			return x === state.pan.x && y === state.pan.y
+				? state
+				: { ...state, pan: action.payload };
+		}
 		case 'RESET_VIEWPORT':
-			return DEFAULT_VIEWPORT_STATE;
+			return state.zoom === DEFAULT_VIEWPORT_STATE.zoom &&
+				state.pan.x === DEFAULT_VIEWPORT_STATE.pan.x &&
+				state.pan.y === DEFAULT_VIEWPORT_STATE.pan.y
+				? state
+				: DEFAULT_VIEWPORT_STATE;
 	}
 }

--- a/packages/media-editor/src/image-editor/docs/architecture.md
+++ b/packages/media-editor/src/image-editor/docs/architecture.md
@@ -32,7 +32,7 @@ graph TD
         restrictPanZoom["restrictPanZoom()\nbuilds camera → inverse → clamp"]
         restrictCropRect["restrictCropRect()"]
         getMinZoomForCover["getMinZoomForCover()"]
-        getCropBounds["getCropBounds()"]
+        getImageCropBounds["getImageCropBounds()"]
     end
 
     subgraph Rendering["Render Path"]

--- a/packages/media-editor/src/image-editor/react/components/cropper.scss
+++ b/packages/media-editor/src/image-editor/react/components/cropper.scss
@@ -23,6 +23,13 @@ $handle-touch-target-size: 44px;
 		inset: calc($handle-touch-target-size / 2);
 	}
 
+	// Inner stage — receives the viewport pan transform so the canvas div
+	// itself stays fixed, preventing the root background from showing through.
+	&__stage {
+		position: absolute;
+		inset: 0;
+	}
+
 	&--dragging {
 		cursor: grabbing;
 	}
@@ -69,6 +76,11 @@ $handle-touch-target-size: 44px;
 	&__canvas--show-grid &__grid {
 		opacity: 1;
 		transition-delay: 0s;
+	}
+
+	&__canvas--settling &__grid {
+		opacity: 0;
+		transition: none;
 	}
 
 	&__grid-line {

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -310,7 +310,7 @@ function CropperInner(
 			return;
 		}
 		const handleWheel = ( event: WheelEvent ) => {
-			// Block wheel zoom while resizing or settling — the canvas CSS
+			// Block wheel zoom while resizing or settling — the stage CSS
 			// transform changes getBoundingClientRect() during this window,
 			// so focal-point math would resolve against the wrong center.
 			if ( isResizingRef.current || isSettlingRef.current ) {
@@ -448,10 +448,14 @@ function CropperInner(
 		}, 200 );
 	}, [ settleCrop, onGestureEnd, resetViewport ] );
 
-	const imageTransition =
-		settling || isZooming ? 'transform 150ms linear' : undefined;
+	let imageTransition: string | undefined;
+	if ( settling ) {
+		imageTransition = 'transform 200ms ease-out';
+	} else if ( isZooming ) {
+		imageTransition = 'transform 150ms linear';
+	}
 	const settleStencilTransition = settling
-		? 'left 150ms linear, top 150ms linear, width 150ms linear, height 150ms linear'
+		? 'left 200ms ease-out, top 200ms ease-out, width 200ms ease-out, height 200ms ease-out'
 		: undefined;
 
 	// Compute the image's CSS style.
@@ -473,22 +477,22 @@ function CropperInner(
 		};
 	}, [ canvasSize, elementSize, transformString, imageTransition ] );
 
-	// Viewport pan CSS transform for the canvas div. Applied during resize
+	// Viewport pan CSS transform for the stage div. Applied during resize
 	// drags to keep handles visible when the crop extends past the canvas edge.
 	// Transitions back to zero during the settle animation.
-	// will-change promotes the canvas to its own compositor layer while the
+	// will-change promotes the stage to its own compositor layer while the
 	// transform is active, keeping per-frame pan updates off the main thread.
 	const settleTransition = settling ? 'transform 200ms ease-out' : undefined;
 	const willChange = isResizing || settling ? 'transform' : undefined;
-	let canvasStyle: React.CSSProperties | undefined;
+	let stageStyle: React.CSSProperties | undefined;
 	if ( viewportState.pan.x !== 0 || viewportState.pan.y !== 0 ) {
-		canvasStyle = {
+		stageStyle = {
 			transform: `translate(${ viewportState.pan.x }px, ${ viewportState.pan.y }px)`,
 			transition: settleTransition,
 			willChange,
 		};
 	} else if ( settling ) {
-		canvasStyle = { transition: settleTransition, willChange };
+		stageStyle = { transition: settleTransition, willChange };
 	}
 
 	// Forward the root element to the consumer's ref.
@@ -533,56 +537,70 @@ function CropperInner(
 					isInteractiveGrid &&
 						'wp-media-editor-image-editor__canvas--grid-interactive',
 					showInteractiveGrid &&
-						'wp-media-editor-image-editor__canvas--show-grid'
+						'wp-media-editor-image-editor__canvas--show-grid',
+					settling && 'wp-media-editor-image-editor__canvas--settling'
 				) }
-				style={ canvasStyle }
 				tabIndex={ 0 }
 				role="group"
 				aria-label={ __( 'Image editor' ) }
 				{ ...handlers }
 			>
-				{ /* The image layer */ }
-				<img
-					className="wp-media-editor-image-editor__image"
-					src={ src }
-					alt=""
-					onLoad={ handleImageLoad }
-					style={ imageStyle }
-					draggable={ false }
-				/>
+				{ /*
+				 * The stage is an inner full-size div that receives the
+				 * viewport pan CSS transform. Keeping the transform here
+				 * (rather than on the canvas) means the canvas always stays
+				 * at its natural position, so the root div's background is
+				 * never exposed when the stage is panned during a resize drag.
+				 */ }
+				<div
+					className="wp-media-editor-image-editor__stage"
+					data-testid="cropper-stage"
+					style={ stageStyle }
+				>
+					{ /* The image layer */ }
+					<img
+						className="wp-media-editor-image-editor__image"
+						src={ src }
+						alt=""
+						onLoad={ handleImageLoad }
+						style={ imageStyle }
+						draggable={ false }
+					/>
 
-				{ /* Dimming overlay outside the crop area */ }
-				{ showDimming && (
-					<DimmingOverlay
+					{ /* Dimming overlay outside the crop area */ }
+					{ showDimming && (
+						<DimmingOverlay
+							cropRect={ state.cropRect }
+							containerSize={ canvasSize }
+							imageSize={ visualSize }
+							transition={ settleStencilTransition }
+						/>
+					) }
+
+					{ /* The stencil (crop area with handles) */ }
+					<StencilComponent
 						cropRect={ state.cropRect }
 						containerSize={ canvasSize }
 						imageSize={ visualSize }
+						onCropChange={ handleCropChange }
+						onResizeStart={ handleResizeStart }
+						onResizeEnd={ handleResizeEnd }
+						onEscape={ handleEscape }
+						aspectRatio={ aspectRatio }
+						freeformCrop={ freeformCrop }
+						stencilTransition={ settleStencilTransition }
+						cropBounds={ cropBounds }
 					/>
-				) }
 
-				{ /* The stencil (crop area with handles) */ }
-				<StencilComponent
-					cropRect={ state.cropRect }
-					containerSize={ canvasSize }
-					imageSize={ visualSize }
-					onCropChange={ handleCropChange }
-					onResizeStart={ handleResizeStart }
-					onResizeEnd={ handleResizeEnd }
-					onEscape={ handleEscape }
-					aspectRatio={ aspectRatio }
-					freeformCrop={ freeformCrop }
-					stencilTransition={ settleStencilTransition }
-					cropBounds={ cropBounds }
-				/>
-
-				{ /* Rule-of-thirds grid */ }
-				{ ( showGrid === true || isInteractiveGrid ) && (
-					<GridOverlay
-						cropRect={ state.cropRect }
-						containerSize={ canvasSize }
-						imageSize={ visualSize }
-					/>
-				) }
+					{ /* Rule-of-thirds grid */ }
+					{ ( showGrid === true || isInteractiveGrid ) && (
+						<GridOverlay
+							cropRect={ state.cropRect }
+							containerSize={ canvasSize }
+							imageSize={ visualSize }
+						/>
+					) }
+				</div>
 
 				{ /* ARIA live region for screen reader announcements */ }
 				<div

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -28,7 +28,7 @@ import type {
 } from '../../core/types';
 import type { UseCropperStateReturn } from '../hooks/use-cropper-state';
 import { getImageFit } from '../../core/camera';
-import { getCropBounds } from '../../core/containment';
+import { getImageCropBounds } from '../../core/containment';
 import { useInteraction } from '../hooks/use-interaction';
 import { useTransformStyle } from '../hooks/use-transform-style';
 import { useAriaAnnouncer } from '../hooks/use-aria-announcer';
@@ -272,7 +272,7 @@ function CropperInner(
 	}, [ aspectRatio, freeformCrop, visualSize, setCropRect ] );
 
 	// Compute the crop handle bounds from the actual image footprint.
-	// Depends on the full state object because getCropBounds reads
+	// Depends on the full state object because getImageCropBounds reads
 	// crop, zoom, rotation, flip, and image. React Compiler requires
 	// the complete dependency; the computation is lightweight (a few
 	// trig ops + 4 corner transforms).
@@ -280,7 +280,7 @@ function CropperInner(
 		if ( ! state.image || elementSize.width === 0 ) {
 			return undefined;
 		}
-		return getCropBounds( state, elementSize, visualSize );
+		return getImageCropBounds( state, elementSize, visualSize );
 	}, [ state, elementSize, visualSize ] );
 	const [ isResizing, setIsResizing ] = useState( false );
 	const isResizingRef = useRef( false );

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -357,7 +357,11 @@ function CropperInner(
 			setCropRect( rect );
 			// During a resize drag, pan the viewport so the handle stays
 			// visible even when the crop extends beyond the canvas edge.
-			if ( isResizingRef.current && visualSize.width > 0 ) {
+			if (
+				isResizingRef.current &&
+				visualSize.width > 0 &&
+				visualSize.height > 0
+			) {
 				const offsetX = ( canvasSize.width - visualSize.width ) / 2;
 				const offsetY = ( canvasSize.height - visualSize.height ) / 2;
 				const rightOverflow = Math.max(

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -284,6 +284,7 @@ function CropperInner(
 	}, [ state, elementSize, visualSize ] );
 	const [ isResizing, setIsResizing ] = useState( false );
 	const isResizingRef = useRef( false );
+	const isSettlingRef = useRef( false );
 
 	// Use the interaction hook for mouse, touch, and keyboard events.
 	const {
@@ -309,7 +310,10 @@ function CropperInner(
 			return;
 		}
 		const handleWheel = ( event: WheelEvent ) => {
-			if ( isResizingRef.current ) {
+			// Block wheel zoom while resizing or settling — the canvas CSS
+			// transform changes getBoundingClientRect() during this window,
+			// so focal-point math would resolve against the wrong center.
+			if ( isResizingRef.current || isSettlingRef.current ) {
 				event.preventDefault();
 				return;
 			}
@@ -413,6 +417,12 @@ function CropperInner(
 	const handleResizeStart = useCallback( () => {
 		isResizingRef.current = true;
 		setIsResizing( true );
+		// Clear any in-flight settle so transitions don't apply during the
+		// new drag (rapid successive resizes would otherwise inherit the
+		// previous settle animation).
+		clearTimeout( settleTimerRef.current );
+		isSettlingRef.current = false;
+		setSettling( false );
 		resetViewport();
 		onGestureStart?.();
 	}, [ onGestureStart, resetViewport ] );
@@ -424,6 +434,7 @@ function CropperInner(
 	const handleResizeEnd = useCallback( () => {
 		isResizingRef.current = false;
 		setIsResizing( false );
+		isSettlingRef.current = true;
 		setSettling( true );
 		// Reset viewport pan first so it transitions back to zero in sync
 		// with the settle animation on the image.
@@ -432,6 +443,7 @@ function CropperInner(
 		onGestureEnd?.();
 		clearTimeout( settleTimerRef.current );
 		settleTimerRef.current = setTimeout( () => {
+			isSettlingRef.current = false;
 			setSettling( false );
 		}, 200 );
 	}, [ settleCrop, onGestureEnd, resetViewport ] );
@@ -464,15 +476,19 @@ function CropperInner(
 	// Viewport pan CSS transform for the canvas div. Applied during resize
 	// drags to keep handles visible when the crop extends past the canvas edge.
 	// Transitions back to zero during the settle animation.
+	// will-change promotes the canvas to its own compositor layer while the
+	// transform is active, keeping per-frame pan updates off the main thread.
 	const settleTransition = settling ? 'transform 200ms ease-out' : undefined;
+	const willChange = isResizing || settling ? 'transform' : undefined;
 	let canvasStyle: React.CSSProperties | undefined;
 	if ( viewportState.pan.x !== 0 || viewportState.pan.y !== 0 ) {
 		canvasStyle = {
 			transform: `translate(${ viewportState.pan.x }px, ${ viewportState.pan.y }px)`,
 			transition: settleTransition,
+			willChange,
 		};
 	} else if ( settling ) {
-		canvasStyle = { transition: settleTransition };
+		canvasStyle = { transition: settleTransition, willChange };
 	}
 
 	// Forward the root element to the consumer's ref.

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -35,7 +35,7 @@ import { useAriaAnnouncer } from '../hooks/use-aria-announcer';
 import { RectangleStencil } from './stencils/rectangle-stencil';
 import { DimmingOverlay } from './overlays/dimming-overlay';
 import { GridOverlay } from './overlays/grid-overlay';
-import { ViewportProvider, useViewportOptional } from './viewport-provider';
+import { ViewportProvider, useViewport } from './viewport-provider';
 import './cropper.scss';
 
 /** Threshold for comparing normalized crop rect values. */
@@ -170,7 +170,11 @@ function CropperInner(
 	ref: React.ForwardedRef< HTMLDivElement >
 ) {
 	const { state, setImage, setCropRect, settleCrop } = controller;
-	const viewport = useViewportOptional();
+	const {
+		viewport: viewportState,
+		setViewportPan,
+		resetViewport,
+	} = useViewport();
 	// Canvas measurement via ResizeObserver. The canvas is the inner
 	// positioning context for image/stencil/handles — inset from the root
 	// by the handle gutter, so crop math operates on the reduced box.
@@ -349,7 +353,7 @@ function CropperInner(
 			setCropRect( rect );
 			// During a resize drag, pan the viewport so the handle stays
 			// visible even when the crop extends beyond the canvas edge.
-			if ( isResizingRef.current && viewport && visualSize.width > 0 ) {
+			if ( isResizingRef.current && visualSize.width > 0 ) {
 				const offsetX = ( canvasSize.width - visualSize.width ) / 2;
 				const offsetY = ( canvasSize.height - visualSize.height ) / 2;
 				const rightOverflow = Math.max(
@@ -372,13 +376,13 @@ function CropperInner(
 					0,
 					-( offsetY + rect.y * visualSize.height )
 				);
-				viewport.setViewportPan( {
+				setViewportPan( {
 					x: -rightOverflow + leftOverflow,
 					y: -bottomOverflow + topOverflow,
 				} );
 			}
 		},
-		[ setCropRect, viewport, canvasSize, visualSize ]
+		[ setCropRect, setViewportPan, canvasSize, visualSize ]
 	);
 
 	// Settling animation: brief linear transition after resize end.
@@ -409,9 +413,9 @@ function CropperInner(
 	const handleResizeStart = useCallback( () => {
 		isResizingRef.current = true;
 		setIsResizing( true );
-		viewport?.resetViewport();
+		resetViewport();
 		onGestureStart?.();
-	}, [ onGestureStart, viewport ] );
+	}, [ onGestureStart, resetViewport ] );
 
 	/**
 	 * Handle resize end — settle the crop rect (re-center, fill height)
@@ -423,14 +427,14 @@ function CropperInner(
 		setSettling( true );
 		// Reset viewport pan first so it transitions back to zero in sync
 		// with the settle animation on the image.
-		viewport?.resetViewport();
+		resetViewport();
 		settleCrop();
 		onGestureEnd?.();
 		clearTimeout( settleTimerRef.current );
 		settleTimerRef.current = setTimeout( () => {
 			setSettling( false );
 		}, 200 );
-	}, [ settleCrop, onGestureEnd, viewport ] );
+	}, [ settleCrop, onGestureEnd, resetViewport ] );
 
 	const imageTransition =
 		settling || isZooming ? 'transform 150ms linear' : undefined;
@@ -462,12 +466,9 @@ function CropperInner(
 	// Transitions back to zero during the settle animation.
 	const settleTransition = settling ? 'transform 200ms ease-out' : undefined;
 	let canvasStyle: React.CSSProperties | undefined;
-	if (
-		viewport &&
-		( viewport.viewport.pan.x !== 0 || viewport.viewport.pan.y !== 0 )
-	) {
+	if ( viewportState.pan.x !== 0 || viewportState.pan.y !== 0 ) {
 		canvasStyle = {
-			transform: `translate(${ viewport.viewport.pan.x }px, ${ viewport.viewport.pan.y }px)`,
+			transform: `translate(${ viewportState.pan.x }px, ${ viewportState.pan.y }px)`,
 			transition: settleTransition,
 		};
 	} else if ( settling ) {

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -35,6 +35,7 @@ import { useAriaAnnouncer } from '../hooks/use-aria-announcer';
 import { RectangleStencil } from './stencils/rectangle-stencil';
 import { DimmingOverlay } from './overlays/dimming-overlay';
 import { GridOverlay } from './overlays/grid-overlay';
+import { useViewportOptional } from './viewport-provider';
 import './cropper.scss';
 
 /** Threshold for comparing normalized crop rect values. */
@@ -169,6 +170,7 @@ function CropperInner(
 	ref: React.ForwardedRef< HTMLDivElement >
 ) {
 	const { state, setImage, setCropRect, settleCrop } = controller;
+	const viewport = useViewportOptional();
 	// Canvas measurement via ResizeObserver. The canvas is the inner
 	// positioning context for image/stencil/handles — inset from the root
 	// by the handle gutter, so crop math operates on the reduced box.
@@ -274,8 +276,8 @@ function CropperInner(
 		if ( ! state.image || elementSize.width === 0 ) {
 			return undefined;
 		}
-		return getCropBounds( state, elementSize, visualSize, canvasSize );
-	}, [ state, elementSize, visualSize, canvasSize ] );
+		return getCropBounds( state, elementSize, visualSize );
+	}, [ state, elementSize, visualSize ] );
 	const [ isResizing, setIsResizing ] = useState( false );
 	const isResizingRef = useRef( false );
 
@@ -342,14 +344,41 @@ function CropperInner(
 		[ src, setImage, onImageLoaded ]
 	);
 
-	/**
-	 * Handle crop rect changes from the stencil (during drag).
-	 */
 	const handleCropChange = useCallback(
 		( rect: NormalizedRect ) => {
 			setCropRect( rect );
+			// During a resize drag, pan the viewport so the handle stays
+			// visible even when the crop extends beyond the canvas edge.
+			if ( isResizingRef.current && viewport && visualSize.width > 0 ) {
+				const offsetX = ( canvasSize.width - visualSize.width ) / 2;
+				const offsetY = ( canvasSize.height - visualSize.height ) / 2;
+				const rightOverflow = Math.max(
+					0,
+					offsetX +
+						( rect.x + rect.width ) * visualSize.width -
+						canvasSize.width
+				);
+				const leftOverflow = Math.max(
+					0,
+					-( offsetX + rect.x * visualSize.width )
+				);
+				const bottomOverflow = Math.max(
+					0,
+					offsetY +
+						( rect.y + rect.height ) * visualSize.height -
+						canvasSize.height
+				);
+				const topOverflow = Math.max(
+					0,
+					-( offsetY + rect.y * visualSize.height )
+				);
+				viewport.setViewportPan( {
+					x: -rightOverflow + leftOverflow,
+					y: -bottomOverflow + topOverflow,
+				} );
+			}
 		},
-		[ setCropRect ]
+		[ setCropRect, viewport, canvasSize, visualSize ]
 	);
 
 	// Settling animation: brief linear transition after resize end.
@@ -380,23 +409,28 @@ function CropperInner(
 	const handleResizeStart = useCallback( () => {
 		isResizingRef.current = true;
 		setIsResizing( true );
+		viewport?.resetViewport();
 		onGestureStart?.();
-	}, [ onGestureStart ] );
+	}, [ onGestureStart, viewport ] );
 
 	/**
-	 * Handle resize end — settle the crop rect (re-center, fill height).
+	 * Handle resize end — settle the crop rect (re-center, fill height)
+	 * and reset the viewport pan back to neutral.
 	 */
 	const handleResizeEnd = useCallback( () => {
 		isResizingRef.current = false;
 		setIsResizing( false );
 		setSettling( true );
+		// Reset viewport pan first so it transitions back to zero in sync
+		// with the settle animation on the image.
+		viewport?.resetViewport();
 		settleCrop();
 		onGestureEnd?.();
 		clearTimeout( settleTimerRef.current );
 		settleTimerRef.current = setTimeout( () => {
 			setSettling( false );
 		}, 200 );
-	}, [ settleCrop, onGestureEnd ] );
+	}, [ settleCrop, onGestureEnd, viewport ] );
 
 	const imageTransition =
 		settling || isZooming ? 'transform 150ms linear' : undefined;
@@ -422,6 +456,23 @@ function CropperInner(
 			transition: imageTransition,
 		};
 	}, [ canvasSize, elementSize, transformString, imageTransition ] );
+
+	// Viewport pan CSS transform for the canvas div. Applied during resize
+	// drags to keep handles visible when the crop extends past the canvas edge.
+	// Transitions back to zero during the settle animation.
+	const settleTransition = settling ? 'transform 200ms ease-out' : undefined;
+	let canvasStyle: React.CSSProperties | undefined;
+	if (
+		viewport &&
+		( viewport.viewport.pan.x !== 0 || viewport.viewport.pan.y !== 0 )
+	) {
+		canvasStyle = {
+			transform: `translate(${ viewport.viewport.pan.x }px, ${ viewport.viewport.pan.y }px)`,
+			transition: settleTransition,
+		};
+	} else if ( settling ) {
+		canvasStyle = { transition: settleTransition };
+	}
 
 	// Forward the root element to the consumer's ref.
 	const setContainerRef = useCallback(
@@ -467,6 +518,7 @@ function CropperInner(
 					showInteractiveGrid &&
 						'wp-media-editor-image-editor__canvas--show-grid'
 				) }
+				style={ canvasStyle }
 				tabIndex={ 0 }
 				role="group"
 				aria-label={ __( 'Image editor' ) }

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -35,7 +35,7 @@ import { useAriaAnnouncer } from '../hooks/use-aria-announcer';
 import { RectangleStencil } from './stencils/rectangle-stencil';
 import { DimmingOverlay } from './overlays/dimming-overlay';
 import { GridOverlay } from './overlays/grid-overlay';
-import { useViewportOptional } from './viewport-provider';
+import { ViewportProvider, useViewportOptional } from './viewport-provider';
 import './cropper.scss';
 
 /** Threshold for comparing normalized crop rect values. */
@@ -591,6 +591,14 @@ function CropperInner(
 	);
 }
 
-export const Cropper = forwardRef< HTMLDivElement, CropperProps >(
+const CropperInnerWithRef = forwardRef< HTMLDivElement, CropperProps >(
 	CropperInner
+);
+
+export const Cropper = forwardRef< HTMLDivElement, CropperProps >(
+	( props, ref ) => (
+		<ViewportProvider>
+			<CropperInnerWithRef { ...props } ref={ ref } />
+		</ViewportProvider>
+	)
 );

--- a/packages/media-editor/src/image-editor/react/components/overlays/dimming-overlay.tsx
+++ b/packages/media-editor/src/image-editor/react/components/overlays/dimming-overlay.tsx
@@ -36,10 +36,22 @@ export function DimmingOverlay( {
 	const width = cropRect.width * imageSize.width;
 	const height = cropRect.height * imageSize.height;
 
+	// Compose any incoming transition with the stylesheet's box-shadow
+	// transition so the drag-dimming effect isn't overwritten.
+	const composedTransition = transition
+		? `${ transition }, box-shadow 0.15s ease`
+		: undefined;
+
 	return (
 		<div
 			className="wp-media-editor-image-editor__dimming"
-			style={ { left, top, width, height, transition } }
+			style={ {
+				left,
+				top,
+				width,
+				height,
+				transition: composedTransition,
+			} }
 		/>
 	);
 }

--- a/packages/media-editor/src/image-editor/react/components/overlays/dimming-overlay.tsx
+++ b/packages/media-editor/src/image-editor/react/components/overlays/dimming-overlay.tsx
@@ -13,24 +13,17 @@ interface DimmingOverlayProps {
 	containerSize: Size;
 	/** The rendered image dimensions in pixels within the container. */
 	imageSize: Size;
+	/** CSS transition string, e.g. during settle animation. */
+	transition?: string;
 }
 
-/**
- * Renders a semi-transparent overlay outside the crop rectangle.
- *
- * Uses the box-shadow approach: a div matching the crop rect position
- * with a large box-shadow that dims everything outside it.
- *
- * @param props               Component props.
- * @param props.cropRect      The crop rectangle in normalized coordinates.
- * @param props.containerSize The container element dimensions in pixels.
- * @param props.imageSize     The rendered image dimensions in pixels.
- * @return The dimming overlay element.
- */
+// Renders a semi-transparent overlay outside the crop rectangle using a
+// box-shadow that dims everything outside the crop rect position.
 export function DimmingOverlay( {
 	cropRect,
 	containerSize,
 	imageSize,
+	transition,
 }: DimmingOverlayProps ) {
 	if ( containerSize.width === 0 || containerSize.height === 0 ) {
 		return null;
@@ -46,12 +39,7 @@ export function DimmingOverlay( {
 	return (
 		<div
 			className="wp-media-editor-image-editor__dimming"
-			style={ {
-				left,
-				top,
-				width,
-				height,
-			} }
+			style={ { left, top, width, height, transition } }
 		/>
 	);
 }

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -171,7 +171,9 @@ describe( 'Cropper', () => {
 		const handle = await screen.findByRole( 'button', {
 			name: 'Resize top-left corner',
 		} );
-		const canvas = screen.getByRole( 'group', { name: 'Image editor' } );
+		// The settle transition and viewport pan live on the stage, not the
+		// canvas (which stays fixed so the root background is never exposed).
+		const stage = screen.getByTestId( 'cropper-stage' );
 
 		// Start and end a resize to trigger the settle animation.
 		fireEvent.pointerDown( handle, {
@@ -182,8 +184,8 @@ describe( 'Cropper', () => {
 		} );
 		fireEvent.pointerUp( handle, { pointerId: 1 } );
 
-		// The settle transition should now be active.
-		expect( canvas ).toHaveStyle( 'transition: transform 200ms ease-out' );
+		// The settle transition should now be active on the stage.
+		expect( stage ).toHaveStyle( 'transition: transform 200ms ease-out' );
 
 		// Start a new resize before the 200 ms settle timer fires.
 		fireEvent.pointerDown( handle, {
@@ -194,14 +196,14 @@ describe( 'Cropper', () => {
 		} );
 
 		// Settling must be cleared — no transition on the drag.
-		expect( canvas ).not.toHaveStyle(
+		expect( stage ).not.toHaveStyle(
 			'transition: transform 200ms ease-out'
 		);
 
-		// Advance past the old settle timer; it was cancelled so the canvas
+		// Advance past the old settle timer; it was cancelled so the stage
 		// should still have no transition.
 		act( () => jest.advanceTimersByTime( 200 ) );
-		expect( canvas ).not.toHaveStyle(
+		expect( stage ).not.toHaveStyle(
 			'transition: transform 200ms ease-out'
 		);
 
@@ -231,7 +233,7 @@ describe( 'Cropper', () => {
 		const eHandle = await screen.findByRole( 'button', {
 			name: 'Resize right edge',
 		} );
-		const canvas = screen.getByRole( 'group', { name: 'Image editor' } );
+		const stage = screen.getByTestId( 'cropper-stage' );
 
 		// cropRect starts at {x:0, y:0, width:1, height:1} (right edge = 1.0).
 		// One ArrowRight step (+0.01 normalized) puts the right edge at 1.01.
@@ -239,7 +241,7 @@ describe( 'Cropper', () => {
 		//   rightOverflow = 1.01 * 600 − 600 = 6 → pan.x = −6
 		fireEvent.keyDown( eHandle, { key: 'ArrowRight' } );
 
-		expect( canvas ).toHaveStyle( 'transform: translate(-6px, 0px)' );
+		expect( stage ).toHaveStyle( 'transform: translate(-6px, 0px)' );
 
 		jest.useRealTimers();
 	} );

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -154,6 +154,94 @@ describe( 'Cropper', () => {
 		const canvas = screen.getByRole( 'group', { name: 'Image editor' } );
 		expect( canvas ).toHaveClass( GRID_INTERACTIVE_CLASS );
 		expect( canvas ).toHaveClass( SHOW_GRID_CLASS );
+	} );
+
+	it( 'clears settling state when a new resize starts before the settle timer fires', async () => {
+		jest.useFakeTimers();
+
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ createController() }
+				showDimming={ false }
+				freeformCrop
+			/>
+		);
+
+		const handle = await screen.findByRole( 'button', {
+			name: 'Resize top-left corner',
+		} );
+		const canvas = screen.getByRole( 'group', { name: 'Image editor' } );
+
+		// Start and end a resize to trigger the settle animation.
+		fireEvent.pointerDown( handle, {
+			button: 0,
+			clientX: 100,
+			clientY: 100,
+			pointerId: 1,
+		} );
+		fireEvent.pointerUp( handle, { pointerId: 1 } );
+
+		// The settle transition should now be active.
+		expect( canvas ).toHaveStyle( 'transition: transform 200ms ease-out' );
+
+		// Start a new resize before the 200 ms settle timer fires.
+		fireEvent.pointerDown( handle, {
+			button: 0,
+			clientX: 100,
+			clientY: 100,
+			pointerId: 1,
+		} );
+
+		// Settling must be cleared — no transition on the drag.
+		expect( canvas ).not.toHaveStyle(
+			'transition: transform 200ms ease-out'
+		);
+
+		// Advance past the old settle timer; it was cancelled so the canvas
+		// should still have no transition.
+		act( () => jest.advanceTimersByTime( 200 ) );
+		expect( canvas ).not.toHaveStyle(
+			'transition: transform 200ms ease-out'
+		);
+
+		fireEvent.pointerUp( handle, { pointerId: 1 } );
+
+		jest.useRealTimers();
+	} );
+
+	it( 'pans the canvas when a keyboard resize extends the crop past the canvas edge', async () => {
+		jest.useFakeTimers();
+
+		// zoom: 2 so the image bounds extend past [0, 1] in normalized space,
+		// allowing the crop to be resized beyond the canvas edge.
+		const controller = createController();
+		controller.state = { ...controller.state, zoom: 2 };
+
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ controller }
+				showDimming={ false }
+				freeformCrop
+			/>
+		);
+
+		// East handle (4th button clockwise: nw, n, ne, e).
+		const eHandle = await screen.findByRole( 'button', {
+			name: 'Resize right edge',
+		} );
+		const canvas = screen.getByRole( 'group', { name: 'Image editor' } );
+
+		// cropRect starts at {x:0, y:0, width:1, height:1} (right edge = 1.0).
+		// One ArrowRight step (+0.01 normalized) puts the right edge at 1.01.
+		// With canvasSize=600×400 and visualSize=600×400:
+		//   rightOverflow = 1.01 * 600 − 600 = 6 → pan.x = −6
+		fireEvent.keyDown( eHandle, { key: 'ArrowRight' } );
+
+		expect( canvas ).toHaveStyle( 'transform: translate(-6px, 0px)' );
+
+		jest.useRealTimers();
 	} );
 
 	it( 'ignores wheel zoom while a crop resize is active', async () => {

--- a/packages/media-editor/src/image-editor/react/components/viewport-provider.tsx
+++ b/packages/media-editor/src/image-editor/react/components/viewport-provider.tsx
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	useViewportState,
+	type UseViewportStateReturn,
+} from '../hooks/use-viewport-state';
+
+type ViewportContextValue = UseViewportStateReturn | null;
+
+const ViewportContext = createContext< ViewportContextValue >( null );
+
+export function ViewportProvider( {
+	children,
+}: {
+	children: React.ReactNode;
+} ) {
+	const viewportState = useViewportState();
+	return (
+		<ViewportContext.Provider value={ viewportState }>
+			{ children }
+		</ViewportContext.Provider>
+	);
+}
+
+/**
+ * Returns the viewport context. Throws if used outside a ViewportProvider.
+ */
+export function useViewport(): UseViewportStateReturn {
+	const context = useContext( ViewportContext );
+	if ( ! context ) {
+		throw new Error(
+			'useViewport must be used within a ViewportProvider.'
+		);
+	}
+	return context;
+}
+
+/**
+ * Returns the viewport context, or null when used outside a ViewportProvider.
+ * Use this in components that work with or without a viewport.
+ */
+export function useViewportOptional(): UseViewportStateReturn | null {
+	return useContext( ViewportContext );
+}

--- a/packages/media-editor/src/image-editor/react/components/viewport-provider.tsx
+++ b/packages/media-editor/src/image-editor/react/components/viewport-provider.tsx
@@ -11,9 +11,9 @@ import {
 	type UseViewportStateReturn,
 } from '../hooks/use-viewport-state';
 
-type ViewportContextValue = UseViewportStateReturn | null;
+type ViewportContextValue = UseViewportStateReturn;
 
-const ViewportContext = createContext< ViewportContextValue >( null );
+const ViewportContext = createContext< ViewportContextValue | null >( null );
 
 export function ViewportProvider( {
 	children,
@@ -28,9 +28,6 @@ export function ViewportProvider( {
 	);
 }
 
-/**
- * Returns the viewport context. Throws if used outside a ViewportProvider.
- */
 export function useViewport(): UseViewportStateReturn {
 	const context = useContext( ViewportContext );
 	if ( ! context ) {
@@ -39,12 +36,4 @@ export function useViewport(): UseViewportStateReturn {
 		);
 	}
 	return context;
-}
-
-/**
- * Returns the viewport context, or null when used outside a ViewportProvider.
- * Use this in components that work with or without a viewport.
- */
-export function useViewportOptional(): UseViewportStateReturn | null {
-	return useContext( ViewportContext );
 }

--- a/packages/media-editor/src/image-editor/react/hooks/use-viewport-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-viewport-state.ts
@@ -14,6 +14,10 @@ import {
 
 export interface UseViewportStateReturn {
 	viewport: ViewportState;
+	/**
+	 * Unused in the current Cropper implementation — scaffolded for the
+	 * upcoming navigator panel (viewport zoom slider).
+	 */
 	setViewportZoom: ( zoom: number ) => void;
 	setViewportPan: ( pan: { x: number; y: number } ) => void;
 	resetViewport: () => void;

--- a/packages/media-editor/src/image-editor/react/hooks/use-viewport-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-viewport-state.ts
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { useReducer, useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { ViewportState } from '../../core/types';
+import {
+	viewportReducer,
+	DEFAULT_VIEWPORT_STATE,
+} from '../../core/viewport-state';
+
+export interface UseViewportStateReturn {
+	viewport: ViewportState;
+	setViewportZoom: ( zoom: number ) => void;
+	setViewportPan: ( pan: { x: number; y: number } ) => void;
+	resetViewport: () => void;
+}
+
+export function useViewportState(): UseViewportStateReturn {
+	const [ viewport, dispatch ] = useReducer(
+		viewportReducer,
+		DEFAULT_VIEWPORT_STATE
+	);
+
+	const setViewportZoom = useCallback( ( zoom: number ) => {
+		dispatch( { type: 'SET_VIEWPORT_ZOOM', payload: zoom } );
+	}, [] );
+
+	const setViewportPan = useCallback( ( pan: { x: number; y: number } ) => {
+		dispatch( { type: 'SET_VIEWPORT_PAN', payload: pan } );
+	}, [] );
+
+	const resetViewport = useCallback( () => {
+		dispatch( { type: 'RESET_VIEWPORT' } );
+	}, [] );
+
+	return { viewport, setViewportZoom, setViewportPan, resetViewport };
+}

--- a/packages/media-editor/src/image-editor/react/hooks/use-viewport-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-viewport-state.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useReducer, useCallback } from '@wordpress/element';
+import { useReducer, useCallback, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -41,5 +41,8 @@ export function useViewportState(): UseViewportStateReturn {
 		dispatch( { type: 'RESET_VIEWPORT' } );
 	}, [] );
 
-	return { viewport, setViewportZoom, setViewportPan, resetViewport };
+	return useMemo(
+		() => ( { viewport, setViewportZoom, setViewportPan, resetViewport } ),
+		[ viewport, setViewportZoom, setViewportPan, resetViewport ]
+	);
 }


### PR DESCRIPTION
## What?

Part of:

* #73771

In the image cropper in the media editor modal experiment, allow dragging a drag handle beyond the current viewable area of the cropper canvas. Pan to follow the drag, and then settle once the interaction is complete.

This effectively (to a user) should be the inverse of the behaviour we have when reducing a crop size. When we reduce the crop, we then zoom in to the new crop size so that it sits comfortably in the viewport. This PR is the reverse of that behaviour for when we _expand_ the crop area.

## Why?

In `trunk` it's very hard to expand the crop size again, as we quickly reach the `canvasSize` bounds of the cropper. A user needs to either manually zoom out or perform multiple gestures in order to expand the crop size again.

While in the future we might offer more fine-grained control over the viewport (e.g. the navigator idea I was looking at in https://github.com/WordPress/gutenberg/pull/77879), the goal here is to simply add a little panning in order to allow expanding the crop size, without creating a complex set of new UI gestures or components.

## How?

* Remove `canvasSize` from `getCropBounds`. The idea in this PR is that the crop isn't bounded by the viewport area, and instead we'll pan (and then zoom) to try to fit things into frame.
* Add the concept of viewport state with pan and zoom (for this PR, zoom is 1, but I've added it in for now as we might want to support a navigator-like control in follow-ups)
* When a crop is resized, pan to cover the overflow area: this is what achieves the feeling of panning the viewport as a user drags beyond the visible area
* Try with different aspect ratios and rotation and make sure nothing feels broken

## Testing Instructions

1. Enable the Media Editor Modal experiment
2. Add an image to a post or page
3. Click on the Crop button in the block toolbar
4. Reduce the size of the image in the canvas
5. Use either the keyboard or mouse to adjust drag handles to make the image bigger again
6. In this PR it should feel a softer experience overall, and easier to expand the size of the crop again
7. When you release the key or mouse button, the viewport should smoothly transition to the whole crop area being visible again

## Screenshots or screencast <!-- if applicable -->

### Before

Note how easy it is to get stuck and how many times it takes to try to get the crop back to its original size:

https://github.com/user-attachments/assets/9241173c-c65d-4c23-a272-1732408c33a6

### After

It should now feel much easier to spring back to a larger size:

https://github.com/user-attachments/assets/3bd76f66-c8ad-4738-b9d7-6c7dd98480c5

## Use of AI Tools

Claude Code