### PR TITLE
Button block: move align attribute to buttons wrapper on transform

### DIFF
--- a/packages/block-library/src/buttons/test/transforms.js
+++ b/packages/block-library/src/buttons/test/transforms.js
@@ -1,0 +1,78 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createBlock,
+	getBlockTypes,
+	registerBlockType,
+	switchToBlockType,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import {
+	metadata as buttonsMetadata,
+	settings as buttonsSettings,
+} from '../index';
+import {
+	metadata as buttonMetadata,
+	settings as buttonSettings,
+} from '../../button/index';
+
+describe( 'transforms', () => {
+	beforeAll( () => {
+		registerBlockType( buttonMetadata, buttonSettings );
+		registerBlockType( buttonsMetadata, buttonsSettings );
+	} );
+
+	afterAll( () => {
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
+	describe( 'from core/button', () => {
+		it( 'should move the align attribute from the button to the buttons wrapper', () => {
+			const block = createBlock( 'core/button', {
+				text: 'Click me',
+				align: 'center',
+			} );
+
+			// Manually set align on the block attributes to simulate old markup
+			// where core/button supported align before it was moved to core/buttons.
+			block.attributes.align = 'center';
+
+			const [ result ] = switchToBlockType( block, 'core/buttons' );
+
+			expect( result.name ).toBe( 'core/buttons' );
+			expect( result.attributes.align ).toBe( 'center' );
+			expect( result.innerBlocks[ 0 ].attributes.align ).toBeUndefined();
+		} );
+
+		it( 'should not set align on the wrapper when the button has no align', () => {
+			const block = createBlock( 'core/button', { text: 'Click me' } );
+
+			const [ result ] = switchToBlockType( block, 'core/buttons' );
+
+			expect( result.name ).toBe( 'core/buttons' );
+			expect( result.attributes.align ).toBeUndefined();
+		} );
+
+		it( 'should move align from the first button when transforming multiple buttons', () => {
+			const block1 = createBlock( 'core/button', { text: 'First' } );
+			const block2 = createBlock( 'core/button', { text: 'Second' } );
+			block1.attributes.align = 'wide';
+
+			const [ result ] = switchToBlockType(
+				[ block1, block2 ],
+				'core/buttons'
+			);
+
+			expect( result.attributes.align ).toBe( 'wide' );
+			expect( result.innerBlocks[ 0 ].attributes.align ).toBeUndefined();
+			expect( result.innerBlocks[ 1 ].attributes.align ).toBeUndefined();
+		} );
+	} );
+} );

--- a/packages/block-library/src/buttons/transforms.js
+++ b/packages/block-library/src/buttons/transforms.js
@@ -15,17 +15,18 @@ const transforms = {
 			type: 'block',
 			isMultiBlock: true,
 			blocks: [ 'core/button' ],
-			transform: ( buttons ) =>
-				// Creates the buttons block.
-				createBlock(
+			transform: ( buttons ) => {
+				// Move align from the first button to the outer wrapper.
+				// core/button does not support align; it belongs on core/buttons.
+				const { align } = buttons[ 0 ];
+				return createBlock(
 					'core/buttons',
-					{},
-					// Loop the selected buttons.
-					buttons.map( ( attributes ) =>
-						// Create singular button in the buttons block.
-						createBlock( 'core/button', attributes )
+					align ? { align } : {},
+					buttons.map( ( { align: _align, ...buttonAttributes } ) =>
+						createBlock( 'core/button', buttonAttributes )
 					)
-				),
+				);
+			},
 		},
 		{
 			type: 'block',


### PR DESCRIPTION
Fixes #28957

## What?

When a `core/button` block with an `align` attribute is transformed to `core/buttons`, the `align` was incorrectly kept on the inner button block. Since `core/button` has `align: false` in its block supports, the attribute had no effect there — causing the button to fill its row via `flex-grow` regardless of the intended alignment.

## Why?

Old `core/button` blocks supported alignment directly on the button. After the `core/buttons` wrapper was introduced, alignment belongs on the wrapper. The transform was not moving it, leaving old markup in a broken state after the "Transform to Buttons" action.

## How?

In `buttons/transforms.js`, extract `align` from the first button's attributes and apply it to the outer `core/buttons` wrapper. Strip `align` from all inner button blocks since it is unsupported there (`align: false` in block supports).

**Before:**
\`\`\`
<!-- wp:buttons -->
<div class="wp-block-buttons">
  <!-- wp:button {"align":"center"} -->
  <div class="wp-block-button aligncenter">...</div>
  <!-- /wp:button -->
</div>
<!-- /wp:buttons -->
\`\`\`

**After:**
\`\`\`
<!-- wp:buttons {"align":"center"} -->
<div class="wp-block-buttons aligncenter">
  <!-- wp:button -->
  <div class="wp-block-button">...</div>
  <!-- /wp:button -->
</div>
<!-- /wp:buttons -->
\`\`\`

## Testing Instructions

1. Create a new post and insert a Button block (the singular one, not Buttons).
2. In the toolbar, set its alignment to **Wide width** or **Full width**.
3. Select the block and use **Transform to → Buttons**.
4. Confirm the resulting Buttons wrapper has the alignment applied (wide/full toolbar option is selected on the wrapper).
5. Confirm the inner button renders at its natural size, not filling the full row.
6. Repeat with no alignment set — the Buttons wrapper should have no alignment.

### Testing Instructions for Keyboard

1. Use **Tab** to focus the Button block.
2. Open the block toolbar with **Alt+F10** (or **Option+F10** on Mac).
3. Navigate to the alignment control with arrow keys and select **Wide width**.
4. Tab to the Transform button and activate with **Enter**.
5. Select **Buttons** from the transform list with arrow keys and **Enter**.
6. Verify the resulting Buttons wrapper has wide alignment applied correctly.

## Screenshots or screencast

_No visual change to add — the fix affects serialized block markup and transform behavior, not the visual appearance of the editor UI._

## Use of AI Tools

This pull request was developed with assistance from Claude (Anthropic). Claude was used to identify the root cause, implement the fix in `transforms.js`, and write the unit tests. The changes were reviewed and validated by running the test suite locally before submission.