### PR TITLE
Content Types: Abstract and reuse label autofilling for post types

### DIFF
--- a/packages/content-types/src/post-types/edit.tsx
+++ b/packages/content-types/src/post-types/edit.tsx
@@ -37,6 +37,7 @@ import {
 	insertIntoItemField,
 	itemsListField,
 	itemsListNavigationField,
+	labelsActionsField,
 	labelsForm,
 	menuNameField,
 	newItemField,
@@ -153,6 +154,7 @@ function PostTypePage( {
 				showInRestField,
 				statusField,
 				// Labels
+				labelsActionsField,
 				menuNameField,
 				allItemsField,
 				addNewField,
@@ -200,9 +202,6 @@ function PostTypePage( {
 				{
 					id: 'labels',
 					label: __( 'Labels' ),
-					description: __(
-						'Override the text WordPress shows in admin lists, menus, and forms. Leave blank to use defaults derived from the plural and singular names.'
-					),
 					layout: {
 						type: 'card',
 						isCollapsible: true,

--- a/packages/content-types/src/post-types/fields/labels.tsx
+++ b/packages/content-types/src/post-types/fields/labels.tsx
@@ -8,7 +8,12 @@ import type { Form } from '@wordpress/dataviews';
  * Internal dependencies
  */
 import { createLabelField } from '../../utils/fields';
-import { STRING_LABEL_KEYS } from '../utils';
+import {
+	createLabelsActionsField,
+	LABELS_ACTIONS_FIELD_ID,
+} from '../../utils/labels';
+import type { PostTypeFormData } from '../types';
+import { deriveLabels, STRING_LABEL_KEYS } from '../utils';
 
 export const menuNameField = createLabelField( 'menu_name', __( 'Menu name' ), {
 	placeholder: __( 'Posts' ),
@@ -155,8 +160,24 @@ export const itemsListField = createLabelField(
 	}
 );
 
+export const labelsActionsField = createLabelsActionsField< PostTypeFormData >(
+	{
+		labelKeys: STRING_LABEL_KEYS,
+		deriveLabels,
+		helpText: __(
+			'Override the text WordPress shows in admin lists, menus, and forms. Auto-fill replaces every label below with values derived from the current plural and singular names — including any you have already customized. Clearing removes all overrides so WordPress falls back to its defaults. If you rename the post type after auto-filling, click Auto-fill again to keep them in sync.'
+		),
+	}
+);
+
 export const labelsForm: Form = {
 	layout: { type: 'regular' },
-	// singular_name lives in the General card, so exclude it here.
-	fields: STRING_LABEL_KEYS.filter( ( key ) => key !== 'singular_name' ),
+	fields: [
+		{
+			id: LABELS_ACTIONS_FIELD_ID,
+			layout: { type: 'regular', labelPosition: 'none' },
+		},
+		// singular_name lives in the General card, so exclude it here.
+		...STRING_LABEL_KEYS.filter( ( key ) => key !== 'singular_name' ),
+	],
 };

--- a/packages/content-types/src/post-types/utils.ts
+++ b/packages/content-types/src/post-types/utils.ts
@@ -4,6 +4,7 @@
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -60,6 +61,107 @@ export const STRING_LABEL_KEYS: ( keyof StoredLabels )[] = [
 	'items_list_navigation',
 	'items_list',
 ];
+
+export function deriveLabels(
+	plural: string,
+	singular: string
+): Omit< StoredLabels, 'singular_name' > {
+	const lcPlural = plural.toLowerCase();
+	const lcSingular = singular.toLowerCase();
+	return {
+		menu_name: plural,
+		all_items: sprintf(
+			/* translators: %s: Plural post type label. */
+			__( 'All %s' ),
+			plural
+		),
+		add_new: __( 'Add New' ),
+		add_new_item: sprintf(
+			/* translators: %s: Singular post type label. */
+			__( 'Add New %s' ),
+			singular
+		),
+		edit_item: sprintf(
+			/* translators: %s: Singular post type label. */
+			__( 'Edit %s' ),
+			singular
+		),
+		new_item: sprintf(
+			/* translators: %s: Singular post type label. */
+			__( 'New %s' ),
+			singular
+		),
+		view_item: sprintf(
+			/* translators: %s: Singular post type label. */
+			__( 'View %s' ),
+			singular
+		),
+		view_items: sprintf(
+			/* translators: %s: Plural post type label. */
+			__( 'View %s' ),
+			plural
+		),
+		search_items: sprintf(
+			/* translators: %s: Plural post type label. */
+			__( 'Search %s' ),
+			plural
+		),
+		not_found: sprintf(
+			/* translators: %s: Plural post type label, lowercase. */
+			__( 'No %s found.' ),
+			lcPlural
+		),
+		not_found_in_trash: sprintf(
+			/* translators: %s: Plural post type label, lowercase. */
+			__( 'No %s found in Trash.' ),
+			lcPlural
+		),
+		parent_item_colon: sprintf(
+			/* translators: %s: Singular post type label. */
+			__( 'Parent %s:' ),
+			singular
+		),
+		archives: sprintf(
+			/* translators: %s: Singular post type label. */
+			__( '%s Archives' ),
+			singular
+		),
+		attributes: sprintf(
+			/* translators: %s: Singular post type label. */
+			__( '%s Attributes' ),
+			singular
+		),
+		insert_into_item: sprintf(
+			/* translators: %s: Singular post type label, lowercase. */
+			__( 'Insert into %s' ),
+			lcSingular
+		),
+		uploaded_to_this_item: sprintf(
+			/* translators: %s: Singular post type label, lowercase. */
+			__( 'Uploaded to this %s' ),
+			lcSingular
+		),
+		featured_image: __( 'Featured image' ),
+		set_featured_image: __( 'Set featured image' ),
+		remove_featured_image: __( 'Remove featured image' ),
+		use_featured_image: __( 'Use as featured image' ),
+		filter_items_list: sprintf(
+			/* translators: %s: Plural post type label, lowercase. */
+			__( 'Filter %s list' ),
+			lcPlural
+		),
+		items_list_navigation: sprintf(
+			/* translators: %s: Plural post type label. */
+			__( '%s list navigation' ),
+			plural
+		),
+		items_list: sprintf(
+			/* translators: %s: Plural post type label. */
+			__( '%s list' ),
+			plural
+		),
+	};
+}
 
 export const SUPPORT_FEATURES: SupportFeature[] = [
 	'title',

--- a/packages/content-types/src/taxonomies/fields/labels.tsx
+++ b/packages/content-types/src/taxonomies/fields/labels.tsx
@@ -1,18 +1,18 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
-import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
+import type { Form } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { trash } from '@wordpress/icons';
-
-import { Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
  */
 import { createLabelField } from '../../utils/fields';
-import type { StoredLabels, TaxonomyFormData } from '../types';
+import {
+	createLabelsActionsField,
+	LABELS_ACTIONS_FIELD_ID,
+} from '../../utils/labels';
+import type { TaxonomyFormData } from '../types';
 import { deriveLabels, STRING_LABEL_KEYS } from '../utils';
 
 export const menuNameField = createLabelField( 'menu_name', __( 'Menu name' ), {
@@ -126,90 +126,19 @@ export const chooseFromMostUsedField = createLabelField(
 	}
 );
 
-function LabelsActionsEdit( {
-	data,
-	onChange,
-}: DataFormControlProps< TaxonomyFormData > ) {
-	const plural = data.title.raw.trim();
-	const singular = data.config.labels.singular_name.trim();
-	const canAutoFill = !! plural.length && !! singular.length;
-	const hasOverrides = STRING_LABEL_KEYS.some(
-		( key ) =>
-			key !== 'singular_name' &&
-			( data.config.labels[ key ] ?? '' ) !== ''
-	);
-	return (
-		<Stack direction="column" gap="md">
-			<Text variant="body-md" className="taxonomy-form__help-text">
-				{ __(
-					'Override the text WordPress shows in admin lists, menus, and forms. Auto-fill replaces every label below with values derived from the current plural and singular names — including any you have already customized. Clearing removes all overrides so WordPress falls back to its defaults. If you rename the taxonomy after auto-filling, click Auto-fill again to keep them in sync.'
-				) }
-			</Text>
-			<Stack direction="row" justify="flex-end" gap="sm">
-				<Button
-					__next40pxDefaultSize
-					variant="secondary"
-					size="compact"
-					accessibleWhenDisabled
-					disabled={ ! canAutoFill }
-					onClick={ () =>
-						onChange( {
-							config: {
-								...data.config,
-								labels: {
-									...data.config.labels,
-									...deriveLabels( plural, singular ),
-								},
-							},
-						} )
-					}
-				>
-					{ __( 'Auto-fill labels' ) }
-				</Button>
-				<Button
-					__next40pxDefaultSize
-					size="compact"
-					icon={ trash }
-					isDestructive
-					label={ __( 'Clear labels' ) }
-					accessibleWhenDisabled
-					disabled={ ! hasOverrides }
-					onClick={ () => {
-						const cleared: StoredLabels = {
-							singular_name: data.config.labels.singular_name,
-						};
-						for ( const key of STRING_LABEL_KEYS ) {
-							if ( key !== 'singular_name' ) {
-								cleared[ key ] = '';
-							}
-						}
-						onChange( {
-							config: { ...data.config, labels: cleared },
-						} );
-					} }
-				/>
-			</Stack>
-		</Stack>
-	);
-}
-
-// TODO: Replace this phantom field once DataForm supports per-card header
-// actions or arbitrary React among children. We register a no-value Field
-// solely to render the Labels card's description and action buttons,
-// suppressing its label via labelPosition: 'none'.
-export const labelsActionsField: Field< TaxonomyFormData > = {
-	id: '__labels_actions',
-	label: '',
-	getValue: () => '',
-	setValue: () => ( {} ),
-	Edit: LabelsActionsEdit,
-	enableSorting: false,
-	filterBy: false,
-};
+export const labelsActionsField = createLabelsActionsField< TaxonomyFormData >(
+	{
+		labelKeys: STRING_LABEL_KEYS,
+		deriveLabels,
+		helpText: __(
+			'Override the text WordPress shows in admin lists, menus, and forms. Auto-fill replaces every label below with values derived from the current plural and singular names — including any you have already customized. Clearing removes all overrides so WordPress falls back to its defaults. If you rename the taxonomy after auto-filling, click Auto-fill again to keep them in sync.'
+		),
+	}
+);
 
 export const labelsFormFields: Form[ 'fields' ] = [
 	{
-		id: '__labels_actions',
+		id: LABELS_ACTIONS_FIELD_ID,
 		layout: { type: 'regular', labelPosition: 'none' },
 	},
 	// singular_name lives in the General card, so exclude it here.

--- a/packages/content-types/src/utils/labels.tsx
+++ b/packages/content-types/src/utils/labels.tsx
@@ -1,0 +1,122 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import type { DataFormControlProps, Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { trash } from '@wordpress/icons';
+import { Stack, Text } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import type { ContentType } from '../types';
+
+export const LABELS_ACTIONS_FIELD_ID = '__labels_actions';
+
+interface LabelsActionsOptions {
+	labelKeys: ReadonlyArray< string >;
+	deriveLabels: (
+		plural: string,
+		singular: string
+	) => Record< string, string >;
+	helpText: string;
+}
+
+/**
+ * Builds the phantom Field rendered at the top of a Labels card. It supplies
+ * descriptive help text plus Auto-fill / Clear buttons that mutate the labels
+ * sub-record in place. Auto-fill delegates to the caller-supplied
+ * `deriveLabels` (per content type), and Clear blanks every key in
+ * `labelKeys` except `singular_name`.
+ *
+ * @param options
+ */
+export function createLabelsActionsField< T extends ContentType >(
+	options: LabelsActionsOptions
+): Field< T > {
+	const { labelKeys, deriveLabels, helpText } = options;
+
+	function LabelsActionsEdit( {
+		data,
+		onChange,
+	}: DataFormControlProps< T > ) {
+		const plural = data.title.raw.trim();
+		const singular = data.config.labels.singular_name.trim();
+		const canAutoFill = !! plural.length && !! singular.length;
+		const currentLabels = data.config.labels as Record<
+			string,
+			string | undefined
+		>;
+		const hasOverrides = labelKeys.some(
+			( key ) =>
+				key !== 'singular_name' && ( currentLabels[ key ] ?? '' ) !== ''
+		);
+		return (
+			<Stack direction="column" gap="md">
+				<Text variant="body-md">{ helpText }</Text>
+				<Stack direction="row" justify="flex-end" gap="sm">
+					<Button
+						__next40pxDefaultSize
+						variant="secondary"
+						size="compact"
+						accessibleWhenDisabled
+						disabled={ ! canAutoFill }
+						onClick={ () =>
+							onChange( {
+								config: {
+									...data.config,
+									labels: {
+										...data.config.labels,
+										...deriveLabels( plural, singular ),
+									},
+								},
+							} as Partial< T > )
+						}
+					>
+						{ __( 'Auto-fill labels' ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						size="compact"
+						icon={ trash }
+						isDestructive
+						label={ __( 'Clear labels' ) }
+						accessibleWhenDisabled
+						disabled={ ! hasOverrides }
+						onClick={ () => {
+							const cleared: Record<
+								string,
+								string | undefined
+							> = {
+								singular_name: data.config.labels.singular_name,
+							};
+							for ( const key of labelKeys ) {
+								if ( key !== 'singular_name' ) {
+									cleared[ key ] = '';
+								}
+							}
+							onChange( {
+								config: { ...data.config, labels: cleared },
+							} as Partial< T > );
+						} }
+					/>
+				</Stack>
+			</Stack>
+		);
+	}
+
+	// TODO: Replace this phantom field once DataForm supports per-card header
+	// actions or arbitrary React among children. We register a no-value Field
+	// solely to render the Labels card's description and action buttons,
+	// suppressing its label via labelPosition: 'none' at the form-fields site.
+	return {
+		id: LABELS_ACTIONS_FIELD_ID,
+		label: '',
+		getValue: () => '',
+		setValue: () => ( {} ),
+		Edit: LabelsActionsEdit,
+		enableSorting: false,
+		filterBy: false,
+	} as Field< T >;
+}


### PR DESCRIPTION
## What?
In the Content Types experiment, there is an existing functionality for auto-filling and clearing label texts for taxonomies.

This PR extracts the underlying UI into a small shared factory so both surfaces use the same component.

It also reuses that functionality in the post type editor.

Part of #77600.

## Why?
For reusability, consistency, practicality, and better user experience.

## How?
* Extract the labels auto-fill action into a shared util.
* Add labels auto-fill to post types.

## Testing Instructions
1. Enable the Content Types experiment (Gutenberg > Experiments > Content Types).
2. Go to Content Types > Post Types and click Add new.
3. Under General, enter a plural label (e.g. Books) and a singular label (e.g. Book).
4. Expand the Labels card, and verify it shows Auto-fill / Clear buttons with a help text.
5. Click Auto-fill labels. Every label field below should populate (Menu name > Books, Add new item > Add New Book,
All items > All Books, Not found > No books found., Archives > Book Archives, etc.).
6. Edit any individual label, then click Clear labels. All overrides should reset to empty (placeholders return) —
except Singular label in the General card, which is preserved.
7. Rename the post type (change either label), click Auto-fill labels again, and confirm every label updates to
match.
8. Open an existing post type and confirm the same flow: Auto-fill is gated on both names being present; Clear is
gated on at least one override being set.
9. Verify autofill still works with taxonomies: open Content Types > Taxonomies > Add new, confirm the Labels card still behaves identically to before (same help text, same buttons, same enabled/disabled states).

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

<img width="657" height="334" alt="Screenshot 2026-05-08 at 16 16 09" src="https://github.com/user-attachments/assets/acec407f-bc79-4895-828d-840cde05daeb" />


## Use of AI Tools

Opus 4.7