### PR TITLE
Fix flaky homepage-settings e2e test

### DIFF
--- a/test/e2e/specs/site-editor/homepage-settings.spec.js
+++ b/test/e2e/specs/site-editor/homepage-settings.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Homepage Settings via Editor', () => {
 			status: 'publish',
 		} );
 		await requestUtils.createPage( {
-			title: 'Sample page',
+			title: 'Posts page',
 			status: 'publish',
 		} );
 		await requestUtils.createPage( {
@@ -62,36 +62,37 @@ test.describe( 'Homepage Settings via Editor', () => {
 	test( 'should show correct homepage actions based on current homepage or posts page', async ( {
 		page,
 	} ) => {
-		const samplePage = page
-			.getByRole( 'gridcell' )
-			.getByLabel( 'Homepage' );
-		const samplePageRow = page
-			.getByRole( 'row' )
-			.filter( { has: samplePage } );
-		await samplePageRow.click();
-		await samplePageRow
+		const homePage = page.getByRole( 'gridcell' ).getByLabel( 'Homepage' );
+		const homePageRow = page.getByRole( 'row' ).filter( { has: homePage } );
+		await homePageRow.click();
+		await homePageRow
 			.getByRole( 'button', {
 				name: 'Actions',
 			} )
 			.click();
 		await page.getByRole( 'menuitem', { name: 'Set as homepage' } ).click();
 		await page.getByRole( 'button', { name: 'Set homepage' } ).click();
+		await expect( page.getByRole( 'dialog' ) ).toBeHidden();
+
+		await homePageRow.getByRole( 'button', { name: 'Actions' } ).click();
+		await expect( page.getByRole( 'menu' ) ).toBeVisible();
 		await expect(
 			page.getByRole( 'menuitem', { name: 'Set as homepage' } )
 		).toBeHidden();
 		await expect(
 			page.getByRole( 'menuitem', { name: 'Set as posts page' } )
 		).toBeHidden();
+		await page.keyboard.press( 'Escape' );
+		await expect( page.getByRole( 'menu' ) ).toBeHidden();
 
-		const samplePageTwo = page
+		const postsPage = page
 			.getByRole( 'gridcell' )
-			.getByLabel( 'Sample page' );
-		const samplePageTwoRow = page
+			.getByLabel( 'Posts page' );
+		const postsPageRow = page
 			.getByRole( 'row' )
-			.filter( { has: samplePageTwo } );
-		// eslint-disable-next-line playwright/no-force-option
-		await samplePageTwoRow.click( { force: true } );
-		await samplePageTwoRow
+			.filter( { has: postsPage } );
+		await postsPageRow.click();
+		await postsPageRow
 			.getByRole( 'button', {
 				name: 'Actions',
 			} )
@@ -100,11 +101,17 @@ test.describe( 'Homepage Settings via Editor', () => {
 			.getByRole( 'menuitem', { name: 'Set as posts page' } )
 			.click();
 		await page.getByRole( 'button', { name: 'Set posts page' } ).click();
+		await expect( page.getByRole( 'dialog' ) ).toBeHidden();
+
+		await postsPageRow.getByRole( 'button', { name: 'Actions' } ).click();
+		await expect( page.getByRole( 'menu' ) ).toBeVisible();
 		await expect(
 			page.getByRole( 'menuitem', { name: 'Set as homepage' } )
 		).toBeHidden();
 		await expect(
 			page.getByRole( 'menuitem', { name: 'Set as posts page' } )
 		).toBeHidden();
+		await page.keyboard.press( 'Escape' );
+		await expect( page.getByRole( 'menu' ) ).toBeHidden();
 	} );
 } );


### PR DESCRIPTION
Fixes #77385 where the test sometimes sees a duplicate "Sample page" row and fails. That's because "Sample page" is one of two default pages your WordPress install will create:

<img width="682" height="316" alt="Screenshot 2026-05-07 at 15 27 54" src="https://github.com/user-attachments/assets/825e036f-57b0-4a3b-9231-0df51b1196e4" />

and the test setup will create another one. I fixed this by giving the test pages more meaningful names: "Homepage" and "Posts page". This way it doesn't conflict with the default pages.

The test was failing when no previous test ran `deleteAllPages` for it, in the same shard.

The fix in #77893 calls `deleteAllPages` before the test. That's OK, but the usual convention is that the test _assumes_ at the start that the environment is clean, and takes the responsibility to clean up after.

I'm also fixing another important thing: as written, the test wasn't testing the tested behavior at all! It is supposed to check that after setting a page as a homepage, the menu items "Set as homepage" and "Set as posts page" are no longer present. But at the time of the check, the menu is not even displayed! I fixed the workflow to run through the UI correctly. Wait until a confirmation modal is closed, open and close the menu properly. You can check in the `test:e2e:debug` mode what it does now. This part of the fix wasn't done by the AI agent at all.