### PR TITLE
Core Data: Reuse site settings permissions

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -22,6 +22,7 @@ import {
 	getPostChangesFromCRDTDoc,
 	POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
 } from './utils/crdt';
+import { getUserPermissionsFromAllowHeader } from './utils';
 
 export const DEFAULT_ENTITY_KEY = 'id';
 const POST_RAW_ATTRIBUTES = [ 'title', 'excerpt', 'content' ];
@@ -507,10 +508,15 @@ async function loadSiteEntity() {
 		meta: {},
 	};
 
-	const site = await apiFetch( {
+	const response = await apiFetch( {
 		path: entity.baseURL,
 		method: 'OPTIONS',
+		parse: false,
 	} );
+	const site = await response.json();
+	const permissions = getUserPermissionsFromAllowHeader(
+		response.headers?.get( 'allow' )
+	);
 
 	const labels = {};
 	Object.entries( site?.schema?.properties ?? {} ).forEach(
@@ -522,7 +528,9 @@ async function loadSiteEntity() {
 		}
 	);
 
-	return [ { ...entity, meta: { labels } } ];
+	return [
+		{ ...entity, meta: { labels }, __unstablePermissions: permissions },
+	];
 }
 
 /**

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -672,7 +672,8 @@ export const canUser =
 			throw new Error( `'${ requestedAction }' is not a valid action.` );
 		}
 
-		const { hasStartedResolution } = registry.select( STORE_NAME );
+		const coreSelect = registry.select( STORE_NAME );
+		const { hasStartedResolution } = coreSelect;
 
 		// Prevent resolving the same resource twice.
 		for ( const relatedAction of ALLOWED_RESOURCE_ACTIONS ) {
@@ -703,6 +704,12 @@ export const canUser =
 					config.name === resource.name &&
 					config.kind === resource.kind
 			);
+			if (
+				coreSelect.canUser?.( requestedAction, resource, id ) !==
+				undefined
+			) {
+				return;
+			}
 			if ( ! entityConfig ) {
 				return;
 			}
@@ -1306,7 +1313,32 @@ export const getEntitiesConfig =
 				return;
 			}
 
-			dispatch.addEntities( configs );
+			const canUserResolutionsArgs = [];
+			const receiveUserPermissionArgs = {};
+			const entityConfigs = configs.map(
+				( { __unstablePermissions, ...config } ) => {
+					if ( __unstablePermissions ) {
+						for ( const action of ALLOWED_RESOURCE_ACTIONS ) {
+							const resource = {
+								kind: config.kind,
+								name: config.name,
+							};
+							canUserResolutionsArgs.push( [ action, resource ] );
+							receiveUserPermissionArgs[
+								getUserPermissionCacheKey( action, resource )
+							] = __unstablePermissions[ action ];
+						}
+					}
+					return config;
+				}
+			);
+
+			dispatch.addEntities( entityConfigs );
+
+			if ( canUserResolutionsArgs.length > 0 ) {
+				dispatch.receiveUserPermissions( receiveUserPermissionArgs );
+				dispatch.finishResolutions( 'canUser', canUserResolutionsArgs );
+			}
 		} catch {
 			// Do nothing if the request comes back with an API error.
 		}

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -21,6 +21,7 @@ import {
 	getEntityRecord,
 	getEntityRecords,
 	getEmbedPreview,
+	getEntitiesConfig,
 	canUser,
 	getAutosaves,
 	getCurrentUser,
@@ -933,6 +934,63 @@ describe( 'taxonomy pagination', () => {
 	} );
 } );
 
+describe( 'getEntitiesConfig', () => {
+	beforeEach( async () => {
+		triggerFetch.mockReset();
+	} );
+
+	it( 'caches root site permissions from the entity config request', async () => {
+		const dispatch = Object.assign( jest.fn(), {
+			addEntities: jest.fn(),
+			receiveUserPermissions: jest.fn(),
+			finishResolutions: jest.fn(),
+		} );
+
+		triggerFetch.mockResolvedValueOnce( {
+			json: () =>
+				Promise.resolve( {
+					schema: {
+						properties: {
+							title: { title: 'Title' },
+							description: { title: 'Description' },
+						},
+					},
+				} ),
+			headers: new Map( [ [ 'allow', 'GET, POST, PUT' ] ] ),
+		} );
+
+		await getEntitiesConfig( 'root' )( { dispatch } );
+
+		expect( triggerFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/settings',
+			method: 'OPTIONS',
+			parse: false,
+		} );
+		expect( dispatch.addEntities ).toHaveBeenCalledWith(
+			expect.arrayContaining( [
+				expect.not.objectContaining( {
+					__unstablePermissions: expect.anything(),
+				} ),
+			] )
+		);
+		expect( dispatch.receiveUserPermissions ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				'create/root/site': true,
+				'read/root/site': true,
+				'update/root/site': true,
+				'delete/root/site': false,
+			} )
+		);
+		expect( dispatch.finishResolutions ).toHaveBeenCalledWith(
+			'canUser',
+			expect.arrayContaining( [
+				[ 'create', { kind: 'root', name: 'site' } ],
+				[ 'read', { kind: 'root', name: 'site' } ],
+			] )
+		);
+	} );
+} );
+
 describe( 'getEmbedPreview', () => {
 	const SUCCESSFUL_EMBED_RESPONSE = { data: '<p>some html</p>' };
 	const UNEMBEDDABLE_RESPONSE = false;
@@ -1261,6 +1319,31 @@ describe( 'canUser', () => {
 				'read/postType/wp_block': true,
 			} )
 		);
+	} );
+
+	it( 'does not request permissions already cached while loading entity config', async () => {
+		registry = {
+			...registry,
+			select: () => ( {
+				hasStartedResolution: () => false,
+				canUser: () => true,
+			} ),
+		};
+		resolveSelect.getEntitiesConfig.mockResolvedValueOnce( [
+			{
+				name: 'site',
+				kind: 'root',
+				baseURL: '/wp/v2/settings',
+			},
+		] );
+
+		await canUser( 'read', { kind: 'root', name: 'site' } )( {
+			dispatch,
+			registry,
+			resolveSelect,
+		} );
+
+		expect( triggerFetch ).not.toHaveBeenCalled();
 	} );
 
 	it( 'retrieves all permissions even when ID is not given', async () => {


### PR DESCRIPTION
## What?
Reuses the `Allow` header from the root `site` entity config request to cache `canUser()` permissions for the `root/site` entity.

Fixes https://github.com/WordPress/gutenberg/issues/78259.

## Why?
The root `site` entity loader already requests `OPTIONS /wp/v2/settings` to read the settings schema labels. Later, `canUser()` can request the same `OPTIONS /wp/v2/settings` route again to resolve permissions.

This keeps the existing entity-config request, captures its `Allow` permissions, caches the corresponding `canUser()` results, and lets `canUser()` skip its own network request when entity config resolution already populated the permission cache.

## Testing Instructions
1. Run `npm run test:unit -- --runTestsByPath packages/core-data/src/test/resolvers.js --runInBand`.
2. Run `npm run lint:js -- packages/core-data/src/entities.js packages/core-data/src/resolvers.js packages/core-data/src/test/resolvers.js`.

## Evidence
- Added a regression test that verifies `getEntitiesConfig( 'root' )` caches permissions from the existing `OPTIONS /wp/v2/settings` response.
- Added a regression test that verifies `canUser( 'read', { kind: 'root', name: 'site' } )` does not issue a second permissions request when the permission was already cached while loading entity config.
- Targeted resolver tests passed: 38 tests passed.
- Local lint passed for all changed files.
- The duplicate request was originally observed in Site Editor profiling where `OPTIONS /wp/v2/settings` was preloaded, consumed by entity config/schema loading, then requested again by `canUser()`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the duplicate settings permissions request, drafting the small core-data fix and regression tests, and running local verification for Chris to review.