### PR TITLE
RTC: Fix useInnerBlockTemplateSync race condition

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/test/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/test/use-inner-block-template-sync.js
@@ -1,0 +1,157 @@
+/**
+ * External dependencies
+ */
+import { act, render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	createBlock,
+	registerBlockType,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import useInnerBlockTemplateSync from '../use-inner-block-template-sync';
+import { store as blockEditorStore, storeConfig } from '../../../store';
+import { STORE_NAME as blockEditorStoreName } from '../../../store/constants';
+
+const PARENT_BLOCK = 'test/template-sync-parent';
+const CHILD_BLOCK = 'test/template-sync-child';
+const TEMPLATE = [ [ CHILD_BLOCK, { fruit: 'apple' } ] ];
+
+function createBlockEditorRegistry() {
+	const registry = createRegistry();
+	registry.registerStore( blockEditorStoreName, storeConfig );
+	return registry;
+}
+
+async function flushTemplateSync() {
+	await act( async () => {
+		await Promise.resolve();
+	} );
+}
+
+function TemplateSync( {
+	clientId,
+	template = TEMPLATE,
+	templateLock = false,
+	templateInsertUpdatesSelection = false,
+} ) {
+	useInnerBlockTemplateSync(
+		clientId,
+		template,
+		templateLock,
+		templateInsertUpdatesSelection
+	);
+	return null;
+}
+
+describe( 'useInnerBlockTemplateSync', () => {
+	beforeAll( () => {
+		registerBlockType( PARENT_BLOCK, {
+			apiVersion: 3,
+			title: 'Template sync parent',
+			category: 'text',
+		} );
+		registerBlockType( CHILD_BLOCK, {
+			apiVersion: 3,
+			title: 'Template sync child',
+			category: 'text',
+			attributes: {
+				fruit: {
+					type: 'string',
+				},
+			},
+		} );
+	} );
+
+	afterAll( () => {
+		unregisterBlockType( CHILD_BLOCK );
+		unregisterBlockType( PARENT_BLOCK );
+	} );
+
+	it( 'fills an empty block template when the block was not remotely synced', async () => {
+		const registry = createBlockEditorRegistry();
+		const parentBlock = createBlock( PARENT_BLOCK );
+
+		act( () => {
+			registry
+				.dispatch( blockEditorStore )
+				.resetBlocks( [ parentBlock ] );
+		} );
+
+		render(
+			<RegistryProvider value={ registry }>
+				<TemplateSync clientId={ parentBlock.clientId } />
+			</RegistryProvider>
+		);
+
+		await flushTemplateSync();
+
+		expect(
+			registry
+				.select( blockEditorStore )
+				.getBlocks( parentBlock.clientId )
+		).toEqual( [
+			expect.objectContaining( {
+				name: CHILD_BLOCK,
+				attributes: { fruit: 'apple' },
+			} ),
+		] );
+	} );
+
+	it( 'skips an empty remote-synced block and treats the template as seen', async () => {
+		const registry = createBlockEditorRegistry();
+		const parentBlock = createBlock( PARENT_BLOCK );
+
+		act( () => {
+			registry
+				.dispatch( blockEditorStore )
+				.resetBlocks( [ parentBlock ] );
+			registry
+				.dispatch( blockEditorStore )
+				.__unstableMarkRemoteSyncedBlocks( [ parentBlock.clientId ] );
+		} );
+
+		const { rerender } = render(
+			<RegistryProvider value={ registry }>
+				<TemplateSync clientId={ parentBlock.clientId } />
+			</RegistryProvider>
+		);
+
+		await flushTemplateSync();
+
+		expect(
+			registry
+				.select( blockEditorStore )
+				.getBlocks( parentBlock.clientId )
+		).toHaveLength( 0 );
+		expect(
+			registry
+				.select( blockEditorStore )
+				.__unstableIsRemoteSyncedBlock( parentBlock.clientId )
+		).toBe( false );
+
+		rerender(
+			<RegistryProvider value={ registry }>
+				<TemplateSync
+					clientId={ parentBlock.clientId }
+					templateInsertUpdatesSelection
+				/>
+			</RegistryProvider>
+		);
+
+		await flushTemplateSync();
+
+		expect(
+			registry
+				.select( blockEditorStore )
+				.getBlocks( parentBlock.clientId )
+		).toHaveLength( 0 );
+	} );
+} );

--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -53,10 +53,14 @@ export default function useInnerBlockTemplateSync(
 		const {
 			getBlocks,
 			getSelectedBlocksInitialCaretPosition,
+			__unstableIsRemoteSyncedBlock,
 			isBlockSelected,
 		} = registry.select( blockEditorStore );
-		const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
-			registry.dispatch( blockEditorStore );
+		const {
+			replaceInnerBlocks,
+			__unstableClearRemoteSyncedBlock,
+			__unstableMarkNextChangeAsNotPersistent,
+		} = registry.dispatch( blockEditorStore );
 
 		// There's an implicit dependency between useInnerBlockTemplateSync and useNestedSettingsUpdate
 		// The former needs to happen after the latter and since the latter is using microtasks to batch updates (performance optimization),
@@ -70,6 +74,14 @@ export default function useInnerBlockTemplateSync(
 			// Only synchronize innerBlocks with template if innerBlocks are empty
 			// or a locking "all" or "contentOnly" exists directly on the block.
 			const currentInnerBlocks = getBlocks( clientId );
+			const wasRemoteSynced = __unstableIsRemoteSyncedBlock( clientId );
+			if ( wasRemoteSynced ) {
+				// Remote sync marks are single-use. Clear them as soon as this
+				// effect observes them so stale marks do not suppress later
+				// intentional template sync work.
+				__unstableClearRemoteSyncedBlock( clientId );
+			}
+
 			const shouldApplyTemplate =
 				currentInnerBlocks.length === 0 ||
 				templateLock === 'all' ||
@@ -85,6 +97,14 @@ export default function useInnerBlockTemplateSync(
 			}
 
 			existingTemplateRef.current = template;
+
+			// Remote peers should wait for the originator's template fill
+			// instead of broadcasting their own. Record this template as seen so
+			// a rerun does not fill the same empty remote-synced block later.
+			if ( wasRemoteSynced && currentInnerBlocks.length === 0 ) {
+				return;
+			}
+
 			const nextBlocks = synchronizeBlocksWithTemplate(
 				currentInnerBlocks,
 				template

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -380,6 +380,7 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 					value={ props.value }
 					onChange={ props.onChange }
 					onInput={ props.onInput }
+					__unstableIsRemoteSynced={ props.__unstableIsRemoteSynced }
 				/>
 				{ children }
 			</SelectionContext.Provider>

--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -241,6 +241,49 @@ describe( 'useBlockSync hook', () => {
 		expect( setAsController ).toHaveBeenCalledWith( 'test', true );
 	} );
 
+	it( 'marks incoming remotely synced blocks', async () => {
+		let registry;
+		const setRegistry = ( reg ) => {
+			registry = reg;
+		};
+		const value = [
+			{
+				name: 'test/test-block',
+				clientId: 'a',
+				innerBlocks: [
+					{
+						name: 'test/test-block',
+						clientId: 'b',
+						innerBlocks: [],
+						attributes: { foo: 2 },
+					},
+				],
+				attributes: { foo: 1 },
+			},
+		];
+
+		render(
+			<TestWrapper
+				setRegistry={ setRegistry }
+				value={ value }
+				onChange={ jest.fn() }
+				onInput={ jest.fn() }
+				__unstableIsRemoteSynced
+			/>
+		);
+
+		expect(
+			registry
+				.select( blockEditorStore )
+				.__unstableIsRemoteSyncedBlock( 'a' )
+		).toBe( true );
+		expect(
+			registry
+				.select( blockEditorStore )
+				.__unstableIsRemoteSyncedBlock( 'b' )
+		).toBe( true );
+	} );
+
 	it( 'calls onInput when a non-persistent block change occurs', async () => {
 		const onChange = jest.fn();
 		const onInput = jest.fn();

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -92,6 +92,13 @@ function restoreSelectionIds( selectionState, mapping ) {
 	};
 }
 
+function getClientIdsFromBlocks( blocks = [] ) {
+	return blocks.flatMap( ( block ) => [
+		block.clientId,
+		...getClientIdsFromBlocks( block.innerBlocks ),
+	] );
+}
+
 /**
  * A function to call when the block value has been updated in the block-editor
  * store.
@@ -123,30 +130,33 @@ function restoreSelectionIds( selectionState, mapping ) {
  *   controllers.
  * - Passes selection state from the block-editor store to the controlling entity.
  *
- * @param {Object}        props          Props for the block sync hook
- * @param {string}        props.clientId The client ID of the inner block controller.
- *                                       If none is passed, then it is assumed to be a
- *                                       root controller rather than an inner block
- *                                       controller.
- * @param {Object[]}      props.value    The control value for the blocks. This value
- *                                       is used to initialize the block-editor store
- *                                       and for resetting the blocks to incoming
- *                                       changes like undo.
- * @param {onBlockUpdate} props.onChange Function to call when a persistent
- *                                       change has been made in the block-editor blocks
- *                                       for the given clientId. For example, after
- *                                       this function is called, an entity is marked
- *                                       dirty because it has changes to save.
- * @param {onBlockUpdate} props.onInput  Function to call when a non-persistent
- *                                       change has been made in the block-editor blocks
- *                                       for the given clientId. When this is called,
- *                                       controlling sources do not become dirty.
+ * @param {Object}        props                          Props for the block sync hook
+ * @param {string}        props.clientId                 The client ID of the inner block controller.
+ *                                                       If none is passed, then it is assumed to be a
+ *                                                       root controller rather than an inner block
+ *                                                       controller.
+ * @param {Object[]}      props.value                    The control value for the blocks. This value
+ *                                                       is used to initialize the block-editor store
+ *                                                       and for resetting the blocks to incoming
+ *                                                       changes like undo.
+ * @param {onBlockUpdate} props.onChange                 Function to call when a persistent
+ *                                                       change has been made in the block-editor blocks
+ *                                                       for the given clientId. For example, after
+ *                                                       this function is called, an entity is marked
+ *                                                       dirty because it has changes to save.
+ * @param {onBlockUpdate} props.onInput                  Function to call when a non-persistent
+ *                                                       change has been made in the block-editor blocks
+ *                                                       for the given clientId. When this is called,
+ *                                                       controlling sources do not become dirty.
+ * @param {boolean}       props.__unstableIsRemoteSynced Whether the current control
+ *                                                       value was received from remote sync.
  */
 export default function useBlockSync( {
 	clientId = null,
 	value: controlledBlocks,
 	onChange = noop,
 	onInput = noop,
+	__unstableIsRemoteSynced = false,
 } ) {
 	const registry = useRegistry();
 	const { getSelection, onChangeSelection } = useContext( SelectionContext );
@@ -156,6 +166,7 @@ export default function useBlockSync( {
 		resetSelection,
 		replaceInnerBlocks,
 		setHasControlledInnerBlocks,
+		__unstableMarkRemoteSyncedBlocks,
 		__unstableMarkNextChangeAsNotPersistent,
 	} = registry.dispatch( blockEditorStore );
 	const { getBlockName, getBlocks, getSelectionStart, getSelectionEnd } =
@@ -259,6 +270,11 @@ export default function useBlockSync( {
 				}
 				__unstableMarkNextChangeAsNotPersistent();
 				replaceInnerBlocks( clientId, storeBlocks );
+				if ( __unstableIsRemoteSynced ) {
+					__unstableMarkRemoteSyncedBlocks(
+						getClientIdsFromBlocks( storeBlocks )
+					);
+				}
 
 				// Invalidate the applied-selection ref so that
 				// restoreSelection() at the end of the
@@ -267,11 +283,18 @@ export default function useBlockSync( {
 				appliedSelectionRef.current = null;
 			} );
 		} else {
-			if ( subscribedRef.current ) {
-				pendingChangesRef.current.incoming = controlledBlocks;
-			}
-			__unstableMarkNextChangeAsNotPersistent();
-			resetBlocks( controlledBlocks );
+			registry.batch( () => {
+				if ( subscribedRef.current ) {
+					pendingChangesRef.current.incoming = controlledBlocks;
+				}
+				__unstableMarkNextChangeAsNotPersistent();
+				resetBlocks( controlledBlocks );
+				if ( __unstableIsRemoteSynced ) {
+					__unstableMarkRemoteSyncedBlocks(
+						getClientIdsFromBlocks( controlledBlocks )
+					);
+				}
+			} );
 		}
 	};
 
@@ -336,7 +359,7 @@ export default function useBlockSync( {
 			// character undo levels.
 			restoreSelection();
 		}
-	}, [ controlledBlocks, clientId ] );
+	}, [ controlledBlocks, clientId, __unstableIsRemoteSynced ] );
 
 	useEffect( () => {
 		const {

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1655,6 +1655,26 @@ export function __unstableMarkNextChangeAsNotPersistent() {
 }
 
 /**
+ * Action that marks blocks as having just been received from remote sync.
+ *
+ * @param {string[]} clientIds Client IDs for blocks received from remote sync.
+ * @return {Object} Action object.
+ */
+export function __unstableMarkRemoteSyncedBlocks( clientIds ) {
+	return { type: 'MARK_REMOTE_SYNCED_BLOCKS', clientIds };
+}
+
+/**
+ * Action that clears a remote sync mark for a block.
+ *
+ * @param {string} clientId Block client ID.
+ * @return {Object} Action object.
+ */
+export function __unstableClearRemoteSyncedBlock( clientId ) {
+	return { type: 'CLEAR_REMOTE_SYNCED_BLOCK', clientId };
+}
+
+/**
  * Action that marks the last block change as an automatic change, meaning it was not
  * performed by the user, and can be undone using the `Escape` and `Backspace` keys.
  * This action must be called after the change was made, and any actions that are a

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1186,6 +1186,41 @@ export const blocks = pipe(
 		return state;
 	},
 
+	remoteSyncedBlocks( state = new Set(), action ) {
+		switch ( action.type ) {
+			case 'RESET_BLOCKS':
+				return new Set();
+
+			case 'MARK_REMOTE_SYNCED_BLOCKS':
+				if ( ! action.clientIds?.length ) {
+					return state;
+				}
+				return new Set( [ ...state, ...action.clientIds ] );
+
+			case 'CLEAR_REMOTE_SYNCED_BLOCK': {
+				if ( ! state.has( action.clientId ) ) {
+					return state;
+				}
+				const nextState = new Set( state );
+				nextState.delete( action.clientId );
+				return nextState;
+			}
+
+			case 'REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN': {
+				const nextState = new Set( state );
+				let hasChange = false;
+				action.removedClientIds.forEach( ( clientId ) => {
+					if ( nextState.delete( clientId ) ) {
+						hasChange = true;
+					}
+				} );
+				return hasChange ? nextState : state;
+			}
+		}
+
+		return state;
+	},
+
 	controlledInnerBlocks(
 		state = new Set(),
 		{ type, clientId, hasControlledInnerBlocks }

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2977,6 +2977,18 @@ export function __unstableIsLastBlockChangeIgnored( state ) {
 }
 
 /**
+ * Returns true if a block was just received from remote sync.
+ *
+ * @param {Object} state    Block editor state.
+ * @param {string} clientId Block client ID.
+ *
+ * @return {boolean} Whether the block was just received from remote sync.
+ */
+export function __unstableIsRemoteSyncedBlock( state, clientId ) {
+	return state.blocks.remoteSyncedBlocks.has( clientId );
+}
+
+/**
  * Returns the block attributes changed as a result of the last dispatched
  * action.
  *

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -287,6 +287,7 @@ describe( 'state', () => {
 						} )
 					),
 					controlledInnerBlocks: new Set(),
+					remoteSyncedBlocks: new Set(),
 					blockEditingModes: new Map(),
 				} );
 
@@ -346,6 +347,7 @@ describe( 'state', () => {
 						} )
 					),
 					controlledInnerBlocks: new Set(),
+					remoteSyncedBlocks: new Set(),
 					blockEditingModes: new Map(),
 				} );
 				expect( state.tree.get( 'chicken' ) ).not.toBe(
@@ -389,6 +391,7 @@ describe( 'state', () => {
 						} )
 					),
 					controlledInnerBlocks: new Set(),
+					remoteSyncedBlocks: new Set(),
 					blockEditingModes: new Map(),
 				} );
 
@@ -448,6 +451,7 @@ describe( 'state', () => {
 						} )
 					),
 					controlledInnerBlocks: new Set(),
+					remoteSyncedBlocks: new Set(),
 					blockEditingModes: new Map(),
 				} );
 				expect( state.tree.get( 'chicken' ) ).not.toBe(
@@ -520,6 +524,7 @@ describe( 'state', () => {
 					),
 					tree: new Map(),
 					controlledInnerBlocks: new Set(),
+					remoteSyncedBlocks: new Set(),
 					blockEditingModes: new Map(),
 				} );
 
@@ -615,6 +620,7 @@ describe( 'state', () => {
 						} )
 					),
 					controlledInnerBlocks: new Set(),
+					remoteSyncedBlocks: new Set(),
 					blockEditingModes: new Map(),
 				} );
 
@@ -691,6 +697,7 @@ describe( 'state', () => {
 						} )
 					),
 					controlledInnerBlocks: new Set(),
+					remoteSyncedBlocks: new Set(),
 					blockEditingModes: new Map(),
 				} );
 
@@ -744,6 +751,7 @@ describe( 'state', () => {
 						} )
 					),
 					controlledInnerBlocks: new Set(),
+					remoteSyncedBlocks: new Set(),
 					blockEditingModes: new Map(),
 				} );
 
@@ -766,6 +774,7 @@ describe( 'state', () => {
 				isIgnoredChange: false,
 				tree: new Map(),
 				controlledInnerBlocks: new Set(),
+				remoteSyncedBlocks: new Set(),
 				blockEditingModes: new Map(),
 			} );
 		} );
@@ -2269,6 +2278,35 @@ describe( 'state', () => {
 					} );
 
 					expect( state.isIgnoredChange ).toBe( true );
+				} );
+			} );
+
+			describe( 'remoteSyncedBlocks', () => {
+				it( 'should track and clear blocks received from remote sync', () => {
+					let state = blocks( undefined, {
+						type: 'MARK_REMOTE_SYNCED_BLOCKS',
+						clientIds: [ 'kumquat', 'persimmon' ],
+					} );
+
+					expect( state.remoteSyncedBlocks ).toEqual(
+						new Set( [ 'kumquat', 'persimmon' ] )
+					);
+
+					state = blocks( state, {
+						type: 'CLEAR_REMOTE_SYNCED_BLOCK',
+						clientId: 'kumquat',
+					} );
+
+					expect( state.remoteSyncedBlocks ).toEqual(
+						new Set( [ 'persimmon' ] )
+					);
+
+					state = blocks( state, {
+						type: 'RESET_BLOCKS',
+						blocks: [],
+					} );
+
+					expect( state.remoteSyncedBlocks ).toEqual( new Set() );
 				} );
 			} );
 

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -11,7 +11,7 @@ import { useRef, useMemo } from '@wordpress/element';
 import {
 	useEntityRecord,
 	store as coreStore,
-	useEntityBlockEditor,
+	__unstableUseEntityBlockEditorProps as useEntityBlockEditorProps,
 } from '@wordpress/core-data';
 import {
 	Placeholder,
@@ -162,9 +162,14 @@ function ReusableBlockEdit( {
 		'wp_block',
 		ref
 	);
-	const [ blocks ] = useEntityBlockEditor( 'postType', 'wp_block', {
-		id: ref,
-	} );
+	const blockEditorProps = useEntityBlockEditorProps(
+		'postType',
+		'wp_block',
+		{
+			id: ref,
+		}
+	);
+	const { blocks } = blockEditorProps;
 	const isMissing = hasResolved && ! record;
 
 	const { __unstableMarkLastChangeAsPersistent } =
@@ -216,7 +221,7 @@ function ReusableBlockEdit( {
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		layout,
-		value: blocks,
+		...blockEditorProps,
 		onInput: NOOP,
 		onChange: NOOP,
 		renderAppender: blocks?.length

--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -14,7 +14,7 @@ import {
  */
 import { useState, useCallback } from '@wordpress/element';
 import {
-	useEntityBlockEditor,
+	__unstableUseEntityBlockEditorProps as useEntityBlockEditorProps,
 	useEntityProp,
 	store as coreStore,
 } from '@wordpress/core-data';
@@ -115,10 +115,12 @@ export default function ReusableBlockEdit( {
 		useDispatch( reusableBlocksStore );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 
-	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
+	const blockEditorProps = useEntityBlockEditorProps(
 		'postType',
 		'wp_block',
-		{ id: ref }
+		{
+			id: ref,
+		}
 	);
 
 	const [ title ] = useEntityProp( 'postType', 'wp_block', 'title', ref );
@@ -215,13 +217,7 @@ export default function ReusableBlockEdit( {
 		);
 	}
 
-	let element = (
-		<InnerBlocks
-			value={ blocks }
-			onChange={ onChange }
-			onInput={ onInput }
-		/>
-	);
+	let element = <InnerBlocks { ...blockEditorProps } />;
 
 	if ( ! isEditing ) {
 		element = <Disabled>{ element }</Disabled>;

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEntityBlockEditor } from '@wordpress/core-data';
+import { __unstableUseEntityBlockEditorProps as useEntityBlockEditorProps } from '@wordpress/core-data';
 import {
 	useInnerBlocksProps,
 	InnerBlocks,
@@ -52,10 +52,11 @@ export default function NavigationInnerBlocks( {
 		[ clientId ]
 	);
 
-	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
+	const blockEditorProps = useEntityBlockEditorProps(
 		'postType',
 		'wp_navigation'
 	);
+	const { blocks } = blockEditorProps;
 
 	// When the block is selected itself or has a top level item selected that
 	// doesn't itself have children, show the standard appender. Else show no
@@ -80,9 +81,7 @@ export default function NavigationInnerBlocks( {
 			className: 'wp-block-navigation__container',
 		},
 		{
-			value: blocks,
-			onInput,
-			onChange,
+			...blockEditorProps,
 			prioritizedInserterBlocks: PRIORITIZED_INSERTER_BLOCKS,
 			defaultBlock: DEFAULT_BLOCK,
 			directInsert: true,

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -15,7 +15,7 @@ import {
 import { parse } from '@wordpress/blocks';
 import {
 	useEntityProp,
-	useEntityBlockEditor,
+	__unstableUseEntityBlockEditorProps as useEntityBlockEditorProps,
 	store as coreStore,
 } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
@@ -80,11 +80,10 @@ function ReadOnlyContent( {
 function EditableContent( { context = {}, tagName: TagName = 'div' } ) {
 	const { postType, postId } = context;
 
-	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
-		'postType',
-		postType,
-		{ id: postId }
-	);
+	const blockEditorProps = useEntityBlockEditorProps( 'postType', postType, {
+		id: postId,
+	} );
+	const { blocks } = blockEditorProps;
 
 	const entityRecord = useSelect(
 		( select ) => {
@@ -104,9 +103,7 @@ function EditableContent( { context = {}, tagName: TagName = 'div' } ) {
 	const props = useInnerBlocksProps(
 		useBlockProps( { className: 'entry-content' } ),
 		{
-			value: blocks,
-			onInput,
-			onChange,
+			...blockEditorProps,
 			template: ! hasInnerBlocks ? initialInnerBlocks : undefined,
 		}
 	);

--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
+import {
+	__unstableUseEntityBlockEditorProps as useEntityBlockEditorProps,
+	store as coreStore,
+} from '@wordpress/core-data';
 import {
 	InnerBlocks,
 	useInnerBlocksProps,
@@ -106,16 +109,14 @@ function EditableTemplatePartInnerBlocks( {
 		[]
 	);
 
-	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
+	const blockEditorProps = useEntityBlockEditorProps(
 		'postType',
 		'wp_template_part',
 		{ id }
 	);
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		value: blocks,
-		onInput,
-		onChange,
+		...blockEditorProps,
 		renderAppender: useRenderAppender( hasInnerBlocks ),
 		layout: useLayout( layout ),
 	} );

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -1031,7 +1031,9 @@ The following set of react hooks available to import from the `@wordpress/core-d
 
 Hook that returns block content getters and setters for the nearest provided entity of the specified type.
 
-The return value has the shape `[ blocks, onInput, onChange ]`. `onInput` is for block changes that don't create undo levels or dirty the post, non-persistent changes, and `onChange` is for persistent changes. They map directly to the props of a `BlockEditorProvider` and are intended to be used with it, or similar components or hooks.
+The return value has the shape `[ blocks, onInput, onChange, options ]`. `onInput` is for block changes that don't create undo levels or dirty the post, non-persistent changes, and `onChange` is for persistent changes.
+
+Prefer `__unstableUseEntityBlockEditorProps` when passing entity blocks to a controlled block editor surface like `BlockEditorProvider`, `InnerBlocks`, or `useInnerBlocksProps`. Use this lower-level tuple hook when a component only needs to inspect blocks or call one of the returned callbacks.
 
 _Parameters_
 
@@ -1042,7 +1044,7 @@ _Parameters_
 
 _Returns_
 
--   `[unknown[], Function, Function]`: The block array and setters.
+-   `[unknown[], Function, Function, Object]`: The block array, setters, and block editor options.
 
 ### useEntityId
 

--- a/packages/core-data/src/hooks/index.ts
+++ b/packages/core-data/src/hooks/index.ts
@@ -19,6 +19,9 @@ export {
 	default as useResourcePermissions,
 	useDeprecatedResourcePermissions as __experimentalUseResourcePermissions,
 } from './use-resource-permissions';
-export { default as useEntityBlockEditor } from './use-entity-block-editor';
+export {
+	default as useEntityBlockEditor,
+	__unstableUseEntityBlockEditorProps,
+} from './use-entity-block-editor';
 export { default as useEntityId } from './use-entity-id';
 export { default as useEntityProp } from './use-entity-prop';

--- a/packages/core-data/src/hooks/use-entity-block-editor.js
+++ b/packages/core-data/src/hooks/use-entity-block-editor.js
@@ -19,31 +19,42 @@ const EMPTY_ARRAY = [];
  * Hook that returns block content getters and setters for
  * the nearest provided entity of the specified type.
  *
- * The return value has the shape `[ blocks, onInput, onChange ]`.
+ * The return value has the shape `[ blocks, onInput, onChange, options ]`.
  * `onInput` is for block changes that don't create undo levels
  * or dirty the post, non-persistent changes, and `onChange` is for
- * persistent changes. They map directly to the props of a
- * `BlockEditorProvider` and are intended to be used with it,
- * or similar components or hooks.
+ * persistent changes.
+ *
+ * Prefer `__unstableUseEntityBlockEditorProps` when passing entity blocks to a
+ * controlled block editor surface like `BlockEditorProvider`, `InnerBlocks`, or
+ * `useInnerBlocksProps`. Use this lower-level tuple hook when a component only
+ * needs to inspect blocks or call one of the returned callbacks.
  *
  * @param {string} kind         The entity kind.
  * @param {string} name         The entity name.
  * @param {Object} options
  * @param {string} [options.id] An entity ID to use instead of the context-provided one.
  *
- * @return {[unknown[], Function, Function]} The block array and setters.
+ * @return {[unknown[], Function, Function, Object]} The block array, setters, and block editor options.
  */
 export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 	const providerId = useEntityId( kind, name );
 	const id = _id ?? providerId;
-	const { content, editedBlocks, meta } = useSelect(
+	const { blockEditSource, content, editedBlocks, meta } = useSelect(
 		( select ) => {
 			if ( ! id ) {
 				return {};
 			}
-			const { getEditedEntityRecord } = select( STORE_NAME );
+			const {
+				__unstableGetEntityRecordBlockEditSource,
+				getEditedEntityRecord,
+			} = select( STORE_NAME );
 			const editedRecord = getEditedEntityRecord( kind, name, id );
 			return {
+				blockEditSource: __unstableGetEntityRecordBlockEditSource(
+					kind,
+					name,
+					id
+				),
 				editedBlocks: editedRecord.blocks,
 				content: editedRecord.content,
 				meta: editedRecord.meta,
@@ -133,5 +144,47 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 		[ kind, name, id, meta, editEntityRecord ]
 	);
 
-	return [ blocks, onInput, onChange ];
+	const options = useMemo(
+		() => ( {
+			__unstableIsRemoteSynced:
+				blockEditSource === 'remote-sync' && blocks === editedBlocks,
+		} ),
+		[ blockEditSource, blocks, editedBlocks ]
+	);
+
+	return [ blocks, onInput, onChange, options ];
 }
+
+/**
+ * Hook that returns the spreadable block editor props for an entity record.
+ *
+ * This is a convenience wrapper around `useEntityBlockEditor` for controlled
+ * block editor surfaces. Prefer this helper when passing entity-backed blocks
+ * to `BlockEditorProvider`, `InnerBlocks`, or `useInnerBlocksProps`, so callers
+ * receive the full prop bundle including private editor sync metadata. The
+ * returned object includes both `blocks` for local reads and `value` for
+ * spreading into controlled block editor APIs.
+ *
+ * @param {string} kind    The entity kind.
+ * @param {string} name    The entity name.
+ * @param {Object} options Hook options.
+ *
+ * @return {Object} Block editor props.
+ */
+function useEntityBlockEditorProps( kind, name, options ) {
+	const [ blocks, onInput, onChange, { __unstableIsRemoteSynced } = {} ] =
+		useEntityBlockEditor( kind, name, options );
+
+	return useMemo(
+		() => ( {
+			blocks,
+			value: blocks,
+			onInput,
+			onChange,
+			__unstableIsRemoteSynced,
+		} ),
+		[ blocks, onInput, onChange, __unstableIsRemoteSynced ]
+	);
+}
+
+export { useEntityBlockEditorProps as __unstableUseEntityBlockEditorProps };

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -283,6 +283,59 @@ function entity( entityConfig ) {
 				return state;
 			},
 
+			editSources: ( state = {}, action ) => {
+				switch ( action.type ) {
+					case 'RECEIVE_ITEMS': {
+						const nextState = { ...state };
+						const itemsList = Array.isArray( action.items )
+							? action.items
+							: [ action.items ];
+						let hasChange = false;
+
+						for ( const record of itemsList ) {
+							const recordId = record?.[ action.key ];
+							if ( nextState[ recordId ] ) {
+								delete nextState[ recordId ];
+								hasChange = true;
+							}
+						}
+
+						return hasChange ? nextState : state;
+					}
+
+					case 'EDIT_ENTITY_RECORD': {
+						if (
+							! Object.prototype.hasOwnProperty.call(
+								action.edits,
+								'blocks'
+							)
+						) {
+							return state;
+						}
+
+						if ( action.options?.__unstableIsRemoteSync ) {
+							return {
+								...state,
+								[ action.recordId ]: {
+									...state[ action.recordId ],
+									blocks: 'remote-sync',
+								},
+							};
+						}
+
+						if ( ! state[ action.recordId ] ) {
+							return state;
+						}
+
+						const nextState = { ...state };
+						delete nextState[ action.recordId ];
+						return nextState;
+					}
+				}
+
+				return state;
+			},
+
 			saving: ( state = {}, action ) => {
 				switch ( action.type ) {
 					case 'SAVE_ENTITY_RECORD_START':

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -82,6 +82,7 @@ interface RevisionsQueriedData {
 
 interface EntityState< EntityRecord extends ET.EntityRecord > {
 	edits: Record< string, Partial< EntityRecord > >;
+	editSources: Record< string, { blocks?: 'remote-sync' } >;
 	saving: Record<
 		string,
 		Partial< { pending: boolean; isAutosave: boolean; error: Error } >
@@ -869,6 +870,27 @@ export function getEntityRecordEdits(
 	return state.entities.records?.[ kind ]?.[ name ]?.edits?.[
 		recordId as string | number
 	];
+}
+
+/**
+ * Returns source metadata for the latest block edit to an entity record.
+ *
+ * @param state    State tree.
+ * @param kind     Entity kind.
+ * @param name     Entity name.
+ * @param recordId Record ID.
+ *
+ * @return The source of the latest block edit, if known.
+ */
+export function __unstableGetEntityRecordBlockEditSource(
+	state: State,
+	kind: string,
+	name: string,
+	recordId: EntityRecordKey
+): Optional< 'remote-sync' > {
+	return state.entities.records?.[ kind ]?.[ name ]?.editSources?.[
+		recordId as string | number
+	]?.blocks;
 }
 
 /**

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -29,6 +29,60 @@ describe( 'entities', () => {
 		} );
 	} );
 
+	it( 'tracks and clears remote block edit sources', () => {
+		let state = entities( undefined, {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'root',
+			name: 'postType',
+			recordId: 'post',
+			edits: { blocks: [] },
+			options: { __unstableIsRemoteSync: true },
+		} );
+
+		expect( state.records.root.postType.editSources ).toEqual( {
+			post: { blocks: 'remote-sync' },
+		} );
+
+		state = entities( state, {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'root',
+			name: 'postType',
+			recordId: 'post',
+			edits: { title: 'A local title edit' },
+		} );
+
+		expect( state.records.root.postType.editSources ).toEqual( {
+			post: { blocks: 'remote-sync' },
+		} );
+
+		state = entities( state, {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'root',
+			name: 'postType',
+			recordId: 'post',
+			edits: { blocks: [] },
+		} );
+
+		expect( state.records.root.postType.editSources ).toEqual( {} );
+
+		state = entities( state, {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'root',
+			name: 'postType',
+			recordId: 'post',
+			edits: { blocks: [] },
+			options: { __unstableIsRemoteSync: true },
+		} );
+		state = entities( state, {
+			type: 'RECEIVE_ITEMS',
+			kind: 'root',
+			name: 'postType',
+			items: { slug: 'post' },
+		} );
+
+		expect( state.records.root.postType.editSources ).toEqual( {} );
+	} );
+
 	it( 'returns with received post types by slug', () => {
 		const originalState = deepFreeze( {} );
 		const state = entities( originalState, {

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -14,6 +14,7 @@ import {
 	getRawEntityRecord,
 	__experimentalGetDirtyEntityRecords,
 	__experimentalGetEntitiesBeingSaved,
+	__unstableGetEntityRecordBlockEditSource,
 	getEntityRecordNonTransientEdits,
 	getEmbedPreview,
 	isPreviewEmbedFallback,
@@ -898,6 +899,41 @@ describe( 'getEntityRecordNonTransientEdits', () => {
 				'someId'
 			)
 		).toEqual( {} );
+	} );
+} );
+
+describe( '__unstableGetEntityRecordBlockEditSource', () => {
+	it( 'returns the latest block edit source for an entity record', () => {
+		const state = deepFreeze( {
+			entities: {
+				records: {
+					postType: {
+						post: {
+							editSources: {
+								1: { blocks: 'remote-sync' },
+							},
+						},
+					},
+				},
+			},
+		} );
+
+		expect(
+			__unstableGetEntityRecordBlockEditSource(
+				state,
+				'postType',
+				'post',
+				1
+			)
+		).toBe( 'remote-sync' );
+		expect(
+			__unstableGetEntityRecordBlockEditSource(
+				state,
+				'postType',
+				'post',
+				2
+			)
+		).toBeUndefined();
 	} );
 } );
 

--- a/packages/edit-widgets/src/blocks/widget-area/edit/inner-blocks.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/inner-blocks.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useEntityBlockEditor } from '@wordpress/core-data';
+import { __unstableUseEntityBlockEditorProps as useEntityBlockEditorProps } from '@wordpress/core-data';
 import { InnerBlocks, useInnerBlocksProps } from '@wordpress/block-editor';
 import { useRef } from '@wordpress/element';
 
@@ -16,10 +16,7 @@ import { useRef } from '@wordpress/element';
 import useIsDraggingWithin from './use-is-dragging-within';
 
 export default function WidgetAreaInnerBlocks( { id } ) {
-	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
-		'root',
-		'postType'
-	);
+	const blockEditorProps = useEntityBlockEditorProps( 'root', 'postType' );
 	const innerBlocksRef = useRef();
 	const isDraggingWithinInnerBlocks = useIsDraggingWithin( innerBlocksRef );
 	const shouldHighlightDropZone = isDraggingWithinInnerBlocks;
@@ -27,9 +24,7 @@ export default function WidgetAreaInnerBlocks( { id } ) {
 	const innerBlocksProps = useInnerBlocksProps(
 		{ ref: innerBlocksRef },
 		{
-			value: blocks,
-			onInput,
-			onChange,
+			...blockEditorProps,
 			templateLock: false,
 			renderAppender: InnerBlocks.ButtonBlockAppender,
 		}

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -5,7 +5,10 @@ import { SlotFillProvider } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { uploadMedia } from '@wordpress/media-utils';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
+import {
+	__unstableUseEntityBlockEditorProps as useEntityBlockEditorProps,
+	store as coreStore,
+} from '@wordpress/core-data';
 import { useMemo } from '@wordpress/element';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { privateApis as editPatternsPrivateApis } from '@wordpress/patterns';
@@ -110,20 +113,16 @@ export default function WidgetAreasBlockEditorProvider( {
 
 	const widgetAreaId = useLastSelectedWidgetArea();
 
-	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
-		KIND,
-		POST_TYPE,
-		{ id: buildWidgetAreasPostId() }
-	);
+	const blockEditorProps = useEntityBlockEditorProps( KIND, POST_TYPE, {
+		id: buildWidgetAreasPostId(),
+	} );
 
 	return (
 		<SlotFillProvider>
 			<KeyboardShortcuts.Register />
 			<BlockKeyboardShortcuts />
 			<ExperimentalBlockEditorProvider
-				value={ blocks }
-				onInput={ onInput }
-				onChange={ onChange }
+				{ ...blockEditorProps }
 				settings={ settings }
 				useSubRegistry={ false }
 				{ ...props }

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -11,7 +11,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
 	EntityProvider,
-	useEntityBlockEditor,
+	__unstableUseEntityBlockEditorProps as useEntityBlockEditorProps,
 	store as coreStore,
 } from '@wordpress/core-data';
 import {
@@ -50,6 +50,13 @@ const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
 
 const noop = () => {};
+const DEFAULT_BLOCK_EDITOR_PROPS = {
+	blocks: undefined,
+	value: undefined,
+	onInput: noop,
+	onChange: noop,
+	__unstableIsRemoteSynced: false,
+};
 
 /**
  * These are global entities that are only there to split blocks into logical units
@@ -73,23 +80,30 @@ const NON_CONTEXTUAL_POST_TYPES = [
  *
  * @example
  * ```jsx
- * const [ blocks, onInput, onChange ] = useBlockEditorProps( post, template, mode );
+ * const blockEditorProps = useBlockEditorProps( post, template, mode );
  * ```
  *
- * @return {Array} Block editor props.
+ * @return {Object} Block editor props.
  */
 function useBlockEditorProps( post, template, mode ) {
 	const revisionBlocks = useRevisionBlocks();
 	const rootLevelPost = mode === 'template-locked' ? 'template' : 'post';
-	const [ postBlocks, onInput, onChange ] = useEntityBlockEditor(
+	const postBlockEditorProps = useEntityBlockEditorProps(
 		'postType',
 		post.type,
-		{ id: post.id }
+		{
+			id: post.id,
+		}
 	);
-	const [ templateBlocks, onInputTemplate, onChangeTemplate ] =
-		useEntityBlockEditor( 'postType', template?.type, {
+	const templateBlockEditorProps = useEntityBlockEditorProps(
+		'postType',
+		template?.type,
+		{
 			id: template?.id,
-		} );
+		}
+	);
+	const postBlocks = postBlockEditorProps.blocks;
+	const templateBlocks = templateBlockEditorProps.blocks;
 	const maybeNavigationBlocks = useMemo( () => {
 		if ( post.type === 'wp_navigation' ) {
 			return [
@@ -120,8 +134,17 @@ function useBlockEditorProps( post, template, mode ) {
 
 	// In revisions mode, use the revision blocks and disable editing.
 	if ( revisionBlocks !== null ) {
-		return [ revisionBlocks, noop, noop ];
+		return {
+			...DEFAULT_BLOCK_EDITOR_PROPS,
+			blocks: revisionBlocks,
+			value: revisionBlocks,
+		};
 	}
+
+	const blockEditorProps =
+		rootLevelPost === 'post'
+			? postBlockEditorProps
+			: templateBlockEditorProps;
 
 	// Handle fallback to postBlocks outside of the above useMemo, to ensure
 	// that constructed block templates that call `createBlock` are not generated
@@ -130,14 +153,24 @@ function useBlockEditorProps( post, template, mode ) {
 		( !! template && mode === 'template-locked' ) ||
 		post.type === 'wp_navigation';
 	if ( disableRootLevelChanges ) {
-		return [ blocks, noop, noop ];
+		const disabledBlockEditorProps =
+			post.type === 'wp_navigation'
+				? DEFAULT_BLOCK_EDITOR_PROPS
+				: blockEditorProps;
+		return {
+			...disabledBlockEditorProps,
+			blocks,
+			value: blocks,
+			onInput: noop,
+			onChange: noop,
+		};
 	}
 
-	return [
+	return {
+		...blockEditorProps,
 		blocks,
-		rootLevelPost === 'post' ? onInput : onInputTemplate,
-		rootLevelPost === 'post' ? onChange : onChangeTemplate,
-	];
+		value: blocks,
+	};
 }
 
 /**
@@ -295,11 +328,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			id,
 			mode
 		);
-		const [ blocks, onInput, onChange ] = useBlockEditorProps(
-			post,
-			template,
-			mode
-		);
+		const blockEditorProps = useBlockEditorProps( post, template, mode );
 
 		const {
 			updatePostLock,
@@ -410,9 +439,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 				>
 					<BlockContextProvider value={ defaultBlockContext }>
 						<BlockEditorProviderComponent
-							value={ blocks }
-							onChange={ onChange }
-							onInput={ onInput }
+							{ ...blockEditorProps }
 							selection={
 								isInRevisionsMode ? undefined : selection
 							}

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -223,6 +223,8 @@ export function createSyncManager( debug = false ): SyncManager {
 			_events: Y.YEvent< any >[],
 			transaction: Y.Transaction
 		): void => {
+			const isRemoteSync = ! transaction.local;
+
 			if (
 				transaction.local &&
 				! ( transaction.origin instanceof Y.UndoManager )
@@ -230,7 +232,9 @@ export function createSyncManager( debug = false ): SyncManager {
 				return;
 			}
 
-			void internal.updateEntityRecord( objectType, objectId );
+			void internal.updateEntityRecord( objectType, objectId, {
+				isRemoteSync,
+			} );
 		};
 
 		const onStateMapUpdate = (
@@ -675,12 +679,16 @@ export function createSyncManager( debug = false ): SyncManager {
 	 * Update the entity record in the local store with changes from the CRDT
 	 * document.
 	 *
-	 * @param {ObjectType} objectType Object type of record to update.
-	 * @param {ObjectID}   objectId   Object ID of record to update.
+	 * @param {ObjectType} objectType           Object type of record to update.
+	 * @param {ObjectID}   objectId             Object ID of record to update.
+	 * @param {Object}     options              Update options.
+	 * @param {boolean}    options.isRemoteSync Whether the update originated from
+	 *                                          remote sync.
 	 */
 	async function _updateEntityRecord(
 		objectType: ObjectType,
-		objectId: ObjectID
+		objectId: ObjectID,
+		options: { isRemoteSync?: boolean } = {}
 	): Promise< void > {
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
@@ -708,7 +716,9 @@ export function createSyncManager( debug = false ): SyncManager {
 		log( 'updateEntityRecord', 'changes', entityId, {
 			changedKeys,
 		} );
-		handlers.editRecord( changes );
+		handlers.editRecord( changes, {
+			__unstableIsRemoteSync: !! options.isRemoteSync,
+		} );
 	}
 
 	/**

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -888,9 +888,12 @@ describe( 'SyncManager', () => {
 			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 
 			expect( mockHandlers.editRecord ).toHaveBeenCalledTimes( 1 );
-			expect( mockHandlers.editRecord ).toHaveBeenCalledWith( {
-				title: 'Title from remote peer',
-			} );
+			expect( mockHandlers.editRecord ).toHaveBeenCalledWith(
+				{
+					title: 'Title from remote peer',
+				},
+				{ __unstableIsRemoteSync: true }
+			);
 		} );
 
 		it( 'does not edit the local record for local transactions', async () => {

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -127,7 +127,7 @@ export interface RecordHandlers {
 	addUndoMeta: ( ydoc: Y.Doc, meta: Map< string, any > ) => void;
 	editRecord: (
 		data: Partial< ObjectData >,
-		options?: { undoIgnore?: boolean }
+		options?: { __unstableIsRemoteSync?: boolean; undoIgnore?: boolean }
 	) => void;
 	getEditedRecord: () => Promise< ObjectData >;
 	onStatusChange: OnStatusChangeCallback;


### PR DESCRIPTION
Edit: I don't really like this approach, and ideally the sender using `queueMicrotask` can be in charge of keeping the RTC sync updates together. I'll keep this draft open while I try something new.

## What?

Presently in real-time collaboration over WebSockets, inserting templated blocks (like `core/list`) can result in multiple inner block insertions:

https://github.com/user-attachments/assets/f164ac3d-7235-4439-9644-7801a9550df6

Notice that two inner `core/list-item` blocks were inserted. This scales with the number of users collaborating on a post, so 10 users could see 10 empty list items inserted with one outer `core/list` block.

This PR prevents remotely received blocks from running local inner-block template insertion when they first appear in the editor. In practice, this fixes the RTC case above and any other block that utilizes `useInnerBlocksProps()` with a template:

https://github.com/user-attachments/assets/3756ca9d-b9aa-462d-b021-712d9849a95b

## Why?

1. When a user adds a list block, the outer `core/list` block is added [with an innerBlocks template](https://github.com/WordPress/gutenberg/blob/ea0d91be40e283219bd9056bd1cbe55dc116d724/packages/block-library/src/list/edit.js#L130-L133).
2. After a `queueMicrotask` (async delay), the block detects it has no template yet, and [inserts the template block](https://github.com/WordPress/gutenberg/blob/ea0d91be40e283219bd9056bd1cbe55dc116d724/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js#L65-L95) into the list block.

On WebSockets in production, the first action syncs to other users pretty much immediately, and then all users have an empty `core/list` block. They then all run the same template insertion logic and add a fresh list item to the list. This is less common in HTTP polling because operations are sent in 500ms merged updates, which typically contain both the outer and inner list blocks.

In general, when a user inserts a block with a default inner-block template, the parent block can sync to other peers before the queued template-fill microtask runs. Each peer then sees an empty templated block and fills it locally, so the template child is duplicated across collaborators. This sort of deferred behavior is very difficult for RTC, since operations aren't rolled into the same transaction and can be spread across an arbitrary amount of time.

In this PR, we want the originator to remain responsible for the template fill, while remote peers wait for that canonical update instead of broadcasting their own copy.

## How?

In short, we tag remote CRDT updates (`__unstableIsRemoteSynced`) on remotely-synced blocks. When we hit the inner template insertion logic, we check to see if the outer block has a remote origin. We then run a template insertion only when the local editor is the originator. This takes some plumbing.

### Inner Blocks Remote-Sync Order

There are a lot of changed files in this PR, but many of them are just plumbing for the new flag. Here's how it's piped down from initial remote sync into the inner `queueMicrotask` call:

```text
Remote Yjs transaction
        │
        ▼
┌─────────────────────┐
│ sync/src/manager.ts │
└─────────────────────┘
  editRecord(..., { __unstableIsRemoteSync: true })
        │
        ▼
┌──────────────────────────┐
│ core-data/src/reducer.js │
└──────────────────────────┘
  editSources[recordId].blocks = 'remote-sync'
        │
        ▼
┌────────────────────────────┐
│ core-data/src/selectors.ts │
└────────────────────────────┘
  __unstableGetEntityRecordBlockEditSource()
        │
        ▼
┌────────────────────────────────────────────────┐
│ core-data/src/hooks/use-entity-block-editor.js │
└────────────────────────────────────────────────┘
  useEntityBlockEditor()
    -> options.__unstableIsRemoteSynced
  __unstableUseEntityBlockEditorProps()
    -> { blocks, value, onInput, onChange, __unstableIsRemoteSynced }
        │
        ▼
┌───────────────────────────────────────────────┐
│ block-editor/src/components/provider/index.js │
└───────────────────────────────────────────────┘
  BlockEditorProvider forwards __unstableIsRemoteSynced
        │
        ▼
┌────────────────────────────────────────────────────────┐
│ block-editor/src/components/provider/use-block-sync.js │
└────────────────────────────────────────────────────────┘
  useBlockSync() receives remote controlled value
    -> walks incoming blocks
    -> marks incoming clientIds
        │
        ▼
┌───────────────────────────────────┐
│ block-editor/src/store/actions.js │
└───────────────────────────────────┘
  __unstableMarkRemoteSyncedBlocks()
  __unstableClearRemoteSyncedBlock()
        │
        ▼
┌───────────────────────────────────┐
│ block-editor/src/store/reducer.js │
└───────────────────────────────────┘
  remoteSyncedBlocks = Set(clientIds)
        │
        ▼
┌─────────────────────────────────────┐
│ block-editor/src/store/selectors.js │
└─────────────────────────────────────┘
  __unstableIsRemoteSyncedBlock(clientId)
        │
        ▼
┌───────────────────────────────────────────────────────────────────────────┐
│ block-editor/src/components/inner-blocks/use-inner-block-template-sync.js │
└───────────────────────────────────────────────────────────────────────────┘
  queued microtask checks the mark
    -> clear mark
    -> if remote + empty, skip local template fill
    -> record template as seen so same-template reruns no-op
```

### Usage

`useEntityBlockEditor` remains the lower-level tuple hook for callers that only need part of the block editor binding, such as reading `blocks` for a preview or using `onChange` for a one-off template selection. Its tuple now has a backward-compatible fourth `options` item. `__unstableUseEntityBlockEditorProps` is a small wrapper around it for controlled block-editor surfaces: it returns `{ blocks, value, onInput, onChange, __unstableIsRemoteSynced }`, where `blocks` is the readable block array and `value` is the same array under the prop name expected by `BlockEditorProvider`, `InnerBlocks`, and `useInnerBlocksProps`.

Both exist to keep the existing tuple API backwards-compatible while making the safer path obvious for entity-backed block editor bindings. In general, use the props helper when connecting entity blocks to an editor surface, and use `useEntityBlockEditor` directly when a component only needs to inspect blocks or call one of the tuple callbacks.

### Tradeoffs

Remote-sync block marks are intentionally single-use, because the distinction doesn't matter after template insertion. Once `useInnerBlockTemplateSync` sees the mark, it clears it. `useBlockSync` currently marks the whole incoming controlled subtree instead of diffing only newly added blocks; that keeps the implementation simple and matches the existing whole-tree reset path, but it does mean remote updates do a full clientId walk. Core-data also keeps remote block edit source metadata until a later local block edit or record receive; the runtime guard only treats it as active while the current blocks reference is the remote edit, so stale metadata should be inert.

This intentionally does not try to synthesize a missing template child on remote peers if the originator disappears before its queued template-fill microtask runs. Without a larger coordination mechanism, peers cannot reliably distinguish "the originator's fill is still in flight" from "the originator will never send it"; this PR chooses to prevent duplicate children rather than adding a fallback that could reintroduce the fan-out race.

## Testing Instructions

1. Enable RTC via Settings -> Writing -> "Enable real-time collaboration" checkbox.

2. Open the same post in two browser sessions as different users.
    IMPORTANT: Use two separate browsers, not just two tabs, as `queueMicrotask()` seems to avoid race conditions between two tabs in the same browser.
3. In one session, insert a List block.
4. Confirm the List block contains a single List Item in both sessions.
5. Repeat with three or more connected sessions and confirm only one List Item is created.
6. In one session, insert another block that uses a default inner-block template, such as Columns, and confirm peers do not create duplicate template children.
7. Confirm normal local insertion still works when RTC is disabled or only one editor session is open.
8. Run `npm run test:unit -- packages/block-editor/src/components/inner-blocks/test/use-inner-block-template-sync.js`.

## Use of AI Tools

AI assistance: Yes
Tool(s): Codex + Claude
Used for: Investigate the RTC race, implement the remote-synced guard, make PR description additions.