### PR TITLE
Welcome widget: draw the version number in the banner

### DIFF
--- a/widgets/welcome/components/banner/banner.module.css
+++ b/widgets/welcome/components/banner/banner.module.css
@@ -1,19 +1,19 @@
 .banner {
 	--banner-bg: var(--wpds-color-bg-interactive-neutral-strong);
 	--banner-fg: var(--wpds-color-fg-interactive-neutral-strong);
-	--banner-line-brand: var(--wpds-color-bg-interactive-brand-strong);
-	--banner-line-caution: var(--wpds-color-bg-surface-caution-weak);
-	--banner-line-success: var(--wpds-color-bg-surface-success);
-	--banner-line-error: color-mix(in srgb, var(--wpds-color-fg-interactive-error) 30%, var(--banner-bg));
-	--banner-line-info: color-mix(in srgb, var(--wpds-color-bg-interactive-brand-strong) 60%, var(--banner-bg));
+	--banner-accent-brand: var(--wpds-color-bg-interactive-brand-strong);
+	--banner-accent-warm: color-mix(in srgb, var(--wpds-color-stroke-surface-warning) 60%, var(--wpds-color-bg-surface-neutral-strong));
+	--banner-accent-dark: var(--wpds-color-fg-content-neutral);
 
 	position: relative;
 	padding: var(--wpds-dimension-padding-3xl);
 	background-color: var(--banner-bg);
+	background-image: linear-gradient(108deg, var(--banner-bg) 0%, var(--banner-bg) 26%, var(--banner-accent-brand) 66%, var(--banner-accent-warm) 100%);
 	color: var(--banner-fg);
 	flex-grow: 1;
 	min-height: 120px;
 	max-height: 300px;
+	overflow: hidden;
 }
 
 .bannerContent {

--- a/widgets/welcome/components/banner/banner.tsx
+++ b/widgets/welcome/components/banner/banner.tsx
@@ -31,7 +31,7 @@ export function Banner( { isWide = false, isTiny = false }: BannerProps ) {
 
 	return (
 		<Stack className={ className } direction="column" justify="center">
-			<HeaderBackground />
+			<HeaderBackground version={ DISPLAY_VERSION } />
 
 			<Stack
 				className={ styles.bannerContent }

--- a/widgets/welcome/components/header-background/header-background.module.css
+++ b/widgets/welcome/components/header-background/header-background.module.css
@@ -4,4 +4,5 @@
 	inline-size: 100%;
 	block-size: 100%;
 	z-index: 0;
+	pointer-events: none;
 }

--- a/widgets/welcome/components/header-background/header-background.tsx
+++ b/widgets/welcome/components/header-background/header-background.tsx
@@ -156,8 +156,6 @@ export function HeaderBackground( { version }: HeaderBackgroundProps ) {
 			fill="none"
 			viewBox={ `0 0 ${ VIEW_WIDTH } ${ VIEW_HEIGHT }` }
 			xmlns="http://www.w3.org/2000/svg"
-			aria-hidden="true"
-			focusable="false"
 		>
 			<G
 				fill="none"

--- a/widgets/welcome/components/header-background/header-background.tsx
+++ b/widgets/welcome/components/header-background/header-background.tsx
@@ -6,9 +6,9 @@ import {
 	SVG,
 	G,
 	Path,
+	Circle,
 	Defs,
 	LinearGradient,
-	RadialGradient,
 	Stop,
 } from '@wordpress/primitives';
 
@@ -17,228 +17,215 @@ import {
  */
 import styles from './header-background.module.css';
 
-export function HeaderBackground() {
+type StopSet = 'ring' | 'linear';
+
+interface Stroke {
+	d: string;
+	// Gradient vector in local glyph coords; defaults to a diagonal across the glyph.
+	vec?: [ number, number, number, number ];
+	stops?: StopSet;
+}
+
+interface Glyph {
+	advance: number;
+	strokes?: Stroke[];
+	circles?: { cx: number; cy: number; r: number }[];
+}
+
+/* Stylized version digits drawn with thick strokes, in the core About-banner
+   style: each stroke carries its own gradient (sand -> blue -> near-black), so
+   on the 6 and 9 the stem (drawn over the ring) meets the ring with a
+   dark/light seam that reads as a folded ribbon. Glyphs are placed
+   right-to-left so any version hugs the right edge; each is its own
+   <g data-glyph> group so sectors can be decorated or animated later. */
+const GLYPH_HEIGHT = 200;
+const GLYPHS: Record< string, Glyph > = {
+	'0': {
+		advance: 150,
+		strokes: [ { d: 'M76 30 a48 82 0 1 0 0 164 a48 82 0 1 0 0 -164 Z' } ],
+	},
+	'1': { advance: 110, strokes: [ { d: 'M30 56 L74 22 L74 202' } ] },
+	'2': {
+		advance: 150,
+		strokes: [
+			{ d: 'M34 66 A44 40 0 1 1 120 70 C120 112 38 152 30 196 L124 196' },
+		],
+	},
+	'3': {
+		advance: 150,
+		strokes: [ { d: 'M34 54 A42 36 0 1 1 80 102 A50 48 0 1 1 30 174' } ],
+	},
+	'4': { advance: 150, strokes: [ { d: 'M106 196 V40 L28 138 H128' } ] },
+	'5': {
+		advance: 150,
+		strokes: [ { d: 'M114 40 H58 L57 104 H74 A46 48 0 1 1 50 186' } ],
+	},
+	'6': {
+		advance: 150,
+		strokes: [
+			{
+				d: 'M28 143 a46 46 0 1 0 92 0 a46 46 0 1 0 -92 0',
+				vec: [ -39, 156, 78, 39 ],
+				stops: 'ring',
+			},
+			{ d: 'M117 34 L42 110', vec: [ 97, -18, -56, 135 ] },
+		],
+	},
+	'7': { advance: 150, strokes: [ { d: 'M30 24 H128 L64 202' } ] },
+	'8': {
+		advance: 150,
+		strokes: [
+			{
+				d: 'M76 26 a38 38 0 1 0 0 76 a38 38 0 1 0 0 -76',
+				vec: [ 120, 16, 30, 200 ],
+			},
+			{
+				d: 'M76 106 a46 46 0 1 0 0 92 a46 46 0 1 0 0 -92',
+				vec: [ 120, 16, 30, 200 ],
+			},
+		],
+	},
+	'9': {
+		advance: 150,
+		strokes: [
+			{
+				d: 'M30 82 a46 46 0 1 0 92 0 a46 46 0 1 0 -92 0',
+				vec: [ 190, 69, 73, 186 ],
+				stops: 'ring',
+			},
+			{ d: 'M33 190 L109 115', vec: [ 54, 243, 207, 90 ] },
+		],
+	},
+	'.': { advance: 80, circles: [ { cx: 40, cy: 178, r: 26 } ] },
+};
+
+const VIEW_WIDTH = 1000;
+const VIEW_HEIGHT = 300;
+const RIGHT_MARGIN = 40;
+const GLYPH_GAP = 2;
+const GLYPH_TOP = ( VIEW_HEIGHT - GLYPH_HEIGHT ) / 2;
+
+// Gradient stops, shared by all strokes; colors come from CSS tokens on .banner.
+const STOP_SETS = {
+	// Ring of the 6/9: light at the bottom, near-black where the stem lands.
+	ring: [
+		[ 'var(--banner-accent-warm)', 0 ],
+		[ 'var(--banner-accent-brand)', 0.665 ],
+		[ 'var(--banner-accent-dark)', 1 ],
+	],
+	// Stems and plain digits: near-black to light along the stroke.
+	linear: [
+		[ 'var(--banner-accent-dark)', 0 ],
+		[ 'var(--banner-accent-brand)', 0.5 ],
+		[ 'var(--banner-accent-warm)', 1 ],
+	],
+} as const;
+
+interface HeaderBackgroundProps {
+	version: string;
+}
+
+export function HeaderBackground( { version }: HeaderBackgroundProps ) {
 	const idBase = useId();
-	const clipId = `${ idBase }-clip`;
-	const maskId = `${ idBase }-mask`;
-	const radialId = `${ idBase }-radial`;
-	const fadeId = `${ idBase }-fade`;
-	const lineIds = [ 1, 2, 3, 4, 5 ].map(
-		( index ) => `${ idBase }-line-${ index }`
-	);
+
+	// Place glyphs right-to-left so the version stays anchored to the right.
+	const placed: { key: string; x: number; char: string; glyph: Glyph }[] = [];
+	let cursor = VIEW_WIDTH - RIGHT_MARGIN;
+	const chars = Array.from( version );
+	for ( let i = chars.length - 1; i >= 0; i-- ) {
+		const char = chars[ i ];
+		if ( ! char ) {
+			continue;
+		}
+		const glyph = GLYPHS[ char ];
+		if ( ! glyph ) {
+			continue;
+		}
+		const x = cursor - glyph.advance;
+		placed.unshift( { key: `${ i }-${ char }`, x, char, glyph } );
+		cursor = x - GLYPH_GAP;
+	}
+
+	const strokeId = ( glyphIndex: number, strokeIndex: number ) =>
+		`${ idBase }-${ glyphIndex }-${ strokeIndex }`;
 
 	return (
 		<SVG
 			className={ styles.root }
-			preserveAspectRatio="xMidYMin slice"
+			preserveAspectRatio="xMaxYMid slice"
 			fill="none"
-			viewBox="0 0 1232 240"
+			viewBox={ `0 0 ${ VIEW_WIDTH } ${ VIEW_HEIGHT }` }
 			xmlns="http://www.w3.org/2000/svg"
 			aria-hidden="true"
 			focusable="false"
 		>
-			<G clipPath={ `url(#${ clipId })` }>
-				<Path fill="var(--banner-bg)" d="M0 0h1232v240H0z" />
-
-				<ellipse
-					cx="616"
-					cy="232"
-					fill={ `url(#${ radialId })` }
-					opacity=".05"
-					rx="1497"
-					ry="249"
-				/>
-
-				<mask
-					id={ maskId }
-					width="1000"
-					height="400"
-					x="232"
-					y="20"
-					maskUnits="userSpaceOnUse"
-					style={ { maskType: 'alpha' } }
-				>
-					<Path
-						fill={ `url(#${ fadeId })` }
-						d="M0 0h1000v400H0z"
-						transform="translate(232 20)"
-					/>
-				</mask>
-
-				<G strokeWidth="2" mask={ `url(#${ maskId })` }>
-					<Path
-						stroke={ `url(#${ lineIds[ 0 ] })` }
-						d="M387 20v1635"
-					/>
-					<Path
-						stroke={ `url(#${ lineIds[ 1 ] })` }
-						d="M559.5 20v1635"
-					/>
-					<Path
-						stroke={ `url(#${ lineIds[ 2 ] })` }
-						d="M732 20v1635"
-					/>
-					<Path
-						stroke={ `url(#${ lineIds[ 3 ] })` }
-						d="M904.5 20v1635"
-					/>
-					<Path
-						stroke={ `url(#${ lineIds[ 4 ] })` }
-						d="M1077 20v1635"
-					/>
-				</G>
+			<G
+				fill="none"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				strokeWidth="44"
+			>
+				{ placed.map( ( { key, x, char, glyph }, glyphIndex ) => (
+					<G
+						key={ key }
+						data-glyph={ char }
+						transform={ `translate(${ x } ${ GLYPH_TOP })` }
+					>
+						{ glyph.strokes?.map( ( stroke, strokeIndex ) => (
+							<Path
+								key={ strokeIndex }
+								d={ stroke.d }
+								stroke={ `url(#${ strokeId(
+									glyphIndex,
+									strokeIndex
+								) })` }
+							/>
+						) ) }
+						{ glyph.circles?.map( ( circle, circleIndex ) => (
+							<Circle
+								key={ circleIndex }
+								cx={ circle.cx }
+								cy={ circle.cy }
+								r={ circle.r }
+								fill="var(--banner-accent-brand)"
+							/>
+						) ) }
+					</G>
+				) ) }
 			</G>
 
 			<Defs>
-				<LinearGradient
-					id={ lineIds[ 0 ] }
-					x1="387.5"
-					x2="387.5"
-					y1="20"
-					y2="1655"
-					gradientUnits="userSpaceOnUse"
-				>
-					<Stop
-						stopColor="var(--banner-line-brand)"
-						stopOpacity="0"
-					/>
-					<Stop offset=".297" stopColor="var(--banner-line-brand)" />
-					<Stop offset=".734" stopColor="var(--banner-line-brand)" />
-					<Stop
-						offset="1"
-						stopColor="var(--banner-line-brand)"
-						stopOpacity="0"
-					/>
-				</LinearGradient>
-
-				<LinearGradient
-					id={ lineIds[ 1 ] }
-					x1="560"
-					x2="560"
-					y1="20"
-					y2="1655"
-					gradientUnits="userSpaceOnUse"
-				>
-					<Stop
-						stopColor="var(--banner-line-caution)"
-						stopOpacity="0"
-					/>
-					<Stop
-						offset=".297"
-						stopColor="var(--banner-line-caution)"
-					/>
-					<Stop
-						offset=".734"
-						stopColor="var(--banner-line-caution)"
-					/>
-					<Stop
-						offset="1"
-						stopColor="var(--banner-line-caution)"
-						stopOpacity="0"
-					/>
-				</LinearGradient>
-
-				<LinearGradient
-					id={ lineIds[ 2 ] }
-					x1="732.5"
-					x2="732.5"
-					y1="20"
-					y2="1655"
-					gradientUnits="userSpaceOnUse"
-				>
-					<Stop
-						stopColor="var(--banner-line-success)"
-						stopOpacity="0"
-					/>
-					<Stop
-						offset=".297"
-						stopColor="var(--banner-line-success)"
-					/>
-					<Stop
-						offset=".693"
-						stopColor="var(--banner-line-success)"
-					/>
-					<Stop
-						offset="1"
-						stopColor="var(--banner-line-success)"
-						stopOpacity="0"
-					/>
-				</LinearGradient>
-
-				<LinearGradient
-					id={ lineIds[ 3 ] }
-					x1="905"
-					x2="905"
-					y1="20"
-					y2="1655"
-					gradientUnits="userSpaceOnUse"
-				>
-					<Stop
-						stopColor="var(--banner-line-error)"
-						stopOpacity="0"
-					/>
-					<Stop offset=".297" stopColor="var(--banner-line-error)" />
-					<Stop offset=".734" stopColor="var(--banner-line-error)" />
-					<Stop
-						offset="1"
-						stopColor="var(--banner-line-error)"
-						stopOpacity="0"
-					/>
-				</LinearGradient>
-
-				<LinearGradient
-					id={ lineIds[ 4 ] }
-					x1="1077.5"
-					x2="1077.5"
-					y1="20"
-					y2="1655"
-					gradientUnits="userSpaceOnUse"
-				>
-					<Stop stopColor="var(--banner-line-info)" stopOpacity="0" />
-					<Stop offset=".297" stopColor="var(--banner-line-info)" />
-					<Stop offset=".734" stopColor="var(--banner-line-info)" />
-					<Stop
-						offset="1"
-						stopColor="var(--banner-line-info)"
-						stopOpacity="0"
-					/>
-				</LinearGradient>
-
-				<RadialGradient
-					id={ radialId }
-					cx="0"
-					cy="0"
-					r="1"
-					gradientTransform="matrix(0 249 -1497 0 616 232)"
-					gradientUnits="userSpaceOnUse"
-				>
-					<Stop stopColor="var(--banner-line-brand)" />
-					<Stop
-						offset="1"
-						stopColor="var(--banner-bg)"
-						stopOpacity="0"
-					/>
-				</RadialGradient>
-
-				<RadialGradient
-					id={ fadeId }
-					cx="0"
-					cy="0"
-					r="1"
-					gradientTransform="matrix(0 765 -1912.5 0 500 -110)"
-					gradientUnits="userSpaceOnUse"
-				>
-					<Stop
-						offset=".161"
-						stopColor="var(--banner-bg)"
-						stopOpacity="0"
-					/>
-					<Stop offset=".682" stopColor="var(--banner-bg)" />
-				</RadialGradient>
-
-				<clipPath id={ clipId }>
-					<Path fill="var(--banner-fg)" d="M0 0h1232v240H0z" />
-				</clipPath>
+				{ placed.flatMap( ( { glyph }, glyphIndex ) =>
+					( glyph.strokes ?? [] ).map( ( stroke, strokeIndex ) => {
+						const [ x1, y1, x2, y2 ] = stroke.vec ?? [
+							glyph.advance * 0.8,
+							6,
+							glyph.advance * 0.15,
+							196,
+						];
+						return (
+							<LinearGradient
+								key={ `${ glyphIndex }-${ strokeIndex }` }
+								id={ strokeId( glyphIndex, strokeIndex ) }
+								gradientUnits="userSpaceOnUse"
+								x1={ x1 }
+								y1={ y1 }
+								x2={ x2 }
+								y2={ y2 }
+							>
+								{ STOP_SETS[ stroke.stops ?? 'linear' ].map(
+									( [ color, offset ] ) => (
+										<Stop
+											key={ offset }
+											offset={ offset }
+											stopColor={ color }
+										/>
+									)
+								) }
+							</LinearGradient>
+						);
+					} )
+				) }
 			</Defs>
 		</SVG>
 	);


### PR DESCRIPTION
## What?

The Welcome dashboard widget's banner now renders the WordPress version as a stylized SVG graphic anchored to the right, replacing the previous decorative vertical-lines motif. The version digits are drawn as thick strokes with gradients, in the spirit of the core About page banner.

## Why?

The banner gains a more polished, recognizable look and surfaces the version visually, rather than showing generic decoration. The digits are parametric, so the graphic follows whatever version the widget is given instead of being a fixed illustration.

## How?

- `HeaderBackground` is now parametric: it receives a `version` string and draws it.
- Glyphs `0`–`9` and `.` are defined as stroke paths inside a local box and placed right-to-left, so any version length stays anchored to the right edge (`xMaxYMid slice`).
- Each stroke carries its own gradient (sand → blue → near-black). The `6` and `9` use a tangent stem drawn over the ring, so the dark/light seam reads as a folded ribbon (matching the About banner); the `8` shares one gradient across both rings.
- The banner background is a diagonal gradient. Every color comes from WPDS tokens (`--banner-accent-*` → `bg-interactive-brand-strong`, `stroke-surface-warning`, `fg-content-neutral`); no raw hex.
- Each glyph renders as its own `<g data-glyph>` group, leaving room to decorate or animate individual sectors later.

## Testing

1. Build the plugin and open the dashboard (beta) → Welcome widget.
2. The banner shows the version (e.g. `7.1`) as a graphic on the right; the heading and link stay legible over the dark left side.
3. Resize the widget across narrow and wide tile sizes and confirm the graphic stays anchored to the right and the layout adapts.

<img width="1728" height="1004" alt="image" src="https://github.com/user-attachments/assets/79489aa4-885f-4bb0-aa18-f0354a71bde1" />

<img width="1728" height="780" alt="image" src="https://github.com/user-attachments/assets/6ce413ee-8fdd-4167-9e8a-5b968792513d" />

## Follow-ups

- [ ] Source the version from WordPress instead of the hardcoded `DISPLAY_VERSION` constant in `banner.tsx`, so the heading text and the graphic share a single source.
