### PR TITLE
Tooltip migration: boot consumers + shell-level Tooltip.Provider (5/5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59646,6 +59646,7 @@
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/route": "file:../route",
 				"@wordpress/theme": "file:../theme",
+				"@wordpress/ui": "file:../ui",
 				"@wordpress/url": "file:../url",
 				"clsx": "^2.1.1"
 			},

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -62,6 +62,7 @@
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/route": "file:../route",
 		"@wordpress/theme": "file:../theme",
+		"@wordpress/ui": "file:../ui",
 		"@wordpress/url": "file:../url",
 		"clsx": "^2.1.1"
 	},

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -19,6 +19,8 @@ import { menu } from '@wordpress/icons';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Page } from '@wordpress/admin-ui';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -59,130 +61,138 @@ export default function Root() {
 
 	return (
 		<SlotFillProvider>
-			<UserThemeProvider isRoot color={ { bg: '#f8f8f8' } }>
-				<UserThemeProvider color={ { bg: '#1d2327' } }>
-					<div
-						className={ clsx( 'boot-layout', {
-							'has-canvas': !! canvas || canvas === null,
-							'has-full-canvas': isFullScreen,
-						} ) }
-					>
-						<SavePanel />
-						<SnackbarNotices className="boot-notices__snackbar" />
-						{ isMobileViewport && (
-							<Page.SidebarToggleFill>
-								<Button
-									icon={ menu }
-									onClick={ () =>
-										setIsMobileSidebarOpen( true )
-									}
-									label={ __( 'Open navigation panel' ) }
-									size="compact"
-								/>
-							</Page.SidebarToggleFill>
-						) }
-						{ /* Mobile Sidebar Backdrop */ }
-						<AnimatePresence>
-							{ isMobileViewport &&
-								isMobileSidebarOpen &&
-								! isFullScreen && (
-									<motion.div
-										initial={ { opacity: 0 } }
-										animate={ { opacity: 1 } }
-										exit={ { opacity: 0 } }
-										transition={ {
-											type: 'tween',
-											duration: disableMotion ? 0 : 0.2,
-											ease: 'easeOut',
-										} }
-										className="boot-layout__sidebar-backdrop"
+			<Tooltip.Provider>
+				<UserThemeProvider isRoot color={ { bg: '#f8f8f8' } }>
+					<UserThemeProvider color={ { bg: '#1d2327' } }>
+						<div
+							className={ clsx( 'boot-layout', {
+								'has-canvas': !! canvas || canvas === null,
+								'has-full-canvas': isFullScreen,
+							} ) }
+						>
+							<SavePanel />
+							<SnackbarNotices className="boot-notices__snackbar" />
+							{ isMobileViewport && (
+								<Page.SidebarToggleFill>
+									<Button
+										icon={ menu }
 										onClick={ () =>
-											setIsMobileSidebarOpen( false )
+											setIsMobileSidebarOpen( true )
 										}
-										onKeyDown={ ( event ) => {
-											if ( event.key === 'Escape' ) {
-												setIsMobileSidebarOpen( false );
-											}
-										} }
-										role="button"
-										tabIndex={ -1 }
-										aria-label={ __(
-											'Close navigation panel'
-										) }
+										label={ __( 'Open navigation panel' ) }
+										size="compact"
 									/>
-								) }
-						</AnimatePresence>
-						{ /* Mobile Sidebar */ }
-						<AnimatePresence>
-							{ isMobileViewport &&
-								isMobileSidebarOpen &&
-								! isFullScreen && (
-									<motion.div
-										initial={ { x: '-100%' } }
-										animate={ { x: 0 } }
-										exit={ { x: '-100%' } }
-										transition={ {
-											type: 'tween',
-											duration: disableMotion ? 0 : 0.2,
-											ease: 'easeOut',
-										} }
-										className="boot-layout__sidebar is-mobile"
-									>
-										<Sidebar />
-									</motion.div>
-								) }
-						</AnimatePresence>
-						{ /* Desktop Sidebar */ }
-						{ ! isMobileViewport && ! isFullScreen && (
-							<div className="boot-layout__sidebar">
-								<Sidebar />
-							</div>
-						) }
-						<div className="boot-layout__surfaces">
-							<UserThemeProvider color={ { bg: '#ffffff' } }>
-								<Outlet />
-								{ /* Render Canvas in Root to prevent remounting on route changes */ }
-								{ ( canvas || canvas === null ) && (
-									<div
-										className={ clsx(
-											'boot-layout__canvas',
-											{
-												'has-mobile-drawer':
-													canvas?.isPreview &&
-													isMobileViewport,
+								</Page.SidebarToggleFill>
+							) }
+							{ /* Mobile Sidebar Backdrop */ }
+							<AnimatePresence>
+								{ isMobileViewport &&
+									isMobileSidebarOpen &&
+									! isFullScreen && (
+										<motion.div
+											initial={ { opacity: 0 } }
+											animate={ { opacity: 1 } }
+											exit={ { opacity: 0 } }
+											transition={ {
+												type: 'tween',
+												duration: disableMotion
+													? 0
+													: 0.2,
+												ease: 'easeOut',
+											} }
+											className="boot-layout__sidebar-backdrop"
+											onClick={ () =>
+												setIsMobileSidebarOpen( false )
 											}
-										) }
-									>
-										{ canvas?.isPreview &&
-											isMobileViewport && (
-												<div className="boot-layout__mobile-sidebar-drawer">
-													<Button
-														icon={ menu }
-														onClick={ () =>
-															setIsMobileSidebarOpen(
-																true
-															)
-														}
-														label={ __(
-															'Open navigation panel'
-														) }
-														size="compact"
-													/>
-												</div>
+											onKeyDown={ ( event ) => {
+												if ( event.key === 'Escape' ) {
+													setIsMobileSidebarOpen(
+														false
+													);
+												}
+											} }
+											role="button"
+											tabIndex={ -1 }
+											aria-label={ __(
+												'Close navigation panel'
 											) }
-										<CanvasRenderer
-											canvas={ canvas }
-											routeContentModule={
-												routeContentModule
-											}
 										/>
-									</div>
-								) }
-							</UserThemeProvider>
+									) }
+							</AnimatePresence>
+							{ /* Mobile Sidebar */ }
+							<AnimatePresence>
+								{ isMobileViewport &&
+									isMobileSidebarOpen &&
+									! isFullScreen && (
+										<motion.div
+											initial={ { x: '-100%' } }
+											animate={ { x: 0 } }
+											exit={ { x: '-100%' } }
+											transition={ {
+												type: 'tween',
+												duration: disableMotion
+													? 0
+													: 0.2,
+												ease: 'easeOut',
+											} }
+											className="boot-layout__sidebar is-mobile"
+										>
+											<Sidebar />
+										</motion.div>
+									) }
+							</AnimatePresence>
+							{ /* Desktop Sidebar */ }
+							{ ! isMobileViewport && ! isFullScreen && (
+								<div className="boot-layout__sidebar">
+									<Sidebar />
+								</div>
+							) }
+							<div className="boot-layout__surfaces">
+								<UserThemeProvider color={ { bg: '#ffffff' } }>
+									<Outlet />
+									{ /* Render Canvas in Root to prevent remounting on route changes */ }
+									{ ( canvas || canvas === null ) && (
+										<div
+											className={ clsx(
+												'boot-layout__canvas',
+												{
+													'has-mobile-drawer':
+														canvas?.isPreview &&
+														isMobileViewport,
+												}
+											) }
+										>
+											{ canvas?.isPreview &&
+												isMobileViewport && (
+													<div className="boot-layout__mobile-sidebar-drawer">
+														<Button
+															icon={ menu }
+															onClick={ () =>
+																setIsMobileSidebarOpen(
+																	true
+																)
+															}
+															label={ __(
+																'Open navigation panel'
+															) }
+															size="compact"
+														/>
+													</div>
+												) }
+											<CanvasRenderer
+												canvas={ canvas }
+												routeContentModule={
+													routeContentModule
+												}
+											/>
+										</div>
+									) }
+								</UserThemeProvider>
+							</div>
 						</div>
-					</div>
+					</UserThemeProvider>
 				</UserThemeProvider>
-			</UserThemeProvider>
+			</Tooltip.Provider>
 		</SlotFillProvider>
 	);
 }

--- a/packages/boot/src/components/save-button/index.tsx
+++ b/packages/boot/src/components/save-button/index.tsx
@@ -8,7 +8,9 @@ import { store as coreStore } from '@wordpress/core-data';
 import { displayShortcut, rawShortcut } from '@wordpress/keycodes';
 import { check } from '@wordpress/icons';
 import { EntitiesSavedStates } from '@wordpress/editor';
-import { Button, Modal, Tooltip as WCTooltip } from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -82,28 +84,37 @@ export default function SaveButton() {
 		);
 	};
 	const label = getLabel();
+	const shortcut = displayShortcut.primary( 's' );
 
 	return (
 		<>
-			<WCTooltip
-				text={ hasChanges ? label : undefined }
-				shortcut={ displayShortcut.primary( 's' ) }
-			>
-				<Button
-					variant="primary"
-					size="compact"
-					onClick={ () => setIsSaveViewOpened( true ) }
-					onBlur={ hideSavedState }
-					disabled={ disabled }
-					accessibleWhenDisabled
-					isBusy={ isSaving }
-					aria-keyshortcuts={ rawShortcut.primary( 's' ) }
-					className="boot-save-button"
-					icon={ isInSavedState ? check : undefined }
-				>
-					{ label }
-				</Button>
-			</WCTooltip>
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					render={
+						<Button
+							variant="primary"
+							size="compact"
+							onClick={ () => setIsSaveViewOpened( true ) }
+							onBlur={ hideSavedState }
+							disabled={ disabled }
+							accessibleWhenDisabled
+							isBusy={ isSaving }
+							aria-keyshortcuts={ rawShortcut.primary( 's' ) }
+							className="boot-save-button"
+							icon={ isInSavedState ? check : undefined }
+						>
+							{ label }
+						</Button>
+					}
+				/>
+				<Tooltip.Popup>
+					{ hasChanges && <span>{ label }</span> }
+					{ /* TODO: replace with a future `@wordpress/ui` `Shortcut` primitive once available */ }
+					<span className="boot-save-button__shortcut">
+						{ shortcut }
+					</span>
+				</Tooltip.Popup>
+			</Tooltip.Root>
 			{ isSaveViewOpen && (
 				<Modal
 					title={ __( 'Review changes' ) }

--- a/packages/boot/src/components/save-button/style.scss
+++ b/packages/boot/src/components/save-button/style.scss
@@ -1,3 +1,9 @@
+@use "@wordpress/base-styles/variables" as *;
+
 .boot-save-button {
 	width: 100%;
+}
+
+.boot-save-button__shortcut:not(:first-child) {
+	margin-left: $grid-unit-10;
 }

--- a/packages/boot/src/components/site-icon-link/index.tsx
+++ b/packages/boot/src/components/site-icon-link/index.tsx
@@ -2,12 +2,14 @@
  * WordPress dependencies
  */
 import { Link, privateApis as routePrivateApis } from '@wordpress/route';
-import { Tooltip as WCTooltip } from '@wordpress/components';
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Tooltip` is not yet on the recommended `@wordpress/ui` allow-list; landing as a migration step ahead of the wider rollout.
+import { Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+
 import SiteIcon from '../site-icon';
 import './style.scss';
 
@@ -26,23 +28,30 @@ function SiteIconLink( {
 	const canGoBack = useCanGoBack();
 
 	return (
-		<WCTooltip text={ props[ 'aria-label' ] } placement="right">
-			<Link
-				to={ to }
-				aria-label={ props[ 'aria-label' ] }
-				className="boot-site-icon-link"
-				onClick={ ( event ) => {
-					// If possible, restore the previous page with
-					// filters etc.
-					if ( canGoBack && isBackButton ) {
-						event.preventDefault();
-						router.history.back();
-					}
-				} }
-			>
-				<SiteIcon />
-			</Link>
-		</WCTooltip>
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				render={
+					<Link
+						to={ to }
+						aria-label={ props[ 'aria-label' ] }
+						className="boot-site-icon-link"
+						onClick={ ( event ) => {
+							// If possible, restore the previous page with
+							// filters etc.
+							if ( canGoBack && isBackButton ) {
+								event.preventDefault();
+								router.history.back();
+							}
+						} }
+					>
+						<SiteIcon />
+					</Link>
+				}
+			/>
+			<Tooltip.Popup positioner={ <Tooltip.Positioner side="right" /> }>
+				{ props[ 'aria-label' ] }
+			</Tooltip.Popup>
+		</Tooltip.Root>
 	);
 }
 

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -25,6 +25,7 @@
 		{ "path": "../private-apis" },
 		{ "path": "../route" },
 		{ "path": "../theme" },
+		{ "path": "../ui" },
 		{ "path": "../url" }
 	]
 }


### PR DESCRIPTION
## What?

Tooltip migration **part 5 of 5** (final): migrates the 2 `Tooltip` consumers in `@wordpress/boot` from the legacy `Tooltip` (`@wordpress/components`) to the compositional `Tooltip` (`@wordpress/ui`), plus mounts a shell-level `<Tooltip.Provider>` inside `boot/root` so sibling tooltips coordinate as a group (mirrors #78466 for `edit-post` / `edit-site`).

<details>
<summary>Sites migrated</summary>

- `boot/components/site-icon-link` — codemod output; tooltip on the site-icon `Link`, positioned to the right.
- `boot/components/save-button` — **manual migration** (the codemod bails on the legacy `shortcut` prop). The shortcut renders inline inside `Tooltip.Popup` as a local `.boot-save-button__shortcut` span; CSS mirrors the legacy `components-tooltip__shortcut` rule (left-margin only when a label sits to its left). An inline `TODO` flags a future `@wordpress/ui` `Shortcut` primitive.
- `boot/components/root` — shell-level `<Tooltip.Provider>` inside `<SlotFillProvider>`.

</details>

<details>
<summary>5-PR plan</summary>

1. ~~block-editor + block-directory (+ codemod)~~ — #78411 landed
2. ~~editor + edit-post + edit-site~~ — #78466 landed
3. ~~dataviews~~ — #78470 landed
4. fields + media-editor + media-fields + global-styles-ui — #78691 (draft)
5. **boot (+ manual `save-button` + shell-level `Tooltip.Provider`) ← this PR**

Follow-ups: codemod cleanup (#78669), mark `Tooltip` recommended (after this PR).

</details>

## Why?

With this PR, all consumers outside `@wordpress/components` itself are migrated — unlocking the recommendation flip in a follow-up.

<details>
<summary>Out of scope</summary>

Call sites *inside* `@wordpress/components` (notably `Button`'s internal Tooltip and `TooltipInternalContext`) stay on the legacy implementation — separate follow-up.

</details>

## How?

`site-icon-link` was rewritten by the codemod from #78411; import placement and the per-line `eslint-disable` directive were finished by hand.

`save-button` was done by hand because the codemod intentionally bails on the legacy `shortcut` prop. The shortcut is rendered as a sibling inside `<Tooltip.Popup>` with a local class name; CSS replicates the legacy `margin-left: $grid-unit-10` (gated on `:not(:first-child)` so a lonely shortcut — in the saved state — stays flush left, mirroring the legacy conditional class).

The shell-level `<Tooltip.Provider>` sits inside `<SlotFillProvider>`, matching the placement used by `edit-post`/`edit-site` shells. Once the first tooltip in a session has been shown, subsequent siblings open instantly within the same provider scope.

`@wordpress/ui` was added as a runtime dependency to `@wordpress/boot`.

## Testing Instructions

1. Open a boot-based app (or any consumer mounting `boot/root`).
2. Hover the site icon — tooltip appears to the right, showing the link's `aria-label`.
3. With unsaved changes, hover the "Review N change(s)…" button — tooltip shows the label + keyboard shortcut.
4. Immediately after a save, hover the "Saved" button — tooltip shows only the keyboard shortcut (no extra left-indent).
5. After one tooltip has been shown, sibling tooltips in the same shell should open instantly (provider coordination).

### Testing Instructions for Keyboard

Keyboard focus on the save button still announces the visible label + `aria-keyshortcuts`. The visible tooltip is hover-only — no change vs trunk in keyboard interaction.

## Screenshots or screencast

Inline review comments on each call site include before/after snapshots where useful.

## Use of AI Tools

This PR was authored with assistance from Cursor; the author reviewed and verified all changes.
