### PR TITLE
Experiment: Add term/post type count fields in content types

### DIFF
--- a/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
+++ b/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
@@ -177,8 +177,8 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 			)
 		);
 
-		$schema['properties']['post_count'] = array(
-			'description' => __( 'Number of posts in this post type.', 'gutenberg' ),
+		$schema['properties']['count'] = array(
+			'description' => __( 'Number of posts in this post type with publish, future, draft, pending, or private status.', 'gutenberg' ),
 			'type'        => 'integer',
 			'context'     => array( 'view', 'edit' ),
 			'readonly'    => true,
@@ -238,7 +238,7 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 			$data['config'] = empty( $config ) ? new stdClass() : $config;
 		}
 
-		if ( rest_is_field_included( 'post_count', $fields ) && 'publish' === $item->post_status ) {
+		if ( rest_is_field_included( 'count', $fields ) && 'publish' === $item->post_status ) {
 			// Drafts aren't registered, so the count is undefined — omit the
 			// field rather than report a value the server can't vouch for.
 			$counts = wp_count_posts( $item->post_name );
@@ -246,7 +246,7 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 			foreach ( array( 'publish', 'future', 'draft', 'pending', 'private' ) as $status ) {
 				$total += isset( $counts->$status ) ? (int) $counts->$status : 0;
 			}
-			$data['post_count'] = $total;
+			$data['count'] = $total;
 		}
 
 		$response->set_data( $data );

--- a/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
+++ b/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
@@ -178,7 +178,7 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 		);
 
 		$schema['properties']['count'] = array(
-			'description' => __( 'Number of posts in this post type with publish, future, draft, pending, or private status.', 'gutenberg' ),
+			'description' => __( 'Number of posts of this post type, matching the count shown in the admin list table\'s "All" view.', 'gutenberg' ),
 			'type'        => 'integer',
 			'context'     => array( 'view', 'edit' ),
 			'readonly'    => true,
@@ -239,12 +239,10 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 		}
 
 		if ( rest_is_field_included( 'count', $fields ) && 'publish' === $item->post_status ) {
-			// Drafts aren't registered, so the count is undefined — omit the
-			// field rather than report a value the server can't vouch for.
-			$counts = wp_count_posts( $item->post_name );
-			$total  = 0;
-			foreach ( array( 'publish', 'future', 'draft', 'pending', 'private' ) as $status ) {
-				$total += isset( $counts->$status ) ? (int) $counts->$status : 0;
+			$num_posts = wp_count_posts( $item->post_name, 'readable' );
+			$total     = array_sum( (array) $num_posts );
+			foreach ( get_post_stati( array( 'show_in_admin_all_list' => false ) ) as $state ) {
+				$total -= isset( $num_posts->$state ) ? (int) $num_posts->$state : 0;
 			}
 			$data['count'] = $total;
 		}

--- a/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
+++ b/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
@@ -177,6 +177,13 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 			)
 		);
 
+		$schema['properties']['post_count'] = array(
+			'description' => __( 'Number of posts in this post type.', 'gutenberg' ),
+			'type'        => 'integer',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
 		$this->schema = $schema;
 		return $this->add_additional_fields_schema( $this->schema );
 	}
@@ -229,6 +236,17 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 			// `type: 'object'`. PHP encodes empty associative arrays as `[]`
 			// in JSON, so cast empties to stdClass.
 			$data['config'] = empty( $config ) ? new stdClass() : $config;
+		}
+
+		if ( rest_is_field_included( 'post_count', $fields ) && 'publish' === $item->post_status ) {
+			// Drafts aren't registered, so the count is undefined — omit the
+			// field rather than report a value the server can't vouch for.
+			$counts = wp_count_posts( $item->post_name );
+			$total  = 0;
+			foreach ( array( 'publish', 'future', 'draft', 'pending', 'private' ) as $status ) {
+				$total += isset( $counts->$status ) ? (int) $counts->$status : 0;
+			}
+			$data['post_count'] = $total;
 		}
 
 		$response->set_data( $data );

