### PR TITLE
Make e2e tests runnable without Gutenberg plugin active

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/gutenberg-experiments.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/gutenberg-experiments.ts
@@ -9,22 +9,11 @@ import type { RequestUtils } from './index';
  * @param this
  * @param experiments Array of experimental flags to enable. Pass in an empty array to disable all experiments.
  *                    Use 'active_templates' for the template activation feature.
- * @return `true` when experiments were applied, `false` when the Gutenberg
- *         plugin is not active (the `gutenberg-experiments` setting is only
- *         registered by the plugin).
  */
 async function setGutenbergExperiments(
 	this: RequestUtils,
 	experiments: string[]
-): Promise< boolean > {
-	const currentSiteSettings = ( await this.getSiteSettings() ) as unknown as {
-		'gutenberg-experiments'?: unknown;
-		active_templates?: unknown;
-	};
-	if ( ! ( 'gutenberg-experiments' in currentSiteSettings ) ) {
-		return false;
-	}
-
+) {
 	// Separate regular experiments from active_templates.
 	// active_templates is stored as a separate option, not in the experiments array.
 	const regularExperiments = experiments.filter(
@@ -49,12 +38,18 @@ async function setGutenbergExperiments(
 	// it.
 	if ( hasActiveTemplates ) {
 		settingsData.active_templates = {};
-	} else if ( currentSiteSettings.active_templates !== null ) {
+	} else {
 		// WP_REST_Settings_Controller rejects null updates when the stored
 		// value does not match the `type: 'object'` schema (including when the
 		// option is absent and `get_option` falls back to `false`), so we only
 		// send null when the option actually exists.
-		settingsData.active_templates = null;
+		const currentSiteSettings =
+			( await this.getSiteSettings() ) as unknown as {
+				active_templates?: unknown;
+			};
+		if ( currentSiteSettings.active_templates !== null ) {
+			settingsData.active_templates = null;
+		}
 	}
 
 	await this.rest( {
@@ -62,8 +57,6 @@ async function setGutenbergExperiments(
 		method: 'POST',
 		data: settingsData,
 	} );
-
-	return true;
 }
 
 export { setGutenbergExperiments };

--- a/packages/e2e-test-utils-playwright/src/request-utils/gutenberg-experiments.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/gutenberg-experiments.ts
@@ -9,11 +9,22 @@ import type { RequestUtils } from './index';
  * @param this
  * @param experiments Array of experimental flags to enable. Pass in an empty array to disable all experiments.
  *                    Use 'active_templates' for the template activation feature.
+ * @return `true` when experiments were applied, `false` when the Gutenberg
+ *         plugin is not active (the `gutenberg-experiments` setting is only
+ *         registered by the plugin).
  */
 async function setGutenbergExperiments(
 	this: RequestUtils,
 	experiments: string[]
-) {
+): Promise< boolean > {
+	const currentSiteSettings = ( await this.getSiteSettings() ) as unknown as {
+		'gutenberg-experiments'?: unknown;
+		active_templates?: unknown;
+	};
+	if ( ! ( 'gutenberg-experiments' in currentSiteSettings ) ) {
+		return false;
+	}
+
 	// Separate regular experiments from active_templates.
 	// active_templates is stored as a separate option, not in the experiments array.
 	const regularExperiments = experiments.filter(
@@ -38,18 +49,12 @@ async function setGutenbergExperiments(
 	// it.
 	if ( hasActiveTemplates ) {
 		settingsData.active_templates = {};
-	} else {
+	} else if ( currentSiteSettings.active_templates !== null ) {
 		// WP_REST_Settings_Controller rejects null updates when the stored
 		// value does not match the `type: 'object'` schema (including when the
 		// option is absent and `get_option` falls back to `false`), so we only
 		// send null when the option actually exists.
-		const currentSiteSettings =
-			( await this.getSiteSettings() ) as unknown as {
-				active_templates?: unknown;
-			};
-		if ( currentSiteSettings.active_templates !== null ) {
-			settingsData.active_templates = null;
-		}
+		settingsData.active_templates = null;
 	}
 
 	await this.rest( {
@@ -57,6 +62,8 @@ async function setGutenbergExperiments(
 		method: 'POST',
 		data: settingsData,
 	} );
+
+	return true;
 }
 
 export { setGutenbergExperiments };

--- a/packages/e2e-test-utils-playwright/src/test.ts
+++ b/packages/e2e-test-utils-playwright/src/test.ts
@@ -135,6 +135,7 @@ const test = base.extend<
 	{
 		requestUtils: RequestUtils;
 		lighthousePort: number;
+		isGutenbergPluginActive: boolean;
 	}
 >( {
 	admin: async ( { page, pageUtils, editor }, use ) => {
@@ -199,6 +200,19 @@ const test = base.extend<
 	metrics: async ( { page }, use ) => {
 		await use( new Metrics( { page } ) );
 	},
+	isGutenbergPluginActive: [
+		async ( { requestUtils }, use ) => {
+			const plugins = await requestUtils.rest( {
+				path: '/wp/v2/plugins',
+			} );
+			const gutenberg = plugins.find(
+				( p: { plugin: string; status: string } ) =>
+					p.plugin === 'gutenberg/gutenberg'
+			);
+			await use( gutenberg?.status === 'active' );
+		},
+		{ scope: 'worker' },
+	],
 } );
 
 export { test, expect };

--- a/packages/e2e-tests/plugins/connectors-empty-state.php
+++ b/packages/e2e-tests/plugins/connectors-empty-state.php
@@ -9,11 +9,12 @@
  * @package gutenberg-test-connectors-empty-state
  */
 
-// Remove the Gutenberg filter that provides default connector data.
+// Remove the filter that provides default connector data.
 add_action(
 	'init',
 	static function () {
 		remove_filter( 'script_module_data_options-connectors-wp-admin', '_gutenberg_get_connector_script_module_data' );
+		remove_filter( 'script_module_data_options-connectors-wp-admin', '_wp_connectors_get_connector_script_module_data' );
 	},
 	PHP_INT_MAX
 );

--- a/packages/e2e-tests/plugins/connectors-js-extensibility.php
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility.php
@@ -64,8 +64,12 @@ add_action(
 // Enqueue the script module on the connectors page.
 add_action(
 	'admin_enqueue_scripts',
-	static function () {
-		if ( ! isset( $_GET['page'] ) || 'options-connectors-wp-admin' !== $_GET['page'] ) {
+	static function ( $hook_suffix ) {
+		$connectors_pages = array(
+			'settings_page_options-connectors-wp-admin', // Gutenberg.
+			'options-connectors.php',                    // Core.
+		);
+		if ( ! in_array( $hook_suffix, $connectors_pages, true ) ) {
 			return;
 		}
 

--- a/packages/e2e-tests/plugins/delete-installed-fonts.php
+++ b/packages/e2e-tests/plugins/delete-installed-fonts.php
@@ -56,7 +56,7 @@ function gutenberg_delete_installed_fonts() {
 	}
 
 	// Delete any installed fonts from global styles.
-	$global_styles_post_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
+	$global_styles_post_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
 	$request               = new WP_REST_Request( 'POST', '/wp/v2/global-styles/' . $global_styles_post_id );
 	$request->set_body_params( array( 'settings' => array( 'typography' => array( 'fontFamilies' => array() ) ) ) );
 

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -3,8 +3,8 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-const SETTINGS_PAGE_PATH = 'options-general.php';
-const CONNECTORS_PAGE_QUERY = 'page=options-connectors-wp-admin';
+let SETTINGS_PAGE_PATH;
+let CONNECTORS_PAGE_QUERY;
 
 const CONNECTORS = [
 	{
@@ -36,6 +36,16 @@ const getConnectorCardByName = ( page, name ) =>
 		.first();
 
 test.describe( 'Connectors', () => {
+	test.beforeAll( async ( { isGutenbergPluginActive } ) => {
+		if ( isGutenbergPluginActive ) {
+			SETTINGS_PAGE_PATH = 'options-general.php';
+			CONNECTORS_PAGE_QUERY = 'page=options-connectors-wp-admin';
+		} else {
+			SETTINGS_PAGE_PATH = 'options-connectors.php';
+			CONNECTORS_PAGE_QUERY = '';
+		}
+	} );
+
 	test( 'should show a Connectors link in the Settings menu', async ( {
 		page,
 		admin,
@@ -49,7 +59,9 @@ test.describe( 'Connectors', () => {
 		await expect( connectorsLink ).toBeVisible();
 		await expect( connectorsLink ).toHaveAttribute(
 			'href',
-			`${ SETTINGS_PAGE_PATH }?${ CONNECTORS_PAGE_QUERY }`
+			CONNECTORS_PAGE_QUERY
+				? `${ SETTINGS_PAGE_PATH }?${ CONNECTORS_PAGE_QUERY }`
+				: SETTINGS_PAGE_PATH
 		);
 	} );
 

--- a/test/e2e/specs/admin/guidelines.spec.js
+++ b/test/e2e/specs/admin/guidelines.spec.js
@@ -64,15 +64,15 @@ async function saveCategoryGuidelines( page, title, text ) {
 }
 
 test.describe( 'Guidelines', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
-			[ 'gutenberg-guidelines' ]
-		);
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
 		// eslint-disable-next-line playwright/no-skipped-test
 		test.skip(
-			! experimentsAvailable,
+			! isGutenbergPluginActive,
 			'gutenberg-guidelines experiment requires Gutenberg plugin'
 		);
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-guidelines',
+		] );
 		await deleteAllGuidelines( requestUtils );
 	} );
 

--- a/test/e2e/specs/admin/guidelines.spec.js
+++ b/test/e2e/specs/admin/guidelines.spec.js
@@ -65,9 +65,14 @@ async function saveCategoryGuidelines( page, title, text ) {
 
 test.describe( 'Guidelines', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.setGutenbergExperiments( [
-			'gutenberg-guidelines',
-		] );
+		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
+			[ 'gutenberg-guidelines' ]
+		);
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! experimentsAvailable,
+			'gutenberg-guidelines experiment requires Gutenberg plugin'
+		);
 		await deleteAllGuidelines( requestUtils );
 	} );
 

--- a/test/e2e/specs/admin/user-post-types.spec.js
+++ b/test/e2e/specs/admin/user-post-types.spec.js
@@ -21,9 +21,14 @@ async function createUserPostType( requestUtils ) {
 
 test.describe( 'User post types', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.setGutenbergExperiments( [
-			'gutenberg-content-types',
-		] );
+		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
+			[ 'gutenberg-content-types' ]
+		);
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! experimentsAvailable,
+			'gutenberg-content-types experiment requires Gutenberg plugin'
+		);
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {

--- a/test/e2e/specs/admin/user-post-types.spec.js
+++ b/test/e2e/specs/admin/user-post-types.spec.js
@@ -20,15 +20,15 @@ async function createUserPostType( requestUtils ) {
 }
 
 test.describe( 'User post types', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
-			[ 'gutenberg-content-types' ]
-		);
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
 		// eslint-disable-next-line playwright/no-skipped-test
 		test.skip(
-			! experimentsAvailable,
+			! isGutenbergPluginActive,
 			'gutenberg-content-types experiment requires Gutenberg plugin'
 		);
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-content-types',
+		] );
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {

--- a/test/e2e/specs/admin/user-taxonomies.spec.js
+++ b/test/e2e/specs/admin/user-taxonomies.spec.js
@@ -35,9 +35,14 @@ async function createUserTaxonomy( requestUtils ) {
 
 test.describe( 'User taxonomies', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.setGutenbergExperiments( [
-			'gutenberg-content-types',
-		] );
+		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
+			[ 'gutenberg-content-types' ]
+		);
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! experimentsAvailable,
+			'gutenberg-content-types experiment requires Gutenberg plugin'
+		);
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {

--- a/test/e2e/specs/admin/user-taxonomies.spec.js
+++ b/test/e2e/specs/admin/user-taxonomies.spec.js
@@ -34,15 +34,15 @@ async function createUserTaxonomy( requestUtils ) {
 }
 
 test.describe( 'User taxonomies', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
-			[ 'gutenberg-content-types' ]
-		);
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
 		// eslint-disable-next-line playwright/no-skipped-test
 		test.skip(
-			! experimentsAvailable,
+			! isGutenbergPluginActive,
 			'gutenberg-content-types experiment requires Gutenberg plugin'
 		);
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-content-types',
+		] );
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {

--- a/test/e2e/specs/admin/workflow-palette.spec.js
+++ b/test/e2e/specs/admin/workflow-palette.spec.js
@@ -4,15 +4,15 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Workflow palette', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
-			[ 'gutenberg-workflow-palette' ]
-		);
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
 		// eslint-disable-next-line playwright/no-skipped-test
 		test.skip(
-			! experimentsAvailable,
+			! isGutenbergPluginActive,
 			'gutenberg-workflow-palette experiment requires Gutenberg plugin'
 		);
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-workflow-palette',
+		] );
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {

--- a/test/e2e/specs/admin/workflow-palette.spec.js
+++ b/test/e2e/specs/admin/workflow-palette.spec.js
@@ -5,9 +5,14 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Workflow palette', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.setGutenbergExperiments( [
-			'gutenberg-workflow-palette',
-		] );
+		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
+			[ 'gutenberg-workflow-palette' ]
+		);
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! experimentsAvailable,
+			'gutenberg-workflow-palette experiment requires Gutenberg plugin'
+		);
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {

--- a/test/e2e/specs/editor/collaboration/fixtures/index.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/index.ts
@@ -18,9 +18,15 @@ type Fixtures = {
 
 export const test = base.extend< Fixtures >( {
 	collaborationUtils: async (
-		{ admin, editor, requestUtils, page },
+		{ admin, editor, requestUtils, page, isGutenbergPluginActive },
 		use
 	) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Collaboration tests require Gutenberg plugin to be active'
+		);
+
 		const utils = new CollaborationUtils( {
 			admin,
 			editor,

--- a/test/e2e/specs/editor/local/demo.spec.js
+++ b/test/e2e/specs/editor/local/demo.spec.js
@@ -8,7 +8,14 @@ test.describe( 'New editor state', () => {
 		page,
 		admin,
 		editor,
+		isGutenbergPluginActive,
 	} ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'This test requires Gutenberg plugin to be active'
+		);
+
 		await admin.visitAdminPage( 'post-new.php', 'gutenberg-demo' );
 		await editor.setPreferences( 'core/edit-site', {
 			welcomeGuide: false,

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -377,9 +377,15 @@ test.describe( 'Post Meta source', () => {
 
 	test.describe( 'Movie CPT post', () => {
 		test.beforeAll( async ( { requestUtils } ) => {
-			await requestUtils.setGutenbergExperiments( [
-				'gutenberg-content-only-inspector-fields',
-			] );
+			const experimentsAvailable =
+				await requestUtils.setGutenbergExperiments( [
+					'gutenberg-content-only-inspector-fields',
+				] );
+			// eslint-disable-next-line playwright/no-skipped-test
+			test.skip(
+				! experimentsAvailable,
+				'Block Fields experiment requires Gutenberg plugin'
+			);
 		} );
 
 		test.beforeEach( async ( { admin } ) => {

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -376,16 +376,15 @@ test.describe( 'Post Meta source', () => {
 	} );
 
 	test.describe( 'Movie CPT post', () => {
-		test.beforeAll( async ( { requestUtils } ) => {
-			const experimentsAvailable =
-				await requestUtils.setGutenbergExperiments( [
-					'gutenberg-content-only-inspector-fields',
-				] );
+		test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
 			// eslint-disable-next-line playwright/no-skipped-test
 			test.skip(
-				! experimentsAvailable,
+				! isGutenbergPluginActive,
 				'Block Fields experiment requires Gutenberg plugin'
 			);
+			await requestUtils.setGutenbergExperiments( [
+				'gutenberg-content-only-inspector-fields',
+			] );
 		} );
 
 		test.beforeEach( async ( { admin } ) => {

--- a/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
+++ b/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
@@ -40,7 +40,12 @@ test.use( {
 } );
 
 test.describe( 'Document-Isolation-Policy', () => {
-	test.beforeEach( async ( { admin, page } ) => {
+	test.beforeEach( async ( { admin, page, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Document-Isolation-Policy header requires Gutenberg plugin'
+		);
 		// These tests only apply to Chromium 137+.
 		test.skip(
 			( await getChromiumMajorVersion( page ) ) < 137,

--- a/test/e2e/specs/editor/various/fullscreen-mode.spec.js
+++ b/test/e2e/specs/editor/various/fullscreen-mode.spec.js
@@ -64,9 +64,14 @@ test.describe( 'Fullscreen Mode', () => {
 		admin,
 		requestUtils,
 	} ) => {
-		await requestUtils.setGutenbergExperiments( [
-			'gutenberg-admin-bar-in-editor',
-		] );
+		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
+			[ 'gutenberg-admin-bar-in-editor' ]
+		);
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! experimentsAvailable,
+			'gutenberg-admin-bar-in-editor experiment requires Gutenberg plugin'
+		);
 		await admin.createNewPost();
 		await enableFullscreenMode( page );
 
@@ -84,9 +89,14 @@ test.describe( 'Fullscreen Mode', () => {
 		requestUtils,
 		pageUtils,
 	} ) => {
-		await requestUtils.setGutenbergExperiments( [
-			'gutenberg-admin-bar-in-editor',
-		] );
+		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
+			[ 'gutenberg-admin-bar-in-editor' ]
+		);
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! experimentsAvailable,
+			'gutenberg-admin-bar-in-editor experiment requires Gutenberg plugin'
+		);
 		await admin.createNewPost();
 		await enableFullscreenMode( page );
 		await enableDistractionFreeMode( pageUtils );
@@ -103,9 +113,14 @@ test.describe( 'Fullscreen Mode', () => {
 		requestUtils,
 		pageUtils,
 	} ) => {
-		await requestUtils.setGutenbergExperiments( [
-			'gutenberg-admin-bar-in-editor',
-		] );
+		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
+			[ 'gutenberg-admin-bar-in-editor' ]
+		);
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! experimentsAvailable,
+			'gutenberg-admin-bar-in-editor experiment requires Gutenberg plugin'
+		);
 		await pageUtils.setBrowserViewport( 'small' );
 		await admin.createNewPost();
 		await enableDistractionFreeMode( pageUtils );
@@ -130,9 +145,15 @@ test.describe( 'Fullscreen Mode', () => {
 			admin,
 			requestUtils,
 		} ) => {
-			await requestUtils.setGutenbergExperiments( [
-				'gutenberg-admin-bar-in-editor',
-			] );
+			const experimentsAvailable =
+				await requestUtils.setGutenbergExperiments( [
+					'gutenberg-admin-bar-in-editor',
+				] );
+			// eslint-disable-next-line playwright/no-skipped-test
+			test.skip(
+				! experimentsAvailable,
+				'gutenberg-admin-bar-in-editor experiment requires Gutenberg plugin'
+			);
 			await admin.visitSiteEditor( { canvas: 'edit' } );
 
 			await expect( page.locator( '#wpadminbar' ) ).toBeVisible();

--- a/test/e2e/specs/editor/various/fullscreen-mode.spec.js
+++ b/test/e2e/specs/editor/various/fullscreen-mode.spec.js
@@ -63,15 +63,16 @@ test.describe( 'Fullscreen Mode', () => {
 		page,
 		admin,
 		requestUtils,
+		isGutenbergPluginActive,
 	} ) => {
-		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
-			[ 'gutenberg-admin-bar-in-editor' ]
-		);
 		// eslint-disable-next-line playwright/no-skipped-test
 		test.skip(
-			! experimentsAvailable,
+			! isGutenbergPluginActive,
 			'gutenberg-admin-bar-in-editor experiment requires Gutenberg plugin'
 		);
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-admin-bar-in-editor',
+		] );
 		await admin.createNewPost();
 		await enableFullscreenMode( page );
 
@@ -88,15 +89,16 @@ test.describe( 'Fullscreen Mode', () => {
 		admin,
 		requestUtils,
 		pageUtils,
+		isGutenbergPluginActive,
 	} ) => {
-		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
-			[ 'gutenberg-admin-bar-in-editor' ]
-		);
 		// eslint-disable-next-line playwright/no-skipped-test
 		test.skip(
-			! experimentsAvailable,
+			! isGutenbergPluginActive,
 			'gutenberg-admin-bar-in-editor experiment requires Gutenberg plugin'
 		);
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-admin-bar-in-editor',
+		] );
 		await admin.createNewPost();
 		await enableFullscreenMode( page );
 		await enableDistractionFreeMode( pageUtils );
@@ -112,15 +114,16 @@ test.describe( 'Fullscreen Mode', () => {
 		admin,
 		requestUtils,
 		pageUtils,
+		isGutenbergPluginActive,
 	} ) => {
-		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
-			[ 'gutenberg-admin-bar-in-editor' ]
-		);
 		// eslint-disable-next-line playwright/no-skipped-test
 		test.skip(
-			! experimentsAvailable,
+			! isGutenbergPluginActive,
 			'gutenberg-admin-bar-in-editor experiment requires Gutenberg plugin'
 		);
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-admin-bar-in-editor',
+		] );
 		await pageUtils.setBrowserViewport( 'small' );
 		await admin.createNewPost();
 		await enableDistractionFreeMode( pageUtils );
@@ -144,16 +147,16 @@ test.describe( 'Fullscreen Mode', () => {
 			page,
 			admin,
 			requestUtils,
+			isGutenbergPluginActive,
 		} ) => {
-			const experimentsAvailable =
-				await requestUtils.setGutenbergExperiments( [
-					'gutenberg-admin-bar-in-editor',
-				] );
 			// eslint-disable-next-line playwright/no-skipped-test
 			test.skip(
-				! experimentsAvailable,
+				! isGutenbergPluginActive,
 				'gutenberg-admin-bar-in-editor experiment requires Gutenberg plugin'
 			);
+			await requestUtils.setGutenbergExperiments( [
+				'gutenberg-admin-bar-in-editor',
+			] );
 			await admin.visitSiteEditor( { canvas: 'edit' } );
 
 			await expect( page.locator( '#wpadminbar' ) ).toBeVisible();

--- a/test/e2e/specs/editor/various/should-iframe.spec.js
+++ b/test/e2e/specs/editor/various/should-iframe.spec.js
@@ -11,6 +11,7 @@ test.describe( 'Should iframe', () => {
 	test( 'should remain iframed when a v1 block is added', async ( {
 		page,
 		editor,
+		isGutenbergPluginActive,
 	} ) => {
 		const iframe = page.locator( 'iframe[name="editor-canvas"]' );
 
@@ -33,7 +34,12 @@ test.describe( 'Should iframe', () => {
 		// Insert the v1 block.
 		await editor.insertBlock( { name: 'test/v1' } );
 
-		// The editor should remain iframed because Gutenberg is active.
-		await expect( iframe ).toBeVisible();
+		if ( isGutenbergPluginActive ) {
+			// Gutenberg keeps the editor iframed even with v1 blocks.
+			await expect( iframe ).toBeVisible();
+		} else {
+			// Core exits iframe mode when a v1 block is added.
+			await expect( iframe ).toBeHidden();
+		}
 	} );
 } );

--- a/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
@@ -20,7 +20,10 @@ test.describe( 'Global styles sidebar', () => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	test( 'should filter blocks list results', async ( { page } ) => {
+	test( 'should filter blocks list results', async ( {
+		page,
+		isGutenbergPluginActive,
+	} ) => {
 		// Navigate to Styles -> Blocks.
 		await page
 			.getByRole( 'region', { name: 'Editor top bar' } )
@@ -43,5 +46,12 @@ test.describe( 'Global styles sidebar', () => {
 		await expect(
 			page.getByRole( 'button', { name: 'Accordion Item' } )
 		).toBeVisible();
+		if ( isGutenbergPluginActive ) {
+			await expect(
+				page.getByRole( 'button', {
+					name: 'Table of Contents',
+				} )
+			).toBeVisible();
+		}
 	} );
 } );

--- a/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
+++ b/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
@@ -4,15 +4,17 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'calling saveEntityRecord with a theme template ID', () => {
-	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
-		// eslint-disable-next-line playwright/no-skipped-test
-		test.skip(
-			! isGutenbergPluginActive,
-			'Template activation experiment requires Gutenberg plugin'
-		);
+	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		// Enable the template activation feature.
-		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
+		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
+			[ 'active_templates' ]
+		);
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! experimentsAvailable,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 	} );
 
 	test.beforeEach( async ( { requestUtils } ) => {

--- a/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
+++ b/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
@@ -4,7 +4,12 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'calling saveEntityRecord with a theme template ID', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 		await requestUtils.activateTheme( 'emptytheme' );
 		// Enable the template activation feature.
 		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );

--- a/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
+++ b/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
@@ -4,17 +4,15 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'calling saveEntityRecord with a theme template ID', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'emptytheme' );
-		// Enable the template activation feature.
-		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
-			[ 'active_templates' ]
-		);
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
 		// eslint-disable-next-line playwright/no-skipped-test
 		test.skip(
-			! experimentsAvailable,
+			! isGutenbergPluginActive,
 			'Template activation experiment requires Gutenberg plugin'
 		);
+		await requestUtils.activateTheme( 'emptytheme' );
+		// Enable the template activation feature.
+		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
 	} );
 
 	test.beforeEach( async ( { requestUtils } ) => {

--- a/test/e2e/specs/site-editor/template-activate.spec.js
+++ b/test/e2e/specs/site-editor/template-activate.spec.js
@@ -4,7 +4,12 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Template Activate', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );

--- a/test/e2e/specs/site-editor/template-activate.spec.js
+++ b/test/e2e/specs/site-editor/template-activate.spec.js
@@ -4,19 +4,17 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Template Activate', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
 		// Enable the template activation feature.
-		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
-			[ 'active_templates' ]
-		);
-		// eslint-disable-next-line playwright/no-skipped-test
-		test.skip(
-			! experimentsAvailable,
-			'Template activation experiment requires Gutenberg plugin'
-		);
+		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
 	} );
 
 	test.beforeEach( async ( { admin, requestUtils } ) => {

--- a/test/e2e/specs/site-editor/template-activate.spec.js
+++ b/test/e2e/specs/site-editor/template-activate.spec.js
@@ -4,17 +4,19 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Template Activate', () => {
-	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
-		// eslint-disable-next-line playwright/no-skipped-test
-		test.skip(
-			! isGutenbergPluginActive,
-			'Template activation experiment requires Gutenberg plugin'
-		);
+	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
 		// Enable the template activation feature.
-		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
+		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
+			[ 'active_templates' ]
+		);
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! experimentsAvailable,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 	} );
 
 	test.beforeEach( async ( { admin, requestUtils } ) => {

--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -64,6 +64,16 @@ test.describe( 'Template ID Format', () => {
 	let pageId;
 
 	test.beforeAll( async ( { requestUtils } ) => {
+		// Probe whether the active_templates experiment is available;
+		// the rest of this suite assumes it can be toggled.
+		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
+			[]
+		);
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! experimentsAvailable,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 		await requestUtils.activateTheme( 'twentytwentyfive' );
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );

--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -63,15 +63,10 @@ async function saveEntities( { page } ) {
 test.describe( 'Template ID Format', () => {
 	let pageId;
 
-	test.beforeAll( async ( { requestUtils } ) => {
-		// Probe whether the active_templates experiment is available;
-		// the rest of this suite assumes it can be toggled.
-		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
-			[]
-		);
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
 		// eslint-disable-next-line playwright/no-skipped-test
 		test.skip(
-			! experimentsAvailable,
+			! isGutenbergPluginActive,
 			'Template activation experiment requires Gutenberg plugin'
 		);
 		await requestUtils.activateTheme( 'twentytwentyfive' );

--- a/test/e2e/specs/site-editor/template-registration-activation.spec.js
+++ b/test/e2e/specs/site-editor/template-registration-activation.spec.js
@@ -10,18 +10,20 @@ test.use( {
 } );
 
 test.describe( 'Block template registration', () => {
-	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
-		// eslint-disable-next-line playwright/no-skipped-test
-		test.skip(
-			! isGutenbergPluginActive,
-			'Template activation experiment requires Gutenberg plugin'
-		);
+	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.activatePlugin(
 			'gutenberg-test-block-template-registration'
 		);
 		// Enable the template activation feature.
-		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
+		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
+			[ 'active_templates' ]
+		);
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! experimentsAvailable,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {

--- a/test/e2e/specs/site-editor/template-registration-activation.spec.js
+++ b/test/e2e/specs/site-editor/template-registration-activation.spec.js
@@ -10,7 +10,12 @@ test.use( {
 } );
 
 test.describe( 'Block template registration', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.activatePlugin(
 			'gutenberg-test-block-template-registration'

--- a/test/e2e/specs/site-editor/template-registration-activation.spec.js
+++ b/test/e2e/specs/site-editor/template-registration-activation.spec.js
@@ -10,20 +10,18 @@ test.use( {
 } );
 
 test.describe( 'Block template registration', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.activatePlugin(
 			'gutenberg-test-block-template-registration'
 		);
 		// Enable the template activation feature.
-		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
-			[ 'active_templates' ]
-		);
-		// eslint-disable-next-line playwright/no-skipped-test
-		test.skip(
-			! experimentsAvailable,
-			'Template activation experiment requires Gutenberg plugin'
-		);
+		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {


### PR DESCRIPTION
## What?

Make e2e tests runnable without the Gutenberg plugin active.

Related: #77066, #78464

## Why?

It would be nice if all e2e tests can run on core without the plugin active. This requires a few tests to be skipped or adjusted when Gutenberg-specific features aren't present.

## How?

- Add `isGutenbergPluginActive` fixture to e2e test utils
- Guard or skip tests that depend on Gutenberg-only behavior:
  - Template activation experiment (template-activate, template-registration-activation, save-entity-record-template-compat)
  - Abilities-only block (global-styles-sidebar)
  - iframe v1 fallback behavior (should-iframe)
  - Connectors page URL difference (admin/connectors)
  - Demo post (editor/local/demo)
  - Block Fields experiment (post-meta block bindings)
  - Cross-origin isolation / client-side media processing
  - Collaboration suite (skipped at fixture level)
- Fix connector test plugins to work with both core and Gutenberg

## History

- Spun off from #78464 (wp/7.0) against trunk, without the `.wp-env.json` / `.wp-env.test.json` changes so the Gutenberg plugin stays active in normal CI runs