### PR TITLE
Sync: Defer applyPersistedCrdtDoc until a peer connects

### DIFF
--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -53,6 +53,8 @@ interface CollectionState {
 interface EntityState {
 	awareness?: Awareness;
 	handlers: RecordHandlers;
+	hydrated: boolean;
+	hydrate: () => void;
 	objectId: ObjectID;
 	objectType: ObjectType;
 	syncConfig: SyncConfig;
@@ -256,9 +258,35 @@ export function createSyncManager( debug = false ): SyncManager {
 			restoreUndoMeta,
 		} );
 
+		// Lazy hydration: the persisted CRDT document is only deserialised and
+		// applied when there's a reason to. The two triggers are:
+		//   1. A peer is detected via awareness.
+		//   2. Something explicitly asks for it (e.g. saving the entity needs
+		//      the CRDT to exist; not handled by this trigger).
+		// While unhydrated, CRDT-side updates are skipped — edits flow through
+		// the regular entity store only.
+		async function hydrate() {
+			if ( entityState.hydrated ) {
+				return;
+			}
+			entityState.hydrated = true;
+			log( 'loadEntity', 'hydrating', entityId );
+			// The original record may be stale by now if local edits have
+			// happened. Use the current edited record so the CRDT seeds with
+			// what the user actually sees.
+			const currentRecord = await handlers.getEditedRecord();
+			internal.applyPersistedCrdtDoc(
+				objectType,
+				objectId,
+				currentRecord
+			);
+		}
+
 		const entityState: EntityState = {
 			awareness,
 			handlers,
+			hydrated: false,
+			hydrate,
 			objectId,
 			objectType,
 			syncConfig,
@@ -289,12 +317,20 @@ export function createSyncManager( debug = false ): SyncManager {
 		// Initialize the Yjs document with the necessary CRDT state.
 		initializeYjsDoc( ydoc );
 
-		// Get and apply the persisted CRDT document, if it exists.
-		// Observers are attached after hydration so the applyUpdateV2 inside
-		// _applyPersistedCrdtDoc does not trigger _updateEntityRecord with the
-		// just-loaded state, which would dispatch a redundant editRecord whose
-		// blocks already match the editor's parsed content.
-		internal.applyPersistedCrdtDoc( objectType, objectId, record );
+		// Watch awareness for the appearance of a peer — that's when the
+		// persisted CRDT doc actually matters. For solo sessions, this
+		// listener never fires and the deserialise cost is avoided entirely.
+		if ( awareness ) {
+			const onAwarenessChange = () => {
+				const stateCount = awareness.getStates().size;
+				// `getStates()` includes our own client. Any additional entry
+				// means another peer is present.
+				if ( stateCount > 1 ) {
+					void hydrate();
+				}
+			};
+			awareness.on( 'change', onAwarenessChange );
+		}
 
 		// Attach observers.
 		recordMap.observeDeep( onRecordUpdate );
@@ -572,6 +608,16 @@ export function createSyncManager( debug = false ): SyncManager {
 
 		if ( entityState ) {
 			const { syncConfig, ydoc } = entityState;
+
+			// Skip CRDT mutation while unhydrated. Without hydration the doc
+			// is empty by design — pushing edits into it now would seed the
+			// CRDT without the persisted history, which would then be sent
+			// to any peer who later joins. When hydration is triggered
+			// (peer detection), it seeds the doc from the persisted form +
+			// the current edited record, so the missed edits are captured.
+			if ( ! entityState.hydrated ) {
+				return;
+			}
 
 			// If this is change should create a new undo level, tell the undo
 			// manager to stop capturing and create a new undo group.


### PR DESCRIPTION
## What?
Prototype: defer the persisted-CRDT hydration in `@wordpress/sync` until a peer is actually detected via awareness. Solo editing sessions never pay the deserialise + state-vector apply cost.

## Why?
`loadEntity` calls `applyPersistedCrdtDoc` synchronously today, which deserialises a base64-encoded Yjs update and applies it to the doc. For sessions with no peers (the common case), the CRDT doc just sits there unused — pure overhead. Cost scales with edit history.

## How?
- `EntityState` gains `hydrated` + `hydrate()`.
- `loadEntity` skips the eager `applyPersistedCrdtDoc` call; the Yjs doc is created empty.
- An `awareness.on('change')` listener watches `getStates().size` — when it exceeds 1, a peer is present and `hydrate()` runs, calling `applyPersistedCrdtDoc` with the **edited** record. Local edits made before the peer joined appear as drift between (persisted CRDT) and (edited record); the existing drift handler pushes them into the freshly hydrated CRDT, so the peer that just joined sees them via normal sync.
- `updateCRDTDoc` short-circuits while unhydrated. Local edits flow through the regular entity store; the CRDT only starts receiving mutations after hydration.

For solo sessions, neither the deserialise nor the apply ever runs. The save path also stays untouched — `persistCRDTDoc` is only called from inside the CRDT-mutating code paths, which are gated.

## Caveats / open questions
- Awareness detection must fire before the user's first collaborative action — the polling provider needs to keep observing awareness even without a hydrated CRDT. Believe it does, but worth verifying.
- Two clients opening the same post simultaneously: each detects the other and hydrates. Both apply (persisted CRDT) + (own edited record). The persisted doc is a common ancestor, so the Yjs op-log should converge, but worth testing.
- Save path while unhydrated: CRDT meta on the server stays unchanged. Anyone who later opens the post reads the *old* CRDT history. Correct: our session never had to coordinate with peers, so the historical CRDT remains authoritative until someone collaborates.

## Testing Instructions
1. Open a post. Inspect the loaded YDoc state vector — should be empty (no persisted history applied).
2. Edit freely. Save. The CRDT meta field on the server should be unchanged.
3. Open the same post in a second tab. Both tabs should hydrate within one awareness tick, sync edits between themselves, and start persisting CRDT updates on save.

## Use of AI Tools
Authored with Claude Code assistance; reviewed and verified by the author.