### PR TITLE
Remove root uuid dependency

### DIFF
--- a/bin/plugin/lib/utils.js
+++ b/bin/plugin/lib/utils.js
@@ -5,7 +5,7 @@
 const { confirm } = require( '@inquirer/prompts' );
 const fs = require( 'fs' );
 const childProcess = require( 'child_process' );
-const { v4: uuid } = require( 'uuid' );
+const { randomUUID } = require( 'crypto' );
 const path = require( 'path' );
 const os = require( 'os' );
 
@@ -123,7 +123,7 @@ async function askForConfirmation(
  * @return {string} Temporary Path.
  */
 function getRandomTemporaryPath() {
-	return path.join( os.tmpdir(), uuid() );
+	return path.join( os.tmpdir(), randomUUID() );
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,6 @@
 				"style-loader": "3.2.1",
 				"stylelint-plugin-logical-css": "^1.2.3",
 				"typescript": "6.0.2",
-				"uuid": "11.1.1",
 				"wait-on": "8.0.1"
 			},
 			"engines": {
@@ -54735,17 +54734,16 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-			"dev": true,
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/esm/bin/uuid"
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"node_modules/v8-to-istanbul": {
@@ -57776,19 +57774,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"packages/annotations/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
-			}
-		},
 		"packages/api-fetch": {
 			"name": "@wordpress/api-fetch",
 			"version": "7.45.0",
@@ -58285,19 +58270,6 @@
 				"url": "https://github.com/sponsors/arraypress"
 			}
 		},
-		"packages/block-library/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
-			}
-		},
 		"packages/block-serialization-default-parser": {
 			"name": "@wordpress/block-serialization-default-parser",
 			"version": "5.45.0",
@@ -58370,19 +58342,6 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
-		},
-		"packages/blocks/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
-			}
 		},
 		"packages/boot": {
 			"name": "@wordpress/boot",
@@ -58618,19 +58577,6 @@
 			"peerDependencies": {
 				"react": ">=16.8.0",
 				"react-dom": ">=16.8.0"
-			}
-		},
-		"packages/components/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"packages/compose": {
@@ -59464,19 +59410,6 @@
 				"node": ">=8"
 			}
 		},
-		"packages/core-data/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
-			}
-		},
 		"packages/core-data/node_modules/write-file-atomic": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
@@ -60138,19 +60071,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"packages/editor/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"packages/element": {
@@ -63103,19 +63023,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"packages/upload-media/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"packages/url": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
 		"style-loader": "3.2.1",
 		"stylelint-plugin-logical-css": "^1.2.3",
 		"typescript": "6.0.2",
