### PR TITLE
Media Editor Modal: Fix empty author and attached to fields

### DIFF
--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -448,6 +448,13 @@ function MediaEditorContent( {
 						metadataEdits[ key ] = pendingEdits[ key ];
 					}
 				}
+				// The `/edit` endpoint creates a new attachment for the crop
+				// and doesn't inherit `post_parent` from the source (unlike
+				// title/caption/etc.), so carry the existing value across when
+				// the user hasn't explicitly edited it.
+				if ( ! ( 'post' in metadataEdits ) && media?.post ) {
+					metadataEdits.post = media.post;
+				}
 
 				saved = ( await apiFetch( {
 					path: `/wp/v2/media/${ id }/edit`,

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -273,6 +273,7 @@ function MediaEditorContent( {
 	const {
 		clearEntityRecordEdits,
 		editEntityRecord,
+		invalidateResolution,
 		receiveEntityRecords,
 		saveEditedEntityRecord,
 	} = useDispatch( coreStore );
@@ -316,6 +317,18 @@ function MediaEditorContent( {
 		setIsPlacementActive( false );
 		setIsCanvasGestureActive( false );
 	}, [ id ] );
+
+	// Bust the cached `_embed` resolution each time the editor mounts (or the
+	// id changes) so embedded data such as the attached post's title or the
+	// author's name reflects any edits made elsewhere since the last open.
+	useEffect( () => {
+		invalidateResolution( 'getEntityRecord', [
+			'postType',
+			'attachment',
+			id,
+			{ _embed: 'author,wp:attached-to' },
+		] );
+	}, [ id, invalidateResolution ] );
 
 	const mediaType = getMediaTypeFromMimeType( media?.mime_type ).type;
 	const isImage = !! media && mediaType === 'image';

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -239,8 +239,18 @@ function MediaEditorContent( {
 
 	const { media, hasEdits } = useSelect(
 		( select ) => {
-			const { getEditedEntityRecord, hasEditsForEntityRecord } =
-				select( coreStore );
+			const {
+				getEditedEntityRecord,
+				getEntityRecord,
+				hasEditsForEntityRecord,
+			} = select( coreStore );
+			// Trigger an _embed fetch so `_embedded.author` and
+			// `_embedded['wp:attached-to']` land on the record for the Details
+			// fields to read. `getEditedEntityRecord` doesn't formally accept a
+			// query, so we can't embed via that selector directly.
+			getEntityRecord( 'postType', 'attachment', id, {
+				_embed: 'author,wp:attached-to',
+			} );
 			return {
 				media: getEditedEntityRecord(
 					'postType',

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -65,6 +65,11 @@ const METADATA_EDIT_KEYS = [
 	'post',
 ] as const;
 
+// Embed query for the attachment's author and parent post. Shared between
+// the `getEntityRecord` read and the matching `invalidateResolution` so the
+// two stay in lockstep.
+const ATTACHMENT_EMBED_QUERY = { _embed: 'author,wp:attached-to' } as const;
+
 // Scope save-failure snackbars so they don't leak into the host editor/page.
 const NOTICES_CONTEXT = 'media-editor';
 const PLACEMENT_CONTROL_IDLE_MS = 300;
@@ -248,9 +253,12 @@ function MediaEditorContent( {
 			// `_embedded['wp:attached-to']` land on the record for the Details
 			// fields to read. `getEditedEntityRecord` doesn't formally accept a
 			// query, so we can't embed via that selector directly.
-			getEntityRecord( 'postType', 'attachment', id, {
-				_embed: 'author,wp:attached-to',
-			} );
+			getEntityRecord(
+				'postType',
+				'attachment',
+				id,
+				ATTACHMENT_EMBED_QUERY
+			);
 			return {
 				media: getEditedEntityRecord(
 					'postType',
@@ -326,7 +334,7 @@ function MediaEditorContent( {
 			'postType',
 			'attachment',
 			id,
-			{ _embed: 'author,wp:attached-to' },
+			ATTACHMENT_EMBED_QUERY,
 		] );
 	}, [ id, invalidateResolution ] );
 
@@ -451,8 +459,12 @@ function MediaEditorContent( {
 				// The `/edit` endpoint creates a new attachment for the crop
 				// and doesn't inherit `post_parent` from the source (unlike
 				// title/caption/etc.), so carry the existing value across when
-				// the user hasn't explicitly edited it.
-				if ( ! ( 'post' in metadataEdits ) && media?.post ) {
+				// the user hasn't explicitly edited it. Use a defined-check so
+				// an explicit `0` (unattached) is also preserved.
+				if (
+					! ( 'post' in metadataEdits ) &&
+					media?.post !== undefined
+				) {
 					metadataEdits.post = media.post;
 				}
 

--- a/packages/media-fields/src/attached_to/test/view.test.tsx
+++ b/packages/media-fields/src/attached_to/test/view.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import type { NormalizedField } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import MediaAttachedToView from '../view';
+import type { MediaItem } from '../../types';
+
+// The view component only reads `item`; a stub is enough to satisfy the
+// `DataViewRenderFieldProps` signature without dragging in the edit
+// component's `@wordpress/core-data` import chain.
+const field = {} as NormalizedField< MediaItem >;
+
+describe( 'MediaAttachedToView', () => {
+	it( 'renders the rendered post title when the embedded post matches the parent', () => {
+		const item: Partial< MediaItem > = {
+			post: 42,
+			_embedded: {
+				'wp:attached-to': [
+					{
+						id: 42,
+						title: { raw: 'Hello world', rendered: 'Hello world' },
+					},
+				],
+			},
+		};
+
+		render(
+			<MediaAttachedToView item={ item as MediaItem } field={ field } />
+		);
+
+		expect( screen.getByText( 'Hello world' ) ).toBeInTheDocument();
+	} );
+
+	it( 'falls back to "(no title)" when the embedded post is loaded but has an empty title', () => {
+		const item: Partial< MediaItem > = {
+			post: 42,
+			_embedded: {
+				'wp:attached-to': [
+					{
+						id: 42,
+						title: { raw: '', rendered: '' },
+					},
+				],
+			},
+		};
+
+		render(
+			<MediaAttachedToView item={ item as MediaItem } field={ field } />
+		);
+
+		expect( screen.getByText( '(no title)' ) ).toBeInTheDocument();
+		expect( screen.queryByText( '42' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders "(Unattached)" when there is no parent post', () => {
+		const item: Partial< MediaItem > = {
+			post: 0,
+		};
+
+		render(
+			<MediaAttachedToView item={ item as MediaItem } field={ field } />
+		);
+
+		expect( screen.getByText( '(Unattached)' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not render the title yet when the embedded post id does not match the parent', () => {
+		// Stale embedded data from a prior attachment shouldn't be shown
+		// for the new parent until the matching record loads.
+		const item: Partial< MediaItem > = {
+			post: 42,
+			_embedded: {
+				'wp:attached-to': [
+					{
+						id: 7,
+						title: { raw: 'Old title', rendered: 'Old title' },
+					},
+				],
+			},
+		};
+
+		const { container } = render(
+			<MediaAttachedToView item={ item as MediaItem } field={ field } />
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/packages/media-fields/src/attached_to/view.tsx
+++ b/packages/media-fields/src/attached_to/view.tsx
@@ -28,9 +28,7 @@ export default function MediaAttachedToView( {
 	useEffect( () => {
 		if ( !! parentId && parentId === embeddedPostId ) {
 			setAttachedPostTitle(
-				getRenderedContent( embeddedPostTitle ) ||
-					embeddedPostId?.toString() ||
-					''
+				getRenderedContent( embeddedPostTitle ) || __( '(no title)' )
 			);
 		}
 


### PR DESCRIPTION
## What?

Part of:

* #73771

Fix the sometimes empty nature of the author and attached to fields in the experimental Media Editor Modal.

## Why?

Sometimes these fields aren't populated because the entity hasn't resolved the embedded fields. In order to use these properly, we need to make sure that they are fetched and stored in the store. The main way you encounter this is if you drag and drop an image from your desktop onto a post (a published post is a better way to test this, as it'll have a title that gets shown in the Attached To field).

In such a case, a new upload has occurred but when we click the crop button in the block toolbar on the image block, the loaded entity doesn't have the embedded data it needs, and so the username and attached to fields appear blank, when they are not.

## How?

* In `MediaEditorContent`, fill the data store by triggering an `_embed` fetch with the embedded author and attached to fields
* Note: I went with this approach instead of passing a fourth value to `getEditedEntityRecord`. While that _technically_ works, that method's signature doesn't include a `query` param, and it's only an artifact of its resolver that it's possible to pass a query object to it. The approach in this PR seemed a bit more "correct" without going into core-data and updating the selector itself. Let me know if that direction seems better and I can update this PR (or close it out and open a fresh PR)

### Included tweaks to polish the behaviour

* Update rendering of the attached_to field when there is no title for the post. It now displays `(no title)` for consistency with the core media library. I've included a few tests to make sure this is covered.
* Invalidate the resolution whenever opening the media editor (or if the id changes) so that the embed data is always fresh. Now if you save the post or add a title and save, and then open the modal, the attached_to label should be current
* Note that if the post hasn't yet been saved, the Attached to field says "Auto Draft". This matches what happens in the core media library currently.

Note: things to deal with separately (as it's possibly more to do with the field itself):

* The "Date Added" field seems to wrap its text and doesn't fit all in one row, at least for some date/time strings like "May 12, 2026 6:44 am"

## Testing Instructions

* Enable the Media Editor Modal experiment
* In a post (best to test this on a saved post with a title), go to drag an image into the editor
* Click on the image and then click the Crop button in the block toolbar
* Go to the Details tab
* The Author field should not be empty (i.e. it should say `admin` if you're the admin user)
* The Attached to field should show the name of the post it's attached to

## Screenshots or screencast <!-- if applicable -->

### Before

Note the empty Author and Attached to fields

<img width="1200" height="833" alt="image" src="https://github.com/user-attachments/assets/22bce763-542b-4c73-b642-edcec90807bc" />

### After

<img width="1200" height="775" alt="image" src="https://github.com/user-attachments/assets/e6bf7ae0-4d0c-49e7-afbf-dfad9bec3d9f" />

## Use of AI Tools

Claude Code