### PR TITLE
Polish dashboard drag preview motion, elevation, and drop exit.

### DIFF
--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -30,6 +30,8 @@
     with preview exit keyframes (via drop side effects). Split scale into
     an inner `__lift` wrapper so drop translation does not fight the lift
     transform.
+-   Defer placeholder fade and dashed outline until `data-wp-grid-dragging`
+    is set and the drag-preview enter animation completes (both surfaces).
 -   Set `data-wp-dashboard-grid-resizing` on the `DashboardGrid` root
     element while any tile resize gesture is active, so consumers can
     adjust styles when the pointer may still hover tiles ([#78234](https://github.com/WordPress/gutenberg/pull/78234)).

--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -23,9 +23,11 @@
     border (default `solid`).
 -   Add `--wp-grid-drag-preview-radius` so consumers can round the
     drag-preview functional frame without targeting package internals.
--   Animate drag preview `box-shadow` from resting `xs` to `sm` (same
-    motion tokens as scale) and apply static `sm` when reduced motion
+-   Animate drag preview `box-shadow` from resting `xs` to `md` (same
+    motion tokens as scale) and apply static `md` when reduced motion
     is requested, on the `.drag-preview-frame` wrapper (both surfaces).
+    Widget dashboard edit tiles use `xs` at rest and on hover so only
+    the drag preview elevates to `md`.
     On drop, compose `@dnd-kit/core`'s default `DragOverlay` translation
     with preview exit keyframes (via drop side effects). Split scale into
     an inner `__lift` wrapper so drop translation does not fight the lift

--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -21,6 +21,12 @@
     `--wp-grid-resize-preview-outline-style` CSS custom properties for
     the drag-placeholder outline (default `dashed`) and resize-preview
     border (default `solid`).
+-   Animate drag preview `box-shadow` from resting `sm` to `lg` (same
+    motion tokens as scale) and apply static `lg` when reduced motion
+    is requested, on the `.drag-preview-frame` wrapper (both surfaces).
+    On drop, compose `@dnd-kit/core`'s default `DragOverlay` animation
+    with a frame exit transition (scale + shadow back to resting) so
+    release does not snap.
 -   Set `data-wp-dashboard-grid-resizing` on the `DashboardGrid` root
     element while any tile resize gesture is active, so consumers can
     adjust styles when the pointer may still hover tiles ([#78234](https://github.com/WordPress/gutenberg/pull/78234)).

--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -26,9 +26,10 @@
 -   Animate drag preview `box-shadow` from resting `xs` to `sm` (same
     motion tokens as scale) and apply static `sm` when reduced motion
     is requested, on the `.drag-preview-frame` wrapper (both surfaces).
-    On drop, compose `@dnd-kit/core`'s default `DragOverlay` animation
-    with a frame exit transition (scale + shadow back to resting) so
-    release does not snap.
+    On drop, compose `@dnd-kit/core`'s default `DragOverlay` translation
+    with preview exit keyframes (via drop side effects). Split scale into
+    an inner `__lift` wrapper so drop translation does not fight the lift
+    transform.
 -   Set `data-wp-dashboard-grid-resizing` on the `DashboardGrid` root
     element while any tile resize gesture is active, so consumers can
     adjust styles when the pointer may still hover tiles ([#78234](https://github.com/WordPress/gutenberg/pull/78234)).

--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -23,8 +23,8 @@
     border (default `solid`).
 -   Add `--wp-grid-drag-preview-radius` so consumers can round the
     drag-preview functional frame without targeting package internals.
--   Animate drag preview `box-shadow` from resting `sm` to `lg` (same
-    motion tokens as scale) and apply static `lg` when reduced motion
+-   Animate drag preview `box-shadow` from resting `xs` to `sm` (same
+    motion tokens as scale) and apply static `sm` when reduced motion
     is requested, on the `.drag-preview-frame` wrapper (both surfaces).
     On drop, compose `@dnd-kit/core`'s default `DragOverlay` animation
     with a frame exit transition (scale + shadow back to resting) so

--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -21,6 +21,8 @@
     `--wp-grid-resize-preview-outline-style` CSS custom properties for
     the drag-placeholder outline (default `dashed`) and resize-preview
     border (default `solid`).
+-   Add `--wp-grid-drag-preview-radius` so consumers can round the
+    drag-preview functional frame without targeting package internals.
 -   Animate drag preview `box-shadow` from resting `sm` to `lg` (same
     motion tokens as scale) and apply static `lg` when reduced motion
     is requested, on the `.drag-preview-frame` wrapper (both surfaces).
@@ -61,6 +63,7 @@
 -   Expose CSS custom properties for theming the lift scale,
     placeholder opacity, placeholder outline color, and placeholder
     radius (`--wp-grid-drag-preview-scale`,
+    `--wp-grid-drag-preview-radius`,
     `--wp-grid-placeholder-opacity`,
     `--wp-grid-placeholder-outline-color`,
     `--wp-grid-placeholder-radius`).

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -479,6 +479,7 @@ root itself via `style`). All values fall back to sensible defaults.
 |----------|---------|------------|
 | `--wp-grid-gap` | `var(--wpds-dimension-gap-xl)` | Gap between tiles on `DashboardGrid`, `DashboardLanes`, and the edit overlay. |
 | `--wp-grid-drag-preview-scale` | `1.05` | Lift scale of the drag-preview functional frame. Set to `1` to disable the lift. |
+| `--wp-grid-drag-preview-radius` | `0` | Border radius of the drag-preview functional frame so the lift shadow follows the consumer's tile shape. |
 | `--wp-grid-placeholder-opacity` | `0.4` | Opacity of the placeholder tile (the original item while a drag is in flight). |
 | `--wp-grid-placeholder-outline-style` | `dashed` | Outline style of the drag placeholder (for example `solid` or `dotted`). |
 | `--wp-grid-resize-preview-outline-style` | `solid` | Border style of the resize-preview overlay (for example `dashed` or `dotted`). |

--- a/packages/grid/src/dashboard-grid/grid-item.module.css
+++ b/packages/grid/src/dashboard-grid/grid-item.module.css
@@ -21,23 +21,59 @@
 /*
  * During drag, the original item acts as a placeholder in its grid
  * cell while `<DragOverlay>` renders a clone that follows the cursor.
- * Fading the placeholder and outlining it makes
- * the destination visible without any scaling or translation on the
- * original element.
+ * Fading the placeholder and outlining it makes the destination visible
+ * without any scaling or translation on the original element.
+ *
+ * Placeholder chrome waits until `data-wp-grid-dragging` is set and the
+ * drag-preview enter animation (`--wpds-motion-duration-sm`) finishes
+ * so the dashed outline does not flash under the lifting clone.
  */
 .is-dragging {
-	opacity: var(--wp-grid-placeholder-opacity, 0.4);
 	pointer-events: none;
-	outline:
-		var(--wpds-border-width-sm)
-		var(--wp-grid-placeholder-outline-style, dashed)
-		var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
+}
+
+:global([data-wp-grid-dragging]) .is-dragging {
 	border-radius: var(--wp-grid-placeholder-radius, 0);
 }
 
+@media not (prefers-reduced-motion: reduce) {
+	:global([data-wp-grid-dragging]) .is-dragging {
+		opacity: 1;
+		outline-width: 0;
+		outline-style: var(--wp-grid-placeholder-outline-style, dashed);
+		outline-color: transparent;
+		animation: wp-grid-item-placeholder-in 0ms linear
+			var(--wpds-motion-duration-sm) forwards;
+	}
+
+	@keyframes wp-grid-item-placeholder-in {
+		to {
+			opacity: var(--wp-grid-placeholder-opacity, 0.4);
+			outline-width: var(--wpds-border-width-sm);
+			outline-color: var(
+				--wp-grid-placeholder-outline-color,
+				var(--wpds-color-stroke-interactive-brand)
+			);
+		}
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	:global([data-wp-grid-dragging]) .is-dragging {
+		opacity: var(--wp-grid-placeholder-opacity, 0.4);
+		outline:
+			var(--wpds-border-width-sm)
+			var(--wp-grid-placeholder-outline-style, dashed)
+			var(
+				--wp-grid-placeholder-outline-color,
+				var(--wpds-color-stroke-interactive-brand)
+			);
+	}
+}
+
 @media (forced-colors: active) {
-	.is-dragging {
-		outline-color: Highlight;
+	:global([data-wp-grid-dragging]) .is-dragging {
+		--wp-grid-placeholder-outline-color: Highlight;
 	}
 }
 

--- a/packages/grid/src/dashboard-grid/grid-item.module.css
+++ b/packages/grid/src/dashboard-grid/grid-item.module.css
@@ -42,7 +42,8 @@
 		outline-width: 0;
 		outline-style: var(--wp-grid-placeholder-outline-style, dashed);
 		outline-color: transparent;
-		animation: wp-grid-item-placeholder-in 0ms linear
+		animation:
+			wp-grid-item-placeholder-in 0ms linear
 			var(--wpds-motion-duration-sm) forwards;
 	}
 
@@ -50,10 +51,7 @@
 		to {
 			opacity: var(--wp-grid-placeholder-opacity, 0.4);
 			outline-width: var(--wpds-border-width-sm);
-			outline-color: var(
-				--wp-grid-placeholder-outline-color,
-				var(--wpds-color-stroke-interactive-brand)
-			);
+			outline-color: var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
 		}
 	}
 }
@@ -64,10 +62,7 @@
 		outline:
 			var(--wpds-border-width-sm)
 			var(--wp-grid-placeholder-outline-style, dashed)
-			var(
-				--wp-grid-placeholder-outline-color,
-				var(--wpds-color-stroke-interactive-brand)
-			);
+			var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
 	}
 }
 

--- a/packages/grid/src/dashboard-grid/grid.module.css
+++ b/packages/grid/src/dashboard-grid/grid.module.css
@@ -9,13 +9,15 @@
  * Always applied, including when the consumer passes a
  * `renderDragPreview` wrapper. Owns the lift cue (`scale` with motion
  * tokens), drag elevation (`box-shadow` animating from resting `sm` to
- * `lg`), the pointer feedback (`cursor`), and the pointer pass-through during
- * the gesture. Further visual chrome (padding, inner surfaces) belongs
+ * `lg`), optional corner radius via `--wp-grid-drag-preview-radius`, the
+ * pointer feedback (`cursor`), and the pointer pass-through during the
+ * gesture. Further visual chrome (padding, inner surfaces) belongs
  * to the consumer, either on the children passed to <DashboardGrid />
  * or via `renderDragPreview`.
  */
 .drag-preview-frame {
 	height: 100%;
+	border-radius: var(--wp-grid-drag-preview-radius, 0);
 	cursor: grabbing;
 	pointer-events: none;
 	box-shadow: var(--wpds-elevation-lg);

--- a/packages/grid/src/dashboard-grid/grid.module.css
+++ b/packages/grid/src/dashboard-grid/grid.module.css
@@ -8,8 +8,8 @@
  * Functional frame for the drag-preview clone inside `<DragOverlay>`.
  * Always applied, including when the consumer passes a
  * `renderDragPreview` wrapper. Owns the lift cue (`scale` with motion
- * tokens), drag elevation (`box-shadow` animating from resting `sm` to
- * `lg`), optional corner radius via `--wp-grid-drag-preview-radius`, the
+ * tokens), drag elevation (`box-shadow` animating from resting `xs` to
+ * `sm`), optional corner radius via `--wp-grid-drag-preview-radius`, the
  * pointer feedback (`cursor`), and the pointer pass-through during the
  * gesture. Further visual chrome (padding, inner surfaces) belongs
  * to the consumer, either on the children passed to <DashboardGrid />
@@ -20,18 +20,31 @@
 	border-radius: var(--wp-grid-drag-preview-radius, 0);
 	cursor: grabbing;
 	pointer-events: none;
-	box-shadow: var(--wpds-elevation-lg);
+	box-shadow: var(--wpds-elevation-sm);
 	transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
 
 	@media not (prefers-reduced-motion: reduce) {
-		@starting-style {
-			box-shadow: var(--wpds-elevation-sm);
+		/*
+		 * Keyframes (not @starting-style) so each DragOverlay mount
+		 * reliably runs xs → sm; var() box-shadow pairs can fail to
+		 * interpolate in entry transitions.
+		 */
+		animation: wp-grid-drag-preview-enter var(--wpds-motion-duration-sm)
+			var(--wpds-motion-easing-balanced) both;
+	}
+}
+
+@media not (prefers-reduced-motion: reduce) {
+	@keyframes wp-grid-drag-preview-enter {
+		from {
+			box-shadow: var(--wpds-elevation-xs);
 			transform: scale(1);
 		}
 
-		transition:
-			transform var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced),
-			box-shadow var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced);
+		to {
+			box-shadow: var(--wpds-elevation-sm);
+			transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
+		}
 	}
 }
 
