### PR TITLE
Dashboard: use design animation tokens

### DIFF
--- a/routes/dashboard/widget-dashboard/components/actions/actions.module.css
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.module.css
@@ -12,11 +12,11 @@
 	}
 
 	.editActionsEnter {
-		animation: actions-slide-in 220ms ease-out forwards;
+		animation: actions-slide-in var(--wpds-motion-duration-md) var(--wpds-motion-easing-expressive) forwards;
 	}
 
 	.editActionsExit {
-		animation: actions-fold-out 50ms ease-in forwards;
+		animation: actions-fold-out var(--wpds-motion-duration-xs) var(--wpds-motion-easing-subtle) forwards;
 	}
 
 	@keyframes actions-slide-in {

--- a/routes/dashboard/widget-dashboard/components/actions/actions.module.css
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.module.css
@@ -16,7 +16,7 @@
 	}
 
 	.editActionsExit {
-		animation: actions-fold-out var(--wpds-motion-duration-xs) var(--wpds-motion-easing-subtle) forwards;
+		animation: actions-fold-out var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced) forwards;
 	}
 
 	@keyframes actions-slide-in {

--- a/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
@@ -39,6 +39,6 @@
 
 @media not ( prefers-reduced-motion ) {
 	.tile {
-		transition: box-shadow 180ms ease;
+		transition: box-shadow var(--wpds-motion-duration-md) var(--wpds-motion-easing-subtle);
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Uses newly added (https://github.com/WordPress/gutenberg/pull/76097) design tokens for animation in dashboard.




<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Design consistency across WP.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before


https://github.com/user-attachments/assets/10578ff9-98bc-4564-9279-5ad37108b8f8



### After

https://github.com/user-attachments/assets/b47b37c7-17ee-464e-bc48-6b400f814ef1


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
