### PR TITLE
Breadcrumbs block: Hide separator from screen readers

### DIFF
--- a/packages/block-library/src/breadcrumbs/style.scss
+++ b/packages/block-library/src/breadcrumbs/style.scss
@@ -18,7 +18,7 @@
 		align-items: center;
 
 		&:not(:last-child)::after {
-			content: var(--separator, "/");
+			content: var(--separator, "/") / "";
 			margin: 0 0.5em;
 			opacity: 0.7;
 		}


### PR DESCRIPTION
## What?
Closes #78523

Adds CSS content alt text syntax to the breadcrumbs block separator so screen readers treat it as presentational and do not announce it.

## Why?
The breadcrumbs block uses a CSS pseudo-element to render the separator character between items:

    content: var(--separator, "/");

The CSS `content` property supports an alt text syntax, `content: value / ""`, where an empty string after the slash instructs assistive technologies to skip the generated content entirely. Without this, screen readers such as VoiceOver and NVDA announce the separator character (e.g. "slash") between every breadcrumb item, adding noise that is not useful to the user.

## How?
Single line change in `packages/block-library/src/breadcrumbs/style.scss`:

    - content: var(--separator, "/");
    + content: var(--separator, "/") / "";

## Testing Instructions
1. Add the Breadcrumbs block to a header template part in the Site Editor
2. Navigate to a page with a breadcrumb trail on the front end
3. Enable a screen reader (VoiceOver on macOS: Cmd+F5, NVDA on Windows)
4. Navigate through the breadcrumb items
5. Confirm the separator character is no longer announced between items
6. Confirm the breadcrumb link text is still announced correctly

### Testing Instructions for Keyboard
1. Tab through the breadcrumb links on the front end
2. Confirm focus order is correct and each link is reachable
3. Confirm no unexpected announcements occur between items

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="735" height="211" alt="Screenshot 2026-05-21 at 3 46 23 PM" src="https://github.com/user-attachments/assets/5abd42af-2d0c-4eb4-bc45-b8867a5e2467" />|<img width="489" height="327" alt="2026-05-21 15 56 15" src="https://github.com/user-attachments/assets/6a5d6d2c-8540-40fc-bd1f-8efc5792c346" />|

## Use of AI Tools
Claude (Anthropic) was used to assist in drafting the PR description. 
The code change was authored and reviewed by the contributor.
