### PR TITLE
Dashboard: add elevation to widget actionable area

### DIFF
--- a/routes/dashboard/widget-dashboard/components/widgets/widget-chrome-actionable-area.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widget-chrome-actionable-area.module.css
@@ -6,5 +6,6 @@
 	padding: var(--wpds-dimension-padding-xs);
 	background: var(--wpds-color-bg-surface-neutral-strong);
 	border-radius: var(--wpds-border-radius-md);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
 	box-shadow: var(--wpds-elevation-xs);
 }

--- a/routes/dashboard/widget-dashboard/components/widgets/widget-chrome-actionable-area.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widget-chrome-actionable-area.module.css
@@ -6,4 +6,5 @@
 	padding: var(--wpds-dimension-padding-xs);
 	background: var(--wpds-color-bg-surface-neutral-strong);
 	border-radius: var(--wpds-border-radius-md);
+	box-shadow: var(--wpds-elevation-xs);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/77616

<!-- In a few words, what is the PR actually doing? -->

Adds a small elevation to the actionable area in widgets customisation mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I've noticed visual issues with the tools currently when they get close to or over the widget UI:

<img width="231" height="82" alt="Screenshot 2026-05-22 at 13 45 46" src="https://github.com/user-attachments/assets/bb04625b-7fbd-450b-9dad-ea9d0612cdea" />
<img width="458" height="103" alt="Screenshot 2026-05-22 at 13 45 20" src="https://github.com/user-attachments/assets/fce1d018-ca6b-4a6e-a821-ced461cfd53c" />


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds elevation with box shadow and border.

We originally had a border, but I removed it because the widget chrome felt "boxy". Without a border, the UI feels "breathy"/ "airy", but I have no strong opinion.

Screenshots of different combos over different widget UIs:

#### Box shadow:
<img width="234" height="77" alt="Screenshot 2026-05-22 at 13 45 53" src="https://github.com/user-attachments/assets/b52f8249-31ee-4e5d-8cb3-071b13fd4906" />
<img width="462" height="82" alt="Screenshot 2026-05-22 at 13 43 14" src="https://github.com/user-attachments/assets/054c6fee-17a0-417e-9e96-0daae46bbaf7" />
<img width="458" height="92" alt="Screenshot 2026-05-22 at 13 42 44" src="https://github.com/user-attachments/assets/33930532-d147-4d72-819f-ede651e0d3a9" />


#### Box shadow+Border _(currently in this PR)_:
<img width="231" height="79" alt="Screenshot 2026-05-22 at 13 45 57" src="https://github.com/user-attachments/assets/a7f44a3c-c56f-48bb-b3a3-fcf8fa39ab71" />
<img width="467" height="89" alt="Screenshot 2026-05-22 at 13 43 21" src="https://github.com/user-attachments/assets/50eaae35-c01a-4414-ad55-4dfbba03f095" />
<img width="468" height="99" alt="Screenshot 2026-05-22 at 13 42 48" src="https://github.com/user-attachments/assets/6263f6a7-1060-4067-bd33-8bbf9b3ad440" />


#### Border:
<img width="230" height="80" alt="Screenshot 2026-05-22 at 13 46 02" src="https://github.com/user-attachments/assets/f1554d0a-4f28-4afc-a1f7-9ac31339a5c6" />
<img width="464" height="77" alt="Screenshot 2026-05-22 at 13 43 25" src="https://github.com/user-attachments/assets/5d9f4759-6f72-49c3-bfc1-dde5b2b71ea5" />
<img width="468" height="103" alt="Screenshot 2026-05-22 at 13 42 58" src="https://github.com/user-attachments/assets/57dd5bfb-45b4-4f44-82c1-9ec79876f5c7" />



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
