### PR TITLE
Media & Text: clip media to block border-radius using overflow: clip

### DIFF
--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -10,6 +10,11 @@
 	grid-template-rows: auto;
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
+	// Clip the media element so it respects any border-radius applied to the block.
+	// `overflow: hidden` is provided as a fallback for browsers that don't support `overflow: clip`.
+	overflow: hidden;
+	// Use clip instead of hidden so that sticky position works on child elements.
+	overflow: clip;
 
 	&.has-media-on-the-right {
 		grid-template-columns: 1fr 50%;


### PR DESCRIPTION
## What?

When a `border-radius` is applied to the Media & Text block (via block controls or Global Styles), the inner media element overflows the rounded corners rather than being clipped by them. This affects both the **frontend** and the **block editor canvas**.

Fixes #69596
Related: EDI-481 (Automattic internal issue tracker)

## Why?

The block applies `border-radius` to the outer `.wp-block-media-text` container, but the inner `<figure>` and its image/video overflow the rounded corners because there is nothing clipping them.

## How?

The cover block already solves the exact same problem using `overflow: hidden` as a fallback and `overflow: clip` as the preferred value — `overflow: clip` is preferred because it does **not** create a new block formatting context, meaning `position: sticky` continues to work on child elements (unlike `overflow: hidden`).

Apply the same two-line pattern to `.wp-block-media-text` in `style.scss`:

```scss
overflow: hidden; // fallback for browsers without overflow: clip support
overflow: clip;   // preferred: clips at border-radius without breaking sticky positioning
```

This is a **CSS-only fix**:
- No `save.js` changes → no new deprecated block version required
- Works for border-radius set via inline block controls **and** via Global Styles (since the clip is always active)
- Fixes both the frontend and the editor canvas (both surfaces load from the same `style.scss` source — frontend via `wp-includes/blocks/media-text/style.css`, editor via the aggregated `wp-includes/css/dist/block-library/style.css`)
- Follows an established pattern already used in the cover block

## Testing Instructions

1. Add a Media & Text block with an image
2. In the block sidebar under **Border**, set a **Color** (so the border is clearly visible) and a **Radius** (e.g. 24px) — requires a block theme or a theme with `appearanceTools` enabled
3. Confirm the image is clipped at the rounded corners **in the editor canvas**
4. View the post on the **frontend** — confirm the image is clipped there too
5. Test with **Global Styles** → set a border color and radius on the Media & Text block type → confirm it clips on both surfaces
6. Test the **image fill** (`is-image-fill-element`) variant — confirm it also clips correctly
7. Test the **stacked on mobile** layout — confirm the top image clips at the top corners
8. Confirm the column **resize handle** still works in the editor (drag the boundary between media and content)
9. Confirm no visual regressions on blocks **without** border-radius set

🤖 Generated with [Claude Code](https://claude.com/claude-code)