### PR TITLE
Editor: Inline text editor toolbar z-index

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   Remove the following entries from the `z-index()` helper ([#77753](https://github.com/WordPress/gutenberg/pull/77753), [#77759](https://github.com/WordPress/gutenberg/pull/77759), [#77772](https://github.com/WordPress/gutenberg/pull/77772), [#77806](https://github.com/WordPress/gutenberg/pull/77806), [#77807](https://github.com/WordPress/gutenberg/pull/77807), [#77808](https://github.com/WordPress/gutenberg/pull/77808), [#78180](https://github.com/WordPress/gutenberg/pull/78180), [#78181](https://github.com/WordPress/gutenberg/pull/78181)):
+-   Remove the following entries from the `z-index()` helper ([#77753](https://github.com/WordPress/gutenberg/pull/77753), [#77759](https://github.com/WordPress/gutenberg/pull/77759), [#77772](https://github.com/WordPress/gutenberg/pull/77772), [#77806](https://github.com/WordPress/gutenberg/pull/77806), [#77807](https://github.com/WordPress/gutenberg/pull/77807), [#77808](https://github.com/WordPress/gutenberg/pull/77808), [#78180](https://github.com/WordPress/gutenberg/pull/78180), [#78181](https://github.com/WordPress/gutenberg/pull/78181), [#78309](https://github.com/WordPress/gutenberg/pull/78309)):
     -   `.block-editor-block-manager__category-title`
     -   `.block-editor-block-manager__disabled-blocks-count`
     -   `.block-library-query-pattern__selection-search`
@@ -20,6 +20,7 @@
     -   `.editor-post-template__swap-template-search`
     -   `.editor-start-page-options__modal__actions`
     -   `.editor-start-template-options__modal__actions`
+    -   `.editor-text-editor__toolbar`
     -   `.wp-block-cover__image-background`
     -   `.wp-block-cover__inner-container`
     -   `.wp-block-cover__video-background`

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -6,7 +6,6 @@
 
 $z-layers: (
 	".block-editor-block-list__block.is-selected": 20,
-	".editor-text-editor__toolbar": 1,
 
 	".components-modal__header": 10,
 	".edit-post-layout__footer": 30,

--- a/packages/editor/src/components/text-editor/style.scss
+++ b/packages/editor/src/components/text-editor/style.scss
@@ -6,6 +6,7 @@
 .editor-text-editor {
 	@include reset;
 	position: relative;
+	isolation: isolate;
 	width: 100%;
 	background-color: $white;
 	flex-grow: 1;

--- a/packages/editor/src/components/text-editor/style.scss
+++ b/packages/editor/src/components/text-editor/style.scss
@@ -2,7 +2,6 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables" as *;
-@use "@wordpress/base-styles/z-index" as *;
 
 .editor-text-editor {
 	@include reset;
@@ -53,7 +52,7 @@
 // Exit code editor toolbar.
 .editor-text-editor__toolbar {
 	position: sticky;
-	z-index: z-index(".editor-text-editor__toolbar");
+	z-index: 1;
 	top: 0;
 	left: 0;
 	right: 0;


### PR DESCRIPTION
## What?

Inlines the text editor toolbar z-index value and removes the now-unused shared z-index map entry.

## Why?

This z-index is only used by the text editor toolbar, so keeping it in the shared z-index map adds indirection without coordinating with other layers.

## How?

- Removes the `editor-text-editor__toolbar` entry from the shared z-index map.
- Replaces the Sass z-index helper call with `z-index: 1` in the text editor stylesheet.
- Adds `isolation: isolate` to the text editor wrapper so the toolbar's z-index is scoped to the text editor.

## Testing Instructions

1. Open a post or page in the editor.
2. Switch to the code editor.
3. Scroll the editor content.
4. Confirm that the "Editing code" toolbar remains sticky at the top and appears above the raw title/content fields.

## Screenshots or screencast

<img width="777" height="314" alt="editor toolbar" src="https://github.com/user-attachments/assets/ef42ad80-9db0-4eb5-a9a3-dcddca2ef629" />