### PR TITLE
Navigation: Animate hamburger morph to close button on overlay open

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -539,7 +539,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 -	**Category:** theme
 -	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/icon, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
 -	**Supports:** align (full, wide), anchor, ariaLabel, contentRole, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, overlay, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, submenuVisibility, templateLock, textColor
+-	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, overlay, overlayBackgroundColor, overlayMenu, overlayMenuIconAnimation, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, submenuVisibility, templateLock, textColor
 
 ## Custom Link
 

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -67,6 +67,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"overlayMenuIconAnimation": {
+			"type": "boolean",
+			"default": true
+		},
 		"__unstableLocation": {
 			"type": "string"
 		},

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -297,6 +297,7 @@ function Navigation( {
 		} = {},
 		hasIcon,
 		icon = 'handle',
+		overlayMenuIconAnimation = true,
 	} = attributes;
 
 	const ref = attributes.ref;
@@ -809,6 +810,7 @@ function Navigation( {
 								overlayMenu: 'mobile',
 								hasIcon: true,
 								icon: 'handle',
+								overlayMenuIconAnimation: true,
 							} );
 						} }
 						dropdownMenuProps={ dropdownMenuProps }
@@ -928,6 +930,7 @@ function Navigation( {
 						setOverlayMenuPreview={ setOverlayMenuPreview }
 						hasIcon={ hasIcon }
 						icon={ icon }
+						overlayMenuIconAnimation={ overlayMenuIconAnimation }
 						overlayMenuPreviewClasses={ overlayMenuPreviewClasses }
 						overlayMenuPreviewId={ overlayMenuPreviewId }
 						isResponsive={ isResponsive }

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -3,6 +3,7 @@
  */
 import {
 	PanelBody,
+	ToggleControl,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -28,6 +29,7 @@ import OverlayPreview from './overlay-preview';
  * @param {Function} props.setOverlayMenuPreview     Function to toggle overlay menu preview.
  * @param {boolean}  props.hasIcon                   Whether the overlay menu has an icon.
  * @param {string}   props.icon                      Icon type for overlay menu.
+ * @param {boolean}  props.overlayMenuIconAnimation  Whether the overlay menu icon animates.
  * @param {string}   props.overlayMenuPreviewClasses CSS classes for overlay menu preview button.
  * @param {string}   props.overlayMenuPreviewId      ID for overlay menu preview.
  * @param {boolean}  props.isResponsive              Whether overlay menu is responsive.
@@ -44,6 +46,7 @@ export default function OverlayPanel( {
 	setOverlayMenuPreview,
 	hasIcon,
 	icon,
+	overlayMenuIconAnimation,
 	overlayMenuPreviewClasses,
 	overlayMenuPreviewId,
 	isResponsive,
@@ -70,6 +73,19 @@ export default function OverlayPanel( {
 						setAttributes={ setAttributes }
 						overlayMenuPreviewClasses={ overlayMenuPreviewClasses }
 						overlayMenuPreviewId={ overlayMenuPreviewId }
+					/>
+				) }
+
+				{ overlayMenu !== 'never' && hasIcon && icon === 'handle' && (
+					<ToggleControl
+						__nextHasNoMarginBottom
+						checked={ overlayMenuIconAnimation }
+						label={ __( 'Animate menu icon' ) }
+						onChange={ ( value ) =>
+							setAttributes( {
+								overlayMenuIconAnimation: value,
+							} )
+						}
 					/>
 				) }
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -734,7 +734,7 @@ class WP_Navigation_Block_Renderer {
 		);
 
 		$should_display_icon_label = isset( $attributes['hasIcon'] ) && true === $attributes['hasIcon'];
-		$toggle_button_icon        = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4 7.5h16v1.5H4z"></path><path d="M4 15h16v1.5H4z"></path></svg>';
+		$toggle_button_icon        = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect class="wp-block-navigation__hamburger-line" x="4" y="7.5" width="16" height="1.5" /><rect class="wp-block-navigation__hamburger-line" x="4" y="15" width="16" height="1.5" /></svg>';
 		if ( isset( $attributes['icon'] ) ) {
 			if ( 'menu' === $attributes['icon'] ) {
 				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 5v1.5h14V5H5z"></path><path d="M5 12.8h14v-1.5H5v1.5z"></path><path d="M5 19h14v-1.5H5V19z"></path></svg>';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -888,15 +888,15 @@ class WP_Navigation_Block_Renderer {
 		// When adding to this array be mindful of security concerns.
 		$nav_element_context    = wp_interactivity_data_wp_context(
 			array(
-				'overlayOpenedBy'           => array(
+				'overlayOpenedBy'          => array(
 					'click' => false,
 					'hover' => false,
 					'focus' => false,
 				),
-				'type'                      => 'overlay',
-				'roleAttribute'             => '',
-				'ariaLabel'                 => __( 'Menu' ),
-				'overlayMenuIconAnimation'  => $overlay_menu_icon_animation,
+				'type'                     => 'overlay',
+				'roleAttribute'            => '',
+				'ariaLabel'                => __( 'Menu' ),
+				'overlayMenuIconAnimation' => $overlay_menu_icon_animation,
 			)
 		);
 		$nav_element_directives = '

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -863,7 +863,7 @@ class WP_Navigation_Block_Renderer {
 		$wrapper_attributes = get_block_wrapper_attributes( $extra_attributes );
 
 		if ( $is_responsive_menu ) {
-			$nav_element_directives = static::get_nav_element_directives( $is_interactive );
+			$nav_element_directives = static::get_nav_element_directives( $is_interactive, $attributes );
 			$wrapper_attributes    .= ' ' . $nav_element_directives;
 		}
 
@@ -875,24 +875,28 @@ class WP_Navigation_Block_Renderer {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param bool $is_interactive Whether the block is interactive.
+	 * @param bool  $is_interactive Whether the block is interactive.
+	 * @param array $attributes     The block attributes.
 	 * @return string the directives for the navigation element.
 	 */
-	private static function get_nav_element_directives( $is_interactive ) {
+	private static function get_nav_element_directives( $is_interactive, $attributes ) {
 		if ( ! $is_interactive ) {
 			return '';
 		}
+		$overlay_menu_icon_animation = ! isset( $attributes['overlayMenuIconAnimation'] ) ||
+			true === $attributes['overlayMenuIconAnimation'];
 		// When adding to this array be mindful of security concerns.
 		$nav_element_context    = wp_interactivity_data_wp_context(
 			array(
-				'overlayOpenedBy' => array(
+				'overlayOpenedBy'           => array(
 					'click' => false,
 					'hover' => false,
 					'focus' => false,
 				),
-				'type'            => 'overlay',
-				'roleAttribute'   => '',
-				'ariaLabel'       => __( 'Menu' ),
+				'type'                      => 'overlay',
+				'roleAttribute'             => '',
+				'ariaLabel'                 => __( 'Menu' ),
+				'overlayMenuIconAnimation'  => $overlay_menu_icon_animation,
 			)
 		);
 		$nav_element_directives = '

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -527,6 +527,48 @@ button.wp-block-navigation-item__content {
 		transform: translateY(0);
 	}
 }
+
+// Phantom element used for the hamburger-to-close flying morph animation.
+// A cloned hamburger button flies from its position to the close button
+// while the two horizontal lines rotate into an X shape.
+.wp-block-navigation__morph-phantom {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	background: transparent;
+	border: none;
+	padding: 0;
+	color: currentColor;
+
+	svg {
+		fill: currentColor;
+		display: block;
+		width: $navigation-icon-size;
+		height: $navigation-icon-size;
+	}
+
+	.wp-block-navigation__hamburger-line {
+		transform-box: fill-box;
+		transform-origin: center;
+	}
+
+	@media not (prefers-reduced-motion) {
+		.wp-block-navigation__hamburger-line {
+			transition: transform 350ms cubic-bezier(0.4, 0, 0.2, 1);
+		}
+	}
+
+	// Morphed state: two horizontal lines become an X.
+	// Each line translates to the SVG center (y=12) and rotates.
+	&.is-morphed .wp-block-navigation__hamburger-line:first-child {
+		transform: translateY(3.75px) rotate(45deg);
+	}
+
+	&.is-morphed .wp-block-navigation__hamburger-line:last-child {
+		transform: translateY(-3.75px) rotate(-45deg);
+	}
+}
+
 .wp-block-navigation__responsive-container {
 	display: none;
 	position: fixed;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -559,13 +559,14 @@ button.wp-block-navigation-item__content {
 	}
 
 	// Morphed state: two horizontal lines become an X.
-	// Each line translates to the SVG center (y=12) and rotates.
+	// Each line translates to the SVG center (y=12), rotates, and scales
+	// to match the close icon's longer diagonal arms (~21px vs 16px).
 	&.is-morphed .wp-block-navigation__hamburger-line:first-child {
-		transform: translateY(3.75px) rotate(45deg);
+		transform: translateY(3.75px) rotate(45deg) scaleX(1.24);
 	}
 
 	&.is-morphed .wp-block-navigation__hamburger-line:last-child {
-		transform: translateY(-3.75px) rotate(-45deg);
+		transform: translateY(-3.75px) rotate(-45deg) scaleX(1.24);
 	}
 }
 

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -536,15 +536,6 @@ const { state, actions } = store(
 							ref.style.animation = 'none';
 							ref.style.transform = 'none';
 
-							// Anchor the close button to the hamburger's
-							// exact viewport position so the morph ends
-							// where it started.
-							closeBtn.style.position = 'fixed';
-							closeBtn.style.top = ctx.morphStartRect.top + 'px';
-							closeBtn.style.left =
-								ctx.morphStartRect.left + 'px';
-							closeBtn.style.right = 'auto';
-
 							runOpenMorphAnimation(
 								nav,
 								hamburgerBtn,

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -55,6 +55,47 @@ document.addEventListener( 'click', () => {} );
 const MORPH_DURATION = 350;
 const MORPH_EASING = 'cubic-bezier(0.4, 0, 0.2, 1)';
 
+// Morphed-state transforms for the two hamburger lines. Mirror of the
+// .is-morphed CSS rules in style.scss; driven via WAAPI so the morph
+// fires reliably in both directions (CSS transitions on
+// freshly-inserted elements can fail to trigger).
+const MORPH_LINE_TRANSFORM = [
+	'translateY(3.75px) rotate(45deg) scaleX(1.24)',
+	'translateY(-3.75px) rotate(-45deg) scaleX(1.24)',
+];
+const MORPH_LINE_IDENTITY = 'translateY(0) rotate(0) scaleX(1)';
+
+/**
+ * Animate a phantom's two hamburger-line rects from one transform to another.
+ *
+ * @param {HTMLElement} phantom - The phantom element.
+ * @param {boolean}     toMorphed - true to animate horizontal lines → X;
+ *                                  false to animate X → horizontal lines.
+ */
+function animatePhantomLines( phantom, toMorphed ) {
+	const lines = phantom.querySelectorAll(
+		'.wp-block-navigation__hamburger-line'
+	);
+	lines.forEach( ( line, i ) => {
+		line.animate(
+			toMorphed
+				? [
+						{ transform: MORPH_LINE_IDENTITY },
+						{ transform: MORPH_LINE_TRANSFORM[ i ] },
+				  ]
+				: [
+						{ transform: MORPH_LINE_TRANSFORM[ i ] },
+						{ transform: MORPH_LINE_IDENTITY },
+				  ],
+			{
+				duration: MORPH_DURATION,
+				easing: MORPH_EASING,
+				fill: 'forwards',
+			}
+		);
+	} );
+}
+
 // Track active morph animations per navigation block element.
 const activeMorphAnimations = new WeakMap();
 
@@ -151,39 +192,33 @@ function runOpenMorphAnimation( nav, hamburgerBtn, closeBtn, startRect ) {
 			( endRect.height - startRect.height ) / 2 -
 			startRect.top;
 
-		// Use a second rAF so the browser paints the phantom at start position
-		// before the transition begins.
-		requestAnimationFrame( () => {
-			// Trigger the CSS morph transition (horizontal lines → X).
-			phantom.classList.add( 'is-morphed' );
+		animatePhantomLines( phantom, true );
 
-			// Fly the phantom from hamburger to close button position.
-			const animation = phantom.animate(
-				[
-					{ transform: 'translate(0, 0)' },
-					{
-						transform: `translate(${ dx }px, ${ dy }px)`,
-					},
-				],
+		const animation = phantom.animate(
+			[
+				{ transform: 'translate(0, 0)' },
 				{
-					duration: MORPH_DURATION,
-					easing: MORPH_EASING,
-					fill: 'forwards',
-				}
-			);
+					transform: `translate(${ dx }px, ${ dy }px)`,
+				},
+			],
+			{
+				duration: MORPH_DURATION,
+				easing: MORPH_EASING,
+				fill: 'forwards',
+			}
+		);
 
-			activeMorphAnimations.set( nav, {
-				animation,
-				phantom,
-				closeBtn,
-			} );
-
-			animation.onfinish = () => {
-				phantom.remove();
-				closeBtn.style.visibility = '';
-				activeMorphAnimations.delete( nav );
-			};
+		activeMorphAnimations.set( nav, {
+			animation,
+			phantom,
+			closeBtn,
 		} );
+
+		animation.onfinish = () => {
+			phantom.remove();
+			closeBtn.style.visibility = '';
+			activeMorphAnimations.delete( nav );
+		};
 	} );
 }
 
@@ -215,12 +250,12 @@ function runCloseMorphAnimation(
 	// Hide the real close button.
 	closeBtn.style.visibility = 'hidden';
 
-	// Create phantom at close button's position (morphed as X).
-	const phantom = createMorphPhantom( hamburgerBtn, true );
+	// Create the phantom without the morphed class; WAAPI applies the
+	// X transform as its first keyframe and then animates back.
+	const phantom = createMorphPhantom( hamburgerBtn, false );
 	phantom.style.top = closeRect.top + 'px';
 	phantom.style.left = closeRect.left + 'px';
 
-	// Calculate translation back to hamburger position.
 	const dx =
 		hamburgerRect.left +
 		( hamburgerRect.width - closeRect.width ) / 2 -
@@ -230,31 +265,27 @@ function runCloseMorphAnimation(
 		( hamburgerRect.height - closeRect.height ) / 2 -
 		closeRect.top;
 
-	requestAnimationFrame( () => {
-		// Trigger the CSS morph transition (X → horizontal lines).
-		phantom.classList.remove( 'is-morphed' );
+	animatePhantomLines( phantom, false );
 
-		// Fly the phantom from close button to hamburger position.
-		const animation = phantom.animate(
-			[
-				{ transform: 'translate(0, 0)' },
-				{ transform: `translate(${ dx }px, ${ dy }px)` },
-			],
-			{
-				duration: MORPH_DURATION,
-				easing: MORPH_EASING,
-				fill: 'forwards',
-			}
-		);
+	const animation = phantom.animate(
+		[
+			{ transform: 'translate(0, 0)' },
+			{ transform: `translate(${ dx }px, ${ dy }px)` },
+		],
+		{
+			duration: MORPH_DURATION,
+			easing: MORPH_EASING,
+			fill: 'forwards',
+		}
+	);
 
-		activeMorphAnimations.set( nav, { animation, phantom, closeBtn } );
+	activeMorphAnimations.set( nav, { animation, phantom, closeBtn } );
 
-		animation.onfinish = () => {
-			phantom.remove();
-			activeMorphAnimations.delete( nav );
-			onComplete();
-		};
-	} );
+	animation.onfinish = () => {
+		phantom.remove();
+		activeMorphAnimations.delete( nav );
+		onComplete();
+	};
 }
 
 const { state, actions } = store(

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -352,12 +352,16 @@ const { state, actions } = store(
 				const { ref } = getElement();
 
 				// Check if the reverse morph animation should play.
-				// Only applies when clicking the Navigation Overlay Close block.
+				// Applies to both the default close button and the custom
+				// Navigation Overlay Close block.
 				if (
 					ctx.morphStartRect &&
-					ref.classList.contains(
+					( ref.classList.contains(
 						'wp-block-navigation-overlay-close'
-					)
+					) ||
+						ref.classList.contains(
+							'wp-block-navigation__responsive-container-close'
+						) )
 				) {
 					const nav = ref.closest( '.wp-block-navigation' );
 					const hamburgerBtn = nav?.querySelector(
@@ -511,10 +515,29 @@ const { state, actions } = store(
 							'.wp-block-navigation__responsive-container-open'
 						);
 						const closeBtn = ref.querySelector(
-							'.wp-block-navigation-overlay-close'
+							'.wp-block-navigation-overlay-close, .wp-block-navigation__responsive-container-close'
 						);
 
 						if ( nav && hamburgerBtn && closeBtn ) {
+							// Suppress the overlay's translateY fade-in
+							// animation. Any transform on an ancestor makes
+							// it the containing block for position: fixed
+							// descendants, which would otherwise drag the
+							// close button as the transform animates away
+							// and cause a snap at the end of the morph.
+							ref.style.animation = 'none';
+							ref.style.transform = 'none';
+
+							// Anchor the close button to the hamburger's
+							// exact viewport position so the morph ends
+							// where it started.
+							closeBtn.style.position = 'fixed';
+							closeBtn.style.top =
+								ctx.morphStartRect.top + 'px';
+							closeBtn.style.left =
+								ctx.morphStartRect.left + 'px';
+							closeBtn.style.right = 'auto';
+
 							runOpenMorphAnimation(
 								nav,
 								hamburgerBtn,

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -332,10 +332,12 @@ const { state, actions } = store(
 				const ctx = getContext();
 				const { ref } = getElement();
 				ctx.previousFocus = ref;
+				ctx.morphStartRect = null;
 
 				// Capture hamburger position before the overlay covers it.
 				// Only for the "handle" icon variant (has rect-based SVG lines).
 				if (
+					ctx.overlayMenuIconAnimation !== false &&
 					ref.querySelector( '.wp-block-navigation__hamburger-line' )
 				) {
 					const rect = ref.getBoundingClientRect();

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -5,6 +5,7 @@ import {
 	store,
 	getContext,
 	getElement,
+	withScope,
 	withSyncEvent,
 } from '@wordpress/interactivity';
 
@@ -422,10 +423,14 @@ const { state, actions } = store(
 							hamburgerBtn,
 							ref,
 							ctx.morphStartRect,
-							() => {
+							// onComplete fires from WAAPI's onfinish,
+							// which runs outside the Interactivity scope;
+							// withScope restores it so actions.closeMenu
+							// can call getContext().
+							withScope( () => {
 								actions.closeMenu( 'click' );
 								actions.closeMenu( 'focus' );
-							}
+							} )
 						);
 						return;
 					}

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -295,6 +295,7 @@ function runCloseMorphAnimation(
 
 	animation.onfinish = () => {
 		phantom.remove();
+		closeBtn.style.opacity = '';
 		activeMorphAnimations.delete( nav );
 		onComplete();
 	};

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -66,13 +66,7 @@ const MORPH_LINE_TRANSFORM = [
 ];
 const MORPH_LINE_IDENTITY = 'translateY(0px) rotate(0deg) scaleX(1)';
 
-/**
- * Animate a phantom's two hamburger-line rects from one transform to another.
- *
- * @param {HTMLElement} phantom - The phantom element.
- * @param {boolean}     toMorphed - true to animate horizontal lines → X;
- *                                  false to animate X → horizontal lines.
- */
+// Animate a phantom's two hamburger-line rects from one transform to another.
 function animatePhantomLines( phantom, toMorphed ) {
 	const lines = phantom.querySelectorAll(
 		'.wp-block-navigation__hamburger-line'
@@ -90,10 +84,7 @@ function animatePhantomLines( phantom, toMorphed ) {
 		// the CSS default doesn't match the animation's first keyframe).
 		line.style.transform = startTransform;
 		line.animate(
-			[
-				{ transform: startTransform },
-				{ transform: endTransform },
-			],
+			[ { transform: startTransform }, { transform: endTransform } ],
 			{
 				duration: MORPH_DURATION,
 				easing: MORPH_EASING,
@@ -106,20 +97,12 @@ function animatePhantomLines( phantom, toMorphed ) {
 // Track active morph animations per navigation block element.
 const activeMorphAnimations = new WeakMap();
 
-/**
- * Whether morph animation should play (respects reduced motion preference).
- *
- * @return {boolean} True if animation should play.
- */
+// Whether morph animation should play (respects reduced motion preference).
 function shouldAnimateMorph() {
 	return ! window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
 }
 
-/**
- * Cancel and clean up any in-progress morph animation for a navigation block.
- *
- * @param {HTMLElement} nav - The navigation block element.
- */
+// Cancel and clean up any in-progress morph animation for a navigation block.
 function cleanupMorphAnimation( nav ) {
 	const morph = activeMorphAnimations.get( nav );
 	if ( morph ) {
@@ -132,15 +115,7 @@ function cleanupMorphAnimation( nav ) {
 	}
 }
 
-/**
- * Create a phantom element (clone of the hamburger button) for the flight
- * animation. The phantom is positioned fixed above the overlay and is inert
- * (no click handlers, not focusable, hidden from screen readers).
- *
- * @param {HTMLElement} hamburgerBtn - The hamburger button to clone.
- * @param {boolean}     isMorphed   - Whether to start in the morphed (X) state.
- * @return {HTMLElement} The phantom element, already appended to document.body.
- */
+// Create an inert clone of the hamburger button for the flight animation.
 function createMorphPhantom( hamburgerBtn, isMorphed ) {
 	const phantom = hamburgerBtn.cloneNode( true );
 	// Remove Interactivity API directives so the clone is inert.
@@ -162,14 +137,7 @@ function createMorphPhantom( hamburgerBtn, isMorphed ) {
 	return phantom;
 }
 
-/**
- * Run the open morph animation: hamburger flies to close button, lines → X.
- *
- * @param {HTMLElement} nav          - The navigation block element.
- * @param {HTMLElement} hamburgerBtn - The hamburger button element.
- * @param {HTMLElement} closeBtn     - The overlay close button element.
- * @param {DOMRect}     startRect   - The hamburger's bounding rect (captured before overlay opened).
- */
+// Run the open morph animation: hamburger flies to close button, lines → X.
 function runOpenMorphAnimation( nav, hamburgerBtn, closeBtn, startRect ) {
 	cleanupMorphAnimation( nav );
 
@@ -177,7 +145,7 @@ function runOpenMorphAnimation( nav, hamburgerBtn, closeBtn, startRect ) {
 		return;
 	}
 
-	requestAnimationFrame( () => {
+	window.requestAnimationFrame( () => {
 		const endRect = closeBtn.getBoundingClientRect();
 
 		// Hide the real close button visually but keep it focusable. Using
@@ -233,15 +201,7 @@ function runOpenMorphAnimation( nav, hamburgerBtn, closeBtn, startRect ) {
 	} );
 }
 
-/**
- * Run the close morph animation: X flies back to hamburger, lines restore.
- *
- * @param {HTMLElement} nav           - The navigation block element.
- * @param {HTMLElement} hamburgerBtn  - The hamburger button element.
- * @param {HTMLElement} closeBtn      - The overlay close button element.
- * @param {DOMRect}     hamburgerRect - The hamburger's original bounding rect.
- * @param {Function}    onComplete    - Callback to run after animation finishes.
- */
+// Run the close morph animation: X flies back to hamburger, lines restore.
 function runCloseMorphAnimation(
 	nav,
 	hamburgerBtn,
@@ -376,9 +336,7 @@ const { state, actions } = store(
 				// Capture hamburger position before the overlay covers it.
 				// Only for the "handle" icon variant (has rect-based SVG lines).
 				if (
-					ref.querySelector(
-						'.wp-block-navigation__hamburger-line'
-					)
+					ref.querySelector( '.wp-block-navigation__hamburger-line' )
 				) {
 					const rect = ref.getBoundingClientRect();
 					ctx.morphStartRect = {
@@ -580,8 +538,7 @@ const { state, actions } = store(
 							// exact viewport position so the morph ends
 							// where it started.
 							closeBtn.style.position = 'fixed';
-							closeBtn.style.top =
-								ctx.morphStartRect.top + 'px';
+							closeBtn.style.top = ctx.morphStartRect.top + 'px';
 							closeBtn.style.left =
 								ctx.morphStartRect.left + 'px';
 							closeBtn.style.right = 'auto';

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -63,7 +63,7 @@ const MORPH_LINE_TRANSFORM = [
 	'translateY(3.75px) rotate(45deg) scaleX(1.24)',
 	'translateY(-3.75px) rotate(-45deg) scaleX(1.24)',
 ];
-const MORPH_LINE_IDENTITY = 'translateY(0) rotate(0) scaleX(1)';
+const MORPH_LINE_IDENTITY = 'translateY(0px) rotate(0deg) scaleX(1)';
 
 /**
  * Animate a phantom's two hamburger-line rects from one transform to another.
@@ -77,16 +77,22 @@ function animatePhantomLines( phantom, toMorphed ) {
 		'.wp-block-navigation__hamburger-line'
 	);
 	lines.forEach( ( line, i ) => {
+		const startTransform = toMorphed
+			? MORPH_LINE_IDENTITY
+			: MORPH_LINE_TRANSFORM[ i ];
+		const endTransform = toMorphed
+			? MORPH_LINE_TRANSFORM[ i ]
+			: MORPH_LINE_IDENTITY;
+		// Pre-set the starting transform inline so the first paint shows
+		// the correct state even if the WAAPI effect hasn't been sampled
+		// yet (particularly important for the reverse direction, where
+		// the CSS default doesn't match the animation's first keyframe).
+		line.style.transform = startTransform;
 		line.animate(
-			toMorphed
-				? [
-						{ transform: MORPH_LINE_IDENTITY },
-						{ transform: MORPH_LINE_TRANSFORM[ i ] },
-				  ]
-				: [
-						{ transform: MORPH_LINE_TRANSFORM[ i ] },
-						{ transform: MORPH_LINE_IDENTITY },
-				  ],
+			[
+				{ transform: startTransform },
+				{ transform: endTransform },
+			],
 			{
 				duration: MORPH_DURATION,
 				easing: MORPH_EASING,
@@ -119,7 +125,7 @@ function cleanupMorphAnimation( nav ) {
 		morph.animation?.cancel();
 		morph.phantom?.remove();
 		if ( morph.closeBtn ) {
-			morph.closeBtn.style.visibility = '';
+			morph.closeBtn.style.opacity = '';
 		}
 		activeMorphAnimations.delete( nav );
 	}
@@ -173,8 +179,12 @@ function runOpenMorphAnimation( nav, hamburgerBtn, closeBtn, startRect ) {
 	requestAnimationFrame( () => {
 		const endRect = closeBtn.getBoundingClientRect();
 
-		// Hide the real close button during the animation.
-		closeBtn.style.visibility = 'hidden';
+		// Hide the real close button visually but keep it focusable. Using
+		// visibility/display would remove focus from the close button after
+		// it's clicked, firing a focusout with a null relatedTarget that
+		// handleMenuFocusout reads as "focus left the menu" — closing it
+		// and aborting our morph.
+		closeBtn.style.opacity = '0';
 
 		// Create phantom at the hamburger's captured position (un-morphed).
 		const phantom = createMorphPhantom( hamburgerBtn, false );
@@ -216,7 +226,7 @@ function runOpenMorphAnimation( nav, hamburgerBtn, closeBtn, startRect ) {
 
 		animation.onfinish = () => {
 			phantom.remove();
-			closeBtn.style.visibility = '';
+			closeBtn.style.opacity = '';
 			activeMorphAnimations.delete( nav );
 		};
 	} );
@@ -247,8 +257,9 @@ function runCloseMorphAnimation(
 
 	const closeRect = closeBtn.getBoundingClientRect();
 
-	// Hide the real close button.
-	closeBtn.style.visibility = 'hidden';
+	// Hide the real close button visually but keep it focusable; see the
+	// matching comment in runOpenMorphAnimation.
+	closeBtn.style.opacity = '0';
 
 	// Create the phantom without the morphed class; WAAPI applies the
 	// X transform as its first keyframe and then animates back.

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -45,6 +45,218 @@ function getFocusableElements( ref ) {
 // capture the clicks, instead of relying on the focusout event.
 document.addEventListener( 'click', () => {} );
 
+/**
+ * Hamburger-to-close morph animation.
+ *
+ * When a Navigation block has a custom overlay with a Navigation Overlay Close
+ * block, the hamburger icon flies to the close button's position while its two
+ * horizontal lines morph into an X. The reverse plays on close.
+ */
+const MORPH_DURATION = 350;
+const MORPH_EASING = 'cubic-bezier(0.4, 0, 0.2, 1)';
+
+// Track active morph animations per navigation block element.
+const activeMorphAnimations = new WeakMap();
+
+/**
+ * Whether morph animation should play (respects reduced motion preference).
+ *
+ * @return {boolean} True if animation should play.
+ */
+function shouldAnimateMorph() {
+	return ! window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+}
+
+/**
+ * Cancel and clean up any in-progress morph animation for a navigation block.
+ *
+ * @param {HTMLElement} nav - The navigation block element.
+ */
+function cleanupMorphAnimation( nav ) {
+	const morph = activeMorphAnimations.get( nav );
+	if ( morph ) {
+		morph.animation?.cancel();
+		morph.phantom?.remove();
+		if ( morph.closeBtn ) {
+			morph.closeBtn.style.visibility = '';
+		}
+		activeMorphAnimations.delete( nav );
+	}
+}
+
+/**
+ * Create a phantom element (clone of the hamburger button) for the flight
+ * animation. The phantom is positioned fixed above the overlay and is inert
+ * (no click handlers, not focusable, hidden from screen readers).
+ *
+ * @param {HTMLElement} hamburgerBtn - The hamburger button to clone.
+ * @param {boolean}     isMorphed   - Whether to start in the morphed (X) state.
+ * @return {HTMLElement} The phantom element, already appended to document.body.
+ */
+function createMorphPhantom( hamburgerBtn, isMorphed ) {
+	const phantom = hamburgerBtn.cloneNode( true );
+	// Remove Interactivity API directives so the clone is inert.
+	phantom.removeAttribute( 'data-wp-on--click' );
+	phantom.removeAttribute( 'data-wp-on--keydown' );
+	phantom.setAttribute( 'aria-hidden', 'true' );
+	phantom.setAttribute( 'tabindex', '-1' );
+	phantom.classList.add( 'wp-block-navigation__morph-phantom' );
+	phantom.style.position = 'fixed';
+	phantom.style.zIndex = '100001';
+	phantom.style.pointerEvents = 'none';
+	phantom.style.margin = '0';
+	// Inherit the computed color so the phantom matches the hamburger's theme.
+	phantom.style.color = window.getComputedStyle( hamburgerBtn ).color;
+	if ( isMorphed ) {
+		phantom.classList.add( 'is-morphed' );
+	}
+	document.body.appendChild( phantom );
+	return phantom;
+}
+
+/**
+ * Run the open morph animation: hamburger flies to close button, lines → X.
+ *
+ * @param {HTMLElement} nav          - The navigation block element.
+ * @param {HTMLElement} hamburgerBtn - The hamburger button element.
+ * @param {HTMLElement} closeBtn     - The overlay close button element.
+ * @param {DOMRect}     startRect   - The hamburger's bounding rect (captured before overlay opened).
+ */
+function runOpenMorphAnimation( nav, hamburgerBtn, closeBtn, startRect ) {
+	cleanupMorphAnimation( nav );
+
+	if ( ! shouldAnimateMorph() ) {
+		return;
+	}
+
+	requestAnimationFrame( () => {
+		const endRect = closeBtn.getBoundingClientRect();
+
+		// Hide the real close button during the animation.
+		closeBtn.style.visibility = 'hidden';
+
+		// Create phantom at the hamburger's captured position (un-morphed).
+		const phantom = createMorphPhantom( hamburgerBtn, false );
+		phantom.style.top = startRect.top + 'px';
+		phantom.style.left = startRect.left + 'px';
+
+		// Calculate the translation to fly from hamburger to close button,
+		// centering on the close button's position.
+		const dx =
+			endRect.left +
+			( endRect.width - startRect.width ) / 2 -
+			startRect.left;
+		const dy =
+			endRect.top +
+			( endRect.height - startRect.height ) / 2 -
+			startRect.top;
+
+		// Use a second rAF so the browser paints the phantom at start position
+		// before the transition begins.
+		requestAnimationFrame( () => {
+			// Trigger the CSS morph transition (horizontal lines → X).
+			phantom.classList.add( 'is-morphed' );
+
+			// Fly the phantom from hamburger to close button position.
+			const animation = phantom.animate(
+				[
+					{ transform: 'translate(0, 0)' },
+					{
+						transform: `translate(${ dx }px, ${ dy }px)`,
+					},
+				],
+				{
+					duration: MORPH_DURATION,
+					easing: MORPH_EASING,
+					fill: 'forwards',
+				}
+			);
+
+			activeMorphAnimations.set( nav, {
+				animation,
+				phantom,
+				closeBtn,
+			} );
+
+			animation.onfinish = () => {
+				phantom.remove();
+				closeBtn.style.visibility = '';
+				activeMorphAnimations.delete( nav );
+			};
+		} );
+	} );
+}
+
+/**
+ * Run the close morph animation: X flies back to hamburger, lines restore.
+ *
+ * @param {HTMLElement} nav           - The navigation block element.
+ * @param {HTMLElement} hamburgerBtn  - The hamburger button element.
+ * @param {HTMLElement} closeBtn      - The overlay close button element.
+ * @param {DOMRect}     hamburgerRect - The hamburger's original bounding rect.
+ * @param {Function}    onComplete    - Callback to run after animation finishes.
+ */
+function runCloseMorphAnimation(
+	nav,
+	hamburgerBtn,
+	closeBtn,
+	hamburgerRect,
+	onComplete
+) {
+	cleanupMorphAnimation( nav );
+
+	if ( ! shouldAnimateMorph() ) {
+		onComplete();
+		return;
+	}
+
+	const closeRect = closeBtn.getBoundingClientRect();
+
+	// Hide the real close button.
+	closeBtn.style.visibility = 'hidden';
+
+	// Create phantom at close button's position (morphed as X).
+	const phantom = createMorphPhantom( hamburgerBtn, true );
+	phantom.style.top = closeRect.top + 'px';
+	phantom.style.left = closeRect.left + 'px';
+
+	// Calculate translation back to hamburger position.
+	const dx =
+		hamburgerRect.left +
+		( hamburgerRect.width - closeRect.width ) / 2 -
+		closeRect.left;
+	const dy =
+		hamburgerRect.top +
+		( hamburgerRect.height - closeRect.height ) / 2 -
+		closeRect.top;
+
+	requestAnimationFrame( () => {
+		// Trigger the CSS morph transition (X → horizontal lines).
+		phantom.classList.remove( 'is-morphed' );
+
+		// Fly the phantom from close button to hamburger position.
+		const animation = phantom.animate(
+			[
+				{ transform: 'translate(0, 0)' },
+				{ transform: `translate(${ dx }px, ${ dy }px)` },
+			],
+			{
+				duration: MORPH_DURATION,
+				easing: MORPH_EASING,
+				fill: 'forwards',
+			}
+		);
+
+		activeMorphAnimations.set( nav, { animation, phantom, closeBtn } );
+
+		animation.onfinish = () => {
+			phantom.remove();
+			activeMorphAnimations.delete( nav );
+			onComplete();
+		};
+	} );
+}
+
 const { state, actions } = store(
 	'core/navigation',
 	{
@@ -116,9 +328,63 @@ const { state, actions } = store(
 				const ctx = getContext();
 				const { ref } = getElement();
 				ctx.previousFocus = ref;
+
+				// Capture hamburger position before the overlay covers it.
+				// Only for the "handle" icon variant (has rect-based SVG lines).
+				if (
+					ref.querySelector(
+						'.wp-block-navigation__hamburger-line'
+					)
+				) {
+					const rect = ref.getBoundingClientRect();
+					ctx.morphStartRect = {
+						top: rect.top,
+						left: rect.left,
+						width: rect.width,
+						height: rect.height,
+					};
+				}
+
 				actions.openMenu( 'click' );
 			},
 			closeMenuOnClick() {
+				const ctx = getContext();
+				const { ref } = getElement();
+
+				// Check if the reverse morph animation should play.
+				// Only applies when clicking the Navigation Overlay Close block.
+				if (
+					ctx.morphStartRect &&
+					ref.classList.contains(
+						'wp-block-navigation-overlay-close'
+					)
+				) {
+					const nav = ref.closest( '.wp-block-navigation' );
+					const hamburgerBtn = nav?.querySelector(
+						'.wp-block-navigation__responsive-container-open'
+					);
+
+					if (
+						nav &&
+						hamburgerBtn &&
+						hamburgerBtn.querySelector(
+							'.wp-block-navigation__hamburger-line'
+						)
+					) {
+						runCloseMorphAnimation(
+							nav,
+							hamburgerBtn,
+							ref,
+							ctx.morphStartRect,
+							() => {
+								actions.closeMenu( 'click' );
+								actions.closeMenu( 'focus' );
+							}
+						);
+						return;
+					}
+				}
+
 				actions.closeMenu( 'click' );
 				actions.closeMenu( 'focus' );
 			},
@@ -237,6 +503,33 @@ const { state, actions } = store(
 					ctx.firstFocusableElement = focusableElements[ 0 ];
 					ctx.lastFocusableElement =
 						focusableElements[ focusableElements.length - 1 ];
+
+					// Trigger the open morph animation if applicable.
+					if ( ctx.morphStartRect ) {
+						const nav = ref.closest( '.wp-block-navigation' );
+						const hamburgerBtn = nav?.querySelector(
+							'.wp-block-navigation__responsive-container-open'
+						);
+						const closeBtn = ref.querySelector(
+							'.wp-block-navigation-overlay-close'
+						);
+
+						if ( nav && hamburgerBtn && closeBtn ) {
+							runOpenMorphAnimation(
+								nav,
+								hamburgerBtn,
+								closeBtn,
+								ctx.morphStartRect
+							);
+						}
+					}
+				} else if ( ctx.type === 'overlay' ) {
+					// Menu closed — clean up any in-progress morph animation
+					// (e.g. if Escape was pressed during a close animation).
+					const nav = ref.closest( '.wp-block-navigation' );
+					if ( nav ) {
+						cleanupMorphAnimation( nav );
+					}
 				}
 			},
 			focusFirstElement() {

--- a/test/integration/fixtures/blocks/core__navigation.json
+++ b/test/integration/fixtures/blocks/core__navigation.json
@@ -6,6 +6,7 @@
 			"showSubmenuIcon": true,
 			"submenuVisibility": "hover",
 			"overlayMenu": "mobile",
+			"overlayMenuIconAnimation": true,
 			"icon": "handle",
 			"hasIcon": true,
 			"maxNestingLevel": 5


### PR DESCRIPTION
## What?

Adds a flying morph animation for the Navigation block's hamburger icon. When the responsive overlay opens, the hamburger flies to the overlay close button's position while its two horizontal lines rotate into an X. The reverse animation plays when the menu is closed from the close button.

This also adds an `overlayMenuIconAnimation` Navigation block attribute, exposes an "Animate menu icon" toggle in the overlay settings panel, and updates the generated block docs plus full-content fixture for the new default attribute.

## Why?

The open and close controls currently appear as two separate buttons. Morphing the hamburger into the close icon makes the transition feel like a single continuous control and clarifies the relationship between opening and closing the overlay.

## How?

A cloned hamburger button is positioned `fixed` above the overlay and animated with the Web Animations API. Its SVG line elements morph into an X while the clone moves from the captured hamburger position to the close button position. The real close button is temporarily hidden with opacity during the flight, reduced-motion preferences are respected, and the animation is limited to the handle icon variant.

The Navigation block context now includes `overlayMenuIconAnimation` so the frontend view script can skip the morph when the setting is disabled.

## Screencaps
Default overlay:

https://github.com/user-attachments/assets/5bfdbe69-973d-4b06-9697-a001d44ab8ea

Custom overlay:

https://github.com/user-attachments/assets/ce696fe8-f1b4-4411-89ca-f72bd7866e06


## Testing Instructions

1. Insert a Navigation block using the handle hamburger icon with a responsive overlay.
2. Open the block settings and confirm the overlay settings include "Animate menu icon".
3. On the frontend, click the hamburger and verify it flies to the close button position while morphing into an X.
4. Click the close button and verify the reverse animation plays before the overlay closes.
5. Disable "Animate menu icon" and confirm the overlay opens and closes without the morph animation.
6. Enable "Reduce motion" in OS/browser settings and confirm the overlay opens and closes without the morph animation.

### Testing Instructions for Keyboard

1. Tab to the hamburger button and press Enter; verify the overlay opens and focus moves into the overlay.
2. Tab to the close button and press Enter; verify the overlay closes and focus returns appropriately.

## Validation

- `npm run test:unit -- test/integration/full-content/full-content.test.js`
- `npm run docs:blocks`
- `git diff --check`

## Use of AI Tools

This PR was authored with assistance from Claude Code and Codex.