### PR TITLE
[Lightbox] Add theme.json support for lightbox overlay background color

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -138,6 +138,7 @@ Settings related to the lightbox.
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
 | enabled | Defines whether the lightbox is enabled or not. | `boolean` |  |
+| overlayBackgroundColor | The background color of the lightbox overlay. Accepts any valid CSS color value. | `string` |  |
 | allowEditing | Defines whether to show the Lightbox UI in the block editor. If set to `false`, the user won't be able to change the lightbox settings in the block editor. | `boolean` |  |
 
 ---

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -439,8 +439,9 @@ class WP_Theme_JSON_Gutenberg {
 			'allowCustomContentAndWideSize' => null,
 		),
 		'lightbox'                      => array(
-			'enabled'      => true,
-			'allowEditing' => true,
+			'enabled'                => true,
+			'allowEditing'           => true,
+			'overlayBackgroundColor' => null,
 		),
 		'position'                      => array(
 			'fixed'  => null,

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -344,20 +344,20 @@ function block_core_image_print_lightbox_overlay() {
 		}
 	}
 
-    // Check for a lightbox specific overlay background color.
-    // Themes can set this in theme.json under:
-    //    settings.blocks.core/image.lightbox.overlayBackgroundColor  (block-level)
-    //    settings.lightbox.overlayBackgroundColor                     (global fallback)
+	// Check for a lightbox specific overlay background color.
+	// Themes can set this in theme.json under:
+	// settings.blocks.core/image.lightbox.overlayBackgroundColor (block-level)
+	// settings.lightbox.overlayBackgroundColor (global fallback).
 	$lightbox_overlay_background_color = null;
-    $lightbox_block_settings = wp_get_global_settings( array( 'lightbox' ), array( 'block_name' => 'core/image' ) );
-    if ( isset( $lightbox_block_settings['overlayBackgroundColor'] ) ) {
-        $lightbox_overlay_background_color = esc_attr( $lightbox_block_settings['overlayBackgroundColor'] );
-    } else {
-        $lightbox_global_settings = wp_get_global_settings( array( 'lightbox' ) );
-        if ( isset( $lightbox_global_settings['overlayBackgroundColor'] ) ) {
-            $lightbox_overlay_background_color = esc_attr( $lightbox_global_settings['overlayBackgroundColor'] );
-        }
-    }
+	$lightbox_block_settings           = wp_get_global_settings( array( 'lightbox' ), array( 'block_name' => 'core/image' ) );
+	if ( isset( $lightbox_block_settings['overlayBackgroundColor'] ) ) {
+		$lightbox_overlay_background_color = esc_attr( $lightbox_block_settings['overlayBackgroundColor'] );
+	} else {
+		$lightbox_global_settings = wp_get_global_settings( array( 'lightbox' ) );
+		if ( isset( $lightbox_global_settings['overlayBackgroundColor'] ) ) {
+			$lightbox_overlay_background_color = esc_attr( $lightbox_global_settings['overlayBackgroundColor'] );
+		}
+	}
 
 	// Prefer the lightbox specific color when set, otherwise fall back to
 	// the global background color.

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -344,6 +344,25 @@ function block_core_image_print_lightbox_overlay() {
 		}
 	}
 
+    // Check for a lightbox specific overlay background color.
+    // Themes can set this in theme.json under:
+    //    settings.blocks.core/image.lightbox.overlayBackgroundColor  (block-level)
+    //    settings.lightbox.overlayBackgroundColor                     (global fallback)
+	$lightbox_overlay_background_color = null;
+    $lightbox_block_settings = wp_get_global_settings( array( 'lightbox' ), array( 'block_name' => 'core/image' ) );
+    if ( isset( $lightbox_block_settings['overlayBackgroundColor'] ) ) {
+        $lightbox_overlay_background_color = esc_attr( $lightbox_block_settings['overlayBackgroundColor'] );
+    } else {
+        $lightbox_global_settings = wp_get_global_settings( array( 'lightbox' ) );
+        if ( isset( $lightbox_global_settings['overlayBackgroundColor'] ) ) {
+            $lightbox_overlay_background_color = esc_attr( $lightbox_global_settings['overlayBackgroundColor'] );
+        }
+    }
+
+	// Prefer the lightbox specific color when set, otherwise fall back to
+	// the global background color.
+	$overlay_background_color = $lightbox_overlay_background_color ?? $background_color;
+
 	echo <<<HTML
 		<div
 			class="wp-lightbox-overlay zoom"
