### PR TITLE
Media Editor: make the modal the default crop experience

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -33,9 +33,6 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-media-editor' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalMediaEditor = true', 'before' );
 	}
-	if ( gutenberg_is_experiment_enabled( 'gutenberg-media-editor-modal' ) ) {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalMediaEditorModal = true', 'before' );
-	}
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-dashboard-widgets' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalDashboardWidgets = true', 'before' );
 	}

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -51,11 +51,6 @@ function gutenberg_initialize_experiments_settings() {
 					'description' => __( 'Enables a dedicated route-based media editor screen for editing media items (metadata and content).', 'gutenberg' ),
 				),
 				array(
-					'id'          => 'gutenberg-media-editor-modal',
-					'label'       => __( 'Media Editor Modal', 'gutenberg' ),
-					'description' => __( 'Enables an in-place modal for image editing — cropping, adjustments, and metadata — opened from blocks like the image block without navigating away from the current post.', 'gutenberg' ),
-				),
-				array(
 					'id'          => 'gutenberg-dataviews-media-modal',
 					'label'       => __( 'Media Upload Modal', 'gutenberg' ),
 					'description' => __( 'Replaces the existing WordPress media modal with a new modal powered by Data Views, supporting browsing, selecting, and uploading media.', 'gutenberg' ),

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   Editor: Add padding around inline notices in the editor content area and distraction-free header.
+-   The Media Editor modal is now mounted unconditionally and the `openMediaEditorModal` setting is always provided to the block editor. Previously both were gated behind the `gutenberg-media-editor-modal` experiment, which has been removed.
 
 ### Bug Fixes
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -447,9 +447,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 									<StartTemplateOptions />
 									<PatternRenameModal />
 									<PatternDuplicateModal />
-									{ window?.__experimentalMediaEditorModal && (
-										<MediaEditorModalMount />
-									) }
+									<MediaEditorModalMount />
 								</>
 							) }
 						</BlockEditorProviderComponent>

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -351,10 +351,8 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			[ mediaEditKey ]: hasUploadPermissions
 				? editMediaEntity
 				: undefined,
-			[ openMediaEditorModalKey ]: window?.__experimentalMediaEditorModal
-				? ( { id, onUpdate } ) =>
-						openMediaEditorModal( { id, onUpdate } )
-				: undefined,
+			[ openMediaEditorModalKey ]: ( { id, onUpdate } ) =>
+				openMediaEditorModal( { id, onUpdate } ),
 			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,
 			[ mediaUploadOnSuccessKey ]: hasUploadPermissions
 				? mediaUploadOnSuccess


### PR DESCRIPTION
## What?

Makes the Media Editor modal the default crop experience for image content in the editor. The modal has been opt-in behind the `gutenberg-media-editor-modal` experiment since #77480.  

This PR removes that experiment and always mounts the modal.

> [!NOTE]
> This is deliberately the **minimum** change to flip the default. 

Consumer code in the Image and Site Logo blocks is not touched here, and the inline `__experimentalImageEditor` component remains in the tree as (now unreachable) code. 

A follow-up PR will do the cleanup. See the draft PR to get an idea of what's involved:

- https://github.com/WordPress/gutenberg/pull/78652

## Why?

The modal-based cropper has stabilized. Keeping it behind an experiment means the default cropping experience that ships in Core is still the older inline cropper. Flipping the default now lets us collect feedback on the modal as the real, observed crop UX rather than something only opt-in users see.

See also: https://make.wordpress.org/core/2026/05/21/media-editor-modal-call-for-testing/

## How?

Three behaviour changes:

1. Remove the experiment registration from the Experiments screen (`lib/experimental/experiments/load.php`).
2. Remove the PHP bridge that set `window.__experimentalMediaEditorModal` (`lib/experimental/editor-settings.php`).
3. Remove the JS gates in the editor provider so the modal is always mounted and the `openMediaEditorModal` block-editor setting is always supplied (`packages/editor/src/components/provider/`).

After these changes, the existing toolbar branches in the Image and Site Logo blocks (which check `openMediaEditorModal ? open : inline`) always resolve to the modal because the callback is now always defined. No consumer-side code needs to change for this PR.

Reverting this PR puts the modal back behind the experiment toggle with no other side effects.

## Testing Instructions

1. Apply this branch and rebuild.
2. Insert an Image block, upload an image, click the Crop toolbar button. The Media Editor modal should open. (Previously you would have seen the inline cropper unless you had the experiment toggled on.)
3. Repeat for Site Logo in the Site Editor.
4. Visit `wp-admin > Gutenberg > Experiments`. Confirm "Media Editor Modal" is no longer listed.

## Screenshots or screencast


https://github.com/user-attachments/assets/8e75e415-f573-4ab1-aef4-733c08e9c873


