### PR TITLE
Media Editor: remove inline cropper (follow-up to #78653)

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Deprecations
+
+-   Soft-deprecate the `__experimentalImageEditor` component. The Media Editor modal is now the default crop experience for core blocks ([#78654](https://github.com/WordPress/gutenberg/pull/78654)).
+
 ## 15.22.0 (2026-06-24)
 
 ### Enhancements

--- a/packages/block-editor/src/components/image-editor/index.js
+++ b/packages/block-editor/src/components/image-editor/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { ToolbarGroup, ToolbarItem } from '@wordpress/components';
+import deprecated from '@wordpress/deprecated';
 import { ImageCropperProvider } from '@wordpress/image-cropper';
 
 /**
@@ -15,6 +16,22 @@ import ZoomDropdown from './zoom-dropdown';
 import RotationButton from './rotation-button';
 import FormControls from './form-controls';
 
+/**
+ * @deprecated since 7.1. The Media Editor modal is now the default crop
+ * experience for core blocks. This component (exported as
+ * `__experimentalImageEditor`) will be removed in a future major release.
+ *
+ * @param {Object}   root0                 Component props.
+ * @param {number}   root0.id              Media attachment ID.
+ * @param {string}   root0.url             Media URL.
+ * @param {number}   root0.width           Rendered image width.
+ * @param {number}   root0.height          Rendered image height.
+ * @param {number}   root0.naturalHeight   Natural image height.
+ * @param {number}   root0.naturalWidth    Natural image width.
+ * @param {Function} root0.onSaveImage     Callback to save image attributes.
+ * @param {Function} root0.onFinishEditing Callback when editing finishes.
+ * @param {Object}   root0.borderProps     Border classes and styles.
+ */
 export default function ImageEditor( {
 	id,
 	url,
@@ -26,6 +43,11 @@ export default function ImageEditor( {
 	onFinishEditing,
 	borderProps,
 } ) {
+	deprecated( 'wp.blockEditor.__experimentalImageEditor', {
+		since: '7.1',
+		hint: 'The Media Editor modal is now the default crop experience for core blocks. This component will be removed in a future major release.',
+	} );
+
 	return (
 		<ImageCropperProvider>
 			<ImageEditingProvider

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Enhancements
 
+-   Image and Site Logo blocks: the Crop toolbar button now opens the Media Editor modal instead of an inline cropper. The previous inline experience is removed ([#78654](https://github.com/WordPress/gutenberg/pull/78654)).
 -   Search: Expose an HTML element selector in the Advanced inspector panel that can render the block in the semantic HTML `<search>` landmark element instead of `<form role="search">`. Defers to `add_theme_support( 'html5', array( 'search-element' ) )` when the per-block value is left at "Default".
 -   Icon Block: Insert with a default icon instead of an empty placeholder ([#79111](https://github.com/WordPress/gutenberg/pull/79111)).
 

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -34,7 +34,6 @@ import {
 	MediaReplaceFlow,
 	store as blockEditorStore,
 	useSettings,
-	__experimentalImageEditor as ImageEditor,
 	__experimentalUseBorderProps as useBorderProps,
 	__experimentalGetShadowClassesAndStyles as getShadowClassesAndStyles,
 	privateApis as blockEditorPrivateApis,
@@ -416,7 +415,6 @@ export default function Image( {
 		{ loadedNaturalWidth, loadedNaturalHeight },
 		setLoadedNaturalSize,
 	] = useState( {} );
-	const [ isEditingImage, setIsEditingImage ] = useState( false );
 	const [ externalBlob, setExternalBlob ] = useState();
 	const [ hasImageErrored, setHasImageErrored ] = useState( false );
 	const hasNonContentControls = blockEditingMode === 'default';
@@ -636,12 +634,6 @@ export default function Image( {
 		} );
 	}
 
-	useEffect( () => {
-		if ( ! isSingleSelected ) {
-			setIsEditingImage( false );
-		}
-	}, [ isSingleSelected ] );
-
 	const canEditImage =
 		id &&
 		naturalWidth &&
@@ -651,7 +643,7 @@ export default function Image( {
 	const allowCrop =
 		isSingleSelected &&
 		canEditImage &&
-		! isEditingImage &&
+		!! openImageMediaEditorModal &&
 		! isContentOnlyMode &&
 		! isUploading;
 
@@ -663,8 +655,8 @@ export default function Image( {
 	}
 
 	// TODO: Can allow more units after figuring out how they should interact
-	// with the ResizableBox and ImageEditor components. Calculations later on
-	// for those components are currently assuming px units.
+	// with the ResizableBox component. Calculations later on for that
+	// component are currently assuming px units.
 	const dimensionsUnitsOptions = useCustomUnits( {
 		availableUnits: [ 'px' ],
 	} );
@@ -881,7 +873,6 @@ export default function Image( {
 
 	const showUrlInput =
 		isSingleSelected &&
-		! isEditingImage &&
 		! lockHrefControls &&
 		! lockUrlControls &&
 		! isDecorative;
@@ -891,24 +882,22 @@ export default function Image( {
 
 	const showBlockControls = showUrlInput || allowCrop || showCoverControls;
 
-	const mediaReplaceFlow = isSingleSelected &&
-		! isEditingImage &&
-		! lockUrlControls && (
-			// For contentOnly mode, put this button in its own area so it has borders around it.
-			<BlockControls group={ isContentOnlyMode ? 'inline' : 'other' }>
-				<MediaReplaceFlow
-					mediaId={ id }
-					mediaURL={ url }
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					onSelect={ onSelectImage }
-					onSelectURL={ onSelectURL }
-					onError={ onUploadError }
-					name={ ! url ? __( 'Add image' ) : __( 'Replace' ) }
-					onReset={ () => onSelectImage( undefined ) }
-					variant="toolbar"
-				/>
-			</BlockControls>
-		);
+	const mediaReplaceFlow = isSingleSelected && ! lockUrlControls && (
+		// For contentOnly mode, put this button in its own area so it has borders around it.
+		<BlockControls group={ isContentOnlyMode ? 'inline' : 'other' }>
+			<MediaReplaceFlow
+				mediaId={ id }
+				mediaURL={ url }
+				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				onSelect={ onSelectImage }
+				onSelectURL={ onSelectURL }
+				onError={ onUploadError }
+				name={ ! url ? __( 'Add image' ) : __( 'Replace' ) }
+				onReset={ () => onSelectImage( undefined ) }
+				variant="toolbar"
+			/>
+		</BlockControls>
+	);
 
 	const hasDataFormBlockFields =
 		window?.__experimentalContentOnlyInspectorFields;
@@ -936,14 +925,8 @@ export default function Image( {
 					{ allowCrop && (
 						<ToolbarButton
 							ref={ cropButtonRef }
-							onClick={
-								openImageMediaEditorModal
-									? openImageMediaEditorModal
-									: () => setIsEditingImage( true )
-							}
-							aria-haspopup={
-								openImageMediaEditorModal ? 'dialog' : undefined
-							}
+							onClick={ openImageMediaEditorModal }
+							aria-haspopup="dialog"
 							icon={ crop }
 							label={ __( 'Crop' ) }
 						/>
@@ -1194,108 +1177,88 @@ export default function Image( {
 
 	const borderProps = useBorderProps( attributes );
 	const shadowProps = getShadowClassesAndStyles( attributes );
-	const isRounded = attributes.className?.includes( 'is-style-rounded' );
 
 	const { postType, postId, queryId } = context;
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 
-	let img =
-		temporaryURL && hasImageErrored ? (
-			// Show a placeholder during upload when the blob URL can't be loaded. This can
-			// happen when the user uploads a HEIC image in a browser that doesn't support them.
-			<Placeholder
-				className="wp-block-image__placeholder"
-				withIllustration
-			>
-				<Spinner />
-			</Placeholder>
-		) : (
-			<>
-				<img
-					src={ temporaryURL || url }
-					alt={ defaultedAlt }
-					onError={ onImageError }
-					onLoad={ onImageLoad }
-					ref={ setRefs }
-					className={ borderProps.className }
-					width={ naturalWidth }
-					height={ naturalHeight }
-					style={ {
-						aspectRatio,
-						...( resizeDelta
-							? {
-									width: pixelSize.width + resizeDelta.width,
-									height:
-										pixelSize.height + resizeDelta.height,
-							  }
-							: ( () => {
-									const style = {};
-									if ( width === 'auto' ) {
-										style.width = 'auto';
-									} else if (
-										width !== undefined &&
-										width !== null
-									) {
-										style.width =
-											typeof width === 'number'
-												? `${ width }px`
-												: width;
-									}
-									if (
-										height === 'auto' ||
-										height === undefined ||
-										height === null
-									) {
-										style.height = 'auto';
-									} else {
-										style.height =
-											typeof height === 'number'
-												? `${ height }px`
-												: height;
-									}
-									return style;
-							  } )() ),
-						objectFit: scale,
-						objectPosition:
-							focalPoint && scale
-								? mediaPosition( focalPoint )
-								: undefined,
-						...borderProps.style,
-						...shadowProps.style,
-					} }
-				/>
-				{ isUploading && <Spinner /> }
-			</>
-		);
-
-	if ( canEditImage && isEditingImage ) {
-		img = (
-			<ImageWrapper href={ href }>
-				<ImageEditor
-					id={ id }
-					url={ url }
-					{ ...pixelSize }
-					naturalHeight={ naturalHeight }
-					naturalWidth={ naturalWidth }
-					onSaveImage={ ( imageAttributes ) =>
-						setAttributes( imageAttributes )
-					}
-					onFinishEditing={ () => {
-						setIsEditingImage( false );
-					} }
-					borderProps={ isRounded ? undefined : borderProps }
-				/>
-			</ImageWrapper>
-		);
-	} else {
-		img = <ImageWrapper href={ href }>{ img }</ImageWrapper>;
-	}
+	const img = (
+		<ImageWrapper href={ href }>
+			{ temporaryURL && hasImageErrored ? (
+				// Show a placeholder during upload when the blob URL can't be loaded. This can
+				// happen when the user uploads a HEIC image in a browser that doesn't support them.
+				<Placeholder
+					className="wp-block-image__placeholder"
+					withIllustration
+				>
+					<Spinner />
+				</Placeholder>
+			) : (
+				<>
+					<img
+						src={ temporaryURL || url }
+						alt={ defaultedAlt }
+						onError={ onImageError }
+						onLoad={ onImageLoad }
+						ref={ setRefs }
+						className={ borderProps.className }
+						width={ naturalWidth }
+						height={ naturalHeight }
+						style={ {
+							aspectRatio,
+							...( resizeDelta
+								? {
+										width:
+											pixelSize.width + resizeDelta.width,
+										height:
+											pixelSize.height +
+											resizeDelta.height,
+								  }
+								: ( () => {
+										const style = {};
+										if ( width === 'auto' ) {
+											style.width = 'auto';
+										} else if (
+											width !== undefined &&
+											width !== null
+										) {
+											style.width =
+												typeof width === 'number'
+													? `${ width }px`
+													: width;
+										}
+										if (
+											height === 'auto' ||
+											height === undefined ||
+											height === null
+										) {
+											style.height = 'auto';
+										} else {
+											style.height =
+												typeof height === 'number'
+													? `${ height }px`
+													: height;
+										}
+										return style;
+								  } )() ),
+							objectFit: scale,
+							objectPosition:
+								focalPoint && scale
+									? mediaPosition( focalPoint )
+									: undefined,
+							...borderProps.style,
+							...shadowProps.style,
+						} }
+					/>
+					{ isUploading && <Spinner /> }
+				</>
+			) }
+		</ImageWrapper>
+	);
 
 	let resizableBox;
 	if (
 		isResizable &&
 		isSingleSelected &&
-		! isEditingImage &&
 		! isUploading &&
 		! SIZED_LAYOUTS.includes( parentLayoutType )
 	) {

--- a/packages/block-library/src/image/test/use-open-image-media-editor-modal.js
+++ b/packages/block-library/src/image/test/use-open-image-media-editor-modal.js
@@ -109,6 +109,25 @@ describe( 'useOpenImageMediaEditorModal', () => {
 		jest.clearAllMocks();
 	} );
 
+	it( 'returns no opener when the media editor modal setting is unavailable', () => {
+		useRegistry.mockReturnValue( createRegistry() );
+		mockMediaEditorModalSetting( undefined );
+
+		const { result } = renderHook( () =>
+			useOpenImageMediaEditorModal( {
+				attributes: {
+					id: 1,
+					url: 'original.jpg',
+					alt: '',
+					caption: '',
+				},
+				setAttributes: jest.fn(),
+			} )
+		);
+
+		expect( result.current ).toBeUndefined();
+	} );
+
 	it( 'passes an onClose handler for returning focus when the media editor closes', async () => {
 		const cropButton = document.createElement( 'button' );
 		const otherButton = document.createElement( 'button' );

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -34,7 +34,6 @@ import {
 	MediaReplaceFlow,
 	useBlockProps,
 	store as blockEditorStore,
-	__experimentalImageEditor as ImageEditor,
 	useBlockEditingMode,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
@@ -73,7 +72,6 @@ const SiteLogo = ( {
 	const isWideAligned = [ 'wide', 'full' ].includes( align );
 	const isResizable = ! isWideAligned && isLargeViewport;
 	const [ { naturalWidth, naturalHeight }, setNaturalSize ] = useState( {} );
-	const [ isEditingImage, setIsEditingImage ] = useState( false );
 	const cropButtonRef = useRef();
 	const { toggleSelection, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
@@ -113,12 +111,6 @@ const SiteLogo = ( {
 			setAttributes( { shouldSyncIcon: false } );
 		}
 	}, [] );
-
-	useEffect( () => {
-		if ( ! isSelected ) {
-			setIsEditingImage( false );
-		}
-	}, [ isSelected ] );
 
 	// Always apply modal updates as snackbar Undo may restore the original id.
 	const handleMediaUpdate = ( { id: newId } ) => {
@@ -232,58 +224,6 @@ const SiteLogo = ( {
 
 	// Hide crop and dimensions editing in write mode
 	const shouldShowCropAndDimensions = ! isContentOnlyMode;
-
-	let imgEdit;
-	if ( canEditImage && isEditingImage ) {
-		imgEdit = (
-			<ImageEditor
-				id={ logoId }
-				url={ logoUrl }
-				width={ currentWidth }
-				height={ currentHeight }
-				naturalHeight={ naturalHeight }
-				naturalWidth={ naturalWidth }
-				onSaveImage={ ( imageAttributes ) => {
-					setLogo( imageAttributes.id );
-				} }
-				onFinishEditing={ () => {
-					setIsEditingImage( false );
-				} }
-			/>
-		);
-	} else {
-		// Always render ResizableBox but disable resize functionality in contentOnly mode
-		imgEdit = (
-			<ResizableBox
-				size={ {
-					width: currentWidth,
-					height: currentHeight,
-				} }
-				showHandle={ isSelected && shouldShowCropAndDimensions }
-				minWidth={ minWidth }
-				maxWidth={ maxWidthBuffer }
-				minHeight={ minHeight }
-				maxHeight={ maxWidthBuffer / ratio }
-				lockAspectRatio
-				enable={ {
-					top: false,
-					right: showRightHandle,
-					bottom: true,
-					left: showLeftHandle,
-				} }
-				onResizeStart={ onResizeStart }
-				onResizeStop={ ( event, direction, elt, delta ) => {
-					onResizeStop();
-					setAttributes( {
-						width: parseInt( currentWidth + delta.width, 10 ),
-						height: parseInt( currentHeight + delta.height, 10 ),
-					} );
-				} }
-			>
-				{ imgWrapper }
-			</ResizableBox>
-		);
-	}
 
 	// Support the previous location for the Site Icon settings. To be removed
 	// when the required WP core version for Gutenberg is >= 6.5.0.
@@ -401,33 +341,54 @@ const SiteLogo = ( {
 				</ToolsPanel>
 			</InspectorControls>
 			{ canEditImage &&
-				! isEditingImage &&
+				openMediaEditorModal &&
 				shouldShowCropAndDimensions && (
 					<BlockControls group="block">
 						<ToolbarButton
 							ref={ cropButtonRef }
-							onClick={
-								openMediaEditorModal && logoId
-									? () =>
-											openMediaEditorModal( {
-												id: logoId,
-												onUpdate: handleMediaUpdate,
-												onClose: () =>
-													cropButtonRef.current?.focus(),
-											} )
-									: () => setIsEditingImage( true )
+							onClick={ () =>
+								openMediaEditorModal( {
+									id: logoId,
+									onUpdate: handleMediaUpdate,
+									onClose: () =>
+										cropButtonRef.current?.focus(),
+								} )
 							}
-							aria-haspopup={
-								openMediaEditorModal && logoId
-									? 'dialog'
-									: undefined
-							}
+							aria-haspopup="dialog"
 							icon={ crop }
 							label={ __( 'Crop' ) }
 						/>
 					</BlockControls>
 				) }
-			{ imgEdit }
+			{ /* Always render ResizableBox but disable resize functionality in contentOnly mode */ }
+			<ResizableBox
+				size={ {
+					width: currentWidth,
+					height: currentHeight,
+				} }
+				showHandle={ isSelected && shouldShowCropAndDimensions }
+				minWidth={ minWidth }
+				maxWidth={ maxWidthBuffer }
+				minHeight={ minHeight }
+				maxHeight={ maxWidthBuffer / ratio }
+				lockAspectRatio
+				enable={ {
+					top: false,
+					right: showRightHandle,
+					bottom: true,
+					left: showLeftHandle,
+				} }
+				onResizeStart={ onResizeStart }
+				onResizeStop={ ( event, direction, elt, delta ) => {
+					onResizeStop();
+					setAttributes( {
+						width: parseInt( currentWidth + delta.width, 10 ),
+						height: parseInt( currentHeight + delta.height, 10 ),
+					} );
+				} }
+			>
+				{ imgWrapper }
+			</ResizableBox>
 		</>
 	);
 };


### PR DESCRIPTION
> Follow-up to #78653.

## What?

This removes the inline cropper path from the Image and Site Logo blocks. Their Crop buttons now always open the Media Editor modal.

It keeps `wp.blockEditor.__experimentalImageEditor` exported for compatibility, but soft-deprecates it with `@deprecated` docs and a one-time warning when it renders.

## Why?

Core no longer needs two cropper paths. The modal is the path we use.

But removing the exported component outright is risky for plugins, so this PR gives that API a deprecation window instead of pulling it immediately.

## Testing Instructions

1. Insert an Image block, upload an image, and click Crop. The Media Editor modal should open.
2. Confirm the Image block edit component no longer imports or renders `ImageEditor`.
3. Repeat the Crop check with the Site Logo block.
4. Confirm `wp.blockEditor.__experimentalImageEditor` still exists, and rendering it logs a deprecation warning once.

### Testing Instructions for Keyboard

No new keyboard surface. The toolbar-to-modal interaction is unchanged.

## Screenshots or screencast

N/A. No intended visual change from trunk.

## Use of AI Tools

Codex helped update the branch and PR text.
