### PR TITLE
Revisions: Scale diff markers width with user text-size preference

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -35,7 +35,7 @@
 .revision-diff-markers {
 	position: relative;
 	flex-shrink: 0;
-	width: 12px;
+	width: max(16px, 1rem);
 	background: rgba(0, 0, 0, 0.05);
 
 	.revision-diff-marker {

--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -35,7 +35,7 @@
 .revision-diff-markers {
 	position: relative;
 	flex-shrink: 0;
-	width: 24px;
+	width: 12px;
 	background: rgba(0, 0, 0, 0.05);
 
 	.revision-diff-marker {


### PR DESCRIPTION
## What?

Replaces the fixed 24px width from #77671 with `max(16px, 1rem)`, so the diff markers minimap scales with the user's browser/OS text-size preference rather than being uniformly enlarged for everyone.

## Why?

The diff markers minimap was designed as a subtle, scrollbar-style visual hint of where changes occur in the document, with click-to-jump as a shortcut. #77671 widened it to 24px to satisfy WCAG 2.5.8 (Target Size — Minimum), but at that width the minimap competes visually with the primary content and loses its quiet-indicator character. It also enlarges UI for every user regardless of whether they need it.

This PR takes a different approach that targets the actual user population the SC was written for — people who scale up text for low vision or motor precision.

### Sizing behaviour

`width: max(16px, 1rem)` resolves to:

| Browser font setting | Root font | Marker width | Notes |
|---|---|---|---|
| Default (Medium) | 16px | **16px** | floor wins; sized like a slim scrollbar thumb |
| Large | 20px | **20px** | rem wins |
| Very Large | 24px | **24px** | hits WCAG 2.5.8 24×24 width threshold |
| 200% | 32px | **32px** | scales further |

iOS/Android and Chrome's font-size preference all funnel into root font size, so this responds to genuine user signals about UI scale.

### Accessibility framing

WCAG 2.5.8 has an explicit **Equivalent** exception:

> The function can be achieved through a different control on the same page that meets the target size requirement.

Every changed block in the document area is reachable through normal scrolling, keyboard navigation, the list view, and block selection — all at full size. The minimap markers are a redundant shortcut layered on top of an already-accessible primary path. That is the case the Equivalent exception was written for, and it's the same pattern used by scrollbar thumbs, IDE minimaps, and diff-view change indicators across the industry.

The width-scaling on top of that means users who *have* signaled they want larger UI also get markers that hit the 24px threshold directly, without imposing that size on the default experience.

A subsequent comment on the original PR ([#77671 (comment)](https://github.com/WordPress/gutenberg/pull/77671#issuecomment-4434018781)) framed the SC as requiring 24×24 for any navigation target; this PR pushes back on that reading by leaning on the Equivalent exception while still improving the experience for the population the guideline targets.

## Testing Instructions

1. Open a post or page with at least two saved revisions.
2. Open the Revisions panel.
3. At default browser font size, the markers minimap should render at 16px wide as a slim column to the side of the document. Click a marker — it should still scroll/focus the corresponding block.
4. Open `chrome://settings/appearance` and change **Font size** to **Very Large**. Refresh. Markers should now render at 24px wide.
5. Try **Large** (20px) and the default again to confirm scaling between the floor and the WCAG threshold.
6. Quick alternative: in DevTools, set `html { font-size: 32px; }` to see the marker at 32px wide.

Note: do **not** test with ⌘+ / ⌘- (page zoom). That scales the viewport proportionally and will not exercise the `rem` branching.

## Use of AI Tools

Drafted with assistance from Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)