### PR TITLE
Media Editor Modal: Only show the crop active state when using keyboard

### DIFF
--- a/packages/media-editor/src/image-editor/react/components/cropper.scss
+++ b/packages/media-editor/src/image-editor/react/components/cropper.scss
@@ -117,8 +117,10 @@ $handle-touch-target-size: 44px;
 	// Blue border on the crop rectangle when the canvas has keyboard focus.
 	// Uses a JS-controlled class rather than :focus-visible — browsers can
 	// restore :focus-visible across programmatic focus calls, making pure
-	// CSS unreliable for pointer-to-keyboard transitions.
-	&__canvas--focus-visible &__stencil-rect {
+	// CSS unreliable for pointer-to-keyboard transitions. The :focus check
+	// on the canvas ensures the outline appears only when the canvas
+	// itself is focused, not when focus is on a child handle.
+	&__canvas--focus-visible:focus &__stencil-rect {
 		border-color: var(--wp-image-editor-focus-color, var(--wp-admin-theme-color, #007cba));
 		box-shadow: 0 0 0 1px var(--wp-image-editor-focus-color, var(--wp-admin-theme-color, #007cba));
 	}
@@ -148,8 +150,11 @@ $handle-touch-target-size: 44px;
 		}
 
 		// Double ring (white inner + theme-color outer) for legibility
-		// over the dark dimming overlay.
-		&:focus-visible {
+		// over the dark dimming overlay. Gated on the JS-controlled
+		// keyboard-active class so that mouse interactions after a
+		// keyboard session — e.g., clicking a handle to start a drag —
+		// don't leave the active ring stuck on the handle.
+		.wp-media-editor-image-editor__canvas--focus-visible &:focus {
 			background: var(--wp-image-editor-focus-color, var(--wp-admin-theme-color, #007cba));
 			border-color: transparent;
 			box-shadow: 0 0 0 2px #fff, 0 0 0 4px var(--wp-image-editor-focus-color, var(--wp-admin-theme-color, #007cba));

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -202,18 +202,20 @@ function CropperInner(
 
 	const handleCropAreaFocus = useCallback(
 		( event: React.FocusEvent< HTMLDivElement > ) => {
-			if ( event.target === event.currentTarget ) {
+			const target = event.target as HTMLElement;
+			if ( target === event.currentTarget ) {
 				setIsCropAreaFocused( true );
-				// Show the outline only when focus arrived via keyboard
-				// navigation. relatedTarget is null for pointer-initiated and
-				// cross-window focus, so it reliably excludes those cases
-				// without needing a separate ref or flag.
-				if (
-					event.relatedTarget !== null &&
-					event.currentTarget.matches( ':focus-visible' )
-				) {
-					setIsFocusVisible( true );
-				}
+			}
+			// Show the outline only when focus arrived via keyboard
+			// navigation. relatedTarget is null for pointer-initiated and
+			// cross-window focus, so it reliably excludes those cases
+			// without needing a separate ref or flag. Applies to focus
+			// arriving on the canvas itself or on a descendant handle.
+			if (
+				event.relatedTarget !== null &&
+				target.matches( ':focus-visible' )
+			) {
+				setIsFocusVisible( true );
 			}
 		},
 		[]
@@ -223,6 +225,15 @@ function CropperInner(
 		( event: React.FocusEvent< HTMLDivElement > ) => {
 			if ( event.target === event.currentTarget ) {
 				setIsCropAreaFocused( false );
+			}
+			// Reset keyboard-active styling only when focus leaves the
+			// cropper entirely. Moves between the canvas and a handle (or
+			// between handles) keep the keyboard-active state intact.
+			if (
+				! event.currentTarget.contains(
+					event.relatedTarget as Node | null
+				)
+			) {
 				setIsFocusVisible( false );
 			}
 		},
@@ -351,27 +362,31 @@ function CropperInner(
 	// Compose focus-visibility tracking into the canvas event handlers.
 	// Kept as a spread rather than explicit props to avoid triggering
 	// jsx-a11y/no-noninteractive-element-interactions on role="group".
+	//
+	// The pointer/key tracking lives in the capture phase so it runs
+	// before any child handler — handles call stopPropagation in their
+	// own onPointerDown / onKeyDown, which would otherwise prevent the
+	// keyboard-active state from updating when the user interacts with
+	// a handle directly.
 	const canvasHandlers = {
 		...handlers,
-		onPointerDown: ( event: React.PointerEvent< HTMLDivElement > ) => {
-			handlers.onPointerDown?.( event );
-			// Called after handlers so it lands last in the React batch —
-			// el.focus() inside the handler fires onFocus, which may
-			// otherwise set isFocusVisible back to true.
+		onPointerDownCapture: () => {
 			setIsFocusVisible( false );
 		},
-		onKeyDown: ( event: React.KeyboardEvent< HTMLDivElement > ) => {
-			// Guard against keydowns bubbling up from child handles
-			// (e.g. Tab between handles, unhandled keys). Modifier-only
-			// keypresses are excluded — they precede another key rather
-			// than indicating deliberate keyboard interaction on their own.
+		onKeyDownCapture: ( event: React.KeyboardEvent< HTMLDivElement > ) => {
+			// Modifier-only keypresses precede another key rather than
+			// indicating deliberate keyboard interaction on their own.
 			if (
-				event.target === event.currentTarget &&
 				! [ 'Shift', 'Control', 'Alt', 'Meta' ].includes( event.key )
 			) {
 				setIsFocusVisible( true );
 			}
-			handlers.onKeyDown?.( event );
+		},
+		onPointerDown: ( event: React.PointerEvent< HTMLDivElement > ) => {
+			handlers.onPointerDown?.( event );
+			// Re-assert false after handlers run — el.focus() inside the
+			// handler fires onFocus, which may otherwise set it back to true.
+			setIsFocusVisible( false );
 		},
 	};
 
@@ -622,10 +637,12 @@ function CropperInner(
 						'wp-media-editor-image-editor__canvas--show-grid',
 					settling &&
 						'wp-media-editor-image-editor__canvas--settling',
-					// Show the keyboard focus outline only when the canvas
-					// itself (not a child handle) has keyboard focus.
+					// Marks the cropper as in keyboard-interaction mode.
+					// CSS uses :focus on the canvas to show the stencil
+					// outline and :focus on a handle to show its ring,
+					// so the class applies whenever any cropper element
+					// has keyboard focus.
 					isFocusVisible &&
-						isCropAreaFocused &&
 						'wp-media-editor-image-editor__canvas--focus-visible'
 				) }
 				tabIndex={ 0 }

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -176,6 +176,46 @@ describe( 'Cropper', () => {
 		);
 	} );
 
+	it( 'clears the keyboard-active class when a pointer drag starts on a handle', async () => {
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ createController() }
+				showDimming={ false }
+				freeformCrop
+				focusOnMount
+			/>
+		);
+
+		const canvas = screen.getByRole( 'group', { name: 'Crop area' } );
+		const handle = await screen.findByRole( 'button', {
+			name: 'Resize top-left corner',
+		} );
+		const focusVisibleClass =
+			'wp-media-editor-image-editor__canvas--focus-visible';
+
+		// Simulate keyboard resize on a handle — the canvas should pick up
+		// the keyboard-active class via the capture-phase keydown listener.
+		act( () => {
+			handle.focus();
+		} );
+		fireEvent.keyDown( handle, { key: 'ArrowRight' } );
+		expect( canvas ).toHaveClass( focusVisibleClass );
+
+		// Switching to the mouse on the same handle must drop the
+		// keyboard-active state, even though the handle's pointerdown
+		// handler calls stopPropagation.
+		fireEvent.pointerDown( handle, {
+			button: 0,
+			clientX: 100,
+			clientY: 100,
+			pointerId: 1,
+		} );
+		expect( canvas ).not.toHaveClass( focusVisibleClass );
+
+		fireEvent.pointerUp( handle, { pointerId: 1 } );
+	} );
+
 	it( 'returns focus to the crop area on Escape from a resize handle', async () => {
 		render(
 			<Cropper


### PR DESCRIPTION
## What?

Fix a bug in the media editor image cropper where the blue \"active\" styling on the resize handle (and crop rectangle) lingered after the user switched from keyboard to mouse. The active styling should only appear during keyboard interaction.

## Why?

The resize handle's blue ring used the browser-native `:focus-visible` pseudo-class. After a keyboard arrow-key resize, the handle's pointerdown handler blurs the handle and `setPointerCapture()`s it, then `onEnd` programmatically calls `el.focus()` to restore focus for the next keystroke. Browsers don't reliably drop `:focus-visible` across that programmatic-focus boundary when the prior modality was keyboard, so the ring stayed lit.

The canvas-level keyboard-active flag also had a hole: the handle's `onPointerDown` calls `event.stopPropagation()`, which meant the canvas's bubble-phase pointerdown listener — the thing that flipped the flag back to false — never fired when the user pressed a handle.


### Before


https://github.com/user-attachments/assets/cad88765-ee13-4395-851d-3c256e6e689f



### After


https://github.com/user-attachments/assets/1f29ee77-7133-4ad4-8f5f-44ab67ed57a6




## How?

- Move pointer/key tracking to capture-phase listeners (`onPointerDownCapture` / `onKeyDownCapture`) on the canvas. The capture phase runs before any descendant handler, so `stopPropagation` in a handle can't suppress it.
- Replace the handle's `&:focus-visible` CSS with `.wp-media-editor-image-editor__canvas--focus-visible &:focus`, gating its blue ring on the same JS-controlled keyboard-active class the stencil rectangle already uses.
- Drop the `isCropAreaFocused` requirement from the canvas class; instead, CSS `:focus` selectors distinguish whether the stencil rectangle (canvas focused) or a handle (handle focused) should show blue.
- Update `handleCropAreaFocus` / `handleCropAreaBlur` so the keyboard-active flag persists when focus moves between the canvas and a handle, and resets only when focus leaves the cropper entirely.

## Testing Instructions

1. Open an image in the Media Editor and start a crop.
2. Tab to a resize handle. The handle shows the blue active ring. ✓
3. Press arrow keys to resize. The blue ring stays. ✓
4. Without moving keyboard focus, click and drag the same handle with the mouse. The blue ring should disappear immediately and stay off during and after the drag. ✓ (Before this fix it stayed lit until you clicked outside the canvas.)
5. Press an arrow key again on the now-mouse-focused handle. The blue ring returns. ✓
6. Tab into the canvas itself, press arrow keys (image pan). The crop rectangle border shows blue. Click anywhere inside the canvas with the mouse — the border goes back to its default white. ✓

### Test plan

- [x] Added a regression unit test (`clears the keyboard-active class when a pointer drag starts on a handle`) that exercises the capture-phase pointerdown path.
- [x] All existing cropper unit tests still pass (13/13).
- [x] Manual verification against the steps above in Chrome, Firefox, and Safari.