### PR TITLE
WIP: Upgrade Playwright to version 1.60.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13198,13 +13198,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-			"integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.58.2"
+				"playwright": "1.59.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -46640,13 +46640,13 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-			"integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.58.2"
+				"playwright-core": "1.59.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -46659,9 +46659,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -62968,7 +62968,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.58.2",
+				"@playwright/test": "^1.59.1",
 				"@wordpress/env": ">=10.0.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
@@ -64779,7 +64779,7 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@playwright/test": "^1.58.2",
+				"@playwright/test": "^1.59.1",
 				"@types/node": "^20.19.39",
 				"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 				"@wordpress/scripts": "file:../../packages/scripts",
@@ -64879,7 +64879,7 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@playwright/test": "^1.58.2",
+				"@playwright/test": "^1.59.1",
 				"@types/node": "^20.19.39",
 				"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 				"@wordpress/scripts": "file:../../packages/scripts"
@@ -64890,7 +64890,7 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@playwright/test": "^1.58.2",
+				"@playwright/test": "^1.59.1",
 				"@storybook/react-vite": "^10.1.11",
 				"@types/node": "^20.19.39",
 				"@wordpress/element": "file:../../packages/element",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13198,13 +13198,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.59.1"
+				"playwright": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -46640,13 +46640,13 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.59.1"
+				"playwright-core": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -46659,9 +46659,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -62968,7 +62968,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.59.1",
+				"@playwright/test": "^1.60.0",
 				"@wordpress/env": ">=10.0.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
@@ -64779,7 +64779,7 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@playwright/test": "^1.59.1",
+				"@playwright/test": "^1.60.0",
 				"@types/node": "^20.19.39",
 				"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 				"@wordpress/scripts": "file:../../packages/scripts",
@@ -64879,7 +64879,7 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@playwright/test": "^1.59.1",
+				"@playwright/test": "^1.60.0",
 				"@types/node": "^20.19.39",
 				"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 				"@wordpress/scripts": "file:../../packages/scripts"
@@ -64890,7 +64890,7 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@playwright/test": "^1.59.1",
+				"@playwright/test": "^1.60.0",
 				"@storybook/react-vite": "^10.1.11",
 				"@types/node": "^20.19.39",
 				"@wordpress/element": "file:../../packages/element",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -94,7 +94,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.59.1",
+		"@playwright/test": "^1.60.0",
 		"@wordpress/env": ">=10.0.0",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -94,7 +94,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.58.2",
+		"@playwright/test": "^1.59.1",
 		"@wordpress/env": ">=10.0.0",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -21,7 +21,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.59.1",
+		"@playwright/test": "^1.60.0",
 		"@types/node": "^20.19.39",
 		"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 		"@wordpress/scripts": "file:../../packages/scripts",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -21,7 +21,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.58.2",
+		"@playwright/test": "^1.59.1",
 		"@types/node": "^20.19.39",
 		"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 		"@wordpress/scripts": "file:../../packages/scripts",

--- a/test/performance/package.json
+++ b/test/performance/package.json
@@ -21,7 +21,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.58.2",
+		"@playwright/test": "^1.59.1",
 		"@types/node": "^20.19.39",
 		"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 		"@wordpress/scripts": "file:../../packages/scripts"

--- a/test/performance/package.json
+++ b/test/performance/package.json
@@ -21,7 +21,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.59.1",
+		"@playwright/test": "^1.60.0",
 		"@types/node": "^20.19.39",
 		"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 		"@wordpress/scripts": "file:../../packages/scripts"

--- a/test/storybook-playwright/package.json
+++ b/test/storybook-playwright/package.json
@@ -21,7 +21,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.59.1",
+		"@playwright/test": "^1.60.0",
 		"@storybook/react-vite": "^10.1.11",
 		"@types/node": "^20.19.39",
 		"@wordpress/element": "file:../../packages/element",

--- a/test/storybook-playwright/package.json
+++ b/test/storybook-playwright/package.json
@@ -21,7 +21,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.58.2",
+		"@playwright/test": "^1.59.1",
 		"@storybook/react-vite": "^10.1.11",
 		"@types/node": "^20.19.39",
 		"@wordpress/element": "file:../../packages/element",


### PR DESCRIPTION
## What?
Upgrade Playwright to v1.60.0

## What's new?

https://playwright.dev/docs/release-notes#version-160

### Breaking Changes (Source: Playwright release notes)

- Removes `Locator.ariaRef()` 
- Removes `handle` option on `BrowserContext.exposeBinding` and `Page.exposeBinding`
- Removes `logger` option on `BrowserType.connect` and `BrowserType.connectOverCDP`
- `Context` options `videosPath` / `videoSize` — use `recordVideo` instead.

### Browser Versions
Chromium 148.0.7778.96
Mozilla Firefox 150.0.2
WebKit 26.4

## Testing Instructions

- Run an e2e test locally. New browsers should be downloaded, and the test should run successfully.
- Confirm that the CI checks are all passing.

## Use of AI Tools
N/A