### PR TITLE
Media Editor: Enforce a minimum crop size in the image editor

### DIFF
--- a/packages/media-editor/src/image-editor/core/constants.ts
+++ b/packages/media-editor/src/image-editor/core/constants.ts
@@ -12,6 +12,14 @@ export const MIN_ZOOM = 1;
 export const MAX_ZOOM = 10;
 
 /**
+ * Minimum crop rect dimension in source-image pixels, enforced per axis
+ * during resize. Prevents accidental sub-pixel crops while staying small
+ * enough to allow tight crops (favicons, icons). Adjust here to tune the
+ * floor globally.
+ */
+export const MIN_CROP_PIXELS = 24;
+
+/**
  * Wheel zoom sensitivity. A deltaY of 100 changes zoom by 0.25.
  * This could be made configurable as a prop to the Cropper component.
  */

--- a/packages/media-editor/src/image-editor/core/state.ts
+++ b/packages/media-editor/src/image-editor/core/state.ts
@@ -345,24 +345,27 @@ export function cropperReducer(
 				return state;
 			}
 
-			// New crop: fill height (or width), maintain aspect ratio, center.
-			const normalizedRatio = rect.width / rect.height;
-			let newH = 1;
-			let newW = normalizedRatio;
-			if ( newW > 1 ) {
-				newW = 1;
-				newH = 1 / normalizedRatio;
-			}
+			// Scale factor: how much the crop grows. fitScale fills the
+			// larger axis to 1 (viewport-filling settle). Cap so the
+			// resulting zoom stays at or below MAX_ZOOM — tight crops
+			// would otherwise push state.zoom past the user-facing cap
+			// and break wheel/slider interactions, which clamp to
+			// MAX_ZOOM and snap state.zoom down on the first input.
+			const fitScale = 1 / Math.max( rect.width, rect.height );
+			const zoomCap = state.zoom > 0 ? MAX_ZOOM / state.zoom : fitScale;
+			const s = Math.min( fitScale, zoomCap );
 
-			// Scale factor: how much the crop grew.
-			const s = newH / rect.height;
+			const newW = rect.width * s;
+			const newH = rect.height * s;
 
 			// The old crop center in normalized visual space.
 			const oldCx = rect.x + rect.width / 2;
 			const oldCy = rect.y + rect.height / 2;
 
-			// Zoom scales by s so the same image region fills the
-			// larger crop at the same relative size.
+			// Zoom scales by s so the same image region fills the new
+			// crop at the same relative size. When s is capped, the new
+			// crop is smaller than the viewport but the visible content
+			// inside it remains the source region the user framed.
 			// Pan: the visible content center was at
 			//   (cropCx - crop.x, cropCy - crop.y)
 			// in visual-normalized space. After centering the crop to

--- a/packages/media-editor/src/image-editor/core/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/stencil-math.ts
@@ -5,8 +5,13 @@ import type { HandlePosition, NormalizedRect, Size } from './types';
 
 export type { HandlePosition };
 
