### PR TITLE
Image editor: suppress interaction while undo/redo

### DIFF
--- a/packages/media-editor/src/image-editor/core/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/interaction-controller.ts
@@ -13,6 +13,8 @@ import { restrictPanZoom } from './containment';
 
 /** Time window for detecting a double-tap gesture (ms). */
 const DOUBLE_TAP_TIME = 300;
+/** Inactivity window after which a wheel stream is considered idle (ms). */
+const WHEEL_IDLE_MS = 300;
 /** Max distance between taps to count as a double-tap (px). */
 const DOUBLE_TAP_DISTANCE = 30;
 /** Duration of the zoom animation state (ms). */
@@ -192,6 +194,12 @@ export class InteractionController {
 	/** Whether a wheel gesture is currently active. */
 	private wheelGestureActive = false;
 
+	/** Timer for clearing suppressed wheel momentum after an interaction cancel. */
+	private wheelSuppressTimer: ReturnType< typeof setTimeout > | undefined;
+
+	/** Whether wheel events should be swallowed until the wheel stream goes idle. */
+	private suppressWheelUntilIdle = false;
+
 	/** Current requestAnimationFrame ID. */
 	private rafId = 0;
 
@@ -264,6 +272,46 @@ export class InteractionController {
 				isDragging: this.isDragging,
 				isZooming: this.isZooming,
 			} );
+		}
+	}
+
+	private scheduleWheelSuppressClear(): void {
+		clearTimeout( this.wheelSuppressTimer );
+		this.wheelSuppressTimer = setTimeout( () => {
+			this.suppressWheelUntilIdle = false;
+		}, WHEEL_IDLE_MS );
+	}
+
+	/**
+	 * Cancel any in-flight interaction without reporting a gesture end.
+	 *
+	 * This is used when external state replacement (undo/redo/reset) wins
+	 * over the current gesture. Reporting `onGestureEnd` here would let the
+	 * just-replaced state create a fresh history entry.
+	 *
+	 * @param options               Cancellation options.
+	 * @param options.suppressWheel Whether to swallow wheel momentum until idle.
+	 */
+	cancelActiveInteraction( options: { suppressWheel?: boolean } = {} ): void {
+		cancelAnimationFrame( this.rafId );
+		this.rafId = 0;
+
+		clearTimeout( this.zoomTimer );
+		clearTimeout( this.wheelGestureTimer );
+
+		this.pointerCleanup?.();
+		this.pointerCleanup = null;
+		this.touchCleanup?.();
+		this.touchCleanup = null;
+		this.drag = null;
+		this.touch = null;
+		this.lastTap = null;
+		this.wheelGestureActive = false;
+		this.setStatus( { isDragging: false, isZooming: false } );
+
+		if ( options.suppressWheel ) {
+			this.suppressWheelUntilIdle = true;
+			this.scheduleWheelSuppressClear();
 		}
 	}
 
