### PR TITLE
Fix/query default posts per page

### DIFF
--- a/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
+++ b/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
@@ -13,9 +13,10 @@ By registering your own block variation with some specific Query Loop block sett
 With the block variations API you can provide the default settings that make the most sense for your use-case.
 
 In order to have a Query Loop variation properly working, we'll need to:
-- Register the block variation for the `core/query` block with some default values
-- Define a layout for the block variation
-- Use the `namespace` attribute in the `isActive` block variation property
+
+-   Register the block variation for the `core/query` block with some default values
+-   Define a layout for the block variation
+-   Use the `namespace` attribute in the `isActive` block variation property
 
 Let's go on a journey, for example, of setting up a variation for a plugin which registers a `book` [custom post type](https://developer.wordpress.org/plugins/post-types/).
 
@@ -275,6 +276,8 @@ Currently, you'll likely have to implement slightly different paths to make the 
 ### Making your custom query work on the front-end side
 
 The Query Loop block functions mainly through the Post Template block which receives the attributes and builds the query from there. Other first-class children of the Query Loop block (such as the Pagination block) behave in the same way. They build their query and then expose the result via the filter [`query_loop_block_query_vars`](https://developer.wordpress.org/reference/hooks/query_loop_block_query_vars/).
+
+When a Query Loop uses the default query type, it still inherits the current template query context, but the `perPage` query value can override how many posts are displayed by that Query Loop. This is useful for archive templates that should keep the archive constraints, such as the current author or taxonomy term, while displaying fewer posts than the site's reading setting.
 
 You can hook into that filter and modify your query accordingly. Just make sure you don't cause side-effects to other Query Loop blocks by at least checking that you apply the filter only to your variation!
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Query Loop Block: Allow default queries to override items per page.
+
 ## 9.45.0 (2026-04-29)
 
 ## 9.44.0 (2026-04-15)

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -56,16 +56,16 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	if ( $use_global_query ) {
 		global $wp_query;
 
+		$query = block_core_query_get_inherited_query( $block );
+
 		/*
 		 * If already in the main query loop, duplicate the query instance to not tamper with the main instance.
 		 * Since this is a nested query, it should start at the beginning, therefore rewind posts.
 		 * Otherwise, the main query loop has not started yet and this block is responsible for doing so.
 		 */
-		if ( in_the_loop() ) {
+		if ( $query === $wp_query && in_the_loop() ) {
 			$query = clone $wp_query;
 			$query->rewind_posts();
-		} else {
-			$query = $wp_query;
 		}
 	} else {
 		$query_args = build_query_vars_from_query_block( $block, $page );

--- a/packages/block-library/src/query-no-results/index.php
+++ b/packages/block-library/src/query-no-results/index.php
@@ -29,8 +29,7 @@ function render_block_core_query_no_results( $attributes, $content, $block ) {
 	// Override the custom query with the global query if needed.
 	$use_global_query = ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] );
 	if ( $use_global_query ) {
-		global $wp_query;
-		$query = $wp_query;
+		$query = block_core_query_get_inherited_query( $block );
 	} else {
 		$query_args = build_query_vars_from_query_block( $block, $page );
 		$query      = new WP_Query( $query_args );

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -54,7 +54,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		if ( $max_page > $inherited_query->max_num_pages ) {
 			$max_page = $inherited_query->max_num_pages;
 		}
-		$content = get_next_posts_link( $label, $max_page );
+		$content  = get_next_posts_link( $label, $max_page );
 		$wp_query = $prev_wp_query;
 		remove_filter( 'next_posts_link_attributes', $filter_link_attributes );
 	} elseif ( ! $max_page || $max_page > $page ) {

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -48,10 +48,14 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		// Take into account if we have set a bigger `max page`
 		// than what the query has.
 		global $wp_query;
-		if ( $max_page > $wp_query->max_num_pages ) {
-			$max_page = $wp_query->max_num_pages;
+		$inherited_query = block_core_query_get_inherited_query( $block );
+		$prev_wp_query   = $wp_query;
+		$wp_query        = $inherited_query;
+		if ( $max_page > $inherited_query->max_num_pages ) {
+			$max_page = $inherited_query->max_num_pages;
 		}
 		$content = get_next_posts_link( $label, $max_page );
+		$wp_query = $prev_wp_query;
 		remove_filter( 'next_posts_link_attributes', $filter_link_attributes );
 	} elseif ( ! $max_page || $max_page > $page ) {
 		$custom_query           = new WP_Query( build_query_vars_from_query_block( $block, $page ) );

--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -29,6 +29,8 @@ function render_block_core_query_pagination_numbers( $attributes, $content, $blo
 	global $wp_query;
 	$mid_size = isset( $block->attributes['midSize'] ) ? (int) $block->attributes['midSize'] : null;
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
+		$prev_wp_query = $wp_query;
+		$wp_query      = block_core_query_get_inherited_query( $block );
 		// Take into account if we have set a bigger `max page`
 		// than what the query has.
 		$total         = ! $max_page || $max_page > $wp_query->max_num_pages ? $wp_query->max_num_pages : $max_page;
@@ -40,6 +42,7 @@ function render_block_core_query_pagination_numbers( $attributes, $content, $blo
 			$paginate_args['mid_size'] = $mid_size;
 		}
 		$content = paginate_links( $paginate_args );
+		$wp_query = $prev_wp_query;
 	} else {
 		$block_query = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
 		// `paginate_links` works with the global $wp_query, so we have to

--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -41,7 +41,7 @@ function render_block_core_query_pagination_numbers( $attributes, $content, $blo
 		if ( null !== $mid_size ) {
 			$paginate_args['mid_size'] = $mid_size;
 		}
-		$content = paginate_links( $paginate_args );
+		$content  = paginate_links( $paginate_args );
 		$wp_query = $prev_wp_query;
 	} else {
 		$block_query = new WP_Query( build_query_vars_from_query_block( $block, $page ) );

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -43,10 +43,10 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 
 		add_filter( 'previous_posts_link_attributes', $filter_link_attributes );
 		global $wp_query;
-		$prev_wp_query = $wp_query;
-		$wp_query      = block_core_query_get_inherited_query( $block );
-		$content = get_previous_posts_link( $label );
-		$wp_query = $prev_wp_query;
+		$prev_wp_query  = $wp_query;
+		$wp_query       = block_core_query_get_inherited_query( $block );
+		$content        = get_previous_posts_link( $label );
+		$wp_query       = $prev_wp_query;
 		remove_filter( 'previous_posts_link_attributes', $filter_link_attributes );
 	} else {
 		$block_query     = new WP_Query( build_query_vars_from_query_block( $block, $page ) );

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -42,7 +42,11 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 		};
 
 		add_filter( 'previous_posts_link_attributes', $filter_link_attributes );
+		global $wp_query;
+		$prev_wp_query = $wp_query;
+		$wp_query      = block_core_query_get_inherited_query( $block );
 		$content = get_previous_posts_link( $label );
+		$wp_query = $prev_wp_query;
 		remove_filter( 'previous_posts_link_attributes', $filter_link_attributes );
 	} else {
 		$block_query     = new WP_Query( build_query_vars_from_query_block( $block, $page ) );

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -43,10 +43,10 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 
 		add_filter( 'previous_posts_link_attributes', $filter_link_attributes );
 		global $wp_query;
-		$prev_wp_query  = $wp_query;
-		$wp_query       = block_core_query_get_inherited_query( $block );
-		$content        = get_previous_posts_link( $label );
-		$wp_query       = $prev_wp_query;
+		$prev_wp_query = $wp_query;
+		$wp_query      = block_core_query_get_inherited_query( $block );
+		$content       = get_previous_posts_link( $label );
+		$wp_query      = $prev_wp_query;
 		remove_filter( 'previous_posts_link_attributes', $filter_link_attributes );
 	} else {
 		$block_query     = new WP_Query( build_query_vars_from_query_block( $block, $page ) );

--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -19,7 +19,6 @@
  * @return string The rendered block content.
  */
 function render_block_core_query_total( $attributes, $content, $block ) {
-	global $wp_query;
 	$wrapper_attributes = get_block_wrapper_attributes();
 	if ( $block->context['query']['inherit'] ?? false ) {
 		$query_to_use = block_core_query_get_inherited_query( $block );

--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -22,7 +22,7 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 	global $wp_query;
 	$wrapper_attributes = get_block_wrapper_attributes();
 	if ( $block->context['query']['inherit'] ?? false ) {
-		$query_to_use = $wp_query;
+		$query_to_use = block_core_query_get_inherited_query( $block );
 		$current_page = max( 1, (int) get_query_var( 'paged', 1 ) );
 	} else {
 		$page_key     = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -334,12 +334,13 @@ export default function QueryInspectorControls( props ) {
 					) }
 				</ToolsPanel>
 			) }
-			{ ! inherit && showDisplayPanel && (
+			{ showDisplayPanel && (
 				<ToolsPanel
 					className="block-library-query-toolspanel__display"
 					label={ __( 'Display' ) }
 					resetAll={ () => {
 						setQuery( {
+							perPage: 0,
 							offset: 0,
 							pages: 0,
 						} );
@@ -349,6 +350,7 @@ export default function QueryInspectorControls( props ) {
 					<ToolsPanelItem
 						label={ __( 'Items per page' ) }
 						hasValue={ () => perPage > 0 }
+						onDeselect={ () => setQuery( { perPage: 0 } ) }
 					>
 						<PerPageControl
 							perPage={ perPage }
@@ -356,16 +358,18 @@ export default function QueryInspectorControls( props ) {
 							onChange={ setQuery }
 						/>
 					</ToolsPanelItem>
-					<ToolsPanelItem
-						label={ __( 'Offset' ) }
-						hasValue={ () => offset > 0 }
-						onDeselect={ () => setQuery( { offset: 0 } ) }
-					>
-						<OffsetControl
-							offset={ offset }
-							onChange={ setQuery }
-						/>
-					</ToolsPanelItem>
+					{ ! inherit && (
+						<ToolsPanelItem
+							label={ __( 'Offset' ) }
+							hasValue={ () => offset > 0 }
+							onDeselect={ () => setQuery( { offset: 0 } ) }
+						>
+							<OffsetControl
+								offset={ offset }
+								onChange={ setQuery }
+							/>
+						</ToolsPanelItem>
+					) }
 					<ToolsPanelItem
 						label={ __( 'Max pages to show' ) }
 						hasValue={ () => pages > 0 }

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -95,11 +95,7 @@ export default function QueryContent( {
 	);
 	useEffect( () => {
 		const newQuery = {};
-		// When we inherit from global query always need to set the `perPage`
-		// based on the reading settings.
-		if ( inherit && query.perPage !== postsPerPage ) {
-			newQuery.perPage = postsPerPage;
-		} else if ( ! query.perPage && postsPerPage ) {
+		if ( ! query.perPage && postsPerPage ) {
 			newQuery.perPage = postsPerPage;
 		}
 

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -71,6 +71,37 @@ function register_block_core_query() {
 add_action( 'init', 'register_block_core_query' );
 
 /**
+ * Returns the inherited query for a Query block.
+ *
+ * If the Query block inherits the global query but defines its own posts per page
+ * value, run a matching query with that override so template-specific Query blocks
+ * can limit the number of displayed posts without changing the site reading setting.
+ *
+ * @since 7.1.0
+ *
+ * @global WP_Query $wp_query WordPress Query object.
+ *
+ * @param WP_Block $block Block instance.
+ * @return WP_Query Query object.
+ */
+function block_core_query_get_inherited_query( $block ) {
+	global $wp_query;
+
+	$per_page = isset( $block->context['query']['perPage'] )
+		? absint( $block->context['query']['perPage'] )
+		: 0;
+
+	if ( ! $per_page || $per_page === absint( $wp_query->get( 'posts_per_page' ) ) ) {
+		return $wp_query;
+	}
+
+	$query_vars                   = $wp_query->query_vars;
+	$query_vars['posts_per_page'] = $per_page;
+
+	return new WP_Query( $query_vars );
+}
+
+/**
  * Traverse the tree of blocks looking for any plugin block (i.e., a block from
  * an installed plugin) inside a Query block with the enhanced pagination
  * enabled. If at least one is found, the enhanced pagination is effectively

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -91,7 +91,7 @@ function block_core_query_get_inherited_query( $block ) {
 		? absint( $block->context['query']['perPage'] )
 		: 0;
 
-	if ( ! $per_page || $per_page === absint( $wp_query->get( 'posts_per_page' ) ) ) {
+	if ( ! $per_page || absint( $wp_query->get( 'posts_per_page' ) ) === $per_page ) {
 		return $wp_query;
 	}
 

--- a/phpunit/blocks/render-post-template-test.php
+++ b/phpunit/blocks/render-post-template-test.php
@@ -216,4 +216,48 @@ END;
 
 		$this->assertSame( $expected, $output, 'Unexpected parsed post content' );
 	}
+
+	/**
+	 * Tests that an inherited Query block can override the number of posts
+	 * rendered by the default query.
+	 *
+	 * @ticket 77886
+	 */
+	public function test_rendering_post_template_with_inherited_query_per_page() {
+		global $wp_query, $wp_the_query;
+
+		$content  = '<!-- wp:query {"query":{"inherit":true,"perPage":1}} -->';
+		$content .= '<!-- wp:post-template {"align":"wide"} -->';
+		$content .= '<!-- wp:post-title /-->';
+		$content .= '<!-- /wp:post-template -->';
+		$content .= '<!-- /wp:query -->';
+
+		$wp_query     = new WP_Query(
+			array(
+				'post_type'      => 'post',
+				'posts_per_page' => 10,
+				'orderby'        => 'ID',
+				'order'          => 'DESC',
+			)
+		);
+		$wp_the_query = $wp_query;
+
+		$output = do_blocks( $content );
+
+		$this->assertSame(
+			1,
+			substr_count( $output, '<li class="wp-block-post' ),
+			'Only one post should be rendered.'
+		);
+		$this->assertStringContainsString(
+			self::$other_post->post_title,
+			$output,
+			'The inherited query should preserve the global query parameters.'
+		);
+		$this->assertStringNotContainsString(
+			self::$post->post_title,
+			$output,
+			'The inherited query per-page override should limit rendered posts.'
+		);
+	}
 }


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/77886

Allows the Query Loop block’s default query type to override “Items per page”.

## Why?

Default Query Loop blocks inherit the current template query, but users could not reduce the number of displayed posts for archive templates without custom code.

## How?

Shows the “Items per page” control for inherited queries and applies `query.perPage` when rendering inherited Query Loop results, pagination, totals, and no-results state.

## Testing Instructions

1. Set Settings > Reading > Blog pages show at most to `10`.
2. Create or edit an author archive template.
3. Add a Query Loop block using the Default query type.
4. Set Items per page to `3`.
5. Confirm the template shows 3 posts while still filtering to the current author.

### Testing Instructions for Keyboard

1. Select the Query Loop block.
2. Use keyboard navigation to open the block inspector.
3. Set Query type to Default.
4. Navigate to Display > Items per page and change the value.
5. Confirm the setting updates and remains usable by keyboard.

## Screenshots or screencast

N/A

## Use of AI Tools

AI tooling was used to help draft and implement the change. The code was reviewed before submission.