### PR TITLE
Add custom widget dashboard resize handle styling.

### DIFF
--- a/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.module.css
@@ -50,7 +50,11 @@
 	/* Elbow only: matches tile scale; arm ends stay square. */
 	border-end-end-radius: var(--wpds-border-radius-md);
 	transform: scale(1);
-	transform-origin: inline-end block-end;
+	transform-origin: 100% 100%;
+}
+
+[dir="rtl"] .handleCorner::after {
+	transform-origin: 0% 100%;
 }
 
 .handleCorner.resizing::after,
@@ -102,7 +106,7 @@
 	height: 12px;
 	background-color: var(--wpds-color-fg-interactive-brand);
 	transform: scale(1);
-	transform-origin: center block-end;
+	transform-origin: 50% 100%;
 }
 
 .handleHorizontal.resizing::after,

--- a/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.module.css
@@ -13,7 +13,8 @@
 
 .handle:focus-visible {
 	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus-brand);
-	outline-offset: 2px;
+	/* @TODO: Replace with a `size` token once that category exists in the theme package. */
+	outline-offset: calc(var(--wpds-dimension-base) * 0.5);
 	border-radius: var(--wpds-border-radius-sm);
 }
 
@@ -26,8 +27,9 @@
  * logical borders so RTL needs no mirroring).
  */
 .handleCorner {
-	width: 24px;
-	height: 24px;
+	/* @TODO: Replace with a `size` token once that category exists in the theme package. */
+	width: calc(var(--wpds-dimension-base) * 6);
+	height: calc(var(--wpds-dimension-base) * 6);
 	cursor: nwse-resize;
 }
 
@@ -36,8 +38,9 @@
 	position: absolute;
 	bottom: var(--widget-resize-handle-visual-inset);
 	inset-inline-end: var(--widget-resize-handle-visual-inset);
-	width: 12px;
-	height: 12px;
+	/* @TODO: Replace with a `size` token once that category exists in the theme package. */
+	width: calc(var(--wpds-dimension-base) * 3);
+	height: calc(var(--wpds-dimension-base) * 3);
 	box-sizing: border-box;
 	border-block-end:
 		var(--wpds-border-width-sm) solid
@@ -73,8 +76,9 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 24px;
-	height: 40px;
+	/* @TODO: Replace with a `size` token once that category exists in the theme package. */
+	width: calc(var(--wpds-dimension-base) * 6);
+	height: calc(var(--wpds-dimension-base) * 10);
 	padding-inline-end: var(--widget-resize-handle-visual-inset);
 	cursor: ew-resize;
 	border: none;
@@ -103,7 +107,8 @@
 .handleHorizontal::after {
 	content: "";
 	width: var(--wpds-border-width-sm);
-	height: 12px;
+	/* @TODO: Replace with a `size` token once that category exists in the theme package. */
+	height: calc(var(--wpds-dimension-base) * 3);
 	background-color: var(--wpds-color-fg-interactive-brand);
 	transform: scale(1);
 	transform-origin: 50% 100%;

--- a/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.module.css
@@ -39,8 +39,8 @@
 	bottom: var(--widget-resize-handle-visual-inset);
 	inset-inline-end: var(--widget-resize-handle-visual-inset);
 	/* @TODO: Replace with a `size` token once that category exists in the theme package. */
-	width: calc(var(--wpds-dimension-base) * 3);
-	height: calc(var(--wpds-dimension-base) * 3);
+	width: calc(var(--wpds-dimension-base) * 2);
+	height: calc(var(--wpds-dimension-base) * 2);
 	box-sizing: border-box;
 	border-block-end:
 		var(--wpds-border-width-sm) solid

--- a/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.module.css
@@ -39,9 +39,11 @@
 	width: 12px;
 	height: 12px;
 	box-sizing: border-box;
-	border-block-end: var(--wpds-border-width-sm) solid
+	border-block-end:
+		var(--wpds-border-width-sm) solid
 		var(--wpds-color-fg-interactive-brand);
-	border-inline-end: var(--wpds-border-width-sm) solid
+	border-inline-end:
+		var(--wpds-border-width-sm) solid
 		var(--wpds-color-fg-interactive-brand);
 	border-block-start: none;
 	border-inline-start: none;
@@ -55,9 +57,11 @@
 .handleCorner:hover::after,
 .handleCorner:focus-visible::after {
 	transform: scale(var(--widget-resize-handle-hover-scale));
-	border-block-end: var(--wpds-border-width-sm) solid
+	border-block-end:
+		var(--wpds-border-width-sm) solid
 		var(--wpds-color-fg-interactive-brand-active);
-	border-inline-end: var(--wpds-border-width-sm) solid
+	border-inline-end:
+		var(--wpds-border-width-sm) solid
 		var(--wpds-color-fg-interactive-brand-active);
 }
 
@@ -76,19 +80,19 @@
 	.handleCorner::after {
 		transition:
 			transform var(--wpds-motion-duration-xs)
-				var(--wpds-motion-easing-subtle),
+			var(--wpds-motion-easing-subtle),
 			border-block-end-color var(--wpds-motion-duration-xs)
-				var(--wpds-motion-easing-subtle),
+			var(--wpds-motion-easing-subtle),
 			border-inline-end-color var(--wpds-motion-duration-xs)
-				var(--wpds-motion-easing-subtle);
+			var(--wpds-motion-easing-subtle);
 	}
 
 	.handleHorizontal::after {
 		transition:
 			transform var(--wpds-motion-duration-xs)
-				var(--wpds-motion-easing-subtle),
+			var(--wpds-motion-easing-subtle),
 			background-color var(--wpds-motion-duration-xs)
-				var(--wpds-motion-easing-subtle);
+			var(--wpds-motion-easing-subtle);
 	}
 }
 

