### PR TITLE
Taxonomies and Post types: add empty state

### DIFF
--- a/routes/post-types/stage.tsx
+++ b/routes/post-types/stage.tsx
@@ -71,7 +71,9 @@ function PostTypesEmptyState( {
 			{ ! hasSearchOrFilters && (
 				<EmptyState.Actions>
 					<Link
-						href="https://wordpress.org/documentation/article/what-is-post-type/"
+						href={ __(
+							'https://wordpress.org/documentation/article/what-is-post-type/'
+						) }
 						openInNewTab
 					>
 						{ __( 'Learn more about post types' ) }

--- a/routes/post-types/stage.tsx
+++ b/routes/post-types/stage.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import { Button } from '@wordpress/components';
+import { Button, Link } from '@wordpress/components';
 import { DataViews, type View } from '@wordpress/dataviews';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useMemo, useState } from '@wordpress/element';
@@ -60,6 +60,16 @@ function PostTypesEmptyState( { hasSearch }: { hasSearch: boolean } ) {
 					? __( 'Try a different search term.' )
 					: __( 'Create your first post type to get started.' ) }
 			</EmptyState.Description>
+			{ ! hasSearch && (
+				<EmptyState.Actions>
+					<Link
+						href="https://wordpress.org/documentation/article/what-is-post-type/"
+						openInNewTab
+					>
+						{ __( 'Learn more about post types' ) }
+					</Link>
+				</EmptyState.Actions>
+			) }
 		</EmptyState.Root>
 	);
 }

--- a/routes/post-types/stage.tsx
+++ b/routes/post-types/stage.tsx
@@ -7,7 +7,9 @@ import { DataViews, type View } from '@wordpress/dataviews';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { customPostType, search } from '@wordpress/icons';
 import { useNavigate } from '@wordpress/route';
+import { EmptyState } from '@wordpress/ui';
 import {
 	hasArchiveField,
 	hierarchicalField,
@@ -43,6 +45,24 @@ const DEFAULT_VIEW: View = {
 	titleField: 'title',
 	layout: {},
 };
+
+function PostTypesEmptyState( { hasSearch }: { hasSearch: boolean } ) {
+	return (
+		<EmptyState.Root>
+			<EmptyState.Icon icon={ hasSearch ? search : customPostType } />
+			<EmptyState.Title>
+				{ hasSearch
+					? __( 'No post types match your search' )
+					: __( 'No post types yet' ) }
+			</EmptyState.Title>
+			<EmptyState.Description>
+				{ hasSearch
+					? __( 'Try a different search term.' )
+					: __( 'Create your first post type to get started.' ) }
+			</EmptyState.Description>
+		</EmptyState.Root>
+	);
+}
 
 function PostTypesPage() {
 	const navigate = useNavigate();
@@ -105,6 +125,8 @@ function PostTypesPage() {
 		} ),
 		[ totalItems, totalPages ]
 	);
+	const hasSearch = !! view.search?.trim();
+
 	return (
 		<Page
 			title={ __( 'Post Types' ) }
@@ -135,6 +157,7 @@ function PostTypesPage() {
 				onClickItem={ ( item ) =>
 					navigate( { to: `/edit/${ item.id }` } )
 				}
+				empty={ <PostTypesEmptyState hasSearch={ hasSearch } /> }
 			/>
 		</Page>
 	);

--- a/routes/post-types/stage.tsx
+++ b/routes/post-types/stage.tsx
@@ -58,7 +58,7 @@ function PostTypesEmptyState( {
 			/>
 			<EmptyState.Title>
 				{ hasSearchOrFilters
-					? __( 'No results found' )
+					? __( 'No post types found' )
 					: __( 'No post types yet' ) }
 			</EmptyState.Title>
 			<EmptyState.Description>

--- a/routes/post-types/stage.tsx
+++ b/routes/post-types/stage.tsx
@@ -2,14 +2,14 @@
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import { Button, Link } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { DataViews, type View } from '@wordpress/dataviews';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { customPostType, search } from '@wordpress/icons';
 import { useNavigate } from '@wordpress/route';
-import { EmptyState } from '@wordpress/ui';
+import { EmptyState, Link } from '@wordpress/ui';
 import {
 	hasArchiveField,
 	hierarchicalField,
@@ -46,21 +46,29 @@ const DEFAULT_VIEW: View = {
 	layout: {},
 };
 
-function PostTypesEmptyState( { hasSearch }: { hasSearch: boolean } ) {
+function PostTypesEmptyState( {
+	hasSearchOrFilters,
+}: {
+	hasSearchOrFilters: boolean;
+} ) {
 	return (
 		<EmptyState.Root>
-			<EmptyState.Icon icon={ hasSearch ? search : customPostType } />
+			<EmptyState.Icon
+				icon={ hasSearchOrFilters ? search : customPostType }
+			/>
 			<EmptyState.Title>
-				{ hasSearch
-					? __( 'No post types match your search' )
+				{ hasSearchOrFilters
+					? __( 'No results found' )
 					: __( 'No post types yet' ) }
 			</EmptyState.Title>
 			<EmptyState.Description>
-				{ hasSearch
-					? __( 'Try a different search term.' )
+				{ hasSearchOrFilters
+					? __(
+							"Try adjusting your search or filter to find what you're looking for."
+					  )
 					: __( 'Create your first post type to get started.' ) }
 			</EmptyState.Description>
-			{ ! hasSearch && (
+			{ ! hasSearchOrFilters && (
 				<EmptyState.Actions>
 					<Link
 						href="https://wordpress.org/documentation/article/what-is-post-type/"
@@ -136,6 +144,8 @@ function PostTypesPage() {
 		[ totalItems, totalPages ]
 	);
 	const hasSearch = !! view.search?.trim();
+	const hasFilters = !! view.filters?.length;
+	const hasSearchOrFilters = hasSearch || hasFilters;
 
 	return (
 		<Page
@@ -167,7 +177,11 @@ function PostTypesPage() {
 				onClickItem={ ( item ) =>
 					navigate( { to: `/edit/${ item.id }` } )
 				}
-				empty={ <PostTypesEmptyState hasSearch={ hasSearch } /> }
+				empty={
+					<PostTypesEmptyState
+						hasSearchOrFilters={ hasSearchOrFilters }
+					/>
+				}
 			/>
 		</Page>
 	);

--- a/routes/taxonomies/stage.tsx
+++ b/routes/taxonomies/stage.tsx
@@ -2,14 +2,14 @@
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import { Button, Link } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { DataViews, type View } from '@wordpress/dataviews';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { tag, search } from '@wordpress/icons';
 import { useNavigate } from '@wordpress/route';
-import { EmptyState } from '@wordpress/ui';
+import { EmptyState, Link } from '@wordpress/ui';
 import {
 	hierarchicalField,
 	publicField,
@@ -44,21 +44,27 @@ const DEFAULT_VIEW: View = {
 	layout: {},
 };
 
-function TaxonomiesEmptyState( { hasSearch }: { hasSearch: boolean } ) {
+function TaxonomiesEmptyState( {
+	hasSearchOrFilters,
+}: {
+	hasSearchOrFilters: boolean;
+} ) {
 	return (
 		<EmptyState.Root>
-			<EmptyState.Icon icon={ hasSearch ? search : tag } />
+			<EmptyState.Icon icon={ hasSearchOrFilters ? search : tag } />
 			<EmptyState.Title>
-				{ hasSearch
-					? __( 'No taxonomies match your search' )
+				{ hasSearchOrFilters
+					? __( 'No results found' )
 					: __( 'No taxonomies yet' ) }
 			</EmptyState.Title>
 			<EmptyState.Description>
-				{ hasSearch
-					? __( 'Try a different search term.' )
+				{ hasSearchOrFilters
+					? __(
+							"Try adjusting your search or filter to find what you're looking for."
+					  )
 					: __( 'Create your first taxonomy to get started.' ) }
 			</EmptyState.Description>
-			{ ! hasSearch && (
+			{ ! hasSearchOrFilters && (
 				<EmptyState.Actions>
 					<Link
 						href="https://wordpress.org/documentation/article/taxonomies/"
@@ -136,6 +142,8 @@ function TaxonomiesPage() {
 		[ totalItems, totalPages ]
 	);
 	const hasSearch = !! view.search?.trim();
+	const hasFilters = !! view.filters?.length;
+	const hasSearchOrFilters = hasSearch || hasFilters;
 
 	return (
 		<Page
@@ -167,7 +175,11 @@ function TaxonomiesPage() {
 				onClickItem={ ( item ) =>
 					navigate( { to: `/edit/${ item.id }` } )
 				}
-				empty={ <TaxonomiesEmptyState hasSearch={ hasSearch } /> }
+				empty={
+					<TaxonomiesEmptyState
+						hasSearchOrFilters={ hasSearchOrFilters }
+					/>
+				}
 			/>
 		</Page>
 	);

--- a/routes/taxonomies/stage.tsx
+++ b/routes/taxonomies/stage.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import { Button } from '@wordpress/components';
+import { Button, Link } from '@wordpress/components';
 import { DataViews, type View } from '@wordpress/dataviews';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useMemo, useState } from '@wordpress/element';
@@ -58,6 +58,16 @@ function TaxonomiesEmptyState( { hasSearch }: { hasSearch: boolean } ) {
 					? __( 'Try a different search term.' )
 					: __( 'Create your first taxonomy to get started.' ) }
 			</EmptyState.Description>
+			{ ! hasSearch && (
+				<EmptyState.Actions>
+					<Link
+						href="https://wordpress.org/documentation/article/taxonomies/"
+						openInNewTab
+					>
+						{ __( 'Learn more about taxonomies' ) }
+					</Link>
+				</EmptyState.Actions>
+			) }
 		</EmptyState.Root>
 	);
 }

--- a/routes/taxonomies/stage.tsx
+++ b/routes/taxonomies/stage.tsx
@@ -67,7 +67,9 @@ function TaxonomiesEmptyState( {
 			{ ! hasSearchOrFilters && (
 				<EmptyState.Actions>
 					<Link
-						href="https://wordpress.org/documentation/article/taxonomies/"
+						href={ __(
+							'https://wordpress.org/documentation/article/taxonomies/'
+						) }
 						openInNewTab
 					>
 						{ __( 'Learn more about taxonomies' ) }

--- a/routes/taxonomies/stage.tsx
+++ b/routes/taxonomies/stage.tsx
@@ -7,7 +7,7 @@ import { DataViews, type View } from '@wordpress/dataviews';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { customPostType, search } from '@wordpress/icons';
+import { tag, search } from '@wordpress/icons';
 import { useNavigate } from '@wordpress/route';
 import { EmptyState } from '@wordpress/ui';
 import {
@@ -47,7 +47,7 @@ const DEFAULT_VIEW: View = {
 function TaxonomiesEmptyState( { hasSearch }: { hasSearch: boolean } ) {
 	return (
 		<EmptyState.Root>
-			<EmptyState.Icon icon={ hasSearch ? search : customPostType } />
+			<EmptyState.Icon icon={ hasSearch ? search : tag } />
 			<EmptyState.Title>
 				{ hasSearch
 					? __( 'No taxonomies match your search' )

--- a/routes/taxonomies/stage.tsx
+++ b/routes/taxonomies/stage.tsx
@@ -54,7 +54,7 @@ function TaxonomiesEmptyState( {
 			<EmptyState.Icon icon={ hasSearchOrFilters ? search : tag } />
 			<EmptyState.Title>
 				{ hasSearchOrFilters
-					? __( 'No taxonimies found' )
+					? __( 'No taxonomies found' )
 					: __( 'No taxonomies yet' ) }
 			</EmptyState.Title>
 			<EmptyState.Description>

--- a/routes/taxonomies/stage.tsx
+++ b/routes/taxonomies/stage.tsx
@@ -54,7 +54,7 @@ function TaxonomiesEmptyState( {
 			<EmptyState.Icon icon={ hasSearchOrFilters ? search : tag } />
 			<EmptyState.Title>
 				{ hasSearchOrFilters
-					? __( 'No results found' )
+					? __( 'No taxonimies found' )
 					: __( 'No taxonomies yet' ) }
 			</EmptyState.Title>
 			<EmptyState.Description>

--- a/routes/taxonomies/stage.tsx
+++ b/routes/taxonomies/stage.tsx
@@ -7,7 +7,9 @@ import { DataViews, type View } from '@wordpress/dataviews';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { customPostType, search } from '@wordpress/icons';
 import { useNavigate } from '@wordpress/route';
+import { EmptyState } from '@wordpress/ui';
 import {
 	hierarchicalField,
 	publicField,
@@ -41,6 +43,24 @@ const DEFAULT_VIEW: View = {
 	titleField: 'title',
 	layout: {},
 };
+
+function TaxonomiesEmptyState( { hasSearch }: { hasSearch: boolean } ) {
+	return (
+		<EmptyState.Root>
+			<EmptyState.Icon icon={ hasSearch ? search : customPostType } />
+			<EmptyState.Title>
+				{ hasSearch
+					? __( 'No taxonomies match your search' )
+					: __( 'No taxonomies yet' ) }
+			</EmptyState.Title>
+			<EmptyState.Description>
+				{ hasSearch
+					? __( 'Try a different search term.' )
+					: __( 'Create your first taxonomy to get started.' ) }
+			</EmptyState.Description>
+		</EmptyState.Root>
+	);
+}
 
 function TaxonomiesPage() {
 	const navigate = useNavigate();
@@ -105,6 +125,8 @@ function TaxonomiesPage() {
 		} ),
 		[ totalItems, totalPages ]
 	);
+	const hasSearch = !! view.search?.trim();
+
 	return (
 		<Page
 			title={ __( 'Taxonomies' ) }
@@ -135,6 +157,7 @@ function TaxonomiesPage() {
 				onClickItem={ ( item ) =>
 					navigate( { to: `/edit/${ item.id }` } )
 				}
+				empty={ <TaxonomiesEmptyState hasSearch={ hasSearch } /> }
 			/>
 		</Page>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of  https://github.com/WordPress/gutenberg/issues/77600

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The default empty state in DataViews is pretty bland; this improves UX with more elaborate, friendlier copy.

Also adds links to documentation to answer _"what are taxonomies and custom post types?"_

- https://wordpress.org/documentation/article/taxonomies/
-  https://wordpress.org/documentation/article/what-is-post-type/


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use [EmptyState component from DS](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-emptystate--docs). 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

See both taxonomy and post type pages without content.

Try searching with text input so that there are no search results.

Try filters so that there are no results.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
<img width="1085" height="752" alt="Screenshot 2026-05-06 at 14 07 13" src="https://github.com/user-attachments/assets/f2d82108-acac-4307-94dc-40d75811df29" />
<img width="1081" height="753" alt="Screenshot 2026-05-06 at 14 07 02" src="https://github.com/user-attachments/assets/b74f542a-ec7e-4fbf-be28-fdd501d3d627" />


### After

#### Taxonomies
<img width="1130" height="856" alt="Screenshot 2026-05-06 at 14 40 33" src="https://github.com/user-attachments/assets/0c3bde56-5cd5-4f0f-9bf3-9b9ed9c8ae66" />

<img width="1172" height="873" alt="Screenshot 2026-05-06 at 14 26 30" src="https://github.com/user-attachments/assets/8e61fa36-2d13-44e1-becd-aaf9bdddd941" />



#### Post types
<img width="1131" height="857" alt="Screenshot 2026-05-06 at 14 40 21" src="https://github.com/user-attachments/assets/23361b1e-4fad-47c7-af8e-27da9f6a8780" />

<img width="1164" height="872" alt="Screenshot 2026-05-06 at 14 23 19" src="https://github.com/user-attachments/assets/2834c8dd-d039-4e9b-8169-f61bc933f2fd" />



## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
yes