### PR TITLE
bin/dev.mjs: warn on stale webpack watching this checkout

### DIFF
--- a/bin/dev.mjs
+++ b/bin/dev.mjs
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { spawn } from 'child_process';
+import { execSync, spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import fs from 'fs';
@@ -259,4 +259,60 @@ async function dev() {
 	}
 }
 
+/**
+ * Warn if a webpack process is watching this checkout. A stale webpack
+ * dev server (e.g. left over from a previous setup) can clobber the
+ * non-minified index.js files in build/scripts/ with webpack chunk
+ * format, breaking the editor when SCRIPT_DEBUG is enabled.
+ *
+ * Best-effort and intentionally non-fatal: webpack processes that
+ * happen to be running for an unrelated project shouldn't block
+ * `npm run dev`. Match against this checkout's path (with trailing /)
+ * to avoid false positives on sibling directories.
+ */
+function checkForConflictingProcesses() {
+	try {
+		const ps = execSync( 'ps aux', { encoding: 'utf-8' } );
+		const repoPathPrefix = ROOT_DIR + '/';
+		const webpackLines = ps
+			.split( '\n' )
+			.filter(
+				( line ) =>
+					/webpack/.test( line ) &&
+					! /grep/.test( line ) &&
+					! line.includes( String( process.pid ) ) &&
+					line.includes( repoPathPrefix )
+			);
+
+		if ( webpackLines.length === 0 ) {
+			return;
+		}
+
+		const pids = webpackLines
+			.map( ( line ) => line.trim().split( /\s+/ )[ 1 ] )
+			.filter( Boolean );
+
+		console.warn(
+			`\n⚠️  Found ${ pids.length } webpack process(es) that look like they may be watching this checkout:\n`
+		);
+		for ( const line of webpackLines ) {
+			console.warn( `   ${ line.trim() }` );
+		}
+		console.warn(
+			`\nA stale webpack dev server can overwrite esbuild output in build/scripts/`
+		);
+		console.warn(
+			`with webpack chunk format, breaking the editor when SCRIPT_DEBUG is enabled.`
+		);
+		console.warn(
+			`If things look wrong, kill them with:  kill -9 ${ pids.join(
+				' '
+			) }\n`
+		);
+	} catch {
+		// If ps fails, just continue — this is a best-effort check.
+	}
+}
+
+checkForConflictingProcesses();
 dev();


### PR DESCRIPTION
## What?

Add a non-fatal startup check to \`bin/dev.mjs\` that warns if a webpack process is watching this checkout, with the offending PIDs. Best-effort, opt-out by simply not having webpack running.

## Why?

\`npm run dev\` produces output via \`wp-build\` / esbuild into \`build/scripts/\`. A stale webpack dev server still watching this checkout (left over from a pre-migration setup, or another package's watcher with overly broad globs) can clobber the non-minified \`index.js\` files in \`build/scripts/\` with webpack chunk format. The result is:

- The editor breaks silently when \`SCRIPT_DEBUG\` is enabled (the file is no longer the IIFE wp-build emitted).
- There's no obvious signal in the dev terminal that anything's wrong.

This bug bit me while developing #76204 and burned more than a couple of hours figuring out why the bundle on disk wasn't what wp-build said it had emitted. A warning at startup would have caught it immediately.

## How?

Adds a single \`checkForConflictingProcesses()\` function called before \`dev()\`. It does \`ps aux\`, filters lines that contain both \`webpack\` and this repo's path (with a trailing \`/\` so sibling directories like \`/Users/.../gutenberg-fork/\` don't false-match), and prints a warning + the matching PIDs + a kill command.

Deliberately:

- **Scoped to \`ROOT_DIR + '/'\`** so unrelated webpack processes from other projects on the same machine don't trigger false positives.
- **\`console.warn\`, not \`process.exit\`** so a misdetection can't block dev startup. If the file is silently corrupted later, the SCRIPT_DEBUG user will notice; the warning gives them a place to look first.
- **Best-effort**: a \`ps aux\` failure is swallowed silently.

## Testing Instructions

1. Run \`npm run dev\` in a clean checkout — no warning, dev starts as before.
2. From a separate terminal: \`cd $GUTENBERG && npx webpack --watch\` (or any other webpack invocation that mentions the gutenberg path).
3. Run \`npm run dev\` again — see the warning + PID. The dev process keeps running.
4. Kill the webpack watcher; warning goes away on next \`npm run dev\`.

### Testing Instructions for Keyboard

N/A — dev tooling only.