### PR TITLE
Text: Fix render prop CSS defenses

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+-   `Text`: Provide CSS defense values for every variant when rendered as either a paragraph or heading element ([#78172](https://github.com/WordPress/gutenberg/pull/78172)).
 -   `Autocomplete`, `Select`: Do not show the interactive cursor for disabled select triggers or disabled popup items ([#78112](https://github.com/WordPress/gutenberg/pull/78112)).
 -   `Select`: Hide the browser focus ring on highlighted popup items ([#77919](https://github.com/WordPress/gutenberg/pull/77919)).
 -   `Drawer`: Restore the slide-out animation when the popup closes ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).

--- a/packages/ui/src/text/stories/index.story.tsx
+++ b/packages/ui/src/text/stories/index.story.tsx
@@ -66,6 +66,12 @@ export const WithRenderProp: Story = {
 				A paragraph of body text rendered as a semantic paragraph
 				element.
 			</Text>
+			<Text variant="body-sm" render={ <h3 /> }>
+				Body typography rendered as a semantic heading.
+			</Text>
+			<Text variant="heading-md" render={ <p /> }>
+				Heading typography rendered as a semantic paragraph.
+			</Text>
 		</Stack>
 	),
 };

--- a/packages/ui/src/text/stories/index.story.tsx
+++ b/packages/ui/src/text/stories/index.story.tsx
@@ -66,12 +66,6 @@ export const WithRenderProp: Story = {
 				A paragraph of body text rendered as a semantic paragraph
 				element.
 			</Text>
-			<Text variant="body-sm" render={ <h3 /> }>
-				Body typography rendered as a semantic heading.
-			</Text>
-			<Text variant="heading-md" render={ <p /> }>
-				Heading typography rendered as a semantic paragraph.
-			</Text>
 		</Stack>
 	),
 };

--- a/packages/ui/src/text/style.module.css
+++ b/packages/ui/src/text/style.module.css
@@ -9,9 +9,7 @@
 	   provides values for both element-specific CSS defenses. */
 	.heading-2xl {
 		--_gcd-heading-font-size: var(--wpds-typography-font-size-2xl);
-		--_gcd-heading-font-weight: var(
-			--wpds-typography-font-weight-medium
-		);
+		--_gcd-heading-font-weight: var(--wpds-typography-font-weight-medium);
 		--_gcd-p-font-size: var(--wpds-typography-font-size-2xl);
 		--_gcd-p-line-height: var(--wpds-typography-line-height-2xl);
 
@@ -23,9 +21,7 @@
 
 	.heading-xl {
 		--_gcd-heading-font-size: var(--wpds-typography-font-size-xl);
-		--_gcd-heading-font-weight: var(
-			--wpds-typography-font-weight-medium
-		);
+		--_gcd-heading-font-weight: var(--wpds-typography-font-weight-medium);
 		--_gcd-p-font-size: var(--wpds-typography-font-size-xl);
 		--_gcd-p-line-height: var(--wpds-typography-line-height-md);
 
@@ -37,9 +33,7 @@
 
 	.heading-lg {
 		--_gcd-heading-font-size: var(--wpds-typography-font-size-lg);
-		--_gcd-heading-font-weight: var(
-			--wpds-typography-font-weight-medium
-		);
+		--_gcd-heading-font-weight: var(--wpds-typography-font-weight-medium);
 		--_gcd-p-font-size: var(--wpds-typography-font-size-lg);
 		--_gcd-p-line-height: var(--wpds-typography-line-height-sm);
 
@@ -51,9 +45,7 @@
 
 	.heading-md {
 		--_gcd-heading-font-size: var(--wpds-typography-font-size-md);
-		--_gcd-heading-font-weight: var(
-			--wpds-typography-font-weight-medium
-		);
+		--_gcd-heading-font-weight: var(--wpds-typography-font-weight-medium);
 		--_gcd-p-font-size: var(--wpds-typography-font-size-md);
 		--_gcd-p-line-height: var(--wpds-typography-line-height-sm);
 
@@ -65,9 +57,7 @@
 
 	.heading-sm {
 		--_gcd-heading-font-size: var(--wpds-typography-font-size-xs);
-		--_gcd-heading-font-weight: var(
-			--wpds-typography-font-weight-medium
-		);
+		--_gcd-heading-font-weight: var(--wpds-typography-font-weight-medium);
 		--_gcd-p-font-size: var(--wpds-typography-font-size-xs);
 		--_gcd-p-line-height: var(--wpds-typography-line-height-xs);
 
@@ -80,9 +70,7 @@
 
 	.body-xl {
 		--_gcd-heading-font-size: var(--wpds-typography-font-size-xl);
-		--_gcd-heading-font-weight: var(
-			--wpds-typography-font-weight-regular
-		);
+		--_gcd-heading-font-weight: var(--wpds-typography-font-weight-regular);
 		--_gcd-p-font-size: var(--wpds-typography-font-size-xl);
 		--_gcd-p-line-height: var(--wpds-typography-line-height-xl);
 
@@ -94,9 +82,7 @@
 
 	.body-lg {
 		--_gcd-heading-font-size: var(--wpds-typography-font-size-lg);
-		--_gcd-heading-font-weight: var(
-			--wpds-typography-font-weight-regular
-		);
+		--_gcd-heading-font-weight: var(--wpds-typography-font-weight-regular);
 		--_gcd-p-font-size: var(--wpds-typography-font-size-lg);
 		--_gcd-p-line-height: var(--wpds-typography-line-height-md);
 
@@ -108,9 +94,7 @@
 
 	.body-md {
 		--_gcd-heading-font-size: var(--wpds-typography-font-size-md);
-		--_gcd-heading-font-weight: var(
-			--wpds-typography-font-weight-regular
-		);
+		--_gcd-heading-font-weight: var(--wpds-typography-font-weight-regular);
 		--_gcd-p-font-size: var(--wpds-typography-font-size-md);
 		--_gcd-p-line-height: var(--wpds-typography-line-height-sm);
 
@@ -122,9 +106,7 @@
 
 	.body-sm {
 		--_gcd-heading-font-size: var(--wpds-typography-font-size-sm);
-		--_gcd-heading-font-weight: var(
-			--wpds-typography-font-weight-regular
-		);
+		--_gcd-heading-font-weight: var(--wpds-typography-font-weight-regular);
 		--_gcd-p-font-size: var(--wpds-typography-font-size-sm);
 		--_gcd-p-line-height: var(--wpds-typography-line-height-xs);
 

--- a/packages/ui/src/text/style.module.css
+++ b/packages/ui/src/text/style.module.css
@@ -5,8 +5,15 @@
 		margin: 0;
 	}
 
+	/* Text variants can render as either paragraphs or headings, so each variant
+	   provides values for both element-specific CSS defenses. */
 	.heading-2xl {
 		--_gcd-heading-font-size: var(--wpds-typography-font-size-2xl);
+		--_gcd-heading-font-weight: var(
+			--wpds-typography-font-weight-medium
+		);
+		--_gcd-p-font-size: var(--wpds-typography-font-size-2xl);
+		--_gcd-p-line-height: var(--wpds-typography-line-height-2xl);
 
 		font-family: var(--wpds-typography-font-family-heading);
 		font-size: var(--wpds-typography-font-size-2xl);
@@ -16,6 +23,11 @@
 
 	.heading-xl {
 		--_gcd-heading-font-size: var(--wpds-typography-font-size-xl);
+		--_gcd-heading-font-weight: var(
+			--wpds-typography-font-weight-medium
+		);
+		--_gcd-p-font-size: var(--wpds-typography-font-size-xl);
+		--_gcd-p-line-height: var(--wpds-typography-line-height-md);
 
 		font-family: var(--wpds-typography-font-family-heading);
 		font-size: var(--wpds-typography-font-size-xl);
@@ -25,6 +37,11 @@
 
 	.heading-lg {
 		--_gcd-heading-font-size: var(--wpds-typography-font-size-lg);
+		--_gcd-heading-font-weight: var(
+			--wpds-typography-font-weight-medium
+		);
+		--_gcd-p-font-size: var(--wpds-typography-font-size-lg);
+		--_gcd-p-line-height: var(--wpds-typography-line-height-sm);
 
 		font-family: var(--wpds-typography-font-family-heading);
 		font-size: var(--wpds-typography-font-size-lg);
@@ -34,6 +51,11 @@
 
 	.heading-md {
 		--_gcd-heading-font-size: var(--wpds-typography-font-size-md);
+		--_gcd-heading-font-weight: var(
+			--wpds-typography-font-weight-medium
+		);
+		--_gcd-p-font-size: var(--wpds-typography-font-size-md);
+		--_gcd-p-line-height: var(--wpds-typography-line-height-sm);
 
 		font-family: var(--wpds-typography-font-family-heading);
 		font-size: var(--wpds-typography-font-size-md);
@@ -43,6 +65,11 @@
 
 	.heading-sm {
 		--_gcd-heading-font-size: var(--wpds-typography-font-size-xs);
+		--_gcd-heading-font-weight: var(
+			--wpds-typography-font-weight-medium
+		);
+		--_gcd-p-font-size: var(--wpds-typography-font-size-xs);
+		--_gcd-p-line-height: var(--wpds-typography-line-height-xs);
 
 		font-family: var(--wpds-typography-font-family-heading);
 		font-size: var(--wpds-typography-font-size-xs);
@@ -52,6 +79,10 @@
 	}
 
 	.body-xl {
+		--_gcd-heading-font-size: var(--wpds-typography-font-size-xl);
+		--_gcd-heading-font-weight: var(
+			--wpds-typography-font-weight-regular
+		);
 		--_gcd-p-font-size: var(--wpds-typography-font-size-xl);
 		--_gcd-p-line-height: var(--wpds-typography-line-height-xl);
 
@@ -62,6 +93,10 @@
 	}
 
 	.body-lg {
+		--_gcd-heading-font-size: var(--wpds-typography-font-size-lg);
+		--_gcd-heading-font-weight: var(
+			--wpds-typography-font-weight-regular
+		);
 		--_gcd-p-font-size: var(--wpds-typography-font-size-lg);
 		--_gcd-p-line-height: var(--wpds-typography-line-height-md);
 
@@ -72,6 +107,10 @@
 	}
 
 	.body-md {
+		--_gcd-heading-font-size: var(--wpds-typography-font-size-md);
+		--_gcd-heading-font-weight: var(
+			--wpds-typography-font-weight-regular
+		);
 		--_gcd-p-font-size: var(--wpds-typography-font-size-md);
 		--_gcd-p-line-height: var(--wpds-typography-line-height-sm);
 
@@ -82,6 +121,10 @@
 	}
 
 	.body-sm {
+		--_gcd-heading-font-size: var(--wpds-typography-font-size-sm);
+		--_gcd-heading-font-weight: var(
+			--wpds-typography-font-weight-regular
+		);
 		--_gcd-p-font-size: var(--wpds-typography-font-size-sm);
 		--_gcd-p-line-height: var(--wpds-typography-line-height-xs);
 


### PR DESCRIPTION
## What?

Follow up to #77461

Updates `Text` variant styles so every variant provides the CSS defense values needed when rendered as either a paragraph or a heading element.

## Why?
`Text` applies both paragraph and heading defense classes because the `render` prop can decouple the typographic variant from the rendered element. The variant styles need to provide values for both defenses so wp-admin global CSS does not leak through in mismatched render-prop cases.

## How?
Adds the corresponding paragraph defense values to heading variants and heading defense values to body variants. Also expands the render-prop story with mismatched variant/element examples for manual verification.

## Testing Instructions

In Storybook, render a body variant as a semantic heading, and vice versa.

## Screenshots

| Before | After |
|--------|-------|
|<img width="816" height="130" alt="Text as reverse elements, before" src="https://github.com/user-attachments/assets/6f5798dc-c728-45a0-982a-daabd723aee0" />|<img width="814" height="128" alt="Text as reverse elements, after" src="https://github.com/user-attachments/assets/3eec9a4f-d470-4103-9996-4f7480f4cbbb" />|
