### PR TITLE
Grid: add edit-mode overlay to DashboardGrid and DashboardLanes

### DIFF
--- a/packages/grid/src/dashboard-grid/grid.module.css
+++ b/packages/grid/src/dashboard-grid/grid.module.css
@@ -1,5 +1,6 @@
 .grid {
 	display: grid;
+	position: relative;
 }
 
 /*

--- a/packages/grid/src/dashboard-grid/index.tsx
+++ b/packages/grid/src/dashboard-grid/index.tsx
@@ -481,16 +481,23 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 		// gap, and row height. `'auto'` collapses to `undefined` for
 		// the overlay so it falls back to columns-only (row dividers
 		// have no anchor when the row height is content-driven).
+		// Memoized so drag/resize re-renders don't reconstruct the
+		// element while its inputs are stable; React then shortcuts
+		// the reconciliation of the overlay subtree by identity.
 		const Overlay = renderGridOverlay ?? GridOverlay;
-		const gridOverlay = editMode ? (
-			<Overlay
-				columns={ effectiveColumns }
-				gapPx={ gapPx }
-				rowHeight={
-					typeof rowHeight === 'number' ? rowHeight : undefined
-				}
-			/>
-		) : null;
+		const overlayRowHeight =
+			typeof rowHeight === 'number' ? rowHeight : undefined;
+		const gridOverlay = useMemo(
+			() =>
+				editMode ? (
+					<Overlay
+						columns={ effectiveColumns }
+						gapPx={ gapPx }
+						rowHeight={ overlayRowHeight }
+					/>
+				) : null,
+			[ Overlay, editMode, effectiveColumns, gapPx, overlayRowHeight ]
+		);
 
 		return (
 			<DndContext

--- a/packages/grid/src/dashboard-grid/index.tsx
+++ b/packages/grid/src/dashboard-grid/index.tsx
@@ -481,21 +481,22 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 		// gap, and row height. `'auto'` collapses to `undefined` for
 		// the overlay so it falls back to columns-only (row dividers
 		// have no anchor when the row height is content-driven).
-		// Memoized so drag/resize re-renders don't reconstruct the
-		// element while its inputs are stable; React then shortcuts
-		// the reconciliation of the overlay subtree by identity.
+		// Rendered unconditionally so the overlay can cross-fade on
+		// edit-mode toggles; `isActive` drives the opacity transition
+		// inside the overlay. Memoized so drag/resize re-renders skip
+		// reconciliation while inputs are stable.
 		const Overlay = renderGridOverlay ?? GridOverlay;
 		const overlayRowHeight =
 			typeof rowHeight === 'number' ? rowHeight : undefined;
 		const gridOverlay = useMemo(
-			() =>
-				editMode ? (
-					<Overlay
-						columns={ effectiveColumns }
-						gapPx={ gapPx }
-						rowHeight={ overlayRowHeight }
-					/>
-				) : null,
+			() => (
+				<Overlay
+					columns={ effectiveColumns }
+					gapPx={ gapPx }
+					rowHeight={ overlayRowHeight }
+					isActive={ editMode }
+				/>
+			),
 			[ Overlay, editMode, effectiveColumns, gapPx, overlayRowHeight ]
 		);
 

--- a/packages/grid/src/dashboard-grid/index.tsx
+++ b/packages/grid/src/dashboard-grid/index.tsx
@@ -36,6 +36,7 @@ import {
  * Internal dependencies
  */
 import { GridItem } from './grid-item';
+import { GridOverlay } from '../shared/grid-overlay';
 import { resolveFillWidths } from './resolve-fill-widths';
 import type { DashboardGridLayoutItem, DashboardGridProps } from './types';
 import type { ResizeDelta } from '../shared/types';
@@ -96,6 +97,7 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 			onPreviewLayout,
 			renderResizeHandle,
 			renderDragPreview,
+			renderGridOverlay,
 			...divProps
 		} = props;
 		// Preview layout applied during drag/resize before committing.
@@ -473,6 +475,23 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 				</div>
 			) : null;
 
+		// Edit-mode background visual. Default paints diagonal stripes
+		// and dashed track guides; a consumer can replace it via
+		// `renderGridOverlay` while reusing the resolved column count,
+		// gap, and row height. `'auto'` collapses to `undefined` for
+		// the overlay so it falls back to columns-only (row dividers
+		// have no anchor when the row height is content-driven).
+		const Overlay = renderGridOverlay ?? GridOverlay;
+		const gridOverlay = editMode ? (
+			<Overlay
+				columns={ effectiveColumns }
+				gapPx={ gapPx }
+				rowHeight={
+					typeof rowHeight === 'number' ? rowHeight : undefined
+				}
+			/>
+		) : null;
+
 		return (
 			<DndContext
 				sensors={ sensors }
@@ -499,6 +518,7 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 							gap: gapPx,
 						} }
 					>