@@ -400,7 +419,7 @@ function block_core_image_print_lightbox_overlay() {
 					<span class="wp-lightbox-navigation-icon" data-wp-bind--hidden="!state.hasNavigationIcon">{$next_button_icon}</span>
 				</button>
 				<div data-wp-text="state.ariaLabel" aria-live="polite" aria-atomic="true" class="screen-reader-text"></div>
-				<div class="scrim" style="background-color: {$background_color}" aria-hidden="true"></div>
+				<div class="scrim" style="--wp--lightbox--overlay-background-color: {$overlay_background_color}" aria-hidden="true"></div>
 		</div>
 HTML;
 }

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -341,7 +341,7 @@
 		height: 100%;
 		position: absolute;
 		z-index: 2000000;
-		background-color: rgb(255, 255, 255);
+		background-color: var(--wp--lightbox--overlay-background-color, rgb(255, 255, 255));
 		opacity: 0.9;
 	}
 

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -369,6 +369,10 @@
 							"description": "Defines whether the lightbox is enabled or not.",
 							"type": "boolean"
 						},
+						"overlayBackgroundColor": {
+							"description": "The background color of the lightbox overlay. Accepts any valid CSS color value.",
+							"type": "string"
+						},
 						"allowEditing": {
 							"description": "Defines whether to show the Lightbox UI in the block editor. If set to `false`, the user won't be able to change the lightbox settings in the block editor.",
 							"type": "boolean"


### PR DESCRIPTION
## What?
Closes #78506

This PR adds support for a new `overlayBackgroundColor` property within the `lightbox` settings in `theme.json`. It updates the Image block's lightbox rendering to use a CSS custom property for the overlay background instead of a hardcoded inline style.

## Why?
Currently, the Image and Gallery block lightbox feature hardcodes the `scrim` background color as an inline style (`style="background-color: #fff"`). This is a major pain point for dark themes or portfolio sites, as it forces theme developers to use `!important` in their custom CSS to override the white background. By moving this to `theme.json` and utilizing CSS custom properties, we align the lightbox feature with the standard Gutenberg design tools system and make it much easier for theme authors to customize.

## How?
* Added `overlayBackgroundColor` to the lightbox configuration.
* The image block now checks for an `overlayBackgroundColor` value in the block level settings (`settings.blocks.core/image.lightbox`) and falls back to the global settings (`settings.lightbox`).
* Replaced the hardcoded inline `background-color` on the `.scrim` div with a CSS custom property: `--wp--lightbox--overlay-background-color`.
* Updated `packages/block-library/src/image/style.scss` to consume the new `var(--wp--lightbox--overlay-background-color)` with a default fallback of `rgb(255, 255, 255)`.

## Testing Instructions
1. Activate a block theme.
2. Open the theme's `theme.json` file and add a global lightbox background color:
   ```json
   "settings": {
       "lightbox": {
           "overlayBackgroundColor": "rgba(0, 0, 0, 0.9)"
       }
   }
   ```
3. Open a post or page in the editor.
4. Insert an Image block, upload an image.
5. Save the post and view it on the front end.
6. Click the image to trigger the lightbox. Verify that the background color is now the dark, semi-transparent color defined in theme.json.
7. Update your theme.json to define a specific color just for the image block (settings.blocks.core/image.lightbox.overlayBackgroundColor = "red"). Verify that the block-level setting successfully overrides the global setting on the front end.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="2940" height="1442" alt="image" src="https://github.com/user-attachments/assets/a3fa93bc-f1aa-4cbf-913d-ccd58a26b28c" />|<img width="2940" height="1442" alt="image" src="https://github.com/user-attachments/assets/6aa7db1f-5aa7-4528-a394-ceb28a14c079" />|