### PR TITLE
Use WCTooltip alias for component Tooltip imports

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -7,7 +7,11 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Tooltip, Spinner, Composite } from '@wordpress/components';
+import {
+	Tooltip as WCTooltip,
+	Spinner,
+	Composite,
+} from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { getBlockType } from '@wordpress/blocks';
@@ -97,7 +101,7 @@ function DownloadableBlockListItem( { item, onClick } ) {
 	} );
 
 	return (
-		<Tooltip placement="top" text={ itemLabel }>
+		<WCTooltip placement="top" text={ itemLabel }>
 			<Composite.Item
 				className={ clsx(
 					'block-directory-downloadable-block-list-item',
@@ -158,7 +162,7 @@ function DownloadableBlockListItem( { item, onClick } ) {
 					) }
 				</span>
 			</Composite.Item>
-		</Tooltip>
+		</WCTooltip>
 	);
 }
 

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -10,7 +10,7 @@ import { cloneBlock } from '@wordpress/blocks';
 import { useEffect, useState, forwardRef, useMemo } from '@wordpress/element';
 import {
 	Composite,
-	Tooltip,
+	Tooltip as WCTooltip,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { VisuallyHidden, Text } from '@wordpress/ui';
@@ -28,7 +28,7 @@ import { INSERTER_PATTERN_TYPES } from '../inserter/block-patterns-tab/utils';
 
 const WithToolTip = ( { showTooltip, title, children } ) => {
 	if ( showTooltip ) {
-		return <Tooltip text={ title }>{ children }</Tooltip>;
+		return <WCTooltip text={ title }>{ children }</WCTooltip>;
 	}
 	return <>{ children }</>;
 };

--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -11,7 +11,7 @@ import {
 	FlexItem,
 	Dropdown,
 	Composite,
-	Tooltip,
+	Tooltip as WCTooltip,
 } from '@wordpress/components';
 import { useMemo, useRef } from '@wordpress/element';
 import { shadow as shadowIcon, Icon, check, reset } from '@wordpress/icons';
@@ -82,7 +82,7 @@ export function ShadowPresets( { presets, activeShadow, onSelect } ) {
 
 export function ShadowIndicator( { type, label, isActive, onSelect, shadow } ) {
 	return (
-		<Tooltip text={ label }>
+		<WCTooltip text={ label }>
 			<Composite.Item
 				role="option"
 				aria-label={ label }
@@ -106,7 +106,7 @@ export function ShadowIndicator( { type, label, isActive, onSelect, shadow } ) {
 					</button>
 				}
 			/>
-		</Tooltip>
+		</WCTooltip>
 	);
 }
 

--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import {
-	Tooltip,
+	Tooltip as WCTooltip,
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
@@ -261,7 +261,7 @@ export function MediaPreview( { media, onClick, category } ) {
 							onMouseEnter={ onMouseEnter }
 							onMouseLeave={ onMouseLeave }
 						>
-							<Tooltip text={ title }>
+							<WCTooltip text={ title }>
 								<Composite.Item
 									render={
 										<div
@@ -281,7 +281,7 @@ export function MediaPreview( { media, onClick, category } ) {
 										) }
 									</div>
 								</Composite.Item>
-							</Tooltip>
+							</WCTooltip>
 							{ ! isInserting && (
 								<MediaPreviewOptions
 									category={ category }

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -3,7 +3,7 @@
  */
 import {
 	Icon as WCIcon,
-	Tooltip,
+	Tooltip as WCTooltip,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useEffect, useState, useRef } from '@wordpress/element';
@@ -175,14 +175,14 @@ export default function InspectorControlsTabs( {
 								{ tab.title }
 							</Tabs.Tab>
 						) : (
-							<Tooltip text={ tab.title } key={ tab.name }>
+							<WCTooltip text={ tab.title } key={ tab.name }>
 								<Tabs.Tab
 									tabId={ tab.name }
 									aria-label={ tab.title }
 								>
 									<WCIcon icon={ tab.icon } />
 								</Tabs.Tab>
-							</Tooltip>
+							</WCTooltip>
 						)
 					) }
 				</Tabs.TabList>

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import {
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
-	Tooltip,
+	Tooltip as WCTooltip,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
@@ -164,14 +164,14 @@ function ListViewBlockSelectButton(
 					</span>
 				) : null }
 				{ !! visibilityLabel && (
-					<Tooltip text={ visibilityLabel }>
+					<WCTooltip text={ visibilityLabel }>
 						<span
 							className="block-editor-list-view-block-select-button__block-visibility"
 							aria-hidden="true"
 						>
 							<Icon icon={ unseen } />
 						</span>
-					</Tooltip>
+					</WCTooltip>
 				) }
 				{ shouldShowLockIcon && (
 					<span className="block-editor-list-view-block-select-button__lock">

--- a/packages/block-editor/src/components/preset-input-control/custom-value-controls.js
+++ b/packages/block-editor/src/components/preset-input-control/custom-value-controls.js
@@ -3,7 +3,7 @@
  */
 import {
 	RangeControl,
-	Tooltip,
+	Tooltip as WCTooltip,
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 
@@ -93,11 +93,11 @@ export default function CustomValueControls( {
 	);
 
 	const wrappedUnitControl = showTooltip ? (
-		<Tooltip text={ ariaLabel } placement="top">
+		<WCTooltip text={ ariaLabel } placement="top">
 			<div className="preset-input-control__tooltip-wrapper">
 				{ unitControl }
 			</div>
-		</Tooltip>
+		</WCTooltip>
 	) : (
 		unitControl
 	);

--- a/packages/boot/src/components/save-button/index.tsx
+++ b/packages/boot/src/components/save-button/index.tsx
@@ -8,7 +8,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { displayShortcut, rawShortcut } from '@wordpress/keycodes';
 import { check } from '@wordpress/icons';
 import { EntitiesSavedStates } from '@wordpress/editor';
-import { Button, Modal, Tooltip } from '@wordpress/components';
+import { Button, Modal, Tooltip as WCTooltip } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -85,7 +85,7 @@ export default function SaveButton() {
 
 	return (
 		<>
-			<Tooltip
+			<WCTooltip
 				text={ hasChanges ? label : undefined }
 				shortcut={ displayShortcut.primary( 's' ) }
 			>
@@ -103,7 +103,7 @@ export default function SaveButton() {
 				>
 					{ label }
 				</Button>
-			</Tooltip>
+			</WCTooltip>
 			{ isSaveViewOpen && (
 				<Modal
 					title={ __( 'Review changes' ) }

--- a/packages/boot/src/components/site-icon-link/index.tsx
+++ b/packages/boot/src/components/site-icon-link/index.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Link, privateApis as routePrivateApis } from '@wordpress/route';
-import { Tooltip } from '@wordpress/components';
+import { Tooltip as WCTooltip } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -26,7 +26,7 @@ function SiteIconLink( {
 	const canGoBack = useCanGoBack();
 
 	return (
-		<Tooltip text={ props[ 'aria-label' ] } placement="right">
+		<WCTooltip text={ props[ 'aria-label' ] } placement="right">
 			<Link
 				to={ to }
 				aria-label={ props[ 'aria-label' ] }
@@ -42,7 +42,7 @@ function SiteIconLink( {
 			>
 				<SiteIcon />
 			</Link>
-		</Tooltip>
+		</WCTooltip>
 	);
 }
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -6,7 +6,11 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { Button, Icon as WCIcon, Tooltip } from '@wordpress/components';
+import {
+	Button,
+	Icon as WCIcon,
+	Tooltip as WCTooltip,
+} from '@wordpress/components';
 import { sprintf, _x } from '@wordpress/i18n';
 import { error as errorIcon, pencil } from '@wordpress/icons';
 import { useInstanceId } from '@wordpress/compose';
@@ -111,11 +115,11 @@ export default function SummaryButton< Item >( {
 				<span className={ labelClassName }>{ labelContent }</span>
 			) }
 			{ labelPosition === 'none' && showError && (
-				<Tooltip text={ errorMessage } placement="top">
+				<WCTooltip text={ errorMessage } placement="top">
 					<span className="dataforms-layouts-panel__field-label-error-content">
 						<WCIcon icon={ errorIcon } size={ 16 } />
 					</span>
-				</Tooltip>
+				</WCTooltip>
 			) }
 			<span
 				id={ `${ controlId }` }

--- a/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-content.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-content.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Icon as WCIcon, Tooltip } from '@wordpress/components';
+import { Icon as WCIcon, Tooltip as WCTooltip } from '@wordpress/components';
 import { error as errorIcon } from '@wordpress/icons';
 
 function getLabelContent(
@@ -10,12 +10,12 @@ function getLabelContent(
 	fieldLabel?: string
 ) {
 	return showError ? (
-		<Tooltip text={ errorMessage } placement="top">
+		<WCTooltip text={ errorMessage } placement="top">
 			<span className="dataforms-layouts-panel__field-label-error-content">
 				<WCIcon icon={ errorIcon } size={ 16 } />
 				{ fieldLabel }
 			</span>
-		</Tooltip>
+		</WCTooltip>
 	) : (
 		fieldLabel
 	);

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -11,7 +11,7 @@ import {
 	Dropdown,
 	FlexItem,
 	SelectControl,
-	Tooltip,
+	Tooltip as WCTooltip,
 	Icon as WCIcon,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -267,7 +267,7 @@ export default function Filter( {
 			} }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<div className="dataviews-filters__summary-chip-container">
-					<Tooltip
+					<WCTooltip
 						text={ sprintf(
 							/* translators: 1: Filter name. */
 							__( 'Filter by: %1$s' ),
@@ -311,9 +311,9 @@ export default function Filter( {
 								filter={ filter }
 							/>
 						</div>
-					</Tooltip>
+					</WCTooltip>
 					{ canResetOrRemove && (
-						<Tooltip
+						<WCTooltip
 							text={ isPrimary ? __( 'Reset' ) : __( 'Remove' ) }
 							placement="top"
 						>
@@ -343,7 +343,7 @@ export default function Filter( {
 							>
 								<WCIcon icon={ closeSmall } />
 							</button>
-						</Tooltip>
+						</WCTooltip>
 					) }
 				</div>
 			) }

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -10,7 +10,7 @@ import type { ComponentProps, ReactElement, HTMLAttributes } from 'react';
 import {
 	Flex,
 	FlexItem,
-	Tooltip,
+	Tooltip as WCTooltip,
 	Composite,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
@@ -304,11 +304,11 @@ const GridItem = forwardRef< HTMLDivElement, GridItemProps< any > >(
 										direction="row"
 									>
 										<>
-											<Tooltip text={ field.label }>
+											<WCTooltip text={ field.label }>
 												<FlexItem className="dataviews-view-grid__field-name">
 													{ field.header }
 												</FlexItem>
-											</Tooltip>
+											</WCTooltip>
 											<FlexItem
 												className="dataviews-view-grid__field-value"
 												style={ { maxHeight: 'none' } }

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -40,7 +40,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import {
 	Icon as WCIcon,
 	SlotFillProvider,
-	Tooltip,
+	Tooltip as WCTooltip,
 	__unstableUseNavigateRegions as useNavigateRegions,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
@@ -328,7 +328,7 @@ function MetaBoxesMain( { isLegacy } ) {
 	// The separator button that provides a11y for resizing.
 	const separator = ! isShort && (
 		<>
-			<Tooltip text={ __( 'Drag to resize' ) }>
+			<WCTooltip text={ __( 'Drag to resize' ) }>
 				<button
 					ref={ separatorRef }
 					role="separator" // eslint-disable-line jsx-a11y/no-interactive-element-to-noninteractive-role
@@ -337,7 +337,7 @@ function MetaBoxesMain( { isLegacy } ) {
 					aria-describedby={ separatorHelpId }
 					{ ...bindDragGesture() }
 				/>
-			</Tooltip>
+			</WCTooltip>
 			<VisuallyHidden id={ separatorHelpId }>
 				{ __(
 					'Use up and down arrow keys to resize the meta box pane.'

--- a/packages/edit-post/src/components/layout/index.native.js
+++ b/packages/edit-post/src/components/layout/index.native.js
@@ -19,7 +19,7 @@ import {
 	HTMLTextInput,
 	KeyboardAvoidingView,
 	NoticeList,
-	Tooltip,
+	Tooltip as WCTooltip,
 	__unstableAutocompletionItemsSlot as AutocompletionItemsSlot,
 } from '@wordpress/components';
 import {
@@ -145,7 +145,7 @@ class Layout extends Component {
 		];
 
 		return (
-			<Tooltip.Slot>
+			<WCTooltip.Slot>
 				<SafeAreaView
 					style={ containerStyles }
 					onLayout={ this.onRootViewLayout }
@@ -184,7 +184,7 @@ class Layout extends Component {
 					) }
 					{ Platform.OS === 'android' && <AutocompletionItemsSlot /> }
 				</SafeAreaView>
-			</Tooltip.Slot>
+			</WCTooltip.Slot>
 		);
 	}
 }

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import { useState, useRef } from '@wordpress/element';
 import {
 	ResizableBox,
-	Tooltip,
+	Tooltip as WCTooltip,
 	__unstableMotion as motion,
 } from '@wordpress/components';
 import { useInstanceId, useReducedMotion } from '@wordpress/compose';
@@ -17,12 +17,12 @@ import { __, isRTL } from '@wordpress/i18n';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
-import { addQueryArgs } from '@wordpress/url';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
@@ -294,7 +294,7 @@ function ResizableFrame( {
 			handleComponent={ {
 				[ isRTL() ? 'right' : 'left' ]: canvas === 'view' && (
 					<>
-						<Tooltip text={ __( 'Drag to resize' ) }>
+						<WCTooltip text={ __( 'Drag to resize' ) }>
 							{ /* Disable reason: role="separator" does in fact support aria-valuenow */ }
 							{ /* eslint-disable-next-line jsx-a11y/role-supports-aria-props */ }
 							<motion.button
@@ -321,7 +321,7 @@ function ResizableFrame( {
 								whileFocus="active"
 								whileHover="active"
 							/>
-						</Tooltip>
+						</WCTooltip>
 						<div hidden id={ resizableHandleHelpId }>
 							{ __(
 								'Use left and right arrow keys to resize the canvas. Hold shift to resize in larger increments.'

--- a/packages/editor/src/components/collab-sidebar/note-byline.js
+++ b/packages/editor/src/components/collab-sidebar/note-byline.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Tooltip } from '@wordpress/components';
+import { Tooltip as WCTooltip } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 import { __, _x } from '@wordpress/i18n';
 import {
@@ -95,14 +95,14 @@ export function NoteByline( { avatar, name, date, userId } ) {
 					{ name ?? currentUserName }
 				</span>
 				{ date && (
-					<Tooltip text={ tooltipText }>
+					<WCTooltip text={ tooltipText }>
 						<time
 							dateTime={ commentDateTime }
 							className="editor-collab-sidebar-panel__user-time"
 						>
 							{ commentDateText }
 						</time>
-					</Tooltip>
+					</WCTooltip>
 				) }
 			</Stack>
 		</>

--- a/packages/editor/src/components/collaborators-presence/avatar/component.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar/component.tsx
@@ -10,7 +10,7 @@ extend( [ a11yPlugin ] );
 /**
  * WordPress dependencies
  */
-import { Icon as WCIcon, Tooltip } from '@wordpress/components';
+import { Icon as WCIcon, Tooltip as WCTooltip } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 
 /**
@@ -114,7 +114,7 @@ function Avatar( {
 	);
 
 	if ( name && ( ! showBadge || label ) ) {
-		return <Tooltip text={ name }>{ avatar }</Tooltip>;
+		return <WCTooltip text={ name }>{ avatar }</WCTooltip>;
 	}
 
 	return avatar;

--- a/packages/editor/src/components/post-revisions-preview/diff-markers.js
+++ b/packages/editor/src/components/post-revisions-preview/diff-markers.js
@@ -15,7 +15,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { Tooltip } from '@wordpress/components';
+import { Tooltip as WCTooltip } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -98,7 +98,7 @@ function DiffMarkerButton( { clientId, status, subscribe } ) {
 	}
 
 	return (
-		<Tooltip text={ STATUS_LABELS[ status ] }>
+		<WCTooltip text={ STATUS_LABELS[ status ] }>
 			<button
 				className={ `revision-diff-marker is-${ status }` }
 				style={ {
@@ -108,7 +108,7 @@ function DiffMarkerButton( { clientId, status, subscribe } ) {
 				onClick={ () => blockRef.current?.focus() }
 				aria-label={ STATUS_LABELS[ status ] }
 			/>
-		</Tooltip>
+		</WCTooltip>
 	);
 }
 

--- a/packages/editor/src/components/resizable-editor/resize-handle.js
+++ b/packages/editor/src/components/resizable-editor/resize-handle.js
@@ -3,7 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import { LEFT, RIGHT } from '@wordpress/keycodes';
-import { Tooltip, __unstableMotion as motion } from '@wordpress/components';
+import {
+	Tooltip as WCTooltip,
+	__unstableMotion as motion,
+} from '@wordpress/components';
 import { VisuallyHidden } from '@wordpress/ui';
 
 const DELTA_DISTANCE = 20; // The distance to resize per keydown in pixels.
@@ -41,7 +44,7 @@ export default function ResizeHandle( { direction, resizeWidthBy } ) {
 
 	return (
 		<>
-			<Tooltip text={ __( 'Drag to resize' ) }>
+			<WCTooltip text={ __( 'Drag to resize' ) }>
 				<motion.button
 					className={ `editor-resizable-editor__resize-handle is-${ direction }` }
 					aria-label={ __( 'Drag to resize' ) }
@@ -55,7 +58,7 @@ export default function ResizeHandle( { direction, resizeWidthBy } ) {
 					role="separator"
 					aria-orientation="vertical"
 				/>
-			</Tooltip>
+			</WCTooltip>
 			<VisuallyHidden id={ resizableHandleHelpId }>
 				{ __( 'Use left and right arrow keys to resize the canvas.' ) }
 			</VisuallyHidden>

--- a/packages/editor/src/components/template-actions-panel/block-theme-content.js
+++ b/packages/editor/src/components/template-actions-panel/block-theme-content.js
@@ -11,7 +11,7 @@ import { BlockPreview } from '@wordpress/block-editor';
 import {
 	PanelBody,
 	Button,
-	Tooltip,
+	Tooltip as WCTooltip,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -117,7 +117,7 @@ export default function TemplateActionsPanelContent() {
 		if ( hasSwapTargets ) {
 			const tooltipText = __( 'Change template' );
 			return (
-				<Tooltip text={ tooltipText }>
+				<WCTooltip text={ tooltipText }>
 					<div
 						className="editor-template-actions-panel__preview"
 						role="button"
@@ -128,7 +128,7 @@ export default function TemplateActionsPanelContent() {
 					>
 						{ previewContent }
 					</div>
-				</Tooltip>
+				</WCTooltip>
 			);
 		}
 

--- a/packages/fields/src/components/media-edit/index.tsx
+++ b/packages/fields/src/components/media-edit/index.tsx
@@ -16,7 +16,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 	BaseControl,
-	Tooltip,
+	Tooltip as WCTooltip,
 } from '@wordpress/components';
 import { isBlobURL, getBlobTypeByURL } from '@wordpress/blob';
 import { store as coreStore, type Attachment } from '@wordpress/core-data';
@@ -193,9 +193,9 @@ function MediaPickerButton( {
 		return mediaPickerButton;
 	}
 	return (
-		<Tooltip text={ label } placement="top">
+		<WCTooltip text={ label } placement="top">
 			{ mediaPickerButton }
-		</Tooltip>
+		</WCTooltip>
 	);
 }
 

--- a/packages/fields/src/fields/pattern-title/view.tsx
+++ b/packages/fields/src/fields/pattern-title/view.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Icon, lockSmall } from '@wordpress/icons';
-import { Tooltip } from '@wordpress/components';
+import { Tooltip as WCTooltip } from '@wordpress/components';
 // @ts-ignore
 import { privateApis as patternPrivateApis } from '@wordpress/patterns';
 
@@ -20,12 +20,12 @@ export default function PatternTitleView( { item }: { item: CommonPost } ) {
 	return (
 		<BaseTitleView item={ item } className="fields-field__pattern-title">
 			{ item.type === PATTERN_TYPES.theme && (
-				<Tooltip
+				<WCTooltip
 					placement="top"
 					text={ __( 'This pattern cannot be edited.' ) }
 				>
 					<Icon icon={ lockSmall } size={ 24 } />
-				</Tooltip>
+				</WCTooltip>
 			) }
 		</BaseTitleView>
 	);

--- a/packages/global-styles-ui/src/variations/variation.tsx
+++ b/packages/global-styles-ui/src/variations/variation.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { Tooltip } from '@wordpress/components';
+import { Tooltip as WCTooltip } from '@wordpress/components';
 import { useMemo, useContext, useState } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import { _x, sprintf } from '@wordpress/i18n';
@@ -107,7 +107,7 @@ export default function Variation( {
 	return (
 		<GlobalStylesContext.Provider value={ context }>
 			{ showTooltip ? (
-				<Tooltip text={ variation?.title }>{ content }</Tooltip>
+				<WCTooltip text={ variation?.title }>{ content }</WCTooltip>
 			) : (
 				content
 			) }

--- a/packages/media-editor/src/components/media-form/sidebar-datetime-view.tsx
+++ b/packages/media-editor/src/components/media-form/sidebar-datetime-view.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { dateI18n, getDate, getSettings } from '@wordpress/date';
-import { Tooltip } from '@wordpress/components';
+import { Tooltip as WCTooltip } from '@wordpress/components';
 import type { NormalizedField } from '@wordpress/dataviews';
 
 /**
@@ -28,8 +28,8 @@ export default function SidebarDatetimeView( {
 		getDate( value )
 	);
 	return (
-		<Tooltip text={ fullDatetime } placement="top">
+		<WCTooltip text={ fullDatetime } placement="top">
 			<time dateTime={ value }>{ dateOnly }</time>
-		</Tooltip>
+		</WCTooltip>
 	);
 }

--- a/packages/media-fields/src/filename/view.tsx
+++ b/packages/media-fields/src/filename/view.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import {
-	Tooltip,
+	Tooltip as WCTooltip,
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
@@ -30,11 +30,11 @@ export default function FileNameView( {
 	}
 
 	return fileName.length > TRUNCATE_LENGTH ? (
-		<Tooltip text={ fileName }>
+		<WCTooltip text={ fileName }>
 			<Truncate limit={ TRUNCATE_LENGTH } ellipsizeMode="tail">
 				{ fileName }
 			</Truncate>
-		</Tooltip>
+		</WCTooltip>
 	) : (
 		<>{ fileName }</>
 	);

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -266,6 +266,7 @@ export default dedupePlugins( [
 						Autocomplete: 'WCAutocomplete',
 						Badge: 'WCBadge',
 						Icon: 'WCIcon',
+						Tooltip: 'WCTooltip',
 					},
 				},
 			],


### PR DESCRIPTION
## What?

Requires `Tooltip` from `@wordpress/components` to be imported as `WCTooltip`, and updates the existing imports that use it.

## Why?

This avoids name clashes with a future `Tooltip` from `@wordpress/ui` as the UI package is introduced alongside the existing components package.

## How?

Adds `Tooltip: 'WCTooltip'` to the `@wordpress/use-import-as` ESLint config, then renames the affected `@wordpress/components` imports and references.

Follows the same pattern as #78366 for the `Icon` component.

## Testing Instructions

ESLint should pass.