### PR TITLE
Hide block variation selector when style state is selected

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -483,7 +483,11 @@ const BlockInspectorSingleBlock = ( {
 			) }
 			<ViewportVisibilityInfo clientId={ renderedBlockClientId } />
 			<EditContents clientId={ renderedBlockClientId } />
-			<BlockVariationTransforms blockClientId={ renderedBlockClientId } />
+			{ ! isBlockStyleStateSelected && (
+				<BlockVariationTransforms
+					blockClientId={ renderedBlockClientId }
+				/>
+			) }
 			<BlockInspectorPreTabsSlot />
 			{ isBlockStyleStateSelected && ! isSectionBlock && (
 				<StyleStateInspectorSlots


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
With particular blocks like heading and group, when a user has a responsive state selected on a block, the variation selector is displayed. This makes it seem like the user can switch to a different variation on tablet/mobile to the one they use by default. This isn't supported, so in this PR the variation selector is hidden.

## Testing Instructions
1. Add a heading or group block
2. Select tablet or mobile from the state dropdown near the block title
3. Observe the variation switcher is hidden.
## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="277" height="697" alt="Screenshot 2026-05-26 at 4 05 46 pm" src="https://github.com/user-attachments/assets/f9c63881-ef7b-4172-9a5c-93a01e14fef5" /> | <img width="274" height="642" alt="Screenshot 2026-05-26 at 4 05 19 pm" src="https://github.com/user-attachments/assets/98a6b586-ea0d-4af2-8f91-ba189ce8c730" /> |



## Use of AI Tools

OpenCode / Codex