### PR TITLE
Fix flaky media upload save lock test

### DIFF
--- a/test/e2e/specs/editor/various/upload-save-lock.spec.js
+++ b/test/e2e/specs/editor/various/upload-save-lock.spec.js
@@ -20,6 +20,14 @@ const TEST_IMAGE_FILE_PATH = path.join(
 	'10x10_e2e_test_image_z9T8jK.png'
 );
 
+const MEDIA_URLS = [
+	'/wp/v2/media',
+	`rest_route=${ encodeURIComponent( '/wp/v2/media' ) }`,
+];
+
+const isMediaURL = ( url ) =>
+	MEDIA_URLS.some( ( u ) => url.href.includes( u ) );
+
 /**
  * Creates a temporary copy of the test image with a unique name.
  *
@@ -67,7 +75,10 @@ test.describe( 'Upload save lock', () => {
 		const uploadPromise = new Promise( ( resolve ) => {
 			resolveUpload = resolve;
 		} );
-		await page.route( '**/wp/v2/media', async ( route ) => {
+		await page.route( isMediaURL, async ( route ) => {
+			if ( route.request().method() !== 'POST' ) {
+				return route.fallback();
+			}
 			await uploadPromise;
 			await route.continue();
 		} );
@@ -128,7 +139,10 @@ test.describe( 'Upload save lock', () => {
 			resolveAllUploads = resolve;
 		} );
 
-		await page.route( '**/wp/v2/media', async ( route ) => {
+		await page.route( isMediaURL, async ( route ) => {
+			if ( route.request().method() !== 'POST' ) {
+				return route.fallback();
+			}
 			await allUploadsPromise;
 			await route.continue();
 		} );
@@ -197,7 +211,10 @@ test.describe( 'Upload save lock', () => {
 		const uploadPromise = new Promise( ( resolve ) => {
 			resolveUpload = resolve;
 		} );
-		await page.route( '**/wp/v2/media', async ( route ) => {
+		await page.route( isMediaURL, async ( route ) => {
+			if ( route.request().method() !== 'POST' ) {
+				return route.fallback();
+			}
 			await uploadPromise;
 			await route.continue();
 		} );
@@ -268,7 +285,10 @@ test.describe( 'Upload save lock', () => {
 		const uploadPromise = new Promise( ( resolve ) => {
 			resolveUpload = resolve;
 		} );
-		await page.route( '**/wp/v2/media', async ( route ) => {
+		await page.route( isMediaURL, async ( route ) => {
+			if ( route.request().method() !== 'POST' ) {
+				return route.fallback();
+			}
 			await uploadPromise;
 			await route.continue();
 		} );
@@ -326,7 +346,10 @@ test.describe( 'Upload save lock', () => {
 		await expect( saveDraftButton ).toBeEnabled();
 
 		// Intercept the upload request and return an error.
-		await page.route( '**/wp/v2/media', async ( route ) => {
+		await page.route( isMediaURL, async ( route ) => {
+			if ( route.request().method() !== 'POST' ) {
+				return route.fallback();
+			}
 			await route.fulfill( {
 				status: 500,
 				contentType: 'application/json',


### PR DESCRIPTION
Fixes #77596 and #77701. The problem is that the test is checking a disabled Save draft button during upload, but at the time of the check the upload has already finished.

The test tries to prevent this by creating an artificial wait inside the upload request, but it fails to do it, because it checks the upload URL incorrectly. The `/wp/v2/media` URL is encoded inside a `rest_route` query param.

I'm fixing this by improving the check in the `page.route` handler (we use the same pattern in many other tests) and also intercepting only `POST` requests.

The flaky test was introduced in #76973.