### PR TITLE
Post Date block: Always show modified date for newly published posts

### DIFF
--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -47,13 +47,32 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 	}
 
 	if ( empty( $attributes['datetime'] ) ) {
-		// If the `datetime` attribute is set but empty, it could be because Block Bindings
-		// set it that way. This can happen e.g. if the block is bound to the
-		// post's last modified date, and the latter lies before the publish date.
+		// If the `datetime` attribute is empty, it could be because Block Bindings
+		// set it that way when the modified date is before the publish date.
 		// (See https://github.com/WordPress/gutenberg/pull/46839 where this logic was originally
 		// implemented.)
-		// In this case, we have to respect and return the empty value.
-		return '';
+		//
+		// However, when a post is first published, WordPress sets post_modified equal to
+		// post_date. In that case we still want to render the modified date.
+		// Detect this scenario and fall back to the actual modified date.
+		// See https://github.com/WordPress/gutenberg/issues/57915.
+		$post_id = $block->context['postId'] ?? null;
+
+		// Determine whether this block is displaying the modified date — either via
+		// the legacy displayType attribute or via a Block Bindings binding.
+		$binding_args  = $attributes['metadata']['bindings']['datetime']['args'] ?? array();
+		$binding_field = $binding_args['field'] ?? $binding_args['key'] ?? null;
+		$is_modified   = ( isset( $source_args['field'] ) && 'modified' === $source_args['field'] )
+			|| 'modified' === $binding_field;
+
+		if ( $post_id && $is_modified
+			&& get_the_modified_date( 'U', $post_id ) >= get_the_date( 'U', $post_id ) ) {
+			// Modified date is equal to or later than publish date — render it.
+			$attributes['datetime'] = esc_attr( get_the_modified_date( 'c', $post_id ) );
+		} else {
+			// Modified date is strictly before the publish date; respect the empty value.
+			return '';
+		}
 	}
 
 	$unformatted_date = $attributes['datetime'];


### PR DESCRIPTION
## What?

Fixes the Post Date block so that when set to display the last modified date, it always shows a date for newly published posts (where `post_modified` equals `post_date`), instead of rendering nothing.

Closes #57915.

## Why?

Previously, the block bindings source for `core/post-data` would return an empty value if the modified date was not strictly after the publish date. This caused the Post Date block to render nothing for newly published posts, even though the modified date is valid and expected to be shown.

## How?

The fix is implemented directly in the block’s render callback (`render_block_core_post_date`). When the block is set to display the modified date and the `datetime` attribute is empty, the callback checks if the post’s modified date is equal to or later than the publish date. If so, it falls back to rendering the modified date. This ensures the block always displays a date for new posts, without affecting other blocks or the block bindings source.

## Testing Instructions

1. Create a new post.
2. Add a Post Date block set to “Display last modified date” (or use the “Modified Date” variation).
3. Publish the post without making further edits.
4. View the post on the frontend — the block should now display the date instead of being empty.
5. Confirm that posts where the modified date is strictly before the publish date (e.g. scheduled posts) still render nothing for the modified date block.

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/user-attachments/assets/908a20df-5849-47b1-84c6-4629d9e15563


After:

https://github.com/user-attachments/assets/908a4a4e-933d-4efd-b5af-0bc9610e50d6

