### PR TITLE
Guidelines: Fix fatal when `rest_api_init` fires before init

### DIFF
--- a/lib/experimental/guidelines/index.php
+++ b/lib/experimental/guidelines/index.php
@@ -21,6 +21,24 @@ require_once __DIR__ . '/class-gutenberg-content-guidelines-rest-controller.php'
  */
 add_action( 'init', array( 'Gutenberg_Guidelines_Post_Type', 'register' ) );
 
+/*
+ * Ensure the post type is registered before any other `rest_api_init` callback
+ * runs. `init` normally fires before `rest_api_init`, but anything that calls
+ * `rest_get_server()` early (e.g. from `plugins_loaded`) fires `rest_api_init`
+ * before `init` priority 10. The callbacks below — both `register_post_meta`
+ * and the controller instantiations — dereference the post type object and
+ * would fatal (or trip `_doing_it_wrong`) without this guard.
+ */
+add_action(
+	'rest_api_init',
+	static function () {
+		if ( ! post_type_exists( Gutenberg_Guidelines_Post_Type::POST_TYPE ) ) {
+			Gutenberg_Guidelines_Post_Type::register();
+		}
+	},
+	1
+);
+
 // Register post meta once the REST API loads and the block registry is available.
 add_action( 'rest_api_init', array( 'Gutenberg_Guidelines_Post_Type', 'register_post_meta' ) );
 

--- a/phpunit/experimental/guidelines/class-gutenberg-content-guidelines-revisions-controller-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-content-guidelines-revisions-controller-test.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Tests for Gutenberg_Content_Guidelines_Revisions_Controller initialization.
+ *
+ * @package gutenberg
+ */
+class Gutenberg_Content_Guidelines_Revisions_Controller_Test extends WP_UnitTestCase {
+
+	/**
+	 * Re-register the post type after each test, since some tests
+	 * unregister it to simulate ordering edge cases.
+	 */
+	public function tear_down() {
+		if ( ! post_type_exists( Gutenberg_Guidelines_Post_Type::POST_TYPE ) ) {
+			Gutenberg_Guidelines_Post_Type::register();
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * `rest_api_init` can fire before `init` priority 10 when something
+	 * (e.g. an early `rest_get_server()` call from `plugins_loaded`)
+	 * boots the REST server early. In that window the `wp_guideline`
+	 * post type is not yet registered, so both controllers instantiated
+	 * by the `rest_api_init` handler dereference a null post type object
+	 * in their parent constructors and fatal — the singleton REST
+	 * controller via WP_REST_Posts_Controller::__construct, the revisions
+	 * controller via WP_REST_Revisions_Controller::__construct.
+	 *
+	 * The handler in lib/experimental/guidelines/index.php must defend
+	 * against this ordering by ensuring the post type exists before
+	 * instantiating the controllers.
+	 */
+	public function test_rest_api_init_does_not_fatal_when_post_type_not_yet_registered() {
+		unregister_post_type( Gutenberg_Guidelines_Post_Type::POST_TYPE );
+		$this->assertFalse(
+			post_type_exists( Gutenberg_Guidelines_Post_Type::POST_TYPE ),
+			'Pre-condition: post type must be unregistered to exercise the ordering bug.'
+		);
+
+		do_action( 'rest_api_init' );
+
+		$this->assertTrue(
+			post_type_exists( Gutenberg_Guidelines_Post_Type::POST_TYPE ),
+			'The rest_api_init handler should defensively register the post type.'
+		);
+	}
+}


### PR DESCRIPTION
## What?

<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Ensures the `wp_guideline` custom post type is registered before any `rest_api_init` callback runs, so the Guidelines feature does not fatal when `rest_api_init` fires before `init` priority 10.

## Why?

`Gutenberg_Guidelines_Post_Type::register()` is hooked to `init` at priority 10. The `rest_api_init` callbacks in `lib/experimental/guidelines/index.php` then assume the post type exists:

- `Gutenberg_Content_Guidelines_REST_Controller` and `Gutenberg_Content_Guidelines_Revisions_Controller` are instantiated via `parent::__construct( 'wp_guideline' )`, where the WP core parent constructors dereference `get_post_type_object( $parent_post_type )` without a null check (`WP_REST_Posts_Controller::__construct`, `WP_REST_Revisions_Controller::__construct`).
- `Gutenberg_Guidelines_Post_Type::register_post_meta()` registers meta with revisions support, which `_doing_it_wrong`s if the parent post type does not yet declare `revisions` support.

`init` normally fires before `rest_api_init`, but anything that calls `rest_get_server()` early — for example a host plugin that needs an internal REST dispatch during `plugins_loaded` — boots the REST server, which fires `rest_api_init` immediately. In that window the post type is not yet registered and the callbacks above fatal.

This was observed in production on WordPress.com when activating the Gutenberg `gutenberg-guidelines` experiment alongside hosting code that boots the REST server during `plugins_loaded`:

```
Fatal error: Uncaught Error: Call to a member function get_rest_controller() on null
  in wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php:61
```

## How?

Adds a single priority-1 `rest_api_init` callback that registers the post type if it does not already exist:
```php
add_action(
    'rest_api_init',
    static function () {
        if ( ! post_type_exists( Gutenberg_Guidelines_Post_Type::POST_TYPE ) ) {
            Gutenberg_Guidelines_Post_Type::register();
        }
    },
    1
);

Running at priority 1 means every subsequent rest_api_init callback — including register_post_meta and the controller instantiations — sees a fully-registered post type regardless of how the REST server was booted. The normal init priority-10 registration remains in place; this is purely a defensive guard for the early-boot path.

## Testing Instructions

npm run test:unit:php:base -- --filter test_rest_api_init_does_not_fatal_when_post_type_not_yet_registered

The new test (phpunit/experimental/guidelines/class-gutenberg-content-guidelines-revisions-controller-test.php) unregisters the post type and fires rest_api_init directly, simulating the ordering scenario. Without the fix it errors on the null post type object; with the fix it passes.