### PR TITLE
Fix hidden `InnerBlocks.DefaultBlockAppender` when block is deselected

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -44,6 +44,7 @@ export default function BlockListAppender( {
 	CustomAppender,
 	className,
 	tagName: TagName = 'div',
+	isDefaultAppender,
 } ) {
 	const isDragOver = useSelect(
 		( select ) => {
@@ -78,6 +79,7 @@ export default function BlockListAppender( {
 			tabIndex={ -1 }
 			className={ clsx( 'block-list-appender wp-block', className, {
 				'is-drag-over': isDragOver,
+				'is-default-appender': isDefaultAppender,
 			} ) }
 			// Needed in case the whole editor is content editable (for multi
 			// selection). It fixes an edge case where ArrowDown and ArrowRight

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -362,13 +362,17 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 	}
 }
 
-.block-editor-block-list__block:not(.is-selected):not(.has-child-selected) .block-editor-default-block-appender {
+.block-editor-block-list__block:not(.is-selected):not(.has-child-selected) .block-list-appender:not(.is-default-appender) .block-editor-default-block-appender {
 	display: none;
 
 	.block-editor-inserter__toggle {
 		opacity: 0;
 		transform: scale(0);
 	}
+}
+
+.block-editor-block-list__block .block-list-appender.is-default-appender .block-editor-default-block-appender {
+	height: fit-content;
 }
 
 .block-editor-block-list__block .block-editor-block-list__block-html-textarea {

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -26,6 +26,7 @@ import { getDefaultBlockName } from '@wordpress/blocks';
  */
 import BlockListBlock from './block';
 import BlockListAppender from '../block-list-appender';
+import DefaultBlockAppender from '../inner-blocks/default-block-appender';
 import { useInBetweenInserter } from './use-in-between-inserter';
 import { store as blockEditorStore } from '../../store';
 import { LayoutProvider, defaultLayout } from './layout';
@@ -297,6 +298,9 @@ function Items( {
 					tagName={ __experimentalAppenderTagName }
 					rootClientId={ rootClientId }
 					CustomAppender={ CustomAppender }
+					isDefaultAppender={
+						CustomAppender === DefaultBlockAppender
+					}
 				/>
 			) }
 		</LayoutProvider>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #74060 

<!-- In a few words, what is the PR actually doing? -->
Fixes a bug where using `renderAppender={ InnerBlocks.DefaultBlockAppender }` on a block causes the appender to be hidden and a empty dashed outline to appear when the block is deselected.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When a block author explicitly passes `renderAppender={ InnerBlocks.DefaultBlockAppender }` to `InnerBlocks`, the expectation is that the “Type / to choose a block” placeholder remains visible even when the block is not selected.

However, `.block-editor-default-block-appender` was previously hidden whenever its parent block was neither selected nor has a selected child, without accounting for cases where the default appender had been explicitly forced via `renderAppender`. As a result, the appender disappeared when the block was deselected.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- In `block-list/index.js`, detect when `CustomAppender` is explicitly `DefaultBlockAppender` and pass an `isDefaultAppender` flag to `BlockListAppender`.
- In `block-list-appender/index.js`, convert that flag into an `is-default-appender` class on the appender wrapper element, providing a reliable CSS hook.
- In `block-list/content.scss`, scope the existing hiding rule so it excludes appenders explicitly rendered via `renderAppender` using `.block-list-appender:not(.is-default-appender)`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post or page in the block editor.
2. Temporarily modify `packages/block-library/src/group/edit.js` ([line 102](https://github.com/WordPress/gutenberg/blob/18021f2a04d0cd0aa5288572f76657a8c24bbae3/packages/block-library/src/group/edit.js#L102)) as following:
```diff
        } else if ( ! hasInnerBlocks ) {
                // When there is no placeholder, but the block is also empty,
                // use the larger button appender.
-               renderAppender = InnerBlocks.ButtonBlockAppender;
+               renderAppender = InnerBlocks.DefaultBlockAppender;
        }
```
3. Insert a Group block and select an option on the placeholder.
4. Click away to deselect the block.
5. **Expected:** The "Type / to choose a block" placeholder is visible.
6. **Before this fix:** The appender is hidden and a dashed outline appears.

<!-- ### Testing Instructions for Keyboard -->
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|State|Before|After|
|-|-|-|
|Selected|<img width="682" height="110" alt="Screenshot 2026-05-15 at 4 06 11 PM" src="https://github.com/user-attachments/assets/f9144483-7df1-4a50-b3a3-31fd24a2228e" />|<img width="693" height="121" alt="Screenshot 2026-05-15 at 4 06 53 PM" src="https://github.com/user-attachments/assets/d330ba56-ab59-4008-9f0c-5a576ed1b4cf" />|
|Unselected|<img width="678" height="45" alt="Screenshot 2026-05-15 at 4 06 28 PM" src="https://github.com/user-attachments/assets/ca6bc04b-0a9e-40f9-9b1f-1cac82414a5c" />|<img width="694" height="63" alt="Screenshot 2026-05-15 at 4 07 08 PM" src="https://github.com/user-attachments/assets/97190d77-ef8c-46bd-b191-d35c1f6a04ed" />|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
- ChatGPT for rephrasing and refining the PR description.
- GitHub Copilot for implementation-related assistance.