### PR TITLE
Editor: Migrate `PostActions` modal from `Modal` to `@wordpress/ui` `Dialog`

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 -   Migrate the post-actions modal from `@wordpress/components` `Modal` to `@wordpress/ui` `Dialog`, hoisting `Dialog.Root` / `Dialog.Trigger` to each menu item to drop the parent-owned active-action state. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))
 -   Post-actions modals now respect `action.modalSize` and `action.modalFocusOnMount`, mirroring the `@wordpress/dataviews` implementation. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))
+-   Post-actions menu trigger composes `Dialog.Trigger` with the existing menu-item component via render-prop, removing the `setOpen`-on-click duplication. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))
 
 ## 14.45.0 (2026-04-29)
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Migrate the post-actions modal from `@wordpress/components` `Modal` to `@wordpress/ui` `Dialog`, hoisting `Dialog.Root` / `Dialog.Trigger` to each menu item to drop the parent-owned active-action state. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))
+
 ## 14.45.0 (2026-04-29)
 
 ## 14.44.0 (2026-04-15)

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Post-actions confirmations registered with `hideModalHeader` (e.g. trash) now use `role="alertdialog"` and no longer dismiss on backdrop click — matching their alert semantics and bringing parity with the equivalent dataviews flow. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))
+-   Post-actions modals now honour `action.modalHeader` when supplied as a function (called with the selected items), matching the `@wordpress/dataviews` contract. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))
+-   Post-actions menu items now propagate `action.disabled` to the underlying `Menu.Item`, matching the `@wordpress/dataviews` behaviour. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))
+
 ### Code Quality
 
 -   Migrate the post-actions modal from `@wordpress/components` `Modal` to `@wordpress/ui` `Dialog`, hoisting `Dialog.Root` / `Dialog.Trigger` to each menu item to drop the parent-owned active-action state. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))
+-   Post-actions modals now respect `action.modalSize` and `action.modalFocusOnMount`, mirroring the `@wordpress/dataviews` implementation. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))
 
 ## 14.45.0 (2026-04-29)
 

