### PR TITLE
Core Data: Share parsed blocks cache between resolver and editor hook

### DIFF
--- a/packages/core-data/src/hooks/use-entity-block-editor.js
+++ b/packages/core-data/src/hooks/use-entity-block-editor.js
@@ -11,9 +11,9 @@ import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
 import { STORE_NAME } from '../name';
 import useEntityId from './use-entity-id';
 import { updateFootnotesFromMeta } from '../footnotes';
+import { parsedBlocksCache, getCacheKey } from '../parsed-blocks-cache';
 
 const EMPTY_ARRAY = [];
-const parsedBlocksCache = new Map();
 
 /**
  * Hook that returns block content getters and setters for
@@ -69,7 +69,7 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 
 		// Cache parsed blocks by entity identity. Store the content
 		// alongside the blocks so we can validate it hasn't changed.
-		const cacheKey = `${ kind }:${ name }:${ id }`;
+		const cacheKey = getCacheKey( kind, name, id );
 		const cached = parsedBlocksCache.get( cacheKey );
 		let _blocks;
 

--- a/packages/core-data/src/parsed-blocks-cache.js
+++ b/packages/core-data/src/parsed-blocks-cache.js
@@ -1,0 +1,12 @@
+/**
+ * Shared cache of blocks parsed from an entity's `content` string, keyed by
+ * `kind:name:id`. Populated both eagerly by the `getEntityRecord` resolver
+ * (when the sync manager parses content for transient edits) and lazily by
+ * `useEntityBlockEditor`. The stored `content` string acts as a validator so
+ * stale entries are discarded when the underlying record changes.
+ */
+export const parsedBlocksCache = new Map();
+
+export function getCacheKey( kind, name, id ) {
+	return `${ kind }:${ name }:${ id }`;
+}

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -28,6 +28,7 @@ import {
 } from './utils';
 import { fetchBlockPatterns } from './fetch';
 import { restoreSelection, getSelectionHistory } from './utils/crdt-selection';
+import { parsedBlocksCache, getCacheKey } from './parsed-blocks-cache';
 
 /**
  * Requests authors from the REST API.
@@ -179,6 +180,18 @@ export const getEntityRecord =
 						recordWithTransients[ propName ] =
 							transientConfig.read( recordWithTransients );
 					} );
+
+				// Share the parsed blocks with `useEntityBlockEditor` so the
+				// editor doesn't re-parse the same `content` string.
+				if (
+					recordWithTransients.blocks &&
+					typeof recordWithTransients.content?.raw === 'string'
+				) {
+					parsedBlocksCache.set( getCacheKey( kind, name, key ), {
+						content: recordWithTransients.content.raw,
+						blocks: recordWithTransients.blocks,
+					} );
+				}
 
 				// Load the entity record for syncing. Do not await promise.
 				void getSyncManager()?.load(


### PR DESCRIPTION
## What?

When the post editor loads, `parse()` runs twice over the same `content` string:

1. In `useEntityBlockEditor` (`packages/core-data/src/hooks/use-entity-block-editor.js:79`) — to feed the editor's block array.
2. In `blocksTransientEdits.read` (`packages/core-data/src/entities.js:31`), invoked from the `getEntityRecord` resolver (`packages/core-data/src/resolvers.js:180`) — to seed the sync manager with transient blocks.

This PR extracts the hook's existing per-entity parse cache into a shared module and populates it from the resolver, so the hook reuses the parsed blocks instead of re-parsing.

## Why?

`parse()` on post content is one of the more expensive operations during editor load, and we were paying for it twice for every post that goes through the sync-enabled resolver path (which is all numeric-keyed post types). The two call sites parse the same string reference (`record.content.raw`), so deduplication is safe.

## How?

- New `packages/core-data/src/parsed-blocks-cache.js` exporting the shared `Map` and a `getCacheKey( kind, name, id )` helper.
- `useEntityBlockEditor` imports the cache instead of owning a private one; lookup logic is unchanged (`cached.content === content` validator; falls back to `parse()` on miss).
- The resolver, after `transientConfig.read()` parses content for the sync manager, writes `{ content, blocks }` into the shared cache keyed by `kind:name:id`. When the hook later mounts with no edits, the cached entry hits and the second parse is skipped.

The transient `read()` itself is unchanged — it has no entity context, but the resolver does, so populating from there is the simplest threading.

### Edge cases

- Sync disabled / non-numeric key / query fetch: resolver branch doesn't run; hook parses as before.
- `editedBlocks` already exists: hook returns those without consulting the cache.
- Record refetched with a new content string: validator mismatches, hook re-parses and rewrites the entry.

## Testing Instructions

1. `npm run test:unit -- packages/core-data/src/test/resolvers.js packages/core-data/src/test/entity-provider.js` — should pass (39 tests).
2. Open a long post in the editor with React DevTools / a `parse` profiler attached and confirm `parse()` runs once on initial load instead of twice.
3. Verify normal editing flows still work: typing, undo/redo, autosave, refresh-restore, switching between posts.

### Testing Instructions for Keyboard

No UI changes; standard keyboard editing in the post editor should be unaffected.

## Screenshots or screencast

N/A — no UI changes.

## Use of AI Tools

This PR was authored with Claude Code (Opus 4.7). I reviewed the analysis, the proposed approach, and every line of the diff before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)