### PR TITLE
Experiment: Render badges for some content types' fields

### DIFF
--- a/packages/content-types/src/post-types/fields/general.tsx
+++ b/packages/content-types/src/post-types/fields/general.tsx
@@ -19,6 +19,7 @@ import {
 	createDescriptionField,
 	SlugEdit,
 } from '../../utils/fields';
+import { OverflowingBadges } from '../../utils/overflowing-badges';
 import { SUPPORT_FEATURES, usePublicTaxonomies } from '../utils';
 import type { PostTypeFormData, SupportFeature } from '../types';
 
@@ -131,11 +132,12 @@ export const supportsField: Field< PostTypeFormData > = {
 			return <span aria-hidden="true">—</span>;
 		}
 		return (
-			<>
-				{ features
-					.map( ( f ) => SUPPORT_LABELS[ f ] ?? f )
-					.join( ', ' ) }
-			</>
+			<OverflowingBadges
+				items={ features.map( ( f ) => ( {
+					key: f,
+					label: SUPPORT_LABELS[ f ] ?? f,
+				} ) ) }
+			/>
 		);
 	},
 	filterBy: false,
@@ -247,11 +249,12 @@ export function useTaxonomiesField(): Field< PostTypeFormData > {
 					return <span aria-hidden="true">—</span>;
 				}
 				return (
-					<>
-						{ slugs
-							.map( ( s ) => labelMap[ s ] ?? s )
-							.join( ', ' ) }
-					</>
+					<OverflowingBadges
+						items={ slugs.map( ( s ) => ( {
+							key: s,
+							label: labelMap[ s ] ?? s,
+						} ) ) }
+					/>
 				);
 			},
 			filterBy: false,

--- a/packages/content-types/src/post-types/list.tsx
+++ b/packages/content-types/src/post-types/list.tsx
@@ -43,7 +43,12 @@ const DEFAULT_VIEW: View = {
 	page: 1,
 	fields: [ 'taxonomies', 'count', 'status' ],
 	titleField: 'title',
-	layout: {},
+	layout: {
+		styles: {
+			taxonomies: { minWidth: 230 },
+			supports: { minWidth: 230 },
+		},
+	},
 };
 
 export function PostTypesList() {

--- a/packages/content-types/src/taxonomies/fields/general.tsx
+++ b/packages/content-types/src/taxonomies/fields/general.tsx
@@ -19,6 +19,7 @@ import {
 	createDescriptionField,
 	SlugEdit,
 } from '../../utils/fields';
+import { OverflowingBadges } from '../../utils/overflowing-badges';
 import { usePublicPostTypes } from '../utils';
 import type { TaxonomyFormData } from '../types';
 
@@ -144,11 +145,12 @@ export function useObjectTypeField(): Field< TaxonomyFormData > {
 					return <span aria-hidden="true">—</span>;
 				}
 				return (
-					<>
-						{ slugs
-							.map( ( s ) => labelMap[ s ] ?? s )
-							.join( ', ' ) }
-					</>
+					<OverflowingBadges
+						items={ slugs.map( ( s ) => ( {
+							key: s,
+							label: labelMap[ s ] ?? s,
+						} ) ) }
+					/>
 				);
 			},
 			isValid: { required: true },

--- a/packages/content-types/src/taxonomies/list.tsx
+++ b/packages/content-types/src/taxonomies/list.tsx
@@ -41,7 +41,11 @@ const DEFAULT_VIEW: View = {
 	page: 1,
 	fields: [ 'object_type', 'count', 'status' ],
 	titleField: 'title',
-	layout: {},
+	layout: {
+		styles: {
+			object_type: { minWidth: 230 },
+		},
+	},
 };
 
 export function TaxonomiesList() {

--- a/packages/content-types/src/utils/overflowing-badges.tsx
+++ b/packages/content-types/src/utils/overflowing-badges.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, sprintf, _n } from '@wordpress/i18n';
 // eslint-disable-next-line @wordpress/use-recommended-components -- Used here because it supports rendering as a `span` via the `render` prop to avoid invalid HTML.
 import { Badge, Button, Popover, Stack, Tooltip } from '@wordpress/ui';
 

--- a/packages/content-types/src/utils/overflowing-badges.tsx
+++ b/packages/content-types/src/utils/overflowing-badges.tsx
@@ -2,8 +2,16 @@
  * WordPress dependencies
  */
 import { __, sprintf, _n } from '@wordpress/i18n';
-// eslint-disable-next-line @wordpress/use-recommended-components -- Used here because it supports rendering as a `span` via the `render` prop to avoid invalid HTML.
-import { Badge, Button, Popover, Stack, Tooltip } from '@wordpress/ui';
+/* eslint-disable @wordpress/use-recommended-components -- Used here because it supports rendering as a `span` via the `render` prop to avoid invalid HTML. */
+import {
+	Badge,
+	Button,
+	Popover,
+	Stack,
+	Tooltip,
+	VisuallyHidden,
+} from '@wordpress/ui';
+/* eslint-enable @wordpress/use-recommended-components */
 
 const DEFAULT_MAX = 3;
 
