### PR TITLE
Try gating sync package and excluding it from the core artifact

### DIFF
--- a/packages/npm-package-json-lint-config/CHANGELOG.md
+++ b/packages/npm-package-json-lint-config/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Add package property ordering for WordPress Core build metadata.
+
 ## 5.40.0 (2026-02-18)
 
 ## 5.39.0 (2026-01-29)

--- a/packages/npm-package-json-lint-config/index.js
+++ b/packages/npm-package-json-lint-config/index.js
@@ -58,6 +58,8 @@ const defaultConfig = {
 				'module',
 				'exports',
 				'react-native',
+				'wpCore',
+				'wpCoreStub',
 				'wpScript',
 				'wpScriptModuleExports',
 				'types',

--- a/packages/sync/CHANGELOG.md
+++ b/packages/sync/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Exclude the package from WordPress Core build artifacts.
+
 ## 1.40.0 (2026-02-18)
 
 ## 1.39.0 (2026-01-29)

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -40,6 +40,8 @@
 		"./package.json": "./package.json"
 	},
 	"react-native": "src/index",
+	"wpCore": false,
+	"wpCoreStub": "src/core-stub.ts",
 	"wpScript": true,
 	"types": "build-types",
 	"sideEffects": false,

--- a/packages/sync/src/core-stub.ts
+++ b/packages/sync/src/core-stub.ts
@@ -1,0 +1,186 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+/**
+ * A minimal no-op replacement used when the real-time collaboration package is
+ * excluded from WordPress Core builds.
+ */
+
+class StubDoc {
+	getMap() {
+		return new StubMap();
+	}
+}
+
+class StubMap {
+	private values = new globalThis.Map< PropertyKey, unknown >();
+	public parent = null;
+
+	constructor( entries: Iterable< [ PropertyKey, unknown ] > = [] ) {
+		this.values = new globalThis.Map( entries );
+	}
+
+	get( key: PropertyKey ) {
+		return this.values.get( key );
+	}
+
+	set( key: PropertyKey, value: unknown ) {
+		this.values.set( key, value );
+	}
+
+	has( key: PropertyKey ) {
+		return this.values.has( key );
+	}
+
+	delete( key: PropertyKey ) {
+		return this.values.delete( key );
+	}
+
+	toJSON() {
+		return Object.fromEntries( this.values );
+	}
+}
+
+class StubArray {
+	private values: unknown[] = [];
+	public parent = null;
+
+	get length() {
+		return this.values.length;
+	}
+
+	get( index: number ) {
+		return this.values[ index ];
+	}
+
+	insert( index: number, values: unknown[] ) {
+		this.values.splice( index, 0, ...values );
+	}
+
+	delete( index: number, length = 1 ) {
+		this.values.splice( index, length );
+	}
+
+	map< T >( callback: ( value: unknown, index: number ) => T ) {
+		return this.values.map( callback );
+	}
+
+	forEach( callback: ( value: unknown, index: number ) => void ) {
+		this.values.forEach( callback );
+	}
+
+	toArray() {
+		return [ ...this.values ];
+	}
+}
+
+class StubText {
+	private value: string;
+	public parent = null;
+
+	constructor( value = '' ) {
+		this.value = value;
+	}
+
+	insert( index: number, text: string ) {
+		this.value =
+			this.value.slice( 0, index ) + text + this.value.slice( index );
+	}
+
+	delete( index: number, length: number ) {
+		this.value =
+			this.value.slice( 0, index ) + this.value.slice( index + length );
+	}
+
+	toDelta() {
+		return [];
+	}
+
+	applyDelta() {
+		return undefined;
+	}
+
+	toJSON() {
+		return this.value;
+	}
+
+	toString() {
+		return this.value;
+	}
+}
+
+export const Y = {
+	Doc: StubDoc,
+	Map: StubMap,
+	Array: StubArray,
+	Text: StubText,
+	createAbsolutePositionFromRelativePosition: () => null,
+	createRelativePositionFromTypeIndex: () => null,
+	compareRelativePositions: ( a: unknown, b: unknown ) => a === b,
+};
+
+export const YJS_VERSION = '13';
+
+export class Awareness {
+	getStates() {
+		return new globalThis.Map();
+	}
+
+	getLocalState() {
+		return null;
+	}
+
+	setLocalStateField() {
+		return undefined;
+	}
+
+	on() {
+		return undefined;
+	}
+
+	off() {
+		return undefined;
+	}
+
+	destroy() {
+		return undefined;
+	}
+}
+
+class Delta {
+	public ops: unknown[];
+
+	constructor( ops: unknown[] = [] ) {
+		this.ops = ops;
+	}
+
+	diffWithCursor() {
+		return { ops: [] };
+	}
+}
+
+const { lock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/sync'
+);
+
+export const privateApis = {};
+
+lock( privateApis, {
+	ConnectionErrorCode: {
+		AUTHENTICATION_FAILED: 'authentication-failed',
+		CONNECTION_EXPIRED: 'connection-expired',
+		CONNECTION_LIMIT_EXCEEDED: 'connection-limit-exceeded',
+		DOCUMENT_SIZE_LIMIT_EXCEEDED: 'document-size-limit-exceeded',
+		UNKNOWN_ERROR: 'unknown-error',
+	},
+	createSyncManager: () => undefined,
+	Delta,
+	CRDT_DOC_META_PERSISTENCE_KEY: '',
+	CRDT_RECORD_MAP_KEY: '',
+	LOCAL_EDITOR_ORIGIN: '',
+	LOCAL_UNDO_IGNORED_ORIGIN: '',
+	retrySyncConnection: () => undefined,
+} );

