### PR TITLE
Support media queries in custom CSS to individual blocks

### DIFF
--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -6,6 +6,161 @@
  */
 
 /**
+ * Splits a raw CSS string into top level segments, at rules with blocks
+ * (e.g. @media, @supports, @layer) and ordinary rule sets.
+ *
+ * Each returned item is an associative array with:
+ *   - 'type'    => 'at-rule' | 'rule'
+ *   - 'header'  => string  (for at-rules: e.g. "@media (min-width: 1024px)")
+ *   - 'inner'   => string  (content between the outermost braces)
+ *   - 'raw'     => string  (full original text, for plain rules)
+ *
+ * @since 23.0.0
+ *
+ * @param string $css Raw CSS string.
+ * @return array<int, array<string, string>> Parsed segments.
+ */
+function gutenberg_split_css_top_level_segments( $css ) {
+	$segments = array();
+	$len      = strlen( $css );
+	$i        = 0;
+
+	while ( $i < $len ) {
+		// Skip whitespace between rules.
+		while ( $i < $len && ctype_space( $css[ $i ] ) ) {
+			++$i;
+		}
+		if ( $i >= $len ) {
+			break;
+		}
+
+		if ( '@' === $css[ $i ] ) {
+			// Collect up to the first '{' or ';'.
+			$j = $i;
+			while ( $j < $len && '{' !== $css[ $j ] && ';' !== $css[ $j ] ) {
+				++$j;
+			}
+
+			if ( $j < $len && '{' === $css[ $j ] ) {
+				$header = trim( substr( $css, $i, $j - $i ) );
+				++$j;
+
+				$depth       = 1;
+				$inner_start = $j;
+				while ( $j < $len && $depth > 0 ) {
+					if ( '{' === $css[ $j ] ) {
+						++$depth;
+					} elseif ( '}' === $css[ $j ] ) {
+						--$depth;
+					}
+					++$j;
+				}
+
+				$inner      = substr( $css, $inner_start, $j - $inner_start - 1 );
+				$segments[] = array(
+					'type'   => 'at-rule',
+					'header' => $header,
+					'inner'  => $inner,
+				);
+				$i          = $j;
+			} elseif ( $j < $len && ';' === $css[ $j ] ) {
+				$segments[] = array(
+					'type' => 'rule',
+					'raw'  => substr( $css, $i, $j - $i + 1 ),
+				);
+				$i          = $j + 1;
+			} else {
+				$i = $j;
+			}
+			continue;
+		}
+
+		$j           = $i;
+		$found_brace = false;
+		$depth       = 0;
+		$end         = -1;
+
+		while ( $j < $len ) {
+			if ( '{' === $css[ $j ] ) {
+				++$depth;
+				$found_brace = true;
+			} elseif ( '}' === $css[ $j ] ) {
+				--$depth;
+				if ( 0 === $depth && $found_brace ) {
+					$end = $j;
+					break;
+				}
+			}
+			++$j;
+		}
+
+		if ( -1 === $end ) {
+			break;
+		}
+
+		$segments[] = array(
+			'type' => 'rule',
+			'raw'  => substr( $css, $i, $end - $i + 1 ),
+		);
+		$i          = $end + 1;
+	}
+
+	return $segments;
+}
+
+/**
+ * This wrapper splits the CSS into top-level segments first.  For each
+ * conditional at rule it delegates only the inner content to the core
+ * processor (so `&` resolution still works), then re wraps the result with
+ * the original at rule header.  Plain rule sets are passed through unchanged.
+ *
+ * @since 23.0.0
+ *
+ * @param string $css      Raw CSS entered by the user.
+ * @param string $selector The block's unique CSS class selector, e.g. '.wp-custom-css-abc123'.
+ * @return string Processed, browser-ready CSS.
+ */
+function gutenberg_process_block_custom_css_with_at_rules( $css, $selector ) {
+	if ( empty( trim( $css ) ) ) {
+		return '';
+	}
+
+	$output   = array();
+	$segments = gutenberg_split_css_top_level_segments( $css );
+
+	foreach ( $segments as $segment ) {
+		if ( 'at-rule' === $segment['type'] ) {
+			/*
+			 * Recursively process the inner content so that:
+			 *   @supports (display: grid) {
+			 *     @media (min-width: 768px) { & { … } }
+			 *   }
+			 * is handled correctly at every nesting depth.
+			 */
+			$processed_inner = gutenberg_process_block_custom_css_with_at_rules(
+				$segment['inner'],
+				$selector
+			);
+
+			if ( ! empty( trim( $processed_inner ) ) ) {
+				$output[] = $segment['header'] . " {\n" . $processed_inner . "\n}";
+			}
+		} else {
+			$processed = WP_Theme_JSON_Gutenberg::process_blocks_custom_css(
+				$segment['raw'],
+				$selector
+			);
+
+			if ( ! empty( trim( $processed ) ) ) {
+				$output[] = $processed;
+			}
+		}
+	}
+
+	return implode( "\n", $output );
+}
+
+/**
  * Render the custom CSS stylesheet and add class name to block as required.
  *
  * @since 7.0.0
@@ -39,9 +194,9 @@ function gutenberg_render_custom_css_support_styles( $parsed_block ) {
 
 	_wp_array_set( $parsed_block, array( 'attrs', 'className' ), $updated_class_name );
 
-	// Process the custom CSS using the same method as global styles.
+	// Process the custom CSS with full at rule support (@media, @supports …).
 	$selector      = '.' . $class_name;
-	$processed_css = WP_Theme_JSON_Gutenberg::process_blocks_custom_css( $custom_css, $selector );
+	$processed_css = gutenberg_process_block_custom_css_with_at_rules( $custom_css, $selector );
 
 	if ( ! empty( $processed_css ) ) {
 		/*

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1522,6 +1522,146 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
+	 * Splits CSS into top level segments and processes each one so that
+	 * conditional at rules (@media, @supports, @layer) are preserved while
+	 * `&` nesting inside them is still resolved correctly.
+	 *
+	 * @since 23.0.0
+	 *
+	 * @param string $css      Raw CSS entered by the user.
+	 * @param string $selector The block's unique CSS class selector.
+	 * @return string Processed, browser-ready CSS.
+	 */
+	public static function process_blocks_custom_css_with_at_rules( $css, $selector ) {
+		if ( empty( trim( $css ) ) ) {
+			return '';
+		}
+
+		$output   = array();
+		$segments = static::split_css_top_level_segments( $css );
+
+		foreach ( $segments as $segment ) {
+			if ( 'at-rule' === $segment['type'] ) {
+				$processed_inner = static::process_blocks_custom_css_with_at_rules(
+					$segment['inner'],
+					$selector
+				);
+
+				if ( ! empty( trim( $processed_inner ) ) ) {
+					$output[] = $segment['header'] . " {\n" . $processed_inner . "\n}";
+				}
+			} else {
+				$processed = static::process_blocks_custom_css( $segment['raw'], $selector );
+
+				if ( ! empty( trim( $processed ) ) ) {
+					$output[] = $processed;
+				}
+			}
+		}
+
+		return implode( "\n", $output );
+	}
+
+	/**
+	 * Splits a raw CSS string into top level segments: at rules with blocks
+	 * (@media, @supports, @layer) and ordinary rule sets.
+	 *
+	 * Each item is one of:
+	 *   [ 'type' => 'at-rule', 'header' => string, 'inner' => string ]
+	 *   [ 'type' => 'rule',    'raw'    => string ]
+	 *
+	 * @since 23.0.0
+	 *
+	 * @param string $css Raw CSS string.
+	 * @return array Parsed top-level segments.
+	 */
+	private static function split_css_top_level_segments( $css ) {
+		$segments = array();
+		$len      = strlen( $css );
+		$i        = 0;
+
+		while ( $i < $len ) {
+			// Skip whitespace between rules.
+			while ( $i < $len && ctype_space( $css[ $i ] ) ) {
+				++$i;
+			}
+			if ( $i >= $len ) {
+				break;
+			}
+
+			if ( '@' === $css[ $i ] ) {
+				$j = $i;
+				while ( $j < $len && '{' !== $css[ $j ] && ';' !== $css[ $j ] ) {
+					++$j;
+				}
+
+				if ( $j < $len && '{' === $css[ $j ] ) {
+					$header = trim( substr( $css, $i, $j - $i ) );
+					++$j;
+
+					$depth       = 1;
+					$inner_start = $j;
+					while ( $j < $len && $depth > 0 ) {
+						if ( '{' === $css[ $j ] ) {
+							++$depth;
+						} elseif ( '}' === $css[ $j ] ) {
+							--$depth;
+						}
+						++$j;
+					}
+
+					$segments[] = array(
+						'type'   => 'at-rule',
+						'header' => $header,
+						'inner'  => substr( $css, $inner_start, $j - $inner_start - 1 ),
+					);
+					$i          = $j;
+				} elseif ( $j < $len && ';' === $css[ $j ] ) {
+					$segments[] = array(
+						'type' => 'rule',
+						'raw'  => substr( $css, $i, $j - $i + 1 ),
+					);
+					$i          = $j + 1;
+				} else {
+					$i = $j;
+				}
+				continue;
+			}
+
+			$j           = $i;
+			$found_brace = false;
+			$depth       = 0;
+			$end         = -1;
+
+			while ( $j < $len ) {
+				if ( '{' === $css[ $j ] ) {
+					++$depth;
+					$found_brace = true;
+				} elseif ( '}' === $css[ $j ] ) {
+					--$depth;
+					if ( 0 === $depth && $found_brace ) {
+						$end = $j;
+						break;
+					}
+				}
+				++$j;
+			}
+
+			if ( -1 === $end ) {
+				break;
+			}
+
+			$segments[] = array(
+				'type' => 'rule',
+				'raw'  => substr( $css, $i, $end - $i + 1 ),
+			);
+			$i          = $end + 1;
+		}
+
+		return $segments;
+	}
+
+	/**
 	 * Processes the CSS, to apply nesting.
 	 *
 	 * @since 6.2.0
@@ -3277,7 +3417,7 @@ class WP_Theme_JSON_Gutenberg {
 
 				// Store custom CSS for the style variation.
 				if ( isset( $style_variation_node['css'] ) ) {
-					$style_variation_custom_css[ $style_variation['selector'] ] = $this->process_blocks_custom_css( $style_variation_node['css'], $style_variation['selector'] );
+					$style_variation_custom_css[ $style_variation['selector'] ] = static::process_blocks_custom_css_with_at_rules( $style_variation_node['css'], $style_variation['selector'] );
 				}
 
 				// Store variation metadata and node for layout styles generation.
@@ -3466,7 +3606,7 @@ class WP_Theme_JSON_Gutenberg {
 				$css_feature_selector = $css_feature_selector['root'] ?? null;
 			}
 			$css_selector = is_string( $css_feature_selector ) ? $css_feature_selector : $selector;
-			$block_rules .= $this->process_blocks_custom_css( $node['css'], $css_selector );
+			$block_rules .= static::process_blocks_custom_css_with_at_rules( $node['css'], $css_selector );
 		}
 
 		return $block_rules;

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -26,6 +26,147 @@ const CUSTOM_CSS_INSTANCE_REFERENCE = {};
 const EMPTY_STYLE = {};
 
 /**
+ * Splits a raw CSS string into top level segments, conditional at rules with
+ * blocks (@media, @supports, @layer …) and ordinary rule sets.
+ *
+ * Each returned item is one of:
+ *   { type: 'at-rule', header: string, inner: string }
+ *   { type: 'rule',    raw: string }
+ *
+ * @param {string} css Raw CSS string.
+ * @return {Array<Object>} Parsed top-level segments.
+ */
+function splitCSSTopLevelSegments( css ) {
+	const segments = [];
+	let i = 0;
+
+	while ( i < css.length ) {
+		// Skip whitespace between rules.
+		while ( i < css.length && css[ i ].trim() === '' ) {
+			i++;
+		}
+		if ( i >= css.length ) {
+			break;
+		}
+
+		if ( css[ i ] === '@' ) {
+			// Advance to the first '{' or ';'.
+			let j = i;
+			while ( j < css.length && css[ j ] !== '{' && css[ j ] !== ';' ) {
+				j++;
+			}
+
+			if ( j < css.length && css[ j ] === '{' ) {
+				const header = css.slice( i, j ).trim();
+				j++;
+
+				// Walk to the matching closing brace, respecting nesting.
+				let depth = 1;
+				const innerStart = j;
+				while ( j < css.length && depth > 0 ) {
+					if ( css[ j ] === '{' ) {
+						depth++;
+					} else if ( css[ j ] === '}' ) {
+						depth--;
+					}
+					j++;
+				}
+
+				segments.push( {
+					type: 'at-rule',
+					header,
+					inner: css.slice( innerStart, j - 1 ),
+				} );
+				i = j;
+			} else if ( j < css.length && css[ j ] === ';' ) {
+				segments.push( { type: 'rule', raw: css.slice( i, j + 1 ) } );
+				i = j + 1;
+			} else {
+				i = j;
+			}
+			continue;
+		}
+
+		let j = i;
+		let depth = 0;
+		let foundBrace = false;
+		let end = -1;
+
+		while ( j < css.length ) {
+			if ( css[ j ] === '{' ) {
+				depth++;
+				foundBrace = true;
+			} else if ( css[ j ] === '}' ) {
+				depth--;
+				if ( depth === 0 && foundBrace ) {
+					end = j;
+					break;
+				}
+			}
+			j++;
+		}
+
+		if ( end === -1 ) {
+			break;
+		}
+
+		segments.push( { type: 'rule', raw: css.slice( i, end + 1 ) } );
+		i = end + 1;
+	}
+
+	return segments;
+}
+
+/**
+ * This function splits the raw CSS into top level segments first.  For each
+ * conditional at rule it delegates only the inner content to processCSSNesting
+ * (so `&` resolution still works as expected), then re-wraps the processed
+ * result with the original at rule header.  Plain rule sets are passed through
+ * unchanged.
+ *
+ * @param {string} css      Raw CSS entered by the user.
+ * @param {string} selector The block's unique CSS class selector, e.g. `.wp-custom-css-abc`.
+ * @return {string} Processed, browser-ready CSS.
+ */
+export function processCustomBlockCSS( css, selector ) {
+	if ( ! css ) {
+		return '';
+	}
+
+	const output = [];
+	const segments = splitCSSTopLevelSegments( css );
+
+	for ( const segment of segments ) {
+		if ( segment.type === 'at-rule' ) {
+			/*
+			 * Recursively process the inner content so that:
+			 *
+			 *   @supports (display: grid) {
+			 *     @media (min-width: 768px) { & { … } }
+			 *   }
+			 *
+			 * is handled correctly at every nesting depth.
+			 */
+			const processedInner = processCustomBlockCSS(
+				segment.inner,
+				selector
+			);
+
+			if ( processedInner.trim() ) {
+				output.push( `${ segment.header } {\n${ processedInner }\n}` );
+			}
+		} else {
+			const processed = processCSSNesting( segment.raw, selector );
+			if ( processed.trim() ) {
+				output.push( processed );
+			}
+		}
+	}
+
+	return output.join( '\n' );
+}
+
+/**
  * Inspector control for custom CSS.
  *
  * @param {Object}   props               Component props.
@@ -120,13 +261,13 @@ function useBlockProps( { style } ) {
 
 	const customCSSSelector = `.${ customCSSIdentifier }`;
 
-	// Transform the custom CSS using the same logic as global styles.
+	// Process the custom CSS with full at rule support (@media, @supports …).
 	// Only process if CSS is valid (doesn't contain HTML markup).
 	const transformedCSS = useMemo( () => {
 		if ( ! isValidCSS ) {
 			return undefined;
 		}
-		return processCSSNesting( customCSS, customCSSSelector );
+		return processCustomBlockCSS( customCSS, customCSSSelector );
 	}, [ customCSS, customCSSSelector, isValidCSS ] );
 
 	// Inject the CSS via style override.

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1483,10 +1483,7 @@ export const transformToStyles = (
 					) };}`;
 				}
 				if ( styles?.css ) {
-					ruleset += processCSSNesting(
-						styles.css,
-						`:root :where(${ selector })`
-					);
+					ruleset += processCustomBlockCSS( styles.css, selector );
 				}
 
 				if ( options.variationStyles && styleVariationSelectors ) {
@@ -1553,9 +1550,9 @@ export const transformToStyles = (
 									) };}`;
 								}
 								if ( styleVariations?.css ) {
-									ruleset += processCSSNesting(
+									ruleset += processCustomBlockCSS(
 										styleVariations.css,
-										`:root :where(${ styleVariationSelector })`
+										styleVariationSelector as string
 									);
 								}
 								// Generate layout styles for the variation if it supports layout and has blockGap defined.
@@ -1813,6 +1810,133 @@ function updateConfigWithSeparator(
 	return config;
 }
 
+/**
+ * Splits a raw CSS string into top-level segments: conditional at rules with
+ * blocks (@media, @supports, @layer) and ordinary rule sets.
+ *
+ * Each item is one of:
+ *   { type: 'at-rule', header: string, inner: string }
+ *   { type: 'rule',    raw:    string }
+ * @param css
+ */
+function splitCSSTopLevelSegments(
+	css: string
+): Array<
+	| { type: 'at-rule'; header: string; inner: string }
+	| { type: 'rule'; raw: string }
+> {
+	const segments: ReturnType< typeof splitCSSTopLevelSegments > = [];
+	let i = 0;
+
+	while ( i < css.length ) {
+		// Skip whitespace between rules.
+		while ( i < css.length && css[ i ].trim() === '' ) {
+			i++;
+		}
+		if ( i >= css.length ) {
+			break;
+		}
+
+		if ( css[ i ] === '@' ) {
+			let j = i;
+			while ( j < css.length && css[ j ] !== '{' && css[ j ] !== ';' ) {
+				j++;
+			}
+
+			if ( j < css.length && css[ j ] === '{' ) {
+				const header = css.slice( i, j ).trim();
+				j++;
+				let depth = 1;
+				const innerStart = j;
+				while ( j < css.length && depth > 0 ) {
+					if ( css[ j ] === '{' ) {
+						depth++;
+					} else if ( css[ j ] === '}' ) {
+						depth--;
+					}
+					j++;
+				}
+				segments.push( {
+					type: 'at-rule',
+					header,
+					inner: css.slice( innerStart, j - 1 ),
+				} );
+				i = j;
+			} else if ( j < css.length && css[ j ] === ';' ) {
+				segments.push( { type: 'rule', raw: css.slice( i, j + 1 ) } );
+				i = j + 1;
+			} else {
+				i = j;
+			}
+			continue;
+		}
+
+		let j = i;
+		let depth = 0;
+		let foundBrace = false;
+		let end = -1;
+		while ( j < css.length ) {
+			if ( css[ j ] === '{' ) {
+				depth++;
+				foundBrace = true;
+			} else if ( css[ j ] === '}' ) {
+				depth--;
+				if ( depth === 0 && foundBrace ) {
+					end = j;
+					break;
+				}
+			}
+			j++;
+		}
+		if ( end === -1 ) {
+			break;
+		}
+
+		segments.push( { type: 'rule', raw: css.slice( i, end + 1 ) } );
+		i = end + 1;
+	}
+
+	return segments;
+}
+
+/**
+ * Like processCSSNesting but preserves top level at rules (@media, @supports, @layer)
+ * by extracting their inner content, processing it recursively, then
+ * re-wrapping with the original at rule header.
+ *
+ * @param css
+ * @param blockSelector
+ */
+export function processCustomBlockCSS(
+	css: string,
+	blockSelector: string
+): string {
+	if ( ! css ) {
+		return '';
+	}
+
+	const output: string[] = [];
+
+	for ( const segment of splitCSSTopLevelSegments( css ) ) {
+		if ( segment.type === 'at-rule' ) {
+			const processedInner = processCustomBlockCSS(
+				segment.inner,
+				blockSelector
+			);
+			if ( processedInner.trim() ) {
+				output.push( `${ segment.header } {\n${ processedInner }\n}` );
+			}
+		} else {
+			const processed = processCSSNesting( segment.raw, blockSelector );
+			if ( processed.trim() ) {
+				output.push( processed );
+			}
+		}
+	}
+
+	return output.join( '\n' );
+}
+
 export function processCSSNesting( css: string, blockSelector: string ) {
 	let processedCSS = '';
 
@@ -1971,7 +2095,7 @@ export function generateGlobalStyles(
 				resolvedCssSelector ??
 				blockSelectors[ blockType.name ].selector;
 			styles.push( {
-				css: processCSSNesting( blockStyles.css, selector ),
+				css: processCustomBlockCSS( blockStyles.css, selector ),
 				isGlobalStyles: true,
 			} );
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/76728

This PR updates the custom CSS feature for individual blocks so that it properly handles media queries and other similar at-rules, like `@supports` or `@layer`.

## Why?
Right now, if you try to add a media query to a block's custom CSS, the final output gets broken. The logic currently ignore the media queries entirely. People need media queries in this tab to create responsive designs, like changing a grid layout on smaller screens, without having to write code in the global stylesheet.

## How?
The code now splits the CSS into parts before doing anything else. When it finds a rule like `@media`, it sets that header aside, processes the CSS inside of it so that features like nesting (`&`) still work perfectly, and then wraps the `@media` header back around the finished result. This new step was added to both the PHP files for the live website and the JavaScript files for the editor screen.

## Testing Instructions
1. Open a post or page in the editor and insert a Group block.
2. Go to the block settings sidebar, open the Advanced panel, and find the Additional CSS box.
3. Paste in a media query, such as: `@media (min-width: 600px) { & { background-color: lightblue; } }`
4. Resize your browser window. Check that the block's background turns blue when the window is wider than 600 pixels.
5. Save the post and check the live front end to make sure the same styling works there.