### PR TITLE
Commands: add toggle for content-only pattern/template part editing

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
+++ b/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
@@ -34,7 +34,10 @@ function getBlockIconVariant( { select, clientIds } ) {
 		getSettings,
 	} = unlock( select( blockEditorStore ) );
 	const { getBlockStyles } = select( blocksStore );
-	const isIsolatedEditor = !! getSettings()?.[ isIsolatedEditorKey ];
+	const settings = getSettings();
+	const isIsolatedEditor = !! settings?.[ isIsolatedEditorKey ];
+	const disableContentOnlyForUnsyncedPatterns =
+		!! settings?.disableContentOnlyForUnsyncedPatterns;
 
 	const hasTemplateLock = clientIds.some(
 		( id ) => getTemplateLock( id ) === 'contentOnly'
@@ -49,7 +52,8 @@ function getBlockIconVariant( { select, clientIds } ) {
 		( id ) =>
 			!! getBlockAttributes( id )?.metadata?.patternName &&
 			! isWithinEditedContentOnlySection( id ) &&
-			! isIsolatedEditor
+			! isIsolatedEditor &&
+			! disableContentOnlyForUnsyncedPatterns
 	);
 	const hasPatternOverrides = clientIds.every( ( clientId ) =>
 		hasPatternOverridesDefaultBinding(
@@ -99,7 +103,10 @@ function getBlockIcon( { select, clientIds } ) {
 		isWithinEditedContentOnlySection,
 		getSettings,
 	} = unlock( select( blockEditorStore ) );
-	const isIsolatedEditor = !! getSettings()?.[ isIsolatedEditorKey ];
+	const settings = getSettings();
+	const isIsolatedEditor = !! settings?.[ isIsolatedEditorKey ];
+	const disableContentOnlyForUnsyncedPatterns =
+		!! settings?.disableContentOnlyForUnsyncedPatterns;
 
 	const _isSingleBlock = clientIds.length === 1;
 	const firstClientId = clientIds[ 0 ];
@@ -109,7 +116,8 @@ function getBlockIcon( { select, clientIds } ) {
 		_isSingleBlock &&
 		blockAttributes?.metadata?.patternName &&
 		! isWithinEditedContentOnlySection( firstClientId ) &&
-		! isIsolatedEditor
+		! isIsolatedEditor &&
+		! disableContentOnlyForUnsyncedPatterns
 	) {
 		return symbol;
 	}

--- a/packages/block-editor/src/components/block-toolbar/test/block-toolbar-icon.js
+++ b/packages/block-editor/src/components/block-toolbar/test/block-toolbar-icon.js
@@ -241,6 +241,23 @@ describe( 'BlockToolbarIcon', () => {
 				'core/group-icon'
 			);
 		} );
+
+		it( 'should show the block switcher when content-only editing is disabled', () => {
+			setupToolbarSelectors( {
+				settings: {
+					disableContentOnlyForUnsyncedPatterns: true,
+				},
+			} );
+
+			render( <BlockToolbarIcon { ...defaultProps } /> );
+
+			expect(
+				screen.getByTestId( 'block-switcher' )
+			).toBeInTheDocument();
+			expect( screen.getByTestId( 'block-icon' ) ).toHaveTextContent(
+				'core/group-icon'
+			);
+		} );
 	} );
 
 	describe( 'label calculation', () => {

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -91,7 +91,10 @@ export default function useBlockDisplayInformation( clientId ) {
 			const attributes = getBlockAttributes( clientId );
 			const { isWithinEditedContentOnlySection } =
 				unlock( blockEditorSelect );
-			const isIsolatedEditor = !! getSettings()?.[ isIsolatedEditorKey ];
+			const settings = getSettings();
+			const isIsolatedEditor = !! settings?.[ isIsolatedEditorKey ];
+			const disableContentOnlyForUnsyncedPatterns =
+				!! settings?.disableContentOnlyForUnsyncedPatterns;
 
 			// Check if this block is a pattern
 			const patternName = attributes?.metadata?.patternName;
@@ -101,7 +104,8 @@ export default function useBlockDisplayInformation( clientId ) {
 			if (
 				patternName &&
 				! isEditedContentOnlySection &&
-				! isIsolatedEditor
+				! isIsolatedEditor &&
+				! disableContentOnlyForUnsyncedPatterns
 			) {
 				const pattern = __experimentalGetParsedPattern( patternName );
 				const positionLabel = getPositionTypeLabel( attributes );

--- a/packages/block-editor/src/components/use-block-display-information/test/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/test/index.js
@@ -137,4 +137,24 @@ describe( 'useBlockDisplayInformation', () => {
 			} )
 		);
 	} );
+
+	it( 'displays block information for a pattern wrapper when content-only editing is disabled', () => {
+		setupUseSelect( {
+			settings: {
+				disableContentOnlyForUnsyncedPatterns: true,
+			},
+		} );
+		const onChange = jest.fn();
+
+		render( <TestComponent onChange={ onChange } /> );
+
+		expect( onChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				title: 'Group',
+				icon: groupIcon,
+				description: 'Gather blocks in a layout container.',
+				name: 'Hero pattern',
+			} )
+		);
+	} );
 } );

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -95,6 +95,10 @@ const getEditorCommandLoader = () =>
 			toggleTopToolbar,
 			updateEditorSettings,
 		} = useDispatch( editorStore );
