### PR TITLE
Collab Notes: Defer the full comments fetch behind preloaded count probes

### DIFF
--- a/lib/compat/wordpress-7.0/preload.php
+++ b/lib/compat/wordpress-7.0/preload.php
@@ -57,3 +57,37 @@ function gutenberg_block_editor_preload_paths_root_fields( $paths ) {
 	return $paths;
 }
 add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_root_fields' );
+
+/**
+ * Preload the notes-presence probes for the post editor.
+ *
+ * The collab notes feature drives sidebar visibility and the
+ * floating-sidebar auto-open from two count probes:
+ *   - total note count   (`status=all`)
+ *   - unresolved count   (`status=hold`)
+ * Each is a tiny list call (`per_page=1&_fields=id`) whose
+ * `X-WP-Total` header carries the count. Preloading them keeps the
+ * boot path cache-only — the full per-page comments fetch only fires
+ * when the total count is > 0.
+ *
+ * @param array                   $paths   REST API paths to preload.
+ * @param WP_Block_Editor_Context $context Current block editor context.
+ * @return array Filtered preload paths.
+ */
+function gutenberg_block_editor_preload_paths_notes_counts( $paths, $context ) {
+	if ( 'core/edit-post' !== $context->name || ! isset( $context->post ) ) {
+		return $paths;
+	}
+	$post_id = (int) $context->post->ID;
+	if ( ! $post_id ) {
+		return $paths;
+	}
+	$base = sprintf(
+		'/wp/v2/comments?context=edit&post=%d&type=note&per_page=1&_fields=id',
+		$post_id
+	);
+	$paths[] = $base . '&status=all';
+	$paths[] = $base . '&status=hold';
+	return $paths;
+}
+add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_notes_counts', 10, 2 );

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -236,6 +236,26 @@ async function preloadResolutions( postType, postId ) {
 							postId
 						),
 						core.getAutosaves( postType, postId ),
