### PR TITLE
ColorPicker : Fix inconsistent HEX input clearing behavior

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bug Fixes
 
 -   `TabPanel`: Fix tab indicator animation while switching tabs ([#77812](https://github.com/WordPress/gutenberg/pull/77812)).
--   `ColorPicker`: Fix issue where clearing the hex input entirely doesn't reset the selected color to black ([#75243](https://github.com/WordPress/gutenberg/pull/77912)).
+-   `ColorPicker`: Fix issue where clearing the hex input entirely doesn't reset the selected color to black ([#77912](https://github.com/WordPress/gutenberg/pull/77912)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 -   `TabPanel`: Fix tab indicator animation while switching tabs ([#77812](https://github.com/WordPress/gutenberg/pull/77812)).
+-   `ColorPicker`: Fix issue where clearing the hex input entirely doesn't reset the selected color to black ([#75243](https://github.com/WordPress/gutenberg/pull/77912)).
 
 ### Internal
 

--- a/packages/components/src/color-picker/hex-input.tsx
+++ b/packages/components/src/color-picker/hex-input.tsx
@@ -20,7 +20,7 @@ import InputControlPrefixWrapper from '../input-control/input-prefix-wrapper';
 
 export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 	const handleChange = ( nextValue: string | undefined ) => {
-		if ( ! nextValue ) {
+		if ( nextValue === undefined ) {
 			return;
 		}
 		const hexValue = nextValue.startsWith( '#' )

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -95,7 +95,7 @@ describe( 'ColorPicker', () => {
 			await user.clear( hexInput );
 			await user.type( hexInput, '1ab' );
 
-			expect( onChangeComplete ).toHaveBeenCalledTimes( 3 );
+			expect( onChangeComplete ).toHaveBeenCalledTimes( 4 );
 			expect( onChangeComplete ).toHaveBeenLastCalledWith(
 				legacyColorMatcher
 			);
@@ -126,7 +126,7 @@ describe( 'ColorPicker', () => {
 			await user.clear( hexInput );
 			await user.type( hexInput, '1ab' );
 
-			expect( onChange ).toHaveBeenCalledTimes( 3 );
+			expect( onChange ).toHaveBeenCalledTimes( 4 );
 			expect( onChange ).toHaveBeenLastCalledWith( '#11aabb' );
 		} );
 	} );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -129,6 +129,28 @@ describe( 'ColorPicker', () => {
 			expect( onChange ).toHaveBeenCalledTimes( 4 );
 			expect( onChange ).toHaveBeenLastCalledWith( '#11aabb' );
 		} );
+
+		it( 'should reset color to black when the hex input is completely cleared', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+			const color = '#11aabb';
+
+			render(
+				<ColorPicker
+					onChange={ onChange }
+					color={ color }
+					enableAlpha={ false }
+				/>
+			);
+
+			const formatSelector = screen.getByRole( 'combobox' );
+			await user.selectOptions( formatSelector, 'hex' );
+
+			const hexInput = screen.getByRole( 'textbox' );
+			await user.clear( hexInput );
+
+			expect( onChange ).toHaveBeenLastCalledWith( '#000000' );
+		} );
 	} );
 
 	describe.each( [


### PR DESCRIPTION
## What?

Closes #75243 

This PR ensures that the `ColorPicker` component consistently resets to black when its HEX input field is cleared, regardless of whether the deletion happens character by character or in a single action (e.g., selecting all and deleting).

## Why?

Previously, clearing the HEX input in a single action would trigger an early return in the `handleChange` function because of a falsy value check. This left the previously selected color active in the picker despite the input field being empty, causing user confusion. By strictly checking for `undefined`, we allow the empty string to be processed, resulting in a consistent fallback to black.

## How?

The logic in `packages/components/src/color-picker/hex-input.tsx` was modified to change the early return condition from `if ( ! nextValue )` to `if ( nextValue === undefined )`. This ensures that empty strings (which are falsy) are passed to `colord()`, which handles invalid/empty strings by defaulting to black. Unit tests in `packages/components/src/color-picker/test/index.tsx` were also updated to reflect the additional `onChange` call triggered by the field clearance.

## Testing Instructions

1. Open any block or component that uses the `ColorPicker` (e.g., a Paragraph block's text color).
2. Select a custom color from the picker.
3. Click into the HEX input field.
4. Select the entire HEX value (e.g., `Cmd+A` or `Ctrl+A`) and press `Backspace` or `Delete`.
5. **Expected Result:** The color picker should reset to black, and the input field should display `#000000`.
6. Repeat the process but delete the HEX value character by character. Verify it also resets to black.

### Testing Instructions for Keyboard

1. Tab into the `ColorPicker` and navigate to the HEX input field.
2. Type a custom HEX code (e.g., `f00`).
3. Press `Cmd+A` (Mac) or `Ctrl+A` (Windows) to select the text.
4. Press `Backspace`.
5. Confirm the color picker updates visually to black and the input field updates to `#000000`.

## Screenshots or screencast

### Before Fix :

https://github.com/user-attachments/assets/1ebc2313-00a7-457d-9f87-642609d8ff81

### After Fix :

https://github.com/user-attachments/assets/5e867cf6-267d-43a6-9d88-33f1653f2ffe

## Use of AI Tools

AI is used to draft PR description.