### PR TITLE
Image editor: suppress image editor undo/redo while a crop interaction is active

### DIFF
--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -12,6 +12,10 @@ export interface MediaEditorCanvasProps {
 	freeformCrop?: boolean;
 	/** Whether external placement activity should reveal the grid. */
 	isPlacementActive?: boolean;
+	/** Fires when a canvas cropper gesture begins. */
+	onGestureStart?: () => void;
+	/** Fires when a canvas cropper gesture ends. */
+	onGestureEnd?: () => void;
 }
 
 /**
@@ -25,11 +29,15 @@ export interface MediaEditorCanvasProps {
  * @param props.aspectRatio
  * @param props.freeformCrop
  * @param props.isPlacementActive
+ * @param props.onGestureStart
+ * @param props.onGestureEnd
  */
 export default function MediaEditorCanvas( {
 	aspectRatio,
 	freeformCrop,
 	isPlacementActive = false,
+	onGestureStart,
+	onGestureEnd,
 }: MediaEditorCanvasProps ) {
 	const { media } = useMediaEditorContext();
 	const controller = useCropper();
@@ -53,8 +61,14 @@ export default function MediaEditorCanvas( {
 				// Flush on gesture start so any pending sidebar interaction
 				// (e.g. zoom slider debounce) is committed as its own undo
 				// step before the canvas gesture begins.
-				onGestureStart={ controller.commitHistory }
-				onGestureEnd={ controller.commitHistory }
+				onGestureStart={ () => {
+					onGestureStart?.();
+					controller.commitHistory();
+				} }
+				onGestureEnd={ () => {
+					controller.commitHistory();
+					onGestureEnd?.();
+				} }
 			/>
 		</div>
 	);

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -251,8 +251,6 @@ function MediaEditorModalContent( {
 	const [ isPlacementActive, setIsPlacementActive ] = useState( false );
 	const [ isCanvasGestureActive, setIsCanvasGestureActive ] =
 		useState( false );
-	const isPlacementActiveRef = useRef( false );
-	const isCanvasGestureActiveRef = useRef( false );
 	const placementControlTimerRef =
 		useRef< ReturnType< typeof setTimeout > >();
 
@@ -260,26 +258,18 @@ function MediaEditorModalContent( {
 	const [ freeformCrop, setFreeformCrop ] = useState( true );
 
 	const signalPlacementControlInteraction = useCallback( () => {
-		isPlacementActiveRef.current = true;
 		setIsPlacementActive( true );
 		clearTimeout( placementControlTimerRef.current );
 		placementControlTimerRef.current = setTimeout( () => {
-			isPlacementActiveRef.current = false;
 			setIsPlacementActive( false );
 		}, PLACEMENT_CONTROL_IDLE_MS );
 	}, [] );
 	const handleCanvasGestureStart = useCallback( () => {
-		isCanvasGestureActiveRef.current = true;
 		setIsCanvasGestureActive( true );
 	}, [] );
 	const handleCanvasGestureEnd = useCallback( () => {
-		isCanvasGestureActiveRef.current = false;
 		setIsCanvasGestureActive( false );
 	}, [] );
-	const shouldSuppressUndoRedo = useCallback(
-		() => isPlacementActiveRef.current || isCanvasGestureActiveRef.current,
-		[]
-	);
 	const isCropInteractionActive = isPlacementActive || isCanvasGestureActive;
 
 	useEffect( () => {
@@ -293,9 +283,7 @@ function MediaEditorModalContent( {
 	useEffect( () => {
 		setAspectRatioValue( '0' );
 		setFreeformCrop( true );
-		isPlacementActiveRef.current = false;
 		setIsPlacementActive( false );
-		isCanvasGestureActiveRef.current = false;
 		setIsCanvasGestureActive( false );
 	}, [ id ] );
 
@@ -518,7 +506,7 @@ function MediaEditorModalContent( {
 						! target.closest( `[${ CROP_CONTROL_ATTR }]` );
 					if ( ! isMetadataField ) {
 						event.preventDefault();
-						if ( shouldSuppressUndoRedo() ) {
+						if ( isCropInteractionActive ) {
 							return;
 						}
 						if ( isRedoShortcut ) {
@@ -619,9 +607,6 @@ function MediaEditorModalContent( {
 										}
 										isUndoRedoDisabled={
 											isCropInteractionActive
-										}
-										shouldSuppressUndoRedo={
-											shouldSuppressUndoRedo
 										}
 									/>
 								) : undefined

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -249,6 +249,10 @@ function MediaEditorModalContent( {
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ isDiscardDialogOpen, setIsDiscardDialogOpen ] = useState( false );
 	const [ isPlacementActive, setIsPlacementActive ] = useState( false );
+	const [ isCanvasGestureActive, setIsCanvasGestureActive ] =
+		useState( false );
+	const isPlacementActiveRef = useRef( false );
+	const isCanvasGestureActiveRef = useRef( false );
 	const placementControlTimerRef =
 		useRef< ReturnType< typeof setTimeout > >();
 
@@ -256,12 +260,27 @@ function MediaEditorModalContent( {
 	const [ freeformCrop, setFreeformCrop ] = useState( true );
 
 	const signalPlacementControlInteraction = useCallback( () => {
+		isPlacementActiveRef.current = true;
 		setIsPlacementActive( true );
 		clearTimeout( placementControlTimerRef.current );
 		placementControlTimerRef.current = setTimeout( () => {
+			isPlacementActiveRef.current = false;
 			setIsPlacementActive( false );
 		}, PLACEMENT_CONTROL_IDLE_MS );
 	}, [] );
+	const handleCanvasGestureStart = useCallback( () => {
+		isCanvasGestureActiveRef.current = true;
+		setIsCanvasGestureActive( true );
+	}, [] );
+	const handleCanvasGestureEnd = useCallback( () => {
+		isCanvasGestureActiveRef.current = false;
+		setIsCanvasGestureActive( false );
+	}, [] );
+	const shouldSuppressUndoRedo = useCallback(
+		() => isPlacementActiveRef.current || isCanvasGestureActiveRef.current,
+		[]
+	);
+	const isCropInteractionActive = isPlacementActive || isCanvasGestureActive;
 
 	useEffect( () => {
 		return () => {
@@ -274,6 +293,10 @@ function MediaEditorModalContent( {
 	useEffect( () => {
 		setAspectRatioValue( '0' );
 		setFreeformCrop( true );
+		isPlacementActiveRef.current = false;
+		setIsPlacementActive( false );
+		isCanvasGestureActiveRef.current = false;
+		setIsCanvasGestureActive( false );
 	}, [ id ] );
 
 	const mediaType = getMediaTypeFromMimeType( media?.mime_type ).type;
@@ -495,6 +518,9 @@ function MediaEditorModalContent( {
 						! target.closest( `[${ CROP_CONTROL_ATTR }]` );
 					if ( ! isMetadataField ) {
 						event.preventDefault();
+						if ( shouldSuppressUndoRedo() ) {
+							return;
+						}
 						if ( isRedoShortcut ) {
 							cropper.redo();
 						} else {
@@ -569,6 +595,12 @@ function MediaEditorModalContent( {
 											isPlacementActive={
 												isPlacementActive
 											}
+											onGestureStart={
+												handleCanvasGestureStart
+											}
+											onGestureEnd={
+												handleCanvasGestureEnd
+											}
 										/>
 									) : (
 										<MediaPreview />
@@ -584,6 +616,12 @@ function MediaEditorModalContent( {
 										} }
 										onPlacementControlInteraction={
 											signalPlacementControlInteraction
+										}
+										isUndoRedoDisabled={
+											isCropInteractionActive
+										}
+										shouldSuppressUndoRedo={
+											shouldSuppressUndoRedo
 										}
 									/>
 								) : undefined

--- a/packages/media-editor/src/components/media-editor-toolbar/index.tsx
+++ b/packages/media-editor/src/components/media-editor-toolbar/index.tsx
@@ -30,6 +30,10 @@ export interface MediaEditorToolbarProps {
 	onReset?: () => void;
 	/** Signal that a placement-oriented control is being adjusted. */
 	onPlacementControlInteraction?: () => void;
+	/** Whether undo/redo should be unavailable during an active gesture. */
+	isUndoRedoDisabled?: boolean;
+	/** Synchronous guard for undo/redo clicks before disabled state renders. */
+	shouldSuppressUndoRedo?: () => boolean;
 }
 
 /**
@@ -40,10 +44,14 @@ export interface MediaEditorToolbarProps {
  * @param props
  * @param props.onReset
  * @param props.onPlacementControlInteraction
+ * @param props.isUndoRedoDisabled
+ * @param props.shouldSuppressUndoRedo
  */
 export default function MediaEditorToolbar( {
 	onReset,
 	onPlacementControlInteraction,
+	isUndoRedoDisabled = false,
+	shouldSuppressUndoRedo,
 }: MediaEditorToolbarProps ) {
 	const {
 		state,
@@ -62,6 +70,18 @@ export default function MediaEditorToolbar( {
 	const handleReset = () => {
 		reset();
 		onReset?.();
+	};
+	const handleUndo = () => {
+		if ( shouldSuppressUndoRedo?.() ) {
+			return;
+		}
+		undoCrop();
+	};
+	const handleRedo = () => {
+		if ( shouldSuppressUndoRedo?.() ) {
+			return;
+		}
+		redoCrop();
 	};
 
 	// `setRotation` is an absolute-angle setter. When a single flip is active
@@ -103,9 +123,9 @@ export default function MediaEditorToolbar( {
 				label={ __( 'Undo' ) }
 				showTooltip
 				shortcut={ displayShortcut.primary( 'z' ) }
-				disabled={ ! hasUndo }
+				disabled={ isUndoRedoDisabled || ! hasUndo }
 				accessibleWhenDisabled
-				onClick={ undoCrop }
+				onClick={ handleUndo }
 			/>
 			<Button
 				size="compact"
@@ -117,9 +137,9 @@ export default function MediaEditorToolbar( {
 						? displayShortcut.primaryShift( 'z' )
 						: displayShortcut.primary( 'y' )
 				}
-				disabled={ ! hasRedo }
+				disabled={ isUndoRedoDisabled || ! hasRedo }
 				accessibleWhenDisabled
-				onClick={ redoCrop }
+				onClick={ handleRedo }
 			/>
 			<Button
 				size="compact"

--- a/packages/media-editor/src/components/media-editor-toolbar/index.tsx
+++ b/packages/media-editor/src/components/media-editor-toolbar/index.tsx
@@ -32,8 +32,6 @@ export interface MediaEditorToolbarProps {
 	onPlacementControlInteraction?: () => void;
 	/** Whether undo/redo should be unavailable during an active gesture. */
 	isUndoRedoDisabled?: boolean;
-	/** Synchronous guard for undo/redo clicks before disabled state renders. */
-	shouldSuppressUndoRedo?: () => boolean;
 }
 
 /**
@@ -45,13 +43,11 @@ export interface MediaEditorToolbarProps {
  * @param props.onReset
  * @param props.onPlacementControlInteraction
  * @param props.isUndoRedoDisabled
- * @param props.shouldSuppressUndoRedo
  */
 export default function MediaEditorToolbar( {
 	onReset,
 	onPlacementControlInteraction,
 	isUndoRedoDisabled = false,
-	shouldSuppressUndoRedo,
 }: MediaEditorToolbarProps ) {
 	const {
 		state,
@@ -72,13 +68,13 @@ export default function MediaEditorToolbar( {
 		onReset?.();
 	};
 	const handleUndo = () => {
-		if ( shouldSuppressUndoRedo?.() ) {
+		if ( isUndoRedoDisabled ) {
 			return;
 		}
 		undoCrop();
 	};
 	const handleRedo = () => {
-		if ( shouldSuppressUndoRedo?.() ) {
+		if ( isUndoRedoDisabled ) {
 			return;
 		}
 		redoCrop();


### PR DESCRIPTION
## What?

Alternative to:

- https://github.com/WordPress/gutenberg/pull/77928

Suppresses image editor undo/redo while a crop interaction is active (rather than suppressing the animation)


https://github.com/user-attachments/assets/5f07cd5d-81ab-4823-b592-e76f6d043125



## Why?

Wheel zoom can continue briefly because of animation / input momentum. If undo runs during that window, the state can be restored while the gesture is still active.

This change tries a simpler interaction model: undo/redo is only available once the current crop interaction has finished.

## How?

- Tracks active canvas cropper gestures in the media editor modal.
- Reuses the existing placement-control active state for sidebar / toolbar crop controls.
- Disables the toolbar Undo and Redo buttons while a crop interaction is active.
- Suppresses keyboard undo/redo shortcuts during active crop interactions.
- Adds a synchronous guard for Undo and Redo toolbar clicks in case the user clicks before the disabled state has rendered.

## Testing Instructions

1. Open the Media Library.
2. Select an image and open the media editor.
3. Use the mouse wheel or trackpad to zoom the image.
4. While the wheel zoom is still active, confirm Undo and Redo are disabled.
5. Press `Cmd+Z` / `Ctrl+Z` during the active zoom and confirm undo does not run.
6. Wait for the wheel input to settle.
7. Confirm Undo becomes available and works normally.
8. Repeat with the zoom slider, crop handles, and keyboard pan/zoom controls.
