### PR TITLE
Embed: Add '[embed]' shortcode transform

### DIFF
--- a/packages/block-library/src/embed/transforms.js
+++ b/packages/block-library/src/embed/transforms.js
@@ -34,6 +34,17 @@ const transforms = {
 				} );
 			},
 		},
+		{
+			type: 'shortcode',
+			tag: 'embed',
+			transform: ( _attrs, { shortcode } ) => {
+				const url = rewriteXToTwitter( shortcode.content?.trim() );
+				return createBlock( EMBED_BLOCK, {
+					url,
+					...findMoreSuitableBlock( url )?.attributes,
+				} );
+			},
+		},
 	],
 	to: [
 		{


### PR DESCRIPTION
## What?
Closes #13852.

Adds a `shortcode` transform to the Embed block for the WordPress `[embed]` shortcode. This fixes the covert-to-blocks action and paste transformations, creating an embed block instead of a general shortcode block.

## Testing Instructions
1. Create a post.
2. Switch to code editor.
3. Paste following markup - `<p>[embed]https://www.youtube.com/watch?v=2YWPJjOa-2w[/embed]</p>`.
4. Switch back to the visual editor.
5. Click on the "Convert to blocks" toolbar button on the classic editor.
6. Confirm the shortcode is correctly transformed to the appropriate embed block.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/ef3a9a63-140f-4d2a-a4c1-442459f65bd5

## Use of AI Tools

None.