+						// Collab notes presence probes — paired with the
+						// preload entries in `wordpress-7.0/preload.php`.
+						// The hook in `useNoteThreads` reads `totalItems`
+						// from these to drive the sidebar/floating gates
+						// without doing the full per-page comments fetch
+						// on every boot.
+						core.getEntityRecords( 'root', 'comment', {
+							post: postId,
+							type: 'note',
+							status: 'all',
+							per_page: 1,
+							_fields: 'id',
+						} ),
+						core.getEntityRecords( 'root', 'comment', {
+							post: postId,
+							type: 'note',
+							status: 'hold',
+							per_page: 1,
+							_fields: 'id',
+						} ),
 				  ]
 				: [] ),
 		] );

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -36,6 +36,39 @@ import {
 const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
 
 export function useNoteThreads( postId ) {
+	const enabled = !! postId && typeof postId === 'number';
+
+	// Cheap presence probes: 1-record list calls whose response body is
+	// effectively empty but whose `X-WP-Total` header gives the exact
+	// count. The kickoff's PHP preload covers these (see
+	// `lib/compat/wordpress-7.0/preload.php`), so the boot path resolves
+	// them from cache. The counts then gate the heavier full fetch
+	// below.
+	const { totalItems: notesCount } = useEntityRecords(
+		'root',
+		'comment',
+		{
+			post: postId,
+			type: 'note',
+			status: 'all',
+			per_page: 1,
+			_fields: 'id',
+		},
+		{ enabled }
+	);
+	const { totalItems: unresolvedCount } = useEntityRecords(
+		'root',
+		'comment',
+		{
+			post: postId,
+			type: 'note',
+			status: 'hold',
+			per_page: 1,
+			_fields: 'id',
+		},
+		{ enabled }
+	);
+
 	const queryArgs = {
 		post: postId,
 		type: 'note',
@@ -43,11 +76,14 @@ export function useNoteThreads( postId ) {
 		per_page: -1,
 	};
 
+	// Full fetch only when there's at least one note. Posts with no
+	// notes pay just the cached count probes; posts with notes pay the
+	// same fetch they pay today.
 	const { records: threads } = useEntityRecords(
 		'root',
 		'comment',
 		queryArgs,
-		{ enabled: !! postId && typeof postId === 'number' }
+		{ enabled: enabled && ( notesCount ?? 0 ) > 0 }
 	);
 
 	const { getBlockAttributes } = useSelect( blockEditorStore );
@@ -142,6 +178,8 @@ export function useNoteThreads( postId ) {
 	return {
 		notes,
 		unresolvedNotes,
+		hasNotes: ( notesCount ?? 0 ) > 0,
+		hasUnresolvedNotes: ( unresolvedCount ?? 0 ) > 0,
 	};
 }
 

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -67,15 +67,16 @@ function NotesSidebar( { postId } ) {
 		[]
 	);
 
-	const { notes, unresolvedNotes } = useNoteThreads( postId );
+	const { notes, unresolvedNotes, hasNotes, hasUnresolvedNotes } =
+		useNoteThreads( postId );
 
 	// Only enable the floating sidebar for large viewports.
 	const showFloatingSidebar = isLargeViewport;
 	// Fallback to "All notes" sidebar on smaller viewports.
-	const showAllNotesSidebar = notes.length > 0 || ! showFloatingSidebar;
+	const showAllNotesSidebar = hasNotes || ! showFloatingSidebar;
 	useEnableFloatingSidebar(
 		showFloatingSidebar &&
-			( unresolvedNotes.length > 0 || selectedNote !== undefined )
+			( hasUnresolvedNotes || selectedNote !== undefined )
 	);
 
 	async function focusNote( {


### PR DESCRIPTION
## What?

The collab notes feature fires \`GET /wp/v2/comments?type=note&per_page=-1\` on every editor mount of every post supporting \`editor.notes\`. The full response only feeds two pieces of UI that need *counts*, not threads:

1. The All Notes sidebar's presence on the toolbar (\`notes.length > 0\`).
2. The floating-sidebar's auto-open arming (\`unresolvedNotes.length > 0\`).

(Per-block indicators and the All Notes sidebar contents are gated by user interaction — block selection / sidebar open — so they don't run on mount.)

For the common case of a post with no notes, today we still pay the eager fetch on every mount.

## How?

Replace with two small preloadable presence probes plus a gated full fetch:

1. \`useNoteThreads\` adds two \`useEntityRecords\` calls with \`per_page=1&_fields=id\` — one for \`status=all\`, one for \`status=hold\`. Their \`X-WP-Total\` populates \`notesCount\` / \`unresolvedCount\`.
2. The full per-page fetch is gated on \`notesCount > 0\` — posts with no notes never fire it.
3. \`NotesSidebar\` reads \`hasNotes\` / \`hasUnresolvedNotes\` from the hook instead of \`notes.length\` / \`unresolvedNotes.length\`, so the gates work even before the (now-conditional) full fetch resolves.
4. The two count URLs are added to \`block_editor_rest_api_preload_paths\` for the post-editor context, and driven in the kickoff alongside the other per-post resolvers so they consume the preload entries before \`clearPreloadedData\` runs.

## Test results

### Post with no notes (the common case)

Before:
\`\`\`
GET /wp-json/wp/v2/comments?context=edit&post=…&type=note&status=all&per_page=100
\`\`\`

After:
\`\`\`
[api-fetch][preload] All preloads consumed.
(no /wp/v2/comments request)
\`\`\`

### Post with at least one note

Count probes cache-hit via the kickoff. Full fetch fires the same as today — drives indicators + sidebar content rendering.

\`\`\`
[api-fetch][preload] All preloads consumed.
GET /wp-json/wp/v2/comments?context=edit&post=…&type=note&status=all&per_page=100
\`\`\`

## Testing Instructions

1. Open the post editor on a draft with no notes. Filter DevTools Network for \`comments\` — should see no \`/wp/v2/comments\` request during boot.
2. Add a note on a block, reload — the full fetch should fire, same as today.
3. Confirm \`[api-fetch][preload] All preloads consumed.\` logs in the console in both cases.

## Follow-ups

The full fetch is still eager when there's at least one note. Future work could defer it to either (a) the user opening the All Notes sidebar, or (b) per-block-selection single-comment fetches with placeholders. This PR is the smallest step that covers the no-notes case (which is most posts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)