### PR TITLE
CI: Include workflow run URL in cherry-pick PR comments

### DIFF
--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -135,7 +135,7 @@ jobs:
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         issue_number: prNumber,
-                        body: `I just cherry-picked this PR to the ${targetBranch} branch to get it included in the next release: ${cherryPickSha}`
+                        body: `I just cherry-picked this PR to the ${targetBranch} branch to get it included in the next release: ${cherryPickSha}\n\nWorkflow run: ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
                       });
 
             - name: Comment on the PR about conflict
@@ -181,5 +181,6 @@ jobs:
                         # Create a PR and set the base to the ${targetBranch} branch.
                         # See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request.
                         \`\`\`
+                        Workflow run: ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}
                         `
                       });


### PR DESCRIPTION
## What?

Closes #76575

Adds a link to the GitHub Actions workflow run URL in comments left on PRs by the auto cherry-pick workflow.

## Why?

When the cherry-pick workflow comments on a PR — either to confirm a successful cherry-pick or to report a conflict — there's no easy way to find the workflow run logs. Including the run URL makes it easier to debug failures or verify what happened. This was identified in #76575 after needing to track down logs for a failed cherry-pick on #76398.

## How?

Appends a `Workflow run:` URL to the comment body in both the success and conflict comment steps in `.github/workflows/cherry-pick-wp-release.yml`. The URL is constructed from the standard GitHub Actions environment variables `GITHUB_SERVER_URL`, `GITHUB_REPOSITORY`, and `GITHUB_RUN_ID`.

## Testing Instructions

This workflow runs on `pull_request_target` events for labeled/merged PRs, so it can't be triggered manually in a fork. To verify:

1. Review the changes in `.github/workflows/cherry-pick-wp-release.yml`.
2. Confirm that both the success and conflict comment steps now include a `Workflow run:` line.
3. The environment variables used are standard GitHub Actions defaults, documented [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables).

### Testing Instructions for Keyboard

No UI changes.

## Screenshots or screencast

Not applicable — this change only affects the text content of automated PR comments.

## Use of AI Tools

Claude (Anthropic) was used to help identify the relevant workflow file and draft the PR description. The code change itself was written manually.