### PR TITLE
E2E: Reset preferences after navigable-toolbar tests

### DIFF
--- a/test/e2e/specs/editor/various/navigable-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/navigable-toolbar.spec.js
@@ -14,6 +14,12 @@ test.describe( 'Block Toolbar', () => {
 		await admin.createNewPost();
 	} );
 
+	test.afterEach( async ( { requestUtils } ) => {
+		// Reset preferences via REST so a mid-test failure doesn't leak
+		// the fixed-toolbar setting (or any other pref) to other tests.
+		await requestUtils.resetPreferences();
+	} );
+
 	test.describe( 'Contextual Toolbar', () => {
 		test( 'should not scroll page', async ( { page, pageUtils } ) => {
 			while (
@@ -180,8 +186,6 @@ test.describe( 'Block Toolbar', () => {
 
 		await BlockToolbarUtils.testScrollable( blockToolbar, blockButton );
 
-		// Test cleanup
-		await editor.setIsFixedToolbar( false );
 		await pageUtils.setBrowserViewport( 'large' );
 	} );
 
@@ -248,8 +252,6 @@ test.describe( 'Block Toolbar', () => {
 		// check focus is on the block
 		await BlockToolbarUtils.expectLabelToHaveFocus( 'Block: Paragraph' );
 
-		// Test cleanup
-		await editor.setIsFixedToolbar( false );
 		await pageUtils.setBrowserViewport( 'large' );
 	} );
 


### PR DESCRIPTION
## What?

The `Block toolbar will scroll...` and `Tab order...` tests flip the `fixedToolbar` preference and reset it inline at the end. If anything fails in between, the pref leaks into subsequent tests (it's persisted via user meta). Move cleanup to an `afterEach` that calls `requestUtils.resetPreferences()` so it always runs and doesn't depend on the editor page being healthy.

See: https://github.com/WordPress/gutenberg/actions/runs/25591555327. Pattern test traces show it failed with an unexpected top toolbar.

## Testing Instructions
Verify that the logic and CI checks are green.

## Use of AI Tools

None.
