### PR TITLE
Dashboard: persist layout via @wordpress/preferences

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63105,6 +63105,7 @@
 				"@wordpress/hooks": "file:../../packages/hooks",
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
+				"@wordpress/preferences": "file:../../packages/preferences",
 				"@wordpress/ui": "file:../../packages/ui",
 				"@wordpress/warning": "file:../../packages/warning",
 				"clsx": "^2.1.1"

--- a/routes/dashboard/hooks/index.ts
+++ b/routes/dashboard/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useDashboardLayout } from './use-dashboard-layout';

--- a/routes/dashboard/hooks/test/use-dashboard-layout.test.ts
+++ b/routes/dashboard/hooks/test/use-dashboard-layout.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { dispatch } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import useDashboardLayout from '../use-dashboard-layout/use-dashboard-layout';
+import type { DashboardWidget } from '../../widget-dashboard';
+
+const SCOPE = 'core/dashboard';
+const KEY = 'dashboardLayout';
+
+const SAMPLE_LAYOUT: DashboardWidget[] = [
+	{ uuid: 'a', type: 'core/quick-draft' },
+	{ uuid: 'b', type: 'core/at-a-glance' },
+];
+
+describe( 'useDashboardLayout', () => {
+	beforeEach( () => {
+		dispatch( preferencesStore ).set( SCOPE, KEY, undefined );
+	} );
+
+	it( 'returns an empty array when nothing is persisted', () => {
+		const { result } = renderHook( () => useDashboardLayout() );
+		const [ layout ] = result.current;
+		expect( layout ).toEqual( [] );
+	} );
+
+	it( 'persists updates written through setLayout', () => {
+		const { result } = renderHook( () => useDashboardLayout() );
+
+		act( () => {
+			const [ , setLayout ] = result.current;
+			setLayout( SAMPLE_LAYOUT );
+		} );
+
+		const [ layout ] = result.current;
+		expect( layout ).toEqual( SAMPLE_LAYOUT );
+	} );
+
+	it( 'reads the layout written from outside the hook', () => {
+		dispatch( preferencesStore ).set( SCOPE, KEY, SAMPLE_LAYOUT );
+
+		const { result } = renderHook( () => useDashboardLayout() );
+		const [ layout ] = result.current;
+		expect( layout ).toEqual( SAMPLE_LAYOUT );
+	} );
+
+	it( 'clears the layout via resetLayout', () => {
+		const { result } = renderHook( () => useDashboardLayout() );
+
+		act( () => {
+			const [ , setLayout ] = result.current;
+			setLayout( SAMPLE_LAYOUT );
+		} );
+
+		act( () => {
+			const [ , , resetLayout ] = result.current;
+			resetLayout();
+		} );
+
+		const [ layout ] = result.current;
+		expect( layout ).toEqual( [] );
+	} );
+} );

--- a/routes/dashboard/hooks/use-dashboard-layout/index.ts
+++ b/routes/dashboard/hooks/use-dashboard-layout/index.ts
@@ -1,0 +1,1 @@
+export { default as useDashboardLayout } from './use-dashboard-layout';

--- a/routes/dashboard/hooks/use-dashboard-layout/use-dashboard-layout.ts
+++ b/routes/dashboard/hooks/use-dashboard-layout/use-dashboard-layout.ts
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import type { DashboardWidget } from '../../widget-dashboard';
+
+const SCOPE = 'core/dashboard';
+const KEY = 'dashboardLayout';
+
+/**
+ * Hook for managing dashboard layout preferences.
+ *
+ * Returns the persisted layout, a setter that writes through to the
+ * preferences store, and a reset action that clears the layout to its
+ * empty state. Plugin-provided defaults will replace the empty fallback
+ * once the defaults source lands.
+ *
+ * @return Tuple `[ layout, setLayout, resetLayout ]`.
+ */
+function useDashboardLayout(): [
+	DashboardWidget[],
+	( layout: DashboardWidget[] ) => void,
+	() => void,
+] {
+	const layout = useSelect(
+		( select ) =>
+			( select( preferencesStore ).get( SCOPE, KEY ) as
+				| DashboardWidget[]
+				| undefined ) ?? [],
+		[]
+	);
+
+	const { set } = useDispatch( preferencesStore );
+
+	function setLayout( newLayout: DashboardWidget[] ) {
+		void set( SCOPE, KEY, newLayout );
+	}
+
+	function resetLayout() {
+		void set( SCOPE, KEY, [] );
+	}
+
+	return [ layout, setLayout, resetLayout ];
+}
+
+export default useDashboardLayout;

