### PR TITLE
Site Editor: Preserve non-global editor styles in pattern previews

### DIFF
--- a/packages/edit-site/src/components/page-patterns/use-pattern-settings.js
+++ b/packages/edit-site/src/components/page-patterns/use-pattern-settings.js
@@ -64,9 +64,14 @@ export default function usePatternSettings() {
 			...restStoredSettings
 		} = storedSettings;
 
+		// Preserve non-global styles from settings.styles (e.g., editor styles from add_editor_style)
+		const nonGlobalStyles = ( styles ?? [] ).filter(
+			( style ) => ! style.isGlobalStyles
+		);
+
 		return {
 			...restStoredSettings,
-			styles: globalStyles,
+			styles: [ ...nonGlobalStyles, ...globalStyles ],
 			__experimentalFeatures: globalSettings,
 			[ globalStylesDataKey ]: mergedConfig.styles ?? {},
 			__experimentalBlockPatterns: blockPatterns,


### PR DESCRIPTION
## What?

- Closes: #75779
- Follow up to:
  -  #73952 
  - #74088

Restore non-global styles (e.g. those registered via `add_editor_style()`) inside pattern previews on the Site Editor's Patterns page.

## Why?

#73952 replaced `settings.styles` with the output of `generateGlobalStyles`, which only emits styles tagged with `isGlobalStyles: true`. As a side effect, theme editor styles registered via `add_editor_style()` were dropped from any place that rebuilt `settings.styles` from generated global styles.

## How?

Apply the same `isGlobalStyles` filter pattern used in #74088 to `usePatternSettings`.

## Testing Instructions

1. Apply the following change to `test/emptytheme/style.css` so theme editor styles produce a clearly visible effect:
   ```diff
   --- a/test/emptytheme/style.css
   +++ b/test/emptytheme/style.css
   @@ -13,3 +13,7 @@ Text Domain: emptytheme
    Emptytheme WordPress Theme, (C) 2021 WordPress.org
    Emptytheme is distributed under the terms of the GNU GPL.
    */
   +
   +p {
   +	background-color: red !important;
   +}
   ```
   `emptytheme` already calls `add_editor_style( 'style.css' )`.
2. Activate **Emptytheme**.
3. Create a pattern that contains at least one paragraph block.
4. Open the Patterns page in the Site Editor.
5. Confirm that the paragraph in the pattern thumbnail has a red background.

## Screenshots or screencast

### Before

<img width="1074" height="616" alt="image" src="https://github.com/user-attachments/assets/c9fa598e-6ae4-40a2-90ce-9dcd4a4a8c74" />

### After

<img width="1062" height="616" alt="image" src="https://github.com/user-attachments/assets/77665cee-32e4-4d2f-822b-f1d80355ebac" />

## Use of AI Tools

This PR was prepared with assistance from Claude Code (Anthropic Claude Opus 4.7). All code and the description were reviewed by the author before submission.
