### PR TITLE
UI: `Tooltip.Provider` — forward upstream `closeDelay` and `timeout` props

### DIFF
--- a/packages/editor/src/components/collaborators-presence/avatar/test/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar/test/index.tsx
@@ -16,13 +16,18 @@ import { Tooltip } from '@wordpress/ui';
 import Avatar from '..';
 
 /**
- * Wraps the avatar in a `Tooltip.Provider` with `delay={ 0 }` so hover-based
- * tooltip-presence assertions don't have to wait for the real-world delay.
+ * Wraps the avatar in a `Tooltip.Provider` with `delay={ 0 }` and
+ * `closeDelay={ 0 }` so hover-based tooltip-presence assertions don't have to
+ * wait for the real-world open/close delay.
  *
  * @param ui The avatar element (or anything else) to render.
  */
 function renderAvatar( ui: React.ReactElement ): ReturnType< typeof render > {
-	return render( <Tooltip.Provider delay={ 0 }>{ ui }</Tooltip.Provider> );
+	return render(
+		<Tooltip.Provider delay={ 0 } closeDelay={ 0 }>
+			{ ui }
+		</Tooltip.Provider>
+	);
 }
 
 /**

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `Tooltip.Provider`: Widen the types to accept all props of the equivalent `Tooltip.Provider` from `@base-ui/react` (types-only change) ([#78642](https://github.com/WordPress/gutenberg/pull/78642)).
+
 ## 0.14.0 (2026-05-27)
 
 ### Breaking Changes

--- a/packages/ui/src/tooltip/types.ts
+++ b/packages/ui/src/tooltip/types.ts
@@ -9,10 +9,7 @@ export type PositionerProps = ComponentProps< typeof _Tooltip.Positioner >;
 
 export type RootProps = Pick< _Tooltip.Root.Props, 'disabled' | 'children' >;
 
-export type ProviderProps = Pick<
-	_Tooltip.Provider.Props,
-	'delay' | 'children'
->;
+export type ProviderProps = _Tooltip.Provider.Props;
 
 export interface TriggerProps extends ComponentProps< 'button' > {
 	/**


### PR DESCRIPTION
## What?

Widen `Tooltip.Provider`'s public type to expose the full upstream `@base-ui/react` `Tooltip.Provider` props (previously only `delay` and `children` were typed publicly; `closeDelay` and `timeout` were already forwarded at runtime but invisible to TypeScript consumers).

## Why?

Follow-up to #78466 — see [this thread](https://github.com/WordPress/gutenberg/pull/78466#discussion_r2467229517).

<details>
<summary>Upstream <code>Tooltip.Provider</code> props</summary>

| Prop          | Description                                                                                                                |
| ------------- | -------------------------------------------------------------------------------------------------------------------------- |
| `delay`       | How long to wait before opening a tooltip.                                                                                  |
| `closeDelay`  | How long to wait before closing a tooltip.                                                                                  |
| `timeout`     | Another tooltip will open instantly if the previous tooltip is closed within this timeout (default `400`).                  |
| `children`    | The provider's children.                                                                                                    |

</details>

## How?

- Replace the `Pick< _Tooltip.Provider.Props, 'delay' | 'children' >` with the full `_Tooltip.Provider.Props` in `packages/ui/src/tooltip/types.ts`. No runtime change in `provider.tsx`: it already spreads `{ ...props }` straight through to the upstream provider — this is a types-only widening.
- Restore `closeDelay={ 0 }` on the `renderAvatar` `Tooltip.Provider` wrapper in `packages/editor/src/components/collaborators-presence/avatar/test/index.tsx` — it was temporarily removed in #78466 because the prop wasn't yet part of the typed API surface.

## Testing Instructions

1. `npm run test:unit -- packages/ui packages/editor` — Jest unit tests should pass.
2. `npx tsc -p packages/ui --noEmit` — type-check should pass.

### Testing Instructions for Keyboard

No behavioural change for keyboard users; this only widens the public type surface of the provider.

## Screenshots or screencast

N/A — type-only change to `@wordpress/ui`.

## Use of AI Tools

This PR was authored with assistance from Cursor (Claude). All changes were reviewed by a human before being committed.
