### PR TITLE
Block/Tabs: Fix editor dirty state on reload by removing unnecessary mount-time attribute init

### DIFF
--- a/packages/block-library/src/tabs/edit.js
+++ b/packages/block-library/src/tabs/edit.js
@@ -8,7 +8,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { useMemo, useEffect } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -34,16 +34,6 @@ const TABS_TEMPLATE = [ [ 'core/tab-list' ], [ 'core/tab-panels' ] ];
 
 function Edit( { clientId, attributes, setAttributes } ) {
 	const { anchor, activeTabIndex, editorActiveTabIndex } = attributes;
-
-	/**
-	 * Initialize editorActiveTabIndex to activeTabIndex on mount.
-	 * This ensures the ephemeral editor state starts at the persisted default.
-	 */
-	useEffect( () => {
-		if ( editorActiveTabIndex === undefined ) {
-			setAttributes( { editorActiveTabIndex: activeTabIndex } );
-		}
-	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const { tabPanels, tabPanelsClientId, tabs, tabListClientId } = useSelect(
 		( select ) => {


### PR DESCRIPTION
## What?

Removes the `useEffect` in `tabs/edit.js` that initialised `editorActiveTabIndex` via `setAttributes` on mount.

Closes #78337.

## Why?

`editorActiveTabIndex` has `"role": "local"` in `block.json` — it is never serialised to post content. This means it is always `undefined` when a saved post is reloaded. The `useEffect` on mount called `setAttributes({ editorActiveTabIndex: activeTabIndex })` without `__unstableMarkNextChangeAsNotPersistent`, recording a persistent edit every time the editor loaded a post containing a Tabs block. This caused the "Save draft" button to appear instead of the "Saved" checkmark with no user changes.

## How?

All consumers of `editorActiveTabIndex` already gracefully handle `undefined` by falling back to `activeTabIndex` via `??`:

- `tab/edit.js`: `editorActiveTabIndex ?? activeTabIndex`
- `tab-panel/edit.js`: `editorActiveTabIndex ?? activeTabIndex`
- `remove-tab-toolbar-control.js`: `tabsAttributes?.editorActiveTabIndex ?? tabsAttributes?.activeTabIndex ?? 0`

Removing the `useEffect` means `editorActiveTabIndex` stays `undefined` until the user actively clicks a tab, at which point the child blocks already set it correctly via `__unstableMarkNextChangeAsNotPersistent`.

## Testing Instructions

1. Create a new post.
2. Insert a **Tabs** block.
3. Save or publish the post.
4. Reload the editor page.
5. Without making any changes, verify the header shows **"Saved"** with the checkmark — not **"Save draft"**.
6. Click between tabs and verify the active tab still switches correctly.
7. Add/remove tabs and verify they still work correctly.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:

https://github.com/user-attachments/assets/e4c362ed-6466-4eef-896a-ea9380da45e4

After:

https://github.com/user-attachments/assets/bf953fbf-36a1-4b2a-8704-d7e4091aca38

