### PR TITLE
Preload: Backport user global styles entry for classic themes on WP 6.9

### DIFF
--- a/lib/compat/wordpress-6.9/preload.php
+++ b/lib/compat/wordpress-6.9/preload.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Preload path adjustments for the WordPress 6.9 block editor.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Append the user global styles preload entries for classic themes.
+ *
+ * Core's `edit-form-blocks.php` derives the user global styles post id from
+ * `WP_Theme_JSON_Resolver::get_user_global_styles_post_id()`. On WP 6.9 that
+ * short-circuits to `null` for themes without a `theme.json`, leaving the two
+ * derived preload entries with an empty id (see the early-return removed by
+ * https://github.com/WordPress/wordpress-develop/commit/fd2693d9 for the WP 7.0
+ * fix). The Gutenberg-shipped resolver has no such early-return, so use it to
+ * append the correctly-id'd entries — the malformed core ones go unused.
+ *
+ * @param array $paths REST API paths to preload.
+ * @return array Filtered preload paths.
+ */
+function gutenberg_block_editor_preload_paths_user_global_styles_6_9( $paths ) {
+	if ( ! class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' ) ) {
+		return $paths;
+	}
+	$id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
+	if ( ! $id ) {
+		return $paths;
+	}
+	$context = current_user_can( 'edit_theme_options' ) ? 'edit' : 'view';
+	$paths[] = '/wp/v2/global-styles/' . $id . '?context=' . $context;
+	$paths[] = array( '/wp/v2/global-styles/' . $id, 'OPTIONS' );
+	return $paths;
+}
+add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_user_global_styles_6_9' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -109,6 +109,7 @@ require __DIR__ . '/compat/plugin/fonts.php';
 require __DIR__ . '/compat/wordpress-6.9/customizer-preview-custom-css.php';
 require __DIR__ . '/compat/wordpress-6.9/command-palette.php';
 require __DIR__ . '/compat/wordpress-6.9/client-assets.php';
+require __DIR__ . '/compat/wordpress-6.9/preload.php';
 
 // WordPress 7.0 compat.
 require __DIR__ . '/compat/wordpress-7.0/preload.php';


### PR DESCRIPTION
## What?

When the post editor runs against WP 6.9 with a classic theme, the kickoff fires real network requests for the user's `wp_global_styles` record — both `GET /wp/v2/global-styles/{id}?context=edit` and `OPTIONS /wp/v2/global-styles/{id}` — even though WordPress core *intends* to preload them. This PR backports the WP 7.0 behavior at the preload layer so those requests cache-hit. That alone resolves the trunk Performance Tests failure that's been happening since [#78508](https://github.com/WordPress/gutenberg/pull/78508) merged.

## Why?

Core's `edit-form-blocks.php` computes the id via `WP_Theme_JSON_Resolver::get_user_global_styles_post_id()`:

```php
array( '/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id(), 'OPTIONS' ),
'/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id() . '?context=' . $global_styles_endpoint_context,
```

On WP 6.9, the resolver's `get_user_data_from_wp_global_styles` short-circuits with an early return for themes without a `theme.json`:

```php
if ( $theme->get_stylesheet() === get_stylesheet() && ! wp_theme_has_theme_json() ) {
    return array();
}
```

The function exists on `WP_Theme_JSON_Resolver` (the *core* class), so `get_user_global_styles_post_id()` returns `null`. The preload entries become `/wp/v2/global-styles/` (empty id), which `normalizePath` turns into the **collection** URL — not the per-id URL the kickoff actually requests.

[wordpress-develop@fd2693d9](https://github.com/WordPress/wordpress-develop/commit/fd2693d9) ("Global Styles: Lift classic block restrictions", [#64408](https://core.trac.wordpress.org/ticket/64408), WP 7.0) removed that early return.

Gutenberg already ships the matching change in its own `WP_Theme_JSON_Resolver_Gutenberg` — `lib/class-wp-theme-json-resolver-gutenberg.php:457` has no early-return. So the post id is reachable for classic themes, the *core* preload-path generator just doesn't use the Gutenberg resolver.

## How?

`lib/compat/wordpress-6.9/preload.php` hooks `block_editor_rest_api_preload_paths` and appends the correctly-id'd entries via the Gutenberg resolver. The malformed core entries (`/wp/v2/global-styles/`) remain in the preload data but go unused.

## Test results

Reproduced against WP 6.9 + Twenty Twenty-One (classic theme), same configuration the trunk perf job uses.

**Before — request trace during post editor boot:**
```
REQ [+1332ms pre-mount]: GET /wp/v2/global-styles/373?context=edit
REQ [+1332ms pre-mount]: OPTIONS /wp/v2/global-styles/373
MOUNT @ +1403ms [api-fetch][preload] Some preloads were never consumed: [OPTIONS /wp/v2/global-styles]
```

**After:**
```
MOUNT @ +959ms [api-fetch][preload] Some preloads were never consumed: [OPTIONS /wp/v2/global-styles]
```

No more pre-mount global-styles requests. Mount completes ~444 ms earlier. The unused-preload warning for the malformed `OPTIONS /wp/v2/global-styles` core entry is the harmless residue.

**Trunk perf failure (media-upload spec) — fixed:**

```
$ npm exec --no release-cli -- perf $TRUNK dae102af1458... --tests-branch $TRUNK --wp-version 6.9 -c

  ✓  1 [chromium] › specs/media-upload.spec.js:134:3 › … › JPEG uploads (6.6s)
  ✓  2 [chromium] › specs/media-upload.spec.js:153:3 › … › PNG uploads (6.1s)
  ✓  3 [chromium] › specs/media-upload.spec.js:172:3 › … › Large JPEG uploads (23.0s)
  ✓  4 [chromium] › specs/media-upload.spec.js:197:3 › … › Batch upload 5 images (4.2s)

  4 passed
```

(Same wp-env that failed 4-of-4 before this change.)

## Testing Instructions

1. Install Twenty Twenty-One (classic theme) and activate it on WP 6.9.
2. Open the post editor (`post-new.php`).
3. In DevTools Network panel, search for `global-styles/`. Before this PR: two pre-mount fetches against `/wp-json/wp/v2/global-styles/{id}` (one `GET ?context=edit`, one `OPTIONS`). After this PR: both absent.

## History

- Trunk Performance Tests failure since [#78508](https://github.com/WordPress/gutenberg/pull/78508) — see [Actions run 26248025334](https://github.com/WordPress/gutenberg/actions/runs/26248025334/job/77251371576).
- [#78541](https://github.com/WordPress/gutenberg/pull/78541) was an earlier attempt at the helper-level (test spec) workaround; closed in favor of this root-cause fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)