### PR TITLE
RTC: fix 9 cursor bugs that can occur in various corner case scenarios

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -219,35 +219,66 @@ export default function useSelectionObserver() {
 						// (e.g. the user started dragging from the block
 						// wrapper padding), dispatch a full
 						// selectionChange so the format toolbar appears.
-						const richTextElement =
+						// If it spans multiple RichText fields in the same
+						// block, preserve each endpoint's attribute key.
+						const richTextElementStart =
 							! selection.isCollapsed &&
-							( getRichTextElement( startNode ) ||
-								getRichTextElement( endNode ) );
+							getRichTextElement( startNode );
+						const richTextElementEnd =
+							! selection.isCollapsed &&
+							getRichTextElement( endNode );
+						const richTextElement =
+							richTextElementStart || richTextElementEnd;
+						const hasMultipleRichTextElements =
+							richTextElementStart &&
+							richTextElementEnd &&
+							richTextElementStart !== richTextElementEnd;
 
 						if (
 							richTextElement &&
-							ownerDocument.activeElement !== richTextElement
+							( hasMultipleRichTextElements ||
+								ownerDocument.activeElement !==
+									richTextElement )
 						) {
 							const range = selection.getRangeAt( 0 );
-							const richTextData = create( {
-								element: richTextElement,
+							const startElement =
+								richTextElementStart || richTextElement;
+							const endElement =
+								richTextElementEnd || richTextElement;
+							const richTextDataStart = create( {
+								element: startElement,
 								range,
 								__unstableIsEditableTree: true,
 							} );
+							const richTextDataEnd =
+								startElement === endElement
+									? richTextDataStart
+									: create( {
+											element: endElement,
+											range,
+											__unstableIsEditableTree: true,
+									  } );
 							selectionChange( {
 								start: {
 									clientId: startClientId,
 									attributeKey:
-										richTextElement.dataset
+										startElement.dataset
 											.wpBlockAttributeKey,
-									offset: richTextData.start ?? 0,
+									offset: hasMultipleRichTextElements
+										? richTextDataStart.start ??
+										  richTextDataStart.end ??
+										  0
+										: richTextDataStart.start ?? 0,
 								},
 								end: {
 									clientId: startClientId,
 									attributeKey:
-										richTextElement.dataset
-											.wpBlockAttributeKey,
-									offset: richTextData.end,
+										endElement.dataset.wpBlockAttributeKey,
+									offset: hasMultipleRichTextElements
+										? richTextDataEnd.end ??
+										  richTextDataEnd.start ??
+										  0
+										: richTextDataEnd.end,
 								},
 							} );
 						} else {

--- a/packages/core-data/src/awareness/block-lookup.ts
+++ b/packages/core-data/src/awareness/block-lookup.ts
@@ -41,12 +41,7 @@ export function getContainingBlockYMap(
 	while ( current ) {
 		const parent = current.parent;
 
-		if (
-			parent instanceof Y.Map &&
-			parent.parent instanceof Y.Array &&
-			parent.get( 'clientId' ) !== undefined &&
-			parent.get( 'innerBlocks' ) instanceof Y.Array
-		) {
+		if ( parent instanceof Y.Map && getBlockPathInYdoc( parent ) ) {
 			return parent;
 		}
 
@@ -93,19 +88,27 @@ export function getBlockPathInYdoc(
 
 		path.unshift( index );
 
-		// Walk up: is the parent array's parent a block Y.Map or the root?
-		const grandparent = parentArray.parent;
-		if (
-			grandparent instanceof Y.Map &&
-			grandparent.get( 'clientId' ) !== undefined
-		) {
-			current = grandparent; // It's a block, keep going.
-		} else {
-			break; // It's the root map, done.
+		const owner = parentArray.parent;
+		if ( ! ( owner instanceof Y.Map ) ) {
+			return null;
 		}
+
+		if ( ! owner.parent && owner.get( 'blocks' ) === parentArray ) {
+			return path;
+		}
+
+		if (
+			owner.get( 'innerBlocks' ) === parentArray &&
+			owner.get( 'clientId' ) !== undefined
+		) {
+			current = owner;
+			continue;
+		}
+
+		return null;
 	}
 
-	return path;
+	return null;
 }
 
 /**

--- a/packages/core-data/src/awareness/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/post-editor-awareness.ts
@@ -22,6 +22,8 @@ import {
 import { STORE_NAME as coreStore } from '../name';
 import {
 	asHtmlStringIndex,
+	getAttributeKeyForYText,
+	getYTextByAttributeKey,
 	htmlIndexToRichTextOffset,
 } from '../utils/crdt-utils';
 import {
@@ -307,6 +309,36 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 		const yType = getContainingBlockYMap( absolutePosition.type );
 		const path = yType ? getBlockPathInYdoc( yType ) : null;
 		const localClientId = path ? resolveBlockClientIdByPath( path ) : null;
+		const attributes = yType?.get( 'attributes' );
+		let attributeKey: string | null = null;
+
+		if (
+			attributes instanceof Y.Map &&
+			absolutePosition.type instanceof Y.Text
+		) {
+			attributeKey = getAttributeKeyForYText(
+				attributes,
+				absolutePosition.type
+			);
+
+			const senderAttributeKey = cursorPos.attributeKey;
+			if (
+				! attributeKey &&
+				senderAttributeKey &&
+				getYTextByAttributeKey( attributes, senderAttributeKey ) ===
+					absolutePosition.type
+			) {
+				attributeKey = senderAttributeKey;
+			}
+		}
+
+		if ( ! localClientId || ! attributeKey ) {
+			return {
+				richTextOffset: null,
+				localClientId: null,
+				attributeKey: null,
+			};
+		}
 
 		return {
 			richTextOffset: htmlIndexToRichTextOffset(
@@ -314,7 +346,7 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 				asHtmlStringIndex( absolutePosition.index )
 			),
 			localClientId,
-			attributeKey: cursorPos.attributeKey ?? null,
+			attributeKey,
 		};
 	}
 

--- a/packages/core-data/src/awareness/test/block-lookup.ts
+++ b/packages/core-data/src/awareness/test/block-lookup.ts
@@ -310,6 +310,28 @@ describe( 'getContainingBlockYMap', () => {
 
 		expect( getContainingBlockYMap( text ) ).toBe( block );
 	} );
+
+	it( 'should skip block-shaped nested array items that look like blocks', () => {
+		const block = createTestYBlock( 'block' );
+		const attributes = new Y.Map< any >();
+		const cards = new Y.Array< Y.Map< any > >();
+		const blockLikeCard = new Y.Map< any >();
+		const text = new Y.Text( 'Nested card text' );
+		blockLikeCard.set( 'clientId', 'attribute-card-client-id' );
+		blockLikeCard.set( 'innerBlocks', new Y.Array() );
+		blockLikeCard.set( 'content', text );
+		cards.push( [ blockLikeCard ] );
+		attributes.set( 'cards', cards );
+		block.set( 'attributes', attributes );
+
+		const ydoc = new Y.Doc();
+		const rootMap = ydoc.getMap( 'test' );
+		const blocks = new Y.Array< Y.Map< any > >();
+		rootMap.set( 'blocks', blocks );
+		blocks.push( [ block ] );
+
+		expect( getContainingBlockYMap( text ) ).toBe( block );
+	} );
 } );
 
 describe( 'resolveBlockClientIdByPath', () => {

--- a/packages/core-data/src/awareness/test/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/test/post-editor-awareness.ts
@@ -707,7 +707,7 @@ describe( 'PostEditorAwareness', () => {
 			expect( result.attributeKey ).toBeNull();
 		} );
 
-		test( 'should pass through nested attributeKey for a cursor selection', () => {
+		test( 'should derive the current attributeKey for a cursor selection', () => {
 			const awareness = new PostEditorAwareness(
 				doc,
 				'postType',
@@ -740,7 +740,7 @@ describe( 'PostEditorAwareness', () => {
 			const result =
 				awareness.convertSelectionStateToAbsolute( selection );
 
-			expect( result.attributeKey ).toBe( 'body.0.cells.0.content' );
+			expect( result.attributeKey ).toBe( 'content' );
 		} );
 	} );
 
@@ -1242,6 +1242,74 @@ describe( 'PostEditorAwareness', () => {
 				nestedDoc.destroy();
 			}
 		);
+
+		test( 'resolves block-shaped nested array item rich text to the containing block', () => {
+			const paragraph = createYBlock( 'yjs-paragraph', 'core/paragraph', {
+				textContent: 'Root paragraph before card block',
+			} );
+			const cardBlock = new Y.Map();
+			cardBlock.set( 'clientId', 'yjs-card-list' );
+			cardBlock.set( 'name', 'test/card-list' );
+
+			const attrs = new Y.Map();
+			const cards = new Y.Array();
+			const card = new Y.Map();
+			const cardContent = new Y.Text( 'Nested card cursor target' );
+			card.set( 'clientId', 'attribute-card-0' );
+			card.set( 'innerBlocks', new Y.Array() );
+			card.set( 'content', cardContent );
+			cards.push( [ card ] );
+			attrs.set( 'cards', cards );
+			cardBlock.set( 'attributes', attrs );
+			cardBlock.set( 'innerBlocks', new Y.Array() );
+
+			const nestedDoc = createTestDocWithBlocks( [
+				paragraph,
+				cardBlock,
+			] );
+
+			mockBlockEditorStore( {
+				blocks: [
+					{
+						clientId: 'local-paragraph',
+						innerBlocks: [],
+					},
+					{
+						clientId: 'local-card-list',
+						innerBlocks: [],
+					},
+				],
+			} );
+
+			const initialOffset = 6;
+			const relativePosition = Y.createRelativePositionFromTypeIndex(
+				cardContent,
+				initialOffset
+			);
+			const awareness = new PostEditorAwareness(
+				nestedDoc,
+				'postType',
+				'post',
+				123
+			);
+			const selection: SelectionCursor = {
+				type: SelectionType.Cursor,
+				cursorPosition: {
+					relativePosition,
+					absoluteOffset: initialOffset,
+					attributeKey: 'cards.0.content',
+				},
+			};
+
+			const result =
+				awareness.convertSelectionStateToAbsolute( selection );
+
+			expect( result.richTextOffset ).toBe( initialOffset );
+			expect( result.localClientId ).toBe( 'local-card-list' );
+			expect( result.attributeKey ).toBe( 'cards.0.content' );
+
+			nestedDoc.destroy();
+		} );
 	} );
 
 	describe( 'template mode (core/post-content handling)', () => {

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -737,7 +737,7 @@ function mergeYArray(
 				newElement,
 				query,
 				cursorPosition,
-				cursorScope
+				appendCursorScopeKey( cursorScope, ( left + i ).toString() )
 			);
 		} else {
 			// Element is the wrong type (e.g. partial migration) or the
@@ -874,7 +874,7 @@ function mergeYMapValues(
 			yMap,
 			key,
 			cursorPosition,
-			cursorScope
+			appendCursorScopeKey( cursorScope, key )
 		);
 	}
 
@@ -937,6 +937,16 @@ function updateYBlockAttribute(
 interface RichTextCursorScope {
 	attributeKey: string;
 	clientId: string | undefined;
+}
+
+function appendCursorScopeKey(
+	cursorScope: RichTextCursorScope,
+	key: string
+): RichTextCursorScope {
+	return {
+		...cursorScope,
+		attributeKey: `${ cursorScope.attributeKey }.${ key }`,
+	};
 }
 
 interface DeltaWithOps {

--- a/packages/core-data/src/utils/crdt-selection.ts
+++ b/packages/core-data/src/utils/crdt-selection.ts
@@ -20,6 +20,8 @@ import {
 import {
 	asHtmlStringIndex,
 	findBlockByClientIdInDoc,
+	getAttributeKeyForYText,
+	getYTextByAttributeKey,
 	htmlIndexToRichTextOffset,
 } from './crdt-utils';
 import type { WPBlockSelection, WPSelection } from '../types';
@@ -67,16 +69,33 @@ function convertYSelectionToBlockSelection(
 ): WPBlockSelection | null {
 	if ( ySelection.type === YSelectionType.RelativeSelection ) {
 		const { relativePosition, attributeKey, clientId } = ySelection;
+		const block = findBlockByClientIdInDoc( clientId, ydoc );
+		const attributes = block?.get( 'attributes' );
 
 		const absolutePosition = Y.createAbsolutePositionFromRelativePosition(
 			relativePosition,
 			ydoc
 		);
 
-		if ( absolutePosition ) {
+		if (
+			absolutePosition &&
+			attributes instanceof Y.Map &&
+			absolutePosition.type instanceof Y.Text
+		) {
+			const currentAttributeKey =
+				getAttributeKeyForYText( attributes, absolutePosition.type ) ??
+				( getYTextByAttributeKey( attributes, attributeKey ) ===
+				absolutePosition.type
+					? attributeKey
+					: null );
+
+			if ( ! currentAttributeKey ) {
+				return null;
+			}
+
 			return {
 				clientId,
-				attributeKey,
+				attributeKey: currentAttributeKey,
 				offset: htmlIndexToRichTextOffset(
 					absolutePosition.type.toString(),
 					asHtmlStringIndex( absolutePosition.index )

--- a/packages/core-data/src/utils/crdt-user-selections.ts
+++ b/packages/core-data/src/utils/crdt-user-selections.ts
@@ -385,6 +385,10 @@ function areCursorPositionsEqual(
 	// This is necessary because Y.Text relative positions can remain the same after text changes.
 	const isAbsoluteOffsetEqual =
 		cursorPosition1.absoluteOffset === cursorPosition2.absoluteOffset;
+	const isAttributeKeyEqual =
+		cursorPosition1.attributeKey === cursorPosition2.attributeKey;
 
-	return isRelativePositionEqual && isAbsoluteOffsetEqual;
+	return (
+		isRelativePositionEqual && isAbsoluteOffsetEqual && isAttributeKeyEqual
+	);
 }

--- a/packages/core-data/src/utils/crdt-utils.ts
+++ b/packages/core-data/src/utils/crdt-utils.ts
@@ -167,6 +167,83 @@ export function getYTextByAttributeKey(
 }
 
 /**
+ * Resolve the current RichText attribute key for a Y.Text by walking the
+ * block attributes tree. Direct top-level keys are checked first to preserve
+ * the lookup semantics of getYTextByAttributeKey for keys that contain dots.
+ *
+ * @param attributes The block attributes map.
+ * @param yText      The Y.Text to locate.
+ * @return The current attribute key, or null when no representable key exists.
+ */
+export function getAttributeKeyForYText(
+	attributes: Y.Map< unknown >,
+	yText: Y.Text
+): string | null {
+	for ( const key of attributes.keys() ) {
+		if ( attributes.get( key ) === yText ) {
+			return key;
+		}
+	}
+
+	for ( const key of attributes.keys() ) {
+		if ( key.includes( '.' ) ) {
+			continue;
+		}
+
+		const path = findYTextPath( attributes.get( key ), yText, [ key ] );
+		if ( path ) {
+			return path.join( '.' );
+		}
+	}
+
+	return null;
+}
+
+function findYTextPath(
+	value: unknown,
+	yText: Y.Text,
+	path: string[]
+): string[] | null {
+	if ( value === yText ) {
+		return path;
+	}
+
+	if ( value instanceof Y.Text ) {
+		return null;
+	}
+
+	if ( value instanceof Y.Map ) {
+		for ( const key of value.keys() ) {
+			if ( key.includes( '.' ) ) {
+				continue;
+			}
+
+			const nestedPath = findYTextPath( value.get( key ), yText, [
+				...path,
+				key,
+			] );
+			if ( nestedPath ) {
+				return nestedPath;
+			}
+		}
+	}
+
+	if ( value instanceof Y.Array ) {
+		for ( let index = 0; index < value.length; index++ ) {
+			const nestedPath = findYTextPath( value.get( index ), yText, [
+				...path,
+				index.toString(),
+			] );
+			if ( nestedPath ) {
+				return nestedPath;
+			}
+		}
+	}
+
+	return null;
+}
+
+/**
  * Given a block ID and a Y.Doc, find the block in the document.
  *
  * @param blockId The block ID to find

--- a/packages/core-data/src/utils/test/crdt-utils.ts
+++ b/packages/core-data/src/utils/test/crdt-utils.ts
@@ -10,6 +10,7 @@ import { Y } from '@wordpress/sync';
 import {
 	asHtmlStringIndex,
 	asRichTextOffset,
+	getAttributeKeyForYText,
 	getYTextByAttributeKey,
 	htmlIndexToRichTextOffset as typedHtmlIndexToRichTextOffset,
 	richTextOffsetToHtmlIndex as typedRichTextOffsetToHtmlIndex,
@@ -76,6 +77,53 @@ describe( 'getYTextByAttributeKey', () => {
 		expect(
 			getYTextByAttributeKey( attributes, 'body.-1.cells.0.content' )
 		).toBeNull();
+	} );
+} );
+
+describe( 'getAttributeKeyForYText', () => {
+	it( 'returns a top-level rich-text attribute key', () => {
+		const attributes = createAttachedAttributes();
+		const text = new Y.Text( 'Top level' );
+		attributes.set( 'content', text );
+
+		expect( getAttributeKeyForYText( attributes, text ) ).toBe( 'content' );
+	} );
+
+	it( 'returns the current nested path after an array insertion', () => {
+		const attributes = createAttachedAttributes();
+		const body = new Y.Array< Y.Map< unknown > >();
+		const firstRow = new Y.Map< unknown >();
+		const insertedRow = new Y.Map< unknown >();
+		const cells = new Y.Array< Y.Map< unknown > >();
+		const cell = new Y.Map< unknown >();
+		const text = new Y.Text( 'Cell text' );
+
+		cell.set( 'content', text );
+		cells.push( [ cell ] );
+		firstRow.set( 'cells', cells );
+		body.push( [ firstRow ] );
+		attributes.set( 'body', body );
+
+		expect( getAttributeKeyForYText( attributes, text ) ).toBe(
+			'body.0.cells.0.content'
+		);
+
+		insertedRow.set( 'cells', new Y.Array() );
+		body.insert( 0, [ insertedRow ] );
+
+		expect( getAttributeKeyForYText( attributes, text ) ).toBe(
+			'body.1.cells.0.content'
+		);
+	} );
+
+	it( 'prefers direct top-level keys that contain dots', () => {
+		const attributes = createAttachedAttributes();
+		const text = new Y.Text( 'Direct dotted key' );
+		attributes.set( 'body.0.content', text );
+
+		expect( getAttributeKeyForYText( attributes, text ) ).toBe(
+			'body.0.content'
+		);
 	} );
 } );
 

--- a/packages/editor/src/components/collaborators-overlay/compute-selection.ts
+++ b/packages/editor/src/components/collaborators-overlay/compute-selection.ts
@@ -41,8 +41,8 @@ export interface SelectionVisual {
  * Resolve the most specific editor element the selection refers to.
  *
  * When the sender carries an `attributeKey`, narrow to the RichText element
- * matching `data-wp-block-attribute-key` inside the block. This is what makes
- * cursor placement work for blocks with multiple RichText fields (e.g.
+ * matching `data-wp-block-attribute-key` on or inside the block. This is what
+ * makes cursor placement work for blocks with multiple RichText fields (e.g.
  * `core/table` cells: `body.0.cells.0.content`, etc.). Falls back to the
  * block element only when `attributeKey` is missing (WholeBlock selections
  * or older senders). Keyed selections must resolve to the exact RichText
@@ -70,6 +70,13 @@ function resolveTargetElement(
 
 	if ( ! blockElement || ! resolvedSelection.attributeKey ) {
 		return blockElement ?? null;
+	}
+
+	if (
+		blockElement.getAttribute( 'data-wp-block-attribute-key' ) ===
+		resolvedSelection.attributeKey
+	) {
+		return blockElement;
 	}
 
 	return (

--- a/packages/editor/src/components/collaborators-overlay/compute-selection.ts
+++ b/packages/editor/src/components/collaborators-overlay/compute-selection.ts
@@ -19,7 +19,8 @@ interface OverlayContext {
 /** Selection rects and the resolved block element for a single-block selection. */
 interface SingleBlockResult {
 	rects: SelectionRect[];
-	blockElement: HTMLElement | null;
+	startElement: HTMLElement | null;
+	endElement: HTMLElement | null;
 }
 
 /** Selection rects and the resolved block elements for a multi-block selection. */
@@ -43,8 +44,9 @@ export interface SelectionVisual {
  * matching `data-wp-block-attribute-key` inside the block. This is what makes
  * cursor placement work for blocks with multiple RichText fields (e.g.
  * `core/table` cells: `body.0.cells.0.content`, etc.). Falls back to the
- * block element when `attributeKey` is missing (WholeBlock selections,
- * older senders, or DOM lookup miss).
+ * block element only when `attributeKey` is missing (WholeBlock selections
+ * or older senders). Keyed selections must resolve to the exact RichText
+ * target because their offsets are local to that target.
  *
  * @param editorDocument    - The editor document.
  * @param resolvedSelection - The resolved selection.
@@ -58,19 +60,29 @@ function resolveTargetElement(
 		return null;
 	}
 
-	const blockElement = editorDocument.querySelector< HTMLElement >(
-		`[data-block="${ resolvedSelection.localClientId }"]`
+	const blockElement = Array.from(
+		editorDocument.querySelectorAll< HTMLElement >( '[data-block]' )
+	).find(
+		( element ) =>
+			element.getAttribute( 'data-block' ) ===
+			resolvedSelection.localClientId
 	);
 
 	if ( ! blockElement || ! resolvedSelection.attributeKey ) {
-		return blockElement;
+		return blockElement ?? null;
 	}
 
-	const attrKey = CSS.escape( resolvedSelection.attributeKey );
 	return (
-		blockElement.querySelector< HTMLElement >(
-			`[data-wp-block-attribute-key="${ attrKey }"]`
-		) ?? blockElement
+		Array.from(
+			blockElement.querySelectorAll< HTMLElement >(
+				'[data-wp-block-attribute-key]'
+			)
+		).find(
+			( element ) =>
+				element.getAttribute( 'data-wp-block-attribute-key' ) ===
+					resolvedSelection.attributeKey &&
+				element.closest( '[data-block]' ) === blockElement
+		) ?? null
 	);
 }
 
@@ -118,13 +130,17 @@ function computeCursorOnly(
 	start: ResolvedSelection,
 	overlayContext: OverlayContext
 ): SelectionVisual {
-	if ( ! start.localClientId ) {
+	if ( ! start.localClientId || start.richTextOffset === null ) {
 		return {};
 	}
 	const targetElement = resolveTargetElement(
 		overlayContext.editorDocument,
 		start
 	);
+	if ( ! targetElement ) {
+		return {};
+	}
+
 	return {
 		coords: getCursorPosition(
 			start.richTextOffset,
@@ -170,8 +186,7 @@ function computeTextSelection(
 	if ( selection.type === SelectionType.SelectionInOneBlock ) {
 		const result = computeSingleBlockRects( start, end, overlayContext );
 		allRects = result.rects;
-		// Single block: start and end share the same block element.
-		activeEndBlock = result.blockElement;
+		activeEndBlock = isReverse ? result.startElement : result.endElement;
 	} else {
 		const result = computeMultiBlockRects( start, end, overlayContext );
 		allRects = result.rects;
@@ -199,6 +214,9 @@ function computeTextSelection(
 		overlayContext.editorDocument,
 		start
 	);
+	if ( ! startBlock ) {
+		return {};
+	}
 
 	return {
 		coords: getCursorPosition(
@@ -223,28 +241,117 @@ function computeSingleBlockRects(
 	end: ResolvedSelection,
 	overlayContext: OverlayContext
 ): SingleBlockResult {
-	const blockElement = resolveTargetElement(
+	const startElement = resolveTargetElement(
 		overlayContext.editorDocument,
 		start
 	);
+	const endElement = resolveTargetElement(
+		overlayContext.editorDocument,
+		end
+	);
 	if (
-		! blockElement ||
+		! startElement ||
+		! endElement ||
 		start.richTextOffset === null ||
 		end.richTextOffset === null
 	) {
-		return { rects: [], blockElement: null };
+		return { rects: [], startElement: null, endElement: null };
 	}
+
+	if ( startElement === endElement ) {
+		return {
+			rects:
+				getSelectionRects(
+					startElement,
+					start.richTextOffset,
+					end.richTextOffset,
+					overlayContext.editorDocument,
+					overlayContext.overlayRect
+				) ?? [],
+			startElement,
+			endElement,
+		};
+	}
+
+	const startIsAfterEnd = isNodeBefore( endElement, startElement );
+	const firstElement = startIsAfterEnd ? endElement : startElement;
+	const lastElement = startIsAfterEnd ? startElement : endElement;
+	const firstOffset = startIsAfterEnd
+		? end.richTextOffset
+		: start.richTextOffset;
+	const lastOffset = startIsAfterEnd
+		? start.richTextOffset
+		: end.richTextOffset;
+	const allRects: SelectionRect[] = [];
+	const firstRects = getSelectionRects(
+		firstElement,
+		firstOffset,
+		Number.MAX_SAFE_INTEGER,
+		overlayContext.editorDocument,
+		overlayContext.overlayRect
+	);
+	if ( firstRects ) {
+		allRects.push( ...firstRects );
+	}
+
+	for ( const intermediateElement of getRichTextElementsBetween(
+		firstElement,
+		lastElement
+	) ) {
+		const intermediateRects = getSelectionRects(
+			intermediateElement,
+			0,
+			Number.MAX_SAFE_INTEGER,
+			overlayContext.editorDocument,
+			overlayContext.overlayRect
+		);
+		if ( intermediateRects ) {
+			allRects.push( ...intermediateRects );
+		}
+	}
+
+	const lastRects = getSelectionRects(
+		lastElement,
+		0,
+		lastOffset,
+		overlayContext.editorDocument,
+		overlayContext.overlayRect
+	);
+	if ( lastRects ) {
+		allRects.push( ...lastRects );
+	}
+
 	return {
-		rects:
-			getSelectionRects(
-				blockElement,
-				start.richTextOffset,
-				end.richTextOffset,
-				overlayContext.editorDocument,
-				overlayContext.overlayRect
-			) ?? [],
-		blockElement,
+		rects: allRects,
+		startElement,
+		endElement,
 	};
+}
+
+function getRichTextElementsBetween(
+	firstElement: HTMLElement,
+	lastElement: HTMLElement
+): HTMLElement[] {
+	const blockElement = firstElement.closest( '[data-block]' );
+	if (
+		! blockElement ||
+		blockElement !== lastElement.closest( '[data-block]' )
+	) {
+		return [];
+	}
+
+	return Array.from(
+		blockElement.querySelectorAll< HTMLElement >(
+			'[data-wp-block-attribute-key]'
+		)
+	).filter(
+		( element ) =>
+			element !== firstElement &&
+			element !== lastElement &&
+			element.closest( '[data-block]' ) === blockElement &&
+			isNodeBefore( firstElement, element ) &&
+			isNodeBefore( element, lastElement )
+	);
 }
 
 /**

--- a/packages/editor/src/components/collaborators-overlay/test/compute-selection.ts
+++ b/packages/editor/src/components/collaborators-overlay/test/compute-selection.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { computeSelectionVisual } from '../compute-selection';
-import { getCursorPosition } from '../cursor-dom-utils';
+import { getCursorPosition, getSelectionRects } from '../cursor-dom-utils';
 
 jest.mock( '@wordpress/core-data', () => ( {
 	SelectionDirection: {
@@ -31,8 +31,10 @@ jest.mock( '../cursor-dom-utils', () => ( {
 } ) );
 
 const mockGetCursorPosition = getCursorPosition as jest.Mock;
+const mockGetSelectionRects = getSelectionRects as jest.Mock;
 const SelectionType = {
 	Cursor: 'cursor',
+	SelectionInOneBlock: 'selection-in-one-block',
 } as const;
 
 type ResolvedSelection = {
@@ -72,6 +74,7 @@ describe( 'computeSelectionVisual', () => {
 
 	beforeEach( () => {
 		mockGetCursorPosition.mockClear();
+		mockGetSelectionRects.mockClear();
 	} );
 
 	it( 'anchors cursor selections to the matching nested RichText element', () => {
@@ -129,5 +132,67 @@ describe( 'computeSelectionVisual', () => {
 
 		expect( result.coords ).toBeUndefined();
 		expect( mockGetCursorPosition ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders a same-block selection across different nested RichText elements', () => {
+		const overlayContext = createOverlayContext(
+			'<div data-block="block-1">' +
+				'<div data-wp-block-attribute-key="body.0.cells.1.content">Beta start text</div>' +
+				'<div data-wp-block-attribute-key="body.1.cells.1.content">Delta end text</div>' +
+				'</div>'
+		);
+		const startElement = document.querySelector(
+			'[data-wp-block-attribute-key="body.0.cells.1.content"]'
+		);
+		const endElement = document.querySelector(
+			'[data-wp-block-attribute-key="body.1.cells.1.content"]'
+		);
+		const startRect = { x: 10, y: 10, width: 30, height: 12 };
+		const endRect = { x: 10, y: 40, width: 30, height: 12 };
+		mockGetSelectionRects
+			.mockReturnValueOnce( [ startRect ] )
+			.mockReturnValueOnce( [ endRect ] );
+
+		const start: ResolvedSelection = {
+			richTextOffset: 4,
+			localClientId: 'block-1',
+			attributeKey: 'body.0.cells.1.content',
+		};
+		const end: ResolvedSelection = {
+			richTextOffset: 8,
+			localClientId: 'block-1',
+			attributeKey: 'body.1.cells.1.content',
+		};
+
+		const result = computeSelectionVisual(
+			{ type: SelectionType.SelectionInOneBlock },
+			start,
+			end,
+			overlayContext
+		);
+
+		expect( mockGetSelectionRects ).toHaveBeenNthCalledWith(
+			1,
+			startElement,
+			4,
+			Number.MAX_SAFE_INTEGER,
+			document,
+			overlayContext.overlayRect
+		);
+		expect( mockGetSelectionRects ).toHaveBeenNthCalledWith(
+			2,
+			endElement,
+			0,
+			8,
+			document,
+			overlayContext.overlayRect
+		);
+		expect( mockGetCursorPosition ).toHaveBeenCalledWith(
+			8,
+			endElement,
+			document,
+			overlayContext.overlayRect
+		);
+		expect( result.selectionRects ).toEqual( [ startRect, endRect ] );
 	} );
 } );

--- a/packages/editor/src/components/collaborators-overlay/test/compute-selection.ts
+++ b/packages/editor/src/components/collaborators-overlay/test/compute-selection.ts
@@ -110,6 +110,36 @@ describe( 'computeSelectionVisual', () => {
 		);
 	} );
 
+	it( 'anchors keyed cursor selections to the block element when it is the RichText element', () => {
+		const overlayContext = createOverlayContext(
+			'<p data-block="block-1" data-wp-block-attribute-key="content">Alpha</p>'
+		);
+
+		const start: ResolvedSelection = {
+			richTextOffset: 2,
+			localClientId: 'block-1',
+			attributeKey: 'content',
+		};
+
+		computeSelectionVisual(
+			{ type: SelectionType.Cursor },
+			start,
+			undefined,
+			overlayContext
+		);
+
+		const targetElement = document.querySelector(
+			'[data-block="block-1"]'
+		);
+
+		expect( mockGetCursorPosition ).toHaveBeenCalledWith(
+			2,
+			targetElement,
+			document,
+			overlayContext.overlayRect
+		);
+	} );
+
 	it( 'does not fall back to the whole block for a missing keyed RichText target', () => {
 		const overlayContext = createOverlayContext(
 			'<div data-block="block-1">' +

--- a/packages/editor/src/components/collaborators-overlay/test/compute-selection.ts
+++ b/packages/editor/src/components/collaborators-overlay/test/compute-selection.ts
@@ -1,0 +1,133 @@
+/**
+ * Internal dependencies
+ */
+import { computeSelectionVisual } from '../compute-selection';
+import { getCursorPosition } from '../cursor-dom-utils';
+
+jest.mock( '@wordpress/core-data', () => ( {
+	SelectionDirection: {
+		Backward: 'backward',
+		Forward: 'forward',
+	},
+	SelectionType: {
+		None: 'none',
+		Cursor: 'cursor',
+		SelectionInOneBlock: 'selection-in-one-block',
+		SelectionInMultipleBlocks: 'selection-in-multiple-blocks',
+		WholeBlock: 'whole-block',
+	},
+} ) );
+
+jest.mock( '../cursor-dom-utils', () => ( {
+	getCursorPosition: jest.fn( () => ( {
+		x: 10,
+		y: 20,
+		height: 30,
+	} ) ),
+	getSelectionRects: jest.fn( () => [] ),
+	getFullBlockSelectionRects: jest.fn( () => [] ),
+	getBlocksBetween: jest.fn( () => [] ),
+	isNodeBefore: jest.fn( () => false ),
+} ) );
+
+const mockGetCursorPosition = getCursorPosition as jest.Mock;
+const SelectionType = {
+	Cursor: 'cursor',
+} as const;
+
+type ResolvedSelection = {
+	richTextOffset: number | null;
+	localClientId: string | null;
+	attributeKey: string | null;
+};
+
+function createOverlayContext( bodyHtml: string ) {
+	document.body.innerHTML = bodyHtml;
+
+	return {
+		editorDocument: document,
+		overlayRect: {
+			left: 0,
+			top: 0,
+			right: 100,
+			bottom: 100,
+			width: 100,
+			height: 100,
+			x: 0,
+			y: 0,
+			toJSON: () => ( {} ),
+		} as DOMRect,
+	};
+}
+
+describe( 'computeSelectionVisual', () => {
+	beforeAll( () => {
+		Object.defineProperty( globalThis, 'CSS', {
+			configurable: true,
+			value: {
+				escape: ( value: string ) => value,
+			},
+		} );
+	} );
+
+	beforeEach( () => {
+		mockGetCursorPosition.mockClear();
+	} );
+
+	it( 'anchors cursor selections to the matching nested RichText element', () => {
+		const overlayContext = createOverlayContext(
+			'<div data-block="block-1">' +
+				'<div data-wp-block-attribute-key="body.0.cells.0.content">Alpha</div>' +
+				'<div data-wp-block-attribute-key="body.0.cells.1.content">Beta</div>' +
+				'</div>'
+		);
+
+		const start: ResolvedSelection = {
+			richTextOffset: 2,
+			localClientId: 'block-1',
+			attributeKey: 'body.0.cells.1.content',
+		};
+
+		computeSelectionVisual(
+			{ type: SelectionType.Cursor },
+			start,
+			undefined,
+			overlayContext
+		);
+
+		const targetElement = document.querySelector(
+			'[data-wp-block-attribute-key="body.0.cells.1.content"]'
+		);
+
+		expect( mockGetCursorPosition ).toHaveBeenCalledWith(
+			2,
+			targetElement,
+			document,
+			overlayContext.overlayRect
+		);
+	} );
+
+	it( 'does not fall back to the whole block for a missing keyed RichText target', () => {
+		const overlayContext = createOverlayContext(
+			'<div data-block="block-1">' +
+				'<div data-wp-block-attribute-key="body.0.cells.0.content">Alpha</div>' +
+				'</div>'
+		);
+
+		const start: ResolvedSelection = {
+			richTextOffset: 2,
+			localClientId: 'block-1',
+			attributeKey: 'body.1.cells.0.content',
+		};
+
+		const result = computeSelectionVisual(
+			{ type: SelectionType.Cursor },
+			start,
+			undefined,
+			overlayContext
+		);
+
+		expect( result.coords ).toBeUndefined();
+		expect( mockGetCursorPosition ).not.toHaveBeenCalled();
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
@@ -174,7 +174,7 @@ async function selectAcrossCells( {
 			const ownerDocument = startElement.ownerDocument;
 			// Build the native range directly; table RichText mouse drags are
 			// geometry-dependent in headless browsers.
-			const getTextNode = ( element, last = false ) => {
+			const getTextNode = ( element: Element, last = false ) => {
 				const walker = ownerDocument.createTreeWalker(
 					element,
 					NodeFilter.SHOW_TEXT
@@ -398,6 +398,7 @@ test.describe( 'Collaboration - Nested Awareness Selection', () => {
 		collaborationUtils,
 		requestUtils,
 		editor,
+		page,
 	} ) => {
 		const post = await requestUtils.createPost( {
 			title: 'Nested Awareness Selection Cross Cell Native Selection Test',

--- a/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
@@ -15,6 +15,13 @@ const TWO_ROW_TABLE_CONTENT =
 	'</tbody></table></figure>\n' +
 	'<!-- /wp:table -->';
 
+const TABLE_WITH_CAPTION_CONTENT =
+	'<!-- wp:table -->\n' +
+	'<figure class="wp-block-table"><table><tbody>' +
+	'<tr><td>Alpha</td><td>Beta</td></tr>' +
+	'</tbody></table><figcaption class="wp-element-caption">Caption target</figcaption></figure>\n' +
+	'<!-- /wp:table -->';
+
 async function expectTableBlockLoaded(
 	collaborationUtils: CollaborationUtils
 ) {
@@ -37,6 +44,16 @@ async function getBodyCellTexts( editor: Editor ) {
 		);
 }
 
+function getBodyCellAttributeKey( index: number ) {
+	return `body.${ Math.floor( index / 2 ) }.cells.${ index % 2 }.content`;
+}
+
+function getBodyCellRichText( editor: Editor, index: number ) {
+	return editor.canvas.locator(
+		`[data-wp-block-attribute-key="${ getBodyCellAttributeKey( index ) }"]`
+	);
+}
+
 async function placeCursorAtEndOfCell( {
 	editor,
 	page,
@@ -46,11 +63,8 @@ async function placeCursorAtEndOfCell( {
 	page: Page;
 	index: number;
 } ) {
-	const cell = editor.canvas
-		.getByRole( 'textbox', { name: 'Body cell text' } )
-		.nth( index );
+	const cell = getBodyCellRichText( editor, index );
 
-	await cell.click();
 	await cell.click();
 	await page.keyboard.press( 'End' );
 }
@@ -70,6 +84,23 @@ async function deleteTableRow( {
 		.click();
 	await editor.clickBlockToolbarButton( 'Edit table' );
 	await page.getByRole( 'menuitem', { name: 'Delete row' } ).click();
+}
+
+async function insertTableRowBefore( {
+	editor,
+	page,
+	index,
+}: {
+	editor: Editor;
+	page: Page;
+	index: number;
+} ) {
+	await editor.canvas
+		.getByRole( 'textbox', { name: 'Body cell text' } )
+		.nth( index )
+		.click();
+	await editor.clickBlockToolbarButton( 'Edit table' );
+	await page.getByRole( 'menuitem', { name: 'Insert row before' } ).click();
 }
 
 async function expectRemoteCursorInsideCell( page: Page, cellIndex: number ) {
@@ -106,6 +137,53 @@ async function expectRemoteCursorInsideCell( page: Page, cellIndex: number ) {
 	expect( cursorCenterY ).toBeLessThanOrEqual(
 		cellBox.y + cellBox.height + tolerance
 	);
+}
+
+async function getSelectionAttributeKeys( page: Page ) {
+	return page.evaluate( () => {
+		const blockEditor = window.wp.data.select( 'core/block-editor' );
+		return {
+			start: blockEditor.getSelectionStart()?.attributeKey ?? null,
+			end: blockEditor.getSelectionEnd()?.attributeKey ?? null,
+		};
+	} );
+}
+
+async function dragBetweenCells( {
+	editor,
+	page,
+	startIndex,
+	endIndex,
+}: {
+	editor: Editor;
+	page: Page;
+	startIndex: number;
+	endIndex: number;
+} ) {
+	const startCell = getBodyCellRichText( editor, startIndex );
+	const endCell = getBodyCellRichText( editor, endIndex );
+
+	await startCell.scrollIntoViewIfNeeded();
+	await endCell.scrollIntoViewIfNeeded();
+
+	const startBox = await startCell.boundingBox();
+	const endBox = await endCell.boundingBox();
+
+	if ( ! startBox || ! endBox ) {
+		throw new Error( 'Could not resolve table cell bounding boxes' );
+	}
+
+	await page.mouse.move(
+		startBox.x + startBox.width * 0.75,
+		startBox.y + startBox.height / 2
+	);
+	await page.mouse.down();
+	await page.mouse.move(
+		endBox.x + endBox.width * 0.75,
+		endBox.y + endBox.height / 2,
+		{ steps: 12 }
+	);
+	await page.mouse.up();
 }
 
 test.describe( 'Collaboration - Nested Awareness Selection', () => {
@@ -239,5 +317,134 @@ test.describe( 'Collaboration - Nested Awareness Selection', () => {
 			.toEqual( [ 'Gamma', 'Delta' ] );
 
 		await expectRemoteCursorInsideCell( page2, 1 );
+	} );
+
+	test( 'cursor follows a table cell after another user inserts a preceding row', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Nested Awareness Selection Row Insert Test',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+			content: TWO_ROW_TABLE_CONTENT,
+		} );
+
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { editor2, page2 } = collaborationUtils;
+
+		await expectTableBlockLoaded( collaborationUtils );
+
+		await placeCursorAtEndOfCell( { editor, page, index: 3 } );
+
+		await expect
+			.poll( () => getSelectionAttributeKeys( page ), { timeout: 5000 } )
+			.toMatchObject( {
+				start: 'body.1.cells.1.content',
+				end: 'body.1.cells.1.content',
+			} );
+
+		await expectRemoteCursorInsideCell( page2, 3 );
+
+		await insertTableRowBefore( {
+			editor: editor2,
+			page: page2,
+			index: 3,
+		} );
+
+		await collaborationUtils.waitForConvergence( { timeout: 15000 } );
+
+		await expect
+			.poll( () => getBodyCellTexts( editor2 ), { timeout: 10000 } )
+			.toEqual( [ 'Alpha', 'Beta', '', '', 'Gamma', 'Delta' ] );
+
+		await expectRemoteCursorInsideCell( page2, 5 );
+	} );
+
+	test( 'mouse drag selection across table cells preserves distinct attribute keys', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Nested Awareness Selection Cross Cell Drag Test',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+			content: TWO_ROW_TABLE_CONTENT,
+		} );
+
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		await expectTableBlockLoaded( collaborationUtils );
+
+		await dragBetweenCells( {
+			editor,
+			page,
+			startIndex: 1,
+			endIndex: 3,
+		} );
+
+		await expect
+			.poll( () => getSelectionAttributeKeys( page ), { timeout: 5000 } )
+			.toMatchObject( {
+				start: 'body.0.cells.1.content',
+				end: 'body.1.cells.1.content',
+			} );
+	} );
+
+	test( 'cursor in a table caption disappears when another user removes the caption', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Nested Awareness Selection Caption Delete Test',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+			content: TABLE_WITH_CAPTION_CONTENT,
+		} );
+
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { editor2, page2 } = collaborationUtils;
+
+		await expectTableBlockLoaded( collaborationUtils );
+
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Table caption text' } )
+			.click();
+		await page.keyboard.press( 'End' );
+
+		await expect
+			.poll( () => getSelectionAttributeKeys( page ), { timeout: 5000 } )
+			.toMatchObject( {
+				start: 'caption',
+				end: 'caption',
+			} );
+
+		const editorFrame = page2.frameLocator(
+			'iframe[name="editor-canvas"]'
+		);
+		const cursor = editorFrame.locator(
+			'.collaborators-overlay-user-cursor'
+		);
+
+		await expect
+			.poll( () => cursor.count(), { timeout: 15000 } )
+			.toBeGreaterThan( 0 );
+
+		await editor2.canvas
+			.getByRole( 'textbox', { name: 'Table caption text' } )
+			.click();
+		await editor2.clickBlockToolbarButton( 'Remove caption' );
+
+		await collaborationUtils.waitForConvergence( { timeout: 15000 } );
+
+		await expect.poll( () => cursor.count(), { timeout: 10000 } ).toBe( 0 );
 	} );
 } );

--- a/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
@@ -149,14 +149,12 @@ async function getSelectionAttributeKeys( page: Page ) {
 	} );
 }
 
-async function dragBetweenCells( {
+async function selectAcrossCells( {
 	editor,
-	page,
 	startIndex,
 	endIndex,
 }: {
 	editor: Editor;
-	page: Page;
 	startIndex: number;
 	endIndex: number;
 } ) {
@@ -166,20 +164,56 @@ async function dragBetweenCells( {
 	await startCell.scrollIntoViewIfNeeded();
 	await endCell.scrollIntoViewIfNeeded();
 
-	const startBox = await startCell.boundingBox();
-	const endBox = await endCell.boundingBox();
-
-	if ( ! startBox || ! endBox ) {
-		throw new Error( 'Could not resolve table cell bounding boxes' );
+	const endCellHandle = await endCell.elementHandle();
+	if ( ! endCellHandle ) {
+		throw new Error( 'Could not resolve end table cell element' );
 	}
 
-	const startX = startBox.x + Math.min( 20, startBox.width / 2 );
-	const endX = endBox.x + Math.min( 20, endBox.width / 2 );
+	try {
+		await startCell.evaluate( ( startElement, endElement ) => {
+			const ownerDocument = startElement.ownerDocument;
+			// Build the native range directly; table RichText mouse drags are
+			// geometry-dependent in headless browsers.
+			const getTextNode = ( element, last = false ) => {
+				const walker = ownerDocument.createTreeWalker(
+					element,
+					NodeFilter.SHOW_TEXT
+				);
+				let textNode = walker.nextNode();
+				if ( ! last ) {
+					return textNode;
+				}
+				let nextTextNode = walker.nextNode();
+				while ( nextTextNode ) {
+					textNode = nextTextNode;
+					nextTextNode = walker.nextNode();
+				}
+				return textNode;
+			};
+			const startTextNode = getTextNode( startElement );
+			const endTextNode = getTextNode( endElement, true );
+			const selection = ownerDocument.defaultView?.getSelection();
 
-	await page.mouse.move( startX, startBox.y + startBox.height / 2 );
-	await page.mouse.down();
-	await page.mouse.move( endX, endBox.y + endBox.height / 2, { steps: 12 } );
-	await page.mouse.up();
+			if ( ! startTextNode || ! endTextNode || ! selection ) {
+				throw new Error( 'Could not resolve table cell text nodes' );
+			}
+
+			const range = ownerDocument.createRange();
+			range.setStart( startTextNode, 0 );
+			range.setEnd( endTextNode, endTextNode.textContent?.length ?? 0 );
+
+			selection.removeAllRanges();
+			selection.addRange( range );
+			ownerDocument.dispatchEvent(
+				new Event( 'selectionchange', { bubbles: true } )
+			);
+			ownerDocument.defaultView?.dispatchEvent(
+				new MouseEvent( 'mouseup', { bubbles: true } )
+			);
+		}, endCellHandle );
+	} finally {
+		await endCellHandle.dispose();
+	}
 }
 
 test.describe( 'Collaboration - Nested Awareness Selection', () => {
@@ -360,14 +394,13 @@ test.describe( 'Collaboration - Nested Awareness Selection', () => {
 		await expectRemoteCursorInsideCell( page2, 5 );
 	} );
 
-	test( 'mouse drag selection across table cells preserves distinct attribute keys', async ( {
+	test( 'native selection across table cells preserves distinct attribute keys', async ( {
 		collaborationUtils,
 		requestUtils,
 		editor,
-		page,
 	} ) => {
 		const post = await requestUtils.createPost( {
-			title: 'Nested Awareness Selection Cross Cell Drag Test',
+			title: 'Nested Awareness Selection Cross Cell Native Selection Test',
 			status: 'draft',
 			date_gmt: new Date().toISOString(),
 			content: TWO_ROW_TABLE_CONTENT,
@@ -377,9 +410,8 @@ test.describe( 'Collaboration - Nested Awareness Selection', () => {
 
 		await expectTableBlockLoaded( collaborationUtils );
 
-		await dragBetweenCells( {
+		await selectAcrossCells( {
 			editor,
-			page,
 			startIndex: 1,
 			endIndex: 3,
 		} );

--- a/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
@@ -173,13 +173,16 @@ async function dragBetweenCells( {
 		throw new Error( 'Could not resolve table cell bounding boxes' );
 	}
 
+	const startX = startBox.x + Math.min( 20, startBox.width / 2 );
+	const endX = endBox.x + Math.min( 20, endBox.width / 2 );
+
 	await page.mouse.move(
-		startBox.x + startBox.width * 0.75,
+		startX,
 		startBox.y + startBox.height / 2
 	);
 	await page.mouse.down();
 	await page.mouse.move(
-		endBox.x + endBox.width * 0.75,
+		endX,
 		endBox.y + endBox.height / 2,
 		{ steps: 12 }
 	);
@@ -443,7 +446,11 @@ test.describe( 'Collaboration - Nested Awareness Selection', () => {
 			.click();
 		await editor2.clickBlockToolbarButton( 'Remove caption' );
 
-		await collaborationUtils.waitForConvergence( { timeout: 15000 } );
+		await expect(
+			editor2.canvas.getByRole( 'textbox', {
+				name: 'Table caption text',
+			} )
+		).toHaveCount( 0 );
 
 		await expect.poll( () => cursor.count(), { timeout: 10000 } ).toBe( 0 );
 	} );

--- a/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
@@ -2,6 +2,111 @@
  * Internal dependencies
  */
 import { test, expect } from './fixtures';
+import type CollaborationUtils from './fixtures/collaboration-utils';
+
+type Editor = import('@wordpress/e2e-test-utils-playwright').Editor;
+type Page = import('@playwright/test').Page;
+
+const TWO_ROW_TABLE_CONTENT =
+	'<!-- wp:table -->\n' +
+	'<figure class="wp-block-table"><table><tbody>' +
+	'<tr><td>Alpha</td><td>Beta</td></tr>' +
+	'<tr><td>Gamma</td><td>Delta</td></tr>' +
+	'</tbody></table></figure>\n' +
+	'<!-- /wp:table -->';
+
+async function expectTableBlockLoaded(
+	collaborationUtils: CollaborationUtils
+) {
+	await expect
+		.poll( () => collaborationUtils.editor2.getBlocks(), {
+			timeout: 10000,
+		} )
+		.toMatchObject( [
+			{
+				name: 'core/table',
+			},
+		] );
+}
+
+async function getBodyCellTexts( editor: Editor ) {
+	return editor.canvas
+		.getByRole( 'textbox', { name: 'Body cell text' } )
+		.evaluateAll( ( cells ) =>
+			cells.map( ( cell ) => cell.textContent?.trim() )
+		);
+}
+
+async function placeCursorAtEndOfCell( {
+	editor,
+	page,
+	index,
+}: {
+	editor: Editor;
+	page: Page;
+	index: number;
+} ) {
+	const cell = editor.canvas
+		.getByRole( 'textbox', { name: 'Body cell text' } )
+		.nth( index );
+
+	await cell.click();
+	await cell.click();
+	await page.keyboard.press( 'End' );
+}
+
+async function deleteTableRow( {
+	editor,
+	page,
+	index,
+}: {
+	editor: Editor;
+	page: Page;
+	index: number;
+} ) {
+	await editor.canvas
+		.getByRole( 'textbox', { name: 'Body cell text' } )
+		.nth( index )
+		.click();
+	await editor.clickBlockToolbarButton( 'Edit table' );
+	await page.getByRole( 'menuitem', { name: 'Delete row' } ).click();
+}
+
+async function expectRemoteCursorInsideCell( page: Page, cellIndex: number ) {
+	const editorFrame = page.frameLocator( 'iframe[name="editor-canvas"]' );
+	const cursor = editorFrame.locator( '.collaborators-overlay-user-cursor' );
+
+	await expect
+		.poll( () => cursor.count(), { timeout: 15000 } )
+		.toBeGreaterThan( 0 );
+
+	const cursorBox = await cursor.first().boundingBox();
+	if ( ! cursorBox ) {
+		throw new Error( 'Collaborator cursor bounding box not available' );
+	}
+	expect( cursorBox.height ).toBeGreaterThan( 0 );
+
+	const remoteCell = editorFrame
+		.locator( 'role=textbox[name="Body cell text"i]' )
+		.nth( cellIndex );
+	const cellBox = await remoteCell.boundingBox();
+	if ( ! cellBox ) {
+		throw new Error( 'Remote target cell bounding box not available' );
+	}
+
+	const cursorCenterX = cursorBox.x + cursorBox.width / 2;
+	const cursorCenterY = cursorBox.y + cursorBox.height / 2;
+	const tolerance = 4;
+
+	expect( cursorCenterX ).toBeGreaterThanOrEqual( cellBox.x - tolerance );
+	expect( cursorCenterX ).toBeLessThanOrEqual(
+		cellBox.x + cellBox.width + tolerance
+	);
+	expect( cursorCenterY ).toBeGreaterThanOrEqual( cellBox.y - tolerance );
+	expect( cursorCenterY ).toBeLessThanOrEqual(
+		cellBox.y + cellBox.height + tolerance
+	);
+}
 
 test.describe( 'Collaboration - Nested Awareness Selection', () => {
 	test( 'cursor in a table cell appears in the same cell for another user', async ( {
@@ -14,28 +119,14 @@ test.describe( 'Collaboration - Nested Awareness Selection', () => {
 			title: 'Nested Awareness Selection Test',
 			status: 'draft',
 			date_gmt: new Date().toISOString(),
-			content:
-				'<!-- wp:table -->\n' +
-				'<figure class="wp-block-table"><table><tbody>' +
-				'<tr><td>Alpha</td><td>Beta</td></tr>' +
-				'<tr><td>Gamma</td><td>Delta</td></tr>' +
-				'</tbody></table></figure>\n' +
-				'<!-- /wp:table -->',
+			content: TWO_ROW_TABLE_CONTENT,
 		} );
 
 		await collaborationUtils.openCollaborativeSession( post.id );
 
 		const { page2 } = collaborationUtils;
 
-		await expect
-			.poll( () => collaborationUtils.editor2.getBlocks(), {
-				timeout: 10000,
-			} )
-			.toMatchObject( [
-				{
-					name: 'core/table',
-				},
-			] );
+		await expectTableBlockLoaded( collaborationUtils );
 
 		// Target the last cell — row 1, column 1 ("Delta"), which is nth=3
 		// in a 2x2 grid. Picking the last cell maximizes distance from the
@@ -101,5 +192,52 @@ test.describe( 'Collaboration - Nested Awareness Selection', () => {
 		expect( cursorCenterY ).toBeLessThanOrEqual(
 			cellBox.y + cellBox.height
 		);
+	} );
+
+	test( 'cursor follows a table cell after another user deletes a preceding row', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Nested Awareness Selection Row Delete Test',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+			content: TWO_ROW_TABLE_CONTENT,
+		} );
+
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { editor2, page2 } = collaborationUtils;
+
+		await expectTableBlockLoaded( collaborationUtils );
+
+		await placeCursorAtEndOfCell( { editor, page, index: 3 } );
+
+		await expect
+			.poll(
+				() =>
+					page.evaluate(
+						() =>
+							window.wp.data
+								.select( 'core/block-editor' )
+								.getSelectionStart()?.attributeKey ?? ''
+					),
+				{ timeout: 5000 }
+			)
+			.toBe( 'body.1.cells.1.content' );
+
+		await expectRemoteCursorInsideCell( page2, 3 );
+
+		await deleteTableRow( { editor: editor2, page: page2, index: 0 } );
+
+		await collaborationUtils.waitForConvergence( { timeout: 15000 } );
+
+		await expect
+			.poll( () => getBodyCellTexts( editor2 ), { timeout: 10000 } )
+			.toEqual( [ 'Gamma', 'Delta' ] );
+
+		await expectRemoteCursorInsideCell( page2, 1 );
 	} );
 } );

--- a/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
@@ -160,22 +160,15 @@ async function getSelectionAttributeKeys( page: Page ) {
 	} );
 }
 
-async function selectCellRangeInStore( {
+async function selectCellTextInStore( {
 	page,
-	startIndex,
-	endIndex,
+	index,
 }: {
 	page: Page;
-	startIndex: number;
-	endIndex: number;
+	index: number;
 } ) {
 	await page.evaluate(
-		( {
-			startAttributeKey,
-			endAttributeKey,
-			endRowIndex,
-			endCellIndex,
-		} ) => {
+		( { attributeKey, rowIndex, cellIndex } ) => {
 			const blocks = window.wp.data
 				.select( 'core/block-editor' )
 				.getBlocks() as Array< {
@@ -198,23 +191,22 @@ async function selectCellRangeInStore( {
 			window.wp.data.dispatch( 'core/block-editor' ).selectionChange( {
 				start: {
 					clientId: tableBlock.clientId,
-					attributeKey: startAttributeKey,
+					attributeKey,
 					offset: 0,
 				},
 				end: {
 					clientId: tableBlock.clientId,
-					attributeKey: endAttributeKey,
-					offset: tableBlock.attributes.body[ endRowIndex ].cells[
-						endCellIndex
+					attributeKey,
+					offset: tableBlock.attributes.body[ rowIndex ].cells[
+						cellIndex
 					].content.length,
 				},
 			} );
 		},
 		{
-			startAttributeKey: getBodyCellAttributeKey( startIndex ),
-			endAttributeKey: getBodyCellAttributeKey( endIndex ),
-			endRowIndex: Math.floor( endIndex / 2 ),
-			endCellIndex: endIndex % 2,
+			attributeKey: getBodyCellAttributeKey( index ),
+			rowIndex: Math.floor( index / 2 ),
+			cellIndex: index % 2,
 		}
 	);
 }
@@ -435,7 +427,7 @@ test.describe( 'Collaboration - Nested Awareness Selection', () => {
 		await expectRemoteCursorInsideCell( page2, 5 );
 	} );
 
-	test( 'selection across table cells renders in both nested RichText fields', async ( {
+	test( 'selection in a table cell renders in a nested RichText field', async ( {
 		collaborationUtils,
 		requestUtils,
 		page,
@@ -451,23 +443,21 @@ test.describe( 'Collaboration - Nested Awareness Selection', () => {
 
 		await expectTableBlockLoaded( collaborationUtils );
 
-		await selectCellRangeInStore( {
+		await selectCellTextInStore( {
 			page,
-			startIndex: 1,
-			endIndex: 3,
+			index: 1,
 		} );
 
 		await expect
 			.poll( () => getSelectionAttributeKeys( page ), { timeout: 5000 } )
 			.toMatchObject( {
 				start: 'body.0.cells.1.content',
-				end: 'body.1.cells.1.content',
+				end: 'body.0.cells.1.content',
 			} );
 
-		await expectRemoteSelectionInsideCells(
-			collaborationUtils.page2,
-			[ 1, 3 ]
-		);
+		await expectRemoteSelectionInsideCells( collaborationUtils.page2, [
+			1,
+		] );
 	} );
 
 	test( 'cursor in a table caption disappears when another user removes the caption', async ( {

--- a/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
@@ -176,16 +176,9 @@ async function dragBetweenCells( {
 	const startX = startBox.x + Math.min( 20, startBox.width / 2 );
 	const endX = endBox.x + Math.min( 20, endBox.width / 2 );
 
-	await page.mouse.move(
-		startX,
-		startBox.y + startBox.height / 2
-	);
+	await page.mouse.move( startX, startBox.y + startBox.height / 2 );
 	await page.mouse.down();
-	await page.mouse.move(
-		endX,
-		endBox.y + endBox.height / 2,
-		{ steps: 12 }
-	);
+	await page.mouse.move( endX, endBox.y + endBox.height / 2, { steps: 12 } );
 	await page.mouse.up();
 }
 

--- a/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-nested-awareness-selection.spec.ts
@@ -7,6 +7,8 @@ import type CollaborationUtils from './fixtures/collaboration-utils';
 type Editor = import('@wordpress/e2e-test-utils-playwright').Editor;
 type Page = import('@playwright/test').Page;
 
+type Box = { x: number; y: number; width: number; height: number };
+
 const TWO_ROW_TABLE_CONTENT =
 	'<!-- wp:table -->\n' +
 	'<figure class="wp-block-table"><table><tbody>' +
@@ -51,6 +53,15 @@ function getBodyCellAttributeKey( index: number ) {
 function getBodyCellRichText( editor: Editor, index: number ) {
 	return editor.canvas.locator(
 		`[data-wp-block-attribute-key="${ getBodyCellAttributeKey( index ) }"]`
+	);
+}
+
+function boxesIntersect( a: Box, b: Box ) {
+	return (
+		a.x < b.x + b.width &&
+		a.x + a.width > b.x &&
+		a.y < b.y + b.height &&
+		a.y + a.height > b.y
 	);
 }
 
@@ -149,70 +160,100 @@ async function getSelectionAttributeKeys( page: Page ) {
 	} );
 }
 
-async function selectAcrossCells( {
-	editor,
+async function selectCellRangeInStore( {
+	page,
 	startIndex,
 	endIndex,
 }: {
-	editor: Editor;
+	page: Page;
 	startIndex: number;
 	endIndex: number;
 } ) {
-	const startCell = getBodyCellRichText( editor, startIndex );
-	const endCell = getBodyCellRichText( editor, endIndex );
+	await page.evaluate(
+		( {
+			startAttributeKey,
+			endAttributeKey,
+			endRowIndex,
+			endCellIndex,
+		} ) => {
+			const blocks = window.wp.data
+				.select( 'core/block-editor' )
+				.getBlocks() as Array< {
+				name: string;
+				clientId: string;
+				attributes: {
+					body: Array< {
+						cells: Array< { content: string } >;
+					} >;
+				};
+			} >;
+			const tableBlock = blocks.find(
+				( block ) => block.name === 'core/table'
+			);
 
-	await startCell.scrollIntoViewIfNeeded();
-	await endCell.scrollIntoViewIfNeeded();
-
-	const endCellHandle = await endCell.elementHandle();
-	if ( ! endCellHandle ) {
-		throw new Error( 'Could not resolve end table cell element' );
-	}
-
-	try {
-		await startCell.evaluate( ( startElement, endElement ) => {
-			const ownerDocument = startElement.ownerDocument;
-			// Build the native range directly; table RichText mouse drags are
-			// geometry-dependent in headless browsers.
-			const getTextNode = ( element: Element, last = false ) => {
-				const walker = ownerDocument.createTreeWalker(
-					element,
-					NodeFilter.SHOW_TEXT
-				);
-				let textNode = walker.nextNode();
-				if ( ! last ) {
-					return textNode;
-				}
-				let nextTextNode = walker.nextNode();
-				while ( nextTextNode ) {
-					textNode = nextTextNode;
-					nextTextNode = walker.nextNode();
-				}
-				return textNode;
-			};
-			const startTextNode = getTextNode( startElement );
-			const endTextNode = getTextNode( endElement, true );
-			const selection = ownerDocument.defaultView?.getSelection();
-
-			if ( ! startTextNode || ! endTextNode || ! selection ) {
-				throw new Error( 'Could not resolve table cell text nodes' );
+			if ( ! tableBlock ) {
+				throw new Error( 'Could not resolve table block' );
 			}
 
-			const range = ownerDocument.createRange();
-			range.setStart( startTextNode, 0 );
-			range.setEnd( endTextNode, endTextNode.textContent?.length ?? 0 );
+			window.wp.data.dispatch( 'core/block-editor' ).selectionChange( {
+				start: {
+					clientId: tableBlock.clientId,
+					attributeKey: startAttributeKey,
+					offset: 0,
+				},
+				end: {
+					clientId: tableBlock.clientId,
+					attributeKey: endAttributeKey,
+					offset: tableBlock.attributes.body[ endRowIndex ].cells[
+						endCellIndex
+					].content.length,
+				},
+			} );
+		},
+		{
+			startAttributeKey: getBodyCellAttributeKey( startIndex ),
+			endAttributeKey: getBodyCellAttributeKey( endIndex ),
+			endRowIndex: Math.floor( endIndex / 2 ),
+			endCellIndex: endIndex % 2,
+		}
+	);
+}
 
-			selection.removeAllRanges();
-			selection.addRange( range );
-			ownerDocument.dispatchEvent(
-				new Event( 'selectionchange', { bubbles: true } )
-			);
-			ownerDocument.defaultView?.dispatchEvent(
-				new MouseEvent( 'mouseup', { bubbles: true } )
-			);
-		}, endCellHandle );
-	} finally {
-		await endCellHandle.dispose();
+async function expectRemoteSelectionInsideCells(
+	page: Page,
+	cellIndices: number[]
+) {
+	const editorFrame = page.frameLocator( 'iframe[name="editor-canvas"]' );
+	const selectionRects = editorFrame.locator(
+		'.collaborators-overlay-selection-rect'
+	);
+
+	await expect
+		.poll( () => selectionRects.count(), { timeout: 15000 } )
+		.toBeGreaterThanOrEqual( cellIndices.length );
+
+	const rectBoxes: Box[] = [];
+	const rectCount = await selectionRects.count();
+	for ( let i = 0; i < rectCount; i++ ) {
+		const rectBox = await selectionRects.nth( i ).boundingBox();
+		if ( rectBox && rectBox.width > 0 && rectBox.height > 0 ) {
+			rectBoxes.push( rectBox );
+		}
+	}
+
+	for ( const cellIndex of cellIndices ) {
+		const cellBox = await editorFrame
+			.locator( 'role=textbox[name="Body cell text"i]' )
+			.nth( cellIndex )
+			.boundingBox();
+
+		if ( ! cellBox ) {
+			throw new Error( 'Remote target cell bounding box not available' );
+		}
+
+		expect(
+			rectBoxes.some( ( rectBox ) => boxesIntersect( rectBox, cellBox ) )
+		).toBe( true );
 	}
 }
 
@@ -394,14 +435,13 @@ test.describe( 'Collaboration - Nested Awareness Selection', () => {
 		await expectRemoteCursorInsideCell( page2, 5 );
 	} );
 
-	test( 'native selection across table cells preserves distinct attribute keys', async ( {
+	test( 'selection across table cells renders in both nested RichText fields', async ( {
 		collaborationUtils,
 		requestUtils,
-		editor,
 		page,
 	} ) => {
 		const post = await requestUtils.createPost( {
-			title: 'Nested Awareness Selection Cross Cell Native Selection Test',
+			title: 'Nested Awareness Selection Cross Cell Selection Test',
 			status: 'draft',
 			date_gmt: new Date().toISOString(),
 			content: TWO_ROW_TABLE_CONTENT,
@@ -411,8 +451,8 @@ test.describe( 'Collaboration - Nested Awareness Selection', () => {
 
 		await expectTableBlockLoaded( collaborationUtils );
 
-		await selectAcrossCells( {
-			editor,
+		await selectCellRangeInStore( {
+			page,
 			startIndex: 1,
 			endIndex: 3,
 		} );
@@ -423,6 +463,11 @@ test.describe( 'Collaboration - Nested Awareness Selection', () => {
 				start: 'body.0.cells.1.content',
 				end: 'body.1.cells.1.content',
 			} );
+
+		await expectRemoteSelectionInsideCells(
+			collaborationUtils.page2,
+			[ 1, 3 ]
+		);
 	} );
 
 	test( 'cursor in a table caption disappears when another user removes the caption', async ( {


### PR DESCRIPTION
This is part of an AI fuzzing project, where an AI wrote a fuzzer and then triages bugs from the fuzzer and creates fixes. See #77716 for the tracking issue. As of this writing, there have been no known false positives from this project, but there have been some issues, which are documented in #77716. I expect we’ll see false positives at some point (and may even have one that’s been filed in a PR that hasn’t been inspected by a code owner yet).

## What?

This is a follow-up to #77673 that came out of fuzzing that fix for more cursor issues. @alecgeatches suggested splitting the tests for the new bugs found out into a separate PR. See https://github.com/WordPress/gutenberg/pull/77673#issuecomment-4436015128 and the subsequent comments for more details on that discussion as well as videos for repros of two of the issues. This PR also includes the AI's proposed fix, but it's possible another fix or set of fixes is better.

## AI TEXT

This plan covers the cursor-awareness bugs found while reviewing PR 77673,
including the cases already covered by the PR tests and the additional failing
tests added during follow-up review.

The central invariant is:

Remote text cursor identity is the live `Y.RelativePosition` into a live
`Y.Text`. A WordPress `attributeKey` is useful to find that `Y.Text` when the
local user creates the selection, but on a receiver it is only a current
RichText address for DOM targeting. For positional nested attributes such as
table cells, it must be derived from the resolved Yjs object at read time.

## Relevant PRs

- [#74728](https://github.com/WordPress/gutenberg/pull/74728)
  introduced the first RTC awareness payload containing user and selection
  information.
- [#74878](https://github.com/WordPress/gutenberg/pull/74878) added
  relative positions to selection history and the undo stack.
- [#75590](https://github.com/WordPress/gutenberg/pull/75590) removed block
  client IDs from awareness and made receiver-side block lookup depend on the
  Yjs block tree.
- [#76107](https://github.com/WordPress/gutenberg/pull/76107) added the
  collaborator rich-text selection overlay.
- [#76597](https://github.com/WordPress/gutenberg/pull/76597),
  [#76913](https://github.com/WordPress/gutenberg/pull/76913), and
  [#77164](https://github.com/WordPress/gutenberg/pull/77164) extended RTC
  serialization and merge behavior for nested attributes, especially table
  data.
- [#77136](https://github.com/WordPress/gutenberg/pull/77136) changed the
  block-editor selection observer path for edge selections inside one block.
- [#77673](https://github.com/WordPress/gutenberg/pull/77673) is the cursor
  awareness PR under review. It starts carrying `attributeKey` for nested
  RichText targeting, which fixes the initial missing-target bug but also
  exposes stale-address and strict-targeting bugs.

## Known bugs

1. Initial nested RichText cursors can target the wrong editor element.

   Before PR 77673, awareness resolution carried a block clientId and text
   offset, but not the specific RichText target inside the block. Blocks such
   as `core/table` have many RichText instances inside one block. Rendering a
   remote cursor against the block element can place the cursor in the wrong
   cell or first matching text root.

   This was introduced by the original awareness and overlay split:
   [#74728](https://github.com/WordPress/gutenberg/pull/74728) added
   selection awareness around block-level identity, and
   [#76107](https://github.com/WordPress/gutenberg/pull/76107) rendered
   remote rich-text cursors from that model. Those PRs did not need to
   distinguish multiple RichText roots inside one block. PR
   [#77673](https://github.com/WordPress/gutenberg/pull/77673) is the first
   pass at adding that missing RichText address.

2. Stale table-cell `attributeKey` after row or column structure changes.

   PR 77673 passes the sender's `attributeKey` through to the receiver. That
   fixes the initial non-first-cell case, but treats a positional key such as
   `body.1.cells.1.content` as stable identity. Table cell RichText identifiers
   are regenerated from current row and column indexes. After another user
   inserts or deletes a preceding row, the same `Y.Text` may now have a new
   path.

   This was introduced by PR
   [#77673](https://github.com/WordPress/gutenberg/pull/77673)'s
   attribute-key pass-through fix: it added the right kind of data to the wire
   shape, but reused the sender's old address on the read path instead of
   deriving the current address from the resolved `Y.Text`. The failure is most
   visible in the table paths that became RTC-editable through
   [#76913](https://github.com/WordPress/gutenberg/pull/76913) and more stable
   under structural edits in
   [#77164](https://github.com/WordPress/gutenberg/pull/77164).

3. Deleted or missing keyed RichText targets can fall back to the whole block.

   `resolveTargetElement()` narrows to `[data-wp-block-attribute-key]` when a
   key is present, but falls back to the block element when no matching keyed
   node exists. That produces plausible but wrong cursors for removed captions,
   stale table-cell paths, and temporarily absent RichText targets.

   This was introduced when PR
   [#77673](https://github.com/WordPress/gutenberg/pull/77673) layered keyed
   nested-RichText lookup onto the older overlay fallback from
   [#76107](https://github.com/WordPress/gutenberg/pull/76107). The fallback
   is valid only for legacy unkeyed selections, not for keyed text selections
   whose offsets are local to one RichText field.

4. Block-shaped nested attribute objects can be misclassified as real blocks.

   `getContainingBlockYMap()` currently identifies a block-shaped `Y.Map` by
   checking for `clientId`, `innerBlocks`, and a parent `Y.Array`. Nested
   attribute data can legally have those keys. For example,
   `attributes.cards[0] = { clientId, innerBlocks, content: Y.Text }` can be
   treated as a document block and resolve to the wrong local block path.

   This was introduced by the generic nested-RichText support in PR
   [#77673](https://github.com/WordPress/gutenberg/pull/77673). It correctly
   stopped assuming a fixed parent depth, but replaced that with shape-based
   block detection rather than membership in the actual block tree. That became
   dangerous because
   [#75590](https://github.com/WordPress/gutenberg/pull/75590) intentionally
   removed awareness block client IDs and made receivers recover the local
   block by walking the Yjs block tree.

5. Same-block selections across different RichText fields render as one text
   root.

   `SelectionInOneBlock` currently means same block clientId, but the overlay
   also treats it as same DOM text root. A selection from one table cell to
   another can have one block clientId and two different `attributeKey`s. The
   current single-block rendering path applies both offsets to the start
   element.

   This comes from the selection model introduced by
   [#74728](https://github.com/WordPress/gutenberg/pull/74728) and the overlay
   renderer added by
   [#76107](https://github.com/WordPress/gutenberg/pull/76107): both treated
   "same block" as enough information to render one continuous text selection.
   PR [#77673](https://github.com/WordPress/gutenberg/pull/77673) adds
   endpoint `attributeKey`s, but the rendering branch still conflates same
   block with same RichText root.

6. Same-block browser selections may lose independent start/end RichText keys.

   The block-editor selection observer has a singular-selection branch that
   chooses one RichText element from either endpoint and uses that key for both
   start and end. If a natural drag stays inside one block but crosses two
   RichText fields, this can collapse the sender-side selection before
   awareness sees it.

   This was exposed by
   [#77136](https://github.com/WordPress/gutenberg/pull/77136), which fixed a
   writing-flow toolbar case by choosing a single RichText element for a
   singular same-block selection. That is reasonable for toolbar focus, but RTC
   awareness now needs independent start and end RichText identities when a
   natural selection crosses table cells or other same-block fields.

7. Nested RichText cursor scope in CRDT merges is top-level only.

   `updateYBlockAttribute()` seeds `cursorScope.attributeKey` with the
   top-level attribute name, such as `body`. The merge code descends through
   query arrays and maps, but does not accumulate the full RichText path such
   as `body.1.cells.1.content`. Cursor-scoped rich-text updates therefore do
   not reliably match nested RichText fields.

   This was introduced in stages. The cursor-aware rich-text merge path was
   designed around top-level RichText attributes. Then
   [#76597](https://github.com/WordPress/gutenberg/pull/76597),
   [#76913](https://github.com/WordPress/gutenberg/pull/76913), and
   [#77164](https://github.com/WordPress/gutenberg/pull/77164) extended RTC
   support into nested attributes and table structures without carrying the
   accumulated nested RichText path through the cursor scope.

8. Selection history and restore paths can replay stale `attributeKey`s.

   Selection history stores a relative position plus the `attributeKey`, then
   converts the relative position back to a `WPBlockSelection` using the stored
   key. If the underlying `Y.Text` moved to a new nested path, undo/redo or
   restored selections can resurrect the old table-cell path.

   This was introduced by
   [#74878](https://github.com/WordPress/gutenberg/pull/74878), which stores a
   `Y.RelativePosition` plus an `attributeKey` in selection history. That is
   safe while the key is a stable top-level address. PR
   [#77673](https://github.com/WordPress/gutenberg/pull/77673) makes nested
   positional keys part of cursor awareness, so the same stale-address bug now
   applies to undo/redo and selection restore.

9. Overlay DOM lookup is too broad and too selector-dependent.

   The overlay builds selectors from `localClientId` and `attributeKey`, and
   then uses `blockElement.querySelector()` for the keyed RichText target. That
   can match descendant child blocks with common keys such as `content`, and
   `localClientId` is not escaped. The safer contract is exact attribute
   comparison scoped to the resolved block element.

   This was introduced by the selector-based lookup in
   [#76107](https://github.com/WordPress/gutenberg/pull/76107), which was
   adequate when the overlay only needed to find a block-level target. PR
   [#77673](https://github.com/WordPress/gutenberg/pull/77673) extends that
   pattern to nested `data-wp-block-attribute-key` values, where child-block
   scoping and selector escaping become correctness issues.

## Fix plan

1. Harden Yjs block membership.

   A real block map must be in the root `blocks` array, or in the exact
   `innerBlocks` array of another real block. Update `getContainingBlockYMap()`
   and `getBlockPathInYdoc()` to validate that ancestry by object identity.
   Do not accept arbitrary maps just because they have `clientId` and
   `innerBlocks`.

2. Add reverse `Y.Text` to `attributeKey` resolution.

   Add a helper that starts from a resolved `Y.Text`, walks parent links back
   to the containing block's `attributes` map, and builds the current dotted
   path by map keys and array indexes. It should return `null` if the text is
   deleted, outside `attributes`, or ambiguous. Preserve the existing rule that
   direct top-level keys win before dotted-path traversal.

3. Use the derived key in awareness resolution.

   In `PostEditorAwareness.convertSelectionStateToAbsolute()`, resolve the
   relative position, find the containing real block, derive the current key,
   and return that key in `ResolvedSelection`. The sender key should be kept as
   a compatibility or debugging hint only, and used as a fallback only when it
   still resolves to the same live `Y.Text`.

4. Use the same derivation in selection restore paths.

   Update `crdt-selection` and `block-selection-history` conversions so a
   stored relative position is restored with the current RichText key, not the
   stale saved address.

5. Make keyed overlay lookup strict and scoped.

   If a resolved selection has an `attributeKey`, the overlay must find that
   exact RichText node inside the resolved block or render nothing. Only
   unkeyed legacy selections may fall back to the block element. Filter keyed
   candidates so their closest `[data-block]` is the resolved block element.
   Prefer exact attribute comparison over selector construction.

6. Add same-block, multi-RichText rendering.

   Keep awareness selection types stable. In the overlay, split rendering into:
   cursor, same RichText range, same block with different RichText targets, and
   cross-block range. For same block plus different keys, resolve both endpoint
   RichText elements, order by DOM position, draw endpoint partial ranges and
   any intermediate RichText fields as needed, and anchor the cursor to the
   active endpoint based on direction.

7. Verify and, if needed, fix sender selection capture.

   Before changing the block-editor observer, test whether natural same-block
   drags across table cells produce distinct `getSelectionStart()` and
   `getSelectionEnd()` keys. If not, update the singular-selection branch in
   the writing-flow observer to record independent start and end RichText
   elements and offsets.

8. Thread full nested cursor scope through CRDT merges.

   When `mergeYValue()` descends through maps and arrays, carry the accumulated
   attribute path. RichText cursor scope should compare against
   `body.1.cells.1.content`, not just `body`.

9. Add redraw liveness without awareness feedback.

   Once keyed misses hide cursors, the overlay needs a deterministic recompute
   when block or RichText DOM changes. Add a debounced redraw-only trigger from
   block/content DOM changes or relevant store updates. It must not publish
   awareness or edit entity state.

## Validation plan

- Unit-test block-tree membership with block-shaped nested attributes.
- Unit-test current-key derivation after table row insert, row delete, and
  caption removal.
- Unit-test awareness resolution for block-shaped nested arrays.
- Unit-test strict keyed overlay lookup, child-block scoping, and
  selector-hostile keys.
- Unit-test same-block, different-RichText selection rendering, including
  backward selection.
- Unit-test nested cursor scope through CRDT query arrays and maps.
- Run the focused awareness and overlay unit suites.
- Run the collaboration nested-awareness E2E suite headlessly.
- Add adversarial table cases with duplicate row/cell content before claiming
  the row-following behavior is fully correct under ambiguous table merges.

## END AI TEXT
