### PR TITLE
Dashboard: add "removeWidget" API to widgets

### DIFF
--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -51,6 +51,7 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/global-styles-ui',
 	'@wordpress/ui',
 	'@wordpress/views',
+	'@wordpress/welcome-widget',
 ];
 
 /*

--- a/routes/dashboard/widget-dashboard/README.md
+++ b/routes/dashboard/widget-dashboard/README.md
@@ -129,10 +129,13 @@ Widget render modules receive only what they need to render and edit:
 interface WidgetRenderProps< Item = unknown > {
 	attributes: Item;
 	setAttributes?: ( next: Partial< Item > ) => void;
+	removeWidget?: () => void;
 }
 ```
 
-`setAttributes` flows back through `onLayoutChange` on the dashboard. Removal, badges, and error chrome are not part of this contract — those belong to the surface.
+`setAttributes` flows back through `onLayoutChange` on the dashboard. `removeWidget` removes the current instance from the layout; when the dashboard is not in edit mode, the change commits immediately.
+
+For compound components and other dashboard internals, `useRemoveDashboardWidget()` is also exported from this module. Pass an explicit `uuid` when calling outside a widget render subtree (for example, edit-mode chrome that renders in a grid `actionableArea` slot).
 
 ## Types
 

--- a/routes/dashboard/widget-dashboard/components/widget-render/widget-render.tsx
+++ b/routes/dashboard/widget-dashboard/components/widget-render/widget-render.tsx
@@ -7,6 +7,7 @@ import { useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import { useDashboardInternalContext } from '../../context/dashboard-context';
+import { useRemoveDashboardWidget } from '../../hooks/use-remove-dashboard-widget';
 import { getLazyWidgetComponent } from '../../utils/get-lazy-widget-component';
 import type { DashboardWidget, WidgetType } from '../../types';
 
@@ -43,6 +44,8 @@ function WidgetRenderImpl( { widget, widgetType }: WidgetRenderInternalProps ) {
 		[ widget.uuid, layout, onLayoutChange ]
 	);
 
+	const removeWidget = useRemoveDashboardWidget( widget.uuid );
+
 	return (
 		<>
 			{ /* WidgetComponent is a cached `lazy()` keyed by renderModule, so its identity stays stable across renders. */ }
@@ -50,6 +53,7 @@ function WidgetRenderImpl( { widget, widgetType }: WidgetRenderInternalProps ) {
 			<WidgetComponent
 				attributes={ widget.attributes }
 				setAttributes={ setAttributes }
+				removeWidget={ removeWidget }
 			/>
 		</>
 	);

--- a/routes/dashboard/widget-dashboard/components/widgets/widget-chrome-actionable-area.tsx
+++ b/routes/dashboard/widget-dashboard/components/widgets/widget-chrome-actionable-area.tsx
@@ -13,6 +13,7 @@ import { IconButton, Stack } from '@wordpress/ui';
  */
 import { unlock } from '../../../lock-unlock';
 import { useDashboardInternalContext } from '../../context/dashboard-context';
+import { useRemoveDashboardWidget } from '../../hooks/use-remove-dashboard-widget';
 import styles from './widget-chrome-actionable-area.module.css';
 import type { DashboardWidget, GridTilePlacement } from '../../types';
 
