### PR TITLE
@wordpress/ui: Compat overlay slot — viewport-sized containing block

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Bug Fixes
 
 -   Apply shared item popup typography to inline lists and empty states ([#78403](https://github.com/WordPress/gutenberg/pull/78403)).
+-   Stretch the compat overlay slot to viewport size so portaled popups stop collapsing to their min-content width — most visible on long-text tooltips, which wrapped to one word per line ([#78441](https://github.com/WordPress/gutenberg/pull/78441)).
 
 ## 0.13.0 (2026-05-14)
 

--- a/packages/ui/src/tooltip/style.module.css
+++ b/packages/ui/src/tooltip/style.module.css
@@ -25,7 +25,7 @@
 		 * positioner (via the shared `.box-sizing` reset utility), so
 		 * the 1px is absorbed and non-FC layout is unchanged.
 		 */
-		@media (forced-colors: active) {
+		@media ( forced-colors: active ) {
 			border: 1px solid CanvasText;
 		}
 	}

--- a/packages/ui/src/utils/css/wp-compat-overlay-slot.module.css
+++ b/packages/ui/src/utils/css/wp-compat-overlay-slot.module.css
@@ -1,24 +1,35 @@
+@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;
+
 /*
  * Compat overlay slot — body-level positioned container that hosts
  * `@wordpress/ui` overlays so they reliably stack in mixed-library
  * compositions. See `getWpCompatOverlaySlot()` for the runtime side.
  *
- * Authored unlayered (outside `@layer wp-ui-*`) so the slot's z-index and
- * positioning win against any `@layer`-scoped rule.
+ * The `.slot` rule is authored unlayered (outside `@layer wp-ui-*`) so the
+ * slot's z-index and positioning win against any `@layer`-scoped rule.
  */
 
 .slot {
-	/* `position: fixed` is load-bearing: `z-index` is ignored on `static`,
-	 * and the slot must be a containing block at viewport `(0, 0)` so
-	 * floating-ui's viewport-relative `top`/`left` resolve correctly. */
+	/* Viewport-sized so `position: absolute` overlay positioners inside
+	 * the slot have a non-zero containing block — otherwise `width: auto`
+	 * popups collapse to their min-content width. */
 	position: fixed;
-	top: 0;
-	/* Physical, not logical. `inset-inline-start: 0` would resolve to
-	 * `right: 0` in RTL and offset every absolute child off-viewport. */
-	/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- See comment above. */
-	left: 0;
-	/* Sits in a reserved billion-scale band above the legacy z-index map in
+	inset: 0;
+	/* Reserved band above the legacy z-index map in
 	 * `packages/base-styles/_z-index.scss`. */
 	z-index: 1000000003;
 	isolation: isolate;
+	/* The slot itself doesn't capture clicks; portaled overlays opt back in
+	 * via the `.slot > *` rule below. */
+	pointer-events: none;
+}
+
+/*
+ * Re-enable interaction for portaled overlays. Placed in the lowest layer
+ * so any consumer can override with a higher-layer (or unlayered) rule.
+ */
+@layer wp-ui-utilities {
+	.slot > * {
+		pointer-events: auto;
+	}
 }


### PR DESCRIPTION
## What?

Stretch the `@wordpress/ui` compat overlay slot to viewport size so portaled overlays — most visibly long-text `Tooltip` popups — stop wrapping to their min-content width (one word per line).

Surfaced while migrating consumers to the new `Tooltip` in [#78411](https://github.com/WordPress/gutenberg/pull/78411).

## Why?

The slot was `position: fixed; top: 0; left: 0;` with no width or height — its only DOM child is `position: absolute`, which doesn't contribute to the parent's intrinsic size, so the slot collapsed to **0×0**. Absolutely-positioned popups inside a 0-width containing block fall back to shrink-to-fit against zero available width → **min-content width** (longest unbreakable word).

The legacy `@wordpress/components` `Tooltip` didn't have this problem because it portaled into `document.body`.

<details>
<summary>Measurement from a minimal browser repro (identical popup CSS in both rows)</summary>

| Slot                                       | Popup width | Popup height        |
| ------------------------------------------ | ----------- | ------------------- |
| `position: fixed; top: 0; left: 0;` (was)  | 65.7 px     | 125.6 px (≈8 lines) |
| `position: fixed; inset: 0;` (this PR)     | 292.6 px    | 24.8 px (1 line)    |

</details>

## How?

1. Slot becomes `position: fixed; inset: 0; pointer-events: none;` — viewport-sized containing block, with `pointer-events: none` so the now-full-bleed slot doesn't intercept clicks on the rest of the page.
2. A `.slot > * { pointer-events: auto; }` rule in the slot's own stylesheet (scoped to `@layer wp-ui-utilities`, the lowest layer) re-enables interaction for portaled overlays. Centralized here so every opt-in component — and any consumer-portaled content via `getWpCompatOverlaySlot()` — gets the right default without each one having to opt back in. A higher-layer or unlayered rule can still override.

<details>
<summary>Opt-in audit — which components currently route their portal into the compat slot</summary>

- `Tooltip`
- `Autocomplete`
- `Select`

`Popover`, `Dialog`, `AlertDialog`, and `Drawer` do **not** opt in (they use base-ui's default `document.body` portaling), so they're unaffected.

</details>

<details>
<summary>Files touched</summary>

- `packages/ui/src/utils/css/wp-compat-overlay-slot.module.css` — slot layout, `pointer-events: none` on the slot, `pointer-events: auto` on `.slot > *` in `@layer wp-ui-utilities`.
- `packages/ui/CHANGELOG.md` — entry under Bug Fixes.

</details>

## Testing Instructions

Existing playground fixtures already mount the compat slot and render an `@wordpress/ui` `Tooltip` / `Select` / `Autocomplete` inside a `@wordpress/components` overlay — they're the natural regression-watch surface:

1. In Storybook, open *Playground / Debug fixtures / WP Compat Overlay Slot / Overlays inside @wordpress/components Modal* (and the `Popover` variant). Open the modal/popover, hover the *Hover me* tooltip trigger, and confirm the tooltip text renders on one line (before this PR it wrapped to roughly one word per line).
2. From the same fixtures, open the `Select` and `Autocomplete` popups inside the modal/popover and confirm clicking an item still selects it (verifies the slot's `> *` rule keeps portaled overlays interactive).
3. With the modal/popover open, click on **regular page content behind** the overlay area to confirm clicks pass through the now-full-bleed slot (the slot itself should not intercept events).
4. `npm run test:unit -- packages/ui/src/utils/test/wp-compat-overlay-slot packages/ui/src/tooltip/test packages/ui/src/form/primitives/autocomplete/test packages/ui/src/form/primitives/select/test` — 52 tests should pass.

### Testing Instructions for Keyboard

No keyboard-surface changes. Focus order, `Esc` to dismiss, etc. behave as before — this PR only adjusts floating layout and pointer-events.

## Screenshots or screencast

|Before (slot 0×0)|After (slot `inset: 0`)|
|-|-|
| <img width="346" height="470" alt="Screenshot 2026-05-19 at 16 12 23" src="https://github.com/user-attachments/assets/5ebae942-03f1-4a04-8775-1e2a33a67cf8" /> | <img width="380" height="488" alt="Screenshot 2026-05-19 at 16 24 43" src="https://github.com/user-attachments/assets/e9db9157-7a9f-4db7-b127-4ce553c6b021" /> |
| <img width="1236" height="483" alt="Screenshot 2026-05-19 at 16 26 40" src="https://github.com/user-attachments/assets/fca9137f-f717-406e-b3bc-e01ba176014c" /> | <img width="1236" height="483" alt="Screenshot 2026-05-19 at 16 26 06" src="https://github.com/user-attachments/assets/d10720cd-b5e8-4aea-ac43-0cc349a9b607" /> |

## Use of AI Tools

This PR was authored with assistance from Cursor (Claude). All changes were reviewed by a human before being committed; the slot change was validated against a minimal standalone browser repro, and unit tests + lint were exercised locally before pushing.