--- a/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.module.css
@@ -7,7 +7,7 @@
 	padding: 0;
 	background: transparent;
 	/* Nudge painted affordance away from tile chrome; hit target stays flush. */
-	--widget-resize-handle-visual-inset: var(--wpds-border-width-md);
+	--widget-resize-handle-visual-inset: var(--wpds-dimension-padding-xs);
 	--widget-resize-handle-hover-scale: 1.18;
 }
 

--- a/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.module.css
@@ -84,19 +84,19 @@
 	.handleCorner::after {
 		transition:
 			transform var(--wpds-motion-duration-xs)
-			var(--wpds-motion-easing-subtle),
+			var(--wpds-motion-easing-balanced),
 			border-block-end-color var(--wpds-motion-duration-xs)
-			var(--wpds-motion-easing-subtle),
+			var(--wpds-motion-easing-balanced),
 			border-inline-end-color var(--wpds-motion-duration-xs)
-			var(--wpds-motion-easing-subtle);
+			var(--wpds-motion-easing-balanced);
 	}
 
 	.handleHorizontal::after {
 		transition:
 			transform var(--wpds-motion-duration-xs)
-			var(--wpds-motion-easing-subtle),
+			var(--wpds-motion-easing-balanced),
 			background-color var(--wpds-motion-duration-xs)
-			var(--wpds-motion-easing-subtle);
+			var(--wpds-motion-easing-balanced);
 	}
 }
 

