### PR TITLE
Env: bin/cherry-pick: exit early when gh CLI is not available

### DIFF
--- a/tools/release/cherry-pick.mjs
+++ b/tools/release/cherry-pick.mjs
@@ -30,7 +30,7 @@ const AUTO_PROPAGATE_RESULTS_TO_GITHUB = GITHUB_CLI_AVAILABLE;
  */
 async function main() {
 	if ( ! GITHUB_CLI_AVAILABLE ) {
-		await reportGhUnavailable();
+		reportGhUnavailable();
 	}
 
 	console.log( `You are on branch "${ BRANCH }".` );
@@ -499,27 +499,22 @@ function getCurrentBranch() {
 }
 
 /**
- * Reports when the gh CLI tool is missing, describes the consequences, asks
- * whether to proceed.
- *
- * @return {Promise<void>}
+ * Reports that the gh CLI tool is missing and exits.
+ * The script cannot function without gh because it is required for GitHub API
+ * authentication via `gh auth token`.
  */
-async function reportGhUnavailable() {
-	console.log(
-		'GitHub CLI is not setup. This script will not be able to automatically'
+function reportGhUnavailable() {
+	console.error(
+		'Error: GitHub CLI (gh) is not installed or not authenticated.'
 	);
-	console.log(
-		'comment on the processed PRs and remove the backport label from them.'
+	console.error(
+		'This script requires gh to authenticate with the GitHub API.'
 	);
-	console.log(
-		'Instead, you will see a detailed list of next steps to perform manually.'
+	console.error( '' );
+	console.error(
+		'Install gh from https://cli.github.com/ and run `gh auth login`, then try again.'
 	);
-	console.log( '' );
-	console.log(
-		'To enable automatic handling, install the `gh` utility from https://cli.github.com/'
-	);
-	console.log( '' );
-	await promptDoYouWantToProceed();
+	process.exit( 1 );
 }
 
 /**


### PR DESCRIPTION
## What?

Part of #59399

Improves error handling in the cherry-pick script when `gh` CLI is not installed or authenticated.

## Why?

`gh` is required not just for commenting on PRs and removing labels, but also for GitHub API authentication via `gh auth token`, used by every `GitHubFetch()` call in the script. Without it, the script always crashes with an unhandled error mid-execution.

The previous `reportGhUnavailable()` misled the user by saying the script would continue with manual steps, then let execution proceed directly into a guaranteed crash at `getGitHubAuthToken()`.

## How?

Replaces the misleading warning-and-prompt in `reportGhUnavailable()` with an immediate `process.exit(1)` and a clear error message directing the user to install `gh` and run `gh auth login` before retrying.

## Testing Instructions

1. Temporarily rename the `gh` binary so it is unavailable: `sudo mv $(which gh) $(which gh).bak`
2. Run `npm run other:cherry-pick`.
3. Confirm the script immediately prints an error and exits with code `1`,  it should **not** prompt `Do you want to proceed?`.
4. Restore `gh`: `sudo mv $(which gh).bak $(which gh)`
5. Run again, script should proceed normally.