### PR TITLE
Tests: Add `timezone-mock` to `test/unit/package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64170,7 +64170,8 @@
 				"jest-message-util": "^29.6.2",
 				"jest-watch-typeahead": "^2.2.2",
 				"resize-observer-polyfill": "^1.5.1",
-				"snapshot-diff": "^0.10.0"
+				"snapshot-diff": "^0.10.0",
+				"timezone-mock": "^1.3.6"
 			}
 		},
 		"tools/api-docs": {

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -35,7 +35,8 @@
 		"jest-message-util": "^29.6.2",
 		"jest-watch-typeahead": "^2.2.2",
 		"resize-observer-polyfill": "^1.5.1",
-		"snapshot-diff": "^0.10.0"
+		"snapshot-diff": "^0.10.0",
+		"timezone-mock": "^1.3.6"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## What?

Follow-up to #78056.

Adds `timezone-mock` as an explicit `devDependency` of the `@wordpress/unit-tests` package (`test/unit/package.json`).

## Why?

In #78056 the global Jest setup at `test/unit/config/global-mocks.js` was updated to `import timezoneMock from 'timezone-mock'` so that a `fallbackFn` could be configured for `MockDate`. However, the dependency was only declared in `packages/components/package.json` (where it had previously been used directly by the date-time tests).

As [pointed out in review](https://github.com/WordPress/gutenberg/pull/78056#pullrequestreview-4283248261) by @manzoorwanijk, the package that actually imports the module should declare it. This keeps the dependency graph honest and avoids relying on hoisting from another workspace package.

## How?

- Add `"timezone-mock": "^1.3.6"` to the `devDependencies` of `test/unit/package.json` (matching the version already declared by `@wordpress/components`).
- Regenerate `package-lock.json` accordingly (no version change; only the workspace's declared `devDependencies` block is updated).

## Testing Instructions

1. Run the existing unit tests for date-time components:
   `npm run test:unit -- packages/components/src/date-time`
2. Verify that all tests pass and that no resolution warnings are emitted for `timezone-mock`.

### Testing Instructions for Keyboard

N/A — test infrastructure change only.

## Screenshots or screencast

N/A

## Use of AI Tools

This pull request was authored with the assistance of Claude Opus 4.7, used to confirm the location of the `timezone-mock` import and to draft this PR addressing the follow-up review feedback.