### PR TITLE
 Fix: Register user-defined taxonomies after user-defined post types

### DIFF
--- a/lib/experimental/content-types/index.php
+++ b/lib/experimental/content-types/index.php
@@ -462,4 +462,6 @@ function gutenberg_register_user_defined_taxonomies() {
 		register_taxonomy( $slug, $object_type, $args );
 	}
 }
-add_action( 'init', 'gutenberg_register_user_defined_taxonomies', 20 );
+// Priority 21 — after gutenberg_register_user_defined_post_types() (priority 20)
+// so user CPT slugs exist when register_taxonomy() records the object_type association.
+add_action( 'init', 'gutenberg_register_user_defined_taxonomies', 21 );

--- a/lib/experimental/content-types/index.php
+++ b/lib/experimental/content-types/index.php
@@ -462,6 +462,6 @@ function gutenberg_register_user_defined_taxonomies() {
 		register_taxonomy( $slug, $object_type, $args );
 	}
 }
-// Priority 21 — after gutenberg_register_user_defined_post_types() (priority 20)
+// Priority 25 — after gutenberg_register_user_defined_post_types() (priority 20)
 // so user CPT slugs exist when register_taxonomy() records the object_type association.
-add_action( 'init', 'gutenberg_register_user_defined_taxonomies', 21 );
+add_action( 'init', 'gutenberg_register_user_defined_taxonomies', 25 );

--- a/lib/experimental/content-types/post-types.php
+++ b/lib/experimental/content-types/post-types.php
@@ -304,4 +304,6 @@ function gutenberg_register_user_defined_post_types() {
 		register_post_type( $slug, $args );
 	}
 }
+// Priority 20 — must run before gutenberg_register_user_defined_taxonomies() (priority 25)
+// so user CPT slugs exist when register_taxonomy() records the object_type association.
 add_action( 'init', 'gutenberg_register_user_defined_post_types', 20 );


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/77600

Fixes user-defined taxonomies not appearing in the block editor's inspector panel (Document Settings) when attached to a user-defined post type.

## Why?

Both functions were hooked to init at priority 20, so taxonomies registered before post types (due to file load order), causing WordPress to silently drop the [object_type]

## How?

Bumped `gutenberg_register_user_defined_taxonomies` to init priority 21 so CPT slugs exist when register_taxonomy() records the [object_type]

## Testing Instructions

1. Enable the Content Types experiment.
2. Create a new post type (e.g. `book`), set it to Active.
3. Create a new taxonomy (e.g. `genre`), attach it to the `book` post type, set it to Active.
4. Open a `book` post in the block editor.
5. Check the inspector panel (Document Settings) on the right — the `genre` taxonomy should now appear.

## Screencast

### Before
<img width="1470" height="808" alt="image" src="https://github.com/user-attachments/assets/bddb0cd3-1bfa-41bc-83ba-d5ca286b8244" />

### After


https://github.com/user-attachments/assets/061ca827-d1c3-4ff3-94a0-459bf83a5bbe


