### PR TITLE
Block Pattern: Fix "Change design" button not appearing when pattern is inserted with `/`

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -6,7 +6,7 @@ import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
 	store as blocksStore,
-	parse,
+	cloneBlock,
 } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useMemo } from '@wordpress/element';
@@ -54,7 +54,7 @@ const useBlockTypesState = ( rootClientId, onInsert, isQuick ) => {
 
 	const onSelectItem = useCallback(
 		(
-			{ name, initialAttributes, innerBlocks, syncStatus, content },
+			{ name, initialAttributes, innerBlocks, syncStatus, blocks },
 			shouldFocusBlock
 		) => {
 			const destinationClientId = getClosestAllowedInsertionPoint(
@@ -79,9 +79,7 @@ const useBlockTypesState = ( rootClientId, onInsert, isQuick ) => {
 
 			const insertedBlock =
 				syncStatus === 'unsynced'
-					? parse( content, {
-							__unstableSkipMigrationLogs: true,
-					  } )
+					? ( blocks ?? [] ).map( ( block ) => cloneBlock( block ) )
 					: createBlock(
 							name,
 							initialAttributes,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2342,7 +2342,10 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 							foreground: 'var(--wp-block-synced-color)',
 					  }
 					: symbol;
-				const userPattern = mapUserPattern( reusableBlock );
+				const userPattern = mapUserPattern(
+					reusableBlock,
+					state.settings.__experimentalUserPatternCategories
+				);
 				const { time, count = 0 } =
 					getInsertUsage( state, userPattern.name ) || {};
 				const frecency = calculateFrecency( time, count );
@@ -2467,6 +2470,7 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 			unlock( select( STORE_NAME ) ).getReusableBlocks(),
 			state.blocks.order,
 			state.preferences.insertUsage,
+			state.settings.__experimentalUserPatternCategories,
 			...getInsertBlockTypeDependants( select )( state, rootClientId ),
 		]
 	)


### PR DESCRIPTION
## What?
When inserting an unsynced block pattern via the `/` slash command (or the Blocks tab of the inserter), the "Change design" toolbar button (pattern shuffle) never appeared, even though patterns with the same category existed.
Closes #63068
## Why?
`getInserterItems` called `mapUserPattern` **without** passing `__experimentalUserPatternCategories`. This meant `userPattern.categories` contained raw numeric IDs (e.g. `[5]`) instead of slugs (e.g. `["tester"]`). `getParsedPattern` then stored those IDs in `metadata.categories`. The `ChangeDesign` component compares `metadata.categories` against slug-based categories from `__experimentalGetAllowedPatterns` — the types never matched, so no patterns were found in the same category and the button was hidden.

Inserting via the `+` Patterns tab went through `getAllPatterns`, which *does* pass the category mapping, so that path worked correctly.

## How?
- Pass `state.settings.__experimentalUserPatternCategories` to `mapUserPattern` inside `getInserterItems` so the resulting `userPattern.categories` contains slugs consistently with the rest of the system.
- Add `state.settings.__experimentalUserPatternCategories` to the `createSelector` memoization dependency array.
- In `use-block-types-state` `onSelectItem`, replace `parse(content)` (which produced blocks with no metadata at all) with the pre-parsed `blocks` getter (already returned by `getInserterItems`), cloning each block to avoid mutating the cache.

## Testing Instructions
1. Create at least one unsynced block pattern that contains a group block, and assign it a category.
2. Create a second unsynced pattern in the **same category**.
3. In a page/post, type `/` and insert the pattern via the slash command.
4. Click the inserted pattern block — the **"Change design"** button should now appear in the toolbar. 
5. Repeat by inserting via the `+` button → Patterns tab and confirm it still works. 

