### PR TITLE
Dashboard: mobile improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64365,6 +64365,7 @@
 				"@wordpress/primitives": "file:../../packages/primitives",
 				"@wordpress/private-apis": "file:../../packages/private-apis",
 				"@wordpress/ui": "file:../../packages/ui",
+				"@wordpress/viewport": "file:../../packages/viewport",
 				"@wordpress/warning": "file:../../packages/warning",
 				"clsx": "^2.1.1",
 				"fast-deep-equal": "^3.1.3"

--- a/routes/dashboard/package.json
+++ b/routes/dashboard/package.json
@@ -28,6 +28,7 @@
 		"@wordpress/primitives": "file:../../packages/primitives",
 		"@wordpress/private-apis": "file:../../packages/private-apis",
 		"@wordpress/ui": "file:../../packages/ui",
+		"@wordpress/viewport": "file:../../packages/viewport",
 		"@wordpress/warning": "file:../../packages/warning",
 		"clsx": "^2.1.1",
 		"fast-deep-equal": "^3.1.3"

--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -2,10 +2,11 @@
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { store as viewportStore } from '@wordpress/viewport';
 
 /**
  * Internal dependencies
@@ -26,6 +27,14 @@ function Dashboard() {
 
 	const [ editMode, setEditMode ] = useState( false );
 
+	const isMobileViewport = useSelect(
+		( select ) => select( viewportStore ).isViewportMatch( '< medium' ),
+		[]
+	);
+
+	const customizeDashboardLabel = __( 'Customize Dashboard' );
+	const dashboardLabel = __( 'Dashboard' );
+
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	const handleLayoutChange = ( next: DashboardWidget[] ) => {
@@ -34,6 +43,8 @@ function Dashboard() {
 			type: 'snackbar',
 		} );
 	};
+
+	const pageTitle = editMode ? customizeDashboardLabel : dashboardLabel;
 
 	return (
 		<WidgetDashboard
@@ -47,9 +58,8 @@ function Dashboard() {
 			onEditChange={ setEditMode }
 		>
 			<Page
-				title={
-					editMode ? __( 'Customize Dashboard' ) : __( 'Dashboard' )
-				}
+				title={ editMode && isMobileViewport ? undefined : pageTitle }
+				ariaLabel={ pageTitle }
 				actions={ <WidgetDashboard.Actions /> }
 				hasPadding
 			>

--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -27,6 +27,8 @@ function Dashboard() {
 
 	const [ editMode, setEditMode ] = useState( false );
 
+	// @TODO: switch to using Admin UI declaratively for mobile viewport support once available.
+	// https://github.com/WordPress/gutenberg/issues/77628
 	const isMobileViewport = useSelect(
 		( select ) => select( viewportStore ).isViewportMatch( '< small' ),
 		[]

--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -28,7 +28,7 @@ function Dashboard() {
 	const [ editMode, setEditMode ] = useState( false );
 
 	const isMobileViewport = useSelect(
-		( select ) => select( viewportStore ).isViewportMatch( '< medium' ),
+		( select ) => select( viewportStore ).isViewportMatch( '< small' ),
 		[]
 	);
 

--- a/routes/dashboard/widget-dashboard/components/actions/actions.module.css
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.module.css
@@ -10,7 +10,7 @@
 	flex-shrink: 0;
 	align-self: center;
 	width: 1px;
-	height: 16px;
+	height: calc(4 * var(--wpds-dimension-base));
 	background-color: var(--wpds-color-stroke-surface-neutral);
 }
 

--- a/routes/dashboard/widget-dashboard/components/actions/actions.module.css
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.module.css
@@ -10,6 +10,7 @@
 	flex-shrink: 0;
 	align-self: center;
 	width: 1px;
+	/* TODO: Replace `$button-size-small` with a WPDS size token once size tokens land in `@wordpress/theme`. */
 	height: calc(4 * var(--wpds-dimension-base));
 	background-color: var(--wpds-color-stroke-surface-neutral);
 }

--- a/routes/dashboard/widget-dashboard/components/actions/actions.tsx
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.tsx
@@ -82,7 +82,7 @@ export function Actions(): React.ReactNode {
 		setResetDialogOpen,
 	} = useDashboardUIContext();
 	const isMobileViewport = useSelect(
-		( select ) => select( viewportStore ).isViewportMatch( '< medium' ),
+		( select ) => select( viewportStore ).isViewportMatch( '< small' ),
 		[]
 	);
 

--- a/routes/dashboard/widget-dashboard/components/actions/actions.tsx
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.tsx
@@ -1,9 +1,11 @@
 /**
  * WordPress dependencies
  */
+import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
+import { store as viewportStore } from '@wordpress/viewport';
 // eslint-disable-next-line @wordpress/use-recommended-components
 import { AlertDialog, Button, Stack } from '@wordpress/ui';
 
@@ -79,6 +81,10 @@ export function Actions(): React.ReactNode {
 		resetDialogOpen,
 		setResetDialogOpen,
 	} = useDashboardUIContext();
+	const isMobileViewport = useSelect(
+		( select ) => select( viewportStore ).isViewportMatch( '< medium' ),
+		[]
+	);
 
 	const handleEditMode = useCallback( () => {
 		onEditChange?.( ! editMode );
@@ -139,7 +145,7 @@ export function Actions(): React.ReactNode {
 						size="compact"
 						onClick={ insert }
 					>
-						<Button.Icon icon={ plus } />
+						{ ! isMobileViewport && <Button.Icon icon={ plus } /> }
 						{ __( 'Add widget' ) }
 					</Button>
 

--- a/routes/dashboard/widget-dashboard/components/actions/actions.tsx
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.tsx
@@ -81,6 +81,8 @@ export function Actions(): React.ReactNode {
 		resetDialogOpen,
 		setResetDialogOpen,
 	} = useDashboardUIContext();
+	// @TODO: switch to using Admin UI declaratively for mobile viewport support once available.
+	// https://github.com/WordPress/gutenberg/issues/77628
 	const isMobileViewport = useSelect(
 		( select ) => select( viewportStore ).isViewportMatch( '< small' ),
 		[]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow-up to https://github.com/WordPress/gutenberg/pull/78513
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Better mobile support for dashboard UI.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Hide/shorten some elements in the header, using "small" breakpoint of [viewport package.](https://github.com/WordPress/gutenberg/tree/trunk/packages/viewport#readme)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Non edit mode (no change):
<img width="371" height="128" alt="image" src="https://github.com/user-attachments/assets/8317904b-9e36-46e5-b978-0302ed318654" />

Edit mode:

### Before

<img width="376" height="135" alt="image" src="https://github.com/user-attachments/assets/e2a903a3-97ed-43f4-af37-3780527a797f" />

### After

<img width="387" height="143" alt="image" src="https://github.com/user-attachments/assets/a8bbdf29-9347-4ffc-86f6-a5b5bd23c02c" />


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
