### PR TITLE
Fix flaky e2e test for Pages dataview keyboard navigation

### DIFF
--- a/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
+++ b/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
@@ -21,6 +21,13 @@ test.describe( 'Dataviews List Layout', () => {
 		// Go to the pages page, as it has the list layout enabled by default.
 		await admin.visitSiteEditor();
 		await page.getByRole( 'button', { name: 'Pages' } ).click();
+
+		// Wait for the pages dataviews UI to fully load including:
+		// - the "Add filter" button, enabled only after post type fields are loaded
+		// - the actual pages in the list, appearing after a REST fetch finishes
+		// Only then we can start testing keyboard navigation around the full UI.
+		await page.getByRole( 'button', { name: 'Add filter' } ).waitFor();
+		await page.getByRole( 'grid' ).waitFor();
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {

--- a/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
+++ b/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
@@ -26,8 +26,10 @@ test.describe( 'Dataviews List Layout', () => {
 		// - the "Add filter" button, enabled only after post type fields are loaded
 		// - the actual pages in the list, appearing after a REST fetch finishes
 		// Only then we can start testing keyboard navigation around the full UI.
-		await page.getByRole( 'button', { name: 'Add filter' } ).waitFor();
-		await page.getByRole( 'grid' ).waitFor();
+		await expect(
+			page.getByRole( 'button', { name: 'Add filter' } )
+		).toBeVisible();
+		await expect( page.getByRole( 'grid' ) ).toBeVisible();
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
@@ -58,8 +60,6 @@ test.describe( 'Dataviews List Layout', () => {
 			page.getByRole( 'button', { name: 'View options' } )
 		).toBeFocused();
 
-		// Make sure the items have loaded before reaching for the 1st item in the list.
-		await expect( page.getByRole( 'grid' ) ).toBeVisible();
 		await page.keyboard.press( 'Tab' );
 		await expect(
 			page.getByRole( 'grid' ).getByRole( 'button' ).first()
@@ -82,8 +82,6 @@ test.describe( 'Dataviews List Layout', () => {
 			.getByRole( 'button' )
 			.first();
 
-		// Make sure the items have loaded before reaching for the 1st item in the list.
-		await expect( page.getByRole( 'grid' ) ).toBeVisible();
 		await page.keyboard.press( 'Tab' );
 		await expect( firstItem ).toBeFocused();
 
@@ -110,9 +108,6 @@ test.describe( 'Dataviews List Layout', () => {
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
-
-		// Make sure the items have loaded before reaching for the 1st item in the list.
-		await expect( page.getByRole( 'grid' ) ).toBeVisible();
 		await page.keyboard.press( 'Tab' );
 
 		// Use arrow up/down to move through the list.
@@ -133,9 +128,6 @@ test.describe( 'Dataviews List Layout', () => {
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
-
-		// Make sure the items have loaded before reaching for the 1st item in the list.
-		await expect( page.getByRole( 'grid' ) ).toBeVisible();
 		await page.keyboard.press( 'Tab' );
 
 		// Use right/left arrow keys to move horizontally.
@@ -202,9 +194,6 @@ test.describe( 'Dataviews List Layout', () => {
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
-
-		// Make sure the items have loaded before reaching for the 1st item in the list.
-		await expect( page.getByRole( 'grid' ) ).toBeVisible();
 		await page.keyboard.press( 'Tab' );
 
 		// Use arrow up/down to move through the list from the edit primary action button.


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/76012 and https://github.com/WordPress/gutenberg/issues/61701, flaky tests for Pages dataview keyboard navigation.

The the "Pages" dataview loads, it first shows an empty dataview, with no title and data, not "Add filter" button, there is just the always-enabled search box and layout and settings buttons:

<img width="578" height="214" alt="Screenshot 2026-05-07 at 11 05 14" src="https://github.com/user-attachments/assets/2febd354-c6ac-4da7-8afa-1062dfabc5b6" />

After REST data about a given post type are fetched, and when we can calculate a non-empty `fields` array for the `DataViews`, additional pieces of the UI appear. The "Add filter" button, the title, the "Add Page" button:

<img width="577" height="213" alt="Screenshot 2026-05-07 at 11 05 29" src="https://github.com/user-attachments/assets/cccee49f-3bb0-43e3-a450-eb1b2dcd9d53" />

After another REST request finishes, the actual items in the list are displayed.

The keyboard navigation e2e test waits only for the `searchbox` element before starting the test: clicking in the searchbox to focus it, and then pressing TAB to get to another UI element, etc.

But at this moment it's still too early. The `searchbox` is there, but the other elements are not. That's why the tests are failing. The improvements in #77981 probably aggravated this, because the `visitSiteEditor` wait is now shorter.

I'm fixing this by always waiting for the full UI to appear and starting the test only after that.
