### PR TITLE
Connectors: Avoid using centered text

### DIFF
--- a/routes/connectors-home/style.scss
+++ b/routes/connectors-home/style.scss
@@ -83,7 +83,6 @@ $sticky-header-clearance: 120px;
 	}
 
 	> p {
-		text-align: left;
 		color: $gray-600;
 	}
 

--- a/routes/connectors-home/style.scss
+++ b/routes/connectors-home/style.scss
@@ -83,7 +83,7 @@ $sticky-header-clearance: 120px;
 	}
 
 	> p {
-		text-align: center;
+		text-align: left;
 		color: $gray-600;
 	}
 


### PR DESCRIPTION
## What?
Left-align the footer text on the Connectors page.

## Why?
Centered text that wraps to multiple lines increases cognitive load and is an accessibility concern — particularly for users with dyslexia or those using zoom. The text is a single line in English but wraps in several other languages (Japanese, French, Dutch).

Fixes #78120