### PR TITLE
[Navigation] Close mobile overlay menu when window is resized past mobile breakpoint

### DIFF
--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -6,6 +6,7 @@ import {
 	getContext,
 	getElement,
 	withSyncEvent,
+	withScope,
 } from '@wordpress/interactivity';
 
 const focusableSelectors = [
@@ -237,6 +238,27 @@ const { state, actions } = store(
 					ctx.firstFocusableElement = focusableElements[ 0 ];
 					ctx.lastFocusableElement =
 						focusableElements[ focusableElements.length - 1 ];
+
+					const handleResize = withScope( () => {
+						const toggle = ref.parentElement?.querySelector(
+							'.wp-block-navigation__responsive-container-open'
+						);
+
+						if (
+							toggle &&
+							window.getComputedStyle( toggle ).display === 'none'
+						) {
+							actions.closeMenu( 'click' );
+							actions.closeMenu( 'focus' );
+							actions.closeMenu( 'hover' );
+						}
+					} );
+
+					window.addEventListener( 'resize', handleResize );
+
+					return () => {
+						window.removeEventListener( 'resize', handleResize );
+					};
 				}
 			},
 			focusFirstElement() {


### PR DESCRIPTION
## What?
Closes #78486

This PR ensures that the mobile navigation overlay menu automatically closes itself if a user resizes their browser window back up to a desktop screen size.

## Why?
Previously, if a user opened the mobile hamburger menu on a small screen and then expanded their browser window, the navigation overlay would remain open and stuck on top of the desktop layout. This happens because the Interactivity API was only listening for specific click or focus interactions to close the menu, completely ignoring window resize events.

## How?
Updated the `initMenu` callback inside the Navigation block's frontend script (view.js). When the mobile menu is opened, it now registers a window resize event listener.

Because standard browser events run outside of Gutenberg's engine context, wrapped the resize handler in `withScope` from `@wordpress/interactivity` to safely retain access to the block's state and context. Inside the handler, the code checks if the hamburger toggle button becomes hidden via CSS `(display: none)`. If it is hidden, we know the desktop breakpoint has been reached, and it safely fires the standard `closeMenu` actions.

## Testing Instructions

1. Add a Navigation block to a page and set the mobile overlay menu setting to "Mobile" (so the hamburger menu appears on smaller screens).
2. Save the post and view the front end of your site.
3. Shrink your browser window down until the hamburger menu appears.
4. Click the hamburger menu to open the overlay.
5. Drag your browser window wider to simulate moving to a desktop view.
6. Verify that the mobile overlay automatically disappears and you are returned cleanly to the standard desktop navigation layout.