### PR TITLE
Automated Testing: Skip ESLint for bundled library code via ignore patterns

### DIFF
--- a/packages/global-styles-ui/src/font-library/lib/inflate.js
+++ b/packages/global-styles-ui/src/font-library/lib/inflate.js
@@ -28,8 +28,6 @@
  * SOFTWARE.
  */
 
-/* eslint @eslint-community/eslint-comments/no-unlimited-disable: 0 */
-/* eslint-disable */
 /* pako 1.0.10 nodeca/pako */
 export default ( function () {
 	var define, module, exports;
@@ -4092,4 +4090,3 @@ export default ( function () {
 		[]
 	)( '/lib/inflate.js' );
 } )();
-/* eslint-enable */

--- a/packages/global-styles-ui/src/font-library/lib/lib-font.browser.js
+++ b/packages/global-styles-ui/src/font-library/lib/lib-font.browser.js
@@ -28,8 +28,6 @@
  * SOFTWARE.
  */
 
-/* eslint @eslint-community/eslint-comments/no-unlimited-disable: 0 */
-/* eslint-disable */
 // import pako from 'pako';
 import unbrotli from './unbrotli';
 import GzipDecode from './inflate';
@@ -3858,4 +3856,3 @@ class LongVertMetric {
 }
 var vmtx$1 = Object.freeze( { __proto__: null, vmtx: vmtx } );
 export { Font };
-/* eslint-enable */

--- a/packages/global-styles-ui/src/font-library/lib/unbrotli.js
+++ b/packages/global-styles-ui/src/font-library/lib/unbrotli.js
@@ -28,8 +28,6 @@
  * SOFTWARE.
  */
 
-/* eslint @eslint-community/eslint-comments/no-unlimited-disable: 0 */
-/* eslint-disable */
 export default ( function () {
 	var define, module, exports;
 	return ( function () {
@@ -2685,4 +2683,3 @@ export default ( function () {
 		[ 12 ]
 	)( 12 );
 } )();
-/* eslint-enable */

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -193,6 +193,7 @@ export default dedupePlugins( [
 			'**/build-wp/**',
 			'**/node_modules/**',
 			'packages/block-serialization-spec-parser/parser.js',
+			'packages/global-styles-ui/src/font-library/lib/**',
 			'packages/icons/src/library/*.tsx',
 			'packages/react-native-editor/bundle/**',
 			'packages/vips/src/worker-code.ts',


### PR DESCRIPTION
## What?

Ignores ESLint errors in bundled library code by using ignore patterns in the ESLint configuration rather than inline code comments.

## Why?

Performance: Skip parsing these files altogether. Inline comments mean that the errors are ignored, but the file is still parsed.

Maintenance: These inline comments are manual revisions to what is otherwise an untouched, bundled artifact from the library. This makes future updates more difficult because we'd have to do the manual revisions each time.

Simplicity: One path entry in an established ignore set replaces 3 lines of ignore code per every of the 3 files in the folder. Additional files in the `lib/` directory are ignored automatically.

## Testing Instructions

`npm run lint:js` should pass.

## Use of AI Tools

Explored and implemented ignore pattern with Cursor + Claude Opus 4.7. Revisions to `lib/` file were edited manually.