### PR TITLE
Guidelines: Refine access policy

### DIFF
--- a/lib/experimental/guidelines/class-gutenberg-content-guidelines-rest-controller.php
+++ b/lib/experimental/guidelines/class-gutenberg-content-guidelines-rest-controller.php
@@ -261,7 +261,7 @@ class Gutenberg_Content_Guidelines_REST_Controller extends WP_REST_Posts_Control
 			);
 		}
 
-		$content_term_id = Gutenberg_Guidelines_Post_Type::get_or_create_term_id(
+		$content_term_id = self::get_or_create_term_id(
 			Gutenberg_Guidelines_Post_Type::TERM_CONTENT,
 			__( 'Content', 'gutenberg' )
 		);
@@ -790,5 +790,34 @@ class Gutenberg_Content_Guidelines_REST_Controller extends WP_REST_Posts_Control
 		);
 
 		return $this->add_additional_fields_schema( $this->schema );
+	}
+
+	/**
+	 * Resolve the `wp_guideline_type` term by slug, creating it if missing.
+	 *
+	 * Used by the create flow to attach the freshly-inserted content guideline
+	 * to the `content` term on first use, before the term is otherwise needed.
+	 *
+	 * @param string $slug Term slug.
+	 * @param string $name Human-readable term name, used when creating.
+	 * @return int|WP_Error Term ID on success, WP_Error on failure.
+	 */
+	private static function get_or_create_term_id( string $slug, string $name ) {
+		$term = get_term_by( 'slug', $slug, Gutenberg_Guidelines_Post_Type::TAXONOMY );
+		if ( $term ) {
+			return (int) $term->term_id;
+		}
+
+		$inserted = wp_insert_term(
+			$name,
+			Gutenberg_Guidelines_Post_Type::TAXONOMY,
+			array( 'slug' => $slug )
+		);
+
+		if ( is_wp_error( $inserted ) ) {
+			return $inserted;
+		}
+
+		return (int) $inserted['term_id'];
 	}
 }

--- a/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
@@ -167,7 +167,7 @@ class Gutenberg_Guidelines_Post_Type {
 				),
 				'capabilities'       => array(
 					'manage_terms' => 'manage_options',
-					'edit_terms'   => 'manage_options',
+					'edit_terms'   => 'edit_guidelines',
 					'delete_terms' => 'manage_options',
 					'assign_terms' => 'edit_guidelines',
 				),

--- a/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
@@ -113,9 +113,10 @@ class Gutenberg_Guidelines_Post_Type {
 					'view_items'               => __( 'View Guidelines', 'gutenberg' ),
 				),
 				'public'                => false,
-				'publicly_queryable'    => false,
-				'show_ui'               => true,
-				'show_in_menu'          => false,
+				// Guidelines have no native post-type screens; management
+				// flows through the Settings → Guidelines page (see
+				// load.php) and the REST API.
+				'show_ui'               => false,
 				'show_in_rest'          => true,
 				'rest_base'             => 'guidelines',
 
@@ -123,19 +124,12 @@ class Gutenberg_Guidelines_Post_Type {
 
 				'capability_type'       => 'guideline',
 				'map_meta_cap'          => true,
+				// `read` is remapped so Subscribers (who hold the base `read`
+				// cap) are blocked at the post-type door. Every other primitive
+				// defaults to a guideline-prefixed cap synthesized by
+				// `_wp_guidelines_synthesize_caps()`.
 				'capabilities'          => array(
-					'read'                   => 'edit_posts',
-					'create_posts'           => 'publish_posts',
-					'edit_posts'             => 'edit_posts',
-					'publish_posts'          => 'publish_posts',
-					'read_private_posts'     => 'read_private_posts',
-					'edit_private_posts'     => 'edit_private_posts',
-					'edit_published_posts'   => 'edit_published_posts',
-					'delete_private_posts'   => 'delete_private_posts',
-					'delete_published_posts' => 'delete_published_posts',
-					'delete_posts'           => 'delete_posts',
-					'edit_others_posts'      => 'edit_others_posts',
-					'delete_others_posts'    => 'delete_others_posts',
+					'read' => 'read_guidelines',
 				),
 				'supports'              => array( 'title', 'editor', 'excerpt', 'author', 'revisions' ),
 				'hierarchical'          => false,
@@ -172,10 +166,10 @@ class Gutenberg_Guidelines_Post_Type {
 					'view_item'             => __( 'View Guideline Type', 'gutenberg' ),
 				),
 				'capabilities'       => array(
-					'manage_terms' => 'manage_categories',
-					'edit_terms'   => 'edit_posts',
-					'delete_terms' => 'delete_categories',
-					'assign_terms' => 'edit_posts',
+					'manage_terms' => 'manage_options',
+					'edit_terms'   => 'manage_options',
+					'delete_terms' => 'manage_options',
+					'assign_terms' => 'edit_guidelines',
 				),
 				'query_var'          => false,
 				'rewrite'            => false,
@@ -186,6 +180,7 @@ class Gutenberg_Guidelines_Post_Type {
 			)
 		);
 
+		add_filter( 'user_has_cap', '_wp_guidelines_synthesize_caps', 10, 4 );
 		add_action( 'save_post_' . self::POST_TYPE, '_wp_guidelines_ensure_default_type_term' );
 		add_filter( 'wp_insert_term_data', '_wp_guidelines_maybe_map_term_label', 10, 2 );
 	}

--- a/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
@@ -186,32 +186,6 @@ class Gutenberg_Guidelines_Post_Type {
 	}
 
 	/**
-	 * Resolves a taxonomy term by slug, creating it if it doesn't exist yet.
-	 *
-	 * @param string $slug Term slug.
-	 * @param string $name Human-readable term name, used when creating.
-	 * @return int|WP_Error Term ID on success, WP_Error on failure.
-	 */
-	public static function get_or_create_term_id( string $slug, string $name ) {
-		$term = get_term_by( 'slug', $slug, self::TAXONOMY );
-		if ( $term ) {
-			return (int) $term->term_id;
-		}
-
-		$inserted = wp_insert_term(
-			$name,
-			self::TAXONOMY,
-			array( 'slug' => $slug )
-		);
-
-		if ( is_wp_error( $inserted ) ) {
-			return $inserted;
-		}
-
-		return (int) $inserted['term_id'];
-	}
-
-	/**
 	 * Determines whether a guideline post belongs to the content singleton.
 	 *
 	 * Used by the /wp/v2/content-guidelines route to reject non-content-typed

--- a/lib/experimental/guidelines/class-gutenberg-guidelines-rest-controller.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-rest-controller.php
@@ -102,6 +102,9 @@ class Gutenberg_Guidelines_REST_Controller extends WP_REST_Posts_Controller {
 	 * (the parent would fall back to `draft`). Updates pass through so a
 	 * partial PATCH preserves the existing status.
 	 *
+	 * `wp_guideline_type` is optional on create. When omitted, the post
+	 * falls back to the default guideline taxonomy term `artifact`.
+	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return stdClass|WP_Error Prepared post object or error.
 	 */

--- a/lib/experimental/guidelines/class-gutenberg-guidelines-rest-controller.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-rest-controller.php
@@ -38,6 +38,25 @@ class Gutenberg_Guidelines_REST_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
+	 * Scope collection queries to rows readable by the current user.
+	 *
+	 * The parent controller filters unreadable posts after the query runs, but
+	 * collection totals and pagination headers are based on the unfiltered
+	 * query. Setting `perm` lets WP_Query apply private-post visibility before
+	 * totals are calculated.
+	 *
+	 * @param array                $prepared_args Prepared WP_Query arguments.
+	 * @param WP_REST_Request|null $request       Full details about the request.
+	 * @return array Updated WP_Query arguments.
+	 */
+	protected function prepare_items_query( $prepared_args = array(), $request = null ) {
+		$query_args         = parent::prepare_items_query( $prepared_args, $request );
+		$query_args['perm'] = 'readable';
+
+		return $query_args;
+	}
+
+	/**
 	 * Gate per-item reads on the user-specific read capability.
 	 *
 	 * The default treats every `publish` post as universally readable;

--- a/lib/experimental/guidelines/class-gutenberg-guidelines-rest-controller.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-rest-controller.php
@@ -15,7 +15,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Gutenberg_Guidelines_REST_Controller extends WP_REST_Posts_Controller {
 
 	/**
-	 * Checks if a given request has access to read guideline posts.
+	 * Gate the guidelines collection on the post-type read capability.
+	 *
+	 * The default `WP_REST_Posts_Controller` allows unauthenticated reads of
+	 * `publish` posts; guidelines store private data and require an
+	 * authenticated user with read access.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
@@ -34,11 +38,11 @@ class Gutenberg_Guidelines_REST_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Checks if a given request has access to read a guideline post.
+	 * Gate per-item reads on the user-specific read capability.
 	 *
-	 * Guidelines are not public content, so every direct item read must pass
-	 * the post-specific read capability before falling through to the standard
-	 * post checks.
+	 * The default treats every `publish` post as universally readable;
+	 * guidelines reach the parent's checks only after `read_post` passes,
+	 * which factors in ownership and status.
 	 *
 	 * @param WP_Post $post Post object.
 	 * @return bool Whether the post can be read.
@@ -49,5 +53,43 @@ class Gutenberg_Guidelines_REST_Controller extends WP_REST_Posts_Controller {
 		}
 
 		return parent::check_read_permission( $post );
+	}
+
+	/**
+	 * Restrict the status surface for callers without publish capability
+	 * to `private`. Administrators retain the parent's full status surface.
+	 *
+	 * @param string       $post_status Requested post status.
+	 * @param WP_Post_Type $post_type   Post type object.
+	 * @return string|WP_Error Status, or WP_Error if not permitted.
+	 */
+	protected function handle_status_param( $post_status, $post_type ) {
+		if ( ! current_user_can( $post_type->cap->publish_posts ) ) {
+			if ( 'private' !== $post_status ) {
+				return new WP_Error(
+					'rest_cannot_publish',
+					__( 'Sorry, you are only allowed to set status to private for guidelines.', 'gutenberg' ),
+					array( 'status' => rest_authorization_required_code() )
+				);
+			}
+			return $post_status;
+		}
+
+		return parent::handle_status_param( $post_status, $post_type );
+	}
+
+	/**
+	 * Default the status to `private` on create when none is supplied
+	 * (the parent would fall back to `draft`). Updates pass through so a
+	 * partial PATCH preserves the existing status.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return stdClass|WP_Error Prepared post object or error.
+	 */
+	protected function prepare_item_for_database( $request ) {
+		if ( ! isset( $request['id'] ) && null === $request['status'] ) {
+			$request->set_param( 'status', 'private' );
+		}
+		return parent::prepare_item_for_database( $request );
 	}
 }

