### PR TITLE
Fix flaky Menu space key unit test

### DIFF
--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -161,7 +161,7 @@ describe( 'Menu', () => {
 				<Menu>
 					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
 					<Menu.Popover>
-						<Menu.Item disabled>First item</Menu.Item>
+						<Menu.Item>First item</Menu.Item>
 						<Menu.Item>Second item</Menu.Item>
 						<Menu.Item>Third item</Menu.Item>
 					</Menu.Popover>
@@ -183,7 +183,6 @@ describe( 'Menu', () => {
 			await press.Space();
 
 			// Menu open, focus is on the first focusable item
-			// (disabled items are still focusable and accessible
 			await waitForFocusedMenuItem( 'First item' );
 		} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes a flaky `Menu` unit test by avoiding duplicate coverage of disabled item focus behavior in the Space-key trigger test.

## Why?

The recent CI failures all had the same shape: after pressing Space on the menu trigger, the menu opened but focus stayed on the menu container instead of moving to the disabled first menu item. The ArrowDown test already covers focusing disabled-but-accessible menu items, so the Space-key test can focus on whether Space opens the menu and moves focus to the first normal item.

## How?

Updates the Space-key test fixture so its first menu item is not disabled, and removes the disabled-item-specific test comment from that case.

## Testing Instructions

1. Run `npm run test:unit packages/components/src/menu/test/index.tsx -- --runInBand`.

