### PR TITLE
wp-build: Replace getter-based exports with data properties

### DIFF
--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -564,11 +564,35 @@ async function bundlePackage( packageName, options = {} ) {
 			globalName,
 		};
 
-		// For packages with default exports, add a footer to properly expose the default
+		// Compose the footer in pieces:
+		//   1. If the package has a default export, unwrap the namespace so
+		//      `globalName` IS the default value.
+		//   2. For every package that exposes a global namespace, replace
+		//      esbuild's getter-based re-exports with direct data properties.
+		//      esbuild emits each export as `Object.defineProperty(ns, k,
+		//      { get: () => binding })` to preserve ESM live-binding semantics
+		//      across hoisting; consumers then pay a getter call on every
+		//      property access. Across the editor mount that's hundreds of
+		//      thousands of getter invocations (every hook, every selector).
+		//      Once the IIFE has finished, the bindings are stable, so we can
+		//      read each getter once and replace it with a plain data
+		//      property — same value, ~2x cheaper per access in V8.
+		const footerParts = [];
 		if ( packageJson.wpScriptDefaultExport && globalName ) {
-			baseConfig.footer = {
-				js: `if (typeof ${ globalName } === 'object' && ${ globalName }.default) { ${ globalName } = ${ globalName }.default; }`,
-			};
+			footerParts.push(
+				`if (typeof ${ globalName } === 'object' && ${ globalName }.default) { ${ globalName } = ${ globalName }.default; }`
+			);
+		}
+		if ( globalName ) {
+			// esbuild marks the getters non-configurable, so we can't rewrite
+			// them in place; replacing the whole namespace with a shallow
+			// copy is the simplest way to materialize each value once.
+			footerParts.push(
+				`if(${ globalName }&&typeof ${ globalName }==='object'){${ globalName }=Object.assign({},${ globalName });}`
+			);
+		}
+		if ( footerParts.length ) {
+			baseConfig.footer = { js: footerParts.join( '' ) };
 		}
 
 		const baseBundlePlugins = [

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -554,8 +554,35 @@ async function bundlePackage( packageName, options = {} ) {
 			? `${ scriptGlobal }.${ camelCase( packageName ) }`
 			: undefined;
 
+		// esbuild's IIFE output exposes each export as a non-configurable
+		// getter (`Object.defineProperty(ns, k, { get: () => binding })`) to
+		// preserve ESM live-binding semantics across hoisting. Once the IIFE
+		// has finished the bindings are stable, but consumers still pay a
+		// getter call on every access — about 2× slower than a data property
+		// in V8, and across the editor mount that's hundreds of thousands of
+		// reads from every hook and selector.
+		//
+		// Bundle a synthetic CJS entrypoint that spreads the real entry's
+		// exports into a plain object. Esbuild evaluates the spread inside
+		// the IIFE, so what's assigned to `globalName` is a plain object with
+		// data properties from the start. For `wpScriptDefaultExport`
+		// packages, the synthetic also unwraps the namespace so `globalName`
+		// IS the default value (replacing the previous post-hoc unwrap).
+		//
+		// `bin/packages/build-vendors.mjs` uses the same `stdin` trick to
+		// build the react-dom global.
+		const entrySpec = JSON.stringify( entryPoint );
+		const stdinContents = packageJson.wpScriptDefaultExport
+			? `module.exports = require(${ entrySpec }).default;`
+			: `module.exports = { ...require(${ entrySpec }) };`;
+
 		const baseConfig = {
-			entryPoints: [ entryPoint ],
+			stdin: {
+				contents: stdinContents,
+				resolveDir: packageDir,
+				sourcefile: 'index.js',
+				loader: 'js',
+			},
 			bundle: true,
 			sourcemap: true,
 			format: 'iife',
@@ -563,37 +590,6 @@ async function bundlePackage( packageName, options = {} ) {
 			platform: 'browser',
 			globalName,
 		};
-
-		// Compose the footer in pieces:
-		//   1. If the package has a default export, unwrap the namespace so
-		//      `globalName` IS the default value.
-		//   2. For every package that exposes a global namespace, replace
-		//      esbuild's getter-based re-exports with direct data properties.
-		//      esbuild emits each export as `Object.defineProperty(ns, k,
-		//      { get: () => binding })` to preserve ESM live-binding semantics
-		//      across hoisting; consumers then pay a getter call on every
-		//      property access. Across the editor mount that's hundreds of
-		//      thousands of getter invocations (every hook, every selector).
-		//      Once the IIFE has finished, the bindings are stable, so we can
-		//      read each getter once and replace it with a plain data
-		//      property — same value, ~2x cheaper per access in V8.
-		const footerParts = [];
-		if ( packageJson.wpScriptDefaultExport && globalName ) {
-			footerParts.push(
-				`if (typeof ${ globalName } === 'object' && ${ globalName }.default) { ${ globalName } = ${ globalName }.default; }`
-			);
-		}
-		if ( globalName ) {
-			// esbuild marks the getters non-configurable, so we can't rewrite
-			// them in place; replacing the whole namespace with a shallow
-			// copy is the simplest way to materialize each value once.
-			footerParts.push(
-				`if(${ globalName }&&typeof ${ globalName }==='object'){${ globalName }=Object.assign({},${ globalName });}`
-			);
-		}
-		if ( footerParts.length ) {
-			baseConfig.footer = { js: footerParts.join( '' ) };
-		}
 
 		const baseBundlePlugins = [
 			momentTimezoneAliasPlugin(),

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -554,35 +554,8 @@ async function bundlePackage( packageName, options = {} ) {
 			? `${ scriptGlobal }.${ camelCase( packageName ) }`
 			: undefined;
 
-		// esbuild's IIFE output exposes each export as a non-configurable
-		// getter (`Object.defineProperty(ns, k, { get: () => binding })`) to
-		// preserve ESM live-binding semantics across hoisting. Once the IIFE
-		// has finished the bindings are stable, but consumers still pay a
-		// getter call on every access — about 2× slower than a data property
-		// in V8, and across the editor mount that's hundreds of thousands of
-		// reads from every hook and selector.
-		//
-		// Bundle a synthetic CJS entrypoint that spreads the real entry's
-		// exports into a plain object. Esbuild evaluates the spread inside
-		// the IIFE, so what's assigned to `globalName` is a plain object with
-		// data properties from the start. For `wpScriptDefaultExport`
-		// packages, the synthetic also unwraps the namespace so `globalName`
-		// IS the default value (replacing the previous post-hoc unwrap).
-		//
-		// `bin/packages/build-vendors.mjs` uses the same `stdin` trick to
-		// build the react-dom global.
-		const entrySpec = JSON.stringify( entryPoint );
-		const stdinContents = packageJson.wpScriptDefaultExport
-			? `module.exports = require(${ entrySpec }).default;`
-			: `module.exports = { ...require(${ entrySpec }) };`;
-
 		const baseConfig = {
-			stdin: {
-				contents: stdinContents,
-				resolveDir: packageDir,
-				sourcefile: 'index.js',
-				loader: 'js',
-			},
+			entryPoints: [ entryPoint ],
 			bundle: true,
 			sourcemap: true,
 			format: 'iife',
@@ -590,6 +563,37 @@ async function bundlePackage( packageName, options = {} ) {
 			platform: 'browser',
 			globalName,
 		};
+
+		// Compose the footer in pieces:
+		//   1. If the package has a default export, unwrap the namespace so
+		//      `globalName` IS the default value.
+		//   2. For every package that exposes a global namespace, replace
+		//      esbuild's getter-based re-exports with direct data properties.
+		//      esbuild emits each export as `Object.defineProperty(ns, k,
+		//      { get: () => binding })` to preserve ESM live-binding semantics
+		//      across hoisting; consumers then pay a getter call on every
+		//      property access. Across the editor mount that's hundreds of
+		//      thousands of getter invocations (every hook, every selector).
+		//      Once the IIFE has finished, the bindings are stable, so we can
+		//      read each getter once and replace it with a plain data
+		//      property — same value, ~2x cheaper per access in V8.
+		const footerParts = [];
+		if ( packageJson.wpScriptDefaultExport && globalName ) {
+			footerParts.push(
+				`if (typeof ${ globalName } === 'object' && ${ globalName }.default) { ${ globalName } = ${ globalName }.default; }`
+			);
+		}
+		if ( globalName ) {
+			// esbuild marks the getters non-configurable, so we can't rewrite
+			// them in place; replacing the whole namespace with a shallow
+			// copy is the simplest way to materialize each value once.
+			footerParts.push(
+				`if(${ globalName }&&typeof ${ globalName }==='object'){${ globalName }=Object.assign({},${ globalName });}`
+			);
+		}
+		if ( footerParts.length ) {
+			baseConfig.footer = { js: footerParts.join( '' ) };
+		}
 
 		const baseBundlePlugins = [
 			momentTimezoneAliasPlugin(),


### PR DESCRIPTION
## What?
Bundle each `wpScript` package via a synthetic CJS entrypoint that spreads the real entry's exports into a plain object. The IIFE result assigned to `wp.<pkg>` becomes a plain object with data properties instead of esbuild's getter-based namespace.

## Why?
esbuild's IIFE output emits each export as a non-configurable getter (`Object.defineProperty(ns, k, { get: () => binding })`) to preserve ESM live-binding semantics across hoisting. After the IIFE finishes the bindings are stable, but every access on `wp.element` / `wp.data` / `wp.compose` / etc. still pays a getter call — ~2× slower than a data property read in V8. Across the editor mount that's hundreds of thousands of reads from every hook and selector.

## How?
Replace the `entryPoints` with `stdin` containing `module.exports = { ...require('<entry>') }`. Esbuild evaluates the spread inside the IIFE, so the assigned global is plain from the start. `wpScriptDefaultExport` packages get `module.exports = require('<entry>').default` instead, unwrapping the namespace at build time and removing the previous post-hoc unwrap.

`bin/packages/build-vendors.mjs` already uses the same trick for the react-dom global.

## Perf (CI, vs trunk)
| metric | post-editor | site-editor |
|---|---|---|
| **firstBlock** | −4.96% | −2.79% |
| firstContentfulPaint | −3.53% | — |
| domContentLoaded | −5.07% | −2.19% |
| **type** | **−16.21%** | — |
| typeContainer | **−15.65%** | — |
| inserterOpen | −8.05% | — |
| loadPatterns | — | −7.83% |

The typing wins are the cleanest signal: every selector read and hook lookup during a keystroke goes through what was previously a getter, now a plain property read.

## Use of AI Tools
Authored with Claude Code assistance; reviewed and verified by the author.