### PR TITLE
Navigation: Restore block_core_navigation_submenu_render_submenu_icon() as deprecated shim

### DIFF
--- a/packages/block-library/src/navigation-link/shared/render-submenu-icon.php
+++ b/packages/block-library/src/navigation-link/shared/render-submenu-icon.php
@@ -15,16 +15,3 @@
 function block_core_shared_navigation_render_submenu_icon() {
 	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg>';
 }
-
-/**
- * Renders the submenu icon SVG for the Navigation Submenu block.
- *
- * @since 5.9.0
- * @deprecated 7.0.0 Use block_core_shared_navigation_render_submenu_icon() instead.
- *
- * @return string SVG markup for the submenu icon.
- */
-function block_core_navigation_submenu_render_submenu_icon() {
-	_deprecated_function( __FUNCTION__, '7.0.0', 'block_core_shared_navigation_render_submenu_icon()' );
-	return block_core_shared_navigation_render_submenu_icon();
-}

--- a/packages/block-library/src/navigation-link/shared/render-submenu-icon.php
+++ b/packages/block-library/src/navigation-link/shared/render-submenu-icon.php
@@ -15,3 +15,16 @@
 function block_core_shared_navigation_render_submenu_icon() {
 	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg>';
 }
+
+/**
+ * Renders the submenu icon SVG for the Navigation Submenu block.
+ *
+ * @since 5.9.0
+ * @deprecated 7.0.0 Use block_core_shared_navigation_render_submenu_icon() instead.
+ *
+ * @return string SVG markup for the submenu icon.
+ */
+function block_core_navigation_submenu_render_submenu_icon() {
+	_deprecated_function( __FUNCTION__, '7.0.0', 'block_core_shared_navigation_render_submenu_icon()' );
+	return block_core_shared_navigation_render_submenu_icon();
+}

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -9,6 +9,21 @@ require_once __DIR__ . '/navigation-link/shared/item-should-render.php';
 require_once __DIR__ . '/navigation-link/shared/render-submenu-icon.php';
 require_once __DIR__ . '/navigation-link/shared/build-css-font-sizes.php';
 
+if ( ! function_exists( 'block_core_navigation_submenu_render_submenu_icon' ) ) {
+	/**
+	 * Renders the submenu icon SVG for the Navigation Submenu block.
+	 *
+	 * @since 5.9.0
+	 * @deprecated 7.0.0 Use block_core_shared_navigation_render_submenu_icon() instead.
+	 *
+	 * @return string SVG markup for the submenu icon.
+	 */
+	function block_core_navigation_submenu_render_submenu_icon() {
+		_deprecated_function( __FUNCTION__, '7.0.0', 'block_core_shared_navigation_render_submenu_icon()' );
+		return block_core_shared_navigation_render_submenu_icon();
+	}
+}
+
 /**
  * Returns the submenu visibility value with backward compatibility
  * for the deprecated openSubmenusOnClick attribute.

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -9,19 +9,17 @@ require_once __DIR__ . '/navigation-link/shared/item-should-render.php';
 require_once __DIR__ . '/navigation-link/shared/render-submenu-icon.php';
 require_once __DIR__ . '/navigation-link/shared/build-css-font-sizes.php';
 
-if ( ! function_exists( 'block_core_navigation_submenu_render_submenu_icon' ) ) {
-	/**
-	 * Renders the submenu icon SVG for the Navigation Submenu block.
-	 *
-	 * @since 5.9.0
-	 * @deprecated 7.0.0 Use block_core_shared_navigation_render_submenu_icon() instead.
-	 *
-	 * @return string SVG markup for the submenu icon.
-	 */
-	function block_core_navigation_submenu_render_submenu_icon() {
-		_deprecated_function( __FUNCTION__, '7.0.0', 'block_core_shared_navigation_render_submenu_icon()' );
-		return block_core_shared_navigation_render_submenu_icon();
-	}
+/**
+ * Renders the submenu icon SVG for the Navigation Submenu block.
+ *
+ * @since 5.9.0
+ * @deprecated 7.0.0 Use block_core_shared_navigation_render_submenu_icon() instead.
+ *
+ * @return string SVG markup for the submenu icon.
+ */
+function block_core_navigation_submenu_render_submenu_icon() {
+	_deprecated_function( __FUNCTION__, '7.0.0', 'block_core_shared_navigation_render_submenu_icon()' );
+	return block_core_shared_navigation_render_submenu_icon();
 }
 
 /**

--- a/phpunit/blocks/block-core-navigation-submenu-render-submenu-icon-test.php
+++ b/phpunit/blocks/block-core-navigation-submenu-render-submenu-icon-test.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Tests for the deprecated block_core_navigation_submenu_render_submenu_icon() shim.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * @group blocks
+ */
+class Block_Core_Navigation_Submenu_Render_Submenu_Icon_Test extends WP_UnitTestCase {
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		require_once dirname( __DIR__, 2 ) . '/packages/block-library/src/navigation-link/shared/render-submenu-icon.php';
+	}
+
+	/**
+	 * @ticket 65287
+	 */
+	public function test_function_exists() {
+		$this->assertTrue(
+			function_exists( 'block_core_navigation_submenu_render_submenu_icon' ),
+			'The deprecated shim block_core_navigation_submenu_render_submenu_icon() should exist.'
+		);
+	}
+
+	/**
+	 * @ticket 65287
+	 * @expectedDeprecated block_core_navigation_submenu_render_submenu_icon
+	 */
+	public function test_returns_same_markup_as_shared_helper() {
+		$this->assertSame(
+			block_core_shared_navigation_render_submenu_icon(),
+			block_core_navigation_submenu_render_submenu_icon()
+		);
+	}
+}

