### PR TITLE
Performance tests: fix template click, delete pages at startup

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/index.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/index.ts
@@ -11,6 +11,7 @@ import { getPageError } from './get-page-error';
 import { visitAdminPage } from './visit-admin-page';
 import { editPost } from './edit-post';
 import { visitSiteEditor } from './visit-site-editor';
+import { waitForSiteEditor } from './wait-for-site-editor';
 import type { PageUtils } from '../page-utils';
 import type { Editor } from '../editor';
 
@@ -45,4 +46,7 @@ export class Admin {
 	visitAdminPage: typeof visitAdminPage = visitAdminPage.bind( this );
 	/** @borrows visitSiteEditor as this.visitSiteEditor */
 	visitSiteEditor: typeof visitSiteEditor = visitSiteEditor.bind( this );
+	/** @borrows waitForSiteEditor as this.waitForSiteEditor */
+	waitForSiteEditor: typeof waitForSiteEditor =
+		waitForSiteEditor.bind( this );
 }

--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -57,44 +57,6 @@ export async function visitSiteEditor(
 	 * `waitWhileSiteEditorLoading` function in the `edit-site` package.
 	 */
 	if ( ! query.size || postId || canvas === 'edit' ) {
-		await this.page.evaluate( () => {
-			const MAX_LOADING_TIME = 10000;
-			const MAX_PAUSE_TIME = 100;
-
-			return new Promise< void >( ( resolve ) => {
-				let pauseTimeout: ReturnType< typeof setTimeout > | undefined;
-
-				function finish() {
-					unsubscribe();
-					clearTimeout( pauseTimeout );
-					clearTimeout( maxTimeout );
-					resolve();
-				}
-
-				const maxTimeout = setTimeout( finish, MAX_LOADING_TIME );
-
-				function checkResolving() {
-					const isResolving = window.wp.data
-						.select( 'core' )
-						.hasResolvingSelectors();
-
-					if ( isResolving ) {
-						clearTimeout( pauseTimeout );
-						pauseTimeout = undefined;
-						return;
-					}
-
-					if ( ! pauseTimeout ) {
-						pauseTimeout = setTimeout( finish, MAX_PAUSE_TIME );
-					}
-				}
-
-				const unsubscribe = window.wp.data.subscribe(
-					checkResolving,
-					'core'
-				);
-				checkResolving();
-			} );
-		} );
+		await this.waitForSiteEditor();
 	}
 }

--- a/packages/e2e-test-utils-playwright/src/admin/wait-for-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/wait-for-site-editor.ts
@@ -1,0 +1,52 @@
+/**
+ * Internal dependencies
+ */
+import type { Admin } from './';
+
+/**
+ * Waits for the Site Editor to finish loading, i.e., for all resolvers
+ * in the `core` store to finish and then pause for a short period.
+ *
+ * @param this
+ */
+export async function waitForSiteEditor( this: Admin ) {
+	await this.page.evaluate( () => {
+		const MAX_LOADING_TIME = 10000;
+		const MAX_PAUSE_TIME = 100;
+
+		return new Promise< void >( ( resolve ) => {
+			let pauseTimeout: ReturnType< typeof setTimeout > | undefined;
+
+			function finish() {
+				unsubscribe();
+				clearTimeout( pauseTimeout );
+				clearTimeout( maxTimeout );
+				resolve();
+			}
+
+			const maxTimeout = setTimeout( finish, MAX_LOADING_TIME );
+
+			function checkResolving() {
+				const isResolving = window.wp.data
+					.select( 'core' )
+					.hasResolvingSelectors();
+
+				if ( isResolving ) {
+					clearTimeout( pauseTimeout );
+					pauseTimeout = undefined;
+					return;
+				}
+
+				if ( ! pauseTimeout ) {
+					pauseTimeout = setTimeout( finish, MAX_PAUSE_TIME );
+				}
+			}
+
+			const unsubscribe = window.wp.data.subscribe(
+				checkResolving,
+				'core'
+			);
+			checkResolving();
+		} );
+	} );
+}

