### PR TITLE
Revisions: Sync active revision ID with URL to support direct linking

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -308,6 +308,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			setCurrentTemplateId,
 			setEditedPost,
 			setRenderingMode,
+			setCurrentRevisionId,
 		} = unlock( useDispatch( editorStore ) );
 		const { editEntityRecord } = useDispatch( coreStore );
 
@@ -387,6 +388,35 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 				setRenderingMode( defaultMode );
 			}
 		}, [ defaultMode, setRenderingMode ] );
+
+		// If the URL contains ?revision=<id>, open that revision.
+		useEffect( () => {
+			if ( typeof window === 'undefined' ) {
+				return;
+			}
+			const urlParams = new URLSearchParams( window.location.search );
+			const revisionParam = urlParams.get( 'revision' );
+			if ( revisionParam ) {
+				setCurrentRevisionId( parseInt( revisionParam, 10 ) );
+			}
+			// Run once on mount only.
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, [] );
+
+		// Whenever the active revision changes, keep the URL in sync so the
+		// revision is bookmarkable / shareable.
+		useEffect( () => {
+			if ( typeof window === 'undefined' ) {
+				return;
+			}
+			const url = new URL( window.location.href );
+			if ( currentRevisionId ) {
+				url.searchParams.set( 'revision', currentRevisionId );
+			} else {
+				url.searchParams.delete( 'revision' );
+			}
+			window.history.replaceState( {}, '', url.toString() );
+		}, [ currentRevisionId ] );
 
 		useHideBlocksFromInserter( post.type, mode );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #76552

This PR makes it possible to link directly to a specific post revision inside the editor by keeping the browser's URL synced up with the active revision.

## Why?
Right now, if you are looking at a specific revision in the visual editor and try to reload the page or share the link with a coworker, it just drops you back into the current draft of the post. The classic revisions screen used to support this by adding a query parameter to the URL, so this PR brings that same functionality over to the new visual revisions experience. Having this parity makes it much easier to share, bookmark, and review past changes.

## How?
Added two `useEffect`. When the editor first loads up, it checks the window's URL for a revision query parameter. If it spots one, it automatically sets that revision ID as the current one in the data store.

On the flip side, whenever you click around and change the active revision in the UI, another `useEffect` catches that change. It then silently updates the browser URL using the browser's history API, so the query parameter is always accurate without needing to trigger a full page reload.

## Testing Instructions

1. Open up any post or page that has been saved a few times so you have some revision history to work with.
2. Open the visual revisions sidebar and click on an older revision.
3. Look at your browser's address bar, you should immediately see a `?revision=` parameter added to the URL with an ID number.
4. Copy that entire URL, open a brand new tab, and paste it in.
5. Verify that the editor loads up and automatically jumps right back into that exact same revision view you were just looking at.
6. Click to "Exit" to the current draft and verify that the URL cleans itself up and removes the parameter.