### PR TITLE
Media Editor Modal: Add custom datetime view for the sidebar to ensure minimal display of dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61367,6 +61367,7 @@
 				"@wordpress/core-data": "file:../core-data",
 				"@wordpress/data": "file:../data",
 				"@wordpress/dataviews": "file:../dataviews",
+				"@wordpress/date": "file:../date",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -50,6 +50,7 @@
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
 		"@wordpress/dataviews": "file:../dataviews",
+		"@wordpress/date": "file:../date",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",

--- a/packages/media-editor/src/components/media-form/index.tsx
+++ b/packages/media-editor/src/components/media-form/index.tsx
@@ -6,6 +6,7 @@ import type { Form, Field } from '@wordpress/dataviews';
 import { Spinner, __experimentalVStack as VStack } from '@wordpress/components';
 import { VisuallyHidden } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
 import type { ReactNode } from 'react';
 
 /**
@@ -13,6 +14,7 @@ import type { ReactNode } from 'react';
  */
 import { useMediaEditorContext } from '../media-editor-provider';
 import type { Media } from '../media-editor-provider';
+import SidebarDatetimeView from './sidebar-datetime-view';
 
 /**
  * Props for MediaForm component.
@@ -38,6 +40,18 @@ export default function MediaForm( {
 	header,
 }: MediaFormProps ) {
 	const { media, fields, onChange } = useMediaEditorContext();
+
+	// Render readonly datetime fields compactly in the sidebar: date only,
+	// with the full datetime exposed on hover via Tooltip and `title`.
+	const formFields = useMemo(
+		() =>
+			fields.map( ( field: Field< Media > ) =>
+				field.type === 'datetime' && field.readOnly
+					? { ...field, render: SidebarDatetimeView }
+					: field
+			),
+		[ fields ]
+	);
 
 	if ( ! media || ! onChange ) {
 		return (
@@ -82,7 +96,7 @@ export default function MediaForm( {
 				{ header }
 				<DataForm
 					data={ media }
-					fields={ fields }
+					fields={ formFields }
 					form={ form }
 					onChange={ onChange }
 				/>

--- a/packages/media-editor/src/components/media-form/sidebar-datetime-view.tsx
+++ b/packages/media-editor/src/components/media-form/sidebar-datetime-view.tsx
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { dateI18n, getDate, getSettings } from '@wordpress/date';
+import { Tooltip } from '@wordpress/components';
+import type { NormalizedField } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { Media } from '../media-editor-provider';
+
+export default function SidebarDatetimeView( {
+	item,
+	field,
+}: {
+	item: Media;
+	field: NormalizedField< Media >;
+} ) {
+	const value = field.getValue( { item } ) as string | null | undefined;
+	if ( ! value ) {
+		return null;
+	}
+	const settings = getSettings();
+	const dateOnly = dateI18n( settings.formats.date, getDate( value ) );
+	const fullDatetime = dateI18n(
+		settings.formats.datetimeAbbreviated,
+		getDate( value )
+	);
+	return (
+		<Tooltip text={ fullDatetime } placement="top">
+			<time dateTime={ value }>{ dateOnly }</time>
+		</Tooltip>
+	);
+}

--- a/packages/media-editor/tsconfig.json
+++ b/packages/media-editor/tsconfig.json
@@ -11,6 +11,7 @@
 		{ "path": "../core-data" },
 		{ "path": "../data" },
 		{ "path": "../dataviews" },
+		{ "path": "../date" },
 		{ "path": "../element" },
 		{ "path": "../i18n" },
 		{ "path": "../icons" },


### PR DESCRIPTION
## What?

Part of:

* https://github.com/WordPress/gutenberg/issues/73771

In the experimental Media Editor Modal swap out datetime fields' rendering to use a compact form that just shows the date, with the full datetime available on hover.

## Why?

Currently, the date added field has a tendency to wrap. Not always, but depending on the particular date and time it can extend _just_ beyond the available room for it visually. To tidy this up, I thought we could try just showing the date, but revealing the full string on hover. This is similar to how it's dealt with in Github.

The reason I went with this approach is that I believe we want an opinionated rendering of datetime strings for this particular UI, rather than to change the fields themselves. This ensures that in the full media library or media _upload_ modal, we continue to render the full datetime string, which is important when it comes to sorting data of many media items.

## How?

* Add a `SidebarDatetimeView` component
* When rendering the media editor's dataform, iterate over the provided fields. If a field is of type datetime and is readonly then use our custom component

## Testing Instructions

* Activate both the Media Editor Modal and Media Upload Modal experiments
* Add an image to a post or page
* Click on the crop icon in the block toolbar to open the media editor modal
* Go to the Details tab and take a look at the Date added field
* Hover over the date and you should see the full string
* Now, to ensure there's no regressions, go to add an image block again, and use the media library to open the media upload modal
* Switch to the table view, and you should see that the Date added field continues to render the full datetime string

## Screenshots or screencast <!-- if applicable -->

### Media Editor Modal (simplified string with full string available on hover)

<img width="1200" height="879" alt="image" src="https://github.com/user-attachments/assets/ee55bbbf-2558-4a22-928a-cd5307b8dfc5" />

### Media Upload Modal (still uses the full string)

<img width="1200" height="655" alt="image" src="https://github.com/user-attachments/assets/08fbeaa4-4015-4ff9-971f-90a9297c5aac" />

## Use of AI Tools

Claude Code
