### PR TITLE
Fix: Guard require_once calls in generated PHP files against deployment race conditions

### DIFF
--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1243,7 +1243,10 @@ async function generatePagesPhp( pageData, replacements ) {
 	// Generate pages.php loader
 	const pageIncludes = pageData
 		.map( ( page ) => {
-			return `require_once __DIR__ . '/pages/${ page.slug }/page.php';\nrequire_once __DIR__ . '/pages/${ page.slug }/page-wp-admin.php';`;
+			return [
+				`if ( file_exists( __DIR__ . '/pages/${ page.slug }/page.php' ) ) {\n\trequire_once __DIR__ . '/pages/${ page.slug }/page.php';\n}`,
+				`if ( file_exists( __DIR__ . '/pages/${ page.slug }/page-wp-admin.php' ) ) {\n\trequire_once __DIR__ . '/pages/${ page.slug }/page-wp-admin.php';\n}`,
+			].join( '\n' );
 		} )
 		.join( '\n' );
 

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1241,14 +1241,19 @@ async function generatePagesPhp( pageData, replacements ) {
 	await Promise.all( pageGenerationPromises );
 
 	// Generate pages.php loader
-	const pageIncludes = pageData
-		.map( ( page ) => {
-			return [
-				`if ( file_exists( __DIR__ . '/pages/${ page.slug }/page.php' ) ) {\n\trequire_once __DIR__ . '/pages/${ page.slug }/page.php';\n}`,
-				`if ( file_exists( __DIR__ . '/pages/${ page.slug }/page-wp-admin.php' ) ) {\n\trequire_once __DIR__ . '/pages/${ page.slug }/page-wp-admin.php';\n}`,
-			].join( '\n' );
-		} )
-		.join( '\n' );
+	const pageFiles = pageData.flatMap( ( page ) => [
+		`\t__DIR__ . '/pages/${ page.slug }/page.php'`,
+		`\t__DIR__ . '/pages/${ page.slug }/page-wp-admin.php'`,
+	] );
+	const pageIncludes = [
+		'foreach ( [',
+		pageFiles.join( ',\n' ) + ',',
+		'] as $file ) {',
+		'\tif ( file_exists( $file ) ) {',
+		'\t\trequire_once $file;',
+		'\t}',
+		'}',
+	].join( '\n' );
 
 	await generatePhpFromTemplate(
 		'pages.php.template',

--- a/packages/wp-build/templates/module-registration.php.template
+++ b/packages/wp-build/templates/module-registration.php.template
@@ -21,7 +21,11 @@ function {{PREFIX}}_register_script_modules() {
 	$already_registered = true;
 
 	// Load build constants
-	$build_constants = require __DIR__ . '/constants.php';
+	$constants_file = __DIR__ . '/constants.php';
+	if ( ! file_exists( $constants_file ) ) {
+		return;
+	}
+	$build_constants = require $constants_file;
 	$modules_dir     = __DIR__ . '/modules';
 	$modules_file    = $modules_dir . '/registry.php';
 


### PR DESCRIPTION
Adds `file_exists()` guards around `require`/`require_once` calls in two auto-generated build files to prevent fatal errors during rolling deployments.

## Why?
During a rolling deployment, individual files can become available at different times. If `pages.php` or `modules.php` is loaded before their dependencies (`pages/*/page.php`, `pages/*/page-wp-admin.php`, or `constants.php`) have finished deploying, PHP throws a fatal error.

## How?
- `packages/wp-build/lib/build.mjs`: Updates the `pageIncludes` generator to collect all page file paths into a flat array and iterate over them with a foreach loop containing a single `file_exists()` guard, so `build/pages.php` skips any page files that haven't arrived yet.
- `packages/wp-build/templates/module-registration.php.template`: Guards the `require __DIR__ . '/constants.php'` call with a `file_exists()` check and early return, consistent with the existing guard already in place for `modules/registry.php`.

## Testing Instructions
1. Run `npm run build`.
2. Open `build/pages.php` and verify the page file includes use a `foreach` loop over an array of paths, with each file loaded only if `file_exists()` returns true.
3. Open `build/modules.php` and verify `constants.php` is loaded via a `file_exists()` guard before `require`.

## Use of AI Tools

This PR was created with the assistance of Claude Code (claude.ai/code). All changes were reviewed and verified manually.