### PR TITLE
Block Editor: Replace zoom-out "Change design" to "Replace' with pattern explorer modal

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/change-design.js
+++ b/packages/block-editor/src/components/block-toolbar/change-design.js
@@ -1,127 +1,75 @@
 /**
  * WordPress dependencies
  */
-import {
-	ToolbarButton,
-	ToolbarGroup,
-	Dropdown,
-	__experimentalDropdownContentWrapper as DropdownContentWrapper,
-} from '@wordpress/components';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { cloneBlock } from '@wordpress/blocks';
-import { useMemo } from '@wordpress/element';
+import { cloneBlock, createBlock } from '@wordpress/blocks';
+import { useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
-import BlockPatternsList from '../block-patterns-list';
+import PatternsExplorerModal from '../inserter/block-patterns-explorer';
+import { INSERTER_PATTERN_TYPES } from '../inserter/block-patterns-tab/utils';
 
 const EMPTY_ARRAY = [];
-const MAX_PATTERNS_TO_SHOW = 6;
-const POPOVER_PROPS = {
-	placement: 'bottom-start',
-};
 
-export default function ChangeDesign( { clientId } ) {
-	const { categories, currentPatternName, patterns } = useSelect(
+export default function Replace( { clientId } ) {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const { categories, rootClientId } = useSelect(
 		( select ) => {
-			const {
-				getBlockAttributes,
-				getBlockRootClientId,
-				__experimentalGetAllowedPatterns,
-			} = select( blockEditorStore );
+			const { getBlockAttributes, getBlockRootClientId } =
+				select( blockEditorStore );
 			const attributes = getBlockAttributes( clientId );
-			const _categories = attributes?.metadata?.categories || EMPTY_ARRAY;
-			const rootBlock = getBlockRootClientId( clientId );
 
-			// Calling `__experimentalGetAllowedPatterns` is expensive.
-			// Checking if the block can be changed prevents unnecessary selector calls.
-			// See: https://github.com/WordPress/gutenberg/pull/64736.
-			const _patterns =
-				_categories.length > 0
-					? __experimentalGetAllowedPatterns( rootBlock )
-					: EMPTY_ARRAY;
 			return {
-				categories: _categories,
-				currentPatternName: attributes?.metadata?.patternName,
-				patterns: _patterns,
+				categories: attributes?.metadata?.categories || EMPTY_ARRAY,
+				rootClientId: getBlockRootClientId( clientId ),
 			};
 		},
 		[ clientId ]
 	);
 	const { replaceBlocks } = useDispatch( blockEditorStore );
-	const sameCategoryPatternsWithSingleWrapper = useMemo( () => {
-		if ( categories.length === 0 || ! patterns || patterns.length === 0 ) {
-			return EMPTY_ARRAY;
-		}
-		return patterns
-			.filter( ( pattern ) => {
-				const isCorePattern =
-					pattern.source === 'core' ||
-					( pattern.source?.startsWith( 'pattern-directory' ) &&
-						pattern.source !== 'pattern-directory/theme' );
-				return (
-					// Check if the pattern has only one top level block,
-					// otherwise we may switch to a pattern that doesn't have replacement suggestions.
-					pattern.blocks.length === 1 &&
-					// We exclude the core patterns and pattern directory patterns that are not theme patterns.
-					! isCorePattern &&
-					// Exclude current pattern.
-					currentPatternName !== pattern.name &&
-					pattern.categories?.some( ( category ) => {
-						return categories.includes( category );
-					} ) &&
-					// Check if the pattern is not a synced pattern.
-					( pattern.syncStatus === 'unsynced' || ! pattern.id )
-				);
-			} )
-			.slice( 0, MAX_PATTERNS_TO_SHOW );
-	}, [ categories, currentPatternName, patterns ] );
 
-	if ( sameCategoryPatternsWithSingleWrapper.length < 2 ) {
+	if ( categories.length === 0 ) {
 		return null;
 	}
 
-	const onClickPattern = ( pattern ) => {
-		const newBlocks = ( pattern.blocks ?? [] ).map( ( block ) => {
-			return cloneBlock( block );
-		} );
-		newBlocks[ 0 ].attributes.metadata = {
-			...newBlocks[ 0 ].attributes.metadata,
-			categories,
-		};
+	const onPatternSelect = ( pattern, blocks ) => {
+		const patternBlocks =
+			pattern.type === INSERTER_PATTERN_TYPES.user &&
+			pattern.syncStatus !== 'unsynced'
+				? [ createBlock( 'core/block', { ref: pattern.id } ) ]
+				: blocks ?? pattern.blocks ?? [];
+		const newBlocks = patternBlocks.map( ( block ) => cloneBlock( block ) );
+		if ( newBlocks[ 0 ] ) {
+			newBlocks[ 0 ].attributes.metadata = {
+				...newBlocks[ 0 ].attributes.metadata,
+				categories,
+			};
+		}
 		replaceBlocks( clientId, newBlocks );
 	};
 
 	return (
-		<Dropdown
-			popoverProps={ POPOVER_PROPS }
-			renderToggle={ ( { onToggle, isOpen } ) => {
-				return (
-					<ToolbarGroup>
-						<ToolbarButton
-							onClick={ () => onToggle( ! isOpen ) }
-							aria-expanded={ isOpen }
-						>
-							{ __( 'Change design' ) }
-						</ToolbarButton>
-					</ToolbarGroup>
-				);
-			} }
-			renderContent={ () => (
-				<DropdownContentWrapper
-					className="block-editor-block-toolbar-change-design-content-wrapper"
-					paddingSize="none"
-				>
-					<BlockPatternsList
-						blockPatterns={ sameCategoryPatternsWithSingleWrapper }
-						onClickPattern={ onClickPattern }
-						showTitlesAsTooltip
-					/>
-				</DropdownContentWrapper>
+		<>
+			<ToolbarGroup>
+				<ToolbarButton onClick={ () => setIsModalOpen( true ) }>
+					{ __( 'Replace' ) }
+				</ToolbarButton>
+			</ToolbarGroup>
+			{ isModalOpen && (
+				<PatternsExplorerModal
+					rootClientId={ rootClientId }
+					initialCategory={
+						categories[ 0 ] ? { name: categories[ 0 ] } : undefined
+					}
+					onPatternSelect={ onPatternSelect }
+					onModalClose={ () => setIsModalOpen( false ) }
+				/>
 			) }
-		/>
+		</>
 	);
 }

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -34,7 +34,7 @@ import { useShowHoveredOrFocusedGestures } from './utils';
 import { store as blockEditorStore } from '../../store';
 import NavigableToolbar from '../navigable-toolbar';
 import { useHasBlockToolbar } from './use-has-block-toolbar';
-import Replace from './change-design';
+import ReplacePattern from './replace-pattern';
 import SwitchSectionStyle from './switch-section-style';
 import EditSectionButton from './edit-section-button';
 import { unlock } from '../../lock-unlock';
@@ -254,7 +254,7 @@ export function PrivateBlockToolbar( {
 					<EditSectionButton clientId={ blockClientIds[ 0 ] } />
 				) }
 				{ ! areSelectedBlocksHiddenOnViewport && showReplaceButton && (
-					<Replace clientId={ blockClientIds[ 0 ] } />
+					<ReplacePattern clientId={ blockClientIds[ 0 ] } />
 				) }
 				{ ! areSelectedBlocksHiddenOnViewport &&
 					showSwitchSectionStyleButton && (

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -34,7 +34,7 @@ import { useShowHoveredOrFocusedGestures } from './utils';
 import { store as blockEditorStore } from '../../store';
 import NavigableToolbar from '../navigable-toolbar';
 import { useHasBlockToolbar } from './use-has-block-toolbar';
-import ChangeDesign from './change-design';
+import Replace from './change-design';
 import SwitchSectionStyle from './switch-section-style';
 import EditSectionButton from './edit-section-button';
 import { unlock } from '../../lock-unlock';
@@ -71,7 +71,7 @@ export function PrivateBlockToolbar( {
 		isUsingBindings,
 		isSectionContainer,
 		hasContentOnlyLocking,
-		showShuffleButton,
+		showReplaceButton,
 		showSlots,
 		showGroupButtons,
 		showLockButtons,
@@ -157,7 +157,7 @@ export function PrivateBlockToolbar( {
 			isUsingBindings: _isUsingBindings,
 			isSectionContainer: _isSectionBlock,
 			hasContentOnlyLocking: _hasTemplateLock,
-			showShuffleButton: _isZoomOut,
+			showReplaceButton: _isZoomOut,
 			showSlots: ! _isZoomOut,
 			showGroupButtons: ! _isZoomOut,
 			showLockButtons: ! _isZoomOut,
@@ -253,8 +253,8 @@ export function PrivateBlockToolbar( {
 				{ ! isMultiToolbar && canEdit && (
 					<EditSectionButton clientId={ blockClientIds[ 0 ] } />
 				) }
-				{ ! areSelectedBlocksHiddenOnViewport && showShuffleButton && (
-					<ChangeDesign clientId={ blockClientIds[ 0 ] } />
+				{ ! areSelectedBlocksHiddenOnViewport && showReplaceButton && (
+					<Replace clientId={ blockClientIds[ 0 ] } />
 				) }
 				{ ! areSelectedBlocksHiddenOnViewport &&
 					showSwitchSectionStyleButton && (

--- a/packages/block-editor/src/components/block-toolbar/replace-pattern.js
+++ b/packages/block-editor/src/components/block-toolbar/replace-pattern.js
@@ -16,7 +16,7 @@ import { INSERTER_PATTERN_TYPES } from '../inserter/block-patterns-tab/utils';
 
 const EMPTY_ARRAY = [];
 
-export default function Replace( { clientId } ) {
+export default function ReplacePattern( { clientId } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const { categories, rootClientId } = useSelect(
 		( select ) => {

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/index.js
@@ -12,7 +12,12 @@ import PatternExplorerSidebar from './pattern-explorer-sidebar';
 import PatternList from './pattern-list';
 import { usePatternCategories } from '../block-patterns-tab/use-pattern-categories';
 
-function PatternsExplorer( { initialCategory, rootClientId, onModalClose } ) {
+function PatternsExplorer( {
+	initialCategory,
+	rootClientId,
+	onModalClose,
+	onPatternSelect,
+} ) {
 	const [ searchValue, setSearchValue ] = useState( '' );
 	const [ selectedCategory, setSelectedCategory ] = useState(
 		initialCategory?.name
@@ -35,6 +40,7 @@ function PatternsExplorer( { initialCategory, rootClientId, onModalClose } ) {
 				patternCategories={ patternCategories }
 				rootClientId={ rootClientId }
 				onModalClose={ onModalClose }
+				onPatternSelect={ onPatternSelect }
 			/>
 		</div>
 	);

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-list.js
@@ -54,6 +54,7 @@ function PatternList( {
 	patternCategories,
 	rootClientId,
 	onModalClose,
+	onPatternSelect,
 } ) {
 	const container = useRef();
 	const debouncedSpeak = useDebounce( speak, 500 );
@@ -66,6 +67,7 @@ function PatternList( {
 		destinationRootClientId,
 		selectedCategory
 	);
+	const handleClickPattern = onPatternSelect ?? onClickPattern;
 
 	const registeredPatternCategories = useMemo(
 		() =>
@@ -161,7 +163,7 @@ function PatternList( {
 						<BlockPatternsList
 							blockPatterns={ pagingProps.categoryPatterns }
 							onClickPattern={ ( pattern, blocks ) => {
-								onClickPattern( pattern, blocks );
+								handleClickPattern( pattern, blocks );
 								onModalClose();
 							} }
 							isDraggable={ false }


### PR DESCRIPTION
## What?

This updates the zoom-out toolbar’s pattern replacement flow.

- Renames the toolbar action from `Change design` to `Replace`.
- Opens the existing Patterns Explorer modal instead of the custom dropdown that showed a small set of patterns.
- Opens the modal to the selected section’s first pattern category when category metadata exists.
- Adds an optional `onPatternSelect` callback to the Patterns Explorer so callers can override the default insert behavior.
- Uses that callback to replace the currently selected section with the selected pattern.
- Opens with the current category pre-selected, but you can navigate to all your patterns.

The default Patterns Explorer insertion behavior is unchanged when `onPatternSelect` is not provided.

## Why?

This aligns zoom-out pattern replacement with the existing replacement UX used elsewhere, such as the Query Loop block, where users browse replacement patterns in a modal instead of a small custom dropdown.

It also follows the same principle as #78604, which uses the Patterns Explorer modal for zoom-out pattern insertion: reuse the existing pattern browsing experience instead of introducing another custom pattern picker.

## Before

https://github.com/user-attachments/assets/48551a3a-92e9-4139-b372-6b8c660d4fcd

## After

https://github.com/user-attachments/assets/13f17bce-eafe-4b27-83df-436c5932f0b9


## Testing Instructions

1. Run `npm run wp-env start`.
2. Run `npm start`.
3. Open the editor and enter zoom-out mode.
4. Select a section/pattern that supports replacement.
5. Confirm the toolbar shows `Replace` instead of `Change design`.
6. Click `Replace`.
7. Confirm the Patterns Explorer modal opens.
8. Confirm the modal opens to the selected pattern’s category when category metadata exists.
9. Select a pattern.
10. Confirm the selected section is replaced, not inserted before or after.
11. Confirm surrounding sections remain in place.