### PR TITLE
Hide paragraph Drop Cap and Fit Text controls when a state is selected

### DIFF
--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -23,6 +23,7 @@ import { store as blockEditorStore } from '../store';
 import { useBlockElement } from '../components/block-list/use-block-props/use-block-refs';
 import InspectorControls from '../components/inspector-controls';
 import FitTextSizeWarning from '../components/fit-text-size-warning';
+import { unlock } from '../lock-unlock';
 
 export const FIT_TEXT_SUPPORT_KEY = 'typography.fitText';
 
@@ -248,9 +249,24 @@ export function FitTextControl( {
 	fontSize,
 	style,
 } ) {
+	const hasSelectedStyleState = useSelect(
+		( select ) => {
+			const { hasSelectedStyleState: hasSelectedBlockStyleState } =
+				unlock( select( blockEditorStore ) );
+
+			return hasSelectedBlockStyleState( clientId );
+		},
+		[ clientId ]
+	);
+
 	if ( ! hasBlockSupport( name, FIT_TEXT_SUPPORT_KEY ) ) {
 		return null;
 	}
+
+	if ( hasSelectedStyleState ) {
+		return null;
+	}
+
 	return (
 		<ToolsPanelItem
 			hasValue={ () => fitText }

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -19,7 +19,9 @@ import {
 	useBlockProps,
 	useSettings,
 	useBlockEditingMode,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 import { getBlockSupport } from '@wordpress/blocks';
 import { formatLTR } from '@wordpress/icons';
 /**
@@ -27,6 +29,7 @@ import { formatLTR } from '@wordpress/icons';
  */
 import { useOnEnter } from './use-enter';
 import useDeprecatedAlign from './deprecated-attributes';
+import { unlock } from '../lock-unlock';
 
 function ParagraphRTLControl( { direction, setDirection } ) {
 	return (
@@ -53,8 +56,17 @@ function DropCapControl( { clientId, attributes, setAttributes, name } ) {
 	// and type performance. By moving it within InspectorControls, the subscription is
 	// now only added for the selected block(s).
 	const [ isDropCapFeatureEnabled ] = useSettings( 'typography.dropCap' );
+	const hasSelectedStyleState = useSelect(
+		( select ) => {
+			const { hasSelectedStyleState: hasSelectedBlockStyleState } =
+				unlock( select( blockEditorStore ) );
 
-	if ( ! isDropCapFeatureEnabled ) {
+			return hasSelectedBlockStyleState( clientId );
+		},
+		[ clientId ]
+	);
+
+	if ( ! isDropCapFeatureEnabled || hasSelectedStyleState ) {
 		return null;
 	}
 


### PR DESCRIPTION
Stacked on top of #78670, so that should be merged first. Also lets check perf results before merging this. If it shows issues I can look at further optimizations.

## What?
Hides the paragraph block's drop cap control when a responsive state (Mobile / Tablet) is selected.

## Why?
Currently changing drop cap for a given viewport isn't supported, so this avoid confusion for users.

The drop cap implementation will need some improvements for it to be supported.

## How?
Hides the control by checking the `hasSelectedStyleState`, which was implemented in #78670.

## Testing Instructions
1. Add a paragraph with some text
2. Select 'Mobile' or 'Tablet' from the state dropdown in the block inspector block card
3. Check that Drop cap can't be changed for those responsive states

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| <img width="547" height="881" alt="Screenshot 2026-05-26 at 5 48 01 pm" src="https://github.com/user-attachments/assets/8a47c1b2-7340-4810-8a57-18c857bff1da" /> | <img width="578" height="846" alt="Screenshot 2026-05-26 at 5 47 31 pm" src="https://github.com/user-attachments/assets/d3609479-e9f8-4d2d-b78e-4db2792b738a" /> |

## Use of AI Tools
OpenCode / Codex