### PR TITLE
Image editor: remove unnecessary __nextHasNoMarginBottom prop

### DIFF
--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -68,7 +68,6 @@ export default function MediaEditorCropPanel( {
 			</VisuallyHidden>
 			<SelectControl
 				__next40pxDefaultSize
-				__nextHasNoMarginBottom
 				label={ __( 'Aspect ratio' ) }
 				value={ aspectRatioValue }
 				onChange={ onAspectRatioChange }
@@ -78,7 +77,6 @@ export default function MediaEditorCropPanel( {
 				} ) ) }
 			/>
 			<ToggleControl
-				__nextHasNoMarginBottom
 				label={ __( 'Resize crop area' ) }
 				help={ __( 'Show handles to adjust the crop box.' ) }
 				checked={ freeformCrop }
@@ -87,7 +85,6 @@ export default function MediaEditorCropPanel( {
 			<div role="presentation" { ...zoomGestureHandlers }>
 				<RangeControl
 					__next40pxDefaultSize
-					__nextHasNoMarginBottom
 					label={ __( 'Zoom' ) }
 					min={ minZoom }
 					max={ MAX_ZOOM }

--- a/packages/media-editor/src/image-editor/stories/rectangle-crop.story.tsx
+++ b/packages/media-editor/src/image-editor/stories/rectangle-crop.story.tsx
@@ -396,7 +396,6 @@ const WithControlsComponent = () => {
 					<FlexItem>
 						<SelectControl
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							label="Aspect ratio"
 							hideLabelFromVision
 							value={ aspectRatioValue }
@@ -411,7 +410,6 @@ const WithControlsComponent = () => {
 					</FlexItem>
 					<FlexItem>
 						<ToggleControl
-							__nextHasNoMarginBottom
 							label="Freeform"
 							checked={ freeformCrop }
 							onChange={ setFreeformCrop }
@@ -420,7 +418,6 @@ const WithControlsComponent = () => {
 					<FlexItem>
 						<SelectControl
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							label="Grid"
 							hideLabelFromVision
 							value={ gridMode }
@@ -454,7 +451,6 @@ const WithControlsComponent = () => {
 				<div className="image-editor-story__sliders">
 					<RangeControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						label="Fine rotation"
 						min={ -MAX_ROTATION_OFFSET }
 						max={ MAX_ROTATION_OFFSET }
@@ -464,7 +460,6 @@ const WithControlsComponent = () => {
 					/>
 					<RangeControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						label="Zoom"
 						min={ getMinZoom( state ) }
 						max={ MAX_ZOOM }
@@ -816,7 +811,6 @@ const DebugComponent = () => {
 					</FlexItem>
 					<FlexItem>
 						<ToggleControl
-							__nextHasNoMarginBottom
 							label="Freeform"
 							checked={ freeformCrop }
 							onChange={ setFreeformCrop }
@@ -838,7 +832,6 @@ const DebugComponent = () => {
 					<FlexItem>
 						<SelectControl
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							label="Format"
 							hideLabelFromVision
 							value={ exportFormat as 'image/jpeg' }
@@ -874,7 +867,6 @@ const DebugComponent = () => {
 				<div className="image-editor-story__sliders">
 					<RangeControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						label="Fine rotation"
 						min={ -MAX_ROTATION_OFFSET }
 						max={ MAX_ROTATION_OFFSET }
@@ -884,7 +876,6 @@ const DebugComponent = () => {
 					/>
 					<RangeControl
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 						label="Zoom"
 						min={ getMinZoom( state ) }
 						max={ MAX_ZOOM }


### PR DESCRIPTION


## What?

Removes deprecated `__nextHasNoMarginBottom` from image editor controls.


## Why?

The prop is deprecated. 

See:

https://github.com/WordPress/gutenberg/pull/78046#discussion_r3284774056

## How?

Find. Destroy.

## Testing Instructions

There should be no visual regressions in the crop panel controls (aspect ratio and freeform toggle).

## Screenshots or screencast <!-- if applicable -->


|Before|After|
|-|-|
|<img width="1128" height="710" alt="Screenshot 2026-05-22 at 8 54 45 am" src="https://github.com/user-attachments/assets/4a6a6d10-ee0f-4993-ac0b-8561b4e80eae" />|<img width="1130" height="711" alt="Screenshot 2026-05-22 at 8 53 38 am" src="https://github.com/user-attachments/assets/f9d8f695-9318-4775-b81e-edcfcadc3caf" />|

## Use of AI Tools

None.




