### PR TITLE
Select: Support placeholder prop on Trigger

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Breaking Changes
 
 -   `InputControl`: Narrow the TypeScript type of the `label` prop to plain strings ([#77860](https://github.com/WordPress/gutenberg/pull/77860)).
+-   `Select`: `Select.Item` values that are empty strings no longer render with placeholder styling on the trigger. Use the new `placeholder` prop on `Select.Trigger`, or a `null` item value, instead ([#78076](https://github.com/WordPress/gutenberg/pull/78076)).
+-   `Select`: `Select.Trigger` now renders a default `"Select"` placeholder when no value is selected, where it previously rendered empty ([#78076](https://github.com/WordPress/gutenberg/pull/78076)).
 
 ### Bug Fixes
 
@@ -14,7 +16,7 @@
 
 ### Enhancements
 
--   `Select`: Add a `placeholder` prop to `Select.Trigger`, and support `null` item values for clearable placeholder options. A default placeholder is now applied when no initial value is specified ([#78076](https://github.com/WordPress/gutenberg/pull/78076)).
+-   `Select`: Add a `placeholder` prop to `Select.Trigger`, and support `null` item values for clearable placeholder options ([#78076](https://github.com/WordPress/gutenberg/pull/78076)).
 -   `Drawer`: Fade the popup elevation shadow alongside the slide ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).
 -   `Drawer`: Allow mouse-drag swipe-dismiss in the popup-edge padding gutter ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Enhancements
 
+-   `Select`: Add a `placeholder` prop to `Select.Trigger`, and support `null` item values for clearable placeholder options. A default placeholder is now applied when no initial value is specified ([#78076](https://github.com/WordPress/gutenberg/pull/78076)).
 -   `Drawer`: Fade the popup elevation shadow alongside the slide ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).
 -   `Drawer`: Allow mouse-drag swipe-dismiss in the popup-edge padding gutter ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).
 

--- a/packages/ui/src/form/primitives/select/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/select/stories/index.story.tsx
@@ -103,6 +103,40 @@ export const WithCustomPlaceholder: Story = {
 	},
 };
 
+const nullValueOptionItems = [
+	{ value: null, label: 'Select theme' },
+	{ value: 'system', label: 'System default' },
+	{ value: 'light', label: 'Light' },
+	{ value: 'dark', label: 'Dark' },
+];
+
+/**
+ * Use a `null` item when users should be able to clear the selected value from
+ * the popup. When `items` includes a `null` item, its label is used as the
+ * placeholder text.
+ */
+export const WithNullValueOption: Story = {
+	args: {
+		items: nullValueOptionItems,
+		children: (
+			<>
+				<Select.Trigger />
+				<Select.Popup>
+					{ nullValueOptionItems.map( ( item ) => (
+						<Select.Item
+							key={ item.value ?? 'null' }
+							value={ item.value }
+						>
+							{ item.label }
+						</Select.Item>
+					) ) }
+				</Select.Popup>
+			</>
+		),
+		// defaultValue: 'system',
+	},
+};
+
 /**
  * When accessibly labeling a `Select`, note that the label must be associated with the `Select.Trigger`,
  * not the `Select.Root`.

--- a/packages/ui/src/form/primitives/select/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/select/stories/index.story.tsx
@@ -80,46 +80,26 @@ export const Minimal: Story = {
 	},
 };
 
-const withEmptyOptionItems = [
-	{
-		value: '',
-		label: 'Select',
-		disabled: true,
-	},
-	{
-		value: 'Item 2',
-		label: 'Item 2',
-	},
-];
+const placeholderItems = [ 'Item 1', 'Item 2' ];
 
 /**
- * By passing an `items` array to `Select.Root`, the `Select.Trigger` will be able to
- * render a `label` string for each item rather than the raw `value` string. In this
- * case, the option with an empty string value has a `"Select"` label string.
- *
- * This may be easier than writing a custom render function for the `Select.Trigger`.
+ * Use the `placeholder` prop on `Select.Trigger` to show text when no
+ * value is selected. The default placeholder is `"Select"`.
  */
-export const WithEmptyValueOption: Story = {
+export const WithCustomPlaceholder: Story = {
 	args: {
-		items: withEmptyOptionItems,
 		children: (
 			<>
-				<Select.Trigger />
+				<Select.Trigger placeholder="Choose an item" />
 				<Select.Popup>
-					{ withEmptyOptionItems.map( ( item ) => (
-						<Select.Item
-							key={ item.value }
-							value={ item.value }
-							label={ item.label }
-							disabled={ item.disabled }
-						>
-							{ item.label }
+					{ placeholderItems.map( ( item ) => (
+						<Select.Item key={ item } value={ item }>
+							{ item }
 						</Select.Item>
 					) ) }
 				</Select.Popup>
 			</>
 		),
-		defaultValue: '',
 	},
 };
 

--- a/packages/ui/src/form/primitives/select/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/select/stories/index.story.tsx
@@ -133,7 +133,6 @@ export const WithNullValueOption: Story = {
 				</Select.Popup>
 			</>
 		),
-		// defaultValue: 'system',
 	},
 };
 

--- a/packages/ui/src/form/primitives/select/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/select/test/index.test.tsx
@@ -4,6 +4,56 @@ import { createRef } from '@wordpress/element';
 import * as Select from '../index';
 
 describe( 'Select', () => {
+	it( 'renders a default placeholder when no value is selected', () => {
+		render(
+			<Select.Root>
+				<Select.Trigger />
+				<Select.Popup>
+					<Select.Item value="Item 1" />
+				</Select.Popup>
+			</Select.Root>
+		);
+
+		const placeholder = screen.getByText( 'Select' );
+
+		expect( screen.getByRole( 'combobox' ) ).toHaveTextContent( 'Select' );
+		expect( placeholder ).toHaveAttribute( 'data-placeholder' );
+	} );
+
+	it( 'supports custom placeholder text', () => {
+		render(
+			<Select.Root>
+				<Select.Trigger placeholder="Choose an item" />
+				<Select.Popup>
+					<Select.Item value="Item 1" />
+				</Select.Popup>
+			</Select.Root>
+		);
+
+		const placeholder = screen.getByText( 'Choose an item' );
+
+		expect( screen.getByRole( 'combobox' ) ).toHaveTextContent(
+			'Choose an item'
+		);
+		expect( placeholder ).toHaveAttribute( 'data-placeholder' );
+	} );
+
+	it( 'does not use placeholder styling when a value is selected', () => {
+		render(
+			<Select.Root defaultValue="Item 1">
+				<Select.Trigger />
+				<Select.Popup>
+					<Select.Item value="Item 1" />
+				</Select.Popup>
+			</Select.Root>
+		);
+
+		const value = screen.getByText( 'Item 1' );
+
+		expect( screen.getByRole( 'combobox' ) ).toHaveTextContent( 'Item 1' );
+		expect( value ).not.toHaveAttribute( 'data-placeholder' );
+	} );
+
 	it( 'forwards ref', async () => {
 		const user = userEvent.setup();
 		const triggerRef = createRef< HTMLButtonElement >();

--- a/packages/ui/src/form/primitives/select/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/select/test/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';
 import * as Select from '../index';
@@ -48,10 +48,12 @@ describe( 'Select', () => {
 			</Select.Root>
 		);
 
-		const value = screen.getByText( 'Item 1' );
+		const trigger = screen.getByRole( 'combobox' );
 
-		expect( screen.getByRole( 'combobox' ) ).toHaveTextContent( 'Item 1' );
-		expect( value ).not.toHaveAttribute( 'data-placeholder' );
+		expect( trigger ).toHaveTextContent( 'Item 1' );
+		expect( within( trigger ).getByText( 'Item 1' ) ).not.toHaveAttribute(
+			'data-placeholder'
+		);
 	} );
 
 	it( 'forwards ref', async () => {

--- a/packages/ui/src/form/primitives/select/trigger.tsx
+++ b/packages/ui/src/form/primitives/select/trigger.tsx
@@ -2,6 +2,7 @@ import { Select as _Select } from '@base-ui/react/select';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { chevronDown } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 import focusStyles from '../../../utils/css/focus.module.css';
 import selectTriggerStyles from '../../../utils/css/select-trigger.module.css';
 import { InputLayout } from '../input-layout';
@@ -10,7 +11,14 @@ import type { SelectTriggerProps } from './types';
 
 export const Trigger = forwardRef< HTMLButtonElement, SelectTriggerProps >(
 	function Trigger(
-		{ className, size, variant, children, ...restProps },
+		{
+			className,
+			size,
+			variant,
+			children,
+			placeholder = __( 'Select' ),
+			...restProps
+		},
 		ref
 	) {
 		return (
@@ -36,13 +44,8 @@ export const Trigger = forwardRef< HTMLButtonElement, SelectTriggerProps >(
 					ref={ ref }
 				>
 					<_Select.Value
-						className={ ( state ) =>
-							clsx(
-								selectTriggerStyles[ 'trigger-value' ],
-								state.value === '' &&
-									selectTriggerStyles[ 'is-placeholder' ]
-							)
-						}
+						placeholder={ placeholder }
+						className={ selectTriggerStyles[ 'trigger-value' ] }
 					>
 						{ children }
 					</_Select.Value>

--- a/packages/ui/src/form/primitives/select/types.ts
+++ b/packages/ui/src/form/primitives/select/types.ts
@@ -26,6 +26,13 @@ export type SelectTriggerProps = ComponentProps< typeof _Select.Trigger > & {
 	 */
 	variant?: 'default' | 'minimal';
 	/**
+	 * Text to show when no value is selected.
+	 * This is overridden by `children` if specified, or by a null item's label in `items`.
+	 *
+	 * @default __( 'Select' )
+	 */
+	placeholder?: _Select.Value.Props[ 'placeholder' ];
+	/**
 	 * A function that gets called with the current value as an argument.
 	 * Use this to customize the trigger content.
 	 */

--- a/packages/ui/src/form/primitives/select/types.ts
+++ b/packages/ui/src/form/primitives/select/types.ts
@@ -60,7 +60,7 @@ export type SelectItemProps = Omit<
 	/**
 	 * A unique value that identifies this select item.
 	 */
-	value?: string;
+	value?: string | null;
 	/**
 	 * The size of the item.
 	 *

--- a/packages/ui/src/form/primitives/select/types.ts
+++ b/packages/ui/src/form/primitives/select/types.ts
@@ -35,6 +35,9 @@ export type SelectTriggerProps = ComponentProps< typeof _Select.Trigger > & {
 	/**
 	 * A function that gets called with the current value as an argument.
 	 * Use this to customize the trigger content.
+	 *
+	 * When no value is selected, the rendered content inherits the
+	 * placeholder text color.
 	 */
 	children?: _Select.Value.Props[ 'children' ];
 };

--- a/packages/ui/src/utils/css/select-trigger.module.css
+++ b/packages/ui/src/utils/css/select-trigger.module.css
@@ -48,7 +48,7 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 
-		&.is-placeholder {
+		&[data-placeholder] {
 			color: var(--wpds-color-fg-interactive-neutral-disabled);
 		}
 	}


### PR DESCRIPTION
## What?

Adds a `placeholder` prop to the `Select.Trigger` primitive, defaulting to `Select`, and aligns placeholder styling with Base UI's built-in placeholder state.

Also updates the Select stories to demonstrate a custom placeholder and a clearable `null` value option.

## Why?

Base UI now provides official placeholder handling for Select. Using that state directly keeps the wrapper behavior aligned with upstream and avoids relying on an empty-string item value as a placeholder convention.

## How?

- Passes `placeholder` from `Select.Trigger` to Base UI's `Select.Value`.
- Uses Base UI's `data-placeholder` attribute for placeholder styling.
- Allows `Select.Item` values to be `null`, matching Base UI's clearable item pattern.
- Adds focused unit coverage for default placeholder, custom placeholder, and selected-value states.

## Testing Instructions

3. Open Storybook and review `Design System/Components/Form/Primitives/Select`.
4. Confirm the custom placeholder story shows custom text before selection.
5. Confirm the null value option story can clear the selected value from the popup.

## Screenshots or screencast

<img width="562" height="67" alt="Select with placeholder" src="https://github.com/user-attachments/assets/c5ad281d-5386-49d4-be1b-beadc5202002" />
