### PR TITLE
RTC: add WebSocket e2e tests that do not run in CI

### DIFF
--- a/bin/rtc-test-ws-sync-server.mjs
+++ b/bin/rtc-test-ws-sync-server.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+
+import http from 'node:http';
+import process from 'node:process';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import ws from 'ws';
+
+const WebSocketServer = ws.WebSocketServer || ws.Server;
+
+/**
+ * @typedef {import('ws').RawData} RawData
+ * @typedef {import('ws').WebSocket & { roomName?: string, clientId?: string | number }} TestSocket
+ * @typedef {{ awareness: Map<string, unknown>, clients: Set<TestSocket>, updates: string[] }} Room
+ * @typedef {{ type?: string, room?: string, clientId?: string | number, state?: string, awareness?: unknown, update?: string }} TestMessage
+ */
+
+const DEFAULT_PORT = 18991;
+const PORT = parsePortArg();
+/** @type {Map<string, Room>} */
+const rooms = new Map();
+
+function parsePortArg() {
+	const portIndex = process.argv.indexOf( '--port' );
+	const rawPort =
+		portIndex === -1
+			? process.env.GUTENBERG_RTC_TEST_WS_PORT
+			: process.argv[ portIndex + 1 ];
+
+	if ( ! rawPort ) {
+		return DEFAULT_PORT;
+	}
+
+	const port = Number.parseInt( rawPort, 10 );
+	if ( ! Number.isInteger( port ) || port <= 0 ) {
+		throw new Error( `Invalid port: ${ rawPort }` );
+	}
+	return port;
+}
+
+/**
+ * @param {string} roomName Room name.
+ * @return {Room} Matching room.
+ */
+function getRoom( roomName ) {
+	let room = rooms.get( roomName );
+	if ( ! room ) {
+		room = {
+			awareness: new Map(),
+			clients: new Set(),
+			updates: [],
+		};
+		rooms.set( roomName, room );
+	}
+	return room;
+}
+
+/**
+ * @param {TestSocket}              socket  WebSocket client.
+ * @param {Record<string, unknown>} payload JSON payload.
+ */
+function sendJson( socket, payload ) {
+	if ( socket.readyState !== socket.OPEN ) {
+		return;
+	}
+	socket.send( JSON.stringify( payload ) );
+}
+
+/**
+ * @param {Room}                    room         Room to broadcast to.
+ * @param {Record<string, unknown>} payload      JSON payload.
+ * @param {TestSocket | null}       exceptSocket Socket to skip.
+ */
+function broadcastJson( room, payload, exceptSocket = null ) {
+	for ( const client of room.clients ) {
+		if ( client !== exceptSocket ) {
+			sendJson( client, payload );
+		}
+	}
+}
+
+/**
+ * @param {TestSocket} socket WebSocket client.
+ */
+function removeSocketFromRooms( socket ) {
+	for ( const [ roomName, room ] of rooms ) {
+		if ( ! room.clients.delete( socket ) ) {
+			continue;
+		}
+
+		if ( socket.clientId ) {
+			room.awareness.delete( String( socket.clientId ) );
+			broadcastJson( room, {
+				type: 'remove-awareness',
+				room: roomName,
+				clientIds: [ socket.clientId ],
+			} );
+		}
+	}
+}
+
+/**
+ * @param {Room} room Room to read.
+ * @return {Record<string, unknown>} Serialized awareness by client ID.
+ */
+function roomAwarenessObject( room ) {
+	return Object.fromEntries( room.awareness.entries() );
+}
+
+/**
+ * @param {TestSocket}  socket  WebSocket client.
+ * @param {TestMessage} message Parsed message.
+ */
+function handleJoin( socket, message ) {
+	if ( ! message.room || ! message.clientId ) {
+		return;
+	}
+
+	const room = getRoom( message.room );
+	socket.roomName = message.room;
+	socket.clientId = message.clientId;
+	room.clients.add( socket );
+
+	if ( message.state ) {
+		room.updates.push( message.state );
+	}
+	if ( Object.prototype.hasOwnProperty.call( message, 'awareness' ) ) {
+		room.awareness.set( String( message.clientId ), message.awareness );
+	}
+
+	sendJson( socket, {
+		type: 'snapshot',
+		room: message.room,
+		updates: room.updates,
+		awareness: roomAwarenessObject( room ),
+	} );
+
+	if ( message.state ) {
+		broadcastJson(
+			room,
+			{
+				type: 'update',
+				room: message.room,
+				clientId: message.clientId,
+				update: message.state,
+			},
+			socket
+		);
+	}
+
+	broadcastJson(
+		room,
+		{
+			type: 'awareness',
+			room: message.room,
+			awareness: {
+				[ message.clientId ]: message.awareness ?? {},
+			},
+		},
+		socket
+	);
+}
+
+/**
+ * @param {TestSocket}  socket  WebSocket client.
+ * @param {TestMessage} message Parsed message.
+ */
+function handleUpdate( socket, message ) {
+	if ( ! socket.roomName || ! message.update ) {
+		return;
+	}
+
+	const room = getRoom( socket.roomName );
+	room.updates.push( message.update );
+	broadcastJson(
+		room,
+		{
+			type: 'update',
+			room: socket.roomName,
+			clientId: socket.clientId,
+			update: message.update,
+		},
+		socket
+	);
+}
+
+/**
+ * @param {TestSocket}  socket  WebSocket client.
+ * @param {TestMessage} message Parsed message.
+ */
+function handleAwareness( socket, message ) {
+	if ( ! socket.roomName ) {
+		return;
+	}
+
+	const room = getRoom( socket.roomName );
+	if ( message.awareness === null ) {
+		room.awareness.delete( String( socket.clientId ) );
+		broadcastJson( room, {
+			type: 'remove-awareness',
+			room: socket.roomName,
+			clientIds: [ socket.clientId ],
+		} );
+		return;
+	}
+
+	room.awareness.set( String( socket.clientId ), message.awareness ?? {} );
+	broadcastJson( room, {
+		type: 'awareness',
+		room: socket.roomName,
+		awareness: {
+			[ String( socket.clientId ) ]: message.awareness ?? {},
+		},
+	} );
+}
+
+/**
+ * @param {TestSocket} socket     WebSocket client.
+ * @param {RawData}    rawMessage Raw WebSocket message.
+ */
+function handleMessage( socket, rawMessage ) {
+	let message;
+	try {
+		message = JSON.parse( rawMessage.toString() );
+	} catch {
+		return;
+	}
+
+	switch ( message.type ) {
+		case 'join':
+			handleJoin( socket, message );
+			break;
+		case 'update':
+			handleUpdate( socket, message );
+			break;
+		case 'awareness':
+			handleAwareness( socket, message );
+			break;
+		case 'leave':
+			removeSocketFromRooms( socket );
+			break;
+	}
+}
+
+function reset() {
+	for ( const room of rooms.values() ) {
+		for ( const client of room.clients ) {
+			client.close( 1001, 'reset' );
+		}
+	}
+	rooms.clear();
+}
+
+const server = http.createServer( ( request, response ) => {
+	if ( request.url === '/health' ) {
+		response.writeHead( 200, { 'content-type': 'application/json' } );
+		response.end(
+			JSON.stringify( {
+				name: 'gutenberg-rtc-test-ws-sync-server',
+				ok: true,
+				port: PORT,
+				rooms: rooms.size,
+			} )
+		);
+		return;
+	}
+
+	if ( request.method === 'POST' && request.url === '/reset' ) {
+		reset();
+		response.writeHead( 204 );
+		response.end();
+		return;
+	}
+
+	response.writeHead( 404, { 'content-type': 'application/json' } );
+	response.end( JSON.stringify( { ok: false } ) );
+} );
+
+const wss = new WebSocketServer( { server } );
+wss.on( 'connection', ( socket ) => {
+	socket.on( 'message', ( message ) => handleMessage( socket, message ) );
+	socket.on( 'close', () => removeSocketFromRooms( socket ) );
+	socket.on( 'error', () => removeSocketFromRooms( socket ) );
+} );
+
+server.listen( PORT, '127.0.0.1', () => {
+	process.stdout.write(
+		`gutenberg-rtc-test-ws-sync-server listening on 127.0.0.1:${ PORT }\n`
+	);
+} );
+
+function shutdown() {
+	reset();
+	wss.close();
+	server.close( () => process.exit( 0 ) );
+	setTimeout( () => process.exit( 0 ), 500 ).unref();
+}
+
+process.on( 'SIGINT', shutdown );
+process.on( 'SIGTERM', shutdown );

