### PR TITLE
Collab Sidebar: Swap near-identical pink for red in avatar palette

### DIFF
--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -23,7 +23,7 @@ const OVERLAP_MARGIN = 20;
  */
 const AVATAR_BORDER_COLORS = [
 	'#C36EFF', // Purple
-	'#FF51A8', // Pink
+	'#D94145', // Red
 	'#E4780A', // Orange
 	'#FF35EE', // Magenta
 	'#879F11', // Olive


### PR DESCRIPTION
## What

Replaces slot 1 of `AVATAR_BORDER_COLORS` in `packages/editor/src/components/collab-sidebar/utils.js`:

| Slot | Before | After |
|:----:|:-------|:------|
| 1    | `#FF51A8` (Pink) | **`#D94145` (Red)** |

The other six hues are unchanged.

## Why

The 7-color palette used to tint per-user avatar borders — and, after #78218, inline-note highlights — contained two perceptually near-identical hues:

- Slot 1: `#FF51A8` (Pink) — user ids 1, 8, 15, …
- Slot 3: `#FF35EE` (Magenta) — user ids 3, 10, 17, …

In real-world editing sessions with low single-digit user ids (the common case), two different users routinely looked like they shared a color. Issue #78255 has the full background, palette card, and reproduction steps.

This swap follows the design direction from @jasmussen in https://github.com/WordPress/gutenberg/issues/78255#issuecomment-4448232189: a slightly more vibrant red (`#D94145`) than the original suggestion in the issue. Replacing slot 1 (Pink) rather than slot 3 (Magenta) keeps the remaining palette farthest from the new red.

## How to test

1. Open a post with the Notes / collab sidebar feature enabled.
2. Leave notes as user id 1 (e.g. `admin`) and user id 3 (e.g. `guest`).
3. In the **All notes** sidebar, confirm:
   - User id 1's avatar border / note highlight is now red (`#D94145`)
   - User id 3's is still magenta (`#FF35EE`)
   - The two are clearly distinguishable at a glance, on both light and dark canvases.

## Notes

Deliberately minimal — moving fast as suggested in the linked comment. The palette is not a public API and can be refined further in follow-ups. The broader test-coverage tasks listed in #78255 (unit tests for `getAvatarBorderColor` / `buildHighlightCss` across user ids 1–10, E2E sweep, Storybook swatch entry) are out of scope for this swap and can land separately.

Fixes #78255.