### PR TITLE
Add session-owned source image state

### DIFF
--- a/packages/media-editor/src/components/image-editing-session/index.tsx
+++ b/packages/media-editor/src/components/image-editing-session/index.tsx
@@ -6,6 +6,7 @@ import {
 	useCallback,
 	useContext,
 	useMemo,
+	useState,
 } from '@wordpress/element';
 import type { ReactNode } from 'react';
 
@@ -22,17 +23,30 @@ import {
 	type Modifier,
 } from '../media-editor-modal/build-modifiers';
 
-interface WorkingImage {
+export interface ImageEditingSessionImage {
 	src: string;
 	width: number;
 	height: number;
 }
 
+function areImagesEqual(
+	a: ImageEditingSessionImage | null,
+	b: ImageEditingSessionImage | null
+): boolean {
+	return (
+		a?.src === b?.src && a?.width === b?.width && a?.height === b?.height
+	);
+}
+
 export interface ImageEditingSession {
-	/** Current source being edited by the image session. */
-	workingImage: WorkingImage | null;
+	/** Original image source loaded into the current session. */
+	sourceImage: ImageEditingSessionImage | null;
+	/** Current image source being edited by the image session. */
+	workingImage: ImageEditingSessionImage | null;
 	/** Low-level cropper controller. */
 	cropper: UseCropperStateReturn;
+	/** Replace the source image and reset dependent image edits. */
+	setSourceImage: ( image: ImageEditingSessionImage | null ) => void;
 	/** Whether the image session has unsaved image edits. */
 	isDirty: boolean;
 	/** Whether the image session has undo history. */
@@ -49,6 +63,19 @@ export interface ImageEditingSession {
 	commitHistory: () => void;
 	/** Build the Core REST media edit modifiers for the current image state. */
 	buildSaveModifiers: () => Modifier[];
+	/**
+	 * Render the current working image to a `Blob`.
+	 *
+	 * Defaults to lossless PNG. Pass `type: 'image/jpeg'` (or `'image/webp'`)
+	 * with an optional `quality` (0–1) to produce a compressed encoding —
+	 * useful for AI vision APIs and uploads where bytes matter.
+	 *
+	 * Rejects when no source image has been loaded.
+	 */
+	getWorkingImage: ( options?: {
+		type?: string;
+		quality?: number;
+	} ) => Promise< Blob >;
 }
 
 const ImageEditingSessionContext = createContext<
@@ -61,32 +88,55 @@ export function ImageEditingSessionProvider( {
 	children: ReactNode;
 } ) {
 	const cropper = useCropperState();
+	const setCropperImage = cropper.setImage;
+	const [ sourceImage, setSourceImageState ] =
+		useState< ImageEditingSessionImage | null >( null );
 
-	const workingImage = useMemo< WorkingImage | null >( () => {
-		if ( ! cropper.state.image ) {
-			return null;
-		}
-		return {
-			src: cropper.state.image.src,
-			width: cropper.state.image.naturalWidth,
-			height: cropper.state.image.naturalHeight,
-		};
-	}, [ cropper.state.image ] );
+	const setSourceImage = useCallback(
+		( image: ImageEditingSessionImage | null ) => {
+			if ( areImagesEqual( sourceImage, image ) ) {
+				return;
+			}
+			setSourceImageState( image );
+			setCropperImage(
+				image
+					? {
+							src: image.src,
+							naturalWidth: image.width,
+							naturalHeight: image.height,
+					  }
+					: null
+			);
+		},
+		[ setCropperImage, sourceImage ]
+	);
+
+	const workingImage = sourceImage;
 
 	const buildSaveModifiers = useCallback( () => {
-		if ( ! cropper.isDirty || ! cropper.state.image ) {
+		if ( ! cropper.isDirty || ! workingImage ) {
 			return [];
 		}
 		return buildModifiers( cropper.state, {
-			width: cropper.state.image.naturalWidth,
-			height: cropper.state.image.naturalHeight,
+			width: workingImage.width,
+			height: workingImage.height,
 		} );
-	}, [ cropper.isDirty, cropper.state ] );
+	}, [ cropper.isDirty, cropper.state, workingImage ] );
+
+	const cropperGetCroppedImage = cropper.getCroppedImage;
+	const getWorkingImage = useCallback(
+		( options?: { type?: string; quality?: number } ): Promise< Blob > => {
+			return cropperGetCroppedImage( options?.type, options?.quality );
+		},
+		[ cropperGetCroppedImage ]
+	);
 
 	const session = useMemo< ImageEditingSession >(
 		() => ( {
+			sourceImage,
 			workingImage,
 			cropper,
+			setSourceImage,
 			isDirty: cropper.isDirty,
 			hasUndo: cropper.hasUndo,
 			hasRedo: cropper.hasRedo,
@@ -95,8 +145,16 @@ export function ImageEditingSessionProvider( {
 			reset: () => cropper.reset(),
 			commitHistory: cropper.commitHistory,
 			buildSaveModifiers,
+			getWorkingImage,
 		} ),
-		[ cropper, workingImage, buildSaveModifiers ]
+		[
+			cropper,
+			setSourceImage,
+			sourceImage,
+			workingImage,
+			buildSaveModifiers,
+			getWorkingImage,
+		]
 	);
 
 	return (

--- a/packages/media-editor/src/components/image-editing-session/test/index.tsx
+++ b/packages/media-editor/src/components/image-editing-session/test/index.tsx
@@ -13,8 +13,14 @@ import { buildModifiers } from '../../media-editor-modal/build-modifiers';
 
 const TEST_IMAGE = {
 	src: 'test.jpg',
-	naturalWidth: 1000,
-	naturalHeight: 500,
+	width: 1000,
+	height: 500,
+};
+
+const NEXT_IMAGE = {
+	src: 'next.jpg',
+	width: 1200,
+	height: 800,
 };
 
 function SessionWrapper( { children }: { children: ReactNode } ) {
@@ -36,6 +42,7 @@ describe( 'ImageEditingSessionProvider', () => {
 		expect( result.current.isDirty ).toBe( false );
 		expect( result.current.hasUndo ).toBe( false );
 		expect( result.current.hasRedo ).toBe( false );
+		expect( result.current.sourceImage ).toBeNull();
 		expect( result.current.workingImage ).toBeNull();
 	} );
 
@@ -43,13 +50,14 @@ describe( 'ImageEditingSessionProvider', () => {
 		const { result } = setup();
 
 		act( () => {
-			result.current.cropper.setImage( TEST_IMAGE );
+			result.current.setSourceImage( TEST_IMAGE );
 		} );
 
+		expect( result.current.sourceImage ).toEqual( TEST_IMAGE );
 		expect( result.current.workingImage ).toEqual( {
 			src: TEST_IMAGE.src,
-			width: TEST_IMAGE.naturalWidth,
-			height: TEST_IMAGE.naturalHeight,
+			width: TEST_IMAGE.width,
+			height: TEST_IMAGE.height,
 		} );
 		expect( result.current.isDirty ).toBe( false );
 	} );
@@ -64,6 +72,39 @@ describe( 'ImageEditingSessionProvider', () => {
 		);
 
 		expect( result.current.cropper ).toBe( result.current.session.cropper );
+	} );
+
+	it( 'resets cropper edits when the source image changes', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.setSourceImage( TEST_IMAGE );
+		} );
+		act( () => {
+			result.current.cropper.setZoom( 3 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+
+		expect( result.current.isDirty ).toBe( true );
+		expect( result.current.hasUndo ).toBe( true );
+
+		act( () => {
+			result.current.setSourceImage( NEXT_IMAGE );
+		} );
+
+		expect( result.current.sourceImage ).toEqual( NEXT_IMAGE );
+		expect( result.current.workingImage ).toEqual( NEXT_IMAGE );
+		expect( result.current.cropper.state.image ).toEqual( {
+			src: NEXT_IMAGE.src,
+			naturalWidth: NEXT_IMAGE.width,
+			naturalHeight: NEXT_IMAGE.height,
+		} );
+		expect( result.current.cropper.state.zoom ).toBe( 1 );
+		expect( result.current.isDirty ).toBe( false );
+		expect( result.current.hasUndo ).toBe( false );
+		expect( result.current.hasRedo ).toBe( false );
 	} );
 
 	it( 'marks the image session dirty when cropper state changes', () => {
@@ -127,17 +168,25 @@ describe( 'ImageEditingSessionProvider', () => {
 		const { result } = setup();
 
 		act( () => {
-			result.current.cropper.setImage( TEST_IMAGE );
+			result.current.setSourceImage( TEST_IMAGE );
 		} );
 
 		expect( result.current.buildSaveModifiers() ).toEqual( [] );
+	} );
+
+	it( 'rejects getWorkingImage when no source image is loaded', async () => {
+		const { result } = setup();
+
+		await expect( result.current.getWorkingImage() ).rejects.toThrow(
+			/No image loaded/
+		);
 	} );
 
 	it( 'builds the same save modifiers as the cropper modifier helper', () => {
 		const { result } = setup();
 
 		act( () => {
-			result.current.cropper.setImage( TEST_IMAGE );
+			result.current.setSourceImage( TEST_IMAGE );
 		} );
 		act( () => {
 			result.current.cropper.snapRotate90( 1 );
@@ -145,8 +194,8 @@ describe( 'ImageEditingSessionProvider', () => {
 
 		expect( result.current.buildSaveModifiers() ).toEqual(
 			buildModifiers( result.current.cropper.state, {
-				width: TEST_IMAGE.naturalWidth,
-				height: TEST_IMAGE.naturalHeight,
+				width: TEST_IMAGE.width,
+				height: TEST_IMAGE.height,
 			} )
 		);
 	} );

--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -4,6 +4,7 @@
 import { useMediaEditorContext } from '../media-editor-provider';
 import { getMediaTypeFromMimeType } from '../../utils';
 import { Cropper, useCropper } from '../../image-editor';
+import { useImageEditingSession } from '../image-editing-session';
 
 export interface MediaEditorCanvasProps {
 	/** Fixed aspect ratio (width / height). `undefined` means free. */
@@ -45,6 +46,7 @@ export default function MediaEditorCanvas( {
 }: MediaEditorCanvasProps ) {
 	const { media } = useMediaEditorContext();
 	const controller = useCropper();
+	const imageSession = useImageEditingSession();
 
 	const mediaUrl = media?.source_url;
 	const mediaType = getMediaTypeFromMimeType( media?.mime_type );
@@ -63,6 +65,13 @@ export default function MediaEditorCanvas( {
 				focusOnMount={ focusOnMount }
 				showGrid="interactive"
 				isPlacementActive={ isPlacementActive }
+				onImageLoaded={ ( size ) =>
+					imageSession.setSourceImage( {
+						src: mediaUrl,
+						width: size.width,
+						height: size.height,
+					} )
+				}
 				// Flush on gesture start so any pending sidebar interaction
 				// (e.g. zoom slider debounce) is committed as its own undo
 				// step before the canvas gesture begins.

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -54,6 +54,7 @@ import { CROP_CONTROL_ATTR } from '../../hooks/use-crop-gesture-handlers';
 import {
 	ImageEditingSessionProvider,
 	useImageEditingSession,
+	type ImageEditingSessionImage,
 } from '../image-editing-session';
 import MediaEditorKeyboardShortcutsModal from '../media-editor-keyboard-shortcuts-modal';
 
@@ -238,6 +239,7 @@ function MediaEditorContent( {
 	shouldCloseOnEsc = false,
 }: MediaEditorProps ) {
 	const imageSession = useImageEditingSession();
+	const setSourceImage = imageSession.setSourceImage;
 
 	const { media, hasEdits } = useSelect(
 		( select ) => {
@@ -311,6 +313,36 @@ function MediaEditorContent( {
 
 	const mediaType = getMediaTypeFromMimeType( media?.mime_type ).type;
 	const isImage = !! media && mediaType === 'image';
+
+	const sourceImage = useMemo< ImageEditingSessionImage | null >( () => {
+		if ( ! isImage || ! media?.source_url ) {
+			return null;
+		}
+		const naturalWidth = Number( media.media_details?.width );
+		const naturalHeight = Number( media.media_details?.height );
+		if (
+			Number.isFinite( naturalWidth ) &&
+			Number.isFinite( naturalHeight ) &&
+			naturalWidth > 0 &&
+			naturalHeight > 0
+		) {
+			return {
+				src: media.source_url,
+				width: naturalWidth,
+				height: naturalHeight,
+			};
+		}
+		return null;
+	}, [
+		isImage,
+		media?.source_url,
+		media?.media_details?.width,
+		media?.media_details?.height,
+	] );
+
+	useEffect( () => {
+		setSourceImage( sourceImage );
+	}, [ setSourceImage, sourceImage ] );
 
 	const imageAspectRatio = useMemo( () => {
 		if ( ! isImage ) {
@@ -426,7 +458,7 @@ function MediaEditorContent( {
 					path: `/wp/v2/media/${ id }/edit`,
 					method: 'POST',
 					data: {
-						src: media?.source_url,
+						src: imageSession.sourceImage?.src,
 						modifiers,
 						...metadataEdits,
 					},

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
@@ -1040,6 +1040,40 @@ describe( 'useCropperState', () => {
 			expect( result.current.hasUndo ).toBe( false );
 		} );
 
+		it( 'setImage resets crop edits and clears history for a new image', () => {
+			const { result } = renderHook( () => useCropperState() );
+
+			act( () => {
+				result.current.setImage( {
+					src: 'test.jpg',
+					naturalWidth: 1000,
+					naturalHeight: 500,
+				} );
+			} );
+			act( () => {
+				result.current.setZoom( 3 );
+			} );
+			act( () => {
+				result.current.commitHistory();
+			} );
+
+			expect( result.current.isDirty ).toBe( true );
+			expect( result.current.hasUndo ).toBe( true );
+
+			act( () => {
+				result.current.setImage( {
+					src: 'next.jpg',
+					naturalWidth: 1200,
+					naturalHeight: 800,
+				} );
+			} );
+
+			expect( result.current.state.zoom ).toBe( 1 );
+			expect( result.current.isDirty ).toBe( false );
+			expect( result.current.hasUndo ).toBe( false );
+			expect( result.current.hasRedo ).toBe( false );
+		} );
+
 		it( 'reset is undoable and restores a clean current state', () => {
 			const { result } = renderHook( () => useCropperState() );
 			act( () => result.current.setZoom( 3 ) );

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-history.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-history.ts
@@ -94,4 +94,19 @@ describe( 'useHistory', () => {
 		expect( result.current.state.value ).toBe( 1 );
 		expect( result.current.hasUndo ).toBe( false );
 	} );
+
+	it( 'clears undo and redo history', () => {
+		const { result } = renderHook( () => useNumberHistory() );
+
+		act( () => result.current.setState( { value: 1 } ) );
+		act( () => result.current.commitHistory() );
+		act( () => result.current.undo() );
+
+		expect( result.current.hasRedo ).toBe( true );
+
+		act( () => result.current.clearHistory() );
+
+		expect( result.current.hasUndo ).toBe( false );
+		expect( result.current.hasRedo ).toBe( false );
+	} );
 } );

--- a/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
@@ -34,7 +34,7 @@ import { useHistory } from './use-history';
 export interface UseCropperStateReturn {
 	/** The current cropper state (read-only). */
 	state: CropperState;
-	/** Set the loaded image (natural size and src). */
+	/** Set the loaded image and reset image-dependent crop state. */
 	setImage: ( image: CropperState[ 'image' ] ) => void;
 	/**
 	 * Set the image pan offset in normalized coordinates. Use
@@ -128,6 +128,17 @@ function areHistoryStatesEqual( a: CropperState, b: CropperState ): boolean {
 	);
 }
 
+function areImagesEqual(
+	a: CropperState[ 'image' ],
+	b: CropperState[ 'image' ]
+): boolean {
+	return (
+		a?.src === b?.src &&
+		a?.naturalWidth === b?.naturalWidth &&
+		a?.naturalHeight === b?.naturalHeight
+	);
+}
+
 /**
  * Reducer-based state management hook for the image editor.
  *
@@ -175,6 +186,7 @@ export function useCropperState(
 		undo,
 		redo,
 		suppressNextChange,
+		clearHistory,
 	} = useHistory( {
 		state,
 		isEqual: areHistoryStatesEqual,
@@ -184,18 +196,19 @@ export function useCropperState(
 
 	const setImage = useCallback(
 		( image: CropperState[ 'image' ] ) => {
-			suppressNextChange( { clearPending: true } );
-			dispatch( { type: 'SET_IMAGE', payload: image } );
-			// Refresh the "clean" snapshot to match the post-load state
-			// produced by the reducer. Otherwise containment can nudge
-			// pan/zoom by tiny amounts on load and `isDirty` would
-			// report true from the start.
-			initialRef.current = enforceContainment( {
-				...initialRef.current,
+			if ( areImagesEqual( stateRef.current.image, image ) ) {
+				return;
+			}
+			const nextInitialState = enforceContainment( {
+				...DEFAULT_STATE,
 				image,
 			} );
+			clearHistory( nextInitialState );
+			suppressNextChange( { clearPending: true } );
+			dispatch( { type: 'RESET', payload: { image } } );
+			initialRef.current = nextInitialState;
 		},
-		[ dispatch, suppressNextChange ]
+		[ clearHistory, dispatch, suppressNextChange ]
 	);
 
 	const setPan = useCallback(

--- a/packages/media-editor/src/image-editor/react/hooks/use-history.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-history.ts
@@ -29,6 +29,8 @@ export interface UseHistoryReturn< T > {
 	redo: () => void;
 	/** Suppress the next observed state change from creating history. */
 	suppressNextChange: ( options?: { clearPending?: boolean } ) => void;
+	/** Clear undo/redo history and optionally replace the clean baseline. */
+	clearHistory: ( state?: T ) => void;
 }
 
 /**
@@ -128,6 +130,15 @@ export function useHistory< T >( {
 		[]
 	);
 
+	const clearHistory = useCallback( ( nextState?: T ) => {
+		clearTimeout( debounceTimerRef.current );
+		historyRef.current = [];
+		redoStackRef.current = [];
+		lastCommittedStateRef.current = nextState ?? stateRef.current;
+		setHasUndo( false );
+		setHasRedo( false );
+	}, [] );
+
 	const undo = useCallback( () => {
 		commitHistory();
 		const prev = historyRef.current[ historyRef.current.length - 1 ];
@@ -164,5 +175,6 @@ export function useHistory< T >( {
 		undo,
 		redo,
 		suppressNextChange,
+		clearHistory,
 	};
 }


### PR DESCRIPTION
## What changed

Adds explicit source image state to the image editing session.

The session now exposes `sourceImage`, `workingImage`, and `setSourceImage()`. The media editor modal seeds that state from the selected attachment, and the canvas reports loaded image dimensions back into the same session path.

Changing the source image resets cropper-dependent state and clears undo/redo history instead of treating source replacement as an undoable crop edit. Save modifier generation now reads dimensions from the session-owned working image.

This is a stacked follow-up to #77926.

## Why

Future adjustments, filters, and image-surface extensions need a single session-owned image identity to attach to. Crop can remain the low-level geometry controller, but replacing the underlying image must reset dependent crop state predictably.

## Validation

- `npm run test:unit packages/media-editor/src/components/image-editing-session/test/index.tsx -- --runInBand`
- `npm run test:unit packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts -- --runInBand`
- `npm run test:unit packages/media-editor/src/image-editor/react/hooks/test/use-history.ts -- --runInBand`
- `npm exec -- prettier --check packages/media-editor/src/components/image-editing-session/index.tsx packages/media-editor/src/components/image-editing-session/test/index.tsx packages/media-editor/src/components/media-editor-modal/index.tsx packages/media-editor/src/components/media-editor-canvas/index.tsx packages/media-editor/src/image-editor/react/hooks/use-history.ts packages/media-editor/src/image-editor/react/hooks/test/use-history.ts packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts`
- `npm run lint:js packages/media-editor/src/components/image-editing-session/index.tsx packages/media-editor/src/components/image-editing-session/test/index.tsx packages/media-editor/src/components/media-editor-modal/index.tsx packages/media-editor/src/components/media-editor-canvas/index.tsx packages/media-editor/src/image-editor/react/hooks/use-history.ts packages/media-editor/src/image-editor/react/hooks/test/use-history.ts packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts`
- `git diff --check`