### PR TITLE
Content Types: Introduce view items actions

### DIFF
--- a/packages/content-types/src/post-types/actions/view-posts.tsx
+++ b/packages/content-types/src/post-types/actions/view-posts.tsx
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import type { Action } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import type { PostTypeFormData } from '../types';
+
+const viewPostsAction: Action< PostTypeFormData > = {
+	id: 'view-posts',
+	label: __( 'View posts' ),
+	icon: external,
+	isPrimary: true,
+	// Drafts are not registered with WordPress, so `edit.php?post_type=…`
+	// would 404. Only surface the link for active post types.
+	isEligible: ( item ) => item.status === 'publish',
+	callback: ( items, { onActionPerformed } ) => {
+		const item = items[ 0 ];
+		if ( ! item?.slug ) {
+			return;
+		}
+		document.location.href = addQueryArgs( 'edit.php', {
+			post_type: item.slug,
+		} );
+		onActionPerformed?.( items );
+	},
+};
+
+export default viewPostsAction;

--- a/packages/content-types/src/post-types/list.tsx
+++ b/packages/content-types/src/post-types/list.tsx
@@ -15,6 +15,7 @@ import activateAction from './actions/activate';
 import deactivateAction from './actions/deactivate';
 import deletePostTypeAction from './actions/delete';
 import duplicatePostTypeAction from './actions/duplicate';
+import viewPostsAction from './actions/view-posts';
 import {
 	hasArchiveField,
 	hierarchicalField,
@@ -52,6 +53,7 @@ export function PostTypesList() {
 			editAction,
 			quickEditPostTypeAction,
 			duplicatePostTypeAction,
+			viewPostsAction,
 			activateAction,
 			deactivateAction,
 			deletePostTypeAction,

--- a/packages/content-types/src/taxonomies/actions/view-terms.tsx
+++ b/packages/content-types/src/taxonomies/actions/view-terms.tsx
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import type { Action } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import type { TaxonomyFormData } from '../types';
+
+const viewTermsAction: Action< TaxonomyFormData > = {
+	id: 'view-terms',
+	label: __( 'View terms' ),
+	icon: external,
+	isPrimary: true,
+	// Drafts aren't registered, and `edit-tags.php` requires a `post_type`
+	// query arg to render the term list, so the taxonomy must also be
+	// attached to at least one post type.
+	isEligible: ( item ) =>
+		item.status === 'publish' &&
+		Array.isArray( item.config.object_type ) &&
+		item.config.object_type.length > 0,
+	callback: ( items, { onActionPerformed } ) => {
+		const item = items[ 0 ];
+		const postType = item?.config.object_type?.[ 0 ];
+		if ( ! item?.slug || ! postType ) {
+			return;
+		}
+		document.location.href = addQueryArgs( 'edit-tags.php', {
+			taxonomy: item.slug,
+			post_type: postType,
+		} );
+		onActionPerformed?.( items );
+	},
+};
+
+export default viewTermsAction;

--- a/packages/content-types/src/taxonomies/list.tsx
+++ b/packages/content-types/src/taxonomies/list.tsx
@@ -15,6 +15,7 @@ import activateAction from './actions/activate';
 import deactivateAction from './actions/deactivate';
 import deleteTaxonomyAction from './actions/delete';
 import duplicateTaxonomyAction from './actions/duplicate';
+import viewTermsAction from './actions/view-terms';
 import {
 	hierarchicalField,
 	publicField,
@@ -50,6 +51,7 @@ export function TaxonomiesList() {
 			editAction,
 			quickEditTaxonomyAction,
 			duplicateTaxonomyAction,
+			viewTermsAction,
 			activateAction,
 			deactivateAction,
 			deleteTaxonomyAction,


### PR DESCRIPTION
## What?

Adds a primary "View posts" / "View terms" action to each row in the Content Types DataViews lists, providing a one-click jump from a CPT/taxonomy definition to its corresponding admin list screen.

Part of #77600.

## Why?

The Content Types screens let users define post types and taxonomies, but there was no easy way to jump from a definition to the actual posts/terms it produces. 

## How?

- Adds two new DataViews actions:
  - View posts: navigates to `edit.php?post_type={slug}`.
  - View terms: navigates to `edit-tags.php?taxonomy={slug}&post_type={postType}`
- Both `isPrimary: true`, so they appear inline on row hover alongside the kebab menu.
- Eligibility:
  - Post types: only when status is `'publish'` (drafts aren't registered and would 404).
  - Taxonomies: only when active and attached to one or more post type.
- The actions navigate to the corresponding posts/terms list
- Both actions are wired into their respective DV lists.

## Testing Instructions

1. Enable the Content Types experiment and visit the Content Types admin screen.
2. Create a post type (e.g. `book`) and activate it; create a taxonomy (e.g. `genre`) attached to that post type and activate it.
3. On the Post Types tab, hover the `book` row > confirm a "View posts" button with the external icon appears next to the kebab menu.
4. Click "View posts" > confirm the same tab navigates to `edit.php?post_type=book` and shows the posts list for that CPT.
5. Deactivate `book` (set to draft) > confirm the "View posts" action no longer appears for that row.
6. On the Taxonomies tab, hover the `genre` row > confirm "View terms" appears.
7. Click it > confirm navigation to `edit-tags.php?taxonomy=genre&post_type=book`.
8. Detach `genre` from all post types > confirm "View terms" disappears for that row.
9. Verify the actions are also listed inside the kebab (overflow) menu for both rows.

### Testing Instructions for Keyboard

Same

## Screenshots or screencast

<img width="242" height="297" alt="Screenshot 2026-05-08 at 17 28 24" src="https://github.com/user-attachments/assets/52ba8260-226b-4cb3-987c-80e91f5ed9b2" />
<img width="236" height="246" alt="Screenshot 2026-05-08 at 17 28 16" src="https://github.com/user-attachments/assets/230f23fb-6246-44e8-9260-d21d59509206" />


## Use of AI Tools

Claude Code with Opus 4.7
