### PR TITLE
Grid: fix keyboard activation on draggable items

### DIFF
--- a/packages/grid/src/dashboard-grid/grid-item.tsx
+++ b/packages/grid/src/dashboard-grid/grid-item.tsx
@@ -72,7 +72,13 @@ export function GridItem( {
 	// frame that follows a column step never renders the overlay
 	// at the pre-step offset.
 	const lastResizeDeltaRef = useRef< ResizeDelta | null >( null );
-	const { attributes, listeners, setNodeRef, isDragging } = useSortable( {
+	const {
+		attributes,
+		listeners,
+		setNodeRef,
+		setActivatorNodeRef,
+		isDragging,
+	} = useSortable( {
 		id: item.key,
 		disabled,
 	} );
@@ -197,12 +203,7 @@ export function GridItem( {
 	) : null;
 
 	return (
-		<div
-			ref={ mergedRef }
-			className={ itemClassName }
-			style={ style }
-			{ ...attributes }
-		>
+		<div ref={ mergedRef } className={ itemClassName } style={ style }>
 			{ actionableArea ? (
 				<div
 					style={ { display: 'contents' } }
@@ -213,9 +214,24 @@ export function GridItem( {
 			) : null }
 
 			<div
+				ref={ setActivatorNodeRef }
+				{ ...attributes }
 				{ ...listeners }
 				style={ {
 					height: '100%',
+					// `attributes` (tabIndex, role, aria-*) and
+					// `listeners` (onKeyDown, onPointerDown) live on
+					// the same element so keyboard activation works:
+					// Tab focuses this wrapper, Space dispatches the
+					// keydown that the listener catches. Splitting
+					// them across the outer tile and this wrapper
+					// would land focus on the outer but route the
+					// keydown only to children, never firing the
+					// activation. `setActivatorNodeRef` tells dnd-kit
+					// to treat this element as the keyboard sensor
+					// target while the outer keeps its role as the
+					// measured sortable node.
+					//
 					// Cursor lives on the listener wrapper rather
 					// than the outer tile so `actionableArea`
 					// children render their own cursor (e.g.

--- a/packages/grid/src/dashboard-grid/grid-item.tsx
+++ b/packages/grid/src/dashboard-grid/grid-item.tsx
@@ -219,27 +219,16 @@ export function GridItem( {
 				{ ...listeners }
 				style={ {
 					height: '100%',
-					// `attributes` (tabIndex, role, aria-*) and
-					// `listeners` (onKeyDown, onPointerDown) live on
-					// the same element so keyboard activation works:
-					// Tab focuses this wrapper, Space dispatches the
-					// keydown that the listener catches. Splitting
-					// them across the outer tile and this wrapper
-					// would land focus on the outer but route the
-					// keydown only to children, never firing the
-					// activation. `setActivatorNodeRef` tells dnd-kit
-					// to treat this element as the keyboard sensor
-					// target while the outer keeps its role as the
-					// measured sortable node.
+					// Keyboard activation needs `attributes` (tabIndex)
+					// and `listeners` (onKeyDown) on the same focused
+					// node; `setActivatorNodeRef` points dnd-kit's
+					// keyboard sensor here, the outer keeps `setNodeRef`
+					// for measurement.
 					//
-					// Cursor lives on the listener wrapper rather
-					// than the outer tile so `actionableArea`
-					// children render their own cursor (e.g.
-					// `pointer` on buttons) instead of inheriting
-					// the grid's `grab`. Setting `undefined`
-					// during an active gesture leaves the property
-					// off the DOM so the document-level cursor
-					// lock from the resize handle takes over.
+					// Cursor lives on this wrapper so `actionableArea`
+					// children (mounted outside it) keep their own;
+					// `undefined` during a gesture defers to the resize
+					// handle's document cursor lock.
 					cursor: getItemCursor( disabled, interacting ),
 				} }
 			>

--- a/packages/grid/src/dashboard-grid/test/keyboard-activation.test.tsx
+++ b/packages/grid/src/dashboard-grid/test/keyboard-activation.test.tsx
@@ -40,17 +40,9 @@ afterEach( () => {
 
 describe( 'DashboardGrid keyboard activation', () => {
 	it( 'places the dnd-kit keyboard activator on the inner wrapper, not the outer item', () => {
-		// dnd-kit's `useSortable` spreads `attributes` (with `role`,
-		// `tabIndex`, `aria-*`) on whatever element should receive
-		// focus, and `listeners` (with `onKeyDown`) on the element
-		// that should observe key events. Both must live on the same
-		// node for keyboard activation to fire: focus on outer + key
-		// listener on inner would never wire up because React events
-		// bubble up from the target, not down.
-		//
-		// This test asserts the DOM hierarchy that makes the wiring
-		// work, so it uses container queries and node traversal
-		// rather than role/text queries (testing-library's default).
+		// Verifies the DOM hierarchy: keyboard activation needs the
+		// focused node and the keydown listener to share a node, so
+		// the activator must live nested inside the outer item.
 		/* eslint-disable testing-library/no-container, testing-library/no-node-access */
 		const { container } = render(
 			<DashboardGrid
@@ -62,21 +54,16 @@ describe( 'DashboardGrid keyboard activation', () => {
 			</DashboardGrid>
 		);
 
-		// Edit mode also mounts a resize handle that dnd-kit decorates
-		// with `role="button"`; filter by `aria-roledescription="sortable"`
-		// so we land on the sortable activator specifically (the resize
-		// handle is `aria-roledescription="draggable"`).
+		// Edit mode also renders a resize handle with `role="button"`;
+		// `aria-roledescription="sortable"` isolates the activator.
 		const activator = container.querySelector(
 			'[role="button"][aria-roledescription="sortable"]'
 		);
 		expect( activator ).not.toBeNull();
 		expect( activator ).toHaveAttribute( 'tabindex', '0' );
 
-		// Locate the outer grid item via its inline `grid-column-end`
-		// placement style. The activator wrapper must be a strict
-		// descendant of that node; if a future change moves attributes
-		// back onto the outer, `role="button"` would land on the same
-		// node as the placement style and this assertion would fail.
+		// Outer item is identified by its inline `grid-column-end`
+		// placement style; the activator must be its descendant.
 		const items = container.querySelectorAll(
 			'[style*="grid-column-end"]'
 		);

--- a/packages/grid/src/dashboard-grid/test/keyboard-activation.test.tsx
+++ b/packages/grid/src/dashboard-grid/test/keyboard-activation.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { DashboardGrid } from '..';
+
+class MockResizeObserver {
+	observed: Set< Element > = new Set();
+	observe( element: Element ) {
+		this.observed.add( element );
+	}
+	unobserve( element: Element ) {
+		this.observed.delete( element );
+	}
+	disconnect() {
+		this.observed.clear();
+	}
+}
+
+let originalResizeObserver: typeof ResizeObserver;
+
+beforeEach( () => {
+	originalResizeObserver = global.ResizeObserver;
+	( global as unknown as { ResizeObserver: unknown } ).ResizeObserver =
+		MockResizeObserver;
+} );
+
+afterEach( () => {
+	( global as unknown as { ResizeObserver: unknown } ).ResizeObserver =
+		originalResizeObserver;
+} );
+
+describe( 'DashboardGrid keyboard activation', () => {
+	it( 'places the dnd-kit keyboard activator on the inner wrapper, not the outer item', () => {
+		// dnd-kit's `useSortable` spreads `attributes` (with `role`,
+		// `tabIndex`, `aria-*`) on whatever element should receive
+		// focus, and `listeners` (with `onKeyDown`) on the element
+		// that should observe key events. Both must live on the same
+		// node for keyboard activation to fire: focus on outer + key
+		// listener on inner would never wire up because React events
+		// bubble up from the target, not down.
+		//
+		// This test asserts the DOM hierarchy that makes the wiring
+		// work, so it uses container queries and node traversal
+		// rather than role/text queries (testing-library's default).
+		/* eslint-disable testing-library/no-container, testing-library/no-node-access */
+		const { container } = render(
+			<DashboardGrid
+				layout={ [ { key: 'a', width: 1 } ] }
+				columns={ 2 }
+				editMode
+			>
+				<div key="a">A</div>
+			</DashboardGrid>
+		);
+
+		// Edit mode also mounts a resize handle that dnd-kit decorates
+		// with `role="button"`; filter by `aria-roledescription="sortable"`
+		// so we land on the sortable activator specifically (the resize
+		// handle is `aria-roledescription="draggable"`).
+		const activator = container.querySelector(
+			'[role="button"][aria-roledescription="sortable"]'
+		);
+		expect( activator ).not.toBeNull();
+		expect( activator ).toHaveAttribute( 'tabindex', '0' );
+
+		// Locate the outer grid item via its inline `grid-column-end`
+		// placement style. The activator wrapper must be a strict
+		// descendant of that node; if a future change moves attributes
+		// back onto the outer, `role="button"` would land on the same
+		// node as the placement style and this assertion would fail.
+		const items = container.querySelectorAll(
+			'[style*="grid-column-end"]'
+		);
+		expect( items ).toHaveLength( 1 );
+		const item = items[ 0 ];
+		expect( activator ).not.toBe( item );
+		expect( item.contains( activator! ) ).toBe( true );
+		/* eslint-enable testing-library/no-container, testing-library/no-node-access */
+	} );
+} );

--- a/packages/grid/src/dashboard-lanes/lanes-item.tsx
+++ b/packages/grid/src/dashboard-lanes/lanes-item.tsx
@@ -98,7 +98,13 @@ export function LanesItem( {
 	} | null >( null );
 	const lastResizeDeltaRef = useRef< ResizeDelta | null >( null );
 
-	const { attributes, listeners, setNodeRef, isDragging } = useSortable( {
+	const {
+		attributes,
+		listeners,
+		setNodeRef,
+		setActivatorNodeRef,
+		isDragging,
+	} = useSortable( {
 		id: itemKey,
 		disabled,
 	} );
@@ -206,7 +212,6 @@ export function LanesItem( {
 			className={ itemClassName }
 			style={ style }
 			{ ...{ [ LANES_DATA_KEY ]: itemKey } }
-			{ ...attributes }
 		>
 			{ actionableArea ? (
 				<div
@@ -218,9 +223,24 @@ export function LanesItem( {
 			) : null }
 
 			<div
+				ref={ setActivatorNodeRef }
+				{ ...attributes }
 				{ ...listeners }
 				style={ {
 					height: '100%',
+					// `attributes` (tabIndex, role, aria-*) and
+					// `listeners` (onKeyDown, onPointerDown) live on
+					// the same element so keyboard activation works:
+					// Tab focuses this wrapper, Space dispatches the
+					// keydown that the listener catches. Splitting
+					// them across the outer item and this wrapper
+					// would land focus on the outer but route the
+					// keydown only to children, never firing the
+					// activation. `setActivatorNodeRef` tells dnd-kit
+					// to treat this element as the keyboard sensor
+					// target while the outer keeps its role as the
+					// measured sortable node.
+					//
 					// Cursor lives on the listener wrapper rather
 					// than the outer item so `actionableArea`
 					// children render their own cursor (e.g.

--- a/packages/grid/src/dashboard-lanes/lanes-item.tsx
+++ b/packages/grid/src/dashboard-lanes/lanes-item.tsx
@@ -228,27 +228,16 @@ export function LanesItem( {
 				{ ...listeners }
 				style={ {
 					height: '100%',
-					// `attributes` (tabIndex, role, aria-*) and
-					// `listeners` (onKeyDown, onPointerDown) live on
-					// the same element so keyboard activation works:
-					// Tab focuses this wrapper, Space dispatches the
-					// keydown that the listener catches. Splitting
-					// them across the outer item and this wrapper
-					// would land focus on the outer but route the
-					// keydown only to children, never firing the
-					// activation. `setActivatorNodeRef` tells dnd-kit
-					// to treat this element as the keyboard sensor
-					// target while the outer keeps its role as the
-					// measured sortable node.
+					// Keyboard activation needs `attributes` (tabIndex)
+					// and `listeners` (onKeyDown) on the same focused
+					// node; `setActivatorNodeRef` points dnd-kit's
+					// keyboard sensor here, the outer keeps `setNodeRef`
+					// for measurement.
 					//
-					// Cursor lives on the listener wrapper rather
-					// than the outer item so `actionableArea`
-					// children render their own cursor (e.g.
-					// `pointer` on buttons) instead of inheriting
-					// the surface's `grab`. Setting `undefined`
-					// during an active gesture leaves the property
-					// off the DOM so the document-level cursor
-					// lock from the resize handle takes over.
+					// Cursor lives on this wrapper so `actionableArea`
+					// children (mounted outside it) keep their own;
+					// `undefined` during a gesture defers to the resize
+					// handle's document cursor lock.
 					cursor: getItemCursor( disabled, interacting ),
 				} }
 			>

--- a/packages/grid/src/dashboard-lanes/test/keyboard-activation.test.tsx
+++ b/packages/grid/src/dashboard-lanes/test/keyboard-activation.test.tsx
@@ -40,17 +40,9 @@ afterEach( () => {
 
 describe( 'DashboardLanes keyboard activation', () => {
 	it( 'places the dnd-kit keyboard activator on the inner wrapper, not the outer item', () => {
-		// dnd-kit's `useSortable` spreads `attributes` (with `role`,
-		// `tabIndex`, `aria-*`) on whatever element should receive
-		// focus, and `listeners` (with `onKeyDown`) on the element
-		// that should observe key events. Both must live on the same
-		// node for keyboard activation to fire: focus on outer + key
-		// listener on inner would never wire up because React events
-		// bubble up from the target, not down.
-		//
-		// This test asserts the DOM hierarchy that makes the wiring
-		// work, so it uses container queries and node traversal
-		// rather than role/text queries (testing-library's default).
+		// Verifies the DOM hierarchy: keyboard activation needs the
+		// focused node and the keydown listener to share a node, so
+		// the activator must live nested inside the outer item.
 		/* eslint-disable testing-library/no-container, testing-library/no-node-access */
 		const { container } = render(
 			<DashboardLanes layout={ [ { key: 'a' } ] } columns={ 2 } editMode>
@@ -58,22 +50,16 @@ describe( 'DashboardLanes keyboard activation', () => {
 			</DashboardLanes>
 		);
 
-		// Edit mode also mounts a resize handle that dnd-kit decorates
-		// with `role="button"`; filter by `aria-roledescription="sortable"`
-		// so we land on the sortable activator specifically (the resize
-		// handle is `aria-roledescription="draggable"`).
+		// Edit mode also renders a resize handle with `role="button"`;
+		// `aria-roledescription="sortable"` isolates the activator.
 		const activator = container.querySelector(
 			'[role="button"][aria-roledescription="sortable"]'
 		);
 		expect( activator ).not.toBeNull();
 		expect( activator ).toHaveAttribute( 'tabindex', '0' );
 
-		// Locate the outer lanes item via the placement marker
-		// `useLanePlacement` reads. The activator wrapper must be a
-		// strict descendant of that node; if a future change moves
-		// attributes back onto the outer, `role="button"` would land
-		// on the same node as `data-lanes-key` and this assertion
-		// would fail.
+		// Outer item is identified by `data-lanes-key`; the activator
+		// must be its descendant.
 		const lanesItem = container.querySelector( '[data-lanes-key="a"]' );
 		expect( lanesItem ).not.toBeNull();
 		expect( activator ).not.toBe( lanesItem );

--- a/packages/grid/src/dashboard-lanes/test/keyboard-activation.test.tsx
+++ b/packages/grid/src/dashboard-lanes/test/keyboard-activation.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { DashboardLanes } from '..';
+
+class MockResizeObserver {
+	observed: Set< Element > = new Set();
+	observe( element: Element ) {
+		this.observed.add( element );
+	}
+	unobserve( element: Element ) {
+		this.observed.delete( element );
+	}
+	disconnect() {
+		this.observed.clear();
+	}
+}
+
+let originalResizeObserver: typeof ResizeObserver;
+
+beforeEach( () => {
+	originalResizeObserver = global.ResizeObserver;
+	( global as unknown as { ResizeObserver: unknown } ).ResizeObserver =
+		MockResizeObserver;
+} );
+
+afterEach( () => {
+	( global as unknown as { ResizeObserver: unknown } ).ResizeObserver =
+		originalResizeObserver;
+} );
+
+describe( 'DashboardLanes keyboard activation', () => {
+	it( 'places the dnd-kit keyboard activator on the inner wrapper, not the outer item', () => {
+		// dnd-kit's `useSortable` spreads `attributes` (with `role`,
+		// `tabIndex`, `aria-*`) on whatever element should receive
+		// focus, and `listeners` (with `onKeyDown`) on the element
+		// that should observe key events. Both must live on the same
+		// node for keyboard activation to fire: focus on outer + key
+		// listener on inner would never wire up because React events
+		// bubble up from the target, not down.
+		//
+		// This test asserts the DOM hierarchy that makes the wiring
+		// work, so it uses container queries and node traversal
+		// rather than role/text queries (testing-library's default).
+		/* eslint-disable testing-library/no-container, testing-library/no-node-access */
+		const { container } = render(
+			<DashboardLanes layout={ [ { key: 'a' } ] } columns={ 2 } editMode>
+				<div key="a">A</div>
+			</DashboardLanes>
+		);
+
+		// Edit mode also mounts a resize handle that dnd-kit decorates
+		// with `role="button"`; filter by `aria-roledescription="sortable"`
+		// so we land on the sortable activator specifically (the resize
+		// handle is `aria-roledescription="draggable"`).
+		const activator = container.querySelector(
+			'[role="button"][aria-roledescription="sortable"]'
+		);
+		expect( activator ).not.toBeNull();
+		expect( activator ).toHaveAttribute( 'tabindex', '0' );
+
+		// Locate the outer lanes item via the placement marker
+		// `useLanePlacement` reads. The activator wrapper must be a
+		// strict descendant of that node; if a future change moves
+		// attributes back onto the outer, `role="button"` would land
+		// on the same node as `data-lanes-key` and this assertion
+		// would fail.
+		const lanesItem = container.querySelector( '[data-lanes-key="a"]' );
+		expect( lanesItem ).not.toBeNull();
+		expect( activator ).not.toBe( lanesItem );
+		expect( lanesItem!.contains( activator! ) ).toBe( true );
+		/* eslint-enable testing-library/no-container, testing-library/no-node-access */
+	} );
+} );


### PR DESCRIPTION

## What?

Anchors the dnd-kit `useSortable` `attributes` next to its `listeners` on the same element inside `DashboardGrid` and `DashboardLanes` items, and wires `setActivatorNodeRef` so the keyboard sensor focuses the activator wrapper directly.

Adds regression tests for both surfaces under `dashboard-grid/test/keyboard-activation.test.tsx` and `dashboard-lanes/test/keyboard-activation.test.tsx`.

~**⚠️ Branched off from https://github.com/WordPress/gutenberg/pull/78107**~
Part of #77626 #77616

## Why?

Each tile used to split the sortable bindings across two nested elements: `attributes` (with `tabIndex`, `role`, `aria-*`) on the outer item, `listeners` (with `onKeyDown`) on an inner wrapper that also owned the `grab` cursor.

When the user tabbed to a tile, focus landed on the outer because of its `tabIndex`. Pressing `Space` fired `keydown` on the focused outer element.

React's synthetic events bubble up the ancestor chain from the target, never down to descendants, so the inner wrapper's `onKeyDown` listener never saw the event and the keyboard sensor's activation never fired. The Tab → Space → Arrow keys → Space drag, documented in `packages/grid/README.md` as supported, was broken in practice.

## How?

Moves `attributes` to live on the same inner wrapper as `listeners`, restoring the dnd-kit pattern where focus and keydown handlers share a node.

The outer `.item` keeps `setNodeRef` so dnd-kit measures the correct bounds for collision detection; the inner wrapper takes `setActivatorNodeRef` so the keyboard sensor and screen reader attributes target the focusable element.

The original split existed so `actionableArea` buttons could render their own cursor (e.g. `pointer`) instead of inheriting the surface's `grab`. That goal is preserved: `actionableArea` still sits outside the cursor-bearing wrapper, so its children keep their native cursors.

## Testing

### Unit / structural

```bash
npm run test:unit -- packages/grid
```

The new `keyboard-activation.test.tsx` files render each surface in edit mode and assert that the dnd-kit activator (`role="button"`, `aria-roledescription="sortable"`) is nested *inside* the outer item, not on it. Reverting the fix flips the assertion: `role="button"` lands on the same node as the placement marker (`data-lanes-key` on lanes, the inline `grid-column-end` style on grid) and the tests fail.

### Manual: before / after in Storybook

The base branch of this PR (`update/dashboard-masonry-layout`) has a `Revert` commit at HEAD that removes the fix, so checking out either branch flips between the two states without further setup.

1. From this branch, run `npm run storybook:dev`. Open the URL it prints.
2. Navigate to one of:
   - `Grid > DashboardGrid > Customization` (turn on `editMode` in Controls)
   - `Grid > DashboardLanes > EditMode`
3. Click once on the canvas so focus enters the iframe.
4. `Tab` until a tile is focused (you should see a focus ring).
5. Press `Space`. The tile should lift: the original becomes a dashed placeholder, and a clone follows the cursor in the drag overlay.
6. Use the arrow keys to move the clone between slots.
7. `Space` to drop, or `Escape` to cancel.

**Before**

https://github.com/user-attachments/assets/b35d4dce-3585-441b-877e-74b7351fa30d


**After**


https://github.com/user-attachments/assets/e0c08db7-778d-4009-9376-bdf35966555a


