### PR TITLE
Compose: Share a single change listener per MediaQueryList in useMediaQuery

### DIFF
--- a/packages/compose/src/hooks/use-media-query/index.ts
+++ b/packages/compose/src/hooks/use-media-query/index.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useSyncExternalStore } from '@wordpress/element';
+import { useSyncExternalStore } from '@wordpress/element';
 
 type MQLCache = Map< string, MediaQueryList >;
 
@@ -106,12 +106,10 @@ export default function useMediaQuery(
 	query?: string,
 	view: Window = window
 ): boolean {
-	const source = useMemo< MQLSubscriber >( () => {
-		const mediaQueryList = getMediaQueryList( view, query );
-		return mediaQueryList
-			? getSubscriber( mediaQueryList )
-			: EMPTY_SUBSCRIBER;
-	}, [ view, query ] );
+	const mediaQueryList = getMediaQueryList( view, query );
+	const source = mediaQueryList
+		? getSubscriber( mediaQueryList )
+		: EMPTY_SUBSCRIBER;
 
 	return useSyncExternalStore(
 		source.subscribe,

--- a/packages/compose/src/hooks/use-media-query/index.ts
+++ b/packages/compose/src/hooks/use-media-query/index.ts
@@ -5,7 +5,24 @@ import { useMemo, useSyncExternalStore } from '@wordpress/element';
 
 type MQLCache = Map< string, MediaQueryList >;
 
+type MQLSubscriber = {
+	subscribe: ( onStoreChange: () => void ) => () => void;
+	getValue: () => boolean;
+};
+
 const perWindowCache = new WeakMap< Window, MQLCache >();
+
+// One subscriber object per MediaQueryList, with a single underlying
+// `change` listener that fans out to all React consumers. Without this,
+// every component that calls `useMediaQuery` registers its own listener
+// on the (shared) MediaQueryList, which adds noticeable cost when many
+// components mount at once (~85 ms during a large-post editor mount).
+const subscriberCache = new WeakMap< MediaQueryList, MQLSubscriber >();
+
+const EMPTY_SUBSCRIBER: MQLSubscriber = {
+	subscribe: () => () => {},
+	getValue: () => false,
+};
 
 /**
  * A new MediaQueryList object for the media query
@@ -42,6 +59,42 @@ function getMediaQueryList(
 	return null;
 }
 
+function getSubscriber( mediaQueryList: MediaQueryList ): MQLSubscriber {
+	const cached = subscriberCache.get( mediaQueryList );
+	if ( cached ) {
+		return cached;
+	}
+
+	const listeners = new Set< () => void >();
+	const notify = () => {
+		for ( const listener of listeners ) {
+			listener();
+		}
+	};
+
+	const subscriber: MQLSubscriber = {
+		subscribe( onStoreChange ) {
+			if ( listeners.size === 0 ) {
+				// Avoid a fatal error when browsers don't support `addEventListener` on MediaQueryList.
+				mediaQueryList.addEventListener?.( 'change', notify );
+			}
+			listeners.add( onStoreChange );
+			return () => {
+				listeners.delete( onStoreChange );
+				if ( listeners.size === 0 ) {
+					mediaQueryList.removeEventListener?.( 'change', notify );
+				}
+			};
+		},
+		getValue() {
+			return mediaQueryList.matches;
+		},
+	};
+
+	subscriberCache.set( mediaQueryList, subscriber );
+	return subscriber;
+}
+
 /**
  * Runs a media query and returns its value when it changes.
  *
@@ -53,28 +106,11 @@ export default function useMediaQuery(
 	query?: string,
 	view: Window = window
 ): boolean {
-	const source = useMemo( () => {
+	const source = useMemo< MQLSubscriber >( () => {
 		const mediaQueryList = getMediaQueryList( view, query );
-
-		return {
-			subscribe( onStoreChange: any ) {
-				if ( ! mediaQueryList ) {
-					return () => {};
-				}
-
-				// Avoid a fatal error when browsers don't support `addEventListener` on MediaQueryList.
-				mediaQueryList.addEventListener?.( 'change', onStoreChange );
-				return () => {
-					mediaQueryList.removeEventListener?.(
-						'change',
-						onStoreChange
-					);
-				};
-			},
-			getValue() {
-				return mediaQueryList?.matches ?? false;
-			},
-		};
+		return mediaQueryList
+			? getSubscriber( mediaQueryList )
+			: EMPTY_SUBSCRIBER;
 	}, [ view, query ] );
 
 	return useSyncExternalStore(

--- a/packages/compose/src/hooks/use-media-query/index.ts
+++ b/packages/compose/src/hooks/use-media-query/index.ts
@@ -3,68 +3,39 @@
  */
 import { useSyncExternalStore } from '@wordpress/element';
 
-type MQLCache = Map< string, MediaQueryList >;
-
 type MQLSubscriber = {
 	subscribe: ( onStoreChange: () => void ) => () => void;
 	getValue: () => boolean;
 };
 
-const perWindowCache = new WeakMap< Window, MQLCache >();
-
-// One subscriber object per MediaQueryList, with a single underlying
-// `change` listener that fans out to all React consumers. Without this,
-// every component that calls `useMediaQuery` registers its own listener
-// on the (shared) MediaQueryList, which adds noticeable cost when many
-// components mount at once (~85 ms during a large-post editor mount).
-const subscriberCache = new WeakMap< MediaQueryList, MQLSubscriber >();
+// One subscriber per (window, query). The underlying MediaQueryList lives
+// inside the subscriber's closure; a single `change` listener fans out to
+// every React consumer via an in-JS `Set` to avoid the per-consumer
+// `addEventListener` cost (~85 ms during a large-post editor mount).
+const perWindowCache = new WeakMap< Window, Map< string, MQLSubscriber > >();
 
 const EMPTY_SUBSCRIBER: MQLSubscriber = {
 	subscribe: () => () => {},
 	getValue: () => false,
 };
 
-/**
- * A new MediaQueryList object for the media query
- *
- * @param view    Window.
- * @param [query] Media Query.
- */
-function getMediaQueryList(
-	view: Window,
-	query?: string
-): MediaQueryList | null {
-	if ( ! query ) {
-		return null;
+function getMQLSubscriber( view: Window, query?: string ): MQLSubscriber {
+	if ( ! query || typeof view?.matchMedia !== 'function' ) {
+		return EMPTY_SUBSCRIBER;
 	}
 
-	const matchMediaCache: MQLCache = perWindowCache.get( view ) ?? new Map();
-
-	if ( ! perWindowCache.has( view ) ) {
-		perWindowCache.set( view, matchMediaCache );
+	let queryCache = perWindowCache.get( view );
+	if ( ! queryCache ) {
+		queryCache = new Map();
+		perWindowCache.set( view, queryCache );
 	}
 
-	let match = matchMediaCache.get( query );
-
-	if ( match ) {
-		return match;
-	}
-
-	if ( typeof view?.matchMedia === 'function' ) {
-		match = view.matchMedia( query );
-		matchMediaCache.set( query, match );
-		return match;
-	}
-
-	return null;
-}
-
-function getSubscriber( mediaQueryList: MediaQueryList ): MQLSubscriber {
-	const cached = subscriberCache.get( mediaQueryList );
+	const cached = queryCache.get( query );
 	if ( cached ) {
 		return cached;
 	}
 
+	const mediaQueryList = view.matchMedia( query );
 	const listeners = new Set< () => void >();
 	const notify = () => {
 		for ( const listener of listeners ) {
@@ -91,7 +62,7 @@ function getSubscriber( mediaQueryList: MediaQueryList ): MQLSubscriber {
 		},
 	};
 
-	subscriberCache.set( mediaQueryList, subscriber );
+	queryCache.set( query, subscriber );
 	return subscriber;
 }
 
@@ -106,10 +77,7 @@ export default function useMediaQuery(
 	query?: string,
 	view: Window = window
 ): boolean {
-	const mediaQueryList = getMediaQueryList( view, query );
-	const source = mediaQueryList
-		? getSubscriber( mediaQueryList )
-		: EMPTY_SUBSCRIBER;
+	const source = getMQLSubscriber( view, query );
 
 	return useSyncExternalStore(
 		source.subscribe,


### PR DESCRIPTION
## What?
Share one `change` listener per `MediaQueryList` across all `useMediaQuery` consumers, instead of one per consumer.

## Why?
Each consumer was attaching its own listener via `useSyncExternalStore`. `useViewportMatch` is used in ~24 editor/library components, so a large-post mount registers many listeners on the same MQL — each one a JS↔C++ boundary crossing. Trace shows **494 `addEventListener` samples (~85 ms)** during the React commit under `subscribe @ compose`.

## How?
`WeakMap<Window, Map<string, MQLSubscriber>>` keyed by `(view, query)`. The subscriber owns one underlying listener that fans out to an in-JS `Set` of React callbacks; attach on first subscriber, detach on last. Stable identities from the cache let the `useMemo` go too.

## Perf (CI, post-editor)
| metric | PR | trunk | Δ |
|---|---|---|---|
| **firstBlock** | 3480.5 ms | 3605.15 ms | **−3.46%** |
| firstContentfulPaint | 1520.7 ms | 1578.05 ms | −3.63% |

## Testing
1. `npm run test:unit -- packages/compose/src/hooks/use-media-query/`
2. Verify breakpoint-driven UI (toolbar collapse, mobile inserter, sidebar) still responds to viewport changes.

## Use of AI Tools
Authored with Claude Code assistance; reviewed and verified by the author.