### PR TITLE
Dashboard: use `Page` `hasPadding` prop for content spacing

### DIFF
--- a/routes/dashboard/stage.module.css
+++ b/routes/dashboard/stage.module.css
@@ -1,3 +1,0 @@
-.dashboard-widgets-container {
-	margin: var(--wpds-dimension-padding-2xl);
-}

--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -14,7 +14,6 @@ import { useDashboardGridSettings, useDashboardLayout } from './hooks';
 import { WidgetDashboard } from './widget-dashboard';
 import type { DashboardWidget } from './widget-dashboard';
 import { useWidgetTypes } from './widget-types';
-import styles from './stage.module.css';
 
 function Dashboard() {
 	const [ layout, setLayout, resetLayout ] = useDashboardLayout(
@@ -50,11 +49,10 @@ function Dashboard() {
 			<Page
 				title={ __( 'Dashboard' ) }
 				actions={ <WidgetDashboard.Actions /> }
+				hasPadding
 			>
-				<div className={ styles[ 'dashboard-widgets-container' ] }>
-					<WidgetDashboard.NoWidgetsState />
-					<WidgetDashboard.Widgets />
-				</div>
+				<WidgetDashboard.NoWidgetsState />
+				<WidgetDashboard.Widgets />
 			</Page>
 		</WidgetDashboard>
 	);


### PR DESCRIPTION
## What?

Replace the dashboard stage's bespoke margin wrapper with the `Page` component's built-in `hasPadding` prop, and remove the now-unused `stage.module.css`.

## Why?

The dashboard route applied its own container margin ( `--wpds-dimension-padding-2xl` ) through a one-off stylesheet instead of relying on the standard page spacing that `Page` already provides via `hasPadding`. Using the prop keeps the dashboard consistent with other admin pages and drops a redundant CSS module.

## How?

- Pass `hasPadding` to `<Page>` in `routes/dashboard/stage.tsx`.
- Render `WidgetDashboard.NoWidgetsState` and `WidgetDashboard.Widgets` directly as page children instead of wrapping them in a `.dashboard-widgets-container` div.
- Delete `routes/dashboard/stage.module.css` and its import.

## Testing Instructions

1. Enable the dashboard widgets experiment.
2. Open the Dashboard page.
3. Confirm the content area has consistent padding matching other admin pages, with no layout regression around the widgets or the empty state.

Before

<img width="983" height="626" alt="Screenshot 2026-05-20 at 2 49 57 PM" src="https://github.com/user-attachments/assets/ae2054a0-b0a6-431c-a8f3-a59dd5b9a4a3" />

After

<img width="1728" height="823" alt="Screenshot 2026-05-20 at 2 50 33 PM" src="https://github.com/user-attachments/assets/6c250d29-90db-4e98-b941-5492a9e2f246" />

