### PR TITLE
Fix lockfile drift and missing dep from content-types consolidation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58426,6 +58426,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/admin-ui": "file:../admin-ui",
+				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/core-data": "file:../core-data",
@@ -62860,44 +62861,6 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"packages/user-post-types": {
-			"name": "@wordpress/user-post-types",
-			"version": "1.0.0",
-			"extraneous": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/components": "file:../components",
-				"@wordpress/core-data": "file:../core-data",
-				"@wordpress/data": "file:../data",
-				"@wordpress/dataviews": "file:../dataviews",
-				"@wordpress/element": "file:../element",
-				"@wordpress/i18n": "file:../i18n",
-				"@wordpress/icons": "file:../icons",
-				"@wordpress/notices": "file:../notices",
-				"@wordpress/private-apis": "file:../private-apis",
-				"@wordpress/ui": "file:../ui",
-				"@wordpress/url": "file:../url"
-			}
-		},
-		"packages/user-taxonomies": {
-			"name": "@wordpress/user-taxonomies",
-			"version": "1.0.0",
-			"extraneous": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/components": "file:../components",
-				"@wordpress/core-data": "file:../core-data",
-				"@wordpress/data": "file:../data",
-				"@wordpress/dataviews": "file:../dataviews",
-				"@wordpress/element": "file:../element",
-				"@wordpress/i18n": "file:../i18n",
-				"@wordpress/icons": "file:../icons",
-				"@wordpress/notices": "file:../notices",
-				"@wordpress/private-apis": "file:../private-apis",
-				"@wordpress/ui": "file:../ui",
-				"@wordpress/url": "file:../url"
-			}
-		},
 		"packages/viewport": {
 			"name": "@wordpress/viewport",
 			"version": "6.45.0",
@@ -63356,26 +63319,6 @@
 				"@wordpress/route": "file:../../packages/route"
 			}
 		},
-		"routes/post-types": {
-			"name": "@wordpress/post-types-route",
-			"version": "1.0.0",
-			"extraneous": true,
-			"dependencies": {
-				"@wordpress/admin-ui": "file:../../packages/admin-ui",
-				"@wordpress/base-styles": "file:../../packages/base-styles",
-				"@wordpress/components": "file:../../packages/components",
-				"@wordpress/core-data": "file:../../packages/core-data",
-				"@wordpress/data": "file:../../packages/data",
-				"@wordpress/dataviews": "file:../../packages/dataviews",
-				"@wordpress/element": "file:../../packages/element",
-				"@wordpress/i18n": "file:../../packages/i18n",
-				"@wordpress/icons": "file:../../packages/icons",
-				"@wordpress/notices": "file:../../packages/notices",
-				"@wordpress/route": "file:../../packages/route",
-				"@wordpress/ui": "file:../../packages/ui",
-				"@wordpress/user-post-types": "file:../../packages/user-post-types"
-			}
-		},
 		"routes/post-types-list": {
 			"name": "@wordpress/post-types-list-route",
 			"version": "1.0.0",
@@ -63402,26 +63345,6 @@
 				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
 				"@wordpress/route": "file:../../packages/route",
 				"@wordpress/url": "file:../../packages/url"
-			}
-		},
-		"routes/taxonomies": {
-			"name": "@wordpress/taxonomies-route",
-			"version": "1.0.0",
-			"extraneous": true,
-			"dependencies": {
-				"@wordpress/admin-ui": "file:../../packages/admin-ui",
-				"@wordpress/base-styles": "file:../../packages/base-styles",
-				"@wordpress/components": "file:../../packages/components",
-				"@wordpress/core-data": "file:../../packages/core-data",
-				"@wordpress/data": "file:../../packages/data",
-				"@wordpress/dataviews": "file:../../packages/dataviews",
-				"@wordpress/element": "file:../../packages/element",
-				"@wordpress/i18n": "file:../../packages/i18n",
-				"@wordpress/icons": "file:../../packages/icons",
-				"@wordpress/notices": "file:../../packages/notices",
-				"@wordpress/route": "file:../../packages/route",
-				"@wordpress/ui": "file:../../packages/ui",
-				"@wordpress/user-taxonomies": "file:../../packages/user-taxonomies"
 			}
 		},
 		"routes/taxonomies-list": {

--- a/packages/content-types/package.json
+++ b/packages/content-types/package.json
@@ -34,6 +34,7 @@
 	"types": "build-types",
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../admin-ui",
+		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/core-data": "file:../core-data",


### PR DESCRIPTION
## What?

Follow up to #78059.

Cleans up two issues left behind by the content-types consolidation:

1. Removes four stale workspace entries from `package-lock.json` that were marked `"extraneous": true` after the rename/removal of workspaces in #78059.
2. Adds a missing `@wordpress/base-styles` dependency to the new `@wordpress/content-types` package.

## Why?

#78059 deleted two workspaces (`packages/user-post-types`, `packages/user-taxonomies`) and renamed two more (`routes/post-types` → `routes/post-types-list`, `routes/taxonomies` → `routes/taxonomies-list`), but the corresponding entries in `package-lock.json` were never pruned — they remained in the lockfile flagged `"extraneous": true`.

This is a known limitation in npm itself: when a workspace is removed or renamed, npm marks the lockfile entry as extraneous instead of pruning it, and no `npm` CLI command (`install`, `install --package-lock-only`, `prune`, `dedupe`, `uninstall -w`) actually removes it. See [npm/cli#5463](https://github.com/npm/cli/issues/5463) and related [npm/cli#2056](https://github.com/npm/cli/issues/2056), [npm/cli#3141](https://github.com/npm/cli/issues/3141). The only reliable fixes are regenerating the lockfile from scratch or editing it directly.

Separately, while reviewing the new `@wordpress/content-types` package I noticed it was missing a `@wordpress/base-styles` dependency that it relies on. Adding it here so it doesn't drift further.

## How?

-   Removed the four extraneous workspace blocks from `package-lock.json` (`packages/user-post-types`, `packages/user-taxonomies`, `routes/post-types`, `routes/taxonomies`). The newly-named workspaces (`packages/content-types`, `routes/post-types-list`, `routes/taxonomies-list`) are already present in the lockfile and are unchanged.
-   Added `"@wordpress/base-styles": "file:../base-styles"` to `packages/content-types/package.json`.

## Testing Instructions

1. Pull the branch and run `npm install` — it should complete without rewriting the lockfile or warning about extraneous workspaces.
2. Confirm there are no remaining stale entries:
    ```bash
    grep -E '"(packages/user-post-types|packages/user-taxonomies|routes/post-types"|routes/taxonomies")' package-lock.json
    # (no output expected)
    ```
3. Confirm no workspace entry is marked extraneous:
    ```bash
    node -e "const p = require('./package-lock.json').packages; for (const [k, v] of Object.entries(p)) if (v.extraneous && !k.includes('node_modules')) console.log(k)"
    # (no output expected)
    ```
4. Run `npm run build` and verify the build still passes.
5. Optionally smoke-test post-types / taxonomies admin screens to confirm the renamed routes still load.

### Testing Instructions for Keyboard

N/A — no UI changes.

## Screenshots or screencast

N/A — lockfile and dependency manifest changes only.

## Use of AI Tools

Claude Code (Opus 4.7) was used to draft this PR description.
