### PR TITLE
Fix: stale missing blocks after persisted CRDT restore

### DIFF
--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -6,7 +6,7 @@ import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 /**
  * WordPress dependencies
  */
-import { __unstableSerializeAndClean } from '@wordpress/blocks';
+import { __unstableSerializeAndClean, getBlockType } from '@wordpress/blocks';
 import {
 	type CRDTDoc,
 	type ObjectData,
@@ -291,6 +291,32 @@ function defaultGetChangesFromCRDTDoc( crdtDoc: CRDTDoc ): ObjectData {
 }
 
 /**
+ * Returns true when a missing block can now be parsed as its original block
+ * type because that block type has become available again.
+ *
+ * This can happen when a plugin that registers a block is temporarily
+ * deactivated and then reactivated. The persisted CRDT document may still
+ * contain `core/missing`, even though parsing the raw post content would now
+ * produce the original block type.
+ *
+ * @param {Block[]} blocks Blocks from the CRDT document.
+ *
+ * @return {boolean} Whether the blocks contain a recoverable missing block.
+ */
+function hasRecoverableMissingBlock( blocks: Block[] = [] ): boolean {
+	return blocks.some( ( block ) => {
+		const originalName = block.attributes?.originalName;
+
+		return (
+			( block.name === 'core/missing' &&
+				typeof originalName === 'string' &&
+				!! getBlockType( originalName ) ) ||
+			hasRecoverableMissingBlock( block.innerBlocks ?? [] )
+		);
+	} );
+}
+
+/**
  * Given a local Y.Doc that *may* contain changes from remote peers, compare
  * against the local record and determine if there are changes (edits) we want
  * to dispatch.
@@ -341,10 +367,13 @@ export function getPostChangesFromCRDTDoc(
 						editedRecord.content
 					) {
 						const blocksJson = ymap.get( 'blocks' )?.toJSON() ?? [];
+						const serializedBlocks =
+							__unstableSerializeAndClean( blocksJson ).trim();
+						const rawContent = getRawValue( editedRecord.content );
 
 						return (
-							__unstableSerializeAndClean( blocksJson ).trim() !==
-							getRawValue( editedRecord.content )
+							serializedBlocks !== rawContent ||
+							hasRecoverableMissingBlock( blocksJson as Block[] )
 						);
 					}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

#77796 

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

This PR invalidates persisted CRDT blocks when they contain a `core/missing` block whose original block type is now available again.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When a block type is unavailable, Gutenberg renders it as `core/missing`.

With RTC persistence enabled, that stale `core/missing` state can be restored from the persisted CRDT document after the block type becomes available again. The editor then keeps rendering `core/missing` after reload, even though the block type is registered.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The persisted CRDT block comparison now also checks whether any restored `core/missing` block has an `originalName` that is currently registered.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Install and activate a plugin that registers custom blocks, such as WooCommerce.
2. Create a page.
3. Add a WooCommerce block, for example the Cart Link block.
4. Save the page.
5. Deactivate WooCommerce.
6. Reload the editor.
7. Confirm the block renders as a missing block.
8.  Reactivate WooCommerce.
9. Reload the editor.
10. Confirm the block is restored as the WooCommerce block instead of remaining `core/missing`.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
