### PR TITLE
Select: Hide user agent focus ring in popup

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `Select`: Hide the browser focus ring on highlighted popup items ([#77919](https://github.com/WordPress/gutenberg/pull/77919)).
 -   `Drawer`: Restore the slide-out animation when the popup closes ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).
 
 ### Enhancements

--- a/packages/ui/src/utils/css/item-popup.module.css
+++ b/packages/ui/src/utils/css/item-popup.module.css
@@ -90,6 +90,7 @@
 		&[data-highlighted]:not([aria-disabled="true"]) {
 			background-color: var(--wpds-color-bg-interactive-brand-weak-active);
 			color: var(--wpds-color-fg-interactive-neutral);
+			outline: none; /* Disable user agent focus ring */
 
 			@media ( forced-colors: active ) {
 				outline: 1px solid Highlight;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Hides the browser-provided focus outline from highlighted Select popup items.

## Why?

The highlighted popup item already uses the component's selected item styling. The browser focus outline adds an extra focus ring that makes the popup state look visually inconsistent.

## How?

Adds `outline: none` to highlighted, enabled popup items while preserving the existing forced-colors outline for high contrast mode.

## Testing Instructions

### Testing Instructions for Keyboard

1. In the Storybook for `Select`, focus the Select trigger with the keyboard.
2. Press Enter or Space to open the popup.
3. Use the arrow keys to move through options.
4. Confirm that the highlighted option remains visually clear and does not show an additional browser focus ring.

## Screenshots or screencast

| Before | After |
|--------|-------|
|<img width="1150" height="576" alt="Select popover, before" src="https://github.com/user-attachments/assets/0a73fcba-1603-4395-b146-3a1893fb6436" />|<img width="1150" height="576" alt="Select popover, after" src="https://github.com/user-attachments/assets/2503e3d0-a8e2-4bfe-9a1e-cc5c49f4d949" />|
