### PR TITLE
Embed: Tighten raw URL transform isMatch

### DIFF
--- a/packages/block-library/src/embed/transforms.js
+++ b/packages/block-library/src/embed/transforms.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
+import { isURL, getFilename } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -22,10 +23,22 @@ const transforms = {
 	from: [
 		{
 			type: 'raw',
-			isMatch: ( node ) =>
-				node.nodeName === 'P' &&
-				/^\s*(https?:\/\/\S+)\s*$/i.test( node.textContent ) &&
-				node.textContent?.match( /https/gi )?.length === 1,
+			isMatch: ( node ) => {
+				if ( node.nodeName !== 'P' ) {
+					return false;
+				}
+				const trimmed = node.textContent.trim();
+				if (
+					! isURL( trimmed ) ||
+					! /^https:\/\//i.test( trimmed ) ||
+					trimmed.match( /https:\/\//gi )?.length !== 1
+				) {
+					return false;
+				}
+				// Reject URLs whose pathname ends in a file extension.
+				// Embed providers don't use such URLs
+				return ! /\.[a-z0-9]+$/i.test( getFilename( trimmed ) );
+			},
 			transform: ( node ) => {
 				const url = rewriteXToTwitter( node.textContent.trim() );
 				return createBlock( EMBED_BLOCK, {

--- a/packages/block-library/src/embed/transforms.js
+++ b/packages/block-library/src/embed/transforms.js
@@ -35,9 +35,11 @@ const transforms = {
 				) {
 					return false;
 				}
-				// Reject URLs whose pathname ends in a file extension.
-				// Embed providers don't use such URLs
-				return ! /\.[a-z0-9]+$/i.test( getFilename( trimmed ) );
+				// Reject URLs whose filename ends in a file extension,
+				// except common page extensions used by permalinks.
+				return ! /\.(?!(html?|php)$)[a-z0-9]+$/i.test(
+					getFilename( trimmed ) || ''
+				);
 			},
 			transform: ( node ) => {
 				const url = rewriteXToTwitter( node.textContent.trim() );


### PR DESCRIPTION
## What?
Part of #74734.

PR improves the `type: 'raw'` `isMatch` for the embed block transform:

- Replace hand-rolled URL regex with `isURL()` from `@wordpress/url` for proper URL validation (rejects malformed inputs like `https:// foo`).
- Restrict to `https://` only — `http://` embeds aren't supported.
- Generalize the duplicate-URL guard to count `https://` prefixes (was counting `https`, also fixes brittle matching).
- Skip transformation when the URL points to a file (image, audio, video, document, etc.) by checking the pathname for a trailing extension via `getFilename()`. Such URLs should be treated as file/image/video/audio blocks, not embeds.
- Preserve the existing `<br>`-joined URL guard — concatenated URLs with no whitespace still get rejected.

## Testing Instructions
1. Create a post.
2. Try pasting the image URL into the paragraph.
3. It shouldn't convert to an embed block.
4. Try pasting any embeddable link - `https://www.youtube.com/watch?v=dQw4w9WgXcQ`
5. It should create an embed block

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Claude to validate regexes.