### PR TITLE
Dashboard: scale widget picker previews to fill their card

### DIFF
--- a/routes/dashboard/widget-dashboard/components/widget-picker/widget-picker.module.css
+++ b/routes/dashboard/widget-dashboard/components/widget-picker/widget-picker.module.css
@@ -1,5 +1,8 @@
 .preview {
-	height: 100%;
+	width: 125%;
+	height: 125%;
 	overflow: hidden;
-	padding: var(--wpds-dimension-padding-md);
+	padding: 0;
+	transform: scale(0.8);
+	transform-origin: top left;
 }


### PR DESCRIPTION
## What?

Scales the live widget previews in the dashboard widget picker (the "Add widget" inserter grid) so each preview fills its card instead of rendering cramped in the top-left corner.

The preview content now renders at `0.8` scale inside a `125%` box, so the scaled result occupies 100% of the slot area.

## Why?

Each widget type is shown in the picker as a live preview inside a square media slot. Widgets are designed as full-size dashboard tiles, so at thumbnail scale they were clipped to their top-left corner, leaving the preview hard to read and visually unbalanced.

Rendering the widget slightly zoomed out lets more of it show within the same card, so the preview reads as a representation of the whole widget rather than a cropped fragment.

## How?

The change is confined to the picker's own `.preview` wrapper. It is sized to `125%` of the slot in both dimensions and scaled down with `transform: scale(0.8)` anchored at the top-left. Since `125% × 0.8 = 100%`, the scaled content fills the slot exactly, with no empty margins.

```css
.preview {
	width: 125%;
	height: 125%;
	overflow: hidden;
	padding: 0;
	transform: scale(0.8);
	transform-origin: top left;
}
```

No DataViews internals are touched: only the class we render ourselves is styled.

## Testing

1. Open the dashboard and launch the widget inserter via "Add widget".
2. Confirm each widget preview renders slightly zoomed out and fills its card edge to edge, with no empty margin and without being clipped to the top-left corner.
3. Confirm selecting and inserting one or more widgets still works.


Before | After
-----------|------------
<img width="1126" height="997" alt="image" src="https://github.com/user-attachments/assets/85ae8b0b-7f36-4089-b83a-d1bd8ff68679" /> | <img width="1125" height="998" alt="image" src="https://github.com/user-attachments/assets/a990df6b-858e-43ab-93c5-06ac58a19d10" />
<img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/751e5d94-4020-4f95-9496-045324fa5425" /> | <img width="1728" height="999" alt="image" src="https://github.com/user-attachments/assets/e5bc9da5-f897-4713-822e-d4cb025bbd72" />


## Follow-ups

- [ ] Explore a richer preview representation for widget types (e.g. surfacing title/description metadata alongside the preview).