--- a/package.json
+++ b/package.json
@@ -174,6 +174,8 @@
 		"test:e2e:debug": "npm exec --workspace @wordpress/e2e-tests-playwright -- wp-scripts test-playwright --config playwright.config.ts --ui",
 		"test:e2e:playwright": "npm run test:e2e",
 		"test:e2e:playwright:debug": "npm run test:e2e:debug",
+		"test:e2e:rtc-websocket": "npm exec --workspace @wordpress/e2e-tests-playwright -- wp-scripts test-playwright --config playwright.rtc-websocket.config.ts",
+		"test:e2e:rtc-websocket:debug": "npm exec --workspace @wordpress/e2e-tests-playwright -- wp-scripts test-playwright --config playwright.rtc-websocket.config.ts --ui",
 		"test:e2e:storybook": "npm exec --workspace @wordpress/storybook-playwright -- playwright test --config playwright.config.ts",
 		"test:e2e:watch": "npm run test:e2e -- --watch",
 		"test:native": "cross-env NODE_ENV=test jest --config test/native/jest.config.js",

--- a/packages/e2e-tests/plugins/rtc-websocket-provider.php
+++ b/packages/e2e-tests/plugins/rtc-websocket-provider.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Plugin, RTC WebSocket Provider
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-rtc-websocket-provider
+ */
+
+/**
+ * Enqueues a test-only WebSocket sync provider for RTC e2e tests.
+ */
+function gutenberg_test_rtc_websocket_provider_enqueue() {
+	$script_path = plugin_dir_path( __FILE__ ) . 'rtc-websocket-provider/index.js';
+	$ws_url      = getenv( 'GUTENBERG_RTC_TEST_WS_URL' );
+
+	if ( ! $ws_url ) {
+		$ws_port = getenv( 'GUTENBERG_RTC_TEST_WS_PORT' );
+		if ( ! $ws_port ) {
+			$ws_port = '18991';
+		}
+		$ws_url = 'ws://127.0.0.1:' . $ws_port;
+	}
+
+	wp_enqueue_script(
+		'gutenberg-test-rtc-websocket-provider',
+		plugins_url( 'rtc-websocket-provider/index.js', __FILE__ ),
+		array( 'wp-hooks', 'wp-sync' ),
+		filemtime( $script_path ),
+		true
+	);
+
+	wp_add_inline_script(
+		'gutenberg-test-rtc-websocket-provider',
+		'window.gutenbergTestWebSocketSync = ' . wp_json_encode(
+			array(
+				'url' => $ws_url,
+			)
+		) . ';',
+		'before'
+	);
+}
+
+add_action( 'enqueue_block_editor_assets', 'gutenberg_test_rtc_websocket_provider_enqueue' );

