### PR TITLE
fix: discard unsaved HTML block changes on cancel

### DIFF
--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -49,12 +49,14 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 						{ __( 'Edit HTML' ) }
 					</Button>
 				</Placeholder>
-				<HTMLEditModal
-					isOpen={ isModalOpen }
-					onRequestClose={ () => setIsModalOpen( false ) }
-					content={ attributes.content }
-					setAttributes={ setAttributes }
-				/>
+				{ isModalOpen && (
+					<HTMLEditModal
+						isOpen={ isModalOpen }
+						onRequestClose={ () => setIsModalOpen( false ) }
+						content={ attributes.content }
+						setAttributes={ setAttributes }
+					/>
+				) }
 			</div>
 		);
 	}
@@ -84,12 +86,14 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 				</VStack>
 			</InspectorControls>
 			<Preview content={ attributes.content } isSelected={ isSelected } />
-			<HTMLEditModal
-				isOpen={ isModalOpen }
-				onRequestClose={ () => setIsModalOpen( false ) }
-				content={ attributes.content }
-				setAttributes={ setAttributes }
-			/>
+			{ isModalOpen && (
+				<HTMLEditModal
+					isOpen={ isModalOpen }
+					onRequestClose={ () => setIsModalOpen( false ) }
+					content={ attributes.content }
+					setAttributes={ setAttributes }
+				/>
+			) }
 		</div>
 	);
 }

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -51,7 +51,6 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 				</Placeholder>
 				{ isModalOpen && (
 					<HTMLEditModal
-						isOpen={ isModalOpen }
 						onRequestClose={ () => setIsModalOpen( false ) }
 						content={ attributes.content }
 						setAttributes={ setAttributes }
@@ -88,7 +87,6 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 			<Preview content={ attributes.content } isSelected={ isSelected } />
 			{ isModalOpen && (
 				<HTMLEditModal
-					isOpen={ isModalOpen }
 					onRequestClose={ () => setIsModalOpen( false ) }
 					content={ attributes.content }
 					setAttributes={ setAttributes }

--- a/packages/block-library/src/html/modal.js
+++ b/packages/block-library/src/html/modal.js
@@ -27,7 +27,6 @@ import { parseContent, serializeContent } from './utils';
 const { Tabs } = unlock( componentsPrivateApis );
 
 export default function HTMLEditModal( {
-	isOpen,
 	onRequestClose,
 	content,
 	setAttributes,
@@ -53,10 +52,6 @@ export default function HTMLEditModal( {
 	// Determine if we should show a warning about CSS/JS content being stripped
 	const hasRestrictedContent =
 		! canUserUseUnfilteredHTML && ( css.trim() || js.trim() );
-
-	if ( ! isOpen ) {
-		return null;
-	}
 
 	const handleUpdate = () => {
 		// For users without unfiltered_html capability, strip CSS and JS content


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/78548

<!-- In a few words, what is the PR actually doing? -->
This PR conditionally renders the Custom HTML block's edit modal (`HTMLEditModal`) so that it is unmounted when closed. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Previously, the modal component remained mounted in the React tree even when closed, simply returning `null` internally. This caused React to retain the local state variables (`editedHtml`, `editedCss`, `editedJs`) representing the user's edits. 

As a result, if a user modified the code in the modal, clicked "Cancel" to discard their changes, and reopened the modal, the modal still displayed their discarded changes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updated `packages/block-library/src/html/edit.js` to conditionally render `<HTMLEditModal>` using the state flag `isModalOpen`: `{ isModalOpen && <HTMLEditModal ... /> }`
This is done for both occurrences (the placeholder block view and the main edit block view).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. In the Gutenberg editor, insert a **Custom HTML** block.
2. Click **Edit code** to open the code editing modal.
3. Type some HTML code
4. Click **Cancel** in the bottom-right corner of the modal.
5. Click **Edit code** again to reopen the modal.
6. Verify that the changes you typed in step 3 are discarded, and the modal shows the original unedited block content.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before

https://github.com/user-attachments/assets/d2c23613-e38d-4acd-bb27-d66294125271

After 

https://github.com/user-attachments/assets/122298d8-9a15-4597-a6f4-e3e39df388ee

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini 3.5 Flash
Used for: Suggesting and implementing the fix. Final implementation was reviewed and edited by me.