### PR TITLE
Global Styles: Allow overriding default theme font from typography panel

### DIFF
--- a/packages/global-styles-ui/src/confirm-apply-font-to-all-dialog.tsx
+++ b/packages/global-styles-ui/src/confirm-apply-font-to-all-dialog.tsx
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+interface ConfirmApplyFontToAllDialogProps {
+	fontName: string;
+	elementCount: number;
+	isOpen: boolean;
+	toggleOpen: () => void;
+	onConfirm: () => void;
+}
+
+function ConfirmApplyFontToAllDialog( {
+	fontName,
+	elementCount,
+	isOpen,
+	toggleOpen,
+	onConfirm,
+}: ConfirmApplyFontToAllDialogProps ) {
+	const handleConfirm = async () => {
+		toggleOpen();
+		onConfirm();
+	};
+
+	const handleCancel = () => {
+		toggleOpen();
+	};
+
+	return (
+		<ConfirmDialog
+			isOpen={ isOpen }
+			cancelButtonText={ __( 'Cancel' ) }
+			confirmButtonText={ __( 'Apply to All' ) }
+			onCancel={ handleCancel }
+			onConfirm={ handleConfirm }
+			size="medium"
+		>
+			{ sprintf(
+				/* translators: 1: Font name, 2: Number of elements */
+				__(
+					'Apply "%1$s" to all %2$d typography elements? This will replace any custom fonts set on headings, links, buttons, and captions.'
+				),
+				fontName,
+				elementCount
+			) }
+		</ConfirmDialog>
+	);
+}
+
+export default ConfirmApplyFontToAllDialog;

--- a/packages/global-styles-ui/src/global-styles-ui.tsx
+++ b/packages/global-styles-ui/src/global-styles-ui.tsx
@@ -23,6 +23,7 @@ import ScreenBlockList from './screen-block-list';
 import ScreenBlock from './screen-block';
 import ScreenTypography from './screen-typography';
 import ScreenTypographyElement from './screen-typography-element';
+import ScreenTypographyDefault from './screen-typography-default';
 import ScreenColors from './screen-colors';
 import ScreenColorPalette from './screen-color-palette';
 import ScreenBackground from './screen-background';
