### PR TITLE
design-system-mcp: Include component status notes in details response

### DIFF
--- a/packages/design-system-mcp/src/format.ts
+++ b/packages/design-system-mcp/src/format.ts
@@ -48,6 +48,10 @@ export function formatComponentDetail( detail: ComponentDetail ): string {
 
 	lines.push( '', `**Package:** \`${ detail.packageName }\`` );
 
+	if ( detail.notes ) {
+		lines.push( '', `**Notes:** ${ detail.notes }` );
+	}
+
 	if ( detail.importStatement ) {
 		lines.push(
 			'',

--- a/packages/design-system-mcp/src/parse-components.ts
+++ b/packages/design-system-mcp/src/parse-components.ts
@@ -135,13 +135,21 @@ export function parseComponents(
 		const key = `${ packageName }:${ name }`;
 		const existing = byKey.get( key );
 		const description = component.description || '';
+		const notes = component.notes || '';
 
 		if ( ! existing ) {
-			byKey.set( key, { name, description, packageName } );
+			const entry: Component = { name, description, packageName };
+			if ( notes ) {
+				entry.notes = notes;
+			}
+			byKey.set( key, entry );
 		} else {
-			// Prefer a non-empty description from a later entry over an
-			// empty one from the first.
+			// Prefer a non-empty value from a later entry over an empty one
+			// from the first.
 			existing.description ||= description;
+			if ( ! existing.notes && notes ) {
+				existing.notes = notes;
+			}
 		}
 	}
 
@@ -180,6 +188,7 @@ export function parseComponentDetail(
 		}
 
 		const description = component.description || '';
+		const notes = component.notes || '';
 		const props = parseProps( component.reactDocgen?.props || {} );
 		const stories = component.stories || [];
 
@@ -192,8 +201,14 @@ export function parseComponentDetail(
 				props,
 				stories: [ ...stories ],
 			};
+			if ( notes ) {
+				detail.notes = notes;
+			}
 		} else if ( detail.packageName === pkg ) {
 			detail.description ||= description;
+			if ( ! detail.notes && notes ) {
+				detail.notes = notes;
+			}
 			if ( detail.props.length === 0 ) {
 				detail.props = props;
 			}

--- a/packages/design-system-mcp/src/test/data.ts
+++ b/packages/design-system-mcp/src/test/data.ts
@@ -62,6 +62,7 @@ describe( 'data', () => {
 					name: 'Button',
 					description: 'A button.',
 					packageName: '@wordpress/components',
+					notes: 'Will be superseded by `Button` in `@wordpress/ui`, but continue using for now.',
 				},
 			] );
 		} );
@@ -102,6 +103,7 @@ describe( 'data', () => {
 				packageName: '@wordpress/components',
 				importStatement:
 					"import { Button } from '@wordpress/components';",
+				notes: 'Will be superseded by `Button` in `@wordpress/ui`, but continue using for now.',
 				props: [
 					{
 						name: 'variant',

--- a/packages/design-system-mcp/src/test/fixtures/manifest.json
+++ b/packages/design-system-mcp/src/test/fixtures/manifest.json
@@ -12,6 +12,7 @@
 			"name": "Button",
 			"path": "../packages/components/src/button/stories/index.story.tsx",
 			"description": "A button.",
+			"notes": "Will be superseded by `Button` in `@wordpress/ui`, but continue using for now.",
 			"reactDocgen": {
 				"props": {
 					"variant": {

--- a/packages/design-system-mcp/src/test/format.ts
+++ b/packages/design-system-mcp/src/test/format.ts
@@ -49,6 +49,20 @@ A badge.`
 ## Button`
 		);
 	} );
+
+	it( 'should not surface notes in the list output', () => {
+		const result = formatComponents( [
+			{
+				name: 'Button',
+				description: 'A button.',
+				packageName: '@wordpress/components',
+				notes: 'Will be superseded by `Button` in `@wordpress/ui`.',
+			},
+		] );
+
+		expect( result ).not.toContain( 'superseded' );
+		expect( result ).not.toContain( 'Notes:' );
+	} );
 } );
 
 describe( 'formatComponentDetail', () => {
@@ -182,6 +196,48 @@ Button content.
 			`# Button
 
 **Package:** \`@wordpress/ui\``
+		);
+	} );
+
+	it( 'should render notes as a labeled line after the package', () => {
+		const result = formatComponentDetail( {
+			name: 'Button',
+			description: 'A button.',
+			packageName: '@wordpress/components',
+			importStatement: null,
+			notes: 'Will be superseded by `Button` in `@wordpress/ui`.',
+			props: [],
+			stories: [],
+		} );
+
+		expect( result ).toBe(
+			`# Button
+
+A button.
+
+**Package:** \`@wordpress/components\`
+
+**Notes:** Will be superseded by \`Button\` in \`@wordpress/ui\`.`
+		);
+	} );
+
+	it( 'should render notes when description is absent', () => {
+		const result = formatComponentDetail( {
+			name: 'Button',
+			description: '',
+			packageName: '@wordpress/components',
+			importStatement: null,
+			notes: 'A short note.',
+			props: [],
+			stories: [],
+		} );
+
+		expect( result ).toBe(
+			`# Button
+
+**Package:** \`@wordpress/components\`
+
+**Notes:** A short note.`
 		);
 	} );
 } );

