### PR TITLE
RTC: fix data corruption on concurrent list move

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -462,7 +462,7 @@ export const editEntityRecord =
 				objectId,
 				editsWithMerges,
 				origin,
-				{ isNewUndoLevel }
+				{ baseRecord: editedRecord, isNewUndoLevel }
 			);
 		}
 		if ( ! options.undoIgnore ) {

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -412,10 +412,24 @@ async function loadPostTypeEntities() {
 			 *
 			 * @param {import('@wordpress/sync').CRDTDoc}               crdtDoc
 			 * @param {Partial< import('@wordpress/sync').ObjectData >} changes
+			 * @param {Object}                                          options
 			 * @return {void}
 			 */
-			applyChangesToCRDTDoc: ( crdtDoc, changes ) =>
-				applyPostChangesToCRDTDoc( crdtDoc, changes, syncedProperties ),
+			applyChangesToCRDTDoc: ( crdtDoc, changes, options ) => {
+				if ( options ) {
+					return applyPostChangesToCRDTDoc(
+						crdtDoc,
+						changes,
+						syncedProperties,
+						options
+					);
+				}
+				return applyPostChangesToCRDTDoc(
+					crdtDoc,
+					changes,
+					syncedProperties
+				);
+			},
 
 			/**
 			 * Create the awareness instance for the entity's CRDT document.

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -319,7 +319,16 @@ describe( 'editEntityRecord', () => {
 					},
 				},
 				'local-editor',
-				{ isNewUndoLevel: true }
+				{
+					baseRecord: {
+						id: 1,
+						meta: {
+							existingKey: 'existingValue',
+							editedKey: 'editedValue',
+						},
+					},
+					isNewUndoLevel: true,
+				}
 			);
 		} );
 
@@ -361,7 +370,13 @@ describe( 'editEntityRecord', () => {
 					},
 				},
 				'local-editor',
-				{ isNewUndoLevel: true }
+				{
+					baseRecord: {
+						id: 1,
+						meta: { key1: 'value1' },
+					},
+					isNewUndoLevel: true,
+				}
 			);
 
 			// But the local store dispatch should still receive undefined for the cleaned edit
@@ -417,7 +432,14 @@ describe( 'editEntityRecord', () => {
 					},
 				},
 				'local-editor',
-				{ isNewUndoLevel: true }
+				{
+					baseRecord: {
+						id: 1,
+						title: 'Original Title',
+						meta: { existingKey: 'existingValue' },
+					},
+					isNewUndoLevel: true,
+				}
 			);
 		} );
 

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -411,6 +411,459 @@ function createNewYBlock( block: Block ): YBlock {
 	);
 }
 
+function getBlockClientId( block: Block ): string | null {
+	return block.clientId || null;
+}
+
+function getYBlockClientId( yblock: YBlock ): string | null {
+	const clientId = yblock.get( 'clientId' );
+	return typeof clientId === 'string' && clientId ? clientId : null;
+}
+
+function normalizeBlockForIdentity( value: unknown ): unknown {
+	if ( Array.isArray( value ) ) {
+		return value.map( normalizeBlockForIdentity );
+	}
+
+	if ( isRecord( value ) ) {
+		return Object.fromEntries(
+			Object.entries( value )
+				.filter( ( [ key ] ) => key !== 'clientId' )
+				.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
+				.map( ( [ key, innerValue ] ) => [
+					key,
+					normalizeBlockForIdentity( innerValue ),
+				] )
+		);
+	}
+
+	return value;
+}
+
+function getBlockSemanticKey( block: Block ): string {
+	return JSON.stringify( normalizeBlockForIdentity( block ) );
+}
+
+function getUniqueKeys< T >(
+	items: T[],
+	getKey: ( item: T ) => string | null
+): string[] | null {
+	const keys: string[] = [];
+	const seenKeys = new Set< string >();
+
+	for ( const item of items ) {
+		const key = getKey( item );
+
+		if ( ! key || seenKeys.has( key ) ) {
+			return null;
+		}
+
+		keys.push( key );
+		seenKeys.add( key );
+	}
+
+	return keys;
+}
+
+function getBlockIdentityKeys(
+	yblocks: YBlocks,
+	baseBlocks: Block[],
+	blocksToSync: Block[]
+): {
+	currentKeys: string[];
+	baseKeys: string[];
+	incomingKeys: string[];
+} | null {
+	const currentClientIds = getUniqueKeys(
+		yblocks.toArray(),
+		getYBlockClientId
+	);
+	const baseClientIds = getUniqueKeys( baseBlocks, getBlockClientId );
+	const incomingClientIds = getUniqueKeys( blocksToSync, getBlockClientId );
+
+	if ( currentClientIds && baseClientIds && incomingClientIds ) {
+		const currentSet = new Set( currentClientIds );
+		const baseSet = new Set( baseClientIds );
+
+		if (
+			currentSet.size === baseSet.size &&
+			incomingClientIds.length === baseClientIds.length &&
+			baseClientIds.every( ( key ) => currentSet.has( key ) ) &&
+			incomingClientIds.every( ( key ) => baseSet.has( key ) )
+		) {
+			return {
+				currentKeys: currentClientIds,
+				baseKeys: baseClientIds,
+				incomingKeys: incomingClientIds,
+			};
+		}
+	}
+
+	const currentBlocks = yblocks.toArray().map( ( yblock ) => {
+		return yblock.toJSON() as unknown as Block;
+	} );
+	const currentSemanticKeys = getUniqueKeys(
+		currentBlocks,
+		getBlockSemanticKey
+	);
+	const baseSemanticKeys = getUniqueKeys( baseBlocks, getBlockSemanticKey );
+	const incomingSemanticKeys = getUniqueKeys(
+		blocksToSync,
+		getBlockSemanticKey
+	);
+
+	if (
+		! currentSemanticKeys ||
+		! baseSemanticKeys ||
+		! incomingSemanticKeys
+	) {
+		return null;
+	}
+
+	const currentSet = new Set( currentSemanticKeys );
+	const baseSet = new Set( baseSemanticKeys );
+
+	if (
+		currentSet.size !== baseSet.size ||
+		incomingSemanticKeys.length !== baseSemanticKeys.length ||
+		! baseSemanticKeys.every( ( key ) => currentSet.has( key ) ) ||
+		! incomingSemanticKeys.every( ( key ) => baseSet.has( key ) )
+	) {
+		return null;
+	}
+
+	return {
+		currentKeys: currentSemanticKeys,
+		baseKeys: baseSemanticKeys,
+		incomingKeys: incomingSemanticKeys,
+	};
+}
+
+function getUniqueBlockMapBySemanticKey(
+	blocks: Block[]
+): Map< string, Block > | null {
+	const blockMap = new Map< string, Block >();
+
+	for ( const block of blocks ) {
+		const key = getBlockSemanticKey( block );
+
+		if ( blockMap.has( key ) ) {
+			return null;
+		}
+
+		blockMap.set( key, block );
+	}
+
+	return blockMap;
+}
+
+function canReorderYBlocksByClientId(
+	yblocks: YBlocks,
+	blocksToSync: Block[]
+): boolean {
+	if ( yblocks.length !== blocksToSync.length || yblocks.length < 2 ) {
+		return false;
+	}
+
+	const incomingClientIds = blocksToSync.map( getBlockClientId );
+	const currentClientIds = yblocks.toArray().map( getYBlockClientId );
+
+	if (
+		incomingClientIds.some( ( clientId ) => ! clientId ) ||
+		currentClientIds.some( ( clientId ) => ! clientId )
+	) {
+		return false;
+	}
+
+	const incomingSet = new Set( incomingClientIds );
+
+	if ( incomingSet.size !== incomingClientIds.length ) {
+		return false;
+	}
+
+	const currentSet = new Set( currentClientIds );
+
+	return (
+		currentSet.size === currentClientIds.length &&
+		currentSet.size === incomingSet.size &&
+		currentClientIds.every( ( clientId ) => incomingSet.has( clientId ) )
+	);
+}
+
+function reorderYBlocksByClientId(
+	yblocks: YBlocks,
+	blocksToSync: Block[]
+): void {
+	if ( ! canReorderYBlocksByClientId( yblocks, blocksToSync ) ) {
+		return;
+	}
+
+	for (
+		let targetIndex = 0;
+		targetIndex < blocksToSync.length;
+		targetIndex++
+	) {
+		const targetClientId = getBlockClientId( blocksToSync[ targetIndex ] );
+
+		if (
+			getYBlockClientId( yblocks.get( targetIndex ) ) === targetClientId
+		) {
+			continue;
+		}
+
+		const currentIndex = yblocks
+			.toArray()
+			.findIndex(
+				( yblock ) => getYBlockClientId( yblock ) === targetClientId
+			);
+
+		if ( currentIndex === -1 ) {
+			return;
+		}
+
+		const reorderedBlock = createNewYBlock( blocksToSync[ targetIndex ] );
+		yblocks.delete( currentIndex, 1 );
+		yblocks.insert( targetIndex, [ reorderedBlock ] );
+	}
+}
+
+function rebaseYBlocksByClientId(
+	yblocks: YBlocks,
+	baseBlocks: Block[] | undefined,
+	blocksToSync: Block[]
+): boolean {
+	if ( ! baseBlocks || yblocks.length !== blocksToSync.length ) {
+		return false;
+	}
+
+	const identityKeys = getBlockIdentityKeys(
+		yblocks,
+		baseBlocks,
+		blocksToSync
+	);
+
+	if ( ! identityKeys || identityKeys.baseKeys.length < 2 ) {
+		return false;
+	}
+
+	const rebasedKeys = [ ...identityKeys.baseKeys ];
+
+	for (
+		let targetIndex = 0;
+		targetIndex < blocksToSync.length;
+		targetIndex++
+	) {
+		const targetKey = identityKeys.incomingKeys[ targetIndex ];
+
+		if ( rebasedKeys[ targetIndex ] === targetKey ) {
+			continue;
+		}
+
+		const baseIndex = rebasedKeys.indexOf( targetKey );
+		const currentIndex = identityKeys.currentKeys.indexOf( targetKey );
+
+		if ( baseIndex === -1 || currentIndex === -1 ) {
+			return false;
+		}
+
+		const reorderedBlock = createNewYBlock(
+			yblocks.get( currentIndex ).toJSON() as unknown as Block
+		);
+		yblocks.delete( currentIndex, 1 );
+		yblocks.insert( targetIndex, [ reorderedBlock ] );
+
+		identityKeys.currentKeys.splice( currentIndex, 1 );
+		identityKeys.currentKeys.splice( targetIndex, 0, targetKey );
+		rebasedKeys.splice( baseIndex, 1 );
+		rebasedKeys.splice( targetIndex, 0, targetKey );
+	}
+
+	return true;
+}
+
+function mergeBlockIntoYBlock(
+	yblock: YBlock,
+	block: Block,
+	attributeCursor: MergeCursorPosition,
+	baseBlock?: Block
+): void {
+	const baseAttributes = baseBlock?.attributes ?? {};
+
+	Object.entries( block ).forEach( ( [ key, value ] ) => {
+		switch ( key ) {
+			case 'attributes': {
+				const currentAttributes = yblock.get( key );
+
+				// If attributes are not set on the yblock, use the new values.
+				if ( ! currentAttributes ) {
+					yblock.set(
+						key,
+						createNewYAttributeMap( block.name, value )
+					);
+					break;
+				}
+
+				Object.entries( value ).forEach(
+					( [ attributeName, attributeValue ] ) => {
+						if (
+							baseBlock &&
+							fastDeepEqual(
+								baseAttributes[ attributeName ],
+								attributeValue
+							)
+						) {
+							return;
+						}
+
+						const currentAttribute =
+							currentAttributes?.get( attributeName );
+
+						const isExpectedType = isExpectedAttributeType(
+							block.name,
+							attributeName,
+							currentAttribute
+						);
+
+						// Y types (Y.Text, Y.Array, Y.Map) cannot be compared
+						// with fastDeepEqual against plain values. Delegate to
+						// mergeYValue which handles no-op detection at the edges.
+						const isYType =
+							currentAttribute instanceof Y.AbstractType;
+
+						const isAttributeChanged =
+							! isExpectedType ||
+							isYType ||
+							! fastDeepEqual( currentAttribute, attributeValue );
+
+						if ( isAttributeChanged ) {
+							updateYBlockAttribute(
+								block.name,
+								block.clientId,
+								attributeName,
+								attributeValue,
+								currentAttributes,
+								attributeCursor
+							);
+						}
+					}
+				);
+
+				// Delete any attributes that are no longer present.
+				currentAttributes.forEach(
+					( _attrValue: unknown, attrName: string ) => {
+						if ( ! value.hasOwnProperty( attrName ) ) {
+							if (
+								baseBlock &&
+								! Object.prototype.hasOwnProperty.call(
+									baseAttributes,
+									attrName
+								)
+							) {
+								return;
+							}
+							currentAttributes.delete( attrName );
+						}
+					}
+				);
+
+				break;
+			}
+
+			case 'innerBlocks': {
+				if (
+					baseBlock &&
+					fastDeepEqual( baseBlock.innerBlocks, value ?? [] )
+				) {
+					break;
+				}
+
+				// Recursively merge innerBlocks.
+				let yInnerBlocks = yblock.get( key );
+
+				if ( ! ( yInnerBlocks instanceof Y.Array ) ) {
+					yInnerBlocks = new Y.Array< YBlock >();
+					yblock.set( key, yInnerBlocks );
+				}
+
+				mergeCrdtBlocks(
+					yInnerBlocks,
+					value ?? [],
+					attributeCursor,
+					baseBlock?.innerBlocks
+				);
+				break;
+			}
+
+			default: {
+				const blockKey = key as keyof Block;
+
+				if (
+					baseBlock &&
+					fastDeepEqual( baseBlock[ blockKey ], value )
+				) {
+					break;
+				}
+
+				if ( ! fastDeepEqual( value, yblock.get( key ) ) ) {
+					yblock.set( key, value );
+				}
+			}
+		}
+	} );
+	yblock.forEach( ( _v, k ) => {
+		if ( ! Object.hasOwn( block, k ) ) {
+			if (
+				baseBlock &&
+				! Object.prototype.hasOwnProperty.call( baseBlock, k )
+			) {
+				return;
+			}
+			yblock.delete( k );
+		}
+	} );
+}
+
+function mergeYBlocksByClientId(
+	yblocks: YBlocks,
+	blocksToSync: Block[],
+	attributeCursor: MergeCursorPosition,
+	baseBlocks?: Block[]
+): void {
+	const incomingBlocksByClientId = new Map(
+		blocksToSync.map( ( block ) => [ getBlockClientId( block ), block ] )
+	);
+	const baseBlocksByClientId = new Map(
+		( baseBlocks ?? [] ).map( ( block ) => [
+			getBlockClientId( block ),
+			block,
+		] )
+	);
+	const incomingBlocksBySemanticKey =
+		getUniqueBlockMapBySemanticKey( blocksToSync );
+	const baseBlocksBySemanticKey = baseBlocks
+		? getUniqueBlockMapBySemanticKey( baseBlocks )
+		: null;
+
+	for ( let index = 0; index < yblocks.length; index++ ) {
+		const yblock = yblocks.get( index );
+		const clientId = getYBlockClientId( yblock );
+		let block = incomingBlocksByClientId.get( clientId );
+		let baseBlock = baseBlocksByClientId.get( clientId );
+
+		if ( ! block && incomingBlocksBySemanticKey ) {
+			const semanticKey = getBlockSemanticKey(
+				yblock.toJSON() as unknown as Block
+			);
+			block = incomingBlocksBySemanticKey.get( semanticKey );
+			baseBlock = baseBlocksBySemanticKey?.get( semanticKey );
+		}
+
+		if ( block ) {
+			mergeBlockIntoYBlock( yblock, block, attributeCursor, baseBlock );
+		}
+	}
+}
+
 /**
  * Merge incoming block data into the local Y.Doc.
  * This function is called to sync local block changes to a shared Y.Doc.
@@ -420,11 +873,13 @@ function createNewYBlock( block: Block ): YBlock {
  * @param attributeCursor When provided, describes a selection cursor falling within a
  *                        RichText field associated with a specific block and attribute.
  *                        Derived from the changes that produced the blocks.
+ * @param baseBlocks      Optional pre-change block snapshot used for rebasing.
  */
 export function mergeCrdtBlocks(
 	yblocks: YBlocks,
 	incomingBlocks: Block[],
-	attributeCursor: MergeCursorPosition
+	attributeCursor: MergeCursorPosition,
+	baseBlocks?: Block[]
 ): void {
 	// Ensure we are working with serializable block data.
 	if ( ! serializableBlocksCache.has( incomingBlocks ) ) {
@@ -434,8 +889,25 @@ export function mergeCrdtBlocks(
 		);
 	}
 
-	const incomingBlocksToSync =
-		serializableBlocksCache.get( incomingBlocks ) ?? [];
+	const blocksToSync = serializableBlocksCache.get( incomingBlocks ) ?? [];
+	const baseBlocksToSync = baseBlocks
+		? makeBlocksSerializable( baseBlocks )
+		: undefined;
+
+	if ( rebaseYBlocksByClientId( yblocks, baseBlocksToSync, blocksToSync ) ) {
+		mergeYBlocksByClientId(
+			yblocks,
+			blocksToSync,
+			attributeCursor,
+			baseBlocksToSync
+		);
+		removeDuplicateClientIds( yblocks );
+		return;
+	}
+
+	if ( ! baseBlocksToSync ) {
+		reorderYBlocksByClientId( yblocks, blocksToSync );
+	}
 
 	// This is a rudimentary diff implementation similar to the y-prosemirror diffing
 	// approach.
@@ -451,7 +923,7 @@ export function mergeCrdtBlocks(
 	// @credit Kevin Jahns (dmonad)
 	// @link https://github.com/WordPress/gutenberg/pull/68483
 	const numOfCommonEntries = Math.min(
-		incomingBlocksToSync.length ?? 0,
+		blocksToSync.length ?? 0,
 		yblocks.length
 	);
 
@@ -462,7 +934,7 @@ export function mergeCrdtBlocks(
 	for (
 		;
 		left < numOfCommonEntries &&
-		areBlocksEqual( incomingBlocksToSync[ left ], yblocks.get( left ) );
+		areBlocksEqual( blocksToSync[ left ], yblocks.get( left ) );
 		left++
 	) {
 		/* nop */
@@ -473,7 +945,7 @@ export function mergeCrdtBlocks(
 		;
 		right < numOfCommonEntries - left &&
 		areBlocksEqual(
-			incomingBlocksToSync[ incomingBlocksToSync.length - right - 1 ],
+			blocksToSync[ blocksToSync.length - right - 1 ],
 			yblocks.get( yblocks.length - right - 1 )
 		);
 		right++
@@ -484,141 +956,24 @@ export function mergeCrdtBlocks(
 	const numOfUpdatesNeeded = numOfCommonEntries - left - right;
 	const numOfInsertionsNeeded = Math.max(
 		0,
-		incomingBlocksToSync.length - yblocks.length
+		blocksToSync.length - yblocks.length
 	);
 	const numOfDeletionsNeeded = Math.max(
 		0,
-		yblocks.length - incomingBlocksToSync.length
+		yblocks.length - blocksToSync.length
 	);
 
 	// updates
 	for ( let i = 0; i < numOfUpdatesNeeded; i++, left++ ) {
-		const incomingYBlock = incomingBlocksToSync[ left ];
-		const localYBlock = yblocks.get( left );
+		const block = blocksToSync[ left ];
+		const yblock = yblocks.get( left );
 
-		Object.entries( incomingYBlock ).forEach(
-			( [ incomingBlockProperty, incomingBlockPropertyValue ] ) => {
-				switch ( incomingBlockProperty ) {
-					case 'attributes': {
-						const localAttributes = localYBlock.get(
-							incomingBlockProperty
-						);
-						const incomingAttributes = incomingBlockPropertyValue;
-
-						// When the local block has no attributes, adopt the incoming set.
-						if ( ! localAttributes ) {
-							localYBlock.set(
-								incomingBlockProperty,
-								createNewYAttributeMap(
-									incomingYBlock.name,
-									incomingAttributes
-								)
-							);
-							break;
-						}
-
-						// Otherwise the attributes need to be merged.
-						Object.entries( incomingAttributes ).forEach(
-							( [
-								incomingAttributeName,
-								incomingAttributeValue,
-							] ) => {
-								const currentAttribute = localAttributes?.get(
-									incomingAttributeName
-								);
-
-								const isExpectedType = isExpectedAttributeType(
-									incomingYBlock.name,
-									incomingAttributeName,
-									currentAttribute
-								);
-
-								// Y types (Y.Text, Y.Array, Y.Map) cannot be
-								// compared with fastDeepEqual against plain values.
-								// Delegate to mergeYValue which handles no-op
-								// detection at the edges.
-								const isYType =
-									currentAttribute instanceof Y.AbstractType;
-
-								const isAttributeChanged =
-									! isExpectedType ||
-									isYType ||
-									! fastDeepEqual(
-										currentAttribute,
-										incomingAttributeValue
-									);
-
-								if ( isAttributeChanged ) {
-									updateYBlockAttribute(
-										incomingYBlock.name,
-										incomingYBlock.clientId,
-										incomingAttributeName,
-										incomingAttributeValue,
-										localAttributes,
-										attributeCursor
-									);
-								}
-							}
-						);
-
-						// Delete any attributes that are no longer present.
-						localAttributes.forEach(
-							( _attrValue: unknown, attrName: string ) => {
-								if (
-									! incomingBlockPropertyValue.hasOwnProperty(
-										attrName
-									)
-								) {
-									localAttributes.delete( attrName );
-								}
-							}
-						);
-
-						break;
-					}
-
-					case 'innerBlocks': {
-						// Recursively merge innerBlocks
-						let yInnerBlocks = localYBlock.get(
-							incomingBlockProperty
-						);
-
-						if ( ! ( yInnerBlocks instanceof Y.Array ) ) {
-							yInnerBlocks = new Y.Array< YBlock >();
-							localYBlock.set(
-								incomingBlockProperty,
-								yInnerBlocks
-							);
-						}
-
-						mergeCrdtBlocks(
-							yInnerBlocks,
-							incomingBlockPropertyValue ?? [],
-							attributeCursor
-						);
-						break;
-					}
-
-					default:
-						if (
-							! fastDeepEqual(
-								incomingYBlock[ incomingBlockProperty ],
-								localYBlock.get( incomingBlockProperty )
-							)
-						) {
-							localYBlock.set(
-								incomingBlockProperty,
-								incomingBlockPropertyValue
-							);
-						}
-				}
-			}
+		mergeBlockIntoYBlock(
+			yblock,
+			block,
+			attributeCursor,
+			baseBlocksToSync?.[ left ]
 		);
-		localYBlock.forEach( ( _v, k ) => {
-			if ( ! incomingYBlock.hasOwnProperty( k ) ) {
-				localYBlock.delete( k );
-			}
-		} );
 	}
 
 	// deletes
@@ -626,12 +981,15 @@ export function mergeCrdtBlocks(
 
 	// inserts
 	for ( let i = 0; i < numOfInsertionsNeeded; i++, left++ ) {
-		const newBlock = [ createNewYBlock( incomingBlocksToSync[ left ] ) ];
+		const newBlock = [ createNewYBlock( blocksToSync[ left ] ) ];
 
 		yblocks.insert( left, newBlock );
 	}
 
-	// remove duplicate clientids
+	removeDuplicateClientIds( yblocks );
+}
+
+function removeDuplicateClientIds( yblocks: YBlocks ): void {
 	const knownClientIds = new Set< string >();
 	for ( let j = 0; j < yblocks.length; j++ ) {
 		const yblock: YBlock = yblocks.get( j );

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -122,12 +122,15 @@ function defaultApplyChangesToCRDTDoc(
  * @param {CRDTDoc}     ydoc
  * @param {PostChanges} changes
  * @param {Set<string>} syncedProperties
+ * @param {Object}      options
+ * @param {ObjectData}  options.baseRecord
  * @return {void}
  */
 export function applyPostChangesToCRDTDoc(
 	ydoc: CRDTDoc,
 	changes: PostChanges,
-	syncedProperties: Set< string >
+	syncedProperties: Set< string >,
+	options: { baseRecord?: ObjectData } = {}
 ): void {
 	const ymap = getRootMap< YPostRecord >( ydoc, CRDT_RECORD_MAP_KEY );
 
@@ -169,7 +172,12 @@ export function applyPostChangesToCRDTDoc(
 
 				// Merge blocks does not need `setValue` because it is operating on a
 				// Yjs type that is already in the Y.Doc.
-				mergeCrdtBlocks( currentBlocks, newValue, newCursorPosition );
+				mergeCrdtBlocks(
+					currentBlocks,
+					newValue,
+					newCursorPosition,
+					( options.baseRecord as PostChanges | undefined )?.blocks
+				);
 				break;
 			}
 

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -362,6 +362,378 @@ describe( 'crdt-blocks', () => {
 			expect( content1.toString() ).toBe( 'First' );
 		} );
 
+		it( 'preserves concurrent list item moves by client ID', () => {
+			const createListBlock = ( itemOrder: string[] ): Block[] => [
+				{
+					name: 'core/list',
+					attributes: {},
+					innerBlocks: itemOrder.map( ( item ) => ( {
+						name: 'core/list-item',
+						attributes: { content: `Item ${ item }` },
+						innerBlocks: [],
+						clientId: `item-${ item.toLowerCase() }`,
+					} ) ),
+					clientId: 'list-block',
+				},
+			];
+			const getListItems = ( checkBlocks: YBlocks ): string[] =>
+				( checkBlocks.get( 0 ).get( 'innerBlocks' ) as YBlocks )
+					.toArray()
+					.map( ( item ) =>
+						(
+							(
+								item.get( 'attributes' ) as YBlockAttributes
+							 ).get( 'content' ) as Y.Text
+						 ).toString()
+					);
+			const initialOrder = [
+				'Alpha',
+				'Beta',
+				'Gamma',
+				'Delta',
+				'Epsilon',
+				'Zeta',
+			];
+
+			mergeCrdtBlocks( yblocks, createListBlock( initialOrder ), null );
+
+			const doc2 = new Y.Doc();
+			const yblocks2 = doc2.getArray< YBlock >();
+			Y.applyUpdate( doc2, Y.encodeStateAsUpdate( doc ) );
+
+			mergeCrdtBlocks(
+				yblocks,
+				createListBlock( [
+					'Alpha',
+					'Gamma',
+					'Beta',
+					'Delta',
+					'Epsilon',
+					'Zeta',
+				] ),
+				null
+			);
+			mergeCrdtBlocks(
+				yblocks2,
+				createListBlock( [
+					'Alpha',
+					'Beta',
+					'Gamma',
+					'Epsilon',
+					'Delta',
+					'Zeta',
+				] ),
+				null
+			);
+
+			const updateA = Y.encodeStateAsUpdate( doc );
+			const updateB = Y.encodeStateAsUpdate( doc2 );
+			Y.applyUpdate( doc2, updateA );
+			Y.applyUpdate( doc, updateB );
+
+			for ( const checkBlocks of [ yblocks, yblocks2 ] ) {
+				expect( getListItems( checkBlocks ) ).toEqual( [
+					'Item Alpha',
+					'Item Gamma',
+					'Item Beta',
+					'Item Epsilon',
+					'Item Delta',
+					'Item Zeta',
+				] );
+			}
+
+			doc2.destroy();
+		} );
+
+		it( 'preserves concurrent list item moves by client ID with base records', () => {
+			const createListBlock = ( itemOrder: string[] ): Block[] => [
+				{
+					name: 'core/list',
+					attributes: {},
+					innerBlocks: itemOrder.map( ( item ) => ( {
+						name: 'core/list-item',
+						attributes: { content: `Item ${ item }` },
+						innerBlocks: [],
+						clientId: `item-${ item.toLowerCase() }`,
+					} ) ),
+					clientId: 'list-block',
+				},
+			];
+			const getListItems = ( checkBlocks: YBlocks ): string[] =>
+				( checkBlocks.get( 0 ).get( 'innerBlocks' ) as YBlocks )
+					.toArray()
+					.map( ( item ) =>
+						(
+							(
+								item.get( 'attributes' ) as YBlockAttributes
+							 ).get( 'content' ) as Y.Text
+						 ).toString()
+					);
+			const initialBlocks = createListBlock( [
+				'Alpha',
+				'Beta',
+				'Gamma',
+				'Delta',
+				'Epsilon',
+				'Zeta',
+			] );
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			const doc2 = new Y.Doc();
+			const yblocks2 = doc2.getArray< YBlock >();
+			Y.applyUpdate( doc2, Y.encodeStateAsUpdate( doc ) );
+
+			mergeCrdtBlocks(
+				yblocks,
+				createListBlock( [
+					'Alpha',
+					'Gamma',
+					'Beta',
+					'Delta',
+					'Epsilon',
+					'Zeta',
+				] ),
+				null,
+				initialBlocks
+			);
+			mergeCrdtBlocks(
+				yblocks2,
+				createListBlock( [
+					'Alpha',
+					'Beta',
+					'Gamma',
+					'Epsilon',
+					'Delta',
+					'Zeta',
+				] ),
+				null,
+				initialBlocks
+			);
+
+			const updateA = Y.encodeStateAsUpdate( doc );
+			const updateB = Y.encodeStateAsUpdate( doc2 );
+			Y.applyUpdate( doc2, updateA );
+			Y.applyUpdate( doc, updateB );
+
+			for ( const checkBlocks of [ yblocks, yblocks2 ] ) {
+				expect( getListItems( checkBlocks ) ).toEqual( [
+					'Item Alpha',
+					'Item Gamma',
+					'Item Beta',
+					'Item Epsilon',
+					'Item Delta',
+					'Item Zeta',
+				] );
+			}
+
+			doc2.destroy();
+		} );
+
+		it( 'rebases a delayed list item move over a remote list item move', () => {
+			const createListBlock = ( itemOrder: string[] ): Block[] => [
+				{
+					name: 'core/list',
+					attributes: {},
+					innerBlocks: itemOrder.map( ( item ) => ( {
+						name: 'core/list-item',
+						attributes: { content: `Item ${ item }` },
+						innerBlocks: [],
+						clientId: `item-${ item.toLowerCase() }`,
+					} ) ),
+					clientId: 'list-block',
+				},
+			];
+			const getListItems = ( checkBlocks: YBlocks ): string[] =>
+				( checkBlocks.get( 0 ).get( 'innerBlocks' ) as YBlocks )
+					.toArray()
+					.map( ( item ) =>
+						(
+							(
+								item.get( 'attributes' ) as YBlockAttributes
+							 ).get( 'content' ) as Y.Text
+						 ).toString()
+					);
+			const initialBlocks = createListBlock( [
+				'Alpha',
+				'Beta',
+				'Gamma',
+				'Delta',
+				'Epsilon',
+				'Zeta',
+			] );
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+			mergeCrdtBlocks(
+				yblocks,
+				createListBlock( [
+					'Alpha',
+					'Beta',
+					'Gamma',
+					'Epsilon',
+					'Delta',
+					'Zeta',
+				] ),
+				null,
+				initialBlocks
+			);
+			mergeCrdtBlocks(
+				yblocks,
+				createListBlock( [
+					'Alpha',
+					'Gamma',
+					'Beta',
+					'Delta',
+					'Epsilon',
+					'Zeta',
+				] ),
+				null,
+				initialBlocks
+			);
+
+			expect( getListItems( yblocks ) ).toEqual( [
+				'Item Alpha',
+				'Item Gamma',
+				'Item Beta',
+				'Item Epsilon',
+				'Item Delta',
+				'Item Zeta',
+			] );
+		} );
+
+		it( 'rebases a delayed list item move when equivalent blocks have different client IDs', () => {
+			const createListBlock = (
+				itemOrder: string[],
+				clientIdPrefix: string
+			): Block[] => [
+				{
+					name: 'core/list',
+					attributes: {},
+					innerBlocks: itemOrder.map( ( item ) => ( {
+						name: 'core/list-item',
+						attributes: { content: `Item ${ item }` },
+						innerBlocks: [],
+						clientId: `${ clientIdPrefix }-${ item.toLowerCase() }`,
+					} ) ),
+					clientId: `${ clientIdPrefix }-list-block`,
+				},
+			];
+			const getListItems = ( checkBlocks: YBlocks ): string[] =>
+				( checkBlocks.get( 0 ).get( 'innerBlocks' ) as YBlocks )
+					.toArray()
+					.map( ( item ) =>
+						(
+							(
+								item.get( 'attributes' ) as YBlockAttributes
+							 ).get( 'content' ) as Y.Text
+						 ).toString()
+					);
+			const initialBlocks = createListBlock(
+				[ 'Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon', 'Zeta' ],
+				'local'
+			);
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+			mergeCrdtBlocks(
+				yblocks,
+				createListBlock(
+					[ 'Alpha', 'Gamma', 'Beta', 'Delta', 'Epsilon', 'Zeta' ],
+					'remote'
+				),
+				null
+			);
+			mergeCrdtBlocks(
+				yblocks,
+				createListBlock(
+					[ 'Alpha', 'Beta', 'Gamma', 'Epsilon', 'Delta', 'Zeta' ],
+					'local'
+				),
+				null,
+				initialBlocks
+			);
+
+			expect( getListItems( yblocks ) ).toEqual( [
+				'Item Alpha',
+				'Item Gamma',
+				'Item Beta',
+				'Item Epsilon',
+				'Item Delta',
+				'Item Zeta',
+			] );
+		} );
+
+		it( 'does not overwrite remote list item content while rebasing a delayed move', () => {
+			const createListBlock = (
+				itemOrder: string[],
+				contentByItem: Record< string, string > = {}
+			): Block[] => [
+				{
+					name: 'core/list',
+					attributes: {},
+					innerBlocks: itemOrder.map( ( item ) => ( {
+						name: 'core/list-item',
+						attributes: {
+							content: contentByItem[ item ] ?? `Item ${ item }`,
+						},
+						innerBlocks: [],
+						clientId: `item-${ item.toLowerCase() }`,
+					} ) ),
+					clientId: 'list-block',
+				},
+			];
+			const getListItems = ( checkBlocks: YBlocks ): string[] =>
+				( checkBlocks.get( 0 ).get( 'innerBlocks' ) as YBlocks )
+					.toArray()
+					.map( ( item ) =>
+						(
+							(
+								item.get( 'attributes' ) as YBlockAttributes
+							 ).get( 'content' ) as Y.Text
+						 ).toString()
+					);
+			const initialBlocks = createListBlock( [
+				'Alpha',
+				'Beta',
+				'Gamma',
+				'Delta',
+				'Epsilon',
+				'Zeta',
+			] );
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+			mergeCrdtBlocks(
+				yblocks,
+				createListBlock(
+					[ 'Alpha', 'Beta', 'Gamma', 'Epsilon', 'Delta', 'Zeta' ],
+					{ Epsilon: 'Item Epsilon remote edit' }
+				),
+				null,
+				initialBlocks
+			);
+			mergeCrdtBlocks(
+				yblocks,
+				createListBlock( [
+					'Alpha',
+					'Gamma',
+					'Beta',
+					'Delta',
+					'Epsilon',
+					'Zeta',
+				] ),
+				null,
+				initialBlocks
+			);
+
+			expect( getListItems( yblocks ) ).toEqual( [
+				'Item Alpha',
+				'Item Gamma',
+				'Item Beta',
+				'Item Epsilon remote edit',
+				'Item Delta',
+				'Item Zeta',
+			] );
+		} );
+
 		it( 'creates Y.Text for rich-text attributes', () => {
 			const blocks: Block[] = [
 				{

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -13,11 +13,7 @@ import {
 	CRDT_STATE_MAP_SAVED_AT_KEY as SAVED_AT_KEY,
 	LOCAL_SYNC_MANAGER_ORIGIN,
 } from './config';
-import {
-	logPerformanceTiming,
-	passThru,
-	yieldToEventLoop,
-} from './performance';
+import { logPerformanceTiming, passThru } from './performance';
 import { getProviderCreators } from './providers';
 import type {
 	CollectionHandlers,
@@ -55,6 +51,8 @@ interface EntityState {
 	handlers: RecordHandlers;
 	objectId: ObjectID;
 	objectType: ObjectType;
+	remoteKeyVersions: Map< string, number >;
+	reconcilingRemoteKeys: Set< string >;
 	syncConfig: SyncConfig;
 	unload: () => void;
 	ydoc: CRDTDoc;
@@ -71,6 +69,45 @@ function getEntityId(
 	objectId: ObjectID | null
 ): EntityID {
 	return `${ objectType }_${ objectId }`;
+}
+
+function getTopLevelRecordKeysFromEvents(
+	events: Y.YEvent< any >[]
+): string[] {
+	const keys = new Set< string >();
+
+	for ( const event of events ) {
+		const [ key ] = event.path;
+		if ( 'string' === typeof key ) {
+			keys.add( key );
+			continue;
+		}
+
+		if ( event instanceof Y.YMapEvent ) {
+			event.keysChanged.forEach( ( changedKey ) =>
+				keys.add( changedKey )
+			);
+		}
+	}
+
+	return [ ...keys ];
+}
+
+function getScheduledRemoteKeyVersions(
+	entityState: EntityState | undefined,
+	changes: Partial< ObjectData >
+): Map< string, number > {
+	const versions = new Map< string, number >();
+
+	if ( ! entityState ) {
+		return versions;
+	}
+
+	Object.keys( changes ).forEach( ( key ) => {
+		versions.set( key, entityState.remoteKeyVersions.get( key ) ?? 0 );
+	} );
+
+	return versions;
 }
 
 /**
@@ -209,7 +246,7 @@ export function createSyncManager( debug = false ): SyncManager {
 		// When the CRDT document is updated by an UndoManager or a connection (not
 		// a local origin), update the local store.
 		const onRecordUpdate = (
-			_events: Y.YEvent< any >[],
+			events: Y.YEvent< any >[],
 			transaction: Y.Transaction
 		): void => {
 			if (
@@ -219,7 +256,27 @@ export function createSyncManager( debug = false ): SyncManager {
 				return;
 			}
 
-			void internal.updateEntityRecord( objectType, objectId );
+			const remoteChangedKeys = transaction.local
+				? []
+				: getTopLevelRecordKeysFromEvents( events );
+
+			const currentEntityState = entityStates.get( entityId );
+			if ( currentEntityState ) {
+				remoteChangedKeys.forEach( ( key ) => {
+					currentEntityState.remoteKeyVersions.set(
+						key,
+						( currentEntityState.remoteKeyVersions.get( key ) ??
+							0 ) + 1
+					);
+					currentEntityState.reconcilingRemoteKeys.add( key );
+				} );
+			}
+
+			void internal.updateEntityRecord(
+				objectType,
+				objectId,
+				remoteChangedKeys
+			);
 		};
 
 		const onStateMapUpdate = (
@@ -261,6 +318,8 @@ export function createSyncManager( debug = false ): SyncManager {
 			handlers,
 			objectId,
 			objectType,
+			remoteKeyVersions: new Map(),
+			reconcilingRemoteKeys: new Set(),
 			syncConfig,
 			unload,
 			ydoc,
@@ -550,28 +609,58 @@ export function createSyncManager( debug = false ): SyncManager {
 	/**
 	 * Update CRDT document with changes from the local store.
 	 *
-	 * @param {ObjectType}               objectType             Object type.
-	 * @param {ObjectID}                 objectId               Object ID.
-	 * @param {Partial< ObjectData >}    changes                Updates to make.
-	 * @param {string}                   origin                 The source of change.
-	 * @param {SyncManagerUpdateOptions} options                Optional flags for the update.
-	 * @param {boolean}                  options.isSave         Whether this update is part of a save operation. Defaults to false.
-	 * @param {boolean}                  options.isNewUndoLevel Whether to create a new undo level for this change. Defaults to false.
+	 * @param {ObjectType}               objectType                 Object type.
+	 * @param {ObjectID}                 objectId                   Object ID.
+	 * @param {Partial< ObjectData >}    changes                    Updates to make.
+	 * @param {string}                   origin                     The source of change.
+	 * @param {SyncManagerUpdateOptions} options                    Optional flags for the update.
+	 * @param {boolean}                  options.isSave             Whether this update is part of a save operation. Defaults to false.
+	 * @param {boolean}                  options.isNewUndoLevel     Whether to create a new undo level for this change. Defaults to false.
+	 * @param {Map< string, number >}    scheduledRemoteKeyVersions Remote key versions captured when the local update was scheduled.
 	 */
 	function updateCRDTDoc(
 		objectType: ObjectType,
 		objectId: ObjectID | null,
 		changes: Partial< ObjectData >,
 		origin: string,
-		options: SyncManagerUpdateOptions = {}
+		options: SyncManagerUpdateOptions = {},
+		scheduledRemoteKeyVersions: Map< string, number > = new Map()
 	): void {
 		const { isSave = false, isNewUndoLevel = false } = options;
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
-		const collectionState = collectionStates.get( objectType );
 
 		if ( entityState ) {
 			const { syncConfig, ydoc } = entityState;
+			let changesToApply = changes;
+
+			if (
+				! isSave &&
+				! options.baseRecord &&
+				entityState.reconcilingRemoteKeys.size > 0
+			) {
+				changesToApply = Object.fromEntries(
+					Object.entries( changes ).filter( ( [ key ] ) => {
+						if ( key === 'blocks' ) {
+							return true;
+						}
+
+						if ( ! entityState.reconcilingRemoteKeys.has( key ) ) {
+							return true;
+						}
+
+						return (
+							( entityState.remoteKeyVersions.get( key ) ??
+								0 ) ===
+							( scheduledRemoteKeyVersions.get( key ) ?? 0 )
+						);
+					} )
+				);
+
+				if ( 0 === Object.keys( changesToApply ).length ) {
+					return;
+				}
+			}
 
 			// If this is change should create a new undo level, tell the undo
 			// manager to stop capturing and create a new undo group.
@@ -584,9 +673,15 @@ export function createSyncManager( debug = false ): SyncManager {
 
 			ydoc.transact( () => {
 				log( 'updateCRDTDoc', 'applying changes', entityId, {
-					changedKeys: Object.keys( changes ),
+					changedKeys: Object.keys( changesToApply ),
 				} );
-				syncConfig.applyChangesToCRDTDoc( ydoc, changes );
+				if ( options.baseRecord ) {
+					syncConfig.applyChangesToCRDTDoc( ydoc, changesToApply, {
+						baseRecord: options.baseRecord,
+					} );
+				} else {
+					syncConfig.applyChangesToCRDTDoc( ydoc, changesToApply );
+				}
 
 				if ( isSave ) {
 					markEntityAsSaved( ydoc );
@@ -594,6 +689,7 @@ export function createSyncManager( debug = false ): SyncManager {
 			}, origin );
 		}
 
+		const collectionState = collectionStates.get( objectType );
 		if ( collectionState && isSave ) {
 			collectionState.ydoc.transact( () => {
 				markEntityAsSaved( collectionState.ydoc );
@@ -605,12 +701,14 @@ export function createSyncManager( debug = false ): SyncManager {
 	 * Update the entity record in the local store with changes from the CRDT
 	 * document.
 	 *
-	 * @param {ObjectType} objectType Object type of record to update.
-	 * @param {ObjectID}   objectId   Object ID of record to update.
+	 * @param {ObjectType} objectType        Object type of record to update.
+	 * @param {ObjectID}   objectId          Object ID of record to update.
+	 * @param {string[]}   preReconciledKeys Keys being reconciled before this update.
 	 */
 	async function _updateEntityRecord(
 		objectType: ObjectType,
-		objectId: ObjectID
+		objectId: ObjectID,
+		preReconciledKeys: string[] = []
 	): Promise< void > {
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
@@ -632,13 +730,55 @@ export function createSyncManager( debug = false ): SyncManager {
 		const changedKeys = Object.keys( changes );
 
 		if ( 0 === changedKeys.length ) {
+			preReconciledKeys.forEach( ( key ) =>
+				entityState.reconcilingRemoteKeys.delete( key )
+			);
 			return;
 		}
 
 		log( 'updateEntityRecord', 'changes', entityId, {
 			changedKeys,
 		} );
+		const keysToReconcile = [
+			...new Set( [ ...preReconciledKeys, ...changedKeys ] ),
+		];
+		keysToReconcile.forEach( ( key ) =>
+			entityState.reconcilingRemoteKeys.add( key )
+		);
 		handlers.editRecord( changes );
+		void clearReconciledRemoteKeys( entityState, keysToReconcile );
+	}
+
+	async function clearReconciledRemoteKeys(
+		entityState: EntityState,
+		keys: string[],
+		attempt = 0
+	): Promise< void > {
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		const changes = entityState.syncConfig.getChangesFromCRDTDoc(
+			entityState.ydoc,
+			await entityState.handlers.getEditedRecord()
+		);
+
+		for ( const key of keys ) {
+			if ( ! Object.prototype.hasOwnProperty.call( changes, key ) ) {
+				entityState.reconcilingRemoteKeys.delete( key );
+			}
+		}
+
+		if (
+			keys.some( ( key ) =>
+				entityState.reconcilingRemoteKeys.has( key )
+			) &&
+			attempt < 5
+		) {
+			return clearReconciledRemoteKeys( entityState, keys, attempt + 1 );
+		}
+
+		keys.forEach( ( key ) =>
+			entityState.reconcilingRemoteKeys.delete( key )
+		);
 	}
 
 	/**
@@ -666,6 +806,30 @@ export function createSyncManager( debug = false ): SyncManager {
 		return serializeCrdtDoc( entityState.ydoc );
 	}
 
+	function scheduleUpdateCRDTDoc(
+		objectType: ObjectType,
+		objectId: ObjectID | null,
+		changes: Partial< ObjectData >,
+		origin: string,
+		options: SyncManagerUpdateOptions = {}
+	): void {
+		const scheduledRemoteKeyVersions = getScheduledRemoteKeyVersions(
+			entityStates.get( getEntityId( objectType, objectId ) ),
+			changes
+		);
+
+		setTimeout( () => {
+			updateCRDTDoc(
+				objectType,
+				objectId,
+				changes,
+				origin,
+				options,
+				scheduledRemoteKeyVersions
+			);
+		}, 0 );
+	}
+
 	// Collect internal functions so that they can be wrapped before calling.
 	const internal = {
 		applyPersistedCrdtDoc: debugWrap( _applyPersistedCrdtDoc ),
@@ -683,6 +847,6 @@ export function createSyncManager( debug = false ): SyncManager {
 			return undoManager;
 		},
 		unload: debugWrap( unloadEntity ),
-		update: debugWrap( yieldToEventLoop( updateCRDTDoc ) ),
+		update: debugWrap( scheduleUpdateCRDTDoc ),
 	};
 }

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -809,12 +809,17 @@ describe( 'SyncManager', () => {
 
 			// Simulate a remote change.
 			const remoteDoc = new Y.Doc();
+			Y.applyUpdateV2(
+				remoteDoc,
+				Y.encodeStateAsUpdateV2( capturedDoc as unknown as Y.Doc )
+			);
+			const remoteStateVector = Y.encodeStateVector( remoteDoc );
 			remoteDoc
 				.getMap( CRDT_RECORD_MAP_KEY )
 				.set( 'title', 'Title from remote peer' );
 			Y.applyUpdateV2(
 				capturedDoc as unknown as Y.Doc,
-				Y.encodeStateAsUpdateV2( remoteDoc )
+				Y.encodeStateAsUpdateV2( remoteDoc, remoteStateVector )
 			);
 			remoteDoc.destroy();
 
@@ -825,6 +830,247 @@ describe( 'SyncManager', () => {
 			expect( mockHandlers.editRecord ).toHaveBeenCalledWith( {
 				title: 'Title from remote peer',
 			} );
+		} );
+
+		it( 'allows local same-key updates scheduled while remote updates are reconciling', async () => {
+			let capturedDoc: Y.Doc | null = null;
+			mockProviderCreator.mockImplementation( async ( { ydoc } ) => {
+				capturedDoc = ydoc;
+				return mockProviderResult;
+			} );
+			mockSyncConfig.applyChangesToCRDTDoc = jest.fn(
+				( ydoc: CRDTDoc, changes: Partial< ObjectData > ) => {
+					const ymap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+					Object.entries( changes ).forEach( ( [ key, value ] ) =>
+						ymap.set( key, value )
+					);
+				}
+			);
+
+			const manager = createSyncManager();
+
+			await manager.load(
+				mockSyncConfig,
+				'post',
+				'123',
+				mockRecord,
+				mockHandlers
+			);
+
+			mockSyncConfig.applyChangesToCRDTDoc.mockClear();
+			mockHandlers.editRecord.mockClear();
+
+			const remoteDoc = new Y.Doc();
+			Y.applyUpdateV2(
+				remoteDoc,
+				Y.encodeStateAsUpdateV2( capturedDoc as unknown as Y.Doc )
+			);
+			const remoteStateVector = Y.encodeStateVector( remoteDoc );
+			remoteDoc
+				.getMap( CRDT_RECORD_MAP_KEY )
+				.set( 'title', 'Title from remote peer' );
+			Y.applyUpdateV2(
+				capturedDoc as unknown as Y.Doc,
+				Y.encodeStateAsUpdateV2( remoteDoc, remoteStateVector )
+			);
+			remoteDoc.destroy();
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+			expect( mockHandlers.editRecord ).toHaveBeenCalledWith( {
+				title: 'Title from remote peer',
+			} );
+
+			manager.update(
+				'post',
+				'123',
+				{
+					content: 'Local content edit',
+					title: mockRecord.title,
+				},
+				LOCAL_EDITOR_ORIGIN
+			);
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+			expect( mockSyncConfig.applyChangesToCRDTDoc ).toHaveBeenCalledWith(
+				capturedDoc as unknown as Y.Doc,
+				{
+					content: 'Local content edit',
+					title: mockRecord.title,
+				}
+			);
+		} );
+
+		it( 'filters stale local keys before the edited record lookup resolves', async () => {
+			let capturedDoc: Y.Doc | null = null;
+			mockProviderCreator.mockImplementation( async ( { ydoc } ) => {
+				capturedDoc = ydoc;
+				return mockProviderResult;
+			} );
+			mockSyncConfig.applyChangesToCRDTDoc = jest.fn(
+				( ydoc: CRDTDoc, changes: Partial< ObjectData > ) => {
+					const ymap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+					Object.entries( changes ).forEach( ( [ key, value ] ) =>
+						ymap.set( key, value )
+					);
+				}
+			);
+
+			const manager = createSyncManager();
+
+			await manager.load(
+				mockSyncConfig,
+				'post',
+				'123',
+				mockRecord,
+				mockHandlers
+			);
+
+			mockSyncConfig.applyChangesToCRDTDoc.mockClear();
+			mockHandlers.editRecord.mockClear();
+
+			let resolveEditedRecord!: ( record: ObjectData ) => void;
+			const editedRecordPromise = new Promise< ObjectData >(
+				( resolve ) => {
+					resolveEditedRecord = resolve;
+				}
+			);
+			mockHandlers.getEditedRecord.mockImplementationOnce(
+				() => editedRecordPromise
+			);
+
+			manager.update(
+				'post',
+				'123',
+				{
+					content: 'Local content edit',
+					title: mockRecord.title,
+				},
+				LOCAL_EDITOR_ORIGIN
+			);
+
+			const remoteDoc = new Y.Doc();
+			Y.applyUpdateV2(
+				remoteDoc,
+				Y.encodeStateAsUpdateV2( capturedDoc as unknown as Y.Doc )
+			);
+			const remoteStateVector = Y.encodeStateVector( remoteDoc );
+			remoteDoc
+				.getMap( CRDT_RECORD_MAP_KEY )
+				.set( 'title', 'Title from remote peer' );
+			Y.applyUpdateV2(
+				capturedDoc as unknown as Y.Doc,
+				Y.encodeStateAsUpdateV2( remoteDoc, remoteStateVector )
+			);
+			remoteDoc.destroy();
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+			expect( mockSyncConfig.applyChangesToCRDTDoc ).toHaveBeenCalledWith(
+				capturedDoc as unknown as Y.Doc,
+				{
+					content: 'Local content edit',
+				}
+			);
+
+			mockHandlers.getEditedRecord.mockImplementation( async () => ( {
+				...mockRecord,
+				content: 'Local content edit',
+				title: 'Title from remote peer',
+			} ) );
+			resolveEditedRecord( {
+				...mockRecord,
+				content: 'Local content edit',
+			} );
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+			expect( mockHandlers.editRecord ).toHaveBeenCalledWith( {
+				title: 'Title from remote peer',
+			} );
+		} );
+
+		it( 'allows local same-key updates scheduled after remote reconciliation starts', async () => {
+			let capturedDoc: Y.Doc | null = null;
+			mockProviderCreator.mockImplementation( async ( { ydoc } ) => {
+				capturedDoc = ydoc;
+				return mockProviderResult;
+			} );
+			mockSyncConfig.applyChangesToCRDTDoc = jest.fn(
+				( ydoc: CRDTDoc, changes: Partial< ObjectData > ) => {
+					const ymap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+					Object.entries( changes ).forEach( ( [ key, value ] ) =>
+						ymap.set( key, value )
+					);
+				}
+			);
+
+			const manager = createSyncManager();
+
+			await manager.load(
+				mockSyncConfig,
+				'post',
+				'123',
+				mockRecord,
+				mockHandlers
+			);
+
+			mockSyncConfig.applyChangesToCRDTDoc.mockClear();
+			mockHandlers.editRecord.mockClear();
+
+			let resolveEditedRecord!: ( record: ObjectData ) => void;
+			const editedRecordPromise = new Promise< ObjectData >(
+				( resolve ) => {
+					resolveEditedRecord = resolve;
+				}
+			);
+			mockHandlers.getEditedRecord.mockImplementationOnce(
+				() => editedRecordPromise
+			);
+
+			const remoteDoc = new Y.Doc();
+			Y.applyUpdateV2(
+				remoteDoc,
+				Y.encodeStateAsUpdateV2( capturedDoc as unknown as Y.Doc )
+			);
+			const remoteStateVector = Y.encodeStateVector( remoteDoc );
+			remoteDoc
+				.getMap( CRDT_RECORD_MAP_KEY )
+				.set( 'title', 'Title from remote peer' );
+			Y.applyUpdateV2(
+				capturedDoc as unknown as Y.Doc,
+				Y.encodeStateAsUpdateV2( remoteDoc, remoteStateVector )
+			);
+			remoteDoc.destroy();
+
+			manager.update(
+				'post',
+				'123',
+				{
+					title: 'Local title after remote peer',
+				},
+				LOCAL_EDITOR_ORIGIN
+			);
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+			expect( mockSyncConfig.applyChangesToCRDTDoc ).toHaveBeenCalledWith(
+				capturedDoc as unknown as Y.Doc,
+				{
+					title: 'Local title after remote peer',
+				}
+			);
+
+			mockHandlers.getEditedRecord.mockImplementation( async () => ( {
+				...mockRecord,
+				title: 'Local title after remote peer',
+			} ) );
+			resolveEditedRecord( {
+				...mockRecord,
+			} );
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 		} );
 
 		it( 'does not edit the local record for local transactions', async () => {

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -119,6 +119,7 @@ export interface CollectionHandlers {
 }
 
 export interface SyncManagerUpdateOptions {
+	baseRecord?: ObjectData;
 	isSave?: boolean;
 	isNewUndoLevel?: boolean;
 }
@@ -139,7 +140,8 @@ export interface RecordHandlers {
 export interface SyncConfig {
 	applyChangesToCRDTDoc: (
 		ydoc: Y.Doc,
-		changes: Partial< ObjectData >
+		changes: Partial< ObjectData >,
+		options?: SyncManagerUpdateOptions
 	) => void;
 	createAwareness?: (
 		ydoc: Y.Doc,

--- a/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
@@ -122,21 +122,16 @@ async function expectSharedListReady(
 	editors: Editor[],
 	expectedOrder: string[]
 ) {
-	const renderedItems = await Promise.all(
-		editors.map( ( ed ) => getRenderedListItems( ed ) )
-	);
-	for ( const items of renderedItems ) {
-		expect( items.map( ( item ) => item.content ) ).toEqual(
-			expectedOrder
+	await expect( async () => {
+		const renderedItems = await Promise.all(
+			editors.map( ( ed ) => getRenderedListItems( ed ) )
 		);
-	}
-
-	const firstClientIds = renderedItems[ 0 ].map( ( item ) => item.clientId );
-	for ( const items of renderedItems.slice( 1 ) ) {
-		expect( items.map( ( item ) => item.clientId ) ).toEqual(
-			firstClientIds
-		);
-	}
+		for ( const items of renderedItems ) {
+			expect( items.map( ( item ) => item.content ) ).toEqual(
+				expectedOrder
+			);
+		}
+	} ).toPass( { timeout: 10_000 } );
 }
 
 function bol( items: string[] ): string {
@@ -613,33 +608,36 @@ test.describe( 'Collaboration - Stress Test', () => {
 		// ── Phase 2 — Concurrent list-item moves ────────────────
 		// User 1 moves "Item Beta" down; User 2 moves "Item Epsilon" up.
 		// The items are well-separated so the moves don't conflict.
-		await Promise.all( [
-			( async () => {
-				await editor.canvas
-					.getByText( 'Item Beta', { exact: true } )
-					.click();
-				await editor.showBlockToolbar();
-				await page
-					.locator(
-						'role=toolbar[name="Block tools"i] >> role=button[name="Move down"i]'
-					)
-					.click();
-			} )(),
-			( async () => {
-				await editor2.canvas
-					.getByText( 'Item Epsilon', { exact: true } )
-					.click();
-				await editor2.showBlockToolbar();
-				await page2
-					.locator(
-						'role=toolbar[name="Block tools"i] >> role=button[name="Move up"i]'
-					)
-					.click();
-			} )(),
-		] );
+		await editor.canvas.getByText( 'Item Beta', { exact: true } ).click();
+		await editor.showBlockToolbar();
 
-		// Verify both moves on both users: Beta after Gamma,
-		// Epsilon before Delta.
+		await editor2.canvas
+			.getByText( 'Item Epsilon', { exact: true } )
+			.click();
+		await editor2.showBlockToolbar();
+
+		const moveBetaDown = page.locator(
+			'role=toolbar[name="Block tools"i] >> role=button[name="Move down"i]'
+		);
+		const moveEpsilonUp = page2.locator(
+			'role=toolbar[name="Block tools"i] >> role=button[name="Move up"i]'
+		);
+
+		await expect( moveBetaDown ).toBeVisible();
+		await expect( moveEpsilonUp ).toBeVisible();
+
+		await Promise.all( [ moveBetaDown.click(), moveEpsilonUp.click() ] );
+
+		const expectedMovedOrder = [
+			'Item Alpha',
+			'Item Gamma',
+			'Item Beta',
+			'Item Epsilon',
+			'Item Delta',
+			'Item Zeta',
+		];
+
+		// Verify both moves on both users.
 		const assertMovedOrder = async ( ed: Editor ) => {
 			await expect( async () => {
 				const blocks = await ed.getBlocks();
@@ -650,13 +648,7 @@ test.describe( 'Collaboration - Stress Test', () => {
 				const items = listBlock!.innerBlocks.map( ( item ) =>
 					String( item.attributes.content )
 				);
-				expect( items ).toHaveLength( 6 );
-				const betaIdx = items.indexOf( 'Item Beta' );
-				const gammaIdx = items.indexOf( 'Item Gamma' );
-				const epsilonIdx = items.indexOf( 'Item Epsilon' );
-				const deltaIdx = items.indexOf( 'Item Delta' );
-				expect( betaIdx ).toBeGreaterThan( gammaIdx );
-				expect( epsilonIdx ).toBeLessThan( deltaIdx );
+				expect( items ).toEqual( expectedMovedOrder );
 			} ).toPass( { timeout: 10_000 } );
 		};
 
@@ -666,6 +658,9 @@ test.describe( 'Collaboration - Stress Test', () => {
 
 		// ── Phase 3 — Save draft ────────────────────────────────
 		await editor.saveDraft();
+		for ( const ed of [ editor, editor2 ] ) {
+			await assertMovedOrder( ed );
+		}
 
 		// ── Phase 4 — User 1 refreshes ──────────────────────────
 		await page.reload( { waitUntil: 'load' } );


### PR DESCRIPTION
This is part of an AI fuzzing project, where an AI wrote a fuzzer and then triages bugs from the fuzzer and creates fixes. See #77716 for the tracking issue. As of this writing, there have been no known false positives from this project, but there have been some issues, which are documented in #77716. I expect we’ll see false positives at some point (and may even have one that’s been filed in a PR that hasn’t been inspected by a code owner yet).

## What?

Per @alecgeatches's request, this is part 1 of N of splitting #77924 into multiple PRs. This fixes the issue shown in the 3rd video there. I'm opening this single PR rather than doing all N parts to get feedback one to see if other PRs from this series should be modified before submitting them.

## AI TEXT

The failure is not from one isolated bad commit. It comes from a few RTC design
choices interacting:

- [#68483](https://github.com/WordPress/gutenberg/pull/68483) introduced the
  reliable sync protocol foundation. The block merge strategy remained largely
  snapshot-oriented: local block trees are converted into Yjs structures, and
  later snapshots are merged into the current Yjs document.
- [#75699](https://github.com/WordPress/gutenberg/pull/75699) removed plugin
  checks around collaborative editing and made this path more broadly active.
- [#75029](https://github.com/WordPress/gutenberg/pull/75029) deferred
  `SyncManager.update()` through `yieldToEventLoop()`. That improved scheduling,
  but it also opened a race: a local snapshot can be captured before a remote
  update arrives, then applied after that remote update has already modified the
  Yjs document.
- [#75975](https://github.com/WordPress/gutenberg/pull/75975) fixed one save
  manifestation of this by waiting for deferred Y.Doc writes before serializing
  `_crdt_document`, confirming that deferred local writes are observable at save
  boundaries.
- [#77966](https://github.com/WordPress/gutenberg/pull/77966) moved sync
  observers after persisted CRDT hydration, fixing a redundant hydration edit.
  That did not address stale local snapshots that are already queued before
  remote reconciliation finishes.
- [#76913](https://github.com/WordPress/gutenberg/pull/76913) added
  schema-aware table/query merging. That is relevant to the full PR 77924
  branch, but is not part of this first split.

## Bug Shape

The list-item stress failure is:

```sh
npm run test:e2e:rtc-websocket -- \
  --grep "two users concurrently move list items"
```

Two users move different list items at about the same time. The old merge path
could only see the incoming full block snapshot, not the record the local user
edited from. When a queued local snapshot was stale, the merge could not tell:

- "this field is unchanged relative to my local base, preserve the remote
  update", from
- "this field is a deliberate local write, apply it over the remote update".

For structural block changes, the positional merge also treated moves as
delete/insert-like rewrites. That can replace Yjs block objects instead of moving
the existing objects. Once that happens, rich text and nested block state may
attach to the wrong list item, duplicate an item, or smear text across siblings.

The visible e2e symptom was a persisted/reloaded list such as:

```text
Item Alpha
Item Gamma
Item Gamma
Item EpsiEpsilonon
Item DeDeltata
Item Zeta
```

The live editors could converge before save, while a reload immediately after
save exposed stale provider/store reconciliation. The test now waits for the
semantic post-save state on both editors before reloading; without that wait,
the test can race its own save boundary instead of testing the merge semantics.

## Fix Plan Used In The Split

This split keeps the fix to the smallest code surface that made the list-move
case reliable.

1. Pass a pre-edit `baseRecord` from `editEntityRecord()` into
   `SyncManager.update()`.

   This gives CRDT block merging a three-way view: base record, current Yjs
   document, and incoming local edits.

2. Thread `baseRecord.blocks` into `mergeCrdtBlocks()`.

   The block merger can now skip fields that are unchanged from the local base
   instead of overwriting remote changes with stale local values.

3. Rebase block order by identity before falling back to positional merging.

   For same-size block arrays with stable `clientId`s, the merger moves the
   current Yjs block objects into the incoming order. This preserves nested
   Yjs state and avoids rewriting adjacent blocks. Where `clientId`s are not
   enough, the code can use unique semantic block keys.

4. Track remote key versions in `SyncManager`.

   Remote Yjs updates mark top-level record keys as reconciling. A deferred
   local update that was scheduled before a remote change can then filter stale
   non-block keys instead of replaying them. Block updates are still passed
   through to the base-aware block merger.

5. Strengthen the list-move e2e assertion.

   The old test only checked relative ordering:

   - Beta after Gamma.
   - Epsilon before Delta.

   The split asserts the exact semantic order:

   ```text
   Item Alpha
   Item Gamma
   Item Beta
   Item Epsilon
   Item Delta
   Item Zeta
   ```

   It also checks that exact order after save and before reload, so the reload
   phase does not race a pending sync/save boundary.

## What Stayed Out

The first split does not attempt to fix every RTC stress failure that remains
when PR 77924's behavioral changes are layered onto current trunk. In local
validation, the other existing failure,
`three users concurrently edit a large post with diverse blocks`, still failed
after this reduced branch. Its failures were broader: same-paragraph convergence,
block toolbar movement, and final paragraph propagation. Those require more of
the full PR 77924 surface and should be reviewed in later splits.

The table/query-array merge work and WebSocket/provider reload behavior fixes
should also remain separate review slices. The WebSocket test harness itself is
not a later slice; it comes from PR 78179 and must be preserved by every split
unless a future split explicitly replaces that harness.

## END AI TEXT
