### PR TITLE
REST: Guard `setAccessible()` behind PHP < 8.1 in block-editor settings controller

### DIFF
--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -553,7 +553,15 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 			$registered     = array();
 			$reflection     = new ReflectionClass( $script_modules );
 			$property       = $reflection->getProperty( 'registered' );
-			$property->setAccessible( true );
+			/*
+			 * ReflectionProperty::setAccessible is:
+			 * - needed until 8.1.0, as property `registered` is private.
+			 * - redundant as of 8.1.0, which made non-public reflection accessible by default.
+			 * - deprecated as of 8.5.0.
+			 */
+			if ( PHP_VERSION_ID < 80100 ) {
+				$property->setAccessible( true );
+			}
 			$registered = $property->getValue( $script_modules );
 			$import_map = array();
 			foreach ( $registered as $id => $module ) {


### PR DESCRIPTION
## What?
Closes #78474

Guards the remaining `ReflectionProperty::setAccessible()` call in `WP_REST_Block_Editor_Settings_Controller` behind a `PHP_VERSION_ID < 80100` check, matching the pattern already applied in #78137 to the script-modules polyfill and in `class-wp-icons-registry-gutenberg.php`.

## Why?
`ReflectionProperty::setAccessible()` is a no-op since PHP 8.1 and is formally deprecated in PHP 8.5, which triggers a deprecation notice (e.g. visible in Query Monitor) for anyone running Gutenberg on PHP 8.5+.

## How?
Reused the established pattern from the other call sites in `lib/`: keep the call only for PHP < 8.1, and add a short comment explaining why the guard is there.

## Testing Instructions
1. On a site running PHP 8.5+ with Gutenberg installed, open the block editor and check Query Monitor (or the PHP error log).
2. Without this fix, you'll see `Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1`.
3. With this fix, the deprecation notice no longer appears.

### Testing Instructions for Keyboard
N/A — no UI changes.

### AI Use?

- Yes, Claude