### PR TITLE
Hide wrap by default in flex layout panel

### DIFF
--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -168,7 +168,6 @@ export default {
 						label={ __( 'Wrapping' ) }
 						hasValue={ hasWrapValue }
 						onDeselect={ resetWrap }
-						isShownByDefault
 						panelId={ clientId }
 					>
 						<FlexWrapControl

--- a/packages/block-editor/src/layouts/test/flex.js
+++ b/packages/block-editor/src/layouts/test/flex.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * WordPress dependencies
@@ -47,36 +48,63 @@ describe( 'getLayoutStyle', () => {
 } );
 
 describe( 'FlexLayoutInspectorControls', () => {
-	it( 'should render the wrap toggle by default', () => {
+	it( 'should not render the wrap toggle by default', () => {
 		renderInspectorControls();
-
-		expect(
-			screen.getByRole( 'checkbox', {
-				name: 'Allow to wrap to multiple lines',
-			} )
-		).toBeInTheDocument();
-	} );
-
-	it( 'should render the wrap toggle when allowWrap is true', () => {
-		renderInspectorControls( {
-			layoutBlockSupport: { allowWrap: true },
-		} );
-
-		expect(
-			screen.getByRole( 'checkbox', {
-				name: 'Allow to wrap to multiple lines',
-			} )
-		).toBeInTheDocument();
-	} );
-
-	it( 'should not render the wrap toggle when allowWrap is false', () => {
-		renderInspectorControls( {
-			layoutBlockSupport: { allowWrap: false },
-		} );
 
 		expect(
 			screen.queryByRole( 'checkbox', {
 				name: 'Allow to wrap to multiple lines',
+			} )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should render the wrap toggle when it has a value', () => {
+		renderInspectorControls( {
+			layout: { flexWrap: 'nowrap' },
+		} );
+
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Allow to wrap to multiple lines',
+			} )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should allow the wrap toggle to be selected from the tools panel menu', async () => {
+		const user = userEvent.setup();
+		renderInspectorControls( {
+			layoutBlockSupport: { allowWrap: true },
+		} );
+
+		await user.click(
+			screen.getByRole( 'button', { name: /Layout options/i } )
+		);
+		await user.click(
+			screen.getByRole( 'menuitemcheckbox', {
+				name: 'Show Wrapping',
+			} )
+		);
+
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Allow to wrap to multiple lines',
+			} )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not include the wrap toggle in the tools panel menu when allowWrap is false', async () => {
+		const user = userEvent.setup();
+		renderInspectorControls( {
+			layoutBlockSupport: { allowWrap: false },
+		} );
+
+		await user.click(
+			screen.getByRole( 'button', { name: /Layout options/i } )
+		);
+
+		expect(
+			screen.queryByRole( 'menuitemcheckbox', {
+				name: 'Show Wrapping',
 			} )
 		).not.toBeInTheDocument();
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #44560.

Now that layout is using ToolsPanel (see #77922) it only remains to hide the wrap control by default.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a block with flex layout e.g. Row or Buttons
2. Check the layout panel (now in the styles tab if there are tabs) and verify that the wrap control is hidden by default
3. Clicking the options button in the panel should allow enabling the wrap control to show.

<img width="270" height="144" alt="Screenshot 2026-05-14 at 4 40 57 pm" src="https://github.com/user-attachments/assets/3a0ae5c2-1c75-4e4d-9189-cbe7b5aed6e5" />


AI (GPT 5.5/codex) updated the unit tests!