### PR TITLE
SlotFill: add dependencies to updateFill effect

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Internal
 
 -   Update code to comply with `eslint-plugin-react-hooks` v7 ([#69962](https://github.com/WordPress/gutenberg/pull/69962)).
+-   `SlotFill`: Add dependencies to `updateFill` effect ([#77907](https://github.com/WordPress/gutenberg/pull/77907)).
 
 ## 33.0.0 (2026-04-29)
 

--- a/packages/components/src/slot-fill/fill.tsx
+++ b/packages/components/src/slot-fill/fill.tsx
@@ -37,9 +37,9 @@ export default function Fill( { name, children }: FillComponentProps ) {
 	useLayoutEffect( () => {
 		registry.updateFill( name, {
 			instance: instanceRef.current,
-			children: childrenRef.current,
+			children,
 		} );
-	} );
+	}, [ registry, name, children ] );
 
 	const slot = useObservableValue( registry.slots, name );
 


### PR DESCRIPTION
Follow-up to #68056 which I promised in the review (https://github.com/WordPress/gutenberg/pull/68056#discussion_r2698030640) and now @obenland reminded me about it 🙂

Adds dependencies to layout effect that calls `updateFill` with updated `children`.

I don't think anything will really change after this PR. `children` are typically different on every render (a new element created from JSX markup), so the effect will be triggered on every render. And it will store the latest `children` and trigger a re-render of the `Slot`. Now we're just adding the `children` explicitly as dependency and avoid suspicious effect without dependencies.

I'm also updating the `childrenRef.current` expression to simply `children`. They are guaranteed to be the same, because an earllier layout effects calls `childrenRef.current = children`. And if I didn't do it, eslint would complain about a dependency that is not really used by the effect callback.