### PR TITLE
Edit Site: Consume preload cache before React mount

### DIFF
--- a/lib/compat/wordpress-7.0/preload.php
+++ b/lib/compat/wordpress-7.0/preload.php
@@ -27,6 +27,28 @@ function gutenberg_block_editor_preload_paths_6_9( $paths, $context ) {
 		// editor doesn't. Adding it here lets the site-editor boot
 		// kickoff fully consume from cache.
 		$paths[] = '/wp/v2/taxonomies?context=view';
+
+		// Site editor's page-edit context (`?p=/page/{id}`). Mount-time
+		// consumers of these URLs:
+		//
+		// - `post-actions/actions.js` calls
+		//   `getDefaultTemplateId({ slug: 'front-page' })` to gate
+		//   homepage-specific actions for any page.
+		// - `post-template/hooks.js` calls
+		//   `getDefaultTemplateId({ slug: 'page' })` when the page has no
+		//   slug. (For named pages it fires `page-{slug}`, already added
+		//   by core's `site-editor.php`.)
+		// - `getPostType('page')` fires from publish panel / preview
+		//   button / others; core preloads `/wp/v2/types?context=view`
+		//   but not the per-type record.
+		if (
+			isset( $context->post ) &&
+			'page' === $context->post->post_type
+		) {
+			$paths[] = '/wp/v2/templates/lookup?slug=front-page';
+			$paths[] = '/wp/v2/templates/lookup?slug=page';
+			$paths[] = '/wp/v2/types/page?context=edit';
+		}
 	}
 
 	return $paths;

--- a/lib/compat/wordpress-7.0/preload.php
+++ b/lib/compat/wordpress-7.0/preload.php
@@ -34,19 +34,18 @@ function gutenberg_block_editor_preload_paths_6_9( $paths, $context ) {
 		// - `post-actions/actions.js` calls
 		//   `getDefaultTemplateId({ slug: 'front-page' })` to gate
 		//   homepage-specific actions for any page.
-		// - `post-template/hooks.js` calls
-		//   `getDefaultTemplateId({ slug: 'page' })` when the page has no
-		//   slug. (For named pages it fires `page-{slug}`, already added
-		//   by core's `site-editor.php`.)
 		// - `getPostType('page')` fires from publish panel / preview
 		//   button / others; core preloads `/wp/v2/types?context=view`
 		//   but not the per-type record.
+		//
+		// Note: core's `site-editor.php` already preloads the per-slug
+		// template lookup (`slug=page` for unnamed, `slug=page-{name}`
+		// for named) — handled in the kickoff's phase 3.
 		if (
 			isset( $context->post ) &&
 			'page' === $context->post->post_type
 		) {
 			$paths[] = '/wp/v2/templates/lookup?slug=front-page';
-			$paths[] = '/wp/v2/templates/lookup?slug=page';
 			$paths[] = '/wp/v2/types/page?context=edit';
 		}
 	}

--- a/lib/compat/wordpress-7.0/preload.php
+++ b/lib/compat/wordpress-7.0/preload.php
@@ -21,6 +21,12 @@ function gutenberg_block_editor_preload_paths_6_9( $paths, $context ) {
 				}
 			);
 		}
+
+		// `getEntitiesConfig('postType')` chains into a taxonomies fetch
+		// when collaboration is enabled. Post-editor preloads this; site
+		// editor doesn't. Adding it here lets the site-editor boot
+		// kickoff fully consume from cache.
+		$paths[] = '/wp/v2/taxonomies?context=view';
 	}
 
 	return $paths;

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -1032,10 +1032,15 @@ export const getDefaultTemplateId =
 	};
 
 getDefaultTemplateId.shouldInvalidate = ( action ) => {
+	// Only invalidate on an actual site-settings update — `persistedEdits`
+	// is set on save responses, not on initial fetches, so distinguishing
+	// the two keeps the kickoff from invalidating its own just-resolved
+	// template id when the site record is received for the first time.
 	return (
 		action.type === 'RECEIVE_ITEMS' &&
 		action.kind === 'root' &&
-		action.name === 'site'
+		action.name === 'site' &&
+		!! action.persistedEdits
 	);
 };
 

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -232,16 +232,12 @@ async function preloadResolutions() {
 				} )
 			);
 		}