+						{ gridOverlay }
 						{ items.map( ( id ) => (
 							<GridItem
 								key={ id }

--- a/packages/grid/src/dashboard-grid/stories/index.story.tsx
+++ b/packages/grid/src/dashboard-grid/stories/index.story.tsx
@@ -86,7 +86,9 @@ const bgTokens: Record< Tone, string > = {
 };
 
 const fgTokens: Record< Tone, string > = {
-	brand: 'var(--wpds-color-fg-content-info)',
+	// `brand` has no dedicated fg-content token in the design system,
+	// so neutral content reads safely against the brand surface tint.
+	brand: 'var(--wpds-color-fg-content-neutral)',
 	info: 'var(--wpds-color-fg-content-info)',
 	success: 'var(--wpds-color-fg-content-success)',
 	warning: 'var(--wpds-color-fg-content-warning)',

--- a/packages/grid/src/dashboard-grid/stories/index.story.tsx
+++ b/packages/grid/src/dashboard-grid/stories/index.story.tsx
@@ -437,10 +437,21 @@ export const RowHeight: Story = {
 };
 
 /**
- * Edit mode with drag, resize, and all width modes. The grid paints
- * its default overlay (diagonal stripes plus dashed column and row
- * tracks) behind the tiles to visualize the underlying template. A
- * state panel shows the raw layout JSON. Drag items to reorder;
+ * Edit mode with drag, resize, and all width modes. While `editMode`
+ * is on, `<DashboardGrid />` paints its default overlay behind the
+ * tiles to visualize the underlying template: diagonal stripes, a
+ * dashed outline on each column track, a subtle column fill that
+ * marks the drop zones against the gaps, and a 1px row divider when
+ * `rowHeight` is numeric. The overlay disappears when `editMode`
+ * flips back to `false`.
+ *
+ * Theme the default look in place via CSS custom properties exposed
+ * by the package (`--wp-grid-overlay-stripe-color`,
+ * `--wp-grid-overlay-track-color`, `--wp-grid-overlay-column-fill`),
+ * or replace the visual wholesale by passing `renderGridOverlay`.
+ * See the `Custom Grid Overlay` story for a full override example.
+ *
+ * A state panel shows the raw layout JSON. Drag items to reorder;
  * resize from the bottom-right handle. Keyboard sensor is enabled:
  * use Tab to focus an item, Space to grab, arrow keys to move, Space
  * to drop.
@@ -760,11 +771,17 @@ export const Customization: Story = {
 };
 
 /**
- * Replaces the package's default edit-mode overlay with a custom
- * visual. Receives the resolved column count, gap, and row height
- * from the grid; here, the override drops the row dividers, swaps to
- * an info tone, and labels each column track with its index. The
- * grid still owns when the overlay is rendered (only in edit mode).
+ * Example custom overlay supplied to `<DashboardGrid />` through the
+ * `renderGridOverlay` prop. Receives the grid's resolved column
+ * count, gap, and row height; this implementation drops the row
+ * dividers, swaps to an info tone, and labels each column track
+ * with its index. The grid keeps full control of *when* the overlay
+ * mounts (only when `editMode` is on); the consumer owns the
+ * markup.
+ *
+ * @param props         Render props supplied by the grid.
+ * @param props.columns Number of column tracks to mirror.
+ * @param props.gapPx   Gap between tracks in pixels.
  */
 function NumberedOverlay( { columns, gapPx }: GridOverlayRenderProps ) {
 	return (
@@ -813,6 +830,20 @@ function NumberedOverlay( { columns, gapPx }: GridOverlayRenderProps ) {
 	);
 }
 
+/**
+ * Replaces the package's default edit-mode overlay with a custom
+ * visual through the `renderGridOverlay` prop. The grid mounts the
+ * supplied component as a sibling behind the tiles whenever
+ * `editMode` is on, passing the resolved `{ columns, gapPx,
+ * rowHeight }` so the override can reproduce the column and row
+ * tracks pixel-accurately without re-deriving them.
+ *
+ * Here the override (see `NumberedOverlay` above) swaps the warning
+ * tone for info, drops the row dividers, and labels each column
+ * track with its index. Pass `renderGridOverlay={ () => null }` to
+ * suppress the overlay entirely while keeping `editMode` interactions
+ * on.
+ */
 export const CustomGridOverlayStory: Story = {
 	name: 'Custom Grid Overlay',
 	args: {

--- a/packages/grid/src/dashboard-grid/stories/index.story.tsx
+++ b/packages/grid/src/dashboard-grid/stories/index.story.tsx
@@ -773,17 +773,22 @@ export const Customization: Story = {
 /**
  * Example custom overlay supplied to `<DashboardGrid />` through the
  * `renderGridOverlay` prop. Receives the grid's resolved column
- * count, gap, and row height; this implementation drops the row
- * dividers, swaps to an info tone, and labels each column track
- * with its index. The grid keeps full control of *when* the overlay
- * mounts (only when `editMode` is on); the consumer owns the
- * markup.
+ * count, gap, row height, and `isActive` flag; this implementation
+ * drops the row dividers, swaps to an info tone, labels each column
+ * track with its index, and fades in/out on `isActive` toggles. The
+ * grid always mounts the overlay; the consumer owns the visual and
+ * its transition.
  *
- * @param props         Render props supplied by the grid.
- * @param props.columns Number of column tracks to mirror.
- * @param props.gapPx   Gap between tracks in pixels.
+ * @param props          Render props supplied by the grid.
+ * @param props.columns  Number of column tracks to mirror.
+ * @param props.gapPx    Gap between tracks in pixels.
+ * @param props.isActive Whether the overlay should be visible.
  */
-function NumberedOverlay( { columns, gapPx }: GridOverlayRenderProps ) {
+function NumberedOverlay( {
+	columns,
+	gapPx,
+	isActive,
+}: GridOverlayRenderProps ) {
 	return (
 		<div
 			aria-hidden
@@ -794,6 +799,11 @@ function NumberedOverlay( { columns, gapPx }: GridOverlayRenderProps ) {
 				gridTemplateColumns: `repeat(${ columns }, minmax(0, 1fr))`,
 				gap: gapPx,
 				pointerEvents: 'none',
+				opacity: isActive ? 1 : 0,
+				visibility: isActive ? 'visible' : 'hidden',
+				transition: isActive
+					? 'opacity 200ms ease, visibility 0s linear 0s'
+					: 'opacity 200ms ease, visibility 0s linear 200ms',
 				backgroundImage: `repeating-linear-gradient(135deg, color-mix(in srgb, var(--wpds-color-bg-surface-info) 24%, transparent) 0 6px, transparent 6px 12px)`,
 			} }
 		>

--- a/packages/grid/src/dashboard-grid/stories/index.story.tsx
+++ b/packages/grid/src/dashboard-grid/stories/index.story.tsx
@@ -18,6 +18,7 @@ import { DashboardGrid } from '..';
 import type { DashboardGridLayoutItem } from '../types';
 import type {
 	DragPreviewRenderProps,
+	GridOverlayRenderProps,
 	ResizeHandleRenderProps,
 } from '../../shared/types';
 
@@ -436,72 +437,13 @@ export const RowHeight: Story = {
 };
 
 /**
- * Visualizes the grid's column tracks and gaps as a Chrome
- * DevTools-style overlay. Renders a sibling grid behind
- * `DashboardGrid` with the same template, so the column tracks
- * line up exactly with the live layout.
- */
-function GridVisualizer( {
-	columns,
-	spacing,
-}: {
-	columns: number;
-	spacing: number;
-} ) {
-	const gapPx = spacing * 4;
-	return (
-		<div
-			aria-hidden
-			style={ {
-				position: 'absolute',
-				top: 24,
-				right: 0,
-				bottom: 0,
-				left: 0,
-				background: `repeating-linear-gradient(135deg, color-mix(in srgb, var(--wpds-color-bg-surface-warning) 28%, transparent) 0 6px, transparent 6px 12px)`,
-				display: 'grid',
-				gridTemplateColumns: `repeat(${ columns }, minmax(0, 1fr))`,
-				gap: gapPx,
-				pointerEvents: 'none',
-				zIndex: 0,
-			} }
-		>
-			{ Array.from( { length: columns } ).map( ( _, i ) => (
-				<div
-					key={ i }
-					style={ {
-						outline:
-							'1px dashed var(--wpds-color-stroke-surface-warning)',
-						position: 'relative',
-					} }
-				>
-					<span
-						style={ {
-							position: 'absolute',
-							top: -18,
-							left: 0,
-							fontSize: 10,
-							padding: '1px 4px',
-							borderRadius: 2,
-							background: 'var(--wpds-color-bg-surface-warning)',
-							color: 'var(--wpds-color-fg-content-warning)',
-							fontFamily:
-								'var(--wpds-typography-font-family-mono)',
-						} }
-					>
-						{ i + 1 }
-					</span>
-				</div>
-			) ) }
-		</div>
-	);
-}
-
-/**
- * Edit mode with drag, resize, and all width modes. A state panel
- * shows the raw layout JSON. Drag items to reorder; resize from the
- * bottom-right handle. Keyboard sensor is enabled: use Tab to focus
- * an item, Space to grab, arrow keys to move, Space to drop.
+ * Edit mode with drag, resize, and all width modes. The grid paints
+ * its default overlay (diagonal stripes plus dashed column and row
+ * tracks) behind the tiles to visualize the underlying template. A
+ * state panel shows the raw layout JSON. Drag items to reorder;
+ * resize from the bottom-right handle. Keyboard sensor is enabled:
+ * use Tab to focus an item, Space to grab, arrow keys to move, Space
+ * to drop.
  */
 export const EditMode: Story = {
 	args: {
@@ -643,17 +585,7 @@ export const EditMode: Story = {
 
 		return (
 			<Stack direction="row" gap="lg" align="flex-start">
-				<div
-					style={ {
-						width: '800px',
-						position: 'relative',
-						paddingTop: 24,
-					} }
-				>
-					<GridVisualizer
-						columns={ args.columns ?? 12 }
-						spacing={ args.spacing ?? 4 }
-					/>
+				<div style={ { width: '800px' } }>
 					<DashboardGrid
 						{ ...args }
 						layout={ layout }
@@ -823,6 +755,114 @@ export const Customization: Story = {
 					{ tiles }
 				</DashboardGrid>
 			</div>
+		);
+	},
+};
+
+/**
+ * Replaces the package's default edit-mode overlay with a custom
+ * visual. Receives the resolved column count, gap, and row height
+ * from the grid; here, the override drops the row dividers, swaps to
+ * an info tone, and labels each column track with its index. The
+ * grid still owns when the overlay is rendered (only in edit mode).
+ */
+function NumberedOverlay( { columns, gapPx }: GridOverlayRenderProps ) {
+	return (
+		<div
+			aria-hidden
+			style={ {
+				position: 'absolute',
+				inset: 0,
+				display: 'grid',
+				gridTemplateColumns: `repeat(${ columns }, minmax(0, 1fr))`,
+				gap: gapPx,
+				pointerEvents: 'none',
+				backgroundImage: `repeating-linear-gradient(135deg, color-mix(in srgb, var(--wpds-color-bg-surface-info) 24%, transparent) 0 6px, transparent 6px 12px)`,
+			} }
+		>
+			{ Array.from( { length: columns } ).map( ( _, i ) => (
+				<div
+					key={ i }
+					style={ {
+						outline:
+							'1px dashed var(--wpds-color-stroke-surface-info)',
+						backgroundColor:
+							'color-mix(in srgb, var(--wpds-color-bg-surface-info) 10%, transparent)',
+						position: 'relative',
+					} }
+				>
+					<span
+						style={ {
+							position: 'absolute',
+							top: 4,
+							insetInlineStart: 4,
+							fontSize: 10,
+							padding: '1px 6px',
+							borderRadius: 2,
+							background: 'var(--wpds-color-bg-surface-info)',
+							color: 'var(--wpds-color-fg-content-info)',
+							fontFamily:
+								'var(--wpds-typography-font-family-mono)',
+						} }
+					>
+						{ i + 1 }
+					</span>
+				</div>
+			) ) }
+		</div>
+	);
+}
+
+export const CustomGridOverlayStory: Story = {
+	name: 'Custom Grid Overlay',
+	args: {
+		columns: 12,
+		spacing: 4,
+		rowHeight: 80,
+		editMode: true,
+		layout: [
+			{ key: 'a', width: 3, height: 1 },
+			{ key: 'b', width: 5, height: 1 },
+			{ key: 'c', width: 4, height: 1 },
+			{ key: 'd', width: 2, height: 2 },
+			{ key: 'e', width: 6, height: 1 },
+		],
+	},
+	render: function CustomGridOverlayRender( args ) {
+		const [ layout, setLayout ] = useState< DashboardGridLayoutItem[] >(
+			args.layout
+		);
+
+		const tiles = useMemo(
+			() => [
+				<Tile key="a" tone="brand">
+					A
+				</Tile>,
+				<Tile key="b" tone="info">
+					B
+				</Tile>,
+				<Tile key="c" tone="success">
+					C
+				</Tile>,
+				<Tile key="d" tone="warning">
+					D
+				</Tile>,
+				<Tile key="e" tone="error">
+					E
+				</Tile>,
+			],
+			[]
+		);
+
+		return (
+			<DashboardGrid
+				{ ...args }
+				layout={ layout }
+				onChangeLayout={ setLayout }
+				renderGridOverlay={ NumberedOverlay }
+			>
+				{ tiles }
+			</DashboardGrid>
 		);
 	},
 };

--- a/packages/grid/src/dashboard-grid/types.ts
+++ b/packages/grid/src/dashboard-grid/types.ts
@@ -3,6 +3,7 @@
  */
 import type {
 	DragPreviewRenderProps,
+	GridOverlayRenderProps,
 	ResizeDelta,
 	ResizeHandleRenderProps,
 } from '../shared/types';
@@ -209,6 +210,17 @@ interface BaseDashboardGridProps
 	 * properties documented in the README.
 	 */
 	renderDragPreview?: React.ComponentType< DragPreviewRenderProps >;
+
+	/**
+	 * Override the default edit-mode overlay (diagonal stripes plus
+	 * dashed column and row tracks) with a custom component. The grid
+	 * supplies the resolved column count, gap, and row height; the
+	 * consumer is responsible for the visual.
+	 *
+	 * The overlay only renders when `editMode` is true. When omitted,
+	 * the package's default visual is used.
+	 */
+	renderGridOverlay?: React.ComponentType< GridOverlayRenderProps >;
 }
 
 interface FixedDashboardGridProps extends BaseDashboardGridProps {

--- a/packages/grid/src/dashboard-lanes/index.tsx
+++ b/packages/grid/src/dashboard-lanes/index.tsx
@@ -425,16 +425,20 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 
 		// Edit-mode background visual. Lanes are content-driven
 		// vertically, so the overlay only mirrors columns; the default
-		// can be replaced wholesale via `renderGridOverlay`. Memoized
-		// so drag/resize re-renders don't reconstruct the element
-		// while its inputs are stable; React then shortcuts the
-		// reconciliation of the overlay subtree by identity.
+		// can be replaced wholesale via `renderGridOverlay`. Rendered
+		// unconditionally so the overlay can cross-fade on edit-mode
+		// toggles; `isActive` drives the opacity transition inside the
+		// overlay. Memoized so drag/resize re-renders skip
+		// reconciliation while inputs are stable.
 		const Overlay = renderGridOverlay ?? GridOverlay;
 		const gridOverlay = useMemo(
-			() =>
-				editMode ? (
-					<Overlay columns={ effectiveColumns } gapPx={ gapPx } />
-				) : null,
+			() => (
+				<Overlay
+					columns={ effectiveColumns }
+					gapPx={ gapPx }
+					isActive={ editMode }
+				/>
+			),
 			[ Overlay, editMode, effectiveColumns, gapPx ]
 		);
 

--- a/packages/grid/src/dashboard-lanes/index.tsx
+++ b/packages/grid/src/dashboard-lanes/index.tsx
@@ -425,11 +425,18 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 
 		// Edit-mode background visual. Lanes are content-driven
 		// vertically, so the overlay only mirrors columns; the default
-		// can be replaced wholesale via `renderGridOverlay`.
+		// can be replaced wholesale via `renderGridOverlay`. Memoized
+		// so drag/resize re-renders don't reconstruct the element
+		// while its inputs are stable; React then shortcuts the
+		// reconciliation of the overlay subtree by identity.
 		const Overlay = renderGridOverlay ?? GridOverlay;
-		const gridOverlay = editMode ? (
-			<Overlay columns={ effectiveColumns } gapPx={ gapPx } />
-		) : null;
+		const gridOverlay = useMemo(
+			() =>
+				editMode ? (
+					<Overlay columns={ effectiveColumns } gapPx={ gapPx } />
+				) : null,
+			[ Overlay, editMode, effectiveColumns, gapPx ]
+		);
 
 		return (
 			<DndContext

--- a/packages/grid/src/dashboard-lanes/index.tsx
+++ b/packages/grid/src/dashboard-lanes/index.tsx
@@ -37,6 +37,7 @@ import {
  */
 import { LanesItem } from './lanes-item';
 import { useLanePlacement } from './use-lane-placement';
+import { GridOverlay } from '../shared/grid-overlay';
 import type { DashboardLanesLayoutItem, DashboardLanesProps } from './types';
 import type { ResizeDelta } from '../shared/types';
 import styles from './lanes.module.css';
@@ -97,6 +98,7 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 			onPreviewLayout,
 			renderResizeHandle,
 			renderDragPreview,
+			renderGridOverlay,
 			...divProps
 		} = props;
 
@@ -421,6 +423,14 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 				</div>
 			) : null;
 
+		// Edit-mode background visual. Lanes are content-driven
+		// vertically, so the overlay only mirrors columns; the default
+		// can be replaced wholesale via `renderGridOverlay`.
+		const Overlay = renderGridOverlay ?? GridOverlay;
+		const gridOverlay = editMode ? (
+			<Overlay columns={ effectiveColumns } gapPx={ gapPx } />
+		) : null;
+
 		return (
 			<DndContext
 				sensors={ sensors }
@@ -458,6 +468,7 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 							} as React.CSSProperties
 						}
 					>
+						{ gridOverlay }
 						{ items.map( ( id ) => {
 							const child = childrenMap.get( id );
 							if ( ! child ) {

--- a/packages/grid/src/dashboard-lanes/lanes.module.css
+++ b/packages/grid/src/dashboard-lanes/lanes.module.css
@@ -2,6 +2,7 @@
 	display: grid-lanes;
 	column-gap: var(--wp-grid-lane-gap, 0);
 	row-gap: var(--wp-grid-lane-gap, 0);
+	position: relative;
 }
 
 /*

--- a/packages/grid/src/dashboard-lanes/stories/index.story.tsx
+++ b/packages/grid/src/dashboard-lanes/stories/index.story.tsx
@@ -82,7 +82,9 @@ const bgTokens: Record< Tone, string > = {
 };
 
 const fgTokens: Record< Tone, string > = {
-	brand: 'var(--wpds-color-fg-content-info)',
+	// `brand` has no dedicated fg-content token in the design system,
+	// so neutral content reads safely against the brand surface tint.
+	brand: 'var(--wpds-color-fg-content-neutral)',
 	info: 'var(--wpds-color-fg-content-info)',
 	success: 'var(--wpds-color-fg-content-success)',
 	warning: 'var(--wpds-color-fg-content-warning)',

--- a/packages/grid/src/dashboard-lanes/stories/index.story.tsx
+++ b/packages/grid/src/dashboard-lanes/stories/index.story.tsx
@@ -348,15 +348,22 @@ export const EditMode: Story = {
 
 /**
  * Example custom overlay supplied to `<DashboardLanes />` through the
- * `renderGridOverlay` prop. Receives `{ columns, gapPx }` from the
- * surface (no `rowHeight` because lane heights are content-driven)
- * and is responsible for the markup mounted behind the tiles.
+ * `renderGridOverlay` prop. Receives `{ columns, gapPx, isActive }`
+ * from the surface (no `rowHeight` because lane heights are
+ * content-driven). The custom must honor `isActive` for the same
+ * cross-fade behavior as the default; the surface always mounts the
+ * overlay.
  *
- * @param props         Render props supplied by the surface.
- * @param props.columns Number of lane tracks to mirror.
- * @param props.gapPx   Gap between lanes in pixels.
+ * @param props          Render props supplied by the surface.
+ * @param props.columns  Number of lane tracks to mirror.
+ * @param props.gapPx    Gap between lanes in pixels.
+ * @param props.isActive Whether the overlay should be visible.
  */
-function NumberedLanesOverlay( { columns, gapPx }: GridOverlayRenderProps ) {
+function NumberedLanesOverlay( {
+	columns,
+	gapPx,
+	isActive,
+}: GridOverlayRenderProps ) {
 	return (
 		<div
 			aria-hidden
@@ -367,6 +374,11 @@ function NumberedLanesOverlay( { columns, gapPx }: GridOverlayRenderProps ) {
 				gridTemplateColumns: `repeat(${ columns }, minmax(0, 1fr))`,
 				gap: gapPx,
 				pointerEvents: 'none',
+				opacity: isActive ? 1 : 0,
+				visibility: isActive ? 'visible' : 'hidden',
+				transition: isActive
+					? 'opacity 200ms ease, visibility 0s linear 0s'
+					: 'opacity 200ms ease, visibility 0s linear 200ms',
 				backgroundImage: `repeating-linear-gradient(135deg, color-mix(in srgb, var(--wpds-color-bg-surface-info) 24%, transparent) 0 6px, transparent 6px 12px)`,
 			} }
 		>

--- a/packages/grid/src/dashboard-lanes/stories/index.story.tsx
+++ b/packages/grid/src/dashboard-lanes/stories/index.story.tsx
@@ -13,6 +13,7 @@ import { useState, useMemo } from '@wordpress/element';
  */
 import { DashboardLanes } from '..';
 import type { DashboardLanesLayoutItem } from '../types';
+import type { GridOverlayRenderProps } from '../../shared/types';
 
 const meta: Meta< typeof DashboardLanes > = {
 	title: 'Grid/DashboardLanes',
@@ -258,6 +259,18 @@ export const Spanning: Story = {
  * Edit mode: drag to reorder, resize from the bottom-right corner
  * (horizontal only — heights are content-driven). Drop commits the
  * new layout via `onChangeLayout`.
+ *
+ * While `editMode` is on, `<DashboardLanes />` paints its default
+ * overlay behind the tiles to mark the lane tracks: diagonal stripes
+ * plus a dashed outline and subtle fill on each column. Lanes paint
+ * columns only — there are no row dividers because heights are
+ * content-driven.
+ *
+ * Theme the default look in place via CSS custom properties
+ * (`--wp-grid-overlay-stripe-color`, `--wp-grid-overlay-track-color`,
+ * `--wp-grid-overlay-column-fill`), or replace the visual wholesale
+ * by passing `renderGridOverlay`. See the `Custom Grid Overlay`
+ * story below for a full override example.
  */
 export const EditMode: Story = {
 	args: {
@@ -326,6 +339,147 @@ export const EditMode: Story = {
 				{ ...args }
 				layout={ layout }
 				onChangeLayout={ onChangeLayout }
+			>
+				{ tileElements }
+			</DashboardLanes>
+		);
+	},
+};
+
+/**
+ * Example custom overlay supplied to `<DashboardLanes />` through the
+ * `renderGridOverlay` prop. Receives `{ columns, gapPx }` from the
+ * surface (no `rowHeight` because lane heights are content-driven)
+ * and is responsible for the markup mounted behind the tiles.
+ *
+ * @param props         Render props supplied by the surface.
+ * @param props.columns Number of lane tracks to mirror.
+ * @param props.gapPx   Gap between lanes in pixels.
+ */
+function NumberedLanesOverlay( { columns, gapPx }: GridOverlayRenderProps ) {
+	return (
+		<div
+			aria-hidden
+			style={ {
+				position: 'absolute',
+				inset: 0,
+				display: 'grid',
+				gridTemplateColumns: `repeat(${ columns }, minmax(0, 1fr))`,
+				gap: gapPx,
+				pointerEvents: 'none',
+				backgroundImage: `repeating-linear-gradient(135deg, color-mix(in srgb, var(--wpds-color-bg-surface-info) 24%, transparent) 0 6px, transparent 6px 12px)`,
+			} }
+		>
+			{ Array.from( { length: columns } ).map( ( _, i ) => (
+				<div
+					key={ i }
+					style={ {
+						outline:
+							'1px dashed var(--wpds-color-stroke-surface-info)',
+						backgroundColor:
+							'color-mix(in srgb, var(--wpds-color-bg-surface-info) 10%, transparent)',
+						position: 'relative',
+					} }
+				>
+					<span
+						style={ {
+							position: 'absolute',
+							top: 4,
+							insetInlineStart: 4,
+							fontSize: 10,
+							padding: '1px 6px',
+							borderRadius: 2,
+							background: 'var(--wpds-color-bg-surface-info)',
+							color: 'var(--wpds-color-fg-content-info)',
+							fontFamily:
+								'var(--wpds-typography-font-family-mono)',
+						} }
+					>
+						{ i + 1 }
+					</span>
+				</div>
+			) ) }
+		</div>
+	);
+}
+
+/**
+ * Replaces the surface's default edit-mode overlay with a custom
+ * visual through the `renderGridOverlay` prop. The same contract as
+ * `<DashboardGrid />`'s override path, with `rowHeight` omitted from
+ * the render props because lanes are content-driven vertically.
+ *
+ * Pass `renderGridOverlay={ () => null }` to suppress the overlay
+ * entirely while keeping `editMode` interactions on.
+ */
+export const CustomGridOverlayStory: Story = {
+	name: 'Custom Grid Overlay',
+	args: {
+		columns: 4,
+		spacing: 2,
+		editMode: true,
+	},
+	render: function CustomGridOverlayRender( args ) {
+		const initial: ( DashboardLanesLayoutItem & {
+			tone: Tone;
+			height: number;
+			label: string;
+		} )[] = [
+			{ key: 'a', tone: 'brand', height: 140, label: '140px' },
+			{ key: 'b', tone: 'info', height: 200, label: '200px' },
+			{
+				key: 'wide',
+				width: 2,
+				tone: 'success',
+				height: 120,
+				label: 'span 2',
+			},
+			{ key: 'c', tone: 'warning', height: 180, label: '180px' },
+			{ key: 'd', tone: 'error', height: 100, label: '100px' },
+			{ key: 'e', tone: 'neutral', height: 220, label: '220px' },
+		];
+
+		const [ tiles, setTiles ] = useState( initial );
+
+		const layout: DashboardLanesLayoutItem[] = tiles.map(
+			( { tone: _tone, height: _height, label: _label, ...item } ) => item
+		);
+
+		const onChangeLayout = ( next: DashboardLanesLayoutItem[] ) => {
+			setTiles(
+				next.map( ( item ) => {
+					const existing = tiles.find( ( t ) => t.key === item.key );
+					return {
+						...item,
+						tone: existing?.tone ?? 'neutral',
+						height: existing?.height ?? 100,
+						label: existing?.label ?? item.key,
+					};
+				} )
+			);
+		};
+
+		const tileElements = useMemo(
+			() =>
+				tiles.map( ( tile, i ) => (
+					<Tile
+						key={ tile.key }
+						tone={ tile.tone }
+						height={ tile.height }
+						index={ i + 1 }
+					>
+						{ tile.label }
+					</Tile>
+				) ),
+			[ tiles ]
+		);
+
+		return (
+			<DashboardLanes
+				{ ...args }
+				layout={ layout }
+				onChangeLayout={ onChangeLayout }
+				renderGridOverlay={ NumberedLanesOverlay }
 			>
 				{ tileElements }
 			</DashboardLanes>

--- a/packages/grid/src/dashboard-lanes/types.ts
+++ b/packages/grid/src/dashboard-lanes/types.ts
@@ -3,6 +3,7 @@
  */
 import type {
 	DragPreviewRenderProps,
+	GridOverlayRenderProps,
 	ResizeHandleRenderProps,
 } from '../shared/types';
 
@@ -145,6 +146,17 @@ interface BaseDashboardLanesProps
 	 * properties documented in the README.
 	 */
 	renderDragPreview?: React.ComponentType< DragPreviewRenderProps >;
+
+	/**
+	 * Override the default edit-mode overlay (diagonal stripes plus
+	 * dashed column track guides) with a custom component. Lanes are
+	 * content-driven vertically, so no `rowHeight` is supplied and the
+	 * default visual paints columns only.
+	 *
+	 * The overlay only renders when `editMode` is true. When omitted,
+	 * the package's default visual is used.
+	 */
+	renderGridOverlay?: React.ComponentType< GridOverlayRenderProps >;
 }
 
 interface FixedDashboardLanesProps extends BaseDashboardLanesProps {

--- a/packages/grid/src/index.ts
+++ b/packages/grid/src/index.ts
@@ -11,6 +11,7 @@ export type {
 } from './dashboard-lanes/types';
 export type {
 	DragPreviewRenderProps,
+	GridOverlayRenderProps,
 	ResizeDelta,
 	ResizeHandleRenderProps,
 } from './shared/types';

--- a/packages/grid/src/shared/grid-overlay.module.css
+++ b/packages/grid/src/shared/grid-overlay.module.css
@@ -36,22 +36,19 @@
 }
 
 /*
- * Dashed row dividers between rows. A `::after` pseudo-element tiles a
- * 1px stroke at the top of each row track and is masked with a
- * horizontal dash pattern so the stroke renders dashed instead of
- * solid. The pattern is shifted up by 1px so the first stroke lands
- * just above the grid (clipped) and the last visible stroke sits at
- * the top of the final row, leaving no divider at the bottom of the
- * grid.
+ * Dashed row dividers framing every row. A `::after` pseudo-element
+ * tiles two 1px strokes per row (top of the row area and bottom of
+ * the row area, leaving the gap clear between them) and is masked
+ * with a horizontal dash pattern so the strokes render dashed instead
+ * of solid.
  */
 .has-rows .column::after {
 	content: "";
 	position: absolute;
 	inset: 0;
 	pointer-events: none;
-	background-image: linear-gradient(to bottom, var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning)) 0, var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning)) 1px, transparent 1px, transparent var(--wp-grid-overlay-row-tile));
+	background-image: linear-gradient(to bottom, var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning)) 0, var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning)) 1px, transparent 1px, transparent calc(var(--wp-grid-overlay-row-height) - 1px), var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning)) calc(var(--wp-grid-overlay-row-height) - 1px), var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning)) var(--wp-grid-overlay-row-height), transparent var(--wp-grid-overlay-row-height), transparent var(--wp-grid-overlay-row-tile));
 	background-size: 100% var(--wp-grid-overlay-row-tile);
-	background-position: 0 -1px;
 	background-repeat: repeat;
 	mask-image: repeating-linear-gradient(to right, #000 0 4px, transparent 4px 8px);
 	-webkit-mask-image: repeating-linear-gradient(to right, #000 0 4px, transparent 4px 8px);

--- a/packages/grid/src/shared/grid-overlay.module.css
+++ b/packages/grid/src/shared/grid-overlay.module.css
@@ -3,9 +3,28 @@
 	inset: 0;
 	display: grid;
 	pointer-events: none;
+	opacity: 0;
+	visibility: hidden;
+	transition:
+		opacity 200ms ease,
+		visibility 0s linear 200ms;
 	background-image:
 		repeating-linear-gradient(135deg, var(--wp-grid-overlay-stripe-color, color-mix(in srgb, var(--wpds-color-bg-surface-warning) 28%, transparent))
 		0 6px, transparent 6px 12px);
+}
+
+.overlay.is-active {
+	opacity: 1;
+	visibility: visible;
+	transition:
+		opacity 200ms ease,
+		visibility 0s linear 0s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.overlay {
+		transition: none;
+	}
 }
 
 .column {

--- a/packages/grid/src/shared/grid-overlay.module.css
+++ b/packages/grid/src/shared/grid-overlay.module.css
@@ -9,7 +9,7 @@
 		opacity 200ms ease,
 		visibility 0s linear 200ms;
 	background-image:
-		repeating-linear-gradient(135deg, var(--wp-grid-overlay-stripe-color, color-mix(in srgb, var(--wpds-color-bg-surface-warning) 28%, transparent))
+		repeating-linear-gradient(135deg, var(--wp-grid-overlay-stripe-color, color-mix(in srgb, var(--wpds-color-bg-surface-warning) 15%, transparent))
 		0 6px, transparent 6px 12px);
 }
 
@@ -32,19 +32,27 @@
 		1px dashed
 		var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning));
 	background-color: var(--wp-grid-overlay-column-fill, color-mix(in srgb, var(--wpds-color-bg-surface-warning) 10%, transparent));
+	position: relative;
 }
 
 /*
- * Tile a 1px solid stroke at the bottom edge of each row track. The
- * gradient paints transparent for most of the row, a 1px band of the
- * track color where the row ends, then transparent through the gap.
- * `background-size` makes that single stop repeat for every row.
+ * Dashed row dividers between rows. A `::after` pseudo-element tiles a
+ * 1px stroke at the top of each row track and is masked with a
+ * horizontal dash pattern so the stroke renders dashed instead of
+ * solid. The pattern is shifted up by 1px so the first stroke lands
+ * just above the grid (clipped) and the last visible stroke sits at
+ * the top of the final row, leaving no divider at the bottom of the
+ * grid.
  */
-.has-rows .column {
-	background-image:
-		linear-gradient(to bottom, transparent var(--wp-grid-overlay-row-line), var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning))
-		var(--wp-grid-overlay-row-line), var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning))
-		var(--wp-grid-overlay-row-line-end), transparent var(--wp-grid-overlay-row-line-end));
+.has-rows .column::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	background-image: linear-gradient(to bottom, var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning)) 0, var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning)) 1px, transparent 1px, transparent var(--wp-grid-overlay-row-tile));
 	background-size: 100% var(--wp-grid-overlay-row-tile);
+	background-position: 0 -1px;
 	background-repeat: repeat;
+	mask-image: repeating-linear-gradient(to right, #000 0 4px, transparent 4px 8px);
+	-webkit-mask-image: repeating-linear-gradient(to right, #000 0 4px, transparent 4px 8px);
 }

--- a/packages/grid/src/shared/grid-overlay.module.css
+++ b/packages/grid/src/shared/grid-overlay.module.css
@@ -1,0 +1,31 @@
+.overlay {
+	position: absolute;
+	inset: 0;
+	display: grid;
+	pointer-events: none;
+	background-image:
+		repeating-linear-gradient(135deg, var(--wp-grid-overlay-stripe-color, color-mix(in srgb, var(--wpds-color-bg-surface-warning) 28%, transparent))
+		0 6px, transparent 6px 12px);
+}
+
+.column {
+	outline:
+		1px dashed
+		var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning));
+	background-color: var(--wp-grid-overlay-column-fill, color-mix(in srgb, var(--wpds-color-bg-surface-warning) 10%, transparent));
+}
+
+/*
+ * Tile a 1px solid stroke at the bottom edge of each row track. The
+ * gradient paints transparent for most of the row, a 1px band of the
+ * track color where the row ends, then transparent through the gap.
+ * `background-size` makes that single stop repeat for every row.
+ */
+.has-rows .column {
+	background-image:
+		linear-gradient(to bottom, transparent var(--wp-grid-overlay-row-line), var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning))
+		var(--wp-grid-overlay-row-line), var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning))
+		var(--wp-grid-overlay-row-line-end), transparent var(--wp-grid-overlay-row-line-end));
+	background-size: 100% var(--wp-grid-overlay-row-tile);
+	background-repeat: repeat;
+}

