### PR TITLE
Experiment: Content types use `toggle` for `active` prop edit

### DIFF
--- a/packages/content-types/src/utils/fields.tsx
+++ b/packages/content-types/src/utils/fields.tsx
@@ -19,7 +19,9 @@ import { cleanForSlug } from '@wordpress/url';
 import { unlock } from '../lock-unlock';
 import type { ContentType } from '../types';
 
-const { ValidatedInputControl } = unlock( componentsPrivateApis );
+const { ValidatedInputControl, ValidatedToggleControl } = unlock(
+	componentsPrivateApis
+);
 
 // Surface field-level validity messages in priority order: structural rules
 // (required, pattern, maxLength) first, async/custom last. `required` only
@@ -168,6 +170,37 @@ export const statusField: Field< ContentType > = {
 	id: 'status',
 	label: __( 'Status' ),
 	description: __( 'Enabled and registered with WordPress when active.' ),
+	// The field keeps `label: 'Status'` so the filter chip and column header
+	// read naturally ("Status: Active"); the form toggle uses its own "Active"
+	// label — the on/off semantic is clearer next to a switch.
+	Edit: ( {
+		data,
+		field,
+		onChange,
+		hideLabelFromVision,
+		markWhenOptional,
+		validity,
+	} ) => {
+		const isActive = field.getValue( { item: data } ) === 'publish';
+		return (
+			<ValidatedToggleControl
+				label={ __( 'Active' ) }
+				hidden={ hideLabelFromVision }
+				help={ field.description }
+				markWhenOptional={ markWhenOptional }
+				customValidity={ getCustomValidity( validity ) }
+				checked={ isActive }
+				onChange={ ( next: boolean ) =>
+					onChange(
+						field.setValue( {
+							item: data,
+							value: next ? 'publish' : 'draft',
+						} )
+					)
+				}
+			/>
+		);
+	},
 	elements: [
 		{ value: 'publish', label: __( 'Active' ) },
 		{ value: 'draft', label: __( 'Inactive' ) },


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR just updates the control of the `status` field to a `toggle`

## Notes
In your testing you might encounter validation issues when post types are linked with `inactive` taxonomies and vice versa. This is tracked to be handled better and is out of scope of this PR.


## Testing instructions
1. Enable the `Content types` experiment.
2. Go to `Settings → Content types` and edit or quick edit a post type. Observe the `toggle` active control
3. Filter the list by `status` and everything should work as expected
4. Do the same for taxonomies 