### PR TITLE
Welcome widget: add a subtle shine to the version digits

### DIFF
--- a/routes/dashboard/widget-dashboard/components/widget-chrome/widget-chrome.module.css
+++ b/routes/dashboard/widget-dashboard/components/widget-chrome/widget-chrome.module.css
@@ -1,5 +1,17 @@
 .widgetChrome {
 	height: 100%;
+
+	/*
+	 * Isolate the widget body from the surrounding layout. In a fixed-row
+	 * grid the tile height comes from its row span, but a body taller than
+	 * the tile lets its intrinsic size feed the grid item's `min-height: auto`
+	 * and overflow the cell, adding scroll space below the grid. Layout
+	 * containment severs that propagation so the body stays within the tile
+	 * and scrolls internally. It contains layout only, not size or paint, so
+	 * the masonry surface still measures the tile from its content and the
+	 * tile elevation is not clipped.
+	 */
+	contain: layout;
 }
 
 /*

--- a/widgets/welcome/components/banner/banner.module.css
+++ b/widgets/welcome/components/banner/banner.module.css
@@ -4,6 +4,7 @@
 	--banner-accent-brand: var(--wpds-color-bg-interactive-brand-strong);
 	--banner-accent-warm: color-mix(in srgb, var(--wpds-color-stroke-surface-warning) 60%, var(--wpds-color-bg-surface-neutral-strong));
 	--banner-accent-dark: var(--wpds-color-fg-content-neutral);
+	--banner-glint: color-mix(in srgb, var(--banner-fg) 80%, var(--banner-accent-warm));
 
 	position: relative;
 	padding: var(--wpds-dimension-padding-3xl);

--- a/widgets/welcome/components/banner/banner.module.css
+++ b/widgets/welcome/components/banner/banner.module.css
@@ -1,19 +1,19 @@
 .banner {
 	--banner-bg: var(--wpds-color-bg-interactive-neutral-strong);
 	--banner-fg: var(--wpds-color-fg-interactive-neutral-strong);
-	--banner-line-brand: var(--wpds-color-bg-interactive-brand-strong);
-	--banner-line-caution: var(--wpds-color-bg-surface-caution-weak);
-	--banner-line-success: var(--wpds-color-bg-surface-success);
-	--banner-line-error: color-mix(in srgb, var(--wpds-color-fg-interactive-error) 30%, var(--banner-bg));
-	--banner-line-info: color-mix(in srgb, var(--wpds-color-bg-interactive-brand-strong) 60%, var(--banner-bg));
+	--banner-accent-brand: var(--wpds-color-bg-interactive-brand-strong);
+	--banner-accent-warm: color-mix(in srgb, var(--wpds-color-stroke-surface-warning) 60%, var(--wpds-color-bg-surface-neutral-strong));
+	--banner-accent-dark: var(--wpds-color-fg-content-neutral);
 
 	position: relative;
 	padding: var(--wpds-dimension-padding-3xl);
 	background-color: var(--banner-bg);
+	background-image: linear-gradient(108deg, var(--banner-bg) 0%, var(--banner-bg) 26%, var(--banner-accent-brand) 66%, var(--banner-accent-warm) 100%);
 	color: var(--banner-fg);
 	flex-grow: 1;
 	min-height: 120px;
 	max-height: 300px;
+	overflow: hidden;
 }
 
 .bannerContent {

--- a/widgets/welcome/components/banner/banner.tsx
+++ b/widgets/welcome/components/banner/banner.tsx
@@ -31,7 +31,7 @@ export function Banner( { isWide = false, isTiny = false }: BannerProps ) {
 
 	return (
 		<Stack className={ className } direction="column" justify="center">
-			<HeaderBackground />
+			<HeaderBackground version={ DISPLAY_VERSION } />
 
 			<Stack
 				className={ styles.bannerContent }

--- a/widgets/welcome/components/header-background/header-background.module.css
+++ b/widgets/welcome/components/header-background/header-background.module.css
@@ -4,4 +4,5 @@
 	inline-size: 100%;
 	block-size: 100%;
 	z-index: 0;
+	pointer-events: none;
 }

--- a/widgets/welcome/components/header-background/header-background.module.css
+++ b/widgets/welcome/components/header-background/header-background.module.css
@@ -6,3 +6,31 @@
 	z-index: 0;
 	pointer-events: none;
 }
+
+/* Specular sweep across the version digits: a slow gleam that grazes the
+   bevel. It rests off-screen, so reduced-motion users see the static glyphs. */
+.glint {
+	transform: translateX(-360px);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.glint {
+		animation:
+			welcomeVersionGlint 10s var(--wpds-motion-easing-balanced)
+			infinite;
+	}
+}
+
+@keyframes welcomeVersionGlint {
+	0% {
+		transform: translateX(-360px);
+	}
+
+	50% {
+		transform: translateX(1040px);
+	}
+
+	100% {
+		transform: translateX(1040px);
+	}
+}

