### PR TITLE
Testing: Add `createRecord` e2e request util

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/blocks.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/blocks.ts
@@ -54,11 +54,5 @@ export async function createBlock(
 	this: RequestUtils,
 	payload: CreateBlockPayload
 ) {
-	const block = await this.rest( {
-		path: '/wp/v2/blocks',
-		method: 'POST',
-		data: { ...payload },
-	} );
-
-	return block;
+	return this.createRecord( 'blocks', { ...payload } );
 }

--- a/packages/e2e-test-utils-playwright/src/request-utils/index.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/index.ts
@@ -32,6 +32,7 @@ import {
 	getNavigationMenus,
 } from './menus';
 import { deleteAllPages, createPage } from './pages';
+import { createRecord } from './records';
 import { resetPreferences } from './preferences';
 import { getSiteSettings, updateSiteSettings } from './site-settings';
 import { deleteAllWidgets, addWidgetBlock } from './widgets';
@@ -134,6 +135,10 @@ class RequestUtils {
 	getMaxBatchSize: typeof getMaxBatchSize = getMaxBatchSize.bind( this );
 	// .bind() drops the generic types. Re-casting it to keep the type signature.
 	batchRest: typeof batchRest = batchRest.bind( this ) as typeof batchRest;
+	// .bind() drops the generic types. Re-casting it to keep the type signature.
+	createRecord: typeof createRecord = createRecord.bind(
+		this
+	) as typeof createRecord;
 	/** @borrows getPluginsMap as this.getPluginsMap */
 	getPluginsMap: typeof getPluginsMap = getPluginsMap.bind( this );
 	/** @borrows activatePlugin as this.activatePlugin */

--- a/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
@@ -63,13 +63,9 @@ export async function createNavigationMenu(
 	this: RequestUtils,
 	menuData: MenuData
 ) {
-	return this.rest( {
-		method: 'POST',
-		path: `/wp/v2/navigation/`,
-		data: {
-			status: 'publish',
-			...menuData,
-		},
+	return this.createRecord< NavigationMenu >( 'navigation', {
+		status: 'publish',
+		...menuData,
 	} );
 }
 

--- a/packages/e2e-test-utils-playwright/src/request-utils/pages.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/pages.ts
@@ -71,11 +71,5 @@ export async function createPage(
 	payload: CreatePagePayload
 ) {
 	// https://developer.wordpress.org/rest-api/reference/pages/#create-a-page
-	const page = await this.rest< Page >( {
-		method: 'POST',
-		path: `/wp/v2/pages`,
-		data: { ...payload },
-	} );
-
-	return page;
+	return this.createRecord< Page >( 'pages', { ...payload } );
 }

--- a/packages/e2e-test-utils-playwright/src/request-utils/posts.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/posts.ts
@@ -65,11 +65,5 @@ export async function createPost(
 	this: RequestUtils,
 	payload: CreatePostPayload
 ) {
-	const post = await this.rest< Post >( {
-		method: 'POST',
-		path: `/wp/v2/posts`,
-		data: { ...payload },
-	} );
-
-	return post;
+	return this.createRecord< Post >( 'posts', { ...payload } );
 }

--- a/packages/e2e-test-utils-playwright/src/request-utils/records.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/records.ts
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import type { RequestUtils } from './index';
+
+/**
+ * Create a new record at the given REST base path.
+ *
+ * Generic seeding helper for per-type wrappers (createPost, createPage, etc.).
+ * Call directly for content types without a dedicated wrapper:
+ *
+ *     requestUtils.createRecord( 'user-taxonomies', { ... } );
+ *
+ * @param this
+ * @param restBase REST base, appended to `/wp/v2/`.
+ * @param payload  Record attributes.
+ */
+export async function createRecord< T = unknown >(
+	this: RequestUtils,
+	restBase: string,
+	payload: Record< string, unknown >
+) {
+	return this.rest< T >( {
+		method: 'POST',
+		path: `/wp/v2/${ restBase }`,
+		data: payload,
+	} );
+}

--- a/test/e2e/specs/admin/user-taxonomies.spec.js
+++ b/test/e2e/specs/admin/user-taxonomies.spec.js
@@ -7,35 +7,28 @@ const SETTINGS_PAGE_PATH = 'options-general.php';
 const TAXONOMIES_PAGE_QUERY = 'page=taxonomies-wp-admin';
 const TAXONOMIES_REST_BASE = 'user-taxonomies';
 
-// TODO: once the user-taxonomies feature stabilizes, promote this seeding
-// helper into packages/e2e-test-utils-playwright/src/request-utils/ alongside
-// createPost / createPage so other specs can reuse it.
 // Seeds all visibility booleans so the form's `toFormData` reads each toggle
 // as a defined value — the form contract requires every flag present, to
 // avoid passing `undefined` for unchecked toggles and relying on defaults
 // in register_taxonomy.
 async function createUserTaxonomy( requestUtils ) {
-	return requestUtils.rest( {
-		path: `/wp/v2/${ TAXONOMIES_REST_BASE }`,
-		method: 'POST',
-		data: {
-			title: 'Genres',
-			slug: 'genre',
-			status: 'publish',
-			object_type: [ 'post' ],
-			config: {
-				labels: { singular_name: 'Genre' },
-				public: true,
-				hierarchical: false,
-				publicly_queryable: true,
-				show_ui: true,
-				show_in_menu: true,
-				show_in_nav_menus: true,
-				show_tagcloud: true,
-				show_in_quick_edit: true,
-				show_admin_column: false,
-				show_in_rest: true,
-			},
+	return requestUtils.createRecord( TAXONOMIES_REST_BASE, {
+		title: 'Genres',
+		slug: 'genre',
+		status: 'publish',
+		object_type: [ 'post' ],
+		config: {
+			labels: { singular_name: 'Genre' },
+			public: true,
+			hierarchical: false,
+			publicly_queryable: true,
+			show_ui: true,
+			show_in_menu: true,
+			show_in_nav_menus: true,
+			show_tagcloud: true,
+			show_in_quick_edit: true,
+			show_admin_column: false,
+			show_in_rest: true,
 		},
 	} );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
see: https://github.com/WordPress/gutenberg/pull/77998/changes#r3194246751

The new content types experiment introduces user-defined post types and taxonomies, and their e2e specs need to seed records of arbitrary REST bases. Today there's no shared helper for that. This PR adds the missing util so any post type or custom resource can be seeded with one call, without another per-type wrapper. 



 Three of the existing per-type seeding wrappers (`createPost`, `createPage`, `createBlock`) and `createNavigationMenu` are identical except for the REST base. This adds a generic `requestUtils.createRecord<T>(restBase, payload)` and converts those four to one-line wrappers over it. Specs without a dedicated wrapper (e.g. user taxonomies, user post types) can now seed records with `requestUtils.createRecord('user-taxonomies', { ... })` directly, and the existing typed payloads (`CreatePostPayload`, etc.) are preserved.

## Notes
  No matching `deleteRecord` / `deleteAllRecords` is added: `deleteAllPosts(postType)` is already polymorphic on the REST base, so the only flaw on the delete side is the name. Kept out of this PR.

  `createComment` and `createClassicMenu` are intentionally untouched: they have real per-type logic (auto-author lookup, batched menu-item creation) and don't fit the generic shape.

## Testing Instructions
1. CI should be green



## Use of AI Tools
Opus 4.7 with direction, changes and review
