### PR TITLE
Dashboard: forbid non-module stylesheets in experimental, new widgets

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -65,8 +65,9 @@ module.exports = {
 		{
 			files: [
 				'**/*.module.{css,scss}',
-				// Can be removed when all `routes/` stylesheets are converted to CSS modules.
+				// Can be removed when all `routes/` and `widgets/` stylesheets are converted to CSS modules.
 				'routes/**/*.{css,scss}',
+				'widgets/**/*.{css,scss}',
 			],
 			rules: {
 				'function-no-unknown': [
@@ -131,7 +132,11 @@ module.exports = {
 		},
 		{
 			// SCSS-only: use the Sass-aware `function-no-unknown` variant.
-			files: [ '**/*.module.scss', 'routes/**/*.scss' ],
+			files: [
+				'**/*.module.scss',
+				'routes/**/*.scss',
+				'widgets/**/*.scss',
+			],
 			rules: {
 				'function-no-unknown': null,
 				'scss/function-no-unknown': [

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -65,9 +65,8 @@ module.exports = {
 		{
 			files: [
 				'**/*.module.{css,scss}',
-				// Can be removed when all `routes/` and `widgets/` stylesheets are converted to CSS modules.
+				// Can be removed when all `routes/` stylesheets are converted to CSS modules.
 				'routes/**/*.{css,scss}',
-				'widgets/**/*.{css,scss}',
 			],
 			rules: {
 				'function-no-unknown': [
@@ -132,11 +131,7 @@ module.exports = {
 		},
 		{
 			// SCSS-only: use the Sass-aware `function-no-unknown` variant.
-			files: [
-				'**/*.module.scss',
-				'routes/**/*.scss',
-				'widgets/**/*.scss',
-			],
+			files: [ '**/*.module.scss', 'routes/**/*.scss' ],
 			rules: {
 				'function-no-unknown': null,
 				'scss/function-no-unknown': [

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -372,7 +372,11 @@ export default dedupePlugins( [
 	// Override: Package source files — non-module stylesheets should be
 	// bundled through package stylesheet entry points, not runtime injected.
 	{
-		files: [ 'packages/*/src/**/*.[tj]s?(x)', 'routes/**/*.[tj]s?(x)' ],
+		files: [
+			'packages/*/src/**/*.[tj]s?(x)',
+			'routes/**/*.[tj]s?(x)',
+			'widgets/**/*.[tj]s?(x)',
+		],
 		ignores: [
 			...developmentFiles,
 			'**/*.@(android|ios|native).[tj]s?(x)',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/77616

Adds `widgets/*` to Eslint setup for `@wordpress/no-non-module-stylesheet-imports` rule:

Not allowed:
`import './style.scss'`
`import styles from './style.css'` (non module)

Allowed:
`import styles from './foo.module.css'`

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Restricts to the latest approach to CSS in the Gutenberg repo, now that the folder is still fresh.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
You can try non-allowed imports in `widgets/hello-world` and se it fail `npm run lint:js`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
