### PR TITLE
i18n: add context to breadcrumbs area label

### DIFF
--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Link as RouterLink } from '@wordpress/route';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { Link, Stack, Text } from '@wordpress/ui';
 
 /**
@@ -51,7 +51,7 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 	}
 
 	return (
-		<nav aria-label={ __( 'Breadcrumbs' ) }>
+		<nav aria-label={ _x( 'Breadcrumbs', 'area label' ) }>
 			<Stack
 				render={ <ul /> }
 				direction="row"

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Link as RouterLink } from '@wordpress/route';
-import { __, _x } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { Link, Stack, Text } from '@wordpress/ui';
 
 /**

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -186,7 +186,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
 			'style'      => '--separator: "' . addcslashes( $attributes['separator'], '\\"' ) . '";',
-			'aria-label' => __( 'Breadcrumbs' ),
+			'aria-label' => _x( 'Breadcrumbs', 'area label' ),
 		)
 	);
 


### PR DESCRIPTION
related to: #78133

can't find the third one.