### PR TITLE
Experiment: Add default term for taxonomies

### DIFF
--- a/lib/experimental/content-types/class-wp-rest-user-taxonomies-controller-gutenberg.php
+++ b/lib/experimental/content-types/class-wp-rest-user-taxonomies-controller-gutenberg.php
@@ -91,6 +91,18 @@ class WP_REST_User_Taxonomies_Controller_Gutenberg extends WP_REST_Posts_Control
 				'show_in_quick_edit' => array( 'type' => 'boolean' ),
 				'show_admin_column'  => array( 'type' => 'boolean' ),
 				'show_in_rest'       => array( 'type' => 'boolean' ),
+				'sort'               => array( 'type' => 'boolean' ),
+				'default_term'       => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'name' => array(
+							'type'      => 'string',
+							// Matches the `wp_terms.name` column (varchar(200)).
+							'maxLength' => 200,
+						),
+					),
+				),
 				'labels'             => array(
 					'type'                 => 'object',
 					'additionalProperties' => false,

--- a/lib/experimental/content-types/index.php
+++ b/lib/experimental/content-types/index.php
@@ -411,6 +411,7 @@ function gutenberg_build_user_taxonomy_args( WP_Post $record ) {
 		'show_tagcloud',
 		'show_in_quick_edit',
 		'show_admin_column',
+		'sort',
 	);
 	foreach ( $bool_keys as $key ) {
 		if ( array_key_exists( $key, $config ) ) {
@@ -418,6 +419,13 @@ function gutenberg_build_user_taxonomy_args( WP_Post $record ) {
 		}
 	}
 	$args['show_in_rest'] = isset( $config['show_in_rest'] ) ? (bool) $config['show_in_rest'] : true;
+
+	if ( isset( $config['default_term']['name'] ) ) {
+		$default_term_name = sanitize_text_field( (string) $config['default_term']['name'] );
+		if ( '' !== $default_term_name ) {
+			$args['default_term'] = array( 'name' => $default_term_name );
+		}
+	}
 
 	return array( $slug, $object_type, $args );
 }

--- a/packages/content-types/src/taxonomies/edit.tsx
+++ b/packages/content-types/src/taxonomies/edit.tsx
@@ -24,9 +24,12 @@ import { Stack } from '@wordpress/ui';
 import {
 	addNewItemLabelField,
 	addOrRemoveItemsField,
+	advancedFormFields,
 	allItemsField,
 	backToItemsField,
 	chooseFromMostUsedField,
+	defaultTermEnabledField,
+	defaultTermNameField,
 	descriptionField,
 	editItemField,
 	generalFormFields,
@@ -50,6 +53,7 @@ import {
 	showInRestField,
 	showTagcloudField,
 	showUiField,
+	sortField,
 	updateItemField,
 	useObjectTypeField,
 	useSlugField,
@@ -182,6 +186,10 @@ function TaxonomyPage( {
 				parentItemColonField,
 				addOrRemoveItemsField,
 				chooseFromMostUsedField,
+				// Advanced
+				sortField,
+				defaultTermEnabledField,
+				defaultTermNameField,
 			] as Field< TaxonomyFormData >[],
 		[ slugField, objectTypeField ]
 	);
@@ -225,6 +233,16 @@ function TaxonomyPage( {
 						isOpened: false,
 					},
 					children: labelsFormFields,
+				},
+				{
+					id: 'advanced',
+					label: __( 'Advanced' ),
+					layout: {
+						type: 'card',
+						isCollapsible: true,
+						isOpened: false,
+					},
+					children: advancedFormFields,
 				},
 			],
 		} ),

--- a/packages/content-types/src/taxonomies/fields/advanced.tsx
+++ b/packages/content-types/src/taxonomies/fields/advanced.tsx
@@ -12,7 +12,7 @@ import type { TaxonomyFormData } from '../types';
 
 export const sortField = createBooleanField( 'sort', __( 'Sort terms' ), {
 	description: __(
-		'Whether terms in this taxonomy should be sorted in the order they are provided to wp_set_object_terms().'
+		'Whether terms in this taxonomy should be saved in the order they are assigned to an item.'
 	),
 } );
 

