### PR TITLE
Core Abilities: Defer fetch until workflow palette opens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64258,6 +64258,7 @@
 				"@wordpress/abilities": "file:../abilities",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
+				"@wordpress/core-abilities": "file:../core-abilities",
 				"@wordpress/data": "file:../data",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",

--- a/packages/core-abilities/README.md
+++ b/packages/core-abilities/README.md
@@ -16,26 +16,18 @@ _This package assumes that your code will run in an ES2015+ environment. If you'
 
 ## Usage
 
-This package is designed to be loaded as a script module on WordPress admin pages. When loaded, it automatically:
+This package is designed to be loaded as a script module on WordPress admin pages. It exposes an `initialize()` function that, on first call:
 
-1. Fetches all ability categories from `/wp-abilities/v1/categories`
-2. Registers them with `@wordpress/abilities`
-3. Fetches all abilities from `/wp-abilities/v1/abilities`
-4. Registers them with a `callback` that handles execution via REST API
+1. Fetches all ability categories from `/wp-abilities/v1/categories` and registers them with `@wordpress/abilities`
+2. Fetches all abilities from `/wp-abilities/v1/abilities` and registers them with a `callback` that handles execution via REST API
 
-Simply import the package to initialize the WordPress abilities:
+Initialization is lazy: importing the package does not trigger network requests. Call `initialize()` from the feature that needs abilities — for example, when the workflow palette opens. Repeated calls return the same in-flight or resolved promise, so the requests fire at most once.
 
 ```js
-import '@wordpress/core-abilities';
-```
-
-Initialization is asynchronous because categories and abilities are fetched from the REST API. To wait for registration to finish before calling `getAbilities()` or `executeAbility()`, await the exported `ready` promise:
-
-```js
-import { ready } from '@wordpress/core-abilities';
+import { initialize } from '@wordpress/core-abilities';
 import { getAbilities, executeAbility } from '@wordpress/abilities';
 
-await ready;
+await initialize();
 
 console.log( getAbilities() );
 console.log( await executeAbility( 'core/get-site-info' ) );

--- a/packages/core-abilities/src/index.ts
+++ b/packages/core-abilities/src/index.ts
@@ -133,14 +133,21 @@ async function initializeAbilities(): Promise< void > {
 	}
 }
 
-/**
- * Initialize WordPress abilities integration.
- */
-async function initialize(): Promise< void > {
-	// Fetch and register categories, then abilities
-	await initializeCategories();
-	await initializeAbilities();
-}
+let initializePromise: Promise< void > | null = null;
 
-// Auto-initialize on import.
-export const ready: Promise< void > = initialize();
+/**
+ * Fetches and registers core abilities and their categories.
+ *
+ * Memoized: repeated calls return the same in-flight or resolved promise, so
+ * callers can invoke it from multiple entry points without triggering duplicate
+ * REST requests.
+ */
+export function initialize(): Promise< void > {
+	if ( ! initializePromise ) {
+		initializePromise = ( async () => {
+			await initializeCategories();
+			await initializeAbilities();
+		} )();
+	}
+	return initializePromise;
+}

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -50,6 +50,7 @@
 		"@wordpress/abilities": "file:../abilities",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",
+		"@wordpress/core-abilities": "file:../core-abilities",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/workflow/src/components/workflow-menu.js
+++ b/packages/workflow/src/components/workflow-menu.js
@@ -21,6 +21,7 @@ import {
 } from '@wordpress/keyboard-shortcuts';
 import { Icon, search as inputIcon } from '@wordpress/icons';
 import { executeAbility, store as abilitiesStore } from '@wordpress/abilities';
+import { initialize as initializeCoreAbilities } from '@wordpress/core-abilities';
 
 /**
  * Internal dependencies
@@ -124,6 +125,12 @@ export function WorkflowMenu() {
 			bindGlobal: true,
 		}
 	);
+
+	useEffect( () => {
+		if ( isOpen ) {
+			initializeCoreAbilities();
+		}
+	}, [ isOpen ] );
 
 	const closeAndReset = () => {
 		setSearch( '' );

--- a/test/e2e/specs/admin/workflow-palette.spec.js
+++ b/test/e2e/specs/admin/workflow-palette.spec.js
@@ -1,0 +1,68 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Workflow palette', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-workflow-palette',
+		] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test( 'fetches abilities only when the palette is opened', async ( {
+		page,
+		admin,
+	} ) => {
+		const abilityRequests = [];
+		page.on( 'request', ( request ) => {
+			const url = new URL( request.url() );
+			const restRoute =
+				url.searchParams.get( 'rest_route' ) ??
+				url.pathname.replace( /^\/wp-json/, '' );
+			if ( restRoute.startsWith( '/wp-abilities/v1/' ) ) {
+				abilityRequests.push( restRoute );
+			}
+		} );
+
+		await admin.visitAdminPage( 'index.php' );
+
+		// Lazy init: nothing should have been fetched at admin load.
+		expect( abilityRequests ).toEqual( [] );
+
+		// Open the palette via its keyboard shortcut.
+		await page.keyboard.press( 'ControlOrMeta+j' );
+
+		const palette = page.getByRole( 'dialog', {
+			name: 'Workflow palette',
+		} );
+		await expect( palette ).toBeVisible();
+
+		// Opening the palette triggers the lazy fetch.
+		await expect
+			.poll( () => abilityRequests.sort() )
+			.toEqual( [
+				expect.stringMatching( /^\/wp-abilities\/v1\/abilities/ ),
+				expect.stringMatching( /^\/wp-abilities\/v1\/categories/ ),
+			] );
+
+		// Once the fetch resolves, abilities should populate the palette.
+		await expect(
+			palette.getByRole( 'option', { name: 'Get Site Information' } )
+		).toBeVisible();
+
+		// Close the palette.
+		await page.keyboard.press( 'Escape' );
+		await expect( palette ).toBeHidden();
+
+		// Reopening does not refetch.
+		const requestCountAfterFirstOpen = abilityRequests.length;
+		await page.keyboard.press( 'ControlOrMeta+j' );
+		await expect( palette ).toBeVisible();
+		expect( abilityRequests.length ).toBe( requestCountAfterFirstOpen );
+	} );
+} );

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -41,9 +41,6 @@ test.describe( 'Preload', () => {
 
 		// To do: these should all be removed or preloaded.
 		expect( requests ).toEqual( [
-			// Abilities system initialization.
-			'/wp-abilities/v1/categories',
-			'/wp-abilities/v1/abilities',
 			// Seems to be coming from `enableComplementaryArea`.
 			'/wp/v2/users/me',
 			'/wp/v2/settings',


### PR DESCRIPTION
## What

`@wordpress/core-abilities` previously auto-ran two sequential REST requests at module load on every wp-admin page:

1. `GET /wp-abilities/v1/categories`
2. `GET /wp-abilities/v1/abilities`

The only consumer is the workflow palette modal (Cmd+J), which is hidden until invoked and gated behind the `gutenberg-workflow-palette` experiment.

## How

- `packages/core-abilities/src/index.ts` — replaces the top-level `initialize()` call with an exported memoized `initialize()` function.
- `packages/workflow/src/components/workflow-menu.js` — calls `initialize()` from a `useEffect` that fires when the modal first opens.
- `packages/workflow/package.json` — adds `@wordpress/core-abilities` as a dependency.

## Notes

The previous exported `ready` promise is removed. All affected packages are pre-1.0 (`abilities` 0.11.0, `core-abilities` 0.10.0, `workflow` 0.1.0) and the feature is in `lib/experimental/` behind an experiment flag, so the contract is explicitly unstable.

## Test plan

E2E added (`test/e2e/specs/admin/workflow-palette.spec.js`):

- [x] No `/wp-abilities/v1/*` requests during admin page load.
- [x] First Cmd+J triggers the two fetches and surfaces the registered ability in the palette.
- [x] Closing and reopening does not refetch.

Authored by Claude (Opus 4.7) in collaboration with @ellatrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)