--- a/lib/experimental/guidelines/guidelines.php
+++ b/lib/experimental/guidelines/guidelines.php
@@ -50,6 +50,9 @@ if ( ! function_exists( 'wp_guideline_types' ) ) {
 				'content'  => array(
 					'title' => __( 'Content', 'gutenberg' ),
 				),
+				'memory'   => array(
+					'title' => __( 'Memory', 'gutenberg' ),
+				),
 			)
 		);
 	}
@@ -76,10 +79,9 @@ if ( ! function_exists( '_wp_guidelines_ensure_default_type_term' ) ) {
 			return;
 		}
 
-		// wp_set_object_terms() expects term IDs for hierarchical taxonomies —
-		// strings are interpreted as term names, not slugs. Resolve 'artifact'
-		// to an ID up front (creating the term on first use) so we assign the
-		// exact term we mean instead of relying on name-based lookup.
+		// Resolve to an ID up front (creating the term on first use):
+		// wp_set_object_terms() interprets strings as names for hierarchical
+		// taxonomies, not slugs.
 		$term = term_exists( 'artifact', 'wp_guideline_type' );
 		if ( ! $term ) {
 			$term = wp_insert_term( 'artifact', 'wp_guideline_type' );
@@ -89,6 +91,78 @@ if ( ! function_exists( '_wp_guidelines_ensure_default_type_term' ) ) {
 		}
 
 		wp_set_object_terms( $post_id, (int) $term['term_id'], 'wp_guideline_type' );
+	}
+}
+
+if ( ! function_exists( '_wp_guidelines_synthesize_caps' ) ) {
+	/**
+	 * Hook callback for the `user_has_cap` filter that grants guideline
+	 * capabilities based on the user's role, post ownership, and post status.
+	 *
+	 * Administrators get every guideline capability. Contributors, Authors,
+	 * and Editors can list and create guidelines, and fully manage their own
+	 * private rows. Publishing guidelines and acting on other users' rows is
+	 * reserved for Administrators.
+	 *
+	 * @access private
+	 *
+	 * @param array   $allcaps All capabilities of the user.
+	 * @param array   $caps    Required primitive capabilities for the requested capability.
+	 * @param array   $args    Arguments that accompany the requested capability check.
+	 * @param WP_User $user    The user object.
+	 * @return array Possibly augmented capabilities.
+	 */
+	function _wp_guidelines_synthesize_caps( array $allcaps, array $caps, array $args, WP_User $user ): array {
+		if ( ! empty( $allcaps['manage_options'] ) ) {
+			$allcaps['read_guidelines']             = true;
+			$allcaps['edit_guidelines']             = true;
+			$allcaps['edit_others_guidelines']      = true;
+			$allcaps['edit_published_guidelines']   = true;
+			$allcaps['edit_private_guidelines']     = true;
+			$allcaps['publish_guidelines']          = true;
+			$allcaps['delete_guidelines']           = true;
+			$allcaps['delete_others_guidelines']    = true;
+			$allcaps['delete_published_guidelines'] = true;
+			$allcaps['delete_private_guidelines']   = true;
+			$allcaps['read_private_guidelines']     = true;
+			return $allcaps;
+		}
+
+		if ( empty( $allcaps['edit_posts'] ) ) {
+			return $allcaps;
+		}
+
+		// Ambient floor for Contributor+: `read_guidelines` clears the
+		// post-type read check; `edit_guidelines` clears the create and
+		// ownership checks that don't pass a post ID. Per-post primitives
+		// are granted only in the per-post branch below.
+		$allcaps['read_guidelines'] = true;
+		$allcaps['edit_guidelines'] = true;
+
+		if ( ! isset( $args[0], $args[2] ) ) {
+			return $allcaps;
+		}
+
+		if ( ! in_array( $args[0], array( 'edit_post', 'delete_post', 'read_post' ), true ) ) {
+			return $allcaps;
+		}
+
+		$post = get_post( $args[2] );
+		if (
+			! $post instanceof WP_Post ||
+			'wp_guideline' !== $post->post_type ||
+			(int) $post->post_author !== (int) $user->ID ||
+			'private' !== $post->post_status
+		) {
+			return $allcaps;
+		}
+
+		$allcaps['edit_private_guidelines']   = true;
+		$allcaps['delete_guidelines']         = true;
+		$allcaps['delete_private_guidelines'] = true;
+		$allcaps['read_private_guidelines']   = true;
+
+		return $allcaps;
 	}
 }
 

--- a/lib/experimental/guidelines/index.php
+++ b/lib/experimental/guidelines/index.php
@@ -41,32 +41,3 @@ add_action(
 		$content_revisions_controller->register_routes();
 	}
 );
-
-add_action(
-	'current_screen',
-	function ( $screen ) {
-		if ( Gutenberg_Guidelines_Post_Type::POST_TYPE !== $screen->post_type ) {
-			return;
-		}
-
-		// Disable the block editor for this post type.
-		add_filter( 'use_block_editor_for_post_type', '__return_false' );
-
-		// Remove the media button.
-		remove_action( 'media_buttons', 'media_buttons' );
-
-		// Use a plain textarea by disabling TinyMCE and Quicktags.
-		add_filter(
-			'wp_editor_settings',
-			static function ( $settings, $editor_id ) {
-				if ( 'content' === $editor_id ) {
-					$settings['tinymce']   = false;
-					$settings['quicktags'] = false;
-				}
-				return $settings;
-			},
-			10,
-			2
-		);
-	}
-);

