### PR TITLE
Paste: keep `<img>` inside `<a>` when pasting plain-text HTML

### DIFF
--- a/packages/blocks/src/api/raw-handling/test/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/test/paste-handler.js
@@ -263,6 +263,35 @@ describe( 'pasteHandler', () => {
 		} );
 	} );
 
+	it( 'preserves <img> wrapped in <a> when source is plain text only', () => {
+		const result = pasteHandler( {
+			HTML: '',
+			plainText:
+				'<a href="https://example.com/"><img src="https://example.com/img.png" alt="x"/></a>',
+			mode: 'INLINE',
+			tagName: 'p',
+		} );
+
+		expect( console ).toHaveLogged();
+		expect( result ).toBe(
+			'<a href="https://example.com/"><img src="https://example.com/img.png" alt="x"></a>'
+		);
+	} );
+
+	it( 'preserves <img> wrapped in <a> when source is HTML', () => {
+		const result = pasteHandler( {
+			HTML: '<a href="https://example.com/"><img src="https://example.com/img.png" alt="x"/></a>',
+			plainText: '',
+			mode: 'INLINE',
+			tagName: 'p',
+		} );
+
+		expect( console ).toHaveLogged();
+		expect( result ).toBe(
+			'<a href="https://example.com/"><img src="https://example.com/img.png" alt="x"></a>'
+		);
+	} );
+
 	it( 'can handle a video', () => {
 		const [ result ] = pasteHandler( {
 			HTML: '<video controls src="https://example.com/media.mp4" autoplay loop muted controls playsinline preload="auto" poster="https://example.com/media.jpg"></video>',

--- a/packages/dom/src/phrasing-content.js
+++ b/packages/dom/src/phrasing-content.js
@@ -56,17 +56,6 @@ const textContentSchema = {
 	'#text': {},
 };
 
-// Recursion is needed.
-// Possible: strong > em > strong.
-// Impossible: strong > strong.
-const excludedElements = [ '#text', 'br' ];
-Object.keys( textContentSchema )
-	.filter( ( element ) => ! excludedElements.includes( element ) )
-	.forEach( ( tag ) => {
-		const { [ tag ]: removedTag, ...restSchema } = textContentSchema;
-		textContentSchema[ tag ].children = restSchema;
-	} );
-
 /**
  * Embedded content elements.
  *
@@ -130,18 +119,21 @@ const embeddedContentSchema = {
 	},
 };
 
-/**
- * <a> uses the transparent content model. The spec disallows interactive
- * content descendants, which excludes most embedded elements (e.g. <embed>,
- * <object>, <audio controls>, <video controls>). Of the embedded set, <img>
- * is the common non-interactive case worth allowing here.
- *
- * @see https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element
- */
-textContentSchema.a.children = {
-	.../** @type {ContentSchema} */ ( textContentSchema.a.children ),
-	img: embeddedContentSchema.img,
-};
+const excludedElements = [ '#text', 'br' ];
+
+// Wire up children for each text-level wrapper.
+// - Recursion is needed (e.g. strong > em > strong; not strong > strong).
+// - <img> is allowed too: text-level wrappers accept phrasing content, and
+//   <a>'s transparent model permits non-interactive embedded content.
+Object.keys( textContentSchema )
+	.filter( ( element ) => ! excludedElements.includes( element ) )
+	.forEach( ( tag ) => {
+		const { [ tag ]: removedTag, ...restSchema } = textContentSchema;
+		textContentSchema[ tag ].children = {
+			...restSchema,
+			img: embeddedContentSchema.img,
+		};
+	} );
 
 /**
  * Phrasing content elements.

--- a/packages/dom/src/phrasing-content.js
+++ b/packages/dom/src/phrasing-content.js
@@ -131,6 +131,19 @@ const embeddedContentSchema = {
 };
 
 /**
+ * <a> uses the transparent content model. The spec disallows interactive
+ * content descendants, which excludes most embedded elements (e.g. <embed>,
+ * <object>, <audio controls>, <video controls>). Of the embedded set, <img>
+ * is the common non-interactive case worth allowing here.
+ *
+ * @see https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element
+ */
+textContentSchema.a.children = {
+	.../** @type {ContentSchema} */ ( textContentSchema.a.children ),
+	img: embeddedContentSchema.img,
+};
+
+/**
  * Phrasing content elements.
  *
  * @see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content-0

--- a/packages/dom/src/phrasing-content.js
+++ b/packages/dom/src/phrasing-content.js
@@ -119,7 +119,7 @@ const embeddedContentSchema = {
 	},
 };
 
-const excludedElements = [ '#text', 'br' ];
+const excludedElements = [ '#text', 'br', 'wbr' ];
 
 // Wire up children for each text-level wrapper.
 // - Recursion is needed (e.g. strong > em > strong; not strong > strong).


### PR DESCRIPTION
## What?
Closes #17942.

PR fixes pasting (plain text) linked images by allowing `<img>` as a child of `<a>` in the phrasing-content schema used by `removeInvalidHTML` during paste.

## Why?
The HTML spec says links can wrap pictures (the `<a>` element follows the "transparent" content model, which lets it contain whatever its parent allows — including images). Our paste cleanup rules were stricter than the spec and didn't allow `<img>` inside `<a>`, so pasted picture links had their images stripped out. This change aligns our rules with the spec.

## Testing Instructions
1. Open a post or page.
2. Grab the embed code from Flickr (or example HTML) - https://www.flickr.com/photos/mobilene/48726201381/in/dateposted/
3. Paste code into paragraph.
4. Confirm image is preserved, while any unwanted HTML is removed.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Claude for sanity checks. Tested and reviewed manually.

