### PR TITLE
UI Button: Fix disabled cursor style

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Bug Fixes
 
+-   `Button`: Do not show the interactive cursor when disabled ([#78479](https://github.com/WordPress/gutenberg/pull/78479)).
 -   `Autocomplete`: Fix the TypeScript prop types for the `Root` and `Value` primitives ([#78450](https://github.com/WordPress/gutenberg/pull/78450)).
 -   Apply shared item popup typography to inline lists and empty states ([#78403](https://github.com/WordPress/gutenberg/pull/78403)).
 -   Stretch the compat overlay slot to viewport size so portaled popups stop collapsing to their min-content width — most visible on long-text tooltips, which wrapped to one word per line ([#78441](https://github.com/WordPress/gutenberg/pull/78441)).

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -59,7 +59,10 @@
 		text-decoration: none;
 		color: var(--wp-ui-button-foreground-color);
 		overflow-wrap: anywhere;
-		cursor: var(--wpds-cursor-control);
+
+		&:not([data-disabled]) {
+			cursor: var(--wpds-cursor-control);
+		}
 
 		@media not ( prefers-reduced-motion ) {
 			transition: color 0.1s ease-out;


### PR DESCRIPTION
## What?
Fixes the `@wordpress/ui` `Button` cursor style so disabled buttons do not receive the interactive control cursor.

## Why?
Disabled buttons should not visually suggest that they are interactive. The base button styles were applying `--wpds-cursor-control` regardless of the disabled state.

## How?
Only applies the control cursor when the button does not have `data-disabled`. The existing link-specific cursor styling remains unchanged.

## Testing Instructions
1. Open a Storybook example with both enabled and disabled `Button` components.
2. Hover the enabled button and confirm it still uses the expected interactive cursor.
3. Hover the disabled button and confirm it no longer uses the interactive control cursor.