### PR TITLE
RTC: Fix find_canonical_storage_post_id() always returning null

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -197,8 +197,9 @@ jobs:
                       php: '8.2'
                     - event: 'pull_request'
                       multisite: true
-                    - event: 'pull_request'
-                      wordpress: 'previous major version'
+                    # TODO: Revert before merging.
+                    # - event: 'pull_request'
+                    #   wordpress: 'previous major version'
                     # On trunk/releases: Only test previous WP version with specific PHP versions
                     - php: '8.0'
                       wordpress: 'previous major version'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -197,9 +197,8 @@ jobs:
                       php: '8.2'
                     - event: 'pull_request'
                       multisite: true
-                    # TODO: Revert before merging.
-                    # - event: 'pull_request'
-                    #   wordpress: 'previous major version'
+                    - event: 'pull_request'
+                      wordpress: 'previous major version'
                     # On trunk/releases: Only test previous WP version with specific PHP versions
                     - php: '8.0'
                       wordpress: 'previous major version'

--- a/backport-changelog/7.0/11660.md
+++ b/backport-changelog/7.0/11660.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/11660
 
 * https://github.com/WordPress/gutenberg/pull/77675
+* https://github.com/WordPress/gutenberg/pull/78053

--- a/lib/compat/wordpress-7.0/class-wp-sync-post-meta-storage.php
+++ b/lib/compat/wordpress-7.0/class-wp-sync-post-meta-storage.php
@@ -335,7 +335,7 @@ if ( ! class_exists( 'WP_Sync_Post_Meta_Storage' ) ) {
 		 * @return int|null Canonical storage post ID.
 		 */
 		private function find_canonical_storage_post_id( string $room_hash ): ?int {
-			$post_id = get_posts(
+			$posts = get_posts(
 				array(
 					'post_type'      => self::POST_TYPE,
 					'posts_per_page' => 1,
@@ -347,7 +347,11 @@ if ( ! class_exists( 'WP_Sync_Post_Meta_Storage' ) ) {
 				)
 			);
 
-			return is_numeric( $post_id ) ? (int) $post_id : null;
+			if ( empty( $posts ) ) {
+				return null;
+			}
+
+			return $posts[0];
 		}
 
 		/**


### PR DESCRIPTION
Follow up to #77675

## What?

Fix `WP_Sync_Post_Meta_Storage::find_canonical_storage_post_id()` always returning `null`.

## Why?

The function calls `get_posts( ..., 'fields' => 'ids' )` which returns an array of IDs, but checked `is_numeric( $post_id )`. That check is always `false` for an array, so the function always returned `null`.

This issue surfaced when it was merged into trunk. The problem went unnoticed because the PR only runs unit tests on the latest WordPress version. This is because [the latest version of WordPress skips these unit tests](https://github.com/WordPress/gutenberg/blob/49b5ba56ba6fde40feab5a7174ac099aeafb84e0/phpunit/tests/collaboration/wpSyncPostMetaStorage.php#L76).

## Testing Instructions

In this PR, I will intentionally run unit tests with an older WP version. Once I confirm that the tests do not fail, I will remove the temporary code.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: Root-cause analysis and the fix. Reviewed and validated by me.
