### PR TITLE
Docs: Clarify block registration `parent` parameter type, default value, and empty array behavior

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -166,12 +166,15 @@ An implementation should expect and tolerate unknown categories, providing some 
 -   Optional
 -   Localized: No
 -   Property: `parent`
+-   Default: `undefined`
 
 ```json
 { "parent": [ "my-block/product" ] }
 ```
 
-Setting `parent` lets a block require that it is only available when nested within the specified blocks. For example, you might want to allow an 'Add to Cart' block to only be available within a 'Product' block.
+Setting `parent` lets a block require that it is only available when nested within the specified blocks. For example, you might want to allow an 'Add to Cart' block to only be available within a 'Product' block. When `parent` is omitted or `undefined`, the block can be inserted anywhere in the editor without restriction.
+
+Note: Providing an empty array (`"parent": []`) will prevent the block from being inserted anywhere in the editor, effectively making it unavailable. To allow a block everywhere, omit the `parent` property entirely.
 
 ### Ancestor
 

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -275,16 +275,19 @@ Transforms provide rules for what a block can be transformed from and what it ca
 
 #### parent (optional)
 
--   **Type:** `Array`
+-   **Type:** `string[]`
+-   **Default:** `undefined`
 
 Blocks are able to be inserted into blocks that use [`InnerBlocks`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inner-blocks/README.md) as nested content. Sometimes it is useful to restrict a block so that it is only available as a nested block. For example, you might want to allow an 'Add to Cart' block to only be available within a 'Product' block.
 
-Setting `parent` lets a block require that it is only available when nested within the specified blocks.
+Setting `parent` lets a block require that it is only available when nested within the specified blocks. When `parent` is omitted or `undefined`, the block can be inserted anywhere in the editor without restriction.
 
 ```js
 // Only allow this block when it is nested in a Columns block
 parent: [ 'core/columns' ],
 ```
+
+Note: Providing an empty array (`parent: []`) will prevent the block from being inserted anywhere in the editor, effectively making it unavailable. To allow a block everywhere, omit the `parent` property entirely.
 
 #### ancestor (optional)
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes [#15731](https://github.com/WordPress/gutenberg/issues/15731)

Improves documentation for the `parent` block registration parameter in two reference guides:
- `block-registration.md`
- `block-metadata.md`

## Changes
- Updated type from vague `Array` to `string[]`
- Added explicit `Default: undefined` field
- Clarified that omitting `parent` allows the block to be inserted anywhere
- Documented that `parent: []` (empty array) prevents the block from being inserted anywhere, effectively disabling it

The empty array behavior was confirmed by tracing `checkAllowList()` in `packages/block-editor/src/store/utils.js`.