### PR TITLE
Migrate `Action.RenderModal` Cancel buttons from `Button` to `@wordpress/ui` `Dialog.Action`

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- DataViews: `Action.RenderModal` host contract refinement — implementations are now expected to be rendered inside a `@wordpress/ui` `Dialog.Root` ancestor. All in-tree DataViews item-action and DataForm panel-modal hosts already provide one, but custom hosts (e.g. plugins that consume registered entity actions through their own UI shell) that render `RenderModal` outside a `Dialog.Root` will crash with "Dialog parts must be placed within `<Dialog.Root>`" if the body uses Dialog parts such as `Dialog.Action`. The implicit pre-migration contract was "render inside any modal-like host" (`<Modal>` or `<Dialog>` both qualified); the new contract narrows that to "Dialog-shaped host". External callers must wrap their custom host in `<Dialog.Root>`, or migrate to using the in-tree DataViews/editor surfaces. See the `RenderModalProps` JSDoc for details. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))
+
 ## 14.2.0 (2026-04-29)
 
 ### Enhancements

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -399,6 +399,14 @@ interface ActionBase< Item > {
 
 export interface RenderModalProps< Item > {
 	items: Item[];
+	/**
+	 * Imperative close handler. Calling it dismisses the host dialog. The
+	 * exact mechanism is host-defined: the host typically wires it to its
+	 * own `setOpen(false)` (which in turn drives its `Dialog.Root.open`).
+	 * Async consumer code (e.g. after a network round-trip) should call
+	 * `closeModal()` on success rather than relying on the user clicking
+	 * a Cancel button.
+	 */
 	closeModal?: () => void;
 	onActionPerformed?: ( items: Item[] ) => void;
 }
@@ -406,6 +414,17 @@ export interface RenderModalProps< Item > {
 export interface ActionModal< Item > extends ActionBase< Item > {
 	/**
 	 * Modal to render when the action is triggered.
+	 *
+	 * **Host requirement (since the migration from `@wordpress/components`
+	 * `Modal` to `@wordpress/ui` `Dialog`):** the rendered output is
+	 * expected to be mounted inside an `@wordpress/ui` `Dialog.Root`
+	 * ancestor. All in-tree hosts (`@wordpress/dataviews` action menus,
+	 * `@wordpress/editor` `PostActions`, `@wordpress/edit-site` page
+	 * templates) satisfy this. Custom hosts that render `RenderModal`
+	 * outside a `Dialog.Root` will crash if the body uses Dialog parts
+	 * such as `Dialog.Action` (Base UI throws "Dialog parts must be
+	 * placed within `<Dialog.Root>`"). When in doubt, render through one
+	 * of the in-tree hosts or wrap your custom host in `Dialog.Root`.
 	 */
 	RenderModal: ( {
 		items,

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The `RenderModal` implementations registered by this package (`useSetAsHomepageAction`, `useSetAsPostsPageAction`) now use `@wordpress/ui` `Dialog.Action` for their Cancel buttons and therefore require a `Dialog.Root` ancestor at render time. The editor's own `PostActions` component (which is the only in-tree consumer) supplies one. Plugins or custom UIs that consume these action objects and render `Action.RenderModal` outside a `Dialog.Root` will crash with "Dialog parts must be placed within `<Dialog.Root>`". Wrap the rendered output in `<Dialog.Root>` or render through the editor's `PostActions` component. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))
+
 ### Code Quality
 
 -   Migrate the Cancel button in the "Set as homepage" / "Set as posts page" modals from a tertiary `Button` to `Dialog.Action`. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Migrate the Cancel button in the "Set as homepage" / "Set as posts page" modals from a tertiary `Button` to `Dialog.Action`. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))
+
 ## 14.45.0 (2026-04-29)
 
 ## 14.44.0 (2026-04-15)

--- a/packages/editor/src/components/post-actions/set-as-homepage.js
+++ b/packages/editor/src/components/post-actions/set-as-homepage.js
@@ -9,6 +9,8 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Dialog } from '@wordpress/ui';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -94,17 +96,9 @@ const SetAsHomepageModal = ( { items, closeModal } ) => {
 			<VStack spacing="5">
 				<WCText>{ modalText }</WCText>
 				<HStack justify="right">
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						onClick={ () => {
-							closeModal?.();
-						} }
-						disabled={ isSaving }
-						accessibleWhenDisabled
-					>
+					<Dialog.Action variant="outline" disabled={ isSaving }>
 						{ __( 'Cancel' ) }
-					</Button>
+					</Dialog.Action>
 					<Button
 						__next40pxDefaultSize
 						variant="primary"

--- a/packages/editor/src/components/post-actions/set-as-homepage.js
+++ b/packages/editor/src/components/post-actions/set-as-homepage.js
@@ -155,6 +155,11 @@ export const useSetAsHomepageAction = () => {
 				return true;
 			},
 			modalFocusOnMount: 'firstContentElement',
+			// `SetAsHomepageModal` uses `Dialog.Action`, so it requires a
+			// `@wordpress/ui` `Dialog.Root` ancestor at render time. Every
+			// in-tree consumer of `Action.RenderModal` provides one; external
+			// hosts rendering it outside `Dialog.Root` will crash. See
+			// `RenderModalProps` JSDoc in `@wordpress/dataviews`.
 			RenderModal: SetAsHomepageModal,
 		} ),
 		[ pageForPosts, pageOnFront ]

