### PR TITLE
isFulfilled: don't change resolution state, call in resolveSelect (backport)

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -122,6 +122,29 @@ The `resolvers` option should be passed as an object where each key is the name 
 
 Resolvers, in combination with [thunks](https://github.com/WordPress/gutenberg/blob/trunk/docs/how-to-guides/thunks.md#thunks-can-be-async), can be used to implement asynchronous data flows for your store.
 
+##### Object-form resolvers
+
+A resolver can be defined as an object with a `fulfill` method and optional `isFulfilled` and `shouldInvalidate` methods:
+
+```js
+resolvers: {
+	getPage: {
+		fulfill: ( id ) => async ( { dispatch } ) => {
+			const data = await fetchPage( id );
+			dispatch( { type: 'RECEIVE_PAGE', id, data } );
+		},
+		isFulfilled: ( state, id ) => !! state.pages[ id ],
+		shouldInvalidate: ( action, id ) => action.type === 'INVALIDATE_PAGE' && action.id === id,
+	},
+},
+```
+
+A resolver can also be a plain function with `isFulfilled` or `shouldInvalidate` assigned as properties. It will be normalized into the `{ fulfill, isFulfilled, shouldInvalidate }` object form internally.
+
+**`isFulfilled( state, ...args )`** lets you override the `hasFinishedResolution` meta selector for a given set of args. Normally, a resolver is skipped only when the resolution metadata records that it has already run for those args. With `isFulfilled`, you can look at the actual store state and decide that the data is already there: for example because it was loaded by a different resolver or preloaded server-side. When `isFulfilled` returns `true`, the `fulfill` method is not called and no resolution metadata is written.
+
+**`shouldInvalidate( action, ...args )`** is called on every dispatched action for each set of args that has already been resolved. If it returns `true`, the resolution for those args is invalidated, causing the resolver to run again on the next selector call. This is useful for automatically re-fetching data when a related action signals that the cached result may be stale.
+
 #### `controls` (deprecated)
 
 To handle asynchronous data flows, it is recommended to use [thunks](https://github.com/WordPress/gutenberg/blob/trunk/docs/how-to-guides/thunks.md#thunks-can-be-async) instead of `controls`.

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -388,6 +388,7 @@ export default function createReduxStore( key, options ) {
 			// a promise that resolves when the resolution is finished.
 			const bindResolveSelector = mapResolveSelector(
 				store,
+				resolvers,
 				boundMetadataSelectors
 			);
 
@@ -552,11 +553,12 @@ function instantiateReduxStore( key, options, registry, thunkArgs ) {
  * Maps selectors to functions that return a resolution promise for them.
  *
  * @param {Object} store                  The redux store the selectors are bound to.
+ * @param {Object} resolvers              The normalized resolvers for the store.
  * @param {Object} boundMetadataSelectors The bound metadata selectors.
  *
  * @return {Function} Function that maps selectors to resolvers.
  */
-function mapResolveSelector( store, boundMetadataSelectors ) {
+function mapResolveSelector( store, resolvers, boundMetadataSelectors ) {
 	return ( selector, selectorName ) => {
 		// If the selector doesn't have a resolver, just convert the return value
 		// (including exceptions) to a Promise, no additional extra behavior is needed.
@@ -566,10 +568,15 @@ function mapResolveSelector( store, boundMetadataSelectors ) {
 
 		return ( ...args ) =>
 			new Promise( ( resolve, reject ) => {
+				const resolver = resolvers[ selectorName ];
 				const hasFinished = () => {
-					return boundMetadataSelectors.hasFinishedResolution(
-						selectorName,
-						args
+					return (
+						boundMetadataSelectors.hasFinishedResolution(
+							selectorName,
+							args
+						) ||
+						( typeof resolver.isFulfilled === 'function' &&
+							resolver.isFulfilled( store.getState(), ...args ) )
 					);
 				};
 				const finalize = ( result ) => {
@@ -702,7 +709,9 @@ function mapSelectorWithResolver(
 	function fulfillSelector( args ) {
 		if (
 			resolversCache.isRunning( selectorName, args ) ||
-			boundMetadataSelectors.hasStartedResolution( selectorName, args )
+			boundMetadataSelectors.hasStartedResolution( selectorName, args ) ||
+			( typeof resolver.isFulfilled === 'function' &&
+				resolver.isFulfilled( store.getState(), ...args ) )
 		) {
 			return;
 		}
@@ -715,14 +724,9 @@ function mapSelectorWithResolver(
 				metadataActions.startResolution( selectorName, args )
 			);
 			try {
-				const isFulfilled =
-					typeof resolver.isFulfilled === 'function' &&
-					resolver.isFulfilled( store.getState(), ...args );
-				if ( ! isFulfilled ) {
-					const action = resolver.fulfill( ...args );
-					if ( action ) {
-						await store.dispatch( action );
-					}
+				const action = resolver.fulfill( ...args );
+				if ( action ) {
+					await store.dispatch( action );
 				}
 				store.dispatch(
 					metadataActions.finishResolution( selectorName, args )

--- a/packages/data/src/redux-store/test/index.js
+++ b/packages/data/src/redux-store/test/index.js
@@ -306,8 +306,7 @@ describe( 'resolveSelect', () => {
 			},
 		} );
 
-		const promise = registry.resolveSelect( 'demo' ).getItems();
-		const result = await promise;
+		const result = await registry.resolveSelect( 'demo' ).getItems();
 		expect( result ).toEqual( [ 'item' ] );
 	} );
 
@@ -332,15 +331,13 @@ describe( 'resolveSelect', () => {
 			},
 		} );
 
-		const promise1 = registry.resolveSelect( 'demo' ).getPage( 1 );
-		const result1 = await promise1;
+		const result1 = await registry.resolveSelect( 'demo' ).getPage( 1 );
 		expect( result1 ).toEqual( {
 			title: 'Page 1',
 			content: 'Content 1',
 		} );
 
-		const promise2 = registry.resolveSelect( 'demo' ).getPage( 2 );
-		const result2 = await promise2;
+		const result2 = await registry.resolveSelect( 'demo' ).getPage( 2 );
 		expect( result2 ).toEqual( {
 			title: 'Page 2',
 			content: 'Content 2',
@@ -348,6 +345,35 @@ describe( 'resolveSelect', () => {
 
 		// Resolver should not be called since isFulfilled returns truthy
 		expect( fulfilledResolver ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not change Redux state when isFulfilled returns true', async () => {
+		const fulfill = jest.fn();
+		const isFulfilled = () => true;
+
+		registry.registerStore( 'demo', {
+			reducer: ( state = { items: [ 'item' ] } ) => state,
+			selectors: {
+				getItems: ( state ) => state.items,
+			},
+			resolvers: {
+				getItems: { fulfill, isFulfilled },
+			},
+		} );
+
+		const listener = jest.fn();
+		const unsubscribe = registry.subscribe( listener );
+
+		// Call the selector — isFulfilled is true, so no resolution should happen.
+		registry.select( 'demo' ).getItems();
+
+		// Wait long enough for any setTimeout(0) resolver to have fired.
+		await new Promise( ( resolve ) => setTimeout( resolve, 10 ) );
+
+		expect( fulfill ).not.toHaveBeenCalled();
+		expect( listener ).not.toHaveBeenCalled();
+
+		unsubscribe();
 	} );
 
 	it( 'calls resolver when isFulfilled returns false', async () => {
@@ -372,55 +398,17 @@ describe( 'resolveSelect', () => {
 			},
 		} );
 
-		const promise = registry.resolveSelect( 'demo' ).getData();
-		const result = await promise;
+		const result = await registry.resolveSelect( 'demo' ).getData();
 
 		// Initial state has hasData: false, so resolver should be called
-		expect( isFulfilled ).toHaveBeenCalledTimes( 1 );
 		expect( fulfill ).toHaveBeenCalledTimes( 1 );
 		expect( result ).toBe( 'resolved data' );
 
-		// Subsequent call should use cached result, not calling isFulfilled or fulfill again
-		const promise2 = registry.resolveSelect( 'demo' ).getData();
-		const result2 = await promise2;
+		// Subsequent call should use cached result, not calling `fulfill` again
+		const result2 = await registry.resolveSelect( 'demo' ).getData();
 		expect( result2 ).toBe( 'resolved data' );
-		// isFulfilled is only called once since resolution is already marked as finished
-		expect( isFulfilled ).toHaveBeenCalledTimes( 1 );
-		expect( fulfill ).toHaveBeenCalledTimes( 1 ); // Still only called once
-	} );
-
-	it( 'marks resolution as failed when isFulfilled throws an error', async () => {
-		const fulfill = jest.fn().mockImplementation( () => ( {
-			type: 'SET_DATA',
-			data: 'resolved data',
-		} ) );
-		const isFulfilled = jest.fn( () => {
-			throw new Error( 'isFulfilled error' );
-		} );
-
-		registry.registerStore( 'demo', {
-			reducer: ( state = { hasData: false }, action ) => {
-				if ( action.type === 'SET_DATA' ) {
-					return { hasData: true, data: action.data };
-				}
-				return state;
-			},
-			selectors: {
-				getData: ( state ) => state.data,
-			},
-			resolvers: {
-				getData: { fulfill, isFulfilled },
-			},
-		} );
-
-		const promise = registry.resolveSelect( 'demo' ).getData();
-		await expect( promise ).rejects.toThrow( 'isFulfilled error' );
-
-		expect( isFulfilled ).toHaveBeenCalledTimes( 1 );
-		expect( fulfill ).not.toHaveBeenCalled();
-		expect(
-			registry.select( 'demo' ).hasResolutionFailed( 'getData' )
-		).toBe( true );
+		// `fulfill` is only called once since resolution is already marked as finished
+		expect( fulfill ).toHaveBeenCalledTimes( 1 );
 	} );
 } );
 


### PR DESCRIPTION
Backport of #78151 to 7.0. I had to do it manually, because in `trunk` the `redux-store` folder has been migrated to TypeScript, while `wp/7.0` is still JavaScript, which leads to obvious conflicts.
