### PR TITLE
Fix: Rename "Code" block to "Preformatted Code" and recategorize "Custom HTML"

### DIFF
--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/code",
-	"title": "Code",
+	"title": "Preformatted Code",
 	"category": "text",
 	"description": "Display code snippets that respect your spacing and tabs.",
 	"textdomain": "default",

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -47,7 +47,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 	settings[ fieldsKey ] = [
 		{
 			id: 'content',
-			label: __( 'Code' ),
+			label: __( 'Preformatted Code' ),
 			type: 'text',
 			Edit: 'rich-text', // TODO: replace with custom component
 		},

--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -3,9 +3,9 @@
 	"apiVersion": 3,
 	"name": "core/html",
 	"title": "Custom HTML",
-	"category": "widgets",
+	"category": "text",
 	"description": "Add custom HTML code and preview it as you edit.",
-	"keywords": [ "embed" ],
+	"keywords": [ "embed", "code" ],
 	"textdomain": "default",
 	"attributes": {
 		"content": {


### PR DESCRIPTION
## What?

Closes #78044

Renames the "Code" block to "Preformatted Code" and moves the "Custom HTML" block from the Widgets category to the Text category to improve discoverability and reduce user confusion.

## Why?

The "Code" block (`core/code`) displays preformatted text — it does not render HTML. However, its name implies to developers and technically-minded users that it accepts executable code. Meanwhile, the "Custom HTML" block (`core/html`), which *does* render raw HTML, is filed under the Widgets category where users don't think to look.

This creates a discoverability failure on two fronts: the wrong block has an attractive name, and the right block is in an unintuitive location.

## How?

**Metadata-only changes — no logic changes:**

1. **`packages/block-library/src/code/block.json`** — Changed `title` from `"Code"` to `"Preformatted Code"`.
2. **`packages/block-library/src/code/index.js`** — Updated the experimental content field label from `"Code"` to `"Preformatted Code"` to match.
3. **`packages/block-library/src/html/block.json`** — Changed `category` from `"widgets"` to `"text"` and added `"code"` to the `keywords` array.

The internal block names (`core/code`, `core/html`) are unchanged, so existing saved content, transforms, and programmatic references are unaffected.

## Testing Instructions

1. Open a new post or page in the editor.
2. Open the block inserter (click the `+` button or press `/`).
3. Browse the **Text** category — verify you see both **"Preformatted Code"** and **"Custom HTML"** listed there.
4. Verify **"Custom HTML"** no longer appears under the **Widgets** category.
5. Search for "code" in the inserter — verify both **"Preformatted Code"** and **"Custom HTML"** appear in results.
6. Insert a **Preformatted Code** block — verify it functions normally (displays preformatted text, does not render HTML).
7. Insert a **Custom HTML** block — verify it functions normally (renders raw HTML on preview/frontend).
8. Open an existing post that contains a Code or Custom HTML block — verify it loads without errors and the blocks render correctly.

### Testing Instructions for Keyboard

1. Press `/` in an empty paragraph to open the inserter.
2. Type `code` and press `Enter`/arrow keys to navigate results — verify both "Preformatted Code" and "Custom HTML" are reachable and selectable.
3. Tab through the block inserter categories — verify "Preformatted Code" and "Custom HTML" are both under Text.

## Screenshots or screencast

<!-- Screenshots to be added after running wp-env -->

|Before|After|
|-|-|
|"Code" block under Text category, "Custom HTML" under Widgets|"Preformatted Code" under Text category, "Custom HTML" also under Text|

## Use of AI Tools

- This PR was authored with the assistance of Claude.

- All changes were manually reviewed and verified for correctness.