### PR TITLE
Block Editor: Fall back to allowed block when replacement is not insertable

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -262,6 +262,9 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 		removeBlock,
 		selectBlock,
 	} = dispatch( blockEditorStore );
+	const { replaceBlocksWithFallback } = unlock(
+		dispatch( blockEditorStore )
+	);
 
 	// Do not add new properties here, use `useDispatch` instead to avoid
 	// leaking new props to the public API (editor.BlockListBlock filter).
@@ -528,11 +531,10 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 				blocks?.length === 1 && Array.isArray( blocks[ 0 ] )
 					? blocks[ 0 ]
 					: blocks;
-			replaceBlocks(
+			replaceBlocksWithFallback(
 				[ ownProps.clientId ],
 				replacementBlocks,
-				indexToSelect,
-				initialPosition
+				{ indexToSelect, initialPosition }
 			);
 		},
 		onRemove() {

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -5,6 +5,13 @@ import { Platform } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 import { speak } from '@wordpress/a11y';
 import { __ } from '@wordpress/i18n';
+import {
+	createBlock,
+	getBlockType,
+	getPossibleBlockTransformations,
+	getSaveContent,
+	switchToBlockType,
+} from '@wordpress/blocks';
 
 const castArray = ( maybeArray ) =>
 	Array.isArray( maybeArray ) ? maybeArray : [ maybeArray ];
@@ -529,3 +536,60 @@ export function clearRequestedInspectorTab() {
 		type: 'CLEAR_REQUESTED_INSPECTOR_TAB',
 	};
 }
+
+/**
+ * Like `replaceBlocks`, but maps any block that cannot be inserted at the
+ * target location to a fallback. The fallback is the first available `to`
+ * transform target that is insertable, or a paragraph block created from the
+ * serialized HTML if none qualifies.
+ *
+ * @param {string|string[]} clientIds                 Client ID(s) of the block(s) to replace.
+ * @param {Object|Object[]} blocks                    Replacement block(s).
+ * @param {Object}          [options]                 Options.
+ * @param {number}          [options.indexToSelect]   Index of replacement block to select.
+ * @param {0|-1|null}       [options.initialPosition] Caret position after replacement.
+ * @param {Object}          [options.meta]            Meta values passed to the action.
+ */
+export const replaceBlocksWithFallback =
+	( clientIds, blocks, options = {} ) =>
+	( { select, dispatch, registry } ) => {
+		const { indexToSelect, initialPosition = 0, meta } = options;
+		clientIds = castArray( clientIds );
+		blocks = castArray( blocks );
+		const rootClientId = select.getBlockRootClientId( clientIds[ 0 ] );
+
+		const mappedBlocks = blocks.flatMap( ( block ) => {
+			if ( select.canInsertBlockType( block.name, rootClientId ) ) {
+				return block;
+			}
+			// Pick the first `to` transform whose target is insertable
+			// (e.g. heading → paragraph, embed → paragraph).
+			const target = getPossibleBlockTransformations( [ block ] ).find(
+				( { name } ) => select.canInsertBlockType( name, rootClientId )
+			);
+			const switched = target && switchToBlockType( block, target.name );
+			if ( switched ) {
+				return switched;
+			}
+			// No transform path — preserve markup verbatim as raw HTML.
+			return createBlock( 'core/html', {
+				content: getSaveContent(
+					getBlockType( block.name ),
+					block.attributes
+				),
+			} );
+		} );
+
+		registry.batch( () => {
+			dispatch( {
+				type: 'REPLACE_BLOCKS',
+				clientIds,
+				blocks: mappedBlocks,
+				time: Date.now(),
+				indexToSelect,
+				initialPosition,
+				meta,
+			} );
+			dispatch( ensureDefaultBlock() );
+		} );
+	};

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -709,6 +709,52 @@ test.describe( 'Copy/cut/paste', () => {
 		] );
 	} );
 
+	test( 'should fall back to paragraph when target block is not allowed', async ( {
+		pageUtils,
+		editor,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: { allowedBlocks: [ 'core/paragraph' ] },
+			innerBlocks: [ { name: 'core/paragraph' } ],
+		} );
+		await editor.canvas
+			.getByRole( 'document', { name: 'Empty block' } )
+			.click();
+		pageUtils.setClipboardData( {
+			plainText:
+				'Lorem ipsum.\n\nhttps://www.youtube.com/watch?v=FcTLMTyD2DU\n\nDolor sit amet.',
+			html: '<p>Lorem ipsum.</p><h2>Heading text.</h2><p>https://www.youtube.com/watch?v=FcTLMTyD2DU</p><p>Dolor sit amet.</p>',
+		} );
+		await pageUtils.pressKeys( 'primary+v' );
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/group',
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'Lorem ipsum.' },
+					},
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'Heading text.' },
+					},
+					{
+						name: 'core/paragraph',
+						attributes: {
+							content:
+								'<a href="https://www.youtube.com/watch?v=FcTLMTyD2DU">https://www.youtube.com/watch?v=FcTLMTyD2DU</a>',
+						},
+					},
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'Dolor sit amet.' },
+					},
+				],
+			},
+		] );
+	} );
+
 	test( 'should not link selection for non http(s) protocol', async ( {
 		pageUtils,
 		editor,


### PR DESCRIPTION
## What?
🚧 A work in progress 🚧 

Adds private `replaceBlocksWithFallback` action. When a replacement block can't be inserted at the target (disallowed by `allowed_block_types_all` or a parent's `allowedBlocks`), it's swapped via the first matching `to` transform (e.g., heading/embed → paragraph), or `core/html` if no transform path exists.

## Why?

## How?

## Testing Instructions

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

## Use of AI Tools
