### PR TITLE
[WP/7.0] RTC: Make sync/collaboration APIs private

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -771,14 +771,6 @@ _Returns_
 
 -   `boolean`: Whether new post and unsaved values exist.
 
-### isCollaborationEnabledForCurrentPost
-
-Returns whether the collaboration is enabled for the current post.
-
-_Returns_
-
--   `boolean`: Whether collaboration is enabled.
-
 ### isCurrentPostPending
 
 Returns true if post is pending review.

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -554,18 +554,6 @@ _Returns_
 
 -   `RevisionRecord[] | null`: Record.
 
-### getSyncConnectionStatus
-
-Returns the current sync connection status across all entities. Prioritizes disconnected states, then connecting, then connected.
-
-_Parameters_
-
--   _state_ `State`: Data state.
-
-_Returns_
-
--   `ConnectionStatus | undefined`: The current sync connection state, prioritized by importance.
-
 ### getThemeSupports
 
 Return theme supports data in the index.
@@ -948,21 +936,6 @@ _Parameters_
 -   _options.isAutosave_ `[boolean]`: Whether this is an autosave.
 -   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a promise.
 -   _options.throwOnError_ `[boolean]`: If false, this action suppresses all the exceptions. Defaults to false.
-
-### setSyncConnectionStatus
-
-Returns an action object used to set the sync connection status for an entity or collection.
-
-_Parameters_
-
--   _kind_ `string`: Kind of the entity.
--   _name_ `string`: Name of the entity.
--   _key_ `number|string|null`: The entity key, or null for collections.
--   _status_ `Object|null`: The connection state object or null on unload.
-
-_Returns_
-
--   `Object`: Action object.
 
 ### undo
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -329,21 +329,6 @@ _Parameters_
 -   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a promise.
 -   _options.throwOnError_ `[boolean]`: If false, this action suppresses all the exceptions. Defaults to false.
 
-### setSyncConnectionStatus
-
-Returns an action object used to set the sync connection status for an entity or collection.
-
-_Parameters_
-
--   _kind_ `string`: Kind of the entity.
--   _name_ `string`: Name of the entity.
--   _key_ `number|string|null`: The entity key, or null for collections.
--   _status_ `Object|null`: The connection state object or null on unload.
-
-_Returns_
-
--   `Object`: Action object.
-
 ### undo
 
 Action triggered to undo the last edit to an entity record, if any.
@@ -804,18 +789,6 @@ _Parameters_
 _Returns_
 
 -   `RevisionRecord[] | null`: Record.
-
-### getSyncConnectionStatus
-
-Returns the current sync connection status across all entities. Prioritizes disconnected states, then connecting, then connected.
-
-_Parameters_
-
--   _state_ `State`: Data state.
-
-_Returns_
-
--   `ConnectionStatus | undefined`: The current sync connection state, prioritized by importance.
 
 ### getThemeSupports
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -1131,32 +1131,3 @@ export const receiveRevisions =
 			invalidateCache,
 		} );
 	};
-
-/**
- * Returns an action object used to set the sync connection status for an entity or collection.
- *
- * @param {string}             kind   Kind of the entity.
- * @param {string}             name   Name of the entity.
- * @param {number|string|null} key    The entity key, or null for collections.
- * @param {Object|null}        status The connection state object or null on unload.
- *
- * @return {Object} Action object.
- */
-export function setSyncConnectionStatus( kind, name, key, status ) {
-	if ( ! status ) {
-		return {
-			type: 'CLEAR_SYNC_CONNECTION_STATUS',
-			kind,
-			name,
-			key,
-		};
-	}
-
-	return {
-		type: 'SET_SYNC_CONNECTION_STATUS',
-		kind,
-		name,
-		key,
-		status,
-	};
-}

--- a/packages/core-data/src/awareness/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/post-editor-awareness.ts
@@ -21,9 +21,9 @@ import {
 	areSelectionsStatesEqual,
 	getSelectionState,
 	SelectionType,
+	SelectionDirection,
 } from '../utils/crdt-user-selections';
 
