### PR TITLE
Grid: animate sibling tiles when layout reflows during drag or resize

### DIFF
--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -9,6 +9,8 @@
     column backgrounds, outlines, and repeating row dividers. Theme via
     `--wp-grid-overlay-tile-bg`.
     `GridOverlayRenderProps` now includes `rows` for uniform-row grids.
+-   Animate sibling tiles when layout reflows during drag or resize in
+    edit mode (FLIP transform). Respects `prefers-reduced-motion`.
 -   Add `--wp-grid-placeholder-outline-style` and
     `--wp-grid-resize-preview-outline-style` CSS custom properties for
     the drag-placeholder outline (default `dashed`) and resize-preview

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -186,6 +186,8 @@ When `editMode` is true:
 - `onPreviewLayout` fires continuously during the interaction for
   live feedback; the committed layout is still emitted via
   `onChangeLayout`.
+- Sibling tiles animate into their new positions when the layout
+  reflows.
 
 ---
 
@@ -308,6 +310,9 @@ Drag-to-reorder works the same as in `DashboardGrid`. Resize is
 **horizontal-only**: tile heights are content-driven, so there is
 no vertical resize gesture. The default handle is a vertical bar
 centered on the trailing edge; the cursor is `ew-resize`.
+
+Sibling tiles animate into their new positions when the layout
+reflows.
 
 ---
 

--- a/packages/grid/src/dashboard-grid/grid-item.tsx
+++ b/packages/grid/src/dashboard-grid/grid-item.tsx
@@ -13,6 +13,7 @@ import { useMergeRefs } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import { GRID_ITEM_DATA_KEY } from '../shared/grid-item-key';
 import ResizeHandle from '../shared/resize-handle';
 import type { ResizeSnapSize } from '../shared/resize-snap';
 import type { ResizeDelta } from '../shared/types';
@@ -128,7 +129,12 @@ export function GridItem( {
 	) : null;
 
 	return (
-		<div ref={ mergedRef } className={ itemClassName } style={ style }>
+		<div
+			ref={ mergedRef }
+			className={ itemClassName }
+			style={ style }
+			{ ...{ [ GRID_ITEM_DATA_KEY ]: item.key } }
+		>
 			{ actionableArea ? (
 				<div
 					style={ { display: 'contents' } }

--- a/packages/grid/src/dashboard-grid/index.tsx
+++ b/packages/grid/src/dashboard-grid/index.tsx
@@ -566,11 +566,9 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 		);
 
 		const layoutAnimating =
-			editMode &&
-			( isResizing || temporaryLayout !== undefined );
+			editMode && ( isResizing || temporaryLayout !== undefined );
 		const layoutFingerprint = useMemo(
-			() =>
-				getLayoutFingerprint( [ ...resolvedItemMap.values() ] ),
+			() => getLayoutFingerprint( [ ...resolvedItemMap.values() ] ),
 			[ resolvedItemMap ]
 		);
 		const excludeLayoutAnimationKey =

--- a/packages/grid/src/dashboard-grid/index.tsx
+++ b/packages/grid/src/dashboard-grid/index.tsx
@@ -38,6 +38,11 @@ import {
 import { GridItem } from './grid-item';
 import { GridOverlay } from '../shared/grid-overlay';
 import { gridSpanToPixelSize } from '../shared/resize-snap';
+import layoutAnimationStyles from '../shared/layout-shift-animation.module.css';
+import {
+	getLayoutFingerprint,
+	useLayoutShiftAnimation,
+} from '../shared/use-layout-shift-animation';
 import { resolveFillWidths } from './resolve-fill-widths';
 import type { DashboardGridLayoutItem, DashboardGridProps } from './types';
 import type { ResizeSnapSize } from '../shared/resize-snap';
@@ -150,9 +155,12 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 			width: number;
 			height: number;
 		} | null >( null );
+		const captureLayoutSnapshotRef = useRef< () => void >( () => {} );
 		const activeLayout = temporaryLayout ?? layout;
 
-		const rootRef = useRef< HTMLDivElement >( null );
+		const [ gridRoot, setGridRoot ] = useState< HTMLDivElement | null >(
+			null
+		);
 		const [ containerWidth, setContainerWidth ] = useState( 0 );
 		const [ containerHeight, setContainerHeight ] = useState( 0 );
 		const [ gapPx, setGapPx ] = useState( FALLBACK_GAP_PX );
@@ -163,7 +171,7 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 			}
 		);
 		const mergedGridRef = useMergeRefs( [
-			rootRef,
+			setGridRoot,
 			resizeObserverRef,
 			ref,
 		] );
@@ -173,10 +181,10 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 		// computed `column-gap` is read from the resolved CSS so the
 		// math tracks the design-system token under any density.
 		useLayoutEffect( () => {
-			if ( ! rootRef.current ) {
+			if ( ! gridRoot ) {
 				return;
 			}
-			const { width, height } = rootRef.current.getBoundingClientRect();
+			const { width, height } = gridRoot.getBoundingClientRect();
 			if ( width > 0 ) {
 				setContainerWidth( width );
 			}
@@ -184,12 +192,12 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 				setContainerHeight( height );
 			}
 			const parsed = Number.parseFloat(
-				window.getComputedStyle( rootRef.current ).columnGap
+				window.getComputedStyle( gridRoot ).columnGap
 			);
 			if ( Number.isFinite( parsed ) && parsed > 0 ) {
 				setGapPx( parsed );
 			}
-		}, [] );
+		}, [ gridRoot ] );
 		const effectiveColumns = useMemo( () => {
 			if ( ! minColumnWidth ) {
 				return columns ?? DEFAULT_COLUMNS;
@@ -218,39 +226,28 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 		// is derived inline from state). Without this, downstream memos
 		// would invalidate on every parent re-render and the children
 		// walk skip during gestures wouldn't hold.
-		const layoutKeysSig = layout.map( ( item ) => item.key ).join( '\0' );
-		const layoutKeysRef = useRef< {
-			sig: string;
-			set: Set< string >;
-		} | null >( null );
-		if ( layoutKeysRef.current?.sig !== layoutKeysSig ) {
-			layoutKeysRef.current = {
-				sig: layoutKeysSig,
-				set: new Set( layout.map( ( item ) => item.key ) ),
-			};
-		}
-		const layoutKeys = layoutKeysRef.current.set;
+		const layoutKeys = useMemo(
+			() => new Set( layout.map( ( item ) => item.key ) ),
+			[ layout ]
+		);
 
 		// Sorted item keys, identity-stable when the resulting sequence is
 		// unchanged. Avoids producing a fresh `items` array on every parent
 		// re-render so `<SortableContext>` doesn't update its context value
 		// and notify every `useSortable` subscriber unnecessarily.
-		const sortedItems = activeLayout
-			.map( ( item, index ) => ( { item, index } ) )
-			.sort(
-				( a, b ) =>
-					( a.item.order ?? a.index ) - ( b.item.order ?? b.index )
-			)
-			.map( ( { item } ) => item.key );
-		const itemsSig = sortedItems.join( '\0' );
-		const itemsRef = useRef< {
-			sig: string;
-			arr: string[];
-		} | null >( null );
-		if ( itemsRef.current?.sig !== itemsSig ) {
-			itemsRef.current = { sig: itemsSig, arr: sortedItems };
-		}
-		const items = itemsRef.current.arr;
+		const sortedItems = useMemo(
+			() =>
+				activeLayout
+					.map( ( item, index ) => ( { item, index } ) )
+					.sort(
+						( a, b ) =>
+							( a.item.order ?? a.index ) -
+							( b.item.order ?? b.index )
+					)
+					.map( ( { item } ) => item.key ),
+			[ activeLayout ]
+		);
+		const items = sortedItems;
 
 		// Resolve `width: 'fill'` items to concrete column spans.
 		const resolvedItemMap = useMemo( () => {
@@ -384,6 +381,7 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 				y: activeCenterY,
 			};
 			latestLayoutRef.current = updatedLayout;
+			captureLayoutSnapshotRef.current();
 			setTemporaryLayout( updatedLayout );
 			onPreviewLayout?.( updatedLayout );
 		} );
@@ -501,6 +499,8 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 			);
 
 			latestLayoutRef.current = updatedLayout;
+			captureLayoutSnapshotRef.current();
+			setTemporaryLayout( updatedLayout );
 			onPreviewLayout?.( updatedLayout );
 		} );
 
