### PR TITLE
Script Modules: Guard setAccessible() calls behind PHP < 8.1 check

### DIFF
--- a/lib/compat/wordpress-7.0/script-modules.php
+++ b/lib/compat/wordpress-7.0/script-modules.php
@@ -31,7 +31,9 @@ function gutenberg_get_script_module_src( string $id ): ?string {
 	// Fallback for WP versions without get_registered().
 	$reflection = new ReflectionClass( $script_modules );
 	$prop       = $reflection->getProperty( 'registered' );
-	$prop->setAccessible( true );
+	if ( PHP_VERSION_ID < 80100 ) {
+		$prop->setAccessible( true );
+	}
 	$registered = $prop->getValue( $script_modules );
 
 	return $registered[ $id ]['src'] ?? null;
@@ -56,7 +58,9 @@ function gutenberg_print_script_module_translations() {
 	$reflection = new ReflectionClass( $script_modules );
 	if ( $reflection->hasMethod( 'get_sorted_dependencies' ) ) {
 		$method = $reflection->getMethod( 'get_sorted_dependencies' );
-		$method->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		$module_ids = $method->invoke( $script_modules, $queue );
 	} else {
 		$module_ids = $queue;


### PR DESCRIPTION
## What?

Wraps the two `ReflectionProperty`/`ReflectionMethod::setAccessible( true )` calls in `lib/compat/wordpress-7.0/script-modules.php` with a `PHP_VERSION_ID < 80100` guard.

Follow-up to #77214. Fixes #78124.

## Why?

As of PHP 8.1, private/protected members are accessible via reflection without calling `setAccessible()`, so the call is a no-op. PHP 8.5 deprecates it, emitting:

> Method ReflectionMethod::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1

…on every editor page load when `WP_DEBUG` is enabled on WP < 7.0 (where this polyfill runs).

## How?

Guards each `setAccessible( true )` call behind `if ( PHP_VERSION_ID < 80100 )` so it only runs where it has an effect.

## Testing Instructions

1. On PHP 8.5 with `WP_DEBUG` and `WP_DEBUG_LOG` enabled, on WP < 7.0 (so the polyfill path runs), edit any post.
2. Before this patch: deprecation notice referencing `script-modules.php` line 59 in the debug log.
3. After this patch: no deprecation notice; script module translations continue to work (verify via the steps in #77214).

### Testing Instructions for Keyboard

No UI changes — infrastructure-only.