### PR TITLE
Content Types: Add checkbox for deletion of terms 

### DIFF
--- a/lib/experimental/content-types/class-wp-rest-user-taxonomies-controller-gutenberg.php
+++ b/lib/experimental/content-types/class-wp-rest-user-taxonomies-controller-gutenberg.php
@@ -452,7 +452,28 @@ class WP_REST_User_Taxonomies_Controller_Gutenberg extends WP_REST_Posts_Control
 	public function delete_item( $request ) {
 		$existing       = get_post( (int) $request['id'] );
 		$was_registered = $existing instanceof WP_Post && 'publish' === $existing->post_status;
-		$response       = parent::delete_item( $request );
+		$taxonomy_slug  = $existing instanceof WP_Post ? $existing->post_name : '';
+
+		// Delete all terms belonging to this taxonomy before removing the
+		// record, so no orphaned rows are left in wp_terms / wp_term_taxonomy.
+		// Note: only active (published) taxonomies are registered in-memory;
+		// terms under inactive taxonomies are not cleaned up here.
+		if ( $request['delete_terms'] && '' !== $taxonomy_slug && taxonomy_exists( $taxonomy_slug ) ) {
+			$term_ids = get_terms(
+				array(
+					'taxonomy'   => $taxonomy_slug,
+					'hide_empty' => false,
+					'fields'     => 'ids',
+				)
+			);
+			if ( is_array( $term_ids ) ) {
+				foreach ( $term_ids as $term_id ) {
+					wp_delete_term( (int) $term_id, $taxonomy_slug );
+				}
+			}
+		}
+
+		$response = parent::delete_item( $request );
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}

--- a/packages/content-types/src/taxonomies/actions/delete.tsx
+++ b/packages/content-types/src/taxonomies/actions/delete.tsx
@@ -155,7 +155,6 @@ function DeleteTaxonomyModal( {
 					  ) }
 			</Text>
 			<CheckboxControl
-				__nextHasNoMarginBottom
 				label={
 					items.length > 1
 						? __( 'Also delete all terms in these taxonomies' )

--- a/packages/content-types/src/taxonomies/actions/delete.tsx
+++ b/packages/content-types/src/taxonomies/actions/delete.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button, CheckboxControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import type { Action } from '@wordpress/dataviews';
@@ -29,6 +29,7 @@ function DeleteTaxonomyModal( {
 	onActionPerformed?: ( items: TaxonomyFormData[] ) => void;
 } ) {
 	const [ isDeleting, setIsDeleting ] = useState( false );
+	const [ deleteTerms, setDeleteTerms ] = useState( false );
 	const { deleteEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
@@ -46,7 +47,10 @@ function DeleteTaxonomyModal( {
 					'postType',
 					TAXONOMY_ENTITY,
 					item.id as number,
-					{ force: true },
+					{
+						force: true,
+						...( deleteTerms ? { delete_terms: true } : {} ),
+					},
 					{ throwOnError: true }
 				)
 			)
@@ -150,6 +154,17 @@ function DeleteTaxonomyModal( {
 							items[ 0 ].title.raw
 					  ) }
 			</Text>
+			<CheckboxControl
+				__nextHasNoMarginBottom
+				label={
+					items.length > 1
+						? __( 'Also delete all terms in these taxonomies' )
+						: __( 'Also delete all terms in this taxonomy' )
+				}
+				checked={ deleteTerms }
+				onChange={ setDeleteTerms }
+				disabled={ isDeleting }
+			/>
 			<Stack direction="row" justify="flex-end" gap="sm">
 				<Button
 					__next40pxDefaultSize


### PR DESCRIPTION

## What?
Part of https://github.com/WordPress/gutenberg/issues/77600

This PR adds a checkbox to delete terms associated with a taxonomy when the taxonomy/taxonomies are deleted in the UI.

## Why?
Cleans up database with orphan terms in the db.

## How?
Introduced `delete_terms` a extra key in the API, which when passed assumes we want to delete the terms in the DB .

## Testing Instructions
1. Add a taxonomy 
2. Delete the recently added taxonomy 
3. Observe that the terms are now deleted in the database by visiting this URL, http://localhost:9000/index.php?route=/database/structure&db=wordpress, depends if you are using docker based development setup. 

## Screenshots or screencast 

### Before

https://github.com/user-attachments/assets/924051c3-3275-4801-8218-65cc5bf2ea27


### After

https://github.com/user-attachments/assets/7cb63151-f8a6-47e1-b7b1-737bb9d31d80


