### PR TITLE
Updated the BlockAttribute typedef to allow for multi-type attributes

### DIFF
--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -135,7 +135,7 @@ export interface BlockVariation<
  * Block attribute definition.
  */
 export interface BlockAttribute {
-	type?: string;
+	type?: string | string[];
 	source?: string;
 	selector?: string;
 	attribute?: string;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #78516

<!-- In a few words, what is the PR actually doing? -->
Adds support for a list of types to be passed to `BlockAttribute['type']`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Block attributes support multiple types. This should be reflected in the typedef.

## How?
I updated the typedef

## Testing Instructions
Run a build? Idk. This is a strictly backwards-compatible addition to the typedef, so there isn't really anything to test

## Use of AI Tools
I don't use AI tools