### PR TITLE
Fix: Prevent visual jitter when changing block styles

### DIFF
--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -7,7 +7,14 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { getBlockSupport } from '@wordpress/blocks';
-import { memo, useMemo, useEffect, useId, useState } from '@wordpress/element';
+import {
+	memo,
+	useMemo,
+	useEffect,
+	useLayoutEffect,
+	useId,
+	useState,
+} from '@wordpress/element';
 import { useDispatch, useRegistry } from '@wordpress/data';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
@@ -614,7 +621,7 @@ function BlockProps( {
 		} );
 	// Setting state after every render is fine because this component is
 	// pure and will only re-render when needed props change.
-	useEffect( () => {
+	useLayoutEffect( () => {
 		// We could shallow compare the props, but since this component only
 		// changes when needed attributes change, the benefit is probably small.
 		setWrapperProps( wrapperProps );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #77830

This PR updates the `BlockProps` hook in the block editor to use `useLayoutEffect` instead of `useEffect` when setting wrapper properties.

## Why?
When a block style variation (like "Rounded") is applied, there is currently a visual "jerk" or flash. This happens because `useEffect` runs after the browser has already painted the initial state.

In the case of the Image block (e.g., in Twenty Twenty-Four theme):
1. The browser paints the default "Rounded" style (which defaults to a `9999px` border-radius/circle).
2. `useEffect` fires, adding the specific theme variation classes (e.g., `is-style-rounded-[hash]`).
3. The browser paints again with the theme's specific `border-radius` (e.g., 20px), causing a visible snap from a circle to a rounded square.

## How?
By switching to `useLayoutEffect`, the wrapper properties (including theme-specific variation classes) are applied synchronously after all DOM mutations but before the browser has a chance to paint. This ensures the very first frame the user sees already contains the correct, theme-defined CSS classes, eliminating the intermediate "fully rounded" state.

## Testing Instructions
1. Use a theme that defines a specific border-radius for the "Rounded" image variation (e.g., `Twenty Twenty-Four`).
2. Open the Site Editor or Post Editor.
3. Insert an Image block and select an image.
4. In the Settings Sidebar, click on the Styles tab.
5. Switch the style from "Default" to "Rounded".
6. Observe: The image should transition to the theme's rounded setting immediately without flashing as a full circle first.

## Screenshots or screencast 

### Before

https://github.com/user-attachments/assets/31a6ad32-7a32-4cbc-beda-80a7d5d36bbe

### After

https://github.com/user-attachments/assets/ae6eea87-1fd6-43d0-8084-b7195b7871d6


## Use of AI Tools
I used Gemini 3 Flash to help draft PR description.
