### PR TITLE
Blocks: Migrate Markdown converter from showdown to marked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47907,7 +47907,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"hpq": "^1.3.0",
 				"is-plain-object": "^5.0.0",
-				"marked": "18.0.3",
+				"marked": "^18.0.3",
 				"memize": "^2.1.0",
 				"react-is": "^18.3.0",
 				"remove-accents": "^0.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23723,11 +23723,6 @@
 				"url": "https://github.com/sindresorhus/emittery?sponsor=1"
 			}
 		},
-		"node_modules/emoji-regex": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-		},
 		"node_modules/emojis-list": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -28235,14 +28230,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-fullwidth-code-point": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/is-generator-fn": {
@@ -32910,6 +32897,18 @@
 			"resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.16.0.tgz",
 			"integrity": "sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w=="
 		},
+		"node_modules/marked": {
+			"version": "18.0.3",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+			"integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
 		"node_modules/marky": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
@@ -37124,6 +37123,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
 			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -39731,11 +39731,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/require-main-filename": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-		},
 		"node_modules/requireindex": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -41105,11 +41100,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
-		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -41287,166 +41277,6 @@
 			"integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/showdown": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
-			"integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
-			"dependencies": {
-				"yargs": "^14.2"
-			},
-			"bin": {
-				"showdown": "bin/showdown.js"
-			}
-		},
-		"node_modules/showdown/node_modules/ansi-regex": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-			"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/showdown/node_modules/cliui": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-			"dependencies": {
-				"string-width": "^3.1.0",
-				"strip-ansi": "^5.2.0",
-				"wrap-ansi": "^5.1.0"
-			}
-		},
-		"node_modules/showdown/node_modules/find-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-			"dependencies": {
-				"locate-path": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-			"dependencies": {
-				"p-locate": "^3.0.0",
-				"path-exists": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dependencies": {
-				"p-try": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/showdown/node_modules/p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-			"dependencies": {
-				"p-limit": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/string-width": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-			"dependencies": {
-				"emoji-regex": "^7.0.1",
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^5.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/strip-ansi": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-			"dependencies": {
-				"ansi-regex": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/wrap-ansi": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-			"dependencies": {
-				"ansi-styles": "^3.2.0",
-				"string-width": "^3.0.0",
-				"strip-ansi": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/yargs": {
-			"version": "14.2.3",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-			"integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-			"dependencies": {
-				"cliui": "^5.0.0",
-				"decamelize": "^1.2.0",
-				"find-up": "^3.0.0",
-				"get-caller-file": "^2.0.1",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^2.0.0",
-				"set-blocking": "^2.0.0",
-				"string-width": "^3.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
-				"yargs-parser": "^15.0.1"
-			}
-		},
-		"node_modules/showdown/node_modules/yargs-parser": {
-			"version": "15.0.3",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
-			"integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
-			"dependencies": {
-				"camelcase": "^5.0.0",
-				"decamelize": "^1.2.0"
 			}
 		},
 		"node_modules/side-channel": {
@@ -46568,11 +46398,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/which-module": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
-		},
 		"node_modules/which-typed-array": {
 			"version": "1.1.19",
 			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
@@ -47038,7 +46863,8 @@
 		"node_modules/y18n": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+			"dev": true
 		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
@@ -48081,10 +47907,10 @@
 				"fast-deep-equal": "^3.1.3",
 				"hpq": "^1.3.0",
 				"is-plain-object": "^5.0.0",
+				"marked": "18.0.3",
 				"memize": "^2.1.0",
 				"react-is": "^18.3.0",
 				"remove-accents": "^0.5.0",
-				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
 				"uuid": "^14.0.0"
 			},

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+- Replace `showdown` with `marked` for Markdown paste handling. Smaller bundle, modern maintenance, native types.
+
 ## 15.21.0 (2026-06-10)
 
 ### Code Quality

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -71,10 +71,10 @@
 		"fast-deep-equal": "^3.1.3",
 		"hpq": "^1.3.0",
 		"is-plain-object": "^5.0.0",
+		"marked": "18.0.3",
 		"memize": "^2.1.0",
 		"react-is": "^18.3.0",
 		"remove-accents": "^0.5.0",
-		"showdown": "^1.9.1",
 		"simple-html-tokenizer": "^0.5.7",
 		"uuid": "^14.0.0"
 	},

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -71,7 +71,7 @@
 		"fast-deep-equal": "^3.1.3",
 		"hpq": "^1.3.0",
 		"is-plain-object": "^5.0.0",
-		"marked": "18.0.3",
+		"marked": "^18.0.3",
 		"memize": "^2.1.0",
 		"react-is": "^18.3.0",
 		"remove-accents": "^0.5.0",