-		if ( tasks.length ) {
-			await Promise.all( tasks );
-		}
-
-		// Phase 3: the page's per-slug template lookup needs the page
-		// record from phase 2. Mirrors the slug formula in
-		// `post-template/hooks.js`: `page-{slug}` for named pages,
-		// `page` for unnamed (drafts). Core's `site-editor.php`
-		// preloads the matching variant.
 		if ( pageId ) {
+			// The page's per-slug template lookup needs the resolved
+			// page record. Mirrors the slug formula in
+			// `post-template/hooks.js`: `page-{slug}` for named pages,
+			// `page` for unnamed (drafts). Core's `site-editor.php`
+			// preloads the matching variant.
 			const page = coreSelect.getEntityRecord(
 				'postType',
 				'page',
@@ -249,8 +245,11 @@ async function preloadResolutions() {
 			);
 			if ( page ) {
 				const slug = page.slug ? `page-${ page.slug }` : 'page';
-				await core.getDefaultTemplateId( { slug } );
+				tasks.push( core.getDefaultTemplateId( { slug } ) );
 			}
+		}
+		if ( tasks.length ) {
+			await Promise.all( tasks );
 		}
 	} catch {
 		// Resolver failures here would also surface on demand; don't block render.

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -201,9 +201,24 @@ async function preloadResolutions() {
 						core.getDefaultTemplateId( { slug: 'home' } ),
 				  ]
 				: [] ),
+			...( pageId
+				? [
+						core.getEntityRecord( 'postType', 'page', pageId ),
+						// `getPostType( getEditedPostAttribute( 'type' ) )`
+						// fires across many post-editor components
+						// (publish panel, preview button, ...).
+						core.getPostType( 'page' ),
+						// `shouldShowHomepageActions` in
+						// `post-actions/actions.js` calls
+						// `getDefaultTemplateId({ slug: 'front-page' })`
+						// for every page being edited, to decide whether
+						// to surface homepage-specific actions.
+						core.getDefaultTemplateId( { slug: 'front-page' } ),
+				  ]
+				: [] ),
 		] );
 
-		// Phase 2: theme-derived resolvers that need phase-1 state.
+		// Phase 2: derived resolvers that need phase-1 state.
 		const tasks = [];
 		const globalStylesId =
 			coreSelect.__experimentalGetCurrentGlobalStylesId();
@@ -215,22 +230,6 @@ async function preloadResolutions() {
 					name: 'globalStyles',
 					id: globalStylesId,
 				} )
