### PR TITLE
Media Editor: Remove redundant Cancel button from the modal header

### DIFF
--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -176,15 +176,6 @@ function HeaderActions( {
 			<PinnedItems.Slot scope="media-editor" />
 			<Button
 				size="compact"
-				variant="tertiary"
-				onClick={ onCancel }
-				disabled={ isSaving }
-				accessibleWhenDisabled
-			>
-				{ __( 'Cancel' ) }
-			</Button>
-			<Button
-				size="compact"
 				variant="primary"
 				onClick={ onSave }
 				isBusy={ isSaving }


### PR DESCRIPTION
## What?

Removes the explicit **Cancel** button from the media editor modal's header. The header's existing **X (Close)** button continues to handle dismissal — including the unsaved-changes confirmation flow — so the user keeps the same exit affordance with less visual weight.

Before: `[Cancel] [Save] [X]`
After:  `[Save] [X]`

## Why?

The Cancel button and the X both call the same `onCancel` handler, so they were duplicate controls. The X is the conventional modal-dismiss affordance and is the smaller, less attention-grabbing of the two, which lets **Save** stand alone as the only labelled action in the header.

## Testing instructions

1. Open the site editor (or any editor surface that opens the media editor modal).
2. Open an image in the media editor.
3. Confirm only the **Save** button and the **X** close icon appear in the modal header (no **Cancel** button).
4. Make a change (e.g., crop), then click the **X**. Confirm the discard-changes confirmation still appears.
5. With no changes pending, click **X**. Confirm the modal closes immediately.
6. Press `Esc`. Confirm the same close/confirm behaviour.