### PR TITLE
Draggable: Scope the clone's fallback `z-index` to non-slot placements

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `Draggable`: Render the drag clone inside the `@wordpress/ui` compat overlay slot so it shares stacking with `@wordpress/ui` overlays opened mid-drag. Auto-enabled in WordPress environments; other hosts can opt in via `useEnableWpCompatOverlaySlot()` ([#78183](https://github.com/WordPress/gutenberg/pull/78183)).
 
+### Bug Fixes
+
+-   `Draggable`: Drop the fallback `z-index` when the clone is routed into the `@wordpress/ui` compat overlay slot, so DOM order decides stacking against other slot residents (e.g. `@wordpress/ui` portals).
+
 ## 33.1.0 (2026-05-14)
 
 ### Enhancements

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,11 +4,7 @@
 
 ### Enhancements
 
--   `Draggable`: Render the drag clone inside the `@wordpress/ui` compat overlay slot so it shares stacking with `@wordpress/ui` overlays opened mid-drag. Auto-enabled in WordPress environments; other hosts can opt in via `useEnableWpCompatOverlaySlot()` ([#78183](https://github.com/WordPress/gutenberg/pull/78183)).
-
-### Bug Fixes
-
--   `Draggable`: Drop the fallback `z-index` when the clone is routed into the `@wordpress/ui` compat overlay slot, so DOM order decides stacking against other slot residents (e.g. `@wordpress/ui` portals).
+-   `Draggable`: Render the drag clone inside the `@wordpress/ui` compat overlay slot so it shares stacking with `@wordpress/ui` overlays opened mid-drag. Auto-enabled in WordPress environments; other hosts can opt in via `useEnableWpCompatOverlaySlot()` ([#78183](https://github.com/WordPress/gutenberg/pull/78183), [#78354](https://github.com/WordPress/gutenberg/pull/78354)).
 
 ## 33.1.0 (2026-05-14)
 

--- a/packages/components/src/draggable/index.tsx
+++ b/packages/components/src/draggable/index.tsx
@@ -144,8 +144,8 @@ export function Draggable( {
 
 		cloneWrapper.classList.add( ...cloneWrapperClasses );
 
-		// Marks the in-slot case so `.clone`'s fallback `z-index`
-		// can be reset (see `style.module.scss`).
+		// Marks the in-slot case so the fallback `z-index` is skipped
+		// (see `style.module.scss`).
 		const inSlotClass = styles[ 'is-in-compat-slot' ];
 		if ( compatSlot && inSlotClass ) {
 			cloneWrapper.classList.add( inSlotClass );

--- a/packages/components/src/draggable/index.tsx
+++ b/packages/components/src/draggable/index.tsx
@@ -144,6 +144,13 @@ export function Draggable( {
 
 		cloneWrapper.classList.add( ...cloneWrapperClasses );
 
+		// Marks the in-slot case so `.clone`'s fallback `z-index`
+		// can be reset (see `style.module.scss`).
+		const inSlotClass = styles[ 'is-in-compat-slot' ];
+		if ( compatSlot && inSlotClass ) {
+			cloneWrapper.classList.add( inSlotClass );
+		}
+
 		if ( cloneClassname ) {
 			cloneWrapper.classList.add( cloneClassname );
 		}

--- a/packages/components/src/draggable/index.tsx
+++ b/packages/components/src/draggable/index.tsx
@@ -144,8 +144,6 @@ export function Draggable( {
 
 		cloneWrapper.classList.add( ...cloneWrapperClasses );
 
-		// Marks the in-slot case so the fallback `z-index` is skipped
-		// (see `style.module.scss`).
 		const inSlotClass = styles[ 'is-in-compat-slot' ];
 		if ( compatSlot && inSlotClass ) {
 			cloneWrapper.classList.add( inSlotClass );

--- a/packages/components/src/draggable/style.module.scss
+++ b/packages/components/src/draggable/style.module.scss
@@ -13,17 +13,13 @@
 	padding: 0; // Should match clonePadding variable.
 	background: transparent;
 	pointer-events: none;
-	// Stacking fallback for when the clone is not routed into the
-	// `@wordpress/ui` compat overlay slot.
-	z-index: z-index(".components-draggable__clone");
 }
 
-// The slot already supplies an isolated stacking context, so the
-// fallback `z-index` would only bias intra-slot ordering against
-// other slot residents (e.g. `@wordpress/ui` portals). Let DOM
-// order decide instead.
-.clone.is-in-compat-slot {
-	z-index: auto;
+// Apply the stacking fallback only outside the `@wordpress/ui` compat
+// overlay slot — inside it, the slot's isolated stacking context
+// already handles ordering.
+.clone:not(.is-in-compat-slot) {
+	z-index: z-index(".components-draggable__clone");
 }
 
 // Keep this selector global so external code that toggles the same

--- a/packages/components/src/draggable/style.module.scss
+++ b/packages/components/src/draggable/style.module.scss
@@ -18,6 +18,14 @@
 	z-index: z-index(".components-draggable__clone");
 }
 
+// The slot already supplies an isolated stacking context, so the
+// fallback `z-index` would only bias intra-slot ordering against
+// other slot residents (e.g. `@wordpress/ui` portals). Let DOM
+// order decide instead.
+.clone.is-in-compat-slot {
+	z-index: auto;
+}
+
 // Keep this selector global so external code that toggles the same
 // body class (e.g. block-editor keyboard drag) gets the same cursor.
 :global(body.is-dragging-components-draggable) {


### PR DESCRIPTION
## What?

Follow up to #78183. Drop the drag clone's legacy `z-index` when it lands inside the `@wordpress/ui` compat overlay slot. Addresses [this review comment](https://github.com/WordPress/gutenberg/pull/78183#issuecomment-4461172516).

## Why?

The compat slot already supplies an isolated stacking context. Inside it, the legacy `z-index` only biases _intra-slot_ ordering — currently pinning the clone above other slot residents (e.g. `@wordpress/ui` portals from #78095). Letting DOM order decide is the more conservative default.

<details><summary>More on the stacking interaction</summary>

The compat slot in `@wordpress/ui` is `position: fixed; z-index: 1000000003; isolation: isolate`. Inside it, any positive `z-index` resolves only against siblings inside the slot. The clone's legacy `z-index: 1000000000` was originally chosen to compete with the page; carrying it into the slot was an opinionated stacking choice we never explicitly made.

For the fallback paths (non-WP hosts, cross-document drags) the legacy `z-index` still applies — those placements have to compete with the rest of the page.

</details>

## How?

Add an `is-in-compat-slot` modifier class on the clone wrapper when (and only when) `compatSlot` is non-null, and gate the fallback `z-index` rule with `:not(.is-in-compat-slot)`.

<details><summary>Why a modifier class rather than a structural CSS selector?</summary>

The CSS-only alternative would be `[data-wp-compat-overlay-slot] > .clone { z-index: auto; }`. That works, but it couples the override to the slot's DOM relationship; the modifier-class approach keeps the conditional styling intent at the JS call site (where the `compatSlot` branch already lives) and the CSS rule self-contained.

</details>

## Testing Instructions

1. Open Storybook (`npm run storybook:dev`) → **Playground / Debug fixtures / Draggable cross-document fallback** → drag inside the iframe; clone still renders with the legacy z-index.
2. **Playground / Debug fixtures / WP Compat Overlay Slot** → confirm `@wordpress/ui` tooltips/portals continue stacking above `@wordpress/components` overlay hosts.
3. In a WP environment, drag a block; clone still appears in `[data-wp-compat-overlay-slot]` above other overlays.

## Use of AI Tools

Cursor + Claude 4.7