### PR TITLE
Testing: Customizable Dashboard integration (do not merge)

### DIFF
--- a/lib/experimental/dashboard-widgets/dashboard-layout.php
+++ b/lib/experimental/dashboard-widgets/dashboard-layout.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Dashboard Layout: server-side defaults.
+ *
+ * Allows plugins and themes to register a default dashboard layout
+ * that surfaces transparently through the `@wordpress/preferences`
+ * store for users who have not customized theirs.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Preferences scope under which the dashboard layout is stored.
+ * Mirrors the scope read by the JS surface.
+ */
+const GUTENBERG_DASHBOARD_LAYOUT_SCOPE = 'core/dashboard';
+
+/**
+ * Preferences key under `GUTENBERG_DASHBOARD_LAYOUT_SCOPE` that holds
+ * the layout array.
+ */
+const GUTENBERG_DASHBOARD_LAYOUT_KEY = 'dashboardLayout';
+
+/**
+ * Injects a registered default dashboard layout into the user's
+ * `persisted_preferences` read when the stored layout is empty.
+ *
+ * Hooks into `get_user_metadata` so the default propagates through
+ * the same persistence layer the dashboard's JS surface reads from.
+ * The JS side stays oblivious: a default and a user-saved layout
+ * look identical at the preferences-store boundary.
+ *
+ * @param mixed  $value    The pre-fetched value, or null to let the
+ *                         meta API resolve normally.
+ * @param int    $user_id  User ID.
+ * @param string $meta_key Meta key being read.
+ * @return mixed The original value, or a single-element array
+ *               containing the extended persisted preferences.
+ */
+function gutenberg_inject_dashboard_default_layout( $value, $user_id, $meta_key ) {
+	global $wpdb;
+
+	$expected_key = $wpdb->get_blog_prefix() . 'persisted_preferences';
+	if ( $meta_key !== $expected_key ) {
+		return $value;
+	}
+
+	// Avoid recursion when reading the user meta.
+	remove_filter( 'get_user_metadata', __FUNCTION__, 99 );
+	$base = get_user_meta( $user_id, $meta_key, true );
+	add_filter( 'get_user_metadata', __FUNCTION__, 99, 3 );
+
+	if ( ! is_array( $base ) ) {
+		$base = array();
+	}
+
+	$committed = isset( $base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ][ GUTENBERG_DASHBOARD_LAYOUT_KEY ] )
+		? $base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ][ GUTENBERG_DASHBOARD_LAYOUT_KEY ]
+		: array();
+
+	if ( ! empty( $committed ) ) {
+		return $value;
+	}
+
+	/**
+	 * Filters the default dashboard layout served to users who have
+	 * not customized theirs.
+	 *
+	 * Each entry should match the dashboard's widget instance shape:
+	 * `uuid`, `type`, optional `attributes`, optional `placement`.
+	 *
+	 * @param array $default_layout Default array of widget instances.
+	 */
+	$default = apply_filters( 'gutenberg_dashboard_default_layout', array() );
+
+	if ( empty( $default ) || ! is_array( $default ) ) {
+		return $value;
+	}
+
+	if ( ! isset( $base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ] ) || ! is_array( $base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ] ) ) {
+		$base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ] = array();
+	}
+
+	$base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ][ GUTENBERG_DASHBOARD_LAYOUT_KEY ] = $default;
+
+	return array( $base );
+}
+
+add_filter( 'get_user_metadata', 'gutenberg_inject_dashboard_default_layout', 99, 3 );

--- a/lib/experimental/dashboard-widgets/default-layout-seed.php
+++ b/lib/experimental/dashboard-widgets/default-layout-seed.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Dashboard Layout: starter content shipped with the experiment.
+ *
+ * Registers a small default layout under `gutenberg_dashboard_default_layout`
+ * so the dashboard renders something meaningful the first time a user opens
+ * it. Plugins and themes can layer their own callback on top of the same
+ * filter to extend or replace this set.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Appends the bundled `core/hello-world` instance to the default layout
+ * unless something earlier in the filter chain already added it.
+ *
+ * @param array $dashboard_layout Default layout produced by previous
+ *                                callbacks on `gutenberg_dashboard_default_layout`.
+ * @return array The layout extended with the bundled widget instance.
+ */
+function gutenberg_seed_default_dashboard_layout( $dashboard_layout ) {
+	$uuids = array_column( $dashboard_layout, 'uuid' );
+
+	if ( in_array( 'default-hello-world-widget-instance', $uuids, true ) ) {
+		return $dashboard_layout;
+	}
+
+	$dashboard_layout[] = array(
+		'uuid'      => 'default-hello-world-widget-instance',
+		'type'      => 'core/hello-world',
+		'placement' => array(
+			'width'  => 2,
+			'height' => 1,
+		),
+	);
+
+	return $dashboard_layout;
+}
+
+add_filter( 'gutenberg_dashboard_default_layout', 'gutenberg_seed_default_dashboard_layout' );

