### PR TITLE
Use WCIcon alias for component Icon imports

### DIFF
--- a/packages/block-editor/src/components/audio-player/index.native.js
+++ b/packages/block-editor/src/components/audio-player/index.native.js
@@ -14,7 +14,7 @@ import { default as VideoPlayer } from 'react-native-video';
  * WordPress dependencies
  */
 import { View } from '@wordpress/primitives';
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 import { withPreferredColorScheme } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { audio, cautionFilled } from '@wordpress/icons';
@@ -160,13 +160,17 @@ function Player( {
 		>
 			<View style={ containerStyle }>
 				<View style={ iconContainerStyle }>
-					<Icon icon={ audio } style={ finalIconStyle } size={ 24 } />
+					<WCIcon
+						icon={ audio }
+						style={ finalIconStyle }
+						size={ 24 }
+					/>
 				</View>
 				<View style={ titleContainerStyle }>
 					<Text style={ titleStyle }>{ title }</Text>
 					<View style={ styles.subtitleContainer }>
 						{ isUploadFailed && (
-							<Icon
+							<WCIcon
 								icon={ cautionFilled }
 								style={ {
 									...styles.errorIcon,

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -8,7 +8,7 @@ import clsx from 'clsx';
  */
 import {
 	Button,
-	Icon,
+	Icon as WCIcon,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { Text, Stack } from '@wordpress/ui';
@@ -179,7 +179,7 @@ function BlockCard( {
 						) }
 						{ isChild && (
 							<span className="block-editor-block-card__child-indicator-icon">
-								<Icon
+								<WCIcon
 									icon={ isRTL() ? arrowLeft : arrowRight }
 								/>
 							</span>

--- a/packages/block-editor/src/components/block-heading-level-dropdown/heading-level-icon.js
+++ b/packages/block-editor/src/components/block-heading-level-dropdown/heading-level-icon.js
@@ -10,7 +10,7 @@ import {
 	headingLevel6,
 	paragraph,
 } from '@wordpress/icons';
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 
 /** @typedef {React.ComponentType} ComponentType */
 
@@ -41,7 +41,7 @@ const LEVEL_TO_PATH = {
  */
 export default function HeadingLevelIcon( { level } ) {
 	if ( LEVEL_TO_PATH[ level ] ) {
-		return <Icon icon={ LEVEL_TO_PATH[ level ] } />;
+		return <WCIcon icon={ LEVEL_TO_PATH[ level ] } />;
 	}
 
 	return null;

--- a/packages/block-editor/src/components/block-icon/index.js
+++ b/packages/block-editor/src/components/block-icon/index.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 import { blockDefault } from '@wordpress/icons';
 import { memo } from '@wordpress/element';
 
@@ -18,7 +18,10 @@ function BlockIcon( { icon, showColors = false, className, context } ) {
 	}
 
 	const renderedIcon = (
-		<Icon icon={ icon && icon.src ? icon.src : icon } context={ context } />
+		<WCIcon
+			icon={ icon && icon.src ? icon.src : icon }
+			context={ context }
+		/>
 	);
 	const style = showColors
 		? {

--- a/packages/block-editor/src/components/block-icon/index.native.js
+++ b/packages/block-editor/src/components/block-icon/index.native.js
@@ -6,7 +6,7 @@ import { View } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 import { blockDefault } from '@wordpress/icons';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 
@@ -29,7 +29,7 @@ export function BlockIcon( { icon, fill, size, showColors = false } ) {
 	const iconForeground = showColors ? icon?.foreground : undefined;
 
 	const renderedIcon = (
-		<Icon
+		<WCIcon
 			icon={ icon && icon.src ? icon.src : icon }
 			fill={ fill || iconForeground || defaultFill }
 			{ ...( size && { size } ) }

--- a/packages/block-editor/src/components/block-list/block-selection-button.native.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.native.js
@@ -1,16 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { getBlockType } from '@wordpress/blocks';
+import { View, Text, TouchableOpacity } from 'react-native';
 import { BlockIcon } from '@wordpress/block-editor';
 
 /**
  * External dependencies
  */
-import { View, Text, TouchableOpacity } from 'react-native';
 
 /**
  * Internal dependencies
@@ -44,7 +44,7 @@ const BlockSelectionButton = ( {
 			>
 				{ rootClientId &&
 					rootBlockIcon && [
-						<Icon
+						<WCIcon
 							key="parent-icon"
 							size={ 24 }
 							icon={ rootBlockIcon.src }

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -8,7 +8,7 @@ import {
 	CheckboxControl,
 	Flex,
 	FlexItem,
-	Icon,
+	Icon as WCIcon,
 	Modal,
 	ToggleControl,
 } from '@wordpress/components';
@@ -153,7 +153,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 												} ) )
 											}
 										/>
-										<Icon
+										<WCIcon
 											className="block-editor-block-lock-modal__lock-icon"
 											icon={
 												lock.edit
@@ -174,7 +174,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 											} ) )
 										}
 									/>
-									<Icon
+									<WCIcon
 										className="block-editor-block-lock-modal__lock-icon"
 										icon={
 											lock.move ? lockIcon : unlockIcon
@@ -192,7 +192,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 											} ) )
 										}
 									/>
-									<Icon
+									<WCIcon
 										className="block-editor-block-lock-modal__lock-icon"
 										icon={
 											lock.remove ? lockIcon : unlockIcon

--- a/packages/block-editor/src/components/block-toolbar/switch-section-style.js
+++ b/packages/block-editor/src/components/block-toolbar/switch-section-style.js
@@ -4,7 +4,7 @@
 import {
 	ToolbarButton,
 	ToolbarGroup,
-	Icon,
+	Icon as WCIcon,
 	Path,
 	SVG,
 } from '@wordpress/components';
@@ -98,7 +98,7 @@ function SwitchSectionStyle( { clientId } ) {
 				onClick={ handleStyleSwitch }
 				label={ __( 'Shuffle styles' ) }
 			>
-				<Icon
+				<WCIcon
 					icon={ styleIcon }
 					style={ {
 						fill: activeStyleBackground || 'transparent',

--- a/packages/block-editor/src/components/block-visibility/modal.js
+++ b/packages/block-editor/src/components/block-visibility/modal.js
@@ -18,7 +18,7 @@ import {
 	CheckboxControl,
 	Flex,
 	FlexItem,
-	Icon,
+	Icon as WCIcon,
 	Modal,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -287,7 +287,7 @@ export default function BlockVisibilityModal( { clientIds, onClose } ) {
 														)
 													}
 												/>
-												<Icon
+												<WCIcon
 													icon={ icon }
 													className={ clsx( {
 														'block-editor-block-visibility-modal__options-icon--checked':

--- a/packages/block-editor/src/components/block-visibility/viewport-visibility-info.js
+++ b/packages/block-editor/src/components/block-visibility/viewport-visibility-info.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import {
-	Icon,
+	Icon as WCIcon,
 	__experimentalText as WCText,
 	__experimentalHStack as HStack,
 	privateApis as componentsPrivateApis,
@@ -130,7 +130,7 @@ export default function ViewportVisibilityInfo( { clientId } ) {
 	return (
 		<WCBadge className="block-editor-block-visibility-info">
 			<HStack spacing={ 2 } justify="start">
-				<Icon icon={ unseen } />
+				<WCIcon icon={ unseen } />
 				<WCText>{ label }</WCText>
 			</HStack>
 		</WCBadge>

--- a/packages/block-editor/src/components/inserter-button/index.native.js
+++ b/packages/block-editor/src/components/inserter-button/index.native.js
@@ -7,7 +7,7 @@ import { View, TouchableHighlight, Text } from 'react-native';
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 import { withPreferredColorScheme } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -78,7 +78,10 @@ function MenuItem( {
 					] }
 				>
 					{ blockIsNew && (
-						<Icon icon={ sparkles } style={ styles.newIndicator } />
+						<WCIcon
+							icon={ sparkles }
+							style={ styles.newIndicator }
+						/>
 					) }
 					<View style={ modalIconStyle }>
 						<BlockIcon

--- a/packages/block-editor/src/components/inserter/panel.js
+++ b/packages/block-editor/src/components/inserter/panel.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 
 function InserterPanel( { title, icon, children } ) {
 	return (
@@ -10,7 +10,7 @@ function InserterPanel( { title, icon, children } ) {
 				<h2 className="block-editor-inserter__panel-title">
 					{ title }
 				</h2>
-				<Icon icon={ icon } />
+				<WCIcon icon={ icon } />
 			</div>
 			<div className="block-editor-inserter__panel-content">
 				{ children }

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import {
-	Icon,
+	Icon as WCIcon,
 	Tooltip,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
@@ -180,7 +180,7 @@ export default function InspectorControlsTabs( {
 									tabId={ tab.name }
 									aria-label={ tab.title }
 								>
-									<Icon icon={ tab.icon } />
+									<WCIcon icon={ tab.icon } />
 								</Tabs.Tab>
 							</Tooltip>
 						)

--- a/packages/block-editor/src/components/preset-input-control/index.js
+++ b/packages/block-editor/src/components/preset-input-control/index.js
@@ -4,7 +4,7 @@
 import {
 	Button,
 	CustomSelectControl,
-	Icon,
+	Icon as WCIcon,
 	RangeControl,
 	__experimentalHStack as HStack,
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
@@ -208,7 +208,7 @@ export default function PresetInputControl( {
 			className={ `preset-input-control__wrapper ${ className }__wrapper` }
 		>
 			{ icon && (
-				<Icon
+				<WCIcon
 					className="preset-input-control__icon"
 					icon={ icon }
 					size={ ICON_SIZE }

--- a/packages/block-editor/src/components/unsupported-block-details/index.native.js
+++ b/packages/block-editor/src/components/unsupported-block-details/index.native.js
@@ -6,7 +6,11 @@ import { View, Text } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { BottomSheet, Icon, TextControl } from '@wordpress/components';
+import {
+	BottomSheet,
+	Icon as WCIcon,
+	TextControl,
+} from '@wordpress/components';
 import {
 	requestUnsupportedBlockFallback,
 	sendActionButtonPressedAction,
@@ -148,7 +152,7 @@ const UnsupportedBlockDetails = ( {
 			} }
 		>
 			<View style={ styles[ 'unsupported-block-details__container' ] }>
-				<Icon
+				<WCIcon
 					icon={ icon || help }
 					color={ iconStyle.color }
 					size={ iconStyle.size }

--- a/packages/block-editor/src/components/video-player/index.native.js
+++ b/packages/block-editor/src/components/video-player/index.native.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -118,7 +118,7 @@ class Video extends Component {
 						style={ [ style, styles.overlayContainer ] }
 					>
 						<View style={ styles.blackOverlay } />
-						<Icon
+						<WCIcon
 							icon={ PlayIcon }
 							style={ styles.playIcon }
 							size={ styles.playIcon.size }

--- a/packages/block-editor/src/components/warning/index.native.js
+++ b/packages/block-editor/src/components/warning/index.native.js
@@ -6,7 +6,7 @@ import { View, Text } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 import { withPreferredColorScheme } from '@wordpress/compose';
 import { normalizeIconObject } from '@wordpress/blocks';
 
@@ -48,7 +48,7 @@ function Warning( {
 		<View style={ containerStyle } { ...viewProps }>
 			{ icon && (
 				<View style={ styles.icon }>
-					<Icon
+					<WCIcon
 						className={ iconClass || internalIconClass }
 						icon={ icon && icon.src ? icon.src : icon }
 					/>

--- a/packages/block-editor/src/hooks/block-fields/link/index.js
+++ b/packages/block-editor/src/hooks/block-fields/link/index.js
@@ -3,7 +3,7 @@
  */
 import {
 	Button,
-	Icon,
+	Icon as WCIcon,
 	__experimentalGrid as Grid,
 	Popover,
 } from '@wordpress/components';
@@ -104,7 +104,7 @@ export default function Link( { data, field, onChange } ) {
 				>
 					{ url && (
 						<>
-							<Icon icon={ link } size={ 24 } />
+							<WCIcon icon={ link } size={ 24 } />
 							<span className="block-editor-content-only-controls__link-title">
 								{ url }
 							</span>
@@ -112,7 +112,7 @@ export default function Link( { data, field, onChange } ) {
 					) }
 					{ ! url && (
 						<>
-							<Icon
+							<WCIcon
 								icon={ link }
 								size={ 24 }
 								style={ { opacity: 0.3 } }

--- a/packages/block-editor/src/hooks/block-fields/media/index.js
+++ b/packages/block-editor/src/hooks/block-fields/media/index.js
@@ -3,7 +3,7 @@
  */
 import {
 	Button,
-	Icon,
+	Icon as WCIcon,
 	__experimentalGrid as Grid,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -92,11 +92,11 @@ function MediaThumbnail( { data, field, attachment, config } ) {
 		}
 
 		if ( icon ) {
-			return <Icon icon={ icon } size={ 20 } />;
+			return <WCIcon icon={ icon } size={ 20 } />;
 		}
 	}
 
-	return <Icon icon={ mediaIcon } size={ 20 } />;
+	return <WCIcon icon={ mediaIcon } size={ 20 } />;
 }
 
 export default function Media( { data, field, onChange, config = {} } ) {

--- a/packages/block-library/src/block/edit-title.native.js
+++ b/packages/block-library/src/block/edit-title.native.js
@@ -6,7 +6,7 @@ import { Text, View } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 import { useGlobalStyles } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { withPreferredColorScheme } from '@wordpress/compose';
@@ -41,7 +41,7 @@ function EditTitle( { getStylesFromColorScheme, title } ) {
 	return (
 		<View style={ styles.titleContainer }>
 			<View style={ styles.lockIconContainer }>
-				<Icon
+				<WCIcon
 					label={ __( 'Lock icon' ) }
 					icon={ lock }
 					size={ 16 }
@@ -52,7 +52,7 @@ function EditTitle( { getStylesFromColorScheme, title } ) {
 				{ title }
 			</Text>
 			<View style={ styles.helpIconContainer }>
-				<Icon
+				<WCIcon
 					label={ __( 'Help icon' ) }
 					icon={ help }
 					size={ 20 }

--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -20,7 +20,7 @@ import {
 } from '@wordpress/core-data';
 import {
 	BottomSheet,
-	Icon,
+	Icon as WCIcon,
 	Disabled,
 	TextControl,
 } from '@wordpress/components';
@@ -167,7 +167,7 @@ export default function ReusableBlockEdit( {
 				onClose={ closeSheet }
 			>
 				<View style={ styles.infoContainer }>
-					<Icon
+					<WCIcon
 						icon={ help }
 						color={ infoSheetIconStyle.color }
 						size={ styles.infoSheetIcon.size }

--- a/packages/block-library/src/cover/controls.native.js
+++ b/packages/block-library/src/cover/controls.native.js
@@ -9,7 +9,7 @@ import Video from 'react-native-video';
  */
 import {
 	Image,
-	Icon,
+	Icon as WCIcon,
 	IMAGE_DEFAULT_FOCAL_POINT,
 	PanelBody,
 	RangeControl,
@@ -138,7 +138,7 @@ function Controls( {
 	];
 
 	const focalPointHint = ! hasParallax && ! displayPlaceholder && (
-		<Icon
+		<WCIcon
 			icon={ plus }
 			size={ styles.focalPointHint?.width }
 			style={ [

--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -23,7 +23,7 @@ import {
 } from '@wordpress/react-native-bridge';
 import { __ } from '@wordpress/i18n';
 import {
-	Icon,
+	Icon as WCIcon,
 	Image,
 	ImageEditingButton,
 	IMAGE_DEFAULT_FOCAL_POINT,
@@ -354,7 +354,9 @@ const Cover = ( {
 		styles.iconDark
 	);
 
-	const placeholderIcon = <Icon icon={ icon } { ...placeholderIconStyle } />;
+	const placeholderIcon = (
+		<WCIcon icon={ icon } { ...placeholderIconStyle } />
+	);
 
 	const toolbarControls = ( open ) => (
 		<BlockControls group="other">
@@ -380,7 +382,7 @@ const Cover = ( {
 		>
 			<View style={ styles.selectImageContainer }>
 				<View style={ styles.selectImage }>
-					<Icon
+					<WCIcon
 						size={ 16 }
 						icon={ image }
 						{ ...styles.selectImageIcon }
@@ -665,7 +667,7 @@ const Cover = ( {
 					style={ styles.uploadFailedContainer }
 				>
 					<View style={ styles.uploadFailed }>
-						<Icon
+						<WCIcon
 							icon={ cautionFilled }
 							{ ...styles.uploadFailedIcon }
 						/>

--- a/packages/block-library/src/cover/focal-point-settings-button.native.js
+++ b/packages/block-library/src/cover/focal-point-settings-button.native.js
@@ -8,7 +8,7 @@ import { View } from 'react-native';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Icon, BottomSheet } from '@wordpress/components';
+import { Icon as WCIcon, BottomSheet } from '@wordpress/components';
 import { blockSettingsScreens } from '@wordpress/block-editor';
 import { chevronRight } from '@wordpress/icons';
 
@@ -44,7 +44,7 @@ function FocalPointSettingsButton( {
 			 * issue: https://github.com/react-native-svg/react-native-svg/issues/1345
 			 */ }
 			<View style={ disabled && styles.dimmedActionButton }>
-				<Icon icon={ chevronRight } />
+				<WCIcon icon={ chevronRight } />
 			</View>
 		</BottomSheet.Cell>
 	);

--- a/packages/block-library/src/embed/embed-no-preview.native.js
+++ b/packages/block-library/src/embed/embed-no-preview.native.js
@@ -14,7 +14,11 @@ import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import { requestPreview } from '@wordpress/react-native-bridge';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { BottomSheet, Icon, TextControl } from '@wordpress/components';
+import {
+	BottomSheet,
+	Icon as WCIcon,
+	TextControl,
+} from '@wordpress/components';
 import { help } from '@wordpress/icons';
 import { BlockIcon } from '@wordpress/block-editor';
 
@@ -150,7 +154,7 @@ const EmbedNoPreview = ( {
 						onPress={ onPressHelp }
 						style={ helpIconStyle }
 					>
-						<Icon
+						<WCIcon
 							icon={ help }
 							fill={ helpIconStyle.fill }
 							size={ helpIconStyle.width }
@@ -167,7 +171,7 @@ const EmbedNoPreview = ( {
 			>
 				<View style={ styles[ 'embed-no-preview__container' ] }>
 					<View style={ sheetIconStyle }>
-						<Icon
+						<WCIcon
 							icon={ help }
 							fill={ sheetIconStyle.fill }
 							size={ sheetIconStyle.width }

--- a/packages/block-library/src/embed/embed-placeholder.native.js
+++ b/packages/block-library/src/embed/embed-placeholder.native.js
@@ -8,7 +8,7 @@ import { View, Text, TouchableOpacity } from 'react-native';
  */
 import { __ } from '@wordpress/i18n';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
-import { Icon, Picker } from '@wordpress/components';
+import { Icon as WCIcon, Picker } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/block-editor';
 import { useRef } from '@wordpress/element';
 
@@ -110,7 +110,7 @@ const EmbedPlaceholder = ( {
 			<View style={ containerStyle }>
 				{ cannotEmbed ? (
 					<>
-						<Icon
+						<WCIcon
 							icon={ noticeOutline }
 							fill={ embedIconErrorStyle.fill }
 							style={ embedIconErrorStyle }

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -31,7 +31,7 @@ import {
 	ToggleControl,
 	TextControl,
 	SelectControl,
-	Icon,
+	Icon as WCIcon,
 } from '@wordpress/components';
 import {
 	file as icon,
@@ -476,7 +476,7 @@ export class FileEdit extends Component {
 									/>
 									{ isUploadFailed && (
 										<View style={ styles.errorContainer }>
-											<Icon
+											<WCIcon
 												icon={ cautionFilled }
 												style={ errorIconStyle }
 											/>

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -22,7 +22,7 @@ import {
 	setFeaturedImage,
 } from '@wordpress/react-native-bridge';
 import {
-	Icon,
+	Icon as WCIcon,
 	PanelBody,
 	ToolbarButton,
 	ToolbarGroup,
@@ -514,7 +514,7 @@ export class ImageEdit extends Component {
 
 	getPlaceholderIcon() {
 		return (
-			<Icon
+			<WCIcon
 				icon={ placeholderIcon }
 				{ ...this.props.getStylesFromColorScheme(
 					styles.iconPlaceholder,

--- a/packages/block-library/src/latest-posts/edit.native.js
+++ b/packages/block-library/src/latest-posts/edit.native.js
@@ -17,7 +17,7 @@ import {
 } from '@wordpress/block-editor';
 import apiFetch from '@wordpress/api-fetch';
 import {
-	Icon,
+	Icon as WCIcon,
 	PanelBody,
 	ToggleControl,
 	RangeControl,
@@ -265,7 +265,7 @@ class LatestPostsEdit extends Component {
 			>
 				<View style={ blockStyle }>
 					{ isSelected && this.getInspectorControls() }
-					<Icon icon={ icon } { ...iconStyle } />
+					<WCIcon icon={ icon } { ...iconStyle } />
 					<Text style={ titleStyle }>{ blockTitle }</Text>
 					<Text style={ styles.latestPostBlockSubtitle }>
 						{ __( 'CUSTOMIZE' ) }

--- a/packages/block-library/src/list-item/list-style-type.native.js
+++ b/packages/block-library/src/list-item/list-style-type.native.js
@@ -6,7 +6,7 @@ import { View, Text } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 import { Platform } from '@wordpress/element';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 
@@ -85,7 +85,7 @@ function IconList( { fontSize, color, defaultFontSize, indentationLevel } ) {
 
 	return (
 		<View style={ listStyles }>
-			<Icon icon={ listIcon } size={ iconSize } />
+			<WCIcon icon={ listIcon } size={ iconSize } />
 		</View>
 	);
 }

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -12,7 +12,11 @@ import {
 	requestImageUploadCancelDialog,
 	requestImageFullscreenPreview,
 } from '@wordpress/react-native-bridge';
-import { Icon, Image, IMAGE_DEFAULT_FOCAL_POINT } from '@wordpress/components';
+import {
+	Icon as WCIcon,
+	Image,
+	IMAGE_DEFAULT_FOCAL_POINT,
+} from '@wordpress/components';
 import {
 	MEDIA_TYPE_IMAGE,
 	MEDIA_TYPE_VIDEO,
@@ -117,7 +121,7 @@ class MediaContainer extends Component {
 								styles.iconRetryVideoDark
 						  );
 
-				return <Icon icon={ SvgIconRetry } { ...iconStyle } />;
+				return <WCIcon icon={ SvgIconRetry } { ...iconStyle } />;
 			case ICON_TYPE.PLACEHOLDER:
 				iconStyle = getStylesFromColorScheme(
 					styles.iconPlaceholder,
@@ -125,7 +129,7 @@ class MediaContainer extends Component {
 				);
 				break;
 		}
-		return <Icon icon={ icon } { ...iconStyle } />;
+		return <WCIcon icon={ icon } { ...iconStyle } />;
 	}
 
 	updateMediaProgress( payload ) {

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -6,9 +6,8 @@ import { View, Text, TouchableOpacity } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
-import { coreBlocks } from '@wordpress/block-library';
 import { normalizeIconObject, rawHandler, serialize } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -21,6 +20,7 @@ import {
 } from '@wordpress/block-editor';
 import { store as noticesStore } from '@wordpress/notices';
 import { requestUnsupportedBlockFallback } from '@wordpress/react-native-bridge';
+import { coreBlocks } from '@wordpress/block-library';
 
 /**
  * Internal dependencies
@@ -116,7 +116,7 @@ export class UnsupportedBlockEdit extends Component {
 				accessibilityRole="button"
 				accessibilityHint={ __( 'Tap here to show help' ) }
 			>
-				<Icon
+				<WCIcon
 					className="unsupported-icon-help"
 					label={ __( 'Help icon' ) }
 					icon={ help }
@@ -245,7 +245,7 @@ export class UnsupportedBlockEdit extends Component {
 					{ ! this.canEditUnsupportedBlock() &&
 						this.renderHelpIcon() }
 					<View style={ styles.unsupportedBlockHeader }>
-						<Icon
+						<WCIcon
 							className={ iconClassName }
 							icon={ icon && icon.src ? icon.src : icon }
 							fill={ iconStyle.color }

--- a/packages/block-library/src/missing/test/edit.native.js
+++ b/packages/block-library/src/missing/test/edit.native.js
@@ -7,7 +7,7 @@ import { Text } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { BottomSheet, Icon } from '@wordpress/components';
+import { BottomSheet, Icon as WCIcon } from '@wordpress/components';
 import { help, plugins } from '@wordpress/icons';
 import { storeConfig } from '@wordpress/block-editor';
 jest.mock( '@wordpress/block-editor/src/store/selectors' );
@@ -39,7 +39,7 @@ describe( 'Missing block', () => {
 	describe( 'help modal', () => {
 		it( 'renders help icon', () => {
 			const testInstance = getTestComponentWithContent();
-			const icons = testInstance.UNSAFE_getAllByType( Icon );
+			const icons = testInstance.UNSAFE_getAllByType( WCIcon );
 			expect( icons.length ).toBe( 2 );
 			expect( icons[ 0 ].props.icon ).toBe( help );
 		} );
@@ -66,7 +66,7 @@ describe( 'Missing block', () => {
 
 	it( 'renders admin plugins icon', () => {
 		const testInstance = getTestComponentWithContent();
-		const icons = testInstance.UNSAFE_getAllByType( Icon );
+		const icons = testInstance.UNSAFE_getAllByType( WCIcon );
 		expect( icons.length ).toBe( 2 );
 		expect( icons[ 1 ].props.icon ).toBe( plugins );
 	} );

--- a/packages/block-library/src/search/edit.native.js
+++ b/packages/block-library/src/search/edit.native.js
@@ -17,7 +17,7 @@ import {
 	PanelBody,
 	SelectControl,
 	ToggleControl,
-	Icon,
+	Icon as WCIcon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { search } from '@wordpress/icons';
@@ -374,7 +374,7 @@ export default function SearchEdit( {
 		return (
 			<View style={ richTextButtonContainerStyle }>
 				{ buttonUseIcon && (
-					<Icon
+					<WCIcon
 						icon={ search }
 						{ ...iconStyles }
 						onLayout={ onLayoutButton }

--- a/packages/block-library/src/search/test/edit.native.js
+++ b/packages/block-library/src/search/test/edit.native.js
@@ -6,7 +6,7 @@ import { render } from 'test/helpers';
 /**
  * WordPress dependencies
  */
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -129,7 +129,7 @@ describe( 'Search Block', () => {
 		} );
 
 		it( 'search button uses icon', () => {
-			const button = instance.UNSAFE_getByType( Icon );
+			const button = instance.UNSAFE_getByType( WCIcon );
 			expect( button ).toBeTruthy();
 		} );
 

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -19,7 +19,7 @@ import {
 } from '@wordpress/block-editor';
 import { useState, useRef, createInterpolateElement } from '@wordpress/element';
 import {
-	Icon,
+	Icon as WCIcon,
 	Button,
 	Dropdown,
 	TextControl,
@@ -277,7 +277,7 @@ const SocialLinkEdit = ( {
 				 */
 				/* eslint-disable jsx-a11y/no-redundant-roles */ }
 				<button aria-haspopup="dialog" { ...blockProps } role="button">
-					<Icon icon={ icon } />
+					<WCIcon icon={ icon } />
 					<span
 						className={ clsx( 'wp-block-social-link-label', {
 							'screen-reader-text': ! showLabels,

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -13,7 +13,7 @@ import {
 	requestImageUploadCancelDialog,
 } from '@wordpress/react-native-bridge';
 import {
-	Icon,
+	Icon as WCIcon,
 	ToolbarButton,
 	ToolbarGroup,
 	PanelBody,
@@ -191,7 +191,7 @@ class VideoEdit extends Component {
 		let iconStyle;
 		switch ( iconType ) {
 			case ICON_TYPE.RETRY:
-				return <Icon icon={ SvgIconRetry } { ...style.icon } />;
+				return <WCIcon icon={ SvgIconRetry } { ...style.icon } />;
 			case ICON_TYPE.PLACEHOLDER:
 				iconStyle = this.props.getStylesFromColorScheme(
 					style.icon,
@@ -206,7 +206,7 @@ class VideoEdit extends Component {
 				break;
 		}
 
-		return <Icon icon={ SvgIcon } { ...iconStyle } />;
+		return <WCIcon icon={ SvgIcon } { ...iconStyle } />;
 	}
 
 	render() {

--- a/packages/boot/src/components/canvas/back-button.tsx
+++ b/packages/boot/src/components/canvas/back-button.tsx
@@ -3,7 +3,7 @@
  */
 import {
 	Button,
-	Icon,
+	Icon as WCIcon,
 	__unstableMotion as motion,
 } from '@wordpress/components';
 import { arrowUpLeft } from '@wordpress/icons';
@@ -79,7 +79,7 @@ export default function BootBackButton( { length }: { length: number } ) {
 				className="boot-canvas-back-button__icon"
 				variants={ toggleHomeIconVariants }
 			>
-				<Icon icon={ arrowUpLeft } />
+				<WCIcon icon={ arrowUpLeft } />
 			</motion.div>
 		</motion.div>
 	);

--- a/packages/boot/src/components/navigation/drilldown-item/index.tsx
+++ b/packages/boot/src/components/navigation/drilldown-item/index.tsx
@@ -12,7 +12,7 @@ import {
 	__experimentalItem as Item,
 	// @ts-ignore
 	__experimentalHStack as HStack,
-	Icon,
+	Icon as WCIcon,
 } from '@wordpress/components';
 import { isRTL } from '@wordpress/i18n';
 import { chevronRightSmall, chevronLeftSmall } from '@wordpress/icons';
@@ -81,7 +81,9 @@ export default function DrilldownItem( {
 			>
 				{ wrapIcon( icon, shouldShowPlaceholder ) }
 				<FlexBlock>{ children }</FlexBlock>
-				<Icon icon={ isRTL() ? chevronLeftSmall : chevronRightSmall } />
+				<WCIcon
+					icon={ isRTL() ? chevronLeftSmall : chevronRightSmall }
+				/>
 			</HStack>
 		</Item>
 	);

--- a/packages/boot/src/components/navigation/dropdown-item/index.tsx
+++ b/packages/boot/src/components/navigation/dropdown-item/index.tsx
@@ -12,7 +12,7 @@ import {
 	__experimentalItem as Item,
 	// @ts-ignore
 	__experimentalHStack as HStack,
-	Icon,
+	Icon as WCIcon,
 	__unstableMotion as motion,
 	__unstableAnimatePresence as AnimatePresence,
 } from '@wordpress/components';
@@ -96,7 +96,7 @@ export default function DropdownItem( {
 				>
 					{ wrapIcon( icon, false ) }
 					<FlexBlock>{ children }</FlexBlock>
-					<Icon
+					<WCIcon
 						icon={ chevronDownSmall }
 						className={ clsx( 'boot-dropdown-item__chevron', {
 							'is-up': isExpanded,

--- a/packages/boot/src/components/navigation/items.tsx
+++ b/packages/boot/src/components/navigation/items.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { isValidElement } from '@wordpress/element';
-import { Dashicon, Icon } from '@wordpress/components';
+import { Dashicon, Icon as WCIcon } from '@wordpress/components';
 import { SVG } from '@wordpress/primitives';
 
 /**
@@ -38,7 +38,7 @@ export function wrapIcon(
 	shouldShowPlaceholder: boolean = true
 ) {
 	if ( isSvg( icon ) ) {
-		return <Icon icon={ icon } />;
+		return <WCIcon icon={ icon } />;
 	}
 
 	if ( typeof icon === 'string' && icon.startsWith( 'dashicons-' ) ) {

--- a/packages/dataviews/src/components/dataform-controls/date.tsx
+++ b/packages/dataviews/src/components/dataform-controls/date.tsx
@@ -18,7 +18,7 @@ import {
 import {
 	BaseControl,
 	Button,
-	Icon,
+	Icon as WCIcon,
 	privateApis as componentsPrivateApis,
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
@@ -269,7 +269,7 @@ function ValidatedDateControl< Item >( {
 								: undefined
 						) }
 					>
-						<Icon
+						<WCIcon
 							className="components-validated-control__indicator-icon"
 							icon={ errorIcon }
 							size={ 16 }

--- a/packages/dataviews/src/components/dataform-controls/email.tsx
+++ b/packages/dataviews/src/components/dataform-controls/email.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import {
-	Icon,
+	Icon as WCIcon,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 } from '@wordpress/components';
 import { envelope } from '@wordpress/icons';
@@ -33,7 +33,7 @@ export default function Email< Item >( {
 				type: 'email',
 				prefix: (
 					<InputControlPrefixWrapper variant="icon">
-						<Icon icon={ envelope } />
+						<WCIcon icon={ envelope } />
 					</InputControlPrefixWrapper>
 				),
 			} }

--- a/packages/dataviews/src/components/dataform-controls/telephone.tsx
+++ b/packages/dataviews/src/components/dataform-controls/telephone.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import {
-	Icon,
+	Icon as WCIcon,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 } from '@wordpress/components';
 import { mobile } from '@wordpress/icons';
@@ -33,7 +33,7 @@ export default function Telephone< Item >( {
 				type: 'tel',
 				prefix: (
 					<InputControlPrefixWrapper variant="icon">
-						<Icon icon={ mobile } />
+						<WCIcon icon={ mobile } />
 					</InputControlPrefixWrapper>
 				),
 			} }

--- a/packages/dataviews/src/components/dataform-controls/url.tsx
+++ b/packages/dataviews/src/components/dataform-controls/url.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import {
-	Icon,
+	Icon as WCIcon,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 } from '@wordpress/components';
 import { link } from '@wordpress/icons';
@@ -33,7 +33,7 @@ export default function Url< Item >( {
 				type: 'url',
 				prefix: (
 					<InputControlPrefixWrapper variant="icon">
-						<Icon icon={ link } />
+						<WCIcon icon={ link } />
 					</InputControlPrefixWrapper>
 				),
 			} }

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { Button, Icon, Tooltip } from '@wordpress/components';
+import { Button, Icon as WCIcon, Tooltip } from '@wordpress/components';
 import { sprintf, _x } from '@wordpress/i18n';
 import { error as errorIcon, pencil } from '@wordpress/icons';
 import { useInstanceId } from '@wordpress/compose';
@@ -113,7 +113,7 @@ export default function SummaryButton< Item >( {
 			{ labelPosition === 'none' && showError && (
 				<Tooltip text={ errorMessage } placement="top">
 					<span className="dataforms-layouts-panel__field-label-error-content">
-						<Icon icon={ errorIcon } size={ 16 } />
+						<WCIcon icon={ errorIcon } size={ 16 } />
 					</span>
 				</Tooltip>
 			) }

--- a/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-content.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-content.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Icon, Tooltip } from '@wordpress/components';
+import { Icon as WCIcon, Tooltip } from '@wordpress/components';
 import { error as errorIcon } from '@wordpress/icons';
 
 function getLabelContent(
@@ -12,7 +12,7 @@ function getLabelContent(
 	return showError ? (
 		<Tooltip text={ errorMessage } placement="top">
 			<span className="dataforms-layouts-panel__field-label-error-content">
-				<Icon icon={ errorIcon } size={ 16 } />
+				<WCIcon icon={ errorIcon } size={ 16 } />
 				{ fieldLabel }
 			</span>
 		</Tooltip>

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -12,7 +12,7 @@ import {
 	FlexItem,
 	SelectControl,
 	Tooltip,
-	Icon,
+	Icon as WCIcon,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useRef } from '@wordpress/element';
@@ -341,7 +341,7 @@ export default function Filter( {
 									}
 								} }
 							>
-								<Icon icon={ closeSmall } />
+								<WCIcon icon={ closeSmall } />
 							</button>
 						</Tooltip>
 					) }

--- a/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
@@ -12,7 +12,7 @@ import clsx from 'clsx';
 import { useInstanceId } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useMemo, useDeferredValue } from '@wordpress/element';
-import { Icon, Composite, Spinner } from '@wordpress/components';
+import { Icon as WCIcon, Composite, Spinner } from '@wordpress/components';
 import { search, check } from '@wordpress/icons';
 import { VisuallyHidden } from '@wordpress/ui';
 
@@ -68,7 +68,7 @@ const MultiSelectionOption = ( { selected }: { selected: boolean } ) => {
 				{ 'is-selected': selected }
 			) }
 		>
-			{ selected && <Icon icon={ check } /> }
+			{ selected && <WCIcon icon={ check } /> }
 		</span>
 	);
 };
@@ -272,7 +272,7 @@ function ComboboxList( { view, filter, onChangeView }: SearchWidgetProps ) {
 					className="dataviews-filters__search-widget-filter-combobox__input"
 				/>
 				<div className="dataviews-filters__search-widget-filter-combobox__icon">
-					<Icon icon={ search } />
+					<WCIcon icon={ search } />
 				</div>
 			</div>
 			<Ariakit.ComboboxList

--- a/packages/dataviews/src/components/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/column-header-menu.tsx
@@ -10,7 +10,7 @@ import { __, isRTL } from '@wordpress/i18n';
 import { arrowLeft, arrowRight, unseen, funnel } from '@wordpress/icons';
 import {
 	Button,
-	Icon,
+	Icon as WCIcon,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { forwardRef, Children, Fragment, useContext } from '@wordpress/element';
@@ -181,7 +181,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 					{ canAddFilter && (
 						<Menu.Group>
 							<Menu.Item
-								prefix={ <Icon icon={ funnel } /> }
+								prefix={ <WCIcon icon={ funnel } /> }
 								onClick={ () => {
 									setOpenedFilter( fieldId );
 									setIsShowingFilter( true );
@@ -209,7 +209,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 						<Menu.Group>
 							{ canMove && (
 								<Menu.Item
-									prefix={ <Icon icon={ arrowLeft } /> }
+									prefix={ <WCIcon icon={ arrowLeft } /> }
 									disabled={
 										isRtl
 											? index >=
@@ -243,7 +243,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 							) }
 							{ canMove && (
 								<Menu.Item
-									prefix={ <Icon icon={ arrowRight } /> }
+									prefix={ <WCIcon icon={ arrowRight } /> }
 									disabled={
 										isRtl
 											? index < 1
@@ -357,7 +357,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 							) }
 							{ isHidable && field && (
 								<Menu.Item
-									prefix={ <Icon icon={ unseen } /> }
+									prefix={ <WCIcon icon={ unseen } /> }
 									onClick={ () => {
 										onHide( field );
 										onChangeView( {

--- a/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
@@ -5,7 +5,7 @@ import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
 	BaseControl,
-	Icon,
+	Icon as WCIcon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
@@ -32,7 +32,7 @@ function FieldItem( {
 		<Item onClick={ field.enableHiding ? onToggleVisibility : undefined }>
 			<Stack direction="row" gap="sm" justify="flex-start" align="center">
 				<div style={ { height: 24, width: 24 } }>
-					{ isVisible && <Icon icon={ check } /> }
+					{ isVisible && <WCIcon icon={ check } /> }
 				</div>
 				<span className="dataviews-view-config__label">
 					{ field.label }

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -3,7 +3,7 @@
  */
 import { useState, useMemo } from '@wordpress/element';
 import {
-	Icon,
+	Icon as WCIcon,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
 } from '@wordpress/components';
@@ -88,7 +88,7 @@ const DollarPrefix = () => (
 );
 const StarIconPrefix = () => (
 	<InputControlPrefixWrapper variant="icon">
-		<Icon icon={ starFilled } />
+		<WCIcon icon={ starFilled } />
 	</InputControlPrefixWrapper>
 );
 const PercentSuffix = () => (

--- a/packages/edit-post/src/components/back-button/fullscreen-mode-close.js
+++ b/packages/edit-post/src/components/back-button/fullscreen-mode-close.js
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import { useSelect } from '@wordpress/data';
 import {
 	Button,
-	Icon,
+	Icon as WCIcon,
 	__unstableMotion as motion,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -90,7 +90,7 @@ function FullscreenModeClose( { showTooltip, icon, href, initialPost } ) {
 		);
 	} else {
 		siteIconContent = (
-			<Icon
+			<WCIcon
 				className="edit-post-fullscreen-mode-close-site-icon__icon"
 				icon={ wordpress }
 				size={ 48 }
@@ -100,7 +100,7 @@ function FullscreenModeClose( { showTooltip, icon, href, initialPost } ) {
 
 	// Override default icon if custom icon is provided via props.
 	const buttonIcon = icon ? (
-		<Icon size="36px" icon={ icon } />
+		<WCIcon size="36px" icon={ icon } />
 	) : (
 		<div className="edit-post-fullscreen-mode-close-site-icon">
 			{ siteIconContent }
@@ -151,7 +151,7 @@ function FullscreenModeClose( { showTooltip, icon, href, initialPost } ) {
 				) }
 				variants={ ! disableMotion && toggleHomeIconVariants }
 			>
-				<Icon icon={ arrowUpLeft } />
+				<WCIcon icon={ arrowUpLeft } />
 			</motion.div>
 		</motion.div>
 	);

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -38,7 +38,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
 import {
-	Icon,
+	Icon as WCIcon,
 	SlotFillProvider,
 	Tooltip,
 	__unstableUseNavigateRegions as useNavigateRegions,
@@ -321,7 +321,7 @@ function MetaBoxesMain( { isLegacy } ) {
 			{ ...( ! isShort && bindDragGesture( persistIsOpen ) ) }
 		>
 			{ paneLabel }
-			<Icon icon={ isOpen ? chevronUp : chevronDown } />
+			<WCIcon icon={ isOpen ? chevronUp : chevronDown } />
 		</button>
 	);
 

--- a/packages/edit-site/src/components/add-new-template-legacy/index.js
+++ b/packages/edit-site/src/components/add-new-template-legacy/index.js
@@ -13,7 +13,7 @@ import {
 	__experimentalText as WCText,
 	__experimentalVStack as VStack,
 	Flex,
-	Icon,
+	Icon as WCIcon,
 } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState, memo, useRef, useEffect } from '@wordpress/element';
@@ -123,7 +123,7 @@ function TemplateListItem( {
 				direction={ direction }
 			>
 				<div className="edit-site-add-new-template__template-icon">
-					<Icon icon={ icon } />
+					<WCIcon icon={ icon } />
 				</div>
 				<VStack
 					className="edit-site-add-new-template__template-name"

--- a/packages/edit-site/src/components/add-new-template/index.js
+++ b/packages/edit-site/src/components/add-new-template/index.js
@@ -13,7 +13,7 @@ import {
 	__experimentalText as WCText,
 	__experimentalVStack as VStack,
 	Flex,
-	Icon,
+	Icon as WCIcon,
 } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState, memo, useRef, useEffect } from '@wordpress/element';
@@ -122,7 +122,7 @@ function TemplateListItem( {
 				direction={ direction }
 			>
 				<div className="edit-site-add-new-template__template-icon">
-					<Icon icon={ icon } />
+					<WCIcon icon={ icon } />
 				</div>
 				<VStack
 					className="edit-site-add-new-template__template-name"

--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import {
-	Icon,
+	Icon as WCIcon,
 	__experimentalHStack as HStack,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
@@ -138,7 +138,7 @@ function AuthorField( { item } ) {
 			) }
 			{ ! imageUrl && (
 				<div className="fields-controls__author-icon">
-					<Icon icon={ icon } />
+					<WCIcon icon={ icon } />
 				</div>
 			) }
 			<span className="fields-controls__author-name">{ text }</span>

--- a/packages/edit-site/src/components/site-icon/index.js
+++ b/packages/edit-site/src/components/site-icon/index.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import { store as coreDataStore } from '@wordpress/core-data';
@@ -34,7 +34,7 @@ function SiteIcon( { className } ) {
 			src={ siteIconUrl }
 		/>
 	) : (
-		<Icon
+		<WCIcon
 			className="edit-site-site-icon__icon"
 			icon={ wordpress }
 			size={ 48 }

--- a/packages/editor/src/components/collaborators-presence/avatar/component.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar/component.tsx
@@ -10,7 +10,7 @@ extend( [ a11yPlugin ] );
 /**
  * WordPress dependencies
  */
-import { Icon, Tooltip } from '@wordpress/components';
+import { Icon as WCIcon, Tooltip } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 
 /**
@@ -104,7 +104,7 @@ function Avatar( {
 			</span>
 			{ dimmed && !! statusIndicator && (
 				<span className="editor-avatar__status-indicator">
-					<Icon icon={ statusIndicator } />
+					<WCIcon icon={ statusIndicator } />
 				</span>
 			) }
 			{ showBadge && (

--- a/packages/editor/src/components/editor-help/help-topic-row.native.js
+++ b/packages/editor/src/components/editor-help/help-topic-row.native.js
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 /**
  * WordPress dependencies
  */
-import { TextControl, Icon } from '@wordpress/components';
+import { TextControl, Icon as WCIcon } from '@wordpress/components';
 import { chevronRight } from '@wordpress/icons';
 
 const HelpTopicRow = ( { label, icon, screenName, isLastItem } ) => {
@@ -25,7 +25,7 @@ const HelpTopicRow = ( { label, icon, screenName, isLastItem } ) => {
 			label={ label }
 			icon={ icon }
 		>
-			<Icon icon={ chevronRight } />
+			<WCIcon icon={ chevronRight } />
 		</TextControl>
 	);
 };

--- a/packages/editor/src/components/error-boundary/index.native.js
+++ b/packages/editor/src/components/error-boundary/index.native.js
@@ -17,7 +17,7 @@ import {
 	withPreferredColorScheme,
 } from '@wordpress/compose';
 import { cautionFilled } from '@wordpress/icons';
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -140,7 +140,7 @@ class ErrorBoundary extends Component {
 				>
 					<View style={ styles[ 'error-boundary__container' ] }>
 						<View style={ iconContainerStyle }>
-							<Icon
+							<WCIcon
 								icon={ cautionFilled }
 								{ ...styles[ 'error-boundary__icon' ] }
 							/>

--- a/packages/editor/src/components/offline-status/index.native.js
+++ b/packages/editor/src/components/offline-status/index.native.js
@@ -11,7 +11,7 @@ import {
 	useNetworkConnectivity,
 	usePrevious,
 } from '@wordpress/compose';
-import { Icon } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 import { offline as offlineIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
@@ -90,7 +90,7 @@ const OfflineStatus = () => {
 			) }
 			style={ containerStyle }
 		>
-			<Icon fill={ iconStyle.fill } icon={ offlineIcon } />
+			<WCIcon fill={ iconStyle.fill } icon={ offlineIcon } />
 			<Text style={ textStyle }>{ __( 'Working Offline' ) } </Text>
 		</View>
 	) : null;

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import {
-	Icon,
+	Icon as WCIcon,
 	Button,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -130,7 +130,10 @@ export default function PostCardPanel( {
 				className="editor-post-card-panel__header"
 				alignment="flex-start"
 			>
-				<Icon className="editor-post-card-panel__icon" icon={ icon } />
+				<WCIcon
+					className="editor-post-card-panel__icon"
+					icon={ icon }
+				/>
 				<WCText
 					numberOfLines={ 2 }
 					truncate

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Icon, PanelBody } from '@wordpress/components';
+import { Icon as WCIcon, PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { wordpress } from '@wordpress/icons';
 import { filterURLForDisplay } from '@wordpress/url';
@@ -53,7 +53,11 @@ function PostPublishPanelPrepublish( { children } ) {
 	}, [] );
 
 	let siteIcon = (
-		<Icon className="components-site-icon" size="36px" icon={ wordpress } />
+		<WCIcon
+			className="components-site-icon"
+			size="36px"
+			icon={ wordpress }
+		/>
 	);
 
 	if ( siteIconUrl ) {

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -12,7 +12,7 @@ import {
 	MenuGroup,
 	MenuItem,
 	MenuItemsChoice,
-	Icon,
+	Icon as WCIcon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { desktop, mobile, tablet, external, check } from '@wordpress/icons';
@@ -189,7 +189,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 								textContent={
 									<>
 										{ __( 'Preview in new tab' ) }
-										<Icon icon={ external } />
+										<WCIcon icon={ external } />
 									</>
 								}
 								onPreview={ onClose }

--- a/packages/fields/src/components/create-template-part-modal/index.tsx
+++ b/packages/fields/src/components/create-template-part-modal/index.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import {
-	Icon,
+	Icon as WCIcon,
 	BaseControl,
 	TextControl,
 	Button,
@@ -231,7 +231,7 @@ export function CreateTemplatePartModalContents( {
 												instanceId
 											) }
 										/>
-										<Icon
+										<WCIcon
 											icon={ icon }
 											className="fields-create-template-part-modal__area-radio-icon"
 										/>
@@ -244,7 +244,7 @@ export function CreateTemplatePartModalContents( {
 										>
 											{ item.label }
 										</label>
-										<Icon
+										<WCIcon
 											icon={ check }
 											className="fields-create-template-part-modal__area-radio-checkmark"
 										/>

--- a/packages/fields/src/components/media-edit/index.tsx
+++ b/packages/fields/src/components/media-edit/index.tsx
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import {
 	Button,
 	DropZone,
-	Icon,
+	Icon as WCIcon,
 	Spinner,
 	__experimentalText as WCText,
 	__experimentalTruncate as Truncate,
@@ -291,13 +291,13 @@ function MediaPreview( { attachment }: { attachment: MediaEditAttachment } ) {
 			/>
 		);
 	} else if ( mimeType.startsWith( 'audio' ) ) {
-		return <Icon icon={ audio } />;
+		return <WCIcon icon={ audio } />;
 	} else if ( mimeType.startsWith( 'video' ) ) {
-		return <Icon icon={ video } />;
+		return <WCIcon icon={ video } />;
 	} else if ( archiveMimeTypes.includes( mimeType ) ) {
-		return <Icon icon={ archive } />;
+		return <WCIcon icon={ archive } />;
 	}
-	return <Icon icon={ file } />;
+	return <WCIcon icon={ file } />;
 }
 
 type MediaEditAttachment = Attachment< 'view' > | BlobItem;
@@ -971,7 +971,7 @@ export default function MediaEdit< Item >( {
 							}
 						) }
 					>
-						<Icon
+						<WCIcon
 							className="components-validated-control__indicator-icon"
 							icon={ errorIcon }
 							size={ 16 }

--- a/packages/fields/src/fields/author/author-view.tsx
+++ b/packages/fields/src/fields/author/author-view.tsx
@@ -9,7 +9,10 @@ import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { commentAuthorAvatar as authorIcon } from '@wordpress/icons';
-import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	Icon as WCIcon,
+} from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -64,7 +67,7 @@ function AuthorView( { item }: { item: BasePostWithEmbeddedAuthor } ) {
 			) }
 			{ ! imageUrl && (
 				<div className="fields-controls__author-icon">
-					<Icon icon={ authorIcon } />
+					<WCIcon icon={ authorIcon } />
 				</div>
 			) }
 			<span className="fields-controls__author-name">{ text }</span>

--- a/packages/fields/src/fields/status/status-view.tsx
+++ b/packages/fields/src/fields/status/status-view.tsx
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	Icon as WCIcon,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,7 +20,7 @@ function StatusView( { item }: { item: BasePost } ) {
 		<HStack alignment="left" spacing={ 0 }>
 			{ icon && (
 				<div className="fields-controls__status-icon">
-					<Icon icon={ icon } />
+					<WCIcon icon={ icon } />
 				</div>
 			) }
 			<span>{ label }</span>

--- a/packages/media-fields/src/author/view.tsx
+++ b/packages/media-fields/src/author/view.tsx
@@ -9,7 +9,10 @@ import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import { useState, useCallback, useEffect } from '@wordpress/element';
 import { commentAuthorAvatar as authorIcon } from '@wordpress/icons';
-import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	Icon as WCIcon,
+} from '@wordpress/components';
 import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
 
 /**
@@ -67,7 +70,7 @@ export default function AuthorView( {
 			) }
 			{ ! imageUrl && (
 				<div className="media-author-field__icon">
-					<Icon icon={ authorIcon } />
+					<WCIcon icon={ authorIcon } />
 				</div>
 			) }
 			<span className="media-author-field__name">{ text }</span>

--- a/packages/media-fields/src/media_thumbnail/view.tsx
+++ b/packages/media-fields/src/media_thumbnail/view.tsx
@@ -11,7 +11,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import {
 	__experimentalTruncate as Truncate,
 	__experimentalVStack as VStack,
-	Icon,
+	Icon as WCIcon,
 } from '@wordpress/components';
 import { useState, useRef, useLayoutEffect } from '@wordpress/element';
 import type { Attachment } from '@wordpress/core-data';
@@ -91,7 +91,7 @@ function FallbackView( {
 				className="dataviews-media-field__media-thumbnail__stack"
 				spacing={ 0 }
 			>
-				<Icon
+				<WCIcon
 					className="dataviews-media-field__media-thumbnail--icon"
 					icon={ getMediaTypeFromMimeType( item.mime_type ).icon }
 					size={ 24 }

--- a/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
@@ -3,7 +3,13 @@
  */
 import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
-import { Button, Icon, Notice, Popover, Spinner } from '@wordpress/components';
+import {
+	Button,
+	Icon as WCIcon,
+	Notice,
+	Popover,
+	Spinner,
+} from '@wordpress/components';
 import { check, chevronDown } from '@wordpress/icons';
 
 export interface UploadingFile {
@@ -123,7 +129,7 @@ export function UploadStatusPopover( {
 							>
 								{ file.status === 'uploading' && <Spinner /> }
 								{ file.status === 'uploaded' && (
-									<Icon icon={ check } size={ 16 } />
+									<WCIcon icon={ check } size={ 16 } />
 								) }
 								{ ( file.status === 'uploading' ||
 									file.status === 'uploaded' ) && (

--- a/routes/dashboard/widget-dashboard/components/widget-chrome/widget-chrome.tsx
+++ b/routes/dashboard/widget-dashboard/components/widget-chrome/widget-chrome.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react';
 /**
  * WordPress dependencies
  */
-import { Icon, Spinner } from '@wordpress/components';
+import { Icon as WCIcon, Spinner } from '@wordpress/components';
 import {
 	Component,
 	Suspense,
@@ -85,7 +85,7 @@ function Header( { titleId, widgetType }: HeaderProps ) {
 						className={ styles.widgetChromeHeaderIcon }
 						aria-hidden="true"
 					>
-						<Icon icon={ widgetType.icon } />
+						<WCIcon icon={ widgetType.icon } />
 					</span>
 				) }
 				<Card.Title id={ titleId } render={ <h3 /> }>

--- a/routes/guidelines/components/block-guidelines.tsx
+++ b/routes/guidelines/components/block-guidelines.tsx
@@ -3,7 +3,7 @@
  */
 import {
 	Button,
-	Icon,
+	Icon as WCIcon,
 	Notice,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -57,7 +57,7 @@ const fields = [
 		type: 'media' as const,
 		render: ( { item } ) => (
 			<div className="block-guidelines__icon">
-				<Icon icon={ item.icon ?? blockDefault } size={ 16 } />
+				<WCIcon icon={ item.icon ?? blockDefault } size={ 16 } />
 			</div>
 		),
 	},

--- a/routes/template-list/add-new-template/index.tsx
+++ b/routes/template-list/add-new-template/index.tsx
@@ -13,7 +13,7 @@ import {
 	__experimentalText as WCText,
 	__experimentalVStack as VStack,
 	Flex,
-	Icon,
+	Icon as WCIcon,
 } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState, memo, useRef, useEffect } from '@wordpress/element';
@@ -127,7 +127,7 @@ function TemplateListItem( {
 				direction={ direction }
 			>
 				<div className="template-list-add-new-template__template-icon">
-					<Icon icon={ icon } />
+					<WCIcon icon={ icon } />
 				</div>
 				<VStack
 					className="template-list-add-new-template__template-name"

--- a/routes/template-list/fields/author.tsx
+++ b/routes/template-list/fields/author.tsx
@@ -6,7 +6,10 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	Icon as WCIcon,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
@@ -72,7 +75,7 @@ function AuthorField( { item }: { item: any } ) {
 			) }
 			{ ! imageUrl && (
 				<div className="routes-template-list-author-field__icon">
-					<Icon icon={ icon } />
+					<WCIcon icon={ icon } />
 				</div>
 			) }
 			<span className="routes-template-list-author-field__name">

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -265,6 +265,7 @@ export default dedupePlugins( [
 						// wp-ui Autocomplete is not a replacement for wp-components Autocomplete, but we need to avoid name clashes.
 						Autocomplete: 'WCAutocomplete',
 						Badge: 'WCBadge',
+						Icon: 'WCIcon',
 					},
 				},
 			],


### PR DESCRIPTION
## What?

Requires `Icon` from `@wordpress/components` to be imported as `WCIcon`, and updates the existing imports that use it.

## Why?

This avoids name clashes with `Icon` from `@wordpress/ui` as the UI package is introduced alongside the existing components package.

## How?

Adds `Icon: 'WCIcon'` to the `@wordpress/use-import-as` ESLint config, then renames the affected `@wordpress/components` imports and references.

## Testing Instructions

Eslint should pass.