--- a/packages/content-types/src/taxonomies/fields/advanced.tsx
+++ b/packages/content-types/src/taxonomies/fields/advanced.tsx
@@ -1,0 +1,67 @@
+/**
+ * WordPress dependencies
+ */
+import type { Field, Form } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { createBooleanField } from '../../utils/fields';
+import type { TaxonomyFormData } from '../types';
+
+export const sortField = createBooleanField( 'sort', __( 'Sort terms' ), {
+	description: __(
+		'Whether terms in this taxonomy should be sorted in the order they are provided to wp_set_object_terms().'
+	),
+} );
+
+export const defaultTermEnabledField = createBooleanField(
+	'default_term_enabled',
+	__( 'Set a default term' ),
+	{
+		description: __(
+			'Default term to be used for the taxonomy, similar to how "Uncategorized" works for categories.'
+		),
+	}
+);
+
+export const defaultTermNameField: Field< TaxonomyFormData > = {
+	id: 'default_term_name',
+	label: __( 'Default term name' ),
+	type: 'text',
+	description: __(
+		"Once saved, updating the name creates a new term — the previous default term remains in the terms list. To change the term's slug or description, edit it from the terms list."
+	),
+	getValue: ( { item } ) => item.config.default_term.name,
+	setValue: ( { item, value } ) => ( {
+		config: {
+			...item.config,
+			default_term: { name: String( value ?? '' ) },
+		},
+	} ),
+	isValid: {
+		// `useFormValidity` does not skip invisible fields, so `required:
+		// true` would mark the form invalid whenever the toggle is off.
+		// Gate the requirement on the toggle via `custom` instead.
+		custom: ( item ) => {
+			if ( ! item.config.default_term_enabled ) {
+				return null;
+			}
+			return item.config.default_term.name.trim()
+				? null
+				: __( 'A default term name is required.' );
+		},
+		// Mirrors `wp_terms.name` column width (varchar(200)).
+		maxLength: 200,
+	},
+	isVisible: ( item ) => item.config.default_term_enabled,
+	enableSorting: false,
+	filterBy: false,
+};
+
+export const advancedFormFields: Form[ 'fields' ] = [
+	'sort',
+	'default_term_enabled',
+	'default_term_name',
+];

--- a/packages/content-types/src/taxonomies/fields/index.ts
+++ b/packages/content-types/src/taxonomies/fields/index.ts
@@ -1,3 +1,4 @@
+export * from './advanced';
 export * from './general';
 export * from './labels';
 export * from './visibility';

--- a/packages/content-types/src/taxonomies/types.ts
+++ b/packages/content-types/src/taxonomies/types.ts
@@ -44,6 +44,8 @@ export interface StoredConfig {
 	show_in_quick_edit: boolean;
 	show_admin_column: boolean;
 	show_in_rest: boolean;
+	sort?: boolean;
+	default_term?: { name: string };
 }
 
 import type { ContentType } from '../types';
@@ -67,6 +69,11 @@ export interface TaxonomyFormData extends ContentType {
 		show_tagcloud: boolean;
 		show_in_quick_edit: boolean;
 		show_admin_column: boolean;
+		sort: boolean;
+		// Form-only — controls whether `default_term` is sent on save.
+		// Not part of `StoredConfig`; stripped by `serializeForSave`.
+		default_term_enabled: boolean;
+		default_term: { name: string };
 	};
 	count?: number;
 }

--- a/packages/content-types/src/taxonomies/utils.ts
+++ b/packages/content-types/src/taxonomies/utils.ts
@@ -30,6 +30,9 @@ export const BLANK_RECORD: TaxonomyFormData = {
 		show_in_quick_edit: true,
 		show_admin_column: false,
 		show_in_rest: true,
+		sort: false,
+		default_term_enabled: false,
+		default_term: { name: '' },
 	},
 };
 
