### PR TITLE
Widget dashboard: skip tile hover elevation while resizing

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -114,6 +114,15 @@ module.exports = {
 						],
 					},
 				],
+				'selector-pseudo-class-no-unknown': [
+					true,
+					{
+						ignorePseudoClasses: [
+							// CSS Modules global escape hatch.
+							'global',
+						],
+					},
+				],
 			},
 		},
 	],

--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Set `data-wp-dashboard-grid-resizing` on the `DashboardGrid` root
+    element while any tile resize gesture is active, so consumers can
+    adjust styles when the pointer may still hover tiles.
+
 ### New Features
 
 -   Initial release. Ships two layout components:

--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   Set `data-wp-dashboard-grid-resizing` on the `DashboardGrid` root
     element while any tile resize gesture is active, so consumers can
-    adjust styles when the pointer may still hover tiles.
+    adjust styles when the pointer may still hover tiles ([#78234](https://github.com/WordPress/gutenberg/pull/78234)).
 
 ### New Features
 

--- a/packages/grid/src/dashboard-grid/index.tsx
+++ b/packages/grid/src/dashboard-grid/index.tsx
@@ -519,6 +519,9 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 						{ ...divProps }
 						ref={ mergedGridRef }
 						className={ clsx( styles.grid, className ) }
+						data-wp-dashboard-grid-resizing={
+							isResizing || undefined
+						}
 						style={ {
 							...style,
 							gridTemplateColumns: `repeat(${ effectiveColumns }, minmax(0, 1fr))`,

--- a/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
@@ -16,6 +16,18 @@
 	box-shadow: var(--wpds-elevation-md);
 }
 
+/*
+ * While a resize is in progress, the pointer often sits over the tile;
+ * keep resting elevation so the hover lift does not flicker or fight the
+ * gesture. `data-wp-dashboard-grid-resizing` is set on `@wordpress/grid`
+ * `DashboardGrid` root for the duration of the resize.
+ */
+:global( [data-wp-dashboard-grid-resizing] ) .tileEditMode:hover,
+:global( [data-wp-dashboard-grid-resizing] )
+	.tileEditMode:focus-visible {
+	box-shadow: var(--wpds-elevation-xs);
+}
+
 .tileEditMode:focus-visible {
 	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus-brand);
 	outline-offset: 2px;

--- a/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
@@ -22,9 +22,8 @@
  * gesture. `data-wp-dashboard-grid-resizing` is set on `@wordpress/grid`
  * `DashboardGrid` root for the duration of the resize.
  */
-:global( [data-wp-dashboard-grid-resizing] ) .tileEditMode:hover,
-:global( [data-wp-dashboard-grid-resizing] )
-	.tileEditMode:focus-visible {
+:global([data-wp-dashboard-grid-resizing]) .tileEditMode:hover,
+:global([data-wp-dashboard-grid-resizing]) .tileEditMode:focus-visible {
 	box-shadow: var(--wpds-elevation-xs);
 }
 


### PR DESCRIPTION
## What

- Sets `data-wp-dashboard-grid-resizing` on the `DashboardGrid` root while any tile resize is active.
- Updates widget dashboard tile styles so hover/focus elevation does not bump to `--wpds-elevation-md` when that attribute is present (tiles stay at `--wpds-elevation-xs`).
- Documents the behavior in `packages/grid/CHANGELOG.md`.

Part of #77626 #77616

## Why

While shrinking a widget, the pointer often stays over the tile body, so `:hover` stays true and the stronger shadow keeps applying. That reads as flicker or visual noise and fights the resize gesture. Drag/reorder is unchanged; only resize needed a signal.

## How

- `DashboardGrid` already tracks `isResizing`; the grid root now mirrors that with a stable `data-*` hook for styling.
- `widgets.module.css` adds a higher-specificity override under `:global([data-wp-dashboard-grid-resizing])` so resting elevation wins over `.tileEditMode:hover` / `:focus-visible` for the duration of the gesture.
- `.stylelintrc.js`: For *.module.{css,scss} only, selector-pseudo-class-no-unknown now ignores the global pseudo-class, matching the existing module-file exception for composes. That keeps :global usable in module styles without file-level disables whenever we need to target unscoped markup (e.g. the grid root’s data-wp-dashboard-grid-resizing attribute).

## Testing instructions
- Enable the Dashboard Gutenberg experiment
- View the Dashboard and enable customization mode
- Resize a widget, notice that when the resize cursor hovers the widget elevation doesn't change