### PR TITLE
UI: Add component status notes to Storybook

### DIFF
--- a/packages/components/src/alignment-matrix-control/stories/index.story.tsx
+++ b/packages/components/src/alignment-matrix-control/stories/index.story.tsx
@@ -34,7 +34,7 @@ const meta: Meta< typeof AlignmentMatrixControl > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'editor',
 		},
 	},

--- a/packages/components/src/angle-picker-control/stories/index.story.tsx
+++ b/packages/components/src/angle-picker-control/stories/index.story.tsx
@@ -30,7 +30,7 @@ const meta: Meta< typeof AnglePickerControl > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'editor',
 		},
 	},

--- a/packages/components/src/base-control/stories/index.story.tsx
+++ b/packages/components/src/base-control/stories/index.story.tsx
@@ -26,7 +26,7 @@ const meta: Meta< typeof BaseControl > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `Field` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/border-box-control/stories/index.story.tsx
+++ b/packages/components/src/border-box-control/stories/index.story.tsx
@@ -26,7 +26,7 @@ const meta: Meta< typeof BorderBoxControl > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'editor',
 		},
 	},

--- a/packages/components/src/border-control/stories/index.story.tsx
+++ b/packages/components/src/border-control/stories/index.story.tsx
@@ -29,7 +29,7 @@ const meta: Meta< typeof BorderControl > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'editor',
 		},
 	},

--- a/packages/components/src/button/stories/index.story.tsx
+++ b/packages/components/src/button/stories/index.story.tsx
@@ -53,7 +53,7 @@ const meta: Meta< typeof Button > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `Button` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/checkbox-control/stories/index.story.tsx
+++ b/packages/components/src/checkbox-control/stories/index.story.tsx
@@ -36,7 +36,7 @@ const meta: Meta< typeof CheckboxControl > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `CheckboxControl` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/color-indicator/stories/index.story.tsx
+++ b/packages/components/src/color-indicator/stories/index.story.tsx
@@ -24,7 +24,7 @@ const meta: Meta< typeof ColorIndicator > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/color-palette/stories/index.story.tsx
+++ b/packages/components/src/color-palette/stories/index.story.tsx
@@ -28,7 +28,7 @@ const meta: Meta< typeof ColorPalette > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/color-picker/stories/index.story.tsx
+++ b/packages/components/src/color-picker/stories/index.story.tsx
@@ -27,7 +27,7 @@ const meta: Meta< typeof ColorPicker > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/combobox-control/stories/index.story.tsx
+++ b/packages/components/src/combobox-control/stories/index.story.tsx
@@ -50,7 +50,7 @@ const meta: Meta< typeof ComboboxControl > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `SearchableSelectControl` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -49,7 +49,7 @@ const meta: Meta< typeof Composite > = {
 			canvas: { sourceState: 'shown' },
 		},
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/confirm-dialog/stories/index.story.tsx
+++ b/packages/components/src/confirm-dialog/stories/index.story.tsx
@@ -34,7 +34,7 @@ const meta: Meta< typeof ConfirmDialog > = {
 			expanded: true,
 		},
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 		docs: { canvas: { sourceState: 'shown' } },

--- a/packages/components/src/custom-select-control/stories/index.story.tsx
+++ b/packages/components/src/custom-select-control/stories/index.story.tsx
@@ -32,7 +32,7 @@ const meta: Meta< typeof CustomSelectControl > = {
 			source: { excludeDecorators: true },
 		},
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `SelectControl` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/disabled/stories/index.story.tsx
+++ b/packages/components/src/disabled/stories/index.story.tsx
@@ -32,7 +32,7 @@ const meta: Meta< typeof Disabled > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/drop-zone/stories/index.story.tsx
+++ b/packages/components/src/drop-zone/stories/index.story.tsx
@@ -37,7 +37,7 @@ const meta: Meta< typeof DropZone > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/dropdown/stories/index.story.tsx
+++ b/packages/components/src/dropdown/stories/index.story.tsx
@@ -43,7 +43,7 @@ const meta: Meta< typeof Dropdown > = {
 			expanded: true,
 		},
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/duotone-picker/stories/duotone-picker.story.tsx
+++ b/packages/components/src/duotone-picker/stories/duotone-picker.story.tsx
@@ -25,7 +25,7 @@ const meta: Meta< typeof DuotonePicker > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'editor',
 		},
 	},

--- a/packages/components/src/duotone-picker/stories/duotone-swatch.story.tsx
+++ b/packages/components/src/duotone-picker/stories/duotone-swatch.story.tsx
@@ -15,7 +15,7 @@ const meta: Meta< typeof DuotoneSwatch > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'editor',
 		},
 	},

--- a/packages/components/src/focal-point-picker/stories/index.story.tsx
+++ b/packages/components/src/focal-point-picker/stories/index.story.tsx
@@ -30,7 +30,7 @@ const meta: Meta< typeof FocalPointPicker > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'editor',
 		},
 	},

--- a/packages/components/src/font-size-picker/stories/index.story.tsx
+++ b/packages/components/src/font-size-picker/stories/index.story.tsx
@@ -31,7 +31,7 @@ const meta: Meta< typeof FontSizePicker > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'editor',
 		},
 	},

--- a/packages/components/src/form-file-upload/stories/index.story.tsx
+++ b/packages/components/src/form-file-upload/stories/index.story.tsx
@@ -27,7 +27,7 @@ const meta: Meta< typeof FormFileUpload > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/form-toggle/stories/index.story.tsx
+++ b/packages/components/src/form-toggle/stories/index.story.tsx
@@ -28,7 +28,7 @@ const meta: Meta< typeof FormToggle > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'For standard toggles with labels, use `ToggleControl` instead.',
 		},

