### PR TITLE
Media Editor Modal: Fix unexpected tab stop on date fields in the Details sidebar

### DIFF
--- a/packages/media-editor/src/components/media-form/sidebar-datetime-view.tsx
+++ b/packages/media-editor/src/components/media-form/sidebar-datetime-view.tsx
@@ -27,9 +27,21 @@ export default function SidebarDatetimeView( {
 		settings.formats.datetimeAbbreviated,
 		getDate( value )
 	);
+	// `aria-label` makes assistive tech announce the full date (the visible
+	// text is a shortened summary; `<time dateTime>` is for machines, not
+	// announced by screen readers). `tabIndex={-1}` keeps the Tooltip anchor
+	// out of the keyboard tab order — Ariakit's `useFocusable` preserves an
+	// explicit `tabIndex` on non-natively-focusable elements rather than
+	// defaulting it to `0`. The Tooltip remains available on mouse hover.
 	return (
 		<WCTooltip text={ fullDatetime } placement="top">
-			<time dateTime={ value }>{ dateOnly }</time>
+			<time
+				dateTime={ value }
+				aria-label={ fullDatetime }
+				tabIndex={ -1 }
+			>
+				{ dateOnly }
+			</time>
 		</WCTooltip>
 	);
 }

--- a/packages/media-editor/src/components/media-form/test/sidebar-datetime-view.test.tsx
+++ b/packages/media-editor/src/components/media-form/test/sidebar-datetime-view.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { dateI18n, getDate, getSettings } from '@wordpress/date';
+import type { NormalizedField } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import SidebarDatetimeView from '../sidebar-datetime-view';
+import type { Media } from '../../media-editor-provider';
+
+function makeField(
+	value: string | null | undefined
+): NormalizedField< Media > {
+	return {
+		id: 'date_created',
+		type: 'datetime',
+		label: 'Date created',
+		getValue: () => value,
+	} as unknown as NormalizedField< Media >;
+}
+
+describe( 'SidebarDatetimeView', () => {
+	it( 'exposes the full datetime to assistive tech via aria-label', () => {
+		const value = '2026-05-20T14:30:00';
+		const settings = getSettings();
+		const fullDatetime = dateI18n(
+			settings.formats.datetimeAbbreviated,
+			getDate( value )
+		);
+
+		render(
+			<SidebarDatetimeView
+				item={ {} as Media }
+				field={ makeField( value ) }
+			/>
+		);
+
+		const rendered = screen.getByLabelText( fullDatetime );
+		expect( rendered.tagName ).toBe( 'TIME' );
+		expect( rendered ).toHaveAttribute( 'datetime', value );
+	} );
+
+	it( 'does not add a tab stop for the datetime anchor', () => {
+		const value = '2026-05-20T14:30:00';
+		const settings = getSettings();
+		const fullDatetime = dateI18n(
+			settings.formats.datetimeAbbreviated,
+			getDate( value )
+		);
+
+		render(
+			<SidebarDatetimeView
+				item={ {} as Media }
+				field={ makeField( value ) }
+			/>
+		);
+
+		expect( screen.getByLabelText( fullDatetime ) ).toHaveAttribute(
+			'tabindex',
+			'-1'
+		);
+	} );
+
+	it( 'shows the short date as visible text', () => {
+		const value = '2026-05-20T14:30:00';
+		const settings = getSettings();
+		const dateOnly = dateI18n( settings.formats.date, getDate( value ) );
+
+		render(
+			<SidebarDatetimeView
+				item={ {} as Media }
+				field={ makeField( value ) }
+			/>
+		);
+
+		expect( screen.getByText( dateOnly ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders nothing when the field value is missing', () => {
+		const { container } = render(
+			<SidebarDatetimeView
+				item={ {} as Media }
+				field={ makeField( null ) }
+			/>
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );


### PR DESCRIPTION
## What?

Part of:

* #73771 

Remove the unexpected tab stop in the Details tab of the experimental Media Editor Modal for the date added field (or, well, the date fields that we override in the form component).

## Why?

This is a very similar PR to the one to fix the truncation of the filename field (#78453). Currently in trunk, in the details sidebar, if you tab through you unexpectedly land on both the "Date added" and "File name" fields because of their tooltips. #78453 fixes the file name field, and this PR fixes the Date added field.

In principle, what we want is for the full field value to be available to screen readers (and either be in the DOM markup or in an `aria-label` attribute) and for the tooltip to be available via hover. These fields should not create tab stops as they are otherwise non-interactive and are not buttons or input fields.

## How?

* Add `tabIndex={ -1 }` to ensure the overridden field does not create a tab stop
* Include the full date string in an `aria-label` attribute
* Add some test coverage

## Testing Instructions

* Enable the Media Editor Modal experiment
* Add an image block (and an image) to a post or page
* Click the Crop icon in the block toolbar to open the media editor modal
* Go to the details tab and try tabbing through via the keyboard. You should not be able to land on the `Date added` field.
* If you hover, you should still be able to see the full date string
* Note that you also shouldn't be able to land on the file name field, but that's being fixed separately over in #78453

## Screenshots or screencast <!-- if applicable -->

This is the field I'm talking about. If you tab down from the close button you shouldn't be able to land on the "Date added" field, but the Tooltip should still be available on hover.

<img width="408" height="362" alt="image" src="https://github.com/user-attachments/assets/4077e15c-e480-4308-8f78-ded75c553def" />

## Use of AI Tools

Claude Code