### PR TITLE
Tooltip migration: dataviews consumers (3/5)

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -23,6 +23,10 @@
 
 - DataViews: Migrate styles from `@wordpress/base-styles` SCSS variables to `@wordpress/theme` CSS custom properties (design tokens) where possible. [#75204](https://github.com/WordPress/gutenberg/pull/75204)
 
+### Internal
+
+- DataViews: Migrate `Tooltip` consumers from `@wordpress/components` to the new compositional `Tooltip` in `@wordpress/ui`. [#78470](https://github.com/WordPress/gutenberg/pull/78470)
+
 ## 14.3.0 (2026-05-14)
 
 ## 14.2.0 (2026-04-29)

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -6,14 +6,12 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	Icon as WCIcon,
-	Tooltip as WCTooltip,
-} from '@wordpress/components';
+import { Button, Icon as WCIcon } from '@wordpress/components';
 import { sprintf, _x } from '@wordpress/i18n';
 import { error as errorIcon, pencil } from '@wordpress/icons';
 import { useInstanceId } from '@wordpress/compose';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip } from '@wordpress/ui';
 import { useRef } from '@wordpress/element';
 
 /**
@@ -115,11 +113,20 @@ export default function SummaryButton< Item >( {
 				<span className={ labelClassName }>{ labelContent }</span>
 			) }
 			{ labelPosition === 'none' && showError && (
-				<WCTooltip text={ errorMessage } placement="top">
-					<span className="dataforms-layouts-panel__field-label-error-content">
-						<WCIcon icon={ errorIcon } size={ 16 } />
-					</span>
-				</WCTooltip>
+				<Tooltip.Root>
+					<Tooltip.Trigger
+						render={
+							<span
+								className="dataforms-layouts-panel__field-label-error-content"
+								role="img"
+								aria-label={ errorMessage }
+							>
+								<WCIcon icon={ errorIcon } size={ 16 } />
+							</span>
+						}
+					/>
+					<Tooltip.Popup>{ errorMessage }</Tooltip.Popup>
+				</Tooltip.Root>
 			) }
 			<span
 				id={ `${ controlId }` }

--- a/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-content.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-content.tsx
@@ -1,8 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { Icon as WCIcon, Tooltip as WCTooltip } from '@wordpress/components';
+import { Icon as WCIcon } from '@wordpress/components';
 import { error as errorIcon } from '@wordpress/icons';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip, VisuallyHidden } from '@wordpress/ui';
 
 function getLabelContent(
 	showError?: boolean,
@@ -10,12 +12,18 @@ function getLabelContent(
 	fieldLabel?: string
 ) {
 	return showError ? (
-		<WCTooltip text={ errorMessage } placement="top">
-			<span className="dataforms-layouts-panel__field-label-error-content">
-				<WCIcon icon={ errorIcon } size={ 16 } />
-				{ fieldLabel }
-			</span>
-		</WCTooltip>
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				render={
+					<span className="dataforms-layouts-panel__field-label-error-content">
+						<WCIcon icon={ errorIcon } size={ 16 } />
+						<VisuallyHidden>{ errorMessage }: </VisuallyHidden>
+						{ fieldLabel }
+					</span>
+				}
+			/>
+			<Tooltip.Popup>{ errorMessage }</Tooltip.Popup>
+		</Tooltip.Root>
 	) : (
 		fieldLabel
 	);

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -11,13 +11,13 @@ import {
 	Dropdown,
 	FlexItem,
 	SelectControl,
-	Tooltip as WCTooltip,
 	Icon as WCIcon,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useRef } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
-import { Stack } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Stack, Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -257,6 +257,10 @@ export default function Filter( {
 	const isLocked = filterInView?.isLocked;
 	const hasValues = ! isLocked && filterInView?.value !== undefined;
 	const canResetOrRemove = ! isLocked && ( ! isPrimary || hasValues );
+	// TODO: revisit once `@wordpress/ui`'s `IconButton` is ready — it should
+	// collapse the manual icon-only `<button>` + `aria-label` + Tooltip
+	// composition below into a single primitive.
+	const resetOrRemoveLabel = isPrimary ? __( 'Reset' ) : __( 'Remove' );
 	return (
 		<Dropdown
 			defaultOpen={ openedFilter === filter.field }
@@ -267,83 +271,95 @@ export default function Filter( {
 			} }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<div className="dataviews-filters__summary-chip-container">
-					<WCTooltip
-						text={ sprintf(
-							/* translators: 1: Filter name. */
-							__( 'Filter by: %1$s' ),
-							filter.name.toLowerCase()
-						) }
-						placement="top"
-					>
-						<div
-							className={ clsx(
-								'dataviews-filters__summary-chip',
-								{
-									'has-reset': canResetOrRemove,
-									'has-values': hasValues,
-									'is-not-clickable': isLocked,
-								}
+					<Tooltip.Root>
+						<Tooltip.Trigger
+							render={
+								<div
+									className={ clsx(
+										'dataviews-filters__summary-chip',
+										{
+											'has-reset': canResetOrRemove,
+											'has-values': hasValues,
+											'is-not-clickable': isLocked,
+										}
+									) }
+									role="button"
+									tabIndex={ isLocked ? -1 : 0 }
+									onClick={ () => {
+										if ( ! isLocked ) {
+											onToggle();
+										}
+									} }
+									onKeyDown={ ( event ) => {
+										if (
+											! isLocked &&
+											[ ENTER, SPACE ].includes(
+												event.key
+											)
+										) {
+											onToggle();
+											event.preventDefault();
+										}
+									} }
+									aria-disabled={ isLocked }
+									aria-pressed={ isOpen }
+									aria-expanded={ isOpen }
+									ref={ toggleRef }
+								>
+									<FilterText
+										activeElements={ activeElements }
+										filterInView={ filterInView }
+										filter={ filter }
+									/>
+								</div>
+							}
+						/>
+						<Tooltip.Popup>
+							{ sprintf(
+								/* translators: 1: Filter name. */
+								__( 'Filter by: %1$s' ),
+								filter.name.toLowerCase()
 							) }
-							role="button"
-							tabIndex={ isLocked ? -1 : 0 }
-							onClick={ () => {
-								if ( ! isLocked ) {
-									onToggle();
-								}
-							} }
-							onKeyDown={ ( event ) => {
-								if (
-									! isLocked &&
-									[ ENTER, SPACE ].includes( event.key )
-								) {
-									onToggle();
-									event.preventDefault();
-								}
-							} }
-							aria-disabled={ isLocked }
-							aria-pressed={ isOpen }
-							aria-expanded={ isOpen }
-							ref={ toggleRef }
-						>
-							<FilterText
-								activeElements={ activeElements }
-								filterInView={ filterInView }
-								filter={ filter }
-							/>
-						</div>
-					</WCTooltip>
+						</Tooltip.Popup>
+					</Tooltip.Root>
 					{ canResetOrRemove && (
-						<WCTooltip
-							text={ isPrimary ? __( 'Reset' ) : __( 'Remove' ) }
-							placement="top"
-						>
-							<button
-								className={ clsx(
-									'dataviews-filters__summary-chip-remove',
-									{ 'has-values': hasValues }
-								) }
-								onClick={ () => {
-									onChangeView( {
-										...view,
-										page: 1,
-										filters: view.filters?.filter(
-											( _filter ) =>
-												_filter.field !== filter.field
-										),
-									} );
-									// If the filter is not primary and can be removed, it will be added
-									// back to the available filters from `Add filter` component.
-									if ( ! isPrimary ) {
-										addFilterRef.current?.focus();
-									} else {
-										// If is primary, focus the toggle button.
-										toggleRef.current?.focus();
-									}
-								} }
-							>
-								<WCIcon icon={ closeSmall } />
-							</button>
-						</WCTooltip>
+						<Tooltip.Root>
+							<Tooltip.Trigger
+								render={
+									<button
+										className={ clsx(
+											'dataviews-filters__summary-chip-remove',
+											{ 'has-values': hasValues }
+										) }
+										aria-label={ resetOrRemoveLabel }
+										onClick={ () => {
+											onChangeView( {
+												...view,
+												page: 1,
+												filters: view.filters?.filter(
+													( _filter ) =>
+														_filter.field !==
+														filter.field
+												),
+											} );
+											// If the filter is not primary and can be removed, it will be added
+											// back to the available filters from `Add filter` component.
+											if ( ! isPrimary ) {
+												addFilterRef.current?.focus();
+											} else {
+												// If is primary, focus the toggle button.
+												toggleRef.current?.focus();
+											}
+										} }
+									>
+										<WCIcon icon={ closeSmall } />
+									</button>
+								}
+							/>
+							<Tooltip.Popup>
+								{ resetOrRemoveLabel }
+							</Tooltip.Popup>
+						</Tooltip.Root>
 					) }
 				</div>
 			) }

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -10,11 +10,11 @@ import type { ComponentProps, ReactElement, HTMLAttributes } from 'react';
 import {
 	Flex,
 	FlexItem,
-	Tooltip as WCTooltip,
 	Composite,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { Stack } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Stack, Tooltip } from '@wordpress/ui';
 import { __, sprintf } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { isAppleOS } from '@wordpress/keycodes';
