### PR TITLE
Global Styles: keep block previews top aligned

### DIFF
--- a/packages/global-styles-ui/src/block-preview-panel.tsx
+++ b/packages/global-styles-ui/src/block-preview-panel.tsx
@@ -88,9 +88,9 @@ const BlockPreviewPanel = ( {
 									padding: 24px;
 									min-height:${ Math.round( minHeight ) }px;
 									display:flex;
-									align-items:center;
+									align-items: flex-start;
 								}
-								.is-root-container { width: 100%; }
+								.is-root-container { width: 100%; transform-origin: top center; }
 								${ stateCSS }
 							`,
 							},


### PR DESCRIPTION


## What

Keeps the Global Styles block preview content aligned to the top of the preview frame.

Noticed while testing:

- https://github.com/WordPress/gutenberg/pull/78538#discussion_r3285722260

## Why

Some block previews shift vertically when their rendered width changes. Aligning the preview body to the start and setting a top transform origin keeps the content anchored while preview styles are applied.

## What changed

- Changed the preview iframe body alignment from centred to top aligned.
- Set `.is-root-container` to use a top transform origin so scaled preview content does not move down.

## Manual testing

1. Open Appearance > Editor > Styles > Blocks.
2. Select a block with visible preview content.
3. Switch between available block states or responsive preview states.
4. Confirm the preview content stays anchored to the top instead of jumping down.

A lot of block previews won't show any noticeable change. 

Here are some of the block previews for which you can see a difference:

| Block | Before | After |
|--------|--------|--------|
| Group | <img width="364" height="228" alt="Screenshot 2026-05-22 at 3 37 06 pm" src="https://github.com/user-attachments/assets/0e089775-436a-402d-ab4a-da07124c127f" /> | <img width="344" height="212" alt="Screenshot 2026-05-22 at 2 54 07 pm" src="https://github.com/user-attachments/assets/9f299267-59a1-40ad-aa53-c158814b1113" /> |
| Gallery | <img width="365" height="236" alt="Screenshot 2026-05-22 at 3 37 50 pm" src="https://github.com/user-attachments/assets/c90e0c90-431c-4702-8541-9de5f1312bb5" /> | <img width="356" height="221" alt="Screenshot 2026-05-22 at 2 53 16 pm" src="https://github.com/user-attachments/assets/f13d9c9e-d284-4c5c-bca6-8cd7b9280f6e" />  |
| Navigation | <img width="349" height="224" alt="Screenshot 2026-05-22 at 3 38 07 pm" src="https://github.com/user-attachments/assets/915341f4-0795-46b3-9059-c621bd170509" /> | <img width="352" height="213" alt="Screenshot 2026-05-22 at 2 52 41 pm" src="https://github.com/user-attachments/assets/8b114da6-9fa8-4acb-aae2-733e0a713c08" /> |
| Table | <img width="352" height="228" alt="Screenshot 2026-05-22 at 3 38 31 pm" src="https://github.com/user-attachments/assets/9ac51603-b82a-43f6-98e1-cb3d3c897bb0" /> | <img width="358" height="216" alt="Screenshot 2026-05-22 at 2 52 33 pm" src="https://github.com/user-attachments/assets/7c68e980-7870-458e-880b-cf813110d108" /> | 
| Accordian | <img width="348" height="224" alt="Screenshot 2026-05-22 at 3 38 49 pm" src="https://github.com/user-attachments/assets/61be148b-742f-440e-9be5-4aca6e831345" /> | <img width="382" height="248" alt="Screenshot 2026-05-22 at 2 52 05 pm" src="https://github.com/user-attachments/assets/096e6c97-bbde-4f6c-b8c0-56232f154417" /> | 

Also narrow the window width and check that the preview appears okay:

<img width="563" height="427" alt="Screenshot 2026-05-22 at 3 44 44 pm" src="https://github.com/user-attachments/assets/bd810a41-a2cb-4d9a-93e8-bc682034eb97" />
