### PR TITLE
ESLint: Restrict deprecated `__nextHasNoMarginBottom` prop

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -993,7 +993,6 @@ export default function Image( {
 								}
 							>
 								<CheckboxControl
-									__nextHasNoMarginBottom
 									label={ __( 'Mark as decorative' ) }
 									checked={ !! isDecorative }
 									onChange={ updateIsDecorative }

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -278,7 +278,6 @@ export default function PostFeaturedImageEdit( {
 							}
 						>
 							<ToggleControl
-								__nextHasNoMarginBottom
 								label={ __( 'Make image a link' ) }
 								onChange={ () =>
 									setAttributes( { isLink: ! isLink } )

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -158,6 +158,10 @@ const restrictedSyntax = [
 		message: 'Do not use string literals for IDs; use useId hook instead.',
 	},
 	{
+		selector: 'JSXAttribute[name.name="__nextHasNoMarginBottom"]',
+		message: 'The `__nextHasNoMarginBottom` prop is no longer needed.',
+	},
+	{
 		selector:
 			'CallExpression[callee.name="withDispatch"] > :function > BlockStatement > :not(VariableDeclaration,ReturnStatement)',
 		message:

--- a/widgets/quick-draft/fields/quick-draft-content-field/quick-draft-content-field.tsx
+++ b/widgets/quick-draft/fields/quick-draft-content-field/quick-draft-content-field.tsx
@@ -57,7 +57,6 @@ export default function QuickDraftContentField< Item >( {
 	return (
 		<Stack direction="column" className={ styles.root }>
 			<TextareaControl
-				__nextHasNoMarginBottom
 				label={ field.label }
 				hideLabelFromVision={ hideLabelFromVision }
 				value={ value ?? '' }


### PR DESCRIPTION
## What?

Adds an ESLint `no-restricted-syntax` rule to disallow the `__nextHasNoMarginBottom` JSX prop, and removes existing usages.

## Why?

Margin-free styles are now the default for the affected `@wordpress/components` controls, so the opt-in prop is redundant. However, I've noticed a recent uptick (for example [here](https://github.com/WordPress/gutenberg/pull/78046#discussion_r3284774056)) in new code including this prop — apparently agents are doing this even without any code snippets or guidance in the codebase to do so.

Let's restrict this with a lint to keep the codebase clean. We should also do this for the `__next40pxDefaultSize` prop that we will be removing soon for WP 7.1.

## How?

- Add a `JSXAttribute` selector to the shared `restrictedSyntax` list in `tools/eslint/config.mjs`.
- Remove the prop from the three remaining call sites (Quick Draft widget, Image block, Post Featured Image block).

## Testing Instructions

1. Run `npm run lint:js` (or lint one of the touched files) and confirm no `__nextHasNoMarginBottom` violations.
2. Optionally add the prop to a JSX element locally and confirm ESLint reports: "The `__nextHasNoMarginBottom` prop is no longer needed."
