### PR TITLE
Perf tests: Disable Playwright tracing to remove snapshot overhead

### DIFF
--- a/test/performance/playwright.config.ts
+++ b/test/performance/playwright.config.ts
@@ -31,6 +31,12 @@ const config = defineConfig( {
 		...baseConfig.use,
 		actionTimeout: 120_000, // 2 minutes.
 		video: 'off',
+		// Playwright's own tracing injects a DOM snapshot recorder into
+		// every page (captureSnapshot/visitNode/_getSheetText), which runs
+		// on the main thread on each action and shows up as ~750ms of
+		// extra work in our captured Chromium traces. We don't need
+		// Playwright's trace artifacts for perf measurements.
+		trace: 'off',
 	},
 } );
 


### PR DESCRIPTION
## What?
Set `trace: 'off'` for the performance test suite.

## Why?
The shared `@wordpress/scripts` Playwright config defaults to `trace: 'retain-on-failure'`. That enables Playwright's own tracing on every test, which is separate from the Chromium tracing we use for perf measurements (`browser.startTracing` in `Metrics`).

Playwright's tracing injects a DOM snapshot recorder into every page (`captureSnapshot`, `visitNode`, `visitChild`, `_getSheetText`, `_updateLinkStyleSheetTextIfNeeded`). It runs on the page's main thread on each action. In a representative post-editor first-block Chromium trace it accounts for ~750 ms of non-Gutenberg work after the editor mounts and adds noise to the interaction metrics (`type`, `focus`, `click`, `hover`) that measure event durations across actions.

Perf tests don't use Playwright's `.trace.zip` artifacts — we capture and analyse our own Chromium traces — so the snapshotter is pure overhead.

## How?
Override `trace` in `test/performance/playwright.config.ts` so the perf suite opts out without affecting the e2e suite, which still benefits from `retain-on-failure` for debugging.

## Testing Instructions
1. Run any perf spec and save a trace artifact (the `firstBlock` iteration in `post-editor.spec.js` or `site-editor.spec.js`).
2. Inspect the trace for functions with `url: null` matching `captureSnapshot` / `visitNode` / `_getSheetText` — they should no longer appear.
3. Compare `type` / `focus` / interaction metric values across a few runs; variance should be slightly tighter.

## Use of AI Tools
Authored with Claude Code assistance; reviewed and verified by the author.