--- a/packages/design-system-mcp/src/test/parse-components.ts
+++ b/packages/design-system-mcp/src/test/parse-components.ts
@@ -299,6 +299,58 @@ describe( 'parseComponents', () => {
 			},
 		] );
 	} );
+
+	it( 'should propagate notes from the manifest', () => {
+		const components = createComponents( {
+			button: {
+				name: 'Button',
+				description: 'A button.',
+				notes: 'Will be superseded by `Button` in `@wordpress/ui`.',
+				path: '../packages/components/src/button/stories/index.story.tsx',
+			},
+		} );
+
+		expect( parseComponents( components ) ).toEqual( [
+			{
+				name: 'Button',
+				description: 'A button.',
+				packageName: '@wordpress/components',
+				notes: 'Will be superseded by `Button` in `@wordpress/ui`.',
+			},
+		] );
+	} );
+
+	it( 'should omit notes when the manifest entry has none', () => {
+		const components = createComponents( {
+			badge: {
+				name: 'Badge',
+				path: '../packages/ui/src/badge/stories/index.story.tsx',
+			},
+		} );
+
+		const [ result ] = parseComponents( components );
+		expect( result ).not.toHaveProperty( 'notes' );
+	} );
+
+	it( 'should prefer non-empty notes when merging entries', () => {
+		const components = createComponents( {
+			'badge-index': {
+				name: 'Badge',
+				// First entry has no notes
+				path: '../packages/ui/src/badge/stories/index.story.tsx',
+			},
+			'badge-intent': {
+				name: 'Badge',
+				notes: 'Use intent="high" for the most important badges.',
+				path: '../packages/ui/src/badge/stories/choosing-intent.story.tsx',
+			},
+		} );
+
+		const [ result ] = parseComponents( components );
+		expect( result.notes ).toBe(
+			'Use intent="high" for the most important badges.'
+		);
+	} );
 } );
 
 describe( 'parseComponentDetail', () => {
@@ -522,6 +574,53 @@ describe( 'parseComponentDetail', () => {
 				name: 'AlertDialog',
 				importStatement: "import { AlertDialog } from '@wordpress/ui';",
 			} )
+		);
+	} );
+
+	it( 'should propagate notes from the manifest', () => {
+		const components = createComponents( {
+			button: {
+				name: 'Button',
+				notes: 'Will be superseded by `Button` in `@wordpress/ui`.',
+				path: '../packages/components/src/button/stories/index.story.tsx',
+			},
+		} );
+
+		const result = parseComponentDetail( components, 'Button' );
+		expect( result?.notes ).toBe(
+			'Will be superseded by `Button` in `@wordpress/ui`.'
+		);
+	} );
+
+	it( 'should omit notes when the manifest entry has none', () => {
+		const components = createComponents( {
+			button: {
+				name: 'Button',
+				path: '../packages/ui/src/button/stories/index.story.tsx',
+			},
+		} );
+
+		const result = parseComponentDetail( components, 'Button' );
+		expect( result ).not.toHaveProperty( 'notes' );
+	} );
+
+	it( 'should prefer non-empty notes when merging story files', () => {
+		const components = createComponents( {
+			'badge-index': {
+				name: 'Badge',
+				// First entry has no notes
+				path: '../packages/ui/src/badge/stories/index.story.tsx',
+			},
+			'badge-intent': {
+				name: 'Badge',
+				notes: 'Use intent="high" for the most important badges.',
+				path: '../packages/ui/src/badge/stories/choosing-intent.story.tsx',
+			},
+		} );
+
+		const result = parseComponentDetail( components, 'Badge' );
+		expect( result?.notes ).toBe(
+			'Use intent="high" for the most important badges.'
 		);
 	} );
 } );

