### PR TITLE
DataViewsPicker Table: Fix first-click row selection

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+- DataViewsPicker: Fix first-click row selection in the table layout being swallowed by Ariakit's focus shift, which also scrolled the active row under the sticky header. [#78423](https://github.com/WordPress/gutenberg/pull/78423)
 - DataViews: Restore the `padding` rule on grid item titles that was lost when the wrapping element's class was renamed. [#75204](https://github.com/WordPress/gutenberg/pull/75204)
 - DataViews: Restore the original 16px padding on the first/last table header cells (had drifted to 32px during the token migration). [#75204](https://github.com/WordPress/gutenberg/pull/75204)
 - DataViews: Restore the original 4px gap inside table header buttons (had drifted to 8px during the token migration). [#75204](https://github.com/WordPress/gutenberg/pull/75204)

--- a/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
@@ -143,14 +143,21 @@ function TableRow< Item >( {
 			aria-posinset={ posinset }
 			role={ infiniteScrollEnabled ? 'article' : 'option' }
 			onMouseDown={ ( event ) => {
-				// Prevent the browser from moving focus to the row on click.
-				// Without this, Ariakit's first focus into the Composite calls
+				if ( event.button !== 0 ) {
+					return;
+				}
+				// Prevent the browser from moving focus to the row. Without
+				// this, Ariakit's first focus into the Composite calls
 				// `baseElement.focus()` without `preventScroll`, which both
 				// swallows the click and scrolls the active row under the
 				// sticky table header.
-				if ( event.button === 0 ) {
-					event.preventDefault();
-				}
+				event.preventDefault();
+				// Still put focus on the Composite container (the parent
+				// `tbody`) so keyboard navigation is available after click.
+				// `preventScroll` avoids the scroll the browser would
+				// otherwise apply when focus moves.
+				const composite = event.currentTarget.parentElement;
+				composite?.focus( { preventScroll: true } );
 			} }
 			onClick={ () => {
 				// Toggle in/out of selection array

--- a/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
@@ -146,18 +146,16 @@ function TableRow< Item >( {
 				if ( event.button !== 0 ) {
 					return;
 				}
-				// Prevent the browser from moving focus to the row. Without
-				// this, Ariakit's first focus into the Composite calls
-				// `baseElement.focus()` without `preventScroll`, which both
-				// swallows the click and scrolls the active row under the
-				// sticky table header.
-				event.preventDefault();
-				// Still put focus on the Composite container (the parent
-				// `tbody`) so keyboard navigation is available after click.
-				// `preventScroll` avoids the scroll the browser would
-				// otherwise apply when focus moves.
-				const composite = event.currentTarget.parentElement;
-				composite?.focus( { preventScroll: true } );
+				// Pre-focus the Composite container (parent `tbody`) so that
+				// when the row is focused on click, Ariakit sees the focus
+				// coming from within the Composite and uses `focusSilently`
+				// (which passes `preventScroll: true`). Without this, the
+				// first focus into the Composite scrolls the active row
+				// under the sticky table header, which also causes the click
+				// to land on a different element than the original target.
+				event.currentTarget.parentElement?.focus( {
+					preventScroll: true,
+				} );
 			} }
 			onClick={ () => {
 				// Toggle in/out of selection array

--- a/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
@@ -153,6 +153,7 @@ function TableRow< Item >( {
 				}
 			} }
 			onClick={ () => {
+				// Toggle in/out of selection array
 				if ( isSelected ) {
 					onChangeSelection(
 						selection.filter( ( itemId ) => id !== itemId )

--- a/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
@@ -142,8 +142,15 @@ function TableRow< Item >( {
 			aria-setsize={ paginationInfo.totalItems || undefined }
 			aria-posinset={ posinset }
 			role={ infiniteScrollEnabled ? 'article' : 'option' }
-			onClick={ () => {
-				// Toggle in/out of selection array
+			onMouseDown={ ( event ) => {
+				if ( event.button !== 0 ) {
+					return;
+				}
+				// Prevent the browser from moving focus to the row. Without
+				// this, Ariakit's first focus into the Composite calls
+				// `baseElement.focus()` without `preventScroll`, which
+				// scrolls the active row under the sticky table header.
+				event.preventDefault();
 				if ( isSelected ) {
 					onChangeSelection(
 						selection.filter( ( itemId ) => id !== itemId )

--- a/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
@@ -143,14 +143,16 @@ function TableRow< Item >( {
 			aria-posinset={ posinset }
 			role={ infiniteScrollEnabled ? 'article' : 'option' }
 			onMouseDown={ ( event ) => {
-				if ( event.button !== 0 ) {
-					return;
+				// Prevent the browser from moving focus to the row on click.
+				// Without this, Ariakit's first focus into the Composite calls
+				// `baseElement.focus()` without `preventScroll`, which both
+				// swallows the click and scrolls the active row under the
+				// sticky table header.
+				if ( event.button === 0 ) {
+					event.preventDefault();
 				}
-				// Prevent the browser from moving focus to the row. Without
-				// this, Ariakit's first focus into the Composite calls
-				// `baseElement.focus()` without `preventScroll`, which
-				// scrolls the active row under the sticky table header.
-				event.preventDefault();
+			} }
+			onClick={ () => {
 				if ( isSelected ) {
 					onChangeSelection(
 						selection.filter( ( itemId ) => id !== itemId )

--- a/packages/dataviews/src/components/dataviews-layouts/picker-table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-table/style.scss
@@ -10,6 +10,14 @@
 		width: calc(var(--wpds-dimension-base) * 12);
 	}
 
+	// When focus enters the tbody (e.g. tabbing into the table), the
+	// browser scrolls it into view by default. Without margin, the sticky
+	// `thead` would obscure the first row. The value is a generous
+	// approximation of the header height.
+	tbody {
+		scroll-margin-top: calc(var(--wpds-dimension-base) * 10);
+	}
+
 	tbody:focus-visible {
 		// Only show one focus outline at a time. When focus is on a child element,
 		// hide the table's own focus outline.

--- a/packages/dataviews/src/components/dataviews-layouts/picker-table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-table/style.scss
@@ -10,14 +10,6 @@
 		width: calc(var(--wpds-dimension-base) * 12);
 	}
 
-	// When focus enters the tbody (e.g. tabbing into the table), the
-	// browser scrolls it into view by default. Without margin, the sticky
-	// `thead` would obscure the first row. The value is a generous
-	// approximation of the header height.
-	tbody {
-		scroll-margin-top: calc(var(--wpds-dimension-base) * 10);
-	}
-
 	tbody:focus-visible {
 		// Only show one focus outline at a time. When focus is on a child element,
 		// hide the table's own focus outline.


### PR DESCRIPTION
## Summary

In the picker-table layout, the first click on a row was swallowed and scrolled the active row out from under the sticky `<thead>`. On first focus into the Composite, Ariakit calls `baseElement.focus()` without `preventScroll` — which both ate the click and shifted the scroll.

Handle selection on `onMouseDown` and `preventDefault()` so the browser never moves focus to the row. Subsequent rendered focus is managed by Ariakit on the Composite container, as before.


### Before


https://github.com/user-attachments/assets/c18c64e0-1f57-4302-b7c5-289bfdd763cf



### After


https://github.com/user-attachments/assets/1a009f80-cfbf-4589-a7e5-63668130ddb4




## Test plan

- [ ] Open a post with an image block, click *Replace* → *Open Media Library*.
- [ ] Switch the modal to **Table** layout.
- [ ] Click any row (including the top row). It should select on the first click, and the table should not scroll.
- [ ] Repeat with a row that's already selected (the post's current image) — it should deselect on first click.
- [ ] Keyboard nav: Tab into the table, arrow up/down between rows, Enter/Space to select — should still work.