--- a/packages/components/src/form-token-field/stories/index.story.tsx
+++ b/packages/components/src/form-token-field/stories/index.story.tsx
@@ -33,7 +33,7 @@ const meta: Meta< typeof FormTokenField > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `SearchableChipSelect` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/gradient-picker/stories/index.story.tsx
+++ b/packages/components/src/gradient-picker/stories/index.story.tsx
@@ -23,7 +23,7 @@ const meta: Meta< typeof GradientPicker > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/guide/stories/index.story.tsx
+++ b/packages/components/src/guide/stories/index.story.tsx
@@ -26,7 +26,7 @@ const meta: Meta< typeof Guide > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'editor',
 		},
 	},

--- a/packages/components/src/icon/stories/index.story.tsx
+++ b/packages/components/src/icon/stories/index.story.tsx
@@ -23,7 +23,7 @@ const meta: Meta< typeof Icon > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Prefer this component over the `Icon` component from `@wordpress/icons`.',
 		},

--- a/packages/components/src/input-control/stories/index.story.tsx
+++ b/packages/components/src/input-control/stories/index.story.tsx
@@ -41,7 +41,7 @@ const meta: Meta< typeof InputControl > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `InputControl` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/item-group/stories/index.story.tsx
+++ b/packages/components/src/item-group/stories/index.story.tsx
@@ -24,7 +24,7 @@ const meta: Meta< typeof ItemGroup > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/keyboard-shortcuts/stories/index.story.tsx
+++ b/packages/components/src/keyboard-shortcuts/stories/index.story.tsx
@@ -17,7 +17,7 @@ const meta: Meta< typeof KeyboardShortcuts > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/menu-group/stories/index.story.tsx
+++ b/packages/components/src/menu-group/stories/index.story.tsx
@@ -27,7 +27,7 @@ const meta: Meta< typeof MenuGroup > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Subcomponent of `DropdownMenu`.',
 		},

--- a/packages/components/src/menu-item/stories/index.story.tsx
+++ b/packages/components/src/menu-item/stories/index.story.tsx
@@ -38,7 +38,7 @@ const meta: Meta< typeof MenuItem > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Subcomponent of `DropdownMenu`.',
 		},

--- a/packages/components/src/menu-items-choice/stories/index.story.tsx
+++ b/packages/components/src/menu-items-choice/stories/index.story.tsx
@@ -30,7 +30,7 @@ const meta: Meta< typeof MenuItemsChoice > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Subcomponent of `DropdownMenu`.',
 		},

--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -56,7 +56,7 @@ const meta: Meta< typeof Menu > = {
 			source: { excludeDecorators: true },
 		},
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'When building for the Gutenberg repo, use this component instead of `DropdownMenu`. Otherwise, continue using `DropdownMenu` for now.',
 		},

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -46,7 +46,7 @@ const meta: Meta< typeof Modal > = {
 	parameters: {
 		controls: { expanded: true },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `Dialog` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -30,7 +30,7 @@ const meta: Meta< typeof Navigator > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/notice/stories/index.story.tsx
+++ b/packages/components/src/notice/stories/index.story.tsx
@@ -31,7 +31,7 @@ const meta: Meta< typeof Notice > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `Notice` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/number-control/stories/index.story.tsx
+++ b/packages/components/src/number-control/stories/index.story.tsx
@@ -30,7 +30,7 @@ const meta: Meta< typeof NumberControl > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `InputControl` with `type="number"` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/palette-edit/stories/index.story.tsx
+++ b/packages/components/src/palette-edit/stories/index.story.tsx
@@ -25,7 +25,7 @@ const meta: Meta< typeof PaletteEdit > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'editor',
 		},
 	},

--- a/packages/components/src/panel/stories/index.story.tsx
+++ b/packages/components/src/panel/stories/index.story.tsx
@@ -29,7 +29,7 @@ const meta: Meta< typeof Panel > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/placeholder/stories/index.story.tsx
+++ b/packages/components/src/placeholder/stories/index.story.tsx
@@ -34,7 +34,7 @@ const meta: Meta< typeof Placeholder > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'editor',
 		},
 	},

--- a/packages/components/src/popover/stories/index.story.tsx
+++ b/packages/components/src/popover/stories/index.story.tsx
@@ -57,7 +57,7 @@ const meta: Meta< typeof Popover > = {
 	parameters: {
 		controls: { expanded: true },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/progress-bar/stories/index.story.tsx
+++ b/packages/components/src/progress-bar/stories/index.story.tsx
@@ -22,7 +22,7 @@ const meta: Meta< typeof ProgressBar > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/query-controls/stories/index.story.tsx
+++ b/packages/components/src/query-controls/stories/index.story.tsx
@@ -41,7 +41,7 @@ const meta: Meta< typeof QueryControls > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'editor',
 		},
 	},

