### PR TITLE
Validate additional CSS on mount

### DIFF
--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -86,10 +86,6 @@ export default function AdvancedPanel( {
 	function handleOnBlur( event ) {
 		const cssValue = event?.target?.value;
 
-		if ( ! cssValue || ! validateCSS( cssValue ) ) {
-			return;
-		}
-
 		setCSSError( getCSSValidationError( cssValue ) );
 	}
 

--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -29,6 +29,41 @@ export function validateCSS( css ) {
 	return true;
 }
 
+/**
+ * Returns the error message string if the CSS contains HTML markup, or null if it is clean.
+ *
+ * @param {string} css The CSS string to check.
+ * @return {string|null} An error message, or null if the CSS is valid.
+ */
+function getMarkupValidationError( css ) {
+	return validateCSS( css )
+		? null
+		: __( 'The custom CSS is invalid. Do not use <> markup.' );
+}
+
+/**
+ * Full CSS validation: markup check first (fast), then a CSS parser (slower).
+ *
+ * @param {string} css The CSS string to validate.
+ * @return {string|null} An error message, or null if the CSS is valid.
+ */
+export function getCSSValidationError( css ) {
+	if ( ! css ) {
+		return null;
+	}
+	const markupError = getMarkupValidationError( css );
+	if ( markupError ) {
+		return markupError;
+	}
+	const [ transformed ] = transformStyles(
+		[ { css } ],
+		'.for-validation-only'
+	);
+	return transformed === null
+		? __( 'There is an error with your CSS structure.' )
+		: null;
+}
+
 export default function AdvancedPanel( {
 	value,
 	onChange,
@@ -36,26 +71,17 @@ export default function AdvancedPanel( {
 	help,
 } ) {
 	// Custom CSS
-	const [ cssError, setCSSError ] = useState( null );
 	const customCSS = inheritedValue?.css;
+	const [ cssError, setCSSError ] = useState( () =>
+		getCSSValidationError( customCSS )
+	);
 	function handleOnChange( newValue ) {
 		onChange( {
 			...value,
 			css: newValue,
 		} );
 
-		// Validate immediately on change for quick feedback.
-		if ( ! validateCSS( newValue ) ) {
-			setCSSError(
-				__( 'The custom CSS is invalid. Do not use <> markup.' )
-			);
-			return;
-		}
-
-		// Clear HTML markup error if CSS is now valid.
-		if ( cssError ) {
-			setCSSError( null );
-		}
+		setCSSError( getMarkupValidationError( newValue ) );
 	}
 	function handleOnBlur( event ) {
 		const cssValue = event?.target?.value;
@@ -64,19 +90,7 @@ export default function AdvancedPanel( {
 			return;
 		}
 
-		// Check if the value is valid CSS structure on blur (more expensive check).
-		// Pass a wrapping selector to ensure that `transformStyles` validates the CSS.
-		// Note that the wrapping selector here is not used in the actual output of any styles.
-		const [ transformed ] = transformStyles(
-			[ { css: cssValue } ],
-			'.for-validation-only'
-		);
-
-		setCSSError(
-			transformed === null
-				? __( 'There is an error with your CSS structure.' )
-				: null
-		);
+		setCSSError( getCSSValidationError( cssValue ) );
 	}
 
 	return (

--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -87,7 +87,7 @@ export default function AdvancedPanel( {
 	}
 
 	return (
-		<Stack direction="column" spacing={ 3 }>
+		<Stack direction="column" gap="md">
 			{ cssError && (
 				<Notice status="error" onRemove={ () => setCSSError( null ) }>
 					{ cssError }

--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -81,9 +81,7 @@ export default function AdvancedPanel( {
 		setCSSError( getMarkupValidationError( newValue ) );
 	}
 	function handleOnBlur( event ) {
-		const cssValue = event?.target?.value;
-
-		setCSSError( getCSSValidationError( cssValue ) );
+		setCSSError( getCSSValidationError( event?.target?.value ) );
 	}
 
 	return (

--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -1,11 +1,8 @@
 /**
  * WordPress dependencies
  */
-import {
-	TextareaControl,
-	Notice,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { TextareaControl, Notice } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -90,7 +87,7 @@ export default function AdvancedPanel( {
 	}
 
 	return (
-		<VStack spacing={ 3 }>
+		<Stack direction="column" spacing={ 3 }>
 			{ cssError && (
 				<Notice status="error" onRemove={ () => setCSSError( null ) }>
 					{ cssError }
@@ -105,6 +102,6 @@ export default function AdvancedPanel( {
 				spellCheck={ false }
 				help={ help }
 			/>
-		</VStack>
+		</Stack>
 	);
 }

--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -47,7 +47,7 @@ function getMarkupValidationError( css ) {
  * @param {string} css The CSS string to validate.
  * @return {string|null} An error message, or null if the CSS is valid.
  */
-export function getCSSValidationError( css ) {
+function getCSSValidationError( css ) {
 	if ( ! css ) {
 		return null;
 	}

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -132,11 +132,6 @@
 			"count": 2
 		}
 	},
-	"packages/block-editor/src/components/global-styles/advanced-panel.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/block-editor/src/components/global-styles/color-panel.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 3
@@ -1552,11 +1547,6 @@
 	"packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx": {
 		"react-hooks/refs": {
 			"count": 1
-		}
-	},
-	"packages/media-editor/src/image-editor/react/hooks/use-cropper-state.ts": {
-		"react-hooks/refs": {
-			"count": 2
 		}
 	},
 	"packages/media-editor/src/image-editor/react/hooks/use-interaction.ts": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

If you have invalid CSS saved in the Additional CSS field (either site-wide or per-block) and navigate away and come back, the error notice wouldn't appear until you actually interact with the field (typed or tabbed out of it). 

This fix modifies the checks to show the CSS validation error notice immediately when the additional CSS panel mounts, without requiring any interaction.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

If you had some invalid CSS saved you wouldn't have any indication that things were wrong until you interacted with the field.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

`useState( null )` always started with no error. We're replacing that with a lazy initializer. Two smaller refactors came along with this, so that we can re-use the checks for the different actions.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Go to Appearance > Editor > Styles > Additional CSS
2. Enter some invalid CSS, save, and navigate away
3. Come back to the Additional CSS panel, and see the error notice without clicking or typing anything
4. Repeat with a block that has per-block CSS set to something invalid via the block's advanced inspector panel
5. Confirm that typing in the field still shows the markup error inline as you type, and that tabbing out still catches structural CSS errors.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/774df3f9-19f5-453d-900a-0e4d39b7f506


https://github.com/user-attachments/assets/d3bb3f03-8176-4db9-8329-5cb526cfa384

