### PR TITLE
Add image adjustment panel

### DIFF
--- a/packages/media-editor/src/components/image-editing-session/index.tsx
+++ b/packages/media-editor/src/components/image-editing-session/index.tsx
@@ -1,0 +1,117 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+} from '@wordpress/element';
+import type { ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	CropperProvider,
+	useCropperState,
+	type UseCropperStateReturn,
+} from '../../image-editor';
+import {
+	buildModifiers,
+	type Modifier,
+} from '../media-editor-modal/build-modifiers';
+
+interface WorkingImage {
+	src: string;
+	width: number;
+	height: number;
+}
+
+export interface ImageEditingSession {
+	/** Current source being edited by the image session. */
+	workingImage: WorkingImage | null;
+	/** Low-level cropper controller. */
+	cropper: UseCropperStateReturn;
+	/** Whether the image session has unsaved image edits. */
+	isDirty: boolean;
+	/** Whether the image session has undo history. */
+	hasUndo: boolean;
+	/** Whether the image session has redo history. */
+	hasRedo: boolean;
+	/** Undo the last image session edit. */
+	undo: () => void;
+	/** Redo the last undone image session edit. */
+	redo: () => void;
+	/** Reset the current image edits. */
+	reset: () => void;
+	/** Commit any pending continuous edit to history. */
+	commitHistory: () => void;
+	/** Build the Core REST media edit modifiers for the current image state. */
+	buildSaveModifiers: () => Modifier[];
+}
+
+const ImageEditingSessionContext = createContext<
+	ImageEditingSession | undefined
+>( undefined );
+
+export function ImageEditingSessionProvider( {
+	children,
+}: {
+	children: ReactNode;
+} ) {
+	const cropper = useCropperState();
+
+	const workingImage = useMemo< WorkingImage | null >( () => {
+		if ( ! cropper.state.image ) {
+			return null;
+		}
+		return {
+			src: cropper.state.image.src,
+			width: cropper.state.image.naturalWidth,
+			height: cropper.state.image.naturalHeight,
+		};
+	}, [ cropper.state.image ] );
+
+	const buildSaveModifiers = useCallback( () => {
+		if ( ! cropper.isDirty || ! cropper.state.image ) {
+			return [];
+		}
+		return buildModifiers( cropper.state, {
+			width: cropper.state.image.naturalWidth,
+			height: cropper.state.image.naturalHeight,
+		} );
+	}, [ cropper.isDirty, cropper.state ] );
+
+	const session = useMemo< ImageEditingSession >(
+		() => ( {
+			workingImage,
+			cropper,
+			isDirty: cropper.isDirty,
+			hasUndo: cropper.hasUndo,
+			hasRedo: cropper.hasRedo,
+			undo: cropper.undo,
+			redo: cropper.redo,
+			reset: () => cropper.reset(),
+			commitHistory: cropper.commitHistory,
+			buildSaveModifiers,
+		} ),
+		[ cropper, workingImage, buildSaveModifiers ]
+	);
+
+	return (
+		<ImageEditingSessionContext.Provider value={ session }>
+			<CropperProvider value={ cropper }>{ children }</CropperProvider>
+		</ImageEditingSessionContext.Provider>
+	);
+}
+
+export function useImageEditingSession(): ImageEditingSession {
+	const context = useContext( ImageEditingSessionContext );
+	if ( ! context ) {
+		throw new Error(
+			'useImageEditingSession must be used within ImageEditingSessionProvider.'
+		);
+	}
+	return context;
+}

--- a/packages/media-editor/src/components/image-editing-session/index.tsx
+++ b/packages/media-editor/src/components/image-editing-session/index.tsx
@@ -6,6 +6,7 @@ import {
 	useCallback,
 	useContext,
 	useMemo,
+	useState,
 } from '@wordpress/element';
 import type { ReactNode } from 'react';
 
@@ -22,17 +23,30 @@ import {
 	type Modifier,
 } from '../media-editor-modal/build-modifiers';
 
