### PR TITLE
Edit post: consume preload cache before React mount

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59017,6 +59017,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/i18n": "file:../i18n",
+				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/url": "file:../url"
 			},
 			"engines": {

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -46,6 +46,7 @@
 	"types": "build-types",
 	"dependencies": {
 		"@wordpress/i18n": "file:../i18n",
+		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/url": "file:../url"
 	},
 	"publishConfig": {

--- a/packages/api-fetch/src/index.ts
+++ b/packages/api-fetch/src/index.ts
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { lock } from './lock-unlock';
 import createNonceMiddleware from './middlewares/nonce';
 import createRootURLMiddleware from './middlewares/root-url';
 import createPreloadingMiddleware from './middlewares/preloading';
@@ -59,6 +60,21 @@ const middlewares: Array< APIFetchMiddleware > = [
  */
 function registerMiddleware( middleware: APIFetchMiddleware ) {
 	middlewares.unshift( middleware );
+}
+
+/**
+ * Switches every installed `createPreloadingMiddleware` into multi-use
+ * mode: cached entries are reused for subsequent reads until
+ * {@link clearPreloadedData} runs. Used by the editor bootstrap so a
+ * shared URL can back multiple selectors during the kickoff window.
+ */
+function enablePreloadMultiUse() {
+	for ( const middleware of middlewares ) {
+		const enable = ( middleware as any ).__unstableEnableMultiUse;
+		if ( typeof enable === 'function' ) {
+			enable();
+		}
+	}
 }
 
 /**
@@ -166,7 +182,7 @@ export interface ApiFetch {
 	fetchAllMiddleware: typeof fetchAllMiddleware;
 	mediaUploadMiddleware: typeof mediaUploadMiddleware;
 	createThemePreviewMiddleware: typeof createThemePreviewMiddleware;
-	__unstableClearPreloadedData: () => void;
+	privateApis: object;
 }
 
 /**
@@ -214,7 +230,17 @@ const apiFetch: ApiFetch = ( options ) => {
 
 apiFetch.use = registerMiddleware;
 apiFetch.setFetchHandler = setFetchHandler;
-apiFetch.__unstableClearPreloadedData = clearPreloadedData;
+
+// Attached to the function (rather than a named export) because
+// `wpScriptDefaultExport: true` flattens this module to its default
+// export — `wp.apiFetch` is the function itself, so anything that
+// needs to be reachable from a consumer's `wp.apiFetch.X` lookup has
+// to live on the function.
+apiFetch.privateApis = {};
+lock( apiFetch.privateApis, {
+	enablePreloadMultiUse,
+	clearPreloadedData,
+} );
 
 apiFetch.createNonceMiddleware = createNonceMiddleware;
 apiFetch.createPreloadingMiddleware = createPreloadingMiddleware;

--- a/packages/api-fetch/src/index.ts
+++ b/packages/api-fetch/src/index.ts
@@ -65,26 +65,12 @@ function registerMiddleware( middleware: APIFetchMiddleware ) {
 	middlewares.unshift( middleware );
 }
 
-/**
- * Switches every installed `createPreloadingMiddleware` into multi-use
- * mode: cached entries are reused for subsequent reads until
- * {@link clearPreloadedData} runs. Used by the editor bootstrap so a
- * shared URL can back multiple selectors during the kickoff window.
- */
 function enablePreloadMultiUse() {
 	for ( const middleware of middlewares ) {
 		( middleware as any )[ PRELOADING_ENABLE_MULTI_USE ]?.();
 	}
 }
 
-/**
- * Drops any still-unconsumed entries from every installed
- * `createPreloadingMiddleware`. Used by the editor bootstrap once
- * its kickoff resolvers have settled — anything the kickoff missed
- * then falls through to a real network request (and surfaces in
- * tests / DevTools) instead of being silently served from the
- * preload bucket.
- */
 function clearPreloadedData() {
 	for ( const middleware of middlewares ) {
 		( middleware as any )[ PRELOADING_CLEAR ]?.();

--- a/packages/api-fetch/src/index.ts
+++ b/packages/api-fetch/src/index.ts
@@ -9,7 +9,10 @@ import { __ } from '@wordpress/i18n';
 import { lock } from './lock-unlock';
 import createNonceMiddleware from './middlewares/nonce';
 import createRootURLMiddleware from './middlewares/root-url';
-import createPreloadingMiddleware from './middlewares/preloading';
+import createPreloadingMiddleware, {
+	CLEAR as PRELOADING_CLEAR,
+	ENABLE_MULTI_USE as PRELOADING_ENABLE_MULTI_USE,
+} from './middlewares/preloading';
 import fetchAllMiddleware from './middlewares/fetch-all-middleware';
 import namespaceEndpointMiddleware from './middlewares/namespace-endpoint';
 import httpV1Middleware from './middlewares/http-v1';
@@ -70,10 +73,7 @@ function registerMiddleware( middleware: APIFetchMiddleware ) {
  */
 function enablePreloadMultiUse() {
 	for ( const middleware of middlewares ) {
-		const enable = ( middleware as any ).__unstableEnableMultiUse;
-		if ( typeof enable === 'function' ) {
-			enable();
-		}
+		( middleware as any )[ PRELOADING_ENABLE_MULTI_USE ]?.();
 	}
 }
 
@@ -87,10 +87,7 @@ function enablePreloadMultiUse() {
  */
 function clearPreloadedData() {
 	for ( const middleware of middlewares ) {
-		const clear = ( middleware as any ).__unstableClear;
-		if ( typeof clear === 'function' ) {
-			clear();
-		}
+		( middleware as any )[ PRELOADING_CLEAR ]?.();
 	}
 }
 

--- a/packages/api-fetch/src/index.ts
+++ b/packages/api-fetch/src/index.ts
@@ -61,6 +61,23 @@ function registerMiddleware( middleware: APIFetchMiddleware ) {
 	middlewares.unshift( middleware );
 }
 
+/**
+ * Drops any still-unconsumed entries from every installed
+ * `createPreloadingMiddleware`. Used by the editor bootstrap once
+ * its kickoff resolvers have settled — anything the kickoff missed
+ * then falls through to a real network request (and surfaces in
+ * tests / DevTools) instead of being silently served from the
+ * preload bucket.
+ */
+function clearPreloadedData() {
+	for ( const middleware of middlewares ) {
+		const clear = ( middleware as any ).__unstableClear;
+		if ( typeof clear === 'function' ) {
+			clear();
+		}
+	}
+}
+
 const defaultFetchHandler: FetchHandler = ( nextOptions ) => {
 	const { url, path, data, parse = true, ...remainingOptions } = nextOptions;
 	let { body, headers } = nextOptions;
@@ -149,6 +166,7 @@ export interface ApiFetch {
 	fetchAllMiddleware: typeof fetchAllMiddleware;
 	mediaUploadMiddleware: typeof mediaUploadMiddleware;
 	createThemePreviewMiddleware: typeof createThemePreviewMiddleware;
+	__unstableClearPreloadedData: () => void;
 }
 
 /**
@@ -196,6 +214,7 @@ const apiFetch: ApiFetch = ( options ) => {
 
 apiFetch.use = registerMiddleware;
 apiFetch.setFetchHandler = setFetchHandler;
+apiFetch.__unstableClearPreloadedData = clearPreloadedData;
 
 apiFetch.createNonceMiddleware = createNonceMiddleware;
 apiFetch.createPreloadingMiddleware = createPreloadingMiddleware;

--- a/packages/api-fetch/src/lock-unlock.ts
+++ b/packages/api-fetch/src/lock-unlock.ts
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+		'@wordpress/api-fetch'
+	);

--- a/packages/api-fetch/src/middlewares/preloading.ts
+++ b/packages/api-fetch/src/middlewares/preloading.ts
@@ -8,13 +8,6 @@ import { addQueryArgs, getQueryArgs, normalizePath } from '@wordpress/url';
  */
 import type { APIFetchMiddleware } from '../types';
 
-/**
- * Symbol keys for hooks attached to each `createPreloadingMiddleware`
- * instance. Using symbols (instead of `__unstable*` string properties)
- * keeps these out of any `for…in`, `Object.keys`, or accidental
- * `wp.apiFetch.use( something )` lookup — the only callers that can
- * reach them are the ones inside this package that import the symbols.
- */
 export const ENABLE_MULTI_USE = Symbol( 'preloadingEnableMultiUse' );
 export const CLEAR = Symbol( 'preloadingClear' );
 
@@ -25,19 +18,17 @@ export const CLEAR = Symbol( 'preloadingClear' );
 function createPreloadingMiddleware(
 	preloadedData: Record< string, any >
 ): APIFetchMiddleware {
-	const cache = Object.fromEntries(
+	const { OPTIONS = {}, ...GET } = Object.fromEntries(
 		Object.entries( preloadedData ).map( ( [ path, data ] ) => [
 			normalizePath( path ),
 			data,
 		] )
-	);
+	) as Record< string, any > & { OPTIONS?: Record< string, any > };
 
-	// Entries are single-use by default — the preloading middleware
-	// deletes each one on first read so a subsequent request gets a
-	// fresh response. Callers that know they'll consume the same paths
-	// from multiple selectors (e.g. an editor bootstrap that pre-warms
-	// resolvers before render) can flip this and then call
-	// `__unstableClear` once they're done.
+	// Preload entries that haven't been served yet.
+	const unusedGet = new Set< string >( Object.keys( GET ) );
+	const unusedOptions = new Set< string >( Object.keys( OPTIONS ) );
+
 	let multiUse = false;
 
 	const middleware: APIFetchMiddleware = ( options, next ) => {
@@ -60,43 +51,51 @@ function createPreloadingMiddleware(
 		const method = options.method || 'GET';
 		const path = normalizePath( rawPath );
 
-		if ( 'GET' === method && cache[ path ] ) {
-			const data = cache[ path ];
+		if ( 'GET' === method && GET[ path ] ) {
+			const data = GET[ path ];
 			if ( ! multiUse ) {
-				delete cache[ path ];
+				delete GET[ path ];
 			}
+			unusedGet.delete( path );
 			return prepareResponse( data, !! parse );
-		} else if (
-			'OPTIONS' === method &&
-			cache[ method ] &&
-			cache[ method ][ path ]
-		) {
-			const data = cache[ method ][ path ];
+		} else if ( 'OPTIONS' === method && OPTIONS[ path ] ) {
+			const data = OPTIONS[ path ];
 			if ( ! multiUse ) {
-				delete cache[ method ][ path ];
+				delete OPTIONS[ path ];
 			}
+			unusedOptions.delete( path );
 			return prepareResponse( data, !! parse );
 		}
 
 		return next( options );
 	};
 
-	// Switches this middleware into multi-use mode: cache entries stay
-	// around after the first read until `CLEAR` runs. Useful when
-	// multiple selectors share a URL and the consumer guarantees it
-	// will clear at the right boundary.
 	( middleware as any )[ ENABLE_MULTI_USE ] = () => {
 		multiUse = true;
 	};
 
-	// Drops any still-unconsumed preloaded entries. Used by the editor
-	// bootstrap once kickoff resolvers have settled — anything the
-	// kickoff missed should fall through to a real network request
-	// (and surface in tests / DevTools) instead of being silently served
-	// from the preload bucket.
-	( middleware as any )[ CLEAR ] = () => {
-		for ( const key of Object.keys( cache ) ) {
-			delete cache[ key ];
+	( middleware as any )[ CLEAR ] = (): void => {
+		const tags = [
+			...Array.from( unusedGet, ( p ) => `GET ${ p }` ),
+			...Array.from( unusedOptions, ( p ) => `OPTIONS ${ p }` ),
+		];
+		if ( tags.length ) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				'[api-fetch][preload] Some preloads were never consumed:',
+				tags
+			);
+		} else {
+			// eslint-disable-next-line no-console
+			console.log( '[api-fetch][preload] All preloads consumed.' );
+		}
+		unusedGet.clear();
+		unusedOptions.clear();
+		for ( const key of Object.keys( GET ) ) {
+			delete GET[ key ];
+		}
+		for ( const key of Object.keys( OPTIONS ) ) {
+			delete OPTIONS[ key ];
 		}
 	};
 

--- a/packages/api-fetch/src/middlewares/preloading.ts
+++ b/packages/api-fetch/src/middlewares/preloading.ts
@@ -43,23 +43,19 @@ function createPreloadingMiddleware(
 		const path = normalizePath( rawPath );
 
 		if ( 'GET' === method && cache[ path ] ) {
-			const cacheData = cache[ path ];
-
-			// Unsetting the cache key ensures that the data is only used a single time.
-			delete cache[ path ];
-
-			return prepareResponse( cacheData, !! parse );
+			// Preloaded entries are now multi-use within the boot window:
+			// callers serve from cache until `__unstableClear` runs (e.g.
+			// just before the editor renders). This lets shared URLs back
+			// multiple selectors that would otherwise each try to fetch
+			// (e.g. `getEntityRecord('root', 'postType', name)` and the
+			// `getPostType( name )` shorthand alias both hit /wp/v2/types/X).
+			return prepareResponse( cache[ path ], !! parse );
 		} else if (
 			'OPTIONS' === method &&
 			cache[ method ] &&
 			cache[ method ][ path ]
 		) {
-			const cacheData = cache[ method ][ path ];
-
-			// Unsetting the cache key ensures that the data is only used a single time.
-			delete cache[ method ][ path ];
-
-			return prepareResponse( cacheData, !! parse );
+			return prepareResponse( cache[ method ][ path ], !! parse );
 		}
 
 		return next( options );

--- a/packages/api-fetch/src/middlewares/preloading.ts
+++ b/packages/api-fetch/src/middlewares/preloading.ts
@@ -9,6 +9,16 @@ import { addQueryArgs, getQueryArgs, normalizePath } from '@wordpress/url';
 import type { APIFetchMiddleware } from '../types';
 
 /**
+ * Symbol keys for hooks attached to each `createPreloadingMiddleware`
+ * instance. Using symbols (instead of `__unstable*` string properties)
+ * keeps these out of any `for…in`, `Object.keys`, or accidental
+ * `wp.apiFetch.use( something )` lookup — the only callers that can
+ * reach them are the ones inside this package that import the symbols.
+ */
+export const ENABLE_MULTI_USE = Symbol( 'preloadingEnableMultiUse' );
+export const CLEAR = Symbol( 'preloadingClear' );
+
+/**
  * @param preloadedData
  * @return Preloading middleware.
  */
@@ -72,10 +82,10 @@ function createPreloadingMiddleware(
 	};
 
 	// Switches this middleware into multi-use mode: cache entries stay
-	// around after the first read until `__unstableClear` runs. Useful
-	// when multiple selectors share a URL and the consumer guarantees
-	// it will clear at the right boundary.
-	( middleware as any ).__unstableEnableMultiUse = () => {
+	// around after the first read until `CLEAR` runs. Useful when
+	// multiple selectors share a URL and the consumer guarantees it
+	// will clear at the right boundary.
+	( middleware as any )[ ENABLE_MULTI_USE ] = () => {
 		multiUse = true;
 	};
 
@@ -84,7 +94,7 @@ function createPreloadingMiddleware(
 	// kickoff missed should fall through to a real network request
 	// (and surface in tests / DevTools) instead of being silently served
 	// from the preload bucket.
-	( middleware as any ).__unstableClear = () => {
+	( middleware as any )[ CLEAR ] = () => {
 		for ( const key of Object.keys( cache ) ) {
 			delete cache[ key ];
 		}

--- a/packages/api-fetch/src/middlewares/preloading.ts
+++ b/packages/api-fetch/src/middlewares/preloading.ts
@@ -22,7 +22,7 @@ function createPreloadingMiddleware(
 		] )
 	);
 
-	return ( options, next ) => {
+	const middleware: APIFetchMiddleware = ( options, next ) => {
 		const { parse = true } = options;
 		let rawPath = options.path;
 		if ( ! rawPath && options.url ) {
@@ -64,6 +64,19 @@ function createPreloadingMiddleware(
 
 		return next( options );
 	};
+
+	// Lets callers drop any still-unconsumed preloaded entries. Used by
+	// the editor bootstrap once kickoff resolvers have settled — anything
+	// the kickoff missed should fall through to a real network request
+	// (and surface in tests / DevTools) instead of being silently served
+	// from the preload bucket.
+	( middleware as any ).__unstableClear = () => {
+		for ( const key of Object.keys( cache ) ) {
+			delete cache[ key ];
+		}
+	};
+
+	return middleware;
 }
 
 /**

--- a/packages/api-fetch/src/middlewares/preloading.ts
+++ b/packages/api-fetch/src/middlewares/preloading.ts
@@ -22,6 +22,14 @@ function createPreloadingMiddleware(
 		] )
 	);
 
+	// Entries are single-use by default — the preloading middleware
+	// deletes each one on first read so a subsequent request gets a
+	// fresh response. Callers that know they'll consume the same paths
+	// from multiple selectors (e.g. an editor bootstrap that pre-warms
+	// resolvers before render) can flip this and then call
+	// `__unstableClear` once they're done.
+	let multiUse = false;
+
 	const middleware: APIFetchMiddleware = ( options, next ) => {
 		const { parse = true } = options;
 		let rawPath = options.path;
@@ -43,27 +51,37 @@ function createPreloadingMiddleware(
 		const path = normalizePath( rawPath );
 
 		if ( 'GET' === method && cache[ path ] ) {
-			// Preloaded entries are now multi-use within the boot window:
-			// callers serve from cache until `__unstableClear` runs (e.g.
-			// just before the editor renders). This lets shared URLs back
-			// multiple selectors that would otherwise each try to fetch
-			// (e.g. `getEntityRecord('root', 'postType', name)` and the
-			// `getPostType( name )` shorthand alias both hit /wp/v2/types/X).
-			return prepareResponse( cache[ path ], !! parse );
+			const data = cache[ path ];
+			if ( ! multiUse ) {
+				delete cache[ path ];
+			}
+			return prepareResponse( data, !! parse );
 		} else if (
 			'OPTIONS' === method &&
 			cache[ method ] &&
 			cache[ method ][ path ]
 		) {
-			return prepareResponse( cache[ method ][ path ], !! parse );
+			const data = cache[ method ][ path ];
+			if ( ! multiUse ) {
+				delete cache[ method ][ path ];
+			}
+			return prepareResponse( data, !! parse );
 		}
 
 		return next( options );
 	};
 
-	// Lets callers drop any still-unconsumed preloaded entries. Used by
-	// the editor bootstrap once kickoff resolvers have settled — anything
-	// the kickoff missed should fall through to a real network request
+	// Switches this middleware into multi-use mode: cache entries stay
+	// around after the first read until `__unstableClear` runs. Useful
+	// when multiple selectors share a URL and the consumer guarantees
+	// it will clear at the right boundary.
+	( middleware as any ).__unstableEnableMultiUse = () => {
+		multiUse = true;
+	};
+
+	// Drops any still-unconsumed preloaded entries. Used by the editor
+	// bootstrap once kickoff resolvers have settled — anything the
+	// kickoff missed should fall through to a real network request
 	// (and surface in tests / DevTools) instead of being silently served
 	// from the preload bucket.
 	( middleware as any ).__unstableClear = () => {

--- a/packages/api-fetch/src/middlewares/test/preloading.ts
+++ b/packages/api-fetch/src/middlewares/test/preloading.ts
@@ -57,6 +57,46 @@ describe( 'Preloading Middleware', () => {
 					preloadingMiddleware( requestOptions, nextSpy );
 					expect( nextSpy ).toHaveBeenCalled();
 				} );
+
+				it( 'keeps returning the preloaded data when multi-use is enabled', async () => {
+					const body = {
+						status: 'this is the preloaded response',
+					};
+					const preloadedData = {
+						'wp/v2/posts': { body },
+					};
+					const preloadingMiddleware =
+						createPreloadingMiddleware( preloadedData );
+					(
+						preloadingMiddleware as unknown as {
+							__unstableEnableMultiUse: () => void;
+						}
+					 ).__unstableEnableMultiUse();
+
+					const requestOptions = {
+						method: 'GET',
+						path: 'wp/v2/posts',
+					};
+					const nextSpy = jest.fn();
+
+					await expect(
+						preloadingMiddleware( requestOptions, nextSpy )
+					).resolves.toEqual( body );
+					await expect(
+						preloadingMiddleware( requestOptions, nextSpy )
+					).resolves.toEqual( body );
+					expect( nextSpy ).not.toHaveBeenCalled();
+
+					// `__unstableClear` is the explicit boundary at
+					// which subsequent requests should fall through.
+					(
+						preloadingMiddleware as unknown as {
+							__unstableClear: () => void;
+						}
+					 ).__unstableClear();
+					preloadingMiddleware( requestOptions, nextSpy );
+					expect( nextSpy ).toHaveBeenCalled();
+				} );
 			} );
 
 			describe( 'and the OPTIONS request has a parse flag', () => {

--- a/packages/api-fetch/src/middlewares/test/preloading.ts
+++ b/packages/api-fetch/src/middlewares/test/preloading.ts
@@ -2,7 +2,10 @@
  * Internal dependencies
  */
 import type { FetchHandler } from '../../types';
-import createPreloadingMiddleware from '../preloading';
+import createPreloadingMiddleware, {
+	CLEAR,
+	ENABLE_MULTI_USE,
+} from '../preloading';
 
 describe( 'Preloading Middleware', () => {
 	describe( 'given preloaded data', () => {
@@ -67,11 +70,7 @@ describe( 'Preloading Middleware', () => {
 					};
 					const preloadingMiddleware =
 						createPreloadingMiddleware( preloadedData );
-					(
-						preloadingMiddleware as unknown as {
-							__unstableEnableMultiUse: () => void;
-						}
-					 ).__unstableEnableMultiUse();
+					( preloadingMiddleware as any )[ ENABLE_MULTI_USE ]();
 
 					const requestOptions = {
 						method: 'GET',
@@ -87,13 +86,9 @@ describe( 'Preloading Middleware', () => {
 					).resolves.toEqual( body );
 					expect( nextSpy ).not.toHaveBeenCalled();
 
-					// `__unstableClear` is the explicit boundary at
-					// which subsequent requests should fall through.
-					(
-						preloadingMiddleware as unknown as {
-							__unstableClear: () => void;
-						}
-					 ).__unstableClear();
+					// `CLEAR` is the explicit boundary at which
+					// subsequent requests should fall through.
+					( preloadingMiddleware as any )[ CLEAR ]();
 					preloadingMiddleware( requestOptions, nextSpy );
 					expect( nextSpy ).toHaveBeenCalled();
 				} );

--- a/packages/api-fetch/src/middlewares/test/preloading.ts
+++ b/packages/api-fetch/src/middlewares/test/preloading.ts
@@ -87,8 +87,10 @@ describe( 'Preloading Middleware', () => {
 					expect( nextSpy ).not.toHaveBeenCalled();
 
 					// `CLEAR` is the explicit boundary at which
-					// subsequent requests should fall through.
+					// subsequent requests should fall through. It also
+					// logs whether anything went unconsumed.
 					( preloadingMiddleware as any )[ CLEAR ]();
+					expect( console ).toHaveLogged();
 					preloadingMiddleware( requestOptions, nextSpy );
 					expect( nextSpy ).toHaveBeenCalled();
 				} );

--- a/packages/api-fetch/tsconfig.json
+++ b/packages/api-fetch/tsconfig.json
@@ -1,6 +1,10 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
-	"references": [ { "path": "../i18n" }, { "path": "../url" } ],
+	"references": [
+		{ "path": "../i18n" },
+		{ "path": "../private-apis" },
+		{ "path": "../url" }
+	],
 	"exclude": [ "**/test" ]
 }

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -19,6 +19,7 @@ import {
 	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
 import { store as coreDataStore } from '@wordpress/core-data';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -162,6 +163,11 @@ export function initializeEditor(
 	const preloadedResolutions = preloadResolutions( postType, postId );
 
 	preloadedResolutions.finally( () => {
+		// Drop any preload entries the kickoff didn't consume. After this
+		// point, any resolver firing during render falls through to a
+		// real network request — which makes the misses observable both
+		// in DevTools and in the preload e2e tests.
+		apiFetch.__unstableClearPreloadedData();
 		root.render(
 			<StrictMode>
 				<Layout
@@ -183,41 +189,104 @@ export function initializeEditor(
  * so no resolver issues a network request; we just need them to run
  * their dispatch cycles before React mounts.
  *
+ * Run in two phases:
+ *   1. Selectors whose args we know up-front from PHP (post id + type).
+ *   2. Selectors that need a value derived from phase-1 state — the
+ *      post record yields the default-template slug; the resolved
+ *      current-global-styles id keys the global-styles record + canUser.
+ *
  * @param {string} postType Current post type.
  * @param {number} postId   Current post id.
  * @return {Promise<void>}  Resolves when the kickoff resolvers settle.
  */
-function preloadResolutions( postType, postId ) {
+async function preloadResolutions( postType, postId ) {
 	const core = resolveSelect( coreDataStore );
-	return Promise.all( [
-		core.getCurrentUser(),
-		core.getEntitiesConfig( 'postType' ),
-		core.getEntitiesConfig( 'taxonomy' ),
-		core.getEntitiesConfig( 'root' ),
-		core.getCurrentTheme(),
-		core.getBlockPatternCategories(),
-		core.__experimentalGetCurrentGlobalStylesId(),
-		core.__experimentalGetCurrentThemeBaseGlobalStyles(),
-		core.__experimentalGetCurrentThemeGlobalStylesVariations(),
-		core.getEntityRecord( 'root', '__unstableBase' ),
-		core.getEntityRecord( 'root', 'site' ),
-		core.canUser( 'read', { kind: 'root', name: 'site' } ),
-		core.canUser( 'create', { kind: 'postType', name: 'attachment' } ),
-		core.canUser( 'create', { kind: 'postType', name: 'page' } ),
-		core.canUser( 'create', { kind: 'postType', name: 'wp_block' } ),
-		core.canUser( 'create', { kind: 'postType', name: 'wp_template' } ),
-		// Per-post resolvers — only useful when we actually have a post.
-		...( postType && postId
-			? [
-					core.getEntityRecord( 'root', 'postType', postType ),
-					core.getEntityRecord( 'postType', postType, postId ),
-					core.getAutosaves( postType, postId ),
-			  ]
-			: [] ),
-	] ).catch( () => {
+	const coreSelect = select( coreDataStore );
+
+	try {
+		await Promise.all( [
+			core.getCurrentUser(),
+			core.getEntitiesConfig( 'postType' ),
+			core.getEntitiesConfig( 'taxonomy' ),
+			core.getEntitiesConfig( 'root' ),
+			core.getCurrentTheme(),
+			// `getThemeSupports` is a forwardResolver alias of
+			// `getCurrentTheme`; its resolution metadata is tracked
+			// separately, so we need to drive its resolver too.
+			core.getThemeSupports(),
+			core.getBlockPatternCategories(),
+			core.__experimentalGetCurrentGlobalStylesId(),
+			core.__experimentalGetCurrentThemeBaseGlobalStyles(),
+			core.__experimentalGetCurrentThemeGlobalStylesVariations(),
+			core.getEntityRecord( 'root', '__unstableBase' ),
+			core.getEntityRecord( 'root', 'site' ),
+			core.canUser( 'read', { kind: 'root', name: 'site' } ),
+			core.canUser( 'create', { kind: 'postType', name: 'attachment' } ),
+			core.canUser( 'create', { kind: 'postType', name: 'page' } ),
+			core.canUser( 'create', { kind: 'postType', name: 'wp_block' } ),
+			core.canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_template',
+			} ),
+			// Per-post resolvers — only useful when we actually have a post.
+			...( postType && postId
+				? [
+						// Editor code calls `getPostType( name )` everywhere,
+						// not `getEntityRecord( 'root', 'postType', name )`.
+						// The shorthand is its own selector with its own
+						// resolution metadata — kick that one off so the
+						// editor's first render finds it resolved.
+						core.getPostType( postType ),
+						core.getEntityRecord( 'postType', postType, postId ),
+						core.getEditedEntityRecord(
+							'postType',
+							postType,
+							postId
+						), // forwardResolver alias of getEntityRecord
+						core.getAutosaves( postType, postId ),
+				  ]
+				: [] ),
+		] );
+
+		// Phase 2: read derived data out of state.
+		const tasks = [];
+		const globalStylesId =
+			coreSelect.__experimentalGetCurrentGlobalStylesId();
+		if ( globalStylesId ) {
+			tasks.push(
+				core.getEntityRecord( 'root', 'globalStyles', globalStylesId ),
+				core.canUser( 'read', {
+					kind: 'root',
+					name: 'globalStyles',
+					id: globalStylesId,
+				} )
+			);
+		}
+
+		if ( postType && postId ) {
+			const post = coreSelect.getEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+			if ( post ) {
+				// Mirrors core-data's `getDefaultTemplate` slug formula
+				// (see packages/core-data/src/private-selectors.ts).
+				let slug = 'page' === postType ? 'page' : 'single-' + postType;
+				if ( post.slug ) {
+					slug += '-' + post.slug;
+				}
+				tasks.push( core.getDefaultTemplateId( { slug } ) );
+			}
+		}
+
+		if ( tasks.length ) {
+			await Promise.all( tasks );
+		}
+	} catch {
 		// Any individual resolver failing here is harmless — the editor
 		// would have hit the same failure on demand. Don't block render.
-	} );
+	}
 }
 
 /**

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -156,29 +156,19 @@ export function initializeEditor(
 	window.addEventListener( 'dragover', ( e ) => e.preventDefault(), false );
 	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
 
-	// Kick off the resolvers whose data the existing path-based
-	// createPreloadingMiddleware already has cached. They run end-to-end
-	// (start/receive/finish dispatches + downstream `resolveSelect` chains
-	// + side-effects like priming canUser via the Allow header) against
-	// the cached responses in a single batch before React mounts. By the
-	// time `root.render(...)` runs, every metadata entry these touch is
-	// already `finished`, so useSelect on the first render finds resolved
-	// data and never triggers another `setTimeout(0)` resolution dance.
-	//
-	// Multi-use lets a single preloaded URL back several selectors
-	// (e.g. `getEntitiesConfig('root')` + `canUser({kind:'root', name:'site'})`
-	// + `getEntityRecord('root', 'site')` all hit /wp/v2/settings via
-	// GET + OPTIONS). The matching `__unstableClearPreloadedData` runs
-	// after the kickoff promise settles, restoring the "fall through to
-	// network" behaviour for anything we missed.
+	// Drive the resolvers whose data `createPreloadingMiddleware`
+	// already has cached so every metadata entry they touch is
+	// `finished` by the time React mounts — no `setTimeout(0)`
+	// resolution dance on first render. Multi-use lets a single
+	// preloaded URL back several selectors (e.g. /wp/v2/settings GET +
+	// OPTIONS serves `getEntitiesConfig`, `canUser`, `getEntityRecord`).
 	enablePreloadMultiUse();
 	const preloadedResolutions = preloadResolutions( postType, postId );
 
 	preloadedResolutions.finally( () => {
-		// Drop any preload entries the kickoff didn't consume. After this
-		// point, any resolver firing during render falls through to a
-		// real network request — which makes the misses observable both
-		// in DevTools and in the preload e2e tests.
+		// Anything not consumed by the kickoff falls through to a real
+		// network request from here on. `clearPreloadedData` logs which
+		// preload entries (if any) were never served.
 		clearPreloadedData();
 		root.render(
 			<StrictMode>
@@ -196,16 +186,10 @@ export function initializeEditor(
 }
 
 /**
- * Drive each resolver to completion using the data already cached by
- * `createPreloadingMiddleware`. The middleware short-circuits apiFetch,
- * so no resolver issues a network request; we just need them to run
- * their dispatch cycles before React mounts.
- *
- * Run in two phases:
- *   1. Selectors whose args we know up-front from PHP (post id + type).
- *   2. Selectors that need a value derived from phase-1 state — the
- *      post record yields the default-template slug; the resolved
- *      current-global-styles id keys the global-styles record + canUser.
+ * Drive resolvers to completion against the preload cache before React
+ * mounts. Two phases: known-up-front args (post id + type), then args
+ * derived from phase-1 state (post slug → template, current global
+ * styles id → record + canUser).
  *
  * @param {string} postType Current post type.
  * @param {number} postId   Current post id.
@@ -222,9 +206,8 @@ async function preloadResolutions( postType, postId ) {
 			core.getEntitiesConfig( 'taxonomy' ),
 			core.getEntitiesConfig( 'root' ),
 			core.getCurrentTheme(),
-			// `getThemeSupports` is a forwardResolver alias of
-			// `getCurrentTheme`; its resolution metadata is tracked
-			// separately, so we need to drive its resolver too.
+			// Forward-resolver alias of `getCurrentTheme` with its own
+			// resolution metadata, so it needs a separate kick.
 			core.getThemeSupports(),
 			core.getBlockPatternCategories(),
 			core.__experimentalGetCurrentGlobalStylesId(),
@@ -240,21 +223,18 @@ async function preloadResolutions( postType, postId ) {
 				kind: 'postType',
 				name: 'wp_template',
 			} ),
-			// Per-post resolvers — only useful when we actually have a post.
+			// Per-post resolvers. `getPostType` and `getEditedEntityRecord`
+			// are shorthand/forward-resolver aliases with their own
+			// resolution metadata, so they need separate kicks.
 			...( postType && postId
 				? [
-						// Editor code calls `getPostType( name )` everywhere,
-						// not `getEntityRecord( 'root', 'postType', name )`.
-						// The shorthand is its own selector with its own
-						// resolution metadata — kick that one off so the
-						// editor's first render finds it resolved.
 						core.getPostType( postType ),
 						core.getEntityRecord( 'postType', postType, postId ),
 						core.getEditedEntityRecord(
 							'postType',
 							postType,
 							postId
-						), // forwardResolver alias of getEntityRecord
+						),
 						core.getAutosaves( postType, postId ),
 				  ]
 				: [] ),
@@ -282,8 +262,7 @@ async function preloadResolutions( postType, postId ) {
 				postId
 			);
 			if ( post ) {
-				// Mirrors core-data's `getDefaultTemplate` slug formula
-				// (see packages/core-data/src/private-selectors.ts).
+				// Mirrors core-data's `getDefaultTemplate` slug formula.
 				let slug = 'page' === postType ? 'page' : 'single-' + postType;
 				if ( post.slug ) {
 					slug += '-' + post.slug;
@@ -296,8 +275,7 @@ async function preloadResolutions( postType, postId ) {
 			await Promise.all( tasks );
 		}
 	} catch {
-		// Any individual resolver failing here is harmless — the editor
-		// would have hit the same failure on demand. Don't block render.
+		// Resolver failures here would also surface on demand; don't block render.
 	}
 }
 

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -32,6 +32,10 @@ const {
 	registerCoreBlockBindingsSources,
 } = unlock( editorPrivateApis );
 
+const { enablePreloadMultiUse, clearPreloadedData } = unlock(
+	apiFetch.privateApis
+);
+
 /**
  * Initializes and returns an instance of Editor.
  *
@@ -160,6 +164,14 @@ export function initializeEditor(
 	// time `root.render(...)` runs, every metadata entry these touch is
 	// already `finished`, so useSelect on the first render finds resolved
 	// data and never triggers another `setTimeout(0)` resolution dance.
+	//
+	// Multi-use lets a single preloaded URL back several selectors
+	// (e.g. `getEntitiesConfig('root')` + `canUser({kind:'root', name:'site'})`
+	// + `getEntityRecord('root', 'site')` all hit /wp/v2/settings via
+	// GET + OPTIONS). The matching `__unstableClearPreloadedData` runs
+	// after the kickoff promise settles, restoring the "fall through to
+	// network" behaviour for anything we missed.
+	enablePreloadMultiUse();
 	const preloadedResolutions = preloadResolutions( postType, postId );
 
 	preloadedResolutions.finally( () => {
@@ -167,7 +179,7 @@ export function initializeEditor(
 		// point, any resolver firing during render falls through to a
 		// real network request — which makes the misses observable both
 		// in DevTools and in the preload e2e tests.
-		apiFetch.__unstableClearPreloadedData();
+		clearPreloadedData();
 		root.render(
 			<StrictMode>
 				<Layout

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -8,7 +8,7 @@ import {
 } from '@wordpress/block-library';
 import deprecated from '@wordpress/deprecated';
 import { createRoot, StrictMode } from '@wordpress/element';
-import { dispatch, select } from '@wordpress/data';
+import { dispatch, resolveSelect, select } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
 	registerLegacyWidgetBlock,
@@ -18,6 +18,7 @@ import {
 	store as editorStore,
 	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
+import { store as coreDataStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -150,18 +151,73 @@ export function initializeEditor(
 	window.addEventListener( 'dragover', ( e ) => e.preventDefault(), false );
 	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
 
-	root.render(
-		<StrictMode>
-			<Layout
-				settings={ settings }
-				postId={ postId }
-				postType={ postType }
-				initialEdits={ initialEdits }
-			/>
-		</StrictMode>
-	);
+	// Kick off the resolvers whose data the existing path-based
+	// createPreloadingMiddleware already has cached. They run end-to-end
+	// (start/receive/finish dispatches + downstream `resolveSelect` chains
+	// + side-effects like priming canUser via the Allow header) against
+	// the cached responses in a single batch before React mounts. By the
+	// time `root.render(...)` runs, every metadata entry these touch is
+	// already `finished`, so useSelect on the first render finds resolved
+	// data and never triggers another `setTimeout(0)` resolution dance.
+	const preloadedResolutions = preloadResolutions( postType, postId );
+
+	preloadedResolutions.finally( () => {
+		root.render(
+			<StrictMode>
+				<Layout
+					settings={ settings }
+					postId={ postId }
+					postType={ postType }
+					initialEdits={ initialEdits }
+				/>
+			</StrictMode>
+		);
+	} );
 
 	return root;
+}
+
+/**
+ * Drive each resolver to completion using the data already cached by
+ * `createPreloadingMiddleware`. The middleware short-circuits apiFetch,
+ * so no resolver issues a network request; we just need them to run
+ * their dispatch cycles before React mounts.
+ *
+ * @param {string} postType Current post type.
+ * @param {number} postId   Current post id.
+ * @return {Promise<void>}  Resolves when the kickoff resolvers settle.
+ */
+function preloadResolutions( postType, postId ) {
+	const core = resolveSelect( coreDataStore );
+	return Promise.all( [
+		core.getCurrentUser(),
+		core.getEntitiesConfig( 'postType' ),
+		core.getEntitiesConfig( 'taxonomy' ),
+		core.getEntitiesConfig( 'root' ),
+		core.getCurrentTheme(),
+		core.getBlockPatternCategories(),
+		core.__experimentalGetCurrentGlobalStylesId(),
+		core.__experimentalGetCurrentThemeBaseGlobalStyles(),
+		core.__experimentalGetCurrentThemeGlobalStylesVariations(),
+		core.getEntityRecord( 'root', '__unstableBase' ),
+		core.getEntityRecord( 'root', 'site' ),
+		core.canUser( 'read', { kind: 'root', name: 'site' } ),
+		core.canUser( 'create', { kind: 'postType', name: 'attachment' } ),
+		core.canUser( 'create', { kind: 'postType', name: 'page' } ),
+		core.canUser( 'create', { kind: 'postType', name: 'wp_block' } ),
+		core.canUser( 'create', { kind: 'postType', name: 'wp_template' } ),
+		// Per-post resolvers — only useful when we actually have a post.
+		...( postType && postId
+			? [
+					core.getEntityRecord( 'root', 'postType', postType ),
+					core.getEntityRecord( 'postType', postType, postId ),
+					core.getAutosaves( postType, postId ),
+			  ]
+			: [] ),
+	] ).catch( () => {
+		// Any individual resolver failing here is harmless — the editor
+		// would have hit the same failure on demand. Don't block render.
+	} );
 }
 
 /**

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -144,9 +144,10 @@ function StartPageOptionsModal( { onClose } ) {
 
 export default function StartPageOptions() {
 	const [ isOpen, setIsOpen ] = useState( false );
-	const { isEditedPostDirty, isEditedPostEmpty } = useSelect( editorStore );
+	const { isEditedPostEmpty } = useSelect( editorStore );
+	const { getEntityRecordNonTransientEdits } = useSelect( coreStore );
 	const { isModalActive } = useSelect( interfaceStore );
-	const { enabled, postId } = useSelect( ( select ) => {
+	const { enabled, postType, postId } = useSelect( ( select ) => {
 		const { getCurrentPostId, getCurrentPostType } = select( editorStore );
 		const choosePatternModalEnabled = select( preferencesStore ).get(
 			'core',
@@ -154,6 +155,7 @@ export default function StartPageOptions() {
 		);
 		const currentPostType = getCurrentPostType();
 		return {
+			postType: currentPostType,
 			postId: getCurrentPostId(),
 			enabled:
 				choosePatternModalEnabled &&
@@ -166,7 +168,20 @@ export default function StartPageOptions() {
 	// Note: The `postId` ensures the effect re-runs when pages are switched without remounting the component.
 	// Examples: changing pages in the List View, creating a new page via Command Palette.
 	useEffect( () => {
-		const isFreshPage = ! isEditedPostDirty() && isEditedPostEmpty();
+		// Use the underlying edits selector rather than `isEditedPostDirty`,
+		// which also returns true while an `isSavingEntityRecord` is in
+		// flight. At boot, the CRDT sync manager kicks off a phantom save
+		// of the just-received post record (no real edits) and we don't
+		// want that side-effect to suppress the modal.
+		const hasEdits =
+			Object.keys(
+				getEntityRecordNonTransientEdits(
+					'postType',
+					postType,
+					postId
+				) ?? {}
+			).length > 0;
+		const isFreshPage = ! hasEdits && isEditedPostEmpty();
 		// Prevents immediately opening when features is enabled via preferences modal.
 		const isPreferencesModalActive = isModalActive( 'editor/preferences' );
 		if ( ! enabled || ! isFreshPage || isPreferencesModalActive ) {
@@ -177,8 +192,9 @@ export default function StartPageOptions() {
 		setIsOpen( true );
 	}, [
 		enabled,
+		postType,
 		postId,
-		isEditedPostDirty,
+		getEntityRecordNonTransientEdits,
 		isEditedPostEmpty,
 		isModalActive,
 	] );

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -168,11 +168,10 @@ export default function StartPageOptions() {
 	// Note: The `postId` ensures the effect re-runs when pages are switched without remounting the component.
 	// Examples: changing pages in the List View, creating a new page via Command Palette.
 	useEffect( () => {
-		// Use the underlying edits selector rather than `isEditedPostDirty`,
-		// which also returns true while an `isSavingEntityRecord` is in
-		// flight. At boot, the CRDT sync manager kicks off a phantom save
-		// of the just-received post record (no real edits) and we don't
-		// want that side-effect to suppress the modal.
+		// Read non-transient edits directly. `isEditedPostDirty` /
+		// `hasEditsForEntityRecord` also return true while the CRDT
+		// sync manager's phantom save (fired off `receiveEntityRecords`
+		// at boot) is in flight, which would suppress the modal.
 		const hasEdits =
 			Object.keys(
 				getEntityRecordNonTransientEdits(

--- a/packages/editor/src/components/start-template-options/index.js
+++ b/packages/editor/src/components/start-template-options/index.js
@@ -173,18 +173,24 @@ export default function StartTemplateOptions() {
 				select( editorStore );
 			const _postType = getCurrentPostType();
 			const _postId = getCurrentPostId();
-			const { getEditedEntityRecord, hasEditsForEntityRecord } =
+			const { getEditedEntityRecord, getEntityRecordNonTransientEdits } =
 				select( coreStore );
 			const templateRecord = getEditedEntityRecord(
 				'postType',
 				_postType,
 				_postId
 			);
-			const hasEdits = hasEditsForEntityRecord(
-				'postType',
-				_postType,
-				_postId
-			);
+			// Avoid `hasEditsForEntityRecord` — its `isSavingEntityRecord`
+			// branch fires `true` while the CRDT sync manager's phantom
+			// save is in flight at boot, which would suppress the modal.
+			const hasEdits =
+				Object.keys(
+					getEntityRecordNonTransientEdits(
+						'postType',
+						_postType,
+						_postId
+					) ?? {}
+				).length > 0;
 
 			return {
 				shouldOpenModal:

--- a/packages/editor/src/components/start-template-options/index.js
+++ b/packages/editor/src/components/start-template-options/index.js
@@ -180,9 +180,10 @@ export default function StartTemplateOptions() {
 				_postType,
 				_postId
 			);
-			// Avoid `hasEditsForEntityRecord` — its `isSavingEntityRecord`
-			// branch fires `true` while the CRDT sync manager's phantom
-			// save is in flight at boot, which would suppress the modal.
+			// Read non-transient edits directly. `isEditedPostDirty` /
+			// `hasEditsForEntityRecord` also return true while the CRDT
+			// sync manager's phantom save (fired off `receiveEntityRecords`
+			// at boot) is in flight, which would suppress the modal.
 			const hasEdits =
 				Object.keys(
 					getEntityRecordNonTransientEdits(

--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -11,6 +11,7 @@
  */
 const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/admin-ui',
+	'@wordpress/api-fetch',
 	'@wordpress/block-directory',
 	'@wordpress/block-editor',
 	'@wordpress/block-library',

--- a/test/e2e/specs/preload/post-editor.spec.js
+++ b/test/e2e/specs/preload/post-editor.spec.js
@@ -30,6 +30,19 @@ test.describe( 'Preload', () => {
 		editor,
 	} ) => {
 		const { requests, stop } = recordRequests( page );
+		const { requests: requestsUntilMount, stop: stopOnMount } =
+			recordRequests( page );
+
+		// Mount boundary. `clearPreloadedData` warns if any preload
+		// entry went unused, logs the success line otherwise.
+		let preloadStatus;
+		page.on( 'console', ( msg ) => {
+			const text = msg.text();
+			if ( text.startsWith( '[api-fetch][preload] ' ) ) {
+				preloadStatus = text;
+				stopOnMount();
+			}
+		} );
 
 		await admin.editPost( postId );
 		// Ensure the document sidebar is open — its default state isn't
@@ -50,6 +63,19 @@ test.describe( 'Preload', () => {
 		await page.waitForLoadState( 'networkidle' );
 		stop();
 
+		// Only collab side effects (CRDT save + first wp-sync poll)
+		// should escape before mount — they're detached promise chains
+		// off `receiveEntityRecords`.
+		expect( Array.from( new Set( requestsUntilMount ) ).sort() ).toEqual(
+			[
+				`POST /wp/v2/posts/${ postId }`,
+				'POST /wp-sync/v1/updates',
+			].sort()
+		);
+		// Every preloaded path should be consumed by the kickoff.
+		expect( preloadStatus ).toBe(
+			'[api-fetch][preload] All preloads consumed.'
+		);
 		// `POST /wp/v2/users/me` (preferences persistence) occasionally
 		// fires twice within the captured window; the duplicate count
 		// isn't stable across runs, so this assertion deduplicates.

--- a/test/e2e/specs/preload/post-editor.spec.js
+++ b/test/e2e/specs/preload/post-editor.spec.js
@@ -58,12 +58,10 @@ test.describe( 'Preload', () => {
 			[
 				`GET /wp/v2/comments?context=edit&post=${ postId }&type=note&status=all&per_page=100`,
 				'GET /wp/v2/taxonomies?context=edit&per_page=100',
-				'GET /wp/v2/taxonomies?context=view',
 				'GET /wp/v2/templates/lookup?slug=front-page',
 				'GET /wp/v2/users/1?context=view&_fields=id%2Cname',
 				'GET /wp/v2/wp_pattern_category?context=view&per_page=100&_fields=id%2Cname%2Cdescription%2Cslug',
 				'OPTIONS /wp/v2/posts',
-				'OPTIONS /wp/v2/settings',
 				`POST /wp/v2/posts/${ postId }`,
 				'POST /wp-sync/v1/updates',
 				'POST /wp/v2/users/me',


### PR DESCRIPTION
This PR addresses four things at once:

* Improves performance of preload cache consumption by adding it to the store before mounting React (no store subscribers yet).
* Allow preload cache to be reused across different resolvers. Until now it was not possible to preload e.g. `/wp/settings` for two distinct resolvers.
* Delete preload cache immediately after load. This prevents subtle bugs where preload cache might hang around for different paths (e.g. in the site editor) and then be consumed at a later point (like navigation) with stale data.
* Upon cache deletion we log a warning with all unconsumed cache, which should ideally not have been preloaded server side.

How do we make sure that selectors are added when adding preload paths?

The current preload tests would catch this. Preload cache is cleared after load, which means the path would show up as not preloaded in the test, even if the preload path is there server side. Additionally a warning will be logged (which we could eventually also test for).