### PR TITLE
Classic Block: Unwrap experiment to hide it from inserter

### DIFF
--- a/backport-changelog/7.1/11712.md
+++ b/backport-changelog/7.1/11712.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11712
+
+* https://github.com/WordPress/gutenberg/pull/77911

--- a/lib/classic-block.php
+++ b/lib/classic-block.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Experiment to disable the Classic block.
+ * Controls whether the Classic block is available in the inserter.
  *
  * @package gutenberg
  */

--- a/lib/compat/wordpress-7.1/classic-block.php
+++ b/lib/compat/wordpress-7.1/classic-block.php
@@ -15,7 +15,7 @@ function gutenberg_declare_classic_block_necessary() {
 	}
 	wp_add_inline_script(
 		'wp-block-library',
-		'window.wp = window.wp || {}; window.wp.needsClassicBlock = true;',
+		'window.__needsClassicBlock = true;',
 		'before'
 	);
 }

--- a/lib/compat/wordpress-7.1/classic-block.php
+++ b/lib/compat/wordpress-7.1/classic-block.php
@@ -19,7 +19,7 @@ function gutenberg_declare_classic_block_necessary() {
 		'before'
 	);
 }
-add_action( 'admin_init', 'gutenberg_declare_classic_block_necessary' );
+add_action( 'enqueue_block_editor_assets', 'gutenberg_declare_classic_block_necessary' );
 
 /**
  * Whether the Classic block should be available in the inserter.
@@ -27,15 +27,7 @@ add_action( 'admin_init', 'gutenberg_declare_classic_block_necessary' );
  * @return bool True if the Classic block should be in the inserter.
  */
 function gutenberg_classic_block_supports_inserter() {
-	$post = null;
-	if (
-		is_admin() &&
-		! empty( $_GET['post'] ) &&
-		! empty( $_GET['action'] ) &&
-		'edit' === $_GET['action']
-	) {
-		$post = get_post( absint( $_GET['post'] ) );
-	}
+	global $post;
 
 	/**
 	 * Filters whether the Classic block should be available in the inserter.

--- a/lib/compat/wordpress-7.1/classic-block.php
+++ b/lib/compat/wordpress-7.1/classic-block.php
@@ -6,28 +6,32 @@
  * @package gutenberg
  */
 
-/**
- * Inject a global JS flag that declares the editor will need the classic block.
- */
-function gutenberg_declare_classic_block_necessary() {
-	global $post;
-
+if ( ! function_exists( 'wp_declare_classic_block_necessary' ) ) {
 	/**
-	 * Filters whether the Classic block should be available in the inserter.
+	 * Inject a global JS flag that declares the editor will need the classic block.
 	 *
-	 * Defaults to false. Use this filter to opt in (globally or per post).
-	 *
-	 * @param bool         $supports_inserter Whether the Classic block is available in the inserter.
-	 * @param WP_Post|null $post              The post being edited, or null if not in the post editor.
+	 * @global WP_Post|null $post The post being edited, or null if not in the post editor.
 	 */
-	if ( ! (bool) apply_filters( 'gutenberg_classic_block_supports_inserter', false, $post ) ) {
-		return;
-	}
+	function wp_declare_classic_block_necessary() {
+		global $post;
 
-	wp_add_inline_script(
-		'wp-block-library',
-		'window.__needsClassicBlock = true;',
-		'before'
-	);
+		/**
+		 * Filters whether the Classic block should be available in the inserter.
+		 *
+		 * Defaults to false. Use this filter to opt in (globally or per post).
+		 *
+		 * @param bool         $supports_inserter Whether the Classic block is available in the inserter.
+		 * @param WP_Post|null $post              The post being edited, or null if not in the post editor.
+		 */
+		if ( ! (bool) apply_filters( 'wp_classic_block_supports_inserter', false, $post ) ) {
+			return;
+		}
+
+		wp_add_inline_script(
+			'wp-block-library',
+			'window.__needsClassicBlock = true;',
+			'before'
+		);
+	}
+	add_action( 'enqueue_block_editor_assets', 'wp_declare_classic_block_necessary' );
 }
-add_action( 'enqueue_block_editor_assets', 'gutenberg_declare_classic_block_necessary' );

--- a/lib/compat/wordpress-7.1/classic-block.php
+++ b/lib/compat/wordpress-7.1/classic-block.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * Controls whether the Classic block is available in the inserter.
+ * WordPress 7.1 compatibility: controls whether the Classic block
+ * is available in the inserter.
  *
  * @package gutenberg
  */

--- a/lib/compat/wordpress-7.1/classic-block.php
+++ b/lib/compat/wordpress-7.1/classic-block.php
@@ -7,15 +7,19 @@
  */
 
 /**
- * Render a variable that we'll use to declare that the editor will need the classic block.
+ * Inject a global JS flag that declares the editor will need the classic block.
  */
 function gutenberg_declare_classic_block_necessary() {
 	if ( ! gutenberg_classic_block_supports_inserter() ) {
 		return;
 	}
-	echo '<script type="text/javascript">window.wp.needsClassicBlock = true;</script>';
+	wp_add_inline_script(
+		'wp-block-library',
+		'window.wp = window.wp || {}; window.wp.needsClassicBlock = true;',
+		'before'
+	);
 }
-add_action( 'admin_print_footer_scripts', 'gutenberg_declare_classic_block_necessary', 20 );
+add_action( 'admin_init', 'gutenberg_declare_classic_block_necessary' );
 
 /**
  * Whether the Classic block should be available in the inserter.

--- a/lib/compat/wordpress-7.1/classic-block.php
+++ b/lib/compat/wordpress-7.1/classic-block.php
@@ -10,23 +10,6 @@
  * Inject a global JS flag that declares the editor will need the classic block.
  */
 function gutenberg_declare_classic_block_necessary() {
-	if ( ! gutenberg_classic_block_supports_inserter() ) {
-		return;
-	}
-	wp_add_inline_script(
-		'wp-block-library',
-		'window.__needsClassicBlock = true;',
-		'before'
-	);
-}
-add_action( 'enqueue_block_editor_assets', 'gutenberg_declare_classic_block_necessary' );
-
-/**
- * Whether the Classic block should be available in the inserter.
- *
- * @return bool True if the Classic block should be in the inserter.
- */
-function gutenberg_classic_block_supports_inserter() {
 	global $post;
 
 	/**
@@ -37,5 +20,14 @@ function gutenberg_classic_block_supports_inserter() {
 	 * @param bool         $supports_inserter Whether the Classic block is available in the inserter.
 	 * @param WP_Post|null $post              The post being edited, or null if not in the post editor.
 	 */
-	return (bool) apply_filters( 'gutenberg_classic_block_supports_inserter', false, $post );
+	if ( ! (bool) apply_filters( 'gutenberg_classic_block_supports_inserter', false, $post ) ) {
+		return;
+	}
+
+	wp_add_inline_script(
+		'wp-block-library',
+		'window.__needsClassicBlock = true;',
+		'before'
+	);
 }
+add_action( 'enqueue_block_editor_assets', 'gutenberg_declare_classic_block_necessary' );

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -15,9 +15,6 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-grid-interactivity' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableGridInteractivity = true', 'before' );
 	}
