### PR TITLE
Tooltip migration: editor + edit-post + edit-site consumers (2/5)

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -40,7 +40,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import {
 	Icon as WCIcon,
 	SlotFillProvider,
-	Tooltip as WCTooltip,
 	__unstableUseNavigateRegions as useNavigateRegions,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
@@ -50,7 +49,8 @@ import {
 	useRefEffect,
 	useViewportMatch,
 } from '@wordpress/compose';
-import { VisuallyHidden } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip, VisuallyHidden } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -328,16 +328,21 @@ function MetaBoxesMain( { isLegacy } ) {
 	// The separator button that provides a11y for resizing.
 	const separator = ! isShort && (
 		<>
-			<WCTooltip text={ __( 'Drag to resize' ) }>
-				<button
-					ref={ separatorRef }
-					role="separator" // eslint-disable-line jsx-a11y/no-interactive-element-to-noninteractive-role
-					aria-valuenow={ usedAriaValueNow }
-					aria-label={ __( 'Drag to resize' ) }
-					aria-describedby={ separatorHelpId }
-					{ ...bindDragGesture() }
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					render={
+						<button
+							ref={ separatorRef }
+							role="separator" // eslint-disable-line jsx-a11y/no-interactive-element-to-noninteractive-role
+							aria-valuenow={ usedAriaValueNow }
+							aria-label={ __( 'Drag to resize' ) }
+							aria-describedby={ separatorHelpId }
+							{ ...bindDragGesture() }
+						/>
+					}
 				/>
-			</WCTooltip>
+				<Tooltip.Popup>{ __( 'Drag to resize' ) }</Tooltip.Popup>
+			</Tooltip.Root>
 			<VisuallyHidden id={ separatorHelpId }>
 				{ __(
 					'Use up and down arrow keys to resize the meta box pane.'
@@ -572,52 +577,56 @@ function Layout( {
 
 	return (
 		<SlotFillProvider>
-			<ErrorBoundary canCopyContent>
-				<WelcomeGuide postType={ currentPostType } />
-				<div { ...navigateRegionsProps }>
-					<Editor
-						settings={ editorSettings }
-						initialEdits={ initialEdits }
-						postType={ currentPostType }
-						postId={ currentPostId }
-						templateId={ templateId }
-						className={ className }
-						forceIsDirty={ hasActiveMetaboxes }
-						disableIframe={ ! shouldIframe }
-						// We should auto-focus the canvas (title) on load.
-						// eslint-disable-next-line jsx-a11y/no-autofocus
-						autoFocus={ ! isWelcomeGuideVisible }
-						onActionPerformed={ onActionPerformed }
-						extraSidebarPanels={
-							showMetaBoxes && <MetaBoxes location="side" />
-						}
-						extraContent={
-							! isDistractionFree &&
-							showMetaBoxes && (
-								<MetaBoxesMain isLegacy={ isDevicePreview } />
-							)
-						}
-					>
-						<PostLockedModal />
-						<EditorInitialization />
-						<FullscreenMode isActive={ isFullscreenActive } />
-						<BrowserURL />
-						<UnsavedChangesWarning />
-						<AutosaveMonitor />
-						<LocalAutosaveMonitor />
-						<EditPostKeyboardShortcuts />
-						<EditorKeyboardShortcutsRegister />
-						<BlockKeyboardShortcuts />
-						{ currentPostType === 'wp_block' && (
-							<InitPatternModal />
-						) }
-						<PluginArea onError={ onPluginAreaError } />
-						<PostEditorMoreMenu />
-						{ backButton }
-						<SnackbarNotices className="edit-post-layout__snackbar" />
-					</Editor>
-				</div>
-			</ErrorBoundary>
+			<Tooltip.Provider>
+				<ErrorBoundary canCopyContent>
+					<WelcomeGuide postType={ currentPostType } />
+					<div { ...navigateRegionsProps }>
+						<Editor
+							settings={ editorSettings }
+							initialEdits={ initialEdits }
+							postType={ currentPostType }
+							postId={ currentPostId }
+							templateId={ templateId }
+							className={ className }
+							forceIsDirty={ hasActiveMetaboxes }
+							disableIframe={ ! shouldIframe }
+							// We should auto-focus the canvas (title) on load.
+							// eslint-disable-next-line jsx-a11y/no-autofocus
+							autoFocus={ ! isWelcomeGuideVisible }
+							onActionPerformed={ onActionPerformed }
+							extraSidebarPanels={
+								showMetaBoxes && <MetaBoxes location="side" />
+							}
+							extraContent={
+								! isDistractionFree &&
+								showMetaBoxes && (
+									<MetaBoxesMain
+										isLegacy={ isDevicePreview }
+									/>
+								)
+							}
+						>
+							<PostLockedModal />
+							<EditorInitialization />
+							<FullscreenMode isActive={ isFullscreenActive } />
+							<BrowserURL />
+							<UnsavedChangesWarning />
+							<AutosaveMonitor />
+							<LocalAutosaveMonitor />
+							<EditPostKeyboardShortcuts />
+							<EditorKeyboardShortcutsRegister />
+							<BlockKeyboardShortcuts />
+							{ currentPostType === 'wp_block' && (
+								<InitPatternModal />
+							) }
+							<PluginArea onError={ onPluginAreaError } />
+							<PostEditorMoreMenu />
+							{ backButton }
+							<SnackbarNotices className="edit-post-layout__snackbar" />
+						</Editor>
+					</div>
+				</ErrorBoundary>
+			</Tooltip.Provider>
 		</SlotFillProvider>
 	);
 }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -31,6 +31,8 @@ import { PluginArea } from '@wordpress/plugins';
 import { SnackbarNotices, store as noticesStore } from '@wordpress/notices';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -282,9 +284,11 @@ export default function LayoutWithGlobalStylesProvider( props ) {
 
 	return (
 		<SlotFillProvider>
-			{ /** This needs to be within the SlotFillProvider */ }
-			<PluginArea onError={ onPluginAreaError } />
-			<Layout { ...props } />
+			<Tooltip.Provider>
+				{ /** This needs to be within the SlotFillProvider */ }
+				<PluginArea onError={ onPluginAreaError } />
+				<Layout { ...props } />
+			</Tooltip.Provider>
 		</SlotFillProvider>
 	);
 }

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -9,7 +9,6 @@ import clsx from 'clsx';
 import { useState, useRef } from '@wordpress/element';
 import {
 	ResizableBox,
-	Tooltip as WCTooltip,
 	__unstableMotion as motion,
 } from '@wordpress/components';
 import { useInstanceId, useReducedMotion } from '@wordpress/compose';
@@ -18,6 +17,8 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { addQueryArgs } from '@wordpress/url';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -294,32 +295,43 @@ function ResizableFrame( {
 			handleComponent={ {
 				[ isRTL() ? 'right' : 'left' ]: canvas === 'view' && (
 					<>
-						<WCTooltip text={ __( 'Drag to resize' ) }>
-							<motion.button
-								key="handle"
-								role="separator"
-								aria-orientation="vertical"
-								className={ clsx(
-									'edit-site-resizable-frame__handle',
-									{ 'is-resizing': isResizing }
-								) }
-								variants={ resizeHandleVariants }
-								animate={ currentResizeHandleVariant }
-								aria-label={ __( 'Drag to resize' ) }
-								aria-describedby={ resizableHandleHelpId }
-								aria-valuenow={
-									frameRef.current?.resizable?.offsetWidth ||
-									undefined
+						<Tooltip.Root>
+							<Tooltip.Trigger
+								render={
+									<motion.button
+										key="handle"
+										role="separator"
+										aria-orientation="vertical"
+										className={ clsx(
+											'edit-site-resizable-frame__handle',
+											{ 'is-resizing': isResizing }
+										) }
+										variants={ resizeHandleVariants }
+										animate={ currentResizeHandleVariant }
+										aria-label={ __( 'Drag to resize' ) }
+										aria-describedby={
+											resizableHandleHelpId
+										}
+										aria-valuenow={
+											frameRef.current?.resizable
+												?.offsetWidth || undefined
+										}
+										aria-valuemin={ FRAME_MIN_WIDTH }
+										aria-valuemax={ defaultSize.width }
+										onKeyDown={
+											handleResizableHandleKeyDown
+										}
+										initial="hidden"
+										exit="hidden"
+										whileFocus="active"
+										whileHover="active"
+									/>
 								}
-								aria-valuemin={ FRAME_MIN_WIDTH }
-								aria-valuemax={ defaultSize.width }
-								onKeyDown={ handleResizableHandleKeyDown }
-								initial="hidden"
-								exit="hidden"
-								whileFocus="active"
-								whileHover="active"
 							/>
-						</WCTooltip>
+							<Tooltip.Popup>
+								{ __( 'Drag to resize' ) }
+							</Tooltip.Popup>
+						</Tooltip.Root>
 						<div hidden id={ resizableHandleHelpId }>
 							{ __(
 								'Use left and right arrow keys to resize the canvas. Hold shift to resize in larger increments.'

--- a/packages/editor/src/components/collab-sidebar/note-byline.js
+++ b/packages/editor/src/components/collab-sidebar/note-byline.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Tooltip as WCTooltip } from '@wordpress/components';
-import { Stack } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Stack, Tooltip } from '@wordpress/ui';
 import { __, _x } from '@wordpress/i18n';
 import {
 	dateI18n,
@@ -95,14 +95,19 @@ export function NoteByline( { avatar, name, date, userId } ) {
 					{ name ?? currentUserName }
 				</span>
 				{ date && (
-					<WCTooltip text={ tooltipText }>
-						<time
-							dateTime={ commentDateTime }
-							className="editor-collab-sidebar-panel__user-time"
-						>
-							{ commentDateText }
-						</time>
-					</WCTooltip>
+					<Tooltip.Root>
+						<Tooltip.Trigger
+							render={
+								<time
+									dateTime={ commentDateTime }
+									className="editor-collab-sidebar-panel__user-time"
+								>
+									{ commentDateText }
+								</time>
+							}
+						/>
+						<Tooltip.Popup>{ tooltipText }</Tooltip.Popup>
+					</Tooltip.Root>
 				) }
 			</Stack>
 		</>

--- a/packages/editor/src/components/collaborators-presence/avatar/component.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar/component.tsx
@@ -10,8 +10,10 @@ extend( [ a11yPlugin ] );
 /**
  * WordPress dependencies
  */
-import { Icon as WCIcon, Tooltip as WCTooltip } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -114,7 +116,12 @@ function Avatar( {
 	);
 
 	if ( name && ( ! showBadge || label ) ) {
-		return <WCTooltip text={ name }>{ avatar }</WCTooltip>;
+		return (
+			<Tooltip.Root>
+				<Tooltip.Trigger render={ avatar } />
+				<Tooltip.Popup>{ name }</Tooltip.Popup>
+			</Tooltip.Root>
+		);
 	}
 
 	return avatar;

--- a/packages/editor/src/components/collaborators-presence/avatar/test/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar/test/index.tsx
@@ -2,11 +2,28 @@
  * External dependencies
  */
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
  */
 import Avatar from '..';
+
+/**
+ * Wraps the avatar in a `Tooltip.Provider` with `delay={ 0 }` so hover-based
+ * tooltip-presence assertions don't have to wait for the real-world delay.
+ *
+ * @param ui The avatar element (or anything else) to render.
+ */
+function renderAvatar( ui: React.ReactElement ): ReturnType< typeof render > {
+	return render( <Tooltip.Provider delay={ 0 }>{ ui }</Tooltip.Provider> );
+}
 
 /**
  * In JSDOM, `<img>` elements never fire `load` or `error` events on their
@@ -190,12 +207,13 @@ describe( 'Avatar', () => {
 			expect( avatar ).toBeInTheDocument();
 		} );
 
-		it( 'should wrap in tooltip when label differs from name', () => {
-			render( <Avatar name="Jane Doe" label="You" variant="badge" /> );
-			const avatar = screen.getByRole( 'img', { name: 'Jane Doe' } );
-			// The Tooltip's Ariakit.TooltipAnchor makes the element
-			// focusable so the tooltip can be triggered via keyboard.
-			expect( avatar ).toHaveAttribute( 'tabindex', '0' );
+		it( 'should wrap in tooltip when label differs from name', async () => {
+			const user = userEvent.setup();
+			renderAvatar(
+				<Avatar name="Jane Doe" label="You" variant="badge" />
+			);
+			await user.hover( screen.getByRole( 'img', { name: 'Jane Doe' } ) );
+			expect( await screen.findByText( 'Jane Doe' ) ).toBeVisible();
 		} );
 	} );
 
@@ -367,23 +385,37 @@ describe( 'Avatar', () => {
 	} );
 
 	describe( 'tooltip', () => {
-		it( 'should wrap in tooltip when name is provided without badge', () => {
-			render( <Avatar name="Jane Doe" /> );
-			const avatar = screen.getByRole( 'img', { name: 'Jane Doe' } );
-			expect( avatar ).toHaveAttribute( 'tabindex', '0' );
+		it( 'should wrap in tooltip when name is provided without badge', async () => {
+			const user = userEvent.setup();
+			renderAvatar( <Avatar name="Jane Doe" /> );
+			await user.hover( screen.getByRole( 'img', { name: 'Jane Doe' } ) );
+			expect( await screen.findByText( 'Jane Doe' ) ).toBeVisible();
 		} );
 
-		it( 'should not wrap in tooltip for badge without label', () => {
-			render( <Avatar name="Jane Doe" variant="badge" /> );
-			const avatar = screen.getByRole( 'img', { name: 'Jane Doe' } );
-			// Badge shows the name visibly, so no tooltip needed.
-			expect( avatar ).not.toHaveAttribute( 'tabindex' );
+		it( 'should not wrap in tooltip for badge without label', async () => {
+			const user = userEvent.setup();
+			renderAvatar( <Avatar name="Jane Doe" variant="badge" /> );
+			// Before hovering: the single "Jane Doe" occurrence is the
+			// badge text — that's what the next assertion is allowed to
+			// match. Hovering should not add a second occurrence.
+			expect( screen.getAllByText( 'Jane Doe' ) ).toHaveLength( 1 );
+			await user.hover( screen.getByRole( 'img', { name: 'Jane Doe' } ) );
+			expect( screen.getAllByText( 'Jane Doe' ) ).toHaveLength( 1 );
 		} );
 
-		it( 'should not wrap in tooltip when name is not provided', () => {
-			render( <Avatar data-testid="avatar" /> );
+		it( 'should not wrap in tooltip when name is not provided', async () => {
+			const user = userEvent.setup();
+			renderAvatar( <Avatar data-testid="avatar" /> );
 			const avatar = screen.getByTestId( 'avatar' );
-			expect( avatar ).not.toHaveAttribute( 'tabindex' );
+			const bodyTextBefore = document.body.textContent;
+			await user.hover( avatar );
+			// No name → no `Tooltip.Root` wrapper at all, so hovering
+			// cannot reveal any additional text content anywhere in the
+			// document (no popup mounts). Strict equality is what we
+			// want here — a substring `toHaveTextContent` would still
+			// pass if the popup added text.
+			// eslint-disable-next-line jest-dom/prefer-to-have-text-content -- intentional, see comment above.
+			expect( document.body.textContent ).toBe( bodyTextBefore );
 		} );
 	} );
 } );

--- a/packages/editor/src/components/post-revisions-preview/diff-markers.js
+++ b/packages/editor/src/components/post-revisions-preview/diff-markers.js
@@ -15,7 +15,8 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { Tooltip as WCTooltip } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -98,17 +99,22 @@ function DiffMarkerButton( { clientId, status, subscribe } ) {
 	}
 
 	return (
-		<WCTooltip text={ STATUS_LABELS[ status ] }>
-			<button
-				className={ `revision-diff-marker is-${ status }` }
-				style={ {
-					top: `${ position.top }%`,
-					height: `${ Math.max( position.height, 0.5 ) }%`,
-				} }
-				onClick={ () => blockRef.current?.focus() }
-				aria-label={ STATUS_LABELS[ status ] }
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				render={
+					<button
+						className={ `revision-diff-marker is-${ status }` }
+						style={ {
+							top: `${ position.top }%`,
+							height: `${ Math.max( position.height, 0.5 ) }%`,
+						} }
+						onClick={ () => blockRef.current?.focus() }
+						aria-label={ STATUS_LABELS[ status ] }
+					/>
+				}
 			/>
-		</WCTooltip>
+			<Tooltip.Popup>{ STATUS_LABELS[ status ] }</Tooltip.Popup>
+		</Tooltip.Root>
 	);
 }
 

--- a/packages/editor/src/components/resizable-editor/resize-handle.js
+++ b/packages/editor/src/components/resizable-editor/resize-handle.js
@@ -3,11 +3,9 @@
  */
 import { __ } from '@wordpress/i18n';
 import { LEFT, RIGHT } from '@wordpress/keycodes';
-import {
-	Tooltip as WCTooltip,
-	__unstableMotion as motion,
-} from '@wordpress/components';
-import { VisuallyHidden } from '@wordpress/ui';
+import { __unstableMotion as motion } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip, VisuallyHidden } from '@wordpress/ui';
 
 const DELTA_DISTANCE = 20; // The distance to resize per keydown in pixels.
 
@@ -44,21 +42,26 @@ export default function ResizeHandle( { direction, resizeWidthBy } ) {
 
 	return (
 		<>
-			<WCTooltip text={ __( 'Drag to resize' ) }>
-				<motion.button
-					className={ `editor-resizable-editor__resize-handle is-${ direction }` }
-					aria-label={ __( 'Drag to resize' ) }
-					aria-describedby={ resizableHandleHelpId }
-					onKeyDown={ handleKeyDown }
-					variants={ resizeHandleVariants }
-					whileFocus="active"
-					whileHover="active"
-					whileTap="active"
-					key="handle"
-					role="separator"
-					aria-orientation="vertical"
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					render={
+						<motion.button
+							className={ `editor-resizable-editor__resize-handle is-${ direction }` }
+							aria-label={ __( 'Drag to resize' ) }
+							aria-describedby={ resizableHandleHelpId }
+							onKeyDown={ handleKeyDown }
+							variants={ resizeHandleVariants }
+							whileFocus="active"
+							whileHover="active"
+							whileTap="active"
+							key="handle"
+							role="separator"
+							aria-orientation="vertical"
+						/>
+					}
 				/>
-			</WCTooltip>
+				<Tooltip.Popup>{ __( 'Drag to resize' ) }</Tooltip.Popup>
+			</Tooltip.Root>
 			<VisuallyHidden id={ resizableHandleHelpId }>
 				{ __( 'Use left and right arrow keys to resize the canvas.' ) }
 			</VisuallyHidden>

--- a/packages/editor/src/components/template-actions-panel/block-theme-content.js
+++ b/packages/editor/src/components/template-actions-panel/block-theme-content.js
@@ -11,7 +11,6 @@ import { BlockPreview } from '@wordpress/block-editor';
 import {
 	PanelBody,
 	Button,
-	Tooltip as WCTooltip,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -20,6 +19,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as preferencesStore } from '@wordpress/preferences';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -117,18 +118,23 @@ export default function TemplateActionsPanelContent() {
 		if ( hasSwapTargets ) {
 			const tooltipText = __( 'Change template' );
 			return (
-				<WCTooltip text={ tooltipText }>
-					<div
-						className="editor-template-actions-panel__preview"
-						role="button"
-						tabIndex={ 0 }
-						aria-label={ tooltipText }
-						onClick={ () => setIsSwapModalOpen( true ) }
-						onKeyPress={ () => setIsSwapModalOpen( true ) }
-					>
-						{ previewContent }
-					</div>
-				</WCTooltip>
+				<Tooltip.Root>
+					<Tooltip.Trigger
+						render={
+							<div
+								className="editor-template-actions-panel__preview"
+								role="button"
+								tabIndex={ 0 }
+								aria-label={ tooltipText }
+								onClick={ () => setIsSwapModalOpen( true ) }
+								onKeyPress={ () => setIsSwapModalOpen( true ) }
+							>
+								{ previewContent }
+							</div>
+						}
+					/>
+					<Tooltip.Popup>{ tooltipText }</Tooltip.Popup>
+				</Tooltip.Root>
 			);
 		}
 


### PR DESCRIPTION
## What?

Follow up to #78095 and #78411 (now landed on trunk).

Migrates **7 consumer call sites** in `@wordpress/editor`, `@wordpress/edit-post`, and `@wordpress/edit-site` from the legacy `Tooltip` (`@wordpress/components`) to the new compositional `Tooltip` (`@wordpress/ui`, built on base-ui). Part 2 of a 5-PR series; also mounts the shell-level `<Tooltip.Provider>` for the post and site editors.

<details>
<summary>Sites migrated in this PR</summary>

- `editor/components/collab-sidebar/note-byline` — *non-interactive `<time>` trigger; visual-only on hover, flagged for a11y follow-up*
- `editor/components/collaborators-presence/avatar` — *non-interactive `<div role="img">` trigger; visual-only on hover, flagged for a11y follow-up*
- `editor/components/post-revisions-preview/diff-markers`
- `editor/components/resizable-editor/resize-handle`
- `editor/components/template-actions-panel/block-theme-content`
- `edit-post/components/layout` (resize separator)
- `edit-site/components/resizable-frame`

`edit-post/components/layout/index.native.js` is **intentionally left on the legacy import** — it uses `<WCTooltip.Slot>`, which is the SlotFill pattern of the legacy implementation and has no equivalent in the new compositional `Tooltip`.

</details>

<details>
<summary>Full 5-PR plan</summary>

1. ~~block-editor + block-directory (also lands the codemod)~~ — #78411 ✅ landed
2. **editor + edit-post + edit-site (+ shell-level `Tooltip.Provider`) ← this PR**
3. dataviews
4. fields + media-editor + media-fields + global-styles-ui
5. boot (+ manual save-button + shell-level `Tooltip.Provider`)

</details>

## Why?

#78095 introduced the new compositional `Tooltip` API in `@wordpress/ui`. This PR series migrates all consumers outside `@wordpress/components` itself to the new API, so that future tooltip work (delays, providers, positioner, base-ui upgrades) can happen in one place.

> [!NOTE]
> Call sites *inside* `@wordpress/components` (notably `Button`'s internal Tooltip and `TooltipInternalContext`) stay on the legacy implementation — tracked as a separate follow-up.

## How?

Each `<Tooltip>` is rewritten to the compositional API by the jscodeshift codemod landed in #78411; import placement / ordering and one `jsx-a11y` disable directive that the codemod couldn't preserve were finished by hand. Each migrated `Tooltip` import also carries a per-site `// eslint-disable-next-line @wordpress/use-recommended-components` directive (matching the approach in #78411) — `Tooltip` from `@wordpress/ui` is not yet on the recommended allow-list and we'd rather flip the recommendation in one go after the migration series has bedded in.

<details>
<summary>Codemod</summary>

```sh
npx jscodeshift -t tools/codemods/tooltip-components-to-ui.js \
    --extensions=js,jsx,ts,tsx --parser=tsx \
    packages/editor packages/edit-post packages/edit-site
```

The codemod's API mapping and bailouts are documented in #78411.

</details>

<details>
<summary>Shell-level `Tooltip.Provider`</summary>

Mounted in `packages/edit-post/src/components/layout/index.js` and `packages/edit-site/src/components/layout/index.js`, inside the existing `<SlotFillProvider>`, so that tooltips throughout each editor coordinate as a group: once the first tooltip in a group has been shown, subsequent siblings open instantly. PR 5 will do the same for the new dashboard / `@wordpress/boot` shell.

</details>

<details>
<summary>Avatar test rewrite</summary>

`packages/editor/src/components/collaborators-presence/avatar/test/index.tsx` previously relied on the legacy `Ariakit.TooltipAnchor` adding `tabindex="0"` on a non-interactive trigger. base-ui's `Tooltip.Trigger` doesn't do that. The affected tests now verify tooltip *presence* by hovering the avatar and asserting the popup content becomes visible (the helper wraps the test tree in a `Tooltip.Provider` with `delay={ 0 }` so the assertion doesn't race the real-world hover delay).

The assertions follow the same idiom as `packages/ui/src/tooltip/test/index.test.tsx`: `await screen.findByText( name )` for the positive cases (no more `getByText( … , { selector: 'div *' } )` selector-internal hack) and structural counts/string equality for the negative cases. No assertion now relies on the popup's internal DOM shape.

</details>

## Testing Instructions

1. Hover each migrated trigger listed above and verify the popup appears with the expected text and placement.
2. Specifically exercise the **post editor resize separator** (`edit-post/layout`) and the **site editor canvas resize handle** (`edit-site/resizable-frame`) — both stayed on `<button role="separator">` with the same `aria-*` plumbing they already had.
3. With the post editor or the site editor open, hover any two unrelated tooltip-bearing controls in quick succession: the second tooltip should open instantly (shell-level `Tooltip.Provider` coordinating the group).
4. `npm run test:unit -- packages/editor packages/edit-post packages/edit-site` — Jest unit tests should pass.

### Testing Instructions for Keyboard

1. Tab to each migrated **interactive** trigger and confirm the tooltip opens on focus and closes on blur / `Esc`.
2. The non-interactive `<time>` (in `collab-sidebar/note-byline`) and `<div role="img">` (in `collaborators-presence/avatar`) triggers are **not** keyboard-reachable on purpose; flagged above for a11y follow-up.

## Screenshots or screencast

No visual change is intended versus the legacy `Tooltip` (same placement, same text, same hover/focus behaviour). Each migrated site has a dedicated inline review comment on this PR with a screenshot of the post-migration tooltip in context.

## Use of AI Tools

This PR was authored with assistance from Cursor (Claude). All changes were reviewed by a human before being committed; the codemod and migrated files were also exercised locally (Jest, lint, Prettier) before being pushed.

