### PR TITLE
Perf tests: Capture loading durations before stopTracing()

### DIFF
--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -80,14 +80,16 @@ test.describe( 'Post Editor Performance', () => {
 				// Wait for the first block.
 				await canvas.locator( '.wp-block' ).first().waitFor();
 
+				// Capture timing metrics before `stopTracing()`, which
+				// blocks for the trace download/parse and would otherwise
+				// inflate `timeSinceResponseEnd` by seconds.
+				const loadingDurations = await metrics.getLoadingDurations();
+
 				// Stop tracing. Save just one representative sample.
 				await metrics.stopTracing(
 					i === Math.floor( iterations / 2 ) &&
 						'post-editor-first-block'
 				);
-
-				// Get the durations.
-				const loadingDurations = await metrics.getLoadingDurations();
 
 				// Save the results.
 				if ( i > throwaway ) {

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -95,14 +95,16 @@ test.describe( 'Site Editor Performance', () => {
 				const canvas = await perfUtils.getCanvas();
 				await canvas.locator( '.wp-block' ).first().waitFor();
 
+				// Capture timing metrics before `stopTracing()`, which
+				// blocks for the trace download/parse and would otherwise
+				// inflate `timeSinceResponseEnd` by seconds.
+				const loadingDurations = await metrics.getLoadingDurations();
+
 				// Stop tracing. Save just one representative sample.
 				await metrics.stopTracing(
 					i === Math.floor( iterations / 2 ) &&
 						'site-editor-first-block'
 				);
-
-				// Get the durations.
-				const loadingDurations = await metrics.getLoadingDurations();
 
 				// Save the results.
 				if ( i > throwaway ) {


### PR DESCRIPTION
## What?
Reorder the post-editor and site-editor first-block specs so `getLoadingDurations()` runs before `stopTracing()`.

## Why?
`getLoadingDurations()` reads `performance.now()` to compute `timeSinceResponseEnd` — the `firstBlock` metric. Because it was called *after* `stopTracing()`, the trace buffer download + JSON parse (a few hundred MB for a 30 s spec, ~3 s on CI) was bundled into the measured duration.

In a representative trunk run, the metric reports ~7.5 s while the editor actually finishes loading at ~4.1 s — the rest is the test harness flushing the trace. The contamination is roughly constant, so relative comparisons still work, but absolute numbers are misleading and the noise floor for regression detection is wider than it needs to be.

## How?
Move the `await metrics.getLoadingDurations()` call up so it runs immediately after `.wp-block` becomes visible and before tracing is stopped. No API changes; only `timeSinceResponseEnd` is sensitive to call order (the other returned values come from Navigation Timing entries that are immutable once recorded).

## Testing Instructions
1. Run the post-editor perf spec: `./bin/plugin/cli.js perf HEAD trunk`.
2. Compare `firstBlock` values before/after — expect a step-down of ~2–3 s in absolute terms; `serverResponse`, `firstPaint`, `domContentLoaded`, `loaded`, and `firstContentfulPaint` should be unchanged.

## Use of AI Tools
Authored with Claude Code assistance; reviewed and verified by the author.