### PR TITLE
Experiment: Sync user taxonomies with post types

### DIFF
--- a/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
+++ b/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
@@ -130,6 +130,12 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 					'uniqueItems' => true,
 					'maxItems'    => 50,
 				),
+				// Storage split: the JSON blob in `post_content` holds only
+				// non-user-defined slugs (core/theme/plugin). Slugs that
+				// match a `wp_user_taxonomy` record live on the taxonomy
+				// side via `_wp_user_taxonomy_object_type` meta. Requests
+				// and responses carry the union; `prepare_item_for_database`
+				// and `prepare_item_for_response` reconcile the two sides.
 				'taxonomies'   => array(
 					'type'        => 'array',
 					'items'       => array(
@@ -195,6 +201,30 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 				: array();
 			// Storage marker is server-only; never expose it to clients.
 			unset( $config[ GUTENBERG_USER_POST_TYPE_CONFIG_MARKER ] );
+
+			// `config.taxonomies` in the response is the merged view: the
+			// non-user slugs persisted in this record's JSON, plus any
+			// user-defined taxonomies whose `_wp_user_taxonomy_object_type`
+			// meta points back at this post type. Single field for the
+			// client to read and write — the controller splits writes back
+			// into the two storage sites.
+			$stored = isset( $config['taxonomies'] ) && is_array( $config['taxonomies'] )
+				? array_values( array_filter( $config['taxonomies'], 'is_string' ) )
+				: array();
+			$linked = array();
+			foreach ( self::get_user_taxonomy_ids_with_meta( $item->post_name ) as $tax_id ) {
+				$tax_slug = (string) get_post_field( 'post_name', $tax_id );
+				if ( '' !== $tax_slug ) {
+					$linked[] = $tax_slug;
+				}
+			}
+			$merged = array_values( array_unique( array_merge( $stored, $linked ) ) );
+			if ( ! empty( $merged ) ) {
+				$config['taxonomies'] = $merged;
+			} else {
+				unset( $config['taxonomies'] );
+			}
+
 			// Empty config must serialize as `{}` to match the schema's
 			// `type: 'object'`. PHP encodes empty associative arrays as `[]`
 			// in JSON, so cast empties to stdClass.
@@ -231,6 +261,22 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 		if ( $request->has_param( 'config' ) || empty( $request['id'] ) ) {
 			$config = is_array( $request['config'] ) ? $request['config'] : array();
 
+			// User-defined taxonomy slugs ride on the taxonomy record's
+			// `_wp_user_taxonomy_object_type` meta as the single source of
+			// truth, so they're stripped from `config.taxonomies` here and
+			// reapplied via `sync_taxonomy_associations()` after save. The
+			// JSON keeps only core/theme/plugin slugs.
+			if ( isset( $config['taxonomies'] ) && is_array( $config['taxonomies'] ) ) {
+				$ids_by_slug = self::get_user_taxonomy_ids_by_slug();
+				$stored      = array();
+				foreach ( $config['taxonomies'] as $slug ) {
+					if ( is_string( $slug ) && ! isset( $ids_by_slug[ $slug ] ) ) {
+						$stored[] = $slug;
+					}
+				}
+				$config['taxonomies'] = array_values( array_unique( $stored ) );
+			}
+
 			// `JSON_HEX_TAG | JSON_HEX_AMP` escape `<`, `>`, and `&` to their
 			// `\u00XX` forms before `wp_insert_post()` is called, so when
 			// kses runs first via `content_save_pre` it sees an inert string
@@ -246,6 +292,76 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 		}
 
 		return $prepared;
+	}
+
+	/**
+	 * Creates a record, then mirrors any `config.taxonomies` user-tax slugs
+	 * into the corresponding wp_user_taxonomy records' `object_type` meta.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_item( $request ) {
+		$response = parent::create_item( $request );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+		$data    = $response->get_data();
+		$post_id = (int) $data['id'];
+		$this->sync_taxonomy_associations( $post_id, $request );
+		$refreshed = $this->prepare_item_for_response( get_post( $post_id ), $request );
+		if ( ! is_wp_error( $refreshed ) ) {
+			$response->set_data( $refreshed->get_data() );
+		}
+		return $response;
+	}
+
+	/**
+	 * Updates a record, migrates user-taxonomy back-references when the slug
+	 * changes, and re-syncs taxonomy associations from `config.taxonomies`.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_item( $request ) {
+		$post_id       = (int) $request['id'];
+		$existing      = get_post( $post_id );
+		$previous_slug = $existing instanceof WP_Post ? (string) $existing->post_name : '';
+
+		$response = parent::update_item( $request );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$current_slug = (string) get_post_field( 'post_name', $post_id );
+		if ( '' !== $previous_slug && '' !== $current_slug && $previous_slug !== $current_slug ) {
+			self::migrate_user_tax_back_references( $previous_slug, $current_slug );
+		}
+		$this->sync_taxonomy_associations( $post_id, $request );
+
+		$refreshed = $this->prepare_item_for_response( get_post( $post_id ), $request );
+		if ( ! is_wp_error( $refreshed ) ) {
+			$response->set_data( $refreshed->get_data() );
+		}
+		return $response;
+	}
+
+	/**
+	 * Force-deletes a record after stripping its slug from any user-taxonomy
+	 * `_wp_user_taxonomy_object_type` meta that referenced it. Trash (force
+	 * = false) leaves the meta intact so untrashing restores the linkage.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		if ( ! empty( $request['force'] ) ) {
+			$slug = (string) get_post_field( 'post_name', (int) $request['id'] );
+			foreach ( self::get_user_taxonomy_ids_with_meta( $slug ) as $tax_id ) {
+				gutenberg_user_taxonomy_detach_object_type( $tax_id, $slug );
+			}
+		}
+		return parent::delete_item( $request );
 	}
 
 	/**
@@ -351,5 +467,143 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 		}
 
 		return true;
+	}
+
+	/**
+	 * Reapplies the user-taxonomy half of a `config.taxonomies` write. Walks
+	 * the requested slugs once, finds the user-defined ones, and reconciles
+	 * each affected wp_user_taxonomy record's `_wp_user_taxonomy_object_type`
+	 * meta to match. Slugs in the request that already exist in meta are
+	 * left alone; previously-attached user taxonomies that are no longer in
+	 * the request have the post type slug removed from their meta.
+	 *
+	 * Skipped when the request omits `config.taxonomies`.
+	 *
+	 * @param int             $post_id Saved post ID.
+	 * @param WP_REST_Request $request REST request.
+	 */
+	private function sync_taxonomy_associations( $post_id, $request ) {
+		if ( ! $request->has_param( 'config' ) ) {
+			return;
+		}
+		$config = $request['config'];
+		if ( ! is_array( $config ) || ! isset( $config['taxonomies'] ) || ! is_array( $config['taxonomies'] ) ) {
+			return;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post ) {
+			return;
+		}
+		$current_slug = (string) $post->post_name;
+		if ( '' === $current_slug ) {
+			return;
+		}
+
+		$ids_by_slug = self::get_user_taxonomy_ids_by_slug();
+		$desired     = array();
+		foreach ( $config['taxonomies'] as $slug ) {
+			if ( is_string( $slug ) && isset( $ids_by_slug[ $slug ] ) ) {
+				$desired[ $slug ] = true;
+			}
+		}
+
+		// Walk previously-attached user taxonomies; detach the post-type
+		// slug from any whose taxonomy isn't in the new request, mark the
+		// rest as already-applied so we don't re-attach them below.
+		foreach ( self::get_user_taxonomy_ids_with_meta( $current_slug ) as $tax_id ) {
+			$tax_slug = get_post_field( 'post_name', $tax_id );
+			if ( ! is_string( $tax_slug ) || '' === $tax_slug ) {
+				continue;
+			}
+			if ( isset( $desired[ $tax_slug ] ) ) {
+				unset( $desired[ $tax_slug ] );
+			} else {
+				gutenberg_user_taxonomy_detach_object_type( $tax_id, $current_slug );
+			}
+		}
+
+		// Anything left in $desired is a newly-requested attachment.
+		foreach ( array_keys( $desired ) as $tax_slug ) {
+			gutenberg_user_taxonomy_attach_object_type( $ids_by_slug[ $tax_slug ], $current_slug );
+		}
+	}
+
+	/**
+	 * Rewrites every `_wp_user_taxonomy_object_type` meta row pointing at
+	 * `$previous_slug` to `$current_slug`. Called from {@see update_item}
+	 * whenever the slug changes, independently of `config.taxonomies` —
+	 * a PUT that only renames the slug still needs the back-references
+	 * to follow, otherwise every linked user taxonomy silently disconnects.
+	 *
+	 * @param string $previous_slug Slug the record had before this save.
+	 * @param string $current_slug  Slug after the save.
+	 */
+	private static function migrate_user_tax_back_references( $previous_slug, $current_slug ) {
+		foreach ( self::get_user_taxonomy_ids_with_meta( $previous_slug ) as $tax_id ) {
+			gutenberg_user_taxonomy_detach_object_type( $tax_id, $previous_slug );
+			gutenberg_user_taxonomy_attach_object_type( $tax_id, $current_slug );
+		}
+	}
+
+	/**
+	 * Returns a `slug => ID` map of every wp_user_taxonomy record. Used both
+	 * as the user-tax membership check (`isset( $map[ $slug ] )`) and as the
+	 * slug-to-ID lookup when reattaching `_wp_user_taxonomy_object_type`
+	 * meta. Single bounded query; user taxonomies are a small set.
+	 *
+	 * @return array<string, int>
+	 */
+	private static function get_user_taxonomy_ids_by_slug() {
+		$records = get_posts(
+			array(
+				'post_type'              => 'wp_user_taxonomy',
+				'post_status'            => 'any',
+				'posts_per_page'         => -1,
+				'no_found_rows'          => true,
+				'suppress_filters'       => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			)
+		);
+		$map     = array();
+		foreach ( $records as $record ) {
+			$slug = (string) $record->post_name;
+			if ( '' !== $slug ) {
+				$map[ $slug ] = (int) $record->ID;
+			}
+		}
+		return $map;
+	}
+
+	/**
+	 * Returns wp_user_taxonomy record IDs whose
+	 * `_wp_user_taxonomy_object_type` meta contains the given post type
+	 * slug, fetched directly from the DB.
+	 *
+	 * @param string $post_type_slug Post type slug to match.
+	 * @return int[]
+	 */
+	private static function get_user_taxonomy_ids_with_meta( $post_type_slug ) {
+		if ( '' === (string) $post_type_slug ) {
+			return array();
+		}
+		return get_posts(
+			array(
+				'post_type'        => 'wp_user_taxonomy',
+				'post_status'      => 'any',
+				'posts_per_page'   => -1,
+				'fields'           => 'ids',
+				'no_found_rows'    => true,
+				'suppress_filters' => true,
+				'meta_query'       => array(
+					array(
+						'key'     => GUTENBERG_USER_TAXONOMY_OBJECT_TYPE_META_KEY,
+						'value'   => $post_type_slug,
+						'compare' => '=',
+					),
+				),
+			)
+		);
 	}
 }

