### PR TITLE
Experiment: Auto fill `slug` from singular label for taxonomies and post types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63143,7 +63143,9 @@
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/notices": "file:../notices",
-				"@wordpress/ui": "file:../ui"
+				"@wordpress/private-apis": "file:../private-apis",
+				"@wordpress/ui": "file:../ui",
+				"@wordpress/url": "file:../url"
 			}
 		},
 		"packages/user-taxonomies": {
@@ -63159,7 +63161,9 @@
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/notices": "file:../notices",
-				"@wordpress/ui": "file:../ui"
+				"@wordpress/private-apis": "file:../private-apis",
+				"@wordpress/ui": "file:../ui",
+				"@wordpress/url": "file:../url"
 			}
 		},
 		"packages/viewport": {

--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -47,6 +47,8 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/upload-media',
 	'@wordpress/global-styles-ui',
 	'@wordpress/ui',
+	'@wordpress/user-post-types',
+	'@wordpress/user-taxonomies',
 	'@wordpress/views',
 ];
 

--- a/packages/user-post-types/package.json
+++ b/packages/user-post-types/package.json
@@ -38,7 +38,9 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/notices": "file:../notices",
-		"@wordpress/ui": "file:../ui"
+		"@wordpress/private-apis": "file:../private-apis",
+		"@wordpress/ui": "file:../ui",
+		"@wordpress/url": "file:../url"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/user-post-types/src/fields/general.tsx
+++ b/packages/user-post-types/src/fields/general.tsx
@@ -1,19 +1,29 @@
 /**
  * WordPress dependencies
  */
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { resolveSelect, useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import type { Field, Form } from '@wordpress/dataviews';
+import type {
+	DataFormControlProps,
+	Field,
+	FieldValidity,
+	Form,
+} from '@wordpress/dataviews';
 // eslint-disable-next-line @wordpress/use-recommended-components -- Used here because it supports rendering as a `span` via the `render` prop to avoid invalid HTML.
 import { Badge, Notice, Stack } from '@wordpress/ui';
+import { cleanForSlug } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
+import { unlock } from '../lock-unlock';
 import { SUPPORT_FEATURES, usePublicTaxonomies } from '../utils';
 import type { PostTypeFormData, SupportFeature } from '../types';
+
+const { ValidatedInputControl } = unlock( componentsPrivateApis );
 
 const SUPPORT_LABELS: Record< SupportFeature, string > = {
 	title: __( 'Title' ),
@@ -203,6 +213,23 @@ export const statusField: Field< PostTypeFormData > = {
 	enableSorting: false,
 };
 
+const SLUG_MAX_LENGTH = 20;
+// Slug field has required + pattern + maxLength + a custom (slug-taken) check.
+// Surface them in priority order: structural rules first, async slug-taken last.
+// `required` only overrides the native browser message when our rule supplies
+// one of its own.
+function getSlugCustomValidity( validity?: FieldValidity ) {
+	if ( validity?.required?.message ) {
+		return validity.required;
+	}
+	if ( validity?.pattern ) {
+		return validity.pattern;
+	}
+	if ( validity?.maxLength ) {
+		return validity.maxLength;
+	}
+	return validity?.custom;
+}
 export function useSlugField(
 	originalSlug?: string,
 	currentValue?: string
@@ -239,7 +266,8 @@ export function useSlugField(
 			),
 			isValid: {
 				required: true,
-				pattern: '^[a-z0-9_\\-]{1,20}$',
+				pattern: '^[a-z0-9_\\-]+$',
+				maxLength: SLUG_MAX_LENGTH,
 				custom: async ( value: PostTypeFormData ) => {
 					const slug = value.slug;
 					if ( originalSlug !== undefined && slug === originalSlug ) {
@@ -265,6 +293,60 @@ export function useSlugField(
 						? __( 'This post type key is already in use.' )
 						: null;
 				},
+			},
+			Edit: function SlugEdit( {
+				data,
+				field,
+				onChange,
+				hideLabelFromVision,
+				markWhenOptional,
+				validity,
+			}: DataFormControlProps< PostTypeFormData > ) {
+				const { label, description, getValue, setValue, isValid } =
+					field;
+				const value =
+					( getValue( { item: data } ) as string | undefined ) ?? '';
+				const handleChange = ( newValue: string ) =>
+					onChange( setValue( { item: data, value: newValue } ) );
+				const onFocus = () => {
+					if ( data.id !== undefined || data.slug ) {
+						return;
+					}
+					const singular = data.config.labels.singular_name?.trim();
+					if ( ! singular ) {
+						return;
+					}
+					const cleaned = cleanForSlug( singular );
+					// On a fresh record fill the input from the singular label.
+					// Skip auto-fill if cleanForSlug retained non-ASCII to match
+					// the server's sanitize_key charset.
+					if ( /[^a-z0-9_-]/.test( cleaned ) ) {
+						return;
+					}
+					const trimmed = cleaned
+						.slice( 0, SLUG_MAX_LENGTH )
+						// Slicing can introduce a trailing hyphen — strip it.
+						.replace( /-+$/, '' );
+					if ( trimmed ) {
+						handleChange( trimmed );
+					}
+				};
+				return (
+					<ValidatedInputControl
+						__next40pxDefaultSize
+						required={ !! isValid.required }
+						markWhenOptional={ markWhenOptional }
+						customValidity={ getSlugCustomValidity( validity ) }
+						label={ label }
+						value={ value }
+						help={ description }
+						onChange={ handleChange }
+						onFocus={ onFocus }
+						hideLabelFromVision={ hideLabelFromVision }
+						pattern={ isValid.pattern?.constraint }
+						maxLength={ isValid.maxLength?.constraint }
+					/>
+				);
 			},
 			filterBy: false,
 			enableSorting: false,

--- a/packages/user-post-types/src/lock-unlock.ts
+++ b/packages/user-post-types/src/lock-unlock.ts
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+		'@wordpress/user-post-types'
+	);

--- a/packages/user-post-types/tsconfig.json
+++ b/packages/user-post-types/tsconfig.json
@@ -13,6 +13,8 @@
 		{ "path": "../i18n" },
 		{ "path": "../icons" },
 		{ "path": "../notices" },
-		{ "path": "../ui" }
+		{ "path": "../private-apis" },
+		{ "path": "../ui" },
+		{ "path": "../url" }
 	]
 }

--- a/packages/user-taxonomies/package.json
+++ b/packages/user-taxonomies/package.json
@@ -38,7 +38,9 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/notices": "file:../notices",
-		"@wordpress/ui": "file:../ui"
+		"@wordpress/private-apis": "file:../private-apis",
+		"@wordpress/ui": "file:../ui",
+		"@wordpress/url": "file:../url"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/user-taxonomies/src/fields/general.tsx
+++ b/packages/user-taxonomies/src/fields/general.tsx
@@ -1,20 +1,30 @@
 /**
  * WordPress dependencies
  */
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { resolveSelect, useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import type { Field, Form } from '@wordpress/dataviews';
+import type {
+	DataFormControlProps,
+	Field,
+	FieldValidity,
+	Form,
+} from '@wordpress/dataviews';
 // eslint-disable-next-line @wordpress/use-recommended-components -- Used here because it supports rendering as a `span` via the `render` prop to avoid invalid HTML.
 import { Badge, Notice, Stack } from '@wordpress/ui';
+import { cleanForSlug } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
+import { unlock } from '../lock-unlock';
 import { usePublicPostTypes } from '../utils';
 import type { TaxonomyFormData } from '../types';
 import { booleanField } from './utils';
+
+const { ValidatedInputControl } = unlock( componentsPrivateApis );
 
 export const titleField: Field< TaxonomyFormData > = {
 	id: 'title',
@@ -102,6 +112,23 @@ export const statusField: Field< TaxonomyFormData > = {
 	enableSorting: false,
 };
 
+const SLUG_MAX_LENGTH = 32;
+// Slug field has required + pattern + maxLength + a custom (slug-taken) check.
+// Surface them in priority order: structural rules first, async slug-taken last.
+// `required` only overrides the native browser message when our rule supplies
+// one of its own.
+function getSlugCustomValidity( validity?: FieldValidity ) {
+	if ( validity?.required?.message ) {
+		return validity.required;
+	}
+	if ( validity?.pattern ) {
+		return validity.pattern;
+	}
+	if ( validity?.maxLength ) {
+		return validity.maxLength;
+	}
+	return validity?.custom;
+}
 export function useSlugField(
 	originalSlug?: string,
 	currentValue?: string
@@ -138,7 +165,8 @@ export function useSlugField(
 			),
 			isValid: {
 				required: true,
-				pattern: '^[a-z0-9_\\-]{1,32}$',
+				pattern: '^[a-z0-9_\\-]+$',
+				maxLength: SLUG_MAX_LENGTH,
 				custom: async ( value: TaxonomyFormData ) => {
 					const slug = value.slug;
 					if ( originalSlug !== undefined && slug === originalSlug ) {
@@ -163,6 +191,60 @@ export function useSlugField(
 						? __( 'This taxonomy key is already in use.' )
 						: null;
 				},
+			},
+			Edit: function SlugEdit( {
+				data,
+				field,
+				onChange,
+				hideLabelFromVision,
+				markWhenOptional,
+				validity,
+			}: DataFormControlProps< TaxonomyFormData > ) {
+				const { label, description, getValue, setValue, isValid } =
+					field;
+				const value =
+					( getValue( { item: data } ) as string | undefined ) ?? '';
+				const handleChange = ( newValue: string ) =>
+					onChange( setValue( { item: data, value: newValue } ) );
+				const onFocus = () => {
+					if ( data.id !== undefined || data.slug ) {
+						return;
+					}
+					const singular = data.config.labels.singular_name?.trim();
+					if ( ! singular ) {
+						return;
+					}
+					const cleaned = cleanForSlug( singular );
+					// On a fresh record fill the input from the singular label.
+					// Skip auto-fill if cleanForSlug retained non-ASCII to match
+					// the server's sanitize_key charset.
+					if ( /[^a-z0-9_-]/.test( cleaned ) ) {
+						return;
+					}
+					const trimmed = cleaned
+						.slice( 0, SLUG_MAX_LENGTH )
+						// Slicing can introduce a trailing hyphen — strip it.
+						.replace( /-+$/, '' );
+					if ( trimmed ) {
+						handleChange( trimmed );
+					}
+				};
+				return (
+					<ValidatedInputControl
+						__next40pxDefaultSize
+						required={ !! isValid.required }
+						markWhenOptional={ markWhenOptional }
+						customValidity={ getSlugCustomValidity( validity ) }
+						label={ label }
+						value={ value }
+						help={ description }
+						onChange={ handleChange }
+						onFocus={ onFocus }
+						hideLabelFromVision={ hideLabelFromVision }
+						pattern={ isValid.pattern?.constraint }
+						maxLength={ isValid.maxLength?.constraint }
+					/>
+				);
 			},
 			filterBy: false,
 			enableSorting: false,

--- a/packages/user-taxonomies/src/lock-unlock.ts
+++ b/packages/user-taxonomies/src/lock-unlock.ts
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+		'@wordpress/user-taxonomies'
+	);

--- a/packages/user-taxonomies/tsconfig.json
+++ b/packages/user-taxonomies/tsconfig.json
@@ -13,6 +13,8 @@
 		{ "path": "../i18n" },
 		{ "path": "../icons" },
 		{ "path": "../notices" },
-		{ "path": "../ui" }
+		{ "path": "../private-apis" },
+		{ "path": "../ui" },
+		{ "path": "../url" }
 	]
 }

--- a/test/e2e/specs/admin/user-taxonomies.spec.js
+++ b/test/e2e/specs/admin/user-taxonomies.spec.js
@@ -81,22 +81,25 @@ test.describe( 'User taxonomies', () => {
 		await page
 			.getByRole( 'textbox', { name: 'Singular label' } )
 			.fill( 'Genre' );
-		// The slug field runs an async uniqueness check; the form's
-		// `isValid` stays false while it's in flight, so wait for the
+		// Focusing the slug field auto-fills it from the singular label,
+		// which also kicks off the async uniqueness check. The form's
+		// `isValid` stays false while that's in flight, so wait for the
 		// REST call to settle before submitting.
 		// The button doesn't reflect form validity, so a UI-only wait
 		// isn't possible.
 		// TODO: expolore disabling the button based on the form validity.
+		const slugField = page.getByRole( 'textbox', {
+			name: 'Taxonomy key',
+		} );
 		await Promise.all( [
 			page.waitForResponse(
 				( resp ) =>
 					resp.url().includes( `/${ TAXONOMIES_REST_BASE }` ) &&
 					resp.url().includes( 'slug=genre' )
 			),
-			page
-				.getByRole( 'textbox', { name: 'Taxonomy key' } )
-				.fill( 'genre' ),
+			slugField.focus(),
 		] );
+		await expect( slugField ).toHaveValue( 'genre' );
 		await page.getByRole( 'combobox', { name: 'Post types' } ).click();
 		await page.getByRole( 'option', { name: 'Posts' } ).click();
 		await expect(


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of https://github.com/WordPress/gutenberg/issues/77600


## Testing instructions
1. Enable the `Content types` experiment.
2. Go to `Settings → Post Types` and go to add a new one. 
3. Fill the singular label and then focus on the `slug` field
4. Observe that it is auto-filled based on the singular label and trimmed
5. Try with non-ASCII characters (which are not allowed) e.g. Greek and observe that the `slug` isn't auto-filled 
6. Do the same for `Taxonomies`.

