### PR TITLE
[WP 7.0] Add backport for WP_ALLOW_COLLABORATION

### DIFF
--- a/backport-changelog/7.0/11311.md
+++ b/backport-changelog/7.0/11311.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11311
+
+* https://github.com/WordPress/gutenberg/pull/76716

--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-autosaves-controller.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-autosaves-controller.php
@@ -101,7 +101,7 @@ class Gutenberg_REST_Autosaves_Controller extends WP_REST_Autosaves_Controller {
 		 * Load the real-time collaboration setting and, when enabled, ensure that an
 		 * an autosave revision is always targeted.
 		 */
-		$is_collaboration_enabled = get_option( 'wp_collaboration_enabled' );
+		$is_collaboration_enabled = wp_is_collaboration_enabled();
 
 		if ( $is_draft && (int) $post->post_author === $user_id && ! $post_lock && ! $is_collaboration_enabled ) {
 			/*

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -112,7 +112,7 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 				'type'              => 'boolean',
 				'description'       => __( 'Enable Real-Time Collaboration', 'gutenberg' ),
 				'sanitize_callback' => 'rest_sanitize_boolean',
-				'default'           => false,
+				'default'           => true,
 				'show_in_rest'      => true,
 			)
 		);
@@ -123,17 +123,79 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 			function () use ( $option_name ) {
 				$option_value = get_option( $option_name );
 
-				?>
-				<label for="wp_collaboration_enabled">
-					<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', $option_value ); ?>/>
-					<?php _e( 'Enable real-time collaboration', 'gutenberg' ); ?>
-				</label>
-				<?php
+				if ( wp_is_collaboration_allowed() ) :
+					?>
+					<label for="wp_collaboration_enabled">
+						<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', $option_value ); ?>/>
+						<?php _e( "Enable early access to real-time collaboration. Real-time collaboration may affect your website's performance.", 'gutenberg' ); ?>
+					</label>
+				<?php else : ?>
+					<div class="notice notice-warning inline">
+						<?php
+						printf(
+								/* translators: %s: Prefix "Note:". */
+							'<p>' . __( '%s Real-time collaboration has been disabled.', 'gutenberg' ) . '</p>',
+							'<strong>' . __( 'Note:', 'gutenberg' ) . '</strong>'
+						);
+						?>
+					</div>
+					<?php
+				endif;
 			},
 			'writing'
 		);
 	}
 	add_action( 'admin_init', 'gutenberg_register_real_time_collaboration_setting' );
+}
+
+if ( ! function_exists( 'wp_is_collaboration_enabled' ) ) {
+	/**
+	 * Determines whether real-time collaboration is enabled.
+	 *
+	 * If the WP_ALLOW_COLLABORATION constant is false,
+	 * collaboration is always disabled regardless of the database option.
+	 * Otherwise, falls back to the 'wp_collaboration_enabled' option.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return bool Whether real-time collaboration is enabled.
+	 */
+	function wp_is_collaboration_enabled() {
+		return ( wp_is_collaboration_allowed() && (bool) get_option( 'wp_collaboration_enabled' ) );
+	}
+}
+
+if ( ! function_exists( 'wp_is_collaboration_allowed' ) ) {
+	/**
+	 * Determines whether real-time collaboration is allowed.
+	 *
+	 * If the WP_ALLOW_COLLABORATION constant is false,
+	 * collaboration is not allowed and cannot be enabled.
+	 * The constant defaults to true, unless the WP_ALLOW_COLLABORATION
+	 * environment variable is set to string "false".
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return bool Whether real-time collaboration is allowed.
+	 */
+	function wp_is_collaboration_allowed() {
+		if ( ! defined( 'WP_ALLOW_COLLABORATION' ) ) {
+			$env_value = getenv( 'WP_ALLOW_COLLABORATION' );
+			if ( false === $env_value ) {
+				// Environment variable is not defined, default to allowing collaboration.
+				define( 'WP_ALLOW_COLLABORATION', true );
+			} else {
+				/*
+				* Environment variable is defined, let's confirm it is actually set to
+				* "true" as it may still have a string value "false" – the preceeding
+				* `if` branch only tests for the boolean `false`.
+				*/
+				define( 'WP_ALLOW_COLLABORATION', 'true' === $env_value );
+			}
+		}
+
+		return WP_ALLOW_COLLABORATION;
+	}
 }
 
 /**
@@ -142,7 +204,7 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 function gutenberg_inject_real_time_collaboration_setting() {
 	global $pagenow;
 
-	if ( ! get_option( 'wp_collaboration_enabled' ) ) {
+	if ( ! wp_is_collaboration_enabled() ) {
 		return;
 	}
 
@@ -157,7 +219,7 @@ function gutenberg_inject_real_time_collaboration_setting() {
 
 	wp_add_inline_script(
 		'wp-core-data',
-		'window._wpCollaborationEnabled = ' . ( $enabled ? 'true' : 'false' ) . ';',
+		'window._wpCollaborationEnabled = ' . wp_json_encode( $enabled ) . ';',
 		'after'
 	);
 }
@@ -183,7 +245,7 @@ add_action( 'activate_gutenberg/gutenberg.php', 'gutenberg_set_collaboration_opt
 function gutenberg_post_list_collaboration_ui() {
 	global $pagenow;
 
-	if ( ! get_option( 'wp_collaboration_enabled' ) ) {
+	if ( ! wp_is_collaboration_enabled() ) {
 		return;
 	}
 


### PR DESCRIPTION

## What?

This PR backports #76716 into the `wp/7.0` branch.

## Why?

I noticed a critical error occurring in the post editor on the `wp/7.0` branch.

```
[11-May-2026 12:01:02 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function wp_is_collaboration_enabled() in /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-7.0/meta-box-rtc-compat.php:26
```

This is because the `wp_is_collaboration_enabled()` function no longer exists due to the removal of RTC functionality from the core.

https://core.trac.wordpress.org/changeset/62338

## How?

Manually backports #76716 into the `wp/7.0` branch. The Gutenberg plugin should resolve the PHP error by declaring wp_is_collaboration_allowed on its own.

Note that this PR is solely for fixing CI errors and does NOT enable the RTC feature for the 7.0 release.

## Testing Instructions

~All CI checks should be ✅.~

Unfortunately, this PR alone cannot resolve all CI issues, as the build on the `wp/7.0` branch fails due to a separate problem. See #78117 for more details.

## Use of AI Tools

I used AI to identify the PR that caused the issue.