### PR TITLE
Widget Types: server-side registry, decouple wp-build pages

### DIFF
--- a/lib/experimental/dashboard-widgets/class-wp-widget-type-registry.php
+++ b/lib/experimental/dashboard-widgets/class-wp-widget-type-registry.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Widget Types API: WP_Widget_Type_Registry class.
+ *
+ * @package gutenberg
+ */
+
+if ( ! class_exists( 'WP_Widget_Type_Registry' ) ) {
+
+	/**
+	 * Internal class used for interacting with widget types.
+	 *
+	 * Singleton registry that stores `WP_Widget_Type` instances keyed by their
+	 * namespaced name. Hydrated once per request from the build manifest at
+	 * `init`; consumers query the registry instead of re-parsing the manifest.
+	 */
+	#[AllowDynamicProperties]
+	final class WP_Widget_Type_Registry {
+
+		/**
+		 * Registered widget types, as `$name => $instance` pairs.
+		 *
+		 * @var WP_Widget_Type[]
+		 */
+		private $registered_widget_types = array();
+
+		/**
+		 * Container for the main instance of the class.
+		 *
+		 * @var WP_Widget_Type_Registry|null
+		 */
+		private static $instance = null;
+
+		/**
+		 * Registers a widget type.
+		 *
+		 * @param string|WP_Widget_Type $name Widget type name including
+		 *                                    namespace, or alternatively a
+		 *                                    complete WP_Widget_Type instance.
+		 *                                    When an instance is provided the
+		 *                                    `$args` parameter is ignored.
+		 * @param array                 $args Optional. Array of widget type
+		 *                                    arguments. Accepts any public
+		 *                                    property of `WP_Widget_Type`.
+		 *                                    Default empty array.
+		 * @return WP_Widget_Type|false The registered widget type on success,
+		 *                              or false on failure.
+		 */
+		public function register( $name, $args = array() ) {
+			$widget_type = null;
+			if ( $name instanceof WP_Widget_Type ) {
+				$widget_type = $name;
+				$name        = $widget_type->name;
+			}
+
+			if ( ! is_string( $name ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Widget type names must be strings.', 'gutenberg' ),
+					'23.1.0'
+				);
+				return false;
+			}
+
+			if ( preg_match( '/[A-Z]+/', $name ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Widget type names must not contain uppercase characters.', 'gutenberg' ),
+					'23.1.0'
+				);
+				return false;
+			}
+
+			$name_matcher = '/^[a-z0-9-]+\/[a-z0-9-]+$/';
+			if ( ! preg_match( $name_matcher, $name ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Widget type names must contain a namespace prefix. Example: my-plugin/my-custom-widget-type', 'gutenberg' ),
+					'23.1.0'
+				);
+				return false;
+			}
+
+			if ( $this->is_registered( $name ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					/* translators: %s: Widget type name. */
+					sprintf( __( 'Widget type "%s" is already registered.', 'gutenberg' ), $name ),
+					'23.1.0'
+				);
+				return false;
+			}
+
+			if ( ! $widget_type ) {
+				$widget_type = new WP_Widget_Type( $name, $args );
+			}
+
+			$this->registered_widget_types[ $name ] = $widget_type;
+
+			return $widget_type;
+		}
+
+		/**
+		 * Unregisters a widget type.
+		 *
+		 * @param string|WP_Widget_Type $name Widget type name including
+		 *                                    namespace, or alternatively a
+		 *                                    complete WP_Widget_Type instance.
+		 * @return WP_Widget_Type|false The unregistered widget type on success,
+		 *                              or false on failure.
+		 */
+		public function unregister( $name ) {
+			if ( $name instanceof WP_Widget_Type ) {
+				$name = $name->name;
+			}
+
+			if ( ! $this->is_registered( $name ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					/* translators: %s: Widget type name. */
+					sprintf( __( 'Widget type "%s" is not registered.', 'gutenberg' ), $name ),
+					'23.1.0'
+				);
+				return false;
+			}
+
+			$unregistered_widget_type = $this->registered_widget_types[ $name ];
+			unset( $this->registered_widget_types[ $name ] );
+
+			return $unregistered_widget_type;
+		}
+
+		/**
+		 * Retrieves a registered widget type.
+		 *
+		 * @param string $name Widget type name including namespace.
+		 * @return WP_Widget_Type|null The registered widget type, or null if it
+		 *                             is not registered.
+		 */
+		public function get_registered( $name ) {
+			if ( ! $this->is_registered( $name ) ) {
+				return null;
+			}
+
+			return $this->registered_widget_types[ $name ];
+		}
+
+		/**
+		 * Retrieves all registered widget types.
+		 *
+		 * @return WP_Widget_Type[] Associative array of `$name => $widget_type`
+		 *                          pairs.
+		 */
+		public function get_all_registered() {
+			return $this->registered_widget_types;
+		}
+
+		/**
+		 * Checks if a widget type is registered.
+		 *
+		 * @param string $name Widget type name including namespace.
+		 * @return bool True if the widget type is registered, false otherwise.
+		 */
+		public function is_registered( $name ) {
+			return isset( $this->registered_widget_types[ $name ] );
+		}
+
+		/**
+		 * Utility method to retrieve the main instance of the class.
+		 *
+		 * The instance will be created if it does not exist yet.
+		 *
+		 * @return WP_Widget_Type_Registry The main instance.
+		 */
+		public static function get_instance() {
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+			}
+
+			return self::$instance;
+		}
+	}
+}

