### PR TITLE
Guidelines: Fix fatal when `rest_api_init` fires before init (cherry-pick #78350)

### DIFF
--- a/lib/experimental/guidelines/index.php
+++ b/lib/experimental/guidelines/index.php
@@ -21,6 +21,24 @@ require_once __DIR__ . '/class-gutenberg-content-guidelines-rest-controller.php'
  */
 add_action( 'init', array( 'Gutenberg_Guidelines_Post_Type', 'register' ) );
 
+/*
+ * Ensure the post type is registered before any other `rest_api_init` callback
+ * runs. `init` normally fires before `rest_api_init`, but anything that calls
+ * `rest_get_server()` early (e.g. from `plugins_loaded`) fires `rest_api_init`
+ * before `init` priority 10. The callbacks below — both `register_post_meta`
+ * and the controller instantiations — dereference the post type object and
+ * would fatal (or trip `_doing_it_wrong`) without this guard.
+ */
+add_action(
+	'rest_api_init',
+	static function () {
+		if ( ! post_type_exists( Gutenberg_Guidelines_Post_Type::POST_TYPE ) ) {
+			Gutenberg_Guidelines_Post_Type::register();
+		}
+	},
+	1
+);
+
 // Register post meta once the REST API loads and the block registry is available.
 add_action( 'rest_api_init', array( 'Gutenberg_Guidelines_Post_Type', 'register_post_meta' ) );
 

--- a/phpunit/experimental/guidelines/class-gutenberg-content-guidelines-revisions-controller-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-content-guidelines-revisions-controller-test.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Tests for Gutenberg_Content_Guidelines_Revisions_Controller initialization.
+ *
+ * @package gutenberg
+ */
+class Gutenberg_Content_Guidelines_Revisions_Controller_Test extends WP_UnitTestCase {
+
+	/**
+	 * Re-register the post type after each test, since some tests
+	 * unregister it to simulate ordering edge cases.
+	 */
+	public function tear_down() {
+		if ( ! post_type_exists( Gutenberg_Guidelines_Post_Type::POST_TYPE ) ) {
+			Gutenberg_Guidelines_Post_Type::register();
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * `rest_api_init` can fire before `init` priority 10 when something
+	 * (e.g. an early `rest_get_server()` call from `plugins_loaded`)
+	 * boots the REST server early. In that window the `wp_guideline`
+	 * post type is not yet registered, so both controllers instantiated
+	 * by the `rest_api_init` handler dereference a null post type object
+	 * in their parent constructors and fatal — the singleton REST
+	 * controller via WP_REST_Posts_Controller::__construct, the revisions
+	 * controller via WP_REST_Revisions_Controller::__construct.
+	 *
+	 * The handler in lib/experimental/guidelines/index.php must defend
+	 * against this ordering by ensuring the post type exists before
+	 * instantiating the controllers.
+	 */
+	public function test_rest_api_init_does_not_fatal_when_post_type_not_yet_registered() {
+		unregister_post_type( Gutenberg_Guidelines_Post_Type::POST_TYPE );
+		$this->assertFalse(
+			post_type_exists( Gutenberg_Guidelines_Post_Type::POST_TYPE ),
+			'Pre-condition: post type must be unregistered to exercise the ordering bug.'
+		);
+
+		do_action( 'rest_api_init' );
+
+		$this->assertTrue(
+			post_type_exists( Gutenberg_Guidelines_Post_Type::POST_TYPE ),
+			'The rest_api_init handler should defensively register the post type.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

[Slack-thread](https://wordpress.slack.com/archives/C02QB2JS7/p1779294310140849?thread_ts=1779294306.768159&cid=C02QB2JS7)
Cherry-picks #78350 into `release/23.2`.

Original PR: https://github.com/WordPress/gutenberg/pull/78350

Hosts can call `rest_get_server()` during `plugins_loaded`, which fires `rest_api_init` before `init` priority 10 has had a chance to register the `wp_guideline` post type. The `rest_api_init` callbacks in `lib/experimental/guidelines/index.php` dereference the post type object, so without a defensive guard they fatal (controllers) or trip `_doing_it_wrong` (`register_post_meta`).

This adds a single priority-1 `rest_api_init` guard that registers the post type if it doesn't yet exist, plus a regression test.

## Test plan

- [ ] PHPUnit passes for `phpunit/experimental/guidelines/`
- [ ] Manual: confirm no fatal when `rest_get_server()` is called during `plugins_loaded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)