### PR TITLE
Font Library: clarify active variant state in Library tab

### DIFF
--- a/packages/global-styles-ui/src/font-library/installed-fonts.tsx
+++ b/packages/global-styles-ui/src/font-library/installed-fonts.tsx
@@ -167,7 +167,7 @@ function InstalledFonts() {
 		).length;
 		return sprintf(
 			/* translators: 1: Active font variants, 2: Total font variants. */
-			__( '%1$d/%2$d variants active' ),
+			__( '%1$d of %2$d active' ),
 			variantsActive,
 			variantsInstalled
 		);

--- a/packages/global-styles-ui/src/font-library/style.scss
+++ b/packages/global-styles-ui/src/font-library/style.scss
@@ -136,7 +136,7 @@ $footer-height: 90px;
 	}
 
 	.font-library__font-card__count {
-		color: colors.$gray-700;
+		color: colors.$gray-900;
 	}
 
 	.font-library__font-variant_demo-image {

--- a/packages/global-styles-ui/src/font-library/style.scss
+++ b/packages/global-styles-ui/src/font-library/style.scss
@@ -136,7 +136,7 @@ $footer-height: 90px;
 	}
 
 	.font-library__font-card__count {
-		color: colors.$gray-900;
+		color: colors.$gray-700;
 	}
 
 	.font-library__font-variant_demo-image {


### PR DESCRIPTION
## What?
Closes #58276

Updates the Font Library modal (Library tab) to make active vs inactive font state clearer by:
    - Rewording variant status text from “x/y variants active” to “x of y active”
    - Increasing status text contrast to full dark color for better readability

## Why?
The previous “x/y variants active” wording is easy to skim past and does not clearly communicate active state at a glance. The issue discussion proposed clearer phrasing and stronger visual emphasis. This PR improves scannability and helps users quickly distinguish active/inactive font variants in the installed fonts list.

## Testing Instructions

1. Ensure you have at least one installed font family in Font Library with one or more variants.
2. Open Site Editor.
3. Go to Styles.
4. Open Typography, then open Font Library.
5. In the Library tab, review the font cards under Theme and/or Custom sections.
6. Confirm each card now shows status in the format: `“x of y active”`
7. Confirm the status text appears in darker full text color and is easier to read.
8. Verify there are no layout regressions in the card row (name, count, chevron alignment).

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="1457" height="743" alt="Screenshot 2026-05-21 at 5 42 11 PM" src="https://github.com/user-attachments/assets/54ca3b94-ad60-4762-b211-bbd19ccf3032" />|<img width="1456" height="745" alt="Screenshot 2026-05-21 at 5 41 43 PM" src="https://github.com/user-attachments/assets/c79cbe63-d2b7-4fd1-a88e-d75f7e22b58e" />|

## Use of AI Tools
Claude AI was used for drafting and refining copy/style updates and PR text.