### PR TITLE
Add copilot-instructions.md file

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,9 +12,7 @@ When reviewing pull requests:
 ## What not to flag
 
 - **Do not speculate about external code.** Verify WordPress, PHP, and Node APIs, function signatures, and version constraints against the diff or repo files (`composer.json`, `package.json`, etc.) before flagging compatibility or contract issues. Do not invent strings, error messages, or behaviour in linked codebases such as WordPress core. If a claim cannot be verified from the diff or repository, do not include it.
-- **Do not request refactor of inherited duplication.** If a pattern already exists in the codebase before this PR, do not ask the author to extract a helper or deduplicate. Flag it at most once for awareness.
 - **Calibrate edge-case warnings.** Do not flag theoretical edge cases (`Number.MAX_VALUE`, subnormals, inputs that cannot occur given current callers). Flag edge cases only when they correspond to inputs that can plausibly reach the code.
-- **Do not request tests** when the surrounding test files are out of scope for the PR. Flag missing tests only when the new behaviour is risky and adding a test fits the diff naturally.
 
 ## Gutenberg-specific context
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@ When reviewing pull requests:
 - Keep each comment short — one or two sentences maximum.
 - Do not write long descriptions or summaries of what the code does.
 - Do not suggest refactors or improvements unrelated to the PR's stated goal.
-- NEVER produce a review body or top-level PR overview comment. The review body MUST be empty. Put findings only in inline comments on specific lines.
+- Keep the top-level review body empty unless a finding genuinely spans multiple files and can't be attached to a specific line. Put findings in inline comments wherever possible, and never use the review body to restate what the PR is doing.
 
 ## What not to flag
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,23 @@
+## PR review guidelines
+
+When reviewing pull requests:
+
+- Only comment on semantically meaningful issues: bugs, incorrect logic, security problems, accessibility regressions, or API contract violations.
+- Skip style, formatting, naming, and whitespace observations — these are enforced by lint and PHPCS.
+- Keep each comment short — one or two sentences maximum.
+- Do not write long descriptions or summaries of what the code does.
+- Do not suggest refactors or improvements unrelated to the PR's stated goal.
+- NEVER produce a review body or top-level PR overview comment. The review body MUST be empty. Put findings only in inline comments on specific lines.
+
+## What not to flag
+
+- **Do not speculate about external code.** Verify WordPress, PHP, and Node APIs, function signatures, and version constraints against the diff or repo files (`composer.json`, `package.json`, etc.) before flagging compatibility or contract issues. Do not invent strings, error messages, or behaviour in linked codebases such as WordPress core. If a claim cannot be verified from the diff or repository, do not include it.
+- **Do not request refactor of inherited duplication.** If a pattern already exists in the codebase before this PR, do not ask the author to extract a helper or deduplicate. Flag it at most once for awareness.
+- **Calibrate edge-case warnings.** Do not flag theoretical edge cases (`Number.MAX_VALUE`, subnormals, inputs that cannot occur given current callers). Flag edge cases only when they correspond to inputs that can plausibly reach the code.
+- **Do not request tests** when the surrounding test files are out of scope for the PR. Flag missing tests only when the new behaviour is risky and adding a test fits the diff naturally.
+
+## Gutenberg-specific context
+
+- Do not suggest replacing `@wordpress/data` selectors / actions with local React state — this is the project's intentional state pattern.
+- Do not suggest replacing `__()` / `_x()` / `_n()` calls with template literals — these are WordPress i18n functions.
+- Do not suggest moving code between `block-editor`, `editor`, and `edit-post` packages without considering the layering rule (`block-editor` is WordPress-agnostic; lower layers must not depend on higher ones).


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Adds a `.github/copilot-instructions.md` file to guide GitHub Copilot's PR review behaviour repo-wide.

The file is split into three short sections:

- PR review guidelines: how Copilot should review (short comments, no top-level summary, no style nits as these are caught by lint and PHPCS).
- What not to flag: calibration rules to suppress recurring false positives (hallucinated APIs, refactor requests for inherited duplication, theoretical edge cases).
- Gutenberg-specific context: small set of guardrails against Copilot second-guessing intentional WordPress patterns (`@wordpress/data`, `__()`/`_x()`/`_n()`, the `block-editor` → `editor` → `edit-post` package layering rule).

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Copilot's default PR review in this repo tends toward long summary restatement and style observations that lint already covers, while occasionally producing comments based on hallucinated or unverified WordPress core APIs.

I sampled 50 recent Copilot reviews in this repo to form these rules:

- Already strong (so don't duplicate): cross-file consistency, hook deps, duplication detection, doc/code drift, numeric edge cases.
- Recurring pushback themes from PR authors: hallucinated WordPress core APIs / strings, requests to refactor pre-existing inherited duplication, over-cautious "what about this edge case" comments with no real-world impact.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

GitHub Copilot reads `.github/copilot-instructions.md` and merges its contents into every PR review in the repo.

If this works well and folks agree, we could extend this to include further instruction files for more specific things, like code changes in specific packages having an additional set of guidance. I'm not sure how far we need to take this for it to be as helpful as possible.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Let's see if this improves the quality of Copilot's reviews once it's merged.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

I used Claude Code to sample the recent Copilot reviews and draft the instructions.