### PR TITLE
Editor: Fix the view Revisions menu item to show editor revisions page

### DIFF
--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `MediaEdit`: Decode HTML entities when displaying attachment titles. ([#81269](https://github.com/WordPress/gutenberg/pull/81269))
+-   `viewPostRevisions`: Open the visual revisions view in the site editor instead of the classic revisions screen ([#78424](https://github.com/WordPress/gutenberg/pull/78424)).
 
 ### Internal
 

--- a/packages/fields/src/actions/view-post-revisions.tsx
+++ b/packages/fields/src/actions/view-post-revisions.tsx
@@ -30,6 +30,8 @@ const viewPostRevisions: Action< Post > = {
 	},
 	callback( posts, { onActionPerformed } ) {
 		const post = posts[ 0 ];
+		const lastRevisionId =
+			post?._links?.[ 'predecessor-version' ]?.[ 0 ]?.id;
 		const isSiteEditor = getPath( window.location.href )?.includes(
 			'site-editor.php'
 		);
@@ -37,10 +39,10 @@ const viewPostRevisions: Action< Post > = {
 			? addQueryArgs( 'site-editor.php', {
 					p: `/${ post.type }/${ post.id }`,
 					canvas: 'edit',
+					revision: lastRevisionId,
 			  } )
 			: addQueryArgs( 'revision.php', {
-					revision:
-						post?._links?.[ 'predecessor-version' ]?.[ 0 ]?.id,
+					revision: lastRevisionId,
 			  } );
 		document.location.href = href;
 		if ( onActionPerformed ) {

--- a/packages/fields/src/actions/view-post-revisions.tsx
+++ b/packages/fields/src/actions/view-post-revisions.tsx
@@ -1,4 +1,7 @@
-import { addQueryArgs } from '@wordpress/url';
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs, getPath } from '@wordpress/url';
 import { __, sprintf } from '@wordpress/i18n';
 import type { Action } from '@wordpress/dataviews';
 import type { Post } from '../types';
@@ -27,9 +30,18 @@ const viewPostRevisions: Action< Post > = {
 	},
 	callback( posts, { onActionPerformed } ) {
 		const post = posts[ 0 ];
-		const href = addQueryArgs( 'revision.php', {
-			revision: post?._links?.[ 'predecessor-version' ]?.[ 0 ]?.id,
-		} );
+		const isSiteEditor = getPath( window.location.href )?.includes(
+			'site-editor.php'
+		);
+		const href = isSiteEditor
+			? addQueryArgs( 'site-editor.php', {
+					p: `/${ post.type }/${ post.id }`,
+					canvas: 'edit',
+			  } )
+			: addQueryArgs( 'revision.php', {
+					revision:
+						post?._links?.[ 'predecessor-version' ]?.[ 0 ]?.id,
+			  } );
 		document.location.href = href;
 		if ( onActionPerformed ) {
 			onActionPerformed( posts );

--- a/packages/fields/src/actions/view-post-revisions.tsx
+++ b/packages/fields/src/actions/view-post-revisions.tsx
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import { addQueryArgs, getPath } from '@wordpress/url';
 import { __, sprintf } from '@wordpress/i18n';
 import type { Action } from '@wordpress/dataviews';

--- a/test/e2e/specs/site-editor/revisions.spec.js
+++ b/test/e2e/specs/site-editor/revisions.spec.js
@@ -164,4 +164,65 @@ test.describe( 'Site editor revisions shareable URLs', () => {
 			null
 		);
 	} );
+
+	test( 'should open the newest revision from the pages list action', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/pages',
+			data: {
+				title: 'Revisions action page',
+				content:
+					'<!-- wp:paragraph --><p>Original content</p><!-- /wp:paragraph -->',
+				status: 'publish',
+			},
+		} );
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/pages/${ post.id }`,
+			data: {
+				content:
+					'<!-- wp:paragraph --><p>First revision</p><!-- /wp:paragraph -->',
+			},
+		} );
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/pages/${ post.id }`,
+			data: {
+				content:
+					'<!-- wp:paragraph --><p>Second revision</p><!-- /wp:paragraph -->',
+			},
+		} );
+
+		const revisions = await requestUtils.rest( {
+			path: `/wp/v2/pages/${ post.id }/revisions`,
+		} );
+		const newestRevisionId = revisions[ 0 ].id;
+
+		// Open the pages list directly. Clicking through the navigation panel
+		// races with it rendering.
+		await admin.visitSiteEditor( { postType: 'page' } );
+		await page
+			.getByRole( 'row', { name: 'Revisions action page' } )
+			.getByLabel( 'Actions' )
+			.click();
+		await page.getByRole( 'menuitem', { name: 'View revisions' } ).click();
+
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeVisible();
+
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Modified block: Paragraph',
+			} )
+		).toContainText( 'Second revision' );
+		expect( new URL( page.url() ).searchParams.get( 'revision' ) ).toBe(
+			String( newestRevisionId )
+		);
+	} );
 } );


### PR DESCRIPTION
## What? Why?
Closes #78414

Fixes the "View revisions" action in the site editor page list so it opens the visual revisions view on the page's latest revision, instead of the classic `revision.php` screen.

This was blocked until #79934 made visual revisions linkable; that's now merged, so the action can deep link straight into them.

## How?
The `view-post-revisions` callback branches on the current page's URL. In the site editor it now appends `revision=<id>`, taken from the post's `predecessor-version` link (the latest revision), which the editor opens on load. Classic contexts still go to `revision.php`.

## Testing Instructions
1. Go to **Appearance → Editor**.
2. Navigate to **Pages**.
3. Select a page with at least two revisions in the DataViews list (do not open/edit it).
4. Click the kebab (⋮) menu and choose **View revisions**.
5. Confirm the URL navigates to `site-editor.php?p=%2Fpage%2F{id}&canvas=edit&revision={id}`
   and the page opens in the revisions view, showing the most recent revision.
6. Also verify that "View revisions" from a classic admin context (e.g. Posts list
   in wp-admin) still redirects to `revision.php` as before.

An e2e test covering the site editor path is included in `test/e2e/specs/site-editor/revisions.spec.js`.

## Screenshots or screencast

### Before

Navigates to `revision.php?revision=274`

https://github.com/user-attachments/assets/88d6d00b-5743-4636-bd86-4295bc6d5e6b

### After

Navigates to `site-editor.php?p=%2Fpage%2F271&canvas=edit&revision=279`

https://github.com/user-attachments/assets/0dd0e438-29b4-4bce-b122-683c989118af


