### PR TITLE
Image Block: Fix duplicate image and extra item announcements in Lightbox

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -377,7 +377,7 @@ function block_core_image_print_lightbox_overlay() {
 					<span class="wp-lightbox-navigation-icon" data-wp-bind--hidden="!state.hasNavigationIcon">{$prev_button_icon}</span>
 					<span class="wp-lightbox-navigation-text" data-wp-bind--hidden="!state.hasNavigationText">{$prev_button_text}</span>
 				</button>
-				<div class="lightbox-image-container">
+				<div class="lightbox-image-container" aria-hidden="true">
 					<figure data-wp-bind--class="state.selectedImage.figureClassNames" data-wp-bind--style="state.figureStyles">
 						<img data-wp-bind--alt="state.selectedImage.alt" data-wp-bind--class="state.selectedImage.imgClassNames" data-wp-bind--style="state.imgStyles" data-wp-bind--src="state.selectedImage.currentSrc">
 					</figure>
@@ -399,7 +399,7 @@ function block_core_image_print_lightbox_overlay() {
 					<span class="wp-lightbox-navigation-text" data-wp-bind--hidden="!state.hasNavigationText">{$next_button_text}</span>
 					<span class="wp-lightbox-navigation-icon" data-wp-bind--hidden="!state.hasNavigationIcon">{$next_button_icon}</span>
 				</button>
-				<div data-wp-text="state.ariaLabel" aria-live="polite" aria-atomic="true" class="screen-reader-text"></div>
+				<div data-wp-text="state.currentLiveText" aria-live="polite" aria-atomic="true" class="screen-reader-text"></div>
 				<div class="scrim" style="background-color: {$background_color}" aria-hidden="true"></div>
 		</div>
 HTML;

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -399,7 +399,7 @@ function block_core_image_print_lightbox_overlay() {
 					<span class="wp-lightbox-navigation-text" data-wp-bind--hidden="!state.hasNavigationText">{$next_button_text}</span>
 					<span class="wp-lightbox-navigation-icon" data-wp-bind--hidden="!state.hasNavigationIcon">{$next_button_icon}</span>
 				</button>
-				<div data-wp-text="state.currentLiveText" aria-live="polite" aria-atomic="true" class="screen-reader-text"></div>
+				<div data-wp-text="state.currentLiveText" data-wp-bind--hidden="!state.currentLiveText" aria-live="polite" aria-atomic="true" class="screen-reader-text"></div>
 				<div class="scrim" style="background-color: {$background_color}" aria-hidden="true"></div>
 		</div>
 HTML;

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -73,6 +73,7 @@ const { state, actions, callbacks } = store(
 			selectedGalleryId: null,
 			preloadTimers: new Map(),
 			preloadedImageIds: new Set(),
+			currentLiveText: '',
 			get galleryImages() {
 				if ( ! state.selectedGalleryId ) {
 					return [ state.selectedImageId ];
@@ -217,12 +218,17 @@ const { state, actions, callbacks } = store(
 				state.selectedGalleryId = galleryId || null;
 				state.overlayEnabled = true;
 
+				// Clears the live text so the aria-live region is empty
+				// on initial open and not counted as a dialog item.
+				state.currentLiveText = '';
+
 				// Computes the styles of the overlay for the animation.
 				callbacks.setOverlayStyles();
 			},
 			hideLightbox() {
 				if ( state.overlayEnabled ) {
 					state.overlayEnabled = false;
+					state.currentLiveText = '';
 
 					// Waits until the close animation has completed before allowing a
 					// user to scroll again. The duration of this animation is defined in
@@ -249,6 +255,7 @@ const { state, actions, callbacks } = store(
 					? state.selectedImageIndex - 1
 					: state.galleryImages.length - 1;
 				state.selectedImageId = state.galleryImages[ nextIndex ];
+				state.currentLiveText = state.ariaLabel;
 				callbacks.setOverlayStyles();
 			} ),
 			showNextImage: withSyncEvent( ( event ) => {
@@ -257,6 +264,7 @@ const { state, actions, callbacks } = store(
 					? state.selectedImageIndex + 1
 					: 0;
 				state.selectedImageId = state.galleryImages[ nextIndex ];
+				state.currentLiveText = state.ariaLabel;
 				callbacks.setOverlayStyles();
 			} ),
 			handleKeydown: withSyncEvent( ( event ) => {


### PR DESCRIPTION
## What?

Closes #55255 

This PR resolves an accessibility issue in the image lightbox (Expand on Click) where Safari + VoiceOver inaccurately announced multiple duplicate items upon opening the dialog. It reduces the initial item count announced by VoiceOver from 4 to 2 for single images, and ensures only essential navigation/content elements are counted.

## Why?

The root cause was two-fold:
1. **Duplicate Images:** The lightbox overlay rendered two identical `<img>` elements—one for the smooth zoom-in animation and one for the high resolution display. Both were exposed to the accessibility tree, causing VoiceOver to announce them as separate items and allowing users to navigate through redundant content.
2. **Redundant Live Region:** An `aria-live` region used for gallery announcements was initialized with the dialog's label on load. Even when visually hidden, VoiceOver counted this populated div as an additional item in the dialog.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. **Hidden Animation Container:** Added `aria-hidden="true"` to the first `lightbox-image-container`. This container exists solely for the visual transition and is now ignored by VoiceOver.

2. **Delayed Live Announcements:** 
    - Introduced a new `currentLiveText` state property that initializes as an empty string.
    - Updated the `aria-live` div in `index.php` to bind to this new property instead of `state.ariaLabel`.
    - Modified `showNextImage` and `showPreviousImage` actions in `view.js` to populate `currentLiveText` only during active navigation.
    - This ensures the live region is empty (and thus not counted as a dialog item) when the lightbox first opens, while preserving its functionality to announce new images during gallery navigation.

## Testing Instructions

1. Add an **Image block** to a post and enable "Expand on click" in the block settings.
2. Publish and view the post using **Safari with VoiceOver** enabled.
3. Click the image to open the lightbox. 
4. **Expected:** VoiceOver announces "web dialog with 2 items" (the Close button and the Image).

### Testing Instructions for Gallery
1. Create a **Gallery block** with at least 3 images and ensure "Expand on click" is enabled.
2. Open the lightbox for the first image in Safari/VoiceOver.
3. **Expected:** VoiceOver announces "web dialog with 4 items" (Close button, Previous arrow, Image and Next arrow).
4. Use the keyboard (Right Arrow) or click the "Next" button.
5. **Expected:** VoiceOver automatically announces the label of the new image (e.g., "Enlarged image 2 of 3: [alt text]").

## Screenshots or screencast

### Before Fix :

<img width="1434" alt="273849081-e69b6fff-24b9-4e75-818d-f0180e1dfc1f" src="https://github.com/WordPress/gutenberg/assets/5360536/ea95060b-49c2-4a24-866d-f263e115024e">

### After Fix :

https://github.com/user-attachments/assets/2f78e489-a19a-4bad-bbb5-9842182e9f73

## Use of AI Tools

AI assistance used to validate results and draft PR description