@@ -144,6 +147,7 @@ export function toFormData( row: TaxonomyRecord ): TaxonomyFormData {
 		config.labels,
 		STRING_LABEL_KEYS
 	);
+	const defaultTermName = config.default_term?.name ?? '';
 	const formConfig: TaxonomyFormData[ 'config' ] = {
 		labels: { singular_name: '', ...labels },
 		object_type: Array.isArray( row.object_type ) ? row.object_type : [],
@@ -158,6 +162,9 @@ export function toFormData( row: TaxonomyRecord ): TaxonomyFormData {
 		show_in_quick_edit: config.show_in_quick_edit,
 		show_admin_column: config.show_admin_column,
 		show_in_rest: config.show_in_rest,
+		sort: !! config.sort,
+		default_term_enabled: defaultTermName !== '',
+		default_term: { name: defaultTermName },
 	};
 	return {
 		id: row.id,
@@ -180,6 +187,9 @@ export function serializeForSave( data: TaxonomyFormData ) {
 	);
 
 	const description = config.description.trim();
+	const defaultTermName = config.default_term.name.trim();
+	const includeDefaultTerm =
+		config.default_term_enabled && defaultTermName !== '';
 	return {
 		...( data.id !== undefined ? { id: data.id } : {} ),
 		slug: data.slug,
@@ -198,7 +208,11 @@ export function serializeForSave( data: TaxonomyFormData ) {
 			show_in_quick_edit: config.show_in_quick_edit,
 			show_admin_column: config.show_admin_column,
 			show_in_rest: config.show_in_rest,
+			sort: config.sort,
 			...( description !== '' ? { description } : {} ),
+			...( includeDefaultTerm
+				? { default_term: { name: defaultTermName } }
+				: {} ),
 		},
 	};
 }

--- a/phpunit/experimental/content-types/user-taxonomy-registration-test.php
+++ b/phpunit/experimental/content-types/user-taxonomy-registration-test.php
@@ -92,6 +92,7 @@ class User_Taxonomy_Registration_Test extends WP_UnitTestCase {
 				'show_in_quick_edit' => false,
 				'show_admin_column'  => true,
 				'show_in_rest'       => false,
+				'sort'               => true,
 			),
 			'flagged_tax',
 			'Flagged'
@@ -111,8 +112,65 @@ class User_Taxonomy_Registration_Test extends WP_UnitTestCase {
 		$this->assertFalse( $tax->show_in_quick_edit );
 		$this->assertTrue( $tax->show_admin_column );
 		$this->assertFalse( $tax->show_in_rest );
+		$this->assertTrue( $tax->sort );
 
 		unregister_taxonomy( 'flagged_tax' );
+		wp_delete_post( $created['id'], true );
+	}
+
+	/**
+	 * `default_term` flows through as a `[ 'name' => ... ]` array on the
+	 * registered WP_Taxonomy.
+	 */
+	public function test_default_term_forwarded_to_register_taxonomy() {
+		$created = self::create_user_taxonomy(
+			array(
+				'labels'       => array( 'singular_name' => 'Topic' ),
+				'default_term' => array( 'name' => 'Uncategorized Topic' ),
+			),
+			'topic_tax',
+			'Topics'
+		);
+
+		gutenberg_register_user_defined_taxonomies();
+
+		$tax = get_taxonomy( 'topic_tax' );
+		$this->assertNotFalse( $tax );
+		$this->assertSame( 'Uncategorized Topic', $tax->default_term['name'] );
+
+		// WP core auto-creates the default term during register_taxonomy();
+		// clean up so the test doesn't leak rows.
+		$term_id = (int) get_option( 'default_term_topic_tax' );
+		if ( $term_id > 0 ) {
+			wp_delete_term( $term_id, 'topic_tax' );
+		}
+		delete_option( 'default_term_topic_tax' );
+		unregister_taxonomy( 'topic_tax' );
+		wp_delete_post( $created['id'], true );
+	}
+
+	/**
+	 * An empty `default_term.name` must not call `wp_insert_term()` (which
+	 * would error on an empty name) and must not set the option.
+	 */
+	public function test_default_term_with_empty_name_is_omitted() {
+		$created = self::create_user_taxonomy(
+			array(
+				'labels'       => array( 'singular_name' => 'Empty' ),
+				'default_term' => array( 'name' => '' ),
+			),
+			'empty_default_tax',
+			'Empties'
+		);
+
+		gutenberg_register_user_defined_taxonomies();
+
+		$tax = get_taxonomy( 'empty_default_tax' );
+		$this->assertNotFalse( $tax );
+		$this->assertEmpty( $tax->default_term );
+		$this->assertFalse( get_option( 'default_term_empty_default_tax' ) );
+
+		unregister_taxonomy( 'empty_default_tax' );
 		wp_delete_post( $created['id'], true );
 	}
 }