@@ -565,6 +565,26 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 			]
 		);
 
+		const layoutAnimating =
+			editMode &&
+			( isResizing || temporaryLayout !== undefined );
+		const layoutFingerprint = useMemo(
+			() =>
+				getLayoutFingerprint( [ ...resolvedItemMap.values() ] ),
+			[ resolvedItemMap ]
+		);
+		const excludeLayoutAnimationKey =
+			activeId ?? ( isResizing ? resizeSnapPreview?.id : null );
+		const { captureLayoutSnapshot } = useLayoutShiftAnimation( {
+			container: gridRoot,
+			enabled: layoutAnimating,
+			layoutFingerprint,
+			excludeItemKey: excludeLayoutAnimationKey,
+		} );
+		useLayoutEffect( () => {
+			captureLayoutSnapshotRef.current = captureLayoutSnapshot;
+		}, [ captureLayoutSnapshot ] );
+
 		return (
 			<DndContext
 				sensors={ sensors }
@@ -583,7 +603,12 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 					<div
 						{ ...divProps }
 						ref={ mergedGridRef }
-						className={ clsx( styles.grid, className ) }
+						className={ clsx(
+							styles.grid,
+							layoutAnimating &&
+								layoutAnimationStyles[ 'layout-animating' ],
+							className
+						) }
 						data-wp-dashboard-grid-resizing={
 							isResizing || undefined
 						}

--- a/packages/grid/src/dashboard-lanes/index.tsx
+++ b/packages/grid/src/dashboard-lanes/index.tsx
@@ -138,6 +138,7 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 			y: number;
 		} | null >( null );
 		const resizeBaselineRef = useRef< number | null >( null );
+		const captureLayoutSnapshotRef = useRef< () => void >( () => {} );
 		const activeLayout = temporaryLayout ?? layout;
 
 		const [ container, setContainer ] = useState< HTMLDivElement | null >(
@@ -196,21 +197,10 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 		}, [ activeLayout ] );
 
 		// Stable-identity key set for the children walk (see grid.tsx).