-	if ( gutenberg_is_experiment_enabled( 'gutenberg-no-tinymce' ) ) {
-		wp_add_inline_script( 'wp-block-library', 'window.__experimentalDisableTinymce = true', 'before' );
-	}
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-dataviews-media-modal' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalDataViewsMediaModal = true', 'before' );
 	}

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -34,11 +34,6 @@ function gutenberg_initialize_experiments_settings() {
 					'label'       => __( 'Grid interactivity', 'gutenberg' ),
 					'description' => __( 'Enables enhancements to the Grid block that let you move and resize items in the editor canvas.', 'gutenberg' ),
 				),
-				array(
-					'id'          => 'gutenberg-no-tinymce',
-					'label'       => __( 'Disable Classic block', 'gutenberg' ),
-					'description' => __( 'Hides the Classic block from any inserters in the block editor.', 'gutenberg' ),
-				),
 			),
 		),
 		array(

--- a/lib/load.php
+++ b/lib/load.php
@@ -99,6 +99,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 }
 
 require_once __DIR__ . '/remove-core-enqueue-scripts.php';
+require_once __DIR__ . '/classic-block.php';
 require_once __DIR__ . '/experimental/editor-settings.php';
 require_once __DIR__ . '/experimental/rest-api-overrides.php';
 
