### PR TITLE
Add vertical orientation for Separator block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -921,7 +921,7 @@ Create a break between ideas or sections with a horizontal separator. ([Source](
 -	**Name:** core/separator
 -	**Category:** design
 -	**Supports:** align (center, full, wide), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), interactivity (clientNavigation), spacing (margin)
--	**Attributes:** opacity, tagName
+-	**Attributes:** opacity, orientation, tagName
 
 ## Shortcode
 

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -16,6 +16,11 @@
 			"type": "string",
 			"enum": [ "hr", "div" ],
 			"default": "hr"
+		},
+		"orientation": {
+			"type": "string",
+			"default": "horizontal",
+			"enum": [ "horizontal", "vertical" ]
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -12,7 +12,12 @@ import {
 	useBlockProps,
 	__experimentalUseColorProps as useColorProps,
 } from '@wordpress/block-editor';
-import { HorizontalRule, SelectControl } from '@wordpress/components';
+import {
+	HorizontalRule,
+	SelectControl,
+	ToggleControl,
+	PanelBody,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -20,35 +25,49 @@ import { __ } from '@wordpress/i18n';
  */
 import useDeprecatedOpacity from './use-deprecated-opacity';
 
-const HtmlElementControl = ( { tagName, setAttributes } ) => {
+function getHelpText( disabled, tagName ) {
+	if ( disabled ) {
+		return __(
+			'Vertical separators always use <div> for correct rendering.'
+		);
+	}
+
+	const helpText = {
+		hr: __(
+			'Only select <hr> if the separator conveys important information and should be announced by screen readers.'
+		),
+		div: __(
+			'The <div> element should only be used if the block is a design element with no semantic meaning.'
+		),
+	};
+
+	return helpText[ tagName ];
+}
+
+const HtmlElementControl = ( { tagName, setAttributes, disabled } ) => {
 	return (
 		<SelectControl
 			label={ __( 'HTML element' ) }
 			value={ tagName }
+			disabled={ disabled }
+			help={ getHelpText( disabled, tagName ) }
 			onChange={ ( newValue ) => setAttributes( { tagName: newValue } ) }
 			options={ [
 				{ label: __( 'Default (<hr>)' ), value: 'hr' },
 				{ label: '<div>', value: 'div' },
 			] }
-			help={
-				tagName === 'hr'
-					? __(
-							'Only select <hr> if the separator conveys important information and should be announced by screen readers.'
-					  )
-					: __(
-							'The <div> element should only be used if the block is a design element with no semantic meaning.'
-					  )
-			}
 			__next40pxDefaultSize
 		/>
 	);
 };
 
 export default function SeparatorEdit( { attributes, setAttributes } ) {
-	const { backgroundColor, opacity, style, tagName } = attributes;
+	const { backgroundColor, opacity, style, tagName, orientation } =
+		attributes;
 	const colorProps = useColorProps( attributes );
 	const currentColor = colorProps?.style?.backgroundColor;
 	const hasCustomColor = !! style?.color?.background;
+	const isVertical = orientation === 'vertical';
 
 	useDeprecatedOpacity( opacity, currentColor, setAttributes );
 
@@ -62,6 +81,7 @@ export default function SeparatorEdit( { attributes, setAttributes } ) {
 			[ colorClass ]: colorClass,
 			'has-css-opacity': opacity === 'css',
 			'has-alpha-channel-opacity': opacity === 'alpha-channel',
+			'is-vertical': isVertical,
 		},
 		colorProps.className
 	);
@@ -70,7 +90,25 @@ export default function SeparatorEdit( { attributes, setAttributes } ) {
 		color: currentColor,
 		backgroundColor: currentColor,
 	};
-	const Wrapper = tagName === 'hr' ? HorizontalRule : tagName;
+
+	let Wrapper = tagName;
+	if ( tagName === 'hr' ) {
+		Wrapper = HorizontalRule;
+	}
+
+	let toggleHelp;
+	if ( isVertical ) {
+		toggleHelp = __( 'Set vertical orientation for the separator.' );
+	}
+
+	const ariaProps = {};
+	if ( tagName === 'hr' ) {
+		let ariaOrientation = 'horizontal';
+		if ( isVertical ) {
+			ariaOrientation = 'vertical';
+		}
+		ariaProps[ 'aria-orientation' ] = ariaOrientation;
+	}
 
 	return (
 		<>
@@ -78,12 +116,40 @@ export default function SeparatorEdit( { attributes, setAttributes } ) {
 				<HtmlElementControl
 					tagName={ tagName }
 					setAttributes={ setAttributes }
+					disabled={ isVertical }
 				/>
+			</InspectorControls>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings' ) }>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Vertical' ) }
+						checked={ isVertical }
+						onChange={ () => {
+							let newOrientation = 'vertical';
+							if ( isVertical ) {
+								newOrientation = 'horizontal';
+							}
+							const newAttributes = {
+								orientation: newOrientation,
+							};
+							if (
+								newOrientation === 'vertical' &&
+								tagName === 'hr'
+							) {
+								newAttributes.tagName = 'div';
+							}
+							setAttributes( newAttributes );
+						} }
+						help={ toggleHelp }
+					/>
+				</PanelBody>
 			</InspectorControls>
 			<Wrapper
 				{ ...useBlockProps( {
 					className,
 					style: hasCustomColor ? styles : undefined,
+					...ariaProps,
 				} ) }
 			/>
 		</>

--- a/packages/block-library/src/separator/editor.scss
+++ b/packages/block-library/src/separator/editor.scss
@@ -3,3 +3,8 @@
 	padding-top: 0.1px;
 	padding-bottom: 0.1px;
 }
+
+.wp-block-separator.is-vertical {
+	// Minimum visible width in editor so it's clickable
+	min-width: 2px;
+}

--- a/packages/block-library/src/separator/save.js
+++ b/packages/block-library/src/separator/save.js
@@ -13,9 +13,16 @@ import {
 } from '@wordpress/block-editor';
 
 export default function separatorSave( { attributes } ) {
-	const { backgroundColor, style, opacity, tagName: Tag } = attributes;
+	const {
+		backgroundColor,
+		style,
+		opacity,
+		tagName: Tag,
+		orientation,
+	} = attributes;
 	const customColor = style?.color?.background;
 	const colorProps = getColorClassesAndStyles( attributes );
+	const isVertical = orientation === 'vertical';
 	// The hr support changing color using border-color, since border-color
 	// is not yet supported in the color palette, we use background-color.
 
@@ -29,6 +36,7 @@ export default function separatorSave( { attributes } ) {
 			[ colorClass ]: colorClass,
 			'has-css-opacity': opacity === 'css',
 			'has-alpha-channel-opacity': opacity === 'alpha-channel',
+			'is-vertical': isVertical,
 		},
 		colorProps.className
 	);

--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -35,3 +35,31 @@
 	// Important required to ensure dots does not get a border.
 	border: none !important;
 }
+
+// Vertical separator variation
+.wp-block-separator.is-vertical {
+	// Switch from horizontal border to vertical border
+	border-top: none;
+	border-left: 2px solid currentColor;
+
+	// Width collapses to 0 since its a line
+	width: 0;
+
+	// Height should stretch to fill the parent (Row/Columns block)
+	height: auto;
+	align-self: stretch;
+
+	// HR has auto horizontal margins by default which would misalign it
+	margin-top: 0;
+	margin-bottom: 0;
+
+	// Fallback height if not inside a flex/grid container
+	min-height: 1em;
+}
+
+// Disable dots style in vertical.
+.wp-block-separator.is-vertical.is-style-dots {
+	&::before {
+		content: none;
+	}
+}


### PR DESCRIPTION

## What?
Adds a Vertical Orientation for the Separator Block

<!-- In a few words, what is the PR actually doing? -->

## Why?
https://github.com/WordPress/gutenberg/issues/62963

## How?
Add a orientation attribute and based on that render the separator block as vertical or horizontal

## Testing Instructions
1. Add a row or group block
2. Add an image or a long para.
3. Add a spearator block and select vertical orientation from panel.
4. Add another image or a long para.
5. Save it and view on frontend

## Screenshots or screencast <!-- if applicable -->

### Editor
<img width="1468" height="851" alt="Screenshot 2026-05-18 at 12 23 01" src="https://github.com/user-attachments/assets/a5051c1a-8294-4a32-b467-b2de05168388" />

### Frontend
<img width="1470" height="835" alt="Screenshot 2026-05-18 at 12 23 16" src="https://github.com/user-attachments/assets/9070bc53-2ff0-459f-a666-dafc8d5e0b0c" />


## Use of AI Tools
I have used Claude for debugging, refactoring, pair programming and writing comments only. The code has been thoroughly read and tested by me and AI was just used as an assist
