### PR TITLE
UI Autocomplete: Fix prop types

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Bug Fixes
 
+-   `Autocomplete`: Fix the TypeScript prop types for the `Root` and `Value` primitives ([#78450](https://github.com/WordPress/gutenberg/pull/78450)).
 -   Apply shared item popup typography to inline lists and empty states ([#78403](https://github.com/WordPress/gutenberg/pull/78403)).
 
 ## 0.13.0 (2026-05-14)

--- a/packages/ui/src/form/primitives/autocomplete/types.ts
+++ b/packages/ui/src/form/primitives/autocomplete/types.ts
@@ -68,15 +68,7 @@ export type AutocompletePopupProps = ComponentProps<
 	positioner?: ReactElement< Omit< PositionerProps, 'children' > >;
 };
 
-export type AutocompleteRootProps = ComponentProps<
-	typeof _Autocomplete.Root
-> & {
-	children?: React.ReactNode;
-};
+export type AutocompleteRootProps< Value = unknown > =
+	_Autocomplete.Root.Props< Value >;
 
-export type AutocompleteValueProps = {
-	/**
-	 * Can be used to override the current value of the autocomplete.
-	 */
-	children?: _Autocomplete.Value.Props[ 'children' ];
-};
+export type AutocompleteValueProps = _Autocomplete.Value.Props;


### PR DESCRIPTION
## What?

Fix the exported prop types for the `@wordpress/ui` Autocomplete `Root` and `Value` primitives.

## Why?

There were some mistakes in the types.

## Testing Instructions

None