--- a/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.module.css
@@ -1,0 +1,126 @@
+.handle {
+	position: absolute;
+	bottom: 0;
+	inset-inline-end: 0;
+	z-index: 1;
+	box-sizing: border-box;
+	padding: 0;
+	background: transparent;
+	/* Nudge painted affordance away from tile chrome; hit target stays flush. */
+	--widget-resize-handle-visual-inset: var(--wpds-border-width-md);
+	--widget-resize-handle-hover-scale: 1.18;
+}
+
+.handle:focus-visible {
+	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus-brand);
+	outline-offset: 2px;
+	border-radius: var(--wpds-border-radius-sm);
+}
+
+.resizing {
+	opacity: 0.72;
+}
+
+/*
+ * Larger box = hit target; small `::after` = visual only (still uses
+ * logical borders so RTL needs no mirroring).
+ */
+.handleCorner {
+	width: 24px;
+	height: 24px;
+	cursor: nwse-resize;
+}
+
+.handleCorner::after {
+	content: "";
+	position: absolute;
+	bottom: var(--widget-resize-handle-visual-inset);
+	inset-inline-end: var(--widget-resize-handle-visual-inset);
+	width: 12px;
+	height: 12px;
+	box-sizing: border-box;
+	border-block-end: var(--wpds-border-width-sm) solid
+		var(--wpds-color-fg-interactive-brand);
+	border-inline-end: var(--wpds-border-width-sm) solid
+		var(--wpds-color-fg-interactive-brand);
+	border-block-start: none;
+	border-inline-start: none;
+	/* Elbow only: matches tile scale; arm ends stay square. */
+	border-end-end-radius: var(--wpds-border-radius-md);
+	transform: scale(1);
+	transform-origin: inline-end block-end;
+}
+
+.handleCorner.resizing::after,
+.handleCorner:hover::after,
+.handleCorner:focus-visible::after {
+	transform: scale(var(--widget-resize-handle-hover-scale));
+	border-block-end: var(--wpds-border-width-sm) solid
+		var(--wpds-color-fg-interactive-brand-active);
+	border-inline-end: var(--wpds-border-width-sm) solid
+		var(--wpds-color-fg-interactive-brand-active);
+}
+
+.handleHorizontal {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 40px;
+	padding-inline-end: var(--widget-resize-handle-visual-inset);
+	cursor: ew-resize;
+	border: none;
+}
+
+@media not ( prefers-reduced-motion ) {
+	.handleCorner::after {
+		transition:
+			transform var(--wpds-motion-duration-xs)
+				var(--wpds-motion-easing-subtle),
+			border-block-end-color var(--wpds-motion-duration-xs)
+				var(--wpds-motion-easing-subtle),
+			border-inline-end-color var(--wpds-motion-duration-xs)
+				var(--wpds-motion-easing-subtle);
+	}
+
+	.handleHorizontal::after {
+		transition:
+			transform var(--wpds-motion-duration-xs)
+				var(--wpds-motion-easing-subtle),
+			background-color var(--wpds-motion-duration-xs)
+				var(--wpds-motion-easing-subtle);
+	}
+}
+
+.handleHorizontal::after {
+	content: "";
+	width: var(--wpds-border-width-sm);
+	height: 12px;
+	background-color: var(--wpds-color-fg-interactive-brand);
+	transform: scale(1);
+	transform-origin: center block-end;
+}
+
+.handleHorizontal.resizing::after,
+.handleHorizontal:hover::after,
+.handleHorizontal:focus-visible::after {
+	transform: scale(var(--widget-resize-handle-hover-scale));
+	background-color: var(--wpds-color-fg-interactive-brand-active);
+}
+
+@media (forced-colors: active) {
+	.handleCorner::after,
+	.handleCorner.resizing::after,
+	.handleCorner:hover::after,
+	.handleCorner:focus-visible::after {
+		border-block-end-color: Highlight;
+		border-inline-end-color: Highlight;
+	}
+
+	.handleHorizontal::after,
+	.handleHorizontal.resizing::after,
+	.handleHorizontal:hover::after,
+	.handleHorizontal:focus-visible::after {
+		background-color: Highlight;
+	}
+}

--- a/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.tsx
+++ b/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
+import { forwardRef } from '@wordpress/element';
 import type { ResizeHandleRenderProps } from '@wordpress/grid';
 
 /**
@@ -13,14 +14,22 @@ import type { ResizeHandleRenderProps } from '@wordpress/grid';
  */
 import styles from './widget-resize-handle.module.css';
 
+type WidgetResizeHandleProps = Omit< ResizeHandleRenderProps, 'ref' >;
+
 /**
  * Rounded L-shaped resize affordance for the widget dashboard. Passed to
  * `DashboardGrid` via `renderResizeHandle` so the grid keeps gesture wiring.
  *
- * @param props Props from `DashboardGrid` / `ResizeHandle`.
+ * Uses `forwardRef` because the grid attaches dnd-kit's merged node ref via
+ * the JSX `ref` attribute, not as a regular prop.
  */