--- a/packages/blocks/src/api/raw-handling/markdown-converter.ts
+++ b/packages/blocks/src/api/raw-handling/markdown-converter.ts
@@ -20,7 +20,7 @@ const converter = new Marked( {
 		// before `</code>`, which leaks into the Code block's content as a
 		// trailing blank line.
 		code( { text, lang }: Tokens.Code ): string {
-			const language = ( lang || '' ).match( /\S*/ )?.[ 0 ];
+			const language = ( lang || '' ).match( /^\S*/ )?.[ 0 ];
 			const cls = language
 				? ` class="${ language } language-${ language }"`
 				: '';

--- a/packages/blocks/src/api/raw-handling/markdown-converter.ts
+++ b/packages/blocks/src/api/raw-handling/markdown-converter.ts
@@ -1,17 +1,29 @@
 /**
  * External dependencies
  */
-// @ts-ignore
-import showdown from 'showdown';
+import { Marked, type Tokens } from 'marked';
 
-// Reuse the same showdown converter.
-const converter = new showdown.Converter( {
-	noHeaderId: true,
-	tables: true,
-	literalMidWordUnderscores: true,
-	omitExtraWLInCodeBlocks: true,
-	simpleLineBreaks: true,
-	strikethrough: true,
+const converter = new Marked( {
+	gfm: true,
+	breaks: true,
+	renderer: {
+		// Match showdown's `omitExtraWLInCodeBlocks`: marked appends `\n`
+		// before `</code>`, which leaks into the Code block's content as a
+		// trailing blank line.
+		code( { text, lang }: Tokens.Code ): string {
+			const language = ( lang || '' ).match( /\S*/ )?.[ 0 ];
+			const cls = language
+				? ` class="${ language } language-${ language }"`
+				: '';
+			const escaped = text
+				.replace( /&(?!#?\w+;)/g, '&amp;' )
+				.replace( /</g, '&lt;' )
+				.replace( />/g, '&gt;' )
+				.replace( /"/g, '&quot;' )
+				.replace( /'/g, '&#39;' );
+			return `<pre><code${ cls }>${ escaped }</code></pre>`;
+		},
+	},
 } );
 
 /**
@@ -63,10 +75,11 @@ const correctors = [
  * @return HTML.
  */
 export default function markdownConverter( text: string ): string {
-	return converter.makeHtml(
+	return converter.parse(
 		correctors.reduce(
 			( current, corrector ) => corrector( current ),
 			text
-		)
+		),
+		{ async: false }
 	);
 }

--- a/packages/blocks/src/api/raw-handling/markdown-converter.ts
+++ b/packages/blocks/src/api/raw-handling/markdown-converter.ts
@@ -3,6 +3,15 @@
  */
 import { Marked, type Tokens } from 'marked';
 
+// Skip escaping `"` and `'` so shortcodes like `[gallery ids="123"]` survive
+// for the shortcode converter to match.
+function escapeBodyText( value: string ): string {
+	return value
+		.replace( /&(?!#?\w+;)/g, '&amp;' )
+		.replace( /</g, '&lt;' )
+		.replace( />/g, '&gt;' );
+}
+
 const converter = new Marked( {
 	gfm: true,
 	breaks: true,
@@ -15,13 +24,18 @@ const converter = new Marked( {
 			const cls = language
 				? ` class="${ language } language-${ language }"`
 				: '';
-			const escaped = text
-				.replace( /&(?!#?\w+;)/g, '&amp;' )
-				.replace( /</g, '&lt;' )
-				.replace( />/g, '&gt;' )
-				.replace( /"/g, '&quot;' )
-				.replace( /'/g, '&#39;' );
-			return `<pre><code${ cls }>${ escaped }</code></pre>`;
+			return `<pre><code${ cls }>${ escapeBodyText(
+				text
+			) }</code></pre>`;
+		},
+		text( this: any, token: Tokens.Text | Tokens.Escape ): string {
+			if ( 'tokens' in token && token.tokens ) {
+				return this.parser.parseInline( token.tokens );
+			}
+			if ( 'escaped' in token && token.escaped ) {
+				return token.text;
+			}
+			return escapeBodyText( token.text );
 		},
 	},
 } );

--- a/packages/blocks/src/api/raw-handling/markdown-converter.ts
+++ b/packages/blocks/src/api/raw-handling/markdown-converter.ts
@@ -28,12 +28,15 @@ const converter = new Marked( {
 				text
 			) }</code></pre>`;
 		},
-		text( this: any, token: Tokens.Text | Tokens.Escape ): string {
-			if ( 'tokens' in token && token.tokens ) {
-				return this.parser.parseInline( token.tokens );
-			}
-			if ( 'escaped' in token && token.escaped ) {
-				return token.text;
+		text( token: Tokens.Text | Tokens.Escape ): string | false {
+			// Only the plain-text case differs (skip escaping quotes);
+			// defer inline tokens and already-escaped text to marked's
+			// default by returning `false`.
+			if (
+				( 'tokens' in token && token.tokens ) ||
+				( 'escaped' in token && token.escaped )
+			) {
+				return false;
 			}
 			return escapeBodyText( token.text );
 		},

--- a/packages/blocks/src/api/raw-handling/test/markdown-converter.js
+++ b/packages/blocks/src/api/raw-handling/test/markdown-converter.js
@@ -12,13 +12,13 @@ describe( 'markdownConverter', () => {
 
 	it( 'should correct Slack variant on own line', () => {
 		const input = 'test\n```test```\ntest';
-		const output = '<p>test</p>\n<pre><code>test</code></pre>\n<p>test</p>';
+		const output = '<p>test</p>\n<pre><code>test</code></pre><p>test</p>\n';
 		expect( markdownConverter( input ) ).toEqual( output );
 	} );
 
 	it( 'should not correct inline code', () => {
 		const input = 'test ```test``` test';
-		const output = '<p>test <code>test</code> test</p>';
+		const output = '<p>test <code>test</code> test</p>\n';
 		expect( markdownConverter( input ) ).toEqual( output );
 	} );
 
@@ -43,5 +43,12 @@ describe( 'markdownConverter', () => {
 	it( 'should still convert multi-line ordered list', () => {
 		const input = '1. apple\n2. banana';
 		expect( markdownConverter( input ) ).toContain( '<ol>' );
+	} );
+
+	it( 'should convert bullet characters to asterisks', () => {
+		const input = '• one\n• two';
+		expect( markdownConverter( input ) ).toContain( '<ul>' );
+		expect( markdownConverter( input ) ).toContain( '<li>one</li>' );
+		expect( markdownConverter( input ) ).toContain( '<li>two</li>' );
 	} );
 } );

--- a/packages/blocks/src/api/raw-handling/test/markdown-converter.js
+++ b/packages/blocks/src/api/raw-handling/test/markdown-converter.js
@@ -30,13 +30,13 @@ describe( 'markdownConverter', () => {
 
 	it( 'should not convert single-line date string into an ordered list', () => {
 		const input = '18. May 2021';
-		const output = '<p>18. May 2021</p>';
+		const output = '<p>18. May 2021</p>\n';
 		expect( markdownConverter( input ) ).toEqual( output );
 	} );
 
 	it( 'should not convert single-line "1. foo" into an ordered list', () => {
 		const input = '1. foo';
-		const output = '<p>1. foo</p>';
+		const output = '<p>1. foo</p>\n';
 		expect( markdownConverter( input ) ).toEqual( output );
 	} );
 
@@ -50,5 +50,10 @@ describe( 'markdownConverter', () => {
 		expect( markdownConverter( input ) ).toContain( '<ul>' );
 		expect( markdownConverter( input ) ).toContain( '<li>one</li>' );
 		expect( markdownConverter( input ) ).toContain( '<li>two</li>' );
+	} );
+
+	it( 'should preserve quotes in body text for shortcode matching', () => {
+		const input = '[gallery ids="123"]';
+		expect( markdownConverter( input ) ).toContain( '[gallery ids="123"]' );
 	} );
 } );

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -73,7 +73,7 @@ module.exports = {
 		'^.+\\.m?[jt]sx?$': '<rootDir>/test/unit/scripts/babel-transformer.js',
 	},
 	transformIgnorePatterns: [
-		'/node_modules/(?!(docker-compose|yaml|preact|@preact|parsel-js|comctx|uuid)/)',
+		'/node_modules/(?!(docker-compose|yaml|preact|@preact|parsel-js|comctx|uuid|marked)/)',
 		'\\.pnp\\.[^\\/]+$',
 	],
 	snapshotSerializers: [


### PR DESCRIPTION
## What?
Another attempt at #21972.

Replaces `showdown@1.9.1` (last released 2018) with `marked@18` for Markdown paste handling.

### Benefits

- **Smaller bundle**: marked min+gz ≈ ~14KB vs showdown ≈ ~30KB; also drops transitive `yargs@14` tree.
- **Active maintenance**: marked v18 with regular releases vs showdown stagnant (last 1.x: 2018; 2.x: 2022).
- **Native TypeScript types**: drops the `@ts-ignore` on the import.
- **CommonMark/GFM compliant**: showdown predates the GFM spec and emulates it via flags.
- **Faster parse**.
- **Extensible tokenizer**: cleaner home for future custom rules than regex correctors.

## Testing Instructions
1. Open a post or page.
2. Try pasting (CMD+SHIFT+V) some markdown text.
3. Behavior should be the same as on trunk.

<details><summary>Example</summary>
<p>

``````markdown
# Heading

this is para

> A note

```js
somecode();
```

## Subheading

- List item 1
- List item 2

> Another note

### Sub-subheading
[A link](https://example.com)
![An image](https://example.com/image.png)

---
a section break
---

| Table | Example |
|---|---|
| Cell 1 | Cell 2 |
``````

</p>
</details> 

## Use of AI Tools

Migration done via Claude, review manually.
