### PR TITLE
Perf tests: Add extra tracing categories to investigate idle gaps

### DIFF
--- a/packages/e2e-test-utils-playwright/src/metrics/index.ts
+++ b/packages/e2e-test-utils-playwright/src/metrics/index.ts
@@ -228,6 +228,14 @@ export class Metrics {
 				'disabled-by-default-devtools.timeline.stack',
 				'disabled-by-default-v8.cpu_profiler',
 				'v8.execute',
+				// Extra categories to investigate idle gaps on the main thread
+				// (e.g. long `RunMicrotasks` events with no JS frames inside):
+				// surface IPC traffic, compositor commits and detailed V8
+				// compile events that would otherwise be invisible.
+				'disabled-by-default-ipc.flow',
+				'disabled-by-default-cc.debug',
+				'disabled-by-default-v8.compile',
+				'mojom',
 			],
 			...options,
 		} );


### PR DESCRIPTION
## Why

The post-editor first-block trace shows a ~184 ms `RunMicrotasks` event on the renderer main thread with **no JS frames inside** and no observable trigger at the boundary:

- No network response correlates (all in-flight requests had finished ~14 ms earlier).
- No `BackgroundProcessor::*`, `Compile`, `Streaming` or `InstallCode` event ends near it.
- No GC completes near it.
- All CPU samples inside resolve to V8's `(program)` bucket.

The default DevTools tracing categories don't surface IPC traffic, compositor scheduling or detailed V8 compile events, so the cause of the wait is invisible.

## What

Add `disabled-by-default-ipc.flow`, `disabled-by-default-cc.debug`, `disabled-by-default-v8.compile` and `mojom` to the trace started by `metrics.startTracing()`. This affects every perf test trace (including the `post-editor-first-block` one we look at), so the next CI run will include enough information to identify the underlying cause of the gap.

Draft — not for merge. Once we identify the source of the gap from a CI trace, this should be reverted (or moved behind an env var) since the extra categories increase trace size noticeably.

Authored by Claude (Opus 4.7) in collaboration with @ellatrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)