### PR TITLE
Paste: preserve leading number when pasting single-line text like dates

### DIFF
--- a/packages/blocks/src/api/raw-handling/markdown-converter.ts
+++ b/packages/blocks/src/api/raw-handling/markdown-converter.ts
@@ -48,6 +48,12 @@ function escapeSingleLineOrderedListMarker( text: string ): string {
 	return text.replace( /^(\d+)\.(\s)/, '$1\\.$2' );
 }
 
+const correctors = [
+	escapeSingleLineOrderedListMarker,
+	bulletsToAsterisks,
+	slackMarkdownVariantCorrector,
+];
+
 /**
  * Converts a piece of text into HTML based on any Markdown present.
  * Also decodes any encoded HTML.
@@ -58,8 +64,9 @@ function escapeSingleLineOrderedListMarker( text: string ): string {
  */
 export default function markdownConverter( text: string ): string {
 	return converter.makeHtml(
-		slackMarkdownVariantCorrector(
-			bulletsToAsterisks( escapeSingleLineOrderedListMarker( text ) )
+		correctors.reduce(
+			( current, corrector ) => corrector( current ),
+			text
 		)
 	);
 }

--- a/packages/blocks/src/api/raw-handling/markdown-converter.ts
+++ b/packages/blocks/src/api/raw-handling/markdown-converter.ts
@@ -36,6 +36,19 @@ function bulletsToAsterisks( text: string ): string {
 }
 
 /**
+ * Escapes an ordered-list marker at the start of single-line input so prose
+ * like "18. May 2021" isn't parsed as `<ol start="18"><li>May 2021</li></ol>`.
+ *
+ * @param text The potential Markdown text to correct.
+ */
+function escapeSingleLineOrderedListMarker( text: string ): string {
+	if ( text.includes( '\n' ) ) {
+		return text;
+	}
+	return text.replace( /^(\d+)\.(\s)/, '$1\\.$2' );
+}
+
+/**
  * Converts a piece of text into HTML based on any Markdown present.
  * Also decodes any encoded HTML.
  *
@@ -45,6 +58,8 @@ function bulletsToAsterisks( text: string ): string {
  */
 export default function markdownConverter( text: string ): string {
 	return converter.makeHtml(
-		slackMarkdownVariantCorrector( bulletsToAsterisks( text ) )
+		slackMarkdownVariantCorrector(
+			bulletsToAsterisks( escapeSingleLineOrderedListMarker( text ) )
+		)
 	);
 }

--- a/packages/blocks/src/api/raw-handling/test/markdown-converter.js
+++ b/packages/blocks/src/api/raw-handling/test/markdown-converter.js
@@ -27,4 +27,21 @@ describe( 'markdownConverter', () => {
 		const output = '<pre><code class="js language-js">test</code></pre>';
 		expect( markdownConverter( input ) ).toEqual( output );
 	} );
+
+	it( 'should not convert single-line date string into an ordered list', () => {
+		const input = '18. May 2021';
+		const output = '<p>18. May 2021</p>';
+		expect( markdownConverter( input ) ).toEqual( output );
+	} );
+
+	it( 'should not convert single-line "1. foo" into an ordered list', () => {
+		const input = '1. foo';
+		const output = '<p>1. foo</p>';
+		expect( markdownConverter( input ) ).toEqual( output );
+	} );
+
+	it( 'should still convert multi-line ordered list', () => {
+		const input = '1. apple\n2. banana';
+		expect( markdownConverter( input ) ).toContain( '<ol>' );
+	} );
 } );

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -814,6 +814,22 @@ test.describe( 'Copy/cut/paste', () => {
 		] );
 	} );
 
+	// See https://github.com/WordPress/gutenberg/issues/28149
+	test( 'should not convert pasted date string into an ordered list', async ( {
+		editor,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( { name: 'core/paragraph' } );
+		pageUtils.setClipboardData( { plainText: '4. May 2026' } );
+		await pageUtils.pressKeys( 'primary+v' );
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: '4. May 2026' },
+			},
+		] );
+	} );
+
 	test( 'should replace the default block on paste when the content is unmodified', async ( {
 		editor,
 		pageUtils,


### PR DESCRIPTION
## What?
Fixes #28149 (and the same root cause in #33312).

PR fixes a bug when pasting plain text starting with `<digits>.` (e.g. `18. May 2021`, `4. May 2026`) dropped the leading number, leaving only `May 2021`.

Showdown was parsing the leading `N.` as an ordered-list marker → `<ol start="18"><li>May 2021</li></ol>` → list block → inlined as a single inlineable block, stripping the `<ol>` wrapper and losing the start number.

In `markdown-converter.ts`, escape the dot (`N\.`) before Showdown sees it, but only when the input is a single line. Multi-line ordered lists are unaffected.

## Testing Instructions
1. Create a post.
2. Add paragraph block.
3. Try pasting a date - `18. May 2021`.
4. The test should be pasted without removing the starting digit.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Claude for diagnosing. Reviewed and tested manually.
