### PR TITLE
Editor: Add in-editor preview modal

### DIFF
--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -16,7 +16,7 @@ import DocumentBar from '../document-bar';
 import DocumentTools from '../document-tools';
 import HeaderSkeleton from './header-skeleton';
 import MoreMenu from '../more-menu';
-import PostPreviewButton from '../post-preview-button';
+import PostPreviewModalButton from '../post-preview-modal-button';
 import PostPublishButtonOrToggle from '../post-publish-button/post-publish-button-or-toggle';
 import PostSavedState from '../post-saved-state';
 import PostViewLink from '../post-view-link';
@@ -155,7 +155,7 @@ function Header( {
 						disabled={ disablePreviewOption }
 					/>
 
-					<PostPreviewButton
+					<PostPreviewModalButton
 						className="editor-header__post-preview-button"
 						forceIsAutosaveable={ forceIsDirty }
 					/>

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -239,12 +239,6 @@
 	}
 }
 
-.editor-header__post-preview-button {
-	@include break-mobile {
-		display: none;
-	}
-}
-
 .editor-editor-interface.is-distraction-free {
 	.interface-interface-skeleton__header {
 		border-bottom: none;
@@ -266,6 +260,7 @@
 		}
 
 		& > .editor-header__toolbar .editor-document-tools__document-overview-toggle,
+		& > .editor-header__settings > .editor-header__post-preview-button,
 		& > .editor-header__settings > .editor-preview-dropdown,
 		& > .editor-header__settings > .interface-pinned-items,
 		& > .editor-header__settings > .editor-zoom-out-toggle {

--- a/packages/editor/src/components/post-preview-modal-button/index.js
+++ b/packages/editor/src/components/post-preview-modal-button/index.js
@@ -1,0 +1,171 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal, Spinner } from '@wordpress/components';
+import { desktop, mobile, tablet } from '@wordpress/icons';
+import { __, _x } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+import { VisuallyHidden } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
+const DEVICES = [
+	{
+		name: 'desktop',
+		label: __( 'Desktop' ),
+		icon: desktop,
+	},
+	{
+		name: 'tablet',
+		label: __( 'Tablet' ),
+		icon: tablet,
+	},
+	{
+		name: 'mobile',
+		label: __( 'Mobile' ),
+		icon: mobile,
+	},
+];
+
+/**
+ * Renders a button that opens the current post preview in a modal.
+ *
+ * @param {Object}  props                     The component props.
+ * @param {string}  props.className           The class name for the button.
+ * @param {boolean} props.forceIsAutosaveable Whether to force autosave.
+ *
+ * @return {React.ReactNode} The rendered button component.
+ */
+export default function PostPreviewModalButton( {
+	className,
+	forceIsAutosaveable,
+} ) {
+	const { currentPostLink, previewLink, isSaveable, isViewable } = useSelect(
+		( select ) => {
+			const editor = select( editorStore );
+			const core = select( coreStore );
+
+			const postType = core.getPostType( editor.getCurrentPostType() );
+			const canView = postType?.viewable ?? false;
+			if ( ! canView ) {
+				return { isViewable: canView };
+			}
+
+			return {
+				currentPostLink: editor.getCurrentPostAttribute( 'link' ),
+				previewLink: editor.getEditedPostPreviewLink(),
+				isSaveable: editor.isEditedPostSaveable(),
+				isViewable: canView,
+			};
+		},
+		[]
+	);
+	const { __unstableSaveForPreview } = useDispatch( editorStore );
+	const [ isOpen, setIsOpen ] = useState( false );
+	const [ isGeneratingPreview, setIsGeneratingPreview ] = useState( false );
+	const [ previewUrl, setPreviewUrl ] = useState();
+	const [ previewError, setPreviewError ] = useState();
+	const [ device, setDevice ] = useState( 'desktop' );
+
+	if ( ! isViewable ) {
+		return null;
+	}
+
+	const openPreviewModal = async () => {
+		setIsOpen( true );
+		setIsGeneratingPreview( true );
+		setPreviewError();
+		setPreviewUrl();
+
+		try {
+			const link = await __unstableSaveForPreview( {
+				forceIsAutosaveable,
+			} );
+			setPreviewUrl( link || previewLink || currentPostLink );
+		} catch ( error ) {
+			setPreviewError( error );
+		} finally {
+			setIsGeneratingPreview( false );
+		}
+	};
+
+	const closePreviewModal = () => {
+		setIsOpen( false );
+	};
+
+	return (
+		<>
+			<Button
+				variant={ ! className ? 'tertiary' : undefined }
+				className={ className || 'editor-post-preview' }
+				accessibleWhenDisabled
+				disabled={ ! isSaveable || isGeneratingPreview }
+				onClick={ openPreviewModal }
+				size="compact"
+			>
+				{ _x( 'Preview', 'imperative verb' ) }
+				<VisuallyHidden render={ <span /> }>
+					{ __( '(opens in a modal)' ) }
+				</VisuallyHidden>
+			</Button>
+			{ isOpen && (
+				<Modal
+					title={ __( 'Preview' ) }
+					onRequestClose={ closePreviewModal }
+					isFullScreen
+					className="editor-post-preview-modal"
+					headerActions={
+						<div
+							className="editor-post-preview-modal__toolbar"
+							role="toolbar"
+							aria-label={ __( 'Preview size' ) }
+						>
+							{ DEVICES.map( ( { name, label, icon } ) => (
+								<Button
+									key={ name }
+									icon={ icon }
+									isPressed={ device === name }
+									label={ label }
+									onClick={ () => setDevice( name ) }
+									showTooltip
+									size="compact"
+								/>
+							) ) }
+						</div>
+					}
+				>
+					<div className="editor-post-preview-modal__frame-wrapper">
+						{ isGeneratingPreview && (
+							<div className="editor-post-preview-modal__loading">
+								<Spinner />
+								<p>{ __( 'Generating preview…' ) }</p>
+							</div>
+						) }
+						{ ! isGeneratingPreview && previewError && (
+							<div
+								className="editor-post-preview-modal__error"
+								role="alert"
+							>
+								{ __(
+									'The preview could not be generated. Please try again.'
+								) }
+							</div>
+						) }
+						{ ! isGeneratingPreview && previewUrl && (
+							<iframe
+								className={ `editor-post-preview-modal__iframe is-${ device }-preview` }
+								src={ previewUrl }
+								title={ __( 'Post preview' ) }
+							/>
+						) }
+					</div>
+				</Modal>
+			) }
+		</>
+	);
+}

--- a/packages/editor/src/components/post-preview-modal-button/style.scss
+++ b/packages/editor/src/components/post-preview-modal-button/style.scss
@@ -1,0 +1,82 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.components-modal__frame.editor-post-preview-modal {
+	height: calc(100% - #{ $grid-unit-50 * 2 });
+	max-height: none;
+	max-width: none;
+	width: calc(100% - #{ $grid-unit-50 * 2 });
+}
+
+.editor-post-preview-modal {
+	.components-modal__content {
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+		padding: 0;
+	}
+
+	.components-modal__children-container {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		min-height: 0;
+	}
+}
+
+.editor-post-preview-modal__toolbar {
+	align-items: center;
+	display: flex;
+	gap: $grid-unit-05;
+	justify-content: center;
+	left: 50%;
+	position: absolute;
+	top: 50%;
+	transform: translate(-50%, -50%);
+}
+
+.editor-post-preview-modal__frame-wrapper {
+	align-items: flex-start;
+	background: $gray-100;
+	display: flex;
+	flex: 1;
+	justify-content: center;
+	min-height: 0;
+	overflow: auto;
+	padding: $grid-unit-30;
+}
+
+.editor-post-preview-modal__iframe {
+	background: $white;
+	border: $border-width solid $gray-300;
+	border-radius: $radius-block-ui;
+	box-shadow: 0 $grid-unit-05 $grid-unit-30 rgba($black, 0.12);
+	box-sizing: border-box;
+	height: 100%;
+	max-width: 100%;
+}
+
+.editor-post-preview-modal__iframe.is-desktop-preview {
+	width: min(100%, 1200px);
+}
+
+.editor-post-preview-modal__iframe.is-tablet-preview {
+	width: 781px;
+}
+
+.editor-post-preview-modal__iframe.is-mobile-preview {
+	width: 479px;
+}
+
+.editor-post-preview-modal__loading,
+.editor-post-preview-modal__error {
+	align-items: center;
+	align-self: stretch;
+	color: $gray-700;
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	gap: $grid-unit-10;
+	justify-content: center;
+	text-align: center;
+}

--- a/packages/editor/src/components/post-preview-modal-button/test/index.js
+++ b/packages/editor/src/components/post-preview-modal-button/test/index.js
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import PostPreviewModalButton from '..';
+
+jest.useRealTimers();
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+jest.mock( '@wordpress/data/src/components/use-dispatch/use-dispatch', () =>
+	jest.fn()
+);
+
+function mockUseSelect( overrides ) {
+	useSelect.mockImplementation( ( map ) =>
+		map( () => ( {
+			getPostType: () => ( { viewable: true } ),
+			getCurrentPostType: () => 'post',
+			getCurrentPostAttribute: () => undefined,
+			getEditedPostPreviewLink: () => undefined,
+			isEditedPostSaveable: () => true,
+			...overrides,
+		} ) )
+	);
+}
+
+function mockUseDispatch( overrides ) {
+	useDispatch.mockImplementation( () => ( {
+		__unstableSaveForPreview: () =>
+			Promise.resolve( 'https://example.com/?preview=true' ),
+		...overrides,
+	} ) );
+}
+
+describe( 'PostPreviewModalButton', () => {
+	beforeEach( () => {
+		mockUseSelect();
+		mockUseDispatch();
+	} );
+
+	afterEach( () => {
+		useSelect.mockReset();
+		useDispatch.mockReset();
+	} );
+
+	it( 'should not render if the post is not viewable.', () => {
+		mockUseSelect( { getPostType: () => ( { viewable: false } ) } );
+
+		render( <PostPreviewModalButton /> );
+
+		expect(
+			screen.queryByRole( 'button', { name: /Preview/ } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should be accessibly disabled if the post is not saveable.', () => {
+		mockUseSelect( { isEditedPostSaveable: () => false } );
+
+		render( <PostPreviewModalButton /> );
+
+		expect(
+			screen.getByRole( 'button', { name: /Preview/ } )
+		).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'should open the preview modal and render the generated preview link.', async () => {
+		const user = userEvent.setup();
+		let resolvePreview;
+		const saveForPreview = jest.fn(
+			() =>
+				new Promise( ( resolve ) => {
+					resolvePreview = resolve;
+				} )
+		);
+		mockUseDispatch( { __unstableSaveForPreview: saveForPreview } );
+
+		render( <PostPreviewModalButton forceIsAutosaveable /> );
+
+		await user.click( screen.getByRole( 'button', { name: /Preview/ } ) );
+
+		expect(
+			screen.getByRole( 'dialog', { name: 'Preview' } )
+		).toBeVisible();
+		expect( screen.getByText( 'Generating preview…' ) ).toBeVisible();
+		expect( saveForPreview ).toHaveBeenCalledWith( {
+			forceIsAutosaveable: true,
+		} );
+
+		resolvePreview( 'https://example.com/?preview=true' );
+
+		const iframe = await screen.findByTitle( 'Post preview' );
+		expect( iframe ).toHaveAttribute(
+			'src',
+			'https://example.com/?preview=true'
+		);
+	} );
+
+	it( 'should switch between desktop, tablet, and mobile preview sizes.', async () => {
+		const user = userEvent.setup();
+
+		render( <PostPreviewModalButton /> );
+
+		await user.click( screen.getByRole( 'button', { name: /Preview/ } ) );
+
+		const iframe = await screen.findByTitle( 'Post preview' );
+		expect( iframe ).toHaveClass( 'is-desktop-preview' );
+
+		await user.click( screen.getByRole( 'button', { name: 'Tablet' } ) );
+		expect( iframe ).toHaveClass( 'is-tablet-preview' );
+
+		await user.click( screen.getByRole( 'button', { name: 'Mobile' } ) );
+		expect( iframe ).toHaveClass( 'is-mobile-preview' );
+	} );
+
+	it( 'should close when escape is pressed.', async () => {
+		const user = userEvent.setup();
+
+		render( <PostPreviewModalButton /> );
+
+		await user.click( screen.getByRole( 'button', { name: /Preview/ } ) );
+		await screen.findByRole( 'dialog', { name: 'Preview' } );
+		await user.keyboard( '{Escape}' );
+
+		await waitFor( () =>
+			expect(
+				screen.queryByRole( 'dialog', { name: 'Preview' } )
+			).not.toBeInTheDocument()
+		);
+	} );
+} );

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -37,6 +37,7 @@
 @use "./components/post-last-edited-panel/style.scss" as *;
 @use "./components/post-last-revision/style.scss" as *;
 @use "./components/post-locked-modal/style.scss" as *;
+@use "./components/post-preview-modal-button/style.scss" as *;
 @use "./components/post-panel-row/style.scss" as *;
 @use "./components/post-panel-section/style.scss" as *;
 @use "./components/post-publish-panel/style.scss" as *;


### PR DESCRIPTION
## What?

Adds a new in-editor Preview modal to the post and page editor.

Instead of requiring users to open a separate browser tab to preview content, this introduces a modal preview layer that opens on top of the current editor and preserves editing context.

The modal includes device preview controls for:

- Desktop
- Tablet
- Mobile

The existing external preview flow remains available from the View dropdown as “Preview in new tab”.

## Why?

Previewing content currently requires leaving the editing flow, usually through “Preview in new tab”. Device emulation, View Post, and previewing unsaved changes are also mixed together in ways that can be confusing.

Related issues/discussions:

- #65918
- #65005
- #41723
- #23126

This PR explores a concrete implementation for improving that experience by making preview feel like a layer within the editor rather than a full context switch.

It also creates a potential foundation for future preview extensions, such as:

- Website preview
- Email/newsletter preview
- Social preview
- Paid subscriber / public visitor preview
- RSS or print preview
- Plugin-provided preview modes

## How?

This PR introduces a modal-based preview surface that:

- Opens from the editor preview UI.
- Displays the current preview route inside the modal.
- Provides responsive device controls in the modal header.
- Supports Desktop, Tablet, and Mobile preview sizes.
- Allows users to close the modal and return to their previous editor context.
- Keeps the existing external “Preview in new tab” behavior available from the View dropdown.

## Screenshots

### Desktop preview

![Desktop preview](https://raw.githubusercontent.com/dhanson-wp/gutenberg/pr-assets/post-page-editor-preview-modal/screenshots/post-page-editor-preview-modal/preview-modal-desktop.png)

### Tablet preview

![Tablet preview](https://raw.githubusercontent.com/dhanson-wp/gutenberg/pr-assets/post-page-editor-preview-modal/screenshots/post-page-editor-preview-modal/preview-modal-tablet.png)

### Mobile preview

![Mobile preview](https://raw.githubusercontent.com/dhanson-wp/gutenberg/pr-assets/post-page-editor-preview-modal/screenshots/post-page-editor-preview-modal/preview-modal-mobile.png)

## Testing Instructions

1. Open the post editor or page editor.
2. Create or edit a post/page with several blocks.
3. Click the Preview button in the editor header.
4. Confirm the preview opens in a modal without navigating away from the editor.
5. Switch between Desktop, Tablet, and Mobile preview sizes.
6. Confirm long preview content scrolls inside the modal surface.
7. Press Escape or use the close button to close the modal.
8. Confirm focus/context returns to the editor.
9. Confirm the existing “Preview in new tab” behavior still works from the View dropdown.

Repeat similar checks for:

- Page editor
- Post editor

## Accessibility

Things to verify:

- Keyboard focus moves into the modal when it opens.
- Focus is trapped inside the modal while open.
- Escape closes the modal.
- Focus returns to the triggering control after closing.
- Device controls are keyboard accessible.
- Modal title/label is announced correctly by screen readers.

## Notes / follow-up

This PR does not attempt to solve the entire preview extensibility problem described in #65005, but it may provide a core preview surface that future extensibility work could build on.

Potential follow-up questions:

- Should plugins be able to register additional preview modes?
- Should “Preview in new tab” also live inside the modal, or is the existing View dropdown location enough?
- Should this same modal be used consistently across posts, pages, templates, and the Site Editor?
- How should this work when previewing templates or full site routes?
- Should modal previews visually suppress editor/admin chrome such as the WordPress admin bar?

## Validation

- `npm run test:unit packages/editor/src/components/post-preview-modal-button/test/index.js`
- `npm run lint:js -- packages/editor/src/components/post-preview-modal-button packages/editor/src/components/header/index.js`
- `npm run lint:css -- packages/editor/src/components/header/style.scss packages/editor/src/components/post-preview-modal-button/style.scss`
- `npm run build`
- Manual browser smoke test in `wp-env` for opening, switching device sizes, internal scroll, closing with Escape, and preserving the existing external preview option.
