### PR TITLE
Add support for layout responsive styles

### DIFF
--- a/backport-changelog/7.1/11966.md
+++ b/backport-changelog/7.1/11966.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11966
+
+* https://github.com/WordPress/gutenberg/pull/78543

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -299,134 +299,57 @@ function gutenberg_sanitize_block_gap_value( $gap_value ) {
 }
 
 /**
- * Removes declarations for excluded properties from layout style rules.
- *
- * @param array $layout_styles       Layout style rules.
- * @param array $excluded_properties CSS properties to omit.
- * @return array Layout style rules with excluded declarations removed.
- */
-function gutenberg_filter_layout_style_properties( $layout_styles, $excluded_properties = array() ) {
-	if ( empty( $excluded_properties ) ) {
-		return $layout_styles;
-	}
-
-	$excluded_properties = array_flip( $excluded_properties );
-	$filtered_styles     = array();
-
-	foreach ( $layout_styles as $layout_style ) {
-		if ( empty( $layout_style['declarations'] ) || ! is_array( $layout_style['declarations'] ) ) {
-			continue;
-		}
-
-		foreach ( array_keys( $layout_style['declarations'] ) as $property ) {
-			if ( isset( $excluded_properties[ $property ] ) ) {
-				unset( $layout_style['declarations'][ $property ] );
-			}
-		}
-
-		if ( ! empty( $layout_style['declarations'] ) ) {
-			$filtered_styles[] = $layout_style;
-		}
-	}
-
-	return $filtered_styles;
-}
-
-/**
- * Filters layout style rules down to declarations that differ from base rules.
- *
- * @param array $layout_styles       Layout style rules.
- * @param array $base_layout_styles  Base layout style rules.
- * @param array $excluded_properties CSS properties to always omit.
- * @return array Layout style rules containing changed declarations only.
- */
-function gutenberg_get_layout_style_delta( $layout_styles, $base_layout_styles, $excluded_properties = array() ) {
-	$base_declarations   = array();
-	$excluded_properties = array_flip( $excluded_properties );
-
-	foreach ( $base_layout_styles as $base_layout_style ) {
-		if ( empty( $base_layout_style['selector'] ) || empty( $base_layout_style['declarations'] ) || ! is_array( $base_layout_style['declarations'] ) ) {
-			continue;
-		}
-
-		$rule_key = ( $base_layout_style['rules_group'] ?? '' ) . '|' . $base_layout_style['selector'];
-		if ( ! isset( $base_declarations[ $rule_key ] ) ) {
-			$base_declarations[ $rule_key ] = array();
-		}
-		foreach ( $base_layout_style['declarations'] as $property => $value ) {
-			$base_declarations[ $rule_key ][ $property ] = $value;
-		}
-	}
-
-	$delta_styles = array();
-	foreach ( $layout_styles as $layout_style ) {
-		if ( empty( $layout_style['selector'] ) || empty( $layout_style['declarations'] ) || ! is_array( $layout_style['declarations'] ) ) {
-			continue;
-		}
-
-		$changed_declarations  = array();
-		$rule_key              = ( $layout_style['rules_group'] ?? '' ) . '|' . $layout_style['selector'];
-		$selector_declarations = $base_declarations[ $rule_key ] ?? array();
-		foreach ( $layout_style['declarations'] as $property => $value ) {
-			if ( isset( $excluded_properties[ $property ] ) ) {
-				continue;
-			}
-
-			if ( array_key_exists( $property, $selector_declarations ) && (string) $selector_declarations[ $property ] === (string) $value ) {
-				continue;
-			}
-
-			$changed_declarations[ $property ] = $value;
-		}
-
-		if ( ! empty( $changed_declarations ) ) {
-			$layout_style['declarations'] = $changed_declarations;
-			$delta_styles[]               = $layout_style;
-		}
-	}
-
-	return $delta_styles;
-}
-
-/**
  * Returns child layout styles for a block affected by its parent's layout.
  *
- * @param string $selector      CSS selector.
- * @param array  $child_layout  Child layout values.
- * @param array  $parent_layout Parent layout values.
+ * @param string     $selector         CSS selector.
+ * @param array      $child_layout     Child layout values.
+ * @param array      $parent_layout    Parent layout values.
+ * @param array|null $viewport_overrides Optional. Child viewport layout overrides to emit.
  * @return array Child layout style rules.
  */