-		"uuid": "11.1.1",
 		"wait-on": "8.0.1"
 	},
 	"overrides": {

--- a/test/e2e/specs/editor/blocks/classic.spec.js
+++ b/test/e2e/specs/editor/blocks/classic.spec.js
@@ -4,7 +4,7 @@
 const path = require( 'path' );
 const fs = require( 'fs/promises' );
 const os = require( 'os' );
-const { v4: uuid } = require( 'uuid' );
+const { randomUUID } = require( 'crypto' );
 
 /**
  * WordPress dependencies
@@ -158,7 +158,7 @@ class MediaUtils {
 		const tmpDirectory = await fs.mkdtemp(
 			path.join( os.tmpdir(), 'gutenberg-test-image-' )
 		);
-		const fileName = uuid();
+		const fileName = randomUUID();
 		const tmpFileName = path.join( tmpDirectory, fileName + '.png' );
 		await fs.copyFile( this.TEST_IMAGE_FILE_PATH, tmpFileName );
 

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -4,7 +4,7 @@
 const path = require( 'path' );
 const fs = require( 'fs/promises' );
 const os = require( 'os' );
-const { v4: uuid } = require( 'uuid' );
+const { randomUUID } = require( 'crypto' );
 
 /** @typedef {import('@playwright/test').Page} Page */
 
@@ -576,7 +576,7 @@ class CoverBlockUtils {
 		const tmpDirectory = await fs.mkdtemp(
 			path.join( os.tmpdir(), 'gutenberg-test-image-' )
 		);
-		const fileName = uuid();
+		const fileName = randomUUID();
 		const tmpFileName = path.join( tmpDirectory, fileName + '.png' );
 		await fs.copyFile( srcPath, tmpFileName );
 

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -4,7 +4,7 @@
 const path = require( 'path' );
 const fs = require( 'fs/promises' );
 const os = require( 'os' );
-const { v4: uuid } = require( 'uuid' );
+const { randomUUID } = require( 'crypto' );
 
 /**
  * WordPress dependencies
@@ -295,7 +295,7 @@ class GalleryBlockUtils {
 		const tmpDirectory = await fs.mkdtemp(
 			path.join( os.tmpdir(), 'gutenberg-test-image-' )
 		);
-		const fileName = uuid();
+		const fileName = randomUUID();
 		const tmpFileName = path.join( tmpDirectory, fileName + '.png' );
 		await fs.copyFile( this.TEST_IMAGE_FILE_PATH, tmpFileName );
 

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -4,7 +4,7 @@
 const path = require( 'path' );
 const fs = require( 'fs/promises' );
 const os = require( 'os' );
-const { v4: uuid } = require( 'uuid' );
+const { randomUUID } = require( 'crypto' );
 
 /** @typedef {import('@playwright/test').Page} Page */
 
@@ -1153,7 +1153,7 @@ class ImageBlockUtils {
 		const tmpDirectory = await fs.mkdtemp(
 			path.join( os.tmpdir(), 'gutenberg-test-image-' )
 		);
-		const fileName = uuid();
+		const fileName = randomUUID();
 		const tmpFileName = path.join( tmpDirectory, fileName + '.png' );
 		const filePath = customFile
 			? this.basePath + '/' + customFile

--- a/test/e2e/specs/editor/various/adding-inline-tokens.spec.js
+++ b/test/e2e/specs/editor/various/adding-inline-tokens.spec.js
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
+import { randomUUID } from 'crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { v4 as uuid } from 'uuid';
 
 /**
  * WordPress dependencies
@@ -33,7 +33,7 @@ test.describe( 'adding inline tokens', () => {
 		await page.click( 'role=menuitem[name="Inline image"i]' );
 
 		const testImagePath = './assets/10x10_e2e_test_image_z9T8jK.png';
-		const fileName = uuid();
+		const fileName = randomUUID();
 		const tmpFileName = path.join( os.tmpdir(), fileName + '.png' );
 		fs.copyFileSync( testImagePath, tmpFileName );
 		await page

--- a/test/e2e/specs/editor/various/big-image-size-threshold.spec.js
+++ b/test/e2e/specs/editor/various/big-image-size-threshold.spec.js
@@ -4,7 +4,7 @@
 const path = require( 'path' );
 const fs = require( 'fs/promises' );
 const os = require( 'os' );
-const { v4: uuid } = require( 'uuid' );
+const { randomUUID } = require( 'crypto' );
 
 /**
  * WordPress dependencies
@@ -232,7 +232,7 @@ class ImageBlockUtils {
 		const tmpDirectory = await fs.mkdtemp(
 			path.join( os.tmpdir(), 'gutenberg-test-image-' )
 		);
-		const fileName = uuid();
+		const fileName = randomUUID();
 		const extension = customFile ? path.extname( customFile ) : '.png';
 		const tmpFileName = path.join( tmpDirectory, fileName + extension );
 		const filePath = customFile

--- a/test/e2e/specs/editor/various/upload-save-lock.spec.js
+++ b/test/e2e/specs/editor/various/upload-save-lock.spec.js
@@ -4,7 +4,7 @@
 const path = require( 'path' );
 const fs = require( 'fs/promises' );
 const os = require( 'os' );
-const { v4: uuid } = require( 'uuid' );
+const { randomUUID } = require( 'crypto' );
 
 /**
  * WordPress dependencies
@@ -29,7 +29,7 @@ async function createTempImage() {
 	const tmpDirectory = await fs.mkdtemp(
 		path.join( os.tmpdir(), 'gutenberg-test-image-' )
 	);
-	const tmpFileName = path.join( tmpDirectory, uuid() + '.png' );
+	const tmpFileName = path.join( tmpDirectory, randomUUID() + '.png' );
 	await fs.copyFile( TEST_IMAGE_FILE_PATH, tmpFileName );
 	return tmpFileName;
 }

--- a/test/native/integration-test-helpers/initialize-editor.js
+++ b/test/native/integration-test-helpers/initialize-editor.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
+import { randomUUID } from 'crypto';
 import { render, fireEvent } from '@testing-library/react-native';
-import { v4 as uuid } from 'uuid';
 
 /**
  * WordPress dependencies
@@ -45,7 +45,7 @@ export async function initializeEditor( props, { component } = {} ) {
 		return actualResolution( selectorName, args );
 	} );
 
-	const uniqueId = uuid();
+	const uniqueId = randomUUID();
 	const postId = `post-id-${ uniqueId }`;
 	const postType = 'post';
 

--- a/test/native/jest.config.js
+++ b/test/native/jest.config.js
@@ -89,7 +89,7 @@ module.exports = {
 		// See: https://github.com/wordpress-mobile/gutenberg-mobile/pull/257#discussion_r234978268
 		// There is no overloading in jest so we need to rewrite the config from react-native-jest-preset:
 		// https://github.com/facebook/react-native/blob/HEAD/jest-preset.json#L20
-		'node_modules/(?!(simple-html-tokenizer|(jest-)?react-native|@react-native|react-clone-referenced-element|@react-navigation))',
+		'node_modules/(?!(simple-html-tokenizer|(jest-)?react-native|@react-native|react-clone-referenced-element|@react-navigation|uuid))',
 	],
 	snapshotSerializers: [ '@emotion/jest/serializer' ],
 	snapshotFormat: {

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -66,7 +66,7 @@ module.exports = {
 		'^.+\\.m?[jt]sx?$': '<rootDir>/test/unit/scripts/babel-transformer.js',
 	},
 	transformIgnorePatterns: [
-		'/node_modules/(?!(docker-compose|yaml|preact|@preact|parsel-js|comctx)/)',
+		'/node_modules/(?!(docker-compose|yaml|preact|@preact|parsel-js|comctx|uuid)/)',
 		'\\.pnp\\.[^\\/]+$',
 	],
 	snapshotSerializers: [

--- a/test/unit/scripts/resolver.js
+++ b/test/unit/scripts/resolver.js
@@ -7,19 +7,17 @@ module.exports = ( path, options ) => {
 		...options,
 		// Use packageFilter to process parsed `package.json` before the resolution (see https://www.npmjs.com/package/resolve#resolveid-opts-cb)
 		packageFilter: ( pkg ) => {
-			// This is a workaround for https://github.com/uuidjs/uuid/pull/616
-			//
-			// jest-environment-jsdom 28+ tries to use browser exports instead of default exports,
-			// but uuid v8 only offers an ESM browser export and not a CommonJS one. Jest does not yet
-			// support ESM modules natively, so this causes a Jest error related to trying to parse
-			// "export" syntax.
-			//
-			// This workaround prevents Jest from considering uuid's module-based exports at all;
-			// it falls back to uuid's CommonJS+node "main" property.
-			//
-			// Once we're able to migrate our Jest config to ESM and a browser crypto
-			// implementation is available for the browser+ESM version of uuid to use (eg, via
-			// https://github.com/jsdom/jsdom/pull/3352 or a similar polyfill), this can go away.
+			/*
+			 * jest-environment-jsdom 28+ tries to use browser exports instead
+			 * of default exports for these packages. Stripping the exports
+			 * map forces Jest to fall back to the CommonJS `main` entry.
+			 *
+			 * `uuid` is matched here to handle nested v8 copies (e.g.
+			 * `@actions/core`'s) that still ship a CJS `main`. uuid v14 is
+			 * ESM-only with no `main`, so the `pkg.main` guard below skips it
+			 * and lets Babel transform the ESM build via
+			 * `transformIgnorePatterns`.
+			 */
 			if (
 				pkg.name === 'uuid' ||
 				pkg.name === 'react-colorful' ||
@@ -28,8 +26,10 @@ module.exports = ( path, options ) => {
 				pkg.name === 'nanoid' ||
 				pkg.name?.startsWith( '@wordpress/' )
 			) {
-				delete pkg.exports;
-				delete pkg.module;
+				if ( pkg.main ) {
+					delete pkg.exports;
+					delete pkg.module;
+				}
 			}
 			return pkg;
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow up to #77848.

Updates the monorepo root from `uuid@11.1.1` to `uuid@14.0.0` (matching the version already used by every workspace package), drops the now-unused root `uuid` devDependency, and removes the remaining direct consumers in favour of Node's built-in `crypto.randomUUID()`.

## Why?
[#77848](https://github.com/WordPress/gutenberg/pull/77848) bumped every workspace package to `uuid@14`, but kept the root pinned at `11.1.1` because v11 was the last release that shipped a CommonJS build. v14 is ESM-only:

- `"type": "module"` and no `main` field — only an `exports` map pointing at ESM bundles in `dist/` and `dist-node/`.
- All `require('uuid')` call sites throw `ERR_REQUIRE_ESM`.
- The Jest resolver hack in `test/unit/scripts/resolver.js` that strips `pkg.exports` and falls back to `pkg.main` no longer resolves anything (no `main` field exists), which silently breaks any unit/native test that imports a package depending on `uuid`.

Upstream has deprecated all `uuid` versions before 11 and signaled v11 will likely be deprecated in 2028, so getting the root onto v14 closes out the migration started in #77848.

## How?

**1. Replaced direct root-level consumers with `crypto.randomUUID()`**
Node ≥ 20.19 — already our minimum — ships it natively, returns the same v4-format string, no dependency required.

**2. Fixed the Jest resolver for v14's exports-only layout:**

- Updated the `pkg.exports`-stripping branch in `test/unit/scripts/resolver.js` to only strip when `pkg.main` exists. Older nested `uuid` copies (e.g. `@actions/core`'s pinned `uuid@8.3.2`) keep the v8-era fallback to their CJS `main`, while v14 (which has no `main`) is left alone so the exports map resolves normally.
- Added `uuid` to the `transformIgnorePatterns` allowlist in both `test/unit/jest.config.js` and `test/native/jest.config.js` so Babel transforms uuid v14's ESM build to CJS at test time.

**3. Removed `uuid` from root `devDependencies`** in `package.json` (no root-level imports remain; the hoisted copy in `node_modules/uuid` continues to come from the workspace packages that declare it).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
There should be no functional changes. Verify the build and tests:

```bash
npm install
npm run build
npm run test:unit
```

E2E specs that previously used `require('uuid')` for fake file names should still upload/manipulate media as expected.

### Testing Instructions for Keyboard
N/A — no UI changes.

## Screenshots or screencast <!-- if applicable -->

N/A

## Use of AI Tools

Authored with assistance from Claude Code (Opus 4.7) for analysis and edits; reviewed and tested by the PR author.
