### PR TITLE
Dashboard: small changes to header

### DIFF
--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -47,7 +47,9 @@ function Dashboard() {
 			onEditChange={ setEditMode }
 		>
 			<Page
-				title={ __( 'Dashboard' ) }
+				title={
+					editMode ? __( 'Customize Dashboard' ) : __( 'Dashboard' )
+				}
 				actions={ <WidgetDashboard.Actions /> }
 				hasPadding
 			>

--- a/routes/dashboard/widget-dashboard/README.md
+++ b/routes/dashboard/widget-dashboard/README.md
@@ -88,7 +88,7 @@ Renders its children only when `layout` is empty. Pair it with `<WidgetDashboard
 
 #### `<WidgetDashboard.Actions />`
 
-Edit-mode toggle: a "Customize" button while `editMode` is off, and "Add widgets", "Cancel", "Done" while it is on. Clicking "Customize" or "Done" fires `onEditChange` with the toggled value. Clicking "Add widgets" opens the inserter (see below). Returns `null` when the dashboard is mounted without `onEditChange`, so surfaces that don't expose edit mode can keep `Actions` in their tree unconditionally.
+Edit-mode toggle: a "Customize" button while `editMode` is off, and "Add widget", "Layout" (when `onGridSettingsChange` is provided), "Cancel", "Done" while it is on. Clicking "Customize" or "Done" fires `onEditChange` with the toggled value. Clicking "Add widget" opens the inserter (see below). Returns `null` when the dashboard is mounted without `onEditChange`, so surfaces that don't expose edit mode can keep `Actions` in their tree unconditionally.
 
 `<Page>` from `@wordpress/admin-ui` exposes an `actions` slot used across admin surfaces (DataViews, WidgetDashboard, …). Plug `Actions` straight into it:
 
@@ -115,7 +115,7 @@ import { Page } from '@wordpress/admin-ui';
 
 ## Inserting widgets
 
-A modal-based inserter is mounted automatically inside `WidgetDashboard`. It stays hidden until the "Add widgets" button in `<WidgetDashboard.Actions />` is clicked. The inserter lists every entry in the `widgetTypes` prop as a grid of live previews (each preview renders the type's `example` attributes through its own render module), supports search, and exposes a single "Select" action with bulk support so users can insert one or several widgets in a single layout change.
+A modal-based inserter is mounted automatically inside `WidgetDashboard`. It stays hidden until the "Add widget" button in `<WidgetDashboard.Actions />` is clicked. The inserter lists every entry in the `widgetTypes` prop as a grid of live previews (each preview renders the type's `example` attributes through its own render module), supports search, and exposes a single "Select" action with bulk support so users can insert one or several widgets in a single layout change.
 
 On confirmation, the inserter creates instances via `createDashboardWidget( widgetType )` (using each type's `example.attributes` as the initial values) and appends them to `layout` through `onLayoutChange`. The dialog closes after a successful insertion or when the user dismisses it.
 

--- a/routes/dashboard/widget-dashboard/README.md
+++ b/routes/dashboard/widget-dashboard/README.md
@@ -88,7 +88,7 @@ Renders its children only when `layout` is empty. Pair it with `<WidgetDashboard
 
 #### `<WidgetDashboard.Actions />`
 
-Edit-mode toggle: a "Customize" button while `editMode` is off, and "Add widget", "Layout" (when `onGridSettingsChange` is provided), "Cancel", "Done" while it is on. Clicking "Customize" or "Done" fires `onEditChange` with the toggled value. Clicking "Add widget" opens the inserter (see below). Returns `null` when the dashboard is mounted without `onEditChange`, so surfaces that don't expose edit mode can keep `Actions` in their tree unconditionally.
+Edit-mode toggle: a "Customize" button while `editMode` is off, and "Add widget", "Cancel", "Done" while it is on. Clicking "Customize" or "Done" fires `onEditChange` with the toggled value. Clicking "Add widget" opens the inserter (see below). Returns `null` when the dashboard is mounted without `onEditChange`, so surfaces that don't expose edit mode can keep `Actions` in their tree unconditionally.
 
 `<Page>` from `@wordpress/admin-ui` exposes an `actions` slot used across admin surfaces (DataViews, WidgetDashboard, …). Plug `Actions` straight into it:
 

--- a/routes/dashboard/widget-dashboard/components/actions/actions.module.css
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.module.css
@@ -1,8 +1,17 @@
 .editActionsEnter,
 .editActionsExit {
 	display: inline-flex;
+	align-items: center;
 	gap: var(--wp--preset--spacing--20);
 	transform-origin: right center;
+}
+
+.editActionsDivider {
+	flex-shrink: 0;
+	align-self: center;
+	width: 1px;
+	height: 20px;
+	background-color: var(--wpds-color-stroke-surface-neutral);
 }
 
 @media not ( prefers-reduced-motion ) {

--- a/routes/dashboard/widget-dashboard/components/actions/actions.module.css
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.module.css
@@ -10,7 +10,7 @@
 	flex-shrink: 0;
 	align-self: center;
 	width: 1px;
-	height: 20px;
+	height: 16px;
 	background-color: var(--wpds-color-stroke-surface-neutral);
 }
 

--- a/routes/dashboard/widget-dashboard/components/actions/actions.tsx
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.tsx
@@ -3,6 +3,7 @@
  */
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { layout, plus } from '@wordpress/icons';
 // eslint-disable-next-line @wordpress/use-recommended-components
 import { AlertDialog, Button, Stack } from '@wordpress/ui';
 
@@ -22,13 +23,10 @@ import type { MoreActionsDropdownItem } from '../more-actions-dropdown';
  * - **Customize** (layout edits): toggles edit mode, surfaces the Add
  *   widgets / Cancel / Done toolbar. Commits the layout staging buffer
  *   on Done.
- * - **Layout settings** (more-actions dropdown entry): opens a side
- *   drawer with model, column behavior, and row height. Commits the
- *   settings staging buffer on Save inside the drawer.
- *
- * The two flows are mutually exclusive: the Layout settings entry is
- * disabled while edit mode is on so the settings drawer cannot
- * accumulate changes on top of pending layout edits, and vice versa.
+ * - **Layout** (customize-mode toolbar): opens a side drawer with
+ *   model, column behavior, and row height. Commits the settings
+ *   staging buffer on Save inside the drawer. Only shown while
+ *   `editMode` is on and `onGridSettingsChange` is provided.
  *
  * Returns `null` when the dashboard is mounted without `onEditChange`
  * so surfaces that don't expose edit mode can keep `Actions` in their
@@ -104,15 +102,6 @@ export function Actions(): React.ReactNode {
 		},
 	];
 
