### PR TITLE
Grid: make resize overlay line solid

### DIFF
--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Enhancements
 
+-   Add `--wp-grid-placeholder-outline-style` and
+    `--wp-grid-resize-preview-outline-style` CSS custom properties for
+    the drag-placeholder outline (default `dashed`) and resize-preview
+    border (default `solid`).
 -   Set `data-wp-dashboard-grid-resizing` on the `DashboardGrid` root
     element while any tile resize gesture is active, so consumers can
     adjust styles when the pointer may still hover tiles ([#78234](https://github.com/WordPress/gutenberg/pull/78234)).

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -175,10 +175,10 @@ display order independently of array position.
 When `editMode` is true:
 
 - Items become draggable (powered by `@dnd-kit`). The original tile
-  stays in place as a dashed placeholder while a clone follows the
+  stays in place as an outlined placeholder while a clone follows the
   cursor through `<DragOverlay>`.
-- A resize handle appears on the bottom-right of each item. A
-  dashed outline previews the target size as the cursor moves.
+- A resize handle appears on the bottom-right of each item. An
+  outline previews the target size as the cursor moves.
 - While any tile is dragging or resizing, `actionableArea` content
   on every tile is set `inert` so hovers on other tiles can't steal
   the gesture.
@@ -474,8 +474,9 @@ root itself via `style`). All values fall back to sensible defaults.
 |----------|---------|------------|
 | `--wp-grid-drag-preview-scale` | `1.05` | Lift scale of the drag-preview functional frame. Set to `1` to disable the lift. |
 | `--wp-grid-placeholder-opacity` | `0.4` | Opacity of the placeholder tile (the original item while a drag is in flight). |
-| `--wp-grid-placeholder-outline-color` | `var(--wpds-color-stroke-interactive-brand)` | Dashed outline color of the placeholder and of the resize-preview overlay. |
-| `--wp-grid-placeholder-radius` | `0` | Border radius of the placeholder, used to match the consumer's tile shape so the dashed outline traces the right silhouette. |
+| `--wp-grid-placeholder-outline-style` | `solid` | Outline or border style of the placeholder and of the resize-preview overlay (for example `dashed` or `dotted`). |
+| `--wp-grid-placeholder-outline-color` | `var(--wpds-color-stroke-interactive-brand)` | Outline color of the placeholder and of the resize-preview overlay. |
+| `--wp-grid-placeholder-radius` | `0` | Border radius of the placeholder, used to match the consumer's tile shape so the outline traces the right silhouette. |
 
 ---
 

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -175,10 +175,10 @@ display order independently of array position.
 When `editMode` is true:
 
 - Items become draggable (powered by `@dnd-kit`). The original tile
-  stays in place as an outlined placeholder while a clone follows the
+  stays in place as a dashed placeholder while a clone follows the
   cursor through `<DragOverlay>`.
-- A resize handle appears on the bottom-right of each item. An
-  outline previews the target size as the cursor moves.
+- A resize handle appears on the bottom-right of each item. A
+  solid outline previews the target size as the cursor moves.
 - While any tile is dragging or resizing, `actionableArea` content
   on every tile is set `inert` so hovers on other tiles can't steal
   the gesture.
@@ -474,7 +474,8 @@ root itself via `style`). All values fall back to sensible defaults.
 |----------|---------|------------|
 | `--wp-grid-drag-preview-scale` | `1.05` | Lift scale of the drag-preview functional frame. Set to `1` to disable the lift. |
 | `--wp-grid-placeholder-opacity` | `0.4` | Opacity of the placeholder tile (the original item while a drag is in flight). |
-| `--wp-grid-placeholder-outline-style` | `solid` | Outline or border style of the placeholder and of the resize-preview overlay (for example `dashed` or `dotted`). |
+| `--wp-grid-placeholder-outline-style` | `dashed` | Outline style of the drag placeholder (for example `solid` or `dotted`). |
+| `--wp-grid-resize-preview-outline-style` | `solid` | Border style of the resize-preview overlay (for example `dashed` or `dotted`). |
 | `--wp-grid-placeholder-outline-color` | `var(--wpds-color-stroke-interactive-brand)` | Outline color of the placeholder and of the resize-preview overlay. |
 | `--wp-grid-placeholder-radius` | `0` | Border radius of the placeholder, used to match the consumer's tile shape so the outline traces the right silhouette. |
 

--- a/packages/grid/src/dashboard-grid/grid-item.module.css
+++ b/packages/grid/src/dashboard-grid/grid-item.module.css
@@ -19,7 +19,7 @@
 	pointer-events: none;
 	outline:
 		var(--wpds-border-width-sm)
