### PR TITLE
Performance Tests: Wait for editor canvas before media-upload inserts

### DIFF
--- a/test/performance/specs/media-upload.spec.js
+++ b/test/performance/specs/media-upload.spec.js
@@ -69,6 +69,8 @@ async function runUploadIterations( {
 } ) {
 	const iterations = samples + throwaway;
 
+	await editor.canvas.locator( 'body' ).waitFor();
+
 	for ( let i = 1; i <= iterations; i++ ) {
 		const { tmpFileName, tmpDirectory } = await createTempImage(
 			sourceFile,
@@ -201,6 +203,7 @@ test.describe( 'Media Upload Performance', () => {
 			requestUtils,
 		} ) => {
 			await admin.createNewPost();
+			await editor.canvas.locator( 'body' ).waitFor();
 
 			for ( let i = 1; i <= iterations; i++ ) {
 				await editor.insertBlock( { name: 'core/gallery' } );


### PR DESCRIPTION
## What?

Make the media-upload perf spec wait for the editor canvas iframe to mount before dispatching `insertBlock`. Each test in the spec previously called `admin.createNewPost()` immediately followed by `editor.insertBlock(...)`, racing the editor's initialization.

## Why?

The trunk \"Performance Tests\" job has been failing on every push since [#78508](https://github.com/WordPress/gutenberg/pull/78508) merged (e.g. [run 26248025334](https://github.com/WordPress/gutenberg/actions/runs/26248025334/job/77251371576)) with the same shape: `expect(imageBlock).toBeVisible()` timing out and the canvas screenshot showing an empty editor.

Root cause:

1. **The kickoff (#78508) defers `root.render`.** `initializeEditor` now awaits a `Promise.all([...])` of resolvers before mounting React. `<EditorProvider>`'s `setupEditor` effect — which dispatches `SET_EDITED_POST` and binds the block-editor flow to the post entity — only fires after the kickoff settles.
2. **`editor.insertBlock` only waits for `window.wp.blocks && window.wp.data`.** Both are available within ~10 ms of page load, well before the kickoff settles. The helper then dispatches `wp.data.dispatch('core/block-editor').insertBlock(...)` against a block-editor store that hasn't yet been bound to the post's edited entity.
3. **When `<BlockEditorProvider>` finally mounts**, it resets the block-editor store from the entity's blocks (empty post) — overwriting the pre-mount insertion. Canvas stays empty.

Other perf specs (e.g. `post-editor`) avoid the race by accident: they have a `loadBlocksForLargePost()` call between `createNewPost()` and `insertBlock()`, and that step's `parse(largeHtml)` happens to take long enough for the editor to finish mounting. The media-upload spec has nothing between `createNewPost()` and `insertBlock()`.

The failure shows up on the trunk job specifically (rather than the PR job) because the trunk job pins `--wp-version 6.9`. On that environment the kickoff settles slightly later, deterministically pushing `setupEditor` past the test's 5-second `toBeVisible` timeout.

## How?

`runUploadIterations` (the helper used by the three single-image tests) and the \"Batch upload 5 images\" test each get one extra line right after `createNewPost()`:

\`\`\`js
await editor.canvas.locator( 'body' ).waitFor();
\`\`\`

The `editor.canvas` iframe is only rendered by `<BlockEditorProvider>` after mount, so waiting on its body to appear is the smallest reliable readiness signal. Two call sites cover all four tests in the file.

## Testing Instructions

1. Reproduce the failure on trunk:

   \`\`\`sh
   npm exec --no release-cli -- perf \"$(git rev-parse trunk)\" dae102af1458310b05de3c1281b1654951a729ab --tests-branch \"$(git rev-parse trunk)\" --wp-version 6.9 -c
   \`\`\`

   The `media-upload` suite fails the four tests in `Media Upload Performance`.

2. Run the same command against this branch — all four tests pass.

## History

- The merged preload-kickoff PR is [#78508](https://github.com/WordPress/gutenberg/pull/78508).
- Trunk perf failure reference: [Actions run 26248025334](https://github.com/WordPress/gutenberg/actions/runs/26248025334/job/77251371576).

🤖 Generated with [Claude Code](https://claude.com/claude-code)