### PR TITLE
Experiment: Update view content types actions

### DIFF
--- a/packages/content-types/src/post-types/actions/view-posts.tsx
+++ b/packages/content-types/src/post-types/actions/view-posts.tsx
@@ -3,7 +3,6 @@
  */
 import type { Action } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { external } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -13,9 +12,11 @@ import type { PostTypeFormData } from '../types';
 
 const viewPostsAction: Action< PostTypeFormData > = {
 	id: 'view-posts',
-	label: __( 'View posts' ),
-	icon: external,
-	isPrimary: true,
+	label: ( items ) =>
+		items[ 0 ]?.config.labels.view_items ||
+		( items[ 0 ]?.config.hierarchical
+			? __( 'View pages' )
+			: __( 'View posts' ) ),
 	// Drafts are not registered with WordPress, so `edit.php?post_type=…`
 	// would 404. Only surface the link for active post types.
 	isEligible: ( item ) => item.status === 'publish',

--- a/packages/content-types/src/taxonomies/actions/view-terms.tsx
+++ b/packages/content-types/src/taxonomies/actions/view-terms.tsx
@@ -3,7 +3,6 @@
  */
 import type { Action } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { external } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -14,8 +13,6 @@ import type { TaxonomyFormData } from '../types';
 const viewTermsAction: Action< TaxonomyFormData > = {
 	id: 'view-terms',
 	label: __( 'View terms' ),
-	icon: external,
-	isPrimary: true,
 	// Drafts aren't registered, and `edit-tags.php` requires a `post_type`
 	// query arg to render the term list, so the taxonomy must also be
 	// attached to at least one post type.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Complementary to: https://github.com/WordPress/gutenberg/pull/78157

This PR makes the view terms/posts actions non-primary and prioritizes the post type's `view_items` label if set. I don't think it's worth it to convert this action into a hook to get the label from the store and handle cache invalidations ourselves, so I added the plain JS fallback for `hierarchical` post types like `get_post_type_labels` does.

## Testing instructions
1. Enable the `Content types` experiment.
2. Go to `Settings → Content types` and create a post type and also click `auto-fill labels` in the labels card.
3. Go back to the list and see that the action uses the proper label