### PR TITLE
Hide image dimension tools when a state is selected

### DIFF
--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -32,6 +32,7 @@ import { setImmutably } from '../../utils/object';
 import {
 	DEFAULT_BLOCK_STYLE_STATE,
 	hasPseudoBlockStyleState,
+	isDefaultBlockStyleState,
 } from '../../hooks/block-style-state';
 
 const AXIAL_SIDES = [ 'horizontal', 'vertical' ];
@@ -51,7 +52,7 @@ export function useHasDimensionsPanel(
 			hasMinHeight( settings ) ||
 			hasMinWidth( settings ) ||
 			hasWidth( settings ) ||
-			hasAspectRatio( settings ) ||
+			hasAspectRatio( settings, styleState ) ||
 			hasChildLayout( settings, styleState ) )
 	);
 }
@@ -92,8 +93,11 @@ function hasWidth( settings ) {
 	return settings?.dimensions?.width;
 }
 
-function hasAspectRatio( settings ) {
-	return settings?.dimensions?.aspectRatio;
+function hasAspectRatio( settings, styleState = DEFAULT_BLOCK_STYLE_STATE ) {
+	return (
+		isDefaultBlockStyleState( styleState ) &&
+		settings?.dimensions?.aspectRatio
+	);
 }
 
 function hasChildLayout( settings, styleState = DEFAULT_BLOCK_STYLE_STATE ) {
@@ -484,7 +488,7 @@ export default function DimensionsPanel( {
 	const hasWidthValue = () => !! value?.dimensions?.width;
 
 	// Aspect Ratio
-	const showAspectRatioControl = hasAspectRatio( settings );
+	const showAspectRatioControl = hasAspectRatio( settings, styleState );
 	const aspectRatioValue = decodeValue(
 		inheritedValue?.dimensions?.aspectRatio
 	);

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -1080,6 +1080,23 @@ export function getSelectedBlockStyleState( state, clientId ) {
 }
 
 /**
+ * Returns whether a non-default style state is selected for a block.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId The block client ID.
+ *
+ * @return {boolean} Whether a non-default block style state is selected.
+ */
+export function hasSelectedStyleState( state, clientId ) {
+	const selectedState = getSelectedBlockStyleState( state, clientId );
+
+	return (
+		selectedState.viewport !== DEFAULT_BLOCK_STYLE_STATE.viewport ||
+		selectedState.pseudo !== DEFAULT_BLOCK_STYLE_STATE.pseudo
+	);
+}
+
+/**
  * Returns whether the selected style state is shown on the canvas.
  *
  * @param {Object} state    Global application state.

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -25,6 +25,7 @@ import {
 	isSectionBlock,
 	getParentSectionBlock,
 	getSelectedBlockStyleState,
+	hasSelectedStyleState,
 	isSelectedBlockStyleStateShownOnCanvas,
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
@@ -123,6 +124,58 @@ describe( 'private selectors', () => {
 				viewport: 'default',
 				pseudo: 'default',
 			} );
+		} );
+	} );
+
+	describe( 'hasSelectedStyleState', () => {
+		it( 'returns false when the block has no selected state', () => {
+			const state = {};
+
+			expect( hasSelectedStyleState( state, 'client-1' ) ).toBe( false );
+		} );
+
+		it( 'returns false when another block has the selected state', () => {
+			const state = {
+				selectedBlockStyleState: {
+					clientId: 'client-2',
+					value: { viewport: 'default', pseudo: ':hover' },
+				},
+			};
+
+			expect( hasSelectedStyleState( state, 'client-1' ) ).toBe( false );
+		} );
+
+		it( 'returns true when a viewport state is selected', () => {
+			const state = {
+				selectedBlockStyleState: {
+					clientId: 'client-1',
+					value: { viewport: 'mobile', pseudo: 'default' },
+				},
+			};
+
+			expect( hasSelectedStyleState( state, 'client-1' ) ).toBe( true );
+		} );
+
+		it( 'returns true when a pseudo state is selected', () => {
+			const state = {
+				selectedBlockStyleState: {
+					clientId: 'client-1',
+					value: { viewport: 'default', pseudo: ':hover' },
+				},
+			};
+
+			expect( hasSelectedStyleState( state, 'client-1' ) ).toBe( true );
+		} );
+
+		it( 'returns true when viewport and pseudo states are selected', () => {
+			const state = {
+				selectedBlockStyleState: {
+					clientId: 'client-1',
+					value: { viewport: 'mobile', pseudo: ':hover' },
+				},
+			};
+
+			expect( hasSelectedStyleState( state, 'client-1' ) ).toBe( true );
 		} );
 	} );
 

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -124,9 +124,20 @@ export default function CoverInspectorControls( {
 	const sizeSlug = attributes.sizeSlug || DEFAULT_MEDIA_SIZE_SLUG;
 
 	const { gradientValue, setGradient } = __experimentalUseGradient();
-	const { getSettings } = useSelect( blockEditorStore );
+	const { imageSizes, hasSelectedStyleState } = useSelect(
+		( select ) => {
+			const {
+				getSettings,
+				hasSelectedStyleState: hasSelectedBlockStyleState,
+			} = unlock( select( blockEditorStore ) );
 
-	const imageSizes = getSettings()?.imageSizes;
+			return {
+				imageSizes: getSettings()?.imageSizes,
+				hasSelectedStyleState: hasSelectedBlockStyleState( clientId ),
+			};
+		},
+		[ clientId ]
+	);
 
 	const image = useSelect(
 		( select ) =>
@@ -387,51 +398,53 @@ export default function CoverInspectorControls( {
 					</ToolsPanelItem>
 				</InspectorControls>
 			) }
-			<InspectorControls group="dimensions">
-				<ToolsPanelItem
-					className="single-column"
-					hasValue={ () => !! minHeight }
-					label={ __( 'Minimum height' ) }
-					onDeselect={ () =>
-						setAttributes( {
+			{ ! hasSelectedStyleState && (
+				<InspectorControls group="dimensions">
+					<ToolsPanelItem
+						className="single-column"
+						hasValue={ () => !! minHeight }
+						label={ __( 'Minimum height' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								minHeight: undefined,
+								minHeightUnit: undefined,
+							} )
+						}
+						resetAllFilter={ () => ( {
 							minHeight: undefined,
 							minHeightUnit: undefined,
-						} )
-					}
-					resetAllFilter={ () => ( {
-						minHeight: undefined,
-						minHeightUnit: undefined,
-					} ) }
-					isShownByDefault
-					panelId={ clientId }
-				>
-					<CoverHeightInput
-						value={
-							attributes?.style?.dimensions?.aspectRatio
-								? ''
-								: minHeight
-						}
-						unit={ minHeightUnit }
-						onChange={ ( newMinHeight ) =>
-							setAttributes( {
-								minHeight: newMinHeight,
-								style: cleanEmptyObject( {
-									...attributes?.style,
-									dimensions: {
-										...attributes?.style?.dimensions,
-										aspectRatio: undefined, // Reset aspect ratio when minHeight is set.
-									},
-								} ),
-							} )
-						}
-						onUnitChange={ ( nextUnit ) =>
-							setAttributes( {
-								minHeightUnit: nextUnit,
-							} )
-						}
-					/>
-				</ToolsPanelItem>
-			</InspectorControls>
+						} ) }
+						isShownByDefault
+						panelId={ clientId }
+					>
+						<CoverHeightInput
+							value={
+								attributes?.style?.dimensions?.aspectRatio
+									? ''
+									: minHeight
+							}
+							unit={ minHeightUnit }
+							onChange={ ( newMinHeight ) =>
+								setAttributes( {
+									minHeight: newMinHeight,
+									style: cleanEmptyObject( {
+										...attributes?.style,
+										dimensions: {
+											...attributes?.style?.dimensions,
+											aspectRatio: undefined, // Reset aspect ratio when minHeight is set.
+										},
+									} ),
+								} )
+							}
+							onUnitChange={ ( nextUnit ) =>
+								setAttributes( {
+									minHeightUnit: nextUnit,
+								} )
+							}
+						/>
+					</ToolsPanelItem>
+				</InspectorControls>
+			) }
 			<InspectorControls group="advanced">
 				<HTMLElementControl
 					tagName={ tagName }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -735,11 +735,14 @@ export default function Image( {
 		lockTitleControls = false,
 		lockTitleControlsMessage,
 		hideCaptionControls = false,
+		hasSelectedStyleState = false,
 	} = useSelect(
 		( select ) => {
 			if ( ! isSingleSelected ) {
 				return {};
 			}
+			const { hasSelectedStyleState: hasSelectedBlockStyleState } =
+				unlock( select( blockEditorStore ) );
 			const {
 				url: urlBinding,
 				alt: altBinding,
@@ -757,6 +760,7 @@ export default function Image( {
 				titleBinding?.source
 			);
 			return {
+				hasSelectedStyleState: hasSelectedBlockStyleState( clientId ),
 				lockUrlControls:
 					!! urlBinding &&
 					! urlBindingSource?.canUserEditValue?.( {
@@ -801,6 +805,7 @@ export default function Image( {
 		},
 		[
 			arePatternOverridesEnabled,
+			clientId,
 			context,
 			isSingleSelected,
 			metadata?.bindings,
@@ -1005,45 +1010,47 @@ export default function Image( {
 					</ToolsPanel>
 				</InspectorControls>
 			) }
-			<InspectorControls
-				group="dimensions"
-				resetAllFilter={ ( attrs ) => ( {
-					...attrs,
-					aspectRatio: undefined,
-					width: undefined,
-					height: undefined,
-					scale: undefined,
-					focalPoint: undefined,
-				} ) }
-			>
-				{ dimensionsControl }
-				{ url && scale && (
-					<ToolsPanelItem
-						label={ __( 'Focal point' ) }
-						isShownByDefault
-						hasValue={ () => !! focalPoint }
-						onDeselect={ () =>
-							setAttributes( {
-								focalPoint: undefined,
-							} )
-						}
-						panelId={ clientId }
-					>
-						<FocalPointPicker
+			{ ! hasSelectedStyleState && (
+				<InspectorControls
+					group="dimensions"
+					resetAllFilter={ ( attrs ) => ( {
+						...attrs,
+						aspectRatio: undefined,
+						width: undefined,
+						height: undefined,
+						scale: undefined,
+						focalPoint: undefined,
+					} ) }
+				>
+					{ dimensionsControl }
+					{ url && scale && (
+						<ToolsPanelItem
 							label={ __( 'Focal point' ) }
-							url={ url }
-							value={ focalPoint }
-							onDragStart={ imperativeFocalPointPreview }
-							onDrag={ imperativeFocalPointPreview }
-							onChange={ ( newFocalPoint ) =>
+							isShownByDefault
+							hasValue={ () => !! focalPoint }
+							onDeselect={ () =>
 								setAttributes( {
-									focalPoint: newFocalPoint,
+									focalPoint: undefined,
 								} )
 							}
-						/>
-					</ToolsPanelItem>
-				) }
-			</InspectorControls>
+							panelId={ clientId }
+						>
+							<FocalPointPicker
+								label={ __( 'Focal point' ) }
+								url={ url }
+								value={ focalPoint }
+								onDragStart={ imperativeFocalPointPreview }
+								onDrag={ imperativeFocalPointPreview }
+								onChange={ ( newFocalPoint ) =>
+									setAttributes( {
+										focalPoint: newFocalPoint,
+									} )
+								}
+							/>
+						</ToolsPanelItem>
+					) }
+				</InspectorControls>
+			) }
 			{ !! imageSizeOptions.length && (
 				<InspectorControls>
 					<ToolsPanel

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -137,10 +137,12 @@ export default function PostFeaturedImageEdit( {
 		return imageId;
 	}, [ storedFeaturedImage, useFirstImageFromPost, postContent ] );
 
-	const { media, postType, postPermalink } = useSelect(
+	const { media, postType, postPermalink, hasSelectedStyleState } = useSelect(
 		( select ) => {
 			const { getEntityRecord, getPostType, getEditedEntityRecord } =
 				select( coreStore );
+			const { hasSelectedStyleState: hasSelectedBlockStyleState } =
+				unlock( select( blockEditorStore ) );
 			return {
 				media:
 					featuredImage &&
@@ -153,9 +155,10 @@ export default function PostFeaturedImageEdit( {
 					postTypeSlug,
 					postId
 				)?.link,
+				hasSelectedStyleState: hasSelectedBlockStyleState( clientId ),
 			};
 		},
-		[ featuredImage, postTypeSlug, postId ]
+		[ clientId, featuredImage, postTypeSlug, postId ]
 	);
 
 	const mediaUrl =
@@ -237,14 +240,16 @@ export default function PostFeaturedImageEdit( {
 					clientId={ clientId }
 				/>
 			</InspectorControls>
-			<InspectorControls group="dimensions">
-				<DimensionControls
-					clientId={ clientId }
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					media={ media }
-				/>
-			</InspectorControls>
+			{ ! hasSelectedStyleState && (
+				<InspectorControls group="dimensions">
+					<DimensionControls
+						clientId={ clientId }
+						attributes={ attributes }
+						setAttributes={ setAttributes }
+						media={ media }
+					/>
+				</InspectorControls>
+			) }
 			{ ( featuredImage || isDescendentOfQueryLoop || ! postId ) && (
 				<InspectorControls>
 					<ToolsPanel


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
At the moment, some controls for blocks don't work for responsive style states. 

For the meantime, these controls are being hidden when a style state is selected until they are supported properly.

This PR hides some of the cover, image and featured image block additional dimension tools:
- Cover min. height
- Image focal point
- Image aspect ratio (aspect ratio does work on the cover block since it uses block supports, but not on image, it has a custom implementation)
- Image width/height
- Image scale
- Image focal point (focal point is a 'setting' on the cover block, so is already hidden)
- Featured image aspect ratio
- Featured image height/width 

## How?
- Adds a new `hasSelectedStyleState` private selector
- Uses the selector on the blocks to conditionally render their dimensions inspector control fills 

## Testing Instructions
1. Insert a cover, image and featured image
2. Add media to the blocks
3. Check that the above controls are present normally
4. On each block use the style state dropdown on the block card to select 'Mobile' or 'Tablet'. Check that the above controls are hidden

|Before|After|
|-|-|
| <img width="636" height="853" alt="Screenshot 2026-05-26 at 5 18 52 pm" src="https://github.com/user-attachments/assets/2b6bf824-57e8-43c5-858c-68d812132e55" /> | <img width="551" height="697" alt="Screenshot 2026-05-26 at 5 17 46 pm" src="https://github.com/user-attachments/assets/4d6430e7-defe-45c1-86f1-a846b61a7569" /> |

## Use of AI Tools
OpenCode / Codex