### PR TITLE
Media: Guard gutenberg_delete_heic_companion_file() against non-string $metadata['original']

### DIFF
--- a/backport-changelog/7.1/11323.md
+++ b/backport-changelog/7.1/11323.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/11323
 
 * https://github.com/WordPress/gutenberg/pull/76731
+* https://github.com/WordPress/gutenberg/pull/78128

--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -207,7 +207,7 @@ add_action( 'admin_init', 'gutenberg_set_heic_upload_support_flag' );
 function gutenberg_delete_heic_companion_file( int $post_id ): void {
 	$metadata = wp_get_attachment_metadata( $post_id, true );
 
-	if ( empty( $metadata['original'] ) ) {
+	if ( empty( $metadata['original'] ) || ! is_string( $metadata['original'] ) ) {
 		return;
 	}
 


### PR DESCRIPTION
## What?

Closes #78127.

Adds an `is_string()` guard to `gutenberg_delete_heic_companion_file()` so it bails on attachments whose `wp_get_attachment_metadata()['original']` is not a string filename.

## Why?

The function is hooked to `delete_attachment` for *all* attachment types and assumes `$metadata['original']` is a string (the HEIC sideload's companion filename). Other attachment types — or any plugin filtering `wp_get_attachment_metadata` — may legitimately put a non-string value (commonly an array) at the `original` key.

The existing `empty()` check passes for a non-empty array, so the bad value reaches `path_join()` -> `path_is_absolute()` -> `wp_is_stream()` -> `strpos()`, which throws:

```
Uncaught TypeError: strpos(): Argument #1 ($haystack) must be of type string, array given
```

Full repro and stack trace in #78127.

## How?

Extends the early bail to require `is_string( $metadata['original'] )`. One-line change.

## Testing Instructions

1. Apply this PR.
2. Add the filter from #78127:
   ```php
   add_filter( 'wp_get_attachment_metadata', function ( $data ) {
       return array_merge( (array) $data, [ 'original' => [ 'foo' => 'bar' ] ] );
   } );
   ```
3. Delete an attachment: `wp_delete_attachment( $id, true );`

- **Before:** TypeError from `strpos()` inside `gutenberg_delete_heic_companion_file()`.
- **After:** silent no-op for non-string `original`; HEIC cleanup unaffected when `original` is a string filename.

### Testing Instructions for Keyboard

N/A — server-side fix, no UI.

## Screenshots or screencast

N/A — server-side fix, no UI.

## Use of AI Tools

AI-assisted analysis identified the type-safety gap and drafted the one-line guard. The author reviewed the diff, repro, and PR body before submitting.