### PR TITLE
Remove dependency used for counting available CPUs

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -55,10 +55,6 @@ jobs:
               with:
                   node-version: ${{ matrix.node }}
 
-            - name: Determine the number of CPU cores
-              uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2.0.0
-              id: cpu-cores
-
             - name: Run build scripts
               # It's not necessary to run the full build, since Jest can interpret
               # source files with `babel-jest`. Some packages have their own custom
@@ -67,12 +63,11 @@ jobs:
 
             - name: Running the tests
               env:
-                  MAXWORKERS: ${{ steps.cpu-cores.outputs.count }}
                   SHARD: ${{ matrix.shard }}
               run: |
                   npm run test:unit -- \
                     --ci \
-                    --maxWorkers="$MAXWORKERS" \
+                    --maxWorkers="$(nproc)" \
                     --shard="$SHARD" \
                     --cacheDirectory="$HOME/.jest-cache"
 
@@ -106,10 +101,6 @@ jobs:
               with:
                   node-version: ${{ matrix.node }}
 
-            - name: Determine the number of CPU cores
-              uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2.0.0
-              id: cpu-cores
-
             - name: Run build scripts
               # It's not necessary to run the full build, since Jest can interpret
               # source files with `babel-jest`. Some packages have their own custom
@@ -117,9 +108,7 @@ jobs:
               run: npx lerna run build
 
             - name: Run the date tests
-              env:
-                  MAXWORKERS: ${{ steps.cpu-cores.outputs.count }}
-              run: npm run test:unit:date -- --ci --maxWorkers="$MAXWORKERS" --cacheDirectory="$HOME/.jest-cache"
+              run: npm run test:unit:date -- --ci --maxWorkers="$(nproc)" --cacheDirectory="$HOME/.jest-cache"
 
     compute-previous-wordpress-version:
         name: Compute previous WordPress version


### PR DESCRIPTION
## What?
This removes the [`SimenB/github-actions-cpu-cores`](https://github.com/SimenB/github-actions-cpu-cores) action as a dependency. 

Introduced in https://github.com/WordPress/gutenberg/commit/5571a7948a5eb50208c83aa060b1c7147dbf635d by way of #59904.

<!-- In a few words, what is the PR actually doing? -->

## Why?
The action sets the result of a single expression as an output for future steps to make use of.

With supply chain attacks occurring more and more frequently, it's in the project's best interest to limit the number of dependencies a repository has as much as possible. This is a good example of "a dependency for dependency's sake" as it can be replaced with a single simple command.

## How?
Since every job using this action is Linux-based, the same can be accomplished using `nproc`.

## Use of AI Tools

I used Claude to analyze how the dependency is used within the repository and evaluate whether it can safely be removed in favor of a simpler solution.
