### PR TITLE
Taxonomy edit route: declare `@wordpress/base-styles` as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63671,6 +63671,7 @@
 			"version": "1.0.0",
 			"dependencies": {
 				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/base-styles": "file:../../packages/base-styles",
 				"@wordpress/components": "file:../../packages/components",
 				"@wordpress/compose": "file:../../packages/compose",
 				"@wordpress/core-data": "file:../../packages/core-data",

--- a/routes/taxonomy-edit/package.json
+++ b/routes/taxonomy-edit/package.json
@@ -10,6 +10,7 @@
 	},
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/base-styles": "file:../../packages/base-styles",
 		"@wordpress/components": "file:../../packages/components",
 		"@wordpress/compose": "file:../../packages/compose",
 		"@wordpress/core-data": "file:../../packages/core-data",


### PR DESCRIPTION
## What?
Declares `@wordpress/base-styles` as a dependency of the `@wordpress/taxonomy-edit-route` package. 

## Why?
Add a missing dependency post-merge. See https://github.com/WordPress/gutenberg/pull/77786#discussion_r3179612746

## How?
Just declaring a dependency.

## Testing Instructions
  - npm install should succeed.
  - npm run build should still produce styles for the taxonomy edit route.
  - Visit the taxonomy edit screen and confirm the help text still renders in the expected gray ($gray-700).

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->

None

## Use of AI Tools

Opus 4.7