### PR TITLE
Media Editor: Harden cropper math layer against non-finite inputs

### DIFF
--- a/packages/media-editor/src/image-editor/core/camera.ts
+++ b/packages/media-editor/src/image-editor/core/camera.ts
@@ -8,6 +8,7 @@ import { mat2d, vec2 } from 'gl-matrix';
  */
 import type { CropperState, NormalizedPoint, Size, Camera } from './types';
 import { degreesToRadians } from './math/rotation';
+import { safeBoundedNumber, sanitizeCropperState } from './math/sanitize';
 
 // Pre-allocated scratch buffers for `screenToWorld`, which is called per
 // pointermove. Module-level singletons — safe because usage is synchronous.
@@ -27,6 +28,16 @@ export function getRotatedBBox(
 	height: number,
 	rotation: number
 ): Size {
+	// Guard against non-finite inputs propagating through trig and producing
+	// NaN/Infinity dimensions downstream. Matches the zero-size pattern other
+	// functions already use to short-circuit when geometry is undefined.
+	if (
+		! Number.isFinite( width ) ||
+		! Number.isFinite( height ) ||
+		! Number.isFinite( rotation )
+	) {
+		return { width: 0, height: 0 };
+	}
 	const rad = degreesToRadians( rotation );
 	const cosR = Math.abs( Math.cos( rad ) );
 	const sinR = Math.abs( Math.sin( rad ) );
@@ -65,16 +76,25 @@ export function getImageFit(
 			visualSize: { width: 0, height: 0 },
 		};
 	}
+	const safeRotation = safeBoundedNumber( rotation, 0 );
 	// Snap rotation to the nearest 90° multiple for layout sizing.
 	// This keeps the stencil a stable size through fine ±45° rotation
 	// (no inflation at 15°/30° etc.) while still swapping aspect at
 	// 90°/180°/270° so the snap rotate preserves the framed content.
-	const snapRotation = Math.round( rotation / 90 ) * 90;
+	const snapRotation = Math.round( safeRotation / 90 ) * 90;
 	const naturalBBox = getRotatedBBox(
 		imageSize.width,
 		imageSize.height,
 		snapRotation
 	);
