### PR TITLE
UI: Add Button variant states e2e story

### DIFF
--- a/packages/ui/src/button/stories/e2e/index.story.tsx
+++ b/packages/ui/src/button/stories/e2e/index.story.tsx
@@ -1,5 +1,6 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { Meta, StoryFn } from '@storybook/react-vite';
 import { Button } from '../..';
+import type { ButtonProps } from '../../types';
 
 const meta: Meta< typeof Button > = {
 	title: 'Design System/Components/Button',
@@ -7,14 +8,122 @@ const meta: Meta< typeof Button > = {
 };
 export default meta;
 
-type Story = StoryObj< typeof Button >;
+const variants: NonNullable< ButtonProps[ 'variant' ] >[] = [
+	'solid',
+	'outline',
+	'minimal',
+	'unstyled',
+];
 
-export const TextOverflow: Story = {
-	args: {
-		children:
-			'This is an extremely long label thatshoulddemonstratetextoverflow behavior',
-	},
-	parameters: {
-		textOverflowContainers: true,
-	},
+export const VariantStates: StoryFn< typeof Button > = (
+	props: ButtonProps
+) => {
+	const VariantsRow = ( {
+		buttonProps,
+		name,
+	}: {
+		buttonProps?: ButtonProps;
+		name: string;
+	} ) => {
+		return (
+			<tr>
+				<th
+					style={ {
+						fontSize: 13,
+						fontWeight: 'normal',
+						padding: 8,
+						background: '#f3f4f5',
+					} }
+				>
+					{ name }
+				</th>
+				{ variants.map( ( variant ) => (
+					<td key={ variant } style={ { padding: 4 } }>
+						<Button
+							{ ...props }
+							variant={ variant }
+							{ ...buttonProps }
+						/>
+					</td>
+				) ) }
+			</tr>
+		);
+	};
+
+	return (
+		<table>
+			<thead>
+				<tr style={ { background: '#f3f4f5' } }>
+					<th />
+					{ variants.map( ( variant ) => (
+						<th key={ variant } style={ { padding: 8 } }>
+							{ variant }
+						</th>
+					) ) }
+				</tr>
+			</thead>
+			<tbody>
+				<VariantsRow name="(default)" />
+				<VariantsRow
+					name="disabled"
+					buttonProps={ { disabled: true } }
+				/>
+				<VariantsRow
+					name="disabled unfocusable"
+					buttonProps={ {
+						focusableWhenDisabled: false,
+						disabled: true,
+					} }
+				/>
+				<VariantsRow
+					name="loading"
+					buttonProps={ {
+						loading: true,
+					} }
+				/>
+				<VariantsRow
+					name="loading disabled"
+					buttonProps={ {
+						loading: true,
+						disabled: true,
+					} }
+				/>
+				<VariantsRow
+					name="neutral"
+					buttonProps={ {
+						tone: 'neutral',
+					} }
+				/>
+				<VariantsRow
+					name="pressed"
+					buttonProps={ {
+						tone: 'neutral',
+						'aria-pressed': true,
+					} }
+				/>
+				<VariantsRow
+					name="pressed disabled"
+					buttonProps={ {
+						tone: 'neutral',
+						'aria-pressed': true,
+						disabled: true,
+					} }
+				/>
+			</tbody>
+		</table>
+	);
+};
+VariantStates.args = {
+	children: 'Code is poetry',
+};
+
+export const TextOverflow: StoryFn< typeof Button > = ( props ) => {
+	return <Button { ...props } />;
+};
+TextOverflow.args = {
+	children:
+		'This is an extremely long label thatshoulddemonstratetextoverflow behavior',
+};
+TextOverflow.parameters = {
+	textOverflowContainers: true,
 };

--- a/packages/ui/src/button/stories/e2e/index.story.tsx
+++ b/packages/ui/src/button/stories/e2e/index.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 import { Button } from '../..';
 import type { ButtonProps } from '../../types';
 
@@ -7,6 +7,8 @@ const meta: Meta< typeof Button > = {
 	component: Button,
 };
 export default meta;
+
+type Story = StoryObj< typeof Button >;
 
 const variants: NonNullable< ButtonProps[ 'variant' ] >[] = [
 	'solid',
@@ -117,13 +119,12 @@ VariantStates.args = {
 	children: 'Code is poetry',
 };
 
-export const TextOverflow: StoryFn< typeof Button > = ( props ) => {
-	return <Button { ...props } />;
-};
-TextOverflow.args = {
-	children:
-		'This is an extremely long label thatshoulddemonstratetextoverflow behavior',
-};
-TextOverflow.parameters = {
-	textOverflowContainers: true,
+export const TextOverflow: Story = {
+	args: {
+		children:
+			'This is an extremely long label thatshoulddemonstratetextoverflow behavior',
+	},
+	parameters: {
+		textOverflowContainers: true,
+	},
 };


### PR DESCRIPTION
## What?

Adds a `@wordpress/ui` Button `VariantStates` story to the E2E Storybook build. The story renders a matrix of all button variants across common states (default, disabled, loading, neutral, pressed, and combinations).

## Why?

Visual regression and design review for Button need coverage beyond text overflow. A single matrix story makes it easy to scan variant and state combinations in the E2E Storybook.

## Testing Instructions

1. Run `npm run storybook:e2e:dev`.
2. Open **Design System / Components / Button / Variant States** and confirm all variants render correctly for each row (default, disabled, loading, neutral, pressed, and combined states).

> [!NOTE]
> Pressed disabled button styles are wrong — will fix in #78635. 