### PR TITLE
Components: Popover: don't close when focus moves into the `@wordpress/ui` compat overlay slot

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `Draggable`: Render the drag clone inside the `@wordpress/ui` compat overlay slot so it shares stacking with `@wordpress/ui` overlays opened mid-drag. Auto-enabled in WordPress environments; other hosts can opt in via `useEnableWpCompatOverlaySlot()` ([#78183](https://github.com/WordPress/gutenberg/pull/78183), [#78354](https://github.com/WordPress/gutenberg/pull/78354)).
 
+### Bug Fixes
+
+-   `Popover`: Don't close when focus moves into the `@wordpress/ui` compat overlay slot, so nested `@wordpress/ui` overlays (e.g. `Select`) can be used inside a `Popover` without dismissing it.
+
 ## 33.1.0 (2026-05-14)
 
 ### Enhancements

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
--   `Popover`: Don't close when focus moves into the `@wordpress/ui` compat overlay slot, so nested `@wordpress/ui` overlays (e.g. `Select`) can be used inside a `Popover` without dismissing it.
+-   `Popover`: Don't close when focus moves into the `@wordpress/ui` compat overlay slot, so nested `@wordpress/ui` overlays (e.g. `Select`) can be used inside a `Popover` without dismissing it ([#78407](https://github.com/WordPress/gutenberg/pull/78407)).
 
 ## 33.1.0 (2026-05-14)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
--   `Popover`: Don't close when focus moves into the `@wordpress/ui` compat overlay slot, so nested `@wordpress/ui` overlays (e.g. `Select`) can be used inside a `Popover` without dismissing it ([#78407](https://github.com/WordPress/gutenberg/pull/78407)).
+-   `Popover`: Don't close when focus moves into the `@wordpress/ui` compat overlay slot, or back from a portaled descendant into the popover. Nested `@wordpress/ui` overlays (e.g. `Select`) can now be used inside a `Popover` without dismissing it on hover or on overlay dismissal ([#78407](https://github.com/WordPress/gutenberg/pull/78407)).
 
 ## 33.1.0 (2026-05-14)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
--   `Popover`: Don't close when focus moves into the `@wordpress/ui` compat overlay slot, or back from a portaled descendant into the popover. Nested `@wordpress/ui` overlays (e.g. `Select`) can now be used inside a `Popover` without dismissing it on hover or on overlay dismissal ([#78407](https://github.com/WordPress/gutenberg/pull/78407)).
+-   `Popover`: Don't close when focus moves into the `@wordpress/ui` compat overlay slot, or is restored to the popover from any portaled descendant. This unblocks nested overlays such as `@wordpress/ui` `Select`, which previously dismissed the host `Popover` on hover and on overlay dismissal ([#78407](https://github.com/WordPress/gutenberg/pull/78407)).
 
 ## 33.1.0 (2026-05-14)
 

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -279,19 +279,33 @@ const UnforwardedPopover = (
 				) {
 					return;
 				}
-				// Ignore blur events where focus moves into the `@wordpress/ui`
-				// compat overlay slot. Some `@wordpress/ui` overlays (e.g. `Select`)
-				// portal their popup to a body-level slot and move DOM focus into
-				// it, which would otherwise be perceived as focus leaving the
-				// popover and close it prematurely.
+				// Ignore blur events whose `relatedTarget` is logically inside
+				// this popover. This covers two cases caused by portaled
+				// descendants:
+				// 1. Focus moves into the `@wordpress/ui` compat overlay slot:
+				//    some `@wordpress/ui` overlays (e.g. `Select`) portal their
+				//    popup to a body-level slot and move DOM focus into it.
+				// 2. Focus moves back from a portaled descendant into the
+				//    popover (e.g. base-ui's `FloatingFocusManager` restoring
+				//    focus to its trigger when the popup closes).
+				// Both look like "focus leaving the popover" via DOM
+				// containment alone, but are logically internal.
 				// See https://github.com/WordPress/gutenberg/issues/78406.
 				const relatedTarget =
 					'relatedTarget' in event ? event.relatedTarget : null;
-				if (
-					relatedTarget instanceof Element &&
-					relatedTarget.closest( '[data-wp-compat-overlay-slot]' )
-				) {
-					return;
+				if ( relatedTarget instanceof Element ) {
+					if (
+						relatedTarget.closest( '[data-wp-compat-overlay-slot]' )
+					) {
+						return;
+					}
+					// Note: only the floating element is checked; the
+					// reference element falls back to the popover's parent
+					// when no `anchor` is provided, which would also include
+					// arbitrary siblings.
+					if ( floatingElement?.contains( relatedTarget ) ) {
+						return;
+					}
 				}
 				// Call onFocusOutside if defined or call onClose.
 				if ( onFocusOutside ) {

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -279,22 +279,10 @@ const UnforwardedPopover = (
 				) {
 					return;
 				}
-				// Ignore blur events caused by portaled descendants, which
-				// look like "focus leaving the popover" via DOM containment
-				// alone but are logically internal. Covers three cases:
-				// 1. Focus moves into the `@wordpress/ui` compat overlay
-				//    slot — some `@wordpress/ui` overlays (e.g. `Select`)
-				//    portal their popup to a body-level slot and move DOM
-				//    focus into it.
-				// 2. Focus moves back from a portaled descendant into the
-				//    popover (e.g. base-ui's `FloatingFocusManager`
-				//    restoring focus to its trigger when the popup closes
-				//    via Esc / item selection).
-				// 3. A portaled descendant briefly dropped focus on `body`
-				//    while closing, then focus was restored to the popover
-				//    (e.g. base-ui's `Select` `modal: true` backdrop click,
-				//    where the backdrop blurs the trigger to `body` before
-				//    the popup unmounts and restores focus).
+				// Treat focus moves involving portaled descendants as
+				// internal: either the next focus target is in the
+				// `@wordpress/ui` compat overlay slot, or focus is (back)
+				// inside this popover by the time we evaluate.
 				// See https://github.com/WordPress/gutenberg/issues/78406.
 				const relatedTarget =
 					'relatedTarget' in event ? event.relatedTarget : null;
@@ -304,10 +292,9 @@ const UnforwardedPopover = (
 				) {
 					return;
 				}
-				// Note: only the floating element is checked; the reference
-				// element falls back to the popover's parent when no
-				// `anchor` is provided, which would also include arbitrary
-				// siblings.
+				// `referenceElement` falls back to the popover's parent
+				// when no `anchor` is provided, so it would match arbitrary
+				// siblings — only check the floating element.
 				if (
 					floatingElement &&
 					( ( relatedTarget instanceof Element &&

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -279,6 +279,20 @@ const UnforwardedPopover = (
 				) {
 					return;
 				}
+				// Ignore blur events where focus moves into the `@wordpress/ui`
+				// compat overlay slot. Some `@wordpress/ui` overlays (e.g. `Select`)
+				// portal their popup to a body-level slot and move DOM focus into
+				// it, which would otherwise be perceived as focus leaving the
+				// popover and close it prematurely.
+				// See https://github.com/WordPress/gutenberg/issues/78406.
+				const relatedTarget =
+					'relatedTarget' in event ? event.relatedTarget : null;
+				if (
+					relatedTarget instanceof Element &&
+					relatedTarget.closest( '[data-wp-compat-overlay-slot]' )
+				) {
+					return;
+				}
 				// Call onFocusOutside if defined or call onClose.
 				if ( onFocusOutside ) {
 					onFocusOutside( event );

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -279,33 +279,45 @@ const UnforwardedPopover = (
 				) {
 					return;
 				}
-				// Ignore blur events whose `relatedTarget` is logically inside
-				// this popover. This covers two cases caused by portaled
-				// descendants:
-				// 1. Focus moves into the `@wordpress/ui` compat overlay slot:
-				//    some `@wordpress/ui` overlays (e.g. `Select`) portal their
-				//    popup to a body-level slot and move DOM focus into it.
+				// Ignore blur events caused by portaled descendants, which
+				// look like "focus leaving the popover" via DOM containment
+				// alone but are logically internal. Covers three cases:
+				// 1. Focus moves into the `@wordpress/ui` compat overlay
+				//    slot — some `@wordpress/ui` overlays (e.g. `Select`)
+				//    portal their popup to a body-level slot and move DOM
+				//    focus into it.
 				// 2. Focus moves back from a portaled descendant into the
-				//    popover (e.g. base-ui's `FloatingFocusManager` restoring
-				//    focus to its trigger when the popup closes).
-				// Both look like "focus leaving the popover" via DOM
-				// containment alone, but are logically internal.
+				//    popover (e.g. base-ui's `FloatingFocusManager`
+				//    restoring focus to its trigger when the popup closes
+				//    via Esc / item selection).
+				// 3. A portaled descendant briefly dropped focus on `body`
+				//    while closing, then focus was restored to the popover
+				//    (e.g. base-ui's `Select` `modal: true` backdrop click,
+				//    where the backdrop blurs the trigger to `body` before
+				//    the popup unmounts and restores focus).
 				// See https://github.com/WordPress/gutenberg/issues/78406.
 				const relatedTarget =
 					'relatedTarget' in event ? event.relatedTarget : null;
-				if ( relatedTarget instanceof Element ) {
-					if (
-						relatedTarget.closest( '[data-wp-compat-overlay-slot]' )
-					) {
-						return;
-					}
-					// Note: only the floating element is checked; the
-					// reference element falls back to the popover's parent
-					// when no `anchor` is provided, which would also include
-					// arbitrary siblings.
-					if ( floatingElement?.contains( relatedTarget ) ) {
-						return;
-					}
+				if (
+					relatedTarget instanceof Element &&
+					relatedTarget.closest( '[data-wp-compat-overlay-slot]' )
+				) {
+					return;
+				}
+				// Note: only the floating element is checked; the reference
+				// element falls back to the popover's parent when no
+				// `anchor` is provided, which would also include arbitrary
+				// siblings.
+				if (
+					floatingElement &&
+					( ( relatedTarget instanceof Element &&
+						floatingElement.contains( relatedTarget ) ) ||
+						( ownerDocument?.activeElement instanceof Element &&
+							floatingElement.contains(
+								ownerDocument.activeElement
+							) ) )
+				) {
+					return;
 				}
 				// Call onFocusOutside if defined or call onClose.
 				if ( onFocusOutside ) {

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -281,8 +281,10 @@ const UnforwardedPopover = (
 				}
 				// Treat focus moves involving portaled descendants as
 				// internal: either the next focus target is in the
-				// `@wordpress/ui` compat overlay slot, or focus is (back)
-				// inside this popover by the time we evaluate.
+				// `@wordpress/ui` compat overlay slot, or focus is back
+				// inside this popover by the time we evaluate (e.g. when
+				// a portaled overlay is dismissed and synchronously
+				// restores focus to its trigger).
 				// See https://github.com/WordPress/gutenberg/issues/78406.
 				const relatedTarget =
 					'relatedTarget' in event ? event.relatedTarget : null;
@@ -292,17 +294,10 @@ const UnforwardedPopover = (
 				) {
 					return;
 				}
-				// `referenceElement` falls back to the popover's parent
-				// when no `anchor` is provided, so it would match arbitrary
-				// siblings — only check the floating element.
 				if (
 					floatingElement &&
-					( ( relatedTarget instanceof Element &&
-						floatingElement.contains( relatedTarget ) ) ||
-						( ownerDocument?.activeElement instanceof Element &&
-							floatingElement.contains(
-								ownerDocument.activeElement
-							) ) )
+					ownerDocument?.activeElement instanceof Element &&
+					floatingElement.contains( ownerDocument.activeElement )
 				) {
 					return;
 				}

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -671,21 +671,20 @@ describe( 'Popover', () => {
 	} );
 
 	describe( 'wp compat overlay slot', () => {
-		it( 'should not call onFocusOutside when focus moves into the wp compat overlay slot', async () => {
-			const user = userEvent.setup();
-			const onFocusOutside = jest.fn();
-
-			// Simulate a body-level overlay slot rendered as a sibling of the
-			// Popover. `@wordpress/ui` overlays such as `Select` portal their
-			// popup into a slot tagged with `[data-wp-compat-overlay-slot]`
-			// and move DOM focus into it; the Popover should stay open in
-			// that case.
+		function createOverlaySlot() {
 			const slot = document.createElement( 'div' );
 			slot.setAttribute( 'data-wp-compat-overlay-slot', '' );
 			const slotButton = document.createElement( 'button' );
 			slotButton.textContent = 'Slotted item';
 			slot.appendChild( slotButton );
 			document.body.appendChild( slot );
+			return { slot, slotButton };
+		}
+
+		it( 'should not call onFocusOutside when focus moves into the wp compat overlay slot', async () => {
+			const user = userEvent.setup();
+			const onFocusOutside = jest.fn();
+			const { slot, slotButton } = createOverlaySlot();
 
 			render(
 				<Popover onFocusOutside={ onFocusOutside }>
@@ -705,13 +704,7 @@ describe( 'Popover', () => {
 		it( 'should not call onFocusOutside when focus returns from the slot to a popover descendant', async () => {
 			const user = userEvent.setup();
 			const onFocusOutside = jest.fn();
-
-			const slot = document.createElement( 'div' );
-			slot.setAttribute( 'data-wp-compat-overlay-slot', '' );
-			const slotButton = document.createElement( 'button' );
-			slotButton.textContent = 'Slotted item';
-			slot.appendChild( slotButton );
-			document.body.appendChild( slot );
+			const { slot, slotButton } = createOverlaySlot();
 
 			render(
 				<Popover onFocusOutside={ onFocusOutside }>
@@ -720,9 +713,6 @@ describe( 'Popover', () => {
 			);
 
 			const trigger = screen.getByText( 'Trigger' );
-			// Move focus into the slot, then back to the popover (simulating
-			// a portaled overlay closing and restoring focus to its trigger
-			// inside the host popover).
 			slotButton.focus();
 			await user.click( slotButton );
 			trigger.focus();
@@ -734,18 +724,12 @@ describe( 'Popover', () => {
 		} );
 
 		it( 'should not call onFocusOutside when focus is restored to a popover descendant by the time the blur check runs', async () => {
-			// Simulates the base-ui Select backdrop dismissal path: the
-			// currently-focused element (in the body-level slot) drops
-			// focus to `body` when the backdrop is clicked, then focus is
-			// restored to the popover trigger after the popup unmounts.
+			// Mimics the base-ui `Select` backdrop dismissal: focus drops
+			// to `body` (so the captured `relatedTarget` is `null`), then
+			// is synchronously restored to the popover before the blur
+			// check runs.
 			const onFocusOutside = jest.fn();
-
-			const slot = document.createElement( 'div' );
-			slot.setAttribute( 'data-wp-compat-overlay-slot', '' );
-			const slotButton = document.createElement( 'button' );
-			slotButton.textContent = 'Slotted item';
-			slot.appendChild( slotButton );
-			document.body.appendChild( slot );
+			const { slot, slotButton } = createOverlaySlot();
 
 			render(
 				<Popover
@@ -761,20 +745,13 @@ describe( 'Popover', () => {
 
 			await act( async () => {
 				slotButton.focus();
-				// Native blur fires when focus leaves an element to `body`
-				// (no related target). The blur is dispatched here against
-				// the floating popover content (event.target = floating
-				// element, which is the wrapper bound to useFocusOutside).
 				floating.dispatchEvent(
 					new FocusEvent( 'blur', {
 						bubbles: true,
 						relatedTarget: null,
 					} )
 				);
-				// Restore focus to the popover descendant synchronously,
-				// before the blur-check timeout runs.
 				trigger.focus();
-				// Let the blur-check timeout (setTimeout(0)) run.
 				await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
 			} );
 

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -696,6 +696,37 @@ describe( 'Popover', () => {
 			document.body.removeChild( slot );
 		} );
 
+		it( 'should not call onFocusOutside when focus returns from the slot to a popover descendant', async () => {
+			const user = userEvent.setup();
+			const onFocusOutside = jest.fn();
+
+			const slot = document.createElement( 'div' );
+			slot.setAttribute( 'data-wp-compat-overlay-slot', '' );
+			const slotButton = document.createElement( 'button' );
+			slotButton.textContent = 'Slotted item';
+			slot.appendChild( slotButton );
+			document.body.appendChild( slot );
+
+			render(
+				<Popover onFocusOutside={ onFocusOutside }>
+					<button>Trigger</button>
+				</Popover>
+			);
+
+			const trigger = screen.getByText( 'Trigger' );
+			// Move focus into the slot, then back to the popover (simulating
+			// a portaled overlay closing and restoring focus to its trigger
+			// inside the host popover).
+			slotButton.focus();
+			await user.click( slotButton );
+			trigger.focus();
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			expect( onFocusOutside ).not.toHaveBeenCalled();
+
+			document.body.removeChild( slot );
+		} );
+
 		it( 'should still call onFocusOutside when focus moves to a sibling outside the slot', async () => {
 			const user = userEvent.setup();
 			const onFocusOutside = jest.fn();

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
-import { render, screen, waitFor, getByText } from '@testing-library/react';
+import {
+	act,
+	render,
+	screen,
+	waitFor,
+	getByText,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { CSSProperties } from 'react';
 
@@ -722,6 +728,56 @@ describe( 'Popover', () => {
 			trigger.focus();
 
 			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			expect( onFocusOutside ).not.toHaveBeenCalled();
+
+			document.body.removeChild( slot );
+		} );
+
+		it( 'should not call onFocusOutside when focus is restored to a popover descendant by the time the blur check runs', async () => {
+			// Simulates the base-ui Select backdrop dismissal path: the
+			// currently-focused element (in the body-level slot) drops
+			// focus to `body` when the backdrop is clicked, then focus is
+			// restored to the popover trigger after the popup unmounts.
+			const onFocusOutside = jest.fn();
+
+			const slot = document.createElement( 'div' );
+			slot.setAttribute( 'data-wp-compat-overlay-slot', '' );
+			const slotButton = document.createElement( 'button' );
+			slotButton.textContent = 'Slotted item';
+			slot.appendChild( slotButton );
+			document.body.appendChild( slot );
+
+			render(
+				<Popover
+					data-testid="popover"
+					onFocusOutside={ onFocusOutside }
+				>
+					<button>Trigger</button>
+				</Popover>
+			);
+
+			const trigger = screen.getByText( 'Trigger' );
+			const floating = screen.getByTestId( 'popover' );
+
+			await act( async () => {
+				slotButton.focus();
+				// Native blur fires when focus leaves an element to `body`
+				// (no related target). The blur is dispatched here against
+				// the floating popover content (event.target = floating
+				// element, which is the wrapper bound to useFocusOutside).
+				floating.dispatchEvent(
+					new FocusEvent( 'blur', {
+						bubbles: true,
+						relatedTarget: null,
+					} )
+				);
+				// Restore focus to the popover descendant synchronously,
+				// before the blur-check timeout runs.
+				trigger.focus();
+				// Let the blur-check timeout (setTimeout(0)) run.
+				await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			} );
+
 			expect( onFocusOutside ).not.toHaveBeenCalled();
 
 			document.body.removeChild( slot );

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -708,14 +708,14 @@ describe( 'Popover', () => {
 
 			render(
 				<Popover onFocusOutside={ onFocusOutside }>
-					<button>Trigger</button>
+					<button>Inside popover</button>
 				</Popover>
 			);
 
-			const trigger = screen.getByText( 'Trigger' );
-			slotButton.focus();
+			const insideButton = screen.getByText( 'Inside popover' );
+			await user.click( insideButton );
 			await user.click( slotButton );
-			trigger.focus();
+			insideButton.focus();
 
 			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
 			expect( onFocusOutside ).not.toHaveBeenCalled();

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -663,4 +663,58 @@ describe( 'Popover', () => {
 			} );
 		} );
 	} );
+
+	describe( 'wp compat overlay slot', () => {
+		it( 'should not call onFocusOutside when focus moves into the wp compat overlay slot', async () => {
+			const user = userEvent.setup();
+			const onFocusOutside = jest.fn();
+
+			// Simulate a body-level overlay slot rendered as a sibling of the
+			// Popover. `@wordpress/ui` overlays such as `Select` portal their
+			// popup into a slot tagged with `[data-wp-compat-overlay-slot]`
+			// and move DOM focus into it; the Popover should stay open in
+			// that case.
+			const slot = document.createElement( 'div' );
+			slot.setAttribute( 'data-wp-compat-overlay-slot', '' );
+			const slotButton = document.createElement( 'button' );
+			slotButton.textContent = 'Slotted item';
+			slot.appendChild( slotButton );
+			document.body.appendChild( slot );
+
+			render(
+				<Popover onFocusOutside={ onFocusOutside }>
+					<button>Inside popover</button>
+				</Popover>
+			);
+
+			await user.click( screen.getByText( 'Inside popover' ) );
+			await user.click( slotButton );
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			expect( onFocusOutside ).not.toHaveBeenCalled();
+
+			document.body.removeChild( slot );
+		} );
+
+		it( 'should still call onFocusOutside when focus moves to a sibling outside the slot', async () => {
+			const user = userEvent.setup();
+			const onFocusOutside = jest.fn();
+
+			render(
+				<>
+					<Popover onFocusOutside={ onFocusOutside }>
+						<button>Inside popover</button>
+					</Popover>
+					<button>Outside</button>
+				</>
+			);
+
+			await user.click( screen.getByText( 'Inside popover' ) );
+			await user.click( screen.getByText( 'Outside' ) );
+
+			await waitFor( () => {
+				expect( onFocusOutside ).toHaveBeenCalledTimes( 1 );
+			} );
+		} );
+	} );
 } );


### PR DESCRIPTION
## What?

See #78406. Scoped fix for the most visible manifestation: `@wordpress/ui` `Select` nested in a `Popover` causes the `Popover` to close on hover and on any dismissal.

## Why?

`Popover` closes via `useFocusOutside`, which only checks DOM containment. `Select`'s popup (and any portaled descendant that takes real DOM focus) lives outside the `Popover`'s DOM subtree, so it looks indistinguishable from focus leaving and the `Popover` closes prematurely.

The general bug — and existing per-consumer workarounds elsewhere in the codebase — is tracked in #78406.

## How?

In `Popover`'s `focus-outside` handler, ignore blur events when either:

1. `relatedTarget` is inside `[data-wp-compat-overlay-slot]` (focus moves *into* a portaled `@wordpress/ui` overlay), or
2. `document.activeElement` at the time of the deferred blur check is inside the popover's floating element (focus dropped to `body` and was synchronously restored to the popover before the check ran).

<details>
<summary>Why these two checks?</summary>

- Check 1 (slot) handles the open / hover path: focus moves into the slot, which is a DOM sibling of the popover and would otherwise look like a focus-outside.
- Check 2 (`activeElement`) handles the modal-backdrop dismissal path used by base-ui `Select`: focus drops to `body` first (so the captured `relatedTarget` is `null`), and only `activeElement` queried later reflects the restored focus.

Other dismissal paths (Esc, item click) don't need an explicit bail-out — base-ui's `FloatingFocusManager` restores focus to the `Select` trigger inside the popover, and `useFocusOutside`'s `onFocus` cancels the queued blur check naturally because the focus event bubbles through the React tree.

`Autocomplete` isn't affected because it keeps DOM focus on its input (combobox + `aria-activedescendant`).
</details>

<details>
<summary>Why scoped, not the general fix?</summary>

A general fix needs a way for `useFocusOutside` to know which portaled subtrees are *logically* inside its target — likely via a React-context registry or an opt-in API. Larger surface to design; tracked in #78406.
</details>

## Testing Instructions

1. `npm run storybook:dev`
2. Open `Playground/WP Compat Overlay Slot` → `Inside Components Popover`.
3. Open the `@wordpress/ui` `Select`. Then, in turn: hover items, select one, press Esc, click the modal backdrop. The host `Popover` should stay open in every case.
4. Click outside the `Popover` itself → it should close (regression check).

Unit tests: `npx jest -c test/unit/jest.config.js packages/components/src/popover`.

### Testing Instructions for Keyboard

Same flow as above, opening the `Select` with Space/Enter, highlighting with Arrows, dismissing with Esc / Enter.

## Screenshots or screencast

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/c8a20ef1-e482-4856-9ae0-4010e19e584b" /> | <video src="https://github.com/user-attachments/assets/a6559b76-5259-4180-8d94-7f0fe1568435" /> |

## Use of AI Tools

Drafted with AI assistance; reviewed and verified manually (storybook reproduction + new unit tests).
