### PR TITLE
Editor: Restore Document Overview after closing Inserter

### DIFF
--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -9,6 +9,8 @@ import { combineReducers } from '@wordpress/data';
 import { EDITOR_SETTINGS_DEFAULTS } from './defaults';
 import dataviewsReducer from '../dataviews/store/reducer';
 
+const LIST_VIEW_PANEL_HIDDEN_BY_INSERTER = 'hidden-by-inserter';
+
 /**
  * Returns a post attribute value, flattening nested rendered content using its
  * raw value in place of its original object form.
@@ -343,7 +345,10 @@ export function blockInserterPanel( state = false, action ) {
 export function listViewPanel( state = false, action ) {
 	switch ( action.type ) {
 		case 'SET_IS_INSERTER_OPENED':
-			return action.value ? false : state;
+			if ( action.value ) {
+				return state ? LIST_VIEW_PANEL_HIDDEN_BY_INSERTER : false;
+			}
+			return state === LIST_VIEW_PANEL_HIDDEN_BY_INSERTER ? true : state;
 		case 'SET_IS_LIST_VIEW_OPENED':
 			return action.isOpen;
 	}

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1366,7 +1366,7 @@ export const getDeviceType = createRegistrySelector(
  * @return {boolean} Whether the list view is opened.
  */
 export function isListViewOpened( state ) {
-	return state.listViewPanel;
+	return state.listViewPanel === true;
 }
 
 /**


### PR DESCRIPTION
## What?

Closes #53078 

This PR restores the **Document Overview** sidebar after the **Block Inserter** is closed, when Document Overview was open before the Inserter was opened.

## Why?
Previously, opening the Inserter from an open Document Overview cleared the List View state. When the Inserter was closed, the entire left sidebar disappeared, causing layout shift and forcing users to reopen Document Overview manually.

## How?
- Added an internal hidden state for the List View panel while it is temporarily replaced by the Inserter.
- Restored the List View panel when the Inserter closes if it was open before the Inserter was opened.
- Updated `isListViewOpened()` so it only reports `true` when the List View is actually visible.

## Testing Instructions
1. Open the editor.
2. Open **Document Overview** from the top toolbar.
3. Click the top-left **Block Inserter** button.
4. Close the Inserter using the `x` button.
5. Confirm **Document Overview** is restored instead of the left sidebar closing completely.

Also verify:
1. Open the **Block Inserter** when Document Overview was not open.
2. Close the Inserter.
3. Confirm the left sidebar closes as before.

## Screenshots or Screencast

### Before Fix :

https://github.com/WordPress/gutenberg/assets/737143/765ad243-3ae4-4735-81ac-ab842754f67f

### After Fix :

https://github.com/user-attachments/assets/53e4a9bc-d30c-4536-89c4-9b4b995404f5

## Use of AI Tools
Initial technical analysis and PR documentation for this fix were drafted with the assistance of AI tools.