### PR TITLE
Media Editor: Scope keyboard shortcuts to the modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62133,6 +62133,7 @@
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/interface": "file:../interface",
+				"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 				"@wordpress/keycodes": "file:../keycodes",
 				"@wordpress/notices": "file:../notices",
 				"@wordpress/private-apis": "file:../private-apis",

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -55,6 +55,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/interface": "file:../interface",
+		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/private-apis": "file:../private-apis",

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -4,7 +4,9 @@
 import { Modal } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
 import type { Field } from '@wordpress/dataviews';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 
 /**
  * Internal dependencies
@@ -52,6 +54,16 @@ export function MediaEditorModal( {
 	const portalElement =
 		typeof document === 'undefined' ? null : document.body;
 
+	// React synthetic events bubble through the React tree, not the DOM tree,
+	// so a host `ShortcutProvider` higher up still receives keydown events
+	// from inside this portaled modal. Stop propagation at the modal boundary
+	// so host shortcuts (undo/redo, save, etc.) don't fire from within.
+	const stopKeyDownPropagation = (
+		event: ReactKeyboardEvent< HTMLDivElement >
+	) => {
+		event.stopPropagation();
+	};
+
 	return (
 		<MediaEditor
 			id={ id }
@@ -79,18 +91,25 @@ export function MediaEditorModal( {
 				onKeyDown,
 				shouldCloseOnClickOutside,
 			} ) => (
-				<Modal
-					className="media-editor-modal"
-					title={ __( 'Edit media' ) }
-					size="fill"
-					isDismissible={ false }
-					shouldCloseOnClickOutside={ shouldCloseOnClickOutside }
-					onKeyDown={ onKeyDown }
-					onRequestClose={ onRequestClose }
-					headerActions={ headerActions }
+				<ShortcutProvider
+					className="media-editor-modal__shortcut-scope"
+					onKeyDown={ stopKeyDownPropagation }
 				>
-					{ children }
-				</Modal>
+					<Modal
+						className="media-editor-modal"
+						title={ __( 'Edit media' ) }
+						size="fill"
+						isDismissible={ false }
+						shouldCloseOnClickOutside={
+							shouldCloseOnClickOutside
+						}
+						onKeyDown={ onKeyDown }
+						onRequestClose={ onRequestClose }
+						headerActions={ headerActions }
+					>
+						{ children }
+					</Modal>
+				</ShortcutProvider>
 			) }
 		/>
 	);

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -100,9 +100,7 @@ export function MediaEditorModal( {
 						title={ __( 'Edit media' ) }
 						size="fill"
 						isDismissible={ false }
-						shouldCloseOnClickOutside={
-							shouldCloseOnClickOutside
-						}
+						shouldCloseOnClickOutside={ shouldCloseOnClickOutside }
 						onKeyDown={ onKeyDown }
 						onRequestClose={ onRequestClose }
 						headerActions={ headerActions }

--- a/packages/media-editor/tsconfig.json
+++ b/packages/media-editor/tsconfig.json
@@ -15,6 +15,7 @@
 		{ "path": "../element" },
 		{ "path": "../i18n" },
 		{ "path": "../icons" },
+		{ "path": "../keyboard-shortcuts" },
 		{ "path": "../keycodes" },
 		{ "path": "../notices" },
 		{ "path": "../private-apis" },


### PR DESCRIPTION
## What

When the image editor modal is open, host editor shortcuts (`Ctrl+Z` / `Cmd+Z` undo, redo, save, etc.) still fire in the post editor underneath. So pressing Ctrl+Z to undo a crop also undoes the post — silently, since the modal covers the editor.

This PR isolates the modal's keyboard events from the host editor.


https://github.com/user-attachments/assets/89f8a504-a420-4866-8122-98123250c576



## Why it happens

React synthetic events bubble through the **React tree**, not the DOM tree. So even though the Modal renders into `document.body` via a portal, a keydown inside the modal still bubbles up the React parent chain and reaches the editor's `ShortcutProvider` (the `<div onKeyDown>` that runs all `useShortcut` callbacks). The media editor's existing `handleKeyDown` runs the cropper undo and calls `preventDefault`, but it never `stopPropagation`s — so the editor's undo fires too.

## How

Wrap the `<Modal>` in `media-editor-modal/index.tsx` with a new `<ShortcutProvider>` whose `onKeyDown` calls `event.stopPropagation()`. The modal now has its own keyboard-shortcut scope, and React events stop at the modal boundary instead of climbing up to the host editor.

Why this position works:
- The Modal's internals (frame `onKeyDown` running the cropper undo, overlay handler running Esc-to-close) sit **deeper** in the React tree than our wrapper — they fire first, then propagation is stopped on the way out.
- `stopPropagation` only affects React synthetic events. Browser-native undo on `<input>` / `<textarea>` fields is unaffected, because the existing `handleKeyDown` continues to skip `preventDefault` for those targets.
- Provides scope for any future `useShortcut` calls inside the modal.

## Testing

Open an image in the Media Editor modal from inside the post editor.

- [ ] **Canvas focus, Ctrl/Cmd+Z** — undoes the last crop. Post is unchanged. (Use Ctrl/Cmd+Shift+Z to redo.)
- [ ] **Caption / Alt text input focus, Ctrl/Cmd+Z** — undoes the last text edit in the field (native browser undo). Post is unchanged.
- [ ] **Esc with no unsaved changes** — closes the modal.
- [ ] **Esc with unsaved changes** — opens the discard confirmation dialog.
- [ ] **Ctrl/Cmd+S in the modal** — does not trigger a post save.

Before this PR, all of the Ctrl/Cmd+Z cases above would also undo the post in the background.