### PR TITLE
Edit Site: Migrate Page Templates duplicate dialog from `Modal` to `@wordpress/ui` `Dialog`

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Migrate the registered-template duplicate dialog in Page Templates from `@wordpress/components` `Modal` to `@wordpress/ui` `Dialog`. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))
+
 ## 6.45.0 (2026-04-29)
 
 ## 6.44.0 (2026-04-15)

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -371,8 +371,14 @@ export default function PageTemplates() {
 							// Clear the cached template only after the exit
 							// animation finishes — keeps the modal contents
 							// rendered while the dialog slides out so the
-							// inner DataForm doesn't flash empty.
-							setSelectedRegisteredTemplate( false );
+							// inner DataForm doesn't flash empty. The
+							// functional setter guards against a stale
+							// "complete" callback firing after the user has
+							// already re-opened the dialog with a different
+							// template (mid-animation re-open race).
+							setSelectedRegisteredTemplate( ( prev ) =>
+								isDuplicateOpen ? prev : false
+							);
 						}
 					} }
 				>
@@ -383,7 +389,14 @@ export default function PageTemplates() {
 						</Dialog.Header>
 						<Dialog.Content>
 							{ selectedRegisteredTemplate && (
+								// Keying on the template id ensures the
+								// RenderModal remounts with a fresh internal
+								// `useState` initializer if the user clicks a
+								// different row while the dialog is still
+								// closing — otherwise the previous template's
+								// title would persist into the new session.
 								<duplicateAction.RenderModal
+									key={ selectedRegisteredTemplate.id }
 									items={ [ selectedRegisteredTemplate ] }
 									closeModal={ () =>
 										setIsDuplicateOpen( false )

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -16,7 +16,8 @@ import { addQueryArgs } from '@wordpress/url';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEvent } from '@wordpress/compose';
 import { useView } from '@wordpress/views';
-import { Modal } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Dialog } from '@wordpress/ui';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -54,6 +55,7 @@ export default function PageTemplates() {
 	const [ selection, setSelection ] = useState( [ postId ] );
 	const [ selectedRegisteredTemplate, setSelectedRegisteredTemplate ] =
 		useState( false );
+	const [ isDuplicateOpen, setIsDuplicateOpen ] = useState( false );
 	const defaultView = DEFAULT_VIEW;
 	const activeViewOverrides = useMemo(
 		() => getActiveViewOverridesForTab( activeView ),
@@ -342,6 +344,7 @@ export default function PageTemplates() {
 				onClickItem={ ( item ) => {
 					if ( typeof item.id === 'string' ) {
 						setSelectedRegisteredTemplate( item );
+						setIsDuplicateOpen( true );
 					} else {
 						history.navigate(
 							`/${ item.type }/${ item.id }?canvas=edit`
@@ -359,17 +362,37 @@ export default function PageTemplates() {
 						: false
 				}
 			/>
-			{ selectedRegisteredTemplate && duplicateAction && (
-				<Modal
-					title={ __( 'Duplicate' ) }
-					onRequestClose={ () => setSelectedRegisteredTemplate() }
-					size="small"
+			{ duplicateAction && (
+				<Dialog.Root
+					open={ isDuplicateOpen }
+					onOpenChange={ setIsDuplicateOpen }
+					onOpenChangeComplete={ ( isOpen ) => {
+						if ( ! isOpen ) {
+							// Clear the cached template only after the exit
+							// animation finishes — keeps the modal contents
+							// rendered while the dialog slides out so the
+							// inner DataForm doesn't flash empty.
+							setSelectedRegisteredTemplate( false );
+						}
+					} }
 				>
-					<duplicateAction.RenderModal
-						items={ [ selectedRegisteredTemplate ] }
-						closeModal={ () => setSelectedRegisteredTemplate() }
-					/>
-				</Modal>
+					<Dialog.Popup size="small">
+						<Dialog.Header>
+							<Dialog.Title>{ __( 'Duplicate' ) }</Dialog.Title>
+							<Dialog.CloseIcon />
+						</Dialog.Header>
+						<Dialog.Content>
+							{ selectedRegisteredTemplate && (
+								<duplicateAction.RenderModal
+									items={ [ selectedRegisteredTemplate ] }
+									closeModal={ () =>
+										setIsDuplicateOpen( false )
+									}
+								/>
+							) }
+						</Dialog.Content>
+					</Dialog.Popup>
+				</Dialog.Root>
 			) }
 		</Page>
 	);


### PR DESCRIPTION
## What

Migrates the duplicate-registered-template dialog in Edit Site's Page Templates list from `@wordpress/components` \`Modal\` to the `@wordpress/ui` \`Dialog\` primitive.

## Why

This is the only DataViews-style action surface in Edit Site that wasn't already migrated to \`Dialog\`, because the registered-template duplicate flow is hosted by edit-site directly rather than through a DataViews item-action menu. Bringing it onto \`Dialog\` removes a leftover \`Modal\` consumer and makes its behaviour consistent with the rest of the migration sweep (animations, portal, dismissal semantics).

## How

- Wrap \`<duplicateAction.RenderModal>\` in \`Dialog.Root\` / \`Dialog.Popup\` (with \`size=\"small\"\` to mirror the previous CSS-driven width).
- Keep the dialog mounted in the React tree and toggled via \`open\` / \`onOpenChange\`, so the entry/exit animation plays.
- Bind teardown of the cached \`selectedRegisteredTemplate\` to \`onOpenChangeComplete\` (with a defensive functional setter that no-ops if the user re-opens mid-animation), and key the rendered modal on the template id so a fast row-to-row re-open remounts the inner form cleanly instead of carrying over stale state.

## Testing instructions

1. Edit Site → Patterns → Templates → on a registered template's row open the actions menu and choose "Duplicate".
2. Verify the dialog opens with animation, the form is editable, "Save" creates the duplicate and closes the dialog, and Cancel/Escape dismiss it.
3. While the dialog is closing, click "Duplicate" on a different registered template — the dialog should re-open populated with the new template's data, not the previous one.

## Context

This is one of 5 PRs that split #76837. Independent of the others; can be reviewed/merged on its own.