### PR TITLE
RTC: Fix Edit/Join row action invisible on mobile in post list

### DIFF
--- a/lib/compat/wordpress-7.1/collaboration.php
+++ b/lib/compat/wordpress-7.1/collaboration.php
@@ -400,30 +400,32 @@ function gutenberg_post_list_collaboration_row_actions( $actions, $post ) {
 	$title = _draft_or_post_title( $post->ID );
 
 	/*
-	 * Both "Edit" and "Join" labels are rendered. The visible label is
-	 * toggled by CSS based on the row's `wp-collaborative-editing` class,
-	 * which is added or removed by inline-edit-post.js in response to
-	 * heartbeat ticks.
+	 * Both "Edit" and "Join" links are rendered as sibling <a>s pointing to
+	 * the same URL. CSS in gutenberg_post_list_collaboration_styles() toggles
+	 * which one is visible based on the row's `wp-locked` class, which core's
+	 * inline-edit-post.js maintains in response to heartbeat ticks.
+	 *
+	 * Sibling <a>s (rather than nested spans inside a single <a>) are used so
+	 * the visible label is a direct text child of <a>, matching the row-action
+	 * shape WP core uses for View/Trash/etc. This shape is required by core's
+	 * responsive list-table rule at <=782px:
+	 *     .row-actions span   { font-size: 0;  }
+	 *     .row-actions span a { font-size: 13px; }
+	 * which only restores font-size on the <a> itself, not on descendant
+	 * spans. The previous nested-span markup caused the visible label to
+	 * render at 0px on mobile.
 	 */
 	$actions['edit'] = sprintf(
-		'<a href="%1$s">'
-		. '<span class="edit-action-text">'
-		. '<span aria-hidden="true">%2$s</span>'
-		. '<span class="screen-reader-text">%3$s</span>'
-		. '</span>'
-		. '<span class="join-action-text">'
-		. '<span aria-hidden="true">%4$s</span>'
-		. '<span class="screen-reader-text">%5$s</span>'
-		. '</span>'
-		. '</a>',
-		get_edit_post_link( $post->ID ),
+		'<a class="edit-action-text" href="%1$s" aria-label="%2$s">%3$s</a>'
+		. '<a class="join-action-text" href="%1$s" aria-label="%4$s">%5$s</a>',
+		esc_url( get_edit_post_link( $post->ID ) ),
+		/* translators: %s: Post title. */
+		esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;' ), $title ) ),
 		__( 'Edit' ),
 		/* translators: %s: Post title. */
-		sprintf( __( 'Edit &#8220;%s&#8221;' ), $title ),
+		esc_attr( sprintf( __( 'Join editing &#8220;%s&#8221;', 'gutenberg' ), $title ) ),
 		/* translators: Action link text for a singular post in the post list. Can be any type of post. */
-		_x( 'Join', 'post list', 'gutenberg' ),
-		/* translators: %s: Post title. */
-		sprintf( __( 'Join editing &#8220;%s&#8221;', 'gutenberg' ), $title )
+		_x( 'Join', 'post list', 'gutenberg' )
 	);
 
 	return $actions;

--- a/lib/compat/wordpress-7.1/collaboration.php
+++ b/lib/compat/wordpress-7.1/collaboration.php
@@ -400,24 +400,25 @@ function gutenberg_post_list_collaboration_row_actions( $actions, $post ) {
 	$title = _draft_or_post_title( $post->ID );
 
 	/*
-	 * Both "Edit" and "Join" links are rendered as sibling <a>s pointing to
-	 * the same URL. CSS in gutenberg_post_list_collaboration_styles() toggles
-	 * which one is visible based on the row's `wp-locked` class, which core's
-	 * inline-edit-post.js maintains in response to heartbeat ticks.
-	 *
-	 * Sibling <a>s (rather than nested spans inside a single <a>) are used so
-	 * the visible label is a direct text child of <a>, matching the row-action
-	 * shape WP core uses for View/Trash/etc. This shape is required by core's
-	 * responsive list-table rule at <=782px:
+	 * Each state is rendered as `<span class="…-action-text"><a>…</a></span>`.
+	 * The toggle classes sit on the outer <span> rather than the <a> so they
+	 * fall outside core's responsive selector `.row-actions span a` at
+	 * <=782px, which otherwise outranks our class selectors and (a) leaves
+	 * both labels visible on unlocked rows and (b) forces `display: inline`
+	 * on the visible Join link to misalign with sibling row actions. The
+	 * visible label is still a direct text child of <a>, so core's mobile
+	 * font-size rule
 	 *     .row-actions span   { font-size: 0;  }
 	 *     .row-actions span a { font-size: 13px; }
-	 * which only restores font-size on the <a> itself, not on descendant
-	 * spans. The previous nested-span markup caused the visible label to
-	 * render at 0px on mobile.
+	 * still reaches it — that's the fix for the original "Edit invisible
+	 * at 0px on mobile" regression. CSS in
+	 * gutenberg_post_list_collaboration_styles() flips visibility on the
+	 * outer spans based on the row's `wp-locked` class, which core's
+	 * inline-edit-post.js maintains in response to heartbeat ticks.
 	 */
 	$actions['edit'] = sprintf(
-		'<a class="edit-action-text" href="%1$s" aria-label="%2$s">%3$s</a>'
-		. '<a class="join-action-text" href="%1$s" aria-label="%4$s">%5$s</a>',
+		'<span class="edit-action-text"><a href="%1$s" aria-label="%2$s">%3$s</a></span>'
+		. '<span class="join-action-text"><a href="%1$s" aria-label="%4$s">%5$s</a></span>',
 		esc_url( get_edit_post_link( $post->ID ) ),
 		/* translators: %s: Post title. */
 		esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;' ), $title ) ),


### PR DESCRIPTION
## What?

Related to #76795.
Fixes the Edit/Join row action being invisible at `<=782px` on `wp-admin/edit.php` when RTC is enabled.

## Why?

The `edit` row action wraps its visible label in two `<span>` levels inside the action's `<a>`. WP core's responsive list-table CSS at `<=782px` sets `.row-actions span { font-size: 0 }` and restores `13px` only on the action's `<a>`, expecting the visible label to be a direct text child of `<a>` (as it is for View/Trash/etc.). With the nested spans, the visible Edit/Join word matches the `font-size: 0` rule directly and renders at 0px on mobile.

## How?

Render the two states as sibling `<a>`s sharing the same `href`, with the visible label as a direct text child of each and the descriptive accessible name on `aria-label`. The existing `.wp-locked` CSS selectors in `gutenberg_post_list_collaboration_styles()` continue to drive the toggle — class names move from the inner `<span>`s onto the `<a>`s, nothing else changes. Heartbeat behavior is untouched.

Before:
```html
<a href="…">
  <span class="edit-action-text"><span aria-hidden="true">Edit</span><span class="screen-reader-text">Edit "Hello world!"</span></span>
  <span class="join-action-text"><span aria-hidden="true">Join</span><span class="screen-reader-text">Join editing "Hello world!"</span></span>
</a>
```

After:
```html
<a class="edit-action-text" href="…" aria-label='Edit "Hello world!"'>Edit</a>
<a class="join-action-text"  href="…" aria-label='Join editing "Hello world!"'>Join</a>
```

Two `<a>`s are needed because CSS can hide/show whole elements but can't swap an element's text — keeping the toggle purely CSS-driven requires both labels in the DOM. Using `aria-label` matches WP core's row-action convention for View/Trash/etc.

## Testing Instructions

1. Enable RTC.
2. On `trunk`, visit `edit.php?post_type=post` at viewport `<=782px` → "Edit" label invisible (regression repro). On this branch, label is visible.
3. At desktop (`>782px`), confirm Edit/Trash/View/Quick Edit are unchanged vs `trunk`.
4. From a second session, open a post in the editor. After ~15s the row in the first session swaps Edit → Join via heartbeat; close the editor and after ~15s it swaps back. Verify on both desktop and mobile.
5. Inspect the row DOM: visible label is a direct text child of `<a>`; each `<a>` has a post-specific `aria-label`; both share the same `href`.

## Use of AI Tools

Investigation, root-cause analysis, and the patch were drafted with Claude Opus 4.7 (1M context) via Claude Code, reviewed and accepted by the human author per the [WordPress AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/).
