### PR TITLE
Navigation: Fix missing 'Add block' option in Link UI when inside template parts

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -248,11 +248,12 @@ function UnforwardedLinkUI( props, ref ) {
 										setAddingPage( true );
 									} }
 									canAddPage={
+										blockEditingMode !== 'disabled' &&
 										permissions?.canCreate &&
 										type === 'page'
 									}
 									canAddBlock={
-										blockEditingMode === 'default'
+										blockEditingMode !== 'disabled'
 									}
 								/>
 							);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #78380

This PR enables the "Add block" option inside the Navigation Link popover (`LinkUI`) when the block is in `'contentOnly'` editing mode (e.g. when nested inside a Template Part and edited within a template).

<!-- In a few words, what is the PR actually doing? -->

## Why?
When editing a template containing a template part (like the footer or header) that contains a Navigation block, the site editor's derived editing mode for the Navigation block is `'contentOnly'`. 

Because the Link UI popover previously restricted `canAddBlock` only to when `blockEditingMode === 'default'`, the "Add block" button was completely hidden when editing the menu directly from the Site Editor template context. Users were forced to edit the template part in isolation by navigating to the dedicated template part.

Since Navigation blocks and link/submenu blocks are defined as content blocks (`contentRole: true`), users should be allowed to add blocks to them in content-only editing mode.

## How?
Changed the conditions for `canAddBlock` and `canAddPage` inside `packages/block-library/src/navigation-link/link-ui/index.js` to check `blockEditingMode !== 'disabled'` instead of `blockEditingMode === 'default'`.

This allows adding links/pages in both `'default'` and `'contentOnly'` modes, while still correctly disabling the actions in `'disabled'` mode. The block editor's native `canInsertBlockType` selector automatically filters the quick inserter inside the popover to only allow content blocks (e.g., preventing structural blocks from being added).

## Testing Instructions
1. Activate a block theme.
2. Open the Site Editor (**Appearance > Editor**) and select a template that includes a header or footer template part with a Navigation block (e.g., the Front Page or Index template).
3. Click on a Navigation Link block inside the footer/header to open the link editor popover.
4. Verify that the "Add block" option is visible in the popover toolbar, and clicking it displays the block inserter.
5. Type a page name that does not exist in the search bar and verify that the "Create page" option is also visible and functional.
6. Verify that editing the template part directly in focus mode still displays the correct options.

## Screenshots or screencast

### Before

https://github.com/user-attachments/assets/d0cdd512-7ab2-4748-8a08-ba57a0ebac84

### After

https://github.com/user-attachments/assets/e528533a-6371-49a7-b5ea-f0a6720feedb


## Use of AI Tools
This PR description was drafted with the help of Gemini 3 Flash. All code changes were reviewed and validated.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
