### PR TITLE
docker compose -T if stdin is not a tty

### DIFF
--- a/packages/env/lib/runtime/docker/index.js
+++ b/packages/env/lib/runtime/docker/index.js
@@ -787,7 +787,7 @@ class DockerRuntime {
 			hostUser.fullUser,
 		];
 
-		if ( ! process.stdout.isTTY ) {
+		if ( ! process.stdout.isTTY || ! process.stdin.isTTY ) {
 			composeCommand.push( '-T' );
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR adds `-T` to docker compose commands if stdin is not a TTY.

## Why?

There's already a check for stdout: https://github.com/WordPress/gutenberg/blob/e4fcfecee9271267101a15ebda121374c7410fed/packages/env/lib/runtime/docker/index.js#L790-L792

but git hooks have stdout as a tty but stdin as not a tty. https://github.com/git/git/blob/59ff4886a579f4bc91e976fe18590b9ae02c7a08/hook.c#L589

This means wp-env commands run from a git hook don't have `-T`. docker compose errors with:

```
the input device is not a TTY
✖ Command failed with exit code 1
```

## How?

Always add `-T` if either stdout or stdin is not a tty.

## Testing Instructions

1. Observe error with `wp-env run cli ls < /dev/null`
2. link this package with `npm link` and then where wp-env is a dependency, `npm link @wordpress/env`
3. Observe success with `wp-env run cli ls < /dev/null`

### Testing Instructions for Keyboard

n/a

## Use of AI Tools

I did not use AI tools to write this code.
