### PR TITLE
Revisions: Increase diff marker stripe contrast to 75% primary color proportion

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -48,15 +48,15 @@
 		transition: opacity 0.1s ease;
 
 		&.is-added {
-			background: #00a32a;
+			background: #008a20;
 		}
 
 		&.is-removed {
-			background: repeating-linear-gradient(45deg, #d63638, #d63638 3px, rgba(#d63638, 0.45) 3px, rgba(#d63638, 0.45) 6px);
+			background: repeating-linear-gradient(45deg, #d63638, #d63638 4px, rgba(#d63638, 0.45) 4px, rgba(#d63638, 0.45) 8px);
 		}
 
 		&.is-modified {
-			background: repeating-linear-gradient(-45deg, #dba617, #dba617 3px, rgba(#dba617, 0.45) 3px, rgba(#dba617, 0.45) 6px);
+			background: repeating-linear-gradient(-45deg, #9a7000, #9a7000 4px, rgba(#9a7000, 0.45) 4px, rgba(#9a7000, 0.45) 8px);
 		}
 
 		&:hover {

--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -52,11 +52,11 @@
 		}
 
 		&.is-removed {
-			background: repeating-linear-gradient(45deg, #d63638, #d63638 4px, rgba(#d63638, 0.45) 4px, rgba(#d63638, 0.45) 8px);
+			background: repeating-linear-gradient(45deg, #d63638, #d63638 6px, rgba(#d63638, 0.45) 6px, rgba(#d63638, 0.45) 8px);
 		}
 
 		&.is-modified {
-			background: repeating-linear-gradient(-45deg, #9a7000, #9a7000 4px, rgba(#9a7000, 0.45) 4px, rgba(#9a7000, 0.45) 8px);
+			background: repeating-linear-gradient(-45deg, #9a7000, #9a7000 6px, rgba(#9a7000, 0.45) 6px, rgba(#9a7000, 0.45) 8px);
 		}
 
 		&:hover {


### PR DESCRIPTION


## What?

Follow-up to #77904. Part of #77530.
See https://github.com/WordPress/gutenberg/pull/77904#issuecomment-4405075473

## Why?

The previous implementation divided the diagonal stripe bands equally, 4 px primary color, 4 px lighter accent, for the removed and modified diff markers in the revisions minimap. This 50/50 split caused the two stripe colors to visually blend into a perceived mid-tone, reducing the perceptual contrast of the stripe pattern itself.

This matters for accessibility:

- **WCAG 1.4.11 (Non-text Contrast, Level AA):** The three marker colors must have ≥3:1 (See https://github.com/WordPress/gutenberg/pull/77904#issuecomment-4397609549) contrast against their adjacent background. All three primary colors meet this:

  - `#d63638` (removed) 
  - `#9a7000` (modified) 
  - `#008a20` (added) 

Shifting to a 75/25 ratio (6 px primary, 2 px accent) ensures the primary color dominates the pattern visually, keeping the stripe direction legible without making the lighter accent band compete in weight.


## Testing Instructions

1. Open a post that has multiple revisions (or create one by editing and saving several times).
2. Open the post in the block editor.
3. In the **Post** tab of the Settings panel, click **Revisions** to open the revisions screen.
4. Use the revision slider to navigate between revisions.
5. Observe the narrow diff markers minimap on the right edge:
   - **Added** blocks → solid green (`#008a20`)
   - **Removed** blocks → 45° diagonal red stripes, primary color dominant (~75% width)
   - **Modified** blocks → −45° counter-diagonal golden stripes, primary color dominant (~75% width)
6. Confirm the stripe direction is clearly visible, and the pattern does not blur into a flat mid-tone.


## Screenshots or screencast

### Before



https://github.com/user-attachments/assets/b76e2bb2-ddcd-4f61-bc43-96d71fc4c21c



### After


https://github.com/user-attachments/assets/5713d6f1-ee75-4efa-a2a1-98f8a24aeb79



## Use of AI Tools

GitHub Copilot (Claude Sonnet 4.6) was used to assist with the contrast ratio verification and drafting this description. All changes were reviewed and tested manually.
