### PR TITLE
Connectors: Replace @wordpress/ui Link and Notice usage

### DIFF
--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalHStack as HStack, Button } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	Button,
+	ExternalLink,
+} from '@wordpress/components';
 import { useRef } from '@wordpress/element';
 import {
 	__experimentalRegisterConnector as registerConnector,
@@ -13,7 +17,7 @@ import {
 } from '@wordpress/connectors';
 import { select } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
-import { Badge, Link } from '@wordpress/ui';
+import { Badge } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -109,16 +113,15 @@ const ConnectedBadge = () => (
 );
 
 const PluginDirectoryLink = ( { slug }: { slug: string } ) => (
-	<Link
+	<ExternalLink
 		href={ sprintf(
 			/* translators: %s: plugin slug. */
 			__( 'https://wordpress.org/plugins/%s/' ),
 			slug
 		) }
-		openInNewTab
 	>
 		{ __( 'Learn more' ) }
-	</Link>
+	</ExternalLink>
 );
 
 const UnavailableActionBadge = () => <Badge>{ __( 'Not available' ) }</Badge>;

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { speak } from '@wordpress/a11y';
 import { Page } from '@wordpress/admin-ui';
 import {
 	Button,
@@ -13,11 +14,10 @@ import {
 	type ConnectorConfig,
 } from '@wordpress/connectors';
 import { useSelect } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
-// eslint-disable-next-line @wordpress/use-recommended-components
-import { Notice } from '@wordpress/ui';
+import { Icon, info } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -94,6 +94,25 @@ function ConnectorsPage() {
 	);
 	const isEmpty = renderableConnectors.length === 0;
 
+	const showFileModsNotice =
+		manualInstallPluginSlugs.length > 0 &&
+		( isFileModDisabled || ! canInstallPlugins );
+	const fileModsNoticeMessage = isFileModDisabled
+		? __(
+				'Plugins cannot be installed here due to your site configuration. Install them manually using your normal deployment workflow.'
+		  )
+		: __(
+				'You do not have permission to install plugins. Please ask a site administrator to install them for you.'
+		  );
+
+	// Mirrors `useSpokenMessage` in `@wordpress/ui` Notice so the inlined
+	// markup announces the message to assistive tech the same way.
+	useEffect( () => {
+		if ( showFileModsNotice ) {
+			speak( fileModsNoticeMessage, 'polite' );
+		}
+	}, [ showFileModsNotice, fileModsNoticeMessage ] );
+
 	return (
 		<Page
 			title={ __( 'Connectors' ) }
@@ -106,23 +125,17 @@ function ConnectorsPage() {
 					isEmpty ? ' connectors-page--empty' : ''
 				}` }
 			>
-				{ manualInstallPluginSlugs.length > 0 &&
-					( isFileModDisabled || ! canInstallPlugins ) && (
-						<Notice.Root
-							intent="info"
-							className="connectors-page__file-mods-notice"
-						>
-							<Notice.Description>
-								{ isFileModDisabled
-									? __(
-											'Plugins cannot be installed here due to your site configuration. Install them manually using your normal deployment workflow.'
-									  )
-									: __(
-											'You do not have permission to install plugins. Please ask a site administrator to install them for you.'
-									  ) }
-							</Notice.Description>
-						</Notice.Root>
-					) }
+				{ showFileModsNotice && (
+					<div className="connectors-page__file-mods-notice">
+						<Icon
+							className="connectors-page__file-mods-notice-icon"
+							icon={ info }
+						/>
+						<span className="connectors-page__file-mods-notice-text">
+							{ fileModsNoticeMessage }
+						</span>
+					</div>
+				) }
 				{ isEmpty ? (
 					<VStack
 						alignment="center"

--- a/routes/connectors-home/style.scss
+++ b/routes/connectors-home/style.scss
@@ -30,7 +30,26 @@ $sticky-header-clearance: 120px;
 	}
 
 	&__file-mods-notice {
+		display: grid;
+		grid-template-columns: auto 1fr auto;
+		align-items: start;
+		padding: var(--wpds-dimension-padding-md);
 		margin-bottom: 16px;
+		border: 1px solid var(--wpds-color-stroke-surface-info);
+		border-radius: var(--wpds-border-radius-lg);
+		background-color: var(--wpds-color-bg-surface-info-weak);
+	}
+
+	&__file-mods-notice-icon {
+		margin-inline-end: var(--wpds-dimension-gap-xs);
+		fill: var(--wpds-color-fg-content-info-weak);
+	}
+
+	&__file-mods-notice-text {
+		line-height: 20px;
+		text-wrap: pretty;
+		color: var(--wpds-color-fg-content-neutral);
+		padding-block: 2px;
 	}
 
 	&--empty {


### PR DESCRIPTION
## What?

Replace usage of `Link` and `Notice` from `@wordpress/ui` in the
`connectors-home` route with alternatives that work on the current
branch.

## Why?

`@wordpress/ui` ships TypeScript declarations for `Link` and `Notice`
on this branch, but the corresponding compiled JS is not yet available.
Importing them prevents the connectors-home route from running.

## How?

- Swap `Link` → `ExternalLink` from `@wordpress/components`.
- Reproduce the `Notice` (info intent) with inline `<div>` + `<Icon>` +
  `<span>` markup and grid CSS modeled on the upstream `@wordpress/ui`
  Notice implementation, using `--wpds-*` design tokens.
- Mirror `useSpokenMessage` by calling `speak()` from `@wordpress/a11y`
  inside `useEffect` so the inlined notice keeps the same screen reader
  announcement behavior.

## Testing Instructions

1. Visit `wp-admin` → Connectors.
2. Trigger the file-mods notice condition (e.g. set
   `define( 'DISALLOW_FILE_MODS', true );` in `wp-config.php`, or sign
   in as a user without `install_plugins` capability) so the info
   notice renders.
3. Confirm the notice shows an info icon, body text, and matches the
   `info` intent appearance of `@wordpress/ui` Notice.
4. In a connector card whose plugin is not available (e.g. uninstalled
   AI provider plugin), click the "Learn more" link and confirm it
   opens the wordpress.org plugin page in a new tab.

### Testing Instructions for Keyboard

1. Load the Connectors page with the file-mods notice visible — verify
   that a screen reader announces the notice text (polite live region).
2. Tab through the connector list and confirm each "Learn more" link
   is reachable and announced as an external link.

## Screenshots or screencast

| Before | After |
| - | - |
|  |  |
