### PR TITLE
Add design system agent skills for common workflows

### DIFF
--- a/.agents/skills/design-system-code-review/SKILL.md
+++ b/.agents/skills/design-system-code-review/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: design-system-code-review
+description: >
+  Use when reviewing a @wordpress/ui component PR, a @wordpress/theme token addition, or any design system change — to check architecture (Pattern A/B), types, CSS layers, --wpds-* token usage, accessibility (forced-colors, prefers-reduced-motion, focus), tests, stories, and exports. Works on PRs in forks or upstream. Enhanced by design-system-mcp's get_component_details for comparing against established patterns.
+---
+
+# Reviewing Design System Contributions
+
+## Requirements
+
+Targets Gutenberg `trunk`. Works against any PR diff — no repo write/review permission is required to apply this checklist; it's also useful when reviewing forks or downstream contributions.
+
+## When to use
+
+Use this skill when:
+
+- reviewing a new component PR for `@wordpress/ui`
+- reviewing design token additions/changes in `@wordpress/theme`
+- checking accessibility, testing, or CSS compliance of design system code
+- providing structured feedback on design system architecture
+
+## Inputs required
+
+- The PR diff or files being reviewed.
+- Whether the WPDS MCP server is available (for comparing against existing patterns via `get_component_details`).
+
+## Procedure
+
+### 1) Identify what's being changed
+
+- New component → full checklist applies
+- Existing component modification → focus on changed areas
+- Token addition → focus on token naming and DTCG format
+- Bug fix → focus on regression testing
+
+### 2) Run the checklist
+
+Work through the full review checklist section by section: architecture, types, CSS, accessibility, testing, stories, exports.
+
+Read:
+- `references/review-checklist.md`
+
+### 3) Compare against existing patterns
+
+If MCP is available, use `get_component_details` to compare the PR against an established component (e.g., Button, Dialog) for consistency.
+
+Without MCP, browse `packages/ui/src/button/` or `packages/ui/src/dialog/` as reference implementations.
+
+### 4) Leave feedback
+
+- Be specific — reference the exact pattern or convention being violated.
+- Show the fix — include a corrected code snippet.
+- Distinguish blocking vs. non-blocking — prefix with "nit:" or "suggestion:" for non-blocking.
+- Link to precedent — point to an existing component that follows the pattern correctly.
+
+## Verification
+
+- All checklist items relevant to the PR have been addressed.
+- Blocking issues are clearly distinguished from suggestions.
+- Feedback includes corrected code snippets where applicable.
+
+## Failure modes / debugging
+
+- **Unsure if a pattern is correct**: compare against `packages/ui/src/button/` (Pattern B) or `packages/ui/src/stack/` (Pattern A) as canonical examples.
+- **Token name validity unclear**: check against `packages/theme/tokens/` source JSON files.
+- **CSS convention unclear**: reference the [Contribution skill's CSS reference](../design-system-contribution/references/css-and-tokens.md).
+
+## Escalation
+
+- For ambiguous architectural decisions, consult the [Contribution skill](../design-system-contribution/SKILL.md).
+- For Base UI integration questions, check [base-ui.com](https://base-ui.com/).
+- For design system direction, post in #design-system on WordPress Slack.

--- a/.agents/skills/design-system-code-review/references/review-checklist.md
+++ b/.agents/skills/design-system-code-review/references/review-checklist.md
@@ -1,0 +1,131 @@
+# Review Checklist
+
+## Component Architecture
+
+- [ ] Uses correct pattern: **Pattern A** (`useRender` + `mergeProps`) for custom components, **Pattern B** (wrapping Base UI with `_Component` alias) for Base UI wrappers
+- [ ] `forwardRef` imported from `@wordpress/element` (not `react`)
+- [ ] Named function inside `forwardRef` (not arrow function) for DevTools display
+- [ ] Props destructured with sensible defaults
+- [ ] `render` prop support: Pattern A via `useRender`, Pattern B via Base UI's built-in support
+
+## Types
+
+- [ ] Props interface extends `ComponentProps<E>` from `../utils/types`
+- [ ] Pattern B: wraps `ComponentProps< typeof _BaseComponent >`, not raw HTML types
+- [ ] Every prop has JSDoc comment with `@default` annotation
+- [ ] Variant props use string literal unions (not enums or booleans for multi-state)
+- [ ] `disabled` prop is `boolean` (not inherited from Base UI's conditional type)
+
+## CSS
+
+### Layers & Structure
+
+- [ ] All styles inside `@layer wp-ui-components { ... }` (or appropriate layer)
+- [ ] No styles outside a `@layer` declaration (except utility modules that are intentionally unlayered)
+
+### Design Tokens
+
+- [ ] All colors, spacing, typography, borders, shadows use `--wpds-*` tokens
+- [ ] No hardcoded pixel values, hex colors, or font stacks
+- [ ] No manual fallback values — build pipeline injects them automatically
+- [ ] No directly setting `--wpds-*` properties (Stylelint enforces this)
+- [ ] Token names are valid — check against `packages/theme/tokens/` source files
+
+### Variants
+
+- [ ] Variants use CSS Module class names: `.is-{value}` (e.g., `.is-solid`, `.is-brand`, `.is-compact`)
+- [ ] **Not** using `data-variant`, `data-size`, or similar data attributes for styling
+- [ ] Classes composed via `clsx()` in the component: `styles[ \`is-${ variant }\` ]`
+
+### State Management
+
+- [ ] Custom properties define values, CSS properties are the state machine
+- [ ] State-specific variables use separate properties: `--bg`, `--bg-hover` (not reassigning `--bg` in `:hover`)
+- [ ] Disabled state uses `[data-disabled]` selector (Base UI convention), not `:disabled` or `[aria-disabled]`
+- [ ] Hover styles guarded: `.button:not([data-disabled]):hover`
+
+### Utility Modules
+
+- [ ] Interactive components compose all three utility CSS modules:
+  - `global-css-defense.module.css` — defends against wp-admin global styles
+  - `resets.module.css` — `box-sizing: border-box` inheritance
+  - `focus.module.css` — focus ring variants
+- [ ] Overlay components (Dialog, AlertDialog, Drawer) compose `overlay-chrome.module.css` for shared layout
+
+### Accessibility in CSS
+
+- [ ] `forced-colors` media query for Windows High Contrast Mode support
+- [ ] `prefers-reduced-motion` guard on all transitions/animations
+- [ ] Focus styles visible and use the standard focus ring utilities
+
+## Accessibility
+
+- [ ] Semantic HTML elements used where appropriate (not `<div>` with `role="button"`)
+- [ ] Interactive elements are keyboard accessible
+- [ ] Overlay components have a Title sub-component (enforced by dev-mode validation)
+- [ ] Icon-only buttons have `aria-label`
+- [ ] Focus management correct for dialogs/popovers (auto-focus, return focus)
+
+## Testing
+
+- [ ] Tests import from `../index` (not internal files)
+- [ ] Role-based queries: `getByRole`, `getByLabelText` (not `getByTestId`, `getByClassName`)
+- [ ] User interaction via `userEvent.setup()` (not `fireEvent`)
+- [ ] Async behavior uses `waitFor` or `findBy*`
+- [ ] Ref forwarding tested with `createRef` from `@wordpress/element`
+- [ ] Disabled state tested (focusable but not clickable)
+- [ ] Key test areas covered:
+  - Renders correct element/role
+  - Props apply correctly (variants, sizes)
+  - Keyboard interaction works
+  - Disabled state behavior
+  - Ref forwarding
+
+## Stories
+
+- [ ] Imports from `@storybook/react-vite` (not `@storybook/react`)
+- [ ] Title format: `'Design System/Components/{Name}'`
+- [ ] Uses `StoryObj< typeof Component >` type
+- [ ] Variant stories spread `Default.args`
+- [ ] Compound components list `subcomponents` in meta
+- [ ] Interactive stories use render functions with `useState`
+
+## Exports
+
+- [ ] Component exported from `packages/ui/src/index.ts`
+- [ ] Compound components: namespace export (`export * as Dialog from './dialog'`) or Object.assign pattern
+- [ ] Private APIs properly gated with `unlock()` / `register()` from `@wordpress/private-apis`
+- [ ] Global exports test (`packages/ui/src/test/index.test.ts`) updated if adding new component
+
+## Design Tokens (for token PRs)
+
+- [ ] Source JSON in `packages/theme/tokens/` follows DTCG format
+- [ ] Token name follows convention: `--wpds-{category}-{target}-{variant}[-{state}]`
+- [ ] Tokens are semantic (describe purpose, not appearance)
+- [ ] State variants suffixed: `-hover`, `-active`, `-disabled`
+- [ ] TypeScript types exported from `@wordpress/theme` for props that accept token values
+
+## Review Comment Style
+
+When leaving feedback:
+
+- **Be specific**: reference the exact pattern or convention being violated
+- **Show the fix**: include a corrected code snippet, not just "this is wrong"
+- **Distinguish blocking vs. non-blocking**: prefix with "nit:" or "suggestion:" for non-blocking
+- **Link to precedent**: point to an existing component that follows the pattern correctly
+
+Example:
+```
+Variants should use CSS Module classes, not data attributes.
+
+See Button for the pattern:
+\`\`\`tsx
+className={ clsx( styles.button, styles[ \`is-${ variant }\` ] ) }
+\`\`\`
+
+In CSS:
+\`\`\`css
+.is-solid { /* ... */ }
+.is-outline { /* ... */ }
+\`\`\`
+```

--- a/.agents/skills/design-system-component-implementation/SKILL.md
+++ b/.agents/skills/design-system-component-implementation/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: design-system-component-implementation
+description: >
+  Use when building UI with @wordpress/ui, picking the right component pattern (Pattern A useRender vs. Pattern B Base UI wrapper), wiring --wpds-* design tokens, composing the required utility CSS modules (defense, resets, focus), or writing tests/stories for @wordpress/ui components. Works standalone; enhanced by design-system-mcp's get_components, get_component_details, and get_design_tokens tools when available.
+---
+
+# Implementing Components with @wordpress/ui
+
+## Requirements
+
+Targets Gutenberg `trunk`. Assumes TypeScript, React, and CSS Modules. The `design-system-mcp` server is optional but enhances research steps.
+
+## When to use
+
+Use this skill when:
+
+- building UI with `@wordpress/ui` components
+- learning the component API, design tokens, or CSS patterns
+- creating custom components that integrate with the design system
+- writing tests or stories for @wordpress/ui components
+
+## Inputs required
+
+- What UI you are building (component name, behavior, variants).
+- Where it will be used (Gutenberg core, external plugin, standalone app).
+- Whether the WPDS MCP server is available (for live component/token docs).
+
+## Procedure
+
+### 1) Research available components
+
+Check what already exists before building custom:
+
+- **With MCP**: Use `get_components` and `get_component_details` tools.
+- **Without MCP**: Browse `packages/ui/src/` for component directories.
+
+Read:
+- `references/patterns-and-types.md` (Available Components section)
+
+### 2) Choose a component pattern
+
+Two patterns exist:
+- **Pattern A** (`useRender` + `mergeProps`): for custom components not wrapping Base UI
+- **Pattern B** (wrapping `_Component`): for adding styling/defaults to a Base UI primitive
+
+Read:
+- `references/patterns-and-types.md` (Pattern A and Pattern B sections)
+
+### 3) Define types
+
+Prop types extend `ComponentProps<E>` from `utils/types.ts`. Use JSDoc with `@default` on every prop.
+
+Read:
+- `references/patterns-and-types.md` (Types section)
+
+### 4) Style with CSS and design tokens
+
+- All styles inside `@layer wp-ui-components { ... }`
+- Variants use `.is-{value}` CSS Module classes via `clsx` (not data attributes)
+- All values from `--wpds-*` tokens (never hardcode)
+- Compose three utility CSS modules for interactive components
+
+Read:
+- `references/css-and-tokens.md`
+
+### 5) Write tests and stories
+
+- Tests: `@testing-library/react`, role-based queries, `userEvent.setup()`
+- Stories: `@storybook/react-vite`, title `'Design System/Components/{Name}'`
+
+Read:
+- `references/testing-and-stories.md`
+
+### 6) Handle theming and customization
+
+External consumers customize via token stylesheets or CSS property overrides. `ThemeProvider` is a private API (internal to Gutenberg only).
+
+Read:
+- `references/patterns-and-types.md` (Theming section)
+
+## Verification
+
+- Component renders correctly with all variant combinations.
+- Keyboard navigation and focus management work.
+- `forced-colors` and `prefers-reduced-motion` handled in CSS.
+- Tests pass: `npm run test:unit -- packages/ui`
+- Stories render in Storybook: `npm run storybook`
+- No hardcoded values — all colors, spacing, typography use `--wpds-*` tokens.
+
+## Failure modes / debugging
+
+- **Styles not applying**: check CSS layer order — component styles must be in `@layer wp-ui-components`.
+- **Token not found**: verify token name against `packages/theme/tokens/` source files or `get_design_tokens` MCP tool.
+- **Focus ring missing**: ensure the component composes `focus.module.css` utility.
+- **wp-admin global styles bleeding in**: compose `global-css-defense.module.css`.
+- **Disabled button still clickable**: use `data-disabled` attribute (Base UI convention), not `:disabled`.
+
+## Escalation
+
+- If a needed token doesn't exist, propose it in `packages/theme/tokens/`.
+- If a Base UI primitive is missing behavior, check [base-ui.com](https://base-ui.com/) for alternatives or open an upstream issue.
+- For architectural questions, consult the [Contribution skill](../design-system-contribution/SKILL.md).

--- a/.agents/skills/design-system-component-implementation/references/css-and-tokens.md
+++ b/.agents/skills/design-system-component-implementation/references/css-and-tokens.md
@@ -1,0 +1,80 @@
+# CSS Conventions & Design Tokens
+
+## Design Tokens
+
+Tokens are CSS custom properties following: `--wpds-{category}-{target}-{variant}[-{state}]`
+
+| Category | Examples |
+|----------|---------|
+| `color` | `--wpds-color-bg-interactive-brand-strong`, `--wpds-color-fg-content-neutral` |
+| `dimension` | `--wpds-dimension-padding-md`, `--wpds-dimension-gap-sm` |
+| `typography` | `--wpds-typography-font-size-md`, `--wpds-typography-font-family-body` |
+| `border` | `--wpds-border-radius-sm`, `--wpds-border-width-focus` |
+| `elevation` | `--wpds-elevation-shadow-md` |
+
+Full reference: `packages/theme/docs/tokens.md`. Use `get_design_tokens` MCP tool if available.
+
+**Never hardcode values.** Never manually add fallbacks (the build pipeline does it). Never set `--wpds-*` properties directly (Stylelint enforces this).
+
+## Layer Architecture
+
+```css
+@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;
+```
+
+All component styles go inside `@layer wp-ui-components { ... }`.
+
+## Variant Styling: CSS classes, not data attributes
+
+Variants use CSS Module class composition via `clsx`:
+
+```css
+/* style.module.css */
+@layer wp-ui-components {
+  .button { /* base styles */ }
+  .is-solid { /* solid variant */ }
+  .is-outline { /* outline variant */ }
+  .is-brand { /* brand tone */ }
+  .is-neutral { /* neutral tone */ }
+  .is-compact { /* compact size */ }
+}
+```
+
+```tsx
+className={ clsx( styles.button, styles[ `is-${ variant }` ], styles[ `is-${ tone }` ] ) }
+```
+
+## State CSS Rule
+
+Custom properties define values. CSS properties are the state machine. Never reassign a custom property in `:hover`:
+
+```css
+/* ✅ Correct */
+.button {
+  --button-bg: var(--wpds-color-bg-interactive-brand-strong);
+  --button-bg-hover: var(--wpds-color-bg-interactive-brand-strong-hover);
+  background-color: var(--button-bg);
+}
+.button:not([data-disabled]):hover {
+  background-color: var(--button-bg-hover);
+}
+
+/* ❌ Wrong — don't reassign variables in state selectors */
+.button:hover {
+  --button-bg: var(--wpds-color-bg-interactive-brand-strong-hover);
+}
+```
+
+## Required Utility Modules
+
+Every interactive component should compose these three CSS utility modules:
+
+- `global-css-defense.module.css` — defends against wp-admin global styles (unlayered)
+- `resets.module.css` — `box-sizing: border-box` inheritance
+- `focus.module.css` — focus ring variants (e.g., `outset-ring--focus-visible`)
+
+## Accessibility in CSS
+
+- `forced-colors` media query for Windows High Contrast Mode
+- `prefers-reduced-motion` guard on all transitions/animations
+- Use `data-disabled` (not `:disabled` or `[aria-disabled]`) for disabled states with Base UI

--- a/.agents/skills/design-system-component-implementation/references/patterns-and-types.md
+++ b/.agents/skills/design-system-component-implementation/references/patterns-and-types.md
@@ -1,0 +1,139 @@
+# Component Patterns & Types
+
+## Discovering Available Components
+
+To enumerate the current set of components, in order of preference:
+
+1. The `get_components` MCP tool (if `design-system-mcp` is configured) — always reflects the latest published manifest.
+2. `ls packages/ui/src/` in the Gutenberg repo — the directory names are the component sources.
+3. The package README at `packages/ui/README.md`.
+
+Components are either **direct exports** (`Button`, `Stack`) or **namespace exports** (`Dialog.Root`, `Dialog.Trigger`, `Dialog.Popup`). Do not rely on a hardcoded list inside this skill — the set evolves.
+
+## Pattern A: Custom component with `useRender` + `mergeProps`
+
+For components not wrapping a Base UI primitive:
+
+```tsx
+import { useRender, mergeProps } from '@base-ui/react';
+import { forwardRef } from '@wordpress/element';
+import type { StackProps } from './types';
+import styles from './style.module.css';
+
+export const Stack = forwardRef< HTMLDivElement, StackProps >(
+  function Stack( { direction, gap, align, justify, wrap, render, ...props }, ref ) {
+    const style = {
+      gap: gap && gapTokens[ gap ],
+      alignItems: align,
+      justifyContent: justify,
+      flexDirection: direction,
+      flexWrap: wrap,
+    };
+    return useRender( {
+      render,
+      ref,
+      props: mergeProps< 'div' >( props, { style, className: styles.stack } ),
+    } );
+  }
+);
+```
+
+Key: `useRender` enables the consumer `render` prop. `mergeProps` merges internal + external props safely.
+
+## Pattern B: Wrapping a Base UI primitive
+
+For components that delegate behavior to Base UI:
+
+```tsx
+import { Button as _Button } from '@base-ui/react/button';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import type { ButtonProps } from './types';
+import styles from './style.module.css';
+import resetStyles from '../utils/css/resets.module.css';
+import focusStyles from '../utils/css/focus.module.css';
+import defenseStyles from '../utils/css/global-css-defense.module.css';
+
+export const Button = forwardRef< HTMLButtonElement, ButtonProps >(
+  function Button( { tone = 'brand', variant = 'solid', size = 'default', className, ...props }, ref ) {
+    return (
+      <_Button
+        ref={ ref }
+        className={ clsx(
+          defenseStyles.button,
+          resetStyles[ 'box-sizing' ],
+          focusStyles[ 'outset-ring--focus-except-active' ],
+          variant !== 'unstyled' && styles.button,
+          styles[ `is-${ tone }` ],
+          styles[ `is-${ variant }` ],
+          styles[ `is-${ size }` ],
+          className,
+        ) }
+        { ...props }
+      />
+    );
+  }
+);
+```
+
+Key: No `useRender` needed — Base UI handles the `render` prop internally via `...props`.
+
+## Compound Components
+
+Two patterns for multi-part components:
+
+```tsx
+// Object.assign — optional sub-components (e.g., Button.Icon)
+export const Button = Object.assign( ButtonButton, { Icon: ButtonIcon } );
+
+// Namespace export — required composition (e.g., Dialog.Root, Dialog.Trigger)
+export * as Dialog from './dialog';
+```
+
+## Custom render prop
+
+The `render` prop lets consumers control the rendered element:
+
+```tsx
+<Stack render={ <section /> } gap="md">Content</Stack>
+<Text render={ <label /> } variant="body-sm">Label</Text>
+```
+
+Both function and element forms are supported:
+- Element: `render={ <section className="custom" /> }`
+- Function: `render={ ( props ) => <section { ...props } /> }`
+
+## Types
+
+Prop types derive from Base UI or native HTML, extended with component-specific props:
+
+```tsx
+import { type ComponentProps } from '../utils/types';
+
+// For Pattern A (custom element):
+export interface StackProps extends ComponentProps< 'div' > {
+  gap?: GapSize;  // GapSize from @wordpress/theme
+  direction?: 'row' | 'column';
+}
+
+// For Pattern B (wrapping Base UI):
+type _ButtonProps = ComponentProps< typeof _Button >;
+export interface ButtonProps extends Omit< _ButtonProps, 'disabled' > {
+  variant?: 'solid' | 'outline' | 'minimal' | 'unstyled';
+  tone?: 'brand' | 'neutral';
+  size?: 'default' | 'compact' | 'small';
+  disabled?: boolean;
+}
+```
+
+`ComponentProps<E>` (from `utils/types.ts`) strips and re-declares `className`, `style`, `render`, and `children` with proper types. Use JSDoc with `@default` annotations on every prop.
+
+## Theming
+
+`ThemeProvider` is a **private API** — only accessible within Gutenberg via `unlock()`:
+
+```tsx
+const ThemeProvider = unlock( themePrivateApis ).ThemeProvider;
+```
+
+It accepts `color.primary`, `color.bg`, `cursor.control`, and `density` props. External consumers cannot use it directly — they customize by loading different token stylesheets or overriding CSS custom properties on a wrapper element.

--- a/.agents/skills/design-system-component-implementation/references/testing-and-stories.md
+++ b/.agents/skills/design-system-component-implementation/references/testing-and-stories.md
@@ -1,0 +1,57 @@
+# Testing & Storybook Conventions
+
+## Testing
+
+```tsx
+import { createRef } from '@wordpress/element';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button } from '../index';  // always import from index
+
+describe( 'Button', () => {
+  it( 'renders a button element', () => {
+    render( <Button>Click me</Button> );
+    expect( screen.getByRole( 'button', { name: 'Click me' } ) ).toBeVisible();
+  } );
+
+  it( 'is focusable when disabled', async () => {
+    const user = userEvent.setup();
+    render( <Button disabled>Click me</Button> );
+    await user.keyboard( '{Tab}' );
+    expect( screen.getByRole( 'button' ) ).toHaveFocus();
+  } );
+} );
+```
+
+### Conventions
+
+- Role-based queries (`getByRole`), not text/class queries
+- `userEvent.setup()` for interaction testing
+- `waitFor` for async appearance (dialogs, popovers)
+- `createRef` from `@wordpress/element` for ref tests
+- Import from `../index`, not internal files
+
+## Stories
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from '../index';
+
+const meta: Meta< typeof Button > = {
+  title: 'Design System/Components/Button',
+  component: Button,
+};
+export default meta;
+type Story = StoryObj< typeof Button >;
+
+export const Default: Story = { args: { children: 'Button' } };
+export const Outline: Story = { args: { ...Default.args, variant: 'outline' } };
+```
+
+### Conventions
+
+- Import from `@storybook/react-vite` (not `@storybook/react`)
+- Title: `'Design System/Components/{Name}'`
+- Spread `Default.args` for variant stories
+- Complex stories use render functions with `useState`
+- Compound components list `subcomponents` in meta

--- a/.agents/skills/design-system-contribution/SKILL.md
+++ b/.agents/skills/design-system-contribution/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: design-system-contribution
+description: >
+  Use when proposing or implementing a new component in @wordpress/ui, modifying existing components with breaking changes, proposing new design tokens in @wordpress/theme, or making architectural decisions about the design system. Covers file structure, Pattern A/B selection, Base UI integration, CSS layer/token rules, and testing standards. Works standalone; enhanced by design-system-mcp for context gathering.
+---
+
+# Contributing to the WordPress Design System
+
+## Requirements
+
+Targets Gutenberg `trunk`. Assumes TypeScript, React, and CSS Modules. Intended for contributors opening PRs against the Gutenberg repo (a fork is fine — no special permissions are required to author the work).
+
+## When to use
+
+Use this skill when:
+
+- proposing or implementing a new component in `@wordpress/ui`
+- modifying existing components with breaking changes
+- proposing new design tokens in `@wordpress/theme`
+- making architectural decisions about the design system
+
+**Audience:** Gutenberg contributors with write access.
+
+## Inputs required
+
+- What component or token is being added/changed.
+- Whether a Base UI primitive exists for the behavior (check [base-ui.com](https://base-ui.com/)).
+- Whether a GitHub issue or Slack discussion has been started.
+
+## Procedure
+
+### 1) Check if it already exists
+
+- Browse `packages/ui/src/` or use `get_components` MCP tool.
+- Check if Base UI has a primitive you can wrap.
+- Check if composition of existing components works.
+- If proposing something new, discuss in #design-system Slack or open a GitHub issue.
+
+### 2) Set up the file structure
+
+Create the component directory following the standard layout.
+
+Read:
+- `references/file-structure-and-patterns.md` (Directory Layout section)
+
+### 3) Implement the component
+
+Choose the correct pattern:
+- **Pattern A** (`useRender` + `mergeProps`): custom component not wrapping Base UI
+- **Pattern B** (wrapping `_Component`): adding styling/defaults to a Base UI primitive
+
+Always alias Base UI imports with underscore prefix (`_Button`, `_Dialog`).
+
+Read:
+- `references/file-structure-and-patterns.md` (Pattern A, Pattern B, Exports, Types sections)
+
+### 4) Write CSS styles
+
+- All styles inside `@layer wp-ui-components { ... }`
+- Variants: `.is-{value}` CSS Module classes via `clsx` (not data attributes)
+- All values from `--wpds-*` tokens
+- Compose three utility CSS modules for interactive components
+- Handle `forced-colors` and `prefers-reduced-motion`
+
+Read:
+- `references/css-and-tokens.md`
+
+### 5) Write tests and stories
+
+Read:
+- `references/testing-and-stories.md`
+
+### 6) Export the component
+
+Add the component export to `packages/ui/src/index.ts`. Compound components use namespace exports or Object.assign.
+
+Read:
+- `references/file-structure-and-patterns.md` (Exports section)
+
+## Verification
+
+- [ ] Component follows Pattern A or B correctly
+- [ ] Types extend `ComponentProps<E>` with JSDoc on every prop
+- [ ] CSS uses `@layer wp-ui-components`, design tokens, no hardcoded values
+- [ ] Utility CSS modules composed (defense, resets, focus)
+- [ ] `forced-colors` and `prefers-reduced-motion` handled in CSS
+- [ ] Tests use role-based queries and `userEvent.setup()`
+- [ ] Stories follow `Design System/Components/{Name}` title format
+- [ ] Component exported from `packages/ui/src/index.ts`
+- [ ] Global exports test passes (`packages/ui/src/test/index.test.ts`)
+- [ ] `npm run test:unit -- packages/ui` passes
+- [ ] `npm run lint:js` and Stylelint pass
+
+## Failure modes / debugging
+
+- **Styles not applying**: check CSS layer order and that styles are inside `@layer wp-ui-components`.
+- **wp-admin styles bleeding in**: ensure `global-css-defense.module.css` is composed.
+- **Token not found by Stylelint**: verify token name against `packages/theme/tokens/` source JSON.
+- **Global exports test failing**: add the new component to `packages/ui/src/index.ts`.
+- **Focus ring missing**: compose `focus.module.css` utility and check the correct focus ring variant.
+
+## Escalation
+
+- For Base UI gaps, check [base-ui.com](https://base-ui.com/) or open an upstream issue.
+- For token naming conventions, consult `packages/theme/docs/tokens.md`.
+- For architectural questions, post in #design-system on WordPress Slack.

--- a/.agents/skills/design-system-contribution/references/css-and-tokens.md
+++ b/.agents/skills/design-system-contribution/references/css-and-tokens.md
@@ -1,0 +1,111 @@
+# CSS Conventions & Tokens
+
+## CSS Layers
+
+```css
+@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;
+
+@layer wp-ui-components {
+  .button { /* ... */ }
+  .is-solid { /* ... */ }
+  .is-brand { /* ... */ }
+}
+```
+
+## Variant Classes
+
+Use `is-{value}` CSS Module classes, applied via `clsx`:
+
+```css
+.is-solid { --button-bg: var(--wpds-color-bg-interactive-brand-strong); }
+.is-outline { --button-bg: transparent; }
+```
+
+## State Rule
+
+Custom properties define values. CSS properties are the state machine:
+
+```css
+/* ✅ Correct: separate variables for each state */
+.button {
+  --bg: var(--wpds-color-bg-interactive-brand-strong);
+  --bg-hover: var(--wpds-color-bg-interactive-brand-strong-hover);
+  background-color: var(--bg);
+}
+.button:not([data-disabled]):hover {
+  background-color: var(--bg-hover);
+}
+
+/* ❌ Wrong: reassigning variable in state selector */
+.button:hover { --bg: var(--wpds-color-bg-interactive-brand-strong-hover); }
+```
+
+## Required Utility CSS
+
+Every interactive component must compose:
+
+```tsx
+import resetStyles from '../utils/css/resets.module.css';
+import focusStyles from '../utils/css/focus.module.css';
+import defenseStyles from '../utils/css/global-css-defense.module.css';
+
+className={ clsx(
+  defenseStyles.button,     // wp-admin global CSS defense
+  resetStyles[ 'box-sizing' ],  // box-sizing inheritance
+  focusStyles[ 'outset-ring--focus-visible' ],  // focus ring
+  styles.button,
+) }
+```
+
+## Accessibility in CSS
+
+- `forced-colors` media query for Windows High Contrast Mode
+- `prefers-reduced-motion` guard on all transitions/animations
+- `data-disabled` attribute (not `:disabled` or `[aria-disabled]`) for disabled states with Base UI
+
+## CSS Composition for Shared Patterns
+
+```css
+.header { composes: header from "../utils/css/overlay-chrome.module.css"; }
+```
+
+Dialog, AlertDialog, and Drawer share `overlay-chrome.module.css` for header/content/footer layout.
+
+## Design Tokens
+
+Source: `packages/theme/tokens/*.json` (DTCG format)
+
+Build pipeline: Terrazzo → `packages/theme/src/prebuilt/` → CSS custom properties + TypeScript types + fallback maps
+
+Token types exported from `@wordpress/theme` (type-only): `GapSize`, `PaddingSize`, `BorderRadiusSize`, etc.
+
+Fallbacks are injected automatically by PostCSS (for CSS) and esbuild (for JS) plugins. Brand colors fall back to `--wp-admin-theme-color`:
+```
+var(--wpds-color-bg-interactive-brand-strong)
+→ var(--wpds-color-bg-interactive-brand-strong, var(--wp-admin-theme-color, #3858e9))
+```
+
+Stylelint enforces: no unknown `--wpds-*` tokens, no manual fallbacks, no manually setting `--wpds-*` properties.
+
+## ThemeProvider
+
+`ThemeProvider` is a **private API** — only accessible within Gutenberg:
+
+```tsx
+import { unlock } from '@wordpress/private-apis';
+const ThemeProvider = unlock( themePrivateApis ).ThemeProvider;
+```
+
+It accepts `color.primary`, `color.bg`, `cursor.control`, and `density` props. External consumers cannot use it — they customize via token stylesheets or CSS property overrides.
+
+## Shared Utilities (`packages/ui/src/utils/`)
+
+- `types.ts` — `ComponentProps<E>` base type for all components
+- `css/focus.module.css` — Focus ring variants (`outset-ring--focus-visible`, etc.)
+- `css/resets.module.css` — Box-sizing reset
+- `css/global-css-defense.module.css` — Defense against wp-admin global styles (unlayered)
+- `css/overlay-chrome.module.css` — Shared header/content/footer layout for Dialog/AlertDialog/Drawer
+- `createOverlayModalContext` — Factory for modal context providers
+- `createOverlayTitleValidation` — Dev-only validation that overlays have a Title
+- `useDeprioritizedInitialFocus` — Focus management for overlays
+- `useOverlayScrollStateAttributes` — Scroll position tracking with data attributes

--- a/.agents/skills/design-system-contribution/references/file-structure-and-patterns.md
+++ b/.agents/skills/design-system-contribution/references/file-structure-and-patterns.md
@@ -1,0 +1,130 @@
+# File Structure & Patterns
+
+## Directory Layout
+
+```
+packages/ui/src/{component-name}/
+├── index.ts              # Public exports
+├── {component-name}.tsx  # Main component (or sub-components for compound)
+├── types.ts              # Prop type definitions
+├── style.module.css      # CSS Module styles
+├── stories/
+│   └── index.story.tsx   # Storybook stories
+└── test/
+    └── {component-name}.test.tsx
+```
+
+For compound components (Dialog, Tabs, etc.), each sub-component gets its own file:
+
+```
+packages/ui/src/dialog/
+├── index.ts          # Named exports: Root, Trigger, Popup, Header, Content, Footer, Title, etc.
+├── root.tsx
+├── trigger.tsx
+├── popup.tsx
+├── content.tsx
+├── header.tsx
+├── footer.tsx
+├── title.tsx
+├── action.tsx
+├── close-icon.tsx
+├── types.ts
+├── style.module.css
+├── stories/
+└── test/
+```
+
+## Pattern A: Custom component (`useRender` + `mergeProps`)
+
+Use when building a component that doesn't wrap a Base UI primitive:
+
+```tsx
+import { useRender, mergeProps } from '@base-ui/react';
+import { forwardRef } from '@wordpress/element';
+import type { MyComponentProps } from './types';
+import styles from './style.module.css';
+
+export const MyComponent = forwardRef< HTMLDivElement, MyComponentProps >(
+  function MyComponent( { render, className, ...props }, ref ) {
+    return useRender( {
+      render,
+      ref,
+      props: mergeProps< 'div' >( props, {
+        className: clsx( styles.root, className ),
+      } ),
+    } );
+  }
+);
+```
+
+Used by: `Stack`, `Text`, `Dialog.Content`, `Dialog.Header`, `Dialog.Footer`
+
+## Pattern B: Wrapping Base UI (`_Component`)
+
+Use when wrapping a Base UI primitive to add styling and defaults:
+
+```tsx
+import { Button as _Button } from '@base-ui/react/button';
+import { forwardRef } from '@wordpress/element';
+import type { ButtonProps } from './types';
+import styles from './style.module.css';
+
+export const Button = forwardRef< HTMLButtonElement, ButtonProps >(
+  function Button( { variant = 'solid', tone = 'brand', className, ...props }, ref ) {
+    return (
+      <_Button
+        ref={ ref }
+        className={ clsx(
+          styles.button,
+          styles[ `is-${ variant }` ],
+          styles[ `is-${ tone }` ],
+          className,
+        ) }
+        { ...props }
+      />
+    );
+  }
+);
+```
+
+Used by: `Button`, `Dialog.Root`, `Dialog.Trigger`, `Dialog.Popup`, `Tooltip.*`
+
+Note: always alias Base UI imports with underscore prefix (`_Button`, `_Dialog`).
+
+## Exports
+
+Two compound component patterns:
+
+```tsx
+// Object.assign — for optional sub-components
+import { Button as ButtonButton } from './button';
+import { ButtonIcon } from './icon';
+export const Button = Object.assign( ButtonButton, { Icon: ButtonIcon } );
+
+// Namespace export — for required composition
+// In packages/ui/src/index.ts:
+export * as Dialog from './dialog';  // → Dialog.Root, Dialog.Trigger, etc.
+```
+
+Then in `packages/ui/src/index.ts`, add your component export.
+
+## Types
+
+```tsx
+import { type ComponentProps } from '../utils/types';
+
+// Pattern A (custom element):
+export interface MyComponentProps extends ComponentProps< 'div' > {
+  gap?: GapSize;
+}
+
+// Pattern B (wrapping Base UI):
+import { type Button as _Button } from '@base-ui/react/button';
+type _ButtonProps = ComponentProps< typeof _Button >;
+export interface ButtonProps extends Omit< _ButtonProps, 'disabled' > {
+  variant?: 'solid' | 'outline' | 'minimal' | 'unstyled';
+  disabled?: boolean;
+}
+```
+
+`ComponentProps<E>` (from `utils/types.ts`) strips and re-declares `className`, `style`, `render`, `children`. Add JSDoc with `@default` on every prop.

--- a/.agents/skills/design-system-contribution/references/testing-and-stories.md
+++ b/.agents/skills/design-system-contribution/references/testing-and-stories.md
@@ -1,0 +1,60 @@
+# Testing & Storybook Conventions
+
+## Testing
+
+```tsx
+import { createRef } from '@wordpress/element';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button } from '../index';  // always import from index
+
+describe( 'Button', () => {
+  it( 'renders a button element', () => {
+    render( <Button>Click me</Button> );
+    expect( screen.getByRole( 'button', { name: 'Click me' } ) ).toBeVisible();
+  } );
+
+  it( 'is focusable when disabled', async () => {
+    const user = userEvent.setup();
+    render( <Button disabled>Click me</Button> );
+    await user.keyboard( '{Tab}' );
+    expect( screen.getByRole( 'button' ) ).toHaveFocus();
+  } );
+} );
+```
+
+### Conventions
+
+- Role-based queries (`getByRole`), not text/class queries
+- `userEvent.setup()` for interaction testing
+- `waitFor` for async appearance (dialogs, popovers)
+- `createRef` from `@wordpress/element` for ref tests
+- Import from `../index`, not internal files
+- Dev-mode validation tests catch thrown errors via `window.addEventListener('error')`
+
+There's also a global exports test (`packages/ui/src/test/index.test.ts`) that ensures every component directory is exported from the main `index.ts`.
+
+## Stories
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from '../index';
+
+const meta: Meta< typeof Button > = {
+  title: 'Design System/Components/Button',
+  component: Button,
+};
+export default meta;
+type Story = StoryObj< typeof Button >;
+
+export const Default: Story = { args: { children: 'Button' } };
+export const Outline: Story = { args: { ...Default.args, variant: 'outline' } };
+```
+
+### Conventions
+
+- Import from `@storybook/react-vite` (not `@storybook/react`)
+- Title: `'Design System/Components/{Name}'`
+- Spread `Default.args` for variant stories
+- Complex stories use render functions with `useState`
+- Compound components list `subcomponents` in meta

--- a/.agents/skills/design-system-figma-to-code/SKILL.md
+++ b/.agents/skills/design-system-figma-to-code/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: design-system-figma-to-code
+description: >
+  Use when translating a Figma/Sketch/XD design or screenshot into @wordpress/ui code: mapping design colors/spacing/typography to --wpds-* tokens, picking the right @wordpress/ui component for each element, and filling in missing states (focus, hover, disabled) and responsive behavior. Works standalone; enhanced by design-system-mcp's get_design_tokens and get_components tools.
+---
+
+# Adapting Designs to @wordpress/ui
+
+## Requirements
+
+Targets Gutenberg `trunk`. Assumes TypeScript, React, and CSS Modules. The `design-system-mcp` server is optional but useful for live token/component lookups.
+
+## When to use
+
+Use this skill when:
+
+- translating Figma/Sketch/XD designs into code
+- mapping design values (colors, spacing, typography) to `--wpds-*` tokens
+- identifying which @wordpress/ui components match a design element
+- handling design variants, states, and responsive behavior
+
+## Inputs required
+
+- The design mockup or spec (Figma link, screenshot, or description).
+- Target WordPress version and context (Gutenberg core, plugin, standalone).
+- Whether the WPDS MCP server is available.
+
+## Procedure
+
+### 1) Audit the design
+
+Before writing code, extract these from the design:
+
+- **Layout**: Grid vs. flex? Breakpoints? Alignment?
+- **Colors**: For each color, determine semantic purpose:
+  - Interactive element background → `--wpds-color-bg-interactive-*`
+  - Static content background → `--wpds-color-bg-content-*`
+  - Text/icon → `--wpds-color-fg-*`
+  - Border/divider → `--wpds-color-stroke-*`
+- **Spacing**: Gaps, padding, margins.
+- **Typography**: Font size, weight, line-height.
+- **States**: Default, hover, active, focus, disabled, loading. Add focus and disabled even if design omits them.
+- **Responsive**: What stacks, collapses, or hides at breakpoints?
+
+### 2) Map design values to tokens
+
+Translate every design value to a `--wpds-*` token. Never hardcode.
+
+Read:
+- `references/token-mapping.md`
+
+### 3) Select components
+
+Match design elements to existing @wordpress/ui components before building custom.
+
+Read:
+- `references/component-selection.md`
+
+### 4) Handle missing pieces
+
+- **Color not in tokens**: Propose a token addition to `packages/theme/tokens/color.json`.
+- **Component not in library**: Compose from existing components first. If insufficient, build custom following the [Component Implementation skill](../design-system-component-implementation/SKILL.md).
+- **State not in design**: Always implement focus (accessibility) and disabled states. Use `utils/css/focus.module.css`.
+- **Responsive not specified**: Use mobile-first CSS. `Stack` component's `direction` and `wrap` props help.
+
+### 5) Implement
+
+Follow the [Component Implementation skill](../design-system-component-implementation/SKILL.md) for patterns, CSS, and testing.
+
+## Verification
+
+- Every design value maps to a `--wpds-*` token (no hardcoded colors/spacing).
+- All interactive elements have hover, focus, and disabled states.
+- Component renders correctly at all breakpoints in the design.
+- Accessibility: contrast ratios ≥ 4.5:1 for text, keyboard navigation works.
+
+## Failure modes / debugging
+
+- **Design color not matching any token**: check if it's close to an existing token variant. If genuinely new, propose a token.
+- **Component looks wrong in wp-admin**: ensure `global-css-defense.module.css` is composed.
+- **Spacing inconsistent with design**: verify you're using the correct dimension token category (`padding` vs. `gap` vs. `spacing`).
+
+## Escalation
+
+- If the design is ambiguous, ask the designer:
+  - "What happens with long text — truncate, wrap, or overflow?"
+  - "What are the hover, focus, and disabled states?"
+  - "Is this color semantic (brand, danger, neutral) or decorative?"
+  - "Should this be a new component or a variant of an existing one?"
+- For token naming questions, consult `packages/theme/docs/tokens.md`.

--- a/.agents/skills/design-system-figma-to-code/references/component-selection.md
+++ b/.agents/skills/design-system-figma-to-code/references/component-selection.md
@@ -1,0 +1,40 @@
+# Component Selection
+
+Match design elements to @wordpress/ui components. Use `get_components` / `get_component_details` MCP tools if available.
+
+| Design element | Component | Notes |
+|---------------|-----------|-------|
+| Clickable button | `Button` | Props: `variant`, `tone`, `size` |
+| Icon-only button | `IconButton` | Requires `aria-label` |
+| Text content | `Text` | Props: `variant` for typography |
+| Vertical/horizontal layout | `Stack` | Props: `gap`, `direction`, `align` |
+| Modal/dialog | `Dialog.*` | Compound: `Root`, `Trigger`, `Popup`, `Header`, `Content`, `Footer` |
+| Confirmation dialog | `AlertDialog.*` | Same structure as Dialog |
+| Slide-out panel | `Drawer.*` | Same structure as Dialog |
+| Tooltip | `Tooltip.*` | Compound: `Root`, `Trigger`, `Popup`, `Portal` |
+| Popover | `Popover.*` | Compound: `Root`, `Trigger`, `Popup`, `Portal` |
+| Tab navigation | `Tabs.*` | Compound: `Root`, `List`, `Tab`, `Panel` |
+| Expandable section | `Collapsible.*` | Compound: `Root`, `Trigger`, `Panel` |
+| Card with collapse | `CollapsibleCard.*` | Built on Collapsible |
+| Status indicator | `Badge` | Props: `tone`, `variant` |
+| Empty state | `EmptyState` | |
+| Form feedback | `Notice` | |
+| Hidden label | `VisuallyHidden` | Screen-reader-only content |
+| Link | `Link` | Semantic `<a>` with design system styling |
+
+## Variant Mapping
+
+Design variants (size, style, state) map to component props and CSS classes.
+
+In @wordpress/ui, variants use **CSS Module class names** (not data attributes):
+
+```tsx
+// Button variants: variant='solid'|'outline'|'minimal', tone='brand'|'neutral', size='default'|'compact'|'small'
+<Button variant="outline" tone="neutral" size="compact">Secondary Action</Button>
+
+// Text variants map directly to typography roles:
+<Text variant="heading-xl">Page Title</Text>
+<Text variant="body-sm">Caption text</Text>
+```
+
+If no component matches, check if you can compose existing ones. If not, build a custom component following the [Component Implementation skill](../../design-system-component-implementation/SKILL.md).

--- a/.agents/skills/design-system-figma-to-code/references/token-mapping.md
+++ b/.agents/skills/design-system-figma-to-code/references/token-mapping.md
@@ -1,0 +1,51 @@
+# Token Mapping
+
+Use `get_design_tokens` MCP tool if available. Otherwise reference `packages/theme/docs/tokens.md`.
+
+## Colors
+
+Token pattern: `--wpds-color-{bg|fg|stroke}-{target}-{variant}[-{state}]`
+
+| Design intent | Token pattern | Example |
+|--------------|---------------|---------|
+| Primary button background | `bg-interactive-brand-strong` | `--wpds-color-bg-interactive-brand-strong` |
+| Primary button text | `fg-interactive-brand-strong` | `--wpds-color-fg-interactive-brand-strong` |
+| Page background | `bg-content-neutral` | `--wpds-color-bg-content-neutral` |
+| Body text | `fg-content-neutral` | `--wpds-color-fg-content-neutral` |
+| Secondary/muted text | `fg-content-neutral-weak` | `--wpds-color-fg-content-neutral-weak` |
+| Border/divider | `stroke-content-neutral` | `--wpds-color-stroke-content-neutral` |
+| Focus ring | `stroke-focus-brand` | `--wpds-color-stroke-focus-brand` |
+| Error/danger | `*-danger-*` | `--wpds-color-bg-interactive-danger-strong` |
+| Hover state | append `-hover` | `--wpds-color-bg-interactive-brand-strong-hover` |
+
+If a design color doesn't map to an existing token, don't hardcode it. Propose a new token.
+
+## Spacing
+
+Token pattern: `--wpds-dimension-{padding|gap|spacing}-{size}`
+
+Sizes: `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`
+
+The `Stack` component accepts gap sizes directly: `<Stack gap="md">`.
+
+For custom layouts, use tokens in CSS:
+```css
+.container {
+  padding: var(--wpds-dimension-padding-lg);
+  gap: var(--wpds-dimension-gap-md);
+}
+```
+
+## Typography
+
+Token pattern: `--wpds-typography-{font-size|font-family|line-height}-{size}`
+
+The `Text` component accepts variant props: `<Text variant="heading-xl">`, `<Text variant="body-sm">`.
+
+## Borders & Elevation
+
+```
+--wpds-border-radius-{xs|sm|md|lg|xl|pill}
+--wpds-border-width-{1|2|focus}
+--wpds-elevation-shadow-{sm|md|lg}
+```


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #77209 

<!-- In a few words, what is the PR actually doing? -->
This PR adds a set of design system agent skills for common workflows in `.agents/skills/`, covering:
- component implementation
- adapting designs to code
- design system contribution workflows
- design system code review

Each skill is split into a `SKILL.md` entry point plus focused reference files, instead of a single monolithic skill.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Agents working with the WordPress Design System often lack the repo-specific context needed to complete common tasks reliably. This includes workflows like implementing components with `@wordpress/ui`, translating designs into code, contributing new components or tokens, and reviewing design system changes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR introduces four skills under `.agents/skills/`:

- `design-system-component-implementation`
- `design-system-figma-to-code`
- `design-system-contribution`
- `design-system-code-review`

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
GitHub Copilot was used to help research repository conventions, and refine the skill content, and review the resulting files for accuracy and consistency. All generated content was manually reviewed and edited before submission.