### PR TITLE
Perf tests: Measure firstBlock from iframe FCP, not DOM probe

### DIFF
--- a/packages/e2e-test-utils-playwright/src/metrics/index.ts
+++ b/packages/e2e-test-utils-playwright/src/metrics/index.ts
@@ -162,6 +162,86 @@ export class Metrics {
 	}
 
 	/**
+	 * Waits until the editor canvas iframe (or the top frame, when the
+	 * canvas is rendered inline) reports a `first-contentful-paint` entry.
+	 * Polls the iframe's `performance.getEntriesByName('first-contentful-paint')`
+	 * via `Page.waitForFunction`, so the wait completes the moment the
+	 * browser stamps FCP — not when the DOM contains a probe element.
+	 *
+	 * @return Promise resolving once FCP has fired in the editor canvas.
+	 */
+	async waitForEditorFirstContentfulPaint(): Promise< void > {
+		await this.page.waitForFunction( () => {
+			const iframe = document.querySelector< HTMLIFrameElement >(
+				'iframe[name="editor-canvas"]'
+			);
+			const target = iframe?.contentWindow ?? window;
+			try {
+				return (
+					target.performance?.getEntriesByName(
+						'first-contentful-paint'
+					).length > 0
+				);
+			} catch {
+				return false;
+			}
+		} );
+	}
+
+	/**
+	 * Returns the time, in milliseconds, from when the navigation response
+	 * finished arriving until the editor canvas first painted contentful
+	 * pixels. Bridges the top frame's and the iframe's clocks via their
+	 * absolute `timeOrigin`s.
+	 *
+	 * Reads the browser's `firstContentfulPaint` paint-timing entry directly
+	 * rather than measuring `performance.now()` after `locator.waitFor()`
+	 * resolves, which removes Playwright's polling jitter and the JS event
+	 * loop delay between paint and the test runner's read.
+	 *
+	 * Falls back to the top frame's FCP when the editor canvas is rendered
+	 * inline (non-iframed).
+	 *
+	 * @return Duration in ms, or null when no paint entry is available.
+	 */
+	async getFirstBlockTime(): Promise< number | null > {
+		const topResponseEndAbs = await this.page.evaluate( () => {
+			const [ nav ] = performance.getEntriesByType(
+				'navigation'
+			) as PerformanceNavigationTiming[];
+			if ( ! nav ) {
+				return null;
+			}
+			return performance.timeOrigin + nav.responseEnd;
+		} );
+		if ( topResponseEndAbs === null ) {
+			return null;
+		}
+
+		const editorFrame = this.page
+			.frames()
+			.find( ( frame ) => frame.name() === 'editor-canvas' );
+		const targetFrame = editorFrame ?? this.page.mainFrame();
+
+		const fcpAbs: number | null = await targetFrame.evaluate( () => {
+			const fcp = (
+				performance.getEntriesByType( 'paint' ) as
+					| PerformancePaintTiming[]
+					| undefined
+			 )?.find( ( entry ) => entry.name === 'first-contentful-paint' );
+			if ( ! fcp ) {
+				return null;
+			}
+			return performance.timeOrigin + fcp.startTime;
+		} );
+		if ( fcpAbs === null ) {
+			return null;
+		}
+
+		return fcpAbs - topResponseEndAbs;
+	}
+
+	/**
 	 * Returns the loading durations using the Navigation Timing API. All the
 	 * durations exclude the server response time.
 	 *

--- a/packages/e2e-test-utils-playwright/src/metrics/index.ts
+++ b/packages/e2e-test-utils-playwright/src/metrics/index.ts
@@ -3,7 +3,7 @@
  */
 import { mkdir, writeFile } from 'fs/promises';
 import { join } from 'path';
-import type { Page, Browser } from '@playwright/test';
+import type { Page, Browser, Frame } from '@playwright/test';
 // resolution-mode support in TypeScript 5.3 will resolve this.
 // See https://devblogs.microsoft.com/typescript/announcing-typescript-5-3-beta/
 // @ts-expect-error
@@ -183,13 +183,12 @@ export class Metrics {
 			return performance.timeOrigin + nav.responseEnd;
 		} );
 
