### PR TITLE
Automated Testing: Enable concurrency for ESLint

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
 		"lint": "concurrently \"npm run lint:lockfile\" \"npm run lint:tsconfig\" \"npm run lint:js\" \"npm run lint:pkg-json\" \"npm run lint:css\"",
 		"lint:css": "wp-scripts lint-style \"**/*.scss\" \"**/*.module.css\"",
 		"lint:css:fix": "npm run lint:css -- --fix",
-		"lint:js": "node ./tools/eslint/lint-js.cjs",
+		"lint:js": "node ./tools/eslint/lint-js.cjs --concurrency=auto",
 		"lint:js:fix": "npm run lint:js -- --fix",
 		"lint:js:prune-suppressions": "npm run lint:js -- --prune-suppressions",
 		"lint:lockfile": "npm run --workspace @wordpress/validation-tools validate-package-lock --",


### PR DESCRIPTION
## What?

Updates `npm run lint:js` command to enable [multithreading](https://eslint.org/blog/2025/08/multithread-linting/).


Separately, I plan to explore [caching](https://eslint.org/docs/latest/use/command-line-interface#caching) for compounding performance gains (already validated locally).

## Why?

Improved performance.

Example:

Control: https://github.com/WordPress/gutenberg/actions/runs/25930379921/job/76222446354
Experiment: https://github.com/WordPress/gutenberg/actions/runs/25932422473/job/76229319095

Before: 5m27s
After: 4m7s
Diff: -1m20s (-24.5%)

## How?

Add `--concurrent=auto` flag.

## Testing Instructions

Verify that `npm run lint:js` passes.

Some additional things worth testing that I'll double-check next week:

- Stale suppressions detection in `tools/eslint/lint-js.cjs` wrapper
- `lint-staged` behavior.

## Use of AI Tools

Researched with Cursor + Claude Opus 4.7, implemented manually.