--- a/routes/dashboard/package.json
+++ b/routes/dashboard/package.json
@@ -20,6 +20,7 @@
 		"@wordpress/hooks": "file:../../packages/hooks",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
+		"@wordpress/preferences": "file:../../packages/preferences",
 		"@wordpress/ui": "file:../../packages/ui",
 		"@wordpress/warning": "file:../../packages/warning",
 		"clsx": "^2.1.1"

--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -8,23 +8,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { WidgetDashboard, type DashboardWidget } from './widget-dashboard';
+import { useDashboardLayout } from './hooks';
+import { WidgetDashboard } from './widget-dashboard';
 import { useWidgetTypes } from './widget-types';
 
-const DEFAULT_LAYOUT: DashboardWidget[] = [
-	{
-		uuid: '1',
-		type: 'wordpress/hello-world',
-		placement: {
-			width: 'full',
-			height: 1,
-		},
-	},
-];
-
 function Dashboard() {
-	const [ layout, setLayout ] =
-		useState< DashboardWidget[] >( DEFAULT_LAYOUT );
+	const [ layout, setLayout ] = useDashboardLayout();
 
 	const widgetTypes = useWidgetTypes();
 


### PR DESCRIPTION
## What?

Adds a `useDashboardLayout()` hook in the dashboard route that reads and writes the user's layout through `@wordpress/preferences`, wired into the dashboard route's `<WidgetDashboard>` instance.

The `WidgetDashboard` engine stays stateless. Persistence is the consumer's concern, plugged in via the existing `layout` / `onLayoutChange` props.

Part of #78035

## Why?

The widget dashboard rendering engine is intentionally stateless, so persistence belongs to the consumer.

Today the dashboard route keeps `layout` in `useState`, which means every reload resets the user's customizations to the placeholder seed.

Backing the route with `@wordpress/preferences` solves that without coupling the engine to any storage layer.

## How?

The new `routes/dashboard/hooks/use-dashboard-layout/` hook stores layout under `@wordpress/preferences`, in the scope `core/dashboard` and key `dashboardLayout`. It returns the familiar `[ layout, setLayout, resetLayout ]` tuple.

`resetLayout` clears the layout to `[]` for now. Plugin-provided defaults are scoped to a follow-up that introduces the defaults source.

`routes/dashboard/stage.tsx` now reads and writes the layout through the hook instead of `useState`. The hard-coded `wordpress/hello-world` placeholder is gone, so first paint shows an empty layout until the user inserts widgets.

`@wordpress/preferences` is added as a dependency of the dashboard route package.

## Testing

Run the unit suite for the new hook:

```bash
npm run test:unit -- routes/dashboard/hooks
```

Four cases cover the empty initial state, write-through, external-write read-back, and reset.

Manual smoke from the dashboard page (`?page=gutenberg-dashboard`):

Read the current layout from the browser devtools console:

```js
wp.data.select( 'core/preferences' ).get( 'core/dashboard', 'dashboardLayout' );
```

Seed a layout from the console and watch the dashboard render the new widget immediately:

```js
wp.data.dispatch( 'core/preferences' ).set(
    'core/dashboard',
    'dashboardLayout',
    [ { uuid: 'demo', type: 'wordpress/hello-world', placement: { width: 'full', height: 1 } } ]
);
```


https://github.com/user-attachments/assets/f39df2fb-464a-4448-a3d9-0d8b1cddbf9c

