### PR TITLE
RTC: Fix compaction unit test

### DIFF
--- a/backport-changelog/7.0/11716.md
+++ b/backport-changelog/7.0/11716.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/11716
 
 * https://github.com/WordPress/gutenberg/pull/77980
+* https://github.com/WordPress/gutenberg/pull/77986

--- a/phpunit/tests/collaboration/wpHttpPollingSyncServer.php
+++ b/phpunit/tests/collaboration/wpHttpPollingSyncServer.php
@@ -915,7 +915,7 @@ class Tests_Collaboration_WpHttpPollingSyncServer extends WP_Test_REST_Controlle
 		$this->assertFalse( $data['rooms'][0]['should_compact'] );
 	}
 
-	public function test_sync_stale_compaction_succeeds_when_newer_compaction_exists() {
+	public function test_sync_stale_compaction_is_stored_as_update_when_newer_compaction_exists() {
 		wp_set_current_user( self::$editor_id );
 
 		$room   = $this->get_post_room();
@@ -945,9 +945,12 @@ class Tests_Collaboration_WpHttpPollingSyncServer extends WP_Test_REST_Controlle
 			)
 		);
 
-		// Client 3 sends a stale compaction at cursor 0. The server should find
-		// client 2's compaction in the updates after cursor 0 and silently discard
-		// this one.
+		// Client 3 sends a stale compaction at cursor 0 (mirroring two offline
+		// clients that reconnect from the same baseline cursor). The server
+		// cannot run remove_updates_before_cursor because client 2 has already
+		// advanced the frontier, but the bytes must still be stored as a
+		// regular update so client 3's operations can propagate to other
+		// clients via Yjs state-as-update merging.
 		$stale_compaction = array(
 			'type' => 'compaction',
 			'data' => 'c3RhbGU=',
@@ -960,16 +963,29 @@ class Tests_Collaboration_WpHttpPollingSyncServer extends WP_Test_REST_Controlle
 
 		$this->assertSame( 200, $response->get_status() );
 
-		// Verify the newer compaction is preserved and the stale one was not stored.
-		$response    = $this->dispatch_sync(
+		// Verify the newer compaction is preserved AND the stale compaction's
+		// bytes were persisted (now as type=update so subsequent compactions
+		// don't trip the has_newer_compaction check).
+		$response = $this->dispatch_sync(
 			array(
 				$this->build_room( $room, 4, 0, array( 'user' => 'c4' ) ),
 			)
 		);
-		$update_data = wp_list_pluck( $response->get_data()['rooms'][0]['updates'], 'data' );
+		$updates  = $response->get_data()['rooms'][0]['updates'];
 
+		$update_data = wp_list_pluck( $updates, 'data' );
 		$this->assertContains( 'Y29tcGFjdGVk', $update_data, 'The newer compaction should be preserved.' );
-		$this->assertNotContains( 'c3RhbGU=', $update_data, 'The stale compaction should not be stored.' );
+		$this->assertContains( 'c3RhbGU=', $update_data, 'The stale compaction bytes should be stored so client 3\'s operations propagate.' );
+
+		$stale_entry = null;
+		foreach ( $updates as $entry ) {
+			if ( 'c3RhbGU=' === $entry['data'] ) {
+				$stale_entry = $entry;
+				break;
+			}
+		}
+		$this->assertNotNull( $stale_entry, 'The stale compaction entry should be present in the room.' );
+		$this->assertSame( 'update', $stale_entry['type'], 'The stale compaction should be stored as type=update, not type=compaction.' );
 	}
 
 	/*


### PR DESCRIPTION
## What?

This PR is part of a couple related PRs for fixing a sync issue in RTC:

- Gutenberg fix: https://github.com/WordPress/gutenberg/pull/77980
- Backport to core: https://github.com/WordPress/wordpress-develop/pull/11716

We should be able to merge the Gutenberg PR, but because core replaces the `WP_HTTP_Polling_Sync_Server` class, the changes in that PR won't actually be running in tests. Once the backport merges, it will, and then the `test_sync_stale_compaction_succeeds_when_newer_compaction_exists()` test will start failing.

Note that the fixed unit test in this PR is expected to fail until the backport is merged.

## Why?

So we can fix failing unit tests once the backport PR is merged.

## How?

This PR updates the unit test `test_sync_stale_compaction_succeeds_when_newer_compaction_exists()` to match the new server-side logic which allows multiple compaction results to be processed.

## Testing Instructions

1. See CI tests pass (after https://github.com/WordPress/wordpress-develop/pull/11716 is merged)
2. Rejoice!

Tests can also be run locally via:

```
 npm run test:unit:php:base -- --filter test_sync_stale_compaction_is_stored_as_update_when_newer_compaction_exists phpunit/tests/collaboration/wpHttpPollingSyncServer.php
 ```
