### PR TITLE
[Content Types]: Fix extra Page padding causing vertical scrollbar

### DIFF
--- a/packages/content-types/src/components/layout/style.scss
+++ b/packages/content-types/src/components/layout/style.scss
@@ -14,10 +14,8 @@
 	}
 }
 
-.content-types-page {
-	padding: var(--wpds-dimension-padding-lg);
-}
-
 .content-types-tabs-wrapper {
+	padding-inline: var(--wpds-dimension-padding-lg);
+	padding-block-start: var(--wpds-dimension-padding-lg);
 	border-bottom: 1px solid $gray-100;
 }

--- a/packages/content-types/src/components/layout/style.scss
+++ b/packages/content-types/src/components/layout/style.scss
@@ -15,7 +15,7 @@
 }
 
 .content-types-tabs-wrapper {
-	padding-inline: var(--wpds-dimension-padding-lg);
+	padding-inline: var(--wpds-dimension-padding-2xl);
 	padding-block-start: var(--wpds-dimension-padding-lg);
 	border-bottom: 1px solid $gray-100;
 }


### PR DESCRIPTION
## What, Why, and How?
Related to https://github.com/WordPress/gutenberg/issues/77600 

While testing the Content Types, I noticed that the dashboard displayed an unnecessary vertical scrollbar. The issue was caused by padding applied directly to the Page component, which increased the page height enough to trigger scrolling. 

This PR removes that padding from Page and applies it to the Tab's wrapper instead, matching how it is used elsewhere and fixing the extra scrollbar. Please feel free to close this PR if this is already being handled elsewhere.

Ref:
https://github.com/WordPress/gutenberg/blob/935d434f0aff3e610e427e887936684eed217ab7/routes/template-list/style.scss#L5-L8

## Testing Instructions
1. Enable the "Content Types" Experiment.
2. Navigate to Settings → Content Types.
3. Verify that the unnecessary vertical scrollbar does not appear.

## Screenshots or screencast 

|Before|After|
|-|-|
|<img width="1074" height="839" alt="bug-before" src="https://github.com/user-attachments/assets/88c02b77-a647-4bdb-972c-9d9d94cb56cc" />|<img width="1074" height="839" alt="after(2)" src="https://github.com/user-attachments/assets/5d326fd9-5ed8-4374-b497-458f0e7fd14a" />|

## Use of AI Tools

None