### PR TITLE
Theme: apply ThemeProvider styles inline (I2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53601,6 +53601,7 @@
 			"version": "0.15.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@wordpress/compose": "file:../compose",
 				"@wordpress/element": "file:../element",
 				"@wordpress/style-runtime": "file:../style-runtime",
 				"colorjs.io": "^0.6.0",

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 -   Add unit tests for `ThemeProvider` and `useThemeProviderStyles` ([#79126](https://github.com/WordPress/gutenberg/pull/79126)).
 -   Run the stylelint plugin tests through the stylelint Node API instead of spawning the CLI via `child_process` ([#79199](https://github.com/WordPress/gutenberg/pull/79199)).
+-   `ThemeProvider`: Apply scoped custom properties via inline `style` (and `document.documentElement.style` when `isRoot`) instead of a per-instance `<style>` element ([#78678](https://github.com/WordPress/gutenberg/pull/78678)).
 
 ### Documentation
 

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -38,7 +38,6 @@
 
 -   Add unit tests for `ThemeProvider` and `useThemeProviderStyles` ([#79126](https://github.com/WordPress/gutenberg/pull/79126)).
 -   Run the stylelint plugin tests through the stylelint Node API instead of spawning the CLI via `child_process` ([#79199](https://github.com/WordPress/gutenberg/pull/79199)).
--   `ThemeProvider`: Apply scoped custom properties via inline `style` (and `document.documentElement.style` when `isRoot`) instead of a per-instance `<style>` element ([#78678](https://github.com/WordPress/gutenberg/pull/78678)).
 
 ### Documentation
 
@@ -46,6 +45,7 @@
 
 ### Code Quality
 
+-   `ThemeProvider`: Apply scoped custom properties via inline `style` (mirrored onto the wrapper's own document element when `isRoot`) instead of a per-instance `<style>` element ([#78678](https://github.com/WordPress/gutenberg/pull/78678)).
 -   `ThemeProvider`: Stop serializing `data-wpds-root-provider="false"` on non-root providers by only setting the attribute when `isRoot` is `true` ([#79253](https://github.com/WordPress/gutenberg/pull/79253)).
 -   Declare `postcss`, `esbuild`, and `vite` as optional peer dependencies for the bundler plugins, and move `@types/react` from `dependencies` to an optional peer dependency ([#79095](https://github.com/WordPress/gutenberg/pull/79095)).
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -79,6 +79,7 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
+		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/style-runtime": "file:../style-runtime",
 		"colorjs.io": "^0.6.0",

--- a/packages/theme/src/test/theme-provider.test.tsx
+++ b/packages/theme/src/test/theme-provider.test.tsx
@@ -8,9 +8,8 @@ import { join } from 'path';
 import { render, screen } from '@testing-library/react';
 import { ThemeProvider } from '../theme-provider';
 
-// Mock the CSS module so the provider's wrapper has a stable class. The tests
-// use this class as the scoping selector (in place of any instance-specific
-// attribute) and to read computed custom properties from the wrapper itself.
+// Give the wrapper a stable class so tests can locate it and read its
+// computed custom properties.
 jest.mock( '../style.module.css', () => ( {
 	root: 'theme-provider-root',
 } ) );
@@ -144,20 +143,14 @@ describe( 'ThemeProvider', () => {
 
 			unmount();
 
-			// The effect cleanup restores the previous value — here none, so
-			// the property is removed rather than left stuck on the seed.
+			// No prior value, so cleanup removes the property entirely.
 			expect( readProp( document.documentElement, BRAND_BG ) ).toBe( '' );
 		} );
 
-		// Unlike color/cursor (applied as inline custom properties on the
-		// provider's wrapper), the `cornerRadius` preset resolves to
-		// `--wpds-border-radius-*` values through the prebuilt design-token CSS
-		// (the modes authored in `terrazzo.config.ts`). A root provider relies
-		// on that stylesheet's `:root:has( [data-wpds-root-provider='true']… )`
-		// rule to forward the preset to the document element, so these tests
-		// load the prebuilt CSS to exercise it. It is injected only for this
-		// block (it also defines base tokens on `:root`) to avoid interfering
-		// with the color assertions above.
+		// `cornerRadius` forwards to `:root` through the prebuilt CSS's
+		// `:root:has( [data-wpds-root-provider='true']… )` rule (not the JS
+		// mirror used for color/cursor), so load that stylesheet to exercise
+		// it. Scoped to this block since it also defines base `:root` tokens.
 		describe( 'cornerRadius forwarding', () => {
 			let prebuiltStyle: HTMLStyleElement;
 

--- a/packages/theme/src/test/theme-provider.test.tsx
+++ b/packages/theme/src/test/theme-provider.test.tsx
@@ -147,6 +147,66 @@ describe( 'ThemeProvider', () => {
 			expect( readProp( document.documentElement, BRAND_BG ) ).toBe( '' );
 		} );
 
+		it( "forwards tokens to the wrapper's own document, not the top document", () => {
+			const iframe = document.createElement( 'iframe' );
+			document.body.appendChild( iframe );
+			const iframeDoc = iframe.contentDocument!;
+
+			const { unmount } = render(
+				<ThemeProvider isRoot color={ { primary: PRIMARY } }>
+					<div>x</div>
+				</ThemeProvider>,
+				{ container: iframeDoc.body }
+			);
+
+			expect( readProp( iframeDoc.documentElement, BRAND_BG ) ).toBe(
+				PRIMARY
+			);
+			expect( readProp( document.documentElement, BRAND_BG ) ).toBe( '' );
+
+			unmount();
+			iframe.remove();
+		} );
+
+		it( 'warns when multiple root providers share a document', () => {
+			const warn = jest
+				.spyOn( console, 'warn' )
+				.mockImplementation( () => {} );
+
+			render(
+				<>
+					<ThemeProvider isRoot color={ { primary: PRIMARY } }>
+						<div>a</div>
+					</ThemeProvider>
+					<ThemeProvider isRoot color={ { primary: OTHER_PRIMARY } }>
+						<div>b</div>
+					</ThemeProvider>
+				</>
+			);
+
+			expect( warn ).toHaveBeenCalledWith(
+				expect.stringContaining( 'More than one root provider' )
+			);
+
+			warn.mockRestore();
+		} );
+
+		it( 'does not warn for a single root provider', () => {
+			const warn = jest
+				.spyOn( console, 'warn' )
+				.mockImplementation( () => {} );
+
+			render(
+				<ThemeProvider isRoot color={ { primary: PRIMARY } }>
+					<div>x</div>
+				</ThemeProvider>
+			);
+
+			expect( warn ).not.toHaveBeenCalled();
+
+			warn.mockRestore();
+		} );
+
 		// `cornerRadius` forwards to `:root` through the prebuilt CSS's
 		// `:root:has( [data-wpds-root-provider='true']… )` rule (not the JS
 		// mirror used for color/cursor), so load that stylesheet to exercise

--- a/packages/theme/src/test/theme-provider.test.tsx
+++ b/packages/theme/src/test/theme-provider.test.tsx
@@ -151,12 +151,16 @@ describe( 'ThemeProvider', () => {
 			const iframe = document.createElement( 'iframe' );
 			document.body.appendChild( iframe );
 			const iframeDoc = iframe.contentDocument!;
+			// Mount into a child element (not the iframe `body` directly, which
+			// React warns against) so the wrapper's `ownerDocument` is the iframe.
+			const mount = iframeDoc.createElement( 'div' );
+			iframeDoc.body.appendChild( mount );
 
 			const { unmount } = render(
 				<ThemeProvider isRoot color={ { primary: PRIMARY } }>
 					<div>x</div>
 				</ThemeProvider>,
-				{ container: iframeDoc.body }
+				{ container: mount }
 			);
 
 			expect( readProp( iframeDoc.documentElement, BRAND_BG ) ).toBe(

--- a/packages/theme/src/test/theme-provider.test.tsx
+++ b/packages/theme/src/test/theme-provider.test.tsx
@@ -8,9 +8,9 @@ import { join } from 'path';
 import { render, screen } from '@testing-library/react';
 import { ThemeProvider } from '../theme-provider';
 
-// Mock the CSS module so the provider's scoping class is a real, stable class
-// name. Without this the global Jest CSS mock leaves the class `undefined`, and
-// jsdom cannot match the generated rules to compute the custom properties.
+// Mock the CSS module so the provider's wrapper has a stable class. The tests
+// use this class as the scoping selector (in place of any instance-specific
+// attribute) and to read computed custom properties from the wrapper itself.
 jest.mock( '../style.module.css', () => ( {
 	root: 'theme-provider-root',
 } ) );
@@ -34,7 +34,7 @@ function readProp( element: Element, property: string ) {
 
 // The `ThemeProvider` wrapper element that scopes the given descendant.
 function getScopingProvider( element: Element ) {
-	return element.closest< HTMLElement >( '[data-wpds-theme-provider-id]' )!;
+	return element.closest< HTMLElement >( '.theme-provider-root' )!;
 }
 
 describe( 'ThemeProvider', () => {
@@ -131,8 +131,8 @@ describe( 'ThemeProvider', () => {
 			expect( readProp( document.documentElement, BRAND_BG ) ).toBe( '' );
 		} );
 
-		// Unlike color/cursor (emitted at runtime in the provider's own
-		// `<style>`), the `cornerRadius` preset resolves to
+		// Unlike color/cursor (applied as inline custom properties on the
+		// provider's wrapper), the `cornerRadius` preset resolves to
 		// `--wpds-border-radius-*` values through the prebuilt design-token CSS
 		// (the modes authored in `terrazzo.config.ts`). A root provider relies
 		// on that stylesheet's `:root:has( [data-wpds-root-provider='true']… )`

--- a/packages/theme/src/test/theme-provider.test.tsx
+++ b/packages/theme/src/test/theme-provider.test.tsx
@@ -131,6 +131,24 @@ describe( 'ThemeProvider', () => {
 			expect( readProp( document.documentElement, BRAND_BG ) ).toBe( '' );
 		} );
 
+		it( 'removes the forwarded properties from the document root on unmount', () => {
+			const { unmount } = render(
+				<ThemeProvider isRoot color={ { primary: PRIMARY } }>
+					<div>x</div>
+				</ThemeProvider>
+			);
+
+			expect( readProp( document.documentElement, BRAND_BG ) ).toBe(
+				PRIMARY
+			);
+
+			unmount();
+
+			// The effect cleanup restores the previous value — here none, so
+			// the property is removed rather than left stuck on the seed.
+			expect( readProp( document.documentElement, BRAND_BG ) ).toBe( '' );
+		} );
+
 		// Unlike color/cursor (applied as inline custom properties on the
 		// provider's wrapper), the `cornerRadius` preset resolves to
 		// `--wpds-border-radius-*` values through the prebuilt design-token CSS

--- a/packages/theme/src/theme-provider.tsx
+++ b/packages/theme/src/theme-provider.tsx
@@ -1,8 +1,13 @@
-import { useMemo, useLayoutEffect } from '@wordpress/element';
+import { useMemo, useRef, useLayoutEffect } from '@wordpress/element';
 import { ThemeContext } from './context';
 import { useThemeProviderStyles } from './use-theme-provider-styles';
 import { type ThemeProviderProps } from './types';
 import styles from './style.module.css';
+
+// Dev-only: count active root providers per document so we can warn when more
+// than one is mounted on the same document (their forwarded `html` styles
+// would conflict). Keyed weakly so iframe documents don't leak.
+const rootProviderCountByDocument = new WeakMap< Document, number >();
 
 /**
  * Context provider that generates a theme from a set of seed color values and
@@ -31,16 +36,35 @@ export const ThemeProvider = ( {
 		[ resolvedSettings ]
 	);
 
-	// For root providers, mirror the wrapper's custom properties onto `html`
-	// so they reach portals and content outside the React app. `html` is
-	// shared, so set/remove individual properties (restoring any prior value)
-	// rather than assigning a whole style object. (Preset settings like
-	// `cornerRadius` are forwarded by the prebuilt CSS instead.)
+	const wrapperRef = useRef< HTMLDivElement >( null );
+
+	// For root providers, mirror the wrapper's custom properties onto the
+	// document element of the wrapper's own document (which may be an iframe)
+	// so they reach portals and content rendered outside the React subtree.
+	// `html` is shared, so set/remove individual properties (restoring any
+	// prior value) rather than assigning a whole style object. Preset settings
+	// like `cornerRadius` are forwarded by the prebuilt CSS instead.
 	useLayoutEffect( () => {
-		if ( ! isRoot || typeof document === 'undefined' ) {
+		if ( ! isRoot ) {
 			return;
 		}
-		const root = document.documentElement;
+		const doc = wrapperRef.current?.ownerDocument;
+		if ( ! doc ) {
+			return;
+		}
+		const root = doc.documentElement;
+
+		if ( process.env.NODE_ENV !== 'production' ) {
+			const active = rootProviderCountByDocument.get( doc ) ?? 0;
+			if ( active > 0 ) {
+				// eslint-disable-next-line no-console
+				console.warn(
+					'ThemeProvider: More than one root provider (`isRoot`) is mounted on the same document. Their forwarded document-level styles conflict, and unmounting one can reset the others. Render a single root provider per document.'
+				);
+			}
+			rootProviderCountByDocument.set( doc, active + 1 );
+		}
+
 		const previous = new Map< string, string >();
 		const applied: string[] = [];
 
@@ -60,6 +84,15 @@ export const ThemeProvider = ( {
 		}
 
 		return () => {
+			if ( process.env.NODE_ENV !== 'production' ) {
+				const active = rootProviderCountByDocument.get( doc ) ?? 1;
+				if ( active <= 1 ) {
+					rootProviderCountByDocument.delete( doc );
+				} else {
+					rootProviderCountByDocument.set( doc, active - 1 );
+				}
+			}
+
 			for ( const key of applied ) {
 				const prev = previous.get( key );
 				if ( prev ) {
@@ -73,7 +106,8 @@ export const ThemeProvider = ( {
 
 	return (
 		<div
-			data-wpds-root-provider={ isRoot ? 'true' : undefined }
+			ref={ wrapperRef }
+			data-wpds-root-provider={ isRoot || undefined }
 			data-wpds-corner-radius={ cornerRadiusPreset }
 			className={ styles.root }
 			style={ themeProviderStyles }

--- a/packages/theme/src/theme-provider.tsx
+++ b/packages/theme/src/theme-provider.tsx
@@ -31,16 +31,11 @@ export const ThemeProvider = ( {
 		[ resolvedSettings ]
 	);
 
-	// Mirror the wrapper's dynamic custom properties (color/cursor) onto
-	// `document.documentElement` so they reach portals and anything else
-	// rendered outside the wrapper (e.g. the `html`/`body` background, or
-	// PHP-rendered admin UI alongside the React app). Preset-based settings
-	// (e.g. `cornerRadius`) are forwarded declaratively by the prebuilt CSS
-	// via `:root:has([data-wpds-root-provider="true"]…)`; only the per-seed
-	// values that can't be expressed in a static stylesheet are synced here.
-	// Unlike the wrapper, `html` is a shared element, so we set/remove
-	// individual properties (preserving any prior value) instead of
-	// declaratively assigning a full style object.
+	// For root providers, mirror the wrapper's custom properties onto `html`
+	// so they reach portals and content outside the React app. `html` is
+	// shared, so set/remove individual properties (restoring any prior value)
+	// rather than assigning a whole style object. (Preset settings like
+	// `cornerRadius` are forwarded by the prebuilt CSS instead.)
 	useLayoutEffect( () => {
 		if ( ! isRoot || typeof document === 'undefined' ) {
 			return;

--- a/packages/theme/src/theme-provider.tsx
+++ b/packages/theme/src/theme-provider.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useRef, useLayoutEffect } from '@wordpress/element';
+import { useMemo, useRef } from '@wordpress/element';
+import { useIsomorphicLayoutEffect } from '@wordpress/compose';
 import { ThemeContext } from './context';
 import { useThemeProviderStyles } from './use-theme-provider-styles';
 import { type ThemeProviderProps } from './types';
@@ -44,7 +45,7 @@ export const ThemeProvider = ( {
 	// `html` is shared, so set/remove individual properties (restoring any
 	// prior value) rather than assigning a whole style object. Preset settings
 	// like `cornerRadius` are forwarded by the prebuilt CSS instead.
-	useLayoutEffect( () => {
+	useIsomorphicLayoutEffect( () => {
 		if ( ! isRoot ) {
 			return;
 		}

--- a/packages/theme/src/theme-provider.tsx
+++ b/packages/theme/src/theme-provider.tsx
@@ -1,38 +1,8 @@
-import type { CSSProperties } from 'react';
-import { useMemo, useId } from '@wordpress/element';
+import { useMemo, useLayoutEffect } from '@wordpress/element';
 import { ThemeContext } from './context';
 import { useThemeProviderStyles } from './use-theme-provider-styles';
 import { type ThemeProviderProps } from './types';
 import styles from './style.module.css';
-
-function cssObjectToText( values: CSSProperties ) {
-	return Object.entries( values )
-		.map( ( [ key, value ] ) => `${ key }: ${ value };` )
-		.join( '' );
-}
-
-function generateCSSSelector( {
-	instanceId,
-	isRoot,
-}: {
-	instanceId: string;
-	isRoot: boolean;
-} ) {
-	const rootSel = `[data-wpds-root-provider="true"]`;
-	const instanceIdSel = `[data-wpds-theme-provider-id="${ instanceId }"]`;
-
-	const selectors = [];
-
-	if ( isRoot ) {
-		selectors.push(
-			`:root:has(.${ styles.root }${ rootSel }${ instanceIdSel })`
-		);
-	}
-
-	selectors.push( `.${ styles.root }.${ styles.root }${ instanceIdSel }` );
-
-	return selectors.join( ',' );
-}
 
 /**
  * Context provider that generates a theme from a set of seed color values and
@@ -46,8 +16,6 @@ export const ThemeProvider = ( {
 	cornerRadius,
 	isRoot = false,
 }: ThemeProviderProps ) => {
-	const instanceId = useId();
-
 	const { themeProviderStyles, resolvedSettings } = useThemeProviderStyles( {
 		color,
 		cursor,
@@ -63,26 +31,55 @@ export const ThemeProvider = ( {
 		[ resolvedSettings ]
 	);
 
+	// Mirror the wrapper's custom properties onto `document.documentElement`
+	// so they reach portals and anything else rendered outside the wrapper
+	// (e.g. the `html`/`body` background). Unlike the wrapper, `html` is a
+	// shared element, so we set/remove individual properties (preserving any
+	// prior value) instead of declaratively assigning a full style object.
+	useLayoutEffect( () => {
+		if ( ! isRoot || typeof document === 'undefined' ) {
+			return;
+		}
+		const root = document.documentElement;
+		const previous = new Map< string, string >();
+		const applied: string[] = [];
+
+		for ( const [ rawKey, rawValue ] of Object.entries(
+			themeProviderStyles
+		) ) {
+			if (
+				! rawKey.startsWith( '--' ) ||
+				rawValue === null ||
+				rawValue === undefined
+			) {
+				continue;
+			}
+			previous.set( rawKey, root.style.getPropertyValue( rawKey ) );
+			root.style.setProperty( rawKey, String( rawValue ) );
+			applied.push( rawKey );
+		}
+
+		return () => {
+			for ( const key of applied ) {
+				const prev = previous.get( key );
+				if ( prev ) {
+					root.style.setProperty( key, prev );
+				} else {
+					root.style.removeProperty( key );
+				}
+			}
+		};
+	}, [ isRoot, themeProviderStyles ] );
+
 	return (
-		<>
-			{ themeProviderStyles ? (
-				<style>
-					{ `${ generateCSSSelector( {
-						instanceId,
-						isRoot,
-					} ) } {${ cssObjectToText( themeProviderStyles ) }}` }
-				</style>
-			) : null }
-			<div
-				data-wpds-theme-provider-id={ instanceId }
-				data-wpds-root-provider={ isRoot || undefined }
-				data-wpds-corner-radius={ cornerRadiusPreset }
-				className={ styles.root }
-			>
-				<ThemeContext.Provider value={ contextValue }>
-					{ children }
-				</ThemeContext.Provider>
-			</div>
-		</>
+		<div
+			data-wpds-corner-radius={ cornerRadiusPreset }
+			className={ styles.root }
+			style={ themeProviderStyles }
+		>
+			<ThemeContext.Provider value={ contextValue }>
+				{ children }
+			</ThemeContext.Provider>
+		</div>
 	);
 };

--- a/packages/theme/src/theme-provider.tsx
+++ b/packages/theme/src/theme-provider.tsx
@@ -31,11 +31,16 @@ export const ThemeProvider = ( {
 		[ resolvedSettings ]
 	);
 
-	// Mirror the wrapper's custom properties onto `document.documentElement`
-	// so they reach portals and anything else rendered outside the wrapper
-	// (e.g. the `html`/`body` background). Unlike the wrapper, `html` is a
-	// shared element, so we set/remove individual properties (preserving any
-	// prior value) instead of declaratively assigning a full style object.
+	// Mirror the wrapper's dynamic custom properties (color/cursor) onto
+	// `document.documentElement` so they reach portals and anything else
+	// rendered outside the wrapper (e.g. the `html`/`body` background, or
+	// PHP-rendered admin UI alongside the React app). Preset-based settings
+	// (e.g. `cornerRadius`) are forwarded declaratively by the prebuilt CSS
+	// via `:root:has([data-wpds-root-provider="true"]…)`; only the per-seed
+	// values that can't be expressed in a static stylesheet are synced here.
+	// Unlike the wrapper, `html` is a shared element, so we set/remove
+	// individual properties (preserving any prior value) instead of
+	// declaratively assigning a full style object.
 	useLayoutEffect( () => {
 		if ( ! isRoot || typeof document === 'undefined' ) {
 			return;
@@ -73,6 +78,7 @@ export const ThemeProvider = ( {
 
 	return (
 		<div
+			data-wpds-root-provider={ isRoot ? 'true' : undefined }
 			data-wpds-corner-radius={ cornerRadiusPreset }
 			className={ styles.root }
 			style={ themeProviderStyles }

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -5,6 +5,7 @@
 	},
 	"files": [],
 	"references": [
+		{ "path": "../compose" },
 		{ "path": "../style-runtime" },
 		{ "path": "./tsconfig.src.json" },
 		{ "path": "./tsconfig.bin.json" }

--- a/packages/theme/tsconfig.src.json
+++ b/packages/theme/tsconfig.src.json
@@ -7,5 +7,9 @@
 	},
 	"exclude": [],
 	"files": [ "global.d.ts" ],
-	"references": [ { "path": "../element" }, { "path": "../style-runtime" } ]
+	"references": [
+		{ "path": "../compose" },
+		{ "path": "../element" },
+		{ "path": "../style-runtime" }
+	]
 }


### PR DESCRIPTION
## What?

Addresses **I2** from #77462. Replaces `ThemeProvider`'s per-instance `<style>` with inline custom properties on the wrapper, mirrored onto the document element when `isRoot`.

## Why?

One fewer DOM node per provider and a simpler mental model — no per-instance scoping selector to build, no doubled-class specificity hack, no `data-wpds-theme-provider-id`.

## How?

- Color/cursor tokens go on the wrapper's `style` prop.
- For `isRoot`, a `useLayoutEffect` mirrors them onto the wrapper's own document element (resolved via `ownerDocument`, so it also works inside iframes) and restores the prior value on cleanup (falling back to the prebuilt `:root` defaults from #78664).
- Dev-only: warns when more than one `isRoot` provider is mounted on the same document, since their `<html>`-level forwarding would conflict.
- Drops the per-instance `<style>`, `useId`, the doubled-class hack, the runtime `:root:has(…)` selector, and `data-wpds-theme-provider-id`.
- Keeps `data-wpds-root-provider="true"` on the wrapper so the prebuilt CSS can forward preset-based settings to `:root` (`cornerRadius`, see #79153).

<details>
<summary>Why the asymmetry between color/cursor and cornerRadius forwarding?</summary>

Dynamic values (color seeds, cursor) are per-instance and can't be expressed in a static stylesheet, so JS syncs them to `<html>`. Preset-based values (e.g. `cornerRadius`) are a small known set fully resolved in the prebuilt CSS, where `:root:has([data-wpds-root-provider="true"][data-wpds-corner-radius="…"])` is the cleanest forwarding mechanism. Both paths reuse the same `data-wpds-root-provider` marker.

This always materializes the **full** resolved token set on each provider's own DOM node (it never skips when values match defaults) — required for nested reset-to-default and for theme inheritance across portal boundaries, consistent with the model settled in #78664.

</details>

<details>
<summary>Cascade note</summary>

Custom properties now arrive via inline `style` on the wrapper (and inline on `<html>` for `isRoot`) rather than a scoped `<style>`/`:root:has` rule, i.e. at a higher specificity. Descendant and nested-provider overrides are unaffected (they win by proximity), and `!important` author rules still win. The only thing affected would be a non-`!important` author rule targeting the wrapper element or `:root` directly — unusual against an internal `display: contents` element.

</details>

## Testing Instructions

1. Render `<ThemeProvider isRoot color={…} cursor={…} cornerRadius="…">` with a few nested `<ThemeProvider>`s.
2. In DevTools: confirm no `<style>` element under the provider, color/cursor tokens are inline on the wrapper, and the root wrapper has `data-wpds-root-provider="true"`.
3. Confirm root color/cursor reach `<html>` and revert on unmount.
4. Confirm portals (popovers, drawers, dialogs) still inherit the root provider's tokens.
5. `npm run test:unit -- packages/theme` passes.

### Testing Instructions for Keyboard

No UI-facing changes.

## Screenshots or screencast

N/A — no visual changes intended.

## Use of AI Tools

Made with Cursor.
