### PR TITLE
Editor: Paginate revisions slider by 100 per page (#77200)

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -2,10 +2,17 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { RangeControl, Spinner } from '@wordpress/components';
+import {
+	RangeControl,
+	Spinner,
+	Button,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { useMemo } from '@wordpress/element';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -14,64 +21,61 @@ import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 /**
- * Slider component for navigating revisions.
+ * Slider component for navigating revisions with pagination.
  *
  * @return {React.JSX.Element} The revisions slider component.
  */
 function RevisionsSlider() {
-	const { revisions, isLoading, currentRevisionId, revisionKey } = useSelect(
-		( select ) => {
-			const { getCurrentPostId, getCurrentPostType } =
-				select( editorStore );
-			const { getRevisions, isResolving, getEntityConfig } =
-				select( coreStore );
+	const {
+		revisions: rawRevisions,
+		perPage,
+		currentRevisionId,
+		revisionKey,
+		revisionPage,
+		totalRevisions,
+	} = useSelect( ( select ) => {
+		const {
+			getCurrentRevisionId,
+			getRevisionPage,
+			getPageRevisions,
+			getRevisionsPerPage,
+		} = unlock( select( editorStore ) );
 
-			const postId = getCurrentPostId();
-			const postType = getCurrentPostType();
+		const postType = select( editorStore ).getCurrentPostType();
+		if ( ! postType ) {
+			return {};
+		}
 
-			if ( ! postId || ! postType ) {
-				return {};
-			}
+		const entityConfig = select( coreStore ).getEntityConfig(
+			'postType',
+			postType
+		);
+		const _revisionKey = entityConfig?.revisionKey || 'id';
+		const _revisionPage = getRevisionPage();
 
-			const entityConfig = getEntityConfig( 'postType', postType );
-			const _revisionKey = entityConfig?.revisionKey || 'id';
-			const query = {
-				per_page: -1,
-				context: 'edit',
-				orderby: 'date',
-				order: 'asc',
-				_fields: [
-					...new Set( [
-						'id',
-						'date',
-						'modified',
-						'author',
-						'meta',
-						'title.raw',
-						'excerpt.raw',
-						'content.raw',
-						_revisionKey,
-					] ),
-				].join(),
-			};
-			return {
-				revisions: getRevisions( 'postType', postType, postId, query ),
-				isLoading: isResolving( 'getRevisions', [
-					'postType',
-					postType,
-					postId,
-					query,
-				] ),
-				currentRevisionId: unlock(
-					select( editorStore )
-				).getCurrentRevisionId(),
-				revisionKey: _revisionKey,
-			};
-		},
-		[]
+		return {
+			revisions: getPageRevisions( _revisionPage ),
+			perPage: getRevisionsPerPage(),
+			currentRevisionId: getCurrentRevisionId(),
+			revisionKey: _revisionKey,
+			revisionPage: _revisionPage,
+			totalRevisions:
+				select( editorStore ).getCurrentPostRevisionsCount(),
+		};
+	}, [] );
+
+	const { setCurrentRevisionId, setRevisionPage } = unlock(
+		useDispatch( editorStore )
 	);
 
-	const { setCurrentRevisionId } = unlock( useDispatch( editorStore ) );
+	const isLoading = ! rawRevisions;
+	const totalPages = Math.ceil( totalRevisions / perPage ) || 1;
+
+	// Reverse desc→asc so the slider reads oldest (left) → newest (right).
+	const revisions = useMemo(
+		() => rawRevisions && [ ...rawRevisions ].reverse(),
+		[ rawRevisions ]
+	);
 
 	const selectedIndex = revisions?.findIndex(
 		( r ) => r[ revisionKey ] === currentRevisionId
@@ -94,11 +98,13 @@ function RevisionsSlider() {
 		return dateI18n( dateSettings.formats.datetime, revision.date );
 	};
 
-	if ( isLoading ) {
+	const showPagination = totalPages > 1;
+
+	if ( isLoading && ! showPagination ) {
 		return <Spinner />;
 	}
 
-	if ( ! revisions?.length ) {
+	if ( ! isLoading && ! revisions?.length ) {
 		return (
 			<span className="editor-revisions-header__no-revisions">
 				{ __( 'No revisions found.' ) }
@@ -106,7 +112,7 @@ function RevisionsSlider() {
 		);
 	}
 
-	if ( revisions?.length === 1 ) {
+	if ( totalRevisions <= 1 ) {
 		return (
 			<span className="editor-revisions-header__no-revisions">
 				{ __( 'Only one revision found.' ) }
@@ -114,21 +120,78 @@ function RevisionsSlider() {
 		);
 	}
 
+	const getPageRangeLabel = ( page ) => {
+		const end = totalRevisions - ( page - 1 ) * perPage;
+		const start = Math.max( 1, end - perPage + 1 );
+		return sprintf(
+			/* translators: 1: first revision number, 2: last revision number */
+			__( 'Revisions %1$s–%2$s' ),
+			start,
+			end
+		);
+	};
+
+	const sliderOrSpinner =
+		isLoading || selectedIndex === -1 ? (
+			<Spinner />
+		) : (
+			<RangeControl
+				__next40pxDefaultSize
+				aria-valuetext={ renderTooltipContent( selectedIndex ) }
+				className="editor-revisions-header__slider"
+				hideLabelFromVision
+				label={ __( 'Revision' ) }
+				max={ revisions?.length - 1 }
+				min={ 0 }
+				marks
+				onChange={ handleSliderChange }
+				renderTooltipContent={ renderTooltipContent }
+				value={ selectedIndex }
+				withInputField={ false }
+			/>
+		);
+
+	if ( ! showPagination ) {
+		return sliderOrSpinner;
+	}
+
 	return (
-		<RangeControl
-			__next40pxDefaultSize
-			aria-valuetext={ renderTooltipContent( selectedIndex ) }
-			className="editor-revisions-header__slider"
-			hideLabelFromVision
-			label={ __( 'Revision' ) }
-			max={ revisions?.length - 1 }
-			min={ 0 }
-			marks
-			onChange={ handleSliderChange }
-			renderTooltipContent={ renderTooltipContent }
-			value={ selectedIndex }
-			withInputField={ false }
-		/>
+		<HStack spacing={ 2 } expanded wrap={ false }>
+			<Button
+				icon={ chevronLeft }
+				label={
+					revisionPage < totalPages
+						? getPageRangeLabel( revisionPage + 1 )
+						: __( 'No older revisions' )
+				}
+				onClick={ () => setRevisionPage( revisionPage + 1 ) }
+				disabled={ isLoading || revisionPage >= totalPages }
+				size="compact"
+				accessibleWhenDisabled
+			/>
+			<div
+				style={ {
+					flex: 1,
+					minWidth: 0,
+					display: 'flex',
+					justifyContent: 'center',
+				} }
+			>
+				{ sliderOrSpinner }
+			</div>
+			<Button
+				icon={ chevronRight }
+				label={
+					revisionPage > 1
+						? getPageRangeLabel( revisionPage - 1 )
+						: __( 'No newer revisions' )
+				}
+				onClick={ () => setRevisionPage( revisionPage - 1 ) }
+				disabled={ isLoading || revisionPage <= 1 }
+				size="compact"
+				accessibleWhenDisabled
+			/>
+		</HStack>
 	);
 }
 

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -16,6 +16,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
  * Internal dependencies
  */
 import isTemplateRevertable from './utils/is-template-revertable';
+import { buildRevisionsPageQuery } from './private-selectors';
 export * from '../dataviews/store/private-actions';
 
 /**
@@ -601,6 +602,39 @@ export function setCurrentRevisionId( revisionId ) {
 		revisionId,
 	};
 }
+
+/**
+ * Set the current revisions page number and select the newest
+ * revision on that page once it loads.
+ *
+ * @param {number} page The page number.
+ */
+export const setRevisionPage =
+	( page ) =>
+	async ( { dispatch, select, registry } ) => {
+		const postType = select.getCurrentPostType();
+		const postId = select.getCurrentPostId();
+		const entityConfig = registry
+			.select( coreStore )
+			.getEntityConfig( 'postType', postType );
+		const revisionKey = entityConfig?.revisionKey || 'id';
+
+		const revisions = await registry
+			.resolveSelect( coreStore )
+			.getRevisions(
+				'postType',
+				postType,
+				postId,
+				buildRevisionsPageQuery( revisionKey, page )
+			);
+
+		registry.batch( () => {
+			dispatch( { type: 'SET_REVISION_PAGE', page } );
+			if ( revisions?.length ) {
+				dispatch.setCurrentRevisionId( revisions[ 0 ][ revisionKey ] );
+			}
+		} );
+	};
 
 /**
  * Set whether the revision diff highlighting is shown.

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -21,7 +21,11 @@ import { store as preferencesStore } from '@wordpress/preferences';
 /**
  * Internal dependencies
  */
-import { getRenderingMode, getCurrentPost } from './selectors';
+import {
+	getRenderingMode,
+	getCurrentPost,
+	getCurrentPostRevisionsCount,
+} from './selectors';
 import {
 	getEntityActions as _getEntityActions,
 	getEntityFields as _getEntityFields,
@@ -347,6 +351,85 @@ export function getCanvasMinHeight( state ) {
 }
 
 /**
+ * Returns the current revisions page number.
+ *
+ * @param {Object} state Global application state.
+ * @return {number} The page number.
+ */
+export function getRevisionPage( state ) {
+	return state.revisionPage;
+}
+
+/**
+ * Builds the query object for fetching a page of revisions.
+ *
+ * @param {string} revisionKey The entity's revision key.
+ * @param {number} page        The 1-based page number (page 1 = newest).
+ * @return {Object} Query object for getRevisions.
+ */
+export function buildRevisionsPageQuery( revisionKey, page ) {
+	return {
+		per_page: REVISIONS_PER_PAGE,
+		page,
+		context: 'edit',
+		orderby: 'date',
+		order: 'desc',
+		_fields: [
+			...new Set( [
+				'id',
+				'date',
+				'modified',
+				'author',
+				'meta',
+				'title.raw',
+				'excerpt.raw',
+				'content.raw',
+				revisionKey,
+			] ),
+		].join(),
+	};
+}
+
+const REVISIONS_PER_PAGE = 100;
+
+export function getRevisionsPerPage() {
+	return REVISIONS_PER_PAGE;
+}
+
+/**
+ * Returns revisions for the given page number.
+ *
+ * @param {Object} state Global application state.
+ * @param {number} page  The 1-based page number (page 1 = newest).
+ * @return {Array|null} The revisions array, or null if not yet loaded.
+ */
+export const getPageRevisions = createRegistrySelector(
+	( select ) => ( state, page ) => {
+		if ( ! page ) {
+			return null;
+		}
+
+		const { type: postType, id: postId } = getCurrentPost( state );
+		if ( ! postType || ! postId ) {
+			return null;
+		}
+
+		const entityConfig = select( coreStore ).getEntityConfig(
+			'postType',
+			postType
+		);
+		const revisionKey = entityConfig?.revisionKey || 'id';
+
+		return select( coreStore ).getRevisions(
+			'postType',
+			postType,
+			postId,
+			buildRevisionsPageQuery( revisionKey, page )
+		);
+	}
+);
+
+/**
  * Returns whether the editor is in revisions preview mode.
  *
  * @param {Object} state Global application state.
@@ -389,40 +472,22 @@ export const getCurrentRevision = createRegistrySelector(
 			return undefined;
 		}
 
+		const page = getRevisionPage( state );
+		if ( ! page ) {
+			return null;
+		}
+
 		const { type: postType, id: postId } = getCurrentPost( state );
 		const entityConfig = select( coreStore ).getEntityConfig(
 			'postType',
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
-		// - Use getRevisions (plural) instead of getRevision (singular) to
-		//   avoid a race condition where both API calls complete around the
-		//   same time and the single revision fetch overwrites the list in the
-		//   store.
-		// - getRevision also needs to be updated to check if there's any
-		//   received revisions from the collection API call to avoid unnecessary
-		//   API calls.
 		const revisions = select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
-			{
-				per_page: -1,
-				context: 'edit',
-				_fields: [
-					...new Set( [
-						'id',
-						'date',
-						'modified',
-						'author',
-						'meta',
-						'title.raw',
-						'excerpt.raw',
-						'content.raw',
-						revisionKey,
-					] ),
-				].join(),
-			}
+			buildRevisionsPageQuery( revisionKey, page )
 		);
 		if ( ! revisions ) {
 			return null;
@@ -469,35 +534,23 @@ export const getPreviousRevision = createRegistrySelector(
 			return undefined;
 		}
 
+		const page = getRevisionPage( state );
+		if ( ! page ) {
+			return null;
+		}
+
 		const { type: postType, id: postId } = getCurrentPost( state );
 		const entityConfig = select( coreStore ).getEntityConfig(
 			'postType',
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
+		const query = buildRevisionsPageQuery( revisionKey, page );
 		const revisions = select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
-			{
-				per_page: -1,
-				context: 'edit',
-				orderby: 'date',
-				order: 'asc',
-				_fields: [
-					...new Set( [
-						'id',
-						'date',
-						'modified',
-						'author',
-						'meta',
-						'title.raw',
-						'excerpt.raw',
-						'content.raw',
-						revisionKey,
-					] ),
-				].join(),
-			}
+			query
 		);
 		if ( ! revisions ) {
 			return null;
@@ -509,8 +562,21 @@ export const getPreviousRevision = createRegistrySelector(
 		);
 
 		// Return the previous revision (older one) if it exists.
-		if ( currentIndex > 0 ) {
-			return revisions[ currentIndex - 1 ];
+		if ( currentIndex >= 0 && currentIndex < revisions.length - 1 ) {
+			return revisions[ currentIndex + 1 ];
+		}
+
+		// At page boundary: fetch the first revision from the next page.
+		const totalRevisions = getCurrentPostRevisionsCount( state );
+		const totalPages = Math.ceil( totalRevisions / query.per_page ) || 1;
+		if ( currentIndex === revisions.length - 1 && page < totalPages ) {
+			const nextPageRevisions = select( coreStore ).getRevisions(
+				'postType',
+				postType,
+				postId,
+				buildRevisionsPageQuery( revisionKey, page + 1 )
+			);
+			return nextPageRevisions?.[ 0 ] ?? null;
 		}
 
 		return null;

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -450,12 +450,25 @@ export function revisionId( state = null, action ) {
 }
 
 /**
- * Reducer returning the currently selected note and its options.
+ * Reducer for the current revisions page number.
  *
- * @param {Object} state  Current state.
+ * @param {number} state  Current page number.
  * @param {Object} action Dispatched action.
- * @return {Object} Updated state.
+ * @return {number} Updated state.
  */
+export function revisionPage( state = 1, action ) {
+	switch ( action.type ) {
+		case 'SET_REVISION_PAGE':
+			return action.page;
+		case 'SET_CURRENT_REVISION_ID':
+			if ( ! action.revisionId ) {
+				return 1;
+			}
+			return state;
+	}
+	return state;
+}
+
 /**
  * Reducer for whether the revision diff is shown.
  * Resets to true when entering/exiting revisions mode.
@@ -475,6 +488,13 @@ export function showRevisionDiff( state = true, action ) {
 	return state;
 }
 
+/**
+ * Reducer returning the currently selected note and its options.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ * @return {Object} Updated state.
+ */
 export function selectedNote( state = {}, action ) {
 	switch ( action.type ) {
 		case 'SELECT_NOTE':
@@ -506,6 +526,7 @@ export default combineReducers( {
 	showStylebook,
 	canvasMinHeight,
 	revisionId,
+	revisionPage,
 	showRevisionDiff,
 	selectedNote,
 	dataviews: dataviewsReducer,

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -261,6 +261,124 @@ test.describe( 'Post revisions', () => {
 	} );
 } );
 
+test.describe( 'Post revisions slider pagination', () => {
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test( 'should paginate, navigate pages, and diff across page boundaries', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		// Create a post and update it enough times to require pagination.
+		// Page 1 holds the newest 100 revisions, so > 100 total → 2 pages.
+		const post = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/posts',
+			data: {
+				title: 'Pagination Test',
+				content: '<!-- wp:paragraph --><p>0</p><!-- /wp:paragraph -->',
+				status: 'draft',
+			},
+		} );
+
+		// Sequential REST calls to enforce ordering (concurrent writes to
+		// the same post race and produce non-monotonic revision content).
+		for ( let i = 1; i <= 105; i++ ) {
+			await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/posts/${ post.id }`,
+				data: {
+					content: `<!-- wp:paragraph --><p>${ i }</p><!-- /wp:paragraph -->`,
+				},
+			} );
+		}
+
+		await admin.editPost( post.id );
+
+		const settingsSidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settingsSidebar.getByRole( 'tab', { name: 'Post' } ).click();
+
+		// The revisions button is labeled with the count. The editor count
+		// may differ from the REST version-history count by an autosave,
+		// so read it from the rendered button.
+		const revisionsButton = settingsSidebar
+			.getByRole( 'button' )
+			.filter( { hasText: /^\d+$/ } );
+		await expect( revisionsButton ).toBeVisible();
+		const totalRevisions = parseInt(
+			await revisionsButton.textContent(),
+			10
+		);
+		const olderPageSize = totalRevisions - 100;
+
+		await revisionsButton.click();
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeVisible();
+
+		// Page 1 holds the newest 100 revisions. The prev chevron points
+		// at page 2, which holds the remaining older revisions.
+		const prevPageButton = page.getByRole( 'button', {
+			name: `Revisions 1–${ olderPageSize }`,
+		} );
+		const nextPageButton = page.getByRole( 'button', {
+			name: 'No newer revisions',
+		} );
+		await expect( prevPageButton ).toBeEnabled();
+		await expect( nextPageButton ).toBeDisabled();
+
+		// Page 1 holds 100 revisions, so the slider's max is 99.
+		const slider = page.getByRole( 'slider', { name: 'Revision' } );
+		await expect( slider ).toHaveAttribute( 'max', '99' );
+
+		// Slide to the leftmost (oldest revision on page 1). Computing the
+		// previous-revision diff requires fetching the adjacent page.
+		await slider.focus();
+		await page.keyboard.press( 'Home' );
+
+		// Adjacent revision contents differ by exactly 1 (we created them
+		// as sequential integers), so the boundary diff must show N as
+		// added and N-1 as removed inside a modified paragraph.
+		const canvas = page
+			.locator( 'iframe[name="editor-canvas"]' )
+			.contentFrame()
+			.locator( '.is-revision-modified' );
+		await expect( canvas ).toBeVisible();
+		const added = parseInt(
+			await canvas.locator( '.revision-diff-added' ).textContent(),
+			10
+		);
+		const removed = parseInt(
+			await canvas.locator( '.revision-diff-removed' ).textContent(),
+			10
+		);
+		expect( added - removed ).toBe( 1 );
+
+		// Navigate to page 2 via the chevron.
+		await prevPageButton.click();
+
+		// After loading page 2: prev chevron disabled, next chevron enabled.
+		await expect(
+			page.getByRole( 'button', { name: 'No older revisions' } )
+		).toBeDisabled();
+		await expect(
+			page.getByRole( 'button', {
+				name: `Revisions ${ olderPageSize + 1 }–${ totalRevisions }`,
+			} )
+		).toBeEnabled();
+
+		// Slider now reflects page 2's smaller revision count.
+		await expect( slider ).toHaveAttribute(
+			'max',
+			String( olderPageSize - 1 )
+		);
+	} );
+} );
+
 test.describe( 'Template and template part revisions', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );


### PR DESCRIPTION
Backport of #77200 to the wp/7.0 branch.

## What?

Paginates the revisions slider to load 100 revisions per page instead of fetching all revisions at once.

## Why?

The revisions slider previously used \`per_page: -1\`, fetching every revision in a single API call. For posts with hundreds or thousands of revisions, this is a performance bottleneck — slow to load and memory-heavy on both client and server.

## Manual conflict resolution

This is a clean cherry-pick of #77200 with the following manual conflict resolutions, all caused by unrelated trunk drift (no real dependencies):

- \`private-selectors.js\` import: kept the wp/7.0 baseline import shape and added \`getCurrentPostRevisionsCount\` (trunk also has \`getEditorSettings\` from #77870, not present here).
- \`private-selectors.js\`: kept \`getCanvasMinHeight\` selector (removed on trunk by #77433) and inserted the new pagination selectors after it.
- \`reducer.js\`: kept \`canvasMinHeight\` reducer + restored the \`selectedNote\` JSDoc that was reordered on trunk by #77080.
- \`revisions-slider.js\`: switched \`Stack\` from \`@wordpress/ui\` to \`__experimentalHStack\` from \`@wordpress/components\` since \`@wordpress/ui\` is not a dependency of \`@wordpress/editor\` on wp/7.0.

## Testing Instructions

1. Create or use a post with more than 100 revisions.
2. Open the post in the editor and enter revisions mode.
3. Verify the slider loads quickly with the newest 100 revisions on page 1.
4. Hover the prev/next chevron buttons and verify tooltips show revision ranges.
5. Click the left chevron to load older revisions, verify the slider updates.
6. Slide between revisions and verify diff highlighting works at the page boundary.
7. Test with a post that has fewer than 100 revisions — no pagination buttons should appear.