### PR TITLE
[WP.7.0] Admin UI: Backport accessibility fixes (#77617, #78001)

### DIFF
--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Change default `headingLevel` for the `Page` component's header from `2` to `1`, meaning from `h2` to `h1`. If you need to keep previous behaviour, use `<Page title="Example" headingLevel={ 2 }>` [#77617](https://github.com/WordPress/gutenberg/pull/77617)
+
 ## 1.8.0 (2026-02-18)
 
 ### Enhancements

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Change default `headingLevel` for the `Page` component's header from `2` to `1`, meaning from `h2` to `h1`. If you need to keep previous behaviour, use `<Page title="Example" headingLevel={ 2 }>` [#77617](https://github.com/WordPress/gutenberg/pull/77617)
 
+### Bug Fixes
+
+-   `Page`: Fix nested landmark in header. [#78001](https://github.com/WordPress/gutenberg/pull/78001)
+
 ## 1.8.0 (2026-02-18)
 
 ### Enhancements

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -27,11 +27,7 @@ export default function Header( {
 } ) {
 	const HeadingTag = `h${ headingLevel }` as const;
 	return (
-		<Stack
-			direction="column"
-			className="admin-ui-page__header"
-			render={ <header /> }
-		>
+		<Stack direction="column" className="admin-ui-page__header">
 			<Stack direction="row" justify="space-between" gap="sm">
 				<Stack direction="row" gap="sm" align="center" justify="start">
 					{ showSidebarToggle && (

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -9,7 +9,7 @@ import { Stack } from '@wordpress/ui';
 import { SidebarToggleSlot } from './sidebar-toggle-slot';
 
 export default function Header( {
-	headingLevel = 2,
+	headingLevel = 1,
 	breadcrumbs,
 	badges,
 	title,

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -202,6 +202,7 @@ export default function DataviewsPatterns() {
 			<Page
 				className="edit-site-page-patterns-dataviews"
 				title={ title }
+				headingLevel={ 2 }
 				subTitle={ description }
 				actions={
 					<PatternsActions

--- a/packages/edit-site/src/components/page-templates/index-legacy.js
+++ b/packages/edit-site/src/components/page-templates/index-legacy.js
@@ -133,6 +133,7 @@ export default function PageTemplates() {
 		<Page
 			className="edit-site-page-templates"
 			title={ __( 'Templates' ) }
+			headingLevel={ 2 }
 			actions={ <AddNewTemplate /> }
 		>
 			<DataViews

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -325,6 +325,7 @@ export default function PageTemplates() {
 		<Page
 			className="edit-site-page-templates"
 			title={ __( 'Templates' ) }
+			headingLevel={ 2 }
 			actions={ <AddNewTemplate /> }
 		>
 			<DataViews

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -274,6 +274,7 @@ export default function PostList( { postType } ) {
 	return (
 		<Page
 			title={ labels?.name }
+			headingLevel={ 2 }
 			actions={
 				<>
 					{ labels?.add_new_item && canCreateRecord && (

--- a/packages/edit-site/src/components/sidebar-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-global-styles/index.js
@@ -97,6 +97,7 @@ export default function SidebarGlobalStyles() {
 			}
 			className="edit-site-styles"
 			title={ __( 'Styles' ) }
+			headingLevel={ 2 }
 		>
 			<GlobalStylesUIWrapper
 				path={ section }

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -50,7 +50,6 @@ function ConnectorsPage() {
 	return (
 		<Page
 			title={ __( 'Connectors' ) }
-			headingLevel={ 1 }
 			subTitle={ __(
 				'All of your API keys and credentials are stored here and shared across plugins. Configure once and use everywhere.'
 			) }

--- a/routes/font-list/stage.tsx
+++ b/routes/font-list/stage.tsx
@@ -73,7 +73,7 @@ function FontLibraryPage() {
 	}
 
 	return (
-		<Page headingLevel={ 1 } title={ __( 'Fonts' ) }>
+		<Page title={ __( 'Fonts' ) }>
 			<Tabs
 				selectedTabId={ activeTab }
 				onSelect={ ( tabId: string ) => setActiveTab( tabId ) }

--- a/routes/navigation-edit/stage.tsx
+++ b/routes/navigation-edit/stage.tsx
@@ -43,6 +43,7 @@ function NavigationEditStage() {
 
 	return (
 		<Page
+			headingLevel={ 2 }
 			breadcrumbs={
 				<Breadcrumbs
 					items={ [

--- a/routes/navigation-list/stage.tsx
+++ b/routes/navigation-list/stage.tsx
@@ -131,6 +131,7 @@ function NavigationList() {
 		<>
 			<Page
 				title={ __( 'Navigation' ) }
+				headingLevel={ 2 }
 				className="navigation-page"
 				hasPadding={ false }
 				actions={

--- a/routes/pattern-list/stage.tsx
+++ b/routes/pattern-list/stage.tsx
@@ -258,6 +258,7 @@ function PatternList() {
 	return (
 		<Page
 			title={ __( 'Patterns' ) }
+			headingLevel={ 2 }
 			subTitle={ __(
 				'Reusable design elements for your site. Create once, use everywhere.'
 			) }

--- a/routes/post-list/stage.tsx
+++ b/routes/post-list/stage.tsx
@@ -273,6 +273,7 @@ function PostList() {
 	return (
 		<Page
 			title={ postTypeObject.labels?.name }
+			headingLevel={ 2 }
 			subTitle={ postTypeObject.labels?.description }
 			className={ `${ postTypeObject.name.toLowerCase() }-page` }
 			actions={

--- a/routes/styles/stage.tsx
+++ b/routes/styles/stage.tsx
@@ -40,6 +40,7 @@ function Stage() {
 
 	return (
 		<Page
+			headingLevel={ 2 }
 			actions={
 				! isMobileViewport ? (
 					<HStack>

--- a/routes/template-part-list/stage.tsx
+++ b/routes/template-part-list/stage.tsx
@@ -250,6 +250,7 @@ function TemplatePartList() {
 	return (
 		<Page
 			title={ postTypeObject.labels?.name }
+			headingLevel={ 2 }
 			subTitle={ postTypeObject.labels?.description }
 			className="template-part-page"
 			actions={


### PR DESCRIPTION
## What?

Backport [#77617](https://github.com/WordPress/gutenberg/pull/77617) and [#78001](https://github.com/WordPress/gutenberg/pull/78001) to the `wp/7.0` branch.

- #77617: Change the default `headingLevel` of the Admin UI `Page` header from `h2` to `h1`.
- #78001: Drop the inner `<header>` element from the Admin UI `Page` header so it no longer creates a `banner` landmark nested inside the wrapping `region`.

## Why?

The problems first became apparent in WP 7.0 and should be fixed. However, we cannot directly cherry-pick the two PRs into `WP/7.0` because the structure of admin-ui has diverged slightly.

## How?

Cherry-pick from `trunk` and adapt to `wp/7.0`:

## Testing Instructions

### #77617 

Verify the heading level on the affected screens listed in the [original PR description](https://github.com/WordPress/gutenberg/pull/77617):

- Standalone admin pages (`connectors-home`, `font-list`) render as `h1`.
- Site editor pages (`navigation-list`, `navigation-edit`, `pattern-list`, `post-list`, `styles`, `template-part-list`) render as `h2`.

### #78001 

On any page using `Page` (e.g. Settings → Connectors), open the DevTools Accessibility pane and confirm there is no `banner` landmark nested inside the page's `region` landmark.

## Screenshots or screencast

N/A — no visual changes.
