### PR TITLE
Dashboard: add `WidgetDashboard.Actions` compound

### DIFF
--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -40,7 +40,6 @@ function Dashboard() {
 		>
 			<Page
 				title={ __( 'Dashboard' ) }
-				headingLevel={ 1 }
 				actions={ <WidgetDashboard.Actions /> }
 			>
 				<WidgetDashboard.Widgets />

--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -28,14 +28,24 @@ function Dashboard() {
 
 	const widgetTypes = useWidgetTypes();
 
+	const [ editMode, setEditMode ] = useState( false );
+
 	return (
-		<Page title={ __( 'Dashboard' ) } headingLevel={ 1 }>
-			<WidgetDashboard
-				layout={ layout }
-				onLayoutChange={ setLayout }
-				widgetTypes={ widgetTypes }
-			/>
-		</Page>
+		<WidgetDashboard
+			layout={ layout }
+			onLayoutChange={ setLayout }
+			widgetTypes={ widgetTypes }
+			editMode={ editMode }
+			onEditChange={ setEditMode }
+		>
+			<Page
+				title={ __( 'Dashboard' ) }
+				headingLevel={ 1 }
+				actions={ <WidgetDashboard.Actions /> }
+			>
+				<WidgetDashboard.Widgets />
+			</Page>
+		</WidgetDashboard>
 	);
 }
 

--- a/routes/dashboard/widget-dashboard/README.md
+++ b/routes/dashboard/widget-dashboard/README.md
@@ -90,7 +90,11 @@ Renders its children only when `layout` is empty. Pair it with `<WidgetDashboard
 
 Edit-mode toggle: a "Customize" button while `editMode` is off and a "Done" button while it is on. Clicking either fires `onEditChange` with the toggled value. Returns `null` when the dashboard is mounted without `onEditChange`, so surfaces that don't expose edit mode can keep `Actions` in their tree unconditionally.
 
+`<Page>` from `@wordpress/admin-ui` exposes an `actions` slot used across admin surfaces (DataViews, WidgetDashboard, …). Plug `Actions` straight into it:
+
 ```tsx
+import { Page } from '@wordpress/admin-ui';
+
 <WidgetDashboard
 	layout={ layout }
 	onLayoutChange={ setLayout }
@@ -98,13 +102,16 @@ Edit-mode toggle: a "Customize" button while `editMode` is off and a "Done" butt
 	editMode={ editMode }
 	onEditChange={ setEditMode }
 >
-	<header>
-		<h1>{ __( 'My Dashboard' ) }</h1>
-		<WidgetDashboard.Actions />
-	</header>
-	<WidgetDashboard.Widgets />
+	<Page
+		title={ __( 'My Dashboard' ) }
+		actions={ <WidgetDashboard.Actions /> }
+	>
+		<WidgetDashboard.Widgets />
+	</Page>
 </WidgetDashboard>
 ```
+
+`<Page>` is optional. The compound renders inside any container, so a bare `<header>` or custom chrome works just as well.
 
 ## Authoring widgets
 

--- a/routes/dashboard/widget-dashboard/README.md
+++ b/routes/dashboard/widget-dashboard/README.md
@@ -58,7 +58,7 @@ When `true`, the grid enables drag and resize. Defaults to `false`.
 
 #### `onEditChange`: `( next: boolean ) => void`
 
-Optional. Called when edit mode toggles via a future `WidgetDashboard.Actions` compound.
+Optional. Called when edit mode toggles via `WidgetDashboard.Actions` (or any consumer-built toggle). When omitted, `WidgetDashboard.Actions` renders nothing.
 
 #### `resolveWidgetModule`: `( moduleId: string ) => Promise< { default: ComponentType } >`
 
@@ -85,6 +85,26 @@ Per-instance wrapper. Provides widget identity to the render tree via context an
 #### `<WidgetDashboard.NoWidgetsState>`
 
 Renders its children only when `layout` is empty. Pair it with `<WidgetDashboard.Widgets />` so the empty state shows up in place of the grid until widgets are added.
+
+#### `<WidgetDashboard.Actions />`
+
+Edit-mode toggle: a "Customize" button while `editMode` is off and a "Done" button while it is on. Clicking either fires `onEditChange` with the toggled value. Returns `null` when the dashboard is mounted without `onEditChange`, so surfaces that don't expose edit mode can keep `Actions` in their tree unconditionally.
+
+```tsx
+<WidgetDashboard
+	layout={ layout }
+	onLayoutChange={ setLayout }
+	widgetTypes={ widgetTypes }
+	editMode={ editMode }
+	onEditChange={ setEditMode }
+>
+	<header>
+		<h1>{ __( 'My Dashboard' ) }</h1>
+		<WidgetDashboard.Actions />
+	</header>
+	<WidgetDashboard.Widgets />
+</WidgetDashboard>
+```
 
 ## Authoring widgets
 

--- a/routes/dashboard/widget-dashboard/components/actions/actions.tsx
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.tsx
@@ -25,9 +25,26 @@ import { useDashboardInternalContext } from '../../context/dashboard-context';
 export function Actions(): React.ReactNode {
 	const { editMode, onEditChange } = useDashboardInternalContext();
 
-	const handleClick = useCallback( () => {
+	const handleEditMode = useCallback( () => {
 		onEditChange?.( ! editMode );
 	}, [ editMode, onEditChange ] );
+
+	const handleInsertWidget = useCallback( () => {
+		// eslint-disable-next-line no-console
+		console.log( 'insert widget' ); // TODO: Implement widget insertion
+	}, [] );
+
+	const handleCancel = useCallback( () => {
+		// eslint-disable-next-line no-console
+		console.log( 'cancel' ); // TODO: Implement cancel\
+		onEditChange?.( false );
+	}, [ onEditChange ] );
+
+	const handleDone = useCallback( () => {
+		// eslint-disable-next-line no-console
+		console.log( 'done' ); // TODO: Implement done
+		onEditChange?.( false );
+	}, [ onEditChange ] );
 
 	if ( ! onEditChange ) {
 		return null;
@@ -41,7 +58,7 @@ export function Actions(): React.ReactNode {
 						variant="minimal"
 						tone="brand"
 						size="compact"
-						onClick={ handleClick }
+						onClick={ handleInsertWidget }
 					>
 						{ __( 'Add Widgets' ) }
 					</Button>
@@ -49,7 +66,7 @@ export function Actions(): React.ReactNode {
 						variant="minimal"
 						tone="brand"
 						size="compact"
-						onClick={ handleClick }
+						onClick={ handleCancel }
 					>
 						{ __( 'Cancel' ) }
 					</Button>
@@ -57,7 +74,7 @@ export function Actions(): React.ReactNode {
 						variant="solid"
 						tone="brand"
 						size="compact"
-						onClick={ handleClick }
+						onClick={ handleDone }
 					>
 						{ __( 'Done' ) }
 					</Button>
@@ -67,7 +84,7 @@ export function Actions(): React.ReactNode {
 					variant="outline"
 					tone="brand"
 					size="compact"
-					onClick={ handleClick }
+					onClick={ handleEditMode }
 				>
 					{ __( 'Customize' ) }
 				</Button>

--- a/routes/dashboard/widget-dashboard/components/actions/actions.tsx
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.tsx
@@ -1,0 +1,77 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Button, Stack } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import { useDashboardInternalContext } from '../../context/dashboard-context';
+
+/**
+ * Renders the dashboard's edit-mode toggle. Shows a "Customize" button while
+ * `editMode` is off and a "Done" button while it is on; clicking either fires
+ * `onEditChange` with the toggled value.
+ *
+ * Returns `null` when the dashboard is mounted without `onEditChange` so
+ * surfaces that don't expose edit mode can keep `Actions` in their tree
+ * unconditionally.
+ *
+ * @return {React.ReactNode} - The Actions component.
+ */
+export function Actions(): React.ReactNode {
+	const { editMode, onEditChange } = useDashboardInternalContext();
+
+	const handleClick = useCallback( () => {
+		onEditChange?.( ! editMode );
+	}, [ editMode, onEditChange ] );
+
+	if ( ! onEditChange ) {
+		return null;
+	}
+
+	return (
+		<Stack direction="row" gap="sm">
+			{ editMode ? (
+				<>
+					<Button
+						variant="minimal"
+						tone="brand"
+						size="compact"
+						onClick={ handleClick }
+					>
+						{ __( 'Add Widgets' ) }
+					</Button>
+					<Button
+						variant="minimal"
+						tone="brand"
+						size="compact"
+						onClick={ handleClick }
+					>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						variant="solid"
+						tone="brand"
+						size="compact"
+						onClick={ handleClick }
+					>
+						{ __( 'Done' ) }
+					</Button>
+				</>
+			) : (
+				<Button
+					variant="outline"
+					tone="brand"
+					size="compact"
+					onClick={ handleClick }
+				>
+					{ __( 'Customize' ) }
+				</Button>
+			) }
+		</Stack>
+	);
+}

--- a/routes/dashboard/widget-dashboard/components/actions/actions.tsx
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.tsx
@@ -60,7 +60,7 @@ export function Actions(): React.ReactNode {
 						size="compact"
 						onClick={ handleInsertWidget }
 					>
-						{ __( 'Add Widgets' ) }
+						{ __( 'Add widgets' ) }
 					</Button>
 					<Button
 						variant="minimal"

--- a/routes/dashboard/widget-dashboard/components/actions/index.ts
+++ b/routes/dashboard/widget-dashboard/components/actions/index.ts
@@ -1,0 +1,1 @@
+export { Actions } from './actions';

--- a/routes/dashboard/widget-dashboard/test/actions.test.tsx
+++ b/routes/dashboard/widget-dashboard/test/actions.test.tsx
@@ -78,6 +78,10 @@ describe( 'WidgetDashboard.Actions', () => {
 		await userEvent.click( screen.getByRole( 'button', { name: 'Done' } ) );
 		expect( onEditChange ).toHaveBeenLastCalledWith( false );
 		expect( onEditChange ).toHaveBeenCalledTimes( 2 );
+
+		// TODO: drop once Done has its own committed behavior; today it logs.
+		// eslint-disable-next-line jest/no-standalone-expect
+		expect( console ).toHaveLogged( 'done' );
 	} );
 
 	it( 'renders nothing when onEditChange is not provided', () => {

--- a/routes/dashboard/widget-dashboard/test/actions.test.tsx
+++ b/routes/dashboard/widget-dashboard/test/actions.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { WidgetDashboard } from '../widget-dashboard';
+import type { DashboardWidget, WidgetType } from '../types';
+
+const widgetTypes: WidgetType[] = [];
+const layout: DashboardWidget[] = [];
+
+interface HarnessProps {
+	initialEditMode?: boolean;
+	onEditChange?: ( next: boolean ) => void;
+}
+
+function Harness( { initialEditMode = false, onEditChange }: HarnessProps ) {
+	const [ editMode, setEditMode ] = useState( initialEditMode );
+
+	return (
+		<WidgetDashboard
+			layout={ layout }
+			onLayoutChange={ () => {} }
+			widgetTypes={ widgetTypes }
+			editMode={ editMode }
+			onEditChange={ ( next ) => {
+				setEditMode( next );
+				onEditChange?.( next );
+			} }
+		>
+			<WidgetDashboard.Actions />
+		</WidgetDashboard>
+	);
+}
+
+describe( 'WidgetDashboard.Actions', () => {
+	it( 'renders the Customize button when editMode is false', () => {
+		render( <Harness /> );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Customize' } )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Done' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the Done button when editMode is true', () => {
+		render( <Harness initialEditMode /> );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Done' } )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Customize' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'fires onEditChange with the toggled value on click', async () => {
+		const onEditChange = jest.fn();
+		render( <Harness onEditChange={ onEditChange } /> );
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Customize' } )
+		);
+		expect( onEditChange ).toHaveBeenLastCalledWith( true );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Done' } ) );
+		expect( onEditChange ).toHaveBeenLastCalledWith( false );
+		expect( onEditChange ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'renders nothing when onEditChange is not provided', () => {
+		render(
+			<WidgetDashboard
+				layout={ layout }
+				onLayoutChange={ () => {} }
+				widgetTypes={ widgetTypes }
+			>
+				<WidgetDashboard.Actions />
+			</WidgetDashboard>
+		);
+
+		expect(
+			screen.queryByRole( 'button', { name: 'Customize' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Done' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'throws when used outside a WidgetDashboard subtree', () => {
+		const spy = jest
+			.spyOn( console, 'error' )
+			.mockImplementation( () => {} );
+
+		expect( () => render( <WidgetDashboard.Actions /> ) ).toThrow(
+			/Dashboard compound used outside a WidgetDashboard subtree/
+		);
+
+		spy.mockRestore();
+	} );
+} );

--- a/routes/dashboard/widget-dashboard/widget-dashboard.tsx
+++ b/routes/dashboard/widget-dashboard/widget-dashboard.tsx
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { WidgetDashboardProvider } from './context/dashboard-context';
+import { Actions } from './components/actions';
 import { Widget } from './components/widget';
 import { Widgets } from './components/widgets';
 import type { WidgetDashboardProps } from './types';
@@ -58,11 +59,12 @@ export const WidgetDashboard = Object.assign(
 				{ children ?? (
 					<>
 						<NoWidgetsState />
+						<Actions />
 						<Widgets />
 					</>
 				) }
 			</WidgetDashboardProvider>
 		);
 	},
-	{ Widgets, Widget, NoWidgetsState }
+	{ Actions, Widgets, Widget, NoWidgetsState }
 );


### PR DESCRIPTION
## What?

Adds `WidgetDashboard.Actions` as a compound component of the dashboard rendering engine. It reads `editMode` and `onEditChange` from the internal `WidgetDashboard` context and renders the edit-mode toggle:

- `editMode === false`: a "Customize" button that opens edit mode.
- `editMode === true`: "Add Widgets", "Cancel", and "Done" buttons.

Returns `null` when the dashboard is mounted without `onEditChange`, so consumers that don't expose edit mode can keep `Actions` in their tree unconditionally. The compound is also mounted in the dashboard route's `Page` header via the `actions` slot.

Part of #77616 #77626

## Why?

The dashboard shell needs an actions area for the Customize / Done flow. Shipping it as a compound keeps it stateless and locally composed: any surface using `WidgetDashboard` can drop `<WidgetDashboard.Actions />` wherever the actions belong (header, sidebar, custom chrome) without prop-drilling edit-mode state through the tree.

## How?

- New compound under `routes/dashboard/widget-dashboard/components/actions/`. Reads from `useDashboardInternalContext()` to access `editMode` and `onEditChange`.
- Per-button handlers (`handleEditMode`, `handleInsertWidget`, `handleCancel`, `handleDone`). "Customize" toggles edit mode; "Cancel" and "Done" close it. "Add Widgets", "Cancel", and "Done" log their intent to console as TODO placeholders pending the inserter and revert flows.
- `Button` is imported from `@wordpress/ui` with a single `eslint-disable-next-line @wordpress/use-recommended-components` so the route's dep graph stays aligned with the rest of the package (already on `@wordpress/ui` for `Stack` / `EmptyState`).
- The default render in `widget-dashboard.tsx` now includes `<Actions />` between `NoWidgetsState` and `Widgets`, so consumers that pass no `children` get a working surface out of the box.
- `routes/dashboard/stage.tsx` lifts `editMode` state at the page level and feeds it into `WidgetDashboard`; `<WidgetDashboard.Actions />` is then passed to `<Page actions={...} />`.
- README documents the public Customize / Done contract; placeholder buttons intentionally not documented yet.

## Testing

1. `npm run wp-env start` and navigate to the Dashboard.
2. Verify the "Customize" button appears in the page header.
3. Click "Customize": grid enters edit mode (drag handles visible); buttons swap to "Add Widgets / Cancel / Done".
4. Click "Done" or "Cancel": grid exits edit mode; "Customize" reappears.
5. `npm run test:unit -- routes/dashboard/widget-dashboard` → 15 passing tests across 4 suites.


https://github.com/user-attachments/assets/41ad3787-36db-43a2-939c-c9f492c2fa30




## Follow-ups

- [ ] Wire "Add Widgets" to the Inserter compound when it lands.
- [ ] Wire "Cancel" to a revert / staging-state flow.