### PR TITLE
Font Library: Add `Variant` filter to Install Fonts collection

### DIFF
--- a/packages/global-styles-ui/src/font-library/font-collection.tsx
+++ b/packages/global-styles-ui/src/font-library/font-collection.tsx
@@ -46,7 +46,7 @@ import type {
  */
 import { FontLibraryContext } from './context';
 import FontCard from './font-card';
-import filterFonts from './utils/filter-fonts';
+import filterFonts, { type VariantCountRange } from './utils/filter-fonts';
 import { toggleFont } from './utils/toggleFont';
 import {
 	getFontsOutline,
@@ -87,6 +87,7 @@ function FontCollection( { slug }: { slug: string } ) {
 	const [ filters, setFilters ] = useState< {
 		category?: string;
 		search?: string;
+		variantCount?: VariantCountRange;
 	} >( {} );
 	const [ renderConfirmDialog, setRenderConfirmDialog ] = useState(
 		requiresPermission && ! getGoogleFontsPermissionFromStorage()
@@ -147,6 +148,14 @@ function FontCollection( { slug }: { slug: string } ) {
 
 	const handleCategoryFilter = ( category: string ) => {
 		setFilters( { ...filters, category } );
+		setPage( 1 );
+	};
+
+	const handleVariantCountFilter = ( variantCount: string ) => {
+		setFilters( {
+			...filters,
+			variantCount: variantCount as VariantCountRange,
+		} );
 		setPage( 1 );
 	};
 
@@ -326,6 +335,42 @@ function FontCollection( { slug }: { slug: string } ) {
 											</option>
 										) ) }
 								</SelectControl>
+								<SelectControl
+									__next40pxDefaultSize
+									label={ __( 'Variants' ) }
+									value={ filters.variantCount ?? '' }
+									onChange={ handleVariantCountFilter }
+									options={ [
+										{
+											label: _x(
+												'Any',
+												'font styles count filter'
+											),
+											value: '',
+										},
+										{
+											label: _x(
+												'1–3',
+												'font styles count range'
+											),
+											value: '1-3',
+										},
+										{
+											label: _x(
+												'4–9',
+												'font styles count range'
+											),
+											value: '4-9',
+										},
+										{
+											label: _x(
+												'10+',
+												'font styles count range'
+											),
+											value: '10+',
+										},
+									] }
+								/>
 							</HStack>
 
 							<Spacer margin={ 4 } />

--- a/packages/global-styles-ui/src/font-library/utils/filter-fonts.ts
+++ b/packages/global-styles-ui/src/font-library/utils/filter-fonts.ts
@@ -4,26 +4,46 @@
 import type { CollectionFontFamily } from '@wordpress/core-data';
 
 /**
+ * Variant count range filter values.
+ * - '1-3'  : fonts with 1–3 faces (minimal families)
+ * - '4-9'  : fonts with 4–9 faces (moderate variety)
+ * - '10+'  : fonts with 10 or more faces (extensive families)
+ * - ''     : no filter applied (show all)
+ */
+export type VariantCountRange = '1-3' | '4-9' | '10+' | '';
+
+/**
  * Filters a list of fonts based on the specified filters.
  *
  * This function filters a given array of fonts based on the criteria provided in the filters object.
- * It supports filtering by category and a search term. If the category is provided and not equal to 'all',
- * the function filters the fonts array to include only those fonts that belong to the specified category.
+ * It supports filtering by category, a search term, and number of variants/styles.
+ * If the category is provided and not equal to 'all', the function filters the fonts array to include
+ * only those fonts that belong to the specified category.
  * Additionally, if a search term is provided, it filters the fonts array to include only those fonts
  * whose name includes the search term, case-insensitively.
+ * If a variantCount range is provided, it filters fonts by the number of fontFace entries they define.
  *
- * @param fonts            Array of font objects in font-collection schema fashion to be filtered. Each font object should have a 'categories' property and a 'font_family_settings' property with a 'name' key.
- * @param filters          Object containing the filter criteria. It should have a 'category' key and/or a 'search' key.
- * @param filters.category The category to filter fonts by. If 'all', no category filtering is applied.
- * @param filters.search   The search term to filter fonts by. If provided, only fonts whose
+ * @param fonts                Array of font objects in font-collection schema fashion to be filtered.
+ *                             Each font object should have a 'categories' property and a
+ *                             'font_family_settings' property with a 'name' key.
+ * @param filters              Object containing the filter criteria.
+ * @param filters.category     The category to filter fonts by. If 'all', no category filtering is applied.
+ * @param filters.search       The search term to filter fonts by. If provided, only fonts whose name
+ *                             includes the term (case-insensitive) are returned.
+ * @param filters.variantCount The variant count range to filter by. Ranges correspond to the number
+ *                             of fontFace entries: '1-3', '4-9', or '10+'. Empty string disables filter.
  *
  * @return Array of filtered font objects based on the provided criteria.
  */
 export default function filterFonts(
 	fonts: CollectionFontFamily[],
-	filters: { category?: string; search?: string }
+	filters: {
+		category?: string;
+		search?: string;
+		variantCount?: VariantCountRange;
+	}
 ): CollectionFontFamily[] {
-	const { category, search } = filters;
+	const { category, search, variantCount } = filters;
 	let filteredFonts = fonts || [];
 
 	if ( category && category !== 'all' ) {
@@ -41,6 +61,22 @@ export default function filterFonts(
 					.toLowerCase()
 					.includes( search.toLowerCase() )
 		);
+	}
+
+	if ( variantCount ) {
+		filteredFonts = filteredFonts.filter( ( font ) => {
+			const count = font.font_family_settings?.fontFace?.length ?? 0;
+			switch ( variantCount ) {
+				case '1-3':
+					return count >= 1 && count <= 3;
+				case '4-9':
+					return count >= 4 && count <= 9;
+				case '10+':
+					return count >= 10;
+				default:
+					return true;
+			}
+		} );
 	}
 
 	return filteredFonts;


### PR DESCRIPTION
## What?
Closes #73464

Adds a new "Variants" filter `SelectControl` to the Install Fonts tab of the Font Library modal, allowing users to narrow font collections by the number of available variants/styles (1–3, 4–9, 10+).

## Why?
The existing font collection interface only supports filtering by category and search. For theme designers, typographers, and accessibility-focused creators, the number of available styles is a meaningful signal when choosing a font, a font with 10+ variants offers far more flexibility than one with a single face.

Since the variant count is already fetched and displayed on each font card, extending the filter UI to use this data is a natural next step. The ranges (1–3, 4–9, 10+) intentionally mirror the conventions used by Google Fonts, keeping the experience familiar.

## Testing Instructions
1. Open the Appearance.
2. Navigate to **Fonts ->  Install Fonts**.
4. Confirm the new **Variants** dropdown appears in the filter row alongside Search and Category.
5. Select **1–3** - verify only fonts with 1 to 3 defined font faces are shown.
6. Select **4–9** - verify only fonts with 4 to 9 faces are shown.
7. Select **10+** - verify only fonts with 10 or more faces are shown (e.g. Inter, Roboto).
8. Select **Any** - verify all fonts are shown again.
9. Combine the Styles filter with the Category filter and a search term, verify all three filters apply together correctly.
10. Change to a different font collection, verify the Styles filter resets and behaves correctly for the new collection.

## Screenshots or screencast
https://github.com/user-attachments/assets/5061926e-8fb6-48bc-bf2c-d4dafbb3188a


## Use of AI Tools
Claude was used to assist with drafting the PR.