### PR TITLE
Font Library: delete selected variants only

### DIFF
--- a/packages/global-styles-ui/src/font-library/api.ts
+++ b/packages/global-styles-ui/src/font-library/api.ts
@@ -19,7 +19,7 @@ const FONT_FAMILIES_URL = '/wp/v2/font-families';
  *
  * @param registry The data registry to use for dispatching actions.
  */
-function invalidateFontFamilyCache( registry: DataRegistry ) {
+export function invalidateFontFamilyCache( registry: DataRegistry ) {
 	const { receiveEntityRecords } = registry.dispatch( coreDataStore );
 
 	// Invalidate all font family queries
@@ -69,4 +69,30 @@ export async function fetchInstallFontFace(
 		id: response.id,
 		...response.font_face_settings,
 	};
+}
+
+export async function fetchDeleteFontFace(
+	fontFamilyId: string,
+	fontFaceId: string
+) {
+	const attempts = [
+		`${ FONT_FAMILIES_URL }/${ fontFamilyId }/font-faces/${ fontFaceId }?force=true`,
+		`/wp/v2/font-faces/${ fontFaceId }?force=true`,
+	];
+
+	let lastError: unknown;
+
+	for ( const path of attempts ) {
+		try {
+			const response = await apiFetch( {
+				path,
+				method: 'DELETE',
+			} );
+			return response;
+		} catch ( error ) {
+			lastError = error;
+		}
+	}
+
+	throw lastError;
 }

--- a/packages/global-styles-ui/src/font-library/context.tsx
+++ b/packages/global-styles-ui/src/font-library/context.tsx
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { createContext, useState, useEffect } from '@wordpress/element';
+import {
+	createContext,
+	useState,
+	useEffect,
+	useMemo,
+} from '@wordpress/element';
 import {
 	useSelect,
 	useDispatch,
@@ -29,7 +34,11 @@ import type {
 /**
  * Internal dependencies
  */
-import { fetchInstallFontFamily } from './api';
+import {
+	fetchInstallFontFamily,
+	fetchDeleteFontFace,
+	invalidateFontFamilyCache,
+} from './api';
 import {
 	setUIValuesNeeded,
 	mergeFontFamilies,
@@ -67,7 +76,7 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 
 	const [ isInstalling, setIsInstalling ] = useState( false );
 
-	const { records: libraryPosts = [], isResolving: isResolvingLibrary } =
+	const { records: libraryPosts, isResolving: isResolvingLibrary } =
 		useEntityRecords< CollectionFontFamily >(
 			'postType',
 			'wp_font_family',
@@ -76,15 +85,36 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 			}
 		);
 
+	const libraryPostsList = useMemo(
+		() => ( Array.isArray( libraryPosts ) ? libraryPosts : [] ),
+		[ libraryPosts ]
+	);
+
+	const [ cachedLibraryPosts, setCachedLibraryPosts ] = useState<
+		CollectionFontFamily[]
+	>( [] );
+
+	useEffect( () => {
+		if ( libraryPostsList.length > 0 ) {
+			setCachedLibraryPosts( libraryPostsList );
+		}
+	}, [ libraryPostsList ] );
+
+	const effectiveLibraryPosts =
+		isResolvingLibrary && cachedLibraryPosts.length > 0
+			? cachedLibraryPosts
+			: libraryPostsList;
+
 	const libraryFonts: FontFamilyPreset[] =
-		( libraryPosts || [] ).map( ( fontFamilyPost ) => {
+		( effectiveLibraryPosts || [] ).map( ( fontFamilyPost ) => {
 			return {
 				id: fontFamilyPost.id,
 				...( fontFamilyPost.font_family_settings || {} ),
 				fontFace:
-					fontFamilyPost?._embedded?.font_faces?.map(
-						( face ) => face.font_face_settings
-					) || [],
+					fontFamilyPost?._embedded?.font_faces?.map( ( face ) => ( {
+						id: String( face.id ),
+						...face.font_face_settings,
+					} ) ) || [],
 			};
 		} ) || [];
 
@@ -231,6 +261,9 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 		return getActivatedFontsOutline( source )[ slug ] || [];
 	};
 
+	const getFontFaceKey = ( face: FontFace ) =>
+		`${ face.fontStyle ?? '' }${ face.fontWeight ?? '' }`;
+
 	async function installFonts( fontFamiliesToInstall: FontFamilyToUpload[] ) {
 		setIsInstalling( true );
 		try {
@@ -260,17 +293,17 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 						? fontFamilyRecords[ 0 ]
 						: null;
 
-				let installedFontFamily = fontFamilyPost
+				let installedFontFamily: FontFamily | null = fontFamilyPost
 					? {
-							id: fontFamilyPost.id,
+							id: String( fontFamilyPost.id ),
 							...fontFamilyPost.font_family_settings,
 							fontFace:
 								(
 									fontFamilyPost?._embedded?.font_faces ?? []
-								).map(
-									( face: CollectionFontFace ) =>
-										face.font_face_settings
-								) || [],
+								).map( ( face: CollectionFontFace ) => ( {
+									id: String( face.id ),
+									...face.font_face_settings,
+								} ) ) || [],
 					  }
 					: null;
 
@@ -282,6 +315,11 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 						makeFontFamilyFormData( fontFamilyToInstall ),
 						registry
 					);
+				}
+
+				const installedFontFamilyId = installedFontFamily.id;
+				if ( ! installedFontFamilyId ) {
+					throw new Error( __( 'Installed font family has no ID.' ) );
 				}
 
 				// Collect font faces that have already been installed (to be activated later)
@@ -308,7 +346,7 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 							( fontFaceToInstall ) =>
 								! checkFontFaceInstalled(
 									fontFaceToInstall,
-									installedFontFamily.fontFace
+									installedFontFamily.fontFace ?? []
 								)
 						);
 				}
@@ -320,8 +358,7 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 				}[] = [];
 				if ( fontFamilyToInstall?.fontFace?.length ?? 0 > 0 ) {
 					const response = await batchInstallFontFaces(
-						// @ts-expect-error - Type mismatch: WpFontFamily.id can be number | string, but batchInstallFontFaces expects only string.
-						installedFontFamily.id,
+						installedFontFamilyId,
 						makeFontFacesFormData(
 							fontFamilyToInstall as FontFamily
 						),
@@ -341,7 +378,7 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 					// correct font information is used.
 					installedFontFamily.fontFace = [
 						...successfullyInstalledFontFaces,
-					];
+					] as FontFamily[ 'fontFace' ];
 
 					fontFamiliesToActivate.push( installedFontFamily );
 				}
