### PR TITLE
Show block instance state badges

### DIFF
--- a/packages/block-editor/src/components/global-styles/index.js
+++ b/packages/block-editor/src/components/global-styles/index.js
@@ -24,3 +24,4 @@ export {
 	useHasBackgroundPanel,
 } from './background-panel';
 export { default as StateControl } from './state-control';
+export { default as StateControlBadges } from './state-control-badges';

--- a/packages/block-editor/src/components/global-styles/state-control-badges.js
+++ b/packages/block-editor/src/components/global-styles/state-control-badges.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { Badge: WCBadge } = unlock( componentsPrivateApis );
+
+export default function StateControlBadges( {
+	states,
+	className = 'block-editor-global-styles-state-control__badges',
+} ) {
+	return (
+		<Stack
+			className={ className }
+			direction="row"
+			justify="flex-start"
+			gap="xs"
+			wrap="wrap"
+		>
+			{ states.map( ( state ) => (
+				<WCBadge key={ state.key } intent="info">
+					{ state.label }
+				</WCBadge>
+			) ) }
+		</Stack>
+	);
+}

--- a/packages/block-editor/src/components/global-styles/state-control-badges.js
+++ b/packages/block-editor/src/components/global-styles/state-control-badges.js
@@ -12,9 +12,34 @@ import { unlock } from '../../lock-unlock';
 const { Badge: WCBadge } = unlock( componentsPrivateApis );
 
 export default function StateControlBadges( {
-	states,
+	viewportStates = [],
+	pseudoStates = [],
+	viewportValue = 'default',
+	pseudoStateValue = 'default',
 	className = 'block-editor-global-styles-state-control__badges',
 } ) {
+	const activeStates = [];
+	const selectedViewport = viewportStates.find(
+		( state ) => state.value === viewportValue
+	);
+	const selectedPseudoState = pseudoStates.find(
+		( state ) => state.value === pseudoStateValue
+	);
+
+	if ( selectedViewport ) {
+		activeStates.push( {
+			key: `viewport-${ selectedViewport.value }`,
+			label: selectedViewport.label,
+		} );
+	}
+
+	if ( selectedPseudoState ) {
+		activeStates.push( {
+			key: `pseudo-${ selectedPseudoState.value }`,
+			label: selectedPseudoState.label,
+		} );
+	}
+
 	return (
 		<Stack
 			className={ className }
@@ -23,7 +48,7 @@ export default function StateControlBadges( {
 			gap="xs"
 			wrap="wrap"
 		>
-			{ states.map( ( state ) => (
+			{ activeStates.map( ( state ) => (
 				<WCBadge key={ state.key } intent="info">
 					{ state.label }
 				</WCBadge>

--- a/packages/block-editor/src/components/global-styles/state-control.js
+++ b/packages/block-editor/src/components/global-styles/state-control.js
@@ -18,6 +18,27 @@ import { unlock } from '../../lock-unlock';
 
 const { Badge: WCBadge } = unlock( componentsPrivateApis );
 
+export function StateControlBadges( {
+	states,
+	className = 'block-editor-global-styles-state-control__badges',
+} ) {
+	return (
+		<Stack
+			className={ className }
+			direction="row"
+			justify="flex-start"
+			gap="xs"
+			wrap="wrap"
+		>
+			{ states.map( ( state ) => (
+				<WCBadge key={ state.key } intent="info">
+					{ state.label }
+				</WCBadge>
+			) ) }
+		</Stack>
+	);
+}
+
 /**
  * State control for managing viewport and pseudo-state styles.
  * Displays a dropdown menu with separate groups for each selector.
@@ -174,21 +195,7 @@ export default function StateControl( {
 					</>
 				) }
 			</DropdownMenu>
-			{ showText && (
-				<Stack
-					className="block-editor-global-styles-state-control__badges"
-					direction="row"
-					justify="flex-start"
-					gap="xs"
-					wrap="wrap"
-				>
-					{ activeStates.map( ( activeState ) => (
-						<WCBadge key={ activeState.key } intent="info">
-							{ activeState.label }
-						</WCBadge>
-					) ) }
-				</Stack>
-			) }
+			{ showText && <StateControlBadges states={ activeStates } /> }
 		</Stack>
 	);
 }

--- a/packages/block-editor/src/components/global-styles/state-control.js
+++ b/packages/block-editor/src/components/global-styles/state-control.js
@@ -18,6 +18,7 @@ import { Stack } from '@wordpress/ui';
  * @param {Function} props.onChangeViewport    Callback when viewport selection changes.
  * @param {Function} props.onChangePseudoState Callback when pseudo state selection changes.
  * @param {boolean}  props.showText            Whether to show text label on the toggle. Default true.
+ * @param {Object}   props.popoverProps        Popover props for the dropdown menu.
  * @return {Element|null} State control component.
  */
 export default function StateControl( {
@@ -28,6 +29,7 @@ export default function StateControl( {
 	onChangeViewport,
 	onChangePseudoState,
 	showText = true,
+	popoverProps = {},
 } ) {
 	if ( ! viewportStates.length && ! pseudoStates.length ) {
 		return null;
@@ -107,6 +109,7 @@ export default function StateControl( {
 				}
 				popoverProps={ {
 					placement: 'right-start',
+					...popoverProps,
 				} }
 				text={ showText ? triggerLabel : undefined }
 				toggleProps={ toggleProps }

--- a/packages/block-editor/src/components/global-styles/state-control.js
+++ b/packages/block-editor/src/components/global-styles/state-control.js
@@ -7,11 +7,6 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 
 /**
- * Internal dependencies
- */
-import StateControlBadges from './state-control-badges';
-
-/**
  * State control for managing viewport and pseudo-state styles.
  * Displays a dropdown menu with separate groups for each selector.
  *
@@ -167,7 +162,6 @@ export default function StateControl( {
 					</>
 				) }
 			</DropdownMenu>
-			{ showText && <StateControlBadges states={ activeStates } /> }
 		</Stack>
 	);
 }

--- a/packages/block-editor/src/components/global-styles/state-control.js
+++ b/packages/block-editor/src/components/global-styles/state-control.js
@@ -3,41 +3,13 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { check, chevronDown, moreVertical } from '@wordpress/icons';
-import {
-	DropdownMenu,
-	MenuGroup,
-	MenuItem,
-	privateApis as componentsPrivateApis,
-} from '@wordpress/components';
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
  */
-import { unlock } from '../../lock-unlock';
-
-const { Badge: WCBadge } = unlock( componentsPrivateApis );
-
-export function StateControlBadges( {
-	states,
-	className = 'block-editor-global-styles-state-control__badges',
-} ) {
-	return (
-		<Stack
-			className={ className }
-			direction="row"
-			justify="flex-start"
-			gap="xs"
-			wrap="wrap"
-		>
-			{ states.map( ( state ) => (
-				<WCBadge key={ state.key } intent="info">
-					{ state.label }
-				</WCBadge>
-			) ) }
-		</Stack>
-	);
-}
+import StateControlBadges from './state-control-badges';
 
 /**
  * State control for managing viewport and pseudo-state styles.

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import StateControl from '../components/global-styles/state-control';
 import StateControlBadges from '../components/global-styles/state-control-badges';
 import { BlockCardControlsFill } from '../components/block-card';
+import { useToolsPanelDropdownMenuProps } from '../components/global-styles/utils';
 
 export const PSEUDO_STATE_LABELS = {
 	':hover': __( 'Hover' ),
@@ -47,6 +48,7 @@ function getStateOptions( name ) {
  */
 export function BlockStatesControl( { name, value, onChange } ) {
 	const stateOptions = getStateOptions( name );
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	if ( ! stateOptions.length ) {
 		return null;
@@ -58,6 +60,7 @@ export function BlockStatesControl( { name, value, onChange } ) {
 				pseudoStates={ stateOptions }
 				pseudoStateValue={ value }
 				onChangePseudoState={ onChange }
+				popoverProps={ dropdownMenuProps.popoverProps }
 				showText={ false }
 			/>
 		</BlockCardControlsFill>

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -6,9 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import StateControl, {
-	StateControlBadges,
-} from '../components/global-styles/state-control';
+import StateControl from '../components/global-styles/state-control';
+import StateControlBadges from '../components/global-styles/state-control-badges';
 import { BlockCardControlsFill } from '../components/block-card';
 
 export const PSEUDO_STATE_LABELS = {

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -6,7 +6,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import StateControl from '../components/global-styles/state-control';
+import StateControl, {
+	StateControlBadges,
+} from '../components/global-styles/state-control';
 import { BlockCardControlsFill } from '../components/block-card';
 
 export const PSEUDO_STATE_LABELS = {
@@ -23,6 +25,17 @@ export const VALID_BLOCK_PSEUDO_STATES = {
 	'core/navigation-link': [ ':hover', ':focus', ':focus-visible', ':active' ],
 };
 
+function getStateOptions( name ) {
+	const validStates = VALID_BLOCK_PSEUDO_STATES[ name ] ?? [];
+
+	return validStates
+		.filter( ( state ) => PSEUDO_STATE_LABELS[ state ] )
+		.map( ( state ) => ( {
+			value: state,
+			label: PSEUDO_STATE_LABELS[ state ],
+		} ) );
+}
+
 /**
  * Renders a pseudo-state selector in the block card header.
  * Only shown for blocks with configured pseudo-state support.
@@ -34,13 +47,7 @@ export const VALID_BLOCK_PSEUDO_STATES = {
  * @return {Element|null} State control component, or null if not applicable.
  */
 export function BlockStatesControl( { name, value, onChange } ) {
-	const validStates = VALID_BLOCK_PSEUDO_STATES[ name ] ?? [];
-	const stateOptions = validStates
-		.filter( ( state ) => PSEUDO_STATE_LABELS[ state ] )
-		.map( ( state ) => ( {
-			value: state,
-			label: PSEUDO_STATE_LABELS[ state ],
-		} ) );
+	const stateOptions = getStateOptions( name );
 
 	if ( ! stateOptions.length ) {
 		return null;
@@ -55,5 +62,26 @@ export function BlockStatesControl( { name, value, onChange } ) {
 				showText={ false }
 			/>
 		</BlockCardControlsFill>
+	);
+}
+
+export function BlockStateBadges( { name, value } ) {
+	const selectedState = getStateOptions( name ).find(
+		( option ) => option.value === value
+	);
+
+	if ( ! selectedState ) {
+		return null;
+	}
+
+	return (
+		<StateControlBadges
+			states={ [
+				{
+					key: `pseudo-${ selectedState.value }`,
+					label: selectedState.label,
+				},
+			] }
+		/>
 	);
 }

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -65,22 +65,16 @@ export function BlockStatesControl( { name, value, onChange } ) {
 }
 
 export function BlockStateBadges( { name, value } ) {
-	const selectedState = getStateOptions( name ).find(
-		( option ) => option.value === value
-	);
+	const stateOptions = getStateOptions( name );
 
-	if ( ! selectedState ) {
+	if ( ! stateOptions.length ) {
 		return null;
 	}
 
 	return (
 		<StateControlBadges
-			states={ [
-				{
-					key: `pseudo-${ selectedState.value }`,
-					label: selectedState.label,
-				},
-			] }
+			pseudoStates={ stateOptions }
+			pseudoStateValue={ value }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -39,6 +39,11 @@ import {
 } from './utils';
 import { BlockStatesControl, VALID_BLOCK_PSEUDO_STATES } from './states';
 import { BlockStyleStateProvider } from './block-style-state';
+import {
+	BlockStateBadges,
+	BlockStatesControl,
+	VALID_BLOCK_PSEUDO_STATES,
+} from './states';
 import { buildStateSelector, buildCanvasStateSelector } from './state-utils';
 import { BlockInspectorPreTabsFill } from '../components/block-inspector/inspector-pre-tabs-slot-fill';
 import { scopeSelector } from '../components/global-styles/utils';
@@ -399,6 +404,10 @@ function BlockStyleControls( {
 							label={ __( 'Show state on canvas' ) }
 							checked={ showStateOnCanvas }
 							onChange={ setShowStateOnCanvas }
+						/>
+						<BlockStateBadges
+							name={ name }
+							value={ selectedState }
 						/>
 					</Spacer>
 				</BlockInspectorPreTabsFill>

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -37,7 +37,6 @@ import {
 	useStyleOverride,
 	useBlockSettings,
 } from './utils';
-import { BlockStatesControl, VALID_BLOCK_PSEUDO_STATES } from './states';
 import { BlockStyleStateProvider } from './block-style-state';
 import {
 	BlockStateBadges,

--- a/packages/global-styles-ui/src/screen-header.tsx
+++ b/packages/global-styles-ui/src/screen-header.tsx
@@ -21,7 +21,12 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import type { StateDefinition } from './utils';
 import { unlock } from './lock-unlock';
 
-const { StateControl } = unlock( blockEditorPrivateApis );
+const { StateControl, StateControlBadges } = unlock( blockEditorPrivateApis );
+
+interface ActiveState {
+	key: string;
+	label: string;
+}
 
 interface ScreenHeaderProps {
 	title: string;
@@ -46,6 +51,28 @@ export function ScreenHeader( {
 	onChangeViewport,
 	onChangePseudoState,
 }: ScreenHeaderProps ) {
+	const activeStates: ActiveState[] = [];
+	const activeViewport = viewportStates?.find(
+		( state ) => state.value === selectedViewport
+	);
+	const activePseudoState = pseudoStates?.find(
+		( state ) => state.value === selectedPseudoState
+	);
+
+	if ( activeViewport ) {
+		activeStates.push( {
+			key: `viewport-${ activeViewport.value }`,
+			label: activeViewport.label,
+		} );
+	}
+
+	if ( activePseudoState ) {
+		activeStates.push( {
+			key: `pseudo-${ activePseudoState.value }`,
+			label: activePseudoState.label,
+		} );
+	}
+
 	return (
 		<VStack spacing={ 0 }>
 			<View>
@@ -67,16 +94,25 @@ export function ScreenHeader( {
 									>
 										{ title }
 									</Heading>
-									<StateControl
-										viewportStates={ viewportStates }
-										pseudoStates={ pseudoStates }
-										viewportValue={ selectedViewport }
-										pseudoStateValue={ selectedPseudoState }
-										onChangeViewport={ onChangeViewport }
-										onChangePseudoState={
-											onChangePseudoState
-										}
-									/>
+									<VStack spacing={ 2 } alignment="right">
+										<StateControl
+											viewportStates={ viewportStates }
+											pseudoStates={ pseudoStates }
+											viewportValue={ selectedViewport }
+											pseudoStateValue={
+												selectedPseudoState
+											}
+											onChangeViewport={
+												onChangeViewport
+											}
+											onChangePseudoState={
+												onChangePseudoState
+											}
+										/>
+										<StateControlBadges
+											states={ activeStates }
+										/>
+									</VStack>
 								</HStack>
 							</Spacer>
 						</HStack>

--- a/packages/global-styles-ui/src/screen-header.tsx
+++ b/packages/global-styles-ui/src/screen-header.tsx
@@ -23,11 +23,6 @@ import { unlock } from './lock-unlock';
 
 const { StateControl, StateControlBadges } = unlock( blockEditorPrivateApis );
 
-interface ActiveState {
-	key: string;
-	label: string;
-}
-
 interface ScreenHeaderProps {
 	title: string;
 	description?: string | React.ReactElement;
@@ -51,28 +46,6 @@ export function ScreenHeader( {
 	onChangeViewport,
 	onChangePseudoState,
 }: ScreenHeaderProps ) {
-	const activeStates: ActiveState[] = [];
-	const activeViewport = viewportStates?.find(
-		( state ) => state.value === selectedViewport
-	);
-	const activePseudoState = pseudoStates?.find(
-		( state ) => state.value === selectedPseudoState
-	);
-
-	if ( activeViewport ) {
-		activeStates.push( {
-			key: `viewport-${ activeViewport.value }`,
-			label: activeViewport.label,
-		} );
-	}
-
-	if ( activePseudoState ) {
-		activeStates.push( {
-			key: `pseudo-${ activePseudoState.value }`,
-			label: activePseudoState.label,
-		} );
-	}
-
 	return (
 		<VStack spacing={ 0 }>
 			<View>
@@ -110,7 +83,12 @@ export function ScreenHeader( {
 											}
 										/>
 										<StateControlBadges
-											states={ activeStates }
+											viewportStates={ viewportStates }
+											pseudoStates={ pseudoStates }
+											viewportValue={ selectedViewport }
+											pseudoStateValue={
+												selectedPseudoState
+											}
 										/>
 									</VStack>
 								</HStack>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Based on https://github.com/WordPress/gutenberg/pull/76491 and proposes to merge into that branch.

Proposes adding the badges that indicate state selection to block instances.

Also makes the dropdown open to the left of the inspector sidebar, like other dropdowns in the inspector do.

## Why?
I think this helps indicate to the user that the styling changes they're making will apply only to the specific states (e.g. hover).

The exact UI can probably be refined, but I think this is a good start.

## How?
Extracts a `StateControlBadges` component that can be used in different parts of the UI. Previously the badges were couple to the dropdown, but showing the states underneath the dropdown doesn't work so well for the block card.

## Testing Instructions
1. Insert a button block.
2. Toggle a state in the block inspector
3. Observe the badge appears.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="274" height="185" alt="Screenshot 2026-05-11 at 3 13 30 pm" src="https://github.com/user-attachments/assets/5af8d16b-d38c-4e7a-9549-b68e7cefac16" />

## Use of AI Tools
OpenCode / Codex