### PR TITLE
Block Editor: Add attachmentPagesEnabled setting and update related components

### DIFF
--- a/lib/block-editor-settings.php
+++ b/lib/block-editor-settings.php
@@ -119,6 +119,8 @@ function gutenberg_get_block_editor_settings( $settings ) {
 		$settings['spacingSizes'] = $spacing_sizes_by_origin['custom'] ?? $spacing_sizes_by_origin['theme'] ?? $spacing_sizes_by_origin['default'];
 	}
 
+	$settings['attachmentPagesEnabled'] = (bool) get_option( 'wp_attachment_pages_enabled' );
+
 	$settings['canEditCSS'] = current_user_can( 'edit_css' );
 
 	return $settings;

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -47,6 +47,7 @@ const ImageURLInputUI = ( {
 	mediaType = 'image',
 	mediaUrl,
 	mediaLink,
+	attachmentPagesEnabled = true,
 	linkTarget,
 	linkClass,
 	rel,
@@ -183,7 +184,7 @@ const ImageURLInputUI = ( {
 				icon: image,
 			},
 		];
-		if ( mediaType === 'image' && mediaLink ) {
+		if ( mediaType === 'image' && mediaLink && attachmentPagesEnabled ) {
 			linkDestinations.push( {
 				linkDestination: LINK_DESTINATION_ATTACHMENT,
 				title: __( 'Link to attachment page' ),

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -143,12 +143,6 @@ export default function GalleryEdit( props ) {
 			'dimensions.defaultAspectRatios'
 		);
 
-	const linkOptions = ! lightboxSetting?.allowEditing
-		? LINK_OPTIONS.filter(
-				( option ) => option.value !== LINK_DESTINATION_LIGHTBOX
-		  )
-		: LINK_OPTIONS;
-
 	const {
 		navigationButtonType,
 		columns,
@@ -172,6 +166,7 @@ export default function GalleryEdit( props ) {
 	const {
 		getBlock,
 		getSettings,
+		attachmentPagesEnabled,
 		innerBlockImages,
 		blockWasJustInserted,
 		multiGallerySelection,
@@ -189,6 +184,8 @@ export default function GalleryEdit( props ) {
 			return {
 				getBlock: _getBlock,
 				getSettings: _getSettings,
+				attachmentPagesEnabled:
+					_getSettings()?.attachmentPagesEnabled !== false,
 				innerBlockImages:
 					_getBlock( clientId )?.innerBlocks ?? EMPTY_ARRAY,
 				blockWasJustInserted: wasBlockJustInserted(
@@ -204,6 +201,18 @@ export default function GalleryEdit( props ) {
 			};
 		},
 		[ clientId ]
+	);
+
+	const linkOptions = (
+		! lightboxSetting?.allowEditing
+			? LINK_OPTIONS.filter(
+					( option ) => option.value !== LINK_DESTINATION_LIGHTBOX
+			  )
+			: LINK_OPTIONS
+	).filter(
+		( option ) =>
+			attachmentPagesEnabled ||
+			option.value !== LINK_DESTINATION_ATTACHMENT
 	);
 
 	const images = useMemo(
@@ -439,6 +448,14 @@ export default function GalleryEdit( props ) {
 	}
 
 	function setLinkTo( value ) {
+		// Attachment page links are not supported when attachment pages are disabled, so we prevent the user from selecting that option.
+		if (
+			value === LINK_DESTINATION_ATTACHMENT &&
+			! attachmentPagesEnabled
+		) {
+			return;
+		}
+
 		setAttributes( { linkTo: value } );
 		const changedAttributes = {};
 		const blocks = [];
@@ -467,7 +484,7 @@ export default function GalleryEdit( props ) {
 			sprintf(
 				/* translators: %s: image size settings */
 				__( 'All gallery image links updated to: %s' ),
-				linkToText.noticeText
+				linkToText?.noticeText || value
 			),
 			{
 				id: 'gallery-attributes-linkTo',

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -881,6 +881,9 @@ export default function Image( {
 							linkDestination={ linkDestination }
 							mediaUrl={ ( image && image.source_url ) || url }
 							mediaLink={ image && image.link }
+							attachmentPagesEnabled={
+								settings?.attachmentPagesEnabled !== false
+							}
 							linkTarget={ linkTarget }
 							linkClass={ linkClass }
 							rel={ rel }

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -259,6 +259,14 @@ function MediaTextEdit( {
 		[ isSelected, mediaId ]
 	);
 
+	const { attachmentPagesEnabled } = useSelect( ( select ) => {
+		return {
+			attachmentPagesEnabled:
+				select( blockEditorStore ).getSettings()
+					?.attachmentPagesEnabled !== false,
+		};
+	}, [] );
+
 	const featuredImageURL = useFeaturedImage
 		? featuredImageMedia?.source_url
 		: '';
@@ -528,6 +536,7 @@ function MediaTextEdit( {
 						mediaType={ mediaType }
 						mediaUrl={ image && image.source_url }
 						mediaLink={ image && image.link }
+						attachmentPagesEnabled={ attachmentPagesEnabled }
 						linkTarget={ linkTarget }
 						linkClass={ linkClass }
 						rel={ rel }

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -52,6 +52,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__experimentalGlobalStylesBaseStyles',
 	'allImageSizes',
 	'alignWide',
+	'attachmentPagesEnabled',
 	'blockInspectorTabs',
 	'maxUploadFileSize',
 	'allowedMimeTypes',


### PR DESCRIPTION


## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/78100


This PR adds a new block editor setting, `attachmentPagesEnabled`, and uses it to hide/disable “Link to attachment page” options in blocks when attachment pages are disabled in WordPress. This prevents users from selecting an unsupported link destination and avoids confusing UI states.

#### What changed
- **Expose a new editor setting from WP core option**
  - Adds `attachmentPagesEnabled` to block editor settings, sourced from `get_option( 'wp_attachment_pages_enabled' )`.
- **Plumb the setting through editor settings**
  - Allows `attachmentPagesEnabled` to be read from the editor settings provider (`use-block-editor-settings.js`).
- **Respect the setting in linking UIs**
  - `ImageURLInputUI`: only shows “Link to attachment page” when attachment pages are enabled.
  - `Image` block and `Media & Text` block: pass `attachmentPagesEnabled` into the shared image link UI.
  - `Gallery` block:
    - filters out the “attachment page” link option when disabled
    - guards `setLinkTo()` to prevent selecting the attachment option when not supported
    - makes the notice text resilient if `linkToText` is missing

#### Why
When attachment pages are disabled, linking to an attachment page isn’t a valid destination. This change ensures the block editor UI matches site configuration and prevents selecting an incorrect link target.

#### Testing notes
- With attachment pages **enabled**: confirm “Link to attachment page” is available for Image / Gallery / Media & Text.
- With attachment pages **disabled**: confirm the option is hidden/blocked and existing flows continue to work without errors/notices.

## Use of AI Tools

Have used Github Copilot to create the solution, verified the code with a manual review and tested it to ensure it covers all cases without breaking anything.
