### PR TITLE
Add internal image editing session boundary

### DIFF
--- a/packages/media-editor/src/components/image-editing-session/index.tsx
+++ b/packages/media-editor/src/components/image-editing-session/index.tsx
@@ -1,0 +1,117 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+} from '@wordpress/element';
+import type { ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	CropperProvider,
+	useCropperState,
+	type UseCropperStateReturn,
+} from '../../image-editor';
+import {
+	buildModifiers,
+	type Modifier,
+} from '../media-editor-modal/build-modifiers';
+
+interface WorkingImage {
+	src: string;
+	width: number;
+	height: number;
+}
+
+export interface ImageEditingSession {
+	/** Current source being edited by the image session. */
+	workingImage: WorkingImage | null;
+	/** Low-level cropper controller. */
+	cropper: UseCropperStateReturn;
+	/** Whether the image session has unsaved image edits. */
+	isDirty: boolean;
+	/** Whether the image session has undo history. */
+	hasUndo: boolean;
+	/** Whether the image session has redo history. */
+	hasRedo: boolean;
+	/** Undo the last image session edit. */
+	undo: () => void;
+	/** Redo the last undone image session edit. */
+	redo: () => void;
+	/** Reset the current image edits. */
+	reset: () => void;
+	/** Commit any pending continuous edit to history. */
+	commitHistory: () => void;
+	/** Build the Core REST media edit modifiers for the current image state. */
+	buildSaveModifiers: () => Modifier[];
+}
+
+const ImageEditingSessionContext = createContext<
+	ImageEditingSession | undefined
+>( undefined );
+
+export function ImageEditingSessionProvider( {
+	children,
+}: {
+	children: ReactNode;
+} ) {
+	const cropper = useCropperState();
+
+	const workingImage = useMemo< WorkingImage | null >( () => {
+		if ( ! cropper.state.image ) {
+			return null;
+		}
+		return {
+			src: cropper.state.image.src,
+			width: cropper.state.image.naturalWidth,
+			height: cropper.state.image.naturalHeight,
+		};
+	}, [ cropper.state.image ] );
+
+	const buildSaveModifiers = useCallback( () => {
+		if ( ! cropper.isDirty || ! cropper.state.image ) {
+			return [];
+		}
+		return buildModifiers( cropper.state, {
+			width: cropper.state.image.naturalWidth,
+			height: cropper.state.image.naturalHeight,
+		} );
+	}, [ cropper.isDirty, cropper.state ] );
+
+	const session = useMemo< ImageEditingSession >(
+		() => ( {
+			workingImage,
+			cropper,
+			isDirty: cropper.isDirty,
+			hasUndo: cropper.hasUndo,
+			hasRedo: cropper.hasRedo,
+			undo: cropper.undo,
+			redo: cropper.redo,
+			reset: () => cropper.reset(),
+			commitHistory: cropper.commitHistory,
+			buildSaveModifiers,
+		} ),
+		[ cropper, workingImage, buildSaveModifiers ]
+	);
+
+	return (
+		<ImageEditingSessionContext.Provider value={ session }>
+			<CropperProvider value={ cropper }>{ children }</CropperProvider>
+		</ImageEditingSessionContext.Provider>
+	);
+}
+
+export function useImageEditingSession(): ImageEditingSession {
+	const context = useContext( ImageEditingSessionContext );
+	if ( ! context ) {
+		throw new Error(
+			'useImageEditingSession must be used within ImageEditingSessionProvider.'
+		);
+	}
+	return context;
+}

