### PR TITLE
Add image editor extension panels

### DIFF
--- a/packages/media-editor/src/components/image-editor-extension-registry/index.ts
+++ b/packages/media-editor/src/components/image-editor-extension-registry/index.ts
@@ -1,0 +1,82 @@
+/**
+ * WordPress dependencies
+ */
+import { useSyncExternalStore } from '@wordpress/element';
+import type { ComponentType } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import type { ImageEditingSession } from '../image-editing-session';
+
+export interface ImageEditorExtensionPanelProps {
+	/** Current image editing session. */
+	session: ImageEditingSession;
+}
+
+export interface ImageEditorExtensionPanel {
+	/** Unique extension panel identifier. */
+	name: string;
+	/** Tab label shown in the image editor sidebar. */
+	title: string;
+	/** Sort order within the extension panel group. */
+	order?: number;
+	/** Component rendered inside the extension sidebar panel. */
+	component: ComponentType< ImageEditorExtensionPanelProps >;
+}
+
+type Listener = () => void;
+
+const panels = new Map< string, ImageEditorExtensionPanel >();
+const listeners = new Set< Listener >();
+let snapshot: ImageEditorExtensionPanel[] = [];
+
+function updateSnapshot() {
+	snapshot = [ ...panels.values() ].sort( ( a, b ) => {
+		const order = ( a.order ?? 10 ) - ( b.order ?? 10 );
+		if ( order !== 0 ) {
+			return order;
+		}
+		return a.name.localeCompare( b.name );
+	} );
+	for ( const listener of listeners ) {
+		listener();
+	}
+}
+
+function subscribe( listener: Listener ) {
+	listeners.add( listener );
+	return () => {
+		listeners.delete( listener );
+	};
+}
+
+function getSnapshot() {
+	return snapshot;
+}
+
+export function registerImageEditorExtensionPanel(
+	panel: ImageEditorExtensionPanel
+) {
+	if ( ! panel.name ) {
+		throw new Error( 'Image editor extension panels must include a name.' );
+	}
+	if ( panels.has( panel.name ) ) {
+		throw new Error(
+			`Image editor extension panel "${ panel.name }" is already registered.`
+		);
+	}
+	panels.set( panel.name, panel );
+	updateSnapshot();
+	return () => {
+		if ( panels.get( panel.name ) !== panel ) {
+			return;
+		}
+		panels.delete( panel.name );
+		updateSnapshot();
+	};
+}
+
+export function useImageEditorExtensionPanels() {
+	return useSyncExternalStore( subscribe, getSnapshot, getSnapshot );
+}

--- a/packages/media-editor/src/components/image-editor-extension-registry/test/index.tsx
+++ b/packages/media-editor/src/components/image-editor-extension-registry/test/index.tsx
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	registerImageEditorExtensionPanel,
+	useImageEditorExtensionPanels,
+} from '..';
+
+describe( 'image editor extension panel registry', () => {
+	const unregisterCallbacks: Array< () => void > = [];
+
+	afterEach( () => {
+		act( () => {
+			while ( unregisterCallbacks.length ) {
+				unregisterCallbacks.pop()?.();
+			}
+		} );
+	} );
+
+	function register(
+		...args: Parameters< typeof registerImageEditorExtensionPanel >
+	) {
+		const unregister = registerImageEditorExtensionPanel( ...args );
+		unregisterCallbacks.push( unregister );
+		return unregister;
+	}
+
+	it( 'returns registered panels in deterministic order', () => {
+		const { result } = renderHook( () => useImageEditorExtensionPanels() );
+
+		act( () => {
+			register( {
+				name: 'vendor/filter',
+				title: 'Filter',
+				order: 20,
+				component: () => null,
+			} );
+			register( {
+				name: 'vendor/enhance',
+				title: 'Enhance',
+				order: 10,
+				component: () => null,
+			} );
+		} );
+
+		expect( result.current.map( ( panel ) => panel.name ) ).toEqual( [
+			'vendor/enhance',
+			'vendor/filter',
+		] );
+	} );
+
+	it( 'updates subscribers when a panel unregisters', () => {
+		const { result } = renderHook( () => useImageEditorExtensionPanels() );
+
+		let unregister = () => {};
+		act( () => {
+			unregister = register( {
+				name: 'vendor/enhance',
+				title: 'Enhance',
+				component: () => null,
+			} );
+		} );
+
+		expect( result.current ).toHaveLength( 1 );
+
+		act( () => {
+			unregister();
+		} );
+
+		expect( result.current ).toHaveLength( 0 );
+	} );
+
+	it( 'rejects duplicate panel names', () => {
+		act( () => {
+			register( {
+				name: 'vendor/enhance',
+				title: 'Enhance',
+				component: () => null,
+			} );
+		} );
+
+		expect( () =>
+			registerImageEditorExtensionPanel( {
+				name: 'vendor/enhance',
+				title: 'Enhance again',
+				component: () => null,
+			} )
+		).toThrow(
+			'Image editor extension panel "vendor/enhance" is already registered.'
+		);
+	} );
+} );

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -56,6 +56,7 @@ import {
 	useImageEditingSession,
 	type ImageEditingSessionImage,
 } from '../image-editing-session';
