### PR TITLE
Theme: Remove and prevent dependency grouping comments

### DIFF
--- a/packages/theme/bin/generate-default-ramps/index.ts
+++ b/packages/theme/bin/generate-default-ramps/index.ts
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-/**
- * Internal dependencies
- */
 import {
 	DEFAULT_SEED_COLORS,
 	buildBgRamp,

--- a/packages/theme/bin/generate-default-ramps/index.ts
+++ b/packages/theme/bin/generate-default-ramps/index.ts
@@ -27,9 +27,6 @@ const outputPath = join(
 );
 
 const content = `
-/**
- * Internal dependencies
- */
 import type { RampResult } from './types';
 import type { DEFAULT_SEED_COLORS } from './constants';
 

--- a/packages/theme/bin/generate-primitive-tokens/index.ts
+++ b/packages/theme/bin/generate-primitive-tokens/index.ts
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { ColorSpace, to, sRGB, getAll } from 'colorjs.io/fn';
-
-/**
- * Internal dependencies
- */
 import {
 	DEFAULT_SEED_COLORS,
 	buildBgRamp,

--- a/packages/theme/bin/terrazzo-plugin-ds-tokens-docs/index.ts
+++ b/packages/theme/bin/terrazzo-plugin-ds-tokens-docs/index.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { FORMAT_ID } from '@terrazzo/plugin-css';
 import type { Plugin } from '@terrazzo/parser';
 

--- a/packages/theme/bin/terrazzo-plugin-inline-alias-values/index.ts
+++ b/packages/theme/bin/terrazzo-plugin-inline-alias-values/index.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { type Plugin, type TokenNormalized } from '@terrazzo/parser';
 
 interface InlineAliasValuesOptions {

--- a/packages/theme/bin/terrazzo-plugin-known-wpds-css-variables/index.ts
+++ b/packages/theme/bin/terrazzo-plugin-known-wpds-css-variables/index.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { FORMAT_ID } from '@terrazzo/plugin-css';
 import type { Plugin } from '@terrazzo/parser';
 

--- a/packages/theme/bin/terrazzo-plugin-mode-overrides/index.ts
+++ b/packages/theme/bin/terrazzo-plugin-mode-overrides/index.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Plugin } from '@terrazzo/parser';

--- a/packages/theme/src/color-ramps/index.ts
+++ b/packages/theme/src/color-ramps/index.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { get, OKLCH } from 'colorjs.io/fn';
-
-/**
- * Internal dependencies
- */
 import { buildRamp } from './lib/index';
 import { clampAccentScaleReferenceLightness } from './lib/utils';
 import { BG_RAMP_CONFIG, ACCENT_RAMP_CONFIG } from './lib/ramp-configs';

--- a/packages/theme/src/color-ramps/lib/default-ramps.ts
+++ b/packages/theme/src/color-ramps/lib/default-ramps.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { RampResult } from './types';
 import type { DEFAULT_SEED_COLORS } from './constants';
 

--- a/packages/theme/src/color-ramps/lib/index.ts
+++ b/packages/theme/src/color-ramps/lib/index.ts
@@ -1,8 +1,4 @@
 import { clone, get, OKLCH, set, type PlainColorObject } from 'colorjs.io/fn';
-
-/**
- * Internal dependencies
- */
 import { clampToGamut, getContrast, getColorString } from './color-utils';
 import { findColorMeetingRequirements } from './find-color-with-constraints';
 import {

--- a/packages/theme/src/color-ramps/lib/ramp-configs.ts
+++ b/packages/theme/src/color-ramps/lib/ramp-configs.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { RampStepConfig, RampConfig, RampDirection } from './types';
 import type { TaperChromaOptions } from './taper-chroma';
 

--- a/packages/theme/src/color-ramps/lib/types.ts
+++ b/packages/theme/src/color-ramps/lib/types.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { TaperChromaOptions } from './taper-chroma';
 
 export type Ramp = {

--- a/packages/theme/src/color-ramps/stories/index.story.tsx
+++ b/packages/theme/src/color-ramps/stories/index.story.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import type { Meta, StoryObj } from '@storybook/react-vite';
-
-/**
- * Internal dependencies
- */
 import { RampTable } from './ramp-table';
 import { buildBgRamp, buildAccentRamp, checkAccessibleCombinations } from '..';
 import { DEFAULT_SEED_COLORS } from '../lib/constants';

--- a/packages/theme/src/color-ramps/stories/ramp-table.tsx
+++ b/packages/theme/src/color-ramps/stories/ramp-table.tsx
@@ -1,11 +1,4 @@
-/**
- * WordPress dependencies
- */
 import { forwardRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import type { Ramp } from '../lib/types';
 
 // TODO: show token groups better

--- a/packages/theme/src/context.ts
+++ b/packages/theme/src/context.ts
@@ -1,11 +1,4 @@
-/**
- * WordPress dependencies
- */
 import { createContext } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import type { ThemeProviderSettings } from './types';
 
 interface ThemeContextType {

--- a/packages/theme/src/lock-unlock.ts
+++ b/packages/theme/src/lock-unlock.ts
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 
 export const { lock, unlock } =

--- a/packages/theme/src/private-apis.ts
+++ b/packages/theme/src/private-apis.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { lock } from './lock-unlock';
 import { ThemeProvider } from './theme-provider';
 import { useThemeProviderStyles } from './use-theme-provider-styles';

--- a/packages/theme/src/stories/index.story.tsx
+++ b/packages/theme/src/stories/index.story.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import type { Meta, StoryObj } from '@storybook/react-vite';
-
-/**
- * WordPress dependencies
- */
 import {
 	useEffect,
 	useState,
@@ -13,10 +6,6 @@ import {
 	useId,
 	createPortal,
 } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import { ThemeProvider } from '../theme-provider';
 
 const meta: Meta< typeof ThemeProvider > = {

--- a/packages/theme/src/theme-provider.tsx
+++ b/packages/theme/src/theme-provider.tsx
@@ -1,16 +1,5 @@
-/**
- * External dependencies
- */
 import type { CSSProperties } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { useMemo, useId } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import { ThemeContext } from './context';
 import { useThemeProviderStyles } from './use-theme-provider-styles';
 import { type ThemeProviderProps } from './types';

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { type ReactNode } from 'react';
 
 export interface ThemeProviderSettings {

--- a/packages/theme/src/use-theme-provider-styles.ts
+++ b/packages/theme/src/use-theme-provider-styles.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import type { CSSProperties } from 'react';
 import {
 	ColorSpace,
@@ -12,15 +9,7 @@ import {
 	type PlainColorObject,
 } from 'colorjs.io/fn';
 import memoize from 'memize';
-
-/**
- * WordPress dependencies
- */
 import { useMemo, useContext } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import { ThemeContext } from './context';
 import colorTokens from './prebuilt/ts/color-tokens';
 import {

--- a/packages/theme/terrazzo.config.ts
+++ b/packages/theme/terrazzo.config.ts
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { defineConfig, type Config } from '@terrazzo/parser';
 import pluginCSS from '@terrazzo/plugin-css';
 import { makeCSSVar } from '@terrazzo/token-tools/css';
-
-/**
- * Internal dependencies
- */
 import pluginModeOverrides from './bin/terrazzo-plugin-mode-overrides/index';
 import pluginKnownWpdsCssVariables from './bin/terrazzo-plugin-known-wpds-css-variables/index';
 import pluginDsTokenDocs from './bin/terrazzo-plugin-ds-tokens-docs/index';

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -799,7 +799,11 @@ export default dedupePlugins( [
 	// Override: Packages which have eliminated dependency grouping comments
 	// and explicitly prevent new additions.
 	{
-		files: [ 'packages/ui/**', 'packages/design-system-mcp/**' ],
+		files: [
+			'packages/design-system-mcp/**',
+			'packages/ui/**',
+			'packages/theme/**',
+		],
 		rules: {
 			'@wordpress/dependency-group': [ 'error', 'never' ],
 		},


### PR DESCRIPTION
## What?

Updates ESLint configuration to include `@wordpress/theme` in the set of packages which explicitly do not use dependency grouping comments, and fixes existing issues.

## Why?

Code quality: Since #73616 the project no longer requires these comments, and we've been slowly chipping away at them, but have no enforcement to actually prevent any new additions in the package. Without tooling feedback, AI agents are likely to adopt the convention seen through the codebase (i.e. add new docblocks). #74990 added an option to the dependency comments rule to forbid their usage and fix issues with an auto-fixer, but it is currently only applied to a couple packages.

## How?

1. Add the package path pattern to ESLint config entries in `tools/eslint/config.mjs`, where existing packages already enforce this rule
2. Fix existing issues with `npm run lint:js:fix` (there's an autofixer included in the rule)

## Testing Instructions

Verify no instances of dependency grouping comments in the package, and that `npm run lint:js` is clean.

## Use of AI Tools

No AI was used.