### PR TITLE
Grid: fix immutability lint warning for react hook

### DIFF
--- a/packages/grid/src/shared/resize-handle.tsx
+++ b/packages/grid/src/shared/resize-handle.tsx
@@ -8,7 +8,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef } from '@wordpress/element';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { useMergeRefs, useThrottle } from '@wordpress/compose';
 
 /**
@@ -16,6 +16,29 @@ import { useMergeRefs, useThrottle } from '@wordpress/compose';
  */
 import type { ResizeDelta, ResizeHandleProps } from './types';
 import styles from './resize-handle.module.css';
+
+/**
+ * Sets `document.documentElement.style.cursor` for the duration of a drag
+ * and restores it on cleanup. Lives outside the component so cursor writes
+ * are not analyzed as mutating values derived from refs in the component
+ * body (react-hooks/immutability).
+ *
+ * @param getDocument Returns the document whose root element should receive
+ *                    the cursor (handle owner, or global `document`).
+ * @param cursor      CSS cursor value while active.
+ * @return Cleanup that restores the previous cursor.
+ */
+function lockDocumentCursorWhileActive(
+	getDocument: () => Document,
+	cursor: string
+): () => void {
+	const root = getDocument().documentElement;
+	const previous = root.style.cursor;
+	root.style.cursor = cursor;
+	return () => {
+		root.style.cursor = previous;
+	};
+}
 
 function ResizeHandle( {
 	itemId,
@@ -27,11 +50,13 @@ function ResizeHandle( {
 		data: { itemId },
 	} );
 
-	// Track the rendered node so we can resolve `ownerDocument` for the
-	// cursor lock — needed when the grid lives inside an iframe (e.g.
-	// the block-editor canvas).
-	const nodeRef = useRef< HTMLElement | null >( null );
-	const mergedRef = useMergeRefs( [ nodeRef, setNodeRef ] );
+	// Snapshot owner document on mount/update via ref callback so the
+	// cursor-lock effect can resolve the correct document in an iframe.
+	const ownerDocumentRef = useRef< Document | null >( null );
+	const setOwnerDocumentRef = useCallback( ( node: HTMLElement | null ) => {
+		ownerDocumentRef.current = node?.ownerDocument ?? null;
+	}, [] );
+	const mergedRef = useMergeRefs( [ setOwnerDocumentRef, setNodeRef ] );
 
 	// Lock the document cursor while the gesture is active. Without
 	// this, the OS pointer reverts to the default arrow as soon as it
@@ -42,13 +67,10 @@ function ResizeHandle( {
 			return;
 		}
 		const cursor = verticalResizable ? 'nwse-resize' : 'ew-resize';
-		const root = ( nodeRef.current?.ownerDocument ?? document )
-			.documentElement;
-		const previous = root.style.cursor;
-		root.style.cursor = cursor;
-		return () => {
-			root.style.cursor = previous;
-		};
+		return lockDocumentCursorWhileActive(
+			() => ownerDocumentRef.current ?? document,
+			cursor
+		);
 	}, [ isDragging, verticalResizable ] );
 
 	if ( renderResizeHandle ) {

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1463,16 +1463,6 @@
 			"count": 1
 		}
 	},
-	"packages/grid/src/dashboard-grid/index.tsx": {
-		"react-hooks/refs": {
-			"count": 13
-		}
-	},
-	"packages/grid/src/dashboard-lanes/index.tsx": {
-		"react-hooks/refs": {
-			"count": 13
-		}
-	},
 	"packages/image-cropper/src/stories/index.story.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 3

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1473,11 +1473,6 @@
 			"count": 13
 		}
 	},
-	"packages/grid/src/shared/resize-handle.tsx": {
-		"react-hooks/immutability": {
-			"count": 1
-		}
-	},
 	"packages/image-cropper/src/stories/index.story.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 3


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes `react-hooks/immutability` lint warning for Grid's resize handle
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Resizing icon switcheroo continues to work


https://github.com/user-attachments/assets/ca1d476c-eacd-4be6-81b2-0a30c45b3338



## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
