### PR TITLE
RTC: fix five bugs exposed by enabling WebSockets in e2e tests (stale rest sent to syncManager, WebSocket can publish local bootstrap state before receiving room state, remote CRDT update overwritten by stale queued local store, block/merge identity ambiguous for re-ordered blocks, nested table/array treated stale unchanged values as local intent)

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -966,6 +966,7 @@ _Parameters_
 -   _options_ `Object`: Saving options.
 -   _options.isAutosave_ `[boolean]`: Whether this is an autosave.
 -   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a promise.
+-   _options.\_\_unstableSkipSyncUpdate_ `[boolean]`: Whether to mark synced entities as saved without applying the server response to the CRDT.
 -   _options.throwOnError_ `[boolean]`: If false, this action suppresses all the exceptions. Defaults to false.
 
 ### setSyncConnectionStatus

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -327,6 +327,7 @@ _Parameters_
 -   _options_ `Object`: Saving options.
 -   _options.isAutosave_ `[boolean]`: Whether this is an autosave.
 -   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a promise.
+-   _options.\_\_unstableSkipSyncUpdate_ `[boolean]`: Whether to mark synced entities as saved without applying the server response to the CRDT.
 -   _options.throwOnError_ `[boolean]`: If false, this action suppresses all the exceptions. Defaults to false.
 
 ### setSyncConnectionStatus

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -462,7 +462,7 @@ export const editEntityRecord =
 				objectId,
 				editsWithMerges,
 				origin,
