### PR TITLE
Editor / Block Editor: Lazy-fetch user pattern categories

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -12,7 +12,10 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { store as blockEditorStore } from '../../../store';
 import { unlock } from '../../../lock-unlock';
-import { isNavigationOverlayContextKey } from '../../../store/private-keys';
+import {
+	isNavigationOverlayContextKey,
+	userPatternCategoriesSelectKey,
+} from '../../../store/private-keys';
 import { INSERTER_PATTERN_TYPES } from '../block-patterns-tab/utils';
 import { isFiltered } from '../../../store/utils';
 
@@ -51,17 +54,19 @@ const usePatternsState = (
 			const { getSettings, __experimentalGetAllowedPatterns } = unlock(
 				select( blockEditorStore )
 			);
-			const {
-				__experimentalUserPatternCategories,
-				__experimentalBlockPatternCategories,
-			} = getSettings();
+			const settings = getSettings();
+			const userPatternCategoriesSelect =
+				settings[ userPatternCategoriesSelectKey ];
 			return {
 				patterns: __experimentalGetAllowedPatterns(
 					rootClientId,
 					options
 				),
-				userPatternCategories: __experimentalUserPatternCategories,
-				patternCategories: __experimentalBlockPatternCategories,
+				userPatternCategories: userPatternCategoriesSelect
+					? userPatternCategoriesSelect( select )
+					: settings.__experimentalUserPatternCategories,
+				patternCategories:
+					settings.__experimentalBlockPatternCategories,
 			};
 		},
 		[ rootClientId, options ]

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -40,6 +40,7 @@ import { useFlashEditableBlocks } from './components/use-flash-editable-blocks';
 import {
 	selectBlockPatternsKey,
 	reusableBlocksSelectKey,
+	userPatternCategoriesSelectKey,
 	globalStylesDataKey,
 	globalStylesLinksDataKey,
 	sectionRootClientIdKey,
@@ -119,6 +120,7 @@ lock( privateApis, {
 	PrivateRichText,
 	PrivateInserterLibrary,
 	reusableBlocksSelectKey,
+	userPatternCategoriesSelectKey,
 	PrivateBlockPopover,
 	PrivatePublishDateTimePicker,
 	useSpacingSizes,

--- a/packages/block-editor/src/store/private-keys.js
+++ b/packages/block-editor/src/store/private-keys.js
@@ -2,6 +2,9 @@ export const globalStylesDataKey = Symbol( 'globalStylesDataKey' );
 export const globalStylesLinksDataKey = Symbol( 'globalStylesLinks' );
 export const selectBlockPatternsKey = Symbol( 'selectBlockPatternsKey' );
 export const reusableBlocksSelectKey = Symbol( 'reusableBlocksSelect' );
+export const userPatternCategoriesSelectKey = Symbol(
+	'userPatternCategoriesSelect'
+);
 export const sectionRootClientIdKey = Symbol( 'sectionRootClientIdKey' );
 export const mediaEditKey = Symbol( 'mediaEditKey' );
 export const getMediaSelectKey = Symbol( 'getMediaSelect' );

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -34,6 +34,7 @@ import { unlock } from '../lock-unlock';
 import {
 	selectBlockPatternsKey,
 	reusableBlocksSelectKey,
+	userPatternCategoriesSelectKey,
 	sectionRootClientIdKey,
 	isIsolatedEditorKey,
 } from './private-keys';
@@ -361,7 +362,9 @@ export const getPatternBySlug = createRegistrySelector( ( select ) =>
 
 				return mapUserPattern(
 					block,
-					state.settings.__experimentalUserPatternCategories
+					state.settings[ userPatternCategoriesSelectKey ]?.(
+						select
+					) ?? state.settings.__experimentalUserPatternCategories
 				);
 			}
 
@@ -393,7 +396,9 @@ export const getAllPatterns = createRegistrySelector( ( select ) =>
 				.map( ( userPattern ) =>
 					mapUserPattern(
 						userPattern,
-						state.settings.__experimentalUserPatternCategories
+						state.settings[ userPatternCategoriesSelectKey ]?.(
+							select
+						) ?? state.settings.__experimentalUserPatternCategories
 					)
 				),
 			// This setting is left for back compat.

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -7,7 +7,10 @@ import { parse as grammarParse } from '@wordpress/block-serialization-default-pa
 /**
  * Internal dependencies
  */
-import { selectBlockPatternsKey } from './private-keys';
+import {
+	selectBlockPatternsKey,
+	userPatternCategoriesSelectKey,
+} from './private-keys';
 import { unlock } from '../lock-unlock';
 import { STORE_NAME } from './constants';
 import {
@@ -128,7 +131,8 @@ export const checkAllowListRecursive = ( blocks, allowedBlockTypes ) => {
 export const getAllPatternsDependants = ( select ) => ( state ) => {
 	return [
 		state.settings.__experimentalBlockPatterns,
-		state.settings.__experimentalUserPatternCategories,
+		state.settings[ userPatternCategoriesSelectKey ]?.( select ) ??
+			state.settings.__experimentalUserPatternCategories,
 		state.settings.__experimentalReusableBlocks,
 		state.settings[ selectBlockPatternsKey ]?.( select ),
 		state.blockPatterns,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -45,6 +45,10 @@ function __experimentalReusableBlocksSelect( select ) {
 	} );
 }
 
+function __experimentalUserPatternCategoriesSelect( select ) {
+	return select( coreStore ).getUserPatternCategories();
+}
+
 const BLOCK_EDITOR_SETTINGS = [
 	'__experimentalBlockBindingsSupportedAttributes',
 	'__experimentalBlockDirectory',
@@ -103,6 +107,7 @@ const {
 	globalStylesLinksDataKey,
 	selectBlockPatternsKey,
 	reusableBlocksSelectKey,
+	userPatternCategoriesSelectKey,
 	sectionRootClientIdKey,
 	mediaEditKey,
 	getMediaSelectKey,
@@ -142,7 +147,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		userCanCreatePages,
 		pageOnFront,
 		pageForPosts,
-		userPatternCategories,
 		restBlockPatternCategories,
 		sectionRootClientId,
 		deviceType,
@@ -154,7 +158,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				canUser,
 				getRawEntityRecord,
 				getEntityRecord,
-				getUserPatternCategories,
 				getBlockPatternCategories,
 			} = select( coreStore );
 			const { get } = select( preferencesStore );
@@ -217,7 +220,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				} ),
 				pageOnFront: siteSettings?.page_on_front,
 				pageForPosts: siteSettings?.page_for_posts,
-				userPatternCategories: getUserPatternCategories(),
 				restBlockPatternCategories: getBlockPatternCategories(),
 				sectionRootClientId: getSectionRootBlock(),
 				deviceType: getDeviceType(),
@@ -370,8 +372,9 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 					: undefined;
 			},
 			[ reusableBlocksSelectKey ]: __experimentalReusableBlocksSelect,
+			[ userPatternCategoriesSelectKey ]:
+				__experimentalUserPatternCategoriesSelect,
 			__experimentalBlockPatternCategories: blockPatternCategories,
-			__experimentalUserPatternCategories: userPatternCategories,
 			__experimentalFetchLinkSuggestions: ( search, searchOptions ) =>
 				fetchLinkSuggestions( search, searchOptions, settings ),
 			inserterMediaCategories,
@@ -435,7 +438,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		keepCaretInsideBlock,
 		settings,
 		hasUploadPermissions,
-		userPatternCategories,
 		blockPatterns,
 		blockPatternCategories,
 		canUseUnfilteredHTML,

--- a/test/e2e/specs/editor/collaboration/collaboration-sync-body-size.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-sync-body-size.spec.ts
@@ -11,7 +11,7 @@ const MAX_SYNC_BODY_SIZE = 16 * 1024 * 1024;
 // One room per extra post record, plus the baseline rooms the editor always
 // registers when opening a post (the primary post plus its collection rooms,
 // e.g. root/comment).
-const EXPECTED_ROOMS = EXTRA_POST_COUNT + 4;
+const EXPECTED_ROOMS = EXTRA_POST_COUNT + 3;
 
 function isSyncUpdateRequest( url: string ): boolean {
 	const decodedUrl = decodeURIComponent( url );

--- a/test/e2e/specs/editor/collaboration/collaboration-sync-body-size.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-sync-body-size.spec.ts
@@ -11,7 +11,7 @@ const MAX_SYNC_BODY_SIZE = 16 * 1024 * 1024;
 // One room per extra post record, plus the baseline rooms the editor always
 // registers when opening a post (the primary post plus its collection rooms,
 // e.g. root/comment).
-const EXPECTED_ROOMS = EXTRA_POST_COUNT + 3;
+const EXPECTED_ROOMS = EXTRA_POST_COUNT + 4;
 
 function isSyncUpdateRequest( url: string ): boolean {
 	const decodedUrl = decodeURIComponent( url );

--- a/test/e2e/specs/preload/post-editor.spec.js
+++ b/test/e2e/specs/preload/post-editor.spec.js
@@ -83,7 +83,6 @@ test.describe( 'Preload', () => {
 		expect( Array.from( new Set( requests ) ).sort() ).toEqual(
 			[
 				`GET /wp/v2/comments?context=edit&post=${ postId }&type=note&status=all&per_page=100`,
-				'GET /wp/v2/wp_pattern_category?context=view&per_page=100&_fields=id%2Cname%2Cdescription%2Cslug',
 				`POST /wp/v2/posts/${ postId }`,
 				'POST /wp-sync/v1/updates',
 				'POST /wp/v2/users/me',

--- a/test/e2e/specs/preload/site-editor.spec.js
+++ b/test/e2e/specs/preload/site-editor.spec.js
@@ -52,7 +52,6 @@ test.describe( 'Preload', () => {
 				'GET /wp/v2/posts?context=edit&offset=0&order=desc&orderby=date&per_page=10&ignore_sticky=false',
 				'GET /wp/v2/taxonomies?context=view',
 				'GET /wp/v2/template-parts/emptytheme//header?context=edit',
-				'GET /wp/v2/wp_pattern_category?context=view&per_page=100&_fields=id%2Cname%2Cdescription%2Cslug',
 				'OPTIONS /wp/v2/settings',
 				'POST /wp/v2/users/me',
 			].sort()
@@ -93,7 +92,6 @@ test.describe( 'Preload', () => {
 				'GET /wp/v2/users/1?context=view&_fields=id%2Cname',
 				'GET /wp/v2/users/me',
 				'GET /wp/v2/view-config?kind=postType&name=page',
-				'GET /wp/v2/wp_pattern_category?context=view&per_page=100&_fields=id%2Cname%2Cdescription%2Cslug',
 				'OPTIONS /wp/v2/settings',
 				'OPTIONS /wp/v2/templates',
 				'POST /wp/v2/users/me',

--- a/test/e2e/specs/preload/site-editor.spec.js
+++ b/test/e2e/specs/preload/site-editor.spec.js
@@ -50,7 +50,6 @@ test.describe( 'Preload', () => {
 		expect( Array.from( new Set( requests ) ).sort() ).toEqual(
 			[
 				'GET /wp/v2/posts?context=edit&offset=0&order=desc&orderby=date&per_page=10&ignore_sticky=false',
-				'GET /wp/v2/taxonomies?context=view',
 				'GET /wp/v2/template-parts/emptytheme//header?context=edit',
 				'OPTIONS /wp/v2/settings',
 				'POST /wp/v2/users/me',
@@ -86,7 +85,6 @@ test.describe( 'Preload', () => {
 				`GET /wp/v2/comments?context=edit&post=${ pageId }&type=note&status=all&per_page=100`,
 				`GET /wp/v2/pages/${ pageId }/autosaves?context=edit`,
 				'GET /wp/v2/taxonomies?context=edit',
-				'GET /wp/v2/taxonomies?context=view',
 				'GET /wp/v2/templates/lookup?slug=front-page',
 				'GET /wp/v2/types/page?context=edit',
 				'GET /wp/v2/users/1?context=view&_fields=id%2Cname',


### PR DESCRIPTION
## What?

`useBlockEditorSettings` was calling `getUserPatternCategories()` eagerly in its `useSelect`, firing `GET /wp/v2/wp_pattern_category?per_page=100&_fields=…` on every editor mount. The data is only consumed by the inserter's **Patterns** tab — which is closed by default and frequently never opened — so the fetch is wasted boot work for most sessions.

## Why?

The pattern was already in use for reusable blocks (`reusableBlocksSelectKey`): expose a *function* through the block-editor settings object under a `Symbol` key, and let the consumer call it via `select` inside its own `useSelect`. The resolver only fires when something reads the data.

This PR applies the same shape to user pattern categories.

## How?

1. **New `Symbol` key** in `packages/block-editor/src/store/private-keys.js`:
   ```js
   export const userPatternCategoriesSelectKey = Symbol( 'userPatternCategoriesSelect' );
   ```
   Exported via the block-editor private API.
2. **`useBlockEditorSettings`** exposes a function under that key instead of eagerly evaluating the data:
   ```js
   function __experimentalUserPatternCategoriesSelect( select ) {
       return select( coreStore ).getUserPatternCategories();
   }
   // …
   [ userPatternCategoriesSelectKey ]: __experimentalUserPatternCategoriesSelect,
   ```
   The data setting `__experimentalUserPatternCategories` (and the local destructuring of `getUserPatternCategories` / `userPatternCategories`) is dropped.
3. **`use-patterns-state.js`** (inserter Patterns tab) reads the function from settings inside its own `useSelect` and calls it via the passed-in `select`:
   ```js
   const userPatternCategoriesSelect = settings[ userPatternCategoriesSelectKey ];
   return {
       …,
       userPatternCategories: userPatternCategoriesSelect
           ? userPatternCategoriesSelect( select )
           : settings.__experimentalUserPatternCategories,
   };
   ```

The resolver therefore fires when the Patterns tab is mounted, not when the editor boots.

## Test results

Probed on a fresh draft post.

**Before** — `GET /wp/v2/wp_pattern_category?…` fires during boot:
```
REQ: GET /wp-json/wp/v2/wp_pattern_category?context=view&per_page=100&_fields=id%2Cname%2Cdescription%2Cslug
```

**After** — no `/wp_pattern_category` request during boot. Opening the inserter's Patterns tab triggers the fetch on demand:
```
--- opening inserter ---
--- clicking patterns ---
REQ: GET /wp-json/wp/v2/wp_pattern_category?context=view&per_page=100&_fields=id%2Cname%2Cdescription%2Cslug
```

## Testing Instructions

1. Open the post editor on any draft. In DevTools Network panel, filter for `wp_pattern_category` — should see no request during boot.
2. Open the block inserter and click the Patterns tab. The request should fire on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)