### PR TITLE
Block Editor: Add translation context for “Exit pattern”

### DIFF
--- a/packages/block-editor/src/components/block-inspector/edit-contents.js
+++ b/packages/block-editor/src/components/block-inspector/edit-contents.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { isReusableBlock, isTemplatePart } from '@wordpress/blocks';
 
@@ -76,7 +76,10 @@ function InlineEditButton( {
 				onClick={ handleClick }
 			>
 				{ editedContentOnlySection
-					? __( 'Exit pattern' )
+					? _x(
+							'Exit pattern',
+							'Button label to leave pattern editing mode'
+					  )
 					: __( 'Edit pattern' ) }
 			</Button>
 		</VStack>

--- a/packages/block-editor/src/components/block-inspector/edit-contents.js
+++ b/packages/block-editor/src/components/block-inspector/edit-contents.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { isReusableBlock, isTemplatePart } from '@wordpress/blocks';
 
@@ -67,6 +67,15 @@ function InlineEditButton( {
 		}
 	};
 
+	let buttonLabel;
+	if ( editedContentOnlySection ) {
+		/* translators: Button label to leave pattern editing mode. */
+		buttonLabel = __( 'Exit pattern' );
+	} else {
+		/* translators: Button label to enter pattern editing mode. */
+		buttonLabel = __( 'Edit pattern' );
+	}
+
 	return (
 		<VStack className="block-editor-block-inspector-edit-contents" expanded>
 			<Button
@@ -75,12 +84,7 @@ function InlineEditButton( {
 				variant="secondary"
 				onClick={ handleClick }
 			>
-				{ editedContentOnlySection
-					? _x(
-							'Exit pattern',
-							'Button label to leave pattern editing mode'
-					  )
-					: __( 'Edit pattern' ) }
+				{ buttonLabel }
 			</Button>
 		</VStack>
 	);

--- a/packages/block-editor/src/components/block-inspector/edit-contents.js
+++ b/packages/block-editor/src/components/block-inspector/edit-contents.js
@@ -67,15 +67,6 @@ function InlineEditButton( {
 		}
 	};
 
-	let buttonLabel;
-	if ( editedContentOnlySection ) {
-		/* translators: Button label to leave pattern editing mode. */
-		buttonLabel = __( 'Exit pattern' );
-	} else {
-		/* translators: Button label to enter pattern editing mode. */
-		buttonLabel = __( 'Edit pattern' );
-	}
-
 	return (
 		<VStack className="block-editor-block-inspector-edit-contents" expanded>
 			<Button
@@ -84,7 +75,11 @@ function InlineEditButton( {
 				variant="secondary"
 				onClick={ handleClick }
 			>
-				{ buttonLabel }
+				{ editedContentOnlySection
+					? /* translators: Button label to leave pattern editing mode. */
+					  __( 'Exit pattern' )
+					: /* translators: Button label to enter pattern editing mode. */
+					  __( 'Edit pattern' ) }
 			</Button>
 		</VStack>
 	);

--- a/packages/block-editor/src/components/block-toolbar/edit-section-button.js
+++ b/packages/block-editor/src/components/block-toolbar/edit-section-button.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { isReusableBlock, isTemplatePart } from '@wordpress/blocks';
 
@@ -55,15 +55,19 @@ export default function EditSectionButton( { clientId } ) {
 		}
 	};
 
+	let buttonLabel;
+	if ( isEditing ) {
+		/* translators: Button label to leave pattern editing mode. */
+		buttonLabel = __( 'Exit pattern' );
+	} else {
+		/* translators: Button label to enter pattern editing mode. */
+		buttonLabel = __( 'Edit pattern' );
+	}
+
 	return (
 		<ToolbarGroup>
 			<ToolbarButton onClick={ handleClick }>
-				{ isEditing
-					? _x(
-							'Exit pattern',
-							'Button label to leave pattern editing mode'
-					  )
-					: __( 'Edit pattern' ) }
+				{ buttonLabel }
 			</ToolbarButton>
 		</ToolbarGroup>
 	);

--- a/packages/block-editor/src/components/block-toolbar/edit-section-button.js
+++ b/packages/block-editor/src/components/block-toolbar/edit-section-button.js
@@ -55,19 +55,14 @@ export default function EditSectionButton( { clientId } ) {
 		}
 	};
 
-	let buttonLabel;
-	if ( isEditing ) {
-		/* translators: Button label to leave pattern editing mode. */
-		buttonLabel = __( 'Exit pattern' );
-	} else {
-		/* translators: Button label to enter pattern editing mode. */
-		buttonLabel = __( 'Edit pattern' );
-	}
-
 	return (
 		<ToolbarGroup>
 			<ToolbarButton onClick={ handleClick }>
-				{ buttonLabel }
+				{ isEditing
+					? /* translators: Button label to leave pattern editing mode. */
+					  __( 'Exit pattern' )
+					: /* translators: Button label to enter pattern editing mode. */
+					  __( 'Edit pattern' ) }
 			</ToolbarButton>
 		</ToolbarGroup>
 	);

--- a/packages/block-editor/src/components/block-toolbar/edit-section-button.js
+++ b/packages/block-editor/src/components/block-toolbar/edit-section-button.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { isReusableBlock, isTemplatePart } from '@wordpress/blocks';
 
@@ -58,7 +58,12 @@ export default function EditSectionButton( { clientId } ) {
 	return (
 		<ToolbarGroup>
 			<ToolbarButton onClick={ handleClick }>
-				{ isEditing ? __( 'Exit pattern' ) : __( 'Edit pattern' ) }
+				{ isEditing
+					? _x(
+							'Exit pattern',
+							'Button label to leave pattern editing mode'
+					  )
+					: __( 'Edit pattern' ) }
 			</ToolbarButton>
 		</ToolbarGroup>
 	);


### PR DESCRIPTION
## What?
Adds translation context for the “Exit pattern” label in block-editor so translators understand it means leaving pattern editing mode.
Closes #78154

## Why?
Issue  reports that “Exit Pattern” is unclear in translation tools without additional context.

## How?
Replaced `__( 'Exit pattern' )` with: `_x( 'Exit pattern', 'Button label to leave pattern editing mode' )` in both places where this label is rendered:
- inspector edit contents button
- block toolbar edit section button

## Testing Instructions
1. Open a post/page where pattern editing controls appear.
2. Enter pattern editing mode from:
   - inspector “Edit pattern” flow
   - toolbar “Edit pattern” flow
3. Confirm the label still shows “Exit pattern” and exits editing mode as before.
4. Verify no regressions in UI behavior.

