### PR TITLE
Add dashboard Activity widget

### DIFF
--- a/lib/experimental/dashboard-widgets/load.php
+++ b/lib/experimental/dashboard-widgets/load.php
@@ -6,6 +6,8 @@
  */
 
 add_action( 'admin_menu', 'gutenberg_register_dashboard_widgets_menu' );
+add_action( 'dashboard_init', 'gutenberg_dashboard_widgets_register_activity_widget' );
+add_action( 'dashboard-wp-admin_init', 'gutenberg_dashboard_widgets_register_activity_widget' );
 
 /**
  * Registers the Dashboard Widgets menu item.
@@ -20,4 +22,20 @@ function gutenberg_register_dashboard_widgets_menu() {
 		'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiBhcmlhLWhpZGRlbj0idHJ1ZSIgZm9jdXNhYmxlPSJmYWxzZSI+PHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMTIgNEw0IDcuOVYyMGgxNlY3LjlMMTIgNHptNi41IDE0LjVIMTRWMTNoLTR2NS41SDUuNVY4LjhMMTIgNS43bDYuNSAzLjF2OS43eiI+PC9wYXRoPjwvc3ZnPg==',
 		1
 	);
+}
+
+/**
+ * Wires the `activity` widget as a dynamic dep of the dashboard module so it
+ * lands in the import map and React.lazy in the dashboard stage can resolve it.
+ */
+function gutenberg_dashboard_widgets_register_activity_widget() {
+	$widget_module = 'wp/widgets/activity/render';
+
+	if ( function_exists( 'gutenberg_register_dashboard_route' ) ) {
+		gutenberg_register_dashboard_route( '/__widget_activity', $widget_module );
+	}
+
+	if ( function_exists( 'gutenberg_register_dashboard_wp_admin_route' ) ) {
+		gutenberg_register_dashboard_wp_admin_route( '/__widget_activity', $widget_module );
+	}
 }

--- a/lib/experimental/dashboard-widgets/load.php
+++ b/lib/experimental/dashboard-widgets/load.php
@@ -6,8 +6,6 @@
  */
 
 add_action( 'admin_menu', 'gutenberg_register_dashboard_widgets_menu' );
-add_action( 'dashboard_init', 'gutenberg_dashboard_widgets_register_activity_widget' );
-add_action( 'dashboard-wp-admin_init', 'gutenberg_dashboard_widgets_register_activity_widget' );
 
 /**
  * Registers the Dashboard Widgets menu item.
@@ -22,20 +20,4 @@ function gutenberg_register_dashboard_widgets_menu() {
 		'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiBhcmlhLWhpZGRlbj0idHJ1ZSIgZm9jdXNhYmxlPSJmYWxzZSI+PHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMTIgNEw0IDcuOVYyMGgxNlY3LjlMMTIgNHptNi41IDE0LjVIMTRWMTNoLTR2NS41SDUuNVY4LjhMMTIgNS43bDYuNSAzLjF2OS43eiI+PC9wYXRoPjwvc3ZnPg==',
 		1
 	);
-}
-
-/**
- * Wires the `activity` widget as a dynamic dep of the dashboard module so it
- * lands in the import map and React.lazy in the dashboard stage can resolve it.
- */
-function gutenberg_dashboard_widgets_register_activity_widget() {
-	$widget_module = 'wp/widgets/activity/render';
-
-	if ( function_exists( 'gutenberg_register_dashboard_route' ) ) {
-		gutenberg_register_dashboard_route( '/__widget_activity', $widget_module );
-	}
-
-	if ( function_exists( 'gutenberg_register_dashboard_wp_admin_route' ) ) {
-		gutenberg_register_dashboard_wp_admin_route( '/__widget_activity', $widget_module );
-	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20638,6 +20638,10 @@
 			"resolved": "packages/abilities",
 			"link": true
 		},
+		"node_modules/@wordpress/activity-widget": {
+			"resolved": "widgets/activity",
+			"link": true
+		},
 		"node_modules/@wordpress/admin-ui": {
 			"resolved": "packages/admin-ui",
 			"link": true
@@ -67048,6 +67052,23 @@
 			"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"widgets/activity": {
+			"name": "@wordpress/activity-widget",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/components": "file:../../packages/components",
+				"@wordpress/core-data": "file:../../packages/core-data",
+				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/dataviews": "file:../../packages/dataviews",
+				"@wordpress/date": "file:../../packages/date",
+				"@wordpress/element": "file:../../packages/element",
+				"@wordpress/html-entities": "file:../../packages/html-entities",
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/icons": "file:../../packages/icons",
+				"@wordpress/ui": "file:../../packages/ui",
+				"react": "18.3.1"
+			}
 		},
 		"widgets/hello-world": {
 			"name": "@wordpress/hello-world-widget",

--- a/widgets/activity/package.json
+++ b/widgets/activity/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "@wordpress/activity-widget",
+	"version": "1.0.0",
+	"private": true,
+	"dependencies": {
+		"@wordpress/components": "file:../../packages/components",
+		"@wordpress/core-data": "file:../../packages/core-data",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/dataviews": "file:../../packages/dataviews",
+		"@wordpress/date": "file:../../packages/date",
+		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/html-entities": "file:../../packages/html-entities",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/icons": "file:../../packages/icons",
+		"@wordpress/ui": "file:../../packages/ui",
+		"react": "18.3.1"
+	}
+}

