### PR TITLE
Real-time collaboration: Bundle @wordpress/sync instead of exposing as wp.sync

### DIFF
--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -30,33 +30,9 @@ Private @wordpress/sync APIs.
 
 ### Y
 
-Yjs should not be considered a public API. It is a third-party library that _will_ experience breaking changes in the future. However, in order to allow third-party plugins to provide their own Yjs providers / sync transport, they must import and consume **our instance** of Yjs due to this bug / feature:
+Yjs should not be considered a public API. It is a third-party library that _will_ experience breaking changes in the future. It is re-exported here so that internal `@wordpress/*` consumers of this bundled package have a single import path for Yjs.
 
-<https://github.com/yjs/yjs/issues/438>
-
-In other words, external code must be able to import Yjs from the `@wordpress/sync` package in their code, e.g.:
-
-```ts
-import { Y } from '@wordpress/sync';
-```
-
-Additionally, this import must resolve to `wp.sync` via `DependencyExtractionWebpackPlugin`. If you are using an older version of `@wordpress/scripts` that does not treat `@wordpress/sync` as an unbundled package, then you can use Webpack externals to manually resolve the package to the global `wp.sync` variable:
-
-```ts
-externals: {
-  ...existingConfig.externals,
-  // Resolve @wordpress/sync to the global `wp.sync` provided by WordPress.
-  '@wordpress/sync': 'wp.sync',
-
-  // Resolve Yjs to the global `wp.sync.Y` provided by the sync package.
-  // Since dependencies import 'yjs' directly, we need to avoid importing
-  // and packaging two different Yjs instances, which would result in this
-  // conflict:
-  //
-  // https://github.com/yjs/yjs/issues/438
-  yjs: 'wp.sync.Y',
-},
-```
+Note: this package is bundled into its consumers, so each consumer ends up with its own copy of Yjs. Sharing Yjs documents across separately-bundled scripts is not supported — see <https://github.com/yjs/yjs/issues/438>.
 
 ### YJS_VERSION
 

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -40,7 +40,6 @@
 		"./package.json": "./package.json"
 	},
 	"react-native": "src/index",
-	"wpScript": true,
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -1,38 +1,12 @@
 /**
  * Yjs should not be considered a public API. It is a third-party library that
- * _will_ experience breaking changes in the future. However, in order to allow
- * third-party plugins to provide their own Yjs providers / sync transport, they
- * must import and consume **our instance** of Yjs due to this bug / feature:
+ * _will_ experience breaking changes in the future. It is re-exported here so
+ * that internal `@wordpress/*` consumers of this bundled package have a single
+ * import path for Yjs.
  *
- * https://github.com/yjs/yjs/issues/438
- *
- * In other words, external code must be able to import Yjs from the
- * `@wordpress/sync` package in their code, e.g.:
- *
- * ```ts
- * import { Y } from '@wordpress/sync';
- * ```
- *
- * Additionally, this import must resolve to `wp.sync` via `DependencyExtractionWebpackPlugin`.
- * If you are using an older version of `@wordpress/scripts` that does not treat
- * `@wordpress/sync` as an unbundled package, then you can use Webpack externals
- * to manually resolve the package to the global `wp.sync` variable:
- *
- * ```ts
- * externals: {
- *   ...existingConfig.externals,
- *   // Resolve @wordpress/sync to the global `wp.sync` provided by WordPress.
- *   '@wordpress/sync': 'wp.sync',
- *
- *   // Resolve Yjs to the global `wp.sync.Y` provided by the sync package.
- *   // Since dependencies import 'yjs' directly, we need to avoid importing
- *   // and packaging two different Yjs instances, which would result in this
- *   // conflict:
- *   //
- *   // https://github.com/yjs/yjs/issues/438
- *   yjs: 'wp.sync.Y',
- * },
- * ```
+ * Note: this package is bundled into its consumers, so each consumer ends up
+ * with its own copy of Yjs. Sharing Yjs documents across separately-bundled
+ * scripts is not supported — see https://github.com/yjs/yjs/issues/438.
  */
 export * as Y from 'yjs';
 


### PR DESCRIPTION
## What?

Removes the `wpScript: true` flag from `@wordpress/sync` so it is bundled into its consumers (only `@wordpress/core-data` today) instead of being exposed on `window.wp.sync`. Reverts the externalization introduced in #74671. Updates the JSDoc and regenerated README to drop the now-stale third-party externalization guidance.

## Why?

The original design (#74671) externalized `@wordpress/sync` precisely so third-party scripts could share a single Yjs instance with WordPress (yjs#438). That trade-off is no longer worth carrying: real-time collaboration will remain behind a flag in core, so no third-party should be relying on `wp.sync` as a public extension surface. Reverting to a bundled package keeps the package surface smaller and avoids a `wp.sync` global we don't want to commit to.

Caveat carried forward from the prior design note: any external script that loads its own Yjs and tries to interop with Gutenberg's CRDT documents will hit yjs/yjs#438. With RTC behind a flag in core, this is not a use case we need to support.

## How?

- `packages/sync/package.json` — drop `"wpScript": true`. The dependency-extraction-webpack-plugin no longer rewrites `@wordpress/sync` imports to `wp.sync`; the package gets bundled into each consumer's bundle.
- `packages/sync/src/index.ts` — rewrite the `Y` re-export JSDoc to reflect the bundled reality (each consumer gets its own Yjs copy) and keep the yjs#438 link as a caveat.
- `packages/sync/README.md` — regenerated via `tools/api-docs/update-api-docs.js`.

`@wordpress/core-data` is the only in-repo consumer; it is itself `wpScript: true`, so the change is invisible to its consumers — sync simply becomes part of `wp-core-data.js`. No PHP changes needed.

## Testing Instructions

1. `npm install && npm run build`
2. Confirm `build/sync/index.js` is no longer enqueued/present as a separate `wp-sync` script handle and that `wp.sync` is undefined on `window` after loading the editor.
3. Open the post editor with collaboration enabled (`WP_ALLOW_COLLABORATION=true`) and verify CRDT editing still works (typing, undo/redo, awareness).
4. Run `npm run test:unit -- packages/sync packages/core-data`.

## Use of AI Tools

Authored with Claude Code (Opus 4.7).