### PR TITLE
Docs: Mark React Native mobile editor as unmaintained on trunk after React 19 upgrade

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ To learn all about contributing to the Gutenberg project, see the [Contributor G
 
 -   Accessibility should be top of mind and thoroughly tested by following the [accessibility testing instructions](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md).
 
--   Verify that any changes in your PR that affect function/class/variable names are mirrored in the corresponding `.native.js` versions of the files to avoid introducing breaking changes in the [React Native Mobile Editor](https://github.com/WordPress/gutenberg/tree/trunk/docs/contributors/code/react-native).
+-   The [React Native Mobile Editor](https://github.com/WordPress/gutenberg/tree/trunk/docs/contributors/code/react-native) is currently unmaintained on `trunk` and known to be broken following the upgrade to React 19 ([#61521](https://github.com/WordPress/gutenberg/pull/61521)). Mirroring renamed functions/classes/variables into the corresponding `.native.js` files is no longer required for `trunk` PRs. Fixes for the existing Gutenberg Mobile build should be made by branching from the most recent React Native release — tag [`rnmobile/1.121.0`](https://github.com/WordPress/gutenberg/releases/tag/rnmobile%2F1.121.0) at commit [`e63b8b8`](https://github.com/WordPress/gutenberg/commit/e63b8b8be7bdc5e9dd2781c597e918a7be212fe5) (see [#63744](https://github.com/WordPress/gutenberg/pull/63744)).
 
 -   You maintain copyright over any contribution you make. By submitting a pull request you agree to release that code under [Gutenberg's License](/LICENSE.md).
 

--- a/docs/contributors/code/react-native/README.md
+++ b/docs/contributors/code/react-native/README.md
@@ -2,6 +2,12 @@
 
 The Gutenberg repository includes the source for the [React Native](https://reactnative.dev/) based editor for mobile.
 
+## Project status
+
+The React Native mobile editor is currently unmaintained on `trunk` and is known to be broken following the upgrade to React 19 ([#61521](https://github.com/WordPress/gutenberg/pull/61521)). React 19 is not compatible with the current Gutenberg Mobile setup, and there is little to no active work on Gutenberg Mobile while the WP Mobile project explores paths forward for the block editor in the mobile apps. See the [tracking issue (#71336)](https://github.com/WordPress/gutenberg/issues/71336) for background.
+
+If a fix is required for the existing Gutenberg Mobile build, branch from the most recent React Native release — tag [`rnmobile/1.121.0`](https://github.com/WordPress/gutenberg/releases/tag/rnmobile%2F1.121.0) at commit [`e63b8b8`](https://github.com/WordPress/gutenberg/commit/e63b8b8be7bdc5e9dd2781c597e918a7be212fe5) (see [#63744](https://github.com/WordPress/gutenberg/pull/63744)) — and cut a minor release from there. New work targeting `trunk` to restore React Native compatibility should be coordinated with the WP Mobile team beforehand.
+
 ## Mind the mobile
 
 Contributors need to ensure that they update any affected native mobile files during code refactorings because we cannot yet rely on automated tooling to do this for us. For example, renaming a function or a prop should also be performed in the native modules too, otherwise, the mobile client will break. We have added some mobile specific CI tests as safeguards in place in PRs, but we're still far from done. Please bear with us and thank you in advance. ❤️🙇‍

--- a/docs/contributors/code/react-native/getting-started-react-native.md
+++ b/docs/contributors/code/react-native/getting-started-react-native.md
@@ -2,6 +2,8 @@
 
 Welcome! This is the Getting Started guide for the native mobile port of the block editor, targeting Android and iOS devices. Overall, it's a React Native library to be used in parent greenfield or brownfield apps. Continue reading for information on how to build, test, and run it.
 
+> **Heads up:** The React Native mobile editor is currently unmaintained on `trunk` and is known to be broken following the upgrade to React 19 ([#61521](https://github.com/WordPress/gutenberg/pull/61521)). To build a working demo app or patch the existing Gutenberg Mobile build, check out the most recent React Native release — tag [`rnmobile/1.121.0`](https://github.com/WordPress/gutenberg/releases/tag/rnmobile%2F1.121.0) at commit [`e63b8b8`](https://github.com/WordPress/gutenberg/commit/e63b8b8be7bdc5e9dd2781c597e918a7be212fe5) (see [#63744](https://github.com/WordPress/gutenberg/pull/63744)) — and work from there. See the [project status notice](/docs/contributors/code/react-native/README.md#project-status) for details.
+
 ## Prerequisites
 
 For a developer experience closer to the one the project maintainers current have, make sure you have the following tools installed:

--- a/packages/react-native-aztec/README.md
+++ b/packages/react-native-aztec/README.md
@@ -3,6 +3,8 @@
 This package provides a component, AztecView, that wraps around the Aztec Android and Aztec iOS libraries in a React Native component.
 This component provides rich text editing capabilities that emulate a subset of the HTML functionality.
 
+> **Status:** This package is unmaintained on `trunk` and is known to be broken following the upgrade to React 19 ([#61521](https://github.com/WordPress/gutenberg/pull/61521)). For patches to the existing Gutenberg Mobile build, branch from the most recent React Native release — tag [`rnmobile/1.121.0`](https://github.com/WordPress/gutenberg/releases/tag/rnmobile%2F1.121.0) at commit [`e63b8b8`](https://github.com/WordPress/gutenberg/commit/e63b8b8be7bdc5e9dd2781c597e918a7be212fe5) (see [#63744](https://github.com/WordPress/gutenberg/pull/63744)). See the [React Native mobile editor project status](https://github.com/WordPress/gutenberg/tree/HEAD/docs/contributors/code/react-native/README.md#project-status) for background.
+
 # `RCTAztecView`
 
 Render a rich text area that displays the HTML content provided.

--- a/packages/react-native-bridge/README.md
+++ b/packages/react-native-bridge/README.md
@@ -1,5 +1,7 @@
 # react-native-gutenberg-bridge
 
+> **Status:** This package is unmaintained on `trunk` and is known to be broken following the upgrade to React 19 ([#61521](https://github.com/WordPress/gutenberg/pull/61521)). For patches to the existing Gutenberg Mobile build, branch from the most recent React Native release — tag [`rnmobile/1.121.0`](https://github.com/WordPress/gutenberg/releases/tag/rnmobile%2F1.121.0) at commit [`e63b8b8`](https://github.com/WordPress/gutenberg/commit/e63b8b8be7bdc5e9dd2781c597e918a7be212fe5) (see [#63744](https://github.com/WordPress/gutenberg/pull/63744)). See the [React Native mobile editor project status](https://github.com/WordPress/gutenberg/tree/HEAD/docs/contributors/code/react-native/README.md#project-status) for background.
+
 ## Getting started
 
 This package is not yet published to npm. You can use it locally:

--- a/packages/react-native-editor/README.md
+++ b/packages/react-native-editor/README.md
@@ -2,6 +2,8 @@
 
 This package provides a demo application to simplify the environment setup required for the development of Gutenberg for native Android and iOS. The demo application allows running the mobile versions of Gutenberg blocks while avoiding the additional setup steps required by the [WordPress Android](https://github.com/wordpress-mobile/WordPress-Android) and [WordPress iOS](https://github.com/wordpress-mobile/WordPress-iOS) apps.
 
+> **Status:** This package is unmaintained on `trunk` and is known to be broken following the upgrade to React 19 ([#61521](https://github.com/WordPress/gutenberg/pull/61521)). To patch the existing Gutenberg Mobile build, branch from the most recent React Native release — tag [`rnmobile/1.121.0`](https://github.com/WordPress/gutenberg/releases/tag/rnmobile%2F1.121.0) at commit [`e63b8b8`](https://github.com/WordPress/gutenberg/commit/e63b8b8be7bdc5e9dd2781c597e918a7be212fe5) (see [#63744](https://github.com/WordPress/gutenberg/pull/63744)) — and cut a minor release from there. See the [React Native mobile editor project status](https://github.com/WordPress/gutenberg/tree/HEAD/docs/contributors/code/react-native/README.md#project-status) for background.
+
 ## Getting Started
 
 Please review [Getting Started for the React Native based Mobile Gutenberg](https://github.com/WordPress/gutenberg/tree/HEAD/docs/contributors/code/react-native/getting-started-react-native.md) to learn how to set up and run this demo application.


### PR DESCRIPTION
## What?

Documents the React Native mobile editor's current status on `trunk` following the upgrade to React 19 (#61521) and points contributors at the right branching point for any fixes to the existing Gutenberg Mobile build.

Updated files:

- `docs/contributors/code/react-native/README.md` — adds a **Project status** section as the canonical source for the current state.
- `docs/contributors/code/react-native/getting-started-react-native.md` — adds a heads-up at the top, linking back to the project status section.
- `packages/react-native-editor/README.md`, `packages/react-native-bridge/README.md`, `packages/react-native-aztec/README.md` — adds a short status callout in each package README.
- `CONTRIBUTING.md` — replaces the "mirror `.native.js` changes" directive with a note that it's no longer required on `trunk`, and points RN fixes at the appropriate release tag.

## Why?

From the React 19 tracking issue (#71336):

> While breaking Gutenberg Mobile on `trunk` doesn't seem to be an ideal next step, it's a necessary one. The WP Mobile project is actively exploring paths forward for the block editor in the mobile apps, aiming to reduce complexity and improve alignment with the Gutenberg web project. There is currently little to no active work on the Gutenberg Mobile project. Therefore, to avoid encumbering the web project and its surrounding community, we must upgrade React and accept that doing so introduces technical debt for Gutenberg Mobile.

This PR addresses the still-unchecked task on that tracking issue:

> - [ ] Update documentation to make it clear that the RN implementation is paused and may be broken in `trunk`.

If a fix is needed against the existing Gutenberg Mobile build, the docs now direct contributors to branch from tag [`rnmobile/1.121.0`](https://github.com/WordPress/gutenberg/releases/tag/rnmobile%2F1.121.0) (commit [`e63b8b8`](https://github.com/WordPress/gutenberg/commit/e63b8b8be7bdc5e9dd2781c597e918a7be212fe5), #63744) — the latest React Native release before the React 19 upgrade — and cut a minor release from there.

## How?

Docs-only — no code or build changes. Each notice references PR #61521 and links back to the central **Project status** section so any entry point surfaces the same information.

## Testing Instructions

- Read through the updated files and confirm the wording is accurate.
- Verify the links to #61521, #63744, #71336, the `rnmobile/1.121.0` tag, and the `e63b8b8` commit resolve correctly.
- Confirm the in-repo links (e.g. from `getting-started-react-native.md` to the project status section) work.

### Testing Instructions for Keyboard

N/A — docs only.

## Screenshots or screencast

N/A — docs only.