### PR TITLE
design-system-mcp: Add server instructions for client usage guidance

### DIFF
--- a/packages/design-system-mcp/CHANGELOG.md
+++ b/packages/design-system-mcp/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `get_component_details` now optionally accepts an array of component names so multiple components can be fetched in a single call. ([#78185](https://github.com/WordPress/gutenberg/pull/78185))
+-   The server now provides instructions on how AI agents should be expected to use it, improving discoverability and tool call efficiency. ([#78186](https://github.com/WordPress/gutenberg/pull/78186))
 
 ## 0.3.0 (2026-05-14)
 

--- a/packages/design-system-mcp/src/index.ts
+++ b/packages/design-system-mcp/src/index.ts
@@ -11,7 +11,7 @@ export function createServer() {
 		},
 		{
 			instructions: [
-				'Provides discovery and usage information for the WordPress Design System. Covers components in `@wordpress/components` and `@wordpress/ui`, and the underlying design tokens exposed as `--wpds-*` CSS custom properties.',
+				'Provides discovery and usage information for the WordPress Design System. Covers components in `@wordpress/components` and `@wordpress/ui`, and the underlying design tokens from `@wordpress/theme` exposed as `--wpds-*` CSS custom properties.',
 				'In a typical flow, a user will often refer to components by generic names ("button", "dropdown menu") that don\'t match the actual export. Call `get_components` first to map the request to canonical component names, then `get_component_details` for one or more of those names to get props, descriptions, and usage notes.',
 				'`get_design_tokens` covers the semantic, themeable design tokens that the components are built on. While these can be used for custom styling that adapts to the current design system theme settings, prefer using the available component APIs when available.',
 			].join( '\n\n' ),

--- a/packages/design-system-mcp/src/index.ts
+++ b/packages/design-system-mcp/src/index.ts
@@ -4,10 +4,19 @@ import { registerTools } from './tools/index';
 export { parseComponents, parseComponentDetail } from './parse-components';
 
 export function createServer() {
-	const server = new McpServer( {
-		name: 'WordPress Design System',
-		version: '0.1.0',
-	} );
+	const server = new McpServer(
+		{
+			name: 'WordPress Design System',
+			version: '0.1.0',
+		},
+		{
+			instructions: [
+				'Provides discovery and usage information for the WordPress Design System. Covers components in `@wordpress/components` and `@wordpress/ui`, and the underlying design tokens exposed as `--wpds-*` CSS custom properties.',
+				'In a typical flow, a user will often refer to components by generic names ("button", "dropdown menu") that don\'t match the actual export. Call `get_components` first to map the request to canonical component names, then `get_component_details` for one or more of those names to get props, descriptions, and usage notes.',
+				'`get_design_tokens` covers the semantic, themeable design tokens that the components are built on. While these can be used for custom styling that adapts to the current design system theme settings, prefer using the available component APIs when available.',
+			].join( '\n\n' ),
+		}
+	);
 
 	registerTools( server );
 


### PR DESCRIPTION
## What?

Updates the WordPress Design System MCP server to provide instructions on how it should be used.

Temporarily merges to #78185 because the instructions text claims using "`get_component_details` for one or more of those names", which depends on the changes in #78185.

## Why?

- Discoverability: Instructions are known to AI agents before deciding whether to call any tools, so they can be used to help inform an agent whether an MCP's tools would be relevant to a given request. While the name alone ("WordPress Design System MCP") should provide reasonable context for whether it's relevant, the updated text lists specific packages and workflows that might help reinforce its appropriate usage.
- Efficiency: By describing common workflows, agents are better informed about how to access relevant information. For example, the updated text might help prevent a scenario where an agent attempts to get a component's details without having the component name (which should usually come from an initial `get_components` call).

## Testing Instructions

Verify that the agent knows about the instructions workflow:

1. Connect to MCP using Testing Instructions from #77159
2. Ask your AI agent if it knows how to use the MCP server (see example below)

```
> Does the WordPress MCP server provide any instructions on how it should be used? What would you expect to see?  

Yes — the `wordpress-design-system` MCP server provides instructions, surfaced in the system context at session start. Paraphrased:

- It covers components in `@wordpress/components` and `@wordpress/ui`, plus design tokens exposed as `--wpds-*` CSS custom properties.
- Typical flow: users refer to components by generic names ("button", "dropdown menu") that don't match the actual export, so call `get_components` first to map to canonical names, then `get_component_details` for specifics.
- `get_design_tokens` covers semantic, themeable tokens, but prefer component APIs over custom styling when available.

What I'd expect to see in well-formed MCP server instructions:

1. **Purpose / scope** — one or two sentences on what the server covers and (importantly) what it *doesn't*, so I don't reach for it on out-of-scope requests.
2. **Tool inventory with a recommended flow** — not just "here are the tools," but the order to call them in for common tasks (the discovery → details pattern above is a good example).
3. **Disambiguation guidance** — how to translate fuzzy user language into canonical inputs (e.g., "button" → which export).
4. **Preference hierarchy** — when to prefer one tool/approach over another (e.g., "prefer component APIs over raw tokens").
5. **Auth / setup prerequisites** — if any tools need authentication, what triggers it.
6. **Failure modes / fallback behavior** — what to do if a component isn't found, or if results are empty.
7. **Output shape hints** — what fields come back from each tool, so I can plan multi-step calls without making an exploratory call first.

The current instructions hit 1–4 well. Items 6 and 7 aren't covered, though they're arguably discoverable from a first call.
```

It makes some good points about 6 and 7 😄 

- Failure modes: I'm not sure how we might want to describe how an agent should handle these scenarios?
- Output shape hints: I'm expecting we could improve the JSON Schema for the tool calls to include this

## Use of AI Tools

Initial instructions draft was authored by Claude Code Opus 4.7, with heavy edits by me.