### PR TITLE
Fix flaky 'publish panel' e2e test

### DIFF
--- a/test/e2e/specs/editor/various/publish-panel.spec.js
+++ b/test/e2e/specs/editor/various/publish-panel.spec.js
@@ -19,15 +19,17 @@ test.describe( 'Post publish panel', () => {
 		} );
 
 		// Find and click the Publish panel toggle button.
-		const publishPanelToggleButton = page.locator(
-			'role=region[name="Editor top bar"i] >> role=button[name="Publish"i]'
-		);
+		const publishPanelToggleButton = page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Publish', exact: true } );
 		await publishPanelToggleButton.click();
 
 		// Click the Cancel button.
-		await page.click(
-			'role=region[name="Editor publish"i] >> role=button[name="Cancel"i]'
-		);
+		const cancelButton = page
+			.getByRole( 'region', { name: 'Editor publish' } )
+			.getByRole( 'button', { name: 'Cancel' } );
+		await expect( cancelButton ).toBeEnabled();
+		await cancelButton.click();
 
 		// Test focus is moved back to the Publish panel toggle button.
 		await expect( publishPanelToggleButton ).toBeFocused();
@@ -46,15 +48,16 @@ test.describe( 'Post publish panel', () => {
 		await editor.publishPost();
 
 		// Close the publish panel.
-		await page.click(
-			'role=region[name="Editor publish"i] >> role=button[name="Close panel"i]'
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor publish' } )
+			.getByRole( 'button', { name: 'Close panel' } )
+			.click();
 
 		// Test focus is moved back to the Publish panel toggle button.
 		await expect(
-			page.locator(
-				'role=region[name="Editor top bar"i] >> role=button[name="Save"i]'
-			)
+			page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Save' } )
 		).toBeFocused();
 	} );
 


### PR DESCRIPTION
## What?
Closes #77721.

PR fixes flaky `should move focus back to the Publish panel toggle button when canceling` e2e test. Ensure the `Cancel` button is enabled before clicking on it.

Cancel button uses `disabled={ isSavingNonPostEntityChanges } + accessibleWhenDisabled`. When both are true, the Button renders `aria-disabled` and swallows clicks via `stopPropagation`/`preventDefault`, but Playwright still sees it as interactable. On CI, transient non-post entity saves (e.g., preferences) can flip `disabled` to true right when `page.click('… Cancel')` fires; the click dispatches, but `onClose` never runs, the panel stays open, and the focus assertion fails.

Awaiting `toBeEnabled()` (which treats `aria-disabled` as disabled) prevents the button's click from being actionable.

I've also migrated locators to use `getByRole`, which fixes a couple of ESLint warnings in the file.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
CI checks should be green.