-		const iframeHandle = await this.page.waitForSelector(
-			'iframe[name="editor-canvas"]'
-		);
-		const frame = await iframeHandle.contentFrame();
-		if ( ! frame ) {
-			throw new Error( 'Editor canvas iframe could not be entered.' );
-		}
+		const isEditorCanvas = ( f: Frame ) => f.name() === 'editor-canvas';
+		const frame =
+			this.page.frames().find( isEditorCanvas ) ??
+			( await this.page.waitForEvent( 'frameattached', {
+				predicate: isEditorCanvas,
+			} ) );
 		const fcpAbs = await frame.evaluate(
 			() =>
 				new Promise< number >( ( resolve, reject ) => {

--- a/packages/e2e-test-utils-playwright/src/metrics/index.ts
+++ b/packages/e2e-test-utils-playwright/src/metrics/index.ts
@@ -162,82 +162,69 @@ export class Metrics {
 	}
 
 	/**
-	 * Waits until the editor canvas iframe (or the top frame, when the
-	 * canvas is rendered inline) reports a `first-contentful-paint` entry.
-	 * Polls the iframe's `performance.getEntriesByName('first-contentful-paint')`
-	 * via `Page.waitForFunction`, so the wait completes the moment the
-	 * browser stamps FCP — not when the DOM contains a probe element.
+	 * Waits for the editor canvas iframe's first contentful paint and
+	 * returns its time, in milliseconds, from the top frame's response end.
 	 *
-	 * @return Promise resolving once FCP has fired in the editor canvas.
+	 * Event-driven via a `PerformanceObserver` inside the iframe whose
+	 * Promise is awaited directly through `frame.evaluate()` — no polling,
+	 * no DOM probe wait. Throws if FCP fires before any `.wp-block` is in
+	 * the iframe DOM, since the metric would otherwise silently measure a
+	 * paint of something other than the block tree (e.g., a placeholder).
+	 *
+	 * The two frames' clocks are bridged via their absolute `timeOrigin`s.
+	 *
+	 * @return Duration in ms.
 	 */
-	async waitForEditorFirstContentfulPaint(): Promise< void > {
-		await this.page.waitForFunction( () => {
-			const iframe = document.querySelector< HTMLIFrameElement >(
-				'iframe[name="editor-canvas"]'
-			);
-			const target = iframe?.contentWindow ?? window;
-			try {
-				return (
-					target.performance?.getEntriesByName(
-						'first-contentful-paint'
-					).length > 0
-				);
-			} catch {
-				return false;
-			}
-		} );
-	}
-
-	/**
-	 * Returns the time, in milliseconds, from when the navigation response
-	 * finished arriving until the editor canvas first painted contentful
-	 * pixels. Bridges the top frame's and the iframe's clocks via their
-	 * absolute `timeOrigin`s.
-	 *
-	 * Reads the browser's `firstContentfulPaint` paint-timing entry directly
-	 * rather than measuring `performance.now()` after `locator.waitFor()`
-	 * resolves, which removes Playwright's polling jitter and the JS event
-	 * loop delay between paint and the test runner's read.
-	 *
-	 * Falls back to the top frame's FCP when the editor canvas is rendered
-	 * inline (non-iframed).
-	 *
-	 * @return Duration in ms, or null when no paint entry is available.
-	 */
-	async getFirstBlockTime(): Promise< number | null > {
+	async getFirstBlockTime(): Promise< number > {
 		const topResponseEndAbs = await this.page.evaluate( () => {
 			const [ nav ] = performance.getEntriesByType(
 				'navigation'
 			) as PerformanceNavigationTiming[];
-			if ( ! nav ) {
-				return null;
-			}
 			return performance.timeOrigin + nav.responseEnd;
 		} );
-		if ( topResponseEndAbs === null ) {
-			return null;
+
+		const iframeHandle = await this.page.waitForSelector(
+			'iframe[name="editor-canvas"]'
+		);
+		const frame = await iframeHandle.contentFrame();
+		if ( ! frame ) {
+			throw new Error( 'Editor canvas iframe could not be entered.' );
 		}
-
-		const editorFrame = this.page
-			.frames()
-			.find( ( frame ) => frame.name() === 'editor-canvas' );
-		const targetFrame = editorFrame ?? this.page.mainFrame();
-
-		const fcpAbs: number | null = await targetFrame.evaluate( () => {
-			const fcp = (
-				performance.getEntriesByType( 'paint' ) as
-					| PerformancePaintTiming[]
-					| undefined
-			 )?.find( ( entry ) => entry.name === 'first-contentful-paint' );
-			if ( ! fcp ) {
-				return null;
-			}
-			return performance.timeOrigin + fcp.startTime;
-		} );
-		if ( fcpAbs === null ) {
-			return null;
-		}
-
+		const fcpAbs = await frame.evaluate(
+			() =>
+				new Promise< number >( ( resolve, reject ) => {
+					function emit( startTime: number ): void {
+						if ( ! document.querySelector( '.wp-block' ) ) {
+							reject(
+								new Error(
+									'Editor canvas FCP fired before any `.wp-block` was rendered — the metric would no longer measure the block paint moment.'
+								)
+							);
+							return;
+						}
+						resolve( performance.timeOrigin + startTime );
+					}
+					const existing = performance
+						.getEntriesByName( 'first-contentful-paint' )
+						.at( 0 );
+					if ( existing ) {
+						emit( existing.startTime );
+						return;
+					}
+					new PerformanceObserver( ( list, observer ) => {
+						const fcp = list
+							.getEntries()
+							.find(
+								( entry ) =>
+									entry.name === 'first-contentful-paint'
+							);
+						if ( fcp ) {
+							observer.disconnect();
+							emit( fcp.startTime );
+						}
+					} ).observe( { type: 'paint', buffered: true } );
+				} )
+		);
 		return fcpAbs - topResponseEndAbs;
 	}
 

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -78,14 +78,14 @@ test.describe( 'Post Editor Performance', () => {
 				// Wait for the editor canvas iframe's first-contentful-paint
 				// entry. This is the moment the browser actually painted the
 				// block tree, without the DOM-probe-vs-paint race or polling
-				// jitter of a `.wp-block` locator wait.
-				await metrics.waitForEditorFirstContentfulPaint();
+				// jitter of a `.wp-block` locator wait. Throws if FCP fires
+				// before any `.wp-block` is in the iframe DOM.
+				const firstBlockTime = await metrics.getFirstBlockTime();
 
 				// Capture timing metrics before `stopTracing()`, which
 				// blocks for the trace download/parse and would otherwise
 				// inflate timings by seconds.
 				const loadingDurations = await metrics.getLoadingDurations();
-				const firstBlockTime = await metrics.getFirstBlockTime();
 
 				// Stop tracing. Save just one representative sample.
 				await metrics.stopTracing(

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -67,7 +67,6 @@ test.describe( 'Post Editor Performance', () => {
 		for ( let i = 1; i <= iterations; i++ ) {
 			test( `Run the test (${ i } of ${ iterations })`, async ( {
 				admin,
-				perfUtils,
 				metrics,
 			} ) => {
 				// Start tracing before navigating so the page load is captured.
@@ -75,15 +74,18 @@ test.describe( 'Post Editor Performance', () => {
 
 				// Open the test draft.
 				await admin.editPost( draftId );
-				const canvas = await perfUtils.getCanvas();
 
-				// Wait for the first block.
-				await canvas.locator( '.wp-block' ).first().waitFor();
+				// Wait for the editor canvas iframe's first-contentful-paint
+				// entry. This is the moment the browser actually painted the
+				// block tree, without the DOM-probe-vs-paint race or polling
+				// jitter of a `.wp-block` locator wait.
+				await metrics.waitForEditorFirstContentfulPaint();
 
 				// Capture timing metrics before `stopTracing()`, which
 				// blocks for the trace download/parse and would otherwise
-				// inflate `timeSinceResponseEnd` by seconds.
+				// inflate timings by seconds.
 				const loadingDurations = await metrics.getLoadingDurations();
+				const firstBlockTime = await metrics.getFirstBlockTime();
 
 				// Stop tracing. Save just one representative sample.
 				await metrics.stopTracing(
@@ -96,12 +98,14 @@ test.describe( 'Post Editor Performance', () => {
 					Object.entries( loadingDurations ).forEach(
 						( [ metric, duration ] ) => {
 							if ( metric === 'timeSinceResponseEnd' ) {
-								results.firstBlock.push( duration );
-							} else {
-								results[ metric ].push( duration );
+								return;
 							}
+							results[ metric ].push( duration );
 						}
 					);
+					if ( firstBlockTime !== null ) {
+						results.firstBlock.push( firstBlockTime );
+					}
 
 					const serverTiming = await metrics.getServerTiming();
 


### PR DESCRIPTION
## What?
Replace the `.wp-block` `waitFor()` + `timeSinceResponseEnd` pattern for `firstBlock` with the editor canvas iframe's `first-contentful-paint` PerformanceEntry, captured event-driven via `PerformanceObserver` and bridged to Node through `frame.evaluate()`.

## Why?
The current metric is bounded by Playwright's polling resolution (~50 ms) and the JS event-loop delay between paint and the test runner's read. That noise floor masks commit-time savings of similar size — e.g., #78302's collaborators-overlay fix removes a 64 ms forced Layout that lands fully before FCP, but the `firstBlock` delta in CI is lost in variance.

The iframe's `firstContentfulPaint` entry is stamped by the browser at the actual paint moment (confirmed in the trace: it fires immediately after the Paint frame, with a 154 KB LCP candidate = the block tree).

## How?
- Add `getFirstBlockTime()` on `Metrics`: awaits the editor canvas iframe via `page.on('frameattached')` (event-driven, no DOM polling), runs a `PerformanceObserver` inside the iframe, resolves the Promise the observer's callback creates — read directly through `frame.evaluate()`. Bridges the iframe's `timeOrigin` to the top frame's `responseEnd` so the returned value is in the same clock as the other loading metrics.
- Asserts that `.wp-block` is in the iframe DOM at FCP time. If a future change ever paints contentful pixels in the iframe before any block renders (placeholder, "Loading…", theme chrome), the test fails loud rather than silently measuring the wrong moment.
- Switch the post-editor Loading test to use it. Leave the site-editor test alone — its non-emptytheme runs paint theme chrome before user blocks, so iframe FCP and "first block visible" diverge there.

## Testing
1. Run `bin/plugin/cli.js perf HEAD trunk`; `firstBlock` should land near current trunk's median with a tighter q25–q75 spread.
2. The metric should now be sensitive to commit-time work (verify by comparing #78302's CI with/without this change).

## Use of AI Tools
Authored with Claude Code assistance; reviewed and verified by the author.