### PR TITLE
Media Fields: Ensure pleasing wrap for datetime strings in the date_added and date_modified fields

### DIFF
--- a/packages/media-fields/src/date_added/index.tsx
+++ b/packages/media-fields/src/date_added/index.tsx
@@ -9,11 +9,13 @@ import type { Field } from '@wordpress/dataviews';
  * Internal dependencies
  */
 import type { MediaItem } from '../types';
+import DateView from '../utils/date-view';
 
 const dateAddedField: Partial< Field< MediaItem > > = {
 	id: 'date',
 	type: 'datetime',
 	label: __( 'Date added' ),
+	render: DateView,
 	filterBy: {
 		operators: [ 'before', 'after' ],
 	},

--- a/packages/media-fields/src/date_modified/index.tsx
+++ b/packages/media-fields/src/date_modified/index.tsx
@@ -9,11 +9,13 @@ import type { Field } from '@wordpress/dataviews';
  * Internal dependencies
  */
 import type { MediaItem } from '../types';
+import DateView from '../utils/date-view';
 
 const dateModifiedField: Partial< Field< MediaItem > > = {
 	id: 'modified',
 	type: 'datetime',
 	label: __( 'Date modified' ),
+	render: DateView,
 	filterBy: {
 		operators: [ 'before', 'after' ],
 	},

--- a/packages/media-fields/src/utils/date-view.tsx
+++ b/packages/media-fields/src/utils/date-view.tsx
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { dateI18n, getDate, getSettings } from '@wordpress/date';
+import type { NormalizedField } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { MediaItem } from '../types';
+
+const NBSP = ' ';
+
+const DateView = ( {
+	item,
+	field,
+}: {
+	item: MediaItem;
+	field: NormalizedField< MediaItem >;
+} ) => {
+	const value = field.getValue( { item } ) as string | null | undefined;
+	if ( ! value ) {
+		return null;
+	}
+	// Keep the meridiem ("am"/"pm") tied to the time so it can't orphan
+	// onto a second line in narrow layouts like the media-editor sidebar.
+	const formatted = dateI18n(
+		getSettings().formats.datetimeAbbreviated,
+		getDate( value )
+	).replace( / (am|pm)$/i, `${ NBSP }$1` );
+	return <time dateTime={ value }>{ formatted }</time>;
+};
+
+export default DateView;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of:

* https://github.com/WordPress/gutenberg/issues/73771

Polish the displayed appearance of the Date added and Date modified media fields.

🚧 🚧 🚧 This is a first pass, I'm still playing around with ideas, not yet ready for review 🚧 🚧 🚧 

## Why?

Often a single `am` will wrap to a second line in the Media Editor Modal experiment's sidebar. I'd like to polish these fields so they're always looking clean.

## How?

Right now we're forcing the time and meridiem to be on one line. But I might see if in this context we can display the field as just the date, and have the time be available on hover... that might be more expected for media 🤔

## Testing Instructions

* Enable the Media Editor Modal experiment
* Add an image to a post or page, and click on the crop icon in the block toolbar to open the modal
* Go to the Details tab and take a look at how the date added field displays

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="1200" height="693" alt="image" src="https://github.com/user-attachments/assets/48f432b0-5d53-4fc4-96bd-129196b6d3f1" />

### After

<img width="1200" height="738" alt="image" src="https://github.com/user-attachments/assets/e53d8c4c-2ae9-4c4e-a22e-3b4e00b85fd8" />

## Use of AI Tools

Claude Code