--- a/phpunit/blocks/block-core-navigation-submenu-render-submenu-icon-test.php
+++ b/phpunit/blocks/block-core-navigation-submenu-render-submenu-icon-test.php
@@ -2,11 +2,6 @@
 /**
  * Tests for the deprecated block_core_navigation_submenu_render_submenu_icon() shim.
  *
- * In Gutenberg plugin builds, the function name is prefixed with `gutenberg_`
- * by the build system to avoid colliding with the WordPress Core version. These
- * tests therefore exercise the prefixed name; the unprefixed counterpart is the
- * one Core ships once the change syncs back.
- *
  * @package WordPress
  * @subpackage Blocks
  */
@@ -15,16 +10,6 @@
  * @group blocks
  */
 class Block_Core_Navigation_Submenu_Render_Submenu_Icon_Test extends WP_UnitTestCase {
-
-	/**
-	 * @ticket 65287
-	 */
-	public function test_function_exists() {
-		$this->assertTrue(
-			function_exists( 'gutenberg_block_core_navigation_submenu_render_submenu_icon' ),
-			'The deprecated shim gutenberg_block_core_navigation_submenu_render_submenu_icon() should exist.'
-		);
-	}
 
 	/**
 	 * @ticket 65287

--- a/phpunit/blocks/block-core-navigation-submenu-render-submenu-icon-test.php
+++ b/phpunit/blocks/block-core-navigation-submenu-render-submenu-icon-test.php
@@ -11,12 +11,6 @@
  */
 class Block_Core_Navigation_Submenu_Render_Submenu_Icon_Test extends WP_UnitTestCase {
 
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
-
-		require_once dirname( __DIR__, 2 ) . '/packages/block-library/src/navigation-link/shared/render-submenu-icon.php';
-	}
-
 	/**
 	 * @ticket 65287
 	 */

--- a/phpunit/blocks/block-core-navigation-submenu-render-submenu-icon-test.php
+++ b/phpunit/blocks/block-core-navigation-submenu-render-submenu-icon-test.php
@@ -2,6 +2,11 @@
 /**
  * Tests for the deprecated block_core_navigation_submenu_render_submenu_icon() shim.
  *
+ * In Gutenberg plugin builds, the function name is prefixed with `gutenberg_`
+ * by the build system to avoid colliding with the WordPress Core version. These
+ * tests therefore exercise the prefixed name; the unprefixed counterpart is the
+ * one Core ships once the change syncs back.
+ *
  * @package WordPress
  * @subpackage Blocks
  */
@@ -16,19 +21,20 @@ class Block_Core_Navigation_Submenu_Render_Submenu_Icon_Test extends WP_UnitTest
 	 */
 	public function test_function_exists() {
 		$this->assertTrue(
-			function_exists( 'block_core_navigation_submenu_render_submenu_icon' ),
-			'The deprecated shim block_core_navigation_submenu_render_submenu_icon() should exist.'
+			function_exists( 'gutenberg_block_core_navigation_submenu_render_submenu_icon' ),
+			'The deprecated shim gutenberg_block_core_navigation_submenu_render_submenu_icon() should exist.'
 		);
 	}
 
 	/**
 	 * @ticket 65287
-	 * @expectedDeprecated block_core_navigation_submenu_render_submenu_icon
 	 */
 	public function test_returns_same_markup_as_shared_helper() {
+		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_submenu_render_submenu_icon' );
+
 		$this->assertSame(
 			block_core_shared_navigation_render_submenu_icon(),
-			block_core_navigation_submenu_render_submenu_icon()
+			gutenberg_block_core_navigation_submenu_render_submenu_icon()
 		);
 	}
 }


