### PR TITLE
UI: Update Autocomplete clear disabled state

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -19,6 +19,7 @@
 -   `IconButton`: Default `focusableWhenDisabled` to `true`, matching `Button` ([#78526](https://github.com/WordPress/gutenberg/pull/78526)).
 -   `Button`: Do not show the interactive cursor when disabled ([#78479](https://github.com/WordPress/gutenberg/pull/78479)).
 -   `Autocomplete`: Fix the TypeScript prop types for the `Root` and `Value` primitives ([#78450](https://github.com/WordPress/gutenberg/pull/78450)).
+-   `Autocomplete`: Disable the clear button when the autocomplete is disabled, and hide it from assistive technologies ([#78520](https://github.com/WordPress/gutenberg/pull/78520)).
 -   Apply shared item popup typography to inline lists and empty states ([#78403](https://github.com/WordPress/gutenberg/pull/78403)).
 -   Stretch the compat overlay slot to viewport size so portaled popups stop collapsing to their min-content width — most visible on long-text tooltips, which wrapped to one word per line ([#78441](https://github.com/WordPress/gutenberg/pull/78441)).
 

--- a/packages/ui/src/form/primitives/autocomplete/clear.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/clear.tsx
@@ -5,12 +5,18 @@ import { __ } from '@wordpress/i18n';
 import { IconButton } from '../../../icon-button';
 import type { AutocompleteClearProps } from './types';
 
-const DEFAULT_RENDER = ( {
-	'aria-label': ariaLabel = __( 'Clear' ),
-	...props
-}: AutocompleteClearProps ) => (
+const DEFAULT_RENDER = (
+	{
+		'aria-label': ariaLabel = __( 'Clear' ),
+		...props
+	}: AutocompleteClearProps,
+	{ disabled }: _Autocomplete.Clear.State
+) => (
 	<IconButton
 		icon={ closeSmall }
+		focusableWhenDisabled={ false }
+		disabled={ disabled }
+		aria-hidden={ disabled || undefined }
 		size="small"
 		variant="minimal"
 		tone="neutral"

--- a/packages/ui/src/form/primitives/autocomplete/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/test/index.test.tsx
@@ -11,6 +11,15 @@ const ITEMS = [
 	{ id: '3', value: 'Item 3' },
 ];
 
+function renderDisabledAutocompleteWithClear() {
+	return render(
+		<Autocomplete.Root items={ ITEMS } disabled defaultValue="Item 1">
+			<Autocomplete.Input placeholder="Search" />
+			<Autocomplete.Clear />
+		</Autocomplete.Root>
+	);
+}
+
 describe( 'Autocomplete', () => {
 	it( 'forwards ref', async () => {
 		const user = userEvent.setup();
@@ -347,4 +356,26 @@ describe( 'Autocomplete', () => {
 		} );
 	} );
 	/* eslint-enable testing-library/no-node-access */
+
+	describe( 'when disabled', () => {
+		it( 'hides the clear button from screen readers', () => {
+			renderDisabledAutocompleteWithClear();
+
+			expect(
+				screen.queryByRole( 'button', { name: 'Clear' } )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'does not show a tooltip when the clear button is hovered', async () => {
+			const user = userEvent.setup( { pointerEventsCheck: 0 } );
+			renderDisabledAutocompleteWithClear();
+
+			const clearButton = screen.getByLabelText( 'Clear', {
+				selector: 'button',
+			} );
+			await user.hover( clearButton );
+
+			expect( screen.queryByRole( 'tooltip' ) ).not.toBeInTheDocument();
+		} );
+	} );
 } );


### PR DESCRIPTION
## What?

Related to #78526 (a bug that was hiding this Autocomplete issue)

Updates the `Autocomplete.Clear` primitive so its disabled state follows the disabled autocomplete state.

## Why?
When an autocomplete is disabled, its clear button should not remain an active or focusable affordance. It should also not expose a tooltip or screen-reader-accessible control for an action that cannot be used.

## How?
Passes the Base UI clear-button disabled state through to the `IconButton`, disables focusable-when-disabled behavior, and hides the disabled clear button from assistive technologies.

Adds tests to verify the disabled clear button is not exposed as an accessible button and that hovering it does not show a tooltip.

Implementation now [matches](https://github.com/WordPress/gutenberg/pull/78399/changes#diff-71aeb38fd5e56ac6fe2b3eea1191c2aee6b65001a95883e65548f2869c0ac9f4) the `Combobox` clear button.

## Testing Instructions
1. Open the "With Search Icon And Clear Button" story, and type something in the input to show the clear button.
1. Verify the clear button works when the autocomplete is enabled.
1. Disable the autocomplete and verify the clear button is disabled and does not show a tooltip on hover.