-	if ( canEditGridSettings ) {
-		moreActionsItems.unshift( {
-			label: __( 'Layout settings' ),
-			onClick: openLayoutSettings,
-			disabled: editMode,
-			disabledTooltip: __( 'Disabled while editing widgets' ),
-		} );
-	}
-
 	if ( ! onEditChange ) {
 		return null;
 	}
@@ -135,8 +124,26 @@ export function Actions(): React.ReactNode {
 						size="compact"
 						onClick={ insert }
 					>
-						{ __( 'Add widgets' ) }
+						<Button.Icon icon={ plus } />
+						{ __( 'Add widget' ) }
 					</Button>
+
+					{ canEditGridSettings && (
+						<Button
+							variant="minimal"
+							tone="brand"
+							size="compact"
+							onClick={ openLayoutSettings }
+						>
+							<Button.Icon icon={ layout } />
+							{ __( 'Layout' ) }
+						</Button>
+					) }
+
+					<div
+						className={ styles.editActionsDivider }
+						aria-hidden="true"
+					/>
 
 					<Button
 						variant="minimal"
@@ -159,7 +166,7 @@ export function Actions(): React.ReactNode {
 				</Stack>
 			) : (
 				<Button
-					variant="outline"
+					variant="minimal"
 					tone="brand"
 					size="compact"
 					onClick={ handleEditMode }

--- a/routes/dashboard/widget-dashboard/components/actions/actions.tsx
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.tsx
@@ -3,7 +3,7 @@
  */
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { layout, plus } from '@wordpress/icons';
+import { plus } from '@wordpress/icons';
 // eslint-disable-next-line @wordpress/use-recommended-components
 import { AlertDialog, Button, Stack } from '@wordpress/ui';
 
@@ -23,10 +23,13 @@ import type { MoreActionsDropdownItem } from '../more-actions-dropdown';
  * - **Customize** (layout edits): toggles edit mode, surfaces the Add
  *   widgets / Cancel / Done toolbar. Commits the layout staging buffer
  *   on Done.
- * - **Layout** (customize-mode toolbar): opens a side drawer with
- *   model, column behavior, and row height. Commits the settings
- *   staging buffer on Save inside the drawer. Only shown while
- *   `editMode` is on and `onGridSettingsChange` is provided.
+ * - **Layout settings** (more-actions dropdown entry): opens a side
+ *   drawer with model, column behavior, and row height. Commits the
+ *   settings staging buffer on Save inside the drawer.
+ *
+ * The two flows are mutually exclusive: the Layout settings entry is
+ * disabled while edit mode is on so the settings drawer cannot
+ * accumulate changes on top of pending layout edits, and vice versa.
  *
  * Returns `null` when the dashboard is mounted without `onEditChange`
  * so surfaces that don't expose edit mode can keep `Actions` in their
@@ -102,6 +105,15 @@ export function Actions(): React.ReactNode {
 		},
 	];
 
+	if ( canEditGridSettings ) {
+		moreActionsItems.unshift( {
+			label: __( 'Layout settings' ),
+			onClick: openLayoutSettings,
+			disabled: editMode,
+			disabledTooltip: __( 'Disabled while editing widgets' ),
+		} );
+	}
+
 	if ( ! onEditChange ) {
 		return null;
 	}
@@ -127,18 +139,6 @@ export function Actions(): React.ReactNode {
 						<Button.Icon icon={ plus } />
 						{ __( 'Add widget' ) }
 					</Button>
-
-					{ canEditGridSettings && (
-						<Button
-							variant="minimal"
-							tone="brand"
-							size="compact"
-							onClick={ openLayoutSettings }
-						>
-							<Button.Icon icon={ layout } />
-							{ __( 'Layout' ) }
-						</Button>
-					) }
 
 					<div
 						className={ styles.editActionsDivider }

--- a/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
+++ b/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
@@ -209,10 +209,13 @@ interface LayoutSettingsProps {
  * restores the package's built-in defaults in staging (still
  * subject to Save/Cancel). Closing the drawer through the X icon,
  * an Escape press, or any path other than the explicit Cancel/Save
- * buttons is treated as Cancel.
+ * buttons is treated as Cancel. None of these exit customize mode.
  *
- * The Layout toolbar button that opens this drawer is only available
- * in customize mode, alongside the widget layout editing controls.
+ * Settings and layout-editing are kept as separate flows on the
+ * dashboard surface (the Layout settings entry that opens this
+ * drawer is disabled while edit mode is on), so the drawer's
+ * commit never publishes layout edits that the user is in the
+ * middle of staging through the toolbar.
  *
  * @param {LayoutSettingsProps} props Layout settings props.
  * @return {React.ReactNode} The layout settings component.
@@ -256,19 +259,19 @@ export function LayoutSettings( {
 	);
 
 	const handleCancel = useCallback( () => {
-		cancelStaging();
+		cancelStaging( { exitEditMode: false } );
 		onOpenChange( false );
 	}, [ cancelStaging, onOpenChange ] );
 
 	const handleSave = useCallback( () => {
-		commit();
+		commit( { exitEditMode: false } );
 		onOpenChange( false );
 	}, [ commit, onOpenChange ] );
 
 	const handleOpenChange = useCallback(
 		( nextOpen: boolean ) => {
 			if ( ! nextOpen && open ) {
-				cancelStaging();
+				cancelStaging( { exitEditMode: false } );
 			}
 			onOpenChange( nextOpen );
 		},

--- a/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
+++ b/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
@@ -211,11 +211,8 @@ interface LayoutSettingsProps {
  * an Escape press, or any path other than the explicit Cancel/Save
  * buttons is treated as Cancel.
  *
- * Settings and layout-editing are kept as separate flows on the
- * dashboard surface (the Layout settings entry that opens this
- * drawer is disabled while edit mode is on), so the drawer's
- * commit never publishes layout edits that the user is in the
- * middle of staging through the toolbar.
+ * The Layout toolbar button that opens this drawer is only available
+ * in customize mode, alongside the widget layout editing controls.
  *
  * @param {LayoutSettingsProps} props Layout settings props.
  * @return {React.ReactNode} The layout settings component.

--- a/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
+++ b/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
@@ -117,13 +117,17 @@ interface InternalDashboardContextValue {
 
 	/**
 	 * Publishes staged slices that differ from their committed
-	 * counterparts, then exits edit mode. Best-effort atomic: no
-	 * rollback if a callback throws.
+	 * counterparts. By default also exits edit mode; pass
+	 * `{ exitEditMode: false }` when committing from the layout
+	 * settings drawer so customize mode stays active.
 	 */
-	commit: () => void;
+	commit: ( options?: { exitEditMode?: boolean } ) => void;
 
-	/** Reverts both staging slices and exits edit mode. */
-	cancel: () => void;
+	/**
+	 * Reverts both staging slices. By default also exits edit mode; pass
+	 * `{ exitEditMode: false }` when dismissing the layout settings drawer.
+	 */
+	cancel: ( options?: { exitEditMode?: boolean } ) => void;
 
 	hasUncommittedChanges: boolean;
 	editMode: boolean;
@@ -210,8 +214,10 @@ interface ProviderProps {
  * Two invariants the provider does not enforce on its own:
  *
  * - The shared commit assumes the two slices are not edited
- *   simultaneously. Consumers that compose a different surface must
- *   uphold that invariant or accept cross-publish when both change.
+ *   simultaneously. The bundled `Actions` keeps the layout-edit and
+ *   settings-drawer flows mutually exclusive; consumers that compose
+ *   a different surface must uphold the same invariant or accept the
+ *   cross-publish.
  * - Staging re-syncs from the committed props on prop change.
  *   In-flight edits are dropped silently when an external update
  *   (cross-tab commit, reset, websocket push) lands. Consumers that
@@ -267,31 +273,41 @@ export function WidgetDashboardProvider( {
 
 	const hasUncommittedChanges = hasLayoutChanges || hasGridSettingsChanges;
 
-	const commit = useCallback( () => {
-		if ( hasLayoutChanges ) {
-			onLayoutChange( canonicalize( stagingLayout ) );
-		}
+	const commit = useCallback(
+		( options?: { exitEditMode?: boolean } ) => {
+			if ( hasLayoutChanges ) {
+				onLayoutChange( canonicalize( stagingLayout ) );
+			}
 
-		if ( hasGridSettingsChanges ) {
-			onGridSettingsChange?.( stagingGridSettings );
-		}
+			if ( hasGridSettingsChanges ) {
+				onGridSettingsChange?.( stagingGridSettings );
+			}
 
-		onEditChange?.( false );
-	}, [
-		hasLayoutChanges,
-		hasGridSettingsChanges,
-		onLayoutChange,
-		onGridSettingsChange,
-		stagingLayout,
-		stagingGridSettings,
-		onEditChange,
-	] );
+			if ( options?.exitEditMode !== false ) {
+				onEditChange?.( false );
+			}
+		},
+		[
+			hasLayoutChanges,
+			hasGridSettingsChanges,
+			onLayoutChange,
+			onGridSettingsChange,
+			stagingLayout,
+			stagingGridSettings,
+			onEditChange,
+		]
+	);
 
-	const cancel = useCallback( () => {
-		setStagingLayout( committedLayout );
-		setStagingGridSettings( committedGridSettings );
-		onEditChange?.( false );
-	}, [ committedLayout, committedGridSettings, onEditChange ] );
+	const cancel = useCallback(
+		( options?: { exitEditMode?: boolean } ) => {
+			setStagingLayout( committedLayout );
+			setStagingGridSettings( committedGridSettings );
+			if ( options?.exitEditMode !== false ) {
+				onEditChange?.( false );
+			}
+		},
+		[ committedLayout, committedGridSettings, onEditChange ]
+	);
 
 	const resetGridSettings = useCallback( () => {
 		setStagingGridSettings( DEFAULT_GRID );

--- a/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
+++ b/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
@@ -210,10 +210,8 @@ interface ProviderProps {
  * Two invariants the provider does not enforce on its own:
  *
  * - The shared commit assumes the two slices are not edited
- *   simultaneously. The bundled `Actions` keeps the layout-edit and
- *   settings-drawer flows mutually exclusive; consumers that compose
- *   a different surface must uphold the same invariant or accept the
- *   cross-publish.
+ *   simultaneously. Consumers that compose a different surface must
+ *   uphold that invariant or accept cross-publish when both change.
  * - Staging re-syncs from the committed props on prop change.
  *   In-flight edits are dropped silently when an external update
  *   (cross-tab commit, reset, websocket push) lands. Consumers that

--- a/routes/dashboard/widget-dashboard/context/ui-context.tsx
+++ b/routes/dashboard/widget-dashboard/context/ui-context.tsx
@@ -22,7 +22,7 @@ const Context = createContext< DashboardUIContextValue | null >( null );
 
 /**
  * UI-state hook used by the inserter modal and any compound that needs to
- * open or close it (today: the "Add widgets" trigger in `Actions`).
+ * open or close it (today: the "Add widget" trigger in `Actions`).
  *
  * Throws when called outside `WidgetDashboard` so misuse fails loudly during
  * development.

--- a/routes/dashboard/widget-dashboard/test/inserter.test.tsx
+++ b/routes/dashboard/widget-dashboard/test/inserter.test.tsx
@@ -78,19 +78,19 @@ function Harness( {
 }
 
 describe( 'WidgetDashboard.Inserter', () => {
-	it( 'is hidden until the "Add widgets" trigger is clicked', () => {
+	it( 'is hidden until the "Add widget" trigger is clicked', () => {
 		render( <Harness /> );
 		expect(
 			screen.queryByRole( 'dialog', { name: 'Add widget' } )
 		).not.toBeInTheDocument();
 	} );
 
-	it( 'opens after clicking the "Add widgets" trigger', async () => {
+	it( 'opens after clicking the "Add widget" trigger', async () => {
 		const user = userEvent.setup();
 		render( <Harness /> );
 
 		await user.click(
-			screen.getByRole( 'button', { name: 'Add widgets' } )
+			screen.getByRole( 'button', { name: 'Add widget' } )
 		);
 
 		expect(
@@ -104,7 +104,7 @@ describe( 'WidgetDashboard.Inserter', () => {
 		render( <Harness onLayoutChange={ onLayoutChange } /> );
 
 		await user.click(
-			screen.getByRole( 'button', { name: 'Add widgets' } )
+			screen.getByRole( 'button', { name: 'Add widget' } )
 		);
 
 		const dialog = await screen.findByRole( 'dialog', {
@@ -145,7 +145,7 @@ describe( 'WidgetDashboard.Inserter', () => {
 		render( <Harness onLayoutChange={ onLayoutChange } /> );
 
 		await user.click(
-			screen.getByRole( 'button', { name: 'Add widgets' } )
+			screen.getByRole( 'button', { name: 'Add widget' } )
 		);
 
 		const dialog = await screen.findByRole( 'dialog', {
@@ -189,7 +189,7 @@ describe( 'WidgetDashboard.Inserter', () => {
 		);
 
 		await user.click(
-			screen.getByRole( 'button', { name: 'Add widgets' } )
+			screen.getByRole( 'button', { name: 'Add widget' } )
 		);
 
 		const dialog = await screen.findByRole( 'dialog', {

--- a/routes/dashboard/widget-dashboard/test/staging.test.tsx
+++ b/routes/dashboard/widget-dashboard/test/staging.test.tsx
@@ -30,8 +30,8 @@ interface ProbeApi {
 	editMode: boolean;
 	mutate: ( next: DashboardWidget[] ) => void;
 	mutateGridSettings: ( next: WidgetGridSettings ) => void;
-	commit: () => void;
-	cancel: () => void;
+	commit: ( options?: { exitEditMode?: boolean } ) => void;
+	cancel: ( options?: { exitEditMode?: boolean } ) => void;
 }
 
 const probeRef: { current: ProbeApi | null } = { current: null };
@@ -399,5 +399,36 @@ describe( 'WidgetDashboard staging layer', () => {
 			expect( onLayoutChange ).toHaveBeenCalledTimes( 1 );
 			expect( onGridSettingsChange ).not.toHaveBeenCalled();
 		} );
+	} );
+
+	it( 'stays in edit mode when commit or cancel passes exitEditMode: false', () => {
+		const onLayoutChange = jest.fn();
+		render(
+			<Harness
+				layout={ initialLayout }
+				onLayoutChange={ onLayoutChange }
+			/>
+		);
+
+		act( () => {
+			readProbe().mutate( [ initialLayout[ 0 ] ] );
+		} );
+
+		act( () => {
+			readProbe().commit( { exitEditMode: false } );
+		} );
+
+		expect( readProbe().editMode ).toBe( true );
+		expect( onLayoutChange ).toHaveBeenCalledTimes( 1 );
+
+		act( () => {
+			readProbe().mutate( [ initialLayout[ 0 ] ] );
+		} );
+
+		act( () => {
+			readProbe().cancel( { exitEditMode: false } );
+		} );
+
+		expect( readProbe().editMode ).toBe( true );
 	} );
 } );

--- a/routes/dashboard/widget-dashboard/types.ts
+++ b/routes/dashboard/widget-dashboard/types.ts
@@ -278,8 +278,8 @@ export interface WidgetDashboardProps {
 	 * Called when the user commits in-progress grid-settings edits via
 	 * the Done action. The dashboard maintains a staging copy of
 	 * settings internally; mutations stay local until commit. When
-	 * omitted, the customize-mode `Layout` toolbar button is hidden,
-	 * since there is nowhere to persist the change.
+	 * omitted, the `Layout settings` entry in the more-actions menu is
+	 * hidden, since there is nowhere to persist the change.
 	 */
 	onGridSettingsChange?: ( gridSettings: WidgetGridSettings ) => void;
 

--- a/routes/dashboard/widget-dashboard/types.ts
+++ b/routes/dashboard/widget-dashboard/types.ts
@@ -278,8 +278,8 @@ export interface WidgetDashboardProps {
 	 * Called when the user commits in-progress grid-settings edits via
 	 * the Done action. The dashboard maintains a staging copy of
 	 * settings internally; mutations stay local until commit. When
-	 * omitted, the `Layout settings` entry in the more-actions menu is
-	 * hidden, since there is nowhere to persist the change.
+	 * omitted, the customize-mode `Layout` toolbar button is hidden,
+	 * since there is nowhere to persist the change.
 	 */
 	onGridSettingsChange?: ( gridSettings: WidgetGridSettings ) => void;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/77616

Improvements to customise the flow and design of the header:

- Button styles & icons
- Small divider between cancel/done and the rest
- Header title changes while customising
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Elegance and clarity of UI.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
<img width="984" height="165" alt="image" src="https://github.com/user-attachments/assets/3fbf7558-2a37-49a5-a31b-78cf9ac6f469" />

<img width="979" height="168" alt="image" src="https://github.com/user-attachments/assets/351d3a2a-ecb5-4611-8581-ebf1b5f533a9" />

<img width="985" height="152" alt="image" src="https://github.com/user-attachments/assets/a64e6e93-3e81-4860-b644-847e9e3c158a" />



### After
<img width="988" height="150" alt="image" src="https://github.com/user-attachments/assets/ad472441-1f4e-4fa8-9905-d167c7ab019c" />

<img width="979" height="271" alt="image" src="https://github.com/user-attachments/assets/683c1a05-a6df-41b4-acab-581604f3ea81" />

<img width="983" height="161" alt="image" src="https://github.com/user-attachments/assets/6ca618de-c1b4-49c3-944d-a4c94419bde9" />


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
