### PR TITLE
Compose: Simplify subscribeDelegatedListener root detection

### DIFF
--- a/packages/compose/src/utils/subscribe-delegated-listener/index.ts
+++ b/packages/compose/src/utils/subscribe-delegated-listener/index.ts
@@ -34,27 +34,18 @@ const registries = new WeakMap<
 	Map< string, WeakMap< EventTarget, Set< EventListener > > >
 >();
 
-function getRoot( target: EventTarget ): EventTarget {
-	// Detect Document / Window via duck typing (works across realms —
-	// the iframe's `Document` constructor is distinct from the parent
-	// window's, so `instanceof` is unreliable).
-	if ( ( target as Document ).nodeType === 9 /* DOCUMENT_NODE */ ) {
-		return target;
-	}
-	if ( ( target as Window ).window === target ) {
-		return target;
-	}
-	// Assume Element/Node.
-	return ( target as Node ).ownerDocument as Document;
-}
-
 export default function subscribeDelegatedListener(
 	target: EventTarget,
 	eventType: string,
 	callback: EventListener,
 	capture: boolean = false
 ): () => void {
-	const root = getRoot( target );
+	// Where the native listener is attached:
+	//   Element  → its `ownerDocument`
+	//   Document → itself (own `ownerDocument` is `null`)
+	//   Window   → itself (no `ownerDocument` property)
+	// Works across realms — no `instanceof` checks needed.
+	const root = ( target as Node ).ownerDocument ?? target;
 	// Duck-type detection (cross-realm safe).
 	const isWindow = ( root as Window ).window === root;
 

--- a/packages/compose/src/utils/subscribe-delegated-listener/index.ts
+++ b/packages/compose/src/utils/subscribe-delegated-listener/index.ts
@@ -44,10 +44,11 @@ export default function subscribeDelegatedListener(
 	//   Element  → its `ownerDocument`
 	//   Document → itself (own `ownerDocument` is `null`)
 	//   Window   → itself (no `ownerDocument` property)
-	// Works across realms — no `instanceof` checks needed.
-	const root = ( target as Node ).ownerDocument ?? target;
-	// Duck-type detection (cross-realm safe).
-	const isWindow = ( root as Window ).window === root;
+	// `undefined` (Window) → use a fan-out branch on dispatch since
+	// events bubble *to* window but never *from* it via `parentNode`.
+	const ownerDoc = ( target as Node ).ownerDocument;
+	const root = ownerDoc ?? target;
+	const isWindow = ownerDoc === undefined;
 
 	let perRoot = registries.get( root );
 	if ( ! perRoot ) {


### PR DESCRIPTION
## What?
Follow-up to #78310. Simplifies the root-detection logic in `subscribeDelegatedListener`:

1. **Replace `getRoot` with a one-line nullish coalesce** — `( target as Node ).ownerDocument ?? target` covers all three cases: Element → its document, Document → itself (its `ownerDocument` is `null`), Window → itself (no `ownerDocument` property). Avoids the cross-realm `instanceof` hazards too.
2. **Derive `isWindow` from the same `ownerDocument` access** — `Window.ownerDocument` is `undefined`, so `ownerDoc === undefined` distinguishes Window from Document without a separate `.window === target` duck-typing check.

## Why?
The previous three-branch `getRoot` (Document via `nodeType === 9`, Window via `.window === target`, Element fallback) was correct but verbose. The single `ownerDocument` property access encodes the same information across all three cases.

## How?
- ~15 lines removed from the helper, ~6 added.
- No behaviour change. All 12 unit tests still pass.

## Testing Instructions
- `npx jest --config test/unit/jest.config.js --testPathPattern='subscribe-delegated-listener'` — verifies dispatch behaviour across Element / Document / Window subscribers and cross-realm iframe.

## Use of AI Tools
Authored with Claude Code assistance; reviewed and verified by the author.