@@ -41,8 +54,9 @@
  * `createDashboardDragDropAnimation` (200ms / md token).
  */
 .drag-preview-frame.dragPreviewFrameExiting {
+	animation: none;
 	transform: scale(1);
-	box-shadow: var(--wpds-elevation-sm);
+	box-shadow: var(--wpds-elevation-xs);
 	transition:
 		transform var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced),
 		box-shadow var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced);
@@ -50,13 +64,13 @@
 
 @media (prefers-reduced-motion: reduce) {
 	.drag-preview-frame {
-		box-shadow: var(--wpds-elevation-lg);
+		box-shadow: var(--wpds-elevation-sm);
 		transform: none;
 		transition: none;
 	}
 
 	.drag-preview-frame.dragPreviewFrameExiting {
-		box-shadow: var(--wpds-elevation-sm);
+		box-shadow: var(--wpds-elevation-xs);
 		transition: none;
 	}
 }

--- a/packages/grid/src/dashboard-grid/grid.module.css
+++ b/packages/grid/src/dashboard-grid/grid.module.css
@@ -7,21 +7,56 @@
 /*
  * Functional frame for the drag-preview clone inside `<DragOverlay>`.
  * Always applied, including when the consumer passes a
- * `renderDragPreview` wrapper. Owns the lift cue (`scale`), the
- * pointer feedback (`cursor`), and the pointer pass-through during
- * the gesture. Visual chrome (shadow, radius, padding) belongs to
- * the consumer, either on the children passed to <DashboardGrid />
+ * `renderDragPreview` wrapper. Owns the lift cue (`scale` with motion
+ * tokens), drag elevation (`box-shadow` animating from resting `sm` to
+ * `lg`), matching `border-radius` so the shadow follows the card shape,
+ * the pointer feedback (`cursor`), and the pointer pass-through during
+ * the gesture. Further visual chrome (padding, inner surfaces) belongs
+ * to the consumer, either on the children passed to <DashboardGrid />
  * or via `renderDragPreview`.
  */
 .drag-preview-frame {
 	height: 100%;
-	transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
+	border-radius: var(--wpds-border-radius-lg);
 	cursor: grabbing;
 	pointer-events: none;
+	box-shadow: var(--wpds-elevation-lg);
+	transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
+
+	@media not (prefers-reduced-motion: reduce) {
+		@starting-style {
+			box-shadow: var(--wpds-elevation-sm);
+			transform: scale(1);
+		}
+
+		transition:
+			transform var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced),
+			box-shadow var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced);
+	}
+}
+
+/*
+ * Applied by @dnd-kit `DragOverlay` drop side-effects while the
+ * default overlay transform runs; duration matches
+ * `createDashboardDragDropAnimation` (200ms / md token).
+ */
+.drag-preview-frame.dragPreviewFrameExiting {
+	transform: scale(1);
+	box-shadow: var(--wpds-elevation-sm);
+	transition:
+		transform var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced),
+		box-shadow var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced);
 }
 
 @media (prefers-reduced-motion: reduce) {
 	.drag-preview-frame {
+		box-shadow: var(--wpds-elevation-lg);
 		transform: none;
+		transition: none;
+	}
+
+	.drag-preview-frame.dragPreviewFrameExiting {
+		box-shadow: var(--wpds-elevation-sm);
+		transition: none;
 	}
 }

