### PR TITLE
E2E: Remove slash from bad embed request mock

### DIFF
--- a/test/e2e/specs/editor/various/embedding.spec.js
+++ b/test/e2e/specs/editor/various/embedding.spec.js
@@ -87,7 +87,7 @@ test.describe( 'Embedding content', () => {
 			'https://twitter.com/notnownikki': MOCK_EMBED_RICH_SUCCESS_RESPONSE,
 			'https://twitter.com/wooyaygutenberg123454312':
 				MOCK_CANT_EMBED_RESPONSE,
-			'https://wordpress.org/gutenberg/handbook/':
+			'https://wordpress.org/gutenberg/handbook':
 				MOCK_BAD_WORDPRESS_RESPONSE,
 			'https://twitter.com/thatbunty': MOCK_BAD_EMBED_PROVIDER_RESPONSE,
 			'https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/':
@@ -117,7 +117,7 @@ test.describe( 'Embedding content', () => {
 		).toHaveValue( 'https://twitter.com/wooyaygutenberg123454312' );
 
 		await embedUtils.insertEmbed(
-			'https://wordpress.org/gutenberg/handbook/'
+			'https://wordpress.org/gutenberg/handbook'
 		);
 		await expect(
 			currentEmbedBlock.getByRole( 'textbox', { name: 'Embed URL' } ),


### PR DESCRIPTION
## What?
Closes #37503.

PR updates URL for bad response to avoid triggering trailing slash fail safe. Test expects embed to be bad, there's no need for extra steps.

Props to @jsnajdr for narrowing this down.

## Why?
Bad requests with trailing slash are retried without, which bypasses the request interception and sometime causes test to fail. See: https://github.com/WordPress/gutenberg/pull/78151#issuecomment-4429616899.

The trailing slash behavior is tested separately.

## Testing Instructions
CI checks should be green.