-/** Minimum crop rect dimension in normalized space (5% of visual area). */
-export const MIN_CROP_SIZE = 0.05;
+/**
+ * Default minimum crop rect dimension in normalized space, used when no
+ * explicit per-axis minimum is supplied (e.g. before the source image
+ * has loaded). Real usage derives a pixel-based min from the source
+ * image dimensions and `MIN_CROP_PIXELS` in `constants.ts`.
+ */
+export const DEFAULT_MIN_CROP_SIZE: Size = { width: 0.05, height: 0.05 };
 
 /**
  * Bounds within which the crop rect must stay.
@@ -37,11 +42,12 @@ export interface ResizeDragState {
  * Each edge moves independently based on the handle being dragged.
  * Edges are clamped to the provided bounds and maintain a minimum size.
  *
- * @param drag      The current drag state.
- * @param clientX   Current mouse/touch X position in pixels.
- * @param clientY   Current mouse/touch Y position in pixels.
- * @param imageSize The rendered image dimensions in pixels.
- * @param bounds    The allowed crop area bounds.
+ * @param drag        The current drag state.
+ * @param clientX     Current mouse/touch X position in pixels.
+ * @param clientY     Current mouse/touch Y position in pixels.
+ * @param imageSize   The rendered image dimensions in pixels.
+ * @param bounds      The allowed crop area bounds.
+ * @param minCropSize Minimum crop rect dimension in normalized space, per axis.
  * @return The new crop rect in normalized coordinates.
  */
 export function computeFreeResizeRect(
@@ -49,7 +55,8 @@ export function computeFreeResizeRect(
 	clientX: number,
 	clientY: number,
 	imageSize: Size,
-	bounds: CropBounds
+	bounds: CropBounds,
+	minCropSize: Size = DEFAULT_MIN_CROP_SIZE
 ): NormalizedRect {
 	const dx =
 		imageSize.width > 0 ? ( clientX - drag.startX ) / imageSize.width : 0;
@@ -67,24 +74,24 @@ export function computeFreeResizeRect(
 	if ( handle === 'n' || handle === 'nw' || handle === 'ne' ) {
 		edgeTop = Math.max(
 			bounds.minY,
-			Math.min( s.y + dy, edgeBottom - MIN_CROP_SIZE )
+			Math.min( s.y + dy, edgeBottom - minCropSize.height )
 		);
 	}
 	if ( handle === 's' || handle === 'sw' || handle === 'se' ) {
 		edgeBottom = Math.max(
-			edgeTop + MIN_CROP_SIZE,
+			edgeTop + minCropSize.height,
 			Math.min( s.y + s.height + dy, bounds.maxY )
 		);
 	}
 	if ( handle === 'w' || handle === 'nw' || handle === 'sw' ) {
 		edgeLeft = Math.max(
 			bounds.minX,
-			Math.min( s.x + dx, edgeRight - MIN_CROP_SIZE )
+			Math.min( s.x + dx, edgeRight - minCropSize.width )
 		);
 	}
 	if ( handle === 'e' || handle === 'ne' || handle === 'se' ) {
 		edgeRight = Math.max(
-			edgeLeft + MIN_CROP_SIZE,
+			edgeLeft + minCropSize.width,
 			Math.min( s.x + s.width + dx, bounds.maxX )
 		);
 	}
@@ -110,6 +117,7 @@ export function computeFreeResizeRect(
  * @param imageSize       The rendered image dimensions in pixels.
  * @param bounds          The allowed crop area bounds.
  * @param normalizedRatio The locked aspect ratio (width / height in normalized space).
+ * @param minCropSize     Minimum crop rect dimension in normalized space, per axis.
  * @return The new crop rect in normalized coordinates.
  */
 export function computeLockedResizeRect(
@@ -118,7 +126,8 @@ export function computeLockedResizeRect(
 	clientY: number,
 	imageSize: Size,
 	bounds: CropBounds,
-	normalizedRatio: number
+	normalizedRatio: number,
+	minCropSize: Size = DEFAULT_MIN_CROP_SIZE
 ): NormalizedRect {
 	// The math below divides by `normalizedRatio` and `imageSize`, so
 	// bail out with the start rect when any of them is zero. This can
@@ -156,9 +165,15 @@ export function computeLockedResizeRect(
 	let distW = ( draggedX - anchorX ) * dirX;
 	let distH = ( draggedY - anchorY ) * dirY;
 
-	// Enforce minimum size.
-	distW = Math.max( distW, MIN_CROP_SIZE );
-	distH = Math.max( distH, MIN_CROP_SIZE );
+	// Enforce minimum size on both axes, projecting through the ratio so
+	// neither axis falls below its per-axis floor.
+	const minDistW = Math.max(
+		minCropSize.width,
+		minCropSize.height * normalizedRatio
+	);
+	const minDistH = minDistW / normalizedRatio;
+	distW = Math.max( distW, minDistW );
+	distH = Math.max( distH, minDistH );
 
 	// Determine which axis "drives" — whichever the user moved more
 	// (in pixel space) determines the size, the other follows. The
@@ -192,8 +207,8 @@ export function computeLockedResizeRect(
 	}
 
 	// Enforce minimum after clamping.
-	distW = Math.max( distW, MIN_CROP_SIZE );
-	distH = Math.max( distH, MIN_CROP_SIZE );
+	distW = Math.max( distW, minDistW );
+	distH = Math.max( distH, minDistH );
 
 	// Compute the final rect position from the anchor.
 	const newX = dirX > 0 ? anchorX : anchorX - distW;
@@ -211,11 +226,12 @@ export function computeLockedResizeRect(
  * axis symmetrically around the rect's center to preserve the ratio,
  * clamping symmetrically so the rect stays within bounds.
  *
- * @param drag      The current drag state.
- * @param clientX   Current mouse/touch X position in pixels.
- * @param clientY   Current mouse/touch Y position in pixels.
- * @param imageSize The rendered image dimensions in pixels.
- * @param bounds    The allowed crop area bounds.
+ * @param drag        The current drag state.
+ * @param clientX     Current mouse/touch X position in pixels.
+ * @param clientY     Current mouse/touch Y position in pixels.
+ * @param imageSize   The rendered image dimensions in pixels.
+ * @param bounds      The allowed crop area bounds.
+ * @param minCropSize Minimum crop rect dimension in normalized space, per axis.
  * @return The new crop rect in normalized coordinates.
  */
 export function computeShiftLockedResizeRect(
@@ -223,7 +239,8 @@ export function computeShiftLockedResizeRect(
 	clientX: number,
 	clientY: number,
 	imageSize: Size,
-	bounds: CropBounds
+	bounds: CropBounds,
+	minCropSize: Size = DEFAULT_MIN_CROP_SIZE
 ): NormalizedRect {
 	const s = drag.startRect;
 	const pixelW = s.width * imageSize.width;
@@ -234,7 +251,8 @@ export function computeShiftLockedResizeRect(
 			clientX,
 			clientY,
 			imageSize,
-			bounds
+			bounds,
+			minCropSize
 		);
 	}
 	const normalizedRatio = s.width / s.height;
@@ -252,7 +270,8 @@ export function computeShiftLockedResizeRect(
 			clientY,
 			imageSize,
 			bounds,
-			normalizedRatio
+			normalizedRatio,
+			minCropSize
 		);
 	}
 
@@ -263,7 +282,8 @@ export function computeShiftLockedResizeRect(
 		clientX,
 		clientY,
 		imageSize,
-		bounds
+		bounds,
+		minCropSize
 	);
 
 	if ( handle === 'n' || handle === 's' ) {
@@ -281,11 +301,11 @@ export function computeShiftLockedResizeRect(
 		}
 		// Enforce the minimum on the driving axis, then derive the
 		// other axis from the ratio so it stays consistent. The
-		// effective minimum height has to satisfy MIN_CROP_SIZE on
-		// both axes simultaneously.
+		// effective minimum height has to satisfy the per-axis floor
+		// on both axes simultaneously.
 		const minHeight = Math.max(
-			MIN_CROP_SIZE,
-			MIN_CROP_SIZE / normalizedRatio
+			minCropSize.height,
+			minCropSize.width / normalizedRatio
 		);
 		if ( newHeight < minHeight ) {
 			newHeight = minHeight;
@@ -312,7 +332,10 @@ export function computeShiftLockedResizeRect(
 		newHeight = maxHeight;
 		newWidth = newHeight * normalizedRatio;
 	}
-	const minWidth = Math.max( MIN_CROP_SIZE, MIN_CROP_SIZE * normalizedRatio );
+	const minWidth = Math.max(
+		minCropSize.width,
+		minCropSize.height * normalizedRatio
+	);
 	if ( newWidth < minWidth ) {
 		newWidth = minWidth;
 		newHeight = newWidth / normalizedRatio;

--- a/packages/media-editor/src/image-editor/core/test/state.ts
+++ b/packages/media-editor/src/image-editor/core/test/state.ts
@@ -1,5 +1,5 @@
 import type { CropperState, Size } from '../types';
-import { DEFAULT_STATE } from '../constants';
+import { DEFAULT_STATE, MAX_ZOOM } from '../constants';
 import { cropperReducer, enforceContainment, isStateDirty } from '../state';
 import {
 	createCamera,
@@ -265,6 +265,28 @@ describe( 'cropperReducer — SETTLE_CROP', () => {
 		const settled = cropperReducer( state, { type: 'SETTLE_CROP' } );
 
 		expect( settled.zoom ).toBeGreaterThan( 0 );
+		expectSameVisibleRegion( state, settled );
+	} );
+
+	it( 'caps zoom at MAX_ZOOM for tight crops and keeps the visible region', () => {
+		// A 5% crop at zoom=1 would otherwise settle to zoom=20 (1/0.05),
+		// pushing state past the user-facing zoom cap and breaking wheel
+		// and slider interactions that clamp to MAX_ZOOM. With the cap,
+		// the post-settle crop is smaller than the viewport but the
+		// content the user framed is preserved.
+		const state = makeState( {
+			cropRect: { x: 0.4, y: 0.4, width: 0.05, height: 0.05 },
+			zoom: 1,
+			pan: { x: 0, y: 0 },
+		} );
+		const settled = cropperReducer( state, { type: 'SETTLE_CROP' } );
+
+		expect( settled.zoom ).toBeCloseTo( MAX_ZOOM, 5 );
+		// The scale was capped at MAX_ZOOM/zoom (=10), not at the uncapped
+		// fit scale of 20 — so the new crop is 5% × 10 = 50% of the viewport,
+		// not 100%.
+		expect( settled.cropRect.width ).toBeCloseTo( 0.5, 5 );
+		expect( settled.cropRect.height ).toBeCloseTo( 0.5, 5 );
 		expectSameVisibleRegion( state, settled );
 	} );
 

--- a/packages/media-editor/src/image-editor/core/test/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/test/stencil-math.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import {
+	computeFreeResizeRect,
 	computeLockedResizeRect,
 	computeShiftLockedResizeRect,
 	type CropBounds,
@@ -316,6 +317,198 @@ describe( 'computeShiftLockedResizeRect', () => {
 			const newPixelRatio =
 				( rect.width * IMAGE.width ) / ( rect.height * IMAGE.height );
 			expect( newPixelRatio ).toBeCloseTo( startPixelRatio, 5 );
+		} );
+	} );
+} );
+
+describe( 'per-axis minCropSize', () => {
+	// Cover the explicit per-axis floor introduced for the source-pixel
+	// minimum. The defaults (0.05, 0.05) are already covered by the
+	// suites above; these tests pass `minCropSize` explicitly to lock in
+	// the math the cropper relies on.
+	const IMAGE_NON_SQUARE: Size = { width: 1000, height: 500 };
+
+	describe( 'computeFreeResizeRect', () => {
+		it( 'clamps the dragged edge to the per-axis floor (width)', () => {
+			// SE handle from a wide start rect; drag left far enough that
+			// width would collapse without the floor.
+			const startRect = { x: 0.1, y: 0.1, width: 0.6, height: 0.6 };
+			const drag: ResizeDragState = {
+				handle: 'e',
+				startX: 700,
+				startY: 350,
+				startRect,
+			};
+			const minCropSize: Size = { width: 0.2, height: 0.05 };
+			const rect = computeFreeResizeRect(
+				drag,
+				0,
+				350,
+				IMAGE_NON_SQUARE,
+				FULL_BOUNDS,
+				minCropSize
+			);
+			expect( rect.width ).toBeCloseTo( minCropSize.width, 5 );
+			// Left edge anchored at start; right edge pulled in to the floor.
+			expect( rect.x ).toBeCloseTo( startRect.x, 5 );
+		} );
+
+		it( 'clamps the dragged edge to the per-axis floor (height)', () => {
+			const startRect = { x: 0.1, y: 0.1, width: 0.6, height: 0.6 };
+			const drag: ResizeDragState = {
+				handle: 's',
+				startX: 500,
+				startY: 350,
+				startRect,
+			};
+			const minCropSize: Size = { width: 0.05, height: 0.3 };
+			const rect = computeFreeResizeRect(
+				drag,
+				500,
+				0,
+				IMAGE_NON_SQUARE,
+				FULL_BOUNDS,
+				minCropSize
+			);
+			expect( rect.height ).toBeCloseTo( minCropSize.height, 5 );
+			expect( rect.y ).toBeCloseTo( startRect.y, 5 );
+		} );
+
+		it( 'uses width vs height independently — different floors per axis', () => {
+			// Drag NW corner inward far past both floors. The per-axis
+			// floors clamp x-collapse and y-collapse independently.
+			const startRect = { x: 0.1, y: 0.1, width: 0.8, height: 0.8 };
+			const drag: ResizeDragState = {
+				handle: 'nw',
+				startX: 100,
+				startY: 50,
+				startRect,
+			};
+			const minCropSize: Size = { width: 0.4, height: 0.1 };
+			const rect = computeFreeResizeRect(
+				drag,
+				1000,
+				500,
+				IMAGE_NON_SQUARE,
+				FULL_BOUNDS,
+				minCropSize
+			);
+			// Both floors hit at the same time on different axes.
+			expect( rect.width ).toBeCloseTo( minCropSize.width, 5 );
+			expect( rect.height ).toBeCloseTo( minCropSize.height, 5 );
+		} );
+	} );
+
+	describe( 'computeLockedResizeRect — per-axis floor projects through the ratio', () => {
+		// Wide image, square aspect ratio. The per-axis floor projection
+		// in `minDistW = max(minCropSize.width, minCropSize.height * normalizedRatio)`
+		// is the load-bearing piece for non-equal per-axis floors.
+		const imageSize: Size = { width: 2000, height: 1000 };
+		const aspectRatio = 1; // pixel-square
+		const normalizedRatio =
+			( aspectRatio * imageSize.height ) / imageSize.width; // 0.5
+		const startRect = { x: 0, y: 0, width: 0, height: 0 };
+
+		it( 'lifts width to satisfy the height floor when the height floor is the binding axis', () => {
+			// Drag SE inward to zero — both axes try to collapse. With
+			// minCropSize = { 0.01, 0.05 } and normalizedRatio 0.5,
+			// minDistW = max(0.01, 0.05 * 0.5) = 0.025, minDistH = 0.05.
+			// Driver: pixel motion equal → height drives → distW = distH/2.
+			const drag: ResizeDragState = {
+				handle: 'se',
+				startX: 0,
+				startY: 0,
+				startRect,
+			};
+			const minCropSize: Size = { width: 0.01, height: 0.05 };
+			const rect = computeLockedResizeRect(
+				drag,
+				1,
+				1,
+				imageSize,
+				FULL_BOUNDS,
+				normalizedRatio,
+				minCropSize
+			);
+			// Height floor binds: width is `height * normalizedRatio`.
+			expect( rect.height ).toBeCloseTo( minCropSize.height, 5 );
+			expect( rect.width ).toBeCloseTo(
+				minCropSize.height * normalizedRatio,
+				5
+			);
+		} );
+
+		it( 'lifts height to satisfy the width floor when the width floor binds', () => {
+			// minDistW = max(0.2, 0.05 * 0.5) = 0.2, minDistH = 0.4.
+			const drag: ResizeDragState = {
+				handle: 'se',
+				startX: 0,
+				startY: 0,
+				startRect,
+			};
+			const minCropSize: Size = { width: 0.2, height: 0.05 };
+			const rect = computeLockedResizeRect(
+				drag,
+				1,
+				1,
+				imageSize,
+				FULL_BOUNDS,
+				normalizedRatio,
+				minCropSize
+			);
+			expect( rect.width ).toBeCloseTo( 0.2, 5 );
+			expect( rect.height ).toBeCloseTo( 0.4, 5 );
+		} );
+	} );
+
+	describe( 'computeShiftLockedResizeRect — edge handles', () => {
+		// Shift-locked edge resize must enforce the floor on the driver
+		// axis and on the perpendicular axis after projecting through
+		// the start rect's normalized ratio.
+		const imageSize: Size = { width: 1000, height: 500 };
+		// Wide start rect — normalizedRatio = 0.4/0.4 = 1.
+		const startRect = { x: 0.3, y: 0.3, width: 0.4, height: 0.4 };
+
+		it( 'east edge: width-driver respects width floor and projects to height', () => {
+			const drag: ResizeDragState = {
+				handle: 'e',
+				startX: 700,
+				startY: 400,
+				startRect,
+			};
+			// Drag well past the floor toward the start anchor.
+			const minCropSize: Size = { width: 0.2, height: 0.05 };
+			const rect = computeShiftLockedResizeRect(
+				drag,
+				300,
+				400,
+				imageSize,
+				FULL_BOUNDS,
+				minCropSize
+			);
+			// Width clamped at the per-axis floor; height follows ratio (1:1).
+			expect( rect.width ).toBeCloseTo( minCropSize.width, 5 );
+			expect( rect.height ).toBeCloseTo( minCropSize.width, 5 );
+		} );
+
+		it( 'north edge: height-driver respects height floor and projects to width', () => {
+			const drag: ResizeDragState = {
+				handle: 'n',
+				startX: 500,
+				startY: 300,
+				startRect,
+			};
+			const minCropSize: Size = { width: 0.05, height: 0.2 };
+			const rect = computeShiftLockedResizeRect(
+				drag,
+				500,
+				700,
+				imageSize,
+				FULL_BOUNDS,
+				minCropSize
+			);
+			expect( rect.height ).toBeCloseTo( minCropSize.height, 5 );
+			expect( rect.width ).toBeCloseTo( minCropSize.height, 5 );
 		} );
 	} );
 } );

--- a/packages/media-editor/src/image-editor/core/types.ts
+++ b/packages/media-editor/src/image-editor/core/types.ts
@@ -203,4 +203,10 @@ export interface StencilProps {
 	};
 	/** Called when Escape is pressed on a resize handle. */
 	onEscape?: () => void;
+	/**
+	 * Minimum crop rect dimension in normalized space, per axis. Derived
+	 * by the host from a pixel-based floor (see `MIN_CROP_PIXELS`) and
+	 * the source image dimensions. Omit to use the stencil's default.
+	 */
+	minCropSize?: Size;
 }

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -291,9 +291,13 @@ function CropperInner(
 		[ canvasSize, naturalWidth, naturalHeight, state.rotation ]
 	);
 
-	// Per-axis minimum crop size in normalized space, derived from a
-	// pixel-based floor. The crop rect is normalized in the rotated bbox,
-	// so use bbox dims (which swap at 90°/270°) for the conversion.
+	// Per-axis minimum crop size in normalized space, expressing a
+	// pixel floor on the captured source region. cropRect is normalized
+	// in the viewport's snap-rotation bbox; the captured source-pixel
+	// width is `cropRect.width * bbox.width / zoom`, so the normalized
+	// floor scales with `zoom` to keep the source-pixel floor constant.
+	// Without this, SETTLE_CROP zooms in proportional to the shrink and
+	// successive drags can crop arbitrarily small.
 	const minCropSize: Size | undefined = useMemo( () => {
 		if ( naturalWidth <= 0 || naturalHeight <= 0 ) {
 			return undefined;
@@ -305,10 +309,13 @@ function CropperInner(
 			snapRotation
 		);
 		return {
-			width: Math.min( 1, MIN_CROP_PIXELS / bbox.width ),
-			height: Math.min( 1, MIN_CROP_PIXELS / bbox.height ),
+			width: Math.min( 1, ( MIN_CROP_PIXELS * state.zoom ) / bbox.width ),
+			height: Math.min(
+				1,
+				( MIN_CROP_PIXELS * state.zoom ) / bbox.height
+			),
 		};
-	}, [ naturalWidth, naturalHeight, state.rotation ] );
+	}, [ naturalWidth, naturalHeight, state.rotation, state.zoom ] );
 
 	// In fixed-crop mode, auto-size the crop rect only when a fixed aspect
 	// ratio is selected. With "Free" selected, turning freeform handles off

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -32,7 +32,7 @@ import type {
 import type { UseCropperStateReturn } from '../hooks/use-cropper-state';
 import { getImageFit, getRotatedBBox } from '../../core/camera';
 import { getImageCropBounds } from '../../core/containment';
-import { MIN_CROP_PIXELS } from '../../core/constants';
+import { MIN_CROP_PIXELS, MIN_ZOOM } from '../../core/constants';
 import { useInteraction } from '../hooks/use-interaction';
 import { useTransformStyle } from '../hooks/use-transform-style';
 import { useAriaAnnouncer } from '../hooks/use-aria-announcer';
@@ -49,14 +49,10 @@ const CROP_RECT_EPSILON = 1e-6;
 
 // Largest rect of the given pixel aspect ratio that fits inside the visual
 // bounds, centered in [0,1] × [0,1] normalized space. Returns a full-frame
-// rect (1×1) if `aspectRatio` is unset or non-positive. If `minCropSize`
-// is supplied and the inscribed rect would fall below it on either axis,
-// the rect is scaled up (preserving ratio) until both axes satisfy the
-// floor, capped at the viewport edges.
+// rect (1×1) if `aspectRatio` is unset or non-positive.
 function computeInscribedRect(
 	aspectRatio: number | undefined,
-	visualSize: Size,
-	minCropSize?: Size
+	visualSize: Size
 ): NormalizedRect {
 	let w = 1;
 	let h = 1;
@@ -73,27 +69,6 @@ function computeInscribedRect(
 		} else {
 			h = 1 / normalizedRatio;
 		}
-
-		// Enforce the per-axis minimum (in normalized space). Scale up
-		// the binding axis to the floor and re-derive the other axis
-		// from the ratio so the rect doesn't fall below MIN_CROP_PIXELS
-		// in source pixels on either side.
-		if ( minCropSize ) {
-			if ( w < minCropSize.width ) {
-				w = Math.min( 1, minCropSize.width );
-				h = w / normalizedRatio;
-			}
-			if ( h < minCropSize.height ) {
-				h = Math.min( 1, minCropSize.height );
-				w = h * normalizedRatio;
-			}
-			// Final cap in case both floors push past [0,1]. At extreme
-			// zoom the ratio may no longer be expressible inside the
-			// viewport — accept the deformation rather than crop below
-			// the source-pixel floor.
-			w = Math.min( 1, w );
-			h = Math.min( 1, h );
-		}
 	}
 	return {
 		x: ( 1 - w ) / 2,
@@ -101,44 +76,6 @@ function computeInscribedRect(
 		width: w,
 		height: h,
 	};
-}
-
-// Largest zoom at which the inscribed rect of `aspectRatio` still satisfies
-// `minCropPixels` on both axes. Used on aspect-ratio change to lower the
-// zoom just enough so the new ratio can be expressed without violating
-// the source-pixel floor. Returns Infinity for an unset ratio.
-function computeMaxZoomForRatio(
-	aspectRatio: number | undefined,
-	bbox: Size,
-	minCropPixels: number
-): number {
-	if (
-		! aspectRatio ||
-		aspectRatio <= 0 ||
-		bbox.width <= 0 ||
-		bbox.height <= 0
-	) {
-		return Infinity;
-	}
-	// Inscribed rect proportions in viewport-normalized space (zoom-
-	// independent). One axis fills (=1), the other follows from the
-	// pixel aspect ratio and the bbox aspect.
-	const bboxAspect = bbox.width / bbox.height;
-	let wV: number;
-	let hV: number;
-	if ( aspectRatio <= bboxAspect ) {
-		hV = 1;
-		wV = ( aspectRatio * bbox.height ) / bbox.width;
-	} else {
-		wV = 1;
-		hV = bbox.width / ( aspectRatio * bbox.height );
-	}
-	// At zoom Z, source-pixel dims = wV*bbox.width/Z and hV*bbox.height/Z.
-	// For both ≥ minCropPixels: Z ≤ min(wV*bbox.W, hV*bbox.H) / minCropPixels.
-	return Math.min(
-		( wV * bbox.width ) / minCropPixels,
-		( hV * bbox.height ) / minCropPixels
-	);
 }
 
 /**
@@ -394,11 +331,7 @@ function CropperInner(
 		) {
 			return;
 		}
-		const rect = computeInscribedRect(
-			aspectRatio,
-			visualSize,
-			minCropSize
-		);
+		const rect = computeInscribedRect( aspectRatio, visualSize );
 		const current = state.cropRect;
 		if (
 			Math.abs( current.x - rect.x ) < CROP_RECT_EPSILON &&
@@ -409,19 +342,13 @@ function CropperInner(
 			return;
 		}
 		setCropRect( rect );
-	}, [
-		freeformCrop,
-		aspectRatio,
-		visualSize,
-		setCropRect,
-		state.cropRect,
-		minCropSize,
-	] );
+	}, [ freeformCrop, aspectRatio, visualSize, setCropRect, state.cropRect ] );
 
 	// In freeform mode, when aspectRatio changes, reshape the crop to the
-	// largest inscribed rect of the new ratio. If the current zoom is so
-	// high that the inscribed rect would violate the source-pixel floor,
-	// lower zoom (and reset pan) just enough that both axes satisfy it.
+	// largest inscribed rect of the new ratio. Reset zoom and pan so the
+	// inscribed rect has the full image to work with — without this, a
+	// prior SETTLE_CROP could leave the viewport too zoomed-in for the
+	// new ratio to satisfy the source-pixel floor.
 	const prevAspectRatioRef = useRef( aspectRatio );
 	useEffect( () => {
 		if ( prevAspectRatioRef.current === aspectRatio ) {
@@ -434,52 +361,13 @@ function CropperInner(
 			visualSize.width === 0 ||
 			visualSize.height === 0 ||
 			! aspectRatio ||
-			aspectRatio <= 0 ||
-			naturalWidth <= 0 ||
-			naturalHeight <= 0
+			aspectRatio <= 0
 		) {
 			return;
 		}
-
-		const snapRotation = Math.round( state.rotation / 90 ) * 90;
-		const bbox = getRotatedBBox(
-			naturalWidth,
-			naturalHeight,
-			snapRotation
-		);
-		const ratioMaxZoom = computeMaxZoomForRatio(
-			aspectRatio,
-			bbox,
-			MIN_CROP_PIXELS
-		);
-		const targetZoom = Math.min( state.zoom, ratioMaxZoom );
-		if ( targetZoom < state.zoom ) {
-			setZoomAtPoint( targetZoom, { x: 0, y: 0 } );
-		}
-		// Compute the floor at the (possibly lowered) target zoom so the
-		// inscribed rect we pass to setCropRect is the natural fit for
-		// the new ratio at that zoom — no post-scaling needed.
-		const targetMinCropSize: Size = {
-			width: Math.min( 1, ( MIN_CROP_PIXELS * targetZoom ) / bbox.width ),
-			height: Math.min(
-				1,
-				( MIN_CROP_PIXELS * targetZoom ) / bbox.height
-			),
-		};
-		setCropRect(
-			computeInscribedRect( aspectRatio, visualSize, targetMinCropSize )
-		);
-	}, [
-		aspectRatio,
-		freeformCrop,
-		visualSize,
-		setCropRect,
-		setZoomAtPoint,
-		naturalWidth,
-		naturalHeight,
-		state.rotation,
-		state.zoom,
-	] );
+		setZoomAtPoint( MIN_ZOOM, { x: 0, y: 0 } );
+		setCropRect( computeInscribedRect( aspectRatio, visualSize ) );
+	}, [ aspectRatio, freeformCrop, visualSize, setCropRect, setZoomAtPoint ] );
 
 	// Compute the crop handle bounds from the actual image footprint.
 	// Depends on the full state object because getImageCropBounds reads

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -32,7 +32,7 @@ import type {
 import type { UseCropperStateReturn } from '../hooks/use-cropper-state';
 import { getImageFit, getRotatedBBox } from '../../core/camera';
 import { getImageCropBounds } from '../../core/containment';
-import { MIN_CROP_PIXELS, MIN_ZOOM } from '../../core/constants';
+import { MIN_CROP_PIXELS } from '../../core/constants';
 import { useInteraction } from '../hooks/use-interaction';
 import { useTransformStyle } from '../hooks/use-transform-style';
 import { useAriaAnnouncer } from '../hooks/use-aria-announcer';
@@ -183,8 +183,7 @@ function CropperInner(
 	}: CropperProps,
 	ref: React.ForwardedRef< HTMLDivElement >
 ) {
-	const { state, setImage, setCropRect, settleCrop, setZoomAtPoint } =
-		controller;
+	const { state, setImage, setCropRect, settleCrop } = controller;
 	const {
 		viewport: viewportState,
 		setViewportPan,
@@ -345,10 +344,7 @@ function CropperInner(
 	}, [ freeformCrop, aspectRatio, visualSize, setCropRect, state.cropRect ] );
 
 	// In freeform mode, when aspectRatio changes, reshape the crop to the
-	// largest inscribed rect of the new ratio. Reset zoom and pan so the
-	// inscribed rect has the full image to work with — without this, a
-	// prior SETTLE_CROP could leave the viewport too zoomed-in for the
-	// new ratio to satisfy the source-pixel floor.
+	// largest inscribed rect of the new ratio.
 	const prevAspectRatioRef = useRef( aspectRatio );
 	useEffect( () => {
 		if ( prevAspectRatioRef.current === aspectRatio ) {
@@ -365,9 +361,8 @@ function CropperInner(
 		) {
 			return;
 		}
-		setZoomAtPoint( MIN_ZOOM, { x: 0, y: 0 } );
 		setCropRect( computeInscribedRect( aspectRatio, visualSize ) );
-	}, [ aspectRatio, freeformCrop, visualSize, setCropRect, setZoomAtPoint ] );
+	}, [ aspectRatio, freeformCrop, visualSize, setCropRect ] );
 
 	// Compute the crop handle bounds from the actual image footprint.
 	// Depends on the full state object because getImageCropBounds reads

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -49,10 +49,14 @@ const CROP_RECT_EPSILON = 1e-6;
 
 // Largest rect of the given pixel aspect ratio that fits inside the visual
 // bounds, centered in [0,1] × [0,1] normalized space. Returns a full-frame
-// rect (1×1) if `aspectRatio` is unset or non-positive.
+// rect (1×1) if `aspectRatio` is unset or non-positive. If `minCropSize`
+// is supplied and the inscribed rect would fall below it on either axis,
+// the rect is scaled up (preserving ratio) until both axes satisfy the
+// floor, capped at the viewport edges.
 function computeInscribedRect(
 	aspectRatio: number | undefined,
-	visualSize: Size
+	visualSize: Size,
+	minCropSize?: Size
 ): NormalizedRect {
 	let w = 1;
 	let h = 1;
@@ -68,6 +72,27 @@ function computeInscribedRect(
 			w = normalizedRatio;
 		} else {
 			h = 1 / normalizedRatio;
+		}
+
+		// Enforce the per-axis minimum (in normalized space). Scale up
+		// the binding axis to the floor and re-derive the other axis
+		// from the ratio so the rect doesn't fall below MIN_CROP_PIXELS
+		// in source pixels on either side.
+		if ( minCropSize ) {
+			if ( w < minCropSize.width ) {
+				w = Math.min( 1, minCropSize.width );
+				h = w / normalizedRatio;
+			}
+			if ( h < minCropSize.height ) {
+				h = Math.min( 1, minCropSize.height );
+				w = h * normalizedRatio;
+			}
+			// Final cap in case both floors push past [0,1]. At extreme
+			// zoom the ratio may no longer be expressible inside the
+			// viewport — accept the deformation rather than crop below
+			// the source-pixel floor.
+			w = Math.min( 1, w );
+			h = Math.min( 1, h );
 		}
 	}
 	return {
@@ -330,7 +355,11 @@ function CropperInner(
 		) {
 			return;
 		}
-		const rect = computeInscribedRect( aspectRatio, visualSize );
+		const rect = computeInscribedRect(
+			aspectRatio,
+			visualSize,
+			minCropSize
+		);
 		const current = state.cropRect;
 		if (
 			Math.abs( current.x - rect.x ) < CROP_RECT_EPSILON &&
@@ -341,7 +370,14 @@ function CropperInner(
 			return;
 		}
 		setCropRect( rect );
-	}, [ freeformCrop, aspectRatio, visualSize, setCropRect, state.cropRect ] );
+	}, [
+		freeformCrop,
+		aspectRatio,
+		visualSize,
+		setCropRect,
+		state.cropRect,
+		minCropSize,
+	] );
 
 	// In freeform mode, when aspectRatio changes, reshape the crop to the
 	// largest inscribed rect of the new ratio.
@@ -361,8 +397,10 @@ function CropperInner(
 		) {
 			return;
 		}
-		setCropRect( computeInscribedRect( aspectRatio, visualSize ) );
-	}, [ aspectRatio, freeformCrop, visualSize, setCropRect ] );
+		setCropRect(
+			computeInscribedRect( aspectRatio, visualSize, minCropSize )
+		);
+	}, [ aspectRatio, freeformCrop, visualSize, setCropRect, minCropSize ] );
 
 	// Compute the crop handle bounds from the actual image footprint.
 	// Depends on the full state object because getImageCropBounds reads

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -30,8 +30,9 @@ import type {
 	NormalizedRect,
 } from '../../core/types';
 import type { UseCropperStateReturn } from '../hooks/use-cropper-state';
-import { getImageFit } from '../../core/camera';
+import { getImageFit, getRotatedBBox } from '../../core/camera';
 import { getImageCropBounds } from '../../core/containment';
+import { MIN_CROP_PIXELS } from '../../core/constants';
 import { useInteraction } from '../hooks/use-interaction';
 import { useTransformStyle } from '../hooks/use-transform-style';
 import { useAriaAnnouncer } from '../hooks/use-aria-announcer';
@@ -289,6 +290,25 @@ function CropperInner(
 			),
 		[ canvasSize, naturalWidth, naturalHeight, state.rotation ]
 	);
+
+	// Per-axis minimum crop size in normalized space, derived from a
+	// pixel-based floor. The crop rect is normalized in the rotated bbox,
+	// so use bbox dims (which swap at 90°/270°) for the conversion.
+	const minCropSize: Size | undefined = useMemo( () => {
+		if ( naturalWidth <= 0 || naturalHeight <= 0 ) {
+			return undefined;
+		}
+		const snapRotation = Math.round( state.rotation / 90 ) * 90;
+		const bbox = getRotatedBBox(
+			naturalWidth,
+			naturalHeight,
+			snapRotation
+		);
+		return {
+			width: Math.min( 1, MIN_CROP_PIXELS / bbox.width ),
+			height: Math.min( 1, MIN_CROP_PIXELS / bbox.height ),
+		};
+	}, [ naturalWidth, naturalHeight, state.rotation ] );
 
 	// In fixed-crop mode, auto-size the crop rect only when a fixed aspect
 	// ratio is selected. With "Free" selected, turning freeform handles off
@@ -740,6 +760,7 @@ function CropperInner(
 						freeformCrop={ freeformCrop }
 						stencilTransition={ settleStencilTransition }
 						cropBounds={ cropBounds }
+						minCropSize={ minCropSize }
 					/>
 
 					{ /* Rule-of-thirds grid */ }

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -103,6 +103,44 @@ function computeInscribedRect(
 	};
 }
 
+// Largest zoom at which the inscribed rect of `aspectRatio` still satisfies
+// `minCropPixels` on both axes. Used on aspect-ratio change to lower the
+// zoom just enough so the new ratio can be expressed without violating
+// the source-pixel floor. Returns Infinity for an unset ratio.
+function computeMaxZoomForRatio(
+	aspectRatio: number | undefined,
+	bbox: Size,
+	minCropPixels: number
+): number {
+	if (
+		! aspectRatio ||
+		aspectRatio <= 0 ||
+		bbox.width <= 0 ||
+		bbox.height <= 0
+	) {
+		return Infinity;
+	}
+	// Inscribed rect proportions in viewport-normalized space (zoom-
+	// independent). One axis fills (=1), the other follows from the
+	// pixel aspect ratio and the bbox aspect.
+	const bboxAspect = bbox.width / bbox.height;
+	let wV: number;
+	let hV: number;
+	if ( aspectRatio <= bboxAspect ) {
+		hV = 1;
+		wV = ( aspectRatio * bbox.height ) / bbox.width;
+	} else {
+		wV = 1;
+		hV = bbox.width / ( aspectRatio * bbox.height );
+	}
+	// At zoom Z, source-pixel dims = wV*bbox.width/Z and hV*bbox.height/Z.
+	// For both ≥ minCropPixels: Z ≤ min(wV*bbox.W, hV*bbox.H) / minCropPixels.
+	return Math.min(
+		( wV * bbox.width ) / minCropPixels,
+		( hV * bbox.height ) / minCropPixels
+	);
+}
+
 /**
  * Props for the Cropper component.
  */
@@ -208,7 +246,8 @@ function CropperInner(
 	}: CropperProps,
 	ref: React.ForwardedRef< HTMLDivElement >
 ) {
-	const { state, setImage, setCropRect, settleCrop } = controller;
+	const { state, setImage, setCropRect, settleCrop, setZoomAtPoint } =
+		controller;
 	const {
 		viewport: viewportState,
 		setViewportPan,
@@ -380,7 +419,9 @@ function CropperInner(
 	] );
 
 	// In freeform mode, when aspectRatio changes, reshape the crop to the
-	// largest inscribed rect of the new ratio.
+	// largest inscribed rect of the new ratio. If the current zoom is so
+	// high that the inscribed rect would violate the source-pixel floor,
+	// lower zoom (and reset pan) just enough that both axes satisfy it.
 	const prevAspectRatioRef = useRef( aspectRatio );
 	useEffect( () => {
 		if ( prevAspectRatioRef.current === aspectRatio ) {
@@ -393,14 +434,52 @@ function CropperInner(
 			visualSize.width === 0 ||
 			visualSize.height === 0 ||
 			! aspectRatio ||
-			aspectRatio <= 0
+			aspectRatio <= 0 ||
+			naturalWidth <= 0 ||
+			naturalHeight <= 0
 		) {
 			return;
 		}
-		setCropRect(
-			computeInscribedRect( aspectRatio, visualSize, minCropSize )
+
+		const snapRotation = Math.round( state.rotation / 90 ) * 90;
+		const bbox = getRotatedBBox(
+			naturalWidth,
+			naturalHeight,
+			snapRotation
 		);
-	}, [ aspectRatio, freeformCrop, visualSize, setCropRect, minCropSize ] );
+		const ratioMaxZoom = computeMaxZoomForRatio(
+			aspectRatio,
+			bbox,
+			MIN_CROP_PIXELS
+		);
+		const targetZoom = Math.min( state.zoom, ratioMaxZoom );
+		if ( targetZoom < state.zoom ) {
+			setZoomAtPoint( targetZoom, { x: 0, y: 0 } );
+		}
+		// Compute the floor at the (possibly lowered) target zoom so the
+		// inscribed rect we pass to setCropRect is the natural fit for
+		// the new ratio at that zoom — no post-scaling needed.
+		const targetMinCropSize: Size = {
+			width: Math.min( 1, ( MIN_CROP_PIXELS * targetZoom ) / bbox.width ),
+			height: Math.min(
+				1,
+				( MIN_CROP_PIXELS * targetZoom ) / bbox.height
+			),
+		};
+		setCropRect(
+			computeInscribedRect( aspectRatio, visualSize, targetMinCropSize )
+		);
+	}, [
+		aspectRatio,
+		freeformCrop,
+		visualSize,
+		setCropRect,
+		setZoomAtPoint,
+		naturalWidth,
+		naturalHeight,
+		state.rotation,
+		state.zoom,
+	] );
 
 	// Compute the crop handle bounds from the actual image footprint.
 	// Depends on the full state object because getImageCropBounds reads

--- a/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
@@ -103,6 +103,7 @@ type RectangleStencilProps = StencilProps;
  * @param props.stencilTransition CSS transition string for settle animation.
  * @param props.cropBounds        Maximum crop rect bounds from camera (zoom/rotation-aware).
  * @param props.onEscape          Called when Escape is pressed on a resize handle.
+ * @param props.minCropSize       Minimum crop rect dimension in normalized space, per axis.
  * @return The rectangle stencil element.
  */
 export function RectangleStencil( {
@@ -117,6 +118,7 @@ export function RectangleStencil( {
 	stencilTransition,
 	cropBounds,
 	onEscape,
+	minCropSize,
 }: RectangleStencilProps ) {
 	// Use cropBounds from the camera if available, otherwise default to [0,1].
 	const boundsMinX = cropBounds?.minX ?? 0;
@@ -308,8 +310,15 @@ export function RectangleStencil( {
 			clientX: number,
 			clientY: number
 		): NormalizedRect =>
-			computeFreeResizeRect( drag, clientX, clientY, imageSize, bounds ),
-		[ imageSize, bounds ]
+			computeFreeResizeRect(
+				drag,
+				clientX,
+				clientY,
+				imageSize,
+				bounds,
+				minCropSize
+			),
+		[ imageSize, bounds, minCropSize ]
 	);
 
 	/**
@@ -328,9 +337,10 @@ export function RectangleStencil( {
 				clientY,
 				imageSize,
 				bounds,
-				normalizedRatio
+				normalizedRatio,
+				minCropSize
 			),
-		[ imageSize, bounds, normalizedRatio ]
+		[ imageSize, bounds, normalizedRatio, minCropSize ]
 	);
 
 	/**
@@ -348,9 +358,10 @@ export function RectangleStencil( {
 				clientX,
 				clientY,
 				imageSize,
-				bounds
+				bounds,
+				minCropSize
 			),
-		[ imageSize, bounds ]
+		[ imageSize, bounds, minCropSize ]
 	);
 
 	latestHandlersRef.current = {


### PR DESCRIPTION
## What

Part of

- https://github.com/WordPress/gutenberg/issues/73771

Adds a per-axis minimum crop size to the image editor cropper, expressed in source-image pixels via a single `MIN_CROP_PIXELS` constant (default `24`).

## Why

The previous floor was a hardcoded `MIN_CROP_SIZE = 0.05` in normalized space (5% of the image), which meant:

- On very small source images the floor produced **sub-pixel output crops** (e.g. a 10px-wide source allowed a 0.5px crop).
- On large source images the floor was much bigger than needed (200×150px on a 4000×3000 image), blocking legitimate tight crops.

A pixel-based floor solves both: 24×24 output minimum is small enough for icon/favicon workflows and large enough that fumbled handle drags can't produce a useless tiny crop.

## How

- New constant `MIN_CROP_PIXELS = 24` in `core/constants.ts` — single knob to tune the floor.
- `stencil-math.ts` resize helpers (`computeFreeResizeRect`, `computeLockedResizeRect`, `computeShiftLockedResizeRect`) take a per-axis `minCropSize: Size` parameter in normalized space. Default kept at `{ 0.05, 0.05 }` so existing tests pass unchanged.
- `RectangleStencil` accepts a new `minCropSize` prop and threads it through.
- `Cropper` derives `minCropSize` from `MIN_CROP_PIXELS` and the snap-rotated source bbox (`getRotatedBBox(naturalWidth, naturalHeight, snapRotation)`), so the floor applies in **output** pixels and remains correct at 0°/90°/180°/270°.
- For sources smaller than 24px on an axis, the floor is capped at 1.0 (the whole image), so a tiny favicon source still lets you crop the whole frame.

## Behavior matrix

| Source        | Old min (5%)     | New min (24px output) |
| ------------- | ---------------- | --------------------- |
| 4000 × 3000   | 200 × 150 px     | 24 × 24 px            |
| 1000 × 1000   | 50 × 50 px       | 24 × 24 px            |
| 60 × 60       | 3 × 3 px         | 24 × 24 px            |
| 16 × 16       | 0.8 × 0.8 px ⚠️  | 16 × 16 px (full)     |

## Test plan

- [ ] Open the media editor on a normal-sized image (e.g. 1500×1000). Confirm a resize handle drag inward stops at ~24px on either axis (was 75×50 / 5%).
- [ ] Confirm sub-pixel crops are no longer possible at any source size (visually: the crop rect can never collapse to invisible).
- [ ] With a fixed aspect ratio locked, drag a corner inward — both axes respect the floor without breaking ratio.
- [ ] Hold Shift while dragging a freeform edge — ratio-preserved shrink stops at the per-axis floor.
- [ ] Rotate to 90° / 270° and re-test — minimum still produces 24px output (bbox dims swap).
- [ ] Keyboard resize (arrow keys on a focused handle) respects the same floor.
- [ ] Run `npm test packages/media-editor` — existing `stencil-math` tests still pass (defaults preserved).