### PR TITLE
Fix performance tests when running against old reference commit

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -403,7 +403,7 @@ async function runPerformanceTests( branches, options ) {
 
 		logAtIndent( 3, 'Installing dependencies and building' );
 		await runShellScript(
-			`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm ci && npm run build -- --skip-types"`,
+			`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm ci && (npm run build -- --skip-types || npm run build)"`,
 			buildDir
 		);
 


### PR DESCRIPTION
Fixes broken performance tests in `trunk` after #78237. The `trunk` tests run also against an old "reference" commit from Dec 2025, where `npm run build` didn't support `--skip-types` yet. Let's run a fallback without the option.