--- a/packages/grid/src/dashboard-grid/grid.module.css
+++ b/packages/grid/src/dashboard-grid/grid.module.css
@@ -9,15 +9,13 @@
  * Always applied, including when the consumer passes a
  * `renderDragPreview` wrapper. Owns the lift cue (`scale` with motion
  * tokens), drag elevation (`box-shadow` animating from resting `sm` to
- * `lg`), matching `border-radius` so the shadow follows the card shape,
- * the pointer feedback (`cursor`), and the pointer pass-through during
+ * `lg`), the pointer feedback (`cursor`), and the pointer pass-through during
  * the gesture. Further visual chrome (padding, inner surfaces) belongs
  * to the consumer, either on the children passed to <DashboardGrid />
  * or via `renderDragPreview`.
  */
 .drag-preview-frame {
 	height: 100%;
-	border-radius: var(--wpds-border-radius-lg);
 	cursor: grabbing;
 	pointer-events: none;
 	box-shadow: var(--wpds-elevation-lg);

--- a/packages/grid/src/dashboard-grid/grid.module.css
+++ b/packages/grid/src/dashboard-grid/grid.module.css
@@ -7,13 +7,10 @@
 /*
  * Functional frame for the drag-preview clone inside `<DragOverlay>`.
  * Always applied, including when the consumer passes a
- * `renderDragPreview` wrapper. Owns the lift cue (`scale` with motion
- * tokens), drag elevation (`box-shadow` animating from resting `xs` to
- * `sm`), optional corner radius via `--wp-grid-drag-preview-radius`, the
- * pointer feedback (`cursor`), and the pointer pass-through during the
- * gesture. Further visual chrome (padding, inner surfaces) belongs
- * to the consumer, either on the children passed to <DashboardGrid />
- * or via `renderDragPreview`.
+ * `renderDragPreview` wrapper. The outer frame has no `transform` so
+ * @dnd-kit’s drop translation matches the placeholder; scale lives on
+ * `__lift` (see dnd-kit #398). Owns elevation, radius, cursor, and
+ * pointer pass-through. Further chrome belongs to the consumer.
  */
 .drag-preview-frame {
 	height: 100%;
@@ -21,28 +18,43 @@
 	cursor: grabbing;
 	pointer-events: none;
 	box-shadow: var(--wpds-elevation-sm);
-	transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
+}
 
-	@media not (prefers-reduced-motion: reduce) {
-		/*
-		 * Keyframes (not @starting-style) so each DragOverlay mount
-		 * reliably runs xs → sm; var() box-shadow pairs can fail to
-		 * interpolate in entry transitions.
-		 */
-		animation: wp-grid-drag-preview-enter var(--wpds-motion-duration-sm)
-			var(--wpds-motion-easing-balanced) both;
+.drag-preview-frame__lift {
+	height: 100%;
+	transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
+	transform-origin: center;
+}
+
+@media not (prefers-reduced-motion: reduce) {
+	.drag-preview-frame {
+		animation: wp-grid-drag-preview-shadow-enter
+			var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced) both;
+	}
+
+	.drag-preview-frame__lift {
+		animation: wp-grid-drag-preview-scale-enter
+			var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced) both;
 	}
 }
 
 @media not (prefers-reduced-motion: reduce) {
-	@keyframes wp-grid-drag-preview-enter {
+	@keyframes wp-grid-drag-preview-shadow-enter {
 		from {
 			box-shadow: var(--wpds-elevation-xs);
-			transform: scale(1);
 		}
 
 		to {
 			box-shadow: var(--wpds-elevation-sm);
+		}
+	}
+
+	@keyframes wp-grid-drag-preview-scale-enter {
+		from {
+			transform: scale(1);
+		}
+
+		to {
 			transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
 		}
 	}
@@ -51,26 +63,67 @@
 /*
  * Applied by @dnd-kit `DragOverlay` drop side-effects while the
  * default overlay transform runs; duration matches
- * `createDashboardDragDropAnimation` (200ms / md token).
+ * `createDashboardDragDropAnimation` (200ms / md token). Use keyframed
+ * exit (not transition) so scale does not snap when the enter animation
+ * is replaced.
  */
+@media not (prefers-reduced-motion: reduce) {
+	.drag-preview-frame.dragPreviewFrameExiting {
+		animation: wp-grid-drag-preview-shadow-exit
+			var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced)
+			forwards;
+	}
+
+	.drag-preview-frame.dragPreviewFrameExiting .drag-preview-frame__lift {
+		animation: wp-grid-drag-preview-scale-exit
+			var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced)
+			forwards;
+	}
+
+	@keyframes wp-grid-drag-preview-shadow-exit {
+		from {
+			box-shadow: var(--wpds-elevation-sm);
+		}
+
+		to {
+			box-shadow: var(--wpds-elevation-xs);
+		}
+	}
+
+	@keyframes wp-grid-drag-preview-scale-exit {
+		from {
+			transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
+		}
+
+		to {
+			transform: scale(1);
+		}
+	}
+}
+
 .drag-preview-frame.dragPreviewFrameExiting {
-	animation: none;
-	transform: scale(1);
 	box-shadow: var(--wpds-elevation-xs);
-	transition:
-		transform var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced),
-		box-shadow var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced);
+}
+
+.drag-preview-frame.dragPreviewFrameExiting .drag-preview-frame__lift {
+	transform: scale(1);
 }
 
 @media (prefers-reduced-motion: reduce) {
 	.drag-preview-frame {
 		box-shadow: var(--wpds-elevation-sm);
+	}
+
+	.drag-preview-frame__lift {
 		transform: none;
-		transition: none;
 	}
 
 	.drag-preview-frame.dragPreviewFrameExiting {
 		box-shadow: var(--wpds-elevation-xs);
+		transition: none;
+	}
+
+	.drag-preview-frame.dragPreviewFrameExiting .drag-preview-frame__lift {
 		transition: none;
 	}
 }

--- a/packages/grid/src/dashboard-grid/grid.module.css
+++ b/packages/grid/src/dashboard-grid/grid.module.css
@@ -10,14 +10,15 @@
  * `renderDragPreview` wrapper. The outer frame has no `transform` so
  * @dnd-kit’s drop translation matches the placeholder; scale lives on
  * `__lift` (see dnd-kit #398). Owns elevation, radius, cursor, and
- * pointer pass-through. Further chrome belongs to the consumer.
+ * pointer pass-through. Further chrome belongs to the consumer. Drag
+ * elevation animates `xs` → `md` so it reads above edit tiles at `xs`.
  */
 .drag-preview-frame {
 	height: 100%;
 	border-radius: var(--wp-grid-drag-preview-radius, 0);
 	cursor: grabbing;
 	pointer-events: none;
-	box-shadow: var(--wpds-elevation-sm);
+	box-shadow: var(--wpds-elevation-md);
 }
 
 .drag-preview-frame__lift {
@@ -45,7 +46,7 @@
 		}
 
 		to {
-			box-shadow: var(--wpds-elevation-sm);
+			box-shadow: var(--wpds-elevation-md);
 		}
 	}
 
