### PR TITLE
CustomSelectControl: Portal dropdown popover into Popover.Slot by default

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,11 +11,11 @@
 -   `TabPanel`: Fix tab indicator animation while switching tabs ([#77812](https://github.com/WordPress/gutenberg/pull/77812)).
 -   `ColorPicker`: Fix issue where clearing the hex input entirely doesn't reset the selected color to black ([#77912](https://github.com/WordPress/gutenberg/pull/77912)).
 -   `ExternalLink`: Fix focus outline rendered in wp-admin ([#77935](https://github.com/WordPress/gutenberg/pull/77935)).
--   `CustomSelectControl`: Portal the dropdown popover into the registered `Popover.Slot` (with a `document.body` fallback) so it can no longer be clipped by ancestor `overflow` containers (e.g. the Style Panel) or covered by sticky elements (e.g. the block toolbar). Pass `inline` to opt back into the previous inline rendering.
+-   `CustomSelectControl`: Portal the dropdown popover into the registered `Popover.Slot` (with a `document.body` fallback) so it can no longer be clipped by ancestor `overflow` containers (e.g. the Style Panel) or covered by sticky elements (e.g. the block toolbar). Pass `inline` to opt back into the previous inline rendering ([#77969](https://github.com/WordPress/gutenberg/pull/77969)).
 
 ### New Features
 
--   `CustomSelectControlV2` (unstable): Add `portal` and `portalElement` props that forward to the underlying Ariakit `SelectPopover`, allowing the dropdown to be rendered in a React portal.
+-   `CustomSelectControlV2` (unstable): Add `portal` and `portalElement` props that forward to the underlying Ariakit `SelectPopover`, allowing the dropdown to be rendered in a React portal ([#77969](https://github.com/WordPress/gutenberg/pull/77969)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,11 @@
 -   `TabPanel`: Fix tab indicator animation while switching tabs ([#77812](https://github.com/WordPress/gutenberg/pull/77812)).
 -   `ColorPicker`: Fix issue where clearing the hex input entirely doesn't reset the selected color to black ([#77912](https://github.com/WordPress/gutenberg/pull/77912)).
 -   `ExternalLink`: Fix focus outline rendered in wp-admin ([#77935](https://github.com/WordPress/gutenberg/pull/77935)).
+-   `CustomSelectControl`: Portal the dropdown popover into the registered `Popover.Slot` (with a `document.body` fallback) so it can no longer be clipped by ancestor `overflow` containers (e.g. the Style Panel) or covered by sticky elements (e.g. the block toolbar). Pass `inline` to opt back into the previous inline rendering.
+
+### New Features
+
+-   `CustomSelectControlV2` (unstable): Add `portal` and `portalElement` props that forward to the underlying Ariakit `SelectPopover`, allowing the dropdown to be rendered in a React portal.
 
 ### Internal
 

--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -99,6 +99,8 @@ function CustomSelect(
 		store,
 		className,
 		isLegacy = false,
+		portal,
+		portalElement,
 		...restProps
 	} = props;
 
@@ -113,6 +115,13 @@ function CustomSelect(
 		);
 
 	const contextValue = useMemo( () => ( { store, size } ), [ store, size ] );
+
+	// The legacy adapter historically disabled flipping to mask a stacking
+	// context glitch with the block toolbar (see #63180/#63357). When the
+	// popover is portaled, that workaround is no longer needed because the
+	// popover escapes ancestor stacking contexts; let Floating UI flip
+	// near viewport edges, which is also the right thing for #76126.
+	const flip = isLegacy && ! portal ? false : undefined;
 
 	return (
 		// Where should `restProps` be forwarded to?
@@ -149,8 +158,9 @@ function CustomSelect(
 					sameWidth
 					slide={ false }
 					onKeyDown={ onSelectPopoverKeyDown }
-					// Match legacy behavior
-					flip={ ! isLegacy }
+					flip={ flip }
+					portal={ portal }
+					portalElement={ portalElement }
 				>
 					<CustomSelectContext.Provider value={ contextValue }>
 						{ children }

--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -116,15 +116,6 @@ function CustomSelect(
 
 	const contextValue = useMemo( () => ( { store, size } ), [ store, size ] );
 
-	// The legacy adapter historically disabled flipping to mask a stacking
-	// context glitch with the block toolbar (see #63180/#63357). That
-	// workaround is only needed when the popover renders inline; once
-	// portaled, it escapes ancestor stacking contexts and Floating UI's
-	// default flipping is the right behavior (also fixes #76126). The
-	// non-inline branch sets `true` explicitly rather than relying on
-	// Ariakit's default, so the behavior can't drift in future updates.
-	const flip = isLegacy && ! portal ? false : true;
-
 	return (
 		// Where should `restProps` be forwarded to?
 		<div className={ className }>
@@ -160,7 +151,7 @@ function CustomSelect(
 					sameWidth
 					slide={ false }
 					onKeyDown={ onSelectPopoverKeyDown }
-					flip={ flip }
+					flip
 					portal={ portal }
 					portalElement={ portalElement }
 				>

--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -117,11 +117,13 @@ function CustomSelect(
 	const contextValue = useMemo( () => ( { store, size } ), [ store, size ] );
 
 	// The legacy adapter historically disabled flipping to mask a stacking
-	// context glitch with the block toolbar (see #63180/#63357). When the
-	// popover is portaled, that workaround is no longer needed because the
-	// popover escapes ancestor stacking contexts; let Floating UI flip
-	// near viewport edges, which is also the right thing for #76126.
-	const flip = isLegacy && ! portal ? false : undefined;
+	// context glitch with the block toolbar (see #63180/#63357). That
+	// workaround is only needed when the popover renders inline; once
+	// portaled, it escapes ancestor stacking contexts and Floating UI's
+	// default flipping is the right behavior (also fixes #76126). The
+	// non-inline branch sets `true` explicitly rather than relying on
+	// Ariakit's default, so the behavior can't drift in future updates.
+	const flip = isLegacy && ! portal ? false : true;
 
 	return (
 		// Where should `restProps` be forwarded to?

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -77,6 +77,21 @@ export type _CustomSelectProps = CustomSelectButtonProps & {
 	 * Accessible label for the control.
 	 */
 	label: string;
+	/**
+	 * Determines whether the dropdown popover should be rendered as a React
+	 * Portal. When portaled, the popover escapes ancestor stacking contexts
+	 * and `overflow` containers, but consumers lose the ability to target it
+	 * via descendant selectors.
+	 *
+	 * @default false
+	 */
+	portal?: Ariakit.SelectPopoverProps[ 'portal' ];
+	/**
+	 * The DOM element (or a memoized callback returning one) into which the
+	 * popover should be rendered when `portal` is `true`. When omitted, the
+	 * popover is appended to the document `body`.
+	 */
+	portalElement?: Ariakit.SelectPopoverProps[ 'portalElement' ];
 };
 
 export type CustomSelectProps = _CustomSelectProps & CustomSelectSize;

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -9,6 +9,7 @@ import clsx from 'clsx';
  */
 import { useInstanceId } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -19,6 +20,8 @@ import * as Styled from '../custom-select-control-v2/styles';
 import type { CustomSelectProps, CustomSelectOption } from './types';
 import { VisuallyHidden } from '../visually-hidden';
 import { maybeWarnDeprecated36pxSize } from '../utils/deprecated-36px-size';
+import { useSlot } from '../slot-fill';
+import { SLOT_NAME as POPOVER_SLOT_NAME } from '../popover';
 
 function useDeprecatedProps< T extends CustomSelectOption >( {
 	__experimentalShowSelectedHint,
@@ -65,6 +68,7 @@ function CustomSelectControl< T extends CustomSelectOption >(
 		value,
 		className: classNameProp,
 		showSelectedHint = false,
+		inline = false,
 		...restProps
 	} = useDeprecatedProps( props );
 
@@ -187,6 +191,19 @@ function CustomSelectControl< T extends CustomSelectOption >(
 		return size;
 	} )();
 
+	// Portal into the registered `Popover.Slot` so the dropdown escapes the
+	// ancestor stacking contexts (e.g. the block toolbar) and `overflow`
+	// containers (e.g. the Style Panel) of the trigger. Falls back to the
+	// document `body` when no slot is registered, matching how the rest of
+	// `@wordpress/components` overlays behave. Consumers can opt back into
+	// inline rendering via the `inline` prop.
+	const popoverSlot = useSlot( POPOVER_SLOT_NAME );
+	const portalElement = useCallback(
+		( element: HTMLElement ) =>
+			popoverSlot.ref?.current ?? element.ownerDocument.body,
+		[ popoverSlot.ref ]
+	);
+
 	return (
 		<>
 			<CustomSelect
@@ -200,6 +217,8 @@ function CustomSelectControl< T extends CustomSelectOption >(
 					classNameProp
 				) }
 				isLegacy
+				portal={ ! inline }
+				portalElement={ inline ? undefined : portalElement }
 				{ ...restProps }
 			>
 				{ children }

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -9,7 +9,6 @@ import clsx from 'clsx';
  */
 import { useInstanceId } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
-import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -193,16 +192,13 @@ function CustomSelectControl< T extends CustomSelectOption >(
 
 	// Portal into the registered `Popover.Slot` so the dropdown escapes the
 	// ancestor stacking contexts (e.g. the block toolbar) and `overflow`
-	// containers (e.g. the Style Panel) of the trigger. Falls back to the
-	// document `body` when no slot is registered, matching how the rest of
-	// `@wordpress/components` overlays behave. Consumers can opt back into
+	// containers (e.g. the Style Panel) of the trigger. When no slot is
+	// registered, hand `undefined` to Ariakit so it falls back to its
+	// default (a fresh wrapper div appended to the document `body`, which
+	// is properly cleaned up on unmount). Consumers can opt back into
 	// inline rendering via the `inline` prop.
 	const popoverSlot = useSlot( POPOVER_SLOT_NAME );
-	const portalElement = useCallback(
-		( element: HTMLElement ) =>
-			popoverSlot.ref?.current ?? element.ownerDocument.body,
-		[ popoverSlot.ref ]
-	);
+	const portalElement = popoverSlot.ref?.current ?? undefined;
 
 	return (
 		<>

--- a/packages/components/src/custom-select-control/stories/index.story.tsx
+++ b/packages/components/src/custom-select-control/stories/index.story.tsx
@@ -13,6 +13,8 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import CustomSelectControl from '..';
+import { Popover } from '../../popover';
+import { Provider as SlotFillProvider } from '../../slot-fill';
 
 const meta: Meta< typeof CustomSelectControl > = {
 	tags: [ 'manifest' ],
@@ -38,14 +40,22 @@ const meta: Meta< typeof CustomSelectControl > = {
 		},
 	},
 	decorators: [
+		// Mirror the editor's setup: a `SlotFillProvider` at the root with a
+		// `Popover.Slot` registered above the trigger's wrapper. By default,
+		// `CustomSelectControl` portals its dropdown into this slot. Without
+		// this setup, the dropdown falls back to a fresh container in the
+		// document `body`.
 		( Story ) => (
-			<div
-				style={ {
-					minHeight: '150px',
-				} }
-			>
-				<Story />
-			</div>
+			<SlotFillProvider>
+				<div
+					style={ {
+						minHeight: '150px',
+					} }
+				>
+					<Story />
+				</div>
+				<Popover.Slot />
+			</SlotFillProvider>
 		),
 	],
 };

--- a/packages/components/src/custom-select-control/test/index.tsx
+++ b/packages/components/src/custom-select-control/test/index.tsx
@@ -694,6 +694,45 @@ describe.each( [
 	} );
 } );
 
+describe( 'Portaling', () => {
+	/* These tests intentionally assert on DOM tree position to verify the
+	 * popover is portaled (or not) relative to the trigger's wrapper. */
+	/* eslint-disable testing-library/no-node-access */
+	it( 'portals the dropdown listbox outside the trigger wrapper by default', async () => {
+		await render( <UncontrolledCustomSelectControl { ...props } /> );
+
+		const trigger = screen.getByRole( 'combobox', { expanded: false } );
+		const triggerWrapper = trigger.closest(
+			'.components-custom-select-control'
+		);
+		expect( triggerWrapper ).not.toBeNull();
+
+		await click( trigger );
+
+		const listbox = screen.getByRole( 'listbox', { name: props.label } );
+		expect( listbox ).toBeVisible();
+		expect( triggerWrapper?.contains( listbox ) ).toBe( false );
+		expect( document.body.contains( listbox ) ).toBe( true );
+	} );
+
+	it( 'renders the dropdown listbox inline when `inline` is enabled', async () => {
+		await render( <UncontrolledCustomSelectControl { ...props } inline /> );
+
+		const trigger = screen.getByRole( 'combobox', { expanded: false } );
+		const triggerWrapper = trigger.closest(
+			'.components-custom-select-control'
+		);
+		expect( triggerWrapper ).not.toBeNull();
+
+		await click( trigger );
+
+		const listbox = screen.getByRole( 'listbox', { name: props.label } );
+		expect( listbox ).toBeVisible();
+		expect( triggerWrapper?.contains( listbox ) ).toBe( true );
+	} );
+	/* eslint-enable testing-library/no-node-access */
+} );
+
 describe( 'Type checking', () => {
 	// eslint-disable-next-line jest/expect-expect
 	it( 'should infer the value type from available `options`, but not the `value` or `onChange` prop', () => {

--- a/packages/components/src/custom-select-control/types.ts
+++ b/packages/components/src/custom-select-control/types.ts
@@ -127,4 +127,17 @@ export type CustomSelectProps< T extends CustomSelectOption > = {
 	 * @ignore
 	 */
 	__shouldNotWarnDeprecated36pxSize?: boolean;
+	/**
+	 * By default, the dropdown popover is portaled into the registered
+	 * `Popover.Slot` (or, when no slot is registered, into the document
+	 * `body`). Portaling allows the popover to escape ancestor stacking
+	 * contexts and `overflow` containers, which prevents it from being
+	 * clipped or covered by sticky elements like the block toolbar.
+	 *
+	 * Set this to `true` to opt back into the previous inline rendering,
+	 * where the popover is rendered next to the trigger in the DOM tree.
+	 *
+	 * @default false
+	 */
+	inline?: boolean;
 };


### PR DESCRIPTION
Closes #76126
Closes #63180
Follow up to #63357
Alt to #77947

## What?

Render the legacy `CustomSelectControl` dropdown popover in a React portal by default — into the registered `Popover.Slot`, with a `document.body` fallback — so it can no longer be clipped by ancestor `overflow` containers (e.g. the Style Panel) or covered by sticky elements (e.g. the block toolbar).

A new `inline` prop is exposed as an opt-out for consumers that need the previous inline DOM rendering.

## Why?

The dropdown rendered inline in the DOM, so it inherited the trigger's ancestor stacking contexts and `overflow` containers. That causes #63180 (toolbar overlap) and #76126 (Style Panel clipping). #63357 disabled flipping to mask #63180 and left #76126 unfixed. Portaling addresses both at the root.

## How?

- Internal v2 (`custom-select-control-v2/custom-select.tsx`) accepts and forwards `portal` and `portalElement` to the Ariakit `SelectPopover`.
- Legacy `CustomSelectControl` reads `Popover.Slot` via `useSlot('Popover')` and defaults to `portal=true`.
- The legacy `flip={false}` workaround now applies only when not portaled.
- New `inline` prop on the legacy adapter restores the previous behavior (no portal, no flip).

<details>
<summary>API and design notes</summary>

- `inline` mirrors `Popover`'s existing public prop. Same name, same default (`false`).
- The choice was default-on with an opt-out (rather than opt-in) because the bugs affect every editor consumer of the legacy adapter; an opt-in would leave the broken default in place.
- The high `z-index: 1000000` on the popover was a no-op while inline (it only operated within the trigger's stacking context). Once portaled it stacks at `body` / `Popover.Slot` level, alongside `Popover` and `Menu.Popover`, and the value is meaningful.
- v2 (`CustomSelectControlV2`) gains the new props through pass-through. No default change.

</details>

## Testing Instructions

1. **#76126 (Style Panel clipping):** Select a block exposing a Style Panel combobox (Border Radius, Font Size, Font Family). Resize the window so the panel is short and the combobox sits near the bottom edge. Click the combobox → dropdown should be fully visible and flip upward.
2. **#63180 (toolbar overlap):** With a short viewport, open a dropdown in the block toolbar so it would naturally render upward → dropdown should sit above the sticky toolbar header.
3. Pass `inline` to a legacy `CustomSelectControl` and confirm the previous behavior is preserved (popover rendered inline next to the trigger, no flipping near viewport edges).

<details>
<summary>Places in Gutenberg to spot-check</summary>

The legacy `CustomSelectControl` is used in many places. A few representative spots covering different mounting contexts:

**Style Panel (inspector controls, in a scroll container):**
- `FontFamily` picker — `packages/block-editor/src/components/font-family/index.js`
- `FontAppearance` picker — `packages/block-editor/src/components/font-appearance-control/index.js`
- `FontSizePicker` (select variant, when many presets exist) — `packages/components/src/font-size-picker/font-size-picker-select.tsx`
- `BorderRadiusControl` — via `PresetInputControl` (`packages/block-editor/src/components/preset-input-control/index.js`)
- `SpacingSizesControl` — via `PresetInputControl`
- `DimensionControl` — `packages/block-editor/src/components/dimension-control/index.js`
- Position control — `packages/block-editor/src/hooks/position.js`

**Editor (outside the Style Panel):**
- Date format picker (e.g. Site Logo / Post Date inspector) — `packages/block-editor/src/components/date-format-picker/index.js`
- Block-level inspector dropdowns (Latest Posts / Query Loop / Comments / Table / Navigation Link orders, taxonomies, etc. — search the block-library for `CustomSelectControl`)
- Validated DataForm fields — `packages/components/src/validated-form-controls/components/custom-select-control.tsx`

For each: open the dropdown via mouse and via keyboard (Tab → Enter/Space, Up/Down to navigate, Enter to select, Escape to close, focus returns to trigger).

</details>

### Testing Instructions for Keyboard

- Tab into a legacy combobox and press Enter or Space — dropdown opens.
- Use Up/Down arrows to navigate options; Enter to select.
- Escape to close — focus returns to the trigger.
- Repeat the Style Panel and toolbar repros (steps 1 and 2 above) using the keyboard only.

## Screenshots or screencast

| Before | After |
|-|-|
| <!-- Style Panel clipping repro --> | <!-- Style Panel: dropdown flips and stays visible --> |
| <!-- Toolbar overlap repro --> | <!-- Toolbar: dropdown renders above sticky header --> |

## TODO / Follow-ups

- Cross-document iframe handling (StyleProvider rewrap for popovers triggered from inside the canvas iframe) is intentionally out of scope; existing legacy `CustomSelectControl` consumers all live in the parent document. If a cross-document case surfaces, follow `Popover`'s `<Fill>` + `StyleProvider` pattern.

## Use of AI Tools

- Cursor / Claude Sonnet for the initial investigation, drafting this description, and implementation.