--- a/lib/experimental/dashboard-widgets/class-wp-widget-type.php
+++ b/lib/experimental/dashboard-widgets/class-wp-widget-type.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Widget Types API: WP_Widget_Type class.
+ *
+ * @package gutenberg
+ */
+
+if ( ! class_exists( 'WP_Widget_Type' ) ) {
+
+	/**
+	 * Internal class representing a widget type.
+	 *
+	 * Holds the metadata for a widget discovered by the build pipeline. Stored
+	 * inside `WP_Widget_Type_Registry` once registered, and consumed by surface
+	 * code that needs to enumerate or look up widget types.
+	 *
+	 * The shape is intentionally minimal: identity (`name`) plus the
+	 * script-module handles the build pipeline produced for the widget.
+	 * Placement and surface concerns (which page or sidebar uses the widget)
+	 * live with the consumer, not on the type definition.
+	 */
+	#[AllowDynamicProperties]
+	class WP_Widget_Type {
+
+		/**
+		 * Widget type key. Namespaced identifier, e.g. `wordpress/hello-world`.
+		 *
+		 * @var string
+		 */
+		public $name;
+
+		/**
+		 * Script-module handle for the widget render module.
+		 *
+		 * Null when the widget folder did not ship a render entry point at
+		 * build time.
+		 *
+		 * @var string|null
+		 */
+		public $render_module = null;
+
+		/**
+		 * Script-module handle for the widget metadata module.
+		 *
+		 * Null when the widget folder did not ship a widget entry point at
+		 * build time.
+		 *
+		 * @var string|null
+		 */
+		public $widget_module = null;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string $name Widget type name including namespace.
+		 * @param array  $args Optional. Widget type arguments. Each key is
+		 *                     copied onto the corresponding object property.
+		 *                     Default empty array.
+		 */
+		public function __construct( $name, $args = array() ) {
+			$this->name = $name;
+			$this->set_props( $args );
+		}
+
+		/**
+		 * Returns whether this widget type ships a renderable script module.
+		 *
+		 * @return bool
+		 */
+		public function is_renderable() {
+			return ! empty( $this->render_module );
+		}
+
+		/**
+		 * Hydrates the widget type properties from the args array.
+		 *
+		 * @param array $args Widget type arguments.
+		 */
+		public function set_props( $args ) {
+			if ( ! is_array( $args ) ) {
+				return;
+			}
+
+			unset( $args['name'] );
+
+			foreach ( $args as $property_name => $property_value ) {
+				$this->$property_name = $property_value;
+			}
+		}
+	}
+}

