### PR TITLE
Select: Fix disabled cursor styles

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+-   `Autocomplete`, `Select`: Do not show the interactive cursor for disabled select triggers or disabled popup items ([#78112](https://github.com/WordPress/gutenberg/pull/78112)).
 -   `Select`: Hide the browser focus ring on highlighted popup items ([#77919](https://github.com/WordPress/gutenberg/pull/77919)).
 -   `Drawer`: Restore the slide-out animation when the popup closes ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).
 -   `Drawer`: Forward the `render` prop on `Drawer.Content` to the scroll container instead of leaking it as a DOM attribute, matching `Dialog.Content` ([#77941](https://github.com/WordPress/gutenberg/pull/77941)).

--- a/packages/ui/src/utils/css/item-popup.module.css
+++ b/packages/ui/src/utils/css/item-popup.module.css
@@ -59,7 +59,6 @@
 		align-items: center;
 		justify-content: flex-start;
 		gap: var(--wpds-dimension-gap-xs);
-		cursor: var(--wpds-cursor-control);
 		min-height: var(--wp-ui-popup-item-height);
 		border-radius: var(--wpds-border-radius-sm);
 		user-select: none;
@@ -69,6 +68,10 @@
 		/* Optically adjust the prefix icon to a more balanced position. */
 		padding-inline-start: calc(var(--wp-ui-popup-item-padding-inline) - 4px);
 		padding-inline-end: var(--wp-ui-popup-item-padding-inline);
+
+		&:not([data-disabled]) {
+			cursor: var(--wpds-cursor-control);
+		}
 
 		&.is-size-compact {
 			--wp-ui-popup-item-height: 32px;

--- a/packages/ui/src/utils/css/select-trigger.module.css
+++ b/packages/ui/src/utils/css/select-trigger.module.css
@@ -26,8 +26,11 @@
 		font-size: inherit;
 		line-height: 1.4;
 		text-align: start;
-		cursor: var(--wpds-cursor-control);
 		user-select: none;
+
+		&:not([data-disabled]) {
+			cursor: var(--wpds-cursor-control);
+		}
 
 		&.is-minimal {
 			width: auto;


### PR DESCRIPTION
## What?

Fixes cursor styles for disabled `@wordpress/ui` select controls so disabled triggers and popup items do not use the interactive control cursor.

Also fixes it for disabled items in `Autocomplete`.

## Why?

Disabled controls should not visually imply that they can be interacted with.

## How?

Applies `cursor: var(--wpds-cursor-control)` only when the select trigger or popup item does not have `data-disabled`.

## Testing Instructions

1. Run Storybook for `@wordpress/ui`.
2. Open `Design System/Components/Form/Primitives/Select`.
3. Check the `Disabled` story and confirm the disabled trigger does not show the interactive control cursor.
4. Check the `With Disabled Item` story, open the select, and confirm the disabled item does not show the interactive control cursor while enabled items still do.