### PR TITLE
Latest Comments block: Add filter for pingbacks and trackbacks

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -454,7 +454,7 @@ Display a list of your most recent comments. ([Source](https://github.com/WordPr
 -	**Name:** core/latest-comments
 -	**Category:** widgets
 -	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** commentsToShow, displayAvatar, displayContent, displayDate
+-	**Attributes:** commentsToShow, displayAvatar, displayContent, displayDate, showPingbacks, showTrackbacks
 
 ## Latest Posts
 

--- a/packages/block-library/src/latest-comments/block.json
+++ b/packages/block-library/src/latest-comments/block.json
@@ -26,6 +26,14 @@
 			"type": "string",
 			"default": "excerpt",
 			"enum": [ "none", "excerpt", "full" ]
+		},
+		"showPingbacks": {
+			"type": "boolean",
+			"default": true
+		},
+		"showTrackbacks": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -34,8 +34,14 @@ const MIN_COMMENTS = 1;
 const MAX_COMMENTS = 100;
 
 export default function LatestComments( { attributes, setAttributes, name } ) {
-	const { commentsToShow, displayAvatar, displayDate, displayContent } =
-		attributes;
+	const {
+		commentsToShow,
+		displayAvatar,
+		displayDate,
+		displayContent,
+		showPingbacks,
+		showTrackbacks,
+	} = attributes;
 
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
@@ -65,6 +71,8 @@ export default function LatestComments( { attributes, setAttributes, name } ) {
 							displayAvatar: true,
 							displayDate: true,
 							displayContent: 'excerpt',
+							showPingbacks: true,
+							showTrackbacks: true,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
@@ -148,6 +156,44 @@ export default function LatestComments( { attributes, setAttributes, name } ) {
 							min={ MIN_COMMENTS }
 							max={ MAX_COMMENTS }
 							required
+						/>
+					</ToolsPanelItem>
+
+					<ToolsPanelItem
+						hasValue={ () => ! showPingbacks }
+						label={ __( 'Show pingbacks' ) }
+						onDeselect={ () =>
+							setAttributes( { showPingbacks: true } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							label={ __( 'Show pingbacks' ) }
+							checked={ showPingbacks }
+							onChange={ () =>
+								setAttributes( {
+									showPingbacks: ! showPingbacks,
+								} )
+							}
+						/>
+					</ToolsPanelItem>
+
+					<ToolsPanelItem
+						hasValue={ () => ! showTrackbacks }
+						label={ __( 'Show trackbacks' ) }
+						onDeselect={ () =>
+							setAttributes( { showTrackbacks: true } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							label={ __( 'Show trackbacks' ) }
+							checked={ showTrackbacks }
+							onChange={ () =>
+								setAttributes( {
+									showTrackbacks: ! showTrackbacks,
+								} )
+							}
 						/>
 					</ToolsPanelItem>
 				</ToolsPanel>

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -50,17 +50,30 @@ function render_block_core_latest_comments( $attributes ) {
 		$display_content = $attributes['displayContent'] ?? 'excerpt';
 	}
 
+	// Build the comment type filter. Regular comments are always included.
+	// Pingbacks and trackbacks are included based on block attributes,
+	// defaulting to true for backward compatibility with existing blocks.
+	$comment_types   = array( 'comment' );
+	$show_pingbacks  = $attributes['showPingbacks'] ?? true;
+	$show_trackbacks = $attributes['showTrackbacks'] ?? true;
+
+	if ( $show_pingbacks ) {
+		$comment_types[] = 'pingback';
+	}
+	if ( $show_trackbacks ) {
+		$comment_types[] = 'trackback';
+	}
+
+	$query_args = array(
+		'number'      => $attributes['commentsToShow'],
+		'status'      => 'approve',
+		'post_status' => 'publish',
+		'type__in'    => $comment_types,
+	);
+
 	$comments = get_comments(
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-recent-comments.php */
-		apply_filters(
-			'widget_comments_args',
-			array(
-				'number'      => $attributes['commentsToShow'],
-				'status'      => 'approve',
-				'post_status' => 'publish',
-			),
-			array()
-		)
+		apply_filters( 'widget_comments_args', $query_args, array() )
 	);
 
 	$list_items_markup = '';


### PR DESCRIPTION
## What?
Closes #33682

## Why?
The Latest Comments block currently displays all approved comments including pingbacks and trackbacks. Site owners may want to show only regular comments, or exclude self-pings while keeping external pingbacks. This PR addresses that by giving users explicit control over which comment types are displayed.

## Testing Instructions
1. Open a post or page in the block editor.
2. Insert the **Latest Comments** block.
3. Ensure your site has at least one approved pingback and/or trackback comment.
4. In the block's Inspector Controls sidebar, confirm two new toggles appear:
   **Show pingbacks** and **Show trackbacks**.
5. Verify both toggles are **on** by default and the block output includes
   pingbacks/trackbacks as before.
6. Toggle **Show pingbacks** off, confirm pingbacks disappear from the block
   preview.
7. Toggle **Show trackbacks** off, confirm trackbacks disappear from the block
   preview.
8. Toggle both back on, confirm all comment types reappear.
9. Save the post, reload the frontend, and confirm the filtering is applied
   correctly on the published page.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/6c64e793-1444-4b0a-a3d8-1634227b39f8
