### PR TITLE
Performance Tests: log timestamps, optimize build overhead

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -481,38 +481,37 @@ async function runPerformanceTests( branches, options ) {
 
 	const wpEnvPath = path.join( testRunnerDir, 'node_modules/.bin/wp-env' );
 
-	for ( const testSuite of testSuites ) {
-		for ( let i = 1; i <= TEST_ROUNDS; i++ ) {
+	for ( let i = 1; i <= TEST_ROUNDS; i++ ) {
+		for ( const [ branchIdx, branch ] of branches.entries() ) {
 			logAtIndent(
 				1,
 				// prettier-ignore
-				`Suite: ${ formats.success( testSuite ) } (round ${ i } of ${ TEST_ROUNDS })`
+				`Branch: ${ formats.success( branch ) } (round ${ i } of ${ TEST_ROUNDS })`
 			);
 
-			for ( const [ branchIdx, branch ] of branches.entries() ) {
-				logAtIndent( 2, 'Branch:', formats.success( branch ) );
+			const sanitizedBranchName = sanitizeBranchName( branch );
+			// @ts-ignore
+			const envDir = branchDirs[ branch ];
 
-				const sanitizedBranchName = sanitizeBranchName( branch );
+			logAtIndent( 2, 'Starting environment' );
+			await runShellScript( `${ wpEnvPath } start`, envDir );
+
+			for ( const testSuite of testSuites ) {
+				logAtIndent( 2, `Suite: ${ formats.success( testSuite ) }` );
+
 				const runKey = `${ testSuite }_${ sanitizedBranchName }_round-${ i }`;
-				// @ts-ignore
-				const envDir = branchDirs[ branch ];
-
-				logAtIndent( 3, 'Starting environment' );
-				await runShellScript( `${ wpEnvPath } start`, envDir );
 
 				logAtIndent( 3, 'Running tests' );
-				// Only the head branch saves traces; comparison branches share
-				// the same artifacts directory and would otherwise overwrite.
 				await runTestSuite(
 					testSuite,
 					testRunnerDir,
 					runKey,
 					branchIdx === 0
 				);
-
-				logAtIndent( 3, 'Stopping environment' );
-				await runShellScript( `${ wpEnvPath } stop`, envDir );
 			}
+
+			logAtIndent( 2, 'Stopping environment' );
+			await runShellScript( `${ wpEnvPath } stop`, envDir );
 		}
 	}
 

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -360,7 +360,7 @@ async function runPerformanceTests( branches, options ) {
 
 	logAtIndent( 2, 'Installing dependencies and building' );
 	await runShellScript(
-		`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm ci && npx playwright install chromium --with-deps && npm run build"`,
+		`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm ci && npx playwright install chromium --with-deps"`,
 		testRunnerDir
 	);
 
@@ -403,7 +403,7 @@ async function runPerformanceTests( branches, options ) {
 
 		logAtIndent( 3, 'Installing dependencies and building' );
 		await runShellScript(
-			`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm ci && npm run build"`,
+			`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm ci && npm run build -- --skip-types"`,
 			buildDir
 		);
 

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -32,6 +32,8 @@ const RESULTS_FILE_SUFFIX = '.performance-results.json';
  * @property {string=}  wpVersion   The WordPress version to be used as the base install for testing.
  */
 
+const perfStartTime = performance.now();
+
 /**
  * A logging helper for printing steps and their substeps.
  *
@@ -40,9 +42,21 @@ const RESULTS_FILE_SUFFIX = '.performance-results.json';
  * @param {...any} args   Rest of the arguments to pass to console.log.
  */
 function logAtIndent( indent, msg, ...args ) {
+	const elapsed = performance.now() - perfStartTime;
+	const totalSeconds = Math.floor( elapsed / 100 ) / 10;
+	const minutes = Math.floor( totalSeconds / 60 );
+	const seconds = ( totalSeconds % 60 ).toFixed( 1 ).padStart( 4, '0' );
+	const timestamp = `[${ String( minutes ).padStart(
+		2,
+		'0'
+	) }:${ seconds }]`;
+
 	const prefix = indent === 0 ? '▶ ' : '> ';
 	const newline = indent === 0 ? '\n' : '';
-	return log( newline + '    '.repeat( indent ) + prefix + msg, ...args );
+	return log(
+		newline + timestamp + ' ' + '    '.repeat( indent ) + prefix + msg,
+		...args
+	);
 }
 
 /**

--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -28,11 +28,10 @@
 		"build",
 		"build-types"
 	],
-	"main": "./build/index.cjs",
 	"exports": {
 		".": {
 			"types": "./build-types/index.d.ts",
-			"default": "./build/index.cjs"
+			"default": "./src/index.ts"
 		},
 		"./package.json": "./package.json"
 	},


### PR DESCRIPTION
Running performance tests in CI takes 36 minutes. But the actual run of the perf suite (`npm run test:performance`) takes 6 minutes on my machine. That's 12 minutes of productive work for the two tested branches (`trunk` and PR). The remaining 24 minutes are overhead: checking out the repo, building, setting up the Docker containers...

I was curious about the exact breakdown and that's why this PR adds timestamps to each logged action in the performance script. Let's see where the time is spent.

After seeing the results, I did several optimizations that reduce the run time from 36 minutes to about 29:
- don't `npm run build` at all in the test runner folder. Here we only need to `npm ci`, and the actual Playwright run doesn't need any build step, it can run from the raw sources. Playwright internally uses esbuild to strip types from `.ts` files, transpile JSX when found etc. One thing I needed to do is to remove build step from the `e2e-test-utils-playwright` package. It now exports the original `.ts` files, there is no CJS version in `build`.
- when building the actual Gutenberg for the two branches, use the `--skip-types` option for `npm run build`. We just need to build the JS artifacts for the plugin. We use `--skip-types` at plenty of other places already, and this is another opportunity
- when running the test suites, don't run `wp-env start` and `wp-env stop` all the time, each of them takes about 10 seconds. Just boot the server Docker container once for each branch, run all the suites, and then shut it down. Only the test "rounds", if there are multiple, are isolated.