### PR TITLE
Content Type: Add `menu_icon ` and `menu_position` fields

### DIFF
--- a/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
+++ b/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
@@ -112,10 +112,18 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 			'type'                 => 'object',
 			'additionalProperties' => false,
 			'properties'           => array(
-				'public'       => array( 'type' => 'boolean' ),
-				'hierarchical' => array( 'type' => 'boolean' ),
-				'has_archive'  => array( 'type' => 'boolean' ),
-				'show_in_rest' => array( 'type' => 'boolean' ),
+				'public'        => array( 'type' => 'boolean' ),
+				'hierarchical'  => array( 'type' => 'boolean' ),
+				'has_archive'   => array( 'type' => 'boolean' ),
+				'show_in_rest'  => array( 'type' => 'boolean' ),
+				'menu_icon'     => array(
+					'type'      => array( 'string', 'null' ),
+				),
+				'menu_position' => array(
+					'type'    => array( 'integer', 'null' ),
+					'minimum' => 1,
+					'maximum' => 100,
+				),
 				// Caps payload size; well above any reasonable description.
 				'description'  => array(
 					'type'      => 'string',

--- a/lib/experimental/content-types/post-types.php
+++ b/lib/experimental/content-types/post-types.php
@@ -250,6 +250,14 @@ function gutenberg_build_user_post_type_args( WP_Post $record ) {
 		$args['description'] = (string) $config['description'];
 	}
 
+	if ( ! empty( $config['menu_icon'] ) ) {
+		$args['menu_icon'] = (string) $config['menu_icon'];
+	}
+
+	if ( isset( $config['menu_position'] ) && is_int( $config['menu_position'] ) ) {
+		$args['menu_position'] = (int) $config['menu_position'];
+	}
+
 	// `taxonomies` here is the inverse of the taxonomy record's `object_type`:
 	// it lists the taxonomies attached to this post type. Only existing
 	// taxonomies are passed through so we never reference unregistered slugs.

--- a/packages/content-types/src/post-types/edit.tsx
+++ b/packages/content-types/src/post-types/edit.tsx
@@ -39,7 +39,9 @@ import {
 	itemsListNavigationField,
 	labelsActionsField,
 	labelsForm,
+	menuIconField,
 	menuNameField,
+	menuPositionField,
 	newItemField,
 	notFoundField,
 	notFoundInTrashField,
@@ -152,6 +154,8 @@ function PostTypePage( {
 				hierarchicalField,
 				hasArchiveField,
 				showInRestField,
+				menuIconField,
+				menuPositionField,
 				statusField,
 				// Labels
 				labelsActionsField,

--- a/packages/content-types/src/post-types/fields/general.tsx
+++ b/packages/content-types/src/post-types/fields/general.tsx
@@ -249,6 +249,46 @@ export const defaultForm: Form = {
 	],
 };
 
+export const menuIconField: Field< PostTypeFormData > = {
+	id: 'menu_icon',
+	label: __( 'Menu icon' ),
+	type: 'text',
+	description: __(
+		'Dashicon slug (e.g. "dashicons-book") or a data: URI for a custom icon shown in the admin menu.'
+	),
+	placeholder: 'dashicons-admin-post',
+	getValue: ( { item } ) => item.config.menu_icon ?? '',
+	setValue: ( { item, value } ) => ( {
+		config: {
+			...item.config,
+			menu_icon: value ? String( value ) : null,
+		},
+	} ),
+	filterBy: false,
+	enableSorting: false,
+};
+
+export const menuPositionField: Field< PostTypeFormData > = {
+	id: 'menu_position',
+	label: __( 'Menu position' ),
+	type: 'integer',
+	description: __(
+		'Position in the admin menu. Common values: 5 (below Posts), 10 (below Media), 20 (below Pages). Leave empty to use the default position.'
+	),
+	getValue: ( { item } ) => item.config.menu_position ?? null,
+	setValue: ( { item, value } ) => ( {
+		config: {
+			...item.config,
+			menu_position:
+				value !== '' && value !== null && value !== undefined
+					? Number( value )
+					: null,
+		},
+	} ),
+	filterBy: false,
+	enableSorting: false,
+};
+
 export const generalForm: Form = {
 	layout: { type: 'regular' },
 	fields: [
@@ -262,6 +302,8 @@ export const generalForm: Form = {
 		'hierarchical',
 		'has_archive',
 		'show_in_rest',
+		'menu_icon',
+		'menu_position',
 		'status',
 	],
 };

--- a/packages/content-types/src/post-types/types.ts
+++ b/packages/content-types/src/post-types/types.ts
@@ -68,6 +68,8 @@ export interface StoredConfig {
 	hierarchical?: boolean;
 	has_archive?: boolean;
 	show_in_rest?: boolean;
+	menu_icon?: string | null;
+	menu_position?: number | null;
 }
 
 import type { ContentType } from '../types';
@@ -84,5 +86,7 @@ export interface PostTypeFormData extends ContentType {
 		taxonomies: string[];
 		supports: SupportFeature[];
 		has_archive: boolean;
+		menu_icon: string | null;
+		menu_position: number | null;
 	};
 }

--- a/packages/content-types/src/post-types/utils.ts
+++ b/packages/content-types/src/post-types/utils.ts
@@ -32,6 +32,8 @@ export const BLANK_RECORD: PostTypeFormData = {
 		hierarchical: false,
 		has_archive: false,
 		show_in_rest: true,
+		menu_icon: null,
+		menu_position: null,
 	},
 };
 
@@ -204,6 +206,8 @@ export function toFormData( row: PostTypeRecord ): PostTypeFormData {
 			hierarchical: config.hierarchical ?? false,
 			has_archive: config.has_archive ?? false,
 			show_in_rest: config.show_in_rest ?? true,
+			menu_icon: config.menu_icon ?? null,
+			menu_position: config.menu_position ?? null,
 		},
 	};
 }
@@ -233,6 +237,8 @@ export function serializeForSave( data: PostTypeFormData ) {
 			has_archive: config.has_archive,
 			show_in_rest: config.show_in_rest,
 			...( description !== '' ? { description } : {} ),
+			menu_icon: config.menu_icon,
+			menu_position: config.menu_position,
 		},
 	};
 }

