### PR TITLE
List View: Remove redundant visibilityLabel compoutation

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   `ListView`: Compute the block visibility label once in `ListViewBlock` and pass it down to `ListViewBlockSelectButton`, removing a duplicated `useSelect`/`getBlockVisibilityLabel` call and clarifying that the label is exposed to assistive technology through the row's `aria-describedby` ([#78640](https://github.com/WordPress/gutenberg/pull/78640)).
+
 ## 15.20.0 (2026-05-27)
 
 ### Bug Fixes

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -36,7 +36,6 @@ import { useBlockLock } from '../block-lock';
 import useListViewImages from './use-list-view-images';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import { getBlockVisibilityLabel } from '../block-visibility';
 
 const { Badge: WCBadge } = unlock( componentsPrivateApis );
 
@@ -55,6 +54,7 @@ function ListViewBlockSelectButton(
 		draggable,
 		isExpanded,
 		ariaDescribedBy,
+		visibilityLabel,
 	},
 	ref
 ) {
@@ -64,14 +64,10 @@ function ListViewBlockSelectButton(
 		context: 'list-view',
 	} );
 	const { isLocked } = useBlockLock( clientId );
-	const { hasPatternName, blockVisibility } = useSelect(
+	const hasPatternName = useSelect(
 		( select ) => {
 			const { getBlockAttributes } = unlock( select( blockEditorStore ) );
-			const attributes = getBlockAttributes( clientId );
-			return {
-				hasPatternName: !! attributes?.metadata?.patternName,
-				blockVisibility: attributes?.metadata?.blockVisibility,
-			};
+			return !! getBlockAttributes( clientId )?.metadata?.patternName;
 		},
 		[ clientId ]
 	);
@@ -79,9 +75,6 @@ function ListViewBlockSelectButton(
 	const shouldShowLockIcon = isLocked;
 	const isSticky = blockInformation?.positionType === 'sticky';
 	const images = useListViewImages( { clientId, isExpanded } );
-
-	// Determine visibility label from blockVisibility metadata
-	const visibilityLabel = getBlockVisibilityLabel( blockVisibility );
 
 	// The `href` attribute triggers the browser's native HTML drag operations.
 	// When the link is dragged, the element's outerHTML is set in DataTransfer object as text/html.
@@ -166,9 +159,12 @@ function ListViewBlockSelectButton(
 					</span>
 				) : null }
 				{ !! visibilityLabel && (
-					// TODO: `visibilityLabel` is not exposed to
-					// assistive technology — the trigger is
-					// `aria-hidden`, so the label is sighted-hover-only.
+					// The tooltip below is a sighted-hover affordance for
+					// the (decorative) visibility icon. The same
+					// `visibilityLabel` is exposed to assistive technology
+					// via the row's `aria-describedby`, which references the
+					// hidden `AriaReferencedText` rendered by the parent
+					// `ListViewBlock`.
 					<Tooltip.Root>
 						<Tooltip.Trigger
 							render={

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -630,6 +630,7 @@ function ListViewBlock( {
 							isExpanded={ canEditBlock ? isExpanded : undefined }
 							selectedClientIds={ selectedClientIds }
 							ariaDescribedBy={ descriptionId }
+							visibilityLabel={ blockVisibilityDescription }
 						/>
 						<AriaReferencedText id={ descriptionId }>
 							{ [


### PR DESCRIPTION
## What?

Addresses the inline `TODO` left in `block-select-button.js` by #78411, claiming `visibilityLabel` is sighted-hover-only.

## Why?

The TODO is misleading. The tooltip trigger is `aria-hidden`, but the parent `ListViewBlock` already includes the same label in a hidden `AriaReferencedText` that the row's `<a>` references via `aria-describedby` — so screen readers do announce it.

<details>
<summary>Pre-existing AT exposure path</summary>

```js
// packages/block-editor/src/components/list-view/block.js
const blockVisibilityDescription = getBlockVisibilityLabel(
    block?.attributes?.metadata?.blockVisibility
);
…
<AriaReferencedText id={ descriptionId }>
    { [
        blockPositionDescription,
        blockPropertiesDescription,
        blockVisibilityDescription,
    ]
        .filter( Boolean )
        .join( ' ' ) }
</AriaReferencedText>
```

The row's `<a>` already wires `aria-describedby={ descriptionId }`, so the visibility label is announced as part of the row description.

</details>

## How?

- Compute the label once in `ListViewBlock` and pass it down as a `visibilityLabel` prop.
- Drop the duplicate `useSelect` field + `getBlockVisibilityLabel` call in `ListViewBlockSelectButton`.
- Replace the TODO with a comment pointing to the parent's `AriaReferencedText`.

No visual change.

## Testing Instructions

1. Open the editor on a page with a few blocks, and mark one block as hidden (Settings → Visibility → toggle one or more viewports).
2. Open the List View.
3. Hover the visibility icon on the hidden row: the tooltip still appears with text like _"Block is hidden on Desktop, Tablet"_.

### Testing Instructions for Keyboard / Screen reader

1. With VoiceOver / NVDA / JAWS active, arrow down to the hidden row.
2. Confirm the screen reader announces the block title plus the visibility description (same announcement as before this PR).

## Screenshots or screencast

No visual change. N/A.

## Use of AI Tools

This PR was authored with assistance from Cursor (Claude). All changes were reviewed by a human before being committed.