### PR TITLE
enhancement: add contextual list view labels for specialized blocks

### DIFF
--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -10,6 +10,7 @@ import {
 /**
  * Internal dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { store as blockEditorStore } from '../../store';
 
 /**
@@ -28,6 +29,13 @@ import { store as blockEditorStore } from '../../store';
  * @param {string|undefined} props.context       The context to pass to `getBlockLabel`.
  * @return {?string} Block title.
  */
+
+const CONTEXTUAL_BLOCK_LABELS = {
+	'core/query-no-results': {
+		'core/paragraph': __( 'Query: No results text' ),
+	},
+};
+
 export default function useBlockDisplayTitle( {
 	clientId,
 	maximumLength,
@@ -39,7 +47,7 @@ export default function useBlockDisplayTitle( {
 				return null;
 			}
 
-			const { getBlockName, getBlockAttributes } =
+			const { getBlockName, getBlockAttributes, getBlockParents } =
 				select( blockEditorStore );
 			const { getBlockType, getActiveBlockVariation } =
 				select( blocksStore );
@@ -59,7 +67,22 @@ export default function useBlockDisplayTitle( {
 
 			const match = getActiveBlockVariation( blockName, attributes );
 			// Label will fallback to the title if no label is defined for the current label context.
-			return match?.title || blockType.title;
+			let blockTitleToReturn = match?.title || blockType.title;
+
+			if ( context === 'list-view' ) {
+				const parents = getBlockParents( clientId );
+				if ( parents?.length > 0 ) {
+					const parentClientId = parents[ parents.length - 1 ];
+					const parentName = getBlockName( parentClientId );
+					if (
+						CONTEXTUAL_BLOCK_LABELS[ parentName ]?.[ blockName ]
+					) {
+						blockTitleToReturn =
+							CONTEXTUAL_BLOCK_LABELS[ parentName ][ blockName ];
+					}
+				}
+			}
+			return blockTitleToReturn;
 		},
 		[ clientId, context ]
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of the effort in #71833 

<!-- In a few words, what is the PR actually doing? -->
Adds contextual block labels in List View for specialized content blocks used within parent container blocks.
This PR introduces support for overriding generic block titles based on their immediate parent context. As an initial implementation, paragraphs inside core/query-no-results are labeled as:

> Query: No results text

instead of the generic:

> Paragraph

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, content-only editing surfaces display generic block names even when those blocks serve a very specific purpose within a parent block. This can make editing less intuitive, especially in patterns and content-only modes.

This change improves clarity by surfacing contextual labels that better reflect the role of a block within its parent structure.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Added a CONTEXTUAL_BLOCK_LABELS mapping in use-block-display-title.
- Detects the immediate parent block in List View context.
- Overrides the default block title when a contextual mapping exists.
- Preserves existing priority order for:
    - custom block labels
    - variation titles
    - default block titles

### Example
#### Before:
> Paragraph

#### After (inside core/query-no-results):
> Query: No results text

## Testing Instructions

1. Insert a Query Loop block.
2. Add or select the "No results" state.
3. Open List View.
4. Verify the paragraph inside Query No Results is labeled:
5. Query: No results text
6. Verify normal paragraph blocks outside this context still display as Paragraph.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1256" height="694" alt="Screenshot 2026-05-06 at 8 06 38 PM" src="https://github.com/user-attachments/assets/f66eecd1-4c75-4b5e-a5c0-743c2b691762" />|<img width="1256" height="694" alt="Screenshot 2026-05-06 at 8 04 50 PM" src="https://github.com/user-attachments/assets/e0ddb61a-0d3f-41d9-ba50-4a49f6993e11" />|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Claude AI was used to draft this PR. All changes are manually reviewed by the author.