### PR TITLE
Media Editor Modal: Try adding aspect ratio and resize crop area to the history state

### DIFF
--- a/packages/media-editor/src/components/media-editor/test/use-crop-options.tsx
+++ b/packages/media-editor/src/components/media-editor/test/use-crop-options.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -9,6 +9,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { useCropOptions } from '../use-crop-options';
 import type { Media } from '../../media-editor-provider';
 import { ORIGINAL_ASPECT_RATIO } from '../../../image-editor/core/constants';
+import { CropperProvider, useCropper } from '../../../image-editor';
 
 const media = {
 	id: 1,
@@ -18,13 +19,14 @@ const media = {
 	},
 } as Media;
 
-function CropOptionsHarness( {
+function CropOptionsInner( {
 	id = 1,
 	isImage = true,
 }: {
 	id?: number;
 	isImage?: boolean;
 } ) {
+	const cropper = useCropper();
 	const cropOptions = useCropOptions( {
 		id,
 		isImage,
@@ -51,6 +53,9 @@ function CropOptionsHarness( {
 					.map( ( option ) => option.value )
 					.join( ',' ) }
 			</div>
+			<div data-testid="has-undo">
+				{ cropper.hasUndo ? 'true' : 'false' }
+			</div>
 			<button
 				onClick={ () =>
 					cropOptions.setAspectRatioValue(
@@ -69,8 +74,21 @@ function CropOptionsHarness( {
 			<button onClick={ () => cropOptions.setFreeformCrop( false ) }>
 				Disable handles
 			</button>
+			<button onClick={ () => cropOptions.setFreeformCrop( true ) }>
+				Enable handles
+			</button>
 			<button onClick={ cropOptions.resetCropOptions }>Reset</button>
+			<button onClick={ cropper.undo }>Undo</button>
+			<button onClick={ cropper.redo }>Redo</button>
 		</div>
+	);
+}
+
+function CropOptionsHarness( props: { id?: number; isImage?: boolean } ) {
+	return (
+		<CropperProvider>
+			<CropOptionsInner { ...props } />
+		</CropperProvider>
 	);
 }
 
@@ -122,5 +140,122 @@ describe( 'useCropOptions', () => {
 		expect( screen.getByTestId( 'freeform-crop' ) ).toHaveTextContent(
 			'true'
 		);
+	} );
+
+	describe( 'undo/redo via history satellite', () => {
+		beforeEach( () => {
+			jest.useFakeTimers();
+		} );
+		afterEach( () => {
+			jest.useRealTimers();
+		} );
+
+		const advanceDebounce = () => {
+			act( () => {
+				jest.advanceTimersByTime( 300 );
+			} );
+		};
+
+		it( 'records an aspect-ratio change so undo reverts the sidebar', () => {
+			render( <CropOptionsHarness /> );
+
+			fireEvent.click( screen.getByRole( 'button', { name: 'Square' } ) );
+			advanceDebounce();
+
+			expect(
+				screen.getByTestId( 'aspect-ratio-value' )
+			).toHaveTextContent( '1' );
+			expect( screen.getByTestId( 'has-undo' ) ).toHaveTextContent(
+				'true'
+			);
+
+			fireEvent.click( screen.getByRole( 'button', { name: 'Undo' } ) );
+
+			expect(
+				screen.getByTestId( 'aspect-ratio-value' )
+			).toHaveTextContent( '0' );
+		} );
+
+		it( 'records a Resize-crop toggle even when the crop rect does not move', () => {
+			render( <CropOptionsHarness /> );
+
+			fireEvent.click(
+				screen.getByRole( 'button', { name: 'Disable handles' } )
+			);
+			advanceDebounce();
+
+			expect( screen.getByTestId( 'freeform-crop' ) ).toHaveTextContent(
+				'false'
+			);
+			expect( screen.getByTestId( 'has-undo' ) ).toHaveTextContent(
+				'true'
+			);
+
+			fireEvent.click( screen.getByRole( 'button', { name: 'Undo' } ) );
+
+			expect( screen.getByTestId( 'freeform-crop' ) ).toHaveTextContent(
+				'true'
+			);
+		} );
+
+		it( 'redoes a satellite change after undo', () => {
+			render( <CropOptionsHarness /> );
+
+			fireEvent.click( screen.getByRole( 'button', { name: 'Square' } ) );
+			advanceDebounce();
+			fireEvent.click( screen.getByRole( 'button', { name: 'Undo' } ) );
+
+			expect(
+				screen.getByTestId( 'aspect-ratio-value' )
+			).toHaveTextContent( '0' );
+
+			fireEvent.click( screen.getByRole( 'button', { name: 'Redo' } ) );
+
+			expect(
+				screen.getByTestId( 'aspect-ratio-value' )
+			).toHaveTextContent( '1' );
+		} );
+
+		it( 'restores both aspect ratio and freeform together (Free auto-enables freeform)', () => {
+			render( <CropOptionsHarness /> );
+
+			// Establish a non-default starting point: Square + handles off.
+			fireEvent.click( screen.getByRole( 'button', { name: 'Square' } ) );
+			advanceDebounce();
+			fireEvent.click(
+				screen.getByRole( 'button', { name: 'Disable handles' } )
+			);
+			advanceDebounce();
+
+			expect(
+				screen.getByTestId( 'aspect-ratio-value' )
+			).toHaveTextContent( '1' );
+			expect( screen.getByTestId( 'freeform-crop' ) ).toHaveTextContent(
+				'false'
+			);
+
+			// Picking Free flips freeform back on via the setter side-effect.
+			fireEvent.click( screen.getByRole( 'button', { name: 'Free' } ) );
+			advanceDebounce();
+
+			expect(
+				screen.getByTestId( 'aspect-ratio-value' )
+			).toHaveTextContent( '0' );
+			expect( screen.getByTestId( 'freeform-crop' ) ).toHaveTextContent(
+				'true'
+			);
+
+			// Undo should restore the (Square, handles-off) pair — proving the
+			// satellite captures both fields atomically and the auto-enable
+			// side-effect doesn't leak into the restored state.
+			fireEvent.click( screen.getByRole( 'button', { name: 'Undo' } ) );
+
+			expect(
+				screen.getByTestId( 'aspect-ratio-value' )
+			).toHaveTextContent( '1' );
+			expect( screen.getByTestId( 'freeform-crop' ) ).toHaveTextContent(
+				'false'
+			);
+		} );
 	} );
 } );

--- a/packages/media-editor/src/components/media-editor/use-crop-options.ts
+++ b/packages/media-editor/src/components/media-editor/use-crop-options.ts
@@ -18,9 +18,15 @@ import {
 	ORIGINAL_ASPECT_RATIO,
 } from '../../image-editor/core/constants';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
+import { useCropper } from '../../image-editor';
 
 const FREE_ASPECT_RATIO_VALUE = '0';
 const DEFAULT_FREEFORM_CROP = true;
+
+interface CropOptionsSatelliteSnapshot {
+	aspectRatioValue: string;
+	freeformCrop: boolean;
+}
 
 interface UseCropOptionsArgs {
 	id: number;
@@ -99,6 +105,7 @@ export function useCropOptions( {
 	media,
 	aspectRatioPresets,
 }: UseCropOptionsArgs ): UseCropOptionsReturn {
+	const cropper = useCropper();
 	const [ aspectRatioValue, setAspectRatioValueState ] = useState(
 		FREE_ASPECT_RATIO_VALUE
 	);
@@ -137,6 +144,56 @@ export function useCropOptions( {
 		previousIdRef.current = id;
 		resetCropOptions();
 	}, [ id, resetCropOptions ] );
+
+	// Latest-value refs so the satellite snapshot getter (called by the
+	// cropper hook just before recording a history entry) always reads
+	// the freshest values without forcing callback identity changes.
+	// The write happens in an effect (not at render time) to satisfy
+	// `react-hooks/refs`; the effect flushes after commit and runs
+	// before the notify-on-change effect below (source order), so any
+	// `getSnapshot` call triggered downstream sees up-to-date values.
+	const aspectRatioValueRef = useRef( aspectRatioValue );
+	const freeformCropRef = useRef( freeformCrop );
+	useEffect( () => {
+		aspectRatioValueRef.current = aspectRatioValue;
+		freeformCropRef.current = freeformCrop;
+	}, [ aspectRatioValue, freeformCrop ] );
+
+	// Register the satellite once. The cropper hook calls `getSnapshot`
+	// before each push and `restoreSnapshot` on undo/redo — wiring the
+	// sidebar UI state into the cropper's existing undo history so a
+	// CMD+Z after an aspect-ratio change reverts both the canvas and
+	// the sidebar control.
+	const { registerHistorySatellite, notifySatelliteChanged } = cropper;
+	useEffect( () => {
+		const unregister =
+			registerHistorySatellite< CropOptionsSatelliteSnapshot >( {
+				getSnapshot: () => ( {
+					aspectRatioValue: aspectRatioValueRef.current,
+					freeformCrop: freeformCropRef.current,
+				} ),
+				// Use the raw `useState` setters, not the public
+				// `setAspectRatioValue` wrapper — the wrapper auto-enables
+				// freeform when the new value is "Free", which would
+				// corrupt a restored `(Free, freeform=false)` pairing.
+				restoreSnapshot: ( snapshot ) => {
+					setAspectRatioValueState( snapshot.aspectRatioValue );
+					setFreeformCrop( snapshot.freeformCrop );
+				},
+				areSnapshotsEqual: ( a, b ) =>
+					a.aspectRatioValue === b.aspectRatioValue &&
+					a.freeformCrop === b.freeformCrop,
+			} );
+		return unregister;
+	}, [ registerHistorySatellite ] );
+
+	// Tell the cropper hook to re-evaluate the debounce whenever the
+	// sidebar state changes. Required so satellite-only edits (e.g.
+	// toggling Resize-crop on, which doesn't move the crop rect) still
+	// produce an undo step.
+	useEffect( () => {
+		notifySatelliteChanged();
+	}, [ aspectRatioValue, freeformCrop, notifySatelliteChanged ] );
 
 	return {
 		aspectRatioValue,

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-state.ts
@@ -1196,6 +1196,164 @@ describe( 'useCropperState', () => {
 		} );
 	} );
 
+	describe( 'history satellite', () => {
+		const DEBOUNCE_MS = 300;
+
+		beforeEach( () => jest.useFakeTimers() );
+		afterEach( () => jest.useRealTimers() );
+
+		// Helper that mirrors how a real consumer (e.g. useCropOptions)
+		// uses a closure variable in place of a ref, and a jest mock for
+		// restoreSnapshot.
+		function makeSatellite( initial: string ) {
+			const state = { value: initial };
+			const restoreSnapshot = jest.fn( ( s: string ) => {
+				state.value = s;
+			} );
+			return {
+				state,
+				config: {
+					getSnapshot: () => state.value,
+					restoreSnapshot,
+				},
+				restoreSnapshot,
+			};
+		}
+
+		it( 'bundles the satellite snapshot into a debounced push', () => {
+			const { result } = renderHook( () => useCropperState() );
+			const sat = makeSatellite( 'a' );
+			act( () => {
+				result.current.registerHistorySatellite( sat.config );
+			} );
+			act( () => result.current.setZoom( 3 ) );
+			sat.state.value = 'b';
+			act( () => result.current.notifySatelliteChanged() );
+			act( () => jest.advanceTimersByTime( DEBOUNCE_MS ) );
+
+			expect( result.current.hasUndo ).toBe( true );
+
+			act( () => result.current.undo() );
+
+			expect( result.current.state.zoom ).toBe( 1 );
+			expect( sat.restoreSnapshot ).toHaveBeenLastCalledWith( 'a' );
+			expect( sat.state.value ).toBe( 'a' );
+		} );
+
+		it( 'records a satellite-only change with the pre-change snapshot', () => {
+			const { result } = renderHook( () => useCropperState() );
+			const sat = makeSatellite( 'a' );
+			act( () => {
+				result.current.registerHistorySatellite( sat.config );
+			} );
+
+			sat.state.value = 'b';
+			act( () => result.current.notifySatelliteChanged() );
+			act( () => jest.advanceTimersByTime( DEBOUNCE_MS ) );
+
+			expect( result.current.hasUndo ).toBe( true );
+
+			act( () => result.current.undo() );
+
+			expect( sat.restoreSnapshot ).toHaveBeenLastCalledWith( 'a' );
+			expect( sat.state.value ).toBe( 'a' );
+		} );
+
+		it( 'redo re-applies the satellite snapshot', () => {
+			const { result } = renderHook( () => useCropperState() );
+			const sat = makeSatellite( 'a' );
+			act( () => {
+				result.current.registerHistorySatellite( sat.config );
+			} );
+
+			sat.state.value = 'b';
+			act( () => result.current.notifySatelliteChanged() );
+			act( () => jest.advanceTimersByTime( DEBOUNCE_MS ) );
+			act( () => result.current.undo() );
+			expect( sat.state.value ).toBe( 'a' );
+
+			act( () => result.current.redo() );
+
+			expect( sat.restoreSnapshot ).toHaveBeenLastCalledWith( 'b' );
+			expect( sat.state.value ).toBe( 'b' );
+		} );
+
+		it( 'collapses rapid satellite-only changes within the debounce window', () => {
+			const { result } = renderHook( () => useCropperState() );
+			const sat = makeSatellite( 'a' );
+			act( () => {
+				result.current.registerHistorySatellite( sat.config );
+			} );
+
+			sat.state.value = 'b';
+			act( () => result.current.notifySatelliteChanged() );
+			sat.state.value = 'c';
+			act( () => result.current.notifySatelliteChanged() );
+			act( () => jest.advanceTimersByTime( DEBOUNCE_MS ) );
+
+			// One push, capturing the original pre-change snapshot.
+			act( () => result.current.undo() );
+			expect( sat.restoreSnapshot ).toHaveBeenLastCalledWith( 'a' );
+			expect( result.current.hasUndo ).toBe( false );
+		} );
+
+		it( 'dedups satellite no-op changes via areSnapshotsEqual', () => {
+			const { result } = renderHook( () => useCropperState() );
+			const sat = makeSatellite( 'a' );
+			act( () => {
+				result.current.registerHistorySatellite( {
+					...sat.config,
+					areSnapshotsEqual: ( a, b ) => a === b,
+				} );
+			} );
+
+			// "Change" to the same value — nothing should be recorded.
+			act( () => result.current.notifySatelliteChanged() );
+			act( () => jest.advanceTimersByTime( DEBOUNCE_MS ) );
+
+			expect( result.current.hasUndo ).toBe( false );
+		} );
+
+		it( 'discrete actions bundle the current satellite snapshot', () => {
+			const { result } = renderHook( () => useCropperState() );
+			const sat = makeSatellite( 'a' );
+			act( () => {
+				result.current.registerHistorySatellite( sat.config );
+			} );
+
+			// Mutate the satellite (without notifying), then fire a
+			// discrete action that pushes synchronously. The pushed
+			// entry should carry the latest satellite value as the
+			// pre-action snapshot.
+			sat.state.value = 'b';
+			act( () => result.current.snapRotate90( 1 ) );
+
+			act( () => result.current.undo() );
+			expect( sat.restoreSnapshot ).toHaveBeenLastCalledWith( 'b' );
+		} );
+
+		it( 'unregister stops snapshotting the satellite', () => {
+			const { result } = renderHook( () => useCropperState() );
+			const sat = makeSatellite( 'a' );
+			let unregister: () => void = () => {};
+			act( () => {
+				unregister = result.current.registerHistorySatellite(
+					sat.config
+				);
+			} );
+			act( () => unregister() );
+
+			// A subsequent push happens, but with no satellite registered
+			// there is nothing to restore. Undo must not throw.
+			act( () => result.current.setZoom( 3 ) );
+			act( () => jest.advanceTimersByTime( DEBOUNCE_MS ) );
+			act( () => result.current.undo() );
+
+			expect( sat.restoreSnapshot ).not.toHaveBeenCalled();
+			expect( result.current.state.zoom ).toBe( 1 );
+		} );
+	} );
+
 	describe( 'public controller contract', () => {
 		it( 'does not expose the raw reducer dispatch', () => {
 			const { result } = renderHook( () => useCropperState() );

--- a/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts
@@ -29,6 +29,38 @@ import {
 } from '../../core/state';
 
 /**
+ * Configuration for registering a history "satellite" — an opaque
+ * piece of consumer-owned state that should be snapshotted alongside
+ * each cropper history entry and restored on undo/redo.
+ *
+ * Use this to bring sidebar UI state (e.g. aspect-ratio preset,
+ * freeform toggle) into the cropper's undo history without leaking
+ * those concepts into the framework-agnostic `CropperState`.
+ */
+export interface HistorySatelliteConfig< Snapshot > {
+	/**
+	 * Return the current satellite snapshot. Called by the hook just
+	 * before recording a history entry. Should read from refs (not
+	 * captured state) so it always returns the freshest value.
+	 */
+	getSnapshot: () => Snapshot;
+	/**
+	 * Apply a previously-recorded snapshot to consumer state. Called
+	 * by the hook on undo/redo. Should use side-effect-free setters —
+	 * any "smart" wrapper logic (e.g. auto-toggling related state) will
+	 * be replayed twice, once at the user action and once at restore.
+	 */
+	restoreSnapshot: ( snapshot: Snapshot ) => void;
+	/**
+	 * Compare two snapshots for equality. Used to dedup history entries
+	 * and decide whether a satellite-only change warrants a push.
+	 * Defaults to `Object.is` — supply a structural comparator if
+	 * `getSnapshot` returns fresh object references each call.
+	 */
+	areSnapshotsEqual?: ( a: Snapshot, b: Snapshot ) => boolean;
+}
+
+/**
  * The return type of the useCropperState hook.
  *
  * The hook exposes its state through named setter methods rather
@@ -113,6 +145,28 @@ export interface UseCropperStateReturn {
 	 * try/catch if you need to recover.
 	 */
 	getCroppedImage: ( mimeType?: string, quality?: number ) => Promise< Blob >;
+	/**
+	 * Register a single "satellite" whose snapshot is bundled into
+	 * each history entry and restored on undo/redo. Calling twice
+	 * replaces the previous registration. Returns an unregister
+	 * function.
+	 */
+	registerHistorySatellite: < Snapshot >(
+		config: HistorySatelliteConfig< Snapshot >
+	) => () => void;
+	/**
+	 * Notify the hook that the registered satellite's value has
+	 * changed. Wakes the debounce machinery so satellite-only edits
+	 * (changes that don't move cropper state) still produce history
+	 * entries. Safe to call from a `useEffect` that depends on the
+	 * satellite values.
+	 */
+	notifySatelliteChanged: () => void;
+}
+
+interface HistoryEntry {
+	state: CropperState;
+	satellite: unknown;
 }
 
 /** Milliseconds of inactivity after which a continuous interaction is committed to history. */
@@ -178,73 +232,145 @@ export function useCropperState(
 	const stateRef = useRef( state );
 	stateRef.current = state;
 
-	// History stack for undo/redo. Using refs for the arrays avoids
-	// unnecessary re-renders on every push; a pair of boolean state values
-	// drives the enabled/disabled state of the undo/redo buttons.
-	const historyRef = useRef< CropperState[] >( [] );
-	const redoStackRef = useRef< CropperState[] >( [] );
+	// History stack for undo/redo. Each entry pairs a cropper state with
+	// an opaque satellite snapshot (consumer-owned UI state). Using refs
+	// for the arrays avoids unnecessary re-renders on every push; a pair
+	// of boolean state values drives the enabled/disabled state of the
+	// undo/redo buttons.
+	const historyRef = useRef< HistoryEntry[] >( [] );
+	const redoStackRef = useRef< HistoryEntry[] >( [] );
 	const [ hasUndo, setHasUndo ] = useState( false );
 	const [ hasRedo, setHasRedo ] = useState( false );
 
-	// Debounce-based history: tracks the last committed state and a pending
-	// timer. Any state change resets the timer; when it expires the
-	// pre-change state is pushed to history.
+	// Single optional satellite registration. The hook treats the
+	// snapshot as opaque — it just bundles it into entries and hands it
+	// back on restore. Stored in a ref so callbacks read the latest
+	// registration without re-creating themselves.
+	const satelliteRef = useRef< HistorySatelliteConfig< unknown > | null >(
+		null
+	);
+
+	// Debounce-based history: tracks the last committed state/satellite
+	// and a pending timer. Any state or satellite change resets the
+	// timer; when it expires the pre-change snapshots are pushed.
 	const lastCommittedStateRef = useRef< CropperState | null >( state );
+	const lastCommittedSatelliteRef = useRef< unknown >( undefined );
 	const debounceTimerRef = useRef< ReturnType< typeof setTimeout > >();
 	// Set to true before dispatching actions that must not produce a debounce
 	// history entry (undo, redo, reset, setImage, discrete actions).
 	const suppressDebounceRef = useRef( false );
 
-	// Pushes `entry` (defaults to current state) onto the undo stack and
-	// clears the redo stack. Skips if `entry` is already the last item,
-	// so rapid discrete actions on unchanged state don't create duplicates.
-	const pushToHistory = useCallback( ( entry?: CropperState ) => {
-		const target = entry ?? stateRef.current;
-		const previousEntry =
-			historyRef.current[ historyRef.current.length - 1 ];
-		if ( previousEntry && areHistoryStatesEqual( previousEntry, target ) ) {
+	// Compare two satellite snapshots using the registered comparator,
+	// falling back to Object.is. Safe to call when no satellite is
+	// registered: both args will be `undefined` and Object.is returns true.
+	const areSatellitesEqual = useCallback(
+		( a: unknown, b: unknown ): boolean => {
+			const eq = satelliteRef.current?.areSnapshotsEqual;
+			return eq ? eq( a, b ) : Object.is( a, b );
+		},
+		[]
+	);
+
+	// Compare two history entries by both halves.
+	const areHistoryEntriesEqual = useCallback(
+		( a: HistoryEntry, b: HistoryEntry ): boolean => {
+			return (
+				areHistoryStatesEqual( a.state, b.state ) &&
+				areSatellitesEqual( a.satellite, b.satellite )
+			);
+		},
+		[ areSatellitesEqual ]
+	);
+
+	// Pushes `entry` (defaults to current state + current satellite) onto
+	// the undo stack and clears the redo stack. Skips if `entry` is
+	// already the last item, so rapid discrete actions on unchanged
+	// state don't create duplicates.
+	const pushToHistory = useCallback(
+		( entry?: HistoryEntry ) => {
+			const target: HistoryEntry = entry ?? {
+				state: stateRef.current,
+				satellite: satelliteRef.current?.getSnapshot(),
+			};
+			const previousEntry =
+				historyRef.current[ historyRef.current.length - 1 ];
+			if (
+				previousEntry &&
+				areHistoryEntriesEqual( previousEntry, target )
+			) {
+				return;
+			}
+			historyRef.current = [ ...historyRef.current, target ];
+			redoStackRef.current = [];
+			setHasUndo( true );
+			setHasRedo( false );
+		},
+		[ areHistoryEntriesEqual ]
+	);
+
+	// Core debounce logic, callable from both the state-watching
+	// useEffect and the consumer-driven `notifySatelliteChanged`.
+	// Schedules a push if either the cropper state OR the satellite
+	// snapshot differs from its last committed value.
+	const scheduleDebouncedPush = useCallback( () => {
+		const currentState = stateRef.current;
+		const currentSatellite = satelliteRef.current?.getSnapshot();
+
+		// Suppress flag: undo/redo/reset/setImage/discrete actions set
+		// this to opt out of the debounce for their own state changes.
+		if ( suppressDebounceRef.current ) {
+			suppressDebounceRef.current = false;
+			lastCommittedStateRef.current = currentState;
+			lastCommittedSatelliteRef.current = currentSatellite;
 			return;
 		}
-		historyRef.current = [ ...historyRef.current, target ];
-		redoStackRef.current = [];
-		setHasUndo( true );
-		setHasRedo( false );
-	}, [] );
+
+		const stateUnchanged =
+			lastCommittedStateRef.current !== null &&
+			areHistoryStatesEqual(
+				lastCommittedStateRef.current,
+				currentState
+			);
+		const satelliteUnchanged = areSatellitesEqual(
+			lastCommittedSatelliteRef.current,
+			currentSatellite
+		);
+		if ( stateUnchanged && satelliteUnchanged ) {
+			lastCommittedStateRef.current = currentState;
+			lastCommittedSatelliteRef.current = currentSatellite;
+			return;
+		}
+		clearTimeout( debounceTimerRef.current );
+		debounceTimerRef.current = setTimeout( () => {
+			const stateSnap = lastCommittedStateRef.current;
+			const satSnap = lastCommittedSatelliteRef.current;
+			const nowState = stateRef.current;
+			const nowSat = satelliteRef.current?.getSnapshot();
+			if ( stateSnap !== null ) {
+				const stateChanged = ! areHistoryStatesEqual(
+					stateSnap,
+					nowState
+				);
+				const satChanged = ! areSatellitesEqual( satSnap, nowSat );
+				if ( stateChanged || satChanged ) {
+					pushToHistory( {
+						state: stateSnap,
+						satellite: satSnap,
+					} );
+				}
+			}
+			lastCommittedStateRef.current = nowState;
+			lastCommittedSatelliteRef.current = nowSat;
+		}, HISTORY_DEBOUNCE_MS );
+	}, [ pushToHistory, areSatellitesEqual ] );
 
 	// Watch state and debounce history commits. Any dispatch resets the
 	// timer; once the state has settled for HISTORY_DEBOUNCE_MS the
 	// pre-change snapshot is pushed to the undo stack.
 	useEffect( () => {
-		// Suppress flag: undo/redo/reset/setImage/discrete actions set this
-		// to opt out of the debounce for their own state changes.
-		if ( suppressDebounceRef.current ) {
-			suppressDebounceRef.current = false;
-			lastCommittedStateRef.current = stateRef.current;
-			return;
-		}
-		if (
-			lastCommittedStateRef.current !== null &&
-			areHistoryStatesEqual(
-				lastCommittedStateRef.current,
-				stateRef.current
-			)
-		) {
-			lastCommittedStateRef.current = stateRef.current;
-			return;
-		}
-		clearTimeout( debounceTimerRef.current );
-		debounceTimerRef.current = setTimeout( () => {
-			const snapshot = lastCommittedStateRef.current;
-			if (
-				snapshot !== null &&
-				! areHistoryStatesEqual( snapshot, stateRef.current )
-			) {
-				pushToHistory( snapshot );
-			}
-			lastCommittedStateRef.current = stateRef.current;
-		}, HISTORY_DEBOUNCE_MS );
+		scheduleDebouncedPush();
 		return () => clearTimeout( debounceTimerRef.current );
-	}, [ state, pushToHistory ] );
+	}, [ state, scheduleDebouncedPush ] );
 
 	// Flush the pending debounce immediately: cancel the timer and push the
 	// pre-change snapshot if the state has actually changed. Used by
@@ -252,15 +378,26 @@ export function useCropperState(
 	// undo/redo/discrete actions before recording their own history entry.
 	const commitHistory = useCallback( () => {
 		clearTimeout( debounceTimerRef.current );
-		const snapshot = lastCommittedStateRef.current;
-		if (
-			snapshot !== null &&
-			! areHistoryStatesEqual( snapshot, stateRef.current )
-		) {
-			pushToHistory( snapshot );
+		const stateSnap = lastCommittedStateRef.current;
+		const satSnap = lastCommittedSatelliteRef.current;
+		const currentState = stateRef.current;
+		const currentSatellite = satelliteRef.current?.getSnapshot();
+		if ( stateSnap !== null ) {
+			const stateChanged = ! areHistoryStatesEqual(
+				stateSnap,
+				currentState
+			);
+			const satChanged = ! areSatellitesEqual(
+				satSnap,
+				currentSatellite
+			);
+			if ( stateChanged || satChanged ) {
+				pushToHistory( { state: stateSnap, satellite: satSnap } );
+			}
 		}
-		lastCommittedStateRef.current = stateRef.current;
-	}, [ pushToHistory ] );
+		lastCommittedStateRef.current = currentState;
+		lastCommittedSatelliteRef.current = currentSatellite;
+	}, [ pushToHistory, areSatellitesEqual ] );
 
 	const undo = useCallback( () => {
 		// Flush any pending gesture so it becomes a distinct undo step
@@ -271,12 +408,25 @@ export function useCropperState(
 		if ( ! prev ) {
 			return;
 		}
-		redoStackRef.current = [ stateRef.current, ...redoStackRef.current ];
+		const currentEntry: HistoryEntry = {
+			state: stateRef.current,
+			satellite: satelliteRef.current?.getSnapshot(),
+		};
+		redoStackRef.current = [ currentEntry, ...redoStackRef.current ];
 		historyRef.current = historyRef.current.slice( 0, -1 );
 		suppressDebounceRef.current = true;
 		setHasUndo( historyRef.current.length > 0 );
 		setHasRedo( true );
-		dispatch( { type: 'RESET', payload: prev } );
+		dispatch( { type: 'RESET', payload: prev.state } );
+		// Restore satellite state. Set the last-committed ref to the
+		// restored value so the consumer's follow-up
+		// `notifySatelliteChanged` (fired from their useEffect after the
+		// React state setters run) sees no diff and won't schedule a
+		// spurious push.
+		if ( satelliteRef.current ) {
+			satelliteRef.current.restoreSnapshot( prev.satellite );
+		}
+		lastCommittedSatelliteRef.current = prev.satellite;
 	}, [ dispatch, commitHistory ] );
 
 	const redo = useCallback( () => {
@@ -287,13 +437,45 @@ export function useCropperState(
 		if ( ! next ) {
 			return;
 		}
-		historyRef.current = [ ...historyRef.current, stateRef.current ];
+		const currentEntry: HistoryEntry = {
+			state: stateRef.current,
+			satellite: satelliteRef.current?.getSnapshot(),
+		};
+		historyRef.current = [ ...historyRef.current, currentEntry ];
 		redoStackRef.current = redoStackRef.current.slice( 1 );
 		suppressDebounceRef.current = true;
 		setHasUndo( true );
 		setHasRedo( redoStackRef.current.length > 0 );
-		dispatch( { type: 'RESET', payload: next } );
+		dispatch( { type: 'RESET', payload: next.state } );
+		if ( satelliteRef.current ) {
+			satelliteRef.current.restoreSnapshot( next.satellite );
+		}
+		lastCommittedSatelliteRef.current = next.satellite;
 	}, [ dispatch, commitHistory ] );
+
+	const registerHistorySatellite = useCallback(
+		< Snapshot >(
+			config: HistorySatelliteConfig< Snapshot >
+		): ( () => void ) => {
+			// Treat snapshot as opaque inside the hook — we only ever
+			// hand snapshots back to consumer-supplied callbacks.
+			const opaque =
+				config as unknown as HistorySatelliteConfig< unknown >;
+			satelliteRef.current = opaque;
+			lastCommittedSatelliteRef.current = config.getSnapshot();
+			return () => {
+				if ( satelliteRef.current === opaque ) {
+					satelliteRef.current = null;
+					lastCommittedSatelliteRef.current = undefined;
+				}
+			};
+		},
+		[]
+	);
+
+	const notifySatelliteChanged = useCallback( () => {
+		scheduleDebouncedPush();
+	}, [ scheduleDebouncedPush ] );
 
 	const setImage = useCallback(
 		( image: CropperState[ 'image' ] ) => {
@@ -308,6 +490,12 @@ export function useCropperState(
 				...initialRef.current,
 				image,
 			} );
+			// Refresh the satellite committed ref too — `setImage` is a
+			// "fresh start" boundary and any satellite-only edit made
+			// during the prior image's session should not be replayed as
+			// the pre-change snapshot for the next session.
+			lastCommittedSatelliteRef.current =
+				satelliteRef.current?.getSnapshot();
 		},
 		[ dispatch ]
 	);
@@ -500,6 +688,8 @@ export function useCropperState(
 		undo,
 		redo,
 		commitHistory,
+		registerHistorySatellite,
+		notifySatelliteChanged,
 	};
 	return controller;
 }


### PR DESCRIPTION
## What?

Part of:

* https://github.com/WordPress/gutenberg/issues/73771

Tries out an idea for combining the current state/selection of the aspect ratio and resize crop area controls with the undo/redo history state of the experimental image editor (part of the experimental media editor modal).

🚧 🚧 🚧 Note: this is currently buggy, especially after interacting with the aspect ratio controls and then going to the snap rotation controls and then clicking Undo — it seems it can get stuck in a state where it doesn't properly apply the Undo and it flickers and reverts. So something in the logic is off 🚧 🚧 🚧 

## Why?

On trunk, if you make changes to the aspect ratio dropdown or the "Resize crop area" toggle, these aren't included in Undo actions. It's possible to get kind of stuck where you undo a change but the UI is still on a selected aspect ratio. I'd expect the UI state to undo as well as the values of the cropper that changed.

## How?

* Try out the idea of registering "satellite" history (e.g. `registerHistorySatellite`) so that UI that lives outside of the image cropper can still hook into the undo/redo state. The idea here is that the history will contain both cropper state and satellite state so that consumers can restore to a snapshot when `undo` / `redo` is applied.

## Testing Instructions

* Enable the Media Editor Modal experiment
* Add an image to a post or page
* Click the Crop icon in the block toolbar
* Have a play around with all the tools, especially the aspect ratio and resize crop area toggle
* Try undoing and redoing and see if everything's hooked up correctly and the UI state updates alongside the image cropper undo/redos

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/34af560e-c642-494f-9e90-0cf5be6711f8

## Use of AI Tools

Claude Code