### PR TITLE
Experiment: add first basic user post types e2e tests and update taxonomy tests

### DIFF
--- a/test/e2e/specs/admin/user-post-types.spec.js
+++ b/test/e2e/specs/admin/user-post-types.spec.js
@@ -17,6 +17,7 @@ async function createUserPostType( requestUtils ) {
 			status: 'publish',
 			config: {
 				labels: { singular_name: 'Book' },
+				public: true, // mirrors the form's Create defaults
 			},
 		},
 	} );
@@ -37,11 +38,7 @@ test.describe( 'User post types', () => {
 		await requestUtils.setGutenbergExperiments( [] );
 	} );
 
-	test( 'creates a post type and registers it', async ( {
-		admin,
-		page,
-		requestUtils,
-	} ) => {
+	test( 'creates a post type and registers it', async ( { admin, page } ) => {
 		await admin.visitAdminPage( SETTINGS_PAGE_PATH, POST_TYPES_PAGE_QUERY );
 
 		await page.getByRole( 'button', { name: 'Add post type' } ).click();
@@ -76,13 +73,10 @@ test.describe( 'User post types', () => {
 			'"Books" post type created.'
 		);
 
-		// `show_in_rest: true` is the default for user-defined post types,
-		// so the type endpoint should resolve immediately after activation.
-		const registered = await requestUtils.rest( {
-			path: '/wp/v2/types/book',
-			method: 'GET',
-		} );
-		expect( registered.slug ).toBe( 'book' );
+		await admin.visitAdminPage( 'edit.php', 'post_type=book' );
+		await expect(
+			page.getByRole( 'heading', { level: 1, name: 'Books' } )
+		).toBeVisible();
 	} );
 
 	test( 'deactivating unregisters the post type and activating re-registers it', async ( {
@@ -93,42 +87,47 @@ test.describe( 'User post types', () => {
 		await createUserPostType( requestUtils );
 		await admin.visitAdminPage( SETTINGS_PAGE_PATH, POST_TYPES_PAGE_QUERY );
 
-		const row = page.getByRole( 'row', { name: /Books/ } );
-		await row.getByRole( 'button', { name: 'Actions' } ).click();
+		await page
+			.getByRole( 'row', { name: /Books/ } )
+			.getByRole( 'button', { name: 'Actions' } )
+			.click();
 		await page.getByRole( 'menuitem', { name: 'Deactivate' } ).click();
 
 		await expect( page.getByTestId( 'snackbar' ).last() ).toContainText(
 			'Post type deactivated.'
 		);
-		await expect( row.getByText( 'Inactive' ) ).toBeVisible();
+		await expect(
+			page.getByRole( 'row', { name: /Books/ } ).getByText( 'Inactive' )
+		).toBeVisible();
 
-		// requestUtils.rest() throws on non-2xx — catch and inspect the
-		// error code instead of relying on a status assertion.
-		const deactivated = await requestUtils
-			.rest( {
-				path: '/wp/v2/types/book',
-				method: 'GET',
-			} )
-			.catch( ( error ) => error );
-		expect( deactivated.code ).toBe( 'rest_type_invalid' );
+		// Unregistered post types cause WP core to wp_die with "Invalid post
+		// type." when visiting their admin list URL.
+		await admin.visitAdminPage( 'edit.php', 'post_type=book' );
+		await expect( page.getByText( 'Invalid post type.' ) ).toBeVisible();
 
-		await row.getByRole( 'button', { name: 'Actions' } ).click();
+		await admin.visitAdminPage( SETTINGS_PAGE_PATH, POST_TYPES_PAGE_QUERY );
+		await page
+			.getByRole( 'row', { name: /Books/ } )
+			.getByRole( 'button', { name: 'Actions' } )
+			.click();
 		await page.getByRole( 'menuitem', { name: 'Activate' } ).click();
 
 		await expect( page.getByTestId( 'snackbar' ).last() ).toContainText(
 			'Post type activated.'
 		);
-		await expect( row.getByText( 'Active' ) ).toBeVisible();
+		await expect(
+			page.getByRole( 'row', { name: /Books/ } ).getByText( 'Active' )
+		).toBeVisible();
 
-		const reactivated = await requestUtils.rest( {
-			path: '/wp/v2/types/book',
-			method: 'GET',
-		} );
-		expect( reactivated.slug ).toBe( 'book' );
+		await admin.visitAdminPage( 'edit.php', 'post_type=book' );
+		await expect(
+			page.getByRole( 'heading', { level: 1, name: 'Books' } )
+		).toBeVisible();
 	} );
 
 	test( 'editing a post type persists changes to the registered post type', async ( {
 		admin,
+		editor,
 		page,
 		requestUtils,
 	} ) => {
@@ -154,11 +153,18 @@ test.describe( 'User post types', () => {
 			'"Books" post type updated.'
 		);
 
-		const registered = await requestUtils.rest( {
-			path: '/wp/v2/types/book',
-			method: 'GET',
-		} );
-		expect( registered.hierarchical ).toBe( true );
-		expect( registered.taxonomies ).toContain( 'category' );
+		// Open the post editor for the registered type and confirm the saved
+		// config reached register_post_type():
+		// - Hierarchical post types render a "Parent" row in the document
+		//   sidebar.
+		// - Associating the `category` taxonomy adds a "Categories" panel.
+		await admin.createNewPost( { postType: 'book' } );
+		await editor.openDocumentSettingsSidebar();
+		await expect(
+			page.getByText( 'Parent', { exact: true } )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'button', { name: 'Categories' } )
+		).toBeVisible();
 	} );
 } );

--- a/test/e2e/specs/admin/user-post-types.spec.js
+++ b/test/e2e/specs/admin/user-post-types.spec.js
@@ -8,17 +8,13 @@ const POST_TYPES_PAGE_QUERY = 'page=post-types-wp-admin';
 const POST_TYPES_REST_BASE = 'user-post-types';
 
 async function createUserPostType( requestUtils ) {
-	return requestUtils.rest( {
-		path: `/wp/v2/${ POST_TYPES_REST_BASE }`,
-		method: 'POST',
-		data: {
-			title: 'Books',
-			slug: 'book',
-			status: 'publish',
-			config: {
-				labels: { singular_name: 'Book' },
-				public: true, // mirrors the form's Create defaults
-			},
+	return requestUtils.createRecord( POST_TYPES_REST_BASE, {
+		title: 'Books',
+		slug: 'book',
+		status: 'publish',
+		config: {
+			labels: { singular_name: 'Book' },
+			public: true, // mirrors the form's Create defaults
 		},
 	} );
 }
@@ -88,7 +84,7 @@ test.describe( 'User post types', () => {
 		await admin.visitAdminPage( SETTINGS_PAGE_PATH, POST_TYPES_PAGE_QUERY );
 
 		await page
-			.getByRole( 'row', { name: /Books/ } )
+			.getByRole( 'row', { name: 'Books' } )
 			.getByRole( 'button', { name: 'Actions' } )
 			.click();
 		await page.getByRole( 'menuitem', { name: 'Deactivate' } ).click();
@@ -97,7 +93,7 @@ test.describe( 'User post types', () => {
 			'Post type deactivated.'
 		);
 		await expect(
-			page.getByRole( 'row', { name: /Books/ } ).getByText( 'Inactive' )
+			page.getByRole( 'row', { name: 'Books' } ).getByText( 'Inactive' )
 		).toBeVisible();
 
 		// Unregistered post types cause WP core to wp_die with "Invalid post
@@ -107,7 +103,7 @@ test.describe( 'User post types', () => {
 
 		await admin.visitAdminPage( SETTINGS_PAGE_PATH, POST_TYPES_PAGE_QUERY );
 		await page
-			.getByRole( 'row', { name: /Books/ } )
+			.getByRole( 'row', { name: 'Books' } )
 			.getByRole( 'button', { name: 'Actions' } )
 			.click();
 		await page.getByRole( 'menuitem', { name: 'Activate' } ).click();
@@ -116,7 +112,7 @@ test.describe( 'User post types', () => {
 			'Post type activated.'
 		);
 		await expect(
-			page.getByRole( 'row', { name: /Books/ } ).getByText( 'Active' )
+			page.getByRole( 'row', { name: 'Books' } ).getByText( 'Active' )
 		).toBeVisible();
 
 		await admin.visitAdminPage( 'edit.php', 'post_type=book' );
@@ -161,7 +157,7 @@ test.describe( 'User post types', () => {
 		await admin.createNewPost( { postType: 'book' } );
 		await editor.openDocumentSettingsSidebar();
 		await expect(
-			page.getByText( 'Parent', { exact: true } )
+			page.getByRole( 'button', { name: /Change parent:/ } )
 		).toBeVisible();
 		await expect(
 			page.getByRole( 'button', { name: 'Categories' } )

--- a/test/e2e/specs/admin/user-post-types.spec.js
+++ b/test/e2e/specs/admin/user-post-types.spec.js
@@ -1,0 +1,172 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const SETTINGS_PAGE_PATH = 'options-general.php';
+const POST_TYPES_PAGE_QUERY = 'page=post-types-wp-admin';
+const POST_TYPES_REST_BASE = 'user-post-types';
+
+async function createUserPostType( requestUtils ) {
+	return requestUtils.rest( {
+		path: `/wp/v2/${ POST_TYPES_REST_BASE }`,
+		method: 'POST',
+		data: {
+			title: 'Books',
+			slug: 'book',
+			status: 'publish',
+			config: {
+				labels: { singular_name: 'Book' },
+			},
+		},
+	} );
+}
+
+async function visitPostTypesList( admin ) {
+	await admin.visitAdminPage( SETTINGS_PAGE_PATH, POST_TYPES_PAGE_QUERY );
+}
+
+async function visitPostTypeEdit( admin, id ) {
+	await admin.visitAdminPage(
+		SETTINGS_PAGE_PATH,
+		`${ POST_TYPES_PAGE_QUERY }&p=/edit/${ id }`
+	);
+}
+
+test.describe( 'User post types', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-content-types',
+		] );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts( POST_TYPES_REST_BASE );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test( 'creates a post type and registers it', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		await visitPostTypesList( admin );
+
+		await page.getByRole( 'button', { name: 'Add post type' } ).click();
+
+		await page
+			.getByRole( 'textbox', { name: 'Plural label' } )
+			.fill( 'Books' );
+		await page
+			.getByRole( 'textbox', { name: 'Singular label' } )
+			.fill( 'Book' );
+		// Focusing the slug field auto-fills it from the singular label and
+		// kicks off the async draft-uniqueness check. The form's `isValid`
+		// stays false while that's in flight, so wait for the REST call to
+		// settle before submitting. See user-taxonomies.spec.js for the same
+		// pattern.
+		const slugField = page.getByRole( 'textbox', {
+			name: 'Post type key',
+		} );
+		await Promise.all( [
+			page.waitForResponse(
+				( resp ) =>
+					resp.url().includes( `/${ POST_TYPES_REST_BASE }` ) &&
+					resp.url().includes( 'slug=book' )
+			),
+			slugField.focus(),
+		] );
+		await expect( slugField ).toHaveValue( 'book' );
+
+		await page.getByRole( 'button', { name: 'Create' } ).click();
+
+		await expect( page.getByTestId( 'snackbar' ) ).toContainText(
+			'"Books" post type created.'
+		);
+
+		// `show_in_rest: true` is the default for user-defined post types,
+		// so the type endpoint should resolve immediately after activation.
+		const registered = await requestUtils.rest( {
+			path: '/wp/v2/types/book',
+			method: 'GET',
+		} );
+		expect( registered.slug ).toBe( 'book' );
+	} );
+
+	test( 'deactivating unregisters the post type and activating re-registers it', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		await createUserPostType( requestUtils );
+		await visitPostTypesList( admin );
+
+		const row = page.getByRole( 'row', { name: /Books/ } );
+		await row.getByRole( 'button', { name: 'Actions' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Deactivate' } ).click();
+
+		await expect( page.getByTestId( 'snackbar' ).last() ).toContainText(
+			'Post type deactivated.'
+		);
+		await expect( row.getByText( 'Inactive' ) ).toBeVisible();
+
+		// requestUtils.rest() throws on non-2xx — catch and inspect the
+		// error code instead of relying on a status assertion.
+		const deactivated = await requestUtils
+			.rest( {
+				path: '/wp/v2/types/book',
+				method: 'GET',
+			} )
+			.catch( ( error ) => error );
+		expect( deactivated.code ).toBe( 'rest_type_invalid' );
+
+		await row.getByRole( 'button', { name: 'Actions' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Activate' } ).click();
+
+		await expect( page.getByTestId( 'snackbar' ).last() ).toContainText(
+			'Post type activated.'
+		);
+		await expect( row.getByText( 'Active' ) ).toBeVisible();
+
+		const reactivated = await requestUtils.rest( {
+			path: '/wp/v2/types/book',
+			method: 'GET',
+		} );
+		expect( reactivated.slug ).toBe( 'book' );
+	} );
+
+	test( 'editing a post type persists changes to the registered post type', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const created = await createUserPostType( requestUtils );
+		await visitPostTypeEdit( admin, created.id );
+
+		await page
+			.getByRole( 'checkbox', { name: 'Hierarchical', exact: true } )
+			.click();
+		await page.getByRole( 'combobox', { name: 'Taxonomies' } ).click();
+		await page.getByRole( 'option', { name: 'Categories' } ).click();
+		await expect(
+			page.locator( '.components-form-token-field__token', {
+				hasText: 'Categories',
+			} )
+		).toBeVisible();
+
+		await page.getByRole( 'button', { name: 'Save' } ).click();
+		await expect( page.getByTestId( 'snackbar' ).last() ).toContainText(
+			'"Books" post type updated.'
+		);
+
+		const registered = await requestUtils.rest( {
+			path: '/wp/v2/types/book',
+			method: 'GET',
+		} );
+		expect( registered.hierarchical ).toBe( true );
+		expect( registered.taxonomies ).toContain( 'category' );
+	} );
+} );

--- a/test/e2e/specs/admin/user-post-types.spec.js
+++ b/test/e2e/specs/admin/user-post-types.spec.js
@@ -22,17 +22,6 @@ async function createUserPostType( requestUtils ) {
 	} );
 }
 
-async function visitPostTypesList( admin ) {
-	await admin.visitAdminPage( SETTINGS_PAGE_PATH, POST_TYPES_PAGE_QUERY );
-}
-
-async function visitPostTypeEdit( admin, id ) {
-	await admin.visitAdminPage(
-		SETTINGS_PAGE_PATH,
-		`${ POST_TYPES_PAGE_QUERY }&p=/edit/${ id }`
-	);
-}
-
 test.describe( 'User post types', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.setGutenbergExperiments( [
@@ -53,7 +42,7 @@ test.describe( 'User post types', () => {
 		page,
 		requestUtils,
 	} ) => {
-		await visitPostTypesList( admin );
+		await admin.visitAdminPage( SETTINGS_PAGE_PATH, POST_TYPES_PAGE_QUERY );
 
 		await page.getByRole( 'button', { name: 'Add post type' } ).click();
 
@@ -102,7 +91,7 @@ test.describe( 'User post types', () => {
 		requestUtils,
 	} ) => {
 		await createUserPostType( requestUtils );
-		await visitPostTypesList( admin );
+		await admin.visitAdminPage( SETTINGS_PAGE_PATH, POST_TYPES_PAGE_QUERY );
 
 		const row = page.getByRole( 'row', { name: /Books/ } );
 		await row.getByRole( 'button', { name: 'Actions' } ).click();
@@ -144,7 +133,10 @@ test.describe( 'User post types', () => {
 		requestUtils,
 	} ) => {
 		const created = await createUserPostType( requestUtils );
-		await visitPostTypeEdit( admin, created.id );
+		await admin.visitAdminPage(
+			SETTINGS_PAGE_PATH,
+			`${ POST_TYPES_PAGE_QUERY }&p=/edit/${ created.id }`
+		);
 
 		await page
 			.getByRole( 'checkbox', { name: 'Hierarchical', exact: true } )

--- a/test/e2e/specs/admin/user-taxonomies.spec.js
+++ b/test/e2e/specs/admin/user-taxonomies.spec.js
@@ -116,7 +116,7 @@ test.describe( 'User taxonomies', () => {
 		await admin.visitAdminPage( SETTINGS_PAGE_PATH, TAXONOMIES_PAGE_QUERY );
 
 		await page
-			.getByRole( 'row', { name: /Genres/ } )
+			.getByRole( 'row', { name: 'Genres' } )
 			.getByRole( 'button', { name: 'Actions' } )
 			.click();
 		await page.getByRole( 'menuitem', { name: 'Deactivate' } ).click();
@@ -125,7 +125,7 @@ test.describe( 'User taxonomies', () => {
 			'Taxonomy deactivated.'
 		);
 		await expect(
-			page.getByRole( 'row', { name: /Genres/ } ).getByText( 'Inactive' )
+			page.getByRole( 'row', { name: 'Genres' } ).getByText( 'Inactive' )
 		).toBeVisible();
 
 		// Unregistered taxonomies cause WP core to wp_die with "Invalid
@@ -138,7 +138,7 @@ test.describe( 'User taxonomies', () => {
 
 		await admin.visitAdminPage( SETTINGS_PAGE_PATH, TAXONOMIES_PAGE_QUERY );
 		await page
-			.getByRole( 'row', { name: /Genres/ } )
+			.getByRole( 'row', { name: 'Genres' } )
 			.getByRole( 'button', { name: 'Actions' } )
 			.click();
 		await page.getByRole( 'menuitem', { name: 'Activate' } ).click();
@@ -147,7 +147,7 @@ test.describe( 'User taxonomies', () => {
 			'Taxonomy activated.'
 		);
 		await expect(
-			page.getByRole( 'row', { name: /Genres/ } ).getByText( 'Active' )
+			page.getByRole( 'row', { name: 'Genres' } ).getByText( 'Active' )
 		).toBeVisible();
 
 		await admin.visitAdminPage(
@@ -191,9 +191,6 @@ test.describe( 'User taxonomies', () => {
 			await page
 				.getByRole( 'checkbox', { name: 'Show admin column' } )
 				.click();
-			await page
-				.getByRole( 'checkbox', { name: 'Publicly queryable' } )
-				.click();
 
 			await page.getByRole( 'button', { name: 'Save' } ).click();
 			await expect( page.getByTestId( 'snackbar' ).last() ).toContainText(
@@ -211,6 +208,15 @@ test.describe( 'User taxonomies', () => {
 					.filter( { hasText: 'Genres' } )
 					.first()
 			).toBeVisible();
+
+			// Confirm Posts is no longer attached. With `show_admin_column`
+			// enabled in this test, the column would still render on the
+			// posts list if the taxonomy were attached to `post` — its
+			// absence proves the detach.
+			await admin.visitAdminPage( 'edit.php', 'post_type=post' );
+			await expect(
+				page.getByRole( 'columnheader' ).filter( { hasText: 'Genres' } )
+			).toHaveCount( 0 );
 		} );
 
 		test( 'turning `Show in REST API` off blocks the taxonomy from the REST API', async ( {
@@ -235,9 +241,39 @@ test.describe( 'User taxonomies', () => {
 			expect( result.code ).toBe( 'rest_forbidden' );
 		} );
 
+		test( 'turning `Publicly queryable` off blocks the front-end term archive', async ( {
+			page,
+		} ) => {
+			// Sanity baseline: with publicly_queryable on (from the seed),
+			// WP::parse_request() routes the query vars through and 404s
+			// for an unknown term.
+			let response = await page.request.get(
+				'/?taxonomy=genre&term=missing'
+			);
+			expect( response.status() ).toBe( 404 );
+
+			await page.getByRole( 'button', { name: 'Visibility' } ).click();
+			await page
+				.getByRole( 'checkbox', { name: 'Publicly queryable' } )
+				.click();
+			await page.getByRole( 'button', { name: 'Save' } ).click();
+			await expect( page.getByTestId( 'snackbar' ).last() ).toContainText(
+				'"Genres" taxonomy updated.'
+			);
+
+			// With publicly_queryable off, WP::parse_request() unsets the
+			// taxonomy/term query vars, so the same URL falls through to
+			// the homepage (200) instead of resolving to a term archive.
+			response = await page.request.get(
+				'/?taxonomy=genre&term=missing'
+			);
+			expect( response.status() ).toBe( 200 );
+		} );
+
 		test( 'turning `Public` off does not cascade to `Show admin UI`', async ( {
 			admin,
 			page,
+			requestUtils,
 		} ) => {
 			await page.getByRole( 'button', { name: 'Visibility' } ).click();
 			await page
@@ -247,6 +283,13 @@ test.describe( 'User taxonomies', () => {
 			await expect( page.getByTestId( 'snackbar' ).last() ).toContainText(
 				'"Genres" taxonomy updated.'
 			);
+
+			// Confirm `public` actually flipped.
+			const registered = await requestUtils.rest( {
+				path: '/wp/v2/taxonomies/genre?context=edit',
+				method: 'GET',
+			} );
+			expect( registered.visibility.public ).toBe( false );
 
 			// `show_ui` should stay enabled even when `public` is off, so
 			// the term-management screen should still load.

--- a/test/e2e/specs/admin/user-taxonomies.spec.js
+++ b/test/e2e/specs/admin/user-taxonomies.spec.js
@@ -51,7 +51,6 @@ test.describe( 'User taxonomies', () => {
 	test( 'creates a taxonomy attached to posts and registers it', async ( {
 		admin,
 		page,
-		requestUtils,
 	} ) => {
 		await admin.visitAdminPage( SETTINGS_PAGE_PATH, TAXONOMIES_PAGE_QUERY );
 
@@ -96,14 +95,16 @@ test.describe( 'User taxonomies', () => {
 			'"Genres" taxonomy created.'
 		);
 
-		// Relies on `show_in_rest: true`, which is the current default
-		// for user-defined taxonomies.
-		const registered = await requestUtils.rest( {
-			path: '/wp/v2/taxonomies/genre',
-			method: 'GET',
-		} );
-		expect( registered.slug ).toBe( 'genre' );
-		expect( registered.types ).toContain( 'post' );
+		// Visiting the taxonomy's term-management screen for the attached
+		// post type confirms registration end-to-end — an unregistered
+		// taxonomy slug here would wp_die with "Invalid taxonomy."
+		await admin.visitAdminPage(
+			'edit-tags.php',
+			'taxonomy=genre&post_type=post'
+		);
+		await expect(
+			page.getByRole( 'heading', { level: 1, name: 'Genres' } )
+		).toBeVisible();
 	} );
 
 	test( 'deactivating unregisters the taxonomy and activating re-registers it', async ( {
@@ -114,38 +115,48 @@ test.describe( 'User taxonomies', () => {
 		await createUserTaxonomy( requestUtils );
 		await admin.visitAdminPage( SETTINGS_PAGE_PATH, TAXONOMIES_PAGE_QUERY );
 
-		const row = page.getByRole( 'row', { name: /Genres/ } );
-		await row.getByRole( 'button', { name: 'Actions' } ).click();
+		await page
+			.getByRole( 'row', { name: /Genres/ } )
+			.getByRole( 'button', { name: 'Actions' } )
+			.click();
 		await page.getByRole( 'menuitem', { name: 'Deactivate' } ).click();
 
 		await expect( page.getByTestId( 'snackbar' ).last() ).toContainText(
 			'Taxonomy deactivated.'
 		);
-		await expect( row.getByText( 'Inactive' ) ).toBeVisible();
+		await expect(
+			page.getByRole( 'row', { name: /Genres/ } ).getByText( 'Inactive' )
+		).toBeVisible();
 
-		// requestUtils.rest() throws on non-2xx — catch and inspect the
-		// error code instead of relying on a status assertion.
-		const deactivated = await requestUtils
-			.rest( {
-				path: '/wp/v2/taxonomies/genre',
-				method: 'GET',
-			} )
-			.catch( ( error ) => error );
-		expect( deactivated.code ).toBe( 'rest_taxonomy_invalid' );
+		// Unregistered taxonomies cause WP core to wp_die with "Invalid
+		// taxonomy." when visiting their term-management URL.
+		await admin.visitAdminPage(
+			'edit-tags.php',
+			'taxonomy=genre&post_type=post'
+		);
+		await expect( page.getByText( 'Invalid taxonomy.' ) ).toBeVisible();
 
-		await row.getByRole( 'button', { name: 'Actions' } ).click();
+		await admin.visitAdminPage( SETTINGS_PAGE_PATH, TAXONOMIES_PAGE_QUERY );
+		await page
+			.getByRole( 'row', { name: /Genres/ } )
+			.getByRole( 'button', { name: 'Actions' } )
+			.click();
 		await page.getByRole( 'menuitem', { name: 'Activate' } ).click();
 
 		await expect( page.getByTestId( 'snackbar' ).last() ).toContainText(
 			'Taxonomy activated.'
 		);
-		await expect( row.getByText( 'Active' ) ).toBeVisible();
+		await expect(
+			page.getByRole( 'row', { name: /Genres/ } ).getByText( 'Active' )
+		).toBeVisible();
 
-		const reactivated = await requestUtils.rest( {
-			path: '/wp/v2/taxonomies/genre',
-			method: 'GET',
-		} );
-		expect( reactivated.slug ).toBe( 'genre' );
+		await admin.visitAdminPage(
+			'edit-tags.php',
+			'taxonomy=genre&post_type=post'
+		);
+		await expect(
+			page.getByRole( 'heading', { level: 1, name: 'Genres' } )
+		).toBeVisible();
 	} );
 
 	test.describe( 'Edit taxonomy', () => {
@@ -158,8 +169,8 @@ test.describe( 'User taxonomies', () => {
 		} );
 
 		test( 'editing a taxonomy persists changes to the registered taxonomy', async ( {
+			admin,
 			page,
-			requestUtils,
 		} ) => {
 			const postsToken = page.locator(
 				'.components-form-token-field__token',
@@ -189,13 +200,17 @@ test.describe( 'User taxonomies', () => {
 				'"Genres" taxonomy updated.'
 			);
 
-			const registered = await requestUtils.rest( {
-				path: '/wp/v2/taxonomies/genre?context=edit',
-				method: 'GET',
-			} );
-			expect( registered.types ).toEqual( [ 'page' ] );
-			expect( registered.visibility.show_admin_column ).toBe( true );
-			expect( registered.visibility.publicly_queryable ).toBe( false );
+			// Visiting the pages list confirms two persisted edits at once:
+			// the taxonomy was re-attached from `post` to `page` (otherwise
+			// the column wouldn't render here at all) and `show_admin_column`
+			// was enabled (otherwise no column even when attached).
+			await admin.visitAdminPage( 'edit.php', 'post_type=page' );
+			await expect(
+				page
+					.getByRole( 'columnheader' )
+					.filter( { hasText: 'Genres' } )
+					.first()
+			).toBeVisible();
 		} );
 
 		test( 'turning `Show in REST API` off blocks the taxonomy from the REST API', async ( {
@@ -220,9 +235,9 @@ test.describe( 'User taxonomies', () => {
 			expect( result.code ).toBe( 'rest_forbidden' );
 		} );
 
-		test( 'turning `Public` off does not cascade to `Show admin UI` or REST exposure', async ( {
+		test( 'turning `Public` off does not cascade to `Show admin UI`', async ( {
+			admin,
 			page,
-			requestUtils,
 		} ) => {
 			await page.getByRole( 'button', { name: 'Visibility' } ).click();
 			await page
@@ -233,12 +248,15 @@ test.describe( 'User taxonomies', () => {
 				'"Genres" taxonomy updated.'
 			);
 
-			const registered = await requestUtils.rest( {
-				path: '/wp/v2/taxonomies/genre?context=edit',
-				method: 'GET',
-			} );
-			expect( registered.visibility.public ).toBe( false );
-			expect( registered.visibility.show_ui ).toBe( true );
+			// `show_ui` should stay enabled even when `public` is off, so
+			// the term-management screen should still load.
+			await admin.visitAdminPage(
+				'edit-tags.php',
+				'taxonomy=genre&post_type=post'
+			);
+			await expect(
+				page.getByRole( 'heading', { level: 1, name: 'Genres' } )
+			).toBeVisible();
 		} );
 	} );
 } );

--- a/test/e2e/specs/admin/user-taxonomies.spec.js
+++ b/test/e2e/specs/admin/user-taxonomies.spec.js
@@ -33,17 +33,6 @@ async function createUserTaxonomy( requestUtils ) {
 	} );
 }
 
-async function visitTaxonomiesList( admin ) {
-	await admin.visitAdminPage( SETTINGS_PAGE_PATH, TAXONOMIES_PAGE_QUERY );
-}
-
-async function visitTaxonomyEdit( admin, id ) {
-	await admin.visitAdminPage(
-		SETTINGS_PAGE_PATH,
-		`${ TAXONOMIES_PAGE_QUERY }&p=/edit/${ id }`
-	);
-}
-
 test.describe( 'User taxonomies', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.setGutenbergExperiments( [
@@ -64,7 +53,7 @@ test.describe( 'User taxonomies', () => {
 		page,
 		requestUtils,
 	} ) => {
-		await visitTaxonomiesList( admin );
+		await admin.visitAdminPage( SETTINGS_PAGE_PATH, TAXONOMIES_PAGE_QUERY );
 
 		await page.getByRole( 'button', { name: 'Add taxonomy' } ).click();
 
@@ -123,7 +112,7 @@ test.describe( 'User taxonomies', () => {
 		requestUtils,
 	} ) => {
 		await createUserTaxonomy( requestUtils );
-		await visitTaxonomiesList( admin );
+		await admin.visitAdminPage( SETTINGS_PAGE_PATH, TAXONOMIES_PAGE_QUERY );
 
 		const row = page.getByRole( 'row', { name: /Genres/ } );
 		await row.getByRole( 'button', { name: 'Actions' } ).click();
@@ -162,7 +151,10 @@ test.describe( 'User taxonomies', () => {
 	test.describe( 'Edit taxonomy', () => {
 		test.beforeEach( async ( { requestUtils, admin } ) => {
 			const created = await createUserTaxonomy( requestUtils );
-			await visitTaxonomyEdit( admin, created.id );
+			await admin.visitAdminPage(
+				SETTINGS_PAGE_PATH,
+				`${ TAXONOMIES_PAGE_QUERY }&p=/edit/${ created.id }`
+			);
 		} );
 
 		test( 'editing a taxonomy persists changes to the registered taxonomy', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/77600

This PR adds some first basic e2e tests for the user post types experiment, mirroring the ones for taxonomies.