--- a/phpunit/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg-test.php
+++ b/phpunit/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg-test.php
@@ -562,6 +562,60 @@ class WP_REST_User_Post_Types_Controller_Gutenberg_Test extends WP_Test_REST_Con
 	}
 
 	/**
+	 * `config.menu_icon` and `config.menu_position` round-trip through the
+	 * REST API and are persisted in the stored config JSON.
+	 */
+	public function test_create_item_with_menu_icon_and_position() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', self::REST_BASE );
+		$request->set_body_params(
+			array(
+				'slug'   => 'recipe',
+				'title'  => 'Recipes',
+				'status' => 'publish',
+				'config' => array(
+					'labels'         => array( 'singular_name' => 'Recipe' ),
+					'public'         => true,
+					'menu_icon'      => 'dashicons-food',
+					'menu_position'  => 25,
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( 'dashicons-food', $data['config']['menu_icon'] );
+		$this->assertSame( 25, $data['config']['menu_position'] );
+
+		wp_delete_post( $data['id'], true );
+	}
+
+	/**
+	 * `menu_position` out of the allowed range (1–100) is rejected with a 400.
+	 */
+	public function test_create_item_rejects_out_of_range_menu_position() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', self::REST_BASE );
+		$request->set_body_params(
+			array(
+				'slug'   => 'bad_pos',
+				'title'  => 'Bad Position',
+				'config' => array(
+					'labels'        => array( 'singular_name' => 'Bad' ),
+					'menu_position' => 999,
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
 	 * `config.taxonomies` is stored inline and round-trips cleanly. There is
 	 * no separate top-level field and no collection-param filter on this
 	 * side — the post-type→taxonomy attachment lives entirely within config.


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/issues/77600

Adds `menu_icon` and `menu_position` fields to the user-defined post type management UI.

## Why?
The issue explicitly lists "Add more fields for menu icon, menu position, rewrite, etc." as a missing capability for post type management. Without these fields, users cannot customise where their post type appears in the admin menu or what icon it uses.


## Testing Instructions
1. Ensure the content types experiment is enabled.
2. Go to **Admin → Content Types → Post Types → Add New**.
3. In the General section, confirm **Menu icon** and **Menu position** fields appear.
4. Enter `dashicons-book` for icon and `25` for position, save.
5. Verify the new post type appears in the admin menu with the correct icon and position.
6. Run PHP tests: `npm run test:unit:php:base -- --filter "WP_REST_User_Post_Types_Controller_Gutenberg_Test"`


## Screencast

https://github.com/user-attachments/assets/7ab285f6-f41b-4992-adba-53693bcbf968

