### PR TITLE
Experiment: Content types invaidate cache for synced taxonomies-post types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58937,6 +58937,7 @@
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
+				"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 				"@wordpress/notices": "file:../notices",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/route": "file:../route",

--- a/packages/content-types/package.json
+++ b/packages/content-types/package.json
@@ -43,6 +43,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/route": "file:../route",

--- a/packages/content-types/src/post-types/actions/delete.tsx
+++ b/packages/content-types/src/post-types/actions/delete.tsx
@@ -16,7 +16,7 @@ import { Stack, Text } from '@wordpress/ui';
  */
 import type { PostTypeFormData } from '../types';
 import type { CoreDataError } from '../../types';
-import { useMaybeInvalidateCache } from '../../utils/use-maybe-invalidate-cache';
+import { useMaybeInvalidateContentTypeCache } from '../../utils/use-maybe-invalidate-content-type-cache';
 import { POST_TYPE_ENTITY, TAXONOMY_ENTITY } from '../../constants';
 
 function DeletePostTypeModal( {
@@ -32,7 +32,7 @@ function DeletePostTypeModal( {
 	const { deleteEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
-	const maybeInvalidateCache = useMaybeInvalidateCache();
+	const maybeInvalidateCache = useMaybeInvalidateContentTypeCache();
 
 	async function onDelete() {
 		if ( isDeleting ) {

--- a/packages/content-types/src/post-types/actions/delete.tsx
+++ b/packages/content-types/src/post-types/actions/delete.tsx
@@ -16,7 +16,8 @@ import { Stack, Text } from '@wordpress/ui';
  */
 import type { PostTypeFormData } from '../types';
 import type { CoreDataError } from '../../types';
-import { POST_TYPE_ENTITY } from '../../constants';
+import { useMaybeInvalidateCache } from '../../utils/use-maybe-invalidate-cache';
+import { POST_TYPE_ENTITY, TAXONOMY_ENTITY } from '../../constants';
 
 function DeletePostTypeModal( {
 	items,
@@ -31,6 +32,7 @@ function DeletePostTypeModal( {
 	const { deleteEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
+	const maybeInvalidateCache = useMaybeInvalidateCache();
 
 	async function onDelete() {
 		if ( isDeleting ) {
@@ -120,6 +122,10 @@ function DeletePostTypeModal( {
 			}
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 		}
+		const deletedRefs = itemsToDelete
+			.filter( ( _, i ) => promiseResult[ i ].status === 'fulfilled' )
+			.flatMap( ( item ) => item.config.taxonomies );
+		maybeInvalidateCache( deletedRefs, [], TAXONOMY_ENTITY );
 		onActionPerformed?.( itemsToDelete );
 		setIsDeleting( false );
 		closeModal?.();

--- a/packages/content-types/src/post-types/actions/quick-edit.tsx
+++ b/packages/content-types/src/post-types/actions/quick-edit.tsx
@@ -34,7 +34,8 @@ import {
 } from '../../utils/fields';
 import type { PostTypeFormData } from '../types';
 import { serializeForSave } from '../utils';
-import { POST_TYPE_ENTITY } from '../../constants';
+import { useMaybeInvalidateCache } from '../../utils/use-maybe-invalidate-cache';
+import { POST_TYPE_ENTITY, TAXONOMY_ENTITY } from '../../constants';
 
 function QuickEditPostTypeModal( {
 	items,
@@ -68,6 +69,7 @@ function QuickEditPostTypeModal( {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
+	const maybeInvalidateCache = useMaybeInvalidateCache();
 
 	async function onSave() {
 		if ( isSaving || ! isValid ) {
@@ -88,6 +90,11 @@ function QuickEditPostTypeModal( {
 					data.title.raw
 				),
 				{ type: 'snackbar' }
+			);
+			maybeInvalidateCache(
+				item.config.taxonomies,
+				data.config.taxonomies,
+				TAXONOMY_ENTITY
 			);
 			closeModal?.();
 		} catch ( error: any ) {

--- a/packages/content-types/src/post-types/actions/quick-edit.tsx
+++ b/packages/content-types/src/post-types/actions/quick-edit.tsx
@@ -34,7 +34,7 @@ import {
 } from '../../utils/fields';
 import type { PostTypeFormData } from '../types';
 import { serializeForSave } from '../utils';
-import { useMaybeInvalidateCache } from '../../utils/use-maybe-invalidate-cache';
+import { useMaybeInvalidateContentTypeCache } from '../../utils/use-maybe-invalidate-content-type-cache';
 import { POST_TYPE_ENTITY, TAXONOMY_ENTITY } from '../../constants';
 
 function QuickEditPostTypeModal( {
@@ -69,7 +69,7 @@ function QuickEditPostTypeModal( {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
-	const maybeInvalidateCache = useMaybeInvalidateCache();
+	const maybeInvalidateCache = useMaybeInvalidateContentTypeCache();
 
 	async function onSave() {
 		if ( isSaving || ! isValid ) {

--- a/packages/content-types/src/post-types/edit.tsx
+++ b/packages/content-types/src/post-types/edit.tsx
@@ -64,7 +64,13 @@ import {
 } from '../utils/fields';
 import type { PostTypeFormData, PostTypeRecord } from './types';
 import { BLANK_RECORD, serializeForSave, toFormData } from './utils';
-import { NEW_ID, POST_TYPE_ENTITY, POST_TYPES_PATH } from '../constants';
+import { useMaybeInvalidateCache } from '../utils/use-maybe-invalidate-cache';
+import {
+	NEW_ID,
+	POST_TYPE_ENTITY,
+	POST_TYPES_PATH,
+	TAXONOMY_ENTITY,
+} from '../constants';
 
 type PostTypePageProps = {
 	isAddMode: boolean;
@@ -221,6 +227,7 @@ function PostTypePage( {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
+	const maybeInvalidateCache = useMaybeInvalidateCache();
 
 	async function onSave() {
 		if ( isSaving || ! isValid ) {
@@ -246,6 +253,11 @@ function PostTypePage( {
 						data.title.raw
 				  );
 			createSuccessNotice( successMessage, { type: 'snackbar' } );
+			maybeInvalidateCache(
+				initialData.config.taxonomies,
+				data.config.taxonomies,
+				TAXONOMY_ENTITY
+			);
 			if ( saved?.id !== undefined ) {
 				onSaved?.( { ...data, id: saved.id } );
 			}

--- a/packages/content-types/src/post-types/edit.tsx
+++ b/packages/content-types/src/post-types/edit.tsx
@@ -64,7 +64,7 @@ import {
 } from '../utils/fields';
 import type { PostTypeFormData, PostTypeRecord } from './types';
 import { BLANK_RECORD, serializeForSave, toFormData } from './utils';
-import { useMaybeInvalidateCache } from '../utils/use-maybe-invalidate-cache';
+import { useMaybeInvalidateContentTypeCache } from '../utils/use-maybe-invalidate-content-type-cache';
 import {
 	NEW_ID,
 	POST_TYPE_ENTITY,
@@ -227,7 +227,7 @@ function PostTypePage( {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
-	const maybeInvalidateCache = useMaybeInvalidateCache();
+	const maybeInvalidateCache = useMaybeInvalidateContentTypeCache();
 
 	async function onSave() {
 		if ( isSaving || ! isValid ) {

--- a/packages/content-types/src/taxonomies/actions/delete.tsx
+++ b/packages/content-types/src/taxonomies/actions/delete.tsx
@@ -16,7 +16,8 @@ import { Stack, Text } from '@wordpress/ui';
  */
 import type { TaxonomyFormData } from '../types';
 import type { CoreDataError } from '../../types';
-import { TAXONOMY_ENTITY } from '../../constants';
+import { useMaybeInvalidateCache } from '../../utils/use-maybe-invalidate-cache';
+import { POST_TYPE_ENTITY, TAXONOMY_ENTITY } from '../../constants';
 
 function DeleteTaxonomyModal( {
 	items,
@@ -31,6 +32,7 @@ function DeleteTaxonomyModal( {
 	const { deleteEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
+	const maybeInvalidateCache = useMaybeInvalidateCache();
 
 	async function onDelete() {
 		if ( isDeleting ) {
@@ -120,6 +122,10 @@ function DeleteTaxonomyModal( {
 			}
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 		}
+		const deletedRefs = itemsToDelete
+			.filter( ( _, i ) => promiseResult[ i ].status === 'fulfilled' )
+			.flatMap( ( item ) => item.config.object_type );
+		maybeInvalidateCache( deletedRefs, [], POST_TYPE_ENTITY );
 		onActionPerformed?.( itemsToDelete );
 		setIsDeleting( false );
 		closeModal?.();

--- a/packages/content-types/src/taxonomies/actions/delete.tsx
+++ b/packages/content-types/src/taxonomies/actions/delete.tsx
@@ -16,7 +16,7 @@ import { Stack, Text } from '@wordpress/ui';
  */
 import type { TaxonomyFormData } from '../types';
 import type { CoreDataError } from '../../types';
-import { useMaybeInvalidateCache } from '../../utils/use-maybe-invalidate-cache';
+import { useMaybeInvalidateContentTypeCache } from '../../utils/use-maybe-invalidate-content-type-cache';
 import { POST_TYPE_ENTITY, TAXONOMY_ENTITY } from '../../constants';
 
 function DeleteTaxonomyModal( {
@@ -32,7 +32,7 @@ function DeleteTaxonomyModal( {
 	const { deleteEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
-	const maybeInvalidateCache = useMaybeInvalidateCache();
+	const maybeInvalidateCache = useMaybeInvalidateContentTypeCache();
 
 	async function onDelete() {
 		if ( isDeleting ) {

--- a/packages/content-types/src/taxonomies/actions/quick-edit.tsx
+++ b/packages/content-types/src/taxonomies/actions/quick-edit.tsx
@@ -33,7 +33,8 @@ import {
 } from '../../utils/fields';
 import type { TaxonomyFormData } from '../types';
 import { serializeForSave } from '../utils';
-import { TAXONOMY_ENTITY } from '../../constants';
+import { useMaybeInvalidateCache } from '../../utils/use-maybe-invalidate-cache';
+import { POST_TYPE_ENTITY, TAXONOMY_ENTITY } from '../../constants';
 
 function QuickEditTaxonomyModal( {
 	items,
@@ -66,6 +67,7 @@ function QuickEditTaxonomyModal( {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
+	const maybeInvalidateCache = useMaybeInvalidateCache();
 
 	async function onSave() {
 		if ( isSaving || ! isValid ) {
@@ -86,6 +88,11 @@ function QuickEditTaxonomyModal( {
 					data.title.raw
 				),
 				{ type: 'snackbar' }
+			);
+			maybeInvalidateCache(
+				item.config.object_type,
+				data.config.object_type,
+				POST_TYPE_ENTITY
 			);
 			closeModal?.();
 		} catch ( error: any ) {

--- a/packages/content-types/src/taxonomies/actions/quick-edit.tsx
+++ b/packages/content-types/src/taxonomies/actions/quick-edit.tsx
@@ -33,7 +33,7 @@ import {
 } from '../../utils/fields';
 import type { TaxonomyFormData } from '../types';
 import { serializeForSave } from '../utils';
-import { useMaybeInvalidateCache } from '../../utils/use-maybe-invalidate-cache';
+import { useMaybeInvalidateContentTypeCache } from '../../utils/use-maybe-invalidate-content-type-cache';
 import { POST_TYPE_ENTITY, TAXONOMY_ENTITY } from '../../constants';
 
 function QuickEditTaxonomyModal( {
@@ -67,7 +67,7 @@ function QuickEditTaxonomyModal( {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
-	const maybeInvalidateCache = useMaybeInvalidateCache();
+	const maybeInvalidateCache = useMaybeInvalidateContentTypeCache();
 
 	async function onSave() {
 		if ( isSaving || ! isValid ) {

--- a/packages/content-types/src/taxonomies/edit.tsx
+++ b/packages/content-types/src/taxonomies/edit.tsx
@@ -63,7 +63,7 @@ import {
 } from '../utils/fields';
 import type { TaxonomyFormData, TaxonomyRecord } from './types';
 import { BLANK_RECORD, serializeForSave, toFormData } from './utils';
-import { useMaybeInvalidateCache } from '../utils/use-maybe-invalidate-cache';
+import { useMaybeInvalidateContentTypeCache } from '../utils/use-maybe-invalidate-content-type-cache';
 import {
 	NEW_ID,
 	POST_TYPE_ENTITY,
@@ -238,7 +238,7 @@ function TaxonomyPage( {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
-	const maybeInvalidateCache = useMaybeInvalidateCache();
+	const maybeInvalidateCache = useMaybeInvalidateContentTypeCache();
 
 	async function onSave() {
 		if ( isSaving || ! isValid ) {

--- a/packages/content-types/src/taxonomies/edit.tsx
+++ b/packages/content-types/src/taxonomies/edit.tsx
@@ -63,7 +63,13 @@ import {
 } from '../utils/fields';
 import type { TaxonomyFormData, TaxonomyRecord } from './types';
 import { BLANK_RECORD, serializeForSave, toFormData } from './utils';
-import { NEW_ID, TAXONOMIES_PATH, TAXONOMY_ENTITY } from '../constants';
+import { useMaybeInvalidateCache } from '../utils/use-maybe-invalidate-cache';
+import {
+	NEW_ID,
+	POST_TYPE_ENTITY,
+	TAXONOMIES_PATH,
+	TAXONOMY_ENTITY,
+} from '../constants';
 
 type TaxonomyPageProps = {
 	isAddMode: boolean;
@@ -232,6 +238,7 @@ function TaxonomyPage( {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
+	const maybeInvalidateCache = useMaybeInvalidateCache();
 
 	async function onSave() {
 		if ( isSaving || ! isValid ) {
@@ -257,6 +264,11 @@ function TaxonomyPage( {
 						data.title.raw
 				  );
 			createSuccessNotice( successMessage, { type: 'snackbar' } );
+			maybeInvalidateCache(
+				initialData.config.object_type,
+				data.config.object_type,
+				POST_TYPE_ENTITY
+			);
 			if ( saved?.id !== undefined ) {
 				onSaved?.( { ...data, id: saved.id } );
 			}

--- a/packages/content-types/src/taxonomies/types.ts
+++ b/packages/content-types/src/taxonomies/types.ts
@@ -5,6 +5,8 @@ export interface TaxonomyRecord {
 	status: 'publish' | 'draft';
 	title: { raw: string; rendered: string };
 	config: StoredConfig;
+	// WP core's `register_taxonomy()` accepts `array|string`, but the
+	// `wp_user_taxonomy` REST controller normalizes to `string[]`.
 	object_type: string[];
 }
 

--- a/packages/content-types/src/utils/use-maybe-invalidate-cache.ts
+++ b/packages/content-types/src/utils/use-maybe-invalidate-cache.ts
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+import { useRegistry } from '@wordpress/data';
+import { isShallowEqual } from '@wordpress/is-shallow-equal';
+
+/**
+ * Returns a callback that invalidates every cached `getEntityRecords`
+ * resolution for `postType / <entityName>` when `prev` and `next` differ
+ * as sets, leaving other entity types untouched.
+ *
+ * Used to keep post type and taxonomy list views in sync: they share a
+ * server-side source of truth (the taxonomy's `_wp_user_taxonomy_object_type`
+ * meta), so saving or deleting on one side leaves the opposite list cache
+ * stale.
+ */
+export function useMaybeInvalidateCache() {
+	const registry = useRegistry();
+	return useCallback(
+		( prev: string[], next: string[], entityName: string ) => {
+			if ( isShallowEqual( [ ...prev ].sort(), [ ...next ].sort() ) ) {
+				return;
+			}
+			const resolvers = registry.select( coreStore ).getCachedResolvers();
+
+			const cache = resolvers.getEntityRecords as
+				| Map< unknown[], { status: string } >
+				| undefined;
+
+			cache?.forEach( ( _value, args ) => {
+				if ( args[ 0 ] === 'postType' && args[ 1 ] === entityName ) {
+					registry
+						.dispatch( coreStore )
+						.invalidateResolution( 'getEntityRecords', args );
+				}
+			} );
+		},
+		[ registry ]
+	);
+}

--- a/packages/content-types/src/utils/use-maybe-invalidate-content-type-cache.ts
+++ b/packages/content-types/src/utils/use-maybe-invalidate-content-type-cache.ts
@@ -16,7 +16,7 @@ import { isShallowEqual } from '@wordpress/is-shallow-equal';
  * meta), so saving or deleting on one side leaves the opposite list cache
  * stale.
  */
-export function useMaybeInvalidateCache() {
+export function useMaybeInvalidateContentTypeCache() {
 	const registry = useRegistry();
 	return useCallback(
 		( prev: string[], next: string[], entityName: string ) => {

--- a/packages/content-types/tsconfig.json
+++ b/packages/content-types/tsconfig.json
@@ -14,6 +14,7 @@
 		{ "path": "../element" },
 		{ "path": "../i18n" },
 		{ "path": "../icons" },
+		{ "path": "../is-shallow-equal" },
 		{ "path": "../notices" },
 		{ "path": "../private-apis" },
 		{ "path": "../route" },


### PR DESCRIPTION


## What?

Part of: https://github.com/WordPress/gutenberg/issues/77600

With this [PR](https://github.com/WordPress/gutenberg/pull/77997) we started keeping in sync the user taxonomies with user post types. With the change of having both entities under the same page we also need to handle the invalidation of cache to avoid stale data. This PR does that by checking whether the respective field for each entity (e.g. `config.taxonomies` for post types) have changed


## Testing instructions
1. Enable the `Content types` experiment.
2. Go to `Settings → Content types` and create a post type
3. Then go to `taxonomies` and create one, associated with the post type you created in step 2.
4. Visit `post types` list and observe that cache was invalidated and the linked taxonomy is shown
5. Make similar updates with quick edit
6. Delete a linked entity and see the other list

## Use of AI Tools
Opus 4.7 with direction, changes and review