@@ -304,11 +304,18 @@ const GridItem = forwardRef< HTMLDivElement, GridItemProps< any > >(
 										direction="row"
 									>
 										<>
-											<WCTooltip text={ field.label }>
-												<FlexItem className="dataviews-view-grid__field-name">
-													{ field.header }
-												</FlexItem>
-											</WCTooltip>
+											<Tooltip.Root>
+												<Tooltip.Trigger
+													render={
+														<FlexItem className="dataviews-view-grid__field-name">
+															{ field.header }
+														</FlexItem>
+													}
+												/>
+												<Tooltip.Popup>
+													{ field.label }
+												</Tooltip.Popup>
+											</Tooltip.Root>
 											<FlexItem
 												className="dataviews-view-grid__field-value"
 												style={ { maxHeight: 'none' } }


### PR DESCRIPTION
## What?

Follow up to #78095 and #78411 (now landed on trunk).

Migrates **4 consumer call sites** in `@wordpress/dataviews` from the legacy `Tooltip` (`@wordpress/components`) to the new compositional `Tooltip` (`@wordpress/ui`, built on base-ui). Part 3 of a 5-PR series.

<details>
<summary>Sites migrated in this PR</summary>

- `dataviews/components/dataviews-filters/filter` — filter chip (non-interactive `<div role="button">` trigger) **and** the adjacent reset/remove `<button>` trigger *(a11y fix: the reset/remove button now carries `aria-label` matching the tooltip text, restoring an accessible name lost when the legacy `aria-describedby` injection went away)*
- `dataviews/components/dataform-layouts/panel/utils/get-label-content` — validation error tooltip on the field label `<span>` *(a11y fix: error message now exposed to AT inline via a `<VisuallyHidden>` child)*
- `dataviews/components/dataform-layouts/panel/summary-button` — validation error tooltip on the icon `<span>` *(a11y fix: icon-only span now uses `role="img" aria-label={ errorMessage }`)*
- `dataviews/components/dataviews-layouts/grid/composite-grid` — field-label tooltip on `<FlexItem>`

</details>

<details>
<summary>Full 5-PR plan</summary>

1. ~~block-editor + block-directory (also lands the codemod)~~ — #78411 ✅ landed
2. ~~editor + edit-post + edit-site (+ shell-level `Tooltip.Provider`)~~ — #78466 ✅ landed
3. **dataviews ← this PR**
4. fields + media-editor + media-fields + global-styles-ui
5. boot (+ manual save-button + shell-level `Tooltip.Provider`)

</details>

## Why?

#78095 introduced the new compositional `Tooltip` API in `@wordpress/ui`. This PR series migrates all consumers outside `@wordpress/components` itself to the new API, so that future tooltip work (delays, providers, positioner, base-ui upgrades) can happen in one place.

> [!NOTE]
> Call sites *inside* `@wordpress/components` (notably `Button`'s internal Tooltip and `TooltipInternalContext`) stay on the legacy implementation — tracked as a separate follow-up.

## How?

Each `<Tooltip>` is rewritten to the compositional API by the jscodeshift codemod landed in #78411; only import placement was finished by hand. Each migrated `Tooltip` import also carries a per-site `// eslint-disable-next-line @wordpress/use-recommended-components` directive (matching the approach in #78411) — `Tooltip` from `@wordpress/ui` is not yet on the recommended allow-list and we'd rather flip the recommendation in one go after the migration series has bedded in.

<details>
<summary>Codemod</summary>

```sh
npx jscodeshift -t tools/codemods/tooltip-components-to-ui.js \
    --extensions=js,jsx,ts,tsx --parser=tsx \
    packages/dataviews
```

`placement="top"` is the default for the new `Tooltip`, so no `<Tooltip.Positioner>` is emitted for these sites — visual placement is unchanged.

</details>

<details>
<summary>Why no `<Tooltip.Provider>` in this package?</summary>

Dataviews is a library that's composed inside one of the editor shells (post editor, site editor, dashboard). The shell-level `<Tooltip.Provider>`s mounted in PR 2 (edit-post + edit-site) and PR 5 (boot) cover dataviews automatically.

</details>

## Testing Instructions

1. Open the site editor and a dataviews surface (e.g. *Pages* admin), then hover each of the migrated triggers:
   - Filter chips in the toolbar — the *"Filter by: …"* tooltip should appear above each chip.
   - The reset/remove `×` button on a filter chip with active values — tooltip *"Reset"* / *"Remove"*.
   - In the grid layout, hover any field-label cell — its `field.label` tooltip should appear.
   - In a form panel, trigger a validation error and hover the error icon — the error message tooltip should appear.
2. `npm run test:unit -- packages/dataviews` — Jest unit tests should pass.

### Testing Instructions for Keyboard

1. Tab to each migrated **interactive** trigger (filter chip, reset/remove button, field cell) and confirm the tooltip opens on focus and closes on blur / `Esc`.

## Screenshots or screencast

No visual change is intended versus the legacy `Tooltip` (same placement, same text, same hover/focus behaviour). Each migrated site has a dedicated inline review comment on this PR with a screenshot (or repro steps) for the post-migration tooltip in context.

## Use of AI Tools

This PR was authored with assistance from Cursor (Claude). All changes were reviewed by a human before being committed; the codemod and migrated files were also exercised locally (Jest, lint, Prettier) before being pushed.



