### PR TITLE
Update state support to use config instead of block supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -101,7 +101,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 -	**Name:** core/button
 -	**Category:** design
 -	**Parent:** core/buttons
--	**Supports:** anchor, color (background, gradients, text), dimensions (width), interactivity (clientNavigation), shadow, spacing (padding), splitting, states (:active, :focus, :hover), typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
+-	**Supports:** anchor, color (background, gradients, text), dimensions (width), interactivity (clientNavigation), shadow, spacing (padding), splitting, typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
 -	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textColor, title, type, url
 
 ## Buttons

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Block states support for frontend CSS generation.
+ * Block pseudo-state support for frontend CSS generation.
  *
  * Generates scoped CSS for per-instance pseudo-state styles (e.g., :hover, :focus)
  * declared in block attributes under `style[':hover']`, `style[':focus']`, etc.
@@ -9,24 +9,25 @@
  */
 
 /**
- * Renders per-instance state styles on the frontend for blocks that declare
- * `states` support.
+ * Renders per-instance pseudo-state styles on the frontend for blocks with
+ * configured pseudo-state support.
  *
  * @param string $block_content The block's rendered HTML.
  * @param array  $block         The block data including blockName and attrs.
- * @return string Modified block content with injected state styles.
+ * @return string Modified block content with injected pseudo-state styles.
  */
 function gutenberg_render_block_states_support( $block_content, $block ) {
 	if ( empty( $block['blockName'] ) || empty( $block_content ) ) {
 		return $block_content;
 	}
 
-	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	$block_name = $block['blockName'];
+	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
 	if ( ! $block_type ) {
 		return $block_content;
 	}
 
-	$supported_states = $block_type->supports['states'] ?? null;
+	$supported_states = WP_Theme_JSON_Gutenberg::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] ?? null;
 	if ( empty( $supported_states ) || ! is_array( $supported_states ) ) {
 		return $block_content;
 	}
@@ -55,15 +56,15 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 	$unique_class = 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 );
 
 	/*
-	 * Register each state's CSS rules with the block-supports style engine store.
+	 * Register each pseudo-state's CSS rules with the block-supports style engine store.
 	 * The store deduplicates rules by selector — two block instances with identical
-	 * state styles share the same hash class and therefore the same selector, so
-	 * only one CSS rule is emitted. The store is flushed to the page by
+	 * pseudo-state styles share the same hash class and therefore the same selector,
+	 * so only one CSS rule is emitted. The store is flushed to the page by
 	 * gutenberg_enqueue_stored_styles() rather than injected inline here.
 	 *
 	 * Preset utility classes (e.g. .has-accent-3-background-color) are generated
-	 * with !important, so state styles targeting the same properties must also use
-	 * !important to win. Properties without preset utility classes don't need it.
+	 * with !important, so pseudo-state styles targeting the same properties must also
+	 * use !important to win. Properties without preset utility classes don't need it.
 	 */
 	$preset_class_properties = array( 'color', 'background-color', 'border-color', 'background', 'font-size', 'font-family' );
 
@@ -89,8 +90,8 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		)
 	);
 
-	// Add the unique class to the interactive element so that state selectors
-	// like `.$unique_class:hover` match directly without needing a descendant.
+	// Add the unique class to the interactive element so that pseudo-state
+	// selectors like `.$unique_class:hover` match directly without needing a descendant.
 	// If the block declares selectors.root with a descendant (e.g. the button
 	// block's ".wp-block-button .wp-block-button__link"), we extract the last
 	// class and walk to that element. Otherwise we fall back to the wrapper.

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { getBlockSupport } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -10,17 +9,23 @@ import { __ } from '@wordpress/i18n';
 import StateControl from '../components/global-styles/state-control';
 import { BlockCardControlsFill } from '../components/block-card';
 
