### PR TITLE
Classic Block: Use `get_post()` in `wp_declare_classic_block_necessary`

### DIFF
--- a/backport-changelog/7.1/11712.md
+++ b/backport-changelog/7.1/11712.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/11712
 
 * https://github.com/WordPress/gutenberg/pull/77911
+* https://github.com/WordPress/gutenberg/pull/78613

--- a/lib/compat/wordpress-7.1/classic-block.php
+++ b/lib/compat/wordpress-7.1/classic-block.php
@@ -8,13 +8,11 @@
 
 if ( ! function_exists( 'wp_declare_classic_block_necessary' ) ) {
 	/**
-	 * Inject a global JS flag that declares the editor will need the classic block.
+	 * Declares a flag that the Classic block is necessary for the current post.
 	 *
-	 * @global WP_Post|null $post The post being edited, or null if not in the post editor.
+	 * @since 7.1.0
 	 */
-	function wp_declare_classic_block_necessary() {
-		global $post;
-
+	function wp_declare_classic_block_necessary(): void {
 		/**
 		 * Filters whether the Classic block should be available in the inserter.
 		 *
@@ -23,7 +21,7 @@ if ( ! function_exists( 'wp_declare_classic_block_necessary' ) ) {
 		 * @param bool         $supports_inserter Whether the Classic block is available in the inserter.
 		 * @param WP_Post|null $post              The post being edited, or null if not in the post editor.
 		 */
-		if ( ! (bool) apply_filters( 'wp_classic_block_supports_inserter', false, $post ) ) {
+		if ( ! (bool) apply_filters( 'wp_classic_block_supports_inserter', false, get_post() ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## What

Small cleanup to `wp_declare_classic_block_necessary()` in the WordPress 7.1 compat layer:

- Replaces `global $post;` with `get_post()`.
- Adds a `: void` return type.
- Refreshes the function docblock (description + `@since 7.1.0`).

## Why

Aligns this Gutenberg implementation with the version proposed in the corresponding Core PR ([wordpress-develop#11712](https://github.com/WordPress/wordpress-develop/pull/11712)) so the two stay in sync.

No behavior change.

## Testing instructions

1. Start writing a new post.
2. Verify you don't see the Classic block in the inserter.
3. Open an existing post that contains a classic block (or a `<!-- wp:freeform -->` block) and confirm the Classic block renders correctly and is editable.
4. Add `add_filter( 'wp_classic_block_supports_inserter', '__return_true' );` (or use [this plugin](https://github.com/tyxla/enable-classic-block)) and verify the Classic block appears in the inserter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)