### PR TITLE
Admin bar in editor experiment: apply admin color scheme

### DIFF
--- a/packages/edit-site/src/experimental-admin-bar-in-editor.scss
+++ b/packages/edit-site/src/experimental-admin-bar-in-editor.scss
@@ -1,4 +1,12 @@
 // Styles for the experimental admin bar in editor.
+//
+// The `admin-color-*` blocks below declare new CSS custom properties
+// (`--wp-admin--admin-bar--*` / `--wp-admin--admin-menu--*`) whose per-scheme
+// values are taken verbatim from WordPress Core's admin color schemes.
+//
+// These CSS custom properties should be removed by migrating the underlying
+// components to DS tokens and ThemeProvider, which would handle theming
+// natively without these targeted overrides.
 
 body.has-admin-bar-in-editor {
 	&.admin-color-fresh {

--- a/packages/edit-site/src/experimental-admin-bar-in-editor.scss
+++ b/packages/edit-site/src/experimental-admin-bar-in-editor.scss
@@ -1,11 +1,87 @@
 // Styles for the experimental admin bar in editor.
 
 body.has-admin-bar-in-editor {
+	&.admin-color-fresh {
+		--wp-admin--admin-bar--color-bg: #1d2327;
+		--wp-admin--admin-bar--color-fg: #c3c4c7;
+		--wp-admin--admin-menu--current-color-bg: #0073aa;
+		--wp-admin--admin-menu--submenu-color-bg-alt: #3c434a;
+		--wp-admin--admin-menu--submenu-color-fg: #c3c4c7;
+	}
+
+	&.admin-color-modern {
+		--wp-admin--admin-bar--color-bg: #1e1e1e;
+		--wp-admin--admin-bar--color-fg: #fff;
+		--wp-admin--admin-menu--current-color-bg: #3858e9;
+		--wp-admin--admin-menu--submenu-color-bg-alt: #303030;
+		--wp-admin--admin-menu--submenu-color-fg: #bbb;
+	}
+
+	&.admin-color-midnight {
+		--wp-admin--admin-bar--color-bg: #363b3f;
+		--wp-admin--admin-bar--color-fg: #fff;
+		--wp-admin--admin-menu--current-color-bg: #e14d43;
+		--wp-admin--admin-menu--submenu-color-bg-alt: #4c4c4d;
+		--wp-admin--admin-menu--submenu-color-fg: #c2c4c5;
+	}
+
+	&.admin-color-coffee {
+		--wp-admin--admin-bar--color-bg: #59524c;
+		--wp-admin--admin-bar--color-fg: #fff;
+		--wp-admin--admin-menu--current-color-bg: #c7a589;
+		--wp-admin--admin-menu--submenu-color-bg-alt: #656463;
+		--wp-admin--admin-menu--submenu-color-fg: #cdcbc9;
+	}
+
+	&.admin-color-ocean {
+		--wp-admin--admin-bar--color-bg: #738e96;
+		--wp-admin--admin-bar--color-fg: #fff;
+		--wp-admin--admin-menu--current-color-bg: #9ebaa0;
+		--wp-admin--admin-menu--submenu-color-bg-alt: #8f9a9e;
+		--wp-admin--admin-menu--submenu-color-fg: #d5dddf;
+	}
+
+	&.admin-color-blue {
+		--wp-admin--admin-bar--color-bg: #52accc;
+		--wp-admin--admin-bar--color-fg: #fff;
+		--wp-admin--admin-menu--current-color-bg: #096484;
+		--wp-admin--admin-menu--submenu-color-bg-alt: #74b6ce;
+		--wp-admin--admin-menu--submenu-color-fg: #e2ecf1;
+	}
+
+	&.admin-color-ectoplasm {
+		--wp-admin--admin-bar--color-bg: #523f6d;
+		--wp-admin--admin-bar--color-fg: #fff;
+		--wp-admin--admin-menu--current-color-bg: #a3b745;
+		--wp-admin--admin-menu--submenu-color-bg-alt: #64537c;
+		--wp-admin--admin-menu--submenu-color-fg: #cbc5d3;
+	}
+
+	&.admin-color-sunrise {
+		--wp-admin--admin-bar--color-bg: #cf4944;
+		--wp-admin--admin-bar--color-fg: #fff;
+		--wp-admin--admin-menu--current-color-bg: #dd823b;
+		--wp-admin--admin-menu--submenu-color-bg-alt: #cf6b67;
+		--wp-admin--admin-menu--submenu-color-fg: #f1c8c7;
+	}
+
+	&.admin-color-light {
+		--wp-admin--admin-bar--color-bg: #e5e5e5;
+		--wp-admin--admin-bar--color-fg: #333;
+		--wp-admin--admin-menu--current-color-bg: #888;
+		--wp-admin--admin-menu--submenu-color-bg-alt: #f7f7f7;
+		--wp-admin--admin-menu--submenu-color-fg: #686868;
+	}
+
 	margin-top: 0;
 	height: 100%;
 
 	&:has(.editor-editor-interface.is-distraction-free) {
 		--wp-admin--admin-bar--height: 0;
+	}
+
+	&.js.site-editor-php {
+		background: var(--wp-admin--admin-bar--color-bg);
 	}
 
 	.edit-site-site-hub__title,
@@ -66,6 +142,80 @@ body.has-admin-bar-in-editor {
 
 		&:has(.editor-editor-interface.is-distraction-free) #wpadminbar {
 			display: none;
+		}
+	}
+
+	.edit-site-layout {
+		background: var(--wp-admin--admin-bar--color-bg);
+		color: var(--wp-admin--admin-menu--submenu-color-fg);
+
+		&:not(.is-full-canvas) .editor-visual-editor {
+			background: var(--wp-admin--admin-bar--color-bg);
+		}
+	}
+
+	.edit-site-layout__view-mode-toggle.components-button {
+		background: var(--wp-admin--admin-bar--color-bg);
+		color: var(--wp-admin--admin-bar--color-fg);
+	}
+
+	.edit-site-sidebar-navigation-item.components-item {
+		color: var(--wp-admin--admin-menu--submenu-color-fg);
+
+		&:hover,
+		&:focus,
+		&[aria-current="true"] {
+			color: var(--wp-admin--admin-bar--color-fg);
+		}
+
+		&[aria-current="true"] {
+			background: var(--wp-admin--admin-menu--current-color-bg);
+		}
+	}
+
+	.edit-site-sidebar-navigation-screen__content .components-text {
+		color: var(--wp-admin--admin-menu--submenu-color-fg);
+	}
+
+	.edit-site-sidebar-navigation-screen__title-icon,
+	.edit-site-sidebar-navigation-screen__footer {
+		background: var(--wp-admin--admin-bar--color-bg);
+	}
+
+	.edit-site-save-hub,
+	.edit-site-sidebar-navigation-screen__footer,
+	.edit-site-sidebar-navigation-screen-patterns__divider {
+		border-top-color: var(--wp-admin--admin-menu--submenu-color-bg-alt);
+	}
+
+	.edit-site-save-hub__button[aria-disabled="true"],
+	.edit-site-save-hub__button[aria-disabled="true"]:hover {
+		color: var(--wp-admin--admin-menu--submenu-color-fg);
+	}
+
+	.components-heading.edit-site-sidebar-navigation-screen__title {
+		color: var(--wp-admin--admin-bar--color-fg);
+	}
+
+	.edit-site-sidebar-button,
+	.edit-site-sidebar-button:hover:not(:disabled, [aria-disabled="true"]),
+	.edit-site-sidebar-button:focus-visible,
+	.edit-site-sidebar-button:focus,
+	.edit-site-sidebar-button:not(:disabled, [aria-disabled="true"]):active,
+	.edit-site-sidebar-button[aria-expanded="true"] {
+		color: var(--wp-admin--admin-bar--color-fg);
+	}
+
+	.edit-site-sidebar-navigation-screen-navigation-menus__content {
+		.block-editor-list-view-block-select-button,
+		.block-editor-list-view-block__menu {
+			color: var(--wp-admin--admin-menu--submenu-color-fg);
+
+			&:hover,
+			&:focus,
+			&[aria-current] {
+				color: var(--wp-admin--admin-bar--color-fg);
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This is a continuation of https://github.com/WordPress/gutenberg/pull/77964. Here, we apply the user's admin color scheme to the site editor sidebar, so it follows the admin bar's colors instead of always dark black.

## Why?

Currently the site editor sidebar is always black. On certain color schemes, it looks bad combined with the admin bar color.

## How?

This PR simply adds new color variables to the experiment SCSS file (`packages/edit-site/src/experimental-admin-bar-in-editor.scss`):

https://github.com/WordPress/gutenberg/blob/80b94546ccdbbdb142160c4cc05124d5a4407821/packages/edit-site/src/experimental-admin-bar-in-editor.scss#L3-L18

and then use the variables to override the existing color, in the same SCSS file. So the changes are contained in this file only. The color constants are copied from Core's hardcoded colors.

I know I know, this is not the best solution. However, theming the existing site editor v1 is a bit difficult. The original SCSS hardcodes colors, such as $gray-600, so it would take a bigger refactor to theme it properly. This is just an attempt to make the experiment looks good with user's admin color scheme.

Note that I need to add new variables because Core sidebar background colors are NOT included in `packages/base-styles/_mixins.scss` in any way.

> [!NOTE]  
> This PR only touches site editor v1 (`site-editor.php`) and not v2 yet (`admin.php?page=site-editor-v2`).

## Testing Instructions

Turn on the experiment then test on various color schemes. See: https://github.com/WordPress/gutenberg/pull/77964 for more information.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

|  |  |
| --- | --- |
| <img width="1440" alt="site-editor-styles-fresh" src="https://github.com/user-attachments/assets/fb58e9e5-a46c-4291-962d-6213b2e5afb2" /> | <img width="1440" alt="site-editor-styles-modern" src="https://github.com/user-attachments/assets/11d12502-ea6b-45ac-9938-9523e4311d81" /> |
| <img width="1440" alt="site-editor-styles-blue" src="https://github.com/user-attachments/assets/ee17eb00-bf1d-48b6-8e2a-488815591f20" /> | <img width="1440" alt="site-editor-styles-coffee" src="https://github.com/user-attachments/assets/97cb534f-a059-4d8f-a16c-2efd2ab9b63c" /> |
| <img width="1440" alt="site-editor-styles-ectoplasm" src="https://github.com/user-attachments/assets/e6aaa2d8-77d5-40f5-b87d-f361b65726a9" /> | <img width="1440" alt="site-editor-styles-light" src="https://github.com/user-attachments/assets/a2e81916-02a8-4b1d-9317-f0f332434d55" /> |
| <img width="1440" alt="site-editor-styles-midnight" src="https://github.com/user-attachments/assets/747f6d16-75c6-4716-a346-580ed2bae91d" /> | <img width="1440" alt="site-editor-styles-ocean" src="https://github.com/user-attachments/assets/2eac80ae-9710-4c02-8287-c25c0a2110a6" /> |
| <img width="1440" alt="site-editor-styles-sunrise" src="https://github.com/user-attachments/assets/fef6605d-c004-4730-9def-547283cdd3c4" /> |  |
## Use of AI Tools

I used Claude Code with Claude Opus 4.7 to help generate the CSS, copying Core's colors, and generate the screenshots.