### PR TITLE
Components: Add Badge text overflow e2e story

### DIFF
--- a/packages/components/src/badge/stories/e2e/index.story.tsx
+++ b/packages/components/src/badge/stories/e2e/index.story.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import Badge from '../..';
+
+const meta: Meta< typeof Badge > = {
+	component: Badge,
+	title: 'Components/Badge',
+};
+export default meta;
+
+type Story = StoryObj< typeof Badge >;
+
+export const TextOverflow: Story = {
+	args: {
+		children:
+			'This is an extremely long label thatshoulddemonstratetextoverflow behavior',
+	},
+	parameters: {
+		textOverflowContainers: true,
+	},
+};


### PR DESCRIPTION
## What?

Part of the testing infra for #76135

Adds a `@wordpress/components` Badge text overflow story to the components E2E Storybook build, matching the existing `@wordpress/ui` Badge story.

## Why?

The E2E Storybook setup is useful for visually testing text overflow behavior in constrained containers. Badge already truncates with ellipsis, but it was missing from the components E2E stories added in #78256.

## How?

Adds `packages/components/src/badge/stories/e2e/index.story.tsx` with a `TextOverflow` story that uses the `textOverflowContainers` decorator parameter.

## Testing Instructions

1. Run `npm run storybook:e2e:dev`.
2. Open the Badge text overflow story and confirm long labels truncate with ellipsis in the constrained width scenarios.

## Screenshots

<img width="876" height="547" alt="Legacy Badge overflow stories" src="https://github.com/user-attachments/assets/15390880-2845-4058-a493-601fd4cb02f5" />