-function gutenberg_get_child_layout_style_rules( $selector, $child_layout, $parent_layout = array() ) {
-	$child_layout_declarations = array();
-	$child_layout_styles       = array();
+function gutenberg_get_child_layout_style_rules( $selector, $child_layout, $parent_layout = array(), $viewport_overrides = null ) {
+	$base_child_layout              = is_array( $child_layout ) ? $child_layout : array();
+	$viewport_overrides             = is_array( $viewport_overrides ) ? $viewport_overrides : null;
+	$child_layout                   = null === $viewport_overrides ? $base_child_layout : array_replace( $base_child_layout, $viewport_overrides );
+	$child_layout_declarations      = array();
+	$child_layout_styles            = array();
+	$has_viewport_property_override = static function ( $property ) use ( $viewport_overrides ) {
+		return array_key_exists( $property, $viewport_overrides );
+	};
 
 	$self_stretch = $child_layout['selfStretch'] ?? null;
 
-	if ( 'fixed' === $self_stretch && isset( $child_layout['flexSize'] ) ) {
-		$child_layout_declarations['flex-basis'] = $child_layout['flexSize'];
-		$child_layout_declarations['box-sizing'] = 'border-box';
-	} elseif ( 'fill' === $self_stretch ) {
-		$child_layout_declarations['flex-grow'] = '1';
+	if ( null === $viewport_overrides || $has_viewport_property_override( 'selfStretch' ) || $has_viewport_property_override( 'flexSize' ) ) {
+		if ( 'fixed' === $self_stretch && isset( $child_layout['flexSize'] ) ) {
+			$child_layout_declarations['flex-basis'] = $child_layout['flexSize'];
+			$child_layout_declarations['box-sizing'] = 'border-box';
+		} elseif ( 'fill' === $self_stretch ) {
+			$child_layout_declarations['flex-grow'] = '1';
+		}
 	}
 
 	$column_start = $child_layout['columnStart'] ?? null;
 	$column_span  = $child_layout['columnSpan'] ?? null;
-	if ( $column_start && $column_span ) {
-		$child_layout_declarations['grid-column'] = "$column_start / span $column_span";
-	} elseif ( $column_start ) {
-		$child_layout_declarations['grid-column'] = "$column_start";
-	} elseif ( $column_span ) {
-		$child_layout_declarations['grid-column'] = "span $column_span";
+	if ( null === $viewport_overrides || $has_viewport_property_override( 'columnStart' ) || $has_viewport_property_override( 'columnSpan' ) ) {
+		if ( $column_start && $column_span ) {
+			$child_layout_declarations['grid-column'] = "$column_start / span $column_span";
+		} elseif ( $column_start ) {
+			$child_layout_declarations['grid-column'] = "$column_start";
+		} elseif ( $column_span ) {
+			$child_layout_declarations['grid-column'] = "span $column_span";
+		}
 	}
 
 	$row_start = $child_layout['rowStart'] ?? null;
 	$row_span  = $child_layout['rowSpan'] ?? null;
-	if ( $row_start && $row_span ) {
-		$child_layout_declarations['grid-row'] = "$row_start / span $row_span";
-	} elseif ( $row_start ) {
-		$child_layout_declarations['grid-row'] = "$row_start";
-	} elseif ( $row_span ) {
-		$child_layout_declarations['grid-row'] = "span $row_span";
+	if ( null === $viewport_overrides || $has_viewport_property_override( 'rowStart' ) || $has_viewport_property_override( 'rowSpan' ) ) {
+		if ( $row_start && $row_span ) {
+			$child_layout_declarations['grid-row'] = "$row_start / span $row_span";
+		} elseif ( $row_start ) {
+			$child_layout_declarations['grid-row'] = "$row_start";
+		} elseif ( $row_span ) {
+			$child_layout_declarations['grid-row'] = "span $row_span";
+		}
 	}
 
 	if ( ! empty( $child_layout_declarations ) ) {
@@ -446,7 +369,7 @@ function gutenberg_get_child_layout_style_rules( $selector, $child_layout, $pare
 	 * If there's a minimumColumnWidth, the grid is responsive. But if the minimumColumnWidth value wasn't changed, it won't be set.
 	 * In that case, if columnCount doesn't exist, we can assume that the grid is responsive.
 	 */
-	if ( ( $column_span || $column_start ) && ( $minimum_column_width || ! $column_count ) ) {
+	if ( null === $viewport_overrides && ( $column_span || $column_start ) && ( $minimum_column_width || ! $column_count ) ) {
 		$column_span_number  = floatval( $column_span );
 		$column_start_number = floatval( $column_start );
 		$parent_column_width = $minimum_column_width ? $minimum_column_width : '12rem';
@@ -513,16 +436,25 @@ function gutenberg_get_child_layout_style_rules( $selector, $child_layout, $pare
  * @param bool                 $should_skip_gap_serialization Optional. Whether to skip applying the user-defined value set in the editor. Default false.
  * @param string|array         $fallback_gap_value            Optional. The block gap value to apply. If it's an array expected properties are "top" and/or "left". Default '0.5em'.
  * @param array|null           $block_spacing                 Optional. Custom spacing set on the block. Default null.
- * @param string|null          $rules_group                   Optional. CSS grouping rule, e.g. a media query. Default null.
  * @param array                $options                       Optional. Extra options for internal callers. Default empty array.
- * @return string|array CSS styles, layout rules when requested, or empty string.
+ * @return string CSS styles, or empty string.
  */
-function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null, $should_skip_gap_serialization = false, $fallback_gap_value = '0.5em', $block_spacing = null, $rules_group = null, $options = array() ) {
-	$layout_type   = $layout['type'] ?? 'default';
-	$layout_styles = array();
+function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null, $should_skip_gap_serialization = false, $fallback_gap_value = '0.5em', $block_spacing = null, $options = array() ) {
+	$base_layout                    = is_array( $layout ) ? $layout : array();
+	$viewport_overrides             = $options['viewport_overrides'] ?? null;
+	$layout_for_styles              = null === $viewport_overrides ? $base_layout : array_replace( $base_layout, $viewport_overrides );
+	$layout_type                    = $base_layout['type'] ?? 'default';
+	$rules_group                    = $options['rules_group'] ?? null;
+	$has_block_gap_override         = ! empty( $options['has_block_gap_override'] );
+	$has_block_spacing_override     = ! empty( $options['has_block_spacing_override'] );
+	$should_output_block_gap        = null === $viewport_overrides || $has_block_gap_override;
+	$has_viewport_property_override = static function ( $property ) use ( $viewport_overrides ) {
+		return array_key_exists( $property, $viewport_overrides );
+	};
+	$layout_styles                  = array();
 
 	if ( 'default' === $layout_type ) {
-		if ( $has_block_gap_support ) {
+		if ( $has_block_gap_support && $should_output_block_gap ) {
 			if ( is_array( $gap_value ) ) {
 				$gap_value = $gap_value['top'] ?? null;
 			}
@@ -554,9 +486,9 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 	} elseif ( 'constrained' === $layout_type ) {
-		$content_size    = $layout['contentSize'] ?? '';
-		$wide_size       = $layout['wideSize'] ?? '';
-		$justify_content = $layout['justifyContent'] ?? 'center';
+		$content_size    = $layout_for_styles['contentSize'] ?? '';
+		$wide_size       = $layout_for_styles['wideSize'] ?? '';
+		$justify_content = $layout_for_styles['justifyContent'] ?? 'center';
 
 		$all_max_width_value  = $content_size ? $content_size : $wide_size;
 		$wide_max_width_value = $wide_size ? $wide_size : $content_size;
@@ -568,16 +500,23 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$margin_left  = 'left' === $justify_content ? '0 !important' : 'auto !important';
 		$margin_right = 'right' === $justify_content ? '0 !important' : 'auto !important';
 
-		if ( $content_size || $wide_size ) {
+		$has_justify_content_override    = null !== $viewport_overrides && $has_viewport_property_override( 'justifyContent' );
+		$should_output_constrained_sizes = null === $viewport_overrides || $has_viewport_property_override( 'contentSize' ) || $has_viewport_property_override( 'wideSize' );
+		if ( $should_output_constrained_sizes && ( $content_size || $wide_size ) ) {
+			$content_size_declarations = array(
+				'max-width' => $all_max_width_value,
+			);
+
+			if ( null === $viewport_overrides || $has_justify_content_override ) {
+				$content_size_declarations['margin-left']  = $margin_left;
+				$content_size_declarations['margin-right'] = $margin_right;
+			}
+
 			array_push(
 				$layout_styles,
 				array(
 					'selector'     => "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull))",
-					'declarations' => array(
-						'max-width'    => $all_max_width_value,
-						'margin-left'  => $margin_left,
-						'margin-right' => $margin_right,
-					),
+					'declarations' => $content_size_declarations,
 				),
 				array(
 					'selector'     => "$selector > .alignwide",
@@ -590,7 +529,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			);
 		}
 
-		if ( isset( $block_spacing ) ) {
+		if ( ( null === $viewport_overrides || $has_block_spacing_override ) && isset( $block_spacing ) ) {
 			$block_spacing_values = gutenberg_style_engine_get_styles(
 				array(
 					'spacing' => $block_spacing,
@@ -625,21 +564,31 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 
-		if ( 'left' === $justify_content ) {
+		if ( $has_justify_content_override && ! $should_output_constrained_sizes ) {
 			$layout_styles[] = array(
 				'selector'     => "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull))",
-				'declarations' => array( 'margin-left' => '0 !important' ),
+				'declarations' => array(
+					'margin-left'  => $margin_left,
+					'margin-right' => $margin_right,
+				),
 			);
+		} elseif ( null === $viewport_overrides ) {
+			if ( 'left' === $justify_content ) {
+				$layout_styles[] = array(
+					'selector'     => "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull))",
+					'declarations' => array( 'margin-left' => '0 !important' ),
+				);
+			}
+
+			if ( 'right' === $justify_content ) {
+				$layout_styles[] = array(
+					'selector'     => "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull))",
+					'declarations' => array( 'margin-right' => '0 !important' ),
+				);
+			}
 		}
 
-		if ( 'right' === $justify_content ) {
-			$layout_styles[] = array(
-				'selector'     => "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull))",
-				'declarations' => array( 'margin-right' => '0 !important' ),
-			);
-		}
-
-		if ( $has_block_gap_support ) {
+		if ( $has_block_gap_support && $should_output_block_gap ) {
 			if ( is_array( $gap_value ) ) {
 				$gap_value = $gap_value['top'] ?? null;
 			}
@@ -671,7 +620,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 	} elseif ( 'flex' === $layout_type ) {
-		$layout_orientation = $layout['orientation'] ?? 'horizontal';
+		$layout_orientation = $layout_for_styles['orientation'] ?? 'horizontal';
 
 		$justify_content_options = array(
 			'left'   => 'flex-start',
@@ -693,14 +642,19 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$vertical_alignment_options += array( 'space-between' => 'space-between' );
 		}
 
-		if ( ! empty( $layout['flexWrap'] ) && 'nowrap' === $layout['flexWrap'] ) {
+		$should_output_flex_wrap          = null === $viewport_overrides || $has_viewport_property_override( 'flexWrap' );
+		$should_output_flex_orientation   = null === $viewport_overrides || $has_viewport_property_override( 'orientation' );
+		$should_output_flex_justification = null === $viewport_overrides || $has_viewport_property_override( 'justifyContent' ) || $has_viewport_property_override( 'orientation' );
+		$should_output_flex_alignment     = null === $viewport_overrides || $has_viewport_property_override( 'verticalAlignment' ) || $has_viewport_property_override( 'orientation' );
+
+		if ( $should_output_flex_wrap && ! empty( $layout_for_styles['flexWrap'] ) && 'nowrap' === $layout_for_styles['flexWrap'] ) {
 			$layout_styles[] = array(
 				'selector'     => $selector,
 				'declarations' => array( 'flex-wrap' => 'nowrap' ),
 			);
 		}
 
-		if ( $has_block_gap_support && isset( $gap_value ) ) {
+		if ( $has_block_gap_support && $should_output_block_gap && isset( $gap_value ) ) {
 			$combined_gap_value = '';
 			$gap_sides          = is_array( $gap_value ) ? array( 'top', 'left' ) : array( 'top' );
 
@@ -738,39 +692,41 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			 * since we intend to convert blocks that had flex layout implemented
 			 * by custom css.
 			 */
-			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
+			if ( $should_output_flex_justification && ! empty( $layout_for_styles['justifyContent'] ) && array_key_exists( $layout_for_styles['justifyContent'], $justify_content_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
-					'declarations' => array( 'justify-content' => $justify_content_options[ $layout['justifyContent'] ] ),
+					'declarations' => array( 'justify-content' => $justify_content_options[ $layout_for_styles['justifyContent'] ] ),
 				);
 			}
 
-			if ( ! empty( $layout['verticalAlignment'] ) && array_key_exists( $layout['verticalAlignment'], $vertical_alignment_options ) ) {
+			if ( $should_output_flex_alignment && ! empty( $layout_for_styles['verticalAlignment'] ) && array_key_exists( $layout_for_styles['verticalAlignment'], $vertical_alignment_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
-					'declarations' => array( 'align-items' => $vertical_alignment_options[ $layout['verticalAlignment'] ] ),
+					'declarations' => array( 'align-items' => $vertical_alignment_options[ $layout_for_styles['verticalAlignment'] ] ),
 				);
 			}
 		} else {
-			$layout_styles[] = array(
-				'selector'     => $selector,
-				'declarations' => array( 'flex-direction' => 'column' ),
-			);
-			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
+			if ( $should_output_flex_orientation ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
-					'declarations' => array( 'align-items' => $justify_content_options[ $layout['justifyContent'] ] ),
+					'declarations' => array( 'flex-direction' => 'column' ),
 				);
-			} else {
+			}
+			if ( $should_output_flex_justification && ! empty( $layout_for_styles['justifyContent'] ) && array_key_exists( $layout_for_styles['justifyContent'], $justify_content_options ) ) {
+				$layout_styles[] = array(
+					'selector'     => $selector,
+					'declarations' => array( 'align-items' => $justify_content_options[ $layout_for_styles['justifyContent'] ] ),
+				);
+			} elseif ( $should_output_flex_justification ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
 					'declarations' => array( 'align-items' => 'flex-start' ),
 				);
 			}
-			if ( ! empty( $layout['verticalAlignment'] ) && array_key_exists( $layout['verticalAlignment'], $vertical_alignment_options ) ) {
+			if ( $should_output_flex_alignment && ! empty( $layout_for_styles['verticalAlignment'] ) && array_key_exists( $layout_for_styles['verticalAlignment'], $vertical_alignment_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
-					'declarations' => array( 'justify-content' => $vertical_alignment_options[ $layout['verticalAlignment'] ] ),
+					'declarations' => array( 'justify-content' => $vertical_alignment_options[ $layout_for_styles['verticalAlignment'] ] ),
 				);
 			}
 		}
@@ -816,77 +772,51 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$responsive_gap_value = '0px';
 		}
 
-		if ( ! empty( $layout['columnCount'] ) && ! empty( $layout['minimumColumnWidth'] ) ) {
-			$max_value       = 'max(min(' . $layout['minimumColumnWidth'] . ', 100%), (100% - (' . $responsive_gap_value . ' * (' . $layout['columnCount'] . ' - 1))) /' . $layout['columnCount'] . ')';
-			$layout_styles[] = array(
-				'selector'     => $selector,
-				'declarations' => array(
-					'grid-template-columns' => 'repeat(auto-fill, minmax(' . $max_value . ', 1fr))',
-					'container-type'        => 'inline-size',
-				),
-			);
-			if ( ! empty( $layout['rowCount'] ) ) {
-				$layout_styles[] = array(
-					'selector'     => $selector,
-					'declarations' => array( 'grid-template-rows' => 'repeat(' . $layout['rowCount'] . ', minmax(1rem, auto))' ),
-				);
-			}
-		} elseif ( ! empty( $layout['columnCount'] ) ) {
-			$layout_styles[] = array(
-				'selector'     => $selector,
-				'declarations' => array( 'grid-template-columns' => 'repeat(' . $layout['columnCount'] . ', minmax(0, 1fr))' ),
-			);
-			if ( ! empty( $layout['rowCount'] ) ) {
-				$layout_styles[] = array(
-					'selector'     => $selector,
-					'declarations' => array( 'grid-template-rows' => 'repeat(' . $layout['rowCount'] . ', minmax(1rem, auto))' ),
-				);
-			}
-		} else {
-			$minimum_column_width = ! empty( $layout['minimumColumnWidth'] ) ? $layout['minimumColumnWidth'] : '12rem';
+		$should_output_grid_columns = null === $viewport_overrides || $has_viewport_property_override( 'minimumColumnWidth' ) || $has_viewport_property_override( 'columnCount' );
+		$uses_gap_in_grid_columns   = ! empty( $layout_for_styles['columnCount'] ) && ! empty( $layout_for_styles['minimumColumnWidth'] );
+		if ( $has_block_gap_override && $uses_gap_in_grid_columns ) {
+			$should_output_grid_columns = true;
+		}
 
+		$should_output_grid_rows = ( null === $viewport_overrides || $has_viewport_property_override( 'rowCount' ) ) && ! empty( $layout_for_styles['columnCount'] ) && ! empty( $layout_for_styles['rowCount'] );
+		$grid_declarations       = array();
+
+		if ( $should_output_grid_columns && ! empty( $layout_for_styles['columnCount'] ) && ! empty( $layout_for_styles['minimumColumnWidth'] ) ) {
+			$max_value                                  = 'max(min(' . $layout_for_styles['minimumColumnWidth'] . ', 100%), (100% - (' . $responsive_gap_value . ' * (' . $layout_for_styles['columnCount'] . ' - 1))) /' . $layout_for_styles['columnCount'] . ')';
+			$grid_declarations['grid-template-columns'] = 'repeat(auto-fill, minmax(' . $max_value . ', 1fr))';
+		} elseif ( $should_output_grid_columns && ! empty( $layout_for_styles['columnCount'] ) ) {
+			$grid_declarations['grid-template-columns'] = 'repeat(' . $layout_for_styles['columnCount'] . ', minmax(0, 1fr))';
+		} elseif ( $should_output_grid_columns ) {
+			$minimum_column_width                       = ! empty( $layout_for_styles['minimumColumnWidth'] ) ? $layout_for_styles['minimumColumnWidth'] : '12rem';
+			$grid_declarations['grid-template-columns'] = 'repeat(auto-fill, minmax(min(' . $minimum_column_width . ', 100%), 1fr))';
+		}
+
+		if ( ! empty( $grid_declarations ) ) {
+			$base_has_container_type = empty( $base_layout['columnCount'] ) || ( ! empty( $base_layout['columnCount'] ) && ! empty( $base_layout['minimumColumnWidth'] ) );
+			if ( empty( $layout_for_styles['columnCount'] ) || ! empty( $layout_for_styles['minimumColumnWidth'] ) ) {
+				if ( null === $viewport_overrides || ! $base_has_container_type ) {
+					$grid_declarations['container-type'] = 'inline-size';
+				}
+			}
 			$layout_styles[] = array(
 				'selector'     => $selector,
-				'declarations' => array(
-					'grid-template-columns' => 'repeat(auto-fill, minmax(min(' . $minimum_column_width . ', 100%), 1fr))',
-					'container-type'        => 'inline-size',
-				),
+				'declarations' => $grid_declarations,
 			);
 		}
 
-		if ( $has_block_gap_support && null !== $gap_value && ! $should_skip_gap_serialization ) {
+		if ( $should_output_grid_rows ) {
+			$layout_styles[] = array(
+				'selector'     => $selector,
+				'declarations' => array( 'grid-template-rows' => 'repeat(' . $layout_for_styles['rowCount'] . ', minmax(1rem, auto))' ),
+			);
+		}
+
+		if ( $has_block_gap_support && $should_output_block_gap && null !== $gap_value && ! $should_skip_gap_serialization ) {
 			$layout_styles[] = array(
 				'selector'     => $selector,
 				'declarations' => array( 'gap' => $gap_value ),
 			);
 		}
-	}
-
-	if ( ! empty( $options['return_rules'] ) ) {
-		return $layout_styles;
-	}
-
-	$excluded_properties = $options['excluded_properties'] ?? array();
-
-	if ( ! empty( $layout_styles ) && array_key_exists( 'base_layout', $options ) && is_array( $options['base_layout'] ) ) {
-		$base_layout_styles = gutenberg_get_layout_style(
-			$selector,
-			$options['base_layout'],
-			$has_block_gap_support,
-			$options['base_gap_value'] ?? null,
-			$should_skip_gap_serialization,
-			$fallback_gap_value,
-			$options['base_block_spacing'] ?? null,
-			null,
-			array( 'return_rules' => true )
-		);
-		$layout_styles      = gutenberg_get_layout_style_delta(
-			$layout_styles,
-			$base_layout_styles,
-			$excluded_properties
-		);
-	} else {
-		$layout_styles = gutenberg_filter_layout_style_properties( $layout_styles, $excluded_properties );
 	}
 
 	if ( ! empty( $layout_styles ) ) {
@@ -1027,31 +957,11 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		// Emit responsive child layout CSS using the same container-content class
 		// so that base and responsive child layout share the exact same selector.
 		foreach ( $viewport_child_layouts as $viewport_data ) {
-			$viewport_child_full   = array_replace( $base_child_layout, $viewport_data['child_layout'] );
 			$viewport_child_styles = gutenberg_get_child_layout_style_rules(
 				".$container_content_class",
-				$viewport_child_full,
-				$parent_layout
-			);
-			$base_viewport_styles  = gutenberg_get_child_layout_style_rules(
-				".$container_content_class",
 				$base_child_layout,
-				$parent_layout
-			);
-			$viewport_child_styles = gutenberg_get_layout_style_delta(
-				$viewport_child_styles,
-				$base_viewport_styles
-			);
-
-			// Container queries don't compose with responsive media queries;
-			// drop any container-query rules and wrap the rest in the media query.
-			$viewport_child_styles = array_values(
-				array_filter(
-					$viewport_child_styles,
-					static function ( $rule ) {
-						return empty( $rule['rules_group'] );
-					}
-				)
+				$parent_layout,
+				$viewport_data['child_layout']
 			);
 			foreach ( $viewport_child_styles as $index => $rule ) {
 				$viewport_child_styles[ $index ]['rules_group'] = $viewport_data['media_query'];
@@ -1269,8 +1179,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 		/*
 		 * Emit responsive container layout styles using the same $container_class
-		 * selector as the base layout so they target the inner block wrapper. Only
-		 * the declarations that differ from base are emitted (per viewport).
+		 * selector as the base layout so they target the inner block wrapper.
 		 */
 		foreach ( WP_Theme_JSON_Gutenberg::RESPONSIVE_BREAKPOINTS as $breakpoint => $media_query ) {
 			$viewport_style = $style_attr[ $breakpoint ] ?? null;
@@ -1287,9 +1196,6 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 				continue;
 			}
 
-			$viewport_layout        = $has_viewport_layout
-				? array_replace( $used_layout, $viewport_container_layout )
-				: $used_layout;
 			$viewport_gap_value     = $has_viewport_block_gap
 				? gutenberg_sanitize_block_gap_value( $viewport_style['spacing']['blockGap'] )
 				: $gap_value;
@@ -1299,18 +1205,17 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 			$viewport_styles = gutenberg_get_layout_style(
 				".$container_class",
-				$viewport_layout,
+				$used_layout,
 				$has_block_gap_support,
 				$viewport_gap_value,
 				$should_skip_gap_serialization,
 				$fallback_gap_value,
 				$viewport_block_spacing,
-				$media_query,
 				array(
-					'base_layout'         => $used_layout,
-					'base_gap_value'      => $gap_value,
-					'base_block_spacing'  => $block_spacing,
-					'excluded_properties' => array( 'container-type' ),
+					'rules_group'                => $media_query,
+					'viewport_overrides'         => $viewport_container_layout,
+					'has_block_gap_override'     => $has_viewport_block_gap,
+					'has_block_spacing_override' => $has_viewport_padding,
 				)
 			);
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -238,6 +238,271 @@ function gutenberg_register_layout_support( $block_type ) {
 }
 
 /**
+ * Returns the child-layout-only subset of a layout object.
+ *
+ * Child layout keys are the ones controlling how the block lays itself out
+ * inside its parent's grid or flex container.
+ *
+ * @param mixed $layout Layout object.
+ * @return array Child layout values, or an empty array.
+ */
+function gutenberg_get_layout_child_values( $layout ) {
+	if ( ! is_array( $layout ) ) {
+		return array();
+	}
+
+	return array_intersect_key(
+		$layout,
+		array_flip(
+			array( 'selfStretch', 'flexSize', 'columnStart', 'columnSpan', 'rowStart', 'rowSpan' )
+		)
+	);
+}
+
+/**
+ * Returns the container-layout subset of a layout object (everything except child layout keys).
+ *
+ * @param mixed $layout Layout object.
+ * @return array Container layout values, or an empty array.
+ */
+function gutenberg_get_layout_container_values( $layout ) {
+	if ( ! is_array( $layout ) ) {
+		return array();
+	}
+
+	return array_diff_key(
+		$layout,
+		array_flip(
+			array( 'selfStretch', 'flexSize', 'columnStart', 'columnSpan', 'rowStart', 'rowSpan' )
+		)
+	);
+}
+
+/**
+ * Sanitizes a block gap value before layout style generation.
+ *
+ * Regex for CSS value borrowed from `safecss_filter_attr`, used here to only match
+ * against the value, not the CSS attribute.
+ *
+ * @param string|array|null $gap_value Block gap value.
+ * @return string|array|null Sanitized block gap value.
+ */
+function gutenberg_sanitize_block_gap_value( $gap_value ) {
+	if ( is_array( $gap_value ) ) {
+		foreach ( $gap_value as $key => $value ) {
+			$gap_value[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
+		}
+		return $gap_value;
+	}
+
+	return $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
+}
+
+/**
+ * Removes declarations for excluded properties from layout style rules.
+ *
+ * @param array $layout_styles       Layout style rules.
+ * @param array $excluded_properties CSS properties to omit.
+ * @return array Layout style rules with excluded declarations removed.
+ */
+function gutenberg_filter_layout_style_properties( $layout_styles, $excluded_properties = array() ) {
+	if ( empty( $excluded_properties ) ) {
+		return $layout_styles;
+	}
+
+	$excluded_properties = array_flip( $excluded_properties );
+	$filtered_styles     = array();
+
+	foreach ( $layout_styles as $layout_style ) {
+		if ( empty( $layout_style['declarations'] ) || ! is_array( $layout_style['declarations'] ) ) {
+			continue;
+		}
+
+		foreach ( array_keys( $layout_style['declarations'] ) as $property ) {
+			if ( isset( $excluded_properties[ $property ] ) ) {
+				unset( $layout_style['declarations'][ $property ] );
+			}
+		}
+
+		if ( ! empty( $layout_style['declarations'] ) ) {
+			$filtered_styles[] = $layout_style;
+		}
+	}
+
+	return $filtered_styles;
+}
+
+/**
+ * Filters layout style rules down to declarations that differ from base rules.
+ *
+ * @param array $layout_styles       Layout style rules.
+ * @param array $base_layout_styles  Base layout style rules.
+ * @param array $excluded_properties CSS properties to always omit.
+ * @return array Layout style rules containing changed declarations only.
+ */
+function gutenberg_get_layout_style_delta( $layout_styles, $base_layout_styles, $excluded_properties = array() ) {
+	$base_declarations   = array();
+	$excluded_properties = array_flip( $excluded_properties );
+
+	foreach ( $base_layout_styles as $base_layout_style ) {
+		if ( empty( $base_layout_style['selector'] ) || empty( $base_layout_style['declarations'] ) || ! is_array( $base_layout_style['declarations'] ) ) {
+			continue;
+		}
+
+		$rule_key = ( $base_layout_style['rules_group'] ?? '' ) . '|' . $base_layout_style['selector'];
+		if ( ! isset( $base_declarations[ $rule_key ] ) ) {
+			$base_declarations[ $rule_key ] = array();
+		}
+		foreach ( $base_layout_style['declarations'] as $property => $value ) {
+			$base_declarations[ $rule_key ][ $property ] = $value;
+		}
+	}
+
+	$delta_styles = array();
+	foreach ( $layout_styles as $layout_style ) {
+		if ( empty( $layout_style['selector'] ) || empty( $layout_style['declarations'] ) || ! is_array( $layout_style['declarations'] ) ) {
+			continue;
+		}
+
+		$changed_declarations  = array();
+		$rule_key              = ( $layout_style['rules_group'] ?? '' ) . '|' . $layout_style['selector'];
+		$selector_declarations = $base_declarations[ $rule_key ] ?? array();
+		foreach ( $layout_style['declarations'] as $property => $value ) {
+			if ( isset( $excluded_properties[ $property ] ) ) {
+				continue;
+			}
+
+			if ( array_key_exists( $property, $selector_declarations ) && (string) $selector_declarations[ $property ] === (string) $value ) {
+				continue;
+			}
+
+			$changed_declarations[ $property ] = $value;
+		}
+
+		if ( ! empty( $changed_declarations ) ) {
+			$layout_style['declarations'] = $changed_declarations;
+			$delta_styles[]               = $layout_style;
+		}
+	}
+
+	return $delta_styles;
+}
+
+/**
+ * Returns child layout styles for a block affected by its parent's layout.
+ *
+ * @param string $selector      CSS selector.
+ * @param array  $child_layout  Child layout values.
+ * @param array  $parent_layout Parent layout values.
+ * @return array Child layout style rules.
+ */
+function gutenberg_get_child_layout_style_rules( $selector, $child_layout, $parent_layout = array() ) {
+	$child_layout_declarations = array();
+	$child_layout_styles       = array();
+
+	$self_stretch = $child_layout['selfStretch'] ?? null;
+
+	if ( 'fixed' === $self_stretch && isset( $child_layout['flexSize'] ) ) {
+		$child_layout_declarations['flex-basis'] = $child_layout['flexSize'];
+		$child_layout_declarations['box-sizing'] = 'border-box';
+	} elseif ( 'fill' === $self_stretch ) {
+		$child_layout_declarations['flex-grow'] = '1';
+	}
+
+	$column_start = $child_layout['columnStart'] ?? null;
+	$column_span  = $child_layout['columnSpan'] ?? null;
+	if ( $column_start && $column_span ) {
+		$child_layout_declarations['grid-column'] = "$column_start / span $column_span";
+	} elseif ( $column_start ) {
+		$child_layout_declarations['grid-column'] = "$column_start";
+	} elseif ( $column_span ) {
+		$child_layout_declarations['grid-column'] = "span $column_span";
+	}
+
+	$row_start = $child_layout['rowStart'] ?? null;
+	$row_span  = $child_layout['rowSpan'] ?? null;
+	if ( $row_start && $row_span ) {
+		$child_layout_declarations['grid-row'] = "$row_start / span $row_span";
+	} elseif ( $row_start ) {
+		$child_layout_declarations['grid-row'] = "$row_start";
+	} elseif ( $row_span ) {
+		$child_layout_declarations['grid-row'] = "span $row_span";
+	}
+
+	if ( ! empty( $child_layout_declarations ) ) {
+		$child_layout_styles[] = array(
+			'selector'     => $selector,
+			'declarations' => $child_layout_declarations,
+		);
+	}
+
+	$minimum_column_width = $parent_layout['minimumColumnWidth'] ?? null;
+	$column_count         = $parent_layout['columnCount'] ?? null;
+
+	/*
+	 * If columnSpan or columnStart is set, and the parent grid is responsive, i.e. if it has a minimumColumnWidth set,
+	 * the columnSpan should be removed once the grid is smaller than the span, and columnStart should be removed
+	 * once the grid has less columns than the start.
+	 * If there's a minimumColumnWidth, the grid is responsive. But if the minimumColumnWidth value wasn't changed, it won't be set.
+	 * In that case, if columnCount doesn't exist, we can assume that the grid is responsive.
+	 */
+	if ( ( $column_span || $column_start ) && ( $minimum_column_width || ! $column_count ) ) {
+		$column_span_number  = floatval( $column_span );
+		$column_start_number = floatval( $column_start );
+		$parent_column_width = $minimum_column_width ? $minimum_column_width : '12rem';
+		$parent_column_value = floatval( $parent_column_width );
+		$parent_column_unit  = explode( $parent_column_value, $parent_column_width );
+
+		$num_cols_to_break_at = 2;
+		if ( $column_span_number && $column_start_number ) {
+			$num_cols_to_break_at = $column_start_number + $column_span_number - 1;
+		} elseif ( $column_span_number ) {
+			$num_cols_to_break_at = $column_span_number;
+		} else {
+			$num_cols_to_break_at = $column_start_number;
+		}
+
+		/*
+		 * If there is no unit, the width has somehow been mangled so we reset both unit and value
+		 * to defaults.
+		 * Additionally, the unit should be one of px, rem or em, so that also needs to be checked.
+		 */
+		if ( count( $parent_column_unit ) <= 1 ) {
+			$parent_column_unit  = 'rem';
+			$parent_column_value = 12;
+		} else {
+			$parent_column_unit = $parent_column_unit[1];
+
+			if ( ! in_array( $parent_column_unit, array( 'px', 'rem', 'em' ), true ) ) {
+				$parent_column_unit = 'rem';
+			}
+		}
+
+		/*
+		 * A default gap value is used for this computation because custom gap values may not be
+		 * viable to use in the computation of the container query value.
+		 */
+		$default_gap_value             = 'px' === $parent_column_unit ? 24 : 1.5;
+		$container_query_value         = $num_cols_to_break_at * $parent_column_value + ( $num_cols_to_break_at - 1 ) * $default_gap_value;
+		$minimum_container_query_value = $parent_column_value * 2 + $default_gap_value - 1;
+		$container_query_value         = max( $container_query_value, $minimum_container_query_value ) . $parent_column_unit;
+		// If a span is set we want to preserve it as long as possible, otherwise we just reset the value.
+		$grid_column_value = $column_span && $column_span > 1 ? '1/-1' : 'auto';
+
+		$child_layout_styles[] = array(
+			'rules_group'  => "@container (max-width: $container_query_value )",
+			'selector'     => $selector,
+			'declarations' => array(
+				'grid-column' => $grid_column_value,
+				'grid-row'    => 'auto',
+			),
+		);
+	}
+
+	return $child_layout_styles;
+}
+
+/**
  * Generates the CSS corresponding to the provided layout.
  *
  * @param string               $selector                      CSS selector.
@@ -248,9 +513,11 @@ function gutenberg_register_layout_support( $block_type ) {
  * @param bool                 $should_skip_gap_serialization Optional. Whether to skip applying the user-defined value set in the editor. Default false.
  * @param string|array         $fallback_gap_value            Optional. The block gap value to apply. If it's an array expected properties are "top" and/or "left". Default '0.5em'.
  * @param array|null           $block_spacing                 Optional. Custom spacing set on the block. Default null.
- * @return string CSS styles on success. Else, empty string.
+ * @param string|null          $rules_group                   Optional. CSS grouping rule, e.g. a media query. Default null.
+ * @param array                $options                       Optional. Extra options for internal callers. Default empty array.
+ * @return string|array CSS styles, layout rules when requested, or empty string.
  */
-function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null, $should_skip_gap_serialization = false, $fallback_gap_value = '0.5em', $block_spacing = null ) {
+function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null, $should_skip_gap_serialization = false, $fallback_gap_value = '0.5em', $block_spacing = null, $rules_group = null, $options = array() ) {
 	$layout_type   = $layout['type'] ?? 'default';
 	$layout_styles = array();
 
@@ -595,7 +862,40 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 	}
 
+	if ( ! empty( $options['return_rules'] ) ) {
+		return $layout_styles;
+	}
+
+	$excluded_properties = $options['excluded_properties'] ?? array();
+
+	if ( ! empty( $layout_styles ) && array_key_exists( 'base_layout', $options ) && is_array( $options['base_layout'] ) ) {
+		$base_layout_styles = gutenberg_get_layout_style(
+			$selector,
+			$options['base_layout'],
+			$has_block_gap_support,
+			$options['base_gap_value'] ?? null,
+			$should_skip_gap_serialization,
+			$fallback_gap_value,
+			$options['base_block_spacing'] ?? null,
+			null,
+			array( 'return_rules' => true )
+		);
+		$layout_styles      = gutenberg_get_layout_style_delta(
+			$layout_styles,
+			$base_layout_styles,
+			$excluded_properties
+		);
+	} else {
+		$layout_styles = gutenberg_filter_layout_style_properties( $layout_styles, $excluded_properties );
+	}
+
 	if ( ! empty( $layout_styles ) ) {
+		if ( ! empty( $rules_group ) ) {
+			foreach ( $layout_styles as $index => $layout_style ) {
+				$layout_styles[ $index ]['rules_group'] = $rules_group;
+			}
+		}
+
 		/*
 		 * Add to the style engine store to enqueue and render layout styles.
 		 * Return compiled layout styles to retain backwards compatibility.
@@ -664,142 +964,100 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	$block_type            = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$block_supports_layout = block_has_support( $block_type, array( 'layout' ), false ) || block_has_support( $block_type, array( '__experimentalLayout' ), false );
+	$style_attr            = $block['attrs']['style'] ?? array();
 	// If there is any value in style -> layout, the block has a child layout.
-	$child_layout = $block['attrs']['style']['layout'] ?? null;
+	$child_layout = $style_attr['layout'] ?? null;
 
-	if ( ! $block_supports_layout && ! $child_layout ) {
+	// Collect responsive viewport child layout overrides so that a block with
+	// only responsive child layout (no base child layout) is still processed.
+	$viewport_child_layouts = array();
+	foreach ( WP_Theme_JSON_Gutenberg::RESPONSIVE_BREAKPOINTS as $breakpoint => $media_query ) {
+		$viewport_child = gutenberg_get_layout_child_values( $style_attr[ $breakpoint ]['layout'] ?? null );
+		if ( ! empty( $viewport_child ) ) {
+			$viewport_child_layouts[ $breakpoint ] = array(
+				'media_query'  => $media_query,
+				'child_layout' => $viewport_child,
+			);
+		}
+	}
+
+	if ( ! $block_supports_layout && ! $child_layout && empty( $viewport_child_layouts ) ) {
 		return $block_content;
 	}
 
 	$outer_class_names = array();
 
 	// Child layout specific logic.
-	if ( $child_layout ) {
+	if ( $child_layout || ! empty( $viewport_child_layouts ) ) {
+		$base_child_layout = gutenberg_get_layout_child_values( $child_layout );
+		$parent_layout     = $block['parentLayout'] ?? array();
+
 		/*
 		 * Generates a unique class for child block layout styles.
 		 *
 		 * To ensure consistent class generation across different page renders,
 		 * only properties that affect layout styling are used. These properties
-		 * come from `$block['attrs']['style']['layout']` and `$block['parentLayout']`.
+		 * come from `$block['attrs']['style']['layout']`, viewport overrides in
+		 * `$block['attrs']['style'][$breakpoint]['layout']`, and
+		 * `$block['parentLayout']`.
 		 *
 		 * As long as these properties coincide, the generated class will be the same.
 		 */
-		$container_content_class = gutenberg_unique_id_from_values(
-			array(
-				'layout'       => array_intersect_key(
-					$block['attrs']['style']['layout'] ?? array(),
-					array_flip(
-						array( 'selfStretch', 'flexSize', 'columnStart', 'columnSpan', 'rowStart', 'rowSpan' )
-					)
-				),
-				'parentLayout' => array_intersect_key(
-					$block['parentLayout'] ?? array(),
-					array_flip(
-						array( 'minimumColumnWidth', 'columnCount' )
-					)
-				),
+		$container_content_hash_input = array(
+			'layout'       => $base_child_layout,
+			'parentLayout' => array_intersect_key(
+				$parent_layout,
+				array_flip( array( 'minimumColumnWidth', 'columnCount' ) )
 			),
+		);
+		foreach ( $viewport_child_layouts as $breakpoint => $viewport_data ) {
+			$container_content_hash_input[ $breakpoint ] = $viewport_data['child_layout'];
+		}
+		$container_content_class = gutenberg_unique_id_from_values(
+			$container_content_hash_input,
 			'wp-container-content-'
 		);
 
-		$child_layout_declarations = array();
-		$child_layout_styles       = array();
-
-		$self_stretch = $block['attrs']['style']['layout']['selfStretch'] ?? null;
-
-		if ( 'fixed' === $self_stretch && isset( $block['attrs']['style']['layout']['flexSize'] ) ) {
-			$child_layout_declarations['flex-basis'] = $block['attrs']['style']['layout']['flexSize'];
-			$child_layout_declarations['box-sizing'] = 'border-box';
-		} elseif ( 'fill' === $self_stretch ) {
-			$child_layout_declarations['flex-grow'] = '1';
-		}
-
-		$column_start = $block['attrs']['style']['layout']['columnStart'] ?? null;
-		$column_span  = $block['attrs']['style']['layout']['columnSpan'] ?? null;
-		if ( $column_start && $column_span ) {
-			$child_layout_declarations['grid-column'] = "$column_start / span $column_span";
-		} elseif ( $column_start ) {
-			$child_layout_declarations['grid-column'] = "$column_start";
-		} elseif ( $column_span ) {
-			$child_layout_declarations['grid-column'] = "span $column_span";
-		}
-
-		$row_start = $block['attrs']['style']['layout']['rowStart'] ?? null;
-		$row_span  = $block['attrs']['style']['layout']['rowSpan'] ?? null;
-		if ( $row_start && $row_span ) {
-			$child_layout_declarations['grid-row'] = "$row_start / span $row_span";
-		} elseif ( $row_start ) {
-			$child_layout_declarations['grid-row'] = "$row_start";
-		} elseif ( $row_span ) {
-			$child_layout_declarations['grid-row'] = "span $row_span";
-		}
-
-		$child_layout_styles[] = array(
-			'selector'     => ".$container_content_class",
-			'declarations' => $child_layout_declarations,
+		$child_layout_styles = gutenberg_get_child_layout_style_rules(
+			".$container_content_class",
+			$base_child_layout,
+			$parent_layout
 		);
 
-		$minimum_column_width = $block['parentLayout']['minimumColumnWidth'] ?? null;
-		$column_count         = $block['parentLayout']['columnCount'] ?? null;
-
-		/*
-		 * If columnSpan or columnStart is set, and the parent grid is responsive, i.e. if it has a minimumColumnWidth set,
-		 * the columnSpan should be removed once the grid is smaller than the span, and columnStart should be removed
-		 * once the grid has less columns than the start.
-		 * If there's a minimumColumnWidth, the grid is responsive. But if the minimumColumnWidth value wasn't changed, it won't be set.
-		 * In that case, if columnCount doesn't exist, we can assume that the grid is responsive.
-		 */
-		if ( ( $column_span || $column_start ) && ( $minimum_column_width || ! $column_count ) ) {
-			$column_span_number  = floatval( $column_span );
-			$column_start_number = floatval( $column_start );
-			$parent_column_width = $minimum_column_width ? $minimum_column_width : '12rem';
-			$parent_column_value = floatval( $parent_column_width );
-			$parent_column_unit  = explode( $parent_column_value, $parent_column_width );
-
-			$num_cols_to_break_at = 2;
-			if ( $column_span_number && $column_start_number ) {
-				$num_cols_to_break_at = $column_start_number + $column_span_number - 1;
-			} elseif ( $column_span_number ) {
-				$num_cols_to_break_at = $column_span_number;
-			} else {
-				$num_cols_to_break_at = $column_start_number;
-			}
-
-			/*
-			 * If there is no unit, the width has somehow been mangled so we reset both unit and value
-			 * to defaults.
-			 * Additionally, the unit should be one of px, rem or em, so that also needs to be checked.
-			 */
-			if ( count( $parent_column_unit ) <= 1 ) {
-				$parent_column_unit  = 'rem';
-				$parent_column_value = 12;
-			} else {
-				$parent_column_unit = $parent_column_unit[1];
-
-				if ( ! in_array( $parent_column_unit, array( 'px', 'rem', 'em' ), true ) ) {
-					$parent_column_unit = 'rem';
-				}
-			}
-
-			/*
-			 * A default gap value is used for this computation because custom gap values may not be
-			 * viable to use in the computation of the container query value.
-			 */
-			$default_gap_value             = 'px' === $parent_column_unit ? 24 : 1.5;
-			$container_query_value         = $num_cols_to_break_at * $parent_column_value + ( $num_cols_to_break_at - 1 ) * $default_gap_value;
-			$minimum_container_query_value = $parent_column_value * 2 + $default_gap_value - 1;
-			$container_query_value         = max( $container_query_value, $minimum_container_query_value ) . $parent_column_unit;
-			// If a span is set we want to preserve it as long as possible, otherwise we just reset the value.
-			$grid_column_value = $column_span && $column_span > 1 ? '1/-1' : 'auto';
-
-			$child_layout_styles[] = array(
-				'rules_group'  => "@container (max-width: $container_query_value )",
-				'selector'     => ".$container_content_class",
-				'declarations' => array(
-					'grid-column' => $grid_column_value,
-					'grid-row'    => 'auto',
-				),
+		// Emit responsive child layout CSS using the same container-content class
+		// so that base and responsive child layout share the exact same selector.
+		foreach ( $viewport_child_layouts as $viewport_data ) {
+			$viewport_child_full   = array_replace( $base_child_layout, $viewport_data['child_layout'] );
+			$viewport_child_styles = gutenberg_get_child_layout_style_rules(
+				".$container_content_class",
+				$viewport_child_full,
+				$parent_layout
 			);
+			$base_viewport_styles  = gutenberg_get_child_layout_style_rules(
+				".$container_content_class",
+				$base_child_layout,
+				$parent_layout
+			);
+			$viewport_child_styles = gutenberg_get_layout_style_delta(
+				$viewport_child_styles,
+				$base_viewport_styles
+			);
+
+			// Container queries don't compose with responsive media queries;
+			// drop any container-query rules and wrap the rest in the media query.
+			$viewport_child_styles = array_values(
+				array_filter(
+					$viewport_child_styles,
+					static function ( $rule ) {
+						return empty( $rule['rules_group'] );
+					}
+				)
+			);
+			foreach ( $viewport_child_styles as $index => $rule ) {
+				$viewport_child_styles[ $index ]['rules_group'] = $viewport_data['media_query'];
+			}
+
+			$child_layout_styles = array_merge( $child_layout_styles, $viewport_child_styles );
 		}
 
 		/*
@@ -899,20 +1157,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	 */
 	if ( ! current_theme_supports( 'disable-layout-styles' ) ) {
 
-		$gap_value = $block['attrs']['style']['spacing']['blockGap'] ?? null;
-
-		/*
-		 * Skip if gap value contains unsupported characters.
-		 * Regex for CSS value borrowed from `safecss_filter_attr`, and used here
-		 * to only match against the value, not the CSS attribute.
-		 */
-		if ( is_array( $gap_value ) ) {
-			foreach ( $gap_value as $key => $value ) {
-				$gap_value[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
-			}
-		} else {
-			$gap_value = $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
-		}
+		$gap_value = gutenberg_sanitize_block_gap_value( $block['attrs']['style']['spacing']['blockGap'] ?? null );
 
 		$fallback_gap_value = $block_type->supports['spacing']['blockGap']['__experimentalDefault'] ?? '0.5em';
 		$block_spacing      = $block['attrs']['style']['spacing'] ?? null;
@@ -984,6 +1229,58 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		// Only add container class and enqueue block support styles if unique styles were generated.
 		if ( ! empty( $style ) ) {
 			$class_names[] = $container_class;
+		}
+
+		/*
+		 * Emit responsive container layout styles using the same $container_class
+		 * selector as the base layout so they target the inner block wrapper. Only
+		 * the declarations that differ from base are emitted (per viewport).
+		 */
+		foreach ( WP_Theme_JSON_Gutenberg::RESPONSIVE_BREAKPOINTS as $breakpoint => $media_query ) {
+			$viewport_style = $style_attr[ $breakpoint ] ?? null;
+			if ( ! is_array( $viewport_style ) ) {
+				continue;
+			}
+
+			$viewport_container_layout = gutenberg_get_layout_container_values( $viewport_style['layout'] ?? null );
+			$has_viewport_layout       = ! empty( $viewport_container_layout );
+			$has_viewport_block_gap    = isset( $viewport_style['spacing']['blockGap'] );
+			$has_viewport_padding      = isset( $viewport_style['spacing']['padding'] );
+
+			if ( ! $has_viewport_layout && ! $has_viewport_block_gap && ! $has_viewport_padding ) {
+				continue;
+			}
+
+			$viewport_layout        = $has_viewport_layout
+				? array_replace( $used_layout, $viewport_container_layout )
+				: $used_layout;
+			$viewport_gap_value     = $has_viewport_block_gap
+				? gutenberg_sanitize_block_gap_value( $viewport_style['spacing']['blockGap'] )
+				: $gap_value;
+			$viewport_block_spacing = is_array( $viewport_style['spacing'] ?? null )
+				? array_replace( is_array( $block_spacing ) ? $block_spacing : array(), $viewport_style['spacing'] )
+				: $block_spacing;
+
+			$viewport_styles = gutenberg_get_layout_style(
+				".$container_class",
+				$viewport_layout,
+				$has_block_gap_support,
+				$viewport_gap_value,
+				$should_skip_gap_serialization,
+				$fallback_gap_value,
+				$viewport_block_spacing,
+				$media_query,
+				array(
+					'base_layout'         => $used_layout,
+					'base_gap_value'      => $gap_value,
+					'base_block_spacing'  => $block_spacing,
+					'excluded_properties' => array( 'container-type' ),
+				)
+			);
+
+			if ( ! empty( $viewport_styles ) && ! in_array( $container_class, $class_names, true ) ) {
+				$class_names[] = $container_class;
+			}
 		}
 	}
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -446,7 +446,6 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 	$layout_type                    = $base_layout['type'] ?? 'default';
 	$rules_group                    = $options['rules_group'] ?? null;
 	$has_block_gap_override         = ! empty( $options['has_block_gap_override'] );
-	$has_block_spacing_override     = ! empty( $options['has_block_spacing_override'] );
 	$should_output_block_gap        = null === $viewport_overrides || $has_block_gap_override;
 	$has_viewport_property_override = static function ( $property ) use ( $viewport_overrides ) {
 		return array_key_exists( $property, $viewport_overrides );
@@ -529,7 +528,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			);
 		}
 
-		if ( ( null === $viewport_overrides || $has_block_spacing_override ) && isset( $block_spacing ) ) {
+		if ( null === $viewport_overrides && isset( $block_spacing ) ) {
 			$block_spacing_values = gutenberg_style_engine_get_styles(
 				array(
 					'spacing' => $block_spacing,
@@ -1107,37 +1106,6 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			$fallback_gap_value = $global_block_gap_value;
 		}
 
-		$responsive_style_hash_input = array();
-		foreach ( array_keys( WP_Theme_JSON_Gutenberg::RESPONSIVE_BREAKPOINTS ) as $breakpoint ) {
-			$viewport_style = $style_attr[ $breakpoint ] ?? null;
-			if ( ! is_array( $viewport_style ) ) {
-				continue;
-			}
-
-			$viewport_container_layout = gutenberg_get_layout_container_values( $viewport_style['layout'] ?? null );
-			$has_viewport_layout       = ! empty( $viewport_container_layout );
-			$has_viewport_block_gap    = isset( $viewport_style['spacing']['blockGap'] );
-			$has_viewport_padding      = isset( $viewport_style['spacing']['padding'] );
-
-			if ( ! $has_viewport_layout && ! $has_viewport_block_gap && ! $has_viewport_padding ) {
-				continue;
-			}
-
-			$responsive_style_hash_input[ $breakpoint ] = array();
-
-			if ( $has_viewport_layout ) {
-				$responsive_style_hash_input[ $breakpoint ]['layout'] = $viewport_container_layout;
-			}
-
-			if ( $has_viewport_block_gap ) {
-				$responsive_style_hash_input[ $breakpoint ]['blockGap'] = gutenberg_sanitize_block_gap_value( $viewport_style['spacing']['blockGap'] );
-			}
-
-			if ( $has_viewport_padding ) {
-				$responsive_style_hash_input[ $breakpoint ]['padding'] = $viewport_style['spacing']['padding'];
-			}
-		}
-
 		/*
 		 * We generate a unique ID based on all the data required to obtain the
 		 * corresponding layout style. This way, the CSS class names keep the same
@@ -1153,8 +1121,27 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			$fallback_gap_value,
 			$block_spacing,
 		);
-		if ( ! empty( $responsive_style_hash_input ) ) {
-			$container_class_hash_input[] = $responsive_style_hash_input;
+
+		foreach ( array_keys( WP_Theme_JSON_Gutenberg::RESPONSIVE_BREAKPOINTS ) as $breakpoint ) {
+			$viewport_style = $style_attr[ $breakpoint ] ?? null;
+			if ( ! is_array( $viewport_style ) ) {
+				continue;
+			}
+
+			$viewport_container_layout = gutenberg_get_layout_container_values( $viewport_style['layout'] ?? null );
+			if ( ! empty( $viewport_container_layout ) ) {
+				$container_class_hash_input[] = array(
+					'breakpoint' => $breakpoint,
+					'layout'     => $viewport_container_layout,
+				);
+			}
+
+			if ( isset( $viewport_style['spacing']['blockGap'] ) ) {
+				$container_class_hash_input[] = array(
+					'breakpoint' => $breakpoint,
+					'blockGap'   => gutenberg_sanitize_block_gap_value( $viewport_style['spacing']['blockGap'] ),
+				);
+			}
 		}
 
 		$container_class = gutenberg_unique_id_from_values(
@@ -1190,9 +1177,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			$viewport_container_layout = gutenberg_get_layout_container_values( $viewport_style['layout'] ?? null );
 			$has_viewport_layout       = ! empty( $viewport_container_layout );
 			$has_viewport_block_gap    = isset( $viewport_style['spacing']['blockGap'] );
-			$has_viewport_padding      = isset( $viewport_style['spacing']['padding'] );
 
-			if ( ! $has_viewport_layout && ! $has_viewport_block_gap && ! $has_viewport_padding ) {
+			if ( ! $has_viewport_layout && ! $has_viewport_block_gap ) {
 				continue;
 			}
 
@@ -1212,10 +1198,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 				$fallback_gap_value,
 				$viewport_block_spacing,
 				array(
-					'rules_group'                => $media_query,
-					'viewport_overrides'         => $viewport_container_layout,
-					'has_block_gap_override'     => $has_viewport_block_gap,
-					'has_block_spacing_override' => $has_viewport_padding,
+					'rules_group'            => $media_query,
+					'viewport_overrides'     => $viewport_container_layout,
+					'has_block_gap_override' => $has_viewport_block_gap,
 				)
 			);
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -1197,6 +1197,37 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			$fallback_gap_value = $global_block_gap_value;
 		}
 
+		$responsive_style_hash_input = array();
+		foreach ( array_keys( WP_Theme_JSON_Gutenberg::RESPONSIVE_BREAKPOINTS ) as $breakpoint ) {
+			$viewport_style = $style_attr[ $breakpoint ] ?? null;
+			if ( ! is_array( $viewport_style ) ) {
+				continue;
+			}
+
+			$viewport_container_layout = gutenberg_get_layout_container_values( $viewport_style['layout'] ?? null );
+			$has_viewport_layout       = ! empty( $viewport_container_layout );
+			$has_viewport_block_gap    = isset( $viewport_style['spacing']['blockGap'] );
+			$has_viewport_padding      = isset( $viewport_style['spacing']['padding'] );
+
+			if ( ! $has_viewport_layout && ! $has_viewport_block_gap && ! $has_viewport_padding ) {
+				continue;
+			}
+
+			$responsive_style_hash_input[ $breakpoint ] = array();
+
+			if ( $has_viewport_layout ) {
+				$responsive_style_hash_input[ $breakpoint ]['layout'] = $viewport_container_layout;
+			}
+
+			if ( $has_viewport_block_gap ) {
+				$responsive_style_hash_input[ $breakpoint ]['blockGap'] = gutenberg_sanitize_block_gap_value( $viewport_style['spacing']['blockGap'] );
+			}
+
+			if ( $has_viewport_padding ) {
+				$responsive_style_hash_input[ $breakpoint ]['padding'] = $viewport_style['spacing']['padding'];
+			}
+		}
+
 		/*
 		 * We generate a unique ID based on all the data required to obtain the
 		 * corresponding layout style. This way, the CSS class names keep the same
@@ -1204,15 +1235,20 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		 * make the CSS class names stable across paginations for features like the
 		 * enhanced pagination of the Query block.
 		 */
+		$container_class_hash_input = array(
+			$used_layout,
+			$has_block_gap_support,
+			$gap_value,
+			$should_skip_gap_serialization,
+			$fallback_gap_value,
+			$block_spacing,
+		);
+		if ( ! empty( $responsive_style_hash_input ) ) {
+			$container_class_hash_input[] = $responsive_style_hash_input;
+		}
+
 		$container_class = gutenberg_unique_id_from_values(
-			array(
-				$used_layout,
-				$has_block_gap_support,
-				$gap_value,
-				$should_skip_gap_serialization,
-				$fallback_gap_value,
-				$block_spacing,
-			),
+			$container_class_hash_input,
 			'wp-container-' . sanitize_title( $block['blockName'] ) . '-is-layout-'
 		);
 

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -43,7 +43,9 @@ function gutenberg_normalize_state_preset_vars( $value ) {
  * @return array Normalized state style object.
  */
 function gutenberg_normalize_state_style_for_css_output( $style ) {
-	return gutenberg_normalize_state_preset_vars( $style );
+	$style = gutenberg_normalize_state_preset_vars( $style );
+	unset( $style['layout'] );
+	return $style;
 }
 
 /**
@@ -421,6 +423,10 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 	 *
 	 * State declarations need !important to apply reliably over inline styles and
 	 * preset utility classes such as .has-accent-3-background-color.
+	 *
+	 * Layout-driven state styles (responsive layout, blockGap, child layout) are
+	 * handled by gutenberg_render_layout_support_flag() so they share a selector
+	 * with the base layout and target the correct (inner) wrapper element.
 	 */
 	$style_rules = array();
 	foreach ( $css_rules as $rule ) {

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -43,8 +43,9 @@ function gutenberg_normalize_state_preset_vars( $value ) {
  * @return array Normalized state style object.
  */
 function gutenberg_normalize_state_style_for_css_output( $style ) {
-	$style = gutenberg_normalize_state_preset_vars( $style );
+	// Layout is processed separately by gutenberg_render_layout_support_flag(), so we remove it before declaration generation.
 	unset( $style['layout'] );
+	$style = gutenberg_normalize_state_preset_vars( $style );
 	return $style;
 }
 

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -41,7 +41,11 @@ import { BlockStateBadges, BlockStatesControl } from '../../hooks/states';
 import ContentTab from '../inspector-controls-tabs/content-tab';
 import ViewportVisibilityInfo from '../block-visibility/viewport-visibility-info';
 import { unlock } from '../../lock-unlock';
-import { isDefaultBlockStyleState } from '../../hooks/block-style-state';
+import {
+	hasPseudoBlockStyleState,
+	hasViewportBlockStyleState,
+	isDefaultBlockStyleState,
+} from '../../hooks/block-style-state';
 import { onViewportStateChangeKey } from '../../store/private-keys';
 
 function StyleInspectorSlots( {
@@ -88,8 +92,11 @@ function StyleInspectorSlots( {
 	);
 }
 
-function StyleStateInspectorSlots( { blockName } ) {
+function StyleStateInspectorSlots( { blockName, selectedBlockStyleState } ) {
 	const borderPanelLabel = useBorderPanelLabel( { blockName } );
+	const showLayoutControls =
+		hasViewportBlockStyleState( selectedBlockStyleState ) &&
+		! hasPseudoBlockStyleState( selectedBlockStyleState );
 	return (
 		<>
 			<InspectorControls.Slot
@@ -106,6 +113,12 @@ function StyleStateInspectorSlots( { blockName } ) {
 				group="typography"
 				label={ __( 'Typography' ) }
 			/>
+			{ showLayoutControls && (
+				<InspectorControls.Slot
+					group="layout"
+					label={ __( 'Layout' ) }
+				/>
+			) }
 			<InspectorControls.Slot
 				group="dimensions"
 				label={ __( 'Dimensions' ) }
@@ -473,7 +486,10 @@ const BlockInspectorSingleBlock = ( {
 			<BlockVariationTransforms blockClientId={ renderedBlockClientId } />
 			<BlockInspectorPreTabsSlot />
 			{ isBlockStyleStateSelected && ! isSectionBlock && (
-				<StyleStateInspectorSlots blockName={ blockName } />
+				<StyleStateInspectorSlots
+					blockName={ blockName }
+					selectedBlockStyleState={ selectedBlockStyleState }
+				/>
 			) }
 			{ ! isBlockStyleStateSelected && hasMultipleTabs && (
 				<>

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -31,7 +31,7 @@ import { cleanEmptyObject } from '../../hooks/utils';
 import { setImmutably } from '../../utils/object';
 import {
 	DEFAULT_BLOCK_STYLE_STATE,
-	isDefaultBlockStyleState,
+	hasPseudoBlockStyleState,
 } from '../../hooks/block-style-state';
 
 const AXIAL_SIDES = [ 'horizontal', 'vertical' ];
@@ -97,7 +97,7 @@ function hasAspectRatio( settings ) {
 }
 
 function hasChildLayout( settings, styleState = DEFAULT_BLOCK_STYLE_STATE ) {
-	if ( ! isDefaultBlockStyleState( styleState ) ) {
+	if ( hasPseudoBlockStyleState( styleState ) ) {
 		return false;
 	}
 
@@ -509,6 +509,7 @@ export default function DimensionsPanel( {
 		onChange( {
 			...value,
 			layout: {
+				...value?.layout,
 				...newChildLayout,
 			},
 		} );

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -36,38 +36,22 @@ function serializeRule( { selector, declarations } ) {
 	}`;
 }
 
-function getRuleKey( rule ) {
-	return `${ rule.rulesGroup || '' }|${ rule.selector }`;
-}
-
-function getChildLayoutStyleRuleDelta( baseRules, nextRules ) {
-	const baseDeclarationsByRule = new Map(
-		baseRules.map( ( rule ) => [ getRuleKey( rule ), rule.declarations ] )
-	);
-
-	return nextRules.flatMap( ( rule ) => {
-		const baseDeclarations = baseDeclarationsByRule.get(
-			getRuleKey( rule )
-		);
-		const changedDeclarations = Object.fromEntries(
-			Object.entries( rule.declarations ).filter(
-				( [ property, value ] ) =>
-					baseDeclarations?.[ property ] !== value
-			)
-		);
-
-		return Object.keys( changedDeclarations ).length
-			? [ { ...rule, declarations: changedDeclarations } ]
-			: [];
-	} );
-}
-
 export function getChildLayoutStyleRules( {
 	selector,
 	layout = {},
+	viewportOverrides,
 	parentLayout = {},
 	includeContainerQuery = true,
 } ) {
+	const hasViewportOverrides = viewportOverrides !== undefined;
+	const effectiveLayout = hasViewportOverrides
+		? {
+				...layout,
+				...viewportOverrides,
+		  }
+		: layout;
+	const hasViewportOverride = ( key ) =>
+		Object.hasOwn( viewportOverrides || {}, key );
 	const {
 		selfStretch,
 		flexSize,
@@ -75,41 +59,59 @@ export function getChildLayoutStyleRules( {
 		rowStart,
 		columnSpan,
 		rowSpan,
-	} = layout;
+	} = effectiveLayout;
 	const { columnCount, minimumColumnWidth } = parentLayout;
 	const rules = [];
 
 	const declarations = {};
-	if ( selfStretch === 'fixed' && flexSize ) {
-		declarations[ 'flex-basis' ] = flexSize;
-		declarations[ 'box-sizing' ] = 'border-box';
-	} else if ( selfStretch === 'fill' ) {
-		declarations[ 'flex-grow' ] = '1';
+	if (
+		! hasViewportOverrides ||
+		hasViewportOverride( 'selfStretch' ) ||
+		hasViewportOverride( 'flexSize' )
+	) {
+		if ( selfStretch === 'fixed' && flexSize ) {
+			declarations[ 'flex-basis' ] = flexSize;
+			declarations[ 'box-sizing' ] = 'border-box';
+		} else if ( selfStretch === 'fill' ) {
+			declarations[ 'flex-grow' ] = '1';
+		}
 	}
 
-	if ( columnStart && columnSpan ) {
-		declarations[
-			'grid-column'
-		] = `${ columnStart } / span ${ columnSpan }`;
-	} else if ( columnStart ) {
-		declarations[ 'grid-column' ] = `${ columnStart }`;
-	} else if ( columnSpan ) {
-		declarations[ 'grid-column' ] = `span ${ columnSpan }`;
+	if (
+		! hasViewportOverrides ||
+		hasViewportOverride( 'columnStart' ) ||
+		hasViewportOverride( 'columnSpan' )
+	) {
+		if ( columnStart && columnSpan ) {
+			declarations[
+				'grid-column'
+			] = `${ columnStart } / span ${ columnSpan }`;
+		} else if ( columnStart ) {
+			declarations[ 'grid-column' ] = `${ columnStart }`;
+		} else if ( columnSpan ) {
+			declarations[ 'grid-column' ] = `span ${ columnSpan }`;
+		}
 	}
 
-	if ( rowStart && rowSpan ) {
-		declarations[ 'grid-row' ] = `${ rowStart } / span ${ rowSpan }`;
-	} else if ( rowStart ) {
-		declarations[ 'grid-row' ] = `${ rowStart }`;
-	} else if ( rowSpan ) {
-		declarations[ 'grid-row' ] = `span ${ rowSpan }`;
+	if (
+		! hasViewportOverrides ||
+		hasViewportOverride( 'rowStart' ) ||
+		hasViewportOverride( 'rowSpan' )
+	) {
+		if ( rowStart && rowSpan ) {
+			declarations[ 'grid-row' ] = `${ rowStart } / span ${ rowSpan }`;
+		} else if ( rowStart ) {
+			declarations[ 'grid-row' ] = `${ rowStart }`;
+		} else if ( rowSpan ) {
+			declarations[ 'grid-row' ] = `span ${ rowSpan }`;
+		}
 	}
 
 	if ( Object.keys( declarations ).length ) {
 		rules.push( { selector, declarations } );
 	}
 
-	if ( includeContainerQuery ) {
+	if ( includeContainerQuery && ! hasViewportOverrides ) {
 		/**
 		 * If minimumColumnWidth is set on the parent, or if no
 		 * columnCount is set, the grid is responsive so a
@@ -208,12 +210,6 @@ export function getResponsiveChildLayoutStyles( {
 	parentLayout = {},
 } ) {
 	const baseLayout = style?.layout ?? {};
-	const baseRules = getChildLayoutStyleRules( {
-		selector,
-		layout: baseLayout,
-		parentLayout,
-		includeContainerQuery: false,
-	} );
 
 	return Object.entries( RESPONSIVE_BREAKPOINTS )
 		.map( ( [ viewport, mediaQuery ] ) => {
@@ -222,18 +218,13 @@ export function getResponsiveChildLayoutStyles( {
 				return '';
 			}
 
-			const viewportRules = getChildLayoutStyleRuleDelta(
-				baseRules,
-				getChildLayoutStyleRules( {
-					selector,
-					layout: {
-						...baseLayout,
-						...viewportLayout,
-					},
-					parentLayout,
-					includeContainerQuery: false,
-				} )
-			);
+			const viewportRules = getChildLayoutStyleRules( {
+				selector,
+				layout: baseLayout,
+				viewportOverrides: viewportLayout,
+				parentLayout,
+				includeContainerQuery: false,
+			} );
 			const css = viewportRules.map( serializeRule ).join( '' );
 
 			return css ? `${ mediaQuery }{${ css }}` : '';

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -22,12 +22,52 @@ import { BLOCK_VISIBILITY_VIEWPORTS } from '../components/block-visibility/const
 
 // Used for generating the instance ID
 const LAYOUT_CHILD_BLOCK_PROPS_REFERENCE = {};
+// Keep in sync with WP_Theme_JSON_Gutenberg::RESPONSIVE_BREAKPOINTS.
+const RESPONSIVE_BREAKPOINTS = {
+	mobile: '@media (width <= 480px)',
+	tablet: '@media (480px < width <= 782px)',
+};
 
-function useBlockPropsChildLayoutStyles( { style } ) {
-	const shouldRenderChildLayoutStyles = useSelect( ( select ) => {
-		return ! select( blockEditorStore ).getSettings().disableLayoutStyles;
+function serializeRule( { selector, declarations } ) {
+	return `${ selector } {
+		${ Object.entries( declarations )
+			.map( ( [ property, value ] ) => `${ property }: ${ value }` )
+			.join( '; ' ) };
+	}`;
+}
+
+function getRuleKey( rule ) {
+	return `${ rule.rulesGroup || '' }|${ rule.selector }`;
+}
+
+function getChildLayoutStyleRuleDelta( baseRules, nextRules ) {
+	const baseDeclarationsByRule = new Map(
+		baseRules.map( ( rule ) => [ getRuleKey( rule ), rule.declarations ] )
+	);
+
+	return nextRules.flatMap( ( rule ) => {
+		const baseDeclarations = baseDeclarationsByRule.get(
+			getRuleKey( rule )
+		);
+		const changedDeclarations = Object.fromEntries(
+			Object.entries( rule.declarations ).filter(
+				( [ property, value ] ) =>
+					baseDeclarations?.[ property ] !== value
+			)
+		);
+
+		return Object.keys( changedDeclarations ).length
+			? [ { ...rule, declarations: changedDeclarations } ]
+			: [];
 	} );
-	const layout = style?.layout ?? {};
+}
+
+export function getChildLayoutStyleRules( {
+	selector,
+	layout = {},
+	parentLayout = {},
+	includeContainerQuery = true,
+} ) {
 	const {
 		selfStretch,
 		flexSize,
@@ -36,65 +76,40 @@ function useBlockPropsChildLayoutStyles( { style } ) {
 		columnSpan,
 		rowSpan,
 	} = layout;
-	const parentLayout = useLayout() || {};
 	const { columnCount, minimumColumnWidth } = parentLayout;
-	const id = useInstanceId( LAYOUT_CHILD_BLOCK_PROPS_REFERENCE );
-	const selector = `.wp-container-content-${ id }`;
+	const rules = [];
 
-	// Check that the grid layout attributes are of the correct type, so that we don't accidentally
-	// write code that stores a string attribute instead of a number.
-	if ( process.env.NODE_ENV === 'development' ) {
-		if ( columnStart && typeof columnStart !== 'number' ) {
-			throw new Error( 'columnStart must be a number' );
-		}
-		if ( rowStart && typeof rowStart !== 'number' ) {
-			throw new Error( 'rowStart must be a number' );
-		}
-		if ( columnSpan && typeof columnSpan !== 'number' ) {
-			throw new Error( 'columnSpan must be a number' );
-		}
-		if ( rowSpan && typeof rowSpan !== 'number' ) {
-			throw new Error( 'rowSpan must be a number' );
-		}
+	const declarations = {};
+	if ( selfStretch === 'fixed' && flexSize ) {
+		declarations[ 'flex-basis' ] = flexSize;
+		declarations[ 'box-sizing' ] = 'border-box';
+	} else if ( selfStretch === 'fill' ) {
+		declarations[ 'flex-grow' ] = '1';
 	}
 
-	let css = '';
-	if ( shouldRenderChildLayoutStyles ) {
-		if ( selfStretch === 'fixed' && flexSize ) {
-			css = `${ selector } {
-				flex-basis: ${ flexSize };
-				box-sizing: border-box;
-			}`;
-		} else if ( selfStretch === 'fill' ) {
-			css = `${ selector } {
-				flex-grow: 1;
-			}`;
-		} else if ( columnStart && columnSpan ) {
-			css = `${ selector } {
-				grid-column: ${ columnStart } / span ${ columnSpan };
-			}`;
-		} else if ( columnStart ) {
-			css = `${ selector } {
-				grid-column: ${ columnStart };
-			}`;
-		} else if ( columnSpan ) {
-			css = `${ selector } {
-				grid-column: span ${ columnSpan };
-			}`;
-		}
-		if ( rowStart && rowSpan ) {
-			css += `${ selector } {
-				grid-row: ${ rowStart } / span ${ rowSpan };
-			}`;
-		} else if ( rowStart ) {
-			css += `${ selector } {
-				grid-row: ${ rowStart };
-			}`;
-		} else if ( rowSpan ) {
-			css += `${ selector } {
-				grid-row: span ${ rowSpan };
-			}`;
-		}
+	if ( columnStart && columnSpan ) {
+		declarations[
+			'grid-column'
+		] = `${ columnStart } / span ${ columnSpan }`;
+	} else if ( columnStart ) {
+		declarations[ 'grid-column' ] = `${ columnStart }`;
+	} else if ( columnSpan ) {
+		declarations[ 'grid-column' ] = `span ${ columnSpan }`;
+	}
+
+	if ( rowStart && rowSpan ) {
+		declarations[ 'grid-row' ] = `${ rowStart } / span ${ rowSpan }`;
+	} else if ( rowStart ) {
+		declarations[ 'grid-row' ] = `${ rowStart }`;
+	} else if ( rowSpan ) {
+		declarations[ 'grid-row' ] = `span ${ rowSpan }`;
+	}
+
+	if ( Object.keys( declarations ).length ) {
+		rules.push( { selector, declarations } );
+	}
+
+	if ( includeContainerQuery ) {
 		/**
 		 * If minimumColumnWidth is set on the parent, or if no
 		 * columnCount is set, the grid is responsive so a
@@ -147,16 +162,127 @@ function useBlockPropsChildLayoutStyles( { style } ) {
 			const gridColumnValue =
 				columnSpan && columnSpan > 1 ? '1/-1' : 'auto';
 
-			css += `@container (max-width: ${ Math.max(
-				containerQueryValue,
-				minimumContainerQueryValue
-			) }${ parentColumnUnit }) {
-				${ selector } {
-					grid-column: ${ gridColumnValue };
-					grid-row: auto;
-				}
-			}`;
+			rules.push( {
+				rulesGroup: `@container (max-width: ${ Math.max(
+					containerQueryValue,
+					minimumContainerQueryValue
+				) }${ parentColumnUnit })`,
+				selector,
+				declarations: {
+					'grid-column': gridColumnValue,
+					'grid-row': 'auto',
+				},
+			} );
 		}
+	}
+
+	return rules;
+}
+
+export function getChildLayoutStyles( {
+	selector,
+	layout = {},
+	parentLayout = {},
+	includeContainerQuery = true,
+} ) {
+	return getChildLayoutStyleRules( {
+		selector,
+		layout,
+		parentLayout,
+		includeContainerQuery,
+	} )
+		.map( ( rule ) => {
+			const serializedRule = serializeRule( rule );
+			return rule.rulesGroup
+				? `${ rule.rulesGroup } {
+				${ serializedRule }
+			}`
+				: serializedRule;
+		} )
+		.join( '' );
+}
+
+export function getResponsiveChildLayoutStyles( {
+	style = {},
+	selector,
+	parentLayout = {},
+} ) {
+	const baseLayout = style?.layout ?? {};
+	const baseRules = getChildLayoutStyleRules( {
+		selector,
+		layout: baseLayout,
+		parentLayout,
+		includeContainerQuery: false,
+	} );
+
+	return Object.entries( RESPONSIVE_BREAKPOINTS )
+		.map( ( [ viewport, mediaQuery ] ) => {
+			const viewportLayout = style?.[ viewport ]?.layout;
+			if ( ! viewportLayout || ! Object.keys( viewportLayout ).length ) {
+				return '';
+			}
+
+			const viewportRules = getChildLayoutStyleRuleDelta(
+				baseRules,
+				getChildLayoutStyleRules( {
+					selector,
+					layout: {
+						...baseLayout,
+						...viewportLayout,
+					},
+					parentLayout,
+					includeContainerQuery: false,
+				} )
+			);
+			const css = viewportRules.map( serializeRule ).join( '' );
+
+			return css ? `${ mediaQuery }{${ css }}` : '';
+		} )
+		.filter( Boolean )
+		.join( '' );
+}
+
+function useBlockPropsChildLayoutStyles( { style } ) {
+	const shouldRenderChildLayoutStyles = useSelect( ( select ) => {
+		return ! select( blockEditorStore ).getSettings().disableLayoutStyles;
+	} );
+	const layout = style?.layout ?? {};
+	const { columnStart, rowStart, columnSpan, rowSpan } = layout;
+	const parentLayout = useLayout() || {};
+	const id = useInstanceId( LAYOUT_CHILD_BLOCK_PROPS_REFERENCE );
+	const selector = `.wp-container-content-${ id }`;
+
+	// Check that the grid layout attributes are of the correct type, so that we don't accidentally
+	// write code that stores a string attribute instead of a number.
+	if ( process.env.NODE_ENV === 'development' ) {
+		if ( columnStart && typeof columnStart !== 'number' ) {
+			throw new Error( 'columnStart must be a number' );
+		}
+		if ( rowStart && typeof rowStart !== 'number' ) {
+			throw new Error( 'rowStart must be a number' );
+		}
+		if ( columnSpan && typeof columnSpan !== 'number' ) {
+			throw new Error( 'columnSpan must be a number' );
+		}
+		if ( rowSpan && typeof rowSpan !== 'number' ) {
+			throw new Error( 'rowSpan must be a number' );
+		}
+	}
+
+	let css = '';
+	if ( shouldRenderChildLayoutStyles ) {
+		css = [
+			getChildLayoutStyles( {
+				selector,
+				layout,
+				parentLayout,
+			} ),
+			getResponsiveChildLayoutStyles( {
+				style,
+				selector,
+				parentLayout,
+			} ),
+		].join( '' );
 	}
 
 	useStyleOverride( { css } );

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -42,6 +42,7 @@ import {
 	getStyleForState,
 	hasPseudoBlockStyleState,
 	hasViewportBlockStyleState,
+	isDefaultBlockStyleState,
 	setStyleForState,
 } from './block-style-state';
 
@@ -452,6 +453,10 @@ function LayoutPanelPure( {
 	const displayControlsForLegacyLayouts =
 		! usedLayout.type && ( contentSize || inherit );
 	const hasContentSizeOrLegacySettings = !! inherit || !! contentSize;
+	const showLayoutTypeSwitcher =
+		isDefaultBlockStyleState( selectedState ) &&
+		! inherit &&
+		allowSwitching;
 
 	const onChangeLayout = ( newLayout ) => {
 		if ( isViewportLayoutState ) {
@@ -522,7 +527,7 @@ function LayoutPanelPure( {
 					</ToolsPanelItem>
 				) }
 
-				{ ! inherit && allowSwitching && (
+				{ showLayoutTypeSwitcher && (
 					<ToolsPanelItem
 						label={ __( 'Layout type' ) }
 						hasValue={ hasLayoutTypeValue }

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -37,10 +37,31 @@ import { cleanEmptyObject, useBlockSettings, useStyleOverride } from './utils';
 import { unlock } from '../lock-unlock';
 import { globalStylesDataKey } from '../store/private-keys';
 import { getVariationNameFromClass } from './block-style-variation';
+import {
+	DEFAULT_BLOCK_STYLE_STATE,
+	getStyleForState,
+	hasPseudoBlockStyleState,
+	hasViewportBlockStyleState,
+	setStyleForState,
+} from './block-style-state';
 
 const VARIATION_PREFIX = 'is-style-';
 
 const layoutBlockSupportKey = 'layout';
+// Keep in sync with WP_Theme_JSON_Gutenberg::RESPONSIVE_BREAKPOINTS and
+// packages/global-styles-engine/src/core/render.tsx.
+const RESPONSIVE_BREAKPOINTS = {
+	mobile: '@media (width <= 480px)',
+	tablet: '@media (480px < width <= 782px)',
+};
+const CHILD_LAYOUT_KEYS = [
+	'selfStretch',
+	'flexSize',
+	'columnStart',
+	'columnSpan',
+	'rowStart',
+	'rowSpan',
+];
 const { kebabCase } = unlock( componentsPrivateApis );
 
 function getDefaultLayout( layoutBlockSupport = {}, blockVariation ) {
@@ -61,6 +82,92 @@ export function getResetLayout( layoutBlockSupport = {}, blockVariation ) {
 	return cleanEmptyObject( {
 		...getDefaultLayout( layoutBlockSupport, blockVariation ),
 	} );
+}
+
+function getLayoutStateOverrides(
+	layout = {},
+	baseLayout = {},
+	existingLayout = {}
+) {
+	const overrides = {};
+	const childLayoutValues = Object.fromEntries(
+		CHILD_LAYOUT_KEYS.filter( ( key ) =>
+			Object.hasOwn( existingLayout || {}, key )
+		).map( ( key ) => [ key, existingLayout[ key ] ] )
+	);
+
+	Object.entries( layout || {} ).forEach( ( [ key, value ] ) => {
+		if (
+			! CHILD_LAYOUT_KEYS.includes( key ) &&
+			value !== baseLayout?.[ key ]
+		) {
+			overrides[ key ] = value;
+		}
+	} );
+
+	return cleanEmptyObject( {
+		...childLayoutValues,
+		...overrides,
+	} );
+}
+
+function getCSSRulesBySelector( css = '' ) {
+	const rules = new Map();
+	const rulePattern = /([^{}]+)\{([^{}]*)\}/g;
+	let match;
+
+	while ( ( match = rulePattern.exec( css ) ) ) {
+		const selector = match[ 1 ].trim();
+		const declarations = rules.get( selector ) ?? new Map();
+		match[ 2 ]
+			.split( ';' )
+			.map( ( declaration ) => declaration.trim() )
+			.filter( Boolean )
+			.forEach( ( declaration ) => {
+				const separatorIndex = declaration.indexOf( ':' );
+				if ( separatorIndex === -1 ) {
+					return;
+				}
+				const property = declaration.slice( 0, separatorIndex ).trim();
+				const value = declaration.slice( separatorIndex + 1 ).trim();
+				declarations.set( property, value );
+			} );
+
+		rules.set( selector, declarations );
+	}
+
+	return rules;
+}
+
+function getLayoutStyleDelta( baseCSS = '', nextCSS = '' ) {
+	const baseRules = getCSSRulesBySelector( baseCSS );
+	const nextRules = getCSSRulesBySelector( nextCSS );
+	const excludedProperties = new Set( [ 'container-type' ] );
+	const deltaRules = [];
+
+	nextRules.forEach( ( nextDeclarations, selector ) => {
+		const baseDeclarations = baseRules.get( selector );
+		const changedDeclarations = [];
+
+		nextDeclarations.forEach( ( value, property ) => {
+			if (
+				excludedProperties.has( property ) ||
+				baseDeclarations?.get( property ) === value
+			) {
+				return;
+			}
+
+			changedDeclarations.push( `${ property }: ${ value }` );
+		} );
+
+		if ( changedDeclarations.length ) {
+			deltaRules.push(
+				`${ selector } { ${ changedDeclarations.join( '; ' ) }; }`
+			);
+		}
+	} );
+
+	return deltaRules.join( '' );
 }
 
 function hasLayoutBlockSupport( blockName ) {
@@ -169,8 +276,84 @@ export function useLayoutStyles( blockAttributes = {}, blockName, selector ) {
 	} );
 }
 
+/**
+ * Generates responsive layout CSS for viewport state styles.
+ *
+ * Viewport state blockGap values need to go through the layout definitions
+ * because flow/constrained layouts use child margins while flex/grid use gap.
+ *
+ * @param { Object }  options                     Options.
+ * @param { Object }  options.attributes          Block attributes.
+ * @param { string }  options.blockName           Block name.
+ * @param { string }  options.selector            CSS selector.
+ * @param { Object }  options.layout              Active block layout.
+ * @param { boolean } options.hasBlockGapSupport  Whether block gap is supported.
+ * @param { * }       options.globalBlockGapValue Global block gap fallback.
+ *
+ * @return { string } CSS rule.
+ */
+export function getResponsiveLayoutStyles( {
+	attributes = {},
+	blockName,
+	selector,
+	layout = {},
+	hasBlockGapSupport,
+	globalBlockGapValue,
+} ) {
+	return Object.entries( RESPONSIVE_BREAKPOINTS )
+		.map( ( [ viewport, mediaQuery ] ) => {
+			const viewportStyle = attributes?.style?.[ viewport ];
+			const hasViewportLayout =
+				viewportStyle?.layout &&
+				Object.keys( viewportStyle.layout ).length > 0;
+			const hasViewportBlockGap =
+				viewportStyle?.spacing &&
+				Object.hasOwn( viewportStyle.spacing, 'blockGap' );
+			const hasViewportPadding =
+				viewportStyle?.spacing &&
+				Object.hasOwn( viewportStyle.spacing, 'padding' );
+			if (
+				! hasViewportLayout &&
+				! hasViewportBlockGap &&
+				! hasViewportPadding
+			) {
+				return '';
+			}
+
+			const viewportLayout = hasViewportLayout
+				? { ...layout, ...viewportStyle.layout }
+				: layout;
+			const layoutType = getLayoutType(
+				viewportLayout?.type || 'default'
+			);
+			const viewportCSS = layoutType?.getLayoutStyle?.( {
+				blockName,
+				selector,
+				layout: viewportLayout,
+				style: viewportStyle,
+				hasBlockGapSupport,
+				globalBlockGapValue,
+			} );
+			const baseLayoutType = getLayoutType( layout?.type || 'default' );
+			const baseCSS = baseLayoutType?.getLayoutStyle?.( {
+				blockName,
+				selector,
+				layout,
+				style: attributes?.style,
+				hasBlockGapSupport,
+				globalBlockGapValue,
+			} );
+			const css = getLayoutStyleDelta( baseCSS, viewportCSS );
+
+			return css ? `${ mediaQuery }{${ css }}` : '';
+		} )
+		.filter( Boolean )
+		.join( '' );
+}
+
 function LayoutPanelPure( {
 	layout,
+	style,
 	setAttributes,
 	name: blockName,
 	clientId,
@@ -178,28 +361,59 @@ function LayoutPanelPure( {
 	const settings = useBlockSettings( blockName );
 	// Block settings come from theme.json under settings.[blockName].
 	const { layout: layoutSettings } = settings;
-	const { themeSupportsLayout, activeBlockVariation } = useSelect(
-		( select ) => {
-			const { getBlockAttributes, getSettings } =
-				select( blockEditorStore );
-			return {
-				activeBlockVariation: select(
-					blocksStore
-				).getActiveBlockVariation(
-					blockName,
-					getBlockAttributes( clientId ) || {},
-					'block'
-				),
-				themeSupportsLayout: getSettings().supportsLayout,
-			};
-		},
-		[ blockName, clientId ]
-	);
+	const { themeSupportsLayout, activeBlockVariation, selectedState } =
+		useSelect(
+			( select ) => {
+				const blockEditorSelect = select( blockEditorStore );
+				const { getBlockAttributes, getSettings } = blockEditorSelect;
+				const { getSelectedBlockStyleState } =
+					unlock( blockEditorSelect );
+				return {
+					activeBlockVariation: select(
+						blocksStore
+					).getActiveBlockVariation(
+						blockName,
+						getBlockAttributes( clientId ) || {},
+						'block'
+					),
+					themeSupportsLayout: getSettings().supportsLayout,
+					selectedState:
+						getSelectedBlockStyleState?.( clientId ) ??
+						DEFAULT_BLOCK_STYLE_STATE,
+				};
+			},
+			[ blockName, clientId ]
+		);
 
 	const blockEditingMode = useBlockEditingMode();
+	const isViewportLayoutState =
+		hasViewportBlockStyleState( selectedState ) &&
+		! hasPseudoBlockStyleState( selectedState );
 	const resetLayoutFilter = useCallback(
 		( ...resetArgs ) => {
+			const attributes = resetArgs[ 0 ] || {};
 			const context = resetArgs[ 1 ] || {};
+
+			if ( isViewportLayoutState ) {
+				const existingStateStyle =
+					getStyleForState(
+						attributes.style ?? style,
+						selectedState
+					) || {};
+				const nextStateStyle = cleanEmptyObject( {
+					...existingStateStyle,
+					layout: undefined,
+				} );
+
+				return {
+					style: setStyleForState(
+						attributes.style ?? style,
+						selectedState,
+						nextStateStyle
+					),
+				};
+			}
+
 			const resetBlockName = context.name || blockName;
 			const resetLayoutBlockSupport = getBlockSupport(
 				resetBlockName,
@@ -214,7 +428,13 @@ function LayoutPanelPure( {
 				),
 			};
 		},
-		[ blockName, activeBlockVariation ]
+		[
+			blockName,
+			activeBlockVariation,
+			isViewportLayoutState,
+			selectedState,
+			style,
+		]
 	);
 
 	if ( blockEditingMode !== 'default' ) {
@@ -246,9 +466,23 @@ function LayoutPanelPure( {
 	 * Try to find the layout type from either the
 	 * block's layout settings or any saved layout config.
 	 */
+	const baseLayout = layout || defaultBlockLayout || {};
+	const stateStyle = isViewportLayoutState
+		? getStyleForState( style, selectedState )
+		: undefined;
+	const stateLayout = stateStyle?.layout;
+	const usedLayout = isViewportLayoutState
+		? cleanEmptyObject( {
+				...baseLayout,
+				...stateLayout,
+		  } ) || {}
+		: baseLayout;
+	const resetLayoutDefaults = isViewportLayoutState
+		? baseLayout
+		: getResetLayout( layoutBlockSupport, activeBlockVariation );
 	const blockSupportAndLayout = {
 		...layoutBlockSupport,
-		...layout,
+		...usedLayout,
 	};
 	const { type, default: { type: defaultType = 'default' } = {} } =
 		blockSupportAndLayout;
@@ -264,7 +498,6 @@ function LayoutPanelPure( {
 			blockSupportAndLayout.inherit )
 	);
 
-	const usedLayout = layout || defaultBlockLayout || {};
 	const { inherit = false, contentSize = null } = usedLayout;
 	/**
 	 * `themeSupportsLayout` is only relevant to the `default/flow` or
@@ -278,32 +511,43 @@ function LayoutPanelPure( {
 	) {
 		return null;
 	}
-	const defaultLayout = cleanEmptyObject( {
-		...getDefaultLayout( layoutBlockSupport, activeBlockVariation ),
-	} );
-	const resetLayoutDefaults = getResetLayout(
-		layoutBlockSupport,
-		activeBlockVariation
-	);
 	const layoutType = getLayoutType( blockLayoutType );
 	const constrainedType = getLayoutType( 'constrained' );
 	const displayControlsForLegacyLayouts =
 		! usedLayout.type && ( contentSize || inherit );
 	const hasContentSizeOrLegacySettings = !! inherit || !! contentSize;
 
-	const onChangeType = ( newType ) =>
-		setAttributes( { layout: { type: newType } } );
-	const onChangeLayout = ( newLayout ) =>
+	const onChangeLayout = ( newLayout ) => {
+		if ( isViewportLayoutState ) {
+			const nextStateStyle = cleanEmptyObject( {
+				...stateStyle,
+				layout: getLayoutStateOverrides(
+					cleanEmptyObject( newLayout ),
+					baseLayout,
+					stateStyle?.layout
+				),
+			} );
+			setAttributes( {
+				style: setStyleForState( style, selectedState, nextStateStyle ),
+			} );
+			return;
+		}
+
 		setAttributes( { layout: cleanEmptyObject( newLayout ) } );
-	const resetLayout = () => setAttributes( { layout: defaultLayout } );
-	const resetInheritToggle = () =>
-		setAttributes( { layout: { type: 'default' } } );
+	};
+	const onChangeType = ( newType ) => onChangeLayout( { type: newType } );
+	const resetLayout = () => onChangeLayout( resetLayoutDefaults );
+	const resetInheritToggle = () => onChangeLayout( { type: 'default' } );
 	const isUsingContentWidth = () =>
 		layoutType?.name === 'constrained' || hasContentSizeOrLegacySettings;
-	const hasInheritToggleValue = () => layout?.type === 'constrained';
+	const hasInheritToggleValue = () =>
+		isViewportLayoutState
+			? ( usedLayout?.type ?? 'default' ) !==
+			  ( resetLayoutDefaults?.type ?? 'default' )
+			: layout?.type === 'constrained';
 	const hasLayoutTypeValue = () =>
 		( usedLayout?.type ?? 'default' ) !==
-		( defaultLayout?.type ?? 'default' );
+		( resetLayoutDefaults?.type ?? 'default' );
 
 	return (
 		<>
@@ -323,12 +567,10 @@ function LayoutPanelPure( {
 							label={ __( 'Inner blocks use content width' ) }
 							checked={ isUsingContentWidth() }
 							onChange={ () =>
-								setAttributes( {
-									layout: {
-										type: isUsingContentWidth()
-											? 'default'
-											: 'constrained',
-									},
+								onChangeLayout( {
+									type: isUsingContentWidth()
+										? 'default'
+										: 'constrained',
 								} )
 							}
 							help={
@@ -398,7 +640,7 @@ function LayoutPanelPure( {
 export default {
 	shareWithChildBlocks: true,
 	edit: LayoutPanelPure,
-	attributeKeys: [ 'layout' ],
+	attributeKeys: [ 'layout', 'style' ],
 	hasSupport( name ) {
 		return hasLayoutBlockSupport( name );
 	},
@@ -476,7 +718,7 @@ function BlockWithLayoutStyles( {
 	// Get CSS string for the current layout type.
 	// The CSS and `style` element is only output if it is not empty.
 	const fullLayoutType = getLayoutType( usedLayout?.type || 'default' );
-	const css = fullLayoutType?.getLayoutStyle?.( {
+	const baseLayoutCSS = fullLayoutType?.getLayoutStyle?.( {
 		blockName: name,
 		selector,
 		layout: usedLayout,
@@ -484,6 +726,17 @@ function BlockWithLayoutStyles( {
 		hasBlockGapSupport,
 		globalBlockGapValue,
 	} );
+	const responsiveLayoutCSS = getResponsiveLayoutStyles( {
+		attributes,
+		blockName: name,
+		selector,
+		layout: usedLayout,
+		hasBlockGapSupport,
+		globalBlockGapValue,
+	} );
+	const css = [ baseLayoutCSS, responsiveLayoutCSS ]
+		.filter( Boolean )
+		.join( '' );
 
 	// Attach a `wp-container-` id-based class name as well as a layout class name such as `is-layout-flex`.
 	const layoutClassNames = clsx(

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -111,63 +111,12 @@ function getLayoutStateOverrides(
 	} );
 }
 
-function getCSSRulesBySelector( css = '' ) {
-	const rules = new Map();
-	const rulePattern = /([^{}]+)\{([^{}]*)\}/g;
-	let match;
-
-	while ( ( match = rulePattern.exec( css ) ) ) {
-		const selector = match[ 1 ].trim();
-		const declarations = rules.get( selector ) ?? new Map();
-		match[ 2 ]
-			.split( ';' )
-			.map( ( declaration ) => declaration.trim() )
-			.filter( Boolean )
-			.forEach( ( declaration ) => {
-				const separatorIndex = declaration.indexOf( ':' );
-				if ( separatorIndex === -1 ) {
-					return;
-				}
-				const property = declaration.slice( 0, separatorIndex ).trim();
-				const value = declaration.slice( separatorIndex + 1 ).trim();
-				declarations.set( property, value );
-			} );
-
-		rules.set( selector, declarations );
-	}
-
-	return rules;
-}
-
-function getLayoutStyleDelta( baseCSS = '', nextCSS = '' ) {
-	const baseRules = getCSSRulesBySelector( baseCSS );
-	const nextRules = getCSSRulesBySelector( nextCSS );
-	const excludedProperties = new Set( [ 'container-type' ] );
-	const deltaRules = [];
-
-	nextRules.forEach( ( nextDeclarations, selector ) => {
-		const baseDeclarations = baseRules.get( selector );
-		const changedDeclarations = [];
-
-		nextDeclarations.forEach( ( value, property ) => {
-			if (
-				excludedProperties.has( property ) ||
-				baseDeclarations?.get( property ) === value
-			) {
-				return;
-			}
-
-			changedDeclarations.push( `${ property }: ${ value }` );
-		} );
-
-		if ( changedDeclarations.length ) {
-			deltaRules.push(
-				`${ selector } { ${ changedDeclarations.join( '; ' ) }; }`
-			);
-		}
-	} );
-
-	return deltaRules.join( '' );
+function getLayoutContainerValues( layout = {} ) {
+	return Object.fromEntries(
+		Object.entries( layout || {} ).filter(
+			( [ key ] ) => ! CHILD_LAYOUT_KEYS.includes( key )
+		)
+	);
 }
 
 function hasLayoutBlockSupport( blockName ) {
@@ -303,9 +252,10 @@ export function getResponsiveLayoutStyles( {
 	return Object.entries( RESPONSIVE_BREAKPOINTS )
 		.map( ( [ viewport, mediaQuery ] ) => {
 			const viewportStyle = attributes?.style?.[ viewport ];
-			const hasViewportLayout =
-				viewportStyle?.layout &&
-				Object.keys( viewportStyle.layout ).length > 0;
+			const viewportLayout = getLayoutContainerValues(
+				viewportStyle?.layout
+			);
+			const hasViewportLayout = Object.keys( viewportLayout ).length > 0;
 			const hasViewportBlockGap =
 				viewportStyle?.spacing &&
 				Object.hasOwn( viewportStyle.spacing, 'blockGap' );
@@ -320,32 +270,18 @@ export function getResponsiveLayoutStyles( {
 				return '';
 			}
 
-			const viewportLayout = hasViewportLayout
-				? { ...layout, ...viewportStyle.layout }
-				: layout;
-			const layoutType = getLayoutType(
-				viewportLayout?.type || 'default'
-			);
+			const layoutType = getLayoutType( layout?.type || 'default' );
 			const viewportCSS = layoutType?.getLayoutStyle?.( {
 				blockName,
 				selector,
-				layout: viewportLayout,
+				layout,
+				viewportOverrides: viewportLayout,
 				style: viewportStyle,
 				hasBlockGapSupport,
 				globalBlockGapValue,
 			} );
-			const baseLayoutType = getLayoutType( layout?.type || 'default' );
-			const baseCSS = baseLayoutType?.getLayoutStyle?.( {
-				blockName,
-				selector,
-				layout,
-				style: attributes?.style,
-				hasBlockGapSupport,
-				globalBlockGapValue,
-			} );
-			const css = getLayoutStyleDelta( baseCSS, viewportCSS );
 
-			return css ? `${ mediaQuery }{${ css }}` : '';
+			return viewportCSS ? `${ mediaQuery }{${ viewportCSS }}` : '';
 		} )
 		.filter( Boolean )
 		.join( '' );

--- a/packages/block-editor/src/hooks/test/layout.js
+++ b/packages/block-editor/src/hooks/test/layout.js
@@ -156,7 +156,7 @@ describe( 'layout', () => {
 					hasBlockGapSupport: true,
 				} )
 			).toBe(
-				'@media (width <= 480px){.wp-container-test { grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }}'
+				'@media (width <= 480px){.wp-container-test { grid-template-columns: repeat(3, minmax(0, 1fr)); }.wp-container-test { gap: 12px; }}'
 			);
 		} );
 

--- a/packages/block-editor/src/hooks/test/layout.js
+++ b/packages/block-editor/src/hooks/test/layout.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getResetLayout } from '../layout';
+import { getResetLayout, getResponsiveLayoutStyles } from '../layout';
 
 describe( 'layout', () => {
 	describe( 'getResetLayout()', () => {
@@ -43,6 +43,143 @@ describe( 'layout', () => {
 
 		it( 'should return undefined when there is no layout config', () => {
 			expect( getResetLayout() ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'getResponsiveLayoutStyles()', () => {
+		it( 'generates responsive block gap styles for flow layouts', () => {
+			expect(
+				getResponsiveLayoutStyles( {
+					attributes: {
+						style: {
+							mobile: {
+								spacing: {
+									blockGap: '12px',
+								},
+							},
+						},
+					},
+					blockName: 'core/group',
+					selector: '.wp-container-test',
+					layout: { type: 'default' },
+					hasBlockGapSupport: true,
+				} )
+			).toBe(
+				'@media (width <= 480px){.wp-container-test > :first-child { margin-block-start: 0; }.wp-container-test > :last-child { margin-block-end: 0; }.wp-container-test > * { margin-block-start: 12px; margin-block-end: 0; }}'
+			);
+		} );
+
+		it( 'generates responsive block gap styles for flex layouts', () => {
+			expect(
+				getResponsiveLayoutStyles( {
+					attributes: {
+						style: {
+							mobile: {
+								spacing: {
+									blockGap: '12px',
+								},
+							},
+						},
+					},
+					blockName: 'core/group',
+					selector: '.wp-container-test',
+					layout: { type: 'flex' },
+					hasBlockGapSupport: true,
+				} )
+			).toBe(
+				'@media (width <= 480px){.wp-container-test { gap: 12px; }}'
+			);
+		} );
+
+		it( 'generates responsive layout styles for viewport layout overrides', () => {
+			expect(
+				getResponsiveLayoutStyles( {
+					attributes: {
+						style: {
+							mobile: {
+								layout: {
+									minimumColumnWidth: '8rem',
+								},
+							},
+						},
+					},
+					blockName: 'core/group',
+					selector: '.wp-container-test',
+					layout: { type: 'grid' },
+					hasBlockGapSupport: true,
+				} )
+			).toBe(
+				'@media (width <= 480px){.wp-container-test { grid-template-columns: repeat(auto-fill, minmax(min(8rem, 100%), 1fr)); }}'
+			);
+		} );
+
+		it( 'generates responsive layout styles for grid column overrides', () => {
+			expect(
+				getResponsiveLayoutStyles( {
+					attributes: {
+						style: {
+							mobile: {
+								layout: {
+									columnCount: 3,
+								},
+							},
+						},
+					},
+					blockName: 'core/group',
+					selector: '.wp-container-test',
+					layout: { type: 'grid' },
+					hasBlockGapSupport: true,
+				} )
+			).toBe(
+				'@media (width <= 480px){.wp-container-test { grid-template-columns: repeat(3, minmax(0, 1fr)); }}'
+			);
+		} );
+
+		it( 'keeps responsive grid column overrides when block gap is also changed', () => {
+			expect(
+				getResponsiveLayoutStyles( {
+					attributes: {
+						style: {
+							mobile: {
+								layout: {
+									columnCount: 3,
+								},
+								spacing: {
+									blockGap: '12px',
+								},
+							},
+						},
+					},
+					blockName: 'core/group',
+					selector: '.wp-container-test',
+					layout: { type: 'grid' },
+					hasBlockGapSupport: true,
+				} )
+			).toBe(
+				'@media (width <= 480px){.wp-container-test { grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }}'
+			);
+		} );
+
+		it( 'does not repeat unchanged grid layout declarations for responsive block gap styles', () => {
+			expect(
+				getResponsiveLayoutStyles( {
+					attributes: {
+						style: {
+							tablet: {
+								spacing: {
+									blockGap: '12px',
+								},
+							},
+						},
+					},
+					blockName: 'core/group',
+					selector: '.wp-container-test',
+					layout: { type: 'grid', minimumColumnWidth: '12rem' },
+					hasBlockGapSupport: true,
+				} )
+			).toBe(
+				'@media (480px < width <= 782px){.wp-container-test { gap: 12px; }}'
+			);
 		} );
 	} );
 } );

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -233,13 +233,26 @@ export default {
 	getLayoutStyle: function getLayoutStyle( {
 		selector,
 		layout = {},
+		viewportOverrides,
 		style,
 		blockName,
 		hasBlockGapSupport,
 		layoutDefinitions = LAYOUT_DEFINITIONS,
 	} ) {
-		const { contentSize, wideSize, justifyContent } = layout;
+		const hasViewportOverrides = viewportOverrides !== undefined;
+		const effectiveLayout = hasViewportOverrides
+			? { ...layout, ...viewportOverrides }
+			: layout;
+		const hasViewportOverride = ( key ) =>
+			Object.hasOwn( viewportOverrides || {}, key );
+		const { contentSize, wideSize, justifyContent } = effectiveLayout;
 		const blockGapStyleValue = getGapCSSValue( style?.spacing?.blockGap );
+		const hasBlockGapOverride =
+			! hasViewportOverrides ||
+			Object.hasOwn( style?.spacing || {}, 'blockGap' );
+		const hasBlockSpacingOverride =
+			! hasViewportOverrides ||
+			Object.hasOwn( style?.spacing || {}, 'padding' );
 
 		// If a block's block.json skips serialization for spacing or
 		// spacing.blockGap, don't apply the user-defined value to the styles.
@@ -258,16 +271,29 @@ export default {
 		const marginRight =
 			justifyContent === 'right' ? '0 !important' : 'auto !important';
 
+		const hasJustificationOverride =
+			hasViewportOverrides && hasViewportOverride( 'justifyContent' );
+		const shouldOutputConstrainedSizes =
+			! hasViewportOverrides ||
+			hasViewportOverride( 'contentSize' ) ||
+			hasViewportOverride( 'wideSize' );
+		const constrainedSizeDeclarations = [
+			`max-width: ${ contentSize ?? wideSize }`,
+		];
+		if ( ! hasViewportOverrides || hasJustificationOverride ) {
+			constrainedSizeDeclarations.push(
+				`margin-left: ${ marginLeft }`,
+				`margin-right: ${ marginRight }`
+			);
+		}
 		let output =
-			!! contentSize || !! wideSize
+			shouldOutputConstrainedSizes && ( !! contentSize || !! wideSize )
 				? `
-					${ appendSelectors(
-						selector,
-						'> :where(:not(.alignleft):not(.alignright):not(.alignfull))'
-					) } {
-						max-width: ${ contentSize ?? wideSize };
-						margin-left: ${ marginLeft };
-						margin-right: ${ marginRight };
+						${ appendSelectors(
+							selector,
+							'> :where(:not(.alignleft):not(.alignright):not(.alignfull))'
+						) } {
+						${ constrainedSizeDeclarations.join( '; ' ) };
 					}
 					${ appendSelectors( selector, '> .alignwide' ) }  {
 						max-width: ${ wideSize ?? contentSize };
@@ -275,25 +301,33 @@ export default {
 					${ appendSelectors( selector, '> .alignfull' ) } {
 						max-width: none;
 					}
-				`
+					`
 				: '';
 
-		if ( justifyContent === 'left' ) {
+		if ( hasJustificationOverride && ! shouldOutputConstrainedSizes ) {
 			output += `${ appendSelectors(
 				selector,
 				'> :where(:not(.alignleft):not(.alignright):not(.alignfull))'
 			) }
+				{ margin-left: ${ marginLeft }; margin-right: ${ marginRight }; }`;
+		} else if ( ! hasViewportOverrides ) {
+			if ( justifyContent === 'left' ) {
+				output += `${ appendSelectors(
+					selector,
+					'> :where(:not(.alignleft):not(.alignright):not(.alignfull))'
+				) }
 			{ margin-left: ${ marginLeft }; }`;
-		} else if ( justifyContent === 'right' ) {
-			output += `${ appendSelectors(
-				selector,
-				'> :where(:not(.alignleft):not(.alignright):not(.alignfull))'
-			) }
+			} else if ( justifyContent === 'right' ) {
+				output += `${ appendSelectors(
+					selector,
+					'> :where(:not(.alignleft):not(.alignright):not(.alignfull))'
+				) }
 			{ margin-right: ${ marginRight }; }`;
+			}
 		}
 
 		// If there is custom padding, add negative margins for alignfull blocks.
-		if ( style?.spacing?.padding ) {
+		if ( hasBlockSpacingOverride && style?.spacing?.padding ) {
 			// The style object might be storing a preset so we need to make sure we get a usable value.
 			const paddingValues = getCSSRules( style );
 			paddingValues.forEach( ( rule ) => {
@@ -322,7 +356,7 @@ export default {
 		}
 
 		// Output blockGap styles based on rules contained in layout definitions in theme.json.
-		if ( hasBlockGapSupport && blockGapValue ) {
+		if ( hasBlockGapSupport && hasBlockGapOverride && blockGapValue ) {
 			output += getBlockGapCSS(
 				selector,
 				layoutDefinitions,

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -211,14 +211,21 @@ export default {
 	},
 	getLayoutStyle: function getLayoutStyle( {
 		selector,
-		layout,
+		layout = {},
+		viewportOverrides,
 		style,
 		blockName,
 		hasBlockGapSupport,
 		globalBlockGapValue,
 		layoutDefinitions = LAYOUT_DEFINITIONS,
 	} ) {
-		const { orientation = 'horizontal' } = layout;
+		const hasViewportOverrides = viewportOverrides !== undefined;
+		const effectiveLayout = hasViewportOverrides
+			? { ...layout, ...viewportOverrides }
+			: layout;
+		const hasViewportOverride = ( key ) =>
+			Object.hasOwn( viewportOverrides || {}, key );
+		const { orientation = 'horizontal' } = effectiveLayout;
 
 		// Determine the fallback gap value using global styles (theme.json),
 		// falling back to '0.5em' for backwards compatibility.
@@ -239,35 +246,57 @@ export default {
 			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
 				? getGapCSSValue( style?.spacing?.blockGap, fallbackGapValue )
 				: undefined;
-		const justifyContent = justifyContentMap[ layout.justifyContent ];
-		const flexWrap = flexWrapOptions.includes( layout.flexWrap )
-			? layout.flexWrap
+		const hasBlockGapOverride =
+			! hasViewportOverrides ||
+			Object.hasOwn( style?.spacing || {}, 'blockGap' );
+		const justifyContent =
+			justifyContentMap[ effectiveLayout.justifyContent ];
+		const flexWrap = flexWrapOptions.includes( effectiveLayout.flexWrap )
+			? effectiveLayout.flexWrap
 			: 'wrap';
 		const verticalAlignment =
-			verticalAlignmentMap[ layout.verticalAlignment ];
+			verticalAlignmentMap[ effectiveLayout.verticalAlignment ];
 		const alignItems =
-			alignItemsMap[ layout.justifyContent ] || alignItemsMap.left;
+			alignItemsMap[ effectiveLayout.justifyContent ] ||
+			alignItemsMap.left;
 
 		let output = '';
 		const rules = [];
 
-		if ( flexWrap && flexWrap !== 'wrap' ) {
+		const shouldOutputFlexWrap =
+			! hasViewportOverrides || hasViewportOverride( 'flexWrap' );
+		const shouldOutputFlexOrientation =
+			! hasViewportOverrides || hasViewportOverride( 'orientation' );
+		const shouldOutputFlexJustification =
+			! hasViewportOverrides ||
+			hasViewportOverride( 'justifyContent' ) ||
+			hasViewportOverride( 'orientation' );
+		const shouldOutputFlexAlignment =
+			! hasViewportOverrides ||
+			hasViewportOverride( 'verticalAlignment' ) ||
+			hasViewportOverride( 'orientation' );
+
+		if ( shouldOutputFlexWrap && flexWrap && flexWrap !== 'wrap' ) {
 			rules.push( `flex-wrap: ${ flexWrap }` );
 		}
 
 		if ( orientation === 'horizontal' ) {
-			if ( verticalAlignment ) {
+			if ( shouldOutputFlexAlignment && verticalAlignment ) {
 				rules.push( `align-items: ${ verticalAlignment }` );
 			}
-			if ( justifyContent ) {
+			if ( shouldOutputFlexJustification && justifyContent ) {
 				rules.push( `justify-content: ${ justifyContent }` );
 			}
 		} else {
-			if ( verticalAlignment ) {
+			if ( shouldOutputFlexAlignment && verticalAlignment ) {
 				rules.push( `justify-content: ${ verticalAlignment }` );
 			}
-			rules.push( 'flex-direction: column' );
-			rules.push( `align-items: ${ alignItems }` );
+			if ( shouldOutputFlexOrientation ) {
+				rules.push( 'flex-direction: column' );
+			}
+			if ( shouldOutputFlexJustification ) {
+				rules.push( `align-items: ${ alignItems }` );
+			}
 		}
 
 		if ( rules.length ) {
@@ -277,7 +306,7 @@ export default {
 		}
 
 		// Output blockGap styles based on rules contained in layout definitions in theme.json.
-		if ( hasBlockGapSupport && blockGapValue ) {
+		if ( hasBlockGapSupport && hasBlockGapOverride && blockGapValue ) {
 			output += getBlockGapCSS(
 				selector,
 				layoutDefinitions,

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -170,18 +170,25 @@ export default {
 	},
 	getLayoutStyle: function getLayoutStyle( {
 		selector,
-		layout,
+		layout = {},
+		viewportOverrides,
 		style,
 		blockName,
 		hasBlockGapSupport,
 		globalBlockGapValue,
 		layoutDefinitions = LAYOUT_DEFINITIONS,
 	} ) {
+		const hasViewportOverrides = viewportOverrides !== undefined;
+		const effectiveLayout = hasViewportOverrides
+			? { ...layout, ...viewportOverrides }
+			: layout;
+		const hasViewportOverride = ( key ) =>
+			Object.hasOwn( viewportOverrides || {}, key );
 		const {
 			minimumColumnWidth = null,
 			columnCount = null,
 			rowCount = null,
-		} = layout;
+		} = effectiveLayout;
 
 		// Check that the grid layout attributes are of the correct type, so that we don't accidentally
 		// write code that stores a string attribute instead of a number.
@@ -219,11 +226,27 @@ export default {
 			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
 				? getGapCSSValue( style?.spacing?.blockGap, fallbackGapValue )
 				: undefined;
+		const hasBlockGapOverride =
+			! hasViewportOverrides ||
+			Object.hasOwn( style?.spacing || {}, 'blockGap' );
 
 		let output = '';
 		const rules = [];
+		const shouldOutputGridColumns =
+			! hasViewportOverrides ||
+			hasViewportOverride( 'minimumColumnWidth' ) ||
+			hasViewportOverride( 'columnCount' ) ||
+			( hasBlockGapOverride && minimumColumnWidth && columnCount > 0 );
+		const shouldOutputGridRows =
+			( ! hasViewportOverrides || hasViewportOverride( 'rowCount' ) ) &&
+			columnCount &&
+			rowCount;
 
-		if ( minimumColumnWidth && columnCount > 0 ) {
+		if (
+			shouldOutputGridColumns &&
+			minimumColumnWidth &&
+			columnCount > 0
+		) {
 			let blockGapToUse = blockGapValue || fallbackGapValue;
 			// Ensure 0 values have a unit so they work in calc().
 			if ( blockGapToUse === '0' || blockGapToUse === 0 ) {
@@ -233,29 +256,36 @@ export default {
 				columnCount - 1
 			}) ) / ${ columnCount })`;
 			rules.push(
-				`grid-template-columns: repeat(auto-fill, minmax(${ maxValue }, 1fr))`,
-				`container-type: inline-size`
+				`grid-template-columns: repeat(auto-fill, minmax(${ maxValue }, 1fr))`
 			);
-			if ( rowCount ) {
-				rules.push(
-					`grid-template-rows: repeat(${ rowCount }, minmax(1rem, auto))`
-				);
-			}
-		} else if ( columnCount ) {
+		} else if ( shouldOutputGridColumns && columnCount ) {
 			rules.push(
 				`grid-template-columns: repeat(${ columnCount }, minmax(0, 1fr))`
 			);
-			if ( rowCount ) {
-				rules.push(
-					`grid-template-rows: repeat(${ rowCount }, minmax(1rem, auto))`
-				);
-			}
-		} else {
+		} else if ( shouldOutputGridColumns ) {
 			rules.push(
 				`grid-template-columns: repeat(auto-fill, minmax(min(${
 					minimumColumnWidth || '12rem'
-				}, 100%), 1fr))`,
-				'container-type: inline-size'
+				}, 100%), 1fr))`
+			);
+		}
+
+		if ( shouldOutputGridColumns ) {
+			const baseHasContainerType =
+				! layout?.columnCount ||
+				( layout?.columnCount && layout?.minimumColumnWidth );
+			const needsContainerType = ! columnCount || minimumColumnWidth;
+			if (
+				needsContainerType &&
+				( ! hasViewportOverrides || ! baseHasContainerType )
+			) {
+				rules.push( 'container-type: inline-size' );
+			}
+		}
+
+		if ( shouldOutputGridRows ) {
+			rules.push(
+				`grid-template-rows: repeat(${ rowCount }, minmax(1rem, auto))`
 			);
 		}
 
@@ -266,7 +296,7 @@ export default {
 		}
 
 		// Output blockGap styles based on rules contained in layout definitions in theme.json.
-		if ( hasBlockGapSupport && blockGapValue ) {
+		if ( hasBlockGapSupport && hasBlockGapOverride && blockGapValue ) {
 			output += getBlockGapCSS(
 				selector,
 				layoutDefinitions,

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -1062,6 +1062,90 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that different responsive layout states generate different container
+	 * classes, even when the base layout configuration is identical.
+	 *
+	 * @covers ::gutenberg_render_layout_support_flag
+	 */
+	public function test_responsive_layout_state_generates_distinct_container_classes_for_distinct_viewport_styles() {
+		$this->ensure_block_registered(
+			'test/responsive-grid-distinct-layout-state',
+			array(),
+			array(
+				'layout' => array(
+					'default' => array(
+						'type' => 'grid',
+					),
+				),
+			)
+		);
+
+		$block_content = '<div class="wp-block-test"><p>One</p><p>Two</p></div>';
+		$base_block    = array(
+			'blockName'    => 'test/responsive-grid-distinct-layout-state',
+			'innerContent' => array( '<div class="wp-block-test">', null, '</div>' ),
+			'attrs'        => array(
+				'layout' => array(
+					'type' => 'grid',
+				),
+			),
+		);
+		$first_block   = array_replace_recursive(
+			$base_block,
+			array(
+				'attrs' => array(
+					'style' => array(
+						'mobile' => array(
+							'layout' => array(
+								'columnCount' => 3,
+							),
+						),
+					),
+				),
+			)
+		);
+		$second_block  = array_replace_recursive(
+			$base_block,
+			array(
+				'attrs' => array(
+					'style' => array(
+						'mobile' => array(
+							'layout' => array(
+								'columnCount' => 4,
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$first_actual  = gutenberg_render_layout_support_flag( $block_content, $first_block );
+		$second_actual = gutenberg_render_layout_support_flag( $block_content, $second_block );
+
+		preg_match( '/wp-container-test-responsive-grid-distinct-layout-state-is-layout-[a-f0-9]{8}/', $first_actual, $first_matches );
+		preg_match( '/wp-container-test-responsive-grid-distinct-layout-state-is-layout-[a-f0-9]{8}/', $second_actual, $second_matches );
+
+		$this->assertNotEmpty( $first_matches, "wp-container class missing in: $first_actual" );
+		$this->assertNotEmpty( $second_matches, "wp-container class missing in: $second_actual" );
+
+		$first_container_class  = $first_matches[0];
+		$second_container_class = $second_matches[0];
+
+		$this->assertNotSame( $first_container_class, $second_container_class );
+
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertStringContainsString(
+			'@media (width <= 480px){.' . $first_container_class . '{grid-template-columns:repeat(3, minmax(0, 1fr));}}',
+			$actual_stylesheet
+		);
+		$this->assertStringContainsString(
+			'@media (width <= 480px){.' . $second_container_class . '{grid-template-columns:repeat(4, minmax(0, 1fr));}}',
+			$actual_stylesheet
+		);
+	}
+
+	/**
 	 * Tests that responsive grid layout and block gap state CSS are both generated.
 	 *
 	 * @covers ::gutenberg_render_layout_support_flag

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -31,9 +31,10 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $block_name Block name.
 	 * @param array  $selectors  Optional block selectors (e.g. `['root' => '.foo .bar']`).
+	 * @param array  $supports   Optional block supports.
 	 * @return WP_Block_Type
 	 */
-	private function ensure_block_registered( $block_name, $selectors = array() ) {
+	private function ensure_block_registered( $block_name, $selectors = array(), $supports = array() ) {
 		$registered_block = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
 		if ( $registered_block ) {
 			return $registered_block;
@@ -48,6 +49,9 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 		if ( ! empty( $selectors ) ) {
 			$args['selectors'] = $selectors;
+		}
+		if ( ! empty( $supports ) ) {
+			$args['supports'] = $supports;
 		}
 		register_block_type( $block_name, $args );
 
@@ -831,6 +835,463 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 		$this->assertStringContainsString(
 			'.' . $matches[0] . '{width:50% !important;}',
+			$actual_stylesheet
+		);
+	}
+
+	/**
+	 * Tests that a responsive block gap state generates layout spacing CSS.
+	 *
+	 * Responsive layout CSS is owned by gutenberg_render_layout_support_flag()
+	 * so it shares a selector with the base layout (the inner block wrapper for
+	 * wrapper blocks) instead of being scoped to a separate `wp-states-…` class.
+	 *
+	 * @covers ::gutenberg_render_layout_support_flag
+	 */
+	public function test_responsive_block_gap_state_generates_layout_spacing_css() {
+		$this->ensure_block_registered(
+			'test/responsive-flow-layout-state',
+			array(),
+			array(
+				'layout'  => array(
+					'default' => array(
+						'type' => 'default',
+					),
+				),
+				'spacing' => array(
+					'blockGap' => true,
+				),
+			)
+		);
+
+		add_theme_support( 'appearance-tools' );
+		WP_Theme_JSON_Resolver::clean_cached_data();
+
+		try {
+			$block_content = '<div class="wp-block-test"><p>One</p><p>Two</p></div>';
+			$block         = array(
+				'blockName'    => 'test/responsive-flow-layout-state',
+				'innerContent' => array( '<div class="wp-block-test">', null, '</div>' ),
+				'attrs'        => array(
+					'layout' => array(
+						'type' => 'default',
+					),
+					'style'  => array(
+						'mobile' => array(
+							'spacing' => array(
+								'blockGap' => '12px',
+							),
+						),
+					),
+				),
+			);
+
+			$actual = gutenberg_render_layout_support_flag( $block_content, $block );
+			preg_match( '/wp-container-test-responsive-flow-layout-state-is-layout-[a-f0-9]{8}/', $actual, $matches );
+			$this->assertNotEmpty( $matches, "wp-container class missing in: $actual" );
+			$container_class   = $matches[0];
+			$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+			$this->assertStringContainsString(
+				'@media (width <= 480px){.' . $container_class . ' > *{margin-block-start:0;margin-block-end:0;}}',
+				$actual_stylesheet
+			);
+			$this->assertStringContainsString(
+				'@media (width <= 480px){.' . $container_class . ' > * + *{margin-block-start:12px;margin-block-end:0;}}',
+				$actual_stylesheet
+			);
+		} finally {
+			remove_theme_support( 'appearance-tools' );
+			WP_Theme_JSON_Resolver::clean_cached_data();
+		}
+	}
+
+	/**
+	 * Tests that responsive block gap state CSS uses the block's active layout type.
+	 *
+	 * @covers ::gutenberg_render_layout_support_flag
+	 */
+	public function test_responsive_block_gap_state_uses_active_layout_type() {
+		$this->ensure_block_registered(
+			'test/responsive-flex-layout-state',
+			array(),
+			array(
+				'layout'  => array(
+					'default' => array(
+						'type' => 'flex',
+					),
+				),
+				'spacing' => array(
+					'blockGap' => true,
+				),
+			)
+		);
+
+		add_theme_support( 'appearance-tools' );
+		WP_Theme_JSON_Resolver::clean_cached_data();
+
+		try {
+			$block_content = '<div class="wp-block-test"><p>One</p><p>Two</p></div>';
+			$block         = array(
+				'blockName'    => 'test/responsive-flex-layout-state',
+				'innerContent' => array( '<div class="wp-block-test">', null, '</div>' ),
+				'attrs'        => array(
+					'layout' => array(
+						'type' => 'flex',
+					),
+					'style'  => array(
+						'mobile' => array(
+							'spacing' => array(
+								'blockGap' => '12px',
+							),
+						),
+					),
+				),
+			);
+
+			$actual = gutenberg_render_layout_support_flag( $block_content, $block );
+			preg_match( '/wp-container-test-responsive-flex-layout-state-is-layout-[a-f0-9]{8}/', $actual, $matches );
+			$this->assertNotEmpty( $matches, "wp-container class missing in: $actual" );
+			$container_class   = $matches[0];
+			$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+			$this->assertStringContainsString(
+				'@media (width <= 480px){.' . $container_class . '{gap:12px;}}',
+				$actual_stylesheet
+			);
+		} finally {
+			remove_theme_support( 'appearance-tools' );
+			WP_Theme_JSON_Resolver::clean_cached_data();
+		}
+	}
+
+	/**
+	 * Tests that responsive layout state CSS can override grid layout values.
+	 *
+	 * @covers ::gutenberg_render_layout_support_flag
+	 */
+	public function test_responsive_layout_state_generates_grid_layout_css() {
+		$this->ensure_block_registered(
+			'test/responsive-grid-layout-state',
+			array(),
+			array(
+				'layout' => array(
+					'default' => array(
+						'type' => 'grid',
+					),
+				),
+			)
+		);
+
+		$block_content = '<div class="wp-block-test"><p>One</p><p>Two</p></div>';
+		$block         = array(
+			'blockName'    => 'test/responsive-grid-layout-state',
+			'innerContent' => array( '<div class="wp-block-test">', null, '</div>' ),
+			'attrs'        => array(
+				'layout' => array(
+					'type' => 'grid',
+				),
+				'style'  => array(
+					'mobile' => array(
+						'layout' => array(
+							'minimumColumnWidth' => '8rem',
+						),
+					),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_layout_support_flag( $block_content, $block );
+		preg_match( '/wp-container-test-responsive-grid-layout-state-is-layout-[a-f0-9]{8}/', $actual, $matches );
+		$this->assertNotEmpty( $matches, "wp-container class missing in: $actual" );
+		$container_class   = $matches[0];
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertStringContainsString(
+			'@media (width <= 480px){.' . $container_class . '{grid-template-columns:repeat(auto-fill, minmax(min(8rem, 100%), 1fr));}}',
+			$actual_stylesheet
+		);
+	}
+
+	/**
+	 * Tests that responsive layout state CSS can override grid columns.
+	 *
+	 * @covers ::gutenberg_render_layout_support_flag
+	 */
+	public function test_responsive_layout_state_generates_grid_column_count_css() {
+		$this->ensure_block_registered(
+			'test/responsive-grid-column-layout-state',
+			array(),
+			array(
+				'layout' => array(
+					'default' => array(
+						'type' => 'grid',
+					),
+				),
+			)
+		);
+
+		$block_content = '<div class="wp-block-test"><p>One</p><p>Two</p></div>';
+		$block         = array(
+			'blockName'    => 'test/responsive-grid-column-layout-state',
+			'innerContent' => array( '<div class="wp-block-test">', null, '</div>' ),
+			'attrs'        => array(
+				'layout' => array(
+					'type' => 'grid',
+				),
+				'style'  => array(
+					'mobile' => array(
+						'layout' => array(
+							'columnCount' => 3,
+						),
+					),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_layout_support_flag( $block_content, $block );
+		preg_match( '/wp-container-test-responsive-grid-column-layout-state-is-layout-[a-f0-9]{8}/', $actual, $matches );
+		$this->assertNotEmpty( $matches, "wp-container class missing in: $actual" );
+		$container_class   = $matches[0];
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertStringContainsString(
+			'@media (width <= 480px){.' . $container_class . '{grid-template-columns:repeat(3, minmax(0, 1fr));}}',
+			$actual_stylesheet
+		);
+	}
+
+	/**
+	 * Tests that responsive grid layout and block gap state CSS are both generated.
+	 *
+	 * @covers ::gutenberg_render_layout_support_flag
+	 */
+	public function test_responsive_layout_state_generates_grid_columns_and_gap_css() {
+		$this->ensure_block_registered(
+			'test/responsive-grid-columns-gap-layout-state',
+			array(),
+			array(
+				'layout'  => array(
+					'default' => array(
+						'type' => 'grid',
+					),
+				),
+				'spacing' => array(
+					'blockGap' => true,
+				),
+			)
+		);
+
+		add_theme_support( 'appearance-tools' );
+		WP_Theme_JSON_Resolver::clean_cached_data();
+
+		try {
+			$block_content = '<div class="wp-block-test"><p>One</p><p>Two</p></div>';
+			$block         = array(
+				'blockName'    => 'test/responsive-grid-columns-gap-layout-state',
+				'innerContent' => array( '<div class="wp-block-test">', null, '</div>' ),
+				'attrs'        => array(
+					'layout' => array(
+						'type' => 'grid',
+					),
+					'style'  => array(
+						'mobile' => array(
+							'layout'  => array(
+								'columnCount' => 3,
+							),
+							'spacing' => array(
+								'blockGap' => '12px',
+							),
+						),
+					),
+				),
+			);
+
+			$actual = gutenberg_render_layout_support_flag( $block_content, $block );
+			preg_match( '/wp-container-test-responsive-grid-columns-gap-layout-state-is-layout-[a-f0-9]{8}/', $actual, $matches );
+			$this->assertNotEmpty( $matches, "wp-container class missing in: $actual" );
+			$container_class   = $matches[0];
+			$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+			$this->assertStringContainsString(
+				'@media (width <= 480px){.' . $container_class . '{grid-template-columns:repeat(3, minmax(0, 1fr));gap:12px;}}',
+				$actual_stylesheet
+			);
+		} finally {
+			remove_theme_support( 'appearance-tools' );
+			WP_Theme_JSON_Resolver::clean_cached_data();
+		}
+	}
+
+	/**
+	 * Tests that responsive grid block gap CSS does not repeat unchanged layout declarations.
+	 *
+	 * @covers ::gutenberg_render_layout_support_flag
+	 */
+	public function test_responsive_grid_block_gap_state_only_outputs_changed_layout_css() {
+		$this->ensure_block_registered(
+			'test/responsive-grid-gap-state',
+			array(),
+			array(
+				'layout'  => array(
+					'default' => array(
+						'type'               => 'grid',
+						'minimumColumnWidth' => '12rem',
+					),
+				),
+				'spacing' => array(
+					'blockGap' => true,
+				),
+			)
+		);
+
+		add_theme_support( 'appearance-tools' );
+		WP_Theme_JSON_Resolver::clean_cached_data();
+
+		try {
+			$block_content = '<div class="wp-block-test"><p>One</p><p>Two</p></div>';
+			$block         = array(
+				'blockName'    => 'test/responsive-grid-gap-state',
+				'innerContent' => array( '<div class="wp-block-test">', null, '</div>' ),
+				'attrs'        => array(
+					'layout' => array(
+						'type'               => 'grid',
+						'minimumColumnWidth' => '12rem',
+					),
+					'style'  => array(
+						'tablet' => array(
+							'spacing' => array(
+								'blockGap' => '12px',
+							),
+						),
+					),
+				),
+			);
+
+			$actual = gutenberg_render_layout_support_flag( $block_content, $block );
+			preg_match( '/wp-container-test-responsive-grid-gap-state-is-layout-[a-f0-9]{8}/', $actual, $matches );
+			$this->assertNotEmpty( $matches, "wp-container class missing in: $actual" );
+			$container_class   = $matches[0];
+			$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+			$this->assertStringContainsString(
+				'@media (480px < width <= 782px){.' . $container_class . '{gap:12px;}}',
+				$actual_stylesheet
+			);
+			$this->assertStringNotContainsString(
+				'@media (480px < width <= 782px){.' . $container_class . '{grid-template-columns:',
+				$actual_stylesheet
+			);
+			$this->assertStringNotContainsString(
+				'@media (480px < width <= 782px){.' . $container_class . '{container-type:',
+				$actual_stylesheet
+			);
+		} finally {
+			remove_theme_support( 'appearance-tools' );
+			WP_Theme_JSON_Resolver::clean_cached_data();
+		}
+	}
+
+	/**
+	 * Tests that responsive child layout state CSS is generated.
+	 *
+	 * @covers ::gutenberg_render_layout_support_flag
+	 */
+	public function test_responsive_child_layout_state_generates_grid_span_css() {
+		$this->ensure_block_registered( 'test/responsive-child-layout-state' );
+
+		$block_content = '<p>Some text.</p>';
+		$block         = array(
+			'blockName'    => 'test/responsive-child-layout-state',
+			'innerContent' => array( '<p>Some text.</p>' ),
+			'attrs'        => array(
+				'style' => array(
+					'mobile' => array(
+						'layout' => array(
+							'columnSpan' => '2',
+						),
+					),
+				),
+			),
+			'parentLayout' => array(
+				'type'        => 'grid',
+				'columnCount' => 3,
+			),
+		);
+
+		$actual = gutenberg_render_layout_support_flag( $block_content, $block );
+		preg_match( '/wp-container-content-[a-f0-9]{8}/', $actual, $matches );
+		$this->assertNotEmpty( $matches, "wp-container-content class missing in: $actual" );
+		$container_content_class = $matches[0];
+		$actual_stylesheet       = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertStringContainsString(
+			'@media (width <= 480px){.' . $container_content_class . '{grid-column:span 2;}}',
+			$actual_stylesheet
+		);
+	}
+
+	/**
+	 * Tests that a wrapper block (markup with an inner content wrapper) receives
+	 * responsive grid layout CSS scoped to the inner wrapper, not the outermost tag.
+	 *
+	 * Regression test for the bug where wp-states-… was added to the outer tag
+	 * while the wp-container-… layout class lives on the inner wrapper, causing
+	 * the responsive @media rule to apply to the wrong element.
+	 *
+	 * @covers ::gutenberg_render_layout_support_flag
+	 */
+	public function test_responsive_layout_state_targets_inner_wrapper_for_wrapper_blocks() {
+		$this->ensure_block_registered(
+			'test/responsive-wrapper-grid-state',
+			array(),
+			array(
+				'layout' => array(
+					'default' => array(
+						'type' => 'grid',
+					),
+				),
+			)
+		);
+
+		$block_content = '<div class="wp-block-wrapper"><div class="wp-block-wrapper__inner-container"><p>One</p></div></div>';
+		$block         = array(
+			'blockName'    => 'test/responsive-wrapper-grid-state',
+			'innerContent' => array(
+				'<div class="wp-block-wrapper"><div class="wp-block-wrapper__inner-container">',
+				null,
+				'</div></div>',
+			),
+			'attrs'        => array(
+				'layout' => array(
+					'type' => 'grid',
+				),
+				'style'  => array(
+					'mobile' => array(
+						'layout' => array(
+							'columnCount' => 3,
+						),
+					),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_layout_support_flag( $block_content, $block );
+
+		// The wp-container-…-is-layout-… class should land on the inner wrapper.
+		$this->assertMatchesRegularExpression(
+			'/<div class="wp-block-wrapper__inner-container [^"]*wp-container-test-responsive-wrapper-grid-state-is-layout-[a-f0-9]{8}/',
+			$actual
+		);
+
+		preg_match( '/wp-container-test-responsive-wrapper-grid-state-is-layout-[a-f0-9]{8}/', $actual, $matches );
+		$container_class   = $matches[0];
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		// The responsive @media rule must target the same selector that lives on
+		// the inner wrapper element.
+		$this->assertStringContainsString(
+			'@media (width <= 480px){.' . $container_class . '{grid-template-columns:repeat(3, minmax(0, 1fr));}}',
 			$actual_stylesheet
 		);
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Part of #77817.

Adds support for setting responsive layout, block spacing and child layout styles.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Grid block to a post and define a number of columns, and a block spacing value.
2. Toggle its mobile state and define a different number of columns and a different block spacing.
3. Change the column span on one of the grid children, then toggle its mobile state and add a different span there.
4. Another good block to test is Cover, because layout is applied to its inner container. Check responsive rules are applied correctly.
5. Check other blocks with layout e.g. Buttons work correctly.

Known issues: Navigation block layout styles not being applied correctly. Working on it :)

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Used gpt 5.5/codex and opus 4.7/claude