-			);
-		}
-		if ( pageId ) {
-			tasks.push(
-				core.getEntityRecord( 'postType', 'page', pageId ),
-				// `getPostType( getEditedPostAttribute( 'type' ) )` fires
-				// across many post-editor components (publish panel,
-				// preview button, ...). Kicked off here so it's served
-				// from the preload cache on first mount.
-				core.getPostType( 'page' ),
-				// `shouldShowHomepageActions` in `post-actions/actions.js`
-				// calls `getDefaultTemplateId({ slug: 'front-page' })` for
-				// every page being edited, to decide whether to surface
-				// homepage-specific actions. Always preloaded for the
-				// page-edit context.
-				core.getDefaultTemplateId( { slug: 'front-page' } )
 			);
 		}
 		if ( tasks.length ) {

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -7,7 +7,7 @@ import {
 	__experimentalGetCoreBlocks,
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
-import { dispatch } from '@wordpress/data';
+import { dispatch, resolveSelect, select } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { createRoot, StrictMode } from '@wordpress/element';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
@@ -16,6 +16,8 @@ import {
 	registerLegacyWidgetBlock,
 	registerWidgetGroupBlock,
 } from '@wordpress/widgets';
+import { store as coreDataStore } from '@wordpress/core-data';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -25,6 +27,10 @@ import { unlock } from './lock-unlock';
 import App from './components/app';
 
 const { registerCoreBlockBindingsSources } = unlock( editorPrivateApis );
+
+const { enablePreloadMultiUse, clearPreloadedData } = unlock(
+	apiFetch.privateApis
+);
 
 /**
  * Initializes the site editor screen.
@@ -90,13 +96,141 @@ export function initializeEditor( id, settings ) {
 	window.addEventListener( 'dragover', ( e ) => e.preventDefault(), false );
 	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
 
-	root.render(
-		<StrictMode>
-			<App />
-		</StrictMode>
-	);
+	// Drive the resolvers whose data `createPreloadingMiddleware`
+	// already has cached so every metadata entry they touch is
+	// `finished` by the time React mounts — no `setTimeout(0)`
+	// resolution dance on first render. Multi-use lets a single
+	// preloaded URL back several selectors (e.g. /wp/v2/settings GET +
+	// OPTIONS serves `getEntitiesConfig`, `canUser`, `getEntityRecord`).
+	enablePreloadMultiUse();
+	const preloadedResolutions = preloadResolutions();
+
+	preloadedResolutions.finally( () => {
+		// Anything not consumed by the kickoff falls through to a real
+		// network request from here on. `clearPreloadedData` logs which
+		// preload entries (if any) were never served.
+		clearPreloadedData();
+		root.render(
+			<StrictMode>
+				<App />
+			</StrictMode>
+		);
+	} );
 
 	return root;
+}
+
+/**
+ * Drive the post-agnostic resolvers to completion against the preload
+ * cache before React mounts. The site editor's current entity is
+ * derived from the URL after mount, so per-entity resolvers aren't
+ * kicked off here.
+ *
+ * @return {Promise<void>} Resolves when the kickoff resolvers settle.
+ */
+async function preloadResolutions() {
+	const core = resolveSelect( coreDataStore );
+	const coreSelect = select( coreDataStore );
+
+	// `gutenberg_block_editor_preload_paths_6_9` only ships the
+	// front-page / home template lookups when the site editor is on the
+	// root screen. Mirror that filter here so we don't fire them as real
+	// network requests when they aren't preloaded.
+	const params = new URLSearchParams( window.location.search );
+	const routeParam = params.get( 'p' );
+	const isRootScreen = routeParam === null || routeParam === '/';
+	// When editing a specific page (`p=/page&postId=…`), the server
+	// preloads the page record and its template lookup. Pick those up
+	// in a second phase once the postType entity config has resolved.
+	const pageId =
+		routeParam === '/page' ? Number( params.get( 'postId' ) ) : null;
+
+	try {
+		await Promise.all( [
+			core.getEntitiesConfig( 'postType' ),
+			core.getEntitiesConfig( 'taxonomy' ),
+			core.getEntitiesConfig( 'root' ),
+			core.getCurrentTheme(),
+			// Forward-resolver alias of `getCurrentTheme` with its own
+			// resolution metadata, so it needs a separate kick.
+			core.getThemeSupports(),
+			core.getBlockPatternCategories(),
+			core.__experimentalGetCurrentGlobalStylesId(),
+			core.__experimentalGetCurrentThemeBaseGlobalStyles(),
+			core.__experimentalGetCurrentThemeGlobalStylesVariations(),
+			core.getEntityRecord( 'root', '__unstableBase' ),
+			core.getEntityRecord( 'root', 'site' ),
+			core.canUser( 'read', { kind: 'root', name: 'site' } ),
+			core.canUser( 'create', { kind: 'postType', name: 'attachment' } ),
+			core.canUser( 'create', { kind: 'postType', name: 'page' } ),
+			core.canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_navigation',
+			} ),
+			// Editor code calls `getPostType( name )` everywhere, not
+			// `getEntityRecord( 'root', 'postType', name )`. The
+			// shorthand has its own resolution metadata.
+			core.getPostType( 'wp_template' ),
+			core.getPostType( 'wp_template_part' ),
+			core.getEntityRecords( 'postType', 'wp_template', {
+				per_page: -1,
+			} ),
+			core.getEntityRecords( 'postType', 'wp_template_part', {
+				per_page: -1,
+			} ),
+			core.getEntityRecords( 'postType', 'wp_navigation', {
+				context: 'edit',
+				order: 'desc',
+				orderby: 'date',
+				per_page: 100,
+				status: [ 'publish', 'draft' ],
+			} ),
+			...( isRootScreen
+				? [
+						core.getDefaultTemplateId( { slug: 'front-page' } ),
+						core.getDefaultTemplateId( { slug: 'home' } ),
+				  ]
+				: [] ),
+		] );
+
+		// Phase 2: theme-derived resolvers that need phase-1 state.
+		const tasks = [];
+		const globalStylesId =
+			coreSelect.__experimentalGetCurrentGlobalStylesId();
+		if ( globalStylesId ) {
+			tasks.push(
+				core.getEntityRecord( 'root', 'globalStyles', globalStylesId ),
+				core.canUser( 'read', {
+					kind: 'root',
+					name: 'globalStyles',
+					id: globalStylesId,
+				} )
+			);
+		}
+		if ( pageId ) {
+			tasks.push( core.getEntityRecord( 'postType', 'page', pageId ) );
+		}
+		if ( tasks.length ) {
+			await Promise.all( tasks );
+		}
+
+		// Phase 3: the page's per-slug template lookup needs the page
+		// record from phase 2.
+		if ( pageId ) {
+			const page = coreSelect.getEntityRecord(
+				'postType',
+				'page',
+				pageId
+			);
+			if ( page?.slug ) {
+				await core.getDefaultTemplateId( {
+					slug: `page-${ page.slug }`,
+				} );
+			}
+		}
+	} catch {
+		// Resolver failures here would also surface on demand; don't block render.
+	}
 }
 
 export function reinitializeEditor() {

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -218,7 +218,25 @@ async function preloadResolutions() {
 			);
 		}
 		if ( pageId ) {
-			tasks.push( core.getEntityRecord( 'postType', 'page', pageId ) );
+			tasks.push(
+				core.getEntityRecord( 'postType', 'page', pageId ),
+				// `getPostType( getEditedPostAttribute( 'type' ) )` fires
+				// across many post-editor components (publish panel,
+				// preview button, ...). Kicked off here so it's served
+				// from the preload cache on first mount.
+				core.getPostType( 'page' ),
+				// `shouldShowHomepageActions` in `post-actions/actions.js`
+				// calls `getDefaultTemplateId({ slug: 'front-page' })` for
+				// every page being edited, to decide whether to surface
+				// homepage-specific actions. Always preloaded for the
+				// page-edit context.
+				core.getDefaultTemplateId( { slug: 'front-page' } ),
+				// `post-template/hooks.js` calls
+				// `getDefaultTemplateId({ slug: 'page' })` when the page
+				// has no slug (drafts / unnamed). For named pages it
+				// instead fires `page-{slug}` — handled in phase 3 below.
+				core.getDefaultTemplateId( { slug: 'page' } )
+			);
 		}
 		if ( tasks.length ) {
 			await Promise.all( tasks );

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -18,6 +18,7 @@ import {
 } from '@wordpress/widgets';
 import { store as coreDataStore } from '@wordpress/core-data';
 import apiFetch from '@wordpress/api-fetch';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
  * Internal dependencies
@@ -25,8 +26,10 @@ import apiFetch from '@wordpress/api-fetch';
 import { store as editSiteStore } from './store';
 import { unlock } from './lock-unlock';
 import App from './components/app';
+import { pageItemRoute } from './components/site-editor-routes/page-item';
 
 const { registerCoreBlockBindingsSources } = unlock( editorPrivateApis );
+const { recognizePath } = unlock( routerPrivateApis );
 
 const { enablePreloadMultiUse, clearPreloadedData } = unlock(
 	apiFetch.privateApis
@@ -139,11 +142,18 @@ async function preloadResolutions() {
 	const params = new URLSearchParams( window.location.search );
 	const routeParam = params.get( 'p' );
 	const isRootScreen = routeParam === null || routeParam === '/';
-	// When editing a specific page (`p=/page&postId=…`), the server
-	// preloads the page record and its template lookup. Pick those up
-	// in a second phase once the postType entity config has resolved.
-	const pageId =
-		routeParam === '/page' ? Number( params.get( 'postId' ) ) : null;
+	// When editing a specific page (`p=/page/N`), the server preloads
+	// the page record and its template lookup. Pick those up in a
+	// second phase once the postType entity config has resolved. The
+	// match runs the same `:postId` parsing the post-mount router
+	// uses, but pre-mount so the kickoff can drive the resolver.
+	const pageMatch =
+		routeParam !== null
+			? recognizePath( [ pageItemRoute ], routeParam )
+			: undefined;
+	const pageId = pageMatch?.params?.postId
+		? Number( pageMatch.params.postId )
+		: null;
 
 	try {
 		await Promise.all( [

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -230,12 +230,7 @@ async function preloadResolutions() {
 				// every page being edited, to decide whether to surface
 				// homepage-specific actions. Always preloaded for the
 				// page-edit context.
-				core.getDefaultTemplateId( { slug: 'front-page' } ),
-				// `post-template/hooks.js` calls
-				// `getDefaultTemplateId({ slug: 'page' })` when the page
-				// has no slug (drafts / unnamed). For named pages it
-				// instead fires `page-{slug}` — handled in phase 3 below.
-				core.getDefaultTemplateId( { slug: 'page' } )
+				core.getDefaultTemplateId( { slug: 'front-page' } )
 			);
 		}
 		if ( tasks.length ) {
@@ -243,17 +238,19 @@ async function preloadResolutions() {
 		}
 
 		// Phase 3: the page's per-slug template lookup needs the page
-		// record from phase 2.
+		// record from phase 2. Mirrors the slug formula in
+		// `post-template/hooks.js`: `page-{slug}` for named pages,
+		// `page` for unnamed (drafts). Core's `site-editor.php`
+		// preloads the matching variant.
 		if ( pageId ) {
 			const page = coreSelect.getEntityRecord(
 				'postType',
 				'page',
 				pageId
 			);
-			if ( page?.slug ) {
-				await core.getDefaultTemplateId( {
-					slug: `page-${ page.slug }`,
-				} );
+			if ( page ) {
+				const slug = page.slug ? `page-${ page.slug }` : 'page';
+				await core.getDefaultTemplateId( { slug } );
 			}
 		}
 	} catch {

--- a/packages/router/src/private-apis.ts
+++ b/packages/router/src/private-apis.ts
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import { useHistory, useLocation, RouterProvider } from './router';
+import {
+	useHistory,
+	useLocation,
+	RouterProvider,
+	recognizePath,
+} from './router';
 import { useLink, Link } from './link';
 import { lock } from './lock-unlock';
 
@@ -12,4 +17,5 @@ lock( privateApis, {
 	RouterProvider,
 	useLink,
 	Link,
+	recognizePath,
 } );

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -107,7 +107,9 @@ export function recognizePath(
 			as: route.name,
 		} );
 	}
-	return matcher.recognize( path )?.[ 0 ];
+	return matcher.recognize( path )?.[ 0 ] as
+		| { params?: Record< string, string > }
+		| undefined;
 }
 
 export function useLocation() {

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -87,6 +87,29 @@ function getLocationWithQuery() {
 	return locationWithQuery;
 }
 
+/**
+ * Recognize a path against a set of route definitions. Mirrors the
+ * matching the `RouterProvider` does at render time, but is callable
+ * outside the React tree (e.g. from a pre-mount kickoff) so the same
+ * `:param` patterns can drive route-aware logic before mount.
+ *
+ * @param routes Route definitions to recognize against.
+ * @param path   Path to match (no query string).
+ * @return The first matching route's params, or `undefined` if no match.
+ */
+export function recognizePath(
+	routes: { name: string; path: string }[],
+	path: string
+): { params?: Record< string, string > } | undefined {
+	const matcher = new RouteRecognizer();
+	for ( const route of routes ) {
+		matcher.add( [ { path: route.path, handler: {} } ], {
+			as: route.name,
+		} );
+	}
+	return matcher.recognize( path )?.[ 0 ];
+}
+
 export function useLocation() {
 	const context = useContext( RoutesContext );
 	if ( ! context ) {

--- a/test/e2e/specs/preload/site-editor.spec.js
+++ b/test/e2e/specs/preload/site-editor.spec.js
@@ -9,17 +9,9 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 const { recordRequests } = require( './record-requests' );
 
 test.describe( 'Preload', () => {
-	let pageId;
-
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.resetPreferences();
-		const pg = await requestUtils.createPage( {
-			content:
-				'<!-- wp:heading -->\n<h2 class="wp-block-heading">Hello</h2>\n<!-- /wp:heading -->',
-			status: 'publish',
-		} );
-		pageId = pg.id;
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
@@ -75,62 +67,73 @@ test.describe( 'Preload', () => {
 		);
 	} );
 
-	test( 'Editing a page should fetch a known set of routes during startup', async ( {
-		page,
-		admin,
-	} ) => {
-		const { requests, stop } = recordRequests( page );
-		const { requests: requestsUntilMount, stop: stopOnMount } =
-			recordRequests( page );
+	for ( const status of [ 'draft', 'publish' ] ) {
+		test( `Editing a ${
+			status === 'publish' ? 'published' : 'draft'
+		} page should fetch a known set of routes during startup`, async ( {
+			page,
+			admin,
+			requestUtils,
+		} ) => {
+			const pg = await requestUtils.createPage( {
+				title:
+					status === 'publish' ? 'Published preload page' : undefined,
+				content:
+					'<!-- wp:heading -->\n<h2 class="wp-block-heading">Hello</h2>\n<!-- /wp:heading -->',
+				status,
+			} );
+			const pageId = pg.id;
+			const { requests, stop } = recordRequests( page );
+			const { requests: requestsUntilMount, stop: stopOnMount } =
+				recordRequests( page );
 
-		let preloadStatus;
-		page.on( 'console', ( msg ) => {
-			const text = msg.text();
-			if ( text.startsWith( '[api-fetch][preload] ' ) ) {
-				preloadStatus = text;
-				stopOnMount();
-			}
+			let preloadStatus;
+			page.on( 'console', ( msg ) => {
+				const text = msg.text();
+				if ( text.startsWith( '[api-fetch][preload] ' ) ) {
+					preloadStatus = text;
+					stopOnMount();
+				}
+			} );
+
+			await admin.visitSiteEditor( {
+				postId: pageId,
+				postType: 'page',
+				canvas: 'edit',
+			} );
+			await page
+				.frameLocator( 'iframe[name="editor-canvas"]' )
+				.getByRole( 'document', { name: 'Block: Heading' } )
+				.filter( { hasText: 'Hello' } )
+				.waitFor();
+			// eslint-disable-next-line playwright/no-networkidle
+			await page.waitForLoadState( 'networkidle' );
+			stop();
+
+			// Everything the kickoff touches is served by the preload cache.
+			expect(
+				Array.from( new Set( requestsUntilMount ) ).sort()
+			).toEqual( [] );
+			expect( preloadStatus ).toBe(
+				'[api-fetch][preload] All preloads consumed.'
+			);
+
+			// `POST /wp/v2/users/me` (preferences persistence) occasionally
+			// fires twice within the captured window; the duplicate count
+			// isn't stable across runs, so this assertion deduplicates.
+			// To do: these should all be removed or preloaded.
+			expect( Array.from( new Set( requests ) ).sort() ).toEqual(
+				[
+					`GET /wp/v2/comments?context=edit&post=${ pageId }&type=note&status=all&per_page=100`,
+					`GET /wp/v2/pages/${ pageId }/autosaves?context=edit`,
+					'GET /wp/v2/taxonomies?context=edit&per_page=100',
+					'GET /wp/v2/users/1?context=view&_fields=id%2Cname',
+					'GET /wp/v2/users/me',
+					'GET /wp/v2/wp_pattern_category?context=view&per_page=100&_fields=id%2Cname%2Cdescription%2Cslug',
+					'OPTIONS /wp/v2/templates',
+					'POST /wp/v2/users/me',
+				].sort()
+			);
 		} );
-
-		await admin.visitAdminPage(
-			'site-editor.php',
-			`p=%2Fpage&postId=${ pageId }&canvas=edit`
-		);
-		await page
-			.frameLocator( 'iframe[name="editor-canvas"]' )
-			.getByRole( 'document', { name: 'Block: Heading' } )
-			.filter( { hasText: 'Hello' } )
-			.waitFor();
-		// eslint-disable-next-line playwright/no-networkidle
-		await page.waitForLoadState( 'networkidle' );
-		stop();
-
-		// Everything the kickoff touches is served by the preload cache.
-		expect( Array.from( new Set( requestsUntilMount ) ).sort() ).toEqual(
-			[]
-		);
-		expect( preloadStatus ).toBe(
-			'[api-fetch][preload] All preloads consumed.'
-		);
-
-		// `POST /wp/v2/users/me` (preferences persistence) occasionally
-		// fires twice within the captured window; the duplicate count
-		// isn't stable across runs, so this assertion deduplicates.
-		// To do: these should all be removed or preloaded.
-		expect( Array.from( new Set( requests ) ).sort() ).toEqual(
-			[
-				`GET /wp/v2/comments?context=edit&post=${ pageId }&type=note&status=all&per_page=100`,
-				`GET /wp/v2/pages/${ pageId }/autosaves?context=edit`,
-				'GET /wp/v2/taxonomies?context=edit&per_page=100',
-				'GET /wp/v2/templates/lookup?slug=front-page',
-				'GET /wp/v2/types/page?context=edit',
-				'GET /wp/v2/users/1?context=view&_fields=id%2Cname',
-				'GET /wp/v2/users/me',
-				'GET /wp/v2/view-config?kind=postType&name=page',
-				'GET /wp/v2/wp_pattern_category?context=view&per_page=100&_fields=id%2Cname%2Cdescription%2Cslug',
-				'OPTIONS /wp/v2/templates',
-				'POST /wp/v2/users/me',
-			].sort()
-		);
-	} );
+	}
 } );

--- a/test/e2e/specs/preload/site-editor.spec.js
+++ b/test/e2e/specs/preload/site-editor.spec.js
@@ -32,6 +32,17 @@ test.describe( 'Preload', () => {
 		admin,
 	} ) => {
 		const { requests, stop } = recordRequests( page );
+		const { requests: requestsUntilMount, stop: stopOnMount } =
+			recordRequests( page );
+
+		let preloadStatus;
+		page.on( 'console', ( msg ) => {
+			const text = msg.text();
+			if ( text.startsWith( '[api-fetch][preload] ' ) ) {
+				preloadStatus = text;
+				stopOnMount();
+			}
+		} );
 
 		await admin.visitSiteEditor();
 		await page
@@ -43,6 +54,14 @@ test.describe( 'Preload', () => {
 		await page.waitForLoadState( 'networkidle' );
 		stop();
 
+		// Everything the kickoff touches is served by the preload cache.
+		expect( Array.from( new Set( requestsUntilMount ) ).sort() ).toEqual(
+			[]
+		);
+		expect( preloadStatus ).toBe(
+			'[api-fetch][preload] All preloads consumed.'
+		);
+
 		// `POST /wp/v2/users/me` (preferences persistence) occasionally
 		// fires twice within the captured window; the duplicate count
 		// isn't stable across runs, so this assertion deduplicates.
@@ -50,10 +69,7 @@ test.describe( 'Preload', () => {
 		expect( Array.from( new Set( requests ) ).sort() ).toEqual(
 			[
 				'GET /wp/v2/posts?context=edit&offset=0&order=desc&orderby=date&per_page=10&ignore_sticky=false',
-				'GET /wp/v2/taxonomies?context=view',
-				'GET /wp/v2/template-parts/emptytheme//header?context=edit',
 				'GET /wp/v2/wp_pattern_category?context=view&per_page=100&_fields=id%2Cname%2Cdescription%2Cslug',
-				'OPTIONS /wp/v2/settings',
 				'POST /wp/v2/users/me',
 			].sort()
 		);
@@ -64,6 +80,17 @@ test.describe( 'Preload', () => {
 		admin,
 	} ) => {
 		const { requests, stop } = recordRequests( page );
+		const { requests: requestsUntilMount, stop: stopOnMount } =
+			recordRequests( page );
+
+		let preloadStatus;
+		page.on( 'console', ( msg ) => {
+			const text = msg.text();
+			if ( text.startsWith( '[api-fetch][preload] ' ) ) {
+				preloadStatus = text;
+				stopOnMount();
+			}
+		} );
 
 		await admin.visitAdminPage(
 			'site-editor.php',
@@ -78,6 +105,14 @@ test.describe( 'Preload', () => {
 		await page.waitForLoadState( 'networkidle' );
 		stop();
 
+		// Everything the kickoff touches is served by the preload cache.
+		expect( Array.from( new Set( requestsUntilMount ) ).sort() ).toEqual(
+			[]
+		);
+		expect( preloadStatus ).toBe(
+			'[api-fetch][preload] All preloads consumed.'
+		);
+
 		// `POST /wp/v2/users/me` (preferences persistence) occasionally
 		// fires twice within the captured window; the duplicate count
 		// isn't stable across runs, so this assertion deduplicates.
@@ -87,14 +122,12 @@ test.describe( 'Preload', () => {
 				`GET /wp/v2/comments?context=edit&post=${ pageId }&type=note&status=all&per_page=100`,
 				`GET /wp/v2/pages/${ pageId }/autosaves?context=edit`,
 				'GET /wp/v2/taxonomies?context=edit&per_page=100',
-				'GET /wp/v2/taxonomies?context=view',
 				'GET /wp/v2/templates/lookup?slug=front-page',
 				'GET /wp/v2/types/page?context=edit',
 				'GET /wp/v2/users/1?context=view&_fields=id%2Cname',
 				'GET /wp/v2/users/me',
 				'GET /wp/v2/view-config?kind=postType&name=page',
 				'GET /wp/v2/wp_pattern_category?context=view&per_page=100&_fields=id%2Cname%2Cdescription%2Cslug',
-				'OPTIONS /wp/v2/settings',
 				'OPTIONS /wp/v2/templates',
 				'POST /wp/v2/users/me',
 			].sort()


### PR DESCRIPTION
## What?

Brings the post-editor kickoff pattern (#78508) to the site editor. Before React mounts, the site-editor `initializeEditor` flips the preloading middleware into multi-use mode, drives every resolver whose data the server preloaded, then clears the cache before rendering.

## Why?

1. **Boot-path parity with the post editor.** The post-editor PR shaved a `setTimeout(0)` resolution dance off first render by pre-warming resolvers against the preload cache. The same dance happens on every site-editor mount.
2. **Preload coverage observability.** The middleware warns at clear time when entries the server preloaded never got consumed, and logs the success line otherwise. The site-editor preload spec consumes that signal the same way the post-editor spec does.

## How?

1. **Site-editor kickoff** (`packages/edit-site/src/index.js`). Adds a `preloadResolutions()` that runs before `root.render`. The call list is URL-aware: `p=/` adds the front-page/home template lookups; `p=/page&postId=…` adds a page record + per-slug template lookup in a phase 2. Calls whose resolver chain reaches a non-preloaded URL are deliberately omitted so the kickoff stays cache-only.
2. **`getDefaultTemplateId` invalidation race** (`packages/core-data/src/resolvers.js`). Its `shouldInvalidate` was firing on every `RECEIVE_ITEMS` for `root/site`, so the kickoff's own dispatch of the site record was wiping its just-resolved template id. Tightened to require `action.persistedEdits` (the same pattern `getEntityRecord.shouldInvalidate` uses to distinguish a save response from an initial fetch).
3. **Preload `/wp/v2/taxonomies?context=view` for site editor** (`lib/compat/wordpress-7.0/preload.php`). `getEntitiesConfig('postType')` chain-fires this when collaboration is enabled. The post-editor preload already includes it.
4. **Site-editor preload e2e spec** mirrors the post-editor pattern: a second recorder captures requests up to the `[api-fetch][preload]` boundary log, both scenarios now assert `requestsUntilMount` is empty and `preloadStatus` is the success line.

## Testing Instructions

1. Open the site editor (`wp-admin/site-editor.php`) with DevTools open. Console should show `[api-fetch][preload] All preloads consumed.` and the Network panel should show no GET / OPTIONS requests against the preloaded routes during the initial load.
2. Open a page in the site editor (`site-editor.php?p=/page&postId=N&canvas=edit`). Same expectation — the page record and `templates/lookup?slug=page-N-…` should be served from cache.
3. Run `npm run test:e2e -- test/e2e/specs/preload/ test/e2e/specs/site-editor/template-id-format.spec.js` — all five tests should pass.

## History

- Follow-up to #78508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)