### PR TITLE
Experimental: Content types - disable create/save button based on form validity

### DIFF
--- a/routes/post-type-edit/stage.tsx
+++ b/routes/post-type-edit/stage.tsx
@@ -287,7 +287,7 @@ function PostTypePage( {
 					type="submit"
 					form={ formId }
 					isBusy={ isSaving }
-					disabled={ isSaving }
+					disabled={ isSaving || ! isValid }
 					accessibleWhenDisabled
 				>
 					{ isAddMode ? __( 'Create' ) : __( 'Save' ) }

--- a/routes/taxonomy-edit/stage.tsx
+++ b/routes/taxonomy-edit/stage.tsx
@@ -297,7 +297,7 @@ function TaxonomyPage( {
 					type="submit"
 					form={ formId }
 					isBusy={ isSaving }
-					disabled={ isSaving }
+					disabled={ isSaving || ! isValid }
 					accessibleWhenDisabled
 				>
 					{ isAddMode ? __( 'Create' ) : __( 'Save' ) }


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/77600


Content types - disable create/save button based on form validity

## Testing instructions
1. Enable the `Content types` experiment.
2. Go to `Settings → Post Types` and observe that the `create/save` button is disabled when the form is invalid
3. Do the same for `Taxonomies`