-interface WorkingImage {
+export interface ImageEditingSessionImage {
 	src: string;
 	width: number;
 	height: number;
 }
 
+function areImagesEqual(
+	a: ImageEditingSessionImage | null,
+	b: ImageEditingSessionImage | null
+): boolean {
+	return (
+		a?.src === b?.src && a?.width === b?.width && a?.height === b?.height
+	);
+}
+
 export interface ImageEditingSession {
-	/** Current source being edited by the image session. */
-	workingImage: WorkingImage | null;
+	/** Original image source loaded into the current session. */
+	sourceImage: ImageEditingSessionImage | null;
+	/** Current image source being edited by the image session. */
+	workingImage: ImageEditingSessionImage | null;
 	/** Low-level cropper controller. */
 	cropper: UseCropperStateReturn;
+	/** Replace the source image and reset dependent image edits. */
+	setSourceImage: ( image: ImageEditingSessionImage | null ) => void;
 	/** Whether the image session has unsaved image edits. */
 	isDirty: boolean;
 	/** Whether the image session has undo history. */
@@ -61,32 +75,47 @@ export function ImageEditingSessionProvider( {
 	children: ReactNode;
 } ) {
 	const cropper = useCropperState();
+	const setCropperImage = cropper.setImage;
+	const [ sourceImage, setSourceImageState ] =
+		useState< ImageEditingSessionImage | null >( null );
 
-	const workingImage = useMemo< WorkingImage | null >( () => {
-		if ( ! cropper.state.image ) {
-			return null;
-		}
-		return {
-			src: cropper.state.image.src,
-			width: cropper.state.image.naturalWidth,
-			height: cropper.state.image.naturalHeight,
-		};
-	}, [ cropper.state.image ] );
+	const setSourceImage = useCallback(
+		( image: ImageEditingSessionImage | null ) => {
+			if ( areImagesEqual( sourceImage, image ) ) {
+				return;
+			}
+			setSourceImageState( image );
+			setCropperImage(
+				image
+					? {
+							src: image.src,
+							naturalWidth: image.width,
+							naturalHeight: image.height,
+					  }
+					: null
+			);
+		},
+		[ setCropperImage, sourceImage ]
+	);
+
+	const workingImage = sourceImage;
 
 	const buildSaveModifiers = useCallback( () => {
-		if ( ! cropper.isDirty || ! cropper.state.image ) {
+		if ( ! cropper.isDirty || ! workingImage ) {
 			return [];
 		}
 		return buildModifiers( cropper.state, {
-			width: cropper.state.image.naturalWidth,
-			height: cropper.state.image.naturalHeight,
+			width: workingImage.width,
+			height: workingImage.height,
 		} );
-	}, [ cropper.isDirty, cropper.state ] );
+	}, [ cropper.isDirty, cropper.state, workingImage ] );
 
 	const session = useMemo< ImageEditingSession >(
 		() => ( {
+			sourceImage,
 			workingImage,
 			cropper,
+			setSourceImage,
 			isDirty: cropper.isDirty,
 			hasUndo: cropper.hasUndo,
 			hasRedo: cropper.hasRedo,
@@ -96,7 +125,13 @@ export function ImageEditingSessionProvider( {
 			commitHistory: cropper.commitHistory,
 			buildSaveModifiers,
 		} ),
-		[ cropper, workingImage, buildSaveModifiers ]
+		[
+			cropper,
+			setSourceImage,
+			sourceImage,
+			workingImage,
+			buildSaveModifiers,
+		]
 	);
 
 	return (

--- a/packages/media-editor/src/components/image-editing-session/index.tsx
+++ b/packages/media-editor/src/components/image-editing-session/index.tsx
@@ -5,7 +5,9 @@ import {
 	createContext,
 	useCallback,
 	useContext,
+	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from '@wordpress/element';
 import type { ReactNode } from 'react';
@@ -15,9 +17,14 @@ import type { ReactNode } from 'react';
  */
 import {
 	CropperProvider,
+	areImageEditAdjustmentsDefault,
+	exportImageEdit,
 	useCropperState,
+	type CropperState,
+	type ImageEditAdjustmentValues,
 	type UseCropperStateReturn,
 } from '../../image-editor';
+import { useHistory } from '../../image-editor/react/hooks/use-history';
 import {
 	buildModifiers,
 	type Modifier,
@@ -29,12 +36,71 @@ export interface ImageEditingSessionImage {
 	height: number;
 }
 
+export type ImageEditingAdjustments = ImageEditAdjustmentValues;
+
+export const DEFAULT_IMAGE_EDITING_ADJUSTMENTS: ImageEditingAdjustments = {
+	brightness: 1,
+	contrast: 1,
+	saturation: 1,
+	grayscale: 0,
+};
+
+type HistoryDomain = 'cropper' | 'adjustments';
+const HISTORY_EPSILON = 1e-6;
+
+function nearlyEqual( a: number, b: number ): boolean {
+	return Math.abs( a - b ) < HISTORY_EPSILON;
+}
+
 function areImagesEqual(
 	a: ImageEditingSessionImage | null,
 	b: ImageEditingSessionImage | null
 ): boolean {
 	return (
 		a?.src === b?.src && a?.width === b?.width && a?.height === b?.height
+	);
+}
+
+function areCropperImagesEqual(
+	a: CropperState[ 'image' ],
+	b: CropperState[ 'image' ]
+): boolean {
+	return (
+		a?.src === b?.src &&
+		a?.naturalWidth === b?.naturalWidth &&
+		a?.naturalHeight === b?.naturalHeight
+	);
+}
+
+function areAdjustmentsEqual(
+	a: ImageEditingAdjustments,
+	b: ImageEditingAdjustments
+): boolean {
+	return (
+		a.brightness === b.brightness &&
+		a.contrast === b.contrast &&
+		a.saturation === b.saturation &&
+		a.grayscale === b.grayscale
+	);
+}
+
+function areCropperStatesEqual( a: CropperState, b: CropperState ): boolean {
+	const aImage = a.image;
+	const bImage = b.image;
+	return (
+		aImage?.src === bImage?.src &&
+		aImage?.naturalWidth === bImage?.naturalWidth &&
+		aImage?.naturalHeight === bImage?.naturalHeight &&
+		nearlyEqual( a.pan.x, b.pan.x ) &&
+		nearlyEqual( a.pan.y, b.pan.y ) &&
+		nearlyEqual( a.zoom, b.zoom ) &&
+		nearlyEqual( a.rotation, b.rotation ) &&
+		a.flip.horizontal === b.flip.horizontal &&
+		a.flip.vertical === b.flip.vertical &&
+		nearlyEqual( a.cropRect.x, b.cropRect.x ) &&
+		nearlyEqual( a.cropRect.y, b.cropRect.y ) &&
+		nearlyEqual( a.cropRect.width, b.cropRect.width ) &&
+		nearlyEqual( a.cropRect.height, b.cropRect.height )
 	);
 }
 
@@ -45,10 +111,23 @@ export interface ImageEditingSession {
 	workingImage: ImageEditingSessionImage | null;
 	/** Low-level cropper controller. */
 	cropper: UseCropperStateReturn;
+	/** Image adjustment values applied to the current working image. */
+	adjustments: ImageEditingAdjustments;
 	/** Replace the source image and reset dependent image edits. */
 	setSourceImage: ( image: ImageEditingSessionImage | null ) => void;
+	/** Set one image adjustment value. */
+	setAdjustment: < K extends keyof ImageEditingAdjustments >(
+		key: K,
+		value: ImageEditingAdjustments[ K ]
+	) => void;
+	/** Reset image adjustments to their defaults. */
+	resetAdjustments: () => void;
 	/** Whether the image session has unsaved image edits. */
 	isDirty: boolean;
+	/** Whether the session contains preview edits that are not saveable yet. */
+	hasPreviewOnlyEdits: boolean;
+	/** Whether saving must upload a replacement image blob. */
+	hasReplacementImageEdits: boolean;
 	/** Whether the image session has undo history. */
 	hasUndo: boolean;
 	/** Whether the image session has redo history. */
@@ -63,6 +142,8 @@ export interface ImageEditingSession {
 	commitHistory: () => void;
 	/** Build the Core REST media edit modifiers for the current image state. */
 	buildSaveModifiers: () => Modifier[];
+	/** Export the current image edit as replacement image bytes. */
+	exportImageEdit: ( mimeType?: string, quality?: number ) => Promise< Blob >;
 }
 
 const ImageEditingSessionContext = createContext<
@@ -78,6 +159,77 @@ export function ImageEditingSessionProvider( {
 	const setCropperImage = cropper.setImage;
 	const [ sourceImage, setSourceImageState ] =
 		useState< ImageEditingSessionImage | null >( null );
+	const [ adjustments, setAdjustments ] = useState< ImageEditingAdjustments >(
+		DEFAULT_IMAGE_EDITING_ADJUSTMENTS
+	);
+	const cropperStateRef = useRef( cropper.state );
+	const adjustmentsRef = useRef( adjustments );
+	const pendingCropperBaselineRef = useRef< CropperState | null >( null );
+	const pendingAdjustmentBaselineRef =
+		useRef< ImageEditingAdjustments | null >( null );
+	const undoDomainStackRef = useRef< HistoryDomain[] >( [] );
+	const redoDomainStackRef = useRef< HistoryDomain[] >( [] );
+
+	useEffect( () => {
+		cropperStateRef.current = cropper.state;
+	}, [ cropper.state ] );
+
+	useEffect( () => {
+		adjustmentsRef.current = adjustments;
+	}, [ adjustments ] );
+
+	const applyAdjustmentsState = useCallback(
+		( nextAdjustments: ImageEditingAdjustments ) => {
+			adjustmentsRef.current = nextAdjustments;
+			setAdjustments( nextAdjustments );
+		},
+		[]
+	);
+
+	const pushUndoDomain = useCallback( ( domain: HistoryDomain ) => {
+		undoDomainStackRef.current = [ ...undoDomainStackRef.current, domain ];
+		redoDomainStackRef.current = [];
+	}, [] );
+
+	const clearSessionHistory = useCallback( () => {
+		pendingCropperBaselineRef.current = null;
+		pendingAdjustmentBaselineRef.current = null;
+		undoDomainStackRef.current = [];
+		redoDomainStackRef.current = [];
+	}, [] );
+
+	const {
+		hasUndo: hasAdjustmentsUndo,
+		hasRedo: hasAdjustmentsRedo,
+		pushHistory: pushAdjustmentsHistory,
+		commitHistory: commitAdjustmentsHistory,
+		undo: undoAdjustments,
+		redo: redoAdjustments,
+		suppressNextChange: suppressNextAdjustmentsChange,
+		clearHistory: clearAdjustmentsHistory,
+	} = useHistory( {
+		state: adjustments,
+		isEqual: areAdjustmentsEqual,
+		onApplyState: applyAdjustmentsState,
+		debounceMs: 300,
+	} );
+
+	const areAdjustmentsDirty = ! areAdjustmentsEqual(
+		adjustments,
+		DEFAULT_IMAGE_EDITING_ADJUSTMENTS
+	);
+	const hasReplacementImageEdits =
+		! areImageEditAdjustmentsDefault( adjustments );
+
+	const markCropperEdited = useCallback( () => {
+		if ( pendingAdjustmentBaselineRef.current ) {
+			return;
+		}
+		if ( ! pendingCropperBaselineRef.current ) {
+			pendingCropperBaselineRef.current = cropperStateRef.current;
+		}
+		redoDomainStackRef.current = [];
+	}, [] );
 
 	const setSourceImage = useCallback(
 		( image: ImageEditingSessionImage | null ) => {
@@ -85,6 +237,10 @@ export function ImageEditingSessionProvider( {
 				return;
 			}
 			setSourceImageState( image );
+			adjustmentsRef.current = DEFAULT_IMAGE_EDITING_ADJUSTMENTS;
+			clearSessionHistory();
+			setAdjustments( DEFAULT_IMAGE_EDITING_ADJUSTMENTS );
+			clearAdjustmentsHistory( DEFAULT_IMAGE_EDITING_ADJUSTMENTS );
 			setCropperImage(
 				image
 					? {
@@ -95,40 +251,322 @@ export function ImageEditingSessionProvider( {
 					: null
 			);
 		},
-		[ setCropperImage, sourceImage ]
+		[
+			clearAdjustmentsHistory,
+			clearSessionHistory,
+			setCropperImage,
+			sourceImage,
+		]
 	);
+
+	const setAdjustment = useCallback(
+		< K extends keyof ImageEditingAdjustments >(
+			key: K,
+			value: ImageEditingAdjustments[ K ]
+		) => {
+			const currentAdjustments = adjustmentsRef.current;
+			if ( currentAdjustments[ key ] === value ) {
+				return;
+			}
+			if ( ! pendingAdjustmentBaselineRef.current ) {
+				pendingAdjustmentBaselineRef.current = currentAdjustments;
+			}
+			suppressNextAdjustmentsChange( { clearPending: true } );
+			redoDomainStackRef.current = [];
+			applyAdjustmentsState( {
+				...currentAdjustments,
+				[ key ]: value,
+			} );
+		},
+		[ applyAdjustmentsState, suppressNextAdjustmentsChange ]
+	);
+
+	const resetAdjustments = useCallback( () => {
+		const currentAdjustments = adjustmentsRef.current;
+		if (
+			areAdjustmentsEqual(
+				currentAdjustments,
+				DEFAULT_IMAGE_EDITING_ADJUSTMENTS
+			)
+		) {
+			return;
+		}
+		commitAdjustmentsHistory();
+		pushAdjustmentsHistory( currentAdjustments );
+		suppressNextAdjustmentsChange();
+		pendingAdjustmentBaselineRef.current = null;
+		pushUndoDomain( 'adjustments' );
+		applyAdjustmentsState( DEFAULT_IMAGE_EDITING_ADJUSTMENTS );
+	}, [
+		applyAdjustmentsState,
+		commitAdjustmentsHistory,
+		pushAdjustmentsHistory,
+		pushUndoDomain,
+		suppressNextAdjustmentsChange,
+	] );
+
+	const commitCropperHistory = useCallback( () => {
+		const pendingCropperBaseline = pendingCropperBaselineRef.current;
+		cropper.commitHistory();
+		if (
+			pendingCropperBaseline &&
+			! areCropperStatesEqual(
+				pendingCropperBaseline,
+				cropperStateRef.current
+			)
+		) {
+			pushUndoDomain( 'cropper' );
+		}
+		pendingCropperBaselineRef.current = null;
+	}, [ cropper, pushUndoDomain ] );
+
+	const commitHistory = useCallback( () => {
+		const pendingAdjustmentBaseline = pendingAdjustmentBaselineRef.current;
+		if ( pendingAdjustmentBaseline ) {
+			if (
+				! areAdjustmentsEqual(
+					pendingAdjustmentBaseline,
+					adjustmentsRef.current
+				)
+			) {
+				pushAdjustmentsHistory( pendingAdjustmentBaseline );
+				pushUndoDomain( 'adjustments' );
+			}
+			suppressNextAdjustmentsChange( { clearPending: true } );
+			pendingAdjustmentBaselineRef.current = null;
+			return;
+		}
+		commitCropperHistory();
+		commitAdjustmentsHistory();
+	}, [
+		commitCropperHistory,
+		commitAdjustmentsHistory,
+		pushAdjustmentsHistory,
+		pushUndoDomain,
+		suppressNextAdjustmentsChange,
+	] );
+
+	const sessionCropper = useMemo< UseCropperStateReturn >(
+		() => ( {
+			...cropper,
+			setImage: ( image ) => {
+				if (
+					! areCropperImagesEqual(
+						cropperStateRef.current.image,
+						image
+					)
+				) {
+					clearSessionHistory();
+				}
+				cropper.setImage( image );
+			},
+			setPan: ( pan ) => {
+				markCropperEdited();
+				cropper.setPan( pan );
+			},
+			setZoom: ( zoom ) => {
+				markCropperEdited();
+				cropper.setZoom( zoom );
+			},
+			setZoomAtPoint: ( zoom, pan ) => {
+				markCropperEdited();
+				cropper.setZoomAtPoint( zoom, pan );
+			},
+			setRotation: ( rotation ) => {
+				markCropperEdited();
+				cropper.setRotation( rotation );
+			},
+			setFlip: ( flip ) => {
+				markCropperEdited();
+				cropper.setFlip( flip );
+			},
+			toggleFlip: ( direction ) => {
+				markCropperEdited();
+				cropper.toggleFlip( direction );
+			},
+			snapRotate90: ( direction ) => {
+				markCropperEdited();
+				cropper.snapRotate90( direction );
+			},
+			setCropRect: ( rect ) => {
+				markCropperEdited();
+				cropper.setCropRect( rect );
+			},
+			settleCrop: () => {
+				markCropperEdited();
+				cropper.settleCrop();
+			},
+			applyOperation: ( op ) => {
+				markCropperEdited();
+				cropper.applyOperation( op );
+			},
+			reset: ( resetState ) => {
+				markCropperEdited();
+				cropper.reset( resetState );
+			},
+			commitHistory: commitCropperHistory,
+		} ),
+		[
+			clearSessionHistory,
+			commitCropperHistory,
+			cropper,
+			markCropperEdited,
+		]
+	);
+
+	const undo = useCallback( () => {
+		commitHistory();
+		const domain =
+			undoDomainStackRef.current[ undoDomainStackRef.current.length - 1 ];
+		if ( domain ) {
+			undoDomainStackRef.current = undoDomainStackRef.current.slice(
+				0,
+				-1
+			);
+			redoDomainStackRef.current = [
+				domain,
+				...redoDomainStackRef.current,
+			];
+			if ( domain === 'adjustments' ) {
+				undoAdjustments();
+				return;
+			}
+			cropper.undo();
+			return;
+		}
+		if ( hasAdjustmentsUndo || areAdjustmentsDirty ) {
+			undoAdjustments();
+			redoDomainStackRef.current = [
+				'adjustments',
+				...redoDomainStackRef.current,
+			];
+			return;
+		}
+		if ( cropper.hasUndo ) {
+			cropper.undo();
+			redoDomainStackRef.current = [
+				'cropper',
+				...redoDomainStackRef.current,
+			];
+		}
+	}, [
+		areAdjustmentsDirty,
+		commitHistory,
+		cropper,
+		hasAdjustmentsUndo,
+		undoAdjustments,
+	] );
+
+	const redo = useCallback( () => {
+		const domain = redoDomainStackRef.current[ 0 ];
+		if ( domain ) {
+			redoDomainStackRef.current = redoDomainStackRef.current.slice( 1 );
+			undoDomainStackRef.current = [
+				...undoDomainStackRef.current,
+				domain,
+			];
+			if ( domain === 'adjustments' ) {
+				redoAdjustments();
+				return;
+			}
+			cropper.redo();
+			return;
+		}
+		if ( hasAdjustmentsRedo ) {
+			redoAdjustments();
+			undoDomainStackRef.current = [
+				...undoDomainStackRef.current,
+				'adjustments',
+			];
+			return;
+		}
+		if ( cropper.hasRedo ) {
+			cropper.redo();
+			undoDomainStackRef.current = [
+				...undoDomainStackRef.current,
+				'cropper',
+			];
+		}
+	}, [ cropper, hasAdjustmentsRedo, redoAdjustments ] );
+
+	const reset = useCallback( () => {
+		cropper.reset();
+		resetAdjustments();
+	}, [ cropper, resetAdjustments ] );
 
 	const workingImage = sourceImage;
 
 	const buildSaveModifiers = useCallback( () => {
-		if ( ! cropper.isDirty || ! workingImage ) {
+		if ( hasReplacementImageEdits || ! cropper.isDirty || ! workingImage ) {
 			return [];
 		}
 		return buildModifiers( cropper.state, {
 			width: workingImage.width,
 			height: workingImage.height,
 		} );
-	}, [ cropper.isDirty, cropper.state, workingImage ] );
+	}, [
+		cropper.isDirty,
+		cropper.state,
+		hasReplacementImageEdits,
+		workingImage,
+	] );
+
+	const exportSessionImageEdit = useCallback(
+		( mimeType?: string, quality?: number ) => {
+			if ( ! sourceImage ) {
+				return Promise.reject(
+					new Error( 'No source image is loaded.' )
+				);
+			}
+			return exportImageEdit( {
+				src: sourceImage.src,
+				state: cropper.state,
+				adjustments,
+				mimeType,
+				quality,
+			} );
+		},
+		[ adjustments, cropper.state, sourceImage ]
+	);
 
 	const session = useMemo< ImageEditingSession >(
 		() => ( {
 			sourceImage,
 			workingImage,
-			cropper,
+			cropper: sessionCropper,
+			adjustments,
 			setSourceImage,
-			isDirty: cropper.isDirty,
-			hasUndo: cropper.hasUndo,
-			hasRedo: cropper.hasRedo,
-			undo: cropper.undo,
-			redo: cropper.redo,
-			reset: () => cropper.reset(),
-			commitHistory: cropper.commitHistory,
+			setAdjustment,
+			resetAdjustments,
+			isDirty: cropper.isDirty || areAdjustmentsDirty,
+			hasPreviewOnlyEdits: false,
+			hasReplacementImageEdits,
+			hasUndo: cropper.hasUndo || hasAdjustmentsUndo,
+			hasRedo: cropper.hasRedo || hasAdjustmentsRedo,
+			undo,
+			redo,
+			reset,
+			commitHistory,
 			buildSaveModifiers,
+			exportImageEdit: exportSessionImageEdit,
 		} ),
 		[
+			adjustments,
+			areAdjustmentsDirty,
 			cropper,
+			commitHistory,
+			exportSessionImageEdit,
+			hasReplacementImageEdits,
+			hasAdjustmentsRedo,
+			hasAdjustmentsUndo,
+			redo,
+			reset,
+			resetAdjustments,
+			setAdjustment,
 			setSourceImage,
+			sessionCropper,
 			sourceImage,
+			undo,
 			workingImage,
 			buildSaveModifiers,
 		]
@@ -136,7 +574,9 @@ export function ImageEditingSessionProvider( {
 
 	return (
 		<ImageEditingSessionContext.Provider value={ session }>
-			<CropperProvider value={ cropper }>{ children }</CropperProvider>
+			<CropperProvider value={ sessionCropper }>
+				{ children }
+			</CropperProvider>
 		</ImageEditingSessionContext.Provider>
 	);
 }

--- a/packages/media-editor/src/components/image-editing-session/test/index.tsx
+++ b/packages/media-editor/src/components/image-editing-session/test/index.tsx
@@ -13,8 +13,14 @@ import { buildModifiers } from '../../media-editor-modal/build-modifiers';
 
 const TEST_IMAGE = {
 	src: 'test.jpg',
-	naturalWidth: 1000,
-	naturalHeight: 500,
+	width: 1000,
+	height: 500,
+};
+
+const NEXT_IMAGE = {
+	src: 'next.jpg',
+	width: 1200,
+	height: 800,
 };
 
 function SessionWrapper( { children }: { children: ReactNode } ) {
@@ -36,6 +42,7 @@ describe( 'ImageEditingSessionProvider', () => {
 		expect( result.current.isDirty ).toBe( false );
 		expect( result.current.hasUndo ).toBe( false );
 		expect( result.current.hasRedo ).toBe( false );
+		expect( result.current.sourceImage ).toBeNull();
 		expect( result.current.workingImage ).toBeNull();
 	} );
 
@@ -43,13 +50,14 @@ describe( 'ImageEditingSessionProvider', () => {
 		const { result } = setup();
 
 		act( () => {
-			result.current.cropper.setImage( TEST_IMAGE );
+			result.current.setSourceImage( TEST_IMAGE );
 		} );
 
+		expect( result.current.sourceImage ).toEqual( TEST_IMAGE );
 		expect( result.current.workingImage ).toEqual( {
 			src: TEST_IMAGE.src,
-			width: TEST_IMAGE.naturalWidth,
-			height: TEST_IMAGE.naturalHeight,
+			width: TEST_IMAGE.width,
+			height: TEST_IMAGE.height,
 		} );
 		expect( result.current.isDirty ).toBe( false );
 	} );
@@ -64,6 +72,39 @@ describe( 'ImageEditingSessionProvider', () => {
 		);
 
 		expect( result.current.cropper ).toBe( result.current.session.cropper );
+	} );
+
+	it( 'resets cropper edits when the source image changes', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.setSourceImage( TEST_IMAGE );
+		} );
+		act( () => {
+			result.current.cropper.setZoom( 3 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+
+		expect( result.current.isDirty ).toBe( true );
+		expect( result.current.hasUndo ).toBe( true );
+
+		act( () => {
+			result.current.setSourceImage( NEXT_IMAGE );
+		} );
+
+		expect( result.current.sourceImage ).toEqual( NEXT_IMAGE );
+		expect( result.current.workingImage ).toEqual( NEXT_IMAGE );
+		expect( result.current.cropper.state.image ).toEqual( {
+			src: NEXT_IMAGE.src,
+			naturalWidth: NEXT_IMAGE.width,
+			naturalHeight: NEXT_IMAGE.height,
+		} );
+		expect( result.current.cropper.state.zoom ).toBe( 1 );
+		expect( result.current.isDirty ).toBe( false );
+		expect( result.current.hasUndo ).toBe( false );
+		expect( result.current.hasRedo ).toBe( false );
 	} );
 
 	it( 'marks the image session dirty when cropper state changes', () => {
@@ -127,7 +168,7 @@ describe( 'ImageEditingSessionProvider', () => {
 		const { result } = setup();
 
 		act( () => {
-			result.current.cropper.setImage( TEST_IMAGE );
+			result.current.setSourceImage( TEST_IMAGE );
 		} );
 
 		expect( result.current.buildSaveModifiers() ).toEqual( [] );
@@ -137,7 +178,7 @@ describe( 'ImageEditingSessionProvider', () => {
 		const { result } = setup();
 
 		act( () => {
-			result.current.cropper.setImage( TEST_IMAGE );
+			result.current.setSourceImage( TEST_IMAGE );
 		} );
 		act( () => {
 			result.current.cropper.snapRotate90( 1 );
@@ -145,8 +186,8 @@ describe( 'ImageEditingSessionProvider', () => {
 
 		expect( result.current.buildSaveModifiers() ).toEqual(
 			buildModifiers( result.current.cropper.state, {
-				width: TEST_IMAGE.naturalWidth,
-				height: TEST_IMAGE.naturalHeight,
+				width: TEST_IMAGE.width,
+				height: TEST_IMAGE.height,
 			} )
 		);
 	} );

--- a/packages/media-editor/src/components/image-editing-session/test/index.tsx
+++ b/packages/media-editor/src/components/image-editing-session/test/index.tsx
@@ -7,7 +7,11 @@ import type { ReactNode } from 'react';
 /**
  * Internal dependencies
  */
-import { ImageEditingSessionProvider, useImageEditingSession } from '..';
+import {
+	DEFAULT_IMAGE_EDITING_ADJUSTMENTS,
+	ImageEditingSessionProvider,
+	useImageEditingSession,
+} from '..';
 import { useCropper } from '../../../image-editor';
 import { buildModifiers } from '../../media-editor-modal/build-modifiers';
 
@@ -40,6 +44,8 @@ describe( 'ImageEditingSessionProvider', () => {
 		const { result } = setup();
 
 		expect( result.current.isDirty ).toBe( false );
+		expect( result.current.hasPreviewOnlyEdits ).toBe( false );
+		expect( result.current.hasReplacementImageEdits ).toBe( false );
 		expect( result.current.hasUndo ).toBe( false );
 		expect( result.current.hasRedo ).toBe( false );
 		expect( result.current.sourceImage ).toBeNull();
@@ -107,6 +113,33 @@ describe( 'ImageEditingSessionProvider', () => {
 		expect( result.current.hasRedo ).toBe( false );
 	} );
 
+	it( 'clears session history when the cropper image changes directly', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.setSourceImage( TEST_IMAGE );
+		} );
+		act( () => {
+			result.current.cropper.setZoom( 3 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+
+		expect( result.current.hasUndo ).toBe( true );
+
+		act( () => {
+			result.current.cropper.setImage( {
+				src: NEXT_IMAGE.src,
+				naturalWidth: NEXT_IMAGE.width,
+				naturalHeight: NEXT_IMAGE.height,
+			} );
+		} );
+
+		expect( result.current.hasUndo ).toBe( false );
+		expect( result.current.hasRedo ).toBe( false );
+	} );
+
 	it( 'marks the image session dirty when cropper state changes', () => {
 		const { result } = setup();
 
@@ -115,6 +148,454 @@ describe( 'ImageEditingSessionProvider', () => {
 		} );
 
 		expect( result.current.isDirty ).toBe( true );
+		expect( result.current.hasPreviewOnlyEdits ).toBe( false );
+	} );
+
+	it( 'marks adjustment changes as replacement image edits', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.setAdjustment( 'brightness', 1.25 );
+		} );
+
+		expect( result.current.adjustments.brightness ).toBe( 1.25 );
+		expect( result.current.isDirty ).toBe( true );
+		expect( result.current.hasPreviewOnlyEdits ).toBe( false );
+		expect( result.current.hasReplacementImageEdits ).toBe( true );
+	} );
+
+	it( 'does not create adjustment history before the control gesture commits', () => {
+		jest.useFakeTimers();
+		try {
+			const { result } = setup();
+
+			act( () => {
+				result.current.setAdjustment( 'brightness', 1.25 );
+			} );
+			act( () => {
+				jest.advanceTimersByTime( 300 );
+			} );
+
+			expect( result.current.isDirty ).toBe( true );
+			expect( result.current.hasUndo ).toBe( false );
+
+			act( () => {
+				result.current.commitHistory();
+			} );
+
+			expect( result.current.hasUndo ).toBe( true );
+
+			act( () => {
+				result.current.undo();
+			} );
+
+			expect( result.current.adjustments ).toEqual(
+				DEFAULT_IMAGE_EDITING_ADJUSTMENTS
+			);
+			expect( result.current.hasUndo ).toBe( false );
+		} finally {
+			jest.useRealTimers();
+		}
+	} );
+
+	it( 'keeps one adjustment history entry for a long-running control gesture', () => {
+		jest.useFakeTimers();
+		try {
+			const { result } = setup();
+
+			act( () => {
+				result.current.setAdjustment( 'brightness', 1.1 );
+			} );
+			act( () => {
+				jest.advanceTimersByTime( 300 );
+			} );
+			act( () => {
+				result.current.setAdjustment( 'brightness', 1.2 );
+			} );
+			act( () => {
+				jest.advanceTimersByTime( 300 );
+			} );
+			act( () => {
+				result.current.setAdjustment( 'brightness', 1.3 );
+			} );
+			act( () => {
+				jest.advanceTimersByTime( 300 );
+			} );
+
+			expect( result.current.hasUndo ).toBe( false );
+
+			act( () => {
+				result.current.commitHistory();
+			} );
+
+			expect( result.current.hasUndo ).toBe( true );
+
+			act( () => {
+				result.current.undo();
+			} );
+
+			expect( result.current.adjustments ).toEqual(
+				DEFAULT_IMAGE_EDITING_ADJUSTMENTS
+			);
+			expect( result.current.hasUndo ).toBe( false );
+		} finally {
+			jest.useRealTimers();
+		}
+	} );
+
+	it( 'undoes and redoes adjustment edits through the session', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.setAdjustment( 'contrast', 1.4 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+
+		expect( result.current.hasUndo ).toBe( true );
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.adjustments.contrast ).toBe( 1 );
+		expect( result.current.hasRedo ).toBe( true );
+
+		act( () => {
+			result.current.redo();
+		} );
+
+		expect( result.current.adjustments.contrast ).toBe( 1.4 );
+		expect( result.current.hasRedo ).toBe( false );
+	} );
+
+	it( 'composes rapid adjustment edits without losing earlier values', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.setAdjustment( 'brightness', 1.2 );
+			result.current.setAdjustment( 'contrast', 1.3 );
+			result.current.setAdjustment( 'saturation', 0.8 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+
+		expect( result.current.adjustments ).toEqual( {
+			...DEFAULT_IMAGE_EDITING_ADJUSTMENTS,
+			brightness: 1.2,
+			contrast: 1.3,
+			saturation: 0.8,
+		} );
+	} );
+
+	it( 'undoes committed adjustment edits one value change at a time', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.setAdjustment( 'brightness', 1.2 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+		act( () => {
+			result.current.setAdjustment( 'contrast', 1.3 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+		act( () => {
+			result.current.setAdjustment( 'saturation', 0.8 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+
+		expect( result.current.adjustments ).toEqual( {
+			...DEFAULT_IMAGE_EDITING_ADJUSTMENTS,
+			brightness: 1.2,
+			contrast: 1.3,
+			saturation: 0.8,
+		} );
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.adjustments ).toEqual( {
+			...DEFAULT_IMAGE_EDITING_ADJUSTMENTS,
+			brightness: 1.2,
+			contrast: 1.3,
+		} );
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.adjustments ).toEqual( {
+			...DEFAULT_IMAGE_EDITING_ADJUSTMENTS,
+			brightness: 1.2,
+		} );
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.adjustments ).toEqual(
+			DEFAULT_IMAGE_EDITING_ADJUSTMENTS
+		);
+		expect( result.current.hasUndo ).toBe( false );
+	} );
+
+	it( 'preserves edit order across cropper and multiple adjustment entries', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.setSourceImage( TEST_IMAGE );
+		} );
+		const initialCropRect = result.current.cropper.state.cropRect;
+
+		act( () => {
+			result.current.cropper.setCropRect( {
+				x: 0.2,
+				y: 0.2,
+				width: 0.6,
+				height: 0.6,
+			} );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+		act( () => {
+			result.current.setAdjustment( 'contrast', 1.3 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+		act( () => {
+			result.current.setAdjustment( 'brightness', 1.2 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.adjustments ).toEqual( {
+			...DEFAULT_IMAGE_EDITING_ADJUSTMENTS,
+			contrast: 1.3,
+		} );
+		expect( result.current.cropper.state.cropRect ).not.toEqual(
+			initialCropRect
+		);
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.adjustments ).toEqual(
+			DEFAULT_IMAGE_EDITING_ADJUSTMENTS
+		);
+		expect( result.current.cropper.state.cropRect ).not.toEqual(
+			initialCropRect
+		);
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.cropper.state.cropRect ).toEqual(
+			initialCropRect
+		);
+		expect( result.current.adjustments ).toEqual(
+			DEFAULT_IMAGE_EDITING_ADJUSTMENTS
+		);
+
+		act( () => {
+			result.current.redo();
+		} );
+
+		expect( result.current.cropper.state.cropRect ).not.toEqual(
+			initialCropRect
+		);
+		expect( result.current.adjustments ).toEqual(
+			DEFAULT_IMAGE_EDITING_ADJUSTMENTS
+		);
+
+		act( () => {
+			result.current.redo();
+		} );
+
+		expect( result.current.adjustments ).toEqual( {
+			...DEFAULT_IMAGE_EDITING_ADJUSTMENTS,
+			contrast: 1.3,
+		} );
+
+		act( () => {
+			result.current.redo();
+		} );
+
+		expect( result.current.adjustments ).toEqual( {
+			...DEFAULT_IMAGE_EDITING_ADJUSTMENTS,
+			contrast: 1.3,
+			brightness: 1.2,
+		} );
+	} );
+
+	it( 'undoes adjustment edits after earlier cropper edits', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.cropper.setZoom( 2 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+		act( () => {
+			result.current.setAdjustment( 'brightness', 1.2 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+
+		expect( result.current.hasUndo ).toBe( true );
+		expect( result.current.adjustments.brightness ).toBe( 1.2 );
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.cropper.state.zoom ).toBe( 2 );
+		expect( result.current.adjustments.brightness ).toBe( 1 );
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.cropper.state.zoom ).toBe( 1 );
+		expect( result.current.adjustments.brightness ).toBe( 1 );
+		expect( result.current.hasUndo ).toBe( false );
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.cropper.state.zoom ).toBe( 1 );
+		expect( result.current.adjustments.brightness ).toBe( 1 );
+		expect( result.current.hasUndo ).toBe( false );
+	} );
+
+	it( 'does not create an extra undo entry after crop resize and adjustment', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.setSourceImage( TEST_IMAGE );
+		} );
+		const initialCropRect = result.current.cropper.state.cropRect;
+
+		act( () => {
+			result.current.cropper.setCropRect( {
+				x: 0.2,
+				y: 0.2,
+				width: 0.6,
+				height: 0.6,
+			} );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+		act( () => {
+			result.current.setAdjustment( 'brightness', 1.2 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.adjustments.brightness ).toBe( 1 );
+		expect( result.current.cropper.state.cropRect ).not.toEqual(
+			initialCropRect
+		);
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.cropper.state.cropRect ).toEqual(
+			initialCropRect
+		);
+		expect( result.current.hasUndo ).toBe( false );
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.cropper.state.cropRect ).toEqual(
+			initialCropRect
+		);
+		expect( result.current.cropper.state.image ).toEqual( {
+			src: TEST_IMAGE.src,
+			naturalWidth: TEST_IMAGE.width,
+			naturalHeight: TEST_IMAGE.height,
+		} );
+		expect( result.current.adjustments.brightness ).toBe( 1 );
+		expect( result.current.hasUndo ).toBe( false );
+	} );
+
+	it( 'undoes cropper edits after earlier adjustment edits', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.setAdjustment( 'brightness', 1.2 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+		act( () => {
+			result.current.cropper.setZoom( 2 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.cropper.state.zoom ).toBe( 1 );
+		expect( result.current.adjustments.brightness ).toBe( 1.2 );
+	} );
+
+	it( 'resets adjustments when the source image changes', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.setSourceImage( TEST_IMAGE );
+		} );
+		act( () => {
+			result.current.setAdjustment( 'saturation', 0.5 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+
+		expect( result.current.hasReplacementImageEdits ).toBe( true );
+		expect( result.current.hasUndo ).toBe( true );
+
+		act( () => {
+			result.current.setSourceImage( NEXT_IMAGE );
+		} );
+
+		expect( result.current.adjustments.saturation ).toBe( 1 );
+		expect( result.current.hasPreviewOnlyEdits ).toBe( false );
+		expect( result.current.hasReplacementImageEdits ).toBe( false );
+		expect( result.current.hasUndo ).toBe( false );
 	} );
 
 	it( 'undoes and redoes cropper edits through the session', () => {
@@ -190,5 +671,21 @@ describe( 'ImageEditingSessionProvider', () => {
 				height: TEST_IMAGE.height,
 			} )
 		);
+	} );
+
+	it( 'builds no save modifiers when replacement image edits are dirty', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.setSourceImage( TEST_IMAGE );
+		} );
+		act( () => {
+			result.current.cropper.snapRotate90( 1 );
+		} );
+		act( () => {
+			result.current.setAdjustment( 'brightness', 1.2 );
+		} );
+
+		expect( result.current.buildSaveModifiers() ).toEqual( [] );
 	} );
 } );

--- a/packages/media-editor/src/components/image-editing-session/test/index.tsx
+++ b/packages/media-editor/src/components/image-editing-session/test/index.tsx
@@ -1,0 +1,153 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { ImageEditingSessionProvider, useImageEditingSession } from '..';
+import { useCropper } from '../../../image-editor';
+import { buildModifiers } from '../../media-editor-modal/build-modifiers';
+
+const TEST_IMAGE = {
+	src: 'test.jpg',
+	naturalWidth: 1000,
+	naturalHeight: 500,
+};
+
+function SessionWrapper( { children }: { children: ReactNode } ) {
+	return (
+		<ImageEditingSessionProvider>{ children }</ImageEditingSessionProvider>
+	);
+}
+
+function setup() {
+	return renderHook( () => useImageEditingSession(), {
+		wrapper: SessionWrapper,
+	} );
+}
+
+describe( 'ImageEditingSessionProvider', () => {
+	it( 'starts with a clean session', () => {
+		const { result } = setup();
+
+		expect( result.current.isDirty ).toBe( false );
+		expect( result.current.hasUndo ).toBe( false );
+		expect( result.current.hasRedo ).toBe( false );
+		expect( result.current.workingImage ).toBeNull();
+	} );
+
+	it( 'tracks the current working image without marking the session dirty', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.cropper.setImage( TEST_IMAGE );
+		} );
+
+		expect( result.current.workingImage ).toEqual( {
+			src: TEST_IMAGE.src,
+			width: TEST_IMAGE.naturalWidth,
+			height: TEST_IMAGE.naturalHeight,
+		} );
+		expect( result.current.isDirty ).toBe( false );
+	} );
+
+	it( 'provides the session-owned cropper through the cropper context', () => {
+		const { result } = renderHook(
+			() => ( {
+				session: useImageEditingSession(),
+				cropper: useCropper(),
+			} ),
+			{ wrapper: SessionWrapper }
+		);
+
+		expect( result.current.cropper ).toBe( result.current.session.cropper );
+	} );
+
+	it( 'marks the image session dirty when cropper state changes', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.cropper.setZoom( 3 );
+		} );
+
+		expect( result.current.isDirty ).toBe( true );
+	} );
+
+	it( 'undoes and redoes cropper edits through the session', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.cropper.setZoom( 3 );
+		} );
+		act( () => {
+			result.current.commitHistory();
+		} );
+
+		expect( result.current.isDirty ).toBe( true );
+		expect( result.current.hasUndo ).toBe( true );
+
+		act( () => {
+			result.current.undo();
+		} );
+
+		expect( result.current.cropper.state.zoom ).toBe( 1 );
+		expect( result.current.isDirty ).toBe( false );
+		expect( result.current.hasRedo ).toBe( true );
+
+		act( () => {
+			result.current.redo();
+		} );
+
+		expect( result.current.cropper.state.zoom ).toBe( 3 );
+		expect( result.current.isDirty ).toBe( true );
+		expect( result.current.hasRedo ).toBe( false );
+	} );
+
+	it( 'resets cropper edits through the session', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.cropper.setZoom( 3 );
+		} );
+
+		expect( result.current.isDirty ).toBe( true );
+
+		act( () => {
+			result.current.reset();
+		} );
+
+		expect( result.current.cropper.state.zoom ).toBe( 1 );
+		expect( result.current.isDirty ).toBe( false );
+	} );
+
+	it( 'builds no save modifiers for a clean session', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.cropper.setImage( TEST_IMAGE );
+		} );
+
+		expect( result.current.buildSaveModifiers() ).toEqual( [] );
+	} );
+
+	it( 'builds the same save modifiers as the cropper modifier helper', () => {
+		const { result } = setup();
+
+		act( () => {
+			result.current.cropper.setImage( TEST_IMAGE );
+		} );
+		act( () => {
+			result.current.cropper.snapRotate90( 1 );
+		} );
+
+		expect( result.current.buildSaveModifiers() ).toEqual(
+			buildModifiers( result.current.cropper.state, {
+				width: TEST_IMAGE.naturalWidth,
+				height: TEST_IMAGE.naturalHeight,
+			} )
+		);
+	} );
+} );

--- a/packages/media-editor/src/components/image-editor-extension-registry/index.ts
+++ b/packages/media-editor/src/components/image-editor-extension-registry/index.ts
@@ -1,0 +1,82 @@
+/**
+ * WordPress dependencies
+ */
+import { useSyncExternalStore } from '@wordpress/element';
+import type { ComponentType } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import type { ImageEditingSession } from '../image-editing-session';
+
+export interface ImageEditorExtensionPanelProps {
+	/** Current image editing session. */
+	session: ImageEditingSession;
+}
+
+export interface ImageEditorExtensionPanel {
+	/** Unique extension panel identifier. */
+	name: string;
+	/** Tab label shown in the image editor sidebar. */
+	title: string;
+	/** Sort order within the extension panel group. */
+	order?: number;
+	/** Component rendered inside the extension sidebar panel. */
+	component: ComponentType< ImageEditorExtensionPanelProps >;
+}
+
+type Listener = () => void;
+
+const panels = new Map< string, ImageEditorExtensionPanel >();
+const listeners = new Set< Listener >();
+let snapshot: ImageEditorExtensionPanel[] = [];
+
+function updateSnapshot() {
+	snapshot = [ ...panels.values() ].sort( ( a, b ) => {
+		const order = ( a.order ?? 10 ) - ( b.order ?? 10 );
+		if ( order !== 0 ) {
+			return order;
+		}
+		return a.name.localeCompare( b.name );
+	} );
+	for ( const listener of listeners ) {
+		listener();
+	}
+}
+
+function subscribe( listener: Listener ) {
+	listeners.add( listener );
+	return () => {
+		listeners.delete( listener );
+	};
+}
+
+function getSnapshot() {
+	return snapshot;
+}
+
+export function registerImageEditorExtensionPanel(
+	panel: ImageEditorExtensionPanel
+) {
+	if ( ! panel.name ) {
+		throw new Error( 'Image editor extension panels must include a name.' );
+	}
+	if ( panels.has( panel.name ) ) {
+		throw new Error(
+			`Image editor extension panel "${ panel.name }" is already registered.`
+		);
+	}
+	panels.set( panel.name, panel );
+	updateSnapshot();
+	return () => {
+		if ( panels.get( panel.name ) !== panel ) {
+			return;
+		}
+		panels.delete( panel.name );
+		updateSnapshot();
+	};
+}
+
+export function useImageEditorExtensionPanels() {
+	return useSyncExternalStore( subscribe, getSnapshot, getSnapshot );
+}

--- a/packages/media-editor/src/components/image-editor-extension-registry/test/index.tsx
+++ b/packages/media-editor/src/components/image-editor-extension-registry/test/index.tsx
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	registerImageEditorExtensionPanel,
+	useImageEditorExtensionPanels,
+} from '..';
+
+describe( 'image editor extension panel registry', () => {
+	const unregisterCallbacks: Array< () => void > = [];
+
+	afterEach( () => {
+		act( () => {
+			while ( unregisterCallbacks.length ) {
+				unregisterCallbacks.pop()?.();
+			}
+		} );
+	} );
+
+	function register(
+		...args: Parameters< typeof registerImageEditorExtensionPanel >
+	) {
+		const unregister = registerImageEditorExtensionPanel( ...args );
+		unregisterCallbacks.push( unregister );
+		return unregister;
+	}
+
+	it( 'returns registered panels in deterministic order', () => {
+		const { result } = renderHook( () => useImageEditorExtensionPanels() );
+
+		act( () => {
+			register( {
+				name: 'vendor/filter',
+				title: 'Filter',
+				order: 20,
+				component: () => null,
+			} );
+			register( {
+				name: 'vendor/enhance',
+				title: 'Enhance',
+				order: 10,
+				component: () => null,
+			} );
+		} );
+
+		expect( result.current.map( ( panel ) => panel.name ) ).toEqual( [
+			'vendor/enhance',
+			'vendor/filter',
+		] );
+	} );
+
+	it( 'updates subscribers when a panel unregisters', () => {
+		const { result } = renderHook( () => useImageEditorExtensionPanels() );
+
+		let unregister = () => {};
+		act( () => {
+			unregister = register( {
+				name: 'vendor/enhance',
+				title: 'Enhance',
+				component: () => null,
+			} );
+		} );
+
+		expect( result.current ).toHaveLength( 1 );
+
+		act( () => {
+			unregister();
+		} );
+
+		expect( result.current ).toHaveLength( 0 );
+	} );
+
+	it( 'rejects duplicate panel names', () => {
+		act( () => {
+			register( {
+				name: 'vendor/enhance',
+				title: 'Enhance',
+				component: () => null,
+			} );
+		} );
+
+		expect( () =>
+			registerImageEditorExtensionPanel( {
+				name: 'vendor/enhance',
+				title: 'Enhance again',
+				component: () => null,
+			} )
+		).toThrow(
+			'Image editor extension panel "vendor/enhance" is already registered.'
+		);
+	} );
+} );

--- a/packages/media-editor/src/components/media-editor-adjustments-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-adjustments-panel/index.tsx
@@ -1,0 +1,152 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, RangeControl } from '@wordpress/components';
+import { Stack, VisuallyHidden } from '@wordpress/ui';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	DEFAULT_IMAGE_EDITING_ADJUSTMENTS,
+	type ImageEditingAdjustments,
+	type ImageEditingSession,
+} from '../image-editing-session';
+import { CROP_CONTROL_ATTR } from '../../hooks/use-crop-gesture-handlers';
+
+type AdjustmentKey = keyof ImageEditingAdjustments;
+
+interface AdjustmentControlConfig {
+	key: AdjustmentKey;
+	label: string;
+	min: number;
+	max: number;
+	step: number;
+	format: ( value: number ) => string;
+}
+
+const ADJUSTMENT_CONTROLS: AdjustmentControlConfig[] = [
+	{
+		key: 'brightness',
+		label: __( 'Brightness' ),
+		min: 0,
+		max: 2,
+		step: 0.01,
+		format: ( value ) => `${ Math.round( value * 100 ) }%`,
+	},
+	{
+		key: 'contrast',
+		label: __( 'Contrast' ),
+		min: 0,
+		max: 2,
+		step: 0.01,
+		format: ( value ) => `${ Math.round( value * 100 ) }%`,
+	},
+	{
+		key: 'saturation',
+		label: __( 'Saturation' ),
+		min: 0,
+		max: 2,
+		step: 0.01,
+		format: ( value ) => `${ Math.round( value * 100 ) }%`,
+	},
+	{
+		key: 'grayscale',
+		label: __( 'Greyscale' ),
+		min: 0,
+		max: 1,
+		step: 0.01,
+		format: ( value ) => `${ Math.round( value * 100 ) }%`,
+	},
+];
+
+function isDefaultAdjustment(
+	key: AdjustmentKey,
+	value: ImageEditingAdjustments[ AdjustmentKey ]
+) {
+	return value === DEFAULT_IMAGE_EDITING_ADJUSTMENTS[ key ];
+}
+
+export interface MediaEditorAdjustmentsPanelProps {
+	/** Current image editing session. */
+	session: ImageEditingSession;
+}
+
+/**
+ * Sidebar panel for native image adjustment controls.
+ *
+ * Adjustments are registered through the image editor extension panel surface
+ * so the panel API is exercised by a real internal consumer before it is made
+ * available to third-party extensions.
+ *
+ * @param props
+ * @param props.session Current image editing session.
+ */
+export default function MediaEditorAdjustmentsPanel( {
+	session,
+}: MediaEditorAdjustmentsPanelProps ) {
+	return (
+		<Stack direction="column" gap="md">
+			<VisuallyHidden render={ <h2 /> }>
+				{ __( 'Adjust options' ) }
+			</VisuallyHidden>
+			{ ADJUSTMENT_CONTROLS.map( ( control ) => {
+				const value = session.adjustments[ control.key ];
+				return (
+					<div
+						key={ control.key }
+						role="presentation"
+						{ ...{
+							[ CROP_CONTROL_ATTR ]: true,
+							onPointerUp: session.commitHistory,
+							onPointerCancel: session.commitHistory,
+							onBlur: session.commitHistory,
+						} }
+					>
+						<RangeControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ control.label }
+							min={ control.min }
+							max={ control.max }
+							step={ control.step }
+							value={ value }
+							onChange={ ( nextValue ) =>
+								session.setAdjustment(
+									control.key,
+									typeof nextValue === 'number'
+										? nextValue
+										: DEFAULT_IMAGE_EDITING_ADJUSTMENTS[
+												control.key
+										  ]
+								)
+							}
+							renderTooltipContent={ ( nextValue ) => {
+								const tooltipValue =
+									typeof nextValue === 'number'
+										? nextValue
+										: value;
+								return control.format( tooltipValue );
+							} }
+						/>
+					</div>
+				);
+			} ) }
+			<Button
+				size="compact"
+				variant="tertiary"
+				disabled={ ADJUSTMENT_CONTROLS.every( ( control ) =>
+					isDefaultAdjustment(
+						control.key,
+						session.adjustments[ control.key ]
+					)
+				) }
+				accessibleWhenDisabled
+				onClick={ session.resetAdjustments }
+			>
+				{ __( 'Reset adjustments' ) }
+			</Button>
+		</Stack>
+	);
+}

--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -4,6 +4,7 @@
 import { useMediaEditorContext } from '../media-editor-provider';
 import { getMediaTypeFromMimeType } from '../../utils';
 import { Cropper, useCropper } from '../../image-editor';
+import { useImageEditingSession } from '../image-editing-session';
 
 export interface MediaEditorCanvasProps {
 	/** Fixed aspect ratio (width / height). `undefined` means free. */
@@ -33,6 +34,7 @@ export default function MediaEditorCanvas( {
 }: MediaEditorCanvasProps ) {
 	const { media } = useMediaEditorContext();
 	const controller = useCropper();
+	const imageSession = useImageEditingSession();
 
 	const mediaUrl = media?.source_url;
 	const mediaType = getMediaTypeFromMimeType( media?.mime_type );
@@ -50,6 +52,13 @@ export default function MediaEditorCanvas( {
 				freeformCrop={ freeformCrop }
 				showGrid="interactive"
 				isPlacementActive={ isPlacementActive }
+				onImageLoaded={ ( size ) =>
+					imageSession.setSourceImage( {
+						src: mediaUrl,
+						width: size.width,
+						height: size.height,
+					} )
+				}
 				// Flush on gesture start so any pending sidebar interaction
 				// (e.g. zoom slider debounce) is committed as its own undo
 				// step before the canvas gesture begins.

--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -3,7 +3,11 @@
  */
 import { useMediaEditorContext } from '../media-editor-provider';
 import { getMediaTypeFromMimeType } from '../../utils';
-import { Cropper, useCropper } from '../../image-editor';
+import {
+	Cropper,
+	getImageEditAdjustmentFilter,
+	useCropper,
+} from '../../image-editor';
 import { useImageEditingSession } from '../image-editing-session';
 
 export interface MediaEditorCanvasProps {
@@ -43,6 +47,10 @@ export default function MediaEditorCanvas( {
 		return null;
 	}
 
+	const adjustmentFilter = getImageEditAdjustmentFilter(
+		imageSession.adjustments
+	);
+
 	return (
 		<div className="media-editor-canvas">
 			<Cropper
@@ -52,6 +60,7 @@ export default function MediaEditorCanvas( {
 				freeformCrop={ freeformCrop }
 				showGrid="interactive"
 				isPlacementActive={ isPlacementActive }
+				filter={ adjustmentFilter }
 				onImageLoaded={ ( size ) =>
 					imageSession.setSourceImage( {
 						src: mediaUrl,

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -59,7 +59,11 @@ import {
 	useImageEditingSession,
 	type ImageEditingSessionImage,
 } from '../image-editing-session';
-import { useImageEditorExtensionPanels } from '../image-editor-extension-registry';
+import {
+	registerImageEditorExtensionPanel,
+	useImageEditorExtensionPanels,
+} from '../image-editor-extension-registry';
+import MediaEditorAdjustmentsPanel from '../media-editor-adjustments-panel';
 
 // Details-tab edits the modal bundles into a transformed `/edit` request.
 // Matches Core's `WP_REST_Attachments_Controller::get_edit_media_item_args`
@@ -75,11 +79,14 @@ const METADATA_EDIT_KEYS = [
 	'alt_text',
 	'post',
 ] as const;
+type MetadataEditKey = ( typeof METADATA_EDIT_KEYS )[ number ];
 
 // Scope save-failure snackbars to this modal so they don't leak into the
 // host editor's notices tray (and vice versa).
 const NOTICES_CONTEXT = 'media-editor';
 const PLACEMENT_CONTROL_IDLE_MS = 300;
+const DEFAULT_EXPORT_MIME_TYPE = 'image/png';
+const EXPORT_QUALITY = 0.92;
 
 const { Tabs } = unlock( componentsPrivateApis );
 
@@ -102,6 +109,128 @@ interface ModalTab {
 	id: string;
 	title: string;
 	panel: JSX.Element;
+}
+
+function getTextFieldValue( value: unknown ): string | undefined {
+	if ( typeof value === 'string' ) {
+		return value;
+	}
+	if ( value && typeof value === 'object' ) {
+		const record = value as { raw?: unknown; rendered?: unknown };
+		if ( typeof record.raw === 'string' ) {
+			return record.raw;
+		}
+		if ( typeof record.rendered === 'string' ) {
+			return record.rendered;
+		}
+	}
+	return undefined;
+}
+
+function getReplacementMimeType( media: Media | null ): string {
+	const mimeType = media?.mime_type;
+	if (
+		mimeType === 'image/jpeg' ||
+		mimeType === 'image/png' ||
+		mimeType === 'image/webp'
+	) {
+		return mimeType;
+	}
+	return DEFAULT_EXPORT_MIME_TYPE;
+}
+
+function getReplacementFileExtension( mimeType: string ): string {
+	switch ( mimeType ) {
+		case 'image/jpeg':
+			return 'jpg';
+		case 'image/webp':
+			return 'webp';
+		case 'image/png':
+		default:
+			return 'png';
+	}
+}
+
+function getReplacementFileName( media: Media | null, mimeType: string ) {
+	const title = getTextFieldValue( media?.title );
+	const baseName =
+		typeof media?.slug === 'string' && media.slug
+			? media.slug
+			: title
+					?.trim()
+					.toLowerCase()
+					.replace( /[^a-z0-9]+/g, '-' ) || 'edited-image';
+	return `${
+		baseName.replace( /^-+|-+$/g, '' ) || 'edited-image'
+	}-edited.${ getReplacementFileExtension( mimeType ) }`;
+}
+
+function getMetadataEdits(
+	media: Media | null,
+	pendingEdits: Record< string, unknown > | undefined
+) {
+	const metadataEdits: Partial< Record< MetadataEditKey, string | number > > =
+		{};
+
+	for ( const key of METADATA_EDIT_KEYS ) {
+		const value =
+			pendingEdits && key in pendingEdits
+				? pendingEdits[ key ]
+				: media?.[ key ];
+
+		if ( key === 'post' ) {
+			if ( typeof value === 'number' || typeof value === 'string' ) {
+				metadataEdits[ key ] = value;
+			}
+			continue;
+		}
+
+		const textValue = getTextFieldValue( value );
+		if ( textValue !== undefined ) {
+			metadataEdits[ key ] = textValue;
+		}
+	}
+
+	return metadataEdits;
+}
+
+function appendFormDataValue(
+	formData: FormData,
+	key: string,
+	value: string | number
+) {
+	formData.append( key, String( value ) );
+}
+
+async function uploadReplacementImage( {
+	blob,
+	media,
+	metadataEdits,
+	mimeType,
+}: {
+	blob: Blob;
+	media: Media | null;
+	metadataEdits: Partial< Record< MetadataEditKey, string | number > >;
+	mimeType: string;
+} ) {
+	const data = new FormData();
+	const file = new File(
+		[ blob ],
+		getReplacementFileName( media, mimeType ),
+		{ type: mimeType }
+	);
+	data.append( 'file', file, file.name );
+	for ( const [ key, value ] of Object.entries( metadataEdits ) ) {
+		if ( value !== undefined ) {
+			appendFormDataValue( data, key, value );
+		}
+	}
+
+	return apiFetch( {
+		path: '/wp/v2/media',
+		method: 'POST',
+		body: data,
+	} ) as Promise< Media >;
 }
 
 // Renders the `ComplementaryArea` with a tab list in its header, mirroring
@@ -260,6 +389,15 @@ function MediaEditorModalContent( {
 
 	const [ aspectRatioValue, setAspectRatioValue ] = useState( '0' );
 	const [ freeformCrop, setFreeformCrop ] = useState( true );
+
+	useEffect( () => {
+		return registerImageEditorExtensionPanel( {
+			name: 'core/adjustments',
+			title: __( 'Adjust' ),
+			order: 10,
+			component: MediaEditorAdjustmentsPanel,
+		} );
+	}, [] );
 
 	const signalPlacementControlInteraction = useCallback( () => {
 		setIsPlacementActive( true );
@@ -431,36 +569,59 @@ function MediaEditorModalContent( {
 		try {
 			let saved: Media | null | undefined;
 
+			const pendingEdits = registry
+				.select( coreStore )
+				.getEntityRecordNonTransientEdits(
+					'postType',
+					'attachment',
+					id
+				) as Record< string, unknown > | undefined;
+			const replacementMetadataEdits = getMetadataEdits(
+				media,
+				pendingEdits
+			);
+			const pendingMetadataEdits = getMetadataEdits( null, pendingEdits );
 			const modifiers = imageSession.buildSaveModifiers();
 
-			if ( modifiers.length > 0 ) {
+			if ( imageSession.hasReplacementImageEdits ) {
+				const mimeType = getReplacementMimeType( media );
+				const blob = await imageSession.exportImageEdit(
+					mimeType,
+					EXPORT_QUALITY
+				);
+				saved = await uploadReplacementImage( {
+					blob,
+					media,
+					metadataEdits: replacementMetadataEdits,
+					mimeType,
+				} );
+
+				if ( saved ) {
+					// Put the newly-created attachment into the core-data
+					// cache so downstream consumers see it without an
+					// extra fetch round-trip.
+					receiveEntityRecords(
+						'postType',
+						'attachment',
+						saved,
+						undefined,
+						true
+					);
+				}
+			} else if ( modifiers.length > 0 ) {
 				// Bundle staged Details-tab edits into the same /edit
 				// request. Transformed saves duplicate the attachment,
 				// and the prior core-data edits were staged against the
 				// old id — if we don't forward them here they'd be
 				// silently lost. Core's `edit_media_item` honors these
 				// keys via `prepare_item_for_database` and `alt_text`.
-				const pendingEdits = registry
-					.select( coreStore )
-					.getEntityRecordNonTransientEdits(
-						'postType',
-						'attachment',
-						id
-					) as Record< string, unknown > | undefined;
-				const metadataEdits: Record< string, unknown > = {};
-				for ( const key of METADATA_EDIT_KEYS ) {
-					if ( pendingEdits && key in pendingEdits ) {
-						metadataEdits[ key ] = pendingEdits[ key ];
-					}
-				}
-
 				saved = ( await apiFetch( {
 					path: `/wp/v2/media/${ id }/edit`,
 					method: 'POST',
 					data: {
 						src: imageSession.sourceImage?.src,
 						modifiers,
-						...metadataEdits,
+						...pendingMetadataEdits,
 					},
 				} ) ) as Media;
 

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -51,11 +51,13 @@ import { store as mediaEditorStore } from '../../store';
 import type { MediaEditorModalUpdate } from '../../store/actions';
 import { unlock } from '../../lock-unlock';
 import { getMediaTypeFromMimeType } from '../../utils';
-import { CropperProvider, useCropper } from '../../image-editor';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
 import { CROP_CONTROL_ATTR } from '../../hooks/use-crop-gesture-handlers';
-import { buildModifiers } from './build-modifiers';
 import MediaEditorKeyboardShortcutsModal from '../media-editor-keyboard-shortcuts-modal';
+import {
+	ImageEditingSessionProvider,
+	useImageEditingSession,
+} from '../image-editing-session';
 
 // Details-tab edits the modal bundles into a transformed `/edit` request.
 // Matches Core's `WP_REST_Attachments_Controller::get_edit_media_item_args`
@@ -222,9 +224,9 @@ interface MediaEditorModalContentProps {
 	onUpdate: ( ( updated: MediaEditorModalUpdate ) => void ) | null;
 }
 
-// Inner component rendered inside `CropperProvider` so it can read
-// `isDirty` from the cropper. The outer `MediaEditorModal` keeps the
-// store reads and provider tree above this.
+// Inner component rendered inside `ImageEditingSessionProvider` so it can read
+// image dirty/history state. The outer `MediaEditorModal` keeps the store reads
+// and provider tree above this.
 function MediaEditorModalContent( {
 	fields,
 	id,
@@ -233,8 +235,8 @@ function MediaEditorModalContent( {
 	aspectRatioPresets,
 	onUpdate,
 }: MediaEditorModalContentProps ) {
-	const cropper = useCropper();
-	const hasChanges = cropper.isDirty || hasEdits;
+	const imageSession = useImageEditingSession();
+	const hasChanges = imageSession.isDirty || hasEdits;
 
 	const registry = useRegistry();
 	const {
@@ -376,13 +378,7 @@ function MediaEditorModalContent( {
 		try {
 			let saved: Media | null | undefined;
 
-			const modifiers =
-				cropper.isDirty && cropper.state.image
-					? buildModifiers( cropper.state, {
-							width: cropper.state.image.naturalWidth,
-							height: cropper.state.image.naturalHeight,
-					  } )
-					: [];
+			const modifiers = imageSession.buildSaveModifiers();
 
 			if ( modifiers.length > 0 ) {
 				// Bundle staged Details-tab edits into the same /edit
@@ -496,9 +492,9 @@ function MediaEditorModalContent( {
 					if ( ! isMetadataField ) {
 						event.preventDefault();
 						if ( isRedoShortcut ) {
-							cropper.redo();
+							imageSession.redo();
 						} else {
-							cropper.undo();
+							imageSession.undo();
 						}
 						return;
 					}
@@ -663,16 +659,14 @@ export function MediaEditorModal( {
 		return null;
 	}
 
-	// `CropperProvider` is always mounted while the modal is open — it's
-	// just a `useReducer` with no side effects — so the inner component
-	// can read `isDirty` for images without forking on media type. The
-	// `key` remounts the provider when the edited attachment changes,
-	// discarding the previous cropper state. Keying on `id` (rather than
-	// `media?.id`) avoids a remount when `media` resolves from `null` to
-	// the loaded record on open — that flip would otherwise re-run the
-	// modal's entry animation and cause a visible flicker.
+	// `ImageEditingSessionProvider` is always mounted while the modal is open.
+	// The `key` remounts the session when the edited attachment changes,
+	// discarding previous image edit state. Keying on `id` (rather than
+	// `media?.id`) avoids a remount when `media` resolves from `null` to the
+	// loaded record on open — that flip would otherwise re-run the modal's
+	// entry animation and cause a visible flicker.
 	return (
-		<CropperProvider key={ id }>
+		<ImageEditingSessionProvider key={ id }>
 			<MediaEditorModalContent
 				fields={ fields }
 				id={ id }
@@ -681,7 +675,7 @@ export function MediaEditorModal( {
 				aspectRatioPresets={ aspectRatioPresets }
 				onUpdate={ onUpdate }
 			/>
-		</CropperProvider>
+		</ImageEditingSessionProvider>
 	);
 }
 

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -59,6 +59,7 @@ import {
 	useImageEditingSession,
 	type ImageEditingSessionImage,
 } from '../image-editing-session';
+import { useImageEditorExtensionPanels } from '../image-editor-extension-registry';
 
 // Details-tab edits the modal bundles into a transformed `/edit` request.
 // Matches Core's `WP_REST_Attachments_Controller::get_edit_media_item_args`
@@ -238,6 +239,7 @@ function MediaEditorModalContent( {
 }: MediaEditorModalContentProps ) {
 	const imageSession = useImageEditingSession();
 	const setSourceImage = imageSession.setSourceImage;
+	const extensionPanels = useImageEditorExtensionPanels();
 	const hasChanges = imageSession.isDirty || hasEdits;
 
 	const registry = useRegistry();
@@ -346,6 +348,22 @@ function MediaEditorModalContent( {
 		if ( ! isImage ) {
 			return [ detailsTab ];
 		}
+		const extensionTabs = extensionPanels.map( ( panel ) => {
+			const PanelComponent = panel.component;
+			return {
+				id: `extension/${ panel.name }`,
+				title: panel.title,
+				panel: (
+					<Stack
+						className="media-editor-modal__panel"
+						direction="column"
+						gap="lg"
+					>
+						<PanelComponent session={ imageSession } />
+					</Stack>
+				),
+			};
+		} );
 		return [
 			{
 				id: 'crop',
@@ -369,6 +387,7 @@ function MediaEditorModalContent( {
 					</Stack>
 				),
 			},
+			...extensionTabs,
 			detailsTab,
 		];
 	}, [
@@ -377,6 +396,8 @@ function MediaEditorModalContent( {
 		freeformCrop,
 		aspectRatioPresets,
 		signalPlacementControlInteraction,
+		extensionPanels,
+		imageSession,
 	] );
 
 	const handleChange = ( updates: Partial< Media > ) => {

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -57,6 +57,7 @@ import MediaEditorKeyboardShortcutsModal from '../media-editor-keyboard-shortcut
 import {
 	ImageEditingSessionProvider,
 	useImageEditingSession,
+	type ImageEditingSessionImage,
 } from '../image-editing-session';
 
 // Details-tab edits the modal bundles into a transformed `/edit` request.
@@ -236,6 +237,7 @@ function MediaEditorModalContent( {
 	onUpdate,
 }: MediaEditorModalContentProps ) {
 	const imageSession = useImageEditingSession();
+	const setSourceImage = imageSession.setSourceImage;
 	const hasChanges = imageSession.isDirty || hasEdits;
 
 	const registry = useRegistry();
@@ -280,6 +282,36 @@ function MediaEditorModalContent( {
 
 	const mediaType = getMediaTypeFromMimeType( media?.mime_type ).type;
 	const isImage = !! media && mediaType === 'image';
+
+	const sourceImage = useMemo< ImageEditingSessionImage | null >( () => {
+		if ( ! isImage || ! media?.source_url ) {
+			return null;
+		}
+		const naturalWidth = Number( media.media_details?.width );
+		const naturalHeight = Number( media.media_details?.height );
+		if (
+			Number.isFinite( naturalWidth ) &&
+			Number.isFinite( naturalHeight ) &&
+			naturalWidth > 0 &&
+			naturalHeight > 0
+		) {
+			return {
+				src: media.source_url,
+				width: naturalWidth,
+				height: naturalHeight,
+			};
+		}
+		return null;
+	}, [
+		isImage,
+		media?.source_url,
+		media?.media_details?.width,
+		media?.media_details?.height,
+	] );
+
+	useEffect( () => {
+		setSourceImage( sourceImage );
+	}, [ setSourceImage, sourceImage ] );
 
 	const imageAspectRatio = useMemo( () => {
 		if ( ! isImage ) {
@@ -405,7 +437,7 @@ function MediaEditorModalContent( {
 					path: `/wp/v2/media/${ id }/edit`,
 					method: 'POST',
 					data: {
-						src: media?.source_url,
+						src: imageSession.sourceImage?.src,
 						modifiers,
 						...metadataEdits,
 					},

--- a/packages/media-editor/src/components/media-editor-toolbar/index.tsx
+++ b/packages/media-editor/src/components/media-editor-toolbar/index.tsx
@@ -20,6 +20,7 @@ import {
 import { useCropper } from '../../image-editor';
 import { useCropGestureHandlers } from '../../hooks/use-crop-gesture-handlers';
 import { MAX_ROTATION_OFFSET } from '../../image-editor/core/constants';
+import { useImageEditingSession } from '../image-editing-session';
 
 export interface MediaEditorToolbarProps {
 	/**
@@ -45,22 +46,12 @@ export default function MediaEditorToolbar( {
 	onReset,
 	onPlacementControlInteraction,
 }: MediaEditorToolbarProps ) {
-	const {
-		state,
-		setRotation,
-		setFlip,
-		snapRotate90,
-		reset,
-		isDirty,
-		hasUndo,
-		hasRedo,
-		undo: undoCrop,
-		redo: redoCrop,
-	} = useCropper();
+	const imageSession = useImageEditingSession();
+	const { state, setRotation, setFlip, snapRotate90 } = useCropper();
 	const rotationGestureHandlers = useCropGestureHandlers();
 
 	const handleReset = () => {
-		reset();
+		imageSession.reset();
 		onReset?.();
 	};
 
@@ -103,9 +94,9 @@ export default function MediaEditorToolbar( {
 				label={ __( 'Undo' ) }
 				showTooltip
 				shortcut={ displayShortcut.primary( 'z' ) }
-				disabled={ ! hasUndo }
+				disabled={ ! imageSession.hasUndo }
 				accessibleWhenDisabled
-				onClick={ undoCrop }
+				onClick={ imageSession.undo }
 			/>
 			<Button
 				size="compact"
@@ -117,9 +108,9 @@ export default function MediaEditorToolbar( {
 						? displayShortcut.primaryShift( 'z' )
 						: displayShortcut.primary( 'y' )
 				}
-				disabled={ ! hasRedo }
+				disabled={ ! imageSession.hasRedo }
 				accessibleWhenDisabled
-				onClick={ redoCrop }
+				onClick={ imageSession.redo }
 			/>
 			<Button
 				size="compact"
@@ -182,7 +173,7 @@ export default function MediaEditorToolbar( {
 			<Button
 				size="compact"
 				variant="tertiary"
-				disabled={ ! isDirty }
+				disabled={ ! imageSession.isDirty }
 				accessibleWhenDisabled
 				onClick={ handleReset }
 			>

--- a/packages/media-editor/src/image-editor/README.md
+++ b/packages/media-editor/src/image-editor/README.md
@@ -108,9 +108,9 @@ Same as `getSourceRegion` but returns percentages (0–100): `{ x, y, width, hei
 
 ### Export
 
-#### `exportCroppedImage( src, state, mimeType?, quality? ): Promise<Blob>`
+#### `exportImageEdit( { src, state, adjustments?, mimeType?, quality? } ): Promise<Blob>`
 
-End-to-end: load image, render with transforms, export as Blob. Browser-only (needs `HTMLCanvasElement`).
+End-to-end: load image, render with cropper transforms and optional adjustments, export as Blob. Browser-only (needs `HTMLCanvasElement`).
 
 Rejects on:
 

--- a/packages/media-editor/src/image-editor/core/export/canvas-renderer.ts
+++ b/packages/media-editor/src/image-editor/core/export/canvas-renderer.ts
@@ -7,6 +7,45 @@ import { createExportCamera, getRotatedBBox } from '../camera';
 /** Default export quality for lossy formats (JPEG, WebP). */
 const DEFAULT_QUALITY = 0.92;
 
+export interface ImageEditAdjustmentValues {
+	brightness: number;
+	contrast: number;
+	saturation: number;
+	grayscale: number;
+}
+
+export interface ExportImageEditOptions {
+	src: string;
+	state: CropperState;
+	adjustments?: ImageEditAdjustmentValues;
+	mimeType?: string;
+	quality?: number;
+}
+
+export const DEFAULT_IMAGE_EDIT_ADJUSTMENTS: ImageEditAdjustmentValues = {
+	brightness: 1,
+	contrast: 1,
+	saturation: 1,
+	grayscale: 0,
+};
+
+export function areImageEditAdjustmentsDefault(
+	adjustments: ImageEditAdjustmentValues = DEFAULT_IMAGE_EDIT_ADJUSTMENTS
+): boolean {
+	return (
+		adjustments.brightness === DEFAULT_IMAGE_EDIT_ADJUSTMENTS.brightness &&
+		adjustments.contrast === DEFAULT_IMAGE_EDIT_ADJUSTMENTS.contrast &&
+		adjustments.saturation === DEFAULT_IMAGE_EDIT_ADJUSTMENTS.saturation &&
+		adjustments.grayscale === DEFAULT_IMAGE_EDIT_ADJUSTMENTS.grayscale
+	);
+}
+
+export function getImageEditAdjustmentFilter(
+	adjustments: ImageEditAdjustmentValues = DEFAULT_IMAGE_EDIT_ADJUSTMENTS
+): string {
+	return `brightness(${ adjustments.brightness }) contrast(${ adjustments.contrast }) saturate(${ adjustments.saturation }) grayscale(${ adjustments.grayscale })`;
+}
+
 /**
  * Load an image from a URL with CORS support.
  *
@@ -29,13 +68,15 @@ export function loadImage( src: string ): Promise< HTMLImageElement > {
  * Uses createExportCamera to compose the full transform matrix, then applies
  * it in a single ctx.setTransform call before drawing the image.
  *
- * @param image - The source image element.
- * @param state - The full cropper state containing crop, rotation, and flip settings.
+ * @param image       - The source image element.
+ * @param state       - The full cropper state containing crop, rotation, and flip settings.
+ * @param adjustments - Image adjustment values to apply while drawing.
  * @return A canvas element containing the transformed and cropped image.
  */
 export function renderToCanvas(
 	image: HTMLImageElement,
-	state: CropperState
+	state: CropperState,
+	adjustments: ImageEditAdjustmentValues = DEFAULT_IMAGE_EDIT_ADJUSTMENTS
 ): HTMLCanvasElement {
 	const { naturalWidth, naturalHeight } = image;
 	const { rotation, cropRect } = state;
@@ -71,6 +112,9 @@ export function renderToCanvas(
 		camera[ 4 ],
 		camera[ 5 ]
 	);
+	if ( ! areImageEditAdjustmentsDefault( adjustments ) ) {
+		ctx.filter = getImageEditAdjustmentFilter( adjustments );
+	}
 	ctx.drawImage( image, 0, 0 );
 	return canvas;
 }
@@ -133,22 +177,25 @@ export function canvasToDataURL(
  *
  * Only works in browser environments (needs DOM / HTMLCanvasElement).
  *
- * @param src      - The image URL to load.
- * @param state    - The cropper state with all transform settings.
- * @param mimeType - The output MIME type. Defaults to 'image/png'.
- * @param quality  - The quality parameter for lossy formats (0-1). Defaults to DEFAULT_QUALITY.
+ * @param options             - Export options.
+ * @param options.src         - The image URL to load.
+ * @param options.state       - The cropper state with all transform settings.
+ * @param options.adjustments - Optional image adjustment values to apply.
+ * @param options.mimeType    - The output MIME type. Defaults to 'image/png'.
+ * @param options.quality     - The quality parameter for lossy formats (0-1). Defaults to DEFAULT_QUALITY.
  * @return A promise that resolves to the exported Blob.
  * @throws If the image fails to load, canvas creation fails, or
  *         the resulting canvas is tainted by CORS restrictions.
  */
-export async function exportCroppedImage(
-	src: string,
-	state: CropperState,
-	mimeType: string = 'image/png',
-	quality: number = DEFAULT_QUALITY
-): Promise< Blob > {
+export async function exportImageEdit( {
+	src,
+	state,
+	adjustments = DEFAULT_IMAGE_EDIT_ADJUSTMENTS,
+	mimeType = 'image/png',
+	quality = DEFAULT_QUALITY,
+}: ExportImageEditOptions ): Promise< Blob > {
 	const image = await loadImage( src );
-	const canvas = renderToCanvas( image, state );
+	const canvas = renderToCanvas( image, state, adjustments );
 	return canvasToBlob( canvas, mimeType, quality );
 }
 
@@ -221,12 +268,12 @@ export function applyToCanvas(
 }
 
 /**
- * Download the cropped image as a file.
+ * Download the edited image as a file.
  *
  * Loads the source image, applies all transforms, and triggers a
- * browser download via exportCroppedImage() + object URL + anchor click.
+ * browser download via exportImageEdit() + object URL + anchor click.
  *
- * Throws on export failure (see `exportCroppedImage`).
+ * Throws on export failure (see `exportImageEdit`).
  *
  * @param src      - The image URL to load.
  * @param state    - The cropper state with all transform settings.
@@ -242,7 +289,7 @@ export async function downloadCroppedImage(
 	mimeType: string = 'image/png',
 	quality: number = DEFAULT_QUALITY
 ): Promise< void > {
-	const blob = await exportCroppedImage( src, state, mimeType, quality );
+	const blob = await exportImageEdit( { src, state, mimeType, quality } );
 	const ext = mimeType.split( '/' )[ 1 ] ?? 'png';
 	const url = URL.createObjectURL( blob );
 	const a = document.createElement( 'a' );

--- a/packages/media-editor/src/image-editor/core/export/test/canvas-renderer.ts
+++ b/packages/media-editor/src/image-editor/core/export/test/canvas-renderer.ts
@@ -9,7 +9,7 @@ import {
 	applyToCanvas,
 	canvasToBlob,
 	canvasToDataURL,
-	exportCroppedImage,
+	exportImageEdit,
 } from '../canvas-renderer';
 
 /**
@@ -29,6 +29,7 @@ function createMockContext() {
 		moveTo: jest.fn(),
 		lineTo: jest.fn(),
 		clip: jest.fn(),
+		filter: 'none',
 	};
 }
 
@@ -199,6 +200,26 @@ describe( 'renderToCanvas', () => {
 		expect( mockCtx.drawImage ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'should apply adjustment filters before drawing the image', () => {
+		const state = createTestState();
+		const mockImage = {
+			naturalWidth: 800,
+			naturalHeight: 600,
+		} as HTMLImageElement;
+
+		renderToCanvas( mockImage, state, {
+			brightness: 1.2,
+			contrast: 1.3,
+			saturation: 0.8,
+			grayscale: 0.5,
+		} );
+
+		expect( mockCtx.filter ).toBe(
+			'brightness(1.2) contrast(1.3) saturate(0.8) grayscale(0.5)'
+		);
+		expect( mockCtx.drawImage ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'should apply flip scale factors when flip is enabled', () => {
 		const state = createTestState( {
 			flip: { horizontal: true, vertical: true },
@@ -366,7 +387,7 @@ describe( 'canvasToDataURL', () => {
 	} );
 } );
 
-describe( 'exportCroppedImage', () => {
+describe( 'exportImageEdit', () => {
 	let originalImage: typeof Image;
 
 	beforeEach( () => {
@@ -426,12 +447,12 @@ describe( 'exportCroppedImage', () => {
 
 	it( 'should chain loadImage, renderToCanvas, and canvasToBlob', async () => {
 		const state = createTestState();
-		const result = await exportCroppedImage(
-			'https://example.com/photo.jpg',
+		const result = await exportImageEdit( {
+			src: 'https://example.com/photo.jpg',
 			state,
-			'image/webp',
-			0.9
-		);
+			mimeType: 'image/webp',
+			quality: 0.9,
+		} );
 
 		expect( result ).toBeInstanceOf( Blob );
 	} );
@@ -454,7 +475,10 @@ describe( 'exportCroppedImage', () => {
 
 		const state = createTestState();
 		await expect(
-			exportCroppedImage( 'https://example.com/broken.jpg', state )
+			exportImageEdit( {
+				src: 'https://example.com/broken.jpg',
+				state,
+			} )
 		).rejects.toBeDefined();
 	} );
 
@@ -512,10 +536,10 @@ describe( 'exportCroppedImage', () => {
 
 		const state = createTestState();
 		await expect(
-			exportCroppedImage(
-				'https://cross-origin.example/photo.jpg',
-				state
-			)
+			exportImageEdit( {
+				src: 'https://cross-origin.example/photo.jpg',
+				state,
+			} )
 		).rejects.toMatchObject( { name: 'SecurityError' } );
 
 		jest.restoreAllMocks();

--- a/packages/media-editor/src/image-editor/core/index.ts
+++ b/packages/media-editor/src/image-editor/core/index.ts
@@ -32,4 +32,14 @@ export {
 } from './transforms/pipeline';
 
 // Export / canvas
-export { exportCroppedImage, applyToCanvas } from './export/canvas-renderer';
+export {
+	exportImageEdit,
+	applyToCanvas,
+	areImageEditAdjustmentsDefault,
+	getImageEditAdjustmentFilter,
+	DEFAULT_IMAGE_EDIT_ADJUSTMENTS,
+} from './export/canvas-renderer';
+export type {
+	ExportImageEditOptions,
+	ImageEditAdjustmentValues,
+} from './export/canvas-renderer';

--- a/packages/media-editor/src/image-editor/docs/architecture.md
+++ b/packages/media-editor/src/image-editor/docs/architecture.md
@@ -90,7 +90,7 @@ See [recipes.md](recipes.md) for the full developer guide. Summary:
 |-----------|-----------|
 | Custom crop area UI | `stencil` prop — any component implementing `StencilProps` |
 | AI agent control | `TransformOperation[]` pipeline — JSON-serializable, replayable |
-| Custom export | `exportCroppedImage()` or `applyToCanvas()` for multi-step pipelines |
+| Custom export | `exportImageEdit()` or `applyToCanvas()` for multi-step pipelines |
 | Theming | BEM CSS classes (`.wp-media-editor-image-editor__*`) |
 | State observation | `onStateChange` (every frame), `onGestureStart`/`onGestureEnd` (gesture boundaries) |
 | Undo/redo | Snapshot state at gesture boundaries, `reset()` to restore — see recipes.md |

--- a/packages/media-editor/src/image-editor/docs/recipes.md
+++ b/packages/media-editor/src/image-editor/docs/recipes.md
@@ -430,7 +430,7 @@ The pipeline API is designed for AI agents. An agent can:
 1. **Analyze the image** and determine the optimal crop
 2. **Generate a `TransformOperation[]`** with crop, rotation, zoom
 3. **Apply it** via `applyOperation()` or `stateFromPipeline()`
-4. **Export the result** via `exportCroppedImage()`
+4. **Export the result** via `exportImageEdit()`
 
 ```typescript
 // Agent generates instructions:
@@ -454,7 +454,7 @@ The core layer is pure functions — no React or browser required for steps 1-2:
 import {
   stateFromPipeline,
   getSourceRegion,
-  exportCroppedImage,
+  exportImageEdit,
 } from '../image-editor';
 
 // 1. Build state from operations (pure — runs in Node, workers, anywhere)
@@ -473,7 +473,12 @@ const region = getSourceRegion( state, { width: 4000, height: 3000 } );
 // ffmpeg -i input.jpg -vf "crop=3200:2400:400:300,rotate=0.087" output.jpg
 
 // 3. Or export to Blob (needs canvas — browser or node-canvas)
-const blob = await exportCroppedImage( imageUrl, state, 'image/jpeg', 0.9 );
+const blob = await exportImageEdit( {
+  src: imageUrl,
+  state,
+  mimeType: 'image/jpeg',
+  quality: 0.9,
+} );
 ```
 
 Steps 1 and 2 are pure functions with zero DOM dependencies. Step 3 needs `canvas` and `Image` (browser, jsdom, or node-canvas).

--- a/packages/media-editor/src/image-editor/index.ts
+++ b/packages/media-editor/src/image-editor/index.ts
@@ -33,11 +33,16 @@ export {
 	getSourceRegionPercent,
 	applyOperationToState,
 	stateFromPipeline,
-	exportCroppedImage,
+	exportImageEdit,
+	areImageEditAdjustmentsDefault,
+	getImageEditAdjustmentFilter,
+	DEFAULT_IMAGE_EDIT_ADJUSTMENTS,
 	applyToCanvas,
 } from './core';
 export type {
 	AspectRatioPreset,
+	ExportImageEditOptions,
+	ImageEditAdjustmentValues,
 	SourceRegion,
 	SourceRegionPercent,
 } from './core';

--- a/packages/media-editor/src/image-editor/react/components/cropper-provider.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper-provider.tsx
@@ -6,11 +6,7 @@ import { createContext, useContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import {
-	useCropperState,
-	type UseCropperStateReturn,
-} from '../hooks/use-cropper-state';
-import type { CropperState } from '../../core/types';
+import type { UseCropperStateReturn } from '../hooks/use-cropper-state';
 
 /**
  * The context value type for the CropperProvider.
@@ -24,31 +20,27 @@ const CropperContext = createContext< CropperContextValue >( null );
  * Props for the CropperProvider component.
  */
 interface CropperProviderProps {
-	/** Optional partial initial state to merge with defaults. */
-	initialState?: Partial< CropperState >;
+	/** Cropper controller created by the image editing session. */
+	value: UseCropperStateReturn;
 	/** Child components. */
 	children: React.ReactNode;
 }
 
 /**
- * Convenience context provider that wraps useCropperState.
+ * Context provider for an existing cropper controller.
  *
- * Provides the full cropper state and action creators to all
- * descendant components via React context.
+ * The media editor image editing session owns the controller lifecycle; this
+ * provider only makes that controller available to cropper-specific children
+ * through `useCropper()`.
  *
- * @param props              Provider props.
- * @param props.initialState
+ * @param props
+ * @param props.value
  * @param props.children
  * @return The provider element wrapping children.
  */
-export function CropperProvider( {
-	initialState,
-	children,
-}: CropperProviderProps ) {
-	const cropperReturn = useCropperState( initialState );
-
+export function CropperProvider( { value, children }: CropperProviderProps ) {
 	return (
-		<CropperContext.Provider value={ cropperReturn }>
+		<CropperContext.Provider value={ value }>
 			{ children }
 		</CropperContext.Provider>
 	);

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -86,6 +86,8 @@ export interface CropperProps {
 	showGrid?: boolean | 'interactive';
 	/** Whether external placement activity should keep the grid visible. */
 	isPlacementActive?: boolean;
+	/** CSS filter applied to the image preview. */
+	filter?: string;
 	/** Show the dimming overlay outside the crop area. */
 	showDimming?: boolean;
 	/** Minimum zoom level. */
@@ -137,6 +139,7 @@ export interface CropperProps {
  * @param root0.stencil           Custom stencil component.
  * @param root0.showGrid          Grid overlay mode: false | true | 'interactive'.
  * @param root0.isPlacementActive Keep grid visible during external placement activity.
+ * @param root0.filter            CSS filter applied to the image preview.
  * @param root0.showDimming       Show dimming overlay outside crop.
  * @param root0.minZoom           Minimum zoom level.
  * @param root0.maxZoom           Maximum zoom level.
@@ -156,6 +159,7 @@ function CropperInner(
 		stencil: StencilComponent = RectangleStencil,
 		showGrid = false,
 		isPlacementActive = false,
+		filter,
 		showDimming = true,
 		minZoom,
 		maxZoom,
@@ -477,9 +481,10 @@ function CropperInner(
 			left: centerX,
 			top: centerY,
 			transform: transformString,
+			filter,
 			transition: imageTransition,
 		};
-	}, [ canvasSize, elementSize, transformString, imageTransition ] );
+	}, [ canvasSize, elementSize, transformString, filter, imageTransition ] );
 
 	// Viewport pan CSS transform for the stage div. Applied during resize
 	// drags to keep handles visible when the crop extends past the canvas edge.

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
@@ -1040,6 +1040,40 @@ describe( 'useCropperState', () => {
 			expect( result.current.hasUndo ).toBe( false );
 		} );
 
+		it( 'setImage resets crop edits and clears history for a new image', () => {
+			const { result } = renderHook( () => useCropperState() );
+
+			act( () => {
+				result.current.setImage( {
+					src: 'test.jpg',
+					naturalWidth: 1000,
+					naturalHeight: 500,
+				} );
+			} );
+			act( () => {
+				result.current.setZoom( 3 );
+			} );
+			act( () => {
+				result.current.commitHistory();
+			} );
+
+			expect( result.current.isDirty ).toBe( true );
+			expect( result.current.hasUndo ).toBe( true );
+
+			act( () => {
+				result.current.setImage( {
+					src: 'next.jpg',
+					naturalWidth: 1200,
+					naturalHeight: 800,
+				} );
+			} );
+
+			expect( result.current.state.zoom ).toBe( 1 );
+			expect( result.current.isDirty ).toBe( false );
+			expect( result.current.hasUndo ).toBe( false );
+			expect( result.current.hasRedo ).toBe( false );
+		} );
+
 		it( 'reset is undoable and restores a clean current state', () => {
 			const { result } = renderHook( () => useCropperState() );
 			act( () => result.current.setZoom( 3 ) );

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
@@ -1000,6 +1000,25 @@ describe( 'useCropperState', () => {
 			expect( result.current.isDirty ).toBe( false );
 		} );
 
+		it( 'does not undo a loaded image back to an image-less history state', () => {
+			const { result } = renderHook( () => useCropperState() );
+			const image = {
+				src: 'test.jpg',
+				naturalWidth: 1000,
+				naturalHeight: 500,
+			};
+
+			act( () => result.current.setZoom( 2 ) );
+			act( () => result.current.commitHistory() );
+			act( () => result.current.reset( { image } ) );
+
+			expect( result.current.state.image ).toEqual( image );
+
+			act( () => result.current.undo() );
+
+			expect( result.current.state.image ).toEqual( image );
+		} );
+
 		// --- undo/redo with a pending gesture ---
 
 		it( 'undo flushes a pending gesture before undoing', () => {

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-history.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-history.ts
@@ -94,4 +94,19 @@ describe( 'useHistory', () => {
 		expect( result.current.state.value ).toBe( 1 );
 		expect( result.current.hasUndo ).toBe( false );
 	} );
+
+	it( 'clears undo and redo history', () => {
+		const { result } = renderHook( () => useNumberHistory() );
+
+		act( () => result.current.setState( { value: 1 } ) );
+		act( () => result.current.commitHistory() );
+		act( () => result.current.undo() );
+
+		expect( result.current.hasRedo ).toBe( true );
+
+		act( () => result.current.clearHistory() );
+
+		expect( result.current.hasUndo ).toBe( false );
+		expect( result.current.hasRedo ).toBe( false );
+	} );
 } );

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-history.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-history.ts
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useHistory } from '../use-history';
+
+interface TestState {
+	value: number;
+}
+
+function useNumberHistory() {
+	const [ state, setState ] = useState< TestState >( { value: 0 } );
+	const history = useHistory( {
+		state,
+		isEqual: ( a, b ) => a.value === b.value,
+		onApplyState: setState,
+		debounceMs: 300,
+	} );
+	return { state, setState, ...history };
+}
+
+describe( 'useHistory', () => {
+	beforeEach( () => jest.useFakeTimers() );
+	afterEach( () => jest.useRealTimers() );
+
+	it( 'debounces continuous state changes into one undo entry', () => {
+		const { result } = renderHook( () => useNumberHistory() );
+
+		act( () => {
+			result.current.setState( { value: 1 } );
+			result.current.setState( { value: 2 } );
+			result.current.setState( { value: 3 } );
+		} );
+
+		expect( result.current.hasUndo ).toBe( false );
+
+		act( () => jest.advanceTimersByTime( 300 ) );
+
+		expect( result.current.hasUndo ).toBe( true );
+
+		act( () => result.current.undo() );
+
+		expect( result.current.state.value ).toBe( 0 );
+		expect( result.current.hasUndo ).toBe( false );
+		expect( result.current.hasRedo ).toBe( true );
+	} );
+
+	it( 'can flush a pending entry immediately', () => {
+		const { result } = renderHook( () => useNumberHistory() );
+
+		act( () => result.current.setState( { value: 1 } ) );
+		act( () => result.current.commitHistory() );
+
+		expect( result.current.hasUndo ).toBe( true );
+	} );
+
+	it( 'pushes discrete entries immediately and clears redo', () => {
+		const { result } = renderHook( () => useNumberHistory() );
+
+		act( () => result.current.setState( { value: 1 } ) );
+		act( () => result.current.commitHistory() );
+		act( () => result.current.undo() );
+
+		expect( result.current.hasRedo ).toBe( true );
+
+		act( () => {
+			result.current.pushHistory();
+			result.current.suppressNextChange();
+			result.current.setState( { value: 2 } );
+		} );
+
+		expect( result.current.hasRedo ).toBe( false );
+		expect( result.current.hasUndo ).toBe( true );
+	} );
+
+	it( 'suppresses a state change without creating history', () => {
+		const { result } = renderHook( () => useNumberHistory() );
+
+		act( () => {
+			result.current.suppressNextChange();
+			result.current.setState( { value: 1 } );
+		} );
+		act( () => jest.advanceTimersByTime( 300 ) );
+
+		expect( result.current.state.value ).toBe( 1 );
+		expect( result.current.hasUndo ).toBe( false );
+	} );
+} );

--- a/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
@@ -1,13 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	useReducer,
-	useCallback,
-	useRef,
-	useState,
-	useEffect,
-} from '@wordpress/element';
+import { useReducer, useCallback, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -26,6 +20,7 @@ import {
 	enforceContainment,
 	isStateDirty,
 } from '../../core/state';
+import { useHistory } from './use-history';
 
 /**
  * The return type of the useCropperState hook.
@@ -166,127 +161,30 @@ export function useCropperState(
 	const stateRef = useRef( state );
 	stateRef.current = state;
 
-	// History stack for undo/redo. Using refs for the arrays avoids
-	// unnecessary re-renders on every push; a pair of boolean state values
-	// drives the enabled/disabled state of the undo/redo buttons.
-	const historyRef = useRef< CropperState[] >( [] );
-	const redoStackRef = useRef< CropperState[] >( [] );
-	const [ hasUndo, setHasUndo ] = useState( false );
-	const [ hasRedo, setHasRedo ] = useState( false );
-
-	// Debounce-based history: tracks the last committed state and a pending
-	// timer. Any state change resets the timer; when it expires the
-	// pre-change state is pushed to history.
-	const lastCommittedStateRef = useRef< CropperState | null >( state );
-	const debounceTimerRef = useRef< ReturnType< typeof setTimeout > >();
-	// Set to true before dispatching actions that must not produce a debounce
-	// history entry (undo, redo, reset, setImage, discrete actions).
-	const suppressDebounceRef = useRef( false );
-
-	// Pushes `entry` (defaults to current state) onto the undo stack and
-	// clears the redo stack. Skips if `entry` is already the last item,
-	// so rapid discrete actions on unchanged state don't create duplicates.
-	const pushToHistory = useCallback( ( entry?: CropperState ) => {
-		const target = entry ?? stateRef.current;
-		const previousEntry =
-			historyRef.current[ historyRef.current.length - 1 ];
-		if ( previousEntry && areHistoryStatesEqual( previousEntry, target ) ) {
-			return;
-		}
-		historyRef.current = [ ...historyRef.current, target ];
-		redoStackRef.current = [];
-		setHasUndo( true );
-		setHasRedo( false );
-	}, [] );
-
-	// Watch state and debounce history commits. Any dispatch resets the
-	// timer; once the state has settled for HISTORY_DEBOUNCE_MS the
-	// pre-change snapshot is pushed to the undo stack.
-	useEffect( () => {
-		// Suppress flag: undo/redo/reset/setImage/discrete actions set this
-		// to opt out of the debounce for their own state changes.
-		if ( suppressDebounceRef.current ) {
-			suppressDebounceRef.current = false;
-			lastCommittedStateRef.current = stateRef.current;
-			return;
-		}
-		if (
-			lastCommittedStateRef.current !== null &&
-			areHistoryStatesEqual(
-				lastCommittedStateRef.current,
-				stateRef.current
-			)
-		) {
-			lastCommittedStateRef.current = stateRef.current;
-			return;
-		}
-		clearTimeout( debounceTimerRef.current );
-		debounceTimerRef.current = setTimeout( () => {
-			const snapshot = lastCommittedStateRef.current;
-			if (
-				snapshot !== null &&
-				! areHistoryStatesEqual( snapshot, stateRef.current )
-			) {
-				pushToHistory( snapshot );
-			}
-			lastCommittedStateRef.current = stateRef.current;
-		}, HISTORY_DEBOUNCE_MS );
-		return () => clearTimeout( debounceTimerRef.current );
-	}, [ state, pushToHistory ] );
-
-	// Flush the pending debounce immediately: cancel the timer and push the
-	// pre-change snapshot if the state has actually changed. Used by
-	// pointer-up / key-up handlers for an instant commit feel, and by
-	// undo/redo/discrete actions before recording their own history entry.
-	const commitHistory = useCallback( () => {
-		clearTimeout( debounceTimerRef.current );
-		const snapshot = lastCommittedStateRef.current;
-		if (
-			snapshot !== null &&
-			! areHistoryStatesEqual( snapshot, stateRef.current )
-		) {
-			pushToHistory( snapshot );
-		}
-		lastCommittedStateRef.current = stateRef.current;
-	}, [ pushToHistory ] );
-
-	const undo = useCallback( () => {
-		// Flush any pending gesture so it becomes a distinct undo step
-		// before we pop history. This ensures mid-gesture undo undoes the
-		// pending change rather than silently discarding it.
-		commitHistory();
-		const prev = historyRef.current[ historyRef.current.length - 1 ];
-		if ( ! prev ) {
-			return;
-		}
-		redoStackRef.current = [ stateRef.current, ...redoStackRef.current ];
-		historyRef.current = historyRef.current.slice( 0, -1 );
-		suppressDebounceRef.current = true;
-		setHasUndo( historyRef.current.length > 0 );
-		setHasRedo( true );
-		dispatch( { type: 'RESET', payload: prev } );
-	}, [ dispatch, commitHistory ] );
-
-	const redo = useCallback( () => {
-		// Flush any pending gesture before redoing so the in-flight change
-		// is saved and the redo target lands on top of it.
-		commitHistory();
-		const next = redoStackRef.current[ 0 ];
-		if ( ! next ) {
-			return;
-		}
-		historyRef.current = [ ...historyRef.current, stateRef.current ];
-		redoStackRef.current = redoStackRef.current.slice( 1 );
-		suppressDebounceRef.current = true;
-		setHasUndo( true );
-		setHasRedo( redoStackRef.current.length > 0 );
-		dispatch( { type: 'RESET', payload: next } );
-	}, [ dispatch, commitHistory ] );
+	const applyHistoryState = useCallback(
+		( nextState: CropperState ) => {
+			dispatch( { type: 'RESET', payload: nextState } );
+		},
+		[ dispatch ]
+	);
+	const {
+		hasUndo,
+		hasRedo,
+		pushHistory,
+		commitHistory,
+		undo,
+		redo,
+		suppressNextChange,
+	} = useHistory( {
+		state,
+		isEqual: areHistoryStatesEqual,
+		onApplyState: applyHistoryState,
+		debounceMs: HISTORY_DEBOUNCE_MS,
+	} );
 
 	const setImage = useCallback(
 		( image: CropperState[ 'image' ] ) => {
-			clearTimeout( debounceTimerRef.current );
-			suppressDebounceRef.current = true;
+			suppressNextChange( { clearPending: true } );
 			dispatch( { type: 'SET_IMAGE', payload: image } );
 			// Refresh the "clean" snapshot to match the post-load state
 			// produced by the reducer. Otherwise containment can nudge
@@ -297,7 +195,7 @@ export function useCropperState(
 				image,
 			} );
 		},
-		[ dispatch ]
+		[ dispatch, suppressNextChange ]
 	);
 
 	const setPan = useCallback(
@@ -334,11 +232,11 @@ export function useCropperState(
 	const setFlip = useCallback(
 		( flip: Flip ) => {
 			commitHistory(); // flush any pending continuous gesture first
-			pushToHistory(); // record current state as the undo point
-			suppressDebounceRef.current = true;
+			pushHistory(); // record current state as the undo point
+			suppressNextChange();
 			dispatch( { type: 'SET_FLIP', payload: flip } );
 		},
-		[ dispatch, pushToHistory, commitHistory ]
+		[ dispatch, pushHistory, commitHistory, suppressNextChange ]
 	);
 
 	const toggleFlip = useCallback(
@@ -354,14 +252,14 @@ export function useCropperState(
 	const snapRotate90 = useCallback(
 		( direction: 1 | -1 ) => {
 			commitHistory();
-			pushToHistory();
-			suppressDebounceRef.current = true;
+			pushHistory();
+			suppressNextChange();
 			dispatch( {
 				type: 'SNAP_ROTATE_90',
 				payload: { direction },
 			} );
 		},
-		[ dispatch, pushToHistory, commitHistory ]
+		[ dispatch, pushHistory, commitHistory, suppressNextChange ]
 	);
 
 	const setCropRect = useCallback(
@@ -373,18 +271,18 @@ export function useCropperState(
 
 	const settleCrop = useCallback( () => {
 		commitHistory();
-		suppressDebounceRef.current = true;
+		suppressNextChange();
 		dispatch( { type: 'SETTLE_CROP' } );
-	}, [ dispatch, commitHistory ] );
+	}, [ dispatch, commitHistory, suppressNextChange ] );
 
 	const applyOperation = useCallback(
 		( op: TransformOperation ) => {
 			commitHistory();
-			pushToHistory();
-			suppressDebounceRef.current = true;
+			pushHistory();
+			suppressNextChange();
 			dispatch( { type: 'APPLY_OPERATION', payload: op } );
 		},
-		[ dispatch, pushToHistory, commitHistory ]
+		[ dispatch, pushHistory, commitHistory, suppressNextChange ]
 	);
 
 	const reset = useCallback(
@@ -398,9 +296,9 @@ export function useCropperState(
 			if (
 				! areHistoryStatesEqual( stateRef.current, nextInitialState )
 			) {
-				pushToHistory();
+				pushHistory();
 			}
-			suppressDebounceRef.current = true;
+			suppressNextChange();
 			dispatch( { type: 'RESET', payload: resetState } );
 			// Mirror the reducer's RESET exactly so isDirty stays in
 			// sync. RESET preserves the currently-loaded image; the
@@ -409,7 +307,7 @@ export function useCropperState(
 			// would report true after a reset.
 			initialRef.current = nextInitialState;
 		},
-		[ dispatch, pushToHistory, commitHistory ]
+		[ dispatch, pushHistory, commitHistory, suppressNextChange ]
 	);
 
 	const isDirty = isStateDirty( state, initialRef.current );

--- a/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
@@ -14,7 +14,7 @@ import type {
 	Flip,
 } from '../../core/types';
 import { DEFAULT_STATE } from '../../core/constants';
-import { exportCroppedImage } from '../../core/export/canvas-renderer';
+import { exportImageEdit } from '../../core/export/canvas-renderer';
 import {
 	cropperReducer,
 	enforceContainment,
@@ -91,7 +91,7 @@ export interface UseCropperStateReturn {
 	commitHistory: () => void;
 	/**
 	 * Export the cropped image as a Blob. Throws on failure — see
-	 * `exportCroppedImage` in core for the error semantics (image
+	 * `exportImageEdit` in core for the error semantics (image
 	 * load errors, CORS taint, missing canvas context). Wrap in
 	 * try/catch if you need to recover.
 	 */
@@ -174,7 +174,13 @@ export function useCropperState(
 
 	const applyHistoryState = useCallback(
 		( nextState: CropperState ) => {
-			dispatch( { type: 'RESET', payload: nextState } );
+			dispatch( {
+				type: 'RESET',
+				payload: {
+					...nextState,
+					image: nextState.image ?? stateRef.current.image,
+				},
+			} );
 		},
 		[ dispatch ]
 	);
@@ -332,12 +338,12 @@ export function useCropperState(
 					new Error( 'No image loaded — call setImage first.' )
 				);
 			}
-			return exportCroppedImage(
-				state.image.src,
+			return exportImageEdit( {
+				src: state.image.src,
 				state,
 				mimeType,
-				quality
-			);
+				quality,
+			} );
 		},
 		[ state ]
 	);

--- a/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
@@ -34,7 +34,7 @@ import { useHistory } from './use-history';
 export interface UseCropperStateReturn {
 	/** The current cropper state (read-only). */
 	state: CropperState;
-	/** Set the loaded image (natural size and src). */
+	/** Set the loaded image and reset image-dependent crop state. */
 	setImage: ( image: CropperState[ 'image' ] ) => void;
 	/**
 	 * Set the image pan offset in normalized coordinates. Use
@@ -128,6 +128,17 @@ function areHistoryStatesEqual( a: CropperState, b: CropperState ): boolean {
 	);
 }
 
+function areImagesEqual(
+	a: CropperState[ 'image' ],
+	b: CropperState[ 'image' ]
+): boolean {
+	return (
+		a?.src === b?.src &&
+		a?.naturalWidth === b?.naturalWidth &&
+		a?.naturalHeight === b?.naturalHeight
+	);
+}
+
 /**
  * Reducer-based state management hook for the image editor.
  *
@@ -175,6 +186,7 @@ export function useCropperState(
 		undo,
 		redo,
 		suppressNextChange,
+		clearHistory,
 	} = useHistory( {
 		state,
 		isEqual: areHistoryStatesEqual,
@@ -184,18 +196,19 @@ export function useCropperState(
 
 	const setImage = useCallback(
 		( image: CropperState[ 'image' ] ) => {
-			suppressNextChange( { clearPending: true } );
-			dispatch( { type: 'SET_IMAGE', payload: image } );
-			// Refresh the "clean" snapshot to match the post-load state
-			// produced by the reducer. Otherwise containment can nudge
-			// pan/zoom by tiny amounts on load and `isDirty` would
-			// report true from the start.
-			initialRef.current = enforceContainment( {
-				...initialRef.current,
+			if ( areImagesEqual( stateRef.current.image, image ) ) {
+				return;
+			}
+			const nextInitialState = enforceContainment( {
+				...DEFAULT_STATE,
 				image,
 			} );
+			clearHistory( nextInitialState );
+			suppressNextChange( { clearPending: true } );
+			dispatch( { type: 'RESET', payload: { image } } );
+			initialRef.current = nextInitialState;
 		},
-		[ dispatch, suppressNextChange ]
+		[ clearHistory, dispatch, suppressNextChange ]
 	);
 
 	const setPan = useCallback(

--- a/packages/media-editor/src/image-editor/react/hooks/use-history.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-history.ts
@@ -29,6 +29,8 @@ export interface UseHistoryReturn< T > {
 	redo: () => void;
 	/** Suppress the next observed state change from creating history. */
 	suppressNextChange: ( options?: { clearPending?: boolean } ) => void;
+	/** Clear undo/redo history and optionally replace the clean baseline. */
+	clearHistory: ( state?: T ) => void;
 }
 
 /**
@@ -128,6 +130,15 @@ export function useHistory< T >( {
 		[]
 	);
 
+	const clearHistory = useCallback( ( nextState?: T ) => {
+		clearTimeout( debounceTimerRef.current );
+		historyRef.current = [];
+		redoStackRef.current = [];
+		lastCommittedStateRef.current = nextState ?? stateRef.current;
+		setHasUndo( false );
+		setHasRedo( false );
+	}, [] );
+
 	const undo = useCallback( () => {
 		commitHistory();
 		const prev = historyRef.current[ historyRef.current.length - 1 ];
@@ -164,5 +175,6 @@ export function useHistory< T >( {
 		undo,
 		redo,
 		suppressNextChange,
+		clearHistory,
 	};
 }

--- a/packages/media-editor/src/image-editor/react/hooks/use-history.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-history.ts
@@ -1,0 +1,168 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+
+export interface UseHistoryOptions< T > {
+	/** Current state to observe for debounced history entries. */
+	state: T;
+	/** Compare two history states. */
+	isEqual: ( a: T, b: T ) => boolean;
+	/** Apply a state restored from undo/redo history. */
+	onApplyState: ( state: T ) => void;
+	/** Milliseconds of inactivity before a continuous edit is committed. */
+	debounceMs: number;
+}
+
+export interface UseHistoryReturn< T > {
+	/** Whether there is a history state to undo. */
+	hasUndo: boolean;
+	/** Whether there is a history state to redo. */
+	hasRedo: boolean;
+	/** Push a specific entry, or the current state, to undo history. */
+	pushHistory: ( entry?: T ) => void;
+	/** Flush the pending debounced history entry immediately. */
+	commitHistory: () => void;
+	/** Undo the last committed state. */
+	undo: () => void;
+	/** Redo the last undone state. */
+	redo: () => void;
+	/** Suppress the next observed state change from creating history. */
+	suppressNextChange: ( options?: { clearPending?: boolean } ) => void;
+}
+
+/**
+ * Generic snapshot history for editing surfaces.
+ *
+ * Continuous edits are committed with a debounce, while callers can still push
+ * discrete edits immediately. This mirrors the cropper history semantics and is
+ * intentionally state-shape agnostic so the image editing session can later
+ * reuse the same behavior for adjustments and extension transactions.
+ *
+ * @param options
+ * @param options.state
+ * @param options.isEqual
+ * @param options.onApplyState
+ * @param options.debounceMs
+ */
+export function useHistory< T >( {
+	state,
+	isEqual,
+	onApplyState,
+	debounceMs,
+}: UseHistoryOptions< T > ): UseHistoryReturn< T > {
+	const stateRef = useRef( state );
+
+	const historyRef = useRef< T[] >( [] );
+	const redoStackRef = useRef< T[] >( [] );
+	const [ hasUndo, setHasUndo ] = useState( false );
+	const [ hasRedo, setHasRedo ] = useState( false );
+
+	const lastCommittedStateRef = useRef< T | null >( state );
+	const debounceTimerRef = useRef< ReturnType< typeof setTimeout > >();
+	const suppressDebounceRef = useRef( false );
+
+	useEffect( () => {
+		stateRef.current = state;
+	}, [ state ] );
+
+	const pushHistory = useCallback(
+		( entry?: T ) => {
+			const target = entry ?? stateRef.current;
+			const previousEntry =
+				historyRef.current[ historyRef.current.length - 1 ];
+			if ( previousEntry && isEqual( previousEntry, target ) ) {
+				return;
+			}
+			historyRef.current = [ ...historyRef.current, target ];
+			redoStackRef.current = [];
+			setHasUndo( true );
+			setHasRedo( false );
+		},
+		[ isEqual ]
+	);
+
+	useEffect( () => {
+		if ( suppressDebounceRef.current ) {
+			suppressDebounceRef.current = false;
+			lastCommittedStateRef.current = stateRef.current;
+			return;
+		}
+		if (
+			lastCommittedStateRef.current !== null &&
+			isEqual( lastCommittedStateRef.current, stateRef.current )
+		) {
+			lastCommittedStateRef.current = stateRef.current;
+			return;
+		}
+		clearTimeout( debounceTimerRef.current );
+		debounceTimerRef.current = setTimeout( () => {
+			const snapshot = lastCommittedStateRef.current;
+			if (
+				snapshot !== null &&
+				! isEqual( snapshot, stateRef.current )
+			) {
+				pushHistory( snapshot );
+			}
+			lastCommittedStateRef.current = stateRef.current;
+		}, debounceMs );
+		return () => clearTimeout( debounceTimerRef.current );
+	}, [ state, isEqual, pushHistory, debounceMs ] );
+
+	const commitHistory = useCallback( () => {
+		clearTimeout( debounceTimerRef.current );
+		const snapshot = lastCommittedStateRef.current;
+		if ( snapshot !== null && ! isEqual( snapshot, stateRef.current ) ) {
+			pushHistory( snapshot );
+		}
+		lastCommittedStateRef.current = stateRef.current;
+	}, [ isEqual, pushHistory ] );
+
+	const suppressNextChange = useCallback(
+		( options: { clearPending?: boolean } = {} ) => {
+			if ( options.clearPending ) {
+				clearTimeout( debounceTimerRef.current );
+			}
+			suppressDebounceRef.current = true;
+		},
+		[]
+	);
+
+	const undo = useCallback( () => {
+		commitHistory();
+		const prev = historyRef.current[ historyRef.current.length - 1 ];
+		if ( ! prev ) {
+			return;
+		}
+		redoStackRef.current = [ stateRef.current, ...redoStackRef.current ];
+		historyRef.current = historyRef.current.slice( 0, -1 );
+		suppressNextChange();
+		setHasUndo( historyRef.current.length > 0 );
+		setHasRedo( true );
+		onApplyState( prev );
+	}, [ commitHistory, onApplyState, suppressNextChange ] );
+
+	const redo = useCallback( () => {
+		commitHistory();
+		const next = redoStackRef.current[ 0 ];
+		if ( ! next ) {
+			return;
+		}
+		historyRef.current = [ ...historyRef.current, stateRef.current ];
+		redoStackRef.current = redoStackRef.current.slice( 1 );
+		suppressNextChange();
+		setHasUndo( true );
+		setHasRedo( redoStackRef.current.length > 0 );
+		onApplyState( next );
+	}, [ commitHistory, onApplyState, suppressNextChange ] );
+
+	return {
+		hasUndo,
+		hasRedo,
+		pushHistory,
+		commitHistory,
+		undo,
+		redo,
+		suppressNextChange,
+	};
+}

--- a/packages/media-editor/src/private-apis.ts
+++ b/packages/media-editor/src/private-apis.ts
@@ -4,9 +4,11 @@
 import { lock } from './lock-unlock';
 import { store } from './store';
 import { MediaEditorModal } from './components/media-editor-modal';
+import { registerImageEditorExtensionPanel } from './components/image-editor-extension-registry';
 
 export const privateApis = {};
 lock( privateApis, {
 	store,
 	MediaEditorModal,
+	registerImageEditorExtensionPanel,
 } );


### PR DESCRIPTION
## What changed


https://github.com/user-attachments/assets/281390e7-4ff2-4721-a7bd-2a75a9a71dec



Adds an internal Adjust panel using the image editor extension panel registry from #77932.

The panel exposes native brightness, contrast, saturation, and greyscale controls. Adjustment state lives on the image editing session, participates in session dirty state, undo/redo, reset, and source-image replacement cleanup, and previews on the cropper image surface via CSS filters.

The image session now coordinates cropper and adjustment undo/redo with a session-level domain stack so mixed edit sequences unwind in chronological order.

The image export API is now centered on `exportImageEdit( { src, state, adjustments, mimeType, quality } )`, which renders cropper transforms plus adjustments into a canvas-backed `Blob`.

Saving uses two paths:

- Crop-only edits continue to use the existing `/wp/v2/media/{ id }/edit` modifiers path.
- Adjustment edits export the final image edit as a replacement blob, wrap it in a `File`, and upload it to `/wp/v2/media`, including attachment metadata.

This is a stacked follow-up to #77932.

## Why

This is the first real consumer of the extension-shaped panel API. It validates that a panel can plug into the image editor surface, use the session facade, preserve crop state while switching panels, participate in shared undo/redo without owning the editor shell, and save final pixel edits when the server modifier API cannot represent them.