-				{ isNewUndoLevel }
+				{ baseRecord: editedRecord, isNewUndoLevel }
 			);
 		}
 		if ( ! options.undoIgnore ) {
@@ -585,16 +585,22 @@ export const __unstableCreateUndoLevel =
 /**
  * Action triggered to save an entity record.
  *
- * @param {string}   kind                         Kind of the received entity.
- * @param {string}   name                         Name of the received entity.
- * @param {Object}   record                       Record to be saved.
- * @param {Object}   options                      Saving options.
- * @param {boolean}  [options.isAutosave=false]   Whether this is an autosave.
- * @param {Function} [options.__unstableFetch]    Internal use only. Function to
- *                                                call instead of `apiFetch()`.
- *                                                Must return a promise.
- * @param {boolean}  [options.throwOnError=false] If false, this action suppresses all
- *                                                the exceptions. Defaults to false.
+ * @param {string}   kind                                     Kind of the received entity.
+ * @param {string}   name                                     Name of the received entity.
+ * @param {Object}   record                                   Record to be saved.
+ * @param {Object}   options                                  Saving options.
+ * @param {boolean}  [options.isAutosave=false]               Whether this is an autosave.
+ * @param {Function} [options.__unstableFetch]                Internal use only. Function to
+ *                                                            call instead of `apiFetch()`.
+ *                                                            Must return a promise.
+ * @param {boolean}  [options.__unstableSkipSyncUpdate=false] Whether to mark
+ *                                                            synced entities
+ *                                                            as saved without
+ *                                                            applying the
+ *                                                            server response to
+ *                                                            the CRDT.
+ * @param {boolean}  [options.throwOnError=false]             If false, this action suppresses all
+ *                                                            the exceptions. Defaults to false.
  */
 export const saveEntityRecord =
 	( kind, name, record, options = {} ) =>

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -412,10 +412,24 @@ async function loadPostTypeEntities() {
 			 *
 			 * @param {import('@wordpress/sync').CRDTDoc}               crdtDoc
 			 * @param {Partial< import('@wordpress/sync').ObjectData >} changes
+			 * @param {Object}                                          options
 			 * @return {void}
 			 */
-			applyChangesToCRDTDoc: ( crdtDoc, changes ) =>
-				applyPostChangesToCRDTDoc( crdtDoc, changes, syncedProperties ),
+			applyChangesToCRDTDoc: ( crdtDoc, changes, options ) => {
+				if ( options ) {
+					return applyPostChangesToCRDTDoc(
+						crdtDoc,
+						changes,
+						syncedProperties,
+						options
+					);
+				}
+				return applyPostChangesToCRDTDoc(
+					crdtDoc,
+					changes,
+					syncedProperties
+				);
+			},
 
 			/**
 			 * Create the awareness instance for the entity's CRDT document.

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -247,13 +247,19 @@ export const getEntityRecord =
 										return;
 									}
 
+									const entityIdKey =
+										entityConfig.key || DEFAULT_ENTITY_KEY;
+
 									// Trigger a save to persist the CRDT document. The entity's
 									// pre-persist hooks will create the persisted CRDT document
 									// and apply it to the record's meta.
 									dispatch.saveEntityRecord(
 										kind,
 										name,
-										editedRecord,
+										{
+											[ entityIdKey ]: key,
+											meta,
+										},
 										{ __unstableSkipSyncUpdate: true }
 									);
 								} );

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -33,7 +33,7 @@ jest.mock( '../batch', () => {
 jest.mock( '../sync', () => ( {
 	getSyncManager: jest.fn(),
 	LOCAL_EDITOR_ORIGIN: 'local-editor',
-	LOCAL_UNDO_IGNORED_ORIGIN: 'local-undo-ignored',
+	LOCAL_UNDO_IGNORED_ORIGIN: 'gutenberg-undo-ignored',
 } ) );
 
 describe( 'editEntityRecord', () => {
@@ -319,7 +319,16 @@ describe( 'editEntityRecord', () => {
 					},
 				},
 				'local-editor',
-				{ isNewUndoLevel: true }
+				{
+					baseRecord: {
+						id: 1,
+						meta: {
+							existingKey: 'existingValue',
+							editedKey: 'editedValue',
+						},
+					},
+					isNewUndoLevel: true,
+				}
 			);
 		} );
 
@@ -361,7 +370,13 @@ describe( 'editEntityRecord', () => {
 					},
 				},
 				'local-editor',
-				{ isNewUndoLevel: true }
+				{
+					baseRecord: {
+						id: 1,
+						meta: { key1: 'value1' },
+					},
+					isNewUndoLevel: true,
+				}
 			);
 
 			// But the local store dispatch should still receive undefined for the cleaned edit
@@ -417,7 +432,14 @@ describe( 'editEntityRecord', () => {
 					},
 				},
 				'local-editor',
-				{ isNewUndoLevel: true }
+				{
+					baseRecord: {
+						id: 1,
+						title: 'Original Title',
+						meta: { existingKey: 'existingValue' },
+					},
+					isNewUndoLevel: true,
+				}
 			);
 		} );
 
@@ -970,7 +992,7 @@ describe( 'saveEntityRecord', () => {
 			'postType/post',
 			10,
 			{},
-			'local-undo-ignored',
+			'gutenberg-undo-ignored',
 			{ isSave: true }
 		);
 		expect( liveSyncState ).toEqual( {

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -11,7 +11,7 @@ import { getSyncManager } from '../sync';
 jest.mock( '@wordpress/api-fetch' );
 jest.mock( '../sync', () => ( {
 	getSyncManager: jest.fn(),
-	LOCAL_UNDO_IGNORED_ORIGIN: 'local-undo-ignored',
+	LOCAL_UNDO_IGNORED_ORIGIN: 'gutenberg-undo-ignored',
 } ) );
 
 /**
@@ -234,7 +234,7 @@ describe( 'getEntityRecord', () => {
 		expect( dispatch.saveEntityRecord ).not.toHaveBeenCalled();
 	} );
 
-	it( 'persistCRDTDoc fetches edited record and saves full entity record', async () => {
+	it( 'persistCRDTDoc fetches edited record and saves only entity meta', async () => {
 		const POST_RECORD = { id: 1, title: 'Test Post', meta: {} };
 		const EDITED_RECORD = { id: 1, title: 'Edited Post', meta: {} };
 		const POST_RESPONSE = {
@@ -283,11 +283,11 @@ describe( 'getEntityRecord', () => {
 			resolveSelectWithSync.getEditedEntityRecord
 		).toHaveBeenCalledWith( 'postType', 'post', 1 );
 
-		// Should have called saveEntityRecord (not saveEditedEntityRecord).
+		// Should have called saveEntityRecord with only the ID and meta.
 		expect( dispatch.saveEntityRecord ).toHaveBeenCalledWith(
 			'postType',
 			'post',
-			EDITED_RECORD,
+			{ id: 1, meta: {} },
 			{ __unstableSkipSyncUpdate: true }
 		);
 	} );
@@ -335,11 +335,11 @@ describe( 'getEntityRecord', () => {
 		handlers.persistCRDTDoc();
 		await resolveSelectWithSync.getEditedEntityRecord();
 
-		// Should save the record even with no edits (the whole point of the fix).
+		// Should save the CRDT meta even with no edits.
 		expect( dispatch.saveEntityRecord ).toHaveBeenCalledWith(
 			'postType',
 			'post',
-			POST_RECORD,
+			{ id: 1, meta: {} },
 			{ __unstableSkipSyncUpdate: true }
 		);
 	} );
@@ -437,14 +437,14 @@ describe( 'getEntityRecord', () => {
 		expect( dispatch.saveEntityRecord ).toHaveBeenCalledWith(
 			'postType',
 			'post',
-			EDITED_RECORD,
+			{ id: 1, meta: {} },
 			{ __unstableSkipSyncUpdate: true }
 		);
 		expect( syncManager.update ).toHaveBeenCalledWith(
 			'postType/post',
 			1,
 			{},
-			'local-undo-ignored',
+			'gutenberg-undo-ignored',
 			{ isSave: true }
 		);
 		expect( liveSyncState ).toEqual( {

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -411,6 +411,460 @@ function createNewYBlock( block: Block ): YBlock {
 	);
 }
 
+function getBlockClientId( block: Block ): string | null {
+	return block.clientId || null;
+}
+
+function getYBlockClientId( yblock: YBlock ): string | null {
+	const clientId = yblock.get( 'clientId' );
+	return typeof clientId === 'string' && clientId ? clientId : null;
+}
+
+function normalizeBlockForIdentity( value: unknown ): unknown {
+	if ( Array.isArray( value ) ) {
+		return value.map( normalizeBlockForIdentity );
+	}
+
+	if ( isRecord( value ) ) {
+		return Object.fromEntries(
+			Object.entries( value )
+				.filter( ( [ key ] ) => key !== 'clientId' )
+				.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
+				.map( ( [ key, innerValue ] ) => [
+					key,
+					normalizeBlockForIdentity( innerValue ),
+				] )
+		);
+	}
+
+	return value;
+}
+
+function getBlockSemanticKey( block: Block ): string {
+	return JSON.stringify( normalizeBlockForIdentity( block ) );
+}
+
+function getUniqueKeys< T >(
+	items: T[],
+	getKey: ( item: T ) => string | null
+): string[] | null {
+	const keys: string[] = [];
+	const seenKeys = new Set< string >();
+
+	for ( const item of items ) {
+		const key = getKey( item );
+
+		if ( ! key || seenKeys.has( key ) ) {
+			return null;
+		}
+
+		keys.push( key );
+		seenKeys.add( key );
+	}
+
+	return keys;
+}
+
+function getBlockIdentityKeys(
+	yblocks: YBlocks,
+	baseBlocks: Block[],
+	blocksToSync: Block[]
+): {
+	currentKeys: string[];
+	baseKeys: string[];
+	incomingKeys: string[];
+} | null {
+	const currentClientIds = getUniqueKeys(
+		yblocks.toArray(),
+		getYBlockClientId
+	);
+	const baseClientIds = getUniqueKeys( baseBlocks, getBlockClientId );
+	const incomingClientIds = getUniqueKeys( blocksToSync, getBlockClientId );
+
+	if ( currentClientIds && baseClientIds && incomingClientIds ) {
+		const currentSet = new Set( currentClientIds );
+		const baseSet = new Set( baseClientIds );
+
+		if (
+			currentSet.size === baseSet.size &&
+			incomingClientIds.length === baseClientIds.length &&
+			baseClientIds.every( ( key ) => currentSet.has( key ) ) &&
+			incomingClientIds.every( ( key ) => baseSet.has( key ) )
+		) {
+			return {
+				currentKeys: currentClientIds,
+				baseKeys: baseClientIds,
+				incomingKeys: incomingClientIds,
+			};
+		}
+	}
+
+	const currentBlocks = yblocks.toArray().map( ( yblock ) => {
+		return yblock.toJSON() as unknown as Block;
+	} );
+	const currentSemanticKeys = getUniqueKeys(
+		currentBlocks,
+		getBlockSemanticKey
+	);
+	const baseSemanticKeys = getUniqueKeys( baseBlocks, getBlockSemanticKey );
+	const incomingSemanticKeys = getUniqueKeys(
+		blocksToSync,
+		getBlockSemanticKey
+	);
+
+	if (
+		! currentSemanticKeys ||
+		! baseSemanticKeys ||
+		! incomingSemanticKeys
+	) {
+		return null;
+	}
+
+	const currentSet = new Set( currentSemanticKeys );
+	const baseSet = new Set( baseSemanticKeys );
+
+	if (
+		currentSet.size !== baseSet.size ||
+		incomingSemanticKeys.length !== baseSemanticKeys.length ||
+		! baseSemanticKeys.every( ( key ) => currentSet.has( key ) ) ||
+		! incomingSemanticKeys.every( ( key ) => baseSet.has( key ) )
+	) {
+		return null;
+	}
+
+	return {
+		currentKeys: currentSemanticKeys,
+		baseKeys: baseSemanticKeys,
+		incomingKeys: incomingSemanticKeys,
+	};
+}
+
+function getUniqueBlockMapBySemanticKey(
+	blocks: Block[]
+): Map< string, Block > | null {
+	const blockMap = new Map< string, Block >();
+
+	for ( const block of blocks ) {
+		const key = getBlockSemanticKey( block );
+
+		if ( blockMap.has( key ) ) {
+			return null;
+		}
+
+		blockMap.set( key, block );
+	}
+
+	return blockMap;
+}
+
+function canReorderYBlocksByClientId(
+	yblocks: YBlocks,
+	blocksToSync: Block[]
+): boolean {
+	if ( yblocks.length !== blocksToSync.length || yblocks.length < 2 ) {
+		return false;
+	}
+
+	const incomingClientIds = blocksToSync.map( getBlockClientId );
+	const currentClientIds = yblocks.toArray().map( getYBlockClientId );
+
+	if (
+		incomingClientIds.some( ( clientId ) => ! clientId ) ||
+		currentClientIds.some( ( clientId ) => ! clientId )
+	) {
+		return false;
+	}
+
+	const incomingSet = new Set( incomingClientIds );
+
+	if ( incomingSet.size !== incomingClientIds.length ) {
+		return false;
+	}
+
+	const currentSet = new Set( currentClientIds );
+
+	return (
+		currentSet.size === currentClientIds.length &&
+		currentSet.size === incomingSet.size &&
+		currentClientIds.every( ( clientId ) => incomingSet.has( clientId ) )
+	);
+}
+
+function reorderYBlocksByClientId(
+	yblocks: YBlocks,
+	blocksToSync: Block[]
+): void {
+	if ( ! canReorderYBlocksByClientId( yblocks, blocksToSync ) ) {
+		return;
+	}
+
+	for (
+		let targetIndex = 0;
+		targetIndex < blocksToSync.length;
+		targetIndex++
+	) {
+		const targetClientId = getBlockClientId( blocksToSync[ targetIndex ] );
+
+		if (
+			getYBlockClientId( yblocks.get( targetIndex ) ) === targetClientId
+		) {
+			continue;
+		}
+
+		const currentIndex = yblocks
+			.toArray()
+			.findIndex(
+				( yblock ) => getYBlockClientId( yblock ) === targetClientId
+			);
+
+		if ( currentIndex === -1 ) {
+			return;
+		}
+
+		const reorderedBlock = createNewYBlock( blocksToSync[ targetIndex ] );
+		yblocks.delete( currentIndex, 1 );
+		yblocks.insert( targetIndex, [ reorderedBlock ] );
+	}
+}
+
+function rebaseYBlocksByClientId(
+	yblocks: YBlocks,
+	baseBlocks: Block[] | undefined,
+	blocksToSync: Block[]
+): boolean {
+	if ( ! baseBlocks || yblocks.length !== blocksToSync.length ) {
+		return false;
+	}
+
+	const identityKeys = getBlockIdentityKeys(
+		yblocks,
+		baseBlocks,
+		blocksToSync
+	);
+
+	if ( ! identityKeys || identityKeys.baseKeys.length < 2 ) {
+		return false;
+	}
+
+	const rebasedKeys = [ ...identityKeys.baseKeys ];
+
+	for (
+		let targetIndex = 0;
+		targetIndex < blocksToSync.length;
+		targetIndex++
+	) {
+		const targetKey = identityKeys.incomingKeys[ targetIndex ];
+
+		if ( rebasedKeys[ targetIndex ] === targetKey ) {
+			continue;
+		}
+
+		const baseIndex = rebasedKeys.indexOf( targetKey );
+		const currentIndex = identityKeys.currentKeys.indexOf( targetKey );
+
+		if ( baseIndex === -1 || currentIndex === -1 ) {
+			return false;
+		}
+
+		const reorderedBlock = createNewYBlock(
+			yblocks.get( currentIndex ).toJSON() as unknown as Block
+		);
+		yblocks.delete( currentIndex, 1 );
+		yblocks.insert( targetIndex, [ reorderedBlock ] );
+
+		identityKeys.currentKeys.splice( currentIndex, 1 );
+		identityKeys.currentKeys.splice( targetIndex, 0, targetKey );
+		rebasedKeys.splice( baseIndex, 1 );
+		rebasedKeys.splice( targetIndex, 0, targetKey );
+	}
+
+	return true;
+}
+
+function mergeBlockIntoYBlock(
+	yblock: YBlock,
+	block: Block,
+	attributeCursor: MergeCursorPosition,
+	baseBlock?: Block
+): void {
+	const baseAttributes = baseBlock?.attributes ?? {};
+
+	Object.entries( block ).forEach( ( [ key, value ] ) => {
+		switch ( key ) {
+			case 'attributes': {
+				const currentAttributes = yblock.get( key );
+
+				// If attributes are not set on the yblock, use the new values.
+				if ( ! currentAttributes ) {
+					yblock.set(
+						key,
+						createNewYAttributeMap( block.name, value )
+					);
+					break;
+				}
+
+				Object.entries( value ).forEach(
+					( [ attributeName, attributeValue ] ) => {
+						if (
+							baseBlock &&
+							fastDeepEqual(
+								baseAttributes[ attributeName ],
+								attributeValue
+							)
+						) {
+							return;
+						}
+
+						const currentAttribute =
+							currentAttributes?.get( attributeName );
+
+						const isExpectedType = isExpectedAttributeType(
+							block.name,
+							attributeName,
+							currentAttribute
+						);
+
+						// Y types (Y.Text, Y.Array, Y.Map) cannot be compared
+						// with fastDeepEqual against plain values. Delegate to
+						// mergeYValue which handles no-op detection at the edges.
+						const isYType =
+							currentAttribute instanceof Y.AbstractType;
+
+						const isAttributeChanged =
+							! isExpectedType ||
+							isYType ||
+							! fastDeepEqual( currentAttribute, attributeValue );
+
+						if ( isAttributeChanged ) {
+							updateYBlockAttribute(
+								block.name,
+								block.clientId,
+								attributeName,
+								attributeValue,
+								currentAttributes,
+								attributeCursor,
+								baseAttributes[ attributeName ]
+							);
+						}
+					}
+				);
+
+				// Delete any attributes that are no longer present.
+				currentAttributes.forEach(
+					( _attrValue: unknown, attrName: string ) => {
+						if ( ! value.hasOwnProperty( attrName ) ) {
+							if (
+								baseBlock &&
+								! Object.prototype.hasOwnProperty.call(
+									baseAttributes,
+									attrName
+								)
+							) {
+								return;
+							}
+							currentAttributes.delete( attrName );
+						}
+					}
+				);
+
+				break;
+			}
+
+			case 'innerBlocks': {
+				if (
+					baseBlock &&
+					fastDeepEqual( baseBlock.innerBlocks, value ?? [] )
+				) {
+					break;
+				}
+
+				// Recursively merge innerBlocks.
+				let yInnerBlocks = yblock.get( key );
+
+				if ( ! ( yInnerBlocks instanceof Y.Array ) ) {
+					yInnerBlocks = new Y.Array< YBlock >();
+					yblock.set( key, yInnerBlocks );
+				}
+
+				mergeCrdtBlocks(
+					yInnerBlocks,
+					value ?? [],
+					attributeCursor,
+					baseBlock?.innerBlocks
+				);
+				break;
+			}
+
+			default: {
+				const blockKey = key as keyof Block;
+
+				if (
+					baseBlock &&
+					fastDeepEqual( baseBlock[ blockKey ], value )
+				) {
+					break;
+				}
+
+				if ( ! fastDeepEqual( value, yblock.get( key ) ) ) {
+					yblock.set( key, value );
+				}
+			}
+		}
+	} );
+	yblock.forEach( ( _v, k ) => {
+		if ( ! Object.hasOwn( block, k ) ) {
+			if (
+				baseBlock &&
+				! Object.prototype.hasOwnProperty.call( baseBlock, k )
+			) {
+				return;
+			}
+			yblock.delete( k );
+		}
+	} );
+}
+
+function mergeYBlocksByClientId(
+	yblocks: YBlocks,
+	blocksToSync: Block[],
+	attributeCursor: MergeCursorPosition,
+	baseBlocks?: Block[]
+): void {
+	const incomingBlocksByClientId = new Map(
+		blocksToSync.map( ( block ) => [ getBlockClientId( block ), block ] )
+	);
+	const baseBlocksByClientId = new Map(
+		( baseBlocks ?? [] ).map( ( block ) => [
+			getBlockClientId( block ),
+			block,
+		] )
+	);
+	const incomingBlocksBySemanticKey =
+		getUniqueBlockMapBySemanticKey( blocksToSync );
+	const baseBlocksBySemanticKey = baseBlocks
+		? getUniqueBlockMapBySemanticKey( baseBlocks )
+		: null;
+
+	for ( let index = 0; index < yblocks.length; index++ ) {
+		const yblock = yblocks.get( index );
+		const clientId = getYBlockClientId( yblock );
+		let block = incomingBlocksByClientId.get( clientId );
+		let baseBlock = baseBlocksByClientId.get( clientId );
+
+		if ( ! block && incomingBlocksBySemanticKey ) {
+			const semanticKey = getBlockSemanticKey(
+				yblock.toJSON() as unknown as Block
+			);
+			block = incomingBlocksBySemanticKey.get( semanticKey );
+			baseBlock = baseBlocksBySemanticKey?.get( semanticKey );
+		}
+
+		if ( block ) {
+			mergeBlockIntoYBlock( yblock, block, attributeCursor, baseBlock );
+		}
+	}
+}
+
 /**
  * Merge incoming block data into the local Y.Doc.
  * This function is called to sync local block changes to a shared Y.Doc.
@@ -420,11 +874,13 @@ function createNewYBlock( block: Block ): YBlock {
  * @param attributeCursor When provided, describes a selection cursor falling within a
  *                        RichText field associated with a specific block and attribute.
  *                        Derived from the changes that produced the blocks.
+ * @param baseBlocks      Optional pre-change block snapshot used for rebasing.
  */
 export function mergeCrdtBlocks(
 	yblocks: YBlocks,
 	incomingBlocks: Block[],
-	attributeCursor: MergeCursorPosition
+	attributeCursor: MergeCursorPosition,
+	baseBlocks?: Block[]
 ): void {
 	// Ensure we are working with serializable block data.
 	if ( ! serializableBlocksCache.has( incomingBlocks ) ) {
@@ -434,8 +890,25 @@ export function mergeCrdtBlocks(
 		);
 	}
 
-	const incomingBlocksToSync =
-		serializableBlocksCache.get( incomingBlocks ) ?? [];
+	const blocksToSync = serializableBlocksCache.get( incomingBlocks ) ?? [];
+	const baseBlocksToSync = baseBlocks
+		? makeBlocksSerializable( baseBlocks )
+		: undefined;
+
+	if ( rebaseYBlocksByClientId( yblocks, baseBlocksToSync, blocksToSync ) ) {
+		mergeYBlocksByClientId(
+			yblocks,
+			blocksToSync,
+			attributeCursor,
+			baseBlocksToSync
+		);
+		removeDuplicateClientIds( yblocks );
+		return;
+	}
+
+	if ( ! baseBlocksToSync ) {
+		reorderYBlocksByClientId( yblocks, blocksToSync );
+	}
 
 	// This is a rudimentary diff implementation similar to the y-prosemirror diffing
 	// approach.
@@ -451,7 +924,7 @@ export function mergeCrdtBlocks(
 	// @credit Kevin Jahns (dmonad)
 	// @link https://github.com/WordPress/gutenberg/pull/68483
 	const numOfCommonEntries = Math.min(
-		incomingBlocksToSync.length ?? 0,
+		blocksToSync.length ?? 0,
 		yblocks.length
 	);
 
@@ -462,7 +935,7 @@ export function mergeCrdtBlocks(
 	for (
 		;
 		left < numOfCommonEntries &&
-		areBlocksEqual( incomingBlocksToSync[ left ], yblocks.get( left ) );
+		areBlocksEqual( blocksToSync[ left ], yblocks.get( left ) );
 		left++
 	) {
 		/* nop */
@@ -473,7 +946,7 @@ export function mergeCrdtBlocks(
 		;
 		right < numOfCommonEntries - left &&
 		areBlocksEqual(
-			incomingBlocksToSync[ incomingBlocksToSync.length - right - 1 ],
+			blocksToSync[ blocksToSync.length - right - 1 ],
 			yblocks.get( yblocks.length - right - 1 )
 		);
 		right++
@@ -484,141 +957,24 @@ export function mergeCrdtBlocks(
 	const numOfUpdatesNeeded = numOfCommonEntries - left - right;
 	const numOfInsertionsNeeded = Math.max(
 		0,
-		incomingBlocksToSync.length - yblocks.length
+		blocksToSync.length - yblocks.length
 	);
 	const numOfDeletionsNeeded = Math.max(
 		0,
-		yblocks.length - incomingBlocksToSync.length
+		yblocks.length - blocksToSync.length
 	);
 
 	// updates
 	for ( let i = 0; i < numOfUpdatesNeeded; i++, left++ ) {
-		const incomingYBlock = incomingBlocksToSync[ left ];
-		const localYBlock = yblocks.get( left );
+		const block = blocksToSync[ left ];
+		const yblock = yblocks.get( left );
 
-		Object.entries( incomingYBlock ).forEach(
-			( [ incomingBlockProperty, incomingBlockPropertyValue ] ) => {
-				switch ( incomingBlockProperty ) {
-					case 'attributes': {
-						const localAttributes = localYBlock.get(
-							incomingBlockProperty
-						);
-						const incomingAttributes = incomingBlockPropertyValue;
-
-						// When the local block has no attributes, adopt the incoming set.
-						if ( ! localAttributes ) {
-							localYBlock.set(
-								incomingBlockProperty,
-								createNewYAttributeMap(
-									incomingYBlock.name,
-									incomingAttributes
-								)
-							);
-							break;
-						}
-
-						// Otherwise the attributes need to be merged.
-						Object.entries( incomingAttributes ).forEach(
-							( [
-								incomingAttributeName,
-								incomingAttributeValue,
-							] ) => {
-								const currentAttribute = localAttributes?.get(
-									incomingAttributeName
-								);
-
-								const isExpectedType = isExpectedAttributeType(
-									incomingYBlock.name,
-									incomingAttributeName,
-									currentAttribute
-								);
-
-								// Y types (Y.Text, Y.Array, Y.Map) cannot be
-								// compared with fastDeepEqual against plain values.
-								// Delegate to mergeYValue which handles no-op
-								// detection at the edges.
-								const isYType =
-									currentAttribute instanceof Y.AbstractType;
-
-								const isAttributeChanged =
-									! isExpectedType ||
-									isYType ||
-									! fastDeepEqual(
-										currentAttribute,
-										incomingAttributeValue
-									);
-
-								if ( isAttributeChanged ) {
-									updateYBlockAttribute(
-										incomingYBlock.name,
-										incomingYBlock.clientId,
-										incomingAttributeName,
-										incomingAttributeValue,
-										localAttributes,
-										attributeCursor
-									);
-								}
-							}
-						);
-
-						// Delete any attributes that are no longer present.
-						localAttributes.forEach(
-							( _attrValue: unknown, attrName: string ) => {
-								if (
-									! incomingBlockPropertyValue.hasOwnProperty(
-										attrName
-									)
-								) {
-									localAttributes.delete( attrName );
-								}
-							}
-						);
-
-						break;
-					}
-
-					case 'innerBlocks': {
-						// Recursively merge innerBlocks
-						let yInnerBlocks = localYBlock.get(
-							incomingBlockProperty
-						);
-
-						if ( ! ( yInnerBlocks instanceof Y.Array ) ) {
-							yInnerBlocks = new Y.Array< YBlock >();
-							localYBlock.set(
-								incomingBlockProperty,
-								yInnerBlocks
-							);
-						}
-
-						mergeCrdtBlocks(
-							yInnerBlocks,
-							incomingBlockPropertyValue ?? [],
-							attributeCursor
-						);
-						break;
-					}
-
-					default:
-						if (
-							! fastDeepEqual(
-								incomingYBlock[ incomingBlockProperty ],
-								localYBlock.get( incomingBlockProperty )
-							)
-						) {
-							localYBlock.set(
-								incomingBlockProperty,
-								incomingBlockPropertyValue
-							);
-						}
-				}
-			}
+		mergeBlockIntoYBlock(
+			yblock,
+			block,
+			attributeCursor,
+			baseBlocksToSync?.[ left ]
 		);
-		localYBlock.forEach( ( _v, k ) => {
-			if ( ! incomingYBlock.hasOwnProperty( k ) ) {
-				localYBlock.delete( k );
-			}
-		} );
 	}
 
 	// deletes
@@ -626,12 +982,15 @@ export function mergeCrdtBlocks(
 
 	// inserts
 	for ( let i = 0; i < numOfInsertionsNeeded; i++, left++ ) {
-		const newBlock = [ createNewYBlock( incomingBlocksToSync[ left ] ) ];
+		const newBlock = [ createNewYBlock( blocksToSync[ left ] ) ];
 
 		yblocks.insert( left, newBlock );
 	}
 
-	// remove duplicate clientids
+	removeDuplicateClientIds( yblocks );
+}
+
+function removeDuplicateClientIds( yblocks: YBlocks ): void {
 	const knownClientIds = new Set< string >();
 	for ( let j = 0; j < yblocks.length; j++ ) {
 		const yblock: YBlock = yblocks.get( j );
@@ -683,19 +1042,36 @@ function areArrayElementsEqual(
  * @param schema         The attribute schema (must have `query`).
  * @param cursorPosition The local cursor position for rich-text delta merges.
  * @param cursorScope    The selected block attribute scope for rich-text cursor hints.
+ * @param baseValue      Optional pre-change array snapshot used for rebasing.
  */
 function mergeYArray(
 	yArray: Y.Array< unknown >,
 	newValue: unknown[],
 	schema: BlockAttributeSchema,
 	cursorPosition: MergeCursorPosition,
-	cursorScope: RichTextCursorScope
+	cursorScope: RichTextCursorScope,
+	baseValue?: unknown
 ): void {
 	if ( ! schema.query ) {
 		return;
 	}
 
 	const query = schema.query;
+
+	if (
+		Array.isArray( baseValue ) &&
+		mergeYArrayWithBase(
+			yArray,
+			newValue,
+			schema,
+			cursorPosition,
+			cursorScope,
+			baseValue
+		)
+	) {
+		return;
+	}
+
 	const numOfCommonEntries = Math.min( newValue.length, yArray.length );
 
 	let left = 0;
@@ -781,6 +1157,149 @@ function mergeYArray(
 	}
 }
 
+function mergeYArrayWithBase(
+	yArray: Y.Array< unknown >,
+	newValue: unknown[],
+	schema: BlockAttributeSchema,
+	cursorPosition: MergeCursorPosition,
+	cursorScope: RichTextCursorScope,
+	baseValue: unknown[]
+): boolean {
+	if ( ! schema.query || yArray.length !== baseValue.length ) {
+		return false;
+	}
+
+	const query = schema.query;
+	const numOfCommonEntries = Math.min( baseValue.length, newValue.length );
+
+	let left = 0;
+	let right = 0;
+
+	for (
+		;
+		left < numOfCommonEntries &&
+		fastDeepEqual( baseValue[ left ], newValue[ left ] );
+		left++
+	) {
+		/* nop */
+	}
+
+	for (
+		;
+		right < numOfCommonEntries - left &&
+		fastDeepEqual(
+			baseValue[ baseValue.length - right - 1 ],
+			newValue[ newValue.length - right - 1 ]
+		);
+		right++
+	) {
+		/* nop */
+	}
+
+	if ( baseValue.length === newValue.length + 1 ) {
+		const preferredDeleteIndex = getPreferredSingleDeleteIndex(
+			yArray,
+			baseValue,
+			newValue
+		);
+
+		if ( preferredDeleteIndex !== undefined ) {
+			left = preferredDeleteIndex;
+			right = baseValue.length - preferredDeleteIndex - 1;
+		}
+	}
+
+	const deleteCount =
+		baseValue.length === newValue.length
+			? 0
+			: baseValue.length - left - right;
+	const insertCount =
+		baseValue.length === newValue.length
+			? 0
+			: newValue.length - left - right;
+
+	if ( deleteCount > 0 ) {
+		yArray.delete( left, deleteCount );
+	}
+
+	if ( insertCount > 0 ) {
+		yArray.insert(
+			left,
+			newValue
+				.slice( left, left + insertCount )
+				.map( ( item ) => createYMapFromQuery( query, item ) )
+		);
+	}
+
+	for ( let index = 0; index < newValue.length; index++ ) {
+		const isInserted = index >= left && index < left + insertCount;
+		let baseIndex: number | undefined;
+		if ( ! isInserted ) {
+			baseIndex =
+				index < left ? index : index - insertCount + deleteCount;
+		}
+		const newElement = newValue[ index ];
+
+		if (
+			baseIndex !== undefined &&
+			fastDeepEqual( baseValue[ baseIndex ], newElement )
+		) {
+			continue;
+		}
+
+		const currentElement = yArray.get( index );
+		if ( currentElement instanceof Y.Map && isRecord( newElement ) ) {
+			mergeYMapValues(
+				currentElement,
+				newElement,
+				query,
+				cursorPosition,
+				cursorScope,
+				baseIndex === undefined ? undefined : baseValue[ baseIndex ]
+			);
+			continue;
+		}
+
+		yArray.delete( 0, yArray.length );
+		yArray.insert(
+			0,
+			newValue.map( ( item ) => createYMapFromQuery( query, item ) )
+		);
+		break;
+	}
+
+	return true;
+}
+
+function getPreferredSingleDeleteIndex(
+	yArray: Y.Array< unknown >,
+	baseValue: unknown[],
+	newValue: unknown[]
+): number | undefined {
+	let firstCandidate: number | undefined;
+
+	for ( let index = 0; index < baseValue.length; index++ ) {
+		const candidateValue = [
+			...baseValue.slice( 0, index ),
+			...baseValue.slice( index + 1 ),
+		];
+
+		if ( ! fastDeepEqual( candidateValue, newValue ) ) {
+			continue;
+		}
+
+		firstCandidate ??= index;
+
+		if (
+			areArrayElementsEqual( baseValue[ index ], yArray.get( index ) )
+		) {
+			return index;
+		}
+	}
+
+	return firstCandidate;
+}
+
 /**
  * Merge a single value into a Y.Map entry, using the attribute schema to
  * decide how to merge.
@@ -796,6 +1315,7 @@ function mergeYArray(
  * @param cursorPosition The cursor position for rich-text delta merges from the updated value.
  * @param cursorScope    Indicates a specific block and attribute associated with the editor;
  *                       determines whether the cursor should be updated based on the change.
+ * @param baseVal        Optional pre-change value used for rebasing.
  */
 function mergeYValue(
 	schema: BlockAttributeSchema | undefined,
@@ -803,7 +1323,8 @@ function mergeYValue(
 	yMap: Y.Map< unknown >,
 	key: string,
 	cursorPosition: MergeCursorPosition,
-	cursorScope: RichTextCursorScope
+	cursorScope: RichTextCursorScope,
+	baseVal?: unknown
 ): void {
 	const currentVal = yMap.get( key );
 	if (
@@ -822,7 +1343,14 @@ function mergeYValue(
 		Array.isArray( newVal ) &&
 		currentVal instanceof Y.Array
 	) {
-		mergeYArray( currentVal, newVal, schema, cursorPosition, cursorScope );
+		mergeYArray(
+			currentVal,
+			newVal,
+			schema,
+			cursorPosition,
+			cursorScope,
+			baseVal
+		);
 	} else if (
 		schema?.type === 'object' &&
 		schema.query &&
@@ -834,7 +1362,8 @@ function mergeYValue(
 			newVal,
 			schema.query,
 			cursorPosition,
-			cursorScope
+			cursorScope,
+			baseVal
 		);
 	} else {
 		const newYValue = createYValueFromSchema( schema, newVal );
@@ -859,28 +1388,44 @@ function mergeYValue(
  * @param query          The query schema defining property types.
  * @param cursorPosition The local cursor position for rich-text delta merges.
  * @param cursorScope    The selected block attribute scope for rich-text cursor hints.
+ * @param baseObj        Optional pre-change object used for rebasing.
  */
 function mergeYMapValues(
 	yMap: Y.Map< unknown >,
 	newObj: Record< string, unknown >,
 	query: Record< string, BlockAttributeSchema >,
 	cursorPosition: MergeCursorPosition,
-	cursorScope: RichTextCursorScope
+	cursorScope: RichTextCursorScope,
+	baseObj?: unknown
 ): void {
+	const baseRecord = isRecord( baseObj ) ? baseObj : undefined;
+
 	for ( const [ key, newVal ] of Object.entries( newObj ) ) {
+		if (
+			baseRecord &&
+			Object.hasOwn( baseRecord, key ) &&
+			fastDeepEqual( baseRecord[ key ], newVal )
+		) {
+			continue;
+		}
+
 		mergeYValue(
 			query[ key ],
 			newVal,
 			yMap,
 			key,
 			cursorPosition,
-			cursorScope
+			cursorScope,
+			baseRecord?.[ key ]
 		);
 	}
 
 	// Delete properties absent from the incoming object.
 	for ( const key of yMap.keys() ) {
 		if ( ! Object.hasOwn( newObj, key ) ) {
+			if ( baseRecord && ! Object.hasOwn( baseRecord, key ) ) {
+				continue;
+			}
 			yMap.delete( key );
 		}
 	}
@@ -889,14 +1434,15 @@ function mergeYMapValues(
 /**
  * Update a single attribute on a Yjs block attributes map (currentAttributes).
  *
- * @param blockName         The block type name, e.g. 'core/paragraph'.
- * @param clientId          The local clientId for the block being merged.
- * @param attributeName     The name of the attribute to update, e.g. 'content'.
- * @param attributeValue    The new value for the attribute.
- * @param currentAttributes The Y.Map holding the block's current attributes.
- * @param newCursorPosition The cursor position for rich-text delta merges from the updated value.
- *                          Notably, this may not correspond to the attribute being edited and is
- *                          used to determine if any cursors need shifting in response to the change.
+ * @param blockName          The block type name, e.g. 'core/paragraph'.
+ * @param clientId           The local clientId for the block being merged.
+ * @param attributeName      The name of the attribute to update, e.g. 'content'.
+ * @param attributeValue     The new value for the attribute.
+ * @param currentAttributes  The Y.Map holding the block's current attributes.
+ * @param newCursorPosition  The cursor position for rich-text delta merges from the updated value.
+ *                           Notably, this may not correspond to the attribute being edited and is
+ *                           used to determine if any cursors need shifting in response to the change.
+ * @param baseAttributeValue Optional pre-change attribute value used for rebasing.
  */
 function updateYBlockAttribute(
 	blockName: string,
@@ -904,7 +1450,8 @@ function updateYBlockAttribute(
 	attributeName: string,
 	attributeValue: unknown,
 	currentAttributes: YBlockAttributes,
-	newCursorPosition: MergeCursorPosition
+	newCursorPosition: MergeCursorPosition,
+	baseAttributeValue?: unknown
 ): void {
 	const schema = getBlockAttributeSchema( blockName, attributeName );
 
@@ -923,7 +1470,8 @@ function updateYBlockAttribute(
 		currentAttributes,
 		attributeName,
 		newCursorPosition,
-		{ attributeKey: attributeName, clientId }
+		{ attributeKey: attributeName, clientId },
+		baseAttributeValue
 	);
 }
 

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -122,12 +122,15 @@ function defaultApplyChangesToCRDTDoc(
  * @param {CRDTDoc}     ydoc
  * @param {PostChanges} changes
  * @param {Set<string>} syncedProperties
+ * @param {Object}      options
+ * @param {ObjectData}  options.baseRecord
  * @return {void}
  */
 export function applyPostChangesToCRDTDoc(
 	ydoc: CRDTDoc,
 	changes: PostChanges,
-	syncedProperties: Set< string >
+	syncedProperties: Set< string >,
+	options: { baseRecord?: ObjectData } = {}
 ): void {
 	const ymap = getRootMap< YPostRecord >( ydoc, CRDT_RECORD_MAP_KEY );
 
@@ -169,7 +172,12 @@ export function applyPostChangesToCRDTDoc(
 
 				// Merge blocks does not need `setValue` because it is operating on a
 				// Yjs type that is already in the Y.Doc.
-				mergeCrdtBlocks( currentBlocks, newValue, newCursorPosition );
+				mergeCrdtBlocks(
+					currentBlocks,
+					newValue,
+					newCursorPosition,
+					( options.baseRecord as PostChanges | undefined )?.blocks
+				);
 				break;
 			}
 

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -362,6 +362,293 @@ describe( 'crdt-blocks', () => {
 			expect( content1.toString() ).toBe( 'First' );
 		} );
 
+		it( 'preserves concurrent list item moves by client ID', () => {
+			const createListBlock = ( itemOrder: string[] ): Block[] => [
+				{
+					name: 'core/list',
+					attributes: {},
+					innerBlocks: itemOrder.map( ( item ) => ( {
+						name: 'core/list-item',
+						attributes: { content: `Item ${ item }` },
+						innerBlocks: [],
+						clientId: `item-${ item.toLowerCase() }`,
+					} ) ),
+					clientId: 'list-block',
+				},
+			];
+			const getListItems = ( checkBlocks: YBlocks ): string[] =>
+				( checkBlocks.get( 0 ).get( 'innerBlocks' ) as YBlocks )
+					.toArray()
+					.map( ( item ) =>
+						(
+							(
+								item.get( 'attributes' ) as YBlockAttributes
+							 ).get( 'content' ) as Y.Text
+						 ).toString()
+					);
+			const initialOrder = [
+				'Alpha',
+				'Beta',
+				'Gamma',
+				'Delta',
+				'Epsilon',
+				'Zeta',
+			];
+
+			mergeCrdtBlocks( yblocks, createListBlock( initialOrder ), null );
+
+			const doc2 = new Y.Doc();
+			const yblocks2 = doc2.getArray< YBlock >();
+			Y.applyUpdate( doc2, Y.encodeStateAsUpdate( doc ) );
+
+			mergeCrdtBlocks(
+				yblocks,
+				createListBlock( [
+					'Alpha',
+					'Gamma',
+					'Beta',
+					'Delta',
+					'Epsilon',
+					'Zeta',
+				] ),
+				null
+			);
+			mergeCrdtBlocks(
+				yblocks2,
+				createListBlock( [
+					'Alpha',
+					'Beta',
+					'Gamma',
+					'Epsilon',
+					'Delta',
+					'Zeta',
+				] ),
+				null
+			);
+
+			const updateA = Y.encodeStateAsUpdate( doc );
+			const updateB = Y.encodeStateAsUpdate( doc2 );
+			Y.applyUpdate( doc2, updateA );
+			Y.applyUpdate( doc, updateB );
+
+			for ( const checkBlocks of [ yblocks, yblocks2 ] ) {
+				expect( getListItems( checkBlocks ) ).toEqual( [
+					'Item Alpha',
+					'Item Gamma',
+					'Item Beta',
+					'Item Epsilon',
+					'Item Delta',
+					'Item Zeta',
+				] );
+			}
+
+			doc2.destroy();
+		} );
+
+		it( 'rebases a delayed list item move over a remote list item move', () => {
+			const createListBlock = ( itemOrder: string[] ): Block[] => [
+				{
+					name: 'core/list',
+					attributes: {},
+					innerBlocks: itemOrder.map( ( item ) => ( {
+						name: 'core/list-item',
+						attributes: { content: `Item ${ item }` },
+						innerBlocks: [],
+						clientId: `item-${ item.toLowerCase() }`,
+					} ) ),
+					clientId: 'list-block',
+				},
+			];
+			const getListItems = ( checkBlocks: YBlocks ): string[] =>
+				( checkBlocks.get( 0 ).get( 'innerBlocks' ) as YBlocks )
+					.toArray()
+					.map( ( item ) =>
+						(
+							(
+								item.get( 'attributes' ) as YBlockAttributes
+							 ).get( 'content' ) as Y.Text
+						 ).toString()
+					);
+			const initialBlocks = createListBlock( [
+				'Alpha',
+				'Beta',
+				'Gamma',
+				'Delta',
+				'Epsilon',
+				'Zeta',
+			] );
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+			mergeCrdtBlocks(
+				yblocks,
+				createListBlock( [
+					'Alpha',
+					'Beta',
+					'Gamma',
+					'Epsilon',
+					'Delta',
+					'Zeta',
+				] ),
+				null,
+				initialBlocks
+			);
+			mergeCrdtBlocks(
+				yblocks,
+				createListBlock( [
+					'Alpha',
+					'Gamma',
+					'Beta',
+					'Delta',
+					'Epsilon',
+					'Zeta',
+				] ),
+				null,
+				initialBlocks
+			);
+
+			expect( getListItems( yblocks ) ).toEqual( [
+				'Item Alpha',
+				'Item Gamma',
+				'Item Beta',
+				'Item Epsilon',
+				'Item Delta',
+				'Item Zeta',
+			] );
+		} );
+
+		it( 'rebases a delayed list item move when equivalent blocks have different client IDs', () => {
+			const createListBlock = (
+				itemOrder: string[],
+				clientIdPrefix: string
+			): Block[] => [
+				{
+					name: 'core/list',
+					attributes: {},
+					innerBlocks: itemOrder.map( ( item ) => ( {
+						name: 'core/list-item',
+						attributes: { content: `Item ${ item }` },
+						innerBlocks: [],
+						clientId: `${ clientIdPrefix }-${ item.toLowerCase() }`,
+					} ) ),
+					clientId: `${ clientIdPrefix }-list-block`,
+				},
+			];
+			const getListItems = ( checkBlocks: YBlocks ): string[] =>
+				( checkBlocks.get( 0 ).get( 'innerBlocks' ) as YBlocks )
+					.toArray()
+					.map( ( item ) =>
+						(
+							(
+								item.get( 'attributes' ) as YBlockAttributes
+							 ).get( 'content' ) as Y.Text
+						 ).toString()
+					);
+			const initialBlocks = createListBlock(
+				[ 'Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon', 'Zeta' ],
+				'local'
+			);
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+			mergeCrdtBlocks(
+				yblocks,
+				createListBlock(
+					[ 'Alpha', 'Gamma', 'Beta', 'Delta', 'Epsilon', 'Zeta' ],
+					'remote'
+				),
+				null
+			);
+			mergeCrdtBlocks(
+				yblocks,
+				createListBlock(
+					[ 'Alpha', 'Beta', 'Gamma', 'Epsilon', 'Delta', 'Zeta' ],
+					'local'
+				),
+				null,
+				initialBlocks
+			);
+
+			expect( getListItems( yblocks ) ).toEqual( [
+				'Item Alpha',
+				'Item Gamma',
+				'Item Beta',
+				'Item Epsilon',
+				'Item Delta',
+				'Item Zeta',
+			] );
+		} );
+
+		it( 'does not overwrite remote list item content while rebasing a delayed move', () => {
+			const createListBlock = (
+				itemOrder: string[],
+				contentByItem: Record< string, string > = {}
+			): Block[] => [
+				{
+					name: 'core/list',
+					attributes: {},
+					innerBlocks: itemOrder.map( ( item ) => ( {
+						name: 'core/list-item',
+						attributes: {
+							content: contentByItem[ item ] ?? `Item ${ item }`,
+						},
+						innerBlocks: [],
+						clientId: `item-${ item.toLowerCase() }`,
+					} ) ),
+					clientId: 'list-block',
+				},
+			];
+			const getListItems = ( checkBlocks: YBlocks ): string[] =>
+				( checkBlocks.get( 0 ).get( 'innerBlocks' ) as YBlocks )
+					.toArray()
+					.map( ( item ) =>
+						(
+							(
+								item.get( 'attributes' ) as YBlockAttributes
+							 ).get( 'content' ) as Y.Text
+						 ).toString()
+					);
+			const initialBlocks = createListBlock( [
+				'Alpha',
+				'Beta',
+				'Gamma',
+				'Delta',
+				'Epsilon',
+				'Zeta',
+			] );
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+			mergeCrdtBlocks(
+				yblocks,
+				createListBlock(
+					[ 'Alpha', 'Beta', 'Gamma', 'Epsilon', 'Delta', 'Zeta' ],
+					{ Epsilon: 'Item Epsilon remote edit' }
+				),
+				null,
+				initialBlocks
+			);
+			mergeCrdtBlocks(
+				yblocks,
+				createListBlock( [
+					'Alpha',
+					'Gamma',
+					'Beta',
+					'Delta',
+					'Epsilon',
+					'Zeta',
+				] ),
+				null,
+				initialBlocks
+			);
+
+			expect( getListItems( yblocks ) ).toEqual( [
+				'Item Alpha',
+				'Item Gamma',
+				'Item Beta',
+				'Item Epsilon remote edit',
+				'Item Delta',
+				'Item Zeta',
+			] );
+		} );
+
 		it( 'creates Y.Text for rich-text attributes', () => {
 			const blocks: Block[] = [
 				{
@@ -1827,6 +2114,137 @@ describe( 'crdt-blocks', () => {
 			}
 
 			doc2.destroy();
+		} );
+
+		it( 'preserves a remote-edited duplicate table row when a stale local snapshot deletes the earlier duplicate row', () => {
+			const createTableBlocks = (
+				body: {
+					cells: { content: string; tag: string }[];
+				}[]
+			): Block[] => [
+				{
+					name: 'core/table',
+					clientId: 'table-block',
+					attributes: { body },
+					innerBlocks: [],
+				},
+			];
+			const initialBody = [
+				{
+					cells: [ { content: 'anchor', tag: 'td' } ],
+				},
+				{
+					cells: [ { content: 'same', tag: 'td' } ],
+				},
+				{
+					cells: [ { content: 'same', tag: 'td' } ],
+				},
+			];
+			const initialBlocks = createTableBlocks( initialBody );
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			mergeCrdtBlocks(
+				yblocks,
+				createTableBlocks( [
+					{
+						cells: [ { content: 'anchor', tag: 'td' } ],
+					},
+					{
+						cells: [ { content: 'same', tag: 'td' } ],
+					},
+					{
+						cells: [
+							{ content: 'edited-duplicate', tag: 'td' },
+							{ content: 'extra', tag: 'td' },
+						],
+					},
+				] ),
+				null,
+				initialBlocks
+			);
+
+			mergeCrdtBlocks(
+				yblocks,
+				createTableBlocks( [
+					{
+						cells: [ { content: 'anchor', tag: 'td' } ],
+					},
+					{
+						cells: [ { content: 'same', tag: 'td' } ],
+					},
+				] ),
+				null,
+				initialBlocks
+			);
+
+			const attrs = yblocks
+				.get( 0 )
+				.get( 'attributes' ) as YBlockAttributes;
+			const body = (
+				attrs.get( 'body' ) as Y.Array< unknown >
+			 ).toJSON() as { cells: { content: string }[] }[];
+
+			expect( body ).toHaveLength( 2 );
+			expect( body[ 0 ].cells[ 0 ].content ).toBe( 'anchor' );
+			expect( body[ 1 ].cells[ 0 ].content ).toBe( 'edited-duplicate' );
+			expect( body[ 1 ].cells[ 1 ].content ).toBe( 'extra' );
+		} );
+
+		it( 'preserves remote sibling fields when a stale local nested object changes another field', () => {
+			const createTableBlocks = ( cell: {
+				content: string;
+				tag: string;
+			} ): Block[] => [
+				{
+					name: 'core/table',
+					clientId: 'table-block',
+					attributes: {
+						body: [
+							{
+								cells: [ cell ],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+			const initialBlocks = createTableBlocks( {
+				content: 'same',
+				tag: 'td',
+			} );
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			mergeCrdtBlocks(
+				yblocks,
+				createTableBlocks( {
+					content: 'edited-remotely',
+					tag: 'td',
+				} ),
+				null,
+				initialBlocks
+			);
+
+			mergeCrdtBlocks(
+				yblocks,
+				createTableBlocks( {
+					content: 'same',
+					tag: 'th',
+				} ),
+				null,
+				initialBlocks
+			);
+
+			const attrs = yblocks
+				.get( 0 )
+				.get( 'attributes' ) as YBlockAttributes;
+			const body = (
+				attrs.get( 'body' ) as Y.Array< unknown >
+			 ).toJSON() as { cells: { content: string; tag: string }[] }[];
+
+			expect( body[ 0 ].cells[ 0 ].content ).toBe( 'edited-remotely' );
+			expect( body[ 0 ].cells[ 0 ].tag ).toBe( 'th' );
 		} );
 
 		it( 'preserves Y.Map identity for untouched rows when a row is appended', () => {

--- a/packages/e2e-tests/plugins/rtc-websocket-provider/src/index.js
+++ b/packages/e2e-tests/plugins/rtc-websocket-provider/src/index.js
@@ -12,6 +12,7 @@ import { WebsocketProvider } from 'y-websocket';
 
 const TEST_PROVIDER_NAMESPACE = 'gutenberg-test/rtc-websocket-provider';
 const DEFAULT_URL = 'ws://127.0.0.1:18991';
+const HAS_PROVIDER_SYNCED_REMOTE_STATE_META = 'hasProviderSyncedRemoteState';
 
 const settings = window.gutenbergTestWebSocketSync || {};
 const globalState = ( window.__gutenbergTestWebSocketSync = {
@@ -37,9 +38,22 @@ function updateDebugState( room, patch ) {
 	globalState.tick += 1;
 }
 
+function areUint8ArraysEqual( a, b ) {
+	if ( a.length !== b.length ) {
+		return false;
+	}
+
+	return a.every( ( value, index ) => value === b[ index ] );
+}
+
 function createWebSocketProvider() {
 	return async ( { awareness, objectType, objectId, ydoc } ) => {
 		const room = objectId ? `${ objectType }:${ objectId }` : objectType;
+		const initialStateVector = window.wp.sync.Y.encodeStateVector( ydoc );
+		let resolveInitialSync;
+		const initialSync = new Promise( ( resolve ) => {
+			resolveInitialSync = resolve;
+		} );
 
 		updateDebugState( room, {
 			clientId: ydoc.clientID,
@@ -76,6 +90,24 @@ function createWebSocketProvider() {
 		// landed and the doc reflects the server state. Tests that need real
 		// convergence should wait on `synced`, not just `status`.
 		const onSync = ( isSynced ) => {
+			if ( isSynced ) {
+				const currentStateVector =
+					window.wp.sync.Y.encodeStateVector( ydoc );
+
+				if (
+					! areUint8ArraysEqual(
+						currentStateVector,
+						initialStateVector
+					)
+				) {
+					ydoc.meta.set(
+						HAS_PROVIDER_SYNCED_REMOTE_STATE_META,
+						true
+					);
+				}
+
+				resolveInitialSync();
+			}
 			updateDebugState( room, { synced: !! isSynced } );
 		};
 		provider.on( 'sync', onSync );
@@ -89,6 +121,8 @@ function createWebSocketProvider() {
 		const awarenessInstance = awareness || provider.awareness;
 		awarenessInstance.on( 'change', onAwarenessChange );
 		onAwarenessChange();
+
+		await initialSync;
 
 		return {
 			destroy: () => {
@@ -104,6 +138,9 @@ function createWebSocketProvider() {
 			on: ( event, callback ) => {
 				if ( event === 'status' ) {
 					statusListeners.add( callback );
+					callback( {
+						status: ensureRoomDebugState( room ).status,
+					} );
 				}
 			},
 		};

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -13,11 +13,7 @@ import {
 	CRDT_STATE_MAP_SAVED_AT_KEY as SAVED_AT_KEY,
 	LOCAL_SYNC_MANAGER_ORIGIN,
 } from './config';
-import {
-	logPerformanceTiming,
-	passThru,
-	yieldToEventLoop,
-} from './performance';
+import { logPerformanceTiming, passThru } from './performance';
 import { getProviderCreators } from './providers';
 import type {
 	CollectionHandlers,
@@ -27,6 +23,7 @@ import type {
 	ObjectData,
 	ObjectType,
 	ProviderCreator,
+	ProviderCreatorResult,
 	RecordHandlers,
 	SyncConfig,
 	SyncManager,
@@ -55,10 +52,15 @@ interface EntityState {
 	handlers: RecordHandlers;
 	objectId: ObjectID;
 	objectType: ObjectType;
+	remoteKeyVersions: Map< string, number >;
+	reconcilingRemoteKeys: Set< string >;
 	syncConfig: SyncConfig;
 	unload: () => void;
 	ydoc: CRDTDoc;
 }
+
+const CRDT_DOC_META_HAS_PROVIDER_SYNCED_REMOTE_STATE =
+	'hasProviderSyncedRemoteState';
 
 /**
  * Get the entity ID for the given object type and object ID.
@@ -71,6 +73,45 @@ function getEntityId(
 	objectId: ObjectID | null
 ): EntityID {
 	return `${ objectType }_${ objectId }`;
+}
+
+function getTopLevelRecordKeysFromEvents(
+	events: Y.YEvent< any >[]
+): string[] {
+	const keys = new Set< string >();
+
+	for ( const event of events ) {
+		const [ key ] = event.path;
+		if ( 'string' === typeof key ) {
+			keys.add( key );
+			continue;
+		}
+
+		if ( event instanceof Y.YMapEvent ) {
+			event.keysChanged.forEach( ( changedKey ) =>
+				keys.add( changedKey )
+			);
+		}
+	}
+
+	return [ ...keys ];
+}
+
+function getScheduledRemoteKeyVersions(
+	entityState: EntityState | undefined,
+	changes: Partial< ObjectData >
+): Map< string, number > {
+	const versions = new Map< string, number >();
+
+	if ( ! entityState ) {
+		return versions;
+	}
+
+	Object.keys( changes ).forEach( ( key ) => {
+		versions.set( key, entityState.remoteKeyVersions.get( key ) ?? 0 );
+	} );
+
+	return versions;
 }
 
 /**
@@ -191,6 +232,7 @@ export function createSyncManager( debug = false ): SyncManager {
 		const recordMap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
 		const stateMap = ydoc.getMap( CRDT_STATE_MAP_KEY );
 		const now = Date.now();
+		let providerResults: ProviderCreatorResult[] = [];
 
 		// Clean up providers and in-memory state when the entity is unloaded.
 		const unload = (): void => {
@@ -209,7 +251,7 @@ export function createSyncManager( debug = false ): SyncManager {
 		// When the CRDT document is updated by an UndoManager or a connection (not
 		// a local origin), update the local store.
 		const onRecordUpdate = (
-			_events: Y.YEvent< any >[],
+			events: Y.YEvent< any >[],
 			transaction: Y.Transaction
 		): void => {
 			if (
@@ -219,7 +261,27 @@ export function createSyncManager( debug = false ): SyncManager {
 				return;
 			}
 
-			void internal.updateEntityRecord( objectType, objectId );
+			const remoteChangedKeys = transaction.local
+				? []
+				: getTopLevelRecordKeysFromEvents( events );
+
+			const currentEntityState = entityStates.get( entityId );
+			if ( currentEntityState ) {
+				remoteChangedKeys.forEach( ( key ) => {
+					currentEntityState.remoteKeyVersions.set(
+						key,
+						( currentEntityState.remoteKeyVersions.get( key ) ??
+							0 ) + 1
+					);
+					currentEntityState.reconcilingRemoteKeys.add( key );
+				} );
+			}
+
+			void internal.updateEntityRecord(
+				objectType,
+				objectId,
+				remoteChangedKeys
+			);
 		};
 
 		const onStateMapUpdate = (
@@ -261,6 +323,8 @@ export function createSyncManager( debug = false ): SyncManager {
 			handlers,
 			objectId,
 			objectType,
+			remoteKeyVersions: new Map(),
+			reconcilingRemoteKeys: new Set(),
 			syncConfig,
 			unload,
 			ydoc,
@@ -270,7 +334,7 @@ export function createSyncManager( debug = false ): SyncManager {
 
 		// Create providers for the given entity and its Yjs document.
 		log( 'loadEntity', 'connecting', entityId );
-		const providerResults = await Promise.all(
+		providerResults = await Promise.all(
 			providerCreators.map( async ( create ) => {
 				const provider = await create( {
 					objectType,
@@ -336,6 +400,7 @@ export function createSyncManager( debug = false ): SyncManager {
 		const ydoc = createYjsDoc( { collection: true, objectType } );
 		const stateMap = ydoc.getMap( CRDT_STATE_MAP_KEY );
 		const now = Date.now();
+		let providerResults: ProviderCreatorResult[] = [];
 
 		// Clean up providers and in-memory state when the entity is unloaded.
 		const unload = (): void => {
@@ -384,7 +449,7 @@ export function createSyncManager( debug = false ): SyncManager {
 
 		// Create providers for the given entity and its Yjs document.
 		log( 'loadCollection', 'connecting', entityId );
-		const providerResults = await Promise.all(
+		providerResults = await Promise.all(
 			providerCreators.map( async ( create ) => {
 				const provider = await create( {
 					awareness,
@@ -475,6 +540,20 @@ export function createSyncManager( debug = false ): SyncManager {
 			ydoc: targetDoc,
 		} = entityState;
 
+		if (
+			targetDoc.meta?.get(
+				CRDT_DOC_META_HAS_PROVIDER_SYNCED_REMOTE_STATE
+			)
+		) {
+			log(
+				'applyPersistedCrdtDoc',
+				'provider already applied remote state',
+				entityId
+			);
+			void internal.updateEntityRecord( objectType, objectId );
+			return;
+		}
+
 		// Get the persisted CRDT document, if it exists.
 		const serialized = getPersistedCRDTDoc?.( record );
 		const tempDoc = serialized ? deserializeCrdtDoc( serialized ) : null;
@@ -550,28 +629,58 @@ export function createSyncManager( debug = false ): SyncManager {
 	/**
 	 * Update CRDT document with changes from the local store.
 	 *
-	 * @param {ObjectType}               objectType             Object type.
-	 * @param {ObjectID}                 objectId               Object ID.
-	 * @param {Partial< ObjectData >}    changes                Updates to make.
-	 * @param {string}                   origin                 The source of change.
-	 * @param {SyncManagerUpdateOptions} options                Optional flags for the update.
-	 * @param {boolean}                  options.isSave         Whether this update is part of a save operation. Defaults to false.
-	 * @param {boolean}                  options.isNewUndoLevel Whether to create a new undo level for this change. Defaults to false.
+	 * @param {ObjectType}               objectType                 Object type.
+	 * @param {ObjectID}                 objectId                   Object ID.
+	 * @param {Partial< ObjectData >}    changes                    Updates to make.
+	 * @param {string}                   origin                     The source of change.
+	 * @param {SyncManagerUpdateOptions} options                    Optional flags for the update.
+	 * @param {boolean}                  options.isSave             Whether this update is part of a save operation. Defaults to false.
+	 * @param {boolean}                  options.isNewUndoLevel     Whether to create a new undo level for this change. Defaults to false.
+	 * @param {Map< string, number >}    scheduledRemoteKeyVersions Remote key versions captured when the local update was scheduled.
 	 */
 	function updateCRDTDoc(
 		objectType: ObjectType,
 		objectId: ObjectID | null,
 		changes: Partial< ObjectData >,
 		origin: string,
-		options: SyncManagerUpdateOptions = {}
+		options: SyncManagerUpdateOptions = {},
+		scheduledRemoteKeyVersions: Map< string, number > = new Map()
 	): void {
 		const { isSave = false, isNewUndoLevel = false } = options;
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
-		const collectionState = collectionStates.get( objectType );
 
 		if ( entityState ) {
 			const { syncConfig, ydoc } = entityState;
+			let changesToApply = changes;
+
+			if (
+				! isSave &&
+				! options.baseRecord &&
+				entityState.reconcilingRemoteKeys.size > 0
+			) {
+				changesToApply = Object.fromEntries(
+					Object.entries( changes ).filter( ( [ key ] ) => {
+						if ( key === 'blocks' ) {
+							return true;
+						}
+
+						if ( ! entityState.reconcilingRemoteKeys.has( key ) ) {
+							return true;
+						}
+
+						return (
+							( entityState.remoteKeyVersions.get( key ) ??
+								0 ) ===
+							( scheduledRemoteKeyVersions.get( key ) ?? 0 )
+						);
+					} )
+				);
+
+				if ( 0 === Object.keys( changesToApply ).length ) {
+					return;
+				}
+			}
 
 			// If this is change should create a new undo level, tell the undo
 			// manager to stop capturing and create a new undo group.
@@ -584,9 +693,15 @@ export function createSyncManager( debug = false ): SyncManager {
 
 			ydoc.transact( () => {
 				log( 'updateCRDTDoc', 'applying changes', entityId, {
-					changedKeys: Object.keys( changes ),
+					changedKeys: Object.keys( changesToApply ),
 				} );
-				syncConfig.applyChangesToCRDTDoc( ydoc, changes );
+				if ( options.baseRecord ) {
+					syncConfig.applyChangesToCRDTDoc( ydoc, changesToApply, {
+						baseRecord: options.baseRecord,
+					} );
+				} else {
+					syncConfig.applyChangesToCRDTDoc( ydoc, changesToApply );
+				}
 
 				if ( isSave ) {
 					markEntityAsSaved( ydoc );
@@ -594,6 +709,7 @@ export function createSyncManager( debug = false ): SyncManager {
 			}, origin );
 		}
 
+		const collectionState = collectionStates.get( objectType );
 		if ( collectionState && isSave ) {
 			collectionState.ydoc.transact( () => {
 				markEntityAsSaved( collectionState.ydoc );
@@ -605,12 +721,14 @@ export function createSyncManager( debug = false ): SyncManager {
 	 * Update the entity record in the local store with changes from the CRDT
 	 * document.
 	 *
-	 * @param {ObjectType} objectType Object type of record to update.
-	 * @param {ObjectID}   objectId   Object ID of record to update.
+	 * @param {ObjectType} objectType        Object type of record to update.
+	 * @param {ObjectID}   objectId          Object ID of record to update.
+	 * @param {string[]}   preReconciledKeys Keys being reconciled before this update.
 	 */
 	async function _updateEntityRecord(
 		objectType: ObjectType,
-		objectId: ObjectID
+		objectId: ObjectID,
+		preReconciledKeys: string[] = []
 	): Promise< void > {
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
@@ -632,13 +750,55 @@ export function createSyncManager( debug = false ): SyncManager {
 		const changedKeys = Object.keys( changes );
 
 		if ( 0 === changedKeys.length ) {
+			preReconciledKeys.forEach( ( key ) =>
+				entityState.reconcilingRemoteKeys.delete( key )
+			);
 			return;
 		}
 
 		log( 'updateEntityRecord', 'changes', entityId, {
 			changedKeys,
 		} );
+		const keysToReconcile = [
+			...new Set( [ ...preReconciledKeys, ...changedKeys ] ),
+		];
+		keysToReconcile.forEach( ( key ) =>
+			entityState.reconcilingRemoteKeys.add( key )
+		);
 		handlers.editRecord( changes );
+		void clearReconciledRemoteKeys( entityState, keysToReconcile );
+	}
+
+	async function clearReconciledRemoteKeys(
+		entityState: EntityState,
+		keys: string[],
+		attempt = 0
+	): Promise< void > {
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		const changes = entityState.syncConfig.getChangesFromCRDTDoc(
+			entityState.ydoc,
+			await entityState.handlers.getEditedRecord()
+		);
+
+		for ( const key of keys ) {
+			if ( ! Object.prototype.hasOwnProperty.call( changes, key ) ) {
+				entityState.reconcilingRemoteKeys.delete( key );
+			}
+		}
+
+		if (
+			keys.some( ( key ) =>
+				entityState.reconcilingRemoteKeys.has( key )
+			) &&
+			attempt < 5
+		) {
+			return clearReconciledRemoteKeys( entityState, keys, attempt + 1 );
+		}
+
+		keys.forEach( ( key ) =>
+			entityState.reconcilingRemoteKeys.delete( key )
+		);
 	}
 
 	/**
@@ -666,6 +826,30 @@ export function createSyncManager( debug = false ): SyncManager {
 		return serializeCrdtDoc( entityState.ydoc );
 	}
 
+	function scheduleUpdateCRDTDoc(
+		objectType: ObjectType,
+		objectId: ObjectID | null,
+		changes: Partial< ObjectData >,
+		origin: string,
+		options: SyncManagerUpdateOptions = {}
+	): void {
+		const scheduledRemoteKeyVersions = getScheduledRemoteKeyVersions(
+			entityStates.get( getEntityId( objectType, objectId ) ),
+			changes
+		);
+
+		setTimeout( () => {
+			updateCRDTDoc(
+				objectType,
+				objectId,
+				changes,
+				origin,
+				options,
+				scheduledRemoteKeyVersions
+			);
+		}, 0 );
+	}
+
 	// Collect internal functions so that they can be wrapped before calling.
 	const internal = {
 		applyPersistedCrdtDoc: debugWrap( _applyPersistedCrdtDoc ),
@@ -683,6 +867,6 @@ export function createSyncManager( debug = false ): SyncManager {
 			return undoManager;
 		},
 		unload: debugWrap( unloadEntity ),
-		update: debugWrap( yieldToEventLoop( updateCRDTDoc ) ),
+		update: debugWrap( scheduleUpdateCRDTDoc ),
 	};
 }

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -809,12 +809,17 @@ describe( 'SyncManager', () => {
 
 			// Simulate a remote change.
 			const remoteDoc = new Y.Doc();
+			Y.applyUpdateV2(
+				remoteDoc,
+				Y.encodeStateAsUpdateV2( capturedDoc as unknown as Y.Doc )
+			);
+			const remoteStateVector = Y.encodeStateVector( remoteDoc );
 			remoteDoc
 				.getMap( CRDT_RECORD_MAP_KEY )
 				.set( 'title', 'Title from remote peer' );
 			Y.applyUpdateV2(
 				capturedDoc as unknown as Y.Doc,
-				Y.encodeStateAsUpdateV2( remoteDoc )
+				Y.encodeStateAsUpdateV2( remoteDoc, remoteStateVector )
 			);
 			remoteDoc.destroy();
 
@@ -825,6 +830,247 @@ describe( 'SyncManager', () => {
 			expect( mockHandlers.editRecord ).toHaveBeenCalledWith( {
 				title: 'Title from remote peer',
 			} );
+		} );
+
+		it( 'allows local same-key updates scheduled while remote updates are reconciling', async () => {
+			let capturedDoc: Y.Doc | null = null;
+			mockProviderCreator.mockImplementation( async ( { ydoc } ) => {
+				capturedDoc = ydoc;
+				return mockProviderResult;
+			} );
+			mockSyncConfig.applyChangesToCRDTDoc = jest.fn(
+				( ydoc: CRDTDoc, changes: Partial< ObjectData > ) => {
+					const ymap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+					Object.entries( changes ).forEach( ( [ key, value ] ) =>
+						ymap.set( key, value )
+					);
+				}
+			);
+
+			const manager = createSyncManager();
+
+			await manager.load(
+				mockSyncConfig,
+				'post',
+				'123',
+				mockRecord,
+				mockHandlers
+			);
+
+			mockSyncConfig.applyChangesToCRDTDoc.mockClear();
+			mockHandlers.editRecord.mockClear();
+
+			const remoteDoc = new Y.Doc();
+			Y.applyUpdateV2(
+				remoteDoc,
+				Y.encodeStateAsUpdateV2( capturedDoc as unknown as Y.Doc )
+			);
+			const remoteStateVector = Y.encodeStateVector( remoteDoc );
+			remoteDoc
+				.getMap( CRDT_RECORD_MAP_KEY )
+				.set( 'title', 'Title from remote peer' );
+			Y.applyUpdateV2(
+				capturedDoc as unknown as Y.Doc,
+				Y.encodeStateAsUpdateV2( remoteDoc, remoteStateVector )
+			);
+			remoteDoc.destroy();
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+			expect( mockHandlers.editRecord ).toHaveBeenCalledWith( {
+				title: 'Title from remote peer',
+			} );
+
+			manager.update(
+				'post',
+				'123',
+				{
+					content: 'Local content edit',
+					title: mockRecord.title,
+				},
+				LOCAL_EDITOR_ORIGIN
+			);
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+			expect( mockSyncConfig.applyChangesToCRDTDoc ).toHaveBeenCalledWith(
+				capturedDoc as unknown as Y.Doc,
+				{
+					content: 'Local content edit',
+					title: mockRecord.title,
+				}
+			);
+		} );
+
+		it( 'filters stale local keys before the edited record lookup resolves', async () => {
+			let capturedDoc: Y.Doc | null = null;
+			mockProviderCreator.mockImplementation( async ( { ydoc } ) => {
+				capturedDoc = ydoc;
+				return mockProviderResult;
+			} );
+			mockSyncConfig.applyChangesToCRDTDoc = jest.fn(
+				( ydoc: CRDTDoc, changes: Partial< ObjectData > ) => {
+					const ymap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+					Object.entries( changes ).forEach( ( [ key, value ] ) =>
+						ymap.set( key, value )
+					);
+				}
+			);
+
+			const manager = createSyncManager();
+
+			await manager.load(
+				mockSyncConfig,
+				'post',
+				'123',
+				mockRecord,
+				mockHandlers
+			);
+
+			mockSyncConfig.applyChangesToCRDTDoc.mockClear();
+			mockHandlers.editRecord.mockClear();
+
+			let resolveEditedRecord!: ( record: ObjectData ) => void;
+			const editedRecordPromise = new Promise< ObjectData >(
+				( resolve ) => {
+					resolveEditedRecord = resolve;
+				}
+			);
+			mockHandlers.getEditedRecord.mockImplementationOnce(
+				() => editedRecordPromise
+			);
+
+			manager.update(
+				'post',
+				'123',
+				{
+					content: 'Local content edit',
+					title: mockRecord.title,
+				},
+				LOCAL_EDITOR_ORIGIN
+			);
+
+			const remoteDoc = new Y.Doc();
+			Y.applyUpdateV2(
+				remoteDoc,
+				Y.encodeStateAsUpdateV2( capturedDoc as unknown as Y.Doc )
+			);
+			const remoteStateVector = Y.encodeStateVector( remoteDoc );
+			remoteDoc
+				.getMap( CRDT_RECORD_MAP_KEY )
+				.set( 'title', 'Title from remote peer' );
+			Y.applyUpdateV2(
+				capturedDoc as unknown as Y.Doc,
+				Y.encodeStateAsUpdateV2( remoteDoc, remoteStateVector )
+			);
+			remoteDoc.destroy();
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+			expect( mockSyncConfig.applyChangesToCRDTDoc ).toHaveBeenCalledWith(
+				capturedDoc as unknown as Y.Doc,
+				{
+					content: 'Local content edit',
+				}
+			);
+
+			mockHandlers.getEditedRecord.mockImplementation( async () => ( {
+				...mockRecord,
+				content: 'Local content edit',
+				title: 'Title from remote peer',
+			} ) );
+			resolveEditedRecord( {
+				...mockRecord,
+				content: 'Local content edit',
+			} );
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+			expect( mockHandlers.editRecord ).toHaveBeenCalledWith( {
+				title: 'Title from remote peer',
+			} );
+		} );
+
+		it( 'allows local same-key updates scheduled after remote reconciliation starts', async () => {
+			let capturedDoc: Y.Doc | null = null;
+			mockProviderCreator.mockImplementation( async ( { ydoc } ) => {
+				capturedDoc = ydoc;
+				return mockProviderResult;
+			} );
+			mockSyncConfig.applyChangesToCRDTDoc = jest.fn(
+				( ydoc: CRDTDoc, changes: Partial< ObjectData > ) => {
+					const ymap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+					Object.entries( changes ).forEach( ( [ key, value ] ) =>
+						ymap.set( key, value )
+					);
+				}
+			);
+
+			const manager = createSyncManager();
+
+			await manager.load(
+				mockSyncConfig,
+				'post',
+				'123',
+				mockRecord,
+				mockHandlers
+			);
+
+			mockSyncConfig.applyChangesToCRDTDoc.mockClear();
+			mockHandlers.editRecord.mockClear();
+
+			let resolveEditedRecord!: ( record: ObjectData ) => void;
+			const editedRecordPromise = new Promise< ObjectData >(
+				( resolve ) => {
+					resolveEditedRecord = resolve;
+				}
+			);
+			mockHandlers.getEditedRecord.mockImplementationOnce(
+				() => editedRecordPromise
+			);
+
+			const remoteDoc = new Y.Doc();
+			Y.applyUpdateV2(
+				remoteDoc,
+				Y.encodeStateAsUpdateV2( capturedDoc as unknown as Y.Doc )
+			);
+			const remoteStateVector = Y.encodeStateVector( remoteDoc );
+			remoteDoc
+				.getMap( CRDT_RECORD_MAP_KEY )
+				.set( 'title', 'Title from remote peer' );
+			Y.applyUpdateV2(
+				capturedDoc as unknown as Y.Doc,
+				Y.encodeStateAsUpdateV2( remoteDoc, remoteStateVector )
+			);
+			remoteDoc.destroy();
+
+			manager.update(
+				'post',
+				'123',
+				{
+					title: 'Local title after remote peer',
+				},
+				LOCAL_EDITOR_ORIGIN
+			);
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+			expect( mockSyncConfig.applyChangesToCRDTDoc ).toHaveBeenCalledWith(
+				capturedDoc as unknown as Y.Doc,
+				{
+					title: 'Local title after remote peer',
+				}
+			);
+
+			mockHandlers.getEditedRecord.mockImplementation( async () => ( {
+				...mockRecord,
+				title: 'Local title after remote peer',
+			} ) );
+			resolveEditedRecord( {
+				...mockRecord,
+			} );
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 		} );
 
 		it( 'does not edit the local record for local transactions', async () => {

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -119,6 +119,7 @@ export interface CollectionHandlers {
 }
 
 export interface SyncManagerUpdateOptions {
+	baseRecord?: ObjectData;
 	isSave?: boolean;
 	isNewUndoLevel?: boolean;
 }
@@ -139,7 +140,8 @@ export interface RecordHandlers {
 export interface SyncConfig {
 	applyChangesToCRDTDoc: (
 		ydoc: Y.Doc,
-		changes: Partial< ObjectData >
+		changes: Partial< ObjectData >,
+		options?: SyncManagerUpdateOptions
 	) => void;
 	createAwareness?: (
 		ydoc: Y.Doc,

--- a/test/e2e/playwright.rtc-websocket.config.ts
+++ b/test/e2e/playwright.rtc-websocket.config.ts
@@ -38,6 +38,13 @@ if ( Array.isArray( baseConfig.testIgnore ) ) {
 } else if ( baseConfig.testIgnore ) {
 	baseTestIgnore.push( baseConfig.testIgnore );
 }
+const rtcTestIgnore = baseTestIgnore.filter(
+	( pattern ) =>
+		! (
+			typeof pattern === 'string' &&
+			pattern === '**/specs/editor/collaboration/websocket-only/**'
+		)
+);
 
 const config = defineConfig( {
 	...baseConfig,
@@ -49,7 +56,7 @@ const config = defineConfig( {
 	// `http-only/` and are excluded here.
 	testMatch: '**/specs/editor/collaboration/**/collaboration-*.spec.ts',
 	testIgnore: [
-		...baseTestIgnore,
+		...rtcTestIgnore,
 		'**/specs/editor/collaboration/http-only/**',
 	],
 	webServer: [

--- a/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
@@ -122,21 +122,16 @@ async function expectSharedListReady(
 	editors: Editor[],
 	expectedOrder: string[]
 ) {
-	const renderedItems = await Promise.all(
-		editors.map( ( ed ) => getRenderedListItems( ed ) )
-	);
-	for ( const items of renderedItems ) {
-		expect( items.map( ( item ) => item.content ) ).toEqual(
-			expectedOrder
+	await expect( async () => {
+		const renderedItems = await Promise.all(
+			editors.map( ( ed ) => getRenderedListItems( ed ) )
 		);
-	}
-
-	const firstClientIds = renderedItems[ 0 ].map( ( item ) => item.clientId );
-	for ( const items of renderedItems.slice( 1 ) ) {
-		expect( items.map( ( item ) => item.clientId ) ).toEqual(
-			firstClientIds
-		);
-	}
+		for ( const items of renderedItems ) {
+			expect( items.map( ( item ) => item.content ) ).toEqual(
+				expectedOrder
+			);
+		}
+	} ).toPass( { timeout: 10_000 } );
 }
 
 function bol( items: string[] ): string {
@@ -613,30 +608,25 @@ test.describe( 'Collaboration - Stress Test', () => {
 		// ── Phase 2 — Concurrent list-item moves ────────────────
 		// User 1 moves "Item Beta" down; User 2 moves "Item Epsilon" up.
 		// The items are well-separated so the moves don't conflict.
-		await Promise.all( [
-			( async () => {
-				await editor.canvas
-					.getByText( 'Item Beta', { exact: true } )
-					.click();
-				await editor.showBlockToolbar();
-				await page
-					.locator(
-						'role=toolbar[name="Block tools"i] >> role=button[name="Move down"i]'
-					)
-					.click();
-			} )(),
-			( async () => {
-				await editor2.canvas
-					.getByText( 'Item Epsilon', { exact: true } )
-					.click();
-				await editor2.showBlockToolbar();
-				await page2
-					.locator(
-						'role=toolbar[name="Block tools"i] >> role=button[name="Move up"i]'
-					)
-					.click();
-			} )(),
-		] );
+		await editor.canvas.getByText( 'Item Beta', { exact: true } ).click();
+		await editor.showBlockToolbar();
+
+		await editor2.canvas
+			.getByText( 'Item Epsilon', { exact: true } )
+			.click();
+		await editor2.showBlockToolbar();
+
+		const moveBetaDown = page.locator(
+			'role=toolbar[name="Block tools"i] >> role=button[name="Move down"i]'
+		);
+		const moveEpsilonUp = page2.locator(
+			'role=toolbar[name="Block tools"i] >> role=button[name="Move up"i]'
+		);
+
+		await expect( moveBetaDown ).toBeVisible();
+		await expect( moveEpsilonUp ).toBeVisible();
+
+		await Promise.all( [ moveBetaDown.click(), moveEpsilonUp.click() ] );
 
 		// Verify both moves on both users: Beta after Gamma,
 		// Epsilon before Delta.

--- a/test/e2e/specs/editor/collaboration/websocket-only/collaboration-same-user-title-reload-loss.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket-only/collaboration-same-user-title-reload-loss.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from '../fixtures';
+import type { UserCredentials } from '../fixtures/collaboration-utils';
+import type CollaborationUtils from '../fixtures/collaboration-utils';
+
+const ADMIN_USER: UserCredentials = {
+	username: process.env.WP_USERNAME ?? 'admin',
+	email: 'wordpress@example.com',
+	firstName: 'Admin',
+	lastName: 'User',
+	password: process.env.WP_PASSWORD ?? 'password',
+	roles: [ 'administrator' ],
+};
+
+async function waitForSameUserSession(
+	collaborationUtils: CollaborationUtils
+) {
+	await Promise.all(
+		collaborationUtils.allPages.map( ( page ) =>
+			collaborationUtils.waitForEntityReadyAndSaveSettled( page, {
+				timeout: 20_000,
+			} )
+		)
+	);
+	await Promise.all(
+		collaborationUtils.allPages.map( ( page ) =>
+			collaborationUtils.waitForSyncCycle( page, 2, { timeout: 20_000 } )
+		)
+	);
+}
+
+async function getEditedTitle( page: {
+	evaluate: < T >( callback: () => T ) => Promise< T >;
+} ): Promise< string > {
+	return page.evaluate( () =>
+		( window as any ).wp.data
+			.select( 'core/editor' )
+			.getEditedPostAttribute( 'title' )
+	);
+}
+
+test.describe( 'Collaboration - same-user title reload loss', () => {
+	test( 'keeps an unsaved same-user title in a reloaded browser session', async ( {
+		collaborationUtils,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		test.setTimeout( 90_000 );
+
+		const customerTitle = 'RTC same-user unsaved title before reload';
+
+		const post = await requestUtils.createPost( {
+			title: 'RTC same-user reload initial',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+			content:
+				'<!-- wp:paragraph --><p>Initial body.</p><!-- /wp:paragraph -->',
+		} );
+
+		await collaborationUtils.openPost( post.id );
+		await collaborationUtils.joinUser( post.id, ADMIN_USER );
+		await waitForSameUserSession( collaborationUtils );
+		const { editor2, page2 } = collaborationUtils;
+
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( customerTitle );
+		await expect
+			.poll( () => getEditedTitle( page2 ), { timeout: 20_000 } )
+			.toBe( customerTitle );
+
+		await editor2.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.click();
+		await page2.keyboard.press( 'End' );
+		await page2.keyboard.press( 'Enter' );
+		await page2.keyboard.type( 'same user reload companion edit' );
+
+		await page2.reload( { waitUntil: 'domcontentloaded' } );
+		await waitForSameUserSession( collaborationUtils );
+
+		await expect
+			.poll( () => getEditedTitle( page2 ), { timeout: 20_000 } )
+			.toBe( customerTitle );
+		expect( await getEditedTitle( page ) ).toBe( customerTitle );
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/websocket-only/collaboration-table-followups.spec.ts
+++ b/test/e2e/specs/editor/collaboration/websocket-only/collaboration-table-followups.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * External dependencies
+ */
+import type { Page } from '@playwright/test';
+
+/**
+ * WordPress dependencies
+ */
+import type { Editor } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { test, expect } from '../fixtures';
+import type { UserCredentials } from '../fixtures/collaboration-utils';
+
+const COLLABORATOR: UserCredentials = {
+	username: 'table_collaborator',
+	email: 'table_collaborator@example.com',
+	firstName: 'Table',
+	lastName: 'Collaborator',
+	password: 'password',
+	roles: [ 'editor' ],
+};
+
+async function tableCells( editor: Editor ) {
+	return editor.canvas.getByRole( 'textbox', { name: 'Body cell text' } );
+}
+
+async function typeCell(
+	editor: Editor,
+	page: Page,
+	index: number,
+	text: string
+) {
+	await ( await tableCells( editor ) ).nth( index ).click();
+	await page.keyboard.press( 'ControlOrMeta+a' );
+	await page.keyboard.type( text );
+}
+
+async function clickTableMenuItem( editor: Editor, page: Page, name: string ) {
+	await editor.clickBlockToolbarButton( 'Edit table' );
+	await page.getByRole( 'menuitem', { name } ).click();
+}
+
+async function getVisibleTable( editor: Editor ): Promise< string[][] > {
+	return editor.canvas
+		.locator( '[data-type="core/table"] tbody tr' )
+		.evaluateAll( ( rows ) =>
+			rows.map( ( row ) =>
+				Array.from( row.querySelectorAll( 'td, th' ) ).map( ( cell ) =>
+					( cell.textContent || '' ).trim()
+				)
+			)
+		);
+}
+
+async function expectVisibleTables(
+	editorA: Editor,
+	editorB: Editor,
+	expected: string[][]
+) {
+	await expect
+		.poll( () => getVisibleTable( editorA ), { timeout: 15_000 } )
+		.toEqual( expected );
+	await expect
+		.poll( () => getVisibleTable( editorB ), { timeout: 15_000 } )
+		.toEqual( expected );
+}
+
+function expectSavedTableContent( content: string ) {
+	expect( content.match( /<tr>/g ) ).toHaveLength( 2 );
+	expect( content ).toContain( '<td>anchor</td><td></td>' );
+	expect( content ).toContain( '<td>edited-duplicate</td><td>extra</td>' );
+	expect( content ).not.toContain( '<td>same</td>' );
+}
+
+function tableContent( rows: string[][] ) {
+	const body = rows
+		.map(
+			( row ) =>
+				`<tr>${ row
+					.map( ( cell ) => `<td>${ cell }</td>` )
+					.join( '' ) }</tr>`
+		)
+		.join( '' );
+
+	return `<!-- wp:table -->\n<figure class="wp-block-table"><table><tbody>${ body }</tbody></table></figure>\n<!-- /wp:table -->`;
+}
+
+test.describe( 'Collaboration - WebSocket table follow-ups', () => {
+	// eslint-disable-next-line playwright/expect-expect
+	test( 'preserves a remote-edited duplicate table row when another user deletes the earlier duplicate row', async ( {
+		collaborationUtils,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		test.setTimeout( 90_000 );
+
+		await requestUtils.createUser( COLLABORATOR );
+		const post = await requestUtils.createPost( {
+			title: 'RTC table duplicate row follow-up',
+			content: tableContent( [ [ 'anchor' ], [ 'same' ] ] ),
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+		} );
+
+		await collaborationUtils.openPost( post.id );
+		const { editor: editor2, page: page2 } =
+			await collaborationUtils.joinUser( post.id, COLLABORATOR );
+		await collaborationUtils.waitForMutualDiscovery();
+		await expectVisibleTables( editor, editor2, [
+			[ 'anchor' ],
+			[ 'same' ],
+		] );
+
+		await ( await tableCells( editor ) ).nth( 1 ).click();
+		await clickTableMenuItem( editor, page, 'Insert row after' );
+		await typeCell( editor, page, 2, 'same' );
+		await collaborationUtils.waitForMutualDiscovery();
+		await expectVisibleTables( editor, editor2, [
+			[ 'anchor' ],
+			[ 'same' ],
+			[ 'same' ],
+		] );
+
+		await ( await tableCells( editor ) ).nth( 1 ).click();
+		await typeCell( editor2, page2, 2, 'edited-duplicate' );
+		await ( await tableCells( editor2 ) ).nth( 2 ).click();
+		await clickTableMenuItem( editor2, page2, 'Insert column after' );
+		await typeCell( editor2, page2, 5, 'extra' );
+		await clickTableMenuItem( editor, page, 'Delete row' );
+		await collaborationUtils.waitForMutualDiscovery();
+
+		await expectVisibleTables( editor, editor2, [
+			[ 'anchor', '' ],
+			[ 'edited-duplicate', 'extra' ],
+		] );
+
+		await editor2.saveDraft();
+		const savedPost = await requestUtils.rest< {
+			content: { raw: string };
+		} >( {
+			path: `/wp/v2/posts/${ post.id }`,
+			params: { context: 'edit' },
+		} );
+		expectSavedTableContent( savedPost.content.raw );
+
+		await page.reload( { waitUntil: 'load' } );
+		await collaborationUtils.waitForEntityReadyAndSaveSettled( page );
+		await page2.reload( { waitUntil: 'load' } );
+		await collaborationUtils.waitForEntityReadyAndSaveSettled( page2 );
+
+		await expectVisibleTables( editor, editor2, [
+			[ 'anchor', '' ],
+			[ 'edited-duplicate', 'extra' ],
+		] );
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

This is part of an AI fuzzing project, where an AI wrote a fuzzer and then triages bugs from the fuzzer and creates fixes. See #77716 for the tracking issue. As of this writing, there have been no known false positives from this project, but there have been some issues, which are documented in #77716. I expect we’ll see false positives at some point (and may even have one that’s been filed in a PR that hasn’t been inspected by a code owner yet).

## What?

Depends on #77920 (add e2e WebSocket tests).

This fixes a set of issues that were exposed by porting the existing RTC e2e tests to WebSockets. Here are videos that show some symptoms from the set of bugs this fixes:


https://github.com/user-attachments/assets/90ba1fb3-31fb-4358-b0fe-976d9f8ff047

https://github.com/user-attachments/assets/01e85265-d2a7-4812-817c-c62d4de3ec1a

https://github.com/user-attachments/assets/6ec9adb5-a95b-4d26-b332-d01b40d539fa

Two of these videos look very similar to other PRs that are part of #77716, but they still reproduce with all of those fixes applied, so the source of the bugs seems to be distinct.

Only the WebSocket room readiness bug requires WebSockets, and that's a bug in the test WebSocket provider, but just running the e2e tests triggered multiple failures and on debugging and fixing those, there are nearby failures that seem to make sense to bundle into a fix since a lot of the failures are related. Some of these bugs are easier to hit with WebSockets than HTTP, but they're generally bugs that could be hit over WebSockets or HTTP.


## AI TEXT

This branch fixes stale-state bugs at the boundaries between the WordPress
entity store, Yjs CRDT documents, and the local WebSocket RTC transport. The
user-visible repros are:

-   same-user unsaved title loss after another browser session reloads;
-   concurrent list-item moves where each browser can lose the other user's
    move;
-   duplicate table row follow-up divergence after normal table toolbar edits.

Those symptoms are grouped below by source rather than by surface behavior. The
common failure pattern is that stale state is treated as fresh authority: a REST
record, local bootstrap document, queued editor-store snapshot, or value-based
table row match becomes a CRDT update after newer peer state already exists.

## Bug Source 1: CRDT Persistence Saves Re-Applied Stale REST Fields

### Cause

`persistCRDTDoc()` needs to save the entity so the pre-persist hook can refresh
`meta._crdt_document`. That save is not meant to make the REST title/content
authoritative. Before this branch, it could still pass the full edited record to
`saveEntityRecord()`, then `saveEntityRecord()` could feed the full REST save
response back into `syncManager.update( ..., { isSave: true } )`. If the edited
record or REST response was older than the current Y.Doc, stale title/content
became a fresh collaborative update.

### How It Was Introduced

[`84019935998c`](https://github.com/WordPress/gutenberg/commit/84019935998c16f877e976ad85e84748355d7282)
from [WordPress/gutenberg#72262](https://github.com/WordPress/gutenberg/pull/72262)
introduced the post-entity CRDT merge path, including `mergeCrdtBlocks()` and
conversion between edited post records and Yjs state. That was the point where
the WordPress entity store and the Y.Doc both started carrying values for the
same logical post fields.

[`be1c20e213e`](https://github.com/WordPress/gutenberg/commit/be1c20e213e7d2a2858d6ec92da23268ea0a8127)
from [WordPress/gutenberg#74637](https://github.com/WordPress/gutenberg/pull/74637)
added saved-entity metadata and refetch behavior for RTC. As part of that, a
normal entity save began calling
`syncManager.update( updatedRecord, ..., { isSave: true } )`. That is reasonable
for a user save, but unsafe for a save whose only purpose is persisting the CRDT
blob.

[`c4e4fac0a26`](https://github.com/WordPress/gutenberg/commit/c4e4fac0a26bfb2dc38f17c765f2e84266b68b99)
from [WordPress/gutenberg#75699](https://github.com/WordPress/gutenberg/pull/75699)
removed the Gutenberg-plugin-only guard around collaborative editing paths,
making this save-response sync path generally active.

[`4961c7e3c3`](https://github.com/WordPress/gutenberg/commit/4961c7e3c3e1d32e72e7ad76ec8f7bd0810a1b2e)
from [WordPress/gutenberg#76206](https://github.com/WordPress/gutenberg/pull/76206)
changed save-response updates to use `LOCAL_UNDO_IGNORED_ORIGIN`, which avoided
creating undo levels. It did not change the fact that the full REST response
could still be applied as a new CRDT update.

### Reproduced Symptom

Same-user title reload loss:

1. Browser A and Browser B open the same draft as the same user.
2. Browser A changes the title but does not save.
3. Browser B makes a companion edit, reloads, and rejoins the WebSocket room.
4. Expected: both browsers keep Browser A's unsaved title.
5. Failing behavior: Browser B briefly receives the unsaved title, then a stale
   persistence save writes the old REST title back into the CRDT and broadcasts
   it to Browser A.

Evidence:

-   video:
    `/private/tmp/gutenberg-ws-current-known-fixes-videos-20260505/ws-title-reload-loss-current-known-fixes-wrong-convergence.mp4`;
-   action log:
    `/private/tmp/gutenberg-ws-current-known-fixes-videos-20260505/ws-title-reload-loss-current-known-fixes-wrong-convergence-action-log.md`;
-   Playwright regression:
    `test/e2e/specs/editor/collaboration/websocket/collaboration-same-user-title-reload-loss.spec.ts`;
-   unit coverage:
    `packages/core-data/src/test/resolvers.js`.

### Fix

`persistCRDTDoc()` now saves only the entity key and `meta`, and passes
`__unstableSkipSyncUpdate`. `saveEntityRecord()` can still mark the Y.Doc saved,
but it does not apply REST title/content fields back into the collaborative
document for this persistence-only save.

## Bug Source 2: WebSocket Join Readiness Published Local Bootstrap State Too Early

### Cause

The local WebSocket provider used by the RTC e2e suite treated an open socket as
effectively ready. A joining peer sent its local Yjs state in the `join`
message, and the relay stored and broadcast that state before the peer had
received a canonical room snapshot. A reload or late join could therefore turn
local bootstrap/REST state into room history.

This source is WebSocket-transport-specific. The other bug sources in this
report are core-data/sync/merge bugs that WebSockets make easier to trigger but
do not inherently require WebSockets.

### How It Was Introduced

[`77132ffead0`](https://github.com/danluu/gutenberg/commit/77132ffead006848e2c581a410ce0f6767013e87)
added the branch-local RTC WebSocket e2e suite and test provider. There is no
upstream WordPress PR for this local test-provider commit. Its first relay
stored `message.state` during `join` and immediately broadcast it. The provider
also emitted `connected` on socket open and flushed queued messages before a
snapshot/peer-state boundary existed.

The same bug source was fixed in this branch by
[`c72cbb4a0e8`](https://github.com/danluu/gutenberg/commit/c72cbb4a0e89f14bcb0a794be96a0ce916926760),
which changed the relay to maintain room Y.Doc state, ask existing peers for
missing state via state vectors, and resolve provider readiness only after the
snapshot or peer-state response has been applied.

### Reproduced Symptoms

The title reload repro above depends on this source to make the stale state
easy to hit: the reloaded browser joins while it has REST/bootstrap state and
must not publish that state before it receives the room's current Y.Doc.

The same readiness boundary also protects list/table tests from starting user
actions while a peer's document can still be local bootstrap state.

### Fix

The WebSocket relay now stores only updates that apply to the room Y.Doc and
uses Yjs state vectors for join synchronization. The provider resolves
readiness after it has applied a snapshot or a peer-state update. Joining peers
that received remote state mark the Y.Doc with provider-synced metadata, discard
queued local bootstrap messages, and prevent local sync-manager bootstrap
updates from becoming room history.

## Bug Source 3: Remote Reconciliation Allowed Stale Local Echoes

### Cause

Remote CRDT updates are reconciled into the editor store by computing changes
from the Y.Doc and dispatching `EDIT_ENTITY_RECORD`. Local editor-store updates
flow the other direction through `syncManager.update()`. Before this branch,
there was no per-key guard for the window where a remote `blocks` update had
entered the Y.Doc but the edited record had not fully caught up. A scheduled
local update based on the pre-remote edited record could echo the stale value
back into the Y.Doc.

For `blocks`, that stale value is a whole block tree, not an operation. A
delayed whole-tree write can erase a non-conflicting remote move.

### How It Was Introduced

[`84019935998c`](https://github.com/WordPress/gutenberg/commit/84019935998c16f877e976ad85e84748355d7282)
from [WordPress/gutenberg#72262](https://github.com/WordPress/gutenberg/pull/72262)
introduced the bidirectional entity/CRDT conversion for post blocks. The code
was designed around snapshots of entity fields. That made the editor/CRDT
handoff generic, but it also meant a list-item move reached the CRDT layer as
"here is the current `blocks` array" rather than "move this item after that
item".

The original merge path did not carry the pre-edit base record into
`applyChangesToCRDTDoc()`, and the sync manager did not track which top-level
keys were still reconciling from remote state. Those missing happens-before
edges are what allowed stale whole-key echoes.

### Reproduced Symptom

Concurrent list-item move loss:

1. Browser A and Browser B open the same list:
   `Alpha, Beta, Gamma, Delta, Epsilon, Zeta`.
2. Browser A moves `Beta` down with the normal toolbar button.
3. Browser B moves `Epsilon` up with the normal toolbar button.
4. Expected merged order:
   `Alpha, Gamma, Beta, Epsilon, Delta, Zeta`.
5. Failing behavior: each browser keeps its own move and loses the other move.

Evidence:

-   clearer attempt-4 video:
    `/private/tmp/gutenberg-ws-current-known-fixes-videos-20260505/ws-concurrent-list-item-move-loss-test4-annotated.mp4`;
-   action log:
    `/private/tmp/gutenberg-ws-current-known-fixes-videos-20260505/ws-concurrent-list-item-move-loss-test4-annotated-action-log.md`;
-   Playwright regression:
    `test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts`
    (`two users concurrently move list items`), imported by the WebSocket suite;
-   sync-manager and block-merge unit coverage:
    `packages/sync/src/test/manager.ts` and
    `packages/core-data/src/utils/test/crdt-blocks.ts`.

### Fix

Local store-to-CRDT updates now carry the pre-edit `baseRecord`. The sync
manager tracks remote key versions and keeps keys in a reconciling set while
remote changes are being applied to the edited record. Non-save local updates
for those keys are filtered if a newer remote version arrived after the local
update was scheduled.

## Bug Source 4: Block Reorder Merges Lacked Identity/Base Rebasing

### Cause

Even after stale local echoes are filtered, block moves still need a way to
preserve non-conflicting remote edits. The original block merge used left/right
equality sweeps over whole arrays. That can update the changed middle of a list,
but it does not by itself rebase a delayed local move over a remote move or
preserve a remote edit inside a block that moved.

List items do have stable block `clientId`s during an editing session, so the
merge can use them as an identity source when the base and current arrays have
the same set of blocks.

### How It Was Introduced

[`84019935998c`](https://github.com/WordPress/gutenberg/commit/84019935998c16f877e976ad85e84748355d7282)
from [WordPress/gutenberg#72262](https://github.com/WordPress/gutenberg/pull/72262)
introduced `mergeCrdtBlocks()` with a generic array-diff approach. That was a
reasonable starting point for many block edits, but it intentionally avoided
block-specific operation semantics.

The list-move failure exposed the missing rebase step. A branch-local fix in
[`c72cbb4a0e8`](https://github.com/danluu/gutenberg/commit/c72cbb4a0e89f14bcb0a794be96a0ce916926760)
added base-record propagation and `clientId` reorder support.
[`87a680ece2e`](https://github.com/danluu/gutenberg/commit/87a680ece2e8805693b34f10287f4115ce932e7e)
then fixed the follow-up case where rebasing the order could still overwrite a
remote edit inside a moved block by treating base-unchanged fields as stale, not
local intent.

### Reproduced Symptom

This source contributes to the same concurrent list-item move repro as Bug
Source 3. The additional unit evidence is:

-   `does not overwrite remote list item content while rebasing a delayed move`
    in `packages/core-data/src/utils/test/crdt-blocks.ts`.

### Fix

`mergeCrdtBlocks()` can rebase block arrays by `clientId` when the base,
incoming, and current arrays contain the same block identities. During the
field merge, values unchanged from the base are skipped so a delayed local move
does not overwrite remote edits inside the moved blocks.

## Bug Source 5: Nested Table Array/Object Merges Had No Durable Row Identity

### Cause

`core/table` rows and cells are nested schema-aware attributes. Unlike list
items, table rows/cells do not have durable block `clientId`s. When two rows
contain the same visible value, a value-based two-way merge can match the wrong
duplicate. A stale local snapshot that says "one `same` row remains" can be
satisfied by deleting a remotely edited duplicate and keeping the stale
unchanged duplicate.

Nested object merging had a second version of the same authority bug: while a
base object was available, the merge still applied every key present in the
incoming object. A key unchanged from the base could overwrite a remote sibling
edit in the current Y.Map.

### How It Was Introduced

[`09a21c64b5b9`](https://github.com/WordPress/gutenberg/commit/09a21c64b5b92c2626bd93065d4a0192eb4fac47)
from [WordPress/gutenberg#76913](https://github.com/WordPress/gutenberg/pull/76913)
changed `core/table` cells from plain replacement values into schema-aware Yjs
structures. This fixed important cell-level merge cases, but table rows and
cells still had no durable identity. Matching remained value/position based.

[`a6bfd3e55432`](https://github.com/WordPress/gutenberg/commit/a6bfd3e55432981c7c2cb09190ee77954530b1a5)
from [WordPress/gutenberg#77164](https://github.com/WordPress/gutenberg/pull/77164)
improved array attribute stability with a left/right sweep. That preserved
Yjs object identity for many structural edits, but it was still a two-way diff
between the incoming snapshot and current CRDT value. It did not use the local
pre-edit base value to identify which duplicate row was deleted.

The duplicate-row follow-up repro is the bad case for that design: Browser A's
stale local table body says one duplicate remains; Browser B has already edited
the other duplicate and added a cell to it.

### Reproduced Symptom

Duplicate table row follow-up divergence:

1. Browser A creates a 1-column table with rows `anchor`, `same`, `same`.
2. Browser B edits the second duplicate row to `edited-duplicate`.
3. Browser B inserts a column after that row and types `extra`.
4. Browser A deletes the earlier duplicate row.
5. Expected: both browsers show `anchor / empty` and
   `edited-duplicate / extra`.
6. Failing behavior: Browser B can keep an extra stale duplicate row. Follow-up
   save/reload can then converge the editors to content that differs from saved
   raw post content.

Evidence:

-   video:
    `/private/tmp/gutenberg-ws-current-known-fixes-videos-20260505/table-duplicate-row-followup-visible-divergence-fullwindow.mp4`;
-   action log:
    `/private/tmp/gutenberg-ws-current-known-fixes-videos-20260505/table-duplicate-row-followup-visible-divergence-fullwindow-action-log.md`;
-   unit regressions:
    `preserves a remote-edited duplicate table row when a stale local snapshot deletes the earlier duplicate row`
    and
    `preserves remote sibling fields when a stale local nested object changes another field`
    in `packages/core-data/src/utils/test/crdt-blocks.ts`;
-   Playwright regression:
    `test/e2e/specs/editor/collaboration/websocket/collaboration-table-followups.spec.ts`.

### Fix

Nested schema-aware array merges now receive the pre-edit base value. When the
current Y.Array still has the base shape, the merge applies structural changes
relative to that base and skips elements/fields unchanged from the base. For an
ambiguous single deletion among duplicate values, it prefers deleting the
duplicate whose current Yjs value still equals the base row, preserving the row
that has remote edits. Nested object merges also skip keys unchanged from the
base so stale sibling fields do not clobber remote edits.

This is intentionally conservative. If the current Y.Array no longer has the
base shape, the merge falls back to the older two-way behavior. Durable row/cell
identity would be a better long-term model for more complex simultaneous table
structure edits.

## Fix Plan

1. Keep CRDT persistence saves narrow: save only entity key plus `meta`, and
   use `__unstableSkipSyncUpdate` so REST fields do not become collaborative
   updates.
2. Keep the WebSocket snapshot/readiness protocol: joining peers must receive a
   room snapshot or peer-state response before publishing local bootstrap state.
3. Keep remote-key reconciliation filtering in the sync manager: stale local
   scheduled writes for keys being reconciled from remote state are dropped.
4. Keep base-record propagation through store-to-CRDT updates.
5. Keep block `clientId` rebasing for block arrays where stable identity exists.
6. Keep base-aware nested array/object merging for schema-aware attributes.
7. Treat durable identity for structured attributes such as table rows/cells as
   follow-up work beyond the reproduced bugs fixed here.

## END AI TEXT
