### PR TITLE
Add a 1-day minimum release age to npm installs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -3,3 +3,4 @@ engine-strict = true
 legacy-peer-deps = true
 prefer-dedupe = true
 lockfile-version = 3
+min-release-age = 1


### PR DESCRIPTION
## Summary
- Set `min-release-age = 1` in the project `.npmrc` to require package releases to be at least one day old before install.
- Keep the existing npm install policy unchanged otherwise.

## Testing
- Not run (not requested)