### PR TITLE
Edit Post: Hoist setupEditor to run before root.render

### DIFF
--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -166,10 +166,21 @@ export function initializeEditor(
 	const preloadedResolutions = preloadResolutions( postType, postId );
 
 	preloadedResolutions.finally( () => {
-		// Anything not consumed by the kickoff falls through to a real
-		// network request from here on. `clearPreloadedData` logs which
-		// preload entries (if any) were never served.
 		clearPreloadedData();
+		if ( postType && postId ) {
+			const post = select( coreDataStore ).getEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+			if ( post ) {
+				dispatch( editorStore ).setupEditor(
+					post,
+					initialEdits,
+					settings.template
+				);
+			}
+		}
 		root.render(
 			<StrictMode>
 				<Layout

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -166,6 +166,9 @@ export function initializeEditor(
 	const preloadedResolutions = preloadResolutions( postType, postId );
 
 	preloadedResolutions.finally( () => {
+		// Anything not consumed by the kickoff falls through to a real
+		// network request from here on. `clearPreloadedData` logs which
+		// preload entries (if any) were never served.
 		clearPreloadedData();
 		if ( postType && postId ) {
 			const post = select( coreDataStore ).getEntityRecord(

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -7,7 +7,7 @@ import {
 	useLayoutEffect,
 	useMemo,
 } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
 	EntityProvider,
@@ -310,6 +310,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			setRenderingMode,
 		} = unlock( useDispatch( editorStore ) );
 		const { editEntityRecord } = useDispatch( coreStore );
+		const registry = useRegistry();
 
 		const onChangeSelection = useCallback(
 			( newSelection ) => {
@@ -334,7 +335,13 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			}
 
 			updatePostLock( settings.postLock );
-			setupEditor( post, initialEdits, settings.template );
+			// `setupEditor` may already have been dispatched by the
+			// editor's pre-mount kickoff (see edit-post's
+			// `initializeEditor`). Skip the redundant dispatch — it
+			// would otherwise re-parse + reset blocks for new posts.
+			if ( ! registry.select( editorStore ).__unstableIsEditorReady() ) {
+				setupEditor( post, initialEdits, settings.template );
+			}
 			if ( settings.autosave ) {
 				createWarningNotice(
 					__(


### PR DESCRIPTION
Calls setupEditor() before mounting the editor in React, reducing the re-renders from 3 to 1 on mount.