### PR TITLE
Media Fields: Fix filename truncation with Tooltip

### DIFF
--- a/packages/media-fields/src/filename/style.scss
+++ b/packages/media-fields/src/filename/style.scss
@@ -1,0 +1,8 @@
+.dataviews-media-field__filename {
+	display: inline-block;
+	max-inline-size: 15ch;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	vertical-align: top;
+}

--- a/packages/media-fields/src/filename/style.scss
+++ b/packages/media-fields/src/filename/style.scss
@@ -1,8 +1,14 @@
+// CSS-based truncation (rather than `__experimentalTruncate`) so the full
+// filename stays in the DOM — keeps it available to assistive technology
+// reading the row, and lets the cell respond to column width changes.
 .dataviews-media-field__filename {
 	display: inline-block;
 	max-inline-size: 15ch;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	// Snap to the top of the line box so the cell aligns correctly in the
+	// DataViews Grid layout — without this the inline-block sits on the
+	// baseline and pushes the row out of alignment.
 	vertical-align: top;
 }

--- a/packages/media-fields/src/filename/test/view.test.tsx
+++ b/packages/media-fields/src/filename/test/view.test.tsx
@@ -17,7 +17,7 @@ import type { MediaItem } from '../../types';
 
 describe( 'FileNameView', () => {
 	describe( 'filename rendering', () => {
-		it( 'renders short filename without a title attribute', () => {
+		it( 'renders short filename without a tooltip anchor or tabindex', () => {
 			const item: Partial< MediaItem > = {
 				source_url: 'https://example.com/uploads/12345678901.jpg', // exactly 15 chars
 			};
@@ -31,10 +31,10 @@ describe( 'FileNameView', () => {
 
 			const rendered = screen.getByText( '12345678901.jpg' );
 			expect( rendered ).toHaveClass( 'dataviews-media-field__filename' );
-			expect( rendered ).not.toHaveAttribute( 'title' );
+			expect( rendered ).not.toHaveAttribute( 'tabindex' );
 		} );
 
-		it( 'renders long filename with full name as title attribute', () => {
+		it( 'renders long filename inside a Tooltip and exposes the full name in the DOM', () => {
 			const longFilename =
 				'very-long-filename-that-exceeds-fifteen-characters.jpg';
 			const item: Partial< MediaItem > = {
@@ -50,10 +50,9 @@ describe( 'FileNameView', () => {
 
 			// CSS handles the visual ellipsis; the DOM text remains the full
 			// filename so assistive technology reading the row gets the
-			// complete name, and the title attribute exposes it on hover.
+			// complete name, and the Tooltip exposes it on mouse hover.
 			const rendered = screen.getByText( longFilename );
 			expect( rendered ).toHaveClass( 'dataviews-media-field__filename' );
-			expect( rendered ).toHaveAttribute( 'title', longFilename );
 		} );
 
 		it( 'does not add a tab stop for truncated filenames', () => {
@@ -70,8 +69,9 @@ describe( 'FileNameView', () => {
 				/>
 			);
 
-			expect( screen.getByTitle( longFilename ) ).not.toHaveAttribute(
-				'tabindex'
+			expect( screen.getByText( longFilename ) ).toHaveAttribute(
+				'tabindex',
+				'-1'
 			);
 		} );
 	} );

--- a/packages/media-fields/src/filename/test/view.test.tsx
+++ b/packages/media-fields/src/filename/test/view.test.tsx
@@ -17,7 +17,7 @@ import type { MediaItem } from '../../types';
 
 describe( 'FileNameView', () => {
 	describe( 'filename rendering', () => {
-		it( 'renders short filename (15 characters or less)', () => {
+		it( 'renders short filename without a title attribute', () => {
 			const item: Partial< MediaItem > = {
 				source_url: 'https://example.com/uploads/12345678901.jpg', // exactly 15 chars
 			};
@@ -29,11 +29,12 @@ describe( 'FileNameView', () => {
 				/>
 			);
 
-			// Verify the filename is visible to users
-			expect( screen.getByText( '12345678901.jpg' ) ).toBeInTheDocument();
+			const rendered = screen.getByText( '12345678901.jpg' );
+			expect( rendered ).toHaveClass( 'dataviews-media-field__filename' );
+			expect( rendered ).not.toHaveAttribute( 'title' );
 		} );
 
-		it( 'renders long filename (more than 15 characters)', () => {
+		it( 'renders long filename with full name as title attribute', () => {
 			const longFilename =
 				'very-long-filename-that-exceeds-fifteen-characters.jpg';
 			const item: Partial< MediaItem > = {
@@ -47,11 +48,31 @@ describe( 'FileNameView', () => {
 				/>
 			);
 
-			// Verify the full filename text is accessible to users
-			// (the component handles truncation via Truncate/Tooltip, but the text is still present)
-			expect(
-				screen.getByText( longFilename.slice( 0, 15 ) + '…' )
-			).toBeInTheDocument();
+			// CSS handles the visual ellipsis; the DOM text remains the full
+			// filename so assistive technology reading the row gets the
+			// complete name, and the title attribute exposes it on hover.
+			const rendered = screen.getByText( longFilename );
+			expect( rendered ).toHaveClass( 'dataviews-media-field__filename' );
+			expect( rendered ).toHaveAttribute( 'title', longFilename );
+		} );
+
+		it( 'does not add a tab stop for truncated filenames', () => {
+			const longFilename =
+				'very-long-filename-that-exceeds-fifteen-characters.jpg';
+			const item: Partial< MediaItem > = {
+				source_url: `https://example.com/uploads/${ longFilename }`,
+			};
+
+			render(
+				<FileNameView
+					item={ item as MediaItem }
+					field={ filenameField as NormalizedField< MediaItem > }
+				/>
+			);
+
+			expect( screen.getByTitle( longFilename ) ).not.toHaveAttribute(
+				'tabindex'
+			);
 		} );
 	} );
 

--- a/packages/media-fields/src/filename/view.tsx
+++ b/packages/media-fields/src/filename/view.tsx
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { Tooltip as WCTooltip } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { getFilename } from '@wordpress/url';
 import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
@@ -10,8 +11,8 @@ import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
 import type { MediaItem } from '../types';
 
 // Proxy threshold for "long enough that the cell will visually truncate" —
-// used to decide whether to expose the full filename via the native `title`
-// attribute. Visual truncation itself is handled in CSS.
+// used to decide whether to wrap the filename in a Tooltip showing the full
+// name on hover. Visual truncation itself is handled in CSS.
 const TRUNCATE_LENGTH = 15;
 
 export default function FileNameView( {
@@ -26,14 +27,24 @@ export default function FileNameView( {
 		return '';
 	}
 
-	const isTruncated = fileName.length > TRUNCATE_LENGTH;
+	if ( fileName.length <= TRUNCATE_LENGTH ) {
+		return (
+			<span className="dataviews-media-field__filename">
+				{ fileName }
+			</span>
+		);
+	}
 
+	// `tabIndex={-1}` keeps the Tooltip anchor out of the keyboard tab order:
+	// Ariakit's `useFocusable` (via TooltipAnchor) preserves an explicit
+	// `tabIndex` on non-natively-focusable elements rather than defaulting it
+	// to `0`. Hover-only reveal is intentional — the full filename text is
+	// already in the DOM for assistive technology reading the row.
 	return (
-		<span
-			className="dataviews-media-field__filename"
-			title={ isTruncated ? fileName : undefined }
-		>
-			{ fileName }
-		</span>
+		<WCTooltip text={ fileName }>
+			<span className="dataviews-media-field__filename" tabIndex={ -1 }>
+				{ fileName }
+			</span>
+		</WCTooltip>
 	);
 }

--- a/packages/media-fields/src/filename/view.tsx
+++ b/packages/media-fields/src/filename/view.tsx
@@ -1,10 +1,6 @@
 /**
  * WordPress dependencies
  */
-import {
-	Tooltip as WCTooltip,
-	__experimentalTruncate as Truncate,
-} from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { getFilename } from '@wordpress/url';
 import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
@@ -13,8 +9,9 @@ import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
  */
 import type { MediaItem } from '../types';
 
-// Hard-coded truncate length to match the available area in the media sidebar.
-// Longer file names will be truncated and wrapped in a tooltip showing the full name.
+// Proxy threshold for "long enough that the cell will visually truncate" —
+// used to decide whether to expose the full filename via the native `title`
+// attribute. Visual truncation itself is handled in CSS.
 const TRUNCATE_LENGTH = 15;
 
 export default function FileNameView( {
@@ -29,13 +26,14 @@ export default function FileNameView( {
 		return '';
 	}
 
-	return fileName.length > TRUNCATE_LENGTH ? (
-		<WCTooltip text={ fileName }>
-			<Truncate limit={ TRUNCATE_LENGTH } ellipsizeMode="tail">
-				{ fileName }
-			</Truncate>
-		</WCTooltip>
-	) : (
-		<>{ fileName }</>
+	const isTruncated = fileName.length > TRUNCATE_LENGTH;
+
+	return (
+		<span
+			className="dataviews-media-field__filename"
+			title={ isTruncated ? fileName : undefined }
+		>
+			{ fileName }
+		</span>
 	);
 }

--- a/packages/media-fields/src/style.scss
+++ b/packages/media-fields/src/style.scss
@@ -1,2 +1,3 @@
 @use "./author/style.scss" as *;
+@use "./filename/style.scss" as *;
 @use "./media_thumbnail/style.scss" as *;


### PR DESCRIPTION
## What?

Update how the filename field truncates its text by avoiding a tab stop while ensuring the full filename is still accessible to screen readers.

Part of:

* #73085 

And addresses the review feedback in: https://github.com/WordPress/gutenberg/pull/78423#issuecomment-4484790384 from @talldan (thanks for catching it!)

## Why?

The previous approach of using `Tooltip` without explicitly setting `tabIndex={ -1 }` on its child meant that in the DataViewsPicker the filename field would receive an extra tab stop while navigating across the media modal by keyboard.

This is unexpected and particularly in large lists makes it harder to navigate around the media library.

From comparing some other web apps, it turns out that in web apps like Google Drive, truncated titles are available via a tooltip on hover, but don't result in a tab stop. By adjusting the filename field to use CSS truncation instead of `Truncate`, we can take a similar approach here while ensuring the full filename is still reachable to screen readers.

## How?

* Remove `Truncate` usage and instead use a `span` with CSS truncation
* For the tooltip, use `tabIndex={ -1 }` to prevent the tab stop

## Testing Instructions

* Enable the Media Upload Modal experiment
* Make sure your media library has a bunch of different files/images of varying filename lengths
* Add an image block and select media library to open the modal
* Switch to the table layout and hover over truncated filenames and you should see the full filename in a tooltip
* Try tabbing across the interface by keyboard and you shouldn't reach the filename itself
* Also switch to the Grid view and make sure the field displays correctly once you make it visible (i.e. via the cog / settings dropdown)
* Bonus points: activate the Media Editor Modal experiment and go to crop an image and switch to the Details tab. Ensure the filename field renders correctly

## Screenshots or screencast <!-- if applicable -->

It should look like this, with no tab stop:

<img width="1600" height="657" alt="image" src="https://github.com/user-attachments/assets/aee8322d-b310-4b73-a0f1-745eff75d07b" />

## Use of AI Tools

Claude Code