@@ -363,7 +400,7 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 					await deleteEntityRecord(
 						'postType',
 						'wp_font_family',
-						installedFontFamily.id,
+						installedFontFamilyId,
 						{ force: true }
 					);
 				}
@@ -385,7 +422,6 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 			if ( fontFamiliesToActivate.length > 0 ) {
 				// Activate the font family (add the font family to the global styles).
 				const activeFonts = activateCustomFontFamilies(
-					// @ts-expect-error - Type mismatch: items may have id as number | string, but FontFamily.id should be string | undefined.
 					fontFamiliesToActivate
 				);
 				// Save the global styles to the database.
@@ -411,20 +447,90 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 			throw new Error( __( 'Font family to uninstall is not defined.' ) );
 		}
 		try {
-			// Uninstall the font family.
-			// (Removes the font files from the server and the posts from the database).
-			await deleteEntityRecord(
-				'postType',
-				'wp_font_family',
-				fontFamilyToUninstall.id,
-				{ force: true }
+			const fontFaces = fontFamilyToUninstall.fontFace ?? [];
+			const activeFaceKeys = new Set(
+				getFontFacesActivated(
+					fontFamilyToUninstall.slug,
+					fontFamilyToUninstall.source
+				)
 			);
 
-			// Deactivate the font family (remove from global styles).
-			const activeFonts = deactivateFontFamily( fontFamilyToUninstall );
+			const fontFacesToDelete = fontFaces.filter( ( face ) =>
+				activeFaceKeys.has( getFontFaceKey( face ) )
+			);
+
+			const shouldDeleteFontFamily =
+				! fontFaces.length ||
+				fontFacesToDelete.length === fontFaces.length;
+
+			if ( shouldDeleteFontFamily ) {
+				// Uninstall the font family.
+				// (Removes the font files from the server and the posts from the database).
+				const response = await deleteEntityRecord(
+					'postType',
+					'wp_font_family',
+					fontFamilyToUninstall.id,
+					{ force: true }
+				);
+
+				if ( ! response ) {
+					throw new Error(
+						__( 'Unable to delete the selected font family.' )
+					);
+				}
+			} else {
+				if ( ! fontFacesToDelete.length ) {
+					throw new Error(
+						__( 'Select at least one font variant to delete.' )
+					);
+				}
+
+				const missingIds = fontFacesToDelete.some(
+					( face ) => ! face.id
+				);
+				if ( missingIds ) {
+					throw new Error(
+						__(
+							'Unable to delete selected font variants. Please reload and try again.'
+						)
+					);
+				}
+
+				const responses = await Promise.all(
+					fontFacesToDelete.map( ( face ) =>
+						fetchDeleteFontFace(
+							fontFamilyToUninstall.id!,
+							face.id!
+						)
+					)
+				);
+
+				if ( responses.some( ( response ) => ! response ) ) {
+					throw new Error(
+						__(
+							'Unable to delete selected font variants. Please reload and try again.'
+						)
+					);
+				}
+			}
+
+			invalidateFontFamilyCache( registry );
+			await resolveSelect( coreStore ).getEntityRecords(
+				'postType',
+				'wp_font_family',
+				{
+					_embed: true,
+				}
+			);
+
+			// Deactivate the deleted font variants from global styles.
+			const activeFonts = deactivateFontFamily(
+				fontFamilyToUninstall,
+				shouldDeleteFontFamily ? undefined : fontFacesToDelete
+			);
 			// Save the global styles to the database.
 			await saveFontFamilies( activeFonts );
-			return { deleted: true };
+			return { deleted: true, deletedFontFamily: shouldDeleteFontFamily };
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
 			console.error(
@@ -435,24 +541,62 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 		}
 	}
 
-	const deactivateFontFamily = ( font: FontFamily ) => {
+	const deactivateFontFamily = (
+		font: FontFamily,
+		fontFacesToDeactivate?: FontFace[]
+	) => {
 		// If the user doesn't have custom fonts defined, include as custom fonts all the theme fonts
 		// We want to save as active all the theme fonts at the beginning
-		const initialCustomFonts = fontFamilies?.[ font.source ?? '' ] ?? [];
-		const newCustomFonts = initialCustomFonts.filter(
-			( f ) => f.slug !== font.slug
-		);
+		const source = font.source ?? '';
+		const initialCustomFonts = fontFamilies?.[ source ] ?? [];
+		const newCustomFonts =
+			fontFacesToDeactivate && fontFacesToDeactivate.length > 0
+				? initialCustomFonts.reduce< FontFamily[] >(
+						( acc, currentFont ) => {
+							if ( currentFont.slug !== font.slug ) {
+								acc.push( currentFont );
+								return acc;
+							}
+
+							const facesToDeactivate = new Set(
+								fontFacesToDeactivate.map( getFontFaceKey )
+							);
+							const remainingFaces = (
+								currentFont.fontFace ?? []
+							).filter(
+								( face ) =>
+									! facesToDeactivate.has(
+										getFontFaceKey( face )
+									)
+							);
+
+							if ( ! remainingFaces.length ) {
+								return acc;
+							}
+
+							acc.push( {
+								...currentFont,
+								fontFace: remainingFaces,
+							} );
+							return acc;
+						},
+						[]
+				  )
+				: initialCustomFonts.filter( ( f ) => f.slug !== font.slug );
 		const activeFonts = {
 			...fontFamilies,
-			[ font.source ?? '' ]: newCustomFonts,
+			[ source ]: newCustomFonts,
 		};
 		setFontFamilies( activeFonts );
 
-		if ( font.fontFace ) {
-			font.fontFace.forEach( ( face ) => {
-				unloadFontFaceInBrowser( face, 'all' );
-			} );
-		}
+		const facesToUnload =
+			fontFacesToDeactivate && fontFacesToDeactivate.length > 0
+				? fontFacesToDeactivate
+				: font.fontFace ?? [];
+
+		facesToUnload.forEach( ( face ) => {
+			unloadFontFaceInBrowser( face, 'all' );
+		} );
 		return activeFonts;
 	};
 

--- a/packages/global-styles-ui/src/font-library/installed-fonts.tsx
+++ b/packages/global-styles-ui/src/font-library/installed-fonts.tsx
@@ -19,7 +19,7 @@ import {
 import { useEntityRecord, store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useContext, useEffect, useState } from '@wordpress/element';
-import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
+import { __, _x, _n, sprintf, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import type {
 	FontFamilyPreset,
@@ -349,6 +349,8 @@ function InstalledFonts() {
 							{ libraryFontSelected && (
 								<ConfirmDeleteDialog
 									font={ libraryFontSelected }
+									selectedVariantCount={ activeFontsCount }
+									totalVariantCount={ selectedFontsCount }
 									isOpen={ isConfirmDeleteOpen }
 									setIsOpen={ setIsConfirmDeleteOpen }
 									setNotice={ setNotice }
@@ -469,6 +471,8 @@ function InstalledFonts() {
 
 function ConfirmDeleteDialog( {
 	font,
+	selectedVariantCount,
+	totalVariantCount,
 	isOpen,
 	setIsOpen,
 	setNotice,
@@ -476,6 +480,8 @@ function ConfirmDeleteDialog( {
 	handleSetLibraryFontSelected,
 }: {
 	font: FontFamily;
+	selectedVariantCount: number;
+	totalVariantCount: number;
 	isOpen: boolean;
 	setIsOpen: ( isOpen: boolean ) => void;
 	setNotice: (
@@ -486,7 +492,7 @@ function ConfirmDeleteDialog( {
 	) => void;
 	uninstallFontFamily: (
 		fontFamily: FontFamily
-	) => Promise< { deleted: boolean } >;
+	) => Promise< { deleted: boolean; deletedFontFamily: boolean } >;
 	handleSetLibraryFontSelected: ( font?: FontFamily ) => void;
 } ) {
 	const navigator = useNavigator();
@@ -495,12 +501,14 @@ function ConfirmDeleteDialog( {
 		setNotice( null );
 		setIsOpen( false );
 		try {
-			await uninstallFontFamily( font );
+			const result = await uninstallFontFamily( font );
 			navigator.goBack();
 			handleSetLibraryFontSelected( undefined );
 			setNotice( {
 				type: 'success',
-				message: __( 'Font family uninstalled successfully.' ),
+				message: result.deletedFontFamily
+					? __( 'Font family uninstalled successfully.' )
+					: __( 'Selected font variants deleted successfully.' ),
 			} );
 		} catch ( error ) {
 			setNotice( {
@@ -525,14 +533,24 @@ function ConfirmDeleteDialog( {
 			onConfirm={ handleConfirmUninstall }
 			size="medium"
 		>
-			{ font &&
-				sprintf(
-					/* translators: %s: Name of the font. */
-					__(
-						'Are you sure you want to delete "%s" font and all its variants and assets?'
-					),
-					font.name
-				) }
+			{ font && totalVariantCount > selectedVariantCount
+				? sprintf(
+						/* translators: 1: Number of selected variants, 2: Name of the font. */
+						_n(
+							'Are you sure you want to delete %1$d selected variant from "%2$s"?',
+							'Are you sure you want to delete %1$d selected variants from "%2$s"?',
+							selectedVariantCount
+						),
+						selectedVariantCount,
+						font.name
+				  )
+				: sprintf(
+						/* translators: %s: Name of the font. */
+						__(
+							'Are you sure you want to delete "%s" font and all its variants and assets?'
+						),
+						font.name
+				  ) }
 		</ConfirmDialog>
 	);
 }

--- a/packages/global-styles-ui/src/font-library/types.ts
+++ b/packages/global-styles-ui/src/font-library/types.ts
@@ -23,6 +23,7 @@ export interface FontLibraryState {
 	installFonts: ( fonts: FontFamily[] ) => Promise< void >;
 	uninstallFontFamily: ( fontFamily: FontFamily ) => Promise< {
 		deleted: boolean;
+		deletedFontFamily: boolean;
 	} >;
 	// Additional properties found in the codebase
 	baseCustomFonts: FontFamily[];


### PR DESCRIPTION
Closes #55176

## What?
Updates Font Library uninstall behavior in the font details view so deleting respects the currently selected variants instead of always deleting the entire family.

## Why?
The previous behavior was confusing and incorrect for users:
- Variant checkboxes implied selective deletion.
- Delete action removed all variants regardless of selection.

## Testing Instructions

1. Open Site Editor.
2. Go to Styles and open Fonts library.
3. Install a font family with multiple variants, for example Alegreya or Alexandria.
4. Open that font in Installed fonts details.
5. Leave all variants selected and click Delete.
6. Confirm deletion.
7. Verify the whole family is removed and success notice indicates family uninstall.
8. Reinstall the same family with multiple variants.
9. Open font details again.
10. Uncheck all variants except one variant, for example 500 Medium.
11. Click Delete and confirm.
12. After reloading Verify:
- only selected variant is deleted
- remaining variants are still present immediately
13. Repeat with two selected variants and verify only those selected variants are removed.

## Screenshots or screencast

https://github.com/user-attachments/assets/6a181178-1649-4e83-b836-a87fe2f1479b


## Use of AI Tools
Used Claude to help draft and iterate on implementation ideas, patch generation, and test plan wording.