--- a/packages/components/src/radio-control/stories/index.story.tsx
+++ b/packages/components/src/radio-control/stories/index.story.tsx
@@ -38,7 +38,7 @@ const meta: Meta< typeof RadioControl > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `RadioGroupControl` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/range-control/stories/index.story.tsx
+++ b/packages/components/src/range-control/stories/index.story.tsx
@@ -59,7 +59,7 @@ const meta: Meta< typeof RangeControl > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `SliderControl` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/resizable-box/stories/index.story.tsx
+++ b/packages/components/src/resizable-box/stories/index.story.tsx
@@ -27,7 +27,7 @@ const meta: Meta< typeof ResizableBox > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/sandbox/stories/index.story.tsx
+++ b/packages/components/src/sandbox/stories/index.story.tsx
@@ -24,7 +24,7 @@ const meta: Meta< typeof SandBox > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/scroll-lock/stories/index.story.tsx
+++ b/packages/components/src/scroll-lock/stories/index.story.tsx
@@ -24,7 +24,7 @@ const meta: Meta< typeof ScrollLock > = {
 		controls: { hideNoControlsWarning: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/search-control/stories/index.story.tsx
+++ b/packages/components/src/search-control/stories/index.story.tsx
@@ -26,7 +26,7 @@ const meta: Meta< typeof SearchControl > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `SearchControl` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/select-control/stories/index.story.tsx
+++ b/packages/components/src/select-control/stories/index.story.tsx
@@ -34,7 +34,7 @@ const meta: Meta< typeof SelectControl > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `SelectControl` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/shortcut/stories/index.story.tsx
+++ b/packages/components/src/shortcut/stories/index.story.tsx
@@ -19,7 +19,7 @@ const meta: Meta< typeof Shortcut > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/slot-fill/stories/index.story.tsx
+++ b/packages/components/src/slot-fill/stories/index.story.tsx
@@ -28,7 +28,7 @@ const meta: Meta< typeof Slot > = {
 		controls: { expanded: true },
 		docs: { source: { state: 'open' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/snackbar/stories/index.story.tsx
+++ b/packages/components/src/snackbar/stories/index.story.tsx
@@ -39,7 +39,7 @@ const meta: Meta< typeof Snackbar > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/spinner/stories/index.story.tsx
+++ b/packages/components/src/spinner/stories/index.story.tsx
@@ -20,7 +20,7 @@ const meta: Meta< typeof Spinner > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/tabs/stories/index.story.tsx
+++ b/packages/components/src/tabs/stories/index.story.tsx
@@ -35,7 +35,7 @@ const meta: Meta< typeof Tabs > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'When building for the Gutenberg repo, use this component instead of `TabPanel`. Otherwise, continue using `TabPanel`. Both will be superseded by `Tabs` in `@wordpress/ui`, but continue using these for now.',
 		},

--- a/packages/components/src/text-control/stories/index.story.tsx
+++ b/packages/components/src/text-control/stories/index.story.tsx
@@ -30,7 +30,7 @@ const meta: Meta< typeof TextControl > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Prefer `InputControl` when placing buttons or icons in the prefix/suffix slots.',
 		},

--- a/packages/components/src/text-highlight/stories/index.story.tsx
+++ b/packages/components/src/text-highlight/stories/index.story.tsx
@@ -19,7 +19,7 @@ const meta: Meta< typeof TextHighlight > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/textarea-control/stories/index.story.tsx
+++ b/packages/components/src/textarea-control/stories/index.story.tsx
@@ -33,7 +33,7 @@ const meta: Meta< typeof TextareaControl > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `TextareaControl` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/toggle-control/stories/index.story.tsx
+++ b/packages/components/src/toggle-control/stories/index.story.tsx
@@ -28,7 +28,7 @@ const meta: Meta< typeof ToggleControl > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `ToggleControl` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/toggle-group-control/stories/index.story.tsx
+++ b/packages/components/src/toggle-group-control/stories/index.story.tsx
@@ -38,7 +38,7 @@ const meta: Meta< typeof ToggleGroupControl > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 			notes: 'Will be superseded by `ToggleGroupControl` in `@wordpress/ui`, but continue using for now.',
 		},

--- a/packages/components/src/toolbar/stories/index.story.tsx
+++ b/packages/components/src/toolbar/stories/index.story.tsx
@@ -57,7 +57,7 @@ const meta: Meta< typeof Toolbar > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'editor',
 		},
 	},

--- a/packages/components/src/tools-panel/stories/index.story.tsx
+++ b/packages/components/src/tools-panel/stories/index.story.tsx
@@ -46,7 +46,7 @@ const meta: Meta< typeof ToolsPanel > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'editor',
 		},
 	},

