### PR TITLE
Content Types: Remove "show in REST API"

### DIFF
--- a/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
+++ b/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
@@ -115,7 +115,6 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 				'public'       => array( 'type' => 'boolean' ),
 				'hierarchical' => array( 'type' => 'boolean' ),
 				'has_archive'  => array( 'type' => 'boolean' ),
-				'show_in_rest' => array( 'type' => 'boolean' ),
 				// Caps payload size; well above any reasonable description.
 				'description'  => array(
 					'type'      => 'string',

--- a/lib/experimental/content-types/class-wp-rest-user-taxonomies-controller-gutenberg.php
+++ b/lib/experimental/content-types/class-wp-rest-user-taxonomies-controller-gutenberg.php
@@ -90,7 +90,6 @@ class WP_REST_User_Taxonomies_Controller_Gutenberg extends WP_REST_Posts_Control
 				'show_tagcloud'      => array( 'type' => 'boolean' ),
 				'show_in_quick_edit' => array( 'type' => 'boolean' ),
 				'show_admin_column'  => array( 'type' => 'boolean' ),
-				'show_in_rest'       => array( 'type' => 'boolean' ),
 				'sort'               => array( 'type' => 'boolean' ),
 				'default_term'       => array(
 					'type'                 => 'object',

--- a/lib/experimental/content-types/index.php
+++ b/lib/experimental/content-types/index.php
@@ -418,7 +418,7 @@ function gutenberg_build_user_taxonomy_args( WP_Post $record ) {
 			$args[ $key ] = (bool) $config[ $key ];
 		}
 	}
-	$args['show_in_rest'] = isset( $config['show_in_rest'] ) ? (bool) $config['show_in_rest'] : true;
+	$args['show_in_rest'] = true;
 
 	if ( isset( $config['default_term']['name'] ) ) {
 		$default_term_name = sanitize_text_field( (string) $config['default_term']['name'] );

--- a/lib/experimental/content-types/post-types.php
+++ b/lib/experimental/content-types/post-types.php
@@ -243,7 +243,7 @@ function gutenberg_build_user_post_type_args( WP_Post $record ) {
 		'public'       => ! empty( $config['public'] ),
 		'hierarchical' => $is_hierarchical,
 		'has_archive'  => ! empty( $config['has_archive'] ),
-		'show_in_rest' => isset( $config['show_in_rest'] ) ? (bool) $config['show_in_rest'] : true,
+		'show_in_rest' => true,
 		'supports'     => $supports,
 	);
 

--- a/packages/content-types/src/post-types/edit.tsx
+++ b/packages/content-types/src/post-types/edit.tsx
@@ -48,7 +48,6 @@ import {
 	removeFeaturedImageField,
 	searchItemsField,
 	setFeaturedImageField,
-	showInRestField,
 	supportsField,
 	uploadedToThisItemField,
 	useFeaturedImageField,
@@ -157,7 +156,6 @@ function PostTypePage( {
 				publicField,
 				hierarchicalField,
 				hasArchiveField,
-				showInRestField,
 				statusField,
 				// Labels
 				labelsActionsField,

--- a/packages/content-types/src/post-types/fields/general.tsx
+++ b/packages/content-types/src/post-types/fields/general.tsx
@@ -69,16 +69,6 @@ export const hasArchiveField = createBooleanField(
 	}
 );
 
-export const showInRestField = createBooleanField(
-	'show_in_rest',
-	__( 'Show in REST API' ),
-	{
-		description: __(
-			'Required for the block editor. Disable only if posts of this type should not be available via the REST API.'
-		),
-	}
-);
-
 export const countField: Field< PostTypeFormData > = {
 	id: 'count',
 	label: __( 'Posts' ),
@@ -289,7 +279,6 @@ export const generalForm: Form = {
 		'public',
 		'hierarchical',
 		'has_archive',
-		'show_in_rest',
 		'status',
 	],
 };

--- a/packages/content-types/src/post-types/types.ts
+++ b/packages/content-types/src/post-types/types.ts
@@ -68,7 +68,6 @@ export interface StoredConfig {
 	public?: boolean;
 	hierarchical?: boolean;
 	has_archive?: boolean;
-	show_in_rest?: boolean;
 }
 
 import type { ContentType } from '../types';

--- a/packages/content-types/src/post-types/utils.ts
+++ b/packages/content-types/src/post-types/utils.ts
@@ -31,7 +31,6 @@ export const BLANK_RECORD: PostTypeFormData = {
 		public: true,
 		hierarchical: false,
 		has_archive: false,
-		show_in_rest: true,
 	},
 };
 
@@ -203,7 +202,6 @@ export function toFormData( row: PostTypeRecord ): PostTypeFormData {
 			public: config.public ?? true,
 			hierarchical: config.hierarchical ?? false,
 			has_archive: config.has_archive ?? false,
-			show_in_rest: config.show_in_rest ?? true,
 		},
 		count: row.count,
 	};
@@ -232,7 +230,6 @@ export function serializeForSave( data: PostTypeFormData ) {
 			public: config.public,
 			hierarchical: config.hierarchical,
 			has_archive: config.has_archive,
-			show_in_rest: config.show_in_rest,
 			...( description !== '' ? { description } : {} ),
 		},
 	};

--- a/packages/content-types/src/taxonomies/edit.tsx
+++ b/packages/content-types/src/taxonomies/edit.tsx
@@ -50,7 +50,6 @@ import {
 	showInMenuField,
 	showInNavMenusField,
 	showInQuickEditField,
-	showInRestField,
 	showTagcloudField,
 	showUiField,
 	sortField,
@@ -160,7 +159,6 @@ function TaxonomyPage( {
 				statusField,
 				// Visibility
 				publicField,
-				showInRestField,
 				publiclyQueryableField,
 				showUiField,
 				showInMenuField,

--- a/packages/content-types/src/taxonomies/fields/visibility.tsx
+++ b/packages/content-types/src/taxonomies/fields/visibility.tsx
@@ -15,16 +15,6 @@ export const publicField = createBooleanField( 'public', __( 'Public' ), {
 	),
 } );
 
-export const showInRestField = createBooleanField(
-	'show_in_rest',
-	__( 'Show in REST API' ),
-	{
-		description: __(
-			'Required for the block editor. Turn off only for taxonomies that should not be exposed via REST.'
-		),
-	}
-);
-
 export const publiclyQueryableField = createBooleanField(
 	'publicly_queryable',
 	__( 'Publicly queryable' ),
@@ -101,7 +91,6 @@ export const showTagcloudField = createBooleanField(
 
 export const visibilityFormFields: Form[ 'fields' ] = [
 	'public',
-	'show_in_rest',
 	'publicly_queryable',
 	'show_ui',
 	'show_in_menu',

--- a/packages/content-types/src/taxonomies/types.ts
+++ b/packages/content-types/src/taxonomies/types.ts
@@ -43,7 +43,6 @@ export interface StoredConfig {
 	show_tagcloud: boolean;
 	show_in_quick_edit: boolean;
 	show_admin_column: boolean;
-	show_in_rest: boolean;
 	sort?: boolean;
 	default_term?: { name: string };
 }

--- a/packages/content-types/src/taxonomies/utils.ts
+++ b/packages/content-types/src/taxonomies/utils.ts
@@ -29,7 +29,6 @@ export const BLANK_RECORD: TaxonomyFormData = {
 		show_tagcloud: true,
 		show_in_quick_edit: true,
 		show_admin_column: false,
-		show_in_rest: true,
 		sort: false,
 		default_term_enabled: false,
 		default_term: { name: '' },
@@ -161,7 +160,6 @@ export function toFormData( row: TaxonomyRecord ): TaxonomyFormData {
 		show_tagcloud: config.show_tagcloud,
 		show_in_quick_edit: config.show_in_quick_edit,
 		show_admin_column: config.show_admin_column,
-		show_in_rest: config.show_in_rest,
 		sort: !! config.sort,
 		default_term_enabled: defaultTermName !== '',
 		default_term: { name: defaultTermName },
@@ -207,7 +205,6 @@ export function serializeForSave( data: TaxonomyFormData ) {
 			show_tagcloud: config.show_tagcloud,
 			show_in_quick_edit: config.show_in_quick_edit,
 			show_admin_column: config.show_admin_column,
-			show_in_rest: config.show_in_rest,
 			sort: config.sort,
 			...( description !== '' ? { description } : {} ),
 			...( includeDefaultTerm

--- a/packages/content-types/src/types.ts
+++ b/packages/content-types/src/types.ts
@@ -14,7 +14,6 @@ export interface ContentType {
 		description: string;
 		public: boolean;
 		hierarchical: boolean;
-		show_in_rest: boolean;
 	};
 }
 

--- a/test/e2e/specs/admin/user-taxonomies.spec.js
+++ b/test/e2e/specs/admin/user-taxonomies.spec.js
@@ -228,28 +228,6 @@ test.describe( 'User taxonomies', () => {
 			).toHaveCount( 0 );
 		} );
 
-		test( 'turning `Show in REST API` off blocks the taxonomy from the REST API', async ( {
-			page,
-			requestUtils,
-		} ) => {
-			await page.getByRole( 'button', { name: 'Visibility' } ).click();
-			await page
-				.getByRole( 'checkbox', { name: 'Show in REST API' } )
-				.click();
-			await page.getByRole( 'button', { name: 'Save' } ).click();
-			await expect( page.getByTestId( 'snackbar' ).last() ).toContainText(
-				'"Genres" taxonomy updated.'
-			);
-
-			const result = await requestUtils
-				.rest( {
-					path: '/wp/v2/taxonomies/genre',
-					method: 'GET',
-				} )
-				.catch( ( error ) => error );
-			expect( result.code ).toBe( 'rest_forbidden' );
-		} );
-
 		test( 'turning `Publicly queryable` off blocks the front-end term archive', async ( {
 			page,
 		} ) => {

--- a/test/e2e/specs/admin/user-taxonomies.spec.js
+++ b/test/e2e/specs/admin/user-taxonomies.spec.js
@@ -28,7 +28,6 @@ async function createUserTaxonomy( requestUtils ) {
 			show_tagcloud: true,
 			show_in_quick_edit: true,
 			show_admin_column: false,
-			show_in_rest: true,
 		},
 	} );
 }


### PR DESCRIPTION

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. --> 

Related: https://github.com/WordPress/gutenberg/issues/77600

Removes the Show in REST API toggle from the taxonomy visibility controls.

## Why?
Allowing users to disable `show_in_rest` on a user-defined taxonomy is dangerous, it silently breaks REST API access and block editor support for that taxonomy.

## How?

1. Removed the Show in REST API field from the taxonomy visibility form.
2. Removed the E2E test that verified toggling it off blocked REST access (the control no longer exists).

## Testing Instructions

1. Enable the gutenberg-content-types experiment.
2. Create a user taxonomy and open the Visibility panel.
3. Confirm there is no Show in REST API toggle.
4. Run `npm run test:e2e -- test/e2e/specs/admin/user-taxonomies.spec.js` and confirm all remaining tests pass.