@@ -82,7 +83,7 @@
 
 	@keyframes wp-grid-drag-preview-shadow-exit {
 		from {
-			box-shadow: var(--wpds-elevation-sm);
+			box-shadow: var(--wpds-elevation-md);
 		}
 
 		to {
@@ -111,7 +112,7 @@
 
 @media (prefers-reduced-motion: reduce) {
 	.drag-preview-frame {
-		box-shadow: var(--wpds-elevation-sm);
+		box-shadow: var(--wpds-elevation-md);
 	}
 
 	.drag-preview-frame__lift {

--- a/packages/grid/src/dashboard-grid/grid.module.css
+++ b/packages/grid/src/dashboard-grid/grid.module.css
@@ -29,12 +29,14 @@
 
 @media not (prefers-reduced-motion: reduce) {
 	.drag-preview-frame {
-		animation: wp-grid-drag-preview-shadow-enter
+		animation:
+			wp-grid-drag-preview-shadow-enter
 			var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced) both;
 	}
 
 	.drag-preview-frame__lift {
-		animation: wp-grid-drag-preview-scale-enter
+		animation:
+			wp-grid-drag-preview-scale-enter
 			var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced) both;
 	}
 }
@@ -70,13 +72,15 @@
  */
 @media not (prefers-reduced-motion: reduce) {
 	.drag-preview-frame.dragPreviewFrameExiting {
-		animation: wp-grid-drag-preview-shadow-exit
+		animation:
+			wp-grid-drag-preview-shadow-exit
 			var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced)
 			forwards;
 	}
 
 	.drag-preview-frame.dragPreviewFrameExiting .drag-preview-frame__lift {
-		animation: wp-grid-drag-preview-scale-exit
+		animation:
+			wp-grid-drag-preview-scale-exit
 			var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced)
 			forwards;
 	}

--- a/packages/grid/src/dashboard-grid/index.tsx
+++ b/packages/grid/src/dashboard-grid/index.tsx
@@ -53,6 +53,7 @@ import { createDashboardDragDropAnimation } from '../shared/drag-overlay-drop-an
 import styles from './grid.module.css';
 
 const dashboardDragDropAnimation = createDashboardDragDropAnimation(
+	styles[ 'drag-preview-frame' ],
 	styles.dragPreviewFrameExiting
 );
 
@@ -554,10 +555,7 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 		const DragPreview = renderDragPreview;
 		const dragOverlayContent =
 			activeId && activeClone ? (
-				<div
-					className={ styles[ 'drag-preview-frame' ] }
-					data-wp-dashboard-drag-preview-frame
-				>
+				<div className={ styles[ 'drag-preview-frame' ] }>
 					{ DragPreview ? (
 						<DragPreview itemId={ activeId }>
 							{ activeClone }

--- a/packages/grid/src/dashboard-grid/index.tsx
+++ b/packages/grid/src/dashboard-grid/index.tsx
@@ -49,7 +49,12 @@ import { resolveFillWidths } from './resolve-fill-widths';
 import type { DashboardGridLayoutItem, DashboardGridProps } from './types';
 import type { ResizeSnapSize } from '../shared/resize-snap';
 import type { ResizeDelta } from '../shared/types';
+import { createDashboardDragDropAnimation } from '../shared/drag-overlay-drop-animation';
 import styles from './grid.module.css';
+
+const dashboardDragDropAnimation = createDashboardDragDropAnimation(
+	styles.dragPreviewFrameExiting
+);
 
 // Fallback gap in pixels for math that runs before the computed gap
 // can be read from the DOM. Matches the `'xl'` step the surface
@@ -549,7 +554,10 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 		const DragPreview = renderDragPreview;
 		const dragOverlayContent =
 			activeId && activeClone ? (
-				<div className={ styles[ 'drag-preview-frame' ] }>
+				<div
+					className={ styles[ 'drag-preview-frame' ] }
+					data-wp-dashboard-drag-preview-frame
+				>
 					{ DragPreview ? (
 						<DragPreview itemId={ activeId }>
 							{ activeClone }
@@ -700,7 +708,9 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 						) ) }
 					</div>
 				</SortableContext>
-				<DragOverlay>{ dragOverlayContent }</DragOverlay>
+				<DragOverlay dropAnimation={ dashboardDragDropAnimation }>
+					{ dragOverlayContent }
+				</DragOverlay>
 			</DndContext>
 		);
 	}

--- a/packages/grid/src/dashboard-grid/index.tsx
+++ b/packages/grid/src/dashboard-grid/index.tsx
@@ -556,13 +556,15 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 		const dragOverlayContent =
 			activeId && activeClone ? (
 				<div className={ styles[ 'drag-preview-frame' ] }>
-					{ DragPreview ? (
-						<DragPreview itemId={ activeId }>
-							{ activeClone }
-						</DragPreview>
-					) : (
-						activeClone
-					) }
+					<div className={ styles[ 'drag-preview-frame__lift' ] }>
+						{ DragPreview ? (
+							<DragPreview itemId={ activeId }>
+								{ activeClone }
+							</DragPreview>
+						) : (
+							activeClone
+						) }
+					</div>
 				</div>
 			) : null;
 
@@ -640,8 +642,8 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 				onDragMove={ handleDragMove }
 				onDragEnd={ () => {
 					persistTemporaryLayout();
-					setActiveId( null );
 					lastReorderCursorRef.current = null;
+					setActiveId( null );
 				} }
 			>
 				{ /* No-op strategy: reorder comes from `temporaryLayout`

--- a/packages/grid/src/dashboard-grid/stories/index.story.tsx
+++ b/packages/grid/src/dashboard-grid/stories/index.story.tsx
@@ -711,8 +711,9 @@ function CustomResizeHandle( {
 /**
  * Example `renderDragPreview` wrapper: keeps the clone height chain
  * intact. Lift, shadow, and motion live on the grid
- * `.drag-preview-frame`; add radius or extra chrome here only when a
- * surface needs it (see widget dashboard).
+ * `.drag-preview-frame`; set `--wp-grid-drag-preview-radius` on the
+ * surface when the lift shadow should match rounded tiles (see widget
+ * dashboard).
  */
 function CustomDragPreview( { children }: DragPreviewRenderProps ) {
 	return <div style={ { height: '100%' } }>{ children }</div>;

--- a/packages/grid/src/dashboard-grid/stories/index.story.tsx
+++ b/packages/grid/src/dashboard-grid/stories/index.story.tsx
@@ -709,23 +709,13 @@ function CustomResizeHandle( {
 }
 
 /**
- * Drop-in wrapper that bumps the dragged-clone shadow and clips its
- * corners. The grid keeps the lift scale and the grabbing cursor on
- * the functional frame; the consumer's wrapper sits inside it.
+ * Example `renderDragPreview` wrapper: keeps the clone height chain
+ * intact. Lift, shadow, and motion live on the grid
+ * `.drag-preview-frame`; add radius or extra chrome here only when a
+ * surface needs it (see widget dashboard).
  */
 function CustomDragPreview( { children }: DragPreviewRenderProps ) {
-	return (
-		<div
-			style={ {
-				height: '100%',
-				boxShadow: 'var(--wpds-elevation-lg)',
-				borderRadius: 'var(--wpds-border-radius-lg)',
-				overflow: 'hidden',
-			} }
-		>
-			{ children }
-		</div>
-	);
+	return <div style={ { height: '100%' } }>{ children }</div>;
 }
 
 /**
@@ -733,8 +723,8 @@ function CustomDragPreview( { children }: DragPreviewRenderProps ) {
  *
  * 1. `renderResizeHandle` swaps the default corner triangle for a
  *    custom diagonal-arrow icon.
- * 2. `renderDragPreview` wraps the dragged clone with extra chrome
- *    (stronger shadow, rounded corners, overflow clipping).
+ * 2. `renderDragPreview` wraps the dragged clone (here only for the
+ *    height chain; lift and shadow stay on the grid frame).
  * 3. CSS custom properties on an ancestor retheme the lift scale,
  *    placeholder opacity, placeholder outline color, and placeholder
  *    border-radius without touching the package.

--- a/packages/grid/src/dashboard-lanes/index.tsx
+++ b/packages/grid/src/dashboard-lanes/index.tsx
@@ -50,7 +50,12 @@ import { useItemExitAnimation } from '../shared/use-item-exit-animation';
 import type { DashboardLanesLayoutItem, DashboardLanesProps } from './types';
 import type { ResizeSnapSize } from '../shared/resize-snap';
 import type { ResizeDelta } from '../shared/types';
+import { createDashboardDragDropAnimation } from '../shared/drag-overlay-drop-animation';
 import styles from './lanes.module.css';
+
+const dashboardDragDropAnimation = createDashboardDragDropAnimation(
+	styles.dragPreviewFrameExiting
+);
 
 // Fallback gap in pixels for math that runs before the computed gap
 // can be read from the DOM. Matches the `'xl'` step the surface
@@ -473,7 +478,10 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 		const DragPreview = renderDragPreview;
 		const dragOverlayContent =
 			activeId && activeClone ? (
-				<div className={ styles[ 'drag-preview-frame' ] }>
+				<div
+					className={ styles[ 'drag-preview-frame' ] }
+					data-wp-dashboard-drag-preview-frame
+				>
 					{ DragPreview ? (
 						<DragPreview itemId={ activeId }>
 							{ activeClone }
@@ -615,7 +623,9 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 						) ) }
 					</div>
 				</SortableContext>
-				<DragOverlay>{ dragOverlayContent }</DragOverlay>
+				<DragOverlay dropAnimation={ dashboardDragDropAnimation }>
+					{ dragOverlayContent }
+				</DragOverlay>
 			</DndContext>
 		);
 	}

--- a/packages/grid/src/dashboard-lanes/index.tsx
+++ b/packages/grid/src/dashboard-lanes/index.tsx
@@ -54,6 +54,7 @@ import { createDashboardDragDropAnimation } from '../shared/drag-overlay-drop-an
 import styles from './lanes.module.css';
 
 const dashboardDragDropAnimation = createDashboardDragDropAnimation(
+	styles[ 'drag-preview-frame' ],
 	styles.dragPreviewFrameExiting
 );
 
@@ -478,10 +479,7 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 		const DragPreview = renderDragPreview;
 		const dragOverlayContent =
 			activeId && activeClone ? (
-				<div
-					className={ styles[ 'drag-preview-frame' ] }
-					data-wp-dashboard-drag-preview-frame
-				>
+				<div className={ styles[ 'drag-preview-frame' ] }>
 					{ DragPreview ? (
 						<DragPreview itemId={ activeId }>
 							{ activeClone }

--- a/packages/grid/src/dashboard-lanes/index.tsx
+++ b/packages/grid/src/dashboard-lanes/index.tsx
@@ -480,13 +480,15 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 		const dragOverlayContent =
 			activeId && activeClone ? (
 				<div className={ styles[ 'drag-preview-frame' ] }>
-					{ DragPreview ? (
-						<DragPreview itemId={ activeId }>
-							{ activeClone }
-						</DragPreview>
-					) : (
-						activeClone
-					) }
+					<div className={ styles[ 'drag-preview-frame__lift' ] }>
+						{ DragPreview ? (
+							<DragPreview itemId={ activeId }>
+								{ activeClone }
+							</DragPreview>
+						) : (
+							activeClone
+						) }
+					</div>
 				</div>
 			) : null;
 
@@ -539,8 +541,8 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 				onDragMove={ handleDragMove }
 				onDragEnd={ () => {
 					persistTemporaryLayout();
-					setActiveId( null );
 					lastReorderCursorRef.current = null;
+					setActiveId( null );
 				} }
 			>
 				<SortableContext items={ items } strategy={ NO_SORT_STRATEGY }>

--- a/packages/grid/src/dashboard-lanes/lanes-item.module.css
+++ b/packages/grid/src/dashboard-lanes/lanes-item.module.css
@@ -21,23 +21,59 @@
 /*
  * During drag, the original item acts as a placeholder in its lane
  * while `<DragOverlay>` renders a clone that follows the cursor.
- * Fading the placeholder and outlining it makes
- * the destination visible without any scaling or translation on the
- * original element.
+ * Fading the placeholder and outlining it makes the destination visible
+ * without any scaling or translation on the original element.
+ *
+ * Placeholder chrome waits until `data-wp-grid-dragging` is set and the
+ * drag-preview enter animation (`--wpds-motion-duration-sm`) finishes
+ * so the dashed outline does not flash under the lifting clone.
  */
 .is-dragging {
-	opacity: var(--wp-grid-placeholder-opacity, 0.4);
 	pointer-events: none;
-	outline:
-		var(--wpds-border-width-sm)
-		var(--wp-grid-placeholder-outline-style, dashed)
-		var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
+}
+
+:global([data-wp-grid-dragging]) .is-dragging {
 	border-radius: var(--wp-grid-placeholder-radius, 0);
 }
 
+@media not (prefers-reduced-motion: reduce) {
+	:global([data-wp-grid-dragging]) .is-dragging {
+		opacity: 1;
+		outline-width: 0;
+		outline-style: var(--wp-grid-placeholder-outline-style, dashed);
+		outline-color: transparent;
+		animation: wp-grid-item-placeholder-in 0ms linear
+			var(--wpds-motion-duration-sm) forwards;
+	}
+
+	@keyframes wp-grid-item-placeholder-in {
+		to {
+			opacity: var(--wp-grid-placeholder-opacity, 0.4);
+			outline-width: var(--wpds-border-width-sm);
+			outline-color: var(
+				--wp-grid-placeholder-outline-color,
+				var(--wpds-color-stroke-interactive-brand)
+			);
+		}
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	:global([data-wp-grid-dragging]) .is-dragging {
+		opacity: var(--wp-grid-placeholder-opacity, 0.4);
+		outline:
+			var(--wpds-border-width-sm)
+			var(--wp-grid-placeholder-outline-style, dashed)
+			var(
+				--wp-grid-placeholder-outline-color,
+				var(--wpds-color-stroke-interactive-brand)
+			);
+	}
+}
+
 @media (forced-colors: active) {
-	.is-dragging {
-		outline-color: Highlight;
+	:global([data-wp-grid-dragging]) .is-dragging {
+		--wp-grid-placeholder-outline-color: Highlight;
 	}
 }
 

--- a/packages/grid/src/dashboard-lanes/lanes-item.module.css
+++ b/packages/grid/src/dashboard-lanes/lanes-item.module.css
@@ -51,8 +51,7 @@
 		to {
 			opacity: var(--wp-grid-placeholder-opacity, 0.4);
 			outline-width: var(--wpds-border-width-sm);
-			outline-color:
- var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
+			outline-color: var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
 		}
 	}
 }

--- a/packages/grid/src/dashboard-lanes/lanes-item.module.css
+++ b/packages/grid/src/dashboard-lanes/lanes-item.module.css
@@ -42,7 +42,8 @@
 		outline-width: 0;
 		outline-style: var(--wp-grid-placeholder-outline-style, dashed);
 		outline-color: transparent;
-		animation: wp-grid-item-placeholder-in 0ms linear
+		animation:
+			wp-grid-item-placeholder-in 0ms linear
 			var(--wpds-motion-duration-sm) forwards;
 	}
 
@@ -50,10 +51,8 @@
 		to {
 			opacity: var(--wp-grid-placeholder-opacity, 0.4);
 			outline-width: var(--wpds-border-width-sm);
-			outline-color: var(
-				--wp-grid-placeholder-outline-color,
-				var(--wpds-color-stroke-interactive-brand)
-			);
+			outline-color:
+ var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
 		}
 	}
 }
@@ -64,10 +63,7 @@
 		outline:
 			var(--wpds-border-width-sm)
 			var(--wp-grid-placeholder-outline-style, dashed)
-			var(
-				--wp-grid-placeholder-outline-color,
-				var(--wpds-color-stroke-interactive-brand)
-			);
+			var(--wp-grid-placeholder-outline-color, var(--wpds-color-stroke-interactive-brand));
 	}
 }
 

