### PR TITLE
Docs: shortcode transforms with wrapped content + rawHandler JSDoc

### DIFF
--- a/docs/reference-guides/block-api/block-transforms.md
+++ b/docs/reference-guides/block-api/block-transforms.md
@@ -337,6 +337,33 @@ transforms: {
 },
 ```
 
+**Example: shortcode with wrapped content to block with InnerBlocks**
+
+Shortcodes that wrap inner content (e.g. `[example]<p>Inner.</p>[/example]`) can be transformed into a block with InnerBlocks by passing `match.shortcode.content` through [`rawHandler`](/packages/blocks/README.md#rawHandler) inside `transform`.
+
+```js
+transforms: {
+    from: [
+        {
+            type: 'shortcode',
+            tag: 'example',
+            transform( attrs, match ) {
+                const innerBlocks = rawHandler( {
+                    HTML: match.shortcode.content || '',
+                } );
+                return createBlock(
+                    'myplugin/example',
+                    { att1: attrs.named.att1 || '' },
+                    innerBlocks
+                );
+            },
+        },
+    ],
+},
+```
+
+`rawHandler` recurses into the content, so nested shortcodes and HTML are converted to blocks the same way pasted content is.
+
 ## `ungroup` blocks
 
 Via the optional `transforms` key of the block configuration, blocks can use the `ungroup` subkey to define the blocks that will replace the block being processed. These new blocks will usually be a subset of the existing inner blocks, but could also include new blocks.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -504,10 +504,18 @@ Undocumented declaration.
 
 Converts an HTML string to known blocks.
 
+_Usage_
+
+```js
+import { rawHandler } from '@wordpress/blocks';
+
+const blocks = rawHandler( { HTML: '<p>Hello</p><p>World</p>' } );
+```
+
 _Parameters_
 
--   _$1_ `{ HTML?: string; }`:
--   _$1.HTML_ `string`: The HTML to convert.
+-   _options_ `{ HTML?: string; }`: Options.
+-   _options.HTML_ `string`: The HTML to convert.
 
 _Returns_
 

--- a/packages/blocks/src/api/raw-handling/index.ts
+++ b/packages/blocks/src/api/raw-handling/index.ts
@@ -33,8 +33,15 @@ export function deprecatedGetPhrasingContentSchema(
 /**
  * Converts an HTML string to known blocks.
  *
- * @param $1
- * @param $1.HTML The HTML to convert.
+ * @param options      Options.
+ * @param options.HTML The HTML to convert.
+ *
+ * @example
+ * ```js
+ * import { rawHandler } from '@wordpress/blocks';
+ *
+ * const blocks = rawHandler( { HTML: '<p>Hello</p><p>World</p>' } );
+ * ```
  *
  * @return A list of blocks.
  */


### PR DESCRIPTION
## What?
Closes #17758.

PR adds shortcode type transforms example that covers wrapped inner content transformation. I've also updated the `rawHandler` example, so that reference is more helpful.

## Testing Instructions
Confirm docs make sense.

## Use of AI Tools

Claude generated a test code example, then adopted it into the docs example.
