### PR TITLE
Experiment: Add Classic block migration notice

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -39,8 +39,8 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-dashboard-widgets' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalDashboardWidgets = true', 'before' );
 	}
-	if ( gutenberg_is_experiment_enabled( 'gutenberg-classic-block-migration-notice' ) ) {
-		wp_add_inline_script( 'wp-block-library', 'window.__experimentalClassicBlockMigrationNotice = true', 'before' );
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-classic-block-deprecation' ) ) {
+		wp_add_inline_script( 'wp-block-library', 'window.__experimentalClassicBlockDeprecation = true', 'before' );
 	}
 }
 

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -39,6 +39,9 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-dashboard-widgets' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalDashboardWidgets = true', 'before' );
 	}
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-classic-block-migration-notice' ) ) {
+		wp_add_inline_script( 'wp-block-library', 'window.__experimentalClassicBlockMigrationNotice = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -34,6 +34,11 @@ function gutenberg_initialize_experiments_settings() {
 					'label'       => __( 'Grid interactivity', 'gutenberg' ),
 					'description' => __( 'Enables enhancements to the Grid block that let you move and resize items in the editor canvas.', 'gutenberg' ),
 				),
+				array(
+					'id'          => 'gutenberg-classic-block-migration-notice',
+					'label'       => __( 'Classic block migration notice', 'gutenberg' ),
+					'description' => __( 'Shows an in-block notice on existing Classic blocks prompting authors to convert them to blocks or to a Custom HTML block. Aimed at reducing reliance on the Classic block ahead of its deprecation.', 'gutenberg' ),
+				),
 			),
 		),
 		array(

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -35,9 +35,9 @@ function gutenberg_initialize_experiments_settings() {
 					'description' => __( 'Enables enhancements to the Grid block that let you move and resize items in the editor canvas.', 'gutenberg' ),
 				),
 				array(
-					'id'          => 'gutenberg-classic-block-migration-notice',
-					'label'       => __( 'Classic block migration notice', 'gutenberg' ),
-					'description' => __( 'Shows an in-block notice on existing Classic blocks prompting authors to convert them to blocks or to a Custom HTML block. Aimed at reducing reliance on the Classic block ahead of its deprecation.', 'gutenberg' ),
+					'id'          => 'gutenberg-classic-block-deprecation',
+					'label'       => __( 'Classic block deprecation', 'gutenberg' ),
+					'description' => __( 'Enables UI changes aimed at deprecating the Classic block, including prompts on existing Classic blocks to migrate their content to blocks or to a Custom HTML block.', 'gutenberg' ),
 				),
 			),
 		),