--- a/packages/grid/src/dashboard-lanes/lanes.module.css
+++ b/packages/grid/src/dashboard-lanes/lanes.module.css
@@ -26,8 +26,8 @@
  * Functional frame for the drag-preview clone inside `<DragOverlay>`.
  * Always applied, including when the consumer passes a
  * `renderDragPreview` wrapper. Owns the lift cue (`scale` with motion
- * tokens), drag elevation (`box-shadow` animating from resting `sm` to
- * `lg`), optional corner radius via `--wp-grid-drag-preview-radius`, the
+ * tokens), drag elevation (`box-shadow` animating from resting `xs` to
+ * `sm`), optional corner radius via `--wp-grid-drag-preview-radius`, the
  * pointer feedback (`cursor`), and the pointer pass-through during the
  * gesture. Further visual chrome (padding, inner surfaces) belongs
  * to the consumer, either on the children passed to <DashboardLanes />
@@ -38,18 +38,31 @@
 	border-radius: var(--wp-grid-drag-preview-radius, 0);
 	cursor: grabbing;
 	pointer-events: none;
-	box-shadow: var(--wpds-elevation-lg);
+	box-shadow: var(--wpds-elevation-sm);
 	transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
 
 	@media not (prefers-reduced-motion: reduce) {
-		@starting-style {
-			box-shadow: var(--wpds-elevation-sm);
+		/*
+		 * Keyframes (not @starting-style) so each DragOverlay mount
+		 * reliably runs xs → sm; var() box-shadow pairs can fail to
+		 * interpolate in entry transitions.
+		 */
+		animation: wp-grid-drag-preview-enter var(--wpds-motion-duration-sm)
+			var(--wpds-motion-easing-balanced) both;
+	}
+}
+
+@media not (prefers-reduced-motion: reduce) {
+	@keyframes wp-grid-drag-preview-enter {
+		from {
+			box-shadow: var(--wpds-elevation-xs);
 			transform: scale(1);
 		}
 
-		transition:
-			transform var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced),
-			box-shadow var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced);
+		to {
+			box-shadow: var(--wpds-elevation-sm);
+			transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
+		}
 	}
 }
 
@@ -59,8 +72,9 @@
  * `createDashboardDragDropAnimation` (200ms / md token).
  */
 .drag-preview-frame.dragPreviewFrameExiting {
+	animation: none;
 	transform: scale(1);
-	box-shadow: var(--wpds-elevation-sm);
+	box-shadow: var(--wpds-elevation-xs);
 	transition:
 		transform var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced),
 		box-shadow var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced);
@@ -68,13 +82,13 @@
 
 @media (prefers-reduced-motion: reduce) {
 	.drag-preview-frame {
-		box-shadow: var(--wpds-elevation-lg);
+		box-shadow: var(--wpds-elevation-sm);
 		transform: none;
 		transition: none;
 	}
 
 	.drag-preview-frame.dragPreviewFrameExiting {
-		box-shadow: var(--wpds-elevation-sm);
+		box-shadow: var(--wpds-elevation-xs);
 		transition: none;
 	}
 }