+	// Defensive: getRotatedBBox returns zero dims for hostile inputs, which
+	// would make fitScale infinite. Mirror the zero-container short-circuit.
+	if ( naturalBBox.width === 0 || naturalBBox.height === 0 ) {
+		return {
+			elementSize: { width: 0, height: 0 },
+			visualSize: { width: 0, height: 0 },
+		};
+	}
 	const fitScale = Math.min(
 		containerSize.width / naturalBBox.width,
 		containerSize.height / naturalBBox.height
@@ -122,11 +142,13 @@ export function createCamera(
 		return m;
 	}
 
+	const safeState = sanitizeCropperState( state );
+
 	// Use the nearest 90° multiple for layout sizing so the stencil
 	// and visual bounds are stable through fine rotation. The actual
 	// `state.rotation` is still used for the rotation component of
 	// the matrix below.
-	const snapRotation = Math.round( state.rotation / 90 ) * 90;
+	const snapRotation = Math.round( safeState.rotation / 90 ) * 90;
 
 	// Rotated bounding box of the natural image (at snap angle).
 	const naturalBBox = getRotatedBBox(
@@ -162,20 +184,23 @@ export function createCamera(
 	] );
 
 	// Pan offset in visual-space pixels.
-	mat2d.translate( m, m, [ state.pan.x * visualW, state.pan.y * visualH ] );
+	mat2d.translate( m, m, [
+		safeState.pan.x * visualW,
+		safeState.pan.y * visualH,
+	] );
 
 	// Flip (viewport-relative — composed outside rotation so horizontal
 	// flip always mirrors across the viewport's vertical axis).
 	mat2d.scale( m, m, [
-		state.flip.horizontal ? -1 : 1,
-		state.flip.vertical ? -1 : 1,
+		safeState.flip.horizontal ? -1 : 1,
+		safeState.flip.vertical ? -1 : 1,
 	] );
 
 	// Rotate.
-	mat2d.rotate( m, m, degreesToRadians( state.rotation ) );
+	mat2d.rotate( m, m, degreesToRadians( safeState.rotation ) );
 
 	// Zoom.
-	mat2d.scale( m, m, [ state.zoom, state.zoom ] );
+	mat2d.scale( m, m, [ safeState.zoom, safeState.zoom ] );
 
 	// Center origin (shift so 0.5,0.5 in rendered-pixel space = origin).
 	mat2d.translate( m, m, [ -renderedW / 2, -renderedH / 2 ] );
@@ -304,7 +329,8 @@ export function createExportCamera(
 	outputSize: Size
 ): Camera {
 	const m = mat2d.create();
-	const { rotation, flip, cropRect, zoom, pan } = state;
+	const { rotation, flip, cropRect, zoom, pan } =
+		sanitizeCropperState( state );
 	if (
 		imageSize.width === 0 ||
 		imageSize.height === 0 ||

--- a/packages/media-editor/src/image-editor/core/camera.ts
+++ b/packages/media-editor/src/image-editor/core/camera.ts
@@ -8,7 +8,12 @@ import { mat2d, vec2 } from 'gl-matrix';
  */
 import type { CropperState, NormalizedPoint, Size, Camera } from './types';
 import { degreesToRadians } from './math/rotation';
-import { safeBoundedNumber, sanitizeCropperState } from './math/sanitize';
+import {
+	isSafeNumber,
+	isValidSize,
+	safeBoundedNumber,
+	sanitizeCropperState,
+} from './math/sanitize';
 
 // Pre-allocated scratch buffers for `screenToWorld`, which is called per
 // pointermove. Module-level singletons — safe because usage is synchronous.
@@ -28,13 +33,16 @@ export function getRotatedBBox(
 	height: number,
 	rotation: number
 ): Size {
-	// Guard against non-finite inputs propagating through trig and producing
-	// NaN/Infinity dimensions downstream. Matches the zero-size pattern other
-	// functions already use to short-circuit when geometry is undefined.
+	// Short-circuit on any unsafe input. `isSafeNumber` is stricter than
+	// `Number.isFinite`: very large but technically-finite rotations (e.g.
+	// `Number.MAX_VALUE`) overflow inside `degreesToRadians` and then
+	// `Math.cos`/`Math.sin` return `NaN`, so the magnitude bound matters.
 	if (
-		! Number.isFinite( width ) ||
-		! Number.isFinite( height ) ||
-		! Number.isFinite( rotation )
+		! isSafeNumber( width ) ||
+		! isSafeNumber( height ) ||
+		! isSafeNumber( rotation ) ||
+		width <= 0 ||
+		height <= 0
 	) {
 		return { width: 0, height: 0 };
 	}
@@ -65,12 +73,7 @@ export function getImageFit(
 	imageSize: Size,
 	rotation: number
 ): { elementSize: Size; visualSize: Size } {
-	if (
-		containerSize.width === 0 ||
-		containerSize.height === 0 ||
-		imageSize.width === 0 ||
-		imageSize.height === 0
-	) {
+	if ( ! isValidSize( containerSize ) || ! isValidSize( imageSize ) ) {
 		return {
 			elementSize: { width: 0, height: 0 },
 			visualSize: { width: 0, height: 0 },
@@ -133,12 +136,7 @@ export function createCamera(
 ): Camera {
 	const m = mat2d.create();
 
-	if (
-		containerSize.width === 0 ||
-		containerSize.height === 0 ||
-		imageSize.width === 0 ||
-		imageSize.height === 0
-	) {
+	if ( ! isValidSize( containerSize ) || ! isValidSize( imageSize ) ) {
 		return m;
 	}
 
@@ -156,6 +154,12 @@ export function createCamera(
 		imageSize.height,
 		snapRotation
 	);
+
+	// Defensive: getRotatedBBox returns zero dims for unsafe inputs. Mirror
+	// the zero-size short-circuit so `fitScale` doesn't become Infinity.
+	if ( naturalBBox.width === 0 || naturalBBox.height === 0 ) {
+		return m;
+	}
 
 	// "Contain" fit: scale rotated bounding box to fit within container.
 	const fitScale = Math.min(
@@ -329,16 +333,11 @@ export function createExportCamera(
 	outputSize: Size
 ): Camera {
 	const m = mat2d.create();
-	const { rotation, flip, cropRect, zoom, pan } =
-		sanitizeCropperState( state );
-	if (
-		imageSize.width === 0 ||
-		imageSize.height === 0 ||
-		outputSize.width === 0 ||
-		outputSize.height === 0
-	) {
+	if ( ! isValidSize( imageSize ) || ! isValidSize( outputSize ) ) {
 		return m;
 	}
+	const { rotation, flip, cropRect, zoom, pan } =
+		sanitizeCropperState( state );
 	// Reference frame for cropRect/pan is the snap-rotation bbox — that's
 	// what the stencil and CSS matrix use in the preview (see createCamera
 	// and getImageFit). Using the true rotation here would position the

--- a/packages/media-editor/src/image-editor/core/containment.ts
+++ b/packages/media-editor/src/image-editor/core/containment.ts
@@ -8,6 +8,7 @@ import { mat2d, vec2 } from 'gl-matrix';
  */
 import type { CropperState, NormalizedRect, Size } from './types';
 import { degreesToRadians } from './math/rotation';
+import { safeBoundedNumber, sanitizeCropperState } from './math/sanitize';
 import { createCamera, getRotatedBBox, getVisibleBounds } from './camera';
 
 /** Floating-point epsilon for "close enough to equal" comparisons. */
@@ -118,16 +119,18 @@ export function getImageCropBounds(
 		return { minX: 0, minY: 0, maxX: 1, maxY: 1 };
 	}
 
+	const safeState = sanitizeCropperState( state );
+
 	// Build the same CSS matrix as use-transform-style: flip * rotate * zoom.
 	// Flip is outside rotation so it acts in viewport axes (see createCamera).
-	const tx = state.pan.x * visualSize.width;
-	const ty = state.pan.y * visualSize.height;
-	const rad = degreesToRadians( state.rotation );
+	const tx = safeState.pan.x * visualSize.width;
+	const ty = safeState.pan.y * visualSize.height;
+	const rad = degreesToRadians( safeState.rotation );
 	const cos = Math.cos( rad );
 	const sin = Math.sin( rad );
-	const sx = state.flip.horizontal ? -1 : 1;
-	const sy = state.flip.vertical ? -1 : 1;
-	const z = state.zoom;
+	const sx = safeState.flip.horizontal ? -1 : 1;
+	const sy = safeState.flip.vertical ? -1 : 1;
+	const z = safeState.zoom;
 	const ma = sx * cos * z;
 	const mb = sy * sin * z;
 	const mc = -sx * sin * z;
@@ -190,17 +193,24 @@ export function restrictCropRect(
 	rotation: number,
 	imageAspectRatio: number
 ): NormalizedRect {
-	const aspectRatio = Math.max( imageAspectRatio, Number.EPSILON );
+	// Guard against non-finite inputs. The reducer normalizes these, but
+	// programmatic callers or deserialized state could still send NaN/±Infinity
+	// through here, where it would silently propagate into the crop rect.
+	const zoomCandidate = safeBoundedNumber( zoom, 1 );
+	const safeZoom = zoomCandidate >= Number.EPSILON ? zoomCandidate : 1;
+	const safeRotation = safeBoundedNumber( rotation, 0 );
+	const safeAspect = safeBoundedNumber( imageAspectRatio, 1 );
+	const aspectRatio = Math.max( safeAspect, Number.EPSILON );
 	// Crop rect lives in the SNAP-rotation visual bbox (matching the stencil
 	// layout); projection into the image-local frame uses the TRUE rotation.
-	const snapRotation = Math.round( rotation / 90 ) * 90;
+	const snapRotation = Math.round( safeRotation / 90 ) * 90;
 	const { visualW, visualH } = getVisualDimensions(
 		snapRotation,
 		aspectRatio
 	);
-	const { absC, absS } = getVisualDimensions( rotation, aspectRatio );
-	const W = cropRect.width;
-	const H = cropRect.height;
+	const { absC, absS } = getVisualDimensions( safeRotation, aspectRatio );
+	const W = safeBoundedNumber( cropRect.width, 0 );
+	const H = safeBoundedNumber( cropRect.height, 0 );
 
 	// Crop full-extents in pixel-proportional space, projected to image-local frame.
 	const cropWPx = W * visualW;
@@ -209,8 +219,8 @@ export function restrictCropRect(
 	const spanBeta = cropWPx * absS + cropHPx * absC;
 
 	// Image full-extents at zoom z: (aspectRatio*z, z).
-	const limitAlpha = aspectRatio * zoom;
-	const limitBeta = zoom;
+	const limitAlpha = aspectRatio * safeZoom;
+	const limitBeta = safeZoom;
 
 	let t = 1;
 	if ( spanAlpha > 0 ) {
@@ -226,8 +236,8 @@ export function restrictCropRect(
 	}
 	const newW = W * t;
 	const newH = H * t;
-	const centerX = cropRect.x + W / 2;
-	const centerY = cropRect.y + H / 2;
+	const centerX = safeBoundedNumber( cropRect.x, 0 ) + W / 2;
+	const centerY = safeBoundedNumber( cropRect.y, 0 ) + H / 2;
 	let newX = centerX - newW / 2;
 	let newY = centerY - newH / 2;
 	newX = Math.max( 0, Math.min( newX, 1 - newW ) );
@@ -280,15 +290,20 @@ export function restrictPanZoom(
 	// 6. Convert the world-space correction to a pan-field correction by
 	//    mapping it through the camera's linear part back to screen space,
 	//    then dividing by the visual bounds.
+	const safeState = sanitizeCropperState( state );
 	const aspectRatio =
 		imageSize.width > 0 && imageSize.height > 0
 			? imageSize.width / imageSize.height
 			: 1;
-	const minZoom = getMinZoomForCover( state.rotation, aspectRatio, cropRect );
-	const zoom = Math.max( state.zoom, minZoom );
+	const minZoom = getMinZoomForCover(
+		safeState.rotation,
+		aspectRatio,
+		cropRect
+	);
+	const zoom = Math.max( safeState.zoom, minZoom );
 
 	// Step 2: build camera with candidate pan and corrected zoom.
-	const candidateState = { ...state, zoom };
+	const candidateState = { ...safeState, zoom };
 	const camera = createCamera(
 		candidateState,
 		CANONICAL_CONTAINER,
@@ -300,7 +315,7 @@ export function restrictPanZoom(
 	// nearest 90° rotation (matching `getImageFit`), so it's stable
 	// through fine rotation. CSS zoom only affects the <img> element,
 	// not the stencil.
-	const snapRotation = Math.round( state.rotation / 90 ) * 90;
+	const snapRotation = Math.round( safeState.rotation / 90 ) * 90;
 	const baseCamera = createCamera(
 		{
 			...candidateState,
@@ -371,7 +386,7 @@ export function restrictPanZoom(
 		minWy >= -EPSILON &&
 		maxWy <= 1 + EPSILON
 	) {
-		return { pan: state.pan, zoom };
+		return { pan: safeState.pan, zoom };
 	}
 
 	// Compute world-space correction needed.
@@ -410,10 +425,10 @@ export function restrictPanZoom(
 	// The correction is subtractive: a positive world shift (dw > 0) means
 	// the image needs to move opposite to pan direction, so pan decreases.
 	const newPanX =
-		state.pan.x -
+		safeState.pan.x -
 		( visibleBounds.width > 0 ? dsx / visibleBounds.width : 0 );
 	const newPanY =
-		state.pan.y -
+		safeState.pan.y -
 		( visibleBounds.height > 0 ? dsy / visibleBounds.height : 0 );
 
 	return {

--- a/packages/media-editor/src/image-editor/core/containment.ts
+++ b/packages/media-editor/src/image-editor/core/containment.ts
@@ -294,10 +294,12 @@ export function restrictPanZoom(
 	//    then dividing by the visual bounds.
 	const safeState = sanitizeCropperState( state );
 	const safeCropRect = sanitizeRect( cropRect );
-	const aspectRatio =
-		imageSize.width > 0 && imageSize.height > 0
-			? imageSize.width / imageSize.height
-			: 1;
+	// Use `isValidSize` rather than a bare `> 0` check so Infinity dims
+	// don't drive `Infinity / Infinity = NaN` into `getMinZoomForCover`
+	// and leak as `zoom: NaN` through the no-correction early return.
+	const aspectRatio = isValidSize( imageSize )
+		? imageSize.width / imageSize.height
+		: 1;
 	const minZoom = getMinZoomForCover(
 		safeState.rotation,
 		aspectRatio,

--- a/packages/media-editor/src/image-editor/core/containment.ts
+++ b/packages/media-editor/src/image-editor/core/containment.ts
@@ -8,7 +8,12 @@ import { mat2d, vec2 } from 'gl-matrix';
  */
 import type { CropperState, NormalizedRect, Size } from './types';
 import { degreesToRadians } from './math/rotation';
-import { safeBoundedNumber, sanitizeCropperState } from './math/sanitize';
+import {
+	isValidSize,
+	safeBoundedNumber,
+	sanitizeCropperState,
+	sanitizeRect,
+} from './math/sanitize';
 import { createCamera, getRotatedBBox, getVisibleBounds } from './camera';
 
 /** Floating-point epsilon for "close enough to equal" comparisons. */
@@ -110,12 +115,7 @@ export function getImageCropBounds(
 	elementSize: Size,
 	visualSize: Size
 ): { minX: number; minY: number; maxX: number; maxY: number } {
-	if (
-		elementSize.width === 0 ||
-		elementSize.height === 0 ||
-		visualSize.width === 0 ||
-		visualSize.height === 0
-	) {
+	if ( ! isValidSize( elementSize ) || ! isValidSize( visualSize ) ) {
 		return { minX: 0, minY: 0, maxX: 1, maxY: 1 };
 	}
 
@@ -196,6 +196,7 @@ export function restrictCropRect(
 	// Guard against non-finite inputs. The reducer normalizes these, but
 	// programmatic callers or deserialized state could still send NaN/±Infinity
 	// through here, where it would silently propagate into the crop rect.
+	const safeRect = sanitizeRect( cropRect );
 	const zoomCandidate = safeBoundedNumber( zoom, 1 );
 	const safeZoom = zoomCandidate >= Number.EPSILON ? zoomCandidate : 1;
 	const safeRotation = safeBoundedNumber( rotation, 0 );
@@ -209,8 +210,8 @@ export function restrictCropRect(
 		aspectRatio
 	);
 	const { absC, absS } = getVisualDimensions( safeRotation, aspectRatio );
-	const W = safeBoundedNumber( cropRect.width, 0 );
-	const H = safeBoundedNumber( cropRect.height, 0 );
+	const W = safeRect.width;
+	const H = safeRect.height;
 
 	// Crop full-extents in pixel-proportional space, projected to image-local frame.
 	const cropWPx = W * visualW;
@@ -231,13 +232,14 @@ export function restrictCropRect(
 	}
 	if ( t >= 1 - EPSILON ) {
 		// Crop fits at the current zoom — no size change needed.
-		// Position is handled by restrictPanZoom, not here.
-		return cropRect;
+		// Return the sanitized rect (not the raw arg) so non-finite fields
+		// don't slip through this path. Position is handled by restrictPanZoom.
+		return safeRect;
 	}
 	const newW = W * t;
 	const newH = H * t;
-	const centerX = safeBoundedNumber( cropRect.x, 0 ) + W / 2;
-	const centerY = safeBoundedNumber( cropRect.y, 0 ) + H / 2;
+	const centerX = safeRect.x + W / 2;
+	const centerY = safeRect.y + H / 2;
 	let newX = centerX - newW / 2;
 	let newY = centerY - newH / 2;
 	newX = Math.max( 0, Math.min( newX, 1 - newW ) );
@@ -291,6 +293,7 @@ export function restrictPanZoom(
 	//    mapping it through the camera's linear part back to screen space,
 	//    then dividing by the visual bounds.
 	const safeState = sanitizeCropperState( state );
+	const safeCropRect = sanitizeRect( cropRect );
 	const aspectRatio =
 		imageSize.width > 0 && imageSize.height > 0
 			? imageSize.width / imageSize.height
@@ -298,7 +301,7 @@ export function restrictPanZoom(
 	const minZoom = getMinZoomForCover(
 		safeState.rotation,
 		aspectRatio,
-		cropRect
+		safeCropRect
 	);
 	const zoom = Math.max( safeState.zoom, minZoom );
 
@@ -331,24 +334,24 @@ export function restrictPanZoom(
 	// Stencil corners in screen space (axis-aligned rect within visual bounds).
 	const stencilCorners: [ number, number ][] = [
 		[
-			visibleBounds.left + cropRect.x * visibleBounds.width,
-			visibleBounds.top + cropRect.y * visibleBounds.height,
+			visibleBounds.left + safeCropRect.x * visibleBounds.width,
+			visibleBounds.top + safeCropRect.y * visibleBounds.height,
 		],
 		[
 			visibleBounds.left +
-				( cropRect.x + cropRect.width ) * visibleBounds.width,
-			visibleBounds.top + cropRect.y * visibleBounds.height,
+				( safeCropRect.x + safeCropRect.width ) * visibleBounds.width,
+			visibleBounds.top + safeCropRect.y * visibleBounds.height,
 		],
 		[
 			visibleBounds.left +
-				( cropRect.x + cropRect.width ) * visibleBounds.width,
+				( safeCropRect.x + safeCropRect.width ) * visibleBounds.width,
 			visibleBounds.top +
-				( cropRect.y + cropRect.height ) * visibleBounds.height,
+				( safeCropRect.y + safeCropRect.height ) * visibleBounds.height,
 		],
 		[
-			visibleBounds.left + cropRect.x * visibleBounds.width,
+			visibleBounds.left + safeCropRect.x * visibleBounds.width,
 			visibleBounds.top +
-				( cropRect.y + cropRect.height ) * visibleBounds.height,
+				( safeCropRect.y + safeCropRect.height ) * visibleBounds.height,
 		],
 	];
 

--- a/packages/media-editor/src/image-editor/core/math/sanitize.ts
+++ b/packages/media-editor/src/image-editor/core/math/sanitize.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import type { CropperState } from '../types';
+import type { CropperState, NormalizedRect, Size } from '../types';
 
 /**
  * Magnitude beyond which any cropper-math input is treated as corrupt.
@@ -14,9 +14,12 @@ const MAX_SAFE_MAGNITUDE = 1e6;
 /**
  * Returns `value` if it's finite and within `[-MAX_SAFE_MAGNITUDE,
  * MAX_SAFE_MAGNITUDE]`, otherwise `fallback`. Stricter than `Number.isFinite`
- * because extreme finite numbers (`MAX_VALUE`, sub-normal denormals) can
- * still overflow downstream trig/matrix math even though the spec reports
- * them as finite.
+ * because extreme finite magnitudes (e.g. `Number.MAX_VALUE`) overflow
+ * downstream trig/matrix math even though the spec reports them as finite.
+ *
+ * Note: sub-normal denormals (e.g. `Number.MIN_VALUE`) are accepted by this
+ * function — they don't overflow on their own. Protection against divisions
+ * by sub-normal values lives in `sanitizeCropperState`'s zoom guard.
  *
  * @param value    The candidate value.
  * @param fallback The replacement to return when `value` is unsafe.
@@ -33,6 +36,63 @@ export function safeBoundedNumber( value: number, fallback: number ): number {
 }
 
 /**
+ * Returns `true` when `value` is finite and within `[-MAX_SAFE_MAGNITUDE,
+ * MAX_SAFE_MAGNITUDE]`. The predicate companion to {@link safeBoundedNumber}
+ * for callers that need to short-circuit rather than substitute a fallback.
+ *
+ * @param value The candidate value.
+ * @return Whether `value` is safe to use in math.
+ */
+export function isSafeNumber( value: number ): boolean {
+	return Number.isFinite( value ) && Math.abs( value ) <= MAX_SAFE_MAGNITUDE;
+}
+
+/**
+ * Returns `true` when both dimensions are finite, strictly positive, and
+ * within the safe magnitude range. Use this to short-circuit math that
+ * would otherwise divide by zero, produce `Infinity` from large dims, or
+ * propagate `NaN`.
+ *
+ * @param size The size to check.
+ * @return Whether `size` is safe to use in math.
+ */
+export function isValidSize( size: Size ): boolean {
+	return (
+		Number.isFinite( size.width ) &&
+		Number.isFinite( size.height ) &&
+		size.width > 0 &&
+		size.height > 0 &&
+		size.width <= MAX_SAFE_MAGNITUDE &&
+		size.height <= MAX_SAFE_MAGNITUDE
+	);
+}
+
+/**
+ * Returns a copy of `rect` with every numeric field replaced by a safe
+ * value via {@link safeBoundedNumber}. Returns the same reference when no
+ * field needed substitution so callers can keep their reference-equality
+ * short-circuits intact for clean inputs.
+ *
+ * @param rect The rect to sanitize.
+ * @return A rect with all numeric fields finite.
+ */
+export function sanitizeRect( rect: NormalizedRect ): NormalizedRect {
+	const x = safeBoundedNumber( rect.x, 0 );
+	const y = safeBoundedNumber( rect.y, 0 );
+	const width = safeBoundedNumber( rect.width, 0 );
+	const height = safeBoundedNumber( rect.height, 0 );
+	if (
+		x === rect.x &&
+		y === rect.y &&
+		width === rect.width &&
+		height === rect.height
+	) {
+		return rect;
+	}
+	return { x, y, width, height };
+}
+
+/**
  * Returns a copy of `state` with any non-finite numeric fields replaced by
  * safe defaults. The reducer already normalizes these on every action, so
  * downstream math layers can call this as defense-in-depth without changing
@@ -45,8 +105,13 @@ export function sanitizeCropperState( state: CropperState ): CropperState {
 	const zoom = safeBoundedNumber( state.zoom, 1 );
 	const baseZoom = safeBoundedNumber( state.baseZoom, 1 );
 	// Zoom must be strictly positive AND large enough that 1/zoom doesn't
-	// overflow. Subnormals (e.g. Number.MIN_VALUE) pass `> 0` but make
+	// overflow. Sub-normals (e.g. Number.MIN_VALUE) pass `> 0` but make
 	// division explode, so guard against them with Number.EPSILON.
+	// Note: `state.image` is intentionally not cloned here. The math layer
+	// receives image dimensions as a separate `imageSize` argument, so the
+	// `state.image` numeric fields don't feed into any math we need to defend.
+	// Sanitizing them would force a new image object every call and break
+	// reference-equality optimizations the reducer relies on.
 	return {
 		...state,
 		pan: {
@@ -61,11 +126,6 @@ export function sanitizeCropperState( state: CropperState ): CropperState {
 		},
 		baseZoom: baseZoom >= Number.EPSILON ? baseZoom : 1,
 		baseRotation: safeBoundedNumber( state.baseRotation, 0 ),
-		cropRect: {
-			x: safeBoundedNumber( state.cropRect.x, 0 ),
-			y: safeBoundedNumber( state.cropRect.y, 0 ),
-			width: safeBoundedNumber( state.cropRect.width, 0 ),
-			height: safeBoundedNumber( state.cropRect.height, 0 ),
-		},
+		cropRect: sanitizeRect( state.cropRect ),
 	};
 }

--- a/packages/media-editor/src/image-editor/core/math/sanitize.ts
+++ b/packages/media-editor/src/image-editor/core/math/sanitize.ts
@@ -1,0 +1,71 @@
+/**
+ * Internal dependencies
+ */
+import type { CropperState } from '../types';
+
+/**
+ * Magnitude beyond which any cropper-math input is treated as corrupt.
+ * Picks a value well above any realistic image/rotation/zoom/pan but far
+ * below `Number.MAX_VALUE`, so multiplications inside trig and matrix code
+ * can't overflow to `Infinity`.
+ */
+const MAX_SAFE_MAGNITUDE = 1e6;
+
+/**
+ * Returns `value` if it's finite and within `[-MAX_SAFE_MAGNITUDE,
+ * MAX_SAFE_MAGNITUDE]`, otherwise `fallback`. Stricter than `Number.isFinite`
+ * because extreme finite numbers (`MAX_VALUE`, sub-normal denormals) can
+ * still overflow downstream trig/matrix math even though the spec reports
+ * them as finite.
+ *
+ * @param value    The candidate value.
+ * @param fallback The replacement to return when `value` is unsafe.
+ * @return Either `value` or `fallback`.
+ */
+export function safeBoundedNumber( value: number, fallback: number ): number {
+	if ( ! Number.isFinite( value ) ) {
+		return fallback;
+	}
+	if ( Math.abs( value ) > MAX_SAFE_MAGNITUDE ) {
+		return fallback;
+	}
+	return value;
+}
+
+/**
+ * Returns a copy of `state` with any non-finite numeric fields replaced by
+ * safe defaults. The reducer already normalizes these on every action, so
+ * downstream math layers can call this as defense-in-depth without changing
+ * behavior under normal flows.
+ *
+ * @param state The cropper state to sanitize.
+ * @return A cropper state with all numeric fields finite.
+ */
+export function sanitizeCropperState( state: CropperState ): CropperState {
+	const zoom = safeBoundedNumber( state.zoom, 1 );
+	const baseZoom = safeBoundedNumber( state.baseZoom, 1 );
+	// Zoom must be strictly positive AND large enough that 1/zoom doesn't
+	// overflow. Subnormals (e.g. Number.MIN_VALUE) pass `> 0` but make
+	// division explode, so guard against them with Number.EPSILON.
+	return {
+		...state,
+		pan: {
+			x: safeBoundedNumber( state.pan.x, 0 ),
+			y: safeBoundedNumber( state.pan.y, 0 ),
+		},
+		zoom: zoom >= Number.EPSILON ? zoom : 1,
+		rotation: safeBoundedNumber( state.rotation, 0 ),
+		basePan: {
+			x: safeBoundedNumber( state.basePan.x, 0 ),
+			y: safeBoundedNumber( state.basePan.y, 0 ),
+		},
+		baseZoom: baseZoom >= Number.EPSILON ? baseZoom : 1,
+		baseRotation: safeBoundedNumber( state.baseRotation, 0 ),
+		cropRect: {
+			x: safeBoundedNumber( state.cropRect.x, 0 ),
+			y: safeBoundedNumber( state.cropRect.y, 0 ),
+			width: safeBoundedNumber( state.cropRect.width, 0 ),
+			height: safeBoundedNumber( state.cropRect.height, 0 ),
+		},
+	};
+}

--- a/packages/media-editor/src/image-editor/core/math/sanitize.ts
+++ b/packages/media-editor/src/image-editor/core/math/sanitize.ts
@@ -48,10 +48,12 @@ export function isSafeNumber( value: number ): boolean {
 }
 
 /**
- * Returns `true` when both dimensions are finite, strictly positive, and
- * within the safe magnitude range. Use this to short-circuit math that
- * would otherwise divide by zero, produce `Infinity` from large dims, or
- * propagate `NaN`.
+ * Returns `true` when both dimensions are finite and within the safe
+ * range `[Number.EPSILON, MAX_SAFE_MAGNITUDE]`. The lower bound matters
+ * because sub-normal dimensions (e.g. `Number.MIN_VALUE`) pass `> 0` but
+ * make `container / dim` overflow to `Infinity` downstream in
+ * `getImageFit` / `createCamera`. Use this to short-circuit math that
+ * would otherwise produce non-finite output.
  *
  * @param size The size to check.
  * @return Whether `size` is safe to use in math.
@@ -60,8 +62,8 @@ export function isValidSize( size: Size ): boolean {
 	return (
 		Number.isFinite( size.width ) &&
 		Number.isFinite( size.height ) &&
-		size.width > 0 &&
-		size.height > 0 &&
+		size.width >= Number.EPSILON &&
+		size.height >= Number.EPSILON &&
 		size.width <= MAX_SAFE_MAGNITUDE &&
 		size.height <= MAX_SAFE_MAGNITUDE
 	);
@@ -93,39 +95,64 @@ export function sanitizeRect( rect: NormalizedRect ): NormalizedRect {
 }
 
 /**
- * Returns a copy of `state` with any non-finite numeric fields replaced by
- * safe defaults. The reducer already normalizes these on every action, so
- * downstream math layers can call this as defense-in-depth without changing
- * behavior under normal flows.
+ * Returns a copy of `state` with the cropper-math numeric fields replaced
+ * by safe defaults. Covers `pan`, `zoom`, `rotation`, the matching base
+ * pose, and `cropRect`. The `state.image` numeric fields (naturalWidth /
+ * naturalHeight) are intentionally NOT sanitized — image dimensions reach
+ * the math layer as a separate `imageSize` argument, and cloning the
+ * image object here would break the reducer's reference-equality
+ * short-circuit.
+ *
+ * Returns the same `state` reference when no field needed substitution
+ * so callers in hot paths (every pointermove via `restrictPanZoom`) can
+ * keep their reference-equality optimizations. Sub-object references
+ * (`pan`, `basePan`, `cropRect`) are also preserved when their fields
+ * are individually clean.
  *
  * @param state The cropper state to sanitize.
- * @return A cropper state with all numeric fields finite.
+ * @return A cropper state with the math-relevant numeric fields finite.
  */
 export function sanitizeCropperState( state: CropperState ): CropperState {
-	const zoom = safeBoundedNumber( state.zoom, 1 );
-	const baseZoom = safeBoundedNumber( state.baseZoom, 1 );
+	const panX = safeBoundedNumber( state.pan.x, 0 );
+	const panY = safeBoundedNumber( state.pan.y, 0 );
+	const basePanX = safeBoundedNumber( state.basePan.x, 0 );
+	const basePanY = safeBoundedNumber( state.basePan.y, 0 );
+	const rotation = safeBoundedNumber( state.rotation, 0 );
+	const baseRotation = safeBoundedNumber( state.baseRotation, 0 );
+	const rawZoom = safeBoundedNumber( state.zoom, 1 );
 	// Zoom must be strictly positive AND large enough that 1/zoom doesn't
 	// overflow. Sub-normals (e.g. Number.MIN_VALUE) pass `> 0` but make
 	// division explode, so guard against them with Number.EPSILON.
-	// Note: `state.image` is intentionally not cloned here. The math layer
-	// receives image dimensions as a separate `imageSize` argument, so the
-	// `state.image` numeric fields don't feed into any math we need to defend.
-	// Sanitizing them would force a new image object every call and break
-	// reference-equality optimizations the reducer relies on.
+	const zoom = rawZoom >= Number.EPSILON ? rawZoom : 1;
+	const rawBaseZoom = safeBoundedNumber( state.baseZoom, 1 );
+	const baseZoom = rawBaseZoom >= Number.EPSILON ? rawBaseZoom : 1;
+	const cropRect = sanitizeRect( state.cropRect );
+
+	const panUnchanged = panX === state.pan.x && panY === state.pan.y;
+	const basePanUnchanged =
+		basePanX === state.basePan.x && basePanY === state.basePan.y;
+
+	if (
+		panUnchanged &&
+		basePanUnchanged &&
+		zoom === state.zoom &&
+		baseZoom === state.baseZoom &&
+		rotation === state.rotation &&
+		baseRotation === state.baseRotation &&
+		cropRect === state.cropRect
+	) {
+		return state;
+	}
 	return {
 		...state,
-		pan: {
-			x: safeBoundedNumber( state.pan.x, 0 ),
-			y: safeBoundedNumber( state.pan.y, 0 ),
-		},
-		zoom: zoom >= Number.EPSILON ? zoom : 1,
-		rotation: safeBoundedNumber( state.rotation, 0 ),
-		basePan: {
-			x: safeBoundedNumber( state.basePan.x, 0 ),
-			y: safeBoundedNumber( state.basePan.y, 0 ),
-		},
-		baseZoom: baseZoom >= Number.EPSILON ? baseZoom : 1,
-		baseRotation: safeBoundedNumber( state.baseRotation, 0 ),
-		cropRect: sanitizeRect( state.cropRect ),
+		pan: panUnchanged ? state.pan : { x: panX, y: panY },
+		zoom,
+		rotation,
+		basePan: basePanUnchanged
+			? state.basePan
+			: { x: basePanX, y: basePanY },
+		baseZoom,
+		baseRotation,
+		cropRect,
 	};
 }

--- a/packages/media-editor/src/image-editor/core/math/test/sanitize.ts
+++ b/packages/media-editor/src/image-editor/core/math/test/sanitize.ts
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import { safeBoundedNumber, sanitizeCropperState } from '../sanitize';
+import {
+	isValidSize,
+	safeBoundedNumber,
+	sanitizeCropperState,
+	sanitizeRect,
+} from '../sanitize';
 import { DEFAULT_STATE } from '../../constants';
 import type { CropperState } from '../../types';
 
@@ -22,8 +27,8 @@ describe( 'safeBoundedNumber', () => {
 	} );
 
 	it( 'returns the fallback for finite values beyond the safe magnitude', () => {
-		// MAX_VALUE / MIN_VALUE are technically finite but cause overflow
-		// when multiplied through trig and matrix code.
+		// MAX_VALUE is technically finite but multiplying it through trig
+		// and matrix code overflows to Infinity.
 		expect( safeBoundedNumber( Number.MAX_VALUE, 1 ) ).toBe( 1 );
 		expect( safeBoundedNumber( -Number.MAX_VALUE, 1 ) ).toBe( 1 );
 		expect( safeBoundedNumber( 1e10, 1 ) ).toBe( 1 );
@@ -32,6 +37,67 @@ describe( 'safeBoundedNumber', () => {
 	it( 'accepts values right at the safe magnitude boundary', () => {
 		expect( safeBoundedNumber( 1e6, 0 ) ).toBe( 1e6 );
 		expect( safeBoundedNumber( -1e6, 0 ) ).toBe( -1e6 );
+	} );
+
+	it( 'accepts sub-normal values (sub-normal protection lives elsewhere)', () => {
+		// Sub-normals don't overflow on their own; they only cause trouble
+		// when used as divisors. That guard lives in sanitizeCropperState's
+		// zoom check, not here.
+		expect( safeBoundedNumber( Number.MIN_VALUE, 0 ) ).toBe(
+			Number.MIN_VALUE
+		);
+	} );
+} );
+
+describe( 'isValidSize', () => {
+	it( 'returns true for finite, positive, in-range sizes', () => {
+		expect( isValidSize( { width: 100, height: 100 } ) ).toBe( true );
+		expect( isValidSize( { width: 1, height: 1 } ) ).toBe( true );
+		expect( isValidSize( { width: 1e6, height: 1e6 } ) ).toBe( true );
+	} );
+
+	it( 'returns false for zero or negative dimensions', () => {
+		expect( isValidSize( { width: 0, height: 100 } ) ).toBe( false );
+		expect( isValidSize( { width: 100, height: 0 } ) ).toBe( false );
+		expect( isValidSize( { width: -1, height: 100 } ) ).toBe( false );
+	} );
+
+	it( 'returns false for non-finite dimensions', () => {
+		expect( isValidSize( { width: Number.NaN, height: 100 } ) ).toBe(
+			false
+		);
+		expect(
+			isValidSize( {
+				width: Number.POSITIVE_INFINITY,
+				height: 100,
+			} )
+		).toBe( false );
+	} );
+
+	it( 'returns false for dimensions beyond the safe magnitude', () => {
+		expect( isValidSize( { width: Number.MAX_VALUE, height: 100 } ) ).toBe(
+			false
+		);
+		expect( isValidSize( { width: 1e10, height: 100 } ) ).toBe( false );
+	} );
+} );
+
+describe( 'sanitizeRect', () => {
+	it( 'replaces non-finite fields with 0', () => {
+		expect(
+			sanitizeRect( {
+				x: Number.NaN,
+				y: 0.1,
+				width: Number.POSITIVE_INFINITY,
+				height: 0.5,
+			} )
+		).toEqual( { x: 0, y: 0.1, width: 0, height: 0.5 } );
+	} );
+
+	it( 'leaves a clean rect unchanged', () => {
+		expect(
+			sanitizeRect( { x: 0.1, y: 0.2, width: 0.5, height: 0.3 } )
+		).toEqual( { x: 0.1, y: 0.2, width: 0.5, height: 0.3 } );
 	} );
 } );
 
@@ -126,5 +192,19 @@ describe( 'sanitizeCropperState', () => {
 		expect( out.basePan ).toEqual( { x: 0, y: 0 } );
 		expect( out.baseZoom ).toBe( 1 );
 		expect( out.baseRotation ).toBe( 0 );
+	} );
+
+	it( 'leaves state.image untouched (caller passes imageSize separately)', () => {
+		// The math layer never reads state.image — image dimensions arrive as
+		// a separate `imageSize` argument. Cloning state.image on every call
+		// would break the reducer's reference-equality short-circuit.
+		const image = {
+			src: 'test.jpg',
+			naturalWidth: 1600,
+			naturalHeight: 900,
+		};
+		const state = makeBaseState( { image } );
+		const out = sanitizeCropperState( state );
+		expect( out.image ).toBe( image );
 	} );
 } );

--- a/packages/media-editor/src/image-editor/core/math/test/sanitize.ts
+++ b/packages/media-editor/src/image-editor/core/math/test/sanitize.ts
@@ -1,0 +1,130 @@
+/**
+ * Internal dependencies
+ */
+import { safeBoundedNumber, sanitizeCropperState } from '../sanitize';
+import { DEFAULT_STATE } from '../../constants';
+import type { CropperState } from '../../types';
+
+describe( 'safeBoundedNumber', () => {
+	it( 'returns the value when it is finite and in range', () => {
+		expect( safeBoundedNumber( 42, 0 ) ).toBe( 42 );
+		expect( safeBoundedNumber( -3.14, 0 ) ).toBe( -3.14 );
+		expect( safeBoundedNumber( 0, 1 ) ).toBe( 0 );
+	} );
+
+	it( 'returns the fallback for NaN', () => {
+		expect( safeBoundedNumber( Number.NaN, 7 ) ).toBe( 7 );
+	} );
+
+	it( 'returns the fallback for ±Infinity', () => {
+		expect( safeBoundedNumber( Number.POSITIVE_INFINITY, 7 ) ).toBe( 7 );
+		expect( safeBoundedNumber( Number.NEGATIVE_INFINITY, 7 ) ).toBe( 7 );
+	} );
+
+	it( 'returns the fallback for finite values beyond the safe magnitude', () => {
+		// MAX_VALUE / MIN_VALUE are technically finite but cause overflow
+		// when multiplied through trig and matrix code.
+		expect( safeBoundedNumber( Number.MAX_VALUE, 1 ) ).toBe( 1 );
+		expect( safeBoundedNumber( -Number.MAX_VALUE, 1 ) ).toBe( 1 );
+		expect( safeBoundedNumber( 1e10, 1 ) ).toBe( 1 );
+	} );
+
+	it( 'accepts values right at the safe magnitude boundary', () => {
+		expect( safeBoundedNumber( 1e6, 0 ) ).toBe( 1e6 );
+		expect( safeBoundedNumber( -1e6, 0 ) ).toBe( -1e6 );
+	} );
+} );
+
+describe( 'sanitizeCropperState', () => {
+	function makeBaseState(
+		overrides: Partial< CropperState > = {}
+	): CropperState {
+		return {
+			...DEFAULT_STATE,
+			...overrides,
+		};
+	}
+
+	it( 'leaves a clean state unchanged', () => {
+		const state = makeBaseState( {
+			pan: { x: 0.1, y: -0.05 },
+			zoom: 1.5,
+			rotation: 30,
+		} );
+		const out = sanitizeCropperState( state );
+		expect( out.pan ).toEqual( { x: 0.1, y: -0.05 } );
+		expect( out.zoom ).toBe( 1.5 );
+		expect( out.rotation ).toBe( 30 );
+	} );
+
+	it( 'replaces NaN pan with zero', () => {
+		const state = makeBaseState( {
+			pan: { x: Number.NaN, y: Number.NaN },
+		} );
+		const out = sanitizeCropperState( state );
+		expect( out.pan ).toEqual( { x: 0, y: 0 } );
+	} );
+
+	it( 'replaces non-finite zoom with 1 (identity)', () => {
+		expect(
+			sanitizeCropperState( makeBaseState( { zoom: Number.NaN } ) ).zoom
+		).toBe( 1 );
+		expect(
+			sanitizeCropperState(
+				makeBaseState( { zoom: Number.POSITIVE_INFINITY } )
+			).zoom
+		).toBe( 1 );
+		expect(
+			sanitizeCropperState( makeBaseState( { zoom: -2 } ) ).zoom
+		).toBe( 1 );
+	} );
+
+	it( 'replaces sub-normal zoom with 1 (prevents division explosion)', () => {
+		expect(
+			sanitizeCropperState( makeBaseState( { zoom: Number.MIN_VALUE } ) )
+				.zoom
+		).toBe( 1 );
+	} );
+
+	it( 'replaces extreme rotation magnitudes with 0', () => {
+		expect(
+			sanitizeCropperState(
+				makeBaseState( { rotation: Number.MAX_VALUE } )
+			).rotation
+		).toBe( 0 );
+		expect(
+			sanitizeCropperState( makeBaseState( { rotation: Number.NaN } ) )
+				.rotation
+		).toBe( 0 );
+	} );
+
+	it( 'sanitizes cropRect fields independently', () => {
+		const state = makeBaseState( {
+			cropRect: {
+				x: Number.NaN,
+				y: 0.1,
+				width: Number.POSITIVE_INFINITY,
+				height: 0.5,
+			},
+		} );
+		const out = sanitizeCropperState( state );
+		expect( out.cropRect ).toEqual( {
+			x: 0,
+			y: 0.1,
+			width: 0,
+			height: 0.5,
+		} );
+	} );
+
+	it( 'sanitizes base pose fields (basePan, baseZoom, baseRotation)', () => {
+		const state = makeBaseState( {
+			basePan: { x: Number.NaN, y: 0 },
+			baseZoom: Number.NEGATIVE_INFINITY,
+			baseRotation: Number.MAX_VALUE,
+		} );
+		const out = sanitizeCropperState( state );
+		expect( out.basePan ).toEqual( { x: 0, y: 0 } );
+		expect( out.baseZoom ).toBe( 1 );
+		expect( out.baseRotation ).toBe( 0 );
+	} );
+} );

--- a/packages/media-editor/src/image-editor/core/math/test/sanitize.ts
+++ b/packages/media-editor/src/image-editor/core/math/test/sanitize.ts
@@ -80,6 +80,17 @@ describe( 'isValidSize', () => {
 		);
 		expect( isValidSize( { width: 1e10, height: 100 } ) ).toBe( false );
 	} );
+
+	it( 'returns false for sub-normal dimensions (overflow when divided into)', () => {
+		// Number.MIN_VALUE passes `> 0` but `container / MIN_VALUE`
+		// overflows to Infinity downstream in getImageFit / createCamera.
+		expect( isValidSize( { width: Number.MIN_VALUE, height: 100 } ) ).toBe(
+			false
+		);
+		expect( isValidSize( { width: 100, height: Number.MIN_VALUE } ) ).toBe(
+			false
+		);
+	} );
 } );
 
 describe( 'sanitizeRect', () => {
@@ -192,6 +203,29 @@ describe( 'sanitizeCropperState', () => {
 		expect( out.basePan ).toEqual( { x: 0, y: 0 } );
 		expect( out.baseZoom ).toBe( 1 );
 		expect( out.baseRotation ).toBe( 0 );
+	} );
+
+	it( 'returns the same reference when no field needs substitution', () => {
+		// Called once per pointermove (via restrictPanZoom + createCamera),
+		// so the no-change fast path matters. Clean state → same reference,
+		// no per-frame GC churn.
+		const state = makeBaseState( {
+			pan: { x: 0.1, y: -0.05 },
+			zoom: 1.5,
+			rotation: 30,
+		} );
+		expect( sanitizeCropperState( state ) ).toBe( state );
+	} );
+
+	it( 'preserves sub-object references when only some fields change', () => {
+		// If pan is clean but zoom is corrupted, pan should keep its
+		// reference even though the parent state must be a new object.
+		const pan = { x: 0.1, y: -0.05 };
+		const state = makeBaseState( { pan, zoom: Number.NaN } );
+		const out = sanitizeCropperState( state );
+		expect( out ).not.toBe( state );
+		expect( out.pan ).toBe( pan );
+		expect( out.zoom ).toBe( 1 );
 	} );
 
 	it( 'leaves state.image untouched (caller passes imageSize separately)', () => {

--- a/packages/media-editor/src/image-editor/core/source-region.ts
+++ b/packages/media-editor/src/image-editor/core/source-region.ts
@@ -8,6 +8,7 @@ import { mat2d, vec2 } from 'gl-matrix';
  */
 import type { CropperState, Size } from './types';
 import { createCamera, getRotatedBBox, getVisibleBounds } from './camera';
+import { sanitizeCropperState } from './math/sanitize';
 
 /**
  * The selected image region in source-pixel coordinates.
@@ -63,10 +64,12 @@ export function getSourceRegion(
 		};
 	}
 
+	const safeState = sanitizeCropperState( state );
+
 	// Use a synthetic 1:1 container so the camera maps normalized coords
 	// to a known pixel space. The container size cancels out.
 	const syntheticContainer: Size = { width: 1000, height: 1000 };
-	const camera = createCamera( state, syntheticContainer, imageSize );
+	const camera = createCamera( safeState, syntheticContainer, imageSize );
 
 	// Inverse camera maps screen pixels back to normalized [0,1] world coords.
 	const inv = mat2d.create();
@@ -76,13 +79,13 @@ export function getSourceRegion(
 	// (zoom=1, no pan) to locate the visual bounds, then place the
 	// crop rect within them.
 	const baseCamera = createCamera(
-		{ ...state, pan: { x: 0, y: 0 }, zoom: 1 },
+		{ ...safeState, pan: { x: 0, y: 0 }, zoom: 1 },
 		syntheticContainer,
 		imageSize
 	);
 	const visibleBounds = getVisibleBounds( baseCamera );
 
-	const cropRect = state.cropRect;
+	const cropRect = safeState.cropRect;
 	const cropCenterScreenX =
 		visibleBounds.left +
 		( cropRect.x + cropRect.width / 2 ) * visibleBounds.width;
@@ -100,23 +103,23 @@ export function getSourceRegion(
 
 	// Crop rect size in the snap-rotation visual space, divided by zoom
 	// for source-pixel dimensions. Matches the stencil's reference frame.
-	const snapRotation = Math.round( state.rotation / 90 ) * 90;
+	const snapRotation = Math.round( safeState.rotation / 90 ) * 90;
 	const { width: rotW, height: rotH } = getRotatedBBox(
 		imageSize.width,
 		imageSize.height,
 		snapRotation
 	);
-	const sourceW = ( cropRect.width * rotW ) / state.zoom;
-	const sourceH = ( cropRect.height * rotH ) / state.zoom;
+	const sourceW = ( cropRect.width * rotW ) / safeState.zoom;
+	const sourceH = ( cropRect.height * rotH ) / safeState.zoom;
 
 	return {
 		x: srcCenter[ 0 ] * imageSize.width - sourceW / 2,
 		y: srcCenter[ 1 ] * imageSize.height - sourceH / 2,
 		width: sourceW,
 		height: sourceH,
-		rotation: state.rotation,
-		flip: { ...state.flip },
-		zoom: state.zoom,
+		rotation: safeState.rotation,
+		flip: { ...safeState.flip },
+		zoom: safeState.zoom,
 	};
 }
 

--- a/packages/media-editor/src/image-editor/core/source-region.ts
+++ b/packages/media-editor/src/image-editor/core/source-region.ts
@@ -53,8 +53,9 @@ export function getSourceRegion(
 	imageSize: Size
 ): SourceRegion {
 	// Sanitize before the zero-size short-circuit so the early return
-	// doesn't leak raw non-finite state.rotation/state.zoom/state.flip
-	// out through the metadata fields.
+	// doesn't leak raw non-finite state.rotation or state.zoom out
+	// through the metadata fields. (state.flip is boolean and isn't
+	// at risk of NaN propagation.)
 	const safeState = sanitizeCropperState( state );
 
 	if ( ! isValidSize( imageSize ) ) {

--- a/packages/media-editor/src/image-editor/core/source-region.ts
+++ b/packages/media-editor/src/image-editor/core/source-region.ts
@@ -8,7 +8,7 @@ import { mat2d, vec2 } from 'gl-matrix';
  */
 import type { CropperState, Size } from './types';
 import { createCamera, getRotatedBBox, getVisibleBounds } from './camera';
-import { sanitizeCropperState } from './math/sanitize';
+import { isValidSize, sanitizeCropperState } from './math/sanitize';
 
 /**
  * The selected image region in source-pixel coordinates.
@@ -52,19 +52,22 @@ export function getSourceRegion(
 	state: CropperState,
 	imageSize: Size
 ): SourceRegion {
-	if ( imageSize.width === 0 || imageSize.height === 0 ) {
+	// Sanitize before the zero-size short-circuit so the early return
+	// doesn't leak raw non-finite state.rotation/state.zoom/state.flip
+	// out through the metadata fields.
+	const safeState = sanitizeCropperState( state );
+
+	if ( ! isValidSize( imageSize ) ) {
 		return {
 			x: 0,
 			y: 0,
 			width: 0,
 			height: 0,
-			rotation: state.rotation,
-			flip: { ...state.flip },
-			zoom: state.zoom,
+			rotation: safeState.rotation,
+			flip: { ...safeState.flip },
+			zoom: safeState.zoom,
 		};
 	}
-
-	const safeState = sanitizeCropperState( state );
 
 	// Use a synthetic 1:1 container so the camera maps normalized coords
 	// to a known pixel space. The container size cancels out.
@@ -156,7 +159,7 @@ export function getSourceRegionPercent(
 	state: CropperState,
 	imageSize: Size
 ): SourceRegionPercent {
-	if ( imageSize.width === 0 || imageSize.height === 0 ) {
+	if ( ! isValidSize( imageSize ) ) {
 		return { x: 0, y: 0, width: 0, height: 0 };
 	}
 	const region = getSourceRegion( state, imageSize );

--- a/packages/media-editor/src/image-editor/core/test/camera.ts
+++ b/packages/media-editor/src/image-editor/core/test/camera.ts
@@ -604,6 +604,10 @@ describe( 'getRotatedBBox — non-finite input regression', () => {
 		[ '±Infinity height', 100, Number.POSITIVE_INFINITY, 30 ],
 		[ 'NaN rotation', 100, 100, Number.NaN ],
 		[ '-Infinity rotation', 100, 100, Number.NEGATIVE_INFINITY ],
+		// MAX_VALUE is finite but degreesToRadians( MAX_VALUE ) overflows
+		// to Infinity, then Math.cos/sin return NaN. The magnitude bound
+		// in `safeBoundedNumber` catches this before the trig.
+		[ 'MAX_VALUE rotation', 100, 100, Number.MAX_VALUE ],
 	] )( 'returns {0, 0} for %s', ( _label, w, h, rot ) => {
 		expect( getRotatedBBox( w, h, rot ) ).toEqual( {
 			width: 0,
@@ -628,14 +632,20 @@ describe( 'getImageFit — non-finite input regression', () => {
 		expect( Number.isFinite( out.visualSize.height ) ).toBe( true );
 	} );
 
-	it( 'returns finite sizes when rotation magnitude overflows', () => {
-		// MAX_VALUE rotation would otherwise overflow
-		// Math.round(rotation/90)*90 and cascade NaN into the fit math.
-		const out = getImageFit( CONTAINER, IMAGE, Number.MAX_VALUE );
-		expect( Number.isFinite( out.elementSize.width ) ).toBe( true );
-		expect( Number.isFinite( out.elementSize.height ) ).toBe( true );
-		expect( Number.isFinite( out.visualSize.width ) ).toBe( true );
-		expect( Number.isFinite( out.visualSize.height ) ).toBe( true );
+	it( 'returns zero sizes when containerSize has a non-finite dimension', () => {
+		const out = getImageFit( { width: Number.NaN, height: 600 }, IMAGE, 0 );
+		expect( out.elementSize ).toEqual( { width: 0, height: 0 } );
+		expect( out.visualSize ).toEqual( { width: 0, height: 0 } );
+	} );
+
+	it( 'returns zero sizes when imageSize has a non-finite dimension', () => {
+		const out = getImageFit(
+			CONTAINER,
+			{ width: Number.POSITIVE_INFINITY, height: 900 },
+			0
+		);
+		expect( out.elementSize ).toEqual( { width: 0, height: 0 } );
+		expect( out.visualSize ).toEqual( { width: 0, height: 0 } );
 	} );
 } );
 
@@ -646,6 +656,15 @@ describe( 'createCamera — non-finite input regression', () => {
 		for ( let i = 0; i < 6; i++ ) {
 			expect( Number.isFinite( m[ i ] ) ).toBe( true );
 		}
+	} );
+
+	it( 'returns identity matrix when imageSize has non-finite dimensions', () => {
+		const m = createCamera( makeState(), CONTAINER, {
+			width: Number.NaN,
+			height: 900,
+		} );
+		// mat2d.create() returns [1, 0, 0, 1, 0, 0] (identity).
+		expect( Array.from( m ) ).toEqual( [ 1, 0, 0, 1, 0, 0 ] );
 	} );
 } );
 
@@ -660,6 +679,14 @@ describe( 'createExportCamera — non-finite input regression', () => {
 		for ( let i = 0; i < 6; i++ ) {
 			expect( Number.isFinite( m[ i ] ) ).toBe( true );
 		}
+	} );
+
+	it( 'returns identity matrix when outputSize has non-finite dimensions', () => {
+		const m = createExportCamera( makeState(), IMAGE, {
+			width: Number.POSITIVE_INFINITY,
+			height: 400,
+		} );
+		expect( Array.from( m ) ).toEqual( [ 1, 0, 0, 1, 0, 0 ] );
 	} );
 } );
 
@@ -684,6 +711,20 @@ describe( 'restrictCropRect — non-finite input regression', () => {
 		expect( Number.isFinite( out.width ) ).toBe( true );
 		expect( Number.isFinite( out.height ) ).toBe( true );
 	} );
+
+	it( 'sanitizes cropRect fields on the no-resize (fit-through) path', () => {
+		// When the crop already fits (t >= 1 - EPSILON) the function used to
+		// return the raw cropRect, letting non-finite fields slip through.
+		const hostileRect = {
+			x: Number.NaN,
+			y: 0.1,
+			width: 0.3,
+			height: 0.3,
+		};
+		const out = restrictCropRect( hostileRect, 10, 0, 16 / 9 );
+		expect( Number.isFinite( out.x ) ).toBe( true );
+		expect( out.x ).toBe( 0 );
+	} );
 } );
 
 describe( 'restrictPanZoom — non-finite input regression', () => {
@@ -701,6 +742,21 @@ describe( 'restrictPanZoom — non-finite input regression', () => {
 		const out = restrictPanZoom( state, IMAGE, cropRect );
 		expect( Number.isFinite( out.zoom ) ).toBe( true );
 		expect( out.zoom ).toBeGreaterThanOrEqual( 1 );
+	} );
+
+	it( 'sanitizes the cropRect argument before feeding it into the math', () => {
+		// A NaN cropRect.width would drive getMinZoomForCover to NaN via
+		// Math.max(1, NaN, NaN), and that NaN would be returned as zoom.
+		const hostileRect = {
+			x: 0.1,
+			y: 0.1,
+			width: Number.NaN,
+			height: 0.5,
+		};
+		const out = restrictPanZoom( makeState(), IMAGE, hostileRect );
+		expect( Number.isFinite( out.zoom ) ).toBe( true );
+		expect( Number.isFinite( out.pan.x ) ).toBe( true );
+		expect( Number.isFinite( out.pan.y ) ).toBe( true );
 	} );
 } );
 
@@ -729,5 +785,18 @@ describe( 'getSourceRegion — non-finite input regression', () => {
 		expect( Number.isFinite( out.y ) ).toBe( true );
 		expect( Number.isFinite( out.width ) ).toBe( true );
 		expect( Number.isFinite( out.height ) ).toBe( true );
+	} );
+
+	it( 'returns finite metadata on the zero-size early-return path', () => {
+		// When imageSize is zero/invalid, the function returns a zero region
+		// plus rotation/flip/zoom metadata. Hostile state must not leak NaN
+		// out through those metadata fields.
+		const out = getSourceRegion( HOSTILE_STATE, {
+			width: 0,
+			height: 0,
+		} );
+		expect( Number.isFinite( out.rotation ) ).toBe( true );
+		expect( Number.isFinite( out.zoom ) ).toBe( true );
+		expect( out.zoom ).toBeGreaterThanOrEqual( 1 );
 	} );
 } );

--- a/packages/media-editor/src/image-editor/core/test/camera.ts
+++ b/packages/media-editor/src/image-editor/core/test/camera.ts
@@ -13,6 +13,7 @@ import {
 	getImageCropBounds,
 } from '../containment';
 import { getSourceRegion, getSourceRegionPercent } from '../source-region';
+import { computeTransformStyle } from '../transform-style';
 import { DEFAULT_STATE } from '../constants';
 import type { CropperState, Size } from '../types';
 
@@ -606,7 +607,7 @@ describe( 'getRotatedBBox — non-finite input regression', () => {
 		[ '-Infinity rotation', 100, 100, Number.NEGATIVE_INFINITY ],
 		// MAX_VALUE is finite but degreesToRadians( MAX_VALUE ) overflows
 		// to Infinity, then Math.cos/sin return NaN. The magnitude bound
-		// in `safeBoundedNumber` catches this before the trig.
+		// in `isSafeNumber` catches this before the trig.
 		[ 'MAX_VALUE rotation', 100, 100, Number.MAX_VALUE ],
 	] )( 'returns {0, 0} for %s', ( _label, w, h, rot ) => {
 		expect( getRotatedBBox( w, h, rot ) ).toEqual( {
@@ -757,6 +758,31 @@ describe( 'restrictPanZoom — non-finite input regression', () => {
 		expect( Number.isFinite( out.zoom ) ).toBe( true );
 		expect( Number.isFinite( out.pan.x ) ).toBe( true );
 		expect( Number.isFinite( out.pan.y ) ).toBe( true );
+	} );
+
+	it( 'returns finite zoom when imageSize is Infinity (aspectRatio NaN guard)', () => {
+		// Infinity / Infinity = NaN, which used to leak as `zoom: NaN`
+		// through the no-correction early return.
+		const rect = { x: 0.1, y: 0.1, width: 0.5, height: 0.5 };
+		const out = restrictPanZoom(
+			makeState(),
+			{ width: Infinity, height: Infinity },
+			rect
+		);
+		expect( Number.isFinite( out.zoom ) ).toBe( true );
+		expect( Number.isFinite( out.pan.x ) ).toBe( true );
+		expect( Number.isFinite( out.pan.y ) ).toBe( true );
+	} );
+} );
+
+describe( 'computeTransformStyle — non-finite input regression', () => {
+	it( 'produces a finite matrix string for hostile state', () => {
+		// CSS preview path must agree with createCamera under hostile state
+		// (both should produce safe output, not divergent NaN vs finite).
+		const out = computeTransformStyle( HOSTILE_STATE, IMAGE );
+		expect( out ).toMatch( /^matrix\(/ );
+		expect( out ).not.toMatch( /NaN/ );
+		expect( out ).not.toMatch( /Infinity/ );
 	} );
 } );
 

--- a/packages/media-editor/src/image-editor/core/test/camera.ts
+++ b/packages/media-editor/src/image-editor/core/test/camera.ts
@@ -784,6 +784,24 @@ describe( 'computeTransformStyle — non-finite input regression', () => {
 		expect( out ).not.toMatch( /NaN/ );
 		expect( out ).not.toMatch( /Infinity/ );
 	} );
+
+	it( 'returns the identity matrix when imageSize is hostile', () => {
+		// State sanitization only covers state fields; imageSize NaN/Infinity
+		// would still emit `matrix(..., NaN, NaN)` in the translate components
+		// without this explicit guard.
+		expect(
+			computeTransformStyle( makeState(), {
+				width: Number.NaN,
+				height: 900,
+			} )
+		).toBe( 'matrix(1, 0, 0, 1, 0, 0)' );
+		expect(
+			computeTransformStyle( makeState(), {
+				width: Infinity,
+				height: Infinity,
+			} )
+		).toBe( 'matrix(1, 0, 0, 1, 0, 0)' );
+	} );
 } );
 
 describe( 'getImageCropBounds — non-finite input regression', () => {

--- a/packages/media-editor/src/image-editor/core/test/camera.ts
+++ b/packages/media-editor/src/image-editor/core/test/camera.ts
@@ -5,6 +5,7 @@ import {
 	getVisibleBounds,
 	createExportCamera,
 	getImageFit,
+	getRotatedBBox,
 } from '../camera';
 import {
 	restrictPanZoom,
@@ -578,5 +579,155 @@ describe( 'getImageCropBounds', () => {
 		expect( bounds.maxX ).toBeGreaterThan( 1.3 );
 		expect( bounds.minY ).toBeLessThan( -0.3 );
 		expect( bounds.maxY ).toBeGreaterThan( 1.3 );
+	} );
+} );
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Non-finite input regressions.
+//
+// The reducer normalizes rotation/zoom/pan on every action, so these paths
+// aren't user-reachable today. But programmatic callers and deserialized
+// state could still feed corrupted values, which used to silently propagate
+// NaN/Infinity into the crop rect, camera matrix, or REST /edit payload.
+// These tests pin the defense-in-depth guards in place.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const HOSTILE_STATE: CropperState = makeState( {
+	pan: { x: Number.NaN, y: Number.NEGATIVE_INFINITY },
+	zoom: Number.POSITIVE_INFINITY,
+	rotation: Number.NaN,
+} );
+
+describe( 'getRotatedBBox — non-finite input regression', () => {
+	it.each( [
+		[ 'NaN width', Number.NaN, 100, 30 ],
+		[ '±Infinity height', 100, Number.POSITIVE_INFINITY, 30 ],
+		[ 'NaN rotation', 100, 100, Number.NaN ],
+		[ '-Infinity rotation', 100, 100, Number.NEGATIVE_INFINITY ],
+	] )( 'returns {0, 0} for %s', ( _label, w, h, rot ) => {
+		expect( getRotatedBBox( w, h, rot ) ).toEqual( {
+			width: 0,
+			height: 0,
+		} );
+	} );
+
+	it( 'still returns correct dimensions for normal inputs', () => {
+		// Sanity check that the guard doesn't break the happy path.
+		const out = getRotatedBBox( 200, 100, 90 );
+		expect( out.width ).toBeCloseTo( 100, 5 );
+		expect( out.height ).toBeCloseTo( 200, 5 );
+	} );
+} );
+
+describe( 'getImageFit — non-finite input regression', () => {
+	it( 'returns finite sizes when rotation is NaN (treated as 0)', () => {
+		const out = getImageFit( CONTAINER, IMAGE, Number.NaN );
+		expect( Number.isFinite( out.elementSize.width ) ).toBe( true );
+		expect( Number.isFinite( out.elementSize.height ) ).toBe( true );
+		expect( Number.isFinite( out.visualSize.width ) ).toBe( true );
+		expect( Number.isFinite( out.visualSize.height ) ).toBe( true );
+	} );
+
+	it( 'returns finite sizes when rotation magnitude overflows', () => {
+		// MAX_VALUE rotation would otherwise overflow
+		// Math.round(rotation/90)*90 and cascade NaN into the fit math.
+		const out = getImageFit( CONTAINER, IMAGE, Number.MAX_VALUE );
+		expect( Number.isFinite( out.elementSize.width ) ).toBe( true );
+		expect( Number.isFinite( out.elementSize.height ) ).toBe( true );
+		expect( Number.isFinite( out.visualSize.width ) ).toBe( true );
+		expect( Number.isFinite( out.visualSize.height ) ).toBe( true );
+	} );
+} );
+
+describe( 'createCamera — non-finite input regression', () => {
+	it( 'returns a matrix with all finite entries even for hostile state', () => {
+		const m = createCamera( HOSTILE_STATE, CONTAINER, IMAGE );
+		expect( m ).toHaveLength( 6 );
+		for ( let i = 0; i < 6; i++ ) {
+			expect( Number.isFinite( m[ i ] ) ).toBe( true );
+		}
+	} );
+} );
+
+describe( 'createExportCamera — non-finite input regression', () => {
+	it( 'returns a matrix with all finite entries even for hostile state', () => {
+		// This is the matrix passed to ctx.setTransform → ctx.drawImage at
+		// export time, so NaN here would corrupt the saved file.
+		const m = createExportCamera( HOSTILE_STATE, IMAGE, {
+			width: 600,
+			height: 400,
+		} );
+		for ( let i = 0; i < 6; i++ ) {
+			expect( Number.isFinite( m[ i ] ) ).toBe( true );
+		}
+	} );
+} );
+
+describe( 'restrictCropRect — non-finite input regression', () => {
+	const cropRect = { x: 0.1, y: 0.1, width: 0.5, height: 0.5 };
+
+	it.each( [
+		[ 'NaN zoom', cropRect, Number.NaN, 0, 16 / 9 ],
+		[ '-Infinity rotation', cropRect, 1, Number.NEGATIVE_INFINITY, 16 / 9 ],
+		[ 'NaN aspectRatio', cropRect, 1, 0, Number.NaN ],
+		[
+			'MAX_VALUE zoom (overflow guard)',
+			cropRect,
+			Number.MAX_VALUE,
+			0,
+			16 / 9,
+		],
+	] )( 'returns a finite rect for %s', ( _label, rect, z, r, a ) => {
+		const out = restrictCropRect( rect, z, r, a );
+		expect( Number.isFinite( out.x ) ).toBe( true );
+		expect( Number.isFinite( out.y ) ).toBe( true );
+		expect( Number.isFinite( out.width ) ).toBe( true );
+		expect( Number.isFinite( out.height ) ).toBe( true );
+	} );
+} );
+
+describe( 'restrictPanZoom — non-finite input regression', () => {
+	const cropRect = { x: 0.1, y: 0.1, width: 0.5, height: 0.5 };
+
+	it( 'returns finite pan and zoom for hostile state', () => {
+		const out = restrictPanZoom( HOSTILE_STATE, IMAGE, cropRect );
+		expect( Number.isFinite( out.zoom ) ).toBe( true );
+		expect( Number.isFinite( out.pan.x ) ).toBe( true );
+		expect( Number.isFinite( out.pan.y ) ).toBe( true );
+	} );
+
+	it( 'returns finite pan and zoom when only state.zoom is corrupted', () => {
+		const state = makeState( { zoom: Number.NaN } );
+		const out = restrictPanZoom( state, IMAGE, cropRect );
+		expect( Number.isFinite( out.zoom ) ).toBe( true );
+		expect( out.zoom ).toBeGreaterThanOrEqual( 1 );
+	} );
+} );
+
+describe( 'getImageCropBounds — non-finite input regression', () => {
+	it( 'returns finite bounds for hostile state', () => {
+		const out = getImageCropBounds(
+			HOSTILE_STATE,
+			{ width: 800, height: 450 },
+			{ width: 800, height: 450 }
+		);
+		expect( Number.isFinite( out.minX ) ).toBe( true );
+		expect( Number.isFinite( out.minY ) ).toBe( true );
+		expect( Number.isFinite( out.maxX ) ).toBe( true );
+		expect( Number.isFinite( out.maxY ) ).toBe( true );
+		expect( out.minX ).toBeLessThanOrEqual( out.maxX );
+		expect( out.minY ).toBeLessThanOrEqual( out.maxY );
+	} );
+} );
+
+describe( 'getSourceRegion — non-finite input regression', () => {
+	it( 'returns a finite source region for hostile state', () => {
+		// getSourceRegion feeds the REST /edit endpoint, so NaN here would
+		// reach the server.
+		const out = getSourceRegion( HOSTILE_STATE, IMAGE );
+		expect( Number.isFinite( out.x ) ).toBe( true );
+		expect( Number.isFinite( out.y ) ).toBe( true );
+		expect( Number.isFinite( out.width ) ).toBe( true );
+		expect( Number.isFinite( out.height ) ).toBe( true );
 	} );
 } );

--- a/packages/media-editor/src/image-editor/core/transform-style.ts
+++ b/packages/media-editor/src/image-editor/core/transform-style.ts
@@ -3,6 +3,7 @@
  */
 import type { CropperState, Size } from './types';
 import { degreesToRadians } from './math/rotation';
+import { sanitizeCropperState } from './math/sanitize';
 
 /**
  * Computes a CSS matrix() transform string from the cropper state.
@@ -25,14 +26,18 @@ export function computeTransformStyle(
 	state: CropperState,
 	imageSize: Size
 ): string {
-	const translateX = state.pan.x * imageSize.width;
-	const translateY = state.pan.y * imageSize.height;
-	const rad = degreesToRadians( state.rotation );
+	// Sanitize so hostile state can't produce `matrix(NaN, NaN, ...)` here
+	// while the parallel `createCamera` path returns a finite matrix. Both
+	// paths must agree under defense-in-depth conditions.
+	const safeState = sanitizeCropperState( state );
+	const translateX = safeState.pan.x * imageSize.width;
+	const translateY = safeState.pan.y * imageSize.height;
+	const rad = degreesToRadians( safeState.rotation );
 	const cos = Math.cos( rad );
 	const sin = Math.sin( rad );
-	const sx = state.flip.horizontal ? -1 : 1;
-	const sy = state.flip.vertical ? -1 : 1;
-	const z = state.zoom;
+	const sx = safeState.flip.horizontal ? -1 : 1;
+	const sy = safeState.flip.vertical ? -1 : 1;
+	const z = safeState.zoom;
 
 	// Combined: translate(tx,ty) * scale(sx,sy) * rotate(r) * scale(z)
 	const a = sx * cos * z;

--- a/packages/media-editor/src/image-editor/core/transform-style.ts
+++ b/packages/media-editor/src/image-editor/core/transform-style.ts
@@ -3,7 +3,10 @@
  */
 import type { CropperState, Size } from './types';
 import { degreesToRadians } from './math/rotation';
-import { sanitizeCropperState } from './math/sanitize';
+import { isValidSize, sanitizeCropperState } from './math/sanitize';
+
+/** Identity CSS transform — applied when inputs aren't safe to compose. */
+const IDENTITY_MATRIX_STYLE = 'matrix(1, 0, 0, 1, 0, 0)';
 
 /**
  * Computes a CSS matrix() transform string from the cropper state.
@@ -26,6 +29,13 @@ export function computeTransformStyle(
 	state: CropperState,
 	imageSize: Size
 ): string {
+	// Match the identity short-circuit used by `createCamera` and
+	// `getSourceRegion` so the preview path stays consistent with the math
+	// path when `imageSize` itself is hostile (state sanitization below
+	// only guards the state fields, not these size arguments).
+	if ( ! isValidSize( imageSize ) ) {
+		return IDENTITY_MATRIX_STYLE;
+	}
 	// Sanitize so hostile state can't produce `matrix(NaN, NaN, ...)` here
 	// while the parallel `createCamera` path returns a finite matrix. Both
 	// paths must agree under defense-in-depth conditions.


### PR DESCRIPTION
Ran property-based fuzz testing on the cropper math layer and it surfaced a handful of silent NaN/Infinity propagation paths. Low severity in practice (the reducer normalizes inputs upstream), but worth fixing so bad input fails at the boundary instead of reaching `ctx.drawImage()` or the REST `/edit` endpoint.

The fuzz testing itself isn't being checked in. This PR is just the fixes plus regression unit tests.

### What changed

- New `core/math/sanitize.ts` with `safeBoundedNumber` (rejects non-finite values and anything beyond ±1e6) and `sanitizeCropperState` (returns a state with all numeric fields safe).
- Guards applied at the top of `getRotatedBBox`, `getImageFit`, `createCamera`, `createExportCamera`, `restrictCropRect`, `restrictPanZoom`, `getImageCropBounds`, `getSourceRegion`.
- Regression tests in `core/test/camera.ts` and `core/math/test/sanitize.ts`.

The three `stencil-math` resize functions already had this pattern with their existing zero/negative guards — they were the model.

### Test plan

- [ ] CI green
- [ ] Cropper still works normally in `npm start` (rotate, zoom, drag, snap-rotate, flip) — the guards are no-ops under normal reducer-normalized state