### PR TITLE
Block Editor: Add zoom-out pattern insertion menu items

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -9,7 +9,7 @@ import {
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { chevronDown, chevronUp, moreVertical } from '@wordpress/icons';
-import { Children, cloneElement } from '@wordpress/element';
+import { Children, cloneElement, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { pipe, useCopyToClipboard } from '@wordpress/compose';
@@ -26,6 +26,8 @@ import BlockParentSelectorMenuItem from './block-parent-selector-menu-item';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import { useNotifyCopy } from '../../utils/use-notify-copy';
+import PatternsExplorerModal from '../inserter/block-patterns-explorer';
+import { allPatternsCategory } from '../inserter/block-patterns-tab/utils';
 
 const POPOVER_PROPS = {
 	className: 'block-editor-block-settings-menu__popover',
@@ -80,6 +82,9 @@ export function BlockSettingsDropdown( {
 	// Get the client id of the current block for this menu, if one is set.
 	const count = clientIds.length;
 	const firstBlockClientId = clientIds[ 0 ];
+	const lastBlockClientId = clientIds[ count - 1 ];
+	const [ patternsExplorerIndex, setPatternsExplorerIndex ] =
+		useState( null );
 
 	const {
 		firstParentClientId,
@@ -92,6 +97,8 @@ export function BlockSettingsDropdown( {
 		canMove,
 		isFirst,
 		isLast,
+		firstBlockIndex,
+		lastBlockIndex,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -136,9 +143,11 @@ export function BlockSettingsDropdown( {
 				isLast:
 					getBlockIndex( firstBlockClientId ) ===
 					getBlockCount( _firstParentClientId ) - 1,
+				firstBlockIndex: getBlockIndex( firstBlockClientId ),
+				lastBlockIndex: getBlockIndex( lastBlockClientId ),
 			};
 		},
-		[ firstBlockClientId, clientIds ]
+		[ firstBlockClientId, lastBlockClientId, clientIds ]
 	);
 
 	const { getBlockOrder, getSelectedBlockClientIds } =
@@ -234,8 +243,9 @@ export function BlockSettingsDropdown( {
 					return null;
 				}
 
-				return (
+				return [
 					<DropdownMenu
+						key="dropdown"
 						icon={ moreVertical }
 						label={ __( 'Options' ) }
 						className="block-editor-block-settings-menu"
@@ -322,6 +332,28 @@ export function BlockSettingsDropdown( {
 											{ __( 'Duplicate' ) }
 										</MenuItem>
 									) }
+									{ canInsertBlock && isZoomOut && (
+										<>
+											<MenuItem
+												onClick={ pipe( onClose, () =>
+													setPatternsExplorerIndex(
+														firstBlockIndex
+													)
+												) }
+											>
+												{ __( 'Add before' ) }
+											</MenuItem>
+											<MenuItem
+												onClick={ pipe( onClose, () =>
+													setPatternsExplorerIndex(
+														lastBlockIndex + 1
+													)
+												) }
+											>
+												{ __( 'Add after' ) }
+											</MenuItem>
+										</>
+									) }
 									{ canInsertBlock && ! isZoomOut && (
 										<>
 											<MenuItem
@@ -403,8 +435,19 @@ export function BlockSettingsDropdown( {
 								) }
 							</>
 						) }
-					</DropdownMenu>
-				);
+					</DropdownMenu>,
+					patternsExplorerIndex !== null && (
+						<PatternsExplorerModal
+							key="patterns-explorer"
+							initialCategory={ allPatternsCategory }
+							rootClientId={ firstParentClientId }
+							insertionIndex={ patternsExplorerIndex }
+							onModalClose={ () =>
+								setPatternsExplorerIndex( null )
+							}
+						/>
+					),
+				];
 			} }
 		</BlockActions>
 	);

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -264,10 +264,10 @@ test.describe( 'Zoom Out', () => {
 			.getByRole( 'menuitem' );
 
 		await expect( optionsMenu ).toHaveText( [
-			'Duplicate',
+			/^Duplicate/,
 			'Add before',
 			'Add after',
-			'Delete',
+			/^Delete/,
 		] );
 	} );
 

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -263,8 +263,12 @@ test.describe( 'Zoom Out', () => {
 			.getByRole( 'menu', { name: 'Options' } )
 			.getByRole( 'menuitem' );
 
-		// we expect 2 items in the options menu: Duplicate and Delete.
-		await expect( optionsMenu ).toHaveCount( 2 );
+		await expect( optionsMenu ).toHaveText( [
+			'Duplicate',
+			'Add before',
+			'Add after',
+			'Delete',
+		] );
 	} );
 
 	test( 'Zoom Out cannot be activated when the section root is missing', async ( {


### PR DESCRIPTION
## What?

Adds Add before and Add after actions to the block settings menu while zoomed out. These actions open the Patterns Explorer from the stacked modal PR and insert the selected pattern before or after the selected section.

## Stacking

This PR is intentionally stacked on #78604 (`rich/zoom-out-pattern-modal`). Review #78604 first. After #78604 lands, this PR can be rebased/retargeted onto `trunk` with a small diff limited to the menu entry points and test update.

## Why?

Zoom-out mode should expose pattern insertion from the section options menu, not only from the in-between inserter affordance.

## How?

- Tracks the selected section index from the block settings menu.
- Shows Add before / Add after when zoomed out.
- Opens `PatternsExplorerModal` with the correct insertion index.
- Updates the existing zoom-out menu e2e assertion.

## Testing Instructions

1. Check out this branch on top of #78604.
2. Start wp-env, using alternate ports if needed: `WP_ENV_PORT=8890 WP_ENV_PHPMYADMIN_PORT=9001 npm run wp-env start`.
3. Open the Site Editor and enter zoom-out mode.
4. Select a section, open the block settings Options menu, and confirm Add before and Add after appear after Duplicate.
5. Click Add before, choose a pattern in the Patterns Explorer, and confirm it inserts before the selected section.
6. Repeat with Add after and confirm it inserts after the selected section.

## Automated testing

`npm run lint:js -- packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js test/e2e/specs/site-editor/zoom-out.spec.js`