--- a/packages/grid/src/dashboard-lanes/lanes.module.css
+++ b/packages/grid/src/dashboard-lanes/lanes.module.css
@@ -27,15 +27,13 @@
  * Always applied, including when the consumer passes a
  * `renderDragPreview` wrapper. Owns the lift cue (`scale` with motion
  * tokens), drag elevation (`box-shadow` animating from resting `sm` to
- * `lg`), matching `border-radius` so the shadow follows the card shape,
- * the pointer feedback (`cursor`), and the pointer pass-through during
+ * `lg`), the pointer feedback (`cursor`), and the pointer pass-through during
  * the gesture. Further visual chrome (padding, inner surfaces) belongs
  * to the consumer, either on the children passed to <DashboardLanes />
  * or via `renderDragPreview`.
  */
 .drag-preview-frame {
 	height: 100%;
-	border-radius: var(--wpds-border-radius-lg);
 	cursor: grabbing;
 	pointer-events: none;
 	box-shadow: var(--wpds-elevation-lg);

--- a/packages/grid/src/dashboard-lanes/lanes.module.css
+++ b/packages/grid/src/dashboard-lanes/lanes.module.css
@@ -25,13 +25,10 @@
 /*
  * Functional frame for the drag-preview clone inside `<DragOverlay>`.
  * Always applied, including when the consumer passes a
- * `renderDragPreview` wrapper. Owns the lift cue (`scale` with motion
- * tokens), drag elevation (`box-shadow` animating from resting `xs` to
- * `sm`), optional corner radius via `--wp-grid-drag-preview-radius`, the
- * pointer feedback (`cursor`), and the pointer pass-through during the
- * gesture. Further visual chrome (padding, inner surfaces) belongs
- * to the consumer, either on the children passed to <DashboardLanes />
- * or via `renderDragPreview`.
+ * `renderDragPreview` wrapper. The outer frame has no `transform` so
+ * @dnd-kit’s drop translation matches the placeholder; scale lives on
+ * `__lift` (see dnd-kit #398). Owns elevation, radius, cursor, and
+ * pointer pass-through. Further chrome belongs to the consumer.
  */
 .drag-preview-frame {
 	height: 100%;
@@ -39,28 +36,43 @@
 	cursor: grabbing;
 	pointer-events: none;
 	box-shadow: var(--wpds-elevation-sm);
-	transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
+}
 
-	@media not (prefers-reduced-motion: reduce) {
-		/*
-		 * Keyframes (not @starting-style) so each DragOverlay mount
-		 * reliably runs xs → sm; var() box-shadow pairs can fail to
-		 * interpolate in entry transitions.
-		 */
-		animation: wp-grid-drag-preview-enter var(--wpds-motion-duration-sm)
-			var(--wpds-motion-easing-balanced) both;
+.drag-preview-frame__lift {
+	height: 100%;
+	transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
+	transform-origin: center;
+}
+
+@media not (prefers-reduced-motion: reduce) {
+	.drag-preview-frame {
+		animation: wp-grid-drag-preview-shadow-enter
+			var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced) both;
+	}
+
+	.drag-preview-frame__lift {
+		animation: wp-grid-drag-preview-scale-enter
+			var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced) both;
 	}
 }
 
 @media not (prefers-reduced-motion: reduce) {
-	@keyframes wp-grid-drag-preview-enter {
+	@keyframes wp-grid-drag-preview-shadow-enter {
 		from {
 			box-shadow: var(--wpds-elevation-xs);
-			transform: scale(1);
 		}
 
 		to {
 			box-shadow: var(--wpds-elevation-sm);
+		}
+	}
+
+	@keyframes wp-grid-drag-preview-scale-enter {
+		from {
+			transform: scale(1);
+		}
+
+		to {
 			transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
 		}
 	}
@@ -69,26 +81,67 @@
 /*
  * Applied by @dnd-kit `DragOverlay` drop side-effects while the
  * default overlay transform runs; duration matches
- * `createDashboardDragDropAnimation` (200ms / md token).
+ * `createDashboardDragDropAnimation` (200ms / md token). Use keyframed
+ * exit (not transition) so scale does not snap when the enter animation
+ * is replaced.
  */
+@media not (prefers-reduced-motion: reduce) {
+	.drag-preview-frame.dragPreviewFrameExiting {
+		animation: wp-grid-drag-preview-shadow-exit
+			var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced)
+			forwards;
+	}
+
+	.drag-preview-frame.dragPreviewFrameExiting .drag-preview-frame__lift {
+		animation: wp-grid-drag-preview-scale-exit
+			var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced)
+			forwards;
+	}
+
+	@keyframes wp-grid-drag-preview-shadow-exit {
+		from {
+			box-shadow: var(--wpds-elevation-sm);
+		}
+
+		to {
+			box-shadow: var(--wpds-elevation-xs);
+		}
+	}
+
+	@keyframes wp-grid-drag-preview-scale-exit {
+		from {
+			transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
+		}
+
+		to {
+			transform: scale(1);
+		}
+	}
+}
+
 .drag-preview-frame.dragPreviewFrameExiting {
-	animation: none;
-	transform: scale(1);
 	box-shadow: var(--wpds-elevation-xs);
-	transition:
-		transform var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced),
-		box-shadow var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced);
+}
+
+.drag-preview-frame.dragPreviewFrameExiting .drag-preview-frame__lift {
+	transform: scale(1);
 }
 
 @media (prefers-reduced-motion: reduce) {
 	.drag-preview-frame {
 		box-shadow: var(--wpds-elevation-sm);
+	}
+
+	.drag-preview-frame__lift {
 		transform: none;
-		transition: none;
 	}
 
 	.drag-preview-frame.dragPreviewFrameExiting {
 		box-shadow: var(--wpds-elevation-xs);
+		transition: none;
+	}
+
+	.drag-preview-frame.dragPreviewFrameExiting .drag-preview-frame__lift {
 		transition: none;
 	}
 }

--- a/packages/grid/src/dashboard-lanes/lanes.module.css
+++ b/packages/grid/src/dashboard-lanes/lanes.module.css
@@ -47,12 +47,14 @@
 
 @media not (prefers-reduced-motion: reduce) {
 	.drag-preview-frame {
-		animation: wp-grid-drag-preview-shadow-enter
+		animation:
+			wp-grid-drag-preview-shadow-enter
 			var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced) both;
 	}
 
 	.drag-preview-frame__lift {
-		animation: wp-grid-drag-preview-scale-enter
+		animation:
+			wp-grid-drag-preview-scale-enter
 			var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced) both;
 	}
 }
@@ -88,13 +90,15 @@
  */
 @media not (prefers-reduced-motion: reduce) {
 	.drag-preview-frame.dragPreviewFrameExiting {
-		animation: wp-grid-drag-preview-shadow-exit
+		animation:
+			wp-grid-drag-preview-shadow-exit
 			var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced)
 			forwards;
 	}
 
 	.drag-preview-frame.dragPreviewFrameExiting .drag-preview-frame__lift {
-		animation: wp-grid-drag-preview-scale-exit
+		animation:
+			wp-grid-drag-preview-scale-exit
 			var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced)
 			forwards;
 	}

--- a/packages/grid/src/dashboard-lanes/lanes.module.css
+++ b/packages/grid/src/dashboard-lanes/lanes.module.css
@@ -25,21 +25,56 @@
 /*
  * Functional frame for the drag-preview clone inside `<DragOverlay>`.
  * Always applied, including when the consumer passes a
- * `renderDragPreview` wrapper. Owns the lift cue (`scale`), the
- * pointer feedback (`cursor`), and the pointer pass-through during
- * the gesture. Visual chrome (shadow, radius, padding) belongs to
- * the consumer, either on the children passed to <DashboardLanes />
+ * `renderDragPreview` wrapper. Owns the lift cue (`scale` with motion
+ * tokens), drag elevation (`box-shadow` animating from resting `sm` to
+ * `lg`), matching `border-radius` so the shadow follows the card shape,
+ * the pointer feedback (`cursor`), and the pointer pass-through during
+ * the gesture. Further visual chrome (padding, inner surfaces) belongs
+ * to the consumer, either on the children passed to <DashboardLanes />
  * or via `renderDragPreview`.
  */
 .drag-preview-frame {
 	height: 100%;
-	transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
+	border-radius: var(--wpds-border-radius-lg);
 	cursor: grabbing;
 	pointer-events: none;
+	box-shadow: var(--wpds-elevation-lg);
+	transform: scale(var(--wp-grid-drag-preview-scale, 1.05));
+
+	@media not (prefers-reduced-motion: reduce) {
+		@starting-style {
+			box-shadow: var(--wpds-elevation-sm);
+			transform: scale(1);
+		}
+
+		transition:
+			transform var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced),
+			box-shadow var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced);
+	}
+}
+
+/*
+ * Applied by @dnd-kit `DragOverlay` drop side-effects while the
+ * default overlay transform runs; duration matches
+ * `createDashboardDragDropAnimation` (200ms / md token).
+ */
+.drag-preview-frame.dragPreviewFrameExiting {
+	transform: scale(1);
+	box-shadow: var(--wpds-elevation-sm);
+	transition:
+		transform var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced),
+		box-shadow var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced);
 }
 
 @media (prefers-reduced-motion: reduce) {
 	.drag-preview-frame {
+		box-shadow: var(--wpds-elevation-lg);
 		transform: none;
+		transition: none;
+	}
+
+	.drag-preview-frame.dragPreviewFrameExiting {
+		box-shadow: var(--wpds-elevation-sm);
+		transition: none;
 	}
 }

