### PR TITLE
Experiment: Content types - use `form` for quick edit dialogs

### DIFF
--- a/packages/content-types/src/post-types/actions/quick-edit.tsx
+++ b/packages/content-types/src/post-types/actions/quick-edit.tsx
@@ -103,7 +103,12 @@ function QuickEditPostTypeModal( {
 	}
 
 	return (
-		<>
+		<form
+			onSubmit={ ( event ) => {
+				event.preventDefault();
+				onSave();
+			} }
+		>
 			<Stack
 				className="dataviews-action-modal__quick-edit-post-type-header"
 				direction="row"
@@ -149,15 +154,15 @@ function QuickEditPostTypeModal( {
 				<Button
 					__next40pxDefaultSize
 					variant="primary"
+					type="submit"
 					isBusy={ isSaving }
-					disabled={ isSaving }
+					disabled={ isSaving || ! isValid }
 					accessibleWhenDisabled
-					onClick={ onSave }
 				>
 					{ __( 'Done' ) }
 				</Button>
 			</Stack>
-		</>
+		</form>
 	);
 }
 

--- a/packages/content-types/src/taxonomies/actions/quick-edit.tsx
+++ b/packages/content-types/src/taxonomies/actions/quick-edit.tsx
@@ -101,7 +101,12 @@ function QuickEditTaxonomyModal( {
 	}
 
 	return (
-		<>
+		<form
+			onSubmit={ ( event ) => {
+				event.preventDefault();
+				onSave();
+			} }
+		>
 			<Stack
 				className="dataviews-action-modal__quick-edit-taxonomy-header"
 				direction="row"
@@ -147,15 +152,15 @@ function QuickEditTaxonomyModal( {
 				<Button
 					__next40pxDefaultSize
 					variant="primary"
+					type="submit"
 					isBusy={ isSaving }
-					disabled={ isSaving }
+					disabled={ isSaving || ! isValid }
 					accessibleWhenDisabled
-					onClick={ onSave }
 				>
 					{ __( 'Done' ) }
 				</Button>
 			</Stack>
-		</>
+		</form>
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR does a couple of things for quick edit forms
1. `Done` is disabled while the form is invalid
2. Validation messages now surface when the user clicks `Done` with pre-existing invalid state (e.g. a linked taxonomy was deactivated).

**Noting** that better handling for `inactive` linked taxonomies/post types is tracked and will be handled separately.

## Testing instructions
1. Enable the `Content types` experiment.
3. Go to `Settings → Content types` and in `quick edit` action for a taxonomy or post type remove a value that is required(e.g. `Singular label`)
4. Observe that the submit button (`Done`) is disabled
