### PR TITLE
Post Editor perf test: remove unwanted actions from timed area

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/index.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/index.ts
@@ -33,7 +33,7 @@ import {
 } from './menus';
 import { deleteAllPages, createPage } from './pages';
 import { createRecord } from './records';
-import { resetPreferences } from './preferences';
+import { resetPreferences, setPreferences } from './preferences';
 import { getSiteSettings, updateSiteSettings } from './site-settings';
 import { deleteAllWidgets, addWidgetBlock } from './widgets';
 import { deleteAllPatternCategories } from './patterns';
@@ -182,6 +182,8 @@ class RequestUtils {
 	createTemplate: typeof createTemplate = createTemplate.bind( this );
 	/** @borrows resetPreferences as this.resetPreferences */
 	resetPreferences: typeof resetPreferences = resetPreferences.bind( this );
+	/** @borrows setPreferences as this.setPreferences */
+	setPreferences: typeof setPreferences = setPreferences.bind( this );
 	/** @borrows listMedia as this.listMedia */
 	listMedia: typeof listMedia = listMedia.bind( this );
 	/** @borrows uploadMedia as this.uploadMedia */

--- a/packages/e2e-test-utils-playwright/src/request-utils/preferences.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/preferences.ts
@@ -19,3 +19,45 @@ export async function resetPreferences( this: RequestUtils ) {
 		},
 	} );
 }
+
+/**
+ * Set scoped user preferences via the REST API.
+ *
+ * Reads the current persisted preferences, merges the new values under the
+ * given scope, and writes them back.
+ *
+ * @param this        Request utils.
+ * @param scope       The preference scope (e.g. 'core/edit-post').
+ * @param preferences Key/value map of preference names to values.
+ */
+export async function setPreferences(
+	this: RequestUtils,
+	scope: string,
+	preferences: Record< string, any >
+) {
+	const user = await this.rest< {
+		meta: { persisted_preferences: Record< string, any > };
+	} >( {
+		path: '/wp/v2/users/me',
+		method: 'GET',
+		params: { context: 'edit' },
+	} );
+
+	const currentPreferences = user.meta?.persisted_preferences ?? {};
+
+	await this.rest( {
+		path: '/wp/v2/users/me',
+		method: 'PUT',
+		data: {
+			meta: {
+				persisted_preferences: {
+					...currentPreferences,
+					[ scope ]: {
+						...( currentPreferences[ scope ] ?? {} ),
+						...preferences,
+					},
+				},
+			},
+		},
+	} );
+}

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -55,10 +55,21 @@ test.describe( 'Post Editor Performance', () => {
 	test.describe( 'Loading', () => {
 		let draftId = null;
 
-		test( 'Setup the test post', async ( { admin, perfUtils } ) => {
+		test( 'Setup the test post', async ( {
+			admin,
+			requestUtils,
+			perfUtils,
+		} ) => {
 			await admin.createNewPost();
 			await perfUtils.loadBlocksForLargePost();
 			draftId = await perfUtils.saveDraft();
+
+			// Set preferences via REST so that welcomeGuide and fullscreenMode
+			// are reliably persisted before the timed iterations start.
+			await requestUtils.setPreferences( 'core/edit-post', {
+				welcomeGuide: false,
+				fullscreenMode: false,
+			} );
 		} );
 
 		const samples = 10;
@@ -74,10 +85,12 @@ test.describe( 'Post Editor Performance', () => {
 				await metrics.startTracing();
 
 				// Open the test draft.
-				await admin.editPost( draftId );
-				const canvas = await perfUtils.getCanvas();
+				await admin.page.goto(
+					'wp-admin/post.php?post=' + draftId + '&action=edit'
+				);
 
 				// Wait for the first block.
+				const canvas = await perfUtils.getCanvas();
 				await canvas.locator( '.wp-block' ).first().waitFor();
 
 				// Capture timing metrics before `stopTracing()`, which

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -70,6 +70,15 @@ test.describe( 'Site Editor Performance', () => {
 			} );
 
 			draftId = page.id;
+
+			// Set preferences via REST so that welcomeGuide is reliably
+			// persisted before the timed iterations start.
+			await requestUtils.setPreferences( 'core/edit-site', {
+				welcomeGuide: false,
+				welcomeGuideStyles: false,
+				welcomeGuidePage: false,
+				welcomeGuideTemplate: false,
+			} );
 		} );
 
 		const samples = 10;
@@ -85,11 +94,11 @@ test.describe( 'Site Editor Performance', () => {
 				await metrics.startTracing();
 
 				// Go to the test draft.
-				await admin.visitSiteEditor( {
-					postId: draftId,
-					postType: 'page',
-					canvas: 'edit',
-				} );
+				await admin.page.goto(
+					'wp-admin/site-editor.php?postId=' +
+						draftId +
+						'&postType=page&canvas=edit'
+				);
 
 				// Wait for the first block.
 				const canvas = await perfUtils.getCanvas();


### PR DESCRIPTION
Updates the Post Editor perf test, the one that measures the `firstBlock` metric and others, so that no unwanted actions (like switching preferences, checking errors) happens inside the measured time interval.