### PR TITLE
Revisions: don't render phantom "modified" entries in block diff

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/block-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/block-diff.js
@@ -45,6 +45,61 @@ function stringifyValue( value ) {
 }
 
 /**
+ * Deterministic JSON.stringify: recursively sorts object keys so that two
+ * objects with the same attributes serialize identically regardless of the
+ * order their keys were inserted in.
+ *
+ * Used for block-signature comparison and attrs-equality checks below.
+ * `@wordpress/block-serialization-default-parser` preserves whatever key
+ * order the source block-comment JSON used, so the same logical block can
+ * round-trip to two different `JSON.stringify` outputs (e.g. after a
+ * programmatic re-serialization), which produced phantom "removed + added"
+ * pairs and no-op "modified" entries.
+ *
+ * @param {*} value The value to stringify.
+ * @return {string} The stringified value with object keys in sorted order.
+ */
+function canonicalStringify( value ) {
+	if ( value === null || typeof value !== 'object' ) {
+		return JSON.stringify( value ) ?? 'null';
+	}
+	if ( Array.isArray( value ) ) {
+		return '[' + value.map( canonicalStringify ).join( ',' ) + ']';
+	}
+	const keys = Object.keys( value )
+		.filter( ( k ) => value[ k ] !== undefined )
+		.sort();
+	return (
+		'{' +
+		keys
+			.map(
+				( k ) =>
+					JSON.stringify( k ) + ':' + canonicalStringify( value[ k ] )
+			)
+			.join( ',' ) +
+		'}'
+	);
+}
+
+/**
+ * Block's own structural content fragments (between/around its inner blocks),
+ * normalized for comparison: null entries dropped, each remaining segment
+ * trimmed, then empty results dropped. Used for the position-swap escape
+ * hatch in `pairSimilarBlocks` so that purely-cosmetic whitespace
+ * differences in `innerContent` don't cause genuinely-equal blocks to be
+ * paired as a no-op "modified" entry.
+ *
+ * @param {Object} block Raw block.
+ * @return {string[]} Trimmed non-empty content fragments.
+ */
+function normalizedInnerContent( block ) {
+	return ( block.innerContent || [] )
+		.filter( ( c ) => c !== null )
+		.map( ( c ) => c.trim() )
+		.filter( ( c ) => c !== '' );
+}
+
+/**
  * Calculate text similarity using word-set overlap.
  *
  * Uses a variant of the Jaccard index (https://en.wikipedia.org/wiki/Jaccard_index)
@@ -188,13 +243,19 @@ function pairSimilarBlocks( blocks ) {
 		// pair them directly — no ambiguity, no similarity check needed.
 		if ( sameNameRemoved.length === 1 && unpaired.length === 1 ) {
 			const add = unpaired[ 0 ];
+			// canonicalStringify (sorted-key) and normalizedInnerContent
+			// (trimmed) so that the position-swap escape hatch fires for
+			// genuinely-equal blocks even when their attrs were
+			// re-serialized in a different key order or their innerHTML
+			// picked up cosmetic whitespace.
 			const attrsMatch =
-				JSON.stringify( rem.block.attrs ) ===
-				JSON.stringify( add.block.attrs );
+				canonicalStringify( rem.block.attrs ) ===
+				canonicalStringify( add.block.attrs );
 			// Only skip pairing if both content and attrs are identical
 			// (position swap, not a modification).
 			const contentMatch =
-				( rem.block.innerHTML || '' ) === ( add.block.innerHTML || '' );
+				canonicalStringify( normalizedInnerContent( rem.block ) ) ===
+				canonicalStringify( normalizedInnerContent( add.block ) );
 			if ( ! contentMatch || ! attrsMatch ) {
 				bestMatch = add;
 			}
@@ -210,8 +271,8 @@ function pairSimilarBlocks( blocks ) {
 				// are position swaps, not modifications. They should show
 				// as separate removed + added, not as a no-op "modified".
 				const attrsMatch =
-					JSON.stringify( rem.block.attrs ) ===
-					JSON.stringify( add.block.attrs );
+					canonicalStringify( rem.block.attrs ) ===
+					canonicalStringify( add.block.attrs );
 				if (
 					score > bestScore &&
 					score > SIMILARITY_THRESHOLD &&
@@ -293,14 +354,14 @@ function pairSimilarBlocks( blocks ) {
  */
 function diffRawBlocks( currentRaw, previousRaw ) {
 	const createBlockSignature = ( rawBlock ) =>
-		JSON.stringify( {
+		// canonicalStringify (sorted keys) + normalizedInnerContent so that
+		// identical blocks with re-ordered attrs or whitespace-only innerHTML
+		// differences collapse to the same signature and are matched as
+		// unchanged by the LCS — not as a phantom removed + added pair.
+		canonicalStringify( {
 			name: rawBlock.blockName,
 			attrs: rawBlock.attrs,
-			// Use innerContent filtered to non-null and non-whitespace-only strings.
-			// This excludes whitespace between inner blocks which changes based on count.
-			html: ( rawBlock.innerContent || [] ).filter(
-				( c ) => c !== null && c.trim() !== ''
-			),
+			html: normalizedInnerContent( rawBlock ),
 		} );
 	const currentSigs = currentRaw.map( createBlockSignature );
 	const previousSigs = previousRaw.map( createBlockSignature );

--- a/packages/editor/src/components/post-revisions-preview/test/block-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/test/block-diff.js
@@ -368,6 +368,95 @@ describe( 'diffRevisionContent', () => {
 		] );
 	} );
 
+	it( 'treats identical attrs with different key order as unchanged', () => {
+		// `@wordpress/block-serialization-default-parser` preserves whatever
+		// key order the source block-comment JSON used. Two semantically
+		// identical blocks can therefore round-trip to two different
+		// JSON.stringify outputs — they must still be detected as unchanged.
+		const previous =
+			'<!-- wp:paragraph {"align":"center","textColor":"primary"} -->\n' +
+			'<p class="has-text-align-center has-primary-color has-text-color">Hello</p>\n' +
+			'<!-- /wp:paragraph -->';
+		const current =
+			'<!-- wp:paragraph {"textColor":"primary","align":"center"} -->\n' +
+			'<p class="has-text-align-center has-primary-color has-text-color">Hello</p>\n' +
+			'<!-- /wp:paragraph -->';
+		const blocks = diffRevisionContent( current, previous );
+
+		expect( normalizeBlockTree( blocks ) ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					__revisionDiffStatus: undefined,
+				},
+			},
+		] );
+	} );
+
+	it( 'treats trailing-whitespace-only innerHTML differences as unchanged', () => {
+		// Trailing whitespace inside a block comment is structurally
+		// invisible — the rendered output is the same, so the block must
+		// not show up as a no-op "modified" entry.
+		const previous =
+			'<!-- wp:paragraph {"align":"center"} -->\n' +
+			'<p class="has-text-align-center">Hello</p>\n' +
+			'<!-- /wp:paragraph -->';
+		const current =
+			'<!-- wp:paragraph {"align":"center"} -->\n' +
+			'<p class="has-text-align-center">Hello</p>  \n' +
+			'<!-- /wp:paragraph -->';
+		const blocks = diffRevisionContent( current, previous );
+
+		expect( normalizeBlockTree( blocks ) ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					__revisionDiffStatus: undefined,
+				},
+			},
+		] );
+	} );
+
+	it( 'does not drag a neighbour with a key-order swap into a real change', () => {
+		// One real change (className flip) next to one cosmetic-only
+		// difference (attr key reorder). Only the real change should be
+		// reported as modified — the neighbour must remain unchanged.
+		const previous =
+			'<!-- wp:paragraph {"className":"has-large-padding-top"} -->\n' +
+			'<p class="has-large-padding-top">First</p>\n' +
+			'<!-- /wp:paragraph -->\n\n' +
+			'<!-- wp:paragraph {"align":"center","textColor":"primary"} -->\n' +
+			'<p class="has-text-align-center has-primary-color has-text-color">Second</p>\n' +
+			'<!-- /wp:paragraph -->';
+		const current =
+			'<!-- wp:paragraph {"className":"has-medium-padding-top"} -->\n' +
+			'<p class="has-medium-padding-top">First</p>\n' +
+			'<!-- /wp:paragraph -->\n\n' +
+			'<!-- wp:paragraph {"textColor":"primary","align":"center"} -->\n' +
+			'<p class="has-text-align-center has-primary-color has-text-color">Second</p>\n' +
+			'<!-- /wp:paragraph -->';
+		const blocks = diffRevisionContent( current, previous );
+
+		// Only the first paragraph (real className change) is modified.
+		// The second paragraph (cosmetic key reorder) stays unchanged.
+		expect( normalizeBlockTree( blocks ) ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					__revisionDiffStatus: {
+						status: 'modified',
+					},
+				},
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					__revisionDiffStatus: undefined,
+				},
+			},
+		] );
+	} );
+
 	it( 'pairs blocks as modified when attrs differ but content is identical', () => {
 		const previous = serialize( [
 			createBlock( 'core/paragraph', { content: 'Same content' } ),


### PR DESCRIPTION
## What?

Fixes false-positive `Modified` entries in the in-editor post revisions diff. When two semantically-identical blocks differ only in attribute key order (or in trailing whitespace inside `innerHTML`), they are currently shown as `Modified` in the revisions preview but with no rich-text or attribute diff to display.

## Why?

`pairSimilarBlocks` has a position-swap escape hatch: when one block is removed and one is added with the same `blockName`, the pair is only promoted to `modified` if the attrs or `innerHTML` actually differ. Identical pairs stay as separate `removed` + `added` (the position-swap case).

The escape hatch compares attrs with raw `JSON.stringify` and content with raw `innerHTML` string equality. Both are brittle:

- `JSON.stringify` is sensitive to attribute key insertion order. `@wordpress/block-serialization-default-parser` preserves whatever order the source block-comment JSON used, so two semantically identical blocks can serialize to two different signatures.
- Raw `innerHTML` is whitespace-sensitive. A trailing newline added by a save round-trip breaks equality.

When either triggers, the pair gets paired as `modified` with no actual semantic change. Downstream rendering then shows a `Modified` decoration on a block whose diff is empty.

The same comparison runs in two places: `pairSimilarBlocks`' direct-pair branch (and its multi-candidate fallback) and `createBlockSignature` inside `diffRawBlocks` (which decides which pairs even reach `pairSimilarBlocks` in the first place).

## How?

- Add a small `canonicalStringify` helper that recursively sorts object keys.
- Add a small `normalizedInnerContent` helper that drops nulls, trims each remaining segment, and drops empty results.
- Use them at all three call sites: `createBlockSignature` (LCS bucketing) and both `attrsMatch` checks in `pairSimilarBlocks`.

Identical-but-reorganized blocks now collapse to `unchanged` in LCS, and the position-swap escape hatch fires correctly for genuinely-equal pairs.

No new dependencies — both helpers are a few lines each, in the spirit of `stringifyValue` and `textSimilarity` already in this file.

## Testing Instructions

1. Open a post with at least two paragraph blocks.
2. Save it.
3. From a script or the REST API, save a new revision where the block-comment JSON has the same attrs in a different key order (e.g. swap `{"align":"center","textColor":"primary"}` ↔ `{"textColor":"primary","align":"center"}`).
4. Open the revisions view and step from the prior revision to the new one.
5. Before this PR: the paragraph shows a `Modified` decoration with no diff body.
6. After this PR: the paragraph is unchanged.
7. Repeat with a trailing newline added to `innerHTML` instead of a key reorder — same expectation.

### Unit tests

```
npm run test:unit -- --testPathPattern="post-revisions-preview/test/block-diff"
```

Adds three new cases (all under the existing `describe( 'diffRevisionContent', ... )` block):

- `treats identical attrs with different key order as unchanged`
- `treats trailing-whitespace-only innerHTML differences as unchanged`
- `does not drag a neighbour with a key-order swap into a real change`

All 33 existing tests plus the 3 new ones pass.

## Types of changes

Bug fix (non-breaking).

## Checklist

- [x] My code is tested.
- [x] My code follows the WordPress Coding Standards.
- [x] My code has proper inline documentation.
