### PR TITLE
Enhancement: Add preview toggle and hidden code placeholder to Custom HTML block

### DIFF
--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 import {
 	BlockControls,
 	BlockIcon,
@@ -16,7 +16,7 @@ import {
 	Button,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { code } from '@wordpress/icons';
+import { code, seen, unseen } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -24,11 +24,28 @@ import { code } from '@wordpress/icons';
 import Preview from './preview';
 import HTMLEditModal from './modal';
 
+function hasVisibleContent( html ) {
+	if ( ! html?.trim() ) {
+		return false;
+	}
+	const doc = new window.DOMParser().parseFromString( html, 'text/html' );
+	[ 'script', 'style', 'meta', 'link', 'noscript', 'template' ].forEach(
+		( tag ) => doc.querySelectorAll( tag ).forEach( ( el ) => el.remove() )
+	);
+	return doc.body.innerHTML.trim().length > 0;
+}
+
 export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const [ isPreviewDisabled, setIsPreviewDisabled ] = useState( false );
+
 	const blockProps = useBlockProps( {
 		className: 'block-library-html__edit',
 	} );
+
+	const containsVisibleContent = useMemo( () => {
+		return hasVisibleContent( attributes.content );
+	}, [ attributes.content ] );
 
 	// Show placeholder when content is empty
 	if ( ! attributes.content?.trim() ) {
@@ -66,6 +83,16 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 					<ToolbarButton onClick={ () => setIsModalOpen( true ) }>
 						{ __( 'Edit code' ) }
 					</ToolbarButton>
+					<ToolbarButton
+						icon={ isPreviewDisabled ? unseen : seen }
+						label={
+							isPreviewDisabled
+								? __( 'Enable preview' )
+								: __( 'Disable preview' )
+						}
+						isPressed={ isPreviewDisabled }
+						onClick={ () => setIsPreviewDisabled( ( v ) => ! v ) }
+					/>
 				</ToolbarGroup>
 			</BlockControls>
 			<InspectorControls>
@@ -83,7 +110,22 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 					</Button>
 				</VStack>
 			</InspectorControls>
-			<Preview content={ attributes.content } isSelected={ isSelected } />
+			{ isPreviewDisabled || ! containsVisibleContent ? (
+				<Placeholder
+					icon={ <BlockIcon icon={ code } /> }
+					label={ __( 'Custom HTML' ) }
+					instructions={
+						isPreviewDisabled
+							? __( 'Preview is disabled.' )
+							: __( 'This code has no visual preview.' )
+					}
+				/>
+			) : (
+				<Preview
+					content={ attributes.content }
+					isSelected={ isSelected }
+				/>
+			) }
 			<HTMLEditModal
 				isOpen={ isModalOpen }
 				onRequestClose={ () => setIsModalOpen( false ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #78507

Adds a "Disable preview" toggle to the toolbar and automatically detects non visual HTML to display a placeholder instead of an invisible block.

## Why?
When users insert non visual structured data (like JSON-LD scripts) or `<style>` tags into a Custom HTML block, the editor attempts to render it visually. Because there is no visual output, the block collapses into a empty space. This creates a frustrating UX where the block essentially becomes invisible on the canvas and can only be found by blindly clicking around or using List View. This PR solves this by proactively identifying non visual code and falling back to a placeholder, while also giving users a manual toggle.

## How?
* Added a `hasVisibleContent` helper function that strips non-rendering tags (`script`, `style`, `meta`, `link`, `noscript`, `template`) and checks if the body retains any inner text/HTML.
* Introduced a local `isPreviewDisabled` state toggled via a new icon button (`seen`/`unseen`) in the `BlockControls` toolbar.
* If the preview is manually disabled OR the content lacks visual output, the block renders the standard Gutenberg `<Placeholder>` with a clear message ("This code has no visual preview.") instead of rendering an empty iframe.

## Testing Instructions
1. Open a post or page in the block editor.
2. Insert a Custom HTML block.
3. Paste non-visual code into it, such as a JSON-LD script (e.g., `<script type="application/ld+json">{"@context": "https://schema.org", "@type": "Event"}</script>`).
4. Click away to deselect the block. Verify that instead of disappearing, it now displays a placeholder reading: "This code has no visual preview."
5. Select the block again and add standard visual HTML (e.g., `<h1>Hello World</h1>`). Verify the preview updates and works normally.
6. In the block toolbar, click the new "Disable preview" (eye) icon. Verify the block swaps to the "Preview is disabled" placeholder, regardless of the HTML content.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1306" height="330" alt="image" src="https://github.com/user-attachments/assets/9776e13e-49d0-406d-b725-30d3ff7b493b" />|<img width="1306" height="330" alt="image" src="https://github.com/user-attachments/assets/2c7de8b1-b922-4a45-8bf4-d5706d41856f" />|
