### PR TITLE
RTC: Do not sync taxonomy term entities

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -18,7 +18,6 @@ import { getSyncManager } from './sync';
 import {
 	applyPostChangesToCRDTDoc,
 	defaultCollectionSyncConfig,
-	defaultSyncConfig,
 	getPostChangesFromCRDTDoc,
 	POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
 } from './utils/crdt';
@@ -475,7 +474,7 @@ async function loadTaxonomyEntities() {
 	} );
 	return Object.entries( taxonomies ?? {} ).map( ( [ name, taxonomy ] ) => {
 		const namespace = taxonomy?.rest_namespace ?? 'wp/v2';
-		const entity = {
+		return {
 			kind: 'taxonomy',
 			baseURL: `/${ namespace }/${ taxonomy.rest_base }`,
 			baseURLParams: { context: 'edit' },
@@ -483,11 +482,8 @@ async function loadTaxonomyEntities() {
 			label: taxonomy.name,
 			getTitle: ( record ) => record?.name,
 			supportsPagination: true,
+			syncConfig: defaultCollectionSyncConfig,
 		};
-
-		entity.syncConfig = defaultSyncConfig;
-
-		return entity;
 	} );
 }
 

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -333,4 +333,28 @@ describe( 'loadTaxonomyEntities', () => {
 
 		expect( entities[ 0 ].supportsPagination ).toBe( true );
 	} );
+
+	it( 'should only enable collection syncing for taxonomy term records', async () => {
+		const mockTaxonomies = {
+			category: {
+				name: 'Categories',
+				rest_base: 'categories',
+			},
+		};
+
+		apiFetch.mockResolvedValueOnce( mockTaxonomies );
+
+		const taxonomyLoader = additionalEntityConfigLoaders.find(
+			( loader ) => loader.kind === 'taxonomy'
+		);
+		const entities = await taxonomyLoader.loadEntities();
+
+		expect( entities[ 0 ].syncConfig ).toBeDefined();
+		expect(
+			entities[ 0 ].syncConfig.shouldSync( 'taxonomy/category', null )
+		).toBe( true );
+		expect(
+			entities[ 0 ].syncConfig.shouldSync( 'taxonomy/category', 1 )
+		).toBe( false );
+	} );
 } );


### PR DESCRIPTION
## What?

Use collection-only RTC syncing for taxonomy entities.

Post records still sync taxonomy assignments such as `categories` and `tags` as part of the post entity. Taxonomy collection rooms such as `taxonomy/category` remain enabled so clients can be notified when the term collection changes, but individual taxonomy term rooms such as `taxonomy/category:1` are blocked.

## Why?

We investigated an RTC-only unsaved changes warning that appeared after scheduling a post and then leaving the editor, even though the post itself had no unsaved changes.

The dirty entity was not the post. `core/editor` reported `isEditedPostDirty()` as false, and the post had no non-transient edits. However, `core.__experimentalGetDirtyEntityRecords()` contained the default category term:

- kind: `taxonomy`
- name: `category`
- key: `1`

The dirty term record had local raw values from the current site, but RTC-applied edits from stale term data. For example, on the affected staging environment the raw term contained staging URLs and current counts, while the synced edit contained production URLs and older counts.

This can happen because taxonomy terms were being treated as standalone syncable entities. A term like `Uncategorized` uses a stable RTC room key such as `taxonomy/category:1`, independent of the post being edited and independent of the site URL. If sync storage is copied between environments, or otherwise contains stale term data, stale updates for that term room can be loaded and applied as local edits on the current site.

That marks the taxonomy term entity dirty, and the unsaved-changes warning uses `core.__experimentalGetDirtyEntityRecords()`, not only the current post's dirty state. As a result, navigating away from a clean scheduled post can show the browser "changes may not be saved" warning.

Taxonomy term records do not need collaborative entity editing for the post editor flow. Creating and assigning terms continues to use the normal REST/core-data path, selected term IDs continue to sync through the post record itself, and taxonomy collection syncing remains available for collection-level invalidation/refetch behavior.

## Reproduction

This can be reproduced from a clean WP Studio environment by first creating valid RTC data for the default category term, then changing the local site URL so that the term record returned by REST no longer matches the term record stored in the RTC room.

1. Start a fresh WP Studio site with the Gutenberg plugin and RTC enabled.
2. Add at least one category besides `Uncategorized`. This allows the pre-publish panel to show the category suggestion.
3. Create a new post while the site is still using the original WP Studio local domain.
4. Leave the post without a manually selected category.
5. Open the publish/schedule confirmation panel so the `Suggestion: Assign a category` panel appears. This loads the default category entity and opens the `taxonomy/category:1` RTC room.
6. Confirm that the `taxonomy/category:1` room has been requested by checking the RTC `/updates` request.
7. Close the editor.
8. Change the WP Studio site to use a custom domain.
9. Restart the site.
10. Open the editor again and create a new post without manually selecting a category.
11. Add some content.
12. Set the post to be scheduled for a future publish date.
13. Click **Schedule**.
14. After the schedule request completes, click the WordPress logo to leave the editor.

Before this fix, the browser can show the unsaved changes warning even though the post is clean. Inspecting dirty records shows the category term as dirty, with raw values from the current domain and edits from the previous domain stored in the individual term RTC room:

```js
wp.data.select( 'core' ).__experimentalGetDirtyEntityRecords().map(
	( record ) => ( {
		record,
		raw: wp.data.select( 'core' ).getRawEntityRecord(
			record.kind,
			record.name,
			record.key
		),
		edits: wp.data.select( 'core' ).getEntityRecordEdits(
			record.kind,
			record.name,
			record.key
		),
	} )
);
```

The post itself can be clean at the same time:

```js
const core = wp.data.select( 'core' );
const editor = wp.data.select( 'core/editor' );
const id = editor.getCurrentPostId();

console.log( {
	editorDirty: editor.isEditedPostDirty(),
	postEdits: core.getEntityRecordEdits( 'postType', 'post', id ),
	postNonTransientEdits: core.getEntityRecordNonTransientEdits(
		'postType',
		'post',
		id
	),
	dirtyRecords: core.__experimentalGetDirtyEntityRecords(),
} );
```

Notes from the verified reproduction:

- The issue happens after scheduling.
- It did not happen when saving a draft.
- It did not happen when publishing immediately.
- Saving a draft first, then scheduling afterward, could still reproduce the issue.
- The pre-publish panel loads `taxonomy/category:1` because `MaybeCategoryPanel` requests the default category entity while checking whether to show the category suggestion.

## Testing Instructions

1. Follow the clean WP Studio reproduction steps above on a build before this change.
2. Confirm that `core.__experimentalGetDirtyEntityRecords()` can contain `taxonomy/category:1` with stale URL/count edits after scheduling.
3. Apply this patch.
4. Repeat the same flow and confirm taxonomy collection rooms remain allowed while individual taxonomy term rooms are blocked, so stale term record data is not applied as dirty entity edits.
5. Confirm taxonomy assignment still works, including assigning an existing category.
6. Add a new category from the post taxonomy selector and confirm it is created and assigned.

## Automated testing

- `npm run test:unit packages/core-data/src/test/entities.js -- --runInBand`
- `npm run lint:js packages/core-data/src/entities.js packages/core-data/src/test/entities.js`

## Implementation Notes

Taxonomy entities now use `defaultCollectionSyncConfig`. Its `shouldSync` callback allows collection rooms where `objectId` is `null`, for example `taxonomy/category`, and rejects individual term rooms where `objectId` is present, for example `taxonomy/category:1`.