### PR TITLE
Dashboard: Increase widget spacing with --wp-grid-gap.

### DIFF
--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -18,6 +18,9 @@
 -   Set `data-wp-dashboard-grid-resizing` on the `DashboardGrid` root
     element while any tile resize gesture is active, so consumers can
     adjust styles when the pointer may still hover tiles ([#78234](https://github.com/WordPress/gutenberg/pull/78234)).
+-   Add `--wp-grid-gap` so consumers can set tile spacing per surface
+    without remapping design-system tokens (defaults to
+    `--wpds-dimension-gap-md`).
 
 ### New Features
 

--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -20,7 +20,9 @@
     adjust styles when the pointer may still hover tiles ([#78234](https://github.com/WordPress/gutenberg/pull/78234)).
 -   Add `--wp-grid-gap` so consumers can set tile spacing per surface
     without remapping design-system tokens (defaults to
-    `--wpds-dimension-gap-md`).
+    `--wpds-dimension-gap-xl`).
+-   Increase the default tile gap from `--wpds-dimension-gap-md` to
+    `--wpds-dimension-gap-xl`.
 
 ### New Features
 

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -131,9 +131,9 @@ interface DashboardGridLayoutItem {
 `style`, etc.) flow through. The grid's own layout styles
 (`gridTemplateColumns`, `gridAutoRows`) override any user-supplied
 `style` for those properties. The gap between tiles is owned by the
-design-system gap token (`--wpds-dimension-gap-md` by default). Set
+design-system gap token (`--wpds-dimension-gap-xl` by default). Set
 `--wp-grid-gap` on the grid root or an ancestor to use another gap
-step without remapping `--wpds-dimension-gap-md`.
+step.
 
 #### Child-level props
 
@@ -477,7 +477,7 @@ root itself via `style`). All values fall back to sensible defaults.
 
 | Variable | Default | Applies to |
 |----------|---------|------------|
-| `--wp-grid-gap` | `var(--wpds-dimension-gap-md)` | Gap between tiles on `DashboardGrid`, `DashboardLanes`, and the edit overlay. |
+| `--wp-grid-gap` | `var(--wpds-dimension-gap-xl)` | Gap between tiles on `DashboardGrid`, `DashboardLanes`, and the edit overlay. |
 | `--wp-grid-drag-preview-scale` | `1.05` | Lift scale of the drag-preview functional frame. Set to `1` to disable the lift. |
 | `--wp-grid-placeholder-opacity` | `0.4` | Opacity of the placeholder tile (the original item while a drag is in flight). |
 | `--wp-grid-placeholder-outline-style` | `dashed` | Outline style of the drag placeholder (for example `solid` or `dotted`). |

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -131,9 +131,9 @@ interface DashboardGridLayoutItem {
 `style`, etc.) flow through. The grid's own layout styles
 (`gridTemplateColumns`, `gridAutoRows`) override any user-supplied
 `style` for those properties. The gap between tiles is owned by the
-design-system gap token (`--wpds-dimension-gap-md` by default) and
-is not configurable per instance; theme it through a `ThemeProvider`
-density change or token override.
+design-system gap token (`--wpds-dimension-gap-md` by default). Set
+`--wp-grid-gap` on the grid root or an ancestor to use another gap
+step without remapping `--wpds-dimension-gap-md`.
 
 #### Child-level props
 
@@ -477,6 +477,7 @@ root itself via `style`). All values fall back to sensible defaults.
 
 | Variable | Default | Applies to |
 |----------|---------|------------|
+| `--wp-grid-gap` | `var(--wpds-dimension-gap-md)` | Gap between tiles on `DashboardGrid`, `DashboardLanes`, and the edit overlay. |
 | `--wp-grid-drag-preview-scale` | `1.05` | Lift scale of the drag-preview functional frame. Set to `1` to disable the lift. |
 | `--wp-grid-placeholder-opacity` | `0.4` | Opacity of the placeholder tile (the original item while a drag is in flight). |
 | `--wp-grid-placeholder-outline-style` | `dashed` | Outline style of the drag placeholder (for example `solid` or `dotted`). |

--- a/packages/grid/src/dashboard-grid/grid.module.css
+++ b/packages/grid/src/dashboard-grid/grid.module.css
@@ -1,6 +1,6 @@
 .grid {
 	display: grid;
-	gap: var(--wp-grid-gap, var(--wpds-dimension-gap-md));
+	gap: var(--wp-grid-gap, var(--wpds-dimension-gap-xl));
 	position: relative;
 }
 

--- a/packages/grid/src/dashboard-grid/grid.module.css
+++ b/packages/grid/src/dashboard-grid/grid.module.css
@@ -1,6 +1,6 @@
 .grid {
 	display: grid;
-	gap: var(--wpds-dimension-gap-md);
+	gap: var(--wp-grid-gap, var(--wpds-dimension-gap-md));
 	position: relative;
 }
 

--- a/packages/grid/src/dashboard-grid/index.tsx
+++ b/packages/grid/src/dashboard-grid/index.tsx
@@ -50,10 +50,10 @@ import type { ResizeDelta } from '../shared/types';
 import styles from './grid.module.css';
 
 // Fallback gap in pixels for math that runs before the computed gap
-// can be read from the DOM. Matches the `'md'` step the surface
-// resolves to in CSS (`--wpds-dimension-gap-md`); the next layout
+// can be read from the DOM. Matches the `'xl'` step the surface
+// resolves to in CSS (`--wpds-dimension-gap-xl`); the next layout
 // effect overwrites this with the actual computed value.
-const FALLBACK_GAP_PX = 12;
+const FALLBACK_GAP_PX = 24;
 
 // Default column cap when no explicit `columns` or `minColumnWidth` is
 // supplied. Layered semantics: `columns` acts as a cap and

--- a/packages/grid/src/dashboard-grid/stories/index.story.tsx
+++ b/packages/grid/src/dashboard-grid/stories/index.story.tsx
@@ -827,7 +827,7 @@ function NumberedOverlay( { columns, isActive }: GridOverlayRenderProps ) {
 				inset: 0,
 				display: 'grid',
 				gridTemplateColumns: `repeat(${ columns }, minmax(0, 1fr))`,
-				gap: 'var(--wpds-dimension-gap-md)',
+				gap: 'var(--wpds-dimension-gap-xl)',
 				pointerEvents: 'none',
 				opacity: isActive ? 1 : 0,
 				visibility: isActive ? 'visible' : 'hidden',

--- a/packages/grid/src/dashboard-lanes/index.tsx
+++ b/packages/grid/src/dashboard-lanes/index.tsx
@@ -51,10 +51,10 @@ import type { ResizeDelta } from '../shared/types';
 import styles from './lanes.module.css';
 
 // Fallback gap in pixels for math that runs before the computed gap
-// can be read from the DOM. Matches the `'md'` step the surface
-// resolves to in CSS (`--wpds-dimension-gap-md`); the next layout
+// can be read from the DOM. Matches the `'xl'` step the surface
+// resolves to in CSS (`--wpds-dimension-gap-xl`); the next layout
 // effect overwrites this with the actual computed value.
-const FALLBACK_GAP_PX = 12;
+const FALLBACK_GAP_PX = 24;
 
 // Default lane cap when no explicit `columns` or `minColumnWidth` is
 // supplied. Layered semantics: `columns` acts as a cap and

--- a/packages/grid/src/dashboard-lanes/lanes.module.css
+++ b/packages/grid/src/dashboard-lanes/lanes.module.css
@@ -1,7 +1,7 @@
 .lanes {
 	display: grid-lanes;
-	column-gap: var(--wp-grid-gap, var(--wpds-dimension-gap-md));
-	row-gap: var(--wp-grid-gap, var(--wpds-dimension-gap-md));
+	column-gap: var(--wp-grid-gap, var(--wpds-dimension-gap-xl));
+	row-gap: var(--wp-grid-gap, var(--wpds-dimension-gap-xl));
 	position: relative;
 }
 

--- a/packages/grid/src/dashboard-lanes/lanes.module.css
+++ b/packages/grid/src/dashboard-lanes/lanes.module.css
@@ -1,7 +1,7 @@
 .lanes {
 	display: grid-lanes;
-	column-gap: var(--wpds-dimension-gap-md);
-	row-gap: var(--wpds-dimension-gap-md);
+	column-gap: var(--wp-grid-gap, var(--wpds-dimension-gap-md));
+	row-gap: var(--wp-grid-gap, var(--wpds-dimension-gap-md));
 	position: relative;
 }
 

--- a/packages/grid/src/dashboard-lanes/stories/index.story.tsx
+++ b/packages/grid/src/dashboard-lanes/stories/index.story.tsx
@@ -390,7 +390,7 @@ function NumberedLanesOverlay( { columns, isActive }: GridOverlayRenderProps ) {
 				inset: 0,
 				display: 'grid',
 				gridTemplateColumns: `repeat(${ columns }, minmax(0, 1fr))`,
-				gap: 'var(--wpds-dimension-gap-md)',
+				gap: 'var(--wpds-dimension-gap-xl)',
 				pointerEvents: 'none',
 				opacity: isActive ? 1 : 0,
 				visibility: isActive ? 'visible' : 'hidden',

--- a/packages/grid/src/shared/grid-overlay.module.css
+++ b/packages/grid/src/shared/grid-overlay.module.css
@@ -2,7 +2,7 @@
 	position: absolute;
 	inset: 0;
 	display: grid;
-	gap: var(--wpds-dimension-gap-md);
+	gap: var(--wp-grid-gap, var(--wpds-dimension-gap-md));
 	pointer-events: none;
 	opacity: 0;
 	visibility: hidden;
@@ -69,7 +69,7 @@
 .column {
 	display: flex;
 	flex-direction: column;
-	gap: var(--wpds-dimension-gap-md);
+	gap: var(--wp-grid-gap, var(--wpds-dimension-gap-md));
 	min-width: 0;
 }
 

--- a/packages/grid/src/shared/grid-overlay.module.css
+++ b/packages/grid/src/shared/grid-overlay.module.css
@@ -2,7 +2,7 @@
 	position: absolute;
 	inset: 0;
 	display: grid;
-	gap: var(--wp-grid-gap, var(--wpds-dimension-gap-md));
+	gap: var(--wp-grid-gap, var(--wpds-dimension-gap-xl));
 	pointer-events: none;
 	opacity: 0;
 	visibility: hidden;
@@ -69,7 +69,7 @@
 .column {
 	display: flex;
 	flex-direction: column;
-	gap: var(--wp-grid-gap, var(--wpds-dimension-gap-md));
+	gap: var(--wp-grid-gap, var(--wpds-dimension-gap-xl));
 	min-width: 0;
 }
 

--- a/routes/dashboard/stage.module.css
+++ b/routes/dashboard/stage.module.css
@@ -1,3 +1,3 @@
 .dashboard-widgets-container {
-	margin: var(--wpds-dimension-padding-md);
+	margin: var(--wpds-dimension-padding-2xl);
 }

--- a/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
@@ -1,5 +1,6 @@
 .grid {
 	width: 100%;
+	--wp-grid-gap: var(--wpds-dimension-gap-xl);
 	/* Drag placeholder outline radius: matches `.tile` and `@wordpress/ui` Card (`--wpds-border-radius-lg`). */
 	--wp-grid-placeholder-radius: var(--wpds-border-radius-lg);
 }

--- a/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
@@ -1,6 +1,5 @@
 .grid {
 	width: 100%;
-	--wp-grid-gap: var(--wpds-dimension-gap-xl);
 	/* Drag placeholder outline radius: matches `.tile` and `@wordpress/ui` Card (`--wpds-border-radius-lg`). */
 	--wp-grid-placeholder-radius: var(--wpds-border-radius-lg);
 }


### PR DESCRIPTION
## What

Increases spacing around and between dashboard widgets:

- **Stage inset:** `padding-md` → `padding-2xl` on `.dashboard-widgets-container`
- **Tile gap:** `gap-xl` via a new `--wp-grid-gap` custom property on the widgets wrapper
- **`@wordpress/grid`:** Adds `--wp-grid-gap` (defaults to `--wpds-dimension-gap-md`) on `DashboardGrid`, `DashboardLanes`, and the edit-mode overlay, with README and CHANGELOG updates

`padding-2xl` and `gap-xl` resolve to the same pixel values at each density step (e.g. 24px at default), so the outer inset aligns with the space between tiles.

## Why

At the previous `padding-md` / `gap-md` spacing the Dashboard felt a bit tight and incoherent with other UI (e.g. DataViews).

## How

1. **`@wordpress/grid`** — Tile gap is now `var(--wp-grid-gap, var(--wpds-dimension-gap-md))` in `grid.module.css`, `lanes.module.css`, and `grid-overlay.module.css`. Layout math still reads resolved `column-gap` from the grid root in `useLayoutEffect`.
2. **Dashboard** — Sets `--wp-grid-gap: var(--wpds-dimension-gap-xl)` on the `.grid` wrapper in `widgets.module.css` (inherits into grid surfaces and the edit overlay).
3. **Stage** — Sets `margin: var(--wpds-dimension-padding-2xl)` in `stage.module.css`.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1524" height="955" alt="Screenshot 2026-05-19 at 14 29 13" src="https://github.com/user-attachments/assets/0a39cfe2-e63d-49f4-a2ff-2829247d5cd3" /> | <img width="1523" height="1033" alt="Screenshot 2026-05-19 at 14 24 54" src="https://github.com/user-attachments/assets/ff7d6cb8-6ba1-4153-a9d6-e4f2851d0537" /> |

## Test plan

- [ ] Open the experimental dashboard; confirm increased inset and gap between widgets.
- [ ] Test **grid** and **masonry** layout models.
- [ ] Enter **edit mode**; confirm overlay column markers align with tiles.
- [ ] Drag and resize widgets; confirm layout math and snapping feel correct (no jump on load).
- [ ] Verify Storybook / other `DashboardGrid` consumers still use default `gap-md` when `--wp-grid-gap` is unset.

> [!NOTE]  
> If we prefer to update the default values Grid package itself, that approach would also work. What do y'all prefer?