--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -42,7 +42,7 @@ export default function FreeformEdit( {
 
 	// Gated by an experiment so authors can opt into a stronger nudge to
 	// migrate Classic block content ahead of its planned deprecation.
-	const isDeprecationMode = window.__experimentalClassicBlockMigrationNotice;
+	const isDeprecationMode = window.__experimentalClassicBlockDeprecation;
 
 	return (
 		<>

--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -22,6 +22,7 @@ import { classic } from '@wordpress/icons';
  * Internal dependencies
  */
 import ConvertToBlocksButton from './convert-to-blocks-button';
+import MigrationNotice from './migration-notice';
 import ModalEdit from './modal';
 
 export default function FreeformEdit( {
@@ -38,9 +39,14 @@ export default function FreeformEdit( {
 		[ clientId ]
 	);
 
+	// Gated by an experiment so authors can opt into a stronger nudge to
+	// migrate Classic block content ahead of its planned deprecation.
+	const showMigrationNotice =
+		!! window?.__experimentalClassicBlockMigrationNotice;
+
 	return (
 		<>
-			{ canRemove && (
+			{ canRemove && ! showMigrationNotice && (
 				<BlockControls>
 					<ToolbarGroup>
 						<ConvertToBlocksButton clientId={ clientId } />
@@ -58,6 +64,9 @@ export default function FreeformEdit( {
 				</ToolbarGroup>
 			</BlockControls>
 			<div { ...useBlockProps() }>
+				{ showMigrationNotice && (
+					<MigrationNotice clientId={ clientId } />
+				) }
 				{ content ? (
 					<RawHTML>{ content }</RawHTML>
 				) : (

--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -7,7 +7,7 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	Button,
 	Placeholder,
@@ -38,15 +38,15 @@ export default function FreeformEdit( {
 		( select ) => select( blockEditorStore ).canRemoveBlock( clientId ),
 		[ clientId ]
 	);
+	const { removeBlock } = useDispatch( blockEditorStore );
 
 	// Gated by an experiment so authors can opt into a stronger nudge to
 	// migrate Classic block content ahead of its planned deprecation.
-	const showMigrationNotice =
-		!! window?.__experimentalClassicBlockMigrationNotice;
+	const isDeprecationMode = window.__experimentalClassicBlockMigrationNotice;
 
 	return (
 		<>
-			{ canRemove && ! showMigrationNotice && (
+			{ canRemove && ! isDeprecationMode && (
 				<BlockControls>
 					<ToolbarGroup>
 						<ConvertToBlocksButton clientId={ clientId } />
@@ -64,8 +64,11 @@ export default function FreeformEdit( {
 				</ToolbarGroup>
 			</BlockControls>
 			<div { ...useBlockProps() }>
-				{ showMigrationNotice && (
-					<MigrationNotice clientId={ clientId } />
+				{ isDeprecationMode && canRemove && content && (
+					<MigrationNotice
+						clientId={ clientId }
+						content={ content }
+					/>
 				) }
 				{ content ? (
 					<RawHTML>{ content }</RawHTML>
@@ -73,13 +76,30 @@ export default function FreeformEdit( {
 					<Placeholder
 						icon={ <BlockIcon icon={ classic } /> }
 						label={ __( 'Classic' ) }
-						instructions={ __(
-							'Use the classic editor to add content.'
-						) }
+						instructions={
+							isDeprecationMode
+								? __(
+										'The Classic block is being phased out. It’s recommended to use other blocks for the best editing experience.'
+								  )
+								: __( 'Use the classic editor to add content.' )
+						}
 					>
+						{ isDeprecationMode && canRemove && (
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								onClick={ () => removeBlock( clientId ) }
+							>
+								{ __( 'Remove block' ) }
+							</Button>
+						) }
 						<Button
 							__next40pxDefaultSize
-							variant="primary"
+							variant={
+								isDeprecationMode && canRemove
+									? 'secondary'
+									: 'primary'
+							}
 							onClick={ () => setOpen( true ) }
 						>
 							{ __( 'Edit contents' ) }

--- a/packages/block-library/src/freeform/migration-notice.js
+++ b/packages/block-library/src/freeform/migration-notice.js
@@ -3,7 +3,7 @@
  */
 import { store as blockEditorStore, Warning } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { createBlock, rawHandler, serialize } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
@@ -11,46 +11,32 @@ import { __ } from '@wordpress/i18n';
  * Block-level deprecation warning rendered when the
  * `gutenberg-classic-block-migration-notice` experiment is enabled.
  *
- * Mirrors the existing `core/missing` deprecation treatment for orphaned
- * Classic blocks: a `Warning` with a primary "Convert to blocks" action and a
- * secondary "Convert to Custom HTML" escape hatch.
+ * Uses the same `Warning` primitive as `core/missing` so the experience is
+ * visually consistent with how the editor already surfaces deprecated blocks,
+ * and offers two migration actions - a primary "Convert to blocks", and a
+ * secondary "Convert to Custom HTML".
+ *
+ * Assumes the parent only mounts this component when the block can be removed
+ * and has non-empty content; both conditions are gated in `freeform/edit.js`.
  *
  * @param {Object} props
  * @param {string} props.clientId Client ID of the Classic block.
+ * @param {string} props.content  Raw HTML content of the Classic block.
  */
-export default function MigrationNotice( { clientId } ) {
+export default function MigrationNotice( { clientId, content } ) {
 	const { replaceBlocks } = useDispatch( blockEditorStore );
-
-	const { block, canRemove } = useSelect(
-		( select ) => {
-			const store = select( blockEditorStore );
-			return {
-				block: store.getBlock( clientId ),
-				canRemove: store.canRemoveBlock( clientId ),
-			};
-		},
-		[ clientId ]
-	);
-
-	if ( ! block || ! canRemove ) {
-		return null;
-	}
-
-	const content = block.attributes?.content ?? '';
-	const hasContent = !! content.trim();
 
 	const convertToBlocks = () => {
 		replaceBlocks(
-			block.clientId,
-			rawHandler( { HTML: serialize( block ) } )
+			clientId,
+			rawHandler( {
+				HTML: serialize( createBlock( 'core/freeform', { content } ) ),
+			} )
 		);
 	};
 
 	const convertToHtmlBlock = () => {
-		replaceBlocks(
-			block.clientId,
-			createBlock( 'core/html', { content } )
-		);
+		replaceBlocks( clientId, createBlock( 'core/html', { content } ) );
 	};
 
 	const actions = [
@@ -59,8 +45,6 @@ export default function MigrationNotice( { clientId } ) {
 			key="convert-to-blocks"
 			variant="primary"
 			onClick={ convertToBlocks }
-			disabled={ ! hasContent }
-			accessibleWhenDisabled
 		>
 			{ __( 'Convert to blocks' ) }
 		</Button>,
@@ -69,8 +53,6 @@ export default function MigrationNotice( { clientId } ) {
 			key="convert-to-html"
 			variant="secondary"
 			onClick={ convertToHtmlBlock }
-			disabled={ ! hasContent }
-			accessibleWhenDisabled
 		>
 			{ __( 'Convert to Custom HTML' ) }
 		</Button>,

--- a/packages/block-library/src/freeform/migration-notice.js
+++ b/packages/block-library/src/freeform/migration-notice.js
@@ -51,7 +51,7 @@ export default function MigrationNotice( { clientId, content } ) {
 			variant="secondary"
 			onClick={ convertToHtmlBlock }
 		>
-			{ __( 'Convert to Custom HTML' ) }
+			{ __( 'Convert to HTML' ) }
 		</Button>,
 	];
 

--- a/packages/block-library/src/freeform/migration-notice.js
+++ b/packages/block-library/src/freeform/migration-notice.js
@@ -1,0 +1,86 @@
+/**
+ * WordPress dependencies
+ */
+import { store as blockEditorStore, Warning } from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { createBlock, rawHandler, serialize } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Block-level deprecation warning rendered when the
+ * `gutenberg-classic-block-migration-notice` experiment is enabled.
+ *
+ * Mirrors the existing `core/missing` deprecation treatment for orphaned
+ * Classic blocks: a `Warning` with a primary "Convert to blocks" action and a
+ * secondary "Convert to Custom HTML" escape hatch.
+ *
+ * @param {Object} props
+ * @param {string} props.clientId Client ID of the Classic block.
+ */
+export default function MigrationNotice( { clientId } ) {
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+
+	const { block, canRemove } = useSelect(
+		( select ) => {
+			const store = select( blockEditorStore );
+			return {
+				block: store.getBlock( clientId ),
+				canRemove: store.canRemoveBlock( clientId ),
+			};
+		},
+		[ clientId ]
+	);
+
+	if ( ! block || ! canRemove ) {
+		return null;
+	}
+
+	const content = block.attributes?.content ?? '';
+	const hasContent = !! content.trim();
+
+	const convertToBlocks = () => {
+		replaceBlocks(
+			block.clientId,
+			rawHandler( { HTML: serialize( block ) } )
+		);
+	};
+
+	const convertToHtmlBlock = () => {
+		replaceBlocks(
+			block.clientId,
+			createBlock( 'core/html', { content } )
+		);
+	};
+
+	const actions = [
+		<Button
+			__next40pxDefaultSize
+			key="convert-to-blocks"
+			variant="primary"
+			onClick={ convertToBlocks }
+			disabled={ ! hasContent }
+			accessibleWhenDisabled
+		>
+			{ __( 'Convert to blocks' ) }
+		</Button>,
+		<Button
+			__next40pxDefaultSize
+			key="convert-to-html"
+			variant="secondary"
+			onClick={ convertToHtmlBlock }
+			disabled={ ! hasContent }
+			accessibleWhenDisabled
+		>
+			{ __( 'Convert to Custom HTML' ) }
+		</Button>,
+	];
+
+	return (
+		<Warning actions={ actions }>
+			{ __(
+				'The Classic block is being phased out. Convert this content to blocks for the best editing experience, or move it to a Custom HTML block to preserve the markup as-is.'
+			) }
+		</Warning>
+	);
+}

--- a/packages/block-library/src/freeform/migration-notice.js
+++ b/packages/block-library/src/freeform/migration-notice.js
@@ -9,15 +9,12 @@ import { __ } from '@wordpress/i18n';
 
 /**
  * Block-level deprecation warning rendered when the
- * `gutenberg-classic-block-migration-notice` experiment is enabled.
+ * `gutenberg-classic-block-deprecation` experiment is enabled.
  *
  * Uses the same `Warning` primitive as `core/missing` so the experience is
  * visually consistent with how the editor already surfaces deprecated blocks,
  * and offers two migration actions - a primary "Convert to blocks", and a
  * secondary "Convert to Custom HTML".
- *
- * Assumes the parent only mounts this component when the block can be removed
- * and has non-empty content; both conditions are gated in `freeform/edit.js`.
  *
  * @param {Object} props
  * @param {string} props.clientId Client ID of the Classic block.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of https://github.com/WordPress/gutenberg/issues/78067

Adds a new `gutenberg-classic-block-migration-notice` experiment that shows a deprecation notice inside existing Classic blocks, with one-click actions to convert the content to blocks or to a Custom HTML block.

## Why?
https://github.com/WordPress/gutenberg/pull/77911 steers new posts away from the Classic block usage. This experiment focuses instead on the existing Classic block content inside posts, and explores ways to encourage users to migrate it to native blocks - the next step on the deprecation path, before considering anything more aggressive.

## How?
- Add new experiment under "Blocks" wired to `window.__experimentalClassicBlockMigrationNotice` flag.
- The Classic block renders a `<Warning>` above its content with two actions **Convert to blocks** (`rawHandler`) and **Convert to Custom HTML** (`core/html`).
- The toolbar's Convert to blocks button is hidden while the experiment is on to avoid duplicating the action.


## Testing Instructions
1. Enable Gutenberg > Experiments > Blocks > **Classic block migration notice**.
2. Open a post that already contains a Classic block - the notice should appear above the content with both buttons.
3. Confirm **Convert to blocks** and **Convert to Custom HTML** behave as expected.
4. Disable the experiment - Classic block behaves exactly as before.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


|Before|After|
|-|-|
|<img width="678" height="415" alt="PkWCVhBv1qNpJkOC" src="https://github.com/user-attachments/assets/19be30a5-2800-4221-a08a-0e635a92395e" />|<img width="678" height="415" alt="eC7Ke3q5KQM33Ehq" src="https://github.com/user-attachments/assets/3d73fc2a-9e3e-47cb-a9a8-a58697dc53d9" />|

## Use of AI Tools

Cursor and Claude Opus 4.7
