### PR TITLE
Build: Remove custom job_status output in favor of native result

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -194,9 +194,6 @@ jobs:
             matrix:
                 IS_GUTENBERG_PLUGIN: [true, false]
 
-        outputs:
-            job_status: ${{ job.status }}
-
         steps:
             - name: Checkout code
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -261,7 +258,7 @@ jobs:
             packages: write
         if: |
             always() &&
-            needs.build.outputs.job_status == 'success' &&
+            needs.build.result == 'success' &&
             github.repository == 'WordPress/gutenberg' &&
             github.event_name == 'push'
 
@@ -312,7 +309,7 @@ jobs:
             contents: write
         if: |
             always() &&
-            ( needs.build.outputs.job_status == 'failure' ) &&
+            needs.build.result == 'failure' &&
             needs.bump-version.outputs.release_branch_commit
 
         steps:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> #78203

<!-- In a few words, what is the PR actually doing? -->
Removes the custom `job_status` output from the build job in `build-plugin-zip.yml` and updates downstream jobs to use the native `needs.<job_id>.result` context instead.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Redefining the job status as a custom output is redundant and an anti-pattern that could lead to insecure configurations. GitHub Actions natively provides this context via `needs.<job_id>.result`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. Removed `outputs: job_status: ${{ job.status }}` from the build job.
2. Updated the `publish-to-container-registry` job's `if` condition to check `needs.build.result == 'success'`.
3. Updated the `revert-version-bump` job's `if` condition to `check needs.build.result == 'failure'`.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Tool used: Antigravity
Model(s): Gemini 3.1 Pro
Usage: Gemini refactored the workflow to use the native result, I manually reviewed the changes.