### PR TITLE
Flex Layout: Fix fixed-width child blocks being compressed

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -710,6 +710,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		if ( 'fixed' === $self_stretch && isset( $block['attrs']['style']['layout']['flexSize'] ) ) {
 			$child_layout_declarations['flex-basis'] = $block['attrs']['style']['layout']['flexSize'];
 			$child_layout_declarations['box-sizing'] = 'border-box';
+			$child_layout_declarations['flex-shrink'] = '0';
 		} elseif ( 'fill' === $self_stretch ) {
 			$child_layout_declarations['flex-grow'] = '1';
 		}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -708,8 +708,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$self_stretch = $block['attrs']['style']['layout']['selfStretch'] ?? null;
 
 		if ( 'fixed' === $self_stretch && isset( $block['attrs']['style']['layout']['flexSize'] ) ) {
-			$child_layout_declarations['flex-basis'] = $block['attrs']['style']['layout']['flexSize'];
-			$child_layout_declarations['box-sizing'] = 'border-box';
+			$child_layout_declarations['flex-basis']  = $block['attrs']['style']['layout']['flexSize'];
+			$child_layout_declarations['box-sizing']  = 'border-box';
 			$child_layout_declarations['flex-shrink'] = '0';
 		} elseif ( 'fill' === $self_stretch ) {
 			$child_layout_declarations['flex-grow'] = '1';

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -64,6 +64,7 @@ function useBlockPropsChildLayoutStyles( { style } ) {
 			css = `${ selector } {
 				flex-basis: ${ flexSize };
 				box-sizing: border-box;
+				flex-shrink: 0;
 			}`;
 		} else if ( selfStretch === 'fill' ) {
 			css = `${ selector } {


### PR DESCRIPTION
## What?
Closes #63218 

This PR adds `flex-shrink: 0` to child blocks set to a "Fixed" width within a flex (Row) layout to prevent width mismatch issue.

## Why?

When a child block is set to a "Fixed" width, it generates a `flex-basis` value. However, because `flex-shrink` defaults to `1` in CSS, When adjacent "Fit" blocks have long content that fills the container, these blocks are frequently compressed below their intended size. The provided fixed width is strictly applied when `flex-shrink: 0` is added.

## How?

Modified the layout block support logic to include `flex-shrink: 0` whenever `selfStretch` is set to `fixed`.

### Testing Instructions

1. Open a post or page.
2. Insert a **Row** block.
3. Add two Paragraph blocks with long text.
4. Select the first paragraph and set **Dimensions > Width** to **Fixed** (e.g., `200px`).
5. Leave the second paragraph set to **Fit**.
6. Verify in both the editor and on the frontend that the first paragraph remains at 200px and is not compressed by the second paragraph.

## Screenshots or screencast 

### Before Fix

https://github.com/user-attachments/assets/31a1e5d7-d7f3-473a-b7a3-28736ef7c4f4

### After Fix 

https://github.com/user-attachments/assets/f315ab2a-e5c5-451f-b80b-5b22dc062d99

## Use of AI Tools

AI assistance is used to draft PR description.