### PR TITLE
Dashboard experiment: new sidebar icon

### DIFF
--- a/lib/experimental/dashboard-widgets/load.php
+++ b/lib/experimental/dashboard-widgets/load.php
@@ -17,7 +17,7 @@ function gutenberg_register_dashboard_widgets_menu() {
 		'read',
 		'dashboard-wp-admin',
 		'gutenberg_dashboard_wp_admin_render_page',
-		'dashicons-dashboard',
+		'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiBhcmlhLWhpZGRlbj0idHJ1ZSIgZm9jdXNhYmxlPSJmYWxzZSI+PHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMTIgNEw0IDcuOVYyMGgxNlY3LjlMMTIgNHptNi41IDE0LjVIMTRWMTNoLTR2NS41SDUuNVY4LjhMMTIgNS43bDYuNSAzLjF2OS43eiI+PC9wYXRoPjwvc3ZnPg==',
 		1
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/77616

Uses a new "home" icon for the experimental dashboard.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Refresh to the dashboard deserves a new icon; we can feel it out by updating the icon used by experiment.

Uses "[home](https://wordpress.github.io/gutenberg/?path=/story/icons-icon--library&args=filter:home)" from `@wordpress/icons`:

<img width="77" height="76" alt="image" src="https://github.com/user-attachments/assets/c1c21817-cd3f-4dc6-8857-0dc78fefc232" />

The wp-icon library uses outlined styles vs "filled" icon styles used by old Dashicons.

I'm planning to propose an API to use wp-icons in the sidebar alongside dashicons, and so this would work as an example.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Under Gutenberg → Experiments, enable dashboard experiment
- See the sidebar icon before/after
- Confirm hover, selected, unselected states all work well

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

#### Before
<img width="320" height="116" alt="image" src="https://github.com/user-attachments/assets/88e11016-ad1b-4939-b6bb-5c85b77cd810" />


#### After
<img width="449" height="112" alt="image" src="https://github.com/user-attachments/assets/fe314ee8-4949-495a-929d-8f15ab901c1b" />



## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
yes