### PR TITLE
Post Content focus mode: Fix flaky e2e test

### DIFF
--- a/test/e2e/specs/editor/various/post-content-focus-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-content-focus-mode.spec.js
@@ -15,10 +15,15 @@ test.describe( 'Post Content focus mode', () => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
 
+	test.beforeEach( async ( { requestUtils } ) => {
+		// "Show template" persists the rendering mode in user preferences.
+		// Reset before each test so it starts in post-only mode regardless
+		// of state leaked from previous tests or test files in the shard.
+		await requestUtils.resetPreferences();
+	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
-		// Reset preferences so the persisted "Show template" rendering mode
-		// does not leak into subsequent test files.
 		await requestUtils.resetPreferences();
 	} );
 
@@ -113,12 +118,6 @@ test.describe( 'Post Content focus mode', () => {
 					'<!-- wp:template-part {"slug":"content-area","theme":"emptytheme"} /-->',
 				].join( '\n' ),
 			} );
-		} );
-
-		test.afterEach( async ( { requestUtils } ) => {
-			// "Show template" persists the rendering mode in user preferences.
-			// Reset between tests so each test starts in post-only mode.
-			await requestUtils.resetPreferences();
 		} );
 
 		test.afterAll( async ( { requestUtils } ) => {


### PR DESCRIPTION
## What?
Closes #77720.

PR tries to fix the flaky "Post Content focus mode" e2e test by moving `resetPreferences` to a top-level `beforeEach` and dropping the inner `afterEach`. This should cover most gaps, and `afterAll` handles test cleanup.

Based on the flaky test trace, every failure case started with "Show Template" enabled, which failed to insert a paragraph block.

## Testing Instructions
CI checks pass.