### PR TITLE
Footnotes: Preserve footnotes when copying and pasting content across posts

### DIFF
--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -36,6 +36,7 @@ export const format = {
 	className: 'fn',
 	attributes: {
 		'data-fn': 'data-fn',
+		'data-fn-content': 'data-fn-content',
 	},
 	interactive: true,
 	contentEditable: false,
@@ -132,6 +133,7 @@ export const format = {
 							type: formatName,
 							attributes: {
 								'data-fn': id,
+								'data-fn-content': '',
 							},
 							innerHTML: `<a href="#${ id }" id="${ id }-link">*</a>`,
 						},

--- a/packages/core-data/src/footnotes/index.js
+++ b/packages/core-data/src/footnotes/index.js
@@ -1,14 +1,87 @@
 /**
  * WordPress dependencies
  */
+import { decodeEntities } from '@wordpress/html-entities';
 import { RichTextData, create, toHTMLString } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
  */
 import getFootnotesOrder from './get-footnotes-order';
+import getRichTextValuesCached from './get-rich-text-values-cached';
 
 let oldFootnotes = {};
+
+function getFootnotesFromRawAttributes( value, footnotesFromAttributes ) {
+	if ( typeof value === 'string' ) {
+		const regex =
+			/<sup\b[^>]*\bdata-fn="([^"]+)"[^>]*\bdata-fn-content="([^"]*)"[^>]*>/g;
+		let match;
+
+		while ( ( match = regex.exec( value ) ) !== null ) {
+			const [ , id, content ] = match;
+			if ( id && content ) {
+				footnotesFromAttributes[ id ] = decodeEntities( content );
+			}
+		}
+
+		return;
+	}
+
+	if ( Array.isArray( value ) ) {
+		value.forEach( ( item ) =>
+			getFootnotesFromRawAttributes( item, footnotesFromAttributes )
+		);
+		return;
+	}
+
+	if (
+		value &&
+		typeof value === 'object' &&
+		! ( value instanceof RichTextData )
+	) {
+		Object.values( value ).forEach( ( item ) =>
+			getFootnotesFromRawAttributes( item, footnotesFromAttributes )
+		);
+	}
+}
+
+function getFootnoteContentFromAttributes( blocks ) {
+	const footnotesFromAttributes = {};
+
+	for ( const block of blocks ) {
+		getFootnotesFromRawAttributes(
+			block.attributes,
+			footnotesFromAttributes
+		);
+
+		for ( const value of getRichTextValuesCached( block ) ) {
+			if ( ! value ) {
+				continue;
+			}
+
+			value.replacements.forEach( ( replacement ) => {
+				if ( replacement.type !== 'core/footnote' ) {
+					return;
+				}
+
+				const id = replacement.attributes?.[ 'data-fn' ];
+				const content = replacement.attributes?.[ 'data-fn-content' ];
+
+				if ( id && typeof content === 'string' && content ) {
+					footnotesFromAttributes[ id ] = content;
+				}
+			} );
+		}
+
+		Object.assign(
+			footnotesFromAttributes,
+			getFootnoteContentFromAttributes( block.innerBlocks )
+		);
+	}
+
+	return footnotesFromAttributes;
+}
 
 export function updateFootnotesFromMeta( blocks, meta ) {
 	const output = { blocks };
@@ -30,9 +103,14 @@ export function updateFootnotesFromMeta( blocks, meta ) {
 		return output;
 	}
 
+	const footnotesFromAttributes = getFootnoteContentFromAttributes( blocks );
+
 	const newFootnotes = newOrder.map(
 		( fnId ) =>
 			footnotes.find( ( fn ) => fn.id === fnId ) ||
+			( footnotesFromAttributes[ fnId ]
+				? { id: fnId, content: footnotesFromAttributes[ fnId ] }
+				: null ) ||
 			oldFootnotes[ fnId ] || {
 				id: fnId,
 				content: '',

--- a/packages/core-data/src/test/entity-provider.js
+++ b/packages/core-data/src/test/entity-provider.js
@@ -350,4 +350,157 @@ describe( 'useEntityBlockEditor', () => {
 			firstClientIds
 		);
 	} );
+
+	it( 'derives missing footnote content from block attributes when meta has no entries', () => {
+		registry
+			.dispatch( coreDataStore )
+			.receiveEntityRecords( 'postType', 'post', [
+				{
+					id: 1,
+					type: 'post',
+					content: { raw: '', rendered: '' },
+					meta: { footnotes: '[]' },
+				},
+			] );
+
+		let onChange;
+		const TestComponent = () => {
+			[ , , onChange ] = useEntityBlockEditor( 'postType', 'post', {
+				id: 1,
+			} );
+			return <div />;
+		};
+
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+
+		act( () => {
+			onChange(
+				[
+					createBlock( 'core/paragraph', {
+						content:
+							'Paragraph with footnote<sup data-fn="abcd" data-fn-content="Footnote text" class="fn"><a href="#abcd" id="abcd-link">1</a></sup>',
+					} ),
+					createBlock( 'core/footnotes' ),
+				],
+				{}
+			);
+		} );
+
+		const post = registry
+			.select( coreDataStore )
+			.getEditedEntityRecord( 'postType', 'post', 1 );
+
+		expect( JSON.parse( post.meta.footnotes ) ).toEqual( [
+			{ id: 'abcd', content: 'Footnote text' },
+		] );
+	} );
+
+	it( 'prefers existing footnote meta content over inline block attribute content', () => {
+		registry
+			.dispatch( coreDataStore )
+			.receiveEntityRecords( 'postType', 'post', [
+				{
+					id: 1,
+					type: 'post',
+					content: { raw: '', rendered: '' },
+					meta: {
+						footnotes: JSON.stringify( [
+							{ id: 'abcd', content: 'Saved footnote' },
+						] ),
+					},
+				},
+			] );
+
+		let onChange;
+		const TestComponent = () => {
+			[ , , onChange ] = useEntityBlockEditor( 'postType', 'post', {
+				id: 1,
+			} );
+			return <div />;
+		};
+
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+
+		act( () => {
+			onChange(
+				[
+					createBlock( 'core/paragraph', {
+						content:
+							'Paragraph<sup data-fn="abcd" data-fn-content="Stale attribute" class="fn"><a href="#abcd" id="abcd-link">1</a></sup>' +
+							'<sup data-fn="xyz" data-fn-content="New footnote" class="fn"><a href="#xyz" id="xyz-link">2</a></sup>',
+					} ),
+					createBlock( 'core/footnotes' ),
+				],
+				{}
+			);
+		} );
+
+		const post = registry
+			.select( coreDataStore )
+			.getEditedEntityRecord( 'postType', 'post', 1 );
+		const footnotes = JSON.parse( post.meta.footnotes );
+
+		expect( footnotes.find( ( fn ) => fn.id === 'abcd' ).content ).toBe(
+			'Saved footnote'
+		);
+		expect( footnotes.find( ( fn ) => fn.id === 'xyz' ).content ).toBe(
+			'New footnote'
+		);
+	} );
+
+	it( 'creates an empty footnote entry when no content source is available', () => {
+		registry
+			.dispatch( coreDataStore )
+			.receiveEntityRecords( 'postType', 'post', [
+				{
+					id: 1,
+					type: 'post',
+					content: { raw: '', rendered: '' },
+					meta: { footnotes: '[]' },
+				},
+			] );
+
+		let onChange;
+		const TestComponent = () => {
+			[ , , onChange ] = useEntityBlockEditor( 'postType', 'post', {
+				id: 1,
+			} );
+			return <div />;
+		};
+
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+
+		act( () => {
+			onChange(
+				[
+					createBlock( 'core/paragraph', {
+						content:
+							'Paragraph<sup data-fn="abcd" class="fn"><a href="#abcd" id="abcd-link">1</a></sup>',
+					} ),
+					createBlock( 'core/footnotes' ),
+				],
+				{}
+			);
+		} );
+
+		const post = registry
+			.select( coreDataStore )
+			.getEditedEntityRecord( 'postType', 'post', 1 );
+
+		expect( JSON.parse( post.meta.footnotes ) ).toEqual( [
+			{ id: 'abcd', content: '' },
+		] );
+	} );
 } );

--- a/packages/editor/src/components/more-menu/copy-content-menu-item.js
+++ b/packages/editor/src/components/more-menu/copy-content-menu-item.js
@@ -14,10 +14,75 @@ import { store as editorStore } from '../../store';
 
 export default function CopyContentMenuItem() {
 	const { createNotice } = useDispatch( noticesStore );
-	const { getEditedPostContent } = useSelect( editorStore );
+	const { getEditedPostContent, getEditedPostAttribute } =
+		useSelect( editorStore );
+
+	function enrichCopiedContentWithFootnotes( copiedContent ) {
+		const meta = getEditedPostAttribute( 'meta' );
+		const serializedFootnotes = meta?.footnotes;
+		if ( ! serializedFootnotes ) {
+			return copiedContent;
+		}
+
+		let footnotes;
+		try {
+			footnotes = JSON.parse( serializedFootnotes );
+		} catch {
+			return copiedContent;
+		}
+
+		if ( ! Array.isArray( footnotes ) || ! footnotes.length ) {
+			return copiedContent;
+		}
+
+		const footnotesById = footnotes.reduce( ( acc, footnote ) => {
+			if ( footnote?.id && typeof footnote.content === 'string' ) {
+				acc[ footnote.id ] = footnote.content;
+			}
+			return acc;
+		}, {} );
+
+		if ( Object.keys( footnotesById ).length === 0 ) {
+			return copiedContent;
+		}
+
+		const encodeAttribute = ( value ) =>
+			String( value )
+				.replaceAll( '&', '&amp;' )
+				.replaceAll( '"', '&quot;' )
+				.replaceAll( '<', '&lt;' )
+				.replaceAll( '>', '&gt;' );
+
+		return copiedContent.replace(
+			/<sup\b[^>]*\bdata-fn="([^"]+)"[^>]*>/g,
+			( supTag, id ) => {
+				const content = footnotesById[ id ];
+				if ( ! content ) {
+					return supTag;
+				}
+
+				const encodedContent = encodeAttribute( content );
+
+				if ( /\bdata-fn-content="[^"]*"/.test( supTag ) ) {
+					return supTag.replace(
+						/\bdata-fn-content="[^"]*"/,
+						`data-fn-content="${ encodedContent }"`
+					);
+				}
+
+				return supTag.replace(
+					'<sup',
+					`<sup data-fn-content="${ encodedContent }"`
+				);
+			}
+		);
+	}
 
 	function getText() {
-		return getEditedPostContent();
+		const copiedContent = enrichCopiedContentWithFootnotes(
+			getEditedPostContent()
+		);
+		return copiedContent;
 	}
 
 	function onSuccess() {

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -52,7 +52,7 @@ test.describe( 'Footnotes', () => {
 			{
 				name: 'core/paragraph',
 				attributes: {
-					content: `second paragraph<sup data-fn="${ id1 }" class="fn"><a href="#${ id1 }" id="${ id1 }-link">1</a></sup>`,
+					content: `second paragraph<sup data-fn="${ id1 }" data-fn-content="" class="fn"><a href="#${ id1 }" id="${ id1 }-link">1</a></sup>`,
 				},
 			},
 			{
@@ -79,13 +79,13 @@ test.describe( 'Footnotes', () => {
 			{
 				name: 'core/paragraph',
 				attributes: {
-					content: `first paragraph<sup data-fn="${ id2 }" class="fn"><a href="#${ id2 }" id="${ id2 }-link">1</a></sup>`,
+					content: `first paragraph<sup data-fn="${ id2 }" data-fn-content="" class="fn"><a href="#${ id2 }" id="${ id2 }-link">1</a></sup>`,
 				},
 			},
 			{
 				name: 'core/paragraph',
 				attributes: {
-					content: `second paragraph<sup data-fn="${ id1 }" class="fn"><a href="#${ id1 }" id="${ id1 }-link">2</a></sup>`,
+					content: `second paragraph<sup data-fn="${ id1 }" data-fn-content="" class="fn"><a href="#${ id1 }" id="${ id1 }-link">2</a></sup>`,
 				},
 			},
 			{
@@ -113,13 +113,13 @@ test.describe( 'Footnotes', () => {
 			{
 				name: 'core/paragraph',
 				attributes: {
-					content: `second paragraph<sup data-fn="${ id1 }" class="fn"><a href="#${ id1 }" id="${ id1 }-link">1</a></sup>`,
+					content: `second paragraph<sup data-fn="${ id1 }" data-fn-content="" class="fn"><a href="#${ id1 }" id="${ id1 }-link">1</a></sup>`,
 				},
 			},
 			{
 				name: 'core/paragraph',
 				attributes: {
-					content: `first paragraph<sup data-fn="${ id2 }" class="fn"><a href="#${ id2 }" id="${ id2 }-link">2</a></sup>`,
+					content: `first paragraph<sup data-fn="${ id2 }" data-fn-content="" class="fn"><a href="#${ id2 }" id="${ id2 }-link">2</a></sup>`,
 				},
 			},
 			{
@@ -145,7 +145,7 @@ test.describe( 'Footnotes', () => {
 			{
 				name: 'core/paragraph',
 				attributes: {
-					content: `second paragraph<sup data-fn="${ id1 }" class="fn"><a href="#${ id1 }" id="${ id1 }-link">1</a></sup>`,
+					content: `second paragraph<sup data-fn="${ id1 }" data-fn-content="" class="fn"><a href="#${ id1 }" id="${ id1 }-link">1</a></sup>`,
 				},
 			},
 			{
@@ -211,7 +211,7 @@ test.describe( 'Footnotes', () => {
 					{
 						name: 'core/list-item',
 						attributes: {
-							content: `1<sup data-fn="${ id1 }" class="fn"><a href="#${ id1 }" id="${ id1 }-link">1</a></sup>`,
+							content: `1<sup data-fn="${ id1 }" data-fn-content="" class="fn"><a href="#${ id1 }" id="${ id1 }-link">1</a></sup>`,
 						},
 					},
 				],
@@ -253,7 +253,7 @@ test.describe( 'Footnotes', () => {
 						{
 							cells: [
 								{
-									content: `1<sup data-fn="${ id1 }" class="fn"><a href="#${ id1 }" id="${ id1 }-link">1</a></sup>`,
+									content: `1<sup data-fn="${ id1 }" data-fn-content="" class="fn"><a href="#${ id1 }" id="${ id1 }-link">1</a></sup>`,
 									tag: 'td',
 								},
 								{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/57958
When using **Copy all blocks** and pasting into a new post, the Footnotes block appeared, but its content was empty; the actual footnote text was lost.


<!-- In a few words, what is the PR actually doing? -->

## Why?
Footnote content is stored in post meta (`meta.footnotes`), not in the serialized block HTML. When **Copy all blocks** copies the post content, it only copies the block markup, which contains footnote reference IDs (`data-fn`) but not the text content that lives in meta.

When those blocks are pasted into a different post, `updateFootnotesFromMeta` rebuilds the footnotes list from the new IDs but has no content to fill them with, so every footnote is created with `content: ''`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Three incremental changes:

**1. Enrich copied content at copy time** (`copy-content-menu-item.js`)  
Before returning the serialized block HTML to the clipboard, read `meta.footnotes` and inject `data-fn-content="<footnote text>"` onto each `<sup class="fn" data-fn="…">` tag using a string replacement. The block comment structure is preserved exactly.

**2. Register `data-fn-content` as a known format attribute** (`footnotes/format.js`)  
Added `'data-fn-content': 'data-fn-content'` to the footnote format's `attributes` map so the attribute is recognised when rich-text parses pasted HTML.

**3. Recover footnote content from pasted block attributes** (`footnotes/index.js`)  
Extended `updateFootnotesFromMeta` with two recovery paths:
- Scan raw block attribute strings for `data-fn-content` via regex (handles cases where rich-text parsing doesn't surface custom attributes).
- Walk rich-text replacement objects for `data-fn-content` (handles cases where it is surfaced).

Both paths are used as fallbacks after existing meta content (highest priority) and before the empty-string default.

NOTE:
`data-fn-content=""` will now be persisted to the database in the saved post content for every footnote, even ones that were never pasted. That's harmless functionally, but it's a permanent change to post markup that accumulates for all users going forward. If a future version of this feature wanted to strip the attribute after recovery, those existing posts would already have it embedded. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Create a new post and add a paragraph block.
2. Insert one or more footnotes via the footnote format button in the toolbar.
3. Type content for each footnote in the Footnotes block at the bottom.
4. Open the three-dots (⋮) menu → **Copy all blocks**.
5. Open a **new post** in a new tab.
6. Paste (`Cmd/Ctrl+V`) into the editor.
7. Verify the Footnotes block appears **with the correct footnote text** — not empty entries.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|Footnotes block pasted with empty entries (only ↩ arrow visible)|Footnotes block pasted with original footnote text restored|
|<img width="947" height="502" alt="image" src="https://github.com/user-attachments/assets/b1da22e2-e166-48df-8ea5-7c481132fee9" />|<img width="802" height="616" alt="image" src="https://github.com/user-attachments/assets/e810e061-3432-403d-b71a-1c9e63921612" />|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
This PR was developed with GitHub Copilot. All generated code has been reviewed, tested manually, and validated with unit tests.
