### PR TITLE
Fix: MediaUpload `gallery` prop ignores `allowedTypes`

### DIFF
--- a/packages/media-utils/CHANGELOG.md
+++ b/packages/media-utils/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fix
 
--   `MediaUpload`: Fix `allowedTypes` being ignored when `gallery` prop is `true` ([#53619](https://github.com/WordPress/gutenberg/issues/53619)).
+-   `MediaUpload`: Fix `allowedTypes` being ignored when `gallery` prop is `true` ([#78257](https://github.com/WordPress/gutenberg/pull/78257)).
 
 ## 5.51.0 (2026-07-14)
 

--- a/packages/media-utils/CHANGELOG.md
+++ b/packages/media-utils/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Remove the `window.__heicUploadSupport` type declaration, following the removal of the redundant flag ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
 
+### Bug Fix
+
+-   `MediaUpload`: Fix `allowedTypes` being ignored when `gallery` prop is `true` ([#53619](https://github.com/WordPress/gutenberg/issues/53619)).
+
 ## 5.51.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -334,6 +334,7 @@ class MediaUpload extends Component {
 			multiple,
 			selection,
 			editing: !! value?.length,
+			...( allowedTypes && { library: { type: allowedTypes } } ),
 		} );
 		wp.media.frame = this.frame;
 		this.initializeListeners();


### PR DESCRIPTION
## What?
When `gallery={true}` is passed to `MediaUpload`, the `allowedTypes` prop has no effect, the media modal always shows only images.

Closes #53619

## Why?
In `buildAndSetGalleryFrame`, the `GalleryDetailsMediaFrame` is created without a `library` option. Inside the frame's `createStates` method, the library query is:

```js
library: wp.media.query( {
    type: 'image', // hardcoded
    ...this.options.library, // always undefined → no-op
} )
```

Since `library` is never passed to the frame, `this.options.library` is `undefined`, so `allowedTypes` is silently ignored for gallery frames.

## How?
Pass `library: { type: allowedTypes }` to the `GalleryDetailsMediaFrame` constructor when `allowedTypes` is provided. This is the same pattern already used by `buildAndSetSingleMediaFrame`.

## Testing Instructions
1. Create a `MediaUpload` with `gallery={true}` and `allowedTypes={['image', 'video', 'audio']}`.
2. Open the media modal and confirm that videos and audio files are now visible alongside images.
3. Create a `MediaUpload` with `gallery={true}` and no `allowedTypes`. Confirm only images appear (backward-compatible default).

<details><summary> To test the media component you can use the below code which is used in the video</summary>
<p>

```php
<?php
/**
 * Plugin Name: Test MediaUpload Gallery AllowedTypes
 * Description: Registers a test block to verify MediaUpload gallery + allowedTypes bugfix.
 * Author: Gutenberg Contributor
 */

function test_media_upload_block_register() {
    wp_register_script(
        'test-media-upload-block',
        plugins_url( 'test-media-upload.js', __FILE__ ),
        array( 'wp-blocks', 'wp-element', 'wp-components', 'wp-editor', 'wp-block-editor' ),
        filemtime( plugin_dir_path( __FILE__ ) . 'test-media-upload.js' )
    );
    register_block_type( 'gutenberg/test-media-upload', array(
        'editor_script' => 'test-media-upload-block',
    ) );
}
add_action( 'init', 'test_media_upload_block_register' );

```

```js
( function( blocks, element, components, editor, blockEditor ) {
    var el = element.createElement;
    var MediaUpload = blockEditor.MediaUpload || editor.MediaUpload;
    var Button = components.Button;

    blocks.registerBlockType( 'gutenberg/test-media-upload-1', {
        title: 'Test MediaUpload Gallery 1',
        icon: 'format-gallery',
        category: 'widgets',
        description: 'Test block for MediaUpload gallery + allowedTypes',
        edit: function( props ) {
            return el( 'div', {},
                el( 'p', {}, ' (gallery=true, allowedTypes=["image","video","audio","application","text"])' ),
                el( MediaUpload, {
                    gallery: true,
                    allowedTypes: [ 'image','video', 'audio','application','text' ],
                    render: function( obj ) {
                        return el( Button, {
                            variant: 'secondary',
                            onClick: obj.open
                        }, 'Select files (gallery)' );
                    }
                })
            );
        },
        save: function() {
            return null;
        }
    } );

    blocks.registerBlockType( 'gutenberg/test-media-upload-2', {
        title: 'Test MediaUpload Gallery 2',
        icon: 'format-gallery',
        category: 'widgets',
        description: 'Test block for MediaUpload gallery + allowedTypes',
        edit: function( props ) {
            return el( 'div', {},
                el( 'p', {}, ' (gallery=true, allowedTypes=["video","audio","application","text"])' ),
                el( MediaUpload, {
                    gallery: true,
                    allowedTypes: [ 'video', 'audio', 'application', 'text' ],
                    render: function( obj ) {
                        return el( Button, {
                            variant: 'secondary',
                            onClick: obj.open
                        }, 'Select files (gallery)' );
                    }
                })
            );
        },
        save: function() {
            return null;
        }
    } );

        blocks.registerBlockType( 'gutenberg/test-media-upload-3', {
        title: 'Test MediaUpload Gallery 3',
        icon: 'format-gallery',
        category: 'widgets',
        description: 'Test block for MediaUpload gallery + allowedTypes',
        edit: function( props ) {
            return el( 'div', {},
                el( 'p', {}, ' (allowedTypes=["image","video","audio","application","text"])' ),
                el( MediaUpload, {
                    allowedTypes: [ 'image','video', 'audio','application','text' ],
                    render: function( obj ) {
                        return el( Button, {
                            variant: 'secondary',
                            onClick: obj.open
                        }, 'Select files (gallery)' );
                    }
                })
            );
        },
        save: function() {
            return null;
        }
    } );

        blocks.registerBlockType( 'gutenberg/test-media-upload-4', {
        title: 'Test MediaUpload Gallery 4',
        icon: 'format-gallery',
        category: 'widgets',
        description: 'Test block for MediaUpload gallery + allowedTypes',
        edit: function( props ) {
            return el( 'div', {},
                el( 'p', {}, ' (allowedTypes=["video","audio","application","text"])' ),
                el( MediaUpload, {
                    allowedTypes: [ 'video', 'audio', 'application', 'text' ],
                    render: function( obj ) {
                        return el( Button, {
                            variant: 'secondary',
                            onClick: obj.open
                        }, 'Select files (gallery)' );
                    }
                })
            );
        },
        save: function() {
            return null;
        }
    } );

} )(
    window.wp.blocks,
    window.wp.element,
    window.wp.components,
    window.wp.editor,
    window.wp.blockEditor
);
```
</p>
</details> 

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:


https://github.com/user-attachments/assets/86387fcf-ae4c-4d47-9d43-dbb18f40e0e4


After:


https://github.com/user-attachments/assets/c978492b-9c48-42a8-85a6-90ae595950be

