### PR TITLE
Menu: Fix flaky keyboard focus test

### DIFF
--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -180,7 +180,9 @@ describe( 'Menu', () => {
 			// Menu closed
 			expect( screen.queryByRole( 'menuitem' ) ).not.toBeInTheDocument();
 
-			await press.Space();
+			// Keyboard-triggered clicks have `detail: 0`, which Ariakit uses to
+			// choose the initial item focus path instead of the pointer path.
+			await press.Space( toggleButton, { detail: 0 } );
 
 			// Menu open, focus is on the first focusable item
 			await waitForFocusedMenuItem( 'First item' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Updates a flaky `Menu` unit test so the Space-key interaction is simulated as a keyboard-triggered click.

## Why?

Recent CI failures show the menu opening, but focus sometimes stays on the menu container instead of moving to the first menu item. Ariakit uses the click event's `detail` value to distinguish keyboard activation from pointer activation, so the test should make that path explicit.

## How?

Passes the trigger element to `press.Space` and sets `detail: 0`, matching browser keyboard activation behavior.

## Testing Instructions

1. Run `npm run test:unit packages/components/src/menu/test/index.tsx -- --runInBand`.