### PR TITLE
Fixed additional issues with block registration types

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -635,7 +635,7 @@ registerBlockType( 'namespace/block-name', {
 _Parameters_
 
 -   _blockNameOrMetadata_ `string | BlockConfiguration< Attributes >`: Block type name or its metadata.
--   _settings_ `Partial< BlockConfiguration< Attributes > >`: Block settings.
+-   _settings_ `Partial< SettingsBlockConfiguration< Attributes > >`: Block settings.
 
 _Returns_
 

--- a/packages/blocks/src/api/registration.ts
+++ b/packages/blocks/src/api/registration.ts
@@ -100,6 +100,10 @@ function getBlockSettingsFromMetadata( {
 	return settings;
 }
 
+type SettingsBlockConfiguration<
+	Attributes extends Record< string, unknown > = Record< string, unknown >,
+> = Omit< BlockConfiguration< Attributes >, 'name' > & { name?: unknown };
+
 /**
  * Registers a new block provided a unique name and an object defining its
  * behavior. Once registered, the block is made available as an option to any
@@ -130,19 +134,19 @@ export function registerBlockType<
 	Attributes extends Record< string, unknown > = Record< string, unknown >,
 >(
 	blockNameOrMetadata: BlockConfiguration< Attributes >,
-	settings?: Partial< BlockConfiguration< Attributes > >
+	settings?: Partial< SettingsBlockConfiguration< Attributes > >
 ): BlockType | undefined;
 export function registerBlockType<
 	Attributes extends Record< string, unknown > = Record< string, unknown >,
 >(
 	blockNameOrMetadata: string,
-	settings: BlockConfiguration< Attributes >
+	settings: SettingsBlockConfiguration< Attributes >
 ): BlockType | undefined;
 export function registerBlockType<
 	Attributes extends Record< string, unknown > = Record< string, unknown >,
 >(
 	blockNameOrMetadata: string | BlockConfiguration< Attributes >,
-	settings?: Partial< BlockConfiguration< Attributes > >
+	settings?: Partial< SettingsBlockConfiguration< Attributes > >
 ): BlockType | undefined {
 	const name = isObject( blockNameOrMetadata )
 		? blockNameOrMetadata.name

--- a/packages/blocks/src/api/registration.ts
+++ b/packages/blocks/src/api/registration.ts
@@ -100,6 +100,10 @@ function getBlockSettingsFromMetadata( {
 	return settings;
 }
 
+/**
+ * This acts as an intermediate type to explicitly note that the "name" property
+ * will be ignored if passed into the settings argument
+ */
 type SettingsBlockConfiguration<
 	Attributes extends Record< string, unknown > = Record< string, unknown >,
 > = Omit< BlockConfiguration< Attributes >, 'name' > & { name?: unknown };

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -222,14 +222,14 @@ export interface BlockType<
 	 *
 	 * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-script
 	 */
-	editorScript?: string;
+	editorScript?: string | string[];
 	/**
 	 * Block type editor style definition.
 	 * It will only be enqueued in the context of the editor.
 	 *
 	 * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-style
 	 */
-	editorStyle?: string;
+	editorStyle?: string | string[];
 	/**
 	 * Example provides structured data for the block preview.
 	 * When not defined then no preview is shown.
@@ -295,7 +295,7 @@ export interface BlockType<
 	 *
 	 * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#script
 	 */
-	script?: string;
+	script?: string | string[];
 	/**
 	 * Block type frontend style definition.
 	 * It will be enqueued both in the editor and when viewing
@@ -303,7 +303,7 @@ export interface BlockType<
 	 *
 	 * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#style
 	 */
-	style?: string;
+	style?: string | string[];
 	/**
 	 * Block type frontend script definition.
 	 * It will only be enqueued when viewing the content on
@@ -311,7 +311,7 @@ export interface BlockType<
 	 *
 	 * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script
 	 */
-	viewScript?: string;
+	viewScript?: string | string[];
 	/**
 	 * Block type frontend module script definition.
 	 * It will only be enqueued when viewing the content on
@@ -319,7 +319,7 @@ export interface BlockType<
 	 *
 	 * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script-module
 	 */
-	viewScriptModule?: string;
+	viewScriptModule?: string | string[];
 	/**
 	 * Block type view style definition.
 	 * It will only be enqueued when viewing the content on
@@ -327,7 +327,7 @@ export interface BlockType<
 	 *
 	 * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-style
 	 */
-	viewStyle?: string;
+	viewStyle?: string | string[];
 	/**
 	 * PHP file to use when rendering the block type on the server
 	 * to show on the front end.
@@ -1205,8 +1205,11 @@ export interface BlockEditProps<
  */
 export type BlockConfiguration<
 	Attributes extends Record< string, unknown > = Record< string, unknown >,
-> = Partial< Omit< BlockType< Attributes >, 'icon' > > &
-	Pick< BlockType< Attributes >, 'attributes' | 'category' | 'title' > & {
+> = Partial< Omit< BlockType< Attributes >, 'icon' | 'name' > > &
+	Pick<
+		BlockType< Attributes >,
+		'attributes' | 'category' | 'title' | 'name'
+	> & {
 		icon?: BlockTypeIcon;
 	};
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #78415

Updates the types to match what is missing.

## Why?
The types are currently incorrect.

## How?
- I made name mandatory and separated out the types for the settings parameter from the standard BlockConfiguration parameter
- I added "| string[]" to every script/style type

## Testing Instructions
- Try to compile the code

## Use of AI Tools
- I don't use AI tools