### PR TITLE
Link: Fix focus outline around the new-tab icon

### DIFF
--- a/packages/ui/src/link/style.module.css
+++ b/packages/ui/src/link/style.module.css
@@ -50,6 +50,7 @@
 	 * inline-block so the link underline stays scoped to the text. */
 
 	.link-icon {
+		line-height: 1;
 		display: inline-block;
 		margin-inline-start: var(--wpds-dimension-padding-xs);
 		font-weight: var(--wpds-typography-font-weight-regular);


### PR DESCRIPTION
Follow-up to #77420

## What?

Fix the uneven focus outline rendered around `Link` components when `openInNewTab` is enabled.

## Why?

The link icon has `display:inline-block`, which may cause the resulting inline block box to be taller than the surrounding text's baseline.

## How?

Add `line-height: 1` to `.link-icon` so its box stays within the parent's strut. 

P.S. Separately from this PR, we also need to fix the focus outline for the `ExternalLink` component. See https://github.com/WordPress/gutenberg/pull/77790#issuecomment-4367920633

## Testing Instructions

1. Open Storybook and navigate to a `Link` story rendered with `openInNewTab` set to `true`.
2. Tab to the link.
3. Confirm the focus outline has a uniform height across the text and the trailing arrow.

## Screenshots or screencast

| Before | After |
|--------|--------|
| <img width="150" height="61" alt="image" src="https://github.com/user-attachments/assets/ee8ea12e-387b-4487-bb83-c5eea654d13b" />| <img width="166" height="56" alt="image" src="https://github.com/user-attachments/assets/6b9bfb09-5152-4653-9177-147b713d8b8c" /> | 

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: Diagnosing the root cause (inline-block line-box expansion) and proposing the one-line CSS fix. Final change reviewed and validated by me.
