### PR TITLE
Move @emotion deps out of root package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,11 +25,7 @@
 			"devDependencies": {
 				"@babel/core": "7.25.7",
 				"@emotion/babel-plugin": "11.13.5",
-				"@emotion/is-prop-valid": "1.4.0",
 				"@emotion/jest": "^11.14.2",
-				"@emotion/native": "11.11.0",
-				"@emotion/react": "11.14.0",
-				"@emotion/styled": "11.14.1",
 				"@eslint/eslintrc": "^3.0.0",
 				"@testing-library/jest-dom": "6.9.1",
 				"@types/node": "^20.19.39",
@@ -4601,7 +4597,6 @@
 			"version": "11.11.0",
 			"resolved": "https://registry.npmjs.org/@emotion/native/-/native-11.11.0.tgz",
 			"integrity": "sha512-t1b5bLv+o5OUNLqXlnw+LJYU10OpmYkLC/1W873Y1ohG+vObx5TT3o3Eh1okXb2KCuZTTBPgsEnU/Sl7NNkJ9Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/primitives-core": "^11.11.0"
@@ -4614,7 +4609,6 @@
 			"version": "11.13.2",
 			"resolved": "https://registry.npmjs.org/@emotion/primitives-core/-/primitives-core-11.13.2.tgz",
 			"integrity": "sha512-+MX60ROt1fDi5EYafhE/zs78XD4OuFUn6j0Z274wo5wVMT8sSBRx2CKPMbOUnmCcT0K5GPog+41mtkcppzkMmg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"css-to-react-native": "^3.0.0"
@@ -4628,7 +4622,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
 			"integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"camelize": "^1.0.0",
@@ -4640,7 +4633,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@emotion/react": {
@@ -59669,6 +59661,7 @@
 				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.14.0",
 				"@emotion/css": "^11.13.5",
+				"@emotion/native": "^11.11.0",
 				"@emotion/react": "^11.14.0",
 				"@emotion/serialize": "^1.3.3",
 				"@emotion/styled": "^11.14.1",
@@ -64715,6 +64708,9 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
+				"@emotion/is-prop-valid": "^1.4.0",
+				"@emotion/react": "^11.14.0",
+				"@emotion/styled": "^11.14.1",
 				"@storybook/addon-a11y": "^10.2.8",
 				"@storybook/addon-docs": "^10.2.8",
 				"@storybook/icons": "^2.0.1",
@@ -64941,19 +64937,6 @@
 				"glob": "^7.1.2",
 				"json2md": "^2.0.1",
 				"react-docgen-typescript": "^2.2.2"
-			}
-		},
-		"tools/build": {
-			"name": "@wordpress/build-tools",
-			"version": "0.0.0",
-			"extraneous": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"chalk": "^4.1.1",
-				"cross-spawn": "^7.0.6",
-				"esbuild": "^0.27.2",
-				"fast-glob": "^3.2.7",
-				"source-map": "^0.6.1"
 			}
 		},
 		"tools/build-scripts": {

--- a/package.json
+++ b/package.json
@@ -46,11 +46,7 @@
 	"devDependencies": {
 		"@babel/core": "7.25.7",
 		"@emotion/babel-plugin": "11.13.5",
-		"@emotion/is-prop-valid": "1.4.0",
 		"@emotion/jest": "^11.14.2",
-		"@emotion/native": "11.11.0",
-		"@emotion/react": "11.14.0",
-		"@emotion/styled": "11.14.1",
 		"@eslint/eslintrc": "^3.0.0",
 		"@testing-library/jest-dom": "6.9.1",
 		"@types/node": "^20.19.39",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Internal
 
 -   `Autocomplete`: Share the per-instance `keydown` listener across instances via `subscribeDelegatedListener` so a typical post-editor mount adds 1 native keydown listener on the document instead of one per `RichText` ([#78310](https://github.com/WordPress/gutenberg/pull/78310)).
+-   Declare `@emotion/native` as a direct dependency; it was previously a phantom dependency relying on hoisting ([#78687](https://github.com/WordPress/gutenberg/pull/78687)).
 
 ## 33.1.0 (2026-05-14)
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -55,6 +55,7 @@
 		"@date-fns/utc": "^2.1.1",
 		"@emotion/cache": "^11.14.0",
 		"@emotion/css": "^11.13.5",
+		"@emotion/native": "^11.11.0",
 		"@emotion/react": "^11.14.0",
 		"@emotion/serialize": "^1.3.3",
 		"@emotion/styled": "^11.14.1",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -24,6 +24,9 @@
 		"./preview": "./preview.jsx"
 	},
 	"devDependencies": {
+		"@emotion/is-prop-valid": "^1.4.0",
+		"@emotion/react": "^11.14.0",
+		"@emotion/styled": "^11.14.1",
 		"@storybook/addon-a11y": "^10.2.8",
 		"@storybook/addon-docs": "^10.2.8",
 		"@storybook/icons": "^2.0.1",


### PR DESCRIPTION
## What?

Related to #75041

Move four `@emotion/*` packages out of the root `package.json` and into the workspaces that actually use them:

-   `@emotion/is-prop-valid`
-   `@emotion/native`
-   `@emotion/react`
-   `@emotion/styled`

## Why?

The root `package.json` currently lists every `@emotion/*` dependency, even though most of them are only used by `packages/components` and `storybook`. Other workspaces only access them transitively through root hoisting (phantom dependencies). Declaring dependencies on the workspace that consumes them is the foundational step that #75041 is driving toward.

This also surfaced a real bug: `packages/components` was missing `@emotion/native` from its `dependencies`, even though `src/text/index.native.js` and `src/text/styles/emotion-css.native.js` import from it. It was only working because the root hoisted it. The same package is consumed under stricter dependency isolation (e.g. pnpm strict installs, npm `install-strategy=linked`), where this would break.

## How?

-   **`packages/components/package.json`**: add `@emotion/native` to `dependencies`. Fixes the missing-dep bug above.
-   **`storybook/package.json`**: add `@emotion/react`, `@emotion/styled`, and `@emotion/is-prop-valid` to `devDependencies`. The first two are imported by `main.ts`, decorators, and stories; `@emotion/is-prop-valid` was added at the root in #68202 to silence a `framer-motion` warning surfaced by Storybook, so it belongs here.
-   **Root `package.json`**: remove the four entries above.
-   **`package-lock.json`**: regenerated via `npm install`.

### Out of scope

`@emotion/babel-plugin` and `@emotion/jest` are intentionally left at the root. They get moved as part of the broader **babel deps** and **test/jest deps** sub-tasks of #75041, each of which needs additional config refactors.

## Testing Instructions

1. Check out the branch and run `npm install`.
2. Confirm the build passes: `npm run clean:package-types && npm run build`.
3. Confirm Storybook still builds: `npm run storybook:build`.
4. Confirm unit tests still pass: `npm run test:unit`.
5. Verify `@emotion/*` resolution still works from consumer workspaces, e.g.:
    ```
    node -e "console.log(require.resolve('@emotion/native', { paths: ['packages/components'] }))"
    node -e "console.log(require.resolve('@emotion/styled', { paths: ['storybook'] }))"
    ```

### Testing Instructions for Keyboard

n/a — dependency move only, no UI changes.

## Screenshots or screencast

n/a — dependency move only.

## Use of AI Tools

Authored with Claude Code; all changes were reviewed and verified locally (build + Storybook build + 894 unit-test suites passing).
