### PR TITLE
Dashboard: restrict widget icons to just SVGs (no dashicons)

### DIFF
--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -587,6 +587,7 @@ Rule of thumb: anything expressible as plain JSON goes in `widget.json`. Anythin
 Exports a default object that describes the widget's runtime contract: typed attributes, translated labels, example data. The build system injects the `render_module` handle at registration time, so authors don't need to declare it.
 
 ```ts
+import { wordpress } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 type HelloWorldAttributes = {
@@ -597,6 +598,7 @@ type HelloWorldAttributes = {
 const widget = {
 	name: 'my-plugin/hello-world',
 	title: __( 'Hello World', 'my-plugin' ),
+	icon: wordpress,
 	attributes: [
 		{
 			id: 'greeting',

--- a/routes/dashboard/widget-dashboard/components/widget-chrome/widget-chrome.module.css
+++ b/routes/dashboard/widget-dashboard/components/widget-chrome/widget-chrome.module.css
@@ -4,7 +4,7 @@
 
 .widgetChromeHeaderIcon {
 	display: inline-flex;
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--wpds-color-fg-content-neutral);
 }
 
 .widgetChromeContent {

--- a/routes/dashboard/widget-dashboard/components/widget-chrome/widget-chrome.tsx
+++ b/routes/dashboard/widget-dashboard/components/widget-chrome/widget-chrome.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react';
 /**
  * WordPress dependencies
  */
-import { Icon as WCIcon, Spinner } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import {
 	Component,
 	Suspense,
@@ -17,7 +17,7 @@ import {
 import { __ } from '@wordpress/i18n';
 // Dashboard is still experimental.
 // eslint-disable-next-line @wordpress/use-recommended-components
-import { Card, Stack, Notice, VisuallyHidden } from '@wordpress/ui';
+import { Card, Icon, Stack, Notice, VisuallyHidden } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -85,7 +85,7 @@ function Header( { titleId, widgetType }: HeaderProps ) {
 						className={ styles.widgetChromeHeaderIcon }
 						aria-hidden="true"
 					>
-						<WCIcon icon={ widgetType.icon } />
+						<Icon icon={ widgetType.icon } />
 					</span>
 				) }
 				<Card.Title id={ titleId } render={ <h3 /> }>

--- a/routes/dashboard/widget-types/types.ts
+++ b/routes/dashboard/widget-types/types.ts
@@ -13,8 +13,11 @@
 /**
  * External dependencies
  */
-import type { IconType } from '@wordpress/components';
+import type { ComponentProps } from 'react';
 import type { Field } from '@wordpress/dataviews';
+import type { Icon } from '@wordpress/ui';
+
+type IconProps = ComponentProps< typeof Icon >;
 
 /**
  * Widget type identifier, structured as `<widget-namespace>/<widget-name>`.
@@ -58,9 +61,9 @@ export interface WidgetTypeMetadata< Item = unknown > {
 	description?: string;
 
 	/**
-	 * Visual identifier shown in the widget header; dashicon string, React node, or SVG component.
+	 * Visual identifier shown in the widget header.
 	 */
-	icon?: IconType;
+	icon?: IconProps[ 'icon' ];
 
 	/**
 	 * Grouping category. Core provides `dashboard`; plugins and themes may

--- a/widgets/hello-world/widget.ts
+++ b/widgets/hello-world/widget.ts
@@ -1,8 +1,13 @@
 /**
+ * WordPress dependencies
+ */
+import { wordpress } from '@wordpress/icons';
+
+/**
  * Widget type definition
  */
 export default {
 	name: 'core/hello-world',
 	title: 'Hello World',
-	icon: 'wordpress',
+	icon: wordpress,
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Spin-off from https://github.com/WordPress/gutenberg/pull/78060

- Remove support for dashicons for widget icons; only accepts SVGs (such as `@wordpress/icons`)
- Match icon color with header text color

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Supporting dashicons (like blocks do) would require us to use `Icon` from `@wordpress/icons` and which generally also means increased bytes loaded for everyone. If we just support SVGs (which `@wordpress/icons` are) we're simplifying things and enforcing modern looking icons at dashboard.

In future, we might be able to support backend-registered widgets with SVGs easily with a new API shaping up up at https://github.com/WordPress/gutenberg/pull/78332

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Restrict by using `Icon` from `@wordpress/ui` (which doesn't support dashicons) and by setting types to requires SVGs.

<img width="175" height="74" alt="image" src="https://github.com/user-attachments/assets/b4f92276-2a78-424b-ae53-917c2900f8bc" />


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

String value at `widgets/hello-world/widget.ts` would just fail to output an icon now. in the `widget.json` you need to  temporarily remove `"presentation": "full-bleed"` to test the icon.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Colour difference

Before
<img width="356" height="77" alt="image" src="https://github.com/user-attachments/assets/c895dea7-a08d-4ab6-a0eb-ea524550276b" />

After
<img width="359" height="68" alt="image" src="https://github.com/user-attachments/assets/7fbad987-381f-4dd0-a991-3aa2ae53c586" />


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
