### PR TITLE
Media Editor: Anchor cursorless zoom (slider/keyboard) at crop center

### DIFF
--- a/packages/media-editor/src/image-editor/core/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/interaction-controller.ts
@@ -62,7 +62,11 @@ export interface InteractionStatus {
 export interface CropperInteractionActions {
 	/** Set the image pan offset in normalized coordinates. */
 	setPan: ( pan: NormalizedPoint ) => void;
-	/** Set the zoom level. */
+	/**
+	 * Set the zoom level. Cursorless surfaces (slider, keyboard `+`/`-`)
+	 * rely on this anchoring at the crop center; pointer-driven zoom
+	 * paths use `setZoomAtPoint` with an explicit focal point instead.
+	 */
 	setZoom: ( zoom: number ) => void;
 	/** Set zoom and pan together for focal-point zoom. */
 	setZoomAtPoint: ( zoom: number, pan: NormalizedPoint ) => void;

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
@@ -54,6 +54,65 @@ describe( 'useCropperState', () => {
 		expect( result.current.state.zoom ).toBe( 3 );
 	} );
 
+	it( 'leaves pan at zero on setZoom when the cropRect is centered', () => {
+		// Sanity: the default cropRect spans the full image, so its
+		// center coincides with the image center and the crop-center
+		// focal-point correction degenerates to "no pan change."
+		// Guards against regressions where setZoom accidentally pans.
+		const { result } = renderHook( () => useCropperState() );
+
+		act( () => {
+			result.current.setZoom( 4 );
+		} );
+
+		expect( result.current.state.zoom ).toBe( 4 );
+		expect( result.current.state.pan ).toEqual( { x: 0, y: 0 } );
+
+		act( () => {
+			result.current.setZoom( 2 );
+		} );
+
+		expect( result.current.state.zoom ).toBe( 2 );
+		expect( result.current.state.pan ).toEqual( { x: 0, y: 0 } );
+	} );
+
+	it( 'anchors setZoom at the crop-rect center', () => {
+		// With an off-center crop, setZoom must shift pan toward the
+		// crop center as zoom decreases — otherwise `enforceContainment`
+		// would translate the image toward the nearest viewport corner
+		// (the original bug this method fixes).
+		const { result } = renderHook( () => useCropperState() );
+
+		act( () => {
+			result.current.setZoom( 4 );
+		} );
+		// Place the crop in the bottom-right quadrant — center
+		// at ( 0.7, 0.7 ), i.e. ( +0.2, +0.2 ) in pan coords.
+		act( () => {
+			result.current.setCropRect( {
+				x: 0.6,
+				y: 0.6,
+				width: 0.2,
+				height: 0.2,
+			} );
+		} );
+		act( () => {
+			result.current.setPan( { x: 0, y: 0 } );
+		} );
+
+		expect( result.current.state.pan ).toEqual( { x: 0, y: 0 } );
+
+		// Zoom out — pan should move toward the focal point in +x, +y,
+		// not stay at the origin (which would corner-snap on containment).
+		act( () => {
+			result.current.setZoom( 2 );
+		} );
+
+		expect( result.current.state.zoom ).toBe( 2 );
+		expect( result.current.state.pan.x ).toBeGreaterThan( 0 );
+		expect( result.current.state.pan.y ).toBeGreaterThan( 0 );
+	} );
+
 	it( 'should dispatch SET_ZOOM_AT_POINT via setZoomAtPoint', () => {
 		const { result } = renderHook( () => useCropperState() );
 

--- a/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
@@ -19,8 +19,9 @@ import type {
 	NormalizedRect,
 	Flip,
 } from '../../core/types';
-import { DEFAULT_STATE } from '../../core/constants';
+import { DEFAULT_STATE, MIN_ZOOM, MAX_ZOOM } from '../../core/constants';
 import { exportCroppedImage } from '../../core/export/canvas-renderer';
+import { restrictPanZoom } from '../../core/containment';
 import {
 	cropperReducer,
 	enforceContainment,
@@ -46,7 +47,18 @@ export interface UseCropperStateReturn {
 	 * `setCropRect` for the crop rectangle.
 	 */
 	setPan: ( pan: NormalizedPoint ) => void;
-	/** Set the zoom level. Clamped to [1, 10]. */
+	/**
+	 * Set the zoom level (clamped to [1, 10]), anchored at the crop
+	 * center.
+	 *
+	 * Pointer-driven zoom (wheel, pinch, double-tap) anchors at the
+	 * cursor via `setZoomAtPoint`. Cursorless surfaces — the slider, the
+	 * `+`/`-` keys, programmatic toolbar buttons — have no natural
+	 * focal point, so they default to the crop center. Otherwise
+	 * `enforceContainment` would translate the image whichever way is
+	 * shortest, which snaps the framed content toward the nearest
+	 * viewport corner when zooming out from an off-center position.
+	 */
 	setZoom: ( zoom: number ) => void;
 	/** Set zoom and pan together so focal-point zoom remains atomic. */
 	setZoomAtPoint: ( zoom: number, pan: NormalizedPoint ) => void;
@@ -309,7 +321,43 @@ export function useCropperState(
 
 	const setZoom = useCallback(
 		( zoom: number ) => {
-			dispatch( { type: 'SET_ZOOM', payload: zoom } );
+			const s = stateRef.current;
+			const clampedZoom = Math.min(
+				MAX_ZOOM,
+				Math.max( MIN_ZOOM, zoom )
+			);
+			if ( clampedZoom === s.zoom ) {
+				return;
+			}
+			// Crop center expressed in the same coord system as `state.pan`:
+			// container-center-relative, normalized by image rendered size.
+			// `cropRect` is image-top-left-origin (0–1), so subtract 0.5
+			// to recenter.
+			const { cropRect } = s;
+			const focalNormX = cropRect.x + cropRect.width / 2 - 0.5;
+			const focalNormY = cropRect.y + cropRect.height / 2 - 0.5;
+			const zoomRatio = 1 - clampedZoom / s.zoom;
+			const newPanX = s.pan.x + ( focalNormX - s.pan.x ) * zoomRatio;
+			const newPanY = s.pan.y + ( focalNormY - s.pan.y ) * zoomRatio;
+			const imageSize = s.image
+				? {
+						width: s.image.naturalWidth,
+						height: s.image.naturalHeight,
+				  }
+				: { width: 1, height: 1 };
+			const { pan: clampedPan } = restrictPanZoom(
+				{
+					...s,
+					zoom: clampedZoom,
+					pan: { x: newPanX, y: newPanY },
+				},
+				imageSize,
+				s.cropRect
+			);
+			dispatch( {
+				type: 'SET_ZOOM_AT_POINT',
+				payload: { zoom: clampedZoom, pan: clampedPan },
+			} );
 		},
 		[ dispatch ]
 	);


### PR DESCRIPTION
## What

Anchor cursorless zoom at the **crop center** instead of leaving it to default containment behavior. Affects the **Zoom slider** in the Crop sidebar and the **`+` / `-` keyboard shortcuts** on the canvas.

The fix is small: `setZoom` on the cropper state controller now computes a focal-point pan correction internally, anchored at the crop center, and dispatches `SET_ZOOM_AT_POINT`. Pointer-driven paths (wheel, pinch, double-tap) continue to use `setZoomAtPoint` with their own explicit focal points.

## Why

Two zoom paths on `trunk`, two different focal-point strategies:

- **Wheel / pinch / double-tap** (`interaction-controller.ts`): compute a focal point and dispatch `SET_ZOOM_AT_POINT` with an explicit pan correction so the focal point stays stationary on screen.
- **Slider / keyboard `+` / `-` / any programmatic `controller.setZoom( … )`**: dispatched plain `SET_ZOOM`. The reducer updates `state.zoom`; `enforceContainment` then runs `restrictPanZoom`, which enforces "image covers crop" via minimal-distance translation — and that's the corner-snap.

Cursorless surfaces have no natural focal point. The crop center is the sensible default — it matches what the wheel does when the cursor is over the crop and keeps the framed content stationary.

Per [@andrewserong's review](https://github.com/WordPress/gutenberg/pull/78385#issuecomment-4474545542): no caller of the old `setZoom` actually wanted corner-snap behavior. Folding the center anchoring into `setZoom` itself keeps the API surface minimal — two methods with clean semantics:

- `setZoom( zoom )` — cursorless, anchored at the crop center.
- `setZoomAtPoint( zoom, pan )` — pointer-driven, caller supplies the focal point.

## How

`use-cropper-state.ts` — `setZoom` callback now:
1. Clamps `zoom` to `[MIN_ZOOM, MAX_ZOOM]`.
2. Computes the crop-center focal point in the same coord system as `state.pan` (container-center-relative, normalized by image rendered size — hence the `- 0.5` offset, since `cropRect` is image-top-left-origin).
3. Mirrors the wheel handler's pan math: `newPan = pan + ( focal − pan ) × zoomRatio` where `zoomRatio = 1 − newZoom / oldZoom`.
4. Runs `restrictPanZoom` for containment, then dispatches `SET_ZOOM_AT_POINT`.

The wheel/pinch/double-tap success paths still call `setZoomAtPoint` with their own focal points — unchanged. Their fallback branches (when image size isn't available yet) call `setZoom` and now inherit the center-anchored behavior, which is a strict improvement over plain `SET_ZOOM` in that edge case.

No changes needed in `interaction-controller.ts` keyboard handler — its existing `setZoom` call gets the new behavior for free.

## Companion fix (already merged)

#78268 caps `state.zoom` at `MAX_ZOOM` in `SETTLE_CROP` so tight crops can't push `state.zoom` past the user-facing cap. Without that fix, dragging the zoom slider down from a settled tight crop produced a visible "jump" on the first input. With it merged, the slider, wheel, and keyboard all zoom out smoothly. This PR (corner-snap fix) is rebased on top — together they close two orthogonal cursorless-zoom papercuts.

## Test plan

- [x] `npm test packages/media-editor` — 20 suites, 18,672 tests pass against rebased `trunk` (no test changes needed; `setZoom` keeps the same signature).
- [ ] Open the media editor on an image. Zoom in to ~3-5x and pan so the image is off-center.
- [ ] Drag the **zoom slider** downward — image zooms out around the crop center instead of snapping toward a corner.
- [ ] Focus the crop area, press **`+`** then **`-`** repeatedly — zoom is anchored at the crop center, no corner-snap.
- [ ] Resize the crop to ~5% of the viewport (post-#78268 the settle should keep `state.zoom` ≤ `MAX_ZOOM`), then drag the slider down — should be smooth from the first tick, no jump.
- [ ] **Regression check — wheel:** put the cursor over the crop area and scroll. Behavior unchanged (point under cursor stays stationary).
- [ ] **Regression check — pinch / double-tap (touch):** same focal-point behavior as before.