### PR TITLE
Dashboard: backend default layout filter

### DIFF
--- a/lib/experimental/dashboard-widgets/class-wp-widget-type.php
+++ b/lib/experimental/dashboard-widgets/class-wp-widget-type.php
@@ -23,7 +23,7 @@ if ( ! class_exists( 'WP_Widget_Type' ) ) {
 	class WP_Widget_Type {
 
 		/**
-		 * Widget type key. Namespaced identifier, e.g. `wordpress/hello-world`.
+		 * Widget type key. Namespaced identifier, e.g. `core/hello-world`.
 		 *
 		 * @var string
 		 */

--- a/lib/experimental/dashboard-widgets/dashboard-layout.php
+++ b/lib/experimental/dashboard-widgets/dashboard-layout.php
@@ -10,6 +10,18 @@
  */
 
 /**
+ * Preferences scope under which the dashboard layout is stored.
+ * Mirrors the scope read by the JS surface.
+ */
+const GUTENBERG_DASHBOARD_LAYOUT_SCOPE = 'core/dashboard';
+
+/**
+ * Preferences key under `GUTENBERG_DASHBOARD_LAYOUT_SCOPE` that holds
+ * the layout array.
+ */
+const GUTENBERG_DASHBOARD_LAYOUT_KEY = 'dashboardLayout';
+
+/**
  * Injects a registered default dashboard layout into the user's
  * `persisted_preferences` read when the stored layout is empty.
  *
@@ -42,8 +54,8 @@ function gutenberg_inject_dashboard_default_layout( $value, $user_id, $meta_key 
 		$base = array();
 	}
 
-	$committed = isset( $base['core/dashboard']['dashboardLayout'] )
-		? $base['core/dashboard']['dashboardLayout']
+	$committed = isset( $base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ][ GUTENBERG_DASHBOARD_LAYOUT_KEY ] )
+		? $base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ][ GUTENBERG_DASHBOARD_LAYOUT_KEY ]
 		: array();
 
 	if ( ! empty( $committed ) ) {
@@ -65,10 +77,10 @@ function gutenberg_inject_dashboard_default_layout( $value, $user_id, $meta_key 
 		return $value;
 	}
 
-	if ( ! isset( $base['core/dashboard'] ) || ! is_array( $base['core/dashboard'] ) ) {
-		$base['core/dashboard'] = array();
+	if ( ! isset( $base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ] ) || ! is_array( $base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ] ) ) {
+		$base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ] = array();
 	}
-	$base['core/dashboard']['dashboardLayout'] = $default;
+	$base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ][ GUTENBERG_DASHBOARD_LAYOUT_KEY ] = $default;
 
 	return array( $base );
 }

--- a/lib/experimental/dashboard-widgets/dashboard-layout.php
+++ b/lib/experimental/dashboard-widgets/dashboard-layout.php
@@ -80,6 +80,7 @@ function gutenberg_inject_dashboard_default_layout( $value, $user_id, $meta_key 
 	if ( ! isset( $base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ] ) || ! is_array( $base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ] ) ) {
 		$base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ] = array();
 	}
+
 	$base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ][ GUTENBERG_DASHBOARD_LAYOUT_KEY ] = $default;
 
 	return array( $base );

--- a/lib/experimental/dashboard-widgets/dashboard-layout.php
+++ b/lib/experimental/dashboard-widgets/dashboard-layout.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Dashboard Layout: server-side defaults.
+ *
+ * Allows plugins and themes to register a default dashboard layout
+ * that surfaces transparently through the `@wordpress/preferences`
+ * store for users who have not customized theirs.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Injects a registered default dashboard layout into the user's
+ * `persisted_preferences` read when the stored layout is empty.
+ *
+ * Hooks into `get_user_metadata` so the default propagates through
+ * the same persistence layer the dashboard's JS surface reads from.
+ * The JS side stays oblivious: a default and a user-saved layout
+ * look identical at the preferences-store boundary.
+ *
+ * @param mixed  $value    The pre-fetched value, or null to let the
+ *                         meta API resolve normally.
+ * @param int    $user_id  User ID.
+ * @param string $meta_key Meta key being read.
+ * @return mixed The original value, or a single-element array
+ *               containing the extended persisted preferences.
+ */
+function gutenberg_inject_dashboard_default_layout( $value, $user_id, $meta_key ) {
+	global $wpdb;
+
+	$expected_key = $wpdb->get_blog_prefix() . 'persisted_preferences';
+	if ( $meta_key !== $expected_key ) {
+		return $value;
+	}
+
+	// Avoid recursion when reading the user meta.
+	remove_filter( 'get_user_metadata', __FUNCTION__, 99 );
+	$base = get_user_meta( $user_id, $meta_key, true );
+	add_filter( 'get_user_metadata', __FUNCTION__, 99, 3 );
+
+	if ( ! is_array( $base ) ) {
+		$base = array();
+	}
+
+	$committed = isset( $base['core/dashboard']['dashboardLayout'] )
+		? $base['core/dashboard']['dashboardLayout']
+		: array();
+
+	if ( ! empty( $committed ) ) {
+		return $value;
+	}
+
+	/**
+	 * Filters the default dashboard layout served to users who have
+	 * not customized theirs.
+	 *
+	 * Each entry should match the dashboard's widget instance shape:
+	 * `uuid`, `type`, optional `attributes`, optional `placement`.
+	 *
+	 * @param array $default_layout Default array of widget instances.
+	 */
+	$default = apply_filters( 'gutenberg_dashboard_default_layout', array() );
+
+	if ( empty( $default ) || ! is_array( $default ) ) {
+		return $value;
+	}
+
+	if ( ! isset( $base['core/dashboard'] ) || ! is_array( $base['core/dashboard'] ) ) {
+		$base['core/dashboard'] = array();
+	}
+	$base['core/dashboard']['dashboardLayout'] = $default;
+
+	return array( $base );
+}
+
+add_filter( 'get_user_metadata', 'gutenberg_inject_dashboard_default_layout', 99, 3 );

--- a/lib/experimental/dashboard-widgets/default-layout-seed.php
+++ b/lib/experimental/dashboard-widgets/default-layout-seed.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Dashboard Layout: starter content shipped with the experiment.
+ *
+ * Registers a small default layout under `gutenberg_dashboard_default_layout`
+ * so the dashboard renders something meaningful the first time a user opens
+ * it. Plugins and themes can layer their own callback on top of the same
+ * filter to extend or replace this set.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Appends the bundled `core/hello-world` instance to the default layout
+ * unless something earlier in the filter chain already added it.
+ *
+ * @param array $dashboard_layout Default layout produced by previous
+ *                                callbacks on `gutenberg_dashboard_default_layout`.
+ * @return array The layout extended with the bundled widget instance.
+ */
+function gutenberg_seed_default_dashboard_layout( $dashboard_layout ) {
+	$uuids = array_column( $dashboard_layout, 'uuid' );
+
+	if ( in_array( 'default-hello-world-widget-instance', $uuids, true ) ) {
+		return $dashboard_layout;
+	}
+
+	$dashboard_layout[] = array(
+		'uuid'      => 'default-hello-world-widget-instance',
+		'type'      => 'core/hello-world',
+		'placement' => array(
+			'width'  => 2,
+			'height' => 1,
+		),
+	);
+
+	return $dashboard_layout;
+}
+
+add_filter( 'gutenberg_dashboard_default_layout', 'gutenberg_seed_default_dashboard_layout' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -232,4 +232,5 @@ if ( gutenberg_is_experiment_enabled( 'gutenberg-content-types' ) ) {
 if ( gutenberg_is_experiment_enabled( 'gutenberg-dashboard-widgets' ) ) {
 	require __DIR__ . '/experimental/dashboard-widgets/load.php';
 	require __DIR__ . '/experimental/dashboard-widgets/widget-types.php';
+	require __DIR__ . '/experimental/dashboard-widgets/dashboard-layout.php';
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -233,4 +233,5 @@ if ( gutenberg_is_experiment_enabled( 'gutenberg-dashboard-widgets' ) ) {
 	require __DIR__ . '/experimental/dashboard-widgets/load.php';
 	require __DIR__ . '/experimental/dashboard-widgets/widget-types.php';
 	require __DIR__ . '/experimental/dashboard-widgets/dashboard-layout.php';
+	require __DIR__ . '/experimental/dashboard-widgets/default-layout-seed.php';
 }

--- a/phpunit/experimental/dashboard-layout-test.php
+++ b/phpunit/experimental/dashboard-layout-test.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Tests for the dashboard default layout filter.
+ *
+ * @package gutenberg
+ *
+ * @covers ::gutenberg_inject_dashboard_default_layout
+ */
+class Gutenberg_Dashboard_Default_Layout_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var int
+	 */
+	private $user_id;
+
+	public function set_up() {
+		parent::set_up();
+		$this->user_id = self::factory()->user->create();
+	}
+
+	public function tear_down() {
+		remove_all_filters( 'gutenberg_dashboard_default_layout' );
+		parent::tear_down();
+	}
+
+	private function meta_key() {
+		global $wpdb;
+		return $wpdb->get_blog_prefix() . 'persisted_preferences';
+	}
+
+	public function test_injects_default_when_user_has_no_layout() {
+		$default = array(
+			array(
+				'uuid' => 'a',
+				'type' => 'core/quick-draft',
+			),
+		);
+		add_filter(
+			'gutenberg_dashboard_default_layout',
+			static function () use ( $default ) {
+				return $default;
+			}
+		);
+
+		$value = get_user_meta( $this->user_id, $this->meta_key(), true );
+
+		$this->assertSame( $default, $value['core/dashboard']['dashboardLayout'] );
+	}
+
+	public function test_preserves_user_layout_when_already_committed() {
+		$committed = array(
+			array(
+				'uuid' => 'user-1',
+				'type' => 'core/site-activity',
+			),
+		);
+		update_user_meta(
+			$this->user_id,
+			$this->meta_key(),
+			array(
+				'core/dashboard' => array( 'dashboardLayout' => $committed ),
+			)
+		);
+
+		add_filter(
+			'gutenberg_dashboard_default_layout',
+			static function () {
+				return array(
+					array(
+						'uuid' => 'default',
+						'type' => 'core/quick-draft',
+					),
+				);
+			}
+		);
+
+		$value = get_user_meta( $this->user_id, $this->meta_key(), true );
+
+		$this->assertSame( $committed, $value['core/dashboard']['dashboardLayout'] );
+	}
+
+	public function test_no_op_when_no_default_registered() {
+		$value = get_user_meta( $this->user_id, $this->meta_key(), true );
+		$this->assertEmpty( $value );
+	}
+
+	public function test_ignores_other_meta_keys() {
+		add_filter(
+			'gutenberg_dashboard_default_layout',
+			static function () {
+				return array(
+					array(
+						'uuid' => 'a',
+						'type' => 'core/quick-draft',
+					),
+				);
+			}
+		);
+
+		$value = get_user_meta( $this->user_id, 'some_other_meta', true );
+		$this->assertEmpty( $value );
+	}
+
+	public function test_preserves_other_preference_scopes() {
+		update_user_meta(
+			$this->user_id,
+			$this->meta_key(),
+			array(
+				'core/edit-post' => array( 'fixedToolbar' => true ),
+			)
+		);
+
+		$default = array(
+			array(
+				'uuid' => 'a',
+				'type' => 'core/quick-draft',
+			),
+		);
+		add_filter(
+			'gutenberg_dashboard_default_layout',
+			static function () use ( $default ) {
+				return $default;
+			}
+		);
+
+		$value = get_user_meta( $this->user_id, $this->meta_key(), true );
+
+		$this->assertSame( $default, $value['core/dashboard']['dashboardLayout'] );
+		$this->assertSame( true, $value['core/edit-post']['fixedToolbar'] );
+	}
+}

--- a/phpunit/experimental/dashboard-layout-test.php
+++ b/phpunit/experimental/dashboard-layout-test.php
@@ -16,6 +16,10 @@ class Gutenberg_Dashboard_Default_Layout_Test extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		$this->user_id = self::factory()->user->create();
+
+		// Each test starts with no callbacks so the seed shipped with
+		// the experiment does not leak into the test scenarios.
+		remove_all_filters( 'gutenberg_dashboard_default_layout' );
 	}
 
 	public function tear_down() {

--- a/widgets/hello-world/widget.json
+++ b/widgets/hello-world/widget.json
@@ -1,5 +1,5 @@
 {
-	"name": "wordpress/hello-world",
+	"name": "core/hello-world",
 	"title": "Hello World",
 	"description": "A minimal example widget.",
 	"category": "demo"

--- a/widgets/hello-world/widget.ts
+++ b/widgets/hello-world/widget.ts
@@ -2,6 +2,6 @@
  * Widget type definition
  */
 export default {
-	name: 'wordpress/hello-world',
+	name: 'core/hello-world',
 	title: 'Hello World',
 };


### PR DESCRIPTION
_Part of #78035._

## What?

Adds `gutenberg_inject_dashboard_default_layout()`, a `get_user_metadata` hook that lets plugins and themes register a default dashboard layout from the backend.

The default surfaces transparently through `@wordpress/preferences` for users who have not customized theirs.

## Why?

The dashboard's JS surface reads its layout from the `core/preferences` store, which is persisted on the server through `persisted_preferences` user meta. With the user-meta layer in place, the missing piece is a way for plugins and themes to seed a layout that new users see on first paint, without having to ship JS bootstrap code.

Solving this on the backend keeps the seed logic in one place. Whoever extends WordPress (plugin, theme, mu-plugin) can register a default with a single `add_filter()` call. The dashboard surface stays oblivious: a default and a user-saved layout look identical at the preferences-store boundary.

## How?

A new `lib/experimental/dashboard-widgets/dashboard-layout.php` registers `gutenberg_inject_dashboard_default_layout()` on `get_user_metadata` at priority 99.

The filter only does work when the meta key matches `{prefix}persisted_preferences`. It reads the user's actual stored value (with itself temporarily removed to avoid recursion), and short-circuits when the user already has a non-empty layout under `core/dashboard.dashboardLayout`.

When the stored layout is empty, the filter applies `gutenberg_dashboard_default_layout` and, if the result is a non-empty array, returns the merged preferences with the default placed under the same scope and key the JS side reads.

The file is loaded under the existing `gutenberg-dashboard-widgets` experiment gate, alongside `load.php` and `widget-types.php`.

## Testing

Run the PHPUnit suite for this filter:

```bash
npm run test:unit:php:base -- --filter Gutenberg_Dashboard_Default_Layout_Test
```

Five cases cover:

- Default injected when the user has no committed layout.
- User's committed layout preserved when present.
- No-op when no callback is registered.
- Other meta keys ignored.
- Other preference scopes preserved when injecting.

Manual smoke from a mu-plugin:

```php
add_filter( 'gutenberg_dashboard_default_layout', function () {
    return array(
        array(
            'uuid'      => 'demo-1',
            'type'      => 'core/hello-world',
            'placement' => array( 'width' => 'full', 'height' => 1 ),
        ),
    );
} );
```

Open the dashboard page as a user that has no `dashboardLayout` stored. The widget appears on first paint.

The default registered through the filter is visible from the same store the surface reads. From the browser devtools console:

```js
wp.data.select( 'core/preferences' ).get( 'core/dashboard', 'dashboardLayout' );
```

This returns the array of widget instances currently in the layout. With no user customizations, it's exactly what `gutenberg_dashboard_default_layout` returned. Once the user moves, adds, or removes a widget, the JS side writes back to the same preferences key and the call returns the persisted layout instead.

<img width="602" height="240" alt="image" src="https://github.com/user-attachments/assets/60e0358c-534c-421d-9ba0-afe51d674951" />
