### PR TITLE
Dashboard: seed default layout with bundled widget instances

### DIFF
--- a/lib/experimental/dashboard-widgets/default-layout-seed.php
+++ b/lib/experimental/dashboard-widgets/default-layout-seed.php
@@ -11,8 +11,8 @@
  */
 
 /**
- * Appends the bundled `core/hello-world` instance to the default layout
- * unless something earlier in the filter chain already added it.
+ * Appends the bundled widget instances to the default layout unless an
+ * earlier callback in the filter chain already added them.
  *
  * Only contributes to the bundled `gutenberg_dashboard` surface; other
  * dashboards are left untouched.
@@ -36,20 +36,56 @@ function gutenberg_seed_default_dashboard_layout( $dashboard_layout, $dashboard_
 			'type'      => 'core/welcome',
 			'placement' => array(
 				'width'  => 'full',
-				'height' => 2,
+				'height' => 3,
 				'order'  => 0,
 			),
 		);
 	}
 
-	if ( ! in_array( 'default-hello-world-widget-instance', $uuids, true ) ) {
+	if ( ! in_array( 'default-activity-widget-instance', $uuids, true ) ) {
 		$dashboard_layout[] = array(
-			'uuid'      => 'default-hello-world-widget-instance',
-			'type'      => 'core/hello-world',
+			'uuid'      => 'default-activity-widget-instance',
+			'type'      => 'core/activity',
 			'placement' => array(
-				'width'  => 2,
-				'height' => 1,
+				'width'  => 3,
+				'height' => 4,
 				'order'  => 1,
+			),
+		);
+	}
+
+	if ( ! in_array( 'default-quick-draft-widget-instance', $uuids, true ) ) {
+		$dashboard_layout[] = array(
+			'uuid'      => 'default-quick-draft-widget-instance',
+			'type'      => 'core/quick-draft',
+			'placement' => array(
+				'width'  => 5,
+				'height' => 4,
+				'order'  => 2,
+			),
+		);
+	}
+
+	if ( ! in_array( 'default-site-health-widget-instance', $uuids, true ) ) {
+		$dashboard_layout[] = array(
+			'uuid'      => 'default-site-health-widget-instance',
+			'type'      => 'core/site-health',
+			'placement' => array(
+				'width'  => 'fill',
+				'height' => 2,
+				'order'  => 3,
+			),
+		);
+	}
+
+	if ( ! in_array( 'default-preview-widget-instance', $uuids, true ) ) {
+		$dashboard_layout[] = array(
+			'uuid'      => 'default-preview-widget-instance',
+			'type'      => 'core/site-preview',
+			'placement' => array(
+				'width'  => 'fill',
+				'height' => 2,
+				'order'  => 4,
 			),
 		);
 	}


### PR DESCRIPTION
## What?

Expands the default dashboard layout seeded by `gutenberg_seed_default_dashboard_layout()` so the bundled `gutenberg_dashboard` surface renders the full set of shipped widgets the first time it is opened.

The default layout now seeds five widget instances:

| Widget       | Type               | Width | Height | Order |
| ------------ | ------------------ | ----- | ------ | ----- |
| Welcome      | `core/welcome`     | full  | 3      | 0     |
| Activity     | `core/activity`    | 3     | 4      | 1     |
| Quick Draft  | `core/quick-draft` | 5     | 4      | 2     |
| Site Health  | `core/site-health` | fill  | 2      | 3     |
| Site Preview | `core/site-preview`| fill  | 2      | 4     |

Previously the seed added only `core/welcome` and the `core/hello-world` demo placeholder.

## Why?

The first-run dashboard should present the real bundled widgets instead of the `hello-world` placeholder, giving a meaningful starting layout that exercises every shipped widget.

## How?

- Replaces the `core/hello-world` placeholder with `core/activity`, and appends `core/quick-draft`, `core/site-health` and `core/site-preview`.
- Bumps the `core/welcome` banner height from 2 to 3 to fit its content.
- Each instance keeps its idempotent `in_array()` guard on `uuid`, so re-running the filter (or layering additional callbacks) never duplicates an instance.
- Only the bundled `gutenberg_dashboard` surface is contributed to; other dashboards are left untouched.

## Testing

1. Start with no saved dashboard layout (fresh install, or after clearing the stored layout).
2. Open the dashboard.
3. Confirm all five widgets render in order: Welcome (full width), Activity, Quick Draft, Site Health, Site Preview.
4. Reload the dashboard and confirm no widget instance is duplicated.
