### PR TITLE
Editor: Fix keyboard activation of the template actions preview

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bug Fixes
 
 -   `mediaFinalize` now returns the post-finalize attachment (transformed from the REST response), so the upload-media queue can refresh the in-flight attachment URL. Required for the front-end `srcset` to render on client-side-media uploads that exceeded the big-image threshold.
--   Template actions panel: Fix the keyboard activation of the "Change template" preview so it only opens the swap modal on <kbd>Enter</kbd> / <kbd>Space</kbd> instead of any character key, by replacing the deprecated `onKeyPress` handler with a key-checked `onKeyDown` handler.
+-   Template actions panel: Fix the keyboard activation of the "Change template" preview so it only opens the swap modal on <kbd>Enter</kbd> / <kbd>Space</kbd> ([#78641](https://github.com/WordPress/gutenberg/pull/78641)).
 
 ## 14.46.0 (2026-05-14)
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 -   `mediaFinalize` now returns the post-finalize attachment (transformed from the REST response), so the upload-media queue can refresh the in-flight attachment URL. Required for the front-end `srcset` to render on client-side-media uploads that exceeded the big-image threshold.
+-   Template actions panel: Fix the keyboard activation of the "Change template" preview so it only opens the swap modal on <kbd>Enter</kbd> / <kbd>Space</kbd> instead of any character key, by replacing the deprecated `onKeyPress` handler with a key-checked `onKeyDown` handler.
 
 ## 14.46.0 (2026-05-14)
 

--- a/packages/editor/src/components/template-actions-panel/block-theme-content.js
+++ b/packages/editor/src/components/template-actions-panel/block-theme-content.js
@@ -17,6 +17,7 @@ import {
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
+import { ENTER, SPACE } from '@wordpress/keycodes';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as preferencesStore } from '@wordpress/preferences';
 // eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
@@ -127,7 +128,15 @@ export default function TemplateActionsPanelContent() {
 								tabIndex={ 0 }
 								aria-label={ tooltipText }
 								onClick={ () => setIsSwapModalOpen( true ) }
-								onKeyPress={ () => setIsSwapModalOpen( true ) }
+								onKeyDown={ ( event ) => {
+									if (
+										event.keyCode === ENTER ||
+										event.keyCode === SPACE
+									) {
+										event.preventDefault();
+										setIsSwapModalOpen( true );
+									}
+								} }
 							>
 								{ previewContent }
 							</div>


### PR DESCRIPTION
## What?

Replace the deprecated `onKeyPress` handler on the **"Change template" preview** in the block-theme template actions panel with a key-checked `onKeyDown` handler, so that the swap modal only opens on <kbd>Enter</kbd> / <kbd>Space</kbd> instead of on any character key.

## Why?

Follow-up to #78466 — see [this thread](https://github.com/WordPress/gutenberg/pull/78466#discussion_r2467230033).

<details>
<summary>Background</summary>

[`onKeyPress` is deprecated in React](https://react.dev/reference/react-dom/components/common#keyboardevent-handler) and fires for any key that produces a character. On the `<div role="button" tabIndex={ 0 }>` preview that wraps the template thumbnail, that means pressing **any character key** while the preview is focused opens the swap modal — not just the standard <kbd>Enter</kbd> / <kbd>Space</kbd> button activation keys.

</details>

## How?

- Import `ENTER` and `SPACE` from `@wordpress/keycodes`.
- Replace `onKeyPress={ () => setIsSwapModalOpen( true ) }` with an `onKeyDown` handler that gates on `event.keyCode === ENTER || event.keyCode === SPACE` and calls `event.preventDefault()` before opening the modal (matches the existing pattern in `packages/block-editor/src/components/default-block-appender/index.js`).

No visual change. The `<Tooltip.Root>` / `<Tooltip.Trigger>` composition, `role`, `tabIndex`, `aria-label`, and `onClick` are all untouched.

## Testing Instructions

1. Open a page or post that uses a block theme; in the inspector sidebar, expand the **Template:** section and ensure the "Change template" preview is visible (requires more than one matching template — i.e. `hasSwapTargets` truthy).
2. Click the preview — the **Choose a template** modal should still open. ✅
3. Focus the preview via <kbd>Tab</kbd>; press any letter key (e.g. <kbd>a</kbd>). The modal should **not** open. (Before this change, it does.)
4. Focus the preview; press <kbd>Enter</kbd>. The modal should open. ✅
5. Focus the preview; press <kbd>Space</kbd>. The modal should open (and the page should not scroll). ✅

### Testing Instructions for Keyboard

Covered above — points 3–5 are the keyboard regression / fix surface.

## Screenshots or screencast

No visual change.

## Use of AI Tools

This PR was authored with assistance from Cursor (Claude). All changes were reviewed by a human before being committed.