### PR TITLE
Correct capitalization in help text for Breadcrumbs block

### DIFF
--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -290,7 +290,7 @@ export default function BreadcrumbEdit( {
 						setAttributes( { showOnHomePage: value } )
 					}
 					help={ __(
-						'If this breadcrumbs block appears in a template or template part that’s shown on the homepage, enable this option to display the breadcrumb trail. Otherwise, this setting has no effect.'
+						'If this Breadcrumbs block appears in a template or template part that’s shown on the homepage, enable this option to display the breadcrumb trail. Otherwise, this setting has no effect.'
 					) }
 				/>
 				<CheckboxControl


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/78174

Captilizes block name in help text under Advanced >  Show on home page

## Why?
To match the rest of the capitalization in the User Interface

## Use of AI Tools

none