@@ -205,6 +206,9 @@ export function GlobalStylesUI( {
 					</GlobalStylesNavigationScreen>
 					<GlobalStylesNavigationScreen path="/background">
 						<ScreenBackground />
+					</GlobalStylesNavigationScreen>
+					<GlobalStylesNavigationScreen path="/typography/default">
+						<ScreenTypographyDefault />
 					</GlobalStylesNavigationScreen>
 					<GlobalStylesNavigationScreen path="/typography/text">
 						<ScreenTypographyElement element="text" />

--- a/packages/global-styles-ui/src/screen-typography-default.tsx
+++ b/packages/global-styles-ui/src/screen-typography-default.tsx
@@ -1,0 +1,85 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { __experimentalSpacer as Spacer, Button } from '@wordpress/components';
+import { useState, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import TypographyPanel from './typography-panel';
+import { ScreenHeader } from './screen-header';
+import TypographyPreview from './typography-preview';
+import { GlobalStylesContext } from './context';
+import ConfirmApplyFontToAllDialog from './confirm-apply-font-to-all-dialog';
+import { useStyle } from './hooks';
+import { applyFontFamilyToAllElements, TYPOGRAPHY_ELEMENTS } from './utils';
+
+function ScreenTypographyDefault() {
+	const [ isDialogOpen, setIsDialogOpen ] = useState( false );
+	const { user, onChange } = useContext( GlobalStylesContext );
+
+	// Get root font family (using empty prefix for root)
+	const [ rootFontFamily ] = useStyle< string >( 'typography.fontFamily' );
+
+	// Handler for apply to all
+	const handleApplyToAll = () => {
+		if ( ! rootFontFamily ) {
+			return;
+		}
+
+		const updatedConfig = applyFontFamilyToAllElements(
+			user,
+			rootFontFamily
+		);
+		onChange( updatedConfig );
+	};
+
+	// Get font name for display (extract from var:preset or use raw value)
+	const getFontDisplayName = ( fontFamily: string ) => {
+		if ( fontFamily?.startsWith( 'var:preset|font-family|' ) ) {
+			return fontFamily
+				.replace( 'var:preset|font-family|', '' )
+				.replace( /-/g, ' ' );
+		}
+		return fontFamily || '';
+	};
+
+	return (
+		<>
+			<ScreenHeader
+				title={ __( 'Default' ) }
+				description={ __(
+					'Set the default font that will be applied to all typography elements on the site.'
+				) }
+			/>
+			<Spacer marginX={ 4 }>
+				<TypographyPreview element="text" headingLevel="heading" />
+			</Spacer>
+			<TypographyPanel element="default" headingLevel="heading" />
+
+			<Spacer marginX={ 4 } marginBottom={ 4 }>
+				<Button
+					variant="primary"
+					onClick={ () => setIsDialogOpen( true ) }
+					disabled={ ! rootFontFamily }
+					accessibleWhenDisabled
+					__next40pxDefaultSize
+				>
+					{ __( 'Apply to all elements' ) }
+				</Button>
+			</Spacer>
+
+			<ConfirmApplyFontToAllDialog
+				fontName={ getFontDisplayName( rootFontFamily ) }
+				elementCount={ TYPOGRAPHY_ELEMENTS.length }
+				isOpen={ isDialogOpen }
+				toggleOpen={ () => setIsDialogOpen( ! isDialogOpen ) }
+				onConfirm={ handleApplyToAll }
+			/>
+		</>
+	);
+}
+
+export default ScreenTypographyDefault;

--- a/packages/global-styles-ui/src/screen-typography-element.tsx
+++ b/packages/global-styles-ui/src/screen-typography-element.tsx
@@ -17,6 +17,12 @@ import { ScreenHeader } from './screen-header';
 import TypographyPreview from './typography-preview';
 
 const elements = {
+	default: {
+		description: __(
+			'Set the default font that will be applied to all typography elements on the site.'
+		),
+		title: __( 'Default' ),
+	},
 	text: {
 		description: __( 'Manage the fonts used on the site.' ),
 		title: __( 'Text' ),

--- a/packages/global-styles-ui/src/typography-elements.tsx
+++ b/packages/global-styles-ui/src/typography-elements.tsx
@@ -24,7 +24,9 @@ interface ElementItemProps {
 
 function ElementItem( { parentMenu, element, label }: ElementItemProps ) {
 	const prefix =
-		element === 'text' || ! element ? '' : `elements.${ element }.`;
+		element === 'text' || element === 'default' || ! element
+			? ''
+			: `elements.${ element }.`;
 	const extraStyles =
 		element === 'link'
 			? {
@@ -80,6 +82,11 @@ function TypographyElements() {
 		<VStack spacing={ 3 }>
 			<Subtitle level={ 3 }>{ __( 'Elements' ) }</Subtitle>
 			<ItemGroup isBordered isSeparated>
+				<ElementItem
+					parentMenu={ parentMenu }
+					element="default"
+					label={ __( 'Default' ) }
+				/>
 				<ElementItem
 					parentMenu={ parentMenu }
 					element="text"

--- a/packages/global-styles-ui/src/typography-panel.tsx
+++ b/packages/global-styles-ui/src/typography-panel.tsx
@@ -25,7 +25,7 @@ export default function TypographyPanel( {
 	let prefixParts: string[] = [];
 	if ( element === 'heading' ) {
 		prefixParts = prefixParts.concat( [ 'elements', headingLevel ] );
-	} else if ( element && element !== 'text' ) {
+	} else if ( element && element !== 'text' && element !== 'default' ) {
 		prefixParts = prefixParts.concat( [ 'elements', element ] );
 	}
 	const prefix = prefixParts.join( '.' );

--- a/packages/global-styles-ui/src/utils.ts
+++ b/packages/global-styles-ui/src/utils.ts
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { areGlobalStylesEqual } from '@wordpress/global-styles-engine';
+import {
+	areGlobalStylesEqual,
+	setStyle,
+} from '@wordpress/global-styles-engine';
 import type { GlobalStylesConfig } from '@wordpress/global-styles-engine';
 import { __ } from '@wordpress/i18n';
 
@@ -383,4 +386,48 @@ export function getNewIndexFromPresets(
 		return currentHighest;
 	}, 0 );
 	return highestPresetValue + 1;
+}
+
+/**
+ * Typography elements that can have font family applied.
+ * Includes general elements plus individual heading levels.
+ */
+export const TYPOGRAPHY_ELEMENTS = [
+	'link',
+	'heading',
+	'h1',
+	'h2',
+	'h3',
+	'h4',
+	'h5',
+	'h6',
+	'button',
+	'caption',
+	'cite',
+] as const;
+
+/**
+ * Applies a font family to all typography elements.
+ *
+ * @param user       The current user global styles config.
+ * @param fontFamily The font family value to apply (e.g., "var:preset|font-family|dm-sans").
+ * @return Updated global styles config with font applied to all elements.
+ */
+export function applyFontFamilyToAllElements(
+	user: GlobalStylesConfig,
+	fontFamily: string
+): GlobalStylesConfig {
+	let updatedConfig = user;
+
+	TYPOGRAPHY_ELEMENTS.forEach( ( element ) => {
+		const stylePath = `elements.${ element }.typography.fontFamily`;
+		updatedConfig = setStyle(
+			updatedConfig,
+			stylePath,
+			fontFamily,
+			undefined // blockName
+		);
+	} );
+
+	return updatedConfig;
 }


### PR DESCRIPTION

## What?
Closes #73857

Add a "Default" option to the Typography Elements section that allows users to set a base font family and apply it to all typography elements in one action.

## Why?
When users want to replace a theme's default font (e.g., changing from Manrope to DM Sans in TT5), they currently must manually update the font family for each typography element individually (Text, Links, Headings, Captions, Buttons). This is tedious and error-prone.

This PR addresses the issue by providing a single "Default" entry in the Styles → Typography → Elements section where users can:
1. Select a base font family
2. Apply it to all 11 typography elements (link, heading, h1-h6, button, caption, cite) with one click

This solves the problem of having to navigate to each element screen separately to make the same change.

## Testing Instructions
1. Click "Typography" → "Elements" → "Default"
2. Select a font family (e.g., "DM Sans" or any available font)
3. Click the "Apply to all elements" button
4. Confirm in the dialog
5. Navigate to "Elements" → "Text" → Should show the selected font (Similarly for other elements)

## Screenshots or screencast
https://github.com/user-attachments/assets/21409e3b-6b94-49e5-bd0a-f589f0d62b05
