### PR TITLE
Tests: Preload spec — track query strings and use an existing draft

### DIFF
--- a/test/e2e/specs/editor/various/preload.spec.js
+++ b/test/e2e/specs/editor/various/preload.spec.js
@@ -3,40 +3,56 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+function recordRequests( page ) {
+	const requests = [];
+	function onRequest( request ) {
+		if ( request.resourceType() !== 'fetch' ) {
+			return;
+		}
+		const urlObject = new URL( request.url() );
+		const restRoute =
+			urlObject.searchParams.get( 'rest_route' ) ??
+			urlObject.pathname.replace( /^\/wp-json/, '' );
+		// `_locale` is added uniformly to every apiFetch call and
+		// carries no signal here.
+		urlObject.searchParams.delete( '_locale' );
+		const query = urlObject.searchParams.toString();
+		requests.push(
+			`${ request.method() } ${ restRoute }${
+				query ? `?${ query }` : ''
+			}`
+		);
+	}
+
+	page.on( 'request', onRequest );
+	return {
+		requests,
+		stop: () => page.off( 'request', onRequest ),
+	};
+}
+
 test.describe( 'Preload', () => {
+	let postId;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		const post = await requestUtils.createPost( {
+			content:
+				'<!-- wp:heading -->\n<h2 class="wp-block-heading">Hello</h2>\n<!-- /wp:heading -->',
+			status: 'draft',
+		} );
+		postId = post.id;
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
 	test( 'Should fetch a known set of routes during startup', async ( {
 		page,
 		admin,
 		editor,
-		requestUtils,
 	} ) => {
-		const { id: postId } = await requestUtils.createPost( {
-			content: '<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->',
-			status: 'draft',
-		} );
-
-		const requests = [];
-
-		function onRequest( request ) {
-			if ( request.resourceType() !== 'fetch' ) {
-				return;
-			}
-			const urlObject = new URL( request.url() );
-			const restRoute =
-				urlObject.searchParams.get( 'rest_route' ) ??
-				urlObject.pathname.replace( /^\/wp-json/, '' );
-			// `_locale` is added uniformly to every apiFetch call and
-			// carries no signal here.
-			urlObject.searchParams.delete( '_locale' );
-			const query = urlObject.searchParams.toString();
-			requests.push(
-				`${ request.method() } ${ restRoute }${
-					query ? `?${ query }` : ''
-				}`
-			);
-		}
-
-		page.on( 'request', onRequest );
+		const { requests, stop } = recordRequests( page );
 
 		await admin.editPost( postId );
 		// Ensure the document sidebar is open — its default state isn't
@@ -46,8 +62,8 @@ test.describe( 'Preload', () => {
 		await editor.openDocumentSettingsSidebar();
 		await page
 			.frameLocator( 'iframe[name="editor-canvas"]' )
-			.locator( '[data-block]' )
-			.first()
+			.getByRole( 'document', { name: 'Block: Heading' } )
+			.filter( { hasText: 'Hello' } )
 			.waitFor();
 		// This spec is explicitly testing network behaviour, so waiting for
 		// the network to settle (rather than a UI marker) is the right
@@ -55,11 +71,11 @@ test.describe( 'Preload', () => {
 		// resolver duplicates have all been observed before we assert.
 		// eslint-disable-next-line playwright/no-networkidle
 		await page.waitForLoadState( 'networkidle' );
-		page.off( 'request', onRequest );
+		stop();
 
-		// Some routes may be requested more than once across the captured
-		// window because of resolver races; the duplicate counts are not
-		// stable across runs, so this assertion deduplicates.
+		// `POST /wp/v2/users/me` (preferences persistence) occasionally
+		// fires twice within the captured window; the duplicate count
+		// isn't stable across runs, so this assertion deduplicates.
 		// To do: these should all be removed or preloaded.
 		expect( Array.from( new Set( requests ) ).sort() ).toEqual(
 			[

--- a/test/e2e/specs/editor/various/preload.spec.js
+++ b/test/e2e/specs/editor/various/preload.spec.js
@@ -8,7 +8,13 @@ test.describe( 'Preload', () => {
 		page,
 		admin,
 		editor,
+		requestUtils,
 	} ) => {
+		const { id: postId } = await requestUtils.createPost( {
+			content: '<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->',
+			status: 'draft',
+		} );
+
 		const requests = [];
 
 		function onRequest( request ) {
@@ -19,14 +25,20 @@ test.describe( 'Preload', () => {
 			const restRoute =
 				urlObject.searchParams.get( 'rest_route' ) ??
 				urlObject.pathname.replace( /^\/wp-json/, '' );
-			requests.push( `${ request.method() } ${ restRoute }` );
+			// `_locale` is added uniformly to every apiFetch call and
+			// carries no signal here.
+			urlObject.searchParams.delete( '_locale' );
+			const query = urlObject.searchParams.toString();
+			requests.push(
+				`${ request.method() } ${ restRoute }${
+					query ? `?${ query }` : ''
+				}`
+			);
 		}
 
 		page.on( 'request', onRequest );
 
-		await admin.createNewPost( {
-			content: '<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->',
-		} );
+		await admin.editPost( postId );
 		// Ensure the document sidebar is open — its default state isn't
 		// stable across environments (CI vs. local). Several of the routes
 		// asserted below are fired by panels inside the sidebar (post
@@ -45,20 +57,21 @@ test.describe( 'Preload', () => {
 		await page.waitForLoadState( 'networkidle' );
 		page.off( 'request', onRequest );
 
-		// Some routes are requested more than once across the captured
-		// window because of resolver races (e.g. `GET /wp/v2/templates/lookup`,
-		// `POST /wp/v2/users/me`); the duplicate counts are not stable
-		// across runs, so this assertion deduplicates.
+		// Some routes may be requested more than once across the captured
+		// window because of resolver races; the duplicate counts are not
+		// stable across runs, so this assertion deduplicates.
 		// To do: these should all be removed or preloaded.
 		expect( Array.from( new Set( requests ) ).sort() ).toEqual(
 			[
-				'GET /wp/v2/comments',
-				'GET /wp/v2/taxonomies',
-				'GET /wp/v2/templates/lookup',
-				'GET /wp/v2/users/1',
-				'GET /wp/v2/wp_pattern_category',
+				`GET /wp/v2/comments?context=edit&post=${ postId }&type=note&status=all&per_page=100`,
+				'GET /wp/v2/taxonomies?context=edit&per_page=100',
+				'GET /wp/v2/taxonomies?context=view',
+				'GET /wp/v2/templates/lookup?slug=single-post',
+				'GET /wp/v2/users/1?context=view&_fields=id%2Cname',
+				'GET /wp/v2/wp_pattern_category?context=view&per_page=100&_fields=id%2Cname%2Cdescription%2Cslug',
 				'OPTIONS /wp/v2/posts',
 				'OPTIONS /wp/v2/settings',
+				`POST /wp/v2/posts/${ postId }`,
 				'POST /wp-sync/v1/updates',
 				'POST /wp/v2/users/me',
 			].sort()

--- a/test/e2e/specs/preload/post-editor.spec.js
+++ b/test/e2e/specs/preload/post-editor.spec.js
@@ -59,7 +59,7 @@ test.describe( 'Preload', () => {
 				`GET /wp/v2/comments?context=edit&post=${ postId }&type=note&status=all&per_page=100`,
 				'GET /wp/v2/taxonomies?context=edit&per_page=100',
 				'GET /wp/v2/taxonomies?context=view',
-				'GET /wp/v2/templates/lookup?slug=single-post',
+				'GET /wp/v2/templates/lookup?slug=front-page',
 				'GET /wp/v2/users/1?context=view&_fields=id%2Cname',
 				'GET /wp/v2/wp_pattern_category?context=view&per_page=100&_fields=id%2Cname%2Cdescription%2Cslug',
 				'OPTIONS /wp/v2/posts',

--- a/test/e2e/specs/preload/post-editor.spec.js
+++ b/test/e2e/specs/preload/post-editor.spec.js
@@ -3,33 +3,10 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-function recordRequests( page ) {
-	const requests = [];
-	function onRequest( request ) {
-		if ( request.resourceType() !== 'fetch' ) {
-			return;
-		}
-		const urlObject = new URL( request.url() );
-		const restRoute =
-			urlObject.searchParams.get( 'rest_route' ) ??
-			urlObject.pathname.replace( /^\/wp-json/, '' );
-		// `_locale` is added uniformly to every apiFetch call and
-		// carries no signal here.
-		urlObject.searchParams.delete( '_locale' );
-		const query = urlObject.searchParams.toString();
-		requests.push(
-			`${ request.method() } ${ restRoute }${
-				query ? `?${ query }` : ''
-			}`
-		);
-	}
-
-	page.on( 'request', onRequest );
-	return {
-		requests,
-		stop: () => page.off( 'request', onRequest ),
-	};
-}
+/**
+ * Internal dependencies
+ */
+const { recordRequests } = require( './record-requests' );
 
 test.describe( 'Preload', () => {
 	let postId;

--- a/test/e2e/specs/preload/record-requests.js
+++ b/test/e2e/specs/preload/record-requests.js
@@ -1,0 +1,42 @@
+/**
+ * Subscribes to all `fetch` requests made from `page` and returns
+ * normalised `${ method } ${ path }${ query }` strings.
+ *
+ * Path captures the REST route, stripping the `/wp-json` prefix (or
+ * reading the `rest_route` query arg when the site is on plain
+ * permalinks). The `_locale` query arg is removed because it's added
+ * uniformly to every `apiFetch` call and carries no signal.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @return {{ requests: string[], stop: () => void }} Live array of captured
+ *         request strings, and a function to detach the listener.
+ */
+function recordRequests( page ) {
+	const requests = [];
+
+	function onRequest( request ) {
+		if ( request.resourceType() !== 'fetch' ) {
+			return;
+		}
+		const urlObject = new URL( request.url() );
+		const restRoute =
+			urlObject.searchParams.get( 'rest_route' ) ??
+			urlObject.pathname.replace( /^\/wp-json/, '' );
+		urlObject.searchParams.delete( '_locale' );
+		const query = urlObject.searchParams.toString();
+		requests.push(
+			`${ request.method() } ${ restRoute }${
+				query ? `?${ query }` : ''
+			}`
+		);
+	}
+
+	page.on( 'request', onRequest );
+
+	return {
+		requests,
+		stop: () => page.off( 'request', onRequest ),
+	};
+}
+
+module.exports = { recordRequests };

--- a/test/e2e/specs/preload/site-editor.spec.js
+++ b/test/e2e/specs/preload/site-editor.spec.js
@@ -3,33 +3,10 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-function recordRequests( page ) {
-	const requests = [];
-	function onRequest( request ) {
-		if ( request.resourceType() !== 'fetch' ) {
-			return;
-		}
-		const urlObject = new URL( request.url() );
-		const restRoute =
-			urlObject.searchParams.get( 'rest_route' ) ??
-			urlObject.pathname.replace( /^\/wp-json/, '' );
-		// `_locale` is added uniformly to every apiFetch call and
-		// carries no signal here.
-		urlObject.searchParams.delete( '_locale' );
-		const query = urlObject.searchParams.toString();
-		requests.push(
-			`${ request.method() } ${ restRoute }${
-				query ? `?${ query }` : ''
-			}`
-		);
-	}
-
-	page.on( 'request', onRequest );
-	return {
-		requests,
-		stop: () => page.off( 'request', onRequest ),
-	};
-}
+/**
+ * Internal dependencies
+ */
+const { recordRequests } = require( './record-requests' );
 
 test.describe( 'Preload', () => {
 	let pageId;

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -3,47 +3,124 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+function recordRequests( page ) {
+	const requests = [];
+	function onRequest( request ) {
+		if ( request.resourceType() !== 'fetch' ) {
+			return;
+		}
+		const urlObject = new URL( request.url() );
+		const restRoute =
+			urlObject.searchParams.get( 'rest_route' ) ??
+			urlObject.pathname.replace( /^\/wp-json/, '' );
+		// `_locale` is added uniformly to every apiFetch call and
+		// carries no signal here.
+		urlObject.searchParams.delete( '_locale' );
+		const query = urlObject.searchParams.toString();
+		requests.push(
+			`${ request.method() } ${ restRoute }${
+				query ? `?${ query }` : ''
+			}`
+		);
+	}
+
+	page.on( 'request', onRequest );
+	return {
+		requests,
+		stop: () => page.off( 'request', onRequest ),
+	};
+}
+
 test.describe( 'Preload', () => {
+	let pageId;
+
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.resetPreferences();
+		const pg = await requestUtils.createPage( {
+			content:
+				'<!-- wp:heading -->\n<h2 class="wp-block-heading">Hello</h2>\n<!-- /wp:heading -->',
+			status: 'publish',
+		} );
+		pageId = pg.id;
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPages();
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	test( 'Should make no requests before the iframe is loaded', async ( {
+	test( 'Site editor root should fetch a known set of routes during startup', async ( {
 		page,
 		admin,
 	} ) => {
-		const requests = [];
-
-		function onRequest( request ) {
-			if (
-				request.resourceType() === 'document' &&
-				request.url().startsWith( 'blob:' )
-			) {
-				// Stop recording when the iframe is initialized.
-				page.off( 'request', onRequest );
-			} else if ( request.resourceType() === 'fetch' ) {
-				const urlObject = new URL( request.url() );
-				const restRoute =
-					urlObject.searchParams.get( 'rest_route' ) ??
-					urlObject.pathname.replace( /^\/wp-json/, '' );
-				requests.push( restRoute );
-			}
-		}
-
-		page.on( 'request', onRequest );
+		const { requests, stop } = recordRequests( page );
 
 		await admin.visitSiteEditor();
+		await page
+			.frameLocator( 'iframe[name="editor-canvas"]' )
+			.locator( '[data-block]' )
+			.first()
+			.waitFor();
+		// eslint-disable-next-line playwright/no-networkidle
+		await page.waitForLoadState( 'networkidle' );
+		stop();
 
+		// `POST /wp/v2/users/me` (preferences persistence) occasionally
+		// fires twice within the captured window; the duplicate count
+		// isn't stable across runs, so this assertion deduplicates.
 		// To do: these should all be removed or preloaded.
-		expect( requests ).toEqual( [
-			// Seems to be coming from `enableComplementaryArea`.
-			'/wp/v2/users/me',
-			'/wp/v2/settings',
-		] );
+		expect( Array.from( new Set( requests ) ).sort() ).toEqual(
+			[
+				'GET /wp/v2/posts?context=edit&offset=0&order=desc&orderby=date&per_page=10&ignore_sticky=false',
+				'GET /wp/v2/taxonomies?context=view',
+				'GET /wp/v2/template-parts/emptytheme//header?context=edit',
+				'GET /wp/v2/wp_pattern_category?context=view&per_page=100&_fields=id%2Cname%2Cdescription%2Cslug',
+				'OPTIONS /wp/v2/settings',
+				'POST /wp/v2/users/me',
+			].sort()
+		);
+	} );
+
+	test( 'Editing a page should fetch a known set of routes during startup', async ( {
+		page,
+		admin,
+	} ) => {
+		const { requests, stop } = recordRequests( page );
+
+		await admin.visitAdminPage(
+			'site-editor.php',
+			`p=%2Fpage&postId=${ pageId }&canvas=edit`
+		);
+		await page
+			.frameLocator( 'iframe[name="editor-canvas"]' )
+			.getByRole( 'document', { name: 'Block: Heading' } )
+			.filter( { hasText: 'Hello' } )
+			.waitFor();
+		// eslint-disable-next-line playwright/no-networkidle
+		await page.waitForLoadState( 'networkidle' );
+		stop();
+
+		// `POST /wp/v2/users/me` (preferences persistence) occasionally
+		// fires twice within the captured window; the duplicate count
+		// isn't stable across runs, so this assertion deduplicates.
+		// To do: these should all be removed or preloaded.
+		expect( Array.from( new Set( requests ) ).sort() ).toEqual(
+			[
+				`GET /wp/v2/comments?context=edit&post=${ pageId }&type=note&status=all&per_page=100`,
+				`GET /wp/v2/pages/${ pageId }/autosaves?context=edit`,
+				'GET /wp/v2/taxonomies?context=edit&per_page=100',
+				'GET /wp/v2/taxonomies?context=view',
+				'GET /wp/v2/templates/lookup?slug=front-page',
+				'GET /wp/v2/types/page?context=edit',
+				'GET /wp/v2/users/1?context=view&_fields=id%2Cname',
+				'GET /wp/v2/users/me',
+				'GET /wp/v2/view-config?kind=postType&name=page',
+				'GET /wp/v2/wp_pattern_category?context=view&per_page=100&_fields=id%2Cname%2Cdescription%2Cslug',
+				'OPTIONS /wp/v2/settings',
+				'OPTIONS /wp/v2/templates',
+				'POST /wp/v2/users/me',
+			].sort()
+		);
 	} );
 } );


### PR DESCRIPTION
Best reviewed [without whitespace](https://github.com/WordPress/gutenberg/pull/78343/changes?w=1).

## What, Why & How

1. **Track query strings** when capturing REST routes, so e.g. `templates/lookup?slug=front-page` is no longer collapsed with `templates/lookup?slug=single-post`. `_locale` is stripped (added uniformly, no signal).

2. **Use `requestUtils.createPost` + `admin.editPost` in the post-editor spec.** Gives us the post ID up front so it can be interpolated into expected URLs directly. Adds one expected entry — `POST /wp/v2/posts/{id}` — the initial autosave the editor fires when opening the draft.

3. **Group both preload specs under `test/e2e/specs/preload/`** and extract the shared `recordRequests` helper into a sibling module.

4. **Restructure the site-editor "root" test** to use the same wait-for-block + assert-full-captured-set pattern as the new tests, and add an "Editing a page" test that opens a REST-created page through `?p=/page&postId=…&canvas=edit`.

## Testing Instructions

1. `npm run test:e2e -- test/e2e/specs/preload/` — both spec files pass.
2. The expected lists now contain full URLs — visually verify the values match each editor's startup behaviour.

## Use of AI Tools

Authored by Claude (Opus 4.7) in collaboration with @ellatrix.