--- a/packages/media-editor/src/components/image-editing-session/test/index.tsx
+++ b/packages/media-editor/src/components/image-editing-session/test/index.tsx
@@ -1,0 +1,153 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { ImageEditingSessionProvider, useImageEditingSession } from '..';
+import { useCropper } from '../../../image-editor';
+import { buildModifiers } from '../../media-editor-modal/build-modifiers';
+
+const TEST_IMAGE = {
+	src: 'test.jpg',
+	naturalWidth: 1000,
+	naturalHeight: 500,
+};
+
+function SessionWrapper( { children }: { children: ReactNode } ) {
+	return (
+		<ImageEditingSessionProvider>{ children }</ImageEditingSessionProvider>
+	);
+}
+
+function setup() {
+	return renderHook( () => useImageEditingSession(), {
+		wrapper: SessionWrapper,
+	} );
+}
+
+describe( 'ImageEditingSessionProvider', () => {
+	it( 'starts with a clean session', () => {
+		const { result } = setup();
+
+		expect( result.current.isDirty ).toBe( false );
+		expect( result.current.hasUndo ).toBe( false );
+		expect( result.current.hasRedo ).toBe( false );
+		expect( result.current.workingImage ).toBeNull();
+	} );
+
+	it( 'tracks the current working image without marking the session dirty', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.cropper.setImage( TEST_IMAGE );
+		} );
+
+		expect( result.current.workingImage ).toEqual( {
+			src: TEST_IMAGE.src,
+			width: TEST_IMAGE.naturalWidth,
+			height: TEST_IMAGE.naturalHeight,
+		} );
+		expect( result.current.isDirty ).toBe( false );
+	} );
+
+	it( 'provides the session-owned cropper through the cropper context', () => {
+		const { result } = renderHook(
+			() => ( {
+				session: useImageEditingSession(),
+				cropper: useCropper(),
+			} ),
+			{ wrapper: SessionWrapper }
+		);
+
+		expect( result.current.cropper ).toBe( result.current.session.cropper );
+	} );
+
+	it( 'marks the image session dirty when cropper state changes', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.cropper.setZoom( 3 );
+		} );
+
+		expect( result.current.isDirty ).toBe( true );
+	} );
+
+	it( 'undoes and redoes cropper edits through the session', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.cropper.setZoom( 3 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+
+		expect( result.current.isDirty ).toBe( true );
+		expect( result.current.hasUndo ).toBe( true );
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.cropper.state.zoom ).toBe( 1 );
+		expect( result.current.isDirty ).toBe( false );
+		expect( result.current.hasRedo ).toBe( true );
+
+		act( () => {
+			result.current.redo();
+		} );
+
+		expect( result.current.cropper.state.zoom ).toBe( 3 );
+		expect( result.current.isDirty ).toBe( true );
+		expect( result.current.hasRedo ).toBe( false );
+	} );
+
+	it( 'resets cropper edits through the session', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.cropper.setZoom( 3 );
+		} );
+
+		expect( result.current.isDirty ).toBe( true );
+
+		act( () => {
+			result.current.reset();
+		} );
+
+		expect( result.current.cropper.state.zoom ).toBe( 1 );
+		expect( result.current.isDirty ).toBe( false );
+	} );
+
+	it( 'builds no save modifiers for a clean session', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.cropper.setImage( TEST_IMAGE );
+		} );
+
+		expect( result.current.buildSaveModifiers() ).toEqual( [] );
+	} );
+
+	it( 'builds the same save modifiers as the cropper modifier helper', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.cropper.setImage( TEST_IMAGE );
+		} );
+		act( () => {
+			result.current.cropper.snapRotate90( 1 );
+		} );
+
+		expect( result.current.buildSaveModifiers() ).toEqual(
+			buildModifiers( result.current.cropper.state, {
+				width: TEST_IMAGE.naturalWidth,
+				height: TEST_IMAGE.naturalHeight,
+			} )
+		);
+	} );
+} );

--- a/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
@@ -8,7 +8,12 @@ import { fireEvent, render, screen } from '@testing-library/react';
  */
 import MediaEditorCropPanel from '..';
 import type { MediaEditorCropPanelProps } from '..';
