### PR TITLE
Navigation: Surface blocks and variations in Link UI search results

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -8,7 +8,7 @@ import {
 	VisuallyHidden,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	LinkControl,
 	useBlockEditingMode,
@@ -76,6 +76,11 @@ export function getSuggestionsQuery( type, kind ) {
 			};
 	}
 }
+
+const EXCLUDED = new Set( [
+	'core/navigation-link',
+	'core/navigation-submenu',
+] );
 
 function UnforwardedLinkUI( props, ref ) {
 	const { label, url, opensInNewTab, type, kind, id } = props.link;
@@ -184,51 +189,45 @@ function UnforwardedLinkUI( props, ref ) {
 	}, [ shouldFocusPane ] );
 
 	const blockEditingMode = useBlockEditingMode();
-	const EXCLUDED = new Set( [
-		'core/navigation-link',
-		'core/navigation-submenu',
-	] );
-	const { rootClientId, insertableNavigationBlocks, insertionIndex } =
+	const { rootClientId, insertionIndex, allBlockTypes, canInsertBlockType } =
 		useSelect(
 			( select ) => {
 				const {
 					getBlockRootClientId,
-					canInsertBlockType,
 					getBlockIndex,
+					canInsertBlockType: _canInsert,
 				} = select( blockEditorStore );
 				const root = getBlockRootClientId( props.clientId );
 
-				const index = getBlockIndex( props.clientId );
-				// Get every registered block type that can live inside this navigation.
-				// Exclude navigation-link and navigation-submenu — those are already
-				// handled by LinkControl's own search suggestions.
-				const insertable = root
-					? select( blocksStore )
-							.getBlockTypes()
-							.filter(
-								( blockType ) =>
-									! EXCLUDED.has( blockType.name ) &&
-									canInsertBlockType( blockType.name, root )
-							)
-					: [];
-
 				return {
 					rootClientId: root,
-					insertableNavigationBlocks: insertable,
-					insertionIndex: index + 1,
+					insertionIndex: getBlockIndex( props.clientId ) + 1,
+					allBlockTypes: root
+						? select( blocksStore ).getBlockTypes()
+						: [],
+					canInsertBlockType: _canInsert,
 				};
 			},
 			[ props.clientId ]
 		);
 
