### PR TITLE
Block Editor: Fix Shift + Arrow selection inconsistencies for non-text blocks

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -167,11 +167,13 @@ export default function useArrowNav() {
 	const {
 		getMultiSelectedBlocksStartClientId,
 		getMultiSelectedBlocksEndClientId,
+		getSelectedBlockClientId,
+		getAdjacentBlockClientId,
 		getSettings,
 		hasMultiSelection,
 		__unstableIsFullySelected,
 	} = useSelect( blockEditorStore );
-	const { selectBlock } = useDispatch( blockEditorStore );
+	const { selectBlock, multiSelect } = useDispatch( blockEditorStore );
 	return useRefEffect( ( node ) => {
 		// Here a DOMRect is stored while moving the caret vertically so
 		// vertical position of the start position can be restored. This is to
@@ -180,15 +182,6 @@ export default function useArrowNav() {
 
 		function onMouseDown() {
 			verticalRect = null;
-		}
-
-		function isClosestTabbableABlock( target, isReverse ) {
-			const closestTabbable = getClosestTabbable(
-				target,
-				isReverse,
-				node
-			);
-			return closestTabbable && getBlockClientId( closestTabbable );
 		}
 
 		function onKeyDown( event ) {
@@ -226,6 +219,21 @@ export default function useArrowNav() {
 			// selection to the start or end of the selection.
 			if ( hasMultiSelection() ) {
 				if ( shiftKey ) {
+					if ( __unstableIsFullySelected() && isVertical ) {
+						const endId = getMultiSelectedBlocksEndClientId();
+						const adjacentClientId = getAdjacentBlockClientId(
+							endId,
+							isReverseDir ? -1 : 1
+						);
+
+						if ( adjacentClientId ) {
+							multiSelect(
+								getMultiSelectedBlocksStartClientId(),
+								adjacentClientId
+							);
+							event.preventDefault();
+						}
+					}
 					return;
 				}
 
@@ -268,55 +276,96 @@ export default function useArrowNav() {
 			// In the case of RTL scripts, right means previous and left means
 			// next, which is the exact reverse of LTR.
 			const isReverseDir = isRTL( target ) ? ! isReverse : isReverse;
-			const { keepCaretInsideBlock } = getSettings();
 
 			if ( shiftKey ) {
 				if (
-					isClosestTabbableABlock( target, isReverse ) &&
-					isNavEdge( target, isReverse )
+					( ! target.isContentEditable ||
+						__unstableIsFullySelected() ) &&
+					isVertical
 				) {
+					const clientId = getSelectedBlockClientId();
+					const adjacentClientId = getAdjacentBlockClientId(
+						clientId,
+						isReverseDir ? -1 : 1
+					);
+
+					if ( adjacentClientId ) {
+						multiSelect( clientId, adjacentClientId );
+						event.preventDefault();
+					}
+					return;
+				}
+
+				const closestTabbable = getClosestTabbable(
+					target,
+					isReverse,
+					node
+				);
+				const isClosestBlock =
+					closestTabbable && getBlockClientId( closestTabbable );
+
+				if ( isClosestBlock && isNavEdge( target, isReverse ) ) {
+					if ( closestTabbable.contentEditable !== 'true' ) {
+						const clientId = getSelectedBlockClientId();
+						const adjacentClientId = getAdjacentBlockClientId(
+							clientId,
+							isReverseDir ? -1 : 1
+						);
+
+						if ( adjacentClientId ) {
+							multiSelect( clientId, adjacentClientId );
+							event.preventDefault();
+						}
+						return;
+					}
+
 					node.contentEditable = true;
 					// Firefox doesn't automatically move focus.
 					node.focus();
 				}
-			} else if (
-				isVertical &&
-				isVerticalEdge( target, isReverse ) &&
-				// When Alt is pressed, only intercept if the caret is also at
-				// the horizontal edge.
-				( altKey ? isHorizontalEdge( target, isReverseDir ) : true ) &&
-				! keepCaretInsideBlock
-			) {
-				const closestTabbable = getClosestTabbable(
-					target,
-					isReverse,
-					node,
-					true
-				);
-
-				if ( closestTabbable ) {
-					placeCaretAtVerticalEdge(
-						closestTabbable,
-						// When Alt is pressed, place the caret at the furthest
-						// horizontal edge and the furthest vertical edge.
-						altKey ? ! isReverse : isReverse,
-						altKey ? undefined : verticalRect
+			} else {
+				const { keepCaretInsideBlock } = getSettings();
+				if (
+					isVertical &&
+					isVerticalEdge( target, isReverse ) &&
+					// When Alt is pressed, only intercept if the caret is also at
+					// the horizontal edge.
+					( altKey
+						? isHorizontalEdge( target, isReverseDir )
+						: true ) &&
+					! keepCaretInsideBlock
+				) {
+					const closestTabbable = getClosestTabbable(
+						target,
+						isReverse,
+						node,
+						true
 					);
+
+					if ( closestTabbable ) {
+						placeCaretAtVerticalEdge(
+							closestTabbable,
+							// When Alt is pressed, place the caret at the furthest
+							// horizontal edge and the furthest vertical edge.
+							altKey ? ! isReverse : isReverse,
+							altKey ? undefined : verticalRect
+						);
+						event.preventDefault();
+					}
+				} else if (
+					isHorizontal &&
+					defaultView.getSelection().isCollapsed &&
+					isHorizontalEdge( target, isReverseDir ) &&
+					! keepCaretInsideBlock
+				) {
+					const closestTabbable = getClosestTabbable(
+						target,
+						isReverseDir,
+						node
+					);
+					placeCaretAtHorizontalEdge( closestTabbable, isReverse );
 					event.preventDefault();
 				}
-			} else if (
-				isHorizontal &&
-				defaultView.getSelection().isCollapsed &&
-				isHorizontalEdge( target, isReverseDir ) &&
-				! keepCaretInsideBlock
-			) {
-				const closestTabbable = getClosestTabbable(
-					target,
-					isReverseDir,
-					node
-				);
-				placeCaretAtHorizontalEdge( closestTabbable, isReverse );
-				event.preventDefault();
 			}
 		}
 


### PR DESCRIPTION
## What?
This PR resolves two keyboard navigation bugs in the Gutenberg editor related to block selection:
1. Fixed a problem where pressing `Shift + Down` on a paragraph before a filler block chose three blocks instead of two when it should have only chosen two.
2. As of now, `Shift + Down` did not work to start multi-selection when starting from an Image block in the editing canvas. This has been fixed.

## Why?
The main reason for this was that the editor relied on the browser's built-in selection for `Shift + Arrow` actions at block edges. 
1. **Structural Skipping:** Browsers skip natively elements that do not have `contentEditable` surfaces (like Spacers or Image wrappers) when extending a text selection. This made the editor to interpret the selection range as spanning across the skipped block to the next available text node. Browsers skip natively elements that have no `contentEditable` surface (like Spacers or Image wrappers) when extending a text selection. The editor understood this range of selection as spanning the skipped block to the next available text node.

2. **Non-editable Anchor:** Starting a `Shift + Arrow` from a non-editable block wrapper (Image etc) often would not create a valid native selection range and would not do any action. Starting a `Shift + Arrow` operation from a non-editable block wrapper (like an Image) would typically fail to create a valid native selection range, resulting in no action being taken.

## How?

#### **Updated logic to :**
1. **Manual Multi-Select:** Intercept `Shift + Arrow` events when the current target is non-editable (`! target.isContentEditable`) or the block is already fully selected.
2. **Adjacency Calculation:** Use `getAdjacentBlockClientId` to manually identify the next/previous block in the store and dispatch a `multiSelect` action, effectively bypassing the unpredictable native browser selection for these specific cases.
3. **Refined Fallbacks:** Ensure that native selection is only permitted when both the source and target are editable text surfaces, preserving the ability to perform partial text selections while fixing block-level navigation.

## Testing Instructions
### Spacer Selection
1. Add a **Paragraph**, a **Spacer**, and another **Paragraph**.
2. Place the cursor at the end of the first Paragraph.
3. Press `Shift + Down`.
4. **Expected:** The first Paragraph and the Spacer are multi-selected (2 blocks total).

### Image Selection
1. Add an **Image block** followed by a **Paragraph**.
2. Click the Image block in the editor canvas to select it.
3. Press `Shift + Down`.
4. **Expected:** The Image block and the Paragraph are multi-selected.

## Screenshots or screencast

### Before Fix :

![3 blocks selected](https://github.com/WordPress/gutenberg/assets/1204802/ebacc902-7343-4824-a748-e83474302d91)

### After Fix :

https://github.com/user-attachments/assets/4a4a2ab0-a69c-4af3-8e7e-c7cd333a7706

## Use of AI Tools

For this fix, the initial technical analysis and PR docs were written using AI ( Gemini 3.1 Pro ).