### PR TITLE
Collab Notes: Skip the notes comments fetch when no block references a note

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -36,6 +36,33 @@ import {
 const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
 
 export function useNoteThreads( postId ) {
+	const { getBlockAttributes } = useSelect( blockEditorStore );
+	const { clientIds } = useSelect( ( select ) => {
+		const { getClientIdsWithDescendants } = select( blockEditorStore );
+		return {
+			clientIds: getClientIdsWithDescendants(),
+		};
+	}, [] );
+
+	// Skip the comments fetch entirely when no block in the post
+	// references a note id — the canvas/sidebar surface notes by joining
+	// the fetched threads against block metadata, so threads with no
+	// referencing block are never rendered. This keeps the (often empty)
+	// `GET /wp/v2/comments?type=note&per_page=-1` call off the boot path
+	// for the common case of posts with no notes.
+	const hasAnyNoteIds = useMemo( () => {
+		for ( const clientId of clientIds ) {
+			if (
+				getNoteIdsFromMetadata(
+					getBlockAttributes( clientId )?.metadata
+				).length > 0
+			) {
+				return true;
+			}
+		}
+		return false;
+	}, [ clientIds, getBlockAttributes ] );
+
 	const queryArgs = {
 		post: postId,
 		type: 'note',
@@ -47,16 +74,10 @@ export function useNoteThreads( postId ) {
 		'root',
 		'comment',
 		queryArgs,
-		{ enabled: !! postId && typeof postId === 'number' }
+		{
+			enabled: hasAnyNoteIds && !! postId && typeof postId === 'number',
+		}
 	);
-
-	const { getBlockAttributes } = useSelect( blockEditorStore );
-	const { clientIds } = useSelect( ( select ) => {
-		const { getClientIdsWithDescendants } = select( blockEditorStore );
-		return {
-			clientIds: getClientIdsWithDescendants(),
-		};
-	}, [] );
 
 	// Process notes to build the tree structure.
 	const { notes, unresolvedNotes } = useMemo( () => {


### PR DESCRIPTION
## What?

\`useNoteThreads\` fires \`GET /wp/v2/comments?type=note&per_page=-1\` on every editor mount of every post supporting \`editor.notes\` (which is the default for \`post\` + \`page\`). For the common case — a post with zero blocks referencing a note — the response is processed against block metadata and produces an empty result. This PR makes that fetch conditional on at least one block carrying a note id in its metadata, so the boot path skips it entirely for posts with no notes.

## Why?

The collab notes feature joins the fetched threads against block metadata (\`metadata.noteId\`). Threads with no referencing block are never rendered. So when no block has a \`noteId\`, the fetch is guaranteed to produce no surface-visible work — only network and parse cost.

\`per_page=-1\` semantically means "all". \`fetchAllMiddleware\` rewrites that to \`per_page=100\` and paginates via the Link header, so a post with \`N\` notes pays \`ceil(N/100)\` requests. Today the boot pays at least one of those round-trips for every post; with this change it pays zero for posts with no notes.

## How?

Add a memoized pre-scan of block metadata. The hook already iterates \`clientIds\` to cross-reference threads, so the gate adds no new traversal:

\`\`\`js
const hasAnyNoteIds = useMemo( () => {
    for ( const clientId of clientIds ) {
        if ( getNoteIdsFromMetadata( getBlockAttributes( clientId )?.metadata ).length > 0 ) {
            return true;
        }
    }
    return false;
}, [ clientIds, getBlockAttributes ] );
\`\`\`

Then gate the \`useEntityRecords\` call on it: \`{ enabled: hasAnyNoteIds && !! postId && typeof postId === 'number' }\`.

Adding a note via the editor writes the new id into the active block's metadata before the comments record is saved (see \`onCreate\` in the same hook file), so the gate flips to \`true\` and the fetch fires the next render — preserving today's behavior.

## Test results

Probed against WP 7.0 + Twenty Twenty-Five with a freshly-created draft, captured fetches to \`/wp/v2/comments\` during boot:

**Before** — draft with no notes:
\`\`\`
GET /wp-json/wp/v2/comments?context=edit&post=…&type=note&status=all&per_page=100&_locale=user
\`\`\`

**After** — draft with no notes:
\`\`\`
(no /wp/v2/comments request)
\`\`\`

**After** — draft with a block carrying \`metadata.noteId\`:
\`\`\`
GET /wp-json/wp/v2/comments?context=edit&post=…&type=note&status=all&per_page=100&_locale=user
\`\`\`

(Same as the previous behavior — gate satisfied.)

## Testing Instructions

1. Open the post editor on a draft with no notes (the default). In DevTools Network panel, filter for \`comments\`. Before this PR you should see a \`GET /wp/v2/comments?…type=note&per_page=…\` request during boot. After this PR, no such request.
2. Add a note on a block (Inspector → Notes panel or whatever your build surfaces). Reload. The request should now fire — same as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)