+		// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+		const { stopEditingContentOnlySection } = unlock(
+			useDispatch( blockEditorStore )
+		);
 		const { openModal, enableComplementaryArea, disableComplementaryArea } =
 			useDispatch( interfaceStore );
 		const { getCurrentPostId } = useSelect( editorStore );
@@ -197,6 +201,7 @@ const getEditorCommandLoader = () =>
 			callback: ( { close } ) => {
 				const disableContentOnly =
 					! disableContentOnlyForPatternsAndTemplateParts;
+				stopEditingContentOnlySection();
 				updateEditorSettings( {
 					disableContentOnlyForUnsyncedPatterns: disableContentOnly,
 					disableContentOnlyForTemplateParts: disableContentOnly,

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -184,8 +184,8 @@ const getEditorCommandLoader = () =>
 		commands.push( {
 			name: 'core/toggle-pattern-editing',
 			label: disableContentOnlyForUnsyncedPatterns
-				? __( 'Disable pattern editing' )
-				: __( 'Enable pattern editing' ),
+				? __( 'Enable content-only editing for patterns' )
+				: __( 'Disable content-only editing for patterns' ),
 			icon: symbol,
 			category: 'command',
 			callback: ( { close } ) => {

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -190,12 +190,8 @@ const getEditorCommandLoader = () =>
 		commands.push( {
 			name: 'core/toggle-pattern-editing',
 			label: disableContentOnlyForPatternsAndTemplateParts
-				? __(
-						'Enable content-only editing for patterns and template parts'
-				  )
-				: __(
-						'Disable content-only editing for patterns and template parts'
-				  ),
+				? __( 'Disable editing all patterns' )
+				: __( 'Enable editing all patterns' ),
 			icon: symbol,
 			category: 'command',
 			callback: ( { close } ) => {

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -55,6 +55,7 @@ const getEditorCommandLoader = () =>
 			isRichEditingEnabled,
 			isPublishSidebarEnabled,
 			disableContentOnlyForUnsyncedPatterns,
+			disableContentOnlyForTemplateParts,
 		} = useSelect( ( select ) => {
 			const { get } = select( preferencesStore );
 			const { isListViewOpened, getCurrentPostType, getEditorSettings } =
@@ -78,6 +79,8 @@ const getEditorCommandLoader = () =>
 				disableContentOnlyForUnsyncedPatterns:
 					!! getEditorSettings()
 						.disableContentOnlyForUnsyncedPatterns,
+				disableContentOnlyForTemplateParts:
+					!! getEditorSettings().disableContentOnlyForTemplateParts,
 			};
 		}, [] );
 		const { getActiveComplementaryArea } = useSelect( interfaceStore );
@@ -103,6 +106,9 @@ const getEditorCommandLoader = () =>
 		}
 
 		const commands = [];
+		const disableContentOnlyForPatternsAndTemplateParts =
+			disableContentOnlyForUnsyncedPatterns &&
+			disableContentOnlyForTemplateParts;
 
 		commands.push( {
 			name: 'core/open-shortcut-help',
@@ -183,15 +189,21 @@ const getEditorCommandLoader = () =>
 
 		commands.push( {
 			name: 'core/toggle-pattern-editing',
-			label: disableContentOnlyForUnsyncedPatterns
-				? __( 'Enable content-only editing for patterns' )
-				: __( 'Disable content-only editing for patterns' ),
+			label: disableContentOnlyForPatternsAndTemplateParts
+				? __(
+						'Enable content-only editing for patterns and template parts'
+				  )
+				: __(
+						'Disable content-only editing for patterns and template parts'
+				  ),
 			icon: symbol,
 			category: 'command',
 			callback: ( { close } ) => {
+				const disableContentOnly =
+					! disableContentOnlyForPatternsAndTemplateParts;
 				updateEditorSettings( {
-					disableContentOnlyForUnsyncedPatterns:
-						! disableContentOnlyForUnsyncedPatterns,
+					disableContentOnlyForUnsyncedPatterns: disableContentOnly,
+					disableContentOnlyForTemplateParts: disableContentOnly,
 				} );
 				close();
 			},

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -54,6 +54,7 @@ const getEditorCommandLoader = () =>
 			isCodeEditingEnabled,
 			isRichEditingEnabled,
 			isPublishSidebarEnabled,
+			disableContentOnlyForUnsyncedPatterns,
 		} = useSelect( ( select ) => {
 			const { get } = select( preferencesStore );
 			const { isListViewOpened, getCurrentPostType, getEditorSettings } =
@@ -74,6 +75,9 @@ const getEditorCommandLoader = () =>
 				isRichEditingEnabled: getEditorSettings().richEditingEnabled,
 				isPublishSidebarEnabled:
 					select( editorStore ).isPublishSidebarEnabled(),
+				disableContentOnlyForUnsyncedPatterns:
+					!! getEditorSettings()
+						.disableContentOnlyForUnsyncedPatterns,
 			};
 		}, [] );
 		const { getActiveComplementaryArea } = useSelect( interfaceStore );
@@ -86,6 +90,7 @@ const getEditorCommandLoader = () =>
 			toggleDistractionFree,
 			toggleSpotlightMode,
 			toggleTopToolbar,
+			updateEditorSettings,
 		} = useDispatch( editorStore );
 		const { openModal, enableComplementaryArea, disableComplementaryArea } =
 			useDispatch( interfaceStore );
@@ -172,6 +177,22 @@ const getEditorCommandLoader = () =>
 			category: 'command',
 			callback: ( { close } ) => {
 				toggleTopToolbar();
+				close();
+			},
+		} );
+
+		commands.push( {
+			name: 'core/toggle-pattern-editing',
+			label: disableContentOnlyForUnsyncedPatterns
+				? __( 'Disable pattern editing' )
+				: __( 'Enable pattern editing' ),
+			icon: symbol,
+			category: 'command',
+			callback: ( { close } ) => {
+				updateEditorSettings( {
+					disableContentOnlyForUnsyncedPatterns:
+						! disableContentOnlyForUnsyncedPatterns,
+				} );
 				close();
 			},
 		} );

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -530,6 +530,14 @@ test.describe( 'Unsynced pattern', () => {
 
 		await expect( blockHeading ).toHaveAccessibleName( 'Header Pattern' );
 
+		await editorSettings
+			.getByRole( 'button', { name: 'Edit pattern' } )
+			.click();
+		await expect( blockHeading ).toHaveAccessibleName( 'Header Group' );
+		await expect(
+			editorSettings.getByRole( 'button', { name: 'Exit pattern' } )
+		).toBeVisible();
+
 		await pageUtils.pressKeys( 'primary+k' );
 		await page
 			.getByRole( 'combobox', { name: 'Search commands and settings' } )
@@ -538,6 +546,9 @@ test.describe( 'Unsynced pattern', () => {
 			.getByRole( 'option', { name: 'Enable editing all patterns' } )
 			.click();
 
+		await expect(
+			editorSettings.getByRole( 'button', { name: 'Exit pattern' } )
+		).toBeHidden();
 		await expect( blockHeading ).toHaveAccessibleName( 'Header Group' );
 	} );
 

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -500,6 +500,47 @@ test.describe( 'Unsynced pattern', () => {
 		await expect( blockHeading ).toHaveAccessibleName( 'Header Group' );
 	} );
 
+	test( 'shows the source block in the inspector when full pattern editing is enabled', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.setContent( `<!-- wp:group {"metadata":{"patternName":"theme/header-wrapper","name":"Header"},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Pattern content</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->` );
+
+		await pageUtils.pressKeys( 'access+o' );
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+		await listView
+			.getByRole( 'gridcell', { name: 'Header', exact: true } )
+			.click();
+
+		await editor.openDocumentSettingsSidebar();
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		const blockHeading = editorSettings
+			.getByRole( 'tabpanel', { name: 'Block' } )
+			.getByRole( 'heading' )
+			.first();
+
+		await expect( blockHeading ).toHaveAccessibleName( 'Header Pattern' );
+
+		await pageUtils.pressKeys( 'primary+k' );
+		await page
+			.getByRole( 'combobox', { name: 'Search commands and settings' } )
+			.fill( 'editing all patterns' );
+		await page
+			.getByRole( 'option', { name: 'Enable editing all patterns' } )
+			.click();
+
+		await expect( blockHeading ).toHaveAccessibleName( 'Header Group' );
+	} );
+
 	test( 'detaches an unsynced pattern via the block options menu', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What?

Adds a `core/toggle-pattern-editing` command to the editor command palette that flips `disableContentOnlyForUnsyncedPatterns` and `disableContentOnlyForTemplateParts` for the current editor session.

Part of #77923.

## Why?

In WordPress 7.0, unsynced patterns default to content-only mode. Feedback from the [call for testing](https://make.wordpress.org/test/2026/02/27/call-for-testing-pattern-editing-and-content-only-interactivity-in-wordpress-7-0/) flagged friction for users who edit patterns extensively: every pattern needs an extra click before its structure becomes editable.


## How?

Adds a command to the palette, but not in the contextual/suggested settings.


## Testing instructions

1. Make some tea.
2. Open the site editor, and the list view
3. Insert an unsynced pattern. 
4. Open the command palette (Cmd/Ctrl + K) and search for "content". The command should read "Disable content-only editing for patterns and template parts".
5. Run the command. 
6. Check the unsynced patterns and template parts in the list view. Inner blocks should now be directly selectable / fully editable.
7. Re-open the command palette and search "content". The label should now read "Enable content-only editing for patterns and template parts".
8. Run it. Patterns/template parts return to content-only mode.
9. Reload the editor. The toggle resets to the default (no persistence).


## Screenshots / video



https://github.com/user-attachments/assets/86b0b97c-2d18-4cd5-948d-ebee3d26eb13


