### PR TITLE
Migrate <p> to @wordpress/ui Text in Layout Constraint Helptext

### DIFF
--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -19,6 +19,7 @@ import {
 	justifyRight,
 } from '@wordpress/icons';
 import { getCSSRules } from '@wordpress/style-engine';
+import { Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -127,11 +128,15 @@ export default {
 								</InputControlPrefixWrapper>
 							}
 						/>
-						<p className="block-editor-hooks__layout-constrained-helptext">
+						<Text
+							variant="body-sm"
+							render={ <p /> }
+							className="block-editor-hooks__layout-constrained-helptext"
+						>
 							{ __(
 								'Customize the width for all elements that are assigned to the center or wide columns.'
 							) }
-						</p>
+						</Text>
 					</>
 				) }
 				{ allowJustification && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: #77265

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

> Now that the required tooling is in place, we can start applying consistent text styling across the site and block editor. This can be done by replacing instances of __experimentalText and __experimentalHeading, as well as any ad hoc styled text, with the [Text](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-text--docs) component from the UI package.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Replaced the `<p>` with @wordpress/ui Text in Layout Constraint Helptext

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Open the post editor.
2. Insert a block that exposes constrained layout controls (ex: Group).
3. Open Block settings and the Layout controls where Content width and Wide width appear.
4. Verify the helper sentence that appears under those controls: "Customize the width for all elements that are assigned to the center or wide columns." This sentence is the migrated text.

|Before|After|
|-|-|
|<img width="963" height="525" alt="Screenshot 2026-05-09 at 8 18 36 PM" src="https://github.com/user-attachments/assets/8bf1fe98-41b1-4b41-a73a-dc603d94687f" />|<img width="961" height="522" alt="Screenshot 2026-05-09 at 8 17 12 PM" src="https://github.com/user-attachments/assets/9ec67287-282c-4b90-b546-a55e1cc4dfca" />|