### PR TITLE
Introduce Post Password Form block to enable styling for protected posts

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -746,6 +746,14 @@ Displays the next or previous post link that is adjacent to the current post. ([
 -	**Supports:** anchor, color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight, textAlign), ~~html~~, ~~reusable~~
 -	**Attributes:** arrow, label, linkLabel, showTitle, taxonomy, type
 
+## Post Password Form
+
+Displays a password form for password-protected posts and pages. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-password-form))
+
+-	**Name:** core/post-password-form
+-	**Category:** theme
+-	**Supports:** color (background, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~inserter~~
+
 ## Post Template
 
 Contains the block elements used to render a post, like the title, date, featured image, content or excerpt, and more. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-template))

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -108,6 +108,7 @@ import * as postDate from './post-date';
 import * as postExcerpt from './post-excerpt';
 import * as postFeaturedImage from './post-featured-image';
 import * as postNavigationLink from './post-navigation-link';
+import * as postPasswordForm from './post-password-form';
 import * as postTemplate from './post-template';
 import * as postTerms from './post-terms';
 import * as postTimeToRead from './post-time-to-read';
@@ -242,6 +243,7 @@ const getAllBlocks = () => {
 		postDate,
 		postTerms,
 		postNavigationLink,
+		postPasswordForm,
 		postTemplate,
 		postTimeToRead,
 		queryPagination,

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -37,6 +37,20 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 
 	$seen_ids[ $post_id ] = true;
 
+	if ( post_password_required( $post_id ) ) {
+		unset( $seen_ids[ $post_id ] );
+		$block_data = [
+			'blockName' => 'core/post-password-form',
+			'attrs'     => [],
+		];
+		$context = [
+			'postId' => $post_id
+		];
+		$block_instance = new WP_Block( $block_data, $context );
+
+		return $block_instance->render();
+	}
+
 	// When inside the main loop, we want to use queried object
 	// so that `the_preview` for the current post can apply.
 	// We force this behavior by omitting the third argument (post ID) from the `get_the_content`.

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -39,13 +39,13 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 
 	if ( post_password_required( $post_id ) ) {
 		unset( $seen_ids[ $post_id ] );
-		$block_data = [
+		$block_data     = array(
 			'blockName' => 'core/post-password-form',
-			'attrs'     => [],
-		];
-		$context = [
-			'postId' => $post_id
-		];
+			'attrs'     => array(),
+		);
+		$context        = array(
+			'postId' => $post_id,
+		);
 		$block_instance = new WP_Block( $block_data, $context );
 
 		return $block_instance->render();

--- a/packages/block-library/src/post-password-form/block.json
+++ b/packages/block-library/src/post-password-form/block.json
@@ -1,0 +1,55 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/post-password-form",
+	"title": "Post Password Form",
+	"category": "theme",
+	"description": "Displays a password form for password-protected posts and pages.",
+	"textdomain": "default",
+	"usesContext": [ "postId", "postType" ],
+	"supports": {
+		"html": false,
+		"inserter": false,
+		"color": {
+			"background": true,
+			"text": true,
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": false,
+				"radius": false,
+				"style": false,
+				"width": false
+			}
+		}
+	}
+}

--- a/packages/block-library/src/post-password-form/index.js
+++ b/packages/block-library/src/post-password-form/index.js
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import metadata from './block.json';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const init = () => initBlock( { name, metadata } );

--- a/packages/block-library/src/post-password-form/index.php
+++ b/packages/block-library/src/post-password-form/index.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Server-side rendering of the `core/post-password-form` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/post-password-form` block on the server.
+ *
+ * @since 23.0.0
+ * 
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ * @return string Returns the rendered password form, or an empty string if not applicable.
+ */
+function render_block_core_post_password_form( $attributes, $content, $block ) {
+	error_log("render_block_core_post_password_form" . $block->context['postId']);
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$post = get_post( $block->context['postId'] );
+	error_log("post: " . print_r($post, true));
+
+	if ( ! $post || ! post_password_required( $post ) ) {
+		return '';
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+
+	return sprintf(
+		'<div %1$s>%2$s</div>',
+		$wrapper_attributes,
+		get_the_password_form( $post )
+	);
+}
+
+/**
+ * Registers the `core/post-password-form` block on the server.
+ *
+ * @since 23.0.0
+ */
+function register_block_core_post_password_form() {
+	register_block_type_from_metadata(
+		__DIR__ . '/post-password-form',
+		array(
+			'render_callback' => 'render_block_core_post_password_form',
+		)
+	);
+}
+
+add_action( 'init', 'register_block_core_post_password_form' );

--- a/packages/block-library/src/post-password-form/index.php
+++ b/packages/block-library/src/post-password-form/index.php
@@ -9,20 +9,18 @@
  * Renders the `core/post-password-form` block on the server.
  *
  * @since 23.0.0
- * 
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
  * @return string Returns the rendered password form, or an empty string if not applicable.
  */
 function render_block_core_post_password_form( $attributes, $content, $block ) {
-	error_log("render_block_core_post_password_form" . $block->context['postId']);
 	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
 
 	$post = get_post( $block->context['postId'] );
-	error_log("post: " . print_r($post, true));
 
 	if ( ! $post || ! post_password_required( $post ) ) {
 		return '';

--- a/packages/block-library/src/post-password-form/init.js
+++ b/packages/block-library/src/post-password-form/init.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { init } from './';
+
+export default init();


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/70433

This PR introduces a new, non-insertable `core/post-password-form` block that automatically wraps the default WordPress password form, allowing it to hook into the Block Library's styling supports.

## Why?
Previously, when a post was password protected, the `core/post-content` block would simply output the legacy HTML form generated by `get_the_password_form()`. Because this output lacked standard block wrapper attributes, it was difficult for theme developers and users to apply standard Global Styles (like spacing, typography, colors, and borders) to the password form via the Site Editor or `theme.json`. 

By moving the password form into its own dedicated block, we unlock full block-support styling capabilities for password-protected content.

## How?
1. Created `core/post-password-form` with standard block supports (color, spacing, typography, borders). 
2. *Set `"inserter": false` in `block.json` so users cannot manually add this block to their content. It is meant to be handled dynamically.
3. Modified `packages/block-library/src/post-content/index.php`. During server-side rendering, if `post_password_required( $post_id )` returns true, it intercepts the standard content render and instead renders the new `core/post-password-form` block instance.

## Testing Instructions
1. Create a new Post or Page and add some content.
2. In the Document Settings sidebar, change the Visibility to "Password Protected" and set a password. Publish/Save the post.
3. View the post on the frontend. Verify the standard password form appears.
4. Open your active theme's `theme.json` file and add some test styles targeting the new block. For example:
   ```json
   "styles": {
     "blocks": {
       "core/post-password-form": {
         "color": {
           "background": "red",
           "text": "white"
         },
         "spacing": {
           "padding": "2rem"
         }
       }
     }
   }

<!--## Screenshots or screencast  if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<!--|Before|After|
|-|-|-->
<!-- | Before screenshot here --><!-- | After screenshot here | -->