### PR TITLE
Design System: Add AGENTS guidance for changelogs

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -15,3 +15,13 @@ For adding validation, consider using the [Validated Form Components](./src/vali
 ## Storybook
 
 Don't forget to check a components's Storybook documentation for additional usage guidance. The Storybook links ([public base URL](https://wordpress.github.io/gutenberg/)) are also useful to present to a human when they are asking for help with a component.
+
+## Changelogs
+
+Add an entry to `CHANGELOG.md` for any change in this package.
+
+-   Add the entry under `## Unreleased` at the top of the file. If that heading doesn't exist (i.e. the previous release header is at the top), add it.
+-   One entry per PR, not per commit. If the branch already has a bullet under `## Unreleased` for this PR, edit it to cover any follow-up commits rather than adding a second bullet.
+-   Pick the right sub-heading per the canonical guidance in [`packages/README.md`](../README.md#maintaining-changelogs) (`Breaking Changes`, `Deprecations`, `New Features`, `Enhancements`, `Bug Fixes`, `Internal`, etc.).
+-   When the change is scoped to one or a small number of components, prefix the bullet with the component name(s) in backticks — e.g. `` `Button`: Fix … ``. Omit the prefix for broad cross-cutting changes (build config, shared utilities, repo-wide refactors).
+-   Once the PR exists, append `([#NNNNN](https://github.com/WordPress/gutenberg/pull/NNNNN))` to the end of the bullet. If the PR number isn't known yet, omit the parenthetical.

--- a/packages/theme/AGENTS.md
+++ b/packages/theme/AGENTS.md
@@ -1,0 +1,8 @@
+## Changelogs
+
+Add an entry to `CHANGELOG.md` for any change in this package.
+
+-   Add the entry under `## Unreleased` at the top of the file. If that heading doesn't exist (i.e. the previous release header is at the top), add it.
+-   One entry per PR, not per commit. If the branch already has a bullet under `## Unreleased` for this PR, edit it to cover any follow-up commits rather than adding a second bullet.
+-   Pick the right sub-heading per the canonical guidance in [`packages/README.md`](../README.md#maintaining-changelogs) (`Breaking Changes`, `Deprecations`, `New Features`, `Enhancements`, `Bug Fixes`, `Internal`, etc.).
+-   Once the PR exists, append `([#NNNNN](https://github.com/WordPress/gutenberg/pull/NNNNN))` to the end of the bullet. If the PR number isn't known yet, omit the parenthetical.

--- a/packages/theme/CLAUDE.md
+++ b/packages/theme/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -1,0 +1,9 @@
+## Changelogs
+
+Add an entry to `CHANGELOG.md` for any change in this package.
+
+-   Add the entry under `## Unreleased` at the top of the file. If that heading doesn't exist (i.e. the previous release header is at the top), add it.
+-   One entry per PR, not per commit. If the branch already has a bullet under `## Unreleased` for this PR, edit it to cover any follow-up commits rather than adding a second bullet.
+-   Pick the right sub-heading per the canonical guidance in [`packages/README.md`](../README.md#maintaining-changelogs) (`Breaking Changes`, `Deprecations`, `New Features`, `Enhancements`, `Bug Fixes`, `Internal`, etc.).
+-   When the change is scoped to one or a small number of components, prefix the bullet with the component name(s) in backticks — e.g. `` `Select`: Fix … ``. Omit the prefix for broad cross-cutting changes (build config, shared utilities, repo-wide refactors).
+-   Once the PR exists, append `([#NNNNN](https://github.com/WordPress/gutenberg/pull/NNNNN))` to the end of the bullet. If the PR number isn't known yet, omit the parenthetical.

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## What?

Adds`AGENTS.md` guidance for design system packages (`@wordpress/components`, `@wordpress/ui`, `@wordpress/theme`) to describe expectation that each pull request should include a changelog note describing the changes.

Separately, I'll plan to open a pull request that updates existing CI tooling to cover `@wordpress/ui` and `@wordpress/theme`, in addition to `@wordpress/components`.

## Why?

For these packages, we've been intentional in encouraging changelog descriptions of any change being made, even going as far as [CI workflows which fail on the absence of a changelog](https://github.com/WordPress/gutenberg/blob/trunk/.github/workflows/check-components-changelog.yml). For `@wordpress/ui` and `@wordpress/theme`, since these packages are not bundled as `window.wp` globals and follow [Semantic Versioning](https://semver.org/), it's important that downstream consumers are kept informed about changes that might impact their usage of the package.

Through CI, [human-facing documentation](https://github.com/WordPress/gutenberg/blob/trunk/packages/README.md#maintaining-changelogs), and [inline code references](https://github.com/WordPress/gutenberg/blob/43901a29b98ddaf00e43ec4a9bd12713adaefa11/packages/ui/CHANGELOG.md#L1), our expectations around changelogs are explicitly documented. But in practice, AI agents often skip this procedure, which requires manual intervention later, often in code review [[1]](https://github.com/WordPress/gutenberg/pull/77962#pullrequestreview-4229637678) [[2]](https://github.com/WordPress/gutenberg/pull/77846#discussion_r3168813404) [[3]](https://github.com/WordPress/gutenberg/pull/77746#issuecomment-4345245804) [[4]](https://github.com/WordPress/gutenberg/pull/78057#pullrequestreview-4250362884). This creates more work for both contributors and reviewers. And it's increasingly expected that AI agents are authoring much of the code contributed through pull requests these days. [`AGENTS.md`](https://agents.md/) is purpose-fit for intervening to correct these kinds of common AI agents mistakes.

## How

Adds or updates `AGENTS.md` files, appending a section for including changelog notes for changes. As much as possible, it references existing documentation to avoid duplicating information or prioritizing AI-facing documentation over human-facing documentation.

## Testing Instructions

You could test this locally with a sample change in one of the affected packages, both on this branch and `trunk`, and see if the AI agent creates a CHANGELOG entry in each case. A successful test would produce the CHANGELOG entry on this branch and not on `trunk`.

## Use of AI Tools

Research and initial implementation with Claude Code Opus 4.7, with iterations prompted through human review, and a final human edit of the produced content.