--- a/lib/experimental/dashboard-widgets/widget-types.php
+++ b/lib/experimental/dashboard-widgets/widget-types.php
@@ -1,45 +1,96 @@
 <?php
 /**
- * Widget types client bootstrap.
+ * Widget Types: server-side registry and client bootstrap.
  *
- * Temporary bridge: exposes the build-discovered widgets to the client as
- * the `window.__registeredWidgetTypes` global so the `core/widget-types`
- * resolver has data to read on first paint. Globals on `window` are not
- * the desired surface; this is a stopgap until a REST endpoint backed by
- * a server-side registry takes over and the resolver fetches via
- * `apiFetch`.
+ * Hydrates `WP_Widget_Type_Registry` from the build manifest at `init`, and
+ * exposes the registered widget types to the dashboard client through a
+ * temporary inline global (`window.__registeredWidgetTypes`). The inline
+ * transport is a stopgap until a REST endpoint replaces it.
  *
  * @package gutenberg
  */
 
+require_once __DIR__ . '/class-wp-widget-type.php';
+require_once __DIR__ . '/class-wp-widget-type-registry.php';
+
 /**
- * Prints the inline script that exposes the widget types as a global.
+ * Hydrates the widget type registry from the build manifest.
  *
- * Consumers should read widget types through the `core/widget-types` data
- * store, not by reaching into the global directly.
+ * Iterates the widgets discovered by the build pipeline (via
+ * `gutenberg_get_registered_widget_modules()`) and registers each one in
+ * `WP_Widget_Type_Registry`. The manifest is the single source of widget
+ * authorship in this codebase; this loop is a deterministic copy of it
+ * into the in-memory registry, with no filters in between.
  */
