### PR TITLE
Media Editor Modal: Add focus border styles to the stencil rect when the canvas is keyboard focused

### DIFF
--- a/packages/media-editor/src/image-editor/react/components/cropper.scss
+++ b/packages/media-editor/src/image-editor/react/components/cropper.scss
@@ -115,10 +115,10 @@ $handle-touch-target-size: 44px;
 	}
 
 	// Blue border on the crop rectangle when the canvas has keyboard focus.
-	// :focus-visible is suppressed after pointer interactions, so this only
-	// appears for keyboard navigation (Tab, Escape from a handle, or pressing
-	// a key while the canvas is mouse-focused).
-	&__canvas:focus-visible &__stencil-rect {
+	// Uses a JS-controlled class rather than :focus-visible — browsers can
+	// restore :focus-visible across programmatic focus calls, making pure
+	// CSS unreliable for pointer-to-keyboard transitions.
+	&__canvas--focus-visible &__stencil-rect {
 		border-color: var(--wp-image-editor-focus-color, var(--wp-admin-theme-color, #007cba));
 		box-shadow: 0 0 0 1px var(--wp-image-editor-focus-color, var(--wp-admin-theme-color, #007cba));
 	}

--- a/packages/media-editor/src/image-editor/react/components/cropper.scss
+++ b/packages/media-editor/src/image-editor/react/components/cropper.scss
@@ -21,6 +21,12 @@ $handle-touch-target-size: 44px;
 	&__canvas {
 		position: absolute;
 		inset: calc($handle-touch-target-size / 2);
+
+		// Suppress the browser's default focus ring — the crop rectangle
+		// border provides the custom keyboard-focus indicator instead.
+		&:focus {
+			outline: none;
+		}
 	}
 
 	// Inner stage — receives the viewport pan transform so the canvas div
@@ -105,6 +111,16 @@ $handle-touch-target-size: 44px;
 		border: 1px solid rgba(255, 255, 255, 0.7);
 		box-sizing: border-box;
 		pointer-events: none;
+		transition: border-color 0.15s ease, box-shadow 0.15s ease;
+	}
+
+	// Blue border on the crop rectangle when the canvas has keyboard focus.
+	// :focus-visible is suppressed after pointer interactions, so this only
+	// appears for keyboard navigation (Tab, Escape from a handle, or pressing
+	// a key while the canvas is mouse-focused).
+	&__canvas:focus-visible &__stencil-rect {
+		border-color: var(--wp-image-editor-focus-color, var(--wp-admin-theme-color, #007cba));
+		box-shadow: 0 0 0 1px var(--wp-image-editor-focus-color, var(--wp-admin-theme-color, #007cba));
 	}
 
 	&__handle {

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -188,6 +188,7 @@ function CropperInner(
 	const cropAreaDescriptionId = useId();
 	const [ isCropAreaFocused, setIsCropAreaFocused ] =
 		useState( focusOnMount );
+	const [ isFocusVisible, setIsFocusVisible ] = useState( false );
 	const [ canvasSize, setCanvasSize ] = useState< Size >( {
 		width: 0,
 		height: 0,
@@ -203,6 +204,16 @@ function CropperInner(
 		( event: React.FocusEvent< HTMLDivElement > ) => {
 			if ( event.target === event.currentTarget ) {
 				setIsCropAreaFocused( true );
+				// Show the outline only when focus arrived via keyboard
+				// navigation. relatedTarget is null for pointer-initiated and
+				// cross-window focus, so it reliably excludes those cases
+				// without needing a separate ref or flag.
+				if (
+					event.relatedTarget !== null &&
+					event.currentTarget.matches( ':focus-visible' )
+				) {
+					setIsFocusVisible( true );
+				}
 			}
 		},
 		[]
@@ -212,6 +223,7 @@ function CropperInner(
 		( event: React.FocusEvent< HTMLDivElement > ) => {
 			if ( event.target === event.currentTarget ) {
 				setIsCropAreaFocused( false );
+				setIsFocusVisible( false );
 			}
 		},
 		[]
@@ -336,6 +348,33 @@ function CropperInner(
 		onGestureEnd,
 	} );
 
+	// Compose focus-visibility tracking into the canvas event handlers.
+	// Kept as a spread rather than explicit props to avoid triggering
+	// jsx-a11y/no-noninteractive-element-interactions on role="group".
+	const canvasHandlers = {
+		...handlers,
+		onPointerDown: ( event: React.PointerEvent< HTMLDivElement > ) => {
+			handlers.onPointerDown?.( event );
+			// Called after handlers so it lands last in the React batch —
+			// el.focus() inside the handler fires onFocus, which may
+			// otherwise set isFocusVisible back to true.
+			setIsFocusVisible( false );
+		},
+		onKeyDown: ( event: React.KeyboardEvent< HTMLDivElement > ) => {
+			// Guard against keydowns bubbling up from child handles
+			// (e.g. Tab between handles, unhandled keys). Modifier-only
+			// keypresses are excluded — they precede another key rather
+			// than indicating deliberate keyboard interaction on their own.
+			if (
+				event.target === event.currentTarget &&
+				! [ 'Shift', 'Control', 'Alt', 'Meta' ].includes( event.key )
+			) {
+				setIsFocusVisible( true );
+			}
+			handlers.onKeyDown?.( event );
+		},
+	};
+
 	// Register wheel handler natively with { passive: false } so
 	// preventDefault works. React's onWheel registers as passive. Bound
 	// to the canvas (not the root) so pointer geometry inside the handler
@@ -451,6 +490,9 @@ function CropperInner(
 	 * arrow keys pan the image rather than resize.
 	 */
 	const handleEscape = useCallback( () => {
+		// Escape is always a keyboard action, so show the outline immediately
+		// rather than relying on the focus handler's :focus-visible check.
+		setIsFocusVisible( true );
 		canvasRef.current?.focus( { preventScroll: true } );
 	}, [] );
 
@@ -578,7 +620,13 @@ function CropperInner(
 						'wp-media-editor-image-editor__canvas--grid-interactive',
 					showInteractiveGrid &&
 						'wp-media-editor-image-editor__canvas--show-grid',
-					settling && 'wp-media-editor-image-editor__canvas--settling'
+					settling &&
+						'wp-media-editor-image-editor__canvas--settling',
+					// Show the keyboard focus outline only when the canvas
+					// itself (not a child handle) has keyboard focus.
+					isFocusVisible &&
+						isCropAreaFocused &&
+						'wp-media-editor-image-editor__canvas--focus-visible'
 				) }
 				tabIndex={ 0 }
 				role="group"
@@ -588,7 +636,7 @@ function CropperInner(
 				}
 				onFocus={ handleCropAreaFocus }
 				onBlur={ handleCropAreaBlur }
-				{ ...handlers }
+				{ ...canvasHandlers }
 			>
 				<div
 					id={ cropAreaDescriptionId }


### PR DESCRIPTION
## What?

Part of:

* https://github.com/WordPress/gutenberg/issues/73771

In the Media Editor Modal, add `focus-visible` styles to the stencil rect so that it's got a blue visual indicator that it's focused when interacting with it via the keyboard. It shouldn't be visible when the user hasn't explicitly focused the canvas or drag handles. I.e. if you're dragging the crop handles and crop area via a mouse, you typically shouldn't see these styles. But if you tab to the resize handles or the canvas, you should.

## Why?

When dragging the drag handles via keyboard, they have a focus style of a blue outline to make it clear where you are. If you press <kbd>Escape</kbd> from that point, focus is moved to the overall crop area so that you can move it around via keyboard, but there's no visual indicator that that's where the focus is.

This PR adds that visual indicator to try to make it clearer where the user is focused when tabbing between things. It hopefully shouldn't intrude on the UI when people are interacting via a mouse.

If it feels intrusive, happy to toss this PR out, but the goal is to make things feel clearer when interacting via keyboard.

## How?

* Add similar CSS rules to the ones we already use for the drag handles
* Applying both border-color (to override the border rules already on the stencil rect) and a box-shadow to make the focused style feel a little more weighty

## Testing Instructions

* Enable the Media Editor Modal experiment
* Add an image to a post or page and click the Crop icon in the block toolbar
* In the medial modal, drag the resize handles and move the crop area via mouse. You shouldn't see prominent blue focus outlines.
* However, if you tab to the drag handles, or press the cursor keys after click dragging the canvas, then the focused state should be visible.
* Try moving from a drag handle's focus to the crop area's focus (e.g. press Escape from a drag handle). How does that look and feel?

## Screenshots or screencast <!-- if applicable -->

Focused state:

<img width="1269" height="847" alt="image" src="https://github.com/user-attachments/assets/93cbfb2a-080e-4538-8568-3b9ef17a5397" />

https://github.com/user-attachments/assets/8b607347-ab4d-4846-a934-0b4ebcd44ab7

## Use of AI Tools

Claude Code