### PR TITLE
Tooltip migration: block-editor + block-directory consumers (1/5)

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -7,16 +7,13 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import {
-	Tooltip as WCTooltip,
-	Spinner,
-	Composite,
-} from '@wordpress/components';
+import { Spinner, Composite } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { getBlockType } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-import { VisuallyHidden } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { VisuallyHidden, Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -101,68 +98,76 @@ function DownloadableBlockListItem( { item, onClick } ) {
 	} );
 
 	return (
-		<WCTooltip placement="top" text={ itemLabel }>
-			<Composite.Item
-				className={ clsx(
-					'block-directory-downloadable-block-list-item',
-					isInstalling && 'is-installing'
-				) }
-				accessibleWhenDisabled
-				disabled={ isInstalling || ! isInstallable }
-				onClick={ ( event ) => {
-					event.preventDefault();
-					onClick();
-				} }
-				aria-label={ itemLabel }
-				type="button"
-				role="option"
-			>
-				<div className="block-directory-downloadable-block-list-item__icon">
-					<DownloadableBlockIcon icon={ icon } title={ title } />
-					{ isInstalling ? (
-						<span className="block-directory-downloadable-block-list-item__spinner">
-							<Spinner />
-						</span>
-					) : (
-						<BlockRatings rating={ rating } />
-					) }
-				</div>
-				<span className="block-directory-downloadable-block-list-item__details">
-					<span className="block-directory-downloadable-block-list-item__title">
-						{ createInterpolateElement(
-							sprintf(
-								/* translators: 1: block title. 2: author name. */
-								__( '%1$s <span>by %2$s</span>' ),
-								decodeEntities( title ),
-								author
-							),
-							{
-								span: (
-									<span className="block-directory-downloadable-block-list-item__author" />
-								),
-							}
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				render={
+					<Composite.Item
+						className={ clsx(
+							'block-directory-downloadable-block-list-item',
+							isInstalling && 'is-installing'
 						) }
-					</span>
-					{ hasNotice ? (
-						<DownloadableBlockNotice block={ item } />
-					) : (
-						<>
-							<span className="block-directory-downloadable-block-list-item__desc">
-								{ !! statusText
-									? statusText
-									: decodeEntities( description ) }
-							</span>
-							{ isInstallable &&
-								! ( isInstalled || isInstalling ) && (
-									<VisuallyHidden>
-										{ __( 'Install block' ) }
-									</VisuallyHidden>
+						accessibleWhenDisabled
+						disabled={ isInstalling || ! isInstallable }
+						onClick={ ( event ) => {
+							event.preventDefault();
+							onClick();
+						} }
+						aria-label={ itemLabel }
+						type="button"
+						role="option"
+					>
+						<div className="block-directory-downloadable-block-list-item__icon">
+							<DownloadableBlockIcon
+								icon={ icon }
+								title={ title }
+							/>
+							{ isInstalling ? (
+								<span className="block-directory-downloadable-block-list-item__spinner">
+									<Spinner />
+								</span>
+							) : (
+								<BlockRatings rating={ rating } />
+							) }
+						</div>
+						<span className="block-directory-downloadable-block-list-item__details">
+							<span className="block-directory-downloadable-block-list-item__title">
+								{ createInterpolateElement(
+									sprintf(
+										/* translators: 1: block title. 2: author name. */
+										__( '%1$s <span>by %2$s</span>' ),
+										decodeEntities( title ),
+										author
+									),
+									{
+										span: (
+											<span className="block-directory-downloadable-block-list-item__author" />
+										),
+									}
 								) }
-						</>
-					) }
-				</span>
-			</Composite.Item>
-		</WCTooltip>
+							</span>
+							{ hasNotice ? (
+								<DownloadableBlockNotice block={ item } />
+							) : (
+								<>
+									<span className="block-directory-downloadable-block-list-item__desc">
+										{ !! statusText
+											? statusText
+											: decodeEntities( description ) }
+									</span>
+									{ isInstallable &&
+										! ( isInstalled || isInstalling ) && (
+											<VisuallyHidden>
+												{ __( 'Install block' ) }
+											</VisuallyHidden>
+										) }
+								</>
+							) }
+						</span>
+					</Composite.Item>
+				}
+			/>
+			<Tooltip.Popup>{ itemLabel }</Tooltip.Popup>
+		</Tooltip.Root>
 	);
 }
 

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -10,10 +10,10 @@ import { cloneBlock } from '@wordpress/blocks';
 import { useEffect, useState, forwardRef, useMemo } from '@wordpress/element';
 import {
 	Composite,
-	Tooltip as WCTooltip,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { VisuallyHidden, Text } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { VisuallyHidden, Text, Tooltip } from '@wordpress/ui';
 import { useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Icon, symbol } from '@wordpress/icons';
@@ -28,7 +28,12 @@ import { INSERTER_PATTERN_TYPES } from '../inserter/block-patterns-tab/utils';
 
 const WithToolTip = ( { showTooltip, title, children } ) => {
 	if ( showTooltip ) {
-		return <WCTooltip text={ title }>{ children }</WCTooltip>;
+		return (
+			<Tooltip.Root>
+				<Tooltip.Trigger render={ children } />
+				<Tooltip.Popup>{ title }</Tooltip.Popup>
+			</Tooltip.Root>
+		);
 	}
 	return <>{ children }</>;
 };

--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -11,7 +11,6 @@ import {
 	FlexItem,
 	Dropdown,
 	Composite,
-	Tooltip as WCTooltip,
 } from '@wordpress/components';
 import { useMemo, useRef } from '@wordpress/element';
 import { shadow as shadowIcon, Icon, check, reset } from '@wordpress/icons';
@@ -20,6 +19,9 @@ import { shadow as shadowIcon, Icon, check, reset } from '@wordpress/icons';
  * External dependencies
  */
 import clsx from 'clsx';
+
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip } from '@wordpress/ui';
 
 /**
  * Shared reference to an empty array for cases where it is important to avoid
@@ -82,31 +84,39 @@ export function ShadowPresets( { presets, activeShadow, onSelect } ) {
 
 export function ShadowIndicator( { type, label, isActive, onSelect, shadow } ) {
 	return (
-		<WCTooltip text={ label }>
-			<Composite.Item
-				role="option"
-				aria-label={ label }
-				aria-selected={ isActive }
-				className={ clsx( 'block-editor-global-styles__shadow__item', {
-					'is-active': isActive,
-				} ) }
+		<Tooltip.Root>
+			<Tooltip.Trigger
 				render={
-					<button
+					<Composite.Item
+						role="option"
+						aria-label={ label }
+						aria-selected={ isActive }
 						className={ clsx(
-							'block-editor-global-styles__shadow-indicator',
+							'block-editor-global-styles__shadow__item',
 							{
-								unset: type === 'unset',
+								'is-active': isActive,
 							}
 						) }
-						onClick={ onSelect }
-						style={ { boxShadow: shadow } }
-						aria-label={ label }
-					>
-						{ isActive && <Icon icon={ check } /> }
-					</button>
+						render={
+							<button
+								className={ clsx(
+									'block-editor-global-styles__shadow-indicator',
+									{
+										unset: type === 'unset',
+									}
+								) }
+								onClick={ onSelect }
+								style={ { boxShadow: shadow } }
+								aria-label={ label }
+							>
+								{ isActive && <Icon icon={ check } /> }
+							</button>
+						}
+					/>
 				}
 			/>
-		</WCTooltip>
+			<Tooltip.Popup>{ label }</Tooltip.Popup>
+		</Tooltip.Root>
 	);
 }
 

--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -7,7 +7,6 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import {
-	Tooltip as WCTooltip,
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
@@ -27,6 +26,9 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { isBlobURL } from '@wordpress/blob';
 import { getFilename } from '@wordpress/url';
+
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -261,27 +263,34 @@ export function MediaPreview( { media, onClick, category } ) {
 							onMouseEnter={ onMouseEnter }
 							onMouseLeave={ onMouseLeave }
 						>
-							<WCTooltip text={ title }>
-								<Composite.Item
+							<Tooltip.Root>
+								<Tooltip.Trigger
 									render={
-										<div
-											aria-label={ title }
-											role="option"
-											className="block-editor-inserter__media-list__item"
-										/>
-									}
-									onClick={ () => onMediaInsert( block ) }
-								>
-									<div className="block-editor-inserter__media-list__item-preview">
-										{ preview }
-										{ isInserting && (
-											<div className="block-editor-inserter__media-list__item-preview-spinner">
-												<Spinner />
+										<Composite.Item
+											render={
+												<div
+													aria-label={ title }
+													role="option"
+													className="block-editor-inserter__media-list__item"
+												/>
+											}
+											onClick={ () =>
+												onMediaInsert( block )
+											}
+										>
+											<div className="block-editor-inserter__media-list__item-preview">
+												{ preview }
+												{ isInserting && (
+													<div className="block-editor-inserter__media-list__item-preview-spinner">
+														<Spinner />
+													</div>
+												) }
 											</div>
-										) }
-									</div>
-								</Composite.Item>
-							</WCTooltip>
+										</Composite.Item>
+									}
+								/>
+								<Tooltip.Popup>{ title }</Tooltip.Popup>
+							</Tooltip.Root>
 							{ ! isInserting && (
 								<MediaPreviewOptions
 									category={ category }

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -3,12 +3,14 @@
  */
 import {
 	Icon as WCIcon,
-	Tooltip as WCTooltip,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { useSelect, useDispatch } from '@wordpress/data';
+
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -175,14 +177,16 @@ export default function InspectorControlsTabs( {
 								{ tab.title }
 							</Tabs.Tab>
 						) : (
-							<WCTooltip text={ tab.title } key={ tab.name }>
+							<Tooltip.Root key={ tab.name }>
 								<Tabs.Tab
 									tabId={ tab.name }
 									aria-label={ tab.title }
+									render={ <Tooltip.Trigger /> }
 								>
 									<WCIcon icon={ tab.icon } />
 								</Tabs.Tab>
-							</WCTooltip>
+								<Tooltip.Popup>{ tab.title }</Tooltip.Popup>
+							</Tooltip.Root>
 						)
 					) }
 				</Tabs.TabList>

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -9,7 +9,6 @@ import clsx from 'clsx';
 import {
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
-	Tooltip as WCTooltip,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
@@ -22,6 +21,9 @@ import {
 } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
 import { useSelect } from '@wordpress/data';
+
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -164,14 +166,22 @@ function ListViewBlockSelectButton(
 					</span>
 				) : null }
 				{ !! visibilityLabel && (
-					<WCTooltip text={ visibilityLabel }>
-						<span
-							className="block-editor-list-view-block-select-button__block-visibility"
-							aria-hidden="true"
-						>
-							<Icon icon={ unseen } />
-						</span>
-					</WCTooltip>
+					// TODO: `visibilityLabel` is not exposed to
+					// assistive technology — the trigger is
+					// `aria-hidden`, so the label is sighted-hover-only.
+					<Tooltip.Root>
+						<Tooltip.Trigger
+							render={
+								<span
+									className="block-editor-list-view-block-select-button__block-visibility"
+									aria-hidden="true"
+								>
+									<Icon icon={ unseen } />
+								</span>
+							}
+						/>
+						<Tooltip.Popup>{ visibilityLabel }</Tooltip.Popup>
+					</Tooltip.Root>
 				) }
 				{ shouldShowLockIcon && (
 					<span className="block-editor-list-view-block-select-button__lock">

--- a/packages/block-editor/src/components/preset-input-control/custom-value-controls.js
+++ b/packages/block-editor/src/components/preset-input-control/custom-value-controls.js
@@ -3,9 +3,11 @@
  */
 import {
 	RangeControl,
-	Tooltip as WCTooltip,
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
+
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip } from '@wordpress/ui';
 
 /**
  * CustomValueControls component for handling custom value input.
@@ -93,11 +95,16 @@ export default function CustomValueControls( {
 	);
 
 	const wrappedUnitControl = showTooltip ? (
-		<WCTooltip text={ ariaLabel } placement="top">
-			<div className="preset-input-control__tooltip-wrapper">
-				{ unitControl }
-			</div>
-		</WCTooltip>
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				render={
+					<div className="preset-input-control__tooltip-wrapper">
+						{ unitControl }
+					</div>
+				}
+			/>
+			<Tooltip.Popup>{ ariaLabel }</Tooltip.Popup>
+		</Tooltip.Root>
 	) : (
 		unitControl
 	);

--- a/tools/codemods/tooltip-components-to-ui.js
+++ b/tools/codemods/tooltip-components-to-ui.js
@@ -1,0 +1,440 @@
+/**
+ * One-shot codemod: rewrite `<Tooltip>` imported from `@wordpress/components`
+ * to the compositional `Tooltip` API exported by `@wordpress/ui`.
+ *
+ * Scope and decisions are documented in the migration plan. Highlights:
+ *
+ *   - Rewrites only the `Tooltip` specifier from `@wordpress/components`
+ *     imports; leaves siblings untouched.
+ *   - Adds (or merges into) an `import { Tooltip } from '@wordpress/ui'`.
+ *   - For each `<Tooltip>…</Tooltip>` JSX usage:
+ *       - bails (and logs) if it has more than one JSX child element;
+ *       - bails (and logs) on unsupported props (`shortcut`, `delay`,
+ *         `hideOnClick`, `position`, or anything else not in the allow-list);
+ *       - hoists `key` to `Tooltip.Root`;
+ *       - emits `<Tooltip.Root><Tooltip.Trigger render={ child } />
+ *         <Tooltip.Popup className=…>{ text }</Tooltip.Popup></Tooltip.Root>`;
+ *       - includes a `<Tooltip.Positioner side=… align=… />` only when the
+ *         legacy `placement` is non-default.
+ *
+ * If *any* `<Tooltip>` usage in a file bails out, the whole file is left
+ * untouched (no partial transforms, no import surgery). This avoids the
+ * broken intermediate state where some usages have been rewritten to
+ * `<Tooltip.Root>` while other unconverted `<Tooltip>` usages still depend
+ * on the now-removed `@wordpress/components` import. The bailouts are still
+ * logged so the author knows where to finish the migration by hand.
+ *
+ * Usage:
+ *   npx jscodeshift -t tools/codemods/tooltip-components-to-ui.js \
+ *       --extensions=js,jsx,ts,tsx --parser=tsx \
+ *       packages/<scope>
+ */
+'use strict';
+
+const ALLOWED_PROPS = new Set( [ 'text', 'placement', 'className', 'key' ] );
+
+const PLACEMENT_TO_SIDE_ALIGN = {
+	top: { side: 'top', align: 'center' },
+	'top-start': { side: 'top', align: 'start' },
+	'top-end': { side: 'top', align: 'end' },
+	right: { side: 'right', align: 'center' },
+	'right-start': { side: 'right', align: 'start' },
+	'right-end': { side: 'right', align: 'end' },
+	bottom: { side: 'bottom', align: 'center' },
+	'bottom-start': { side: 'bottom', align: 'start' },
+	'bottom-end': { side: 'bottom', align: 'end' },
+	left: { side: 'left', align: 'center' },
+	'left-start': { side: 'left', align: 'start' },
+	'left-end': { side: 'left', align: 'end' },
+};
+
+module.exports = function transformer( file, api ) {
+	const j = api.jscodeshift;
+	const root = j( file.source );
+
+	// 1. Find `Tooltip` specifier from `@wordpress/components`.
+	const componentsImports = root.find( j.ImportDeclaration, {
+		source: { value: '@wordpress/components' },
+	} );
+
+	// The legacy `Tooltip` may have been imported under an alias (e.g.
+	// `Tooltip as WCTooltip`), so we capture the local name (`sourceName`)
+	// for matching JSX usages. The emitted replacement always uses the
+	// unaliased `Tooltip` namespace from `@wordpress/ui` (which is what
+	// step 6 below imports unconditionally).
+	let sourceName = null;
+	componentsImports.forEach( ( path ) => {
+		const specifiers = path.node.specifiers || [];
+		for ( const spec of specifiers ) {
+			if (
+				spec.type === 'ImportSpecifier' &&
+				spec.imported &&
+				spec.imported.name === 'Tooltip'
+			) {
+				sourceName = spec.local ? spec.local.name : 'Tooltip';
+			}
+		}
+	} );
+
+	if ( ! sourceName ) {
+		return null;
+	}
+
+	const targetName = 'Tooltip';
+
+	// 2. First pass: try to build replacement nodes for every <Tooltip> usage
+	// in the file. Collect bailouts (with reason and source location) but
+	// do not mutate the AST yet.
+	const bailouts = [];
+	/** @type {{ path: any, replacement: any }[]} */
+	const replacements = [];
+
+	function recordBailout( node, reason ) {
+		const loc = node && node.loc && node.loc.start;
+		const line = loc ? loc.line : '?';
+		bailouts.push( `${ file.path }:${ line } ${ reason }` );
+	}
+
+	root.find( j.JSXElement, {
+		openingElement: {
+			name: { type: 'JSXIdentifier', name: sourceName },
+		},
+	} ).forEach( ( path ) => {
+		const result = buildReplacement( j, path.node, sourceName, targetName );
+		if ( result.kind === 'bailout' ) {
+			recordBailout( path.node, result.reason );
+			return;
+		}
+		replacements.push( { path, replacement: result.node } );
+	} );
+
+	// 3. If any usage bailed out, leave the file completely untouched —
+	// partial transforms would break the file by removing the legacy
+	// import while bailed-out usages still depend on it (and pulling in
+	// `Tooltip` from `@wordpress/ui` would clash with the leftover legacy
+	// import that uses the same local name). The bailouts are still logged
+	// so the author can finish them by hand.
+	if ( replacements.length === 0 ) {
+		if ( bailouts.length ) {
+			console.warn( bailouts.join( '\n' ) );
+		}
+		return null;
+	}
+	if ( bailouts.length ) {
+		console.warn( bailouts.join( '\n' ) );
+		return null;
+	}
+
+	// 4. Apply the replacements collected in pass 1.
+	for ( const { path, replacement } of replacements ) {
+		j( path ).replaceWith( replacement );
+	}
+
+	// 5. Remove the `Tooltip` specifier from `@wordpress/components` imports
+	// (and drop the import declaration if nothing else remains).
+	componentsImports.forEach( ( path ) => {
+		const node = path.node;
+		const remaining = ( node.specifiers || [] ).filter( ( spec ) => {
+			return ! (
+				spec.type === 'ImportSpecifier' &&
+				spec.imported &&
+				spec.imported.name === 'Tooltip'
+			);
+		} );
+		if ( remaining.length === 0 ) {
+			j( path ).remove();
+		} else {
+			node.specifiers = remaining;
+		}
+	} );
+
+	// 6. Add (or merge into) the `@wordpress/ui` import.
+	//
+	// Only merge into an existing `@wordpress/ui` import declaration when it
+	// already uses named specifiers (`import { Foo } from '@wordpress/ui'`).
+	// A default import (`import UI from …`) or a namespace import
+	// (`import * as UI from …`) cannot have a named specifier appended
+	// without producing invalid syntax, so in those cases we leave the
+	// existing declaration untouched and add a separate
+	// `import { Tooltip } from '@wordpress/ui'` instead.
+	const uiImports = root.find( j.ImportDeclaration, {
+		source: { value: '@wordpress/ui' },
+	} );
+	const mergeTarget = uiImports.filter( ( path ) => {
+		const specifiers = path.node.specifiers || [];
+		// Reject empty side-effect imports too: pushing into them is fine
+		// syntactically but yields a less readable result; treat them like
+		// the no-existing-import case below.
+		if ( specifiers.length === 0 ) {
+			return false;
+		}
+		return specifiers.every( ( s ) => s.type === 'ImportSpecifier' );
+	} );
+
+	if ( mergeTarget.size() ) {
+		const node = mergeTarget.at( 0 ).get( 0 ).node;
+		const hasTooltip = ( node.specifiers || [] ).some( ( s ) => {
+			return (
+				s.type === 'ImportSpecifier' &&
+				s.imported &&
+				s.imported.name === 'Tooltip'
+			);
+		} );
+		if ( ! hasTooltip ) {
+			node.specifiers.push(
+				j.importSpecifier( j.identifier( 'Tooltip' ) )
+			);
+		}
+	} else {
+		// Insert after the last `import` declaration in the file, or at the
+		// very top of the program when no imports exist. Reviewers may want
+		// to hand-tidy the result into the appropriate import block.
+		const allImports = root.find( j.ImportDeclaration );
+		const newImport = j.importDeclaration(
+			[ j.importSpecifier( j.identifier( 'Tooltip' ) ) ],
+			j.literal( '@wordpress/ui' )
+		);
+		if ( allImports.size() ) {
+			allImports.at( -1 ).insertAfter( newImport );
+		} else {
+			root.get().node.program.body.unshift( newImport );
+		}
+	}
+
+	return root.toSource( { quote: 'single' } );
+};
+
+/**
+ * Validate a single `<Tooltip>` JSX element and, if it is convertible,
+ * return the new `<Tooltip.Root>…</Tooltip.Root>` node that should replace
+ * it. Otherwise, return a bailout descriptor explaining why.
+ *
+ * @param {*}      j          jscodeshift API.
+ * @param {*}      el         The original `<Tooltip>` JSXElement node.
+ * @param {string} sourceName Local name of the legacy `Tooltip` import (used
+ *                            to find usages, e.g. `WCTooltip` or `Tooltip`).
+ * @param {string} targetName Local name of the new `Tooltip` import from
+ *                            `@wordpress/ui` (always `Tooltip` for now).
+ *
+ * @return {{ kind: 'ok', node: any } | { kind: 'bailout', reason: string }} `ok`
+ *         with the replacement node, or `bailout` with a human-readable reason.
+ */
+function buildReplacement( j, el, sourceName, targetName ) {
+	const attrs = el.openingElement.attributes || [];
+	const propMap = {};
+
+	for ( const attr of attrs ) {
+		if ( attr.type !== 'JSXAttribute' ) {
+			return {
+				kind: 'bailout',
+				reason: `bailout: spread attribute on <${ sourceName }>`,
+			};
+		}
+		const name = attr.name && attr.name.name;
+		if ( ! ALLOWED_PROPS.has( name ) ) {
+			return {
+				kind: 'bailout',
+				reason: `bailout: unsupported prop \`${ name }\` on <${ sourceName }>`,
+			};
+		}
+		propMap[ name ] = attr.value;
+	}
+
+	// Validate children: exactly one JSX child (element or expression).
+	const childNodes = ( el.children || [] ).filter( ( c ) => {
+		if ( c.type === 'JSXText' ) {
+			return c.value.trim() !== '';
+		}
+		if (
+			c.type === 'JSXExpressionContainer' &&
+			c.expression.type === 'JSXEmptyExpression'
+		) {
+			return false;
+		}
+		return true;
+	} );
+	if ( childNodes.length !== 1 ) {
+		return {
+			kind: 'bailout',
+			reason: `bailout: expected exactly one child, got ${ childNodes.length }`,
+		};
+	}
+
+	const child = childNodes[ 0 ];
+	let triggerRenderArg = null;
+	if ( child.type === 'JSXElement' ) {
+		triggerRenderArg = child;
+	} else if ( child.type === 'JSXExpressionContainer' ) {
+		triggerRenderArg = child.expression;
+	} else if ( child.type === 'JSXFragment' ) {
+		return { kind: 'bailout', reason: `bailout: child is a JSX fragment` };
+	} else {
+		return {
+			kind: 'bailout',
+			reason: `bailout: child has unexpected type ${ child.type }`,
+		};
+	}
+
+	// `text` must be present (otherwise the legacy tooltip wouldn't render).
+	const textValue = propMap.text;
+	if ( ! textValue ) {
+		return {
+			kind: 'bailout',
+			reason: `bailout: <${ sourceName }> without \`text\``,
+		};
+	}
+
+	// Compute the textual content of the Popup. Accept string literal or
+	// JSX expression container.
+	let popupChild;
+	if ( textValue.type === 'StringLiteral' || textValue.type === 'Literal' ) {
+		popupChild = j.jsxText( textValue.value );
+	} else if ( textValue.type === 'JSXExpressionContainer' ) {
+		popupChild = textValue;
+	} else {
+		return {
+			kind: 'bailout',
+			reason: `bailout: unrecognized \`text\` attribute value type ${ textValue.type }`,
+		};
+	}
+
+	// Compute placement → positioner.
+	let positionerAttr = null;
+	const placementAttr = propMap.placement;
+	if ( placementAttr ) {
+		let placement = null;
+		if (
+			placementAttr.type === 'StringLiteral' ||
+			placementAttr.type === 'Literal'
+		) {
+			placement = placementAttr.value;
+		} else if ( placementAttr.type === 'JSXExpressionContainer' ) {
+			// Only inline literal expressions like {'top'} are supported.
+			const expr = placementAttr.expression;
+			if ( expr.type === 'StringLiteral' || expr.type === 'Literal' ) {
+				placement = expr.value;
+			} else {
+				return {
+					kind: 'bailout',
+					reason: `bailout: dynamic \`placement\` value not statically resolvable`,
+				};
+			}
+		}
+		if ( placement && placement !== 'top' ) {
+			const mapping = PLACEMENT_TO_SIDE_ALIGN[ placement ];
+			if ( ! mapping ) {
+				return {
+					kind: 'bailout',
+					reason: `bailout: unknown placement \`${ placement }\``,
+				};
+			}
+			const sideAttr = j.jsxAttribute(
+				j.jsxIdentifier( 'side' ),
+				j.stringLiteral( mapping.side )
+			);
+			const positionerAttrs = [ sideAttr ];
+			if ( mapping.align !== 'center' ) {
+				positionerAttrs.push(
+					j.jsxAttribute(
+						j.jsxIdentifier( 'align' ),
+						j.stringLiteral( mapping.align )
+					)
+				);
+			}
+			positionerAttr = j.jsxAttribute(
+				j.jsxIdentifier( 'positioner' ),
+				j.jsxExpressionContainer(
+					j.jsxElement(
+						j.jsxOpeningElement(
+							j.jsxMemberExpression(
+								j.jsxIdentifier( targetName ),
+								j.jsxIdentifier( 'Positioner' )
+							),
+							positionerAttrs,
+							true
+						),
+						null,
+						[]
+					)
+				)
+			);
+		}
+	}
+
+	// Build <Tooltip.Trigger render={ child } />
+	const triggerAttrs = [
+		j.jsxAttribute(
+			j.jsxIdentifier( 'render' ),
+			j.jsxExpressionContainer( triggerRenderArg )
+		),
+	];
+	const trigger = j.jsxElement(
+		j.jsxOpeningElement(
+			j.jsxMemberExpression(
+				j.jsxIdentifier( targetName ),
+				j.jsxIdentifier( 'Trigger' )
+			),
+			triggerAttrs,
+			true
+		),
+		null,
+		[]
+	);
+
+	// Build <Tooltip.Popup [positioner] [className]>{ text }</Tooltip.Popup>
+	const popupAttrs = [];
+	if ( positionerAttr ) {
+		popupAttrs.push( positionerAttr );
+	}
+	if ( propMap.className ) {
+		popupAttrs.push(
+			j.jsxAttribute( j.jsxIdentifier( 'className' ), propMap.className )
+		);
+	}
+	const popup = j.jsxElement(
+		j.jsxOpeningElement(
+			j.jsxMemberExpression(
+				j.jsxIdentifier( targetName ),
+				j.jsxIdentifier( 'Popup' )
+			),
+			popupAttrs,
+			false
+		),
+		j.jsxClosingElement(
+			j.jsxMemberExpression(
+				j.jsxIdentifier( targetName ),
+				j.jsxIdentifier( 'Popup' )
+			)
+		),
+		[ popupChild ]
+	);
+
+	// Build <Tooltip.Root [key]>{trigger}{popup}</Tooltip.Root>
+	const rootAttrs = [];
+	if ( propMap.key ) {
+		rootAttrs.push(
+			j.jsxAttribute( j.jsxIdentifier( 'key' ), propMap.key )
+		);
+	}
+	const newRoot = j.jsxElement(
+		j.jsxOpeningElement(
+			j.jsxMemberExpression(
+				j.jsxIdentifier( targetName ),
+				j.jsxIdentifier( 'Root' )
+			),
+			rootAttrs,
+			false
+		),
+		j.jsxClosingElement(
+			j.jsxMemberExpression(
+				j.jsxIdentifier( targetName ),
+				j.jsxIdentifier( 'Root' )
+			)
+		),
+		[ trigger, popup ]
+	);
+
+	return { kind: 'ok', node: newRoot };
+}
+
+module.exports.parser = 'tsx';


### PR DESCRIPTION
## What?

Follow up to #78095.

Migrates **7 consumer call sites** in `@wordpress/block-directory` and `@wordpress/block-editor` from the legacy `Tooltip` (`@wordpress/components`) to the new compositional `Tooltip` (`@wordpress/ui`, built on base-ui). Part 1 of a 5-PR series; also lands the one-shot jscodeshift codemod used across the whole series.

<details>
<summary>Sites migrated in this PR</summary>

- `block-directory/components/downloadable-block-list-item`
- `block-editor/components/block-patterns-list` (`WithToolTip`)
- `block-editor/components/global-styles/shadow-panel-components`
- `block-editor/components/inserter/media-tab/media-preview`
- `block-editor/components/inspector-controls-tabs`
- `block-editor/components/list-view/block-select-button` — *non-interactive `<span aria-hidden>` trigger; the `visibilityLabel` it shows was already not exposed to AT before this PR (flagged for a11y follow-up — see Notes)*
- `block-editor/components/preset-input-control/custom-value-controls`

</details>

<details>
<summary>Full 5-PR plan</summary>

1. **block-editor + block-directory ← this PR** (also lands the codemod)
2. editor + edit-post + edit-site (+ shell-level `Tooltip.Provider`)
3. dataviews
4. fields + media-editor + media-fields + global-styles-ui
5. boot (+ manual save-button + shell-level `Tooltip.Provider`)

</details>

## Why?

#78095 introduced the new compositional `Tooltip` API in `@wordpress/ui`. This PR series migrates all consumers outside `@wordpress/components` itself to the new API, so that future tooltip work (delays, providers, positioner, base-ui upgrades) can happen in one place.

> [!NOTE]
> Call sites *inside* `@wordpress/components` (notably `Button`'s internal Tooltip and `TooltipInternalContext`) stay on the legacy implementation — tracked as a separate follow-up.

## How?

Each `<Tooltip>` is rewritten to the compositional API. The mechanical rewrite is automated by a jscodeshift codemod added in this PR; the few sites the codemod can't safely handle (`shortcut`, dynamic `placement`, multi-child, …) are finished by hand in later PRs.

<details>
<summary>API mapping</summary>

```tsx
// Before
<Tooltip text="…" placement="top-end" className="…">
  <Anchor … />
</Tooltip>

// After
<Tooltip.Root>
  <Tooltip.Trigger render={ <Anchor … /> } />
  <Tooltip.Popup
    positioner={ <Tooltip.Positioner side="top" align="end" /> }
    className="…"
  >
    …
  </Tooltip.Popup>
</Tooltip.Root>
```

The new `Tooltip.Trigger` defaults to a `<button>` and supports non-button anchors via the `render` prop (base-ui takes over event/ref wiring on the rendered element — no double wrapping).

</details>

<details>
<summary>Codemod</summary>

```sh
npx jscodeshift -t tools/codemods/tooltip-components-to-ui.js \
    --extensions=js,jsx,ts,tsx --parser=tsx \
    packages/<scope>
```

- Rewrites the `Tooltip` specifier (named or aliased, e.g. `Tooltip as WCTooltip`) from `@wordpress/components` to `import { Tooltip } from '@wordpress/ui'`.
- For each `<Tooltip>…</Tooltip>` JSX usage, emits `<Tooltip.Root [key]><Tooltip.Trigger render={ child } /><Tooltip.Popup [positioner] [className]>{ text }</Tooltip.Popup></Tooltip.Root>`.
- Bails (leaves the **entire file** untouched, logs a warning) when *any* usage in the file is unconvertible: multi-child, `shortcut`, `delay`, `hideOnClick`, `position`, spread attributes, dynamic placements, or any unknown attribute.

The codemod is a one-shot artifact; it can be removed once the 5-PR series merges.

</details>

<details>
<summary>Notes</summary>

- No per-call-site `Tooltip.Provider` is emitted. Group coordination (instant-open after the first tooltip in a group) is handled by a single shell-level `<Tooltip.Provider>` introduced in PRs 2 and 5.
- `aria-describedby` is no longer injected into triggers — the new tooltips are visual-only. Reviewers may want to flag specific sites for `Popover` + `openOnHover` follow-up.
- `Tooltip` from `@wordpress/ui` is not yet on the `@wordpress/use-recommended-components` allow-list. Each migrated import carries a per-site `// eslint-disable-next-line @wordpress/use-recommended-components` directive (rather than allowlisting `Tooltip` globally) so the Storybook recommendation will be flipped once the new `Tooltip` has bedded in.
- `block-select-button` `visibilityLabel`: the legacy code attached the tooltip to a `<span aria-hidden="true">…</span>` trigger, which made the label unreachable for screen readers regardless of `aria-describedby` injection. This PR preserves that pre-existing behaviour (no regression introduced) and adds an inline `TODO` next to the site flagging the bug for a separate a11y fix.

</details>

## Testing Instructions

1. Open Storybook → *Playground / WP Compat Overlay Slot / Tooltip inside @wordpress/components Modal* and confirm the new tooltips portal into `[data-wp-compat-overlay-slot]` so they stack above components overlays (cross-library check from #78095).
2. Hover each migrated trigger listed above and verify the popup appears with the expected text and placement.
3. `npm run test:unit -- packages/block-editor packages/block-directory` — Jest unit tests should pass.

### Testing Instructions for Keyboard

1. Tab to each migrated interactive trigger (button, `Tabs.Tab`, `Composite.Item`, etc.) and confirm the tooltip opens on focus and closes on blur / `Esc`.
2. The non-interactive `<span aria-hidden>` trigger in `list-view/block-select-button` is **not** keyboard-reachable on purpose; flagged above for a11y follow-up.

## Screenshots or screencast

No visual change is intended versus the legacy `Tooltip` (same placement, same text, same hover/focus behaviour). N/A.

## Use of AI Tools

This PR was authored with assistance from Cursor (Claude). All changes were reviewed by a human before being committed; the codemod and migrated files were also exercised locally (Jest, lint, Prettier) before being pushed.

