### PR TITLE
Navigation Link: show indicator for legacy links with `id` but no dynamic binding

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -35,9 +35,11 @@ import {
 	LinkUI,
 	useEntityBinding,
 	getInvalidLinkHelpText,
+	getLegacyUnboundHelpText,
 	useHandleLinkChange,
 	useIsInvalidLink,
 	InvalidDraftDisplay,
+	NeedsUpdateDisplay,
 	useEnableLinkStatusValidation,
 	useIsDraggingWithin,
 	selectLabelText,
@@ -309,8 +311,13 @@ export default function NavigationLinkEdit( {
 
 	const instanceId = useInstanceId( NavigationLinkEdit );
 	const hasMissingEntity = hasUrlBinding && ! isBoundEntityAvailable;
+	const hasLegacyUnboundId =
+		validateLinkStatus && Number.isInteger( id ) && ! kind;
 	const missingEntityDescriptionId = hasMissingEntity
 		? sprintf( 'navigation-link-edit-%d-desc', instanceId )
+		: undefined;
+	const legacyUnboundDescriptionId = hasLegacyUnboundId
+		? sprintf( 'navigation-link-edit-%d-legacy-unbound-desc', instanceId )
 		: undefined;
 
 	const blockProps = useBlockProps( {
@@ -326,8 +333,11 @@ export default function NavigationLinkEdit( {
 			[ getColorClassName( 'background-color', backgroundColor ) ]:
 				!! backgroundColor,
 		} ),
-		'aria-describedby': missingEntityDescriptionId,
-		'aria-invalid': hasMissingEntity,
+		'aria-describedby': clsx( {
+			[ missingEntityDescriptionId ]: hasMissingEntity,
+			[ legacyUnboundDescriptionId ]: hasLegacyUnboundId,
+		} ),
+		'aria-invalid': hasMissingEntity || hasLegacyUnboundId,
 		style: {
 			color: ! textColor && customTextColor,
 			backgroundColor: ! backgroundColor && customBackgroundColor,
@@ -351,6 +361,7 @@ export default function NavigationLinkEdit( {
 		( ! url && ! ( hasUrlBinding && isBoundEntityAvailable ) ) ||
 		isInvalid ||
 		isDraft ||
+		hasLegacyUnboundId ||
 		( hasUrlBinding && ! isBoundEntityAvailable );
 
 	if ( needsValidLink ) {
@@ -365,6 +376,7 @@ export default function NavigationLinkEdit( {
 
 	const missingText = getMissingText( type );
 	const invalidLinkHelpText = getInvalidLinkHelpText();
+	const legacyUnboundHelpText = getLegacyUnboundHelpText();
 
 	return (
 		<>
@@ -402,6 +414,11 @@ export default function NavigationLinkEdit( {
 						{ invalidLinkHelpText }
 					</VisuallyHidden>
 				) }
+				{ hasLegacyUnboundId && (
+					<VisuallyHidden id={ legacyUnboundDescriptionId }>
+						{ legacyUnboundHelpText }
+					</VisuallyHidden>
+				) }
 				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
 				<a className={ classes }>
 					{ /* eslint-enable */ }
@@ -411,45 +428,53 @@ export default function NavigationLinkEdit( {
 						</div>
 					) : (
 						<>
-							{ ! isInvalid && ! isDraft && (
-								<>
-									<RichText
-										ref={ ref }
-										identifier="label"
-										className="wp-block-navigation-item__label"
-										value={ label }
-										onChange={ ( labelValue ) =>
-											setAttributes( {
-												label: labelValue,
-											} )
-										}
-										onMerge={ mergeBlocks }
-										onReplace={ onReplace }
-										__unstableOnSplitAtEnd={ () =>
-											insertBlocksAfter(
-												createBlock(
-													'core/navigation-link'
+							{ ! isInvalid &&
+								! isDraft &&
+								! hasLegacyUnboundId && (
+									<>
+										<RichText
+											ref={ ref }
+											identifier="label"
+											className="wp-block-navigation-item__label"
+											value={ label }
+											onChange={ ( labelValue ) =>
+												setAttributes( {
+													label: labelValue,
+												} )
+											}
+											onMerge={ mergeBlocks }
+											onReplace={ onReplace }
+											__unstableOnSplitAtEnd={ () =>
+												insertBlocksAfter(
+													createBlock(
+														'core/navigation-link'
+													)
 												)
-											)
-										}
-										aria-label={ __(
-											'Navigation link text'
+											}
+											aria-label={ __(
+												'Navigation link text'
+											) }
+											placeholder={ itemLabelPlaceholder }
+											withoutInteractiveFormatting
+										/>
+										{ description && (
+											<span className="wp-block-navigation-item__description">
+												{ description }
+											</span>
 										) }
-										placeholder={ itemLabelPlaceholder }
-										withoutInteractiveFormatting
-									/>
-									{ description && (
-										<span className="wp-block-navigation-item__description">
-											{ description }
-										</span>
-									) }
-								</>
-							) }
+									</>
+								) }
 							{ ( isInvalid || isDraft ) && (
 								<InvalidDraftDisplay
 									label={ label }
 									isInvalid={ isInvalid }
 									isDraft={ isDraft }
+									className="wp-block-navigation-link__label"
+								/>
+							) }
+							{ hasLegacyUnboundId && (
+								<NeedsUpdateDisplay
+									label={ label }
 									className="wp-block-navigation-link__label"
 								/>
 							) }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -319,6 +319,17 @@ export function getInvalidLinkHelpText() {
 }
 
 /**
+ * Returns the help text for unbound legacy links that were created before entity binding was implemented.
+ *
+ * @return {string} Unbound legacy link help text
+ */
+export function getLegacyUnboundHelpText() {
+	return __(
+		'This link was created before entity binding was added to navigation links. Please select a new link to fix this item or remove it if it is no longer needed.'
+	);
+}
+
+/**
  * Returns the help text for links to draft entities
  *
  * @param {Object} props      - Function props

--- a/packages/block-library/src/navigation-link/shared/index.js
+++ b/packages/block-library/src/navigation-link/shared/index.js
@@ -5,7 +5,11 @@
  * to reduce code duplication and ensure consistent behavior.
  */
 
-export { Controls, getInvalidLinkHelpText } from './controls';
+export {
+	Controls,
+	getInvalidLinkHelpText,
+	getLegacyUnboundHelpText,
+} from './controls';
 export { updateAttributes } from './update-attributes';
 export {
 	useEntityBinding,
@@ -15,6 +19,7 @@ export { LinkUI } from '../link-ui';
 export { useHandleLinkChange } from './use-handle-link-change';
 export { useIsInvalidLink } from './use-is-invalid-link';
 export { InvalidDraftDisplay } from './invalid-draft-display';
+export { NeedsUpdateDisplay } from './needs-update-display';
 export { useEnableLinkStatusValidation } from './use-enable-link-status-validation';
 export { useIsDraggingWithin } from './use-is-dragging-within';
 export { selectLabelText } from './select-label-text';

--- a/packages/block-library/src/navigation-link/shared/needs-update-display.js
+++ b/packages/block-library/src/navigation-link/shared/needs-update-display.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Displays a label with a "(Needs update)" indicator
+ * for legacy navigation links without dynamic bindings.
+ *
+ * @param {Object} props           Component props.
+ * @param {string} props.label     The label text to display.
+ * @param {string} props.className Optional additional CSS class for the label element.
+ *
+ * @return {Element} The needs update display component.
+ */
+export function NeedsUpdateDisplay( {
+	label,
+	className = 'wp-block-navigation-link__label',
+} ) {
+	return (
+		<div
+			className={ clsx(
+				'wp-block-navigation-link__placeholder-text',
+				className,
+				'is-needs-update'
+			) }
+		>
+			<span>
+				{ `${ decodeEntities( label ) } (${ __(
+					'Needs update'
+				) })`.trim() }
+			</span>
+		</div>
+	);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73305 

<!-- In a few words, what is the PR actually doing? -->
This PR adds a "(Needs update)" status indicator to navigation link blocks that carry a legacy numeric `id` attribute but have no `kind` binding.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Some older or manually edited navigation links can retain a numeric `id` without a `kind` attribute. Since `kind` is required for the block’s dynamic entity binding, these links will not automatically update if the linked content changes or is removed. Currently, this state is silent and users receive no indication that the link is no longer properly bound.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Detects legacy unbound links with `Number.isInteger( id) && ! kind` and adds a `NeedsUpdateDisplay` UI, following the existing `InvalidDraftDisplay` pattern, to show a "(Needs update)" indicator.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post or page containing a Navigation block.
2. Insert or edit a navigation link block and remove the `kind` and `metadata` fields using the Code Editor
3. Switch back to the visual editor.
4. Confirm the navigation link displays "(Needs update)" next to the label.
5. Click the link item and re-select the same page through the link editing UI and confirm `kind` is added to the block attributes and the indicator disappears..
6. Confirm fully bound links show no indicator.

https://github.com/user-attachments/assets/d3cafa15-f84a-4b15-8b55-54a294cf08ea

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Used the following block for testing after removing the `kind` and `metadata` attributes:

```
<!-- wp:navigation-link {"label":"Sample Page","type":"page","id":2,"url":"http://localhost:8888/sample-page/"} /-->
```

|Before|After|
|-|-|
|<img width="459" height="152" alt="Screenshot 2026-05-26 at 6 08 25 PM" src="https://github.com/user-attachments/assets/5c6fa912-63e0-4646-b478-5c3b573669d5" />|<img width="338" height="132" alt="Screenshot 2026-05-26 at 6 07 39 PM" src="https://github.com/user-attachments/assets/bc0fca6b-2ab6-40a5-8316-c16eae3302c9" />|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
- ChatGPT for refining the PR description
- GitHub Copilot for implementation assistance