-import { CropperProvider } from '../../../image-editor';
+import { CropperProvider, useCropperState } from '../../../image-editor';
+
+function CropperHarness( { children }: { children: React.ReactNode } ) {
+	const cropper = useCropperState();
+	return <CropperProvider value={ cropper }>{ children }</CropperProvider>;
+}
 
 function setupCropPanel(
 	overrides: Partial< MediaEditorCropPanelProps > = {}
@@ -22,9 +27,9 @@ function setupCropPanel(
 	};
 
 	render(
-		<CropperProvider>
+		<CropperHarness>
 			<MediaEditorCropPanel { ...props } />
-		</CropperProvider>
+		</CropperHarness>
 	);
 
 	return props;

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -49,10 +49,12 @@ import MediaEditorCropPanel, {
 import MediaForm from '../media-form';
 import { unlock } from '../../lock-unlock';
 import { getMediaTypeFromMimeType } from '../../utils';
-import { CropperProvider, useCropper } from '../../image-editor';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
 import { CROP_CONTROL_ATTR } from '../../hooks/use-crop-gesture-handlers';
-import { buildModifiers } from '../media-editor-modal/build-modifiers';
+import {
+	ImageEditingSessionProvider,
+	useImageEditingSession,
+} from '../image-editing-session';
 import MediaEditorKeyboardShortcutsModal from '../media-editor-keyboard-shortcuts-modal';
 
 // Details-tab edits are bundled into transformed `/edit` requests. Core's
@@ -235,7 +237,7 @@ function MediaEditorContent( {
 	showCloseButton = false,
 	shouldCloseOnEsc = false,
 }: MediaEditorProps ) {
-	const cropper = useCropper();
+	const imageSession = useImageEditingSession();
 
 	const { media, hasEdits } = useSelect(
 		( select ) => {
@@ -257,7 +259,7 @@ function MediaEditorContent( {
 		[ id ]
 	);
 
-	const hasChanges = cropper.isDirty || hasEdits;
+	const hasChanges = imageSession.isDirty || hasEdits;
 
 	const registry = useRegistry();
 	const {
@@ -403,13 +405,7 @@ function MediaEditorContent( {
 		try {
 			let saved: Media | null | undefined;
 
-			const modifiers =
-				cropper.isDirty && cropper.state.image
-					? buildModifiers( cropper.state, {
-							width: cropper.state.image.naturalWidth,
-							height: cropper.state.image.naturalHeight,
-					  } )
-					: [];
+			const modifiers = imageSession.buildSaveModifiers();
 
 			if ( modifiers.length > 0 ) {
 				const pendingEdits = registry
@@ -461,7 +457,7 @@ function MediaEditorContent( {
 
 			if ( next && next.id ) {
 				if ( next.id === id ) {
-					cropper.reset();
+					imageSession.reset();
 				}
 				onSaved?.( {
 					id: next.id,
@@ -512,9 +508,9 @@ function MediaEditorContent( {
 					return;
 				}
 				if ( isRedoShortcut ) {
-					cropper.redo();
+					imageSession.redo();
 				} else {
-					cropper.undo();
+					imageSession.undo();
 				}
 			}
 		}
@@ -657,10 +653,13 @@ function MediaEditorContent( {
 }
 
 export function MediaEditor( props: MediaEditorProps ) {
+	// `ImageEditingSessionProvider` owns the cropper controller lifecycle.
+	// Keying on `id` remounts the session when the edited attachment changes,
+	// discarding previous image edit state.
 	return (
-		<CropperProvider key={ props.id }>
+		<ImageEditingSessionProvider key={ props.id }>
 			<MediaEditorContent { ...props } />
-		</CropperProvider>
+		</ImageEditingSessionProvider>
 	);
 }
 

--- a/packages/media-editor/src/image-editor/README.md
+++ b/packages/media-editor/src/image-editor/README.md
@@ -67,7 +67,12 @@ Main cropper component. Fills its parent container.
 
 #### `CropperProvider` / `useCropper()`
 
-Context wrapper for deep component trees. Wraps `useCropperState` and provides it to descendants via `useCropper()`.
+Context wrapper for deep component trees. Owns no state itself — pass a controller from `useCropperState()` as `value`, and any descendant can read it via `useCropper()`.
+
+```tsx
+const cropper = useCropperState();
+return <CropperProvider value={ cropper }>{ children }</CropperProvider>;
+```
 
 ### React hooks
 

--- a/packages/media-editor/src/image-editor/docs/recipes.md
+++ b/packages/media-editor/src/image-editor/docs/recipes.md
@@ -229,11 +229,17 @@ function ImageEditor() {
 When controls and the cropper are in different parts of the tree, use `CropperProvider` to avoid prop-drilling. Any descendant can call `useCropper()` to access the controller:
 
 ```tsx
-import { Cropper, CropperProvider, useCropper } from '../image-editor';
+import {
+  Cropper,
+  CropperProvider,
+  useCropper,
+  useCropperState,
+} from '../image-editor';
 
 function ImageEditor() {
+  const cropper = useCropperState();
   return (
-    <CropperProvider>
+    <CropperProvider value={ cropper }>
       <Toolbar />
       <CropperPanel />
       <Sidebar />

--- a/packages/media-editor/src/image-editor/react/components/cropper-provider.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper-provider.tsx
@@ -6,11 +6,7 @@ import { createContext, useContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import {
-	useCropperState,
-	type UseCropperStateReturn,
-} from '../hooks/use-cropper-state';
-import type { CropperState } from '../../core/types';
+import type { UseCropperStateReturn } from '../hooks/use-cropper-state';
 
 /**
  * The context value type for the CropperProvider.
@@ -24,31 +20,27 @@ const CropperContext = createContext< CropperContextValue >( null );
  * Props for the CropperProvider component.
  */
 interface CropperProviderProps {
-	/** Optional partial initial state to merge with defaults. */
-	initialState?: Partial< CropperState >;
+	/** Cropper controller created by the image editing session. */
+	value: UseCropperStateReturn;
 	/** Child components. */
 	children: React.ReactNode;
 }
 
 /**
- * Convenience context provider that wraps useCropperState.
+ * Context provider for an existing cropper controller.
  *
- * Provides the full cropper state and action creators to all
- * descendant components via React context.
+ * The media editor image editing session owns the controller lifecycle; this
+ * provider only makes that controller available to cropper-specific children
+ * through `useCropper()`.
  *
- * @param props              Provider props.
- * @param props.initialState
+ * @param props
+ * @param props.value
  * @param props.children
  * @return The provider element wrapping children.
  */
-export function CropperProvider( {
-	initialState,
-	children,
-}: CropperProviderProps ) {
-	const cropperReturn = useCropperState( initialState );
-
+export function CropperProvider( { value, children }: CropperProviderProps ) {
 	return (
-		<CropperContext.Provider value={ cropperReturn }>
+		<CropperContext.Provider value={ value }>
 			{ children }
 		</CropperContext.Provider>
 	);


### PR DESCRIPTION
## What changed

Adds an internal image editing session boundary for the media editor modal.

The new `ImageEditingSessionProvider` owns the cropper controller, exposes modal-level image editing state through a session facade, and passes that controller into `CropperProvider` for cropper-specific UI consumers. The modal now reads image dirty state, undo/redo, and save modifier generation through the session instead of directly from the cropper context.

This keeps current crop UI behavior unchanged while creating a clear ownership boundary for future image editing state such as native adjustments, filters, and image-surface extensions.

## Why

The cropper should remain the low-level geometry controller, but the media editor needs a session-level owner before adding adjustments or extension-owned image edits. This avoids a temporary bridge API and makes the internal ownership model explicit from the first step.

## Validation

- `npm run test:unit packages/media-editor/src/components/image-editing-session/test/index.tsx -- --runInBand`
- `npm run test:unit packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts -- --runInBand`
- `npm exec -- prettier --check packages/media-editor/src/components/image-editing-session/index.tsx packages/media-editor/src/components/image-editing-session/test/index.tsx packages/media-editor/src/image-editor/react/components/cropper-provider.tsx`
- `npm run lint:js packages/media-editor/src/components/image-editing-session/index.tsx packages/media-editor/src/components/image-editing-session/test/index.tsx packages/media-editor/src/image-editor/react/components/cropper-provider.tsx`
- `git diff --check`