### PR TITLE
DataViews: Add showLevels prop to LayoutTable and LayoutTableComponent

### DIFF
--- a/packages/dataviews/src/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews/stories/index.story.tsx
@@ -65,6 +65,7 @@ export const LayoutTable = {
 		groupByLabel: true,
 		hasClickableItems: true,
 		perPageSizes: [ 10, 25, 50, 100 ],
+		showLevels: false,
 		showMedia: true,
 	},
 	argTypes: {
@@ -88,6 +89,10 @@ export const LayoutTable = {
 		perPageSizes: {
 			control: 'object',
 			description: 'Array of available page sizes',
+		},
+		showLevels: {
+			control: 'boolean',
+			description: 'Whether to show hierarchical levels',
 		},
 		showMedia: {
 			control: 'boolean',

--- a/packages/dataviews/src/dataviews/stories/layout-table.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-table.tsx
@@ -18,6 +18,7 @@ export const LayoutTableComponent = ( {
 	groupBy = false,
 	groupByLabel = true,
 	perPageSizes = [ 10, 25, 50, 100 ],
+	showLevels = false,
 	showMedia = true,
 }: {
 	backgroundColor?: string;
@@ -25,6 +26,7 @@ export const LayoutTableComponent = ( {
 	groupBy?: boolean;
 	groupByLabel?: boolean;
 	perPageSizes?: number[];
+	showLevels?: boolean;
 	showMedia?: boolean;
 } ) => {
 	const [ view, setView ] = useState< View >( {
@@ -38,6 +40,7 @@ export const LayoutTableComponent = ( {
 		titleField: 'title',
 		descriptionField: 'description',
 		mediaField: 'image',
+		showLevels,
 		showMedia,
 	} );
 
@@ -52,10 +55,11 @@ export const LayoutTableComponent = ( {
 							showLabel: groupByLabel,
 					  }
 					: undefined,
+				showLevels,
 				showMedia,
 			};
 		} );
-	}, [ groupBy, groupByLabel, showMedia ] );
+	}, [ groupBy, groupByLabel, showLevels, showMedia ] );
 
 	const { data: shownData, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( data, view, fields );
@@ -69,6 +73,9 @@ export const LayoutTableComponent = ( {
 		>
 			<DataViews
 				getItemId={ ( item ) => item.id.toString() }
+				getItemLevel={ ( item ) =>
+					item.categories.includes( 'Satellite' ) ? 1 : 0
+				}
 				paginationInfo={ paginationInfo }
 				data={ shownData }
 				view={ view }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