-export const STATES_SUPPORT_KEY = 'states';
-
-export const STATE_LABELS = {
+export const PSEUDO_STATE_LABELS = {
 	':hover': __( 'Hover' ),
 	':focus': __( 'Focus' ),
+	':focus-visible': __( 'Focus-visible' ),
 	':active': __( 'Active' ),
 };
 
+// Keep in sync with WP_Theme_JSON_Gutenberg::VALID_BLOCK_PSEUDO_SELECTORS
+// and packages/global-styles-engine/src/core/render.tsx.
+export const VALID_BLOCK_PSEUDO_STATES = {
+	'core/button': [ ':hover', ':focus', ':focus-visible', ':active' ],
+	'core/navigation-link': [ ':hover', ':focus', ':focus-visible', ':active' ],
+};
+
 /**
- * Renders a state selector (hover, focus, active) in the block card header.
- * Only shown for blocks that declare `states` support.
+ * Renders a pseudo-state selector in the block card header.
+ * Only shown for blocks with configured pseudo-state support.
  *
  * @param {Object}   props          Component props.
  * @param {string}   props.name     Block name.
@@ -29,10 +34,13 @@ export const STATE_LABELS = {
  * @return {Element|null} State control component, or null if not applicable.
  */
 export function BlockStatesControl( { name, value, onChange } ) {
-	const validStates = getBlockSupport( name, STATES_SUPPORT_KEY ) ?? [];
+	const validStates = VALID_BLOCK_PSEUDO_STATES[ name ] ?? [];
 	const stateOptions = validStates
-		.filter( ( state ) => STATE_LABELS[ state ] )
-		.map( ( state ) => ( { value: state, label: STATE_LABELS[ state ] } ) );
+		.filter( ( state ) => PSEUDO_STATE_LABELS[ state ] )
+		.map( ( state ) => ( {
+			value: state,
+			label: PSEUDO_STATE_LABELS[ state ],
+		} ) );
 
 	if ( ! stateOptions.length ) {
 		return null;

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -37,7 +37,7 @@ import {
 	useStyleOverride,
 	useBlockSettings,
 } from './utils';
-import { BlockStatesControl, STATES_SUPPORT_KEY } from './states';
+import { BlockStatesControl, VALID_BLOCK_PSEUDO_STATES } from './states';
 import { buildStateSelector, buildCanvasStateSelector } from './state-utils';
 import { BlockInspectorPreTabsFill } from '../components/block-inspector/inspector-pre-tabs-slot-fill';
 import { scopeSelector } from '../components/global-styles/utils';
@@ -534,8 +534,8 @@ function useBlockProps( { name, style } ) {
 			cssRules.push( elementCSS );
 		}
 
-		// Generate per-instance state CSS (e.g., :hover, :focus).
-		const validStates = getBlockSupport( name, STATES_SUPPORT_KEY );
+		// Generate per-instance pseudo-state CSS (e.g., :hover, :focus).
+		const validStates = VALID_BLOCK_PSEUDO_STATES[ name ];
 		if ( validStates ) {
 			validStates.forEach( ( state ) => {
 				const stateStyles = style?.[ state ];

--- a/packages/block-editor/src/hooks/test/use-block-style.js
+++ b/packages/block-editor/src/hooks/test/use-block-style.js
@@ -48,6 +48,10 @@ describe( 'useBlockStyle', () => {
 			style: {
 				color: { text: '#000000' },
 				':hover': { color: { text: '#ff0000' } },
+				mobile: {
+					color: { text: '#00ff00' },
+					':hover': { color: { text: '#ffff00' } },
+				},
 			},
 		} );
 		await act( async () => {
@@ -125,6 +129,24 @@ describe( 'useBlockStyle', () => {
 				color: { text: '#ff0000' },
 			} );
 		} );
+
+		it( 'reads a value scoped to a viewport state path', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', 'mobile' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toBe( '#00ff00' );
+		} );
+
+		it( 'reads a value scoped to a combined viewport and pseudo-state path', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', 'mobile.:hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toBe( '#ffff00' );
+		} );
 	} );
 
 	describe( 'writing values', () => {
@@ -193,6 +215,54 @@ describe( 'useBlockStyle', () => {
 			expect( style[ ':hover' ] ).toBeUndefined();
 			// Default-state styles must be left intact.
 			expect( style.color.text ).toBe( '#000000' );
+		} );
+
+		it( 'writes a value to a viewport state path without affecting the default state', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', 'mobile' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			act( () => {
+				result.current[ 1 ]( '#0000ff' );
+			} );
+
+			const { style } =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			expect( style.mobile.color.text ).toBe( '#0000ff' );
+			expect( style.color.text ).toBe( '#000000' );
+		} );
+
+		it( 'writes a value to a combined viewport and pseudo-state path', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', 'mobile.:hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			act( () => {
+				result.current[ 1 ]( '#ffffff' );
+			} );
+
+			const { style } =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			expect( style.mobile[ ':hover' ].color.text ).toBe( '#ffffff' );
+			expect( style.mobile.color.text ).toBe( '#00ff00' );
+		} );
+
+		it( 'removes empty nested state path objects when a combined value is cleared', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', 'mobile.:hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			act( () => {
+				result.current[ 1 ]( undefined );
+			} );
+
+			const { style } =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			expect( style.mobile[ ':hover' ] ).toBeUndefined();
+			expect( style.mobile.color.text ).toBe( '#00ff00' );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/hooks/use-block-style.js
+++ b/packages/block-editor/src/hooks/use-block-style.js
@@ -19,12 +19,14 @@ import { cleanEmptyObject } from './utils';
  *
  * Path uses dot notation into the style object, e.g. `'color'` or
  * `'typography.fontSize'`. Pass a separate `state` argument to scope to a
- * pseudo-state or custom state — the state key becomes the first segment of
- * the storage path:
+ * pseudo-state, custom state, viewport state, or combined state path — the
+ * state path becomes the first segments of the storage path:
  *
  *   `useBlockStyle( 'color', ':hover' )`       — `style[':hover'].color`
  *   `useBlockStyle( 'color', '@current' )`     — `style['@current'].color`
  *   `useBlockStyle( 'color', ':hover:focus' )` — compound state
+ *   `useBlockStyle( 'color', 'mobile' )`       — `style.mobile.color`
+ *   `useBlockStyle( 'color', 'mobile.:hover' )` — `style.mobile[':hover'].color`
  *
  * Omit `path` (or pass `null`) to read and write the full style object for
  * that state context, e.g. `useBlockStyle( null, ':hover' )` returns the
@@ -57,9 +59,9 @@ export function useBlockStyle( path, state ) {
 		} else {
 			stylePath = path.split( '.' );
 		}
-		return state && state !== 'default'
-			? [ state, ...stylePath ]
-			: stylePath;
+		const statePath =
+			state && state !== 'default' ? state.split( '.' ) : [];
+		return [ ...statePath, ...stylePath ];
 	}, [ path, state ] );
 
 	const value = useMemo(

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -137,8 +137,7 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
-		},
-		"states": [ ":hover", ":focus", ":active" ]
+		}
 	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -25,21 +25,23 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Registers a block with `states` support.
