### PR TITLE
Routes: Enforce logical CSS properties in stylesheets

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -60,7 +60,11 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ '**/*.module.{css,scss}', 'routes/**/*.{css,scss}' ],
+			files: [
+				'**/*.module.{css,scss}',
+				// Can be removed when all `routes/` stylesheets are converted to CSS modules.
+				'routes/**/*.{css,scss}',
+			],
 			rules: {
 				'function-no-unknown': [
 					true,

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -60,7 +60,7 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ '**/*.module.{css,scss}' ],
+			files: [ '**/*.module.{css,scss}', 'routes/**/*.{css,scss}' ],
 			rules: {
 				'function-no-unknown': [
 					true,

--- a/routes/guidelines/components/block-guidelines.scss
+++ b/routes/guidelines/components/block-guidelines.scss
@@ -15,13 +15,11 @@
 	}
 
 	.dataviews-wrapper {
-		margin-right: -$grid-unit-30;
-		margin-left: -$grid-unit-30;
+		margin-inline: -$grid-unit-30;
 	}
 
 	.dataviews-search {
-		margin-right: $grid-unit-30;
-		margin-left: $grid-unit-30;
+		margin-inline: $grid-unit-30;
 	}
 }
 

--- a/routes/guidelines/components/guideline-actions-section.scss
+++ b/routes/guidelines/components/guideline-actions-section.scss
@@ -25,8 +25,7 @@
 		content: "";
 		position: absolute;
 		top: 0;
-		left: $grid-unit-30;
-		right: $grid-unit-30;
+		inset-inline: $grid-unit-30;
 		height: 1px;
 		background-color: $gray-100;
 	}

--- a/routes/guidelines/style.scss
+++ b/routes/guidelines/style.scss
@@ -36,8 +36,7 @@
 	gap: $grid-unit-20;
 
 	.dataviews-wrapper {
-		margin-right: -$grid-unit-30;
-		margin-left: -$grid-unit-30;
+		margin-inline: -$grid-unit-30;
 	}
 }
 

--- a/routes/guidelines/style.scss
+++ b/routes/guidelines/style.scss
@@ -42,6 +42,7 @@
 
 .guidelines__revision-history-back {
 	align-self: flex-start;
+	// stylelint-disable-next-line plugin/use-logical-properties-and-values -- TODO: Please fix
 	margin-left: -$grid-unit-20;
 	font-weight: 500;
 	color: $gray-900;
@@ -53,6 +54,7 @@
 }
 
 .guidelines__revision-description {
+	// stylelint-disable-next-line plugin/use-logical-properties-and-values -- TODO: Please fix
 	padding-left: $grid-unit-10;
 }
 

--- a/routes/post-list/style.scss
+++ b/routes/post-list/style.scss
@@ -12,6 +12,7 @@
 	align-items: stretch;
 
 	.components-modal__frame {
+		// stylelint-disable-next-line declaration-property-max-values -- TODO: Please fix
 		margin: $grid-unit-20 $grid-unit-20 $grid-unit-20 0;
 		height: calc(100% - #{$grid-unit-20 * 2});
 		max-height: calc(100% - #{$grid-unit-20 * 2});

--- a/routes/styles/style.scss
+++ b/routes/styles/style.scss
@@ -13,8 +13,7 @@
 			border-top: none;
 		}
 		overflow-y: auto;
-		padding-left: 0;
-		padding-right: 0;
+		padding-inline: 0;
 	}
 }
 

--- a/routes/template-list/add-new-template/style.scss
+++ b/routes/template-list/add-new-template/style.scss
@@ -12,8 +12,7 @@
 		}
 
 		&__suggestions_list {
-			margin-left: - $grid-unit-15;
-			margin-right: - $grid-unit-15;
+			margin-inline: - $grid-unit-15;
 			width: calc(100% + #{$grid-unit-15 * 2});
 		}
 	}

--- a/routes/template-list/add-new-template/style.scss
+++ b/routes/template-list/add-new-template/style.scss
@@ -37,6 +37,7 @@
 		&__list-item {
 			display: block;
 			width: 100%;
+			// stylelint-disable-next-line plugin/use-logical-properties-and-values -- TODO: Please fix
 			text-align: left;
 			white-space: pre-wrap;
 			overflow-wrap: break-word;

--- a/routes/template-list/style.scss
+++ b/routes/template-list/style.scss
@@ -12,6 +12,7 @@
 	height: 24px;
 	border-radius: 50%;
 	overflow: hidden;
+	// stylelint-disable-next-line plugin/use-logical-properties-and-values -- TODO: Please fix
 	margin-right: 8px;
 	opacity: 0;
 	transition: opacity 0.1s ease-in;
@@ -33,6 +34,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	// stylelint-disable-next-line plugin/use-logical-properties-and-values -- TODO: Please fix
 	margin-right: 8px;
 	color: $gray-700;
 }


### PR DESCRIPTION
## What?
Part of #76744

Enforces logical CSS properties for `routes/` stylesheets as a stopgap while the remaining directly imported route stylesheets are migrated to CSS modules or stylesheet entry points.

## Why?
Route stylesheets are currently imported from JS, which means they do not go through the build-time RTL stylesheet generation path. Until those stylesheets can be moved to better-scoped CSS modules or central stylesheet entries, linting them for logical properties helps reduce RTL regressions.

## How?
Adds `routes/**/*.{css,scss}` to the Stylelint override that enforces logical CSS properties and values, then fixes the straightforward violations in the affected route stylesheets. Remaining route-specific exceptions are left as inline TODO suppressions where the correct conversion is less mechanical.

## Testing Instructions
1. Run `npx wp-scripts lint-style "routes/**/*.scss"`.
2. Confirm the command passes without Stylelint errors.
