### PR TITLE
CI: replace custom job_status output with native needs.<job>.result

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -194,9 +194,6 @@ jobs:
             matrix:
                 IS_GUTENBERG_PLUGIN: [true, false]
 
-        outputs:
-            job_status: ${{ job.status }}
-
         steps:
             - name: Checkout code
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -261,7 +258,7 @@ jobs:
             packages: write
         if: |
             always() &&
-            needs.build.outputs.job_status == 'success' &&
+            needs.build.result == 'success' &&
             github.repository == 'WordPress/gutenberg' &&
             github.event_name == 'push'
 
@@ -312,7 +309,7 @@ jobs:
             contents: write
         if: |
             always() &&
-            ( needs.build.outputs.job_status == 'failure' ) &&
+            needs.build.result == 'failure' &&
             needs.bump-version.outputs.release_branch_commit
 
         steps:


### PR DESCRIPTION
## What?

Fixes #78203

Removes the custom `job_status` output from the `build` job in `build-plugin-zip.yml` and replaces its two downstream usages with the native GitHub Actions `needs.<job_id>.result` context.

## Why?

GitHub Actions natively exposes job success/failure status through `needs.<job_id>.result`. Using a custom output to re-expose `job.status` is redundant, adds unnecessary indirection, and could introduce subtle bugs or security issues if the pattern spreads.

## How?

- Removed `outputs: job_status: ${{ job.status }}` from the `build` job
- Replaced `needs.build.outputs.job_status == 'success'` with `needs.build.result == 'success'` in `publish-to-container-registry`
- Replaced `needs.build.outputs.job_status == 'failure'` with `needs.build.result == 'failure'` in `revert-version-bump`

Behavior is identical — this is a pure refactor with no functional change.