### PR TITLE
Content Type: Handle duplicate slug generation for CPT's and Taxonomies 

### DIFF
--- a/packages/content-types/src/post-types/actions/duplicate.tsx
+++ b/packages/content-types/src/post-types/actions/duplicate.tsx
@@ -3,7 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	DataForm,
 	useFormValidity,
@@ -34,14 +34,20 @@ const duplicateForm: Form = {
 	fields: [ 'plural_name', 'singular_name', 'slug' ],
 };
 
-function buildCopySlug( slug: string ): string {
+function buildCopySlug( slug: string, takenSlugs: Set< string > ): string {
 	const match = slug.match( /^(.*?)(\d+)$/ );
 	const base = match ? match[ 1 ] : slug;
-	const nextNumber = String( match ? parseInt( match[ 2 ], 10 ) + 1 : 2 );
-	return `${ base.slice(
-		0,
-		SLUG_MAX_LENGTH - nextNumber.length
-	) }${ nextNumber }`;
+	let num = match ? parseInt( match[ 2 ], 10 ) + 1 : 2;
+	let candidate: string;
+	do {
+		const nextNumber = String( num );
+		candidate = `${ base.slice(
+			0,
+			SLUG_MAX_LENGTH - nextNumber.length
+		) }${ nextNumber }`;
+		num++;
+	} while ( takenSlugs.has( candidate ) );
+	return candidate;
 }
 
 function DuplicatePostTypeModal( {
@@ -54,6 +60,19 @@ function DuplicatePostTypeModal( {
 	onActionPerformed?: ( items: PostTypeFormData[] ) => void;
 } ) {
 	const source = items[ 0 ];
+	const takenSlugs = useSelect( ( select ) => {
+		const postTypes = select( coreStore ).getPostTypes() ?? [];
+		const drafts =
+			select( coreStore ).getEntityRecords(
+				'postType',
+				POST_TYPE_ENTITY,
+				{ status: 'draft', per_page: -1, _fields: 'id,slug' }
+			) ?? [];
+		return new Set< string >( [
+			...postTypes.map( ( pt: any ) => pt.slug ),
+			...drafts.map( ( d: any ) => d.slug ),
+		] );
+	}, [] );
 	const [ data, setData ] = useState< PostTypeFormData >( () => ( {
 		...source,
 		id: undefined,
@@ -65,7 +84,7 @@ function DuplicatePostTypeModal( {
 				source.title.raw
 			),
 		},
-		slug: buildCopySlug( source.slug ),
+		slug: buildCopySlug( source.slug, takenSlugs ),
 	} ) );
 	const [ isDuplicating, setIsDuplicating ] = useState( false );
 	const slugField = useSlugField( undefined, data.slug );

--- a/packages/content-types/src/post-types/actions/duplicate.tsx
+++ b/packages/content-types/src/post-types/actions/duplicate.tsx
@@ -3,6 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
+import type { Type as PostType } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	DataForm,
@@ -11,7 +12,7 @@ import {
 	type Field,
 	type Form,
 } from '@wordpress/dataviews';
-import { useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { copy } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
@@ -61,16 +62,17 @@ function DuplicatePostTypeModal( {
 } ) {
 	const source = items[ 0 ];
 	const takenSlugs = useSelect( ( select ) => {
-		const postTypes = select( coreStore ).getPostTypes() ?? [];
-		const drafts =
-			select( coreStore ).getEntityRecords(
-				'postType',
-				POST_TYPE_ENTITY,
-				{ status: 'draft', per_page: -1, _fields: 'id,slug' }
-			) ?? [];
+		const postTypes: PostType[] = select( coreStore ).getPostTypes() ?? [];
+
+		const drafts = ( select( coreStore ).getEntityRecords(
+			'postType',
+			POST_TYPE_ENTITY,
+			{ status: 'draft', per_page: -1, _fields: 'id,slug' }
+		) ?? [] ) as Array< { slug: string } >;
+
 		return new Set< string >( [
-			...postTypes.map( ( pt: any ) => pt.slug ),
-			...drafts.map( ( d: any ) => d.slug ),
+			...postTypes.map( ( pt ) => pt.slug ),
+			...drafts.map( ( d ) => d.slug ),
 		] );
 	}, [] );
 	const [ data, setData ] = useState< PostTypeFormData >( () => ( {
@@ -86,6 +88,19 @@ function DuplicatePostTypeModal( {
 		},
 		slug: buildCopySlug( source.slug, takenSlugs ),
 	} ) );
+	// Track whether the user has manually edited the slug so we don't
+	// overwrite their input when takenSlugs resolves asynchronously.
+	const isSlugEditedRef = useRef( false );
+
+	useEffect( () => {
+		if ( ! isSlugEditedRef.current ) {
+			setData( ( prev ) => ( {
+				...prev,
+				slug: buildCopySlug( source.slug, takenSlugs ),
+			} ) );
+		}
+	}, [ source.slug, takenSlugs ] );
+
 	const [ isDuplicating, setIsDuplicating ] = useState( false );
 	const slugField = useSlugField( undefined, data.slug );
 
@@ -150,12 +165,15 @@ function DuplicatePostTypeModal( {
 				fields={ fields }
 				form={ duplicateForm }
 				validity={ validity }
-				onChange={ ( edits ) =>
+				onChange={ ( edits ) => {
+					if ( 'slug' in edits ) {
+						isSlugEditedRef.current = true;
+					}
 					setData(
 						( prev ) =>
 							( { ...prev, ...edits } ) as PostTypeFormData
-					)
-				}
+					);
+				} }
 			/>
 			<Stack direction="row" justify="flex-end" gap="sm">
 				<Button

--- a/packages/content-types/src/taxonomies/actions/duplicate.tsx
+++ b/packages/content-types/src/taxonomies/actions/duplicate.tsx
@@ -3,7 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	DataForm,
 	useFormValidity,
@@ -34,14 +34,20 @@ const duplicateForm: Form = {
 	fields: [ 'plural_name', 'singular_name', 'slug' ],
 };
 
-function buildCopySlug( slug: string ): string {
+function buildCopySlug( slug: string, takenSlugs: Set< string > ): string {
 	const match = slug.match( /^(.*?)(\d+)$/ );
 	const base = match ? match[ 1 ] : slug;
-	const nextNumber = String( match ? parseInt( match[ 2 ], 10 ) + 1 : 2 );
-	return `${ base.slice(
-		0,
-		SLUG_MAX_LENGTH - nextNumber.length
-	) }${ nextNumber }`;
+	let num = match ? parseInt( match[ 2 ], 10 ) + 1 : 2;
+	let candidate: string;
+	do {
+		const nextNumber = String( num );
+		candidate = `${ base.slice(
+			0,
+			SLUG_MAX_LENGTH - nextNumber.length
+		) }${ nextNumber }`;
+		num++;
+	} while ( takenSlugs.has( candidate ) );
+	return candidate;
 }
 
 function DuplicateTaxonomyModal( {
@@ -54,6 +60,19 @@ function DuplicateTaxonomyModal( {
 	onActionPerformed?: ( items: TaxonomyFormData[] ) => void;
 } ) {
 	const source = items[ 0 ];
+	const takenSlugs = useSelect( ( select ) => {
+		const taxonomies = select( coreStore ).getTaxonomies() ?? [];
+		const drafts =
+			select( coreStore ).getEntityRecords( 'postType', TAXONOMY_ENTITY, {
+				status: 'draft',
+				per_page: -1,
+				_fields: 'id,slug',
+			} ) ?? [];
+		return new Set< string >( [
+			...taxonomies.map( ( t: any ) => t.slug ),
+			...drafts.map( ( d: any ) => d.slug ),
+		] );
+	}, [] );
 	const [ data, setData ] = useState< TaxonomyFormData >( () => ( {
 		...source,
 		id: undefined,
@@ -65,7 +84,7 @@ function DuplicateTaxonomyModal( {
 				source.title.raw
 			),
 		},
-		slug: buildCopySlug( source.slug ),
+		slug: buildCopySlug( source.slug, takenSlugs ),
 	} ) );
 	const [ isDuplicating, setIsDuplicating ] = useState( false );
 	const slugField = useSlugField( undefined, data.slug );

--- a/packages/content-types/src/taxonomies/actions/duplicate.tsx
+++ b/packages/content-types/src/taxonomies/actions/duplicate.tsx
@@ -3,6 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
+import type { Taxonomy } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	DataForm,
@@ -11,7 +12,7 @@ import {
 	type Field,
 	type Form,
 } from '@wordpress/dataviews';
-import { useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { copy } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
@@ -61,16 +62,22 @@ function DuplicateTaxonomyModal( {
 } ) {
 	const source = items[ 0 ];
 	const takenSlugs = useSelect( ( select ) => {
-		const taxonomies = select( coreStore ).getTaxonomies() ?? [];
-		const drafts =
-			select( coreStore ).getEntityRecords( 'postType', TAXONOMY_ENTITY, {
+		const taxonomies: Taxonomy[] =
+			select( coreStore ).getTaxonomies() ?? [];
+
+		const drafts = ( select( coreStore ).getEntityRecords(
+			'postType',
+			TAXONOMY_ENTITY,
+			{
 				status: 'draft',
 				per_page: -1,
 				_fields: 'id,slug',
-			} ) ?? [];
+			}
+		) ?? [] ) as Array< { slug: string } >;
+
 		return new Set< string >( [
-			...taxonomies.map( ( t: any ) => t.slug ),
-			...drafts.map( ( d: any ) => d.slug ),
+			...taxonomies.map( ( t ) => t.slug ),
+			...drafts.map( ( d ) => d.slug ),
 		] );
 	}, [] );
 	const [ data, setData ] = useState< TaxonomyFormData >( () => ( {
@@ -86,6 +93,18 @@ function DuplicateTaxonomyModal( {
 		},
 		slug: buildCopySlug( source.slug, takenSlugs ),
 	} ) );
+	// Track whether the user has manually edited the slug so we don't
+	// overwrite their input when takenSlugs resolves asynchronously.
+	const isSlugEditedRef = useRef( false );
+
+	useEffect( () => {
+		if ( ! isSlugEditedRef.current ) {
+			setData( ( prev ) => ( {
+				...prev,
+				slug: buildCopySlug( source.slug, takenSlugs ),
+			} ) );
+		}
+	}, [ source.slug, takenSlugs ] );
 	const [ isDuplicating, setIsDuplicating ] = useState( false );
 	const slugField = useSlugField( undefined, data.slug );
 
@@ -150,12 +169,15 @@ function DuplicateTaxonomyModal( {
 				fields={ fields }
 				form={ duplicateForm }
 				validity={ validity }
-				onChange={ ( edits ) =>
+				onChange={ ( edits ) => {
+					if ( 'slug' in edits ) {
+						isSlugEditedRef.current = true;
+					}
 					setData(
 						( prev ) =>
 							( { ...prev, ...edits } ) as TaxonomyFormData
-					)
-				}
+					);
+				} }
 			/>
 			<Stack direction="row" justify="flex-end" gap="sm">
 				<Button


### PR DESCRIPTION
## What?
Follow up to #77600

```
When duplicating a post type or taxonomy, we should ensure the generated slug is not taken.

Check https://github.com/WordPress/gutenberg/pull/77938#discussion_r3188159387on auto-fill
```

Ensures the generated slug when duplicating a post type or taxonomy is not already taken.

## Why?
`buildCopySlug` incremented the trailing number once without checking availability, so duplicating the same item twice pre-filled the same slug both times.

## How?
`buildCopySlug` now loops, incrementing the trailing number, until finding a free candidate. Each modal builds a `takenSlugs` set from both active registered types and draft records (since duplicates are stored as drafts).

## Testing Instructions
1. Enable the **Content Types** experiment (Gutenberg → Experiments).
2. Go to **Settings → Post Types** (or **Taxonomies**).
3. Duplicate a post type, confirm slug pre-fills as `test2`.
4. Duplicate it again, confirm slug is now `test3`, not `test2`.

### Testing Instructions for Keyboard
Tab to a row's actions menu → **Duplicate** → confirm slug field is pre-filled with a free slug → submit with Enter.