--- a/packages/sync/src/core-stub.ts
+++ b/packages/sync/src/core-stub.ts
@@ -5,117 +5,15 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 /**
  * A minimal no-op replacement used when the real-time collaboration package is
- * excluded from WordPress Core builds.
+ * excluded from WordPress Core builds. The Yjs constructors are present only
+ * to preserve the import and instanceof shape; createSyncManager() below
+ * returns undefined, so these should not be reached.
  */
-
-class StubDoc {
-	getMap() {
-		return new StubMap();
-	}
-}
-
-class StubMap {
-	private values = new globalThis.Map< PropertyKey, unknown >();
-	public parent = null;
-
-	constructor( entries: Iterable< [ PropertyKey, unknown ] > = [] ) {
-		this.values = new globalThis.Map( entries );
-	}
-
-	get( key: PropertyKey ) {
-		return this.values.get( key );
-	}
-
-	set( key: PropertyKey, value: unknown ) {
-		this.values.set( key, value );
-	}
-
-	has( key: PropertyKey ) {
-		return this.values.has( key );
-	}
-
-	delete( key: PropertyKey ) {
-		return this.values.delete( key );
-	}
-
-	toJSON() {
-		return Object.fromEntries( this.values );
-	}
-}
-
-class StubArray {
-	private values: unknown[] = [];
-	public parent = null;
-
-	get length() {
-		return this.values.length;
-	}
-
-	get( index: number ) {
-		return this.values[ index ];
-	}
-
-	insert( index: number, values: unknown[] ) {
-		this.values.splice( index, 0, ...values );
-	}
-
-	delete( index: number, length = 1 ) {
-		this.values.splice( index, length );
-	}
-
-	map< T >( callback: ( value: unknown, index: number ) => T ) {
-		return this.values.map( callback );
-	}
-
-	forEach( callback: ( value: unknown, index: number ) => void ) {
-		this.values.forEach( callback );
-	}
-
-	toArray() {
-		return [ ...this.values ];
-	}
-}
-
-class StubText {
-	private value: string;
-	public parent = null;
-
-	constructor( value = '' ) {
-		this.value = value;
-	}
-
-	insert( index: number, text: string ) {
-		this.value =
-			this.value.slice( 0, index ) + text + this.value.slice( index );
-	}
-
-	delete( index: number, length: number ) {
-		this.value =
-			this.value.slice( 0, index ) + this.value.slice( index + length );
-	}
-
-	toDelta() {
-		return [];
-	}
-
-	applyDelta() {
-		return undefined;
-	}
-
-	toJSON() {
-		return this.value;
-	}
-
-	toString() {
-		return this.value;
-	}
-}
-
 export const Y = {
-	Doc: StubDoc,
-	Map: StubMap,
-	Array: StubArray,
-	Text: StubText,
+	Doc: class {},
+	Map: class {},
+	Array: class {},
+	Text: class {},
 	createAbsolutePositionFromRelativePosition: () => null,
 	createRelativePositionFromTypeIndex: () => null,
 	compareRelativePositions: ( a: unknown, b: unknown ) => a === b,

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- Add package-level support for excluding scripts and modules from WordPress Core builds.
 - Avoid unexpected results when typecasting `IS_GUTENBERG_PLUGIN` and `IS_WORDPRESS_CORE` values to Booleans ([#75844](https://github.com/WordPress/gutenberg/pull/75844)).
 - Skip PHP transforms during builds when building for WordPress Core ([#75844](https://github.com/WordPress/gutenberg/pull/75844)).
 

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -56,6 +56,31 @@ or via npm script:
 
 Configure your `package.json` with the following optional fields:
 
+### `wpCore`
+
+Controls whether the package is included in WordPress Core-targeted bundled artifacts when `IS_WORDPRESS_CORE` is true.
+
+- **Omitted or `true` (default)**: The package is included in WordPress Core builds when it otherwise qualifies as a WordPress script or module.
+
+- **`false`**: The package is omitted from WordPress Core script/module output. The package can still be transpiled and consumed as an npm dependency.
+
+```json
+{
+	"wpCore": false
+}
+```
+
+### `wpCoreStub`
+
+Defines a package-local stub entry point to use when another package imports a package excluded from WordPress Core builds with `wpCore: false`.
+
+```json
+{
+	"wpCore": false,
+	"wpCoreStub": "src/core-stub.ts"
+}
+```
+
 ### `wpScript`
 
 Controls whether the package is exposed as a bundled WordPress script/module and accessible via the configured global variable.

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { readFile, writeFile, copyFile, mkdir, unlink } from 'fs/promises';
+import { readFile, writeFile, copyFile, mkdir, unlink, rm } from 'fs/promises';
 import path from 'path';
 import { createHash } from 'node:crypto';
 import { parseArgs } from 'node:util';
@@ -480,6 +480,22 @@ function resolveEntryPoint( packageDir, packageJson ) {
 }
 
 /**
+ * Remove generated build output for a package.
+ *
+ * @param {string} packageName Package name.
+ */
+async function removePackageBuildOutput( packageName ) {
+	await Promise.all(
+		[ 'scripts', 'modules', 'styles' ].map( ( buildType ) =>
+			rm( path.join( BUILD_DIR, buildType, packageName ), {
+				force: true,
+				recursive: true,
+			} )
+		)
+	);
+}
+
+/**
  * Bundle a package for WordPress using esbuild.
  *
  * @param {string} packageName Package name.
@@ -503,6 +519,7 @@ async function bundlePackage( packageName, options = {} ) {
 	);
 
 	if ( ! shouldIncludePackageInWordPressCoreBuild( packageJson ) ) {
+		await removePackageBuildOutput( packageName );
 		return false;
 	}
 

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -127,6 +127,20 @@ const boolConfigVal = ( value ) => {
 	return [ 'true', '1' ].includes( value.toLowerCase() );
 };
 
+const isWordPressCoreBuild = () =>
+	boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
+	boolConfigVal( process.env.npm_package_config_IS_WORDPRESS_CORE ) ??
+	false;
+
+/**
+ * Check whether a package should be included in WordPress Core builds.
+ *
+ * @param {import('./package-utils.mjs').PackageJson} packageJson Package.json object.
+ * @return {boolean} Whether the package should be included in WordPress Core builds.
+ */
+const shouldIncludePackageInWordPressCoreBuild = ( packageJson ) =>
+	! ( isWordPressCoreBuild() && packageJson.wpCore === false );
+
 const baseDefine = {
 	'globalThis.IS_GUTENBERG_PLUGIN': JSON.stringify(
 		boolConfigVal( process.env.IS_GUTENBERG_PLUGIN ) ??
@@ -135,11 +149,7 @@ const baseDefine = {
 			) ??
 			false
 	),
-	'globalThis.IS_WORDPRESS_CORE': JSON.stringify(
-		boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
-			boolConfigVal( process.env.npm_package_config_IS_WORDPRESS_CORE ) ??
-			false
-	),
+	'globalThis.IS_WORDPRESS_CORE': JSON.stringify( isWordPressCoreBuild() ),
 };
 const getDefine = ( scriptDebug ) => ( {
 	...baseDefine,
@@ -347,8 +357,7 @@ function transformPhpContent( content, transforms ) {
 	 * necessary to perform these steps.
 	 */
 	if (
-		boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
-		boolConfigVal( process.env.npm_package_config_IS_WORDPRESS_CORE )
+		isWordPressCoreBuild()
 	) {
 		return content;
 	}
@@ -492,6 +501,10 @@ async function bundlePackage( packageName, options = {} ) {
 	const packageJson = getPackageInfoFromFile(
 		path.join( sourceDir, packageName, 'package.json' )
 	);
+
+	if ( ! shouldIncludePackageInWordPressCoreBuild( packageJson ) ) {
+		return false;
+	}
 
 	const builds = [];
 
@@ -1830,9 +1843,7 @@ async function buildAll( baseUrlExpression ) {
 	} );
 
 	// When building for WordPress Core, exclude experimental pages.
-	const isCoreBuild =
-		boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
-		boolConfigVal( process.env.npm_package_config_IS_WORDPRESS_CORE );
+	const isCoreBuild = isWordPressCoreBuild();
 	const activePages = isCoreBuild
 		? normalizedPages.filter( ( page ) => ! page.experimental )
 		: normalizedPages;
@@ -2197,10 +2208,7 @@ async function main() {
 			'base-url': {
 				type: 'string',
 				default:
-					boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
-					boolConfigVal(
-						process.env.npm_package_config_IS_WORDPRESS_CORE
-					)
+					isWordPressCoreBuild()
 						? "includes_url( 'build/' )"
 						: 'plugin_dir_url( __FILE__ )',
 			},

--- a/packages/wp-build/lib/package-utils.mjs
+++ b/packages/wp-build/lib/package-utils.mjs
@@ -7,10 +7,11 @@ import path from 'path';
 
 /**
  * Shared cache for package.json files to avoid redundant reads.
- * Cache is keyed by the full package name from package.json's name field.
+ * Cache is keyed by package name and the package root used for resolution.
  */
 const packageJsonCache = new Map();
 const packagePathCache = new Map();
+const packageJsonPathCache = new Map();
 
 /**
  * @typedef  {Object} PackageJson
@@ -23,6 +24,8 @@ const packagePathCache = new Map();
  * @property {string}                 [main]                  Main entry point.
  * @property {string}                 [module]                ES module entry point.
  * @property {string}                 [react-native]          React Native entry point.
+ * @property {boolean}                [wpCore]                Whether to include the package in WordPress Core builds.
+ * @property {string}                 [wpCoreStub]            Stub entry point for WordPress Core builds.
  * @property {Record<string, string>} [dependencies]          Runtime dependencies.
  * @property {Record<string, string>} [devDependencies]       Development dependencies.
  * @property {Record<string, string>} [peerDependencies]      Peer dependencies.
@@ -74,7 +77,6 @@ function findPackageRoot( startDir ) {
  * @return {PackageJson|null} Package.json object or null if not found.
  */
 export function getPackageInfo( fullPackageName, resolveDir = null ) {
-	// Determine the package root for cache keying
 	const packageRoot = resolveDir
 		? findPackageRoot( resolveDir )
 		: process.cwd();
@@ -84,14 +86,37 @@ export function getPackageInfo( fullPackageName, resolveDir = null ) {
 		return packageJsonCache.get( cacheKey );
 	}
 
-	// Resolve from the package root context to get correct versions
-	const contextPath = path.join( packageRoot, 'package.json' );
-	const require = createRequire( contextPath );
-	const resolved = require.resolve( `${ fullPackageName }/package.json` );
-	const result = getPackageInfoFromFile( resolved );
+	const packageJsonPath = getPackageJsonPath( fullPackageName, resolveDir );
+	const result = getPackageInfoFromFile( packageJsonPath );
 	packageJsonCache.set( cacheKey, result );
 
 	return result;
+}
+
+/**
+ * Get package.json path using Node's module resolution.
+ *
+ * @param {string}      fullPackageName The full package name (e.g., '@wordpress/blocks').
+ * @param {string|null} resolveDir      Optional directory context for resolution (from esbuild).
+ * @return {string} Absolute path to the resolved package.json file.
+ */
+export function getPackageJsonPath( fullPackageName, resolveDir = null ) {
+	const packageRoot = resolveDir
+		? findPackageRoot( resolveDir )
+		: process.cwd();
+	const cacheKey = `${ fullPackageName }@${ packageRoot }`;
+
+	if ( packageJsonPathCache.has( cacheKey ) ) {
+		return packageJsonPathCache.get( cacheKey );
+	}
+
+	const contextPath = path.join( packageRoot, 'package.json' );
+	const require = createRequire( contextPath );
+	const packageJsonPath = require.resolve(
+		`${ fullPackageName }/package.json`
+	);
+	packageJsonPathCache.set( cacheKey, packageJsonPath );
+	return packageJsonPath;
 }
 
 /**

--- a/packages/wp-build/lib/wordpress-externals-plugin.mjs
+++ b/packages/wp-build/lib/wordpress-externals-plugin.mjs
@@ -9,7 +9,35 @@ import { createHash } from 'crypto';
 /**
  * Internal dependencies
  */
-import { getPackageInfo } from './package-utils.mjs';
+import { getPackageInfo, getPackageJsonPath } from './package-utils.mjs';
+
+/**
+ * Interprets a configuration value as a boolean, where `"true"` and `"1"`
+ * are considered true while all other values are false.
+ *
+ * @param {string|undefined} value The configuration value to interpret.
+ * @return {boolean|undefined} Boolean interpretation of the given configuration value, or undefined if not set.
+ */
+const boolConfigVal = ( value ) => {
+	if ( value === undefined ) {
+		return undefined;
+	}
+	return [ 'true', '1' ].includes( value.toLowerCase() );
+};
+
+const isWordPressCoreBuild = () =>
+	boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
+	boolConfigVal( process.env.npm_package_config_IS_WORDPRESS_CORE ) ??
+	false;
+
+/**
+ * Check whether a package should be excluded from WordPress Core builds.
+ *
+ * @param {import('./package-utils.mjs').PackageJson} packageJson Package.json object.
+ * @return {boolean} Whether the package is excluded from WordPress Core builds.
+ */
+const isExcludedFromWordPressCoreBuild = ( packageJson ) =>
+	isWordPressCoreBuild() && packageJson.wpCore === false;
 
 /**
  * Generate a content hash from file contents.
@@ -220,6 +248,28 @@ export function createWordpressExternalsPlugin(
 
 							if ( ! packageJson ) {
 								return undefined;
+							}
+
+							if (
+								isExcludedFromWordPressCoreBuild( packageJson )
+							) {
+								if ( ! packageJson.wpCoreStub ) {
+									throw new Error(
+										`${ packageName } is excluded from WordPress Core builds, but does not define a wpCoreStub.`
+									);
+								}
+
+								return {
+									path: path.resolve(
+										path.dirname(
+											getPackageJsonPath(
+												packageName,
+												args.resolveDir
+											)
+										),
+										packageJson.wpCoreStub
+									),
+								};
 							}
 
 							let isScriptModule = isScriptModuleImport(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Alternative to #78080. 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

This change doesn't disable RTC in gutenberg, so testing the PR in playground should see RTC still working as expected. 

To test the exclusion of the sync package from the core artifact, build that artifact by checking out this branch and running `IS_WORDPRESS_CORE=true IS_GUTENBERG_PLUGIN=false NO_CHECKS=true ./bin/build-plugin-zip.sh`

The resulting zip shouldn't contain a `sync` folder in its `build/scripts` folder.

To test that it works in wp-develop:

In your local wordpress-develop checkout, replace the local Gutenberg artifact:
`GB_SHA=[commit SHA from this Gutenberg PR]`

```
rm -rf gutenberg
mkdir gutenberg
unzip /path/to/gutenberg.zip -d gutenberg
printf '%s\n' "$GB_SHA" > gutenberg/.gutenberg-hash
```
Then update wordpress-develop/package.json so gutenberg.sha matches the same PR commit SHA:
```
"gutenberg": {
	"sha": "<commit SHA from this Gutenberg PR>",
	"ghcrRepo": "WordPress/gutenberg/gutenberg-wp-develop-build"
}
```
Rebuild the Gutenberg files copied into Core:
`grunt build:gutenberg --dev`
Then build/run Core as usual:
`npm run build` or `npm run build:dev` depending on whether your env points at `build` or `src`


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Used GPT 5.5./codex.
