### PR TITLE
[ui] Autocomplete: Default portal container to the wp compat overlay slot

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 -   Export `getWpCompatOverlaySlot()` so consumers can route their own portals into the compat overlay slot ([#78183](https://github.com/WordPress/gutenberg/pull/78183)).
 -   `Select`, `SelectControl`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so select popups stack reliably above other overlays in mixed-library compositions. A caller-supplied `Select.Portal` `container` prop continues to take precedence ([#78372](https://github.com/WordPress/gutenberg/pull/78372)).
+-   `Autocomplete`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so autocomplete popups stack reliably above other overlays in mixed-library compositions. A caller-supplied `Autocomplete.Portal` `container` prop continues to take precedence.
 
 ## 0.13.0 (2026-05-14)
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 -   Export `getWpCompatOverlaySlot()` so consumers can route their own portals into the compat overlay slot ([#78183](https://github.com/WordPress/gutenberg/pull/78183)).
 -   `Select`, `SelectControl`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so select popups stack reliably above other overlays in mixed-library compositions. A caller-supplied `Select.Portal` `container` prop continues to take precedence ([#78372](https://github.com/WordPress/gutenberg/pull/78372)).
--   `Autocomplete`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so autocomplete popups stack reliably above other overlays in mixed-library compositions. A caller-supplied `Autocomplete.Portal` `container` prop continues to take precedence.
+-   `Autocomplete`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so autocomplete popups stack reliably above other overlays in mixed-library compositions. A caller-supplied `Autocomplete.Portal` `container` prop continues to take precedence ([#78375](https://github.com/WordPress/gutenberg/pull/78375)).
 
 ## 0.13.0 (2026-05-14)
 

--- a/packages/ui/src/form/primitives/autocomplete/portal.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/portal.tsx
@@ -1,13 +1,21 @@
 import { Autocomplete as _Autocomplete } from '@base-ui/react/autocomplete';
 import { forwardRef } from '@wordpress/element';
 import type { PortalProps } from './types';
+import { getWpCompatOverlaySlot } from '../../../utils/wp-compat-overlay-slot';
 
 /**
  * Used to apply custom portal behavior to `Autocomplete`'s popup content.
+ * `container` defaults to the `@wordpress/ui` compat overlay slot.
  */
 const Portal = forwardRef< HTMLDivElement, PortalProps >(
-	function AutocompletePortal( props, ref ) {
-		return <_Autocomplete.Portal ref={ ref } { ...props } />;
+	function AutocompletePortal( { container, ...restProps }, ref ) {
+		return (
+			<_Autocomplete.Portal
+				container={ container ?? getWpCompatOverlaySlot() }
+				{ ...restProps }
+				ref={ ref }
+			/>
+		);
 	}
 );
 

--- a/packages/ui/src/form/primitives/autocomplete/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/test/index.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';
+import type { ReactNode } from 'react';
 import * as Autocomplete from '../index';
+import { useEnableWpCompatOverlaySlot } from '../../../../utils/use-enable-wp-compat-overlay-slot';
 
 const ITEMS = [
 	{ id: '1', value: 'Item 1' },
@@ -200,4 +202,149 @@ describe( 'Autocomplete', () => {
 			expect( positioner ).toContainElement( item );
 		} );
 	} );
+
+	// Slot is identified by a data attribute, not a user-facing role/text.
+	/* eslint-disable testing-library/no-node-access */
+	describe( 'wp compat overlay slot', () => {
+		const SLOT_SELECTOR = '[data-wp-compat-overlay-slot]';
+
+		// Exercises the public opt-in path rather than poking the flag.
+		function WithSlotEnabled( { children }: { children: ReactNode } ) {
+			useEnableWpCompatOverlaySlot();
+			return <>{ children }</>;
+		}
+
+		afterEach( () => {
+			// The hook is one-way at runtime; reset explicitly between tests.
+			delete ( window as { __wpUiCompatOverlaySlotEnabled?: boolean } )
+				.__wpUiCompatOverlaySlotEnabled;
+			document
+				.querySelectorAll( SLOT_SELECTOR )
+				.forEach( ( el ) => el.remove() );
+		} );
+
+		it( 'portals the popup into the slot when the consumer opts in', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<WithSlotEnabled>
+					<Autocomplete.Root items={ ITEMS }>
+						<Autocomplete.Input placeholder="Search" />
+						<Autocomplete.Popup>
+							<Autocomplete.List>
+								<Autocomplete.ListBody>
+									<Autocomplete.Collection>
+										{ ( item ) => (
+											<Autocomplete.Item
+												key={ item.id }
+												value={ item }
+											>
+												{ item.value }
+											</Autocomplete.Item>
+										) }
+									</Autocomplete.Collection>
+								</Autocomplete.ListBody>
+							</Autocomplete.List>
+						</Autocomplete.Popup>
+					</Autocomplete.Root>
+				</WithSlotEnabled>
+			);
+
+			await user.type( screen.getByRole( 'combobox' ), 'Item 1' );
+
+			const item = await screen.findByRole( 'option', {
+				name: 'Item 1',
+			} );
+			expect( item ).toBeVisible();
+
+			const slot = document.querySelector( SLOT_SELECTOR );
+			expect( slot ).not.toBeNull();
+			expect( slot ).toContainElement( item );
+		} );
+
+		it( 'does not create a slot when the consumer has not opted in (dormant default)', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<Autocomplete.Root items={ ITEMS }>
+					<Autocomplete.Input placeholder="Search" />
+					<Autocomplete.Popup>
+						<Autocomplete.List>
+							<Autocomplete.ListBody>
+								<Autocomplete.Collection>
+									{ ( item ) => (
+										<Autocomplete.Item
+											key={ item.id }
+											value={ item }
+										>
+											{ item.value }
+										</Autocomplete.Item>
+									) }
+								</Autocomplete.Collection>
+							</Autocomplete.ListBody>
+						</Autocomplete.List>
+					</Autocomplete.Popup>
+				</Autocomplete.Root>
+			);
+
+			await user.type( screen.getByRole( 'combobox' ), 'Item 1' );
+
+			const item = await screen.findByRole( 'option', {
+				name: 'Item 1',
+			} );
+			expect( item ).toBeVisible();
+
+			expect( document.querySelector( SLOT_SELECTOR ) ).toBeNull();
+		} );
+
+		it( 'lets a caller-supplied portal container override the slot', async () => {
+			const user = userEvent.setup();
+			const containerRef = createRef< HTMLDivElement >();
+
+			render(
+				<WithSlotEnabled>
+					<Autocomplete.Root items={ ITEMS }>
+						<Autocomplete.Input placeholder="Search" />
+						<div
+							ref={ containerRef }
+							data-testid="custom-container"
+						/>
+						<Autocomplete.Popup
+							portal={
+								<Autocomplete.Portal
+									container={ containerRef }
+								/>
+							}
+						>
+							<Autocomplete.List>
+								<Autocomplete.ListBody>
+									<Autocomplete.Collection>
+										{ ( item ) => (
+											<Autocomplete.Item
+												key={ item.id }
+												value={ item }
+											>
+												{ item.value }
+											</Autocomplete.Item>
+										) }
+									</Autocomplete.Collection>
+								</Autocomplete.ListBody>
+							</Autocomplete.List>
+						</Autocomplete.Popup>
+					</Autocomplete.Root>
+				</WithSlotEnabled>
+			);
+
+			await user.type( screen.getByRole( 'combobox' ), 'Item 1' );
+
+			const item = await screen.findByRole( 'option', {
+				name: 'Item 1',
+			} );
+			expect( item ).toBeVisible();
+			expect( screen.getByTestId( 'custom-container' ) ).toContainElement(
+				item
+			);
+		} );
+	} );
+	/* eslint-enable testing-library/no-node-access */
 } );

--- a/storybook/stories/playground/wp-compat-overlay-slot.story.jsx
+++ b/storybook/stories/playground/wp-compat-overlay-slot.story.jsx
@@ -10,6 +10,7 @@ import { useState } from '@wordpress/element';
 import * as Tooltip from '../../../packages/ui/src/tooltip';
 import * as Select from '../../../packages/ui/src/form/primitives/select';
 import { SelectControl } from '../../../packages/ui/src/form/select-control';
+import * as Autocomplete from '../../../packages/ui/src/form/primitives/autocomplete';
 import { WithWpCompatOverlaySlot } from './with-wp-compat-overlay-slot';
 
 const selectItems = [
@@ -18,10 +19,16 @@ const selectItems = [
 	{ value: 'option-3', label: 'Option 3' },
 ];
 
+const autocompleteItems = [
+	{ id: '1', value: 'Item 1' },
+	{ id: '2', value: 'Item 2' },
+	{ id: '3', value: 'Item 3' },
+];
+
 // Cross-library stacking: `@wordpress/ui` overlays (`Tooltip`, `Select`,
-// `SelectControl`) inside a `@wordpress/components` Modal / Popover
-// should sit above the components-side overlay via the compat overlay
-// slot.
+// `SelectControl`, `Autocomplete`) inside a `@wordpress/components`
+// Modal / Popover should sit above the components-side overlay via the
+// compat overlay slot.
 export default {
 	title: 'Playground/Debug fixtures/WP Compat Overlay Slot',
 	decorators: [ WithWpCompatOverlaySlot ],
@@ -77,6 +84,34 @@ export const InsideComponentsModal = {
 								label="SelectControl"
 								items={ selectItems }
 							/>
+						</div>
+
+						<div style={ { marginTop: '1rem' } }>
+							<Autocomplete.Root items={ autocompleteItems }>
+								<Autocomplete.Input
+									placeholder="Search items"
+									aria-label="Autocomplete primitive"
+								/>
+								<Autocomplete.Popup>
+									<Autocomplete.Empty>
+										No matching items.
+									</Autocomplete.Empty>
+									<Autocomplete.List>
+										<Autocomplete.ListBody>
+											<Autocomplete.Collection>
+												{ ( item ) => (
+													<Autocomplete.Item
+														key={ item.id }
+														value={ item }
+													>
+														{ item.value }
+													</Autocomplete.Item>
+												) }
+											</Autocomplete.Collection>
+										</Autocomplete.ListBody>
+									</Autocomplete.List>
+								</Autocomplete.Popup>
+							</Autocomplete.Root>
 						</div>
 					</Modal>
 				) }
@@ -140,6 +175,34 @@ export const InsideComponentsPopover = {
 									label="SelectControl"
 									items={ selectItems }
 								/>
+							</div>
+
+							<div style={ { marginTop: '1rem' } }>
+								<Autocomplete.Root items={ autocompleteItems }>
+									<Autocomplete.Input
+										placeholder="Search items"
+										aria-label="Autocomplete primitive"
+									/>
+									<Autocomplete.Popup>
+										<Autocomplete.Empty>
+											No matching items.
+										</Autocomplete.Empty>
+										<Autocomplete.List>
+											<Autocomplete.ListBody>
+												<Autocomplete.Collection>
+													{ ( item ) => (
+														<Autocomplete.Item
+															key={ item.id }
+															value={ item }
+														>
+															{ item.value }
+														</Autocomplete.Item>
+													) }
+												</Autocomplete.Collection>
+											</Autocomplete.ListBody>
+										</Autocomplete.List>
+									</Autocomplete.Popup>
+								</Autocomplete.Root>
 							</div>
 						</div>
 					</Popover>


### PR DESCRIPTION
## What?

Wires `Autocomplete.Portal`'s `container` to default to the wp compat overlay slot from #77851, mirroring the `Tooltip` wiring landed in #78095 (and the `Select` wiring in #78372).

A caller-supplied `Autocomplete.Portal` `container` continues to take precedence. No behavior change for `@wordpress/ui`-only consumers.

## Testing Instructions

### Unit

```sh
npx jest --config=test/unit/jest.config.js --testPathPattern='packages/ui/src/form/primitives/autocomplete/test/index'
```

Expected: 7 passing (4 pre-existing + 3 new under a `wp compat overlay slot` describe block).

### Storybook (cross-library stacking)

```sh
npm run storybook:dev
```

Open **Playground / Debug fixtures / WP Compat Overlay Slot / Overlays inside @wordpress/components Modal** (and the Popover variant): the `Autocomplete` popup renders above the components-side overlay, portaled into `[data-wp-compat-overlay-slot]`.

In any other (un-decorated) story — e.g. **Design System / Components / Form / Primitives / Autocomplete / Default** — confirm the dormant baseline: the popup uses the default portal container and `[data-wp-compat-overlay-slot]` is absent from the DOM.

### Editor (auto-detect, real consumer)

The slot auto-detects `window.wp.components`. To exercise the wiring end-to-end, swap the same Post Author select used in #78372 for an `@wordpress/ui` `Autocomplete` — example below.

Then `npm run dev`, open a post, focus the **Author** field in the Settings sidebar. In DevTools, confirm the autocomplete popup portals into `[data-wp-compat-overlay-slot]` on `document.body`.

<details>
<summary>Example patch — Post Author as Autocomplete</summary>

`@wordpress/ui` `Autocomplete` is a free-form-text-plus-suggestions primitive, not a 1:1 replacement for a `SelectControl`. The patch keeps the swap minimal — enough to render a popup whose portal can be inspected — without trying to fully reproduce the original behavior. Item selection commits the chosen author via `editPost`.

```diff
diff --git a/packages/editor/src/components/post-author/select.js b/packages/editor/src/components/post-author/select.js
--- a/packages/editor/src/components/post-author/select.js
+++ b/packages/editor/src/components/post-author/select.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
-import { SelectControl } from '@wordpress/components';
+import { Autocomplete } from '@wordpress/ui';

 /**
  * Internal dependencies
@@ -15,19 +15,40 @@ export default function PostAuthorSelect() {
 	const { editPost } = useDispatch( editorStore );
 	const { authorId, authorOptions } = useAuthorsQuery();

-	const setAuthorId = ( value ) => {
-		const author = Number( value );
-		editPost( { author } );
-	};
+	const items = ( authorOptions ?? [] ).map( ( { label, value } ) => ( {
+		id: String( value ),
+		value: label,
+	} ) );
+	const selectedLabel =
+		items.find( ( item ) => item.id === String( authorId ) )?.value ?? '';

 	return (
-		<SelectControl
-			__next40pxDefaultSize
-			className="post-author-selector"
-			label={ __( 'Author' ) }
-			options={ authorOptions }
-			onChange={ setAuthorId }
-			value={ authorId }
-			hideLabelFromVision
-		/>
+		<Autocomplete.Root items={ items } defaultValue={ selectedLabel }>
+			<Autocomplete.Input
+				aria-label={ __( 'Author' ) }
+				className="post-author-selector"
+				placeholder={ __( 'Author' ) }
+			/>
+			<Autocomplete.Popup>
+				<Autocomplete.Empty>
+					{ __( 'No matching authors.' ) }
+				</Autocomplete.Empty>
+				<Autocomplete.List>
+					<Autocomplete.ListBody>
+						<Autocomplete.Collection>
+							{ ( item ) => (
+								<Autocomplete.Item
+									key={ item.id }
+									value={ item }
+									onClick={ () =>
+										editPost( { author: Number( item.id ) } )
+									}
+								>
+									{ item.value }
+								</Autocomplete.Item>
+							) }
+						</Autocomplete.Collection>
+					</Autocomplete.ListBody>
+				</Autocomplete.List>
+			</Autocomplete.Popup>
+		</Autocomplete.Root>
 	);
 }
```

</details>

<details>
<summary>Files touched</summary>

- `packages/ui/src/form/primitives/autocomplete/portal.tsx` — the wiring itself.
- `packages/ui/src/form/primitives/autocomplete/test/index.test.tsx` — 3 new tests under a `wp compat overlay slot` describe block.
- `storybook/stories/playground/wp-compat-overlay-slot.story.jsx` — extends the existing cross-library demo with `Autocomplete` alongside `Tooltip`.

</details>

<img width="2442" height="2020" alt="Screenshot 2026-05-16 at 14 58 28" src="https://github.com/user-attachments/assets/409edb34-45c9-410c-8beb-e66898c8e5ee" />

## Next Steps

Continue wiring the remaining `@wordpress/ui` overlays onto the slot in subsequent PRs.

## Use of AI Tools

Authored with Cursor (Claude). Author reviewed all changes.
