### PR TITLE
Block Inspector: Hide Styles tab in preview mode

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -111,13 +111,17 @@ export default function useInspectorControlsTabs(
 		tabs.push( TAB_SETTINGS );
 	}
 
-	if ( hasBlockStyles || hasStyleFills ) {
+	const { tabSettings, isPreviewMode } = useSelect( ( select ) => {
+		const settings = select( blockEditorStore ).getSettings();
+		return {
+			tabSettings: settings.blockInspectorTabs,
+			isPreviewMode: settings.isPreviewMode,
+		};
+	}, [] );
+
+	if ( ! isPreviewMode && ( hasBlockStyles || hasStyleFills ) ) {
 		tabs.push( TAB_STYLES );
 	}
-
-	const tabSettings = useSelect( ( select ) => {
-		return select( blockEditorStore ).getSettings().blockInspectorTabs;
-	}, [] );
 
 	const showTabs = getShowTabs( blockName, tabSettings );
 	return showTabs ? tabs : EMPTY_ARRAY;


### PR DESCRIPTION
## What?

Hide the Styles tab in the block inspector when the editor is in preview mode (e.g. revisions mode).

## Why?

The sidebar UI for manipulating blocks should be entirely hidden on the Revisions screen. However, I noticed that the color panel is displayed for blocks with content-only mode applied. This is because [it is rendered directly without going through InspectorControls fill](https://github.com/WordPress/gutenberg/blob/89c578ab0693fffe75c5d657ea16f96dc0fc18d0/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js#L75-L80).

Please refer to #71982 for the reason why the color UI is directly rendered in the Content-Only pattern.

## How?

This PR prevents the Styles tab from being pushed into the array when in preview mode. I'm not sure if the content tab should also be hidden. If so, the following changes can be made to this PR.

<details><summary>Details</summary>

```diff
diff --git a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
index e7e270b4b2e..e8838c6080d 100644
--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -103,14 +103,6 @@ export default function useInspectorControlsTabs(
                tabs.push( TAB_LIST_VIEW );
        }
 
-       if (
-               settingsFills.length ||
-               // Advanced fills show up in settings tab if available or they blend into the default tab, if there's only one tab.
-               ( advancedFills.length && ( hasContentTab || hasListFills ) )
-       ) {
-               tabs.push( TAB_SETTINGS );
-       }
-
        const { tabSettings, isPreviewMode } = useSelect( ( select ) => {
                const settings = select( blockEditorStore ).getSettings();
                return {
@@ -119,6 +111,15 @@ export default function useInspectorControlsTabs(
                };
        }, [] );
 
+       if (
+               ! isPreviewMode &&
+               ( settingsFills.length ||
+                       // Advanced fills show up in settings tab if available or they blend into the default tab, if there's only one tab.
+                       ( advancedFills.length && ( hasContentTab || hasListFills ) ) )
+       ) {
+               tabs.push( TAB_SETTINGS );
+       }
+
        if ( ! isPreviewMode && ( hasBlockStyles || hasStyleFills ) ) {
                tabs.push( TAB_STYLES );
        }
```

</details> 

## Testing Instructions

1. Open a post in the editor.
2. Insert the following content:
   ```html
   <!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
   <div class="wp-block-group"><!-- wp:paragraph -->
   <p>Content Only</p>
   <!-- /wp:paragraph --></div>
   <!-- /wp:group -->
   ```
3. Save the post, then make another change and save again so that at least one revision exists.
4. Open the post revisions UI and enter Revisions mode.
5. Select the Group block.
6. Verify that the block inspector shows only the Content tab (no empty Styles tab).

## Screenshots or screencast

### Before

<img width="1061" height="583" alt="image" src="https://github.com/user-attachments/assets/5e46e8a2-7557-40c9-8e2e-d49354d88e1f" />

### After

<img width="1061" height="586" alt="image" src="https://github.com/user-attachments/assets/cee61248-2285-493f-a3b5-35f303abcfac" />

## Use of AI Tools

I used Claude Code to investigate the root cause and draft this patch. I reviewed and verified the change myself.
