### PR TITLE
Experiment: Update Classic block deprecation notice

### DIFF
--- a/packages/block-library/src/freeform/migration-notice.js
+++ b/packages/block-library/src/freeform/migration-notice.js
@@ -44,7 +44,7 @@ export default function MigrationNotice( { content, onReplace } ) {
 	return (
 		<Warning actions={ actions }>
 			{ __(
-				'The Classic block is being phased out. Convert this content to blocks for the best editing experience, or move it to a Custom HTML block to preserve the markup as-is.'
+				'The Classic block is being phased out. Convert this content to blocks for the best editing experience, or move it to a Custom HTML block to preserve the original markup.'
 			) }
 		</Warning>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow-up to https://github.com/WordPress/gutenberg/pull/78090#issuecomment-4489073460.

Tweaks the wording of the Classic block deprecation notice introduced by the Classic block deprecation experiment.

## Why?
The updated copy is is clearer  and flows more naturally while keeping the same meaning.

## How?
Updated the notice message in `<MigrationNotice />` component.

## Testing Instructions
1. Enable Gutenberg > Experiments > Blocks > **Classic block migration notice**.
2. Open a post that already contains a Classic block.
3. Confirm the deprecation notice above the content reads:
> The Classic block is being phased out. Convert this content to blocks for the best editing experience, or move it to a Custom HTML block to preserve the original markup.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="670" height="399" alt="F6rPZb6dieibdh4u" src="https://github.com/user-attachments/assets/0af9e942-3cd4-49f8-a7a9-eb9a4474561a" />|<img width="670" height="399" alt="u8kZYwenZ4MLDzCJ" src="https://github.com/user-attachments/assets/91972143-e2ed-4db3-a870-44d756ee4b5f" />|

## Use of AI Tools

Claude Opus 4.7
