### PR TITLE
Fix 'Invalid Date' when clicking on Now in DateTimePicker on Date Block.

### DIFF
--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -99,11 +99,15 @@ export default function PostDateEdit( props ) {
 
 	const blockEditingMode = useBlockEditingMode();
 
+	const validDatetime = datetime || new Date();
 	let postDate = (
-		<time dateTime={ dateI18n( 'c', datetime ) } ref={ setPopoverAnchor }>
+		<time
+			dateTime={ dateI18n( 'c', validDatetime ) }
+			ref={ setPopoverAnchor }
+		>
 			{ format === 'human-diff'
-				? humanTimeDiff( datetime )
-				: dateI18n( format || siteFormat, datetime ) }
+				? humanTimeDiff( validDatetime )
+				: dateI18n( format || siteFormat, validDatetime ) }
 		</time>
 	);
 
@@ -137,9 +141,7 @@ export default function PostDateEdit( props ) {
 										currentDate={ datetime }
 										onChange={ ( newDatetime ) =>
 											setAttributes( {
-												datetime:
-													newDatetime ??
-													new Date().toISOString(),
+												datetime: newDatetime,
 											} )
 										}
 										is12Hour={ is12HourFormat(

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -137,7 +137,9 @@ export default function PostDateEdit( props ) {
 										currentDate={ datetime }
 										onChange={ ( newDatetime ) =>
 											setAttributes( {
-												datetime: newDatetime,
+												datetime:
+													newDatetime ??
+													new Date().toISOString(),
 											} )
 										}
 										is12Hour={ is12HourFormat(

--- a/packages/date/src/index.ts
+++ b/packages/date/src/index.ts
@@ -626,7 +626,7 @@ export function humanTimeDiff(
  * @return A moment instance.
  */
 function buildMoment(
-	dateValue?: Moment | Date | string | number,
+	dateValue: Moment | Date | string | number,
 	timezone: string | number = ''
 ) {
 	const dateMoment = momentLib( dateValue );


### PR DESCRIPTION
## What?
Closes #78283

Fixes the post-date block displaying "Invalid date" when clicking the "Now" button in the date picker.

## Why?
When users clicked the "Now" button in the `PublishDateTimePicker`, it triggered date handling with an invalid `datetime` value. The post-date block then passed this invalid value to `dateI18n` and `humanTimeDiff`, which internally relied on `momentLib`. Since `momentLib` received an invalid or undefined value, it returned `"Invalid date"`, causing the block to render incorrectly.

## How?
Updated the post-date block to always use a valid fallback date when `datetime` is missing or invalid:

```js
const validDatetime = datetime || new Date();
```

Then replaced direct usages of `datetime` with `validDatetime` in both `dateI18n` and `humanTimeDiff` calls:

```js
<time
	dateTime={ dateI18n( 'c', validDatetime ) }
	ref={ setPopoverAnchor }
>
	{ format === 'human-diff'
		? humanTimeDiff( validDatetime )
		: dateI18n( format || siteFormat, validDatetime ) }
</time>
```

Additionally, updated `buildMoment` in `packages/date/src/index.ts` to require a defined `dateValue` parameter instead of allowing it to be optional:

```ts
function buildMoment(
	dateValue: Moment | Date | string | number,
	timezone: string | number = ''
)
```

This ensures the date utilities consistently receive a valid value and prevents `"Invalid date"` from being rendered.

## Testing Instructions
1. Insert a post-date block into a post or page
2. Click the pencil icon in the toolbar to open the date picker
3. Click the "Now" button
4. **Expected:** The date block displays the current date correctly instead of `"Invalid date"`
5. Verify the date updates properly in both standard and `human-diff` formats
6. Save and refresh the post/page to confirm the date persists correctly

## Screenshot
| Before | After |
|---|---|
| ![](https://github.com/user-attachments/assets/2261b8a5-d08b-4397-9d9c-dc7e9792f5ce) | ![](https://github.com/user-attachments/assets/887b7d59-8d05-462c-aa9b-b7be100e145c) |

## Use of AI Tools
None