--- a/packages/editor/src/components/post-actions/set-as-posts-page.js
+++ b/packages/editor/src/components/post-actions/set-as-posts-page.js
@@ -152,6 +152,11 @@ export const useSetAsPostsPageAction = () => {
 				return true;
 			},
 			modalFocusOnMount: 'firstContentElement',
+			// `SetAsPostsPageModal` uses `Dialog.Action`, so it requires a
+			// `@wordpress/ui` `Dialog.Root` ancestor at render time. Every
+			// in-tree consumer of `Action.RenderModal` provides one; external
+			// hosts rendering it outside `Dialog.Root` will crash. See
+			// `RenderModalProps` JSDoc in `@wordpress/dataviews`.
 			RenderModal: SetAsPostsPageModal,
 		} ),
 		[ pageForPosts, pageOnFront ]

--- a/packages/editor/src/components/post-actions/set-as-posts-page.js
+++ b/packages/editor/src/components/post-actions/set-as-posts-page.js
@@ -9,6 +9,8 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Dialog } from '@wordpress/ui';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -90,17 +92,9 @@ const SetAsPostsPageModal = ( { items, closeModal } ) => {
 			<VStack spacing="5">
 				<WCText>{ modalText }</WCText>
 				<HStack justify="right">
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						onClick={ () => {
-							closeModal?.();
-						} }
-						disabled={ isSaving }
-						accessibleWhenDisabled
-					>
+					<Dialog.Action variant="outline" disabled={ isSaving }>
 						{ __( 'Cancel' ) }
-					</Button>
+					</Dialog.Action>
 					<Button
 						__next40pxDefaultSize
 						variant="primary"

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Migrate the Cancel button in `RenderModal` implementations (delete, permanently delete, trash, reset, rename, reorder, duplicate-post) from a tertiary `Button` to `@wordpress/ui` `Dialog.Action`. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))
+
 ## 0.37.0 (2026-04-29)
 
 ## 0.36.0 (2026-04-15)

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The `RenderModal` implementations exported from this package (`deletePostAction`, `permanentlyDeletePostAction`, `trashPostAction`, `resetPostAction`, `renamePostAction`, `reorderPageAction`, `duplicatePostAction`) now use `@wordpress/ui` `Dialog.Action` for their Cancel buttons and therefore require a `Dialog.Root` ancestor at render time. All in-tree consumers (`@wordpress/dataviews` item-action menus, `@wordpress/editor` `PostActions`, `@wordpress/edit-site` page-templates) provide one, but plugins or custom UIs that register these actions and render `Action.RenderModal` outside a `Dialog.Root` will crash with "Dialog parts must be placed within `<Dialog.Root>`". Wrap the rendered output in `<Dialog.Root>` or migrate to one of the in-tree consumers. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))
+
 ### Code Quality
 
 -   Migrate the Cancel button in `RenderModal` implementations (delete, permanently delete, trash, reset, rename, reorder, duplicate-post) from a tertiary `Button` to `@wordpress/ui` `Dialog.Action`. ([#76837](https://github.com/WordPress/gutenberg/pull/76837))

--- a/packages/fields/src/actions/delete-post.tsx
+++ b/packages/fields/src/actions/delete-post.tsx
@@ -50,6 +50,10 @@ const deletePostAction: Action< Template | TemplatePart | Pattern > = {
 	supportsBulk: true,
 	hideModalHeader: true,
 	modalFocusOnMount: 'firstContentElement',
+	// `Dialog.Action` (used inside this body) requires a `@wordpress/ui`
+	// `Dialog.Root` ancestor at render time. Every in-tree consumer of
+	// `Action.RenderModal` provides one; external hosts rendering it
+	// outside `Dialog.Root` will crash. See `RenderModalProps` JSDoc.
 	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
 		const [ isBusy, setIsBusy ] = useState( false );
 		const isResetting = items.every(

--- a/packages/fields/src/actions/delete-post.tsx
+++ b/packages/fields/src/actions/delete-post.tsx
@@ -10,6 +10,8 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Dialog } from '@wordpress/ui';
 // @ts-ignore
 import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
 import type { Action } from '@wordpress/dataviews';
@@ -73,15 +75,9 @@ const deletePostAction: Action< Template | TemplatePart | Pattern > = {
 						  ) }
 				</WCText>
 				<HStack justify="right">
-					<Button
-						variant="tertiary"
-						onClick={ closeModal }
-						disabled={ isBusy }
-						accessibleWhenDisabled
-						__next40pxDefaultSize
-					>
+					<Dialog.Action variant="outline" disabled={ isBusy }>
 						{ __( 'Cancel' ) }
-					</Button>
+					</Dialog.Action>
 					<Button
 						variant="primary"
 						onClick={ async () => {

--- a/packages/fields/src/actions/duplicate-post.tsx
+++ b/packages/fields/src/actions/duplicate-post.tsx
@@ -42,6 +42,10 @@ const duplicatePost: Action< BasePost > = {
 		return status !== 'trash';
 	},
 	modalFocusOnMount: 'firstContentElement',
+	// `Dialog.Action` (used inside this body) requires a `@wordpress/ui`
+	// `Dialog.Root` ancestor at render time. Every in-tree consumer of
+	// `Action.RenderModal` provides one; external hosts rendering it
+	// outside `Dialog.Root` will crash. See `RenderModalProps` JSDoc.
 	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
 		const [ item, setItem ] = useState< BasePost >( {
 			...items[ 0 ],

--- a/packages/fields/src/actions/duplicate-post.tsx
+++ b/packages/fields/src/actions/duplicate-post.tsx
@@ -12,6 +12,8 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Dialog } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -165,13 +167,9 @@ const duplicatePost: Action< BasePost > = {
 						}
 					/>
 					<HStack spacing={ 2 } justify="end">
-						<Button
-							variant="tertiary"
-							onClick={ closeModal }
-							__next40pxDefaultSize
-						>
+						<Dialog.Action variant="outline">
 							{ __( 'Cancel' ) }
-						</Button>
+						</Dialog.Action>
 						<Button
 							variant="primary"
 							type="submit"

--- a/packages/fields/src/actions/permanently-delete-post.tsx
+++ b/packages/fields/src/actions/permanently-delete-post.tsx
@@ -14,6 +14,8 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Dialog } from '@wordpress/ui';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -64,15 +66,9 @@ const permanentlyDeletePost: Action< PostWithPermissions > = {
 						  ) }
 				</WCText>
 				<HStack justify="right">
-					<Button
-						variant="tertiary"
-						onClick={ closeModal }
-						disabled={ isBusy }
-						accessibleWhenDisabled
-						__next40pxDefaultSize
-					>
+					<Dialog.Action variant="outline" disabled={ isBusy }>
 						{ __( 'Cancel' ) }
-					</Button>
+					</Dialog.Action>
 					<Button
 						variant="primary"
 						onClick={ async () => {

--- a/packages/fields/src/actions/permanently-delete-post.tsx
+++ b/packages/fields/src/actions/permanently-delete-post.tsx
@@ -38,6 +38,10 @@ const permanentlyDeletePost: Action< PostWithPermissions > = {
 	},
 	hideModalHeader: true,
 	modalFocusOnMount: 'firstContentElement',
+	// `Dialog.Action` (used inside this body) requires a `@wordpress/ui`
+	// `Dialog.Root` ancestor at render time. Every in-tree consumer of
+	// `Action.RenderModal` provides one; external hosts rendering it
+	// outside `Dialog.Root` will crash. See `RenderModalProps` JSDoc.
 	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
 		const [ isBusy, setIsBusy ] = useState( false );
 		const { createSuccessNotice, createErrorNotice } =

--- a/packages/fields/src/actions/rename-post.tsx
+++ b/packages/fields/src/actions/rename-post.tsx
@@ -13,6 +13,8 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Dialog } from '@wordpress/ui';
 import type { Action } from '@wordpress/dataviews';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -126,15 +128,9 @@ const renamePost: Action< PostWithPermissions > = {
 						required
 					/>
 					<HStack justify="right">
-						<Button
-							__next40pxDefaultSize
-							variant="tertiary"
-							onClick={ () => {
-								closeModal?.();
-							} }
-						>
+						<Dialog.Action variant="outline">
 							{ __( 'Cancel' ) }
-						</Button>
+						</Dialog.Action>
 						<Button
 							__next40pxDefaultSize
 							variant="primary"

--- a/packages/fields/src/actions/rename-post.tsx
+++ b/packages/fields/src/actions/rename-post.tsx
@@ -82,6 +82,10 @@ const renamePost: Action< PostWithPermissions > = {
 
 		return post.type === PATTERN_TYPES.user && post.permissions?.update;
 	},
+	// `Dialog.Action` (used inside this body) requires a `@wordpress/ui`
+	// `Dialog.Root` ancestor at render time. Every in-tree consumer of
+	// `Action.RenderModal` provides one; external hosts rendering it
+	// outside `Dialog.Root` will crash. See `RenderModalProps` JSDoc.
 	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
 		const [ item ] = items;
 		const [ title, setTitle ] = useState( () => getItemTitle( item, '' ) );

--- a/packages/fields/src/actions/reorder-page.tsx
+++ b/packages/fields/src/actions/reorder-page.tsx
@@ -12,6 +12,8 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Dialog } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -111,15 +113,9 @@ function ReorderModal( {
 					} }
 				/>
 				<HStack justify="right">
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						onClick={ () => {
-							closeModal?.();
-						} }
-					>
+					<Dialog.Action variant="outline">
 						{ __( 'Cancel' ) }
-					</Button>
+					</Dialog.Action>
 					<Button
 						__next40pxDefaultSize
 						variant="primary"

--- a/packages/fields/src/actions/reorder-page.tsx
+++ b/packages/fields/src/actions/reorder-page.tsx
@@ -138,6 +138,10 @@ const reorderPage: Action< BasePost > = {
 		return status !== 'trash';
 	},
 	modalFocusOnMount: 'firstContentElement',
+	// `ReorderModal` uses `Dialog.Action`, so it requires a `@wordpress/ui`
+	// `Dialog.Root` ancestor at render time. Every in-tree consumer of
+	// `Action.RenderModal` provides one; external hosts rendering it
+	// outside `Dialog.Root` will crash. See `RenderModalProps` JSDoc.
 	RenderModal: ReorderModal,
 };
 

--- a/packages/fields/src/actions/reset-post.tsx
+++ b/packages/fields/src/actions/reset-post.tsx
@@ -207,6 +207,10 @@ const resetPostAction: Action< Template | TemplatePart > = {
 	supportsBulk: true,
 	hideModalHeader: true,
 	modalFocusOnMount: 'firstContentElement',
+	// `Dialog.Action` (used inside this body) requires a `@wordpress/ui`
+	// `Dialog.Root` ancestor at render time. Every in-tree consumer of
+	// `Action.RenderModal` provides one; external hosts rendering it
+	// outside `Dialog.Root` will crash. See `RenderModalProps` JSDoc.
 	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
 		const [ isBusy, setIsBusy ] = useState( false );
 

--- a/packages/fields/src/actions/reset-post.tsx
+++ b/packages/fields/src/actions/reset-post.tsx
@@ -15,6 +15,8 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Dialog } from '@wordpress/ui';
 import type { Action } from '@wordpress/dataviews';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
@@ -277,15 +279,9 @@ const resetPostAction: Action< Template | TemplatePart > = {
 					{ __( 'Reset to default and clear all customizations?' ) }
 				</WCText>
 				<HStack justify="right">
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						onClick={ closeModal }
-						disabled={ isBusy }
-						accessibleWhenDisabled
-					>
+					<Dialog.Action variant="outline" disabled={ isBusy }>
 						{ __( 'Cancel' ) }
-					</Button>
+					</Dialog.Action>
 					<Button
 						__next40pxDefaultSize
 						variant="primary"

--- a/packages/fields/src/actions/trash-post.tsx
+++ b/packages/fields/src/actions/trash-post.tsx
@@ -13,6 +13,8 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Dialog } from '@wordpress/ui';
 import type { Action } from '@wordpress/dataviews';
 
 /**
@@ -72,15 +74,9 @@ const trashPost: Action< PostWithPermissions > = {
 						  ) }
 				</WCText>
 				<HStack justify="right">
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						onClick={ closeModal }
-						disabled={ isBusy }
-						accessibleWhenDisabled
-					>
+					<Dialog.Action variant="outline" disabled={ isBusy }>
 						{ __( 'Cancel' ) }
-					</Button>
+					</Dialog.Action>
 					<Button
 						__next40pxDefaultSize
 						variant="primary"

--- a/packages/fields/src/actions/trash-post.tsx
+++ b/packages/fields/src/actions/trash-post.tsx
@@ -47,6 +47,10 @@ const trashPost: Action< PostWithPermissions > = {
 	supportsBulk: true,
 	hideModalHeader: true,
 	modalFocusOnMount: 'firstContentElement',
+	// `Dialog.Action` (used inside this body) requires a `@wordpress/ui`
+	// `Dialog.Root` ancestor at render time. Every in-tree consumer of
+	// `Action.RenderModal` provides one; external hosts rendering it
+	// outside `Dialog.Root` will crash. See `RenderModalProps` JSDoc.
 	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
 		const [ isBusy, setIsBusy ] = useState( false );
 		const { createSuccessNotice, createErrorNotice } =

--- a/packages/user-post-types/src/actions/delete.tsx
+++ b/packages/user-post-types/src/actions/delete.tsx
@@ -9,7 +9,8 @@ import { useState } from '@wordpress/element';
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { Stack, Text } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Dialog, Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -143,15 +144,9 @@ function DeletePostTypeModal( {
 					  ) }
 			</Text>
 			<Stack direction="row" justify="flex-end" gap="sm">
-				<Button
-					__next40pxDefaultSize
-					variant="tertiary"
-					onClick={ closeModal }
-					disabled={ isDeleting }
-					accessibleWhenDisabled
-				>
+				<Dialog.Action variant="outline" disabled={ isDeleting }>
 					{ __( 'Cancel' ) }
-				</Button>
+				</Dialog.Action>
 				<Button
 					__next40pxDefaultSize
 					variant="primary"

--- a/packages/user-post-types/src/actions/delete.tsx
+++ b/packages/user-post-types/src/actions/delete.tsx
@@ -171,6 +171,11 @@ const deletePostTypeAction: Action< PostTypeFormData > = {
 	hideModalHeader: true,
 	modalFocusOnMount: 'firstContentElement',
 	modalSize: 'small',
+	// `DeletePostTypeModal` uses `Dialog.Action`, so it requires a
+	// `@wordpress/ui` `Dialog.Root` ancestor at render time. Every
+	// in-tree consumer of `Action.RenderModal` provides one; external
+	// hosts rendering it outside `Dialog.Root` will crash. See
+	// `RenderModalProps` JSDoc.
 	RenderModal: DeletePostTypeModal,
 };
 

--- a/packages/user-taxonomies/src/actions/delete.tsx
+++ b/packages/user-taxonomies/src/actions/delete.tsx
@@ -9,7 +9,8 @@ import { useState } from '@wordpress/element';
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { Stack, Text } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Dialog, Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -143,15 +144,9 @@ function DeleteTaxonomyModal( {
 					  ) }
 			</Text>
 			<Stack direction="row" justify="flex-end" gap="sm">
-				<Button
-					__next40pxDefaultSize
-					variant="tertiary"
-					onClick={ closeModal }
-					disabled={ isDeleting }
-					accessibleWhenDisabled
-				>
+				<Dialog.Action variant="outline" disabled={ isDeleting }>
 					{ __( 'Cancel' ) }
-				</Button>
+				</Dialog.Action>
 				<Button
 					__next40pxDefaultSize
 					variant="primary"

--- a/packages/user-taxonomies/src/actions/delete.tsx
+++ b/packages/user-taxonomies/src/actions/delete.tsx
@@ -171,6 +171,11 @@ const deleteTaxonomyAction: Action< TaxonomyFormData > = {
 	hideModalHeader: true,
 	modalFocusOnMount: 'firstContentElement',
 	modalSize: 'small',
+	// `DeleteTaxonomyModal` uses `Dialog.Action`, so it requires a
+	// `@wordpress/ui` `Dialog.Root` ancestor at render time. Every
+	// in-tree consumer of `Action.RenderModal` provides one; external
+	// hosts rendering it outside `Dialog.Root` will crash. See
+	// `RenderModalProps` JSDoc.
 	RenderModal: DeleteTaxonomyModal,
 };
 


### PR DESCRIPTION
## What

Migrates the Cancel buttons inside every in-tree \`Action.RenderModal\` body (\`@wordpress/fields\`, \`@wordpress/user-taxonomies\`, \`@wordpress/user-post-types\`, plus the editor's set-as-homepage / set-as-posts-page actions) from a \`@wordpress/components\` \`Button\` calling \`closeModal()\` to a \`@wordpress/ui\` \`Dialog.Action\`.

## ⚠️ Heads-up for reviewers — implicit-contract change

\`Dialog.Action\` requires a \`Dialog.Root\` ancestor at render time (Base UI throws \`"Dialog parts must be placed within \`<Dialog.Root>\`"\` otherwise). All in-tree consumers — DataViews item-action menus, editor \`PostActions\`, edit-site page-templates duplicate dialog — provide one once #78028, #78030 and #78031 land. Plugins or custom UIs that consume these registered actions and render \`Action.RenderModal\` outside a \`Dialog.Root\` will crash.

This refines the implicit contract from "render inside any modal-like host" to "render inside a \`Dialog.Root\` host", and is documented as a Breaking Change in the \`packages/dataviews\`, \`packages/fields\`, and \`packages/editor\` CHANGELOGs, plus the \`RenderModalProps\` JSDoc and a 4-line header comment above each migrated \`RenderModal\` body. Happy to revisit if reviewers prefer the safer "keep \`Button onClick\`" approach.

## Why

Idiomatic \`Dialog.Action\` is preferable to a manual \`Button onClick={closeModal}\`: it gets the right default sizing/variant for a dialog footer, integrates with \`Dialog\`'s focus management, and removes one of the few remaining places where \`closeModal()\` is invoked from inside \`RenderModal\` bodies that are by construction always rendered inside a \`Dialog\` host.

## How

For each migrated \`RenderModal\` (delete-post, permanently-delete-post, trash-post, reset-post, rename-post, reorder-page, duplicate-post, the user-taxonomy delete, the user-post-type delete, set-as-homepage, set-as-posts-page):

- Replace the tertiary \`<Button onClick={closeModal}>{ __( 'Cancel' ) }</Button>\` with \`<Dialog.Action variant="outline">{ __( 'Cancel' ) }</Dialog.Action>\`, dropping the now-unused \`Button\` import where applicable.
- Add a 4-line header comment above each \`RenderModal:\` declaration noting the new \`Dialog.Root\` host requirement.
- Update \`RenderModalProps\` JSDoc in \`packages/dataviews/src/types/dataviews.ts\` to document the contract.

## Testing instructions

1. With #78028 / #78030 / #78031 merged (or this branch rebased on top of them), exercise each migrated action — Trash, Delete permanently, Reset, Rename, Reorder, Duplicate, Set as homepage / posts page, plus the user taxonomy / post-type delete — from each in-tree surface (DataViews, editor \`PostActions\`, page-templates duplicate dialog).
2. Confirm the Cancel button still dismisses the dialog without performing the action, focus returns to the trigger, and confirming the action still works as before.
3. As a regression check, verify Storybook still renders the relevant action stories.

## Context

This is the last of 5 PRs that split #76837. It depends on #78028, #78030 and #78031 being merged first (those land the in-tree \`Dialog.Root\` hosts that this PR's \`Dialog.Action\` calls require).