-export function WidgetResizeHandle( props: ResizeHandleRenderProps ) {
-	const { ref, listeners, attributes, verticalResizable, isResizing } = props;
+export const WidgetResizeHandle = forwardRef<
+	HTMLDivElement,
+	WidgetResizeHandleProps
+>( function WidgetResizeHandle(
+	{ listeners, attributes, verticalResizable, isResizing },
+	ref
+) {
 	if ( ! verticalResizable ) {
 		return (
 			<div
@@ -48,4 +57,4 @@ export function WidgetResizeHandle( props: ResizeHandleRenderProps ) {
 			{ ...attributes }
 		></div>
 	);
-}
+} );

--- a/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.tsx
+++ b/routes/dashboard/widget-dashboard/components/widgets/widget-resize-handle.tsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import type { ResizeHandleRenderProps } from '@wordpress/grid';
+
+/**
+ * Internal dependencies
+ */
+import styles from './widget-resize-handle.module.css';
+
+/**
+ * Rounded L-shaped resize affordance for the widget dashboard. Passed to
+ * `DashboardGrid` via `renderResizeHandle` so the grid keeps gesture wiring.
+ *
+ * @param props Props from `DashboardGrid` / `ResizeHandle`.
+ */
+export function WidgetResizeHandle( props: ResizeHandleRenderProps ) {
+	const { ref, listeners, attributes, verticalResizable, isResizing } = props;
+	if ( ! verticalResizable ) {
+		return (
+			<div
+				ref={ ref }
+				className={ clsx(
+					styles.handle,
+					styles.handleHorizontal,
+					isResizing && styles.resizing
+				) }
+				{ ...listeners }
+				{ ...attributes }
+			></div>
+		);
+	}
+
+	return (
+		<div
+			ref={ ref }
+			className={ clsx(
+				styles.handle,
+				styles.handleCorner,
+				isResizing && styles.resizing
+			) }
+			{ ...listeners }
+			{ ...attributes }
+		></div>
+	);
+}

--- a/routes/dashboard/widget-dashboard/components/widgets/widgets.tsx
+++ b/routes/dashboard/widget-dashboard/components/widgets/widgets.tsx
@@ -18,6 +18,7 @@ import type {
  */
 import { useDashboardInternalContext } from '../../context/dashboard-context';
 import { WidgetChrome } from '../widget-chrome';
+import { WidgetResizeHandle } from './widget-resize-handle';
 import styles from './widgets.module.css';
 import type { DashboardWidget, WidgetName } from '../../types';
 
@@ -96,6 +97,7 @@ export const Widgets = forwardRef< HTMLDivElement, WidgetsProps >(
 			editMode,
 			onChangeLayout: handleLayoutChange,
 			renderDragPreview,
+			renderResizeHandle: WidgetResizeHandle,
 		};
 
 		return (


### PR DESCRIPTION
## What

Adds a **dashboard-only resize handle** for the widget grid: new `WidgetResizeHandle` passed into `DashboardGrid` as `renderResizeHandle`, plus `widget-resize-handle.module.css`. The default `@wordpress/grid` corner triangle is unchanged for other consumers.

The handle is a **small L-shaped stroke** (logical borders on a `::after`), **inset** from the tile edge with tokens, **square** free ends, **`border-end-end-radius`** on the elbow only, a **larger invisible hit box**, and **hover / `:focus-visible` / active resize** feedback (scale, `--wpds-color-fg-interactive-brand-active`, motion tokens). **Forced-colors** uses `Highlight` on the glyph.

Part of #77626 #77616

## Why

Aligns the resize affordance with dashboard chrome (radius, spacing, brand colors), improves **target size vs visual weight**, and makes **hover / focus / drag** states clearer without changing grid behavior or APIs beyond the existing `renderResizeHandle` hook.

## How

- **`widgets.tsx`** — `renderResizeHandle={ WidgetResizeHandle }` on both `DashboardGrid` branches.
- **`widget-resize-handle.tsx`** — Implements `ResizeHandleRenderProps` (dnd-kit `ref`, `listeners`, `attributes`), branches for `verticalResizable` (corner L vs horizontal pill).
- **`widget-resize-handle.module.css`** — Hit area on the root; visual on `::after`; `--widget-resize-handle-visual-inset`, `--widget-resize-handle-hover-scale`; transitions on `transform`, border colors, and horizontal `background-color` inside `@media not ( prefers-reduced-motion )`.

## Screenshots

| Before | After |
| --- | --- |
| <img width="462" height="249" alt="Screenshot 2026-05-13 at 13 30 30" src="https://github.com/user-attachments/assets/d8904c1e-9e25-4374-96fd-94adbe71772e" /> | <img width="521" height="305" alt="Screenshot 2026-05-13 at 13 29 41" src="https://github.com/user-attachments/assets/f8571576-9282-44e7-b1fb-5873470ced6a" /> |

---



## Testing instructions

1. **Setup** — From repo root: `npm install` if needed, `npm run wp-env start` (or your usual env), then `npm start` or `npm run build` so the dashboard route picks up the new CSS/JS.

2. **Widget dashboard, edit mode** — Open the experimental widget dashboard, turn **edit mode** on, and confirm:
   - Each tile shows the **inset L** handle at the **trailing bottom** corner (and that tiles still **resize** by dragging it).

3. **Hover / focus** — Hover the handle: **scale** and **active** color should animate (if motion is allowed). Tab to a tile so the handle gets **focus-visible**: same feedback as hover where applicable.

4. **Resize drag** — Drag to resize; during the gesture the handle should stay in the **active** visual state; on release, state should return to default.

5. **Reduced motion** — OS or browser **“reduce motion”** on: inset/scale/color changes should still apply on hover/focus, but **without** (or with minimal) transition animation.

6. **RTL (optional)** — Set document/site to RTL: handle should stay on the **trailing** bottom corner and the L should still read correctly (logical `border-*` / `inset-inline-end`).

7. **Forced colors (optional)** — Windows High Contrast (or equivalent): handle should remain visible (**Highlight**).

8. **Lint (CI parity)** — `npm run lint:js` on touched TS/TSX paths if you change code again; CSS follows project conventions.