### PR TITLE
Templates: Always use i18n title and description for default template types

### DIFF
--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-templates-controller-7-0.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-templates-controller-7-0.php
@@ -171,6 +171,27 @@ class Gutenberg_REST_Templates_Controller_7_0 extends WP_REST_Templates_Controll
 		// Restores the more descriptive, specific name for use within this method.
 		$template = $item;
 
+		//////////////////////////////
+		// START CORE MODIFICATIONS //
+		//////////////////////////////
+		/*
+		 * For default template types, always use the i18n title and description
+		 * from get_default_block_template_types() rather than what may be stored
+		 * in the database. This ensures correct translations when the site language
+		 * or user language changes after a template has been edited and saved.
+		 * See: https://github.com/WordPress/gutenberg/issues/69261
+		 */
+		if ( 'wp_template' === $template->type ) {
+			$default_template_types = get_default_block_template_types();
+			if ( isset( $default_template_types[ $template->slug ] ) ) {
+				$template->title       = $default_template_types[ $template->slug ]['title'];
+				$template->description = $default_template_types[ $template->slug ]['description'];
+			}
+		}
+		//////////////////////////////
+		// END CORE MODIFICATIONS   //
+		//////////////////////////////
+
 		$fields = $this->get_fields_for_response( $request );
 
 		// Base fields for every template.


### PR DESCRIPTION
## What?

For default template types (e.g. 404 Page, Front Page, Single Posts), always return the title and description from  get_default_block_template_types()` in the REST API response, rather than any values stored in the database.
Closes #69261.

## Why?

When a template is edited in the Site Editor, WordPress saves a copy of it in the database including the title and description translated into the language active at the time of the edit.

If the site or user language is later changed, the stored translations are shown instead of the correct current-language strings. This leads to a mixed-language UI (e.g. template titles in English on a Spanish site).

## How?

In `Gutenberg_REST_Templates_Controller_7_0::prepare_item_for_response`, after the template object is resolved, check whether the template's slug matches a key in `get_default_block_template_types()`. If it does, override the template's
`title` and `description` with the values from that function, which are always translated for the current locale.

This is the minimal targeted fix: it applies only to `wp_template` items whose slugs match a default type (not custom templates, not template parts), and only at REST API response time.

## Testing Instructions

1. Start a new WordPress site in English.
2. Edit any default template (e.g. 404 Page) in the Site Editor and save it.
3. Change the site language to Spanish (or any other language) at    `/wp-admin/options-general.php`.
4. Go back to the Site Editor templates list.
5. Confirm the edited template now shows its title and description in Spanish, matching the other (unedited) templates.
   

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:


https://github.com/user-attachments/assets/1b90587f-630f-435b-8bcf-ef10a73c7cab



After:

https://github.com/user-attachments/assets/04a26204-3190-4929-bc6c-c9b8b64e2103


