### PR TITLE
Include accordion block headings in the Document Outline

### DIFF
--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -73,6 +73,37 @@ function EmptyOutlineIllustration() {
 	);
 }
 
+const HEADING_BLOCK_NAMES = [ 'core/heading', 'core/accordion-heading' ];
+
+/**
+ * Builds a map of accordion-heading clientId → resolved heading level
+ * by walking the innerBlocks tree of every core/accordion block in the
+ * flat blocks array. This is needed because accordion heading receives
+ * its level via context from the parent accordion block, so
+ * block.attributes.level may be undefined on initial render before the
+ * attribute has been explicitly persisted.
+ *
+ * @param {Array} blocks Flat array of all blocks (each with innerBlocks).
+ * @return {Object} Map of { [clientId]: level }
+ */
+const buildAccordionHeadingLevelMap = ( blocks ) => {
+	const map = {};
+	blocks.forEach( ( block ) => {
+		if ( block.name !== 'core/accordion' ) {
+			return;
+		}
+		const headingLevel = block.attributes?.headingLevel;
+		( block.innerBlocks ?? [] ).forEach( ( accordionItem ) => {
+			( accordionItem.innerBlocks ?? [] ).forEach( ( child ) => {
+				if ( child.name === 'core/accordion-heading' ) {
+					map[ child.clientId ] = headingLevel;
+				}
+			} );
+		} );
+	} );
+	return map;
+};
+
 /**
  * Returns an array of heading blocks enhanced with the following properties:
  * level   - An integer with the heading level.
@@ -83,18 +114,34 @@ function EmptyOutlineIllustration() {
  * @return {Array} An array of heading blocks enhanced with the properties described above.
  */
 const computeOutlineHeadings = ( blocks = [] ) => {
+	const accordionHeadingLevelMap = buildAccordionHeadingLevelMap( blocks );
 	return blocks
-		.filter( ( block ) => block.name === 'core/heading' )
-		.map( ( block ) => ( {
-			...block,
-			level: block.attributes.level,
-			isEmpty: isEmptyHeading( block ),
-		} ) );
+		.filter( ( block ) => HEADING_BLOCK_NAMES.includes( block.name ) )
+		.map( ( block ) => {
+			// For accordion heading, attributes.level may be undefined on
+			// initial render (level arrives via context, not persisted attrs).
+			// Fall back to the level resolved from the parent accordion block.
+			const level =
+				block.name === 'core/accordion-heading'
+					? block.attributes.level ??
+					  accordionHeadingLevelMap[ block.clientId ]
+					: block.attributes.level;
+
+			return {
+				...block,
+				level,
+				isEmpty: isEmptyHeading( block ),
+			};
+		} );
 };
 
-const isEmptyHeading = ( heading ) =>
-	! heading.attributes.content ||
-	heading.attributes.content.trim().length === 0;
+const isEmptyHeading = ( heading ) => {
+	const content =
+		heading.name === 'core/accordion-heading'
+			? heading.attributes.title
+			: heading.attributes.content;
+	return ! content || content.trim().length === 0;
+};
 
 /**
  * Renders a document outline component.
@@ -230,7 +277,11 @@ export default function DocumentOutline( {
 								? emptyHeadingContent
 								: getTextContent(
 										create( {
-											html: item.attributes.content,
+											html:
+												item.name ===
+												'core/accordion-heading'
+													? item.attributes.title
+													: item.attributes.content,
 										} )
 								  ) }
 							{ isIncorrectLevel && incorrectLevelContent }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #74117

This PR updates the `DocumentOutline` component so that headings inside Accordion blocks `(core/accordion-heading)` are properly detected and displayed in the document overview sidebar.

## Why?
Accordion blocks contain semantic headings that form an important part of a document's structure. Previously, the Document Outline explicitly only looked for `core/heading blocks`, meaning accordion headings were entirely ignored. This broke the authoring experience for users trying to navigate or audit their document structure.

## How?

1. Appended `core/accordion-heading` to the `HEADING_BLOCK_NAMES` allowlist.
2. Accordion headings receive their heading level via context from their parent `core/accordion` block. On initial render, `block.attributes.level` is undefined. I implemented a helper `buildAccordionHeadingLevelMap` to map inner accordion headings to their parent's level so they render correctly in the outline immediately.

Why not dynamically support all blocks?
During development, I explored making the outline fully dynamic by parsing any block that declares a level attribute or uses a heading context. However, doing so immediately polluted the Document Outline with template-level blocks (e.g., core/query-title, core/comments-title).

The Document Outline is designed to help authors navigate their written content, not the site template structure. Until the Block API introduces an explicit opt-in mechanism (like a supports: { documentOutline: true } flag in block.json), utilizing a hardcoded allowlist is the safest, most predictable approach to prevent severe UX regressions for content editors.

## Testing Instructions

1. Open a post or page in the block editor.
2. Insert a standard Heading block and add some text.
3. Insert an Accordion block, and type text into the accordion heading.
4. Open the Document Overview sidebar and switch to the Outline tab.
5. Verify that the Accordion heading appears in the outline alongside the standard heading.
6. Change the Accordion heading level in the block settings and verify the Outline updates correctly.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1814" height="674" alt="image" src="https://github.com/user-attachments/assets/0b1cf2d0-f3f9-40b4-a0cc-1b8c159ed13a" />|<img width="1814" height="674" alt="image" src="https://github.com/user-attachments/assets/cf14d341-3149-4413-a3e5-5ff1d83627f8" />|