--- a/widgets/activity/render.tsx
+++ b/widgets/activity/render.tsx
@@ -1,0 +1,312 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import { dateI18n, getDate } from '@wordpress/date';
+import { Spinner } from '@wordpress/components';
+import { Icon, comment, postList } from '@wordpress/icons';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+
+// Dashboard is still experimental.
+
+import { EmptyState, Link, Stack } from '@wordpress/ui';
+import type { View, Field } from '@wordpress/dataviews';
+import type { Post, Comment } from '@wordpress/core-data';
+
+// ─── Item type ────────────────────────────────────────────────────────────────
+
+type ActivityKind = 'post-future' | 'post-published' | 'comment';
+
+type ActivityEvent = {
+	id: string;
+	// ISO date string — used for sorting and extracting the `date` group key.
+	datetime: string;
+	title: string;
+	description: string;
+	link: string;
+	kind: ActivityKind;
+};
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Formats a `YYYY-MM-DD` string into a human-readable group label:
+ *  - Today / Yesterday / "Jun 15th" / "Jun 15th 2023"
+ *
+ * @param {string} dateStr YYYY-MM-DD date string.
+ */
+function formatGroupDate( dateStr: string ): string {
+	const now = getDate();
+	const today = dateI18n( 'Y-m-d', now );
+
+	if ( dateStr === today ) {
+		return __( 'Today' );
+	}
+
+	const yesterday = getDate();
+	yesterday.setDate( yesterday.getDate() - 1 );
+	const yesterdayStr = dateI18n( 'Y-m-d', yesterday );
+
+	if ( dateStr === yesterdayStr ) {
+		return __( 'Yesterday' );
+	}
+
+	const currentYear = dateI18n( 'Y', now );
+
+	if ( dateStr.slice( 0, 4 ) === currentYear ) {
+		/* translators: Date format for dashboard activity group header (current year), see https://www.php.net/manual/datetime.format.php */
+		return dateI18n( __( 'M jS' ), dateStr );
+	}
+
+	/* translators: Date format for dashboard activity group header (different year), see https://www.php.net/manual/datetime.format.php */
+	return dateI18n( __( 'M jS Y' ), dateStr );
+}
+
+// ─── Fields ───────────────────────────────────────────────────────────────────
+
+const FIELDS: Field< ActivityEvent >[] = [
+	{
+		id: 'icon',
+		label: __( 'Icon' ),
+		type: 'media',
+		render: ( { item } ) => (
+			<Icon icon={ item.kind === 'comment' ? comment : postList } />
+		),
+		enableSorting: false,
+		enableHiding: false,
+	},
+	{
+		id: 'content',
+		label: __( 'Content' ),
+		getValue: ( { item } ) => item.title,
+		render: ( { item } ) => (
+			<>
+				<strong>{ item.title }</strong>
+				{ item.description && (
+					<>
+						{ ': ' }
+						<span
+							dangerouslySetInnerHTML={ {
+								__html: item.description,
+							} }
+						/>
+					</>
+				) }
+			</>
+		),
+		enableSorting: false,
+		enableGlobalSearch: true,
+	},
+	{
+		id: 'time',
+		label: __( 'Time' ),
+		getValue: ( { item } ) => item.datetime,
+		render: ( { item } ) => (
+			<span>
+				{ /* translators: Time format for activity stream, see https://www.php.net/manual/datetime.format.php */ }
+				{ dateI18n( __( 'g:i a' ), item.datetime ) }
+			</span>
+		),
+		enableSorting: false,
+	},
+	{
+		id: 'date',
+		label: __( 'Date' ),
+		getValue: ( { item } ) => item.datetime.split( 'T' )[ 0 ],
+		render: ( { item } ) => (
+			<span>{ formatGroupDate( item.datetime.split( 'T' )[ 0 ] ) }</span>
+		),
+		enableSorting: false,
+		enableHiding: false,
+	},
+];
+
+// ─── Default view ─────────────────────────────────────────────────────────────
+
+const DEFAULT_VIEW: View = {
+	type: 'activity',
+	search: '',
+	page: 1,
+	perPage: 20,
+	filters: [],
+	fields: [ 'time' ],
+	titleField: 'content',
+	mediaField: 'icon',
+	showMedia: true,
+	sort: {
+		field: 'datetime',
+		direction: 'desc',
+	},
+	groupBy: {
+		field: 'date',
+		direction: 'desc',
+		showLabel: false,
+	},
+};
+
+const FUTURE_POSTS_QUERY = {
+	status: 'future',
+	orderby: 'date',
+	order: 'asc',
+	per_page: 5,
+};
+
+const RECENT_POSTS_QUERY = {
+	status: 'publish',
+	orderby: 'date',
+	order: 'desc',
+	per_page: 5,
+};
+
+const COMMENTS_QUERY = {
+	per_page: 5,
+};
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function Activity() {
+	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const { futurePosts, recentPosts, comments, isResolved } = useSelect(
+		( select ) => {
+			const coreData = select( coreStore );
+
+			return {
+				futurePosts: coreData.getEntityRecords< Post >(
+					'postType',
+					'post',
+					FUTURE_POSTS_QUERY
+				),
+				recentPosts: coreData.getEntityRecords< Post >(
+					'postType',
+					'post',
+					RECENT_POSTS_QUERY
+				),
+				comments: coreData.getEntityRecords< Comment >(
+					'root',
+					'comment',
+					COMMENTS_QUERY
+				),
+				isResolved:
+					coreData.hasFinishedResolution( 'getEntityRecords', [
+						'postType',
+						'post',
+						FUTURE_POSTS_QUERY,
+					] ) &&
+					coreData.hasFinishedResolution( 'getEntityRecords', [
+						'postType',
+						'post',
+						RECENT_POSTS_QUERY,
+					] ) &&
+					coreData.hasFinishedResolution( 'getEntityRecords', [
+						'root',
+						'comment',
+						COMMENTS_QUERY,
+					] ),
+			};
+		},
+		[]
+	);
+
+	const allEvents = useMemo< ActivityEvent[] >( () => {
+		const events: ActivityEvent[] = [];
+
+		for ( const post of futurePosts ?? [] ) {
+			events.push( {
+				id: `post-future-${ post.id }`,
+				datetime: post.date ?? '',
+				title: ( post.title as { rendered: string } )?.rendered ?? '',
+				description: '',
+				link: post.link ?? '',
+				kind: 'post-future',
+			} );
+		}
+
+		for ( const post of recentPosts ?? [] ) {
+			events.push( {
+				id: `post-published-${ post.id }`,
+				datetime: post.date ?? '',
+				title: ( post.title as { rendered: string } )?.rendered ?? '',
+				description: '',
+				link: post.link ?? '',
+				kind: 'post-published',
+			} );
+		}
+
+		for ( const c of comments ?? [] ) {
+			events.push( {
+				id: `comment-${ c.id }`,
+				datetime: ( c.date as string ) ?? '',
+				title: ( c.author_name as string ) ?? '',
+				description:
+					( c.content as { rendered: string } )?.rendered ?? '',
+				link: ( c.link as string ) ?? '',
+				kind: 'comment',
+			} );
+		}
+
+		return events;
+	}, [ futurePosts, recentPosts, comments ] );
+
+	const { data: shownData, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( allEvents, view, FIELDS ),
+		[ allEvents, view ]
+	);
+
+	if ( ! isResolved ) {
+		return (
+			<Stack align="center" justify="center" style={ { minHeight: 220 } }>
+				<Spinner />
+			</Stack>
+		);
+	}
+
+	if ( allEvents.length === 0 ) {
+		return (
+			<Stack align="center" justify="center" style={ { minHeight: 220 } }>
+				<EmptyState.Root>
+					<EmptyState.Icon icon={ postList } />
+					<EmptyState.Title>
+						{ __( 'No activity yet.' ) }
+					</EmptyState.Title>
+					<EmptyState.Description>
+						{ __(
+							'When you publish posts or receive comments, they will appear here.'
+						) }
+					</EmptyState.Description>
+				</EmptyState.Root>
+			</Stack>
+		);
+	}
+
+	return (
+		<DataViews
+			data={ shownData }
+			fields={ FIELDS }
+			view={ view }
+			onChangeView={ setView }
+			paginationInfo={ paginationInfo }
+			getItemId={ ( item ) => item.id }
+			search={ false }
+			isLoading={ false }
+			defaultLayouts={ {
+				activity: {
+					sort: {
+						field: 'datetime',
+						direction: 'desc',
+					},
+				},
+			} }
+			renderItemLink={ ( { item, children, ...aProps } ) => (
+				<Link href={ item.link } { ...aProps }>
+					{ children }
+				</Link>
+			) }
+			isItemClickable={ ( item ) => !! item.link }
+		>
+			<DataViews.Layout />
+		</DataViews>
+	);
+}

