### PR TITLE
Shortcode: Offer block-specific transforms when text matches a registered shortcode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58531,6 +58531,7 @@
 				"@wordpress/reusable-blocks": "file:../reusable-blocks",
 				"@wordpress/rich-text": "file:../rich-text",
 				"@wordpress/server-side-render": "file:../server-side-render",
+				"@wordpress/shortcode": "file:../shortcode",
 				"@wordpress/ui": "file:../ui",
 				"@wordpress/upload-media": "file:../upload-media",
 				"@wordpress/url": "file:../url",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -127,6 +127,7 @@
 		"@wordpress/reusable-blocks": "file:../reusable-blocks",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/server-side-render": "file:../server-side-render",
+		"@wordpress/shortcode": "file:../shortcode",
 		"@wordpress/ui": "file:../ui",
 		"@wordpress/upload-media": "file:../upload-media",
 		"@wordpress/url": "file:../url",

--- a/packages/block-library/src/shortcode/transforms.js
+++ b/packages/block-library/src/shortcode/transforms.js
@@ -2,6 +2,25 @@
  * WordPress dependencies
  */
 import { removep, autop } from '@wordpress/autop';
+import { getBlockTransforms, rawHandler } from '@wordpress/blocks';
+import { next } from '@wordpress/shortcode';
+
+const getShortcodeFromTransforms = () =>
+	getBlockTransforms( 'from' ).filter(
+		( transform ) =>
+			transform.type === 'shortcode' &&
+			transform.blockName !== 'core/shortcode'
+	);
+
+// Single-shortcode only: keeps the transform menu honest (one block in, one
+// block out) and avoids unmatched shortcodes silently falling back to freeform.
+const isSingleShortcode = ( text, tag ) => {
+	const trimmed = text.trim();
+	const match = next( tag, trimmed );
+	return (
+		!! match && match.index === 0 && match.content.length === trimmed.length
+	);
+};
 
 const transforms = {
 	from: [
@@ -24,6 +43,30 @@ const transforms = {
 				},
 			},
 			priority: 20,
+		},
+	],
+	to: [
+		{
+			type: 'block',
+			get blocks() {
+				return [
+					...new Set(
+						getShortcodeFromTransforms().map(
+							( transform ) => transform.blockName
+						)
+					),
+				];
+			},
+			isMatch: ( { text } ) => {
+				return getShortcodeFromTransforms().some( ( transform ) =>
+					[]
+						.concat( transform.tag )
+						.some( ( tag ) => isSingleShortcode( text, tag ) )
+				);
+			},
+			transform: ( { text } ) => {
+				return rawHandler( { HTML: `<p>${ text.trim() }</p>` } );
+			},
 		},
 	],
 };

--- a/packages/block-library/src/shortcode/transforms.js
+++ b/packages/block-library/src/shortcode/transforms.js
@@ -45,30 +45,24 @@ const transforms = {
 			priority: 20,
 		},
 	],
-	to: [
-		{
+	// One `to` transform per registered shortcode-from block. A single transform
+	// with a dynamic `blocks` list won't work: `isMatch` runs once per
+	// transform, so all targets would surface (or none) regardless of which
+	// shortcode tag the block actually contains.
+	get to() {
+		return getShortcodeFromTransforms().map( ( fromTransform ) => ( {
 			type: 'block',
-			get blocks() {
-				return [
-					...new Set(
-						getShortcodeFromTransforms().map(
-							( transform ) => transform.blockName
-						)
-					),
-				];
-			},
+			blocks: [ fromTransform.blockName ],
 			isMatch: ( { text } ) => {
-				return getShortcodeFromTransforms().some( ( transform ) =>
-					[]
-						.concat( transform.tag )
-						.some( ( tag ) => isSingleShortcode( text, tag ) )
-				);
+				return []
+					.concat( fromTransform.tag )
+					.some( ( tag ) => isSingleShortcode( text, tag ) );
 			},
 			transform: ( { text } ) => {
 				return rawHandler( { HTML: `<p>${ text.trim() }</p>` } );
 			},
-		},
-	],
+		} ) );
+	},
 };
 
 export default transforms;

--- a/packages/block-library/tsconfig.json
+++ b/packages/block-library/tsconfig.json
@@ -34,6 +34,7 @@
 		{ "path": "../keyboard-shortcuts" },
 		{ "path": "../primitives" },
 		{ "path": "../rich-text" },
