### PR TITLE
Experiment: Content types fix new instance returned in `useSelect`

### DIFF
--- a/routes/post-type-edit/stage.tsx
+++ b/routes/post-type-edit/stage.tsx
@@ -83,24 +83,22 @@ function PostTypeEditStage() {
 	const navigate = useNavigate();
 	const isAddMode = id === NEW_ID;
 	const postTypeId = parseInt( id, 10 );
-	const initialData = useSelect(
+	const record = useSelect(
 		( select ) => {
-			if ( isAddMode ) {
-				return BLANK_RECORD;
-			}
-			// beforeLoad (route.ts) guarantees the record is in cache.
-			const record = select(
-				coreStore
-			).getEntityRecord< PostTypeRecord >(
-				'postType',
-				USER_POST_TYPE_POST_TYPE,
-				postTypeId
-			)!;
-			return toFormData( record );
+			return (
+				! isAddMode &&
+				// beforeLoad (route.ts) guarantees the record is in cache.
+				select( coreStore ).getEntityRecord< PostTypeRecord >(
+					'postType',
+					USER_POST_TYPE_POST_TYPE,
+					postTypeId
+				)!
+			);
 		},
 		[ isAddMode, postTypeId ]
 	);
-
+	const initialData =
+		! isAddMode && record ? toFormData( record ) : BLANK_RECORD;
 	const title = isAddMode ? __( 'Add post type' ) : initialData.title.raw;
 	const commonProps = { initialData, title };
 	const postTypePageProps: PostTypePageProps = isAddMode

--- a/routes/taxonomy-edit/stage.tsx
+++ b/routes/taxonomy-edit/stage.tsx
@@ -83,24 +83,22 @@ function TaxonomyEditStage() {
 	const navigate = useNavigate();
 	const isAddMode = id === NEW_ID;
 	const taxonomyId = parseInt( id, 10 );
-	const initialData = useSelect(
+	const record = useSelect(
 		( select ) => {
-			if ( isAddMode ) {
-				return BLANK_RECORD;
-			}
-			// beforeLoad (route.ts) guarantees the record is in cache.
-			const record = select(
-				coreStore
-			).getEntityRecord< TaxonomyRecord >(
-				'postType',
-				USER_TAXONOMY_POST_TYPE,
-				taxonomyId
-			)!;
-			return toFormData( record );
+			return (
+				! isAddMode &&
+				// beforeLoad (route.ts) guarantees the record is in cache.
+				select( coreStore ).getEntityRecord< TaxonomyRecord >(
+					'postType',
+					USER_TAXONOMY_POST_TYPE,
+					taxonomyId
+				)!
+			);
 		},
 		[ isAddMode, taxonomyId ]
 	);
-
+	const initialData =
+		! isAddMode && record ? toFormData( record ) : BLANK_RECORD;
 	const title = isAddMode ? __( 'Add taxonomy' ) : initialData.title.raw;
 	const commonProps = { initialData, title };
 	const taxonomyPageProps: TaxonomyPageProps = isAddMode


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I noticed the warnings in dev tools when we visit the `edit` taxonomy or post type screen of the **Content types** experiment. This PR just fixes that.


## Testing instructions

1. Enable the **Content types** experiment.
2. Go to **Settings → Taxonomies** and go to the `edit` screen of one.
3. Observe there are no warnings for different values from `useSelect` in the dev tools.
4. Do the same for `Post Types`