### PR TITLE
Experiment: Integrate `useView` in content types lists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58942,7 +58942,8 @@
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/route": "file:../route",
 				"@wordpress/ui": "file:../ui",
-				"@wordpress/url": "file:../url"
+				"@wordpress/url": "file:../url",
+				"@wordpress/views": "file:../views"
 			}
 		},
 		"packages/core-abilities": {

--- a/packages/content-types/package.json
+++ b/packages/content-types/package.json
@@ -48,7 +48,8 @@
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/route": "file:../route",
 		"@wordpress/ui": "file:../ui",
-		"@wordpress/url": "file:../url"
+		"@wordpress/url": "file:../url",
+		"@wordpress/views": "file:../views"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/content-types/src/post-types/list.tsx
+++ b/packages/content-types/src/post-types/list.tsx
@@ -4,9 +4,10 @@
 import { Button } from '@wordpress/components';
 import { DataViews, type Field, type View } from '@wordpress/dataviews';
 import { useEntityRecords } from '@wordpress/core-data';
-import { useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useNavigate } from '@wordpress/route';
+import { useNavigate, useSearch } from '@wordpress/route';
+import { useView } from '@wordpress/views';
 
 /**
  * Internal dependencies
@@ -46,7 +47,26 @@ const DEFAULT_VIEW: View = {
 
 export function PostTypesList() {
 	const navigate = useNavigate();
-	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const searchParams = useSearch( { from: POST_TYPES_PATH } );
+	const handleQueryParamsChange = useCallback(
+		( params: { page?: number; search?: string } ) => {
+			navigate( {
+				search: {
+					...searchParams,
+					...params,
+				},
+			} );
+		},
+		[ searchParams, navigate ]
+	);
+	const { view, updateView, isModified, resetToDefault } = useView( {
+		kind: 'postType',
+		name: POST_TYPE_ENTITY,
+		slug: 'default',
+		defaultView: DEFAULT_VIEW,
+		queryParams: searchParams,
+		onChangeQueryParams: handleQueryParamsChange,
+	} );
 	const editAction = useEditPostTypeAction();
 	const postTypeActions = useMemo(
 		() => [
@@ -113,7 +133,8 @@ export function PostTypesList() {
 			fields={ fields }
 			actions={ postTypeActions }
 			view={ view }
-			onChangeView={ setView }
+			onChangeView={ updateView }
+			onReset={ isModified ? resetToDefault : false }
 			isLoading={ isResolving || ! hasResolved }
 			paginationInfo={ paginationInfo }
 			defaultLayouts={ defaultLayouts }

--- a/packages/content-types/src/taxonomies/list.tsx
+++ b/packages/content-types/src/taxonomies/list.tsx
@@ -4,9 +4,10 @@
 import { Button } from '@wordpress/components';
 import { DataViews, type Field, type View } from '@wordpress/dataviews';
 import { useEntityRecords } from '@wordpress/core-data';
-import { useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useNavigate } from '@wordpress/route';
+import { useNavigate, useSearch } from '@wordpress/route';
+import { useView } from '@wordpress/views';
 
 /**
  * Internal dependencies
@@ -44,7 +45,26 @@ const DEFAULT_VIEW: View = {
 
 export function TaxonomiesList() {
 	const navigate = useNavigate();
-	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const searchParams = useSearch( { from: TAXONOMIES_PATH } );
+	const handleQueryParamsChange = useCallback(
+		( params: { page?: number; search?: string } ) => {
+			navigate( {
+				search: {
+					...searchParams,
+					...params,
+				},
+			} );
+		},
+		[ searchParams, navigate ]
+	);
+	const { view, updateView, isModified, resetToDefault } = useView( {
+		kind: 'postType',
+		name: TAXONOMY_ENTITY,
+		slug: 'default',
+		defaultView: DEFAULT_VIEW,
+		queryParams: searchParams,
+		onChangeQueryParams: handleQueryParamsChange,
+	} );
 	const editAction = useEditTaxonomyAction();
 	const taxonomyActions = useMemo(
 		() => [
@@ -113,7 +133,8 @@ export function TaxonomiesList() {
 			fields={ fields }
 			actions={ taxonomyActions }
 			view={ view }
-			onChangeView={ setView }
+			onChangeView={ updateView }
+			onReset={ isModified ? resetToDefault : false }
 			isLoading={ isResolving || ! hasResolved }
 			paginationInfo={ paginationInfo }
 			defaultLayouts={ defaultLayouts }

--- a/packages/content-types/tsconfig.json
+++ b/packages/content-types/tsconfig.json
@@ -19,6 +19,7 @@
 		{ "path": "../private-apis" },
 		{ "path": "../route" },
 		{ "path": "../ui" },
-		{ "path": "../url" }
+		{ "path": "../url" },
+		{ "path": "../views" }
 	]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/77600

This PR integrates the `useView` hook to persist some view changes in the content types' lists (taxonomies/post types). It also syncs the `search and page` params in the URL.

Noting that `search and page` are not preserved in the persistence layer, so when navigating through the tabs those params are reset. I think that's fine for this iteration and we can revisit if something like this is needed.


## Video (after)
https://github.com/user-attachments/assets/1199100d-bcf3-4c3e-8776-460dbbe4d797

## Testing instructions
1. Enable the `Content types` experiment.
2. Go to `Settings → Content types` and make some changes in the view of either entity (taxonomies/post types) like re-ordering of a field or adding/hiding a field.
3. Refresh or navigate to the other tab and back
4. Observe that the view changes are preserved
5. `Reset view` and observe that works as expected

## Use of AI Tools
Opus 4.7 with direction, changes and review



