### PR TITLE
Fix: Cover block image sizes

### DIFF
--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -140,7 +140,7 @@ function render_block_core_cover( $attributes, $content ) {
 		$min_height      = $attributes['minHeight'] ?? 430;
 		$min_height_unit = $attributes['minHeightUnit'] ?? 'px';
 
-		if ( in_array( $min_height_unit, array( 'px', 'vh' ), true ) ) {
+		if ( in_array( $min_height_unit, array( 'px', 'vh', 'vw', 'em', 'rem' ), true ) ) {
 			$attachment_id = null;
 
 			if ( ! empty( $attributes['useFeaturedImage'] ) ) {
@@ -153,15 +153,14 @@ function render_block_core_cover( $attributes, $content ) {
 				$image_src = wp_get_attachment_image_src( $attachment_id, 'full' );
 
 				if ( $image_src && $image_src[2] > 0 ) {
-					$width          = $image_src[1];
-					$height         = $image_src[2];
-					$aspect_ratio   = $width / $height;
-					$required_width = round( $min_height * $aspect_ratio );
+					$aspect_ratio = $image_src[1] / $image_src[2];
 
 					if ( 'px' === $min_height_unit ) {
-						$custom_sizes = sprintf( '(max-width: %1$dpx) %1$dpx, 100vw', $required_width );
-					} elseif ( 'vh' === $min_height_unit ) {
-						$custom_sizes = sprintf( 'max(100vw, %dvh)', $required_width );
+						$required_width = (int) round( $min_height * $aspect_ratio );
+						$custom_sizes   = sprintf( '(max-width: %1$dpx) %1$dpx, 100vw', $required_width );
+					} else {
+						$required_width = round( $min_height * $aspect_ratio, 2 );
+						$custom_sizes   = sprintf( 'max(100vw, %s%s)', $required_width, $min_height_unit );
 					}
 				}
 			}

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -156,10 +156,10 @@ function render_block_core_cover( $attributes, $content ) {
 					$aspect_ratio = $image_src[1] / $image_src[2];
 
 					if ( 'px' === $min_height_unit ) {
-						$required_width = (int) round( $min_height * $aspect_ratio );
+						$required_width = (int) round( (float) $min_height * $aspect_ratio );
 						$custom_sizes   = sprintf( '(max-width: %1$dpx) %1$dpx, 100vw', $required_width );
 					} else {
-						$required_width = round( $min_height * $aspect_ratio, 2 );
+						$required_width = round( (float) $min_height * $aspect_ratio, 2 );
 						$custom_sizes   = sprintf( 'max(100vw, %s%s)', $required_width, $min_height_unit );
 					}
 				}

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -130,7 +130,52 @@ function render_block_core_cover( $attributes, $content ) {
 		return $content;
 	}
 
-	if ( 'image' !== $attributes['backgroundType'] || false === $attributes['useFeaturedImage'] ) {
+	if ( ( $attributes['backgroundType'] ?? 'image' ) !== 'image' ) {
+		return $content;
+	}
+
+	$custom_sizes = null;
+
+	if ( empty( $attributes['hasParallax'] ) && empty( $attributes['isRepeated'] ) ) {
+		$min_height      = $attributes['minHeight'] ?? 430;
+		$min_height_unit = $attributes['minHeightUnit'] ?? 'px';
+
+		if ( in_array( $min_height_unit, array( 'px', 'vh' ), true ) ) {
+			$attachment_id = null;
+
+			if ( ! empty( $attributes['useFeaturedImage'] ) ) {
+				$attachment_id = get_post_thumbnail_id();
+			} elseif ( isset( $attributes['id'] ) ) {
+				$attachment_id = (int) $attributes['id'];
+			}
+
+			if ( $attachment_id ) {
+				$image_src = wp_get_attachment_image_src( $attachment_id, 'full' );
+
+				if ( $image_src && $image_src[2] > 0 ) {
+					$width          = $image_src[1];
+					$height         = $image_src[2];
+					$aspect_ratio   = $width / $height;
+					$required_width = round( $min_height * $aspect_ratio );
+
+					if ( 'px' === $min_height_unit ) {
+						$custom_sizes = sprintf( '(max-width: %1$dpx) %1$dpx, 100vw', $required_width );
+					} elseif ( 'vh' === $min_height_unit ) {
+						$custom_sizes = sprintf( 'max(100vw, %dvh)', $required_width );
+					}
+				}
+			}
+		}
+	}
+
+	if ( empty( $attributes['useFeaturedImage'] ) ) {
+		if ( $custom_sizes ) {
+			$processor = new WP_HTML_Tag_Processor( $content );
+			if ( $processor->next_tag( array( 'class_name' => 'wp-block-cover__image-background' ) ) ) {
+				$processor->set_attribute( 'sizes', $custom_sizes );
+				$content = $processor->get_updated_html();
+			}
+		}
 		return $content;
 	}
 
@@ -143,6 +188,10 @@ function render_block_core_cover( $attributes, $content ) {
 			'class'           => 'wp-block-cover__image-background',
 			'data-object-fit' => 'cover',
 		);
+
+		if ( $custom_sizes ) {
+			$attr['sizes'] = $custom_sizes;
+		}
 
 		if ( $object_position ) {
 			$attr['data-object-position'] = $object_position;


### PR DESCRIPTION

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #77387

This PR dynamically calculates and overwrites the sizes attribute for Cover block background images based on the block's min-height and the image's aspect ratio. It ensures that when `object-fit: cover` forces an image to scale up vertically, the browser requests an image size adequate for the rendered height rather than defaulting to a narrow rendered width.

## Why?
When standard or auto sizes are applied to a lazy-loaded image inside a Cover block, browsers use the layout width of the image element to determine which srcset image source to download.

However, because the Cover block uses `object-fit: cover` and often enforces a rigid `min-height`, a narrow Cover block container (e.g., inside a column) will clip the sides of a wide image to fulfill that height requirement. This means the layout width is small, but the image is actually scaled up significantly to match the height. The browser mistakenly downloads a low-resolution thumbnail, resulting in highly pixelated, blurry background images on both desktop layouts and mobile viewports.

## How?
In the PHP render callback for the Cover block, we intercept the image rendering logic (for both standard uploaded background images and Featured Images), there we calculate the aspect ratio of the image and dynamically set the sizes for the images.

This is an initial proof of concept to align on the architectural approach. Once the reviewers confirm this implementation path is correct, I will follow up by adding the corresponding tests as needed.

## Testing Instructions

1. Create a post or page with enough content/blocks so that blocks lower on the page will trigger lazy loading.
2. Insert a Columns block to create a narrow layout column.
3. Inside one of the narrow columns, insert a Cover block.
4. Set the Cover block's Minimum Height to 600px.
5. Upload or select a wide, short image (e.g., an image with a 2400x600 or 1600x400 landscape resolution).
6. Save and view the page on the frontend (ensure the Cover block requires scrolling to be lazy-loaded).
7. Inspect the image markup via DevTools. Verify that the sizes attribute contains the newly calculated dynamic fallback (e.g., (max-width: 2400px) 2400px, 100vw) instead of a basic width or only auto.
8. Confirm that the image renders crisp and sharp, pulling a high-resolution source from the srcset rather than a pixelated smaller file.


## Screenshots or screencast <!-- if applicable -->

#### Before

https://github.com/user-attachments/assets/3b7dc9d7-3299-484f-b5da-d1886a64f746

#### After

https://github.com/user-attachments/assets/32f5abe0-c4ba-4ede-a960-316640675193



## Use of AI Tools
I used Gemini 3.5 Flash to draft and format this Pull Request description based on the codebase changes provided.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
