### PR TITLE
Theme: Remove unused `@wordpress/style-runtime` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63940,7 +63940,6 @@
 			"dependencies": {
 				"@wordpress/element": "file:../element",
 				"@wordpress/private-apis": "file:../private-apis",
-				"@wordpress/style-runtime": "file:../style-runtime",
 				"colorjs.io": "^0.6.0",
 				"memize": "^2.1.0"
 			},

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Internal
 
 -   Refactor color space registration to avoid module-level side effects ([#77653](https://github.com/WordPress/gutenberg/pull/77653)).
+-   Remove unused `@wordpress/style-runtime` dependency.
 
 ## 0.13.0 (2026-05-14)
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -82,7 +82,6 @@
 	"dependencies": {
 		"@wordpress/element": "file:../element",
 		"@wordpress/private-apis": "file:../private-apis",
-		"@wordpress/style-runtime": "file:../style-runtime",
 		"colorjs.io": "^0.6.0",
 		"memize": "^2.1.0"
 	},

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -5,7 +5,6 @@
 	},
 	"files": [],
 	"references": [
-		{ "path": "../style-runtime" },
 		{ "path": "./tsconfig.src.json" },
 		{ "path": "./tsconfig.bin.json" }
 	]

--- a/packages/theme/tsconfig.src.json
+++ b/packages/theme/tsconfig.src.json
@@ -7,9 +7,5 @@
 	},
 	"exclude": [],
 	"files": [ "global.d.ts" ],
-	"references": [
-		{ "path": "../element" },
-		{ "path": "../private-apis" },
-		{ "path": "../style-runtime" }
-	]
+	"references": [ { "path": "../element" }, { "path": "../private-apis" } ]
 }


### PR DESCRIPTION
## What?

Removes the declared-but-unused `@wordpress/style-runtime` dependency from `@wordpress/theme`, along with the matching TypeScript project reference. The lockfile and CHANGELOG are updated accordingly.

Addresses **B5** from #77462.

## Why?

`@wordpress/style-runtime` is listed under `dependencies` in `packages/theme/package.json`, but it is not imported anywhere in `packages/theme/src`. Keeping the stale dependency:

- forces installs of an unused package into anything that depends on `@wordpress/theme`,
- adds a misleading project reference in `tsconfig.json` / `tsconfig.src.json`,
- is one of the blockers called out for stabilizing the package.

## How?

- Drop `@wordpress/style-runtime` from `packages/theme/package.json` `dependencies`.
- Drop the matching `{ "path": "../style-runtime" }` references from `packages/theme/tsconfig.json` and `packages/theme/tsconfig.src.json`.
- Update `package-lock.json` to match.
- Add a CHANGELOG entry under the existing `Unreleased > Internal` section.

## Testing Instructions

- `npm install` should be a no-op (lockfile is consistent).
- `npx tsc --build packages/theme/tsconfig.json --force` should succeed.
- Verified with `rg "style-runtime" packages/theme` that no source file references the package after the change.