### PR TITLE
Add image editing functionality to REST API for media attachments

### DIFF
--- a/lib/compat/wordpress-7.0/media.php
+++ b/lib/compat/wordpress-7.0/media.php
@@ -25,3 +25,34 @@ function gutenberg_is_client_side_media_processing_enabled() {
 	 */
 	return apply_filters( 'wp_client_side_media_processing_enabled', true );
 }
+
+if ( ! function_exists( 'wp_get_original_attachment_id' ) ) {
+	/**
+	 * Retrieves the root/original attachment ID for an attachment derivative tree.
+	 *
+	 * Derivative attachments created by the REST media editing flow store the
+	 * root attachment ID in the `_source_attachment_id` meta field. Attachments
+	 * without lineage metadata are treated as their own root.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 * @return int|false Root attachment ID on success, false if the post does not exist
+	 *                   or is not an attachment.
+	 */
+	function wp_get_original_attachment_id( $attachment_id ) {
+		$attachment = get_post( $attachment_id );
+
+		if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+			return false;
+		}
+
+		$source_attachment_id = absint( get_post_meta( $attachment->ID, '_source_attachment_id', true ) );
+
+		if ( ! $source_attachment_id ) {
+			return (int) $attachment->ID;
+		}
+
+		return $source_attachment_id;
+	}
+}

