### PR TITLE
Global Styles: Refactor client side style states to use nodes

### DIFF
--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -152,6 +152,7 @@ export type BlockSelectors = Record<
  * - `hasLayoutSupport`: whether layout styles can be generated for the node.
  * - `styleVariationSelectors`: block style variation selectors keyed by variation name.
  * - `name`: block name used by block-specific declaration adjustments.
+ * - `elementName`: element name used to resolve valid pseudo selectors.
  */
 interface StylesNode {
 	styles: any;
@@ -167,6 +168,7 @@ interface StylesNode {
 	hasLayoutSupport?: boolean;
 	styleVariationSelectors?: Record< string, string >;
 	name?: string;
+	elementName?: string;
 }
 
 type ElementName = keyof typeof ELEMENTS;
@@ -192,6 +194,29 @@ const BLOCK_SUPPORT_FEATURE_LEVEL_SELECTORS = {
 const VALID_BLOCK_PSEUDO_SELECTORS: Record< string, string[] > = {
 	'core/button': [ ':hover', ':focus', ':focus-visible', ':active' ],
 	'core/navigation-link': [ ':hover', ':focus', ':focus-visible', ':active' ],
+};
+
+// The valid pseudo-selectors that can be used for elements.
+// Keep in sync with WP_Theme_JSON_Gutenberg::VALID_ELEMENT_PSEUDO_SELECTORS.
+const VALID_ELEMENT_PSEUDO_SELECTORS: Record< string, string[] > = {
+	link: [
+		':link',
+		':any-link',
+		':visited',
+		':hover',
+		':focus',
+		':focus-visible',
+		':active',
+	],
+	button: [
+		':link',
+		':any-link',
+		':visited',
+		':hover',
+		':focus',
+		':focus-visible',
+		':active',
+	],
 };
 
 /**
@@ -1017,43 +1042,45 @@ function appendPseudoSelectorStyles(
 }
 
 /**
- * Creates style nodes for configured block pseudo selectors.
+ * Creates style nodes for configured block and element pseudo selectors.
  *
- * Only block pseudo selectors listed in `VALID_BLOCK_PSEUDO_SELECTORS` are
+ * Only pseudo selectors listed in the matching block or element allow-list are
  * considered. This mirrors the PHP renderer and avoids treating arbitrary
  * colon-prefixed keys as pseudo selectors.
  *
- * @param node Style node that may contain configured block pseudo styles.
- * @return Style nodes for the block's configured pseudo states.
+ * @param node Style node that may contain configured pseudo styles.
+ * @return Style nodes for the configured pseudo states.
  */
-function getBlockPseudoStyleNodes( node: StylesNode ): StylesNode[] {
-	const { styles, selector, featureSelectors, name } = node;
+function getPseudoStyleNodes( node: StylesNode ): StylesNode[] {
+	const { styles, selector, featureSelectors, name, elementName } = node;
+	const pseudoSelectors = name
+		? VALID_BLOCK_PSEUDO_SELECTORS[ name ] ?? []
+		: VALID_ELEMENT_PSEUDO_SELECTORS[ elementName ?? '' ] ?? [];
 
-	if ( ! name ) {
+	if ( ! pseudoSelectors.length ) {
 		return [];
 	}
 
-	return ( VALID_BLOCK_PSEUDO_SELECTORS[ name ] ?? [] ).flatMap(
-		( pseudoSelector ) => {
-			const pseudoStyles = styles?.[ pseudoSelector ];
-			if ( ! pseudoStyles || typeof pseudoStyles !== 'object' ) {
-				return [];
-			}
-
-			return [
-				{
-					styles: JSON.parse( JSON.stringify( pseudoStyles ) ),
-					selector,
-					selectorSuffix: pseudoSelector,
-					featureSelectors:
-						featureSelectors && typeof featureSelectors !== 'string'
-							? featureSelectors
-							: undefined,
-					name,
-				},
-			];
+	return pseudoSelectors.flatMap( ( pseudoSelector ) => {
+		const pseudoStyles = styles?.[ pseudoSelector ];
+		if ( ! pseudoStyles || typeof pseudoStyles !== 'object' ) {
+			return [];
 		}
-	);
+
+		return [
+			{
+				styles: JSON.parse( JSON.stringify( pseudoStyles ) ),
+				selector,
+				selectorSuffix: pseudoSelector,
+				featureSelectors:
+					featureSelectors && typeof featureSelectors !== 'string'
+						? featureSelectors
+						: undefined,
+				name,
+				elementName,
+			},
+		];
+	} );
 }
 
 /**
@@ -1255,6 +1282,7 @@ export const getNodesWithStyles = (
 			nodes.push( {
 				styles: tree.styles?.elements?.[ name ] ?? {},
 				selector: selector as string,
+				elementName: name,
 				// Top level elements that don't use a class name should not receive the
 				// `:root :where()` wrapper to maintain backwards compatibility.
 				skipSelectorWrapper: ! (
@@ -1312,6 +1340,7 @@ export const getNodesWithStyles = (
 										variationSelector,
 										ELEMENTS[ element as ElementName ]
 									),
+									elementName: element,
 								} );
 							}
 						} );
@@ -1404,6 +1433,8 @@ export const getNodesWithStyles = (
 														variationBlockElement as ElementName
 													]
 												),
+												elementName:
+													variationBlockElement,
 											} );
 										}
 									}
@@ -1459,6 +1490,7 @@ export const getNodesWithStyles = (
 									);
 								} )
 								.join( ',' ),
+							elementName,
 						} );
 					}
 				}
@@ -1890,7 +1922,7 @@ function renderStylesNode(
 						);
 					}
 
-					getBlockPseudoStyleNodes( {
+					getPseudoStyleNodes( {
 						styles: styleVariations,
 						selector: styleVariationSelector as string,
 						featureSelectors,
@@ -1947,7 +1979,7 @@ function renderStylesNode(
 	}
 
 	if ( includeStateStyles ) {
-		const blockPseudoNodes = getBlockPseudoStyleNodes( {
+		const blockPseudoNodes = getPseudoStyleNodes( {
 			styles,
 			selector,
 			featureSelectors,

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1908,17 +1908,22 @@ function renderStylesNode(
 						} );
 					} );
 
-					ruleset = appendResponsiveStyles(
-						styleVariations,
-						styleVariationSelector as string,
-						ruleset,
+					getBlockResponsiveStyleNodes( {
+						styles: styleVariations,
+						selector: styleVariationSelector as string,
 						featureSelectors,
-						tree.settings,
 						name,
-						styleVariationSelector as string,
-						selector,
-						styleVariationName
-					);
+					} ).forEach( ( responsiveNode ) => {
+						ruleset += renderStylesNode( responsiveNode, {
+							tree,
+							options,
+							useRootPaddingAlign,
+							disableLayoutStyles: true,
+							hasBlockGapSupport,
+							hasFallbackGapSupport,
+							disableRootPadding,
+						} );
+					} );
 
 					// Generate layout styles for the variation if it supports layout and has blockGap defined.
 					if (

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -143,6 +143,7 @@ export type BlockSelectors = Record<
  *
  * - `styles`: theme.json style object for this node.
  * - `selector`: CSS selector used for the node's base declarations.
+ * - `selectorSuffix`: optional suffix appended to base and feature selectors.
  * - `skipSelectorWrapper`: omits the `:root :where()` specificity wrapper.
  * - `duotoneSelector`: alternate selector for duotone filter declarations.
  * - `featureSelectors`: feature-level selectors for block supports.
@@ -154,6 +155,7 @@ export type BlockSelectors = Record<
 interface StylesNode {
 	styles: any;
 	selector: string;
+	selectorSuffix?: string;
 	skipSelectorWrapper?: boolean;
 	duotoneSelector?: string;
 	featureSelectors?:
@@ -1013,57 +1015,6 @@ function appendPseudoSelectorStyles(
 }
 
 /**
- * Creates feature-level selectors for a pseudo state.
- *
- * Feature selectors are keyed by block support feature, for example:
- * `{ dimensions: { root: '.wp-block-button', width: '.wp-block-button' } }`.
- * Pseudo nodes need those feature selectors to target the stateful selector,
- * for example `.wp-block-button:hover`, so feature-level declarations are
- * scoped to the same pseudo state as the node's base selector.
- *
- * String feature selectors are skipped to preserve the existing pseudo helper
- * behavior, which only handled object-shaped feature selector maps.
- *
- * @param featureSelectors Feature-level selectors from a style node.
- * @param pseudoSelector   Pseudo selector to append to each feature selector.
- * @return Feature-level selectors scoped to the pseudo state.
- */
-function appendPseudoSelectorToFeatureSelectors(
-	featureSelectors: StylesNode[ 'featureSelectors' ],
-	pseudoSelector: string
-): StylesNode[ 'featureSelectors' ] {
-	if ( ! featureSelectors || typeof featureSelectors === 'string' ) {
-		return undefined;
-	}
-
-	return Object.fromEntries(
-		Object.entries( featureSelectors ).map( ( [ feature, selector ] ) => {
-			if ( typeof selector === 'string' ) {
-				return [
-					feature,
-					appendToSelector( selector, pseudoSelector ),
-				];
-			}
-
-			return [
-				feature,
-				Object.fromEntries(
-					Object.entries( selector ).map(
-						( [ subfeature, subfeatureSelector ] ) => [
-							subfeature,
-							appendToSelector(
-								subfeatureSelector,
-								pseudoSelector
-							),
-						]
-					)
-				),
-			];
-		} )
-	);
-}
-
-/**
  * Creates style nodes for configured block pseudo selectors.
  *
  * Only block pseudo selectors listed in `VALID_BLOCK_PSEUDO_SELECTORS` are
@@ -1090,11 +1041,12 @@ function getBlockPseudoStyleNodes( node: StylesNode ): StylesNode[] {
 			return [
 				{
 					styles: JSON.parse( JSON.stringify( pseudoStyles ) ),
-					selector: appendToSelector( selector, pseudoSelector ),
-					featureSelectors: appendPseudoSelectorToFeatureSelectors(
-						featureSelectors,
-						pseudoSelector
-					),
+					selector,
+					selectorSuffix: pseudoSelector,
+					featureSelectors:
+						featureSelectors && typeof featureSelectors !== 'string'
+							? featureSelectors
+							: undefined,
 					name,
 				},
 			];
@@ -1690,6 +1642,7 @@ export const generateCustomProperties = (
 function renderStylesNode(
 	{
 		selector,
+		selectorSuffix,
 		duotoneSelector,
 		styles,
 		fallbackGapValue,
@@ -1718,6 +1671,9 @@ function renderStylesNode(
 	}
 ): string {
 	let ruleset = '';
+	const effectiveSelector = selectorSuffix
+		? appendToSelector( selector, selectorSuffix )
+		: selector;
 
 	// Process styles for block support features with custom feature level
 	// CSS selectors set.
@@ -1741,10 +1697,13 @@ function renderStylesNode(
 		);
 
 		Object.entries( featureDeclarations ).forEach(
-			( [ cssSelector, declarations ] ) => {
+			( [ featureSelector, declarations ] ) => {
 				if ( declarations.length ) {
+					const selectorForRule = selectorSuffix
+						? appendToSelector( featureSelector, selectorSuffix )
+						: featureSelector;
 					const rules = declarations.join( ';' );
-					ruleset += `:root :where(${ cssSelector }){${ rules };}`;
+					ruleset += `:root :where(${ selectorForRule }){${ rules };}`;
 				}
 			}
 		);
@@ -1768,11 +1727,11 @@ function renderStylesNode(
 	// Process blockGap and layout styles.
 	if (
 		! disableLayoutStyles &&
-		( ROOT_BLOCK_SELECTOR === selector || hasLayoutSupport )
+		( ROOT_BLOCK_SELECTOR === effectiveSelector || hasLayoutSupport )
 	) {
 		ruleset += getLayoutStyles( {
 			style: styles,
-			selector,
+			selector: effectiveSelector,
 			hasBlockGapSupport,
 			hasFallbackGapSupport,
 			fallbackGapValue,
@@ -1782,21 +1741,21 @@ function renderStylesNode(
 	// Process the remaining block styles (they use either normal block class or __experimentalSelector).
 	const styleDeclarations = getStylesDeclarations(
 		styles,
-		selector,
+		effectiveSelector,
 		useRootPaddingAlign,
 		tree,
 		disableRootPadding
 	);
 	if ( styleDeclarations?.length ) {
 		const generalSelector = skipSelectorWrapper
-			? selector
-			: `:root :where(${ selector })`;
+			? effectiveSelector
+			: `:root :where(${ effectiveSelector })`;
 		ruleset += `${ generalSelector }{${ styleDeclarations.join( ';' ) };}`;
 	}
 	if ( styles?.css ) {
 		ruleset += processCSSNesting(
 			styles.css,
-			`:root :where(${ selector })`
+			`:root :where(${ effectiveSelector })`
 		);
 	}
 

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1890,15 +1890,23 @@ function renderStylesNode(
 						);
 					}
 
-					ruleset = appendPseudoSelectorStyles(
-						styleVariations,
-						styleVariationSelector as string,
-						ruleset,
+					getBlockPseudoStyleNodes( {
+						styles: styleVariations,
+						selector: styleVariationSelector as string,
 						featureSelectors,
-						tree.settings,
 						name,
-						styleVariationSelector as string
-					);
+					} ).forEach( ( pseudoNode ) => {
+						ruleset += renderStylesNode( pseudoNode, {
+							tree,
+							options,
+							useRootPaddingAlign,
+							disableLayoutStyles: true,
+							hasBlockGapSupport,
+							hasFallbackGapSupport,
+							disableRootPadding,
+							includeStateStyles: false,
+						} );
+					} );
 
 					ruleset = appendResponsiveStyles(
 						styleVariations,

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -138,6 +138,33 @@ export type BlockSelectors = Record<
 	}
 >;
 
+/**
+ * Style node metadata used to render one selector's style rules.
+ *
+ * - `styles`: theme.json style object for this node.
+ * - `selector`: CSS selector used for the node's base declarations.
+ * - `skipSelectorWrapper`: omits the `:root :where()` specificity wrapper.
+ * - `duotoneSelector`: alternate selector for duotone filter declarations.
+ * - `featureSelectors`: feature-level selectors for block supports.
+ * - `fallbackGapValue`: fallback block gap value used by layout rules.
+ * - `hasLayoutSupport`: whether layout styles can be generated for the node.
+ * - `styleVariationSelectors`: block style variation selectors keyed by variation name.
+ * - `name`: block name used by block-specific declaration adjustments.
+ */
+interface StylesNode {
+	styles: any;
+	selector: string;
+	skipSelectorWrapper?: boolean;
+	duotoneSelector?: string;
+	featureSelectors?:
+		| string
+		| Record< string, string | Record< string, string > >;
+	fallbackGapValue?: string;
+	hasLayoutSupport?: boolean;
+	styleVariationSelectors?: Record< string, string >;
+	name?: string;
+}
+
 type ElementName = keyof typeof ELEMENTS;
 
 // Elements that rely on class names in their selectors.
@@ -1122,19 +1149,7 @@ export const getNodesWithStyles = (
 	tree: GlobalStylesConfig,
 	blockSelectors: string | BlockSelectors
 ): any[] => {
-	const nodes: {
-		styles: Partial< Omit< GlobalStylesStyles, 'elements' | 'blocks' > >;
-		selector: string;
-		skipSelectorWrapper?: boolean;
-		duotoneSelector?: string;
-		featureSelectors?:
-			| string
-			| Record< string, string | Record< string, string > >;
-		fallbackGapValue?: string;
-		hasLayoutSupport?: boolean;
-		styleVariationSelectors?: Record< string, string >;
-		name?: string;
-	}[] = [];
+	const nodes: StylesNode[] = [];
 
 	if ( ! tree?.styles ) {
 		return nodes;
@@ -1582,6 +1597,246 @@ export const generateCustomProperties = (
 	return ruleset;
 };
 
+function renderStylesNode(
+	{
+		selector,
+		duotoneSelector,
+		styles,
+		fallbackGapValue,
+		hasLayoutSupport,
+		featureSelectors,
+		styleVariationSelectors,
+		skipSelectorWrapper,
+		name,
+	}: StylesNode,
+	{
+		tree,
+		options,
+		useRootPaddingAlign,
+		disableLayoutStyles,
+		hasBlockGapSupport,
+		hasFallbackGapSupport,
+		disableRootPadding,
+	}: {
+		tree: GlobalStylesConfig;
+		options: Record< string, boolean >;
+		useRootPaddingAlign?: boolean;
+		disableLayoutStyles: boolean;
+		hasBlockGapSupport?: boolean;
+		hasFallbackGapSupport?: boolean;
+		disableRootPadding: boolean;
+	}
+): string {
+	let ruleset = '';
+
+	// Process styles for block support features with custom feature level
+	// CSS selectors set.
+	if ( featureSelectors ) {
+		let featureDeclarations = getFeatureDeclarations(
+			featureSelectors,
+			styles
+		);
+
+		// Update text indent selector for paragraph blocks based on the textIndent setting.
+		featureDeclarations = updateParagraphTextIndentSelector(
+			featureDeclarations,
+			tree.settings,
+			name
+		);
+
+		// Update button width declarations for percentage values to use calc() with block gap.
+		featureDeclarations = updateButtonWidthDeclarations(
+			featureDeclarations,
+			tree.settings
+		);
+
+		Object.entries( featureDeclarations ).forEach(
+			( [ cssSelector, declarations ] ) => {
+				if ( declarations.length ) {
+					const rules = declarations.join( ';' );
+					ruleset += `:root :where(${ cssSelector }){${ rules };}`;
+				}
+			}
+		);
+	}
+
+	// Process duotone styles.
+	if ( duotoneSelector ) {
+		const duotoneStyles: any = {};
+		if ( styles?.filter ) {
+			duotoneStyles.filter = styles.filter;
+			delete styles.filter;
+		}
+		const duotoneDeclarations = getStylesDeclarations( duotoneStyles );
+		if ( duotoneDeclarations.length ) {
+			ruleset += `${ duotoneSelector }{${ duotoneDeclarations.join(
+				';'
+			) };}`;
+		}
+	}
+
+	// Process blockGap and layout styles.
+	if (
+		! disableLayoutStyles &&
+		( ROOT_BLOCK_SELECTOR === selector || hasLayoutSupport )
+	) {
+		ruleset += getLayoutStyles( {
+			style: styles,
+			selector,
+			hasBlockGapSupport,
+			hasFallbackGapSupport,
+			fallbackGapValue,
+		} );
+	}
+
+	// Process the remaining block styles (they use either normal block class or __experimentalSelector).
+	const styleDeclarations = getStylesDeclarations(
+		styles,
+		selector,
+		useRootPaddingAlign,
+		tree,
+		disableRootPadding
+	);
+	if ( styleDeclarations?.length ) {
+		const generalSelector = skipSelectorWrapper
+			? selector
+			: `:root :where(${ selector })`;
+		ruleset += `${ generalSelector }{${ styleDeclarations.join( ';' ) };}`;
+	}
+	if ( styles?.css ) {
+		ruleset += processCSSNesting(
+			styles.css,
+			`:root :where(${ selector })`
+		);
+	}
+
+	if ( options.variationStyles && styleVariationSelectors ) {
+		Object.entries( styleVariationSelectors ).forEach(
+			( [ styleVariationName, styleVariationSelector ] ) => {
+				const styleVariations =
+					styles?.variations?.[ styleVariationName ];
+				if ( styleVariations ) {
+					// If the block uses any custom selectors for block support, add those first.
+					if ( featureSelectors ) {
+						let featureDeclarations = getFeatureDeclarations(
+							featureSelectors,
+							styleVariations
+						);
+
+						// Update text indent selector for paragraph blocks based on the textIndent setting.
+						featureDeclarations = updateParagraphTextIndentSelector(
+							featureDeclarations,
+							tree.settings,
+							name
+						);
+
+						// Update button width declarations for percentage values to use calc() with block gap.
+						featureDeclarations = updateButtonWidthDeclarations(
+							featureDeclarations,
+							tree.settings
+						);
+
+						Object.entries( featureDeclarations ).forEach(
+							( [ baseSelector, declarations ]: [
+								string,
+								string[],
+							] ) => {
+								if ( declarations.length ) {
+									const cssSelector =
+										concatFeatureVariationSelectorString(
+											baseSelector,
+											styleVariationSelector as string
+										);
+									const rules = declarations.join( ';' );
+									ruleset += `:root :where(${ cssSelector }){${ rules };}`;
+								}
+							}
+						);
+					}
+
+					// Otherwise add regular selectors.
+					const styleVariationDeclarations = getStylesDeclarations(
+						styleVariations,
+						styleVariationSelector as string,
+						useRootPaddingAlign,
+						tree
+					);
+					if ( styleVariationDeclarations.length ) {
+						ruleset += `:root :where(${ styleVariationSelector }){${ styleVariationDeclarations.join(
+							';'
+						) };}`;
+					}
+					if ( styleVariations?.css ) {
+						ruleset += processCSSNesting(
+							styleVariations.css,
+							`:root :where(${ styleVariationSelector })`
+						);
+					}
+
+					ruleset = appendPseudoSelectorStyles(
+						styleVariations,
+						styleVariationSelector as string,
+						ruleset,
+						featureSelectors,
+						tree.settings,
+						name,
+						styleVariationSelector as string
+					);
+
+					ruleset = appendResponsiveStyles(
+						styleVariations,
+						styleVariationSelector as string,
+						ruleset,
+						featureSelectors,
+						tree.settings,
+						name,
+						styleVariationSelector as string,
+						selector,
+						styleVariationName
+					);
+
+					// Generate layout styles for the variation if it supports layout and has blockGap defined.
+					if (
+						hasLayoutSupport &&
+						styleVariations?.spacing?.blockGap
+					) {
+						// Append block selector to variation selector so layout classes are properly constructed.
+						const variationSelectorWithBlock =
+							styleVariationSelector + selector;
+						ruleset += getLayoutStyles( {
+							style: styleVariations,
+							selector: variationSelectorWithBlock,
+							hasBlockGapSupport: true,
+							hasFallbackGapSupport,
+							fallbackGapValue,
+						} );
+					}
+				}
+			}
+		);
+	}
+
+	ruleset = appendPseudoSelectorStyles(
+		styles,
+		selector,
+		ruleset,
+		featureSelectors,
+		tree.settings,
+		name
+	);
+
+	ruleset = appendResponsiveStyles(
+		styles,
+		selector,
+		ruleset,
+		featureSelectors,
+		tree.settings,
+		name
+	);
+
+	return ruleset;
+}
+
 export const transformToStyles = (
 	tree: GlobalStylesConfig,
 	blockSelectors: string | BlockSelectors,
@@ -1651,234 +1906,17 @@ export const transformToStyles = (
 	}
 
 	if ( options.blockStyles ) {
-		nodesWithStyles.forEach(
-			( {
-				selector,
-				duotoneSelector,
-				styles,
-				fallbackGapValue,
-				hasLayoutSupport,
-				featureSelectors,
-				styleVariationSelectors,
-				skipSelectorWrapper,
-				name,
-			} ) => {
-				// Process styles for block support features with custom feature level
-				// CSS selectors set.
-				if ( featureSelectors ) {
-					let featureDeclarations = getFeatureDeclarations(
-						featureSelectors,
-						styles
-					);
-
-					// Update text indent selector for paragraph blocks based on the textIndent setting.
-					featureDeclarations = updateParagraphTextIndentSelector(
-						featureDeclarations,
-						tree.settings,
-						name
-					);
-
-					// Update button width declarations for percentage values to use calc() with block gap.
-					featureDeclarations = updateButtonWidthDeclarations(
-						featureDeclarations,
-						tree.settings
-					);
-
-					Object.entries( featureDeclarations ).forEach(
-						( [ cssSelector, declarations ] ) => {
-							if ( declarations.length ) {
-								const rules = declarations.join( ';' );
-								ruleset += `:root :where(${ cssSelector }){${ rules };}`;
-							}
-						}
-					);
-				}
-
-				// Process duotone styles.
-				if ( duotoneSelector ) {
-					const duotoneStyles: any = {};
-					if ( styles?.filter ) {
-						duotoneStyles.filter = styles.filter;
-						delete styles.filter;
-					}
-					const duotoneDeclarations =
-						getStylesDeclarations( duotoneStyles );
-					if ( duotoneDeclarations.length ) {
-						ruleset += `${ duotoneSelector }{${ duotoneDeclarations.join(
-							';'
-						) };}`;
-					}
-				}
-
-				// Process blockGap and layout styles.
-				if (
-					! disableLayoutStyles &&
-					( ROOT_BLOCK_SELECTOR === selector || hasLayoutSupport )
-				) {
-					ruleset += getLayoutStyles( {
-						style: styles,
-						selector,
-						hasBlockGapSupport,
-						hasFallbackGapSupport,
-						fallbackGapValue,
-					} );
-				}
-
-				// Process the remaining block styles (they use either normal block class or __experimentalSelector).
-				const styleDeclarations = getStylesDeclarations(
-					styles,
-					selector,
-					useRootPaddingAlign,
-					tree,
-					disableRootPadding
-				);
-				if ( styleDeclarations?.length ) {
-					const generalSelector = skipSelectorWrapper
-						? selector
-						: `:root :where(${ selector })`;
-					ruleset += `${ generalSelector }{${ styleDeclarations.join(
-						';'
-					) };}`;
-				}
-				if ( styles?.css ) {
-					ruleset += processCSSNesting(
-						styles.css,
-						`:root :where(${ selector })`
-					);
-				}
-
-				if ( options.variationStyles && styleVariationSelectors ) {
-					Object.entries( styleVariationSelectors ).forEach(
-						( [ styleVariationName, styleVariationSelector ] ) => {
-							const styleVariations =
-								styles?.variations?.[ styleVariationName ];
-							if ( styleVariations ) {
-								// If the block uses any custom selectors for block support, add those first.
-								if ( featureSelectors ) {
-									let featureDeclarations =
-										getFeatureDeclarations(
-											featureSelectors,
-											styleVariations
-										);
-
-									// Update text indent selector for paragraph blocks based on the textIndent setting.
-									featureDeclarations =
-										updateParagraphTextIndentSelector(
-											featureDeclarations,
-											tree.settings,
-											name
-										);
-
-									// Update button width declarations for percentage values to use calc() with block gap.
-									featureDeclarations =
-										updateButtonWidthDeclarations(
-											featureDeclarations,
-											tree.settings
-										);
-
-									Object.entries(
-										featureDeclarations
-									).forEach(
-										( [ baseSelector, declarations ]: [
-											string,
-											string[],
-										] ) => {
-											if ( declarations.length ) {
-												const cssSelector =
-													concatFeatureVariationSelectorString(
-														baseSelector,
-														styleVariationSelector as string
-													);
-												const rules =
-													declarations.join( ';' );
-												ruleset += `:root :where(${ cssSelector }){${ rules };}`;
-											}
-										}
-									);
-								}
-
-								// Otherwise add regular selectors.
-								const styleVariationDeclarations =
-									getStylesDeclarations(
-										styleVariations,
-										styleVariationSelector as string,
-										useRootPaddingAlign,
-										tree
-									);
-								if ( styleVariationDeclarations.length ) {
-									ruleset += `:root :where(${ styleVariationSelector }){${ styleVariationDeclarations.join(
-										';'
-									) };}`;
-								}
-								if ( styleVariations?.css ) {
-									ruleset += processCSSNesting(
-										styleVariations.css,
-										`:root :where(${ styleVariationSelector })`
-									);
-								}
-
-								ruleset = appendPseudoSelectorStyles(
-									styleVariations,
-									styleVariationSelector as string,
-									ruleset,
-									featureSelectors,
-									tree.settings,
-									name,
-									styleVariationSelector as string
-								);
-
-								ruleset = appendResponsiveStyles(
-									styleVariations,
-									styleVariationSelector as string,
-									ruleset,
-									featureSelectors,
-									tree.settings,
-									name,
-									styleVariationSelector as string,
-									selector,
-									styleVariationName
-								);
-
-								// Generate layout styles for the variation if it supports layout and has blockGap defined.
-								if (
-									hasLayoutSupport &&
-									styleVariations?.spacing?.blockGap
-								) {
-									// Append block selector to variation selector so layout classes are properly constructed.
-									const variationSelectorWithBlock =
-										styleVariationSelector + selector;
-									ruleset += getLayoutStyles( {
-										style: styleVariations,
-										selector: variationSelectorWithBlock,
-										hasBlockGapSupport: true,
-										hasFallbackGapSupport,
-										fallbackGapValue,
-									} );
-								}
-							}
-						}
-					);
-				}
-
-				ruleset = appendPseudoSelectorStyles(
-					styles,
-					selector,
-					ruleset,
-					featureSelectors,
-					tree.settings,
-					name
-				);
-
-				ruleset = appendResponsiveStyles(
-					styles,
-					selector,
-					ruleset,
-					featureSelectors,
-					tree.settings,
-					name
-				);
-			}
-		);
+		nodesWithStyles.forEach( ( node ) => {
+			ruleset += renderStylesNode( node, {
+				tree,
+				options,
+				useRootPaddingAlign,
+				disableLayoutStyles,
+				hasBlockGapSupport,
+				hasFallbackGapSupport,
+				disableRootPadding,
+			} );
+		} );
 	}
 
 	if ( options.layoutStyles ) {

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -169,11 +169,6 @@ interface StylesNode {
 	name?: string;
 }
 
-interface ResponsiveStyleNode {
-	breakpointKey: string;
-	node: StylesNode;
-}
-
 type ElementName = keyof typeof ELEMENTS;
 
 // Elements that rely on class names in their selectors.
@@ -1064,16 +1059,13 @@ function getBlockPseudoStyleNodes( node: StylesNode ): StylesNode[] {
 /**
  * Creates style nodes for configured responsive breakpoint states.
  *
- * Breakpoint nodes render feature-level and base declarations through the
- * normal node renderer. Responsive pseudo styles are intentionally handled by
- * a separate fallback so their output can stay in the existing order for now.
+ * Breakpoint nodes render feature-level, base, and pseudo declarations through
+ * the normal node renderer.
  *
  * @param node Style node that may contain configured responsive state styles.
  * @return Responsive style nodes in configured breakpoint order.
  */
-function getBlockResponsiveStyleNodes(
-	node: StylesNode
-): ResponsiveStyleNode[] {
+function getBlockResponsiveStyleNodes( node: StylesNode ): StylesNode[] {
 	const { styles, selector, featureSelectors, name } = node;
 
 	if ( ! name ) {
@@ -1089,54 +1081,18 @@ function getBlockResponsiveStyleNodes(
 
 			return [
 				{
-					breakpointKey,
-					node: {
-						styles: JSON.parse(
-							JSON.stringify( breakpointStyles )
-						),
-						selector,
-						mediaQuery,
-						featureSelectors:
-							featureSelectors &&
-							typeof featureSelectors !== 'string'
-								? featureSelectors
-								: undefined,
-						name,
-					},
+					styles: JSON.parse( JSON.stringify( breakpointStyles ) ),
+					selector,
+					mediaQuery,
+					featureSelectors:
+						featureSelectors && typeof featureSelectors !== 'string'
+							? featureSelectors
+							: undefined,
+					name,
 				},
 			];
 		}
 	);
-}
-
-function appendResponsivePseudoSelectorStyles(
-	styles: Record< string, any >,
-	selector: string,
-	ruleset: string,
-	featureSelectors: StylesNode[ 'featureSelectors' ],
-	treeSettings: Record< string, any > | undefined,
-	blockName: string | undefined,
-	breakpointKey: string
-): string {
-	const breakpointStyle = styles?.[ breakpointKey ];
-	if ( ! breakpointStyle || typeof breakpointStyle !== 'object' ) {
-		return ruleset;
-	}
-
-	const breakpointPseudoRules = appendPseudoSelectorStyles(
-		JSON.parse( JSON.stringify( breakpointStyle ) ),
-		selector,
-		'',
-		featureSelectors,
-		treeSettings,
-		blockName
-	);
-
-	if ( breakpointPseudoRules ) {
-		ruleset += `${ RESPONSIVE_BREAKPOINTS[ breakpointKey ] }{${ breakpointPseudoRules }}`;
-	}
-
-	return ruleset;
 }
 
 /**
@@ -2014,30 +1970,17 @@ function renderStylesNode(
 			name,
 		} );
 		if ( blockResponsiveNodes.length ) {
-			blockResponsiveNodes.forEach(
-				( { breakpointKey, node: responsiveNode } ) => {
-					ruleset += renderStylesNode( responsiveNode, {
-						tree,
-						options,
-						useRootPaddingAlign,
-						disableLayoutStyles: true,
-						hasBlockGapSupport,
-						hasFallbackGapSupport,
-						disableRootPadding,
-						includeStateStyles: false,
-					} );
-
-					ruleset = appendResponsivePseudoSelectorStyles(
-						styles,
-						selector,
-						ruleset,
-						featureSelectors,
-						tree.settings,
-						name,
-						breakpointKey
-					);
-				}
-			);
+			blockResponsiveNodes.forEach( ( responsiveNode ) => {
+				ruleset += renderStylesNode( responsiveNode, {
+					tree,
+					options,
+					useRootPaddingAlign,
+					disableLayoutStyles: true,
+					hasBlockGapSupport,
+					hasFallbackGapSupport,
+					disableRootPadding,
+				} );
+			} );
 		} else {
 			ruleset = appendResponsiveStyles(
 				styles,

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1763,47 +1763,41 @@ function renderStylesNode(
 	}
 
 	if ( includeStateStyles ) {
-		const blockPseudoNodes = getPseudoStyleNodes( {
+		getPseudoStyleNodes( {
 			styles,
 			selector,
 			featureSelectors,
 			name,
 			elementName,
-		} );
-		if ( blockPseudoNodes.length ) {
-			blockPseudoNodes.forEach( ( pseudoNode ) => {
-				ruleset += renderStylesNode( pseudoNode, {
-					tree,
-					options,
-					useRootPaddingAlign,
-					disableLayoutStyles: true,
-					hasBlockGapSupport,
-					hasFallbackGapSupport,
-					disableRootPadding,
-				} );
+		} ).forEach( ( pseudoNode ) => {
+			ruleset += renderStylesNode( pseudoNode, {
+				tree,
+				options,
+				useRootPaddingAlign,
+				disableLayoutStyles: true,
+				hasBlockGapSupport,
+				hasFallbackGapSupport,
+				disableRootPadding,
 			} );
-		}
+		} );
 
-		const blockResponsiveNodes = getResponsiveStyleNodes( {
+		getResponsiveStyleNodes( {
 			styles,
 			selector,
 			featureSelectors,
 			name,
 			elementName,
-		} );
-		if ( blockResponsiveNodes.length ) {
-			blockResponsiveNodes.forEach( ( responsiveNode ) => {
-				ruleset += renderStylesNode( responsiveNode, {
-					tree,
-					options,
-					useRootPaddingAlign,
-					disableLayoutStyles: true,
-					hasBlockGapSupport,
-					hasFallbackGapSupport,
-					disableRootPadding,
-				} );
+		} ).forEach( ( responsiveNode ) => {
+			ruleset += renderStylesNode( responsiveNode, {
+				tree,
+				options,
+				useRootPaddingAlign,
+				disableLayoutStyles: true,
+				hasBlockGapSupport,
+				hasFallbackGapSupport,
+				disableRootPadding,
 			} );
-		}
+		} );
 	}
 
 	if ( mediaQuery && ruleset ) {

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1092,10 +1092,10 @@ function getPseudoStyleNodes( node: StylesNode ): StylesNode[] {
  * @param node Style node that may contain configured responsive state styles.
  * @return Responsive style nodes in configured breakpoint order.
  */
-function getBlockResponsiveStyleNodes( node: StylesNode ): StylesNode[] {
-	const { styles, selector, featureSelectors, name } = node;
+function getResponsiveStyleNodes( node: StylesNode ): StylesNode[] {
+	const { styles, selector, featureSelectors, name, elementName } = node;
 
-	if ( ! name ) {
+	if ( ! name && ! elementName ) {
 		return [];
 	}
 
@@ -1116,6 +1116,7 @@ function getBlockResponsiveStyleNodes( node: StylesNode ): StylesNode[] {
 							? featureSelectors
 							: undefined,
 					name,
+					elementName,
 				},
 			];
 		}
@@ -1765,6 +1766,7 @@ function renderStylesNode(
 		styleVariationSelectors,
 		skipSelectorWrapper,
 		name,
+		elementName,
 	} = node;
 	let ruleset = '';
 	const effectiveSelector = selectorSuffix
@@ -1940,7 +1942,7 @@ function renderStylesNode(
 						} );
 					} );
 
-					getBlockResponsiveStyleNodes( {
+					getResponsiveStyleNodes( {
 						styles: styleVariations,
 						selector: styleVariationSelector as string,
 						featureSelectors,
@@ -2008,11 +2010,12 @@ function renderStylesNode(
 			);
 		}
 
-		const blockResponsiveNodes = getBlockResponsiveStyleNodes( {
+		const blockResponsiveNodes = getResponsiveStyleNodes( {
 			styles,
 			selector,
 			featureSelectors,
 			name,
+			elementName,
 		} );
 		if ( blockResponsiveNodes.length ) {
 			blockResponsiveNodes.forEach( ( responsiveNode ) => {

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1599,7 +1599,6 @@ export const generateCustomProperties = (
  * @param node                          Style node metadata and styles.
  * @param context                       Render context and feature flags.
  * @param context.tree                  Global styles tree.
- * @param context.options               Enabled renderer output groups.
  * @param context.useRootPaddingAlign   Whether root padding alignment is enabled.
  * @param context.disableLayoutStyles   Whether layout styles are disabled.
  * @param context.hasBlockGapSupport    Whether block gap support is enabled.
@@ -1618,7 +1617,6 @@ function renderStylesNode(
 		disableRootPadding,
 	}: {
 		tree: GlobalStylesConfig;
-		options: Record< string, boolean >;
 		useRootPaddingAlign?: boolean;
 		disableLayoutStyles: boolean;
 		hasBlockGapSupport?: boolean;
@@ -1823,7 +1821,6 @@ export const transformToStyles = (
 			].forEach( ( expandedNode ) => {
 				ruleset += renderStylesNode( expandedNode, {
 					tree,
-					options,
 					useRootPaddingAlign,
 					disableLayoutStyles,
 					hasBlockGapSupport,

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1013,6 +1013,96 @@ function appendPseudoSelectorStyles(
 }
 
 /**
+ * Creates feature-level selectors for a pseudo state.
+ *
+ * Feature selectors are keyed by block support feature, for example:
+ * `{ dimensions: { root: '.wp-block-button', width: '.wp-block-button' } }`.
+ * Pseudo nodes need those feature selectors to target the stateful selector,
+ * for example `.wp-block-button:hover`, so feature-level declarations are
+ * scoped to the same pseudo state as the node's base selector.
+ *
+ * String feature selectors are skipped to preserve the existing pseudo helper
+ * behavior, which only handled object-shaped feature selector maps.
+ *
+ * @param featureSelectors Feature-level selectors from a style node.
+ * @param pseudoSelector   Pseudo selector to append to each feature selector.
+ * @return Feature-level selectors scoped to the pseudo state.
+ */
+function appendPseudoSelectorToFeatureSelectors(
+	featureSelectors: StylesNode[ 'featureSelectors' ],
+	pseudoSelector: string
+): StylesNode[ 'featureSelectors' ] {
+	if ( ! featureSelectors || typeof featureSelectors === 'string' ) {
+		return undefined;
+	}
+
+	return Object.fromEntries(
+		Object.entries( featureSelectors ).map( ( [ feature, selector ] ) => {
+			if ( typeof selector === 'string' ) {
+				return [
+					feature,
+					appendToSelector( selector, pseudoSelector ),
+				];
+			}
+
+			return [
+				feature,
+				Object.fromEntries(
+					Object.entries( selector ).map(
+						( [ subfeature, subfeatureSelector ] ) => [
+							subfeature,
+							appendToSelector(
+								subfeatureSelector,
+								pseudoSelector
+							),
+						]
+					)
+				),
+			];
+		} )
+	);
+}
+
+/**
+ * Creates style nodes for configured block pseudo selectors.
+ *
+ * Only block pseudo selectors listed in `VALID_BLOCK_PSEUDO_SELECTORS` are
+ * considered. This mirrors the PHP renderer and avoids treating arbitrary
+ * colon-prefixed keys as pseudo selectors.
+ *
+ * @param node Style node that may contain configured block pseudo styles.
+ * @return Style nodes for the block's configured pseudo states.
+ */
+function getBlockPseudoStyleNodes( node: StylesNode ): StylesNode[] {
+	const { styles, selector, featureSelectors, name } = node;
+
+	if ( ! name ) {
+		return [];
+	}
+
+	return ( VALID_BLOCK_PSEUDO_SELECTORS[ name ] ?? [] ).flatMap(
+		( pseudoSelector ) => {
+			const pseudoStyles = styles?.[ pseudoSelector ];
+			if ( ! pseudoStyles || typeof pseudoStyles !== 'object' ) {
+				return [];
+			}
+
+			return [
+				{
+					styles: JSON.parse( JSON.stringify( pseudoStyles ) ),
+					selector: appendToSelector( selector, pseudoSelector ),
+					featureSelectors: appendPseudoSelectorToFeatureSelectors(
+						featureSelectors,
+						pseudoSelector
+					),
+					name,
+				},
+			];
+		}
+	);
+}
+
+/**
  * Appends CSS rules for responsive breakpoint states to a ruleset string.
  * Block styles stored under responsive keys (for example, 'mobile' and
  * 'tablet') are wrapped in corresponding media queries instead of being
@@ -1816,14 +1906,34 @@ function renderStylesNode(
 		);
 	}
 
-	ruleset = appendPseudoSelectorStyles(
+	const blockPseudoNodes = getBlockPseudoStyleNodes( {
 		styles,
 		selector,
-		ruleset,
 		featureSelectors,
-		tree.settings,
-		name
-	);
+		name,
+	} );
+	if ( blockPseudoNodes.length ) {
+		blockPseudoNodes.forEach( ( pseudoNode ) => {
+			ruleset += renderStylesNode( pseudoNode, {
+				tree,
+				options,
+				useRootPaddingAlign,
+				disableLayoutStyles: true,
+				hasBlockGapSupport,
+				hasFallbackGapSupport,
+				disableRootPadding,
+			} );
+		} );
+	} else {
+		ruleset = appendPseudoSelectorStyles(
+			styles,
+			selector,
+			ruleset,
+			featureSelectors,
+			tree.settings,
+			name
+		);
+	}
 
 	ruleset = appendResponsiveStyles(
 		styles,

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -144,6 +144,7 @@ export type BlockSelectors = Record<
  * - `styles`: theme.json style object for this node.
  * - `selector`: CSS selector used for the node's base declarations.
  * - `selectorSuffix`: optional suffix appended to base and feature selectors.
+ * - `mediaQuery`: optional media query wrapping this node's rules.
  * - `skipSelectorWrapper`: omits the `:root :where()` specificity wrapper.
  * - `duotoneSelector`: alternate selector for duotone filter declarations.
  * - `featureSelectors`: feature-level selectors for block supports.
@@ -156,6 +157,7 @@ interface StylesNode {
 	styles: any;
 	selector: string;
 	selectorSuffix?: string;
+	mediaQuery?: string;
 	skipSelectorWrapper?: boolean;
 	duotoneSelector?: string;
 	featureSelectors?:
@@ -165,6 +167,11 @@ interface StylesNode {
 	hasLayoutSupport?: boolean;
 	styleVariationSelectors?: Record< string, string >;
 	name?: string;
+}
+
+interface ResponsiveStyleNode {
+	breakpointKey: string;
+	node: StylesNode;
 }
 
 type ElementName = keyof typeof ELEMENTS;
@@ -1055,6 +1062,84 @@ function getBlockPseudoStyleNodes( node: StylesNode ): StylesNode[] {
 }
 
 /**
+ * Creates style nodes for configured responsive breakpoint states.
+ *
+ * Breakpoint nodes render feature-level and base declarations through the
+ * normal node renderer. Responsive pseudo styles are intentionally handled by
+ * a separate fallback so their output can stay in the existing order for now.
+ *
+ * @param node Style node that may contain configured responsive state styles.
+ * @return Responsive style nodes in configured breakpoint order.
+ */
+function getBlockResponsiveStyleNodes(
+	node: StylesNode
+): ResponsiveStyleNode[] {
+	const { styles, selector, featureSelectors, name } = node;
+
+	if ( ! name ) {
+		return [];
+	}
+
+	return Object.entries( RESPONSIVE_BREAKPOINTS ).flatMap(
+		( [ breakpointKey, mediaQuery ] ) => {
+			const breakpointStyles = styles?.[ breakpointKey ];
+			if ( ! breakpointStyles || typeof breakpointStyles !== 'object' ) {
+				return [];
+			}
+
+			return [
+				{
+					breakpointKey,
+					node: {
+						styles: JSON.parse(
+							JSON.stringify( breakpointStyles )
+						),
+						selector,
+						mediaQuery,
+						featureSelectors:
+							featureSelectors &&
+							typeof featureSelectors !== 'string'
+								? featureSelectors
+								: undefined,
+						name,
+					},
+				},
+			];
+		}
+	);
+}
+
+function appendResponsivePseudoSelectorStyles(
+	styles: Record< string, any >,
+	selector: string,
+	ruleset: string,
+	featureSelectors: StylesNode[ 'featureSelectors' ],
+	treeSettings: Record< string, any > | undefined,
+	blockName: string | undefined,
+	breakpointKey: string
+): string {
+	const breakpointStyle = styles?.[ breakpointKey ];
+	if ( ! breakpointStyle || typeof breakpointStyle !== 'object' ) {
+		return ruleset;
+	}
+
+	const breakpointPseudoRules = appendPseudoSelectorStyles(
+		JSON.parse( JSON.stringify( breakpointStyle ) ),
+		selector,
+		'',
+		featureSelectors,
+		treeSettings,
+		blockName
+	);
+
+	if ( breakpointPseudoRules ) {
+		ruleset += `${ RESPONSIVE_BREAKPOINTS[ breakpointKey ] }{${ breakpointPseudoRules }}`;
+	}
+
+	return ruleset;
+}
+
+/**
  * Appends CSS rules for responsive breakpoint states to a ruleset string.
  * Block styles stored under responsive keys (for example, 'mobile' and
  * 'tablet') are wrapped in corresponding media queries instead of being
@@ -1639,19 +1724,27 @@ export const generateCustomProperties = (
 	return ruleset;
 };
 
+/**
+ * Renders CSS rules for a single style node.
+ *
+ * The node renderer handles feature-level selectors, duotone declarations,
+ * layout styles, base declarations, custom CSS, and optionally nested state
+ * styles such as variations, pseudo selectors, and responsive breakpoints.
+ *
+ * @param node                          Style node metadata and styles.
+ * @param context                       Render context and feature flags.
+ * @param context.tree                  Global styles tree.
+ * @param context.options               Enabled renderer output groups.
+ * @param context.useRootPaddingAlign   Whether root padding alignment is enabled.
+ * @param context.disableLayoutStyles   Whether layout styles are disabled.
+ * @param context.hasBlockGapSupport    Whether block gap support is enabled.
+ * @param context.hasFallbackGapSupport Whether fallback gap support is enabled.
+ * @param context.disableRootPadding    Whether root padding declarations are disabled.
+ * @param context.includeStateStyles    Whether nested state styles should be rendered.
+ * @return Rendered CSS rules for the node.
+ */
 function renderStylesNode(
-	{
-		selector,
-		selectorSuffix,
-		duotoneSelector,
-		styles,
-		fallbackGapValue,
-		hasLayoutSupport,
-		featureSelectors,
-		styleVariationSelectors,
-		skipSelectorWrapper,
-		name,
-	}: StylesNode,
+	node: StylesNode,
 	{
 		tree,
 		options,
@@ -1660,6 +1753,7 @@ function renderStylesNode(
 		hasBlockGapSupport,
 		hasFallbackGapSupport,
 		disableRootPadding,
+		includeStateStyles = true,
 	}: {
 		tree: GlobalStylesConfig;
 		options: Record< string, boolean >;
@@ -1668,8 +1762,22 @@ function renderStylesNode(
 		hasBlockGapSupport?: boolean;
 		hasFallbackGapSupport?: boolean;
 		disableRootPadding: boolean;
+		includeStateStyles?: boolean;
 	}
 ): string {
+	const {
+		selector,
+		selectorSuffix,
+		mediaQuery,
+		duotoneSelector,
+		styles,
+		fallbackGapValue,
+		hasLayoutSupport,
+		featureSelectors,
+		styleVariationSelectors,
+		skipSelectorWrapper,
+		name,
+	} = node;
 	let ruleset = '';
 	const effectiveSelector = selectorSuffix
 		? appendToSelector( selector, selectorSuffix )
@@ -1759,7 +1867,11 @@ function renderStylesNode(
 		);
 	}
 
-	if ( options.variationStyles && styleVariationSelectors ) {
+	if (
+		includeStateStyles &&
+		options.variationStyles &&
+		styleVariationSelectors
+	) {
 		Object.entries( styleVariationSelectors ).forEach(
 			( [ styleVariationName, styleVariationSelector ] ) => {
 				const styleVariations =
@@ -1865,43 +1977,82 @@ function renderStylesNode(
 		);
 	}
 
-	const blockPseudoNodes = getBlockPseudoStyleNodes( {
-		styles,
-		selector,
-		featureSelectors,
-		name,
-	} );
-	if ( blockPseudoNodes.length ) {
-		blockPseudoNodes.forEach( ( pseudoNode ) => {
-			ruleset += renderStylesNode( pseudoNode, {
-				tree,
-				options,
-				useRootPaddingAlign,
-				disableLayoutStyles: true,
-				hasBlockGapSupport,
-				hasFallbackGapSupport,
-				disableRootPadding,
-			} );
-		} );
-	} else {
-		ruleset = appendPseudoSelectorStyles(
+	if ( includeStateStyles ) {
+		const blockPseudoNodes = getBlockPseudoStyleNodes( {
 			styles,
 			selector,
-			ruleset,
 			featureSelectors,
-			tree.settings,
-			name
-		);
+			name,
+		} );
+		if ( blockPseudoNodes.length ) {
+			blockPseudoNodes.forEach( ( pseudoNode ) => {
+				ruleset += renderStylesNode( pseudoNode, {
+					tree,
+					options,
+					useRootPaddingAlign,
+					disableLayoutStyles: true,
+					hasBlockGapSupport,
+					hasFallbackGapSupport,
+					disableRootPadding,
+				} );
+			} );
+		} else {
+			ruleset = appendPseudoSelectorStyles(
+				styles,
+				selector,
+				ruleset,
+				featureSelectors,
+				tree.settings,
+				name
+			);
+		}
+
+		const blockResponsiveNodes = getBlockResponsiveStyleNodes( {
+			styles,
+			selector,
+			featureSelectors,
+			name,
+		} );
+		if ( blockResponsiveNodes.length ) {
+			blockResponsiveNodes.forEach(
+				( { breakpointKey, node: responsiveNode } ) => {
+					ruleset += renderStylesNode( responsiveNode, {
+						tree,
+						options,
+						useRootPaddingAlign,
+						disableLayoutStyles: true,
+						hasBlockGapSupport,
+						hasFallbackGapSupport,
+						disableRootPadding,
+						includeStateStyles: false,
+					} );
+
+					ruleset = appendResponsivePseudoSelectorStyles(
+						styles,
+						selector,
+						ruleset,
+						featureSelectors,
+						tree.settings,
+						name,
+						breakpointKey
+					);
+				}
+			);
+		} else {
+			ruleset = appendResponsiveStyles(
+				styles,
+				selector,
+				ruleset,
+				featureSelectors,
+				tree.settings,
+				name
+			);
+		}
 	}
 
-	ruleset = appendResponsiveStyles(
-		styles,
-		selector,
-		ruleset,
-		featureSelectors,
-		tree.settings,
-		name
-	);
+	if ( mediaQuery && ruleset ) {
+		return `${ mediaQuery }{${ ruleset }}`;
+	}
 
 	return ruleset;
 }

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1554,7 +1554,7 @@ function renderStylesNode(
 
 	// Process styles for block support features with custom feature level
 	// CSS selectors set.
-	if ( featureSelectors ) {
+	if ( featureSelectors && typeof featureSelectors !== 'string' ) {
 		let featureDeclarations = getFeatureDeclarations(
 			featureSelectors,
 			styles
@@ -1643,7 +1643,10 @@ function renderStylesNode(
 					styles?.variations?.[ styleVariationName ];
 				if ( styleVariations ) {
 					// If the block uses any custom selectors for block support, add those first.
-					if ( featureSelectors ) {
+					if (
+						featureSelectors &&
+						typeof featureSelectors !== 'string'
+					) {
 						let featureDeclarations = getFeatureDeclarations(
 							featureSelectors,
 							styleVariations

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1511,7 +1511,6 @@ export const generateCustomProperties = (
  * @param context.hasBlockGapSupport    Whether block gap support is enabled.
  * @param context.hasFallbackGapSupport Whether fallback gap support is enabled.
  * @param context.disableRootPadding    Whether root padding declarations are disabled.
- * @param context.includeStateStyles    Whether nested state styles should be rendered.
  * @return Rendered CSS rules for the node.
  */
 function renderStylesNode(
@@ -1524,7 +1523,6 @@ function renderStylesNode(
 		hasBlockGapSupport,
 		hasFallbackGapSupport,
 		disableRootPadding,
-		includeStateStyles = true,
 	}: {
 		tree: GlobalStylesConfig;
 		options: Record< string, boolean >;
@@ -1533,7 +1531,6 @@ function renderStylesNode(
 		hasBlockGapSupport?: boolean;
 		hasFallbackGapSupport?: boolean;
 		disableRootPadding: boolean;
-		includeStateStyles?: boolean;
 	}
 ): string {
 	const {
@@ -1639,11 +1636,7 @@ function renderStylesNode(
 		);
 	}
 
-	if (
-		includeStateStyles &&
-		options.variationStyles &&
-		styleVariationSelectors
-	) {
+	if ( options.variationStyles && styleVariationSelectors ) {
 		Object.entries( styleVariationSelectors ).forEach(
 			( [ styleVariationName, styleVariationSelector ] ) => {
 				const styleVariations =
@@ -1720,7 +1713,6 @@ function renderStylesNode(
 							hasBlockGapSupport,
 							hasFallbackGapSupport,
 							disableRootPadding,
-							includeStateStyles: false,
 						} );
 					} );
 
@@ -1762,43 +1754,41 @@ function renderStylesNode(
 		);
 	}
 
-	if ( includeStateStyles ) {
-		getPseudoStyleNodes( {
-			styles,
-			selector,
-			featureSelectors,
-			name,
-			elementName,
-		} ).forEach( ( pseudoNode ) => {
-			ruleset += renderStylesNode( pseudoNode, {
-				tree,
-				options,
-				useRootPaddingAlign,
-				disableLayoutStyles: true,
-				hasBlockGapSupport,
-				hasFallbackGapSupport,
-				disableRootPadding,
-			} );
+	getPseudoStyleNodes( {
+		styles,
+		selector,
+		featureSelectors,
+		name,
+		elementName,
+	} ).forEach( ( pseudoNode ) => {
+		ruleset += renderStylesNode( pseudoNode, {
+			tree,
+			options,
+			useRootPaddingAlign,
+			disableLayoutStyles: true,
+			hasBlockGapSupport,
+			hasFallbackGapSupport,
+			disableRootPadding,
 		} );
+	} );
 
-		getResponsiveStyleNodes( {
-			styles,
-			selector,
-			featureSelectors,
-			name,
-			elementName,
-		} ).forEach( ( responsiveNode ) => {
-			ruleset += renderStylesNode( responsiveNode, {
-				tree,
-				options,
-				useRootPaddingAlign,
-				disableLayoutStyles: true,
-				hasBlockGapSupport,
-				hasFallbackGapSupport,
-				disableRootPadding,
-			} );
+	getResponsiveStyleNodes( {
+		styles,
+		selector,
+		featureSelectors,
+		name,
+		elementName,
+	} ).forEach( ( responsiveNode ) => {
+		ruleset += renderStylesNode( responsiveNode, {
+			tree,
+			options,
+			useRootPaddingAlign,
+			disableLayoutStyles: true,
+			hasBlockGapSupport,
+			hasFallbackGapSupport,
+			disableRootPadding,
 		} );
-	}
+	} );
 
 	if ( mediaQuery && ruleset ) {
 		return `${ mediaQuery }{${ ruleset }}`;

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -143,7 +143,8 @@ export type BlockSelectors = Record<
  *
  * - `styles`: theme.json style object for this node.
  * - `selector`: CSS selector used for the node's base declarations.
- * - `selectorSuffix`: optional suffix appended to base and feature selectors.
+ * - `selectorSuffix`: optional suffix used to append additional selectors,
+ *   such as pseudo selectors, to base and feature selectors.
  * - `mediaQuery`: optional media query wrapping this node's rules.
  * - `skipSelectorWrapper`: omits the `:root :where()` specificity wrapper.
  * - `duotoneSelector`: alternate selector for duotone filter declarations.

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -152,6 +152,9 @@ export type BlockSelectors = Record<
  * - `fallbackGapValue`: fallback block gap value used by layout rules.
  * - `hasLayoutSupport`: whether layout styles can be generated for the node.
  * - `styleVariationSelectors`: block style variation selectors keyed by variation name.
+ * - `isStyleVariation`: whether this node is a block style variation.
+ * - `layoutSelector`: optional selector override for layout styles.
+ * - `layoutHasBlockGapSupport`: optional block gap support override for layout styles.
  * - `name`: block name used by block-specific declaration adjustments.
  * - `elementName`: element name used to resolve valid pseudo selectors.
  */
@@ -168,6 +171,9 @@ interface StylesNode {
 	fallbackGapValue?: string;
 	hasLayoutSupport?: boolean;
 	styleVariationSelectors?: Record< string, string >;
+	isStyleVariation?: boolean;
+	layoutSelector?: string;
+	layoutHasBlockGapSupport?: boolean;
 	name?: string;
 	elementName?: string;
 }
@@ -967,7 +973,14 @@ function pickStyleAndPseudoKeys(
  * @return Style nodes for the configured pseudo states.
  */
 function getPseudoStyleNodes( node: StylesNode ): StylesNode[] {
-	const { styles, selector, featureSelectors, name, elementName } = node;
+	const {
+		styles,
+		selector,
+		featureSelectors,
+		name,
+		elementName,
+		mediaQuery,
+	} = node;
 	const pseudoSelectors = name
 		? VALID_BLOCK_PSEUDO_SELECTORS[ name ] ?? []
 		: VALID_ELEMENT_PSEUDO_SELECTORS[ elementName ?? '' ] ?? [];
@@ -987,6 +1000,7 @@ function getPseudoStyleNodes( node: StylesNode ): StylesNode[] {
 				styles: JSON.parse( JSON.stringify( pseudoStyles ) ),
 				selector,
 				selectorSuffix: pseudoSelector,
+				mediaQuery,
 				featureSelectors:
 					featureSelectors && typeof featureSelectors !== 'string'
 						? featureSelectors
@@ -1008,7 +1022,14 @@ function getPseudoStyleNodes( node: StylesNode ): StylesNode[] {
  * @return Responsive style nodes in configured breakpoint order.
  */
 function getResponsiveStyleNodes( node: StylesNode ): StylesNode[] {
-	const { styles, selector, featureSelectors, name, elementName } = node;
+	const {
+		styles,
+		selector,
+		featureSelectors,
+		name,
+		elementName,
+		isStyleVariation,
+	} = node;
 
 	if ( ! name && ! elementName ) {
 		return [];
@@ -1032,9 +1053,58 @@ function getResponsiveStyleNodes( node: StylesNode ): StylesNode[] {
 							: undefined,
 					name,
 					elementName,
+					isStyleVariation,
 				},
 			];
 		}
+	);
+}
+
+/**
+ * Scopes feature selectors to a style variation selector.
+ *
+ * Variation feature selectors are compound selectors rather than suffixes. For
+ * example, `.wp-image-spacing` becomes `.is-style-foo.wp-image.wp-image-spacing`.
+ *
+ * @param featureSelectors       Feature-level selectors from a style node.
+ * @param styleVariationSelector Selector for the style variation.
+ * @return Feature-level selectors scoped to the style variation.
+ */
+function getVariationFeatureSelectors(
+	featureSelectors: StylesNode[ 'featureSelectors' ],
+	styleVariationSelector: string
+): StylesNode[ 'featureSelectors' ] {
+	if ( ! featureSelectors || typeof featureSelectors === 'string' ) {
+		return undefined;
+	}
+
+	return Object.fromEntries(
+		Object.entries( featureSelectors ).map( ( [ feature, selector ] ) => {
+			if ( typeof selector === 'string' ) {
+				return [
+					feature,
+					concatFeatureVariationSelectorString(
+						selector,
+						styleVariationSelector
+					),
+				];
+			}
+
+			return [
+				feature,
+				Object.fromEntries(
+					Object.entries( selector ).map(
+						( [ subfeature, subfeatureSelector ] ) => [
+							subfeature,
+							concatFeatureVariationSelectorString(
+								subfeatureSelector,
+								styleVariationSelector
+							),
+						]
+					)
+				),
+			];
+		} )
 	);
 }
 
@@ -1081,22 +1151,20 @@ export const getNodesWithStyles = (
 			const blockStyles = pickStyleAndPseudoKeys( node, blockName );
 			const typedNode = node as BlockNode;
 
-			// Store variation data for later processing, but don't add to nodes yet.
-			// Variations should be processed AFTER the main block styles to match PHP order.
+			// Store variation child nodes so they can be inserted after the block's own elements.
 			const variationNodesToAdd: typeof nodes = [];
+			const variationStyleNodesToAdd: typeof nodes = [];
 
 			if ( typedNode?.variations ) {
-				const variations: Record< string, any > = {};
 				Object.entries( typedNode.variations ).forEach(
 					( [ variationName, variation ] ) => {
 						const typedVariation = variation as BlockVariation;
-						variations[ variationName ] = pickStyleAndPseudoKeys(
+						const variationStyles = pickStyleAndPseudoKeys(
 							typedVariation,
 							blockName
 						);
 						if ( typedVariation?.css ) {
-							variations[ variationName ].css =
-								typedVariation.css;
+							variationStyles.css = typedVariation.css;
 						}
 						const variationSelector =
 							typeof blockSelectors !== 'string'
@@ -1105,6 +1173,29 @@ export const getNodesWithStyles = (
 										variationName
 								  ]
 								: undefined;
+						if (
+							variationSelector &&
+							typeof blockSelectors !== 'string'
+						) {
+							const blockSelector = blockSelectors[ blockName ];
+							variationStyleNodesToAdd.push( {
+								styles: variationStyles,
+								selector: variationSelector,
+								featureSelectors: getVariationFeatureSelectors(
+									blockSelector?.featureSelectors,
+									variationSelector
+								),
+								fallbackGapValue:
+									blockSelector?.fallbackGapValue,
+								hasLayoutSupport:
+									blockSelector?.hasLayoutSupport,
+								isStyleVariation: true,
+								layoutSelector:
+									variationSelector + blockSelector.selector,
+								layoutHasBlockGapSupport: true,
+								name: blockName,
+							} );
+						}
 
 						// Process the variation's inner element styles.
 						// This comes before the inner block styles so the
@@ -1124,6 +1215,7 @@ export const getNodesWithStyles = (
 										ELEMENTS[ element as ElementName ]
 									),
 									elementName: element,
+									isStyleVariation: true,
 								} );
 							}
 						} );
@@ -1183,6 +1275,7 @@ export const getNodesWithStyles = (
 								variationNodesToAdd.push( {
 									selector: variationBlockSelector,
 									name: variationBlockName,
+									isStyleVariation: true,
 									duotoneSelector: variationDuotoneSelector,
 									featureSelectors: variationFeatureSelectors,
 									fallbackGapValue:
@@ -1219,6 +1312,7 @@ export const getNodesWithStyles = (
 												),
 												elementName:
 													variationBlockElement,
+												isStyleVariation: true,
 											} );
 										}
 									}
@@ -1227,7 +1321,6 @@ export const getNodesWithStyles = (
 						);
 					}
 				);
-				blockStyles.variations = variations;
 			}
 
 			if (
@@ -1245,11 +1338,11 @@ export const getNodesWithStyles = (
 					styles: blockStyles,
 					featureSelectors:
 						blockSelectors[ blockName ].featureSelectors,
-					styleVariationSelectors:
-						blockSelectors[ blockName ].styleVariationSelectors,
 					name: blockName,
 				} );
 			}
+
+			nodes.push( ...variationStyleNodesToAdd );
 
 			Object.entries( typedNode?.elements ?? {} ).forEach(
 				( [ elementName, value ] ) => {
@@ -1500,8 +1593,8 @@ export const generateCustomProperties = (
  * Renders CSS rules for a single style node.
  *
  * The node renderer handles feature-level selectors, duotone declarations,
- * layout styles, base declarations, custom CSS, and optionally nested state
- * styles such as variations, pseudo selectors, and responsive breakpoints.
+ * layout styles, base declarations, and custom CSS. State nodes are expanded
+ * before rendering so ordering matches the PHP renderer.
  *
  * @param node                          Style node metadata and styles.
  * @param context                       Render context and feature flags.
@@ -1518,7 +1611,6 @@ function renderStylesNode(
 	node: StylesNode,
 	{
 		tree,
-		options,
 		useRootPaddingAlign,
 		disableLayoutStyles,
 		hasBlockGapSupport,
@@ -1543,10 +1635,10 @@ function renderStylesNode(
 		fallbackGapValue,
 		hasLayoutSupport,
 		featureSelectors,
-		styleVariationSelectors,
+		layoutSelector,
+		layoutHasBlockGapSupport,
 		skipSelectorWrapper,
 		name,
-		elementName,
 	} = node;
 	let ruleset = '';
 	const effectiveSelector = selectorSuffix
@@ -1603,14 +1695,17 @@ function renderStylesNode(
 	}
 
 	// Process blockGap and layout styles.
+	const selectorForLayout = layoutSelector ?? effectiveSelector;
+	const hasBlockGapSupportForLayout =
+		layoutHasBlockGapSupport ?? hasBlockGapSupport;
 	if (
 		! disableLayoutStyles &&
-		( ROOT_BLOCK_SELECTOR === effectiveSelector || hasLayoutSupport )
+		( ROOT_BLOCK_SELECTOR === selectorForLayout || hasLayoutSupport )
 	) {
 		ruleset += getLayoutStyles( {
 			style: styles,
-			selector: effectiveSelector,
-			hasBlockGapSupport,
+			selector: selectorForLayout,
+			hasBlockGapSupport: hasBlockGapSupportForLayout,
 			hasFallbackGapSupport,
 			fallbackGapValue,
 		} );
@@ -1636,163 +1731,6 @@ function renderStylesNode(
 			`:root :where(${ effectiveSelector })`
 		);
 	}
-
-	if ( options.variationStyles && styleVariationSelectors ) {
-		Object.entries( styleVariationSelectors ).forEach(
-			( [ styleVariationName, styleVariationSelector ] ) => {
-				const styleVariations =
-					styles?.variations?.[ styleVariationName ];
-				if ( styleVariations ) {
-					// If the block uses any custom selectors for block support, add those first.
-					if (
-						featureSelectors &&
-						typeof featureSelectors !== 'string'
-					) {
-						let featureDeclarations = getFeatureDeclarations(
-							featureSelectors,
-							styleVariations
-						);
-
-						// Update text indent selector for paragraph blocks based on the textIndent setting.
-						featureDeclarations = updateParagraphTextIndentSelector(
-							featureDeclarations,
-							tree.settings,
-							name
-						);
-
-						// Update button width declarations for percentage values to use calc() with block gap.
-						featureDeclarations = updateButtonWidthDeclarations(
-							featureDeclarations,
-							tree.settings
-						);
-
-						Object.entries( featureDeclarations ).forEach(
-							( [ baseSelector, declarations ]: [
-								string,
-								string[],
-							] ) => {
-								if ( declarations.length ) {
-									const cssSelector =
-										concatFeatureVariationSelectorString(
-											baseSelector,
-											styleVariationSelector as string
-										);
-									const rules = declarations.join( ';' );
-									ruleset += `:root :where(${ cssSelector }){${ rules };}`;
-								}
-							}
-						);
-					}
-
-					// Otherwise add regular selectors.
-					const styleVariationDeclarations = getStylesDeclarations(
-						styleVariations,
-						styleVariationSelector as string,
-						useRootPaddingAlign,
-						tree
-					);
-					if ( styleVariationDeclarations.length ) {
-						ruleset += `:root :where(${ styleVariationSelector }){${ styleVariationDeclarations.join(
-							';'
-						) };}`;
-					}
-					if ( styleVariations?.css ) {
-						ruleset += processCSSNesting(
-							styleVariations.css,
-							`:root :where(${ styleVariationSelector })`
-						);
-					}
-
-					getPseudoStyleNodes( {
-						styles: styleVariations,
-						selector: styleVariationSelector as string,
-						featureSelectors,
-						name,
-					} ).forEach( ( pseudoNode ) => {
-						ruleset += renderStylesNode( pseudoNode, {
-							tree,
-							options,
-							useRootPaddingAlign,
-							disableLayoutStyles: true,
-							hasBlockGapSupport,
-							hasFallbackGapSupport,
-							disableRootPadding,
-						} );
-					} );
-
-					getResponsiveStyleNodes( {
-						styles: styleVariations,
-						selector: styleVariationSelector as string,
-						featureSelectors,
-						name,
-					} ).forEach( ( responsiveNode ) => {
-						ruleset += renderStylesNode( responsiveNode, {
-							tree,
-							options,
-							useRootPaddingAlign,
-							disableLayoutStyles: true,
-							hasBlockGapSupport,
-							hasFallbackGapSupport,
-							disableRootPadding,
-						} );
-					} );
-
-					// Generate layout styles for the variation if it supports layout and has blockGap defined.
-					if (
-						hasLayoutSupport &&
-						styleVariations?.spacing?.blockGap
-					) {
-						// Append block selector to variation selector so layout classes are properly constructed.
-						const variationSelectorWithBlock =
-							styleVariationSelector + selector;
-						ruleset += getLayoutStyles( {
-							style: styleVariations,
-							selector: variationSelectorWithBlock,
-							hasBlockGapSupport: true,
-							hasFallbackGapSupport,
-							fallbackGapValue,
-						} );
-					}
-				}
-			}
-		);
-	}
-
-	getPseudoStyleNodes( {
-		styles,
-		selector,
-		featureSelectors,
-		name,
-		elementName,
-	} ).forEach( ( pseudoNode ) => {
-		ruleset += renderStylesNode( pseudoNode, {
-			tree,
-			options,
-			useRootPaddingAlign,
-			disableLayoutStyles: true,
-			hasBlockGapSupport,
-			hasFallbackGapSupport,
-			disableRootPadding,
-		} );
-	} );
-
-	getResponsiveStyleNodes( {
-		styles,
-		selector,
-		featureSelectors,
-		name,
-		elementName,
-	} ).forEach( ( responsiveNode ) => {
-		ruleset += renderStylesNode( responsiveNode, {
-			tree,
-			options,
-			useRootPaddingAlign,
-			disableLayoutStyles: true,
-			hasBlockGapSupport,
-			hasFallbackGapSupport,
-			disableRootPadding,
-		} );
-	} );
 
 	if ( mediaQuery && ruleset ) {
 		return `${ mediaQuery }{${ ruleset }}`;
@@ -1871,14 +1809,27 @@ export const transformToStyles = (
 
 	if ( options.blockStyles ) {
 		nodesWithStyles.forEach( ( node ) => {
-			ruleset += renderStylesNode( node, {
-				tree,
-				options,
-				useRootPaddingAlign,
-				disableLayoutStyles,
-				hasBlockGapSupport,
-				hasFallbackGapSupport,
-				disableRootPadding,
+			if ( node.isStyleVariation && ! options.variationStyles ) {
+				return;
+			}
+
+			const responsiveNodes = getResponsiveStyleNodes( node );
+			// Match PHP node order: base, responsive base, pseudo, responsive pseudo.
+			[
+				node,
+				...responsiveNodes,
+				...getPseudoStyleNodes( node ),
+				...responsiveNodes.flatMap( getPseudoStyleNodes ),
+			].forEach( ( expandedNode ) => {
+				ruleset += renderStylesNode( expandedNode, {
+					tree,
+					options,
+					useRootPaddingAlign,
+					disableLayoutStyles,
+					hasBlockGapSupport,
+					hasFallbackGapSupport,
+					disableRootPadding,
+				} );
 			} );
 		} );
 	}

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -151,7 +151,6 @@ export type BlockSelectors = Record<
  * - `featureSelectors`: feature-level selectors for block supports.
  * - `fallbackGapValue`: fallback block gap value used by layout rules.
  * - `hasLayoutSupport`: whether layout styles can be generated for the node.
- * - `styleVariationSelectors`: block style variation selectors keyed by variation name.
  * - `isStyleVariation`: whether this node is a block style variation.
  * - `layoutSelector`: optional selector override for layout styles.
  * - `layoutHasBlockGapSupport`: optional block gap support override for layout styles.
@@ -170,7 +169,6 @@ interface StylesNode {
 		| Record< string, string | Record< string, string > >;
 	fallbackGapValue?: string;
 	hasLayoutSupport?: boolean;
-	styleVariationSelectors?: Record< string, string >;
 	isStyleVariation?: boolean;
 	layoutSelector?: string;
 	layoutHasBlockGapSupport?: boolean;

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -955,92 +955,6 @@ function pickStyleAndPseudoKeys(
 	return Object.fromEntries( clonedEntries );
 }
 
-function appendPseudoSelectorStyles(
-	styles: Record< string, any >,
-	selector: string,
-	ruleset: string,
-	featureSelectors:
-		| string
-		| Record< string, string | Record< string, string > >
-		| undefined,
-	treeSettings: Record< string, any > | undefined,
-	blockName: string | undefined,
-	styleVariationSelector?: string
-): string {
-	const pseudoSelectorStyles = Object.entries( styles ).filter( ( [ key ] ) =>
-		key.startsWith( ':' )
-	);
-
-	if ( ! pseudoSelectorStyles.length ) {
-		return ruleset;
-	}
-
-	pseudoSelectorStyles.forEach( ( [ pseudoKey, pseudoStyle ] ) => {
-		if ( ! pseudoStyle || typeof pseudoStyle !== 'object' ) {
-			return;
-		}
-
-		const remainingPseudoStyles = JSON.parse(
-			JSON.stringify( pseudoStyle )
-		);
-
-		if ( featureSelectors && typeof featureSelectors !== 'string' ) {
-			let pseudoFeatureDeclarations = getFeatureDeclarations(
-				featureSelectors,
-				remainingPseudoStyles
-			);
-
-			pseudoFeatureDeclarations = updateParagraphTextIndentSelector(
-				pseudoFeatureDeclarations,
-				treeSettings,
-				blockName
-			);
-
-			pseudoFeatureDeclarations = updateButtonWidthDeclarations(
-				pseudoFeatureDeclarations,
-				treeSettings
-			);
-
-			Object.entries( pseudoFeatureDeclarations ).forEach(
-				( [ baseSelector, declarations ] ) => {
-					if ( ! declarations.length ) {
-						return;
-					}
-					const pseudoFeatureSelector = appendToSelector(
-						baseSelector,
-						pseudoKey
-					);
-					const cssSelector = styleVariationSelector
-						? concatFeatureVariationSelectorString(
-								pseudoFeatureSelector,
-								styleVariationSelector
-						  )
-						: pseudoFeatureSelector;
-					const rules = declarations.join( ';' );
-					ruleset += `:root :where(${ cssSelector }){${ rules };}`;
-				}
-			);
-		}
-
-		const pseudoDeclarations = getStylesDeclarations(
-			remainingPseudoStyles
-		);
-
-		if ( ! pseudoDeclarations.length ) {
-			return;
-		}
-
-		const pseudoSelector = appendToSelector( selector, pseudoKey );
-		const pseudoRule = `:root :where(${ pseudoSelector }){${ pseudoDeclarations.join(
-			';'
-		) };}`;
-
-		ruleset += pseudoRule;
-	} );
-
-	return ruleset;
-}
-
 /**
  * Creates style nodes for configured block and element pseudo selectors.
  *
@@ -1121,139 +1035,6 @@ function getResponsiveStyleNodes( node: StylesNode ): StylesNode[] {
 			];
 		}
 	);
-}
-
-/**
- * Appends CSS rules for responsive breakpoint states to a ruleset string.
- * Block styles stored under responsive keys (for example, 'mobile' and
- * 'tablet') are wrapped in corresponding media queries instead of being
- * appended directly to the selector.
- *
- * @param styles                 The styles object potentially containing responsive keys.
- * @param selector               The base CSS selector for the block.
- * @param ruleset                The accumulating CSS ruleset string.
- * @param featureSelectors       Optional feature-level selectors for the block.
- * @param treeSettings           Global styles settings tree.
- * @param blockName              Optional block name used to resolve valid pseudo selectors.
- * @param styleVariationSelector Optional style variation selector.
- * @param blockRootSelector      Optional block root selector used to detect block-level feature selectors.
- * @param styleVariationName     Optional variation name used when applying variation class to block-level feature selectors.
- * @return Updated ruleset string with responsive base, feature-level, and pseudo-state CSS appended.
- */
-function appendResponsiveStyles(
-	styles: Record< string, any >,
-	selector: string,
-	ruleset: string,
-	featureSelectors:
-		| string
-		| Record< string, string | Record< string, string > >
-		| undefined,
-	treeSettings: Record< string, any > | undefined,
-	blockName?: string,
-	styleVariationSelector?: string,
-	blockRootSelector?: string,
-	styleVariationName?: string
-): string {
-	const responsiveStyles = Object.entries( styles ).filter(
-		( [ key ] ) => RESPONSIVE_BREAKPOINTS[ key ]
-	);
-
-	if ( ! responsiveStyles.length ) {
-		return ruleset;
-	}
-
-	responsiveStyles.forEach( ( [ breakpointKey, breakpointStyle ] ) => {
-		if ( ! breakpointStyle || typeof breakpointStyle !== 'object' ) {
-			return;
-		}
-
-		const mediaQuery = RESPONSIVE_BREAKPOINTS[ breakpointKey ];
-		const remainingBreakpointStyles = JSON.parse(
-			JSON.stringify( breakpointStyle )
-		);
-
-		if ( featureSelectors && typeof featureSelectors !== 'string' ) {
-			let breakpointFeatureDeclarations = getFeatureDeclarations(
-				featureSelectors,
-				remainingBreakpointStyles
-			);
-
-			breakpointFeatureDeclarations = updateParagraphTextIndentSelector(
-				breakpointFeatureDeclarations,
-				treeSettings,
-				blockName
-			);
-
-			breakpointFeatureDeclarations = updateButtonWidthDeclarations(
-				breakpointFeatureDeclarations,
-				treeSettings
-			);
-
-			Object.entries( breakpointFeatureDeclarations ).forEach(
-				( [ baseSelector, declarations ] ) => {
-					if ( ! declarations.length ) {
-						return;
-					}
-					let cssSelector: string;
-					if ( ! styleVariationSelector ) {
-						cssSelector = baseSelector;
-					} else if (
-						blockRootSelector &&
-						styleVariationName &&
-						! baseSelector.includes( blockRootSelector )
-					) {
-						/*
-						 * Feature selector is block-level (e.g. `.wp-block-button` for
-						 * dimensions/width) — apply the variation class directly to it.
-						 */
-						cssSelector = getBlockStyleVariationSelector(
-							styleVariationName,
-							baseSelector
-						);
-					} else {
-						cssSelector = concatFeatureVariationSelectorString(
-							baseSelector,
-							styleVariationSelector
-						);
-					}
-					const rules = declarations.join( ';' );
-					ruleset += `${ mediaQuery }{:root :where(${ cssSelector }){${ rules };}}`;
-				}
-			);
-		}
-
-		const breakpointDeclarations = getStylesDeclarations(
-			remainingBreakpointStyles
-		);
-
-		if ( breakpointDeclarations.length ) {
-			const cssSelector = styleVariationSelector
-				? concatFeatureVariationSelectorString(
-						selector,
-						styleVariationSelector
-				  )
-				: selector;
-			ruleset += `${ mediaQuery }{:root :where(${ cssSelector }){${ breakpointDeclarations.join(
-				';'
-			) };}}`;
-		}
-
-		const breakpointPseudoRules = appendPseudoSelectorStyles(
-			remainingBreakpointStyles,
-			selector,
-			'',
-			featureSelectors,
-			treeSettings,
-			blockName,
-			styleVariationSelector
-		);
-
-		if ( breakpointPseudoRules ) {
-			ruleset += `${ mediaQuery }{${ breakpointPseudoRules }}`;
-		}
-	} );
-
-	return ruleset;
 }
 
 export const getNodesWithStyles = (
@@ -1987,6 +1768,7 @@ function renderStylesNode(
 			selector,
 			featureSelectors,
 			name,
+			elementName,
 		} );
 		if ( blockPseudoNodes.length ) {
 			blockPseudoNodes.forEach( ( pseudoNode ) => {
@@ -2000,15 +1782,6 @@ function renderStylesNode(
 					disableRootPadding,
 				} );
 			} );
-		} else {
-			ruleset = appendPseudoSelectorStyles(
-				styles,
-				selector,
-				ruleset,
-				featureSelectors,
-				tree.settings,
-				name
-			);
 		}
 
 		const blockResponsiveNodes = getResponsiveStyleNodes( {
@@ -2030,15 +1803,6 @@ function renderStylesNode(
 					disableRootPadding,
 				} );
 			} );
-		} else {
-			ruleset = appendResponsiveStyles(
-				styles,
-				selector,
-				ruleset,
-				featureSelectors,
-				tree.settings,
-				name
-			);
 		}
 	}
 

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1400,6 +1400,7 @@ export const getNodesWithStyles = (
 
 								variationNodesToAdd.push( {
 									selector: variationBlockSelector,
+									name: variationBlockName,
 									duotoneSelector: variationDuotoneSelector,
 									featureSelectors: variationFeatureSelectors,
 									fallbackGapValue:

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -912,6 +912,65 @@ describe( 'global styles renderer', () => {
 			);
 		} );
 
+		it( 'outputs variation pseudo styles after variation responsive base styles', () => {
+			const tree = {
+				styles: {
+					blocks: {
+						'core/button': {
+							variations: {
+								foo: {
+									color: {
+										text: 'green',
+									},
+									':hover': {
+										color: {
+											text: 'blue',
+										},
+									},
+									mobile: {
+										color: {
+											text: 'red',
+										},
+										':hover': {
+											color: {
+												text: 'orange',
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			const blockSelectors = {
+				'core/button': {
+					selector: '.wp-block-button',
+					styleVariationSelectors: {
+						foo: '.is-style-foo.wp-block-button',
+					},
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors,
+				false,
+				false,
+				true,
+				true,
+				{
+					...minimalStyleOptions,
+					variationStyles: true,
+				}
+			);
+
+			expect( result ).toEqual(
+				':root :where(.is-style-foo.wp-block-button){color: green;}@media (width <= 480px){:root :where(.is-style-foo.wp-block-button){color: red;}}:root :where(.is-style-foo.wp-block-button:hover){color: blue;}@media (width <= 480px){:root :where(.is-style-foo.wp-block-button:hover){color: orange;}}'
+			);
+		} );
+
 		it( 'handles responsive block styles', () => {
 			const tree = {
 				styles: {

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -665,6 +665,72 @@ describe( 'global styles renderer', () => {
 			);
 		} );
 
+		it( 'handles variation inner block states', () => {
+			const tree = {
+				styles: {
+					blocks: {
+						'core/group': {
+							variations: {
+								foo: {
+									blocks: {
+										'core/button': {
+											color: {
+												text: 'red',
+											},
+											':hover': {
+												color: {
+													text: 'blue',
+												},
+											},
+											mobile: {
+												color: {
+													text: 'green',
+												},
+												':hover': {
+													color: {
+														text: 'yellow',
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			const blockSelectors = {
+				'core/group': {
+					selector: '.wp-block-group',
+					styleVariationSelectors: {
+						foo: '.is-style-foo.wp-block-group',
+					},
+				},
+				'core/button': {
+					selector: '.wp-block-button',
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors,
+				false,
+				false,
+				true,
+				true,
+				{
+					...minimalStyleOptions,
+					variationStyles: true,
+				}
+			);
+
+			expect( result ).toEqual(
+				':root :where(.is-style-foo.wp-block-group .wp-block-button){color: red;}:root :where(.is-style-foo.wp-block-group .wp-block-button:hover){color: blue;}@media (width <= 480px){:root :where(.is-style-foo.wp-block-group .wp-block-button){color: green;}:root :where(.is-style-foo.wp-block-group .wp-block-button:hover){color: yellow;}}'
+			);
+		} );
+
 		it( 'should handle block pseudo selectors', () => {
 			const tree = {
 				styles: {

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -168,6 +168,7 @@ describe( 'global styles renderer', () => {
 						},
 					},
 					selector: ELEMENTS.link,
+					elementName: 'link',
 					skipSelectorWrapper: true,
 				},
 				{
@@ -187,6 +188,7 @@ describe( 'global styles renderer', () => {
 						},
 					},
 					selector: '.my-heading1 h1, .my-heading2 h1',
+					elementName: 'h1',
 				},
 				{
 					styles: {
@@ -195,6 +197,7 @@ describe( 'global styles renderer', () => {
 						},
 					},
 					selector: '.my-heading1 h2, .my-heading2 h2',
+					elementName: 'h2',
 				},
 				{
 					styles: {
@@ -213,6 +216,7 @@ describe( 'global styles renderer', () => {
 					},
 					selector:
 						'.my-heading1 a:where(:not(.wp-element-button)), .my-heading2 a:where(:not(.wp-element-button))',
+					elementName: 'link',
 				},
 				{
 					styles: {

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -777,6 +777,43 @@ describe( 'global styles renderer', () => {
 			);
 		} );
 
+		it( 'ignores root-level state styles', () => {
+			const tree = {
+				styles: {
+					color: {
+						text: 'red',
+					},
+					':hover': {
+						color: {
+							text: 'blue',
+						},
+					},
+					mobile: {
+						color: {
+							text: 'green',
+						},
+						':hover': {
+							color: {
+								text: 'yellow',
+							},
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				{},
+				false,
+				false,
+				true,
+				true,
+				minimalStyleOptions
+			);
+
+			expect( result ).toEqual( 'body{color: red;}' );
+		} );
+
 		it( 'should handle style variation pseudo selectors', () => {
 			const tree = {
 				styles: {

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -896,6 +896,44 @@ describe( 'global styles renderer', () => {
 			);
 		} );
 
+		it( 'handles responsive element styles', () => {
+			const tree = {
+				styles: {
+					elements: {
+						link: {
+							color: {
+								text: 'blue',
+							},
+							mobile: {
+								color: {
+									text: 'red',
+								},
+								':hover': {
+									color: {
+										text: 'orange',
+									},
+								},
+							},
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				{},
+				false,
+				false,
+				true,
+				true,
+				minimalStyleOptions
+			);
+
+			expect( result ).toEqual(
+				'a:where(:not(.wp-element-button)){color: blue;}@media (width <= 480px){:root :where(a:where(:not(.wp-element-button))){color: red;}:root :where(a:where(:not(.wp-element-button)):hover){color: orange;}}'
+			);
+		} );
+
 		it( 'handles responsive style variation styles', () => {
 			const tree = {
 				styles: {

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -937,7 +937,7 @@ describe( 'global styles renderer', () => {
 			);
 
 			expect( result ).toEqual(
-				':root :where(.is-style-foo.wp-block-button){color: green;}@media (width <= 480px){:root :where(.is-style-foo.wp-block-button.is-style-foo.wp-block-button){color: yellow;}}'
+				':root :where(.is-style-foo.wp-block-button){color: green;}@media (width <= 480px){:root :where(.is-style-foo.wp-block-button){color: yellow;}}'
 			);
 		} );
 

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -777,6 +777,50 @@ describe( 'global styles renderer', () => {
 			);
 		} );
 
+		it( 'outputs default pseudo styles after responsive base styles', () => {
+			const tree = {
+				styles: {
+					blocks: {
+						'core/button': {
+							color: {
+								text: 'black',
+							},
+							':hover': {
+								color: {
+									text: 'blue',
+								},
+							},
+							mobile: {
+								color: {
+									text: 'red',
+								},
+							},
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			const blockSelectors = {
+				'core/button': {
+					selector: '.wp-block-button',
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors,
+				false,
+				false,
+				true,
+				true,
+				minimalStyleOptions
+			);
+
+			expect( result ).toEqual(
+				':root :where(.wp-block-button){color: black;}@media (width <= 480px){:root :where(.wp-block-button){color: red;}}:root :where(.wp-block-button:hover){color: blue;}'
+			);
+		} );
+
 		it( 'ignores root-level state styles', () => {
 			const tree = {
 				styles: {

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -727,7 +727,7 @@ describe( 'global styles renderer', () => {
 			);
 
 			expect( result ).toEqual(
-				':root :where(.is-style-foo.wp-block-group .wp-block-button){color: red;}:root :where(.is-style-foo.wp-block-group .wp-block-button:hover){color: blue;}@media (width <= 480px){:root :where(.is-style-foo.wp-block-group .wp-block-button){color: green;}:root :where(.is-style-foo.wp-block-group .wp-block-button:hover){color: yellow;}}'
+				':root :where(.is-style-foo.wp-block-group .wp-block-button){color: red;}@media (width <= 480px){:root :where(.is-style-foo.wp-block-group .wp-block-button){color: green;}}:root :where(.is-style-foo.wp-block-group .wp-block-button:hover){color: blue;}@media (width <= 480px){:root :where(.is-style-foo.wp-block-group .wp-block-button:hover){color: yellow;}}'
 			);
 		} );
 
@@ -993,7 +993,7 @@ describe( 'global styles renderer', () => {
 			);
 
 			expect( result ).toEqual(
-				':root :where(.wp-block-button:hover){color: blue;}@media (width <= 480px){:root :where(.wp-block-button){color: red;}:root :where(.wp-block-button:hover){color: orange;}}'
+				'@media (width <= 480px){:root :where(.wp-block-button){color: red;}}:root :where(.wp-block-button:hover){color: blue;}@media (width <= 480px){:root :where(.wp-block-button:hover){color: orange;}}'
 			);
 		} );
 
@@ -1077,7 +1077,7 @@ describe( 'global styles renderer', () => {
 			);
 
 			expect( result ).toEqual(
-				'a:where(:not(.wp-element-button)){color: blue;}@media (width <= 480px){:root :where(a:where(:not(.wp-element-button))){color: red;}:root :where(a:where(:not(.wp-element-button)):hover){color: orange;}}'
+				'a:where(:not(.wp-element-button)){color: blue;}@media (width <= 480px){:root :where(a:where(:not(.wp-element-button))){color: red;}}@media (width <= 480px){:root :where(a:where(:not(.wp-element-button)):hover){color: orange;}}'
 			);
 		} );
 

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -811,6 +811,9 @@ describe( 'global styles renderer', () => {
 								},
 							},
 							mobile: {
+								color: {
+									text: 'red',
+								},
 								':hover': {
 									color: {
 										text: 'orange',
@@ -839,7 +842,7 @@ describe( 'global styles renderer', () => {
 			);
 
 			expect( result ).toEqual(
-				':root :where(.wp-block-button:hover){color: blue;}@media (width <= 480px){:root :where(.wp-block-button:hover){color: orange;}}'
+				':root :where(.wp-block-button:hover){color: blue;}@media (width <= 480px){:root :where(.wp-block-button){color: red;}:root :where(.wp-block-button:hover){color: orange;}}'
 			);
 		} );
 

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -392,6 +392,15 @@ describe( 'global styles renderer', () => {
 	} );
 
 	describe( 'transformToStyles', () => {
+		const minimalStyleOptions = {
+			blockGap: false,
+			blockStyles: true,
+			layoutStyles: false,
+			marginReset: false,
+			presets: false,
+			rootPadding: false,
+		};
+
 		it( 'should return a ruleset', () => {
 			const tree = {
 				settings: {
@@ -749,6 +758,183 @@ describe( 'global styles renderer', () => {
 
 			expect( result ).toEqual(
 				':root :where(.is-style-foo.wp-block-button){color: green;}:root :where(.is-style-foo.wp-block-button:hover){color: yellow;}'
+			);
+		} );
+
+		it( 'handles responsive block styles', () => {
+			const tree = {
+				styles: {
+					blocks: {
+						'core/button': {
+							color: {
+								text: 'red',
+							},
+							mobile: {
+								color: {
+									text: 'blue',
+								},
+							},
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			const blockSelectors = {
+				'core/button': {
+					selector: '.wp-block-button',
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors,
+				false,
+				false,
+				true,
+				true,
+				minimalStyleOptions
+			);
+
+			expect( result ).toEqual(
+				':root :where(.wp-block-button){color: red;}@media (width <= 480px){:root :where(.wp-block-button){color: blue;}}'
+			);
+		} );
+
+		it( 'handles responsive pseudo selector styles', () => {
+			const tree = {
+				styles: {
+					blocks: {
+						'core/button': {
+							':hover': {
+								color: {
+									text: 'blue',
+								},
+							},
+							mobile: {
+								':hover': {
+									color: {
+										text: 'orange',
+									},
+								},
+							},
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			const blockSelectors = {
+				'core/button': {
+					selector: '.wp-block-button',
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors,
+				false,
+				false,
+				true,
+				true,
+				minimalStyleOptions
+			);
+
+			expect( result ).toEqual(
+				':root :where(.wp-block-button:hover){color: blue;}@media (width <= 480px){:root :where(.wp-block-button:hover){color: orange;}}'
+			);
+		} );
+
+		it( 'handles responsive feature selector styles', () => {
+			const tree = {
+				settings: {},
+				styles: {
+					blocks: {
+						'core/button': {
+							dimensions: {
+								width: '25%',
+							},
+							mobile: {
+								dimensions: {
+									width: '50%',
+								},
+							},
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			const blockSelectors = {
+				'core/button': {
+					selector: '.wp-block-button .wp-block-button__link',
+					featureSelectors: {
+						dimensions: {
+							root: '.wp-block-button',
+							width: '.wp-block-button',
+						},
+					},
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors,
+				false,
+				false,
+				true,
+				true,
+				minimalStyleOptions
+			);
+
+			expect( result ).toEqual(
+				':root :where(.wp-block-button){width: calc(25 * 1% - (var(--wp--style--block-gap, 0.5em) * (1 - 25 / 100)));}@media (width <= 480px){:root :where(.wp-block-button){width: calc(50 * 1% - (var(--wp--style--block-gap, 0.5em) * (1 - 50 / 100)));}}'
+			);
+		} );
+
+		it( 'handles responsive style variation styles', () => {
+			const tree = {
+				styles: {
+					blocks: {
+						'core/button': {
+							variations: {
+								foo: {
+									color: {
+										text: 'green',
+									},
+									mobile: {
+										color: {
+											text: 'yellow',
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			const blockSelectors = {
+				'core/button': {
+					selector: '.wp-block-button',
+					styleVariationSelectors: {
+						foo: '.is-style-foo.wp-block-button',
+					},
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors,
+				false,
+				false,
+				true,
+				true,
+				{
+					...minimalStyleOptions,
+					variationStyles: true,
+				}
+			);
+
+			expect( result ).toEqual(
+				':root :where(.is-style-foo.wp-block-button){color: green;}@media (width <= 480px){:root :where(.is-style-foo.wp-block-button.is-style-foo.wp-block-button){color: yellow;}}'
 			);
 		} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a TS equivalent of #77881. It refactors state style rendering (for both pseudo and responsive states) to prefer using nodes instead of generating the styles feature by feature.

## Why?
`renderStylesNode` becomes the central place to change style rendering logic, it should be a bit less error prone for future changes.

Also reduces the number of lines of css output (styles are grouped under `@media` rules more).

## How
- Extracts a `renderStylesNode` function from `transformToStyles` that can be used for outputting individual node styles.
- Removes `appendResponsiveStyles` and `appendPseudoSelectorStyles`, replacing them with `getResponsiveStyleNodes` / `getPseudoStyleNodes` + `renderStylesNode`

## Testing Instructions
It should behave the same as in trunk. Some extra unit tests are added to ensure the output is consistent.

1. Go to Site Editor > Styles > Blocks
2. Use the 'State' dropdown to select responsive and pseudo states and change the styles. Button is a good block to test
3. In the editor change the viewport and check that the styles work as expected for the relevant blocks