### PR TITLE
Tools: Remove save-exact from .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
-save-exact = true
 engine-strict = true
 legacy-peer-deps = true
 prefer-dedupe = true


### PR DESCRIPTION
## What?

Removes `save-exact = true` from `.npmrc` so that `npm install <pkg>` writes caret (`^x.y.z`) ranges instead of exact (`x.y.z`) versions.

Follow up to #77950.

## Why?

`save-exact = true` was [added 8 years ago in #2512](https://github.com/WordPress/gutenberg/pull/2512) by @aduth, when Gutenberg was primarily an application (before the monorepo packages publishing pattern was adopted in #6658). The original rationale was:

> Using exact versions helps avoid and reduce debugging cost of bugs by guaranteeing that two installations of Gutenberg are running the same dependency versions. It is typically recommendable for applications, whereas a library may want to allow some flexibility in the dependencies it supports (assuming trust in SemVer).

Since Gutenberg now publishes ~100 npm libraries under `@wordpress/*`, the original logic actually argues _against_ pinning. Exact versions in published packages prevent downstream consumers from receiving SemVer-compatible security and patch updates for transitive dependencies. @aduth [confirmed this view](https://github.com/WordPress/gutenberg/pull/77950#issuecomment-4385660620) in the #77950 discussion:

> I've recently been frustrated by the use of exact package versions in the project … Since we're now publishing libraries, I think the original logic still follows that it makes sense to remove `save-exact` and use caret versioning.

In addition, #77950 introduces Syncpack with a `range: '^'` rule for `prod`/`dev` dependencies. As [@ciampo flagged](https://github.com/WordPress/gutenberg/pull/77950#issuecomment-4385471795), leaving `save-exact = true` in `.npmrc` would mean every `npm install <pkg>` writes an exact version that Syncpack then immediately flags as a `SemverRangeMismatch`. Removing it here aligns the install behaviour with the lint policy so the two stop fighting.

The drift-prevention role that `save-exact` used to play is now better covered by:

-   `package-lock.json` (committed) — guarantees identical installs across machines and CI.
-   `lint:lockfile` — catches lockfile inconsistencies.
-   Syncpack (introduced in #77950) — enforces a single declared version per dependency across all workspaces.

## How?

-   `.npmrc` — remove the `save-exact = true` line. The remaining options (`engine-strict`, `legacy-peer-deps`, `prefer-dedupe`, `lockfile-version`, `min-release-age`) are unaffected.

No existing declared versions are rewritten in this PR — that realignment happens through Syncpack in the follow-up to #77950. This change only affects how _future_ `npm install <pkg>` invocations record versions in `package.json`.

## Testing Instructions

```sh
# 1. Confirm new installs use caret ranges:
npm install --save-dev --workspace=@wordpress/scripts <some-small-pkg>@latest
# The new entry in packages/scripts/package.json should be "^x.y.z", not "x.y.z".

# 2. Confirm the lockfile is unchanged in shape:
git diff package-lock.json   # no structural drift

# 3. Revert the test install before merging:
git checkout -- packages/scripts/package.json package-lock.json
```

### Testing Instructions for Keyboard

N/A — no UI changes.

## Screenshots or screencast

N/A — tooling/config only.

## Use of AI Tools

Drafted with assistance from Claude Code. The change, rationale, and PR description were reviewed and edited by hand.
