### PR TITLE
Dashboard: migrate Layout settings drawer to DataForm

### DIFF
--- a/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
+++ b/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
+import { __experimentalNumberControl as NumberControl } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
-import type { Field, Form } from '@wordpress/dataviews';
+import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /* eslint-disable @wordpress/use-recommended-components */
@@ -50,6 +51,45 @@ function isAutoRowHeight( item: WidgetGridSettings ): boolean {
 	return getRowHeight( item ) === ROW_HEIGHT_AUTO;
 }
 
+function StepperIntegerEdit( {
+	data,
+	field,
+	onChange,
+}: DataFormControlProps< WidgetGridSettings > ) {
+	const { label, description, getValue, setValue, isValid } = field;
+	const value = getValue( { item: data } );
+	const disabled = field.isDisabled( { item: data, field } );
+	const min =
+		typeof isValid.min?.constraint === 'number'
+			? isValid.min.constraint
+			: undefined;
+	const max =
+		typeof isValid.max?.constraint === 'number'
+			? isValid.max.constraint
+			: undefined;
+
+	return (
+		<NumberControl
+			__next40pxDefaultSize
+			label={ label }
+			help={ description }
+			value={ value ?? '' }
+			min={ min }
+			max={ max }
+			step={ 1 }
+			spinControls="custom"
+			disabled={ disabled }
+			onChange={ ( next ) => {
+				const parsed =
+					next === '' || next === undefined
+						? undefined
+						: Number( next );
+				onChange( setValue( { item: data, value: parsed } ) );
+			} }
+		/>
+	);
+}
+
 const fields: Field< WidgetGridSettings >[] = [
 	{
 		id: 'model',
@@ -86,6 +126,7 @@ const fields: Field< WidgetGridSettings >[] = [
 	{
 		id: 'columns',
 		type: 'integer',
+		Edit: StepperIntegerEdit,
 		label: __( 'Columns' ),
 		isValid: { min: 1, max: 12 },
 		isVisible: ( item ) => isFixedColumns( item ),
@@ -93,6 +134,7 @@ const fields: Field< WidgetGridSettings >[] = [
 	{
 		id: 'minColumnWidth',
 		type: 'integer',
+		Edit: StepperIntegerEdit,
 		label: __( 'Min column width (px)' ),
 		description: __(
 			'Minimum width of each column. The number of columns adapts to the container width.'
@@ -114,6 +156,7 @@ const fields: Field< WidgetGridSettings >[] = [
 	{
 		id: 'rowHeight',
 		type: 'integer',
+		Edit: StepperIntegerEdit,
 		label: __( 'Row height (px)' ),
 		description: __( 'Height of each row in the standard grid.' ),
 		isValid: { min: 100 },

--- a/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
+++ b/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
@@ -1,17 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { ToggleControl } from '@wordpress/components';
+import { DataForm } from '@wordpress/dataviews';
+import type { Field, Form } from '@wordpress/dataviews';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /* eslint-disable @wordpress/use-recommended-components */
-import {
-	Button,
-	Drawer,
-	InputControl,
-	SelectControl,
-	Stack,
-} from '@wordpress/ui';
+import { Button, Drawer } from '@wordpress/ui';
 /* eslint-enable @wordpress/use-recommended-components */
 
 /**
@@ -20,32 +15,128 @@ import {
 import { useDashboardInternalContext } from '../../context/dashboard-context';
 import { migrateLayout } from '../../utils/migrate-layout';
 import type {
+	WidgetGridLayoutSettings,
 	WidgetGridModel,
 	WidgetGridSettings,
-	WidgetMasonryLayoutSettings,
 } from '../../types';
 
-const MODEL_ITEMS = [
-	{ value: 'grid', label: __( 'Standard grid' ) },
-	{ value: 'masonry', label: __( 'Masonry' ) },
-] as const satisfies ReadonlyArray< { value: WidgetGridModel; label: string } >;
-
+const DEFAULT_FIXED_COLUMNS = 6;
+const DEFAULT_MIN_COLUMN_WIDTH = 350;
+const DEFAULT_ROW_HEIGHT = 200;
 const ROW_HEIGHT_AUTO = 'auto' as const;
 
-function getModelValue( settings: WidgetGridSettings ): WidgetGridModel {
-	return settings.model ?? 'grid';
+function getModel( item: WidgetGridSettings ): WidgetGridModel {
+	return item.model ?? 'grid';
 }
 
-function parsePositiveInt( raw: unknown ): number | undefined {
-	if ( typeof raw !== 'string' && typeof raw !== 'number' ) {
-		return undefined;
-	}
-	const parsed = typeof raw === 'number' ? raw : Number.parseInt( raw, 10 );
-	if ( ! Number.isFinite( parsed ) || parsed <= 0 ) {
-		return undefined;
-	}
-	return parsed;
+function isMasonry( item: WidgetGridSettings ): boolean {
+	return getModel( item ) === 'masonry';
 }
+
+function isFixedColumns( item: WidgetGridSettings ): boolean {
+	return item.columns !== undefined;
+}
+
+function getRowHeight(
+	item: WidgetGridSettings
+): WidgetGridLayoutSettings[ 'rowHeight' ] {
+	if ( isMasonry( item ) ) {
+		return undefined;
+	}
+	return ( item as WidgetGridLayoutSettings ).rowHeight;
+}
+
+function isAutoRowHeight( item: WidgetGridSettings ): boolean {
+	return getRowHeight( item ) === ROW_HEIGHT_AUTO;
+}
+
+const fields: Field< WidgetGridSettings >[] = [
+	{
+		id: 'model',
+		type: 'text',
+		Edit: 'select',
+		label: __( 'Layout model' ),
+		description: __(
+			'Standard grid uses explicit widths and heights. Masonry packs items by content height.'
+		),
+		elements: [
+			{ value: 'grid', label: __( 'Standard grid' ) },
+			{ value: 'masonry', label: __( 'Masonry' ) },
+		],
+		getValue: ( { item } ) => getModel( item ),
+	},
+	{
+		id: 'fixedColumns',
+		type: 'boolean',
+		Edit: 'toggle',
+		label: __( 'Fixed column count' ),
+		getValue: ( { item } ) => isFixedColumns( item ),
+		setValue: ( { item, value } ) =>
+			value
+				? {
+						columns: item.columns ?? DEFAULT_FIXED_COLUMNS,
+						minColumnWidth: undefined,
+				  }
+				: {
+						columns: undefined,
+						minColumnWidth:
+							item.minColumnWidth ?? DEFAULT_MIN_COLUMN_WIDTH,
+				  },
+	},
+	{
+		id: 'columns',
+		type: 'integer',
+		label: __( 'Columns' ),
+		isValid: { min: 1, max: 12 },
+		isVisible: ( item ) => isFixedColumns( item ),
+	},
+	{
+		id: 'minColumnWidth',
+		type: 'integer',
+		label: __( 'Min column width (px)' ),
+		description: __(
+			'Minimum width of each column. The number of columns adapts to the container width.'
+		),
+		isValid: { min: 200 },
+		isVisible: ( item ) => ! isFixedColumns( item ),
+	},
+	{
+		id: 'autoRowHeight',
+		type: 'boolean',
+		Edit: 'toggle',
+		label: __( 'Auto-fit row height to content' ),
+		getValue: ( { item } ) => isAutoRowHeight( item ),
+		setValue: ( { value } ) => ( {
+			rowHeight: value ? ROW_HEIGHT_AUTO : DEFAULT_ROW_HEIGHT,
+		} ),
+		isDisabled: ( { item } ) => isMasonry( item ),
+	},
+	{
+		id: 'rowHeight',
+		type: 'integer',
+		label: __( 'Row height (px)' ),
+		description: __( 'Height of each row in the standard grid.' ),
+		isValid: { min: 100 },
+		getValue: ( { item } ) => {
+			const rh = getRowHeight( item );
+			return typeof rh === 'number' ? rh : undefined;
+		},
+		isVisible: ( item ) => ! isMasonry( item ),
+		isDisabled: ( { item } ) => isAutoRowHeight( item ),
+	},
+];
+
+const form: Form = {
+	layout: { type: 'regular', labelPosition: 'top' },
+	fields: [
+		'model',
+		'fixedColumns',
+		'columns',
+		'minColumnWidth',
+		'autoRowHeight',
+		'rowHeight',
+	],
+};
 
 interface LayoutSettingsProps {
 	open: boolean;
@@ -94,109 +185,27 @@ export function LayoutSettings( {
 		hasUncommittedChanges,
 	} = useDashboardInternalContext();
 
-	const currentModel = getModelValue( gridSettings );
-	const isMasonry = currentModel === 'masonry';
+	const handleChange = useCallback(
+		( edits: Record< string, unknown > ) => {
+			const nextModel = edits.model as WidgetGridModel | undefined;
+			const currentModel = getModel( gridSettings );
 
-	const handleModelChange = useCallback(
-		( nextModel: WidgetGridModel ) => {
-			if ( nextModel === currentModel ) {
-				return;
+			if ( nextModel && nextModel !== currentModel ) {
+				const migrated = migrateLayout(
+					layout,
+					currentModel,
+					nextModel,
+					{ columns: gridSettings.columns ?? DEFAULT_FIXED_COLUMNS }
+				);
+				onLayoutChange( migrated );
 			}
 
-			const migrated = migrateLayout( layout, currentModel, nextModel, {
-				columns: gridSettings.columns ?? 6,
-			} );
-
-			onLayoutChange( migrated );
 			onGridSettingsChange( {
 				...gridSettings,
-				model: nextModel,
+				...edits,
 			} as WidgetGridSettings );
 		},
-		[
-			currentModel,
-			gridSettings,
-			layout,
-			onGridSettingsChange,
-			onLayoutChange,
-		]
-	);
-
-	const handleMinColumnWidthChange = useCallback(
-		( raw: unknown ) => {
-			const next = parsePositiveInt( raw );
-			onGridSettingsChange( {
-				...gridSettings,
-				minColumnWidth: next,
-			} as WidgetGridSettings );
-		},
-		[ gridSettings, onGridSettingsChange ]
-	);
-
-	const handleColumnsChange = useCallback(
-		( raw: unknown ) => {
-			const next = parsePositiveInt( raw );
-			onGridSettingsChange( {
-				...gridSettings,
-				columns: next,
-			} as WidgetGridSettings );
-		},
-		[ gridSettings, onGridSettingsChange ]
-	);
-
-	const handleColumnsModeChange = useCallback(
-		( useFixedColumns: boolean ) => {
-			if ( useFixedColumns ) {
-				onGridSettingsChange( {
-					...gridSettings,
-					columns: gridSettings.columns ?? 6,
-					minColumnWidth: undefined,
-				} as WidgetGridSettings );
-			} else {
-				onGridSettingsChange( {
-					...gridSettings,
-					columns: undefined,
-					minColumnWidth: gridSettings.minColumnWidth ?? 350,
-				} as WidgetGridSettings );
-			}
-		},
-		[ gridSettings, onGridSettingsChange ]
-	);
-
-	const setRowHeight = useCallback(
-		( raw: unknown ) => {
-			const next = parsePositiveInt( raw );
-			onGridSettingsChange( {
-				...gridSettings,
-				rowHeight: next,
-			} as WidgetGridSettings );
-		},
-		[ gridSettings, onGridSettingsChange ]
-	);
-
-	const setRowHeightAuto = useCallback(
-		( checked: boolean ) => {
-			onGridSettingsChange( {
-				...gridSettings,
-				rowHeight: checked ? ROW_HEIGHT_AUTO : 200,
-			} as WidgetGridSettings );
-		},
-		[ gridSettings, onGridSettingsChange ]
-	);
-
-	const rowHeight = isMasonry
-		? undefined
-		: (
-				gridSettings as Exclude<
-					WidgetGridSettings,
-					WidgetMasonryLayoutSettings
-				>
-		   ).rowHeight;
-	const isRowHeightAuto = rowHeight === ROW_HEIGHT_AUTO;
-	const isFixedColumns = gridSettings.columns !== undefined;
-
-	const modelItem = MODEL_ITEMS.find(
-		( item ) => item.value === currentModel
+		[ gridSettings, layout, onGridSettingsChange, onLayoutChange ]
 	);
 
 	const handleCancel = useCallback( () => {
@@ -234,84 +243,12 @@ export function LayoutSettings( {
 				</Drawer.Header>
 
 				<Drawer.Content>
-					<Stack direction="column" gap="lg">
-						<SelectControl
-							label={ __( 'Layout model' ) }
-							description={ __(
-								'Standard grid uses explicit widths and heights. Masonry packs items by content height.'
-							) }
-							items={ [ ...MODEL_ITEMS ] }
-							value={ modelItem }
-							onValueChange={ ( item ) => {
-								if ( item ) {
-									handleModelChange(
-										item.value as WidgetGridModel
-									);
-								}
-							} }
-						/>
-
-						<Stack direction="column" gap="xs">
-							<ToggleControl
-								label={ __( 'Fixed column count' ) }
-								checked={ isFixedColumns }
-								onChange={ handleColumnsModeChange }
-							/>
-							{ isFixedColumns ? (
-								<InputControl
-									label={ __( 'Columns' ) }
-									type="number"
-									min={ 1 }
-									max={ 12 }
-									value={ gridSettings.columns ?? '' }
-									onValueChange={ handleColumnsChange }
-								/>
-							) : (
-								<InputControl
-									label={ __( 'Min column width (px)' ) }
-									description={ __(
-										'Minimum width of each column. The number of columns adapts to the container width.'
-									) }
-									type="number"
-									min={ 200 }
-									step={ 10 }
-									value={ gridSettings.minColumnWidth ?? '' }
-									onValueChange={ handleMinColumnWidthChange }
-								/>
-							) }
-						</Stack>
-
-						<Stack direction="column" gap="xs">
-							<ToggleControl
-								label={ __( 'Auto-fit row height to content' ) }
-								checked={ isRowHeightAuto }
-								disabled={ isMasonry }
-								onChange={ setRowHeightAuto }
-							/>
-							<InputControl
-								label={ __( 'Row height (px)' ) }
-								description={
-									isMasonry
-										? __(
-												'Row height is content-driven in masonry layouts.'
-										  )
-										: __(
-												'Height of each row in the standard grid.'
-										  )
-								}
-								type="number"
-								min={ 100 }
-								step={ 10 }
-								disabled={ isMasonry || isRowHeightAuto }
-								value={
-									typeof rowHeight === 'number'
-										? rowHeight
-										: ''
-								}
-								onValueChange={ setRowHeight }
-							/>
-						</Stack>
-					</Stack>
+					<DataForm
+						data={ gridSettings }
+						fields={ fields }
+						form={ form }
+						onChange={ handleChange }
+					/>
 				</Drawer.Content>
 
 				<Drawer.Footer>

--- a/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
+++ b/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
@@ -139,7 +139,14 @@ const form: Form = {
 };
 
 interface LayoutSettingsProps {
+	/**
+	 * Whether the drawer is visible.
+	 */
 	open: boolean;
+
+	/**
+	 * Callback to toggle the drawer.
+	 */
 	onOpenChange: ( open: boolean ) => void;
 }
 
@@ -166,9 +173,8 @@ interface LayoutSettingsProps {
  * commit never publishes layout edits that the user is in the
  * middle of staging through the toolbar.
  *
- * @param props
- * @param props.open         Whether the drawer is visible.
- * @param props.onOpenChange Toggle controller from the trigger.
+ * @param {LayoutSettingsProps} props Layout settings props.
+ * @return {React.ReactNode} The layout settings component.
  */
 export function LayoutSettings( {
 	open,

--- a/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
+++ b/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
@@ -139,7 +139,7 @@ const fields: Field< WidgetGridSettings >[] = [
 		description: __(
 			'Minimum width of each column. The number of columns adapts to the container width.'
 		),
-		isValid: { min: 200 },
+		isValid: { min: 48, max: 1024 },
 		isVisible: ( item ) => ! isFixedColumns( item ),
 	},
 	{


### PR DESCRIPTION

## What?

Migrates `routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx` away from a manual `Stack` + `ToggleControl` + `SelectControl` + `InputControl` composition to a declarative `DataForm` schema. Follow-up from the #78202 review thread (spacing inconsistency between fields; consistency with the rest of the dashboard's form surfaces).

## Why?

* The hand-rolled control composition produced uneven spacing between fields compared to other dashboard form surfaces.
* Each field carried its own `useCallback` setter and inline conditional rendering, which made the drawer's body harder to scan.
* `DataForm` already handles layout, label position, and field-conditional visibility / disabled state, so the drawer now matches the rest of the dashboard for free.

## How?

* **Declarative schema** (`fields` + `form` constants at module scope):
    * `model` — `select` with two elements (`grid`, `masonry`).
    * `fixedColumns` — synthetic boolean toggle; `setValue` returns an atomic `{ columns, minColumnWidth }` update so the underlying grid xor is preserved.
    * `columns` / `minColumnWidth` — integer fields gated by `isVisible` based on `fixedColumns`.
    * `autoRowHeight` — synthetic boolean toggle; `setValue` flips `rowHeight` between `'auto'` and a numeric default. `isDisabled` in masonry mode.
    * `rowHeight` — integer field with `isVisible` (hidden in masonry) and `isDisabled` (locked when `autoRowHeight`).
* **Side-effect handling** — `migrateLayout` moves into a wrapped `onChange` that detects a `model` delta in the edits patch and runs the migration before propagating settings.
* **Custom `+`/`-` steppers** — a local `StepperIntegerEdit` wraps `NumberControl` with `spinControls="custom"` and is applied to all integer fields, addressing the second item in the original review thread. The `step` is currently hardcoded to `1`; see the Follow-ups section.
* **Removed** — `Stack`, `SelectControl`, `ToggleControl`, `InputControl` imports; six per-field `useCallback` setters; the `parsePositiveInt` helper; the `MODEL_ITEMS` const array. The drawer chrome (Header / Content / Footer + Save / Cancel / Reset) is preserved.

## Testing

* Open the dashboard and click **Layout settings** to reveal the drawer.
* Switch the model between **Standard grid** and **Masonry** — the layout migration runs, `Row height` and `Auto-fit row height` hide / disable accordingly.
* Toggle **Fixed column count** — the visible field flips between `Columns` (1–12) and `Min column width` (≥48).
* Toggle **Auto-fit row height** — `Row height` becomes disabled; toggling back restores the previous numeric value (200 default).
* Verify **Save / Cancel / Reset** still operate on the staging buffer (changes appear live behind the drawer; Cancel and the X icon roll back, Save commits).
* Confirm the per-field spacing now matches other dashboard form surfaces.

**Before**

<img width="1083" height="997" alt="image" src="https://github.com/user-attachments/assets/ed2a68b9-3f69-4a37-84d2-61c10aa0ff7d" />

**After**

<img width="1083" height="997" alt="image" src="https://github.com/user-attachments/assets/a6dd0f7a-3e95-4121-9cab-bf3e0460da65" />


## Follow-ups

* [ ] DataForm's `EditConfig` does not currently expose `step` for integer / number fields; the custom `step={ 10 }` previously used for `Min column width` and `Row height` is therefore not yet expressible declaratively. Tracked upstream at https://github.com/WordPress/gutenberg/issues/78335.