--- a/widgets/welcome/components/header-background/header-background.module.css
+++ b/widgets/welcome/components/header-background/header-background.module.css
@@ -13,11 +13,11 @@
 	transform: translateX(-360px);
 }
 
-@media (prefers-reduced-motion: no-preference) {
+@media not ( prefers-reduced-motion ) {
 	.glint {
 		animation:
-			welcomeVersionGlint 10s var(--wpds-motion-easing-balanced)
-			infinite;
+			welcomeVersionGlint 10s
+			var(--wpds-motion-easing-expressive) 3s 3;
 	}
 }
 

--- a/widgets/welcome/components/header-background/header-background.tsx
+++ b/widgets/welcome/components/header-background/header-background.tsx
@@ -7,6 +7,7 @@ import {
 	G,
 	Path,
 	Circle,
+	Rect,
 	Defs,
 	LinearGradient,
 	Stop,
@@ -127,6 +128,8 @@ interface HeaderBackgroundProps {
 
 export function HeaderBackground( { version }: HeaderBackgroundProps ) {
 	const idBase = useId();
+	const maskId = `${ idBase }-glint-mask`;
+	const glintId = `${ idBase }-glint`;
 
 	// Place glyphs right-to-left so the version stays anchored to the right.
 	const placed: { key: string; x: number; char: string; glyph: Glyph }[] = [];
@@ -149,6 +152,43 @@ export function HeaderBackground( { version }: HeaderBackgroundProps ) {
 	const strokeId = ( glyphIndex: number, strokeIndex: number ) =>
 		`${ idBase }-${ glyphIndex }-${ strokeIndex }`;
 
+	/* Paint the placed glyphs. `forMask` swaps the gradients/fills for opaque
+	   white so the same shapes can drive the glint mask. */
+	const renderGlyphs = ( forMask: boolean ) =>
+		placed.map( ( { key, x, char, glyph }, glyphIndex ) => (
+			<G
+				key={ key }
+				data-glyph={ char }
+				transform={ `translate(${ x } ${ GLYPH_TOP })` }
+			>
+				{ glyph.strokes?.map( ( stroke, strokeIndex ) => (
+					<Path
+						key={ strokeIndex }
+						d={ stroke.d }
+						stroke={
+							forMask
+								? 'white'
+								: `url(#${ strokeId(
+										glyphIndex,
+										strokeIndex
+								  ) })`
+						}
+					/>
+				) ) }
+				{ glyph.circles?.map( ( circle, circleIndex ) => (
+					<Circle
+						key={ circleIndex }
+						cx={ circle.cx }
+						cy={ circle.cy }
+						r={ circle.r }
+						fill={
+							forMask ? 'white' : 'var(--banner-accent-brand)'
+						}
+					/>
+				) ) }
+			</G>
+		) );
+
 	return (
 		<SVG
 			className={ styles.root }
@@ -165,33 +205,20 @@ export function HeaderBackground( { version }: HeaderBackgroundProps ) {
 				strokeLinejoin="round"
 				strokeWidth="44"
 			>
-				{ placed.map( ( { key, x, char, glyph }, glyphIndex ) => (
-					<G
-						key={ key }
-						data-glyph={ char }
-						transform={ `translate(${ x } ${ GLYPH_TOP })` }
-					>
-						{ glyph.strokes?.map( ( stroke, strokeIndex ) => (
-							<Path
-								key={ strokeIndex }
-								d={ stroke.d }
-								stroke={ `url(#${ strokeId(
-									glyphIndex,
-									strokeIndex
-								) })` }
-							/>
-						) ) }
-						{ glyph.circles?.map( ( circle, circleIndex ) => (
-							<Circle
-								key={ circleIndex }
-								cx={ circle.cx }
-								cy={ circle.cy }
-								r={ circle.r }
-								fill="var(--banner-accent-brand)"
-							/>
-						) ) }
-					</G>
-				) ) }
+				{ renderGlyphs( false ) }
+			</G>
+
+			{ /* Slow specular sweep, clipped to the digits, so light grazes
+			     the bevel as it travels. It rests off-screen (see CSS). */ }
+			<G mask={ `url(#${ maskId })` }>
+				<Rect
+					className={ styles.glint }
+					x="0"
+					y="0"
+					width="300"
+					height={ VIEW_HEIGHT }
+					fill={ `url(#${ glintId })` }
+				/>
 			</G>
 
 			<Defs>
@@ -226,6 +253,54 @@ export function HeaderBackground( { version }: HeaderBackgroundProps ) {
 						);
 					} )
 				) }
+
+				{ /* Narrow diagonal highlight band; rides the glint rect's box
+				     so it tilts along with the bevel. */ }
+				<LinearGradient id={ glintId } x1="0" y1="0" x2="1" y2="0.55">
+					<Stop
+						offset="0"
+						stopColor="var(--banner-glint)"
+						stopOpacity="0"
+					/>
+					<Stop
+						offset="0.4"
+						stopColor="var(--banner-glint)"
+						stopOpacity="0"
+					/>
+					<Stop
+						offset="0.5"
+						stopColor="var(--banner-glint)"
+						stopOpacity="0.65"
+					/>
+					<Stop
+						offset="0.6"
+						stopColor="var(--banner-glint)"
+						stopOpacity="0"
+					/>
+					<Stop
+						offset="1"
+						stopColor="var(--banner-glint)"
+						stopOpacity="0"
+					/>
+				</LinearGradient>
+
+				<mask
+					id={ maskId }
+					maskUnits="userSpaceOnUse"
+					x="0"
+					y="0"
+					width={ VIEW_WIDTH }
+					height={ VIEW_HEIGHT }
+				>
+					<G
+						fill="none"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						strokeWidth="44"
+					>
+						{ renderGlyphs( true ) }
+					</G>
+				</mask>
 			</Defs>
 		</SVG>
 	);

--- a/widgets/welcome/components/header-background/header-background.tsx
+++ b/widgets/welcome/components/header-background/header-background.tsx
@@ -6,9 +6,9 @@ import {
 	SVG,
 	G,
 	Path,
+	Circle,
 	Defs,
 	LinearGradient,
-	RadialGradient,
 	Stop,
 } from '@wordpress/primitives';
 
@@ -17,228 +17,215 @@ import {
  */
 import styles from './header-background.module.css';
 
-export function HeaderBackground() {
+type StopSet = 'ring' | 'linear';
+
+interface Stroke {
+	d: string;
+	// Gradient vector in local glyph coords; defaults to a diagonal across the glyph.
+	vec?: [ number, number, number, number ];
+	stops?: StopSet;
+}
+
+interface Glyph {
+	advance: number;
+	strokes?: Stroke[];
+	circles?: { cx: number; cy: number; r: number }[];
+}
+
+/* Stylized version digits drawn with thick strokes, in the core About-banner
+   style: each stroke carries its own gradient (sand -> blue -> near-black), so
+   on the 6 and 9 the stem (drawn over the ring) meets the ring with a
+   dark/light seam that reads as a folded ribbon. Glyphs are placed
+   right-to-left so any version hugs the right edge; each is its own
+   <g data-glyph> group so sectors can be decorated or animated later. */
+const GLYPH_HEIGHT = 200;
+const GLYPHS: Record< string, Glyph > = {
+	'0': {
+		advance: 150,
+		strokes: [ { d: 'M76 30 a48 82 0 1 0 0 164 a48 82 0 1 0 0 -164 Z' } ],
+	},
+	'1': { advance: 110, strokes: [ { d: 'M30 56 L74 22 L74 202' } ] },
+	'2': {
+		advance: 150,
+		strokes: [
+			{ d: 'M34 66 A44 40 0 1 1 120 70 C120 112 38 152 30 196 L124 196' },
+		],
+	},
+	'3': {
+		advance: 150,
+		strokes: [ { d: 'M34 54 A42 36 0 1 1 80 102 A50 48 0 1 1 30 174' } ],
+	},
+	'4': { advance: 150, strokes: [ { d: 'M106 196 V40 L28 138 H128' } ] },
+	'5': {
+		advance: 150,
+		strokes: [ { d: 'M114 40 H58 L57 104 H74 A46 48 0 1 1 50 186' } ],
+	},
+	'6': {
+		advance: 150,
+		strokes: [
+			{
+				d: 'M28 143 a46 46 0 1 0 92 0 a46 46 0 1 0 -92 0',
+				vec: [ -39, 156, 78, 39 ],
+				stops: 'ring',
+			},
+			{ d: 'M117 34 L42 110', vec: [ 97, -18, -56, 135 ] },
+		],
+	},
+	'7': { advance: 150, strokes: [ { d: 'M30 24 H128 L64 202' } ] },
+	'8': {
+		advance: 150,
+		strokes: [
+			{
+				d: 'M76 26 a38 38 0 1 0 0 76 a38 38 0 1 0 0 -76',
+				vec: [ 120, 16, 30, 200 ],
+			},
+			{
+				d: 'M76 106 a46 46 0 1 0 0 92 a46 46 0 1 0 0 -92',
+				vec: [ 120, 16, 30, 200 ],
+			},
+		],
+	},
+	'9': {
+		advance: 150,
+		strokes: [
+			{
+				d: 'M30 82 a46 46 0 1 0 92 0 a46 46 0 1 0 -92 0',
+				vec: [ 190, 69, 73, 186 ],
+				stops: 'ring',
+			},
+			{ d: 'M33 190 L109 115', vec: [ 54, 243, 207, 90 ] },
+		],
+	},
+	'.': { advance: 80, circles: [ { cx: 40, cy: 178, r: 26 } ] },
+};
+
+const VIEW_WIDTH = 1000;
+const VIEW_HEIGHT = 300;
+const RIGHT_MARGIN = 40;
+const GLYPH_GAP = 2;
+const GLYPH_TOP = ( VIEW_HEIGHT - GLYPH_HEIGHT ) / 2;
+
+// Gradient stops, shared by all strokes; colors come from CSS tokens on .banner.
+const STOP_SETS = {
+	// Ring of the 6/9: light at the bottom, near-black where the stem lands.
+	ring: [
+		[ 'var(--banner-accent-warm)', 0 ],
+		[ 'var(--banner-accent-brand)', 0.665 ],
+		[ 'var(--banner-accent-dark)', 1 ],
+	],
+	// Stems and plain digits: near-black to light along the stroke.
+	linear: [
+		[ 'var(--banner-accent-dark)', 0 ],
+		[ 'var(--banner-accent-brand)', 0.5 ],
+		[ 'var(--banner-accent-warm)', 1 ],
+	],
+} as const;
+
+interface HeaderBackgroundProps {
+	version: string;
+}
+
+export function HeaderBackground( { version }: HeaderBackgroundProps ) {
 	const idBase = useId();
-	const clipId = `${ idBase }-clip`;
-	const maskId = `${ idBase }-mask`;
-	const radialId = `${ idBase }-radial`;
-	const fadeId = `${ idBase }-fade`;
-	const lineIds = [ 1, 2, 3, 4, 5 ].map(
-		( index ) => `${ idBase }-line-${ index }`
-	);
+
+	// Place glyphs right-to-left so the version stays anchored to the right.
+	const placed: { key: string; x: number; char: string; glyph: Glyph }[] = [];
+	let cursor = VIEW_WIDTH - RIGHT_MARGIN;
+	const chars = Array.from( version );
+	for ( let i = chars.length - 1; i >= 0; i-- ) {
+		const char = chars[ i ];
+		if ( ! char ) {
+			continue;
+		}
+		const glyph = GLYPHS[ char ];
+		if ( ! glyph ) {
+			continue;
+		}
+		const x = cursor - glyph.advance;
+		placed.unshift( { key: `${ i }-${ char }`, x, char, glyph } );
+		cursor = x - GLYPH_GAP;
+	}
+
+	const strokeId = ( glyphIndex: number, strokeIndex: number ) =>
+		`${ idBase }-${ glyphIndex }-${ strokeIndex }`;
 
 	return (
 		<SVG
 			className={ styles.root }
-			preserveAspectRatio="xMidYMin slice"
+			preserveAspectRatio="xMaxYMid slice"
 			fill="none"
-			viewBox="0 0 1232 240"
+			viewBox={ `0 0 ${ VIEW_WIDTH } ${ VIEW_HEIGHT }` }
 			xmlns="http://www.w3.org/2000/svg"
 			aria-hidden="true"
 			focusable="false"
 		>
-			<G clipPath={ `url(#${ clipId })` }>
-				<Path fill="var(--banner-bg)" d="M0 0h1232v240H0z" />
-
-				<ellipse
-					cx="616"
-					cy="232"
-					fill={ `url(#${ radialId })` }
-					opacity=".05"
-					rx="1497"
-					ry="249"
-				/>
-
-				<mask
-					id={ maskId }
-					width="1000"
-					height="400"
-					x="232"
-					y="20"
-					maskUnits="userSpaceOnUse"
-					style={ { maskType: 'alpha' } }
-				>
-					<Path
-						fill={ `url(#${ fadeId })` }
-						d="M0 0h1000v400H0z"
-						transform="translate(232 20)"
-					/>
-				</mask>
-
-				<G strokeWidth="2" mask={ `url(#${ maskId })` }>
-					<Path
-						stroke={ `url(#${ lineIds[ 0 ] })` }
-						d="M387 20v1635"
-					/>
-					<Path
-						stroke={ `url(#${ lineIds[ 1 ] })` }
-						d="M559.5 20v1635"
-					/>
-					<Path
-						stroke={ `url(#${ lineIds[ 2 ] })` }
-						d="M732 20v1635"
-					/>
-					<Path
-						stroke={ `url(#${ lineIds[ 3 ] })` }
-						d="M904.5 20v1635"
-					/>
-					<Path
-						stroke={ `url(#${ lineIds[ 4 ] })` }
-						d="M1077 20v1635"
-					/>
-				</G>
+			<G
+				fill="none"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				strokeWidth="44"
+			>
+				{ placed.map( ( { key, x, char, glyph }, glyphIndex ) => (
+					<G
+						key={ key }
+						data-glyph={ char }
+						transform={ `translate(${ x } ${ GLYPH_TOP })` }
+					>
+						{ glyph.strokes?.map( ( stroke, strokeIndex ) => (
+							<Path
+								key={ strokeIndex }
+								d={ stroke.d }
+								stroke={ `url(#${ strokeId(
+									glyphIndex,
+									strokeIndex
+								) })` }
+							/>
+						) ) }
+						{ glyph.circles?.map( ( circle, circleIndex ) => (
+							<Circle
+								key={ circleIndex }
+								cx={ circle.cx }
+								cy={ circle.cy }
+								r={ circle.r }
+								fill="var(--banner-accent-brand)"
+							/>
+						) ) }
+					</G>
+				) ) }
 			</G>
 
 			<Defs>
-				<LinearGradient
-					id={ lineIds[ 0 ] }
-					x1="387.5"
-					x2="387.5"
-					y1="20"
-					y2="1655"
-					gradientUnits="userSpaceOnUse"
-				>
-					<Stop
-						stopColor="var(--banner-line-brand)"
-						stopOpacity="0"
-					/>
-					<Stop offset=".297" stopColor="var(--banner-line-brand)" />
-					<Stop offset=".734" stopColor="var(--banner-line-brand)" />
-					<Stop
-						offset="1"
-						stopColor="var(--banner-line-brand)"
-						stopOpacity="0"
-					/>
-				</LinearGradient>
-
-				<LinearGradient
-					id={ lineIds[ 1 ] }
-					x1="560"
-					x2="560"
-					y1="20"
-					y2="1655"
-					gradientUnits="userSpaceOnUse"
-				>
-					<Stop
-						stopColor="var(--banner-line-caution)"
-						stopOpacity="0"
-					/>
-					<Stop
-						offset=".297"
-						stopColor="var(--banner-line-caution)"
-					/>
-					<Stop
-						offset=".734"
-						stopColor="var(--banner-line-caution)"
-					/>
-					<Stop
-						offset="1"
-						stopColor="var(--banner-line-caution)"
-						stopOpacity="0"
-					/>
-				</LinearGradient>
-
-				<LinearGradient
-					id={ lineIds[ 2 ] }
-					x1="732.5"
-					x2="732.5"
-					y1="20"
-					y2="1655"
-					gradientUnits="userSpaceOnUse"
-				>
-					<Stop
-						stopColor="var(--banner-line-success)"
-						stopOpacity="0"
-					/>
-					<Stop
-						offset=".297"
-						stopColor="var(--banner-line-success)"
-					/>
-					<Stop
-						offset=".693"
-						stopColor="var(--banner-line-success)"
-					/>
-					<Stop
-						offset="1"
-						stopColor="var(--banner-line-success)"
-						stopOpacity="0"
-					/>
-				</LinearGradient>
-
-				<LinearGradient
-					id={ lineIds[ 3 ] }
-					x1="905"
-					x2="905"
-					y1="20"
-					y2="1655"
-					gradientUnits="userSpaceOnUse"
-				>
-					<Stop
-						stopColor="var(--banner-line-error)"
-						stopOpacity="0"
-					/>
-					<Stop offset=".297" stopColor="var(--banner-line-error)" />
-					<Stop offset=".734" stopColor="var(--banner-line-error)" />
-					<Stop
-						offset="1"
-						stopColor="var(--banner-line-error)"
-						stopOpacity="0"
-					/>
-				</LinearGradient>
-
-				<LinearGradient
-					id={ lineIds[ 4 ] }
-					x1="1077.5"
-					x2="1077.5"
-					y1="20"
-					y2="1655"
-					gradientUnits="userSpaceOnUse"
-				>
-					<Stop stopColor="var(--banner-line-info)" stopOpacity="0" />
-					<Stop offset=".297" stopColor="var(--banner-line-info)" />
-					<Stop offset=".734" stopColor="var(--banner-line-info)" />
-					<Stop
-						offset="1"
-						stopColor="var(--banner-line-info)"
-						stopOpacity="0"
-					/>
-				</LinearGradient>
-
-				<RadialGradient
-					id={ radialId }
-					cx="0"
-					cy="0"
-					r="1"
-					gradientTransform="matrix(0 249 -1497 0 616 232)"
-					gradientUnits="userSpaceOnUse"
-				>
-					<Stop stopColor="var(--banner-line-brand)" />
-					<Stop
-						offset="1"
-						stopColor="var(--banner-bg)"
-						stopOpacity="0"
-					/>
-				</RadialGradient>
-
-				<RadialGradient
-					id={ fadeId }
-					cx="0"
-					cy="0"
-					r="1"
-					gradientTransform="matrix(0 765 -1912.5 0 500 -110)"
-					gradientUnits="userSpaceOnUse"
-				>
-					<Stop
-						offset=".161"
-						stopColor="var(--banner-bg)"
-						stopOpacity="0"
-					/>
-					<Stop offset=".682" stopColor="var(--banner-bg)" />
-				</RadialGradient>
-
-				<clipPath id={ clipId }>
-					<Path fill="var(--banner-fg)" d="M0 0h1232v240H0z" />
-				</clipPath>
+				{ placed.flatMap( ( { glyph }, glyphIndex ) =>
+					( glyph.strokes ?? [] ).map( ( stroke, strokeIndex ) => {
+						const [ x1, y1, x2, y2 ] = stroke.vec ?? [
+							glyph.advance * 0.8,
+							6,
+							glyph.advance * 0.15,
+							196,
+						];
+						return (
+							<LinearGradient
+								key={ `${ glyphIndex }-${ strokeIndex }` }
+								id={ strokeId( glyphIndex, strokeIndex ) }
+								gradientUnits="userSpaceOnUse"
+								x1={ x1 }
+								y1={ y1 }
+								x2={ x2 }
+								y2={ y2 }
+							>
+								{ STOP_SETS[ stroke.stops ?? 'linear' ].map(
+									( [ color, offset ] ) => (
+										<Stop
+											key={ offset }
+											offset={ offset }
+											stopColor={ color }
+										/>
+									)
+								) }
+							</LinearGradient>
+						);
+					} )
+				) }
 			</Defs>
 		</SVG>
 	);


### PR DESCRIPTION
## What?

Adds a slow specular sweep to the stylized version digits in the Welcome widget banner. A narrow highlight travels across the numbers, catching the bevel of the existing gradient glyphs, then pauses before repeating.

The effect is purely decorative and lives entirely inside the existing `HeaderBackground` SVG.

## Why?

The banner already renders the WordPress version as beveled, gradient glyphs that read as folded ribbon. A gentle moving highlight gives that surface a little life and quietly draws attention to the version, without adding any new chrome, text, or layout.

## How?

- Extracted the glyph painting into a `renderGlyphs( forMask )` helper so the same shapes paint both the visible digits and an SVG `<mask>`.
- The mask confines the highlight to the digit shapes, so the sweep never spills onto the banner background.
- A `<Rect>` filled with a narrow diagonal gradient (transparent, highlight, transparent) slides across the masked group via a CSS `translateX` animation. The gradient is tilted to follow the bevel direction.
- The highlight color is a new `--banner-glint` token derived from existing banner tokens, so no raw color values are introduced.
- The animation runs only under `@media (prefers-reduced-motion: no-preference)`. At rest the band sits off-screen, so reduced-motion users see the static glyphs unchanged.

Timing is a 10s cycle: the sweep crosses during the first half and idles for the rest, using the `--wpds-motion-easing-balanced` token.

## Testing

1. Open a dashboard surface that renders the Welcome widget.
2. Confirm a soft highlight slowly travels across the version digits in the banner (about once every 10 seconds), and only over the numbers.
3. Enable "Reduce motion" in the OS settings and reload. Confirm the digits render statically with no sweep.
4. Resize the widget (wide, narrow, tiny). Confirm the effect still tracks the digits and never overflows the banner.


https://github.com/user-attachments/assets/fb6037ad-f3b1-4ac2-83c8-6d9e4e58c2eb

