### PR TITLE
[base-styles] Bump .components-draggable__clone z-index above wp compat overlay slot

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Bump `.components-draggable__clone` z-index from `1000000000` to `1000000004` so an active drag stays above the `@wordpress/ui` compat overlay slot (`1000000003`) introduced in [#77851](https://github.com/WordPress/gutenberg/pull/77851).
+
 ### Breaking Changes
 
 -   Remove the following entries from the `z-index()` helper ([#77753](https://github.com/WordPress/gutenberg/pull/77753), [#77759](https://github.com/WordPress/gutenberg/pull/77759), [#77772](https://github.com/WordPress/gutenberg/pull/77772), [#77806](https://github.com/WordPress/gutenberg/pull/77806), [#77807](https://github.com/WordPress/gutenberg/pull/77807), [#77808](https://github.com/WordPress/gutenberg/pull/77808)):

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -23,8 +23,9 @@ $z-layers: (
 	".has-child .wp-block-navigation__submenu-container": 28,
 	".has-child:hover .wp-block-navigation__submenu-container": 29,
 
-	// The draggable element should show up above the entire UI
-	".components-draggable__clone": 1000000000,
+	// The draggable element should show up above the entire UI, including
+	// the `@wordpress/ui` compat overlay slot at `1000000003`.
+	".components-draggable__clone": 1000000004,
 
 	// Show drop zone above most standard content, but below any overlays
 	".components-drop-zone": 40,


### PR DESCRIPTION
## What?

Bump `.components-draggable__clone` from `1000000000` to `1000000004` in [`packages/base-styles/_z-index.scss`](packages/base-styles/_z-index.scss). The new value sits one above the `@wordpress/ui` compat overlay slot (`1000000003`) introduced in #77851.

Dependency: this PR is meaningful only once #77851 lands. Marked **Draft** for that reason.

## Why?

Once `@wordpress/ui` overlays (Tooltip first, in #78095) start portaling into the compat slot at `1000000003`, an active drag at `1000000000` would render *below* any popup that's mid-flight. Bumping the clone keeps the existing "drag stays above the entire UI" invariant — including above the new slot.

## How?

One-line literal swap on the legacy z-index map, plus a comment that calls out the slot relationship:

```scss
// The draggable element should show up above the entire UI, including
// the `@wordpress/ui` compat overlay slot at `1000000003`.
".components-draggable__clone": 1000000004,
```

## Alternative considered

The cleaner direction is to migrate `.components-draggable__clone` onto the compat overlay slot itself (or its own slot at the same stacking band), which would eliminate the z-index race rather than push it one rung higher. That's a larger refactor across the draggable-clone rendering pipeline; this PR opts for the surgical fix so the migration can happen separately and on its own schedule.

## Testing Instructions

1. Land #77851 and #78095 (or rebase this onto them locally).
2. Open a `@wordpress/components` Draggable instance and a `@wordpress/ui` Tooltip simultaneously in the editor.
3. While dragging, the drag clone should render visually above the tooltip popup.

## Next steps

- Consider migrating `.components-draggable__clone` to its own slot so its z-index doesn't need to chase the compat slot.

## Use of AI Tools

Authored with Cursor (Claude). Author reviewed all changes.