### PR TITLE
Font Library: Normalize variant preview labels between Install and Library tabs

### DIFF
--- a/packages/global-styles-ui/src/font-library/collection-font-variant.tsx
+++ b/packages/global-styles-ui/src/font-library/collection-font-variant.tsx
@@ -38,7 +38,7 @@ function CollectionFontVariant( {
 				/>
 				<label htmlFor={ checkboxId }>
 					<FontDemo
-						font={ face }
+						font={ { ...face, preview: undefined } }
 						text={ displayName }
 						onClick={ handleToggleActivation }
 					/>

--- a/packages/global-styles-ui/src/font-library/library-font-variant.tsx
+++ b/packages/global-styles-ui/src/font-library/library-font-variant.tsx
@@ -53,7 +53,7 @@ function LibraryFontVariant( {
 				/>
 				<label htmlFor={ checkboxId }>
 					<FontDemo
-						font={ face }
+						font={ { ...face, preview: undefined } }
 						text={ displayName }
 						onClick={ handleToggleActivation }
 					/>

--- a/packages/global-styles-ui/src/font-library/utils/index.ts
+++ b/packages/global-styles-ui/src/font-library/utils/index.ts
@@ -8,7 +8,7 @@ import type { DataRegistry } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { FONT_WEIGHTS, FONT_STYLES } from './constants';
+import { FONT_STYLES } from './constants';
 import { fetchInstallFontFace } from '../api';
 import { formatFontFaceName } from './preview-styles';
 import type { FontFamilyToUpload, FontUploadResult } from '../types';
@@ -41,12 +41,22 @@ export function isUrlEncoded( url: string ): boolean {
 }
 
 export function getFontFaceVariantName( face: FontFace ): string {
-	const weightName = FONT_WEIGHTS[ face.fontWeight ?? '' ] || face.fontWeight;
 	const styleName =
-		face.fontStyle === 'normal'
-			? ''
-			: FONT_STYLES[ face.fontStyle ?? '' ] || face.fontStyle;
-	return `${ weightName } ${ styleName }`;
+		FONT_STYLES[ face.fontStyle ?? 'normal' ] || face.fontStyle;
+	const fontWeight = String( face.fontWeight ?? '' ).trim();
+	const rangeMatch = fontWeight.match( /^(\d+)\s+\d+$/ );
+	const keywordToWeight: Record< string, string > = {
+		normal: '400',
+		bold: '700',
+	};
+	const weightValue =
+		rangeMatch?.[ 1 ] || keywordToWeight[ fontWeight ] || fontWeight;
+
+	if ( rangeMatch ) {
+		return `${ weightValue } ${ styleName }`;
+	}
+
+	return `${ weightValue } ${ styleName }`;
 }
 
 export function mergeFontFaces(

--- a/packages/global-styles-ui/src/test/utils.spec.js
+++ b/packages/global-styles-ui/src/test/utils.spec.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { getNewIndexFromPresets } from '../utils';
+import { getFontFaceVariantName } from '../font-library/utils';
 
 const validPresets = {
 	single: [ { slug: 'preset-1' } ],
@@ -55,5 +56,37 @@ describe( 'getNewIndexFromPresets', () => {
 				expect( newIndex ).toBe( 1 );
 			} );
 		} );
+	} );
+} );
+
+describe( 'getFontFaceVariantName', () => {
+	it( 'uses the start of a variable weight range and explicit style', () => {
+		expect(
+			getFontFaceVariantName( {
+				fontFamily: 'Afacad',
+				fontStyle: 'normal',
+				fontWeight: '400 700',
+			} )
+		).toBe( '400 Normal' );
+	} );
+
+	it( 'includes normal style for static weights', () => {
+		expect(
+			getFontFaceVariantName( {
+				fontFamily: 'Afacad',
+				fontStyle: 'normal',
+				fontWeight: '600',
+			} )
+		).toBe( '600 Normal' );
+	} );
+
+	it( 'keeps numeric normal weight instead of semantic duplicated names', () => {
+		expect(
+			getFontFaceVariantName( {
+				fontFamily: 'AR One Sans',
+				fontStyle: 'normal',
+				fontWeight: '400',
+			} )
+		).toBe( '400 Normal' );
 	} );
 } );


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/60188

## What?
This PR fixes inconsistent font variant preview labels in the Font Library by normalizing how variant names are generated and displayed across Install and Library flows.

## Why?
The Install Fonts tab could show variant labels that did not match the Library tab (for example, numeric/range-based values or duplicated semantic labels such as Normal Normal). This made the same font appear differently depending on source, which was confusing and inconsistent with user expectations.

## Testing Instructions

1. Open Appearance ->  fonts.
2. Go to Install Fonts.
3. Select a font with multiple variants (for example, Afacad, AR One Sans).
4. Verify variant labels use normalized format such as: `Afacad 400 Normal`
7. Install one or more variants.
8. Switch to the Library tab and open the same font.
9. Verify labels are consistent with Install Fonts and still use normalized weight + style format.
10. Upload the same font files via Upload tab.
11. Verify uploaded variants follow the same label format and no duplicated semantic labels appear.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1457" height="741" alt="Screenshot 2026-05-20 at 5 05 49 PM" src="https://github.com/user-attachments/assets/5b9a2202-4aff-4c07-ae8a-4776aa77f951" /> |  <img width="1457" height="741" alt="Screenshot 2026-05-20 at 5 03 45 PM" src="https://github.com/user-attachments/assets/3e6c08d1-b786-42e0-a955-5f5c79ca7e06" /> |

## Use of AI Tools
Claude was used to help draft and refine implementation and test changes.