### PR TITLE
[ui] Select: Default portal container to the wp compat overlay slot

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   Export `getWpCompatOverlaySlot()` so consumers can route their own portals into the compat overlay slot ([#78183](https://github.com/WordPress/gutenberg/pull/78183)).
+-   `Select`, `SelectControl`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so select popups stack reliably above other overlays in mixed-library compositions. A caller-supplied `Select.Portal` `container` prop continues to take precedence.
 
 ## 0.13.0 (2026-05-14)
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 -   Export `getWpCompatOverlaySlot()` so consumers can route their own portals into the compat overlay slot ([#78183](https://github.com/WordPress/gutenberg/pull/78183)).
--   `Select`, `SelectControl`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so select popups stack reliably above other overlays in mixed-library compositions. A caller-supplied `Select.Portal` `container` prop continues to take precedence.
+-   `Select`, `SelectControl`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so select popups stack reliably above other overlays in mixed-library compositions. A caller-supplied `Select.Portal` `container` prop continues to take precedence ([#78372](https://github.com/WordPress/gutenberg/pull/78372)).
 
 ## 0.13.0 (2026-05-14)
 

--- a/packages/ui/src/form/primitives/select/portal.tsx
+++ b/packages/ui/src/form/primitives/select/portal.tsx
@@ -1,14 +1,23 @@
 import { Select as _Select } from '@base-ui/react/select';
 import { forwardRef } from '@wordpress/element';
 import type { PortalProps } from './types';
+import { getWpCompatOverlaySlot } from '../../../utils/wp-compat-overlay-slot';
 
 /**
  * Used to apply custom portal behavior to `Select`'s listbox content.
+ * `container` defaults to the `@wordpress/ui` compat overlay slot.
  */
-const Portal = forwardRef< HTMLDivElement, PortalProps >(
-	function SelectPortal( props, ref ) {
-		return <_Select.Portal ref={ ref } { ...props } />;
-	}
-);
+const Portal = forwardRef< HTMLDivElement, PortalProps >( function SelectPortal(
+	{ container, ...restProps },
+	ref
+) {
+	return (
+		<_Select.Portal
+			container={ container ?? getWpCompatOverlaySlot() }
+			{ ...restProps }
+			ref={ ref }
+		/>
+	);
+} );
 
 export { Portal };

--- a/packages/ui/src/form/primitives/select/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/select/test/index.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';
+import type { ReactNode } from 'react';
 import * as Select from '../index';
+import { useEnableWpCompatOverlaySlot } from '../../../../utils/use-enable-wp-compat-overlay-slot';
 
 describe( 'Select', () => {
 	it( 'supports object item values', async () => {
@@ -239,4 +241,108 @@ describe( 'Select', () => {
 			expect( positioner ).toContainElement( item );
 		} );
 	} );
+
+	// Slot is identified by a data attribute, not a user-facing role/text.
+	/* eslint-disable testing-library/no-node-access */
+	describe( 'wp compat overlay slot', () => {
+		const SLOT_SELECTOR = '[data-wp-compat-overlay-slot]';
+
+		// Exercises the public opt-in path rather than poking the flag.
+		function WithSlotEnabled( { children }: { children: ReactNode } ) {
+			useEnableWpCompatOverlaySlot();
+			return <>{ children }</>;
+		}
+
+		afterEach( () => {
+			// The hook is one-way at runtime; reset explicitly between tests.
+			delete ( window as { __wpUiCompatOverlaySlotEnabled?: boolean } )
+				.__wpUiCompatOverlaySlotEnabled;
+			document
+				.querySelectorAll( SLOT_SELECTOR )
+				.forEach( ( el ) => el.remove() );
+		} );
+
+		it( 'portals the popup into the slot when the consumer opts in', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<WithSlotEnabled>
+					<Select.Root>
+						<Select.Trigger />
+						<Select.Popup>
+							<Select.Item value="Item 1">Item 1</Select.Item>
+						</Select.Popup>
+					</Select.Root>
+				</WithSlotEnabled>
+			);
+
+			await user.click( screen.getByRole( 'combobox' ) );
+
+			const item = await screen.findByRole( 'option', {
+				name: 'Item 1',
+			} );
+			expect( item ).toBeVisible();
+
+			const slot = document.querySelector( SLOT_SELECTOR );
+			expect( slot ).not.toBeNull();
+			expect( slot ).toContainElement( item );
+		} );
+
+		it( 'does not create a slot when the consumer has not opted in (dormant default)', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<Select.Root>
+					<Select.Trigger />
+					<Select.Popup>
+						<Select.Item value="Item 1">Item 1</Select.Item>
+					</Select.Popup>
+				</Select.Root>
+			);
+
+			await user.click( screen.getByRole( 'combobox' ) );
+
+			const item = await screen.findByRole( 'option', {
+				name: 'Item 1',
+			} );
+			expect( item ).toBeVisible();
+
+			expect( document.querySelector( SLOT_SELECTOR ) ).toBeNull();
+		} );
+
+		it( 'lets a caller-supplied portal container override the slot', async () => {
+			const user = userEvent.setup();
+			const containerRef = createRef< HTMLDivElement >();
+
+			render(
+				<WithSlotEnabled>
+					<Select.Root>
+						<Select.Trigger />
+						<div
+							ref={ containerRef }
+							data-testid="custom-container"
+						/>
+						<Select.Popup
+							portal={
+								<Select.Portal container={ containerRef } />
+							}
+						>
+							<Select.Item value="Item 1">Item 1</Select.Item>
+						</Select.Popup>
+					</Select.Root>
+				</WithSlotEnabled>
+			);
+
+			await user.click( screen.getByRole( 'combobox' ) );
+
+			const item = await screen.findByRole( 'option', {
+				name: 'Item 1',
+			} );
+			expect( item ).toBeVisible();
+			expect( screen.getByTestId( 'custom-container' ) ).toContainElement(
+				item
+			);
+		} );
+	} );
+	/* eslint-enable testing-library/no-node-access */
 } );

--- a/packages/ui/src/form/select-control/test/index.test.tsx
+++ b/packages/ui/src/form/select-control/test/index.test.tsx
@@ -1,7 +1,9 @@
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';
+import type { ReactNode } from 'react';
 import { SelectControl } from '../index';
+import { useEnableWpCompatOverlaySlot } from '../../../utils/use-enable-wp-compat-overlay-slot';
 
 describe( 'SelectControl', () => {
 	const mockItems = [
@@ -193,4 +195,66 @@ describe( 'SelectControl', () => {
 			expect( formData.get( 'country' ) ).toBe( '' );
 		} );
 	} );
+
+	// Slot is identified by a data attribute, not a user-facing role/text.
+	/* eslint-disable testing-library/no-node-access */
+	describe( 'wp compat overlay slot', () => {
+		const SLOT_SELECTOR = '[data-wp-compat-overlay-slot]';
+
+		// Exercises the public opt-in path rather than poking the flag.
+		function WithSlotEnabled( { children }: { children: ReactNode } ) {
+			useEnableWpCompatOverlaySlot();
+			return <>{ children }</>;
+		}
+
+		afterEach( () => {
+			// The hook is one-way at runtime; reset explicitly between tests.
+			delete ( window as { __wpUiCompatOverlaySlotEnabled?: boolean } )
+				.__wpUiCompatOverlaySlotEnabled;
+			document
+				.querySelectorAll( SLOT_SELECTOR )
+				.forEach( ( el ) => el.remove() );
+		} );
+
+		it( 'portals the popup into the slot when the consumer opts in', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<WithSlotEnabled>
+					<SelectControl label="Country" items={ mockItems } />
+				</WithSlotEnabled>
+			);
+
+			await user.click(
+				screen.getByRole( 'combobox', { name: 'Country' } )
+			);
+
+			const option = await screen.findByRole( 'option', {
+				name: 'Option 1',
+			} );
+			expect( option ).toBeVisible();
+
+			const slot = document.querySelector( SLOT_SELECTOR );
+			expect( slot ).not.toBeNull();
+			expect( slot ).toContainElement( option );
+		} );
+
+		it( 'does not create a slot when the consumer has not opted in (dormant default)', async () => {
+			const user = userEvent.setup();
+
+			render( <SelectControl label="Country" items={ mockItems } /> );
+
+			await user.click(
+				screen.getByRole( 'combobox', { name: 'Country' } )
+			);
+
+			const option = await screen.findByRole( 'option', {
+				name: 'Option 1',
+			} );
+			expect( option ).toBeVisible();
+
+			expect( document.querySelector( SLOT_SELECTOR ) ).toBeNull();
+		} );
+	} );
+	/* eslint-enable testing-library/no-node-access */
 } );

