### PR TITLE
Update nvm installation script to version 0.40.4

### DIFF
--- a/docs/getting-started/devenv/nodejs-development-environment.md
+++ b/docs/getting-started/devenv/nodejs-development-environment.md
@@ -18,7 +18,7 @@ Here are the quick instructions for installing `node` using `nvm` and setting th
 1. Open the terminal and run the following to install `nvm`. On macOS, the required developer tools are not installed by default. Install them if prompted.
 
 ```sh
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
 ```
 
 2. Quit and restart the terminal.


### PR DESCRIPTION
## What?
Update the nvm installation script URL from v0.39.5 to v0.40.4.

## Why?
The nvm install script in the documentation was pointing to v0.39.5, which is outdated. The latest version is v0.40.4.

## How?
Updated the version number in the curl command from v0.39.5 to v0.40.4.

## Testing Instructions
Check that the nvm install command uses the correct latest version.