### PR TITLE
RTC: fix stale delete propagation issue (symptom: delete causes temporary divergence between clients, which heals to incorrect result with deleted content getting re-added)

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -462,7 +462,10 @@ export const editEntityRecord =
 				objectId,
 				editsWithMerges,
 				origin,
-				{ isNewUndoLevel }
+				{
+					baseRecord: options.baseRecord,
+					isNewUndoLevel,
+				}
 			);
 		}
 		if ( ! options.undoIgnore ) {

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -412,10 +412,24 @@ async function loadPostTypeEntities() {
 			 *
 			 * @param {import('@wordpress/sync').CRDTDoc}               crdtDoc
 			 * @param {Partial< import('@wordpress/sync').ObjectData >} changes
+			 * @param {Object}                                          options
 			 * @return {void}
 			 */
-			applyChangesToCRDTDoc: ( crdtDoc, changes ) =>
-				applyPostChangesToCRDTDoc( crdtDoc, changes, syncedProperties ),
+			applyChangesToCRDTDoc: ( crdtDoc, changes, options ) => {
+				if ( options ) {
+					return applyPostChangesToCRDTDoc(
+						crdtDoc,
+						changes,
+						syncedProperties,
+						options
+					);
+				}
+				return applyPostChangesToCRDTDoc(
+					crdtDoc,
+					changes,
+					syncedProperties
+				);
+			},
 
 			/**
 			 * Create the awareness instance for the entity's CRDT document.

--- a/packages/core-data/src/hooks/use-entity-block-editor.js
+++ b/packages/core-data/src/hooks/use-entity-block-editor.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useMemo } from '@wordpress/element';
+import {
+	useCallback,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+} from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
 
@@ -82,6 +87,10 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 
 		return _blocks;
 	}, [ kind, name, id, editedBlocks, content ] );
+	const blocksRef = useRef( blocks );
+	useLayoutEffect( () => {
+		blocksRef.current = blocks;
+	}, [ blocks ] );
 
 	const onChange = useCallback(
 		( newBlocks, options ) => {
@@ -102,6 +111,7 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			};
 
 			editEntityRecord( kind, name, id, edits, {
+				baseRecord: { blocks },
 				isCached: false,
 				...rest,
 			} );
@@ -126,11 +136,12 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			};
 
 			editEntityRecord( kind, name, id, edits, {
+				baseRecord: { blocks: blocksRef.current },
 				isCached: true,
 				...rest,
 			} );
 		},
-		[ kind, name, id, meta, editEntityRecord ]
+		[ kind, name, id, meta, editEntityRecord, blocksRef ]
 	);
 
 	return [ blocks, onInput, onChange ];

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -77,6 +77,10 @@ export type YBlockAttributes = Y.Map< Y.Text | unknown >;
  */
 export type MergeCursorPosition = WPBlockSelection | null;
 
+export interface MergeCrdtBlocksOptions {
+	baseBlocks?: Block[];
+}
+
 const serializableBlocksCache = new WeakMap< WeakKey, Block[] >();
 
 /**
@@ -155,6 +159,185 @@ function makeBlocksSerializable( blocks: Block[] ): Block[] {
 			innerBlocks: makeBlocksSerializable( innerBlocks ),
 		};
 	} );
+}
+
+function getBlockClientId( block: Block ): string | undefined {
+	return typeof block.clientId === 'string' && block.clientId
+		? block.clientId
+		: undefined;
+}
+
+function getClientIdsIfEveryBlockHasUniqueId(
+	blocks: Block[]
+): string[] | undefined {
+	const clientIds = blocks.map( getBlockClientId );
+
+	if ( clientIds.some( ( clientId ) => ! clientId ) ) {
+		return undefined;
+	}
+
+	const uniqueClientIds = new Set( clientIds );
+
+	return uniqueClientIds.size === clientIds.length
+		? ( clientIds as string[] )
+		: undefined;
+}
+
+function getBlocksByClientId( blocks: Block[] ): Map< string, Block > {
+	return new Map(
+		blocks.map( ( block ) => [
+			getBlockClientId( block ) as string,
+			block,
+		] )
+	);
+}
+
+function haveSharedClientId(
+	firstClientIds: string[],
+	secondClientIds: string[]
+): boolean {
+	const secondClientIdSet = new Set( secondClientIds );
+	return firstClientIds.some( ( clientId ) =>
+		secondClientIdSet.has( clientId )
+	);
+}
+
+function findBlockIndexByClientId( blocks: Block[], clientId: string ): number {
+	return blocks.findIndex(
+		( block ) => getBlockClientId( block ) === clientId
+	);
+}
+
+function getRemoteBlockInsertIndex(
+	currentBlocks: Block[],
+	currentIndex: number,
+	blocksToSync: Block[],
+	blockIdsToSync: Set< string >
+): number {
+	for ( let index = currentIndex - 1; index >= 0; index-- ) {
+		const previousClientId = getBlockClientId( currentBlocks[ index ] );
+
+		if ( previousClientId && blockIdsToSync.has( previousClientId ) ) {
+			const previousIndex = findBlockIndexByClientId(
+				blocksToSync,
+				previousClientId
+			);
+
+			return previousIndex === -1
+				? blocksToSync.length
+				: previousIndex + 1;
+		}
+	}
+
+	for (
+		let index = currentIndex + 1;
+		index < currentBlocks.length;
+		index++
+	) {
+		const nextClientId = getBlockClientId( currentBlocks[ index ] );
+
+		if ( nextClientId && blockIdsToSync.has( nextClientId ) ) {
+			const nextIndex = findBlockIndexByClientId(
+				blocksToSync,
+				nextClientId
+			);
+
+			return nextIndex === -1 ? blocksToSync.length : nextIndex;
+		}
+	}
+
+	return blocksToSync.length;
+}
+
+function reconcileBlockWithBase(
+	localBlock: Block,
+	currentBlock: Block,
+	baseBlock: Block
+): Block {
+	const innerBlocks = reconcileBlocksWithBase(
+		localBlock.innerBlocks ?? [],
+		currentBlock.innerBlocks ?? [],
+		baseBlock.innerBlocks ?? []
+	);
+
+	return innerBlocks === localBlock.innerBlocks
+		? localBlock
+		: { ...localBlock, innerBlocks };
+}
+
+function reconcileBlocksWithBase(
+	localBlocksToSync: Block[],
+	currentBlocks: Block[],
+	baseBlocks: Block[]
+): Block[] {
+	const localClientIds =
+		getClientIdsIfEveryBlockHasUniqueId( localBlocksToSync );
+	const currentClientIds =
+		getClientIdsIfEveryBlockHasUniqueId( currentBlocks );
+	const baseClientIds = getClientIdsIfEveryBlockHasUniqueId( baseBlocks );
+
+	if ( ! localClientIds || ! currentClientIds || ! baseClientIds ) {
+		return localBlocksToSync;
+	}
+
+	// Save/reload can regenerate editor client IDs while the CRDT document
+	// still has the old IDs. In that state, ID-based stale-delete rebasing
+	// would treat every local block as remotely deleted.
+	if (
+		baseClientIds.length > 0 &&
+		currentClientIds.length > 0 &&
+		! haveSharedClientId( baseClientIds, currentClientIds )
+	) {
+		return localBlocksToSync;
+	}
+
+	const currentBlocksByClientId = getBlocksByClientId( currentBlocks );
+	const baseBlocksByClientId = getBlocksByClientId( baseBlocks );
+	const localClientIdSet = new Set( localClientIds );
+	const baseClientIdSet = new Set( baseClientIds );
+	const blocksToSync: Block[] = [];
+	const blockIdsToSync = new Set< string >();
+
+	localBlocksToSync.forEach( ( localBlock ) => {
+		const clientId = getBlockClientId( localBlock ) as string;
+		const currentBlock = currentBlocksByClientId.get( clientId );
+		const baseBlock = baseBlocksByClientId.get( clientId );
+
+		if ( baseBlock && ! currentBlock ) {
+			return;
+		}
+
+		const blockToSync =
+			baseBlock && currentBlock
+				? reconcileBlockWithBase( localBlock, currentBlock, baseBlock )
+				: localBlock;
+
+		blocksToSync.push( blockToSync );
+		blockIdsToSync.add( clientId );
+	} );
+
+	currentBlocks.forEach( ( currentBlock, currentIndex ) => {
+		const clientId = getBlockClientId( currentBlock ) as string;
+
+		if (
+			baseClientIdSet.has( clientId ) ||
+			localClientIdSet.has( clientId ) ||
+			blockIdsToSync.has( clientId )
+		) {
+			return;
+		}
+
+		const insertIndex = getRemoteBlockInsertIndex(
+			currentBlocks,
+			currentIndex,
+			blocksToSync,
+			blockIdsToSync
+		);
+		blocksToSync.splice( insertIndex, 0, currentBlock );
+		blockIdsToSync.add( clientId );
+	} );
+
+	return blocksToSync;
 }
 
 /**
@@ -415,16 +598,19 @@ function createNewYBlock( block: Block ): YBlock {
  * Merge incoming block data into the local Y.Doc.
  * This function is called to sync local block changes to a shared Y.Doc.
  *
- * @param yblocks         The blocks in the local Y.Doc.
- * @param incomingBlocks  Gutenberg blocks being synced.
- * @param attributeCursor When provided, describes a selection cursor falling within a
- *                        RichText field associated with a specific block and attribute.
- *                        Derived from the changes that produced the blocks.
+ * @param yblocks            The blocks in the local Y.Doc.
+ * @param incomingBlocks     Gutenberg blocks being synced.
+ * @param attributeCursor    When provided, describes a selection cursor falling within a
+ *                           RichText field associated with a specific block and attribute.
+ *                           Derived from the changes that produced the blocks.
+ * @param options            Merge options.
+ * @param options.baseBlocks Pre-change block snapshot to rebase against.
  */
 export function mergeCrdtBlocks(
 	yblocks: YBlocks,
 	incomingBlocks: Block[],
-	attributeCursor: MergeCursorPosition
+	attributeCursor: MergeCursorPosition,
+	options: MergeCrdtBlocksOptions = {}
 ): void {
 	// Ensure we are working with serializable block data.
 	if ( ! serializableBlocksCache.has( incomingBlocks ) ) {
@@ -434,8 +620,18 @@ export function mergeCrdtBlocks(
 		);
 	}
 
-	const incomingBlocksToSync =
+	const localBlocksToSync =
 		serializableBlocksCache.get( incomingBlocks ) ?? [];
+	const baseBlocksToSync = options.baseBlocks
+		? makeBlocksSerializable( options.baseBlocks )
+		: undefined;
+	const incomingBlocksToSync = baseBlocksToSync
+		? reconcileBlocksWithBase(
+				localBlocksToSync,
+				yblocks.toJSON() as Block[],
+				baseBlocksToSync
+		  )
+		: localBlocksToSync;
 
 	// This is a rudimentary diff implementation similar to the y-prosemirror diffing
 	// approach.

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -24,6 +24,7 @@ import {
 	type Block,
 	deserializeBlockAttributes,
 	mergeCrdtBlocks,
+	type MergeCrdtBlocksOptions,
 	type MergeCursorPosition,
 	mergeRichTextUpdate,
 	type YBlock,
@@ -54,6 +55,10 @@ export type PostChanges = Partial< Post > & {
 	selection?: WPSelection;
 	title?: Post[ 'title' ] | string;
 };
+
+interface ApplyChangesToCRDTDocOptions {
+	baseRecord?: Partial< ObjectData >;
+}
 
 // A post record as represented in the CRDT document (Y.Map).
 export interface YPostRecord extends YMapRecord {
@@ -122,12 +127,15 @@ function defaultApplyChangesToCRDTDoc(
  * @param {CRDTDoc}     ydoc
  * @param {PostChanges} changes
  * @param {Set<string>} syncedProperties
+ * @param {Object}      options
+ * @param {ObjectData}  options.baseRecord
  * @return {void}
  */
 export function applyPostChangesToCRDTDoc(
 	ydoc: CRDTDoc,
 	changes: PostChanges,
-	syncedProperties: Set< string >
+	syncedProperties: Set< string >,
+	options: ApplyChangesToCRDTDocOptions = {}
 ): void {
 	const ymap = getRootMap< YPostRecord >( ydoc, CRDT_RECORD_MAP_KEY );
 
@@ -169,7 +177,21 @@ export function applyPostChangesToCRDTDoc(
 
 				// Merge blocks does not need `setValue` because it is operating on a
 				// Yjs type that is already in the Y.Doc.
-				mergeCrdtBlocks( currentBlocks, newValue, newCursorPosition );
+				const mergeOptions: MergeCrdtBlocksOptions = {};
+				const baseBlocks = (
+					options.baseRecord as PostChanges | undefined
+				 )?.blocks;
+
+				if ( Array.isArray( baseBlocks ) ) {
+					mergeOptions.baseBlocks = baseBlocks;
+				}
+
+				mergeCrdtBlocks(
+					currentBlocks,
+					newValue,
+					newCursorPosition,
+					mergeOptions
+				);
 				break;
 			}
 

--- a/packages/core-data/src/utils/test/crdt-stale-block-base.test.ts
+++ b/packages/core-data/src/utils/test/crdt-stale-block-base.test.ts
@@ -1,0 +1,262 @@
+/**
+ * WordPress dependencies
+ */
+import { Y } from '@wordpress/sync';
+
+/**
+ * External dependencies
+ */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	jest,
+} from '@jest/globals';
+
+jest.mock( '../crdt-selection', () => ( {
+	getSelectionHistory: jest.fn( () => [] ),
+	getShiftedSelection: jest.fn( () => null ),
+	restoreSelection: jest.fn(),
+	updateSelectionHistory: jest.fn(),
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import { CRDT_RECORD_MAP_KEY, LOCAL_EDITOR_ORIGIN } from '../../sync';
+import { applyPostChangesToCRDTDoc, type YPostRecord } from '../crdt';
+import {
+	mergeCrdtBlocks,
+	type Block,
+	type MergeCursorPosition,
+	type YBlock,
+	type YBlocks,
+} from '../crdt-blocks';
+import { getRootMap } from '../crdt-utils';
+
+const SYNCED_BLOCK_PROPERTIES = new Set( [ 'blocks' ] );
+
+function paragraph( clientId: string, content: string ): Block {
+	return {
+		name: 'core/paragraph',
+		clientId,
+		attributes: { content },
+		innerBlocks: [],
+	};
+}
+
+function blockContents( blocks: YBlocks ): string[] {
+	return ( blocks.toJSON() as Block[] ).map(
+		( block ) => block.attributes.content as string
+	);
+}
+
+function postBlocks( ydoc: Y.Doc ): YBlocks {
+	return getRootMap< YPostRecord >( ydoc, CRDT_RECORD_MAP_KEY ).get(
+		'blocks'
+	) as YBlocks;
+}
+
+const mergeCrdtBlocksWithBase = mergeCrdtBlocks as (
+	yblocks: YBlocks,
+	incomingBlocks: Block[],
+	attributeCursor: MergeCursorPosition,
+	options?: { baseBlocks?: Block[] }
+) => void;
+
+const applyPostChangesWithBase = applyPostChangesToCRDTDoc as (
+	ydoc: Y.Doc,
+	changes: { blocks: Block[] },
+	syncedProperties: Set< string >,
+	options?: { baseRecord?: { blocks: Block[] } }
+) => void;
+
+describe( 'CRDT stale block base snapshots', () => {
+	let doc: Y.Doc;
+	let yblocks: YBlocks;
+
+	beforeEach( () => {
+		doc = new Y.Doc();
+		yblocks = doc.getArray< YBlock >();
+	} );
+
+	afterEach( () => {
+		doc.destroy();
+	} );
+
+	it( 'preserves an unseen remote top-level append when applying a stale local edit', () => {
+		const baseBlocks = [
+			paragraph( 'local-edited', 'Alpha' ),
+			paragraph( 'unchanged', 'Beta' ),
+		];
+		const currentBlocks = [
+			paragraph( 'local-edited', 'Alpha' ),
+			paragraph( 'unchanged', 'Beta' ),
+			paragraph( 'remote-appended', 'Gamma' ),
+		];
+		const staleLocalBlocks = [
+			paragraph( 'local-edited', 'Alpha local edit' ),
+			paragraph( 'unchanged', 'Beta' ),
+		];
+
+		mergeCrdtBlocks( yblocks, baseBlocks, null );
+		mergeCrdtBlocks( yblocks, currentBlocks, null );
+		mergeCrdtBlocksWithBase( yblocks, staleLocalBlocks, null, {
+			baseBlocks,
+		} );
+
+		expect( blockContents( yblocks ) ).toEqual( [
+			'Alpha local edit',
+			'Beta',
+			'Gamma',
+		] );
+	} );
+
+	it( 'preserves a remote top-level delete when applying a stale local edit', () => {
+		const baseBlocks = [
+			paragraph( 'local-edited', 'Alpha' ),
+			paragraph( 'unchanged', 'Beta' ),
+			paragraph( 'remote-deleted', 'Gamma' ),
+		];
+		const currentBlocks = [
+			paragraph( 'local-edited', 'Alpha' ),
+			paragraph( 'unchanged', 'Beta' ),
+		];
+		const staleLocalBlocks = [
+			paragraph( 'local-edited', 'Alpha local edit' ),
+			paragraph( 'unchanged', 'Beta' ),
+			paragraph( 'remote-deleted', 'Gamma' ),
+		];
+
+		mergeCrdtBlocks( yblocks, baseBlocks, null );
+		mergeCrdtBlocks( yblocks, currentBlocks, null );
+		mergeCrdtBlocksWithBase( yblocks, staleLocalBlocks, null, {
+			baseBlocks,
+		} );
+
+		expect( blockContents( yblocks ) ).toEqual( [
+			'Alpha local edit',
+			'Beta',
+		] );
+	} );
+
+	it( 'keeps an observed local delete of a top-level block inserted by another peer', () => {
+		const baseBlocks = [
+			paragraph( 'local-edited', 'Alpha' ),
+			paragraph( 'unchanged', 'Beta' ),
+			paragraph( 'observed-remote-insert', 'Gamma' ),
+		];
+		const staleLocalBlocks = [
+			paragraph( 'local-edited', 'Alpha local edit' ),
+			paragraph( 'unchanged', 'Beta' ),
+		];
+
+		mergeCrdtBlocks( yblocks, baseBlocks, null );
+		mergeCrdtBlocksWithBase( yblocks, staleLocalBlocks, null, {
+			baseBlocks,
+		} );
+
+		expect( blockContents( yblocks ) ).toEqual( [
+			'Alpha local edit',
+			'Beta',
+		] );
+	} );
+
+	it( 'uses the post CRDT baseRecord path to preserve a remote delete', () => {
+		const baseBlocks = [
+			paragraph( 'local-edited', 'Alpha' ),
+			paragraph( 'unchanged', 'Beta' ),
+			paragraph( 'remote-deleted', 'Gamma' ),
+		];
+
+		applyPostChangesWithBase(
+			doc,
+			{ blocks: baseBlocks },
+			SYNCED_BLOCK_PROPERTIES
+		);
+
+		applyPostChangesWithBase(
+			doc,
+			{
+				blocks: [
+					paragraph( 'local-edited', 'Alpha' ),
+					paragraph( 'unchanged', 'Beta' ),
+				],
+			},
+			SYNCED_BLOCK_PROPERTIES,
+			{ baseRecord: { blocks: baseBlocks } }
+		);
+
+		expect( blockContents( postBlocks( doc ) ) ).toEqual( [
+			'Alpha',
+			'Beta',
+		] );
+
+		applyPostChangesWithBase(
+			doc,
+			{
+				blocks: [
+					paragraph( 'local-edited', 'Alpha local edit' ),
+					paragraph( 'unchanged', 'Beta' ),
+					paragraph( 'remote-deleted', 'Gamma' ),
+				],
+			},
+			SYNCED_BLOCK_PROPERTIES,
+			{ baseRecord: { blocks: baseBlocks } }
+		);
+
+		expect( blockContents( postBlocks( doc ) ) ).toEqual( [
+			'Alpha local edit',
+			'Beta',
+		] );
+	} );
+
+	it( 'applies local edits after reload regenerates block client IDs', () => {
+		const baseBlocks = [ paragraph( 'after-reload', 'Alpha' ) ];
+		const currentBlocks = [ paragraph( 'before-reload', 'Alpha' ) ];
+		const localBlocks = [ paragraph( 'after-reload', 'Alpha local edit' ) ];
+
+		mergeCrdtBlocks( yblocks, currentBlocks, null );
+		mergeCrdtBlocksWithBase( yblocks, localBlocks, null, {
+			baseBlocks,
+		} );
+
+		expect( blockContents( yblocks ) ).toEqual( [ 'Alpha local edit' ] );
+	} );
+
+	it( 'records undo for local edits after reload regenerates block client IDs', () => {
+		const recordMap = getRootMap< YPostRecord >( doc, CRDT_RECORD_MAP_KEY );
+		const undoManager = new Y.UndoManager( recordMap, {
+			trackedOrigins: new Set( [ LOCAL_EDITOR_ORIGIN ] ),
+		} );
+		const baseBlocks = [ paragraph( 'after-reload', 'Alpha' ) ];
+		const currentBlocks = [ paragraph( 'before-reload', 'Alpha' ) ];
+		const localBlocks = [ paragraph( 'after-reload', 'Alpha local edit' ) ];
+
+		applyPostChangesWithBase(
+			doc,
+			{ blocks: currentBlocks },
+			SYNCED_BLOCK_PROPERTIES
+		);
+
+		doc.transact( () => {
+			applyPostChangesWithBase(
+				doc,
+				{ blocks: localBlocks },
+				SYNCED_BLOCK_PROPERTIES,
+				{ baseRecord: { blocks: baseBlocks } }
+			);
+		}, LOCAL_EDITOR_ORIGIN );
+
+		expect( blockContents( postBlocks( doc ) ) ).toEqual( [
+			'Alpha local edit',
+		] );
+		expect( undoManager.canUndo() ).toBe( true );
+
+		undoManager.undo();
+
+		expect( blockContents( postBlocks( doc ) ) ).toEqual( [ 'Alpha' ] );
+	} );
+} );

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -555,6 +555,7 @@ export function createSyncManager( debug = false ): SyncManager {
 	 * @param {Partial< ObjectData >}    changes                Updates to make.
 	 * @param {string}                   origin                 The source of change.
 	 * @param {SyncManagerUpdateOptions} options                Optional flags for the update.
+	 * @param {ObjectData}               options.baseRecord     Entity record snapshot before the change.
 	 * @param {boolean}                  options.isSave         Whether this update is part of a save operation. Defaults to false.
 	 * @param {boolean}                  options.isNewUndoLevel Whether to create a new undo level for this change. Defaults to false.
 	 */
@@ -565,7 +566,7 @@ export function createSyncManager( debug = false ): SyncManager {
 		origin: string,
 		options: SyncManagerUpdateOptions = {}
 	): void {
-		const { isSave = false, isNewUndoLevel = false } = options;
+		const { baseRecord, isSave = false, isNewUndoLevel = false } = options;
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
 		const collectionState = collectionStates.get( objectType );
@@ -586,7 +587,13 @@ export function createSyncManager( debug = false ): SyncManager {
 				log( 'updateCRDTDoc', 'applying changes', entityId, {
 					changedKeys: Object.keys( changes ),
 				} );
-				syncConfig.applyChangesToCRDTDoc( ydoc, changes );
+				if ( baseRecord ) {
+					syncConfig.applyChangesToCRDTDoc( ydoc, changes, {
+						baseRecord,
+					} );
+				} else {
+					syncConfig.applyChangesToCRDTDoc( ydoc, changes );
+				}
 
 				if ( isSave ) {
 					markEntityAsSaved( ydoc );

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -119,6 +119,7 @@ export interface CollectionHandlers {
 }
 
 export interface SyncManagerUpdateOptions {
+	baseRecord?: Partial< ObjectData >;
 	isSave?: boolean;
 	isNewUndoLevel?: boolean;
 }
@@ -139,7 +140,8 @@ export interface RecordHandlers {
 export interface SyncConfig {
 	applyChangesToCRDTDoc: (
 		ydoc: Y.Doc,
-		changes: Partial< ObjectData >
+		changes: Partial< ObjectData >,
+		options?: { baseRecord?: Partial< ObjectData > }
 	) => void;
 	createAwareness?: (
 		ydoc: Y.Doc,


### PR DESCRIPTION
This is part of an AI fuzzing project, where an AI wrote a fuzzer and then triages bugs from the fuzzer and creates fixes. See #77716 for the tracking issue. As of this writing, there have been no known false positives from this project, but there have been some issues, which are documented in #77716. I expect we’ll see false positives at some point (and may even have one that’s been filed in a PR that hasn’t been inspected by a code owner yet). However, analyses, alleged root causes, etc., are often not correct and any statement from the AI about why something happened should be taken with a grain of salt.

## What?

This is another staleness issue that is related to, but not caused by or fixed by, #77876. The class of failure discussed in this PR repros against trunk and also with #77876 merged. It's possible this fix should supersede that one or can be broadened to supersede that one (TBD, I haven't looked into that yet).

https://github.com/user-attachments/assets/85f2c6af-0dd4-4ca5-ab0e-bc86e6821b28

This was the next PR in the fuzzing queue and, coincidentally, it relates to a class of issue @dmsnell, @alecgeatches, @maxschmeling, and I just discussed.

In the AI text below, it mentions that we can't distinguish between

```
  current Y state:         [A, B, R]
  incoming local snapshot: [A', B]
 ```
 
We have blocks A, B, R. A' is a modified A. In the local snapshot, we see that B still exists, R is gone, and A has been modified. With the information we have, it seems like we can't tell the difference between:

1. Stale local snapshot
```
  local saw:     [A, B]
  remote has:    [A, B, R]
  local sends:   [A', B]
  expected:      [A', B, R]
```  
  
2. R intentionally deleted
```
  local saw:    [A, B, R]
  local sends:  [A', B]
  expected:     [A', B]
```

Note this fix handles the in-memory path but (if codex isn't lying), this fix doesn't try to handle the save/reload path. I don't think I have the full context there, but my understanding is that there was some resistance to serializing a CRDT ID or anything equivalent that's metadata that's not visible content?

I'm not a distributed systems person, so I could be wrong about this, but I think that we'll have some version of this issue on save and reload in one way or another if we don't serialize some kind of provenance information.

## AI TEXT

The headline representative is `890d98d04cda`. The cleanest reduction for the same user-facing family is `3ac375556552`: one collaborator appends a normal top-level paragraph, both editors converge, and another collaborator deletes that visible paragraph through the normal block UI. The deleting peer removes it, but the other peer retains it, or the lower-level Yjs repro reintroduces it on both peers.

Identifier note: short hexadecimal strings such as `890d98d04cda`,
`3ac375556552`, and `007e79caf228` are RTC fuzzing finding identifiers, not
Git commit hashes. The fuzzing and reduction pipeline uses them to name
specific generated findings and their associated local repro artifacts. A
"representative" is one concrete finding chosen to stand for a broader
user-facing bug family after related findings have been clustered or reduced.
These identifiers are useful for matching this explanation to local fuzzing
metadata and videos, but they are not expected to resolve in GitHub.

Local realistic video evidence:

```text
/Users/danluu/dev/fuzz/gutenberg/artifacts/rtc-stale-delete-video/rtc-stale-delete-websocket-realistic-repro.mp4
```

## Evidence

- Ranking row: `890d98d04cda`, "Top-level delete propagation leaves a stale block on a peer"; related clean representatives: `3ac375556552`, `007e79caf228`.
- Realistic browser result: `3ac375556552/realistic-results/append-from-tail-enter-attempt-0.json` records `statesEqualAfterInsert: true`, `exactDeleteBug: true`, and `statesEqualAfterDelete: false`.
- The browser repro uses normal UI actions: B appends by click, `End`, `Enter`, and typing, then A deletes by selecting the inserted paragraph and using block options `Delete`. No injected transport fault, reload, revision restore, parser edge case, or artificial block is needed.
- Lower-level confirmation: `3ac375556552/unit-repro-result.json` records `remoteStillPresent: true`; after the delete, the Yjs state still contains `seed-954092-remote-paragraph`.
- The browser and unit outcomes differ in shape but not in semantics. The browser run diverges with one peer at three blocks and the other at four. The unit probe can converge incorrectly with both replicas retaining the deleted block. Both are lost-delete evidence.
- Branch check excluding PR #77876: current local branch `codex/rtc-stale-delete-890d98d04cda-20260514` at
  `2f59cd94b1ba41b004f4707ff25674506c81d796` does not contain PR #77876 head
  `6aad4e5801af23a5b42cd9fde4044895f06946ea`, but
  `realistic-results-no-77876-current/append-from-tail-enter-attempt-0.json`
  still records `statesEqualAfterInsert: true`, `exactDeleteBug: true`, and
  `statesEqualAfterDelete: false`.
- Longer wait check: with `RTC_3AC3_DELETE_CONVERGENCE_TIMEOUT_MS=60000`, the
  append-from-tail repros no longer diverged after delete, but they converged
  to the wrong state. Both editors still contained the deleted paragraph:
  `realistic-results-long-wait-60000-current/append-from-tail-enter-attempt-0.json`
  and `append-from-tail-enter-attempt-2.json` record
  `statesEqualAfterDelete: true`, `semanticDeleteBug: true`, and
  `insertedPresentAfterDelete: true`.
- Current-trunk lower-level family check: on `origin/trunk` at
  `2b5a7a9930490b13933a89c69f4455252072c14d`, the exact
  `3ac375556552` unit delete probe converges cleanly, but a sibling
  stale-top-level probe reproduces both sides of the same full-snapshot
  ambiguity: remote append is lost after a stale local edit, and remote delete
  is resurrected after a stale local edit. Result:
  `unit-current-origin-trunk-2b5a7a99304/stale-top-level-family-probe-result.json`.
- Current-trunk browser check: after building the current-trunk worktree so the
  Gutenberg plugin actually loaded, the repo-local normal-UI stale-save loop
  reproduced on repeat 1. The primary editor reloaded with
  `["Alpha local stale save loop 1", "Beta"]`, losing collaborator B's
  `Gamma remote stale save loop 1` paragraph. Artifacts:
  `/Users/danluu/dev/fuzz/rtc-repros/current-trunk-stale-top-level-built-20260514/playwright-artifacts/test-results/editor-collaboration-colla-620e7-ith-overlapping-draft-saves-chromium/`.

## How It Was Introduced

The original substrate is [PR #72262](https://github.com/WordPress/gutenberg/pull/72262) /
[`84019935998c16f877e976ad85e84748355d7282`](https://github.com/WordPress/gutenberg/commit/84019935998c16f877e976ad85e84748355d7282), "Improve CRDT merge logic for post entities". That commit created `packages/core-data/src/utils/crdt-blocks.ts` and the left/right full-array merge path used for block CRDT updates.

The architectural gap is that Gutenberg feeds the CRDT merge layer full block
snapshots from the editor, not explicit user operations. A later local snapshot
can be stale relative to the current Yjs block array. Without reliable
per-snapshot base provenance, the merge layer cannot distinguish these cases:

```text
current Y state:      [A, B, R]
incoming local:       [A', B]
```

That tuple can mean either:

- the local editor never observed remote block `R`, so `R` should be preserved;
- the local editor observed remote block `R` and deleted it, so `R` should be deleted.

Current `origin/trunk` still has the first side of this bug family. A stale
local snapshot can erase an unseen remote top-level append, or resurrect a
remote top-level delete, because the left/right merge infers array structure
operations from a stale full snapshot.

Later stale-save/stale-snapshot fixes tried to repair that first side by
preserving remote work from stale snapshots. The local branch that reproduces
the clean browser delete bug does not contain PR #77876, but it does contain an
earlier local copy of that repair line, including
[`7bc178d07b781ce5c24a7597e8e5c412534806d0`](https://github.com/danluu/gutenberg/commit/7bc178d07b781ce5c24a7597e8e5c412534806d0), cherry-picked from
[`cd6822b89c95050e56d39cd217a6bf9e036af315`](https://github.com/danluu/gutenberg/commit/cd6822b89c95050e56d39cd217a6bf9e036af315). PR #77876 later carries related stale-snapshot work, but the browser repro shows #77876 itself is not the original introducer.

Those stale-snapshot repairs have the opposite ambiguity. A preservation rule
without exact outgoing-snapshot provenance can also preserve a block that the
local editor did observe and then delete:

```text
previous local cache: [A, B, C]
current Y state:      [A, B, C, R]
incoming local:       [A, B, C]
```

If `R` was visible in the editor and the outgoing snapshot is based on a view
that contained `R`, omission means delete. If the outgoing snapshot is older
than `R`, omission means stale no-op. Membership in current Y state,
`previousLocalBlocksCache`, or provider receipt is not enough to tell those
apart.

Nearby but not likely direct introducers:

- [PR #72114](https://github.com/WordPress/gutenberg/pull/72114) /
  [`c214929139f50337250efe2bb24ff82c3ff2b6aa`](https://github.com/WordPress/gutenberg/commit/c214929139f50337250efe2bb24ff82c3ff2b6aa) made sync a side-concern over normal editor state. It made this class of stale full-snapshot issue easier to hit, but did not add the block-array merge policy.
- [PR #75923](https://github.com/WordPress/gutenberg/pull/75923) /
  [`128a3c29b7f1db4f35faf9e326dd1e5e7ac11104`](https://github.com/WordPress/gutenberg/commit/128a3c29b7f1db4f35faf9e326dd1e5e7ac11104) expanded `mergeCrdtBlocks()` testing but missed observed remote insert then local delete.
- [PR #76913](https://github.com/WordPress/gutenberg/pull/76913) /
  [`09a21c64b5b92c2626bd93065d4a0192eb4fac47`](https://github.com/WordPress/gutenberg/commit/09a21c64b5b92c2626bd93065d4a0192eb4fac47) and [PR #77164](https://github.com/WordPress/gutenberg/pull/77164) /
  [`a6bfd3e55432981c7c2cb09190ee77954530b1a5`](https://github.com/WordPress/gutenberg/commit/a6bfd3e55432981c7c2cb09190ee77954530b1a5) changed nested/table/array attribute stability, not the top-level observed-delete policy.

Scope caveat: most direct proof is for clean representative `3ac375556552`. The headline representative `890d98d04cda` is the same user-facing stale-delete family, but some audit passes flagged a possible additional stale editor-store refresh path through `getPostChangesFromCRDTDoc()`. `007e79caf228` also deserves separate reduction before treating every related hash as the same exact internal mechanism.

## Fix Plan

The fix must address the shared full-snapshot ambiguity, not just one
stale-preservation helper or one PR branch. The plan is:

1. Treat this as missing operation/base provenance for full block-array
   snapshots, not as a single-PR regression.
2. Define `BlockSnapshotProvenance` as the exact immutable editor-visible base
   block tree that produced this outgoing `blocks` snapshot, or as explicit
   operations/tombstones carrying equivalent information.
3. Preserve durable block identity or equivalent operation identity in the RTC
   path. This does not require serializing Gutenberg `clientId`s into post
   HTML, but a complete fix needs some persisted identity/provenance in the
   CRDT/persistence path; serialized block shape, text, and position alone
   cannot distinguish observed deletes from stale no-op snapshots.
4. Capture that provenance at the editor/core-data boundary when the outgoing
   block array is produced. Pass it through `editEntityRecord()` /
   `SyncManager.update()` / `applyChangesToCRDTDoc()` into `mergeCrdtBlocks()`.
   Do not reconstruct it inside `mergeCrdtBlocks()` from current Y state.
5. Make unknown provenance a compatibility fallback only. It should not occur
   on ordinary editor edits.
6. Define the invariant first:
   - if outgoing snapshot base contains block `R` and the new local snapshot omits `R`, delete wins;
   - if outgoing snapshot base does not contain `R`, preserve `R` as unseen remote work;
   - if current Y state no longer contains a block that the stale local snapshot still contains, preserve the remote delete unless there is explicit local reinsert intent;
   - if the base is unknown, preserve current remote work conservatively and record the ambiguity.
7. Make provenance path-aware if the generic recursive merge is in scope. A
   flat `clientId` set is only a narrow top-level optimization; it does not
   prove moves, reparenting, nested `innerBlocks`, duplicate/missing
   `clientId`s, or delete-plus-reinsert semantics. If the first patch is
   top-level-only, state that scope and add a follow-up for nested block arrays.
8. Use provenance for three-way structural reconciliation per parent block
   array: base, incoming local snapshot, and current Y state. Current-only
   blocks absent from the incoming local snapshot should be preserved only when
   the snapshot base did not include them. Blocks absent from current Y state
   should not be resurrected from a stale local snapshot unless provenance
   proves explicit local reinsert intent.
9. Do not advance base/provenance caches on remote update receipt alone. A
   queued stale snapshot can arrive after a remote update and must not become a
   false delete or false reinsert.
10. Do not treat `previousLocalBlocksCache`, `yblocks.toJSON()`, CRDT receipt,
   provider sync, latest entity record, or global store dispatch as proof of
   user/editor observation. The relevant fact is what base produced the exact
   outgoing local snapshot.
11. Serialize persistence from the post-merge block tree. If blocks participate
   in the edit/save flow, REST `content`, CRDT `content`, and `_crdt_document`
   must not be overwritten by stale serialized HTML, including save-time
   content-only materialization and `prePersistPostType()` paths.
12. Keep stale-snapshot protections as negative controls. The fix must cover
   both current trunk's "stale snapshot destroys remote work" and the local
   known-fix branch's "preservation hides observed delete".
13. Add P0 tests:
   - current-trunk remote append plus stale no-op snapshot;
   - current-trunk remote append plus stale unrelated local edit;
   - current-trunk remote delete plus stale unrelated local edit;
   - same current/incoming block arrays with different bases, proving one case
     preserves remote append and the other deletes observed block `R`;
   - observed remote append then local delete, with forced stale previous-local cache;
   - queued stale snapshot created before a remote update and flushed after the
     remote update is applied;
   - repeated stale snapshot after preservation and repeated sync after deletion;
   - nested `innerBlocks` append/delete, or an explicit top-level-only scope test;
   - post adapter and save/reload tests where `content` is derived from merged
     `blocks`, and REST `content`, CRDT `content`, `_crdt_document`, and a fresh
     third editor agree;
   - repo-local normal-UI browser repro for remote append loss under overlapping saves;
   - repo-local normal-UI browser repro for remote delete resurrection;
   - repo-local normal-UI WebSocket repro for visible remote append then block-options delete.
14. Add follow-up or separate-reduction tests for the `890d98d04cda` stale editor-store refresh hypothesis and for `007e79caf228`.

Bad fixes to avoid:

- wholesale Y.Array replacement;
- global "remote update observed" flags;
- treating current Y state as user observation;
- dropping durable block identity and trying to infer causality from text,
  position, or block count alone;
- updating base caches on remote receipt;
- relying on block count or text-only assertions instead of `clientId` or a unique marker.
- fixing only the local stale-preservation branch while leaving current trunk's stale full-array merge behavior intact.
- accepting unknown provenance on the normal editor path.

## Fix Plan Audit

The current audit incorporates the branch-without-#77876 check and the
current-trunk evidence. Raw Codex outputs are under:

```text
/tmp/rtc-stale-delete-codex-audits/no77876-20260514/round1
/tmp/rtc-stale-delete-codex-audits/no77876-20260514/meta1
/tmp/rtc-stale-delete-codex-audits/no77876-20260514/meta2
```

The audit converged on these conclusions:

- The provenance-based fix plan is necessary. A narrower
  `reconcileStaleLocalBlocks()` heuristic would still permit stale snapshots to
  erase unseen remote work or mask observed deletes.
- Provenance must mean the exact immutable editor-visible block tree that
  produced the outgoing `blocks` snapshot, or explicit operations/tombstones
  with equivalent information.
- A complete fix needs durable block identity or equivalent operation identity
  in the RTC path. It does not need to write Gutenberg `clientId`s into
  serialized post HTML, but it cannot rely only on block text, type, position,
  or count.
- `previousLocalBlocksCache`, current Y state, provider receipt, latest store
  state, and global dispatch are not valid observation signals.
- Unknown provenance is acceptable only for compatibility/import paths. It
  cannot be normal for the editor path because it intentionally masks observed
  deletes.
- A flat `clientId` set is not a complete fix if recursive block arrays are in
  scope. Either make provenance path-aware or explicitly scope the first patch
  to top-level arrays.
- Save/persist is part of the bug surface. A CRDT merge fix can still fail if
  save-time stale serialized HTML bypasses the merged block tree.
- Browser coverage must include current-trunk append loss, visible remote insert
  then local block-options delete, and remote-delete resurrection prevention.

The audit reduced the action items to:

1. Capture exact per-outgoing-snapshot base provenance at the editor/store boundary.
2. Thread it through the real sync pipeline into CRDT merge.
3. Preserve durable block identity or equivalent operation identity through the
   RTC persistence path.
4. Apply a three-way base/incoming/current merge policy.
5. Preserve remote deletes unless provenance proves explicit local reinsert.
6. Serialize persisted content from post-merge blocks.
7. Prove the behavior with unit, adapter, save/reload, and normal-UI browser tests.

## Real Bug Or False Positive

Verdict: real bug, not a false positive.

Evidence hierarchy:

1. Normal-UI Playwright repro: remote append, wait for insert convergence, delete visible inserted block through normal block UI, then peers diverge.
2. Saved realistic results: `statesEqualAfterInsert: true`, `exactDeleteBug: true`, `statesEqualAfterDelete: false`.
3. Clean fuzz metadata: no sync faults, no reload dependency, no parser/revision dependency.
4. Lower-level Yjs repro: after delete, the remote paragraph's `clientId` remains present.
5. Code/history: the full block-array merge substrate lacks base/operation
   provenance; later stale-snapshot preservation repairs can expose the
   opposite-side observed-delete ambiguity even without PR #77876.

False-positive audits:

- linus torvalds: real bug with high confidence; exact cache state in the browser is inferred unless instrumented.
- kyle kingsbury: real bug; the clean representative proves the underlying family even if not every related hash is reduced to the same path.
- marc brooker: real bug; confidence high for user reachability and medium-high for the exact internal mechanism.
- dan luu: real bug; use browser repro for UI reachability and the unit probe for mechanism.
- tptacek: real bug; the fuzz seed is clean merge-path evidence, while the realistic Playwright repro proves normal user actions.
- contrarian: real bug; final wording should not conflate browser divergence and unit-level incorrect convergence.

Meta-audit corrections:

- Do not say the original fuzz seed alone proves manual UI reachability. It is clean supporting evidence; the realistic Playwright repro is the UI proof.
- Do not copy the wrong preservation predicate. Preservation happens for a current block with a clientId that is absent from local, absent from previous, and absent from the planned sync set.
- Do not state the root cause as absolutely proven by browser evidence unless a run records `previousBlocks`, `currentBlocks`, and `localBlocksToSync` at delete time.
- Do explicitly map `3ac375556552` to the `890d98d04cda` stale-delete family and state the remaining uncertainty.

What would invalidate the claim:

- a same-code UI repro where insert convergence succeeds and delete convergence also succeeds across repeated attempts;
- instrumentation showing `previousLocalBlocksCache` already contained the remote block before the delete merge;
- evidence that the deleting editor did not actually observe the inserted block before deletion;
- evidence that the repro depended on injected faults, reload, parser stress, revision restore, direct browser state mutation, or invalid block data;
- an intentional product policy that deleting a collaborator-inserted visible block is local-only, which would be surprising and would still need convergence semantics.

## Follow-Up Instrumentation

To move the root-cause claim from high-confidence to proven for the browser path, instrument the delete merge to record:

- `previousLocalBlocksCache` clientIds;
- current Y block clientIds;
- incoming local snapshot clientIds;
- whether the outgoing snapshot base contained the deleted clientId;
- whether `reconcileStaleLocalBlocks()` spliced the deleted block back into `blocksToSync`.

That instrumentation should be temporary or test-only. The committed regression should remain a durable repo-local unit/browser test, not a triage artifact wrapper.

## END AI TEXT