### PR TITLE
Image editor: update sidebar aspect ratio and resize controls

### DIFF
--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -96,12 +96,36 @@ export default function MediaEditorCropPanel( {
 		...( aspectRatioPresets ??
 			DEFAULT_ASPECT_RATIOS.filter( ( preset ) => preset.value > 0 ) ),
 	];
+	const handleAspectRatioChange = ( value: string ) => {
+		onAspectRatioChange( value );
+		if ( value === '0' && ! freeformCrop ) {
+			onFreeformChange( true );
+		}
+	};
 
 	return (
 		<Stack direction="column" gap="md">
 			<VisuallyHidden render={ <h2 /> }>
 				{ __( 'Crop options' ) }
 			</VisuallyHidden>
+			<SelectControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ __( 'Aspect ratio' ) }
+				value={ aspectRatioValue }
+				onChange={ handleAspectRatioChange }
+				options={ aspectRatioOptions.map( ( preset ) => ( {
+					label: preset.label,
+					value: preset.value.toString(),
+				} ) ) }
+			/>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Resize crop area' ) }
+				help={ __( 'Show handles for adjusting the crop box.' ) }
+				checked={ freeformCrop }
+				onChange={ onFreeformChange }
+			/>
 			<div role="presentation" { ...zoomGestureHandlers }>
 				<RangeControl
 					__next40pxDefaultSize
@@ -126,26 +150,6 @@ export default function MediaEditorCropPanel( {
 					} }
 				/>
 			</div>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ __( 'Aspect ratio' ) }
-				value={ aspectRatioValue }
-				onChange={ onAspectRatioChange }
-				options={ aspectRatioOptions.map( ( preset ) => ( {
-					label: preset.label,
-					value: preset.value.toString(),
-				} ) ) }
-			/>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ __( 'Freeform crop' ) }
-				help={ __(
-					'Drag the crop edges to resize freely. When off, the crop is fixed to the selected ratio.'
-				) }
-				checked={ freeformCrop }
-				onChange={ onFreeformChange }
-			/>
 		</Stack>
 	);
 }