-		const layoutKeysSig = useMemo(
-			() => layout.map( ( item ) => item.key ).join( '\0' ),
+		const layoutKeys = useMemo(
+			() => new Set( layout.map( ( item ) => item.key ) ),
 			[ layout ]
 		);
-		const layoutKeysRef = useRef< {
-			sig: string;
-			set: Set< string >;
-		} | null >( null );
-		if ( layoutKeysRef.current?.sig !== layoutKeysSig ) {
-			layoutKeysRef.current = {
-				sig: layoutKeysSig,
-				set: new Set( layout.map( ( item ) => item.key ) ),
-			};
-		}
-		const layoutKeys = layoutKeysRef.current.set;
 
 		// Sorted item keys, identity-stable when the resulting sequence
 		// is unchanged (avoids invalidating SortableContext).
@@ -226,18 +216,7 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 					.map( ( { item } ) => item.key ),
 			[ activeLayout ]
 		);
-		const itemsSig = useMemo(
-			() => sortedItems.join( '\0' ),
-			[ sortedItems ]
-		);
-		const itemsRef = useRef< {
-			sig: string;
-			arr: string[];
-		} | null >( null );
-		if ( itemsRef.current?.sig !== itemsSig ) {
-			itemsRef.current = { sig: itemsSig, arr: sortedItems };
-		}
-		const items = itemsRef.current.arr;
+		const items = sortedItems;
 
 		// Placement input for the hook: each item with its clamped span
 		// in source (sorted) order. `lane` forwards the optional explicit
@@ -262,24 +241,6 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 			flowTolerance,
 			rowUnit,
 		} );
-
-		const layoutAnimating =
-			editMode && ( isResizing || temporaryLayout !== undefined );
-		const layoutFingerprint = useMemo( () => {
-			const layoutSig = getLayoutFingerprint( activeLayout );
-			const placementSig = getPlacementFingerprint( itemStyles );
-			return `${ layoutSig }\0${ placementSig }`;
-		}, [ activeLayout, itemStyles ] );
-		const excludeLayoutAnimationKey =
-			activeId ?? ( isResizing ? resizeSnapPreview?.id : null );
-		const captureLayoutSnapshotRef = useRef< () => void >( () => {} );
-		const { captureLayoutSnapshot } = useLayoutShiftAnimation( {
-			container,
-			enabled: layoutAnimating,
-			layoutFingerprint,
-			excludeItemKey: excludeLayoutAnimationKey,
-		} );
-		captureLayoutSnapshotRef.current = captureLayoutSnapshot;
 
 		const [ childrenMap, actionableAreaMap, remaining ] = useMemo( () => {
 			const childMap = new Map< string, React.ReactElement >();
@@ -506,6 +467,25 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 			),
 			[ Overlay, editMode, effectiveColumns ]
 		);
+
+		const layoutAnimating =
+			editMode && ( isResizing || temporaryLayout !== undefined );
+		const layoutFingerprint = useMemo( () => {
+			const layoutSig = getLayoutFingerprint( activeLayout );
+			const placementSig = getPlacementFingerprint( itemStyles );
+			return `${ layoutSig }\0${ placementSig }`;
+		}, [ activeLayout, itemStyles ] );
+		const excludeLayoutAnimationKey =
+			activeId ?? ( isResizing ? resizeSnapPreview?.id : null );
+		const { captureLayoutSnapshot } = useLayoutShiftAnimation( {
+			container,
+			enabled: layoutAnimating,
+			layoutFingerprint,
+			excludeItemKey: excludeLayoutAnimationKey,
+		} );
+		useLayoutEffect( () => {
+			captureLayoutSnapshotRef.current = captureLayoutSnapshot;
+		}, [ captureLayoutSnapshot ] );
 
 		return (
 			<DndContext

--- a/packages/grid/src/dashboard-lanes/index.tsx
+++ b/packages/grid/src/dashboard-lanes/index.tsx
@@ -264,8 +264,7 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 		} );
 
 		const layoutAnimating =
-			editMode &&
-			( isResizing || temporaryLayout !== undefined );
+			editMode && ( isResizing || temporaryLayout !== undefined );
 		const layoutFingerprint = useMemo( () => {
 			const layoutSig = getLayoutFingerprint( activeLayout );
 			const placementSig = getPlacementFingerprint( itemStyles );

--- a/packages/grid/src/dashboard-lanes/index.tsx
+++ b/packages/grid/src/dashboard-lanes/index.tsx
@@ -39,6 +39,12 @@ import { LanesItem } from './lanes-item';
 import { useLanePlacement } from './use-lane-placement';
 import { GridOverlay } from '../shared/grid-overlay';
 import { gridSpanToPixelSize } from '../shared/resize-snap';
+import layoutAnimationStyles from '../shared/layout-shift-animation.module.css';
+import {
+	getLayoutFingerprint,
+	getPlacementFingerprint,
+	useLayoutShiftAnimation,
+} from '../shared/use-layout-shift-animation';
 import type { DashboardLanesLayoutItem, DashboardLanesProps } from './types';
 import type { ResizeSnapSize } from '../shared/resize-snap';
 import type { ResizeDelta } from '../shared/types';
@@ -257,6 +263,25 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 			rowUnit,
 		} );
 
