### PR TITLE
Simplify component ESLint rules and extend to routes/widgets

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/stories/index.story.jsx
+++ b/packages/block-editor/src/components/block-patterns-list/stories/index.story.jsx
@@ -9,6 +9,8 @@ import { fn } from 'storybook/test';
 import BlockPatternsList from '../';
 import { ExperimentalBlockEditorProvider } from '../../provider';
 import patterns from './fixtures';
+// Reason: Styles are contained in ExperimentalBlockEditorProvider iframe.
+// eslint-disable-next-line @wordpress/no-non-module-stylesheet-imports
 import blockLibraryStyles from '../../../../../block-library/build-style/style.css?raw';
 
 const blockEditorSettings = {

--- a/packages/dataviews/src/dataviews-picker/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews-picker/stories/index.story.tsx
@@ -254,6 +254,7 @@ export const WithModal = ( {
 			<Stack direction="row" justify="left" gap="sm">
 				<Button
 					variant="primary"
+					__next40pxDefaultSize
 					onClick={ () => setIsModalOpen( true ) }
 				>
 					Open Picker Modal
@@ -262,6 +263,7 @@ export const WithModal = ( {
 					onClick={ () => setSelectedItems( [] ) }
 					disabled={ ! selectedItems.length }
 					accessibleWhenDisabled
+					__next40pxDefaultSize
 				>
 					Clear Selection
 				</Button>

--- a/packages/dataviews/src/dataviews/stories/free-composition.tsx
+++ b/packages/dataviews/src/dataviews/stories/free-composition.tsx
@@ -174,7 +174,9 @@ export const FreeCompositionComponent = () => {
 						No planets
 					</WCText>
 					<WCText variant="muted">{ `Try a different search because “${ view.search }” returned no results.` }</WCText>
-					<Button variant="secondary">Create new planet</Button>
+					<Button variant="secondary" __next40pxDefaultSize>
+						Create new planet
+					</Button>
 				</Stack>
 			}
 		>

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -139,7 +139,11 @@ function ConnectorsPage() {
 								) }
 							</WCText>
 						</VStack>
-						<Button variant="secondary" href="plugin-install.php">
+						<Button
+							variant="secondary"
+							href="plugin-install.php"
+							__next40pxDefaultSize
+						>
 							{ __( 'Learn more' ) }
 						</Button>
 					</VStack>

--- a/routes/guidelines/components/action-item.tsx
+++ b/routes/guidelines/components/action-item.tsx
@@ -62,6 +62,7 @@ export default function ActionItem( {
 				onClick={ onClick }
 				isBusy={ isBusy }
 				disabled={ disabled }
+				accessibleWhenDisabled
 			>
 				{ buttonLabel }
 			</Button>

--- a/routes/guidelines/components/block-guideline-modal.tsx
+++ b/routes/guidelines/components/block-guideline-modal.tsx
@@ -189,6 +189,7 @@ export default function BlockGuidelineModal( {
 							disabled={ isSaving }
 							accessibleWhenDisabled
 							type="button"
+							__next40pxDefaultSize
 						>
 							{ __( 'Remove' ) }
 						</Button>
@@ -199,6 +200,7 @@ export default function BlockGuidelineModal( {
 						disabled={ ! canSubmit || isSaving }
 						isBusy={ isSaving }
 						accessibleWhenDisabled
+						__next40pxDefaultSize
 					>
 						{ submitButtonLabel }
 					</Button>

--- a/routes/guidelines/components/block-guidelines.tsx
+++ b/routes/guidelines/components/block-guidelines.tsx
@@ -231,7 +231,11 @@ export default function BlockGuidelines() {
 				</DataViews>
 			) }
 			<HStack>
-				<Button variant="primary" onClick={ openModal }>
+				<Button
+					variant="primary"
+					onClick={ openModal }
+					__next40pxDefaultSize
+				>
 					{ __( 'Add guidelines' ) }
 				</Button>
 			</HStack>

--- a/routes/guidelines/components/guideline-accordion-form.tsx
+++ b/routes/guidelines/components/guideline-accordion-form.tsx
@@ -143,6 +143,7 @@ export default function GuidelineAccordionForm( { slug }: { slug: string } ) {
 						disabled={ loading || ! draft }
 						accessibleWhenDisabled
 						isBusy={ loading }
+						__next40pxDefaultSize
 					>
 						{ __( 'Save guidelines' ) }
 					</Button>
@@ -153,6 +154,7 @@ export default function GuidelineAccordionForm( { slug }: { slug: string } ) {
 						accessibleWhenDisabled
 						isBusy={ loading }
 						onClick={ handleClearClick }
+						__next40pxDefaultSize
 					>
 						{ __( 'Clear guidelines' ) }
 					</Button>

--- a/routes/guidelines/components/revision-history.tsx
+++ b/routes/guidelines/components/revision-history.tsx
@@ -258,6 +258,7 @@ export default function RevisionHistory() {
 						<Button
 							variant="tertiary"
 							onClick={ () => setRevisionToRestore( null ) }
+							__next40pxDefaultSize
 						>
 							{ __( 'Cancel' ) }
 						</Button>

--- a/routes/guidelines/components/revision-history.tsx
+++ b/routes/guidelines/components/revision-history.tsx
@@ -267,6 +267,7 @@ export default function RevisionHistory() {
 							onClick={ handleRestore }
 							isBusy={ isRestoring }
 							disabled={ isRestoring }
+							accessibleWhenDisabled
 							__next40pxDefaultSize
 						>
 							{ __( 'Restore' ) }

--- a/routes/navigation-list/add-navigation.tsx
+++ b/routes/navigation-list/add-navigation.tsx
@@ -106,6 +106,7 @@ export const AddNavigationModal = ( {
 						label={ __( 'Name' ) }
 						placeholder={ __( 'Enter menu name' ) }
 						disabled={ isBusy }
+						__next40pxDefaultSize
 					/>
 					<HStack justify="right" spacing={ 2 }>
 						<Button
@@ -113,6 +114,7 @@ export const AddNavigationModal = ( {
 							onClick={ closeModal }
 							disabled={ isBusy }
 							accessibleWhenDisabled
+							__next40pxDefaultSize
 						>
 							{ __( 'Cancel' ) }
 						</Button>
@@ -122,6 +124,7 @@ export const AddNavigationModal = ( {
 							aria-busy={ isBusy }
 							disabled={ isBusy || ! menuTitle?.trim() }
 							accessibleWhenDisabled
+							__next40pxDefaultSize
 						>
 							{ __( 'Create Menu' ) }
 						</Button>

--- a/storybook/stories/design-system/patterns/save-and-submit.story.tsx
+++ b/storybook/stories/design-system/patterns/save-and-submit.story.tsx
@@ -41,6 +41,7 @@ const LayoutCardSaveExample = () => {
 						variant="primary"
 						isBusy
 						style={ { marginTop: '16px' } }
+						__next40pxDefaultSize
 					>
 						Save
 					</Button>

--- a/storybook/stories/playground/fullpage/index.jsx
+++ b/storybook/stories/playground/fullpage/index.jsx
@@ -13,6 +13,8 @@ import '@wordpress/format-library';
 /**
  * Internal dependencies
  */
+// Reason: Styles are injected dynamically.
+// eslint-disable-next-line @wordpress/no-non-module-stylesheet-imports
 import styles from './style.lazy.scss?inline';
 import { editorStyles } from '../editor-styles';
 

--- a/storybook/stories/playground/wp-compat-overlay-slot.story.jsx
+++ b/storybook/stories/playground/wp-compat-overlay-slot.story.jsx
@@ -40,7 +40,11 @@ export const InsideComponentsModal = {
 		const [ isOpen, setIsOpen ] = useState( false );
 		return (
 			<>
-				<Button variant="primary" onClick={ () => setIsOpen( true ) }>
+				<Button
+					variant="primary"
+					onClick={ () => setIsOpen( true ) }
+					__next40pxDefaultSize
+				>
 					Open `@wordpress/components` Modal
 				</Button>
 				{ isOpen && (
@@ -131,6 +135,7 @@ export const InsideComponentsPopover = {
 					ref={ setAnchor }
 					variant="primary"
 					onClick={ () => setIsOpen( ( v ) => ! v ) }
+					__next40pxDefaultSize
 				>
 					Toggle `@wordpress/components` Popover
 				</Button>

--- a/storybook/stories/playground/zoom-out/index.jsx
+++ b/storybook/stories/playground/zoom-out/index.jsx
@@ -11,6 +11,8 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 import { parse } from '@wordpress/blocks';
 import { pattern } from './pattern';
 import { editorStyles } from '../editor-styles';
+// Reason: Styles are contained in BlockCanvas iframe.
+// eslint-disable-next-line @wordpress/no-non-module-stylesheet-imports
 import contentCss from '../../../../packages/block-editor/build-style/content.css?raw';
 
 // Temporary hack to access private APIs before stabilizing zoom level.

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -369,23 +369,6 @@ export default dedupePlugins( [
 		},
 	},
 
-	// Override: Package source files — non-module stylesheets should be
-	// bundled through package stylesheet entry points, not runtime injected.
-	{
-		files: [
-			'packages/*/src/**/*.[tj]s?(x)',
-			'routes/**/*.[tj]s?(x)',
-			'widgets/**/*.[tj]s?(x)',
-		],
-		ignores: [
-			...developmentFiles,
-			'**/*.@(android|ios|native).[tj]s?(x)',
-		],
-		rules: {
-			'@wordpress/no-non-module-stylesheet-imports': 'error',
-		},
-	},
-
 	// Override: Package source files — forbid raw SVG elements.
 	{
 		files: [ 'packages/**/*.js' ],
@@ -415,28 +398,17 @@ export default dedupePlugins( [
 		},
 	},
 
-	// Override: Package src + storybook — restricted syntax + unsafe button disabled.
+	// Override: React src + storybook — stylesheet and component rules.
 	{
 		files: [
 			'packages/*/src/**/*.[tj]s?(x)',
+			'routes/**/*.[tj]s?(x)',
+			'widgets/**/*.[tj]s?(x)',
 			'storybook/stories/**/*.[tj]s?(x)',
 		],
 		ignores: [ '**/*.@(android|ios|native).[tj]s?(x)' ],
 		rules: {
-			'no-restricted-syntax': [ 'error', ...restrictedSyntax ],
-			'@wordpress/components-no-unsafe-button-disabled': 'error',
-		},
-	},
-
-	// Override: Package src (non-test, non-stories, non-native) — add 40px size prop rule.
-	{
-		files: [ 'packages/*/src/**/*.[tj]s?(x)' ],
-		ignores: [
-			'packages/*/src/**/@(test|stories)/**',
-			'**/*.@(android|ios|native).[tj]s?(x)',
-		],
-		rules: {
-			'no-restricted-syntax': [ 'error', ...restrictedSyntax ],
+			'@wordpress/no-non-module-stylesheet-imports': 'error',
 			'@wordpress/components-no-unsafe-button-disabled': 'error',
 			'@wordpress/components-no-missing-40px-size-prop': 'error',
 		},

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -49,6 +49,11 @@
 			"count": 1
 		}
 	},
+	"packages/block-editor/src/components/block-patterns-list/stories/index.story.jsx": {
+		"@wordpress/no-non-module-stylesheet-imports": {
+			"count": 1
+		}
+	},
 	"packages/block-editor/src/components/block-patterns-paging/index.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 3
@@ -667,6 +672,11 @@
 			"count": 3
 		}
 	},
+	"packages/components/src/navigation/stories/index.story.tsx": {
+		"@wordpress/no-non-module-stylesheet-imports": {
+			"count": 1
+		}
+	},
 	"packages/components/src/number-control/index.tsx": {
 		"react-hooks/refs": {
 			"count": 2
@@ -808,6 +818,11 @@
 	"packages/dataviews/src/dataviews/stories/free-composition.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 2
+		}
+	},
+	"packages/dataviews/src/dataviews/stories/index.story.tsx": {
+		"@wordpress/no-non-module-stylesheet-imports": {
+			"count": 1
 		}
 	},
 	"packages/dataviews/src/dataviews/stories/layout-activity.tsx": {
@@ -1517,6 +1532,9 @@
 		}
 	},
 	"packages/image-cropper/src/stories/index.story.tsx": {
+		"@wordpress/no-non-module-stylesheet-imports": {
+			"count": 1
+		},
 		"@wordpress/use-recommended-components": {
 			"count": 3
 		}
@@ -1527,6 +1545,11 @@
 		}
 	},
 	"packages/lazy-editor/src/components/preview/index.tsx": {
+		"@wordpress/no-non-module-stylesheet-imports": {
+			"count": 1
+		}
+	},
+	"packages/media-editor/src/components/rotation-ruler/stories/index.story.tsx": {
 		"@wordpress/no-non-module-stylesheet-imports": {
 			"count": 1
 		}
@@ -1554,6 +1577,11 @@
 	"packages/media-editor/src/image-editor/react/hooks/use-interaction.ts": {
 		"react-hooks/refs": {
 			"count": 5
+		}
+	},
+	"packages/media-editor/src/image-editor/stories/rectangle-crop.story.tsx": {
+		"@wordpress/no-non-module-stylesheet-imports": {
+			"count": 1
 		}
 	},
 	"packages/media-fields/src/author/view.tsx": {
@@ -1835,6 +1863,26 @@
 			"count": 1
 		},
 		"@wordpress/use-recommended-components": {
+			"count": 1
+		}
+	},
+	"storybook/stories/playground/box/index.jsx": {
+		"@wordpress/no-non-module-stylesheet-imports": {
+			"count": 1
+		}
+	},
+	"storybook/stories/playground/fullpage/index.jsx": {
+		"@wordpress/no-non-module-stylesheet-imports": {
+			"count": 1
+		}
+	},
+	"storybook/stories/playground/with-undo-redo/index.jsx": {
+		"@wordpress/no-non-module-stylesheet-imports": {
+			"count": 1
+		}
+	},
+	"storybook/stories/playground/zoom-out/index.jsx": {
+		"@wordpress/no-non-module-stylesheet-imports": {
 			"count": 1
 		}
 	}

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -49,11 +49,6 @@
 			"count": 1
 		}
 	},
-	"packages/block-editor/src/components/block-patterns-list/stories/index.story.jsx": {
-		"@wordpress/no-non-module-stylesheet-imports": {
-			"count": 1
-		}
-	},
 	"packages/block-editor/src/components/block-patterns-paging/index.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 3
@@ -1549,11 +1544,6 @@
 			"count": 1
 		}
 	},
-	"packages/media-editor/src/components/rotation-ruler/stories/index.story.tsx": {
-		"@wordpress/no-non-module-stylesheet-imports": {
-			"count": 1
-		}
-	},
 	"packages/media-editor/src/components/media-editor/index.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
@@ -1561,6 +1551,11 @@
 	},
 	"packages/media-editor/src/components/media-form/index.tsx": {
 		"@wordpress/use-recommended-components": {
+			"count": 1
+		}
+	},
+	"packages/media-editor/src/components/rotation-ruler/stories/index.story.tsx": {
+		"@wordpress/no-non-module-stylesheet-imports": {
 			"count": 1
 		}
 	},
@@ -1871,17 +1866,7 @@
 			"count": 1
 		}
 	},
-	"storybook/stories/playground/fullpage/index.jsx": {
-		"@wordpress/no-non-module-stylesheet-imports": {
-			"count": 1
-		}
-	},
 	"storybook/stories/playground/with-undo-redo/index.jsx": {
-		"@wordpress/no-non-module-stylesheet-imports": {
-			"count": 1
-		}
-	},
-	"storybook/stories/playground/zoom-out/index.jsx": {
 		"@wordpress/no-non-module-stylesheet-imports": {
 			"count": 1
 		}


### PR DESCRIPTION
## What?

Inspired by #78496

Consolidates and extends ESLint overrides for `@wordpress/components` button rules and non-module stylesheet imports to `routes/`, `widgets/`, and Storybook stories, alongside `packages/*/src/`.

## Why?

The stylesheet and component button rules were split across multiple overrides and only covered package source (with tests/stories excluded from the 40px rule). Routes and widgets use the same components and should follow the same lint constraints.

## How?

- Merges the separate stylesheet and component-button overrides into a single block in `tools/eslint/config.mjs`.
- Adds `routes/**` and `widgets/**` to the shared file globs.
- Drops redundant `no-restricted-syntax` from the override (already enforced globally).
- Applies the same rules to tests, stories, and Storybook files (no `developmentFiles` ignore in this block) — technically, we don't need to lint "development" files, but we do want to lint Storybook here, and in practice we're currently fine to not exclude `developmentFiles`.
- Fixes new violations in routes and stories by adding `__next40pxDefaultSize` and `accessibleWhenDisabled` where needed — these should be safe.
- Suppresses remaining `@wordpress/no-non-module-stylesheet-imports` violations in story files that import plain CSS for Storybook demos — these are low priority, but the violations were either architecturally problematic or prone to style leaks into other stories, breaking the isolation benefits of Storybook.

## Testing Instructions

Linter should pass.