+	 * Registers a block for tests when the block is not already registered.
 	 *
 	 * @param string $block_name Block name.
 	 * @param array  $selectors  Optional block selectors (e.g. `['root' => '.foo .bar']`).
 	 * @return WP_Block_Type
 	 */
-	private function register_block_with_states( $block_name, $selectors = array() ) {
+	private function ensure_block_registered( $block_name, $selectors = array() ) {
+		$registered_block = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
+		if ( $registered_block ) {
+			return $registered_block;
+		}
+
 		$this->test_block_name = $block_name;
 		$args                  = array(
 			'api_version' => 3,
 			'attributes'  => array(
 				'style' => array( 'type' => 'object' ),
-			),
-			'supports'    => array(
-				'states' => array( ':hover', ':focus', ':active' ),
 			),
 		);
 		if ( ! empty( $selectors ) ) {
@@ -98,10 +100,10 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_render_block_states_support
 	 */
 	public function test_returns_unchanged_when_block_content_empty() {
-		$this->register_block_with_states( 'test/states-empty-content' );
+		$this->ensure_block_registered( 'core/navigation-link' );
 
 		$block = array(
-			'blockName' => 'test/states-empty-content',
+			'blockName' => 'core/navigation-link',
 			'attrs'     => array(
 				'style' => array(
 					':hover' => array( 'color' => array( 'text' => '#ff0000' ) ),
@@ -115,12 +117,12 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that block content is returned unchanged when `states` support is not declared.
+	 * Tests that block content is returned unchanged when the block has no configured pseudo-states.
 	 *
 	 * @covers ::gutenberg_render_block_states_support
 	 */
-	public function test_returns_unchanged_when_states_support_not_declared() {
-		$this->test_block_name = 'test/no-states-support';
+	public function test_returns_unchanged_when_block_has_no_configured_pseudo_states() {
+		$this->test_block_name = 'test/no-pseudo-state-config';
 		register_block_type(
 			$this->test_block_name,
 			array(
@@ -134,7 +136,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 
 		$block_content = '<div class="wp-block-test">Hello</div>';
 		$block         = array(
-			'blockName' => 'test/no-states-support',
+			'blockName' => 'test/no-pseudo-state-config',
 			'attrs'     => array(
 				'style' => array(
 					':hover' => array( 'color' => array( 'text' => '#ff0000' ) ),
@@ -148,16 +150,16 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that block content is returned unchanged when no state styles are set.
+	 * Tests that block content is returned unchanged when no pseudo-state styles are set.
 	 *
 	 * @covers ::gutenberg_render_block_states_support
 	 */
 	public function test_returns_unchanged_when_no_state_styles_set() {
-		$this->register_block_with_states( 'test/states-no-state-style' );
+		$this->ensure_block_registered( 'core/navigation-link' );
 
 		$block_content = '<div class="wp-block-test">Hello</div>';
 		$block         = array(
-			'blockName' => 'test/states-no-state-style',
+			'blockName' => 'core/navigation-link',
 			'attrs'     => array(
 				'style' => array(
 					'color' => array( 'text' => '#000000' ),
@@ -171,16 +173,16 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that block content is returned unchanged when the state key is an empty array.
+	 * Tests that block content is returned unchanged when the pseudo-state key is an empty array.
 	 *
 	 * @covers ::gutenberg_render_block_states_support
 	 */
 	public function test_returns_unchanged_when_state_style_is_empty_array() {
-		$this->register_block_with_states( 'test/states-empty-hover' );
+		$this->ensure_block_registered( 'core/navigation-link' );
 
 		$block_content = '<div class="wp-block-test">Hello</div>';
 		$block         = array(
-			'blockName' => 'test/states-empty-hover',
+			'blockName' => 'core/navigation-link',
 			'attrs'     => array(
 				'style' => array(
 					':hover' => array(),
@@ -199,12 +201,12 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_render_block_states_support
 	 */
 	public function test_hover_text_color_generates_scoped_css() {
-		$this->register_block_with_states( 'test/states-hover-text-color' );
+		$this->ensure_block_registered( 'core/navigation-link' );
 
 		$block_content = '<div class="wp-block-test">Hello</div>';
 		$state_styles  = array( ':hover' => array( 'color' => array( 'text' => '#e6ffe8' ) ) );
 		$block         = array(
-			'blockName' => 'test/states-hover-text-color',
+			'blockName' => 'core/navigation-link',
 			'attrs'     => array( 'style' => $state_styles ),
 		);
 
@@ -221,12 +223,12 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_render_block_states_support
 	 */
 	public function test_hover_background_color_generates_scoped_css() {
-		$this->register_block_with_states( 'test/states-hover-bg-color' );
+		$this->ensure_block_registered( 'core/navigation-link' );
 
 		$block_content = '<div class="wp-block-test">Hello</div>';
 		$state_styles  = array( ':hover' => array( 'color' => array( 'background' => '#ff00d0' ) ) );
 		$block         = array(
-			'blockName' => 'test/states-hover-bg-color',
+			'blockName' => 'core/navigation-link',
 			'attrs'     => array( 'style' => $state_styles ),
 		);
 
@@ -243,7 +245,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_render_block_states_support
 	 */
 	public function test_hover_text_and_background_color_in_same_rule() {
-		$this->register_block_with_states( 'test/states-hover-both-colors' );
+		$this->ensure_block_registered( 'core/navigation-link' );
 
 		$block_content = '<div class="wp-block-test">Hello</div>';
 		$state_styles  = array(
@@ -255,7 +257,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 			),
 		);
 		$block         = array(
-			'blockName' => 'test/states-hover-both-colors',
+			'blockName' => 'core/navigation-link',
 			'attrs'     => array( 'style' => $state_styles ),
 		);
 
@@ -273,7 +275,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_render_block_states_support
 	 */
 	public function test_hover_font_family_preset_reference_generates_css_custom_property() {
-		$this->register_block_with_states( 'test/states-hover-font-family' );
+		$this->ensure_block_registered( 'core/navigation-link' );
 
 		$block_content = '<div class="wp-block-test">Hello</div>';
 		$state_styles  = array(
@@ -282,7 +284,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 			),
 		);
 		$block         = array(
-			'blockName' => 'test/states-hover-font-family',
+			'blockName' => 'core/navigation-link',
 			'attrs'     => array( 'style' => $state_styles ),
 		);
 
@@ -299,7 +301,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_render_block_states_support
 	 */
 	public function test_hover_font_size_generates_scoped_css() {
-		$this->register_block_with_states( 'test/states-hover-font-size' );
+		$this->ensure_block_registered( 'core/navigation-link' );
 
 		$block_content = '<div class="wp-block-test">Hello</div>';
 		$state_styles  = array(
@@ -308,7 +310,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 			),
 		);
 		$block         = array(
-			'blockName' => 'test/states-hover-font-size',
+			'blockName' => 'core/navigation-link',
 			'attrs'     => array( 'style' => $state_styles ),
 		);
 
@@ -325,7 +327,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_render_block_states_support
 	 */
 	public function test_hover_border_width_and_color_generate_scoped_css() {
-		$this->register_block_with_states( 'test/states-hover-border' );
+		$this->ensure_block_registered( 'core/navigation-link' );
 
 		$block_content = '<div class="wp-block-test">Hello</div>';
 		$state_styles  = array(
@@ -337,7 +339,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 			),
 		);
 		$block         = array(
-			'blockName' => 'test/states-hover-border',
+			'blockName' => 'core/navigation-link',
 			'attrs'     => array( 'style' => $state_styles ),
 		);
 
@@ -354,7 +356,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_render_block_states_support
 	 */
 	public function test_hover_border_radius_generates_scoped_css() {
-		$this->register_block_with_states( 'test/states-hover-border-radius' );
+		$this->ensure_block_registered( 'core/navigation-link' );
 
 		$block_content = '<div class="wp-block-test">Hello</div>';
 		$state_styles  = array(
@@ -363,7 +365,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 			),
 		);
 		$block         = array(
-			'blockName' => 'test/states-hover-border-radius',
+			'blockName' => 'core/navigation-link',
 			'attrs'     => array( 'style' => $state_styles ),
 		);
 
@@ -380,15 +382,16 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_render_block_states_support
 	 */
 	public function test_multiple_states_generate_separate_css_rules() {
-		$this->register_block_with_states( 'test/states-multiple' );
+		$this->ensure_block_registered( 'core/navigation-link' );
 
 		$block_content = '<div class="wp-block-test">Hello</div>';
 		$state_styles  = array(
-			':hover' => array( 'color' => array( 'text' => '#ff0000' ) ),
-			':focus' => array( 'color' => array( 'text' => '#00ff00' ) ),
+			':hover'         => array( 'color' => array( 'text' => '#ff0000' ) ),
+			':focus'         => array( 'color' => array( 'text' => '#00ff00' ) ),
+			':focus-visible' => array( 'color' => array( 'text' => '#0000ff' ) ),
 		);
 		$block         = array(
-			'blockName' => 'test/states-multiple',
+			'blockName' => 'core/navigation-link',
 			'attrs'     => array( 'style' => $state_styles ),
 		);
 
@@ -400,18 +403,41 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that unconfigured pseudo-state keys are ignored.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_unconfigured_pseudo_state_is_ignored() {
+		$this->ensure_block_registered( 'core/navigation-link' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$block         = array(
+			'blockName' => 'core/navigation-link',
+			'attrs'     => array(
+				'style' => array(
+					':visited' => array( 'color' => array( 'text' => '#ff0000' ) ),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $block_content, $actual );
+	}
+
+	/**
 	 * Tests that the unique scoped class is added to the wrapper element for a
 	 * block with no descendant root selector.
 	 *
 	 * @covers ::gutenberg_render_block_states_support
 	 */
 	public function test_unique_class_is_added_to_wrapper_when_no_root_selector() {
-		$this->register_block_with_states( 'test/states-wrapper' );
+		$this->ensure_block_registered( 'core/navigation-link' );
 
 		$block_content = '<div class="wp-block-test">Hello</div>';
 		$state_styles  = array( ':hover' => array( 'color' => array( 'text' => '#ff0000' ) ) );
 		$block         = array(
-			'blockName' => 'test/states-wrapper',
+			'blockName' => 'core/navigation-link',
 			'attrs'     => array( 'style' => $state_styles ),
 		);
 
@@ -430,15 +456,15 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_render_block_states_support
 	 */
 	public function test_unique_class_is_added_to_descendant_not_wrapper_when_root_selector_has_descendant() {
-		$this->register_block_with_states(
-			'test/states-descendant',
+		$this->ensure_block_registered(
+			'core/button',
 			array( 'root' => '.wp-block-button .wp-block-button__link' )
 		);
 
 		$block_content = '<div class="wp-block-button"><a class="wp-block-button__link">Click me</a></div>';
 		$state_styles  = array( ':hover' => array( 'color' => array( 'background' => '#ff00d0' ) ) );
 		$block         = array(
-			'blockName' => 'test/states-descendant',
+			'blockName' => 'core/button',
 			'attrs'     => array( 'style' => $state_styles ),
 		);
 
@@ -458,8 +484,8 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_render_block_states_support
 	 */
 	public function test_button_like_block_with_hover_color_and_font_family_preset() {
-		$this->register_block_with_states(
-			'test/states-button-full',
+		$this->ensure_block_registered(
+			'core/button',
 			array( 'root' => '.wp-block-button .wp-block-button__link' )
 		);
 
@@ -477,7 +503,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 			),
 		);
 		$block = array(
-			'blockName' => 'test/states-button-full',
+			'blockName' => 'core/button',
 			'attrs'     => array( 'style' => $state_styles ),
 		);
 
@@ -495,8 +521,8 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_render_block_states_support
 	 */
 	public function test_button_like_block_with_hover_border() {
-		$this->register_block_with_states(
-			'test/states-button-border',
+		$this->ensure_block_registered(
+			'core/button',
 			array( 'root' => '.wp-block-button .wp-block-button__link' )
 		);
 
@@ -511,7 +537,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 			),
 		);
 		$block         = array(
-			'blockName' => 'test/states-button-border',
+			'blockName' => 'core/button',
 			'attrs'     => array( 'style' => $state_styles ),
 		);
 

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -613,13 +613,6 @@
 						}
 					}
 				},
-				"states": {
-					"description": "An array of interactive pseudo-states (e.g. \":hover\", \":focus\", \":active\") for which the block supports per-instance style overrides. Custom state keys are also supported for future extensibility.",
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
 				"shadow": {
 					"description": "Allow blocks to define a box shadow.",
 					"oneOf": [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Based on #76491 and proposes to merge into that branch.

I think it might be too early to consider using a public api like block supports for the states feature. Some reasons:
- Some thought still needs to go into other aspects, like what's configurable in theme.json for style-based states, so adding the block supports now feels early. Maybe the theme.json part and block supports part can be considered at the same time.
- It's not clear yet how the API might work when there are multiple types of states and what shape the API will need (https://github.com/WordPress/gutenberg/pull/76491#discussion_r3135307304).

This PR switches to using an internal config driven approach. There's already quite a lot of config for states (e.g. for the labels, for global styles rendering), so this matches the existing approaches.

The repercussion is right now third-party blocks won't be able to enable pseudo states, but I think this can be re-introduced once state-based features (responsive, pseudo and nav link current) are more finalized.

## Testing Instructions
It should work the same as in trunk:
1. Add a button or navigation link block
2. Use the dropdown next to the block name in the inspector to set a pseudo state (hover etc)
3. Check that the style applies on the frontend and editor