### PR TITLE
Revision: Fix failing e2e test

### DIFF
--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -270,6 +270,7 @@ test.describe( 'Post revisions slider pagination', () => {
 
 	test( 'should paginate, navigate pages, and diff across page boundaries', async ( {
 		admin,
+		editor,
 		page,
 		requestUtils,
 	} ) => {
@@ -299,6 +300,7 @@ test.describe( 'Post revisions slider pagination', () => {
 
 		await admin.editPost( post.id );
 
+		await editor.openDocumentSettingsSidebar();
 		const settingsSidebar = page.getByRole( 'region', {
 			name: 'Editor settings',
 		} );


### PR DESCRIPTION
## What?
This is a follow-up to #77200.

PR fixes failing revisions e2e test by ensuring the document settings sidebar is open before performing related actions.

See: https://github.com/WordPress/gutenberg/actions/runs/25515226783/job/74884451099

## Testing Instructions
CI checks are passing.