### PR TITLE
UI: Add missing `Portal` subcomponents to Storybook

### DIFF
--- a/packages/ui/src/alert-dialog/stories/index.story.tsx
+++ b/packages/ui/src/alert-dialog/stories/index.story.tsx
@@ -12,6 +12,7 @@ const meta: Meta< typeof AlertDialog.Root > = {
 	component: AlertDialog.Root,
 	subcomponents: {
 		'AlertDialog.Trigger': AlertDialog.Trigger,
+		'AlertDialog.Portal': AlertDialog.Portal,
 		'AlertDialog.Popup': AlertDialog.Popup,
 	},
 	argTypes: {

--- a/packages/ui/src/dialog/stories/index.story.tsx
+++ b/packages/ui/src/dialog/stories/index.story.tsx
@@ -10,6 +10,7 @@ const meta: Meta< typeof Dialog.Root > = {
 	component: Dialog.Root,
 	subcomponents: {
 		'Dialog.Trigger': Dialog.Trigger,
+		'Dialog.Portal': Dialog.Portal,
 		'Dialog.Popup': Dialog.Popup,
 		'Dialog.Header': Dialog.Header,
 		'Dialog.Title': Dialog.Title,

--- a/packages/ui/src/form/primitives/autocomplete/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/stories/index.story.tsx
@@ -12,6 +12,7 @@ const meta: Meta< typeof Autocomplete.Root > = {
 	title: 'Design System/Components/Form/Primitives/Autocomplete',
 	component: Autocomplete.Root,
 	subcomponents: {
+		Portal: Autocomplete.Portal,
 		Popup: Autocomplete.Popup,
 		Input: Autocomplete.Input,
 		InputGroup: Autocomplete.InputGroup,

--- a/packages/ui/src/form/primitives/select/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/select/stories/index.story.tsx
@@ -6,6 +6,7 @@ const meta: Meta< typeof Select.Root > = {
 	component: Select.Root,
 	subcomponents: {
 		Trigger: Select.Trigger,
+		Portal: Select.Portal,
 		Popup: Select.Popup,
 		Item: Select.Item,
 	},


### PR DESCRIPTION
## What?
Adds missing `Portal` entries to Storybook `subcomponents` metadata for portal-aware `@wordpress/ui` components.

## Why?
Components that support a `portal` prop should expose their `Portal` subcomponent in Storybook Docs, so consumers can discover the supported portal customization API.

## How?
Adds the `Portal` subcomponent to the Storybook metadata for:

- AlertDialog
- Dialog
- Autocomplete
- Select

## Testing Instructions
1. Open Storybook.
2. Check the Docs pages for AlertDialog, Dialog, Autocomplete, and Select.
3. Confirm `Portal` appears in the subcomponents list for each component.
