### PR TITLE
Plugin: fix activation warning

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -24,7 +24,7 @@ if ( file_exists( $build_registration ) ) {
 // The constants.php file returns an array but doesn't define constants to avoid conflicts.
 $constants_file = plugin_dir_path( __DIR__ ) . 'build/constants.php';
 if ( file_exists( $constants_file ) && ! defined( 'GUTENBERG_VERSION' ) ) {
-	$build_constants = require_once $constants_file;
+	$build_constants = require $constants_file;
 	define( 'GUTENBERG_VERSION', $build_constants['version'] );
 }
 


### PR DESCRIPTION
## What?
Fix the "unexpected output during activation" warning emitted when activating the Gutenberg plugin.

<img width="1039" height="562" alt="image" src="https://github.com/user-attachments/assets/f6c95fc4-5261-4d6e-a7c0-03540a212e80" />

## Why?
`build/constants.php` returns an array and is loaded via plain `require` from several `build/*.php` files. When `lib/load.php` then used `require_once`, PHP returned `true` (because the file had already been included), and `$build_constants['version']` triggered a "Trying to access array offset on true" warning during activation.

## How?
Switch `lib/load.php` to `require` so the array is returned on every call, matching the other consumers.

## Testing Instructions
1. Activate the Gutenberg plugin on a fresh install.
2. Confirm no "unexpected output during activation" notice appears.

## Use of AI Tools
Diagnosis and patch were drafted with Claude Code; the change was reviewed and committed by the author.