@@ -384,6 +432,11 @@ export class InteractionController {
 	handleWheel( e: WheelEvent ): void {
 		e.preventDefault();
 
+		if ( this.suppressWheelUntilIdle ) {
+			this.scheduleWheelSuppressClear();
+			return;
+		}
+
 		if ( this.drag ) {
 			return;
 		}
@@ -398,7 +451,7 @@ export class InteractionController {
 		this.wheelGestureTimer = setTimeout( () => {
 			this.wheelGestureActive = false;
 			this.options.onGestureEnd?.();
-		}, DOUBLE_TAP_TIME );
+		}, WHEEL_IDLE_MS );
 
 		const s = this.options.getState();
 		const delta = -e.deltaY * this.zoomSpeed;
@@ -531,13 +584,17 @@ export class InteractionController {
 			this.options.onGestureStart?.();
 		}
 
+		const removeTouchListeners = () => {
+			doc.removeEventListener( 'touchmove', this.handleTouchMove );
+			doc.removeEventListener( 'touchend', onTouchEnd );
+			doc.removeEventListener( 'touchcancel', onTouchEnd );
+		};
+
 		const onTouchEnd = () => {
 			this.touch = null;
 			this.touchCleanup = null;
 			cancelAnimationFrame( this.rafId );
-			doc.removeEventListener( 'touchmove', this.handleTouchMove );
-			doc.removeEventListener( 'touchend', onTouchEnd );
-			doc.removeEventListener( 'touchcancel', onTouchEnd );
+			removeTouchListeners();
 			this.setStatus( { isDragging: false } );
 			this.options.onGestureEnd?.();
 		};
@@ -551,7 +608,7 @@ export class InteractionController {
 		doc.addEventListener( 'touchend', onTouchEnd );
 		doc.addEventListener( 'touchcancel', onTouchEnd );
 
-		this.touchCleanup = onTouchEnd;
+		this.touchCleanup = removeTouchListeners;
 	}
 
 	// Handle a touchmove event during an active touch gesture. Decides pinch
@@ -934,6 +991,7 @@ export class InteractionController {
 		cancelAnimationFrame( this.rafId );
 		clearTimeout( this.zoomTimer );
 		clearTimeout( this.wheelGestureTimer );
+		clearTimeout( this.wheelSuppressTimer );
 		this.touchCleanup?.();
 		this.touchCleanup = null;
 		this.pointerCleanup?.();
@@ -941,5 +999,9 @@ export class InteractionController {
 		this.drag = null;
 		this.touch = null;
 		this.lastTap = null;
+		this.wheelGestureActive = false;
+		this.suppressWheelUntilIdle = false;
+		this.isDragging = false;
+		this.isZooming = false;
 	}
 }

--- a/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
@@ -523,6 +523,47 @@ describe( 'InteractionController', () => {
 
 			jest.useRealTimers();
 		} );
+
+		it( 'cancels active wheel zoom and suppresses remaining wheel momentum until idle', () => {
+			jest.useFakeTimers( {
+				doNotFake: [ 'requestAnimationFrame', 'cancelAnimationFrame' ],
+			} );
+			const state = makeState( { zoom: 2 } );
+			const onGestureStart = jest.fn();
+			const onGestureEnd = jest.fn();
+			const { controller } = createController( state, {
+				onGestureStart,
+				onGestureEnd,
+			} );
+
+			controller.handleWheel(
+				createWheelEvent( { deltaY: -50, currentTarget: null } )
+			);
+			expect( onGestureStart ).toHaveBeenCalledTimes( 1 );
+			expect( actionMocks.setZoom ).toHaveBeenCalledTimes( 1 );
+
+			controller.cancelActiveInteraction( { suppressWheel: true } );
+			expect( onGestureEnd ).not.toHaveBeenCalled();
+
+			actionMocks.setZoom.mockClear();
+			const suppressedWheelEvent = createWheelEvent( {
+				deltaY: -50,
+				currentTarget: null,
+			} );
+			controller.handleWheel( suppressedWheelEvent );
+
+			expect( suppressedWheelEvent.preventDefault ).toHaveBeenCalled();
+			expect( actionMocks.setZoom ).not.toHaveBeenCalled();
+
+			jest.advanceTimersByTime( 350 );
+			controller.handleWheel(
+				createWheelEvent( { deltaY: -50, currentTarget: null } )
+			);
+
+			expect( actionMocks.setZoom ).toHaveBeenCalledTimes( 1 );
+
+			jest.useRealTimers();
+		} );
 	} );
 
 	describe( 'keyboard', () => {

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -296,6 +296,7 @@ function CropperInner(
 	} = useInteraction( state, controller, canvasSize, visualSize, {
 		minZoom,
 		maxZoom,
+		cancelInteractionSignal: controller.interactionCancellationSignal,
 		onGestureStart,
 		onGestureEnd,
 	} );

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-interaction.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-interaction.ts
@@ -186,6 +186,53 @@ describe( 'useInteraction grid placement signal', () => {
 		expect( result.current.isPlacementActive ).toBe( false );
 	} );
 
+	it( 'cancels wheel placement and ignores wheel momentum when the cancel signal changes', () => {
+		jest.useFakeTimers();
+		const actions = createActions();
+		const { result, rerender } = renderHook(
+			( { cancelSignal }: { cancelSignal: number } ) =>
+				useInteraction(
+					makeState(),
+					actions,
+					CONTAINER_SIZE,
+					IMAGE_SIZE,
+					{ cancelInteractionSignal: cancelSignal }
+				),
+			{ initialProps: { cancelSignal: 0 } }
+		);
+
+		act( () => {
+			result.current.onWheelNative(
+				createWheelEvent( { deltaY: -100, currentTarget: null } )
+			);
+		} );
+
+		expect( result.current.isPlacementActive ).toBe( true );
+		expect( actions.setZoom ).toHaveBeenCalledTimes( 1 );
+
+		rerender( { cancelSignal: 1 } );
+
+		expect( result.current.isPlacementActive ).toBe( false );
+
+		actions.setZoom.mockClear();
+		act( () => {
+			result.current.onWheelNative(
+				createWheelEvent( { deltaY: -100, currentTarget: null } )
+			);
+		} );
+
+		expect( actions.setZoom ).not.toHaveBeenCalled();
+
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+			result.current.onWheelNative(
+				createWheelEvent( { deltaY: -100, currentTarget: null } )
+			);
+		} );
+
+		expect( actions.setZoom ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'sets isPlacementActive during pinch zoom, then clears it on touch end', () => {
 		const doc = createTouchDocument();
 		const target = createTouchTarget( doc );

--- a/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
@@ -83,6 +83,8 @@ export interface UseCropperStateReturn {
 	undo: () => void;
 	/** Redo the last undone cropper operation. */
 	redo: () => void;
+	/** Changes when state-replacing actions should cancel active interactions. */
+	interactionCancellationSignal?: number;
 	/**
 	 * Flush the pending history entry immediately, bypassing the debounce
 	 * timer. Useful in two situations:
@@ -173,6 +175,8 @@ export function useCropperState(
 	const redoStackRef = useRef< CropperState[] >( [] );
 	const [ hasUndo, setHasUndo ] = useState( false );
 	const [ hasRedo, setHasRedo ] = useState( false );
+	const [ interactionCancellationSignal, setInteractionCancellationSignal ] =
+		useState( 0 );
 
 	// Debounce-based history: tracks the last committed state and a pending
 	// timer. Any state change resets the timer; when it expires the
@@ -197,6 +201,10 @@ export function useCropperState(
 		redoStackRef.current = [];
 		setHasUndo( true );
 		setHasRedo( false );
+	}, [] );
+
+	const cancelActiveInteractions = useCallback( () => {
+		setInteractionCancellationSignal( ( signal ) => signal + 1 );
 	}, [] );
 
 	// Watch state and debounce history commits. Any dispatch resets the
@@ -259,13 +267,14 @@ export function useCropperState(
 		if ( ! prev ) {
 			return;
 		}
+		cancelActiveInteractions();
 		redoStackRef.current = [ stateRef.current, ...redoStackRef.current ];
 		historyRef.current = historyRef.current.slice( 0, -1 );
 		suppressDebounceRef.current = true;
 		setHasUndo( historyRef.current.length > 0 );
 		setHasRedo( true );
 		dispatch( { type: 'RESET', payload: prev } );
-	}, [ dispatch, commitHistory ] );
+	}, [ dispatch, commitHistory, cancelActiveInteractions ] );
 
 	const redo = useCallback( () => {
 		// Flush any pending gesture before redoing so the in-flight change
@@ -275,16 +284,18 @@ export function useCropperState(
 		if ( ! next ) {
 			return;
 		}
+		cancelActiveInteractions();
 		historyRef.current = [ ...historyRef.current, stateRef.current ];
 		redoStackRef.current = redoStackRef.current.slice( 1 );
 		suppressDebounceRef.current = true;
 		setHasUndo( true );
 		setHasRedo( redoStackRef.current.length > 0 );
 		dispatch( { type: 'RESET', payload: next } );
-	}, [ dispatch, commitHistory ] );
+	}, [ dispatch, commitHistory, cancelActiveInteractions ] );
 
 	const setImage = useCallback(
 		( image: CropperState[ 'image' ] ) => {
+			cancelActiveInteractions();
 			clearTimeout( debounceTimerRef.current );
 			suppressDebounceRef.current = true;
 			dispatch( { type: 'SET_IMAGE', payload: image } );
@@ -297,7 +308,7 @@ export function useCropperState(
 				image,
 			} );
 		},
-		[ dispatch ]
+		[ dispatch, cancelActiveInteractions ]
 	);
 
 	const setPan = useCallback(
@@ -335,10 +346,11 @@ export function useCropperState(
 		( flip: Flip ) => {
 			commitHistory(); // flush any pending continuous gesture first
 			pushToHistory(); // record current state as the undo point
+			cancelActiveInteractions();
 			suppressDebounceRef.current = true;
 			dispatch( { type: 'SET_FLIP', payload: flip } );
 		},
-		[ dispatch, pushToHistory, commitHistory ]
+		[ dispatch, pushToHistory, commitHistory, cancelActiveInteractions ]
 	);
 
 	const toggleFlip = useCallback(
@@ -355,13 +367,14 @@ export function useCropperState(
 		( direction: 1 | -1 ) => {
 			commitHistory();
 			pushToHistory();
+			cancelActiveInteractions();
 			suppressDebounceRef.current = true;
 			dispatch( {
 				type: 'SNAP_ROTATE_90',
 				payload: { direction },
 			} );
 		},
-		[ dispatch, pushToHistory, commitHistory ]
+		[ dispatch, pushToHistory, commitHistory, cancelActiveInteractions ]
 	);
 
 	const setCropRect = useCallback(
@@ -381,10 +394,11 @@ export function useCropperState(
 		( op: TransformOperation ) => {
 			commitHistory();
 			pushToHistory();
+			cancelActiveInteractions();
 			suppressDebounceRef.current = true;
 			dispatch( { type: 'APPLY_OPERATION', payload: op } );
 		},
-		[ dispatch, pushToHistory, commitHistory ]
+		[ dispatch, pushToHistory, commitHistory, cancelActiveInteractions ]
 	);
 
 	const reset = useCallback(
@@ -400,6 +414,7 @@ export function useCropperState(
 			) {
 				pushToHistory();
 			}
+			cancelActiveInteractions();
 			suppressDebounceRef.current = true;
 			dispatch( { type: 'RESET', payload: resetState } );
 			// Mirror the reducer's RESET exactly so isDirty stays in
@@ -409,7 +424,7 @@ export function useCropperState(
 			// would report true after a reset.
 			initialRef.current = nextInitialState;
 		},
-		[ dispatch, pushToHistory, commitHistory ]
+		[ dispatch, pushToHistory, commitHistory, cancelActiveInteractions ]
 	);
 
 	const isDirty = isStateDirty( state, initialRef.current );
@@ -451,6 +466,7 @@ export function useCropperState(
 		hasRedo,
 		undo,
 		redo,
+		interactionCancellationSignal,
 		commitHistory,
 	};
 	return controller;

--- a/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
@@ -1,7 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -53,6 +59,8 @@ export interface UseInteractionOptions {
 	onGestureStart?: () => void;
 	/** Fires when a continuous gesture ends (pointer release). */
 	onGestureEnd?: () => void;
+	/** Incremented by callers to cancel active interactions after state replacement. */
+	cancelInteractionSignal?: number;
 }
 
 /** How long keyboard placement stays active after the latest handled key. */
@@ -124,6 +132,10 @@ export function useInteraction(
 	imageSizeRef.current = imageSize;
 	const optionsRef = useRef( options );
 	optionsRef.current = options;
+	const cancelInteractionSignal = options?.cancelInteractionSignal;
+	const previousCancelInteractionSignalRef = useRef(
+		cancelInteractionSignal
+	);
 	const actionsRef = useRef( actions );
 	actionsRef.current = actions;
 
@@ -154,6 +166,25 @@ export function useInteraction(
 			clearTimeout( keyboardInteractionTimerRef.current );
 		};
 	}, [] );
+
+	useLayoutEffect( () => {
+		if (
+			cancelInteractionSignal === undefined ||
+			previousCancelInteractionSignalRef.current ===
+				cancelInteractionSignal
+		) {
+			return;
+		}
+
+		previousCancelInteractionSignalRef.current = cancelInteractionSignal;
+		clearTimeout( keyboardInteractionTimerRef.current );
+		isKeyboardGestureActiveRef.current = false;
+		setIsKeyboardPanning( false );
+		setIsGestureActive( false );
+		controllerRef.current?.cancelActiveInteraction( {
+			suppressWheel: true,
+		} );
+	}, [ cancelInteractionSignal ] );
 
 	// Create / destroy the controller. The controller reads all volatile
 	// values through refs, so it can stay mounted across render updates.


### PR DESCRIPTION
## What?

Fixes undo/redo while an image-editor interaction is still active, especially wheel zoom with trackpad/mouse momentum.

### Before

https://github.com/user-attachments/assets/df6d01ce-45c1-4994-abd7-a5ba92bc200f



### After


https://github.com/user-attachments/assets/9fb493f0-91db-4fc2-acf5-8ef2a943b886



## Why?

If a user scroll-zooms the image and immediately hits undo, the cropper state is restored but the interaction controller can keep its active zoom/gesture timers alive. That lets the animated zoom/gesture state continue after undo, making the restored state feel like it is still being driven by the prior wheel gesture.

## How?

- Adds an interaction cancellation signal from `useCropperState`.
- Emits that signal when state-replacing actions run, including undo, redo, reset, image load, and discrete transform actions.
- Teaches `useInteraction` to cancel the active controller state when the signal changes.
- Adds `InteractionController.cancelActiveInteraction()`, which clears active rAF/timers/listeners and resets drag/zoom status.
- Suppresses remaining wheel momentum until the wheel stream goes idle, so late wheel events do not reapply zoom after undo.

## Testing Instructions

1. Open the Media Library.
2. Select an image and open the media editor.
3. In the image editor, use a trackpad or mouse wheel to zoom the image.
4. Immediately click Undo, or press `Cmd+Z` / `Ctrl+Z`, before the zoom motion has fully settled.
5. Confirm the image returns to the previous zoom/crop state and does not continue zooming afterward.
6. Repeat the same flow with Redo and confirm the restored state does not get overridden by remaining wheel momentum.
7. Confirm normal wheel zooming still works after the wheel input has stopped.
8. Check dragging and hitting `Cmd+Z` / `Ctrl+Z` as well. That should interrupt the drag.
