### PR TITLE
Experiment: Make Content Types `_builtin`

### DIFF
--- a/lib/experimental/content-types/index.php
+++ b/lib/experimental/content-types/index.php
@@ -140,6 +140,7 @@ function gutenberg_register_user_taxonomy_cpt() {
 			'has_archive'           => false,
 			'rewrite'               => false,
 			'query_var'             => false,
+			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
 		)
 	);
 

--- a/lib/experimental/content-types/post-types.php
+++ b/lib/experimental/content-types/post-types.php
@@ -73,6 +73,7 @@ function gutenberg_register_user_post_type_cpt() {
 			'has_archive'           => false,
 			'rewrite'               => false,
 			'query_var'             => false,
+			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
 		)
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR just makes the internal CPTs `_builtin`.

## Testing instructions
1. Enable the `Content types` experiment.
2. Go to `Settings → Content types` and everything should work exactly as before