### PR TITLE
UI Button: Optimize overflow styles

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Enhancements
 
+-   `Button`: Allow long labels to wrap within constrained containers ([#78300](https://github.com/WordPress/gutenberg/pull/78300)).
 -   `Select`: Add a `placeholder` prop to `Select.Trigger`, and support `null` item values for clearable placeholder options ([#78076](https://github.com/WordPress/gutenberg/pull/78076)).
 -   `Drawer`: Fade the popup elevation shadow alongside the slide ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).
 -   `Drawer`: Allow mouse-drag swipe-dismiss in the popup-edge padding gutter ([#77800](https://github.com/WordPress/gutenberg/pull/77800)).

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -95,7 +95,7 @@ export const AllTonesAndVariants: Story = {
 		<div
 			style={ {
 				display: 'grid',
-				gridTemplateColumns: 'max-content repeat(2, min-content)',
+				gridTemplateColumns: 'max-content repeat(2, max-content)',
 				color: 'var(--wpds-color-fg-content-neutral)',
 			} }
 		>

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -17,6 +17,7 @@
 		--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-brand-strong);
 		--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-brand-strong-active);
 		--wp-ui-button-foreground-color-disabled: var(--wpds-color-fg-interactive-neutral-strong-disabled);
+		--wp-ui-button-padding-block: var(--wpds-dimension-padding-xs);
 		--wp-ui-button-padding-inline: var(--wpds-dimension-padding-md);
 		--wp-ui-button-height: 40px;
 		--wp-ui-button-aspect-ratio: auto; /* Useful for overrides such as icon buttons */
@@ -42,6 +43,7 @@
 		min-width: var(--wp-ui-button-min-width);
 		max-width: 100%;
 		min-height: var(--wp-ui-button-height);
+		padding-block: var(--wp-ui-button-padding-block);
 		padding-inline: var(--wp-ui-button-padding-inline);
 		border-style: solid;
 		border-width: 1px;
@@ -132,6 +134,7 @@
 	}
 
 	.is-small {
+		--wp-ui-button-padding-block: 0;
 		--wp-ui-button-padding-inline: var(--wpds-dimension-padding-sm);
 		--wp-ui-button-height: 24px;
 	}

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -40,7 +40,8 @@
 		gap: var(--wpds-dimension-gap-sm);
 		aspect-ratio: var(--wp-ui-button-aspect-ratio);
 		min-width: var(--wp-ui-button-min-width);
-		height: var(--wp-ui-button-height);
+		max-width: 100%;
+		min-height: var(--wp-ui-button-height);
 		padding-inline: var(--wp-ui-button-padding-inline);
 		border-style: solid;
 		border-width: 1px;
@@ -52,8 +53,10 @@
 		font-size: var(--wp-ui-button-font-size);
 		font-weight: var(--wp-ui-button-font-weight);
 		line-height: var(--wpds-typography-line-height-sm);
+		text-align: center;
 		text-decoration: none;
 		color: var(--wp-ui-button-foreground-color);
+		overflow-wrap: anywhere;
 		cursor: var(--wpds-cursor-control);
 
 		@media not ( prefers-reduced-motion ) {


### PR DESCRIPTION
## What?

Updates the `@wordpress/ui` Button styles so long labels degrade more gracefully in constrained layouts.

## Why?

Button labels are important for usability, so when labels are longer than expected, for example due to translations or unbroken words, the component should preserve readable text instead of overflowing its container.

`Button` in `@wordpress/components` had inconsistent and suboptimal default wrapping issues which we tried to fix (#73711 #76071), but basically had to give up due to breakage risk. Given the high usage of this component, even in the `@wordpress/ui` where back compat is not a must, we should try to set a robust default before starting widespread adoption.

## How?

- Replaces the fixed button height with a `min-height` so wrapped labels can increase the button height.
- Caps the button at `max-width: 100%` so it respects constrained containers.
- Centers multi-line label text.
- Uses `overflow-wrap: anywhere` so long unbroken labels can wrap instead of overflowing.

## Testing Instructions

1. Run `npm run storybook:e2e:dev`.
2. Open `Design System/Components/Button/Text Overflow`.
3. Confirm the long button label remains visible across constrained container examples.
4. Confirm regular Button examples still render with their expected height and alignment for single-line labels.

## Screenshots or screencast

| Before | After |
|--------|-------|
|<img width="2548" height="940" alt="Overflow tests, before" src="https://github.com/user-attachments/assets/71e1798d-7a67-40fc-a240-129e98b10928" />|<img width="2548" height="1632" alt="Overflow tests, after" src="https://github.com/user-attachments/assets/5b8357d6-ff13-4f34-97a9-6073aea9edb6" />|