--- a/lib/experimental/content-types/class-wp-rest-user-taxonomies-controller-gutenberg.php
+++ b/lib/experimental/content-types/class-wp-rest-user-taxonomies-controller-gutenberg.php
@@ -181,7 +181,7 @@ class WP_REST_User_Taxonomies_Controller_Gutenberg extends WP_REST_Posts_Control
 		if ( rest_is_field_included( 'term_count', $fields ) && 'publish' === $item->post_status ) {
 			// Drafts aren't registered, so the count is undefined — omit the
 			// field rather than report a value the server can't vouch for.
-			$count = wp_count_terms(
+			$count              = wp_count_terms(
 				array(
 					'taxonomy'   => $item->post_name,
 					'hide_empty' => false,

--- a/lib/experimental/content-types/class-wp-rest-user-taxonomies-controller-gutenberg.php
+++ b/lib/experimental/content-types/class-wp-rest-user-taxonomies-controller-gutenberg.php
@@ -137,6 +137,13 @@ class WP_REST_User_Taxonomies_Controller_Gutenberg extends WP_REST_Posts_Control
 			)
 		);
 
+		$schema['properties']['term_count'] = array(
+			'description' => __( 'Number of terms registered in the taxonomy.', 'gutenberg' ),
+			'type'        => 'integer',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
 		$this->schema = $schema;
 		return $this->add_additional_fields_schema( $this->schema );
 	}
@@ -169,6 +176,18 @@ class WP_REST_User_Taxonomies_Controller_Gutenberg extends WP_REST_Posts_Control
 
 		if ( rest_is_field_included( 'object_type', $fields ) ) {
 			$data['object_type'] = gutenberg_user_taxonomy_read_object_type( $item->ID );
+		}
+
+		if ( rest_is_field_included( 'term_count', $fields ) && 'publish' === $item->post_status ) {
+			// Drafts aren't registered, so the count is undefined — omit the
+			// field rather than report a value the server can't vouch for.
+			$count = wp_count_terms(
+				array(
+					'taxonomy'   => $item->post_name,
+					'hide_empty' => false,
+				)
+			);
+			$data['term_count'] = is_wp_error( $count ) ? 0 : (int) $count;
 		}
 
 		$response->set_data( $data );

--- a/lib/experimental/content-types/class-wp-rest-user-taxonomies-controller-gutenberg.php
+++ b/lib/experimental/content-types/class-wp-rest-user-taxonomies-controller-gutenberg.php
@@ -137,8 +137,8 @@ class WP_REST_User_Taxonomies_Controller_Gutenberg extends WP_REST_Posts_Control
 			)
 		);
 
