### PR TITLE
ui/Drawer: Forward `render` on `Drawer.Content` to the scroll container

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `Drawer`: Restore the slide-out animation when the popup closes ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).
+-   `Drawer`: Forward the `render` prop on `Drawer.Content` to the scroll container instead of leaking it as a DOM attribute, matching `Dialog.Content` ([#77941](https://github.com/WordPress/gutenberg/pull/77941)).
 
 ### Enhancements
 

--- a/packages/ui/src/drawer/content.tsx
+++ b/packages/ui/src/drawer/content.tsx
@@ -1,3 +1,4 @@
+import { mergeProps, useRender } from '@base-ui/react';
 import { Drawer as _Drawer } from '@base-ui/react/drawer';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
@@ -28,25 +29,36 @@ import type { ContentProps } from './types';
  * the popup (gated by the scroll edge on vertical drawers).
  */
 const Content = forwardRef< HTMLDivElement, ContentProps >(
-	function DrawerContent( { className, children, onScroll, ...props }, ref ) {
+	function DrawerContent(
+		{ className, render, children, onScroll, ...props },
+		ref
+	) {
 		const { ref: scrollStateRef, onScroll: scrollStateOnScroll } =
 			useOverlayScrollStateAttributes< HTMLDivElement >( onScroll );
 		const mergedRef = useMergeRefs( [ ref, scrollStateRef ] );
 
-		return (
-			<div
-				ref={ mergedRef }
-				className={ clsx(
+		const element = useRender( {
+			defaultTagName: 'div',
+			render,
+			ref: mergedRef,
+			props: mergeProps< 'div' >( props, {
+				className: clsx(
 					styles.content,
 					focusStyles[ 'outset-ring--focus-visible' ],
 					className
-				) }
-				onScroll={ scrollStateOnScroll }
-				{ ...props }
-			>
-				<_Drawer.Content>{ children }</_Drawer.Content>
-			</div>
-		);
+				),
+				onScroll: scrollStateOnScroll,
+				// `_Drawer.Content` carries the `[data-drawer-content]`
+				// marker that Base UI's swipe-dismiss logic uses to skip
+				// mouse-drag swipes started inside the body, preserving
+				// text selection. It must sit *inside* the scroll
+				// container so the popup's edge padding gutter falls
+				// outside the marker and stays mouse-draggable.
+				children: <_Drawer.Content>{ children }</_Drawer.Content>,
+			} ),
+		} );
+
+		return element;
 	}
 );
 


### PR DESCRIPTION
Follow-up to #77800.

## What?

Consume the `render` prop on `Drawer.Content` via Base UI's `useRender`, instead of letting it slip through `{ ...props }` onto the wrapper `<div>` as a no-op DOM attribute.

## Why?

`Drawer.Content`'s prop type extends `ComponentProps<'div'>`, which exposes a polymorphic `render` prop, but the component never actually consumed it. Reported in [a review comment on #77800](https://github.com/WordPress/gutenberg/pull/77800#discussion_r3169207740).

Every other wrapper in `@wordpress/ui` that exposes `render` already consumes it via `useRender` (`Dialog.Content`, `Dialog.Header`, `Dialog.Footer`, `Drawer.Header`, `Drawer.Footer`). `Drawer.Content` was the odd one out.

## How?

`Drawer.Content` keeps its two-element shape — the outer scroll container plus the inner `<_Drawer.Content>` carrying the `[data-drawer-content]` marker — because that split is required for swipe-dismiss to work in the popup-edge padding gutter (locked in by an existing structural test). The fix only changes _how_ the outer element is rendered, not _which_ element receives `ref` and `...props`.

<details>
<summary>Why <code>ref</code> and <code>...props</code> stay on the outer element</summary>

The outer element is the conceptual "Content" the consumer interacts with: it owns the scroll, the focus-visible ring, the `styles.content` class, and the `[data-wp-ui-overlay-scroll-container]` attribute the chrome CSS targets. The inner `<_Drawer.Content>` exists purely to carry the `[data-drawer-content]` marker that Base UI's swipe-dismiss logic checks via `closest()` to skip mouse-drag swipes started inside the body (preserves text selection). The marker has to sit *inside* the scroll container so the popup-edge padding gutter falls outside it and stays mouse-draggable.

The `wraps a [data-drawer-content] marker as the only direct child` test in `packages/ui/src/drawer/test/index.test.tsx` locks this structure.
</details>

## Testing Instructions

1. `npm run test:unit -- packages/ui/src/drawer/test/index.test.tsx` — all 34 tests pass, including the structural wrapper test.
2. In Storybook, open any `Drawer` story and confirm scrolling, focus styling, swipe-dismiss from the popup edge, and text selection in the body all still work.
3. Pass `render={ <section /> }` to `Drawer.Content` and confirm the outer scroll container renders as a `<section>` with the marker `<div data-drawer-content>` as its only child (previously, `render` was silently dropped).

### Testing Instructions for Keyboard

No keyboard-facing change. Tab into a scrollable `Drawer.Content` and confirm the body remains focusable while overflowing (auto `tabindex="0"`).

## Use of AI Tools

This PR was prepared with AI assistance (Cursor / Claude). I reviewed and verified every change.