### PR DESCRIPTION
## What

Restores `block_core_navigation_submenu_render_submenu_icon()` as a deprecation shim and removes the backwards-incompatibility introduced by #74853.

## Why

In #74853 the function was removed from `packages/block-library/src/navigation-submenu/index.php` as part of consolidating submenu icon rendering into the new shared helper `block_core_shared_navigation_render_submenu_icon()`. The removal landed without a `_deprecated_function()` notice or a backwards-compatible alias.

Once that change synced into Core (wordpress-develop #10865, scheduled for WordPress 7.0), any theme or plugin that called the function — for example from a `render_block_core/navigation-submenu` filter to customise the dropdown chevron — started triggering a fatal PHP error.

Trac ticket: https://core.trac.wordpress.org/ticket/65287

## How

- Adds the shim to `packages/block-library/src/navigation-submenu/index.php` — the same file the original was [first deleted from](https://github.com/WordPress/gutenberg/pull/74853/files#diff-a22b96046ab15d77ae0b88e24a4cf01e5dbfea45c5bb8e489db9204c134026bfL87). ~Wrapped in a `function_exists` guard so a future Core sync that brings the shim back to Core itself doesn't double-declare.~
- The shim triggers `_deprecated_function()` so callers see actionable guidance to migrate to the new shared helper, and returns the new helper's output to preserve the rendered markup.
- Adds a phpunit test asserting the deprecation notice fires and that the return value matches the new helper. The test exercises the `gutenberg_`-prefixed name (matching the build's plugin output and the existing `block-navigation-link-variations-test.php` convention).

## Notes for reviewers

The build's `gutenberg_` prefix transform (`packages/wp-build/lib/build.mjs:413-422`) applies to plugin builds but is skipped for Core (`IS_WORDPRESS_CORE` branch at L392-397). That means:

- **Core 7.0+ (after sync):** receives `block_core_navigation_submenu_render_submenu_icon()` unprefixed — fixes the fatal on standalone Core installs.
- **Gutenberg plugin builds:** the function becomes `gutenberg_block_core_navigation_submenu_render_submenu_icon()`. On WP 7.0+ + plugin, theme calls to the unprefixed name resolve to Core's shim (once synced), so the bug is fixed there too.

## Testing Instructions

1. On a site running WordPress 7.0 (or trunk after the Gutenberg → Core sync), apply this change.
2. Add a theme/plugin snippet that calls `block_core_navigation_submenu_render_submenu_icon()` (e.g. inside a `render_block_core/navigation-submenu` filter).
3. Load a page containing a Navigation block with a submenu.
4. **Expected:** the page renders without a fatal error, and a deprecation notice points to `block_core_shared_navigation_render_submenu_icon()`.
5. **Before this PR:** the page fatals with "Call to undefined function block_core_navigation_submenu_render_submenu_icon()".

Also runnable: `phpunit --filter Block_Core_Navigation_Submenu_Render_Submenu_Icon_Test`.

## Screenshots or screencast

N/A — backend-only change with no UI impact.

## Types of changes

Bug fix (backwards-compatible).

## Checklist

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
- [ ] I've included developer documentation if appropriate — N/A, function is deprecated.
- [x] I've updated all React Native files affected by the changes — N/A, PHP only.
- [x] I've tested the changes on Android and iOS — N/A, PHP only.