+import { useImageEditorExtensionPanels } from '../image-editor-extension-registry';
 import MediaEditorKeyboardShortcutsModal from '../media-editor-keyboard-shortcuts-modal';
 
 // Details-tab edits are bundled into transformed `/edit` requests. Core's
@@ -240,6 +241,7 @@ function MediaEditorContent( {
 }: MediaEditorProps ) {
 	const imageSession = useImageEditingSession();
 	const setSourceImage = imageSession.setSourceImage;
+	const extensionPanels = useImageEditorExtensionPanels();
 
 	const { media, hasEdits } = useSelect(
 		( select ) => {
@@ -377,6 +379,22 @@ function MediaEditorContent( {
 		if ( ! isImage ) {
 			return [ detailsTab ];
 		}
+		const extensionTabs = extensionPanels.map( ( panel ) => {
+			const PanelComponent = panel.component;
+			return {
+				id: `extension/${ panel.name }`,
+				title: panel.title,
+				panel: (
+					<Stack
+						className="media-editor__panel"
+						direction="column"
+						gap="lg"
+					>
+						<PanelComponent session={ imageSession } />
+					</Stack>
+				),
+			};
+		} );
 		return [
 			{
 				id: 'crop',
@@ -400,6 +418,7 @@ function MediaEditorContent( {
 					</Stack>
 				),
 			},
+			...extensionTabs,
 			detailsTab,
 		];
 	}, [
@@ -408,6 +427,8 @@ function MediaEditorContent( {
 		freeformCrop,
 		aspectRatioPresets,
 		signalPlacementControlInteraction,
+		extensionPanels,
+		imageSession,
 	] );
 
 	const handleChange = ( updates: Partial< Media > ) => {

--- a/packages/media-editor/src/private-apis.ts
+++ b/packages/media-editor/src/private-apis.ts
@@ -5,10 +5,12 @@ import { lock } from './lock-unlock';
 import { store } from './store';
 import { MediaEditorModal } from './components/media-editor-modal';
 import { MediaEditor } from './components/media-editor';
+import { registerImageEditorExtensionPanel } from './components/image-editor-extension-registry';
 
 export const privateApis = {};
 lock( privateApis, {
 	store,
 	MediaEditor,
 	MediaEditorModal,
+	registerImageEditorExtensionPanel,
 } );


### PR DESCRIPTION
## What changed

Adds a constrained image editor extension panel registry.

Extensions can register sidebar panel definitions with a unique `name`, `title`, optional `order`, and a React component. The media editor modal renders registered panels as image-only tabs between Crop and Details, and each panel component receives the current image editing session.

The registration function is exposed through media editor private APIs while the feature is still internal.

This is a stacked follow-up to #77929.

## Why

This establishes the first UI extension point without expanding the editor shell. Core still owns the modal layout, tab placement, Save/Cancel, dirty state, undo/redo, and persistence. The initial slot is intentionally limited to sidebar panels so later adjustments, filters, or AI tools can exercise the session API without adding toolbar or canvas overlay extension surfaces yet.

## Validation

- `npm run test:unit packages/media-editor/src/components/image-editor-extension-registry/test/index.tsx -- --runInBand`
- `npm run test:unit packages/media-editor/src/components/image-editing-session/test/index.tsx -- --runInBand`
- `npm run test:unit packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts -- --runInBand`
- `npm exec -- prettier --check packages/media-editor/src/components/image-editor-extension-registry/index.ts packages/media-editor/src/components/image-editor-extension-registry/test/index.tsx packages/media-editor/src/components/media-editor-modal/index.tsx packages/media-editor/src/private-apis.ts`
- `npm run lint:js packages/media-editor/src/components/image-editor-extension-registry/index.ts packages/media-editor/src/components/image-editor-extension-registry/test/index.tsx packages/media-editor/src/components/media-editor-modal/index.tsx packages/media-editor/src/private-apis.ts`
- `git diff --check`