### PR TITLE
Grid: hide resize handles and actions while on tile is resizing

### DIFF
--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -15,10 +15,13 @@
     `--wp-grid-resize-preview-outline-style` CSS custom properties for
     the drag-placeholder outline (default `dashed`) and resize-preview
     border (default `solid`).
+-   Set `data-wp-dashboard-grid-resizing` on the `DashboardGrid` root
+    element while any tile resize gesture is active, so consumers can
+    adjust styles when the pointer may still hover tiles ([#78234](https://github.com/WordPress/gutenberg/pull/78234)).
 -   Set `data-wp-grid-resizing` and `data-wp-grid-dragging` on grid
     surface roots, and `data-wp-grid-item-resizing` on the active tile,
     so interaction chrome (resize handles, actionable areas) can be
-    styled via CSS without per-tile props ([#78234](https://github.com/WordPress/gutenberg/pull/78234)).
+    styled via CSS without per-tile props ([#78391](https://github.com/WordPress/gutenberg/pull/78391)).
 -   Add `--wp-grid-gap` so consumers can set tile spacing per surface
     without remapping design-system tokens (defaults to
     `--wpds-dimension-gap-xl`).

--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -15,9 +15,10 @@
     `--wp-grid-resize-preview-outline-style` CSS custom properties for
     the drag-placeholder outline (default `dashed`) and resize-preview
     border (default `solid`).
--   Set `data-wp-dashboard-grid-resizing` on the `DashboardGrid` root
-    element while any tile resize gesture is active, so consumers can
-    adjust styles when the pointer may still hover tiles ([#78234](https://github.com/WordPress/gutenberg/pull/78234)).
+-   Set `data-wp-grid-resizing` and `data-wp-grid-dragging` on grid
+    surface roots, and `data-wp-grid-item-resizing` on the active tile,
+    so interaction chrome (resize handles, actionable areas) can be
+    styled via CSS without per-tile props ([#78234](https://github.com/WordPress/gutenberg/pull/78234)).
 -   Add `--wp-grid-gap` so consumers can set tile spacing per surface
     without remapping design-system tokens (defaults to
     `--wpds-dimension-gap-xl`).

--- a/packages/grid/src/dashboard-grid/grid-item.tsx
+++ b/packages/grid/src/dashboard-grid/grid-item.tsx
@@ -42,14 +42,13 @@ export function GridItem( {
 	disabled = false,
 	verticalResizable = true,
 	interacting = false,
+	dragging = false,
 	children,
 	actionableArea = null,
 	onResize,
 	onResizeEnd,
 	resizeSnapPreview = null,
 	renderResizeHandle,
-	resizeHandleVisible = true,
-	actionableAreaVisible = true,
 }: GridItemProps ) {
 	const [ resizeDelta, setResizeDelta ] = useState< ResizeDelta | null >(
 		null
@@ -137,22 +136,15 @@ export function GridItem( {
 			className={ itemClassName }
 			style={ style }
 			{ ...{ [ GRID_ITEM_DATA_KEY ]: item.key } }
+			data-wp-grid-item-resizing={ isResizing || undefined }
 		>
 			{ actionableArea ? (
 				<div
-					className={ clsx(
-						actionableAreaStyles[ 'actionable-area-slot' ],
-						! actionableAreaVisible &&
-							actionableAreaStyles[
-								'actionable-area-slot--hidden'
-							]
-					) }
+					className={ actionableAreaStyles[ 'actionable-area-slot' ] }
 				>
 					<div
 						style={ { display: 'contents' } }
-						{ ...( interacting && actionableAreaVisible
-							? { inert: '' }
-							: {} ) }
+						{ ...( dragging ? { inert: '' } : {} ) }
 					>
 						{ actionableArea }
 					</div>
@@ -178,7 +170,6 @@ export function GridItem( {
 						<ResizeHandle
 							itemId={ item.key }
 							verticalResizable={ verticalResizable }
-							visible={ resizeHandleVisible }
 							onResize={ handleResize }
 							onResizeEnd={ handleResizeEnd }
 							renderResizeHandle={ renderResizeHandle }

--- a/packages/grid/src/dashboard-grid/grid-item.tsx
+++ b/packages/grid/src/dashboard-grid/grid-item.tsx
@@ -13,6 +13,7 @@ import { useMergeRefs } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import actionableAreaStyles from '../shared/actionable-area-slot.module.css';
 import { GRID_ITEM_DATA_KEY } from '../shared/grid-item-key';
 import ResizeHandle from '../shared/resize-handle';
 import type { ResizeSnapSize } from '../shared/resize-snap';
@@ -48,6 +49,7 @@ export function GridItem( {
 	resizeSnapPreview = null,
 	renderResizeHandle,
 	resizeHandleVisible = true,
+	actionableAreaVisible = true,
 }: GridItemProps ) {
 	const [ resizeDelta, setResizeDelta ] = useState< ResizeDelta | null >(
 		null
@@ -138,10 +140,22 @@ export function GridItem( {
 		>
 			{ actionableArea ? (
 				<div
-					style={ { display: 'contents' } }
-					{ ...( interacting ? { inert: '' } : {} ) }
+					className={ clsx(
+						actionableAreaStyles[ 'actionable-area-slot' ],
+						! actionableAreaVisible &&
+							actionableAreaStyles[
+								'actionable-area-slot--hidden'
+							]
+					) }
 				>
-					{ actionableArea }
+					<div
+						style={ { display: 'contents' } }
+						{ ...( interacting && actionableAreaVisible
+							? { inert: '' }
+							: {} ) }
+					>
+						{ actionableArea }
+					</div>
 				</div>
 			) : null }
 

--- a/packages/grid/src/dashboard-grid/grid-item.tsx
+++ b/packages/grid/src/dashboard-grid/grid-item.tsx
@@ -47,6 +47,7 @@ export function GridItem( {
 	onResizeEnd,
 	resizeSnapPreview = null,
 	renderResizeHandle,
+	resizeHandleVisible = true,
 }: GridItemProps ) {
 	const [ resizeDelta, setResizeDelta ] = useState< ResizeDelta | null >(
 		null
@@ -163,6 +164,7 @@ export function GridItem( {
 						<ResizeHandle
 							itemId={ item.key }
 							verticalResizable={ verticalResizable }
+							visible={ resizeHandleVisible }
 							onResize={ handleResize }
 							onResizeEnd={ handleResizeEnd }
 							renderResizeHandle={ renderResizeHandle }

--- a/packages/grid/src/dashboard-grid/index.tsx
+++ b/packages/grid/src/dashboard-grid/index.tsx
@@ -135,9 +135,6 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 			id: string;
 			snap: ResizeSnapSize;
 		} | null >( null );
-		const [ resizingItemId, setResizingItemId ] = useState< string | null >(
-			null
-		);
 		// Mirror of `temporaryLayout` read synchronously on drag end —
 		// the state update from `handleDragMove` may still be batched.
 		const latestLayoutRef = useRef<
@@ -325,7 +322,6 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 			resizeBaselineRef.current = null;
 			setIsResizing( false );
 			setResizeSnapPreview( null );
-			setResizingItemId( null );
 			setTemporaryLayout( undefined );
 		} );
 
@@ -398,8 +394,6 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 			resizeBaselineRef.current = null;
 			setIsResizing( false );
 			setResizeSnapPreview( null );
-			setResizingItemId( null );
-
 			if ( ! onChangeLayout || ! latest ) {
 				setTemporaryLayout( undefined );
 				return;
@@ -416,7 +410,6 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 
 			if ( ! isResizing ) {
 				setIsResizing( true );
-				setResizingItemId( id );
 			}
 
 			const relativeDelta = {
@@ -540,16 +533,6 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 		// edit-mode toggles; `isActive` drives the opacity transition
 		// inside the overlay. Memoized so drag/resize re-renders skip
 		// reconciliation while inputs are stable.
-		const resizeHandleVisibleForItem = ( itemId: string ) => {
-			if ( activeId !== null ) {
-				return false;
-			}
-			if ( isResizing ) {
-				return resizingItemId === itemId;
-			}
-			return true;
-		};
-
 		const Overlay = renderGridOverlay ?? GridOverlay;
 		const overlayRowHeight =
 			typeof rowHeight === 'number' ? rowHeight : undefined;
@@ -623,9 +606,8 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 								layoutAnimationStyles[ 'layout-animating' ],
 							className
 						) }
-						data-wp-dashboard-grid-resizing={
-							isResizing || undefined
-						}
+						data-wp-grid-dragging={ activeId || undefined }
+						data-wp-grid-resizing={ isResizing || undefined }
 						style={ {
 							...style,
 							gridTemplateColumns: `repeat(${ effectiveColumns }, minmax(0, 1fr))`,
@@ -645,10 +627,7 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 								disabled={ ! editMode }
 								verticalResizable={ rowHeight !== 'auto' }
 								interacting={ activeId !== null || isResizing }
-								actionableAreaVisible={ ! isResizing }
-								resizeHandleVisible={ resizeHandleVisibleForItem(
-									id
-								) }
+								dragging={ activeId !== null }
 								onResize={ handleResize }
 								onResizeEnd={ persistTemporaryLayout }
 								resizeSnapPreview={

--- a/packages/grid/src/dashboard-grid/index.tsx
+++ b/packages/grid/src/dashboard-grid/index.tsx
@@ -135,6 +135,9 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 			id: string;
 			snap: ResizeSnapSize;
 		} | null >( null );
+		const [ resizingItemId, setResizingItemId ] = useState< string | null >(
+			null
+		);
 		// Mirror of `temporaryLayout` read synchronously on drag end —
 		// the state update from `handleDragMove` may still be batched.
 		const latestLayoutRef = useRef<
@@ -322,6 +325,7 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 			resizeBaselineRef.current = null;
 			setIsResizing( false );
 			setResizeSnapPreview( null );
+			setResizingItemId( null );
 			setTemporaryLayout( undefined );
 		} );
 
@@ -394,6 +398,7 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 			resizeBaselineRef.current = null;
 			setIsResizing( false );
 			setResizeSnapPreview( null );
+			setResizingItemId( null );
 
 			if ( ! onChangeLayout || ! latest ) {
 				setTemporaryLayout( undefined );
@@ -411,6 +416,7 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 
 			if ( ! isResizing ) {
 				setIsResizing( true );
+				setResizingItemId( id );
 			}
 
 			const relativeDelta = {
@@ -534,6 +540,16 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 		// edit-mode toggles; `isActive` drives the opacity transition
 		// inside the overlay. Memoized so drag/resize re-renders skip
 		// reconciliation while inputs are stable.
+		const resizeHandleVisibleForItem = ( itemId: string ) => {
+			if ( activeId !== null ) {
+				return false;
+			}
+			if ( isResizing ) {
+				return resizingItemId === itemId;
+			}
+			return true;
+		};
+
 		const Overlay = renderGridOverlay ?? GridOverlay;
 		const overlayRowHeight =
 			typeof rowHeight === 'number' ? rowHeight : undefined;
@@ -629,6 +645,9 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 								disabled={ ! editMode }
 								verticalResizable={ rowHeight !== 'auto' }
 								interacting={ activeId !== null || isResizing }
+								resizeHandleVisible={ resizeHandleVisibleForItem(
+									id
+								) }
 								onResize={ handleResize }
 								onResizeEnd={ persistTemporaryLayout }
 								resizeSnapPreview={

--- a/packages/grid/src/dashboard-grid/index.tsx
+++ b/packages/grid/src/dashboard-grid/index.tsx
@@ -645,6 +645,7 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 								disabled={ ! editMode }
 								verticalResizable={ rowHeight !== 'auto' }
 								interacting={ activeId !== null || isResizing }
+								actionableAreaVisible={ ! isResizing }
 								resizeHandleVisible={ resizeHandleVisibleForItem(
 									id
 								) }

--- a/packages/grid/src/dashboard-grid/types.ts
+++ b/packages/grid/src/dashboard-grid/types.ts
@@ -75,13 +75,21 @@ export type GridItemProps = {
 
 	/**
 	 * Whether any tile in the grid is currently being dragged or
-	 * resized. When true, the item mutes its `actionableArea` with
-	 * `inert` so pointer hovers over buttons in other tiles do not
-	 * steal the in-progress gesture.
+	 * resized. Drives the drag activator cursor and, while the
+	 * `actionableArea` is visible, mutes it with `inert` so hovers on
+	 * other tiles' controls do not steal the gesture.
 	 *
 	 * @default false
 	 */
 	interacting?: boolean;
+
+	/**
+	 * When false, the tile's `actionableArea` fades out (e.g. while
+	 * any tile in the surface is being resized).
+	 *
+	 * @default true
+	 */
+	actionableAreaVisible?: boolean;
 
 	/**
 	 * When false, the tile's resize handle fades out (e.g. while a

--- a/packages/grid/src/dashboard-grid/types.ts
+++ b/packages/grid/src/dashboard-grid/types.ts
@@ -75,29 +75,20 @@ export type GridItemProps = {
 
 	/**
 	 * Whether any tile in the grid is currently being dragged or
-	 * resized. Drives the drag activator cursor and, while the
-	 * `actionableArea` is visible, mutes it with `inert` so hovers on
-	 * other tiles' controls do not steal the gesture.
+	 * resized. Drives the drag activator cursor.
 	 *
 	 * @default false
 	 */
 	interacting?: boolean;
 
 	/**
-	 * When false, the tile's `actionableArea` fades out (e.g. while
-	 * any tile in the surface is being resized).
+	 * Whether a tile drag is in progress. Mutes each tile's
+	 * `actionableArea` with `inert` so hovers on other tiles' controls
+	 * do not steal the gesture.
 	 *
-	 * @default true
+	 * @default false
 	 */
-	actionableAreaVisible?: boolean;
-
-	/**
-	 * When false, the tile's resize handle fades out (e.g. while a
-	 * tile drag or another tile's resize is active).
-	 *
-	 * @default true
-	 */
-	resizeHandleVisible?: boolean;
+	dragging?: boolean;
 
 	/**
 	 * The content to be displayed within the grid item.
@@ -107,8 +98,9 @@ export type GridItemProps = {
 	/**
 	 * Content rendered above the draggable area that stays interactive
 	 * in edit mode, typically action buttons, menus, or links. While
-	 * any tile in the grid is being dragged or resized, this content
-	 * is set `inert` so hovers on other tiles can't steal the gesture.
+	 * a tile drag is in progress, this content is set `inert` so hovers
+	 * on other tiles can't steal the gesture. During resize, visibility
+	 * is controlled by grid-level CSS hooks.
 	 */
 	actionableArea?: React.ReactNode;
 

--- a/packages/grid/src/dashboard-grid/types.ts
+++ b/packages/grid/src/dashboard-grid/types.ts
@@ -84,6 +84,14 @@ export type GridItemProps = {
 	interacting?: boolean;
 
 	/**
+	 * When false, the tile's resize handle fades out (e.g. while a
+	 * tile drag or another tile's resize is active).
+	 *
+	 * @default true
+	 */
+	resizeHandleVisible?: boolean;
+
+	/**
 	 * The content to be displayed within the grid item.
 	 */
 	children: React.ReactNode;

--- a/packages/grid/src/dashboard-lanes/index.tsx
+++ b/packages/grid/src/dashboard-lanes/index.tsx
@@ -130,6 +130,9 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 			id: string;
 			snap: ResizeSnapSize;
 		} | null >( null );
+		const [ resizingItemId, setResizingItemId ] = useState< string | null >(
+			null
+		);
 		const latestLayoutRef = useRef<
 			DashboardLanesLayoutItem[] | undefined
 		>();
@@ -298,6 +301,7 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 			resizeBaselineRef.current = null;
 			setIsResizing( false );
 			setResizeSnapPreview( null );
+			setResizingItemId( null );
 			setTemporaryLayout( undefined );
 		} );
 
@@ -367,6 +371,7 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 			resizeBaselineRef.current = null;
 			setIsResizing( false );
 			setResizeSnapPreview( null );
+			setResizingItemId( null );
 
 			if ( ! onChangeLayout || ! latest ) {
 				setTemporaryLayout( undefined );
@@ -383,6 +388,7 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 			}
 			if ( ! isResizing ) {
 				setIsResizing( true );
+				setResizingItemId( id );
 			}
 
 			const relativeDelta = Math.round(
@@ -431,6 +437,16 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 		} );
 
 		const interacting = activeId !== null || isResizing;
+
+		const resizeHandleVisibleForItem = ( itemId: string ) => {
+			if ( activeId !== null ) {
+				return false;
+			}
+			if ( isResizing ) {
+				return resizingItemId === itemId;
+			}
+			return true;
+		};
 
 		// Drag-overlay clone composition: the surface always wraps with a
 		// thin functional frame (lift, cursor, pointer pass-through). When
@@ -544,6 +560,9 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 									}
 									disabled={ ! editMode }
 									interacting={ interacting }
+									resizeHandleVisible={ resizeHandleVisibleForItem(
+										id
+									) }
 									onResize={ handleResize }
 									onResizeEnd={ persistTemporaryLayout }
 									resizeSnapPreview={

--- a/packages/grid/src/dashboard-lanes/index.tsx
+++ b/packages/grid/src/dashboard-lanes/index.tsx
@@ -130,9 +130,6 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 			id: string;
 			snap: ResizeSnapSize;
 		} | null >( null );
-		const [ resizingItemId, setResizingItemId ] = useState< string | null >(
-			null
-		);
 		const latestLayoutRef = useRef<
 			DashboardLanesLayoutItem[] | undefined
 		>();
@@ -301,7 +298,6 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 			resizeBaselineRef.current = null;
 			setIsResizing( false );
 			setResizeSnapPreview( null );
-			setResizingItemId( null );
 			setTemporaryLayout( undefined );
 		} );
 
@@ -371,8 +367,6 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 			resizeBaselineRef.current = null;
 			setIsResizing( false );
 			setResizeSnapPreview( null );
-			setResizingItemId( null );
-
 			if ( ! onChangeLayout || ! latest ) {
 				setTemporaryLayout( undefined );
 				return;
@@ -388,7 +382,6 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 			}
 			if ( ! isResizing ) {
 				setIsResizing( true );
-				setResizingItemId( id );
 			}
 
 			const relativeDelta = Math.round(
@@ -437,16 +430,6 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 		} );
 
 		const interacting = activeId !== null || isResizing;
-
-		const resizeHandleVisibleForItem = ( itemId: string ) => {
-			if ( activeId !== null ) {
-				return false;
-			}
-			if ( isResizing ) {
-				return resizingItemId === itemId;
-			}
-			return true;
-		};
 
 		// Drag-overlay clone composition: the surface always wraps with a
 		// thin functional frame (lift, cursor, pointer pass-through). When
@@ -525,6 +508,8 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 								layoutAnimationStyles[ 'layout-animating' ],
 							className
 						) }
+						data-wp-grid-dragging={ activeId || undefined }
+						data-wp-grid-resizing={ isResizing || undefined }
 						style={
 							{
 								...style,
@@ -560,10 +545,7 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 									}
 									disabled={ ! editMode }
 									interacting={ interacting }
-									actionableAreaVisible={ ! isResizing }
-									resizeHandleVisible={ resizeHandleVisibleForItem(
-										id
-									) }
+									dragging={ activeId !== null }
 									onResize={ handleResize }
 									onResizeEnd={ persistTemporaryLayout }
 									resizeSnapPreview={

--- a/packages/grid/src/dashboard-lanes/index.tsx
+++ b/packages/grid/src/dashboard-lanes/index.tsx
@@ -560,6 +560,7 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 									}
 									disabled={ ! editMode }
 									interacting={ interacting }
+									actionableAreaVisible={ ! isResizing }
 									resizeHandleVisible={ resizeHandleVisibleForItem(
 										id
 									) }

--- a/packages/grid/src/dashboard-lanes/lanes-item.tsx
+++ b/packages/grid/src/dashboard-lanes/lanes-item.tsx
@@ -59,26 +59,18 @@ export type LanesItemProps = {
 
 	/**
 	 * Whether any tile in the surface is currently being dragged or
-	 * resized. Drives the drag activator cursor and, while the
-	 * `actionableArea` is visible, mutes it with `inert`.
+	 * resized. Drives the drag activator cursor.
 	 */
 	interacting?: boolean;
 
 	/**
-	 * When false, the tile's `actionableArea` fades out (e.g. while
-	 * any tile in the surface is being resized).
+	 * Whether a tile drag is in progress. Mutes each tile's
+	 * `actionableArea` with `inert` so hovers on other tiles' controls
+	 * do not steal the gesture.
 	 *
-	 * @default true
+	 * @default false
 	 */
-	actionableAreaVisible?: boolean;
-
-	/**
-	 * When false, the tile's resize handle fades out (e.g. while a
-	 * tile drag or another tile's resize is active).
-	 *
-	 * @default true
-	 */
-	resizeHandleVisible?: boolean;
+	dragging?: boolean;
 
 	children: React.ReactNode;
 
@@ -107,8 +99,7 @@ export function LanesItem( {
 	onResizeEnd,
 	resizeSnapPreview = null,
 	renderResizeHandle,
-	resizeHandleVisible = true,
-	actionableAreaVisible = true,
+	dragging = false,
 }: LanesItemProps ) {
 	const [ resizeDelta, setResizeDelta ] = useState< ResizeDelta | null >(
 		null
@@ -185,22 +176,15 @@ export function LanesItem( {
 			className={ itemClassName }
 			style={ style }
 			{ ...{ [ GRID_ITEM_DATA_KEY ]: itemKey } }
+			data-wp-grid-item-resizing={ isResizing || undefined }
 		>
 			{ actionableArea ? (
 				<div
-					className={ clsx(
-						actionableAreaStyles[ 'actionable-area-slot' ],
-						! actionableAreaVisible &&
-							actionableAreaStyles[
-								'actionable-area-slot--hidden'
-							]
-					) }
+					className={ actionableAreaStyles[ 'actionable-area-slot' ] }
 				>
 					<div
 						style={ { display: 'contents' } }
-						{ ...( interacting && actionableAreaVisible
-							? { inert: '' }
-							: {} ) }
+						{ ...( dragging ? { inert: '' } : {} ) }
 					>
 						{ actionableArea }
 					</div>
@@ -226,7 +210,6 @@ export function LanesItem( {
 						<ResizeHandle
 							itemId={ itemKey }
 							verticalResizable={ false }
-							visible={ resizeHandleVisible }
 							onResize={ handleResize }
 							onResizeEnd={ handleResizeEnd }
 							renderResizeHandle={ renderResizeHandle }

--- a/packages/grid/src/dashboard-lanes/lanes-item.tsx
+++ b/packages/grid/src/dashboard-lanes/lanes-item.tsx
@@ -62,6 +62,14 @@ export type LanesItemProps = {
 	 */
 	interacting?: boolean;
 
+	/**
+	 * When false, the tile's resize handle fades out (e.g. while a
+	 * tile drag or another tile's resize is active).
+	 *
+	 * @default true
+	 */
+	resizeHandleVisible?: boolean;
+
 	children: React.ReactNode;
 
 	actionableArea?: React.ReactNode;
@@ -89,6 +97,7 @@ export function LanesItem( {
 	onResizeEnd,
 	resizeSnapPreview = null,
 	renderResizeHandle,
+	resizeHandleVisible = true,
 }: LanesItemProps ) {
 	const [ resizeDelta, setResizeDelta ] = useState< ResizeDelta | null >(
 		null
@@ -194,6 +203,7 @@ export function LanesItem( {
 						<ResizeHandle
 							itemId={ itemKey }
 							verticalResizable={ false }
+							visible={ resizeHandleVisible }
 							onResize={ handleResize }
 							onResizeEnd={ handleResizeEnd }
 							renderResizeHandle={ renderResizeHandle }

--- a/packages/grid/src/dashboard-lanes/lanes-item.tsx
+++ b/packages/grid/src/dashboard-lanes/lanes-item.tsx
@@ -13,6 +13,7 @@ import { useMergeRefs } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import actionableAreaStyles from '../shared/actionable-area-slot.module.css';
 import ResizeHandle from '../shared/resize-handle';
 import { GRID_ITEM_DATA_KEY } from '../shared/grid-item-key';
 import type { ResizeSnapSize } from '../shared/resize-snap';
@@ -58,9 +59,18 @@ export type LanesItemProps = {
 
 	/**
 	 * Whether any tile in the surface is currently being dragged or
-	 * resized. Used to mute `actionableArea` content with `inert`.
+	 * resized. Drives the drag activator cursor and, while the
+	 * `actionableArea` is visible, mutes it with `inert`.
 	 */
 	interacting?: boolean;
+
+	/**
+	 * When false, the tile's `actionableArea` fades out (e.g. while
+	 * any tile in the surface is being resized).
+	 *
+	 * @default true
+	 */
+	actionableAreaVisible?: boolean;
 
 	/**
 	 * When false, the tile's resize handle fades out (e.g. while a
@@ -98,6 +108,7 @@ export function LanesItem( {
 	resizeSnapPreview = null,
 	renderResizeHandle,
 	resizeHandleVisible = true,
+	actionableAreaVisible = true,
 }: LanesItemProps ) {
 	const [ resizeDelta, setResizeDelta ] = useState< ResizeDelta | null >(
 		null
@@ -177,10 +188,22 @@ export function LanesItem( {
 		>
 			{ actionableArea ? (
 				<div
-					style={ { display: 'contents' } }
-					{ ...( interacting ? { inert: '' } : {} ) }
+					className={ clsx(
+						actionableAreaStyles[ 'actionable-area-slot' ],
+						! actionableAreaVisible &&
+							actionableAreaStyles[
+								'actionable-area-slot--hidden'
+							]
+					) }
 				>
-					{ actionableArea }
+					<div
+						style={ { display: 'contents' } }
+						{ ...( interacting && actionableAreaVisible
+							? { inert: '' }
+							: {} ) }
+					>
+						{ actionableArea }
+					</div>
 				</div>
 			) : null }
 

--- a/packages/grid/src/shared/actionable-area-slot.module.css
+++ b/packages/grid/src/shared/actionable-area-slot.module.css
@@ -1,0 +1,16 @@
+.actionable-area-slot {
+	opacity: 1;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.actionable-area-slot {
+		transition:
+			opacity var(--wpds-motion-duration-md)
+			var(--wpds-motion-easing-subtle);
+	}
+}
+
+.actionable-area-slot--hidden {
+	opacity: 0;
+	pointer-events: none;
+}

--- a/packages/grid/src/shared/actionable-area-slot.module.css
+++ b/packages/grid/src/shared/actionable-area-slot.module.css
@@ -10,7 +10,7 @@
 	}
 }
 
-.actionable-area-slot--hidden {
+:global([data-wp-grid-resizing]) .actionable-area-slot {
 	opacity: 0;
 	pointer-events: none;
 }

--- a/packages/grid/src/shared/resize-handle.module.css
+++ b/packages/grid/src/shared/resize-handle.module.css
@@ -1,3 +1,28 @@
+/*
+ * Fade with opacity only: `visibility` is not interpolatable and pairing
+ * it with delayed transitions breaks fade-in (handles stay unpainted
+ * until the delay elapses) or cancels fade-out if flipped to hidden
+ * in the same frame as opacity hits 0. `pointer-events: none` covers
+ * hit-testing while faded out. Transition is omitted when the user
+ * requests reduced motion.
+ */
+.resize-handle-slot {
+	opacity: 1;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.resize-handle-slot {
+		transition:
+			opacity var(--wpds-motion-duration-md)
+			var(--wpds-motion-easing-subtle);
+	}
+}
+
+.resize-handle-slot--hidden {
+	opacity: 0;
+	pointer-events: none;
+}
+
 .resize-handle {
 	position: absolute;
 	bottom: 0;

--- a/packages/grid/src/shared/resize-handle.module.css
+++ b/packages/grid/src/shared/resize-handle.module.css
@@ -18,9 +18,22 @@
 	}
 }
 
-.resize-handle-slot--hidden {
+/*
+ * Grid-level interaction hooks (`data-wp-grid-dragging`,
+ * `data-wp-grid-resizing`, `data-wp-grid-item-resizing`) drive
+ * handle visibility so surfaces do not prop-drill per tile.
+ */
+:global([data-wp-grid-dragging]) .resize-handle-slot,
+:global([data-wp-grid-resizing]) .resize-handle-slot {
 	opacity: 0;
 	pointer-events: none;
+}
+
+:global([data-wp-grid-resizing])
+	:global([data-wp-grid-item-resizing])
+	.resize-handle-slot {
+	opacity: 1;
+	pointer-events: auto;
 }
 
 .resize-handle {

--- a/packages/grid/src/shared/resize-handle.module.css
+++ b/packages/grid/src/shared/resize-handle.module.css
@@ -1,10 +1,6 @@
 /*
  * Fade with opacity only: `visibility` is not interpolatable and pairing
- * it with delayed transitions breaks fade-in (handles stay unpainted
- * until the delay elapses) or cancels fade-out if flipped to hidden
- * in the same frame as opacity hits 0. `pointer-events: none` covers
- * hit-testing while faded out. Transition is omitted when the user
- * requests reduced motion.
+ * it with delayed transitions breaks fade-in.
  */
 .resize-handle-slot {
 	opacity: 1;
@@ -21,7 +17,7 @@
 /*
  * Grid-level interaction hooks (`data-wp-grid-dragging`,
  * `data-wp-grid-resizing`, `data-wp-grid-item-resizing`) drive
- * handle visibility so surfaces do not prop-drill per tile.
+ * handle visibility.
  */
 :global([data-wp-grid-dragging]) .resize-handle-slot,
 :global([data-wp-grid-resizing]) .resize-handle-slot {
@@ -30,8 +26,8 @@
 }
 
 :global([data-wp-grid-resizing])
-	:global([data-wp-grid-item-resizing])
-	.resize-handle-slot {
+:global([data-wp-grid-item-resizing])
+.resize-handle-slot {
 	opacity: 1;
 	pointer-events: auto;
 }

--- a/packages/grid/src/shared/resize-handle.tsx
+++ b/packages/grid/src/shared/resize-handle.tsx
@@ -44,7 +44,6 @@ function ResizeHandle( {
 	itemId,
 	verticalResizable = true,
 	renderResizeHandle,
-	visible = true,
 }: ResizeHandleProps ) {
 	const { attributes, listeners, setNodeRef, isDragging } = useDraggable( {
 		id: 'draggable',
@@ -83,7 +82,6 @@ function ResizeHandle( {
 				attributes={ attributes }
 				verticalResizable={ verticalResizable }
 				isResizing={ isDragging }
-				visible={ visible }
 				itemId={ itemId }
 			/>
 		);
@@ -120,11 +118,10 @@ function ResizeHandle( {
  * @param props Component props.
  */
 export default function ResizeHandleWrapper( props: ResizeHandleProps ) {
-	const { visible = true, ...resizeHandleProps } = props;
 	const throttleDelay = 16;
 	const throttledResize = useThrottle( ( delta: ResizeDelta ) => {
-		if ( resizeHandleProps.onResize ) {
-			resizeHandleProps.onResize( delta );
+		if ( props.onResize ) {
+			props.onResize( delta );
 		}
 	}, throttleDelay );
 
@@ -144,8 +141,8 @@ export default function ResizeHandleWrapper( props: ResizeHandleProps ) {
 	};
 
 	const handleDragEnd = () => {
-		if ( resizeHandleProps.onResizeEnd ) {
-			resizeHandleProps.onResizeEnd();
+		if ( props.onResizeEnd ) {
+			props.onResizeEnd();
 		}
 	};
 
@@ -158,13 +155,8 @@ export default function ResizeHandleWrapper( props: ResizeHandleProps ) {
 			onDragMove={ handleDragMove }
 			onDragEnd={ handleDragEnd }
 		>
-			<div
-				className={ clsx(
-					styles[ 'resize-handle-slot' ],
-					! visible && styles[ 'resize-handle-slot--hidden' ]
-				) }
-			>
-				<ResizeHandle { ...resizeHandleProps } visible={ visible } />
+			<div className={ styles[ 'resize-handle-slot' ] }>
+				<ResizeHandle { ...props } />
 			</div>
 		</DndContext>
 	);

--- a/packages/grid/src/shared/resize-handle.tsx
+++ b/packages/grid/src/shared/resize-handle.tsx
@@ -44,6 +44,7 @@ function ResizeHandle( {
 	itemId,
 	verticalResizable = true,
 	renderResizeHandle,
+	visible = true,
 }: ResizeHandleProps ) {
 	const { attributes, listeners, setNodeRef, isDragging } = useDraggable( {
 		id: 'draggable',
@@ -82,6 +83,7 @@ function ResizeHandle( {
 				attributes={ attributes }
 				verticalResizable={ verticalResizable }
 				isResizing={ isDragging }
+				visible={ visible }
 				itemId={ itemId }
 			/>
 		);
@@ -118,10 +120,11 @@ function ResizeHandle( {
  * @param props Component props.
  */
 export default function ResizeHandleWrapper( props: ResizeHandleProps ) {
+	const { visible = true, ...resizeHandleProps } = props;
 	const throttleDelay = 16;
 	const throttledResize = useThrottle( ( delta: ResizeDelta ) => {
-		if ( props.onResize ) {
-			props.onResize( delta );
+		if ( resizeHandleProps.onResize ) {
+			resizeHandleProps.onResize( delta );
 		}
 	}, throttleDelay );
 
@@ -141,8 +144,8 @@ export default function ResizeHandleWrapper( props: ResizeHandleProps ) {
 	};
 
 	const handleDragEnd = () => {
-		if ( props.onResizeEnd ) {
-			props.onResizeEnd();
+		if ( resizeHandleProps.onResizeEnd ) {
+			resizeHandleProps.onResizeEnd();
 		}
 	};
 
@@ -155,7 +158,14 @@ export default function ResizeHandleWrapper( props: ResizeHandleProps ) {
 			onDragMove={ handleDragMove }
 			onDragEnd={ handleDragEnd }
 		>
-			<ResizeHandle { ...props } />
+			<div
+				className={ clsx(
+					styles[ 'resize-handle-slot' ],
+					! visible && styles[ 'resize-handle-slot--hidden' ]
+				) }
+			>
+				<ResizeHandle { ...resizeHandleProps } visible={ visible } />
+			</div>
 		</DndContext>
 	);
 }

--- a/packages/grid/src/shared/types.ts
+++ b/packages/grid/src/shared/types.ts
@@ -52,15 +52,6 @@ export interface ResizeHandleRenderProps {
 	isResizing: boolean;
 
 	/**
-	 * False while another tile is being dragged or resized, so this
-	 * handle can fade out with the surface chrome. The tile that owns
-	 * the active resize gesture stays `true`.
-	 *
-	 * @default true
-	 */
-	visible?: boolean;
-
-	/**
 	 * Owning item's `key`. Available so consumers can render per-tile
 	 * content if needed.
 	 */
@@ -170,12 +161,4 @@ export interface ResizeHandleProps {
 	 * responsible for the visual.
 	 */
 	renderResizeHandle?: React.ComponentType< ResizeHandleRenderProps >;
-
-	/**
-	 * When false, the handle animates out (e.g. while a tile drag or
-	 * another tile's resize is in progress).
-	 *
-	 * @default true
-	 */
-	visible?: boolean;
 }

--- a/packages/grid/src/shared/types.ts
+++ b/packages/grid/src/shared/types.ts
@@ -52,6 +52,15 @@ export interface ResizeHandleRenderProps {
 	isResizing: boolean;
 
 	/**
+	 * False while another tile is being dragged or resized, so this
+	 * handle can fade out with the surface chrome. The tile that owns
+	 * the active resize gesture stays `true`.
+	 *
+	 * @default true
+	 */
+	visible?: boolean;
+
+	/**
 	 * Owning item's `key`. Available so consumers can render per-tile
 	 * content if needed.
 	 */
@@ -161,4 +170,12 @@ export interface ResizeHandleProps {
 	 * responsible for the visual.
 	 */
 	renderResizeHandle?: React.ComponentType< ResizeHandleRenderProps >;
+
+	/**
+	 * When false, the handle animates out (e.g. while a tile drag or
+	 * another tile's resize is in progress).
+	 *
+	 * @default true
+	 */
+	visible?: boolean;
 }

--- a/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
@@ -21,11 +21,11 @@
 /*
  * While a resize is in progress, the pointer often sits over the tile;
  * keep resting elevation so the hover lift does not flicker or fight the
- * gesture. `data-wp-dashboard-grid-resizing` is set on `@wordpress/grid`
- * `DashboardGrid` root for the duration of the resize.
+ * gesture. `data-wp-grid-resizing` is set on `@wordpress/grid` surface
+ * roots for the duration of the resize.
  */
-:global([data-wp-dashboard-grid-resizing]) .tileEditMode:hover,
-:global([data-wp-dashboard-grid-resizing]) .tileEditMode:focus-visible {
+:global([data-wp-grid-resizing]) .tileEditMode:hover,
+:global([data-wp-grid-resizing]) .tileEditMode:focus-visible {
 	box-shadow: var(--wpds-elevation-xs);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow-up to https://github.com/WordPress/gutenberg/pull/78389#issuecomment-4475847645

<!-- In a few words, what is the PR actually doing? -->

Hides other resize handles expect the one from the tile that's being resized.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Reduces UI noise. Also avoids different layers overlapping in undersided ways; it could be fixed by adjusting z-indices, or we can just hide the resize handles and chrome anyway.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

#### Before

https://github.com/user-attachments/assets/03c1a55f-eb4a-4c1b-a2f3-7c5eab20137a




#### After

https://github.com/user-attachments/assets/72409b39-dfa7-4267-bcfa-7ed2c00040e9



## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