--- a/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
+++ b/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
@@ -309,9 +309,12 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 		$data    = $response->get_data();
 		$post_id = (int) $data['id'];
 		$this->sync_taxonomy_associations( $post_id, $request );
-		$refreshed = $this->prepare_item_for_response( get_post( $post_id ), $request );
-		if ( ! is_wp_error( $refreshed ) ) {
-			$response->set_data( $refreshed->get_data() );
+		$post = get_post( $post_id );
+		if ( $post instanceof WP_Post ) {
+			$refreshed = $this->prepare_item_for_response( $post, $request );
+			if ( ! is_wp_error( $refreshed ) ) {
+				$response->set_data( $refreshed->get_data() );
+			}
 		}
 		return $response;
 	}
@@ -339,9 +342,12 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 		}
 		$this->sync_taxonomy_associations( $post_id, $request );
 
-		$refreshed = $this->prepare_item_for_response( get_post( $post_id ), $request );
-		if ( ! is_wp_error( $refreshed ) ) {
-			$response->set_data( $refreshed->get_data() );
+		$post = get_post( $post_id );
+		if ( $post instanceof WP_Post ) {
+			$refreshed = $this->prepare_item_for_response( $post, $request );
+			if ( ! is_wp_error( $refreshed ) ) {
+				$response->set_data( $refreshed->get_data() );
+			}
 		}
 		return $response;
 	}
