### PR TITLE
Core Data: Use WeakMap keyed by content object for parsed blocks cache

### DIFF
--- a/packages/core-data/src/hooks/use-entity-block-editor.js
+++ b/packages/core-data/src/hooks/use-entity-block-editor.js
@@ -11,7 +11,7 @@ import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
 import { STORE_NAME } from '../name';
 import useEntityId from './use-entity-id';
 import { updateFootnotesFromMeta } from '../footnotes';
-import { parsedBlocksCache, getCacheKey } from '../parsed-blocks-cache';
+import { parsedBlocksCache } from '../parsed-blocks-cache';
 
 const EMPTY_ARRAY = [];
 
@@ -36,17 +36,22 @@ const EMPTY_ARRAY = [];
 export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 	const providerId = useEntityId( kind, name );
 	const id = _id ?? providerId;
-	const { content, editedBlocks, meta } = useSelect(
+	const { content, editedBlocks, meta, contentObject } = useSelect(
 		( select ) => {
 			if ( ! id ) {
 				return {};
 			}
-			const { getEditedEntityRecord } = select( STORE_NAME );
+			const { getEditedEntityRecord, getEntityRecord } =
+				select( STORE_NAME );
 			const editedRecord = getEditedEntityRecord( kind, name, id );
+			const rawRecord = getEntityRecord( kind, name, id );
 			return {
 				editedBlocks: editedRecord.blocks,
 				content: editedRecord.content,
 				meta: editedRecord.meta,
+				// WeakMap key. Stable while content is unchanged; replaced
+				// whenever the record's content changes.
+				contentObject: rawRecord?.content,
 			};
 		},
 		[ kind, name, id ]
@@ -67,21 +72,20 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			return EMPTY_ARRAY;
 		}
 
-		// Cache parsed blocks by entity identity. Store the content
-		// alongside the blocks so we can validate it hasn't changed.
-		const cacheKey = getCacheKey( kind, name, id );
-		const cached = parsedBlocksCache.get( cacheKey );
-		let _blocks;
-
-		if ( cached && cached.content === content ) {
-			_blocks = cached.blocks;
-		} else {
-			_blocks = parse( content );
-			parsedBlocksCache.set( cacheKey, { content, blocks: _blocks } );
+		// Only consult the cache when `content` is the unedited raw value.
+		// An edited-content render would otherwise pollute the entry that
+		// later unedited renders depend on.
+		if ( contentObject && content === contentObject.raw ) {
+			let _blocks = parsedBlocksCache.get( contentObject );
+			if ( ! _blocks ) {
+				_blocks = parse( content );
+				parsedBlocksCache.set( contentObject, _blocks );
+			}
+			return _blocks;
 		}
 
-		return _blocks;
-	}, [ kind, name, id, editedBlocks, content ] );
+		return parse( content );
+	}, [ id, editedBlocks, content, contentObject ] );
 
 	const onChange = useCallback(
 		( newBlocks, options ) => {

--- a/packages/core-data/src/parsed-blocks-cache.js
+++ b/packages/core-data/src/parsed-blocks-cache.js
@@ -1,12 +1,10 @@
 /**
- * Shared cache of blocks parsed from an entity's `content` string, keyed by
- * `kind:name:id`. Populated both eagerly by the `getEntityRecord` resolver
- * (when the sync manager parses content for transient edits) and lazily by
- * `useEntityBlockEditor`. The stored `content` string acts as a validator so
- * stale entries are discarded when the underlying record changes.
+ * Cache of blocks parsed from an entity's `content` string. Keyed by the
+ * record's `content` object reference (the `{ raw, rendered }` value from
+ * the REST response), which the queried-data reducer preserves across
+ * receives via `conservativeMapItem` and replaces whenever content changes.
+ * That gives us free eviction when content is replaced and survival across
+ * unrelated record updates. Populated both eagerly by the `getEntityRecord`
+ * resolver and lazily by `useEntityBlockEditor`.
  */
-export const parsedBlocksCache = new Map();
-
-export function getCacheKey( kind, name, id ) {
-	return `${ kind }:${ name }:${ id }`;
-}
+export const parsedBlocksCache = new WeakMap();

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -28,7 +28,7 @@ import {
 } from './utils';
 import { fetchBlockPatterns } from './fetch';
 import { restoreSelection, getSelectionHistory } from './utils/crdt-selection';
-import { parsedBlocksCache, getCacheKey } from './parsed-blocks-cache';
+import { parsedBlocksCache } from './parsed-blocks-cache';
 
 /**
  * Requests authors from the REST API.
@@ -158,6 +158,7 @@ export const getEntityRecord =
 			}
 
 			// Entity supports syncing.
+			let recordWithTransients;
 			if ( entityConfig.syncConfig && isNumericID( key ) && ! query ) {
 				const objectType = `${ kind }/${ name }`;
 				const objectId = key;
@@ -166,7 +167,7 @@ export const getEntityRecord =
 				// the sync manager. Otherwise these transients are not available
 				// if / until the record is edited. Use a copy of the record so that
 				// it does not change the behavior outside this experimental flag.
-				const recordWithTransients = { ...record };
+				recordWithTransients = { ...record };
 				Object.entries( entityConfig.transientEdits ?? {} )
 					.filter(
 						( [ propName, transientConfig ] ) =>
@@ -180,18 +181,6 @@ export const getEntityRecord =
 						recordWithTransients[ propName ] =
 							transientConfig.read( recordWithTransients );
 					} );
-
-				// Share the parsed blocks with `useEntityBlockEditor` so the
-				// editor doesn't re-parse the same `content` string.
-				if (
-					recordWithTransients.blocks &&
-					typeof recordWithTransients.content?.raw === 'string'
-				) {
-					parsedBlocksCache.set( getCacheKey( kind, name, key ), {
-						content: recordWithTransients.content.raw,
-						blocks: recordWithTransients.blocks,
-					} );
-				}
 
 				// Load the entity record for syncing. Do not await promise.
 				void getSyncManager()?.load(
@@ -307,6 +296,28 @@ export const getEntityRecord =
 				dispatch.receiveUserPermissions( receiveUserPermissionArgs );
 				dispatch.finishResolutions( 'canUser', canUserResolutionsArgs );
 			} );
+
+			// Share the parsed blocks with `useEntityBlockEditor` keyed on
+			// the stored content reference, so the editor doesn't re-parse.
+			// Must run after the receive so the stored content object is in
+			// state — the WeakMap key has to match what `getEntityRecord`
+			// will return to the hook.
+			if (
+				recordWithTransients?.blocks &&
+				typeof record.content?.raw === 'string'
+			) {
+				const storedContent = select.getEntityRecord(
+					kind,
+					name,
+					key
+				)?.content;
+				if ( storedContent ) {
+					parsedBlocksCache.set(
+						storedContent,
+						recordWithTransients.blocks
+					);
+				}
+			}
 		} finally {
 			dispatch.__unstableReleaseStoreLock( lock );
 		}


### PR DESCRIPTION
## What?

Follow-up to #78026. Switches the parsed blocks cache from a string-keyed `Map` + content validator to a `WeakMap` keyed by the record's `content` object.

## Why?

- **Natural eviction.** The queried-data reducer (via `conservativeMapItem`) preserves the `content` object reference when content is unchanged and replaces it when content changes. So the WeakMap key changes iff content changes — no validator needed, no stale entries.
- **Survives unrelated updates.** Keying on `content` (not the whole record) means title/status/meta updates don't invalidate the cache.
- **No pollution.** The hook only writes in the unedited path (`content === contentObject.raw`), so an edited-content render can't overwrite the resolver-populated entry. Addresses [jsnajdr's concern on #78026](https://github.com/WordPress/gutenberg/pull/78026#issuecomment-4442927444).

## How?

- `parsedBlocksCache` is now a `WeakMap`.
- Hook reads `rawRecord.content` via `getEntityRecord` and uses it as the key. Edited-content renders parse uncached.
- Resolver writes to the cache **after** `registry.batch`, using `select.getEntityRecord(...).content` so the key matches what the hook will later see.

## Testing Instructions

1. \`npm run test:unit -- packages/core-data/src/test/resolvers.js packages/core-data/src/test/entity-provider.js\` — 40 tests pass, including the two from #75400 that exercise this cache (same clientIds on remount, new clientIds when content changes).
2. Open a post in the editor and confirm \`parse()\` runs once on initial load.

### Testing Instructions for Keyboard

No UI changes.

## Use of AI Tools

Authored with Claude Code (Opus 4.7). I reviewed the analysis, the keying choice, and every line of the diff before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)