--- a/packages/e2e-tests/plugins/rtc-websocket-provider/index.js
+++ b/packages/e2e-tests/plugins/rtc-websocket-provider/index.js
@@ -1,0 +1,367 @@
+( function () {
+	const TEST_PROVIDER_NAMESPACE = 'gutenberg-test/rtc-websocket-provider';
+	const DEFAULT_URL = 'ws://127.0.0.1:18991';
+	const REMOTE_ORIGIN = { source: TEST_PROVIDER_NAMESPACE };
+
+	const settings = window.gutenbergTestWebSocketSync || {};
+	const globalState = ( window.__gutenbergTestWebSocketSync = {
+		controls: {},
+		rooms: {},
+		tick: 0,
+		url: settings.url || DEFAULT_URL,
+		delayNextMessage( delayMs ) {
+			this.controls.delayNextMessageMs = Number( delayMs ) || 0;
+		},
+		closeNextSocket() {
+			this.controls.closeNextSocket = true;
+		},
+	} );
+
+	function toBase64( bytes ) {
+		let binary = '';
+		for ( let offset = 0; offset < bytes.length; offset += 0x8000 ) {
+			binary += String.fromCharCode.apply(
+				null,
+				bytes.subarray( offset, offset + 0x8000 )
+			);
+		}
+		return window.btoa( binary );
+	}
+
+	function fromBase64( value ) {
+		const binary = window.atob( value );
+		const bytes = new Uint8Array( binary.length );
+		for ( let i = 0; i < binary.length; i++ ) {
+			bytes[ i ] = binary.charCodeAt( i );
+		}
+		return bytes;
+	}
+
+	function ensureRoomDebugState( room ) {
+		if ( ! globalState.rooms[ room ] ) {
+			globalState.rooms[ room ] = {
+				awarenessCount: 0,
+				clientId: null,
+				receivedMessages: 0,
+				sentMessages: 0,
+				status: 'disconnected',
+			};
+		}
+		return globalState.rooms[ room ];
+	}
+
+	function updateDebugState( room, patch ) {
+		Object.assign( ensureRoomDebugState( room ), patch );
+		globalState.tick += 1;
+	}
+
+	function emitAwarenessChange( awareness, change ) {
+		awareness.emit( 'change', [ change ] );
+	}
+
+	function applyAwarenessState( awareness, state ) {
+		const currentStates = awareness.getStates();
+		const added = [];
+		const updated = [];
+		const removed = [];
+
+		for ( const [ clientIdString, awarenessState ] of Object.entries(
+			state || {}
+		) ) {
+			const clientId = Number( clientIdString );
+			if ( clientId === awareness.clientID ) {
+				continue;
+			}
+
+			if ( awarenessState === null ) {
+				if ( currentStates.delete( clientId ) ) {
+					removed.push( clientId );
+				}
+				continue;
+			}
+
+			if ( ! currentStates.has( clientId ) ) {
+				currentStates.set( clientId, awarenessState );
+				added.push( clientId );
+				continue;
+			}
+
+			if (
+				JSON.stringify( currentStates.get( clientId ) ) !==
+				JSON.stringify( awarenessState )
+			) {
+				currentStates.set( clientId, awarenessState );
+				updated.push( clientId );
+			}
+		}
+
+		if ( added.length || updated.length || removed.length ) {
+			emitAwarenessChange( awareness, { added, updated, removed } );
+		}
+	}
+
+	function removeAwarenessClients( awareness, clientIds ) {
+		const removed = [];
+		for ( const clientId of clientIds || [] ) {
+			const normalizedClientId = Number( clientId );
+			if (
+				normalizedClientId !== awareness.clientID &&
+				awareness.getStates().delete( normalizedClientId )
+			) {
+				removed.push( normalizedClientId );
+			}
+		}
+
+		if ( removed.length ) {
+			emitAwarenessChange( awareness, {
+				added: [],
+				updated: [],
+				removed,
+			} );
+		}
+	}
+
+	class TestWebSocketProvider {
+		constructor( { awareness, room, ydoc } ) {
+			this.awareness = awareness || new window.wp.sync.Awareness( ydoc );
+			this.destroyed = false;
+			this.listeners = {
+				status: new Set(),
+			};
+			this.pendingMessages = [];
+			this.reconnectDelayMs = 250;
+			this.room = room;
+			this.socket = null;
+			this.ydoc = ydoc;
+
+			this.onDocUpdate = this.onDocUpdate.bind( this );
+			this.onAwarenessUpdate = this.onAwarenessUpdate.bind( this );
+			this.ydoc.on( 'updateV2', this.onDocUpdate );
+			this.awareness.on( 'change', this.onAwarenessUpdate );
+
+			updateDebugState( this.room, {
+				clientId: this.ydoc.clientID,
+				status: 'connecting',
+			} );
+			this.connect();
+		}
+
+		on( event, callback ) {
+			if ( this.listeners[ event ] ) {
+				this.listeners[ event ].add( callback );
+			}
+		}
+
+		emitStatus( status ) {
+			updateDebugState( this.room, { status: status.status } );
+			for ( const callback of this.listeners.status ) {
+				callback( status );
+			}
+		}
+
+		connect() {
+			if ( this.destroyed ) {
+				return;
+			}
+
+			this.emitStatus( { status: 'connecting' } );
+			const socket = new window.WebSocket( globalState.url );
+			this.socket = socket;
+
+			socket.addEventListener( 'open', () => {
+				this.reconnectDelayMs = 250;
+				this.emitStatus( { status: 'connected' } );
+				this.send( {
+					type: 'join',
+					room: this.room,
+					clientId: this.ydoc.clientID,
+					awareness: this.awareness.getLocalState() || {},
+					state: toBase64(
+						window.wp.sync.Y.encodeStateAsUpdateV2( this.ydoc )
+					),
+				} );
+				this.flushPendingMessages();
+			} );
+
+			socket.addEventListener( 'message', ( event ) => {
+				this.handleMessage( event.data );
+			} );
+
+			socket.addEventListener( 'close', () => {
+				if ( this.destroyed ) {
+					return;
+				}
+
+				this.emitStatus( { status: 'disconnected' } );
+				const delay = this.reconnectDelayMs;
+				this.reconnectDelayMs = Math.min(
+					this.reconnectDelayMs * 2,
+					5000
+				);
+				window.setTimeout( () => this.connect(), delay );
+			} );
+
+			socket.addEventListener( 'error', () => {
+				if ( ! this.destroyed ) {
+					this.emitStatus( { status: 'disconnected' } );
+				}
+			} );
+		}
+
+		flushPendingMessages() {
+			const messages = this.pendingMessages.splice( 0 );
+			for ( const message of messages ) {
+				this.send( message );
+			}
+		}
+
+		send( payload ) {
+			if ( ! this.socket || this.socket.readyState !== WebSocket.OPEN ) {
+				if ( ! this.destroyed ) {
+					this.pendingMessages.push( payload );
+				}
+				return;
+			}
+
+			const sendNow = () => {
+				if (
+					globalState.controls.closeNextSocket &&
+					this.socket.readyState === WebSocket.OPEN
+				) {
+					globalState.controls.closeNextSocket = false;
+					this.pendingMessages.unshift( payload );
+					this.socket.close( 4000, 'Injected test close' );
+					return;
+				}
+
+				this.socket.send( JSON.stringify( payload ) );
+				const state = ensureRoomDebugState( this.room );
+				updateDebugState( this.room, {
+					sentMessages: state.sentMessages + 1,
+				} );
+			};
+
+			const delayMs = globalState.controls.delayNextMessageMs || 0;
+			if ( delayMs > 0 ) {
+				globalState.controls.delayNextMessageMs = 0;
+				window.setTimeout( sendNow, delayMs );
+				return;
+			}
+
+			sendNow();
+		}
+
+		handleMessage( rawMessage ) {
+			let message;
+			try {
+				message = JSON.parse( rawMessage );
+			} catch {
+				return;
+			}
+
+			if ( message.room && message.room !== this.room ) {
+				return;
+			}
+
+			const state = ensureRoomDebugState( this.room );
+			updateDebugState( this.room, {
+				receivedMessages: state.receivedMessages + 1,
+			} );
+
+			if ( message.type === 'snapshot' ) {
+				for ( const update of message.updates || [] ) {
+					window.wp.sync.Y.applyUpdateV2(
+						this.ydoc,
+						fromBase64( update ),
+						REMOTE_ORIGIN
+					);
+				}
+				applyAwarenessState( this.awareness, message.awareness );
+			} else if (
+				message.type === 'update' &&
+				message.clientId !== this.ydoc.clientID
+			) {
+				window.wp.sync.Y.applyUpdateV2(
+					this.ydoc,
+					fromBase64( message.update ),
+					REMOTE_ORIGIN
+				);
+			} else if ( message.type === 'awareness' ) {
+				applyAwarenessState( this.awareness, message.awareness );
+			} else if ( message.type === 'remove-awareness' ) {
+				removeAwarenessClients( this.awareness, message.clientIds );
+			}
+
+			updateDebugState( this.room, {
+				awarenessCount: this.awareness.getStates().size,
+			} );
+		}
+
+		onDocUpdate( update, origin ) {
+			if ( origin === REMOTE_ORIGIN ) {
+				return;
+			}
+
+			this.send( {
+				type: 'update',
+				room: this.room,
+				clientId: this.ydoc.clientID,
+				update: toBase64( update ),
+			} );
+		}
+
+		onAwarenessUpdate() {
+			updateDebugState( this.room, {
+				awarenessCount: this.awareness.getStates().size,
+			} );
+			this.send( {
+				type: 'awareness',
+				room: this.room,
+				clientId: this.ydoc.clientID,
+				awareness: this.awareness.getLocalState() || {},
+			} );
+		}
+
+		destroy() {
+			this.destroyed = true;
+			this.pendingMessages = [];
+			this.ydoc.off( 'updateV2', this.onDocUpdate );
+			this.awareness.off( 'change', this.onAwarenessUpdate );
+			this.send( {
+				type: 'leave',
+				room: this.room,
+				clientId: this.ydoc.clientID,
+			} );
+
+			if ( this.socket ) {
+				this.socket.close( 1000, 'destroy' );
+			}
+
+			this.emitStatus( { status: 'disconnected' } );
+		}
+	}
+
+	function createWebSocketProvider() {
+		return async ( { awareness, objectType, objectId, ydoc } ) => {
+			const room = objectId
+				? `${ objectType }:${ objectId }`
+				: objectType;
+			const provider = new TestWebSocketProvider( {
+				awareness,
+				room,
+				ydoc,
+			} );
+
+			return {
+				destroy: () => provider.destroy(),
+				on: ( event, callback ) => provider.on( event, callback ),
+			};
+		};
+	}
+
+	window.wp.hooks.addFilter(
+		'sync.providers',
+		TEST_PROVIDER_NAMESPACE,
+		() => [ createWebSocketProvider() ]
+	);
+} )();

