### PR TITLE
Editor: Use _n() for revisions count aria-label

### DIFF
--- a/packages/editor/src/components/post-last-revision/index.js
+++ b/packages/editor/src/components/post-last-revision/index.js
@@ -88,10 +88,10 @@ export function PrivatePostLastRevision() {
 					className="editor-private-post-last-revision__button"
 					text={ revisionsCount }
 					aria-label={ sprintf(
-						/* translators: %s: number of revisions. */
+						/* translators: %d: number of revisions. */
 						_n(
-							'Open revisions screen: %s revision',
-							'Open revisions screen: %s revisions',
+							'Open revisions screen: %d revision',
+							'Open revisions screen: %d revisions',
 							revisionsCount
 						),
 						revisionsCount

--- a/packages/editor/src/components/post-last-revision/index.js
+++ b/packages/editor/src/components/post-last-revision/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { sprintf, __ } from '@wordpress/i18n';
+import { sprintf, __, _n } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { backup } from '@wordpress/icons';
@@ -89,7 +89,11 @@ export function PrivatePostLastRevision() {
 					text={ revisionsCount }
 					aria-label={ sprintf(
 						/* translators: %s: number of revisions. */
-						__( 'Open revisions screen: %s revisions' ),
+						_n(
+							'Open revisions screen: %s revision',
+							'Open revisions screen: %s revisions',
+							revisionsCount
+						),
 						revisionsCount
 					) }
 					variant="tertiary"


### PR DESCRIPTION
## What?
Closes #78381

Follow-up to #78140, which introduced a descriptive `aria-label` on the Revisions button in the Post Summary sidebar:

> `Open revisions screen: %s revisions`


Props @tobifjellner 

## Why?
The string was wrapped in `__()`, so the word "revisions" cannot be pluralized for languages with more complex plural rules than English. Switching to `_n()` lets translators provide the correct plural form (including singular "1 revision").

## How?
In `packages/editor/src/components/post-last-revision/index.js`, the `aria-label` now uses `_n()`:

```js
_n(
    'Open revisions screen: %s revision',
    'Open revisions screen: %s revisions',
    revisionsCount
)
```

## Testing Instructions
1. Open a post or page that has revisions.
2. Open the **Settings** sidebar → **Post** tab → **Summary** panel.
3. Inspect the **Revisions** button and confirm the `aria-label` reads `Open revisions screen: N revisions` (or `1 revision` if only one revision exists).
4. Verify with a screen reader that the button is announced correctly.

<img width="842" height="55" alt="Screenshot 2026-05-18 at 10 32 06 am" src="https://github.com/user-attachments/assets/f109a32e-165b-43ef-b04d-c8b7507682d3" />
