### PR TITLE
Update the docblock for the `block_core_social_link_get_services` filter

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -343,8 +343,16 @@ function block_core_social_link_services( $service = '', $field = '' ) {
 	 *
 	 * @since 6.9.0
 	 *
-	 * @param array $services_data The list of services. Each item is an array containing a 'name' and 'icon' key.
-	 * @return array The list of social services.
+	 * @param array $services_data {
+	 *     The list of services keyed by service slug.
+	 *
+	 *     @type array ...$0 {
+	 *         Service definition.
+	 *
+	 *         @type string $name Service name.
+	 *         @type string $icon Service icon as a directly renderable string.
+	 *     }
+	 * }
 	 */
 	$services_data = apply_filters( 'block_core_social_link_get_services', $services_data );
 


### PR DESCRIPTION
## What?

The `block_core_social_link_get_services` filter docblock erroneously includes a `@return` tag.

This PR removes it, and adds array shape notation for the `$services_data` parameter at the same time.

## Why?

`@return` is not a valid tag in a hook docblock.

## Use of AI Tools

None.