### PR TITLE
Media Editor Modal: Tighten labels for crop handles toggle

### DIFF
--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -87,8 +87,7 @@ export default function MediaEditorCropPanel( {
 				} ) ) }
 			/>
 			<ToggleControl
-				label={ __( 'Resize crop area' ) }
-				help={ __( 'Show handles to adjust the crop box.' ) }
+				label={ __( 'Show resize handles' ) }
 				checked={ freeformCrop }
 				onChange={ onFreeformChange }
 			/>

--- a/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
@@ -46,12 +46,9 @@ describe( 'MediaEditorCropPanel', () => {
 		setupCropPanel();
 
 		const aspectRatio = screen.getByLabelText( 'Aspect ratio' );
-		const resizeCropArea = screen.getByLabelText( 'Resize crop area' );
+		const resizeCropArea = screen.getByLabelText( 'Show resize handles' );
 		const zoom = screen.getByRole( 'slider', { name: 'Zoom' } );
 
-		expect(
-			screen.getByText( 'Show handles to adjust the crop box.' )
-		).toBeInTheDocument();
 		expectElementBefore( aspectRatio, resizeCropArea );
 		expectElementBefore( resizeCropArea, zoom );
 	} );
@@ -79,7 +76,7 @@ describe( 'MediaEditorCropPanel', () => {
 			freeformCrop: true,
 		} );
 
-		fireEvent.click( screen.getByLabelText( 'Resize crop area' ) );
+		fireEvent.click( screen.getByLabelText( 'Show resize handles' ) );
 
 		expect( controls.onFreeformChange ).toHaveBeenCalledWith( false );
 	} );


### PR DESCRIPTION
## What?

Part of:

* https://github.com/WordPress/gutenberg/issues/73771

Tighten up the labels for the resize crop area toggle.

## Why?

Based on feedback the current help text is a little redundant and large. There was also the question of whether the toggle is needed. I lean a little toward including it — but I think further down the track we could place it behind an Advanced panel. IMO it's nice that there's visual aspects of the cropper that folks can toggle. In this case, to be able to see the full edges of the image unobscured by the UI controls.

## How?

* Quick rename, update tests.

## Testing Instructions

Enable the Media Editor Modal experiment
Click the Crop icon on an image block in the post editor
Play around with the toggles and see how it looks

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="636" height="724" alt="image" src="https://github.com/user-attachments/assets/73a8ad7b-4ae8-4283-a586-e2422f9a4b06" /> | <img width="652" height="764" alt="image" src="https://github.com/user-attachments/assets/ee0927eb-849f-4a0b-8c84-3456fe826cfa" /> |

## Use of AI Tools

Claude Code for the test updates.