--- a/test/e2e/config/global-setup.ts
+++ b/test/e2e/config/global-setup.ts
@@ -9,6 +9,36 @@ import type { FullConfig } from '@playwright/test';
  */
 import { RequestUtils } from '@wordpress/e2e-test-utils-playwright';
 
+async function resetTestWebSocketSyncServer() {
+	const wsUrl =
+		process.env.GUTENBERG_RTC_TEST_WS_URL ||
+		`ws://127.0.0.1:${ process.env.GUTENBERG_RTC_TEST_WS_PORT || '18991' }`;
+	const resetUrl = new URL( wsUrl );
+	resetUrl.protocol = resetUrl.protocol === 'wss:' ? 'https:' : 'http:';
+	resetUrl.pathname = '/reset';
+	resetUrl.search = '';
+	resetUrl.hash = '';
+
+	let lastError: unknown;
+	for ( let attempts = 0; attempts < 20; attempts++ ) {
+		try {
+			const response = await fetch( resetUrl, { method: 'POST' } );
+			if ( response.ok || response.status === 204 ) {
+				return;
+			}
+			lastError = new Error(
+				`WebSocket sync server reset failed with HTTP ${ response.status }`
+			);
+		} catch ( error ) {
+			lastError = error;
+		}
+
+		await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
+	}
+
+	throw lastError;
+}
+
 async function globalSetup( config: FullConfig ) {
 	const { storageState, baseURL } = config.projects[ 0 ].use;
 	const storageStatePath =
@@ -26,7 +56,7 @@ async function globalSetup( config: FullConfig ) {
 	await requestUtils.setupRest();
 
 	// Reset the test environment before running the tests.
-	await Promise.all( [
+	const resetTasks = [
 		requestUtils.activateTheme( 'twentytwentyone' ),
 		// Disable this test plugin as it's conflicting with some of the tests.
 		// We already have reduced motion enabled and Playwright will wait for most of the animations anyway.
@@ -36,7 +66,30 @@ async function globalSetup( config: FullConfig ) {
 		requestUtils.deleteAllPosts(),
 		requestUtils.deleteAllBlocks(),
 		requestUtils.resetPreferences(),
-	] );
+	];
+
+	const useTestWebSocketProvider =
+		process.env.GUTENBERG_RTC_TEST_WS_PROVIDER === '1';
+
+	if ( useTestWebSocketProvider ) {
+		if ( process.env.GUTENBERG_RTC_TEST_WS_SKIP_RESET !== '1' ) {
+			resetTasks.push( resetTestWebSocketSyncServer() );
+		}
+
+		resetTasks.push(
+			requestUtils.activatePlugin(
+				'gutenberg-test-plugin-rtc-websocket-provider'
+			)
+		);
+	} else {
+		resetTasks.push(
+			requestUtils.deactivatePlugin(
+				'gutenberg-test-plugin-rtc-websocket-provider'
+			)
+		);
+	}
+
+	await Promise.all( resetTasks );
 
 	await requestContext.dispose();
 }

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -32,6 +32,8 @@
 	},
 	"scripts": {
 		"test:e2e": "wp-scripts test-playwright --config playwright.config.ts",
-		"test:e2e:debug": "wp-scripts test-playwright --config playwright.config.ts --ui"
+		"test:e2e:debug": "wp-scripts test-playwright --config playwright.config.ts --ui",
+		"test:e2e:rtc-websocket": "wp-scripts test-playwright --config playwright.rtc-websocket.config.ts",
+		"test:e2e:rtc-websocket:debug": "wp-scripts test-playwright --config playwright.rtc-websocket.config.ts --ui"
 	}
 }

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -10,6 +10,13 @@ import { defineConfig, devices } from '@playwright/test';
  */
 import baseConfig from '@wordpress/scripts/config/playwright.config.js';
 
