### PR TITLE
Connectors: Clarify AI plugin callout copy

### DIFF
--- a/routes/connectors-home/ai-plugin-callout.tsx
+++ b/routes/connectors-home/ai-plugin-callout.tsx
@@ -224,11 +224,11 @@ export function AiPluginCallout() {
 		}
 		if ( isActiveNoProvider ) {
 			return __(
-				'The <strong>AI plugin</strong> is installed. Connect a provider below to generate featured images, alt text, titles, excerpts, and more. <a>Learn more</a>'
+				'The <strong>AI plugin</strong> is installed. Connect an AI provider below to generate featured images, alt text, titles, excerpts, and more. <a>Learn more</a>'
 			);
 		}
 		return __(
-			'The <strong>AI plugin</strong> can use your connectors to generate featured images, alt text, titles, excerpts and more. <a>Learn more</a>'
+			'The <strong>AI plugin</strong> can use your AI connectors to generate featured images, alt text, titles, excerpts and more. <a>Learn more</a>'
 		);
 	};
 


### PR DESCRIPTION
## What

Adds the "AI" qualifier to two strings in the AI plugin callout shown on the connectors home screen:

- `Connect a provider below…` → `Connect an AI provider below…`
- `…can use your connectors to generate…` → `…can use your AI connectors to generate…`

## Why

The connectors home screen can list connectors of multiple kinds, and third-party plugins (or core) may register connectors that are not AI providers. Without the "AI" qualifier, the callout's references to "a provider" and "your connectors" are ambiguous in that context — they could be read as referring to any connector on the screen, not just the AI ones the AI plugin actually consumes.

Adding "AI" makes the copy match what the AI plugin callout is actually talking about: the subset of connectors of type `ai_provider` (the same set already used by the surrounding logic in `ai-plugin-callout.tsx` to decide whether to render the callout at all).

Props to @t-hamano for reporting this issue.

## Testing instructions

1. Open the connectors home screen with the AI plugin **not installed** (or inactive). Confirm the callout reads: *"The **AI plugin** can use your AI connectors to generate featured images, alt text, titles, excerpts and more."*
2. Install/activate the AI plugin without configuring any AI provider. Confirm the callout reads: *"The **AI plugin** is installed. Connect an AI provider below to generate featured images, alt text, titles, excerpts, and more."*
3. Connect an AI provider. Confirm the "ready to use" message still appears (unchanged).