### PR TITLE
Media Editor Modal: Update the rotation ruler to use a vertical line marker

### DIFF
--- a/packages/media-editor/src/components/rotation-ruler/index.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/index.tsx
@@ -193,7 +193,12 @@ export default function RotationRuler( props: RotationRulerProps ) {
 	// major (e.g. "-7°") or the major itself when on-major (e.g. "0°").
 	const closestMajor = Math.round( value / MAJOR_INTERVAL ) * MAJOR_INTERVAL;
 	const onMajor = Math.abs( value - closestMajor ) < 0.01;
-	const activeText = onMajor ? `${ closestMajor }${ unit }` : display;
+	// Split the number into sign + digits so the sign is rendered in a
+	// separate span and excluded from the active label's centering, the
+	// same way the unit is.
+	const numberText = onMajor ? `${ closestMajor }` : formatValue( value );
+	const isNegative = numberText.startsWith( '-' );
+	const digits = isNegative ? numberText.slice( 1 ) : numberText;
 	const majorTicks = ticks.filter( ( tick ) => tick.kind === 'major' );
 
 	return (
@@ -258,7 +263,17 @@ export default function RotationRuler( props: RotationRulerProps ) {
 				</svg>
 			</div>
 			<div className="rotation-ruler__active-label" aria-hidden="true">
-				{ activeText }
+				<span className="rotation-ruler__active-label-number">
+					{ isNegative && (
+						<span className="rotation-ruler__active-label-sign">
+							-
+						</span>
+					) }
+					{ digits }
+					<span className="rotation-ruler__active-label-unit">
+						{ unit }
+					</span>
+				</span>
 			</div>
 			<div className="rotation-ruler__pointer" aria-hidden="true" />
 		</div>

--- a/packages/media-editor/src/components/rotation-ruler/style.scss
+++ b/packages/media-editor/src/components/rotation-ruler/style.scss
@@ -10,7 +10,7 @@ $rotation-ruler-accent: var(--wp-admin-theme-color, #3858e9);
 // Vertical layout (top → bottom):
 //   0–14:  label row (translates with strip; active label sits centered)
 //   14–32: tick lines (anchored to strip bottom)
-//   23–32: pointer triangle (overlapping the bottom of major ticks)
+//   14–32: pointer line (overlays the tick area at center)
 .rotation-ruler {
 	position: relative;
 	min-width: 180px;
@@ -52,18 +52,17 @@ $rotation-ruler-accent: var(--wp-admin-theme-color, #3858e9);
 	white-space: nowrap;
 }
 
-// Upward-pointing triangle anchored to the bottom of the ruler. Marks
-// the centered value cleanly without the vertical stem of a
-// traditional pointer.
+// Thin vertical line marking the centered value. Spans the tick area
+// so it reads as a precise reference line over the ruler graduations
+// without competing with the active label above.
 .rotation-ruler__pointer {
 	position: absolute;
 	bottom: 0;
 	left: 50%;
-	width: 0;
-	height: 0;
-	border-left: 6px solid transparent;
-	border-right: 6px solid transparent;
-	border-bottom: 9px solid $rotation-ruler-accent;
+	width: 2px;
+	height: 18px;
+	background: $rotation-ruler-accent;
+	border-radius: 1px;
 	transform: translateX(-50%);
 	pointer-events: none;
 }
@@ -116,21 +115,58 @@ $rotation-ruler-accent: var(--wp-admin-theme-color, #3858e9);
 }
 
 // Active label is a fixed-center HTML element so it stays steady at the
-// pointer while the SVG behind it transitions smoothly. A white-fading-
-// to-transparent background occludes the static labels directly behind.
+// pointer while the SVG behind it transitions smoothly. The label box
+// is sized to the number alone — the unit is positioned absolutely so
+// it does not influence centering — and a fixed-width ::before
+// pseudo-element provides the white-fading-to-transparent mask that
+// occludes the static labels directly behind.
 .rotation-ruler__active-label {
 	position: absolute;
 	top: 0;
 	left: 50%;
 	height: 14px;
 	transform: translateX(-50%);
-	padding: 0 12px;
 	font-size: 12px;
 	font-weight: 600;
 	line-height: 14px;
 	color: $gray-900;
-	background: linear-gradient(to right, transparent 0, $white 12px, $white calc(100% - 12px), transparent 100%);
 	pointer-events: none;
+
+	&::before {
+		content: "";
+		position: absolute;
+		top: 0;
+		left: 50%;
+		width: 60px;
+		height: 100%;
+		transform: translateX(-50%);
+		background: linear-gradient(to right, transparent 0, $white 12px, $white calc(100% - 12px), transparent 100%);
+	}
+}
+
+// The number drives the centering: the label box's width equals the
+// number's width, so `transform: translateX(-50%)` on the label
+// centers the digits on the marker.
+.rotation-ruler__active-label-number {
+	position: relative;
+	display: inline-block;
+}
+
+// Sign sits flush to the left of the number (mirror of the unit).
+// Rendered only for negative values, and removed from flow so the
+// leading `-` does not nudge the digits off the marker line.
+.rotation-ruler__active-label-sign {
+	position: absolute;
+	top: 0;
+	right: 100%;
+}
+
+// Unit sits flush to the right of the number, out of normal flow so
+// it contributes no width to the label box.
+.rotation-ruler__active-label-unit {
+	position: absolute;
+	top: 0;
+	left: 100%;
 }
 
 // Below ~220px container width, fade out 1° ticks; mid/major remain.


### PR DESCRIPTION
## What?

Part of:

* #73771 

Redesign the marker for the rotation ruler to be a vertical line instead of a triangle. While we're at it, update the centering of the degrees above the marker so that it's directly centered above the marker with the sign (e.g. `-`) and degrees symbols absolute-positioned next to it.

## Why?

Based on design feedback in https://github.com/WordPress/gutenberg/issues/73771#issuecomment-4541412467, but to me I think the vertical line can look a little cleaner and possibly more precise.

The centering of the text also ensures everything lines up irrespective of whether the `-` symbol is present.

## How?

* Redesign the rotation ruler marker to be a vertical line
* Split up the text of the active degrees into its sign, digits, and degrees symbol so that we can center on the digits

## Testing Instructions

Enable the Media Editor Modal experiment
Add an image block (and an image) to a post or page
Click the Crop icon in the block toolbar
Have a play with the fine-grained rotation controls

How does it look and feel now?

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="806" height="150" alt="image" src="https://github.com/user-attachments/assets/797e39aa-4997-4e17-a783-44d88b8de1c9" />

https://github.com/user-attachments/assets/d5fb0c7d-a5ee-4a9a-9bc5-0d921a249eca

### After

<img width="804" height="170" alt="image" src="https://github.com/user-attachments/assets/38737b9e-71da-445c-8d19-6b5ebcd41b92" />

https://github.com/user-attachments/assets/3362d198-9db9-4e54-bc16-bb84dd3ff159

## Use of AI Tools

Claude Code