### PR TITLE
ui/CollapsibleCard: support rendering Header as a heading element

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   `Select`: `Select.Trigger` now renders a default `"Select"` placeholder when no value is selected, where it previously rendered empty ([#78076](https://github.com/WordPress/gutenberg/pull/78076)).
 -   `Select`: `Select.Item` no longer renders its `value` as fallback item content. Pass item content explicitly as `children`. Migrate `<Select.Item value="Foo" />` to `<Select.Item value="Foo">Foo</Select.Item>` ([#77861](https://github.com/WordPress/gutenberg/pull/77861)).
 -   `Tooltip`: **`Popup` positioner API** ([#78089](https://github.com/WordPress/gutenberg/pull/78089)). Add a `Tooltip.Positioner` subcomponent and an optional `positioner` prop on `Tooltip.Popup` (when omitted, the default `Tooltip.Positioner` is used). Remove `side`, `align`, and `sideOffset` from `Tooltip.Popup`; pass `positioner={ <Tooltip.Positioner side="…" align="…" sideOffset={ … } /> }` instead. The new subcomponent exposes the full positioner surface (`alignOffset`, `anchor`, `collisionAvoidance`, `collisionBoundary`, `collisionPadding`, `sticky`, etc.) and mirrors the existing `portal` slot pattern.
+-   `CollapsibleCard.Header`: Now renders an `<h3>` element by default (was `<div>`) so each card contributes to the document outline. Pass `render={ <h2 /> }` (or another heading level) to change the level, or `render={ <div /> }` to opt out. Forwarded props (`className`, `style`, `aria-*`, `data-*`) and `ref` now land on the outer heading wrapper instead of the inner click-target div; `ref` widens from `HTMLDivElement` to `HTMLHeadingElement` ([#77962](https://github.com/WordPress/gutenberg/pull/77962)).
 
 ### New Features
 
@@ -28,6 +29,7 @@
 -   `Drawer`: Fade the popup elevation shadow alongside the slide ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).
 -   `Drawer`: Allow mouse-drag swipe-dismiss in the popup-edge padding gutter ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).
 -   `IconButton`: Add a `positioner` prop, accepting a `<Tooltip.Positioner />` element, to customize how the tooltip is positioned relative to the button ([#78089](https://github.com/WordPress/gutenberg/pull/78089)).
+-   `CollapsibleCard`: Each card now contributes a heading to the document outline by default, following the W3C APG accordion pattern (heading wraps button) ([#77962](https://github.com/WordPress/gutenberg/pull/77962)).
 
 ### Internal
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -9,7 +9,7 @@
 -   `Select`: `Select.Trigger` now renders a default `"Select"` placeholder when no value is selected, where it previously rendered empty ([#78076](https://github.com/WordPress/gutenberg/pull/78076)).
 -   `Select`: `Select.Item` no longer renders its `value` as fallback item content. Pass item content explicitly as `children`. Migrate `<Select.Item value="Foo" />` to `<Select.Item value="Foo">Foo</Select.Item>` ([#77861](https://github.com/WordPress/gutenberg/pull/77861)).
 -   `Tooltip`: **`Popup` positioner API** ([#78089](https://github.com/WordPress/gutenberg/pull/78089)). Add a `Tooltip.Positioner` subcomponent and an optional `positioner` prop on `Tooltip.Popup` (when omitted, the default `Tooltip.Positioner` is used). Remove `side`, `align`, and `sideOffset` from `Tooltip.Popup`; pass `positioner={ <Tooltip.Positioner side="…" align="…" sideOffset={ … } /> }` instead. The new subcomponent exposes the full positioner surface (`alignOffset`, `anchor`, `collisionAvoidance`, `collisionBoundary`, `collisionPadding`, `sticky`, etc.) and mirrors the existing `portal` slot pattern.
--   `CollapsibleCard.Header`: Now renders an `<h3>` element by default (was `<div>`) so each card contributes to the document outline. Pass `render={ <h2 /> }` (or another heading level) to change the level, or `render={ <div /> }` to opt out. Forwarded props (`className`, `style`, `aria-*`, `data-*`) and `ref` now land on the outer heading wrapper instead of the inner click-target div; `ref` widens from `HTMLDivElement` to `HTMLHeadingElement` ([#77962](https://github.com/WordPress/gutenberg/pull/77962)).
+-   `CollapsibleCard.Header`: Now renders an outer `<div>` wrapper around the trigger. Forwarded props (`className`, `aria-*`, `data-*`) and `ref` land on this outer wrapper instead of the inner click-target div ([#77962](https://github.com/WordPress/gutenberg/pull/77962)).
 
 ### New Features
 
@@ -29,7 +29,7 @@
 -   `Drawer`: Fade the popup elevation shadow alongside the slide ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).
 -   `Drawer`: Allow mouse-drag swipe-dismiss in the popup-edge padding gutter ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).
 -   `IconButton`: Add a `positioner` prop, accepting a `<Tooltip.Positioner />` element, to customize how the tooltip is positioned relative to the button ([#78089](https://github.com/WordPress/gutenberg/pull/78089)).
--   `CollapsibleCard`: Each card now contributes a heading to the document outline by default, following the W3C APG accordion pattern (heading wraps button) ([#77962](https://github.com/WordPress/gutenberg/pull/77962)).
+-   `CollapsibleCard.Header`: Pass `render={ <h2 /> }` (or any of `<h1>`–`<h6>`) to wrap the trigger in a heading and contribute to the document outline, following the W3C APG accordion pattern (heading wraps button) ([#77962](https://github.com/WordPress/gutenberg/pull/77962)).
 
 ### Internal
 

--- a/packages/ui/src/collapsible-card/header.tsx
+++ b/packages/ui/src/collapsible-card/header.tsx
@@ -18,6 +18,19 @@ import type { HeaderProps } from './types';
  * Avoid placing interactive elements (buttons, links, inputs) inside the
  * header, since the entire area is clickable and their events will bubble
  * to trigger the collapse toggle.
+ *
+ * To contribute to the document outline, wrap the trigger in a heading
+ * element via the `render` prop:
+ *
+ * ```jsx
+ * <CollapsibleCard.Header
+ *   render={ ( props ) => (
+ *     <h2><div { ...props } /></h2>
+ *   ) }
+ * >
+ *   <Card.Title>Section title</Card.Title>
+ * </CollapsibleCard.Header>
+ * ```
  */
 export const Header = forwardRef< HTMLDivElement, HeaderProps >(
 	function CollapsibleCardHeader(

--- a/packages/ui/src/collapsible-card/header.tsx
+++ b/packages/ui/src/collapsible-card/header.tsx
@@ -16,18 +16,19 @@ import type { HeaderProps } from './types';
  * toggle trigger — clicking anywhere on it expands or collapses the
  * card's content.
  *
- * Renders an `<h3>` element by default so each card contributes to the
- * document outline. Pass `render` to change the heading level (e.g.
- * `render={ <h2 /> }`) or to opt out of heading semantics entirely
- * (`render={ <div /> }`) when no outline contribution is desired.
+ * Defaults to a `<div>` wrapper around the trigger. Since the right heading
+ * level depends on the surrounding document outline, the consumer is
+ * expected to opt in to heading semantics. Pass `render` to wrap the
+ * trigger in a heading (e.g. `render={ <h2 /> }`), following the W3C APG
+ * accordion pattern (heading wraps button).
  *
  * Avoid placing interactive elements (buttons, links, inputs) inside the
  * header, since the entire area is clickable and their events will bubble
  * to trigger the collapse toggle.
  */
-export const Header = forwardRef< HTMLHeadingElement, HeaderProps >(
+export const Header = forwardRef< HTMLDivElement, HeaderProps >(
 	function CollapsibleCardHeader(
-		{ children, className, style, render, ...restProps },
+		{ children, className, render, ...restProps },
 		ref
 	) {
 		const [ descriptionId, setDescriptionId ] = useState< string >();
@@ -38,16 +39,15 @@ export const Header = forwardRef< HTMLHeadingElement, HeaderProps >(
 		);
 
 		return useRender( {
-			defaultTagName: 'h3',
+			defaultTagName: 'div',
 			render,
 			ref,
-			props: mergeProps< 'h3' >( restProps, {
+			props: mergeProps< 'div' >( restProps, {
 				className: clsx(
 					defenseStyles.heading,
 					styles[ 'heading-wrapper' ],
 					className
 				),
-				style,
 				children: (
 					<HeaderDescriptionIdContext.Provider value={ contextValue }>
 						<Collapsible.Trigger

--- a/packages/ui/src/collapsible-card/header.tsx
+++ b/packages/ui/src/collapsible-card/header.tsx
@@ -1,3 +1,4 @@
+import { mergeProps, useRender } from '@base-ui/react';
 import clsx from 'clsx';
 import { forwardRef, useMemo, useState } from '@wordpress/element';
 import { chevronDown } from '@wordpress/icons';
@@ -15,26 +16,18 @@ import type { HeaderProps } from './types';
  * toggle trigger — clicking anywhere on it expands or collapses the
  * card's content.
  *
+ * Renders an `<h3>` element by default so each card contributes to the
+ * document outline. Pass `render` to change the heading level (e.g.
+ * `render={ <h2 /> }`) or to opt out of heading semantics entirely
+ * (`render={ <div /> }`) when no outline contribution is desired.
+ *
  * Avoid placing interactive elements (buttons, links, inputs) inside the
  * header, since the entire area is clickable and their events will bubble
  * to trigger the collapse toggle.
- *
- * To contribute to the document outline, wrap the trigger in a heading
- * element via the `render` prop:
- *
- * ```jsx
- * <CollapsibleCard.Header
- *   render={ ( props ) => (
- *     <h2><div { ...props } /></h2>
- *   ) }
- * >
- *   <Card.Title>Section title</Card.Title>
- * </CollapsibleCard.Header>
- * ```
  */
-export const Header = forwardRef< HTMLDivElement, HeaderProps >(
+export const Header = forwardRef< HTMLHeadingElement, HeaderProps >(
 	function CollapsibleCardHeader(
-		{ children, className, render, ...restProps },
+		{ children, className, style, render, ...restProps },
 		ref
 	) {
 		const [ descriptionId, setDescriptionId ] = useState< string >();
@@ -44,48 +37,55 @@ export const Header = forwardRef< HTMLDivElement, HeaderProps >(
 			[ setDescriptionId ]
 		);
 
-		return (
-			<HeaderDescriptionIdContext.Provider value={ contextValue }>
-				<Collapsible.Trigger
-					className={ clsx( styles.header, className ) }
-					render={
-						<Card.Header
-							ref={ ref }
-							render={ render }
-							{ ...restProps }
-						/>
-					}
-					nativeButton={ false }
-					aria-describedby={ descriptionId }
-				>
-					<div className={ styles[ 'header-content' ] }>
-						{ children }
-					</div>
-					<div
-						className={ clsx(
-							styles[ 'header-trigger-positioner' ]
-						) }
-					>
-						<div
-							className={ clsx(
-								styles[ 'header-trigger-wrapper' ],
-								defenseStyles.div,
-								// While the interactive trigger element is the whole header,
-								// the focus ring will be displayed only on the icon to visually
-								// emulate it being the button.
-								focusStyles[
-									'outset-ring--focus-parent-visible'
-								]
-							) }
+		return useRender( {
+			defaultTagName: 'h3',
+			render,
+			ref,
+			props: mergeProps< 'h3' >( restProps, {
+				className: clsx(
+					defenseStyles.heading,
+					styles[ 'heading-wrapper' ],
+					className
+				),
+				style,
+				children: (
+					<HeaderDescriptionIdContext.Provider value={ contextValue }>
+						<Collapsible.Trigger
+							className={ styles.header }
+							render={ <Card.Header /> }
+							nativeButton={ false }
+							aria-describedby={ descriptionId }
 						>
-							<Icon
-								icon={ chevronDown }
-								className={ styles[ 'header-trigger' ] }
-							/>
-						</div>
-					</div>
-				</Collapsible.Trigger>
-			</HeaderDescriptionIdContext.Provider>
-		);
+							<div className={ styles[ 'header-content' ] }>
+								{ children }
+							</div>
+							<div
+								className={ clsx(
+									styles[ 'header-trigger-positioner' ]
+								) }
+							>
+								<div
+									className={ clsx(
+										styles[ 'header-trigger-wrapper' ],
+										defenseStyles.div,
+										// While the interactive trigger element is the whole header,
+										// the focus ring will be displayed only on the icon to visually
+										// emulate it being the button.
+										focusStyles[
+											'outset-ring--focus-parent-visible'
+										]
+									) }
+								>
+									<Icon
+										icon={ chevronDown }
+										className={ styles[ 'header-trigger' ] }
+									/>
+								</div>
+							</div>
+						</Collapsible.Trigger>
+					</HeaderDescriptionIdContext.Provider>
+				),
+			} ),
+		} );
 	}
 );

--- a/packages/ui/src/collapsible-card/stories/index.story.tsx
+++ b/packages/ui/src/collapsible-card/stories/index.story.tsx
@@ -166,30 +166,56 @@ export const Stacked: Story = {
 };
 
 /**
- * Wraps the trigger in a heading element to contribute to the document outline.
+ * `CollapsibleCard.Header` renders an `<h3>` by default so the card
+ * contributes to the document outline. Use the `render` prop to change the
+ * heading level (e.g. `render={ <h2 /> }`) or to opt out of heading
+ * semantics entirely (`render={ <div /> }`).
  */
-export const WrappedInHeading: Story = {
-	args: {
-		children: (
-			<>
-				<CollapsibleCard.Header
-					render={ ( props ) => (
-						<h2 style={ { margin: 0 } }>
-							<div { ...props } />
-						</h2>
-					) }
-				>
-					<Card.Title>Section title</Card.Title>
+export const WithHeadingElement: Story = {
+	parameters: { controls: { disable: true } },
+	render: () => (
+		<div
+			style={ {
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 'var(--wpds-dimension-gap-lg)',
+			} }
+		>
+			<CollapsibleCard.Root>
+				<CollapsibleCard.Header render={ <h2 /> }>
+					<Card.Title>Heading level 2</Card.Title>
 				</CollapsibleCard.Header>
 				<CollapsibleCard.Content>
 					<Text>
-						The trigger is rendered inside an h2 element so it
-						appears in the document outline.
+						The wrapper renders as an h2 element when the consumer
+						passes an h2 React element to the render prop.
 					</Text>
 				</CollapsibleCard.Content>
-			</>
-		),
-	},
+			</CollapsibleCard.Root>
+			<CollapsibleCard.Root>
+				<CollapsibleCard.Header>
+					<Card.Title>Heading level 3 (default)</Card.Title>
+				</CollapsibleCard.Header>
+				<CollapsibleCard.Content>
+					<Text>
+						Without a render prop, the header defaults to an h3
+						element.
+					</Text>
+				</CollapsibleCard.Content>
+			</CollapsibleCard.Root>
+			<CollapsibleCard.Root>
+				<CollapsibleCard.Header render={ <div /> }>
+					<Card.Title>No heading semantics</Card.Title>
+				</CollapsibleCard.Header>
+				<CollapsibleCard.Content>
+					<Text>
+						Passing a div React element to the render prop opts out
+						of heading semantics entirely.
+					</Text>
+				</CollapsibleCard.Content>
+			</CollapsibleCard.Root>
+		</div>
+	),
 };
 
 /**

--- a/packages/ui/src/collapsible-card/stories/index.story.tsx
+++ b/packages/ui/src/collapsible-card/stories/index.story.tsx
@@ -166,10 +166,11 @@ export const Stacked: Story = {
 };
 
 /**
- * `CollapsibleCard.Header` renders an `<h3>` by default so the card
- * contributes to the document outline. Use the `render` prop to change the
- * heading level (e.g. `render={ <h2 /> }`) or to opt out of heading
- * semantics entirely (`render={ <div /> }`).
+ * `CollapsibleCard.Header` renders a `<div>` wrapper by default. Pass an
+ * `<h1>`–`<h6>` React element to the `render` prop to wrap the trigger in
+ * a heading and contribute to the document outline. The right level
+ * depends on the surrounding outline, so the consumer is expected to opt
+ * in.
  */
 export const WithHeadingElement: Story = {
 	parameters: { controls: { disable: true } },
@@ -193,24 +194,25 @@ export const WithHeadingElement: Story = {
 				</CollapsibleCard.Content>
 			</CollapsibleCard.Root>
 			<CollapsibleCard.Root>
-				<CollapsibleCard.Header>
-					<Card.Title>Heading level 3 (default)</Card.Title>
+				<CollapsibleCard.Header render={ <h3 /> }>
+					<Card.Title>Heading level 3</Card.Title>
 				</CollapsibleCard.Header>
 				<CollapsibleCard.Content>
 					<Text>
-						Without a render prop, the header defaults to an h3
-						element.
+						Pass any of h1–h6 to choose the level that fits the
+						surrounding document outline.
 					</Text>
 				</CollapsibleCard.Content>
 			</CollapsibleCard.Root>
 			<CollapsibleCard.Root>
-				<CollapsibleCard.Header render={ <div /> }>
-					<Card.Title>No heading semantics</Card.Title>
+				<CollapsibleCard.Header>
+					<Card.Title>No heading (default)</Card.Title>
 				</CollapsibleCard.Header>
 				<CollapsibleCard.Content>
 					<Text>
-						Passing a div React element to the render prop opts out
-						of heading semantics entirely.
+						Without a render prop, the header wraps the trigger in a
+						plain div and does not contribute to the document
+						outline.
 					</Text>
 				</CollapsibleCard.Content>
 			</CollapsibleCard.Root>

--- a/packages/ui/src/collapsible-card/stories/index.story.tsx
+++ b/packages/ui/src/collapsible-card/stories/index.story.tsx
@@ -166,6 +166,33 @@ export const Stacked: Story = {
 };
 
 /**
+ * Wraps the trigger in a heading element to contribute to the document outline.
+ */
+export const WrappedInHeading: Story = {
+	args: {
+		children: (
+			<>
+				<CollapsibleCard.Header
+					render={ ( props ) => (
+						<h2 style={ { margin: 0 } }>
+							<div { ...props } />
+						</h2>
+					) }
+				>
+					<Card.Title>Section title</Card.Title>
+				</CollapsibleCard.Header>
+				<CollapsibleCard.Content>
+					<Text>
+						The trigger is rendered inside an h2 element so it
+						appears in the document outline.
+					</Text>
+				</CollapsibleCard.Content>
+			</>
+		),
+	},
+};
+
+/**
  * A collapsible card with a `HeaderDescription` that provides supplementary
  * information (e.g. status, summary) as an `aria-describedby` relationship.
  */

--- a/packages/ui/src/collapsible-card/style.module.css
+++ b/packages/ui/src/collapsible-card/style.module.css
@@ -1,6 +1,24 @@
 @layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;
 
 @layer wp-ui-components {
+	/*
+	 * Style overrides for the outer heading wrapper rendered by
+	 * `CollapsibleCard.Header` (defaults to `<h3>`). Combined with
+	 * `defenseStyles.heading` so the unlayered defense class beats wp-admin's
+	 * bare `h2`/`h3`/etc. selectors. Keeps the wrapper visually transparent so
+	 * UA and host stylesheets don't bleed into the inner trigger.
+	 */
+	.heading-wrapper {
+		--_gcd-heading-color: inherit;
+		--_gcd-heading-font-size: inherit;
+		--_gcd-heading-font-weight: inherit;
+		--_gcd-heading-margin: 0;
+
+		/* Properties not covered by the defense file. */
+		font-family: inherit;
+		line-height: inherit;
+	}
+
 	.header-content {
 		flex: 1;
 		min-width: 0;

--- a/packages/ui/src/collapsible-card/style.module.css
+++ b/packages/ui/src/collapsible-card/style.module.css
@@ -2,11 +2,13 @@
 
 @layer wp-ui-components {
 	/*
-	 * Style overrides for the outer heading wrapper rendered by
-	 * `CollapsibleCard.Header` (defaults to `<h3>`). Combined with
-	 * `defenseStyles.heading` so the unlayered defense class beats wp-admin's
-	 * bare `h2`/`h3`/etc. selectors. Keeps the wrapper visually transparent so
-	 * UA and host stylesheets don't bleed into the inner trigger.
+	 * Style overrides for the outer wrapper rendered by `CollapsibleCard.Header`
+	 * (defaults to `<div>`, but consumers can opt into a heading level via
+	 * `render={ <h2 /> }` etc.). Combined with `defenseStyles.heading` so that,
+	 * when the wrapper renders as an h1–h6, the unlayered defense class beats
+	 * wp-admin's bare `h2`/`h3`/etc. selectors. Keeps the wrapper visually
+	 * transparent so UA and host stylesheets don't bleed into the inner
+	 * trigger.
 	 */
 	.heading-wrapper {
 		--_gcd-heading-color: inherit;

--- a/packages/ui/src/collapsible-card/test/index.test.tsx
+++ b/packages/ui/src/collapsible-card/test/index.test.tsx
@@ -8,7 +8,7 @@ describe( 'CollapsibleCard', () => {
 	describe( 'basic behaviour', () => {
 		it( 'forwards ref', () => {
 			const rootRef = createRef< HTMLDivElement >();
-			const headerRef = createRef< HTMLHeadingElement >();
+			const headerRef = createRef< HTMLDivElement >();
 			const contentRef = createRef< HTMLDivElement >();
 
 			render(
@@ -23,7 +23,7 @@ describe( 'CollapsibleCard', () => {
 			);
 
 			expect( rootRef.current ).toBeInstanceOf( HTMLDivElement );
-			expect( headerRef.current ).toBeInstanceOf( HTMLHeadingElement );
+			expect( headerRef.current ).toBeInstanceOf( HTMLDivElement );
 			expect( contentRef.current ).toBeInstanceOf( HTMLDivElement );
 		} );
 
@@ -179,8 +179,8 @@ describe( 'CollapsibleCard', () => {
 		} );
 	} );
 
-	describe( 'heading wrapper', () => {
-		it( 'renders an `<h3>` heading wrapping the trigger by default', () => {
+	describe( 'header wrapper', () => {
+		it( 'does not contribute a heading to the document outline by default', () => {
 			render(
 				<CollapsibleCard.Root>
 					<CollapsibleCard.Header>
@@ -189,17 +189,15 @@ describe( 'CollapsibleCard', () => {
 				</CollapsibleCard.Root>
 			);
 
-			const heading = screen.getByRole( 'heading', {
-				level: 3,
-				name: 'Title',
-			} );
-			expect( heading ).toBeVisible();
 			expect(
-				within( heading ).getByRole( 'button', { name: 'Title' } )
+				screen.queryByRole( 'heading', { name: 'Title' } )
+			).not.toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', { name: 'Title' } )
 			).toBeVisible();
 		} );
 
-		it( 'renders the heading at a different level via `render`', () => {
+		it( 'wraps the trigger in a heading via `render`', () => {
 			render(
 				<CollapsibleCard.Root>
 					<CollapsibleCard.Header render={ <h2 /> }>
@@ -218,28 +216,11 @@ describe( 'CollapsibleCard', () => {
 			).toBeVisible();
 		} );
 
-		it( 'opts out of heading semantics with `render={ <div /> }`', () => {
-			render(
-				<CollapsibleCard.Root>
-					<CollapsibleCard.Header render={ <div /> }>
-						<Card.Title>Title</Card.Title>
-					</CollapsibleCard.Header>
-				</CollapsibleCard.Root>
-			);
-
-			expect(
-				screen.queryByRole( 'heading', { name: 'Title' } )
-			).not.toBeInTheDocument();
-			expect(
-				screen.getByRole( 'button', { name: 'Title' } )
-			).toBeVisible();
-		} );
-
-		it( 'forwards `className` to the outer heading wrapper', () => {
+		it( 'forwards `className` and other props to the outer wrapper', () => {
 			render(
 				<CollapsibleCard.Root>
 					<CollapsibleCard.Header
-						className="custom-heading"
+						className="custom-header"
 						data-testid="header"
 					>
 						<Card.Title>Title</Card.Title>
@@ -247,12 +228,13 @@ describe( 'CollapsibleCard', () => {
 				</CollapsibleCard.Root>
 			);
 
-			const heading = screen.getByRole( 'heading', {
-				level: 3,
-				name: 'Title',
-			} );
-			expect( heading ).toHaveClass( 'custom-heading' );
-			expect( heading ).toHaveAttribute( 'data-testid', 'header' );
+			const wrapper = screen.getByTestId( 'header' );
+			expect( wrapper ).toHaveClass( 'custom-header' );
+			// The forwarded attributes land on the outer wrapper, not the
+			// inner button trigger.
+			expect(
+				within( wrapper ).getByRole( 'button', { name: 'Title' } )
+			).not.toHaveAttribute( 'data-testid' );
 		} );
 	} );
 
@@ -282,11 +264,6 @@ describe( 'CollapsibleCard', () => {
 				'aria-describedby',
 				descriptionElement.id
 			);
-
-			// aria-describedby must be on the inner button (which is what's
-			// being described), not on the outer heading wrapper.
-			const heading = screen.getByRole( 'heading', { name: 'Settings' } );
-			expect( heading ).not.toHaveAttribute( 'aria-describedby' );
 		} );
 
 		it( 'marks the description content as aria-hidden', () => {

--- a/packages/ui/src/collapsible-card/test/index.test.tsx
+++ b/packages/ui/src/collapsible-card/test/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';
 import * as Card from '../../card';
@@ -8,7 +8,7 @@ describe( 'CollapsibleCard', () => {
 	describe( 'basic behaviour', () => {
 		it( 'forwards ref', () => {
 			const rootRef = createRef< HTMLDivElement >();
-			const headerRef = createRef< HTMLDivElement >();
+			const headerRef = createRef< HTMLHeadingElement >();
 			const contentRef = createRef< HTMLDivElement >();
 
 			render(
@@ -23,7 +23,7 @@ describe( 'CollapsibleCard', () => {
 			);
 
 			expect( rootRef.current ).toBeInstanceOf( HTMLDivElement );
-			expect( headerRef.current ).toBeInstanceOf( HTMLDivElement );
+			expect( headerRef.current ).toBeInstanceOf( HTMLHeadingElement );
 			expect( contentRef.current ).toBeInstanceOf( HTMLDivElement );
 		} );
 
@@ -179,6 +179,83 @@ describe( 'CollapsibleCard', () => {
 		} );
 	} );
 
+	describe( 'heading wrapper', () => {
+		it( 'renders an `<h3>` heading wrapping the trigger by default', () => {
+			render(
+				<CollapsibleCard.Root>
+					<CollapsibleCard.Header>
+						<Card.Title>Title</Card.Title>
+					</CollapsibleCard.Header>
+				</CollapsibleCard.Root>
+			);
+
+			const heading = screen.getByRole( 'heading', {
+				level: 3,
+				name: 'Title',
+			} );
+			expect( heading ).toBeVisible();
+			expect(
+				within( heading ).getByRole( 'button', { name: 'Title' } )
+			).toBeVisible();
+		} );
+
+		it( 'renders the heading at a different level via `render`', () => {
+			render(
+				<CollapsibleCard.Root>
+					<CollapsibleCard.Header render={ <h2 /> }>
+						<Card.Title>Title</Card.Title>
+					</CollapsibleCard.Header>
+				</CollapsibleCard.Root>
+			);
+
+			const heading = screen.getByRole( 'heading', {
+				level: 2,
+				name: 'Title',
+			} );
+			expect( heading ).toBeVisible();
+			expect(
+				within( heading ).getByRole( 'button', { name: 'Title' } )
+			).toBeVisible();
+		} );
+
+		it( 'opts out of heading semantics with `render={ <div /> }`', () => {
+			render(
+				<CollapsibleCard.Root>
+					<CollapsibleCard.Header render={ <div /> }>
+						<Card.Title>Title</Card.Title>
+					</CollapsibleCard.Header>
+				</CollapsibleCard.Root>
+			);
+
+			expect(
+				screen.queryByRole( 'heading', { name: 'Title' } )
+			).not.toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', { name: 'Title' } )
+			).toBeVisible();
+		} );
+
+		it( 'forwards `className` to the outer heading wrapper', () => {
+			render(
+				<CollapsibleCard.Root>
+					<CollapsibleCard.Header
+						className="custom-heading"
+						data-testid="header"
+					>
+						<Card.Title>Title</Card.Title>
+					</CollapsibleCard.Header>
+				</CollapsibleCard.Root>
+			);
+
+			const heading = screen.getByRole( 'heading', {
+				level: 3,
+				name: 'Title',
+			} );
+			expect( heading ).toHaveClass( 'custom-heading' );
+			expect( heading ).toHaveAttribute( 'data-testid', 'header' );
+		} );
+	} );
+
 	describe( 'HeaderDescription', () => {
 		it( 'sets aria-describedby on the trigger pointing to the description', () => {
 			render(
@@ -205,6 +282,11 @@ describe( 'CollapsibleCard', () => {
 				'aria-describedby',
 				descriptionElement.id
 			);
+
+			// aria-describedby must be on the inner button (which is what's
+			// being described), not on the outer heading wrapper.
+			const heading = screen.getByRole( 'heading', { name: 'Settings' } );
+			expect( heading ).not.toHaveAttribute( 'aria-describedby' );
 		} );
 
 		it( 'marks the description content as aria-hidden', () => {

--- a/packages/ui/src/collapsible-card/types.ts
+++ b/packages/ui/src/collapsible-card/types.ts
@@ -30,7 +30,7 @@ export interface RootProps extends ComponentProps< 'div' > {
 	disabled?: boolean;
 }
 
-export interface HeaderProps extends ComponentProps< 'div' > {
+export interface HeaderProps extends ComponentProps< 'h3' > {
 	/**
 	 * The content to be rendered inside the header.
 	 */

--- a/packages/ui/src/collapsible-card/types.ts
+++ b/packages/ui/src/collapsible-card/types.ts
@@ -30,7 +30,7 @@ export interface RootProps extends ComponentProps< 'div' > {
 	disabled?: boolean;
 }
 
-export interface HeaderProps extends ComponentProps< 'h3' > {
+export interface HeaderProps extends ComponentProps< 'div' > {
 	/**
 	 * The content to be rendered inside the header.
 	 */

--- a/routes/guidelines/components/guideline-accordion.tsx
+++ b/routes/guidelines/components/guideline-accordion.tsx
@@ -19,13 +19,7 @@ export default function GuidelineAccordion( {
 }: GuidelineAccordionProps ) {
 	return (
 		<CollapsibleCard.Root>
-			<CollapsibleCard.Header
-				render={ ( props ) => (
-					<h2 style={ { margin: 0 } }>
-						<div { ...props } />
-					</h2>
-				) }
-			>
+			<CollapsibleCard.Header render={ <h2 /> }>
 				<VStack spacing={ 1 }>
 					<Card.Title>{ title }</Card.Title>
 					<CollapsibleCard.HeaderDescription>

--- a/routes/guidelines/components/guideline-accordion.tsx
+++ b/routes/guidelines/components/guideline-accordion.tsx
@@ -19,7 +19,13 @@ export default function GuidelineAccordion( {
 }: GuidelineAccordionProps ) {
 	return (
 		<CollapsibleCard.Root>
-			<CollapsibleCard.Header>
+			<CollapsibleCard.Header
+				render={ ( props ) => (
+					<h2 style={ { margin: 0 } }>
+						<div { ...props } />
+					</h2>
+				) }
+			>
 				<VStack spacing={ 1 }>
 					<Card.Title>{ title }</Card.Title>
 					<CollapsibleCard.HeaderDescription>


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/77903#issuecomment-4379035426

## What?

`CollapsibleCard.Header` now wraps its trigger in an outer element. Default is a `<div>`, but consumers can opt into heading semantics via `render={ <h2 /> }` (or any of `<h1>`–`<h6>`) so the card contributes to the document outline. The Guidelines accordion is migrated to the new API.

## Why?

For accessibility — the right heading level depends on the surrounding outline, so `CollapsibleCard.Header` lets the consumer choose. Each Guidelines section now contributes an `<h2>` to the outline, following the [W3C ARIA APG accordion pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/) (heading wraps button).

## Testing Instructions

1. Guidelines page (http://localhost:8888/wp-admin/options-general.php?page=guidelines-wp-admin) — inspect the DOM and confirm each section header is wrapped in an `<h2>`. No visual changes.
2. Storybook (http://localhost:50240/?path=/story/design-system-components-collapsiblecard--with-heading-element) — verify the three cards render with `<h2>`, `<h3>`, and `<div>` (default) wrappers respectively, with no visual differences.
3. Other `CollapsibleCard` stories should still look identical (the wrapper is now an outer `<div>` instead of the trigger directly — visual output unchanged).

<details>
<summary>How / implementation</summary>

- Renders the outer wrapper via Base UI's `useRender` (default `<div>`); the existing `Collapsible.Trigger` + `Card.Header` click target is nested as the wrapper's children.
- We can't put `role="button"` directly on a heading: per ARIA, an explicit role overrides the host's implicit role completely, so the heading would disappear from the accessibility tree. Two elements (heading wraps button) is the only structure that satisfies the APG pattern, hence the always-present outer wrapper.
- Internal CSS resets combine the existing unlayered `defenseStyles.heading` class with a CollapsibleCard-local `.heading-wrapper` class that overrides the `--_gcd-heading-*` custom properties to `inherit` and adds `font-family: inherit; line-height: inherit;`. When the wrapper renders as an h-tag, this protects the inner trigger from UA / wp-admin h-tag styles bleeding in via inheritance. When it renders as a div, the heading-targeted defense is a no-op.

</details>

<details>
<summary>API change summary</summary>

| | Before | After |
| --- | --- | --- |
| Default rendered element | `<div>` (the trigger itself) | `<div>` wrapper around the trigger |
| Add heading semantics | consumer-supplied `render` callback wrapping the trigger | `render={ <h2 /> }` (or any `<h1>`–`<h6>`) |
| `render` prop target | the inner click-target div (`Card.Header`) | the outer wrapper |
| Forwarded props (`className`, `style`, `aria-*`, `data-*`) target | the inner click-target div | the outer wrapper |
| `ref` element type | `HTMLDivElement` | `HTMLElement` |
| `aria-describedby` (auto-wired by `HeaderDescription`) | inner trigger button (unchanged) | inner trigger button (unchanged) |

</details>

<details>
<summary>Keyboard testing</summary>

- Tab into a Guidelines accordion header; press `Enter` / `Space` — the panel expands and collapses as before.
- Use a screen reader (VoiceOver / NVDA / JAWS) to navigate by heading. Each Guidelines section appears in the headings list at level 2.

</details>

## Screenshots or screencast

There shouldn't be any visual changes

## TODO / Follow-ups

## Use of AI Tools

The implementation and documentation were drafted with Claude Code (and the latest iterations with Cursor + Claude). All output was reviewed before commit.
