### PR TITLE
Dashboard: adds tooltip explaining disabled menu item

### DIFF
--- a/routes/dashboard/widget-dashboard/components/actions/actions.tsx
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.tsx
@@ -109,6 +109,7 @@ export function Actions(): React.ReactNode {
 			label: __( 'Layout settings' ),
 			onClick: openLayoutSettings,
 			disabled: editMode,
+			disabledTooltip: __( 'Disabled while editing widgets' ),
 		} );
 	}
 

--- a/routes/dashboard/widget-dashboard/components/more-actions-dropdown/more-actions-dropdown.tsx
+++ b/routes/dashboard/widget-dashboard/components/more-actions-dropdown/more-actions-dropdown.tsx
@@ -5,7 +5,7 @@ import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 // eslint-disable-next-line @wordpress/use-recommended-components
-import { Button, IconButton } from '@wordpress/ui';
+import { Button, IconButton, Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -18,10 +18,52 @@ export interface MoreActionsDropdownItem {
 	label: string;
 	onClick: () => void;
 	disabled?: boolean;
+	/**
+	 * Shown on hover when the item is disabled (for example, to explain
+	 * why the action is unavailable).
+	 */
+	disabledTooltip?: string;
 }
 
 interface MoreActionsDropdownProps {
 	items: MoreActionsDropdownItem[];
+}
+
+function MoreActionsMenuItem( { item }: { item: MoreActionsDropdownItem } ) {
+	const showDisabledTooltip = item.disabled && item.disabledTooltip;
+
+	const menuItem = (
+		<Menu.Item
+			disabled={ item.disabled }
+			onClick={ item.onClick }
+			render={ <Button variant="minimal" tone="neutral" /> }
+		>
+			{ item.label }
+		</Menu.Item>
+	);
+
+	if ( ! showDisabledTooltip ) {
+		return menuItem;
+	}
+
+	return (
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				render={
+					<Menu.Item
+						disabled={ item.disabled }
+						onClick={ item.onClick }
+						render={ <Button variant="minimal" tone="neutral" /> }
+					/>
+				}
+			>
+				{ item.label }
+			</Tooltip.Trigger>
+			<Tooltip.Popup positioner={ <Tooltip.Positioner side="bottom" /> }>
+				{ item.disabledTooltip }
+			</Tooltip.Popup>
+		</Tooltip.Root>
+	);
 }
 
 /**
@@ -62,20 +104,13 @@ export function MoreActionsDropdown( {
 				}
 			/>
 			<Menu.Popover>
-				<Menu.Group>
-					{ items.map( ( item, index ) => (
-						<Menu.Item
-							key={ index }
-							disabled={ item.disabled }
-							onClick={ item.onClick }
-							render={
-								<Button variant="minimal" tone="neutral" />
-							}
-						>
-							{ item.label }
-						</Menu.Item>
-					) ) }
-				</Menu.Group>
+				<Tooltip.Provider delay={ 0 }>
+					<Menu.Group>
+						{ items.map( ( item, index ) => (
+							<MoreActionsMenuItem key={ index } item={ item } />
+						) ) }
+					</Menu.Group>
+				</Tooltip.Provider>
 			</Menu.Popover>
 		</Menu>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow-up to https://github.com/WordPress/gutenberg/pull/78202

Adds a tooltip explaining why "layout settings" menu item might be disabled.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It was unclear to user why menu item was disabled otherwise.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

#### Before
<img width="360" height="152" alt="Screenshot 2026-05-15 at 15 24 55" src="https://github.com/user-attachments/assets/77da6987-90df-4510-8309-8265e99cf520" />

#### After
<img width="384" height="256" alt="image" src="https://github.com/user-attachments/assets/e05d7bba-be51-403e-bf40-7b93620c7b38" />

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