--- a/lib/media/class-gutenberg-rest-attachments-controller.php
+++ b/lib/media/class-gutenberg-rest-attachments-controller.php
@@ -434,6 +434,312 @@ class Gutenberg_REST_Attachments_Controller extends WP_REST_Attachments_Controll
 	}
 
 	/**
+	 * Crops, rotates, scales, or flips an image and creates a new attachment.
+	 *
+	 * Mirrors Core's REST media editing flow while persisting root attachment
+	 * lineage for newly created derivatives.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error object on failure.
+	 */
+	public function edit_media_item( $request ) {
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+
+		$attachment_id = $request['id'];
+
+		// This also confirms the attachment is an image.
+		$image_file = wp_get_original_image_path( $attachment_id );
+		$image_meta = wp_get_attachment_metadata( $attachment_id );
+
+		if (
+			! $image_meta ||
+			! $image_file ||
+			! wp_image_file_matches_image_meta( $request['src'], $image_meta, $attachment_id )
+		) {
+			return new WP_Error(
+				'rest_unknown_attachment',
+				__( 'Unable to get meta information for file.' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$supported_types = array( 'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/avif', 'image/heic' );
+		$mime_type       = get_post_mime_type( $attachment_id );
+		if ( ! in_array( $mime_type, $supported_types, true ) ) {
+			return new WP_Error(
+				'rest_cannot_edit_file_type',
+				__( 'This type of file cannot be edited.' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// The `modifiers` param takes precedence over the older format.
+		if ( isset( $request['modifiers'] ) ) {
+			$modifiers = $request['modifiers'];
+		} else {
+			$modifiers = array();
+
+			if ( isset( $request['flip']['horizontal'] ) || isset( $request['flip']['vertical'] ) ) {
+				$flip_args = array(
+					'vertical'   => isset( $request['flip']['vertical'] ) ? (bool) $request['flip']['vertical'] : false,
+					'horizontal' => isset( $request['flip']['horizontal'] ) ? (bool) $request['flip']['horizontal'] : false,
+				);
+
+				$modifiers[] = array(
+					'type' => 'flip',
+					'args' => array(
+						'flip' => $flip_args,
+					),
+				);
+			}
+
+			if ( ! empty( $request['rotation'] ) ) {
+				$modifiers[] = array(
+					'type' => 'rotate',
+					'args' => array(
+						'angle' => $request['rotation'],
+					),
+				);
+			}
+
+			if ( isset( $request['x'], $request['y'], $request['width'], $request['height'] ) ) {
+				$modifiers[] = array(
+					'type' => 'crop',
+					'args' => array(
+						'left'   => $request['x'],
+						'top'    => $request['y'],
+						'width'  => $request['width'],
+						'height' => $request['height'],
+					),
+				);
+			}
+
+			if ( 0 === count( $modifiers ) ) {
+				return new WP_Error(
+					'rest_image_not_edited',
+					__( 'The image was not edited. Edit the image before applying the changes.' ),
+					array( 'status' => 400 )
+				);
+			}
+		}
+
+		/*
+		 * If the file doesn't exist, attempt a URL fopen on the src link.
+		 * This can occur with certain file replication plugins.
+		 * Keep the original file path to get a modified name later.
+		 */
+		$image_file_to_edit = $image_file;
+		if ( ! file_exists( $image_file_to_edit ) ) {
+			$image_file_to_edit = _load_image_to_edit_path( $attachment_id );
+		}
+
+		$image_editor = wp_get_image_editor( $image_file_to_edit );
+
+		if ( is_wp_error( $image_editor ) ) {
+			return new WP_Error(
+				'rest_unknown_image_file_type',
+				__( 'Unable to edit this image.' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		foreach ( $modifiers as $modifier ) {
+			$args = $modifier['args'];
+			switch ( $modifier['type'] ) {
+				case 'flip':
+					/*
+					 * Flips the current image.
+					 * The vertical flip is the first argument (flip along horizontal axis), the horizontal flip is the second argument (flip along vertical axis).
+					 * See: WP_Image_Editor::flip()
+					 */
+					$result = $image_editor->flip( $args['flip']['vertical'], $args['flip']['horizontal'] );
+					if ( is_wp_error( $result ) ) {
+						return new WP_Error(
+							'rest_image_flip_failed',
+							__( 'Unable to flip this image.' ),
+							array( 'status' => 500 )
+						);
+					}
+					break;
+				case 'rotate':
+					// Rotation direction: clockwise vs. counterclockwise.
+					$rotate = 0 - $args['angle'];
+
+					if ( 0 !== $rotate ) {
+						$result = $image_editor->rotate( $rotate );
+
+						if ( is_wp_error( $result ) ) {
+							return new WP_Error(
+								'rest_image_rotation_failed',
+								__( 'Unable to rotate this image.' ),
+								array( 'status' => 500 )
+							);
+						}
+					}
+
+					break;
+
+				case 'crop':
+					$size = $image_editor->get_size();
+
+					$crop_x = (int) round( ( $size['width'] * $args['left'] ) / 100.0 );
+					$crop_y = (int) round( ( $size['height'] * $args['top'] ) / 100.0 );
+					$width  = (int) round( ( $size['width'] * $args['width'] ) / 100.0 );
+					$height = (int) round( ( $size['height'] * $args['height'] ) / 100.0 );
+
+					if ( $size['width'] !== $width || $size['height'] !== $height ) {
+						$result = $image_editor->crop( $crop_x, $crop_y, $width, $height );
+
+						if ( is_wp_error( $result ) ) {
+							return new WP_Error(
+								'rest_image_crop_failed',
+								__( 'Unable to crop this image.' ),
+								array( 'status' => 500 )
+							);
+						}
+					}
+
+					break;
+
+			}
+		}
+
+		// Calculate the file name.
+		$image_ext  = pathinfo( $image_file, PATHINFO_EXTENSION );
+		$image_name = wp_basename( $image_file, ".{$image_ext}" );
+
+		/*
+		 * Do not append multiple `-edited` to the file name.
+		 * The user may be editing a previously edited image.
+		 */
+		if ( preg_match( '/-edited(-\d+)?$/', $image_name ) ) {
+			// Remove any `-1`, `-2`, etc. `wp_unique_filename()` will add the proper number.
+			$image_name = preg_replace( '/-edited(-\d+)?$/', '-edited', $image_name );
+		} else {
+			// Append `-edited` before the extension.
+			$image_name .= '-edited';
+		}
+
+		$filename = "{$image_name}.{$image_ext}";
+
+		// Create the uploads subdirectory if needed.
+		$uploads = wp_upload_dir();
+
+		// Make the file name unique in the (new) upload directory.
+		$filename = wp_unique_filename( $uploads['path'], $filename );
+
+		// Save to disk.
+		$saved = $image_editor->save( $uploads['path'] . "/$filename" );
+
+		if ( is_wp_error( $saved ) ) {
+			return $saved;
+		}
+
+		// Grab original attachment post so we can use it to set defaults.
+		$original_attachment_post = get_post( $attachment_id );
+
+		// Check request fields and assign default values.
+		$new_attachment_post                 = $this->prepare_item_for_database( $request );
+		$new_attachment_post->post_mime_type = $saved['mime-type'];
+		$new_attachment_post->guid           = $uploads['url'] . "/$filename";
+
+		// Unset ID so wp_insert_attachment generates a new ID.
+		unset( $new_attachment_post->ID );
+
+		// Set new attachment post title with fallbacks.
+		$new_attachment_post->post_title = $new_attachment_post->post_title ?? $original_attachment_post->post_title ?? $image_name;
+
+		// Set new attachment post caption (post_excerpt).
+		$new_attachment_post->post_excerpt = $new_attachment_post->post_excerpt ?? $original_attachment_post->post_excerpt ?? '';
+
+		// Set new attachment post description (post_content) with fallbacks.
+		$new_attachment_post->post_content = $new_attachment_post->post_content ?? $original_attachment_post->post_content ?? '';
+
+		// Set post parent if set in request, else the default of `0` (no parent).
+		$new_attachment_post->post_parent = $new_attachment_post->post_parent ?? 0;
+
+		// Insert the new attachment post.
+		$new_attachment_id = wp_insert_attachment( wp_slash( (array) $new_attachment_post ), $saved['path'], 0, true );
+
+		if ( is_wp_error( $new_attachment_id ) ) {
+			if ( 'db_update_error' === $new_attachment_id->get_error_code() ) {
+				$new_attachment_id->add_data( array( 'status' => 500 ) );
+			} else {
+				$new_attachment_id->add_data( array( 'status' => 400 ) );
+			}
+
+			return $new_attachment_id;
+		}
+
+		$root_attachment_id = wp_get_original_attachment_id( $attachment_id );
+		if ( ! $root_attachment_id ) {
+			$root_attachment_id = $attachment_id;
+		}
+
+		update_post_meta( $new_attachment_id, '_source_attachment_id', $root_attachment_id );
+
+		// First, try to use the alt text from the request. If not set, copy the image alt text from the original attachment.
+		$image_alt = isset( $request['alt_text'] ) ? sanitize_text_field( $request['alt_text'] ) : get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+
+		if ( ! empty( $image_alt ) ) {
+			// update_post_meta() expects slashed.
+			update_post_meta( $new_attachment_id, '_wp_attachment_image_alt', wp_slash( $image_alt ) );
+		}
+
+		if ( wp_is_serving_rest_request() ) {
+			/*
+			 * Set a custom header with the attachment_id.
+			 * Used by the browser/client to resume creating image sub-sizes after a PHP fatal error.
+			 */
+			header( 'X-WP-Upload-Attachment-ID: ' . $new_attachment_id );
+		}
+
+		// Generate image sub-sizes and meta.
+		$new_image_meta = wp_generate_attachment_metadata( $new_attachment_id, $saved['path'] );
+
+		// Copy the EXIF metadata from the original attachment if not generated for the edited image.
+		if ( isset( $image_meta['image_meta'] ) && isset( $new_image_meta['image_meta'] ) && is_array( $new_image_meta['image_meta'] ) ) {
+			// Merge but skip empty values.
+			foreach ( (array) $image_meta['image_meta'] as $key => $value ) {
+				if ( empty( $new_image_meta['image_meta'][ $key ] ) && ! empty( $value ) ) {
+					$new_image_meta['image_meta'][ $key ] = $value;
+				}
+			}
+		}
+
+		// Reset orientation. At this point the image is edited and orientation is correct.
+		if ( ! empty( $new_image_meta['image_meta']['orientation'] ) ) {
+			$new_image_meta['image_meta']['orientation'] = 1;
+		}
+
+		// The attachment_id may change if the site is exported and imported.
+		$new_image_meta['parent_image'] = array(
+			'attachment_id' => $attachment_id,
+			// Path to the originally uploaded image file relative to the uploads directory.
+			'file'          => _wp_relative_upload_path( $image_file ),
+		);
+
+		/**
+		 * Filters the meta data for the new image created by editing an existing image.
+		 *
+		 * @since 5.5.0
+		 *
+		 * @param array $new_image_meta    Meta data for the new image.
+		 * @param int   $new_attachment_id Attachment post ID for the new image.
+		 * @param int   $attachment_id     Attachment post ID for the edited (parent) image.
+		 */
+		$new_image_meta = apply_filters( 'wp_edited_image_metadata', $new_image_meta, $new_attachment_id, $attachment_id );
+
+		wp_update_attachment_metadata( $new_attachment_id, $new_image_meta );
+
+		$response = $this->prepare_item_for_response( get_post( $new_attachment_id ), $request );
+		$response->set_status( 201 );
+		$response->header( 'Location', rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $new_attachment_id ) ) );
+
+		return $response;
+	}
+
+	/**
 	 * Finalizes an attachment after client-side media processing.
 	 *
 	 * Triggers the {@see 'wp_generate_attachment_metadata'} filter so that

--- a/phpunit/media/class-gutenberg-rest-attachments-controller-test.php
+++ b/phpunit/media/class-gutenberg-rest-attachments-controller-test.php
@@ -37,6 +37,58 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 	}
 
 	/**
+	 * Uploads an image attachment through the REST API.
+	 *
+	 * @param string $filename Upload filename.
+	 * @param string $fixture  Test fixture path.
+	 * @return int Attachment ID.
+	 */
+	private function upload_image_attachment( $filename = 'lineage-test.jpg', $fixture = '/images/canola.jpg' ) {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', "attachment; filename={$filename}" );
+		$request->set_body( file_get_contents( DIR_TESTDATA . $fixture ) );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+
+		return $response->get_data()['id'];
+	}
+
+	/**
+	 * Crops an image attachment through the REST edit endpoint.
+	 *
+	 * @param int   $attachment_id Source attachment ID.
+	 * @param array $extra_params  Optional request params.
+	 * @return WP_REST_Response REST response.
+	 */
+	private function crop_attachment( $attachment_id, array $extra_params = array() ) {
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment_id}/edit" );
+		$request->set_param( 'src', wp_get_attachment_url( $attachment_id ) );
+		$request->set_param(
+			'modifiers',
+			array(
+				array(
+					'type' => 'crop',
+					'args' => array(
+						'left'   => 10,
+						'top'    => 10,
+						'width'  => 80,
+						'height' => 80,
+					),
+				),
+			)
+		);
+
+		foreach ( $extra_params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
 	 * @covers ::register_routes
 	 */
 	public function test_register_routes() {
@@ -205,6 +257,17 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 		$this->assertArrayHasKey( 'image_meta', $data['media_details'] );
 	}
 
+	/**
+	 * @covers ::create_item
+	 */
+	public function test_create_item_does_not_store_lineage_meta() {
+		wp_set_current_user( self::$admin_id );
+
+		$attachment_id = $this->upload_image_attachment( 'lineage-upload-only.jpg' );
+
+		$this->assertFalse( metadata_exists( 'post', $attachment_id, '_source_attachment_id' ) );
+	}
+
 	public function test_prepare_item() {
 		$this->markTestSkipped( 'No need to implement' );
 	}
@@ -234,6 +297,87 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 		$this->assertNotEmpty( $data['missing_image_sizes'] );
 		$this->assertArrayHasKey( 'filename', $data );
 		$this->assertArrayHasKey( 'filesize', $data );
+	}
+
+	/**
+	 * @covers ::edit_media_item
+	 * @covers ::wp_get_original_attachment_id
+	 */
+	public function test_edit_media_item_stores_lineage_meta_from_original_attachment() {
+		wp_set_current_user( self::$admin_id );
+
+		$attachment_id = $this->upload_image_attachment( 'lineage-original.jpg' );
+		$response      = $this->crop_attachment( $attachment_id );
+		$data          = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertNotSame( $attachment_id, $data['id'] );
+		$this->assertSame( (string) $attachment_id, get_post_meta( $data['id'], '_source_attachment_id', true ) );
+
+		$metadata = wp_get_attachment_metadata( $data['id'], true );
+		$this->assertSame( $attachment_id, $metadata['parent_image']['attachment_id'] );
+		$this->assertSame( $attachment_id, wp_get_original_attachment_id( $data['id'] ) );
+		$this->assertSame( $attachment_id, wp_get_original_attachment_id( $attachment_id ) );
+	}
+
+	/**
+	 * @covers ::edit_media_item
+	 * @covers ::wp_get_original_attachment_id
+	 */
+	public function test_edit_media_item_propagates_root_lineage_meta_from_derivative_attachment() {
+		wp_set_current_user( self::$admin_id );
+
+		$original_id      = $this->upload_image_attachment( 'lineage-root.jpg' );
+		$first_response   = $this->crop_attachment( $original_id );
+		$first_crop_id    = $first_response->get_data()['id'];
+		$second_response  = $this->crop_attachment( $first_crop_id );
+		$second_crop_id   = $second_response->get_data()['id'];
+		$second_crop_meta = wp_get_attachment_metadata( $second_crop_id, true );
+
+		$this->assertSame( 201, $first_response->get_status() );
+		$this->assertSame( 201, $second_response->get_status() );
+		$this->assertSame( (string) $original_id, get_post_meta( $first_crop_id, '_source_attachment_id', true ) );
+		$this->assertSame( (string) $original_id, get_post_meta( $second_crop_id, '_source_attachment_id', true ) );
+		$this->assertSame( $first_crop_id, $second_crop_meta['parent_image']['attachment_id'] );
+		$this->assertSame( $original_id, wp_get_original_attachment_id( $second_crop_id ) );
+	}
+
+	/**
+	 * @covers ::edit_media_item
+	 * @covers ::wp_get_original_attachment_id
+	 */
+	public function test_edit_media_item_falls_back_to_source_when_lineage_meta_is_missing_or_malformed() {
+		wp_set_current_user( self::$admin_id );
+
+		$attachment_id = $this->upload_image_attachment( 'lineage-malformed.jpg' );
+
+		$this->assertSame( $attachment_id, wp_get_original_attachment_id( $attachment_id ) );
+
+		update_post_meta( $attachment_id, '_source_attachment_id', 'not-an-id' );
+
+		$response   = $this->crop_attachment( $attachment_id );
+		$cropped_id = $response->get_data()['id'];
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( (string) $attachment_id, get_post_meta( $cropped_id, '_source_attachment_id', true ) );
+
+		update_post_meta( $attachment_id, '_source_attachment_id', 0 );
+
+		$response_zero   = $this->crop_attachment( $attachment_id );
+		$cropped_zero_id = $response_zero->get_data()['id'];
+
+		$this->assertSame( 201, $response_zero->get_status() );
+		$this->assertSame( (string) $attachment_id, get_post_meta( $cropped_zero_id, '_source_attachment_id', true ) );
+	}
+
+	/**
+	 * @covers ::wp_get_original_attachment_id
+	 */
+	public function test_wp_get_original_attachment_id_returns_false_for_invalid_or_non_attachment_posts() {
+		$post_id = self::factory()->post->create();
+
+		$this->assertFalse( wp_get_original_attachment_id( 0 ) );
+		$this->assertFalse( wp_get_original_attachment_id( $post_id ) );
 	}
 
 	/**


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

Closes #78077 

## What?

Add lineage tracking for cropped media created through the Gutenberg/REST image edit flow by storing `_source_attachment_id` on newly created derivative attachments.

## Why?

When Gutenberg crops an image, it creates a brand new attachment instead of updating the existing one. While the generated attachment metadata already stores the immediate source in `parent_image`, there is no stable root/original lineage reference across crop-of-crop chains.

This makes it difficult to:

- identify all derivatives of an original image
- distinguish the root original from intermediate crops
- support future restore/grouping workflows cleanly

This PR adds a minimal backward-compatible MVP for derivative lineage tracking using attachment post meta.

## How?

This PR adds a compatibility helper, `wp_get_original_attachment_id()`, that returns the root/original attachment ID for an attachment derivative tree, or the attachment’s own ID when no lineage meta exists.

It also overrides the Gutenberg REST media edit flow in `Gutenberg_REST_Attachments_Controller::edit_media_item()` so that when a new cropped attachment is created, it stores `_source_attachment_id` on the new attachment. The stored value is always the root/original attachment ID, not the immediate parent crop.

This keeps the two lineage concepts separate:

- `_source_attachment_id` stores the root/original attachment ID
- `parent_image['attachment_id']` in `_wp_attachment_metadata` continues to store the immediate source attachment ID

The change is limited to newly created cropped attachments and does not backfill or migrate existing media.

## Testing Instructions

1. Activate the Gutenberg plugin in your local environment.
2. Open the Site Editor or Post Editor.
3. Insert an Image block.
4. Upload a new image and note its attachment ID.
5. Use the block toolbar crop tool to crop the image and save the change.
6. Identify the new cropped attachment ID in the database.
7. Confirm the cropped attachment has a `_source_attachment_id` row in `wp_postmeta` pointing to the original attachment ID.
8. Confirm the cropped attachment’s `_wp_attachment_metadata` still contains `parent_image['attachment_id']` pointing to the immediate source attachment.
9. Crop the newly cropped image again to create a second derivative.
10. Confirm the second derivative’s `_source_attachment_id` still points to the original root attachment ID.
11. Confirm the second derivative’s `parent_image['attachment_id']` points to the first cropped attachment, not the original.
12. Upload a separate image without cropping it.
13. Confirm that normal uploads do not get a `_source_attachment_id` meta entry.
