### PR TITLE
migrated __experimentalText, __experimentalHStack, and __experimentalVStack to Text and Stack

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -148,8 +148,8 @@ function BlockCard( {
 				className
 			) }
 		>
-			<Stack direction="column">
-				<Stack direction="row" justify="flex-start" spacing={ 0 }>
+			<Stack direction="column" gap="xs">
+				<Stack direction="row" justify="flex-start">
 					{ parentBlockClientId && (
 						<Button
 							onClick={ () => selectBlock( parentBlockClientId ) }
@@ -187,7 +187,7 @@ function BlockCard( {
 						}
 					>
 						<BlockIcon icon={ icon } showColors />
-						<Stack direction="column" spacing={ 1 }>
+						<Stack direction="column">
 							<TitleElement className="block-editor-block-card__title">
 								<span className="block-editor-block-card__name">
 									{ !! name?.length ? name : title }

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -203,10 +203,7 @@ function BlockCard( {
 					</OptionalParentSelectButton>
 				</Stack>
 				{ ! parentClientId && ! isChild && description && (
-					<Text
-						variant="body-md"
-						className="block-editor-block-card__description"
-					>
+					<Text className="block-editor-block-card__description">
 						{ description }
 					</Text>
 				) }

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -187,7 +187,7 @@ function BlockCard( {
 						}
 					>
 						<BlockIcon icon={ icon } showColors />
-						<Stack direction="column">
+						<Stack direction="column" gap="xs">
 							<TitleElement className="block-editor-block-card__title">
 								<span className="block-editor-block-card__name">
 									{ !! name?.length ? name : title }

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -149,7 +149,7 @@ function BlockCard( {
 			) }
 		>
 			<Stack direction="column" gap="sm">
-				<Stack direction="row" justify="flex-start">
+				<Stack direction="row" align="center" justify="flex-start">
 					{ parentBlockClientId && (
 						<Button
 							onClick={ () => selectBlock( parentBlockClientId ) }

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -9,11 +9,9 @@ import clsx from 'clsx';
 import {
 	Button,
 	Icon,
-	__experimentalText as WCText,
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { Text, Stack } from '@wordpress/ui';
 import { useDispatch, useSelect } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { __, sprintf, isRTL } from '@wordpress/i18n';
@@ -150,8 +148,8 @@ function BlockCard( {
 				className
 			) }
 		>
-			<VStack>
-				<HStack justify="flex-start" spacing={ 0 }>
+			<Stack direction="column">
+				<Stack direction="row" justify="flex-start" spacing={ 0 }>
 					{ parentBlockClientId && (
 						<Button
 							onClick={ () => selectBlock( parentBlockClientId ) }
@@ -189,7 +187,7 @@ function BlockCard( {
 						}
 					>
 						<BlockIcon icon={ icon } showColors />
-						<VStack spacing={ 1 }>
+						<Stack direction="column" spacing={ 1 }>
 							<TitleElement className="block-editor-block-card__title">
 								<span className="block-editor-block-card__name">
 									{ !! name?.length ? name : title }
@@ -201,15 +199,18 @@ function BlockCard( {
 									) }
 							</TitleElement>
 							{ children }
-						</VStack>
+						</Stack>
 					</OptionalParentSelectButton>
-				</HStack>
+				</Stack>
 				{ ! parentClientId && ! isChild && description && (
-					<WCText className="block-editor-block-card__description">
+					<Text
+						variant="body-md"
+						className="block-editor-block-card__description"
+					>
 						{ description }
-					</WCText>
+					</Text>
 				) }
-			</VStack>
+			</Stack>
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -148,7 +148,7 @@ function BlockCard( {
 				className
 			) }
 		>
-			<Stack direction="column" gap="xs">
+			<Stack direction="column" gap="sm">
 				<Stack direction="row" justify="flex-start">
 					{ parentBlockClientId && (
 						<Button

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -19,11 +19,6 @@
 			"count": 2
 		}
 	},
-	"packages/block-editor/src/components/block-card/index.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 3
-		}
-	},
 	"packages/block-editor/src/components/block-inspector/edit-contents.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
<!-- #ISSUE-NUMBER or URL -->
Part of: https://github.com/WordPress/gutenberg/issues/77265

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
> Now that the required tooling is in place, we can start applying consistent text styling across the site and block editor. This can be done by replacing instances of __experimentalText and __experimentalHeading, as well as any ad hoc styled text, with the [Text](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-text--docs) component from the UI package.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- replaced the __experimentalText with @wordpress/ui Text
- replaced __experimentalHStack and __experimentalVStack with @wordpress/ui Stack

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post or page editor.
2. Insert any block
3. Open block settings on right sidebar.
4. Check the block description.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
|<img width="466" height="421" alt="Screenshot From 2026-05-11 17-12-33" src="https://github.com/user-attachments/assets/66734f79-3bad-4c88-bca4-ab638c2b306f" />|<img width="466" height="421" alt="Screenshot From 2026-05-11 17-12-54" src="https://github.com/user-attachments/assets/5d2cfa6d-5584-4bb8-a890-482608b34138" />|
## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
- Claude 4.5
