### PR TITLE
Accordion: Enable layout switching controls

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -15,7 +15,7 @@ Displays a foldable layout that groups content in collapsible sections. ([Source
 -	**Name:** core/accordion
 -	**Category:** design
 -	**Allowed Blocks:** core/accordion-item
--	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), contentRole, interactivity, layout, listView, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), contentRole, interactivity, layout (allowSizingOnChildren, allowSwitching), listView, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** autoclose, headingLevel, iconPosition, levelOptions, showIcon
 
 ## Accordion Heading

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Accordion Block: Enable layout switching and child sizing controls.
+
 ## 9.45.0 (2026-04-29)
 
 ## 9.44.0 (2026-04-15)

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -39,7 +39,10 @@
 			"blockGap": true
 		},
 		"shadow": true,
-		"layout": true,
+		"layout": {
+			"allowSwitching": true,
+			"allowSizingOnChildren": true
+		},
 		"ariaLabel": true,
 		"interactivity": true,
 		"typography": {


### PR DESCRIPTION
## What?

Enables layout switching for the Accordion block.

## Why?

The Accordion block already supports layout, but it did not expose the layout type switcher in the editor. This prevented users from using existing Flex and Grid layout controls for multi-column accordion layouts.

## How?

Updates `core/accordion` block supports to use:

- `layout.allowSwitching`
- `layout.allowSizingOnChildren`

## Testing Instructions

1. Insert an Accordion block.
2. Select the parent Accordion block.
3. Open the Settings sidebar.
4. Confirm the Layout panel shows the layout type switcher.
5. Switch to Flex or Grid.
6. Confirm Accordion Item child sizing controls are available.


|Before|After|
|-|-|
|<img width="1466" height="780" alt="image" src="https://github.com/user-attachments/assets/5a52a6c7-19c5-4309-97b8-80f753248966" />|<img width="1466" height="780" alt="image" src="https://github.com/user-attachments/assets/9c68c707-1385-40ea-84fc-c9def736e1af" />|

## Use of AI Tools