--- a/packages/design-system-mcp/src/types.ts
+++ b/packages/design-system-mcp/src/types.ts
@@ -14,12 +14,14 @@ export interface ManifestComponent extends ComponentManifest {
 			}
 		>;
 	};
+	notes?: string;
 }
 
 export interface Component {
 	name: string;
 	description: string;
 	packageName: string;
+	notes?: string;
 }
 
 export interface ComponentProp {
@@ -35,6 +37,7 @@ export interface ComponentDetail {
 	description: string;
 	packageName: string;
 	importStatement: string | null;
+	notes?: string;
 	props: ComponentProp[];
 	stories: Array< {
 		name: string;

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -54,6 +54,7 @@ const config: StorybookConfig = {
 		import.meta.resolve( './addons/source-link/preset.ts' ),
 		'storybook-addon-tag-badges',
 		import.meta.resolve( './addons/design-system-theme/preset.ts' ),
+		import.meta.resolve( './presets/component-status-manifest.ts' ),
 	],
 	framework: '@storybook/react-vite',
 	features: {

--- a/storybook/presets/component-status-manifest.ts
+++ b/storybook/presets/component-status-manifest.ts
@@ -1,0 +1,63 @@
+/**
+ * Storybook preset that merges `notes` from the component-status registry
+ * onto each entry in the components manifest.
+ */
+import type { ComponentManifest, Manifests } from 'storybook/internal/types';
+import { COMPONENT_STATUS } from '../component-status';
+
+type ComponentManifestWithNotes = ComponentManifest & { notes?: string };
+
+const REGISTRY = COMPONENT_STATUS as Record<
+	string,
+	Record< string, { notes?: string } >
+>;
+
+/**
+ * Derive the npm package name from a manifest entry's story file path.
+ *
+ * @param storyPath - The story file path recorded on the manifest entry.
+ * @return The npm package name, or `null` for paths outside `packages/*`.
+ */
+function packageNameFromPath( storyPath: string ): string | null {
+	const match = storyPath.match( /\.\.\/packages\/([^/]+)\// );
+	return match ? `@wordpress/${ match[ 1 ] }` : null;
+}
+
+/**
+ * Reduce a namespace component name (e.g. `AlertDialog.Root`) to the
+ * top-level importable identifier used as the registry key.
+ *
+ * @param name - The component name from the manifest.
+ * @return The top-level importable identifier.
+ */
+function canonicalComponentName( name: string ): string {
+	return name.split( '.', 1 )[ 0 ];
+}
+
+// Disable reason: This is the name that Storybook expects to use for overriding
+// experimental manifests behavior.
+// eslint-disable-next-line camelcase
+export const experimental_manifests = async (
+	existing: Manifests | undefined
+): Promise< Manifests > => {
+	const components = existing?.components;
+	if ( ! components ) {
+		return existing ?? {};
+	}
+
+	const next: Record< string, ComponentManifestWithNotes > = {};
+	for ( const [ id, entry ] of Object.entries( components.components ) ) {
+		const packageName = packageNameFromPath( entry.path );
+		const componentName = canonicalComponentName( entry.name );
+		const status = packageName
+			? REGISTRY[ packageName ]?.[ componentName ]
+			: undefined;
+
+		next[ id ] = status?.notes ? { ...entry, notes: status.notes } : entry;
+	}
+
+	return {
+		...existing,
+		components: { ...components, components: next },
+	};
+};


### PR DESCRIPTION
## What?

- Includes component status notes in [the Storybook components manifest](https://wordpress.github.io/gutenberg/manifests/components.json)
- Updates [the WordPress Design System MCP Server](https://github.com/WordPress/gutenberg/tree/trunk/packages/design-system-mcp) to include component status notes in the component detail response

Builds upon: #78472

## Why?

Component status notes are important context for understanding how a component's usage might change over time. This is already surfaced through the Storybook interface. By making it available through the MCP server, AI agents will have additional context to understand and recommend components accurately, and would be expected to relay relevant details to the user.

## How?

- Hooks Storybook's internal `experimental_manifests` to merge the component status notes into the manifest entry.
- Updates existing MCP code that already uses the manifest to pull this detail and include a new "Notes:" paragraph in the component detail response if it exists.

## Testing Instructions

The tricky part here is that the MCP server uses the hosted URL by default, and because the notes will not be present until after these changes are merged, you need to configure the MCP to use a local running server copy.

To serve a local manifest:

1. Build Storybook with `npm run storybook:build`
2. Run a local server in the built Storybook, e.g. `cd storybook/build && python3 -m http.server 8000`
3. Keep this running while following the instructions below

Testing with [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector):

1. Build changes with `npm run build`
2. `npx @modelcontextprotocol/inspector node packages/design-system-mcp/bin/design-system-mcp.mjs`
3. A browser tab should open at http://localhost:6274/
4. Expand "Environment Variables" and configure `COMPONENTS_MANIFEST_URL` with a value pointing to the manifest on the local server you started above, e.g. http://localhost:8000/manifests/components.json  
5. Click "Connect"
6. Click "Get Component Details" under the "Tools" tab
7. Enter `"Button"` (with quotes) in "name" textarea field
8. Click "Run Tool"
9. In the "Tool Result" Markdown, observe the "Notes: Will be superseded..." note under the package name, same as the status note [on the live Storybook page for the Button component](https://wordpress.github.io/gutenberg/?path=/docs/components-button--docs)

Testing with a real AI agent:

1. Build changes with `npm run build`
2. If you don't already have the design system MCP configured, follow [setup instructions](https://github.com/WordPress/gutenberg/tree/trunk/packages/design-system-mcp)
3. Wherever your MCP is configured (e.g. `mcp.json`, edit the `command` to `"node"` and the `args` to `["path/to/gutenberg/packages/design-system-mcp/bin/design-system-mcp.mjs"]` (replace `path/to/gutenberg` with absolute path to your Gutenberg directory). After `args`, configure and `env` like such `"env": {"COMPONENTS_MANIFEST_URL": "http://localhost:8000/gutenberg/manifests/components.json"}` pointing to the local server
4. Proceed to start a conversation with AI and ask a question which would ideally reflect some component status (example: "Which package should I use for a button from the WordPress design system?")
5. Observe response may include some caveats about the relevant status

## Screenshots or screencast <!-- if applicable -->

MCP Inspector

<img width="1392" height="1300" alt="Screenshot 2026-05-20 at 1 26 29 PM" src="https://github.com/user-attachments/assets/e7f93028-e381-4057-b966-b1c588218d05" />

Claude Desktop

<img width="801" height="525" alt="Screenshot 2026-05-20 at 12 34 36 PM" src="https://github.com/user-attachments/assets/cba67bbc-752f-434f-8119-c3e3ba7855fb" />


## Use of AI Tools

Planned and implemented with Cursor + Claude Opus 4.7. Reviewed manually and iterated on code comments and response formatting accordingly.