### PR TITLE
useCopyToClipboard: Always call onSuccess callback

### DIFF
--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   `useCopyToClipboard`: Call the `onSuccess` callback even when the trigger node unmounts before the copy resolves (e.g. a menu item that closes the menu on click).
+-   `useCopyToClipboard`: Call the `onSuccess` callback even when the trigger node unmounts before the copy resolves ([#78387](https://github.com/WordPress/gutenberg/pull/78387)).
 
 ## 7.46.0 (2026-05-14)
 

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `useCopyToClipboard`: Call the `onSuccess` callback even when the trigger node unmounts before the copy resolves (e.g. a menu item that closes the menu on click).
+
 ## 7.46.0 (2026-05-14)
 
 ## 7.45.0 (2026-04-29)

--- a/packages/compose/src/hooks/use-copy-on-click/index.ts
+++ b/packages/compose/src/hooks/use-copy-on-click/index.ts
@@ -8,7 +8,7 @@ import type { RefObject } from 'react';
 /**
  * Internal dependencies
  */
-import { clearSelection, copyToClipboard } from '../use-copy-to-clipboard';
+import { restoreFocus, copyToClipboard } from '../use-copy-to-clipboard';
 
 /**
  * Copies the text to the clipboard when the element is clicked.
@@ -73,7 +73,7 @@ export default function useCopyOnClick(
 				return;
 			}
 			if ( success ) {
-				clearSelection( trigger );
+				restoreFocus( trigger );
 				if ( timeout ) {
 					setHasCopied( true );
 					clearTimeout( timeoutId );

--- a/packages/compose/src/hooks/use-copy-to-clipboard/index.ts
+++ b/packages/compose/src/hooks/use-copy-to-clipboard/index.ts
@@ -93,7 +93,7 @@ export default function useCopyToClipboard< T extends HTMLElement >(
 	const textRef = useUpdatedRef( text );
 	const onSuccessRef = useUpdatedRef( onSuccess );
 	return useRefEffect( ( node ) => {
-		// Flag to prevent callbacks after unmount when the Promise resolves.
+		// Tracks whether the node is still mounted when the Promise resolves.
 		let isActive = true;
 		const handleClick = async () => {
 			const textToCopy =
@@ -101,11 +101,12 @@ export default function useCopyToClipboard< T extends HTMLElement >(
 					? textRef.current()
 					: textRef.current || '';
 			const success = await copyToClipboard( textToCopy, node );
-			if ( ! isActive ) {
-				return;
-			}
 			if ( success ) {
-				clearSelection( node );
+				// Restoring focus only matters while the node is mounted.
+				if ( isActive ) {
+					clearSelection( node );
+				}
+				// Always run, even after unmount, to allow updating other UI.
 				if ( onSuccessRef.current ) {
 					onSuccessRef.current();
 				}

--- a/packages/compose/src/hooks/use-copy-to-clipboard/index.ts
+++ b/packages/compose/src/hooks/use-copy-to-clipboard/index.ts
@@ -52,15 +52,14 @@ export async function copyToClipboard(
 }
 
 /**
- * Clears the current selection and restores focus to the trigger element.
+ * Restores focus to the trigger element.
  *
  * @param trigger The element that triggered the copy.
  */
-export function clearSelection( trigger: Element ): void {
+export function restoreFocus( trigger: Element ): void {
 	if ( 'focus' in trigger && typeof trigger.focus === 'function' ) {
 		trigger.focus();
 	}
-	trigger.ownerDocument?.defaultView?.getSelection()?.removeAllRanges();
 }
 
 /**
@@ -104,7 +103,7 @@ export default function useCopyToClipboard< T extends HTMLElement >(
 			if ( success ) {
 				// Restoring focus only matters while the node is mounted.
 				if ( isActive ) {
-					clearSelection( node );
+					restoreFocus( node );
 				}
 				// Always run, even after unmount, to allow updating other UI.
 				if ( onSuccessRef.current ) {

--- a/packages/compose/src/hooks/use-copy-to-clipboard/test/index.tsx
+++ b/packages/compose/src/hooks/use-copy-to-clipboard/test/index.tsx
@@ -68,7 +68,7 @@ describe( 'useCopyToClipboard', () => {
 		expect( onSuccess ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should call onSuccess even when the node unmounts before the copy resolves', async () => {
+	it( 'should call onSuccess but skip focus restoration when the node unmounts before the copy resolves', async () => {
 		let resolvePromise: () => void;
 		const delayedPromise = new Promise< void >( ( resolve ) => {
 			resolvePromise = resolve;
@@ -83,8 +83,12 @@ describe( 'useCopyToClipboard', () => {
 			<TestComponent text="test" onSuccess={ onSuccess } />
 		);
 
-		await user.click( screen.getByRole( 'button' ) );
+		const button = screen.getByRole( 'button' );
+		const focusSpy = jest.spyOn( button, 'focus' );
+
+		await user.click( button );
 		unmount();
+		focusSpy.mockClear();
 
 		await act( async () => {
 			resolvePromise();
@@ -92,6 +96,7 @@ describe( 'useCopyToClipboard', () => {
 		} );
 
 		expect( onSuccess ).toHaveBeenCalledTimes( 1 );
+		expect( focusSpy ).not.toHaveBeenCalled();
 	} );
 } );
 

--- a/packages/compose/src/hooks/use-copy-to-clipboard/test/index.tsx
+++ b/packages/compose/src/hooks/use-copy-to-clipboard/test/index.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 /**
  * Internal dependencies
  */
-import useCopyToClipboard, { copyToClipboard, clearSelection } from '../';
+import useCopyToClipboard, { copyToClipboard, restoreFocus } from '../';
 
 interface TestComponentProps {
 	text: string | ( () => string );
@@ -157,13 +157,13 @@ describe( 'copyToClipboard', () => {
 	} );
 } );
 
-describe( 'clearSelection', () => {
+describe( 'restoreFocus', () => {
 	it( 'should focus the trigger element', () => {
 		const trigger = document.createElement( 'button' );
 		document.body.appendChild( trigger );
 		const focusMock = jest.spyOn( trigger, 'focus' );
 
-		clearSelection( trigger );
+		restoreFocus( trigger );
 
 		expect( focusMock ).toHaveBeenCalledTimes( 1 );
 

--- a/packages/compose/src/hooks/use-copy-to-clipboard/test/index.tsx
+++ b/packages/compose/src/hooks/use-copy-to-clipboard/test/index.tsx
@@ -68,7 +68,7 @@ describe( 'useCopyToClipboard', () => {
 		expect( onSuccess ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should not call onSuccess after unmount', async () => {
+	it( 'should call onSuccess even when the node unmounts before the copy resolves', async () => {
 		let resolvePromise: () => void;
 		const delayedPromise = new Promise< void >( ( resolve ) => {
 			resolvePromise = resolve;
@@ -91,7 +91,7 @@ describe( 'useCopyToClipboard', () => {
 			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 		} );
 
-		expect( onSuccess ).not.toHaveBeenCalled();
+		expect( onSuccess ).toHaveBeenCalledTimes( 1 );
 	} );
 } );
 

--- a/packages/compose/src/hooks/use-copy-to-clipboard/test/index.tsx
+++ b/packages/compose/src/hooks/use-copy-to-clipboard/test/index.tsx
@@ -88,6 +88,7 @@ describe( 'useCopyToClipboard', () => {
 
 		await user.click( button );
 		unmount();
+		// Discard focus calls from the initial click; we only care about post-unmount calls.
 		focusSpy.mockClear();
 
 		await act( async () => {

--- a/packages/compose/src/hooks/use-copy-to-clipboard/test/index.tsx
+++ b/packages/compose/src/hooks/use-copy-to-clipboard/test/index.tsx
@@ -68,7 +68,7 @@ describe( 'useCopyToClipboard', () => {
 		expect( onSuccess ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should call onSuccess but skip focus restoration when the node unmounts before the copy resolves', async () => {
+	it( 'should call onSuccess after the node unmounts', async () => {
 		let resolvePromise: () => void;
 		const delayedPromise = new Promise< void >( ( resolve ) => {
 			resolvePromise = resolve;
@@ -83,6 +83,29 @@ describe( 'useCopyToClipboard', () => {
 			<TestComponent text="test" onSuccess={ onSuccess } />
 		);
 
+		await user.click( screen.getByRole( 'button' ) );
+		unmount();
+
+		await act( async () => {
+			resolvePromise();
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+		} );
+
+		expect( onSuccess ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should not restore focus after the node unmounts', async () => {
+		let resolvePromise: () => void;
+		const delayedPromise = new Promise< void >( ( resolve ) => {
+			resolvePromise = resolve;
+		} );
+		jest.spyOn( navigator.clipboard, 'writeText' ).mockReturnValue(
+			delayedPromise
+		);
+
+		const user = userEvent.setup();
+		const { unmount } = render( <TestComponent text="test" /> );
+
 		const button = screen.getByRole( 'button' );
 		const focusSpy = jest.spyOn( button, 'focus' );
 
@@ -96,7 +119,6 @@ describe( 'useCopyToClipboard', () => {
 			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 		} );
 
-		expect( onSuccess ).toHaveBeenCalledTimes( 1 );
 		expect( focusSpy ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
## What?

Follow up to #75723.

This calls the `onSuccess` callback of `useCopyToClipboard` even when the trigger node unmounts before the asynchronous copy resolves.

## Why?

#75723 reimplemented `useCopyToClipboard` on top of the asynchronous native Clipboard API. To avoid acting on an unmounted node when the promise resolves, an `isActive` guard was added that early-returns after unmount.

However, there are use cases where the element that triggered the copy disappears immediately. — for example, a `MenuItem` inside a `DropdownMenu` that closes the menu on click. In that case the guard suppresses `onSuccess` entirely, so consumers can no longer show a "Copied!" notice.

## How?

Slightly relaxes the restrictions of the `isActive` guard. While maintaining focus restoration, this PR ensures that the `onSuccess` callback is always executed.

## Testing Instructions

Make the following change beforehand. This code adds a copy button to the post editor's options menu that unmounts when clicked.

```diff
diff --git a/packages/editor/src/components/more-menu/index.js b/packages/editor/src/components/more-menu/index.js
index 3a4cf8a66d5..ee4f23fdbac 100644
--- a/packages/editor/src/components/more-menu/index.js
+++ b/packages/editor/src/components/more-menu/index.js
@@ -12,6 +12,7 @@ import {
 } from '@wordpress/preferences';
 import { store as interfaceStore, ActionItem } from '@wordpress/interface';
 import { VisuallyHidden } from '@wordpress/ui';
+import { useCopyToClipboard } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -36,6 +37,10 @@ export default function MoreMenu( { disabled = false } ) {
                setPreference( 'core', 'distractionFree', false );
        };
 
+       const copyButtonRef = useCopyToClipboard( 'my text', () => {
+               console.log( 'Text copied to clipboard.' );
+       } );
+
        return (
                <>
                        <DropdownMenu
@@ -150,6 +155,12 @@ export default function MoreMenu( { disabled = false } ) {
                                                        >
                                                                { __( 'Preferences' ) }
                                                        </MenuItem>
+                                                       <MenuItem
+                                                               ref={ copyButtonRef }
+                                                               onClick={ () => onClose() }
+                                                       >
+                                                               { __( 'Copy' ) }
+                                                       </MenuItem>
                                                </MenuGroup>
                                        </>
                                ) }
```

- Open the post editor
- Open the "Options" menu and clock the "Copy" menu
- The log should be recorded in the browser console.

## Screenshot

https://github.com/user-attachments/assets/df4ef5d3-e1b9-40b4-a1dd-b25ee123489f

## Use of AI Tools

This PR was authored with the assistance of Claude Code, including the investigation, the fix, and the unit test. All changes were reviewed by the author.
