### PR TITLE
Show pseudo state global styles on canvas when "Show state on canvas" is active

### DIFF
--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -357,6 +357,8 @@ function BlockStyleControls( {
 				?.blocks?.[ name ],
 		[ name ]
 	);
+	const globalStateValue = globalBlockStyles?.[ selectedState ];
+	const instanceStateValue = style?.[ selectedState ];
 
 	// Inject state styles onto the editor canvas so the selected state is
 	// visible while editing. Scoped to this block instance via data-block so
@@ -366,8 +368,6 @@ function BlockStyleControls( {
 		if ( ! showStateOnCanvas || selectedState === 'default' ) {
 			return undefined;
 		}
-		const globalStateValue = globalBlockStyles?.[ selectedState ];
-		const instanceStateValue = style?.[ selectedState ];
 		let stateValue;
 
 		if ( globalStateValue && instanceStateValue ) {
@@ -391,8 +391,8 @@ function BlockStyleControls( {
 	}, [
 		showStateOnCanvas,
 		selectedState,
-		globalBlockStyles,
-		style,
+		globalStateValue,
+		instanceStateValue,
 		clientId,
 		name,
 	] );

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -9,6 +9,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import { useSelect } from '@wordpress/data';
+import { mergeGlobalStyles } from '@wordpress/global-styles-engine';
 import {
 	getBlockSupport,
 	hasBlockSupport,
@@ -80,34 +81,6 @@ export function getInlineStyles( styles = {} ) {
 	} );
 
 	return output;
-}
-
-function isStyleObject( value ) {
-	return !! value && typeof value === 'object' && ! Array.isArray( value );
-}
-
-export function mergeStyleObjects( ...styles ) {
-	let merged;
-
-	styles.forEach( ( style ) => {
-		if ( ! isStyleObject( style ) ) {
-			return;
-		}
-
-		merged = merged || {};
-
-		Object.entries( style ).forEach( ( [ key, value ] ) => {
-			if ( isStyleObject( value ) && isStyleObject( merged[ key ] ) ) {
-				merged[ key ] = mergeStyleObjects( merged[ key ], value );
-			} else if ( isStyleObject( value ) ) {
-				merged[ key ] = mergeStyleObjects( value );
-			} else {
-				merged[ key ] = value;
-			}
-		} );
-	} );
-
-	return merged;
 }
 
 /**
@@ -393,13 +366,23 @@ function BlockStyleControls( {
 		if ( ! showStateOnCanvas || selectedState === 'default' ) {
 			return undefined;
 		}
-		const stateValue = mergeStyleObjects(
-			globalBlockStyles?.[ selectedState ],
-			style?.[ selectedState ]
-		);
-		if ( ! stateValue ) {
+		const globalStateValue = globalBlockStyles?.[ selectedState ];
+		const instanceStateValue = style?.[ selectedState ];
+		let stateValue;
+
+		if ( globalStateValue && instanceStateValue ) {
+			stateValue = mergeGlobalStyles(
+				globalStateValue,
+				instanceStateValue
+			);
+		} else if ( instanceStateValue ) {
+			stateValue = instanceStateValue;
+		} else if ( globalStateValue ) {
+			stateValue = globalStateValue;
+		} else {
 			return undefined;
 		}
+
 		const selector = buildCanvasStateSelector( clientId, name );
 		const css = compileCSS( stateValue, { selector } );
 		// Use !important to override utility classes (e.g. has-accent-3-color)

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -8,6 +8,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
+import { useSelect } from '@wordpress/data';
 import {
 	getBlockSupport,
 	hasBlockSupport,
@@ -47,6 +48,8 @@ import { buildStateSelector, buildCanvasStateSelector } from './state-utils';
 import { BlockInspectorPreTabsFill } from '../components/block-inspector/inspector-pre-tabs-slot-fill';
 import { scopeSelector } from '../components/global-styles/utils';
 import { useBlockEditingMode } from '../components/block-editing-mode';
+import { store as blockEditorStore } from '../store';
+import { globalStylesDataKey } from '../store/private-keys';
 
 const styleSupportKeys = [
 	...TYPOGRAPHY_SUPPORT_KEYS,
@@ -77,6 +80,34 @@ export function getInlineStyles( styles = {} ) {
 	} );
 
 	return output;
+}
+
+function isStyleObject( value ) {
+	return !! value && typeof value === 'object' && ! Array.isArray( value );
+}
+
+export function mergeStyleObjects( ...styles ) {
+	let merged;
+
+	styles.forEach( ( style ) => {
+		if ( ! isStyleObject( style ) ) {
+			return;
+		}
+
+		merged = merged || {};
+
+		Object.entries( style ).forEach( ( [ key, value ] ) => {
+			if ( isStyleObject( value ) && isStyleObject( merged[ key ] ) ) {
+				merged[ key ] = mergeStyleObjects( merged[ key ], value );
+			} else if ( isStyleObject( value ) ) {
+				merged[ key ] = mergeStyleObjects( value );
+			} else {
+				merged[ key ] = value;
+			}
+		} );
+	} );
+
+	return merged;
 }
 
 /**
@@ -347,6 +378,12 @@ function BlockStyleControls( {
 	const blockEditingMode = useBlockEditingMode();
 	const [ selectedState, setSelectedState ] = useState( 'default' );
 	const [ showStateOnCanvas, setShowStateOnCanvas ] = useState( true );
+	const globalBlockStyles = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings()[ globalStylesDataKey ]
+				?.blocks?.[ name ],
+		[ name ]
+	);
 
 	// Inject state styles onto the editor canvas so the selected state is
 	// visible while editing. Scoped to this block instance via data-block so
@@ -356,7 +393,10 @@ function BlockStyleControls( {
 		if ( ! showStateOnCanvas || selectedState === 'default' ) {
 			return undefined;
 		}
-		const stateValue = style?.[ selectedState ];
+		const stateValue = mergeStyleObjects(
+			globalBlockStyles?.[ selectedState ],
+			style?.[ selectedState ]
+		);
 		if ( ! stateValue ) {
 			return undefined;
 		}
@@ -365,7 +405,14 @@ function BlockStyleControls( {
 		// Use !important to override utility classes (e.g. has-accent-3-color)
 		// that the block's default color support generates with !important.
 		return css ? css.replace( /;/g, ' !important;' ) : undefined;
-	}, [ showStateOnCanvas, selectedState, style, clientId, name ] );
+	}, [
+		showStateOnCanvas,
+		selectedState,
+		globalBlockStyles,
+		style,
+		clientId,
+		name,
+	] );
 	useStyleOverride( { css: canvasStateCSS } );
 
 	if ( blockEditingMode !== 'default' ) {

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -1,11 +1,7 @@
 /**
  * Internal dependencies
  */
-import _style, {
-	getInlineStyles,
-	mergeStyleObjects,
-	omitStyle,
-} from '../style';
+import _style, { getInlineStyles, omitStyle } from '../style';
 
 describe( 'getInlineStyles', () => {
 	it( 'should return an empty object when called with undefined', () => {
@@ -117,41 +113,6 @@ describe( 'getInlineStyles', () => {
 			margin: '10px',
 			padding: '20px',
 		} );
-	} );
-} );
-
-describe( 'mergeStyleObjects', () => {
-	it( 'merges nested style values from left to right', () => {
-		expect(
-			mergeStyleObjects(
-				{
-					color: {
-						text: 'red',
-					},
-					typography: {
-						fontSize: '16px',
-					},
-				},
-				{
-					color: {
-						background: 'blue',
-						text: 'green',
-					},
-				}
-			)
-		).toEqual( {
-			color: {
-				background: 'blue',
-				text: 'green',
-			},
-			typography: {
-				fontSize: '16px',
-			},
-		} );
-	} );
-
-	it( 'returns undefined when no style objects are provided', () => {
-		expect( mergeStyleObjects( undefined, null ) ).toBeUndefined();
 	} );
 } );
 

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import _style, { getInlineStyles, omitStyle } from '../style';
+import _style, {
+	getInlineStyles,
+	mergeStyleObjects,
+	omitStyle,
+} from '../style';
 
 describe( 'getInlineStyles', () => {
 	it( 'should return an empty object when called with undefined', () => {
@@ -113,6 +117,41 @@ describe( 'getInlineStyles', () => {
 			margin: '10px',
 			padding: '20px',
 		} );
+	} );
+} );
+
+describe( 'mergeStyleObjects', () => {
+	it( 'merges nested style values from left to right', () => {
+		expect(
+			mergeStyleObjects(
+				{
+					color: {
+						text: 'red',
+					},
+					typography: {
+						fontSize: '16px',
+					},
+				},
+				{
+					color: {
+						background: 'blue',
+						text: 'green',
+					},
+				}
+			)
+		).toEqual( {
+			color: {
+				background: 'blue',
+				text: 'green',
+			},
+			typography: {
+				fontSize: '16px',
+			},
+		} );
+	} );
+
+	it( 'returns undefined when no style objects are provided', () => {
+		expect( mergeStyleObjects( undefined, null ) ).toBeUndefined();
 	} );
 } );
 


### PR DESCRIPTION
## What?
Based on https://github.com/WordPress/gutenberg/pull/76491 and proposes to merge into that branch.

As mentioned in https://github.com/WordPress/gutenberg/pull/76491#issuecomment-4427832355, global styles for pseudo states aren't reflected on the canvas when "Show state on canvas" is active.

This PR should fix it.

## Why?
Without it I think it'll be difficult for users to accurately style blocks

## How?
Gets the global styles for the block, and merges it with the block styles before computing the css for "Show state on canvas". This approach should hopefully work as the state object for block instances matches the shape of the global styles state object (AFAIK).

## Testing Instructions
1. Open Appearance > Editor > Styles > Blocks > Button
2. Use the state dropdown to select 'Hover'
3. Set some hover styles for the button block and save.
4. Open an editor and insert a button
5. Using the state dropdown in the block inspector (next to the block title), select hover
6. The "Show state on canvas", and is probably switched on by default, if not switch it on
7. Observe that the button should show the global style you set earlier in the canvas.

## AI use

OpenCode / Codex