### PR TITLE
Display block CSS classes in the Advanced panel header

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/advanced-controls-panel.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/advanced-controls-panel.js
@@ -6,6 +6,7 @@ import {
 	__experimentalUseSlotFills as useSlotFills,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,6 +15,7 @@ import {
 	default as InspectorControls,
 	InspectorAdvancedControls,
 } from '../inspector-controls';
+import { store as blockEditorStore } from '../../store';
 import { PrivateInspectorControlsAllowedBlocks } from '../inspector-controls/groups';
 
 const AdvancedControls = ( { initialOpen = false } ) => {
@@ -24,6 +26,15 @@ const AdvancedControls = ( { initialOpen = false } ) => {
 	const hasFills = Boolean( fills && fills.length );
 	const hasPrivateFills = Boolean( privateFills && privateFills.length );
 
+	const blockClassName = useSelect( ( select ) => {
+		const { getSelectedBlockClientId, getBlockAttributes } =
+			select( blockEditorStore );
+		const clientId = getSelectedBlockClientId();
+		return clientId
+			? getBlockAttributes( clientId )?.className ?? null
+			: null;
+	} );
+
 	if ( ! hasFills && ! hasPrivateFills ) {
 		return null;
 	}
@@ -32,6 +43,7 @@ const AdvancedControls = ( { initialOpen = false } ) => {
 		<PanelBody
 			className="block-editor-block-inspector__advanced"
 			title={ __( 'Advanced' ) }
+			blockClasses={ blockClassName }
 			initialOpen={ initialOpen }
 		>
 			<InspectorControls.Slot group="advanced" />

--- a/packages/components/src/panel/body.tsx
+++ b/packages/components/src/panel/body.tsx
@@ -136,7 +136,10 @@ const PanelBodyTitle = forwardRef(
 						/>
 					</span>
 					{ title }
-					<span className="block-editor-block-inspector__advanced-button__css-class-name">
+					<span
+						title={ blockClasses }
+						className="block-editor-block-inspector__advanced-button__css-class-name"
+					>
 						{ blockClasses }
 					</span>
 					{ icon && (

--- a/packages/components/src/panel/body.tsx
+++ b/packages/components/src/panel/body.tsx
@@ -26,6 +26,7 @@ export function UnforwardedPanelBody(
 	ref: React.ForwardedRef< HTMLDivElement >
 ) {
 	const {
+		blockClasses,
 		buttonProps = {},
 		children,
 		className,
@@ -90,6 +91,7 @@ export function UnforwardedPanelBody(
 				isOpened={ Boolean( isOpened ) }
 				onClick={ handleOnToggle }
 				title={ title }
+				blockClasses={ blockClasses }
 				{ ...buttonProps }
 			/>
 			{ typeof children === 'function'
@@ -102,6 +104,7 @@ export function UnforwardedPanelBody(
 const PanelBodyTitle = forwardRef(
 	(
 		{
+			blockClasses = '',
 			isOpened,
 			icon,
 			title,
@@ -133,6 +136,9 @@ const PanelBodyTitle = forwardRef(
 						/>
 					</span>
 					{ title }
+					<span className="block-editor-block-inspector__advanced-button__css-class-name">
+						{ blockClasses }
+					</span>
 					{ icon && (
 						<Icon
 							icon={ icon }

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -169,3 +169,15 @@
 .components-panel .circle-picker {
 	padding-bottom: 20px;
 }
+
+.block-editor-block-inspector__advanced-button__css-class-name {
+	background-color: $gray-100;
+	color: $gray-800;
+	padding: 2px $grid-unit-10;
+	border-radius: $radius-small;
+	font-size: $font-size-small;
+	font-weight: 400;
+	line-height: $font-line-height-small;
+	position: absolute;
+	right: $grid-unit-60;
+}

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -180,4 +180,8 @@
 	line-height: $font-line-height-small;
 	position: absolute;
 	right: $grid-unit-60;
+	max-width: 50%;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }

--- a/packages/components/src/panel/types.ts
+++ b/packages/components/src/panel/types.ts
@@ -45,6 +45,10 @@ export type PanelRowProps = {
 
 export type PanelBodyProps = {
 	/**
+	 * The block classes.
+	 */
+	blockClasses?: string;
+	/**
 	 * Props that are passed to the `Button` component in title within the
 	 * `PanelBody`.
 	 *
@@ -101,6 +105,10 @@ export type PanelBodyProps = {
 };
 
 export type PanelBodyTitleProps = Omit< ButtonAsButtonProps, 'icon' > & {
+	/**
+	 * The block classes.
+	 */
+	blockClasses?: string;
 	/**
 	 * An icon to be shown next to the title.
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #71168 

This PR surfaces the custom CSS class name(s) of a selected block directly in the header of the "Advanced" Inspector panel.

## Why?
It is currently difficult for users to know which blocks have custom CSS classes applied without manually opening the Advanced panel for every single block. While the original issue proposed adding this indicator to the List View, however, the List View is already heavily populated with metadata. 

As discussed in the issue, this PR uses to the author's alternative suggestion, displaying the applied class in the "Advanced" tab panel header. This keeps the List View clean while still saving users a click, similar to how iOS settings cells display active states before being opened.

## How?
Updated `AdvancedControls` to select the current block's `className` attribute via `useSelect`.
Introduced a new `blockClasses` prop to the `PanelBody` and `PanelBodyTitle` components.
Added a `<span>` element within the `PanelBodyTitle` button to render the class name.

## Testing Instructions
1. Open a post or page in the block editor.
2. Insert any block (e.g., a Heading or Paragraph block).
3. Open the block settings sidebar and expand the **Advanced** panel.
4. Type a custom class name (e.g., `my-custom-highlight`) into the **Additional CSS class(es)** field.
5. Collapse the **Advanced** panel.
6. Verify that `my-custom-highlight` is now visible on the right side of the closed "Advanced" panel header.
7. Select a different block without a custom class and verify the indicator disappears.
8. **PoC Stress Test:** Add a ridiculously long string of CSS classes to ensure the new badge doesn't break the layout or push the chevron icon off-screen & on hover all the classes are shown.

## Screenshots or screencast <!-- if applicable -->
|Inspector|Editor|
|-|-|
|<img width="562" height="1032" alt="image" src="https://github.com/user-attachments/assets/1b8e317b-d8a6-4484-a4ab-b8e092ff1cd5" /><br><img width="564" height="228" alt="image" src="https://github.com/user-attachments/assets/ef03b220-e9ae-4bd2-8c3d-393f61c8efda" />|<img width="2926" height="1276" alt="image" src="https://github.com/user-attachments/assets/a493fb2b-e768-4372-8b54-6053b559b858" />|
