### PR TITLE
Automated Testing: Fix and use built-in mechanism for flagging unused disables

### DIFF
--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -295,8 +295,6 @@ function ResizableFrame( {
 				[ isRTL() ? 'right' : 'left' ]: canvas === 'view' && (
 					<>
 						<WCTooltip text={ __( 'Drag to resize' ) }>
-							{ /* Disable reason: role="separator" does in fact support aria-valuenow */ }
-							{ /* eslint-disable-next-line jsx-a11y/role-supports-aria-props */ }
 							<motion.button
 								key="handle"
 								role="separator"

--- a/routes/dashboard/widget-types/types.ts
+++ b/routes/dashboard/widget-types/types.ts
@@ -15,8 +15,6 @@
  */
 import type { ComponentProps } from 'react';
 import type { Field } from '@wordpress/dataviews';
-// Dashboard is still experimental.
-// eslint-disable-next-line @wordpress/use-recommended-components
 import type { Icon } from '@wordpress/ui';
 
 type IconProps = ComponentProps< typeof Icon >;

--- a/test/performance/fixtures/perf-utils.ts
+++ b/test/performance/fixtures/perf-utils.ts
@@ -198,10 +198,8 @@ export class PerfUtils {
 
 	async expectExpandedState( locator: Locator, state: 'true' | 'false' ) {
 		return await Promise.any( [
-			// eslint-disable-next-line playwright/missing-playwright-await
 			expect( locator ).toHaveAttribute( 'aria-expanded', state ),
 			// Legacy selector.
-			// eslint-disable-next-line playwright/missing-playwright-await
 			expect( locator ).toHaveAttribute( 'aria-pressed', state ),
 		] );
 	}

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -207,13 +207,9 @@ export default dedupePlugins( [
 	...wpPlugin.configs.recommended,
 
 	// eslint-comments recommended (manually converted to flat config).
-	// Register under both names so that existing `eslint-comments/*` rule
-	// references (used below) continue to work alongside the canonical
-	// `@eslint-community/eslint-comments/*` names from the recommended config.
 	{
 		plugins: {
 			'@eslint-community/eslint-comments': eslintCommentsPlugin,
-			'eslint-comments': eslintCommentsPlugin,
 		},
 		rules: eslintCommentsPlugin.configs.recommended.rules,
 	},
@@ -226,6 +222,9 @@ export default dedupePlugins( [
 
 	// Global settings applicable to all files.
 	{
+		linterOptions: {
+			reportUnusedDisableDirectives: 'error',
+		},
 		languageOptions: {
 			globals: {
 				wp: 'off',
@@ -270,7 +269,6 @@ export default dedupePlugins( [
 					},
 				},
 			],
-			'eslint-comments/no-unused-disable': 'error',
 			'import/default': 'error',
 			'import/named': 'error',
 			'no-restricted-imports': [

--- a/widgets/welcome/components/feature-highlight/feature-highlight.tsx
+++ b/widgets/welcome/components/feature-highlight/feature-highlight.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react';
 /**
  * WordPress dependencies
  */
-import { Icon, Link, Stack, Text } from '@wordpress/ui'; // eslint-disable-line @wordpress/use-recommended-components
+import { Icon, Link, Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## What?

Related: #72940

Fixes an issue where unused ESLint disable comments are not being correctly flagged, and fixes existing issues.

This may have regressed as part of the recent ESLint upgrade in #76654. Strangely, we had the rule configured to catch issues as an error, but they were being surfaced as a warning.

## Why?

Unused disables add unnecessary noise to the code and potential confusion.

## How?

Uses [`linterOptions.reportUnusedDisableDirectives`](https://eslint.org/docs/latest/use/configure/rules#report-unused-eslint-disable-comments), which is now a built-in option.

## Testing Instructions

`npm run lint:js` should pass.

## Use of AI Tools

No AI used.