--- a/packages/grid/src/shared/grid-overlay.module.css
+++ b/packages/grid/src/shared/grid-overlay.module.css
@@ -9,7 +9,7 @@
 		opacity 200ms ease,
 		visibility 0s linear 200ms;
 	background-image:
-		repeating-linear-gradient(135deg, var(--wp-grid-overlay-stripe-color, color-mix(in srgb, var(--wpds-color-bg-surface-neutral) 15%, transparent))
+		repeating-linear-gradient(135deg, var(--wp-grid-overlay-stripe-color, color-mix(in srgb, var(--wpds-color-bg-surface-info) 15%, transparent))
 		0 6px, transparent 6px 12px);
 }
 
@@ -31,7 +31,7 @@
 	outline:
 		1px dashed
 		var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-neutral));
-	background-color: var(--wp-grid-overlay-column-fill, color-mix(in srgb, var(--wpds-color-bg-surface-neutral) 10%, transparent));
+	background-color: var(--wp-grid-overlay-column-fill, color-mix(in srgb, var(--wpds-color-bg-surface-info) 10%, transparent));
 	position: relative;
 }
 

--- a/packages/grid/src/shared/grid-overlay.module.css
+++ b/packages/grid/src/shared/grid-overlay.module.css
@@ -9,7 +9,7 @@
 		opacity 200ms ease,
 		visibility 0s linear 200ms;
 	background-image:
