### PR TITLE
Theme: Propagate density through React context

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
--   `ThemeProvider`: Propagate `density` through React context so nested providers inherit it via React (not only via the DOM/CSS cascade).
+-   `ThemeProvider`: Propagate `density` through React context so nested providers inherit it via React (not only via the DOM/CSS cascade) ([#78662](https://github.com/WordPress/gutenberg/pull/78662)).
 
 ### Documentation
 

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   The `color.primary` and `color.bg` props on `ThemeProvider` now require an sRGB-parseable string (hex, `rgb(...)`, or CSS named color). Other CSS color formats like `hsl(...)`, `oklch(...)`, and `lab(...)` are no longer supported ([#77653](https://github.com/WordPress/gutenberg/pull/77653)).
 
+### Bug Fixes
+
+-   `ThemeProvider`: Propagate `density` through React context so nested providers inherit it via React (not only via the DOM/CSS cascade).
+
 ### Documentation
 
 -   Add ["Design System/Tokens/Introduction" page](https://wordpress.github.io/gutenberg/?path=/docs/design-system-tokens-introduction--docs) to Storybook ([#78449](https://github.com/WordPress/gutenberg/pull/78449)).

--- a/packages/theme/src/context.ts
+++ b/packages/theme/src/context.ts
@@ -9,5 +9,6 @@ export const ThemeContext = createContext< ThemeContextType >( {
 	resolvedSettings: {
 		color: {},
 		cursor: undefined,
+		density: undefined,
 	},
 } );

--- a/packages/theme/src/theme-provider.tsx
+++ b/packages/theme/src/theme-provider.tsx
@@ -46,6 +46,7 @@ export const ThemeProvider = ( {
 	const { themeProviderStyles, resolvedSettings } = useThemeProviderStyles( {
 		color,
 		cursor,
+		density,
 	} );
 
 	const contextValue = useMemo(
@@ -68,7 +69,7 @@ export const ThemeProvider = ( {
 			<div
 				data-wpds-theme-provider-id={ instanceId }
 				data-wpds-root-provider={ isRoot }
-				data-wpds-density={ density }
+				data-wpds-density={ resolvedSettings.density }
 				className={ styles.root }
 			>
 				<ThemeContext.Provider value={ contextValue }>

--- a/packages/theme/src/use-theme-provider-styles.ts
+++ b/packages/theme/src/use-theme-provider-styles.ts
@@ -161,9 +161,11 @@ function generateStyles( {
 export function useThemeProviderStyles( {
 	color = {},
 	cursor,
+	density,
 }: {
 	color?: ThemeProviderProps[ 'color' ];
 	cursor?: ThemeProviderProps[ 'cursor' ];
+	density?: ThemeProviderProps[ 'density' ];
 } = {} ) {
 	const { resolvedSettings: inheritedSettings } = useContext( ThemeContext );
 
@@ -178,6 +180,7 @@ export function useThemeProviderStyles( {
 	const bg =
 		color.bg ?? inheritedSettings.color?.bg ?? DEFAULT_SEED_COLORS.bg;
 	const cursorControl = cursor?.control ?? inheritedSettings.cursor?.control;
+	const resolvedDensity = density ?? inheritedSettings.density;
 
 	const resolvedSettings = useMemo(
 		() => ( {
@@ -186,8 +189,9 @@ export function useThemeProviderStyles( {
 				bg,
 			},
 			cursor: cursorControl ? { control: cursorControl } : undefined,
+			density: resolvedDensity,
 		} ),
-		[ primary, bg, cursorControl ]
+		[ primary, bg, cursorControl, resolvedDensity ]
 	);
 
 	const colorStyles = useMemo( () => {


### PR DESCRIPTION
## What?

See task **B1** in #77462. Adds `density` to `resolvedSettings` so nested `ThemeProvider`s inherit it through React context.

## Why?

Today `density` is only propagated via the `data-wpds-density` DOM attribute / CSS cascade. `useContext( ThemeContext ).resolvedSettings.density` is always `undefined`, which is inconsistent with how `color` and `cursor` work.

## How?

- Add `density` to the default `ThemeContext` value.
- Resolve `density` in `useThemeProviderStyles` (`prop ?? inheritedSettings.density`) and include it in `resolvedSettings`.
- Use the resolved value for the `data-wpds-density` attribute, so nested providers that omit the prop still emit the right attribute.

## Testing Instructions

1. In a child of `<ThemeProvider density="compact">`, read `useContext( ThemeContext ).resolvedSettings.density` — should now be `'compact'` (previously `undefined`).
2. Nest a `ThemeProvider` without a `density` prop inside one with `density="compact"`; the inner wrapper's `data-wpds-density` should be `compact`.
3. Open _Design System / Theme / Theme Provider_ in Storybook and confirm existing nesting stories render unchanged.

### Testing Instructions for Keyboard

N/A — internal API change, no UI affordances.

## Screenshots or screencast

N/A — no visual changes.

## Use of AI Tools

This PR was authored with the help of an AI coding assistant (Cursor). All changes were reviewed by a human before submission.