--- a/packages/grid/src/dashboard-lanes/lanes.module.css
+++ b/packages/grid/src/dashboard-lanes/lanes.module.css
@@ -27,13 +27,15 @@
  * Always applied, including when the consumer passes a
  * `renderDragPreview` wrapper. Owns the lift cue (`scale` with motion
  * tokens), drag elevation (`box-shadow` animating from resting `sm` to
- * `lg`), the pointer feedback (`cursor`), and the pointer pass-through during
- * the gesture. Further visual chrome (padding, inner surfaces) belongs
+ * `lg`), optional corner radius via `--wp-grid-drag-preview-radius`, the
+ * pointer feedback (`cursor`), and the pointer pass-through during the
+ * gesture. Further visual chrome (padding, inner surfaces) belongs
  * to the consumer, either on the children passed to <DashboardLanes />
  * or via `renderDragPreview`.
  */
 .drag-preview-frame {
 	height: 100%;
+	border-radius: var(--wp-grid-drag-preview-radius, 0);
 	cursor: grabbing;
 	pointer-events: none;
 	box-shadow: var(--wpds-elevation-lg);

--- a/packages/grid/src/dashboard-lanes/lanes.module.css
+++ b/packages/grid/src/dashboard-lanes/lanes.module.css
@@ -28,14 +28,15 @@
  * `renderDragPreview` wrapper. The outer frame has no `transform` so
  * @dnd-kit’s drop translation matches the placeholder; scale lives on
  * `__lift` (see dnd-kit #398). Owns elevation, radius, cursor, and
- * pointer pass-through. Further chrome belongs to the consumer.
+ * pointer pass-through. Further chrome belongs to the consumer. Drag
+ * elevation animates `xs` → `md` so it reads above edit tiles at `xs`.
  */
 .drag-preview-frame {
 	height: 100%;
 	border-radius: var(--wp-grid-drag-preview-radius, 0);
 	cursor: grabbing;
 	pointer-events: none;
-	box-shadow: var(--wpds-elevation-sm);
+	box-shadow: var(--wpds-elevation-md);
 }
 
 .drag-preview-frame__lift {
@@ -63,7 +64,7 @@
 		}
 
 		to {
-			box-shadow: var(--wpds-elevation-sm);
+			box-shadow: var(--wpds-elevation-md);
 		}
 	}
 
@@ -100,7 +101,7 @@
 
 	@keyframes wp-grid-drag-preview-shadow-exit {
 		from {
-			box-shadow: var(--wpds-elevation-sm);
+			box-shadow: var(--wpds-elevation-md);
 		}
 
 		to {
@@ -129,7 +130,7 @@
 
 @media (prefers-reduced-motion: reduce) {
 	.drag-preview-frame {
-		box-shadow: var(--wpds-elevation-sm);
+		box-shadow: var(--wpds-elevation-md);
 	}
 
 	.drag-preview-frame__lift {

--- a/packages/grid/src/shared/drag-overlay-drop-animation.ts
+++ b/packages/grid/src/shared/drag-overlay-drop-animation.ts
@@ -14,18 +14,18 @@ import type { DropAnimation } from '@dnd-kit/core';
 const DROP_ANIMATION_DURATION_MS = 200;
 const DROP_ANIMATION_EASING = 'cubic-bezier(0.4, 0, 0.2, 1)';
 
-export const DASHBOARD_DRAG_PREVIEW_FRAME_SELECTOR =
-	'[data-wp-dashboard-drag-preview-frame]';
-
 /**
  * Composes @dnd-kit/core’s default overlay drop animation with a CSS
  * transition on the inner drag preview frame (scale + shadow) so
  * release does not snap before the overlay unmounts.
  *
- * @param exitingFrameClassName Hashed class from `*.module.css` (e.g.
- *                              `styles.dragPreviewFrameExiting`).
+ * @param dragPreviewFrameClassName Hashed class for `.drag-preview-frame`
+ *                                  (e.g. `styles[ 'drag-preview-frame' ]`).
+ * @param exitingFrameClassName     Hashed class for the exit state (e.g.
+ *                                  `styles.dragPreviewFrameExiting`).
  */
 export function createDashboardDragDropAnimation(
+	dragPreviewFrameClassName: string,
 	exitingFrameClassName: string
 ): DropAnimation {
 	return {
@@ -41,9 +41,9 @@ export function createDashboardDragDropAnimation(
 				},
 			} )( args );
 
-			const frame = args.dragOverlay.node.querySelector(
-				DASHBOARD_DRAG_PREVIEW_FRAME_SELECTOR
-			);
+			const frame = args.dragOverlay.node.getElementsByClassName(
+				dragPreviewFrameClassName
+			)[ 0 ] as HTMLElement | undefined;
 
 			if ( frame ) {
 				frame.classList.add( exitingFrameClassName );

--- a/packages/grid/src/shared/drag-overlay-drop-animation.ts
+++ b/packages/grid/src/shared/drag-overlay-drop-animation.ts
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import {
+	defaultDropAnimation,
+	defaultDropAnimationSideEffects,
+} from '@dnd-kit/core';
+import type { DropAnimation } from '@dnd-kit/core';
+
+/**
+ * Matches `--wpds-motion-duration-md` (200ms) and
+ * `--wpds-motion-easing-balanced` on the drag preview frame exit.
+ */
+const DROP_ANIMATION_DURATION_MS = 200;
+const DROP_ANIMATION_EASING = 'cubic-bezier(0.4, 0, 0.2, 1)';
+
+export const DASHBOARD_DRAG_PREVIEW_FRAME_SELECTOR =
+	'[data-wp-dashboard-drag-preview-frame]';
+
+/**
+ * Composes @dnd-kit/core’s default overlay drop animation with a CSS
+ * transition on the inner drag preview frame (scale + shadow) so
+ * release does not snap before the overlay unmounts.
+ *
+ * @param exitingFrameClassName Hashed class from `*.module.css` (e.g.
+ *                              `styles.dragPreviewFrameExiting`).
+ */
+export function createDashboardDragDropAnimation(
+	exitingFrameClassName: string
+): DropAnimation {
+	return {
+		...defaultDropAnimation,
+		duration: DROP_ANIMATION_DURATION_MS,
+		easing: DROP_ANIMATION_EASING,
+		sideEffects( args ) {
+			const cleanupDefault = defaultDropAnimationSideEffects( {
+				styles: {
+					active: {
+						opacity: '0',
+					},
+				},
+			} )( args );
+
+			const frame = args.dragOverlay.node.querySelector(
+				DASHBOARD_DRAG_PREVIEW_FRAME_SELECTOR
+			);
+
+			if ( frame ) {
+				frame.classList.add( exitingFrameClassName );
+			}
+
+			return () => {
+				cleanupDefault?.();
+				if ( frame ) {
+					frame.classList.remove( exitingFrameClassName );
+				}
+			};
+		},
+	};
+}

--- a/packages/grid/src/shared/drag-overlay-drop-animation.ts
+++ b/packages/grid/src/shared/drag-overlay-drop-animation.ts
@@ -7,22 +7,19 @@ import {
 } from '@dnd-kit/core';
 import type { DropAnimation } from '@dnd-kit/core';
 
-/**
- * Matches `--wpds-motion-duration-md` (200ms) and
- * `--wpds-motion-easing-balanced` on the drag preview frame exit.
- */
-const DROP_ANIMATION_DURATION_MS = 200;
+/** Matches `--wpds-motion-duration-md` on the drag preview frame exit. */
+export const DROP_ANIMATION_DURATION_MS = 200;
+
+/** Matches `--wpds-motion-easing-balanced` on the drag preview frame exit. */
 const DROP_ANIMATION_EASING = 'cubic-bezier(0.4, 0, 0.2, 1)';
 
 /**
- * Composes @dnd-kit/core’s default overlay drop animation with a CSS
- * transition on the inner drag preview frame (scale + shadow) so
- * release does not snap before the overlay unmounts.
+ * Composes @dnd-kit/core’s default overlay drop translation with preview
+ * exit keyframes (via side effects). When the pointer never moves, @dnd-kit
+ * skips the drop animation and these side effects do not run.
  *
- * @param dragPreviewFrameClassName Hashed class for `.drag-preview-frame`
- *                                  (e.g. `styles[ 'drag-preview-frame' ]`).
- * @param exitingFrameClassName     Hashed class for the exit state (e.g.
- *                                  `styles.dragPreviewFrameExiting`).
+ * @param dragPreviewFrameClassName Hashed class for `.drag-preview-frame`.
+ * @param exitingFrameClassName     Hashed class for the exit state.
  */
 export function createDashboardDragDropAnimation(
 	dragPreviewFrameClassName: string,
@@ -46,6 +43,15 @@ export function createDashboardDragDropAnimation(
 			)[ 0 ] as HTMLElement | undefined;
 
 			if ( frame ) {
+				frame
+					.getAnimations()
+					.forEach( ( animation ) => animation.cancel() );
+				const lift = frame.firstElementChild;
+				if ( lift instanceof HTMLElement ) {
+					lift.getAnimations().forEach( ( animation ) =>
+						animation.cancel()
+					);
+				}
 				frame.classList.add( exitingFrameClassName );
 			}
 

--- a/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
@@ -11,12 +11,12 @@
 }
 
 .tileEditMode {
-	box-shadow: var(--wpds-elevation-sm);
+	box-shadow: var(--wpds-elevation-xs);
 }
 
 .tileEditMode:hover,
 .tileEditMode:focus-visible {
-	box-shadow: var(--wpds-elevation-md);
+	box-shadow: var(--wpds-elevation-sm);
 }
 
 /*
@@ -27,7 +27,7 @@
  */
 :global([data-wp-grid-resizing]) .tileEditMode:hover,
 :global([data-wp-grid-resizing]) .tileEditMode:focus-visible {
-	box-shadow: var(--wpds-elevation-sm);
+	box-shadow: var(--wpds-elevation-xs);
 }
 
 .tileEditMode:focus-visible {
@@ -40,7 +40,7 @@
  * `height: 100%` keeps the inner `.tile` height: 100% chain alive
  * (without it, the wrapper auto-sizes and the cloned tile collapses
  * to content height). Drag elevation is owned by the grid
- * `.drag-preview-frame` (`lg` while dragging); strip the cloned tile shadow so it
+ * `.drag-preview-frame` (`sm` while dragging); strip the cloned tile shadow so it
  * does not stack on the frame.
  */
 .dragPreview {

--- a/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
@@ -10,7 +10,7 @@
 }
 
 .tileEditMode {
-	box-shadow: var(--wpds-elevation-xs);
+	box-shadow: var(--wpds-elevation-sm);
 }
 
 .tileEditMode:hover,
@@ -26,7 +26,7 @@
  */
 :global([data-wp-grid-resizing]) .tileEditMode:hover,
 :global([data-wp-grid-resizing]) .tileEditMode:focus-visible {
-	box-shadow: var(--wpds-elevation-xs);
+	box-shadow: var(--wpds-elevation-sm);
 }
 
 .tileEditMode:focus-visible {
@@ -38,16 +38,16 @@
  * Wrapper applied through `renderDragPreview` on @wordpress/grid.
  * `height: 100%` keeps the inner `.tile` height: 100% chain alive
  * (without it, the wrapper auto-sizes and the cloned tile collapses
- * to content height). Using an ancestor class to bump the shadow
- * lets the dragged-state shadow win over the persistent one without
- * stacking two box-shadows on the same element.
+ * to content height). Drag elevation is owned by the grid
+ * `.drag-preview-frame` (`lg` while dragging); strip the cloned tile shadow so it
+ * does not stack on the frame.
  */
 .dragPreview {
 	height: 100%;
 }
 
 .dragPreview .tile {
-	box-shadow: var(--wpds-elevation-md);
+	box-shadow: none;
 }
 
 @media not ( prefers-reduced-motion ) {

--- a/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
@@ -4,6 +4,15 @@
 	--wp-grid-placeholder-radius: var(--wpds-border-radius-lg);
 }
 
+/*
+ * Rounded drag shadow: `@wordpress/grid` keeps the overlay frame
+ * radius-agnostic; match tile / Card radius here (frame exposes
+ * `data-wp-dashboard-drag-preview-frame`).
+ */
+.grid :global([data-wp-dashboard-drag-preview-frame]) {
+	border-radius: var(--wpds-border-radius-lg);
+}
+
 .tile {
 	height: 100%;
 	border-radius: var(--wpds-border-radius-lg);

--- a/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
@@ -1,16 +1,8 @@
 .grid {
 	width: 100%;
-	/* Drag placeholder outline radius: matches `.tile` and `@wordpress/ui` Card (`--wpds-border-radius-lg`). */
+	/* Placeholder and drag-preview radii: match `.tile` and `@wordpress/ui` Card (`--wpds-border-radius-lg`). */
 	--wp-grid-placeholder-radius: var(--wpds-border-radius-lg);
-}
-
-/*
- * Rounded drag shadow: `@wordpress/grid` keeps the overlay frame
- * radius-agnostic; match tile / Card radius here (frame exposes
- * `data-wp-dashboard-drag-preview-frame`).
- */
-.grid :global([data-wp-dashboard-drag-preview-frame]) {
-	border-radius: var(--wpds-border-radius-lg);
+	--wp-grid-drag-preview-radius: var(--wpds-border-radius-lg);
 }
 
 .tile {

--- a/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
@@ -10,23 +10,11 @@
 	border-radius: var(--wpds-border-radius-lg);
 }
 
-.tileEditMode {
-	box-shadow: var(--wpds-elevation-xs);
-}
-
-.tileEditMode:hover,
-.tileEditMode:focus-visible {
-	box-shadow: var(--wpds-elevation-sm);
-}
-
 /*
- * While a resize is in progress, the pointer often sits over the tile;
- * keep resting elevation so the hover lift does not flicker or fight the
- * gesture. `data-wp-grid-resizing` is set on `@wordpress/grid` surface
- * roots for the duration of the resize.
+ * Edit-mode tiles stay at resting elevation (`xs`) on hover; only the
+ * drag preview (`.drag-preview-frame` on `@wordpress/grid`) lifts to `md`.
  */
-:global([data-wp-grid-resizing]) .tileEditMode:hover,
-:global([data-wp-grid-resizing]) .tileEditMode:focus-visible {
+.tileEditMode {
 	box-shadow: var(--wpds-elevation-xs);
 }
 
@@ -40,7 +28,7 @@
  * `height: 100%` keeps the inner `.tile` height: 100% chain alive
  * (without it, the wrapper auto-sizes and the cloned tile collapses
  * to content height). Drag elevation is owned by the grid
- * `.drag-preview-frame` (`sm` while dragging); strip the cloned tile shadow so it
+ * `.drag-preview-frame` (`md` while dragging); strip the cloned tile shadow so it
  * does not stack on the frame.
  */
 .dragPreview {
@@ -49,10 +37,4 @@
 
 .dragPreview .tile {
 	box-shadow: none;
-}
-
-@media not ( prefers-reduced-motion ) {
-	.tile {
-		transition: box-shadow var(--wpds-motion-duration-md) var(--wpds-motion-easing-subtle);
-	}
 }


### PR DESCRIPTION
## What

- **`@wordpress/grid` (`DashboardGrid` / `DashboardLanes`):** The drag-preview **functional frame** (`.drag-preview-frame`) uses **wpds motion** tokens for **scale** and **box-shadow** on pick-up (**sm → lg**), **`prefers-reduced-motion`** handling (static **lg** shadow, no scale motion), and a **drop exit** path: a shared helper composes **`defaultDropAnimation`** from **`@dnd-kit/core`** with **`defaultDropAnimationSideEffects`** and toggles an exit class so **scale** and **shadow** ease back to resting instead of snapping when the overlay tears down. The frame exposes **`data-wp-dashboard-drag-preview-frame`** for consumer styling and **does not** set **`border-radius`** (package stays shape-agnostic).
- **Widget dashboard:** Tiles use **sm** resting, **md** hover/focus, **sm** again when the grid is resizing and hover is suppressed; **drag clone** tile shadow is **none** so elevation stays on the grid frame. **Rounded drag shadow** is applied only here via **`.grid :global([data-wp-dashboard-drag-preview-frame])`** and **`--wpds-border-radius-lg`**, aligned with **`.tile`** / Card radius.

## Why

- Drag **pick-up** and **release** should feel consistent with the design system (**motion + elevation tokens**) and **not snap** on drop when React clears the overlay.
- **Elevation** should read as **rest → hover → drag** without **stacking** two shadows on the clone and the frame.

## How

- **CSS:** **`@starting-style`** + **`transition`** on **`transform`** and **`box-shadow`** for enter; **`.dragPreviewFrameExiting`** uses **`md`** duration + **balanced** easing for exit; reduced-motion rules disable motion where appropriate.
- **JS:** **`packages/grid/src/shared/drag-overlay-drop-animation.ts`** — spreads **`defaultDropAnimation`**, aligns duration/easing with **`md` / balanced**, wraps **`defaultDropAnimationSideEffects`** (active opacity during drop), adds/removes the exit class on **`[data-wp-dashboard-drag-preview-frame]`**.
- **Markup:** Preview root **`data-wp-dashboard-drag-preview-frame`**; **`DragOverlay`** receives **`dropAnimation={ dashboardDragDropAnimation }`** in both grid and lanes.
- **Dashboard-only radius:** **`widgets.module.css`** targets **`[data-wp-dashboard-drag-preview-frame]`** under **`.grid`** so masonry and fixed grid both get the same rounded shadow when that wrapper is used.

## Screenshots
## Video

### Before

https://github.com/user-attachments/assets/41b57bf8-ec3a-4193-860f-268a84ab62b1

### After

https://github.com/user-attachments/assets/5c06fce5-5259-417c-9fe4-9c256eb87faf

## Use of AI

Made with Cursor