### PR TITLE
Move Layout panel into styles tab so it sits next to Dimensions

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -60,6 +60,7 @@ function StyleInspectorSlots( {
 				group="typography"
 				label={ __( 'Typography' ) }
 			/>
+			<InspectorControls.Slot group="layout" />
 			<InspectorControls.Slot
 				group="dimensions"
 				label={ __( 'Dimensions' ) }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -46,11 +46,6 @@ function StyleInspectorSlots( {
 	return (
 		<>
 			<InspectorControls.Slot />
-			<InspectorControls.Slot group="layout" label={ __( 'Layout' ) } />
-			<InspectorControls.Slot
-				group="dimensions"
-				label={ __( 'Dimensions' ) }
-			/>
 			<InspectorControls.Slot
 				group="color"
 				label={ __( 'Color' ) }
@@ -64,6 +59,11 @@ function StyleInspectorSlots( {
 			<InspectorControls.Slot
 				group="typography"
 				label={ __( 'Typography' ) }
+			/>
+			<InspectorControls.Slot group="layout" label={ __( 'Layout' ) } />
+			<InspectorControls.Slot
+				group="dimensions"
+				label={ __( 'Dimensions' ) }
 			/>
 			<InspectorControls.Slot group="border" label={ borderPanelLabel } />
 			{ showPositionControls && <PositionControls /> }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -61,13 +61,13 @@ function StyleInspectorSlots( {
 				label={ __( 'Typography' ) }
 			/>
 			<InspectorControls.Slot group="layout" label={ __( 'Layout' ) } />
+			{ showPositionControls && <PositionControls /> }
 			<InspectorControls.Slot
 				group="dimensions"
 				label={ __( 'Dimensions' ) }
 			/>
 			<InspectorControls.Slot group="border" label={ borderPanelLabel } />
 			<InspectorControls.Slot group="styles" />
-			{ showPositionControls && <PositionControls /> }
 			{ showBindingsControls && (
 				<InspectorControls.Slot group="bindings" />
 			) }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -46,6 +46,11 @@ function StyleInspectorSlots( {
 	return (
 		<>
 			<InspectorControls.Slot />
+			<InspectorControls.Slot group="layout" label={ __( 'Layout' ) } />
+			<InspectorControls.Slot
+				group="dimensions"
+				label={ __( 'Dimensions' ) }
+			/>
 			<InspectorControls.Slot
 				group="color"
 				label={ __( 'Color' ) }
@@ -60,13 +65,8 @@ function StyleInspectorSlots( {
 				group="typography"
 				label={ __( 'Typography' ) }
 			/>
-			<InspectorControls.Slot group="layout" label={ __( 'Layout' ) } />
-			{ showPositionControls && <PositionControls /> }
-			<InspectorControls.Slot
-				group="dimensions"
-				label={ __( 'Dimensions' ) }
-			/>
 			<InspectorControls.Slot group="border" label={ borderPanelLabel } />
+			{ showPositionControls && <PositionControls /> }
 			<InspectorControls.Slot group="styles" />
 			{ showBindingsControls && (
 				<InspectorControls.Slot group="bindings" />

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -60,7 +60,7 @@ function StyleInspectorSlots( {
 				group="typography"
 				label={ __( 'Typography' ) }
 			/>
-			<InspectorControls.Slot group="layout" />
+			<InspectorControls.Slot group="layout" label={ __( 'Layout' ) } />
 			<InspectorControls.Slot
 				group="dimensions"
 				label={ __( 'Dimensions' ) }

--- a/packages/block-editor/src/components/inspector-controls-tabs/settings-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/settings-tab.js
@@ -7,26 +7,20 @@ import { __experimentalUseSlotFills as useSlotFills } from '@wordpress/component
  * Internal dependencies
  */
 import AdvancedControls from './advanced-controls-panel';
-import PositionControls from './position-controls-panel';
 import { default as InspectorControls } from '../inspector-controls';
 import groups from '../inspector-controls/groups';
 
 const SettingsTab = ( { showAdvancedControls = false } ) => {
 	const defaultFills = useSlotFills( groups.default.name );
-	const positionFills = useSlotFills( groups.position.name );
 	const bindingsFills = useSlotFills( groups.bindings.name );
 
 	// Expand the advanced panel when there are no other fills
 	// in the settings tab.
-	const hasOtherFills =
-		!! defaultFills?.length ||
-		!! positionFills?.length ||
-		!! bindingsFills?.length;
+	const hasOtherFills = !! defaultFills?.length || !! bindingsFills?.length;
 
 	return (
 		<>
 			<InspectorControls.Slot />
-			<PositionControls />
 			<InspectorControls.Slot group="bindings" />
 			{ showAdvancedControls && (
 				<div>

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -95,7 +95,10 @@ const StylesTab = ( {
 						group="typography"
 						label={ __( 'Typography' ) }
 					/>
-					<InspectorControls.Slot group="layout" />
+					<InspectorControls.Slot
+						group="layout"
+						label={ __( 'Layout' ) }
+					/>
 					<InspectorControls.Slot
 						group="dimensions"
 						label={ __( 'Dimensions' ) }

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -95,6 +95,7 @@ const StylesTab = ( {
 						group="typography"
 						label={ __( 'Typography' ) }
 					/>
+					<InspectorControls.Slot group="layout" />
 					<InspectorControls.Slot
 						group="dimensions"
 						label={ __( 'Dimensions' ) }

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -82,14 +82,6 @@ const StylesTab = ( {
 			{ ! isSectionBlock && (
 				<>
 					<InspectorControls.Slot
-						group="layout"
-						label={ __( 'Layout' ) }
-					/>
-					<InspectorControls.Slot
-						group="dimensions"
-						label={ __( 'Dimensions' ) }
-					/>
-					<InspectorControls.Slot
 						group="color"
 						label={ __( 'Color' ) }
 						className="color-block-support-panel__inner-wrapper"
@@ -103,6 +95,14 @@ const StylesTab = ( {
 					<InspectorControls.Slot
 						group="typography"
 						label={ __( 'Typography' ) }
+					/>
+					<InspectorControls.Slot
+						group="layout"
+						label={ __( 'Layout' ) }
+					/>
+					<InspectorControls.Slot
+						group="dimensions"
+						label={ __( 'Dimensions' ) }
 					/>
 					<InspectorControls.Slot
 						group="border"

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -82,6 +82,14 @@ const StylesTab = ( {
 			{ ! isSectionBlock && (
 				<>
 					<InspectorControls.Slot
+						group="layout"
+						label={ __( 'Layout' ) }
+					/>
+					<InspectorControls.Slot
+						group="dimensions"
+						label={ __( 'Dimensions' ) }
+					/>
+					<InspectorControls.Slot
 						group="color"
 						label={ __( 'Color' ) }
 						className="color-block-support-panel__inner-wrapper"
@@ -97,18 +105,10 @@ const StylesTab = ( {
 						label={ __( 'Typography' ) }
 					/>
 					<InspectorControls.Slot
-						group="layout"
-						label={ __( 'Layout' ) }
-					/>
-					<PositionControls />
-					<InspectorControls.Slot
-						group="dimensions"
-						label={ __( 'Dimensions' ) }
-					/>
-					<InspectorControls.Slot
 						group="border"
 						label={ borderPanelLabel }
 					/>
+					<PositionControls />
 					<InspectorControls.Slot group="styles" />
 				</>
 			) }

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -9,6 +9,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import BlockStyles from '../block-styles';
 import InspectorControls from '../inspector-controls';
+import PositionControls from './position-controls-panel';
 import { useBorderPanelLabel } from '../../hooks/border';
 import { useBlockSettings } from '../../hooks/utils';
 import { store as blockEditorStore } from '../../store';
@@ -99,6 +100,7 @@ const StylesTab = ( {
 						group="layout"
 						label={ __( 'Layout' ) }
 					/>
+					<PositionControls />
 					<InspectorControls.Slot
 						group="dimensions"
 						label={ __( 'Dimensions' ) }

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -64,6 +64,7 @@ export default function useInspectorControlsTabs(
 		...( useSlotFills( borderGroup.name ) || [] ),
 		...( useSlotFills( colorGroup.name ) || [] ),
 		...( useSlotFills( layoutGroup.name ) || [] ),
+		...( useSlotFills( positionGroup.name ) || [] ),
 		...( useSlotFills( dimensionsGroup.name ) || [] ),
 		...( useSlotFills( stylesGroup.name ) || [] ),
 		...( useSlotFills( typographyGroup.name ) || [] ),
@@ -72,7 +73,7 @@ export default function useInspectorControlsTabs(
 	const hasStyleFills = styleFills.length;
 
 	// Settings Tab: If we don't have multiple tabs to display
-	// (i.e. both list view and styles), check only the default and position
+	// (i.e. both list view and styles), check only the default
 	// InspectorControls slots. If we have multiple tabs, we'll need to check
 	// the advanced controls slot as well to ensure they are rendered.
 	const advancedFills = [
@@ -82,7 +83,6 @@ export default function useInspectorControlsTabs(
 
 	const settingsFills = [
 		...( useSlotFills( defaultGroup.name ) || [] ),
-		...( useSlotFills( positionGroup.name ) || [] ),
 		...( hasListFills && hasStyleFills > 1 ? advancedFills : [] ),
 	];
 

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -41,6 +41,7 @@ export default function useInspectorControlsTabs(
 		color: colorGroup,
 		content: contentGroup,
 		default: defaultGroup,
+		layout: layoutGroup,
 		dimensions: dimensionsGroup,
 		list: listGroup,
 		position: positionGroup,
@@ -62,6 +63,7 @@ export default function useInspectorControlsTabs(
 	const styleFills = [
 		...( useSlotFills( borderGroup.name ) || [] ),
 		...( useSlotFills( colorGroup.name ) || [] ),
+		...( useSlotFills( layoutGroup.name ) || [] ),
 		...( useSlotFills( dimensionsGroup.name ) || [] ),
 		...( useSlotFills( stylesGroup.name ) || [] ),
 		...( useSlotFills( typographyGroup.name ) || [] ),

--- a/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
@@ -16,6 +16,7 @@ export default function BlockSupportToolsPanel( { children, group, label } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const {
 		getBlockAttributes,
+		getBlockName,
 		getMultiSelectedBlockClientIds,
 		getSelectedBlockClientId,
 		hasMultiSelection,
@@ -31,13 +32,19 @@ export default function BlockSupportToolsPanel( { children, group, label } ) {
 				: [ panelId ];
 
 			clientIds.forEach( ( clientId ) => {
-				const { style } = getBlockAttributes( clientId );
+				const blockAttributes = getBlockAttributes( clientId ) || {};
+				const { style } = blockAttributes;
 				let newBlockAttributes = { style };
+				const resetContext = {
+					attributes: blockAttributes,
+					clientId,
+					name: getBlockName( clientId ),
+				};
 
 				resetFilters.forEach( ( resetFilter ) => {
 					newBlockAttributes = {
 						...newBlockAttributes,
-						...resetFilter( newBlockAttributes ),
+						...resetFilter( newBlockAttributes, resetContext ),
 					};
 				} );
 
@@ -54,6 +61,7 @@ export default function BlockSupportToolsPanel( { children, group, label } ) {
 		},
 		[
 			getBlockAttributes,
+			getBlockName,
 			getMultiSelectedBlockClientIds,
 			hasMultiSelection,
 			panelId,

--- a/packages/block-editor/src/components/inspector-controls/groups.js
+++ b/packages/block-editor/src/components/inspector-controls/groups.js
@@ -15,6 +15,7 @@ const InspectorControlsFilter = createSlotFill( 'InspectorControlsFilter' );
 const InspectorControlsDimensions = createSlotFill(
 	'InspectorControlsDimensions'
 );
+const InspectorControlsLayout = createSlotFill( 'InspectorControlsLayout' );
 const InspectorControlsPosition = createSlotFill( 'InspectorControlsPosition' );
 const InspectorControlsTypography = createSlotFill(
 	'InspectorControlsTypography'
@@ -35,6 +36,7 @@ const groups = {
 	dimensions: InspectorControlsDimensions,
 	effects: InspectorControlsEffects,
 	filter: InspectorControlsFilter,
+	layout: InspectorControlsLayout,
 	list: InspectorControlsListView,
 	position: InspectorControlsPosition,
 	settings: InspectorControlsDefault, // Alias for default.

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -242,8 +242,7 @@ function LayoutPanelPure( {
 		setAttributes( { layout: { type: 'default' } } );
 	const isUsingContentWidth = () =>
 		layoutType?.name === 'constrained' || hasContentSizeOrLegacySettings;
-	const hasInheritToggleValue = () =>
-		!! ( layout?.type || layout?.inherit || layout?.contentSize );
+	const hasInheritToggleValue = () => layout?.type === 'constrained';
 	const hasLayoutTypeValue = () => !! layout?.type;
 
 	return (

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -18,7 +18,7 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	ToggleControl,
-	PanelBody,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -32,7 +32,7 @@ import { useSettings } from '../components/use-settings';
 import { getLayoutType, getLayoutTypes } from '../layouts';
 import { useBlockEditingMode } from '../components/block-editing-mode';
 import { LAYOUT_DEFINITIONS } from '../layouts/definitions';
-import { useBlockSettings, useStyleOverride } from './utils';
+import { cleanEmptyObject, useBlockSettings, useStyleOverride } from './utils';
 import { unlock } from '../lock-unlock';
 import { globalStylesDataKey } from '../store/private-keys';
 import { getVariationNameFromClass } from './block-style-variation';
@@ -41,6 +41,7 @@ const VARIATION_PREFIX = 'is-style-';
 
 const layoutBlockSupportKey = 'layout';
 const { kebabCase } = unlock( componentsPrivateApis );
+const resetLayoutFilter = () => ( { layout: undefined } );
 
 function hasLayoutBlockSupport( blockName ) {
 	return (
@@ -235,72 +236,90 @@ function LayoutPanelPure( {
 	const onChangeType = ( newType ) =>
 		setAttributes( { layout: { type: newType } } );
 	const onChangeLayout = ( newLayout ) =>
-		setAttributes( { layout: newLayout } );
+		setAttributes( { layout: cleanEmptyObject( newLayout ) } );
+	const resetLayout = () => setAttributes( { layout: undefined } );
+	const resetInheritToggle = () =>
+		setAttributes( { layout: { type: 'default' } } );
+	const isUsingContentWidth = () =>
+		layoutType?.name === 'constrained' || hasContentSizeOrLegacySettings;
+	const hasInheritToggleValue = () =>
+		!! ( layout?.type || layout?.inherit || layout?.contentSize );
+	const hasLayoutTypeValue = () => !! layout?.type;
 
 	return (
 		<>
-			<InspectorControls group="layout">
-				<PanelBody title={ __( 'Layout' ) }>
-					{ showInheritToggle && (
-						<>
-							<ToggleControl
-								label={ __( 'Inner blocks use content width' ) }
-								checked={
-									layoutType?.name === 'constrained' ||
-									hasContentSizeOrLegacySettings
-								}
-								onChange={ () =>
-									setAttributes( {
-										layout: {
-											type:
-												layoutType?.name ===
-													'constrained' ||
-												hasContentSizeOrLegacySettings
-													? 'default'
-													: 'constrained',
-										},
-									} )
-								}
-								help={
-									layoutType?.name === 'constrained' ||
-									hasContentSizeOrLegacySettings
-										? __(
-												'Nested blocks use content width with options for full and wide widths.'
-										  )
-										: __(
-												'Nested blocks will fill the width of this container.'
-										  )
-								}
-							/>
-						</>
-					) }
+			<InspectorControls
+				group="layout"
+				resetAllFilter={ resetLayoutFilter }
+			>
+				{ showInheritToggle && (
+					<ToolsPanelItem
+						label={ __( 'Inner blocks use content width' ) }
+						hasValue={ hasInheritToggleValue }
+						onDeselect={ resetInheritToggle }
+						isShownByDefault
+						panelId={ clientId }
+					>
+						<ToggleControl
+							label={ __( 'Inner blocks use content width' ) }
+							checked={ isUsingContentWidth() }
+							onChange={ () =>
+								setAttributes( {
+									layout: {
+										type: isUsingContentWidth()
+											? 'default'
+											: 'constrained',
+									},
+								} )
+							}
+							help={
+								isUsingContentWidth()
+									? __(
+											'Nested blocks use content width with options for full and wide widths.'
+									  )
+									: __(
+											'Nested blocks will fill the width of this container.'
+									  )
+							}
+						/>
+					</ToolsPanelItem>
+				) }
 
-					{ ! inherit && allowSwitching && (
+				{ ! inherit && allowSwitching && (
+					<ToolsPanelItem
+						label={ __( 'Layout type' ) }
+						hasValue={ hasLayoutTypeValue }
+						onDeselect={ resetLayout }
+						isShownByDefault
+						panelId={ clientId }
+					>
 						<LayoutTypeSwitcher
 							type={ blockLayoutType }
 							onChange={ onChangeType }
 						/>
-					) }
+					</ToolsPanelItem>
+				) }
 
-					{ layoutType && layoutType.name !== 'default' && (
-						<layoutType.inspectorControls
-							layout={ usedLayout }
-							onChange={ onChangeLayout }
-							layoutBlockSupport={ blockSupportAndThemeSettings }
-							name={ blockName }
-							clientId={ clientId }
-						/>
-					) }
-					{ constrainedType && displayControlsForLegacyLayouts && (
-						<constrainedType.inspectorControls
-							layout={ usedLayout }
-							onChange={ onChangeLayout }
-							layoutBlockSupport={ blockSupportAndThemeSettings }
-							name={ blockName }
-							clientId={ clientId }
-						/>
-					) }
-				</PanelBody>
+				{ layoutType && layoutType.name !== 'default' && (
+					<layoutType.inspectorControls
+						layout={ usedLayout }
+						value={ layout }
+						onChange={ onChangeLayout }
+						layoutBlockSupport={ blockSupportAndThemeSettings }
+						name={ blockName }
+						clientId={ clientId }
+					/>
+				) }
+				{ constrainedType && displayControlsForLegacyLayouts && (
+					<constrainedType.inspectorControls
+						layout={ usedLayout }
+						value={ layout }
+						onChange={ onChangeLayout }
+						layoutBlockSupport={ blockSupportAndThemeSettings }
+						name={ blockName }
+						clientId={ clientId }
+					/>
+				) }
 			</InspectorControls>
 			{ ! inherit && layoutType && (
 				<layoutType.toolBarControls

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -43,28 +43,23 @@ const VARIATION_PREFIX = 'is-style-';
 const layoutBlockSupportKey = 'layout';
 const { kebabCase } = unlock( componentsPrivateApis );
 
-export function getResetLayout(
-	layoutBlockSupport = {},
-	blockVariation,
-	currentLayout = {}
-) {
-	const defaultBlockLayout =
-		layoutBlockSupport && typeof layoutBlockSupport === 'object'
-			? layoutBlockSupport.default
-			: undefined;
-	const resetLayout =
-		blockVariation?.attributes?.layout ?? defaultBlockLayout;
-	const resetLayoutWithoutType = resetLayout
-		? Object.fromEntries(
-				Object.entries( resetLayout ).filter(
-					( [ key ] ) => key !== 'type'
-				)
-		  )
-		: {};
+function getDefaultLayout( layoutBlockSupport = {}, blockVariation ) {
+	const defaultBlockLayout = layoutBlockSupport?.default;
 
+	return blockVariation?.attributes?.layout ?? defaultBlockLayout;
+}
+
+/**
+ * Returns the layout values to use when resetting layout controls.
+ *
+ * @param { Object }           layoutBlockSupport Block layout support settings.
+ * @param { Object|undefined } blockVariation     Block variation settings.
+ *
+ * @return { Object|undefined } Reset layout values.
+ */
+export function getResetLayout( layoutBlockSupport = {}, blockVariation ) {
 	return cleanEmptyObject( {
-		...resetLayoutWithoutType,
-		type: currentLayout?.type,
+		...getDefaultLayout( layoutBlockSupport, blockVariation ),
 	} );
 }
 
@@ -183,38 +178,43 @@ function LayoutPanelPure( {
 	const settings = useBlockSettings( blockName );
 	// Block settings come from theme.json under settings.[blockName].
 	const { layout: layoutSettings } = settings;
-	const { themeSupportsLayout } = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		return {
-			themeSupportsLayout: getSettings().supportsLayout,
-		};
-	}, [] );
-	const { getActiveBlockVariation } = useSelect( blocksStore );
+	const { themeSupportsLayout, activeBlockVariation } = useSelect(
+		( select ) => {
+			const { getBlockAttributes, getSettings } =
+				select( blockEditorStore );
+			return {
+				activeBlockVariation: select(
+					blocksStore
+				).getActiveBlockVariation(
+					blockName,
+					getBlockAttributes( clientId ) || {},
+					'block'
+				),
+				themeSupportsLayout: getSettings().supportsLayout,
+			};
+		},
+		[ blockName, clientId ]
+	);
+
 	const blockEditingMode = useBlockEditingMode();
 	const resetLayoutFilter = useCallback(
-		( attributes = {}, context = {} ) => {
+		( ...resetArgs ) => {
+			const context = resetArgs[ 1 ] || {};
 			const resetBlockName = context.name || blockName;
-			const resetBlockAttributes = context.attributes || attributes;
 			const resetLayoutBlockSupport = getBlockSupport(
 				resetBlockName,
 				layoutBlockSupportKey,
 				{}
 			);
-			const activeBlockVariation = getActiveBlockVariation(
-				resetBlockName,
-				resetBlockAttributes,
-				'block'
-			);
 
 			return {
 				layout: getResetLayout(
 					resetLayoutBlockSupport,
-					activeBlockVariation,
-					resetBlockAttributes.layout
+					activeBlockVariation
 				),
 			};
 		},
-		[ blockName, getActiveBlockVariation ]
+		[ blockName, activeBlockVariation ]
 	);
 
 	if ( blockEditingMode !== 'default' ) {
@@ -278,6 +278,13 @@ function LayoutPanelPure( {
 	) {
 		return null;
 	}
+	const defaultLayout = cleanEmptyObject( {
+		...getDefaultLayout( layoutBlockSupport, activeBlockVariation ),
+	} );
+	const resetLayoutDefaults = getResetLayout(
+		layoutBlockSupport,
+		activeBlockVariation
+	);
 	const layoutType = getLayoutType( blockLayoutType );
 	const constrainedType = getLayoutType( 'constrained' );
 	const displayControlsForLegacyLayouts =
@@ -288,13 +295,15 @@ function LayoutPanelPure( {
 		setAttributes( { layout: { type: newType } } );
 	const onChangeLayout = ( newLayout ) =>
 		setAttributes( { layout: cleanEmptyObject( newLayout ) } );
-	const resetLayout = () => setAttributes( { layout: undefined } );
+	const resetLayout = () => setAttributes( { layout: defaultLayout } );
 	const resetInheritToggle = () =>
 		setAttributes( { layout: { type: 'default' } } );
 	const isUsingContentWidth = () =>
 		layoutType?.name === 'constrained' || hasContentSizeOrLegacySettings;
 	const hasInheritToggleValue = () => layout?.type === 'constrained';
-	const hasLayoutTypeValue = () => !! layout?.type;
+	const hasLayoutTypeValue = () =>
+		( usedLayout?.type ?? 'default' ) !==
+		( defaultLayout?.type ?? 'default' );
 
 	return (
 		<>
@@ -356,6 +365,7 @@ function LayoutPanelPure( {
 						value={ layout }
 						onChange={ onChangeLayout }
 						layoutBlockSupport={ blockSupportAndThemeSettings }
+						resetLayout={ resetLayoutDefaults }
 						name={ blockName }
 						clientId={ clientId }
 					/>
@@ -366,6 +376,7 @@ function LayoutPanelPure( {
 						value={ layout }
 						onChange={ onChangeLayout }
 						layoutBlockSupport={ blockSupportAndThemeSettings }
+						resetLayout={ resetLayoutDefaults }
 						name={ blockName }
 						clientId={ clientId }
 					/>

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -253,7 +253,7 @@ function LayoutPanelPure( {
 			>
 				{ showInheritToggle && (
 					<ToolsPanelItem
-						label={ __( 'Inner blocks use content width' ) }
+						label={ __( 'Use content width' ) }
 						hasValue={ hasInheritToggleValue }
 						onDeselect={ resetInheritToggle }
 						isShownByDefault

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -8,6 +8,7 @@ import clsx from 'clsx';
  */
 import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
+import { useCallback } from '@wordpress/element';
 import {
 	getBlockSupport,
 	hasBlockSupport,
@@ -41,7 +42,31 @@ const VARIATION_PREFIX = 'is-style-';
 
 const layoutBlockSupportKey = 'layout';
 const { kebabCase } = unlock( componentsPrivateApis );
-const resetLayoutFilter = () => ( { layout: undefined } );
+
+export function getResetLayout(
+	layoutBlockSupport = {},
+	blockVariation,
+	currentLayout = {}
+) {
+	const defaultBlockLayout =
+		layoutBlockSupport && typeof layoutBlockSupport === 'object'
+			? layoutBlockSupport.default
+			: undefined;
+	const resetLayout =
+		blockVariation?.attributes?.layout ?? defaultBlockLayout;
+	const resetLayoutWithoutType = resetLayout
+		? Object.fromEntries(
+				Object.entries( resetLayout ).filter(
+					( [ key ] ) => key !== 'type'
+				)
+		  )
+		: {};
+
+	return cleanEmptyObject( {
+		...resetLayoutWithoutType,
+		type: currentLayout?.type,
+	} );
+}
 
 function hasLayoutBlockSupport( blockName ) {
 	return (
@@ -164,7 +189,33 @@ function LayoutPanelPure( {
 			themeSupportsLayout: getSettings().supportsLayout,
 		};
 	}, [] );
+	const { getActiveBlockVariation } = useSelect( blocksStore );
 	const blockEditingMode = useBlockEditingMode();
+	const resetLayoutFilter = useCallback(
+		( attributes = {}, context = {} ) => {
+			const resetBlockName = context.name || blockName;
+			const resetBlockAttributes = context.attributes || attributes;
+			const resetLayoutBlockSupport = getBlockSupport(
+				resetBlockName,
+				layoutBlockSupportKey,
+				{}
+			);
+			const activeBlockVariation = getActiveBlockVariation(
+				resetBlockName,
+				resetBlockAttributes,
+				'block'
+			);
+
+			return {
+				layout: getResetLayout(
+					resetLayoutBlockSupport,
+					activeBlockVariation,
+					resetBlockAttributes.layout
+				),
+			};
+		},
+		[ blockName, getActiveBlockVariation ]
+	);
 
 	if ( blockEditingMode !== 'default' ) {
 		return null;

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -239,7 +239,7 @@ function LayoutPanelPure( {
 
 	return (
 		<>
-			<InspectorControls>
+			<InspectorControls group="layout">
 				<PanelBody title={ __( 'Layout' ) }>
 					{ showInheritToggle && (
 						<>

--- a/packages/block-editor/src/hooks/layout.scss
+++ b/packages/block-editor/src/hooks/layout.scss
@@ -13,6 +13,12 @@
 	margin-bottom: 0; // Cancel out margins added by common.css
 }
 
+.layout-block-support-panel {
+	.block-editor-hooks__flex-layout-controls {
+		grid-column: 1 / -1;
+	}
+}
+
 .block-editor-hooks__flex-layout-justification-controls,
 .block-editor-hooks__flex-layout-orientation-controls {
 	margin-bottom: $grid-unit-15;

--- a/packages/block-editor/src/hooks/test/layout.js
+++ b/packages/block-editor/src/hooks/test/layout.js
@@ -1,0 +1,58 @@
+/**
+ * Internal dependencies
+ */
+import { getResetLayout } from '../layout';
+
+describe( 'layout', () => {
+	describe( 'getResetLayout()', () => {
+		it( 'should reset to variation layout defaults without resetting the current layout type', () => {
+			const layout = getResetLayout(
+				{ default: { type: 'flex' } },
+				{
+					attributes: {
+						layout: {
+							type: 'grid',
+							columnCount: 3,
+						},
+					},
+				},
+				{ type: 'flex', columnCount: 6 }
+			);
+
+			expect( layout ).toEqual( {
+				type: 'flex',
+				columnCount: 3,
+			} );
+		} );
+
+		it( 'should fall back to the block support layout defaults without resetting the current layout type', () => {
+			const layout = getResetLayout(
+				{
+					default: {
+						type: 'flex',
+						flexWrap: 'nowrap',
+					},
+				},
+				undefined,
+				{ type: 'grid', flexWrap: 'wrap' }
+			);
+
+			expect( layout ).toEqual( {
+				type: 'grid',
+				flexWrap: 'nowrap',
+			} );
+		} );
+
+		it( 'should preserve the current layout type when there is no layout config', () => {
+			expect(
+				getResetLayout( undefined, undefined, { type: 'flex' } )
+			).toEqual( {
+				type: 'flex',
+			} );
+		} );
+
+		it( 'should return undefined when there is no layout config', () => {
+			expect( getResetLayout() ).toBeUndefined();
+		} );
+	} );
+} );

--- a/packages/block-editor/src/hooks/test/layout.js
+++ b/packages/block-editor/src/hooks/test/layout.js
@@ -5,7 +5,7 @@ import { getResetLayout } from '../layout';
 
 describe( 'layout', () => {
 	describe( 'getResetLayout()', () => {
-		it( 'should reset to variation layout defaults without resetting the current layout type', () => {
+		it( 'should reset to variation layout defaults', () => {
 			const layout = getResetLayout(
 				{ default: { type: 'flex' } },
 				{
@@ -15,17 +15,16 @@ describe( 'layout', () => {
 							columnCount: 3,
 						},
 					},
-				},
-				{ type: 'flex', columnCount: 6 }
+				}
 			);
 
 			expect( layout ).toEqual( {
-				type: 'flex',
+				type: 'grid',
 				columnCount: 3,
 			} );
 		} );
 
-		it( 'should fall back to the block support layout defaults without resetting the current layout type', () => {
+		it( 'should fall back to the block support layout defaults', () => {
 			const layout = getResetLayout(
 				{
 					default: {
@@ -33,21 +32,12 @@ describe( 'layout', () => {
 						flexWrap: 'nowrap',
 					},
 				},
-				undefined,
-				{ type: 'grid', flexWrap: 'wrap' }
+				undefined
 			);
 
 			expect( layout ).toEqual( {
-				type: 'grid',
-				flexWrap: 'nowrap',
-			} );
-		} );
-
-		it( 'should preserve the current layout type when there is no layout config', () => {
-			expect(
-				getResetLayout( undefined, undefined, { type: 'flex' } )
-			).toEqual( {
 				type: 'flex',
+				flexWrap: 'nowrap',
 			} );
 		} );
 

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -7,7 +7,7 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
-	__experimentalVStack as VStack,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
@@ -27,7 +27,7 @@ import { useSettings } from '../components/use-settings';
 import { appendSelectors, getBlockGapCSS, getAlignmentsInfo } from './utils';
 import { getGapCSSValue } from '../hooks/gap';
 import { BlockControls, JustifyContentControl } from '../components';
-import { shouldSkipSerialization } from '../hooks/utils';
+import { cleanEmptyObject, shouldSkipSerialization } from '../hooks/utils';
 import { LAYOUT_DEFINITIONS } from './definitions';
 
 export default {
@@ -35,8 +35,10 @@ export default {
 	label: __( 'Constrained' ),
 	inspectorControls: function DefaultLayoutInspectorControls( {
 		layout,
+		value: savedLayout = {},
 		onChange,
 		layoutBlockSupport = {},
+		clientId,
 	} ) {
 		const { wideSize, contentSize, justifyContent = 'center' } = layout;
 		const {
@@ -70,92 +72,141 @@ export default {
 		const units = useCustomUnits( {
 			availableUnits: availableUnits || [ '%', 'px', 'em', 'rem', 'vw' ],
 		} );
+		const resetContentSize = () =>
+			onChange(
+				cleanEmptyObject( {
+					...layout,
+					contentSize: undefined,
+				} )
+			);
+		const resetWideSize = () =>
+			onChange(
+				cleanEmptyObject( {
+					...layout,
+					wideSize: undefined,
+				} )
+			);
+		const resetJustification = () =>
+			onChange(
+				cleanEmptyObject( {
+					...layout,
+					justifyContent: undefined,
+				} )
+			);
+		const hasContentSizeValue = () => !! savedLayout.contentSize;
+		const hasWideSizeValue = () => !! savedLayout.wideSize;
+		const hasJustificationValue = () =>
+			!! savedLayout.justifyContent &&
+			savedLayout.justifyContent !== 'center';
+
 		return (
-			<VStack
-				spacing={ 4 }
-				className="block-editor-hooks__layout-constrained"
-			>
+			<>
 				{ allowCustomContentAndWideSize && (
 					<>
-						<UnitControl
-							__next40pxDefaultSize
+						<ToolsPanelItem
 							label={ __( 'Content width' ) }
-							labelPosition="top"
-							value={ contentSize || wideSize || '' }
-							onChange={ ( nextWidth ) => {
-								nextWidth =
-									0 > parseFloat( nextWidth )
-										? '0'
-										: nextWidth;
-								onChange( {
-									...layout,
-									contentSize:
-										nextWidth !== ''
-											? nextWidth
-											: undefined,
-								} );
-							} }
-							units={ units }
-							prefix={
-								<InputControlPrefixWrapper variant="icon">
-									<Icon icon={ alignNone } />
-								</InputControlPrefixWrapper>
-							}
-						/>
-						<UnitControl
-							__next40pxDefaultSize
+							hasValue={ hasContentSizeValue }
+							onDeselect={ resetContentSize }
+							panelId={ clientId }
+						>
+							<UnitControl
+								__next40pxDefaultSize
+								label={ __( 'Content width' ) }
+								labelPosition="top"
+								value={ contentSize || wideSize || '' }
+								onChange={ ( nextWidth ) => {
+									nextWidth =
+										0 > parseFloat( nextWidth )
+											? '0'
+											: nextWidth;
+									onChange(
+										cleanEmptyObject( {
+											...layout,
+											contentSize:
+												nextWidth !== ''
+													? nextWidth
+													: undefined,
+										} )
+									);
+								} }
+								units={ units }
+								prefix={
+									<InputControlPrefixWrapper variant="icon">
+										<Icon icon={ alignNone } />
+									</InputControlPrefixWrapper>
+								}
+							/>
+						</ToolsPanelItem>
+						<ToolsPanelItem
 							label={ __( 'Wide width' ) }
-							labelPosition="top"
-							value={ wideSize || contentSize || '' }
-							onChange={ ( nextWidth ) => {
-								nextWidth =
-									0 > parseFloat( nextWidth )
-										? '0'
-										: nextWidth;
-								onChange( {
-									...layout,
-									wideSize:
-										nextWidth !== ''
-											? nextWidth
-											: undefined,
-								} );
-							} }
-							units={ units }
-							prefix={
-								<InputControlPrefixWrapper variant="icon">
-									<Icon icon={ stretchWide } />
-								</InputControlPrefixWrapper>
-							}
-						/>
-						<p className="block-editor-hooks__layout-constrained-helptext">
-							{ __(
-								'Customize the width for all elements that are assigned to the center or wide columns.'
-							) }
-						</p>
+							hasValue={ hasWideSizeValue }
+							onDeselect={ resetWideSize }
+							panelId={ clientId }
+						>
+							<UnitControl
+								__next40pxDefaultSize
+								label={ __( 'Wide width' ) }
+								labelPosition="top"
+								value={ wideSize || contentSize || '' }
+								onChange={ ( nextWidth ) => {
+									nextWidth =
+										0 > parseFloat( nextWidth )
+											? '0'
+											: nextWidth;
+									onChange(
+										cleanEmptyObject( {
+											...layout,
+											wideSize:
+												nextWidth !== ''
+													? nextWidth
+													: undefined,
+										} )
+									);
+								} }
+								units={ units }
+								prefix={
+									<InputControlPrefixWrapper variant="icon">
+										<Icon icon={ stretchWide } />
+									</InputControlPrefixWrapper>
+								}
+							/>
+							<p className="block-editor-hooks__layout-constrained-helptext">
+								{ __(
+									'Customize the width for all elements that are assigned to the center or wide columns.'
+								) }
+							</p>
+						</ToolsPanelItem>
 					</>
 				) }
 				{ allowJustification && (
-					<ToggleGroupControl
-						__next40pxDefaultSize
+					<ToolsPanelItem
 						label={ __( 'Justification' ) }
-						value={ justifyContent }
-						onChange={ onJustificationChange }
+						hasValue={ hasJustificationValue }
+						onDeselect={ resetJustification }
+						panelId={ clientId }
 					>
-						{ justificationOptions.map(
-							( { value, icon, label } ) => {
-								return (
-									<ToggleGroupControlOptionIcon
-										key={ value }
-										value={ value }
-										icon={ icon }
-										label={ label }
-									/>
-								);
-							}
-						) }
-					</ToggleGroupControl>
+						<ToggleGroupControl
+							__next40pxDefaultSize
+							label={ __( 'Justification' ) }
+							value={ justifyContent }
+							onChange={ onJustificationChange }
+						>
+							{ justificationOptions.map(
+								( { value, icon, label } ) => {
+									return (
+										<ToggleGroupControlOptionIcon
+											key={ value }
+											value={ value }
+											icon={ icon }
+											label={ label }
+										/>
+									);
+								}
+							) }
+						</ToggleGroupControl>
+					</ToolsPanelItem>
 				) }
-			</VStack>
+			</>
 		);
 	},
 	toolBarControls: function DefaultLayoutToolbarControls( {

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -35,9 +35,9 @@ export default {
 	label: __( 'Constrained' ),
 	inspectorControls: function DefaultLayoutInspectorControls( {
 		layout,
-		value: savedLayout = {},
 		onChange,
 		layoutBlockSupport = {},
+		resetLayout = {},
 		clientId,
 	} ) {
 		const { wideSize, contentSize, justifyContent = 'center' } = layout;
@@ -72,32 +72,34 @@ export default {
 		const units = useCustomUnits( {
 			availableUnits: availableUnits || [ '%', 'px', 'em', 'rem', 'vw' ],
 		} );
+		const hasLayoutValue = ( key, defaultValue ) =>
+			( layout?.[ key ] ?? defaultValue ) !==
+			( resetLayout?.[ key ] ?? defaultValue );
 		const resetContentSize = () =>
 			onChange(
 				cleanEmptyObject( {
 					...layout,
-					contentSize: undefined,
+					contentSize: resetLayout?.contentSize,
 				} )
 			);
 		const resetWideSize = () =>
 			onChange(
 				cleanEmptyObject( {
 					...layout,
-					wideSize: undefined,
+					wideSize: resetLayout?.wideSize,
 				} )
 			);
 		const resetJustification = () =>
 			onChange(
 				cleanEmptyObject( {
 					...layout,
-					justifyContent: undefined,
+					justifyContent: resetLayout?.justifyContent,
 				} )
 			);
-		const hasContentSizeValue = () => !! savedLayout.contentSize;
-		const hasWideSizeValue = () => !! savedLayout.wideSize;
+		const hasContentSizeValue = () => hasLayoutValue( 'contentSize' );
+		const hasWideSizeValue = () => hasLayoutValue( 'wideSize' );
 		const hasJustificationValue = () =>
-			!! savedLayout.justifyContent &&
-			savedLayout.justifyContent !== 'center';
+			hasLayoutValue( 'justifyContent', 'center' );
 
 		return (
 			<>

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -12,11 +12,11 @@ import {
 	arrowDown,
 } from '@wordpress/icons';
 import {
-	ToggleControl,
 	Flex,
-	FlexItem,
+	ToggleControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 
 /**
@@ -30,7 +30,7 @@ import {
 	JustifyContentControl,
 	BlockVerticalAlignmentControl,
 } from '../components';
-import { shouldSkipSerialization } from '../hooks/utils';
+import { cleanEmptyObject, shouldSkipSerialization } from '../hooks/utils';
 import { LAYOUT_DEFINITIONS } from './definitions';
 
 // Used with the default, horizontal flex orientation.
@@ -69,36 +69,105 @@ export default {
 	label: __( 'Flex' ),
 	inspectorControls: function FlexLayoutInspectorControls( {
 		layout = {},
+		value: savedLayout = {},
 		onChange,
 		layoutBlockSupport = {},
+		clientId,
 	} ) {
 		const {
 			allowOrientation = true,
 			allowJustification = true,
 			allowWrap = true,
 		} = layoutBlockSupport;
+		const hasJustificationValue = () =>
+			!! savedLayout.justifyContent &&
+			savedLayout.justifyContent !== 'left';
+		const hasOrientationValue = () =>
+			!! savedLayout.orientation &&
+			savedLayout.orientation !== 'horizontal';
+		const hasWrapValue = () => savedLayout.flexWrap === 'nowrap';
+		const resetJustification = () =>
+			onChange(
+				cleanEmptyObject( {
+					...layout,
+					justifyContent: undefined,
+				} )
+			);
+		const resetOrientation = () => {
+			const { verticalAlignment, justifyContent } = layout;
+			onChange(
+				cleanEmptyObject( {
+					...layout,
+					orientation: undefined,
+					verticalAlignment:
+						verticalAlignment === 'space-between'
+							? 'center'
+							: verticalAlignment,
+					justifyContent:
+						justifyContent === 'stretch' ? 'left' : justifyContent,
+				} )
+			);
+		};
+		const resetWrap = () =>
+			onChange(
+				cleanEmptyObject( {
+					...layout,
+					flexWrap: undefined,
+				} )
+			);
+
 		return (
 			<>
-				<Flex>
-					{ allowJustification && (
-						<FlexItem>
-							<FlexLayoutJustifyContentControl
-								layout={ layout }
-								onChange={ onChange }
-							/>
-						</FlexItem>
-					) }
-					{ allowOrientation && (
-						<FlexItem>
-							<OrientationControl
-								layout={ layout }
-								onChange={ onChange }
-							/>
-						</FlexItem>
-					) }
-				</Flex>
+				{ ( allowJustification || allowOrientation ) && (
+					<Flex
+						align="flex-start"
+						className="block-editor-hooks__flex-layout-controls"
+						gap={ 4 }
+						justify="flex-start"
+					>
+						{ allowJustification && (
+							<ToolsPanelItem
+								label={ __( 'Justification' ) }
+								hasValue={ hasJustificationValue }
+								onDeselect={ resetJustification }
+								isShownByDefault
+								panelId={ clientId }
+							>
+								<FlexLayoutJustifyContentControl
+									layout={ layout }
+									onChange={ onChange }
+								/>
+							</ToolsPanelItem>
+						) }
+						{ allowOrientation && (
+							<ToolsPanelItem
+								label={ __( 'Orientation' ) }
+								hasValue={ hasOrientationValue }
+								onDeselect={ resetOrientation }
+								isShownByDefault
+								panelId={ clientId }
+							>
+								<OrientationControl
+									layout={ layout }
+									onChange={ onChange }
+								/>
+							</ToolsPanelItem>
+						) }
+					</Flex>
+				) }
 				{ allowWrap && (
-					<FlexWrapControl layout={ layout } onChange={ onChange } />
+					<ToolsPanelItem
+						label={ __( 'Wrapping' ) }
+						hasValue={ hasWrapValue }
+						onDeselect={ resetWrap }
+						isShownByDefault
+						panelId={ clientId }
+					>
+						<FlexWrapControl
+							layout={ layout }
+							onChange={ onChange }
+						/>
+					</ToolsPanelItem>
 				) }
 			</>
 		);

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -69,9 +69,9 @@ export default {
 	label: __( 'Flex' ),
 	inspectorControls: function FlexLayoutInspectorControls( {
 		layout = {},
-		value: savedLayout = {},
 		onChange,
 		layoutBlockSupport = {},
+		resetLayout = {},
 		clientId,
 	} ) {
 		const {
@@ -79,32 +79,40 @@ export default {
 			allowJustification = true,
 			allowWrap = true,
 		} = layoutBlockSupport;
+		const hasLayoutValue = ( key, defaultValue ) =>
+			( layout?.[ key ] ?? defaultValue ) !==
+			( resetLayout?.[ key ] ?? defaultValue );
 		const hasJustificationValue = () =>
-			!! savedLayout.justifyContent &&
-			savedLayout.justifyContent !== 'left';
+			hasLayoutValue( 'justifyContent', 'left' );
 		const hasOrientationValue = () =>
-			!! savedLayout.orientation &&
-			savedLayout.orientation !== 'horizontal';
-		const hasWrapValue = () => savedLayout.flexWrap === 'nowrap';
+			hasLayoutValue( 'orientation', 'horizontal' );
+		const hasWrapValue = () => hasLayoutValue( 'flexWrap', 'wrap' );
 		const resetJustification = () =>
 			onChange(
 				cleanEmptyObject( {
 					...layout,
-					justifyContent: undefined,
+					justifyContent: resetLayout?.justifyContent,
 				} )
 			);
 		const resetOrientation = () => {
 			const { verticalAlignment, justifyContent } = layout;
+			const nextOrientation = resetLayout?.orientation;
+			const isHorizontal =
+				! nextOrientation || nextOrientation === 'horizontal';
 			onChange(
 				cleanEmptyObject( {
 					...layout,
-					orientation: undefined,
+					orientation: nextOrientation,
 					verticalAlignment:
-						verticalAlignment === 'space-between'
+						resetLayout?.verticalAlignment ??
+						( isHorizontal && verticalAlignment === 'space-between'
 							? 'center'
-							: verticalAlignment,
+							: verticalAlignment ),
 					justifyContent:
-						justifyContent === 'stretch' ? 'left' : justifyContent,
+						resetLayout?.justifyContent ??
+						( isHorizontal && justifyContent === 'stretch'
+							? 'left'
+							: justifyContent ),
 				} )
 			);
 		};
@@ -112,7 +120,7 @@ export default {
 			onChange(
 				cleanEmptyObject( {
 					...layout,
-					flexWrap: undefined,
+					flexWrap: resetLayout?.flexWrap,
 				} )
 			);
 

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -68,9 +68,9 @@ export default {
 	label: __( 'Grid' ),
 	inspectorControls: function GridLayoutInspectorControls( {
 		layout = {},
-		value: savedLayout = {},
 		onChange,
 		layoutBlockSupport = {},
+		resetLayout = {},
 		clientId,
 	} ) {
 		const { allowSizingOnChildren = false } = layoutBlockSupport;
@@ -82,35 +82,38 @@ export default {
 			! layout?.isManualPlacement ||
 			window.__experimentalEnableGridInteractivity;
 		const defaultColumnCount = layout.isManualPlacement ? 3 : undefined;
-		const hasGridTypeValue = () => !! savedLayout.isManualPlacement;
+		const hasLayoutValue = ( key, defaultValue ) =>
+			( layout?.[ key ] ?? defaultValue ) !==
+			( resetLayout?.[ key ] ?? defaultValue );
+		const hasGridTypeValue = () =>
+			hasLayoutValue( 'isManualPlacement', false );
 		const hasColumnsAndRowsValue = () =>
-			( savedLayout.columnCount !== undefined &&
-				savedLayout.columnCount !== defaultColumnCount ) ||
-			!! savedLayout.rowCount;
+			hasLayoutValue( 'columnCount', defaultColumnCount ) ||
+			hasLayoutValue( 'rowCount' );
 		const hasMinimumColumnWidthValue = () =>
-			!! savedLayout.minimumColumnWidth;
+			hasLayoutValue( 'minimumColumnWidth' );
 		const resetGridType = () =>
 			onChange(
 				cleanEmptyObject( {
 					...layout,
-					isManualPlacement: undefined,
-					rowCount: undefined,
-					minimumColumnWidth: undefined,
+					isManualPlacement: resetLayout?.isManualPlacement,
+					rowCount: resetLayout?.rowCount,
+					minimumColumnWidth: resetLayout?.minimumColumnWidth,
 				} )
 			);
 		const resetColumnsAndRows = () =>
 			onChange(
 				cleanEmptyObject( {
 					...layout,
-					columnCount: defaultColumnCount,
-					rowCount: undefined,
+					columnCount: resetLayout?.columnCount ?? defaultColumnCount,
+					rowCount: resetLayout?.rowCount,
 				} )
 			);
 		const resetMinimumColumnWidth = () =>
 			onChange(
 				cleanEmptyObject( {
 					...layout,
-					minimumColumnWidth: undefined,
+					minimumColumnWidth: resetLayout?.minimumColumnWidth,
 				} )
 			);
 

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -13,7 +13,7 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalUnitControl as UnitControl,
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
-	__experimentalVStack as VStack,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
@@ -23,7 +23,7 @@ import { useState } from '@wordpress/element';
 import { appendSelectors, getBlockGapCSS } from './utils';
 import { getGapCSSValue, getGapBoxControlValueFromStyle } from '../hooks/gap';
 import { getSpacingPresetCssVar } from '../components/spacing-sizes-control/utils';
-import { shouldSkipSerialization } from '../hooks/utils';
+import { cleanEmptyObject, shouldSkipSerialization } from '../hooks/utils';
 import { LAYOUT_DEFINITIONS } from './definitions';
 
 const RANGE_CONTROL_MAX_VALUES = {
@@ -68,8 +68,10 @@ export default {
 	label: __( 'Grid' ),
 	inspectorControls: function GridLayoutInspectorControls( {
 		layout = {},
+		value: savedLayout = {},
 		onChange,
 		layoutBlockSupport = {},
+		clientId,
 	} ) {
 		const { allowSizingOnChildren = false } = layoutBlockSupport;
 
@@ -79,29 +81,84 @@ export default {
 		const showMinWidthControl =
 			! layout?.isManualPlacement ||
 			window.__experimentalEnableGridInteractivity;
+		const defaultColumnCount = layout.isManualPlacement ? 3 : undefined;
+		const hasGridTypeValue = () => !! savedLayout.isManualPlacement;
+		const hasColumnsAndRowsValue = () =>
+			( savedLayout.columnCount !== undefined &&
+				savedLayout.columnCount !== defaultColumnCount ) ||
+			!! savedLayout.rowCount;
+		const hasMinimumColumnWidthValue = () =>
+			!! savedLayout.minimumColumnWidth;
+		const resetGridType = () =>
+			onChange(
+				cleanEmptyObject( {
+					...layout,
+					isManualPlacement: undefined,
+					rowCount: undefined,
+					minimumColumnWidth: undefined,
+				} )
+			);
+		const resetColumnsAndRows = () =>
+			onChange(
+				cleanEmptyObject( {
+					...layout,
+					columnCount: defaultColumnCount,
+					rowCount: undefined,
+				} )
+			);
+		const resetMinimumColumnWidth = () =>
+			onChange(
+				cleanEmptyObject( {
+					...layout,
+					minimumColumnWidth: undefined,
+				} )
+			);
+
 		return (
 			<>
 				{ window.__experimentalEnableGridInteractivity && (
-					<GridLayoutTypeControl
-						layout={ layout }
-						onChange={ onChange }
-					/>
+					<ToolsPanelItem
+						label={ __( 'Grid item position' ) }
+						hasValue={ hasGridTypeValue }
+						onDeselect={ resetGridType }
+						isShownByDefault
+						panelId={ clientId }
+					>
+						<GridLayoutTypeControl
+							layout={ layout }
+							onChange={ onChange }
+						/>
+					</ToolsPanelItem>
 				) }
-				<VStack spacing={ 4 }>
-					{ showColumnsControl && (
+				{ showColumnsControl && (
+					<ToolsPanelItem
+						label={ __( 'Columns and rows' ) }
+						hasValue={ hasColumnsAndRowsValue }
+						onDeselect={ resetColumnsAndRows }
+						isShownByDefault
+						panelId={ clientId }
+					>
 						<GridLayoutColumnsAndRowsControl
 							layout={ layout }
 							onChange={ onChange }
 							allowSizingOnChildren={ allowSizingOnChildren }
 						/>
-					) }
-					{ showMinWidthControl && (
+					</ToolsPanelItem>
+				) }
+				{ showMinWidthControl && (
+					<ToolsPanelItem
+						label={ __( 'Min. column width' ) }
+						hasValue={ hasMinimumColumnWidthValue }
+						onDeselect={ resetMinimumColumnWidth }
+						isShownByDefault
+						panelId={ clientId }
+					>
 						<GridLayoutMinimumWidthControl
 							layout={ layout }
 							onChange={ onChange }
 						/>
-					) }
-				</VStack>
+					</ToolsPanelItem>
+				) }
 			</>
 		);
 	},

--- a/packages/block-editor/src/layouts/test/flex.js
+++ b/packages/block-editor/src/layouts/test/flex.js
@@ -4,11 +4,30 @@
 import { render, screen } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import flex from '../flex';
 
 const FlexLayoutInspectorControls = flex.inspectorControls;
+const PANEL_ID = 'test-panel';
+
+function renderInspectorControls( props = {} ) {
+	return render(
+		<ToolsPanel label="Layout" resetAll={ jest.fn() } panelId={ PANEL_ID }>
+			<FlexLayoutInspectorControls
+				clientId={ PANEL_ID }
+				layout={ {} }
+				onChange={ jest.fn() }
+				{ ...props }
+			/>
+		</ToolsPanel>
+	);
+}
 
 describe( 'getLayoutStyle', () => {
 	it( 'should return an empty string if no non-default params are provided', () => {
@@ -29,9 +48,7 @@ describe( 'getLayoutStyle', () => {
 
 describe( 'FlexLayoutInspectorControls', () => {
 	it( 'should render the wrap toggle by default', () => {
-		render(
-			<FlexLayoutInspectorControls layout={ {} } onChange={ jest.fn() } />
-		);
+		renderInspectorControls();
 
 		expect(
 			screen.getByRole( 'checkbox', {
@@ -41,13 +58,9 @@ describe( 'FlexLayoutInspectorControls', () => {
 	} );
 
 	it( 'should render the wrap toggle when allowWrap is true', () => {
-		render(
-			<FlexLayoutInspectorControls
-				layout={ {} }
-				onChange={ jest.fn() }
-				layoutBlockSupport={ { allowWrap: true } }
-			/>
-		);
+		renderInspectorControls( {
+			layoutBlockSupport: { allowWrap: true },
+		} );
 
 		expect(
 			screen.getByRole( 'checkbox', {
@@ -57,13 +70,9 @@ describe( 'FlexLayoutInspectorControls', () => {
 	} );
 
 	it( 'should not render the wrap toggle when allowWrap is false', () => {
-		render(
-			<FlexLayoutInspectorControls
-				layout={ {} }
-				onChange={ jest.fn() }
-				layoutBlockSupport={ { allowWrap: false } }
-			/>
-		);
+		renderInspectorControls( {
+			layoutBlockSupport: { allowWrap: false },
+		} );
 
 		expect(
 			screen.queryByRole( 'checkbox', {

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -3,7 +3,6 @@
  */
 import { useMemo } from '@wordpress/element';
 import {
-	ExternalLink,
 	FocalPointPicker,
 	RangeControl,
 	TextareaControl,
@@ -27,6 +26,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { Link } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -193,8 +193,8 @@ export default function CoverInspectorControls( {
 
 	return (
 		<>
-			<InspectorControls>
-				{ ( !! url || useFeaturedImage ) && (
+			{ ( !! url || useFeaturedImage ) && (
+				<InspectorControls>
 					<ToolsPanel
 						label={ __( 'Settings' ) }
 						resetAll={ () => {
@@ -299,7 +299,8 @@ export default function CoverInspectorControls( {
 									}
 									help={
 										<>
-											<ExternalLink
+											<Link
+												openInNewTab
 												href={
 													// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
 													__(
@@ -310,7 +311,7 @@ export default function CoverInspectorControls( {
 												{ __(
 													'Describe the purpose of the image.'
 												) }
-											</ExternalLink>
+											</Link>
 											<br />
 											{ __(
 												'Leave empty if decorative.'
@@ -329,8 +330,8 @@ export default function CoverInspectorControls( {
 							/>
 						) }
 					</ToolsPanel>
-				) }
-			</InspectorControls>
+				</InspectorControls>
+			) }
 			{ colorGradientSettings.hasColorsOrGradients && (
 				<InspectorControls group="color">
 					<ColorGradientSettingsDropdown

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -54,6 +54,16 @@ async function createAndSelectBlock() {
 	await selectBlock( 'Block: Cover' );
 }
 
+async function openStylesTabIfAvailable() {
+	const stylesTab = screen.queryByRole( 'tab', {
+		name: 'Styles',
+	} );
+
+	if ( stylesTab ) {
+		await userEvent.click( stylesTab );
+	}
+}
+
 describe( 'Cover block', () => {
 	describe( 'Editor canvas', () => {
 		test( 'shows placeholder if background image and color not set', async () => {
@@ -189,6 +199,21 @@ describe( 'Cover block', () => {
 					} )
 				).not.toBeInTheDocument();
 			} );
+			test( 'does not display settings tab when media settings are empty', async () => {
+				await setup();
+				await createAndSelectBlock();
+
+				expect(
+					screen.queryByRole( 'tab', {
+						name: 'Settings',
+					} )
+				).not.toBeInTheDocument();
+				expect(
+					screen.getByRole( 'button', {
+						name: 'Advanced',
+					} )
+				).toBeInTheDocument();
+			} );
 			test( 'displays media settings panel if url is set', async () => {
 				await setup( {
 					url: 'http://localhost/my-image.jpg',
@@ -275,11 +300,7 @@ describe( 'Cover block', () => {
 
 				expect( overlay[ 0 ] ).toHaveClass( 'has-background-dim-100' );
 
-				await userEvent.click(
-					screen.getByRole( 'tab', {
-						name: 'Styles',
-					} )
-				);
+				await openStylesTabIfAvailable();
 				// Need act here as the isDark method is async.
 				// eslint-disable-next-line testing-library/no-unnecessary-act
 				await act( async () => {
@@ -308,11 +329,7 @@ describe( 'Cover block', () => {
 
 				expect( overlay[ 0 ] ).toHaveClass( 'has-background-dim-100' );
 
-				await userEvent.click(
-					screen.getByRole( 'tab', {
-						name: 'Styles',
-					} )
-				);
+				await openStylesTabIfAvailable();
 
 				// Need act here as the isDark method is async.
 				// eslint-disable-next-line testing-library/no-unnecessary-act
@@ -332,9 +349,7 @@ describe( 'Cover block', () => {
 				test( 'does not render overlay control', async () => {
 					await setup( undefined, true, disabledColorSettings );
 					await selectBlock( 'Block: Cover' );
-					await userEvent.click(
-						screen.getByRole( 'tab', { name: 'Styles' } )
-					);
+					await openStylesTabIfAvailable();
 
 					const overlayControl = screen.queryByRole( 'button', {
 						name: 'Overlay',
@@ -345,9 +360,7 @@ describe( 'Cover block', () => {
 				test( 'does not render opacity control', async () => {
 					await setup( undefined, true, disabledColorSettings );
 					await selectBlock( 'Block: Cover' );
-					await userEvent.click(
-						screen.getByRole( 'tab', { name: 'Styles' } )
-					);
+					await openStylesTabIfAvailable();
 
 					const opacityControl = screen.queryByRole( 'slider', {
 						name: 'Overlay opacity',
@@ -362,11 +375,7 @@ describe( 'Cover block', () => {
 			test( 'sets minHeight attribute when number control value changed', async () => {
 				await setup();
 				await createAndSelectBlock();
-				await userEvent.click(
-					screen.getByRole( 'tab', {
-						name: 'Styles',
-					} )
-				);
+				await openStylesTabIfAvailable();
 				await userEvent.clear(
 					screen.getByLabelText( 'Minimum height' )
 				);
@@ -395,11 +404,7 @@ describe( 'Cover block', () => {
 			expect( coverBlock ).toHaveClass( 'is-light' );
 
 			await selectBlock( 'Block: Cover' );
-			await userEvent.click(
-				screen.getByRole( 'tab', {
-					name: 'Styles',
-				} )
-			);
+			await openStylesTabIfAvailable();
 			await userEvent.click( screen.getByText( 'Overlay' ) );
 			const popupColorPicker = screen.getByRole( 'option', {
 				name: 'Black',
@@ -416,11 +421,7 @@ describe( 'Cover block', () => {
 			const coverBlock = screen.getByLabelText( 'Block: Cover' );
 			expect( coverBlock ).toHaveClass( 'is-light' );
 			await selectBlock( 'Block: Cover' );
-			await userEvent.click(
-				screen.getByRole( 'tab', {
-					name: 'Styles',
-				} )
-			);
+			await openStylesTabIfAvailable();
 			await userEvent.click( screen.getByText( 'Overlay' ) );
 			// The default color is black, so clicking the black color button will remove the background color,
 			// which should remove the isDark setting and assign the is-light class.

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -19,6 +19,13 @@ test.use( {
 	},
 } );
 
+async function openStylesTabIfAvailable( editorSettings ) {
+	const stylesTab = editorSettings.getByRole( 'tab', { name: 'Styles' } );
+	if ( await stylesTab.count() ) {
+		await stylesTab.click();
+	}
+}
+
 test.describe( 'Cover', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
@@ -134,7 +141,7 @@ test.describe( 'Cover', () => {
 			const editorSettings = page.getByRole( 'region', {
 				name: 'Editor settings',
 			} );
-			await editorSettings.getByRole( 'tab', { name: 'Styles' } ).click();
+			await openStylesTabIfAvailable( editorSettings );
 			await editorSettings
 				.getByRole( 'button', { name: 'Overlay' } )
 				.click();
@@ -231,13 +238,12 @@ test.describe( 'Cover', () => {
 			.getByRole( 'link', { name: 'Cover' } )
 			.click();
 
-		// In the Block Editor Settings panel, click on the Styles subpanel.
+		// In the Block Editor Settings panel, click on the Styles subpanel if
+		// the selected block has more than one inspector tab.
 		const coverBlockEditorSettings = page.getByRole( 'region', {
 			name: 'Editor settings',
 		} );
-		await coverBlockEditorSettings
-			.getByRole( 'tab', { name: 'Styles' } )
-			.click();
+		await openStylesTabIfAvailable( coverBlockEditorSettings );
 
 		// Ensure there the default value for the minimum height of cover is undefined.
 		await expect(
@@ -457,7 +463,7 @@ test.describe( 'Cover', () => {
 		const editorSettings = page.getByRole( 'region', {
 			name: 'Editor settings',
 		} );
-		await editorSettings.getByRole( 'tab', { name: 'Styles' } ).click();
+		await openStylesTabIfAvailable( editorSettings );
 
 		const opacitySlider = editorSettings.getByRole( 'slider', {
 			name: 'Overlay opacity',
@@ -500,7 +506,7 @@ test.describe( 'Cover', () => {
 		const editorSettings = page.getByRole( 'region', {
 			name: 'Editor settings',
 		} );
-		await editorSettings.getByRole( 'tab', { name: 'Styles' } ).click();
+		await openStylesTabIfAvailable( editorSettings );
 
 		const opacitySlider = editorSettings.getByRole( 'slider', {
 			name: 'Overlay opacity',

--- a/test/e2e/specs/editor/blocks/navigation-colors.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-colors.spec.js
@@ -88,9 +88,8 @@ test.describe( 'Navigation colors', () => {
 			.click();
 		await page.getByRole( 'menuitem', { name: 'Group' } ).click();
 
-		// In the sidebar inspector we add a link color and link hover color to the group block.
+		// In the sidebar inspector we add text and background colors to the group block.
 		await editor.openDocumentSettingsSidebar();
-		await page.getByRole( 'tab', { name: 'Styles' } ).click();
 		await page.getByRole( 'button', { name: 'Text' } ).click();
 		await page
 			.getByRole( 'option', { name: 'White' } )
@@ -142,13 +141,14 @@ test.describe( 'Navigation colors', () => {
 
 		// In the sidebar inspector we add a link color and link hover color to the group block.
 		await editor.openDocumentSettingsSidebar();
-		await page.getByRole( 'tab', { name: 'Styles' } ).click();
 		await page.getByRole( 'button', { name: 'Color options' } ).click();
 		await page
 			.getByRole( 'menuitemcheckbox', { name: 'Show Link' } )
 			.click();
-		await page.getByRole( 'tab', { name: 'Styles' } ).click();
-		await page.getByRole( 'button', { name: 'Link', exact: true } ).click();
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Link', exact: true } )
+			.click();
 		// rga(207, 46 ,46) is the color of the "vivid red" color preset.
 		await page
 			.getByRole( 'option', { name: 'Vivid red' } )

--- a/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
@@ -3,6 +3,33 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+async function setNavigationOrientationToVertical( page ) {
+	const editorSettings = page.getByRole( 'region', {
+		name: 'Editor settings',
+	} );
+
+	await editorSettings.getByRole( 'tab', { name: 'Styles' } ).click();
+
+	const stylesPanel = editorSettings.getByRole( 'tabpanel', {
+		name: 'Styles',
+	} );
+
+	await stylesPanel
+		.getByRole( 'radiogroup', { name: 'Orientation' } )
+		.getByRole( 'radio', { name: 'Vertical' } )
+		.click();
+}
+
+async function getSettingsPanel( page ) {
+	const editorSettings = page.getByRole( 'region', {
+		name: 'Editor settings',
+	} );
+
+	await editorSettings.getByRole( 'tab', { name: 'Settings' } ).click();
+
+	return editorSettings.getByRole( 'tabpanel', { name: 'Settings' } );
+}
+
 test.describe( 'Navigation block - Submenu Visibility', () => {
 	test.beforeEach( async ( { admin, editor, requestUtils } ) => {
 		await admin.createNewPost();
@@ -45,23 +72,10 @@ test.describe( 'Navigation block - Submenu Visibility', () => {
 		await test.step( 'Switch to vertical orientation and select Always', async () => {
 			await editor.openDocumentSettingsSidebar();
 
-			// Click the Settings tab button
-			const settingsTab = page
-				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'tab', { name: 'Settings' } );
-			await settingsTab.click();
-
-			const settingsPanel = page
-				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'tabpanel', { name: 'Settings' } );
-
-			// Switch to vertical orientation
-			const verticalOption = settingsPanel.getByRole( 'radio', {
-				name: 'Vertical',
-			} );
-			await verticalOption.click();
+			await setNavigationOrientationToVertical( page );
 
 			// Select Always from Submenu Visibility
+			const settingsPanel = await getSettingsPanel( page );
 			const submenuVisibilityGroup = settingsPanel.getByRole(
 				'radiogroup',
 				{
@@ -187,17 +201,8 @@ test.describe( 'Navigation block - Submenu Visibility', () => {
 			await editor.selectBlocks( navBlock );
 			await editor.openDocumentSettingsSidebar();
 
-			// Click the Settings tab
-			const settingsTab = page
-				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'tab', { name: 'Settings' } );
-			await settingsTab.click();
-
-			const settingsPanel = page
-				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'tabpanel', { name: 'Settings' } );
-
 			// Check if Submenu Visibility control exists
+			const settingsPanel = await getSettingsPanel( page );
 			const submenuVisibilityGroup = settingsPanel.getByRole(
 				'radiogroup',
 				{
@@ -209,17 +214,11 @@ test.describe( 'Navigation block - Submenu Visibility', () => {
 		} );
 
 		await test.step( 'Set submenu visibility to always', async () => {
-			const settingsPanel = page
-				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'tabpanel', { name: 'Settings' } );
-
 			// Switch to vertical orientation first (required for Always option)
-			const verticalOption = settingsPanel.getByRole( 'radio', {
-				name: 'Vertical',
-			} );
-			await verticalOption.click();
+			await setNavigationOrientationToVertical( page );
 
 			// Select Always from Submenu Visibility
+			const settingsPanel = await getSettingsPanel( page );
 			const submenuVisibilityGroup = settingsPanel.getByRole(
 				'radiogroup',
 				{

--- a/test/e2e/specs/editor/various/background-gradient.spec.js
+++ b/test/e2e/specs/editor/various/background-gradient.spec.js
@@ -64,7 +64,6 @@ test.describe( 'Background gradient block support', () => {
 			} );
 
 			await editor.openDocumentSettingsSidebar();
-			await page.getByRole( 'tab', { name: 'Styles' } ).click();
 
 			// The gradient indicator in the Background panel should be visible,
 			// meaning the color.gradient value surfaced via the read-through fallback.
@@ -100,7 +99,6 @@ test.describe( 'Background gradient block support', () => {
 			} );
 
 			await editor.openDocumentSettingsSidebar();
-			await page.getByRole( 'tab', { name: 'Styles' } ).click();
 
 			// Open the gradient picker in the Background panel and select a
 			// preset, which triggers the migration.
@@ -141,7 +139,6 @@ test.describe( 'Background gradient block support', () => {
 			} );
 
 			await editor.openDocumentSettingsSidebar();
-			await page.getByRole( 'tab', { name: 'Styles' } ).click();
 
 			// Open the gradient picker and clear it. The inline reset icon
 			// button (aria-label="Reset") is hidden until hover; using the
@@ -186,7 +183,6 @@ test.describe( 'Background gradient block support', () => {
 			} );
 
 			await editor.openDocumentSettingsSidebar();
-			await page.getByRole( 'tab', { name: 'Styles' } ).click();
 
 			// First, trigger migration by selecting a preset gradient.
 			await page
@@ -239,7 +235,6 @@ test.describe( 'Background gradient block support', () => {
 			} );
 
 			await editor.openDocumentSettingsSidebar();
-			await page.getByRole( 'tab', { name: 'Styles' } ).click();
 
 			// Trigger migration by clearing the gradient via the picker.
 			await page

--- a/test/e2e/specs/site-editor/block-style-variations.spec.js
+++ b/test/e2e/specs/site-editor/block-style-variations.spec.js
@@ -3,6 +3,30 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 const TEST_PAGE_TITLE = 'Test Page for Block Style Variations';
+
+async function selectBlockStyleVariation( page, variationName ) {
+	const editorSettings = page.getByRole( 'region', {
+		name: 'Editor settings',
+	} );
+	const stylesTab = editorSettings.getByRole( 'tab', { name: 'Styles' } );
+	const variationButton = editorSettings.getByRole( 'button', {
+		name: variationName,
+	} );
+
+	const visibleControl = await Promise.any( [
+		stylesTab.waitFor( { state: 'visible' } ).then( () => 'styles-tab' ),
+		variationButton
+			.waitFor( { state: 'visible' } )
+			.then( () => 'variation-button' ),
+	] );
+
+	if ( visibleControl === 'styles-tab' ) {
+		await stylesTab.click();
+	}
+
+	await variationButton.click();
+}
+
 test.use( {
 	siteEditorBlockStyleVariations: async ( { page, editor }, use ) => {
 		await use( new SiteEditorBlockStyleVariations( { page, editor } ) );
@@ -62,10 +86,7 @@ test.describe( 'Block Style Variations', () => {
 		// Apply a block style to the parent Group block.
 		await editor.selectBlocks( firstGroup );
 		await editor.openDocumentSettingsSidebar();
-		await page.getByRole( 'tab', { name: 'Styles' } ).click();
-		await page
-			.getByRole( 'button', { name: 'Block Style Variation A' } )
-			.click();
+		await selectBlockStyleVariation( page, 'Block Style Variation A' );
 
 		// Check parent styles have variation A styles.
 		await expect( firstGroup ).toHaveCSS( 'border-style', 'dotted' );
@@ -79,10 +100,7 @@ test.describe( 'Block Style Variations', () => {
 
 		// Apply a block style to the nested child Group block.
 		await editor.selectBlocks( secondGroup );
-		await page.getByRole( 'tab', { name: 'Styles' } ).click();
-		await page
-			.getByRole( 'button', { name: 'Block Style Variation B' } )
-			.click();
+		await selectBlockStyleVariation( page, 'Block Style Variation B' );
 
 		// Check nested child styles have variation B styles.
 		await expect( secondGroup ).toHaveCSS( 'border-style', 'dashed' );
@@ -94,10 +112,7 @@ test.describe( 'Block Style Variations', () => {
 
 		// Apply a block style to the nested grandchild Group block.
 		await editor.selectBlocks( thirdGroup );
-		await page.getByRole( 'tab', { name: 'Styles' } ).click();
-		await page
-			.getByRole( 'button', { name: 'Block Style Variation A' } )
-			.click();
+		await selectBlockStyleVariation( page, 'Block Style Variation A' );
 
 		// Check that the child's inner block styles from variation B are overridden by the grandchild's block style variation A.
 		await expect( thirdGroup ).toHaveCSS( 'border-style', 'dotted' );
@@ -130,17 +145,11 @@ test.describe( 'Block Style Variations', () => {
 		// Apply a block style to the parent Group block.
 		await editor.selectBlocks( firstGroup );
 		await editor.openDocumentSettingsSidebar();
-		await page.getByRole( 'tab', { name: 'Styles' } ).click();
-		await page
-			.getByRole( 'button', { name: 'Block Style Variation A' } )
-			.click();
+		await selectBlockStyleVariation( page, 'Block Style Variation A' );
 
 		// Apply a block style to the first, nested Group block.
 		await editor.selectBlocks( secondGroup );
-		await page.getByRole( 'tab', { name: 'Styles' } ).click();
-		await page
-			.getByRole( 'button', { name: 'Block Style Variation B' } )
-			.click();
+		await selectBlockStyleVariation( page, 'Block Style Variation B' );
 
 		// Update user global styles with new block style variation values.
 		// First revision.

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -303,16 +303,6 @@
 			"count": 1
 		}
 	},
-	"packages/block-editor/src/layouts/constrained.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
-	"packages/block-editor/src/layouts/grid.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/block-library/src/breadcrumbs/edit.js": {
 		"react-hooks/refs": {
 			"count": 2

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -331,11 +331,6 @@
 			"count": 2
 		}
 	},
-	"packages/block-library/src/cover/edit/inspector-controls.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/block-library/src/embed/embed-placeholder.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 3


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Preliminary work for addressing responsive block instance controls (see #77817) which will require only styles controls (that output CSS) to display when in responsive mode.

Also a matter of practicality: Some Dimensions controls are closely tied to Layout, such as block spacing and flex/grid child widths and heights. It makes sense for the controls to be close together.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a block with layout support to a post - Group or Cover will do.
2. Select the block and check that Layout panel displays in the styles tab.

Post Template controls:

<img width="273" height="422" alt="Screenshot 2026-05-05 at 10 32 32 am" src="https://github.com/user-attachments/assets/44071c90-3937-4a39-a7b8-33c892b8212c" />

Group nested inside a Row:

<img width="269" height="904" alt="Screenshot 2026-05-05 at 10 38 29 am" src="https://github.com/user-attachments/assets/c3e59955-1a93-49e3-bdfa-b3c817fc46b6" />

Note: we might need to look at moving the "Advanced" panel into styles for those blocks with a now-empty settings tab.