### PR TITLE
Tabs, TabPanel: Align styles with wp-ui

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   `Tabs`, `TabPanel`: Align selected tab colors and indicators with `@wordpress/ui` `Tabs` ([#78418](https://github.com/WordPress/gutenberg/pull/78418)).
 -   `Draggable`: Render the drag clone inside the `@wordpress/ui` compat overlay slot so it shares stacking with `@wordpress/ui` overlays opened mid-drag. Auto-enabled in WordPress environments; other hosts can opt in via `useEnableWpCompatOverlaySlot()` ([#78183](https://github.com/WordPress/gutenberg/pull/78183), [#78354](https://github.com/WordPress/gutenberg/pull/78354)).
 
 ## 33.1.0 (2026-05-14)

--- a/packages/components/src/tab-panel/style.scss
+++ b/packages/components/src/tab-panel/style.scss
@@ -18,9 +18,9 @@
 	border: none;
 	box-shadow: none;
 	cursor: var(--wpds-cursor-control);
-	padding: 3px $grid-unit-20; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
+	padding: 3px var(--wpds-dimension-padding-lg); // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	margin-left: 0;
-	font-weight: $font-weight-regular;
+	font-weight: var(--wpds-typography-font-weight-regular);
 	color: var(--wpds-color-fg-interactive-neutral);
 
 	&:disabled,
@@ -71,15 +71,12 @@
 	&::before {
 		content: "";
 		position: absolute;
-		top: $grid-unit-15;
-		right: $grid-unit-15;
-		bottom: $grid-unit-15;
-		left: $grid-unit-15;
+		inset: var(--wpds-dimension-padding-md);
 		pointer-events: none;
 
 		// Draw the indicator.
 		box-shadow: 0 0 0 0 transparent;
-		border-radius: $radius-small;
+		border-radius: var(--wpds-border-radius-sm);
 
 		// Animation
 		@media not (prefers-reduced-motion) {
@@ -97,7 +94,7 @@
 	}
 
 	.components-tab-panel__tabs[aria-orientation="vertical"] & {
-		border-radius: $radius-small;
+		border-radius: var(--wpds-border-radius-sm);
 
 		&::after {
 			display: none;

--- a/packages/components/src/tab-panel/style.scss
+++ b/packages/components/src/tab-panel/style.scss
@@ -1,11 +1,10 @@
-@use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
-@use "../utils/theme-variables" as *;
 
 .components-tab-panel__tabs {
 	display: flex;
 	align-items: stretch;
 	flex-direction: row;
+
 	&[aria-orientation="vertical"] {
 		flex-direction: column;
 	}
@@ -22,6 +21,16 @@
 	padding: 3px $grid-unit-20; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	margin-left: 0;
 	font-weight: $font-weight-regular;
+	color: var(--wpds-color-fg-interactive-neutral);
+
+	&:disabled,
+	&[aria-disabled="true"] {
+		color: var(--wpds-color-fg-interactive-neutral-disabled);
+	}
+
+	&:not(:disabled, [aria-disabled="true"]):is(:hover, :focus-visible) {
+		color: var(--wpds-color-fg-interactive-neutral-active);
+	}
 
 	&:focus:not(:disabled) {
 		position: relative;
@@ -39,7 +48,7 @@
 		pointer-events: none;
 
 		// Draw the indicator.
-		background: $components-color-accent;
+		background: var(--wpds-color-stroke-interactive-neutral-strong);
 		height: calc(0 * var(--wp-admin-border-width-focus));
 		border-radius: 0;
 
@@ -79,10 +88,24 @@
 	}
 
 	&:focus-visible::before {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
+		box-shadow:
+			0 0 0 var(--wp-admin-border-width-focus)
+			var(--wpds-color-stroke-focus-brand);
 
 		// Windows high contrast mode.
 		outline: 2px solid transparent;
+	}
+
+	.components-tab-panel__tabs[aria-orientation="vertical"] & {
+		border-radius: $radius-small;
+
+		&::after {
+			display: none;
+		}
+
+		&.is-active {
+			background: var(--wpds-color-bg-interactive-neutral-weak-active);
+		}
 	}
 }
 
@@ -93,7 +116,9 @@
 	}
 
 	&:focus-visible {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
+		box-shadow:
+			0 0 0 var(--wp-admin-border-width-focus)
+			var(--wpds-color-stroke-focus-brand);
 
 		// Windows high contrast mode.
 		outline: 2px solid transparent;

--- a/packages/components/src/tab-panel/style.scss
+++ b/packages/components/src/tab-panel/style.scss
@@ -49,7 +49,7 @@
 
 		// Draw the indicator.
 		background: var(--wpds-color-stroke-interactive-neutral-strong);
-		height: calc(0 * var(--wp-admin-border-width-focus));
+		height: calc(0 * var(--wpds-border-width-focus));
 		border-radius: 0;
 
 		// Animation
@@ -60,7 +60,7 @@
 
 	// Active.
 	&.is-active::after {
-		height: calc(1 * var(--wp-admin-border-width-focus));
+		height: calc(1 * var(--wpds-border-width-focus));
 
 		// Windows high contrast mode.
 		outline: 2px solid transparent;
@@ -89,7 +89,7 @@
 
 	&:focus-visible::before {
 		box-shadow:
-			0 0 0 var(--wp-admin-border-width-focus)
+			0 0 0 var(--wpds-border-width-focus)
 			var(--wpds-color-stroke-focus-brand);
 
 		// Windows high contrast mode.
@@ -117,7 +117,7 @@
 
 	&:focus-visible {
 		box-shadow:
-			0 0 0 var(--wp-admin-border-width-focus)
+			0 0 0 var(--wpds-border-width-focus)
 			var(--wpds-color-stroke-focus-brand);
 
 		// Windows high contrast mode.

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -99,7 +99,7 @@ export const StyledTabList = styled( Ariakit.TabList )`
 					)
 				);
 			border-bottom: var( --wp-admin-border-width-focus ) solid
-				${ COLORS.theme.accent };
+				${ COLORS.theme.gray[ 700 ] };
 		}
 	}
 	&[aria-orientation='vertical'] {
@@ -124,11 +124,7 @@ export const StyledTabList = styled( Ariakit.TabList )`
 							var( --antialiasing-factor )
 					)
 				);
-			background-color: color-mix(
-				in srgb,
-				${ COLORS.theme.accent },
-				transparent 96%
-			);
+			background-color: ${ COLORS.theme.gray[ 100 ] };
 		}
 		&[data-select-on-move='true']:has(
 				:is( :focus-visible, [data-focus-visible] )
@@ -173,7 +169,7 @@ export const Tab = styled( Ariakit.Tab )`
 		}
 
 		&:not( [aria-disabled='true'] ):is( :hover, [data-focus-visible] ) {
-			color: ${ COLORS.theme.accent };
+			color: ${ COLORS.theme.foreground };
 		}
 
 		&:focus:not( :disabled ) {
@@ -222,7 +218,6 @@ export const Tab = styled( Ariakit.Tab )`
 		min-height: ${ space( 10 ) };
 
 		&[aria-selected='true'] {
-			color: ${ COLORS.theme.accent };
 			fill: currentColor;
 		}
 	}


### PR DESCRIPTION
## What?

Part of #76135

Updates the selected tab colors and indicator styles in `@wordpress/components` `Tabs` and `TabPanel` to better match `@wordpress/ui` `Tabs`.

## Why?

So it's less jarring for users during the transition phase with mixed usage of the components.

## How?
- Changes selected `Tabs` indicators from accent/brand styling to neutral colors.
- Updates `TabPanel` tab text, selected indicator, vertical selected state, and focus ring styles to use the corresponding design system tokens.
- Replaces several legacy Sass variables in `TabPanel` styles with design system tokens.

## Testing Instructions
1. Open Storybook for `Components/TabPanel` and `Components/Tabs`.
2. Confirm the selected tab indicator uses neutral styling instead of the blue brand accent.
3. Confirm focus rings still use the brand focus color.
4. Confirm disabled, hover, and vertical selected tab states still render as expected.

## Screenshots or screencast
| Before | After |
|--------|-------|
|<img width="462" height="266" alt="horizontal tabs, before" src="https://github.com/user-attachments/assets/42df6e80-2ca1-4af2-9410-3d0f2cc6bc95" />|<img width="462" height="266" alt="horizontal tabs, after" src="https://github.com/user-attachments/assets/2449997c-c257-4f61-857f-80349956dad4" />|

| Before | After |
|--------|-------|
|<img width="364" height="276" alt="vertical tabs, before" src="https://github.com/user-attachments/assets/78b2a965-e8c9-4f0b-b356-ae17cad377f3" />|<img width="366" height="278" alt="vertical tabs, after" src="https://github.com/user-attachments/assets/9a239485-543e-44bd-bc8b-d605673d2e6a" />|

