### PR TITLE
Automated Testing: Enable ESLint caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
 		"lint": "concurrently \"npm run lint:lockfile\" \"npm run lint:tsconfig\" \"npm run lint:js\" \"npm run lint:pkg-json\" \"npm run lint:css\"",
 		"lint:css": "wp-scripts lint-style \"**/*.scss\" \"**/*.module.css\"",
 		"lint:css:fix": "npm run lint:css -- --fix",
-		"lint:js": "node ./tools/eslint/lint-js.cjs --concurrency=auto",
+		"lint:js": "node ./tools/eslint/lint-js.cjs --concurrency=auto --cache",
 		"lint:js:fix": "npm run lint:js -- --fix",
 		"lint:js:prune-suppressions": "npm run lint:js -- --prune-suppressions",
 		"lint:lockfile": "npm run --workspace @wordpress/validation-tools validate-package-lock --",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Updates `npm run lint:js` command (ESLint) to enable [caching](https://eslint.org/docs/latest/use/command-line-interface#caching).

Builds on #78360.

## Why?

For improved linting performance in local development assuming frequent iteration and having a fast feedback loop with linting.

Example local run of `npm run lint:js`

- First run without cache (`rm .eslintcache` + `npm run lint:js`): 51.745s
- Second run with cache (`npm run lint:js`): 8.275s

Diff: -43.47s (-84%)

## How?

Adds the `--cache` flag to the existing `lint:js` command. The cache file is [already `.gitignore`'d](https://github.com/WordPress/gutenberg/blob/fc8a660251941759577cec6223c5162371a3ef58/.gitignore#L35), which appears to have been added by @tyxla in #44938 for compatibility with an external tool (i.e. not due to a previous attempt to use caching that we intentionally moved away from).

After some debate and exploration, I opted to **intentionally not include CI support** as part of this initial change, meaning that these changes will likely have no impact on CI build times as-is. I think we absolutely should want to save the cache between CI builds so subsequent builds can benefit, but in practice this is quite difficult with our current CI setup because the behavior of `actions/cache` only _saves_ when there's a cache miss. While they [document this and a workaround including incorporating unique values in the cache key](https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache), I think our current cache usage is incompatible with this approach. [GitHub Actions caches are limited to 10 GB](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#default-limits), and the behavior when exceeding this limit is to eject the least-recently-used caches (globally across all caches). But our caches already exceed this limit with relatively few entries due to the size of our Node.js dependencies, so ejecting individual entries presents a likely risk of ejecting valid, reusable caches, especially if ESLint cache insertion is happening rapidly enough to insert many new cache entries in quick succession (even if we only limited to trunk commits). Separately, we should explore reducing the size and number of caches (e.g. does `node_modules` contain more than it needs to in CI? do we need the `-date-` caches? similarly on OS if we can tolerate slower builds on trunk for OS dependencies only used there? etc.). Alternatively, we could probably tolerate a somewhat-stale ESLint configuration (updated semi-regularly), but the issues described above make are problematic enough that I think _any_ new additions to the existing cache may create issues.

## Testing Instructions

Run `npm run lint:js` twice and observe the second run is much faster than the first.

## Use of AI Tools

Used Cursor + Claude Opus 4.7 to research and implement. Yes, I had Claude add the 7-characters-long flag to the `package.json` command for me 😂 