--- a/storybook/stories/playground/wp-compat-overlay-slot.story.jsx
+++ b/storybook/stories/playground/wp-compat-overlay-slot.story.jsx
@@ -8,18 +8,27 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import * as Tooltip from '../../../packages/ui/src/tooltip';
+import * as Select from '../../../packages/ui/src/form/primitives/select';
+import { SelectControl } from '../../../packages/ui/src/form/select-control';
 import { WithWpCompatOverlaySlot } from './with-wp-compat-overlay-slot';
 
-// Cross-library stacking: a `@wordpress/ui` Tooltip inside a
-// `@wordpress/components` Modal / Popover should sit above the
-// components-side overlay via the compat overlay slot.
+const selectItems = [
+	{ value: 'option-1', label: 'Option 1' },
+	{ value: 'option-2', label: 'Option 2' },
+	{ value: 'option-3', label: 'Option 3' },
+];
+
+// Cross-library stacking: `@wordpress/ui` overlays (`Tooltip`, `Select`,
+// `SelectControl`) inside a `@wordpress/components` Modal / Popover
+// should sit above the components-side overlay via the compat overlay
+// slot.
 export default {
 	title: 'Playground/Debug fixtures/WP Compat Overlay Slot',
 	decorators: [ WithWpCompatOverlaySlot ],
 };
 
 export const InsideComponentsModal = {
-	name: 'Tooltip inside @wordpress/components Modal',
+	name: 'Overlays inside @wordpress/components Modal',
 	render: function Render() {
 		const [ isOpen, setIsOpen ] = useState( false );
 		return (
@@ -33,9 +42,9 @@ export const InsideComponentsModal = {
 						onRequestClose={ () => setIsOpen( false ) }
 					>
 						<p>
-							The Tooltip below is from `@wordpress/ui`. Hover its
-							trigger; the tooltip popup should render above this
-							modal, not behind it.
+							The overlays below are from `@wordpress/ui`. Their
+							popups should render above this modal, not behind
+							it.
 						</p>
 						<Tooltip.Provider delay={ 0 }>
 							<Tooltip.Root>
@@ -46,6 +55,29 @@ export const InsideComponentsModal = {
 								</Tooltip.Popup>
 							</Tooltip.Root>
 						</Tooltip.Provider>
+
+						<div style={ { marginTop: '1rem' } }>
+							<Select.Root items={ selectItems }>
+								<Select.Trigger aria-label="Select primitive" />
+								<Select.Popup>
+									{ selectItems.map( ( item ) => (
+										<Select.Item
+											key={ item.value }
+											value={ item }
+										>
+											{ item.label }
+										</Select.Item>
+									) ) }
+								</Select.Popup>
+							</Select.Root>
+						</div>
+
+						<div style={ { marginTop: '1rem' } }>
+							<SelectControl
+								label="SelectControl"
+								items={ selectItems }
+							/>
+						</div>
 					</Modal>
 				) }
 			</>
@@ -54,7 +86,7 @@ export const InsideComponentsModal = {
 };
 
 export const InsideComponentsPopover = {
-	name: 'Tooltip inside @wordpress/components Popover',
+	name: 'Overlays inside @wordpress/components Popover',
 	render: function Render() {
 		const [ anchor, setAnchor ] = useState( null );
 		const [ isOpen, setIsOpen ] = useState( false );
@@ -74,9 +106,8 @@ export const InsideComponentsPopover = {
 					>
 						<div style={ { padding: '1rem', maxWidth: '20rem' } }>
 							<p>
-								The Tooltip below is from `@wordpress/ui`. Hover
-								its trigger; the tooltip popup should render
-								above this popover.
+								The overlays below are from `@wordpress/ui`.
+								Their popups should render above this popover.
 							</p>
 							<Tooltip.Provider delay={ 0 }>
 								<Tooltip.Root>
@@ -87,6 +118,29 @@ export const InsideComponentsPopover = {
 									</Tooltip.Popup>
 								</Tooltip.Root>
 							</Tooltip.Provider>
+
+							<div style={ { marginTop: '1rem' } }>
+								<Select.Root items={ selectItems }>
+									<Select.Trigger aria-label="Select primitive" />
+									<Select.Popup>
+										{ selectItems.map( ( item ) => (
+											<Select.Item
+												key={ item.value }
+												value={ item }
+											>
+												{ item.label }
+											</Select.Item>
+										) ) }
+									</Select.Popup>
+								</Select.Root>
+							</div>
+
+							<div style={ { marginTop: '1rem' } }>
+								<SelectControl
+									label="SelectControl"
+									items={ selectItems }
+								/>
+							</div>
 						</div>
 					</Popover>
 				) }


### PR DESCRIPTION
## What?

Wires `Select.Portal`'s `container` to default to the wp compat overlay slot from #77851, mirroring the `Tooltip` wiring landed in #78095. `SelectControl` wraps `Select` internally, so it inherits the new behavior automatically.

A caller-supplied `Select.Portal` `container` continues to take precedence. No behavior change for `@wordpress/ui`-only consumers.

## Testing Instructions

### Unit

```sh
npx jest --config=test/unit/jest.config.js --testPathPattern='packages/ui/src/form/(primitives/select|select-control)/test/index'
```

Expected: 16 passing — 9 in `Select` (6 pre-existing + 3 new) and 7 in `SelectControl` (5 pre-existing + 2 new), under a `wp compat overlay slot` describe block.

### Storybook (cross-library stacking)

```sh
npm run storybook:dev
```

Open **Playground / Debug fixtures / WP Compat Overlay Slot / Overlays inside @wordpress/components Modal** (and the Popover variant): the `Select` and `SelectControl` popups render above the components-side overlay, portaled into `[data-wp-compat-overlay-slot]`.

In any other (un-decorated) story — e.g. **Design System / Components / Form / Primitives / Select / Default** — confirm the dormant baseline: the popup uses the default portal container and `[data-wp-compat-overlay-slot]` is absent from the DOM.

### Editor (auto-detect, real consumer)

The slot auto-detects `window.wp.components`. To exercise the wiring end-to-end, swap an existing `@wordpress/components` `SelectControl` for a `@wordpress/ui` one — example below.

Then `npm run dev`, open a post, and open the **Author** select in the Settings sidebar. In DevTools, confirm the popup portals into `[data-wp-compat-overlay-slot]` on `document.body`.

<details>
<summary>Example patch — Post Author select</summary>

`@wordpress/ui`'s `SelectControl` types item `value` as `string | null` and passes the matching item object (not the raw value) through `value` / `onValueChange`. `authorOptions` from core-data carry numeric IDs, hence the `String` / `Number` conversions on the boundaries — they're a quirk of the example, not the wiring.

```diff
diff --git a/packages/editor/src/components/post-author/select.js b/packages/editor/src/components/post-author/select.js
--- a/packages/editor/src/components/post-author/select.js
+++ b/packages/editor/src/components/post-author/select.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
-import { SelectControl } from '@wordpress/components';
+import { SelectControl } from '@wordpress/ui';

 /**
  * Internal dependencies
@@ -15,19 +15,21 @@ export default function PostAuthorSelect() {
 	const { editPost } = useDispatch( editorStore );
 	const { authorId, authorOptions } = useAuthorsQuery();

-	const setAuthorId = ( value ) => {
-		const author = Number( value );
-		editPost( { author } );
-	};
+	const items = ( authorOptions ?? [] ).map( ( { label, value } ) => ( {
+		label,
+		value: String( value ),
+	} ) );

 	return (
 		<SelectControl
-			__next40pxDefaultSize
 			className="post-author-selector"
 			label={ __( 'Author' ) }
-			options={ authorOptions }
-			onChange={ setAuthorId }
-			value={ authorId }
-			hideLabelFromVision
+			items={ items }
+			value={
+				items.find( ( item ) => item.value === String( authorId ) ) ?? null
+			}
+			onValueChange={ ( item ) =>
+				editPost( { author: Number( item?.value ) } )
+			}
+			hideLabelFromVision
 		/>
 	);
 }
```

</details>

<details>
<summary>Files touched</summary>

- `packages/ui/src/form/primitives/select/portal.tsx` — the wiring itself.
- `packages/ui/src/form/primitives/select/test/index.test.tsx` — 3 new tests under a `wp compat overlay slot` describe block.
- `packages/ui/src/form/select-control/test/index.test.tsx` — 2 new tests covering the inherited wiring.
- `storybook/stories/playground/wp-compat-overlay-slot.story.jsx` — extends the existing cross-library demo with `Select` and `SelectControl` alongside `Tooltip`.

</details>

<img width="2354" height="1216" alt="Screenshot 2026-05-16 at 13 50 45" src="https://github.com/user-attachments/assets/f812d1e3-670e-4402-a8c8-ed260e204518" />

<img width="3600" height="2016" alt="Screenshot 2026-05-16 at 13 54 22" src="https://github.com/user-attachments/assets/48cd1170-fb0e-42d1-af12-653ef0dca358" />

## Next Steps

Continue wiring the remaining `@wordpress/ui` overlays onto the slot in subsequent PRs.

## Use of AI Tools

Authored with Cursor (Claude). Author reviewed all changes.
