### PR TITLE
Extract media editor crop options hook

### DIFF
--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -14,12 +14,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import { useCropper } from '../../image-editor';
 import { useCropGestureHandlers } from '../../hooks/use-crop-gesture-handlers';
-import {
-	DEFAULT_ASPECT_RATIOS,
-	MAX_ZOOM,
-	MIN_ZOOM,
-	ORIGINAL_ASPECT_RATIO,
-} from '../../image-editor/core/constants';
+import { MAX_ZOOM, MIN_ZOOM } from '../../image-editor/core/constants';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
 
 export interface MediaEditorCropPanelProps {
@@ -37,36 +32,8 @@ export interface MediaEditorCropPanelProps {
 	onFreeformChange: ( value: boolean ) => void;
 	/** Signal that a placement-oriented control is being adjusted. */
 	onPlacementControlInteraction?: () => void;
-	/**
-	 * Fixed aspect-ratio presets to display after Free and Original. When
-	 * omitted, the media editor's default fixed-ratio presets are used.
-	 */
-	aspectRatioPresets?: AspectRatioPreset[];
-}
-
-/**
- * Resolve an aspect-ratio preset value into a number suitable for
- * `<Cropper aspectRatio=...>`. Returns `undefined` for Free (no lock).
- *
- * @param value            Preset value as a string.
- * @param imageAspectRatio Image's natural width / height — used for
- *                         the Original preset.
- */
-export function resolveAspectRatio(
-	value: string,
-	imageAspectRatio: number | null
-): number | undefined {
-	const num = parseFloat( value );
-	if ( num === 0 ) {
-		return undefined;
-	}
-	if ( num === ORIGINAL_ASPECT_RATIO && imageAspectRatio ) {
-		return imageAspectRatio;
-	}
-	if ( num > 0 ) {
-		return num;
-	}
-	return undefined;
+	/** Aspect-ratio presets to display in the selector. */
+	aspectRatioOptions: AspectRatioPreset[];
 }
 
 /**
@@ -79,7 +46,7 @@ export function resolveAspectRatio(
  * @param props.freeformCrop
  * @param props.onFreeformChange
  * @param props.onPlacementControlInteraction
- * @param props.aspectRatioPresets
+ * @param props.aspectRatioOptions
  */
 export default function MediaEditorCropPanel( {
 	aspectRatioValue,
@@ -87,21 +54,10 @@ export default function MediaEditorCropPanel( {
 	freeformCrop,
 	onFreeformChange,
 	onPlacementControlInteraction,
-	aspectRatioPresets,
+	aspectRatioOptions,
 }: MediaEditorCropPanelProps ) {
 	const { state, setZoom } = useCropper();
 	const zoomGestureHandlers = useCropGestureHandlers();
-	const aspectRatioOptions = [
-		...DEFAULT_ASPECT_RATIOS.filter( ( preset ) => preset.value <= 0 ),
-		...( aspectRatioPresets ??
-			DEFAULT_ASPECT_RATIOS.filter( ( preset ) => preset.value > 0 ) ),
-	];
-	const handleAspectRatioChange = ( value: string ) => {
-		onAspectRatioChange( value );
-		if ( value === '0' && ! freeformCrop ) {
-			onFreeformChange( true );
-		}
-	};
 
 	return (
 		<Stack direction="column" gap="md">
@@ -113,7 +69,7 @@ export default function MediaEditorCropPanel( {
 				__nextHasNoMarginBottom
 				label={ __( 'Aspect ratio' ) }
 				value={ aspectRatioValue }
-				onChange={ handleAspectRatioChange }
+				onChange={ onAspectRatioChange }
 				options={ aspectRatioOptions.map( ( preset ) => ( {
 					label: preset.label,
 					value: preset.value.toString(),

--- a/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
@@ -18,6 +18,11 @@ function setupCropPanel(
 		onAspectRatioChange: jest.fn(),
 		freeformCrop: false,
 		onFreeformChange: jest.fn(),
+		aspectRatioOptions: [
+			{ label: 'Free', value: 0 },
+			{ label: 'Original', value: -1 },
+			{ label: 'Square', value: 1 },
+		],
 		...overrides,
 	};
 
@@ -51,7 +56,7 @@ describe( 'MediaEditorCropPanel', () => {
 		expectElementBefore( resizeCropArea, zoom );
 	} );
 
-	it( 'turns freeform crop on when Free is selected while handles are off', () => {
+	it( 'passes selected aspect ratio changes to the caller', () => {
 		const controls = setupCropPanel( {
 			aspectRatioValue: '1',
 			freeformCrop: false,
@@ -61,49 +66,21 @@ describe( 'MediaEditorCropPanel', () => {
 			target: { value: '0' },
 		} );
 
-		expect( controls.onAspectRatioChange ).toHaveBeenCalledWith( '0' );
-		expect( controls.onFreeformChange ).toHaveBeenCalledWith( true );
-	} );
-
-	it( 'does not change freeform crop when a fixed ratio is selected', () => {
-		const controls = setupCropPanel( {
-			aspectRatioValue: '0',
-			freeformCrop: false,
-		} );
-
-		fireEvent.change( screen.getByLabelText( 'Aspect ratio' ), {
-			target: { value: '1' },
-		} );
-
-		expect( controls.onAspectRatioChange ).toHaveBeenCalledWith( '1' );
+		expect( controls.onAspectRatioChange ).toHaveBeenCalled();
+		expect(
+			( controls.onAspectRatioChange as jest.Mock ).mock.calls[ 0 ][ 0 ]
+		).toBe( '0' );
 		expect( controls.onFreeformChange ).not.toHaveBeenCalled();
 	} );
 
-	it( 'does not call onFreeformChange when Free is selected and handles are already on', () => {
-		const controls = setupCropPanel( {
-			aspectRatioValue: '1',
-			freeformCrop: true,
-		} );
-
-		fireEvent.change( screen.getByLabelText( 'Aspect ratio' ), {
-			target: { value: '0' },
-		} );
-
-		expect( controls.onAspectRatioChange ).toHaveBeenCalledWith( '0' );
-		expect( controls.onFreeformChange ).not.toHaveBeenCalled();
-	} );
-
-	it( 'does not call onFreeformChange when a fixed ratio is selected and handles are on', () => {
+	it( 'passes resize-handle changes to the caller', () => {
 		const controls = setupCropPanel( {
 			aspectRatioValue: '0',
 			freeformCrop: true,
 		} );
 
-		fireEvent.change( screen.getByLabelText( 'Aspect ratio' ), {
-			target: { value: '1' },
-		} );
+		fireEvent.click( screen.getByLabelText( 'Resize crop area' ) );
 
-		expect( controls.onAspectRatioChange ).toHaveBeenCalledWith( '1' );
-		expect( controls.onFreeformChange ).not.toHaveBeenCalled();
+		expect( controls.onFreeformChange ).toHaveBeenCalledWith( false );
 	} );
 } );

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -42,9 +42,7 @@ import type { Media } from '../media-editor-provider';
 import MediaPreview from '../media-preview';
 import MediaEditorCanvas from '../media-editor-canvas';
 import MediaEditorToolbar from '../media-editor-toolbar';
-import MediaEditorCropPanel, {
-	resolveAspectRatio,
-} from '../media-editor-crop-panel';
+import MediaEditorCropPanel from '../media-editor-crop-panel';
 import MediaForm from '../media-form';
 import { unlock } from '../../lock-unlock';
 import { getMediaTypeFromMimeType } from '../../utils';
@@ -57,6 +55,7 @@ import {
 	useSaveMediaEditor,
 	type MediaEditorSaveResult,
 } from './use-save-media-editor';
+import { useCropOptions } from './use-crop-options';
 
 export type { MediaEditorSaveResult } from './use-save-media-editor';
 
@@ -273,9 +272,6 @@ function MediaEditorContent( {
 	const placementControlTimerRef =
 		useRef< ReturnType< typeof setTimeout > >();
 
-	const [ aspectRatioValue, setAspectRatioValue ] = useState( '0' );
-	const [ freeformCrop, setFreeformCrop ] = useState( true );
-
 	const signalPlacementControlInteraction = useCallback( () => {
 		setIsPlacementActive( true );
 		clearTimeout( placementControlTimerRef.current );
@@ -298,8 +294,6 @@ function MediaEditorContent( {
 	}, [] );
 
 	useEffect( () => {
-		setAspectRatioValue( '0' );
-		setFreeformCrop( true );
 		setIsPlacementActive( false );
 		setIsCanvasGestureActive( false );
 	}, [ id ] );
@@ -318,6 +312,20 @@ function MediaEditorContent( {
 
 	const mediaType = getMediaTypeFromMimeType( media?.mime_type ).type;
 	const isImage = !! media && mediaType === 'image';
+	const {
+		aspectRatioValue,
+		setAspectRatioValue,
+		aspectRatioOptions,
+		freeformCrop,
+		setFreeformCrop,
+		resolvedAspectRatio,
+		resetCropOptions,
+	} = useCropOptions( {
+		id,
+		isImage,
+		media,
+		aspectRatioPresets,
+	} );
 	const { isSaving, save: saveMediaEditor } = useSaveMediaEditor( {
 		cropper,
 		id,
@@ -325,22 +333,6 @@ function MediaEditorContent( {
 		media,
 		onSaved,
 	} );
-
-	const imageAspectRatio = useMemo( () => {
-		if ( ! isImage ) {
-			return null;
-		}
-		const naturalWidth = Number( media?.media_details?.width );
-		const naturalHeight = Number( media?.media_details?.height );
-		if (
-			Number.isFinite( naturalWidth ) &&
-			Number.isFinite( naturalHeight ) &&
-			naturalHeight > 0
-		) {
-			return naturalWidth / naturalHeight;
-		}
-		return null;
-	}, [ isImage, media ] );
 
 	const tabs = useMemo< EditorTab[] >( () => {
 		const detailsTab: EditorTab = {
@@ -377,7 +369,7 @@ function MediaEditorContent( {
 							onPlacementControlInteraction={
 								signalPlacementControlInteraction
 							}
-							aspectRatioPresets={ aspectRatioPresets }
+							aspectRatioOptions={ aspectRatioOptions }
 						/>
 					</Stack>
 				),
@@ -387,8 +379,10 @@ function MediaEditorContent( {
 	}, [
 		isImage,
 		aspectRatioValue,
+		setAspectRatioValue,
 		freeformCrop,
-		aspectRatioPresets,
+		setFreeformCrop,
+		aspectRatioOptions,
 		signalPlacementControlInteraction,
 	] );
 
@@ -489,10 +483,7 @@ function MediaEditorContent( {
 								<div className="media-editor__canvas">
 									{ isImage ? (
 										<MediaEditorCanvas
-											aspectRatio={ resolveAspectRatio(
-												aspectRatioValue,
-												imageAspectRatio
-											) }
+											aspectRatio={ resolvedAspectRatio }
 											freeformCrop={ freeformCrop }
 											focusOnMount
 											isPlacementActive={
@@ -513,10 +504,7 @@ function MediaEditorContent( {
 							footer={
 								isImage ? (
 									<MediaEditorToolbar
-										onReset={ () => {
-											setAspectRatioValue( '0' );
-											setFreeformCrop( true );
-										} }
+										onReset={ resetCropOptions }
 										onPlacementControlInteraction={
 											signalPlacementControlInteraction
 										}

--- a/packages/media-editor/src/components/media-editor/test/use-crop-options.tsx
+++ b/packages/media-editor/src/components/media-editor/test/use-crop-options.tsx
@@ -1,0 +1,126 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { useCropOptions } from '../use-crop-options';
+import type { Media } from '../../media-editor-provider';
+import { ORIGINAL_ASPECT_RATIO } from '../../../image-editor/core/constants';
+
+const media = {
+	id: 1,
+	media_details: {
+		width: 1200,
+		height: 600,
+	},
+} as Media;
+
+function CropOptionsHarness( {
+	id = 1,
+	isImage = true,
+}: {
+	id?: number;
+	isImage?: boolean;
+} ) {
+	const cropOptions = useCropOptions( {
+		id,
+		isImage,
+		media,
+		aspectRatioPresets: [
+			{ label: 'Square', value: 1 },
+			{ label: 'Landscape', value: 4 / 3 },
+		],
+	} );
+
+	return (
+		<div>
+			<div data-testid="aspect-ratio-value">
+				{ cropOptions.aspectRatioValue }
+			</div>
+			<div data-testid="freeform-crop">
+				{ cropOptions.freeformCrop ? 'true' : 'false' }
+			</div>
+			<div data-testid="resolved-aspect-ratio">
+				{ cropOptions.resolvedAspectRatio ?? 'undefined' }
+			</div>
+			<div data-testid="aspect-ratio-options">
+				{ cropOptions.aspectRatioOptions
+					.map( ( option ) => option.value )
+					.join( ',' ) }
+			</div>
+			<button
+				onClick={ () =>
+					cropOptions.setAspectRatioValue(
+						ORIGINAL_ASPECT_RATIO.toString()
+					)
+				}
+			>
+				Original
+			</button>
+			<button onClick={ () => cropOptions.setAspectRatioValue( '1' ) }>
+				Square
+			</button>
+			<button onClick={ () => cropOptions.setAspectRatioValue( '0' ) }>
+				Free
+			</button>
+			<button onClick={ () => cropOptions.setFreeformCrop( false ) }>
+				Disable handles
+			</button>
+			<button onClick={ cropOptions.resetCropOptions }>Reset</button>
+		</div>
+	);
+}
+
+describe( 'useCropOptions', () => {
+	it( 'builds explicit aspect-ratio options', () => {
+		render( <CropOptionsHarness /> );
+
+		expect(
+			screen.getByTestId( 'aspect-ratio-options' )
+		).toHaveTextContent( '0,-1,1,1.3333333333333333' );
+	} );
+
+	it( 'resolves the Original aspect ratio from image dimensions', () => {
+		render( <CropOptionsHarness /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Original' } ) );
+
+		expect(
+			screen.getByTestId( 'resolved-aspect-ratio' )
+		).toHaveTextContent( '2' );
+	} );
+
+	it( 'enables freeform crop when Free is selected', () => {
+		render( <CropOptionsHarness /> );
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Disable handles' } )
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Free' } ) );
+
+		expect( screen.getByTestId( 'freeform-crop' ) ).toHaveTextContent(
+			'true'
+		);
+	} );
+
+	it( 'resets crop options when the media id changes', () => {
+		const { rerender } = render( <CropOptionsHarness id={ 1 } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Square' } ) );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Disable handles' } )
+		);
+
+		rerender( <CropOptionsHarness id={ 2 } /> );
+
+		expect( screen.getByTestId( 'aspect-ratio-value' ) ).toHaveTextContent(
+			'0'
+		);
+		expect( screen.getByTestId( 'freeform-crop' ) ).toHaveTextContent(
+			'true'
+		);
+	} );
+} );

--- a/packages/media-editor/src/components/media-editor/use-crop-options.ts
+++ b/packages/media-editor/src/components/media-editor/use-crop-options.ts
@@ -1,0 +1,150 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { Media } from '../media-editor-provider';
+import {
+	DEFAULT_ASPECT_RATIOS,
+	ORIGINAL_ASPECT_RATIO,
+} from '../../image-editor/core/constants';
+import type { AspectRatioPreset } from '../../image-editor/core/constants';
+
+const FREE_ASPECT_RATIO_VALUE = '0';
+const DEFAULT_FREEFORM_CROP = true;
+
+interface UseCropOptionsArgs {
+	id: number;
+	isImage: boolean;
+	media?: Media | null;
+	aspectRatioPresets?: AspectRatioPreset[];
+}
+
+interface UseCropOptionsReturn {
+	aspectRatioValue: string;
+	setAspectRatioValue: ( value: string ) => void;
+	aspectRatioOptions: AspectRatioPreset[];
+	freeformCrop: boolean;
+	setFreeformCrop: ( value: boolean ) => void;
+	resolvedAspectRatio: number | undefined;
+	resetCropOptions: () => void;
+}
+
+/**
+ * Resolve an aspect-ratio preset value into a number suitable for
+ * `<Cropper aspectRatio=...>`. Returns `undefined` for Free (no lock).
+ *
+ * @param value            Preset value as a string.
+ * @param imageAspectRatio Image's natural width / height — used for
+ *                         the Original preset.
+ */
+export function resolveAspectRatio(
+	value: string,
+	imageAspectRatio: number | null
+): number | undefined {
+	const num = parseFloat( value );
+	if ( num === 0 ) {
+		return undefined;
+	}
+	if ( num === ORIGINAL_ASPECT_RATIO && imageAspectRatio ) {
+		return imageAspectRatio;
+	}
+	if ( num > 0 ) {
+		return num;
+	}
+	return undefined;
+}
+
+export function getAspectRatioOptions(
+	aspectRatioPresets?: AspectRatioPreset[]
+): AspectRatioPreset[] {
+	return [
+		...DEFAULT_ASPECT_RATIOS.filter( ( preset ) => preset.value <= 0 ),
+		...( aspectRatioPresets ??
+			DEFAULT_ASPECT_RATIOS.filter( ( preset ) => preset.value > 0 ) ),
+	];
+}
+
+function getImageAspectRatio(
+	media: Media | null | undefined,
+	isImage: boolean
+): number | null {
+	if ( ! isImage ) {
+		return null;
+	}
+	const naturalWidth = Number( media?.media_details?.width );
+	const naturalHeight = Number( media?.media_details?.height );
+	if (
+		Number.isFinite( naturalWidth ) &&
+		Number.isFinite( naturalHeight ) &&
+		naturalHeight > 0
+	) {
+		return naturalWidth / naturalHeight;
+	}
+	return null;
+}
+
+export function useCropOptions( {
+	id,
+	isImage,
+	media,
+	aspectRatioPresets,
+}: UseCropOptionsArgs ): UseCropOptionsReturn {
+	const [ aspectRatioValue, setAspectRatioValueState ] = useState(
+		FREE_ASPECT_RATIO_VALUE
+	);
+	const [ freeformCrop, setFreeformCrop ] = useState( DEFAULT_FREEFORM_CROP );
+	const previousIdRef = useRef( id );
+
+	const aspectRatioOptions = useMemo(
+		() => getAspectRatioOptions( aspectRatioPresets ),
+		[ aspectRatioPresets ]
+	);
+	const imageAspectRatio = useMemo(
+		() => getImageAspectRatio( media, isImage ),
+		[ isImage, media ]
+	);
+	const resolvedAspectRatio = useMemo(
+		() => resolveAspectRatio( aspectRatioValue, imageAspectRatio ),
+		[ aspectRatioValue, imageAspectRatio ]
+	);
+
+	const resetCropOptions = useCallback( () => {
+		setAspectRatioValueState( FREE_ASPECT_RATIO_VALUE );
+		setFreeformCrop( DEFAULT_FREEFORM_CROP );
+	}, [] );
+
+	const setAspectRatioValue = useCallback( ( value: string ) => {
+		setAspectRatioValueState( value );
+		if ( value === FREE_ASPECT_RATIO_VALUE ) {
+			setFreeformCrop( true );
+		}
+	}, [] );
+
+	useEffect( () => {
+		if ( previousIdRef.current === id ) {
+			return;
+		}
+		previousIdRef.current = id;
+		resetCropOptions();
+	}, [ id, resetCropOptions ] );
+
+	return {
+		aspectRatioValue,
+		setAspectRatioValue,
+		aspectRatioOptions,
+		freeformCrop,
+		setFreeformCrop,
+		resolvedAspectRatio,
+		resetCropOptions,
+	};
+}


### PR DESCRIPTION
## What?
- Extracts media editor crop option state into a dedicated `useCropOptions` hook.
- Moves aspect-ratio option construction, Original ratio resolution, Free/freeform behavior, and reset behavior out of `MediaEditorContent` and `MediaEditorCropPanel`.
- Keeps `MediaEditorCropPanel` focused on rendering crop controls from explicit props.

## Why?
This makes the crop controls easier to reason about and gives future UX changes a single place to adjust crop-option behavior.

## Testing Instructions
There should be no visual or behavioral regression. In the media editor, confirm that:
- Aspect ratio options still appear in the same order.
- Choosing Free still enables resize handles.
- Choosing Original still uses the image's original aspect ratio.
- Reset returns crop options to Free with resize handles enabled.
