### PR TITLE
Use logical CSS properties in routes styles

### DIFF
--- a/routes/guidelines/style.scss
+++ b/routes/guidelines/style.scss
@@ -42,8 +42,7 @@
 
 .guidelines__revision-history-back {
 	align-self: flex-start;
-	// stylelint-disable-next-line plugin/use-logical-properties-and-values -- TODO: Please fix
-	margin-left: -$grid-unit-20;
+	margin-inline-start: -$grid-unit-20;
 	font-weight: 500;
 	color: $gray-900;
 }
@@ -54,8 +53,7 @@
 }
 
 .guidelines__revision-description {
-	// stylelint-disable-next-line plugin/use-logical-properties-and-values -- TODO: Please fix
-	padding-left: $grid-unit-10;
+	padding-inline-start: $grid-unit-10;
 }
 
 .guidelines__restore-modal-actions {

--- a/routes/template-list/add-new-template/style.scss
+++ b/routes/template-list/add-new-template/style.scss
@@ -37,8 +37,7 @@
 		&__list-item {
 			display: block;
 			width: 100%;
-			// stylelint-disable-next-line plugin/use-logical-properties-and-values -- TODO: Please fix
-			text-align: left;
+			text-align: start;
 			white-space: pre-wrap;
 			overflow-wrap: break-word;
 			height: auto;

--- a/routes/template-list/style.scss
+++ b/routes/template-list/style.scss
@@ -12,8 +12,7 @@
 	height: 24px;
 	border-radius: 50%;
 	overflow: hidden;
-	// stylelint-disable-next-line plugin/use-logical-properties-and-values -- TODO: Please fix
-	margin-right: 8px;
+	margin-inline-end: 8px;
 	opacity: 0;
 	transition: opacity 0.1s ease-in;
 
@@ -34,8 +33,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	// stylelint-disable-next-line plugin/use-logical-properties-and-values -- TODO: Please fix
-	margin-right: 8px;
+	margin-inline-end: 8px;
 	color: $gray-700;
 }
 


### PR DESCRIPTION
## What?
Replaces a few left/right physical CSS properties in route styles with logical properties/values.

## Why?
These styles had `stylelint-disable-next-line plugin/use-logical-properties-and-values` comments. Using logical properties keeps the same behavior in LTR while improving RTL support and lets us remove those suppressions.

## How?
This PR updates:
- `margin-right` to `margin-inline-end`
- `margin-left` to `margin-inline-start`
- `padding-left` to `padding-inline-start`
- `text-align: left` to `text-align: start`

Affected files:
- `routes/template-list/style.scss`
- `routes/guidelines/style.scss`
- `routes/template-list/add-new-template/style.scss`

## Testing Instructions
1. Run `npm run lint:css -- routes/template-list/style.scss routes/guidelines/style.scss routes/template-list/add-new-template/style.scss`
2. Confirm lint passes
3. Optionally preview the affected routes in both LTR and RTL and confirm spacing/alignment remains correct

### Testing Instructions for Keyboard
N/A

## AI disclosure
I did not use AI assistance to help identify and implement this small CSS cleanup. Reviewed the final changes locally before opening the PR.