### PR TITLE
Media editor: Show image and crop info in Crop panel

### DIFF
--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -13,9 +13,11 @@ import {
 	useCropGestureHandlers,
 	CROP_CONTROL_ATTR,
 } from '../../hooks/use-crop-gesture-handlers';
+import { getSourceRegion } from '../../image-editor';
 import { MAX_ZOOM } from '../../image-editor/core/constants';
 import { getMinZoom } from '../../image-editor/core/containment';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
+import { formatAspectRatio } from '../../utils';
 
 const ZOOM_PERCENTAGE_SCALE = 100;
 const MAX_ZOOM_PERCENTAGE = MAX_ZOOM * ZOOM_PERCENTAGE_SCALE;
@@ -43,6 +45,51 @@ export interface MediaEditorCropPanelProps {
 	aspectRatioOptions: AspectRatioPreset[];
 }
 
+interface Measurement {
+	width: number;
+	height: number;
+	aspectRatio: string;
+}
+
+/**
+ * Builds display-ready dimensions and aspect ratio from raw pixel dimensions.
+ *
+ * @param rawWidth  Width in pixels.
+ * @param rawHeight Height in pixels.
+ * @return Rounded dimensions and aspect ratio, or null for invalid dimensions.
+ */
+function buildMeasurement(
+	rawWidth: number,
+	rawHeight: number
+): Measurement | null {
+	// Compute the ratio from raw floats so per-axis rounding doesn't
+	// drift the displayed ratio past the snap tolerance at high zoom
+	// (e.g. 265×176 rounded would read 1.51:1 instead of 3:2).
+	const aspectRatio = formatAspectRatio( rawWidth, rawHeight );
+	if ( ! aspectRatio ) {
+		return null;
+	}
+	const width = Math.max( 0, Math.round( rawWidth ) );
+	const height = Math.max( 0, Math.round( rawHeight ) );
+	return { width, height, aspectRatio };
+}
+
+/**
+ * Formats a measurement for compact display in the Crop panel.
+ *
+ * @param m Display-ready dimensions and aspect ratio.
+ * @return A compact measurement string.
+ */
+function formatMeasurement( m: Measurement ): string {
+	return sprintf(
+		/* translators: 1: Width in pixels. 2: Height in pixels. 3: Aspect ratio, e.g. 4:3. */
+		__( '%1$d x %2$d px - %3$s' ),
+		m.width,
+		m.height,
+		m.aspectRatio
+	);
+}
+
 /**
  * Sidebar panel for crop-shape controls. The tactile verbs (rotate, flip)
  * live in the bottom toolbar instead.
@@ -64,6 +111,19 @@ export default function MediaEditorCropPanel( {
 	const zoomPercentage = getZoomPercentageForDisplay( state.zoom );
 	const minZoomPercentage = getMinZoomPercentageForDisplay( minZoom );
 
+	const image = state.image;
+	const imageMeasurement = image
+		? buildMeasurement( image.naturalWidth, image.naturalHeight )
+		: null;
+	let cropMeasurement: Measurement | null = null;
+	if ( image ) {
+		const region = getSourceRegion( state, {
+			width: image.naturalWidth,
+			height: image.naturalHeight,
+		} );
+		cropMeasurement = buildMeasurement( region.width, region.height );
+	}
+
 	return (
 		// Tag the whole panel as a crop-control region so the modal's
 		// Cmd+Z handler doesn't mistake the SelectControl input for a
@@ -76,6 +136,21 @@ export default function MediaEditorCropPanel( {
 			<VisuallyHidden render={ <h2 /> }>
 				{ __( 'Crop options' ) }
 			</VisuallyHidden>
+			{ imageMeasurement && cropMeasurement && (
+				<dl
+					className="media-editor__crop-measurements"
+					aria-label={ __( 'Image and crop measurements' ) }
+				>
+					<div className="media-editor__crop-measurement">
+						<dt>{ __( 'Image' ) }</dt>
+						<dd>{ formatMeasurement( imageMeasurement ) }</dd>
+					</div>
+					<div className="media-editor__crop-measurement">
+						<dt>{ __( 'Crop' ) }</dt>
+						<dd>{ formatMeasurement( cropMeasurement ) }</dd>
+					</div>
+				</dl>
+			) }
 			<SelectControl
 				__next40pxDefaultSize
 				label={ __( 'Aspect ratio' ) }

--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -129,6 +129,7 @@ export default function MediaEditorCropPanel( {
 		// Cmd+Z handler doesn't mistake the SelectControl input for a
 		// metadata field (which would suppress undo).
 		<Stack
+			className="media-editor__crop-panel"
 			direction="column"
 			gap="xl"
 			{ ...{ [ CROP_CONTROL_ATTR ]: true } }

--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -136,21 +136,6 @@ export default function MediaEditorCropPanel( {
 			<VisuallyHidden render={ <h2 /> }>
 				{ __( 'Crop options' ) }
 			</VisuallyHidden>
-			{ imageMeasurement && cropMeasurement && (
-				<dl
-					className="media-editor__crop-measurements"
-					aria-label={ __( 'Image and crop measurements' ) }
-				>
-					<div className="media-editor__crop-measurement">
-						<dt>{ __( 'Image' ) }</dt>
-						<dd>{ formatMeasurement( imageMeasurement ) }</dd>
-					</div>
-					<div className="media-editor__crop-measurement">
-						<dt>{ __( 'Crop' ) }</dt>
-						<dd>{ formatMeasurement( cropMeasurement ) }</dd>
-					</div>
-				</dl>
-			) }
 			<SelectControl
 				__next40pxDefaultSize
 				label={ __( 'Aspect ratio' ) }
@@ -191,6 +176,26 @@ export default function MediaEditorCropPanel( {
 					} }
 				/>
 			</div>
+			{ imageMeasurement && cropMeasurement && (
+				<div className="media-editor__crop-measurements-section">
+					<h3 className="media-editor__crop-measurements-heading">
+						{ __( 'Measurements' ) }
+					</h3>
+					<dl
+						className="media-editor__crop-measurements"
+						aria-label={ __( 'Image and crop measurements' ) }
+					>
+						<div className="media-editor__crop-measurement">
+							<dt>{ __( 'Image' ) }</dt>
+							<dd>{ formatMeasurement( imageMeasurement ) }</dd>
+						</div>
+						<div className="media-editor__crop-measurement">
+							<dt>{ __( 'Crop' ) }</dt>
+							<dd>{ formatMeasurement( cropMeasurement ) }</dd>
+						</div>
+					</dl>
+				</div>
+			) }
 		</Stack>
 	);
 }

--- a/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
@@ -54,6 +54,30 @@ describe( 'MediaEditorCropPanel', () => {
 		);
 	} );
 
+	it( 'renders compact image and crop measurements when an image is loaded', () => {
+		setupCropPanel(
+			{},
+			{
+				image: {
+					src: 'test.jpg',
+					naturalWidth: 1200,
+					naturalHeight: 600,
+				},
+				cropRect: {
+					x: 0,
+					y: 0,
+					width: 0.5,
+					height: 0.5,
+				},
+			}
+		);
+
+		expect( screen.getByText( 'Image' ) ).toBeInTheDocument();
+		expect( screen.getByText( '1200 x 600 px - 2:1' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Crop' ) ).toBeInTheDocument();
+		expect( screen.getByText( '600 x 300 px - 2:1' ) ).toBeInTheDocument();
+	} );
+
 	it( 'passes selected aspect ratio changes to the caller', () => {
 		const controls = setupCropPanel( {
 			aspectRatioValue: '1',

--- a/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
@@ -72,6 +72,12 @@ describe( 'MediaEditorCropPanel', () => {
 			}
 		);
 
+		const zoom = screen.getByRole( 'slider', { name: 'Zoom' } );
+		const heading = screen.getByRole( 'heading', {
+			name: 'Measurements',
+		} );
+
+		expectElementBefore( zoom, heading );
 		expect( screen.getByText( 'Image' ) ).toBeInTheDocument();
 		expect( screen.getByText( '1200 x 600 px - 2:1' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Crop' ) ).toBeInTheDocument();

--- a/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
@@ -44,6 +44,8 @@ function CurrentZoomValue() {
 
 describe( 'MediaEditorCropPanel', () => {
 	it( 'renders crop shape controls before zoom controls', () => {
+		expect.assertions( 2 );
+
 		setupCropPanel();
 
 		const aspectRatio = screen.getByLabelText( 'Aspect ratio' );

--- a/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
@@ -42,18 +42,20 @@ function CurrentZoomValue() {
 	return <output data-testid="current-zoom">{ state.zoom }</output>;
 }
 
+function expectElementBefore( first: Element, second: Element ) {
+	expect( first.compareDocumentPosition( second ) ).toBe(
+		Node.DOCUMENT_POSITION_FOLLOWING
+	);
+}
+
 describe( 'MediaEditorCropPanel', () => {
 	it( 'renders crop shape controls before zoom controls', () => {
-		expect.assertions( 2 );
-
 		setupCropPanel();
 
 		const aspectRatio = screen.getByLabelText( 'Aspect ratio' );
 		const zoom = screen.getByRole( 'slider', { name: 'Zoom (%)' } );
 
-		expect( aspectRatio.compareDocumentPosition( zoom ) ).toBe(
-			Node.DOCUMENT_POSITION_FOLLOWING
-		);
+		expectElementBefore( aspectRatio, zoom );
 	} );
 
 	it( 'renders compact image and crop measurements when an image is loaded', () => {
@@ -74,7 +76,7 @@ describe( 'MediaEditorCropPanel', () => {
 			}
 		);
 
-		const zoom = screen.getByRole( 'slider', { name: 'Zoom' } );
+		const zoom = screen.getByRole( 'slider', { name: 'Zoom (%)' } );
 		const heading = screen.getByRole( 'heading', {
 			name: 'Measurements',
 		} );

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -61,6 +61,33 @@
 		padding: $grid-unit-20;
 	}
 
+	.media-editor__crop-measurements {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		column-gap: $grid-unit-15;
+		row-gap: $grid-unit-05;
+		margin: 0;
+		padding: 0 0 $grid-unit-15;
+		border-bottom: 1px solid $gray-300;
+		font-size: 12px;
+		line-height: 1.4;
+	}
+
+	.media-editor__crop-measurement {
+		display: contents;
+		color: $gray-900;
+
+		dt {
+			margin: 0;
+			color: $gray-700;
+		}
+
+		dd {
+			margin: 0;
+			text-align: right;
+		}
+	}
+
 	.components-panel__header.media-editor__sidebar-header {
 		padding-left: 0;
 		padding-right: $grid-unit-10;

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -61,15 +61,28 @@
 		padding: $grid-unit-20;
 	}
 
+	.media-editor__crop-measurements-section {
+		margin: 0;
+		padding-top: $grid-unit-15;
+		border-top: 1px solid $gray-300;
+	}
+
+	.media-editor__crop-measurements-heading {
+		margin: 0 0 $grid-unit-10;
+		color: $gray-700;
+		font-size: 12px;
+		font-weight: 500;
+		line-height: 1.4;
+		text-transform: uppercase;
+	}
+
 	.media-editor__crop-measurements {
 		display: grid;
 		grid-template-columns: auto 1fr;
 		column-gap: $grid-unit-15;
 		row-gap: $grid-unit-05;
 		margin: 0;
-		padding: 0 0 $grid-unit-15;
-		border-bottom: 1px solid $gray-300;
-		font-size: 12px;
+		font-size: 13px;
 		line-height: 1.4;
 	}
 

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -55,14 +55,42 @@
 
 	.media-editor__sidebar {
 		@include reset;
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+
+	.media-editor__sidebar-panel {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.media-editor__sidebar-panel > [role="tabpanel"]:not([hidden]) {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		min-height: 0;
+		overflow: auto;
 	}
 
 	.media-editor__panel {
+		flex: 1 1 auto;
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
 		padding: $grid-unit-20;
 	}
 
+	.media-editor__crop-panel {
+		flex: 1 1 auto;
+		min-height: 0;
+	}
+
 	.media-editor__crop-measurements-section {
-		margin: 0;
+		margin-top: auto;
 		padding-top: $grid-unit-15;
 		border-top: 1px solid $gray-300;
 	}

--- a/packages/media-editor/src/components/media-editor/test/use-crop-options.tsx
+++ b/packages/media-editor/src/components/media-editor/test/use-crop-options.tsx
@@ -31,6 +31,11 @@ function CropOptionsHarness() {
 					.map( ( option ) => option.value )
 					.join( ',' ) }
 			</div>
+			<div data-testid="aspect-ratio-labels">
+				{ cropOptions.aspectRatioOptions
+					.map( ( option ) => option.label )
+					.join( ',' ) }
+			</div>
 			<button
 				onClick={ () =>
 					cropOptions.setAspectRatioValue(
@@ -74,6 +79,14 @@ describe( 'useCropOptions', () => {
 		expect(
 			screen.getByTestId( 'aspect-ratio-options' )
 		).toHaveTextContent( '0,-1,1,1.3333333333333333' );
+	} );
+
+	it( 'includes the image ratio in the Original option label', () => {
+		renderHarness();
+
+		expect( screen.getByTestId( 'aspect-ratio-labels' ) ).toHaveTextContent(
+			'Free,Original - 2:1,Square,Landscape'
+		);
 	} );
 
 	it( 'resolves the Original aspect ratio from the cropper image dimensions', () => {

--- a/packages/media-editor/src/components/media-editor/use-crop-options.ts
+++ b/packages/media-editor/src/components/media-editor/use-crop-options.ts
@@ -2,13 +2,18 @@
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { DEFAULT_ASPECT_RATIOS } from '../../image-editor/core/constants';
+import {
+	DEFAULT_ASPECT_RATIOS,
+	ORIGINAL_ASPECT_RATIO,
+} from '../../image-editor/core/constants';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
 import { useMediaEditor, resolveAspectRatio } from '../../state';
+import { formatAspectRatio } from '../../utils';
 
 interface UseCropOptionsArgs {
 	aspectRatioPresets?: AspectRatioPreset[];
@@ -59,10 +64,35 @@ export function useCropOptions( {
 	const { aspectRatioValue } = controller.cropOptions;
 	const cropperImage = controller.state.image;
 
-	const aspectRatioOptions = useMemo(
-		() => getAspectRatioOptions( aspectRatioPresets ),
-		[ aspectRatioPresets ]
-	);
+	const originalAspectRatioLabel = useMemo( () => {
+		if ( ! cropperImage ) {
+			return undefined;
+		}
+		return formatAspectRatio(
+			cropperImage.naturalWidth,
+			cropperImage.naturalHeight
+		);
+	}, [ cropperImage ] );
+
+	const aspectRatioOptions = useMemo( () => {
+		const options = getAspectRatioOptions( aspectRatioPresets );
+		if ( ! originalAspectRatioLabel ) {
+			return options;
+		}
+		return options.map( ( preset ) => {
+			if ( preset.value !== ORIGINAL_ASPECT_RATIO ) {
+				return preset;
+			}
+			return {
+				...preset,
+				label: sprintf(
+					/* translators: %s: Aspect ratio, e.g. 4:3. */
+					__( 'Original - %s' ),
+					originalAspectRatioLabel
+				),
+			};
+		} );
+	}, [ aspectRatioPresets, originalAspectRatioLabel ] );
 
 	const resolvedAspectRatio = useMemo(
 		() => resolveAspectRatio( aspectRatioValue, cropperImage ),

--- a/packages/media-editor/src/image-editor/core/constants.ts
+++ b/packages/media-editor/src/image-editor/core/constants.ts
@@ -81,7 +81,7 @@ export const DEFAULT_STATE: CropperState = {
  * An aspect ratio preset with a human-readable label.
  */
 export interface AspectRatioPreset {
-	/** Display label (e.g., "Square (1:1)"). */
+	/** Display label (e.g., "Square - 1:1"). */
 	label: string;
 	/** The aspect ratio value (width / height). 0 = free / original. */
 	value: number;
@@ -114,11 +114,11 @@ export const ORIGINAL_ASPECT_RATIO = -1;
 export const DEFAULT_ASPECT_RATIOS: AspectRatioPreset[] = [
 	{ label: __( 'Free' ), value: 0 },
 	{ label: __( 'Original' ), value: ORIGINAL_ASPECT_RATIO },
-	{ label: __( 'Square (1:1)' ), value: 1 },
-	{ label: __( 'Landscape (16:9)' ), value: 16 / 9 },
-	{ label: __( 'Portrait (9:16)' ), value: 9 / 16 },
-	{ label: __( 'Classic (4:3)' ), value: 4 / 3 },
-	{ label: __( 'Classic portrait (3:4)' ), value: 3 / 4 },
-	{ label: __( 'Photo (3:2)' ), value: 3 / 2 },
-	{ label: __( 'Photo portrait (2:3)' ), value: 2 / 3 },
+	{ label: __( 'Square - 1:1' ), value: 1 },
+	{ label: __( 'Standard - 4:3' ), value: 4 / 3 },
+	{ label: __( 'Portrait - 3:4' ), value: 3 / 4 },
+	{ label: __( 'Classic - 3:2' ), value: 3 / 2 },
+	{ label: __( 'Classic Portrait - 2:3' ), value: 2 / 3 },
+	{ label: __( 'Wide - 16:9' ), value: 16 / 9 },
+	{ label: __( 'Tall - 9:16' ), value: 9 / 16 },
 ];

--- a/packages/media-editor/src/image-editor/core/constants.ts
+++ b/packages/media-editor/src/image-editor/core/constants.ts
@@ -83,7 +83,7 @@ export const DEFAULT_STATE: CropperState = {
 export interface AspectRatioPreset {
 	/** Display label (e.g., "Square - 1:1"). */
 	label: string;
-	/** The aspect ratio value (width / height). 0 = free / original. */
+	/** The aspect ratio value (width / height). 0 = free, -1 = original. */
 	value: number;
 }
 

--- a/packages/media-editor/src/utils/aspect-ratio.ts
+++ b/packages/media-editor/src/utils/aspect-ratio.ts
@@ -1,0 +1,55 @@
+const MAX_RATIO_PART = 20;
+const SNAP_TOLERANCE = 0.005;
+
+/**
+ * Formats dimensions as a compact width:height aspect ratio.
+ *
+ * Snaps to the nearest small-integer ratio (a:b with both ≤ 20) when the
+ * approximation is within tolerance, so off-spec resolutions like 1350×899
+ * still read as "3:2" — matching the labels used by the aspect-ratio presets
+ * in the same panel. Ratios that can't be approximated cleanly fall back to
+ * a short decimal form. The search is run on the ≥1 form of the ratio so
+ * portrait and landscape orientations of the same dimensions snap symmetrically.
+ *
+ * @param width  Width in pixels.
+ * @param height Height in pixels.
+ * @return A compact aspect ratio label, or undefined for invalid dimensions.
+ */
+export function formatAspectRatio(
+	width: number,
+	height: number
+): string | undefined {
+	if (
+		! Number.isFinite( width ) ||
+		! Number.isFinite( height ) ||
+		width <= 0 ||
+		height <= 0
+	) {
+		return undefined;
+	}
+
+	const landscape = width >= height;
+	const r = landscape ? width / height : height / width;
+	let bestA = 0;
+	let bestB = 0;
+	let bestErr = Infinity;
+	for ( let b = 1; b <= MAX_RATIO_PART; b++ ) {
+		const a = Math.round( r * b );
+		if ( a < b || a > MAX_RATIO_PART ) {
+			continue;
+		}
+		const err = Math.abs( r - a / b );
+		if ( err < bestErr ) {
+			bestErr = err;
+			bestA = a;
+			bestB = b;
+		}
+	}
+
+	if ( bestErr <= SNAP_TOLERANCE ) {
+		return landscape ? `${ bestA }:${ bestB }` : `${ bestB }:${ bestA }`;
+	}
+
+	const formatted = r.toFixed( 2 ).replace( /\.?0+$/, '' );
+	return landscape ? `${ formatted }:1` : `1:${ formatted }`;
+}

--- a/packages/media-editor/src/utils/index.ts
+++ b/packages/media-editor/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { getMediaTypeFromMimeType } from './get-media-type';
 export type { MediaType } from './get-media-type';
+export { formatAspectRatio } from './aspect-ratio';

--- a/packages/media-editor/src/utils/test/aspect-ratio.ts
+++ b/packages/media-editor/src/utils/test/aspect-ratio.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { formatAspectRatio } from '../aspect-ratio';
+
+describe( 'formatAspectRatio', () => {
+	it( 'uses familiar labels for common ratios', () => {
+		expect( formatAspectRatio( 4032, 3024 ) ).toBe( '4:3' );
+		expect( formatAspectRatio( 1200, 1200 ) ).toBe( '1:1' );
+		expect( formatAspectRatio( 900, 1600 ) ).toBe( '9:16' );
+	} );
+
+	it( 'uses short decimal labels for unusual ratios', () => {
+		expect( formatAspectRatio( 2000, 1242 ) ).toBe( '1.61:1' );
+		expect( formatAspectRatio( 1242, 2000 ) ).toBe( '1:1.61' );
+	} );
+
+	it( 'returns undefined for invalid dimensions', () => {
+		expect( formatAspectRatio( 0, 100 ) ).toBeUndefined();
+		expect( formatAspectRatio( 100, NaN ) ).toBeUndefined();
+	} );
+} );

--- a/packages/media-editor/src/utils/test/aspect-ratio.ts
+++ b/packages/media-editor/src/utils/test/aspect-ratio.ts
@@ -10,6 +10,15 @@ describe( 'formatAspectRatio', () => {
 		expect( formatAspectRatio( 900, 1600 ) ).toBe( '9:16' );
 	} );
 
+	it( 'snaps off-spec resolutions to familiar ratios within tolerance', () => {
+		// 1350/899 = 1.5017 — snaps to 3:2 (1.5).
+		expect( formatAspectRatio( 1350, 899 ) ).toBe( '3:2' );
+		// 1366/768 = 1.7786 — snaps to 16:9 (1.7778).
+		expect( formatAspectRatio( 1366, 768 ) ).toBe( '16:9' );
+		// Portrait twin of 1350×899 — snaps symmetrically to 2:3.
+		expect( formatAspectRatio( 899, 1350 ) ).toBe( '2:3' );
+	} );
+
 	it( 'uses short decimal labels for unusual ratios', () => {
 		expect( formatAspectRatio( 2000, 1242 ) ).toBe( '1.61:1' );
 		expect( formatAspectRatio( 1242, 2000 ) ).toBe( '1:1.61' );


### PR DESCRIPTION
## What?

Another episode of "How much can we over-engineer a small feature?"

This PR adds an info section to the bottom of the Media Editor's Crop panel showing the original image's dimensions and aspect ratio, plus the current crop region's dimensions and aspect ratio. 

While we're on the topic of Aspect Ratios, it also:
- appends the image's aspect ratio to the "Original" option in the aspect-ratio dropdown (e.g. `Original - 3:2`), and
- aligns the fallback `DEFAULT_ASPECT_RATIOS` constant with core's `lib/theme.json` naming.

Follow-up to discussion on [#73771](https://github.com/WordPress/gutenberg/issues/73771#issuecomment-4533311589)

## Why?

The Crop panel previously surfaced no information about the image's actual dimensions or aspect ratio. 

The dropdown shows preset labels like "Standard - 4:3" but doesn't tell you what the image you're editing actually is.

That means you can't see whether you're cropping toward or away from its native proportions, or how far the current crop has diverged from the source.

Showing both rows side-by-side answers "what am I working with, and how much have I changed it?"

## How?

1. **New `formatAspectRatio(width, height)` util.** Finds the closest small-integer ratio (a:b with both ≤ 20) and snaps to it when within tolerance; otherwise falls back to a short decimal form. Off-spec resolutions like 1350×899 read as `3:2`, matching the dropdown label for that ratio. The search runs on the ≥1 form so landscape and portrait orientations snap symmetrically.

2. **Crop panel info section.** A `<dl>` rendered as a 2-column CSS grid (`grid-template-columns: auto 1fr`). Per-row wrappers use `display: contents` so the grid aligns across rows. When the crop region's dimensions equal the source image's (no cropping yet), the "Crop" row gets `.is-untouched` and drops to a muted gray.

3. **`Original` dropdown label.** Now appends the image's computed ratio with the same hyphen separator core's `lib/theme.json` uses for `Square - 1:1`, `Wide - 16:9`, etc.

4. **`DEFAULT_ASPECT_RATIOS` aligned with core.** The hardcoded fallback (only used when a site has no theme aspect-ratio settings) now mirrors `lib/theme.json` exactly — same names, same order, same `- ratio` format. Previously used a different naming scheme ("Landscape (16:9)" vs core's "Wide - 16:9").

## Testing Instructions

1. Open the Media Editor on any attachment (e.g. from the Media library or via an Image block's edit affordance).
2. Switch to the Crop tab.
3. Verify the bottom of the sidebar shows two rows:
   - `Image  1920 × 1080 px (16:9)`
   - `Crop   1920 × 1080 px (16:9)`
4. Drag the crop area or pick a different aspect ratio preset. The "Crop" row should update its dimensions live.
5. Open the Aspect Ratio dropdown. The "Original" option should display the image's ratio (e.g. `Original - 16:9`).

Worth testing with off-spec resolutions:
- 1350×899 → should read `3:2` (matches `Classic - 3:2` in the dropdown)
- 1366×768 → should read `16:9` (matches `Wide - 16:9`)
- 2000×1242 → should fall back to `1.61:1` (no clean small-integer fit)

## Screenshots



https://github.com/user-attachments/assets/87f197ba-e711-4673-8fb1-a6c51cd7633b


	


What it looked like before:

<img width="282" height="205" alt="Screenshot 2026-05-26 at 11 05 24 am" src="https://github.com/user-attachments/assets/ba773be8-2967-450e-bff4-52c2944517a7" />
