### PR TITLE
e2e tests: use editPost and createNewPost helpers everywhere

### DIFF
--- a/test/e2e/specs/editor/blocks/comments.spec.js
+++ b/test/e2e/specs/editor/blocks/comments.spec.js
@@ -275,7 +275,6 @@ test.describe( 'Post Comments', () => {
 		admin,
 		editor,
 		requestUtils,
-		commentsBlockUtils,
 	} ) => {
 		// Create a post with the old "Post Comments" block.
 		const { id: postId } = await requestUtils.createPost( {
@@ -288,13 +287,7 @@ test.describe( 'Post Comments', () => {
 		} );
 
 		// Go to the post editor.
-		await admin.visitAdminPage(
-			'/post.php',
-			`post=${ postId }&action=edit`
-		);
-
-		// Hide welcome guide.
-		await commentsBlockUtils.hideWelcomeGuide();
+		await admin.editPost( postId );
 
 		// Check that the Post Comments block has been replaced with Comments.
 		await expect(
@@ -369,22 +362,5 @@ class CommentsBlockUtils {
 		await this.page.click( '#Update' );
 
 		return previousValue;
-	}
-
-	async hideWelcomeGuide() {
-		await this.page.evaluate( async () => {
-			const isWelcomeGuideActive = window.wp.data
-				.select( 'core/edit-post' )
-				.isFeatureActive( 'welcomeGuide' );
-
-			if ( isWelcomeGuideActive ) {
-				window.wp.data
-					.dispatch( 'core/edit-post' )
-					.toggleFeature( 'welcomeGuide' );
-			}
-		} );
-
-		await this.page.reload();
-		await this.page.waitForSelector( '.edit-post-layout' );
 	}
 }

--- a/test/e2e/specs/editor/collaboration/collaboration-autodraft-autosave-loss.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-autodraft-autosave-loss.spec.ts
@@ -72,11 +72,7 @@ test.describe( 'Collaboration - auto-draft autosave retention', () => {
 		const title = 'RTC automatic auto-draft autosave title';
 		const marker = 'rtc-automatic-auto-draft-autosave-content';
 
-		await admin.visitAdminPage( 'post-new.php' );
-		await editor.setPreferences( 'core/edit-post', {
-			welcomeGuide: false,
-			fullscreenMode: false,
-		} );
+		await admin.createNewPost();
 		await collaborationUtils.waitForEntityReady( page, {
 			requireCollaboration: false,
 			timeout: 30_000,

--- a/test/e2e/specs/editor/collaboration/collaboration-autodraft-collaborator-autosave-loss.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-autodraft-collaborator-autosave-loss.spec.ts
@@ -64,7 +64,6 @@ test.describe( 'Collaboration - auto-draft collaborator autosave retention', () 
 	test( 'keeps a new post discoverable when a collaborator makes the first autosaved edit', async ( {
 		admin,
 		collaborationUtils,
-		editor,
 		page,
 		requestUtils,
 	} ) => {
@@ -73,11 +72,7 @@ test.describe( 'Collaboration - auto-draft collaborator autosave retention', () 
 		const title = 'RTC collaborator first autosave title';
 		const marker = 'rtc-collaborator-first-autosave-content';
 
-		await admin.visitAdminPage( 'post-new.php' );
-		await editor.setPreferences( 'core/edit-post', {
-			welcomeGuide: false,
-			fullscreenMode: false,
-		} );
+		await admin.createNewPost();
 		await collaborationUtils.waitForEntityReady( page, {
 			requireCollaboration: false,
 			timeout: 30_000,

--- a/test/e2e/specs/editor/collaboration/collaboration-document-size-lock.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-document-size-lock.spec.ts
@@ -29,14 +29,7 @@ test.describe( 'Collaboration with large documents', () => {
 		const postRoom = `postType/post:${ post.id }`;
 
 		// User 1 (admin) opens the post.
-		await admin.visitAdminPage(
-			'post.php',
-			`post=${ post.id }&action=edit`
-		);
-		await editor.setPreferences( 'core/edit-post', {
-			welcomeGuide: false,
-			fullscreenMode: false,
-		} );
+		await admin.editPost( post.id );
 
 		// Wait for collaboration runtime and entity record to be ready.
 		await collaborationUtils.waitForEntityReady( page );

--- a/test/e2e/specs/editor/collaboration/collaboration-metabox-lock.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-metabox-lock.spec.ts
@@ -24,7 +24,6 @@ test.describe( 'Collaboration with meta boxes', () => {
 			collaborationUtils,
 			requestUtils,
 			admin,
-			editor,
 			page,
 		} ) => {
 			// Create a draft post.
@@ -35,14 +34,7 @@ test.describe( 'Collaboration with meta boxes', () => {
 			} );
 
 			// User 1 (admin) opens the post.
-			await admin.visitAdminPage(
-				'post.php',
-				`post=${ post.id }&action=edit`
-			);
-			await editor.setPreferences( 'core/edit-post', {
-				welcomeGuide: false,
-				fullscreenMode: false,
-			} );
+			await admin.editPost( post.id );
 
 			// Wait for collaboration runtime and entity record to be ready.
 			await collaborationUtils.waitForEntityReady( page );
@@ -132,7 +124,6 @@ test.describe( 'Collaboration with meta boxes', () => {
 			collaborationUtils,
 			requestUtils,
 			admin,
-			editor,
 			page,
 		} ) => {
 			// Create a draft post.
@@ -143,14 +134,7 @@ test.describe( 'Collaboration with meta boxes', () => {
 			} );
 
 			// User 1 (admin) opens the post.
-			await admin.visitAdminPage(
-				'post.php',
-				`post=${ post.id }&action=edit`
-			);
-			await editor.setPreferences( 'core/edit-post', {
-				welcomeGuide: false,
-				fullscreenMode: false,
-			} );
+			await admin.editPost( post.id );
 
 			// Wait for collaboration runtime and entity record to be ready.
 			await collaborationUtils.waitForEntityReady( page );

--- a/test/e2e/specs/editor/collaboration/collaboration-persistence.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-persistence.spec.ts
@@ -7,7 +7,6 @@ test.describe( 'Collaboration - CRDT persistence', () => {
 	test( 'persists CRDT document when loading existing post without one', async ( {
 		admin,
 		collaborationUtils,
-		editor,
 		page,
 		requestUtils,
 	} ) => {
@@ -19,14 +18,7 @@ test.describe( 'Collaboration - CRDT persistence', () => {
 		} );
 
 		// Open the post in the editor.
-		await admin.visitAdminPage(
-			'post.php',
-			`post=${ post.id }&action=edit`
-		);
-		await editor.setPreferences( 'core/edit-post', {
-			welcomeGuide: false,
-			fullscreenMode: false,
-		} );
+		await admin.editPost( post.id );
 
 		// Wait for collaboration runtime and entity record to be ready.
 		await collaborationUtils.waitForEntityReady( page );
@@ -51,15 +43,10 @@ test.describe( 'Collaboration - CRDT persistence', () => {
 	test( 'does not save CRDT document for auto-draft posts', async ( {
 		admin,
 		collaborationUtils,
-		editor,
 		page,
 	} ) => {
 		// Navigate to create a new post (auto-draft).
-		await admin.visitAdminPage( 'post-new.php' );
-		await editor.setPreferences( 'core/edit-post', {
-			welcomeGuide: false,
-			fullscreenMode: false,
-		} );
+		await admin.createNewPost();
 
 		// Wait for collaboration runtime to initialize separately first, then
 		// wait for the entity record resolver to finish.
@@ -94,14 +81,7 @@ test.describe( 'Collaboration - CRDT persistence', () => {
 		} );
 
 		// Open the post in the editor.
-		await admin.visitAdminPage(
-			'post.php',
-			`post=${ post.id }&action=edit`
-		);
-		await editor.setPreferences( 'core/edit-post', {
-			welcomeGuide: false,
-			fullscreenMode: false,
-		} );
+		await admin.editPost( post.id );
 
 		// Wait for collaboration runtime and entity record to be ready.
 		await collaborationUtils.waitForEntityReady( page );

--- a/test/e2e/specs/editor/collaboration/collaboration-refresh.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-refresh.spec.ts
@@ -43,14 +43,7 @@ test.describe( 'Collaboration - Refresh', () => {
 		} );
 
 		// Step 1: User A opens the post, adds content, and saves.
-		await admin.visitAdminPage(
-			'post.php',
-			`post=${ post.id }&action=edit`
-		);
-		await editor.setPreferences( 'core/edit-post', {
-			welcomeGuide: false,
-			fullscreenMode: false,
-		} );
+		await admin.editPost( post.id );
 		await page.waitForFunction(
 			() =>
 				( window as any )._wpCollaborationEnabled === true &&

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -89,19 +89,7 @@ export default class CollaborationUtils {
 	 * @param postId The post ID to open.
 	 */
 	async openPost( postId: number ) {
-		await this.admin.visitAdminPage(
-			'post.php',
-			`post=${ postId }&action=edit`
-		);
-		await this.primaryPage.waitForFunction(
-			() => window?.wp?.data && window?.wp?.blocks,
-			undefined,
-			{ timeout: 30000 }
-		);
-		await this.editor.setPreferences( 'core/edit-post', {
-			welcomeGuide: false,
-			fullscreenMode: false,
-		} );
+		await this.admin.editPost( postId );
 		await this.waitForCollaborationReady( this.primaryPage );
 	}
 

--- a/test/e2e/specs/editor/various/post-title.spec.js
+++ b/test/e2e/specs/editor/various/post-title.spec.js
@@ -55,7 +55,6 @@ test.describe( 'Post title', () => {
 
 	test.describe( 'HTML handling', () => {
 		test( `should (visually) render any HTML in Post Editor's post title field when in Visual editing mode`, async ( {
-			page,
 			editor,
 			admin,
 			requestUtils,
@@ -66,20 +65,7 @@ test.describe( 'Post title', () => {
 				status: 'publish',
 			} );
 
-			await admin.visitAdminPage(
-				'post.php',
-				`post=${ postId }&action=edit`
-			);
-
-			await page.evaluate( () => {
-				window.wp.data
-					.dispatch( 'core/preferences' )
-					.set( 'core/edit-post', 'welcomeGuide', false );
-
-				window.wp.data
-					.dispatch( 'core/preferences' )
-					.set( 'core/edit-post', 'fullscreenMode', false );
-			}, false );
+			await admin.editPost( postId );
 
 			const pageTitleField = editor.canvas.getByRole( 'textbox', {
 				name: 'Add title',
@@ -116,20 +102,7 @@ test.describe( 'Post title', () => {
 				status: 'publish',
 			} );
 
-			await admin.visitAdminPage(
-				'post.php',
-				`post=${ postId }&action=edit`
-			);
-
-			await page.evaluate( () => {
-				window.wp.data
-					.dispatch( 'core/preferences' )
-					.set( 'core/edit-post', 'welcomeGuide', false );
-
-				window.wp.data
-					.dispatch( 'core/preferences' )
-					.set( 'core/edit-post', 'fullscreenMode', false );
-			}, false );
+			await admin.editPost( postId );
 
 			// switch Editor to code editor mode
 			// Open code editor


### PR DESCRIPTION
While fixing flaky tests and searching for optimization opportunities, I noticed that we have plenty of usages of `visitAdminPage` that should be replaced with the `editPost` and `createNewPost` helpers. Which reset preferences automatically etc.

This doesn't speed up or fix anything, but still a worthy refactor.