### PR TITLE
Use theme gray for muted Text

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `Button`: Align `link` variant underline (offset and thickness) with `ExternalLink` and `Link` from `@wordpress/ui` ([#77842](https://github.com/WordPress/gutenberg/pull/77842)).
+-   `Text`: Use a theme-aware gray token for the muted variant ([#77999](https://github.com/WordPress/gutenberg/pull/77999)).
 
 ### Bug Fixes
 

--- a/packages/components/src/text/styles.ts
+++ b/packages/components/src/text/styles.ts
@@ -28,7 +28,7 @@ export const destructive = css`
 `;
 
 export const muted = css`
-	color: ${ COLORS.gray[ 700 ] };
+	color: ${ COLORS.theme.gray[ 700 ] };
 `;
 
 export const highlighterText = css`

--- a/packages/components/src/text/test/index.tsx
+++ b/packages/components/src/text/test/index.tsx
@@ -69,7 +69,7 @@ describe( 'Text', () => {
 			</Text>
 		);
 		expect( screen.getByRole( 'heading' ) ).toHaveStyle( {
-			color: COLORS.gray[ 700 ],
+			color: COLORS.theme.gray[ 700 ],
 		} );
 	} );
 


### PR DESCRIPTION
## What?
Updates the muted `Text` variant to use `COLORS.theme.gray[ 700 ]` instead of the hardcoded `COLORS.gray[ 700 ]` value, and updates the related test expectation.

## Why?
The muted `Text` color should not be locked to a hardcoded gray value. Using the theme-aware gray token lets `ThemeProvider` override `--wp-components-color-gray-700`, so the component can follow themed color values such as the Storybook dark theme.

## How?
The muted style now reads from `COLORS.theme.gray[ 700 ]`, which resolves to the `--wp-components-color-gray-700` CSS variable with the existing gray fallback. The test now asserts against the same theme-aware token.

## Testing Instructions
1. Run Storybook with `npm run storybook:dev`.
2. Go to http://localhost:50240/?path=/story/components-text--default.
3. Change the `variant` control to `muted`.
4. Confirm the rendered text color uses the new `--wp-components-color-gray-700` var instead of the hardcoded gray value.

### Testing Instructions for Keyboard
No keyboard-specific behavior changed.

## Screenshots or screencast
N/A

## Use of AI Tools
AI tools were used to investigate the codebase and help draft this PR description. AI was not used for the coding change.