-		var(--wp-grid-placeholder-outline-style, solid)
+		var(--wp-grid-placeholder-outline-style, dashed)
 		var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
 	border-radius: var(--wp-grid-placeholder-radius, 0);
 }
@@ -38,7 +38,7 @@
 	z-index: 1;
 	border:
 		var(--wpds-border-width-sm)
-		var(--wp-grid-placeholder-outline-style, solid)
+		var(--wp-grid-resize-preview-outline-style, solid)
 		var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
 	background: transparent;
 	border-radius: var(--wp-grid-placeholder-radius, 0);

--- a/packages/grid/src/dashboard-grid/grid-item.module.css
+++ b/packages/grid/src/dashboard-grid/grid-item.module.css
@@ -10,7 +10,7 @@
 /*
  * During drag, the original item acts as a placeholder in its grid
  * cell while `<DragOverlay>` renders a clone that follows the cursor.
- * Fading the placeholder and outlining it with a dashed border makes
+ * Fading the placeholder and outlining it makes
  * the destination visible without any scaling or translation on the
  * original element.
  */
@@ -18,7 +18,8 @@
 	opacity: var(--wp-grid-placeholder-opacity, 0.4);
 	pointer-events: none;
 	outline:
-		var(--wpds-border-width-sm) dashed
+		var(--wpds-border-width-sm)
+		var(--wp-grid-placeholder-outline-style, solid)
 		var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
 	border-radius: var(--wp-grid-placeholder-radius, 0);
 }
@@ -36,7 +37,8 @@
 	pointer-events: none;
 	z-index: 1;
 	border:
-		var(--wpds-border-width-sm) dashed
+		var(--wpds-border-width-sm)
+		var(--wp-grid-placeholder-outline-style, solid)
 		var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
 	background: transparent;
 	border-radius: var(--wp-grid-placeholder-radius, 0);

--- a/packages/grid/src/dashboard-lanes/lanes-item.module.css
+++ b/packages/grid/src/dashboard-lanes/lanes-item.module.css
@@ -19,7 +19,7 @@
 	pointer-events: none;
 	outline:
 		var(--wpds-border-width-sm)
-		var(--wp-grid-placeholder-outline-style, solid)
+		var(--wp-grid-placeholder-outline-style, dashed)
 		var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
 	border-radius: var(--wp-grid-placeholder-radius, 0);
 }
@@ -38,7 +38,7 @@
 	z-index: 1;
 	border:
 		var(--wpds-border-width-sm)
-		var(--wp-grid-placeholder-outline-style, solid)
+		var(--wp-grid-resize-preview-outline-style, solid)
 		var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
 	background: transparent;
 }

--- a/packages/grid/src/dashboard-lanes/lanes-item.module.css
+++ b/packages/grid/src/dashboard-lanes/lanes-item.module.css
@@ -10,7 +10,7 @@
 /*
  * During drag, the original item acts as a placeholder in its lane
  * while `<DragOverlay>` renders a clone that follows the cursor.
- * Fading the placeholder and outlining it with a dashed border makes
+ * Fading the placeholder and outlining it makes
  * the destination visible without any scaling or translation on the
  * original element.
  */
@@ -18,7 +18,8 @@
 	opacity: var(--wp-grid-placeholder-opacity, 0.4);
 	pointer-events: none;
 	outline:
-		var(--wpds-border-width-sm) dashed
+		var(--wpds-border-width-sm)
+		var(--wp-grid-placeholder-outline-style, solid)
 		var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
 	border-radius: var(--wp-grid-placeholder-radius, 0);
 }
@@ -36,7 +37,8 @@
 	pointer-events: none;
 	z-index: 1;
 	border:
-		var(--wpds-border-width-sm) dashed
+		var(--wpds-border-width-sm)
+		var(--wp-grid-placeholder-outline-style, solid)
 		var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
 	background: transparent;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Follow-up to https://github.com/WordPress/gutenberg/pull/78292

- Adds CSS token for setting border _style_  in the grid, documented in the readme.
- Set default line style to _solid_ instead of _dashed_

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Design feedback follow-up https://github.com/WordPress/gutenberg/pull/78292#issuecomment-4451112450

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Enable experimental dashboard
- Visit dashboard
- Click customize
- Drag widgets, resize them
- See how resize outline is solid, while placeholder remains dashed

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

#### Before
https://github.com/user-attachments/assets/96c2e954-3401-47e6-b8b2-63118d3a7590

#### After

https://github.com/user-attachments/assets/fb1dd4fb-c24c-48be-8f90-892060f17e7e




## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
yes