### PR TITLE
Add missing package file to the site preview widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21180,6 +21180,10 @@
 			"resolved": "packages/shortcode",
 			"link": true
 		},
+		"node_modules/@wordpress/site-preview-widget": {
+			"resolved": "widgets/site-preview",
+			"link": true
+		},
 		"node_modules/@wordpress/storybook": {
 			"resolved": "storybook",
 			"link": true
@@ -67100,6 +67104,19 @@
 				"@wordpress/ui": "file:../../packages/ui",
 				"@wordpress/url": "file:../../packages/url",
 				"clsx": "^2.1.1"
+			}
+		},
+		"widgets/site-preview": {
+			"name": "@wordpress/site-preview-widget",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/components": "file:../../packages/components",
+				"@wordpress/core-data": "file:../../packages/core-data",
+				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/element": "file:../../packages/element",
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/icons": "file:../../packages/icons",
+				"@wordpress/ui": "file:../../packages/ui"
 			}
 		},
 		"widgets/welcome": {

--- a/widgets/site-preview/package.json
+++ b/widgets/site-preview/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "@wordpress/site-preview-widget",
+	"version": "1.0.0",
+	"private": true,
+	"dependencies": {
+		"@wordpress/components": "file:../../packages/components",
+		"@wordpress/core-data": "file:../../packages/core-data",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/icons": "file:../../packages/icons",
+		"@wordpress/ui": "file:../../packages/ui"
+	}
+}


### PR DESCRIPTION
## What?

Adds the missing workspace `package.json` to the Site Preview dashboard widget (`widgets/site-preview/`) and declares the dependencies it imports.

Follow-up to #78556, which added the widget without a workspace `package.json`. It applies the convention raised in the review of #78408 (https://github.com/WordPress/gutenberg/pull/78408#pullrequestreview-4346684631): each widget workspace should declare all the dependencies it uses.

## Why?

Every other dashboard widget (`activity`, `hello-world`, `quick-draft`, `welcome`) is a workspace with its own `package.json` declaring its dependencies. Site Preview was merged without one, so it neither declares the packages it imports nor registers as a workspace member.

## How?

- Add `widgets/site-preview/package.json` (`@wordpress/site-preview-widget`), matching the format of the sibling widgets.
- Declare exactly what the widget imports:
  - `render.tsx`: `@wordpress/components`, `@wordpress/core-data`, `@wordpress/data`, `@wordpress/element`, `@wordpress/i18n`, `@wordpress/ui`.
  - `widget.ts`: `@wordpress/icons`, `@wordpress/i18n`.
- `npm install` registers the workspace (symlink under `node_modules/@wordpress/site-preview-widget` + lockfile entry), consistent with the other widgets.

## Testing Instructions

1. Run `npm install`.
2. Confirm `node_modules/@wordpress/site-preview-widget` is a symlink to `widgets/site-preview`.
3. Build and open the experimental dashboard; confirm the Site Preview widget still renders (site preview iframe plus the Visit / Edit site actions).