+const baseTestIgnore: Array< string | RegExp > = [];
+if ( Array.isArray( baseConfig.testIgnore ) ) {
+	baseTestIgnore.push( ...baseConfig.testIgnore );
+} else if ( baseConfig.testIgnore ) {
+	baseTestIgnore.push( baseConfig.testIgnore );
+}
+
 const config = defineConfig( {
 	...baseConfig,
 	webServer: {
@@ -23,6 +30,10 @@ const config = defineConfig( {
 	globalSetup: fileURLToPath(
 		new URL( './config/global-setup.ts', 'file:' + __filename ).href
 	),
+	testIgnore: [
+		...baseTestIgnore,
+		'**/specs/editor/collaboration/websocket/**',
+	],
 	projects: [
 		{
 			name: 'chromium',

--- a/test/e2e/playwright.rtc-websocket.config.ts
+++ b/test/e2e/playwright.rtc-websocket.config.ts
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { defineConfig, type PlaywrightTestConfig } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import baseConfig from './playwright.config';
+
+if ( process.env.CI && process.env.GUTENBERG_RTC_TEST_WS_ALLOW_CI !== '1' ) {
+	throw new Error(
+		'RTC WebSocket e2e tests are local-only. They are intentionally disabled in CI.'
+	);
+}
+
+const wsPort = process.env.GUTENBERG_RTC_TEST_WS_PORT || '18991';
+process.env.GUTENBERG_RTC_TEST_WS_PORT = wsPort;
+process.env.GUTENBERG_RTC_TEST_WS_PROVIDER = '1';
+process.env.GUTENBERG_RTC_TEST_WS_URL =
+	process.env.GUTENBERG_RTC_TEST_WS_URL || `ws://127.0.0.1:${ wsPort }`;
+
+type ArrayElement< T > = T extends Array< infer Item > ? Item : T;
+type WebServerConfig = ArrayElement<
+	Exclude< PlaywrightTestConfig[ 'webServer' ], undefined >
+>;
+
+const baseWebServer: WebServerConfig[] = [];
+if ( Array.isArray( baseConfig.webServer ) ) {
+	baseWebServer.push( ...baseConfig.webServer );
+} else if ( baseConfig.webServer ) {
+	baseWebServer.push( baseConfig.webServer );
+}
+
+const config = defineConfig( {
+	...baseConfig,
+	testIgnore: [],
+	testMatch:
+		'**/specs/editor/collaboration/websocket/collaboration-*.spec.ts',
+	webServer: [
+		...baseWebServer,
+		{
+			command: `exec node ../../bin/rtc-test-ws-sync-server.mjs --port ${ wsPort }`,
+			reuseExistingServer:
+				process.env.GUTENBERG_RTC_TEST_WS_REUSE_SERVER === '1',
+			stderr: 'pipe',
+			stdout: 'pipe',
+			url: `http://127.0.0.1:${ wsPort }/health`,
+		},
+	],
+} );
+
+export default config;

--- a/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
@@ -100,6 +100,45 @@ function bul( items: string[] ): string {
 	return `<!-- wp:list -->\n<ul class="wp-block-list">${ inner }</ul>\n<!-- /wp:list -->`;
 }
 
+async function getRenderedListItems( editor: Editor ) {
+	const blocks = await editor.getBlocks();
+	const listBlock = blocks.find( ( block ) => block.name === 'core/list' );
+
+	if ( ! listBlock ) {
+		throw new Error( 'Expected a list block.' );
+	}
+
+	return listBlock.innerBlocks.map( ( item ) => {
+		const listItem = item as typeof item & { clientId: string };
+
+		return {
+			clientId: listItem.clientId,
+			content: String( listItem.attributes.content ),
+		};
+	} );
+}
+
+async function expectSharedListReady(
+	editors: Editor[],
+	expectedOrder: string[]
+) {
+	const renderedItems = await Promise.all(
+		editors.map( ( ed ) => getRenderedListItems( ed ) )
+	);
+	for ( const items of renderedItems ) {
+		expect( items.map( ( item ) => item.content ) ).toEqual(
+			expectedOrder
+		);
+	}
+
+	const firstClientIds = renderedItems[ 0 ].map( ( item ) => item.clientId );
+	for ( const items of renderedItems.slice( 1 ) ) {
+		expect( items.map( ( item ) => item.clientId ) ).toEqual(
+			firstClientIds
+		);
+	}
+}
+
 function bol( items: string[] ): string {
 	const inner = items
 		.map(
@@ -558,6 +597,18 @@ test.describe( 'Collaboration - Stress Test', () => {
 		const { page: page2, editor: editor2 } =
 			await collaborationUtils.joinUser( post.id, STRESS_USERS[ 0 ] );
 		await collaborationUtils.waitForMutualDiscovery();
+
+		await expectSharedListReady(
+			[ editor, editor2 ],
+			[
+				'Item Alpha',
+				'Item Beta',
+				'Item Gamma',
+				'Item Delta',
+				'Item Epsilon',
+				'Item Zeta',
+			]
+		);
 
 		// ── Phase 2 — Concurrent list-item moves ────────────────
 		// User 1 moves "Item Beta" down; User 2 moves "Item Epsilon" up.

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -38,6 +38,7 @@ export const SECOND_USER: UserCredentials = {
 };
 
 const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8889';
+const USE_TEST_WS_PROVIDER = process.env.GUTENBERG_RTC_TEST_WS_PROVIDER === '1';
 
 export default class CollaborationUtils {
 	private admin: Admin;
@@ -97,6 +98,9 @@ export default class CollaborationUtils {
 	): Promise< { page: Page; editor: Editor } > {
 		const context = await this.admin.browser.newContext( {
 			baseURL: BASE_URL,
+			...( USE_TEST_WS_PROVIDER
+				? { storageState: { cookies: [], origins: [] } }
+				: {} ),
 		} );
 		const newPage = await context.newPage();
 
@@ -150,15 +154,79 @@ export default class CollaborationUtils {
 		const pages = this.allPages;
 		const resolvedTimeout = timeout ?? 10000 + pages.length * 2500;
 
+		if ( USE_TEST_WS_PROVIDER ) {
+			const roomName = await this.getCurrentPostRoomName(
+				this.primaryPage
+			);
+			await Promise.all(
+				pages.map( ( pg ) =>
+					this.waitForTestWebSocketAwarenessPeerCount(
+						pg,
+						pages.length,
+						resolvedTimeout,
+						roomName
+					)
+				)
+			);
+		} else {
+			await Promise.all(
+				pages.map( ( pg ) =>
+					pg
+						.getByRole( 'button', {
+							name: /Collaborators list/,
+						} )
+						.waitFor( { timeout: resolvedTimeout } )
+				)
+			);
+		}
+
 		await Promise.all(
 			pages.map( ( pg ) =>
-				pg
-					.getByRole( 'button', { name: /Collaborators list/ } )
-					.waitFor( { timeout: resolvedTimeout } )
+				this.waitForSyncCycle( pg, 3, { timeout: resolvedTimeout } )
 			)
 		);
+	}
 
-		await Promise.all( pages.map( ( pg ) => this.waitForSyncCycle( pg ) ) );
+	async waitForTestWebSocketAwarenessPeerCount(
+		page: Page,
+		expectedPeerCount: number,
+		timeout: number,
+		roomName?: string
+	) {
+		await page.waitForFunction(
+			( { expected, room }: { expected: number; room?: string } ) => {
+				const state = ( window as any ).__gutenbergTestWebSocketSync;
+				const rooms = state?.rooms ?? {};
+				const matchingRoom = room
+					? rooms[ room ]
+					: Object.values( rooms ).find(
+							( candidate: any ) =>
+								candidate?.awarenessCount >= expected
+					  );
+
+				return (
+					matchingRoom?.status === 'connected' &&
+					matchingRoom?.awarenessCount >= expected
+				);
+			},
+			{ expected: expectedPeerCount, room: roomName },
+			{ timeout }
+		);
+	}
+
+	async getCurrentPostRoomName( page: Page ): Promise< string > {
+		const postId = await page.evaluate(
+			() =>
+				( window as any ).wp?.data
+					?.select( 'core/editor' )
+					?.getCurrentPostId?.()
+		);
+
+		if ( ! postId ) {
+			throw new Error( 'Current post ID is unavailable.' );
+		}
+
+		return `postType/post:${ postId }`;
 	}
 
 	/**
@@ -323,6 +391,22 @@ export default class CollaborationUtils {
 		cycles = 3,
 		{ timeout = 10000 }: { timeout?: number } = {}
 	) {
+		if ( USE_TEST_WS_PROVIDER ) {
+			await page.waitForFunction(
+				() => {
+					const state = ( window as any )
+						.__gutenbergTestWebSocketSync;
+					const rooms = Object.values( state?.rooms ?? {} );
+					return rooms.some(
+						( room: any ) => room?.status === 'connected'
+					);
+				},
+				undefined,
+				{ timeout }
+			);
+			return;
+		}
+
 		for ( let i = 0; i < cycles; i++ ) {
 			await page.waitForResponse(
 				( response ) =>

--- a/test/e2e/specs/editor/collaboration/websocket/README.md
+++ b/test/e2e/specs/editor/collaboration/websocket/README.md
@@ -1,0 +1,21 @@
+# RTC WebSocket E2E Tests
+
+This directory contains local-only WebSocket transport variants of the editor
+collaboration e2e tests in the parent directory. Each spec imports the matching
+HTTP-polling RTC spec; the dedicated Playwright config enables
+`GUTENBERG_RTC_TEST_WS_PROVIDER`, activates the test provider plugin, and starts
+`bin/rtc-test-ws-sync-server.mjs`.
+
+Run them locally with:
+
+```sh
+npm run test:e2e:rtc-websocket
+```
+
+The config starts a fresh server on `ws://127.0.0.1:18991` by default. Set
+`GUTENBERG_RTC_TEST_WS_REUSE_SERVER=1` only when intentionally reusing a
+manually started server on that port.
+
+The default e2e config ignores this directory, and
+`playwright.rtc-websocket.config.ts` fails by default when `CI` is set because
+the WebSocket transport is not expected to work in CI.

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-awareness-cursor-position.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-awareness-cursor-position.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-awareness-cursor-position.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-block-gauntlet.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-block-gauntlet.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-block-gauntlet.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-code-editor-performance.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-code-editor-performance.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-code-editor-performance.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-cursor-stability.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-cursor-stability.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-cursor-stability.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-document-size-lock.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-document-size-lock.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-document-size-lock.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-metabox-lock.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-metabox-lock.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-metabox-lock.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-multibyte.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-multibyte.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-multibyte.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-notes.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-notes.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-notes.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-persistence.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-persistence.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-persistence.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-presence.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-presence.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-presence.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-refresh.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-refresh.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-refresh.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-same-user-title-reload-loss.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-same-user-title-reload-loss.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from '../fixtures';
+import type { UserCredentials } from '../fixtures/collaboration-utils';
+import type CollaborationUtils from '../fixtures/collaboration-utils';
+
+const ADMIN_USER: UserCredentials = {
+	username: process.env.WP_USERNAME ?? 'admin',
+	email: 'wordpress@example.com',
+	firstName: 'Admin',
+	lastName: 'User',
+	password: process.env.WP_PASSWORD ?? 'password',
+	roles: [ 'administrator' ],
+};
+
+async function waitForSameUserSession(
+	collaborationUtils: CollaborationUtils
+) {
+	await Promise.all(
+		collaborationUtils.allPages.map( ( page ) =>
+			collaborationUtils.waitForEntityReadyAndSaveSettled( page, {
+				timeout: 20_000,
+			} )
+		)
+	);
+	await Promise.all(
+		collaborationUtils.allPages.map( ( page ) =>
+			collaborationUtils.waitForSyncCycle( page, 2, { timeout: 20_000 } )
+		)
+	);
+}
+
+async function getEditedTitle( page: {
+	evaluate: < T >( callback: () => T ) => Promise< T >;
+} ): Promise< string > {
+	return page.evaluate( () =>
+		( window as any ).wp.data
+			.select( 'core/editor' )
+			.getEditedPostAttribute( 'title' )
+	);
+}
+
+test.describe( 'Collaboration - same-user title reload loss', () => {
+	test( 'keeps an unsaved same-user title in a reloaded browser session', async ( {
+		collaborationUtils,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		test.setTimeout( 90_000 );
+
+		const customerTitle = 'RTC same-user unsaved title before reload';
+
+		const post = await requestUtils.createPost( {
+			title: 'RTC same-user reload initial',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+			content:
+				'<!-- wp:paragraph --><p>Initial body.</p><!-- /wp:paragraph -->',
+		} );
+
+		await collaborationUtils.openPost( post.id );
+		await collaborationUtils.joinUser( post.id, ADMIN_USER );
+		await waitForSameUserSession( collaborationUtils );
+		const { editor2, page2 } = collaborationUtils;
+
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( customerTitle );
+		await expect
+			.poll( () => getEditedTitle( page2 ), { timeout: 20_000 } )
+			.toBe( customerTitle );
+
+		await editor2.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.click();
+		await page2.keyboard.press( 'End' );
+		await page2.keyboard.press( 'Enter' );
+		await page2.keyboard.type( 'same user reload companion edit' );
+
+		await page2.reload( { waitUntil: 'domcontentloaded' } );
+		await waitForSameUserSession( collaborationUtils );
+
+		await expect
+			.poll( () => getEditedTitle( page2 ), { timeout: 20_000 } )
+			.toBe( customerTitle );
+		expect( await getEditedTitle( page ) ).toBe( customerTitle );
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-selection.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-selection.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-selection.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-self-presence.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-self-presence.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-self-presence.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-stress.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-stress.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-stress.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-sync-error-filter.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-sync-error-filter.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-sync-error-filter.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-sync.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-sync.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-sync.spec';

--- a/test/e2e/specs/editor/collaboration/websocket/collaboration-undo-redo.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket/collaboration-undo-redo.spec.ts
@@ -1,0 +1,1 @@
+import '../collaboration-undo-redo.spec';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

This is part of an AI fuzzing project, where an AI wrote a fuzzer and then triages bugs from the fuzzer and creates fixes. See #77716 for the tracking issue.

## What?

This ports existing RTC e2e tests to use WebSockets and adds an additional test.

## Why?

I tried adding WebSockets support to the #77716 fuzzer because the world's largest deployment of Gutenberg RTC uses WebSockets. On adding WS support, the fuzzer immediately found what appear to be a large number of distinct bugs. Users are reporting issues and some of the bugs the fuzzer turned up have symptoms that are very similar to issues users have reported. It's likely that some of the bugs that are turned up are issues users are seeing (although we can't tell for sure with the instrumentation we have).

I then tried porting (that is, had my AI agent port) the existing HTTP e2e tests to WS and found that two failed. On applying all outstanding fixes from #77716, this fixed 1.95 of the tests (one test would fail 1 in 20 times in what seems to be a real failure that's non-determinstic for timing reasons).

I'd like to a submit a PR to fix the bug causing that failure, but I think it makes sense to have all of these tests available to run and this is a large enough diff that, although I don't know what the standards/norms are for Gutenberg, my inclination would be to split it out into a separate diff and then have that PR fix this PR.

These tests do not attempt to run in CI because I'm presuming there's some kind of "Chesterton's Fence" reason we don't have WS RTC support in CI today. If that's an incorrect assumption, this PR could be modified to try to run WS tests in CI. I don't know if WS is blocked in CI, but Storybook CI seems to run a TCP server and talk to it and WS runs over TCP, so it seems like it should be do-able?

## Testing Instructions

```
npm run test:e2e:rtc-websocket
```

Setup, if necessary:

```
  npm install
  composer install
  npm run wp-env status
  npm run wp-env start   # only if wp-env is not already running
  npm run build
```

Run non-determistically failing test many times:

```
  npm run test:e2e:rtc-websocket -- --project=chromium \
    test/e2e/specs/editor/collaboration/websocket/collaboration-same-user-title-reload-loss.spec.ts \
    test/e2e/specs/editor/collaboration/websocket/collaboration-stress.spec.ts \
    --grep "keeps an unsaved same-user title|two users concurrently move list items" \
    --repeat-each=50
```

As noted above, this PR is test only and doesn't include the fix for the e2e WS tests, so these tests are expected to fail.

## Use of AI Tools

As noted above, this is an AI generated PR for an AI fuzzing project.