@@ -355,13 +361,20 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function delete_item( $request ) {
-		if ( ! empty( $request['force'] ) ) {
-			$slug = (string) get_post_field( 'post_name', (int) $request['id'] );
+		// Capture the slug before the parent runs — once force-delete fires
+		// the post is gone and `post_name` is no longer reachable.
+		$force    = ! empty( $request['force'] );
+		$slug     = $force ? (string) get_post_field( 'post_name', (int) $request['id'] ) : '';
+		$response = parent::delete_item( $request );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+		if ( $force && '' !== $slug ) {
 			foreach ( self::get_user_taxonomy_ids_with_meta( $slug ) as $tax_id ) {
 				gutenberg_user_taxonomy_detach_object_type( $tax_id, $slug );
 			}
 		}
-		return parent::delete_item( $request );
+		return $response;
 	}
 
 	/**
@@ -496,9 +509,6 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 			return;
 		}
 		$current_slug = (string) $post->post_name;
-		if ( '' === $current_slug ) {
-			return;
-		}
 
 		$ids_by_slug = self::get_user_taxonomy_ids_by_slug();
 		$desired     = array();

--- a/lib/experimental/content-types/class-wp-rest-user-taxonomies-controller-gutenberg.php
+++ b/lib/experimental/content-types/class-wp-rest-user-taxonomies-controller-gutenberg.php
@@ -345,7 +345,7 @@ class WP_REST_User_Taxonomies_Controller_Gutenberg extends WP_REST_Posts_Control
 		$data    = $response->get_data();
 		$post_id = (int) $data['id'];
 
-		$this->save_object_type_meta( $post_id, $request );
+		gutenberg_user_taxonomy_replace_object_types( $post_id, (array) $request['object_type'] );
 
 		$refreshed = $this->prepare_item_for_response( get_post( $post_id ), $request );
 		if ( ! is_wp_error( $refreshed ) ) {
@@ -374,7 +374,7 @@ class WP_REST_User_Taxonomies_Controller_Gutenberg extends WP_REST_Posts_Control
 
 		$post_id = (int) $request['id'];
 
-		$this->save_object_type_meta( $post_id, $request );
+		gutenberg_user_taxonomy_replace_object_types( $post_id, (array) $request['object_type'] );
 
 		$refreshed = $this->prepare_item_for_response( get_post( $post_id ), $request );
 		if ( ! is_wp_error( $refreshed ) ) {
@@ -382,35 +382,6 @@ class WP_REST_User_Taxonomies_Controller_Gutenberg extends WP_REST_Posts_Control
 		}
 
 		return $response;
-	}
-
-	/**
-	 * Persists the `object_type` array from the request as repeated rows of
-	 * `_wp_user_taxonomy_object_type` post meta. Stored separately from the
-	 * JSON config so listings can filter via `meta_query` IN. Callers must
-	 * have already verified that the request includes the `object_type`
-	 * param.
-	 *
-	 * @param int             $post_id Saved post ID.
-	 * @param WP_REST_Request $request REST request.
-	 */
-	private function save_object_type_meta( $post_id, $request ) {
-		$values = array();
-		foreach ( (array) $request['object_type'] as $slug ) {
-			if ( ! is_string( $slug ) ) {
-				continue;
-			}
-			$clean = sanitize_key( $slug );
-			if ( '' !== $clean && post_type_exists( $clean ) ) {
-				$values[] = $clean;
-			}
-		}
-		$values = array_values( array_unique( $values ) );
-
-		delete_post_meta( $post_id, GUTENBERG_USER_TAXONOMY_OBJECT_TYPE_META_KEY );
-		foreach ( $values as $slug ) {
-			add_post_meta( $post_id, GUTENBERG_USER_TAXONOMY_OBJECT_TYPE_META_KEY, $slug );
-		}
 	}
 
 	/**

--- a/lib/experimental/content-types/index.php
+++ b/lib/experimental/content-types/index.php
@@ -230,6 +230,61 @@ function gutenberg_user_taxonomy_read_object_type( $post_id ) {
 }
 
 /**
+ * Appends a post-type slug to a wp_user_taxonomy record's
+ * `_wp_user_taxonomy_object_type` meta if not already present. No-op if
+ * the slug is already attached.
+ *
+ * @param int    $tax_post_id wp_user_taxonomy record ID.
+ * @param string $object_type Post type slug to attach.
+ */
+function gutenberg_user_taxonomy_attach_object_type( $tax_post_id, $object_type ) {
+	$existing = (array) get_post_meta( $tax_post_id, GUTENBERG_USER_TAXONOMY_OBJECT_TYPE_META_KEY );
+	if ( in_array( $object_type, $existing, true ) ) {
+		return;
+	}
+	add_post_meta( $tax_post_id, GUTENBERG_USER_TAXONOMY_OBJECT_TYPE_META_KEY, $object_type );
+}
+
+/**
+ * Removes a single post-type slug from a wp_user_taxonomy record's
+ * `_wp_user_taxonomy_object_type` meta. Other slugs remain.
+ *
+ * @param int    $tax_post_id wp_user_taxonomy record ID.
+ * @param string $object_type Post type slug to detach.
+ */
+function gutenberg_user_taxonomy_detach_object_type( $tax_post_id, $object_type ) {
+	delete_post_meta( $tax_post_id, GUTENBERG_USER_TAXONOMY_OBJECT_TYPE_META_KEY, $object_type );
+}
+
+/**
+ * Replaces every `_wp_user_taxonomy_object_type` meta row on a record
+ * with the given list. Each value is sanitized via `sanitize_key()` and
+ * filtered against `post_type_exists()` so only registered post types
+ * land in storage; duplicates are collapsed.
+ *
+ * @param int                $tax_post_id  wp_user_taxonomy record ID.
+ * @param array<int, string> $object_types Post type slugs to store.
+ */
+function gutenberg_user_taxonomy_replace_object_types( $tax_post_id, array $object_types ) {
+	$values = array();
+	foreach ( $object_types as $slug ) {
+		if ( ! is_string( $slug ) ) {
+			continue;
+		}
+		$clean = sanitize_key( $slug );
+		if ( '' !== $clean && post_type_exists( $clean ) ) {
+			$values[] = $clean;
+		}
+	}
+	$values = array_values( array_unique( $values ) );
+
+	delete_post_meta( $tax_post_id, GUTENBERG_USER_TAXONOMY_OBJECT_TYPE_META_KEY );
+	foreach ( $values as $slug ) {
+		add_post_meta( $tax_post_id, GUTENBERG_USER_TAXONOMY_OBJECT_TYPE_META_KEY, $slug );
+	}
+}
+
+/**
  * Builds register_taxonomy() arguments from a wp_user_taxonomy record.
  * Returns null for invalid records so callers can skip them uniformly.
  *
@@ -296,13 +351,13 @@ function gutenberg_build_user_taxonomy_args( WP_Post $record ) {
 		'show_tagcloud',
 		'show_in_quick_edit',
 		'show_admin_column',
-		'show_in_rest',
 	);
 	foreach ( $bool_keys as $key ) {
 		if ( array_key_exists( $key, $config ) ) {
 			$args[ $key ] = (bool) $config[ $key ];
 		}
 	}
+	$args['show_in_rest'] = isset( $config['show_in_rest'] ) ? (bool) $config['show_in_rest'] : true;
 
 	return array( $slug, $object_type, $args );
 }

--- a/lib/experimental/content-types/index.php
+++ b/lib/experimental/content-types/index.php
@@ -238,11 +238,18 @@ function gutenberg_user_taxonomy_read_object_type( $post_id ) {
  * @param string $object_type Post type slug to attach.
  */
 function gutenberg_user_taxonomy_attach_object_type( $tax_post_id, $object_type ) {
-	$existing = (array) get_post_meta( $tax_post_id, GUTENBERG_USER_TAXONOMY_OBJECT_TYPE_META_KEY );
-	if ( in_array( $object_type, $existing, true ) ) {
+	if ( 'wp_user_taxonomy' !== get_post_type( $tax_post_id ) ) {
 		return;
 	}
-	add_post_meta( $tax_post_id, GUTENBERG_USER_TAXONOMY_OBJECT_TYPE_META_KEY, $object_type );
+	$clean = is_string( $object_type ) ? sanitize_key( $object_type ) : '';
+	if ( '' === $clean ) {
+		return;
+	}
+	$existing = (array) get_post_meta( $tax_post_id, GUTENBERG_USER_TAXONOMY_OBJECT_TYPE_META_KEY );
+	if ( in_array( $clean, $existing, true ) ) {
+		return;
+	}
+	add_post_meta( $tax_post_id, GUTENBERG_USER_TAXONOMY_OBJECT_TYPE_META_KEY, $clean );
 }
 
 /**
@@ -253,7 +260,14 @@ function gutenberg_user_taxonomy_attach_object_type( $tax_post_id, $object_type 
  * @param string $object_type Post type slug to detach.
  */
 function gutenberg_user_taxonomy_detach_object_type( $tax_post_id, $object_type ) {
-	delete_post_meta( $tax_post_id, GUTENBERG_USER_TAXONOMY_OBJECT_TYPE_META_KEY, $object_type );
+	if ( 'wp_user_taxonomy' !== get_post_type( $tax_post_id ) ) {
+		return;
+	}
+	$clean = is_string( $object_type ) ? sanitize_key( $object_type ) : '';
+	if ( '' === $clean ) {
+		return;
+	}
+	delete_post_meta( $tax_post_id, GUTENBERG_USER_TAXONOMY_OBJECT_TYPE_META_KEY, $clean );
 }
 
 /**

--- a/packages/user-post-types/src/types.ts
+++ b/packages/user-post-types/src/types.ts
@@ -54,6 +54,13 @@ export type SupportFeature =
 
 export interface StoredConfig {
 	labels?: StoredLabels;
+	/**
+	 * The merged set of taxonomy slugs attached to this post type. The REST
+	 * controller composes this on read from two storage sites — non-user
+	 * slugs persisted on the post type record's JSON, and user-defined
+	 * taxonomies whose `_wp_user_taxonomy_object_type` meta points back —
+	 * and splits writes back into those sites.
+	 */
 	taxonomies?: string[];
 	supports?: SupportFeature[];
 	description?: string;

--- a/packages/user-post-types/src/utils.ts
+++ b/packages/user-post-types/src/utils.ts
@@ -150,7 +150,7 @@ export function usePublicTaxonomies() {
 	);
 	return useMemo( () => {
 		return taxonomies
-			?.filter( ( t: any ) => t.visibility?.public ?? false )
+			?.filter( ( t: any ) => !! t.visibility?.public )
 			.sort( ( a: any, b: any ) => {
 				// Core taxonomies first (alphabetically), then the rest
 				// (alphabetically). The REST API doesn't expose `_builtin`,

--- a/phpunit/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg-test.php
+++ b/phpunit/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg-test.php
@@ -892,6 +892,35 @@ class WP_REST_User_Post_Types_Controller_Gutenberg_Test extends WP_Test_REST_Con
 	}
 
 	/**
+	 * Trash (force = false) preserves user-taxonomy meta so untrashing
+	 * restores the linkage. Companion to the force-delete test above.
+	 */
+	public function test_delete_item_trash_preserves_user_tax_meta() {
+		wp_set_current_user( self::$admin_id );
+		$genre_id = self::insert_user_taxonomy_record_for_sync( 'sync_genre', 'Genres' );
+
+		$post_id = self::insert_user_post_type_record(
+			array(
+				'labels'     => array( 'singular_name' => 'Album' ),
+				'taxonomies' => array( 'sync_genre' ),
+			),
+			'sync_album',
+			'Albums'
+		);
+		$this->assertSame( array( 'sync_album' ), self::get_object_type_meta( $genre_id ) );
+
+		// No `force` param — trash, not delete.
+		$request  = new WP_REST_Request( 'DELETE', self::REST_BASE . '/' . $post_id );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assertSame( array( 'sync_album' ), self::get_object_type_meta( $genre_id ) );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_post( $genre_id, true );
+	}
+
+	/**
 	 * Renaming a post type's slug carries its user-taxonomy back-references
 	 * to the new slug — without this, every linked user taxonomy would
 	 * silently disconnect after a rename.

--- a/phpunit/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg-test.php
+++ b/phpunit/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg-test.php
@@ -703,4 +703,221 @@ class WP_REST_User_Post_Types_Controller_Gutenberg_Test extends WP_Test_REST_Con
 		$this->assertSame( 'array', $taxonomies_schema['type'] );
 		$this->assertSame( '^[a-z0-9_-]{1,32}$', $taxonomies_schema['items']['pattern'] );
 	}
+
+	/**
+	 * Seed a wp_user_taxonomy record via its REST endpoint, mirroring the
+	 * production write path. Used by the cross-CPT sync tests below.
+	 *
+	 * @param string $slug        Taxonomy slug.
+	 * @param string $title       Taxonomy plural label.
+	 * @param array  $object_type Post type slugs to attach.
+	 * @return int Post ID.
+	 */
+	protected static function insert_user_taxonomy_record_for_sync( $slug, $title, $object_type = array() ) {
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/user-taxonomies' );
+		$request->set_body_params(
+			array(
+				'title'       => $title,
+				'slug'        => $slug,
+				'status'      => 'publish',
+				'object_type' => $object_type,
+				'config'      => array(
+					'labels' => array( 'singular_name' => $title ),
+					'public' => true,
+				),
+			)
+		);
+		return rest_get_server()->dispatch( $request )->get_data()['id'];
+	}
+
+	/**
+	 * Reads the slugs stored in `_wp_user_taxonomy_object_type` meta on a
+	 * given wp_user_taxonomy record. Sorted for stable assertions.
+	 *
+	 * @param int $taxonomy_id wp_user_taxonomy record ID.
+	 * @return string[]
+	 */
+	protected static function get_object_type_meta( $taxonomy_id ) {
+		$values = get_post_meta( $taxonomy_id, GUTENBERG_USER_TAXONOMY_OBJECT_TYPE_META_KEY );
+		$values = array_values( array_filter( (array) $values, 'is_string' ) );
+		sort( $values );
+		return $values;
+	}
+
+	/**
+	 * Writes that include a user-defined taxonomy slug in `config.taxonomies`
+	 * persist only the non-user slugs in the post type's stored JSON; the
+	 * user-tax slugs are mirrored into the corresponding wp_user_taxonomy
+	 * record's `_wp_user_taxonomy_object_type` meta. Single source of truth
+	 * per side, with the controller doing the split.
+	 */
+	public function test_create_item_routes_user_tax_slugs_to_taxonomy_meta() {
+		wp_set_current_user( self::$admin_id );
+		$genre_id = self::insert_user_taxonomy_record_for_sync( 'sync_genre', 'Genres' );
+
+		$post_id = self::insert_user_post_type_record(
+			array(
+				'labels'     => array( 'singular_name' => 'Album' ),
+				'taxonomies' => array( 'category', 'sync_genre' ),
+			),
+			'sync_album',
+			'Albums'
+		);
+
+		// Stored JSON: only the core slug. The user-tax slug was lifted out.
+		$raw     = get_post( $post_id )->post_content;
+		$decoded = json_decode( $raw, true );
+		$this->assertSame( array( 'category' ), $decoded['taxonomies'] );
+
+		// User-taxonomy meta: now references the post type slug.
+		$this->assertSame( array( 'sync_album' ), self::get_object_type_meta( $genre_id ) );
+
+		// Response: the merged view, so the form sees what was sent.
+		$request = new WP_REST_Request( 'GET', self::REST_BASE . '/' . $post_id );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$merged   = $data['config']['taxonomies'];
+		sort( $merged );
+		$this->assertSame( array( 'category', 'sync_genre' ), $merged );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_post( $genre_id, true );
+	}
+
+	/**
+	 * Updating `config.taxonomies` to drop a previously-linked user-tax slug
+	 * removes the post type slug from that taxonomy's meta. Other user-tax
+	 * records are not touched.
+	 */
+	public function test_update_item_removes_dropped_user_tax_associations() {
+		wp_set_current_user( self::$admin_id );
+		$genre_id = self::insert_user_taxonomy_record_for_sync( 'sync_genre', 'Genres' );
+		$mood_id  = self::insert_user_taxonomy_record_for_sync( 'sync_mood', 'Moods' );
+
+		$post_id = self::insert_user_post_type_record(
+			array(
+				'labels'     => array( 'singular_name' => 'Album' ),
+				'taxonomies' => array( 'sync_genre', 'sync_mood' ),
+			),
+			'sync_album',
+			'Albums'
+		);
+
+		// Both attached after the create.
+		$this->assertSame( array( 'sync_album' ), self::get_object_type_meta( $genre_id ) );
+		$this->assertSame( array( 'sync_album' ), self::get_object_type_meta( $mood_id ) );
+
+		// Now drop sync_mood, keep sync_genre.
+		$request = new WP_REST_Request( 'PUT', self::REST_BASE . '/' . $post_id );
+		$request->set_body_params(
+			array(
+				'config' => array(
+					'labels'     => array( 'singular_name' => 'Album' ),
+					'taxonomies' => array( 'sync_genre' ),
+				),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assertSame( array( 'sync_album' ), self::get_object_type_meta( $genre_id ) );
+		$this->assertSame( array(), self::get_object_type_meta( $mood_id ) );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_post( $genre_id, true );
+		wp_delete_post( $mood_id, true );
+	}
+
+	/**
+	 * Status-only updates (the activate/deactivate flow) leave user-tax
+	 * associations intact — there's no `config.taxonomies` in the request,
+	 * so the controller skips the sync entirely.
+	 */
+	public function test_update_item_without_config_does_not_touch_meta() {
+		wp_set_current_user( self::$admin_id );
+		$genre_id = self::insert_user_taxonomy_record_for_sync( 'sync_genre', 'Genres' );
+
+		$post_id = self::insert_user_post_type_record(
+			array(
+				'labels'     => array( 'singular_name' => 'Album' ),
+				'taxonomies' => array( 'sync_genre' ),
+			),
+			'sync_album',
+			'Albums'
+		);
+		$this->assertSame( array( 'sync_album' ), self::get_object_type_meta( $genre_id ) );
+
+		$request = new WP_REST_Request( 'PUT', self::REST_BASE . '/' . $post_id );
+		$request->set_body_params( array( 'status' => 'draft' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		// Meta is unchanged — deactivating a post type doesn't disconnect
+		// linked user taxonomies, so reactivation restores everything.
+		$this->assertSame( array( 'sync_album' ), self::get_object_type_meta( $genre_id ) );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_post( $genre_id, true );
+	}
+
+	/**
+	 * Force-deleting a post type strips its slug from every user-taxonomy
+	 * record's meta. Trash (force = false) leaves the meta intact so
+	 * untrashing restores the linkage.
+	 */
+	public function test_delete_item_force_cleans_user_tax_meta() {
+		wp_set_current_user( self::$admin_id );
+		$genre_id = self::insert_user_taxonomy_record_for_sync( 'sync_genre', 'Genres' );
+
+		$post_id = self::insert_user_post_type_record(
+			array(
+				'labels'     => array( 'singular_name' => 'Album' ),
+				'taxonomies' => array( 'sync_genre' ),
+			),
+			'sync_album',
+			'Albums'
+		);
+		$this->assertSame( array( 'sync_album' ), self::get_object_type_meta( $genre_id ) );
+
+		$request = new WP_REST_Request( 'DELETE', self::REST_BASE . '/' . $post_id );
+		$request->set_param( 'force', true );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assertSame( array(), self::get_object_type_meta( $genre_id ) );
+
+		wp_delete_post( $genre_id, true );
+	}
+
+	/**
+	 * Renaming a post type's slug carries its user-taxonomy back-references
+	 * to the new slug — without this, every linked user taxonomy would
+	 * silently disconnect after a rename.
+	 */
+	public function test_update_item_slug_rename_migrates_user_tax_meta() {
+		wp_set_current_user( self::$admin_id );
+		$genre_id = self::insert_user_taxonomy_record_for_sync( 'sync_genre', 'Genres' );
+
+		$post_id = self::insert_user_post_type_record(
+			array(
+				'labels'     => array( 'singular_name' => 'Album' ),
+				'taxonomies' => array( 'sync_genre' ),
+			),
+			'sync_album',
+			'Albums'
+		);
+		$this->assertSame( array( 'sync_album' ), self::get_object_type_meta( $genre_id ) );
+
+		$request = new WP_REST_Request( 'PUT', self::REST_BASE . '/' . $post_id );
+		$request->set_body_params( array( 'slug' => 'sync_record' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assertSame( array( 'sync_record' ), self::get_object_type_meta( $genre_id ) );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_post( $genre_id, true );
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/77600

This PR handles the syncing between user post types and taxonomies. 

## Storage split for `config.taxonomies`    

The post type's `config.taxonomies` field is split across two storage sites:
                                                                                                                                       
  - **Non-user slugs** (core/theme/plugin) live in the post type's JSON config (`post_content`).
  - **User-defined taxonomy slugs** live on the taxonomy record's `_wp_user_taxonomy_object_type` meta, which is the single source of  truth for the post-type↔user-taxonomy relationship.   
                                                                                                                                       
  The client only ever sees a single `config.taxonomies` field — the controller splits writes back into the two sites and rejoins them on read. Adding a user-taxonomy from the post-types form and adding the same post type from the user-taxonomies form converge on the same meta, so updating either side stays in sync.     
                                                                                                                                       
  ## Slug rename migration                              
                                                                                                                                       
  When a post type's slug changes (PUT with `slug`), every `_wp_user_taxonomy_object_type` meta row pointing at the old slug is rewritten to the new one. Without this, every linked user taxonomy would silently disconnect on rename. 


## Relationship helpers live outside the REST controllers

  The post-type↔taxonomy relationship is mediated by module-level helpers in `lib/experimental/content-types/index.php` (`gutenberg_user_taxonomy_attach_object_type` / `_detach_object_type` / `_replace_object_types`), not inside either controller.

  Both controllers need to read and write the same `_wp_user_taxonomy_object_type` meta to keep the two entities in sync. That's a   domain concern, not a REST concern — keeping it in shared helpers means the storage shape, sanitization (`sanitize_key`), and `post_type_exists` filtering live in one place, and either side can be invoked outside the REST flow.                   
   
  Same factoring as WordPress's template helpers (`_build_block_template_result_from_post`, `_inject_theme_attribute_in_template_part_block`) which are called from both REST and non-REST code paths.
                                                                                                                                       
  ## Testing instructions                               
                                                                                                                                       
  1. Enable the **Content types** experiment (Settings → Gutenberg → Experiments).
  2. Go to **Settings → Post Types** and click **Add new** to create a post type (e.g., `album`). Confirm it appears in the list.
  3. Go to **Settings → Taxonomies**, add a new taxonomy (e.g., `genre`) and select the `album` post type in its associated post types.
  4. Return to **Settings → Post Types** and observe that the linked taxonomy is shown in the post types list (taxonomies field).  Edit `album` — `genre` should now appear in its taxonomies list.
  5. Edit the post type and add another taxonomy from the post types form. Save, then open the taxonomies page — the post type should  appear on that taxonomy's associations.               
  6. Remove the association from either side. Confirm the other side reflects the removal.                                             
  7. Rename the post type's slug (e.g., `album` → `record`). Confirm:                                                                  
     - The associated taxonomies still show the post type under its new slug.                                                          
     - The post type still lists the same taxonomies after rename.                                                                     
     - A slug-only PUT (without `config` in the request body) also migrates correctly.                                                 
                                                        
  ## Use of AI Tools                                                                                                                   
  Opus 4.7 with direction, changes and review. 
