### PR TITLE
Admin UI: Fix nested landmark in Page header

### DIFF
--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `Page`: Fix nested landmark in header. [#78001](https://github.com/WordPress/gutenberg/pull/78001)
+
 ## 2.0.0 (2026-04-29)
 
 ### Enhancements

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -30,11 +30,7 @@ export default function Header( {
 } ) {
 	const HeadingTag = `h${ headingLevel }` as const;
 	return (
-		<Stack
-			direction="column"
-			className={ styles.header }
-			render={ <header /> }
-		>
+		<Stack direction="column" className={ styles.header }>
 			<Stack
 				className={ styles[ 'header-content' ] }
 				direction="row"


### PR DESCRIPTION
Closes #77481

## What?
Removes the `<header>` element from the Admin UI `Page` header.

## Why?
`Page` wraps content in `NavigableRegion` (`role="region"`). Since `role="region"` is not an HTML sectioning element, the inner `<header>` kept its implicit `banner` role, producing a `banner` nested inside a `region`.

## How?
Drop `render={ <header /> }` from the outer `Stack`. `

## Testing Instructions
1. Open a screen using `Page` (e.g. Appearance > Connectors or Settings > Connectors).
2. In DevTools Accessibility pane, confirm there is no `banner` nested in the page's `region` landmark.

```html
<div class="admin-ui-navigable-region admin-ui-page" aria-label="Connectors" role="region" tabindex="-1">
  <div class="admin-ui-page__header">
    <div>
      <div>
        <div class="admin-ui-page__sidebar-toggle-slot"></div>
        <h1 class="admin-ui-page__header-title">Connectors</h1>
      </div>
      <div class="admin-ui-page__header-actions"></div>
    </div>
    <p class="admin-ui-page__header-subtitle">All of your API keys and credentials are stored here and shared across plugins. Configure once and use everywhere.</p>
  </div>
  <div class="connectors-page">
    <p>If the connector you need is not listed, search the plugin directory to see if a connector is available.</p>
  </div>
</div>
```

## Screenshots or screencast
N/A — no visual changes.

## Use of AI Tools
Authored with assistance from Claude Code; reviewed by the author.