--- a/phpunit/experimental/guidelines/class-gutenberg-content-guidelines-rest-controller-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-content-guidelines-rest-controller-test.php
@@ -443,10 +443,12 @@ class Gutenberg_Content_Guidelines_REST_Controller_Test extends WP_Test_REST_Pos
 	 * @return int Post ID.
 	 */
 	private function create_artifact_post() {
-		$artifact_term_id = Gutenberg_Guidelines_Post_Type::get_or_create_term_id(
-			'artifact',
-			'Artifact'
+		$inserted         = wp_insert_term(
+			'Artifact',
+			Gutenberg_Guidelines_Post_Type::TAXONOMY,
+			array( 'slug' => 'artifact' )
 		);
+		$artifact_term_id = is_wp_error( $inserted ) ? (int) $inserted->get_error_data()['term_id'] : (int) $inserted['term_id'];
 
 		$post_id = wp_insert_post(
 			array(

--- a/phpunit/experimental/guidelines/class-gutenberg-content-guidelines-rest-controller-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-content-guidelines-rest-controller-test.php
@@ -3,6 +3,8 @@
  * Tests for the Content Guidelines REST API Controller (singleton).
  *
  * @package gutenberg
+ *
+ * @group guidelines
  */
 class Gutenberg_Content_Guidelines_REST_Controller_Test extends WP_Test_REST_Post_Type_Controller_Testcase {
 

--- a/phpunit/experimental/guidelines/class-gutenberg-content-guidelines-rest-controller-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-content-guidelines-rest-controller-test.php
@@ -46,24 +46,6 @@ class Gutenberg_Content_Guidelines_REST_Controller_Test extends WP_Test_REST_Pos
 	}
 
 	/**
-	 * Clean up after each test.
-	 */
-	public function tear_down() {
-		$posts = get_posts(
-			array(
-				'post_type'      => Gutenberg_Guidelines_Post_Type::POST_TYPE,
-				'post_status'    => array( 'publish', 'draft' ),
-				'posts_per_page' => -1,
-			)
-		);
-		foreach ( $posts as $post ) {
-			wp_delete_post( $post->ID, true );
-		}
-
-		parent::tear_down();
-	}
-
-	/**
 	 * Helper: create a guidelines post via the REST API.
 	 *
 	 * @param array $args Optional request params to merge.

--- a/phpunit/experimental/guidelines/class-gutenberg-content-guidelines-rest-controller-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-content-guidelines-rest-controller-test.php
@@ -443,14 +443,15 @@ class Gutenberg_Content_Guidelines_REST_Controller_Test extends WP_Test_REST_Pos
 	 * @return int Post ID.
 	 */
 	private function create_artifact_post() {
-		$inserted         = wp_insert_term(
-			'Artifact',
-			Gutenberg_Guidelines_Post_Type::TAXONOMY,
-			array( 'slug' => 'artifact' )
+		$artifact_term_id = self::factory()->term->create(
+			array(
+				'taxonomy' => Gutenberg_Guidelines_Post_Type::TAXONOMY,
+				'name'     => 'Artifact',
+				'slug'     => 'artifact',
+			)
 		);
-		$artifact_term_id = is_wp_error( $inserted ) ? (int) $inserted->get_error_data()['term_id'] : (int) $inserted['term_id'];
 
-		$post_id = wp_insert_post(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => Gutenberg_Guidelines_Post_Type::POST_TYPE,
 				'post_status' => 'draft',

--- a/phpunit/experimental/guidelines/class-gutenberg-guidelines-access-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-guidelines-access-test.php
@@ -40,25 +40,6 @@ class Gutenberg_Guidelines_Access_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Clean up guideline posts after each test so per-post matrix tests
-	 * don't leak state into each other.
-	 */
-	public function tear_down() {
-		$posts = get_posts(
-			array(
-				'post_type'      => Gutenberg_Guidelines_Post_Type::POST_TYPE,
-				'post_status'    => array( 'private', 'publish' ),
-				'posts_per_page' => -1,
-			)
-		);
-		foreach ( $posts as $post ) {
-			wp_delete_post( $post->ID, true );
-		}
-
-		parent::tear_down();
-	}
-
-	/**
 	 * Returns a fresh WP_User for the named role so tests don't share
 	 * mutable user state.
 	 */
@@ -67,15 +48,20 @@ class Gutenberg_Guidelines_Access_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Insert a guideline post owned by the named role.
+	 * Creates a guideline fixture owned by the named role and saved with the
+	 * given post status.
+	 *
+	 * @param string $owner_role Role key from the self::$users fixture map.
+	 * @param string $status     Post status for the guideline fixture.
+	 * @return int Inserted guideline post ID.
 	 */
-	private function make_post( $owner_role, $status ) {
+	private function create_guideline( string $owner_role, string $status ): int {
 		return self::factory()->post->create(
 			array(
 				'post_type'    => Gutenberg_Guidelines_Post_Type::POST_TYPE,
 				'post_status'  => $status,
-				'post_title'   => "access test {$owner_role} {$status}",
-				'post_content' => 'body',
+				'post_title'   => "{$status} guideline owned by {$owner_role}",
+				'post_content' => "Guideline fixture content for {$owner_role} with {$status} status.",
 				'post_author'  => self::$users[ $owner_role ],
 			)
 		);
@@ -158,47 +144,39 @@ class Gutenberg_Guidelines_Access_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Subscriber per-post `read_post`, `edit_post`, and `delete_post`
-	 * checks fail regardless of the row's owner or status.
-	 */
-	public function test_subscriber_per_post_caps() {
-		$subscriber = $this->user( 'subscriber' );
-		$post_id    = $this->make_post( 'administrator', 'publish' );
-
-		$this->assertFalse( $subscriber->has_cap( 'read_post', $post_id ) );
-		$this->assertFalse( $subscriber->has_cap( 'edit_post', $post_id ) );
-		$this->assertFalse( $subscriber->has_cap( 'delete_post', $post_id ) );
-	}
-
-	/**
-	 * Per-post access policy for Editor, Author, and Contributor:
+	 * Per-post access policy across every role:
 	 *
-	 * - own private rows: full read, edit, and delete
-	 * - own publish rows: read only — edit and delete require Administrator
-	 * - others' private rows: invisible (no read, edit, or delete)
-	 * - others' publish rows: read only
+	 * - Administrator: full read, edit, and delete on every row.
+	 * - Editor / Author / Contributor:
+	 *   - own private rows: full read, edit, and delete
+	 *   - own publish rows: read only — edit and delete require Administrator
+	 *   - others' private rows: invisible
+	 *   - others' publish rows: read only
+	 * - Subscriber: blocked on every per-post check.
 	 *
-	 * @dataProvider data_per_post_caps
+	 * @dataProvider data_per_post_caps_by_role
 	 */
-	public function test_contributor_plus_per_post_caps( $role, $cap, $ownership, $status, $expected ) {
-		$owner_role = 'self' === $ownership ? $role : 'administrator';
-		$post_id    = $this->make_post( $owner_role, $status );
+	public function test_per_post_caps_per_role( $role, $cap, $ownership, $status, $expected ) {
+		$owner_role = 'self' === $ownership
+			? $role
+			: ( 'administrator' === $role ? 'contributor' : 'administrator' );
+		$post_id    = $this->create_guideline( $owner_role, $status );
 
 		$result = $this->user( $role )->has_cap( $cap, $post_id );
 
-		if ( $expected ) {
-			$this->assertTrue( $result, "{$role}.{$cap}({$ownership} {$status}) should be allowed" );
-		} else {
-			$this->assertFalse( $result, "{$role}.{$cap}({$ownership} {$status}) should be denied" );
-		}
+		$this->assertSame(
+			$expected,
+			$result,
+			"{$role}.{$cap}({$ownership} {$status}) should be " . ( $expected ? 'allowed' : 'denied' )
+		);
 	}
 
 	/**
 	 * @return array Rows keyed `{role}.{cap}({ownership} {status})` so test
 	 *               failures point at the exact combination.
 	 */
-	public function data_per_post_caps() {
-		$matrix = array(
+	public function data_per_post_caps_by_role() {
+		$contributor_plus_rules = array(
 			// Own private: full CRUD.
 			array( 'edit_post', 'self', 'private', true ),
 			array( 'delete_post', 'self', 'private', true ),
@@ -220,9 +198,29 @@ class Gutenberg_Guidelines_Access_Test extends WP_UnitTestCase {
 			array( 'read_post', 'other', 'publish', true ),
 		);
 
+		$expand = static function ( bool $expected ): array {
+			$rows = array();
+			foreach ( array( 'self', 'other' ) as $ownership ) {
+				foreach ( array( 'private', 'publish' ) as $status ) {
+					foreach ( array( 'read_post', 'edit_post', 'delete_post' ) as $cap ) {
+						$rows[] = array( $cap, $ownership, $status, $expected );
+					}
+				}
+			}
+			return $rows;
+		};
+
+		$rules_by_role = array(
+			'administrator' => $expand( true ),
+			'editor'        => $contributor_plus_rules,
+			'author'        => $contributor_plus_rules,
+			'contributor'   => $contributor_plus_rules,
+			'subscriber'    => $expand( false ),
+		);
+
 		$cases = array();
-		foreach ( array( 'editor', 'author', 'contributor' ) as $role ) {
-			foreach ( $matrix as $row ) {
+		foreach ( $rules_by_role as $role => $rules ) {
+			foreach ( $rules as $row ) {
 				list( $cap, $ownership, $status, $expected )       = $row;
 				$cases[ "{$role}.{$cap}({$ownership} {$status})" ] = array( $role, $cap, $ownership, $status, $expected );
 			}
@@ -231,23 +229,69 @@ class Gutenberg_Guidelines_Access_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Administrator passes every per-post check regardless of the row's
-	 * owner or status.
+	 * Taxonomy capability policy:
+	 *
+	 * - `manage_terms` / `delete_terms` — Administrator only.
+	 * - `edit_terms` / `assign_terms` — Contributor and above, so agent flows
+	 *   can introduce new type slugs (e.g. `memory`) and attach them to
+	 *   guideline posts.
+	 * - Subscribers hold none of these.
+	 *
+	 * @dataProvider data_taxonomy_caps_by_role
 	 */
-	public function test_administrator_per_post_caps() {
-		$admin = $this->user( 'administrator' );
+	public function test_taxonomy_caps_per_role( $role, $cap_key, $expected ) {
+		$taxonomy  = get_taxonomy( Gutenberg_Guidelines_Post_Type::TAXONOMY );
+		$primitive = $taxonomy->cap->{$cap_key};
 
-		foreach ( array( 'private', 'publish' ) as $status ) {
-			foreach ( array( 'administrator', 'contributor' ) as $owner_role ) {
-				$post_id = $this->make_post( $owner_role, $status );
+		$this->assertSame(
+			$expected,
+			$this->user( $role )->has_cap( $primitive ),
+			"{$role}.{$cap_key} (resolves to {$primitive}) should be " . ( $expected ? 'allowed' : 'denied' )
+		);
+	}
 
-				foreach ( array( 'edit_post', 'delete_post', 'read_post' ) as $cap ) {
-					$this->assertTrue(
-						$admin->has_cap( $cap, $post_id ),
-						"Administrator should have {$cap} on {$owner_role}'s {$status} row"
-					);
-				}
+	/**
+	 * @return array Rows keyed `{role}.{cap_key}` so test failures point at
+	 *               the exact combination. Each row is [role, cap_key, expected].
+	 */
+	public function data_taxonomy_caps_by_role() {
+		$matrix = array(
+			'manage_terms' => array(
+				'administrator' => true,
+				'editor'        => false,
+				'author'        => false,
+				'contributor'   => false,
+				'subscriber'    => false,
+			),
+			'edit_terms'   => array(
+				'administrator' => true,
+				'editor'        => true,
+				'author'        => true,
+				'contributor'   => true,
+				'subscriber'    => false,
+			),
+			'delete_terms' => array(
+				'administrator' => true,
+				'editor'        => false,
+				'author'        => false,
+				'contributor'   => false,
+				'subscriber'    => false,
+			),
+			'assign_terms' => array(
+				'administrator' => true,
+				'editor'        => true,
+				'author'        => true,
+				'contributor'   => true,
+				'subscriber'    => false,
+			),
+		);
+
+		$cases = array();
+		foreach ( $matrix as $cap_key => $role_map ) {
+			foreach ( $role_map as $role => $expected ) {
+				$cases[ "{$role}.{$cap_key}" ] = array( $role, $cap_key, $expected );
 			}
 		}
+		return $cases;
 	}
 }

--- a/phpunit/experimental/guidelines/class-gutenberg-guidelines-access-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-guidelines-access-test.php
@@ -8,6 +8,8 @@
  * surfaces at the shortest possible path through the stack.
  *
  * @package gutenberg
+ *
+ * @group guidelines
  */
 class Gutenberg_Guidelines_Access_Test extends WP_UnitTestCase {
 

--- a/phpunit/experimental/guidelines/class-gutenberg-guidelines-access-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-guidelines-access-test.php
@@ -70,7 +70,7 @@ class Gutenberg_Guidelines_Access_Test extends WP_UnitTestCase {
 	 * Insert a guideline post owned by the named role.
 	 */
 	private function make_post( $owner_role, $status ) {
-		return wp_insert_post(
+		return self::factory()->post->create(
 			array(
 				'post_type'    => Gutenberg_Guidelines_Post_Type::POST_TYPE,
 				'post_status'  => $status,

--- a/phpunit/experimental/guidelines/class-gutenberg-guidelines-access-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-guidelines-access-test.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * Tests for the `wp_guideline` capability policy: ambient cap synthesis and
+ * per-post meta-cap resolution across the default roles.
+ *
+ * Each test asserts `WP_User::has_cap()` directly against a known role,
+ * status, and ownership combination so a regression in the cap filter
+ * surfaces at the shortest possible path through the stack.
+ *
+ * @package gutenberg
+ */
+class Gutenberg_Guidelines_Access_Test extends WP_UnitTestCase {
+
+	/**
+	 * Map of role => user ID. Populated once per test class.
+	 *
+	 * @var array<string,int>
+	 */
+	protected static $users = array();
+
+	/**
+	 * Set up class fixtures: one user per default role.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		foreach ( array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' ) as $role ) {
+			self::$users[ $role ] = $factory->user->create( array( 'role' => $role ) );
+		}
+	}
+
+	/**
+	 * Clean up class fixtures.
+	 */
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$users as $user_id ) {
+			self::delete_user( $user_id );
+		}
+		self::$users = array();
+	}
+
+	/**
+	 * Clean up guideline posts after each test so per-post matrix tests
+	 * don't leak state into each other.
+	 */
+	public function tear_down() {
+		$posts = get_posts(
+			array(
+				'post_type'      => Gutenberg_Guidelines_Post_Type::POST_TYPE,
+				'post_status'    => array( 'private', 'publish' ),
+				'posts_per_page' => -1,
+			)
+		);
+		foreach ( $posts as $post ) {
+			wp_delete_post( $post->ID, true );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Returns a fresh WP_User for the named role so tests don't share
+	 * mutable user state.
+	 */
+	private function user( $role ) {
+		return new WP_User( self::$users[ $role ] );
+	}
+
+	/**
+	 * Insert a guideline post owned by the named role.
+	 */
+	private function make_post( $owner_role, $status ) {
+		return wp_insert_post(
+			array(
+				'post_type'    => Gutenberg_Guidelines_Post_Type::POST_TYPE,
+				'post_status'  => $status,
+				'post_title'   => "access test {$owner_role} {$status}",
+				'post_content' => 'body',
+				'post_author'  => self::$users[ $owner_role ],
+			)
+		);
+	}
+
+	/**
+	 * Administrator holds every guideline-prefixed capability without a
+	 * post context.
+	 */
+	public function test_administrator_ambient_caps() {
+		$admin = $this->user( 'administrator' );
+
+		foreach ( array(
+			'read_guidelines',
+			'edit_guidelines',
+			'edit_others_guidelines',
+			'edit_published_guidelines',
+			'edit_private_guidelines',
+			'publish_guidelines',
+			'delete_guidelines',
+			'delete_others_guidelines',
+			'delete_published_guidelines',
+			'delete_private_guidelines',
+			'read_private_guidelines',
+		) as $cap ) {
+			$this->assertTrue( $admin->has_cap( $cap ), "Administrator should hold {$cap} ambiently" );
+		}
+	}
+
+	/**
+	 * Editor, Author, and Contributor hold the post-type read floor
+	 * (`read_guidelines`) and the namespace-wide ownership cap
+	 * (`edit_guidelines`) ambiently. Publish, private, and others-scoped
+	 * primitives are not granted without a post context.
+	 */
+	public function test_contributor_plus_ambient_caps() {
+		foreach ( array( 'editor', 'author', 'contributor' ) as $role ) {
+			$user = $this->user( $role );
+
+			foreach ( array( 'read_guidelines', 'edit_guidelines' ) as $cap ) {
+				$this->assertTrue( $user->has_cap( $cap ), "{$role} should hold {$cap} ambiently" );
+			}
+
+			foreach ( array(
+				'publish_guidelines',
+				'read_private_guidelines',
+				'edit_others_guidelines',
+				'delete_others_guidelines',
+				'edit_private_guidelines',
+				'edit_published_guidelines',
+				'delete_private_guidelines',
+				'delete_published_guidelines',
+			) as $cap ) {
+				$this->assertFalse( $user->has_cap( $cap ), "{$role} must not hold {$cap} ambiently" );
+			}
+		}
+	}
+
+	/**
+	 * Subscriber holds none of the guideline-prefixed capabilities.
+	 */
+	public function test_subscriber_ambient_caps() {
+		$subscriber = $this->user( 'subscriber' );
+
+		foreach ( array(
+			'read_guidelines',
+			'edit_guidelines',
+			'edit_others_guidelines',
+			'edit_published_guidelines',
+			'edit_private_guidelines',
+			'publish_guidelines',
+			'delete_guidelines',
+			'delete_others_guidelines',
+			'delete_published_guidelines',
+			'delete_private_guidelines',
+			'read_private_guidelines',
+		) as $cap ) {
+			$this->assertFalse( $subscriber->has_cap( $cap ), "Subscriber must not hold {$cap}" );
+		}
+	}
+
+	/**
+	 * Subscriber per-post `read_post`, `edit_post`, and `delete_post`
+	 * checks fail regardless of the row's owner or status.
+	 */
+	public function test_subscriber_per_post_caps() {
+		$subscriber = $this->user( 'subscriber' );
+		$post_id    = $this->make_post( 'administrator', 'publish' );
+
+		$this->assertFalse( $subscriber->has_cap( 'read_post', $post_id ) );
+		$this->assertFalse( $subscriber->has_cap( 'edit_post', $post_id ) );
+		$this->assertFalse( $subscriber->has_cap( 'delete_post', $post_id ) );
+	}
+
+	/**
+	 * Per-post access policy for Editor, Author, and Contributor:
+	 *
+	 * - own private rows: full read, edit, and delete
+	 * - own publish rows: read only — edit and delete require Administrator
+	 * - others' private rows: invisible (no read, edit, or delete)
+	 * - others' publish rows: read only
+	 *
+	 * @dataProvider data_per_post_caps
+	 */
+	public function test_contributor_plus_per_post_caps( $role, $cap, $ownership, $status, $expected ) {
+		$owner_role = 'self' === $ownership ? $role : 'administrator';
+		$post_id    = $this->make_post( $owner_role, $status );
+
+		$result = $this->user( $role )->has_cap( $cap, $post_id );
+
+		if ( $expected ) {
+			$this->assertTrue( $result, "{$role}.{$cap}({$ownership} {$status}) should be allowed" );
+		} else {
+			$this->assertFalse( $result, "{$role}.{$cap}({$ownership} {$status}) should be denied" );
+		}
+	}
+
+	/**
+	 * @return array Rows keyed `{role}.{cap}({ownership} {status})` so test
+	 *               failures point at the exact combination.
+	 */
+	public function data_per_post_caps() {
+		$matrix = array(
+			// Own private: full CRUD.
+			array( 'edit_post', 'self', 'private', true ),
+			array( 'delete_post', 'self', 'private', true ),
+			array( 'read_post', 'self', 'private', true ),
+
+			// Own publish: read only.
+			array( 'edit_post', 'self', 'publish', false ),
+			array( 'delete_post', 'self', 'publish', false ),
+			array( 'read_post', 'self', 'publish', true ),
+
+			// Others' private: invisible.
+			array( 'edit_post', 'other', 'private', false ),
+			array( 'delete_post', 'other', 'private', false ),
+			array( 'read_post', 'other', 'private', false ),
+
+			// Others' publish: read only.
+			array( 'edit_post', 'other', 'publish', false ),
+			array( 'delete_post', 'other', 'publish', false ),
+			array( 'read_post', 'other', 'publish', true ),
+		);
+
+		$cases = array();
+		foreach ( array( 'editor', 'author', 'contributor' ) as $role ) {
+			foreach ( $matrix as $row ) {
+				list( $cap, $ownership, $status, $expected )       = $row;
+				$cases[ "{$role}.{$cap}({$ownership} {$status})" ] = array( $role, $cap, $ownership, $status, $expected );
+			}
+		}
+		return $cases;
+	}
+
+	/**
+	 * Administrator passes every per-post check regardless of the row's
+	 * owner or status.
+	 */
+	public function test_administrator_per_post_caps() {
+		$admin = $this->user( 'administrator' );
+
+		foreach ( array( 'private', 'publish' ) as $status ) {
+			foreach ( array( 'administrator', 'contributor' ) as $owner_role ) {
+				$post_id = $this->make_post( $owner_role, $status );
+
+				foreach ( array( 'edit_post', 'delete_post', 'read_post' ) as $cap ) {
+					$this->assertTrue(
+						$admin->has_cap( $cap, $post_id ),
+						"Administrator should have {$cap} on {$owner_role}'s {$status} row"
+					);
+				}
+			}
+		}
+	}
+}

--- a/phpunit/experimental/guidelines/class-gutenberg-guidelines-post-type-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-guidelines-post-type-test.php
@@ -3,6 +3,8 @@
  * Tests for the Guidelines Post Type registration and type-term behavior.
  *
  * @package gutenberg
+ *
+ * @group guidelines
  */
 class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 

--- a/phpunit/experimental/guidelines/class-gutenberg-guidelines-post-type-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-guidelines-post-type-test.php
@@ -77,25 +77,28 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The post type maps generated guideline primitive caps back to the core
-	 * post caps used by built-in roles.
+	 * The post type exposes a self-contained, guideline-prefixed capability
+	 * namespace. The CPT-level `read` is remapped to keep Subscribers blocked
+	 * at the post-type door; every other primitive is auto-derived from
+	 * `capability_type = 'guideline'` and granted at runtime via the
+	 * `user_has_cap` synthesis filter.
 	 */
-	public function test_post_type_uses_core_primitive_capabilities() {
+	public function test_post_type_uses_guideline_prefixed_capabilities() {
 		$post_type = get_post_type_object( Gutenberg_Guidelines_Post_Type::POST_TYPE );
 
 		$this->assertNotFalse( $post_type );
-		$this->assertSame( 'edit_posts', $post_type->cap->read );
-		$this->assertSame( 'publish_posts', $post_type->cap->create_posts );
-		$this->assertSame( 'edit_posts', $post_type->cap->edit_posts );
-		$this->assertSame( 'publish_posts', $post_type->cap->publish_posts );
-		$this->assertSame( 'read_private_posts', $post_type->cap->read_private_posts );
-		$this->assertSame( 'edit_private_posts', $post_type->cap->edit_private_posts );
-		$this->assertSame( 'edit_published_posts', $post_type->cap->edit_published_posts );
-		$this->assertSame( 'delete_private_posts', $post_type->cap->delete_private_posts );
-		$this->assertSame( 'delete_published_posts', $post_type->cap->delete_published_posts );
-		$this->assertSame( 'delete_posts', $post_type->cap->delete_posts );
-		$this->assertSame( 'edit_others_posts', $post_type->cap->edit_others_posts );
-		$this->assertSame( 'delete_others_posts', $post_type->cap->delete_others_posts );
+		$this->assertSame( 'read_guidelines', $post_type->cap->read );
+		$this->assertSame( 'edit_guidelines', $post_type->cap->create_posts );
+		$this->assertSame( 'edit_guidelines', $post_type->cap->edit_posts );
+		$this->assertSame( 'publish_guidelines', $post_type->cap->publish_posts );
+		$this->assertSame( 'read_private_guidelines', $post_type->cap->read_private_posts );
+		$this->assertSame( 'edit_private_guidelines', $post_type->cap->edit_private_posts );
+		$this->assertSame( 'edit_published_guidelines', $post_type->cap->edit_published_posts );
+		$this->assertSame( 'delete_private_guidelines', $post_type->cap->delete_private_posts );
+		$this->assertSame( 'delete_published_guidelines', $post_type->cap->delete_published_posts );
+		$this->assertSame( 'delete_guidelines', $post_type->cap->delete_posts );
+		$this->assertSame( 'edit_others_guidelines', $post_type->cap->edit_others_posts );
+		$this->assertSame( 'delete_others_guidelines', $post_type->cap->delete_others_posts );
 	}
 
 	/**
@@ -125,7 +128,7 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 	/**
 	 * A post inserted with an explicit type keeps that type.
 	 */
-	public function test_explicit_term_is_preserved() {
+	public function test_save_post_preserves_explicit_term() {
 		wp_set_current_user( self::$admin_id );
 
 		$content_term_id = Gutenberg_Guidelines_Post_Type::get_or_create_term_id(
@@ -157,7 +160,7 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 	/**
 	 * Updates to an existing post do not overwrite an already-assigned term.
 	 */
-	public function test_term_is_not_overwritten_on_update() {
+	public function test_save_post_preserves_term_on_update() {
 		wp_set_current_user( self::$admin_id );
 
 		$content_term_id = Gutenberg_Guidelines_Post_Type::get_or_create_term_id(
@@ -193,7 +196,7 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 	 * The fallback is skipped for revisions (including autosaves, which are
 	 * stored as revisions).
 	 */
-	public function test_revision_is_ignored() {
+	public function test_save_post_skips_revisions() {
 		wp_set_current_user( self::$admin_id );
 
 		$post_id = wp_insert_post(

--- a/phpunit/experimental/guidelines/class-gutenberg-guidelines-post-type-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-guidelines-post-type-test.php
@@ -12,12 +12,18 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 	protected static $admin_id;
 
 	/**
+	 * @var int Contributor user ID.
+	 */
+	protected static $contributor_id;
+
+	/**
 	 * Set up class fixtures.
 	 *
 	 * @param WP_UnitTest_Factory $factory Factory instance.
 	 */
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$admin_id       = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$contributor_id = $factory->user->create( array( 'role' => 'contributor' ) );
 	}
 
 	/**
@@ -25,36 +31,7 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 	 */
 	public static function wpTearDownAfterClass() {
 		self::delete_user( self::$admin_id );
-	}
-
-	/**
-	 * Clean up guidelines posts and taxonomy terms after each test.
-	 */
-	public function tear_down() {
-		$posts = get_posts(
-			array(
-				'post_type'      => Gutenberg_Guidelines_Post_Type::POST_TYPE,
-				'post_status'    => array( 'publish', 'draft' ),
-				'posts_per_page' => -1,
-			)
-		);
-		foreach ( $posts as $post ) {
-			wp_delete_post( $post->ID, true );
-		}
-
-		$terms = get_terms(
-			array(
-				'taxonomy'   => Gutenberg_Guidelines_Post_Type::TAXONOMY,
-				'hide_empty' => false,
-			)
-		);
-		if ( ! is_wp_error( $terms ) ) {
-			foreach ( $terms as $term ) {
-				wp_delete_term( $term->term_id, Gutenberg_Guidelines_Post_Type::TAXONOMY );
-			}
-		}
-
-		parent::tear_down();
+		self::delete_user( self::$contributor_id );
 	}
 
 	/**
@@ -136,7 +113,7 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$post_id = wp_insert_post(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => Gutenberg_Guidelines_Post_Type::POST_TYPE,
 				'post_status' => 'draft',
@@ -144,16 +121,49 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 				'tax_input'   => array(
 					Gutenberg_Guidelines_Post_Type::TAXONOMY => array( $content_term_id ),
 				),
-			),
-			true
+			)
 		);
-
-		$this->assertIsInt( $post_id );
-		$this->assertNotWPError( $post_id );
 
 		$terms = wp_get_object_terms( $post_id, Gutenberg_Guidelines_Post_Type::TAXONOMY, array( 'fields' => 'slugs' ) );
 
 		$this->assertSame( array( Gutenberg_Guidelines_Post_Type::TERM_CONTENT ), $terms );
+	}
+
+	/**
+	 * End-to-end check for the agent flow the cap relaxation enables: a
+	 * Contributor creates a new `wp_guideline_type` term and attaches a
+	 * private guideline to it in the same session. The post must end up
+	 * tagged with the new term instead of the `artifact` fallback.
+	 */
+	public function test_save_post_preserves_new_term_for_contributor() {
+		wp_set_current_user( self::$contributor_id );
+
+		$memory_term_id = self::factory()->term->create(
+			array(
+				'taxonomy' => Gutenberg_Guidelines_Post_Type::TAXONOMY,
+				'name'     => 'Memory',
+				'slug'     => 'memory',
+			)
+		);
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => Gutenberg_Guidelines_Post_Type::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Contributor memory',
+				'post_author' => self::$contributor_id,
+				'tax_input'   => array(
+					Gutenberg_Guidelines_Post_Type::TAXONOMY => array( $memory_term_id ),
+				),
+			)
+		);
+
+		$terms = wp_get_object_terms(
+			$post_id,
+			Gutenberg_Guidelines_Post_Type::TAXONOMY,
+			array( 'fields' => 'slugs' )
+		);
+		$this->assertSame( array( 'memory' ), $terms );
 	}
 
 	/**
@@ -170,7 +180,7 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$post_id = wp_insert_post(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => Gutenberg_Guidelines_Post_Type::POST_TYPE,
 				'post_status' => 'draft',
@@ -178,8 +188,7 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 				'tax_input'   => array(
 					Gutenberg_Guidelines_Post_Type::TAXONOMY => array( $content_term_id ),
 				),
-			),
-			true
+			)
 		);
 
 		wp_update_post(

--- a/phpunit/experimental/guidelines/class-gutenberg-guidelines-post-type-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-guidelines-post-type-test.php
@@ -131,11 +131,13 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 	public function test_save_post_preserves_explicit_term() {
 		wp_set_current_user( self::$admin_id );
 
-		$content_term_id = Gutenberg_Guidelines_Post_Type::get_or_create_term_id(
-			Gutenberg_Guidelines_Post_Type::TERM_CONTENT,
-			'Content'
+		$inserted = wp_insert_term(
+			'Content',
+			Gutenberg_Guidelines_Post_Type::TAXONOMY,
+			array( 'slug' => Gutenberg_Guidelines_Post_Type::TERM_CONTENT )
 		);
-		$this->assertIsInt( $content_term_id );
+		$this->assertNotWPError( $inserted );
+		$content_term_id = (int) $inserted['term_id'];
 
 		$post_id = wp_insert_post(
 			array(
@@ -163,10 +165,13 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 	public function test_save_post_preserves_term_on_update() {
 		wp_set_current_user( self::$admin_id );
 
-		$content_term_id = Gutenberg_Guidelines_Post_Type::get_or_create_term_id(
-			Gutenberg_Guidelines_Post_Type::TERM_CONTENT,
-			'Content'
+		$inserted = wp_insert_term(
+			'Content',
+			Gutenberg_Guidelines_Post_Type::TAXONOMY,
+			array( 'slug' => Gutenberg_Guidelines_Post_Type::TERM_CONTENT )
 		);
+		$this->assertNotWPError( $inserted );
+		$content_term_id = (int) $inserted['term_id'];
 
 		$post_id = wp_insert_post(
 			array(

--- a/phpunit/experimental/guidelines/class-gutenberg-guidelines-post-type-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-guidelines-post-type-test.php
@@ -106,16 +106,13 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 	 * the save_post hook (replacement for default_term).
 	 */
 	public function test_save_post_assigns_artifact_fallback() {
-		$post_id = wp_insert_post(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => Gutenberg_Guidelines_Post_Type::POST_TYPE,
 				'post_status' => 'draft',
 				'post_title'  => 'No-type guideline',
 			)
 		);
-
-		$this->assertIsInt( $post_id );
-		$this->assertGreaterThan( 0, $post_id );
 
 		$terms = wp_get_object_terms( $post_id, Gutenberg_Guidelines_Post_Type::TAXONOMY );
 		$this->assertCount( 1, $terms );
@@ -131,13 +128,13 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 	public function test_save_post_preserves_explicit_term() {
 		wp_set_current_user( self::$admin_id );
 
-		$inserted = wp_insert_term(
-			'Content',
-			Gutenberg_Guidelines_Post_Type::TAXONOMY,
-			array( 'slug' => Gutenberg_Guidelines_Post_Type::TERM_CONTENT )
+		$content_term_id = self::factory()->term->create(
+			array(
+				'taxonomy' => Gutenberg_Guidelines_Post_Type::TAXONOMY,
+				'name'     => 'Content',
+				'slug'     => Gutenberg_Guidelines_Post_Type::TERM_CONTENT,
+			)
 		);
-		$this->assertNotWPError( $inserted );
-		$content_term_id = (int) $inserted['term_id'];
 
 		$post_id = wp_insert_post(
 			array(
@@ -165,13 +162,13 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 	public function test_save_post_preserves_term_on_update() {
 		wp_set_current_user( self::$admin_id );
 
-		$inserted = wp_insert_term(
-			'Content',
-			Gutenberg_Guidelines_Post_Type::TAXONOMY,
-			array( 'slug' => Gutenberg_Guidelines_Post_Type::TERM_CONTENT )
+		$content_term_id = self::factory()->term->create(
+			array(
+				'taxonomy' => Gutenberg_Guidelines_Post_Type::TAXONOMY,
+				'name'     => 'Content',
+				'slug'     => Gutenberg_Guidelines_Post_Type::TERM_CONTENT,
+			)
 		);
-		$this->assertNotWPError( $inserted );
-		$content_term_id = (int) $inserted['term_id'];
 
 		$post_id = wp_insert_post(
 			array(
@@ -204,7 +201,7 @@ class Gutenberg_Guidelines_Post_Type_Test extends WP_UnitTestCase {
 	public function test_save_post_skips_revisions() {
 		wp_set_current_user( self::$admin_id );
 
-		$post_id = wp_insert_post(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => Gutenberg_Guidelines_Post_Type::POST_TYPE,
 				'post_status' => 'draft',

--- a/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
@@ -77,10 +77,10 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	 *
 	 * @param string $owner_role Role key from the self::$users fixture map.
 	 * @param string $status     Post status for the guideline fixture.
-	 * @return int Inserted guideline post ID, or 0 on failure.
+	 * @return int Inserted guideline post ID.
 	 */
 	private function create_guideline( string $owner_role, string $status ): int {
-		return wp_insert_post(
+		$post_id = wp_insert_post(
 			array(
 				'post_type'    => Gutenberg_Guidelines_Post_Type::POST_TYPE,
 				'post_status'  => $status,
@@ -89,6 +89,11 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 				'post_author'  => self::$users[ $owner_role ],
 			)
 		);
+
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+
+		return $post_id;
 	}
 
 	/**

--- a/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
@@ -3,6 +3,8 @@
  * Tests for the standard Guidelines REST API collection.
  *
  * @package gutenberg
+ *
+ * @group guidelines
  */
 class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase {
 

--- a/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
@@ -80,7 +80,7 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	 * @return int Inserted guideline post ID.
 	 */
 	private function create_guideline( string $owner_role, string $status ): int {
-		$post_id = wp_insert_post(
+		return self::factory()->post->create(
 			array(
 				'post_type'    => Gutenberg_Guidelines_Post_Type::POST_TYPE,
 				'post_status'  => $status,
@@ -89,11 +89,6 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 				'post_author'  => self::$users[ $owner_role ],
 			)
 		);
-
-		$this->assertIsInt( $post_id );
-		$this->assertGreaterThan( 0, $post_id );
-
-		return $post_id;
 	}
 
 	/**
@@ -143,6 +138,38 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 		$terms = wp_get_object_terms( $data['id'], Gutenberg_Guidelines_Post_Type::TAXONOMY, array( 'fields' => 'slugs' ) );
 
 		$this->assertSame( array( 'artifact' ), $terms );
+	}
+
+	/**
+	 * A POST that explicitly supplies a `wp_guideline_type` term keeps that
+	 * term; the `artifact` fallback only applies when no term is given.
+	 */
+	public function test_create_guideline_preserves_explicit_type(): void {
+		$memory_term_id = self::factory()->term->create(
+			array(
+				'taxonomy' => Gutenberg_Guidelines_Post_Type::TAXONOMY,
+				'name'     => 'Memory',
+				'slug'     => 'memory',
+			)
+		);
+
+		$this->switch_to_user_role( 'administrator' );
+
+		$request = new WP_REST_Request( 'POST', self::REST_BASE );
+		$request->set_param( 'status', 'private' );
+		$request->set_param( 'title', 'Typed guideline' );
+		$request->set_param( Gutenberg_Guidelines_Post_Type::TAXONOMY, array( $memory_term_id ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$terms = wp_get_object_terms(
+			$response->get_data()['id'],
+			Gutenberg_Guidelines_Post_Type::TAXONOMY,
+			array( 'fields' => 'slugs' )
+		);
+
+		$this->assertSame( array( 'memory' ), $terms );
 	}
 
 	/**

--- a/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
@@ -7,9 +7,11 @@
 class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase {
 
 	/**
-	 * @var int Administrator user ID.
+	 * Map of role => user ID. Populated once per test class.
+	 *
+	 * @var array<string,int>
 	 */
-	protected static $admin_id;
+	protected static $users = array();
 
 	/**
 	 * REST API route base.
@@ -19,19 +21,24 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	const REST_BASE = '/wp/v2/guidelines';
 
 	/**
-	 * Set up class fixtures.
+	 * Set up class fixtures: one user per default role.
 	 *
 	 * @param WP_UnitTest_Factory $factory Factory instance.
 	 */
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+		foreach ( array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' ) as $role ) {
+			self::$users[ $role ] = $factory->user->create( array( 'role' => $role ) );
+		}
 	}
 
 	/**
 	 * Clean up class fixtures.
 	 */
 	public static function wpTearDownAfterClass() {
-		self::delete_user( self::$admin_id );
+		foreach ( self::$users as $user_id ) {
+			self::delete_user( $user_id );
+		}
+		self::$users = array();
 	}
 
 	/**
@@ -65,19 +72,19 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
-	 * Creates an artifact guideline through the standard REST collection.
+	 * Dispatch a create request to the collection as the administrator.
 	 *
-	 * @param array $args Optional request params to merge.
+	 * @param array $args Optional request params merged over the defaults.
 	 * @return WP_REST_Response
 	 */
-	private function create_artifact_guideline( array $args = array() ): WP_REST_Response {
-		wp_set_current_user( self::$admin_id );
+	private function create_guideline( array $args = array() ): WP_REST_Response {
+		wp_set_current_user( self::$users['administrator'] );
 
 		$defaults = array(
 			'status'  => 'draft',
-			'title'   => 'Artifact guideline',
-			'content' => 'Artifact guideline content.',
-			'excerpt' => 'Artifact guideline excerpt.',
+			'title'   => 'Guideline',
+			'content' => 'Guideline content.',
+			'excerpt' => 'Guideline excerpt.',
 		);
 
 		$request = new WP_REST_Request( 'POST', self::REST_BASE );
@@ -89,8 +96,22 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
-	 * The standard collection route is registered independently from the
-	 * content-guidelines singleton route.
+	 * Insert a guideline post owned by the named role.
+	 */
+	private function make_post( $owner_role, $status ) {
+		return wp_insert_post(
+			array(
+				'post_type'    => Gutenberg_Guidelines_Post_Type::POST_TYPE,
+				'post_status'  => $status,
+				'post_title'   => "endpoint test {$owner_role} {$status}",
+				'post_content' => 'body',
+				'post_author'  => self::$users[ $owner_role ],
+			)
+		);
+	}
+
+	/**
+	 * The standard collection and single-item routes are registered.
 	 */
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
@@ -100,11 +121,11 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
-	 * Artifact guidelines can be created through the standard collection and
-	 * receive the requested publish status and fallback artifact type term.
+	 * A POST to the collection creates the guideline and the save_post
+	 * hook assigns the `artifact` fallback type term.
 	 */
-	public function test_create_artifact_guideline() {
-		$response = $this->create_artifact_guideline( array( 'status' => 'publish' ) );
+	public function test_create_guideline() {
+		$response = $this->create_guideline( array( 'status' => 'publish' ) );
 
 		$this->assertSame( 201, $response->get_status() );
 
@@ -122,11 +143,11 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
-	 * Artifact guidelines are listed by the standard collection route.
+	 * The collection route returns guidelines created via the same route.
 	 */
-	public function test_get_items_lists_artifact_guidelines() {
-		$first_response  = $this->create_artifact_guideline( array( 'title' => 'First artifact' ) );
-		$second_response = $this->create_artifact_guideline( array( 'title' => 'Second artifact' ) );
+	public function test_get_items_lists_guidelines() {
+		$first_response  = $this->create_guideline( array( 'title' => 'First guideline' ) );
+		$second_response = $this->create_guideline( array( 'title' => 'Second guideline' ) );
 
 		$request = new WP_REST_Request( 'GET', self::REST_BASE );
 		$request->set_param( 'status', 'draft' );
@@ -141,10 +162,10 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
-	 * Unauthenticated users cannot list published artifact guidelines.
+	 * Anonymous reads of the collection are rejected with `rest_forbidden`.
 	 */
-	public function test_get_items_unauthenticated_cannot_read_published_artifacts() {
-		$this->create_artifact_guideline( array( 'status' => 'publish' ) );
+	public function test_get_items_blocks_anonymous() {
+		$this->create_guideline( array( 'status' => 'publish' ) );
 
 		wp_set_current_user( 0 );
 
@@ -156,10 +177,11 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
-	 * Unauthenticated users cannot read a published artifact guideline by ID.
+	 * Anonymous reads of a single item are rejected with `rest_forbidden`,
+	 * even when the row is `publish`.
 	 */
-	public function test_get_item_unauthenticated_cannot_read_published_artifact() {
-		$create_response = $this->create_artifact_guideline( array( 'status' => 'publish' ) );
+	public function test_get_item_blocks_anonymous() {
+		$create_response = $this->create_guideline( array( 'status' => 'publish' ) );
 		$post_id         = $create_response->get_data()['id'];
 
 		wp_set_current_user( 0 );
@@ -172,45 +194,39 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
-	 * Authors can pass the post type read capability but must still satisfy
-	 * the per-post check for non-public statuses.
+	 * An authenticated reader cannot fetch another user's private row.
 	 */
-	public function test_get_item_author_cannot_read_other_users_private_guideline() {
-		$create_response = $this->create_artifact_guideline( array( 'status' => 'private' ) );
+	public function test_get_item_blocks_others_private() {
+		$create_response = $this->create_guideline( array( 'status' => 'private' ) );
 		$post_id         = $create_response->get_data()['id'];
 
-		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
-		wp_set_current_user( $author_id );
+		wp_set_current_user( self::$users['author'] );
 
 		$request  = new WP_REST_Request( 'GET', self::REST_BASE . '/' . $post_id );
 		$response = rest_get_server()->dispatch( $request );
 
-		$status = $response->get_status();
-		$code   = $response->get_data()['code'] ?? null;
-
-		self::delete_user( $author_id );
-
-		$this->assertSame( 403, $status );
-		$this->assertSame( 'rest_forbidden', $code );
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
 	}
 
 	/**
-	 * Artifact guidelines can be updated through the standard item route.
+	 * A PATCH to the item route updates title and content without
+	 * changing the row's taxonomy assignment.
 	 */
-	public function test_update_artifact_guideline() {
-		$create_response = $this->create_artifact_guideline();
+	public function test_update_guideline() {
+		$create_response = $this->create_guideline();
 		$post_id         = $create_response->get_data()['id'];
 
 		$request = new WP_REST_Request( 'PATCH', self::REST_BASE . '/' . $post_id );
-		$request->set_param( 'title', 'Updated artifact guideline' );
-		$request->set_param( 'content', 'Updated artifact content.' );
+		$request->set_param( 'title', 'Updated guideline' );
+		$request->set_param( 'content', 'Updated guideline content.' );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
 
 		$data = $response->get_data();
-		$this->assertSame( 'Updated artifact guideline', $data['title']['raw'] );
-		$this->assertSame( 'Updated artifact content.', $data['content']['raw'] );
+		$this->assertSame( 'Updated guideline', $data['title']['raw'] );
+		$this->assertSame( 'Updated guideline content.', $data['content']['raw'] );
 		$this->assertSame( 'draft', $data['status'] );
 
 		$terms = wp_get_object_terms( $post_id, Gutenberg_Guidelines_Post_Type::TAXONOMY, array( 'fields' => 'slugs' ) );
@@ -219,10 +235,10 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
-	 * Artifact guidelines can be deleted through the standard item route.
+	 * A DELETE with `force=true` removes the row entirely.
 	 */
-	public function test_delete_artifact_guideline() {
-		$create_response = $this->create_artifact_guideline();
+	public function test_delete_guideline() {
+		$create_response = $this->create_guideline();
 		$post_id         = $create_response->get_data()['id'];
 
 		$request = new WP_REST_Request( 'DELETE', self::REST_BASE . '/' . $post_id );
@@ -231,5 +247,127 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertNull( get_post( $post_id ) );
+	}
+
+	/**
+	 * Non-publishers may only create rows with `status: private` (or
+	 * omit the param, in which case the controller defaults to
+	 * `private`); Administrators may use any status the parent accepts.
+	 *
+	 * @dataProvider data_create_enforces_status_policy
+	 */
+	public function test_create_enforces_status_policy( $role, $requested_status, $expected_status, $expected_error ) {
+		wp_set_current_user( self::$users[ $role ] );
+
+		$request = new WP_REST_Request( 'POST', self::REST_BASE );
+		if ( null !== $requested_status ) {
+			$request->set_param( 'status', $requested_status );
+		}
+		$request->set_param( 'title', "{$role} requesting " . ( null === $requested_status ? '(omitted)' : $requested_status ) );
+		$request->set_param( 'content', 'body' );
+		$response = rest_get_server()->dispatch( $request );
+
+		if ( null === $expected_error ) {
+			$this->assertSame( 201, $response->get_status() );
+			$this->assertSame( $expected_status, $response->get_data()['status'] );
+			return;
+		}
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( $expected_error, $response->get_data()['code'] );
+	}
+
+	/**
+	 * @return array Rows: [role, requested_status, expected_status, expected_error].
+	 */
+	public function data_create_enforces_status_policy() {
+		return array(
+			// Status omitted: controller defaults to `private`.
+			'contributor + omitted'   => array( 'contributor', null, 'private', null ),
+			'administrator + omitted' => array( 'administrator', null, 'private', null ),
+
+			// Explicit `private` honored for any role above Subscriber.
+			'contributor + private'   => array( 'contributor', 'private', 'private', null ),
+
+			// Administrator may use any status the parent accepts.
+			'administrator + publish' => array( 'administrator', 'publish', 'publish', null ),
+			'administrator + draft'   => array( 'administrator', 'draft', 'draft', null ),
+
+			// Non-publishers limited to `private` — any other status is rejected.
+			'contributor + publish'   => array( 'contributor', 'publish', null, 'rest_cannot_publish' ),
+			'contributor + draft'     => array( 'contributor', 'draft', null, 'rest_cannot_publish' ),
+
+			// Subscriber fails the parent's `create_posts` floor.
+			'subscriber + private'    => array( 'subscriber', 'private', null, 'rest_cannot_create' ),
+		);
+	}
+
+	/**
+	 * Owners may update their own private rows; updates to other users'
+	 * rows are denied with `rest_cannot_edit`.
+	 *
+	 * @dataProvider data_update_enforces_per_post_permission
+	 */
+	public function test_update_enforces_per_post_permission( $role, $owner_role, $status, $expected_error ) {
+		$post_id = $this->make_post( $owner_role, $status );
+		wp_set_current_user( self::$users[ $role ] );
+
+		$request = new WP_REST_Request( 'PATCH', self::REST_BASE . '/' . $post_id );
+		$request->set_param( 'title', "{$role} updating {$owner_role}'s {$status}" );
+		$response = rest_get_server()->dispatch( $request );
+
+		if ( null === $expected_error ) {
+			$this->assertSame( 200, $response->get_status() );
+			return;
+		}
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( $expected_error, $response->get_data()['code'] );
+	}
+
+	/**
+	 * @return array Rows: [role, owner_role, status, expected_error].
+	 */
+	public function data_update_enforces_per_post_permission() {
+		return array(
+			'contributor + own private'    => array( 'contributor', 'contributor', 'private', null ),
+			'contributor + others private' => array( 'contributor', 'administrator', 'private', 'rest_cannot_edit' ),
+		);
+	}
+
+	/**
+	 * Owners may delete their own private rows; deletes of other users'
+	 * rows are denied with `rest_cannot_delete` and the row remains in
+	 * place.
+	 *
+	 * @dataProvider data_delete_enforces_per_post_permission
+	 */
+	public function test_delete_enforces_per_post_permission( $role, $owner_role, $status, $expected_error ) {
+		$post_id = $this->make_post( $owner_role, $status );
+		wp_set_current_user( self::$users[ $role ] );
+
+		$request = new WP_REST_Request( 'DELETE', self::REST_BASE . '/' . $post_id );
+		$request->set_param( 'force', true );
+		$response = rest_get_server()->dispatch( $request );
+
+		if ( null === $expected_error ) {
+			$this->assertSame( 200, $response->get_status() );
+			$this->assertNull( get_post( $post_id ) );
+			return;
+		}
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( $expected_error, $response->get_data()['code'] );
+		$this->assertInstanceOf( WP_Post::class, get_post( $post_id ) );
+	}
+
+	/**
+	 * @return array Rows: [role, owner_role, status, expected_error].
+	 */
+	public function data_delete_enforces_per_post_permission() {
+		return array(
+			'contributor + own private'    => array( 'contributor', 'contributor', 'private', null ),
+			'contributor + others private' => array( 'contributor', 'administrator', 'private', 'rest_cannot_delete' ),
+		);
 	}
 }

--- a/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
@@ -25,7 +25,7 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	 *
 	 * @param WP_UnitTest_Factory $factory Factory instance.
 	 */
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
 		foreach ( array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' ) as $role ) {
 			self::$users[ $role ] = $factory->user->create( array( 'role' => $role ) );
 		}
@@ -34,7 +34,7 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	/**
 	 * Clean up class fixtures.
 	 */
-	public static function wpTearDownAfterClass() {
+	public static function wpTearDownAfterClass(): void {
 		foreach ( self::$users as $user_id ) {
 			self::delete_user( $user_id );
 		}
@@ -44,7 +44,7 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	/**
 	 * Clean up guidelines posts and taxonomy terms after each test.
 	 */
-	public function tear_down() {
+	public function tear_down(): void {
 		$posts = get_posts(
 			array(
 				'post_type'      => Gutenberg_Guidelines_Post_Type::POST_TYPE,
@@ -72,48 +72,39 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
-	 * Dispatch a create request to the collection as the administrator.
+	 * Creates a guideline fixture owned by the named role and saved with the
+	 * given post status.
 	 *
-	 * @param array $args Optional request params merged over the defaults.
-	 * @return WP_REST_Response
+	 * @param string $owner_role Role key from the self::$users fixture map.
+	 * @param string $status     Post status for the guideline fixture.
+	 * @return int Inserted guideline post ID, or 0 on failure.
 	 */
-	private function create_guideline( array $args = array() ): WP_REST_Response {
-		wp_set_current_user( self::$users['administrator'] );
-
-		$defaults = array(
-			'status'  => 'draft',
-			'title'   => 'Guideline',
-			'content' => 'Guideline content.',
-			'excerpt' => 'Guideline excerpt.',
-		);
-
-		$request = new WP_REST_Request( 'POST', self::REST_BASE );
-		foreach ( array_merge( $defaults, $args ) as $key => $value ) {
-			$request->set_param( $key, $value );
-		}
-
-		return rest_get_server()->dispatch( $request );
-	}
-
-	/**
-	 * Insert a guideline post owned by the named role.
-	 */
-	private function make_post( $owner_role, $status ) {
+	private function create_guideline( string $owner_role, string $status ): int {
 		return wp_insert_post(
 			array(
 				'post_type'    => Gutenberg_Guidelines_Post_Type::POST_TYPE,
 				'post_status'  => $status,
-				'post_title'   => "endpoint test {$owner_role} {$status}",
-				'post_content' => 'body',
+				'post_title'   => "{$status} guideline owned by {$owner_role}",
+				'post_content' => "Guideline fixture content for {$owner_role} with {$status} status.",
 				'post_author'  => self::$users[ $owner_role ],
 			)
 		);
 	}
 
 	/**
+	 * Switches the current user to a fixture user with the named role.
+	 *
+	 * @param string $role Role key from the self::$users fixture map.
+	 * @return void
+	 */
+	private function switch_to_user_role( string $role ): void {
+		wp_set_current_user( self::$users[ $role ] );
+	}
+
+	/**
 	 * The standard collection and single-item routes are registered.
 	 */
-	public function test_register_routes() {
+	public function test_register_routes(): void {
 		$routes = rest_get_server()->get_routes();
 
 		$this->assertArrayHasKey( self::REST_BASE, $routes, 'Collection route not registered.' );
@@ -124,8 +115,15 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	 * A POST to the collection creates the guideline and the save_post
 	 * hook assigns the `artifact` fallback type term.
 	 */
-	public function test_create_guideline() {
-		$response = $this->create_guideline( array( 'status' => 'publish' ) );
+	public function test_create_guideline(): void {
+		$this->switch_to_user_role( 'administrator' );
+
+		$request = new WP_REST_Request( 'POST', self::REST_BASE );
+		$request->set_param( 'status', 'publish' );
+		$request->set_param( 'title', 'Guideline' );
+		$request->set_param( 'content', 'Guideline content.' );
+		$request->set_param( 'excerpt', 'Guideline excerpt.' );
+		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 201, $response->get_status() );
 
@@ -143,11 +141,13 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
-	 * The collection route returns guidelines created via the same route.
+	 * The collection route returns matching guidelines and totals.
 	 */
-	public function test_get_items_lists_guidelines() {
-		$first_response  = $this->create_guideline( array( 'title' => 'First guideline' ) );
-		$second_response = $this->create_guideline( array( 'title' => 'Second guideline' ) );
+	public function test_get_items_lists_guidelines(): void {
+		$first_post_id  = $this->create_guideline( 'administrator', 'draft' );
+		$second_post_id = $this->create_guideline( 'administrator', 'draft' );
+
+		$this->switch_to_user_role( 'administrator' );
 
 		$request = new WP_REST_Request( 'GET', self::REST_BASE );
 		$request->set_param( 'status', 'draft' );
@@ -155,17 +155,42 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 
 		$this->assertSame( 200, $response->get_status() );
 
-		$ids = wp_list_pluck( $response->get_data(), 'id' );
+		$ids     = wp_list_pluck( $response->get_data(), 'id' );
+		$headers = $response->get_headers();
 
-		$this->assertContains( $first_response->get_data()['id'], $ids );
-		$this->assertContains( $second_response->get_data()['id'], $ids );
+		$this->assertContains( $first_post_id, $ids );
+		$this->assertContains( $second_post_id, $ids );
+		$this->assertSame( 2, (int) $headers['X-WP-Total'] );
+	}
+
+	/**
+	 * Collection totals are scoped to the private rows readable by the caller.
+	 */
+	public function test_get_items_private_totals_are_scoped_to_current_user(): void {
+		$own_private_post_id   = $this->create_guideline( 'contributor', 'private' );
+		$other_private_post_id = $this->create_guideline( 'author', 'private' );
+
+		$this->switch_to_user_role( 'contributor' );
+
+		$request = new WP_REST_Request( 'GET', self::REST_BASE );
+		$request->set_param( 'status', 'private' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$ids     = wp_list_pluck( $response->get_data(), 'id' );
+		$headers = $response->get_headers();
+
+		$this->assertContains( $own_private_post_id, $ids );
+		$this->assertNotContains( $other_private_post_id, $ids );
+		$this->assertSame( 1, (int) $headers['X-WP-Total'] );
 	}
 
 	/**
 	 * Anonymous reads of the collection are rejected with `rest_forbidden`.
 	 */
-	public function test_get_items_blocks_anonymous() {
-		$this->create_guideline( array( 'status' => 'publish' ) );
+	public function test_get_items_blocks_anonymous(): void {
+		$this->create_guideline( 'administrator', 'publish' );
 
 		wp_set_current_user( 0 );
 
@@ -180,9 +205,8 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	 * Anonymous reads of a single item are rejected with `rest_forbidden`,
 	 * even when the row is `publish`.
 	 */
-	public function test_get_item_blocks_anonymous() {
-		$create_response = $this->create_guideline( array( 'status' => 'publish' ) );
-		$post_id         = $create_response->get_data()['id'];
+	public function test_get_item_blocks_anonymous(): void {
+		$post_id = $this->create_guideline( 'administrator', 'publish' );
 
 		wp_set_current_user( 0 );
 
@@ -196,11 +220,10 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	/**
 	 * An authenticated reader cannot fetch another user's private row.
 	 */
-	public function test_get_item_blocks_others_private() {
-		$create_response = $this->create_guideline( array( 'status' => 'private' ) );
-		$post_id         = $create_response->get_data()['id'];
+	public function test_get_item_blocks_others_private(): void {
+		$post_id = $this->create_guideline( 'administrator', 'private' );
 
-		wp_set_current_user( self::$users['author'] );
+		$this->switch_to_user_role( 'author' );
 
 		$request  = new WP_REST_Request( 'GET', self::REST_BASE . '/' . $post_id );
 		$response = rest_get_server()->dispatch( $request );
@@ -213,9 +236,10 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	 * A PATCH to the item route updates title and content without
 	 * changing the row's taxonomy assignment.
 	 */
-	public function test_update_guideline() {
-		$create_response = $this->create_guideline();
-		$post_id         = $create_response->get_data()['id'];
+	public function test_update_guideline(): void {
+		$post_id = $this->create_guideline( 'administrator', 'draft' );
+
+		$this->switch_to_user_role( 'administrator' );
 
 		$request = new WP_REST_Request( 'PATCH', self::REST_BASE . '/' . $post_id );
 		$request->set_param( 'title', 'Updated guideline' );
@@ -237,9 +261,10 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	/**
 	 * A DELETE with `force=true` removes the row entirely.
 	 */
-	public function test_delete_guideline() {
-		$create_response = $this->create_guideline();
-		$post_id         = $create_response->get_data()['id'];
+	public function test_delete_guideline(): void {
+		$post_id = $this->create_guideline( 'administrator', 'draft' );
+
+		$this->switch_to_user_role( 'administrator' );
 
 		$request = new WP_REST_Request( 'DELETE', self::REST_BASE . '/' . $post_id );
 		$request->set_param( 'force', true );
@@ -256,8 +281,13 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	 *
 	 * @dataProvider data_create_enforces_status_policy
 	 */
-	public function test_create_enforces_status_policy( $role, $requested_status, $expected_status, $expected_error ) {
-		wp_set_current_user( self::$users[ $role ] );
+	public function test_create_enforces_status_policy(
+		string $role,
+		?string $requested_status,
+		?string $expected_status,
+		?string $expected_error
+	): void {
+		$this->switch_to_user_role( $role );
 
 		$request = new WP_REST_Request( 'POST', self::REST_BASE );
 		if ( null !== $requested_status ) {
@@ -280,7 +310,7 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	/**
 	 * @return array Rows: [role, requested_status, expected_status, expected_error].
 	 */
-	public function data_create_enforces_status_policy() {
+	public function data_create_enforces_status_policy(): array {
 		return array(
 			// Status omitted: controller defaults to `private`.
 			'contributor + omitted'   => array( 'contributor', null, 'private', null ),
@@ -308,9 +338,14 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	 *
 	 * @dataProvider data_update_enforces_per_post_permission
 	 */
-	public function test_update_enforces_per_post_permission( $role, $owner_role, $status, $expected_error ) {
-		$post_id = $this->make_post( $owner_role, $status );
-		wp_set_current_user( self::$users[ $role ] );
+	public function test_update_enforces_per_post_permission(
+		string $role,
+		string $owner_role,
+		string $status,
+		?string $expected_error
+	): void {
+		$post_id = $this->create_guideline( $owner_role, $status );
+		$this->switch_to_user_role( $role );
 
 		$request = new WP_REST_Request( 'PATCH', self::REST_BASE . '/' . $post_id );
 		$request->set_param( 'title', "{$role} updating {$owner_role}'s {$status}" );
@@ -328,7 +363,7 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	/**
 	 * @return array Rows: [role, owner_role, status, expected_error].
 	 */
-	public function data_update_enforces_per_post_permission() {
+	public function data_update_enforces_per_post_permission(): array {
 		return array(
 			'contributor + own private'    => array( 'contributor', 'contributor', 'private', null ),
 			'contributor + others private' => array( 'contributor', 'administrator', 'private', 'rest_cannot_edit' ),
@@ -342,9 +377,14 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	 *
 	 * @dataProvider data_delete_enforces_per_post_permission
 	 */
-	public function test_delete_enforces_per_post_permission( $role, $owner_role, $status, $expected_error ) {
-		$post_id = $this->make_post( $owner_role, $status );
-		wp_set_current_user( self::$users[ $role ] );
+	public function test_delete_enforces_per_post_permission(
+		string $role,
+		string $owner_role,
+		string $status,
+		?string $expected_error
+	): void {
+		$post_id = $this->create_guideline( $owner_role, $status );
+		$this->switch_to_user_role( $role );
 
 		$request = new WP_REST_Request( 'DELETE', self::REST_BASE . '/' . $post_id );
 		$request->set_param( 'force', true );
@@ -364,7 +404,7 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	/**
 	 * @return array Rows: [role, owner_role, status, expected_error].
 	 */
-	public function data_delete_enforces_per_post_permission() {
+	public function data_delete_enforces_per_post_permission(): array {
 		return array(
 			'contributor + own private'    => array( 'contributor', 'contributor', 'private', null ),
 			'contributor + others private' => array( 'contributor', 'administrator', 'private', 'rest_cannot_delete' ),

--- a/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
@@ -42,36 +42,6 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
-	 * Clean up guidelines posts and taxonomy terms after each test.
-	 */
-	public function tear_down(): void {
-		$posts = get_posts(
-			array(
-				'post_type'      => Gutenberg_Guidelines_Post_Type::POST_TYPE,
-				'post_status'    => 'any',
-				'posts_per_page' => -1,
-			)
-		);
-		foreach ( $posts as $post ) {
-			wp_delete_post( $post->ID, true );
-		}
-
-		$terms = get_terms(
-			array(
-				'taxonomy'   => Gutenberg_Guidelines_Post_Type::TAXONOMY,
-				'hide_empty' => false,
-			)
-		);
-		if ( ! is_wp_error( $terms ) ) {
-			foreach ( $terms as $term ) {
-				wp_delete_term( $term->term_id, Gutenberg_Guidelines_Post_Type::TAXONOMY );
-			}
-		}
-
-		parent::tear_down();
-	}
-
-	/**
 	 * Creates a guideline fixture owned by the named role and saved with the
 	 * given post status.
 	 *

--- a/phpunit/experimental/guidelines/guidelines-test.php
+++ b/phpunit/experimental/guidelines/guidelines-test.php
@@ -20,6 +20,7 @@ class Guidelines_Test extends WP_UnitTestCase {
 			array(
 				'artifact' => array( 'title' => 'Artifact' ),
 				'content'  => array( 'title' => 'Content' ),
+				'memory'   => array( 'title' => 'Memory' ),
 			),
 			wp_guideline_types()
 		);
@@ -28,7 +29,7 @@ class Guidelines_Test extends WP_UnitTestCase {
 	/**
 	 * The wp_guideline_types filter should be able to add new entries.
 	 */
-	public function test_filter_can_register_additional_types() {
+	public function test_types_filter_can_register_additional_types() {
 		add_filter(
 			'wp_guideline_types',
 			static function ( $types ) {
@@ -46,7 +47,7 @@ class Guidelines_Test extends WP_UnitTestCase {
 	/**
 	 * The wp_guideline_types filter should be able to remove built-in entries.
 	 */
-	public function test_filter_can_remove_default_types() {
+	public function test_types_filter_can_remove_default_types() {
 		add_filter(
 			'wp_guideline_types',
 			static function ( $types ) {

--- a/phpunit/experimental/guidelines/guidelines-test.php
+++ b/phpunit/experimental/guidelines/guidelines-test.php
@@ -8,6 +8,8 @@
  * direct unit and end-to-end through wp_set_object_terms()).
  *
  * @package gutenberg
+ *
+ * @group guidelines
  */
 class Guidelines_Test extends WP_UnitTestCase {
 


### PR DESCRIPTION
Related: #77230.

Co-authored with @artpi.

## What

Rebuild the `wp_guideline` access model so the post type can host a family of guideline kinds whose expected visibility differs by type — site-wide curation for some, private author-owned working records for others.

- Replace static post-cap aliases on the CPT with runtime capability synthesis. Administrators receive every guideline primitive; Contributor / Author / Editor get ambient `read_guidelines` and `edit_guidelines` plus CRUD on **their own private rows only**. Subscribers are blocked at the post-type door.
- Harden the REST controller: collection reads require authentication, per-item reads flow through `read_post`, which routes to the right `*_guidelines` primitive based on the row's status and ownership. Non-publishers can only set `status: private`, and creates default to `private` instead of `draft`.
- Drop the native post-type UI (`show_ui: false`); management continues to flow through the existing Settings → Guidelines page, which is already gated to Administrators via `manage_options`.
- Scope taxonomy capabilities so Contributor and above can create, rename, and assign `wp_guideline_type` terms via `edit_guidelines` (so agent flows can introduce a new type slug, e.g. `memory`, on first use). Deletion and the term-admin UI remain Administrator-only.
- Add `memory` to the default `wp_guideline_types()` registry alongside `artifact` and `content`.

## Why

Part of the broader content guidelines CPT direction (#77230). That issue establishes `wp_guideline` as the foundation for several guideline kinds — `content` for site-wide curation today, plus future additions like `skill`, `plan`, and `instruction`. Each kind has an intended visibility profile, while this PR enforces access through post status and ownership:

- **`content`** — site-wide configuration. Authenticated users with guideline read access can read it through `/wp/v2/content-guidelines`; creation, updates, deletion, and the Settings → Guidelines page remain Administrator-only via `manage_options`. This PR keeps that admin-side write and management path explicit by removing the native post-type UI.
- **`artifact`** — private working material for in-progress agent tasks: drafts, notes, sketches, intermediate outputs, or other scratchpad-style documents. Think of it as an agent sketchbook rather than durable site configuration.
- **`memory`** — (introduced here) private reusable context captured over time: useful facts about the user, site, preferences, decisions, or recurring work that an agent may want to recall in future sessions.
- Future kinds (`skill`, `plan`, `instruction`) can build on the same storage and access foundation.

This PR only prepares the storage and access model for these types. Artifacts and memories are expected to be stored as private, author-owned rows; the capability model ensures those private rows are only readable and manageable by their author or Administrators. The workflows that decide when to create, update, retrieve, or delete artifacts and memories are expected to live in abilities/integration layers built on top of the WP AI Client layer, leaving those behaviors to extenders.

The current cap mapping aliases every guideline primitive to a core post cap (`edit_posts`, `publish_posts`, …), which makes any guideline editable by anyone with `edit_posts` and readable by anyone authenticated. That doesn't support private, author-owned artifacts and memories. This PR introduces a self-contained `*_guidelines` capability namespace synthesized at runtime so each row's reach is scoped by ownership and status.

## Testing Instructions

1. As a Contributor, create a guideline via REST — should land as `private` with `post_author` set to you. Attempt `status: publish` — should return `rest_cannot_publish`.
2. As another Contributor / Author / Editor, `GET` the row above — should 403.
3. As an Administrator, the same row is readable, editable, and publishable.
4. Visit `/wp-admin/edit.php?post_type=wp_guideline` directly — should hit "Invalid post type" for every role, because the post type no longer exposes native admin screens. Use the existing Settings → Guidelines page (Administrator-only) for any admin-side management.
5. Run the full guidelines suite (requires `wp-env` running):

   ```sh
   npm run test:unit:php:base -- --group=guidelines
   ```


