### PR TITLE
Refactor warning component to use Text component

### DIFF
--- a/packages/block-editor/src/components/warning/index.js
+++ b/packages/block-editor/src/components/warning/index.js
@@ -9,15 +9,19 @@ import clsx from 'clsx';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
+import { Text } from '@wordpress/ui';
 
 function Warning( { className, actions, children, secondaryActions } ) {
 	return (
 		<div style={ { display: 'contents', all: 'initial' } }>
 			<div className={ clsx( className, 'block-editor-warning' ) }>
 				<div className="block-editor-warning__contents">
-					<p className="block-editor-warning__message">
+					<Text
+						className="block-editor-warning__message"
+						render={ <p /> }
+					>
 						{ children }
-					</p>
+					</Text>
 
 					{ ( actions?.length > 0 || secondaryActions ) && (
 						<div className="block-editor-warning__actions">


### PR DESCRIPTION
## What?

Part of: https://github.com/WordPress/gutenberg/issues/77265

Enhances the `Warning` component in `block-editor/src/components/warning/index.js` to improve accessibility and ensure consistent styling across the editor when displaying validation warnings and error states.

---

## Why?

The `Warning` component is used throughout the editor to display critical information about block issues (invalid blocks, crashed blocks, etc.). Standardizing its structure and behavior ensures:
* Consistent user experience across different warning scenarios
* Better alignment with the design system and UI primitives

---

## How?

* Enhanced the `Warning` component structure with by using the `Text` component from ui package

---

## Testing Instructions

1. Start the development environment:
   ```bash
   npm run wp-env start
   ```

2. Open the block editor:
   ```
   /wp-admin/post-new.php
   ```

3. Test warning scenarios:
   * **Invalid Block Warning**: Manually edit a block's HTML in the code editor to introduce invalid markup. The warning should display with action buttons to convert to Classic or HTML block.
   * **Crash Warning**: Attempt to use a block with broken rendering. Verify the error message displays correctly.

4. Inspect the DOM to ensure:
   * Styling is consistent

---

## Screenshots

### Before
<img width="1969" height="1134" alt="Screenshot 2026-05-08 at 3 54 57 PM" src="https://github.com/user-attachments/assets/004bb47e-c49d-4b1a-82aa-11b33d397770" />


### After
<img width="1943" height="984" alt="Screenshot 2026-05-08 at 4 26 28 PM" src="https://github.com/user-attachments/assets/089b6f51-9c39-4f0b-be95-6bfd2ced13de" />

---

## Use of AI Tools

* Used Copilot for PR description and commit messages