+		{ "path": "../shortcode" },
 		{ "path": "../ui" },
 		{ "path": "../upload-media" },
 		{ "path": "../url" },

--- a/packages/blocks/src/api/factory.ts
+++ b/packages/blocks/src/api/factory.ts
@@ -442,7 +442,8 @@ export function getBlockTransforms(
 	// Validate that block type exists and has array of direction.
 	const blockType = normalizeBlockType( blockTypeOrName );
 	const { name: blockName, transforms } = blockType || {};
-	if ( ! transforms || ! Array.isArray( transforms[ direction ] ) ) {
+	const directionTransforms = transforms?.[ direction ];
+	if ( ! transforms || ! Array.isArray( directionTransforms ) ) {
 		return [];
 	}
 
@@ -450,7 +451,7 @@ export function getBlockTransforms(
 		transforms.supportedMobileTransforms &&
 		Array.isArray( transforms.supportedMobileTransforms );
 	const filteredTransforms = usingMobileTransformations
-		? transforms[ direction ].filter( ( t ) => {
+		? directionTransforms.filter( ( t ) => {
 				if ( t.type === 'raw' ) {
 					return true;
 				}
@@ -473,7 +474,7 @@ export function getBlockTransforms(
 					)
 				);
 		  } )
-		: transforms[ direction ];
+		: directionTransforms;
 
 	// Map transforms to normal form.
 	return filteredTransforms.map( ( transform ) => ( {

--- a/test/e2e/specs/editor/blocks/shortcode.spec.js
+++ b/test/e2e/specs/editor/blocks/shortcode.spec.js
@@ -1,0 +1,80 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Shortcode', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'should transform to a matching block when the text is a single recognized shortcode', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/shortcode',
+			attributes: { text: '[gallery ids="1,2,3"]' },
+		} );
+		await editor.clickBlockToolbarButton( 'Shortcode' );
+		await page
+			.getByRole( 'menu', { name: 'Shortcode' } )
+			.getByRole( 'menuitem', { name: 'Gallery' } )
+			.click();
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/gallery',
+				innerBlocks: [
+					{ name: 'core/image', attributes: { id: 1 } },
+					{ name: 'core/image', attributes: { id: 2 } },
+					{ name: 'core/image', attributes: { id: 3 } },
+				],
+			},
+		] );
+	} );
+
+	test( 'should not offer transforms when the text is not a recognized shortcode', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/shortcode',
+			attributes: { text: '[totally_unknown_shortcode_tag]' },
+		} );
+		await editor.clickBlockToolbarButton( 'Shortcode' );
+
+		const transformations = page
+			.getByRole( 'menu', { name: 'Shortcode' } )
+			.getByRole( 'menuitem' );
+		await expect( transformations ).toHaveCount( 3 );
+		await expect( transformations ).toHaveText( [
+			'Columns',
+			'Details',
+			'Group',
+		] );
+	} );
+
+	test( 'should not offer transforms when the text contains more than one shortcode', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/shortcode',
+			attributes: {
+				text: '[gallery ids="1,2,3"] [gallery ids="4,5,6"]',
+			},
+		} );
+		await editor.clickBlockToolbarButton( 'Shortcode' );
+
+		const transformations = page
+			.getByRole( 'menu', { name: 'Shortcode' } )
+			.getByRole( 'menuitem' );
+		await expect( transformations ).toHaveCount( 3 );
+		await expect( transformations ).toHaveText( [
+			'Columns',
+			'Details',
+			'Group',
+		] );
+	} );
+} );


### PR DESCRIPTION
## What?
Closes #8569.

PR aims to provide more intelligent transformations for shortcodes. It adds a "Transform to" option in the Shortcode block when the text consists of a single shortcode that matches a block's registered `type: 'shortcode'` from-transform. For example, a Shortcode block containing `[gallery ids="…"]` will now offer the option to convert it into a Gallery block.

## Why?
If a user converts content to blocks before a plugin or core provides its block alternative, their shortcodes remain stuck in `core/shortcode` indefinitely, even after a matching transform has been registered. See #8569.

## Testing Instructions
1. Create a post and add a shortcode block.
2. Use any shortcode that supports transformations - `[embed]https://www.youtube.com/watch?v=FcTLMTyD2DU[/embed]`.
3. Opens "Transforms to" menu.
4. Confirm that the correct block is suggested.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/dcf559a4-c62e-4945-9f2c-5c3318f9c37c

## Use of AI Tools

Iterated using Claude, reviewed and tested manually.