-		$schema['properties']['term_count'] = array(
-			'description' => __( 'Number of terms registered in the taxonomy.', 'gutenberg' ),
+		$schema['properties']['count'] = array(
+			'description' => __( 'Number of terms in this taxonomy.', 'gutenberg' ),
 			'type'        => 'integer',
 			'context'     => array( 'view', 'edit' ),
 			'readonly'    => true,
@@ -178,16 +178,16 @@ class WP_REST_User_Taxonomies_Controller_Gutenberg extends WP_REST_Posts_Control
 			$data['object_type'] = gutenberg_user_taxonomy_read_object_type( $item->ID );
 		}
 
-		if ( rest_is_field_included( 'term_count', $fields ) && 'publish' === $item->post_status ) {
+		if ( rest_is_field_included( 'count', $fields ) && 'publish' === $item->post_status ) {
 			// Drafts aren't registered, so the count is undefined — omit the
 			// field rather than report a value the server can't vouch for.
-			$count              = wp_count_terms(
+			$count         = wp_count_terms(
 				array(
 					'taxonomy'   => $item->post_name,
 					'hide_empty' => false,
 				)
 			);
-			$data['term_count'] = is_wp_error( $count ) ? 0 : (int) $count;
+			$data['count'] = is_wp_error( $count ) ? 0 : (int) $count;
 		}
 
 		$response->set_data( $data );

--- a/packages/content-types/src/post-types/fields/general.tsx
+++ b/packages/content-types/src/post-types/fields/general.tsx
@@ -78,13 +78,13 @@ export const showInRestField = createBooleanField(
 	}
 );
 
-export const postCountField: Field< PostTypeFormData > = {
-	id: 'post_count',
+export const countField: Field< PostTypeFormData > = {
+	id: 'count',
 	label: __( 'Posts' ),
 	type: 'integer',
 	readOnly: true,
 	render: ( { item } ) => {
-		const count = item.post_count;
+		const count = item.count;
 		if ( item.status !== 'publish' || ! count ) {
 			return <span aria-hidden="true">—</span>;
 		}

--- a/packages/content-types/src/post-types/fields/general.tsx
+++ b/packages/content-types/src/post-types/fields/general.tsx
@@ -6,8 +6,9 @@ import { resolveSelect, useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import type { Field, Form } from '@wordpress/dataviews';
+import { addQueryArgs } from '@wordpress/url';
 // eslint-disable-next-line @wordpress/use-recommended-components -- Used here because it supports rendering as a `span` via the `render` prop to avoid invalid HTML.
-import { Notice, Stack } from '@wordpress/ui';
+import { Link, Notice, Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -76,6 +77,30 @@ export const showInRestField = createBooleanField(
 		),
 	}
 );
+
+export const postCountField: Field< PostTypeFormData > = {
+	id: 'post_count',
+	label: __( 'Posts' ),
+	type: 'integer',
+	readOnly: true,
+	render: ( { item } ) => {
+		const count = item.post_count;
+		if ( item.status !== 'publish' || ! count ) {
+			return <span aria-hidden="true">—</span>;
+		}
+		return (
+			<Link
+				href={ addQueryArgs( 'edit.php', {
+					post_type: item.slug,
+				} ) }
+			>
+				{ count }
+			</Link>
+		);
+	},
+	enableSorting: false,
+	filterBy: false,
+};
 
 export const supportsField: Field< PostTypeFormData > = {
 	id: 'supports',

--- a/packages/content-types/src/post-types/list.tsx
+++ b/packages/content-types/src/post-types/list.tsx
@@ -19,6 +19,7 @@ import viewPostsAction from './actions/view-posts';
 import {
 	hasArchiveField,
 	hierarchicalField,
+	postCountField,
 	publicField,
 	supportsField,
 	useSlugField,
@@ -39,7 +40,7 @@ const DEFAULT_VIEW: View = {
 	type: 'table',
 	perPage: 20,
 	page: 1,
-	fields: [ 'taxonomies', 'status', 'public', 'hierarchical' ],
+	fields: [ 'taxonomies', 'post_count', 'status' ],
 	titleField: 'title',
 	layout: {},
 };
@@ -67,6 +68,7 @@ export function PostTypesList() {
 			[
 				titleField,
 				taxonomiesField,
+				postCountField,
 				statusField,
 				publicField,
 				slugField,

--- a/packages/content-types/src/post-types/list.tsx
+++ b/packages/content-types/src/post-types/list.tsx
@@ -17,9 +17,9 @@ import deletePostTypeAction from './actions/delete';
 import duplicatePostTypeAction from './actions/duplicate';
 import viewPostsAction from './actions/view-posts';
 import {
+	countField,
 	hasArchiveField,
 	hierarchicalField,
-	postCountField,
 	publicField,
 	supportsField,
 	useSlugField,
@@ -40,7 +40,7 @@ const DEFAULT_VIEW: View = {
 	type: 'table',
 	perPage: 20,
 	page: 1,
-	fields: [ 'taxonomies', 'post_count', 'status' ],
+	fields: [ 'taxonomies', 'count', 'status' ],
 	titleField: 'title',
 	layout: {},
 };
@@ -68,7 +68,7 @@ export function PostTypesList() {
 			[
 				titleField,
 				taxonomiesField,
-				postCountField,
+				countField,
 				statusField,
 				publicField,
 				slugField,

--- a/packages/content-types/src/post-types/types.ts
+++ b/packages/content-types/src/post-types/types.ts
@@ -5,7 +5,7 @@ export interface PostTypeRecord {
 	status: 'publish' | 'draft';
 	title: { raw: string; rendered: string };
 	config: StoredConfig;
-	post_count: number;
+	count: number;
 }
 
 export interface StoredLabels {
@@ -86,5 +86,5 @@ export interface PostTypeFormData extends ContentType {
 		supports: SupportFeature[];
 		has_archive: boolean;
 	};
-	post_count?: number;
+	count?: number;
 }

--- a/packages/content-types/src/post-types/types.ts
+++ b/packages/content-types/src/post-types/types.ts
@@ -5,6 +5,7 @@ export interface PostTypeRecord {
 	status: 'publish' | 'draft';
 	title: { raw: string; rendered: string };
 	config: StoredConfig;
+	post_count: number;
 }
 
 export interface StoredLabels {
@@ -85,4 +86,5 @@ export interface PostTypeFormData extends ContentType {
 		supports: SupportFeature[];
 		has_archive: boolean;
 	};
+	post_count?: number;
 }

--- a/packages/content-types/src/post-types/utils.ts
+++ b/packages/content-types/src/post-types/utils.ts
@@ -205,6 +205,7 @@ export function toFormData( row: PostTypeRecord ): PostTypeFormData {
 			has_archive: config.has_archive ?? false,
 			show_in_rest: config.show_in_rest ?? true,
 		},
+		post_count: row.post_count,
 	};
 }
 

--- a/packages/content-types/src/post-types/utils.ts
+++ b/packages/content-types/src/post-types/utils.ts
@@ -205,7 +205,7 @@ export function toFormData( row: PostTypeRecord ): PostTypeFormData {
 			has_archive: config.has_archive ?? false,
 			show_in_rest: config.show_in_rest ?? true,
 		},
-		post_count: row.post_count,
+		count: row.count,
 	};
 }
 

--- a/packages/content-types/src/taxonomies/fields/general.tsx
+++ b/packages/content-types/src/taxonomies/fields/general.tsx
@@ -157,13 +157,13 @@ export function useObjectTypeField(): Field< TaxonomyFormData > {
 	}, [ publicPostTypes ] );
 }
 
-export const termCountField: Field< TaxonomyFormData > = {
-	id: 'term_count',
+export const countField: Field< TaxonomyFormData > = {
+	id: 'count',
 	label: __( 'Terms' ),
 	type: 'integer',
 	readOnly: true,
 	render: ( { item } ) => {
-		const count = item.term_count;
+		const count = item.count;
 		if ( item.status !== 'publish' || ! count ) {
 			return <span aria-hidden="true">—</span>;
 		}

--- a/packages/content-types/src/taxonomies/fields/general.tsx
+++ b/packages/content-types/src/taxonomies/fields/general.tsx
@@ -6,8 +6,9 @@ import { resolveSelect, useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import type { Field, Form } from '@wordpress/dataviews';
+import { addQueryArgs } from '@wordpress/url';
 // eslint-disable-next-line @wordpress/use-recommended-components -- Used here because it supports rendering as a `span` via the `render` prop to avoid invalid HTML.
-import { Notice, Stack } from '@wordpress/ui';
+import { Link, Notice, Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -155,6 +156,37 @@ export function useObjectTypeField(): Field< TaxonomyFormData > {
 		};
 	}, [ publicPostTypes ] );
 }
+
+export const termCountField: Field< TaxonomyFormData > = {
+	id: 'term_count',
+	label: __( 'Terms' ),
+	type: 'integer',
+	readOnly: true,
+	render: ( { item } ) => {
+		const count = item.term_count;
+		if ( item.status !== 'publish' || ! count ) {
+			return <span aria-hidden="true">—</span>;
+		}
+		const postType = item.config.object_type?.[ 0 ];
+		// `edit-tags.php` requires a `post_type` arg, so a taxonomy with no
+		// attached post types can't be linked even when it has terms.
+		if ( ! postType ) {
+			return <>{ count }</>;
+		}
+		return (
+			<Link
+				href={ addQueryArgs( 'edit-tags.php', {
+					taxonomy: item.slug,
+					post_type: postType,
+				} ) }
+			>
+				{ count }
+			</Link>
+		);
+	},
+	enableSorting: false,
+	filterBy: false,
+};
 
 // The minimal form used by the quick-edit modal.
 export const defaultForm: Form = {

--- a/packages/content-types/src/taxonomies/fields/general.tsx
+++ b/packages/content-types/src/taxonomies/fields/general.tsx
@@ -171,7 +171,7 @@ export const countField: Field< TaxonomyFormData > = {
 		// `edit-tags.php` requires a `post_type` arg, so a taxonomy with no
 		// attached post types can't be linked even when it has terms.
 		if ( ! postType ) {
-			return <>{ count }</>;
+			return count;
 		}
 		return (
 			<Link

--- a/packages/content-types/src/taxonomies/list.tsx
+++ b/packages/content-types/src/taxonomies/list.tsx
@@ -17,9 +17,9 @@ import deleteTaxonomyAction from './actions/delete';
 import duplicateTaxonomyAction from './actions/duplicate';
 import viewTermsAction from './actions/view-terms';
 import {
+	countField,
 	hierarchicalField,
 	publicField,
-	termCountField,
 	useObjectTypeField,
 	useSlugField,
 } from './fields';
@@ -38,7 +38,7 @@ const DEFAULT_VIEW: View = {
 	type: 'table',
 	perPage: 20,
 	page: 1,
-	fields: [ 'object_type', 'term_count', 'status' ],
+	fields: [ 'object_type', 'count', 'status' ],
 	titleField: 'title',
 	layout: {},
 };
@@ -66,7 +66,7 @@ export function TaxonomiesList() {
 			[
 				titleField,
 				objectTypeField,
-				termCountField,
+				countField,
 				statusField,
 				publicField,
 				slugField,

--- a/packages/content-types/src/taxonomies/list.tsx
+++ b/packages/content-types/src/taxonomies/list.tsx
@@ -19,6 +19,7 @@ import viewTermsAction from './actions/view-terms';
 import {
 	hierarchicalField,
 	publicField,
+	termCountField,
 	useObjectTypeField,
 	useSlugField,
 } from './fields';
@@ -37,7 +38,7 @@ const DEFAULT_VIEW: View = {
 	type: 'table',
 	perPage: 20,
 	page: 1,
-	fields: [ 'object_type', 'status', 'public' ],
+	fields: [ 'object_type', 'term_count', 'status' ],
 	titleField: 'title',
 	layout: {},
 };
@@ -65,6 +66,7 @@ export function TaxonomiesList() {
 			[
 				titleField,
 				objectTypeField,
+				termCountField,
 				statusField,
 				publicField,
 				slugField,

--- a/packages/content-types/src/taxonomies/types.ts
+++ b/packages/content-types/src/taxonomies/types.ts
@@ -6,6 +6,7 @@ export interface TaxonomyRecord {
 	title: { raw: string; rendered: string };
 	config: StoredConfig;
 	object_type: string[];
+	term_count: number;
 }
 
 export interface StoredLabels {
@@ -65,4 +66,5 @@ export interface TaxonomyFormData extends ContentType {
 		show_in_quick_edit: boolean;
 		show_admin_column: boolean;
 	};
+	term_count?: number;
 }

--- a/packages/content-types/src/taxonomies/types.ts
+++ b/packages/content-types/src/taxonomies/types.ts
@@ -6,7 +6,7 @@ export interface TaxonomyRecord {
 	title: { raw: string; rendered: string };
 	config: StoredConfig;
 	object_type: string[];
-	term_count: number;
+	count: number;
 }
 
 export interface StoredLabels {
@@ -66,5 +66,5 @@ export interface TaxonomyFormData extends ContentType {
 		show_in_quick_edit: boolean;
 		show_admin_column: boolean;
 	};
-	term_count?: number;
+	count?: number;
 }

--- a/packages/content-types/src/taxonomies/utils.ts
+++ b/packages/content-types/src/taxonomies/utils.ts
@@ -165,6 +165,7 @@ export function toFormData( row: TaxonomyRecord ): TaxonomyFormData {
 		status: row.status,
 		title: { raw: row.title.raw },
 		config: formConfig,
+		term_count: row.term_count,
 	};
 }
 

--- a/packages/content-types/src/taxonomies/utils.ts
+++ b/packages/content-types/src/taxonomies/utils.ts
@@ -165,7 +165,7 @@ export function toFormData( row: TaxonomyRecord ): TaxonomyFormData {
 		status: row.status,
 		title: { raw: row.title.raw },
 		config: formConfig,
-		term_count: row.term_count,
+		count: row.count,
 	};
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/77600

This PR adds a terms count and a posts count field in each list (taxonomies and post types) in `Content types` experiment.

Additionally updates the default fields shown in each list.

I'll open a separate PR for making the view terms/posts action non-primary, since users would probably need this link as a shortcut to visit the entities.

## Testing instructions
1. Enable the `Content types` experiment.
2. Go to `Settings → Content types` and add some posts or terms for an entity
3. Observe that the count is correct and the link is right.
4. Noting that the count is shown for **active** entities