### PR TITLE
Popover: Remove close button z-index

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### Breaking Changes
 
--   Remove the following entries from the `z-index()` helper ([#77753](https://github.com/WordPress/gutenberg/pull/77753), [#77759](https://github.com/WordPress/gutenberg/pull/77759), [#77772](https://github.com/WordPress/gutenberg/pull/77772), [#77806](https://github.com/WordPress/gutenberg/pull/77806), [#77807](https://github.com/WordPress/gutenberg/pull/77807), [#77808](https://github.com/WordPress/gutenberg/pull/77808)):
+-   Remove the following entries from the `z-index()` helper ([#77753](https://github.com/WordPress/gutenberg/pull/77753), [#77759](https://github.com/WordPress/gutenberg/pull/77759), [#77772](https://github.com/WordPress/gutenberg/pull/77772), [#77806](https://github.com/WordPress/gutenberg/pull/77806), [#77807](https://github.com/WordPress/gutenberg/pull/77807), [#77808](https://github.com/WordPress/gutenberg/pull/77808), [#78180](https://github.com/WordPress/gutenberg/pull/78180)):
     -   `.block-editor-block-manager__category-title`
     -   `.block-editor-block-manager__disabled-blocks-count`
     -   `.block-library-query-pattern__selection-search`
     -   `.block-library-template-part__selection-search`
+    -   `.components-popover__close`
     -   `.edit-site-layout__canvas-container.is-resizing::after`
     -   `.edit-site-layout__canvas-container`
     -   `.edit-site-layout__sidebar`

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -11,7 +11,6 @@ $z-layers: (
 	".components-modal__header": 10,
 	".edit-post-meta-boxes-area.is-loading::before": 1,
 	".edit-post-meta-boxes-area .spinner": 5,
-	".components-popover__close": 5,
 	".edit-post-layout__footer": 30,
 	".interface-interface-skeleton__header": 30,
 	".interface-interface-skeleton__content": 20,

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,6 +21,7 @@
 -   Update `date-fns` dependency to `v4.1.0` ([#78057](https://github.com/WordPress/gutenberg/pull/78057)).
 -   Update code to comply with `eslint-plugin-react-hooks` v7 ([#69962](https://github.com/WordPress/gutenberg/pull/69962)).
 -   `SlotFill`: Add dependencies to `updateFill` effect ([#77907](https://github.com/WordPress/gutenberg/pull/77907)).
+-   `Popover`: Remove unnecessary close button z-index style ([#78180](https://github.com/WordPress/gutenberg/pull/78180)).
 
 ## 33.0.0 (2026-04-29)
 

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -73,10 +73,6 @@ $shadow-popover-border-top-only-alternate: 0 #{-$border-width} 0 $gray-900;
 	width: 100%;
 }
 
-.components-popover__close.components-button {
-	z-index: z-index(".components-popover__close");
-}
-
 .components-popover__arrow {
 	position: absolute;
 	width: $arrow-triangle-base-size;


### PR DESCRIPTION
## What?

Removes the `components-popover__close` entry from the shared `$z-layers` map in `packages/base-styles/_z-index.scss` and removes the corresponding `z-index` rule from the Popover close button.

## Why?

The close button is now a normal flex item in the Popover header, so it no longer needs its own stacking value. Removing the shared entry keeps the z-index registry focused on values that coordinate across components.

Removing or changing this z-index _can_ potentially break a layout, if the popover content was setting a hacky, absolutely positioned, full bleed background with a z-index more than 1. But again, that would be really hacky to begin with, and I couldn't find any instances like that on [Veloria](https://veloria.dev/).

<details><summary>Why was it z-index 5?</summary>
<p>

In #4348, CodeMirror was added to the Custom HTML block, and review feedback called out a z-index issue where adjacent block toolbar UI could appear underneath the CodeMirror gutter. The follow-up commit `bc4f047` bumped “every element that is at the same depth as the block toolbar” above `4`, which is how the affected entries ended up at values like `5`. That was a CodeMirror-specific stacking workaround from 2018; the current Popover close button is now a normal flex item in the expanded mobile popover header.

</p>
</details> 

## How?

Removes the unused local `z-index()` call from `packages/components/src/popover/style.scss` and removes the corresponding key from `packages/base-styles/_z-index.scss`.

## Testing Instructions

Enable the `expandOnMobile` prop on a `Popover`, and see it in a narrow viewport. The close button should function as expected.

## Screenshots or screencast

These are the relevant instances in the app. None of them have concerns related to the z-index of the close button.

<img width="400" alt="block inserter" src="https://github.com/user-attachments/assets/1b73c2ea-d685-425d-8755-d913bd586c98" />
<img width="400"  alt="Patterns popover" src="https://github.com/user-attachments/assets/edbdd245-c294-4990-b628-08a97914666a" />
<img width="400"  alt="DataViews view options" src="https://github.com/user-attachments/assets/915d6df8-5d02-46e2-b67d-e603e311139c" />