-	// Filter insertable blocks by the live search input.
+	// Filter insertable blocks by both capabilities AND the live search input in one pass.
 	// Empty query > no results (avoids flooding the UI before the user types).
 	const matchingBlocks = useMemo( () => {
 		const query = searchInputValue.trim().toLowerCase();
-		if ( ! query ) {
+
+		if ( ! query || ! rootClientId ) {
 			return [];
 		}
-		return insertableNavigationBlocks.filter( ( blockType ) => {
+
+		return allBlockTypes.filter( ( blockType ) => {
+			if ( EXCLUDED.has( blockType.name ) ) {
+				return false;
+			}
+			if ( ! canInsertBlockType( blockType.name, rootClientId ) ) {
+				return false;
+			}
+
 			const title = blockType.title.toLowerCase();
 			const keywords = ( blockType.keywords ?? [] ).map( ( k ) =>
 				k.toLowerCase()
@@ -238,7 +237,7 @@ function UnforwardedLinkUI( props, ref ) {
 				keywords.some( ( kw ) => kw.includes( query ) )
 			);
 		} );
-	}, [ searchInputValue, insertableNavigationBlocks ] );
+	}, [ searchInputValue, allBlockTypes, canInsertBlockType, rootClientId ] );
 
 	const { insertBlock } = useDispatch( blockEditorStore );
 
@@ -396,9 +395,12 @@ const LinkUITools = ( {
 							e.preventDefault();
 							onInsertBlock( blockType );
 						} }
-						aria-haspopup={ blockInserterAriaRole }
 					>
-						{ __( 'Add' ) } { blockType.title } { __( 'Block' ) }
+						{ sprintf(
+							/* translators: %s: Block title (e.g., "Site Logo") */
+							__( 'Add %s Block' ),
+							blockType.title
+						) }
 					</Button>
 				) ) }
 			{ canAddPage && (

--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -184,34 +184,42 @@ function UnforwardedLinkUI( props, ref ) {
 	}, [ shouldFocusPane ] );
 
 	const blockEditingMode = useBlockEditingMode();
-	const { rootClientId, insertableNavigationBlocks } = useSelect(
-		( select ) => {
-			const { getBlockRootClientId, canInsertBlockType } =
-				select( blockEditorStore );
-			const root = getBlockRootClientId( props.clientId );
+	const EXCLUDED = new Set( [
+		'core/navigation-link',
+		'core/navigation-submenu',
+	] );
+	const { rootClientId, insertableNavigationBlocks, insertionIndex } =
+		useSelect(
+			( select ) => {
+				const {
+					getBlockRootClientId,
+					canInsertBlockType,
+					getBlockIndex,
+				} = select( blockEditorStore );
+				const root = getBlockRootClientId( props.clientId );
 
-			// Get every registered block type that can live inside this navigation.
-			// Exclude navigation-link and navigation-submenu — those are already
-			// handled by LinkControl's own search suggestions.
-			const EXCLUDED = new Set( [
-				'core/navigation-link',
-				'core/navigation-submenu',
-			] );
-			const insertable = select( blocksStore )
-				.getBlockTypes()
-				.filter(
-					( blockType ) =>
-						! EXCLUDED.has( blockType.name ) &&
-						canInsertBlockType( blockType.name, root )
-				);
+				const index = getBlockIndex( props.clientId );
+				// Get every registered block type that can live inside this navigation.
+				// Exclude navigation-link and navigation-submenu — those are already
+				// handled by LinkControl's own search suggestions.
+				const insertable = root
+					? select( blocksStore )
+							.getBlockTypes()
+							.filter(
+								( blockType ) =>
+									! EXCLUDED.has( blockType.name ) &&
+									canInsertBlockType( blockType.name, root )
+							)
+					: [];
 
-			return {
-				rootClientId: root,
-				insertableNavigationBlocks: insertable,
-			};
-		},
-		[ props.clientId ]
-	);
+				return {
+					rootClientId: root,
+					insertableNavigationBlocks: insertable,
+					insertionIndex: index + 1,
+				};
+			},
+			[ props.clientId ]
+		);
 
 	// Filter insertable blocks by the live search input.
 	// Empty query > no results (avoids flooding the UI before the user types).
@@ -309,7 +317,7 @@ function UnforwardedLinkUI( props, ref ) {
 										);
 										insertBlock(
 											newBlock,
-											undefined,
+											insertionIndex,
 											rootClientId
 										);
 										if ( props.onBlockInsert ) {
@@ -378,19 +386,21 @@ const LinkUITools = ( {
 
 	return (
 		<VStack spacing={ 0 } className="link-ui-tools">
-			{ matchingBlocks.map( ( blockType ) => (
-				<Button
-					__next40pxDefaultSize
-					key={ blockType.name }
-					icon={ <BlockIcon icon={ blockType.icon } /> }
-					onClick={ ( e ) => {
-						e.preventDefault();
-						onInsertBlock( blockType );
-					} }
-				>
-					{ __( 'Add' ) } { blockType.title } { __( 'Block' ) }
-				</Button>
-			) ) }
+			{ canAddBlock &&
+				matchingBlocks.map( ( blockType ) => (
+					<Button
+						__next40pxDefaultSize
+						key={ blockType.name }
+						icon={ <BlockIcon icon={ blockType.icon } /> }
+						onClick={ ( e ) => {
+							e.preventDefault();
+							onInsertBlock( blockType );
+						} }
+						aria-haspopup={ blockInserterAriaRole }
+					>
+						{ __( 'Add' ) } { blockType.title } { __( 'Block' ) }
+					</Button>
+				) ) }
 			{ canAddPage && (
 				<Button
 					__next40pxDefaultSize

--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -82,8 +82,23 @@ const EXCLUDED = new Set( [
 	'core/navigation-submenu',
 ] );
 
+function getVariationBadgeLabel( variation ) {
+	if ( variation.attributes?.kind === 'post-type' ) {
+		/* translators: %s: Post type name (e.g. "Post", "Page", "CPT", "Taxonomy"). */
+		return sprintf( __( '%s link' ), variation.attributes?.type );
+	}
+	if ( variation.attributes?.kind === 'taxonomy' ) {
+		return __( 'taxonomy' );
+	}
+	return __( 'Link' );
+}
+const matchesQuery = ( query, title = '', keywords = [] ) =>
+	title.toLowerCase().includes( query ) ||
+	keywords.some( ( kw ) => kw.toLowerCase().includes( query ) );
+
 function UnforwardedLinkUI( props, ref ) {
 	const { label, url, opensInNewTab, type, kind, id } = props.link;
+	const { onBlockInsert, onClose } = props;
 
 	const { entityRecord, hasBinding, isEntityAvailable } = props.entity || {};
 
@@ -189,57 +204,106 @@ function UnforwardedLinkUI( props, ref ) {
 	}, [ shouldFocusPane ] );
 
 	const blockEditingMode = useBlockEditingMode();
-	const { rootClientId, insertionIndex, allBlockTypes, canInsertBlockType } =
-		useSelect(
-			( select ) => {
-				const {
-					getBlockRootClientId,
-					getBlockIndex,
-					canInsertBlockType: _canInsert,
-				} = select( blockEditorStore );
-				const root = getBlockRootClientId( props.clientId );
+	const {
+		rootClientId,
+		insertionIndex,
+		allBlockTypes,
+		canInsertBlockType,
+		navigationLinkVariations,
+	} = useSelect(
+		( select ) => {
+			const {
+				getBlockRootClientId,
+				getBlockIndex,
+				canInsertBlockType: _canInsert,
+			} = select( blockEditorStore );
+			const { getBlockVariations } = select( blocksStore );
+			const root = getBlockRootClientId( props.clientId );
 
-				return {
-					rootClientId: root,
-					insertionIndex: getBlockIndex( props.clientId ) + 1,
-					allBlockTypes: root
-						? select( blocksStore ).getBlockTypes()
-						: [],
-					canInsertBlockType: _canInsert,
-				};
-			},
-			[ props.clientId ]
-		);
+			return {
+				rootClientId: root,
+				insertionIndex: getBlockIndex( props.clientId ) + 1,
+				allBlockTypes: root
+					? select( blocksStore ).getBlockTypes()
+					: [],
+				canInsertBlockType: _canInsert,
+				navigationLinkVariations: root
+					? getBlockVariations( 'core/navigation-link', 'inserter' )
+					: [],
+			};
+		},
+		[ props.clientId ]
+	);
+
+	const { insertBlock } = useDispatch( blockEditorStore );
 
 	// Filter insertable blocks by both capabilities AND the live search input in one pass.
 	// Empty query > no results (avoids flooding the UI before the user types).
-	const matchingBlocks = useMemo( () => {
+	const matchingItems = useMemo( () => {
 		const query = searchInputValue.trim().toLowerCase();
 
-		if ( ! query || ! rootClientId ) {
+		if ( ! query || ! rootClientId || ( type && url ) ) {
 			return [];
 		}
 
-		return allBlockTypes.filter( ( blockType ) => {
-			if ( EXCLUDED.has( blockType.name ) ) {
-				return false;
-			}
-			if ( ! canInsertBlockType( blockType.name, rootClientId ) ) {
-				return false;
-			}
+		const variations = ( navigationLinkVariations ?? [] )
+			.filter(
+				( v ) =>
+					( v.title ?? '' ).toLowerCase() !== 'page link' &&
+					matchesQuery( query, v.title, v.keywords )
+			)
+			.map( ( v ) => ( {
+				key: `${ v.name }-${ v.title }`,
+				icon: v.icon ?? 'admin-links',
+				/* translators: %s: Variation title (e.g., "Category", "Posts") */
+				label: sprintf( __( 'Add %s' ), v.title ),
+				badge: getVariationBadgeLabel( v ),
+				onInsert() {
+					const block = createBlock(
+						'core/navigation-link',
+						v.attributes ?? {}
+					);
+					insertBlock( block, insertionIndex, rootClientId );
+					onBlockInsert?.( block );
+					onClose?.();
+				},
+			} ) );
 
-			const title = blockType.title.toLowerCase();
-			const keywords = ( blockType.keywords ?? [] ).map( ( k ) =>
-				k.toLowerCase()
-			);
-			return (
-				title.includes( query ) ||
-				keywords.some( ( kw ) => kw.includes( query ) )
-			);
-		} );
-	}, [ searchInputValue, allBlockTypes, canInsertBlockType, rootClientId ] );
+		const blocks = allBlockTypes
+			.filter(
+				( bt ) =>
+					! EXCLUDED.has( bt.name ) &&
+					canInsertBlockType( bt.name, rootClientId ) &&
+					matchesQuery( query, bt.title, bt.keywords )
+			)
+			.map( ( bt ) => ( {
+				key: bt.name,
+				icon: bt.icon,
+				/* translators: %s: Block title (e.g., "Site Logo") */
+				label: sprintf( __( 'Add %s Block' ), bt.title ),
+				badge: __( 'Block' ),
+				onInsert() {
+					const block = createBlock( bt.name );
+					insertBlock( block, insertionIndex, rootClientId );
+					onBlockInsert?.( block );
+					onClose?.();
+				},
+			} ) );
 
-	const { insertBlock } = useDispatch( blockEditorStore );
+		return [ ...variations, ...blocks ];
+	}, [
+		searchInputValue,
+		navigationLinkVariations,
+		allBlockTypes,
+		canInsertBlockType,
+		rootClientId,
+		insertionIndex,
+		insertBlock,
+		onBlockInsert,
+		onClose,
+		type,
+		url,
+	] );
 
 	return (
 		<Popover
@@ -309,21 +373,7 @@ function UnforwardedLinkUI( props, ref ) {
 									canAddBlock={
 										blockEditingMode === 'default'
 									}
-									matchingBlocks={ matchingBlocks }
-									onInsertBlock={ ( blockType ) => {
-										const newBlock = createBlock(
-											blockType.name
-										);
-										insertBlock(
-											newBlock,
-											insertionIndex,
-											rootClientId
-										);
-										if ( props.onBlockInsert ) {
-											props.onBlockInsert( newBlock );
-										}
-										props.onClose?.();
-									} }
+									matchingItems={ matchingItems }
 								/>
 							);
 						} }
@@ -373,34 +423,34 @@ const LinkUITools = ( {
 	setAddingPage,
 	canAddPage,
 	canAddBlock,
-	matchingBlocks = [],
-	onInsertBlock,
+	matchingItems = [],
 } ) => {
 	const blockInserterAriaRole = 'listbox';
 
 	// Don't render anything if neither button should be shown
-	if ( ! canAddPage && ! canAddBlock && matchingBlocks.length === 0 ) {
+	if ( ! canAddPage && ! canAddBlock && matchingItems.length === 0 ) {
 		return null;
 	}
 
 	return (
 		<VStack spacing={ 0 } className="link-ui-tools">
-			{ canAddBlock &&
-				matchingBlocks.map( ( blockType ) => (
+			{ canAddPage &&
+				canAddBlock &&
+				matchingItems.map( ( item ) => (
 					<Button
 						__next40pxDefaultSize
-						key={ blockType.name }
-						icon={ <BlockIcon icon={ blockType.icon } /> }
+						key={ item.key }
+						icon={ <BlockIcon icon={ item.icon } /> }
 						onClick={ ( e ) => {
 							e.preventDefault();
-							onInsertBlock( blockType );
+							item.onInsert();
 						} }
+						aria-haspopup={ blockInserterAriaRole }
 					>
-						{ sprintf(
-							/* translators: %s: Block title (e.g., "Site Logo") */
-							__( 'Add %s Block' ),
-							blockType.title
-						) }
+						{ item.label }
+						<span className="link-ui-suggestion-item__badge">
+							{ item.badge }
+						</span>
 					</Button>
 				) ) }
 			{ canAddPage && (
@@ -417,7 +467,7 @@ const LinkUITools = ( {
 					{ __( 'Create page' ) }
 				</Button>
 			) }
-			{ canAddBlock && (
+			{ canAddBlock && matchingItems.length === 0 && (
 				<Button
 					__next40pxDefaultSize
 					ref={ addBlockButtonRef }

--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -9,7 +9,14 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { LinkControl, useBlockEditingMode } from '@wordpress/block-editor';
+import {
+	LinkControl,
+	useBlockEditingMode,
+	store as blockEditorStore,
+	BlockIcon,
+} from '@wordpress/block-editor';
+import { createBlock, store as blocksStore } from '@wordpress/blocks';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	useMemo,
 	useState,
@@ -97,11 +104,13 @@ function UnforwardedLinkUI( props, ref ) {
 	const [ initialSearchValue, setInitialSearchValue ] = useState( '' );
 	// Tracks the live search input between renders without causing re-renders.
 	const searchInputValueRef = useRef( '' );
+	const [ searchInputValue, setSearchInputValue ] = useState( '' );
 	// Call this instead of setting searchInputValueRef.current and
 	// setInitialSearchValue separately, to keep both in sync.
 	const updateSearchValue = ( value ) => {
 		searchInputValueRef.current = value;
 		setInitialSearchValue( value );
+		setSearchInputValue( value );
 	};
 	const linkControlWrapperRef = useRef();
 	const addPageButtonRef = useRef();
@@ -175,6 +184,55 @@ function UnforwardedLinkUI( props, ref ) {
 	}, [ shouldFocusPane ] );
 
 	const blockEditingMode = useBlockEditingMode();
+	const { rootClientId, insertableNavigationBlocks } = useSelect(
+		( select ) => {
+			const { getBlockRootClientId, canInsertBlockType } =
+				select( blockEditorStore );
+			const root = getBlockRootClientId( props.clientId );
+
+			// Get every registered block type that can live inside this navigation.
+			// Exclude navigation-link and navigation-submenu — those are already
+			// handled by LinkControl's own search suggestions.
+			const EXCLUDED = new Set( [
+				'core/navigation-link',
+				'core/navigation-submenu',
+			] );
+			const insertable = select( blocksStore )
+				.getBlockTypes()
+				.filter(
+					( blockType ) =>
+						! EXCLUDED.has( blockType.name ) &&
+						canInsertBlockType( blockType.name, root )
+				);
+
+			return {
+				rootClientId: root,
+				insertableNavigationBlocks: insertable,
+			};
+		},
+		[ props.clientId ]
+	);
+
+	// Filter insertable blocks by the live search input.
+	// Empty query > no results (avoids flooding the UI before the user types).
+	const matchingBlocks = useMemo( () => {
+		const query = searchInputValue.trim().toLowerCase();
+		if ( ! query ) {
+			return [];
+		}
+		return insertableNavigationBlocks.filter( ( blockType ) => {
+			const title = blockType.title.toLowerCase();
+			const keywords = ( blockType.keywords ?? [] ).map( ( k ) =>
+				k.toLowerCase()
+			);
+			return (
+				title.includes( query ) ||
+				keywords.some( ( kw ) => kw.includes( query ) )
+			);
+		} );
+	}, [ searchInputValue, insertableNavigationBlocks ] );
+
+	const { insertBlock } = useDispatch( blockEditorStore );
 
 	return (
 		<Popover
@@ -214,6 +272,7 @@ function UnforwardedLinkUI( props, ref ) {
 							// Observe the input value so we can pass the value to the page creator
 							// and restore it on back button click
 							searchInputValueRef.current = value;
+							setSearchInputValue( value );
 						} }
 						inputValue={ initialSearchValue }
 						onRemove={ props.onRemove }
@@ -243,6 +302,21 @@ function UnforwardedLinkUI( props, ref ) {
 									canAddBlock={
 										blockEditingMode === 'default'
 									}
+									matchingBlocks={ matchingBlocks }
+									onInsertBlock={ ( blockType ) => {
+										const newBlock = createBlock(
+											blockType.name
+										);
+										insertBlock(
+											newBlock,
+											undefined,
+											rootClientId
+										);
+										if ( props.onBlockInsert ) {
+											props.onBlockInsert( newBlock );
+										}
+										props.onClose?.();
+									} }
 								/>
 							);
 						} }
@@ -292,16 +366,31 @@ const LinkUITools = ( {
 	setAddingPage,
 	canAddPage,
 	canAddBlock,
+	matchingBlocks = [],
+	onInsertBlock,
 } ) => {
 	const blockInserterAriaRole = 'listbox';
 
 	// Don't render anything if neither button should be shown
-	if ( ! canAddPage && ! canAddBlock ) {
+	if ( ! canAddPage && ! canAddBlock && matchingBlocks.length === 0 ) {
 		return null;
 	}
 
 	return (
 		<VStack spacing={ 0 } className="link-ui-tools">
+			{ matchingBlocks.map( ( blockType ) => (
+				<Button
+					__next40pxDefaultSize
+					key={ blockType.name }
+					icon={ <BlockIcon icon={ blockType.icon } /> }
+					onClick={ ( e ) => {
+						e.preventDefault();
+						onInsertBlock( blockType );
+					} }
+				>
+					{ __( 'Add' ) } { blockType.title } { __( 'Block' ) }
+				</Button>
+			) ) }
 			{ canAddPage && (
 				<Button
 					__next40pxDefaultSize

--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -467,7 +467,7 @@ const LinkUITools = ( {
 					{ __( 'Create page' ) }
 				</Button>
 			) }
-			{ canAddBlock && matchingItems.length === 0 && (
+			{ canAddBlock && (
 				<Button
 					__next40pxDefaultSize
 					ref={ addBlockButtonRef }

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -31,3 +31,19 @@
 	margin-left: $grid-unit-10;
 	text-transform: uppercase;
 }
+
+.link-ui-suggestion-item__badge {
+	font-size: 10px;
+	font-weight: 500;
+	text-transform: uppercase;
+	color: $gray-600;
+	background-color: $gray-100;
+	padding: 2px 4px;
+	border-radius: 2px;
+	flex-shrink: 0;
+	margin-left: auto;
+	max-width: 30%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}


### PR DESCRIPTION
## What?
Closes #77074 & Closes #76803

This PR enables users to search for and insert allowed inner blocks (such as Site Logo, Search, or Home link) & block variations (like Category Link, Page Link, etc.) directly from the Navigation block's Link UI popover.

It also introduces contextual badges to the dropdown suggestions to help users distinguish between standard links, block variations, and standalone blocks.

## Why?
Previously, adding inner blocks or specific entity variations to the Navigation block required a cumbersome, multi-step workflow separated from standard link addition. For example, adding a Home link required knowing to click "Add Block" -> "Browse All" -> Search "Home".
By integrating block and variation search directly into the Link UI's primary search bar, we:

- Vastly improve the discoverability of specific entity links (Taxonomies, Categories, Home Link).
- Reduce cognitive load by keeping the user in a single, unified search flow.
- Streamline the overall menu-building experience in the Site Editor.

## How?
Uses `useSelect` to gather all available block types and navigation link variations, and check their insertion permissions. It then filters this list in real-time based on the user's search input and whether the blocks/variation are actually allowed within the Navigation menu. Finally, it passes these matching blocks/variation down into the `LinkUITools` component, which loops through the results to display clickable insertion buttons for the user.

Introduces a `getVariationBadgeLabel` helper to dynamically generate right-aligned badges (e.g., "Category Link", "Block", "Taxonomy") for the search results, ensuring users know exactly what type of item they are inserting.

## Testing Instructions

1. Add a Navigation block to the editor and hover to reveal the + appender icon.
2. Click the + to open the Link UI popover.
3. Test Block Search: Type "Home" into the focused search input field. Verify the "Home Link" block appears with a "Block" badge, and clicking it successfully inserts the block.
4. Test Variation Search: Open a new Link UI popover and type "Category". Verify the "Category Link" variation appears with the appropriate badge, and clicking it inserts a category link block.
5. Test Context Isolation: Click on the newly inserted Category link to edit it. Type a generic term into the search bar. Verify that generic blocks (like Site Logo or Home) do not appear in the suggestions, as you are now restricted to searching for category entities.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="702" height="346" alt="image" src="https://github.com/user-attachments/assets/632df067-89d9-491c-9b56-257f4b9a89bd" />|<img width="702" height="424" alt="image" src="https://github.com/user-attachments/assets/5319ebf1-50b6-4965-b55a-82a738e177a5" />|