--- a/widgets/activity/render.tsx
+++ b/widgets/activity/render.tsx
@@ -68,6 +68,18 @@ function formatGroupDate( dateStr: string ): string {
 	return dateI18n( __( 'M jS Y' ), dateStr );
 }
 
+/*
+ * Converts a comment's rendered HTML into a plain-text excerpt, matching the
+ * classic dashboard which shows comment content without markup.
+ */
+function htmlToPlainText( html: string ): string {
+	const { body } = new window.DOMParser().parseFromString(
+		html,
+		'text/html'
+	);
+	return ( body.textContent ?? '' ).trim();
+}
+
 // ─── Fields ───────────────────────────────────────────────────────────────────
 
 const FIELDS: Field< ActivityEvent >[] = [
@@ -82,24 +94,18 @@ const FIELDS: Field< ActivityEvent >[] = [
 		enableHiding: false,
 	},
 	{
-		id: 'content',
-		label: __( 'Content' ),
+		id: 'title',
+		label: __( 'Title' ),
+		type: 'text',
 		getValue: ( { item } ) => item.title,
-		render: ( { item } ) => (
-			<>
-				<strong>{ item.title }</strong>
-				{ item.description && (
-					<>
-						{ ': ' }
-						<span
-							dangerouslySetInnerHTML={ {
-								__html: item.description,
-							} }
-						/>
-					</>
-				) }
-			</>
-		),
+		enableSorting: false,
+		enableGlobalSearch: true,
+	},
+	{
+		id: 'description',
+		label: __( 'Description' ),
+		type: 'text',
+		getValue: ( { item } ) => item.description,
 		enableSorting: false,
 		enableGlobalSearch: true,
 	},
@@ -136,7 +142,8 @@ const DEFAULT_VIEW: View = {
 	perPage: 20,
 	filters: [],
 	fields: [ 'datetime' ],
-	titleField: 'content',
+	titleField: 'title',
+	descriptionField: 'description',
 	mediaField: 'icon',
 	showMedia: true,
 	sort: {
@@ -247,8 +254,9 @@ export default function Activity() {
 				id: `comment-${ c.id }`,
 				datetime: ( c.date as string ) ?? '',
 				title: decodeEntities( ( c.author_name as string ) ?? '' ),
-				description:
-					( c.content as { rendered: string } )?.rendered ?? '',
+				description: htmlToPlainText(
+					( c.content as { rendered: string } )?.rendered ?? ''
+				),
 				link: ( c.link as string ) ?? '',
 				kind: 'comment',
 			} );

--- a/widgets/activity/render.tsx
+++ b/widgets/activity/render.tsx
@@ -101,7 +101,7 @@ const FIELDS: Field< ActivityEvent >[] = [
 		enableGlobalSearch: true,
 	},
 	{
-		id: 'time',
+		id: 'datetime',
 		label: __( 'Time' ),
 		getValue: ( { item } ) => item.datetime,
 		render: ( { item } ) => (
@@ -110,7 +110,7 @@ const FIELDS: Field< ActivityEvent >[] = [
 				{ dateI18n( __( 'g:i a' ), item.datetime ) }
 			</span>
 		),
-		enableSorting: false,
+		enableSorting: true,
 	},
 	{
 		id: 'date',
@@ -119,7 +119,7 @@ const FIELDS: Field< ActivityEvent >[] = [
 		render: ( { item } ) => (
 			<span>{ formatGroupDate( item.datetime.split( 'T' )[ 0 ] ) }</span>
 		),
-		enableSorting: false,
+		enableSorting: true,
 		enableHiding: false,
 	},
 ];
@@ -132,7 +132,7 @@ const DEFAULT_VIEW: View = {
 	page: 1,
 	perPage: 20,
 	filters: [],
-	fields: [ 'time' ],
+	fields: [ 'datetime' ],
 	titleField: 'content',
 	mediaField: 'icon',
 	showMedia: true,

--- a/widgets/activity/render.tsx
+++ b/widgets/activity/render.tsx
@@ -33,6 +33,11 @@ type ActivityEvent = {
 	kind: ActivityKind;
 };
 
+type ActivityAttributes = {
+	// How many items of each activity type to fetch.
+	perPage?: number;
+};
+
 // ─── Date helpers ─────────────────────────────────────────────────────────────
 
 /**
@@ -135,11 +140,18 @@ const FIELDS: Field< ActivityEvent >[] = [
 
 // ─── Default view ─────────────────────────────────────────────────────────────
 
+// Default number of items fetched per activity type.
+const DEFAULT_PER_PAGE = 5;
+
+// Activity sources merged into the stream: scheduled posts, published posts,
+// and comments. Used to size the page so every fetched item is shown.
+const SOURCE_COUNT = 3;
+
 const DEFAULT_VIEW: View = {
 	type: 'activity',
 	search: '',
 	page: 1,
-	perPage: 20,
+	perPage: DEFAULT_PER_PAGE,
 	filters: [],
 	fields: [ 'datetime' ],
 	titleField: 'title',
@@ -157,28 +169,38 @@ const DEFAULT_VIEW: View = {
 	},
 };
 
-const FUTURE_POSTS_QUERY = {
-	status: 'future',
-	orderby: 'date',
-	order: 'asc',
-	per_page: 5,
-};
-
-const RECENT_POSTS_QUERY = {
-	status: 'publish',
-	orderby: 'date',
-	order: 'desc',
-	per_page: 5,
-};
-
-const COMMENTS_QUERY = {
-	per_page: 5,
-};
-
 // ─── Main component ───────────────────────────────────────────────────────────
 
-export default function Activity() {
+export default function Activity( {
+	attributes,
+}: {
+	attributes?: ActivityAttributes;
+} ) {
+	const perPage = Math.max( 1, attributes?.perPage ?? DEFAULT_PER_PAGE );
+
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+
+	// Fetch up to `perPage` items from each source so all three activity types
+	// are represented; the merged result is sorted into one stream.
+	const queries = useMemo(
+		() => ( {
+			future: {
+				status: 'future',
+				orderby: 'date',
+				order: 'asc',
+				per_page: perPage,
+			},
+			recent: {
+				status: 'publish',
+				orderby: 'date',
+				order: 'desc',
+				per_page: perPage,
+			},
+			comments: { per_page: perPage },
+		} ),
+		[ perPage ]
+	);
+
 	const { futurePosts, recentPosts, comments, isResolved } = useSelect(
 		( select ) => {
 			const coreData = select( coreStore );
@@ -187,37 +209,37 @@ export default function Activity() {
 				futurePosts: coreData.getEntityRecords< Post >(
 					'postType',
 					'post',
-					FUTURE_POSTS_QUERY
+					queries.future
 				),
 				recentPosts: coreData.getEntityRecords< Post >(
 					'postType',
 					'post',
-					RECENT_POSTS_QUERY
+					queries.recent
 				),
 				comments: coreData.getEntityRecords< Comment >(
 					'root',
 					'comment',
-					COMMENTS_QUERY
+					queries.comments
 				),
 				isResolved:
 					coreData.hasFinishedResolution( 'getEntityRecords', [
 						'postType',
 						'post',
-						FUTURE_POSTS_QUERY,
+						queries.future,
 					] ) &&
 					coreData.hasFinishedResolution( 'getEntityRecords', [
 						'postType',
 						'post',
-						RECENT_POSTS_QUERY,
+						queries.recent,
 					] ) &&
 					coreData.hasFinishedResolution( 'getEntityRecords', [
 						'root',
 						'comment',
-						COMMENTS_QUERY,
+						queries.comments,
 					] ),
 			};
 		},
-		[]
+		[ queries ]
 	);
 
 	const allEvents = useMemo< ActivityEvent[] >( () => {
@@ -265,9 +287,16 @@ export default function Activity() {
 		return events;
 	}, [ futurePosts, recentPosts, comments ] );
 
+	// Size the page to the full merged set (up to `perPage` per source) so every
+	// fetched item is shown; the widget has no pagination UI yet.
+	const resolvedView = useMemo(
+		() => ( { ...view, perPage: perPage * SOURCE_COUNT } ),
+		[ view, perPage ]
+	);
+
 	const { data: shownData, paginationInfo } = useMemo(
-		() => filterSortAndPaginate( allEvents, view, FIELDS ),
-		[ allEvents, view ]
+		() => filterSortAndPaginate( allEvents, resolvedView, FIELDS ),
+		[ allEvents, resolvedView ]
 	);
 
 	if ( ! isResolved ) {
@@ -310,7 +339,7 @@ export default function Activity() {
 		<DataViews
 			data={ shownData }
 			fields={ FIELDS }
-			view={ view }
+			view={ resolvedView }
 			onChangeView={ setView }
 			paginationInfo={ paginationInfo }
 			getItemId={ ( item ) => item.id }

--- a/widgets/activity/render.tsx
+++ b/widgets/activity/render.tsx
@@ -6,6 +6,7 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { dateI18n, getDate } from '@wordpress/date';
+import { decodeEntities } from '@wordpress/html-entities';
 import { Spinner } from '@wordpress/components';
 import { Icon, comment, postList } from '@wordpress/icons';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
@@ -217,7 +218,9 @@ export default function Activity() {
 			events.push( {
 				id: `post-future-${ post.id }`,
 				datetime: post.date ?? '',
-				title: ( post.title as { rendered: string } )?.rendered ?? '',
+				title: decodeEntities(
+					( post.title as { rendered: string } )?.rendered ?? ''
+				),
 				description: '',
 				link: post.link ?? '',
 				kind: 'post-future',
@@ -228,7 +231,9 @@ export default function Activity() {
 			events.push( {
 				id: `post-published-${ post.id }`,
 				datetime: post.date ?? '',
-				title: ( post.title as { rendered: string } )?.rendered ?? '',
+				title: decodeEntities(
+					( post.title as { rendered: string } )?.rendered ?? ''
+				),
 				description: '',
 				link: post.link ?? '',
 				kind: 'post-published',
@@ -239,7 +244,7 @@ export default function Activity() {
 			events.push( {
 				id: `comment-${ c.id }`,
 				datetime: ( c.date as string ) ?? '',
-				title: ( c.author_name as string ) ?? '',
+				title: decodeEntities( ( c.author_name as string ) ?? '' ),
 				description:
 					( c.content as { rendered: string } )?.rendered ?? '',
 				link: ( c.link as string ) ?? '',

--- a/widgets/activity/render.tsx
+++ b/widgets/activity/render.tsx
@@ -10,12 +10,14 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { Spinner } from '@wordpress/components';
 import { Icon, comment, postList } from '@wordpress/icons';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
-
-// Dashboard is still experimental.
-
 import { EmptyState, Link, Stack } from '@wordpress/ui';
 import type { View, Field } from '@wordpress/dataviews';
 import type { Post, Comment } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
 
 // ─── Item type ────────────────────────────────────────────────────────────────
 
@@ -262,7 +264,12 @@ export default function Activity() {
 
 	if ( ! isResolved ) {
 		return (
-			<Stack align="center" justify="center" style={ { minHeight: 220 } }>
+			<Stack
+				direction="column"
+				align="center"
+				justify="center"
+				className={ styles.center }
+			>
 				<Spinner />
 			</Stack>
 		);
@@ -270,7 +277,12 @@ export default function Activity() {
 
 	if ( allEvents.length === 0 ) {
 		return (
-			<Stack align="center" justify="center" style={ { minHeight: 220 } }>
+			<Stack
+				direction="column"
+				align="center"
+				justify="center"
+				className={ styles.center }
+			>
 				<EmptyState.Root>
 					<EmptyState.Icon icon={ postList } />
 					<EmptyState.Title>

--- a/widgets/activity/render.tsx
+++ b/widgets/activity/render.tsx
@@ -276,7 +276,7 @@ export default function Activity() {
 				direction="column"
 				align="center"
 				justify="center"
-				className={ styles.center }
+				className={ styles.loading }
 			>
 				<Spinner />
 			</Stack>
@@ -289,7 +289,7 @@ export default function Activity() {
 				direction="column"
 				align="center"
 				justify="center"
-				className={ styles.center }
+				className={ styles.loading }
 			>
 				<EmptyState.Root>
 					<EmptyState.Icon icon={ postList } />

--- a/widgets/activity/style.module.css
+++ b/widgets/activity/style.module.css
@@ -1,0 +1,3 @@
+.center {
+	height: 100%;
+}

--- a/widgets/activity/style.module.css
+++ b/widgets/activity/style.module.css
@@ -1,3 +1,3 @@
-.center {
+.loading {
 	height: 100%;
 }

--- a/widgets/activity/widget.json
+++ b/widgets/activity/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "core/activity",
+	"title": "Activity",
+	"description": "Displays recently published posts, scheduled posts, and recent comments.",
+	"category": "dashboard"
+}

--- a/widgets/activity/widget.json
+++ b/widgets/activity/widget.json
@@ -2,5 +2,6 @@
 	"name": "core/activity",
 	"title": "Activity",
 	"description": "Displays recently published posts, scheduled posts, and recent comments.",
-	"category": "dashboard"
+	"category": "dashboard",
+	"presentation": "content-bleed"
 }

--- a/widgets/activity/widget.ts
+++ b/widgets/activity/widget.ts
@@ -1,0 +1,6 @@
+import { __ } from '@wordpress/i18n';
+
+export default {
+	name: 'core/activity',
+	title: __( 'Activity' ),
+};

--- a/widgets/activity/widget.ts
+++ b/widgets/activity/widget.ts
@@ -3,4 +3,11 @@ import { __ } from '@wordpress/i18n';
 export default {
 	name: 'core/activity',
 	title: __( 'Activity' ),
+	attributes: [
+		{
+			id: 'perPage',
+			type: 'integer',
+			label: __( 'Items per page' ),
+		},
+	],
 };


### PR DESCRIPTION
## Summary

- Adds the `core/activity` dashboard widget (recent posts, scheduled posts, and comments).
- Registers the widget module in `load.php` so the dashboard import map can lazy-load it.

Split from dashboard widgets work for standalone review.

## Test plan

- [ ] Enable the `gutenberg-dashboard-widgets` experiment.
- [ ] Open Dashboard (Beta) and add the Activity widget from the inserter.
- [ ] Confirm published, scheduled, and comment activity render correctly.
- [ ] Run `npm run build` and verify the widget module builds without errors.