### PR TITLE
Experiments: deprecate Classic block UI and add Convert to Blocks action

### DIFF
--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -4,10 +4,11 @@
 import {
 	BlockControls,
 	BlockIcon,
+	Warning,
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	Button,
 	Placeholder,
@@ -17,6 +18,7 @@ import {
 import { useState, useRef, RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { classic } from '@wordpress/icons';
+import { rawHandler, serialize } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -33,10 +35,37 @@ export default function FreeformEdit( {
 	const [ isOpen, setOpen ] = useState( false );
 	const editButtonRef = useRef( null );
 
-	const canRemove = useSelect(
-		( select ) => select( blockEditorStore ).canRemoveBlock( clientId ),
+	const { canRemove } = useSelect(
+		( select ) => ( {
+			canRemove: select( blockEditorStore ).canRemoveBlock( clientId ),
+		} ),
 		[ clientId ]
 	);
+
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+
+	const block = useSelect(
+		( select ) => select( blockEditorStore ).getBlock( clientId ),
+		[ clientId ]
+	);
+
+	const convertToBlocks = () => {
+		replaceBlocks(
+			block.clientId,
+			rawHandler( { HTML: serialize( block ) } )
+		);
+	};
+
+	const actions = [
+		<Button
+			__next40pxDefaultSize
+			key="convert"
+			onClick={ convertToBlocks }
+			variant="primary"
+		>
+			{ __( 'Convert to blocks' ) }
+		</Button>,
+	];
 
 	return (
 		<>
@@ -57,7 +86,12 @@ export default function FreeformEdit( {
 					</ToolbarButton>
 				</ToolbarGroup>
 			</BlockControls>
-			<div { ...useBlockProps() }>
+			<div { ...useBlockProps( { className: 'has-warning' } ) }>
+				<Warning actions={ actions }>
+					{ __(
+						'It appears you are using the deprecated Classic block. You can keep editing it for now, but it is recommended to convert it to blocks.'
+					) }
+				</Warning>
 				{ content ? (
 					<RawHTML>{ content }</RawHTML>
 				) : (

--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -35,10 +35,8 @@ export default function FreeformEdit( {
 	const [ isOpen, setOpen ] = useState( false );
 	const editButtonRef = useRef( null );
 
-	const { canRemove } = useSelect(
-		( select ) => ( {
-			canRemove: select( blockEditorStore ).canRemoveBlock( clientId ),
-		} ),
+	const canRemove = useSelect(
+		( select ) => select( blockEditorStore ).canRemoveBlock( clientId ),
 		[ clientId ]
 	);
 


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/78067

- Make the Classic block visually align with the Missing block warning UI.
- Add a visible Convert to Blocks action to support migration.

## Why?
Experiment 1 deprecates the Classic block and needs a clearer migration UX.  
This makes the deprecation state more obvious and conversion easier to find.

## How?
- Render the Classic block with warning-style UI consistent with Missing block treatment.
- Add a Convert to Blocks action in the warning flow while keeping existing edit behavior.

## Testing Instructions
1. Open the block editor for a post/page.
2. Insert a Classic block (or open content containing one).
3. Confirm the Classic block shows a warning-style deprecated UI.
4. Click **Convert to Blocks**.
5. Verify content converts into regular blocks.
6. Save and reload to confirm content persists.

## Use of AI Tools
- Used GitHub Copilot for drafting and implementation assistance; all changes were reviewed manually.