### PR TITLE
Editor: Migrate FlatTermSelector to UI Stack component

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -3,11 +3,8 @@
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { useEffect, useMemo, useState } from '@wordpress/element';
-import {
-	FormTokenField,
-	withFilters,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { FormTokenField, withFilters } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDebounce } from '@wordpress/compose';
@@ -280,7 +277,7 @@ export function FlatTermSelector( { slug } ) {
 	);
 
 	return (
-		<VStack spacing={ 4 }>
+		<Stack direction="column" gap="lg">
 			<FormTokenField
 				__next40pxDefaultSize
 				value={ values }
@@ -296,7 +293,7 @@ export function FlatTermSelector( { slug } ) {
 				} }
 			/>
 			<MostUsedTerms taxonomy={ taxonomy } onSelect={ appendTerm } />
-		</VStack>
+		</Stack>
 	);
 }
 

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1073,11 +1073,6 @@
 			"count": 1
 		}
 	},
-	"packages/editor/src/components/post-taxonomies/flat-term-selector.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/editor/src/components/post-template/create-new-template-modal.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 2


### PR DESCRIPTION
## What?
PR refactors `FlatTermSelector` to use the new recommended `Stack` component.

## Testing Instructions
1. Create a page.
2. Throttle network via dev tools.
3. Create a new tag.
4. Confirm that while the tag is being created, the save/publish buttons are disabled.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude. Mostly for review.