--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useRegistry, useSelect } from '@wordpress/data';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	privateApis as componentsPrivateApis,
@@ -12,6 +12,7 @@ import {
 import { Dialog, VisuallyHidden } from '@wordpress/ui';
 import { moreVertical } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -20,6 +21,9 @@ import { unlock } from '../../lock-unlock';
 import { usePostActions } from './actions';
 
 const { Menu, kebabCase } = unlock( componentsPrivateApis );
+
+const FIRST_INPUT_SELECTOR =
+	'input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled])';
 
 export default function PostActions( { postType, postId, onActionPerformed } ) {
 	const { item, permissions } = useSelect(
@@ -77,16 +81,20 @@ export default function PostActions( { postType, postId, onActionPerformed } ) {
 	);
 }
 
-// From now on all the functions on this file are copied as from the dataviews packages,
-// The editor packages should not be using the dataviews packages directly,
-// and the dataviews package should not be using the editor packages directly,
-// so duplicating the code here seems like the least bad option.
+// The remaining helpers in this file (`DropdownMenuItemTrigger`,
+// `ModalActionMenuItem`, `ActionModal`, `ActionsDropdownMenuGroup`,
+// `mapModalSize`, `useMapFocusOnMount`) are intentionally duplicated from
+// `@wordpress/dataviews` (`packages/dataviews/src/components/dataviews-item-actions/`
+// and `packages/dataviews/src/hooks/use-map-focus-on-mount.ts`). The editor
+// package can't depend on dataviews and dataviews can't depend on the editor,
+// so duplication is the least-bad option until the action-modal API is
+// extracted to a neutral package — a tracked follow-up on the parent PR.
 
 function DropdownMenuItemTrigger( { action, onClick, items } ) {
 	const label =
 		typeof action.label === 'string' ? action.label : action.label( items );
 	return (
-		<Menu.Item onClick={ onClick }>
+		<Menu.Item disabled={ action.disabled } onClick={ onClick }>
 			<Menu.ItemLabel>{ label }</Menu.ItemLabel>
 		</Menu.Item>
 	);
@@ -108,7 +116,10 @@ function ModalActionMenuItem( { action, items } ) {
 			onOpenChange={ setOpen }
 			disablePointerDismissal={ action.hideModalHeader }
 		>
-			<Menu.Item render={ <Dialog.Trigger /> }>
+			<Menu.Item
+				disabled={ action.disabled }
+				render={ <Dialog.Trigger /> }
+			>
 				<Menu.ItemLabel>{ label }</Menu.ItemLabel>
 			</Menu.Item>
 			<ActionModal
@@ -120,10 +131,60 @@ function ModalActionMenuItem( { action, items } ) {
 	);
 }
 
+// Mirrors `mapModalSize` in `@wordpress/dataviews` — translates the public
+// `action.modalSize` value (including the deprecated `'fill'`) into the
+// `Dialog.Popup` size prop.
+function mapModalSize( size ) {
+	if ( size === 'fill' ) {
+		deprecated( "modalSize: 'fill'", {
+			since: '15.0.0',
+			alternative: "'stretch'",
+		} );
+		return 'stretch';
+	}
+	return size ?? 'medium';
+}
+
+// Mirrors `useMapFocusOnMount` in `@wordpress/dataviews` — translates the
+// legacy `action.modalFocusOnMount` values onto Base UI's `initialFocus`
+// prop. Smart-default behavior (skip the close icon, focus the first
+// content tabbable) covers `'firstElement'` and `'firstContentElement'`;
+// `'firstInputElement'` resolves to the first focusable input/select/textarea
+// inside `contentRef`.
+function useMapFocusOnMount( focusOnMount, contentRef ) {
+	const focusFirstInput = useCallback( () => {
+		if ( contentRef.current ) {
+			const target =
+				contentRef.current.querySelector( FIRST_INPUT_SELECTOR );
+			if ( target ) {
+				return target;
+			}
+		}
+		return true;
+	}, [ contentRef ] );
+
+	if ( focusOnMount === false ) {
+		return false;
+	}
+	if ( focusOnMount === 'firstInputElement' ) {
+		return focusFirstInput;
+	}
+	return true;
+}
+
 // Renders the popup half of a post-actions modal. Must be wrapped in a
 // `<Dialog.Root>` that owns the open lifecycle (paired with
 // `<Dialog.Trigger>` at the call site, e.g. `ModalActionMenuItem`).
+//
+// Mirrors `ActionModal` in `@wordpress/dataviews` — see comment block
+// above `DropdownMenuItemTrigger` for the duplication rationale.
 export function ActionModal( { action, items, closeModal } ) {
+	const contentRef = useRef( null );
+	const initialFocus = useMapFocusOnMount(
+		action.modalFocusOnMount ?? true,
+		contentRef
+	);
+
 	const label =
 		typeof action.label === 'string' ? action.label : action.label( items );
 	const modalHeader =
@@ -133,11 +194,12 @@ export function ActionModal( { action, items, closeModal } ) {
 	const title = modalHeader || label;
 	return (
 		<Dialog.Popup
-			size="medium"
+			size={ mapModalSize( action.modalSize ) }
 			className={ `editor-action-modal editor-action-modal__${ kebabCase(
 				action.id
 			) }` }
 			portal={ <Dialog.Portal className="editor-action-modal__portal" /> }
+			initialFocus={ initialFocus }
 			{ ...( action.hideModalHeader && {
 				role: 'alertdialog',
 			} ) }
@@ -152,7 +214,7 @@ export function ActionModal( { action, items, closeModal } ) {
 					<Dialog.CloseIcon />
 				</Dialog.Header>
 			) }
-			<Dialog.Content>
+			<Dialog.Content ref={ contentRef }>
 				<action.RenderModal items={ items } closeModal={ closeModal } />
 			</Dialog.Content>
 		</Dialog.Popup>

--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -2,7 +2,13 @@
  * WordPress dependencies
  */
 import { useRegistry, useSelect } from '@wordpress/data';
-import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
+import {
+	forwardRef,
+	useCallback,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	privateApis as componentsPrivateApis,
@@ -90,15 +96,29 @@ export default function PostActions( { postType, postId, onActionPerformed } ) {
 // so duplication is the least-bad option until the action-modal API is
 // extracted to a neutral package — a tracked follow-up on the parent PR.
 
-function DropdownMenuItemTrigger( { action, onClick, items } ) {
-	const label =
-		typeof action.label === 'string' ? action.label : action.label( items );
-	return (
-		<Menu.Item disabled={ action.disabled } onClick={ onClick }>
-			<Menu.ItemLabel>{ label }</Menu.ItemLabel>
-		</Menu.Item>
-	);
-}
+// Forwards `ref` and unknown props onto `Menu.Item`, so the same
+// component works both as a direct callable (parent supplies `onClick`)
+// and as the body of a render-prop composition (e.g.
+// `<DropdownMenuItemTrigger render={ <Dialog.Trigger /> } />`). Mirrors
+// dataviews' `MenuItemTrigger`.
+const DropdownMenuItemTrigger = forwardRef(
+	( { action, items, render, ...rest }, ref ) => {
+		const label =
+			typeof action.label === 'string'
+				? action.label
+				: action.label( items );
+		return (
+			<Menu.Item
+				ref={ ref }
+				disabled={ action.disabled }
+				render={ render }
+				{ ...rest }
+			>
+				<Menu.ItemLabel>{ label }</Menu.ItemLabel>
+			</Menu.Item>
+		);
+	}
+);
 
 // Wraps a single modal action as a menu item that opens the action's
 // dialog. Owns the dialog's open state locally so each modal action is
@@ -108,20 +128,17 @@ function DropdownMenuItemTrigger( { action, onClick, items } ) {
 function ModalActionMenuItem( { action, items } ) {
 	const [ open, setOpen ] = useState( false );
 	const closeModal = useCallback( () => setOpen( false ), [] );
-	const label =
-		typeof action.label === 'string' ? action.label : action.label( items );
 	return (
 		<Dialog.Root
 			open={ open }
 			onOpenChange={ setOpen }
 			disablePointerDismissal={ action.hideModalHeader }
 		>
-			<Menu.Item
-				disabled={ action.disabled }
+			<DropdownMenuItemTrigger
+				action={ action }
+				items={ items }
 				render={ <Dialog.Trigger /> }
-			>
-				<Menu.ItemLabel>{ label }</Menu.ItemLabel>
-			</Menu.Item>
+			/>
 			<ActionModal
 				action={ action }
 				items={ items }

--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -2,13 +2,14 @@
  * WordPress dependencies
  */
 import { useRegistry, useSelect } from '@wordpress/data';
-import { useState, useMemo } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	privateApis as componentsPrivateApis,
 	Button,
-	Modal,
 } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Dialog, VisuallyHidden } from '@wordpress/ui';
 import { moreVertical } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -21,8 +22,6 @@ import { usePostActions } from './actions';
 const { Menu, kebabCase } = unlock( componentsPrivateApis );
 
 export default function PostActions( { postType, postId, onActionPerformed } ) {
-	const [ activeModalAction, setActiveModalAction ] = useState( null );
-
 	const { item, permissions } = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord, getEntityRecordPermissions } =
@@ -55,36 +54,26 @@ export default function PostActions( { postType, postId, onActionPerformed } ) {
 	}, [ allActions, itemWithPermissions ] );
 
 	return (
-		<>
-			<Menu placement="bottom-end">
-				<Menu.TriggerButton
-					render={
-						<Button
-							size="small"
-							icon={ moreVertical }
-							label={ __( 'Actions' ) }
-							disabled={ ! actions.length }
-							accessibleWhenDisabled
-							className="editor-all-actions-button"
-						/>
-					}
-				/>
-				<Menu.Popover>
-					<ActionsDropdownMenuGroup
-						actions={ actions }
-						items={ [ itemWithPermissions ] }
-						setActiveModalAction={ setActiveModalAction }
+		<Menu placement="bottom-end">
+			<Menu.TriggerButton
+				render={
+					<Button
+						size="small"
+						icon={ moreVertical }
+						label={ __( 'Actions' ) }
+						disabled={ ! actions.length }
+						accessibleWhenDisabled
+						className="editor-all-actions-button"
 					/>
-				</Menu.Popover>
-			</Menu>
-			{ !! activeModalAction && (
-				<ActionModal
-					action={ activeModalAction }
+				}
+			/>
+			<Menu.Popover>
+				<ActionsDropdownMenuGroup
+					actions={ actions }
 					items={ [ itemWithPermissions ] }
-					closeModal={ () => setActiveModalAction( null ) }
 				/>
-			) }
-		</>
+			</Menu.Popover>
+		</Menu>
 	);
 }
 
@@ -103,39 +92,92 @@ function DropdownMenuItemTrigger( { action, onClick, items } ) {
 	);
 }
 
-export function ActionModal( { action, items, closeModal } ) {
+// Wraps a single modal action as a menu item that opens the action's
+// dialog. Owns the dialog's open state locally so each modal action is
+// self-contained: the surrounding parent doesn't need a "which action is
+// active" piece of state. Mirrors `ModalActionMenuItem` in
+// `@wordpress/dataviews`.
+function ModalActionMenuItem( { action, items } ) {
+	const [ open, setOpen ] = useState( false );
+	const closeModal = useCallback( () => setOpen( false ), [] );
 	const label =
 		typeof action.label === 'string' ? action.label : action.label( items );
 	return (
-		<Modal
-			title={ action.modalHeader || label }
-			__experimentalHideHeader={ !! action.hideModalHeader }
-			onRequestClose={ closeModal ?? ( () => {} ) }
-			focusOnMount="firstContentElement"
-			size="medium"
-			overlayClassName={ `editor-action-modal editor-action-modal__${ kebabCase(
-				action.id
-			) }` }
+		<Dialog.Root
+			open={ open }
+			onOpenChange={ setOpen }
+			disablePointerDismissal={ action.hideModalHeader }
 		>
-			<action.RenderModal items={ items } closeModal={ closeModal } />
-		</Modal>
+			<Menu.Item render={ <Dialog.Trigger /> }>
+				<Menu.ItemLabel>{ label }</Menu.ItemLabel>
+			</Menu.Item>
+			<ActionModal
+				action={ action }
+				items={ items }
+				closeModal={ closeModal }
+			/>
+		</Dialog.Root>
 	);
 }
 
-function ActionsDropdownMenuGroup( { actions, items, setActiveModalAction } ) {
+// Renders the popup half of a post-actions modal. Must be wrapped in a
+// `<Dialog.Root>` that owns the open lifecycle (paired with
+// `<Dialog.Trigger>` at the call site, e.g. `ModalActionMenuItem`).
+export function ActionModal( { action, items, closeModal } ) {
+	const label =
+		typeof action.label === 'string' ? action.label : action.label( items );
+	const modalHeader =
+		typeof action.modalHeader === 'function'
+			? action.modalHeader( items )
+			: action.modalHeader;
+	const title = modalHeader || label;
+	return (
+		<Dialog.Popup
+			size="medium"
+			className={ `editor-action-modal editor-action-modal__${ kebabCase(
+				action.id
+			) }` }
+			portal={ <Dialog.Portal className="editor-action-modal__portal" /> }
+			{ ...( action.hideModalHeader && {
+				role: 'alertdialog',
+			} ) }
+		>
+			{ action.hideModalHeader ? (
+				<VisuallyHidden
+					render={ <Dialog.Title>{ title }</Dialog.Title> }
+				/>
+			) : (
+				<Dialog.Header>
+					<Dialog.Title>{ title }</Dialog.Title>
+					<Dialog.CloseIcon />
+				</Dialog.Header>
+			) }
+			<Dialog.Content>
+				<action.RenderModal items={ items } closeModal={ closeModal } />
+			</Dialog.Content>
+		</Dialog.Popup>
+	);
+}
+
+function ActionsDropdownMenuGroup( { actions, items } ) {
 	const registry = useRegistry();
 	return (
 		<Menu.Group>
 			{ actions.map( ( action ) => {
+				if ( 'RenderModal' in action ) {
+					return (
+						<ModalActionMenuItem
+							key={ action.id }
+							action={ action }
+							items={ items }
+						/>
+					);
+				}
 				return (
 					<DropdownMenuItemTrigger
 						key={ action.id }
 						action={ action }
 						onClick={ () => {
-							if ( 'RenderModal' in action ) {
-								setActiveModalAction( action );
-								return;
-							}
 							action.callback( items, { registry } );
 						} }
 						items={ items }

--- a/packages/editor/src/components/post-actions/style.scss
+++ b/packages/editor/src/components/post-actions/style.scss
@@ -1,5 +1,10 @@
 @use "@wordpress/base-styles/z-index" as *;
 
-.editor-action-modal {
-	z-index: z-index(".editor-action-modal");
+// Scope the legacy z-index override to the dialog's portal so the
+// post-actions modal still stacks above older `@wordpress/components`
+// overlays during the transition. The `:root` defaults shared by
+// other migrated overlays come from `@wordpress/dataviews`'
+// `wp-ui-legacy-compat.scss`.
+.editor-action-modal__portal {
+	--wp-ui-dialog-z-index: #{z-index(".editor-action-modal")};
 }


### PR DESCRIPTION
## What

Migrates the duplicated \`ActionModal\` implementation behind \`PostActions\` (the editor's "More" menu for the current post) from `@wordpress/components` \`Modal\` to the `@wordpress/ui` \`Dialog\` primitive, mirroring the dataviews migration in #78028.

## Why

\`PostActions\` carries its own copy of \`ActionModal\` because \`@wordpress/editor\` can't depend on \`@wordpress/dataviews\` (and vice-versa). Keeping the two implementations in lockstep is what makes registered actions behave the same in DataViews tables and in the editor's post menu. This PR brings the editor copy onto \`Dialog\` so both surfaces share the same animation, dismissal, focus, and \`modalSize\` behaviour.

## How

- Replace \`Modal\` with \`Dialog.Root\` / \`Dialog.Popup\` (or \`AlertDialog\` for confirmations with \`hideModalHeader\`), hoisting \`Dialog.Root\` / \`Dialog.Trigger\` to each menu item to drop the parent-owned active-action state.
- Honour \`action.modalSize\` and \`action.modalFocusOnMount\` by duplicating the \`mapModalSize\` / \`useMapFocusOnMount\` helpers from dataviews. The duplication is called out inline; a future follow-up can extract the action-modal API into a shared package.
- Compose \`Dialog.Trigger\` with the existing menu-item trigger via a \`render\` prop so the trigger forwards \`ref\`/\`onClick\` and doesn't carry duplicated \`setOpen\` logic.
- Three small bug fixes brought to parity with dataviews along the way (called out in \`packages/editor/CHANGELOG.md\`):
  - confirmations registered with \`hideModalHeader\` now use \`role="alertdialog"\` and don't dismiss on backdrop click;
  - \`action.modalHeader\` is now invoked when supplied as a function;
  - \`action.disabled\` propagates to the underlying \`Menu.Item\`.

## Testing instructions

1. Open any post in the post editor, click the three-dot "More" menu next to the title.
2. Trigger registered actions (e.g. trash, set as homepage / set as posts page on a page) and confirm the dialog opens/closes with animation, focus is trapped/returned correctly, Escape dismisses non-alert dialogs, and disabled actions appear disabled in the menu.
3. Verify any actions whose \`modalHeader\` is a function still show the correct header.

## Context

This is one of 5 PRs that split #76837. Independent of the others; depends on nothing in that set.