### PR TITLE
Core Data: Avoid duplicate id-less entity permission requests

### DIFF
--- a/packages/block-library/src/navigation/test/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/test/use-navigation-menu.js
@@ -70,8 +70,14 @@ function resolveRecords( registry, menus ) {
 function resolveReadPermission( registry, allowed ) {
 	const dispatch = registry.dispatch( coreStore );
 	dispatch.receiveUserPermission( 'read/postType/wp_navigation', allowed );
-	dispatch.startResolution( 'canUser', [ 'read', BASE_ENTITY ] );
-	dispatch.finishResolution( 'canUser', [ 'read', BASE_ENTITY ] );
+	dispatch.startResolution( 'canUser', [
+		'read',
+		{ kind: 'postType', name: 'wp_navigation' },
+	] );
+	dispatch.finishResolution( 'canUser', [
+		'read',
+		{ kind: 'postType', name: 'wp_navigation' },
+	] );
 }
 
 function resolveReadRecordPermission( registry, ref, allowed ) {

--- a/packages/core-data/src/hooks/test/use-resource-permissions.js
+++ b/packages/core-data/src/hooks/test/use-resource-permissions.js
@@ -127,6 +127,63 @@ describe( 'useResourcePermissions', () => {
 		);
 	} );
 
+	it( 'normalizes id-less entity resources before resolving permissions', async () => {
+		let data;
+		triggerFetch.mockImplementation( ( options ) => {
+			if ( options.path === '/wp/v2/types?context=view' ) {
+				return {
+					wp_navigation: {
+						name: 'Navigation Menus',
+						slug: 'wp_navigation',
+						rest_base: 'navigation',
+						rest_namespace: 'wp/v2',
+					},
+				};
+			}
+			if (
+				options.path === '/wp/v2/navigation' &&
+				options.method === 'OPTIONS'
+			) {
+				return {
+					headers: new Headers( { allow: 'GET, POST' } ),
+				};
+			}
+			throw new Error(
+				`Unexpected request: ${ JSON.stringify( options ) }`
+			);
+		} );
+
+		const TestComponent = () => {
+			data = useResourcePermissions( {
+				kind: 'postType',
+				name: 'wp_navigation',
+				id: undefined,
+			} );
+			return <div />;
+		};
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+
+		await waitFor( () =>
+			expect( data ).toEqual( {
+				status: 'SUCCESS',
+				isResolving: false,
+				hasResolved: true,
+				canCreate: true,
+				canRead: true,
+			} )
+		);
+
+		expect(
+			triggerFetch.mock.calls.filter(
+				( [ options ] ) => options.path === '/wp/v2/navigation'
+			)
+		).toHaveLength( 1 );
+	} );
+
 	it( 'retrieves the relevant permissions for an entity', async () => {
 		let data;
 		const TestComponent = () => {

--- a/packages/core-data/src/hooks/use-resource-permissions.ts
+++ b/packages/core-data/src/hooks/use-resource-permissions.ts
@@ -145,15 +145,13 @@ function useResourcePermissions< IdType = void >(
 		( resolve ) => {
 			const hasId = isEntity ? !! resource.id : !! id;
 			const { canUser } = resolve( coreStore );
-			const create = canUser(
-				'create',
-				isEntity
-					? { kind: resource.kind, name: resource.name }
-					: resource
-			);
+			const collectionResource = isEntity
+				? { kind: resource.kind, name: resource.name }
+				: resource;
+			const create = canUser( 'create', collectionResource );
 
 			if ( ! hasId ) {
-				const read = canUser( 'read', resource );
+				const read = canUser( 'read', collectionResource );
 
 				const isResolving = create.isResolving || read.isResolving;
 				const hasResolved = create.hasResolved && read.hasResolved;


### PR DESCRIPTION
## What?
Fixes duplicate permission resolution for id-less entity resources in `useResourcePermissions()` by normalizing the collection resource once and using that same resource for both `create` and id-less `read` checks.

Fixes https://github.com/WordPress/gutenberg/issues/78260.

## Why?
When callers pass an entity resource with `id: undefined`, `create` was resolved against the normalized collection resource while `read` was resolved against the original object. For entities like `wp_navigation`, both checks target the same REST route, but they used different resolver arguments, so core-data could issue duplicate `OPTIONS /wp/v2/navigation` requests.

## Testing Instructions
1. Run `npm run test:unit -- --runTestsByPath packages/core-data/src/hooks/test/use-resource-permissions.js --runInBand`.
2. Run `npm run lint:js -- packages/core-data/src/hooks/use-resource-permissions.ts packages/core-data/src/hooks/test/use-resource-permissions.js`.

## Evidence
- Added a regression test covering an id-less `wp_navigation` entity resource with `id: undefined`.
- Before the fix, the regression test failed because `/wp/v2/navigation` was requested twice.
- After the fix, the targeted test file passes: 6 tests passed.
- Local lint passed for both changed files.
- Site Editor profiling with a built `core-data` patch removed the duplicate network `OPTIONS /wp/v2/navigation` request. Homeboy run: `2d3a992d-1326-4207-9d00-75aac9e8598f`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the duplicate REST request, drafting the regression test and small core-data fix, and collecting local verification evidence for Chris to review.