### PR TITLE
Image: Fix missing aria-label on lightbox trigger button for single images

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -250,7 +250,8 @@ function block_core_image_render_lightbox( $block_content, $block, $block_instan
 					'galleryId'              => $block_instance->context['galleryId'] ?? null,
 					'customAriaLabel'        => $custom_aria_label ?? null,
 					'navigationButtonType'   => $block_instance->context['navigationButtonType'] ?? 'icon',
-					'triggerButtonAriaLabel' => null,
+					/* translators: %s: Image alt text. */
+					'triggerButtonAriaLabel' => $alt ? sprintf( __( 'Enlarge image: %s' ), $alt ) : __( 'Enlarge image' ),
 				),
 			),
 		)

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -250,8 +250,7 @@ function block_core_image_render_lightbox( $block_content, $block, $block_instan
 					'galleryId'              => $block_instance->context['galleryId'] ?? null,
 					'customAriaLabel'        => $custom_aria_label ?? null,
 					'navigationButtonType'   => $block_instance->context['navigationButtonType'] ?? 'icon',
-					/* translators: %s: Image alt text. */
-					'triggerButtonAriaLabel' => $alt ? sprintf( __( 'Enlarge image: %s' ), $alt ) : __( 'Enlarge image' ),
+					'triggerButtonAriaLabel' => __( 'Enlarge' ),
 				),
 			),
 		)


### PR DESCRIPTION
## What?
Closes #78413 

Restores the `aria-label` attribute on the lightbox trigger button for single image blocks that have "Enlarge on click" enabled.

## Why?
The commit that added gallery lightbox support changed the trigger button to use a dynamic `aria-label` binding, but left `triggerButtonAriaLabel` as `null` for single images. So the attribute was never rendered on the
frontend.

## How?
Set `triggerButtonAriaLabel` to `"Enlarge"` at render time in the image block's PHP render function.

## Testing Instructions
1. Create a new post or page.
2. Insert a single **Image** block and upload or select any image.
3. With the image selected, open the **Link** toolbar dropdown and choose **"Enlarge on click"**.
4. Publish or preview the page.
5. Inspect the lightbox trigger button (`button.lightbox-trigger`) in browser DevTools and confirm it has `aria-label="Enlarge"`. 

### Testing Instructions for Keyboard
1. On the published/previewed page, Tab to the lightbox trigger button on the image.
2. Activate VoiceOver (macOS: `Cmd + F5`) or NVDA (Windows).
3. Confirm the screen reader announces `"Enlarge"`.

## Screenshots or screencast 

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1470" height="836" alt="before" src="https://github.com/user-attachments/assets/e7778056-0ace-46f2-b3c2-956ce5a86e32" /> | <img width="1470" height="836" alt="after" src="https://github.com/user-attachments/assets/ac555b5f-a384-4619-8d53-ccf00514ba78" /> |

## Use of AI Tools

None