--- a/lib/experimental/dashboard-widgets/default-layout-seed.php
+++ b/lib/experimental/dashboard-widgets/default-layout-seed.php
@@ -25,7 +25,7 @@ function gutenberg_seed_default_dashboard_layout( $dashboard_layout ) {
 			'type'      => 'core/welcome',
 			'placement' => array(
 				'width'  => 'full',
-				'height' => 1,
+				'height' => 2,
 			),
 		),
 		array(

--- a/lib/experimental/dashboard-widgets/default-layout-seed.php
+++ b/lib/experimental/dashboard-widgets/default-layout-seed.php
@@ -11,28 +11,88 @@
  */
 
 /**
- * Appends the bundled `core/hello-world` instance to the default layout
- * unless something earlier in the filter chain already added it.
+ * Appends the bundled widget instances to the default layout, skipping any
+ * entry whose `uuid` was already added by an earlier callback in the chain.
  *
  * @param array $dashboard_layout Default layout produced by previous
  *                                callbacks on `gutenberg_dashboard_default_layout`.
- * @return array The layout extended with the bundled widget instance.
+ * @return array The layout extended with the bundled widget instances.
  */
 function gutenberg_seed_default_dashboard_layout( $dashboard_layout ) {
-	$uuids = array_column( $dashboard_layout, 'uuid' );
-
-	if ( in_array( 'default-hello-world-widget-instance', $uuids, true ) ) {
-		return $dashboard_layout;
-	}
-
-	$dashboard_layout[] = array(
-		'uuid'      => 'default-hello-world-widget-instance',
-		'type'      => 'core/hello-world',
-		'placement' => array(
-			'width'  => 2,
-			'height' => 1,
+	$seeds = array(
+		array(
+			'uuid'      => 'default-welcome-widget-instance',
+			'type'      => 'core/welcome',
+			'placement' => array(
+				'width'  => 'full',
+				'height' => 1,
+			),
+		),
+		array(
+			'uuid'      => 'default-site-preview-widget-instance',
+			'type'      => 'core/site-preview',
+			'placement' => array(
+				'width'  => 2,
+				'height' => 2,
+			),
+		),
+		array(
+			'uuid'      => 'default-site-health-widget-instance',
+			'type'      => 'core/site-health',
+			'placement' => array(
+				'width'  => 1,
+				'height' => 2,
+			),
+		),
+		array(
+			'uuid'      => 'default-quick-draft-widget-instance',
+			'type'      => 'core/quick-draft',
+			'placement' => array(
+				'width'  => 1,
+				'height' => 2,
+			),
+		),
+		array(
+			'uuid'      => 'default-activity-widget-instance',
+			'type'      => 'core/activity',
+			'placement' => array(
+				'width'  => 1,
+				'height' => 3,
+			),
+		),
+		array(
+			'uuid'      => 'default-news-widget-instance',
+			'type'      => 'core/news',
+			'placement' => array(
+				'width'  => 1,
+				'height' => 2,
+			),
+		),
+		array(
+			'uuid'      => 'default-events-widget-instance',
+			'type'      => 'core/events',
+			'placement' => array(
+				'width'  => 1,
+				'height' => 2,
+			),
+		),
+		array(
+			'uuid'      => 'default-hello-dolly-widget-instance',
+			'type'      => 'core/hello-dolly',
+			'placement' => array(
+				'width'  => 1,
+				'height' => 1,
+			),
 		),
 	);
+
+	$existing_uuids = array_column( $dashboard_layout, 'uuid' );
+
+	foreach ( $seeds as $seed ) {
+		if ( ! in_array( $seed['uuid'], $existing_uuids, true ) ) {
+			$dashboard_layout[] = $seed;
+		}
+	}
 
 	return $dashboard_layout;
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -232,4 +232,6 @@ if ( gutenberg_is_experiment_enabled( 'gutenberg-content-types' ) ) {
 if ( gutenberg_is_experiment_enabled( 'gutenberg-dashboard-widgets' ) ) {
 	require __DIR__ . '/experimental/dashboard-widgets/load.php';
 	require __DIR__ . '/experimental/dashboard-widgets/widget-types.php';
+	require __DIR__ . '/experimental/dashboard-widgets/dashboard-layout.php';
+	require __DIR__ . '/experimental/dashboard-widgets/default-layout-seed.php';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -63105,6 +63105,7 @@
 				"@wordpress/hooks": "file:../../packages/hooks",
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
+				"@wordpress/preferences": "file:../../packages/preferences",
 				"@wordpress/ui": "file:../../packages/ui",
 				"@wordpress/warning": "file:../../packages/warning",
 				"clsx": "^2.1.1"

--- a/packages/grid/src/resize-handle.module.css
+++ b/packages/grid/src/resize-handle.module.css
@@ -6,12 +6,8 @@
 	height: 0;
 	z-index: 1;
 	cursor: nwse-resize;
-	border-style: solid;
-	border-width: 0;
-	border-block-end-width: 12px;
-	border-inline-start-width: 12px;
-	border-color: transparent;
-	border-block-end-color: var(--wpds-color-fg-interactive-brand);
+	border-block-end: 12px solid var(--wpds-color-fg-interactive-brand);
+	border-inline-start: 12px solid transparent;
 }
 
 .is-horizontal-only {

--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -23,6 +23,7 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/core-commands',
 	'@wordpress/core-data',
 	'@wordpress/customize-widgets',
+	'@wordpress/dashboard-widgets',
 	'@wordpress/data',
 	'@wordpress/edit-post',
 	'@wordpress/edit-site',

--- a/phpunit/experimental/dashboard-layout-test.php
+++ b/phpunit/experimental/dashboard-layout-test.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Tests for the dashboard default layout filter.
+ *
+ * @package gutenberg
+ *
+ * @covers ::gutenberg_inject_dashboard_default_layout
+ */
+class Gutenberg_Dashboard_Default_Layout_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var int
+	 */
+	private $user_id;
+
+	public function set_up() {
+		parent::set_up();
+		$this->user_id = self::factory()->user->create();
+
+		// Each test starts with no callbacks so the seed shipped with
+		// the experiment does not leak into the test scenarios.
+		remove_all_filters( 'gutenberg_dashboard_default_layout' );
+	}
+
+	public function tear_down() {
+		remove_all_filters( 'gutenberg_dashboard_default_layout' );
+		parent::tear_down();
+	}
+
+	private function meta_key() {
+		global $wpdb;
+		return $wpdb->get_blog_prefix() . 'persisted_preferences';
+	}
+
+	public function test_injects_default_when_user_has_no_layout() {
+		$default = array(
+			array(
+				'uuid' => 'a',
+				'type' => 'core/quick-draft',
+			),
+		);
+		add_filter(
+			'gutenberg_dashboard_default_layout',
+			static function () use ( $default ) {
+				return $default;
+			}
+		);
+
+		$value = get_user_meta( $this->user_id, $this->meta_key(), true );
+
+		$this->assertSame( $default, $value['core/dashboard']['dashboardLayout'] );
+	}
+
+	public function test_preserves_user_layout_when_already_committed() {
+		$committed = array(
+			array(
+				'uuid' => 'user-1',
+				'type' => 'core/site-activity',
+			),
+		);
+		update_user_meta(
+			$this->user_id,
+			$this->meta_key(),
+			array(
+				'core/dashboard' => array( 'dashboardLayout' => $committed ),
+			)
+		);
+
+		add_filter(
+			'gutenberg_dashboard_default_layout',
+			static function () {
+				return array(
+					array(
+						'uuid' => 'default',
+						'type' => 'core/quick-draft',
+					),
+				);
+			}
+		);
+
+		$value = get_user_meta( $this->user_id, $this->meta_key(), true );
+
+		$this->assertSame( $committed, $value['core/dashboard']['dashboardLayout'] );
+	}
+
+	public function test_no_op_when_no_default_registered() {
+		$value = get_user_meta( $this->user_id, $this->meta_key(), true );
+		$this->assertEmpty( $value );
+	}
+
+	public function test_ignores_other_meta_keys() {
+		add_filter(
+			'gutenberg_dashboard_default_layout',
+			static function () {
+				return array(
+					array(
+						'uuid' => 'a',
+						'type' => 'core/quick-draft',
+					),
+				);
+			}
+		);
+
+		$value = get_user_meta( $this->user_id, 'some_other_meta', true );
+		$this->assertEmpty( $value );
+	}
+
+	public function test_preserves_other_preference_scopes() {
+		update_user_meta(
+			$this->user_id,
+			$this->meta_key(),
+			array(
+				'core/edit-post' => array( 'fixedToolbar' => true ),
+			)
+		);
+
+		$default = array(
+			array(
+				'uuid' => 'a',
+				'type' => 'core/quick-draft',
+			),
+		);
+		add_filter(
+			'gutenberg_dashboard_default_layout',
+			static function () use ( $default ) {
+				return $default;
+			}
+		);
+
+		$value = get_user_meta( $this->user_id, $this->meta_key(), true );
+
+		$this->assertSame( $default, $value['core/dashboard']['dashboardLayout'] );
+		$this->assertSame( true, $value['core/edit-post']['fixedToolbar'] );
+	}
+}

--- a/routes/dashboard/hooks/index.ts
+++ b/routes/dashboard/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useDashboardLayout } from './use-dashboard-layout';

--- a/routes/dashboard/hooks/test/use-dashboard-layout.test.ts
+++ b/routes/dashboard/hooks/test/use-dashboard-layout.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { dispatch } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import useDashboardLayout from '../use-dashboard-layout/use-dashboard-layout';
+import type { DashboardWidget } from '../../widget-dashboard';
+
+const SCOPE = 'core/dashboard';
+const KEY = 'dashboardLayout';
+
+const SAMPLE_LAYOUT: DashboardWidget[] = [
+	{ uuid: 'a', type: 'core/quick-draft' },
+	{ uuid: 'b', type: 'core/at-a-glance' },
+];
+
+describe( 'useDashboardLayout', () => {
+	beforeEach( () => {
+		dispatch( preferencesStore ).set( SCOPE, KEY, undefined );
+	} );
+
+	it( 'returns an empty array when nothing is persisted', () => {
+		const { result } = renderHook( () => useDashboardLayout() );
+		const [ layout ] = result.current;
+		expect( layout ).toEqual( [] );
+	} );
+
+	it( 'persists updates written through setLayout', () => {
+		const { result } = renderHook( () => useDashboardLayout() );
+
+		act( () => {
+			const [ , setLayout ] = result.current;
+			setLayout( SAMPLE_LAYOUT );
+		} );
+
+		const [ layout ] = result.current;
+		expect( layout ).toEqual( SAMPLE_LAYOUT );
+	} );
+
+	it( 'reads the layout written from outside the hook', () => {
+		dispatch( preferencesStore ).set( SCOPE, KEY, SAMPLE_LAYOUT );
+
+		const { result } = renderHook( () => useDashboardLayout() );
+		const [ layout ] = result.current;
+		expect( layout ).toEqual( SAMPLE_LAYOUT );
+	} );
+
+	it( 'clears the layout via resetLayout', () => {
+		const { result } = renderHook( () => useDashboardLayout() );
+
+		act( () => {
+			const [ , setLayout ] = result.current;
+			setLayout( SAMPLE_LAYOUT );
+		} );
+
+		act( () => {
+			const [ , , resetLayout ] = result.current;
+			resetLayout();
+		} );
+
+		const [ layout ] = result.current;
+		expect( layout ).toEqual( [] );
+	} );
+} );

--- a/routes/dashboard/hooks/use-dashboard-layout/index.ts
+++ b/routes/dashboard/hooks/use-dashboard-layout/index.ts
@@ -1,0 +1,1 @@
+export { default as useDashboardLayout } from './use-dashboard-layout';

--- a/routes/dashboard/hooks/use-dashboard-layout/use-dashboard-layout.ts
+++ b/routes/dashboard/hooks/use-dashboard-layout/use-dashboard-layout.ts
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import type { DashboardWidget } from '../../widget-dashboard';
+
+const SCOPE = 'core/dashboard';
+const KEY = 'dashboardLayout';
+
+/**
+ * Hook for managing dashboard layout preferences.
+ *
+ * Returns the persisted layout, a setter that writes through to the
+ * preferences store, and a reset action that clears the layout to its
+ * empty state. Plugin-provided defaults will replace the empty fallback
+ * once the defaults source lands.
+ *
+ * @return Tuple `[ layout, setLayout, resetLayout ]`.
+ */
+function useDashboardLayout(): [
+	DashboardWidget[],
+	( layout: DashboardWidget[] ) => void,
+	() => void,
+] {
+	const layout = useSelect(
+		( select ) =>
+			( select( preferencesStore ).get( SCOPE, KEY ) as
+				| DashboardWidget[]
+				| undefined ) ?? [],
+		[]
+	);
+
+	const { set } = useDispatch( preferencesStore );
+
+	function setLayout( newLayout: DashboardWidget[] ) {
+		void set( SCOPE, KEY, newLayout );
+	}
+
+	function resetLayout() {
+		void set( SCOPE, KEY, [] );
+	}
+
+	return [ layout, setLayout, resetLayout ];
+}
+
+export default useDashboardLayout;

--- a/routes/dashboard/package.json
+++ b/routes/dashboard/package.json
@@ -20,6 +20,7 @@
 		"@wordpress/hooks": "file:../../packages/hooks",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
+		"@wordpress/preferences": "file:../../packages/preferences",
 		"@wordpress/ui": "file:../../packages/ui",
 		"@wordpress/warning": "file:../../packages/warning",
 		"clsx": "^2.1.1"

--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -17,7 +17,7 @@ function Dashboard() {
 
 	const widgetTypes = useWidgetTypes();
 
-	const [ editMode, setEditMode ] = useState( true );
+	const [ editMode, setEditMode ] = useState( false );
 
 	return (
 		<WidgetDashboard

--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -17,7 +17,7 @@ function Dashboard() {
 
 	const widgetTypes = useWidgetTypes();
 
-	const [ editMode, setEditMode ] = useState( false );
+	const [ editMode, setEditMode ] = useState( true );
 
 	return (
 		<WidgetDashboard
@@ -30,6 +30,7 @@ function Dashboard() {
 			<Page
 				title={ __( 'Dashboard' ) }
 				actions={ <WidgetDashboard.Actions /> }
+				hasPadding
 			>
 				<WidgetDashboard.NoWidgetsState />
 				<WidgetDashboard.Widgets />

--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -11,16 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { WidgetDashboard, type DashboardWidget } from './widget-dashboard';
 import { useWidgetTypes } from './widget-types';
 
-const DEFAULT_LAYOUT: DashboardWidget[] = [
-	{
-		uuid: '1',
-		type: 'wordpress/hello-world',
-		placement: {
-			width: 'full',
-			height: 1,
-		},
-	},
-];
+const DEFAULT_LAYOUT: DashboardWidget[] = [];
 
 function Dashboard() {
 	const [ layout, setLayout ] =
@@ -42,6 +33,7 @@ function Dashboard() {
 				title={ __( 'Dashboard' ) }
 				actions={ <WidgetDashboard.Actions /> }
 			>
+				<WidgetDashboard.NoWidgetsState />
 				<WidgetDashboard.Widgets />
 			</Page>
 		</WidgetDashboard>

--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -8,14 +8,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { WidgetDashboard, type DashboardWidget } from './widget-dashboard';
+import { useDashboardLayout } from './hooks';
+import { WidgetDashboard } from './widget-dashboard';
 import { useWidgetTypes } from './widget-types';
 
-const DEFAULT_LAYOUT: DashboardWidget[] = [];
-
 function Dashboard() {
-	const [ layout, setLayout ] =
-		useState< DashboardWidget[] >( DEFAULT_LAYOUT );
+	const [ layout, setLayout ] = useDashboardLayout();
 
 	const widgetTypes = useWidgetTypes();
 

--- a/routes/dashboard/widget-dashboard/README.md
+++ b/routes/dashboard/widget-dashboard/README.md
@@ -88,7 +88,7 @@ Renders its children only when `layout` is empty. Pair it with `<WidgetDashboard
 
 #### `<WidgetDashboard.Actions />`
 
-Edit-mode toggle: a "Customize" button while `editMode` is off and a "Done" button while it is on. Clicking either fires `onEditChange` with the toggled value. Returns `null` when the dashboard is mounted without `onEditChange`, so surfaces that don't expose edit mode can keep `Actions` in their tree unconditionally.
+Edit-mode toggle: a "Customize" button while `editMode` is off, and "Add widgets", "Cancel", "Done" while it is on. Clicking "Customize" or "Done" fires `onEditChange` with the toggled value. Clicking "Add widgets" opens the inserter (see below). Returns `null` when the dashboard is mounted without `onEditChange`, so surfaces that don't expose edit mode can keep `Actions` in their tree unconditionally.
 
 `<Page>` from `@wordpress/admin-ui` exposes an `actions` slot used across admin surfaces (DataViews, WidgetDashboard, …). Plug `Actions` straight into it:
 
@@ -112,6 +112,14 @@ import { Page } from '@wordpress/admin-ui';
 ```
 
 `<Page>` is optional. The compound renders inside any container, so a bare `<header>` or custom chrome works just as well.
+
+## Inserting widgets
+
+A modal-based inserter is mounted automatically inside `WidgetDashboard`. It stays hidden until the "Add widgets" button in `<WidgetDashboard.Actions />` is clicked. The inserter lists every entry in the `widgetTypes` prop as a grid of live previews (each preview renders the type's `example` attributes through its own render module), supports search, and exposes a single "Select" action with bulk support so users can insert one or several widgets in a single layout change.
+
+On confirmation, the inserter creates instances via `createDashboardWidget( widgetType )` (using each type's `example.attributes` as the initial values) and appends them to `layout` through `onLayoutChange`. The dialog closes after a successful insertion or when the user dismisses it.
+
+The inserter has no opt-out today; surfaces that want a custom widget-picking experience should compose their own UI alongside `<WidgetDashboard.Widgets />` and avoid rendering `<WidgetDashboard.Actions />` (which exposes the trigger).
 
 ## Authoring widgets
 

--- a/routes/dashboard/widget-dashboard/components/actions/actions.tsx
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.tsx
@@ -10,6 +10,7 @@ import { Button, Stack } from '@wordpress/ui';
  * Internal dependencies
  */
 import { useDashboardInternalContext } from '../../context/dashboard-context';
+import { useDashboardUIContext } from '../../context/ui-context';
 
 /**
  * Renders the dashboard's edit-mode toggle. Shows a "Customize" button while
@@ -24,23 +25,23 @@ import { useDashboardInternalContext } from '../../context/dashboard-context';
  */
 export function Actions(): React.ReactNode {
 	const { editMode, onEditChange } = useDashboardInternalContext();
+	const { setInserterOpen } = useDashboardUIContext();
 
 	const handleEditMode = useCallback( () => {
 		onEditChange?.( ! editMode );
 	}, [ editMode, onEditChange ] );
 
-	const handleInsertWidget = useCallback( () => {
-		// eslint-disable-next-line no-console
-		console.log( 'insert widget' ); // TODO: Implement widget insertion
-	}, [] );
+	const insert = useCallback( () => {
+		setInserterOpen( true );
+	}, [ setInserterOpen ] );
 
-	const handleCancel = useCallback( () => {
+	const cancel = useCallback( () => {
 		// eslint-disable-next-line no-console
 		console.log( 'cancel' ); // TODO: Implement cancel\
 		onEditChange?.( false );
 	}, [ onEditChange ] );
 
-	const handleDone = useCallback( () => {
+	const done = useCallback( () => {
 		// eslint-disable-next-line no-console
 		console.log( 'done' ); // TODO: Implement done
 		onEditChange?.( false );
@@ -58,23 +59,25 @@ export function Actions(): React.ReactNode {
 						variant="minimal"
 						tone="brand"
 						size="compact"
-						onClick={ handleInsertWidget }
+						onClick={ insert }
 					>
 						{ __( 'Add widgets' ) }
 					</Button>
+
 					<Button
 						variant="minimal"
 						tone="brand"
 						size="compact"
-						onClick={ handleCancel }
+						onClick={ cancel }
 					>
 						{ __( 'Cancel' ) }
 					</Button>
+
 					<Button
 						variant="solid"
 						tone="brand"
 						size="compact"
-						onClick={ handleDone }
+						onClick={ done }
 					>
 						{ __( 'Done' ) }
 					</Button>

--- a/routes/dashboard/widget-dashboard/components/inserter/index.ts
+++ b/routes/dashboard/widget-dashboard/components/inserter/index.ts
@@ -1,0 +1,1 @@
+export { Inserter } from './inserter';

--- a/routes/dashboard/widget-dashboard/components/inserter/inserter.tsx
+++ b/routes/dashboard/widget-dashboard/components/inserter/inserter.tsx
@@ -1,0 +1,58 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Dialog } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import { useDashboardInternalContext } from '../../context/dashboard-context';
+import { useDashboardUIContext } from '../../context/ui-context';
+import { createDashboardWidget } from '../../utils/create-dashboard-widget';
+import { WidgetPicker } from '../widget-picker';
+import type { WidgetType } from '../../types';
+
+/**
+ * Modal-based widget inserter. The dialog stays hidden until `inserterOpen`
+ * flips to `true` from any compound sharing the UI context.
+ */
+export function Inserter() {
+	const { layout, onLayoutChange } = useDashboardInternalContext();
+	const { inserterOpen, setInserterOpen } = useDashboardUIContext();
+
+	const insertWidgets = useCallback(
+		( widgetTypes: WidgetType[] ) => {
+			if ( widgetTypes.length > 0 ) {
+				const newWidgets = widgetTypes.map( ( widgetType ) =>
+					createDashboardWidget( widgetType )
+				);
+				onLayoutChange( [ ...layout, ...newWidgets ] );
+			}
+
+			setInserterOpen( false );
+		},
+		[ layout, onLayoutChange, setInserterOpen ]
+	);
+
+	if ( ! inserterOpen ) {
+		return null;
+	}
+
+	return (
+		<Dialog.Root open={ inserterOpen } onOpenChange={ setInserterOpen }>
+			<Dialog.Popup size="large">
+				<Dialog.Header>
+					<Dialog.Title>{ __( 'Add widget' ) }</Dialog.Title>
+					<Dialog.CloseIcon />
+				</Dialog.Header>
+
+				<Dialog.Content>
+					<WidgetPicker onSelect={ insertWidgets } />
+				</Dialog.Content>
+			</Dialog.Popup>
+		</Dialog.Root>
+	);
+}

--- a/routes/dashboard/widget-dashboard/components/widget-picker/index.ts
+++ b/routes/dashboard/widget-dashboard/components/widget-picker/index.ts
@@ -1,0 +1,1 @@
+export { WidgetPicker } from './widget-picker';

--- a/routes/dashboard/widget-dashboard/components/widget-picker/widget-picker.module.css
+++ b/routes/dashboard/widget-dashboard/components/widget-picker/widget-picker.module.css
@@ -1,0 +1,5 @@
+.preview {
+	height: 100%;
+	overflow: hidden;
+	padding: var(--wpds-dimension-padding-md);
+}

--- a/routes/dashboard/widget-dashboard/components/widget-picker/widget-picker.tsx
+++ b/routes/dashboard/widget-dashboard/components/widget-picker/widget-picker.tsx
@@ -1,0 +1,136 @@
+/**
+ * WordPress dependencies
+ */
+import { DataViewsPicker, filterSortAndPaginate } from '@wordpress/dataviews';
+import type { Field, View } from '@wordpress/dataviews';
+import { useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useDashboardInternalContext } from '../../context/dashboard-context';
+import { createDashboardWidget } from '../../utils/create-dashboard-widget';
+import { WidgetRender } from '../widget-render';
+import styles from './widget-picker.module.css';
+import type { WidgetType } from '../../types';
+
+const DEFAULT_VIEW: View = {
+	type: 'pickerGrid',
+	page: 1,
+	search: '',
+	mediaField: 'preview',
+	titleField: 'title',
+};
+
+const getItemId = ( item: WidgetType ) => item.name;
+
+function WidgetPreview( { item }: { item: WidgetType } ) {
+	const exampleWidget = useMemo(
+		() => createDashboardWidget( item, item.example?.attributes ),
+		[ item ]
+	);
+
+	return (
+		<div className={ styles.preview } { ...{ inert: '' } }>
+			<WidgetRender widget={ exampleWidget } widgetType={ item } />
+		</div>
+	);
+}
+
+const fields: Field< WidgetType >[] = [
+	{
+		id: 'title',
+		type: 'text',
+		label: __( 'Title' ),
+		filterBy: false,
+	},
+	{
+		id: 'preview',
+		type: 'media',
+		render: WidgetPreview,
+	},
+	{
+		id: 'name',
+		type: 'text',
+		enableGlobalSearch: true,
+		enableHiding: false,
+		enableSorting: false,
+		filterBy: false,
+		getValue: ( { item } ) =>
+			`${ item.name.replace( /[\/,\-_]/g, ' ' ) } ${ item.title }`,
+	},
+];
+
+interface WidgetPickerProps {
+	/**
+	 * Called with the widget types selected by the user. The picker keeps
+	 * its own selection state; consumers receive the resolved list when
+	 * the "Select" action fires.
+	 */
+	onSelect: ( widgetTypes: WidgetType[] ) => void;
+
+	/**
+	 * Accessible label for the picker's item list.
+	 *
+	 * @default __( 'Widget list' )
+	 */
+	itemListLabel?: string;
+}
+
+/**
+ * DataViews-driven widget type picker. Lists `widgetTypes` from the dashboard
+ * context as a grid of live previews, supports search via `name`/`title`, and
+ * exposes a single "Select" action with bulk support so users can insert one
+ * or several widgets at once.
+ *
+ * @param { WidgetPickerProps } props - The props for the WidgetPicker component.
+ * @return { React.ReactNode } - The WidgetPicker component.
+ */
+export function WidgetPicker( {
+	onSelect,
+	itemListLabel = __( 'Widget list' ),
+}: WidgetPickerProps ) {
+	const { widgetTypes: registeredTypes } = useDashboardInternalContext();
+	const [ selection, setSelection ] = useState< string[] >( [] );
+	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+
+	const { data: widgetTypes } = filterSortAndPaginate(
+		registeredTypes,
+		view,
+		fields
+	);
+
+	const actions = useMemo(
+		() => [
+			{
+				id: 'select',
+				label: __( 'Select' ),
+				isPrimary: true,
+				supportsBulk: true,
+				callback: ( items: WidgetType[] ) => onSelect( items ),
+			},
+		],
+		[ onSelect ]
+	);
+
+	return (
+		<DataViewsPicker
+			data={ widgetTypes }
+			fields={ fields }
+			view={ view }
+			actions={ actions }
+			defaultLayouts={ { pickerGrid: {} } }
+			onChangeView={ setView }
+			isLoading={ false }
+			paginationInfo={ {
+				totalItems: widgetTypes.length,
+				totalPages: 1,
+			} }
+			selection={ selection }
+			onChangeSelection={ setSelection }
+			getItemId={ getItemId }
+			itemListLabel={ itemListLabel }
+		/>
+	);
+}

--- a/routes/dashboard/widget-dashboard/components/widget/widget.module.css
+++ b/routes/dashboard/widget-dashboard/components/widget/widget.module.css
@@ -1,4 +1,4 @@
-.widget {
+.widget-chrome-container {
 	height: 100%;
 	box-sizing: border-box;
 }

--- a/routes/dashboard/widget-dashboard/components/widget/widget.tsx
+++ b/routes/dashboard/widget-dashboard/components/widget/widget.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { forwardRef, useMemo } from '@wordpress/element';
+import { Card } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -43,13 +44,22 @@ export const Widget = forwardRef< HTMLDivElement, WidgetProps >(
 
 		return (
 			<WidgetContextProvider value={ contextValue }>
-				<div
-					ref={ ref }
-					className={ styles.widget }
+				<Card.Root
+					className={ styles[ 'widget-chrome-container' ] }
 					{ ...( editMode ? { inert: '' } : {} ) }
+					ref={ ref }
 				>
-					<WidgetRender widget={ widget } widgetType={ widgetType } />
-				</div>
+					<Card.Header>
+						<Card.Title>{ widgetType.title }</Card.Title>
+					</Card.Header>
+
+					<Card.Content>
+						<WidgetRender
+							widget={ widget }
+							widgetType={ widgetType }
+						/>
+					</Card.Content>
+				</Card.Root>
 			</WidgetContextProvider>
 		);
 	}

--- a/routes/dashboard/widget-dashboard/context/ui-context.tsx
+++ b/routes/dashboard/widget-dashboard/context/ui-context.tsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	createContext,
+	useContext,
+	useMemo,
+	useState,
+} from '@wordpress/element';
+
+interface DashboardUIContextValue {
+	inserterOpen: boolean;
+	setInserterOpen: ( next: boolean ) => void;
+}
+
+const Context = createContext< DashboardUIContextValue | null >( null );
+
+/**
+ * UI-state hook used by the inserter modal and any compound that needs to
+ * open or close it (today: the "Add widgets" trigger in `Actions`).
+ *
+ * Throws when called outside `WidgetDashboard` so misuse fails loudly during
+ * development.
+ */
+export function useDashboardUIContext(): DashboardUIContextValue {
+	const ctx = useContext( Context );
+	if ( ! ctx ) {
+		throw new Error(
+			'Dashboard compound used outside a WidgetDashboard subtree.'
+		);
+	}
+	return ctx;
+}
+
+interface ProviderProps {
+	children: ReactNode;
+}
+
+/**
+ * Holds transient UI state shared across compounds (today: whether the
+ * inserter modal is open). Kept separate from the data context so that data
+ * mutations don't churn the UI state and vice-versa.
+ * @param root0
+ * @param root0.children
+ */
+export function WidgetDashboardUIProvider( { children }: ProviderProps ) {
+	const [ inserterOpen, setInserterOpen ] = useState( false );
+
+	const value = useMemo< DashboardUIContextValue >(
+		() => ( { inserterOpen, setInserterOpen } ),
+		[ inserterOpen ]
+	);
+
+	return <Context.Provider value={ value }>{ children }</Context.Provider>;
+}

--- a/routes/dashboard/widget-dashboard/test/inserter.test.tsx
+++ b/routes/dashboard/widget-dashboard/test/inserter.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ComponentType } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { WidgetDashboard } from '../widget-dashboard';
+import type {
+	DashboardWidget,
+	ResolveWidgetModule,
+	WidgetRenderProps,
+	WidgetType,
+} from '../types';
+
+function PreviewWidget( {
+	attributes,
+}: WidgetRenderProps< { label?: string } > ) {
+	return <div data-testid="widget-content">{ attributes?.label ?? '—' }</div>;
+}
+
+const widgetTypes: WidgetType[] = [
+	{
+		apiVersion: 1,
+		name: 'wordpress/welcome',
+		title: 'Welcome',
+		renderModule: 'welcome-module',
+		example: { attributes: { label: 'welcome-example' } },
+	},
+	{
+		apiVersion: 1,
+		name: 'wordpress/notes',
+		title: 'Notes',
+		renderModule: 'notes-module',
+		example: { attributes: { label: 'notes-example' } },
+	},
+];
+
+const resolveWidgetModule: ResolveWidgetModule = async () => ( {
+	default: PreviewWidget as ComponentType< WidgetRenderProps< unknown > >,
+} );
+
+interface HarnessProps {
+	initialLayout?: DashboardWidget[];
+	onLayoutChange?: ( layout: DashboardWidget[] ) => void;
+}
+
+function Harness( {
+	initialLayout = [],
+	onLayoutChange: onChange,
+}: HarnessProps ) {
+	const [ layout, setLayout ] =
+		useState< DashboardWidget[] >( initialLayout );
+	const [ editMode, setEditMode ] = useState( true );
+
+	return (
+		<WidgetDashboard
+			layout={ layout }
+			onLayoutChange={ ( next ) => {
+				setLayout( next );
+				onChange?.( next );
+			} }
+			widgetTypes={ widgetTypes }
+			editMode={ editMode }
+			onEditChange={ setEditMode }
+			resolveWidgetModule={ resolveWidgetModule }
+		/>
+	);
+}
+
+describe( 'WidgetDashboard.Inserter', () => {
+	it( 'is hidden until the "Add widgets" trigger is clicked', () => {
+		render( <Harness /> );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'opens after clicking the "Add widgets" trigger', async () => {
+		const user = userEvent.setup();
+		render( <Harness /> );
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Add widgets' } )
+		);
+
+		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+	} );
+
+	it( 'inserts the selected widget type into the layout and closes', async () => {
+		const user = userEvent.setup();
+		const onLayoutChange = jest.fn();
+		render( <Harness onLayoutChange={ onLayoutChange } /> );
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Add widgets' } )
+		);
+
+		const dialog = await screen.findByRole( 'dialog' );
+		const options = within( dialog ).getAllByRole( 'option' );
+		expect( options ).toHaveLength( widgetTypes.length );
+
+		await user.click( options[ 0 ] );
+		await user.click(
+			within( dialog ).getByRole( 'button', { name: 'Select' } )
+		);
+
+		expect( onLayoutChange ).toHaveBeenCalledTimes( 1 );
+		const [ updated ] = onLayoutChange.mock.calls[ 0 ];
+		expect( updated ).toHaveLength( 1 );
+		expect( updated[ 0 ] ).toMatchObject( {
+			type: 'wordpress/welcome',
+			attributes: { label: 'welcome-example' },
+		} );
+		expect( updated[ 0 ].uuid ).toEqual( expect.any( String ) );
+
+		await waitFor( () =>
+			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument()
+		);
+	} );
+
+	it( 'inserts multiple widgets via multi-select in a single layout change', async () => {
+		const user = userEvent.setup();
+		const onLayoutChange = jest.fn();
+		render( <Harness onLayoutChange={ onLayoutChange } /> );
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Add widgets' } )
+		);
+
+		const dialog = await screen.findByRole( 'dialog' );
+		const options = within( dialog ).getAllByRole( 'option' );
+
+		await user.click( options[ 0 ] );
+		await user.click( options[ 1 ] );
+
+		await user.click(
+			within( dialog ).getByRole( 'button', { name: 'Select' } )
+		);
+
+		expect( onLayoutChange ).toHaveBeenCalledTimes( 1 );
+		const [ updated ] = onLayoutChange.mock.calls[ 0 ];
+		expect( updated ).toHaveLength( 2 );
+		expect( updated.map( ( w: DashboardWidget ) => w.type ) ).toEqual( [
+			'wordpress/welcome',
+			'wordpress/notes',
+		] );
+	} );
+
+	it( 'preserves existing widgets when appending new ones', async () => {
+		const user = userEvent.setup();
+		const onLayoutChange = jest.fn();
+		const existing: DashboardWidget = {
+			uuid: 'existing-1',
+			type: 'wordpress/welcome',
+			attributes: { label: 'kept' },
+			placement: { width: 1, height: 1 },
+		};
+
+		render(
+			<Harness
+				initialLayout={ [ existing ] }
+				onLayoutChange={ onLayoutChange }
+			/>
+		);
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Add widgets' } )
+		);
+
+		const dialog = await screen.findByRole( 'dialog' );
+		await user.click( within( dialog ).getAllByRole( 'option' )[ 1 ] );
+		await user.click(
+			within( dialog ).getByRole( 'button', { name: 'Select' } )
+		);
+
+		const [ updated ] = onLayoutChange.mock.calls[ 0 ];
+		expect( updated ).toHaveLength( 2 );
+		expect( updated[ 0 ] ).toEqual( existing );
+		expect( updated[ 1 ] ).toMatchObject( { type: 'wordpress/notes' } );
+	} );
+} );

--- a/routes/dashboard/widget-dashboard/widget-dashboard.tsx
+++ b/routes/dashboard/widget-dashboard/widget-dashboard.tsx
@@ -2,7 +2,9 @@
  * Internal dependencies
  */
 import { WidgetDashboardProvider } from './context/dashboard-context';
+import { WidgetDashboardUIProvider } from './context/ui-context';
 import { Actions } from './components/actions';
+import { Inserter } from './components/inserter';
 import { Widget } from './components/widget';
 import { Widgets } from './components/widgets';
 import type { WidgetDashboardProps } from './types';
@@ -56,13 +58,17 @@ export const WidgetDashboard = Object.assign(
 				resolveWidgetModule={ resolveWidgetModule }
 				gridSettings={ gridSettings }
 			>
-				{ children ?? (
-					<>
-						<NoWidgetsState />
-						<Actions />
-						<Widgets />
-					</>
-				) }
+				<WidgetDashboardUIProvider>
+					{ children ?? (
+						<>
+							<NoWidgetsState />
+							<Actions />
+							<Widgets />
+						</>
+					) }
+
+					<Inserter />
+				</WidgetDashboardUIProvider>
 			</WidgetDashboardProvider>
 		);
 	},

--- a/widgets/activity/render.tsx
+++ b/widgets/activity/render.tsx
@@ -1,0 +1,312 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import { dateI18n, getDate } from '@wordpress/date';
+import { Spinner } from '@wordpress/components';
+import { Icon, comment, postList } from '@wordpress/icons';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+
+// Dashboard is still experimental.
+
+import { EmptyState, Link, Stack } from '@wordpress/ui';
+import type { View, Field } from '@wordpress/dataviews';
+import type { Post, Comment } from '@wordpress/core-data';
+
+// ─── Item type ────────────────────────────────────────────────────────────────
+
+type ActivityKind = 'post-future' | 'post-published' | 'comment';
+
+type ActivityEvent = {
+	id: string;
+	// ISO date string — used for sorting and extracting the `date` group key.
+	datetime: string;
+	title: string;
+	description: string;
+	link: string;
+	kind: ActivityKind;
+};
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Formats a `YYYY-MM-DD` string into a human-readable group label:
+ *  - Today / Yesterday / "Jun 15th" / "Jun 15th 2023"
+ *
+ * @param {string} dateStr YYYY-MM-DD date string.
+ */
+function formatGroupDate( dateStr: string ): string {
+	const now = getDate();
+	const today = dateI18n( 'Y-m-d', now );
+
+	if ( dateStr === today ) {
+		return __( 'Today' );
+	}
+
+	const yesterday = getDate();
+	yesterday.setDate( yesterday.getDate() - 1 );
+	const yesterdayStr = dateI18n( 'Y-m-d', yesterday );
+
+	if ( dateStr === yesterdayStr ) {
+		return __( 'Yesterday' );
+	}
+
+	const currentYear = dateI18n( 'Y', now );
+
+	if ( dateStr.slice( 0, 4 ) === currentYear ) {
+		/* translators: Date format for dashboard activity group header (current year), see https://www.php.net/manual/datetime.format.php */
+		return dateI18n( __( 'M jS' ), dateStr );
+	}
+
+	/* translators: Date format for dashboard activity group header (different year), see https://www.php.net/manual/datetime.format.php */
+	return dateI18n( __( 'M jS Y' ), dateStr );
+}
+
+// ─── Fields ───────────────────────────────────────────────────────────────────
+
+const FIELDS: Field< ActivityEvent >[] = [
+	{
+		id: 'icon',
+		label: __( 'Icon' ),
+		type: 'media',
+		render: ( { item } ) => (
+			<Icon icon={ item.kind === 'comment' ? comment : postList } />
+		),
+		enableSorting: false,
+		enableHiding: false,
+	},
+	{
+		id: 'content',
+		label: __( 'Content' ),
+		getValue: ( { item } ) => item.title,
+		render: ( { item } ) => (
+			<>
+				<strong>{ item.title }</strong>
+				{ item.description && (
+					<>
+						{ ': ' }
+						<span
+							dangerouslySetInnerHTML={ {
+								__html: item.description,
+							} }
+						/>
+					</>
+				) }
+			</>
+		),
+		enableSorting: false,
+		enableGlobalSearch: true,
+	},
+	{
+		id: 'time',
+		label: __( 'Time' ),
+		getValue: ( { item } ) => item.datetime,
+		render: ( { item } ) => (
+			<span>
+				{ /* translators: Time format for activity stream, see https://www.php.net/manual/datetime.format.php */ }
+				{ dateI18n( __( 'g:i a' ), item.datetime ) }
+			</span>
+		),
+		enableSorting: false,
+	},
+	{
+		id: 'date',
+		label: __( 'Date' ),
+		getValue: ( { item } ) => item.datetime.split( 'T' )[ 0 ],
+		render: ( { item } ) => (
+			<span>{ formatGroupDate( item.datetime.split( 'T' )[ 0 ] ) }</span>
+		),
+		enableSorting: false,
+		enableHiding: false,
+	},
+];
+
+// ─── Default view ─────────────────────────────────────────────────────────────
+
+const DEFAULT_VIEW: View = {
+	type: 'activity',
+	search: '',
+	page: 1,
+	perPage: 20,
+	filters: [],
+	fields: [ 'time' ],
+	titleField: 'content',
+	mediaField: 'icon',
+	showMedia: true,
+	sort: {
+		field: 'datetime',
+		direction: 'desc',
+	},
+	groupBy: {
+		field: 'date',
+		direction: 'desc',
+		showLabel: false,
+	},
+};
+
+const FUTURE_POSTS_QUERY = {
+	status: 'future',
+	orderby: 'date',
+	order: 'asc',
+	per_page: 5,
+};
+
+const RECENT_POSTS_QUERY = {
+	status: 'publish',
+	orderby: 'date',
+	order: 'desc',
+	per_page: 5,
+};
+
+const COMMENTS_QUERY = {
+	per_page: 5,
+};
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function Activity() {
+	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const { futurePosts, recentPosts, comments, isResolved } = useSelect(
+		( select ) => {
+			const coreData = select( coreStore );
+
+			return {
+				futurePosts: coreData.getEntityRecords< Post >(
+					'postType',
+					'post',
+					FUTURE_POSTS_QUERY
+				),
+				recentPosts: coreData.getEntityRecords< Post >(
+					'postType',
+					'post',
+					RECENT_POSTS_QUERY
+				),
+				comments: coreData.getEntityRecords< Comment >(
+					'root',
+					'comment',
+					COMMENTS_QUERY
+				),
+				isResolved:
+					coreData.hasFinishedResolution( 'getEntityRecords', [
+						'postType',
+						'post',
+						FUTURE_POSTS_QUERY,
+					] ) &&
+					coreData.hasFinishedResolution( 'getEntityRecords', [
+						'postType',
+						'post',
+						RECENT_POSTS_QUERY,
+					] ) &&
+					coreData.hasFinishedResolution( 'getEntityRecords', [
+						'root',
+						'comment',
+						COMMENTS_QUERY,
+					] ),
+			};
+		},
+		[]
+	);
+
+	const allEvents = useMemo< ActivityEvent[] >( () => {
+		const events: ActivityEvent[] = [];
+
+		for ( const post of futurePosts ?? [] ) {
+			events.push( {
+				id: `post-future-${ post.id }`,
+				datetime: post.date ?? '',
+				title: ( post.title as { rendered: string } )?.rendered ?? '',
+				description: '',
+				link: post.link ?? '',
+				kind: 'post-future',
+			} );
+		}
+
+		for ( const post of recentPosts ?? [] ) {
+			events.push( {
+				id: `post-published-${ post.id }`,
+				datetime: post.date ?? '',
+				title: ( post.title as { rendered: string } )?.rendered ?? '',
+				description: '',
+				link: post.link ?? '',
+				kind: 'post-published',
+			} );
+		}
+
+		for ( const c of comments ?? [] ) {
+			events.push( {
+				id: `comment-${ c.id }`,
+				datetime: ( c.date as string ) ?? '',
+				title: ( c.author_name as string ) ?? '',
+				description:
+					( c.content as { rendered: string } )?.rendered ?? '',
+				link: ( c.link as string ) ?? '',
+				kind: 'comment',
+			} );
+		}
+
+		return events;
+	}, [ futurePosts, recentPosts, comments ] );
+
+	const { data: shownData, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( allEvents, view, FIELDS ),
+		[ allEvents, view ]
+	);
+
+	if ( ! isResolved ) {
+		return (
+			<Stack align="center" justify="center" style={ { minHeight: 220 } }>
+				<Spinner />
+			</Stack>
+		);
+	}
+
+	if ( allEvents.length === 0 ) {
+		return (
+			<Stack align="center" justify="center" style={ { minHeight: 220 } }>
+				<EmptyState.Root>
+					<EmptyState.Icon icon={ postList } />
+					<EmptyState.Title>
+						{ __( 'No activity yet.' ) }
+					</EmptyState.Title>
+					<EmptyState.Description>
+						{ __(
+							'When you publish posts or receive comments, they will appear here.'
+						) }
+					</EmptyState.Description>
+				</EmptyState.Root>
+			</Stack>
+		);
+	}
+
+	return (
+		<DataViews
+			data={ shownData }
+			fields={ FIELDS }
+			view={ view }
+			onChangeView={ setView }
+			paginationInfo={ paginationInfo }
+			getItemId={ ( item ) => item.id }
+			search={ false }
+			isLoading={ false }
+			defaultLayouts={ {
+				activity: {
+					sort: {
+						field: 'datetime',
+						direction: 'desc',
+					},
+				},
+			} }
+			renderItemLink={ ( { item, children, ...aProps } ) => (
+				<Link href={ item.link } { ...aProps }>
+					{ children }
+				</Link>
+			) }
+			isItemClickable={ ( item ) => !! item.link }
+		>
+			<DataViews.Layout />
+		</DataViews>
+	);
+}

--- a/widgets/activity/widget.json
+++ b/widgets/activity/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "core/activity",
+	"title": "Activity",
+	"description": "Displays recently published posts, scheduled posts, and recent comments.",
+	"category": "dashboard"
+}

--- a/widgets/activity/widget.ts
+++ b/widgets/activity/widget.ts
@@ -1,0 +1,6 @@
+import { __ } from '@wordpress/i18n';
+
+export default {
+	name: 'core/activity',
+	title: __( 'Activity' ),
+};

--- a/widgets/events/list.tsx
+++ b/widgets/events/list.tsx
@@ -1,0 +1,83 @@
+/**
+ * WordPress dependencies
+ */
+import type { ReactNode } from 'react';
+import { Link, Stack, Text } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+
+export type ListItem = {
+	id: string;
+	title: string;
+	url: string;
+	meta?: string[];
+	icon?: ReactNode;
+};
+
+export default function List( {
+	items,
+	empty,
+}: {
+	items: ListItem[];
+	empty?: ReactNode;
+} ) {
+	if ( items.length === 0 ) {
+		return empty ?? null;
+	}
+
+	return (
+		<Stack gap="md" direction="column">
+			{ items.map( ( item ) => (
+				<Stack
+					key={ item.id }
+					gap="md"
+					direction="row"
+					align="start"
+					className={ styles.listItem }
+				>
+					{ item.icon && (
+						<div className={ styles.listItemIcon }>
+							{ item.icon }
+						</div>
+					) }
+					<Stack
+						direction="column"
+						gap="xs"
+						className={ styles.listItemContent }
+					>
+						<Text variant="body-md">
+							{ item.url ? (
+								<Link href={ item.url } openInNewTab>
+									{ item.title }
+								</Link>
+							) : (
+								item.title
+							) }
+						</Text>
+						{ item.meta && item.meta.length > 0 && (
+							<Stack
+								direction="row"
+								gap="xs"
+								className={ styles.statusText }
+							>
+								{ item.meta.map( ( metaItem, index ) => (
+									<Text
+										key={ `${ item.id }-meta-${ index }` }
+										variant="body-sm"
+										className={ styles.statusText }
+									>
+										{ index > 0 && '· ' }
+										{ metaItem }
+									</Text>
+								) ) }
+							</Stack>
+						) }
+					</Stack>
+				</Stack>
+			) ) }
+		</Stack>
+	);
+}

--- a/widgets/events/render.tsx
+++ b/widgets/events/render.tsx
@@ -1,0 +1,618 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	useId,
+	useState,
+	useEffect,
+	createInterpolateElement,
+} from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { dateI18n, format } from '@wordpress/date';
+import { __, _x, sprintf } from '@wordpress/i18n';
+import { calendar, mapMarker, wordpress, people } from '@wordpress/icons';
+import { Spinner } from '@wordpress/components';
+/* eslint-disable @wordpress/use-recommended-components */
+import {
+	Autocomplete,
+	Button,
+	Card,
+	EmptyState,
+	Icon,
+	IconButton,
+	InputControl,
+	InputLayout,
+	Link,
+	Stack,
+	Text,
+} from '@wordpress/ui';
+/* eslint-enable @wordpress/use-recommended-components */
+
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+import List, { type ListItem } from './list';
+
+interface WPEvent {
+	type: 'wordcamp' | 'meetup' | 'online' | string;
+	title: string;
+	url: string;
+	date: string;
+	start_unix_timestamp?: number;
+	end_unix_timestamp?: number;
+	location: {
+		description: string;
+		country: string;
+	};
+	user_formatted_date: string;
+	user_formatted_time?: string;
+	timeZoneAbbreviation?: string;
+}
+
+interface WPEventsResponse {
+	events: WPEvent[];
+	location?: {
+		description: string;
+	};
+}
+
+const EVENTS_API = 'https://api.wordpress.org/events/1.0/';
+type LocationOption = {
+	id: string;
+	value: string;
+};
+
+function formatEventType( type: string ): string {
+	if ( type === 'wordcamp' ) {
+		return 'WordCamp';
+	}
+	if ( type === 'meetup' ) {
+		return __( 'Meetup' );
+	}
+	return type.charAt( 0 ).toUpperCase() + type.slice( 1 );
+}
+
+function getFlippedTimeZoneOffset( startTimestamp: number ): number {
+	return new Date( startTimestamp ).getTimezoneOffset() * -1;
+}
+
+function getTimeZone( startTimestamp: number ): string | number {
+	const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+	if ( typeof timeZone === 'undefined' ) {
+		return getFlippedTimeZoneOffset( startTimestamp );
+	}
+
+	return timeZone;
+}
+
+function getFormattedDate(
+	startDate: number,
+	endDate?: number,
+	timeZone?: string | number
+): string {
+	let formattedDate: string;
+
+	/* translators: Date format for upcoming events on the dashboard. Include the day of the week. See https://www.php.net/manual/datetime.format.php */
+	const singleDayEvent = __( 'l, M j, Y' );
+	/* translators: Date string for upcoming events. 1: Month, 2: Starting day, 3: Ending day, 4: Year. */
+	const multipleDayEvent = __( '%1$s %2$d–%3$d, %4$d' );
+	/* translators: Date string for upcoming events. 1: Starting month, 2: Starting day, 3: Ending month, 4: Ending day, 5: Ending year. */
+	const multipleMonthEvent = __( '%1$s %2$d – %3$s %4$d, %5$d' );
+
+	if (
+		! endDate ||
+		format( 'Y-m-d', startDate ) === format( 'Y-m-d', endDate )
+	) {
+		formattedDate = dateI18n( singleDayEvent, startDate, timeZone );
+	} else if ( format( 'Y-m', startDate ) === format( 'Y-m', endDate ) ) {
+		formattedDate = sprintf(
+			multipleDayEvent,
+			dateI18n(
+				_x( 'F', 'upcoming events month format' ),
+				startDate,
+				timeZone
+			),
+			Number(
+				dateI18n(
+					_x( 'j', 'upcoming events day format' ),
+					startDate,
+					timeZone
+				)
+			),
+			Number(
+				dateI18n(
+					_x( 'j', 'upcoming events day format' ),
+					endDate,
+					timeZone
+				)
+			),
+			Number(
+				dateI18n(
+					_x( 'Y', 'upcoming events year format' ),
+					endDate,
+					timeZone
+				)
+			)
+		);
+	} else {
+		formattedDate = sprintf(
+			multipleMonthEvent,
+			dateI18n(
+				_x( 'F', 'upcoming events month format' ),
+				startDate,
+				timeZone
+			),
+			Number(
+				dateI18n(
+					_x( 'j', 'upcoming events day format' ),
+					startDate,
+					timeZone
+				)
+			),
+			dateI18n(
+				_x( 'F', 'upcoming events month format' ),
+				endDate,
+				timeZone
+			),
+			Number(
+				dateI18n(
+					_x( 'j', 'upcoming events day format' ),
+					endDate,
+					timeZone
+				)
+			),
+			Number(
+				dateI18n(
+					_x( 'Y', 'upcoming events year format' ),
+					endDate,
+					timeZone
+				)
+			)
+		);
+	}
+
+	return formattedDate;
+}
+
+function EventsList( {
+	events,
+	loading,
+	error,
+	showEmptyState,
+}: {
+	events: WPEvent[];
+	loading: boolean;
+	error: boolean;
+	showEmptyState: boolean;
+} ) {
+	if ( loading ) {
+		return (
+			<Stack justify="center" align="center">
+				<Spinner />
+			</Stack>
+		);
+	}
+
+	if ( error ) {
+		return (
+			<p className={ styles.statusText }>
+				{ __( 'An error occurred. Please try again.' ) }
+			</p>
+		);
+	}
+
+	const organizeUrl = __(
+		'https://make.wordpress.org/community/organize-event-landing-page/'
+	);
+
+	const emptyState = (
+		<Stack align="center" justify="center" style={ { margin: '24px 0' } }>
+			<EmptyState.Root>
+				<EmptyState.Icon icon={ calendar } />
+				<EmptyState.Title>
+					{ __( 'No events near you' ) }
+				</EmptyState.Title>
+				<EmptyState.Description>
+					{ createInterpolateElement(
+						__( '<a>Help organize the next one!</a>' ),
+						{
+							a: <Link href={ organizeUrl } openInNewTab />,
+						}
+					) }
+				</EmptyState.Description>
+			</EmptyState.Root>
+		</Stack>
+	);
+
+	const items: ListItem[] = events.map( ( event ) => {
+		const startDate = event.start_unix_timestamp
+			? event.start_unix_timestamp * 1000
+			: Date.parse( event.date );
+		const endDate = event.end_unix_timestamp
+			? event.end_unix_timestamp * 1000
+			: undefined;
+		const timeZone = getTimeZone( startDate );
+		const formattedDate = Number.isNaN( startDate )
+			? event.user_formatted_date || dateI18n( 'M j, Y', event.date )
+			: getFormattedDate( startDate, endDate, timeZone );
+
+		return {
+			id: event.url,
+			title: event.title,
+			url: event.url,
+			icon:
+				event.type === 'wordcamp' ? (
+					<Icon icon={ wordpress } />
+				) : (
+					<Icon icon={ people } />
+				),
+			meta: [
+				event.type !== 'online' ? formatEventType( event.type ) : null,
+				event.location.description,
+				formattedDate,
+				event.user_formatted_time,
+			].filter( Boolean ) as string[],
+		};
+	} );
+
+	return (
+		<>
+			<List
+				items={ items }
+				empty={ showEmptyState ? emptyState : undefined }
+			/>
+			{ events.length > 0 && events.length <= 2 && (
+				<Text variant="body-sm" className={ styles.eventNone }>
+					{ createInterpolateElement(
+						__(
+							'Want more events? <a>Help organize the next one!</a>'
+						),
+						{
+							a: <Link href={ organizeUrl } openInNewTab />,
+						}
+					) }
+				</Text>
+			) }
+		</>
+	);
+}
+
+export default function WordPressEvents() {
+	const locationInputId = useId();
+	const userLocale = useSelect(
+		( select ) =>
+			( ( select( coreStore ) as any ).getCurrentUser()
+				?.locale as string ) ?? 'en_US',
+		[]
+	);
+
+	const [ locationInput, setLocationInput ] = useState( '' );
+	const [ locationOptions, setLocationOptions ] = useState<
+		LocationOption[]
+	>( [] );
+	const [ activeLocation, setActiveLocation ] = useState( '' );
+	const [ locationLabel, setLocationLabel ] = useState( '' );
+	const [ isEditingLocation, setIsEditingLocation ] = useState( false );
+	const [ isLocatingCity, setIsLocatingCity ] = useState( false );
+	const [ events, setEvents ] = useState< WPEvent[] >( [] );
+	const [ eventsLoading, setEventsLoading ] = useState( true );
+	const [ eventsError, setEventsError ] = useState( false );
+
+	const fillCityFromGeolocation = async () => {
+		if ( ! navigator.geolocation || isLocatingCity ) {
+			return;
+		}
+
+		setIsLocatingCity( true );
+
+		try {
+			const position = await new Promise< GeolocationPosition >(
+				( resolve, reject ) => {
+					navigator.geolocation.getCurrentPosition( resolve, reject, {
+						enableHighAccuracy: false,
+						timeout: 10000,
+					} );
+				}
+			);
+
+			const { latitude, longitude } = position.coords;
+			const response = await fetch(
+				`https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${ latitude }&lon=${ longitude }`
+			);
+			const data = ( await response.json() ) as {
+				address?: {
+					city?: string;
+					town?: string;
+					village?: string;
+					municipality?: string;
+				};
+			};
+
+			const city =
+				data.address?.city ??
+				data.address?.town ??
+				data.address?.village ??
+				data.address?.municipality;
+
+			if ( city ) {
+				setLocationInput( city );
+			}
+		} catch {
+			// No-op: keep manual location entry as fallback.
+		} finally {
+			setIsLocatingCity( false );
+		}
+	};
+
+	useEffect( () => {
+		const query = locationInput.trim();
+
+		if ( query.length < 2 ) {
+			setLocationOptions( [] );
+			return;
+		}
+
+		const controller = new AbortController();
+		const timeoutId = setTimeout( async () => {
+			try {
+				const params = new URLSearchParams( {
+					q: query,
+					featureType: 'city',
+					format: 'jsonv2',
+					addressdetails: '1',
+					limit: '8',
+				} );
+				const response = await fetch(
+					`https://nominatim.openstreetmap.org/search?${ params }`,
+					{ signal: controller.signal }
+				);
+				const data = ( await response.json() ) as Array< {
+					place_id: number;
+					address?: {
+						city?: string;
+						town?: string;
+						village?: string;
+						municipality?: string;
+						country?: string;
+					};
+				} >;
+
+				const seen = new Set< string >();
+				const nextOptions = data
+					.map( ( place ) => {
+						const city =
+							place.address?.city ??
+							place.address?.town ??
+							place.address?.village ??
+							place.address?.municipality;
+						const country = place.address?.country;
+
+						if ( ! city ) {
+							return null;
+						}
+
+						const label = country
+							? `${ city }, ${ country }`
+							: city;
+						if ( seen.has( label.toLowerCase() ) ) {
+							return null;
+						}
+
+						seen.add( label.toLowerCase() );
+						return {
+							id: String( place.place_id ),
+							value: label,
+						};
+					} )
+					.filter( Boolean ) as LocationOption[];
+
+				setLocationOptions( nextOptions );
+			} catch ( error: unknown ) {
+				if ( error instanceof Error && error.name === 'AbortError' ) {
+					return;
+				}
+				setLocationOptions( [] );
+			}
+		}, 200 );
+
+		return () => {
+			clearTimeout( timeoutId );
+			controller.abort();
+		};
+	}, [ locationInput ] );
+
+	useEffect( () => {
+		const controller = new AbortController();
+		setEventsLoading( true );
+		setEventsError( false );
+
+		const params = new URLSearchParams( {
+			number: '5',
+			locale: userLocale,
+		} );
+		if ( activeLocation ) {
+			params.set( 'location', activeLocation );
+		}
+
+		fetch( `${ EVENTS_API }?${ params }`, { signal: controller.signal } )
+			.then( ( r ) => r.json() as Promise< WPEventsResponse > )
+			.then( ( data ) => {
+				setEvents( data.events ?? [] );
+				if ( data.location?.description ) {
+					setLocationLabel( data.location.description );
+				}
+				setEventsLoading( false );
+			} )
+			.catch( ( err: Error ) => {
+				if ( err.name !== 'AbortError' ) {
+					setEventsError( true );
+					setEventsLoading( false );
+				}
+			} );
+
+		return () => controller.abort();
+	}, [ activeLocation, userLocale ] );
+
+	return (
+		<Card.Content>
+			{ ! locationLabel || isEditingLocation ? (
+				<div className={ styles.locationPicker }>
+					<form
+						onSubmit={ ( e ) => {
+							e.preventDefault();
+							setActiveLocation( locationInput );
+							setIsEditingLocation( false );
+						} }
+					>
+						<Stack direction="row" align="top" wrap="wrap" gap="sm">
+							<Autocomplete.Root
+								items={ locationOptions }
+								value={ locationInput }
+								onValueChange={ setLocationInput }
+							>
+								<Autocomplete.Input
+									id={ locationInputId }
+									className={ styles.locationInput }
+									render={
+										<InputControl
+											autoComplete="off"
+											label={ __( 'City' ) }
+											hideLabelFromVision
+											size="compact"
+											description={ __(
+												'Select a city to view upcoming events.'
+											) }
+											onValueChange={ () => {} }
+											suffix={
+												<InputLayout.Slot padding="minimal">
+													<Autocomplete.Clear />
+													<IconButton
+														icon={ mapMarker }
+														label={ __(
+															'Use current location'
+														) }
+														onClick={
+															fillCityFromGeolocation
+														}
+														disabled={
+															isLocatingCity
+														}
+														size="small"
+														variant="minimal"
+													/>
+												</InputLayout.Slot>
+											}
+										/>
+									}
+									placeholder={ __( 'City, like Tokyo…' ) }
+								/>
+								{ locationOptions.length > 0 && (
+									<Autocomplete.Popup>
+										<Autocomplete.List>
+											<Autocomplete.ListBody>
+												<Autocomplete.Collection>
+													{ ( item: {
+														id: string;
+														value: string;
+													} ) => (
+														<Autocomplete.Item
+															key={ item.id }
+															value={ item }
+														>
+															{ item.value }
+														</Autocomplete.Item>
+													) }
+												</Autocomplete.Collection>
+											</Autocomplete.ListBody>
+										</Autocomplete.List>
+									</Autocomplete.Popup>
+								) }
+							</Autocomplete.Root>
+							<Button
+								variant="outline"
+								size="compact"
+								type="submit"
+								disabled={ ! locationInput.trim() }
+							>
+								{ __( 'Select' ) }
+							</Button>
+							{ isEditingLocation && (
+								<Button
+									size="compact"
+									tone="neutral"
+									variant="minimal"
+									onClick={ () =>
+										setIsEditingLocation( false )
+									}
+								>
+									{ __( 'Cancel' ) }
+								</Button>
+							) }
+						</Stack>
+					</form>
+				</div>
+			) : null }
+			<EventsList
+				events={ events }
+				loading={ eventsLoading }
+				error={ eventsError }
+				showEmptyState={ Boolean( activeLocation.trim() ) }
+			/>
+			<Stack
+				align="center"
+				className={ styles.footer }
+				direction="row"
+				gap="md"
+				justify="space-between"
+				wrap="wrap"
+			>
+				{ locationLabel && ! isEditingLocation && (
+					<div>
+						{ createInterpolateElement(
+							sprintf(
+								/* translators: %s: city name */
+								__(
+									'Upcoming events near <strong>%s</strong>.'
+								),
+								locationLabel
+							),
+							{
+								strong: <strong />,
+							}
+						) }{ ' ' }
+						<Link
+							onClick={ () => {
+								setLocationInput( activeLocation );
+								setIsEditingLocation( true );
+							} }
+						>
+							{ __( 'Change' ) }
+						</Link>
+					</div>
+				) }
+				<Stack
+					direction="row"
+					align="center"
+					gap="sm"
+					className={ styles.footerLinks }
+				>
+					<Link
+						href="https://make.wordpress.org/community/meetups-landing-page"
+						openInNewTab
+					>
+						{ __( 'Meetups' ) }
+					</Link>
+					<Link
+						href="https://central.wordcamp.org/schedule/"
+						openInNewTab
+					>
+						{ __( 'WordCamps' ) }
+					</Link>
+				</Stack>
+			</Stack>
+		</Card.Content>
+	);
+}

--- a/widgets/events/style.module.css
+++ b/widgets/events/style.module.css
@@ -1,0 +1,51 @@
+
+.locationPicker {
+	margin-block-end: 12px;
+	max-width: 400px;
+}
+
+.locationInput {
+	flex: 1;
+	min-inline-size: 120px;
+}
+
+.eventNone {
+	padding-block: 8px;
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.statusText {
+	color: var(--wpds-color-fg-content-neutral-weak);
+	margin: 0;
+}
+
+.footer {
+	padding: 12px 0 0;
+	margin: 12px 0 0;
+	border-block-start: 1px solid var(--wpds-color-stroke-surface-neutral);
+}
+
+.footerLinks {
+	margin-inline-start: auto;
+}
+
+.listItem {
+	inline-size: 100%;
+}
+
+.listItemIcon {
+	inline-size: 36px;
+	block-size: 36px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 8px;
+	background: var(--wpds-color-bg-track-neutral-weak);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	flex-shrink: 0;
+}
+
+.listItemContent {
+	flex: 1;
+	min-inline-size: 0;
+}

--- a/widgets/events/widget.json
+++ b/widgets/events/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "core/events",
+	"title": "WordPress events",
+	"description": "Displays upcoming WordPress community events.",
+	"category": "dashboard"
+}

--- a/widgets/events/widget.ts
+++ b/widgets/events/widget.ts
@@ -1,0 +1,6 @@
+import { __ } from '@wordpress/i18n';
+
+export default {
+	name: 'core/events',
+	title: __( 'WordPress events' ),
+};

--- a/widgets/hello-dolly/README.md
+++ b/widgets/hello-dolly/README.md
@@ -1,0 +1,3 @@
+# Hello Dolly widget
+
+Adopted from [Hello Dolly](https://github.com/WordPress/WordPress/blob/master/wp-content/plugins/hello.php) plugin.

--- a/widgets/hello-dolly/render.tsx
+++ b/widgets/hello-dolly/render.tsx
@@ -1,0 +1,72 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Card, Stack, Text, VisuallyHidden } from '@wordpress/ui';
+
+// These are the lyrics to Hello Dolly
+const DOLLY_LYRICS = [
+	'Hello, Dolly',
+	'Well, hello, Dolly',
+	"It's so nice to have you back where you belong",
+	"You're lookin' swell, Dolly",
+	'I can tell, Dolly',
+	"You're still glowin', you're still crowin'",
+	"You're still goin' strong",
+	"I feel the room swayin'",
+	"While the band's playin'",
+	'One of our old favorite songs from way back when',
+	'So, take her wrap, fellas',
+	'Dolly, never go away again',
+	'Hello, Dolly',
+	'Well, hello, Dolly',
+	"It's so nice to have you back where you belong",
+	"You're lookin' swell, Dolly",
+	'I can tell, Dolly',
+	"You're still glowin', you're still crowin'",
+	"You're still goin' strong",
+	"I feel the room swayin'",
+	"While the band's playin'",
+	'One of our old favorite songs from way back when',
+	'So, golly, gee, fellas',
+	'Have a little faith in me, fellas',
+	'Dolly, never go away',
+	"Promise, you'll never go away",
+	"Dolly'll never go away again",
+];
+
+export default function HelloDolly() {
+	// Randomly choose a line.
+	const quote = useMemo( () => {
+		return DOLLY_LYRICS[
+			Math.floor( Math.random() * DOLLY_LYRICS.length )
+		];
+	}, [] );
+
+	// Echoes and positions the chosen line of lyrics.
+	return (
+		<Card.Content>
+			<Stack align="center" justify="center" style={ { minHeight: 200 } }>
+				<Text
+					variant="body-lg"
+					render={ <p /> }
+					style={ {
+						textAlign: 'center',
+						fontStyle: 'italic',
+						fontFamily: 'Georgia, "Times New Roman", Times, serif',
+					} }
+				>
+					<VisuallyHidden render={ <span /> }>
+						{ __(
+							'Quote from Hello Dolly song, by Jerry Herman:'
+						) }{ ' ' }
+					</VisuallyHidden>
+					<span dir="ltr" lang="en">
+						{ quote }
+					</span>
+				</Text>
+			</Stack>
+		</Card.Content>
+	);
+}

--- a/widgets/hello-dolly/widget.json
+++ b/widgets/hello-dolly/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "core/hello-dolly",
+	"title": "Hello Dolly",
+	"description": "This is not just a widget, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong: Hello, Dolly. When activated you will randomly see a lyric from <cite>Hello, Dolly</cite> in the dahboard.",
+	"category": "dashboard"
+}

--- a/widgets/hello-world/render.tsx
+++ b/widgets/hello-world/render.tsx
@@ -1,3 +1,0 @@
-export default function HelloWorld() {
-	return <div>Hello World</div>;
-}

--- a/widgets/hello-world/widget.json
+++ b/widgets/hello-world/widget.json
@@ -1,6 +1,0 @@
-{
-	"name": "wordpress/hello-world",
-	"title": "Hello World",
-	"description": "A minimal example widget.",
-	"category": "demo"
-}

--- a/widgets/hello-world/widget.ts
+++ b/widgets/hello-world/widget.ts
@@ -1,7 +1,0 @@
-/**
- * Widget type definition
- */
-export default {
-	name: 'wordpress/hello-world',
-	title: 'Hello World',
-};

--- a/widgets/lock-unlock.ts
+++ b/widgets/lock-unlock.ts
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+		'@wordpress/widgets'
+	);

--- a/widgets/lock-unlock.ts
+++ b/widgets/lock-unlock.ts
@@ -6,5 +6,5 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
 		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
-		'@wordpress/widgets'
+		'@wordpress/dashboard-widgets'
 	);

--- a/widgets/news/list.tsx
+++ b/widgets/news/list.tsx
@@ -1,0 +1,83 @@
+/**
+ * WordPress dependencies
+ */
+import type { ReactNode } from 'react';
+import { Link, Stack, Text } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+
+export type ListItem = {
+	id: string;
+	title: string;
+	url: string;
+	meta?: string[];
+	icon?: ReactNode;
+};
+
+export default function List( {
+	items,
+	empty,
+}: {
+	items: ListItem[];
+	empty?: ReactNode;
+} ) {
+	if ( items.length === 0 ) {
+		return empty ?? null;
+	}
+
+	return (
+		<Stack gap="md" direction="column">
+			{ items.map( ( item ) => (
+				<Stack
+					key={ item.id }
+					gap="md"
+					direction="row"
+					align="start"
+					className={ styles.listItem }
+				>
+					{ item.icon && (
+						<div className={ styles.listItemIcon }>
+							{ item.icon }
+						</div>
+					) }
+					<Stack
+						direction="column"
+						gap="xs"
+						className={ styles.listItemContent }
+					>
+						<Text variant="body-md">
+							{ item.url ? (
+								<Link href={ item.url } openInNewTab>
+									{ item.title }
+								</Link>
+							) : (
+								item.title
+							) }
+						</Text>
+						{ item.meta && item.meta.length > 0 && (
+							<Stack
+								direction="row"
+								gap="xs"
+								className={ styles.statusText }
+							>
+								{ item.meta.map( ( metaItem, index ) => (
+									<Text
+										key={ `${ item.id }-meta-${ index }` }
+										variant="body-sm"
+										className={ styles.statusText }
+									>
+										{ index > 0 && '· ' }
+										{ metaItem }
+									</Text>
+								) ) }
+							</Stack>
+						) }
+					</Stack>
+				</Stack>
+			) ) }
+		</Stack>
+	);
+}

--- a/widgets/news/render.tsx
+++ b/widgets/news/render.tsx
@@ -1,0 +1,153 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { dateI18n } from '@wordpress/date';
+import { __, _x } from '@wordpress/i18n';
+import { globe, postList, wordpress } from '@wordpress/icons';
+import { Spinner } from '@wordpress/components';
+/* eslint-disable @wordpress/use-recommended-components */
+import { Card, EmptyState, Icon, Link, Stack } from '@wordpress/ui';
+/* eslint-enable @wordpress/use-recommended-components */
+
+/**
+ * Internal dependencies
+ */
+import List, { type ListItem } from './list';
+
+interface NewsPost {
+	id: number;
+	title: { rendered: string };
+	link: string;
+	date: string;
+}
+
+interface NewsFeed {
+	key: string;
+	label: string;
+	siteUrl: string;
+	posts: NewsPost[];
+}
+
+const NEWS_FEEDS = [
+	{
+		key: 'news',
+		label: __( 'WordPress Blog' ),
+		siteUrl: _x(
+			'https://wordpress.org/news/',
+			'Events and News dashboard widget'
+		),
+		apiUrl: 'https://wordpress.org/news/wp-json/wp/v2/posts?per_page=3&_fields=id,title,link,date',
+	},
+	{
+		key: 'planet',
+		label: __( 'Other WordPress News' ),
+		siteUrl: _x(
+			'https://planet.wordpress.org/',
+			'Events and News dashboard widget'
+		),
+		apiUrl: 'https://planet.wordpress.org/wp-json/wp/v2/posts?per_page=3&_fields=id,title,link,date',
+	},
+];
+
+function decodeEntities( html: string ): string {
+	const txt = document.createElement( 'textarea' );
+	txt.innerHTML = html;
+	return txt.value;
+}
+
+export default function WordPressNews() {
+	const [ newsFeeds, setNewsFeeds ] = useState< NewsFeed[] >( [] );
+	const [ newsLoading, setNewsLoading ] = useState( true );
+
+	useEffect( () => {
+		Promise.all(
+			NEWS_FEEDS.map( async ( feed ) => {
+				try {
+					const posts: NewsPost[] = await fetch( feed.apiUrl ).then(
+						( r ) => r.json()
+					);
+					return {
+						key: feed.key,
+						label: feed.label,
+						siteUrl: feed.siteUrl,
+						posts,
+					};
+				} catch {
+					return {
+						key: feed.key,
+						label: feed.label,
+						siteUrl: feed.siteUrl,
+						posts: [],
+					};
+				}
+			} )
+		)
+			.then( setNewsFeeds )
+			.finally( () => setNewsLoading( false ) );
+	}, [] );
+
+	const combinedItems: ListItem[] = newsFeeds
+		.flatMap( ( feed ) =>
+			feed.posts.map( ( post ) => ( {
+				feedKey: feed.key,
+				feedLabel: feed.label,
+				id: post.id,
+				title: decodeEntities( post.title.rendered ),
+				url: post.link,
+				date: post.date,
+			} ) )
+		)
+		.sort(
+			( a, b ) =>
+				new Date( b.date ).getTime() - new Date( a.date ).getTime()
+		)
+		.map( ( post ) => ( {
+			id: `${ post.feedKey }-${ post.id }`,
+			title: post.title,
+			url: post.url,
+			icon:
+				post.feedKey === 'news' ? (
+					<Icon icon={ wordpress } />
+				) : (
+					<Icon icon={ globe } />
+				),
+			meta: [
+				post.feedLabel,
+				dateI18n( __( 'M j, Y g:i a' ), post.date ),
+			],
+		} ) );
+
+	const emptyState = (
+		<Stack align="center" justify="center" style={ { margin: '24px 0' } }>
+			<EmptyState.Root>
+				<EmptyState.Icon icon={ postList } />
+				<EmptyState.Title>
+					{ __( 'Quiet for now — the next headline is on its way.' ) }
+				</EmptyState.Title>
+			</EmptyState.Root>
+		</Stack>
+	);
+
+	return (
+		<Card.Content>
+			<Stack direction="column" justify="start" gap="md">
+				{ newsLoading && (
+					<Stack justify="center" align="center">
+						<Spinner />
+					</Stack>
+				) }
+				<List items={ combinedItems } empty={ emptyState } />
+				<Link
+					href={ _x(
+						'https://wordpress.org/news/all-posts/',
+						'Events and News dashboard widget'
+					) }
+					openInNewTab
+				>
+					{ __( 'See all' ) }
+				</Link>
+			</Stack>
+		</Card.Content>
+	);
+}

--- a/widgets/news/style.module.css
+++ b/widgets/news/style.module.css
@@ -1,0 +1,30 @@
+
+.footer {
+	padding: 12px 0 0;
+}
+
+.listItem {
+	inline-size: 100%;
+}
+
+.listItemIcon {
+	inline-size: 36px;
+	block-size: 36px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 8px;
+	background: var(--wpds-color-bg-track-neutral-weak);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	flex-shrink: 0;
+}
+
+.listItemContent {
+	flex: 1;
+	min-inline-size: 0;
+}
+
+.statusText {
+	color: var(--wpds-color-fg-content-neutral-weak);
+	margin: 0;
+}

--- a/widgets/news/widget.json
+++ b/widgets/news/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "core/news",
+	"title": "WordPress news",
+	"description": "Displays the latest news from WordPress.org and Planet WordPress.",
+	"category": "dashboard"
+}

--- a/widgets/news/widget.ts
+++ b/widgets/news/widget.ts
@@ -1,0 +1,6 @@
+import { __ } from '@wordpress/i18n';
+
+export default {
+	name: 'core/news',
+	title: __( 'WordPress news' ),
+};

--- a/widgets/quick-draft/render.tsx
+++ b/widgets/quick-draft/render.tsx
@@ -1,0 +1,295 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useCallback } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { __, _x, sprintf } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
+import {
+	SnackbarList,
+	TextareaControl,
+	TextControl,
+} from '@wordpress/components';
+import { store as noticesStore } from '@wordpress/notices';
+import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
+import { postFeaturedImage } from '@wordpress/icons';
+
+// Dashboard is still experimental.
+/* eslint-disable @wordpress/use-recommended-components */
+import { Button, Card, Icon, Link, Text, Stack, Tooltip } from '@wordpress/ui';
+/* eslint-enable @wordpress/use-recommended-components */
+import type { Post } from '@wordpress/core-data';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type DraftPost = Post & {
+	title: { rendered: string; raw?: string };
+	content: { rendered: string; raw?: string };
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the first N words of a plain-text string, mirroring PHP's
+ * `wp_trim_words()` with the `draft_length` locale value (default 10).
+ *
+ * @param {string} text     Input text.
+ * @param {number} maxWords Maximum number of words to keep.
+ */
+function trimWords( text: string, maxWords: number ): string {
+	const words = text
+		.replace( /<[^>]+>/g, ' ' )
+		.trim()
+		.split( /\s+/ )
+		.filter( Boolean );
+
+	if ( words.length <= maxWords ) {
+		return words.join( ' ' );
+	}
+
+	return words.slice( 0, maxWords ).join( ' ' ) + '\u2026';
+}
+
+// ─── Recent Drafts ────────────────────────────────────────────────────────────
+
+/**
+ * @param {{ id: number }} props
+ */
+function DraftItem( { post }: { post: DraftPost } ) {
+	const title =
+		( post.title as { rendered: string } )?.rendered ||
+		/* translators: Placeholder for a draft post with no title. */
+		__( '(no title)' );
+
+	const rawContent =
+		( post.content as { raw?: string; rendered: string } )?.raw ??
+		( post.content as { rendered: string } )?.rendered ??
+		'';
+
+	/* translators: Maximum number of words used in a draft preview on the dashboard. */
+	const draftLength = parseInt( _x( '10', 'draft_length' ), 10 ) || 10;
+	const excerpt = trimWords( rawContent, draftLength );
+
+	const editUrl = `post.php?post=${ post.id }&action=edit`;
+
+	/* translators: Date format for draft timestamps on the dashboard, see https://www.php.net/manual/datetime.format.php */
+	const formattedDate = dateI18n(
+		__( 'F j, Y' ),
+		( post.modified as string ) ?? ''
+	);
+
+	return (
+		<li>
+			<div>
+				<Link
+					href={ editUrl }
+					aria-label={ sprintf(
+						/* translators: %s: post title */
+						__( 'Edit \u201c%s\u201d' ),
+						title
+					) }
+				>
+					{ title }
+				</Link>
+				<time dateTime={ ( post.modified as string ) ?? '' }>
+					{ formattedDate }
+				</time>
+			</div>
+			{ excerpt && <p>{ excerpt }</p> }
+		</li>
+	);
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function QuickDraft() {
+	const [ title, setTitle ] = useState( '' );
+	const [ content, setContent ] = useState( '' );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ featuredImageId, setFeaturedImageId ] = useState< number | null >(
+		null
+	);
+
+	const currentUser = useSelect(
+		( select ) => select( coreStore ).getCurrentUser(),
+		[]
+	);
+
+	const drafts = useSelect(
+		( select ) => {
+			if ( ! currentUser?.id ) {
+				return undefined;
+			}
+
+			return select( coreStore ).getEntityRecords< DraftPost >(
+				'postType',
+				'post',
+				{
+					status: 'draft',
+					author: currentUser.id,
+					orderby: 'modified',
+					order: 'desc',
+					per_page: 3,
+					context: 'edit',
+				}
+			);
+		},
+		[ currentUser?.id ]
+	);
+
+	const { saveEntityRecord, invalidateResolution } = useDispatch( coreStore );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+	const notices = useSelect(
+		( select ) => select( noticesStore ).getNotices(),
+		[]
+	);
+	const { removeNotice } = useDispatch( noticesStore );
+	const snackbarNotices = notices.filter(
+		( { type } ) => type === 'snackbar'
+	);
+
+	const handleSave = useCallback( async () => {
+		if ( ! title.trim() ) {
+			return;
+		}
+
+		setIsSaving( true );
+
+		try {
+			await saveEntityRecord( 'postType', 'post', {
+				title,
+				content,
+				status: 'draft',
+				...( featuredImageId !== null && {
+					featured_media: featuredImageId,
+				} ),
+			} );
+
+			// Bust the drafts cache so the new post appears in the list.
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				'post',
+				{
+					status: 'draft',
+					author: currentUser?.id,
+					orderby: 'modified',
+					order: 'desc',
+					per_page: 3,
+					context: 'edit',
+				},
+			] );
+
+			setTitle( '' );
+			setContent( '' );
+			setFeaturedImageId( null );
+			createSuccessNotice( __( 'Draft saved.' ), { type: 'snackbar' } );
+		} catch {
+			createErrorNotice( __( 'An error occurred. Please try again.' ), {
+				type: 'snackbar',
+			} );
+		} finally {
+			setIsSaving( false );
+		}
+	}, [
+		title,
+		content,
+		featuredImageId,
+		currentUser?.id,
+		saveEntityRecord,
+		invalidateResolution,
+		createSuccessNotice,
+		createErrorNotice,
+	] );
+
+	const hasDrafts = !! drafts && drafts.length > 0;
+
+	return (
+		<Card.Content>
+			<Stack direction="column" gap="md" align="left">
+				<SnackbarList
+					notices={ snackbarNotices }
+					onRemove={ ( id ) => removeNotice( id ) }
+				/>
+				<Stack
+					aria-label={ __( 'Quick draft' ) }
+					direction="column"
+					gap="md"
+					render={ <section /> }
+				>
+					<TextControl
+						label={ __( 'Title' ) }
+						value={ title }
+						onChange={ setTitle }
+						autoComplete="off"
+					/>
+					<TextareaControl
+						label={ __( 'Content' ) }
+						value={ content }
+						onChange={ setContent }
+						placeholder={ __( 'What\u2019s on your mind?' ) }
+						rows={ 3 }
+					/>
+
+					<Stack
+						direction="row"
+						justify="space-between"
+						align="center"
+					>
+						<MediaUploadCheck>
+							<MediaUpload
+								onSelect={ ( media ) => {
+									setFeaturedImageId( media.id );
+								} }
+								allowedTypes={ [ 'image' ] }
+								value={ featuredImageId ?? undefined }
+								render={ ( { open } ) => (
+									<Tooltip.Root>
+										<Tooltip.Trigger
+											onClick={ open }
+											aria-label={ __(
+												'Add featured image'
+											) }
+										>
+											<Icon icon={ postFeaturedImage } />
+										</Tooltip.Trigger>
+										<Tooltip.Popup>
+											{ __( 'Add featured image' ) }
+										</Tooltip.Popup>
+									</Tooltip.Root>
+								) }
+							/>
+						</MediaUploadCheck>
+						<Button
+							variant="solid"
+							onClick={ handleSave }
+							loading={ isSaving }
+							disabled={ isSaving || ! title.trim() }
+						>
+							{ __( 'Save draft' ) }
+						</Button>
+					</Stack>
+				</Stack>
+
+				{ hasDrafts && (
+					<section aria-label={ __( 'Your Recent Drafts' ) }>
+						<Text variant="heading-md" render={ <h3 /> }>
+							{ __( 'Your recent drafts' ) }
+						</Text>
+						<p>
+							<Link href="edit.php?post_status=draft&post_type=post">
+								{ __( 'View all drafts' ) }
+							</Link>
+						</p>
+						<ul>
+							{ drafts.map( ( post ) => (
+								<DraftItem key={ post.id } post={ post } />
+							) ) }
+						</ul>
+					</section>
+				) }
+			</Stack>
+		</Card.Content>
+	);
+}

--- a/widgets/quick-draft/widget.json
+++ b/widgets/quick-draft/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "core/quick-draft",
+	"title": "Quick draft",
+	"description": "Quickly draft a new post and see your recent drafts.",
+	"category": "publishing"
+}

--- a/widgets/quick-draft/widget.ts
+++ b/widgets/quick-draft/widget.ts
@@ -1,0 +1,6 @@
+import { __ } from '@wordpress/i18n';
+
+export default {
+	name: 'core/quick-draft',
+	title: __( 'Quick Draft' ),
+};

--- a/widgets/site-health/render.tsx
+++ b/widgets/site-health/render.tsx
@@ -1,0 +1,231 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { Spinner } from '@wordpress/components';
+import { Card, Link, Stack, Text } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type TestStatus = 'good' | 'recommended' | 'critical';
+
+type TestResult = {
+	status: TestStatus;
+};
+
+type IssueCounts = {
+	good: number;
+	recommended: number;
+	critical: number;
+};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+// Async site health tests exposed via the REST API.
+const ASYNC_TEST_PATHS = [
+	'/wp-site-health/v1/tests/background-updates',
+	'/wp-site-health/v1/tests/loopback-requests',
+	'/wp-site-health/v1/tests/https-status',
+	'/wp-site-health/v1/tests/dotorg-communication',
+	'/wp-site-health/v1/tests/authorization-header',
+] as const;
+
+// SVG circle geometry (matches WP core's site-health progress ring).
+const RADIUS = 90;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS; // ≈ 565.48
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+type HealthTone = 'success' | 'warning' | 'error';
+
+/**
+ * Maps a percentage to a semantic tone used for CSS class selection.
+ *
+ * @param {number} pct Percentage of passing tests (0–100).
+ */
+function toneForPercentage( pct: number ): HealthTone {
+	if ( pct === 100 ) {
+		return 'success';
+	}
+	if ( pct >= 75 ) {
+		return 'warning';
+	}
+	return 'error';
+}
+
+/**
+ * Returns the human-readable status message matching the PHP widget logic.
+ *
+ * @param {IssueCounts} counts Aggregated issue counts.
+ */
+function statusMessage( counts: IssueCounts ): string {
+	const total = counts.recommended + counts.critical;
+
+	if ( total <= 0 ) {
+		return __(
+			'Great job! Your site currently passes all site health checks.'
+		);
+	}
+
+	if ( counts.critical === 1 ) {
+		return __(
+			'Your site has a critical issue that should be addressed as soon as possible to improve its performance and security.'
+		);
+	}
+
+	if ( counts.critical > 1 ) {
+		return __(
+			'Your site has critical issues that should be addressed as soon as possible to improve its performance and security.'
+		);
+	}
+
+	if ( counts.recommended === 1 ) {
+		return __(
+			'Your site\u2019s health is looking good, but there is still one thing you can do to improve its performance and security.'
+		);
+	}
+
+	return __(
+		'Your site\u2019s health is looking good, but there are still some things you can do to improve its performance and security.'
+	);
+}
+
+// ─── Circle progress ──────────────────────────────────────────────────────────
+
+/**
+ * @param {{ percentage: number, tone: HealthTone }} props
+ */
+function CircleProgress( {
+	percentage,
+	tone,
+}: {
+	percentage: number;
+	tone: HealthTone;
+} ) {
+	const offset = CIRCUMFERENCE * ( 1 - percentage / 100 );
+
+	return (
+		<div className={ `${ styles.circle } ${ styles[ `is-${ tone }` ] }` }>
+			<svg
+				focusable="false"
+				viewBox="0 0 200 200"
+				width="100%"
+				height="100%"
+				role="img"
+				aria-label={ `${ percentage }%` }
+			>
+				<circle
+					r={ RADIUS }
+					cx="100"
+					cy="100"
+					fill="transparent"
+					strokeDasharray={ CIRCUMFERENCE }
+					strokeDashoffset={ 0 }
+				/>
+				<circle
+					r={ RADIUS }
+					cx="100"
+					cy="100"
+					fill="transparent"
+					strokeDasharray={ CIRCUMFERENCE }
+					strokeDashoffset={ offset }
+				/>
+				<text
+					x="100"
+					y="100"
+					textAnchor="middle"
+					dominantBaseline="middle"
+					className={ styles.percentage }
+				>
+					{ percentage }%
+				</text>
+			</svg>
+		</div>
+	);
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function SiteHealth() {
+	const [ counts, setCounts ] = useState< IssueCounts | null >( null );
+	const [ isLoading, setIsLoading ] = useState( true );
+
+	useEffect( () => {
+		const requests = ASYNC_TEST_PATHS.map( ( path ) =>
+			apiFetch< TestResult >( { path } ).catch( () => null )
+		);
+
+		Promise.all( requests ).then( ( results ) => {
+			const totals: IssueCounts = {
+				good: 0,
+				recommended: 0,
+				critical: 0,
+			};
+
+			for ( const result of results ) {
+				if ( result?.status && result.status in totals ) {
+					totals[ result.status ]++;
+				}
+			}
+
+			setCounts( totals );
+			setIsLoading( false );
+		} );
+	}, [] );
+
+	if ( isLoading ) {
+		return (
+			<Stack align="center" justify="center" style={ { minHeight: 220 } }>
+				<Spinner />
+			</Stack>
+		);
+	}
+
+	if ( ! counts ) {
+		return null;
+	}
+
+	const total = counts.good + counts.recommended + counts.critical;
+	const percentage =
+		total > 0 ? Math.round( ( counts.good / total ) * 100 ) : 0;
+	const issuesTotal = counts.recommended + counts.critical;
+	const tone = toneForPercentage( percentage );
+
+	return (
+		<Card.Content>
+			<Stack
+				align="center"
+				direction="column"
+				gap="lg"
+				style={ {
+					margin: '0 auto',
+					maxWidth: 320,
+					textAlign: 'center',
+				} }
+			>
+				<CircleProgress percentage={ percentage } tone={ tone } />
+				<Text variant="body-lg">{ statusMessage( counts ) }</Text>
+				{ issuesTotal > 0 && (
+					<Link href="site-health.php">
+						{ sprintf(
+							/* translators: %d: Number of issues to address. */
+							_n(
+								'Review %d item',
+								'Review %d items',
+								issuesTotal
+							),
+							issuesTotal
+						) }
+					</Link>
+				) }
+			</Stack>
+		</Card.Content>
+	);
+}

--- a/widgets/site-health/style.module.css
+++ b/widgets/site-health/style.module.css
@@ -1,0 +1,42 @@
+
+.circle.is-success {
+	--site-health-stroke: var(--wpds-color-stroke-surface-success);
+	--site-health-fg: var(--wpds-color-fg-content-success);
+}
+
+.circle.is-warning {
+	--site-health-stroke: var(--wpds-color-stroke-surface-warning);
+	--site-health-fg: var(--wpds-color-fg-content-warning);
+}
+
+.circle.is-error {
+	--site-health-stroke: var(--wpds-color-stroke-surface-error);
+	--site-health-fg: var(--wpds-color-fg-content-error);
+}
+
+.circle {
+	flex-shrink: 0;
+	width: 68px;
+	height: 68px;
+}
+
+.circle svg circle:first-child {
+	stroke: var(--wpds-color-bg-track-neutral);
+	stroke-width: 12;
+}
+
+.circle svg circle:last-of-type {
+	stroke: var(--site-health-stroke);
+	stroke-width: 12;
+	stroke-linecap: round;
+	transform: rotate(-90deg);
+	transform-origin: 50% 50%;
+	transition: stroke-dashoffset 0.5s ease;
+}
+
+.percentage {
+	fill: var(--site-health-fg);
+	font-size: 36px;
+	font-weight: 600;
+}
+

--- a/widgets/site-health/widget.json
+++ b/widgets/site-health/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "core/site-health",
+	"title": "Site health",
+	"description": "Shows an overview of your site health and any issues that need attention.",
+	"category": "site"
+}

--- a/widgets/site-health/widget.ts
+++ b/widgets/site-health/widget.ts
@@ -1,0 +1,6 @@
+import { __ } from '@wordpress/i18n';
+
+export default {
+	name: 'core/site-health',
+	title: __( 'Site Health Status' ),
+};

--- a/widgets/site-preview/render.tsx
+++ b/widgets/site-preview/render.tsx
@@ -1,0 +1,84 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import { Spinner } from '@wordpress/components';
+
+// Dashboard is still experimental.
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Button, Stack } from '@wordpress/ui';
+import styles from './style.module.css';
+
+export default function SitePreview() {
+	const [ isIframeLoading, setIsIframeLoading ] = useState( true );
+	const siteUrl = useSelect(
+		( select ) =>
+			select( coreStore ).getEntityRecord< { url: string } >(
+				'root',
+				'site',
+				undefined
+			)?.url,
+		[]
+	);
+
+	const isBlockTheme = useSelect(
+		( select ) =>
+			!! ( select( coreStore ) as any ).getCurrentTheme()?.is_block_theme,
+		[]
+	);
+
+	useEffect( () => {
+		setIsIframeLoading( true );
+	}, [ siteUrl ] );
+
+	if ( ! siteUrl ) {
+		return null;
+	}
+
+	const src = `${ siteUrl }/?hide_banners=true&preview_overlay=true&preview=true`;
+	const editUrl = isBlockTheme ? 'site-editor.php' : 'customize.php';
+
+	return (
+		<div className={ styles.container }>
+			<div className={ styles.previewWrap }>
+				{ isIframeLoading && (
+					<Stack
+						align="center"
+						justify="center"
+						style={ { minHeight: 220 } }
+					>
+						<Spinner />
+					</Stack>
+				) }
+				<iframe
+					className={ styles.iframe }
+					loading="lazy"
+					scrolling="no"
+					title={ __( 'Site preview' ) }
+					src={ src }
+					onLoad={ () => setIsIframeLoading( false ) }
+					// @ts-expect-error — `inert` is not yet in React's HTMLAttributes
+					inert="true"
+				></iframe>
+				<Stack
+					align="center"
+					justify="center"
+					className={ styles.overlay }
+				>
+					<Button
+						variant="solid"
+						tone="neutral"
+						onClick={ () => {
+							window.location.href = editUrl;
+						} }
+					>
+						{ __( 'Edit site' ) }
+					</Button>
+				</Stack>
+			</div>
+		</div>
+	);
+}

--- a/widgets/site-preview/style.module.css
+++ b/widgets/site-preview/style.module.css
@@ -1,0 +1,44 @@
+.container {
+	height: 300px;
+	overflow: hidden;
+}
+
+.previewWrap {
+	position: relative;
+	height: 100%;
+}
+
+.iframe {
+	position: absolute;
+	inset-block-start: 0;
+	inset-inline-start: 50%;
+	width: 250%;
+	min-height: 375%;
+	transform: scale(0.4);
+	transform-origin: center top;
+	translate: -50% -13px;
+}
+
+.overlay {
+	position: absolute;
+	inset: 0;
+	opacity: 0;
+}
+
+.previewWrap:hover .overlay {
+	opacity: 1;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.iframe {
+		transition: transform 0.2s ease-in;
+	}
+
+	.previewWrap:hover .iframe {
+		transform: scale(0.42);
+	}
+
+	.overlay {
+		transition: opacity 0.1s ease-in;
+	}
+}

--- a/widgets/site-preview/widget.json
+++ b/widgets/site-preview/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "core/site-preview",
+	"title": "Site Preview",
+	"description": "Shows a scaled preview of the site homepage.",
+	"category": "site"
+}

--- a/widgets/site-preview/widget.ts
+++ b/widgets/site-preview/widget.ts
@@ -1,0 +1,6 @@
+import { __ } from '@wordpress/i18n';
+
+export default {
+	name: 'core/site-preview',
+	title: __( 'Site Preview' ),
+};

--- a/widgets/welcome/dashboard-background.svg
+++ b/widgets/welcome/dashboard-background.svg
@@ -1,0 +1,63 @@
+<svg preserveAspectRatio="xMidYMin slice" fill="none" viewBox="0 0 1232 240" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+  <g clip-path="url(#a)">
+    <path fill="#151515" d="M0 0h1232v240H0z"/>
+    <ellipse cx="616" cy="232" fill="url(#b)" opacity=".05" rx="1497" ry="249"/>
+    <mask id="d" width="1000" height="400" x="232" y="20" maskUnits="userSpaceOnUse" style="mask-type:alpha">
+      <path fill="url(#c)" d="M0 0h1000v400H0z" transform="translate(232 20)"/>
+    </mask>
+    <g stroke-width="2" mask="url(#d)">
+      <path stroke="url(#e)" d="M387 20v1635"/>
+      <path stroke="url(#f)" d="M559.5 20v1635"/>
+      <path stroke="url(#g)" d="M732 20v1635"/>
+      <path stroke="url(#h)" d="M904.5 20v1635"/>
+      <path stroke="url(#i)" d="M1077 20v1635"/>
+    </g>
+  </g>
+  <defs>
+    <linearGradient id="e" x1="387.5" x2="387.5" y1="20" y2="1655" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#3858E9" stop-opacity="0"/>
+      <stop offset=".297" stop-color="#3858E9"/>
+      <stop offset=".734" stop-color="#3858E9"/>
+      <stop offset="1" stop-color="#3858E9" stop-opacity="0"/>
+      <stop offset="1" stop-color="#3858E9" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="f" x1="560" x2="560" y1="20" y2="1655" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFCB5" stop-opacity="0"/>
+      <stop offset="0" stop-color="#FFFCB5" stop-opacity="0"/>
+      <stop offset=".297" stop-color="#FFFCB5"/>
+      <stop offset=".734" stop-color="#FFFCB5"/>
+      <stop offset="1" stop-color="#FFFCB5" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="g" x1="732.5" x2="732.5" y1="20" y2="1655" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#C7FFDB" stop-opacity="0"/>
+      <stop offset=".297" stop-color="#C7FFDB"/>
+      <stop offset=".693" stop-color="#C7FFDB"/>
+      <stop offset="1" stop-color="#C7FFDB" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="h" x1="905" x2="905" y1="20" y2="1655" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFB7A7" stop-opacity="0"/>
+      <stop offset=".297" stop-color="#FFB7A7"/>
+      <stop offset=".734" stop-color="#FFB7A7"/>
+      <stop offset="1" stop-color="#3858E9" stop-opacity="0"/>
+      <stop offset="1" stop-color="#FFB7A7" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="i" x1="1077.5" x2="1077.5" y1="20" y2="1655" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7B90FF" stop-opacity="0"/>
+      <stop offset=".297" stop-color="#7B90FF"/>
+      <stop offset=".734" stop-color="#7B90FF"/>
+      <stop offset="1" stop-color="#3858E9" stop-opacity="0"/>
+      <stop offset="1" stop-color="#7B90FF" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="b" cx="0" cy="0" r="1" gradientTransform="matrix(0 249 -1497 0 616 232)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#3858E9"/>
+      <stop offset="1" stop-color="#151515" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="c" cx="0" cy="0" r="1" gradientTransform="matrix(0 765 -1912.5 0 500 -110)" gradientUnits="userSpaceOnUse">
+      <stop offset=".161" stop-color="#151515" stop-opacity="0"/>
+      <stop offset=".682"/>
+    </radialGradient>
+    <clipPath id="a">
+      <path fill="#fff" d="M0 0h1232v240H0z"/>
+    </clipPath>
+  </defs>
+</svg>

--- a/widgets/welcome/render.tsx
+++ b/widgets/welcome/render.tsx
@@ -1,0 +1,469 @@
+/**
+ * WordPress dependencies
+ */
+import { useId, useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { __, sprintf } from '@wordpress/i18n';
+import { close } from '@wordpress/icons';
+import {
+	type ThemeProvider as ThemeProviderType,
+	privateApis as themePrivateApis,
+} from '@wordpress/theme';
+// Dashboard is still experimental.
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Card, IconButton, Link, Stack, Text } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+import styles from './style.module.css';
+
+declare global {
+	interface Window {
+		wpDashboardWidgetsConfig?: {
+			wpVersion?: string;
+		};
+	}
+}
+
+const ThemeProvider: typeof ThemeProviderType =
+	unlock( themePrivateApis ).ThemeProvider;
+
+// ─── Icons ────────────────────────────────────────────────────────────────────
+
+function IconBlocks() {
+	return (
+		<svg
+			width="48"
+			height="48"
+			viewBox="0 0 48 48"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<rect width="48" height="48" rx="4" fill="#1E1E1E" />
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M32.0668 17.0854L28.8221 13.9454L18.2008 24.671L16.8983 29.0827L21.4257 27.8309L32.0668 17.0854ZM16 32.75H24V31.25H16V32.75Z"
+				fill="white"
+			/>
+		</svg>
+	);
+}
+
+function IconLayout() {
+	return (
+		<svg
+			width="48"
+			height="48"
+			viewBox="0 0 48 48"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<rect width="48" height="48" rx="4" fill="#1E1E1E" />
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M18 16h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H18a2 2 0 0 1-2-2V18a2 2 0 0 1 2-2zm12 1.5H18a.5.5 0 0 0-.5.5v3h13v-3a.5.5 0 0 0-.5-.5zm.5 5H22v8h8a.5.5 0 0 0 .5-.5v-7.5zm-10 0h-3V30a.5.5 0 0 0 .5.5h2.5v-8z"
+				fill="#fff"
+			/>
+		</svg>
+	);
+}
+
+function IconStyles() {
+	return (
+		<svg
+			width="48"
+			height="48"
+			viewBox="0 0 48 48"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<rect width="48" height="48" rx="4" fill="#1E1E1E" />
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M31 24a7 7 0 0 1-7 7V17a7 7 0 0 1 7 7zm-7-8a8 8 0 1 1 0 16 8 8 0 0 1 0-16z"
+				fill="#fff"
+			/>
+		</svg>
+	);
+}
+
+// ─── Background SVG ───────────────────────────────────────────────────────────
+
+function DashboardBackground() {
+	const uid = useId();
+	const ids = {
+		clip: `${ uid }-clip`,
+		mask: `${ uid }-mask`,
+		line1: `${ uid }-line-1`,
+		line2: `${ uid }-line-2`,
+		line3: `${ uid }-line-3`,
+		line4: `${ uid }-line-4`,
+		line5: `${ uid }-line-5`,
+		radial1: `${ uid }-radial-1`,
+		radial2: `${ uid }-radial-2`,
+	};
+
+	return (
+		<svg
+			preserveAspectRatio="xMidYMin slice"
+			viewBox="0 0 1232 240"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<g clipPath={ `url(#${ ids.clip })` }>
+				<path fill="#151515" d="M0 0h1232v240H0z" />
+				<ellipse
+					cx="616"
+					cy="232"
+					fill={ `url(#${ ids.radial1 })` }
+					opacity=".05"
+					rx="1497"
+					ry="249"
+				/>
+				<mask
+					id={ ids.mask }
+					width="1000"
+					height="400"
+					x="232"
+					y="20"
+					maskUnits="userSpaceOnUse"
+					style={ { maskType: 'alpha' } }
+				>
+					<path
+						fill={ `url(#${ ids.radial2 })` }
+						d="M0 0h1000v400H0z"
+						transform="translate(232 20)"
+					/>
+				</mask>
+				<g strokeWidth="2" mask={ `url(#${ ids.mask })` }>
+					<path stroke={ `url(#${ ids.line1 })` } d="M387 20v1635" />
+					<path
+						stroke={ `url(#${ ids.line2 })` }
+						d="M559.5 20v1635"
+					/>
+					<path stroke={ `url(#${ ids.line3 })` } d="M732 20v1635" />
+					<path
+						stroke={ `url(#${ ids.line4 })` }
+						d="M904.5 20v1635"
+					/>
+					<path stroke={ `url(#${ ids.line5 })` } d="M1077 20v1635" />
+				</g>
+			</g>
+			<defs>
+				<linearGradient
+					id={ ids.line1 }
+					x1="387.5"
+					x2="387.5"
+					y1="20"
+					y2="1655"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop stopColor="#3858E9" stopOpacity="0" />
+					<stop offset=".297" stopColor="#3858E9" />
+					<stop offset=".734" stopColor="#3858E9" />
+					<stop offset="1" stopColor="#3858E9" stopOpacity="0" />
+				</linearGradient>
+				<linearGradient
+					id={ ids.line2 }
+					x1="560"
+					x2="560"
+					y1="20"
+					y2="1655"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop stopColor="#FFFCB5" stopOpacity="0" />
+					<stop offset=".297" stopColor="#FFFCB5" />
+					<stop offset=".734" stopColor="#FFFCB5" />
+					<stop offset="1" stopColor="#FFFCB5" stopOpacity="0" />
+				</linearGradient>
+				<linearGradient
+					id={ ids.line3 }
+					x1="732.5"
+					x2="732.5"
+					y1="20"
+					y2="1655"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop stopColor="#C7FFDB" stopOpacity="0" />
+					<stop offset=".297" stopColor="#C7FFDB" />
+					<stop offset=".693" stopColor="#C7FFDB" />
+					<stop offset="1" stopColor="#C7FFDB" stopOpacity="0" />
+				</linearGradient>
+				<linearGradient
+					id={ ids.line4 }
+					x1="905"
+					x2="905"
+					y1="20"
+					y2="1655"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop stopColor="#FFB7A7" stopOpacity="0" />
+					<stop offset=".297" stopColor="#FFB7A7" />
+					<stop offset=".734" stopColor="#FFB7A7" />
+					<stop offset="1" stopColor="#FFB7A7" stopOpacity="0" />
+				</linearGradient>
+				<linearGradient
+					id={ ids.line5 }
+					x1="1077.5"
+					x2="1077.5"
+					y1="20"
+					y2="1655"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop stopColor="#7B90FF" stopOpacity="0" />
+					<stop offset=".297" stopColor="#7B90FF" />
+					<stop offset=".734" stopColor="#7B90FF" />
+					<stop offset="1" stopColor="#7B90FF" stopOpacity="0" />
+				</linearGradient>
+				<radialGradient
+					id={ ids.radial1 }
+					cx="0"
+					cy="0"
+					r="1"
+					gradientTransform="matrix(0 249 -1497 0 616 232)"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop stopColor="#3858E9" />
+					<stop offset="1" stopColor="#151515" stopOpacity="0" />
+				</radialGradient>
+				<radialGradient
+					id={ ids.radial2 }
+					cx="0"
+					cy="0"
+					r="1"
+					gradientTransform="matrix(0 765 -1912.5 0 500 -110)"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop offset=".161" stopColor="#151515" stopOpacity="0" />
+					<stop offset=".682" />
+				</radialGradient>
+				<clipPath id={ ids.clip }>
+					<path fill="#fff" d="M0 0h1232v240H0z" />
+				</clipPath>
+			</defs>
+		</svg>
+	);
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function Welcome() {
+	const displayVersion = window.wpDashboardWidgetsConfig?.wpVersion ?? '';
+	const currentTheme = useSelect(
+		( select ) => ( select( coreStore ) as any ).getCurrentTheme(),
+		[]
+	);
+
+	const canCustomize = useSelect(
+		( select ) =>
+			!! ( select( coreStore ).getCurrentUser() as any )?.capabilities
+				?.customize,
+		[]
+	);
+
+	const isBlockTheme = !! currentTheme?.is_block_theme;
+	const [ isDismissed, setIsDismissed ] = useState( false );
+
+	if ( isDismissed ) {
+		return null;
+	}
+
+	return (
+		<>
+			<ThemeProvider color={ { bg: '#000000' } }>
+				<div className={ styles.headerWrap }>
+					<div className={ styles.headerImage } aria-hidden="true">
+						<DashboardBackground />
+					</div>
+					<div className={ styles.header }>
+						<IconButton
+							className={ styles.dismissButton }
+							variant="minimal"
+							tone="neutral"
+							size="compact"
+							icon={ close }
+							label={ __( 'Dismiss welcome panel' ) }
+							onClick={ () => setIsDismissed( true ) }
+						/>
+						<Text variant="heading-2xl" render={ <h2 /> }>
+							{ __( 'Welcome to WordPress!' ) }
+						</Text>
+						{ displayVersion && (
+							<Text variant="body-xl" render={ <p /> }>
+								<Link href="about.php">
+									{ sprintf(
+										/* translators: %s: Current WordPress version. */
+										__(
+											'Learn more about the %s version.'
+										),
+										displayVersion
+									) }
+								</Link>
+							</Text>
+						) }
+					</div>
+				</div>
+			</ThemeProvider>
+
+			<Card.Content>
+				<Stack
+					className={ styles.columns }
+					direction="row"
+					gap="lg"
+					wrap="wrap"
+				>
+					<Stack gap="lg" className={ styles.column }>
+						<IconBlocks />
+						<Stack
+							className={ styles.columnContent }
+							direction="column"
+							gap="sm"
+							align="start"
+						>
+							<Text variant="heading-lg" render={ <h3 /> }>
+								{ __(
+									'Author rich content with blocks and patterns'
+								) }
+							</Text>
+							<Text variant="body-lg" render={ <p /> }>
+								{ __(
+									'Block patterns are pre-configured block layouts. Use them to get inspired or create new pages in a flash.'
+								) }
+							</Text>
+							<Text variant="body-lg">
+								<Link href="post-new.php?post_type=page">
+									{ __( 'Add a new page' ) }
+								</Link>
+							</Text>
+						</Stack>
+					</Stack>
+
+					<Stack gap="lg" className={ styles.column }>
+						<IconLayout />
+						<Stack
+							className={ styles.columnContent }
+							direction="column"
+							gap="sm"
+							align="start"
+						>
+							{ isBlockTheme ? (
+								<>
+									<Text
+										variant="heading-lg"
+										render={ <h3 /> }
+									>
+										{ __(
+											'Customize your entire site with block themes'
+										) }
+									</Text>
+									<Text variant="body-md" render={ <p /> }>
+										{ __(
+											'Design everything on your site \u2014 from the header down to the footer, all using blocks and patterns.'
+										) }
+									</Text>
+									<Text variant="body-lg">
+										<Link href="site-editor.php">
+											{ __( 'Open site editor' ) }
+										</Link>
+									</Text>
+								</>
+							) : (
+								<>
+									<Text
+										variant="heading-lg"
+										render={ <h3 /> }
+									>
+										{ __( 'Start Customizing' ) }
+									</Text>
+									<Text variant="body-lg" render={ <p /> }>
+										{ __(
+											'Configure your site\u2019s logo, header, menus, and more in the Customizer.'
+										) }
+									</Text>
+									{ canCustomize && (
+										<Text variant="body-lg">
+											<Link href="customize.php">
+												{ __( 'Open the Customizer' ) }
+											</Link>
+										</Text>
+									) }
+								</>
+							) }
+						</Stack>
+					</Stack>
+
+					<Stack gap="lg" className={ styles.column }>
+						<IconStyles />
+						<Stack
+							className={ styles.columnContent }
+							direction="column"
+							gap="sm"
+							align="start"
+						>
+							{ isBlockTheme ? (
+								<>
+									<Text
+										variant="heading-lg"
+										render={ <h3 /> }
+									>
+										{ __(
+											'Switch up your site\u2019s look & feel with Styles'
+										) }
+									</Text>
+									<Text variant="body-lg" render={ <p /> }>
+										{ __(
+											'Tweak your site, or give it a whole new look! Get creative \u2014 how about a new color palette or font?'
+										) }
+									</Text>
+									<Text variant="body-lg">
+										<Link href="site-editor.php?p=%2Fstyles">
+											{ __( 'Edit styles' ) }
+										</Link>
+									</Text>
+								</>
+							) : (
+								<>
+									<Text
+										variant="heading-lg"
+										render={ <h3 /> }
+									>
+										{ __(
+											'Discover a new way to build your site.'
+										) }
+									</Text>
+									<Text variant="body-lg" render={ <p /> }>
+										{ __(
+											'There is a new kind of WordPress theme, called a block theme, that lets you build the site you\u2019ve always wanted \u2014 with blocks and styles.'
+										) }
+									</Text>
+									<Text variant="body-lg">
+										<Link
+											href={ __(
+												'https://wordpress.org/documentation/article/block-themes/'
+											) }
+										>
+											{ __( 'Learn about block themes' ) }
+										</Link>
+									</Text>
+								</>
+							) }
+						</Stack>
+					</Stack>
+				</Stack>
+			</Card.Content>
+		</>
+	);
+}

--- a/widgets/welcome/style.module.css
+++ b/widgets/welcome/style.module.css
@@ -1,7 +1,7 @@
 .headerWrap {
 	position: relative;
 	overflow: hidden;
-	min-height: 120px;
+	min-height: 240px;
 }
 
 .headerImage {

--- a/widgets/welcome/style.module.css
+++ b/widgets/welcome/style.module.css
@@ -1,0 +1,73 @@
+.headerWrap {
+	position: relative;
+	overflow: hidden;
+	min-height: 120px;
+}
+
+.headerImage {
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+}
+
+.headerImage svg {
+	width: 100%;
+	height: 100%;
+}
+
+.header {
+	padding: 48px 48px 80px;
+	position: relative;
+	z-index: 1;
+}
+
+.dismissButton {
+	position: absolute;
+	inset-block-start: 12px;
+	inset-inline-end: 12px;
+}
+
+@media (max-width: 782px) {
+	.columns {
+		flex-direction: column;
+	}
+}
+
+.column {
+	flex: 1;
+	padding-inline-end: 20px;
+}
+
+.column:last-child {
+	padding-inline-end: 0;
+}
+
+.column + .column {
+	padding-inline-start: 20px;
+	border-inline-start: 1px solid var(--wpds-color-stroke-surface-neutral);
+}
+
+@media (max-width: 782px) {
+	.column {
+		padding-block-end: 20px;
+		padding-inline-end: 0;
+	}
+
+	.column:last-child {
+		padding-block-end: 0;
+	}
+
+	.column + .column {
+		padding-inline-start: 0;
+		padding-block-start: 20px;
+		border-inline-start: none;
+		border-block-start: 1px solid var(--wpds-color-stroke-surface-neutral);
+	}
+}
+
+.column svg {
+	flex-shrink: 0;
+	width: 40px;
+	height: 40px;
+	border-radius: var(--wpds-border-radius-sm);
+}

--- a/widgets/welcome/widget.json
+++ b/widgets/welcome/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "core/welcome",
+	"title": "Welcome",
+	"description": "Displays an introduction to WordPress with links to key admin areas.",
+	"category": "dashboard"
+}

--- a/widgets/welcome/widget.ts
+++ b/widgets/welcome/widget.ts
@@ -1,0 +1,6 @@
+import { __ } from '@wordpress/i18n';
+
+export default {
+	name: 'core/welcome',
+	title: __( 'Welcome' ),
+};


### PR DESCRIPTION
## What?

Integration branch that combines several Customizable Dashboard work-in-progress PRs into a single surface for end-to-end testing. Bundles:

- Widget set: `welcome`, `activity`, `news`, `events`, `site-health`, `site-preview`, `quick-draft`, `hello-dolly`.
- Backend default layout filter (`gutenberg_dashboard_default_layout`) plus the seed that ships those widget instances.
- Widget inserter modal.
- Layout persistence via `@wordpress/preferences`.

## Why?

Provides a single branch to validate the dashboard end-to-end while each piece is still being reviewed in its own PR.

## How?

Each piece was cherry-picked or copied from its underlying feature branch. The original PRs remain the source of truth for review and merge; this branch only stitches them together so reviewers and stakeholders can see the system running as a whole.

## Testing

1. Enable the `gutenberg-dashboard-widgets` experiment.
2. Open the dashboard route.
3. Verify the default layout renders, the inserter opens from the toolbar, and changes persist across reloads.


https://github.com/user-attachments/assets/57c38019-dc0c-4d80-9507-a7187bac767d


## Status

**Do not merge.** This branch exists for testing only; every change here lands through its dedicated PR.