@@ -111,13 +112,7 @@ export function WidgetChromeActionableArea( {
 		updateWidth( nextWidth );
 	};
 
-	const onRemove = () => {
-		onLayoutChange(
-			layout.filter(
-				( currentWidget ) => currentWidget.uuid !== widget.uuid
-			)
-		);
-	};
+	const onRemove = useRemoveDashboardWidget( widget.uuid );
 
 	return (
 		<div className={ styles.widgetChromeActionableArea }>

--- a/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
+++ b/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
@@ -19,6 +19,7 @@ import {
 /**
  * Internal dependencies
  */
+import { removeWidgetFromLayout } from '../utils/remove-widget-from-layout';
 import type {
 	ResolveWidgetModule,
 	WidgetGridSettings,
@@ -133,6 +134,12 @@ interface InternalDashboardContextValue {
 	editMode: boolean;
 	onEditChange?: ( next: boolean ) => void;
 	resolveWidgetModule: ResolveWidgetModule;
+
+	/**
+	 * Removes a widget instance from the staging layout. Commits
+	 * immediately when not in edit mode.
+	 */
+	removeDashboardWidget: ( uuid: string ) => void;
 }
 
 const Context = createContext< InternalDashboardContextValue | null >( null );
@@ -313,6 +320,18 @@ export function WidgetDashboardProvider( {
 		setStagingGridSettings( DEFAULT_GRID );
 	}, [] );
 
+	const removeDashboardWidget = useCallback(
+		( uuid: string ) => {
+			const next = removeWidgetFromLayout( stagingLayout, uuid );
+			setStagingLayout( next );
+
+			if ( ! editMode ) {
+				onLayoutChange( canonicalize( next ) );
+			}
+		},
+		[ stagingLayout, editMode, onLayoutChange ]
+	);
+
 	useEffect( () => {
 		if ( stagingLayout.length === 0 ) {
 			onEditChange?.( true );
@@ -342,6 +361,7 @@ export function WidgetDashboardProvider( {
 			editMode,
 			onEditChange,
 			resolveWidgetModule,
+			removeDashboardWidget,
 		} ),
 		[
 			widgetTypes,
@@ -356,6 +376,7 @@ export function WidgetDashboardProvider( {
 			editMode,
 			onEditChange,
 			resolveWidgetModule,
+			removeDashboardWidget,
 		]
 	);
 

--- a/routes/dashboard/widget-dashboard/hooks/index.ts
+++ b/routes/dashboard/widget-dashboard/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useRemoveDashboardWidget } from './use-remove-dashboard-widget';

--- a/routes/dashboard/widget-dashboard/hooks/use-remove-dashboard-widget.ts
+++ b/routes/dashboard/widget-dashboard/hooks/use-remove-dashboard-widget.ts
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useDashboardInternalContext } from '../context/dashboard-context';
+import { useWidgetContext } from '../context/widget-context';
+
+/**
+ * Returns a callback that removes a widget instance from the dashboard
+ * layout.
+ *
+ * When the dashboard is not in edit mode, the removal commits immediately
+ * so persisted layout state updates without an extra Done action. In edit
+ * mode, removal is staged like other layout mutations until the user
+ * commits or cancels.
+ *
+ * @param uuid Optional instance id. When omitted, uses the widget under
+ *             the current `useWidgetContext()` subtree.
+ */
+export function useRemoveDashboardWidget( uuid?: string ): () => void {
+	const widgetContext = useWidgetContext();
+	const { removeDashboardWidget } = useDashboardInternalContext();
+
+	return useCallback( () => {
+		const targetUuid = uuid ?? widgetContext?.uuid;
+
+		if ( ! targetUuid ) {
+			throw new Error(
+				'useRemoveDashboardWidget() requires a widget uuid. Pass uuid explicitly or call from within a widget render subtree.'
+			);
+		}
+
+		removeDashboardWidget( targetUuid );
+	}, [ uuid, widgetContext?.uuid, removeDashboardWidget ] );
+}

--- a/routes/dashboard/widget-dashboard/index.ts
+++ b/routes/dashboard/widget-dashboard/index.ts
@@ -1,2 +1,3 @@
 export { WidgetDashboard } from './widget-dashboard';
-export type { DashboardWidget, WidgetType } from './types';
+export { useRemoveDashboardWidget } from './hooks';
+export type { DashboardWidget, WidgetType, WidgetRenderProps } from './types';

--- a/routes/dashboard/widget-dashboard/test/use-remove-dashboard-widget.test.tsx
+++ b/routes/dashboard/widget-dashboard/test/use-remove-dashboard-widget.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { act, render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useRemoveDashboardWidget } from '../hooks/use-remove-dashboard-widget';
+import { WidgetDashboard } from '../widget-dashboard';
+import type { DashboardWidget, WidgetType } from '../types';
+
+const widgetTypes: WidgetType[] = [];
+
+const initialLayout: DashboardWidget[] = [
+	{ uuid: 'keep', type: 'core/test', placement: { width: 1, height: 1 } },
+	{
+		uuid: 'remove-me',
+		type: 'core/test',
+		placement: { width: 1, height: 1 },
+	},
+];
+
+interface ProbeApi {
+	remove: () => void;
+}
+
+const probeRef: { current: ProbeApi | null } = { current: null };
+
+function Probe( { uuid }: { uuid: string } ) {
+	const remove = useRemoveDashboardWidget( uuid );
+	useEffect( () => {
+		probeRef.current = { remove };
+	} );
+	return null;
+}
+
+function readProbe(): ProbeApi {
+	if ( ! probeRef.current ) {
+		throw new Error( 'Probe not mounted yet' );
+	}
+	return probeRef.current;
+}
+
+describe( 'useRemoveDashboardWidget', () => {
+	it( 'commits immediately when not in edit mode', () => {
+		const onLayoutChange = jest.fn();
+
+		render(
+			<WidgetDashboard
+				layout={ initialLayout }
+				onLayoutChange={ onLayoutChange }
+				widgetTypes={ widgetTypes }
+				editMode={ false }
+			>
+				<Probe uuid="remove-me" />
+			</WidgetDashboard>
+		);
+
+		act( () => {
+			readProbe().remove();
+		} );
+
+		expect( onLayoutChange ).toHaveBeenCalledTimes( 1 );
+		expect( onLayoutChange ).toHaveBeenCalledWith( [ initialLayout[ 0 ] ] );
+	} );
+
+	it( 'stages removal in edit mode until commit', () => {
+		const onLayoutChange = jest.fn();
+
+		render(
+			<WidgetDashboard
+				layout={ initialLayout }
+				onLayoutChange={ onLayoutChange }
+				widgetTypes={ widgetTypes }
+				editMode
+			>
+				<Probe uuid="remove-me" />
+			</WidgetDashboard>
+		);
+
+		act( () => {
+			readProbe().remove();
+		} );
+
+		expect( onLayoutChange ).not.toHaveBeenCalled();
+	} );
+} );

--- a/routes/dashboard/widget-dashboard/test/widget-dashboard.test.tsx
+++ b/routes/dashboard/widget-dashboard/test/widget-dashboard.test.tsx
@@ -27,6 +27,7 @@ type Attrs = { greeting: string };
 function TestWidget( {
 	attributes,
 	setAttributes,
+	removeWidget,
 }: WidgetRenderProps< Attrs > ) {
 	return (
 		<div>
@@ -36,6 +37,9 @@ function TestWidget( {
 			>
 				Update
 			</button>
+			{ removeWidget && (
+				<button onClick={ removeWidget }>Remove widget</button>
+			) }
 		</div>
 	);
 }
@@ -130,6 +134,20 @@ describe( 'WidgetDashboard', () => {
 			type: 'test/greet',
 			attributes: { greeting: 'updated' },
 		} );
+	} );
+
+	it( 'removes a widget immediately when removeWidget is invoked outside edit mode', async () => {
+		const onChange = jest.fn();
+		const user = userEvent.setup();
+
+		render( <Harness onLayoutChange={ onChange } /> );
+
+		await user.click(
+			await screen.findByRole( 'button', { name: 'Remove widget' } )
+		);
+
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+		expect( onChange ).toHaveBeenCalledWith( [] );
 	} );
 
 	it( 'renders nothing for an unknown widget type (no crash)', () => {

--- a/routes/dashboard/widget-dashboard/types.ts
+++ b/routes/dashboard/widget-dashboard/types.ts
@@ -101,6 +101,12 @@ export interface WidgetRenderProps< Item = unknown > {
 	 * dashboard with the updated layout.
 	 */
 	setAttributes?: ( next: Partial< Item > ) => void;
+
+	/**
+	 * Removes this widget instance from the dashboard layout. When the
+	 * dashboard is not in edit mode, the removal commits immediately.
+	 */
+	removeWidget?: () => void;
 }
 
 /**

--- a/routes/dashboard/widget-dashboard/utils/remove-widget-from-layout/index.ts
+++ b/routes/dashboard/widget-dashboard/utils/remove-widget-from-layout/index.ts
@@ -1,0 +1,1 @@
+export { removeWidgetFromLayout } from './remove-widget-from-layout';

--- a/routes/dashboard/widget-dashboard/utils/remove-widget-from-layout/remove-widget-from-layout.ts
+++ b/routes/dashboard/widget-dashboard/utils/remove-widget-from-layout/remove-widget-from-layout.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import type { DashboardWidget } from '../../types';
+
+/**
+ * Returns a layout with the widget matching `uuid` removed.
+ *
+ * @param layout Layout to filter.
+ * @param uuid   Instance id to remove.
+ */
+export function removeWidgetFromLayout(
+	layout: DashboardWidget[],
+	uuid: string
+): DashboardWidget[] {
+	return layout.filter( ( widget ) => widget.uuid !== uuid );
+}

--- a/routes/dashboard/widget-types/types.ts
+++ b/routes/dashboard/widget-types/types.ts
@@ -163,4 +163,10 @@ export interface WidgetRenderProps< Item = unknown > {
 	 * surfaces render widgets in read-only contexts.
 	 */
 	setAttributes?: ( next: Partial< Item > ) => void;
+
+	/**
+	 * Removes this widget instance from the consuming surface's layout.
+	 * Optional because some surfaces render widgets in read-only contexts.
+	 */
+	removeWidget?: () => void;
 }

--- a/widgets/welcome/components/banner/banner.module.css
+++ b/widgets/welcome/components/banner/banner.module.css
@@ -1,6 +1,6 @@
 .banner {
-	--banner-bg: var(--wpds-color-bg-interactive-neutral-strong);
-	--banner-fg: var(--wpds-color-fg-interactive-neutral-strong);
+	--banner-bg: var(--wpds-color-bg-surface-neutral);
+	--banner-fg: var(--wpds-color-fg-content-neutral);
 	--banner-line-brand: var(--wpds-color-bg-interactive-brand-strong);
 	--banner-line-caution: var(--wpds-color-bg-surface-caution-weak);
 	--banner-line-success: var(--wpds-color-bg-surface-success);

--- a/widgets/welcome/components/banner/banner.tsx
+++ b/widgets/welcome/components/banner/banner.tsx
@@ -7,13 +7,21 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import {
+	privateApis as themePrivateApis,
+	type ThemeProvider as ThemeProviderType,
+} from '@wordpress/theme';
 import { Link, Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
  */
+import { unlock } from '../../lock-unlock';
 import { HeaderBackground } from '../header-background';
 import styles from './banner.module.css';
+
+const ThemeProvider: typeof ThemeProviderType =
+	unlock( themePrivateApis ).ThemeProvider;
 
 const DISPLAY_VERSION = '7.1';
 
@@ -30,32 +38,34 @@ export function Banner( { isWide = false, isTiny = false }: BannerProps ) {
 	);
 
 	return (
-		<Stack className={ className } direction="column" justify="center">
-			<HeaderBackground />
+		<ThemeProvider color={ { bg: '#000000' } }>
+			<Stack className={ className } direction="column" justify="center">
+				<HeaderBackground />
 
-			<Stack
-				className={ styles.bannerContent }
-				gap="sm"
-				direction="column"
-			>
-				<Text variant="heading-2xl">
-					{ __( 'Welcome to WordPress!' ) }
-				</Text>
+				<Stack
+					className={ styles.bannerContent }
+					gap="sm"
+					direction="column"
+				>
+					<Text variant="heading-2xl">
+						{ __( 'Welcome to WordPress!' ) }
+					</Text>
 
-				<Text variant="heading-lg">
-					<Link
-						className={ styles.bannerLink }
-						href="/wp-admin/about.php"
-						variant="unstyled"
-					>
-						{ sprintf(
-							/* translators: %s: Current WordPress version. */
-							__( 'Learn more about the %s version.' ),
-							DISPLAY_VERSION
-						) }
-					</Link>
-				</Text>
+					<Text variant="heading-lg">
+						<Link
+							className={ styles.bannerLink }
+							href="/wp-admin/about.php"
+							variant="unstyled"
+						>
+							{ sprintf(
+								/* translators: %s: Current WordPress version. */
+								__( 'Learn more about the %s version.' ),
+								DISPLAY_VERSION
+							) }
+						</Link>
+					</Text>
+				</Stack>
 			</Stack>
-		</Stack>
+		</ThemeProvider>
 	);
 }

--- a/widgets/welcome/lock-unlock.ts
+++ b/widgets/welcome/lock-unlock.ts
@@ -1,0 +1,9 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/welcome-widget'
+);

--- a/widgets/welcome/package.json
+++ b/widgets/welcome/package.json
@@ -9,6 +9,8 @@
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
+		"@wordpress/private-apis": "file:../../packages/private-apis",
+		"@wordpress/theme": "file:../../packages/theme",
 		"@wordpress/ui": "file:../../packages/ui",
 		"@wordpress/primitives": "file:../../packages/primitives",
 		"clsx": "^2.1.1",

--- a/widgets/welcome/render.tsx
+++ b/widgets/welcome/render.tsx
@@ -6,12 +6,20 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { layout, pencil, styles as stylesIcon } from '@wordpress/icons';
-import { Stack } from '@wordpress/ui';
+import {
+	closeSmall,
+	layout,
+	pencil,
+	styles as stylesIcon,
+} from '@wordpress/icons';
+// Dashboard is still experimental.
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { IconButton, Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
  */
+import type { WidgetRenderProps } from '../../routes/dashboard/widget-dashboard';
 import { Banner, FeatureHighlight } from './components';
 import styles from './style.module.css';
 
@@ -19,7 +27,7 @@ const ROW_LAYOUT_MIN_WIDTH = 800;
 const ROW_LAYOUT_MAX_HEIGHT = 390;
 const TINY_LAYOUT_MAX_SIZE = 120;
 
-export default function WelcomeBanner() {
+export default function WelcomeBanner( { removeWidget }: WidgetRenderProps ) {
 	const [ isWide, setIsWide ] = useState( false );
 	const [ isTiny, setIsTiny ] = useState( false );
 
@@ -89,6 +97,18 @@ export default function WelcomeBanner() {
 			direction={ isWide ? 'row' : 'column' }
 			gap="lg"
 		>
+			{ removeWidget && (
+				<IconButton
+					className={ styles.dismiss }
+					icon={ closeSmall }
+					label={ __( 'Dismiss' ) }
+					size="small"
+					variant="minimal"
+					tone="neutral"
+					onClick={ removeWidget }
+				/>
+			) }
+
 			<Banner isWide={ isWide } isTiny={ isTiny } />
 
 			{ ! isTiny && (

--- a/widgets/welcome/render.tsx
+++ b/widgets/welcome/render.tsx
@@ -103,7 +103,7 @@ export default function WelcomeBanner( { removeWidget }: WidgetRenderProps ) {
 					icon={ closeSmall }
 					label={ __( 'Dismiss' ) }
 					size="small"
-					variant="minimal"
+					variant="solid"
 					tone="neutral"
 					onClick={ removeWidget }
 				/>

--- a/widgets/welcome/style.module.css
+++ b/widgets/welcome/style.module.css
@@ -1,6 +1,14 @@
 .root {
 	container-type: size;
 	height: 100%;
+	position: relative;
+}
+
+.dismiss {
+	position: absolute;
+	top: var(--wpds-dimension-padding-md);
+	right: var(--wpds-dimension-padding-md);
+	z-index: 2;
 }
 
 .columns {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/77616
Follow-up to https://github.com/WordPress/gutenberg/pull/78461

<!-- In a few words, what is the PR actually doing? -->

- Provide `removeWidget` API to widgets as a way to build bespoke UI for dismissing widgets outside "edit" mode.
- Use the API in the Welcome widget
- Add `ThemeProvider` to the welcome widget's header banner to automatically style icon button as white against black background
- Use the new hook in the "widget not available" placeholder.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Widgets might be temporary by nature; for example, the core's Welcome widget, which users need to be able to dismiss.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Expose "Remove widget" API to the widget.

We'll separately need a way to enforce adding a widget to the dashboard, e.g. when a new version of WP has been updated.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Have welcome widget, try dismissing it.

## Screenshots or screencast <!-- if applicable -->
<img width="961" height="475" alt="image" src="https://github.com/user-attachments/assets/9dc14f20-71af-4192-9440-834bde68fbb4" />

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
