### PR TITLE
Compose: Support React 19 ref callback cleanups in `useMergeRefs`

### DIFF
--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `useDialog`: The returned `props` object now exposes an `onKeyDown` handler. Consumers that spread it onto a wrapper which also receives an `onKeyDown` from elsewhere should pass that handler via the new `onKeyDown` option (which merges it with close-on-Escape) or merge the two themselves ([#78433](https://github.com/WordPress/gutenberg/pull/78433)).
 
+### Enhancements
+
+-   `useMergeRefs`: Support cleanup functions returned by inner ref callbacks (React 19 ref callback cleanup pattern). Inner refs that return a cleanup have it invoked at teardown instead of being called with `null`.
+
 ### Bug Fixes
 
 -   `useCopyToClipboard`: Call the `onSuccess` callback even when the trigger node unmounts before the copy resolves ([#78387](https://github.com/WordPress/gutenberg/pull/78387)).

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -451,19 +451,19 @@ As expected, if you pass a new function on every render, the ref callback will b
 
 If you don't wish a ref callback to be called after every render, wrap it with `useCallback( callback, dependencies )`. When a dependency changes, the old ref callback will be called with `null` and the new ref callback will be called with the same value.
 
-To make ref callbacks easier to use, you can also pass the result of `useRefEffect`, which makes cleanup easier by allowing you to return a cleanup function instead of handling `null`.
+Inner ref callbacks may return a cleanup function (React 19's ref callback cleanup pattern). When a ref callback returns a function, that function is invoked at teardown (node change, dependency change, or unmount) **instead of** the callback being called with `null`. Callbacks that do not return a cleanup continue to receive `null` on teardown as before.
 
 It's also possible to _disable_ a ref (and its behaviour) by simply not passing the ref.
 
 ```jsx
-const ref = useRefEffect( ( node ) => {
+const ref = useCallback( ( node ) => {
   node.addEventListener( ... );
   return () => {
     node.removeEventListener( ... );
   };
 }, [ ...dependencies ] );
 const otherRef = useRef();
-const mergedRefs useMergeRefs( [
+const mergedRefs = useMergeRefs( [
   enabled && ref,
   otherRef,
 ] );

--- a/packages/compose/src/hooks/use-merge-refs/index.ts
+++ b/packages/compose/src/hooks/use-merge-refs/index.ts
@@ -17,6 +17,22 @@ function assignRef< T >( ref: Ref< T >, value: T ): ( () => void ) | undefined {
 	return undefined;
 }
 
+// Tear down a ref at the given index: prefer the stored cleanup; otherwise
+// fall back to calling the ref with `null`.
+function detachRef< T >(
+	ref: Ref< T >,
+	index: number,
+	cleanups: Array< ( () => void ) | undefined >
+): void {
+	const cleanup = cleanups[ index ];
+	if ( cleanup ) {
+		cleanups[ index ] = undefined;
+		cleanup();
+	} else {
+		assignRef( ref, null );
+	}
+}
+
 /**
  * Merges refs into one ref callback.
  *
@@ -88,15 +104,7 @@ export default function useMergeRefs< T >(
 			refs.forEach( ( ref, index ) => {
 				const previousRef = previousRefsRef.current[ index ];
 				if ( ref !== previousRef ) {
-					// Tear down: prefer the stored cleanup; otherwise fall
-					// back to calling the previous ref with `null`.
-					const cleanup = cleanupsRef.current[ index ];
-					if ( cleanup ) {
-						cleanupsRef.current[ index ] = undefined;
-						cleanup();
-					} else {
-						assignRef( previousRef, null );
-					}
+					detachRef( previousRef, index, cleanupsRef.current );
 					cleanupsRef.current[ index ] = assignRef(
 						ref,
 						elementRef.current as T
@@ -128,15 +136,7 @@ export default function useMergeRefs< T >(
 		// with the new element and the previous one with `null`.
 		if ( value === null ) {
 			previousRefsRef.current.forEach( ( ref, index ) => {
-				// Tear down: prefer the stored cleanup; otherwise fall back
-				// to calling the ref with `null`.
-				const cleanup = cleanupsRef.current[ index ];
-				if ( cleanup ) {
-					cleanupsRef.current[ index ] = undefined;
-					cleanup();
-				} else {
-					assignRef( ref, null );
-				}
+				detachRef( ref, index, cleanupsRef.current );
 			} );
 		} else {
 			currentRefsRef.current.forEach( ( ref, index ) => {

--- a/packages/compose/src/hooks/use-merge-refs/index.ts
+++ b/packages/compose/src/hooks/use-merge-refs/index.ts
@@ -4,12 +4,17 @@
 import { useRef, useCallback, useLayoutEffect } from '@wordpress/element';
 import type { Ref, RefCallback } from 'react';
 
-function assignRef< T >( ref: Ref< T >, value: T ) {
+// Returns a cleanup function if the ref callback returned one (React 19 ref
+// callback cleanup pattern), otherwise `undefined`. Object refs never have a
+// cleanup and only set `.current`.
+function assignRef< T >( ref: Ref< T >, value: T ): ( () => void ) | undefined {
 	if ( typeof ref === 'function' ) {
-		ref( value );
+		const returned = ref( value );
+		return typeof returned === 'function' ? returned : undefined;
 	} else if ( ref && ref.hasOwnProperty( 'current' ) ) {
 		ref.current = value;
 	}
+	return undefined;
 }
 
 /**
@@ -28,22 +33,24 @@ function assignRef< T >( ref: Ref< T >, value: T ) {
  * old ref callback will be called with `null` and the new ref callback will be
  * called with the same value.
  *
- * To make ref callbacks easier to use, you can also pass the result of
- * `useRefEffect`, which makes cleanup easier by allowing you to return a
- * cleanup function instead of handling `null`.
+ * Inner ref callbacks may return a cleanup function (React 19's ref callback
+ * cleanup pattern). When a ref callback returns a function, that function is
+ * invoked at teardown (node change, dependency change, or unmount) **instead
+ * of** the callback being called with `null`. Callbacks that do not return a
+ * cleanup continue to receive `null` on teardown as before.
  *
  * It's also possible to _disable_ a ref (and its behaviour) by simply not
  * passing the ref.
  *
  * ```jsx
- * const ref = useRefEffect( ( node ) => {
+ * const ref = useCallback( ( node ) => {
  *   node.addEventListener( ... );
  *   return () => {
  *     node.removeEventListener( ... );
  *   };
  * }, [ ...dependencies ] );
  * const otherRef = useRef();
- * const mergedRefs useMergeRefs( [
+ * const mergedRefs = useMergeRefs( [
  *   enabled && ref,
  *   otherRef,
  * ] );
@@ -56,11 +63,15 @@ function assignRef< T >( ref: Ref< T >, value: T ) {
 export default function useMergeRefs< T >(
 	refs: Ref< T >[]
 ): RefCallback< T > {
-	const element = useRef( null );
+	const elementRef = useRef< T | null >( null );
 	const isAttachedRef = useRef( false );
 	const didElementChangeRef = useRef( false );
 	const previousRefsRef = useRef< Ref< T >[] >( [] );
 	const currentRefsRef = useRef( refs );
+	// Position-indexed cleanups returned by inner ref callbacks. A slot is
+	// `undefined` when the ref at that position did not return a cleanup (or
+	// is an object ref / disabled).
+	const cleanupsRef = useRef< Array< ( () => void ) | undefined > >( [] );
 
 	// Update on render before the ref callback is called, so the ref callback
 	// always has access to the current refs.
@@ -77,8 +88,19 @@ export default function useMergeRefs< T >(
 			refs.forEach( ( ref, index ) => {
 				const previousRef = previousRefsRef.current[ index ];
 				if ( ref !== previousRef ) {
-					assignRef( previousRef, null );
-					assignRef( ref, element.current );
+					// Tear down: prefer the stored cleanup; otherwise fall
+					// back to calling the previous ref with `null`.
+					const cleanup = cleanupsRef.current[ index ];
+					if ( cleanup ) {
+						cleanupsRef.current[ index ] = undefined;
+						cleanup();
+					} else {
+						assignRef( previousRef, null );
+					}
+					cleanupsRef.current[ index ] = assignRef(
+						ref,
+						elementRef.current as T
+					);
 				}
 			} );
 		}
@@ -97,20 +119,29 @@ export default function useMergeRefs< T >(
 	return useCallback( ( value: T | null ) => {
 		// Update the element so it can be used when calling ref callbacks on a
 		// dependency change.
-		assignRef( element, value );
+		elementRef.current = value;
 
 		didElementChangeRef.current = true;
 		isAttachedRef.current = value !== null;
 
 		// When an element changes, the current ref callback should be called
 		// with the new element and the previous one with `null`.
-		const refsToAssign = value
-			? currentRefsRef.current
-			: previousRefsRef.current;
-
-		// Update the latest refs.
-		for ( const ref of refsToAssign ) {
-			assignRef( ref, value );
+		if ( value === null ) {
+			previousRefsRef.current.forEach( ( ref, index ) => {
+				// Tear down: prefer the stored cleanup; otherwise fall back
+				// to calling the ref with `null`.
+				const cleanup = cleanupsRef.current[ index ];
+				if ( cleanup ) {
+					cleanupsRef.current[ index ] = undefined;
+					cleanup();
+				} else {
+					assignRef( ref, null );
+				}
+			} );
+		} else {
+			currentRefsRef.current.forEach( ( ref, index ) => {
+				cleanupsRef.current[ index ] = assignRef( ref, value );
+			} );
 		}
 	}, [] );
 }

--- a/packages/compose/src/hooks/use-merge-refs/test/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/test/index.js
@@ -345,3 +345,239 @@ describe( 'useMergeRefs', () => {
 		] );
 	} );
 } );
+
+describe( 'useMergeRefs with cleanup-returning ref callbacks', () => {
+	// Setup
+	// =====
+	//
+	// Same structure as the suite above, but the ref callbacks return a
+	// cleanup function. React 19 (and `useMergeRefs`) invokes the cleanup at
+	// teardown instead of calling the callback with `null`. The cleanup pushes
+	// the string `'cleanup'` into the same history array, so each call site's
+	// full lifecycle is captured as `[ node, 'cleanup', newNode, 'cleanup' ]`.
+	// The strict invariant is that `null` never appears in the history of a
+	// cleanup-returning ref.
+
+	function renderCallback( args ) {
+		renderCallback.history.push( args );
+	}
+
+	renderCallback.history = [];
+
+	function MergedRefs( {
+		count,
+		tagName: TagName = 'ul',
+		disable1,
+		disable2,
+	} ) {
+		function refCallback1( value ) {
+			refCallback1.history.push( value );
+			return () => {
+				refCallback1.history.push( 'cleanup' );
+			};
+		}
+
+		refCallback1.history = [];
+
+		function refCallback2( value ) {
+			refCallback2.history.push( value );
+			return () => {
+				refCallback2.history.push( 'cleanup' );
+			};
+		}
+
+		refCallback2.history = [];
+
+		renderCallback( [ refCallback1.history, refCallback2.history ] );
+
+		const ref1 = useCallback( refCallback1, [] );
+		const ref2 = useCallback( refCallback2, [ count ] );
+		const mergedRefs = useMergeRefs( [
+			! disable1 && ref1,
+			! disable2 && ref2,
+		] );
+
+		return <TagName ref={ mergedRefs } />;
+	}
+
+	afterEach( () => {
+		renderCallback.history = [];
+	} );
+
+	it( 'should invoke cleanup on unmount instead of calling ref with null', () => {
+		const { unmount } = render( <MergedRefs /> );
+
+		const originalElement = screen.getByRole( 'list' );
+
+		expect( renderCallback.history ).toEqual( [
+			[ [ originalElement ], [ originalElement ] ],
+		] );
+
+		unmount();
+
+		// Cleanups run; refs are NOT called with `null`.
+		expect( renderCallback.history ).toEqual( [
+			[
+				[ originalElement, 'cleanup' ],
+				[ originalElement, 'cleanup' ],
+			],
+		] );
+	} );
+
+	it( 'should invoke cleanup on node change instead of calling ref with null', () => {
+		const { rerender, unmount } = render( <MergedRefs /> );
+
+		const originalElement = screen.getByRole( 'list' );
+
+		rerender( <MergedRefs tagName="button" /> );
+
+		const newElement = screen.getByRole( 'button' );
+
+		// Node change triggers the outer callback first with `null` (which
+		// runs the cleanups) and then with the new node (which sets up new
+		// cleanups).
+		expect( renderCallback.history ).toEqual( [
+			[
+				[ originalElement, 'cleanup', newElement ],
+				[ originalElement, 'cleanup', newElement ],
+			],
+			[ [], [] ],
+		] );
+
+		unmount();
+
+		expect( renderCallback.history ).toEqual( [
+			[
+				[ originalElement, 'cleanup', newElement, 'cleanup' ],
+				[ originalElement, 'cleanup', newElement, 'cleanup' ],
+			],
+			[ [], [] ],
+		] );
+	} );
+
+	it( 'should invoke cleanup on dependency change instead of calling ref with null', () => {
+		const { rerender, unmount } = render( <MergedRefs count={ 1 } /> );
+
+		const originalElement = screen.getByRole( 'list' );
+
+		expect( renderCallback.history ).toEqual( [
+			[ [ originalElement ], [ originalElement ] ],
+		] );
+
+		rerender( <MergedRefs count={ 2 } /> );
+
+		// Only ref2's deps changed. Its previous cleanup runs and the new ref
+		// callback is called with the still-attached node. ref1 is untouched.
+		expect( renderCallback.history ).toEqual( [
+			[ [ originalElement ], [ originalElement, 'cleanup' ] ],
+			[ [], [ originalElement ] ],
+		] );
+
+		unmount();
+
+		expect( renderCallback.history ).toEqual( [
+			[
+				[ originalElement, 'cleanup' ],
+				[ originalElement, 'cleanup' ],
+			],
+			[ [], [ originalElement, 'cleanup' ] ],
+		] );
+	} );
+
+	it( 'should invoke cleanup on simultaneous node and dependency change', () => {
+		const { rerender, unmount } = render( <MergedRefs count={ 1 } /> );
+
+		const originalElement = screen.getByRole( 'list' );
+
+		rerender( <MergedRefs count={ 2 } tagName="button" /> );
+
+		const newElement = screen.getByRole( 'button' );
+
+		// Outer callback's null/new-node pair runs both cleanups and sets
+		// up the new ones (ref1 reused, ref2 has a new identity).
+		expect( renderCallback.history ).toEqual( [
+			[
+				[ originalElement, 'cleanup', newElement ],
+				[ originalElement, 'cleanup' ],
+			],
+			[ [], [ newElement ] ],
+		] );
+
+		unmount();
+
+		expect( renderCallback.history ).toEqual( [
+			[
+				[ originalElement, 'cleanup', newElement, 'cleanup' ],
+				[ originalElement, 'cleanup' ],
+			],
+			[ [], [ newElement, 'cleanup' ] ],
+		] );
+	} );
+
+	it( 'should invoke cleanup when a ref becomes disabled', () => {
+		const { rerender, unmount } = render( <MergedRefs /> );
+
+		const originalElement = screen.getByRole( 'list' );
+
+		rerender( <MergedRefs disable1 /> );
+
+		// ref1 is disabled: its stored cleanup must fire. ref2 is unchanged.
+		expect( renderCallback.history ).toEqual( [
+			[ [ originalElement, 'cleanup' ], [ originalElement ] ],
+			[ [], [] ],
+		] );
+
+		unmount();
+
+		expect( renderCallback.history ).toEqual( [
+			[
+				[ originalElement, 'cleanup' ],
+				[ originalElement, 'cleanup' ],
+			],
+			[ [], [] ],
+		] );
+	} );
+
+	it( 'should support mixing a cleanup-returning ref with a void-returning ref', () => {
+		function MergedRefsMixed() {
+			function refCleanup( value ) {
+				refCleanup.history.push( value );
+				return () => {
+					refCleanup.history.push( 'cleanup' );
+				};
+			}
+
+			refCleanup.history = [];
+
+			function refVoid( value ) {
+				refVoid.history.push( value );
+			}
+
+			refVoid.history = [];
+
+			renderCallback( [ refCleanup.history, refVoid.history ] );
+
+			const r1 = useCallback( refCleanup, [] );
+			const r2 = useCallback( refVoid, [] );
+			const merged = useMergeRefs( [ r1, r2 ] );
+
+			return <ul ref={ merged } />;
+		}
+
+		const { unmount } = render( <MergedRefsMixed /> );
+
+		const el = screen.getByRole( 'list' );
+
+		expect( renderCallback.history ).toEqual( [ [ [ el ], [ el ] ] ] );
+
+		unmount();
+
+		// Cleanup ref sees the cleanup; void ref still sees null. Independent.
+		expect( renderCallback.history ).toEqual( [
+			[
+				[ el, 'cleanup' ],
+				[ el, null ],
+			],
+		] );
+	} );
+} );

--- a/packages/compose/src/hooks/use-merge-refs/test/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/test/index.js
@@ -580,4 +580,56 @@ describe( 'useMergeRefs with cleanup-returning ref callbacks', () => {
 			],
 		] );
 	} );
+
+	it( 'should support mixing an object ref with a cleanup-returning ref', () => {
+		const objectRef = { current: null };
+
+		function MergedRefsMixed( { tagName: TagName = 'ul' } ) {
+			function refCleanup( value ) {
+				refCleanup.history.push( value );
+				return () => {
+					refCleanup.history.push( 'cleanup' );
+				};
+			}
+
+			refCleanup.history = [];
+
+			renderCallback( [ refCleanup.history ] );
+
+			const r = useCallback( refCleanup, [] );
+			const merged = useMergeRefs( [ objectRef, r ] );
+
+			return <TagName ref={ merged } />;
+		}
+
+		const { rerender, unmount } = render( <MergedRefsMixed /> );
+
+		const originalElement = screen.getByRole( 'list' );
+
+		// Object ref's .current is set; cleanup ref is called with the node.
+		expect( objectRef.current ).toBe( originalElement );
+		expect( renderCallback.history ).toEqual( [ [ [ originalElement ] ] ] );
+
+		rerender( <MergedRefsMixed tagName="button" /> );
+
+		const newElement = screen.getByRole( 'button' );
+
+		// Node change: object ref retargets, callback ref's cleanup fires
+		// and the callback is re-invoked with the new node.
+		expect( objectRef.current ).toBe( newElement );
+		expect( renderCallback.history ).toEqual( [
+			[ [ originalElement, 'cleanup', newElement ] ],
+			[ [] ],
+		] );
+
+		unmount();
+
+		// Object ref nulled via the fallback assignRef path; callback ref
+		// sees its cleanup, never null.
+		expect( objectRef.current ).toBe( null );
+		expect( renderCallback.history ).toEqual( [
+			[ [ originalElement, 'cleanup', newElement, 'cleanup' ] ],
+			[ [] ],
+		] );
+	} );
 } );


### PR DESCRIPTION
## What

`useMergeRefs` now honors the React 19 ref callback cleanup pattern. If an inner ref callback returns a function, that function is invoked at teardown (node change, dependency change, or unmount) instead of the callback being called with `null`. Callbacks that don't return a cleanup keep the existing `null`-pass behavior, so this is purely additive and none of the 132 call sites need to change.

## Why

Updating `useMergeRefs` to support React 19 ref callback cleanups.

This is a prerequisite for deprecating `useRefEffect` in favor of native `useCallback` ref cleanups, because once `useRefEffect` is gone, every migrated call site becomes a plain `useCallback` whose body returns a cleanup, and `useMergeRefs` is the consumer that has to honor it.

Part of #71336.

## How

- `assignRef` now returns the function ref's return value (typed `() => void | undefined`). Object refs continue to set `.current` and return `undefined`.
- A new position-indexed `cleanupsRef` stores the cleanup returned by each inner ref.
- Teardown branches (outer-callback `null` path; `useLayoutEffect` dep-change path) prefer the stored cleanup over calling the ref with `null`.
- Strict invariant: a cleanup-returning ref is **never** called with `null` by `useMergeRefs`. This matches React 19's own behavior for native refs.
- JSDoc example updated from `useRefEffect` to the React 19-native `useCallback` pattern.

Out of scope:

- `useRefEffect` source, tests, and call sites, untouched. That's the next checkbox.
- The 132 existing `useMergeRefs` call sites, none of their behavior changes.
- Native build re-export, unchanged.

## Testing instructions

- `npm run test:unit -- packages/compose/src/hooks/use-merge-refs`, 14 tests pass (7 existing, regression-protected; 7 new for the cleanup path).
- Existing void-returning ref callbacks behave identically: verified by the unchanged existing test suite still passing.
- Cleanup invocation on unmount, node change, dependency change, simultaneous node+dep change, ref-becoming-disabled, mixed cleanup+void refs, mixed cleanup+object refs.