### PR TITLE
Image: Preserve width/height when converting Classic blocks to blocks

### DIFF
--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -41,7 +41,7 @@ function getFirstAnchorAttributeFormHTML( html, attributeName ) {
 
 const imageSchema = {
 	img: {
-		attributes: [ 'src', 'alt', 'title' ],
+		attributes: [ 'src', 'alt', 'title', 'width', 'height' ],
 		classes: [
 			'alignleft',
 			'aligncenter',
@@ -51,6 +51,14 @@ const imageSchema = {
 		],
 	},
 };
+
+// Read a pixel dimension from an `<img>` HTML attribute and normalise it to
+// the `<value>px` form the Image block stores in its `width` / `height`
+// attributes. Non-integer values (e.g. `50%`) are dropped because the block
+// attribute round-trips through inline styles that expect pixel units.
+function parsePixelDimension( value ) {
+	return value && /^\d+$/.test( value ) ? `${ value }px` : undefined;
+}
 
 const schema = ( { phrasingContentSchema } ) => ( {
 	figure: {
@@ -77,12 +85,10 @@ const transforms = {
 				node.nodeName === 'FIGURE' && !! node.querySelector( 'img' ),
 			schema,
 			transform: ( node ) => {
+				const img = node.querySelector( 'img' );
 				// Search both figure and image classes. Alignment could be
 				// set on either. ID is set on the image.
-				const className =
-					node.className +
-					' ' +
-					node.querySelector( 'img' ).className;
+				const className = node.className + ' ' + img.className;
 				const alignMatches =
 					/(?:^|\s)align(left|center|right)(?:$|\s)/.exec(
 						className
@@ -108,6 +114,14 @@ const transforms = {
 					anchorElement && anchorElement.className
 						? anchorElement.className
 						: undefined;
+				// Preserve explicit pixel dimensions set on the source `<img>`
+				// (e.g. legacy "Add Media" output: `<img width="77" height="77">`).
+				const width = parsePixelDimension(
+					img.getAttribute( 'width' )
+				);
+				const height = parsePixelDimension(
+					img.getAttribute( 'height' )
+				);
 				const attributes = getBlockAttributes(
 					'core/image',
 					node.outerHTML,
@@ -119,6 +133,8 @@ const transforms = {
 						rel,
 						linkClass,
 						anchor,
+						width,
+						height,
 					}
 				);
 

--- a/packages/blocks/src/api/raw-handling/test/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/test/paste-handler.js
@@ -5,6 +5,7 @@ import { pasteHandler } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
+import { init as initAndRegisterImageBlock } from '../../../../../block-library/src/image';
 import { init as initAndRegisterTableBlock } from '../../../../../block-library/src/table';
 import { init as initAndRegisterVideoBlock } from '../../../../../block-library/src/video';
 
@@ -286,5 +287,64 @@ describe( 'pasteHandler', () => {
 		} );
 		expect( result.name ).toEqual( 'core/video' );
 		expect( result.isValid ).toBeTruthy();
+	} );
+} );
+
+describe( 'pasteHandler — core/image', () => {
+	beforeAll( () => {
+		initAndRegisterImageBlock();
+	} );
+
+	it( 'preserves explicit pixel width and height from a bare <img>', () => {
+		const [ result ] = pasteHandler( {
+			HTML: '<img src="https://example.com/i.jpg" width="77" height="77" />',
+			mode: 'BLOCKS',
+		} );
+
+		expect( console ).toHaveLogged();
+
+		expect( result.name ).toBe( 'core/image' );
+		expect( result.attributes.url ).toBe( 'https://example.com/i.jpg' );
+		expect( result.attributes.width ).toBe( '77px' );
+		expect( result.attributes.height ).toBe( '77px' );
+	} );
+
+	it( 'preserves explicit pixel width and height from an <img> inside a <figure>', () => {
+		const [ result ] = pasteHandler( {
+			HTML: '<figure><img src="https://example.com/i.jpg" width="120" height="80" /></figure>',
+			mode: 'BLOCKS',
+		} );
+
+		expect( console ).toHaveLogged();
+
+		expect( result.name ).toBe( 'core/image' );
+		expect( result.attributes.width ).toBe( '120px' );
+		expect( result.attributes.height ).toBe( '80px' );
+	} );
+
+	it( 'drops non-pixel width/height (e.g. percentages)', () => {
+		const [ result ] = pasteHandler( {
+			HTML: '<img src="https://example.com/i.jpg" width="50%" height="auto" />',
+			mode: 'BLOCKS',
+		} );
+
+		expect( console ).toHaveLogged();
+
+		expect( result.name ).toBe( 'core/image' );
+		expect( result.attributes.width ).toBeUndefined();
+		expect( result.attributes.height ).toBeUndefined();
+	} );
+
+	it( 'leaves width/height unset when not present on the source', () => {
+		const [ result ] = pasteHandler( {
+			HTML: '<img src="https://example.com/i.jpg" />',
+			mode: 'BLOCKS',
+		} );
+
+		expect( console ).toHaveLogged();
+
+		expect( result.name ).toBe( 'core/image' );
+		expect( result.attributes.width ).toBeUndefined();
+		expect( result.attributes.height ).toBeUndefined();
 	} );
 } );

--- a/test/integration/fixtures/documents/google-docs-out.html
+++ b/test/integration/fixtures/documents/google-docs-out.html
@@ -54,6 +54,6 @@
 <p>An image:</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image -->
-<figure class="wp-block-image"><img src="https://lh4.googleusercontent.com/ID" alt=""/></figure>
+<!-- wp:image {"width":"544px","height":"184px"} -->
+<figure class="wp-block-image is-resized"><img src="https://lh4.googleusercontent.com/ID" alt="" style="width:544px;height:184px"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/google-docs-with-comments-out.html
+++ b/test/integration/fixtures/documents/google-docs-with-comments-out.html
@@ -54,6 +54,6 @@
 <p>An image:</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image -->
-<figure class="wp-block-image"><img src="https://lh4.googleusercontent.com/ID" alt=""/></figure>
+<!-- wp:image {"width":"544px","height":"184px"} -->
+<figure class="wp-block-image is-resized"><img src="https://lh4.googleusercontent.com/ID" alt="" style="width:544px;height:184px"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/ms-word-out.html
+++ b/test/integration/fixtures/documents/ms-word-out.html
@@ -58,8 +58,8 @@
 <p>An image:</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image -->
-<figure class="wp-block-image"><img src="" alt=""/></figure>
+<!-- wp:image {"width":"451px","height":"338px"} -->
+<figure class="wp-block-image is-resized"><img src="" alt="" style="width:451px;height:338px"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->

--- a/test/integration/fixtures/documents/one-image-out.html
+++ b/test/integration/fixtures/documents/one-image-out.html
@@ -1,3 +1,3 @@
-<!-- wp:image {"id":5114} -->
-<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114"/></figure>
+<!-- wp:image {"id":5114,"width":"300px","height":"137px"} -->
+<figure class="wp-block-image is-resized"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114" style="width:300px;height:137px"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/two-images-out.html
+++ b/test/integration/fixtures/documents/two-images-out.html
@@ -1,7 +1,7 @@
-<!-- wp:image {"id":5114} -->
-<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114"/></figure>
+<!-- wp:image {"id":5114,"width":"300px","height":"137px"} -->
+<figure class="wp-block-image is-resized"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114" style="width:300px;height:137px"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"id":5109} -->
-<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" class="wp-image-5109"/></figure>
+<!-- wp:image {"id":5109,"width":"300px","height":"248px"} -->
+<figure class="wp-block-image is-resized"><img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" class="wp-image-5109" style="width:300px;height:248px"/></figure>
 <!-- /wp:image -->


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/35050

Fixes a long-standing bug where converting a Classic block containing an `<img>` with explicit `width` and `height` HTML attributes drops both dimensions, producing a `core/image` block that renders at the source image's natural size.

## Why?
Legacy "Add Media" output from the pre-Gutenberg editor produces markup like `<img src="…" width="77" height="77" />` to record the in-editor resized dimensions. Until now, the `core/image` raw-HTML transform only matched a `<figure><img></figure>` wrapper and only carried `src`, `alt`, and `title` through the schema, so author-set width/height were silently dropped during the Classic → blocks conversion.

This regularly bites users migrating older posts to the block editor — a sized 77×77 thumbnail comes out as a full-size 300×300 image after conversion.

## How?
- Allow `width` and `height` on the image schema's `<img>` so they survive the raw-handling sanitisation step.
- In the `core/image` raw transform, read `width` / `height` off the source `<img>` and pass them through as block attributes alongside the existing fields.
- Normalise bare integers to `"77px"` so the resulting block matches the format the Image block stores when a user sets dimensions via the block UI (`{"width":"77px","height":"77px"}` JSON + inline `style="width:77px;height:77px"` + `is-resized` class on the figure, all rendered by the block's existing `save.js`). Non-integer values (e.g. `50%`, `auto`) are dropped because the block attribute round-trips through inline styles that expect pixel units.
- Update five `*-out.html` raw-handling integration fixtures (`google-docs`, `google-docs-with-comments`, `one-image`, `two-images`, `ms-word`) whose inputs already contained `<img width="…" height="…">` but whose expected outputs encoded the old (buggy) behavior of dropping the dimensions. The new fixtures encode the corrected serialization — same width/height JSON + `is-resized` + inline style the Image block has always emitted for resized images.

## Testing Instructions
1. Open the post editor and switch to the Code editor (Options → Code editor, or ⇧⌥⌘M).
2. Paste:
   ```
   <!-- wp:freeform -->
   <img src="https://placehold.co/300x300" width="77" height="77" />
   <!-- /wp:freeform -->
   ```
3. Exit the Code editor back to the visual editor.
4. Select the Classic block and click **Convert to blocks** on the block toolbar.
5. Switch back to the Code editor and inspect the resulting `wp:image` block:
   - Before this PR: `<!-- wp:image --><figure class="wp-block-image"><img src="…" alt=""/></figure><!-- /wp:image -->` — dimensions dropped, image renders at 300×300.
   - With this PR: `<!-- wp:image {"width":"77px","height":"77px"} --><figure class="wp-block-image is-resized"><img src="…" alt="" style="width:77px;height:77px"/></figure><!-- /wp:image -->` — image renders at the original 77×77.
6. Repeat with `<img>` wrapped in a `<figure>` and confirm dimensions are preserved there too.
7. Confirm non-integer values (e.g. `width="50%"`) are still dropped rather than carried through invalid.
8. Verify the new unit tests pass:
   ```
   npm run test:unit -- packages/blocks/src/api/raw-handling/test/paste-handler.js
   ```
9. Verify the updated raw-handling integration fixtures pass (covers the Google Docs, MS Word, and WordPress-paste flows):
   ```
   npm run test:unit -- test/integration/blocks-raw-handling.test.js
   ```
10. Quick paste-flow check in the editor: copy an `<img width="…" height="…">` from a Google Docs preview (or any source that emits intrinsic dimensions) and paste into the editor. The resulting Image block should render at those dimensions, not the image's natural size.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast

None

## Use of AI Tools

Claude Code with Opus 4.7