+		const layoutAnimating =
+			editMode &&
+			( isResizing || temporaryLayout !== undefined );
+		const layoutFingerprint = useMemo( () => {
+			const layoutSig = getLayoutFingerprint( activeLayout );
+			const placementSig = getPlacementFingerprint( itemStyles );
+			return `${ layoutSig }\0${ placementSig }`;
+		}, [ activeLayout, itemStyles ] );
+		const excludeLayoutAnimationKey =
+			activeId ?? ( isResizing ? resizeSnapPreview?.id : null );
+		const captureLayoutSnapshotRef = useRef< () => void >( () => {} );
+		const { captureLayoutSnapshot } = useLayoutShiftAnimation( {
+			container,
+			enabled: layoutAnimating,
+			layoutFingerprint,
+			excludeItemKey: excludeLayoutAnimationKey,
+		} );
+		captureLayoutSnapshotRef.current = captureLayoutSnapshot;
+
 		const [ childrenMap, actionableAreaMap, remaining ] = useMemo( () => {
 			const childMap = new Map< string, React.ReactElement >();
 			const actionableMap = new Map< string, React.ReactNode >();
@@ -371,6 +396,7 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 				y: activeCenterY,
 			};
 			latestLayoutRef.current = updatedLayout;
+			captureLayoutSnapshotRef.current();
 			setTemporaryLayout( updatedLayout );
 			onPreviewLayout?.( updatedLayout );
 		} );
@@ -439,6 +465,8 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 			);
 
 			latestLayoutRef.current = updatedLayout;
+			captureLayoutSnapshotRef.current();
+			setTemporaryLayout( updatedLayout );
 			onPreviewLayout?.( updatedLayout );
 		} );
 
@@ -496,7 +524,12 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 					<div
 						{ ...divProps }
 						ref={ mergedRootRef }
