### PR TITLE
Fix: Duotone handle block style variations

### DIFF
--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -895,11 +895,21 @@ class WP_Duotone_Gutenberg {
 
 		$global_styles_block_names = self::get_all_global_style_block_names();
 
-		// The block should have a duotone attribute or have duotone defined in its theme.json to be processed.
+		// Check for block style variation with duotone.
+		$class_name        = $block['attrs']['className'] ?? '';
+		$variation_duotone = null;
+		if ( preg_match( '/is-style-([\w-]+)/', $class_name, $matches ) ) {
+			$variation_name    = $matches[1];
+			$tree              = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+			$raw_json          = $tree->get_raw_data();
+			$variation_duotone = _wp_array_get( $raw_json, array( 'styles', 'blocks', $block['blockName'], 'variations', $variation_name, 'filter', 'duotone' ), null );
+		}
+
+		// The block should have a duotone attribute, variation duotone, or have duotone defined in its theme.json to be processed.
 		$has_duotone_attribute     = isset( $block['attrs']['style']['color']['duotone'] );
 		$has_global_styles_duotone = array_key_exists( $block['blockName'], $global_styles_block_names );
 
-		if ( ! $has_duotone_attribute && ! $has_global_styles_duotone ) {
+		if ( ! $has_duotone_attribute && ! $variation_duotone && ! $has_global_styles_duotone ) {
 			return $block_content;
 		}
 
@@ -908,7 +918,7 @@ class WP_Duotone_Gutenberg {
 
 			// Possible values for duotone attribute:
 			// 1. Array of colors - e.g. array('#000000', '#ffffff').
-			// 2. Variable for an existing Duotone preset - e.g. 'var:preset|duotone|blue-orange' or 'var(--wp--preset--duotone--blue-orange)''
+			// 2. Variable for an existing Duotone preset - e.g. 'var:preset|duotone|blue-orange' or 'var(--wp--preset--duotone--blue-orange)'.
 			// 3. A CSS string - e.g. 'unset' to remove globally applied duotone.
 
 			$duotone_attr = $block['attrs']['style']['color']['duotone'];
@@ -943,6 +953,13 @@ class WP_Duotone_Gutenberg {
 				// SVG filter and block CSS.
 				self::enqueue_custom_filter( $filter_id, $duotone_selector, $filter_value, $filter_data );
 			}
+		} elseif ( $variation_duotone && self::is_preset( $variation_duotone ) ) {
+			// Variation duotone takes precedence over global block duotone.
+			$slug         = self::get_slug_from_attribute( $variation_duotone );
+			$filter_id    = self::get_filter_id( $slug );
+			$filter_value = self::get_css_var( $slug );
+
+			self::enqueue_global_styles_preset( $filter_id, $duotone_selector, $filter_value );
 		} elseif ( $has_global_styles_duotone ) {
 			$slug         = $global_styles_block_names[ $block['blockName'] ]; // e.g. 'blue-orange'.
 			$filter_id    = self::get_filter_id( $slug ); // e.g. 'wp-duotone-filter-blue-orange'.

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -855,6 +855,24 @@ class WP_Duotone_Gutenberg {
 			if ( $slug && $slug !== $duotone_attr ) {
 				self::$global_styles_block_names[ $block_node['name'] ] = $slug;
 			}
+
+			// Collect block style variation duotones from theme.json.
+			$block_variations = _wp_array_get( $theme_json, array_merge( $block_node['path'], array( 'variations' ) ), array() );
+			if ( ! empty( $block_variations ) ) {
+				foreach ( $block_variations as $variation_name => $variation_data ) {
+					$variation_duotone = _wp_array_get( $variation_data, array( 'filter', 'duotone' ), null );
+
+					if ( empty( $variation_duotone ) || ! is_string( $variation_duotone ) || ! self::is_preset( $variation_duotone ) ) {
+						continue;
+					}
+
+					$variation_slug = self::get_slug_from_attribute( $variation_duotone );
+
+					if ( $variation_slug && $variation_slug !== $variation_duotone ) {
+						self::$global_styles_block_names[ $block_node['name'] . ':' . $variation_name ] = $variation_slug;
+					}
+				}
+			}
 		}
 
 		return self::$global_styles_block_names;
@@ -896,20 +914,22 @@ class WP_Duotone_Gutenberg {
 		$global_styles_block_names = self::get_all_global_style_block_names();
 
 		// Check for block style variation with duotone.
-		$class_name        = $block['attrs']['className'] ?? '';
-		$variation_duotone = null;
-		if ( preg_match( '/is-style-([\w-]+)/', $class_name, $matches ) ) {
-			$variation_name    = $matches[1];
-			$tree              = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
-			$raw_json          = $tree->get_raw_data();
-			$variation_duotone = _wp_array_get( $raw_json, array( 'styles', 'blocks', $block['blockName'], 'variations', $variation_name, 'filter', 'duotone' ), null );
+		$class_name             = $block['attrs']['className'] ?? '';
+		$variation_key          = null;
+		$variation_filter_value = null;
+		if ( ! empty( $class_name ) && str_contains( $class_name, 'is-style-' ) && preg_match( '/(?:^|\s)is-style-([\w-]+)(?:\s|$)/', $class_name, $matches ) ) {
+			$variation_name = $matches[1];
+			$variation_key  = $block['blockName'] . ':' . $variation_name;
+			if ( isset( $global_styles_block_names[ $variation_key ] ) ) {
+				$variation_filter_value = self::get_css_var( $global_styles_block_names[ $variation_key ] );
+			}
 		}
 
 		// The block should have a duotone attribute, variation duotone, or have duotone defined in its theme.json to be processed.
 		$has_duotone_attribute     = isset( $block['attrs']['style']['color']['duotone'] );
 		$has_global_styles_duotone = array_key_exists( $block['blockName'], $global_styles_block_names );
 
-		if ( ! $has_duotone_attribute && ! $variation_duotone && ! $has_global_styles_duotone ) {
+		if ( ! $has_duotone_attribute && ! $variation_filter_value && ! $has_global_styles_duotone ) {
 			return $block_content;
 		}
 
@@ -953,11 +973,11 @@ class WP_Duotone_Gutenberg {
 				// SVG filter and block CSS.
 				self::enqueue_custom_filter( $filter_id, $duotone_selector, $filter_value, $filter_data );
 			}
-		} elseif ( $variation_duotone && self::is_preset( $variation_duotone ) ) {
+		} elseif ( $variation_filter_value ) {
 			// Variation duotone takes precedence over global block duotone.
-			$slug         = self::get_slug_from_attribute( $variation_duotone );
+			$slug         = $global_styles_block_names[ $variation_key ];
 			$filter_id    = self::get_filter_id( $slug );
-			$filter_value = self::get_css_var( $slug );
+			$filter_value = $variation_filter_value;
 
 			self::enqueue_global_styles_preset( $filter_id, $duotone_selector, $filter_value );
 		} elseif ( $has_global_styles_duotone ) {

--- a/phpunit/class-wp-duotone-test.php
+++ b/phpunit/class-wp-duotone-test.php
@@ -48,6 +48,110 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertMatchesRegularExpression( $expected, WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block, $wp_block ) );
 	}
 
+	/**
+	 * Tests whether a duotone filter applied to a block style variation in global styles
+	 * is correctly rendered on the front end.
+	 *
+	 * @covers ::render_duotone_support
+	 */
+	public function test_gutenberg_render_duotone_support_block_style_variation() {
+		$block         = array(
+			'blockName' => 'core/image',
+			'attrs'     => array(
+				'className' => 'is-style-rounded',
+			),
+		);
+		$wp_block      = new WP_Block( $block );
+		$block_content = '<figure class="wp-block-image size-full is-style-rounded"><img src="/my-image.jpg" /></figure>';
+
+		$wp_duotone = new WP_Duotone_Gutenberg();
+
+		$global_styles_block_names_property = new ReflectionProperty( 'WP_Duotone_Gutenberg', 'global_styles_block_names' );
+		$global_styles_block_names_property->setAccessible( true );
+		$previous_block_names = $global_styles_block_names_property->getValue();
+		$global_styles_block_names_property->setValue( $wp_duotone, array( 'core/image:rounded' => 'blue-orange' ) );
+
+		$global_styles_presets_property = new ReflectionProperty( 'WP_Duotone_Gutenberg', 'global_styles_presets' );
+		$global_styles_presets_property->setAccessible( true );
+		$previous_presets = $global_styles_presets_property->getValue();
+		$global_styles_presets_property->setValue(
+			$wp_duotone,
+			array(
+				'wp-duotone-blue-orange' => array(
+					'slug'   => 'blue-orange',
+					'colors' => array( '#0000ff', '#ffa500' ),
+				),
+			)
+		);
+
+		$expected = '<figure class="wp-block-image size-full is-style-rounded wp-duotone-blue-orange"><img src="/my-image.jpg" /></figure>';
+		$actual   = WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block, $wp_block );
+
+		$global_styles_block_names_property->setValue( $wp_duotone, $previous_block_names );
+		$global_styles_presets_property->setValue( $wp_duotone, $previous_presets );
+		$global_styles_block_names_property->setAccessible( false );
+		$global_styles_presets_property->setAccessible( false );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether a duotone filter applied to a block style variation in global styles
+	 * correctly overrides the default duotone filter applied to the base block.
+	 *
+	 * @covers ::render_duotone_support
+	 */
+	public function test_gutenberg_render_duotone_support_block_style_variation_precedence() {
+		$block         = array(
+			'blockName' => 'core/image',
+			'attrs'     => array(
+				'className' => 'is-style-rounded',
+			),
+		);
+		$wp_block      = new WP_Block( $block );
+		$block_content = '<figure class="wp-block-image size-full is-style-rounded"><img src="/my-image.jpg" /></figure>';
+
+		$wp_duotone = new WP_Duotone_Gutenberg();
+
+		$global_styles_block_names_property = new ReflectionProperty( 'WP_Duotone_Gutenberg', 'global_styles_block_names' );
+		$global_styles_block_names_property->setAccessible( true );
+		$previous_block_names = $global_styles_block_names_property->getValue();
+		$global_styles_block_names_property->setValue(
+			$wp_duotone,
+			array(
+				'core/image'         => 'red-yellow',
+				'core/image:rounded' => 'blue-orange',
+			)
+		);
+
+		$global_styles_presets_property = new ReflectionProperty( 'WP_Duotone_Gutenberg', 'global_styles_presets' );
+		$global_styles_presets_property->setAccessible( true );
+		$previous_presets = $global_styles_presets_property->getValue();
+		$global_styles_presets_property->setValue(
+			$wp_duotone,
+			array(
+				'wp-duotone-red-yellow'  => array(
+					'slug'   => 'red-yellow',
+					'colors' => array( '#ff0000', '#ffff00' ),
+				),
+				'wp-duotone-blue-orange' => array(
+					'slug'   => 'blue-orange',
+					'colors' => array( '#0000ff', '#ffa500' ),
+				),
+			)
+		);
+
+		$expected = '<figure class="wp-block-image size-full is-style-rounded wp-duotone-blue-orange"><img src="/my-image.jpg" /></figure>';
+		$actual   = WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block, $wp_block );
+
+		$global_styles_block_names_property->setValue( $wp_duotone, $previous_block_names );
+		$global_styles_presets_property->setValue( $wp_duotone, $previous_presets );
+		$global_styles_block_names_property->setAccessible( false );
+		$global_styles_presets_property->setAccessible( false );
+
+		$this->assertSame( $expected, $actual );
+	}
+
 
 	/**
 	 * Tests whether the CSS declarations are generated even if the block content is


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #77539 

This PR ensures that duotone filters applied to block style variations in Global Styles (e.g., a "Rounded" variation of an Image block) are correctly rendered on the frontend and take precedence over the base block's duotone settings.

## Why?
Previously, the `WP_Duotone_Gutenberg` class only checked for duotone settings applied to the base block type. If a user styled a specific variation with a different duotone, the frontend would either fallback to the base block's filter or apply no filter at all. This occurred because the logic did not account for the variations path in `theme.json` and didn't check the block's `className` for `is-style-{variation}` triggers during render.

## How?
- Updated `get_all_global_style_block_names` to iterate through block variations in the theme.json data. It now stores variation-specific duotones using the key format `blockName:variationName`.
- Updated `render_duotone_support` to parse the block's `className` attribute. If an `is-style- class` is found that matches a stored variation, that duotone is prioritized.
- Added a check to ensure the style variation duotone is enqueued via `enqueue_global_styles_preset` before falling back to the default block duotone.
- Added PHPUnit tests to verify both the rendering of variation duotones and the correct precedence when both a base block and a variation have duotones defined.

## Testing Instructions

- Using a block theme, go to Editor > Styles > Blocks > Image.
- Set a Duotone filter for the base Image block.
- In the same menu, select the "Rounded" variation and set a different Duotone filter.
- Save the changes.
- Create a post with two Image blocks: leave one as "Default" and set the other to the "Rounded" style.
- View the frontend.
- Expected: The default image and the rounded image should have different filters as we had set.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before:

https://github.com/user-attachments/assets/d02e4f43-8853-4ab3-b3ab-a63b99a218a7

### After:

https://github.com/user-attachments/assets/a5a5c85f-2145-462d-a271-6659b98eb463


## Use of AI Tools
I used Gemini 3 Flash to help draft the PR description and structure the summary based on my code changes. And Deepseek v4 Flash (via OpenCode) for initial PR review.


<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