-import { SelectionDirection } from '../types';
 import type { SelectionState, WPBlockSelection } from '../types';
 import type { YBlocks } from '../utils/crdt-blocks';
 import type {

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -133,13 +133,6 @@ unlock( store ).registerPrivateSelectors( privateSelectors );
 unlock( store ).registerPrivateActions( privateActions );
 register( store ); // Register store after unlocking private selectors to allow resolvers to use them.
 
-/**
- * Enums cannot be exported private without losing the ability to narrow types
- * based on their values (they blur to string type).
- */
-export { SelectionType } from './utils/crdt-user-selections';
-export { SelectionDirection } from './types';
-
 export { default as EntityProvider } from './entity-provider';
 export * from './entity-provider';
 export * from './entity-types';

--- a/packages/core-data/src/private-actions.js
+++ b/packages/core-data/src/private-actions.js
@@ -173,3 +173,32 @@ export const setCollaborationSupported =
 	( { dispatch } ) => {
 		dispatch( { type: 'SET_COLLABORATION_SUPPORTED', supported } );
 	};
+
+/**
+ * Returns an action object used to set the sync connection status for an entity or collection.
+ *
+ * @param {string}             kind   Kind of the entity.
+ * @param {string}             name   Name of the entity.
+ * @param {number|string|null} key    The entity key, or null for collections.
+ * @param {Object|null}        status The connection state object or null on unload.
+ *
+ * @return {Object} Action object.
+ */
+export function setSyncConnectionStatus( kind, name, key, status ) {
+	if ( ! status ) {
+		return {
+			type: 'CLEAR_SYNC_CONNECTION_STATUS',
+			kind,
+			name,
+			key,
+		};
+	}
+
+	return {
+		type: 'SET_SYNC_CONNECTION_STATUS',
+		kind,
+		name,
+		key,
+		status,
+	};
+}

--- a/packages/core-data/src/private-apis.ts
+++ b/packages/core-data/src/private-apis.ts
@@ -12,9 +12,12 @@ import {
 } from './hooks/use-post-editor-awareness-state';
 import { lock } from './lock-unlock';
 import { retrySyncConnection } from './sync';
+import {
+	SelectionType,
+	SelectionDirection,
+} from './utils/crdt-user-selections';
 
-export const privateApis = {};
-lock( privateApis, {
+const lockedApis = {
 	useEntityRecordsWithPermissions,
 	RECEIVE_INTERMEDIATE_RESULTS,
 	retrySyncConnection,
@@ -23,4 +26,11 @@ lock( privateApis, {
 	useOnCollaboratorJoin,
 	useOnCollaboratorLeave,
 	useOnPostSave,
-} );
+	SelectionType,
+	SelectionDirection,
+};
+
+export type CoreDataPrivateApis = typeof lockedApis;
+
+export const privateApis = {};
+lock( privateApis, lockedApis );

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { createSelector, createRegistrySelector } from '@wordpress/data';
+import type { ConnectionStatus } from '@wordpress/sync';
 
 /**
  * Internal dependencies
@@ -313,4 +314,36 @@ export function getEditorAssets( state: State ): Record< string, any > | null {
  */
 export function isCollaborationSupported( state: State ): boolean {
 	return state.collaborationSupported;
+}
+
+/**
+ * Returns the current sync connection status across all entities. Prioritizes
+ * disconnected states, then connecting, then connected.
+ *
+ * @param state Data state.
+ *
+ * @return The current sync connection state, prioritized by importance.
+ */
+export function getSyncConnectionStatus(
+	state: State
+): ConnectionStatus | undefined {
+	if ( ! state.syncConnectionStatuses ) {
+		return undefined;
+	}
+
+	const PRIORITIZED_STATUSES = [ 'disconnected', 'connecting', 'connected' ];
+
+	let coalesced: ConnectionStatus | undefined;
+
+	for ( const status of Object.values( state.syncConnectionStatuses ) ) {
+		if (
+			! coalesced ||
+			PRIORITIZED_STATUSES.indexOf( status.status ) <
+				PRIORITIZED_STATUSES.indexOf( coalesced.status )
+		) {
+			coalesced = status;
+		}
+	}
+
+	return coalesced;
 }

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1598,35 +1598,3 @@ export const getRevision = createSelector(
 		];
 	}
 );
-
-/**
- * Returns the current sync connection status across all entities. Prioritizes
- * disconnected states, then connecting, then connected.
- *
- * @param state Data state.
- *
- * @return The current sync connection state, prioritized by importance.
- */
-export function getSyncConnectionStatus(
-	state: State
-): ConnectionStatus | undefined {
-	if ( ! state.syncConnectionStatuses ) {
-		return undefined;
-	}
-
-	const PRIORITIZED_STATUSES = [ 'disconnected', 'connecting', 'connected' ];
-
-	let coalesced: ConnectionStatus | undefined;
-
-	for ( const status of Object.values( state.syncConnectionStatuses ) ) {
-		if (
-			! coalesced ||
-			PRIORITIZED_STATUSES.indexOf( status.status ) <
-				PRIORITIZED_STATUSES.indexOf( coalesced.status )
-		) {
-			coalesced = status;
-		}
-	}
-
-	return coalesced;
-}

--- a/packages/core-data/src/types.ts
+++ b/packages/core-data/src/types.ts
@@ -6,7 +6,10 @@ import type { ConnectionStatusDisconnected, Y } from '@wordpress/sync';
 /**
  * Internal dependencies
  */
-import type { SelectionType } from './utils/crdt-user-selections';
+import type {
+	SelectionType,
+	SelectionDirection,
+} from './utils/crdt-user-selections';
 
 export type { ConnectionStatus } from '@wordpress/sync';
 
@@ -71,16 +74,6 @@ export type CursorPosition = {
 	// position will always result in a redraw.
 	absoluteOffset: number;
 };
-
-/**
- * The direction of a text selection, indicating where the caret sits.
- */
-export enum SelectionDirection {
-	/** The caret is at the end of the selection (default / left-to-right). */
-	Forward = 'f',
-	/** The caret is at the start of the selection (right-to-left). */
-	Backward = 'b',
-}
 
 export type SelectionNone = {
 	// The user has not made a selection.

--- a/packages/core-data/src/utils/crdt-user-selections.ts
+++ b/packages/core-data/src/utils/crdt-user-selections.ts
@@ -22,7 +22,6 @@ import type {
 	SelectionInOneBlock,
 	SelectionInMultipleBlocks,
 	SelectionWholeBlock,
-	SelectionDirection,
 	CursorPosition,
 } from '../types';
 
@@ -35,6 +34,16 @@ export enum SelectionType {
 	SelectionInOneBlock = 'selection-in-one-block',
 	SelectionInMultipleBlocks = 'selection-in-multiple-blocks',
 	WholeBlock = 'whole-block',
+}
+
+/**
+ * The direction of a text selection, indicating where the caret sits.
+ */
+export enum SelectionDirection {
+	/** The caret is at the end of the selection (default / left-to-right). */
+	Forward = 'f',
+	/** The caret is at the start of the selection (right-to-left). */
+	Backward = 'b',
 }
 
 /**

--- a/packages/e2e-tests/plugins/sync-connection-error-filter.php
+++ b/packages/e2e-tests/plugins/sync-connection-error-filter.php
@@ -38,6 +38,7 @@ function enqueue_sync_connection_error_filter_scripts() {
 			'wp-element',
 			'wp-i18n',
 			'wp-plugins',
+			'wp-private-apis',
 		),
 		filemtime( plugin_dir_path( __FILE__ ) . 'sync-connection-error-filter/index.js' ),
 		true

--- a/packages/e2e-tests/plugins/sync-connection-error-filter/index.js
+++ b/packages/e2e-tests/plugins/sync-connection-error-filter/index.js
@@ -10,9 +10,15 @@
 	const { __ } = wp.i18n;
 	const { registerPlugin } = wp.plugins;
 
+	const { unlock } =
+		wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+			'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+			'@wordpress/core-data'
+		);
+
 	function CustomConnectionLimitModal() {
 		const connectionStatus = useSelect( function ( select ) {
-			return select( 'core' ).getSyncConnectionStatus() || null;
+			return unlock( select( 'core' ) ).getSyncConnectionStatus() || null;
 		}, [] );
 
 		const error =

--- a/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
@@ -23,17 +23,21 @@ export const useMetaBoxInitialization = ( enabled ) => {
 		isCollaborationEnabled,
 		hasIncompatibleMetaBoxes,
 	} = useSelect(
-		( select ) => ( {
-			isEnabledAndEditorReady:
-				enabled && select( editorStore ).__unstableIsEditorReady(),
-			isCollaborationEnabled:
-				select( editorStore ).isCollaborationEnabledForCurrentPost(),
-			hasIncompatibleMetaBoxes: enabled
-				? select( editPostStore )
-						.getAllMetaBoxes()
-						.some( ( metaBox ) => ! metaBox.__rtc_compatible )
-				: false,
-		} ),
+		( select ) => {
+			const {
+				__unstableIsEditorReady,
+				isCollaborationEnabledForCurrentPost,
+			} = unlock( select( editorStore ) );
+			return {
+				isEnabledAndEditorReady: enabled && __unstableIsEditorReady(),
+				isCollaborationEnabled: isCollaborationEnabledForCurrentPost(),
+				hasIncompatibleMetaBoxes: enabled
+					? select( editPostStore )
+							.getAllMetaBoxes()
+							.some( ( metaBox ) => ! metaBox.__rtc_compatible )
+					: false,
+			};
+		},
 		[ enabled ]
 	);
 	const { setCollaborationSupported } = unlock( useDispatch( coreStore ) );

--- a/packages/editor/src/components/collaborators-overlay/compute-selection.ts
+++ b/packages/editor/src/components/collaborators-overlay/compute-selection.ts
@@ -1,6 +1,10 @@
-import { SelectionDirection, SelectionType } from '@wordpress/core-data';
-import type { ResolvedSelection } from '@wordpress/core-data';
+import { privateApis as coreDataPrivateApis } from '@wordpress/core-data';
+import type {
+	CoreDataPrivateApis,
+	ResolvedSelection,
+} from '@wordpress/core-data';
 
+import { unlock } from '../../lock-unlock';
 import {
 	getCursorPosition,
 	getSelectionRects,
@@ -9,6 +13,10 @@ import {
 	isNodeBefore,
 } from './cursor-dom-utils';
 import type { CursorCoords, SelectionRect } from './cursor-dom-utils';
+
+const { SelectionDirection, SelectionType } = unlock(
+	coreDataPrivateApis
+) as Pick< CoreDataPrivateApis, 'SelectionDirection' | 'SelectionType' >;
 
 /** Common parameters passed to cursor/selection computation helpers. */
 interface OverlayContext {

--- a/packages/editor/src/components/collaborators-overlay/use-block-highlighting.ts
+++ b/packages/editor/src/components/collaborators-overlay/use-block-highlighting.ts
@@ -3,7 +3,7 @@
  */
 import {
 	privateApis as coreDataPrivateApis,
-	SelectionType,
+	type CoreDataPrivateApis,
 	type PostEditorAwarenessState as ActiveCollaborator,
 } from '@wordpress/core-data';
 import { useEffect, useRef, useState } from '@wordpress/element';
@@ -18,6 +18,10 @@ import { useDebouncedRecompute } from './use-debounced-recompute';
 
 const { useActiveCollaborators, useResolvedSelection } =
 	unlock( coreDataPrivateApis );
+const { SelectionType } = unlock( coreDataPrivateApis ) as Pick<
+	CoreDataPrivateApis,
+	'SelectionType'
+>;
 
 export interface BlockHighlightData {
 	blockId: string;

--- a/packages/editor/src/components/collaborators-overlay/use-render-cursors.ts
+++ b/packages/editor/src/components/collaborators-overlay/use-render-cursors.ts
@@ -1,12 +1,12 @@
-import {
-	privateApis as coreDataPrivateApis,
-	SelectionType,
-	type PostEditorAwarenessState as ActiveCollaborator,
+import { privateApis as coreDataPrivateApis } from '@wordpress/core-data';
+import type {
+	CoreDataPrivateApis,
+	ResolvedSelection,
+	PostEditorAwarenessState as ActiveCollaborator,
 } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
-import type { ResolvedSelection } from '@wordpress/core-data';
 
 import { unlock } from '../../lock-unlock';
 import { getAvatarUrl } from './get-avatar-url';
@@ -17,6 +17,10 @@ import type { SelectionRect } from './cursor-dom-utils';
 
 const { useActiveCollaborators, useResolvedSelection } =
 	unlock( coreDataPrivateApis );
+const { SelectionType } = unlock( coreDataPrivateApis ) as Pick<
+	CoreDataPrivateApis,
+	'SelectionType'
+>;
 
 export type { SelectionRect };
 

--- a/packages/editor/src/components/collaborators-presence/test/use-collaborator-notifications.ts
+++ b/packages/editor/src/components/collaborators-presence/test/use-collaborator-notifications.ts
@@ -52,7 +52,8 @@ jest.mock( '@wordpress/core-data', () => ( {
 } ) );
 
 jest.mock( '../../../lock-unlock', () => ( {
-	unlock: jest.fn( () => ( {
+	unlock: jest.fn( ( value: unknown ) => ( {
+		...( value as object ),
 		useOnCollaboratorJoin: jest.fn(
 			( postId: unknown, _postType: unknown, callback: Function ) => {
 				lastJoinPostId = postId;

--- a/packages/editor/src/components/collaborators-presence/use-collaborator-notifications.ts
+++ b/packages/editor/src/components/collaborators-presence/use-collaborator-notifications.ts
@@ -70,13 +70,15 @@ export function useCollaboratorNotifications(
 ): void {
 	const { postStatus, isCollaborationEnabled, showNotifications } = useSelect(
 		( select ) => {
-			const editorSel = select( editorStore );
+			const {
+				getCurrentPostAttribute,
+				isCollaborationEnabledForCurrentPost,
+			} = unlock( select( editorStore ) );
 			return {
-				postStatus: editorSel.getCurrentPostAttribute( 'status' ) as
+				postStatus: getCurrentPostAttribute( 'status' ) as
 					| string
 					| undefined,
-				isCollaborationEnabled:
-					editorSel.isCollaborationEnabledForCurrentPost(),
+				isCollaborationEnabled: isCollaborationEnabledForCurrentPost(),
 				showNotifications:
 					select( preferencesStore ).get(
 						'core',

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -26,10 +26,13 @@ import { store as editorStore } from '../../store';
 function CollaborationContext() {
 	const { isCollaborationSupported, syncConnectionStatus } = useSelect(
 		( select ) => {
-			const selectors = unlock( select( coreStore ) );
+			const {
+				isCollaborationSupported: isSupported,
+				getSyncConnectionStatus,
+			} = unlock( select( coreStore ) );
 			return {
-				isCollaborationSupported: selectors.isCollaborationSupported(),
-				syncConnectionStatus: selectors.getSyncConnectionStatus(),
+				isCollaborationSupported: isSupported(),
+				syncConnectionStatus: getSyncConnectionStatus(),
 			};
 		},
 		[]
@@ -74,7 +77,6 @@ function PostLockedModal() {
 		previewLink,
 	} = useSelect( ( select ) => {
 		const {
-			isCollaborationEnabledForCurrentPost,
 			isPostLocked,
 			isPostLockTakeover,
 			getPostLockUser,
@@ -83,7 +85,8 @@ function PostLockedModal() {
 			getEditedPostAttribute,
 			getEditedPostPreviewLink,
 			getEditorSettings,
-		} = select( editorStore );
+			isCollaborationEnabledForCurrentPost,
+		} = unlock( select( editorStore ) );
 		const { getPostType } = select( coreStore );
 		return {
 			isCollaborationEnabled: isCollaborationEnabledForCurrentPost(),

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -58,7 +58,7 @@ function PreferencesModalContents( { extraSections = {} } ) {
 	const { showBlockBreadcrumbsOption, showCollaborationOptions } = useSelect(
 		( select ) => {
 			const { getEditorSettings, isCollaborationEnabledForCurrentPost } =
-				select( editorStore );
+				unlock( select( editorStore ) );
 			const { get } = select( preferencesStore );
 			const isRichEditingEnabled = getEditorSettings().richEditingEnabled;
 			const isDistractionFreeEnabled = get( 'core', 'distractionFree' );

--- a/packages/editor/src/components/sync-connection-error-modal/index.tsx
+++ b/packages/editor/src/components/sync-connection-error-modal/index.tsx
@@ -50,17 +50,17 @@ export function SyncConnectionErrorModal() {
 
 	const { connectionStatus, isCollaborationEnabled, postType } = useSelect(
 		( selectFn ) => {
-			const currentPostType =
-				selectFn( editorStore ).getCurrentPostType();
+			const { getSyncConnectionStatus, getPostType } = unlock(
+				selectFn( coreDataStore )
+			);
+			const { getCurrentPostType, isCollaborationEnabledForCurrentPost } =
+				unlock( selectFn( editorStore ) );
+			const currentPostType = getCurrentPostType();
 			return {
-				connectionStatus:
-					selectFn( coreDataStore ).getSyncConnectionStatus() || null,
-				isCollaborationEnabled:
-					selectFn(
-						editorStore
-					).isCollaborationEnabledForCurrentPost(),
+				connectionStatus: getSyncConnectionStatus() || null,
+				isCollaborationEnabled: isCollaborationEnabledForCurrentPost(),
 				postType: currentPostType
-					? selectFn( coreDataStore ).getPostType( currentPostType )
+					? getPostType( currentPostType )
 					: null,
 			};
 		},

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -24,6 +24,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import {
 	getRenderingMode,
 	getCurrentPost,
+	getCurrentPostType,
 	getCurrentPostRevisionsCount,
 } from './selectors';
 import {
@@ -32,6 +33,7 @@ import {
 	isEntityReady as _isEntityReady,
 } from '../dataviews/store/private-selectors';
 import { getTemplatePartIcon } from '../utils';
+import { unlock } from '../lock-unlock';
 
 const EMPTY_INSERTION_POINT = {
 	rootClientId: undefined,
@@ -580,5 +582,29 @@ export const getPreviousRevision = createRegistrySelector(
 		}
 
 		return null;
+	}
+);
+
+/**
+ * Returns whether the collaboration is enabled for the current post.
+ *
+ * @return {boolean} Whether collaboration is enabled.
+ */
+export const isCollaborationEnabledForCurrentPost = createRegistrySelector(
+	( select ) => ( state ) => {
+		// Return early, if collaboration is not supported.
+		if ( ! unlock( select( coreStore ) ).isCollaborationSupported() ) {
+			return false;
+		}
+
+		const currentPostType = getCurrentPostType( state );
+		const entityConfig = select( coreStore ).getEntityConfig(
+			'postType',
+			currentPostType
+		);
+
+		return Boolean(
+			entityConfig?.syncConfig && window._wpCollaborationEnabled
+		);
 	}
 );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1879,27 +1879,3 @@ export const getPostTypeLabel = createRegistrySelector(
 export function isPublishSidebarOpened( state ) {
 	return state.publishSidebarActive;
 }
-
-/**
- * Returns whether the collaboration is enabled for the current post.
- *
- * @return {boolean} Whether collaboration is enabled.
- */
-export const isCollaborationEnabledForCurrentPost = createRegistrySelector(
-	( select ) => ( state ) => {
-		// Return early, if collaboration is not supported.
-		if ( ! unlock( select( coreStore ) ).isCollaborationSupported() ) {
-			return false;
-		}
-
-		const currentPostType = getCurrentPostType( state );
-		const entityConfig = select( coreStore ).getEntityConfig(
-			'postType',
-			currentPostType
-		);
-
-		return Boolean(
-			entityConfig?.syncConfig && window._wpCollaborationEnabled
-		);
-	}
-);

--- a/test/e2e/specs/editor/collaboration/collaboration-document-size-lock.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-document-size-lock.spec.ts
@@ -58,24 +58,40 @@ test.describe( 'Collaboration with large documents', () => {
 		// code path ran: onDocUpdate detected the oversized update,
 		// emitted the status, and unregistered the room.
 		await page.waitForFunction(
-			() =>
-				window?.wp?.data
-					?.select( 'core/editor' )
-					?.isCollaborationEnabledForCurrentPost?.() === false,
+			( consent ) => {
+				const privateApis = ( window as any ).wp.privateApis;
+				const { unlock } =
+					privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+						consent,
+						'@wordpress/core-data'
+					);
+				return (
+					unlock(
+						window.wp.data.select( 'core/editor' )
+					).isCollaborationEnabledForCurrentPost() === false
+				);
+			},
+			'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 			{ timeout: 15000 }
 		);
 
 		// Verify the sync connection status is 'disconnected' with
 		// a 'document-size-limit-exceeded' error code.
-		const syncStatus = await page.evaluate( () => {
-			const status = window.wp.data
-				.select( 'core' )
-				.getSyncConnectionStatus();
+		const syncStatus = await page.evaluate( ( consent ) => {
+			const privateApis = ( window as any ).wp.privateApis;
+			const { unlock } =
+				privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+					consent,
+					'@wordpress/core-data'
+				);
+			const status = unlock(
+				window.wp.data.select( 'core' )
+			).getSyncConnectionStatus();
 			return {
 				status: status?.status,
 				errorCode: status?.error?.code,
 			};
-		} );
+		}, 'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.' );
 		expect( syncStatus ).toEqual( {
 			status: 'disconnected',
 			errorCode: 'document-size-limit-exceeded',

--- a/test/e2e/specs/editor/collaboration/collaboration-metabox-lock.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-metabox-lock.spec.ts
@@ -51,10 +51,20 @@ test.describe( 'Collaboration with meta boxes', () => {
 			// collaborationSupported starts as true, then the meta box hook
 			// sets it to false once meta boxes are detected.
 			await page.waitForFunction(
-				() =>
-					window?.wp?.data
-						?.select( 'core/editor' )
-						?.isCollaborationEnabledForCurrentPost?.() === false,
+				( consent ) => {
+					const privateApis = ( window as any ).wp.privateApis;
+					const { unlock } =
+						privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+							consent,
+							'@wordpress/core-data'
+						);
+					return (
+						unlock(
+							window.wp.data.select( 'core/editor' )
+						).isCollaborationEnabledForCurrentPost() === false
+					);
+				},
+				'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 				{ timeout: 15000 }
 			);
 
@@ -156,10 +166,20 @@ test.describe( 'Collaboration with meta boxes', () => {
 			// Verify collaboration remains enabled. The RTC-compatible meta
 			// box should not trigger the incompatibility lock-out.
 			await page.waitForFunction(
-				() =>
-					window?.wp?.data
-						?.select( 'core/editor' )
-						?.isCollaborationEnabledForCurrentPost?.() === true,
+				( consent ) => {
+					const privateApis = ( window as any ).wp.privateApis;
+					const { unlock } =
+						privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+							consent,
+							'@wordpress/core-data'
+						);
+					return (
+						unlock(
+							window.wp.data.select( 'core/editor' )
+						).isCollaborationEnabledForCurrentPost() === true
+					);
+				},
+				'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 				{ timeout: 15000 }
 			);
 
@@ -173,7 +193,7 @@ test.describe( 'Collaboration with meta boxes', () => {
 			const modal = page2.getByRole( 'dialog', {
 				name: 'This post is already being edited',
 			} );
-			await expect( modal ).not.toBeVisible();
+			await expect( modal ).toBeHidden();
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?

Manual backport of #78097 into the `wp/7.0` branch.

## Why?

#78097 will likely fail to auto-cherry-pick to `wp/7.0`. Based on my local testing, there are a significant number of conflicts. 

## Testing Instructions

All CI checks should pass.

## Use of AI Tools

Used Claude Code to apply the upstream diff with 3-way merge and resolve the resulting conflicts against the wp/7.0 baseline.
