### PR TITLE
UI Button: Fix pressed disabled styles for neutral minimal

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 -   `IconButton`: Default `focusableWhenDisabled` to `true`, matching `Button` ([#78526](https://github.com/WordPress/gutenberg/pull/78526)).
 -   `Button`: Do not show the interactive cursor when disabled ([#78479](https://github.com/WordPress/gutenberg/pull/78479)).
+-   `Button`: Fix disabled and hover styles for neutral minimal buttons with `aria-pressed="true"` ([#78635](https://github.com/WordPress/gutenberg/pull/78635)).
 -   `Autocomplete`: Fix the TypeScript prop types for the `Root` and `Value` primitives ([#78450](https://github.com/WordPress/gutenberg/pull/78450)).
 -   `Autocomplete`: Disable the clear button when the autocomplete is disabled, and hide it from assistive technologies ([#78520](https://github.com/WordPress/gutenberg/pull/78520)).
 -   Apply shared item popup typography to inline lists and empty states ([#78403](https://github.com/WordPress/gutenberg/pull/78403)).

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -177,19 +177,11 @@
 		&.is-solid,
 		&.is-minimal[aria-pressed="true"] {
 			--wp-ui-button-background-color: var(--wpds-color-bg-interactive-neutral-strong);
-			--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-neutral-strong);
-			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-neutral-strong-disabled);
-			--wp-ui-button-foreground-color-disabled: var(--wpds-color-fg-interactive-neutral-strong-disabled);
-		}
-
-		&.is-solid {
 			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-neutral-strong-active);
+			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-neutral-strong-disabled);
+			--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-neutral-strong);
 			--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-neutral-strong-active);
-		}
-
-		&.is-minimal[aria-pressed="true"] {
-			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-neutral-strong);
-			--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-neutral-strong);
+			--wp-ui-button-foreground-color-disabled: var(--wpds-color-fg-interactive-neutral-strong-disabled);
 		}
 
 		/* Outline and unpressed minimal buttons use the same foreground color */

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -173,18 +173,28 @@
 	}
 
 	.is-neutral {
-		&.is-solid {
+		/* Solid and pressed minimal share the strong appearance */
+		&.is-solid,
+		&.is-minimal[aria-pressed="true"] {
 			--wp-ui-button-background-color: var(--wpds-color-bg-interactive-neutral-strong);
-			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-neutral-strong-active);
-			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-neutral-strong-disabled);
 			--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-neutral-strong);
-			--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-neutral-strong-active);
+			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-neutral-strong-disabled);
 			--wp-ui-button-foreground-color-disabled: var(--wpds-color-fg-interactive-neutral-strong-disabled);
 		}
 
-		/* Outline and minimal buttons use the same foreground color */
+		&.is-solid {
+			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-neutral-strong-active);
+			--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-neutral-strong-active);
+		}
+
+		&.is-minimal[aria-pressed="true"] {
+			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-neutral-strong);
+			--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-neutral-strong);
+		}
+
+		/* Outline and unpressed minimal buttons use the same foreground color */
 		&.is-outline,
-		&.is-minimal {
+		&.is-minimal:not([aria-pressed="true"]) {
 			--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-neutral);
 			--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-neutral-active);
 			--wp-ui-button-foreground-color-disabled: var(--wpds-color-fg-interactive-neutral-disabled);
@@ -199,7 +209,7 @@
 			--wp-ui-button-border-color-disabled: var(--wpds-color-stroke-interactive-neutral-disabled);
 		}
 
-		&.is-minimal {
+		&.is-minimal:not([aria-pressed="true"]) {
 			--wp-ui-button-background-color: var(--wpds-color-bg-interactive-neutral-weak);
 			--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-neutral-weak-active);
 			--wp-ui-button-background-color-disabled: var(--wpds-color-bg-interactive-neutral-weak-disabled);
@@ -239,12 +249,6 @@
 		}
 	}
 
-	[aria-pressed="true"].is-minimal.is-neutral {
-		--wp-ui-button-background-color: var(--wpds-color-bg-interactive-neutral-strong);
-		--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-neutral-strong);
-		--wp-ui-button-foreground-color: var(--wpds-color-fg-interactive-neutral-strong);
-		--wp-ui-button-foreground-color-active: var(--wpds-color-fg-interactive-neutral-strong);
-	}
 }
 
 @keyframes loading-animation {


### PR DESCRIPTION
## What?

Fixes disabled styling for neutral minimal buttons with `aria-pressed="true"`.

## Why?

Pressed neutral minimal buttons use the strong appearance, but disabled styles still pulled from the unpressed weak minimal tokens. That made pressed + disabled buttons look like unpressed disabled buttons.

## Testing Instructions

1. Run Storybook for `@wordpress/ui`.
2. Open **Design System/Components/Button** → **Variant States** (e2e story).
3. Compare the **minimal** column for **pressed disabled** vs **disabled** and **pressed** rows.
4. Confirm **pressed disabled** uses the strong disabled appearance (matching solid neutral disabled), not the weak minimal disabled look.

## Screenshots or screencast

| Before | After |
|--------|-------|
|<img width="1316" height="314" alt="Neutral button matrix, before" src="https://github.com/user-attachments/assets/75ce854c-3d19-4abc-8171-6085e965543d" />|<img width="1316" height="314" alt="Neutral button matrix, after" src="https://github.com/user-attachments/assets/f8e0a490-44cc-451a-b628-bf883a55a8d1" />|

