### PR TITLE
Classic Block: Use onReplace prop for migration actions

### DIFF
--- a/packages/block-library/src/freeform/convert-to-blocks-button.js
+++ b/packages/block-library/src/freeform/convert-to-blocks-button.js
@@ -3,27 +3,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { rawHandler, serialize } from '@wordpress/blocks';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import { rawHandler } from '@wordpress/blocks';
 
-const ConvertToBlocksButton = ( { clientId } ) => {
-	const { replaceBlocks } = useDispatch( blockEditorStore );
-	const block = useSelect(
-		( select ) => {
-			return select( blockEditorStore ).getBlock( clientId );
-		},
-		[ clientId ]
-	);
-
+const ConvertToBlocksButton = ( { content, onReplace } ) => {
 	return (
 		<ToolbarButton
-			onClick={ () =>
-				replaceBlocks(
-					block.clientId,
-					rawHandler( { HTML: serialize( block ) } )
-				)
-			}
+			onClick={ () => onReplace( rawHandler( { HTML: content } ) ) }
 		>
 			{ __( 'Convert to blocks' ) }
 		</ToolbarButton>

--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -29,6 +29,7 @@ export default function FreeformEdit( {
 	attributes,
 	setAttributes,
 	clientId,
+	onReplace,
 } ) {
 	const { content } = attributes;
 	const [ isOpen, setOpen ] = useState( false );
@@ -49,7 +50,10 @@ export default function FreeformEdit( {
 			{ canRemove && ! isDeprecationMode && (
 				<BlockControls>
 					<ToolbarGroup>
-						<ConvertToBlocksButton clientId={ clientId } />
+						<ConvertToBlocksButton
+							content={ content }
+							onReplace={ onReplace }
+						/>
 					</ToolbarGroup>
 				</BlockControls>
 			) }
@@ -66,8 +70,8 @@ export default function FreeformEdit( {
 			<div { ...useBlockProps() }>
 				{ isDeprecationMode && canRemove && content && (
 					<MigrationNotice
-						clientId={ clientId }
 						content={ content }
+						onReplace={ onReplace }
 					/>
 				) }
 				{ content ? (

--- a/packages/block-library/src/freeform/migration-notice.js
+++ b/packages/block-library/src/freeform/migration-notice.js
@@ -1,10 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { store as blockEditorStore, Warning } from '@wordpress/block-editor';
+import { Warning } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
-import { createBlock, rawHandler, serialize } from '@wordpress/blocks';
+import { createBlock, rawHandler } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -16,32 +15,17 @@ import { __ } from '@wordpress/i18n';
  * and offers two migration actions - a primary "Convert to blocks", and a
  * secondary "Convert to Custom HTML".
  *
- * @param {Object} props
- * @param {string} props.clientId Client ID of the Classic block.
- * @param {string} props.content  Raw HTML content of the Classic block.
+ * @param {Object}   props
+ * @param {string}   props.content   Raw HTML content of the Classic block.
+ * @param {Function} props.onReplace Replace the current block with the given blocks.
  */
-export default function MigrationNotice( { clientId, content } ) {
-	const { replaceBlocks } = useDispatch( blockEditorStore );
-
-	const convertToBlocks = () => {
-		replaceBlocks(
-			clientId,
-			rawHandler( {
-				HTML: serialize( createBlock( 'core/freeform', { content } ) ),
-			} )
-		);
-	};
-
-	const convertToHtmlBlock = () => {
-		replaceBlocks( clientId, createBlock( 'core/html', { content } ) );
-	};
-
+export default function MigrationNotice( { content, onReplace } ) {
 	const actions = [
 		<Button
 			__next40pxDefaultSize
 			key="convert-to-blocks"
 			variant="primary"
-			onClick={ convertToBlocks }
+			onClick={ () => onReplace( rawHandler( { HTML: content } ) ) }
 		>
 			{ __( 'Convert to blocks' ) }
 		</Button>,
@@ -49,7 +33,9 @@ export default function MigrationNotice( { clientId, content } ) {
 			__next40pxDefaultSize
 			key="convert-to-html"
 			variant="secondary"
-			onClick={ convertToHtmlBlock }
+			onClick={ () =>
+				onReplace( createBlock( 'core/html', { content } ) )
+			}
 		>
 			{ __( 'Convert to HTML' ) }
 		</Button>,


### PR DESCRIPTION
## What?
A small follow-up to #78090.

Replaces direct `replaceBlocks` dispatch in `ConvertToBlocksButton` and `MigrationNotice` with the `onReplace` prop already provided to the block edit. Also drops the redundant `serialize( createBlock( 'core/freeform', { content } ) )` round-trip, freeform's serializer is identity for `content`.

Extracted from my ongoing work, it's an atomic change and better handled that way.

## Testing Instructions
1. Create a post.
2. Switch to code editor.
3. Paste some HTML.
4. Switch back to visual. Save helps with repeated steps.
5. Try converting to blocks. Conversion should work as before.
6. Repeat the same step with "Classic block deprecation" setting enabled.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

None.
