### PR TITLE
Revisions: Use CSS outline as secondary non-color indicator for diff blocks

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
@@ -66,6 +66,10 @@ const REVISION_DIFF_STYLES = `
 		text-decoration: line-through;
 		filter: url(#revision-removed-filter);
 	}
+	.is-revision-removed {
+		outline: 3px dashed #d63638;
+		outline-offset: 2px;
+	}
 	.is-revision-modified {
 		outline: 2px solid color-mix(in srgb, currentColor 30%, #dba617 70%) !important;
 		outline-offset: 2px;

--- a/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
@@ -58,6 +58,8 @@ const REVISION_REMOVED_FILTER_SVG = `
 const REVISION_DIFF_STYLES = `
 	.is-revision-added {
 		box-shadow: inset 0 0 0 9999px color-mix(in srgb, currentColor 5%, #00a32a 15%), 0 0 0 4px color-mix(in srgb, currentColor 5%, #00a32a 15%);
+		outline: 3px solid #00a32a;
+		outline-offset: 2px;
 	}
 	.is-revision-removed,
 	.revision-diff-removed {

--- a/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
@@ -71,7 +71,7 @@ const REVISION_DIFF_STYLES = `
 		outline-offset: 2px;
 	}
 	.is-revision-modified {
-		outline: 2px solid color-mix(in srgb, currentColor 30%, #dba617 70%) !important;
+		outline: 3px dotted #9a7000 !important;
 		outline-offset: 2px;
 	}
 	.revision-diff-added {


### PR DESCRIPTION

## What?

Part of #77530.


Add CSS `outline`-based secondary indicators for the diff blocks. Adds a solid outline to added blocks.

## Why?


`outline` was specifically proposed and endorsed as the correct pattern:
- **Solid** = added (permanent, present)
- **Dashed** = removed (impermanent, absent)
- **Dotted** = modified (changed, but still present)

`outline` is used to avoid layout interference and conflict with user-applied image styles. It renders correctly in High Contrast Mode.

## Testing Instructions
1. Open a post with several revisions.
2. Enter the Revisions view and enable "Show changes".
3. Navigate revisions to find added/removed/modified blocks.
4. Verify each has a distinct outline shape (solid/dashed/dotted).
5. Verify content in the removed/modified blocks is fully readable.

## Screenshots or screencast <!-- if applicable -->

See https://github.com/WordPress/gutenberg/issues/77530#issuecomment-4475748780 and https://github.com/WordPress/gutenberg/issues/77530#issuecomment-4475835477
