### PR TITLE
Fix Focus Loss on Tab/Shift+Tab After Changing Heading Level

### DIFF
--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -186,7 +186,11 @@ function useToolbarFocus( {
 		if ( focusEditorOnEscape ) {
 			const handleKeyDown = ( event ) => {
 				const lastFocus = getLastFocus();
-				if ( event.keyCode === ESCAPE && lastFocus?.current ) {
+				if (
+					event.keyCode === ESCAPE &&
+					lastFocus?.current &&
+					lastFocus.current.isConnected
+				) {
 					// Focus the last focused element when pressing escape.
 					event.preventDefault();
 					lastFocus.current.focus();

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -46,8 +46,9 @@ export default function useTabNav() {
 		} else if ( hasMultiSelection() ) {
 			containerRef.current.focus();
 		} else if ( getSelectedBlockClientId() ) {
-			if ( getLastFocus()?.current ) {
-				getLastFocus().current.focus();
+			const lastFocus = getLastFocus();
+			if ( lastFocus?.current && lastFocus.current.isConnected ) {
+				lastFocus.current.focus();
 			} else {
 				// Handles when the last focus has not been set yet, or has been cleared by new blocks being added via the inserter.
 				containerRef.current


### PR DESCRIPTION
## What?

Closes #55745 

This PR fixes a bug where keyboard focus is lost when navigating back to a Heading or Site Title block from the block toolbar using `Tab` or `Escape`, specifically after its heading level was changed.

## Why?

When the heading level is changed (H2 -> H3), React completely unmounts the old element and mounts a new one with the updated tag. However, the internal focus state (`lastFocus.current`) still held a reference to the old, detached DOM element. Consequently, attempting to return focus to the block via `.focus()` failed silently, breaking keyboard accessibility.

## How?

Added a `.isConnected` check for `lastFocus.current`. If the previously focused element is no longer connected to the DOM (i.e. it was replaced by a new heading tag), the logic falls back to querying the active block via its `[data-block]` attribute. This correctly targets the newly mounted element and reliably restores focus.

## Testing Instructions

1. Open the block editor.
2. Add a **Heading block**.
3. Open the block toolbar.
4. Select a different heading level (e.g., change from H2 to H3).
5. Ensure focus can correctly be restored to the block (see keyboard instructions below).

### Testing Instructions for Keyboard

1. Add a **Heading block** and type some text.
2. Press `Shift + Tab` to move focus from the block into the floating block toolbar.
3. Use the keyboard to navigate to the "Change level" button and change the heading level.
4. Press `Tab` to return focus to the block.
5. **Expected:** Focus successfully returns to the Heading block.

## Screenshots or screencast

### Before Fix :

https://github.com/WordPress/gutenberg/assets/967608/72743bd0-7467-4039-b493-5f85f07a67a6

### After Fix :

https://github.com/user-attachments/assets/bb9cac60-b13c-4e51-b240-fd8057b26d4e

## Use of AI Tools

AI assitance used to draft PR description. all the changes are verified manually.