@@ -21,6 +29,11 @@ export function OverflowingBadges( {
 	const moreLabel = sprintf(
 		/* translators: %d: number of additional items */
 		_n( 'Show %d more', 'Show %d more', hidden.length ),
+		hidden.length
+	);
+	const popoverTitle = sprintf(
+		/* translators: %d: number of additional items */
+		_n( '%d more item', '%d more items', hidden.length ),
 		hidden.length
 	);
 	return (
@@ -65,6 +78,9 @@ export function OverflowingBadges( {
 								}
 							/>
 							<Popover.Popup style={ { maxWidth: 320 } }>
+								<VisuallyHidden render={ <Popover.Title /> }>
+									{ popoverTitle }
+								</VisuallyHidden>
 								<Stack direction="row" wrap="wrap" gap="xs">
 									{ hidden.map( ( item ) => (
 										<Badge key={ item.key }>

--- a/packages/content-types/src/utils/overflowing-badges.tsx
+++ b/packages/content-types/src/utils/overflowing-badges.tsx
@@ -1,0 +1,79 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+// eslint-disable-next-line @wordpress/use-recommended-components -- Used here because it supports rendering as a `span` via the `render` prop to avoid invalid HTML.
+import { Badge, Button, Popover, Stack, Tooltip } from '@wordpress/ui';
+
+const DEFAULT_MAX = 3;
+
+type OverflowingBadgesProps = {
+	items: Array< { key: string; label: string } >;
+	max?: number;
+};
+
+export function OverflowingBadges( {
+	items,
+	max = DEFAULT_MAX,
+}: OverflowingBadgesProps ) {
+	const visible = items.slice( 0, max );
+	const hidden = items.slice( max );
+	const moreLabel = sprintf(
+		/* translators: %d: number of additional items */
+		__( 'Show %d more' ),
+		hidden.length
+	);
+	return (
+		<Stack
+			direction="row"
+			wrap="wrap"
+			gap="xs"
+			align="center"
+			render={ <span /> }
+		>
+			{ visible.map( ( item ) => (
+				<Badge key={ item.key }>{ item.label }</Badge>
+			) ) }
+			{ hidden.length > 0 && (
+				<Tooltip.Provider delay={ 0 }>
+					<Tooltip.Root>
+						<Popover.Root>
+							<Tooltip.Trigger
+								render={
+									<Popover.Trigger
+										render={
+											<Button
+												variant="outline"
+												tone="neutral"
+												size="small"
+												aria-label={ moreLabel }
+												style={ {
+													minWidth: 'auto',
+													borderRadius:
+														'var(--wpds-border-radius-lg)',
+													fontWeight: 'normal',
+												} }
+											>
+												{ `+${ hidden.length }` }
+											</Button>
+										}
+									/>
+								}
+							/>
+							<Popover.Popup style={ { maxWidth: 320 } }>
+								<Stack direction="row" wrap="wrap" gap="xs">
+									{ hidden.map( ( item ) => (
+										<Badge key={ item.key }>
+											{ item.label }
+										</Badge>
+									) ) }
+								</Stack>
+							</Popover.Popup>
+							<Tooltip.Popup>{ moreLabel }</Tooltip.Popup>
+						</Popover.Root>
+					</Tooltip.Root>
+				</Tooltip.Provider>
+			) }
+		</Stack>
+	);
+}

--- a/packages/content-types/src/utils/overflowing-badges.tsx
+++ b/packages/content-types/src/utils/overflowing-badges.tsx
@@ -20,7 +20,7 @@ export function OverflowingBadges( {
 	const hidden = items.slice( max );
 	const moreLabel = sprintf(
 		/* translators: %d: number of additional items */
-		__( 'Show %d more' ),
+		_n( 'Show %d more', 'Show %d more', hidden.length ),
 		hidden.length
 	);
 	return (
@@ -54,7 +54,11 @@ export function OverflowingBadges( {
 													fontWeight: 'normal',
 												} }
 											>
-												{ `+${ hidden.length }` }
+												{ sprintf(
+													/* translators: %d: number of additional items */
+													__( '+%d' ),
+													hidden.length
+												) }
 											</Button>
 										}
 									/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR updates the `taxonomies and supports` fields' rendering for the experimental user post types and the `post types` for user taxonomies.

It uses `badges` to make them easier to scan and if more than **three**, renders a button that triggers a popover to show the rest. I think it's fine for first iteration and we can revisit the design if needed.

|Before|After|
|-|-|
|<img width="833" height="414" alt="Screenshot 2026-05-12 at 12 59 11 PM" src="https://github.com/user-attachments/assets/f98e81a4-97cc-4c98-912f-930bc4bc041c" />|<img width="833" height="414" alt="Screenshot 2026-05-12 at 12 58 59 PM" src="https://github.com/user-attachments/assets/f57e7951-3485-4b8b-9bc7-5eeb3ff0cdef" />|




## Testing instructions
1. Enable the `Content types` experiment.
2. Go to `Settings → Content types` and associate a post type with many taxonomies (more than three)
3. observe the button/popover
4. test this with `taxonomies and supports` fields for user post types
5. test this with `post types` for user taxonomies

## Use of AI Tools
Opus 4.7 with direction, changes and review