-		repeating-linear-gradient(135deg, var(--wp-grid-overlay-stripe-color, color-mix(in srgb, var(--wpds-color-bg-surface-warning) 15%, transparent))
+		repeating-linear-gradient(135deg, var(--wp-grid-overlay-stripe-color, color-mix(in srgb, var(--wpds-color-bg-surface-neutral) 15%, transparent))
 		0 6px, transparent 6px 12px);
 }
 
@@ -30,8 +30,8 @@
 .column {
 	outline:
 		1px dashed
-		var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning));
-	background-color: var(--wp-grid-overlay-column-fill, color-mix(in srgb, var(--wpds-color-bg-surface-warning) 10%, transparent));
+		var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-neutral));
+	background-color: var(--wp-grid-overlay-column-fill, color-mix(in srgb, var(--wpds-color-bg-surface-neutral) 10%, transparent));
 	position: relative;
 }
 
@@ -47,7 +47,7 @@
 	position: absolute;
 	inset: 0;
 	pointer-events: none;
-	background-image: linear-gradient(to bottom, var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning)) 0, var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning)) 1px, transparent 1px, transparent calc(var(--wp-grid-overlay-row-height) - 1px), var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning)) calc(var(--wp-grid-overlay-row-height) - 1px), var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-warning)) var(--wp-grid-overlay-row-height), transparent var(--wp-grid-overlay-row-height), transparent var(--wp-grid-overlay-row-tile));
+	background-image: linear-gradient(to bottom, var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-neutral)) 0, var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-neutral)) 1px, transparent 1px, transparent calc(var(--wp-grid-overlay-row-height) - 1px), var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-neutral)) calc(var(--wp-grid-overlay-row-height) - 1px), var(--wp-grid-overlay-track-color, var(--wpds-color-stroke-surface-neutral)) var(--wp-grid-overlay-row-height), transparent var(--wp-grid-overlay-row-height), transparent var(--wp-grid-overlay-row-tile));
 	background-size: 100% var(--wp-grid-overlay-row-tile);
 	background-repeat: repeat;
 	mask-image: repeating-linear-gradient(to right, #000 0 4px, transparent 4px 8px);

--- a/packages/grid/src/shared/grid-overlay.tsx
+++ b/packages/grid/src/shared/grid-overlay.tsx
@@ -19,17 +19,23 @@ import styles from './grid-overlay.module.css';
  * by passing a `renderGridOverlay` to either surface; themed in place
  * via the CSS custom properties documented in the package README.
  *
+ * Cross-fades in and out on `isActive` toggles via a CSS opacity
+ * transition; while inactive, `visibility: hidden` releases paint cost.
+ *
  * @param props           Render props supplied by the surface.
  * @param props.columns   Number of column tracks to mirror.
  * @param props.gapPx     Gap between tracks in pixels.
  * @param props.rowHeight Row height in pixels for surfaces with uniform
  *                        rows. Omitted on lane surfaces or auto-sized
  *                        grids; in that case row dividers are skipped.
+ * @param props.isActive  When `false`, the overlay fades out and stops
+ *                        consuming paint cost.
  */
 export function GridOverlay( {
 	columns,
 	gapPx,
 	rowHeight,
+	isActive,
 }: GridOverlayRenderProps ) {
 	const showRows = typeof rowHeight === 'number';
 	// Custom properties drive the row-divider gradient so the CSS file
@@ -51,6 +57,7 @@ export function GridOverlay( {
 			aria-hidden
 			className={ clsx(
 				styles.overlay,
+				isActive && styles[ 'is-active' ],
 				showRows && styles[ 'has-rows' ]
 			) }
 			style={ style }

--- a/packages/grid/src/shared/grid-overlay.tsx
+++ b/packages/grid/src/shared/grid-overlay.tsx
@@ -38,16 +38,15 @@ export function GridOverlay( {
 	isActive,
 }: GridOverlayRenderProps ) {
 	const showRows = typeof rowHeight === 'number';
-	// Custom properties drive the row-divider gradient so the CSS file
-	// stays static while the values come from the live grid.
+	// `--wp-grid-overlay-row-tile` drives the row-divider tile size so
+	// the CSS file stays static while the value comes from the live
+	// grid.
 	const style: React.CSSProperties = {
 		gridTemplateColumns: `repeat(${ columns }, minmax(0, 1fr))`,
 		gap: `${ gapPx }px`,
 		...( showRows
 			? ( {
 					'--wp-grid-overlay-row-tile': `${ rowHeight + gapPx }px`,
-					'--wp-grid-overlay-row-line': `calc(${ rowHeight }px - 1px)`,
-					'--wp-grid-overlay-row-line-end': `${ rowHeight }px`,
 			  } as React.CSSProperties )
 			: {} ),
 	};

--- a/packages/grid/src/shared/grid-overlay.tsx
+++ b/packages/grid/src/shared/grid-overlay.tsx
@@ -38,14 +38,15 @@ export function GridOverlay( {
 	isActive,
 }: GridOverlayRenderProps ) {
 	const showRows = typeof rowHeight === 'number';
-	// `--wp-grid-overlay-row-tile` drives the row-divider tile size so
-	// the CSS file stays static while the value comes from the live
-	// grid.
+	// `--wp-grid-overlay-row-height` and `--wp-grid-overlay-row-tile`
+	// drive the row-divider stops so the CSS file stays static while
+	// the values come from the live grid.
 	const style: React.CSSProperties = {
 		gridTemplateColumns: `repeat(${ columns }, minmax(0, 1fr))`,
 		gap: `${ gapPx }px`,
 		...( showRows
 			? ( {
+					'--wp-grid-overlay-row-height': `${ rowHeight }px`,
 					'--wp-grid-overlay-row-tile': `${ rowHeight + gapPx }px`,
 			  } as React.CSSProperties )
 			: {} ),

--- a/packages/grid/src/shared/grid-overlay.tsx
+++ b/packages/grid/src/shared/grid-overlay.tsx
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * Internal dependencies
+ */
+import type { GridOverlayRenderProps } from './types';
+import styles from './grid-overlay.module.css';
+
+/**
+ * Default edit-mode overlay. Paints diagonal stripes behind the tiles
+ * to mark the dashboard surface, plus dashed outlines on each column
+ * track and (when `rowHeight` is supplied) repeating dividers for the
+ * row tracks.
+ *
+ * Used by both `DashboardGrid` and `DashboardLanes`. Replaced wholesale
+ * by passing a `renderGridOverlay` to either surface; themed in place
+ * via the CSS custom properties documented in the package README.
+ *
+ * @param props           Render props supplied by the surface.
+ * @param props.columns   Number of column tracks to mirror.
+ * @param props.gapPx     Gap between tracks in pixels.
+ * @param props.rowHeight Row height in pixels for surfaces with uniform
+ *                        rows. Omitted on lane surfaces or auto-sized
+ *                        grids; in that case row dividers are skipped.
+ */
+export function GridOverlay( {
+	columns,
+	gapPx,
+	rowHeight,
+}: GridOverlayRenderProps ) {
+	const showRows = typeof rowHeight === 'number';
+	// Custom properties drive the row-divider gradient so the CSS file
+	// stays static while the values come from the live grid.
+	const style: React.CSSProperties = {
+		gridTemplateColumns: `repeat(${ columns }, minmax(0, 1fr))`,
+		gap: `${ gapPx }px`,
+		...( showRows
+			? ( {
+					'--wp-grid-overlay-row-tile': `${ rowHeight + gapPx }px`,
+					'--wp-grid-overlay-row-line': `calc(${ rowHeight }px - 1px)`,
+					'--wp-grid-overlay-row-line-end': `${ rowHeight }px`,
+			  } as React.CSSProperties )
+			: {} ),
+	};
+
+	return (
+		<div
+			aria-hidden
+			className={ clsx(
+				styles.overlay,
+				showRows && styles[ 'has-rows' ]
+			) }
+			style={ style }
+		>
+			{ Array.from( { length: columns } ).map( ( _, i ) => (
+				<div key={ i } className={ styles.column } />
+			) ) }
+		</div>
+	);
+}

--- a/packages/grid/src/shared/types.ts
+++ b/packages/grid/src/shared/types.ts
@@ -82,6 +82,37 @@ export interface DragPreviewRenderProps {
 }
 
 /**
+ * Props received by a custom grid overlay component. The overlay
+ * paints behind the tiles in edit mode to visualize the column tracks
+ * and (when `rowHeight` is defined) the row tracks. Receives a
+ * snapshot of the surface's resolved layout parameters so the visual
+ * can reproduce the tracks pixel-accurately without re-deriving them.
+ *
+ * Reused by both `DashboardGrid` and `DashboardLanes`: lanes pass no
+ * `rowHeight` because heights are content-driven.
+ */
+export interface GridOverlayRenderProps {
+	/**
+	 * Number of column tracks in the active surface. In responsive
+	 * mode (`minColumnWidth`), this is the count derived from the
+	 * container width, not the prop value.
+	 */
+	columns: number;
+
+	/**
+	 * Gap between tracks in pixels (`spacing * 4`).
+	 */
+	gapPx: number;
+
+	/**
+	 * Row height in pixels for surfaces with uniform rows. Omitted on
+	 * surfaces with content-driven heights (lanes) or when row height
+	 * is `'auto'`; in those cases the overlay paints columns only.
+	 */
+	rowHeight?: number;
+}
+
+/**
  * Props for the internal `<ResizeHandle />` wrapper.
  */
 export interface ResizeHandleProps {

--- a/packages/grid/src/shared/types.ts
+++ b/packages/grid/src/shared/types.ts
@@ -110,6 +110,15 @@ export interface GridOverlayRenderProps {
 	 * is `'auto'`; in those cases the overlay paints columns only.
 	 */
 	rowHeight?: number;
+
+	/**
+	 * Whether the overlay should be visible. Surfaces render the
+	 * overlay even when `false` so the implementation can transition
+	 * opacity in and out; while `false`, the overlay must hide itself
+	 * (and ideally release paint cost via `visibility: hidden` or an
+	 * equivalent).
+	 */
+	isActive: boolean;
 }
 
 /**


### PR DESCRIPTION
## What?

- Adds a default edit-mode overlay rendered behind the tiles whenever `editMode` is on: diagonal stripes plus dashed column track outlines, repeating row dividers when `rowHeight` is numeric, and a subtle column fill to differentiate the drop zones from the gaps.
- Exposes a render-prop contract (`renderGridOverlay` + `GridOverlayRenderProps`) so consumers can replace the visual while reusing the surface's resolved column count, gap, and row height.
- Both `DashboardGrid` and `DashboardLanes` consume the same shared overlay.

## Why?

In edit mode the user needs visual feedback about where tiles can land. Without an overlay, empty cells look identical to the gaps between them and the underlying column structure stays invisible. Surfacing the column and row tracks behind the layout helps when first laying out tiles, resizing, or reorganizing, and the override path keeps the surface a primitive: consumers that want a different look (or no overlay at all) can ship their own.

## How?

- New `packages/grid/src/shared/grid-overlay.{tsx,module.css}` hosts the default overlay: a diagonal `repeating-linear-gradient` for the surface tinting, a sub-grid that mirrors the parent's column tracks (each cell takes a tinted `background-color` plus a dashed outline), and a `background-image` per cell that paints a 1px horizontal divider every `rowHeight + gap` pixels when row height is numeric.
- `GridOverlayRenderProps` lives in `packages/grid/src/shared/types.ts` with `{ columns, gapPx, rowHeight? }`. Lanes pass no `rowHeight` because heights are content-driven; grids with `rowHeight: 'auto'` map it to `undefined` for the same reason.
- Both surfaces destructure `renderGridOverlay`, pick `renderGridOverlay ?? GridOverlay`, and render it as the first child of the grid root (which gained `position: relative`) when `editMode` is on. Document order keeps the overlay behind the items without explicit `z-index`.
- The `EditMode` story drops its inline `GridVisualizer` (the package paints it now) and a new `Custom Grid Overlay` story shows the override path with column number labels and info-tone theming.
- The default look themes through CSS custom properties: `--wp-grid-overlay-stripe-color`, `--wp-grid-overlay-track-color`, `--wp-grid-overlay-column-fill`, plus the internal `--wp-grid-overlay-row-{tile,line,line-end}` driven by the component.

## Testing

- Storybook -> `Grid/DashboardGrid` -> `Edit Mode`: overlay shows warning-tone stripes, dashed columns, a 1px row divider at the bottom of each row, and a 10% warning fill on each column. Drag and resize still work; the overlay does not capture pointer events.
- Storybook -> `Grid/DashboardGrid` -> `Custom Grid Overlay`: the consumer-supplied `NumberedOverlay` replaces the default (info-tone stripes plus numbered columns). Confirms the override path.
- Storybook -> `Grid/DashboardGrid` -> `Default` / `Responsive` / `FillWidth` / `FullWidth` / `RowHeight`: no overlay rendered (those stories don't enable `editMode`); the grid root paints nothing extra.
- Storybook -> `Grid/DashboardLanes` -> `Edit Mode`: overlay paints columns only (no row dividers since heights are content-driven). Drag, resize, and responsive behavior unchanged.
- Storybook -> `Grid/DashboardLanes` -> `Default` / others: no overlay rendered.
- Tab-to-focus plus keyboard reorder still works while the overlay is visible.
- Toggle `editMode` from `false` to `true` in any story: overlay appears and disappears cleanly.


https://github.com/user-attachments/assets/1dbcdfa4-8dc6-49c0-93ea-6c256c50a9a1

