### PR TITLE
Widgets: Declare dependencies in a per-widget package.json

### DIFF
--- a/.npmpackagejsonlintignore
+++ b/.npmpackagejsonlintignore
@@ -4,3 +4,4 @@ build
 vendor
 wordpress
 routes
+widgets

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
 				"test/performance",
 				"test/storybook-playwright",
 				"test/unit",
-				"tools/*"
+				"tools/*",
+				"widgets/*"
 			],
 			"devDependencies": {
 				"@babel/core": "7.25.7",
@@ -20903,6 +20904,10 @@
 		},
 		"node_modules/@wordpress/guidelines-route": {
 			"resolved": "routes/guidelines",
+			"link": true
+		},
+		"node_modules/@wordpress/hello-world-widget": {
+			"resolved": "widgets/hello-world",
 			"link": true
 		},
 		"node_modules/@wordpress/home-route": {
@@ -67037,6 +67042,15 @@
 			"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"widgets/hello-world": {
+			"name": "@wordpress/hello-world-widget",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/icons": "file:../../packages/icons",
+				"@wordpress/ui": "file:../../packages/ui",
+				"clsx": "^2.1.1"
+			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -242,6 +242,7 @@
 		"test/performance",
 		"test/storybook-playwright",
 		"test/unit",
-		"tools/*"
+		"tools/*",
+		"widgets/*"
 	]
 }

--- a/widgets/hello-world/package.json
+++ b/widgets/hello-world/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "@wordpress/hello-world-widget",
+	"version": "1.0.0",
+	"private": true,
+	"dependencies": {
+		"@wordpress/icons": "file:../../packages/icons",
+		"@wordpress/ui": "file:../../packages/ui",
+		"clsx": "^2.1.1"
+	}
+}

--- a/widgets/hello-world/render.tsx
+++ b/widgets/hello-world/render.tsx
@@ -1,16 +1,24 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
 import { Stack, Text } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
 
 export default function HelloWorld() {
 	return (
 		<Stack
 			align="center"
 			justify="center"
-			style={ {
-				height: '100%',
-				padding: 'var(--wpds-dimension-padding-2xl)',
-				backgroundColor: 'var(--wpds-color-bg-surface-brand)',
-				color: 'var(--wpds-color-fg-interactive-brand)',
-			} }
+			className={ clsx( styles.root ) }
 		>
 			<Text variant="heading-2xl">Hello World</Text>
 		</Stack>

--- a/widgets/hello-world/style.module.css
+++ b/widgets/hello-world/style.module.css
@@ -1,0 +1,6 @@
+.root {
+	height: 100%;
+	padding: var(--wpds-dimension-padding-2xl);
+	background-color: var(--wpds-color-bg-surface-brand);
+	color: var(--wpds-color-fg-interactive-brand);
+}


### PR DESCRIPTION
## What?

- Add a `package.json` to `widgets/hello-world` that declares the widget's own dependencies: `@wordpress/icons`, `@wordpress/ui`, and `clsx`.
- Register `widgets/*` as npm workspaces in the root `package.json`.
- Compose the widget's root `className` with `clsx`, moving the inline layout styles into a co-located `style.module.css`.

## Why?

ESLint's `import/no-extraneous-dependencies` resolves a file's dependencies from the nearest `package.json`. With no manifest under `widgets/`, any widget that imports a **bundled** dependency (such as `clsx`) would force that dependency to be declared at the repository root just to satisfy the rule.

A per-widget `package.json` lets each widget declare the dependencies it actually uses, so the root manifest stays free of widget-specific entries. Registering `widgets/*` as workspaces makes npm aware of each widget's manifest and links its dependencies on install.

## How?

- `widgets/hello-world/package.json` declares the `@wordpress/*` packages the widget consumes (externalized at runtime by the build) plus `clsx` (bundled into the widget output). The `@wordpress/*` entries use `file:` links, consistent with the other in-repo workspaces.
- `widgets/*` is added to the root `workspaces` array; `npm install` links the workspace and records it in `package-lock.json`.
- `render.tsx` composes its root `className` with `clsx( styles.root )`; the layout declarations move from an inline `style` object to `style.module.css`.

Note: the build's externals are a fixed list (`@wordpress/*` plus a handful of vendor globals), so the manifest does not change build output. It is dependency-resolution metadata for tooling (ESLint, npm workspaces). `clsx` is not in the externals list, so it is bundled and therefore belongs in the widget's `dependencies`.

## Testing

1. `npm install` runs clean and records `@wordpress/hello-world-widget` as a workspace in `package-lock.json`.
2. `npx eslint widgets/hello-world/render.tsx widgets/hello-world/widget.ts` passes (no `import/no-extraneous-dependencies`).
3. `npx stylelint widgets/hello-world/style.module.css` passes.
4. Build the project and confirm `build/widgets/hello-world/` emits the widget with `clsx` bundled into `render.js`, `@wordpress/*` listed as dependencies in `render.min.asset.php`, and the CSS module emitted as the widget stylesheet.
5. The Hello World widget renders unchanged: a centered `heading-2xl` on the brand surface.

## Follow-ups

- [ ] Add a `package.json` to other widgets as they gain bundled dependencies.
