### PR TITLE
Fix flaky navigation frontend submenu e2e test

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
@@ -599,6 +599,10 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 					.getByRole( 'button', { name: 'Save', exact: true } );
 
 				await saveButton.click();
+				await page
+					.getByRole( 'button', { name: 'Dismiss this notice' } )
+					.filter( { hasText: 'updated' } )
+					.waitFor();
 
 				// Fetch the post from the database to see what was actually saved
 				const savedPost = await requestUtils.rest( {


### PR DESCRIPTION
Fixes #77711. The flaky test in question verifies a saved post, with a REST API fetch, before the saving has finished. This screenshot shows very clearly that the "Saving..." progress indicator is still visible when the REST fetch (and the failed assertion on the fetch result) is performed:

<img width="1022" height="380" alt="Screenshot 2026-05-14 at 8 28 12" src="https://github.com/user-attachments/assets/1a82ffa1-0fc9-4e80-9483-e312595c6a6c" />

I'm fixing this by adding a wait for the notice that announces a finished save. This is the standard way to do this in our e2e suite, used in a large number of other tests.