-						className={ clsx( styles.lanes, className ) }
+						className={ clsx(
+							styles.lanes,
+							layoutAnimating &&
+								layoutAnimationStyles[ 'layout-animating' ],
+							className
+						) }
 						style={
 							{
 								...style,

--- a/packages/grid/src/dashboard-lanes/lanes-item.tsx
+++ b/packages/grid/src/dashboard-lanes/lanes-item.tsx
@@ -38,7 +38,7 @@ function getItemCursor(
 export type LanesItemProps = {
 	/**
 	 * Item key. Forwarded to dnd-kit and emitted as the
-	 * `data-lanes-key` attribute the hook reads to map measured DOM
+	 * `data-wp-grid-item-key` attribute the hook reads to map measured DOM
 	 * nodes back to logical items.
 	 */
 	itemKey: string;

--- a/packages/grid/src/dashboard-lanes/lanes-item.tsx
+++ b/packages/grid/src/dashboard-lanes/lanes-item.tsx
@@ -14,7 +14,7 @@ import { useMergeRefs } from '@wordpress/compose';
  * Internal dependencies
  */
 import ResizeHandle from '../shared/resize-handle';
-import { LANES_DATA_KEY } from './use-lane-placement';
+import { GRID_ITEM_DATA_KEY } from '../shared/grid-item-key';
 import type { ResizeSnapSize } from '../shared/resize-snap';
 import type { ResizeDelta, ResizeHandleRenderProps } from '../shared/types';
 import styles from './lanes-item.module.css';
@@ -164,7 +164,7 @@ export function LanesItem( {
 			ref={ mergedRef }
 			className={ itemClassName }
 			style={ style }
-			{ ...{ [ LANES_DATA_KEY ]: itemKey } }
+			{ ...{ [ GRID_ITEM_DATA_KEY ]: itemKey } }
 		>
 			{ actionableArea ? (
 				<div

--- a/packages/grid/src/dashboard-lanes/test/keyboard-activation.test.tsx
+++ b/packages/grid/src/dashboard-lanes/test/keyboard-activation.test.tsx
@@ -58,9 +58,11 @@ describe( 'DashboardLanes keyboard activation', () => {
 		expect( activator ).not.toBeNull();
 		expect( activator ).toHaveAttribute( 'tabindex', '0' );
 
-		// Outer item is identified by `data-lanes-key`; the activator
+		// Outer item is identified by `data-wp-grid-item-key`; the activator
 		// must be its descendant.
-		const lanesItem = container.querySelector( '[data-lanes-key="a"]' );
+		const lanesItem = container.querySelector(
+			'[data-wp-grid-item-key="a"]'
+		);
 		expect( lanesItem ).not.toBeNull();
 		expect( activator ).not.toBe( lanesItem );
 		expect( lanesItem!.contains( activator! ) ).toBe( true );

--- a/packages/grid/src/dashboard-lanes/test/use-lane-placement.test.tsx
+++ b/packages/grid/src/dashboard-lanes/test/use-lane-placement.test.tsx
@@ -15,7 +15,8 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useLanePlacement, LANES_DATA_KEY } from '../use-lane-placement';
+import { GRID_ITEM_DATA_KEY } from '../../shared/grid-item-key';
+import { useLanePlacement } from '../use-lane-placement';
 import type {
 	UseLanePlacementInput,
 	UseLanePlacementResult,
@@ -144,7 +145,7 @@ function Harness( { input, measuredHeights, onResult }: HarnessProps ) {
 			{ input.items.map( ( item ) => (
 				<div
 					key={ item.key }
-					{ ...{ [ LANES_DATA_KEY ]: item.key } }
+					{ ...{ [ GRID_ITEM_DATA_KEY ]: item.key } }
 					data-testid={ `item-${ item.key }` }
 					style={ {
 						...result.itemStyles.get( item.key ),

--- a/packages/grid/src/dashboard-lanes/use-lane-placement.ts
+++ b/packages/grid/src/dashboard-lanes/use-lane-placement.ts
@@ -140,7 +140,13 @@ export function useLanePlacement(
 			.join( '\0' );
 	}, [ input.items ] );
 
-	const { items, lanes, gap, flowTolerance, rowUnit } = input;
+	// Stable array identity while placement-relevant fields match
+	// `itemsSignature`, so the layout effect is not torn down on every
+	// parent re-render that passes a fresh `items` reference.
+	// eslint-disable-next-line react-hooks/exhaustive-deps -- `itemsSignature` encodes keys/spans/lanes; `input.items` reference often changes without placement changes.
+	const itemsForPlacement = useMemo( () => input.items, [ itemsSignature ] );
+
+	const { lanes, gap, flowTolerance, rowUnit } = input;
 
 	useLayoutEffect( () => {
 		if ( ! isPolyfilled || ! container ) {
@@ -166,7 +172,7 @@ export function useLanePlacement(
 				if ( cancelled ) {
 					return;
 				}
-				const itemsWithHeight = items.map( ( item ) => ( {
+				const itemsWithHeight = itemsForPlacement.map( ( item ) => ( {
 					key: item.key,
 					span: clampSpan( item.span ),
 					lane: item.lane,
@@ -183,7 +189,7 @@ export function useLanePlacement(
 					rowUnit ?? DEFAULT_ROW_UNIT
 				);
 				const next = new Map< string, React.CSSProperties >();
-				for ( const item of items ) {
+				for ( const item of itemsForPlacement ) {
 					const placement = result.placements.get( item.key );
 					if ( ! placement ) {
 						continue;
@@ -288,12 +294,7 @@ export function useLanePlacement(
 		gap,
 		flowTolerance,
 		rowUnit,
-		// `items` is intentionally not a dep: the rAF closure reads
-		// from it, but the only fields that affect placement (keys,
-		// spans, explicit lanes) are captured by `itemsSignature`.
-		// Including the array identity would tear the effect down on
-		// every fresh reference from the parent and defeat the signature.
-		itemsSignature,
+		itemsForPlacement,
 	] );
 
 	if ( ! isPolyfilled ) {

--- a/packages/grid/src/dashboard-lanes/use-lane-placement.ts
+++ b/packages/grid/src/dashboard-lanes/use-lane-placement.ts
@@ -9,15 +9,6 @@ import { useState, useLayoutEffect, useMemo } from '@wordpress/element';
 import { computeLanePlacements } from './lane-placement';
 import { GRID_ITEM_DATA_KEY } from '../shared/grid-item-key';
 
-/**
- * Data attribute children must declare to participate in lane placement.
- * The renderer adds it; the hook reads it to map measured DOM nodes
- * back to logical item keys.
- *
- * @deprecated Use {@link GRID_ITEM_DATA_KEY} from `../shared/grid-item-key`.
- */
-export const LANES_DATA_KEY = GRID_ITEM_DATA_KEY;
-
 const DEFAULT_ROW_UNIT = 4;
 
 function supportsGridLanes(): boolean {
@@ -36,7 +27,7 @@ function clampSpan( span: number | undefined ): number {
 
 /**
  * Logical item passed to the hook. The renderer is responsible for
- * mounting a DOM node with `data-lanes-key={ item.key }` for each
+ * mounting a DOM node with `data-wp-grid-item-key={ item.key }` for each
  * entry; the hook will measure that node and produce inline styles.
  */
 export type LaneItemInput = {
@@ -96,7 +87,7 @@ export type UseLanePlacementResult = {
  *         { items.map( ( item ) => (
  *             <div
  *                 key={ item.key }
- *                 data-lanes-key={ item.key }
+ *                 data-wp-grid-item-key={ item.key }
  *                 style={ itemStyles.get( item.key ) }
  *             >
  *                 { ... }
@@ -219,7 +210,7 @@ export function useLanePlacement(
 			let changed = false;
 			for ( const entry of entries ) {
 				const key = ( entry.target as HTMLElement ).getAttribute(
-					LANES_DATA_KEY
+					GRID_ITEM_DATA_KEY
 				);
 				if ( ! key ) {
 					continue;
@@ -237,13 +228,13 @@ export function useLanePlacement(
 
 		const refreshObserved = () => {
 			const current = container.querySelectorAll(
-				`[${ LANES_DATA_KEY }]`
+				`[${ GRID_ITEM_DATA_KEY }]`
 			);
 			for ( const element of current ) {
 				if ( ! observed.has( element ) ) {
 					observed.add( element );
 					resizeObserver.observe( element );
-					const key = element.getAttribute( LANES_DATA_KEY );
+					const key = element.getAttribute( GRID_ITEM_DATA_KEY );
 					if ( key ) {
 						const rect = (
 							element as HTMLElement
@@ -260,7 +251,7 @@ export function useLanePlacement(
 			}
 		};
 
-		// Children may mount, unmount, or change `data-lanes-key`
+		// Children may mount, unmount, or change `data-wp-grid-item-key`
 		// after the container exists (drag reorders, additions). The
 		// mutation observer keeps the observed set in sync.
 		const mutationObserver =
@@ -275,7 +266,7 @@ export function useLanePlacement(
 				childList: true,
 				subtree: true,
 				attributes: true,
-				attributeFilter: [ LANES_DATA_KEY ],
+				attributeFilter: [ GRID_ITEM_DATA_KEY ],
 			} );
 		}
 

--- a/packages/grid/src/dashboard-lanes/use-lane-placement.ts
+++ b/packages/grid/src/dashboard-lanes/use-lane-placement.ts
@@ -7,13 +7,16 @@ import { useState, useLayoutEffect, useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import { computeLanePlacements } from './lane-placement';
+import { GRID_ITEM_DATA_KEY } from '../shared/grid-item-key';
 
 /**
  * Data attribute children must declare to participate in lane placement.
  * The renderer adds it; the hook reads it to map measured DOM nodes
  * back to logical item keys.
+ *
+ * @deprecated Use {@link GRID_ITEM_DATA_KEY} from `../shared/grid-item-key`.
  */
-export const LANES_DATA_KEY = 'data-lanes-key';
+export const LANES_DATA_KEY = GRID_ITEM_DATA_KEY;
 
 const DEFAULT_ROW_UNIT = 4;
 

--- a/packages/grid/src/shared/grid-item-key.ts
+++ b/packages/grid/src/shared/grid-item-key.ts
@@ -1,0 +1,5 @@
+/**
+ * Data attribute grid tiles declare so layout-shift animation can map
+ * measured DOM nodes back to logical item keys.
+ */
+export const GRID_ITEM_DATA_KEY = 'data-wp-grid-item-key';

--- a/packages/grid/src/shared/layout-shift-animation.module.css
+++ b/packages/grid/src/shared/layout-shift-animation.module.css
@@ -3,14 +3,14 @@
  * on tiles so the browser can interpolate `transform` reliably (inline
  * `transition` + FLIP in the same frame is skipped).
  */
-.layout-animating :global( [data-wp-grid-item-key] ) {
+.layout-animating :global([data-wp-grid-item-key]) {
 	transition:
 		transform var(--wpds-motion-duration-md)
 		var(--wpds-motion-easing-balanced);
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.layout-animating :global( [data-wp-grid-item-key] ) {
+	.layout-animating :global([data-wp-grid-item-key]) {
 		transition: none;
 	}
 }

--- a/packages/grid/src/shared/layout-shift-animation.module.css
+++ b/packages/grid/src/shared/layout-shift-animation.module.css
@@ -1,0 +1,30 @@
+/*
+ * Motion tokens for sibling tiles reflowing during drag/resize. Applied
+ * on the surface root while a gesture is in progress.
+ */
+.layout-animating {
+	--wp-grid-layout-shift-duration: var(--wpds-motion-duration-md, 200ms);
+	--wp-grid-layout-shift-easing: var(
+		--wpds-motion-easing-balanced,
+		cubic-bezier(0.4, 0, 0.2, 1)
+	);
+}
+
+/*
+ * Transition lives on tiles so the browser can interpolate `transform`
+ * reliably (inline `transition` + FLIP in the same frame is skipped).
+ */
+.layout-animating :global( [data-wp-grid-item-key] ) {
+	transition: transform var(--wp-grid-layout-shift-duration)
+		var(--wp-grid-layout-shift-easing);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.layout-animating {
+		--wp-grid-layout-shift-duration: 0ms;
+	}
+
+	.layout-animating :global( [data-wp-grid-item-key] ) {
+		transition: none;
+	}
+}

--- a/packages/grid/src/shared/layout-shift-animation.module.css
+++ b/packages/grid/src/shared/layout-shift-animation.module.css
@@ -1,29 +1,15 @@
 /*
- * Motion tokens for sibling tiles reflowing during drag/resize. Applied
- * on the surface root while a gesture is in progress.
- */
-.layout-animating {
-	--wp-grid-layout-shift-duration: var(--wpds-motion-duration-md, 200ms);
-	--wp-grid-layout-shift-easing: var(
-		--wpds-motion-easing-balanced,
-		cubic-bezier(0.4, 0, 0.2, 1)
-	);
-}
-
-/*
- * Transition lives on tiles so the browser can interpolate `transform`
- * reliably (inline `transition` + FLIP in the same frame is skipped).
+ * Sibling tile reflow during drag/resize in edit mode. Transition lives
+ * on tiles so the browser can interpolate `transform` reliably (inline
+ * `transition` + FLIP in the same frame is skipped).
  */
 .layout-animating :global( [data-wp-grid-item-key] ) {
-	transition: transform var(--wp-grid-layout-shift-duration)
-		var(--wp-grid-layout-shift-easing);
+	transition:
+		transform var(--wpds-motion-duration-md)
+		var(--wpds-motion-easing-balanced);
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.layout-animating {
-		--wp-grid-layout-shift-duration: 0ms;
-	}
-
 	.layout-animating :global( [data-wp-grid-item-key] ) {
 		transition: none;
 	}

--- a/packages/grid/src/shared/use-layout-shift-animation.ts
+++ b/packages/grid/src/shared/use-layout-shift-animation.ts
@@ -1,0 +1,216 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useLayoutEffect, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { GRID_ITEM_DATA_KEY } from './grid-item-key';
+
+type RectSnapshot = {
+	left: number;
+	top: number;
+};
+
+type UseLayoutShiftAnimationOptions = {
+	/**
+	 * Surface root that contains grid tiles.
+	 */
+	container: HTMLElement | null;
+
+	/**
+	 * When false, snapshots are cleared and no transforms run.
+	 */
+	enabled: boolean;
+
+	/**
+	 * Serialized layout/placement state. The hook runs FLIP when this
+	 * value changes while `enabled` is true.
+	 */
+	layoutFingerprint: string;
+
+	/**
+	 * Item key to skip (the tile being dragged or resized).
+	 */
+	excludeItemKey?: string | null;
+};
+
+type UseLayoutShiftAnimationResult = {
+	/**
+	 * Capture tile positions synchronously **before** a layout update
+	 * (call immediately before `setTemporaryLayout` / similar).
+	 */
+	captureLayoutSnapshot: () => void;
+};
+
+function queryGridItems( container: HTMLElement ): HTMLElement[] {
+	return Array.from(
+		container.querySelectorAll< HTMLElement >(
+			`[${ GRID_ITEM_DATA_KEY }]`
+		)
+	);
+}
+
+function readItemKey( element: HTMLElement ): string | null {
+	return element.getAttribute( GRID_ITEM_DATA_KEY );
+}
+
+function snapshotPositions(
+	container: HTMLElement
+): Map< string, RectSnapshot > {
+	const positions = new Map< string, RectSnapshot >();
+	for ( const element of queryGridItems( container ) ) {
+		const key = readItemKey( element );
+		if ( ! key ) {
+			continue;
+		}
+		const { left, top } = element.getBoundingClientRect();
+		positions.set( key, { left, top } );
+	}
+	return positions;
+}
+
+function clearLayoutShiftStyles( element: HTMLElement ): void {
+	element.style.removeProperty( 'transform' );
+	element.style.removeProperty( 'transition' );
+}
+
+function playLayoutShift(
+	element: HTMLElement,
+	deltaX: number,
+	deltaY: number
+): void {
+	if ( deltaX === 0 && deltaY === 0 ) {
+		return;
+	}
+
+	// Invert: show the tile where it was before the layout change.
+	element.style.transition = 'none';
+	element.style.transform = `translate(${ deltaX }px, ${ deltaY }px)`;
+	void element.offsetHeight;
+
+	// Play on the next frame so the inverted transform paints before
+	// the transition back to the committed grid position.
+	requestAnimationFrame( () => {
+		element.style.removeProperty( 'transition' );
+		element.style.transform = '';
+
+		const onTransitionEnd = ( event: TransitionEvent ) => {
+			if ( event.propertyName !== 'transform' ) {
+				return;
+			}
+			element.removeEventListener( 'transitionend', onTransitionEnd );
+			clearLayoutShiftStyles( element );
+		};
+		element.addEventListener( 'transitionend', onTransitionEnd );
+	} );
+}
+
+/**
+ * Animates sibling tiles when grid layout reflows during drag or resize
+ * using a FLIP transform. Respects `--wp-grid-layout-shift-*` tokens on
+ * the container (see `layout-shift-animation.module.css`).
+ */
+export function useLayoutShiftAnimation( {
+	container,
+	enabled,
+	layoutFingerprint,
+	excludeItemKey = null,
+}: UseLayoutShiftAnimationOptions ): UseLayoutShiftAnimationResult {
+	const snapshotBeforeChangeRef = useRef<
+		Map< string, RectSnapshot > | null
+	>( null );
+	const lastRenderedPositionsRef = useRef<
+		Map< string, RectSnapshot > | null
+	>( null );
+
+	const captureLayoutSnapshot = useCallback( () => {
+		if ( container ) {
+			snapshotBeforeChangeRef.current = snapshotPositions( container );
+		}
+	}, [ container ] );
+
+	useLayoutEffect( () => {
+		if ( ! container || ! enabled ) {
+			snapshotBeforeChangeRef.current = null;
+			lastRenderedPositionsRef.current = null;
+			if ( container ) {
+				for ( const element of queryGridItems( container ) ) {
+					clearLayoutShiftStyles( element );
+				}
+			}
+			return;
+		}
+
+		const previous =
+			snapshotBeforeChangeRef.current ??
+			lastRenderedPositionsRef.current;
+		snapshotBeforeChangeRef.current = null;
+
+		if ( previous ) {
+			for ( const element of queryGridItems( container ) ) {
+				const key = readItemKey( element );
+				if ( ! key || key === excludeItemKey ) {
+					continue;
+				}
+				const old = previous.get( key );
+				if ( ! old ) {
+					continue;
+				}
+				const { left, top } = element.getBoundingClientRect();
+				const deltaX = old.left - left;
+				const deltaY = old.top - top;
+				clearLayoutShiftStyles( element );
+				playLayoutShift( element, deltaX, deltaY );
+			}
+		}
+
+		lastRenderedPositionsRef.current = snapshotPositions( container );
+	}, [ container, enabled, layoutFingerprint, excludeItemKey ] );
+
+	return { captureLayoutSnapshot };
+}
+
+/**
+ * Stable fingerprint for {@link useLayoutShiftAnimation}. Width/height
+ * values may be numbers or layout keywords (`'fill'`, `'full'`).
+ */
+export function getLayoutFingerprint(
+	layout: ReadonlyArray< {
+		key: string;
+		width?: number | string;
+		height?: number;
+		order?: number;
+		lane?: number;
+	} >
+): string {
+	return layout
+		.map(
+			( item ) =>
+				`${ item.key }:${ String( item.width ?? '' ) }:${
+					item.height ?? 1
+				}:${ item.order ?? '' }:${ item.lane ?? '' }`
+		)
+		.join( '|' );
+}
+
+/**
+ * Placement fingerprint for lanes polyfill / explicit grid positions.
+ */
+export function getPlacementFingerprint(
+	itemStyles: Map< string, React.CSSProperties >
+): string {
+	return [ ...itemStyles.entries() ]
+		.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
+		.map( ( [ key, style ] ) => {
+			const column = style.gridColumn ?? '';
+			const columnStart = style.gridColumnStart ?? '';
+			const rowStart = style.gridRowStart ?? '';
+			const rowEnd = style.gridRowEnd ?? '';
+			return `${ key }:${ String( column ) }:${ String(
+				columnStart
+			) }:${ String( rowStart ) }:${ String( rowEnd ) }`;
+		} )
+		.join( '|' );
+}

--- a/packages/grid/src/shared/use-layout-shift-animation.ts
+++ b/packages/grid/src/shared/use-layout-shift-animation.ts
@@ -46,9 +46,7 @@ type UseLayoutShiftAnimationResult = {
 
 function queryGridItems( container: HTMLElement ): HTMLElement[] {
 	return Array.from(
-		container.querySelectorAll< HTMLElement >(
-			`[${ GRID_ITEM_DATA_KEY }]`
-		)
+		container.querySelectorAll< HTMLElement >( `[${ GRID_ITEM_DATA_KEY }]` )
 	);
 }
 
@@ -109,8 +107,14 @@ function playLayoutShift(
 
 /**
  * Animates sibling tiles when grid layout reflows during drag or resize
- * using a FLIP transform. Respects `--wp-grid-layout-shift-*` tokens on
- * the container (see `layout-shift-animation.module.css`).
+ * using a FLIP transform (see `layout-shift-animation.module.css`).
+ *
+ * @param root0                   Hook options.
+ * @param root0.container         Surface root that contains grid tiles.
+ * @param root0.enabled           When false, snapshots are cleared and no transforms run.
+ * @param root0.layoutFingerprint Serialized layout/placement state.
+ * @param root0.excludeItemKey    Item key to skip (the tile being dragged or resized).
+ * @return Snapshot capture callback for use before layout updates.
  */
 export function useLayoutShiftAnimation( {
 	container,
@@ -118,12 +122,14 @@ export function useLayoutShiftAnimation( {
 	layoutFingerprint,
 	excludeItemKey = null,
 }: UseLayoutShiftAnimationOptions ): UseLayoutShiftAnimationResult {
-	const snapshotBeforeChangeRef = useRef<
-		Map< string, RectSnapshot > | null
-	>( null );
-	const lastRenderedPositionsRef = useRef<
-		Map< string, RectSnapshot > | null
-	>( null );
+	const snapshotBeforeChangeRef = useRef< Map<
+		string,
+		RectSnapshot
+	> | null >( null );
+	const lastRenderedPositionsRef = useRef< Map<
+		string,
+		RectSnapshot
+	> | null >( null );
 
 	const captureLayoutSnapshot = useCallback( () => {
 		if ( container ) {
@@ -144,8 +150,7 @@ export function useLayoutShiftAnimation( {
 		}
 
 		const previous =
-			snapshotBeforeChangeRef.current ??
-			lastRenderedPositionsRef.current;
+			snapshotBeforeChangeRef.current ?? lastRenderedPositionsRef.current;
 		snapshotBeforeChangeRef.current = null;
 
 		if ( previous ) {
@@ -175,6 +180,9 @@ export function useLayoutShiftAnimation( {
 /**
  * Stable fingerprint for {@link useLayoutShiftAnimation}. Width/height
  * values may be numbers or layout keywords (`'fill'`, `'full'`).
+ *
+ * @param layout Layout items to serialize.
+ * @return Fingerprint string.
  */
 export function getLayoutFingerprint(
 	layout: ReadonlyArray< {
@@ -197,6 +205,9 @@ export function getLayoutFingerprint(
 
 /**
  * Placement fingerprint for lanes polyfill / explicit grid positions.
+ *
+ * @param itemStyles Per-item inline placement styles.
+ * @return Fingerprint string.
  */
 export function getPlacementFingerprint(
 	itemStyles: Map< string, React.CSSProperties >

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1463,16 +1463,6 @@
 			"count": 1
 		}
 	},
-	"packages/grid/src/dashboard-grid/index.tsx": {
-		"react-hooks/refs": {
-			"count": 13
-		}
-	},
-	"packages/grid/src/dashboard-lanes/index.tsx": {
-		"react-hooks/refs": {
-			"count": 13
-		}
-	},
 	"packages/grid/src/shared/resize-handle.tsx": {
 		"react-hooks/immutability": {
 			"count": 1


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Part of https://github.com/WordPress/gutenberg/issues/77616
<!-- In a few words, what is the PR actually doing? -->

Animate widget movements as the widget layout shifts around due to resizing or moving widgets.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Helps user grok better what happens as widgets move around while resizing or moving widgets around.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

#### Before

https://github.com/user-attachments/assets/01acfb84-90ae-4454-9534-5eedf3a6294b


#### After


https://github.com/user-attachments/assets/f2c422ba-7c47-4b76-b333-b9b2431aaff6


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
