### PR TITLE
Fix pasted image dimensions in RichText content

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -163,8 +163,11 @@ html :where([style*="border-left-width"]) {
 
 /**
  * Provide baseline responsiveness for images.
+ * The second rule covers images pasted into block RichText fields that may
+ * lack the wp-image- class (e.g. images copy/pasted into table cells).
  */
-html :where(img[class*="wp-image-"]) {
+html :where(img[class*="wp-image-"]),
+html :where([class*="wp-block-"] img) {
 	height: auto;
 	max-width: 100%;
 }


### PR DESCRIPTION
## What?

Fixes an issue where images pasted into RichText-backed block content can render at incorrect dimensions.
Closes #78342

## Why?

The current responsive image rule only applies to images with a `wp-image-*` class. Images pasted into RichText content do not always carry that class, so they can miss the baseline responsive sizing and render oversized.

## How?

This updates the shared block-library image responsiveness styling so pasted images in RichText content receive the same baseline constrained sizing.

## Testing Instructions

1. Add a Table block.
2. Paste an image into a table cell.
3. Confirm the image no longer renders oversized.
4. Repeat with another RichText-backed block such as Pullquote if needed.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:

https://github.com/user-attachments/assets/ca1f7db3-829f-4975-8656-d37f4127dac5



After:


https://github.com/user-attachments/assets/e4ef38d6-0344-48de-a297-adb512ff7674

