### PR TITLE
Stylelint: Add logical properties exemptions

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -90,6 +90,8 @@ module.exports = {
 					{
 						ignore: [
 							// Doesn't affect RTL styles
+							'border-bottom',
+							'border-top',
 							'width',
 							'min-width',
 							'max-width',
@@ -98,8 +100,12 @@ module.exports = {
 							'max-height',
 							'margin-top',
 							'margin-bottom',
+							'overflow-x',
+							'overflow-y',
 							'padding-top',
 							'padding-bottom',
+							'scroll-margin-top',
+							'scroll-margin-bottom',
 							'top',
 							'bottom',
 						],


### PR DESCRIPTION
## What?
In preparation for https://github.com/WordPress/gutenberg/issues/76744#issuecomment-4444373801

Adds a few more properties to the `plugin/use-logical-properties-and-values` ignore list:

- `border-bottom` and `border-top`
- `overflow-x` and `overflow-y`
- `scroll-margin-top` and `scroll-margin-bottom`

## Why?

This is preparation for enabling logical property linting across the `routes` folders. These properties do not affect RTL directionality, so flagging them creates noise while auditing the route stylesheets for physical directional properties that do need to be converted.

## Testing Instructions

1. Run `npm run lint:css`.
2. Confirm the command passes.
3. Confirm that the newly exempted properties don't affect RTL.