### PR TITLE
Content Types experiment: Restore focus to Save button after creating a post type or taxonomy

### DIFF
--- a/packages/content-types/src/post-types/edit.tsx
+++ b/packages/content-types/src/post-types/edit.tsx
@@ -12,7 +12,7 @@ import {
 	type Field,
 	type Form,
 } from '@wordpress/dataviews';
-import { useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useNavigate, useParams } from '@wordpress/route';
@@ -73,6 +73,7 @@ type PostTypePageProps = {
 	breadcrumbLabel: string;
 	subTitle: string;
 	onSaved?: ( saved: PostTypeFormData & { id: number } ) => void;
+	focusSaveButton?: boolean;
 };
 
 export function PostTypeEdit() {
@@ -80,6 +81,7 @@ export function PostTypeEdit() {
 	const navigate = useNavigate();
 	const isAddMode = id === NEW_ID;
 	const postTypeId = parseInt( id, 10 );
+	const [ justCreated, setJustCreated ] = useState( false );
 	const record = useSelect(
 		( select ) => {
 			return (
@@ -106,10 +108,10 @@ export function PostTypeEdit() {
 				subTitle: __(
 					'Define a new post type. Fill in the essentials under General; expand Labels to customize.'
 				),
-				onSaved: ( saved ) =>
-					navigate( {
-						to: `${ POST_TYPES_PATH }/${ saved.id }`,
-					} ),
+				onSaved: ( saved ) => {
+					setJustCreated( true );
+					navigate( { to: `${ POST_TYPES_PATH }/${ saved.id }` } );
+				},
 		  }
 		: {
 				...commonProps,
@@ -118,6 +120,7 @@ export function PostTypeEdit() {
 				subTitle: __(
 					'Edit this post type. Expand the Labels section to adjust labels.'
 				),
+				focusSaveButton: justCreated,
 		  };
 
 	// key remounts PostTypePage when navigating between records so in-flight
@@ -132,8 +135,18 @@ function PostTypePage( {
 	breadcrumbLabel,
 	subTitle,
 	onSaved,
+	focusSaveButton,
 }: PostTypePageProps ) {
 	const [ data, setData ] = useState< PostTypeFormData >( initialData );
+	const saveButtonRef = useRef< HTMLButtonElement >( null );
+
+	// Restore focus to the Save button after navigating from add mode.
+	useEffect( () => {
+		if ( focusSaveButton ) {
+			saveButtonRef.current?.focus();
+		}
+	}, [ focusSaveButton ] );
+
 	const [ isSaving, setIsSaving ] = useState( false );
 	const originalSlug = ! isAddMode ? initialData.slug : undefined;
 	const slugField = useSlugField( originalSlug, data.slug );
@@ -278,6 +291,7 @@ function PostTypePage( {
 			subTitle={ subTitle }
 			actions={
 				<Button
+					ref={ saveButtonRef }
 					__next40pxDefaultSize
 					variant="primary"
 					size="compact"

--- a/packages/content-types/src/taxonomies/edit.tsx
+++ b/packages/content-types/src/taxonomies/edit.tsx
@@ -12,7 +12,7 @@ import {
 	type Field,
 	type Form,
 } from '@wordpress/dataviews';
-import { useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useNavigate, useParams } from '@wordpress/route';
@@ -72,6 +72,7 @@ type TaxonomyPageProps = {
 	breadcrumbLabel: string;
 	subTitle: string;
 	onSaved?: ( saved: TaxonomyFormData & { id: number } ) => void;
+	focusSaveButton?: boolean;
 };
 
 export function TaxonomyEdit() {
@@ -79,6 +80,7 @@ export function TaxonomyEdit() {
 	const navigate = useNavigate();
 	const isAddMode = id === NEW_ID;
 	const taxonomyId = parseInt( id, 10 );
+	const [ justCreated, setJustCreated ] = useState( false );
 	const record = useSelect(
 		( select ) => {
 			return (
@@ -105,10 +107,10 @@ export function TaxonomyEdit() {
 				subTitle: __(
 					'Define a new taxonomy. Fill in the essentials under General; expand Labels to customize.'
 				),
-				onSaved: ( saved ) =>
-					navigate( {
-						to: `${ TAXONOMIES_PATH }/${ saved.id }`,
-					} ),
+				onSaved: ( saved ) => {
+					setJustCreated( true );
+					navigate( { to: `${ TAXONOMIES_PATH }/${ saved.id }` } );
+				},
 		  }
 		: {
 				...commonProps,
@@ -117,6 +119,7 @@ export function TaxonomyEdit() {
 				subTitle: __(
 					'Edit this taxonomy. Expand the Labels section to adjust labels.'
 				),
+				focusSaveButton: justCreated,
 		  };
 
 	// key remounts TaxonomyPage when navigating between records so in-flight
@@ -131,8 +134,18 @@ function TaxonomyPage( {
 	breadcrumbLabel,
 	subTitle,
 	onSaved,
+	focusSaveButton,
 }: TaxonomyPageProps ) {
 	const [ data, setData ] = useState< TaxonomyFormData >( initialData );
+	const saveButtonRef = useRef< HTMLButtonElement >( null );
+
+	// Restore focus to the Save button after navigating from add mode.
+	useEffect( () => {
+		if ( focusSaveButton ) {
+			saveButtonRef.current?.focus();
+		}
+	}, [ focusSaveButton ] );
+
 	const [ isSaving, setIsSaving ] = useState( false );
 	const originalSlug = ! isAddMode ? initialData.slug : undefined;
 	const slugField = useSlugField( originalSlug, data.slug );
@@ -289,6 +302,7 @@ function TaxonomyPage( {
 			subTitle={ subTitle }
 			actions={
 				<Button
+					ref={ saveButtonRef }
 					__next40pxDefaultSize
 					variant="primary"
 					size="compact"


### PR DESCRIPTION
## What?
Closes #78011 

Restores keyboard focus to the Save button after a new post type or taxonomy is successfully created in the Content Types experiment.

## Why?
When a user creates a post type, the form navigates from Add mode (`/edit/new`) to Edit mode (`/edit/:id`). Because `PostTypePage` is rendered with `key={ id }`, this navigation causes a full remount and the "Create" button DOM node is destroyed and a new "Save" button is created, leaving focus undefined. Keyboard and screen reader users lose their place in the UI with no indication of where to continue.

## How?
A `justCreated` state variable is set to `true` before `navigate()` is called within the `onSaved` callback. Since `PostTypePage` and `TaxonomyPage` are rendered with `key={id}`, navigating causes the component to unmount and remount, which resets any local state within those components.

To preserve this information across navigation, the `justCreated` state is maintained in the parent component (`PostTypeEdit` or `TaxonomyEdit`). This allows the state to persist through the remount and be passed to the newly mounted page component via the `focusSaveButton` prop.

Within `PostTypePage` and `TaxonomyPage`, a `useRef` is attached to the Save button, and a `useEffect` hook calls `.focus()` on that button whenever `focusSaveButton` is `true`. This ensures the Save button receives focus immediately after the page is recreated.

I found a similar pattern already used in `ai-plugin-callout.tsx`, where the `justActivated` state and an `actionButtonRef` are used to restore focus to a button after an async action completes, so I followed the same approach.

## Testing Instructions
1. Enable the **Content Types** experiment under Gutenberg → Experiments.

#### Post Types
1. Navigate to **Settings → Post Types**.
2. Click **Add post type**.
3. Fill in the required fields.
5. Click **Create**.
6. Verify that focus lands on the **Save** button immediately after the taxonomy is created.

#### Taxonomies
1. Navigate to **Settings → Taxonomies**.
2. Click **Add taxonomy**.
3. Fill in the **Plural name**, **Singular name** and **Post type key** fields.
4. Click **Create**.
5. Verify that focus lands on the **Save** button immediately after the post type is created.

### Testing Instructions for Keyboard
1. Complete the steps above using keyboard only (Tab to navigate, Enter/Space to activate).
2. After pressing Enter on **Create**, confirm the **Save** button is visibly focused and Tab continues from it without requiring a mouse click first.

## Screenshots or screencast 
### Before
https://github.com/user-attachments/assets/6c694771-d5b1-4815-b884-e37b84f07d3d

### After
https://github.com/user-attachments/assets/4fd66189-3737-43ed-a474-226c5d9586ad


## Use of AI Tools
I used Claude Code to review the code.
