### PR TITLE
Global Styles respect color.custom and color.customGradient settings in palette editor

### DIFF
--- a/packages/global-styles-ui/src/color-palette-panel.tsx
+++ b/packages/global-styles-ui/src/color-palette-panel.tsx
@@ -51,6 +51,10 @@ export default function ColorPalettePanel( { name }: ColorPalettePanelProps ) {
 		'color.defaultPalette',
 		name
 	);
+	const [ customColorEnabled ] = useSetting< boolean >(
+		'color.custom',
+		name
+	);
 
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const popoverProps = isMobileViewport ? mobilePopoverProps : undefined;
@@ -97,14 +101,16 @@ export default function ColorPalettePanel( { name }: ColorPalettePanelProps ) {
 						popoverProps={ popoverProps }
 					/>
 				) }
-			<PaletteEdit
-				colors={ customColors }
-				onChange={ setCustomColors }
-				paletteLabel={ __( 'Custom' ) }
-				paletteLabelHeadingLevel={ 3 }
-				slugPrefix="custom-"
-				popoverProps={ popoverProps }
-			/>
+			{ customColorEnabled !== false && (
+				<PaletteEdit
+					colors={ customColors }
+					onChange={ setCustomColors }
+					paletteLabel={ __( 'Custom' ) }
+					paletteLabelHeadingLevel={ 3 }
+					slugPrefix="custom-"
+					popoverProps={ popoverProps }
+				/>
+			) }
 			<ColorVariations title={ __( 'Palettes' ) } />
 		</VStack>
 	);

--- a/packages/global-styles-ui/src/gradients-palette-panel.tsx
+++ b/packages/global-styles-ui/src/gradients-palette-panel.tsx
@@ -55,6 +55,10 @@ export default function GradientPalettePanel( {
 		'color.defaultGradients',
 		name
 	);
+	const [ customGradientEnabled ] = useSetting< boolean >(
+		'color.customGradient',
+		name
+	);
 
 	const [ customDuotone ] = useSetting( 'color.duotone.custom' ) || [];
 	const [ defaultDuotone ] = useSetting( 'color.duotone.default' ) || [];
@@ -99,14 +103,16 @@ export default function GradientPalettePanel( {
 						popoverProps={ popoverProps }
 					/>
 				) }
-			<PaletteEdit
-				gradients={ customGradients }
-				onChange={ setCustomGradients }
-				paletteLabel={ __( 'Custom' ) }
-				paletteLabelHeadingLevel={ 3 }
-				slugPrefix="custom-"
-				popoverProps={ popoverProps }
-			/>
+			{ customGradientEnabled !== false && (
+				<PaletteEdit
+					gradients={ customGradients }
+					onChange={ setCustomGradients }
+					paletteLabel={ __( 'Custom' ) }
+					paletteLabelHeadingLevel={ 3 }
+					slugPrefix="custom-"
+					popoverProps={ popoverProps }
+				/>
+			) }
 			{ !! duotonePalette && !! duotonePalette.length && (
 				<div>
 					<Subtitle level={ 3 }>{ __( 'Duotone' ) }</Subtitle>


### PR DESCRIPTION
## What?

Closes [#47928](https://github.com/WordPress/gutenberg/issues/47928)

Hides the "Custom" palette section in the Global Styles color and gradient palette panels when `settings.color.custom` or `settings.color.customGradient` is set to `false` in `theme.json`.

## Why?

When a theme sets `settings.color.custom: false` in `theme.json`, the intention is to prevent users from creating and using custom colors. This worked correctly in the block inspector (post/page editor), but the Global Styles palette editor in the Site Editor still showed the "Custom" section allowing users to add custom colors and make them available everywhere.

This inconsistency meant the setting could be bypassed entirely via the Site Editor.

## How?

In `color-palette-panel.tsx` and `gradients-palette-panel.tsx`, the `color.custom` and `color.customGradient` settings are now read via `useSetting`. The "Custom" `PaletteEdit` section is only rendered when the respective setting is not explicitly disabled (`!== false`).

## Testing Instructions

1. Open your active theme's `theme.json` and add:
   ```json
   {
     "version": 3,
     "settings": {
       "color": {
         "custom": false,
         "customGradient": false
       }
     }
   }
   ```
2. Go to Appearance → Editor → Styles → Colors → Edit palette.
3. On the Color tab: verify the "Custom" section is no longer visible.
4. On the Gradient tab: verify the "Custom" section is no longer visible.
5. Remove the settings (or set to true) and confirm the "Custom" sections return.

## Testing Instructions for Keyboard
1. Navigate to the palette editor using Tab and arrow keys.
2. Confirm that with custom: false, there is no "Custom" section to tab into on either the Color or Gradient tabs.