-function gutenberg_print_widget_types_bootstrap() {
+function gutenberg_register_widget_types() {
 	if ( ! function_exists( 'gutenberg_get_registered_widget_modules' ) ) {
 		return;
 	}
 
-	$entries = array_values(
-		array_filter(
-			array_map(
-				static function ( $widget ) {
-					if ( empty( $widget['name'] ) ) {
-						return null;
-					}
-					return array_filter(
-						array(
-							'name'          => $widget['name'],
-							'render_module' => $widget['render_module'] ?? null,
-							'widget_module' => $widget['widget_module'] ?? null,
-						)
-					);
-				},
-				gutenberg_get_registered_widget_modules()
+	$registry = WP_Widget_Type_Registry::get_instance();
+
+	foreach ( gutenberg_get_registered_widget_modules() as $widget ) {
+		if ( empty( $widget['name'] ) || $registry->is_registered( $widget['name'] ) ) {
+			continue;
+		}
+
+		$registry->register(
+			$widget['name'],
+			array(
+				'render_module' => $widget['render_module'] ?? null,
+				'widget_module' => $widget['widget_module'] ?? null,
 			)
+		);
+	}
+}
+
+if ( did_action( 'init' ) ) {
+	gutenberg_register_widget_types();
+} else {
+	add_action( 'init', 'gutenberg_register_widget_types' );
+}
+
+/**
+ * Returns all widget types registered in the widget type registry.
+ *
+ * Convenience accessor around `WP_Widget_Type_Registry::get_all_registered()`
+ * for callers that prefer a function-based API.
+ *
+ * @return WP_Widget_Type[] Associative array of `$name => $widget_type`
+ *                          pairs.
+ */
+function gutenberg_get_registered_widget_types() {
+	return WP_Widget_Type_Registry::get_instance()->get_all_registered();
+}
+
+/**
+ * Prints the inline script that exposes the widget types as a global.
+ *
+ * Temporary bridge: emits `window.__registeredWidgetTypes` so the
+ * `core/widget-types` data store has data on first paint. Globals on
+ * `window` are not the desired surface; this is a stopgap until a REST
+ * endpoint backed by the widget type registry takes over and the resolver
+ * fetches via `apiFetch`. Consumers should read widget types through the
+ * `core/widget-types` data store, not by reaching into the global directly.
+ */
+function gutenberg_print_widget_types_bootstrap() {
+	$widget_types = gutenberg_get_registered_widget_types();
+	if ( empty( $widget_types ) ) {
+		return;
+	}
+
+	$entries = array_values(
+		array_map(
+			static function ( $widget_type ) {
+				return array_filter(
+					array(
+						'name'          => $widget_type->name,
+						'render_module' => $widget_type->render_module,
+						'widget_module' => $widget_type->widget_module,
+					)
+				);
+			},
+			$widget_types
 		)
 	);
 

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -196,24 +196,6 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suf
 			}
 		}
 
-		// Add registered widgets as dynamic dependencies
-		if ( function_exists( '{{PREFIX}}_get_registered_widget_modules' ) ) {
-			foreach ( {{PREFIX}}_get_registered_widget_modules() as $widget ) {
-				if ( ! empty( $widget['widget_module'] ) ) {
-					$boot_dependencies[] = array(
-						'import' => 'dynamic',
-						'id'     => $widget['widget_module'],
-					);
-				}
-				if ( ! empty( $widget['render_module'] ) ) {
-					$boot_dependencies[] = array(
-						'import' => 'dynamic',
-						'id'     => $widget['render_module'],
-					);
-				}
-			}
-		}
-
 		// Dummy script module to ensure dependencies are loaded
 		wp_register_script_module(
 			'{{PAGE_SLUG}}-wp-admin',

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -209,24 +209,6 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
 			}
 		}
 
-		// Add registered widgets as dynamic dependencies
-		if ( function_exists( '{{PREFIX}}_get_registered_widget_modules' ) ) {
-			foreach ( {{PREFIX}}_get_registered_widget_modules() as $widget ) {
-				if ( ! empty( $widget['widget_module'] ) ) {
-					$boot_dependencies[] = array(
-						'import' => 'dynamic',
-						'id'     => $widget['widget_module'],
-					);
-				}
-				if ( ! empty( $widget['render_module'] ) ) {
-					$boot_dependencies[] = array(
-						'import' => 'dynamic',
-						'id'     => $widget['render_module'],
-					);
-				}
-			}
-		}
-
 		// Dummy script module to ensure dependencies are loaded
 		wp_register_script_module(
 			'{{PAGE_SLUG}}',

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -93,6 +93,7 @@ $GLOBALS['wp_tests_options'] = array(
 		'gutenberg-media-processing'   => 1,
 		'gutenberg-guidelines'         => 1,
 		'gutenberg-content-types'      => 1,
+		'gutenberg-dashboard-widgets'  => 1,
 	),
 );
 

--- a/phpunit/experimental/class-wp-widget-type-registry-test.php
+++ b/phpunit/experimental/class-wp-widget-type-registry-test.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Unit tests covering WP_Widget_Type and WP_Widget_Type_Registry.
+ *
+ * @package gutenberg
+ *
+ * @covers WP_Widget_Type
+ * @covers WP_Widget_Type_Registry
+ */
+class WP_Widget_Type_Registry_Test extends WP_UnitTestCase {
+
+	/**
+	 * Registry instance under test.
+	 *
+	 * @var WP_Widget_Type_Registry
+	 */
+	private $registry;
+
+	public function set_up() {
+		parent::set_up();
+		$this->reset_singleton();
+		$this->registry = WP_Widget_Type_Registry::get_instance();
+	}
+
+	public function tear_down() {
+		$this->reset_singleton();
+		$this->registry = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Resets the singleton between tests so each test starts with a clean
+	 * registry. Mirrors the pattern used by `WP_Test_Icons_Registry_Gutenberg`.
+	 */
+	private function reset_singleton() {
+		$instance_property = new ReflectionProperty( WP_Widget_Type_Registry::class, 'instance' );
+
+		/*
+		 * ReflectionProperty::setAccessible is:
+		 * - redundant as of 8.1.0, which made all properties accessible
+		 * - deprecated as of 8.5.0
+		 * - needed until 8.1.0, as `instance` is private.
+		 */
+		if ( PHP_VERSION_ID < 80100 ) {
+			$instance_property->setAccessible( true );
+		}
+
+		$instance_property->setValue( null, null );
+	}
+
+	public function test_get_instance_returns_singleton() {
+		$a = WP_Widget_Type_Registry::get_instance();
+		$b = WP_Widget_Type_Registry::get_instance();
+
+		$this->assertSame( $a, $b );
+	}
+
+	public function test_register_returns_widget_type_with_resolved_props() {
+		$widget_type = $this->registry->register(
+			'test-plugin/my-widget',
+			array(
+				'render_module' => 'wp/widgets/my-widget/render',
+				'widget_module' => 'wp/widgets/my-widget/widget',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Widget_Type::class, $widget_type );
+		$this->assertSame( 'test-plugin/my-widget', $widget_type->name );
+		$this->assertSame( 'wp/widgets/my-widget/render', $widget_type->render_module );
+		$this->assertSame( 'wp/widgets/my-widget/widget', $widget_type->widget_module );
+		$this->assertTrue( $this->registry->is_registered( 'test-plugin/my-widget' ) );
+	}
+
+	public function test_register_accepts_widget_type_instance() {
+		$widget_type = new WP_Widget_Type(
+			'test-plugin/my-widget',
+			array( 'render_module' => 'wp/widgets/my-widget/render' )
+		);
+
+		$result = $this->registry->register( $widget_type );
+
+		$this->assertSame( $widget_type, $result );
+		$this->assertTrue( $this->registry->is_registered( 'test-plugin/my-widget' ) );
+	}
+
+	public function test_register_rejects_non_string_name() {
+		$this->setExpectedIncorrectUsage( 'WP_Widget_Type_Registry::register' );
+
+		$result = $this->registry->register( array( 'invalid' ) );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_register_rejects_uppercase_name() {
+		$this->setExpectedIncorrectUsage( 'WP_Widget_Type_Registry::register' );
+
+		$result = $this->registry->register( 'test-plugin/MyWidget' );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_register_rejects_name_without_namespace() {
+		$this->setExpectedIncorrectUsage( 'WP_Widget_Type_Registry::register' );
+
+		$result = $this->registry->register( 'no-namespace' );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_register_rejects_duplicate_name() {
+		$this->registry->register( 'test-plugin/my-widget' );
+
+		$this->setExpectedIncorrectUsage( 'WP_Widget_Type_Registry::register' );
+		$result = $this->registry->register( 'test-plugin/my-widget' );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_unregister_returns_unregistered_type() {
+		$widget_type = $this->registry->register( 'test-plugin/my-widget' );
+
+		$result = $this->registry->unregister( 'test-plugin/my-widget' );
+
+		$this->assertSame( $widget_type, $result );
+		$this->assertFalse( $this->registry->is_registered( 'test-plugin/my-widget' ) );
+	}
+
+	public function test_unregister_accepts_widget_type_instance() {
+		$widget_type = $this->registry->register( 'test-plugin/my-widget' );
+
+		$result = $this->registry->unregister( $widget_type );
+
+		$this->assertSame( $widget_type, $result );
+		$this->assertFalse( $this->registry->is_registered( 'test-plugin/my-widget' ) );
+	}
+
+	public function test_unregister_rejects_unknown_name() {
+		$this->setExpectedIncorrectUsage( 'WP_Widget_Type_Registry::unregister' );
+
+		$result = $this->registry->unregister( 'test-plugin/unknown' );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_get_registered_returns_null_for_unknown_name() {
+		$this->assertNull( $this->registry->get_registered( 'test-plugin/unknown' ) );
+	}
+
+	public function test_get_registered_returns_instance_for_known_name() {
+		$widget_type = $this->registry->register( 'test-plugin/my-widget' );
+
+		$this->assertSame( $widget_type, $this->registry->get_registered( 'test-plugin/my-widget' ) );
+	}
+
+	public function test_get_all_registered_returns_keyed_array() {
+		$this->registry->register( 'test-plugin/widget-a' );
+		$this->registry->register( 'test-plugin/widget-b' );
+
+		$all = $this->registry->get_all_registered();
+
+		$this->assertCount( 2, $all );
+		$this->assertArrayHasKey( 'test-plugin/widget-a', $all );
+		$this->assertArrayHasKey( 'test-plugin/widget-b', $all );
+		$this->assertInstanceOf( WP_Widget_Type::class, $all['test-plugin/widget-a'] );
+	}
+
+	public function test_widget_type_is_renderable_when_render_module_present() {
+		$widget_type = new WP_Widget_Type(
+			'test-plugin/widget',
+			array( 'render_module' => 'wp/widgets/widget/render' )
+		);
+
+		$this->assertTrue( $widget_type->is_renderable() );
+	}
+
+	public function test_widget_type_is_not_renderable_without_render_module() {
+		$widget_type = new WP_Widget_Type( 'test-plugin/widget' );
+
+		$this->assertFalse( $widget_type->is_renderable() );
+	}
+
+	public function test_widget_type_set_props_passes_through_extra_keys() {
+		$widget_type = new WP_Widget_Type(
+			'test-plugin/widget',
+			array(
+				'render_module' => 'handle/render',
+				'widget_module' => 'handle/widget',
+				'extra'         => 'value',
+			)
+		);
+
+		$this->assertSame( 'handle/render', $widget_type->render_module );
+		$this->assertSame( 'handle/widget', $widget_type->widget_module );
+		$this->assertSame( 'value', $widget_type->extra );
+	}
+
+	public function test_widget_type_set_props_protects_name_from_overwrite() {
+		$widget_type = new WP_Widget_Type(
+			'test-plugin/widget',
+			array(
+				'name'          => 'rogue-plugin/spoofed',
+				'render_module' => 'handle/render',
+			)
+		);
+
+		$this->assertSame( 'test-plugin/widget', $widget_type->name );
+		$this->assertSame( 'handle/render', $widget_type->render_module );
+	}
+
+	public function test_widget_type_set_props_ignores_non_array_args() {
+		$widget_type = new WP_Widget_Type( 'test-plugin/widget', null );
+
+		$this->assertSame( 'test-plugin/widget', $widget_type->name );
+		$this->assertNull( $widget_type->render_module );
+		$this->assertNull( $widget_type->widget_module );
+	}
+
+	public function test_bootstrap_populates_registry_from_manifest() {
+		if ( ! function_exists( 'gutenberg_register_widget_types' ) ) {
+			$this->markTestSkipped( 'gutenberg_register_widget_types() is not available; the dashboard-widgets experiment must be enabled.' );
+		}
+
+		gutenberg_register_widget_types();
+
+		$registered       = $this->registry->get_all_registered();
+		$manifest_widgets = function_exists( 'gutenberg_get_registered_widget_modules' )
+			? gutenberg_get_registered_widget_modules()
+			: array();
+
+		$expected_names = array_filter(
+			array_map(
+				static function ( $widget ) {
+					return $widget['name'] ?? null;
+				},
+				$manifest_widgets
+			)
+		);
+
+		foreach ( $expected_names as $name ) {
+			$this->assertArrayHasKey( $name, $registered, "Expected $name to be registered from the manifest." );
+		}
+	}
+
+	public function test_bootstrap_is_idempotent() {
+		if ( ! function_exists( 'gutenberg_register_widget_types' ) ) {
+			$this->markTestSkipped( 'gutenberg_register_widget_types() is not available; the dashboard-widgets experiment must be enabled.' );
+		}
+
+		gutenberg_register_widget_types();
+		$first_count = count( $this->registry->get_all_registered() );
+
+		gutenberg_register_widget_types();
+		$second_count = count( $this->registry->get_all_registered() );
+
+		$this->assertSame( $first_count, $second_count );
+	}
+}


### PR DESCRIPTION
## What?

Two related changes that clean up how widget types flow through the system.

**Server-side widget type registry.** `WP_Widget_Type_Registry` (singleton) and `WP_Widget_Type` (value object), hydrated from the build manifest at `init`.

**Decouple `@wordpress/build` page templates from widgets.** The foreach over `gutenberg_get_registered_widget_modules()` is removed from the page templates. Page wiring is now a consumer concern.

Gated behind the existing `gutenberg-dashboard-widgets` experiment.

Part of #77625 #77616

## Why?

There was no PHP-side record of which widget types exist on the site.

The build pipeline emits `build/widgets/registry.php` with the discovered widgets, but nothing in the PHP layer reads it as a typed structure.

Every consumer that needs the list re-parses the manifest itself.

Without a registry there is no canonical place for new server-side concerns (REST endpoints, render helpers, page-module dependency lookups) to plug in.

Separately, `@wordpress/build` is a generic build tool, used inside Gutenberg and by plugins targeting WordPress core directly. Its `AGENTS.md` rule forbids Gutenberg-specific changes.

The page templates were hardcoding a foreach that injected every discovered widget into every page's import map, crossing that boundary. Removing it restores it.

## How?

Singleton `WP_Widget_Type_Registry` exposes `register / unregister / is_registered / get_registered / get_all_registered / get_instance`.

`WP_Widget_Type` is a permissive value object with `name`, `render_module`, `widget_module`, and `is_renderable()`. The constructor uses `#[AllowDynamicProperties]` so future metadata can flow through without a class change. Hydration ignores `name` in `$args` so the registry key always matches the object's identity.

`gutenberg_register_widget_types()` runs at `init`. It reads `gutenberg_get_registered_widget_modules()` and registers each entry.

No filters in the registration loop. The manifest is the single source of authorship; the registry is a deterministic copy.

`gutenberg_get_registered_widget_types()` is a function-based accessor over the registry.

The existing inline bootstrap (`window.__registeredWidgetTypes`) now reads from the registry instead of re-parsing the manifest.

The registry stores type definitions, not placements. Where a widget renders (page, sidebar, any future surface) is a consumer concern, not a registry concern.

The `@wordpress/build` page templates no longer iterate the widget catalog. The build's responsibility ends at discovering widgets, registering their script modules, and exposing the catalog through `{prefix}_get_registered_widget_modules()`.

Surfaces that want to render widgets pull them from the catalog and wire them into their own runtime.

## Testing

Start the test environment if it is not already running:

```
npm run test:unit:php:setup
```

Then run the registry test suite:

```
npm run test:unit:php:base -- --filter WP_Widget_Type_Registry_Test
```

20 tests / 40 assertions cover validation, accessors, manifest hydration, name overwrite protection, and idempotency.

Manual:

1. Enable the `gutenberg-dashboard-widgets` experiment.
2. In any admin request: `var_dump( gutenberg_get_registered_widget_types() );` returns a `WP_Widget_Type[]` keyed by widget name.
3. `WP_Widget_Type_Registry::get_instance()->is_registered( 'wordpress/<existing-widget>' )` returns `true`.
4. Visit `?page=dashboard-wp-admin`. The dashboard renders and the registered widgets bootstrap.

## Follow-ups

- [ ] REST endpoint backed by the registry, replacing the inline `window.__registeredWidgetTypes` bootstrap.
- [ ] Public `register_widget_type()` PHP API for runtime authoring (out of scope while authorship stays build-driven).
- [ ] When an on-demand widget loader lands in a real consumer, design the page-side wiring against that real caller.