--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -122,7 +122,7 @@ export default function MediaEditorCropPanel( {
 			<ToggleControl
 				__nextHasNoMarginBottom
 				label={ __( 'Resize crop area' ) }
-				help={ __( 'Show handles for adjusting the crop box.' ) }
+				help={ __( 'Show handles to adjust the crop box.' ) }
 				checked={ freeformCrop }
 				onChange={ onFreeformChange }
 			/>

--- a/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import MediaEditorCropPanel from '..';
+import type { MediaEditorCropPanelProps } from '..';
+import { CropperProvider } from '../../../image-editor';
+
+function setupCropPanel(
+	overrides: Partial< MediaEditorCropPanelProps > = {}
+) {
+	const props: MediaEditorCropPanelProps = {
+		aspectRatioValue: '1',
+		onAspectRatioChange: jest.fn(),
+		freeformCrop: false,
+		onFreeformChange: jest.fn(),
+		...overrides,
+	};
+
+	render(
+		<CropperProvider>
+			<MediaEditorCropPanel { ...props } />
+		</CropperProvider>
+	);
+
+	return props;
+}
+
+function expectElementBefore( first: HTMLElement, second: HTMLElement ) {
+	expect( first.compareDocumentPosition( second ) ).toBe(
+		Node.DOCUMENT_POSITION_FOLLOWING
+	);
+}
+
+describe( 'MediaEditorCropPanel', () => {
+	it( 'renders crop shape controls before zoom controls', () => {
+		setupCropPanel();
+
+		const aspectRatio = screen.getByLabelText( 'Aspect ratio' );
+		const resizeCropArea = screen.getByLabelText( 'Resize crop area' );
+		const zoom = screen.getByRole( 'slider', { name: 'Zoom' } );
+
+		expect(
+			screen.getByText( 'Show handles for adjusting the crop box.' )
+		).toBeInTheDocument();
+		expectElementBefore( aspectRatio, resizeCropArea );
+		expectElementBefore( resizeCropArea, zoom );
+	} );
+
+	it( 'turns freeform crop on when Free is selected while handles are off', () => {
+		const controls = setupCropPanel( {
+			aspectRatioValue: '1',
+			freeformCrop: false,
+		} );
+
+		fireEvent.change( screen.getByLabelText( 'Aspect ratio' ), {
+			target: { value: '0' },
+		} );
+
+		expect( controls.onAspectRatioChange ).toHaveBeenCalledWith( '0' );
+		expect( controls.onFreeformChange ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'does not change freeform crop when a fixed ratio is selected', () => {
+		const controls = setupCropPanel( {
+			aspectRatioValue: '0',
+			freeformCrop: false,
+		} );
+
+		fireEvent.change( screen.getByLabelText( 'Aspect ratio' ), {
+			target: { value: '1' },
+		} );
+
+		expect( controls.onAspectRatioChange ).toHaveBeenCalledWith( '1' );
+		expect( controls.onFreeformChange ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not call onFreeformChange when Free is selected and handles are already on', () => {
+		const controls = setupCropPanel( {
+			aspectRatioValue: '1',
+			freeformCrop: true,
+		} );
+
+		fireEvent.change( screen.getByLabelText( 'Aspect ratio' ), {
+			target: { value: '0' },
+		} );
+
+		expect( controls.onAspectRatioChange ).toHaveBeenCalledWith( '0' );
+		expect( controls.onFreeformChange ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not call onFreeformChange when a fixed ratio is selected and handles are on', () => {
+		const controls = setupCropPanel( {
+			aspectRatioValue: '0',
+			freeformCrop: true,
+		} );
+
+		fireEvent.change( screen.getByLabelText( 'Aspect ratio' ), {
+			target: { value: '1' },
+		} );
+
+		expect( controls.onAspectRatioChange ).toHaveBeenCalledWith( '1' );
+		expect( controls.onFreeformChange ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
@@ -45,7 +45,7 @@ describe( 'MediaEditorCropPanel', () => {
 		const zoom = screen.getByRole( 'slider', { name: 'Zoom' } );
 
 		expect(
-			screen.getByText( 'Show handles for adjusting the crop box.' )
+			screen.getByText( 'Show handles to adjust the crop box.' )
 		).toBeInTheDocument();
 		expectElementBefore( aspectRatio, resizeCropArea );
 		expectElementBefore( resizeCropArea, zoom );

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -226,13 +226,16 @@ function CropperInner(
 		[ canvasSize, naturalWidth, naturalHeight, state.rotation ]
 	);
 
-	// In fixed-crop mode, auto-size the crop rect to fill the visual area
-	// while respecting the aspect ratio. The crop is always centered.
+	// In fixed-crop mode, auto-size the crop rect only when a fixed aspect
+	// ratio is selected. With "Free" selected, turning freeform handles off
+	// should preserve the user's current unconstrained crop.
 	useEffect( () => {
 		if (
 			freeformCrop ||
 			visualSize.width === 0 ||
-			visualSize.height === 0
+			visualSize.height === 0 ||
+			! aspectRatio ||
+			aspectRatio <= 0
 		) {
 			return;
 		}

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -37,6 +43,11 @@ function createController(): UseCropperStateReturn {
 		applyOperation: jest.fn(),
 		reset: jest.fn(),
 		isDirty: false,
+		hasUndo: false,
+		hasRedo: false,
+		undo: jest.fn(),
+		redo: jest.fn(),
+		commitHistory: jest.fn(),
 		getCroppedImage: jest.fn(),
 	};
 }
@@ -154,6 +165,69 @@ describe( 'Cropper', () => {
 		const canvas = screen.getByRole( 'group', { name: 'Image editor' } );
 		expect( canvas ).toHaveClass( GRID_INTERACTIVE_CLASS );
 		expect( canvas ).toHaveClass( SHOW_GRID_CLASS );
+	} );
+
+	it( 'preserves a free crop when freeform handles are toggled off', async () => {
+		const controller = createController();
+		controller.state = {
+			...controller.state,
+			cropRect: { x: 0.1, y: 0.2, width: 0.5, height: 0.4 },
+		};
+		const { rerender } = render(
+			<Cropper
+				src="test.jpg"
+				controller={ controller }
+				showDimming={ false }
+				freeformCrop
+			/>
+		);
+
+		await screen.findByRole( 'button', {
+			name: 'Resize top-left corner',
+		} );
+		( controller.setCropRect as jest.Mock ).mockClear();
+
+		rerender(
+			<Cropper
+				src="test.jpg"
+				controller={ controller }
+				showDimming={ false }
+				freeformCrop={ false }
+			/>
+		);
+
+		expect(
+			screen.queryByRole( 'button', {
+				name: 'Resize top-left corner',
+			} )
+		).not.toBeInTheDocument();
+		expect( controller.setCropRect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'centers a fixed-ratio crop when freeform handles are off', async () => {
+		const controller = createController();
+		controller.state = {
+			...controller.state,
+			cropRect: { x: 0.1, y: 0.2, width: 0.5, height: 0.4 },
+		};
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ controller }
+				showDimming={ false }
+				freeformCrop={ false }
+				aspectRatio={ 1 }
+			/>
+		);
+
+		await waitFor( () =>
+			expect( controller.setCropRect ).toHaveBeenCalledWith( {
+				x: expect.closeTo( 1 / 6, 5 ),
+				y: 0,
+				width: expect.closeTo( 2 / 3, 5 ),
+				height: 1,
+			} )
+		);
 	} );
 
 	it( 'clears settling state when a new resize starts before the settle timer fires', async () => {


### PR DESCRIPTION
## What?

This PR introduces some UX tweaks around aspect ratio and freeform resizing. 

Here they are in order of "probably good to haves" to "opinionated nice to haves".

1. Preserves the current free crop when crop-box resizing is toggled off while `Free` is selected.
2. Makes selecting `Free` from the aspect ratio dropdown turn crop-box resizing on.
3. Adds unit test coverage for the new control behavior and crop preservation.
4. Renames `Freeform crop` to `Resize crop area`.
5. Updates the toggle help text to clarify that it shows crop-box handles.
6. Moves `Aspect ratio` and crop-box resizing controls above `Zoom`.


https://github.com/user-attachments/assets/2b214e4f-1da6-4ef0-9563-727cd49bc78f


## Why?

1. Toggling resizing off with `Free` selected reset the crop to the original aspect ratio
2. Choosing `Free` while resizing was off was a silent no-op
3. 👍🏻 
4. The previous `Freeform crop` label was a teensy bit ambiguous because the aspect ratio menu also has a `Free` option. `Resize crop area` better describes what the toggle actually does: showing handles for adjusting the crop box.
5. See above.
6. The crop workflow should start with defining the crop frame, then adjusting image placement within it. Aspect ratio and crop-box resizing are shape controls, while zoom is a placement control, so the sidebar order now reflects that.


## Testing Instructions

1. Enable the experimental media editor modal.
7. Open an image in the editor and launch the image editor.
8. Confirm the Crop sidebar order is:
   - Aspect ratio
   - Resize crop area
   - Zoom
9. Select a fixed aspect ratio, such as Square.
10. Turn `Resize crop area` off.
11. Select `Free` from the aspect ratio dropdown.
12. Confirm `Resize crop area` turns on and crop handles are visible.
13. With `Free` selected, adjust the crop to a non-original shape.
14. Turn `Resize crop area` off.
15. Confirm the crop area is preserved and does not reset to the original aspect ratio.
16. Select a fixed ratio with `Resize crop area` off.
17. Confirm the crop recenters/resizes to that fixed ratio.

