### PR TITLE
Validate shortcode with regex

### DIFF
--- a/packages/block-library/src/shortcode/index.php
+++ b/packages/block-library/src/shortcode/index.php
@@ -16,7 +16,13 @@
  * @return string Returns the block content.
  */
 function render_block_core_shortcode( $attributes, $content ) {
-	return wpautop( $content );
+	$pattern = get_shortcode_regex();
+
+	if ( preg_match_all( '/' . $pattern . '/s', $content, $matches ) ) {
+		return wpautop( implode( "\n", $matches[0] ) );
+	}
+
+	return '';
 }
 
 /**

--- a/packages/block-library/src/shortcode/index.php
+++ b/packages/block-library/src/shortcode/index.php
@@ -17,8 +17,9 @@
  */
 function render_block_core_shortcode( $attributes, $content ) {
 	$pattern = get_shortcode_regex();
+	$safe_content = wp_strip_all_tags( $content );
 
-	if ( preg_match_all( '/' . $pattern . '/s', $content, $matches ) ) {
+	if ( preg_match_all( '/' . $pattern . '/s', $safe_content, $matches ) ) {
 		return wpautop( implode( "\n", $matches[0] ) );
 	}
 


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #78232

This PR updates the Shortcode block's server-side render callback to ensure it only outputs valid, registered shortcodes, actively discarding any unassociated or arbitrary HTML (such as `<script>` or `<iframe>` tags).

## Why?
Currently, the `render_block_core_shortcode` callback blindly passes the block's `innerHTML` through `wpautop()`.

## How?
This PR addresses the issue server side in `packages/block-library/src/shortcode/index.php`.

Instead of passing the raw `$content` directly to `wpautop()`, the `render_block_core_shortcode` function now:
1. Fetches the native WordPress regex for registered shortcodes using `get_shortcode_regex()`.
2. Uses `wp_strip_all_tags` & `preg_match_all()` to extract *only* valid shortcodes from the block's content.
3. Reconstructs and returns the content using only the matched strings, safely ignoring any surrounding rogue HTML.

## Testing Instructions
1. Open a new post or page in the block editor.
2. Insert a Shortcode block.
3. Inside the block, add a known shortcode alongside some arbitrary HTML. For example: `[gallery] <script>console.log("Arbitrary HTML executed!");</script> <h1>Rogue Heading</h1>`
4. Publish or save the post.
5. View the post on the frontend.
6. **Expected result:** The `[gallery]` shortcode should render normally, but the `<script>` and `<h1>` tags should be entirely stripped from the DOM and not execute.