@@ -137,10 +138,6 @@ if ( class_exists( '\WordPress\AiClient\AiClient' ) ) {
 
 if ( gutenberg_is_experiment_enabled( 'gutenberg-workflow-palette' ) ) {
 	require __DIR__ . '/experimental/workflow-palette.php';
-}
-
-if ( gutenberg_is_experiment_enabled( 'gutenberg-no-tinymce' ) ) {
-	require __DIR__ . '/experimental/disable-tinymce.php';
 }
 
 // Load the BC Layer to avoid fatal errors of extenders using the Fonts API.

--- a/lib/load.php
+++ b/lib/load.php
@@ -99,7 +99,6 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 }
 
 require_once __DIR__ . '/remove-core-enqueue-scripts.php';
-require_once __DIR__ . '/classic-block.php';
 require_once __DIR__ . '/experimental/editor-settings.php';
 require_once __DIR__ . '/experimental/rest-api-overrides.php';
 
@@ -122,6 +121,9 @@ require __DIR__ . '/compat/wordpress-7.0/media.php';
 require __DIR__ . '/compat/wordpress-7.0/command-palette.php';
 require __DIR__ . '/compat/wordpress-7.0/meta-box-rtc-compat.php';
 require __DIR__ . '/compat/wordpress-7.0/script-modules.php';
+
+// WordPress 7.1 compat.
+require __DIR__ . '/compat/wordpress-7.1/classic-block.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/packages/block-library/src/freeform/index.js
+++ b/packages/block-library/src/freeform/index.js
@@ -26,7 +26,7 @@ export const init = () => {
 	// a classic block.
 	const supports = {
 		...metadata.supports,
-		inserter: !! window?.wp?.needsClassicBlock,
+		inserter: !! window?.__needsClassicBlock,
 	};
 	return initBlock( { name, metadata, settings: { ...settings, supports } } );
 };

--- a/packages/block-library/src/freeform/index.js
+++ b/packages/block-library/src/freeform/index.js
@@ -22,13 +22,11 @@ export const settings = {
 };
 
 export const init = () => {
-	// When the "Disable Classic block" experiment is enabled, only expose the
-	// block in the inserter if the current post actually needs a classic block.
+	// Only expose the block in the inserter if the current post actually needs
+	// a classic block.
 	const supports = {
 		...metadata.supports,
-		inserter:
-			! window?.__experimentalDisableTinymce ||
-			!! window?.wp?.needsClassicBlock,
+		inserter: !! window?.wp?.needsClassicBlock,
 	};
 	return initBlock( { name, metadata, settings: { ...settings, supports } } );
 };


### PR DESCRIPTION
## What?
Promotes the `gutenberg-no-tinymce` experiment to the default behavior. The Classic block will now always be hidden from the block inserter, except when opted in via the ~~gutenberg_classic_block_supports_inserter~~ `wp_classic_block_supports_inserter` filter.

I'm hoping to land this on time for the next version of Gutenberg. 

## Why?
The experiment has been available as an opt-in for long enough, with a much more destructive approach (completely preventing TinyMCE from loading). After we recently made it harmless (just hiding the block in the inserter, changing the block and the underlying TinyMCE to always load), proceeding to enable it for everyone is an obvious next step. Also, hiding the Classic block by default aligns the inserter with the block-first editing model. 

## How?
We're removing the experimental code and moving the filter logic out of the experimental directory. The escape hatch (the filter + global) remains for sites that still rely on classic content.

## Testing Instructions
* Start writing a new post
* Verify you don't see the Classic block in the inserter.
* Open an existing post that contains a classic block (or a `<!-- wp:freeform -->` block) and confirm the Classic block renders correctly and is editable.
* ~~Put this in your code: `add_filter( 'gutenberg_classic_block_supports_inserter', '__return_true' );`. Alternatively, you can use [[this plugin](https://github.com/tyxla/enable-classic-block/archive/refs/tags/v1.0.0.zip)](https://github.com/tyxla/enable-classic-block/archive/refs/tags/v1.0.0.zip) to test it.~~
* Use this filter: `add_filter( 'wp_classic_block_supports_inserter', '__return_true' );`
* Verify you see the Classic block in the inserter. 

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

None

## Use of AI Tools

Opus 4.7