### PR TITLE
Media: Add undo snackbar for media editor image edits

### DIFF
--- a/packages/block-library/src/image/test/use-open-image-media-editor-modal.js
+++ b/packages/block-library/src/image/test/use-open-image-media-editor-modal.js
@@ -317,6 +317,66 @@ describe( 'useOpenImageMediaEditorModal', () => {
 		} );
 	} );
 
+	it( 'updates back to the previous attachment from the original modal callback', async () => {
+		const originalAttachment = {
+			id: 1,
+			alt_text: '',
+			caption: { raw: '' },
+		};
+		const croppedAttachment = {
+			id: 2,
+			alt_text: '',
+			caption: { raw: '' },
+		};
+		const deferredAttachment = createDeferred();
+		const registry = createRegistry( {
+			getEntityRecord: ( kind, name, attachmentId ) =>
+				attachmentId === 1 ? originalAttachment : undefined,
+			resolveGetEntityRecord: ( kind, name, attachmentId ) =>
+				attachmentId === 2 ? deferredAttachment.promise : undefined,
+		} );
+		useRegistry.mockReturnValue( registry );
+		const setAttributes = jest.fn();
+		const openMediaEditorModal = jest.fn();
+		mockMediaEditorModalSetting( openMediaEditorModal );
+		const { result } = renderHook(
+			( { attributes } ) =>
+				useOpenImageMediaEditorModal( { attributes, setAttributes } ),
+			{
+				initialProps: {
+					attributes: {
+						id: 1,
+						url: 'original.jpg',
+						alt: '',
+						caption: '',
+					},
+				},
+			}
+		);
+
+		await act( async () => {
+			await result.current();
+		} );
+		const onUpdate = openMediaEditorModal.mock.calls[ 0 ][ 0 ].onUpdate;
+		let updatePromise;
+		await act( async () => {
+			updatePromise = onUpdate( { id: 2, url: 'cropped.jpg' } );
+		} );
+		await act( async () => {
+			await onUpdate( { id: 1, url: 'original.jpg' } );
+		} );
+		await act( async () => {
+			deferredAttachment.resolve( croppedAttachment );
+			await updatePromise;
+		} );
+
+		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			id: 1,
+			url: 'original.jpg',
+		} );
+	} );
+
 	it( 'resolves fresh metadata when the new attachment id has an incomplete cached record', async () => {
 		const originalAttachment = {
 			id: 1,

--- a/packages/block-library/src/image/use-open-image-media-editor-modal.js
+++ b/packages/block-library/src/image/use-open-image-media-editor-modal.js
@@ -147,11 +147,16 @@ export function useOpenImageMediaEditorModal( { attributes, setAttributes } ) {
 			select( blockEditorStore ).getSettings()[ openMediaEditorModalKey ],
 		[]
 	);
-	// Track the block's current alt and caption in a ref so handleMediaUpdate
-	// can read the latest values without being listed as a dependency (which
-	// would recreate the callback and re-register the onUpdate handler on every
-	// keystroke while the modal is open).
-	const blockMetadataRef = useRef( { alt, caption: caption?.toString() } );
+	// Track the block's current attachment and metadata in a ref so
+	// handleMediaUpdate can read the latest values without being listed as
+	// dependencies (which would recreate the callback and re-register the
+	// onUpdate handler on every block change while the modal is open).
+	const blockAttributesRef = useRef( {
+		id,
+		url,
+		alt,
+		caption: caption?.toString(),
+	} );
 	// Snapshot of the attachment's metadata taken just before the modal opens,
 	// used as the baseline for detecting what changed during the editing session.
 	const mediaEditorMetadataBaselineRef = useRef();
@@ -160,8 +165,13 @@ export function useOpenImageMediaEditorModal( { attributes, setAttributes } ) {
 	const mediaEditorMetadataSyncRequestRef = useRef( 0 );
 
 	useEffect( () => {
-		blockMetadataRef.current = { alt, caption: caption?.toString() };
-	}, [ alt, caption ] );
+		blockAttributesRef.current = {
+			id,
+			url,
+			alt,
+			caption: caption?.toString(),
+		};
+	}, [ alt, caption, id, url ] );
 
 	const getCachedAttachmentRecord = useCallback(
 		( attachmentId ) => {
@@ -245,9 +255,16 @@ export function useOpenImageMediaEditorModal( { attributes, setAttributes } ) {
 			const syncRequest = ++mediaEditorMetadataSyncRequestRef.current;
 			const nextAttributes = {};
 
-			if ( newId !== id ) {
+			const currentBlockAttributes = blockAttributesRef.current;
+
+			if ( newId !== currentBlockAttributes.id ) {
 				nextAttributes.id = newId;
-				nextAttributes.url = newUrl ?? url;
+				nextAttributes.url = newUrl ?? currentBlockAttributes.url;
+				blockAttributesRef.current = {
+					...blockAttributesRef.current,
+					id: nextAttributes.id,
+					url: nextAttributes.url,
+				};
 			}
 
 			if ( originalAttachment ) {
@@ -270,27 +287,32 @@ export function useOpenImageMediaEditorModal( { attributes, setAttributes } ) {
 				// has independently customised on the block (i.e. values
 				// that don't match the pre-session attachment metadata)
 				// are left untouched.
+				const latestBlockAttributes = blockAttributesRef.current;
 				const resolvedMetadataAttributes =
 					getSyncedImageBlockAttributes(
-						blockMetadataRef.current,
+						latestBlockAttributes,
 						originalAttachment,
 						resolvedAttachment
 					);
 
 				if ( Object.keys( resolvedMetadataAttributes ).length ) {
 					Object.assign( nextAttributes, resolvedMetadataAttributes );
-					blockMetadataRef.current = {
-						...blockMetadataRef.current,
+					blockAttributesRef.current = {
+						...blockAttributesRef.current,
 						...resolvedMetadataAttributes,
 					};
 				}
 			}
 
 			if ( Object.keys( nextAttributes ).length ) {
+				blockAttributesRef.current = {
+					...blockAttributesRef.current,
+					...nextAttributes,
+				};
 				setAttributes( nextAttributes );
 			}
 		},
-		[ id, resolveFreshAttachmentRecord, setAttributes, url ]
+		[ resolveFreshAttachmentRecord, setAttributes ]
 	);
 
 	const openImageMediaEditorModal = useCallback( async () => {
@@ -306,7 +328,7 @@ export function useOpenImageMediaEditorModal( { attributes, setAttributes } ) {
 		const cachedAttachmentRecord = getCachedAttachmentRecord( id );
 		const fallbackAttachmentRecord =
 			getAttachmentFallbackForEmptyBlockMetadata(
-				blockMetadataRef.current
+				blockAttributesRef.current
 			);
 		const resolvedAttachmentRecord = hasKnownAttachmentMetadata(
 			cachedAttachmentRecord

--- a/packages/block-library/src/image/use-open-image-media-editor-modal.js
+++ b/packages/block-library/src/image/use-open-image-media-editor-modal.js
@@ -297,10 +297,6 @@ export function useOpenImageMediaEditorModal( { attributes, setAttributes } ) {
 
 				if ( Object.keys( resolvedMetadataAttributes ).length ) {
 					Object.assign( nextAttributes, resolvedMetadataAttributes );
-					blockAttributesRef.current = {
-						...blockAttributesRef.current,
-						...resolvedMetadataAttributes,
-					};
 				}
 			}
 

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -116,6 +116,7 @@ const SiteLogo = ( {
 		}
 	}, [ isSelected ] );
 
+	// Always apply modal updates as snackbar Undo may restore the original id.
 	const handleMediaUpdate = ( { id: newId } ) => {
 		if ( typeof newId === 'number' ) {
 			setLogo( newId );

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -9,7 +9,9 @@ import clsx from 'clsx';
 import { isBlobURL } from '@wordpress/blob';
 import {
 	createInterpolateElement,
+	useCallback,
 	useEffect,
+	useRef,
 	useState,
 } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
@@ -75,6 +77,7 @@ const SiteLogo = ( {
 	const [ isEditingImage, setIsEditingImage ] = useState( false );
 	const { toggleSelection } = useDispatch( blockEditorStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const logoIdRef = useRef( logoId );
 
 	// Check if we're in contentOnly mode
 	const blockEditingMode = useBlockEditingMode();
@@ -102,6 +105,10 @@ const SiteLogo = ( {
 	}, [] );
 
 	useEffect( () => {
+		logoIdRef.current = logoId;
+	}, [ logoId ] );
+
+	useEffect( () => {
 		// Turn the `Use as site icon` toggle off if it is on but the logo and icon have
 		// fallen out of sync. This can happen if the toggle is saved in the `on` position,
 		// but changes are later made to the site icon in the Customizer.
@@ -116,11 +123,15 @@ const SiteLogo = ( {
 		}
 	}, [ isSelected ] );
 
-	const handleMediaUpdate = ( { id: newId } ) => {
-		if ( typeof newId === 'number' && newId !== logoId ) {
-			setLogo( newId );
-		}
-	};
+	const handleMediaUpdate = useCallback(
+		( { id: newId } ) => {
+			if ( typeof newId === 'number' && newId !== logoIdRef.current ) {
+				logoIdRef.current = newId;
+				setLogo( newId );
+			}
+		},
+		[ setLogo ]
+	);
 
 	function onResizeStart() {
 		toggleSelection( false );

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -9,9 +9,7 @@ import clsx from 'clsx';
 import { isBlobURL } from '@wordpress/blob';
 import {
 	createInterpolateElement,
-	useCallback,
 	useEffect,
-	useRef,
 	useState,
 } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
@@ -77,7 +75,6 @@ const SiteLogo = ( {
 	const [ isEditingImage, setIsEditingImage ] = useState( false );
 	const { toggleSelection } = useDispatch( blockEditorStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-	const logoIdRef = useRef( logoId );
 
 	// Check if we're in contentOnly mode
 	const blockEditingMode = useBlockEditingMode();
@@ -105,10 +102,6 @@ const SiteLogo = ( {
 	}, [] );
 
 	useEffect( () => {
-		logoIdRef.current = logoId;
-	}, [ logoId ] );
-
-	useEffect( () => {
 		// Turn the `Use as site icon` toggle off if it is on but the logo and icon have
 		// fallen out of sync. This can happen if the toggle is saved in the `on` position,
 		// but changes are later made to the site icon in the Customizer.
@@ -123,15 +116,11 @@ const SiteLogo = ( {
 		}
 	}, [ isSelected ] );
 
-	const handleMediaUpdate = useCallback(
-		( { id: newId } ) => {
-			if ( typeof newId === 'number' && newId !== logoIdRef.current ) {
-				logoIdRef.current = newId;
-				setLogo( newId );
-			}
-		},
-		[ setLogo ]
-	);
+	const handleMediaUpdate = ( { id: newId } ) => {
+		if ( typeof newId === 'number' ) {
+			setLogo( newId );
+		}
+	};
 
 	function onResizeStart() {
 		toggleSelection( false );

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -91,6 +91,9 @@ export function MediaEditorModal( {
 					savedId !== previous.id &&
 					onUpdate
 				) {
+					// Intentionally unscoped: the modal is closing, so the
+					// snackbar surfaces in the host editor (not the media
+					// editor's `MEDIA_EDITOR_NOTICES_CONTEXT` region).
 					createSuccessNotice( __( 'Image edited.' ), {
 						type: 'snackbar',
 						actions: [

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -76,7 +76,7 @@ export function MediaEditorModal( {
 			noticesClassName="media-editor-modal__snackbar"
 			noticesPortalElement={ portalElement }
 			onClose={ closeMediaEditorModal }
-			onSaved={ ( { id: savedId, url, imageEdited, previous } ) => {
+			onSaved={ ( { id: savedId, url, previous } ) => {
 				if ( savedId && onUpdate ) {
 					const update: MediaEditorModalUpdate = {
 						id: savedId,
@@ -85,12 +85,7 @@ export function MediaEditorModal( {
 					onUpdate( update );
 				}
 				closeMediaEditorModal();
-				if (
-					imageEdited &&
-					previous &&
-					savedId !== previous.id &&
-					onUpdate
-				) {
+				if ( previous && savedId !== previous.id && onUpdate ) {
 					// Intentionally unscoped: the modal is closing, so the
 					// snackbar surfaces in the host editor (not the media
 					// editor's `MEDIA_EDITOR_NOTICES_CONTEXT` region).

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -5,6 +5,7 @@ import { Modal } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
+import { store as noticesStore } from '@wordpress/notices';
 import type { Field } from '@wordpress/dataviews';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 
@@ -46,6 +47,7 @@ export function MediaEditorModal( {
 	}, [] );
 
 	const { closeMediaEditorModal } = useDispatch( mediaEditorStore );
+	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	if ( ! isModalOpen || ! id ) {
 		return null;
@@ -74,7 +76,7 @@ export function MediaEditorModal( {
 			noticesClassName="media-editor-modal__snackbar"
 			noticesPortalElement={ portalElement }
 			onClose={ closeMediaEditorModal }
-			onSaved={ ( { id: savedId, url } ) => {
+			onSaved={ ( { id: savedId, url, imageEdited, previous } ) => {
 				if ( savedId && onUpdate ) {
 					const update: MediaEditorModalUpdate = {
 						id: savedId,
@@ -83,6 +85,27 @@ export function MediaEditorModal( {
 					onUpdate( update );
 				}
 				closeMediaEditorModal();
+				if (
+					imageEdited &&
+					previous &&
+					savedId !== previous.id &&
+					onUpdate
+				) {
+					createSuccessNotice( __( 'Image edited.' ), {
+						type: 'snackbar',
+						actions: [
+							{
+								label: __( 'Undo' ),
+								onClick: () => {
+									onUpdate( {
+										id: previous.id,
+										url: previous.url,
+									} );
+								},
+							},
+						],
+					} );
+				}
 			} }
 			renderFrame={ ( {
 				children,

--- a/packages/media-editor/src/components/media-editor-modal/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/test/index.tsx
@@ -1,0 +1,147 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import { MediaEditorModal } from '../index';
+
+let mockSaveResult = {
+	id: 11,
+	url: 'edited.jpg',
+	media: { id: 11, source_url: 'edited.jpg' },
+	imageEdited: true,
+	previous: {
+		id: 10,
+		url: 'original.jpg',
+		media: { id: 10, source_url: 'original.jpg' },
+	},
+};
+const mockOnUpdate = jest.fn();
+const mockCloseMediaEditorModal = jest.fn();
+const mockCreateSuccessNotice = jest.fn();
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Modal: ( { children } ) => children,
+} ) );
+
+jest.mock( '@wordpress/keyboard-shortcuts', () => ( {
+	ShortcutProvider: ( { children } ) => children,
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( {
+	store: { name: 'notices' },
+} ) );
+
+jest.mock( '../../../store', () => ( {
+	store: { name: 'media-editor' },
+} ) );
+
+jest.mock( '../../media-editor', () => {
+	const { createElement } = jest.requireActual( '@wordpress/element' );
+
+	return {
+		__esModule: true,
+		default: jest.fn( ( props ) =>
+			createElement(
+				'button',
+				{ onClick: () => props.onSaved( mockSaveResult ) },
+				'Save result'
+			)
+		),
+	};
+} );
+
+describe( 'MediaEditorModal', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockSaveResult = {
+			id: 11,
+			url: 'edited.jpg',
+			media: { id: 11, source_url: 'edited.jpg' },
+			imageEdited: true,
+			previous: {
+				id: 10,
+				url: 'original.jpg',
+				media: { id: 10, source_url: 'original.jpg' },
+			},
+		};
+
+		( useSelect as jest.Mock ).mockImplementation( ( mapSelect ) =>
+			mapSelect( () => ( {
+				isOpen: () => true,
+				getId: () => 10,
+				getOnUpdate: () => mockOnUpdate,
+			} ) )
+		);
+		( useDispatch as jest.Mock ).mockImplementation( ( store ) =>
+			store === noticesStore
+				? { createSuccessNotice: mockCreateSuccessNotice }
+				: { closeMediaEditorModal: mockCloseMediaEditorModal }
+		);
+	} );
+
+	it( 'shows an undo snackbar after saving dirty image editor state', () => {
+		render( <MediaEditorModal /> );
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Save result' } )
+		);
+
+		expect( mockOnUpdate ).toHaveBeenCalledWith( {
+			id: 11,
+			url: 'edited.jpg',
+		} );
+		expect( mockCloseMediaEditorModal ).toHaveBeenCalled();
+		expect( mockCreateSuccessNotice ).toHaveBeenCalledWith(
+			'Image edited.',
+			expect.objectContaining( {
+				type: 'snackbar',
+				actions: [
+					expect.objectContaining( {
+						label: 'Undo',
+						onClick: expect.any( Function ),
+					} ),
+				],
+			} )
+		);
+
+		const noticeOptions = mockCreateSuccessNotice.mock.calls[ 0 ][ 1 ];
+		expect( noticeOptions ).not.toHaveProperty( 'context' );
+
+		noticeOptions.actions[ 0 ].onClick();
+
+		expect( mockOnUpdate ).toHaveBeenLastCalledWith( {
+			id: 10,
+			url: 'original.jpg',
+		} );
+	} );
+
+	it( 'does not show the image edited snackbar for metadata-only saves', () => {
+		mockSaveResult = {
+			...mockSaveResult,
+			imageEdited: false,
+		};
+
+		render( <MediaEditorModal /> );
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Save result' } )
+		);
+
+		expect( mockCreateSuccessNotice ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/media-editor/src/components/media-editor-modal/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/test/index.tsx
@@ -22,7 +22,6 @@ let mockSaveResult = {
 	previous: {
 		id: 10,
 		url: 'original.jpg',
-		media: { id: 10, source_url: 'original.jpg' },
 	},
 };
 const mockOnUpdate = jest.fn();
@@ -76,7 +75,6 @@ describe( 'MediaEditorModal', () => {
 			previous: {
 				id: 10,
 				url: 'original.jpg',
-				media: { id: 10, source_url: 'original.jpg' },
 			},
 		};
 

--- a/packages/media-editor/src/components/media-editor-modal/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/test/index.tsx
@@ -18,7 +18,6 @@ let mockSaveResult = {
 	id: 11,
 	url: 'edited.jpg',
 	media: { id: 11, source_url: 'edited.jpg' },
-	imageEdited: true,
 	previous: {
 		id: 10,
 		url: 'original.jpg',
@@ -71,7 +70,6 @@ describe( 'MediaEditorModal', () => {
 			id: 11,
 			url: 'edited.jpg',
 			media: { id: 11, source_url: 'edited.jpg' },
-			imageEdited: true,
 			previous: {
 				id: 10,
 				url: 'original.jpg',
@@ -131,7 +129,7 @@ describe( 'MediaEditorModal', () => {
 	it( 'does not show the image edited snackbar for metadata-only saves', () => {
 		mockSaveResult = {
 			...mockSaveResult,
-			imageEdited: false,
+			previous: undefined,
 		};
 
 		render( <MediaEditorModal /> );

--- a/packages/media-editor/src/components/media-editor/use-save-media-editor.ts
+++ b/packages/media-editor/src/components/media-editor/use-save-media-editor.ts
@@ -37,6 +37,12 @@ export interface MediaEditorSaveResult {
 	id: number;
 	url?: string;
 	media: Media;
+	imageEdited?: boolean;
+	previous?: {
+		id: number;
+		url?: string;
+		media: Media;
+	};
 }
 
 interface UseSaveMediaEditorArgs {
@@ -104,6 +110,15 @@ export function useSaveMediaEditor( {
 		try {
 			let saved: Media | null | undefined;
 			const modifiers = getCropModifiers( cropper );
+			const imageEdited = modifiers.length > 0;
+			const previous =
+				imageEdited && media
+					? {
+							id,
+							url: media.source_url,
+							media,
+					  }
+					: undefined;
 
 			if ( modifiers.length > 0 ) {
 				const pendingEdits = registry
@@ -156,6 +171,8 @@ export function useSaveMediaEditor( {
 					id: next.id,
 					url: next.source_url,
 					media: next,
+					imageEdited,
+					previous,
 				} );
 			}
 		} catch ( error ) {

--- a/packages/media-editor/src/components/media-editor/use-save-media-editor.ts
+++ b/packages/media-editor/src/components/media-editor/use-save-media-editor.ts
@@ -37,7 +37,6 @@ export interface MediaEditorSaveResult {
 	id: number;
 	url?: string;
 	media: Media;
-	imageEdited?: boolean;
 	previous?: {
 		id: number;
 		url?: string;
@@ -109,9 +108,8 @@ export function useSaveMediaEditor( {
 		try {
 			let saved: Media | null | undefined;
 			const modifiers = getCropModifiers( cropper );
-			const imageEdited = modifiers.length > 0;
 			const previous =
-				imageEdited && media
+				modifiers.length > 0 && media
 					? {
 							id,
 							url: media.source_url,
@@ -169,7 +167,6 @@ export function useSaveMediaEditor( {
 					id: next.id,
 					url: next.source_url,
 					media: next,
-					imageEdited,
 					previous,
 				} );
 			}

--- a/packages/media-editor/src/components/media-editor/use-save-media-editor.ts
+++ b/packages/media-editor/src/components/media-editor/use-save-media-editor.ts
@@ -41,7 +41,6 @@ export interface MediaEditorSaveResult {
 	previous?: {
 		id: number;
 		url?: string;
-		media: Media;
 	};
 }
 
@@ -116,7 +115,6 @@ export function useSaveMediaEditor( {
 					? {
 							id,
 							url: media.source_url,
-							media,
 					  }
 					: undefined;
 


### PR DESCRIPTION
## What

Adds an **Undo** snackbar to the image editor. When a user crops an image and saves, a snackbar appears with an Undo action that reverts the block to the pre-crop attachment.


This makes the image editor consistent with the current inline cropper.


https://github.com/user-attachments/assets/5c769432-30eb-4dd0-a02f-2f2f950d4f35



## Why

Cropping in the media editor produces a *new* attachment and rewrites the block's `id`/`url`. Without an undo affordance, recovering the previous image meant reopening the media library and re-selecting it. The snackbar gives users an immediate, low-cost way to back out of an unintended crop.

## How

The Undo path reuses the existing `onUpdate` plumbing; the snackbar simply calls it a second time with the previous ID, and the block's media-update handling does the rest (including resolving fresh metadata and restoring alt/caption from the original attachment's baseline).

## Testing

- Open an Image block, crop and save → snackbar appears with Undo → click Undo → block reverts to original image.
- Same flow for Site Logo.
- Metadata-only edits (alt/caption/title without a crop) do **not** show the snackbar.


