### PR TITLE
Button: Align compound component metadata

### DIFF
--- a/packages/ui/src/button/button.tsx
+++ b/packages/ui/src/button/button.tsx
@@ -11,7 +11,6 @@ import defenseStyles from '../utils/css/global-css-defense.module.css';
 
 /**
  * A versatile button component with multiple variants, tones, and sizes.
- * Built on design tokens for consistent theming and accessibility.
  */
 export const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 	function Button(

--- a/packages/ui/src/button/button.tsx
+++ b/packages/ui/src/button/button.tsx
@@ -9,6 +9,10 @@ import resetStyles from '../utils/css/resets.module.css';
 import focusStyles from '../utils/css/focus.module.css';
 import defenseStyles from '../utils/css/global-css-defense.module.css';
 
+/**
+ * A versatile button component with multiple variants, tones, and sizes.
+ * Built on design tokens for consistent theming and accessibility.
+ */
 export const Button = forwardRef< HTMLButtonElement, ButtonProps >(
 	function Button(
 		{

--- a/packages/ui/src/button/icon.tsx
+++ b/packages/ui/src/button/icon.tsx
@@ -1,13 +1,6 @@
 import { forwardRef } from '@wordpress/element';
-import { type IconProps } from '../icon/types';
+import { type ButtonIconProps } from './types';
 import { Icon } from '../icon';
-
-interface ButtonIconProps extends IconProps {
-	/**
-	 * The icon to display, from the `@wordpress/icons` package.
-	 */
-	icon: IconProps[ 'icon' ];
-}
 
 export const ButtonIcon = forwardRef< SVGSVGElement, ButtonIconProps >(
 	function ButtonIcon( { icon, ...props }, ref ) {

--- a/packages/ui/src/button/icon.tsx
+++ b/packages/ui/src/button/icon.tsx
@@ -22,5 +22,3 @@ export const ButtonIcon = forwardRef< SVGSVGElement, ButtonIconProps >(
 		);
 	}
 );
-
-ButtonIcon.displayName = 'Button.Icon';

--- a/packages/ui/src/button/icon.tsx
+++ b/packages/ui/src/button/icon.tsx
@@ -22,3 +22,5 @@ export const ButtonIcon = forwardRef< SVGSVGElement, ButtonIconProps >(
 		);
 	}
 );
+
+ButtonIcon.displayName = 'Button.Icon';

--- a/packages/ui/src/button/index.ts
+++ b/packages/ui/src/button/index.ts
@@ -5,7 +5,6 @@ ButtonIcon.displayName = 'Button.Icon';
 
 /**
  * A versatile button component with multiple variants, tones, and sizes.
- * Built on design tokens for consistent theming and accessibility.
  */
 export const Button = Object.assign( _Button, {
 	/**

--- a/packages/ui/src/button/index.ts
+++ b/packages/ui/src/button/index.ts
@@ -1,4 +1,4 @@
-import { Button as ButtonButton } from './button';
+import { Button as _Button } from './button';
 import { ButtonIcon } from './icon';
 
 ButtonIcon.displayName = 'Button.Icon';
@@ -7,12 +7,10 @@ ButtonIcon.displayName = 'Button.Icon';
  * A versatile button component with multiple variants, tones, and sizes.
  * Built on design tokens for consistent theming and accessibility.
  */
-export const Button = Object.assign( ButtonButton, {
+export const Button = Object.assign( _Button, {
 	/**
 	 * An icon component specifically designed to work well when rendered inside
 	 * a `Button` component.
 	 */
 	Icon: ButtonIcon,
-} ) as typeof ButtonButton & {
-	Icon: typeof ButtonIcon;
-};
+} );

--- a/packages/ui/src/button/index.ts
+++ b/packages/ui/src/button/index.ts
@@ -1,6 +1,8 @@
 import { Button as ButtonButton } from './button';
 import { ButtonIcon } from './icon';
 
+ButtonIcon.displayName = 'Button.Icon';
+
 /**
  * A versatile button component with multiple variants, tones, and sizes.
  * Built on design tokens for consistent theming and accessibility.

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -7,7 +7,7 @@ const meta: Meta< typeof Button > = {
 	title: 'Design System/Components/Button',
 	component: Button,
 	subcomponents: {
-		Icon: Button.Icon,
+		'Button.Icon': Button.Icon,
 	},
 	argTypes: {
 		'aria-pressed': {

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -6,6 +6,9 @@ import { Button } from '../index';
 const meta: Meta< typeof Button > = {
 	title: 'Design System/Components/Button',
 	component: Button,
+	subcomponents: {
+		Icon: Button.Icon,
+	},
 	argTypes: {
 		'aria-pressed': {
 			control: { type: 'boolean' },

--- a/packages/ui/src/button/types.ts
+++ b/packages/ui/src/button/types.ts
@@ -1,5 +1,6 @@
 import { type ReactNode, type HTMLAttributes } from 'react';
 import type { Button as _Button } from '@base-ui/react/button';
+import { type IconProps } from '../icon/types';
 import type { ComponentProps } from '../utils/types';
 
 type _ButtonProps = ComponentProps< typeof _Button >;
@@ -69,4 +70,11 @@ export interface ButtonProps
 	 * The text used for assistive technology to indicate the loading state.
 	 */
 	loadingAnnouncement?: string;
+}
+
+export interface ButtonIconProps extends IconProps {
+	/**
+	 * The icon to display, from the `@wordpress/icons` package.
+	 */
+	icon: IconProps[ 'icon' ];
 }


### PR DESCRIPTION
## What?
Follow up to #77809 with consistency tweaks for the Button compound component export.

## Why?
`Button.Icon` should follow the same documentation and display-name patterns as the newer compound components in `@wordpress/ui`. This keeps Storybook docs, React DevTools, and editor tooltips consistent.

## How?
- Adds `Button.Icon` to the Button Storybook `subcomponents` metadata.
- Sets the compound subcomponent display name to `Button.Icon`.
- Moves `ButtonIconProps` into the Button `types.ts` file.
- Keeps the root Button description on both the `forwardRef` component and the `Object.assign` export shape, since Storybook and VS Code read those descriptions from different places.

## Testing Instructions
2. Run Storybook and open `Design System/Components/Button`.
3. Confirm `Button.Icon` appears in the subcomponents documentation, and the JSDoc description for the main component is shown in the component description.

