### PR TITLE
Table block: fix insertRow cell count when thead has colspan/rowspan

### DIFF
--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -1,6 +1,25 @@
 const INHERITED_COLUMN_ATTRIBUTES = [ 'align' ];
 
 /**
+ * Expands a row's cells into one entry per logical column, respecting colspan.
+ * A cell with colspan=N occupies N consecutive logical column slots, each
+ * pointing back to the same cell object so attribute inheritance stays correct.
+ *
+ * @param {Object|undefined} row A table row object.
+ * @return {Array} Array whose length equals the row's effective column count.
+ */
+function expandRowCells( row ) {
+	const result = [];
+	for ( const cell of row?.cells ?? [] ) {
+		const span = parseInt( cell.colspan, 10 ) || 1;
+		for ( let i = 0; i < span; i++ ) {
+			result.push( cell );
+		}
+	}
+	return result;
+}
+
+/**
  * Creates a table state.
  *
  * @param {Object} options
@@ -160,8 +179,9 @@ export function isCellSelected( cellLocation, selection ) {
  */
 export function insertRow( state, { sectionName, rowIndex, columnCount } ) {
 	const firstRow = getFirstRow( state );
+	const expandedCells = expandRowCells( firstRow );
 	const cellCount =
-		columnCount === undefined ? firstRow?.cells?.length : columnCount;
+		columnCount === undefined ? expandedCells.length : columnCount;
 
 	// Bail early if the function cannot determine how many cells to add.
 	if ( ! cellCount ) {
@@ -174,8 +194,7 @@ export function insertRow( state, { sectionName, rowIndex, columnCount } ) {
 			{
 				cells: Array.from( { length: cellCount } ).map(
 					( _, index ) => {
-						const firstCellInColumn =
-							firstRow?.cells?.[ index ] ?? {};
+						const firstCellInColumn = expandedCells[ index ] ?? {};
 
 						const inheritedAttributes = Object.fromEntries(
 							Object.entries( firstCellInColumn ).filter(
@@ -317,8 +336,8 @@ export function toggleSection( state, sectionName ) {
 		return { [ sectionName ]: [] };
 	}
 
-	// Get the length of the first row of the body to use when creating the header.
-	const columnCount = state.body?.[ 0 ]?.cells?.length ?? 1;
+	// Get the effective column count of the first body row to use when creating the header.
+	const columnCount = expandRowCells( state.body?.[ 0 ] ).length || 1;
 
 	// Section doesn't exist, insert an empty row to create the section.
 	return insertRow( state, { sectionName, rowIndex: 0, columnCount } );


### PR DESCRIPTION
Fixes #77939

When a table's first header row contains cells with `colspan > 1`,
`insertRow` computes the new row's cell count as `cells.length` — the
number of DOM nodes — rather than the logical column count. A header like

    [A rowspan=2] [B rowspan=2] [Grouped colspan=2] [E rowspan=2]

has 4 `<th>` nodes but 5 logical columns, so every inserted body row
came out short by one cell and broke the table layout.

Add `expandRowCells()`, which expands each cell into one slot per
colspan unit. `insertRow` now uses the length of that expanded list for
`cellCount` and indexes into it for column-attribute inheritance, so
`align` is still carried forward to the right column. `toggleSection`
had the identical `cells.length` pattern when bootstrapping a new
section; fixed the same way.
