### PR TITLE
Dashboard: round widget drag radius

### DIFF
--- a/packages/grid/src/dashboard-grid/grid-item.module.css
+++ b/packages/grid/src/dashboard-grid/grid-item.module.css
@@ -39,6 +39,7 @@
 		var(--wpds-border-width-sm) dashed
 		var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
 	background: transparent;
+	border-radius: var(--wp-grid-placeholder-radius, 0);
 }
 
 @media (forced-colors: active) {

--- a/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
@@ -1,5 +1,7 @@
 .grid {
 	width: 100%;
+	/* Drag placeholder outline radius: matches `.tile` and `@wordpress/ui` Card (`--wpds-border-radius-lg`). */
+	--wp-grid-placeholder-radius: var(--wpds-border-radius-lg);
 }
 
 .tile {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/77616

<!-- In a few words, what is the PR actually doing? -->

- Add `--wp-grid-placeholder-radius` to the dragged placeholder in the grid
- Customize `--wp-grid-placeholder-radius` in dashboard to match widget's radius (which is the same as UI `Card` radius)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Matches the widget's own radius, which uses UI Card component.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

#### Before
<img width="1388" height="608" alt="Screenshot 2026-05-14 at 15 49 12" src="https://github.com/user-attachments/assets/bd571959-071d-400a-b993-a5f645f5cb0f" />


#### After
<img width="1373" height="632" alt="Screenshot 2026-05-14 at 15 48 17" src="https://github.com/user-attachments/assets/ac6c02e7-7bd1-40ba-98df-1e984ef92b33" />

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->