### PR TITLE
Editor: Refactor 'PostPublishPanel' into function component

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1255,12 +1255,12 @@ _Parameters_
 -   _props_ `Object`: Component props.
 -   _props.forceIsDirty_ `[boolean]`: Whether to force the dirty state.
 -   _props.onClose_ `()=>void`: Called when the panel requests to close.
--   _props.PostPublishExtension_ `[WPComponent]`: Component rendered after publishing.
--   _props.PrePublishExtension_ `[WPComponent]`: Component rendered before publishing.
+-   _props.PostPublishExtension_ `[React.ComponentType]`: Component rendered after publishing.
+-   _props.PrePublishExtension_ `[React.ComponentType]`: Component rendered before publishing.
 
 _Returns_
 
--   `Element`: The post publish panel.
+-   `React.JSX.Element`: The post publish panel.
 
 ### PostSavedState
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1250,6 +1250,18 @@ _Returns_
 
 Renders a panel for publishing a post.
 
+_Parameters_
+
+-   _props_ `Object`: Component props.
+-   _props.forceIsDirty_ `[boolean]`: Whether to force the dirty state.
+-   _props.onClose_ `()=>void`: Called when the panel requests to close.
+-   _props.PostPublishExtension_ `[WPComponent]`: Component rendered after publishing.
+-   _props.PrePublishExtension_ `[WPComponent]`: Component rendered before publishing.
+
+_Returns_
+
+-   `Element`: The post publish panel.
+
 ### PostSavedState
 
 Component showing whether the post is saved or not and providing save buttons.

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -3,15 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from '@wordpress/element';
-import {
-	Button,
-	Spinner,
-	CheckboxControl,
-	withFocusReturn,
-	withConstrainedTabbing,
-} from '@wordpress/components';
+import { Button, Spinner, CheckboxControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { compose, useEvent } from '@wordpress/compose';
+import {
+	useConstrainedTabbing,
+	useEvent,
+	useFocusReturn,
+	useMergeRefs,
+} from '@wordpress/compose';
 import { closeSmall } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -23,7 +22,18 @@ import PostPublishPanelPrepublish from './prepublish';
 import PostPublishPanelPostpublish from './postpublish';
 import { store as editorStore } from '../../store';
 
-export function PostPublishPanel( {
+/**
+ * Renders a panel for publishing a post.
+ *
+ * @param {Object}      props                        Component props.
+ * @param {boolean}     [props.forceIsDirty]         Whether to force the dirty state.
+ * @param {()=>void}    props.onClose                Called when the panel requests to close.
+ * @param {WPComponent} [props.PostPublishExtension] Component rendered after publishing.
+ * @param {WPComponent} [props.PrePublishExtension]  Component rendered before publishing.
+ *
+ * @return {Element} The post publish panel.
+ */
+export default function PostPublishPanel( {
 	forceIsDirty,
 	onClose,
 	PostPublishExtension,
@@ -77,6 +87,10 @@ export function PostPublishPanel( {
 		useDispatch( editorStore );
 
 	const cancelButtonRef = useRef( null );
+	const wrapperRef = useMergeRefs( [
+		useFocusReturn(),
+		useConstrainedTabbing(),
+	] );
 
 	useEffect( () => {
 		// This timeout is necessary to make sure the `useEffect` hook of
@@ -121,7 +135,12 @@ export function PostPublishPanel( {
 	const isPostPublish = isPublishedOrScheduled && ! isSaving;
 
 	return (
-		<div className="editor-post-publish-panel" { ...propsForPanel }>
+		<div
+			ref={ wrapperRef }
+			tabIndex={ -1 }
+			className="editor-post-publish-panel"
+			{ ...propsForPanel }
+		>
 			<div className="editor-post-publish-panel__header">
 				{ isPostPublish ? (
 					<Button
@@ -176,10 +195,3 @@ export function PostPublishPanel( {
 		</div>
 	);
 }
-
-/**
- * Renders a panel for publishing a post.
- */
-export default compose( [ withFocusReturn, withConstrainedTabbing ] )(
-	PostPublishPanel
-);

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -93,13 +93,7 @@ export default function PostPublishPanel( {
 	] );
 
 	useEffect( () => {
-		// This timeout is necessary to make sure the `useEffect` hook of
-		// `useFocusReturn` gets the correct element (the button that opens the
-		// PostPublishPanel) otherwise it will get this button.
-		const timeoutID = setTimeout( () => {
-			cancelButtonRef.current?.focus();
-		}, 0 );
-		return () => clearTimeout( timeoutID );
+		cancelButtonRef.current?.focus();
 	}, [] );
 
 	// Auto-collapse the publish sidebar when a post is published and the user

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, createRef } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import {
 	Button,
 	Spinner,
@@ -10,7 +10,7 @@ import {
 	withFocusReturn,
 	withConstrainedTabbing,
 } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { closeSmall } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
@@ -23,135 +23,25 @@ import PostPublishPanelPrepublish from './prepublish';
 import PostPublishPanelPostpublish from './postpublish';
 import { store as editorStore } from '../../store';
 
-export class PostPublishPanel extends Component {
-	constructor() {
-		super( ...arguments );
-		this.onSubmit = this.onSubmit.bind( this );
-		this.cancelButtonNode = createRef();
-	}
-
-	componentDidMount() {
-		// This timeout is necessary to make sure the `useEffect` hook of
-		// `useFocusReturn` gets the correct element (the button that opens the
-		// PostPublishPanel) otherwise it will get this button.
-		this.timeoutID = setTimeout( () => {
-			this.cancelButtonNode.current.focus();
-		}, 0 );
-	}
-
-	componentWillUnmount() {
-		clearTimeout( this.timeoutID );
-	}
-
-	componentDidUpdate( prevProps ) {
-		// Automatically collapse the publish sidebar when a post
-		// is published and the user makes an edit.
-		if (
-			( prevProps.isPublished &&
-				! this.props.isSaving &&
-				this.props.isDirty ) ||
-			this.props.currentPostId !== prevProps.currentPostId
-		) {
-			this.props.onClose();
-		}
-	}
-
-	onSubmit() {
-		const { onClose, hasPublishAction, isPostTypeViewable } = this.props;
-		if ( ! hasPublishAction || ! isPostTypeViewable ) {
-			onClose();
-		}
-	}
-
-	render() {
-		const {
-			forceIsDirty,
-			isBeingScheduled,
-			isPublished,
-			isPublishSidebarEnabled,
-			isScheduled,
-			isSaving,
-			isSavingNonPostEntityChanges,
-			onClose,
-			onTogglePublishSidebar,
-			PostPublishExtension,
-			PrePublishExtension,
-			currentPostId,
-			...additionalProps
-		} = this.props;
-		const {
-			hasPublishAction,
-			isDirty,
-			isPostTypeViewable,
-			...propsForPanel
-		} = additionalProps;
-		const isPublishedOrScheduled =
-			isPublished || ( isScheduled && isBeingScheduled );
-		const isPrePublish = ! isPublishedOrScheduled && ! isSaving;
-		const isPostPublish = isPublishedOrScheduled && ! isSaving;
-		return (
-			<div className="editor-post-publish-panel" { ...propsForPanel }>
-				<div className="editor-post-publish-panel__header">
-					{ isPostPublish ? (
-						<Button
-							size="compact"
-							onClick={ onClose }
-							icon={ closeSmall }
-							label={ __( 'Close panel' ) }
-						/>
-					) : (
-						<>
-							<div className="editor-post-publish-panel__header-cancel-button">
-								<Button
-									ref={ this.cancelButtonNode }
-									accessibleWhenDisabled
-									disabled={ isSavingNonPostEntityChanges }
-									onClick={ onClose }
-									variant="secondary"
-									size="compact"
-								>
-									{ __( 'Cancel' ) }
-								</Button>
-							</div>
-							<div className="editor-post-publish-panel__header-publish-button">
-								<PostPublishButton
-									onSubmit={ this.onSubmit }
-									forceIsDirty={ forceIsDirty }
-								/>
-							</div>
-						</>
-					) }
-				</div>
-				<div className="editor-post-publish-panel__content">
-					{ isPrePublish && (
-						<PostPublishPanelPrepublish>
-							{ PrePublishExtension && <PrePublishExtension /> }
-						</PostPublishPanelPrepublish>
-					) }
-					{ isPostPublish && (
-						<PostPublishPanelPostpublish focusOnMount>
-							{ PostPublishExtension && <PostPublishExtension /> }
-						</PostPublishPanelPostpublish>
-					) }
-					{ isSaving && <Spinner /> }
-				</div>
-				<div className="editor-post-publish-panel__footer">
-					<CheckboxControl
-						label={ __( 'Always show pre-publish checks.' ) }
-						checked={ isPublishSidebarEnabled }
-						onChange={ onTogglePublishSidebar }
-					/>
-				</div>
-			</div>
-		);
-	}
-}
-
-/**
- * Renders a panel for publishing a post.
- */
-export default compose( [
-	withSelect( ( select ) => {
+export function PostPublishPanel( {
+	forceIsDirty,
+	onClose,
+	PostPublishExtension,
+	PrePublishExtension,
+	...propsForPanel
+} ) {
+	const {
+		hasPublishAction,
+		isPostTypeViewable,
+		isBeingScheduled,
+		isDirty,
+		isPublished,
+		isPublishSidebarEnabled,
+		isSaving,
+		isSavingNonPostEntityChanges,
+		isScheduled,
+		currentPostId,
+	} = useSelect( ( select ) => {
 		const { getPostType } = select( coreStore );
 		const {
 			getCurrentPost,
@@ -163,9 +53,9 @@ export default compose( [
 			isEditedPostDirty,
 			isAutosavingPost,
 			isSavingPost,
-			isSavingNonPostEntityChanges,
+			isSavingNonPostEntityChanges: _isSavingNonPostEntityChanges,
+			isPublishSidebarEnabled: _isPublishSidebarEnabled,
 		} = select( editorStore );
-		const { isPublishSidebarEnabled } = select( editorStore );
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 
 		return {
@@ -175,26 +65,127 @@ export default compose( [
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			isDirty: isEditedPostDirty(),
 			isPublished: isCurrentPostPublished(),
-			isPublishSidebarEnabled: isPublishSidebarEnabled(),
+			isPublishSidebarEnabled: _isPublishSidebarEnabled(),
 			isSaving: isSavingPost() && ! isAutosavingPost(),
-			isSavingNonPostEntityChanges: isSavingNonPostEntityChanges(),
+			isSavingNonPostEntityChanges: _isSavingNonPostEntityChanges(),
 			isScheduled: isCurrentPostScheduled(),
 			currentPostId: getCurrentPostId(),
 		};
-	} ),
-	withDispatch( ( dispatch, { isPublishSidebarEnabled } ) => {
-		const { disablePublishSidebar, enablePublishSidebar } =
-			dispatch( editorStore );
-		return {
-			onTogglePublishSidebar: () => {
-				if ( isPublishSidebarEnabled ) {
-					disablePublishSidebar();
-				} else {
-					enablePublishSidebar();
-				}
-			},
-		};
-	} ),
-	withFocusReturn,
-	withConstrainedTabbing,
-] )( PostPublishPanel );
+	}, [] );
+
+	const { disablePublishSidebar, enablePublishSidebar } =
+		useDispatch( editorStore );
+	const onTogglePublishSidebar = () => {
+		if ( isPublishSidebarEnabled ) {
+			disablePublishSidebar();
+		} else {
+			enablePublishSidebar();
+		}
+	};
+
+	const cancelButtonRef = useRef( null );
+
+	useEffect( () => {
+		// This timeout is necessary to make sure the `useEffect` hook of
+		// `useFocusReturn` gets the correct element (the button that opens the
+		// PostPublishPanel) otherwise it will get this button.
+		const timeoutID = setTimeout( () => {
+			cancelButtonRef.current?.focus();
+		}, 0 );
+		return () => clearTimeout( timeoutID );
+	}, [] );
+
+	// Auto-collapse the publish sidebar when a post is published and the user
+	// makes an edit, or when the edited post changes.
+	const prevIsPublishedRef = useRef( isPublished );
+	const prevCurrentPostIdRef = useRef( currentPostId );
+	const didMountRef = useRef( false );
+	useEffect( () => {
+		if ( ! didMountRef.current ) {
+			didMountRef.current = true;
+			return;
+		}
+		if (
+			( prevIsPublishedRef.current && ! isSaving && isDirty ) ||
+			currentPostId !== prevCurrentPostIdRef.current
+		) {
+			onClose?.();
+		}
+		prevIsPublishedRef.current = isPublished;
+		prevCurrentPostIdRef.current = currentPostId;
+	}, [ isPublished, isSaving, isDirty, currentPostId, onClose ] );
+
+	const onSubmit = () => {
+		if ( ! hasPublishAction || ! isPostTypeViewable ) {
+			onClose();
+		}
+	};
+
+	const isPublishedOrScheduled =
+		isPublished || ( isScheduled && isBeingScheduled );
+	const isPrePublish = ! isPublishedOrScheduled && ! isSaving;
+	const isPostPublish = isPublishedOrScheduled && ! isSaving;
+
+	return (
+		<div className="editor-post-publish-panel" { ...propsForPanel }>
+			<div className="editor-post-publish-panel__header">
+				{ isPostPublish ? (
+					<Button
+						size="compact"
+						onClick={ onClose }
+						icon={ closeSmall }
+						label={ __( 'Close panel' ) }
+					/>
+				) : (
+					<>
+						<div className="editor-post-publish-panel__header-cancel-button">
+							<Button
+								ref={ cancelButtonRef }
+								accessibleWhenDisabled
+								disabled={ isSavingNonPostEntityChanges }
+								onClick={ onClose }
+								variant="secondary"
+								size="compact"
+							>
+								{ __( 'Cancel' ) }
+							</Button>
+						</div>
+						<div className="editor-post-publish-panel__header-publish-button">
+							<PostPublishButton
+								onSubmit={ onSubmit }
+								forceIsDirty={ forceIsDirty }
+							/>
+						</div>
+					</>
+				) }
+			</div>
+			<div className="editor-post-publish-panel__content">
+				{ isPrePublish && (
+					<PostPublishPanelPrepublish>
+						{ PrePublishExtension && <PrePublishExtension /> }
+					</PostPublishPanelPrepublish>
+				) }
+				{ isPostPublish && (
+					<PostPublishPanelPostpublish focusOnMount>
+						{ PostPublishExtension && <PostPublishExtension /> }
+					</PostPublishPanelPostpublish>
+				) }
+				{ isSaving && <Spinner /> }
+			</div>
+			<div className="editor-post-publish-panel__footer">
+				<CheckboxControl
+					label={ __( 'Always show pre-publish checks.' ) }
+					checked={ isPublishSidebarEnabled }
+					onChange={ onTogglePublishSidebar }
+				/>
+			</div>
+		</div>
+	);
+}
+
+/**
+ * Renders a panel for publishing a post.
+ */
+export default compose( [ withFocusReturn, withConstrainedTabbing ] )(
+	PostPublishPanel
+);

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -25,13 +25,13 @@ import { store as editorStore } from '../../store';
 /**
  * Renders a panel for publishing a post.
  *
- * @param {Object}      props                        Component props.
- * @param {boolean}     [props.forceIsDirty]         Whether to force the dirty state.
- * @param {()=>void}    props.onClose                Called when the panel requests to close.
- * @param {WPComponent} [props.PostPublishExtension] Component rendered after publishing.
- * @param {WPComponent} [props.PrePublishExtension]  Component rendered before publishing.
+ * @param {Object}              props                        Component props.
+ * @param {boolean}             [props.forceIsDirty]         Whether to force the dirty state.
+ * @param {()=>void}            props.onClose                Called when the panel requests to close.
+ * @param {React.ComponentType} [props.PostPublishExtension] Component rendered after publishing.
+ * @param {React.ComponentType} [props.PrePublishExtension]  Component rendered before publishing.
  *
- * @return {Element} The post publish panel.
+ * @return {React.JSX.Element} The post publish panel.
  */
 export default function PostPublishPanel( {
 	forceIsDirty,
@@ -97,7 +97,9 @@ export default function PostPublishPanel( {
 	}, [] );
 
 	// Auto-collapse the publish sidebar when a post is published and the user
-	// makes an edit, or when the edited post changes.
+	// makes an edit, or when the edited post changes. The panel only mounts
+	// for unpublished posts, so `isPublished && isDirty` cannot be true on
+	// mount — it implies a publish-then-edit transition.
 	const prevPostIdRef = useRef( currentPostId );
 	const stableOnClose = useEvent( onClose );
 	useEffect( () => {

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -11,7 +11,7 @@ import {
 	withConstrainedTabbing,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { compose, useEvent } from '@wordpress/compose';
 import { closeSmall } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -75,13 +75,6 @@ export function PostPublishPanel( {
 
 	const { disablePublishSidebar, enablePublishSidebar } =
 		useDispatch( editorStore );
-	const onTogglePublishSidebar = () => {
-		if ( isPublishSidebarEnabled ) {
-			disablePublishSidebar();
-		} else {
-			enablePublishSidebar();
-		}
-	};
 
 	const cancelButtonRef = useRef( null );
 
@@ -97,29 +90,30 @@ export function PostPublishPanel( {
 
 	// Auto-collapse the publish sidebar when a post is published and the user
 	// makes an edit, or when the edited post changes.
-	const prevIsPublishedRef = useRef( isPublished );
-	const prevCurrentPostIdRef = useRef( currentPostId );
-	const didMountRef = useRef( false );
+	const prevPostIdRef = useRef( currentPostId );
+	const stableOnClose = useEvent( onClose );
 	useEffect( () => {
-		if ( ! didMountRef.current ) {
-			didMountRef.current = true;
-			return;
-		}
-		if (
-			( prevIsPublishedRef.current && ! isSaving && isDirty ) ||
-			currentPostId !== prevCurrentPostIdRef.current
-		) {
-			onClose?.();
-		}
-		prevIsPublishedRef.current = isPublished;
-		prevCurrentPostIdRef.current = currentPostId;
-	}, [ isPublished, isSaving, isDirty, currentPostId, onClose ] );
+		const postChanged = currentPostId !== prevPostIdRef.current;
+		prevPostIdRef.current = currentPostId;
 
-	const onSubmit = () => {
+		if ( postChanged || ( isPublished && ! isSaving && isDirty ) ) {
+			stableOnClose();
+		}
+	}, [ isPublished, isSaving, isDirty, currentPostId, stableOnClose ] );
+
+	function onTogglePublishSidebar() {
+		if ( isPublishSidebarEnabled ) {
+			disablePublishSidebar();
+		} else {
+			enablePublishSidebar();
+		}
+	}
+
+	function onSubmit() {
 		if ( ! hasPublishAction || ! isPostTypeViewable ) {
 			onClose();
 		}
-	};
+	}
 
 	const isPublishedOrScheduled =
 		isPublished || ( isScheduled && isBeingScheduled );

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -54,6 +54,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
 <div>
   <div
     class="editor-post-publish-panel"
+    tabindex="-1"
   >
     <div
       class="editor-post-publish-panel__header"
@@ -278,6 +279,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
 <div>
   <div
     class="editor-post-publish-panel"
+    tabindex="-1"
   >
     <div
       class="editor-post-publish-panel__header"
@@ -472,6 +474,7 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
 <div>
   <div
     class="editor-post-publish-panel"
+    tabindex="-1"
   >
     <div
       class="editor-post-publish-panel__header"
@@ -625,6 +628,7 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
 <div>
   <div
     class="editor-post-publish-panel"
+    tabindex="-1"
   >
     <div
       class="editor-post-publish-panel__header"
@@ -822,6 +826,7 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
 <div>
   <div
     class="editor-post-publish-panel"
+    tabindex="-1"
   >
     <div
       class="editor-post-publish-panel__header"

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -329,7 +329,10 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
             </span>
           </a>
            
-          is now live.
+          is now scheduled. It will go live on
+           
+          Immediately
+          .
         </div>
         <div
           class="components-panel__body is-opened"
@@ -380,30 +383,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
             class="post-publish-panel__postpublish-buttons"
           >
             <a
-              class="components-button is-next-40px-default-size is-primary has-icon has-icon-right"
-              href="https://wordpress.local/sample-page/"
-              target="_blank"
-            >
-              <span
-                data-visually-hidden=""
-              >
-                (opens in a new tab)
-              </span>
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19.5 4.5h-7V6h4.44l-5.97 5.97 1.06 1.06L18 7.06v4.44h1.5v-7Zm-13 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3H17v3a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h3V5.5h-3Z"
-                />
-              </svg>
-            </a>
-            <a
-              class="components-button is-next-40px-default-size is-secondary"
+              class="components-button is-next-40px-default-size is-primary"
               href="post-new.php?"
             />
           </div>
@@ -861,7 +841,7 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
       >
         <button
           aria-disabled="true"
-          class="components-button editor-post-publish-button editor-post-publish-button__button is-primary is-compact"
+          class="components-button editor-post-publish-button editor-post-publish-button__button is-primary is-compact is-busy"
           type="button"
         >
           Submit for Review

--- a/packages/editor/src/components/post-publish-panel/test/index.js
+++ b/packages/editor/src/components/post-publish-panel/test/index.js
@@ -7,8 +7,8 @@ import { render } from '@testing-library/react';
  * WordPress dependencies
  */
 import { select } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -16,49 +16,67 @@ import { store as coreStore } from '@wordpress/core-data';
 import { PostPublishPanel } from '../index';
 
 describe( 'PostPublishPanel', () => {
-	jest.spyOn( select( coreStore ), 'getPostType' ).mockReturnValue( {
-		labels: {
-			singular_name: 'post',
-		},
+	beforeEach( () => {
+		jest.spyOn( select( coreStore ), 'getPostType' ).mockReturnValue( {
+			labels: {
+				singular_name: 'post',
+			},
+		} );
+
+		jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
+			link: 'https://wordpress.local/sample-page/',
+		} );
 	} );
 
-	jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
-		link: 'https://wordpress.local/sample-page/',
+	afterEach( () => {
+		jest.restoreAllMocks();
 	} );
 
 	it( 'should render the pre-publish panel if the post is not saving, published or scheduled', () => {
-		const { container } = render(
-			<PostPublishPanel
-				isPublished={ false }
-				isScheduled={ false }
-				isSaving={ false }
-			/>
-		);
+		const { container } = render( <PostPublishPanel /> );
 		expect( container ).toMatchSnapshot();
 	} );
 
 	it( 'should render the pre-publish panel if post status is scheduled but date is before now', () => {
-		const { container } = render(
-			<PostPublishPanel isScheduled isBeingScheduled={ false } />
-		);
+		jest.spyOn(
+			select( editorStore ),
+			'isCurrentPostScheduled'
+		).mockReturnValue( true );
 
+		const { container } = render( <PostPublishPanel /> );
 		expect( container ).toMatchSnapshot();
 	} );
 
 	it( 'should render the spinner if the post is being saved', () => {
-		const { container } = render( <PostPublishPanel isSaving /> );
+		jest.spyOn( select( editorStore ), 'isSavingPost' ).mockReturnValue(
+			true
+		);
+
+		const { container } = render( <PostPublishPanel /> );
 		expect( container ).toMatchSnapshot();
 	} );
 
 	it( 'should render the post-publish panel if the post is published', () => {
-		const { container } = render( <PostPublishPanel isPublished /> );
+		jest.spyOn(
+			select( editorStore ),
+			'isCurrentPostPublished'
+		).mockReturnValue( true );
+
+		const { container } = render( <PostPublishPanel /> );
 		expect( container ).toMatchSnapshot();
 	} );
 
 	it( 'should render the post-publish panel if the post is scheduled', () => {
-		const { container } = render(
-			<PostPublishPanel isScheduled isBeingScheduled />
-		);
+		jest.spyOn(
+			select( editorStore ),
+			'isCurrentPostScheduled'
+		).mockReturnValue( true );
+		jest.spyOn(
+			select( editorStore ),
+			'isEditedPostBeingScheduled'
+		).mockReturnValue( true );
+
+		const { container } = render( <PostPublishPanel /> );
 		expect( container ).toMatchSnapshot();
 	} );
 } );

--- a/packages/editor/src/components/post-publish-panel/test/index.js
+++ b/packages/editor/src/components/post-publish-panel/test/index.js
@@ -13,7 +13,7 @@ import { store as editorStore } from '@wordpress/editor';
 /**
  * Internal dependencies
  */
-import { PostPublishPanel } from '../index';
+import PostPublishPanel from '../index';
 
 describe( 'PostPublishPanel', () => {
 	beforeEach( () => {

--- a/test/e2e/specs/editor/various/publish-panel.spec.js
+++ b/test/e2e/specs/editor/various/publish-panel.spec.js
@@ -116,4 +116,27 @@ test.describe( 'Post publish panel', () => {
 			} )
 		).toBeFocused();
 	} );
+
+	test( 'should auto-collapse the publish panel after publishing when the user makes an edit', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'Test Post' );
+		await editor.publishPost();
+
+		const prePublishChecksToggle = page.getByRole( 'checkbox', {
+			name: 'Always show pre-publish checks.',
+		} );
+		await expect( prePublishChecksToggle ).toBeVisible();
+
+		// Make an edit after publishing.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Edit after publish' },
+		} );
+
+		await expect( prePublishChecksToggle ).toBeHidden();
+	} );
 } );


### PR DESCRIPTION
## What?

PR  'PostPublishPanel' into a function component, replaces HoC with appropriate hooks. Removes two wrapper divs and flattens the rendered DOM.

Additional changes:

* Auto-collapse effect cleanup - remove `prev.isPublished` check; it was a leftover before the `isSaving` guard and is no longer required. I also added an e2e test for the auto-collapse case.
* Focus-cancel effect cleanup - removed `setTimeout` hack, was working around a child-first lifecycle ordering against the old HoC. Behavior has e2e test coverage.

## Testing Instructions
1. Feature has good e2e test coverage.
2. Smoke test post publishing and publish panels.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Claude to validate some ideas.
