### PR TITLE
Dashboard: contain widget body within its tile to prevent page overflow

### DIFF
--- a/routes/dashboard/widget-dashboard/components/widget-chrome/widget-chrome.module.css
+++ b/routes/dashboard/widget-dashboard/components/widget-chrome/widget-chrome.module.css
@@ -1,5 +1,17 @@
 .widgetChrome {
 	height: 100%;
+
+	/*
+	 * Isolate the widget body from the surrounding layout. In a fixed-row
+	 * grid the tile height comes from its row span, but a body taller than
+	 * the tile lets its intrinsic size feed the grid item's `min-height: auto`
+	 * and overflow the cell, adding scroll space below the grid. Layout
+	 * containment severs that propagation so the body stays within the tile
+	 * and scrolls internally. It contains layout only, not size or paint, so
+	 * the masonry surface still measures the tile from its content and the
+	 * tile elevation is not clipped.
+	 */
+	contain: layout;
 }
 
 /*


### PR DESCRIPTION
## What?

Adds layout containment to the dashboard widget chrome so a widget whose body is taller than its tile scrolls internally instead of overflowing the grid cell and adding empty scroll space below the dashboard.

Single-line change in `routes/dashboard/widget-dashboard/components/widget-chrome/widget-chrome.module.css`.

## Why?

In the fixed-row grid surface, each tile's height comes from its row span (`grid-auto-rows`). The grid item carries `min-height: auto`, which let a tall widget's intrinsic content height propagate up the `height: 100%` chain, past the chrome's `overflow: clip`, and push the body beyond its allotted cell.

When the widget sat at the bottom of the grid, that overflow extended the scroll area of the page and produced unwanted empty space at the end of it, even though the widget body already had its own internal scrollbar.

Measured on the Activity widget (cell `424px`, content `~617px`): the tile leaked `193px` past its cell; with the widget last in the grid the page scrolled `433px` beyond the grid's own height. After the fix the leak is `0` and the page no longer extends.

## How?

`contain: layout` on `.widgetChrome` severs the size propagation from the widget body into the grid item's automatic minimum size.

It was chosen deliberately over the alternatives:

- `overflow: hidden` / `overflow: clip` on the chrome root does **not** stop the leak (the intrinsic size still feeds `min-height: auto`).
- `min-height: 0` along the chain only reduces it partially.
- `contain: size` would stop it but breaks the masonry surface, which measures the tile from its content.

Layout containment contains layout only, not `size` or `paint`, so:

- the masonry surface still grows the tile to fit its content,
- the tile elevation shadow is not clipped,
- portalled popovers (e.g. DataViews dropdowns) are unaffected,
- the widget's own internal scroll container keeps handling overflow within the tile.

## Testing Instructions

1. Open **Dashboard (Beta)** in wp-admin.
2. Make sure a widget with more content than its tile can hold is present (the **Activity** widget is a good candidate on a site with several posts/comments).
3. In the default grid mode, place that widget at the bottom of the dashboard and give it a short tile (1–2 rows).
4. **Before:** the page scrolls past the grid into empty space below the last row. **After:** the widget body scrolls inside its own tile and the page ends with the grid.
5. Switch to the masonry layout (Customize → layout settings) and confirm the same widget's tile still grows to fit its full content with no internal scrollbar.
6. Confirm the tile's hover/elevation shadow in Customize mode is still visible (not clipped).


Before

<img width="1728" height="1010" alt="Screenshot 2026-05-25 at 10 24 46 AM" src="https://github.com/user-attachments/assets/5fb563d4-4aef-4736-a93c-0ecb2d23770b" />

After

<img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/569393c5-a864-40ed-ae82-5a018220a619" />
