### PR TITLE
Dashboard: URL bar in site preview widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67171,7 +67171,8 @@
 				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
-				"@wordpress/ui": "file:../../packages/ui"
+				"@wordpress/ui": "file:../../packages/ui",
+				"@wordpress/url": "file:../../packages/url"
 			}
 		},
 		"widgets/welcome": {

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1875,5 +1875,10 @@
 		"@wordpress/use-recommended-components": {
 			"count": 1
 		}
+	},
+	"widgets/site-preview/render.tsx": {
+		"@wordpress/use-recommended-components": {
+			"count": 1
+		}
 	}
 }

--- a/widgets/site-preview/package.json
+++ b/widgets/site-preview/package.json
@@ -9,6 +9,7 @@
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
-		"@wordpress/ui": "file:../../packages/ui"
+		"@wordpress/ui": "file:../../packages/ui",
+		"@wordpress/url": "file:../../packages/url"
 	}
 }

--- a/widgets/site-preview/render.tsx
+++ b/widgets/site-preview/render.tsx
@@ -5,26 +5,65 @@ import { useEffect, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
+import { wordpress } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
 import { Spinner } from '@wordpress/components';
-
-// Dashboard is still experimental.
-// eslint-disable-next-line @wordpress/use-recommended-components
-import { Button, Stack } from '@wordpress/ui';
+import { Button, Icon, Stack, Text } from '@wordpress/ui';
 import styles from './style.module.css';
+
+function PreviewUrlBar( {
+	siteUrl,
+	siteIconUrl,
+}: {
+	siteUrl: string;
+	siteIconUrl?: string;
+} ) {
+	return (
+		<div className={ styles.urlBar }>
+			<Stack
+				direction="row"
+				align="center"
+				gap="xs"
+				className={ styles.urlField }
+			>
+				{ siteIconUrl ? (
+					<img
+						className={ styles.urlFavicon }
+						src={ siteIconUrl }
+						alt=""
+					/>
+				) : (
+					<Icon
+						className={ styles.urlIcon }
+						icon={ wordpress }
+						size={ 12 }
+					/>
+				) }
+				<Text className={ styles.urlText }>{ siteUrl }</Text>
+			</Stack>
+		</div>
+	);
+}
 
 export default function SitePreview() {
 	const [ isIframeLoading, setIsIframeLoading ] = useState( true );
 	const [ isVisitLoading, setIsVisitLoading ] = useState( false );
 	const [ isEditLoading, setIsEditLoading ] = useState( false );
-	const siteUrl = useSelect(
-		( select ) =>
-			select( coreStore ).getEntityRecord< { url: string } >(
-				'root',
-				'site',
-				undefined
-			)?.url,
-		[]
-	);
+	const { siteUrl, siteIconUrl } = useSelect( ( select ) => {
+		const site = select( coreStore ).getEntityRecord< { url: string } >(
+			'root',
+			'site',
+			undefined
+		);
+		const base = select( coreStore ).getEntityRecord< {
+			site_icon_url?: string;
+		} >( 'root', '__unstableBase', undefined );
+
+		return {
+			siteUrl: site?.url,
+			siteIconUrl: base?.site_icon_url,
+		};
+	}, [] );
 
 	const isBlockTheme = useSelect(
 		( select ) =>
@@ -40,11 +79,14 @@ export default function SitePreview() {
 		return null;
 	}
 
-	const src = `${ siteUrl }/?hide_banners=true&preview_overlay=true&preview=true`;
+	const src = addQueryArgs( siteUrl, {
+		wp_site_preview: 1,
+	} );
 	const editUrl = isBlockTheme ? 'site-editor.php' : 'customize.php';
 
 	return (
-		<div className={ styles.container }>
+		<Stack direction="column" className={ styles.container }>
+			<PreviewUrlBar siteUrl={ siteUrl } siteIconUrl={ siteIconUrl } />
 			<div className={ styles.previewWrap }>
 				{ isIframeLoading && (
 					<Stack
@@ -66,39 +108,39 @@ export default function SitePreview() {
 					// @ts-expect-error — `inert` is not yet in React's HTMLAttributes
 					inert="true"
 				></iframe>
-				<Stack
-					direction="row"
-					align="center"
-					justify="center"
-					gap="sm"
-					className={ styles.overlay }
-				>
-					<Button
-						className={ styles.overlayButton }
-						variant="solid"
-						tone="neutral"
-						loading={ isVisitLoading }
-						onClick={ () => {
-							setIsVisitLoading( true );
-							window.location.href = siteUrl;
-						} }
+				{ ! isIframeLoading && (
+					<Stack
+						direction="row"
+						align="center"
+						justify="center"
+						gap="sm"
+						className={ styles.overlay }
 					>
-						{ __( 'Visit' ) }
-					</Button>
-					<Button
-						className={ styles.overlayButton }
-						variant="solid"
-						tone="brand"
-						loading={ isEditLoading }
-						onClick={ () => {
-							setIsEditLoading( true );
-							window.location.href = editUrl;
-						} }
-					>
-						{ __( 'Edit site' ) }
-					</Button>
-				</Stack>
+						<Button
+							variant="solid"
+							tone="neutral"
+							loading={ isVisitLoading }
+							onClick={ () => {
+								setIsVisitLoading( true );
+								window.location.href = siteUrl;
+							} }
+						>
+							{ __( 'Visit' ) }
+						</Button>
+						<Button
+							variant="solid"
+							tone="brand"
+							loading={ isEditLoading }
+							onClick={ () => {
+								setIsEditLoading( true );
+								window.location.href = editUrl;
+							} }
+						>
+							{ __( 'Edit site' ) }
+						</Button>
+					</Stack>
+				) }
 			</div>
-		</div>
+		</Stack>
 	);
 }

--- a/widgets/site-preview/style.module.css
+++ b/widgets/site-preview/style.module.css
@@ -69,7 +69,7 @@
 	inset-inline-start: 50%;
 	width: 250%;
 	min-height: 375%;
-	transform: translate(-50%, -13px) scale(0.4);
+	transform: translate(-50%, 0) scale(0.4);
 	transform-origin: center top;
 }
 
@@ -81,28 +81,13 @@
 	backdrop-filter: blur(1px);
 }
 
-.overlayButton {
-	box-shadow: var(--wpds-elevation-xs);
-}
-
 .previewWrap:hover .overlay,
 .previewWrap:focus-within .overlay {
 	opacity: 1;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-	.previewWrap:hover .overlay,
-	.previewWrap:focus-within .overlay {
-		animation: fadeIn var(--wpds-motion-duration-md) var(--wpds-motion-easing-subtle) both;
-	}
-}
-
-@keyframes fadeIn {
-	from {
-		opacity: 0;
-	}
-
-	to {
-		opacity: 1;
+@media not (prefers-reduced-motion) {
+	.overlay {
+		transition: opacity var(--wpds-motion-duration-lg) var(--wpds-motion-easing-expressive);
 	}
 }

--- a/widgets/site-preview/style.module.css
+++ b/widgets/site-preview/style.module.css
@@ -13,9 +13,48 @@
 	overflow: hidden;
 }
 
+.urlBar {
+	flex-shrink: 0;
+	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
+	background: var(--wpds-color-bg-surface-neutral-weak);
+	border-block-end: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
+}
+
+.urlField {
+	min-width: 0;
+	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
+	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
+	border-radius: var(--wpds-border-radius-lg);
+	background: var(--wpds-color-bg-surface-neutral);
+}
+
+.urlFavicon {
+	flex-shrink: 0;
+	width: var(--wpds-typography-font-size-xs);
+	height: var(--wpds-typography-font-size-xs);
+	object-fit: contain;
+}
+
+.urlIcon {
+	flex-shrink: 0;
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.urlText {
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: var(--wpds-typography-line-height-xs);
+	color: var(--wpds-color-fg-content-neutral);
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .previewWrap {
 	position: relative;
-	height: 100%;
+	flex: 1;
+	min-height: 0;
 }
 
 .loading {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow-up to https://github.com/WordPress/gutenberg/pull/78556

Part of https://github.com/WordPress/gutenberg/issues/77616

- Adds URL bar + favicon to the site bar
- Adjust hover overlay animation (slower, more expressive); also simplify without keyframes
- Remove shadow from button (we now have overlay)
- Use the correct URL param in preview to hide adminbar

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Adds more info to site preview and overall visual polish.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Enable experimental dashboard.
- In the dashboard, add site preview widget
- Test with and without favicon set

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
<img width="555" height="643" alt="image" src="https://github.com/user-attachments/assets/292681aa-de89-4e61-aa8e-f2fa84df75c5" />

<img width="596" height="651" alt="Screenshot 2026-05-26 at 10 06 11" src="https://github.com/user-attachments/assets/8aebd256-085e-4b64-8f35-cabf8a895cd9" />


### After
Without favicon
<img width="596" height="647" alt="Screenshot 2026-05-26 at 10 05 47" src="https://github.com/user-attachments/assets/6b04bace-eaa2-4fcb-ad40-0c517446aee9" />
<img width="594" height="651" alt="Screenshot 2026-05-26 at 10 05 52" src="https://github.com/user-attachments/assets/ebb47287-4b6d-4233-b2b6-11e4d5f36516" />

With favicon
<img width="586" height="643" alt="Screenshot 2026-05-26 at 10 13 06" src="https://github.com/user-attachments/assets/ac59cd26-6cc9-42d0-a15e-367aab40b5cb" />

Small tile

<img width="212" height="349" alt="image" src="https://github.com/user-attachments/assets/19490b47-f79c-4b4e-a943-5a5724d8e5bc" />


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
