### PR TITLE
Social Links: Support icon color via theme.json

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -976,7 +976,7 @@ Display icons linking to your social profiles or sites. ([Source](https://github
 -	**Name:** core/social-links
 -	**Category:** widgets
 -	**Allowed Blocks:** core/social-link
--	**Supports:** align (center, left, right), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), listView, spacing (blockGap, margin, padding, units), ~~html~~
+-	**Supports:** align (center, left, right), anchor, color (background, gradients, text, ~~enableContrastChecker~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), listView, spacing (blockGap, margin, padding, units), ~~html~~
 -	**Attributes:** customIconBackgroundColor, customIconColor, iconBackgroundColor, iconBackgroundColorValue, iconColor, iconColorValue, openInNewTab, showLabels, size
 
 ## Spacer

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -64,9 +64,10 @@
 			"enableContrastChecker": false,
 			"background": true,
 			"gradients": true,
-			"text": false,
+			"text": true,
 			"__experimentalDefaultControls": {
-				"background": false
+				"background": false,
+				"text": false
 			}
 		},
 		"spacing": {
@@ -103,6 +104,12 @@
 		{ "name": "logos-only", "label": "Logos Only" },
 		{ "name": "pill-shape", "label": "Pill Shape" }
 	],
+	"selectors": {
+		"root": ".wp-block-social-links",
+		"color": {
+			"text": ".wp-block-social-links .wp-social-link"
+		}
+	},
 	"editorStyle": "wp-block-social-links-editor",
 	"style": "wp-block-social-links"
 }

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -688,6 +688,38 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSameCSS( $image_styles, $theme_json->get_styles_for_block( $image_node ) );
 	}
 
+	public function test_get_styles_for_block_color_text_subfeature_selector() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/social-links' => array(
+							'color' => array(
+								'text' => '#ff0000',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$social_links_node = array(
+			'name'      => 'core/social-links',
+			'path'      => array( 'styles', 'blocks', 'core/social-links' ),
+			'selector'  => '.wp-block-social-links',
+			'selectors' => array(
+				'root'  => '.wp-block-social-links',
+				'color' => array(
+					'text' => '.wp-block-social-links .wp-social-link',
+				),
+			),
+		);
+
+		$expected = ':root :where(.wp-block-social-links .wp-social-link){color: #ff0000;}';
+		$this->assertSameCSS( $expected, $theme_json->get_styles_for_block( $social_links_node ) );
+	}
+
 	public function test_get_stylesheet_skips_disabled_protected_properties() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(


### PR DESCRIPTION
## What does this PR do?

Implements [#39989](https://github.com/WordPress/gutenberg/issues/39989) allow theme authors to set default icon colors for the Social Links block using `theme.json`.

Previously, setting `styles.blocks.core/social-links.color.text` in theme.json had no effect on icon colors because the generated CSS targeted the block wrapper element, and brand-specific color rules applied directly to each icon element would always win (inherited values lose to directly applied values).

## How does it work?

This PR uses the block.json `selectors` API to redirect the generated `color.text` CSS to target `.wp-block-social-links .wp-social-link` (the individual icon `<li>` elements) rather than the block wrapper.

**CSS specificity comparison:**
- Theme.json generated: `:root :where(.wp-block-social-links .wp-social-link) { color: X; }` → specificity **0-1-0** (`:root` is a pseudo-class, `:where()` contributes 0)
- Brand colors: `:where(.wp-block-social-links:not(.is-style-logos-only)) .wp-social-link-amazon { color: #fff; }` → specificity **0-1-0** (`:where()` contributes 0, class selector is 0-1-0)

Because global styles are loaded after block styles in the stylesheet, the theme.json color wins at equal specificity. If a user additionally sets an icon color via the editor sidebar, the inline `style` attribute has highest priority and overrides everything.

## Changes

- **`packages/block-library/src/social-links/block.json`**:
  - Enable `color.text` support
  - Add `text: false` to `__experimentalDefaultControls` so the standard "Text color" picker is hidden by default (the block already provides a dedicated "Icon color" control, so exposing a second text color picker would be confusing)
  - Add a `selectors` section to redirect `color.text` CSS to the individual icon elements

- **`phpunit/class-wp-theme-json-test.php`**: New test `test_get_styles_for_block_color_text_subfeature_selector` verifies that `styles.blocks.core/social-links.color.text` generates CSS with the custom selector

- **`docs/reference-guides/core-blocks.md`**: Regenerated to reflect updated color support

## How to test

Add to your theme's `theme.json`:

```json
{
  "styles": {
    "blocks": {
      "core/social-links": {
        "color": {
          "text": "var:preset|color|primary"
        }
      }
    }
  }
}
```

The Social Links block icons should use the specified color as their default, overriding per-brand colors. A user-set icon color from the editor sidebar still takes precedence.

Closes #39989