### PR TITLE
WP Editor Meta Box e2e: wait for TinyMCE init

### DIFF
--- a/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
+++ b/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
@@ -29,18 +29,25 @@ test.describe( 'WP Editor Meta Boxes', () => {
 		await page
 			.getByRole( 'button', { name: 'Meta Boxes' } )
 			.click( { position: { x: 0, y: 0 } } );
-		await page.locator( 'role=button[name="Visual"i]' ).click();
-		// Switch tinymce to Text mode, first waiting for it to initialize
-		// because otherwise it will flip back to Visual mode once initialized.
-		await page.locator( '#test_tinymce_id_ifr' ).waitFor();
-		await page.locator( 'role=button[name="Code"i]' ).click();
 
-		// Type something in the tinymce Text mode textarea.
+		// Switch to Visual mode and wait for TinyMCE to fully initialize.
+		// This ensures getSelection() won't return null when TinyMCE tries
+		// to restore cursor position during subsequent mode switches.
+		await page.locator( 'role=button[name="Visual"i]' ).click();
+		await page.waitForFunction(
+			() => window.tinyMCE?.get( 'test_tinymce_id' )?.initialized
+		);
+
+		// Switch to Code mode and type into the textarea.
+		await page.locator( 'role=button[name="Code"i]' ).click();
 		const metaBoxField = page.locator( '#test_tinymce_id' );
 		await metaBoxField.type( 'Typing in a metabox' );
 
-		// Switch tinymce back to Visual mode.
+		// Switch back to Visual mode and wait for re-initialization.
 		await page.locator( 'role=button[name="Visual"i]' ).click();
+		await page.waitForFunction(
+			() => window.tinyMCE?.get( 'test_tinymce_id' )?.initialized
+		);
 
 		await editor.publishPost();
 		await page.reload();


### PR DESCRIPTION
Fixes #43174, a flaky test that fails extraordinarily often last few days.

The issue is that we "Publish" a new post (including metabox data) a very short time after switching TinyMCE from "Code" mode to "Visual", and at that time the Visual mode is still initializing. When TinyMCE loses focus too quickly, it crashes:
```
Cannot read properties of null (reading 'setBaseAndExtent')
TypeError: Cannot read properties of null (reading 'setBaseAndExtent')
    at i (http://localhost:8889/wp-includes/js/tinymce/tinymce.min.js?ver=49110-20250317:2:291936)
    at Object.each (http://localhost:8889/wp-includes/js/tinymce/tinymce.min.js?ver=49110-20250317:2:1346)
```
because a selection object is `null`. The switch to "Visual" never finishes:

<img width="688" height="399" alt="Screenshot 2026-05-25 at 9 56 47" src="https://github.com/user-attachments/assets/5b3c23f2-b8ee-42c2-af43-61fe2fb4010b" />

The saved content then includes a "bookmark" `span` element that TinyMCE inserts for a very short moment to preserve selection:

<img width="689" height="399" alt="Screenshot 2026-05-25 at 9 56 08" src="https://github.com/user-attachments/assets/9ce21d56-9247-4f14-b791-bad563eb65c4" />

I'm fixing this by adding a better wait after every switch to "Visual", one that checks `window.tinyMCE.get(id).initialized`.