--- a/test/performance/config/global-setup.ts
+++ b/test/performance/config/global-setup.ts
@@ -34,6 +34,7 @@ async function globalSetup( config: FullConfig ) {
 			'gutenberg-test-plugin-disables-the-css-animations'
 		),
 		requestUtils.deleteAllPosts(),
+		requestUtils.deleteAllPages(),
 		requestUtils.deleteAllBlocks(),
 		requestUtils.resetPreferences(),
 	] );

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -219,28 +219,23 @@ test.describe( 'Site Editor Performance', () => {
 					path: '/wp_template',
 				} );
 
-				// The Templates index page has changed, so we need to know which UI is in use in the branch.
-				// We do so by checking the presence of the dataviews component.
-				// If it's there, switch to the list layout before running the test.
-				// See https://github.com/WordPress/gutenberg/pull/59792
-				const isDataViewsUI = await page
-					.getByRole( 'button', { name: 'Layout' } )
-					.isVisible();
-				if ( isDataViewsUI ) {
-					await page
-						.getByRole( 'button', { name: 'Layout' } )
-						.click();
-					await page
-						.getByRole( 'menuitemradio' )
-						.filter( { has: page.getByText( 'List' ) } )
-						.click();
-				}
+				// Switch to the list layout before running the test.
+				await page.getByRole( 'button', { name: 'Layout' } ).click();
+				await page
+					.getByRole( 'menuitemradio' )
+					.filter( { has: page.getByText( 'List' ) } )
+					.click();
+
+				// Wait for the grid to be really visible.
+				await page.getByRole( 'grid' ).waitFor();
+
+				// List view shows the editor canvas, wait for it to be ready so
+				// that the loading doesn't contaminate the navigation test.
+				await admin.waitForSiteEditor();
 
 				await metrics.startTracing();
 				await page
-					.locator( '.fields-field__title', {
-						hasText: 'Single Posts',
-					} )
+					.getByRole( 'button', { name: 'Single Posts' } )
 					.click();
 				await metrics.stopTracing();
 

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -238,11 +238,10 @@ test.describe( 'Site Editor Performance', () => {
 
 				await metrics.startTracing();
 				await page
-					.getByRole( 'button', {
-						name: 'Single Posts',
-						exact: true,
+					.locator( '.fields-field__title', {
+						hasText: 'Single Posts',
 					} )
-					.click( { force: true } );
+					.click();
 				await metrics.stopTracing();
 
 				// Get the durations.


### PR DESCRIPTION
When running `npm run test:performance` locally, I see two permanent errors that this PR fixes.

```
Site Editor Performance › Navigating
Error: strict mode violation: getByRole('button', { name: 'Single Posts', exact: true }) resolved to 2 elements:
```
This happens because a template item has two `role=button` elements that are labelled by the same "Single Posts" label: the image with template preview, and the "Single Posts" title itself:

<img width="262" height="406" alt="Screenshot 2026-05-11 at 18 52 02" src="https://github.com/user-attachments/assets/bd2ceed8-aba4-4b27-b4df-6beaa8d026b6" />

Then the locator resolves to two elements. I don't understand why this is not failing in CI, because even the CI Playwright config should use the `strictSelectors: true` option and fail such locators even if the click itself is done with `force: true`.

I'm fixing this by changing the locator to something else, and unique. The same lookup using the `.fields-field__title` CSS class is already used in many other e2e tests that work with the Templates page.

```
Site Editor Performance › Loading Pages
Error: strict mode violation: getByLabel('Page (0)') resolved to 2 elements:
```
This happens when the `test:performance` job is ran twice without doing a `wp-env reset` in between. There is a leftover "Page (0)" page from the previous run. Fixed by adding `deleteAllPages()` to global setup code that already deletes all posts, blocks etc. Not deleting pages was an obvious omission.

**How to test:**
Run `test:performance` locally a few times and verify it's reliably green.