--- a/packages/components/src/tooltip/stories/index.story.tsx
+++ b/packages/components/src/tooltip/stories/index.story.tsx
@@ -38,7 +38,7 @@ const meta: Meta< typeof Tooltip > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/tree-grid/stories/index.story.tsx
+++ b/packages/components/src/tree-grid/stories/index.story.tsx
@@ -33,7 +33,7 @@ const meta: Meta< typeof TreeGrid > = {
 	parameters: {
 		controls: { expanded: true },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/tree-select/stories/index.story.tsx
+++ b/packages/components/src/tree-select/stories/index.story.tsx
@@ -31,7 +31,7 @@ const meta: Meta< typeof TreeSelect > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/truncate/stories/index.story.tsx
+++ b/packages/components/src/truncate/stories/index.story.tsx
@@ -23,7 +23,7 @@ const meta: Meta< typeof Truncate > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/src/unit-control/stories/index.story.tsx
+++ b/packages/components/src/unit-control/stories/index.story.tsx
@@ -40,7 +40,7 @@ const meta: Meta< typeof UnitControl > = {
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/components/storybook.d.ts
+++ b/packages/components/storybook.d.ts
@@ -4,7 +4,7 @@ declare module 'storybook/internal/types' {
 	interface Parameters {
 		componentStatus?: {
 			status:
-				| 'stable'
+				| 'recommended'
 				| 'use-with-caution'
 				| 'not-recommended'
 				| 'unaudited';

--- a/packages/ui/src/alert-dialog/stories/index.story.tsx
+++ b/packages/ui/src/alert-dialog/stories/index.story.tsx
@@ -23,7 +23,7 @@ const meta: Meta< typeof AlertDialog.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of overlays compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/alert-dialog/stories/index.story.tsx
+++ b/packages/ui/src/alert-dialog/stories/index.story.tsx
@@ -19,6 +19,12 @@ const meta: Meta< typeof AlertDialog.Root > = {
 		onConfirm: { action: fn() },
 		onOpenChange: { action: fn() },
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/alert-dialog/stories/index.story.tsx
+++ b/packages/ui/src/alert-dialog/stories/index.story.tsx
@@ -21,8 +21,9 @@ const meta: Meta< typeof AlertDialog.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/alert-dialog/stories/index.story.tsx
+++ b/packages/ui/src/alert-dialog/stories/index.story.tsx
@@ -23,7 +23,7 @@ const meta: Meta< typeof AlertDialog.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/badge/stories/choosing-intent.story.tsx
+++ b/packages/ui/src/badge/stories/choosing-intent.story.tsx
@@ -14,10 +14,6 @@ const meta: Meta< typeof Badge > = {
 	],
 	parameters: {
 		controls: { disable: true },
-		componentStatus: {
-			status: 'recommended',
-			whereUsed: 'global',
-		},
 	},
 	tags: [ '!dev' /* Hide individual story pages from sidebar */, 'manifest' ],
 };

--- a/packages/ui/src/badge/stories/choosing-intent.story.tsx
+++ b/packages/ui/src/badge/stories/choosing-intent.story.tsx
@@ -14,6 +14,10 @@ const meta: Meta< typeof Badge > = {
 	],
 	parameters: {
 		controls: { disable: true },
+		componentStatus: {
+			status: 'stable',
+			whereUsed: 'global',
+		},
 	},
 	tags: [ '!dev' /* Hide individual story pages from sidebar */, 'manifest' ],
 };

--- a/packages/ui/src/badge/stories/choosing-intent.story.tsx
+++ b/packages/ui/src/badge/stories/choosing-intent.story.tsx
@@ -15,7 +15,7 @@ const meta: Meta< typeof Badge > = {
 	parameters: {
 		controls: { disable: true },
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/ui/src/badge/stories/index.story.tsx
+++ b/packages/ui/src/badge/stories/index.story.tsx
@@ -8,7 +8,7 @@ const meta: Meta< typeof Badge > = {
 	component: Badge,
 	parameters: {
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/ui/src/badge/stories/index.story.tsx
+++ b/packages/ui/src/badge/stories/index.story.tsx
@@ -6,6 +6,12 @@ const meta: Meta< typeof Badge > = {
 	tags: [ 'manifest' ],
 	title: 'Design System/Components/Badge',
 	component: Badge,
+	parameters: {
+		componentStatus: {
+			status: 'stable',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -13,8 +13,9 @@ const meta: Meta< typeof Button > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components` and text overflow behavior. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -11,6 +11,12 @@ const meta: Meta< typeof Button > = {
 			control: { type: 'boolean' },
 		},
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -15,7 +15,7 @@ const meta: Meta< typeof Button > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components` and text overflow behavior. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components` and text overflow behavior. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/card/stories/index.story.tsx
+++ b/packages/ui/src/card/stories/index.story.tsx
@@ -35,7 +35,7 @@ const meta: Meta< typeof Card.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/ui/src/card/stories/index.story.tsx
+++ b/packages/ui/src/card/stories/index.story.tsx
@@ -33,6 +33,12 @@ const meta: Meta< typeof Card.Root > = {
 		'Card.FullBleed': Card.FullBleed,
 		'Card.Title': Card.Title,
 	},
+	parameters: {
+		componentStatus: {
+			status: 'stable',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/collapsible-card/stories/index.story.tsx
+++ b/packages/ui/src/collapsible-card/stories/index.story.tsx
@@ -36,7 +36,7 @@ const meta: Meta< typeof CollapsibleCard.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/ui/src/collapsible-card/stories/index.story.tsx
+++ b/packages/ui/src/collapsible-card/stories/index.story.tsx
@@ -34,6 +34,12 @@ const meta: Meta< typeof CollapsibleCard.Root > = {
 		'CollapsibleCard.HeaderDescription': CollapsibleCard.HeaderDescription,
 		'CollapsibleCard.Content': CollapsibleCard.Content,
 	},
+	parameters: {
+		componentStatus: {
+			status: 'stable',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/collapsible/stories/index.story.tsx
+++ b/packages/ui/src/collapsible/stories/index.story.tsx
@@ -10,6 +10,12 @@ const meta: Meta< typeof Collapsible.Root > = {
 		'Collapsible.Trigger': Collapsible.Trigger,
 		'Collapsible.Panel': Collapsible.Panel,
 	},
+	parameters: {
+		componentStatus: {
+			status: 'stable',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/collapsible/stories/index.story.tsx
+++ b/packages/ui/src/collapsible/stories/index.story.tsx
@@ -12,7 +12,7 @@ const meta: Meta< typeof Collapsible.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/ui/src/dialog/stories/index.story.tsx
+++ b/packages/ui/src/dialog/stories/index.story.tsx
@@ -30,7 +30,7 @@ const meta: Meta< typeof Dialog.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/dialog/stories/index.story.tsx
+++ b/packages/ui/src/dialog/stories/index.story.tsx
@@ -28,8 +28,9 @@ const meta: Meta< typeof Dialog.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/dialog/stories/index.story.tsx
+++ b/packages/ui/src/dialog/stories/index.story.tsx
@@ -30,7 +30,7 @@ const meta: Meta< typeof Dialog.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of overlays compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/dialog/stories/index.story.tsx
+++ b/packages/ui/src/dialog/stories/index.story.tsx
@@ -26,6 +26,12 @@ const meta: Meta< typeof Dialog.Root > = {
 			options: [ true, false, 'trap-focus' ],
 		},
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/drawer/stories/index.story.tsx
+++ b/packages/ui/src/drawer/stories/index.story.tsx
@@ -27,8 +27,9 @@ const meta: Meta< typeof Drawer.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/drawer/stories/index.story.tsx
+++ b/packages/ui/src/drawer/stories/index.story.tsx
@@ -25,6 +25,12 @@ const meta: Meta< typeof Drawer.Root > = {
 			options: [ true, false, 'trap-focus' ],
 		},
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/drawer/stories/index.story.tsx
+++ b/packages/ui/src/drawer/stories/index.story.tsx
@@ -29,7 +29,7 @@ const meta: Meta< typeof Drawer.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of overlays compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/drawer/stories/index.story.tsx
+++ b/packages/ui/src/drawer/stories/index.story.tsx
@@ -29,7 +29,7 @@ const meta: Meta< typeof Drawer.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/empty-state/stories/index.story.tsx
+++ b/packages/ui/src/empty-state/stories/index.story.tsx
@@ -13,6 +13,12 @@ const meta: Meta< typeof EmptyState.Root > = {
 		'EmptyState.Description': EmptyState.Description,
 		'EmptyState.Actions': EmptyState.Actions,
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/empty-state/stories/index.story.tsx
+++ b/packages/ui/src/empty-state/stories/index.story.tsx
@@ -4,6 +4,7 @@ import { Button } from '../../button';
 import * as EmptyState from '../';
 
 const meta: Meta< typeof EmptyState.Root > = {
+	tags: [ 'manifest' ],
 	title: 'Design System/Components/EmptyState',
 	component: EmptyState.Root,
 	subcomponents: {
@@ -15,7 +16,7 @@ const meta: Meta< typeof EmptyState.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'stable',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/ui/src/empty-state/stories/index.story.tsx
+++ b/packages/ui/src/empty-state/stories/index.story.tsx
@@ -16,7 +16,7 @@ const meta: Meta< typeof EmptyState.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/ui/src/form/input-control/stories/index.story.tsx
+++ b/packages/ui/src/form/input-control/stories/index.story.tsx
@@ -23,6 +23,12 @@ const meta: Meta< typeof InputControl > = {
 		value: { control: false },
 		type: { control: 'text' },
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/form/input-control/stories/index.story.tsx
+++ b/packages/ui/src/form/input-control/stories/index.story.tsx
@@ -25,8 +25,9 @@ const meta: Meta< typeof InputControl > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/input-control/stories/index.story.tsx
+++ b/packages/ui/src/form/input-control/stories/index.story.tsx
@@ -27,7 +27,7 @@ const meta: Meta< typeof InputControl > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/input-control/stories/index.story.tsx
+++ b/packages/ui/src/form/input-control/stories/index.story.tsx
@@ -27,7 +27,7 @@ const meta: Meta< typeof InputControl > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/autocomplete/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/stories/index.story.tsx
@@ -26,8 +26,9 @@ const meta: Meta< typeof Autocomplete.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/autocomplete/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/stories/index.story.tsx
@@ -28,7 +28,7 @@ const meta: Meta< typeof Autocomplete.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/autocomplete/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/stories/index.story.tsx
@@ -28,7 +28,7 @@ const meta: Meta< typeof Autocomplete.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, overlays compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/autocomplete/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/stories/index.story.tsx
@@ -24,6 +24,12 @@ const meta: Meta< typeof Autocomplete.Root > = {
 		Empty: Autocomplete.Empty,
 		Clear: Autocomplete.Clear,
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/form/primitives/field/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/field/stories/index.story.tsx
@@ -17,7 +17,7 @@ const meta: Meta< typeof Field.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components` and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components` and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/field/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/field/stories/index.story.tsx
@@ -13,6 +13,12 @@ const meta: Meta< typeof Field.Root > = {
 		Description: Field.Description,
 		Details: Field.Details,
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/form/primitives/field/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/field/stories/index.story.tsx
@@ -15,8 +15,9 @@ const meta: Meta< typeof Field.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components` and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/fieldset/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/fieldset/stories/index.story.tsx
@@ -12,8 +12,9 @@ const meta: Meta< typeof Fieldset.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components` and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/fieldset/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/fieldset/stories/index.story.tsx
@@ -14,7 +14,7 @@ const meta: Meta< typeof Fieldset.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components` and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components` and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/fieldset/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/fieldset/stories/index.story.tsx
@@ -10,6 +10,12 @@ const meta: Meta< typeof Fieldset.Root > = {
 		Description: Fieldset.Description,
 		Details: Fieldset.Details,
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/form/primitives/input-layout/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/input-layout/stories/index.story.tsx
@@ -13,7 +13,7 @@ const meta: Meta< typeof InputLayout > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/input-layout/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/input-layout/stories/index.story.tsx
@@ -13,7 +13,7 @@ const meta: Meta< typeof InputLayout > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/input-layout/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/input-layout/stories/index.story.tsx
@@ -11,8 +11,9 @@ const meta: Meta< typeof InputLayout > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/input-layout/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/input-layout/stories/index.story.tsx
@@ -9,6 +9,12 @@ const meta: Meta< typeof InputLayout > = {
 	subcomponents: {
 		Slot: InputLayout.Slot,
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/form/primitives/input/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/input/stories/index.story.tsx
@@ -16,7 +16,7 @@ const meta: Meta< typeof Input > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/input/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/input/stories/index.story.tsx
@@ -14,8 +14,9 @@ const meta: Meta< typeof Input > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/input/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/input/stories/index.story.tsx
@@ -12,6 +12,12 @@ const meta: Meta< typeof Input > = {
 		value: { control: false },
 		type: { control: 'text' },
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/form/primitives/input/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/input/stories/index.story.tsx
@@ -16,7 +16,7 @@ const meta: Meta< typeof Input > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/select/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/select/stories/index.story.tsx
@@ -14,7 +14,7 @@ const meta: Meta< typeof Select.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, overlays compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/select/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/select/stories/index.story.tsx
@@ -14,7 +14,7 @@ const meta: Meta< typeof Select.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/select/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/select/stories/index.story.tsx
@@ -10,6 +10,12 @@ const meta: Meta< typeof Select.Root > = {
 		Popup: Select.Popup,
 		Item: Select.Item,
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/form/primitives/select/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/select/stories/index.story.tsx
@@ -12,8 +12,9 @@ const meta: Meta< typeof Select.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components`, popover compatibility, and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/textarea/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/textarea/stories/index.story.tsx
@@ -6,8 +6,9 @@ const meta: Meta< typeof Textarea > = {
 	component: Textarea,
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components` and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/form/primitives/textarea/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/textarea/stories/index.story.tsx
@@ -4,6 +4,12 @@ import { Textarea } from '../index';
 const meta: Meta< typeof Textarea > = {
 	title: 'Design System/Components/Form/Primitives/Textarea',
 	component: Textarea,
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/form/primitives/textarea/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/textarea/stories/index.story.tsx
@@ -8,7 +8,7 @@ const meta: Meta< typeof Textarea > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components` and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components` and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/icon-button/stories/index.story.tsx
+++ b/packages/ui/src/icon-button/stories/index.story.tsx
@@ -24,7 +24,7 @@ const meta: Meta< typeof IconButton > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components`, text overflow behavior, and popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, text overflow behavior, and popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/icon-button/stories/index.story.tsx
+++ b/packages/ui/src/icon-button/stories/index.story.tsx
@@ -22,8 +22,9 @@ const meta: Meta< typeof IconButton > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components`, text overflow behavior, and popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/icon-button/stories/index.story.tsx
+++ b/packages/ui/src/icon-button/stories/index.story.tsx
@@ -20,6 +20,12 @@ const meta: Meta< typeof IconButton > = {
 			control: { type: 'boolean' },
 		},
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/icon-button/stories/index.story.tsx
+++ b/packages/ui/src/icon-button/stories/index.story.tsx
@@ -24,7 +24,7 @@ const meta: Meta< typeof IconButton > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, text overflow behavior, and popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`, text overflow behavior, and overlays compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/icon/stories/index.story.tsx
+++ b/packages/ui/src/icon/stories/index.story.tsx
@@ -20,8 +20,9 @@ const meta: Meta< typeof Icon > = {
 	],
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending a general readiness review. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/icon/stories/index.story.tsx
+++ b/packages/ui/src/icon/stories/index.story.tsx
@@ -22,7 +22,7 @@ const meta: Meta< typeof Icon > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending a general readiness review. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending a general readiness review. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/icon/stories/index.story.tsx
+++ b/packages/ui/src/icon/stories/index.story.tsx
@@ -18,6 +18,12 @@ const meta: Meta< typeof Icon > = {
 			);
 		},
 	],
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/link/stories/index.story.tsx
+++ b/packages/ui/src/link/stories/index.story.tsx
@@ -7,6 +7,12 @@ const meta: Meta< typeof Link > = {
 	title: 'Design System/Components/Link',
 	component: Link,
 	tags: [ 'manifest' ],
+	parameters: {
+		componentStatus: {
+			status: 'stable',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/link/stories/index.story.tsx
+++ b/packages/ui/src/link/stories/index.story.tsx
@@ -9,7 +9,7 @@ const meta: Meta< typeof Link > = {
 	tags: [ 'manifest' ],
 	parameters: {
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/ui/src/notice/stories/index.story.tsx
+++ b/packages/ui/src/notice/stories/index.story.tsx
@@ -14,8 +14,9 @@ const meta: Meta< typeof Notice.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components`. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/notice/stories/index.story.tsx
+++ b/packages/ui/src/notice/stories/index.story.tsx
@@ -16,7 +16,7 @@ const meta: Meta< typeof Notice.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of style consistency with `@wordpress/components`. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components`. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/notice/stories/index.story.tsx
+++ b/packages/ui/src/notice/stories/index.story.tsx
@@ -12,6 +12,12 @@ const meta: Meta< typeof Notice.Root > = {
 		'Notice.ActionButton': Notice.ActionButton,
 		'Notice.ActionLink': Notice.ActionLink,
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/popover/stories/index.story.tsx
+++ b/packages/ui/src/popover/stories/index.story.tsx
@@ -25,8 +25,9 @@ const meta: Meta< typeof Popover.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/popover/stories/index.story.tsx
+++ b/packages/ui/src/popover/stories/index.story.tsx
@@ -23,6 +23,12 @@ const meta: Meta< typeof Popover.Root > = {
 	argTypes: {
 		children: { control: false },
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/popover/stories/index.story.tsx
+++ b/packages/ui/src/popover/stories/index.story.tsx
@@ -27,7 +27,7 @@ const meta: Meta< typeof Popover.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/popover/stories/index.story.tsx
+++ b/packages/ui/src/popover/stories/index.story.tsx
@@ -27,7 +27,7 @@ const meta: Meta< typeof Popover.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of overlays compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/stack/stories/index.story.tsx
+++ b/packages/ui/src/stack/stories/index.story.tsx
@@ -5,6 +5,12 @@ const meta: Meta< typeof Stack > = {
 	tags: [ 'manifest' ],
 	title: 'Design System/Components/Stack',
 	component: Stack,
+	parameters: {
+		componentStatus: {
+			status: 'stable',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/stack/stories/index.story.tsx
+++ b/packages/ui/src/stack/stories/index.story.tsx
@@ -7,7 +7,7 @@ const meta: Meta< typeof Stack > = {
 	component: Stack,
 	parameters: {
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/ui/src/tabs/stories/index.story.tsx
+++ b/packages/ui/src/tabs/stories/index.story.tsx
@@ -12,6 +12,12 @@ const meta: Meta< typeof Tabs.Root > = {
 		'Tabs.Tab': Tabs.Tab,
 		'Tabs.Panel': Tabs.Panel,
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/tabs/stories/index.story.tsx
+++ b/packages/ui/src/tabs/stories/index.story.tsx
@@ -14,8 +14,9 @@ const meta: Meta< typeof Tabs.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of color consistency with `@wordpress/components`. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/tabs/stories/index.story.tsx
+++ b/packages/ui/src/tabs/stories/index.story.tsx
@@ -16,7 +16,7 @@ const meta: Meta< typeof Tabs.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of color consistency with `@wordpress/components`. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of color consistency with `@wordpress/components`. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/text/stories/index.story.tsx
+++ b/packages/ui/src/text/stories/index.story.tsx
@@ -6,6 +6,12 @@ const meta: Meta< typeof Text > = {
 	tags: [ 'manifest' ],
 	title: 'Design System/Components/Text',
 	component: Text,
+	parameters: {
+		componentStatus: {
+			status: 'stable',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/text/stories/index.story.tsx
+++ b/packages/ui/src/text/stories/index.story.tsx
@@ -8,7 +8,7 @@ const meta: Meta< typeof Text > = {
 	component: Text,
 	parameters: {
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/ui/src/tooltip/stories/index.story.tsx
+++ b/packages/ui/src/tooltip/stories/index.story.tsx
@@ -14,8 +14,9 @@ const meta: Meta< typeof Tooltip.Root > = {
 	},
 	parameters: {
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/tooltip/stories/index.story.tsx
+++ b/packages/ui/src/tooltip/stories/index.story.tsx
@@ -16,7 +16,7 @@ const meta: Meta< typeof Tooltip.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of overlays compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/tooltip/stories/index.story.tsx
+++ b/packages/ui/src/tooltip/stories/index.story.tsx
@@ -12,6 +12,12 @@ const meta: Meta< typeof Tooltip.Root > = {
 		Popup: Tooltip.Popup,
 		Portal: Tooltip.Portal,
 	},
+	parameters: {
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/packages/ui/src/tooltip/stories/index.story.tsx
+++ b/packages/ui/src/tooltip/stories/index.story.tsx
@@ -16,7 +16,7 @@ const meta: Meta< typeof Tooltip.Root > = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 };

--- a/packages/ui/src/tooltip/stories/usage-guidelines.story.tsx
+++ b/packages/ui/src/tooltip/stories/usage-guidelines.story.tsx
@@ -18,7 +18,7 @@ const meta: Meta = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use in Gutenberg core, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 	tags: [ '!dev' ],

--- a/packages/ui/src/tooltip/stories/usage-guidelines.story.tsx
+++ b/packages/ui/src/tooltip/stories/usage-guidelines.story.tsx
@@ -15,6 +15,10 @@ const meta: Meta = {
 	title: 'Design System/Components/Tooltip/Usage Guidelines',
 	parameters: {
 		controls: { disable: true },
+		componentStatus: {
+			status: 'coming-soon',
+			whereUsed: 'global',
+		},
 	},
 	tags: [ '!dev' ],
 };

--- a/packages/ui/src/tooltip/stories/usage-guidelines.story.tsx
+++ b/packages/ui/src/tooltip/stories/usage-guidelines.story.tsx
@@ -16,8 +16,9 @@ const meta: Meta = {
 	parameters: {
 		controls: { disable: true },
 		componentStatus: {
-			status: 'coming-soon',
+			status: 'use-with-caution',
 			whereUsed: 'global',
+			notes: 'Not yet recommended for use in Gutenberg core, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 	tags: [ '!dev' ],

--- a/packages/ui/src/tooltip/stories/usage-guidelines.story.tsx
+++ b/packages/ui/src/tooltip/stories/usage-guidelines.story.tsx
@@ -18,7 +18,7 @@ const meta: Meta = {
 		componentStatus: {
 			status: 'use-with-caution',
 			whereUsed: 'global',
-			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of popover compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of overlays compatibility. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
 		},
 	},
 	tags: [ '!dev' ],

--- a/packages/ui/src/visually-hidden/stories/index.story.tsx
+++ b/packages/ui/src/visually-hidden/stories/index.story.tsx
@@ -8,7 +8,7 @@ const meta: Meta< typeof VisuallyHidden > = {
 	component: VisuallyHidden,
 	parameters: {
 		componentStatus: {
-			status: 'stable',
+			status: 'recommended',
 			whereUsed: 'global',
 		},
 	},

--- a/packages/ui/src/visually-hidden/stories/index.story.tsx
+++ b/packages/ui/src/visually-hidden/stories/index.story.tsx
@@ -6,6 +6,12 @@ const meta: Meta< typeof VisuallyHidden > = {
 	tags: [ 'manifest' ],
 	title: 'Design System/Components/VisuallyHidden',
 	component: VisuallyHidden,
+	parameters: {
+		componentStatus: {
+			status: 'stable',
+			whereUsed: 'global',
+		},
+	},
 };
 export default meta;
 

--- a/storybook/components/component-status-indicator/statuses.ts
+++ b/storybook/components/component-status-indicator/statuses.ts
@@ -1,5 +1,5 @@
 export type ComponentStatus =
-	| 'stable'
+	| 'recommended'
 	| 'use-with-caution'
 	| 'not-recommended'
 	| 'unaudited';
@@ -11,8 +11,8 @@ export const statuses: Record<
 		icon: string;
 	}
 > = {
-	stable: {
-		label: 'Stable',
+	recommended: {
+		label: 'Recommended',
 		icon: '✅',
 	},
 	'use-with-caution': {

--- a/storybook/components/component-status-indicator/statuses.ts
+++ b/storybook/components/component-status-indicator/statuses.ts
@@ -2,8 +2,7 @@ export type ComponentStatus =
 	| 'stable'
 	| 'use-with-caution'
 	| 'not-recommended'
-	| 'unaudited'
-	| 'coming-soon';
+	| 'unaudited';
 
 export const statuses: Record<
 	ComponentStatus,
@@ -27,9 +26,5 @@ export const statuses: Record<
 	unaudited: {
 		label: 'Unaudited',
 		icon: '❓',
-	},
-	'coming-soon': {
-		label: 'Coming soon',
-		icon: '🔜',
 	},
 };

--- a/storybook/components/component-status-indicator/statuses.ts
+++ b/storybook/components/component-status-indicator/statuses.ts
@@ -2,7 +2,8 @@ export type ComponentStatus =
 	| 'stable'
 	| 'use-with-caution'
 	| 'not-recommended'
-	| 'unaudited';
+	| 'unaudited'
+	| 'coming-soon';
 
 export const statuses: Record<
 	ComponentStatus,
@@ -26,5 +27,9 @@ export const statuses: Record<
 	unaudited: {
 		label: 'Unaudited',
 		icon: '❓',
+	},
+	'coming-soon': {
+		label: 'Coming soon',
+		icon: '🔜',
 	},
 };

--- a/storybook/types.d.ts
+++ b/storybook/types.d.ts
@@ -4,7 +4,7 @@ declare module 'storybook/internal/types' {
 	interface Parameters {
 		componentStatus?: {
 			status:
-				| 'stable'
+				| 'recommended'
 				| 'use-with-caution'
 				| 'not-recommended'
 				| 'unaudited';

--- a/storybook/types.d.ts
+++ b/storybook/types.d.ts
@@ -7,8 +7,7 @@ declare module 'storybook/internal/types' {
 				| 'stable'
 				| 'use-with-caution'
 				| 'not-recommended'
-				| 'unaudited'
-				| 'coming-soon';
+				| 'unaudited';
 			whereUsed: 'global' | 'editor';
 			notes?: string;
 		};

--- a/storybook/types.d.ts
+++ b/storybook/types.d.ts
@@ -7,7 +7,8 @@ declare module 'storybook/internal/types' {
 				| 'stable'
 				| 'use-with-caution'
 				| 'not-recommended'
-				| 'unaudited';
+				| 'unaudited'
+				| 'coming-soon';
 			whereUsed: 'global' | 'editor';
 			notes?: string;
 		};


### PR DESCRIPTION
## What?

Related: #76135 

Updates Storybook stories in `@wordpress/ui` to add status indicators introduced in #74815.

## Why?

To make it clearer which components are ready to use in Gutenberg, and what blockers remain for the components that are not ready yet.

Also serves as a good nudge to ourselves what remains before we can mark a component as stable, or even instances where there's no good reason for a component not to be stable already (e.g. "Icon").

This could also potentially allow us to surface some more nuance through [the design system MCP](https://github.com/WordPress/gutenberg/tree/trunk/packages/design-system-mcp) (e.g. use X component for now, but Y component from `@wordpress/ui` will soon be available for use).

## How?

Add `componentStatus` entry for each component story in `@wordpress/ui`:

- Use `'stable'` if already allowed via [`@wordpress/use-recommended-components` allowlist](https://github.com/WordPress/gutenberg/blob/384489f49bae7a3d5e7e96311e0adbfab5ad50af/packages/eslint-plugin/rules/use-recommended-components.js#L9-L25)
- For every other component, use `'use-with-caution'`, cautioning use in Gutenberg with component-specific warnings based on blockers highlighted in #74815.

Use `whereUsed: 'global'` for every component, since all of these components are meant to be globally usable.

## Testing Instructions

Verify in Storybook:

1. Run `npm run storybook:dev`
2. Go to http://localhost:50240/
3. Verify every "Docs" under "Design System" > "Components" components has a status indicator at the top

Review the individual component status notes. Do they make sense? If you disagree with a component's status, do we have the actual blockers tracked anywhere?

## Screenshots or screencast <!-- if applicable -->

Examples:

Stable:

<img width="509" height="283" alt="image" src="https://github.com/user-attachments/assets/3f5b7250-46fd-4db7-8eb5-04c7925a7edf" />

Use with caution:

<img width="1080" height="330" alt="image" src="https://github.com/user-attachments/assets/2a76795f-5fff-4300-9a9c-f8da7623025b" />

## Use of AI Tools

Implemented using Claude Code and Opus 4.7, pre-prompted with logic described in "How?" and iterations on specific status notes.

cc @grbicsanja