### PR TITLE
Show Font Family control by default in block inspector

### DIFF
--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -181,10 +181,16 @@ export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
 		return null;
 	}
 
-	const defaultControls = getBlockSupport( name, [
+	const blockDefaultControls = getBlockSupport( name, [
 		TYPOGRAPHY_SUPPORT_KEY,
 		'__experimentalDefaultControls',
 	] );
+
+	// Ensure fontFamily is shown by default for blocks that support it,
+	// unless the block explicitly opts out by setting fontFamily: false.
+	const defaultControls = blockDefaultControls
+		? { fontFamily: true, ...blockDefaultControls }
+		: undefined;
 
 	return (
 		<StylesTypographyPanel


### PR DESCRIPTION
## What?

Closes [#56373](https://github.com/WordPress/gutenberg/issues/56373)

Makes the **Font Family** control visible by default in the Typography panel of the block inspector.

## Why?

Font Family is a setting many users want to change, but it was difficult to find. Blocks like Paragraph and Heading define their own `__experimentalDefaultControls` (e.g. `{ fontSize: true }`), which completely overrode the Typography panel's `DEFAULT_CONTROLS` fallback inadvertently hiding Font Family unless the user manually enabled it from the "options" menu.

## How?

In `packages/block-editor/src/hooks/typography.js`, instead of passing the block's `__experimentalDefaultControls` directly to `StylesTypographyPanel`, we now merge `fontFamily: true` as a baseline before spreading the block's own overrides:

```js
const defaultControls = blockDefaultControls
    ? { fontFamily: true, ...blockDefaultControls }
    : undefined;
```

This ensures Font Family is shown by default for all blocks that support it. Blocks can still explicitly opt out by setting `fontFamily: false` in their `__experimentalDefaultControls`.

## Testing Instructions

1. Open a post or page in the editor.
2. Insert a Paragraph block.
3. Open the block Inspector (right sidebar) → Typography panel.
4. Verify that Font Family is visible by default (without needing to click the ⋮ menu to enable it).
5. Repeat steps 2–4 with a Heading block.
6. To confirm opt-out still works: add `"fontFamily": false` to a block's `__experimentalDefaultControls` in [block.json] and verify the control is hidden.

## Testing Instructions for Keyboard
1. Focus the Paragraph block using keyboard navigation.
2. Press Tab to move into the Inspector sidebar.
3. Navigate to the Typography panel and expand it.
4. Confirm the Font Family control is reachable and visible without any additional steps.

## Screenshots
<img width="275" height="416" alt="Screenshot 2026-05-22 at 4 37 42 PM" src="https://github.com/user-attachments/assets/c558fa66-3a8f-496d-816e-b73037a4922f" />
