### PR TITLE
Post Taxonomies: Drop redundant `per_page: -1` from taxonomy queries

### DIFF
--- a/packages/editor/src/components/post-taxonomies/check.js
+++ b/packages/editor/src/components/post-taxonomies/check.js
@@ -22,8 +22,7 @@ export default function PostTaxonomiesCheck( { children } ) {
 		const postType = select( editorStore ).getCurrentPostType();
 		const taxonomies = select( coreStore ).getEntityRecords(
 			'root',
-			'taxonomy',
-			{ per_page: -1 }
+			'taxonomy'
 		);
 		return taxonomies?.some( ( taxonomy ) =>
 			taxonomy.types.includes( postType )

--- a/packages/editor/src/components/post-taxonomies/index.js
+++ b/packages/editor/src/components/post-taxonomies/index.js
@@ -20,8 +20,7 @@ export function PostTaxonomies( { taxonomyWrapper = identity } ) {
 			postType: select( editorStore ).getCurrentPostType(),
 			taxonomies: select( coreStore ).getEntityRecords(
 				'root',
-				'taxonomy',
-				{ per_page: -1 }
+				'taxonomy'
 			),
 		};
 	}, [] );

--- a/test/e2e/specs/preload/post-editor.spec.js
+++ b/test/e2e/specs/preload/post-editor.spec.js
@@ -83,7 +83,7 @@ test.describe( 'Preload', () => {
 		expect( Array.from( new Set( requests ) ).sort() ).toEqual(
 			[
 				`GET /wp/v2/comments?context=edit&post=${ postId }&type=note&status=all&per_page=100`,
-				'GET /wp/v2/taxonomies?context=edit&per_page=100',
+				'GET /wp/v2/taxonomies?context=edit',
 				'GET /wp/v2/templates/lookup?slug=front-page',
 				'GET /wp/v2/users/1?context=view&_fields=id%2Cname',
 				'GET /wp/v2/wp_pattern_category?context=view&per_page=100&_fields=id%2Cname%2Cdescription%2Cslug',

--- a/test/e2e/specs/preload/site-editor.spec.js
+++ b/test/e2e/specs/preload/site-editor.spec.js
@@ -86,7 +86,7 @@ test.describe( 'Preload', () => {
 			[
 				`GET /wp/v2/comments?context=edit&post=${ pageId }&type=note&status=all&per_page=100`,
 				`GET /wp/v2/pages/${ pageId }/autosaves?context=edit`,
-				'GET /wp/v2/taxonomies?context=edit&per_page=100',
+				'GET /wp/v2/taxonomies?context=edit',
 				'GET /wp/v2/taxonomies?context=view',
 				'GET /wp/v2/templates/lookup?slug=front-page',
 				'GET /wp/v2/types/page?context=edit',


### PR DESCRIPTION
## What?

`PostTaxonomiesCheck` and `PostTaxonomies` both pass `{ per_page: -1 }` to `getEntityRecords( 'root', 'taxonomy', … )`. The arg has no effect — `per_page` was vestigial from the generic "give me all" idiom, but the taxonomy endpoint isn't paginated and the entity is already marked `supportsPagination: false`.

Drop the arg. The wire URL becomes `/wp/v2/taxonomies?context=edit` instead of `/wp/v2/taxonomies?context=edit&per_page=100`.

## Why?

The `taxonomy` entity has `supportsPagination: false` (added in [#76406](https://github.com/WordPress/gutenberg/pull/76406)) and the REST `/wp/v2/taxonomies` endpoint returns an object keyed by slug, not an array — so:

- The `getEntityRecords` resolver's paginated branch is skipped; it falls through to a single `apiFetch`.
- `fetchAllMiddleware` sees `per_page=-1`, rewrites to `per_page=100`, fetches, then short-circuits because the response isn't an array.
- The endpoint ignores `per_page` entirely.

So `{ per_page: -1 }` is purely cosmetic noise that bloats the wire URL without changing behavior. The post-#76406 `supportsPagination: false` plumbing handles "give me everything" correctly when no `per_page` is passed.

## How?

Drop the third argument from both call sites; update the preload spec's expected URL accordingly.

## Test results

Verified locally — the request fires once on document-sidebar open, now with the clean URL:

```
REQ: GET /wp-json/wp/v2/taxonomies?context=edit
```

(Before: `GET /wp-json/wp/v2/taxonomies?context=edit&per_page=100`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)