--- a/test/e2e/specs/admin/user-taxonomies.spec.js
+++ b/test/e2e/specs/admin/user-taxonomies.spec.js
@@ -311,4 +311,212 @@ test.describe( 'User taxonomies', () => {
 			).toBeVisible();
 		} );
 	} );
+
+	test.describe( 'Default term', () => {
+		// Nonsense slug to minimize the chance of collision with terms left
+		// behind by other specs that touch built-in taxonomies.
+		const SLUG = 'xyzzy';
+		const PLURAL = 'Xyzzies';
+		const SINGULAR = 'Xyzzy';
+
+		// Outer `afterEach` deletes the wp_user_taxonomy record; this
+		// additionally cleans up the posts the tests publish. The terms
+		// auto-created by WP's default-term mechanism are intentionally
+		// left in place — the current default term is protected from REST
+		// deletion (`rest_cannot_delete`), and tests are resilient to the
+		// leftover terms since `register_taxonomy()` reuses terms by name.
+		// TODO: once wp_user_taxonomy deletion cascades to the
+		// `default_term_{slug}` option and orphan terms, drop this comment
+		// and explicitly clean the terms here.
+		test.afterEach( async ( { requestUtils } ) => {
+			await requestUtils.deleteAllPosts( 'posts' );
+		} );
+
+		async function createHierarchicalTaxonomyWithDefaultTerm( {
+			admin,
+			page,
+			defaultTermName,
+		} ) {
+			await admin.visitAdminPage(
+				SETTINGS_PAGE_PATH,
+				CONTENT_TYPES_PAGE_QUERY
+			);
+			await page.getByRole( 'button', { name: 'Add taxonomy' } ).click();
+			await page
+				.getByRole( 'textbox', { name: 'Plural label' } )
+				.fill( PLURAL );
+			await page
+				.getByRole( 'textbox', { name: 'Singular label' } )
+				.fill( SINGULAR );
+			const slugField = page.getByRole( 'textbox', {
+				name: 'Taxonomy key',
+			} );
+			await Promise.all( [
+				page.waitForResponse(
+					( resp ) =>
+						resp.url().includes( `/${ TAXONOMIES_REST_BASE }` ) &&
+						resp.url().includes( `slug=${ SLUG }` )
+				),
+				slugField.focus(),
+			] );
+			await page
+				.getByRole( 'checkbox', { name: 'Hierarchical' } )
+				.click();
+			await page.getByRole( 'combobox', { name: 'Post types' } ).click();
+			await page.getByRole( 'option', { name: 'Posts' } ).click();
+
+			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+			await page
+				.getByRole( 'checkbox', { name: 'Set a default term' } )
+				.click();
+			await page
+				.getByRole( 'textbox', { name: 'Default term name' } )
+				.fill( defaultTermName );
+			await page.getByRole( 'button', { name: 'Create' } ).click();
+			await expect( page.getByTestId( 'snackbar' ) ).toContainText(
+				`"${ PLURAL }" taxonomy created.`
+			);
+		}
+
+		async function expandTaxonomyPanel( page ) {
+			const button = page.getByRole( 'button', { name: PLURAL } );
+			const expanded = await button.getAttribute( 'aria-expanded' );
+			if ( expanded === 'false' ) {
+				await button.click();
+			}
+		}
+
+		// Resolves the wp_user_taxonomy record id so a test can navigate
+		// back to its edit page. Slug-based lookup avoids depending on the
+		// post-create redirect URL.
+		async function getTaxonomyId( requestUtils ) {
+			const records = await requestUtils.rest( {
+				path: `/wp/v2/${ TAXONOMIES_REST_BASE }?slug=${ SLUG }&status=publish`,
+				method: 'GET',
+			} );
+			return records[ 0 ].id;
+		}
+
+		test( 'auto-applies the default term, and stops after the toggle is disabled', async ( {
+			admin,
+			editor,
+			page,
+			requestUtils,
+		} ) => {
+			await createHierarchicalTaxonomyWithDefaultTerm( {
+				admin,
+				page,
+				defaultTermName: 'Default Xyzzy A',
+			} );
+
+			// Publish a post without touching the taxonomy panel.
+			await admin.createNewPost();
+			await editor.openDocumentSettingsSidebar();
+			await editor.canvas
+				.getByRole( 'textbox', { name: 'Add title' } )
+				.fill( 'Post one' );
+			await editor.publishPost();
+			await page.reload();
+			await editor.openDocumentSettingsSidebar();
+			await expandTaxonomyPanel( page );
+			const genresGroup = page.getByRole( 'group', { name: PLURAL } );
+			await expect(
+				genresGroup.getByRole( 'checkbox', { name: 'Default Xyzzy A' } )
+			).toBeChecked();
+
+			// Disable the default-term toggle via the edit page.
+			const taxonomyId = await getTaxonomyId( requestUtils );
+			await admin.visitAdminPage(
+				SETTINGS_PAGE_PATH,
+				`page=content-types-wp-admin&p=/taxonomies/${ taxonomyId }`
+			);
+			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+			await page
+				.getByRole( 'checkbox', { name: 'Set a default term' } )
+				.click();
+			await page.getByRole( 'button', { name: 'Save' } ).click();
+			await expect( page.getByTestId( 'snackbar' ).last() ).toContainText(
+				`"${ PLURAL }" taxonomy updated.`
+			);
+
+			// Publish another post — the default term must no longer
+			// auto-attach, so no checkbox in the term group is checked.
+			await admin.createNewPost();
+			await editor.openDocumentSettingsSidebar();
+			await editor.canvas
+				.getByRole( 'textbox', { name: 'Add title' } )
+				.fill( 'Post two' );
+			await editor.publishPost();
+			await page.reload();
+			await editor.openDocumentSettingsSidebar();
+			await expandTaxonomyPanel( page );
+			const genresGroupTwo = page.getByRole( 'group', { name: PLURAL } );
+			await expect(
+				genresGroupTwo.getByRole( 'checkbox', { checked: true } )
+			).toHaveCount( 0 );
+		} );
+
+		test( 'renaming the default term creates a new term and preserves the old', async ( {
+			admin,
+			editor,
+			page,
+			requestUtils,
+		} ) => {
+			await createHierarchicalTaxonomyWithDefaultTerm( {
+				admin,
+				page,
+				defaultTermName: 'Original Xyzzy',
+			} );
+
+			// Publish post A — the original default term should be checked.
+			await admin.createNewPost();
+			await editor.openDocumentSettingsSidebar();
+			await editor.canvas
+				.getByRole( 'textbox', { name: 'Add title' } )
+				.fill( 'Post A' );
+			await editor.publishPost();
+			await page.reload();
+			await editor.openDocumentSettingsSidebar();
+			await expandTaxonomyPanel( page );
+			const postAGroup = page.getByRole( 'group', { name: PLURAL } );
+			await expect(
+				postAGroup.getByRole( 'checkbox', { name: 'Original Xyzzy' } )
+			).toBeChecked();
+
+			// Rename the default term via the edit page.
+			const taxonomyId = await getTaxonomyId( requestUtils );
+			await admin.visitAdminPage(
+				SETTINGS_PAGE_PATH,
+				`page=content-types-wp-admin&p=/taxonomies/${ taxonomyId }`
+			);
+			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+			await page
+				.getByRole( 'textbox', { name: 'Default term name' } )
+				.fill( 'Renamed Xyzzy' );
+			await page.getByRole( 'button', { name: 'Save' } ).click();
+			await expect( page.getByTestId( 'snackbar' ).last() ).toContainText(
+				`"${ PLURAL }" taxonomy updated.`
+			);
+
+			// Publish post B — the newly created term should be checked,
+			// and the original term should still appear in the panel
+			// (preserved, not deleted), just unchecked.
+			await admin.createNewPost();
+			await editor.openDocumentSettingsSidebar();
+			await editor.canvas
+				.getByRole( 'textbox', { name: 'Add title' } )
+				.fill( 'Post B' );
+			await editor.publishPost();
+			await page.reload();
+			await editor.openDocumentSettingsSidebar();
+			await expandTaxonomyPanel( page );
+			const postBGroup = page.getByRole( 'group', { name: PLURAL } );
+			await expect(
+				postBGroup.getByRole( 'checkbox', { name: 'Renamed Xyzzy' } )
+			).toBeChecked();
+			await expect(
+				postBGroup.getByRole( 'checkbox', { name: 'Original Xyzzy' } )
+			).not.toBeChecked();
+		} );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/77600

 - Adds an Advanced card to the user-taxonomy add/edit form with two settings: `Sort terms` and `Set a default term`.
 - The default-term toggle plumbs WP core's auto-assignment into user-defined taxonomies — posts saved without any
  term in this taxonomy automatically get the default, the same way "Uncategorized" works for categories.
 
## Notes

 WP core's `register_taxonomy` resolves the default term by name only (`term_exists()`), and the `default_term_{slug}` option short-circuits after first creation. That has two user-visible consequences:

 - Renaming creates a new term. Changing the name on an existing taxonomy doesn't rename the term — term_exists()
 doesn't find it under the new name, so WP inserts a new term and re-points the option. The old term stays in the
 terms list. The field's help text reflects this: "Once saved, updating the name creates a new term — the previous
  default term remains in the terms list."
 - Slug and description are intentionally not exposed. WP only reads them at first creation; once the term exists,
  edits to those args are silent no-ops. Rather than ship two fields that quietly do nothing on edit, the UI exposes the name only and points users to the terms list for slug/description edits.



 ## Testing instructions

 1. Enable the Gutenberg content types experiment.
 2. Go to Settings → Content types → Taxonomies → Add taxonomy and add a post type (e.g. `Posts`), expand `Advanced` card and set a default term, enter a name (e.g. Featured), click `Create`.
 3. `Auto-assign`: create a new post and publish without touching the new taxonomy panel. The
 default term should be checked in the taxonomy panel.
 4. `Disable`: return to the taxonomy edit page, expand Advanced, toggle the default-term setting off, save. Create
 another post and publish without touching the panel. No term should be checked.
 5. Rename: re-enable the toggle, change the name, save. Publish another post — the new term is checked. 


 ### Follow-ups

 - Cascade taxonomy deletion to its terms and default-term option. Today, deleting a `wp_user_taxonomy` record
 leaves the `default_term_{slug}` option and the auto-created default term behind. That's also why the new E2E
 `afterEach` can't authoritatively clean up the term it creates — the current default term is protected from REST
 deletion (`rest_cannot_delete`), and there's no REST endpoint to clear the option. A follow-up should cascade these
  on `wp_user_taxonomy delete`; the E2E cleanup can then be made strict (a TODO is in place).