### PR TITLE
Site Editor e2e tests: reimplement the wait for load

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -53,38 +53,48 @@ export async function visitSiteEditor(
 	}
 
 	/**
-	 * @todo This is a workaround for the fact that the editor canvas is seen as
-	 * ready and visible before the loading spinner is hidden. Ideally, the
-	 * content underneath the loading overlay should be marked inert until the
-	 * loading is done.
+	 * Wait until the editor is loaded. The logic is a copy of the
+	 * `waitWhileSiteEditorLoading` function in the `edit-site` package.
 	 */
 	if ( ! query.size || postId || canvas === 'edit' ) {
-		const canvasLoader = this.page.locator(
-			// Spinner was used instead of the progress bar in an earlier
-			// version of the site editor.
-			'.edit-site-canvas-loader, .edit-site-canvas-spinner'
-		);
+		await this.page.evaluate( () => {
+			const MAX_LOADING_TIME = 10000;
+			const MAX_PAUSE_TIME = 100;
 
-		try {
-			// Wait for the canvas loader to appear first, so that the locator that
-			// waits for the hidden state doesn't resolve prematurely. The loader
-			// either renders within a tick or it is skipped entirely (when the
-			// editor finishes resolving inside the artificial-delay window in
-			// `useIsSiteEditorLoading`), so a long visible-state timeout is just
-			// wasted wall clock when the loader never shows up.
-			await canvasLoader.waitFor( { state: 'visible', timeout: 3_000 } );
-			await canvasLoader.waitFor( {
-				state: 'hidden',
-				// Bigger timeout is needed for larger entities, like the Large Post
-				// HTML fixture that we load for performance tests, which often
-				// doesn't make it under the default timeout value.
-				timeout: 60_000,
+			return new Promise< void >( ( resolve ) => {
+				let pauseTimeout: ReturnType< typeof setTimeout > | undefined;
+
+				function finish() {
+					unsubscribe();
+					clearTimeout( pauseTimeout );
+					clearTimeout( maxTimeout );
+					resolve();
+				}
+
+				const maxTimeout = setTimeout( finish, MAX_LOADING_TIME );
+
+				function checkResolving() {
+					const isResolving = window.wp.data
+						.select( 'core' )
+						.hasResolvingSelectors();
+
+					if ( isResolving ) {
+						clearTimeout( pauseTimeout );
+						pauseTimeout = undefined;
+						return;
+					}
+
+					if ( ! pauseTimeout ) {
+						pauseTimeout = setTimeout( finish, MAX_PAUSE_TIME );
+					}
+				}
+
+				const unsubscribe = window.wp.data.subscribe(
+					checkResolving,
+					'core'
+				);
+				checkResolving();
 			} );
-		} catch {
-			// If the canvas loader is already disappeared, skip the waiting.
-			await this.page
-				.getByRole( 'region', { name: 'Editor content' } )
-				.waitFor();
-		}
+		} );
 	}
 }

--- a/packages/edit-site/src/components/add-new-template-legacy/utils.js
+++ b/packages/edit-site/src/components/add-new-template-legacy/utils.js
@@ -719,15 +719,19 @@ const useEntitiesInfo = (
 						recordsToExcludePerEntity?.[ slug ]?.map(
 							( { id } ) => id
 						) || [];
-					accumulator[ slug ] = !! select(
-						coreStore
-					).getEntityRecords( entityName, slug, {
-						per_page: 1,
-						_fields: 'id',
-						context: 'view',
-						exclude: existingEntitiesIds,
-						...additionalQueryParameters[ slug ],
-					} )?.length;
+					const records = select( coreStore ).getEntityRecords(
+						entityName,
+						slug,
+						{
+							per_page: 1,
+							_fields: 'id',
+							context: 'view',
+							exclude: existingEntitiesIds,
+							...additionalQueryParameters[ slug ],
+						}
+					);
+					accumulator[ slug ] =
+						records === null || records.length > 0;
 					return accumulator;
 				},
 				{}

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -621,14 +621,18 @@ const useEntitiesInfo = (
 		( select ) => {
 			return Object.keys( templatePrefixes || {} ).reduce(
 				( accumulator, slug ) => {
-					accumulator[ slug ] = !! select(
-						coreStore
-					).getEntityRecords( entityName, slug, {
-						per_page: 1,
-						_fields: 'id',
-						context: 'view',
-						...additionalQueryParameters[ slug ],
-					} )?.length;
+					const records = select( coreStore ).getEntityRecords(
+						entityName,
+						slug,
+						{
+							per_page: 1,
+							_fields: 'id',
+							context: 'view',
+							...additionalQueryParameters[ slug ],
+						}
+					);
+					accumulator[ slug ] =
+						records === null || records.length > 0;
 					return accumulator;
 				},
 				{}

--- a/packages/edit-site/src/components/layout/hooks.js
+++ b/packages/edit-site/src/components/layout/hooks.js
@@ -2,61 +2,82 @@
  * WordPress dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { select, subscribe } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
 const MAX_LOADING_TIME = 10000; // 10 seconds
+const MAX_PAUSE_TIME = 100;
+
+/**
+ * Waits until the site editor has finished its initial loading.
+ *
+ * Resolves when there's a pause in resolving selectors (no active requests
+ * for at least MAX_PAUSE_TIME ms), or after MAX_LOADING_TIME as a fallback
+ * to prevent failed requests from blocking the editor indefinitely.
+ *
+ * @return {Promise<void>} Resolves when loading is considered complete.
+ */
+function waitWhileSiteEditorLoading() {
+	let pauseTimeout;
+
+	const { promise, resolve } = Promise.withResolvers();
+
+	function finish() {
+		unsubscribe();
+		clearTimeout( pauseTimeout );
+		clearTimeout( maxTimeout );
+		resolve();
+	}
+
+	/*
+	 * If the maximum expected loading time has passed, we consider the
+	 * editor loaded, in order to prevent any failed requests from blocking
+	 * the editor canvas from appearing.
+	 */
+	const maxTimeout = setTimeout( finish, MAX_LOADING_TIME );
+
+	function checkResolving() {
+		const isResolving = select( coreStore ).hasResolvingSelectors();
+
+		if ( isResolving ) {
+			clearTimeout( pauseTimeout );
+			pauseTimeout = undefined;
+			return;
+		}
+
+		/*
+		 * We're using an arbitrary 100ms timeout here to catch brief
+		 * moments without any resolving selectors that would result in
+		 * displaying brief flickers of loading state and loaded state.
+		 *
+		 * It's worth experimenting with different values, since this also
+		 * adds 100ms of artificial delay after loading has finished.
+		 */
+		if ( ! pauseTimeout ) {
+			pauseTimeout = setTimeout( finish, MAX_PAUSE_TIME );
+		}
+	}
+
+	const unsubscribe = subscribe( checkResolving, coreStore );
+	checkResolving();
+
+	function cancel() {
+		unsubscribe();
+		clearTimeout( pauseTimeout );
+		clearTimeout( maxTimeout );
+	}
+
+	return [ promise, cancel ];
+}
 
 export function useIsSiteEditorLoading() {
 	const [ loaded, setLoaded ] = useState( false );
-	const inLoadingPause = useSelect(
-		( select ) => {
-			const hasResolvingSelectors =
-				select( coreStore ).hasResolvingSelectors();
-			return ! loaded && ! hasResolvingSelectors;
-		},
-		[ loaded ]
-	);
-
-	/*
-	 * If the maximum expected loading time has passed, we're marking the
-	 * editor as loaded, in order to prevent any failed requests from blocking
-	 * the editor canvas from appearing.
-	 */
-	useEffect( () => {
-		let timeout;
-
-		if ( ! loaded ) {
-			timeout = setTimeout( () => {
-				setLoaded( true );
-			}, MAX_LOADING_TIME );
-		}
-
-		return () => {
-			clearTimeout( timeout );
-		};
-	}, [ loaded ] );
 
 	useEffect( () => {
-		if ( inLoadingPause ) {
-			/*
-			 * We're using an arbitrary 100ms timeout here to catch brief
-			 * moments without any resolving selectors that would result in
-			 * displaying brief flickers of loading state and loaded state.
-			 *
-			 * It's worth experimenting with different values, since this also
-			 * adds 100ms of artificial delay after loading has finished.
-			 */
-			const ARTIFICIAL_DELAY = 100;
-			const timeout = setTimeout( () => {
-				setLoaded( true );
-			}, ARTIFICIAL_DELAY );
-
-			return () => {
-				clearTimeout( timeout );
-			};
-		}
-	}, [ inLoadingPause ] );
+		const [ promise, cancel ] = waitWhileSiteEditorLoading();
+		promise.then( () => setLoaded( true ) );
+		return cancel;
+	}, [] );
 
 	return ! loaded;
 }

--- a/routes/template-list/add-new-template/utils.ts
+++ b/routes/template-list/add-new-template/utils.ts
@@ -641,14 +641,18 @@ const useEntitiesInfo = (
 		( select ) => {
 			return Object.keys( templatePrefixes || {} ).reduce(
 				( accumulator: any, slug ) => {
-					accumulator[ slug ] = !! select(
-						coreStore
-					).getEntityRecords( entityName, slug, {
-						per_page: 1,
-						_fields: 'id',
-						context: 'view',
-						...additionalQueryParameters[ slug ],
-					} )?.length;
+					const records = select( coreStore ).getEntityRecords(
+						entityName,
+						slug,
+						{
+							per_page: 1,
+							_fields: 'id',
+							context: 'view',
+							...additionalQueryParameters[ slug ],
+						}
+					);
+					accumulator[ slug ] =
+						records === null || records.length > 0;
 					return accumulator;
 				},
 				{}


### PR DESCRIPTION
Reimplemement e2e wait for site editor load to reuse the `useIsSiteEditorLoading` logic. Alternative to #77726.

This PR refactors the `useIsSiteEditorLoading` hook by extracting the waiting logic to a separate `waitWhileSiteEditorLoading` function that returns a promise. The hook itself then only calls the function in an effect, calls `setState` when it finishes, and does a cleanup in case of a sudden unmount.

Then I copy the waiting logic to the `visitSiteEditor` e2e helper. It's a copy because we run the e2e tests also against older versions, like `trunk`, and they don't have the `waitWhileSiteEditorLoading` yet. The e2e tests must ship the logic independently.

This `waitWhileSiteEditorLoading` code is a "first principles" way to do the waiting, it observes the network activity in the `core` data store and the maximum delay it can ever introduce is 100ms. No need to search for the canvas loader DOM element and handle cases where it didn't appear yet or has already disappeared.

Similar to #77726, it's hard to tell whether there is a speedup with a "naked eye". The "Performance Tests" job runs in the 37m-39m range both in this and other recent PRs. A good method to check this will be to observe the long-term series before and after this PR. Is the average run time lower after merge or not?

I'm also fixing a bug in the `AddNewTemplate` modal which was uncovered by this PR, as it turned a flaky e2e test into a permanent failure. When you want to create a new "Single item: Post" template, sometimes you'll see this modal:

<img width="839" height="303" alt="Screenshot 2026-05-07 at 8 37 24" src="https://github.com/user-attachments/assets/3be79345-f219-4330-ab58-ab8336338fa0" />

The condition to show it is that there are actually some posts that can have a "specific item" template: a post exists and doesn't have such a template already. But the logic to determine this is racy: at the time when I click on the "create template" button, the `useEntitiesInfo` hook hasn't finished fetching the posts and returns a `hasEntities: false` value. Even though there are posts. Then the modal won't be shown at all and the e2e test (`site-editor-url-navigation.spec.js`) that expects to see the modal will fail. This is now fixed by defaulting the `hasEntities` value to `true`. If the fetching hasn't finished yet, we are optimistic and show the modal anyway. It can handle the case when there are no posts pretty well. There are three copies of this logic (!) in our codebase, I'm not sure why, but I'm fixing them all.