### PR TITLE
Extract media editor save hook

### DIFF
--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import {
 	Button,
 	Flex,
@@ -10,7 +9,7 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
-import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
 	createPortal,
@@ -21,7 +20,7 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { close, drawerRight, keyboard } from '@wordpress/icons';
 import { isAppleOS, isKeyboardEvent } from '@wordpress/keycodes';
 import { SnackbarNotices, store as noticesStore } from '@wordpress/notices';
@@ -52,26 +51,20 @@ import { getMediaTypeFromMimeType } from '../../utils';
 import { CropperProvider, useCropper } from '../../image-editor';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
 import { CROP_CONTROL_ATTR } from '../../hooks/use-crop-gesture-handlers';
-import { buildModifiers } from '../media-editor-modal/build-modifiers';
 import MediaEditorKeyboardShortcutsModal from '../media-editor-keyboard-shortcuts-modal';
+import {
+	MEDIA_EDITOR_NOTICES_CONTEXT,
+	useSaveMediaEditor,
+	type MediaEditorSaveResult,
+} from './use-save-media-editor';
 
-// Details-tab edits are bundled into transformed `/edit` requests. Core's
-// endpoint only accepts this whitelist.
-const METADATA_EDIT_KEYS = [
-	'title',
-	'caption',
-	'description',
-	'alt_text',
-	'post',
-] as const;
+export type { MediaEditorSaveResult } from './use-save-media-editor';
 
 // Embed query for the attachment's author and parent post. Shared between
 // the `getEntityRecord` read and the matching `invalidateResolution` so the
 // two stay in lockstep.
 const ATTACHMENT_EMBED_QUERY = { _embed: 'author,wp:attached-to' } as const;
 
-// Scope save-failure snackbars so they don't leak into the host editor/page.
-const NOTICES_CONTEXT = 'media-editor';
 const PLACEMENT_CONTROL_IDLE_MS = 300;
 
 const { Tabs } = unlock( componentsPrivateApis );
@@ -80,12 +73,6 @@ interface EditorTab {
 	id: string;
 	title: string;
 	panel: JSX.Element;
-}
-
-export interface MediaEditorSaveResult {
-	id: number;
-	url?: string;
-	media: Media;
 }
 
 export interface MediaEditorFrameProps {
@@ -226,8 +213,6 @@ function HeaderActions( {
 	);
 }
 
-type PendingMetadataEdits = Record< string, unknown > | undefined;
-
 function MediaEditorContent( {
 	fields = [],
 	id,
@@ -277,17 +262,10 @@ function MediaEditorContent( {
 
 	const hasChanges = cropper.isDirty || hasEdits;
 
-	const registry = useRegistry();
-	const {
-		clearEntityRecordEdits,
-		editEntityRecord,
-		invalidateResolution,
-		receiveEntityRecords,
-		saveEditedEntityRecord,
-	} = useDispatch( coreStore );
-	const { createErrorNotice, removeAllNotices } = useDispatch( noticesStore );
+	const { clearEntityRecordEdits, editEntityRecord, invalidateResolution } =
+		useDispatch( coreStore );
+	const { removeAllNotices } = useDispatch( noticesStore );
 
-	const [ isSaving, setIsSaving ] = useState( false );
 	const [ isDiscardDialogOpen, setIsDiscardDialogOpen ] = useState( false );
 	const [ isPlacementActive, setIsPlacementActive ] = useState( false );
 	const [ isCanvasGestureActive, setIsCanvasGestureActive ] =
@@ -340,6 +318,13 @@ function MediaEditorContent( {
 
 	const mediaType = getMediaTypeFromMimeType( media?.mime_type ).type;
 	const isImage = !! media && mediaType === 'image';
+	const { isSaving, save: saveMediaEditor } = useSaveMediaEditor( {
+		cropper,
+		id,
+		isImage,
+		media,
+		onSaved,
+	} );
 
 	const imageAspectRatio = useMemo( () => {
 		if ( ! isImage ) {
@@ -412,7 +397,7 @@ function MediaEditorContent( {
 	};
 
 	const discardAndClose = () => {
-		removeAllNotices( 'snackbar', NOTICES_CONTEXT );
+		removeAllNotices( 'snackbar', MEDIA_EDITOR_NOTICES_CONTEXT );
 		clearEntityRecordEdits( 'postType', 'attachment', id );
 		onClose?.();
 	};
@@ -426,114 +411,6 @@ function MediaEditorContent( {
 			return;
 		}
 		discardAndClose();
-	};
-
-	const handleSave = async () => {
-		removeAllNotices( 'snackbar', NOTICES_CONTEXT );
-		setIsSaving( true );
-		try {
-			let saved: Media | null | undefined;
-
-			const modifiers =
-				cropper.isDirty && cropper.state.image
-					? buildModifiers( cropper.state, {
-							width: cropper.state.image.naturalWidth,
-							height: cropper.state.image.naturalHeight,
-					  } )
-					: [];
-
-			if ( modifiers.length > 0 ) {
-				const pendingEdits = registry
-					.select( coreStore )
-					.getEntityRecordNonTransientEdits(
-						'postType',
-						'attachment',
-						id
-					) as PendingMetadataEdits;
-				const metadataEdits: Record< string, unknown > = {};
-				for ( const key of METADATA_EDIT_KEYS ) {
-					if ( pendingEdits && key in pendingEdits ) {
-						metadataEdits[ key ] = pendingEdits[ key ];
-					}
-				}
-				// The `/edit` endpoint creates a new attachment for the crop
-				// and doesn't inherit `post_parent` from the source (unlike
-				// title/caption/etc.), so carry the existing value across when
-				// the user hasn't explicitly edited it. Use a defined-check so
-				// an explicit `0` (unattached) is also preserved.
-				if (
-					! ( 'post' in metadataEdits ) &&
-					media?.post !== undefined
-				) {
-					metadataEdits.post = media.post;
-				}
-
-				saved = ( await apiFetch( {
-					path: `/wp/v2/media/${ id }/edit`,
-					method: 'POST',
-					data: {
-						src: media?.source_url,
-						modifiers,
-						...metadataEdits,
-					},
-				} ) ) as Media;
-
-				if ( saved ) {
-					receiveEntityRecords(
-						'postType',
-						'attachment',
-						saved,
-						undefined,
-						true
-					);
-				}
-			} else {
-				saved = ( await saveEditedEntityRecord(
-					'postType',
-					'attachment',
-					id
-				) ) as Media | undefined;
-			}
-
-			const next = ( saved ?? media ) as Media | null;
-
-			if ( next && next.id !== id ) {
-				clearEntityRecordEdits( 'postType', 'attachment', id );
-			}
-
-			if ( next && next.id ) {
-				if ( next.id === id ) {
-					cropper.reset();
-				}
-				onSaved?.( {
-					id: next.id,
-					url: next.source_url,
-					media: next,
-				} );
-			}
-		} catch ( error ) {
-			const message =
-				error instanceof Error
-					? error.message
-					: ( error as { message?: string } )?.message ??
-					  __( 'An unknown error occurred.' );
-			createErrorNotice(
-				isImage
-					? sprintf(
-							/* translators: %s: Error message. */
-							__( 'Could not save image. %s' ),
-							message
-					  )
-					: sprintf(
-							/* translators: %s: Error message. */
-							__( 'Could not save media. %s' ),
-							message
-					  ),
-				{ type: 'snackbar', context: NOTICES_CONTEXT }
-			);
-		} finally {
-			setIsSaving( false );
-		}
 	};
 
 	const handleKeyDown = ( event: ReactKeyboardEvent< HTMLElement > ) => {
@@ -579,7 +456,7 @@ function MediaEditorContent( {
 	const snackbar = (
 		<SnackbarNotices
 			className={ noticesClassName }
-			context={ NOTICES_CONTEXT }
+			context={ MEDIA_EDITOR_NOTICES_CONTEXT }
 		/>
 	);
 
@@ -686,7 +563,7 @@ function MediaEditorContent( {
 				isImage={ isImage }
 				showCloseButton={ showCloseButton }
 				onCancel={ handleRequestClose }
-				onSave={ handleSave }
+				onSave={ saveMediaEditor }
 			/>
 		),
 		onRequestClose: handleRequestClose,

--- a/packages/media-editor/src/components/media-editor/use-save-media-editor.ts
+++ b/packages/media-editor/src/components/media-editor/use-save-media-editor.ts
@@ -1,0 +1,202 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useDispatch, useRegistry } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useCallback, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import type { Media } from '../media-editor-provider';
+import type { UseCropperStateReturn } from '../../image-editor';
+import {
+	buildModifiers,
+	type Modifier,
+} from '../media-editor-modal/build-modifiers';
+
+// Details-tab edits are bundled into transformed `/edit` requests. Core's
+// endpoint only accepts this whitelist.
+const METADATA_EDIT_KEYS = [
+	'title',
+	'caption',
+	'description',
+	'alt_text',
+	'post',
+] as const;
+
+// Scope media editor snackbars so they don't leak into the host editor/page.
+export const MEDIA_EDITOR_NOTICES_CONTEXT = 'media-editor';
+
+type PendingMetadataEdits = Record< string, unknown > | undefined;
+
+export interface MediaEditorSaveResult {
+	id: number;
+	url?: string;
+	media: Media;
+}
+
+interface UseSaveMediaEditorArgs {
+	cropper: UseCropperStateReturn;
+	id: number;
+	isImage: boolean;
+	media?: Media | null;
+	onSaved?: ( result: MediaEditorSaveResult ) => void;
+}
+
+interface UseSaveMediaEditorReturn {
+	isSaving: boolean;
+	save: () => Promise< void >;
+}
+
+function getCropModifiers( cropper: UseCropperStateReturn ): Modifier[] {
+	if ( ! cropper.isDirty || ! cropper.state.image ) {
+		return [];
+	}
+	return buildModifiers( cropper.state, {
+		width: cropper.state.image.naturalWidth,
+		height: cropper.state.image.naturalHeight,
+	} );
+}
+
+function getMetadataEdits(
+	pendingEdits: PendingMetadataEdits,
+	media?: Media | null
+): Record< string, unknown > {
+	const metadataEdits: Record< string, unknown > = {};
+	for ( const key of METADATA_EDIT_KEYS ) {
+		if ( pendingEdits && key in pendingEdits ) {
+			metadataEdits[ key ] = pendingEdits[ key ];
+		}
+	}
+	// The `/edit` endpoint creates a new attachment for the crop and doesn't
+	// inherit `post_parent` from the source (unlike title/caption/etc.), so
+	// carry the existing value across when the user hasn't explicitly edited
+	// it. Use a defined-check so an explicit `0` (unattached) is preserved.
+	if ( ! ( 'post' in metadataEdits ) && media?.post !== undefined ) {
+		metadataEdits.post = media.post;
+	}
+	return metadataEdits;
+}
+
+export function useSaveMediaEditor( {
+	cropper,
+	id,
+	isImage,
+	media,
+	onSaved,
+}: UseSaveMediaEditorArgs ): UseSaveMediaEditorReturn {
+	const registry = useRegistry();
+	const {
+		clearEntityRecordEdits,
+		receiveEntityRecords,
+		saveEditedEntityRecord,
+	} = useDispatch( coreStore );
+	const { createErrorNotice, removeAllNotices } = useDispatch( noticesStore );
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	const save = useCallback( async () => {
+		removeAllNotices( 'snackbar', MEDIA_EDITOR_NOTICES_CONTEXT );
+		setIsSaving( true );
+		try {
+			let saved: Media | null | undefined;
+			const modifiers = getCropModifiers( cropper );
+
+			if ( modifiers.length > 0 ) {
+				const pendingEdits = registry
+					.select( coreStore )
+					.getEntityRecordNonTransientEdits(
+						'postType',
+						'attachment',
+						id
+					) as PendingMetadataEdits;
+				const metadataEdits = getMetadataEdits( pendingEdits, media );
+
+				saved = ( await apiFetch( {
+					path: `/wp/v2/media/${ id }/edit`,
+					method: 'POST',
+					data: {
+						src: media?.source_url,
+						modifiers,
+						...metadataEdits,
+					},
+				} ) ) as Media;
+
+				if ( saved ) {
+					receiveEntityRecords(
+						'postType',
+						'attachment',
+						saved,
+						undefined,
+						true
+					);
+				}
+			} else {
+				saved = ( await saveEditedEntityRecord(
+					'postType',
+					'attachment',
+					id
+				) ) as Media | undefined;
+			}
+
+			const next = ( saved ?? media ) as Media | null;
+
+			if ( next && next.id !== id ) {
+				clearEntityRecordEdits( 'postType', 'attachment', id );
+			}
+
+			if ( next && next.id ) {
+				if ( next.id === id ) {
+					cropper.reset();
+				}
+				onSaved?.( {
+					id: next.id,
+					url: next.source_url,
+					media: next,
+				} );
+			}
+		} catch ( error ) {
+			const message =
+				error instanceof Error
+					? error.message
+					: ( error as { message?: string } )?.message ??
+					  __( 'An unknown error occurred.' );
+			createErrorNotice(
+				isImage
+					? sprintf(
+							/* translators: %s: Error message. */
+							__( 'Could not save image. %s' ),
+							message
+					  )
+					: sprintf(
+							/* translators: %s: Error message. */
+							__( 'Could not save media. %s' ),
+							message
+					  ),
+				{
+					type: 'snackbar',
+					context: MEDIA_EDITOR_NOTICES_CONTEXT,
+				}
+			);
+		} finally {
+			setIsSaving( false );
+		}
+	}, [
+		clearEntityRecordEdits,
+		createErrorNotice,
+		cropper,
+		id,
+		isImage,
+		media,
+		onSaved,
+		receiveEntityRecords,
+		registry,
+		removeAllNotices,
+		saveEditedEntityRecord,
+	] );
+
+	return { isSaving, save };
+}


### PR DESCRIPTION
## What?
- Extracts the media editor save flow from `MediaEditorContent` into a dedicated `useSaveMediaEditor` hook.
- Keeps crop modifier generation, metadata bundling, save notices, entity-store updates, and `onSaved` result handling together.
- Leaves `MediaEditorContent` focused on editor layout, interaction state, discard behavior, and frame wiring.

## Why?
This makes the modal save path easier to reason about independently from the UI shell, while preserving the current crop + metadata save behavior.

## Testing
- `npm run lint:js -- packages/media-editor/src/components/media-editor/index.tsx`
- `git diff origin/trunk... --check`
