### PR TITLE
LinkControl: Show advanced settings when initially creating a link

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -628,8 +628,12 @@ function LinkControl( {
 	// When editing an existing link, also require that the value has changed
 	const isDisabled =
 		currentInputIsEmpty || ! isUrlValid || ( value && ! valueHasChanges );
-	const showSettings = !! settings?.length && isEditingLink && hasLinkValue;
-
+	const showSettings =
+		!! settings?.length &&
+		isEditingLink &&
+		( hasLinkValue || isURLLike( currentUrlInputValue ) );
+	const toolsStyle =
+		showSettings && ! hasLinkValue ? { marginBottom: '15px' } : undefined;
 	const previewValue = useMemo( () => {
 		// There is a chance that the value is not yet set from the entity binding, so we use the preserved URL.
 		if (
@@ -752,7 +756,12 @@ function LinkControl( {
 			) }
 
 			{ showSettings && (
-				<div className="block-editor-link-control__tools">
+				<div
+					className={ clsx( {
+						'block-editor-link-control__tools': true,
+						'suggest-advance-options': toolsStyle,
+					} ) }
+				>
 					{ ! currentInputIsEmpty && (
 						<LinkControlSettingsDrawer
 							settingsOpen={ isSettingsOpen }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -361,6 +361,10 @@ $block-editor-link-control-number-of-actions: 1;
 	padding: $grid-unit-10 $grid-unit-10 0 $grid-unit-10;
 	margin-top: #{$grid-unit-20 * -1};
 
+	&.suggest-advance-options {
+		margin-bottom: $grid-unit-20;
+	}
+
 	.components-button.block-editor-link-control__drawer-toggle {
 		padding-left: 0;
 		gap: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #71143

This PR updates the `LinkControl` component to display the advanced settings drawer (which includes the "Open in new tab" toggle) when a user initially creates a link by typing a URL, rather than restricting it strictly to editing an already established link.

## Why?
Currently, when a user creates a link from plain text, they have to submit the link first, click it again to edit it, and then toggle the "Open in new tab" option. This two-step process adds unnecessary friction. By exposing the settings drawer during the initial creation phase as soon as a valid URL is typed, we streamline the workflow and improve the overall editing experience.

## How?
Allowed the settings drawer to render if the current input is URL like. Added a conditional bottom spacing.

## Testing Instructions

1. Open a post or page in the editor.
2. Insert a Paragraph block and type some plain text.
3. Highlight a word and click the Link icon in the block toolbar.
4. Begin typing a URL (e.g., wordpress.org).
5. Verify the "Advanced" settings should appear underneath the search input.
6. Toggle settings like "Open in new tab" on, and hit Enter (or click Apply).
7. Select the link again or check the code editor to confirm the `target="_blank"` attribute was successfully applied.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="700" height="252" alt="image" src="https://github.com/user-attachments/assets/d7857f3b-33cb-472a-94e1-70fa6d687c37" />|<img width="698" height="544" alt="image" src="https://github.com/user-attachments/assets/a0bd4269-def1-438e-98bc-680a35bc0dca" />|