### PR TITLE
Media editor: replace fine-rotation slider with RotationRuler

### DIFF
--- a/packages/media-editor/src/components/media-editor-toolbar/index.tsx
+++ b/packages/media-editor/src/components/media-editor-toolbar/index.tsx
@@ -62,7 +62,12 @@ export default function MediaEditorToolbar( {
 		undo: undoCrop,
 		redo: redoCrop,
 	} = useCropper();
-	const rotationGestureHandlers = useCropGestureHandlers();
+	// `commitOnKeyUp: false` keeps rapid arrow-key adjustments coalesced
+	// into a single undo entry by the state-change debounce. Pointer-up
+	// still commits immediately so each drag is its own undo step.
+	const rotationGestureHandlers = useCropGestureHandlers( {
+		commitOnKeyUp: false,
+	} );
 
 	const handleReset = () => {
 		reset();

--- a/packages/media-editor/src/components/media-editor-toolbar/index.tsx
+++ b/packages/media-editor/src/components/media-editor-toolbar/index.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Button, RangeControl } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
 import { displayShortcut, isAppleOS } from '@wordpress/keycodes';
@@ -20,6 +20,7 @@ import {
 import { useCropper } from '../../image-editor';
 import { useCropGestureHandlers } from '../../hooks/use-crop-gesture-handlers';
 import { MAX_ROTATION_OFFSET } from '../../image-editor/core/constants';
+import RotationRuler from '../rotation-ruler';
 
 export interface MediaEditorToolbarProps {
 	/**
@@ -88,10 +89,7 @@ export default function MediaEditorToolbar( {
 	const visualDir = singleFlip ? -1 : 1;
 	const fineOffset = ( state.rotation - baseAngle ) * visualDir;
 
-	const handleRotationSlider = ( value: number | undefined ) => {
-		if ( value === undefined ) {
-			return;
-		}
+	const handleRotationSlider = ( value: number ) => {
 		// Clamp strictly inside [-MAX, MAX). Exactly ±MAX lands state on a
 		// 90° midpoint and flips the derived baseAngle on the next render,
 		// causing subsequent events to spiral.
@@ -182,17 +180,12 @@ export default function MediaEditorToolbar( {
 				className="media-editor-toolbar__rotation-slider"
 				{ ...rotationGestureHandlers }
 			>
-				<RangeControl
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
+				<RotationRuler
 					label={ __( 'Fine rotation' ) }
-					hideLabelFromVision
 					min={ -MAX_ROTATION_OFFSET }
 					max={ MAX_ROTATION_OFFSET }
-					step={ 0.5 }
 					value={ fineOffset }
 					onChange={ handleRotationSlider }
-					showTooltip={ false }
 				/>
 			</div>
 			<Button

--- a/packages/media-editor/src/components/media-editor-toolbar/index.tsx
+++ b/packages/media-editor/src/components/media-editor-toolbar/index.tsx
@@ -143,30 +143,6 @@ export default function MediaEditorToolbar( {
 			<div className="media-editor-toolbar__primary-cluster">
 				<Button
 					size="compact"
-					icon={ undo }
-					label={ __( 'Undo' ) }
-					showTooltip
-					shortcut={ displayShortcut.primary( 'z' ) }
-					disabled={ isUndoRedoDisabled || ! hasUndo }
-					accessibleWhenDisabled
-					onClick={ handleUndo }
-				/>
-				<Button
-					size="compact"
-					icon={ redo }
-					label={ __( 'Redo' ) }
-					showTooltip
-					shortcut={
-						isAppleOS()
-							? displayShortcut.primaryShift( 'z' )
-							: displayShortcut.primary( 'y' )
-					}
-					disabled={ isUndoRedoDisabled || ! hasRedo }
-					accessibleWhenDisabled
-					onClick={ handleRedo }
-				/>
-				<Button
-					size="compact"
 					icon={ flipHorizontal }
 					label={ __( 'Flip horizontal' ) }
 					showTooltip
@@ -190,6 +166,30 @@ export default function MediaEditorToolbar( {
 							vertical: ! state.flip.vertical,
 						} )
 					}
+				/>
+				<Button
+					size="compact"
+					icon={ undo }
+					label={ __( 'Undo' ) }
+					showTooltip
+					shortcut={ displayShortcut.primary( 'z' ) }
+					disabled={ isUndoRedoDisabled || ! hasUndo }
+					accessibleWhenDisabled
+					onClick={ handleUndo }
+				/>
+				<Button
+					size="compact"
+					icon={ redo }
+					label={ __( 'Redo' ) }
+					showTooltip
+					shortcut={
+						isAppleOS()
+							? displayShortcut.primaryShift( 'z' )
+							: displayShortcut.primary( 'y' )
+					}
+					disabled={ isUndoRedoDisabled || ! hasRedo }
+					accessibleWhenDisabled
+					onClick={ handleRedo }
 				/>
 				<Button
 					size="compact"

--- a/packages/media-editor/src/components/media-editor-toolbar/index.tsx
+++ b/packages/media-editor/src/components/media-editor-toolbar/index.tsx
@@ -116,7 +116,20 @@ export default function MediaEditorToolbar( {
 			gap="sm"
 			wrap="wrap"
 		>
-			<div className="media-editor-toolbar__rotate-cluster">
+			<div
+				role="presentation"
+				className="media-editor-toolbar__rotation-slider"
+				{ ...rotationGestureHandlers }
+			>
+				<RotationRuler
+					label={ __( 'Fine rotation' ) }
+					min={ -MAX_ROTATION_OFFSET }
+					max={ MAX_ROTATION_OFFSET }
+					value={ fineOffset }
+					onChange={ handleRotationSlider }
+				/>
+			</div>
+			<div className="media-editor-toolbar__action-cluster">
 				<Button
 					size="compact"
 					icon={ rotateLeft }
@@ -124,19 +137,6 @@ export default function MediaEditorToolbar( {
 					showTooltip
 					onClick={ () => snapRotate90( -1 ) }
 				/>
-				<div
-					role="presentation"
-					className="media-editor-toolbar__rotation-slider"
-					{ ...rotationGestureHandlers }
-				>
-					<RotationRuler
-						label={ __( 'Fine rotation' ) }
-						min={ -MAX_ROTATION_OFFSET }
-						max={ MAX_ROTATION_OFFSET }
-						value={ fineOffset }
-						onChange={ handleRotationSlider }
-					/>
-				</div>
 				<Button
 					size="compact"
 					icon={ rotateRight }
@@ -144,8 +144,6 @@ export default function MediaEditorToolbar( {
 					showTooltip
 					onClick={ () => snapRotate90( 1 ) }
 				/>
-			</div>
-			<div className="media-editor-toolbar__primary-cluster">
 				<Button
 					size="compact"
 					icon={ flipHorizontal }

--- a/packages/media-editor/src/components/media-editor-toolbar/index.tsx
+++ b/packages/media-editor/src/components/media-editor-toolbar/index.tsx
@@ -111,92 +111,96 @@ export default function MediaEditorToolbar( {
 			gap="sm"
 			wrap="wrap"
 		>
-			<Button
-				size="compact"
-				icon={ undo }
-				label={ __( 'Undo' ) }
-				showTooltip
-				shortcut={ displayShortcut.primary( 'z' ) }
-				disabled={ isUndoRedoDisabled || ! hasUndo }
-				accessibleWhenDisabled
-				onClick={ handleUndo }
-			/>
-			<Button
-				size="compact"
-				icon={ redo }
-				label={ __( 'Redo' ) }
-				showTooltip
-				shortcut={
-					isAppleOS()
-						? displayShortcut.primaryShift( 'z' )
-						: displayShortcut.primary( 'y' )
-				}
-				disabled={ isUndoRedoDisabled || ! hasRedo }
-				accessibleWhenDisabled
-				onClick={ handleRedo }
-			/>
-			<Button
-				size="compact"
-				icon={ rotateLeft }
-				label={ __( 'Rotate 90° counter-clockwise' ) }
-				showTooltip
-				onClick={ () => snapRotate90( -1 ) }
-			/>
-			<Button
-				size="compact"
-				icon={ rotateRight }
-				label={ __( 'Rotate 90° clockwise' ) }
-				showTooltip
-				onClick={ () => snapRotate90( 1 ) }
-			/>
-			<Button
-				size="compact"
-				icon={ flipHorizontal }
-				label={ __( 'Flip horizontal' ) }
-				showTooltip
-				isPressed={ state.flip.horizontal }
-				onClick={ () =>
-					setFlip( {
-						horizontal: ! state.flip.horizontal,
-						vertical: state.flip.vertical,
-					} )
-				}
-			/>
-			<Button
-				size="compact"
-				icon={ flipVertical }
-				label={ __( 'Flip vertical' ) }
-				showTooltip
-				isPressed={ state.flip.vertical }
-				onClick={ () =>
-					setFlip( {
-						horizontal: state.flip.horizontal,
-						vertical: ! state.flip.vertical,
-					} )
-				}
-			/>
-			<div
-				role="presentation"
-				className="media-editor-toolbar__rotation-slider"
-				{ ...rotationGestureHandlers }
-			>
-				<RotationRuler
-					label={ __( 'Fine rotation' ) }
-					min={ -MAX_ROTATION_OFFSET }
-					max={ MAX_ROTATION_OFFSET }
-					value={ fineOffset }
-					onChange={ handleRotationSlider }
+			<div className="media-editor-toolbar__rotate-cluster">
+				<Button
+					size="compact"
+					icon={ rotateLeft }
+					label={ __( 'Rotate 90° counter-clockwise' ) }
+					showTooltip
+					onClick={ () => snapRotate90( -1 ) }
+				/>
+				<div
+					role="presentation"
+					className="media-editor-toolbar__rotation-slider"
+					{ ...rotationGestureHandlers }
+				>
+					<RotationRuler
+						label={ __( 'Fine rotation' ) }
+						min={ -MAX_ROTATION_OFFSET }
+						max={ MAX_ROTATION_OFFSET }
+						value={ fineOffset }
+						onChange={ handleRotationSlider }
+					/>
+				</div>
+				<Button
+					size="compact"
+					icon={ rotateRight }
+					label={ __( 'Rotate 90° clockwise' ) }
+					showTooltip
+					onClick={ () => snapRotate90( 1 ) }
 				/>
 			</div>
-			<Button
-				size="compact"
-				variant="tertiary"
-				disabled={ ! isDirty }
-				accessibleWhenDisabled
-				onClick={ handleReset }
-			>
-				{ __( 'Reset' ) }
-			</Button>
+			<div className="media-editor-toolbar__primary-cluster">
+				<Button
+					size="compact"
+					icon={ undo }
+					label={ __( 'Undo' ) }
+					showTooltip
+					shortcut={ displayShortcut.primary( 'z' ) }
+					disabled={ isUndoRedoDisabled || ! hasUndo }
+					accessibleWhenDisabled
+					onClick={ handleUndo }
+				/>
+				<Button
+					size="compact"
+					icon={ redo }
+					label={ __( 'Redo' ) }
+					showTooltip
+					shortcut={
+						isAppleOS()
+							? displayShortcut.primaryShift( 'z' )
+							: displayShortcut.primary( 'y' )
+					}
+					disabled={ isUndoRedoDisabled || ! hasRedo }
+					accessibleWhenDisabled
+					onClick={ handleRedo }
+				/>
+				<Button
+					size="compact"
+					icon={ flipHorizontal }
+					label={ __( 'Flip horizontal' ) }
+					showTooltip
+					isPressed={ state.flip.horizontal }
+					onClick={ () =>
+						setFlip( {
+							horizontal: ! state.flip.horizontal,
+							vertical: state.flip.vertical,
+						} )
+					}
+				/>
+				<Button
+					size="compact"
+					icon={ flipVertical }
+					label={ __( 'Flip vertical' ) }
+					showTooltip
+					isPressed={ state.flip.vertical }
+					onClick={ () =>
+						setFlip( {
+							horizontal: state.flip.horizontal,
+							vertical: ! state.flip.vertical,
+						} )
+					}
+				/>
+				<Button
+					size="compact"
+					variant="tertiary"
+					disabled={ ! isDirty }
+					accessibleWhenDisabled
+					onClick={ handleReset }
+				>
+					{ __( 'Reset' ) }
+				</Button>
+			</div>
 		</Stack>
 	);
 }

--- a/packages/media-editor/src/components/media-editor-toolbar/style.scss
+++ b/packages/media-editor/src/components/media-editor-toolbar/style.scss
@@ -3,9 +3,30 @@
 .media-editor-toolbar {
 	width: 100%;
 	padding: $grid-unit-10 $grid-unit-20;
+}
 
-	.media-editor-toolbar__rotation-slider {
-		flex: 1 1 auto;
-		max-width: 240px;
-	}
+// Two clusters wrap as units — at narrow widths the rotate cluster
+// (rotate-90, ruler, rotate+90) stacks on top of the rest. At wide
+// widths everything lives on a single row.
+.media-editor-toolbar__rotate-cluster,
+.media-editor-toolbar__primary-cluster {
+	display: flex;
+	flex-wrap: nowrap;
+	align-items: center;
+	gap: $grid-unit-10;
+}
+
+// Rotate cluster grows to absorb extra horizontal space (the ruler
+// inside it expands to fill). Capped so it doesn't dominate at very
+// wide viewports.
+.media-editor-toolbar__rotate-cluster {
+	flex: 1 1 280px;
+	min-width: 0;
+	max-width: 360px;
+	justify-content: center;
+}
+
+.media-editor-toolbar__rotation-slider {
+	flex: 1 1 auto;
+	min-width: 0;
 }

--- a/packages/media-editor/src/components/media-editor-toolbar/style.scss
+++ b/packages/media-editor/src/components/media-editor-toolbar/style.scss
@@ -1,3 +1,4 @@
+@use "@wordpress/base-styles/breakpoints" as *;
 @use "@wordpress/base-styles/variables" as *;
 
 .media-editor-toolbar {
@@ -29,4 +30,20 @@
 .media-editor-toolbar__rotation-slider {
 	flex: 1 1 auto;
 	min-width: 0;
+}
+
+// Below the modal-sidebar full-page breakpoint, force a deterministic
+// two-row layout: rotate cluster on top, history/flip/reset cluster
+// beneath. Mirrors the InterfaceSkeleton's own side-by-side → stacked
+// flip at `break-medium`.
+@media (max-width: #{ $break-medium - 1 }) {
+	.media-editor-toolbar__rotate-cluster {
+		flex-basis: 100%;
+		max-width: none;
+	}
+
+	.media-editor-toolbar__primary-cluster {
+		flex-basis: 100%;
+		justify-content: center;
+	}
 }

--- a/packages/media-editor/src/components/media-editor-toolbar/style.scss
+++ b/packages/media-editor/src/components/media-editor-toolbar/style.scss
@@ -1,21 +1,11 @@
 @use "@wordpress/base-styles/variables" as *;
-@use "@wordpress/base-styles/breakpoints" as *;
 
 .media-editor-toolbar {
 	width: 100%;
 	padding: $grid-unit-10 $grid-unit-20;
 
-	// Let the rotation slider absorb extra horizontal space (so it grows
-	// between the icon buttons and Reset) while capping its width so it
-	// doesn't dominate on wide viewports.
 	.media-editor-toolbar__rotation-slider {
 		flex: 1 1 auto;
 		max-width: 240px;
-
-		// At narrow widths the slider is too cramped to aim precisely;
-		// the 90° rotate buttons cover the essential need.
-		@media (max-width: #{ $break-mobile }) {
-			display: none;
-		}
 	}
 }

--- a/packages/media-editor/src/components/media-editor-toolbar/style.scss
+++ b/packages/media-editor/src/components/media-editor-toolbar/style.scss
@@ -1,4 +1,5 @@
 @use "@wordpress/base-styles/breakpoints" as *;
+@use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
 .media-editor-toolbar {
@@ -30,6 +31,15 @@
 .media-editor-toolbar__rotation-slider {
 	flex: 1 1 auto;
 	min-width: 0;
+}
+
+// Above break-medium, when the two clusters share a row, divide them
+// with a thin rule. Below the breakpoint they stack — no divider.
+@media (min-width: $break-medium) {
+	.media-editor-toolbar__primary-cluster {
+		border-left: 1px solid $gray-300;
+		padding-left: $grid-unit-15;
+	}
 }
 
 // Below the modal-sidebar full-page breakpoint, force a deterministic

--- a/packages/media-editor/src/components/media-editor-toolbar/style.scss
+++ b/packages/media-editor/src/components/media-editor-toolbar/style.scss
@@ -7,52 +7,42 @@
 	padding: $grid-unit-10 $grid-unit-20;
 }
 
-// Two clusters wrap as units — at narrow widths the rotate cluster
-// (rotate-90, ruler, rotate+90) stacks on top of the rest. At wide
-// widths everything lives on a single row.
-.media-editor-toolbar__rotate-cluster,
-.media-editor-toolbar__primary-cluster {
+// Two flex items: the fine-rotation slider (left, grows) and the
+// action cluster (right, fixed). At narrow widths each takes a full
+// row with the slider on top.
+.media-editor-toolbar__rotation-slider {
+	flex: 1 1 280px;
+	min-width: 0;
+	max-width: 360px;
+}
+
+.media-editor-toolbar__action-cluster {
 	display: flex;
 	flex-wrap: nowrap;
 	align-items: center;
 	gap: $grid-unit-10;
 }
 
-// Rotate cluster grows to absorb extra horizontal space (the ruler
-// inside it expands to fill). Capped so it doesn't dominate at very
-// wide viewports.
-.media-editor-toolbar__rotate-cluster {
-	flex: 1 1 280px;
-	min-width: 0;
-	max-width: 360px;
-	justify-content: center;
-}
-
-.media-editor-toolbar__rotation-slider {
-	flex: 1 1 auto;
-	min-width: 0;
-}
-
-// Above break-medium, when the two clusters share a row, divide them
-// with a thin rule. Below the breakpoint they stack — no divider.
+// Above break-medium, when the slider and action cluster share a row,
+// divide them with a thin rule. Below the breakpoint they stack — no
+// divider.
 @media (min-width: $break-medium) {
-	.media-editor-toolbar__primary-cluster {
+	.media-editor-toolbar__action-cluster {
 		border-left: 1px solid $gray-300;
 		padding-left: $grid-unit-15;
 	}
 }
 
 // Below the modal-sidebar full-page breakpoint, force a deterministic
-// two-row layout: rotate cluster on top, history/flip/reset cluster
-// beneath. Mirrors the InterfaceSkeleton's own side-by-side → stacked
-// flip at `break-medium`.
+// two-row layout: slider on top, action cluster beneath. Mirrors the
+// InterfaceSkeleton's own side-by-side → stacked flip at break-medium.
 @media (max-width: #{ $break-medium - 1 }) {
-	.media-editor-toolbar__rotate-cluster {
+	.media-editor-toolbar__rotation-slider {
 		flex-basis: 100%;
 		max-width: none;
 	}
 
-	.media-editor-toolbar__primary-cluster {
+	.media-editor-toolbar__action-cluster {
 		flex-basis: 100%;
 		justify-content: center;
 	}

--- a/packages/media-editor/src/components/rotation-ruler/README.md
+++ b/packages/media-editor/src/components/rotation-ruler/README.md
@@ -32,5 +32,6 @@ clamp/transform values as they wish before passing them in.
 - **→ / ↑** — increment by `step`
 - **Shift + arrow** — half-step (e.g. 0.5° when `step` is 1°), for
   keyboard precision when the integer drag-step is too coarse.
+  **Shift + drag** does the same on the pointer.
 - **Home / End** — min / max
 - **PageUp / PageDown** — ±10% of range (native input behaviour)

--- a/packages/media-editor/src/components/rotation-ruler/README.md
+++ b/packages/media-editor/src/components/rotation-ruler/README.md
@@ -30,5 +30,7 @@ clamp/transform values as they wish before passing them in.
 
 - **← / ↓** — decrement by `step`
 - **→ / ↑** — increment by `step`
+- **Shift + arrow** — half-step (e.g. 0.5° when `step` is 1°), for
+  keyboard precision when the integer drag-step is too coarse.
 - **Home / End** — min / max
 - **PageUp / PageDown** — ±10% of range (native input behaviour)

--- a/packages/media-editor/src/components/rotation-ruler/README.md
+++ b/packages/media-editor/src/components/rotation-ruler/README.md
@@ -2,10 +2,11 @@
 
 Private to `@wordpress/media-editor`. A horizontal ruler-slider for
 fine-grained numeric values (used for fine-tune rotation in the media
-editor toolbar). Drag the ruler to scrub; the current value sits under
-a fixed center pointer with an always-visible bubble. A visually
+editor toolbar). Drag the ruler to scrub; the current value is shown
+in an active label sitting over the centered pointer triangle, with
+labelled major ticks running through the strip behind it. A visually
 hidden `<input type="range">` underneath provides keyboard access and
-accessibility.
+accessibility. Drag values quantize to multiples of `step`.
 
 ## Usage
 
@@ -27,7 +28,7 @@ clamp/transform values as they wish before passing them in.
 
 ## Keyboard
 
-- **← / →** — ±step
-- **Shift + ← / →** — ±step / 2
+- **← / ↓** — decrement by `step`
+- **→ / ↑** — increment by `step`
 - **Home / End** — min / max
 - **PageUp / PageDown** — ±10% of range (native input behaviour)

--- a/packages/media-editor/src/components/rotation-ruler/README.md
+++ b/packages/media-editor/src/components/rotation-ruler/README.md
@@ -1,0 +1,33 @@
+# RotationRuler
+
+Private to `@wordpress/media-editor`. A horizontal ruler-slider for
+fine-grained numeric values (used for fine-tune rotation in the media
+editor toolbar). Drag the ruler to scrub; the current value sits under
+a fixed center pointer with an always-visible bubble. A visually
+hidden `<input type="range">` underneath provides keyboard access and
+accessibility.
+
+## Usage
+
+```tsx
+<RotationRuler
+    value={ rotation }
+    onChange={ setRotation }
+    label={ __( 'Fine rotation' ) }
+    min={ -45 }
+    max={ 45 }
+/>
+```
+
+## Props
+
+See `index.tsx` for the full `RotationRulerProps` interface. The
+component is controlled (`value` / `onChange`); callers own state and
+clamp/transform values as they wish before passing them in.
+
+## Keyboard
+
+- **← / →** — ±step
+- **Shift + ← / →** — ±step / 2
+- **Home / End** — min / max
+- **PageUp / PageDown** — ±10% of range (native input behaviour)

--- a/packages/media-editor/src/components/rotation-ruler/index.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/index.tsx
@@ -93,7 +93,8 @@ function formatValue( value: number ): string {
  * @param props.max           Upper bound of the range (default: 45).
  * @param props.step          Value step for drag and keyboard arrows
  *                            (default: 1). Drag values are quantized to
- *                            multiples of `step`.
+ *                            multiples of `step`. Shift+arrow halves
+ *                            the step for keyboard precision.
  * @param props.label         Accessible label for the slider input.
  * @param props.unit          Unit suffix shown in the active label and
  *                            `aria-valuetext` (default: `°`).
@@ -150,7 +151,11 @@ export default function RotationRuler( {
 			return;
 		}
 		const direction = isIncrement ? 1 : -1;
-		const next = clampValue( value + direction * step, min, max );
+		// Shift halves the step for a precision keyboard adjustment
+		// (e.g. 0.5° rotation when step is 1°). Drag stays at full
+		// `step` granularity for tactile snapping.
+		const magnitude = event.shiftKey ? step / 2 : step;
+		const next = clampValue( value + direction * magnitude, min, max );
 		if ( next !== value ) {
 			onChange( next );
 		}

--- a/packages/media-editor/src/components/rotation-ruler/index.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/index.tsx
@@ -93,8 +93,9 @@ function formatValue( value: number ): string {
  * @param props.max           Upper bound of the range (default: 45).
  * @param props.step          Value step for drag and keyboard arrows
  *                            (default: 1). Drag values are quantized to
- *                            multiples of `step`. Shift+arrow halves
- *                            the step for keyboard precision.
+ *                            multiples of `step`. Holding Shift during
+ *                            drag or with arrow keys halves the step
+ *                            for precision adjustment.
  * @param props.label         Accessible label for the slider input.
  * @param props.unit          Unit suffix shown in the active label and
  *                            `aria-valuetext` (default: `°`).
@@ -151,9 +152,9 @@ export default function RotationRuler( {
 			return;
 		}
 		const direction = isIncrement ? 1 : -1;
-		// Shift halves the step for a precision keyboard adjustment
-		// (e.g. 0.5° rotation when step is 1°). Drag stays at full
-		// `step` granularity for tactile snapping.
+		// Shift halves the step for precision adjustment
+		// (e.g. 0.5° rotation when step is 1°). Same modifier works
+		// on drag — see `useRulerDrag`.
 		const magnitude = event.shiftKey ? step / 2 : step;
 		const next = clampValue( value + direction * magnitude, min, max );
 		if ( next !== value ) {

--- a/packages/media-editor/src/components/rotation-ruler/index.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/index.tsx
@@ -1,0 +1,222 @@
+/**
+ * External dependencies
+ */
+import type { CSSProperties, KeyboardEvent } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { useId, useMemo, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useRulerDrag, clampValue } from './use-ruler-drag';
+
+export interface RotationRulerProps {
+	value: number;
+	onChange: ( value: number ) => void;
+	min?: number;
+	max?: number;
+	step?: number;
+	label: string;
+	unit?: string;
+	pixelsPerStep?: number;
+	snapToZeroWithin?: number;
+	className?: string;
+	id?: string;
+	disabled?: boolean;
+}
+
+const PX_PER_UNIT = 6;
+
+type TickKind = 'minor' | 'mid' | 'major';
+interface Tick {
+	value: number;
+	kind: TickKind;
+	height: number;
+}
+
+/**
+ * Build the tick list for the ruler strip.
+ *
+ * @param min Lower bound of the ruler in value units.
+ * @param max Upper bound of the ruler in value units.
+ */
+function useTicks( min: number, max: number ): Tick[] {
+	return useMemo( () => {
+		const out: Tick[] = [];
+		for ( let v = Math.ceil( min ); v <= Math.floor( max ); v += 1 ) {
+			let kind: TickKind = 'minor';
+			let height = 6;
+			if ( v % 15 === 0 ) {
+				kind = 'major';
+				height = 18;
+			} else if ( v % 5 === 0 ) {
+				kind = 'mid';
+				height = 12;
+			}
+			out.push( { value: v, kind, height } );
+		}
+		return out;
+	}, [ min, max ] );
+}
+
+/**
+ * Format a numeric ruler value for display, trimming a trailing `.0`.
+ *
+ * @param value Value to format.
+ */
+function formatValue( value: number ): string {
+	const rounded = Math.round( value * 10 ) / 10;
+	return Number.isInteger( rounded )
+		? rounded.toFixed( 0 )
+		: rounded.toFixed( 1 );
+}
+
+/**
+ * Horizontal "scrub-the-ruler" slider for fine-grained numeric input
+ * such as rotation in degrees.
+ *
+ * Renders a visually hidden `<input type="range">` for assistive
+ * technologies and keyboard input alongside a decorative tick strip
+ * that the user can drag with a pointer.
+ *
+ * @param props                  Component props.
+ * @param props.value            Current value.
+ * @param props.onChange         Called with the next value on each change.
+ * @param props.min              Lower bound of the range (default: -45).
+ * @param props.max              Upper bound of the range (default: 45).
+ * @param props.step             Value step for keyboard arrows (default: 1).
+ * @param props.label            Accessible label for the slider input.
+ * @param props.unit             Unit suffix shown in the bubble and
+ *                               `aria-valuetext` (default: `°`).
+ * @param props.pixelsPerStep    CSS pixels of pointer travel per `step`
+ *                               (default: 6).
+ * @param props.snapToZeroWithin Half-width of the zero snap window in
+ *                               value units. 0 disables snapping
+ *                               (default: 0.75).
+ * @param props.className        Optional extra class for the wrapper.
+ * @param props.id               Optional id for the underlying input;
+ *                               auto-generated when omitted.
+ * @param props.disabled         When true, ignores all input.
+ */
+export default function RotationRuler( {
+	value,
+	onChange,
+	min = -45,
+	max = 45,
+	step = 1,
+	label,
+	unit = '°',
+	pixelsPerStep = 6,
+	snapToZeroWithin = 0.75,
+	className,
+	id,
+	disabled = false,
+}: RotationRulerProps ) {
+	const inputRef = useRef< HTMLInputElement >( null );
+	const generatedId = useId();
+	const inputId = id ?? generatedId;
+
+	const dragHandlers = useRulerDrag( {
+		value,
+		onChange,
+		min,
+		max,
+		step,
+		pixelsPerStep,
+		snapToZeroWithin,
+		disabled,
+		onPointerDownStart: () => inputRef.current?.focus(),
+	} );
+
+	const handleKeyDown = ( event: KeyboardEvent< HTMLInputElement > ) => {
+		if ( event.key !== 'ArrowLeft' && event.key !== 'ArrowRight' ) {
+			// Home / End / PageUp / PageDown fall through to native input.
+			return;
+		}
+		// Always prevent default so the native input's own arrow-key
+		// stepping doesn't double-fire `onChange` after our custom emit.
+		event.preventDefault();
+		if ( disabled ) {
+			return;
+		}
+		const direction = event.key === 'ArrowRight' ? 1 : -1;
+		const magnitude = event.shiftKey ? step / 2 : step;
+		const next = clampValue( value + direction * magnitude, min, max );
+		if ( next !== value ) {
+			onChange( next );
+		}
+	};
+
+	const display = `${ formatValue( value ) }${ unit }`;
+	const ticks = useTicks( min, max );
+	const stripStyle: CSSProperties = useMemo( () => {
+		const offset = -value * PX_PER_UNIT;
+		return { transform: `translateX(${ offset }px)` };
+	}, [ value ] );
+
+	const wrapperClassName = [ 'rotation-ruler', className ]
+		.filter( Boolean )
+		.join( ' ' );
+
+	return (
+		<div
+			className={ wrapperClassName }
+			role="presentation"
+			data-disabled={ disabled || undefined }
+		>
+			<input
+				ref={ inputRef }
+				id={ inputId }
+				type="range"
+				className="rotation-ruler__input"
+				min={ min }
+				max={ max }
+				step="any"
+				value={ value }
+				disabled={ disabled }
+				aria-label={ label }
+				aria-valuetext={ display }
+				onChange={ ( event ) =>
+					onChange(
+						clampValue( event.target.valueAsNumber, min, max )
+					)
+				}
+				onKeyDown={ handleKeyDown }
+			/>
+			<div
+				className="rotation-ruler__strip"
+				aria-hidden="true"
+				{ ...dragHandlers }
+			>
+				<svg
+					className="rotation-ruler__ticks"
+					style={ stripStyle }
+					width={ ( max - min ) * PX_PER_UNIT }
+					height="32"
+					viewBox={ `${ min * PX_PER_UNIT } 0 ${
+						( max - min ) * PX_PER_UNIT
+					} 32` }
+					preserveAspectRatio="xMidYMid meet"
+				>
+					{ ticks.map( ( tick ) => (
+						<line
+							key={ tick.value }
+							x1={ tick.value * PX_PER_UNIT }
+							x2={ tick.value * PX_PER_UNIT }
+							y1={ 32 - tick.height }
+							y2={ 32 }
+							className={ `rotation-ruler__tick rotation-ruler__tick--${ tick.kind }` }
+						/>
+					) ) }
+				</svg>
+			</div>
+			<div className="rotation-ruler__pointer" aria-hidden="true" />
+			<div className="rotation-ruler__bubble" aria-hidden="true">
+				{ display }
+			</div>
+		</div>
+	);
+}

--- a/packages/media-editor/src/components/rotation-ruler/index.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/index.tsx
@@ -22,13 +22,14 @@ export interface RotationRulerProps {
 	label: string;
 	unit?: string;
 	pixelsPerStep?: number;
-	snapToZeroWithin?: number;
 	className?: string;
 	id?: string;
 	disabled?: boolean;
 }
 
-const STRIP_HEIGHT = 18;
+const STRIP_HEIGHT = 32;
+const LABEL_BASELINE_Y = 11;
+const MAJOR_INTERVAL = 15;
 const TICK_HEIGHT_MINOR = 4;
 const TICK_HEIGHT_MID = 8;
 const TICK_HEIGHT_MAJOR = 14;
@@ -85,24 +86,23 @@ function formatValue( value: number ): string {
  * technologies and keyboard input alongside a decorative tick strip
  * that the user can drag with a pointer.
  *
- * @param props                  Component props.
- * @param props.value            Current value.
- * @param props.onChange         Called with the next value on each change.
- * @param props.min              Lower bound of the range (default: -45).
- * @param props.max              Upper bound of the range (default: 45).
- * @param props.step             Value step for keyboard arrows (default: 1).
- * @param props.label            Accessible label for the slider input.
- * @param props.unit             Unit suffix shown in the bubble and
- *                               `aria-valuetext` (default: `°`).
- * @param props.pixelsPerStep    CSS pixels of pointer travel per `step`
- *                               (default: 6).
- * @param props.snapToZeroWithin Half-width of the zero snap window in
- *                               value units. 0 disables snapping
- *                               (default: 0.75).
- * @param props.className        Optional extra class for the wrapper.
- * @param props.id               Optional id for the underlying input;
- *                               auto-generated when omitted.
- * @param props.disabled         When true, ignores all input.
+ * @param props               Component props.
+ * @param props.value         Current value.
+ * @param props.onChange      Called with the next value on each change.
+ * @param props.min           Lower bound of the range (default: -45).
+ * @param props.max           Upper bound of the range (default: 45).
+ * @param props.step          Value step for drag and keyboard arrows
+ *                            (default: 1). Drag values are quantized to
+ *                            multiples of `step`.
+ * @param props.label         Accessible label for the slider input.
+ * @param props.unit          Unit suffix shown in the active label and
+ *                            `aria-valuetext` (default: `°`).
+ * @param props.pixelsPerStep CSS pixels of pointer travel per `step`
+ *                            (default: 6).
+ * @param props.className     Optional extra class for the wrapper.
+ * @param props.id            Optional id for the underlying input;
+ *                            auto-generated when omitted.
+ * @param props.disabled      When true, ignores all input.
  */
 export default function RotationRuler( {
 	value,
@@ -113,7 +113,6 @@ export default function RotationRuler( {
 	label,
 	unit = '°',
 	pixelsPerStep = 6,
-	snapToZeroWithin = 0.75,
 	className,
 	id,
 	disabled = false,
@@ -129,7 +128,6 @@ export default function RotationRuler( {
 		max,
 		step,
 		pixelsPerStep,
-		snapToZeroWithin,
 		disabled,
 		onPointerDownStart: () => inputRef.current?.focus(),
 	} );
@@ -152,8 +150,7 @@ export default function RotationRuler( {
 			return;
 		}
 		const direction = isIncrement ? 1 : -1;
-		const magnitude = event.shiftKey ? step / 2 : step;
-		const next = clampValue( value + direction * magnitude, min, max );
+		const next = clampValue( value + direction * step, min, max );
 		if ( next !== value ) {
 			onChange( next );
 		}
@@ -179,6 +176,15 @@ export default function RotationRuler( {
 		};
 	}, [ value, pxPerUnit ] );
 
+	// Closest major (every 15°) to current value. Its normal label is
+	// suppressed and replaced by the active label, which sits exactly
+	// under the pointer and shows the precise current value when off-
+	// major (e.g. "-7°") or the major itself when on-major (e.g. "0°").
+	const closestMajor = Math.round( value / MAJOR_INTERVAL ) * MAJOR_INTERVAL;
+	const onMajor = Math.abs( value - closestMajor ) < 0.01;
+	const activeText = onMajor ? `${ closestMajor }${ unit }` : display;
+	const majorTicks = ticks.filter( ( tick ) => tick.kind === 'major' );
+
 	const wrapperClassName = [ 'rotation-ruler', className ]
 		.filter( Boolean )
 		.join( ' ' );
@@ -188,6 +194,7 @@ export default function RotationRuler( {
 			className={ wrapperClassName }
 			role="presentation"
 			data-disabled={ disabled || undefined }
+			{ ...dragHandlers }
 		>
 			<input
 				ref={ inputRef }
@@ -208,11 +215,7 @@ export default function RotationRuler( {
 				}
 				onKeyDown={ handleKeyDown }
 			/>
-			<div
-				className="rotation-ruler__strip"
-				aria-hidden="true"
-				{ ...dragHandlers }
-			>
+			<div className="rotation-ruler__strip" aria-hidden="true">
 				<svg
 					className="rotation-ruler__ticks"
 					style={ stripStyle }
@@ -233,12 +236,24 @@ export default function RotationRuler( {
 							className={ `rotation-ruler__tick rotation-ruler__tick--${ tick.kind }` }
 						/>
 					) ) }
+					{ majorTicks.map( ( tick ) => (
+						<text
+							key={ tick.value }
+							x={ tick.value * pxPerUnit }
+							y={ LABEL_BASELINE_Y }
+							textAnchor="middle"
+							className="rotation-ruler__label"
+						>
+							{ tick.value }
+							{ unit }
+						</text>
+					) ) }
 				</svg>
 			</div>
-			<div className="rotation-ruler__pointer" aria-hidden="true" />
-			<div className="rotation-ruler__bubble" aria-hidden="true">
-				{ display }
+			<div className="rotation-ruler__active-label" aria-hidden="true">
+				{ activeText }
 			</div>
+			<div className="rotation-ruler__pointer" aria-hidden="true" />
 		</div>
 	);
 }

--- a/packages/media-editor/src/components/rotation-ruler/index.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import clsx from 'clsx';
 import type { CSSProperties, KeyboardEvent } from 'react';
 
 /**
@@ -14,16 +15,37 @@ import { useId, useMemo, useRef } from '@wordpress/element';
 import { useRulerDrag, clampValue } from './use-ruler-drag';
 
 export interface RotationRulerProps {
+	/** Current value. */
 	value: number;
+	/** Called with the next value on each change. */
 	onChange: ( value: number ) => void;
+	/** Lower bound of the range. Default: -45. */
 	min?: number;
+	/** Upper bound of the range. Default: 45. */
 	max?: number;
+	/**
+	 * Value step for drag and keyboard arrows. Default: 1. Drag values
+	 * are quantized to multiples of `step`. Holding Shift during drag
+	 * or with arrow keys halves the step for precision adjustment.
+	 */
 	step?: number;
+	/** Accessible label for the slider input. */
 	label: string;
+	/**
+	 * Unit suffix shown in the active label and `aria-valuetext`.
+	 * Default: `°`.
+	 */
 	unit?: string;
+	/** CSS pixels of pointer travel per `step`. Default: 6. */
 	pixelsPerStep?: number;
+	/** Optional extra class for the wrapper. */
 	className?: string;
+	/**
+	 * Optional id for the underlying input; auto-generated when
+	 * omitted.
+	 */
 	id?: string;
+	/** When true, ignores all input. */
 	disabled?: boolean;
 }
 
@@ -86,39 +108,22 @@ function formatValue( value: number ): string {
  * technologies and keyboard input alongside a decorative tick strip
  * that the user can drag with a pointer.
  *
- * @param props               Component props.
- * @param props.value         Current value.
- * @param props.onChange      Called with the next value on each change.
- * @param props.min           Lower bound of the range (default: -45).
- * @param props.max           Upper bound of the range (default: 45).
- * @param props.step          Value step for drag and keyboard arrows
- *                            (default: 1). Drag values are quantized to
- *                            multiples of `step`. Holding Shift during
- *                            drag or with arrow keys halves the step
- *                            for precision adjustment.
- * @param props.label         Accessible label for the slider input.
- * @param props.unit          Unit suffix shown in the active label and
- *                            `aria-valuetext` (default: `°`).
- * @param props.pixelsPerStep CSS pixels of pointer travel per `step`
- *                            (default: 6).
- * @param props.className     Optional extra class for the wrapper.
- * @param props.id            Optional id for the underlying input;
- *                            auto-generated when omitted.
- * @param props.disabled      When true, ignores all input.
+ * @param props Component props. See `RotationRulerProps`.
  */
-export default function RotationRuler( {
-	value,
-	onChange,
-	min = -45,
-	max = 45,
-	step = 1,
-	label,
-	unit = '°',
-	pixelsPerStep = 6,
-	className,
-	id,
-	disabled = false,
-}: RotationRulerProps ) {
+export default function RotationRuler( props: RotationRulerProps ) {
+	const {
+		value,
+		onChange,
+		min = -45,
+		max = 45,
+		step = 1,
+		label,
+		unit = '°',
+		pixelsPerStep = 6,
+		className,
+		id,
+		disabled = false,
+	} = props;
 	const inputRef = useRef< HTMLInputElement >( null );
 	const generatedId = useId();
 	const inputId = id ?? generatedId;
@@ -191,13 +196,9 @@ export default function RotationRuler( {
 	const activeText = onMajor ? `${ closestMajor }${ unit }` : display;
 	const majorTicks = ticks.filter( ( tick ) => tick.kind === 'major' );
 
-	const wrapperClassName = [ 'rotation-ruler', className ]
-		.filter( Boolean )
-		.join( ' ' );
-
 	return (
 		<div
-			className={ wrapperClassName }
+			className={ clsx( 'rotation-ruler', className ) }
 			role="presentation"
 			data-disabled={ disabled || undefined }
 			{ ...dragHandlers }

--- a/packages/media-editor/src/components/rotation-ruler/index.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/index.tsx
@@ -29,6 +29,10 @@ export interface RotationRulerProps {
 }
 
 const PX_PER_UNIT = 6;
+const STRIP_HEIGHT = 18;
+const TICK_HEIGHT_MINOR = 4;
+const TICK_HEIGHT_MID = 8;
+const TICK_HEIGHT_MAJOR = 14;
 
 type TickKind = 'minor' | 'mid' | 'major';
 interface Tick {
@@ -48,13 +52,13 @@ function useTicks( min: number, max: number ): Tick[] {
 		const out: Tick[] = [];
 		for ( let v = Math.ceil( min ); v <= Math.floor( max ); v += 1 ) {
 			let kind: TickKind = 'minor';
-			let height = 6;
+			let height = TICK_HEIGHT_MINOR;
 			if ( v % 15 === 0 ) {
 				kind = 'major';
-				height = 18;
+				height = TICK_HEIGHT_MAJOR;
 			} else if ( v % 5 === 0 ) {
 				kind = 'mid';
-				height = 12;
+				height = TICK_HEIGHT_MID;
 			}
 			out.push( { value: v, kind, height } );
 		}
@@ -152,9 +156,16 @@ export default function RotationRuler( {
 
 	const display = `${ formatValue( value ) }${ unit }`;
 	const ticks = useTicks( min, max );
+	// `left: 50%` puts the SVG's left edge at the strip's centerline, so
+	// without an additional `-50%` self-offset all ticks would render to
+	// the right of the pointer. Combine the centering offset with the
+	// value-driven offset so value=0 lands the SVG's center on the
+	// pointer.
 	const stripStyle: CSSProperties = useMemo( () => {
 		const offset = -value * PX_PER_UNIT;
-		return { transform: `translateX(${ offset }px)` };
+		return {
+			transform: `translateX(calc(-50% + ${ offset }px))`,
+		};
 	}, [ value ] );
 
 	const wrapperClassName = [ 'rotation-ruler', className ]
@@ -195,10 +206,10 @@ export default function RotationRuler( {
 					className="rotation-ruler__ticks"
 					style={ stripStyle }
 					width={ ( max - min ) * PX_PER_UNIT }
-					height="32"
+					height={ STRIP_HEIGHT }
 					viewBox={ `${ min * PX_PER_UNIT } 0 ${
 						( max - min ) * PX_PER_UNIT
-					} 32` }
+					} ${ STRIP_HEIGHT }` }
 					preserveAspectRatio="xMidYMid meet"
 				>
 					{ ticks.map( ( tick ) => (
@@ -206,8 +217,8 @@ export default function RotationRuler( {
 							key={ tick.value }
 							x1={ tick.value * PX_PER_UNIT }
 							x2={ tick.value * PX_PER_UNIT }
-							y1={ 32 - tick.height }
-							y2={ 32 }
+							y1={ STRIP_HEIGHT - tick.height }
+							y2={ STRIP_HEIGHT }
 							className={ `rotation-ruler__tick rotation-ruler__tick--${ tick.kind }` }
 						/>
 					) ) }

--- a/packages/media-editor/src/components/rotation-ruler/index.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/index.tsx
@@ -28,7 +28,6 @@ export interface RotationRulerProps {
 	disabled?: boolean;
 }
 
-const PX_PER_UNIT = 6;
 const STRIP_HEIGHT = 18;
 const TICK_HEIGHT_MINOR = 4;
 const TICK_HEIGHT_MID = 8;
@@ -136,8 +135,14 @@ export default function RotationRuler( {
 	} );
 
 	const handleKeyDown = ( event: KeyboardEvent< HTMLInputElement > ) => {
-		if ( event.key !== 'ArrowLeft' && event.key !== 'ArrowRight' ) {
-			// Home / End / PageUp / PageDown fall through to native input.
+		// WAI-ARIA slider keyboard pattern: Up/Right increment,
+		// Down/Left decrement. Home / End / PageUp / PageDown fall
+		// through to native input.
+		const isIncrement =
+			event.key === 'ArrowRight' || event.key === 'ArrowUp';
+		const isDecrement =
+			event.key === 'ArrowLeft' || event.key === 'ArrowDown';
+		if ( ! isIncrement && ! isDecrement ) {
 			return;
 		}
 		// Always prevent default so the native input's own arrow-key
@@ -146,7 +151,7 @@ export default function RotationRuler( {
 		if ( disabled ) {
 			return;
 		}
-		const direction = event.key === 'ArrowRight' ? 1 : -1;
+		const direction = isIncrement ? 1 : -1;
 		const magnitude = event.shiftKey ? step / 2 : step;
 		const next = clampValue( value + direction * magnitude, min, max );
 		if ( next !== value ) {
@@ -156,17 +161,23 @@ export default function RotationRuler( {
 
 	const display = `${ formatValue( value ) }${ unit }`;
 	const ticks = useTicks( min, max );
+	// Visual scale is locked to the gesture: 1 step of pointer travel
+	// (`pixelsPerStep`) maps to `step` value units, so 1 value unit
+	// renders at `pixelsPerStep / step` CSS pixels. This keeps the
+	// ticks moving in lock-step with the pointer no matter what the
+	// caller chooses for `pixelsPerStep` and `step`.
+	const pxPerUnit = pixelsPerStep / step;
 	// `left: 50%` puts the SVG's left edge at the strip's centerline, so
 	// without an additional `-50%` self-offset all ticks would render to
 	// the right of the pointer. Combine the centering offset with the
 	// value-driven offset so value=0 lands the SVG's center on the
 	// pointer.
 	const stripStyle: CSSProperties = useMemo( () => {
-		const offset = -value * PX_PER_UNIT;
+		const offset = -value * pxPerUnit;
 		return {
 			transform: `translateX(calc(-50% + ${ offset }px))`,
 		};
-	}, [ value ] );
+	}, [ value, pxPerUnit ] );
 
 	const wrapperClassName = [ 'rotation-ruler', className ]
 		.filter( Boolean )
@@ -205,18 +216,18 @@ export default function RotationRuler( {
 				<svg
 					className="rotation-ruler__ticks"
 					style={ stripStyle }
-					width={ ( max - min ) * PX_PER_UNIT }
+					width={ ( max - min ) * pxPerUnit }
 					height={ STRIP_HEIGHT }
-					viewBox={ `${ min * PX_PER_UNIT } 0 ${
-						( max - min ) * PX_PER_UNIT
+					viewBox={ `${ min * pxPerUnit } 0 ${
+						( max - min ) * pxPerUnit
 					} ${ STRIP_HEIGHT }` }
 					preserveAspectRatio="xMidYMid meet"
 				>
 					{ ticks.map( ( tick ) => (
 						<line
 							key={ tick.value }
-							x1={ tick.value * PX_PER_UNIT }
-							x2={ tick.value * PX_PER_UNIT }
+							x1={ tick.value * pxPerUnit }
+							x2={ tick.value * pxPerUnit }
 							y1={ STRIP_HEIGHT - tick.height }
 							y2={ STRIP_HEIGHT }
 							className={ `rotation-ruler__tick rotation-ruler__tick--${ tick.kind }` }

--- a/packages/media-editor/src/components/rotation-ruler/stories/index.story.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/stories/index.story.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import RotationRuler from '../index';
+
+const meta: Meta< typeof RotationRuler > = {
+	title: 'MediaEditor/RotationRuler',
+	component: RotationRuler,
+	args: {
+		label: __( 'Fine rotation' ),
+		min: -45,
+		max: 45,
+		step: 1,
+		pixelsPerStep: 6,
+		snapToZeroWithin: 0.75,
+		disabled: false,
+	},
+	argTypes: {
+		value: { control: false },
+		onChange: { control: false },
+	},
+};
+export default meta;
+
+type Story = StoryObj< typeof RotationRuler >;
+
+export const Default: Story = {
+	render: ( args ) => {
+		const [ value, setValue ] = useState( 0 );
+		return (
+			<div style={ { width: 360, color: '#1e1e1e' } }>
+				<RotationRuler
+					{ ...args }
+					value={ value }
+					onChange={ setValue }
+				/>
+				<p style={ { marginTop: 16 } }>
+					{ __( 'Current value:' ) } { value }°
+				</p>
+			</div>
+		);
+	},
+};

--- a/packages/media-editor/src/components/rotation-ruler/stories/index.story.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/stories/index.story.tsx
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import RotationRuler from '../index';
+import '../style.scss';
 
 const meta: Meta< typeof RotationRuler > = {
 	title: 'MediaEditor/RotationRuler',

--- a/packages/media-editor/src/components/rotation-ruler/stories/index.story.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/stories/index.story.tsx
@@ -24,7 +24,6 @@ const meta: Meta< typeof RotationRuler > = {
 		max: 45,
 		step: 1,
 		pixelsPerStep: 6,
-		snapToZeroWithin: 0.75,
 		disabled: false,
 	},
 	argTypes: {

--- a/packages/media-editor/src/components/rotation-ruler/style.scss
+++ b/packages/media-editor/src/components/rotation-ruler/style.scss
@@ -1,13 +1,14 @@
 @use "@wordpress/base-styles/variables" as *;
 
+// Vertical layout (top → bottom):
+//   0–13: value bubble
+//   13–19: 6px upward-pointing triangle (the pointer)
+//   19–37: tick strip (18px)
 .rotation-ruler {
 	position: relative;
 	min-width: 180px;
-	height: 56px;
-	display: flex;
-	align-items: flex-end;
-	justify-content: center;
-	padding: $grid-unit-30 $grid-unit-10 $grid-unit-10;
+	height: 37px;
+	padding: 0 $grid-unit-10;
 	box-sizing: border-box;
 	user-select: none;
 	touch-action: none;
@@ -40,9 +41,38 @@
 	white-space: nowrap;
 }
 
+.rotation-ruler__bubble {
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translateX(-50%);
+	font-size: 11px;
+	line-height: 1;
+	font-variant-numeric: tabular-nums;
+	pointer-events: none;
+}
+
+// Single upward-pointing triangle below the bubble. Marks the centered
+// value cleanly without the vertical stem of a traditional pointer.
+.rotation-ruler__pointer {
+	position: absolute;
+	top: 13px;
+	left: 50%;
+	width: 0;
+	height: 0;
+	border-left: 5px solid transparent;
+	border-right: 5px solid transparent;
+	border-bottom: 6px solid var(--wp-admin-theme-color);
+	transform: translateX(-50%);
+	pointer-events: none;
+}
+
 .rotation-ruler__strip {
 	position: absolute;
-	inset: $grid-unit-30 0 $grid-unit-10;
+	left: 0;
+	right: 0;
+	top: 19px;
+	height: 18px;
 	overflow: hidden;
 	cursor: ew-resize;
 }
@@ -69,40 +99,6 @@
 	&--major {
 		opacity: 1;
 	}
-}
-
-.rotation-ruler__pointer {
-	position: absolute;
-	left: 50%;
-	bottom: $grid-unit-10;
-	width: 2px;
-	height: 28px;
-	background: var(--wp-admin-theme-color);
-	transform: translateX(-50%);
-	pointer-events: none;
-}
-
-.rotation-ruler__pointer::after {
-	content: "";
-	position: absolute;
-	top: -4px;
-	left: 50%;
-	width: 0;
-	height: 0;
-	border-left: 4px solid transparent;
-	border-right: 4px solid transparent;
-	border-bottom: 4px solid var(--wp-admin-theme-color);
-	transform: translateX(-50%);
-}
-
-.rotation-ruler__bubble {
-	position: absolute;
-	top: 0;
-	left: 50%;
-	transform: translateX(-50%);
-	font-size: 12px;
-	font-variant-numeric: tabular-nums;
-	pointer-events: none;
 }
 
 // Below ~220px container width, fade out 1° ticks; mid/major remain.

--- a/packages/media-editor/src/components/rotation-ruler/style.scss
+++ b/packages/media-editor/src/components/rotation-ruler/style.scss
@@ -85,6 +85,10 @@
 	bottom: 0;
 	overflow: hidden;
 	cursor: ew-resize;
+	// Fade ticks toward each edge so the strip looks like a continuous
+	// ruler running off-screen rather than a strip with hard cut-offs.
+	mask-image: linear-gradient(to right, transparent 0, #000 16px, #000 calc(100% - 16px), transparent 100%);
+	-webkit-mask-image: linear-gradient(to right, transparent 0, #000 16px, #000 calc(100% - 16px), transparent 100%);
 }
 
 .rotation-ruler__ticks {

--- a/packages/media-editor/src/components/rotation-ruler/style.scss
+++ b/packages/media-editor/src/components/rotation-ruler/style.scss
@@ -54,7 +54,9 @@
 
 // Upward-pointing triangle anchored to the bottom of the ruler. Marks
 // the centered value cleanly without the vertical stem of a
-// traditional pointer.
+// traditional pointer. Resting state is translucent; on hover/focus
+// (which also covers active drag, since pointerdown focuses the input)
+// it goes full color.
 .rotation-ruler__pointer {
 	position: absolute;
 	bottom: 0;
@@ -65,7 +67,14 @@
 	border-right: 6px solid transparent;
 	border-bottom: 9px solid var(--wp-admin-theme-color);
 	transform: translateX(-50%);
+	opacity: 0.5;
 	pointer-events: none;
+	transition: opacity 100ms ease-out;
+}
+
+.rotation-ruler:hover .rotation-ruler__pointer,
+.rotation-ruler:focus-within .rotation-ruler__pointer {
+	opacity: 1;
 }
 
 .rotation-ruler__strip {
@@ -110,7 +119,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.rotation-ruler__ticks {
+	.rotation-ruler__ticks,
+	.rotation-ruler__pointer {
 		transition: none;
 	}
 }

--- a/packages/media-editor/src/components/rotation-ruler/style.scss
+++ b/packages/media-editor/src/components/rotation-ruler/style.scss
@@ -1,0 +1,119 @@
+@use "@wordpress/base-styles/variables" as *;
+
+.rotation-ruler {
+	position: relative;
+	min-width: 180px;
+	height: 56px;
+	display: flex;
+	align-items: flex-end;
+	justify-content: center;
+	padding: $grid-unit-30 $grid-unit-10 $grid-unit-10;
+	box-sizing: border-box;
+	user-select: none;
+	touch-action: none;
+	// Always declare the container so the inline-size query below can
+	// match. Cheap; only affects layout if a child uses cqw/cqh.
+	container-type: inline-size;
+
+	&[data-disabled] {
+		opacity: 0.5;
+		pointer-events: none;
+	}
+
+	&:has(.rotation-ruler__input:focus-visible) {
+		outline: 2px solid var(--wp-admin-theme-color);
+		outline-offset: 2px;
+		border-radius: 4px;
+	}
+}
+
+// Visually hidden but kept in layout so it's focusable.
+.rotation-ruler__input {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	border: 0;
+	clip: rect(0 0 0 0);
+	overflow: hidden;
+	white-space: nowrap;
+}
+
+.rotation-ruler__strip {
+	position: absolute;
+	inset: $grid-unit-30 0 $grid-unit-10;
+	overflow: hidden;
+	cursor: ew-resize;
+}
+
+.rotation-ruler__ticks {
+	position: absolute;
+	left: 50%;
+	top: 0;
+	display: block;
+}
+
+.rotation-ruler__tick {
+	stroke: currentColor;
+	stroke-width: 1;
+
+	&--minor {
+		opacity: 0.35;
+	}
+
+	&--mid {
+		opacity: 0.6;
+	}
+
+	&--major {
+		opacity: 1;
+	}
+}
+
+.rotation-ruler__pointer {
+	position: absolute;
+	left: 50%;
+	bottom: $grid-unit-10;
+	width: 2px;
+	height: 28px;
+	background: var(--wp-admin-theme-color);
+	transform: translateX(-50%);
+	pointer-events: none;
+}
+
+.rotation-ruler__pointer::after {
+	content: "";
+	position: absolute;
+	top: -4px;
+	left: 50%;
+	width: 0;
+	height: 0;
+	border-left: 4px solid transparent;
+	border-right: 4px solid transparent;
+	border-bottom: 4px solid var(--wp-admin-theme-color);
+	transform: translateX(-50%);
+}
+
+.rotation-ruler__bubble {
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translateX(-50%);
+	font-size: 12px;
+	font-variant-numeric: tabular-nums;
+	pointer-events: none;
+}
+
+// Below ~220px container width, fade out 1° ticks; mid/major remain.
+@container (max-width: 220px) {
+	.rotation-ruler__tick--minor {
+		opacity: 0;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.rotation-ruler__ticks {
+		transition: none;
+	}
+}

--- a/packages/media-editor/src/components/rotation-ruler/style.scss
+++ b/packages/media-editor/src/components/rotation-ruler/style.scss
@@ -1,13 +1,13 @@
 @use "@wordpress/base-styles/variables" as *;
 
 // Vertical layout (top → bottom):
-//   0–13: value bubble
-//   13–19: 6px upward-pointing triangle (the pointer)
-//   19–37: tick strip (18px)
+//   0–10: value bubble
+//   10–28: tick strip (18px); the pointer triangle sits at the strip's
+//   bottom edge.
 .rotation-ruler {
 	position: relative;
 	min-width: 180px;
-	height: 37px;
+	height: 28px;
 	padding: 0 $grid-unit-10;
 	box-sizing: border-box;
 	user-select: none;
@@ -52,17 +52,18 @@
 	pointer-events: none;
 }
 
-// Single upward-pointing triangle below the bubble. Marks the centered
-// value cleanly without the vertical stem of a traditional pointer.
+// Upward-pointing triangle anchored to the bottom of the ruler. Marks
+// the centered value cleanly without the vertical stem of a
+// traditional pointer.
 .rotation-ruler__pointer {
 	position: absolute;
-	top: 13px;
+	bottom: 0;
 	left: 50%;
 	width: 0;
 	height: 0;
-	border-left: 5px solid transparent;
-	border-right: 5px solid transparent;
-	border-bottom: 6px solid var(--wp-admin-theme-color);
+	border-left: 6px solid transparent;
+	border-right: 6px solid transparent;
+	border-bottom: 9px solid var(--wp-admin-theme-color);
 	transform: translateX(-50%);
 	pointer-events: none;
 }
@@ -71,8 +72,8 @@
 	position: absolute;
 	left: 0;
 	right: 0;
-	top: 19px;
-	height: 18px;
+	top: 10px;
+	bottom: 0;
 	overflow: hidden;
 	cursor: ew-resize;
 }

--- a/packages/media-editor/src/components/rotation-ruler/style.scss
+++ b/packages/media-editor/src/components/rotation-ruler/style.scss
@@ -8,19 +8,20 @@
 $rotation-ruler-accent: var(--wp-admin-theme-color, #3858e9);
 
 // Vertical layout (top → bottom):
-//   0–10: value bubble
-//   10–28: tick strip (18px); the pointer triangle sits at the strip's
-//   bottom edge.
+//   0–14:  label row (translates with strip; active label sits centered)
+//   14–32: tick lines (anchored to strip bottom)
+//   23–32: pointer triangle (overlapping the bottom of major ticks)
 .rotation-ruler {
 	position: relative;
 	min-width: 180px;
-	height: 28px;
+	height: 32px;
 	padding: 0 $grid-unit-10;
 	box-sizing: border-box;
 	color: $gray-900;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	user-select: none;
 	touch-action: none;
+	cursor: ew-resize;
 	// Always declare the container so the inline-size query below can
 	// match. Cheap; only affects layout if a child uses cqw/cqh.
 	container-type: inline-size;
@@ -28,6 +29,7 @@ $rotation-ruler-accent: var(--wp-admin-theme-color, #3858e9);
 	&[data-disabled] {
 		opacity: 0.5;
 		pointer-events: none;
+		cursor: default;
 	}
 
 	&:has(.rotation-ruler__input:focus-visible) {
@@ -50,17 +52,6 @@ $rotation-ruler-accent: var(--wp-admin-theme-color, #3858e9);
 	white-space: nowrap;
 }
 
-.rotation-ruler__bubble {
-	position: absolute;
-	top: 0;
-	left: 50%;
-	transform: translateX(-50%);
-	font-size: 11px;
-	line-height: 1;
-	font-variant-numeric: tabular-nums;
-	pointer-events: none;
-}
-
 // Upward-pointing triangle anchored to the bottom of the ruler. Marks
 // the centered value cleanly without the vertical stem of a
 // traditional pointer.
@@ -79,16 +70,13 @@ $rotation-ruler-accent: var(--wp-admin-theme-color, #3858e9);
 
 .rotation-ruler__strip {
 	position: absolute;
-	left: 0;
-	right: 0;
-	top: 10px;
-	bottom: 0;
+	inset: 0;
 	overflow: hidden;
-	cursor: ew-resize;
-	// Fade ticks toward each edge so the strip looks like a continuous
-	// ruler running off-screen rather than a strip with hard cut-offs.
-	mask-image: linear-gradient(to right, transparent 0, #000 16px, #000 calc(100% - 16px), transparent 100%);
-	-webkit-mask-image: linear-gradient(to right, transparent 0, #000 16px, #000 calc(100% - 16px), transparent 100%);
+	// Fade ticks/labels toward each edge so the strip looks like a
+	// continuous ruler running off-screen rather than a strip with hard
+	// cut-offs.
+	mask-image: linear-gradient(to right, transparent 0, #000 8px, #000 calc(100% - 8px), transparent 100%);
+	-webkit-mask-image: linear-gradient(to right, transparent 0, #000 8px, #000 calc(100% - 8px), transparent 100%);
 }
 
 .rotation-ruler__ticks {
@@ -96,6 +84,10 @@ $rotation-ruler-accent: var(--wp-admin-theme-color, #3858e9);
 	left: 50%;
 	top: 0;
 	display: block;
+	// Allow text glyphs at the SVG's left/right edges to render outside
+	// the SVG box; the strip's `overflow: hidden` still clips at its
+	// own edges, which is what we want.
+	overflow: visible;
 }
 
 .rotation-ruler__tick {
@@ -113,6 +105,32 @@ $rotation-ruler-accent: var(--wp-admin-theme-color, #3858e9);
 	&--major {
 		opacity: 1;
 	}
+}
+
+// Major-tick labels live inside the SVG and translate with the strip.
+.rotation-ruler__label {
+	fill: currentColor;
+	font-size: 10px;
+	font-weight: 400;
+	opacity: 0.45;
+}
+
+// Active label is a fixed-center HTML element so it stays steady at the
+// pointer while the SVG behind it transitions smoothly. A white-fading-
+// to-transparent background occludes the static labels directly behind.
+.rotation-ruler__active-label {
+	position: absolute;
+	top: 0;
+	left: 50%;
+	height: 14px;
+	transform: translateX(-50%);
+	padding: 0 12px;
+	font-size: 12px;
+	font-weight: 600;
+	line-height: 14px;
+	color: $gray-900;
+	background: linear-gradient(to right, transparent 0, $white 12px, $white calc(100% - 12px), transparent 100%);
+	pointer-events: none;
 }
 
 // Below ~220px container width, fade out 1° ticks; mid/major remain.

--- a/packages/media-editor/src/components/rotation-ruler/style.scss
+++ b/packages/media-editor/src/components/rotation-ruler/style.scss
@@ -1,4 +1,11 @@
+@use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
+
+// Default to WordPress core's admin theme blue when the host hasn't
+// set `--wp-admin-theme-color` (e.g. inside Storybook). Hosts that do
+// set it (the media modal, the editor) will override this with their
+// theme.
+$rotation-ruler-accent: var(--wp-admin-theme-color, #3858e9);
 
 // Vertical layout (top → bottom):
 //   0–10: value bubble
@@ -10,6 +17,8 @@
 	height: 28px;
 	padding: 0 $grid-unit-10;
 	box-sizing: border-box;
+	color: $gray-900;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	user-select: none;
 	touch-action: none;
 	// Always declare the container so the inline-size query below can
@@ -22,7 +31,7 @@
 	}
 
 	&:has(.rotation-ruler__input:focus-visible) {
-		outline: 2px solid var(--wp-admin-theme-color);
+		outline: 2px solid $rotation-ruler-accent;
 		outline-offset: 2px;
 		border-radius: 4px;
 	}
@@ -65,7 +74,7 @@
 	height: 0;
 	border-left: 6px solid transparent;
 	border-right: 6px solid transparent;
-	border-bottom: 9px solid var(--wp-admin-theme-color);
+	border-bottom: 9px solid $rotation-ruler-accent;
 	transform: translateX(-50%);
 	opacity: 0.5;
 	pointer-events: none;

--- a/packages/media-editor/src/components/rotation-ruler/style.scss
+++ b/packages/media-editor/src/components/rotation-ruler/style.scss
@@ -63,9 +63,7 @@ $rotation-ruler-accent: var(--wp-admin-theme-color, #3858e9);
 
 // Upward-pointing triangle anchored to the bottom of the ruler. Marks
 // the centered value cleanly without the vertical stem of a
-// traditional pointer. Resting state is translucent; on hover/focus
-// (which also covers active drag, since pointerdown focuses the input)
-// it goes full color.
+// traditional pointer.
 .rotation-ruler__pointer {
 	position: absolute;
 	bottom: 0;
@@ -76,14 +74,7 @@ $rotation-ruler-accent: var(--wp-admin-theme-color, #3858e9);
 	border-right: 6px solid transparent;
 	border-bottom: 9px solid $rotation-ruler-accent;
 	transform: translateX(-50%);
-	opacity: 0.5;
 	pointer-events: none;
-	transition: opacity 100ms ease-out;
-}
-
-.rotation-ruler:hover .rotation-ruler__pointer,
-.rotation-ruler:focus-within .rotation-ruler__pointer {
-	opacity: 1;
 }
 
 .rotation-ruler__strip {
@@ -132,8 +123,7 @@ $rotation-ruler-accent: var(--wp-admin-theme-color, #3858e9);
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.rotation-ruler__ticks,
-	.rotation-ruler__pointer {
+	.rotation-ruler__ticks {
 		transition: none;
 	}
 }

--- a/packages/media-editor/src/components/rotation-ruler/test/index.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/test/index.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 /**
  * Internal dependencies
  */
-import { pxToValueDelta, clampValue, applyZeroSnap } from '../use-ruler-drag';
+import { pxToValueDelta, clampValue, quantize } from '../use-ruler-drag';
 import RotationRuler from '../index';
 
 describe( 'rotation-ruler math', () => {
@@ -33,23 +33,13 @@ describe( 'rotation-ruler math', () => {
 		} );
 	} );
 
-	describe( 'applyZeroSnap', () => {
-		it( 'snaps to 0 only when entering the window from outside', () => {
-			// previous outside window, next inside window → snap to 0.
-			expect( applyZeroSnap( 0.4, 1.2, 0.75 ) ).toBe( 0 );
-		} );
-
-		it( 'does not snap when previous value was already inside the window', () => {
-			// already at 0; small drag should produce a non-zero value.
-			expect( applyZeroSnap( 0.4, 0, 0.75 ) ).toBe( 0.4 );
-		} );
-
-		it( 'does not snap when next value is outside the window', () => {
-			expect( applyZeroSnap( 1.5, 5, 0.75 ) ).toBe( 1.5 );
-		} );
-
-		it( 'is a no-op when window is 0', () => {
-			expect( applyZeroSnap( 0.1, 5, 0 ) ).toBe( 0.1 );
+	describe( 'quantize', () => {
+		it( 'rounds to the nearest multiple of step', () => {
+			expect( quantize( 0.4, 1 ) ).toBe( 0 );
+			expect( quantize( 0.6, 1 ) ).toBe( 1 );
+			expect( quantize( -0.6, 1 ) ).toBe( -1 );
+			expect( quantize( 12.3, 5 ) ).toBe( 10 );
+			expect( quantize( 12.5, 5 ) ).toBe( 15 );
 		} );
 	} );
 } );
@@ -85,7 +75,7 @@ describe( 'RotationRuler', () => {
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'fires onChange with value + step / 2 on Shift+ArrowRight', async () => {
+	it( 'fires onChange with value + step on Shift+ArrowRight (no half-step)', async () => {
 		const user = userEvent.setup();
 		const onChange = jest.fn();
 		render(
@@ -97,7 +87,7 @@ describe( 'RotationRuler', () => {
 		);
 		screen.getByRole( 'slider', { name: 'Fine rotation' } ).focus();
 		await user.keyboard( '{Shift>}{ArrowRight}{/Shift}' );
-		expect( onChange ).toHaveBeenCalledWith( 0.5 );
+		expect( onChange ).toHaveBeenCalledWith( 1 );
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
 	} );
 

--- a/packages/media-editor/src/components/rotation-ruler/test/index.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/test/index.tsx
@@ -1,0 +1,48 @@
+/**
+ * Internal dependencies
+ */
+import { pxToValueDelta, clampValue, applyZeroSnap } from '../use-ruler-drag';
+
+describe( 'rotation-ruler math', () => {
+	describe( 'pxToValueDelta', () => {
+		it( 'converts pointer delta to a value delta using pixelsPerStep × step', () => {
+			// 60px / 6 px-per-step × 1° step = 10 steps.
+			// Negative because dragging the ruler right exposes smaller values.
+			expect( pxToValueDelta( 60, 6, 1 ) ).toBeCloseTo( -10 );
+			expect( pxToValueDelta( -60, 6, 1 ) ).toBeCloseTo( 10 );
+		} );
+
+		it( 'scales with a custom step', () => {
+			// 60px / 6 px-per-step × 0.5° step = 5°.
+			expect( pxToValueDelta( -60, 6, 0.5 ) ).toBeCloseTo( 5 );
+		} );
+	} );
+
+	describe( 'clampValue', () => {
+		it( 'clamps to [min, max]', () => {
+			expect( clampValue( 100, -45, 45 ) ).toBe( 45 );
+			expect( clampValue( -100, -45, 45 ) ).toBe( -45 );
+			expect( clampValue( 12.3, -45, 45 ) ).toBe( 12.3 );
+		} );
+	} );
+
+	describe( 'applyZeroSnap', () => {
+		it( 'snaps to 0 only when entering the window from outside', () => {
+			// previous outside window, next inside window → snap to 0.
+			expect( applyZeroSnap( 0.4, 1.2, 0.75 ) ).toBe( 0 );
+		} );
+
+		it( 'does not snap when previous value was already inside the window', () => {
+			// already at 0; small drag should produce a non-zero value.
+			expect( applyZeroSnap( 0.4, 0, 0.75 ) ).toBe( 0.4 );
+		} );
+
+		it( 'does not snap when next value is outside the window', () => {
+			expect( applyZeroSnap( 1.5, 5, 0.75 ) ).toBe( 1.5 );
+		} );
+
+		it( 'is a no-op when window is 0', () => {
+			expect( applyZeroSnap( 0.1, 5, 0 ) ).toBe( 0.1 );
+		} );
+	} );
+} );

--- a/packages/media-editor/src/components/rotation-ruler/test/index.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/test/index.tsx
@@ -75,7 +75,7 @@ describe( 'RotationRuler', () => {
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'fires onChange with value + step on Shift+ArrowRight (no half-step)', async () => {
+	it( 'fires onChange with value + step / 2 on Shift+ArrowRight', async () => {
 		const user = userEvent.setup();
 		const onChange = jest.fn();
 		render(
@@ -87,7 +87,7 @@ describe( 'RotationRuler', () => {
 		);
 		screen.getByRole( 'slider', { name: 'Fine rotation' } ).focus();
 		await user.keyboard( '{Shift>}{ArrowRight}{/Shift}' );
-		expect( onChange ).toHaveBeenCalledWith( 1 );
+		expect( onChange ).toHaveBeenCalledWith( 0.5 );
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
 	} );
 

--- a/packages/media-editor/src/components/rotation-ruler/test/index.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/test/index.tsx
@@ -1,7 +1,14 @@
 /**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
  * Internal dependencies
  */
 import { pxToValueDelta, clampValue, applyZeroSnap } from '../use-ruler-drag';
+import RotationRuler from '../index';
 
 describe( 'rotation-ruler math', () => {
 	describe( 'pxToValueDelta', () => {
@@ -44,5 +51,69 @@ describe( 'rotation-ruler math', () => {
 		it( 'is a no-op when window is 0', () => {
 			expect( applyZeroSnap( 0.1, 5, 0 ) ).toBe( 0.1 );
 		} );
+	} );
+} );
+
+describe( 'RotationRuler', () => {
+	it( 'renders the value on the underlying input and in aria-valuetext', () => {
+		render(
+			<RotationRuler
+				value={ -14 }
+				onChange={ () => {} }
+				label="Fine rotation"
+			/>
+		);
+		const input = screen.getByRole( 'slider', { name: 'Fine rotation' } );
+		expect( ( input as HTMLInputElement ).valueAsNumber ).toBe( -14 );
+		expect( input ).toHaveAttribute( 'aria-valuetext', '-14°' );
+	} );
+
+	it( 'fires onChange with value + step on ArrowRight', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+		render(
+			<RotationRuler
+				value={ 0 }
+				onChange={ onChange }
+				label="Fine rotation"
+			/>
+		);
+		const input = screen.getByRole( 'slider', { name: 'Fine rotation' } );
+		input.focus();
+		await user.keyboard( '{ArrowRight}' );
+		expect( onChange ).toHaveBeenCalledWith( 1 );
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'fires onChange with value + step / 2 on Shift+ArrowRight', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+		render(
+			<RotationRuler
+				value={ 0 }
+				onChange={ onChange }
+				label="Fine rotation"
+			/>
+		);
+		screen.getByRole( 'slider', { name: 'Fine rotation' } ).focus();
+		await user.keyboard( '{Shift>}{ArrowRight}{/Shift}' );
+		expect( onChange ).toHaveBeenCalledWith( 0.5 );
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not fire onChange when disabled', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+		render(
+			<RotationRuler
+				value={ 0 }
+				onChange={ onChange }
+				label="Fine rotation"
+				disabled
+			/>
+		);
+		screen.getByRole( 'slider', { name: 'Fine rotation' } ).focus();
+		await user.keyboard( '{ArrowRight}' );
+		expect( onChange ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
+++ b/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useRef } from '@wordpress/element';
+
+/**
  * Convert a horizontal pointer delta (px) into a value delta.
  *
  * Negative because dragging the ruler to the right should expose
@@ -56,4 +61,122 @@ export function applyZeroSnap(
 	const enteringWindow =
 		Math.abs( next ) < windowSize && Math.abs( previous ) >= windowSize;
 	return enteringWindow ? 0 : next;
+}
+
+export interface UseRulerDragOptions {
+	value: number;
+	onChange: ( next: number ) => void;
+	min: number;
+	max: number;
+	step: number;
+	pixelsPerStep: number;
+	snapToZeroWithin: number;
+	disabled: boolean;
+	/** Called once on pointerdown so the caller can focus the input. */
+	onPointerDownStart?: () => void;
+}
+
+export interface RulerDragHandlers {
+	onPointerDown: ( event: React.PointerEvent< HTMLElement > ) => void;
+	onPointerMove: ( event: React.PointerEvent< HTMLElement > ) => void;
+	onPointerUp: ( event: React.PointerEvent< HTMLElement > ) => void;
+	onPointerCancel: ( event: React.PointerEvent< HTMLElement > ) => void;
+}
+
+/**
+ * Drag-the-ruler gesture for a horizontal slider. Translates pointer
+ * movement into value changes; the caller renders the visuals and
+ * holds the value.
+ *
+ * The hook owns no state of its own — every value change is reported
+ * through the supplied `onChange`. The "current value" is read from a
+ * ref so closure staleness during a drag is impossible.
+ *
+ * @param options Ruler-drag configuration. See `UseRulerDragOptions`.
+ */
+export function useRulerDrag(
+	options: UseRulerDragOptions
+): RulerDragHandlers {
+	const {
+		value,
+		onChange,
+		min,
+		max,
+		step,
+		pixelsPerStep,
+		snapToZeroWithin,
+		disabled,
+		onPointerDownStart,
+	} = options;
+
+	// Mutable mirror of the latest committed value. Pointermove handlers
+	// fire far faster than React commits, so we cannot read `value` from
+	// closure. Writes happen in an effect (not at render time) to satisfy
+	// `react-hooks/refs`; the effect flushes after commit, so by the time
+	// any pointer handler runs, the ref reflects the latest committed
+	// `value`.
+	const latestRef = useRef( {
+		value,
+		startX: 0,
+		startValue: 0,
+		dragging: false,
+	} );
+	useEffect( () => {
+		latestRef.current.value = value;
+	}, [ value ] );
+
+	const onPointerDown = useCallback(
+		( event: React.PointerEvent< HTMLElement > ) => {
+			if ( disabled || event.button !== 0 ) {
+				return;
+			}
+			event.currentTarget.setPointerCapture( event.pointerId );
+			latestRef.current.startX = event.clientX;
+			latestRef.current.startValue = latestRef.current.value;
+			latestRef.current.dragging = true;
+			onPointerDownStart?.();
+		},
+		[ disabled, onPointerDownStart ]
+	);
+
+	const onPointerMove = useCallback(
+		( event: React.PointerEvent< HTMLElement > ) => {
+			if ( ! latestRef.current.dragging ) {
+				return;
+			}
+			const deltaPx = event.clientX - latestRef.current.startX;
+			const deltaValue = pxToValueDelta( deltaPx, pixelsPerStep, step );
+			const raw = latestRef.current.startValue + deltaValue;
+			const snapped = applyZeroSnap(
+				raw,
+				latestRef.current.value,
+				snapToZeroWithin
+			);
+			const next = clampValue( snapped, min, max );
+			if ( next !== latestRef.current.value ) {
+				onChange( next );
+			}
+		},
+		[ onChange, min, max, step, pixelsPerStep, snapToZeroWithin ]
+	);
+
+	const endDrag = useCallback(
+		( event: React.PointerEvent< HTMLElement > ) => {
+			if ( ! latestRef.current.dragging ) {
+				return;
+			}
+			latestRef.current.dragging = false;
+			if ( event.currentTarget.hasPointerCapture( event.pointerId ) ) {
+				event.currentTarget.releasePointerCapture( event.pointerId );
+			}
+		},
+		[]
+	);
+
+	return {
+		onPointerDown,
+		onPointerMove,
+		onPointerUp: endDrag,
+		onPointerCancel: endDrag,
+	};
 }

--- a/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
+++ b/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
@@ -40,27 +40,13 @@ export function clampValue( value: number, min: number, max: number ): number {
 }
 
 /**
- * Snap `next` to 0 only when entering the snap window from outside.
+ * Round `value` to the nearest multiple of `step`.
  *
- * Avoids a "sticky zero" while scrubbing through 0; the user gets a
- * single satisfying snap on entry, then is free to leave.
- *
- * @param next       Computed next value.
- * @param previous   Previous value (last emitted).
- * @param windowSize Half-width of the snap window in value units. 0
- *                   disables snapping.
+ * @param value Value to quantize.
+ * @param step  Step granularity (must be > 0).
  */
-export function applyZeroSnap(
-	next: number,
-	previous: number,
-	windowSize: number
-): number {
-	if ( windowSize <= 0 ) {
-		return next;
-	}
-	const enteringWindow =
-		Math.abs( next ) < windowSize && Math.abs( previous ) >= windowSize;
-	return enteringWindow ? 0 : next;
+export function quantize( value: number, step: number ): number {
+	return Math.round( value / step ) * step;
 }
 
 export interface UseRulerDragOptions {
@@ -70,7 +56,6 @@ export interface UseRulerDragOptions {
 	max: number;
 	step: number;
 	pixelsPerStep: number;
-	snapToZeroWithin: number;
 	disabled: boolean;
 	/** Called once on pointerdown so the caller can focus the input. */
 	onPointerDownStart?: () => void;
@@ -85,12 +70,13 @@ export interface RulerDragHandlers {
 
 /**
  * Drag-the-ruler gesture for a horizontal slider. Translates pointer
- * movement into value changes; the caller renders the visuals and
- * holds the value.
+ * movement into value changes quantized to `step`; the caller renders
+ * the visuals and holds the value.
  *
  * The hook owns no state of its own — every value change is reported
  * through the supplied `onChange`. The "current value" is read from a
- * ref so closure staleness during a drag is impossible.
+ * ref so closure staleness during a drag is impossible. The drag ends
+ * automatically if the pointer leaves the wrapper's bounds.
  *
  * @param options Ruler-drag configuration. See `UseRulerDragOptions`.
  */
@@ -104,7 +90,6 @@ export function useRulerDrag(
 		max,
 		step,
 		pixelsPerStep,
-		snapToZeroWithin,
 		disabled,
 		onPointerDownStart,
 	} = options;
@@ -125,6 +110,19 @@ export function useRulerDrag(
 		latestRef.current.value = value;
 	}, [ value ] );
 
+	const endDrag = useCallback(
+		( event: React.PointerEvent< HTMLElement > ) => {
+			if ( ! latestRef.current.dragging ) {
+				return;
+			}
+			latestRef.current.dragging = false;
+			if ( event.currentTarget.hasPointerCapture( event.pointerId ) ) {
+				event.currentTarget.releasePointerCapture( event.pointerId );
+			}
+		},
+		[]
+	);
+
 	const onPointerDown = useCallback(
 		( event: React.PointerEvent< HTMLElement > ) => {
 			if ( disabled || event.button !== 0 ) {
@@ -144,41 +142,34 @@ export function useRulerDrag(
 			if ( ! latestRef.current.dragging ) {
 				return;
 			}
+			// End the drag if the pointer leaves the wrapper bounds. We
+			// keep `setPointerCapture` so this handler still receives
+			// events outside the element; the bounds check is what
+			// turns "drag everywhere" into "drag inside the ruler".
+			const rect = event.currentTarget.getBoundingClientRect();
+			if (
+				event.clientX < rect.left ||
+				event.clientX > rect.right ||
+				event.clientY < rect.top ||
+				event.clientY > rect.bottom
+			) {
+				endDrag( event );
+				return;
+			}
 			const deltaPx = event.clientX - latestRef.current.startX;
 			const deltaValue = pxToValueDelta( deltaPx, pixelsPerStep, step );
 			const raw = latestRef.current.startValue + deltaValue;
-			const snapped = applyZeroSnap(
-				raw,
-				latestRef.current.value,
-				snapToZeroWithin
-			);
-			const next = clampValue( snapped, min, max );
+			const stepped = quantize( raw, step );
+			const next = clampValue( stepped, min, max );
 			if ( next !== latestRef.current.value ) {
 				// Update the ref synchronously so consecutive pointermove
 				// events that fire before React commits still see the
-				// last *emitted* value as `previous` for the next snap
-				// calculation. Without this, dragging through 0 keeps
-				// re-snapping back to 0 on every event until the commit
-				// catches up — the "sticky zero" the snap is designed
-				// to avoid.
+				// last *emitted* value as `previous` for the next math.
 				latestRef.current.value = next;
 				onChange( next );
 			}
 		},
-		[ onChange, min, max, step, pixelsPerStep, snapToZeroWithin ]
-	);
-
-	const endDrag = useCallback(
-		( event: React.PointerEvent< HTMLElement > ) => {
-			if ( ! latestRef.current.dragging ) {
-				return;
-			}
-			latestRef.current.dragging = false;
-			if ( event.currentTarget.hasPointerCapture( event.pointerId ) ) {
-				event.currentTarget.releasePointerCapture( event.pointerId );
-			}
-		},
-		[]
+		[ onChange, min, max, step, pixelsPerStep, endDrag ]
 	);
 
 	return {

--- a/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
+++ b/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
@@ -94,66 +94,93 @@ export function useRulerDrag(
 		onPointerDownStart,
 	} = options;
 
-	// Mutable mirror of the latest committed value. Pointermove handlers
-	// fire far faster than React commits, so we cannot read `value` from
-	// closure. Writes happen in an effect (not at render time) to satisfy
-	// `react-hooks/refs`; the effect flushes after commit, so by the time
-	// any pointer handler runs, the ref reflects the latest committed
-	// `value`.
-	const latestRef = useRef( {
+	// Mutable mirror of the latest committed value plus per-drag state.
+	// Pointermove handlers fire far faster than React commits, so we
+	// cannot read `value` from closure. The `value` write happens in an
+	// effect (not at render time) to satisfy `react-hooks/refs`; the
+	// effect flushes after commit, so by the time any pointer handler
+	// runs, the ref reflects the latest committed `value`.
+	const latestRef = useRef< {
+		value: number;
+		startX: number;
+		startValue: number;
+		dragging: boolean;
+		captureElement: HTMLElement | null;
+		capturePointerId: number;
+		windowPointerUp: ( () => void ) | null;
+	} >( {
 		value,
 		startX: 0,
 		startValue: 0,
 		dragging: false,
+		captureElement: null,
+		capturePointerId: 0,
+		windowPointerUp: null,
 	} );
 	useEffect( () => {
 		latestRef.current.value = value;
 	}, [ value ] );
 
-	const endDrag = useCallback(
-		( event: React.PointerEvent< HTMLElement > ) => {
-			if ( ! latestRef.current.dragging ) {
-				return;
-			}
-			latestRef.current.dragging = false;
-			if ( event.currentTarget.hasPointerCapture( event.pointerId ) ) {
-				event.currentTarget.releasePointerCapture( event.pointerId );
-			}
-		},
-		[]
-	);
+	const endDrag = useCallback( () => {
+		const state = latestRef.current;
+		if ( ! state.dragging ) {
+			return;
+		}
+		state.dragging = false;
+		if (
+			state.captureElement &&
+			state.captureElement.hasPointerCapture( state.capturePointerId )
+		) {
+			state.captureElement.releasePointerCapture(
+				state.capturePointerId
+			);
+		}
+		state.captureElement = null;
+		if ( state.windowPointerUp ) {
+			window.removeEventListener( 'pointerup', state.windowPointerUp );
+			window.removeEventListener(
+				'pointercancel',
+				state.windowPointerUp
+			);
+			state.windowPointerUp = null;
+		}
+	}, [] );
+
+	// Cleanup any in-flight drag on unmount so we never leak window
+	// listeners or stale pointer capture.
+	useEffect( () => endDrag, [ endDrag ] );
 
 	const onPointerDown = useCallback(
 		( event: React.PointerEvent< HTMLElement > ) => {
 			if ( disabled || event.button !== 0 ) {
 				return;
 			}
+			const state = latestRef.current;
 			event.currentTarget.setPointerCapture( event.pointerId );
-			latestRef.current.startX = event.clientX;
-			latestRef.current.startValue = latestRef.current.value;
-			latestRef.current.dragging = true;
+			state.captureElement = event.currentTarget;
+			state.capturePointerId = event.pointerId;
+			state.startX = event.clientX;
+			state.startValue = state.value;
+			state.dragging = true;
 			onPointerDownStart?.();
+
+			// Window-level backstop. With `setPointerCapture`, the
+			// element should always receive `pointerup` even when the
+			// cursor is released outside its bounds — but in practice
+			// some browsers / window-blur sequences drop the event. The
+			// window listener guarantees the drag ends and capture
+			// releases.
+			const onWindowUp = () => endDrag();
+			state.windowPointerUp = onWindowUp;
+			window.addEventListener( 'pointerup', onWindowUp );
+			window.addEventListener( 'pointercancel', onWindowUp );
 		},
-		[ disabled, onPointerDownStart ]
+		[ disabled, onPointerDownStart, endDrag ]
 	);
 
 	const onPointerMove = useCallback(
 		( event: React.PointerEvent< HTMLElement > ) => {
 			if ( ! latestRef.current.dragging ) {
-				return;
-			}
-			// End the drag if the pointer leaves the wrapper bounds. We
-			// keep `setPointerCapture` so this handler still receives
-			// events outside the element; the bounds check is what
-			// turns "drag everywhere" into "drag inside the ruler".
-			const rect = event.currentTarget.getBoundingClientRect();
-			if (
-				event.clientX < rect.left ||
-				event.clientX > rect.right ||
-				event.clientY < rect.top ||
-				event.clientY > rect.bottom
-			) {
-				endDrag( event );
 				return;
 			}
 			const deltaPx = event.clientX - latestRef.current.startX;
@@ -169,7 +196,7 @@ export function useRulerDrag(
 				onChange( next );
 			}
 		},
-		[ onChange, min, max, step, pixelsPerStep, endDrag ]
+		[ onChange, min, max, step, pixelsPerStep ]
 	);
 
 	return {

--- a/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
+++ b/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
@@ -1,0 +1,59 @@
+/**
+ * Convert a horizontal pointer delta (px) into a value delta.
+ *
+ * Negative because dragging the ruler to the right should expose
+ * smaller values to the left of the fixed center pointer (and vice
+ * versa) — the ruler scrubs *under* the pointer.
+ *
+ * @param deltaPx       Pointer movement in CSS pixels.
+ * @param pixelsPerStep CSS pixels of pointer travel per `step`.
+ * @param step          Value units per step.
+ */
+export function pxToValueDelta(
+	deltaPx: number,
+	pixelsPerStep: number,
+	step: number
+): number {
+	return ( -deltaPx / pixelsPerStep ) * step;
+}
+
+/**
+ * Clamp `value` to the inclusive `[min, max]` interval.
+ *
+ * @param value Value to clamp.
+ * @param min   Lower bound (inclusive).
+ * @param max   Upper bound (inclusive).
+ */
+export function clampValue( value: number, min: number, max: number ): number {
+	if ( value < min ) {
+		return min;
+	}
+	if ( value > max ) {
+		return max;
+	}
+	return value;
+}
+
+/**
+ * Snap `next` to 0 only when entering the snap window from outside.
+ *
+ * Avoids a "sticky zero" while scrubbing through 0; the user gets a
+ * single satisfying snap on entry, then is free to leave.
+ *
+ * @param next       Computed next value.
+ * @param previous   Previous value (last emitted).
+ * @param windowSize Half-width of the snap window in value units. 0
+ *                   disables snapping.
+ */
+export function applyZeroSnap(
+	next: number,
+	previous: number,
+	windowSize: number
+): number {
+	if ( windowSize <= 0 ) {
+		return next;
+	}
+	const enteringWindow =
+		Math.abs( next ) < windowSize && Math.abs( previous ) >= windowSize;
+	return enteringWindow ? 0 : next;
+}

--- a/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
+++ b/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
@@ -154,6 +154,14 @@ export function useRulerDrag(
 			);
 			const next = clampValue( snapped, min, max );
 			if ( next !== latestRef.current.value ) {
+				// Update the ref synchronously so consecutive pointermove
+				// events that fire before React commits still see the
+				// last *emitted* value as `previous` for the next snap
+				// calculation. Without this, dragging through 0 keeps
+				// re-snapping back to 0 on every event until the commit
+				// catches up — the "sticky zero" the snap is designed
+				// to avoid.
+				latestRef.current.value = next;
 				onChange( next );
 			}
 		},

--- a/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
+++ b/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
@@ -104,6 +104,7 @@ export function useRulerDrag(
 		value: number;
 		startX: number;
 		startValue: number;
+		activeStep: number;
 		dragging: boolean;
 		captureElement: HTMLElement | null;
 		capturePointerId: number;
@@ -112,6 +113,7 @@ export function useRulerDrag(
 		value,
 		startX: 0,
 		startValue: 0,
+		activeStep: step,
 		dragging: false,
 		captureElement: null,
 		capturePointerId: 0,
@@ -161,6 +163,7 @@ export function useRulerDrag(
 			state.capturePointerId = event.pointerId;
 			state.startX = event.clientX;
 			state.startValue = state.value;
+			state.activeStep = event.shiftKey ? step / 2 : step;
 			state.dragging = true;
 			onPointerDownStart?.();
 
@@ -175,24 +178,40 @@ export function useRulerDrag(
 			window.addEventListener( 'pointerup', onWindowUp );
 			window.addEventListener( 'pointercancel', onWindowUp );
 		},
-		[ disabled, onPointerDownStart, endDrag ]
+		[ disabled, onPointerDownStart, endDrag, step ]
 	);
 
 	const onPointerMove = useCallback(
 		( event: React.PointerEvent< HTMLElement > ) => {
-			if ( ! latestRef.current.dragging ) {
+			const state = latestRef.current;
+			if ( ! state.dragging ) {
 				return;
 			}
-			const deltaPx = event.clientX - latestRef.current.startX;
-			const deltaValue = pxToValueDelta( deltaPx, pixelsPerStep, step );
-			const raw = latestRef.current.startValue + deltaValue;
-			const stepped = quantize( raw, step );
+			// Shift toggles fine mode mid-drag. The drag math computes
+			// from `startX` / `startValue`, so naively swapping `step`
+			// would yank the value backward. Rebase to the current
+			// pointer + value so the granularity changes without a
+			// jump.
+			const requestedStep = event.shiftKey ? step / 2 : step;
+			if ( requestedStep !== state.activeStep ) {
+				state.startX = event.clientX;
+				state.startValue = state.value;
+				state.activeStep = requestedStep;
+			}
+			const deltaPx = event.clientX - state.startX;
+			const deltaValue = pxToValueDelta(
+				deltaPx,
+				pixelsPerStep,
+				state.activeStep
+			);
+			const raw = state.startValue + deltaValue;
+			const stepped = quantize( raw, state.activeStep );
 			const next = clampValue( stepped, min, max );
-			if ( next !== latestRef.current.value ) {
+			if ( next !== state.value ) {
 				// Update the ref synchronously so consecutive pointermove
 				// events that fire before React commits still see the
 				// last *emitted* value as `previous` for the next math.
-				latestRef.current.value = next;
+				state.value = next;
 				onChange( next );
 			}
 		},

--- a/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
+++ b/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
@@ -75,8 +75,11 @@ export interface RulerDragHandlers {
  *
  * The hook owns no state of its own — every value change is reported
  * through the supplied `onChange`. The "current value" is read from a
- * ref so closure staleness during a drag is impossible. The drag ends
- * automatically if the pointer leaves the wrapper's bounds.
+ * ref so closure staleness during a drag is impossible. Drag continues
+ * past the wrapper's bounds (standard slider behaviour); a window-level
+ * `pointerup` listener guarantees the drag ends and pointer capture
+ * releases even if the underlying captured event never fires on the
+ * wrapper.
  *
  * @param options Ruler-drag configuration. See `UseRulerDragOptions`.
  */

--- a/packages/media-editor/src/hooks/use-crop-gesture-handlers.ts
+++ b/packages/media-editor/src/hooks/use-crop-gesture-handlers.ts
@@ -11,12 +11,24 @@ import { useCropper } from '../image-editor';
  */
 export const CROP_CONTROL_ATTR = 'data-crop-control';
 
+export interface UseCropGestureHandlersOptions {
+	/**
+	 * When `true` (default), key-up triggers an immediate history commit so
+	 * each discrete keypress becomes its own undo step. Set to `false` for
+	 * continuous-input controls (e.g. the rotation ruler) where rapid
+	 * keypresses should coalesce into a single history entry via the
+	 * state-change debounce.
+	 */
+	commitOnKeyUp?: boolean;
+}
+
 /**
  * Returns event handler props to spread onto a wrapper element around a
  * crop control. Marks the wrapper as a crop control (via `data-crop-control`)
  * so the modal's Cmd+Z handler can identify it, and wires up immediate-flush
- * signals on pointer-up and key-up so history is committed as soon as the
- * user releases rather than waiting for the debounce window to expire.
+ * signals on pointer-up and (optionally) key-up so history is committed as
+ * soon as the user releases rather than waiting for the debounce window to
+ * expire.
  *
  * The history entry itself is recorded by the state-change debounce in
  * `useCropperState` — no explicit gesture-start signal is needed.
@@ -26,12 +38,17 @@ export const CROP_CONTROL_ATTR = 'data-crop-control';
  *   <div role="presentation" { ...gestureHandlers }>
  *     <RangeControl ... />
  *   </div>
+ *
+ * @param options Optional behavior flags.
  */
-export function useCropGestureHandlers() {
+export function useCropGestureHandlers(
+	options: UseCropGestureHandlersOptions = {}
+) {
+	const { commitOnKeyUp = true } = options;
 	const { commitHistory } = useCropper();
 	return {
 		[ CROP_CONTROL_ATTR ]: true,
 		onPointerUp: commitHistory,
-		onKeyUp: commitHistory,
+		...( commitOnKeyUp ? { onKeyUp: commitHistory } : {} ),
 	};
 }

--- a/packages/media-editor/src/style.scss
+++ b/packages/media-editor/src/style.scss
@@ -4,3 +4,4 @@
 @use "./components/media-editor-modal/style.scss" as *;
 @use "./components/media-editor-canvas/style.scss" as *;
 @use "./components/media-editor-toolbar/style.scss" as *;
+@use "./components/rotation-ruler/style.scss" as *;


### PR DESCRIPTION
## What

Part of:

- https://github.com/WordPress/gutenberg/issues/73771

Replaces the `RangeControl` for fine-tune rotation in the media editor toolbar with `RotationRuler` — a horizontal ruler-slider with drag-the-strip scrubbing, labelled major ticks, and a prominent active-value readout that sits over the pointer.

https://github.com/user-attachments/assets/e565337f-e3aa-4859-97cd-7d412477d904


The toolbar is also reorganised: the ruler is one flex item, the action buttons (snap-rotate, flip, undo, redo, reset) are another. Below the modal-sidebar breakpoint (782 px) they stack — ruler on top, actions below.

## Component

`packages/media-editor/src/components/rotation-ruler/` — private to `@wordpress/media-editor`.

- Controlled-only API: ``value``, ``onChange``, ``label``, plus ``min`` / ``max`` / ``step`` / ``unit`` / ``pixelsPerStep`` / ``className`` / ``id`` / ``disabled``.
- Visually hidden native `<input type="range">` is the source of truth for accessibility — ``aria-label``, ``aria-valuetext`` (e.g. ``-14°``), keyboard, focus, form association.
- Drag-the-ruler gesture in ``useRulerDrag``: ``setPointerCapture`` on ``pointerdown``, px-delta translated to value-delta via the configurable ``pixelsPerStep``. Drag values are quantized to multiples of ``step`` via a pure ``quantize()`` helper.
- **Drag ends when the pointer leaves the wrapper's bounds** — each ``pointermove`` checks the bounding rect and releases capture if outside.
- Visual scale derives from ``pixelsPerStep / step`` so SVG tick spacing always matches the gesture.
- **All major-tick labels render** (every 15°) and translate with the strip; minor (1°) and mid (5°) tick lines fade out as they cross the strip edges via a CSS mask. The current value is shown in a fixed-center HTML "active label" with a white-fading-to-transparent gradient background that obscures whatever static label sits behind it.
- Keyboard: ArrowLeft / ArrowDown decrement by ``step``, ArrowRight / ArrowUp increment by ``step``. Home / End / PageUp / PageDown fall through to the native input. Arrow keys ``preventDefault`` so the native input's own stepping doesn't double-fire ``onChange``.
- Opinionated defaults (explicit text color, system font, ``var(--wp-admin-theme-color, #3858e9)`` fallback for the pointer triangle) so the component renders correctly in Storybook and in any host that isn't setting the admin theme color.

## Toolbar

- Two flex items in the toolbar:
  - **Fine-rotation slider** — wrapped in ``.media-editor-toolbar__rotation-slider`` (still the ``data-crop-control`` ancestor for the modal's Cmd+Z handler), grows to absorb extra horizontal space, capped at 360 px.
  - **Action cluster** — ``[Rotate -90°] [Rotate +90°] [Flip H] [Flip V] [Undo] [Redo] [Reset]``, ``flex-wrap: nowrap``.
- Below 782 px (the same breakpoint where the modal sidebar goes full-page) each takes a full row — slider on top, actions below.
- Above 782 px the action cluster gets a 1 px ``$gray-300`` left border so the two regions are visually divided.

## History coalescing

``useCropGestureHandlers`` gained a ``commitOnKeyUp`` option (default ``true`` — preserves existing behaviour). The rotation ruler passes ``commitOnKeyUp: false`` so rapid arrow-key adjustments collapse into a single undo entry via the existing 300 ms state-change debounce. Pointer drags still commit on release as before.

## Testing

8 tests in ``packages/media-editor/src/components/rotation-ruler/test/index.tsx``:

- Math helpers — ``pxToValueDelta``, ``clampValue``, ``quantize``.
- Render: value reflected on the underlying input and in ``aria-valuetext``.
- Keyboard: ArrowRight emits value + step, Shift+ArrowRight does the same (no half-step), disabled blocks change.

Pointer-drag and bounds-leave behaviours are intentionally not unit-tested in jsdom (would require ``getBoundingClientRect`` stubbing for marginal value); covered end-to-end via the Storybook story and the toolbar.

## Test plan

- [ ] Mouse drag scrubs through angles smoothly; releasing outside the strip doesn't strand the gesture
- [ ] Pointer leaving the ruler bounds during a drag ends the drag (cursor stops scrubbing)
- [ ] Touch drag works on a mobile-shaped viewport
- [ ] Keyboard ←/↓ decrements by 1°, →/↑ increments by 1°; Home/End jumps to ±45°
- [ ] Tab focus draws a ring around the ruler; the visually hidden input is what receives focus
- [ ] All major labels render (every 15°); the active label sits centered with a white background that obscures the static label behind it
- [ ] Ticks render symmetrically around the center pointer at value = 0
- [ ] ±45° labels render fully (not clipped) when the value is at the extremes
- [ ] Below 782 px the toolbar splits into two rows; above 782 px both regions share a row with a thin grey divider
- [ ] Undo after a drag is one step; undo after rapid arrow-key presses is also one step (after a 300 ms idle)
- [ ] Reset still clears all crop state
- [ ] Storybook story (``MediaEditor / RotationRuler / Default``) renders styled with admin-blue pointer