### PR TITLE
Fix flaky e2e test with dataview kbd navigation

### DIFF
--- a/test/e2e/config/global-setup.ts
+++ b/test/e2e/config/global-setup.ts
@@ -39,6 +39,7 @@ async function globalSetup( config: FullConfig ) {
 			'gutenberg-test-plugin-disables-the-css-animations'
 		),
 		requestUtils.deleteAllPosts(),
+		requestUtils.deleteAllPages(),
 		requestUtils.deleteAllBlocks(),
 		requestUtils.resetPreferences(),
 		setupRtcWebSocketProvider( requestUtils ),

--- a/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
+++ b/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
@@ -8,11 +8,11 @@ test.describe( 'Dataviews List Layout', () => {
 		// Activate a theme with permissions to access the site editor.
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.createPage( {
-			title: 'Privacy Policy',
+			title: 'Page One',
 			status: 'publish',
 		} );
 		await requestUtils.createPage( {
-			title: 'Sample Page',
+			title: 'Page Two',
 			status: 'publish',
 		} );
 	} );
@@ -112,10 +112,10 @@ test.describe( 'Dataviews List Layout', () => {
 
 		// Use arrow up/down to move through the list.
 		await page.keyboard.press( 'ArrowDown' );
-		await expect( page.getByLabel( 'Sample Page' ) ).toBeFocused();
+		await expect( page.getByLabel( 'Page Two' ) ).toBeFocused();
 
 		await page.keyboard.press( 'ArrowUp' );
-		await expect( page.getByLabel( 'Privacy Policy' ) ).toBeFocused();
+		await expect( page.getByLabel( 'Page One' ) ).toBeFocused();
 	} );
 
 	test( 'Actions are reachable via RIGHT/LEFT arrow keys', async ( {
@@ -134,26 +134,26 @@ test.describe( 'Dataviews List Layout', () => {
 		await page.keyboard.press( 'ArrowRight' );
 		await expect(
 			page
-				.getByRole( 'row', { name: 'Privacy Policy Edit Actions' } )
+				.getByRole( 'row', { name: 'Page One Edit Actions' } )
 				.getByRole( 'button', { name: 'Edit' } )
 		).toBeFocused();
 
 		await page.keyboard.press( 'ArrowRight' );
 		await expect(
 			page
-				.getByRole( 'row', { name: 'Privacy Policy Edit Actions' } )
+				.getByRole( 'row', { name: 'Page One Edit Actions' } )
 				.getByLabel( 'Actions' )
 		).toBeFocused();
 
 		await page.keyboard.press( 'ArrowLeft' );
 		await expect(
 			page
-				.getByRole( 'row', { name: 'Privacy Policy Edit Actions' } )
+				.getByRole( 'row', { name: 'Page One Edit Actions' } )
 				.getByRole( 'button', { name: 'Edit' } )
 		).toBeFocused();
 
 		await page.keyboard.press( 'ArrowLeft' );
-		await expect( page.getByLabel( 'Privacy Policy' ) ).toBeFocused();
+		await expect( page.getByLabel( 'Page One' ) ).toBeFocused();
 	} );
 
 	test( 'Search input retains focus while typing', async ( { page } ) => {
@@ -169,9 +169,7 @@ test.describe( 'Dataviews List Layout', () => {
 			'[role="row"]:has([data-active-item])'
 		);
 		const activeRowText = await activeRow.textContent();
-		const searchTerm = activeRowText.includes( 'Privacy' )
-			? 'Sample'
-			: 'Privacy';
+		const searchTerm = activeRowText.includes( 'One' ) ? 'Two' : 'One';
 
 		// Type a query that filters out the auto-activated item.
 		await searchBox.click();
@@ -201,14 +199,14 @@ test.describe( 'Dataviews List Layout', () => {
 		await page.keyboard.press( 'ArrowDown' );
 		await expect(
 			page
-				.getByRole( 'row', { name: 'Sample Page Edit Actions' } )
+				.getByRole( 'row', { name: 'Page Two Edit Actions' } )
 				.getByRole( 'button', { name: 'Edit' } )
 		).toBeFocused();
 
 		await page.keyboard.press( 'ArrowUp' );
 		await expect(
 			page
-				.getByRole( 'row', { name: 'Privacy Policy Edit Actions' } )
+				.getByRole( 'row', { name: 'Page One Edit Actions' } )
 				.getByRole( 'button', { name: 'Edit' } )
 		).toBeFocused();
 
@@ -217,14 +215,14 @@ test.describe( 'Dataviews List Layout', () => {
 		await page.keyboard.press( 'ArrowDown' );
 		await expect(
 			page
-				.getByRole( 'row', { name: 'Sample Page Edit Actions' } )
+				.getByRole( 'row', { name: 'Page Two Edit Actions' } )
 				.getByLabel( 'Actions' )
 		).toBeFocused();
 
 		await page.keyboard.press( 'ArrowUp' );
 		await expect(
 			page
-				.getByRole( 'row', { name: 'Privacy Policy Edit Actions' } )
+				.getByRole( 'row', { name: 'Page One Edit Actions' } )
 				.getByLabel( 'Actions' )
 		).toBeFocused();
 	} );


### PR DESCRIPTION
Fixes #64334, a flaky e2e test with up/down keyboard navigation in a dataview. The fix is in spirit very similar to #78063. The problem is that:
1) We don't `deleteAllPages` in `global-setup.js`, leaving the default "Privacy Policy" and "Sample Page" pages created by WordPress install. The starting point of the test is then not always the same. Sometimes there are zero pages, sometimes there are the default two pages. Adding `deleteAllPages` ensures that there are always zero pages at start.
2) The test suite itself creates the "Privacy Policy" and "Sample Page" pages, and that sometimes leads to two pages of the same name:

<img width="1280" height="720" alt="double-pages-sshot" src="https://github.com/user-attachments/assets/9c5b56f4-f127-4d50-a6c2-c153fd3deba7" />

The locator for "Sample Page" then fails because of an ambiguous result.

This PR adds `deleteAllPages` to global setup, and changes the name of the two pages created by the test suite, so that there is never any name confusion. The #78063 fix for homepage settings did a similar change from "Sample page" to "Posts page".
