### PR TITLE
Fix Gutenberg plugin assuming its directory is named "gutenberg"

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -27,7 +27,7 @@ function gutenberg_wordpress_version_notice() {
 	printf( __( 'Gutenberg requires WordPress %s or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' ), GUTENBERG_MINIMUM_WP_VERSION );
 	echo '</p></div>';
 
-	deactivate_plugins( array( 'gutenberg/gutenberg.php' ) );
+	deactivate_plugins( array( plugin_basename( __FILE__ ) ) );
 }
 
 /**

--- a/lib/compat/wordpress-7.1/collaboration.php
+++ b/lib/compat/wordpress-7.1/collaboration.php
@@ -242,7 +242,7 @@ function gutenberg_set_collaboration_option_on_activation() {
 		update_option( 'wp_collaboration_enabled', '1' );
 	}
 }
-add_action( 'activate_gutenberg/gutenberg.php', 'gutenberg_set_collaboration_option_on_activation' );
+add_action( 'activate_' . plugin_basename( dirname( __DIR__, 3 ) . '/gutenberg.php' ), 'gutenberg_set_collaboration_option_on_activation' );
 
 /**
  * Modifies the post list UI and heartbeat responses for real-time collaboration.

--- a/lib/init.php
+++ b/lib/init.php
@@ -27,7 +27,8 @@ function gutenberg_menu() {
 		__( 'Demo', 'gutenberg' ),
 		__( 'Demo', 'gutenberg' ),
 		'edit_posts',
-		'gutenberg'
+		'gutenberg',
+		'__return_null',
 	);
 
 	if ( current_user_can( 'edit_posts' ) ) {


### PR DESCRIPTION
Fixes #76473

## What?

Several parts of the Gutenberg plugin assume it is installed in a directory named exactly `gutenberg`. When the plugin lives in a differently named directory, these code paths break.

This PR removes that hard-coded assumption in three places:

1. The Demo admin menu link.
2. Auto-deactivation when the WordPress version requirement is not met.
3. Setting the RTC  default option on plugin activation.

## Why & How?

- **Broken Demo menu link** — The Demo submenu was registered without a page callback, so WordPress generated its link from the plugin directory instead of a registered admin page, producing a broken link when the directory was not named `gutenberg`. Passing `'__return_null'` as the callback registers a proper page hook, so the link resolves to `admin.php?page=gutenberg` regardless of the directory name.
- **Collaboration default option not set on activation**  — The activation hook was registered as `activate_gutenberg/gutenberg.php`. The `activate_{$plugin}` hook uses the plugin slug, so it never fires under a different directory name and `wp_collaboration_enabled` is left unset on activation. The hook name is now built from the main file's basename via `plugin_basename( dirname( __DIR__, 3 ) . '/gutenberg.php' )`.
- **Plugin not deactivated on WP version mismatch** — When the installed WordPress version is below the minimum requirement, the plugin tries to self-deactivate via `deactivate_plugins( array( 'gutenberg/gutenberg.php' ) )`. With a different directory name the slug does not match, so the plugin keeps running. Since this runs from the main plugin file, `plugin_basename( __FILE__ )` resolves the correct slug.

## Testing Instructions

### Preparing to run the tests

- Start a local site other than wp-env. For example, Studio.
- Clone the Gutenberg repository to the plugins directory and rename the plugin directory to `gutenberg-test`.
- Build Gutenberg.
- Activate the Gutenberg plugin.

### Broken Demo menu link

- Access the Gutenberg > Demo menu.
- The Demo page (http://localhost:8881/wp-admin/post-new.php?gutenberg-demo) will be displayed.

### Collaboration default option not set on activation

Add the following test code beforehand.

```diff
diff --git a/lib/compat/wordpress-7.1/collaboration.php b/lib/compat/wordpress-7.1/collaboration.php
index f6d46d3ac0c..3ec6591fb67 100644
--- a/lib/compat/wordpress-7.1/collaboration.php
+++ b/lib/compat/wordpress-7.1/collaboration.php
@@ -238,6 +238,8 @@ add_action( 'admin_init', 'gutenberg_inject_real_time_collaboration_setting' );
  * collaboration is allowed.
  */
 function gutenberg_set_collaboration_option_on_activation() {
+       wp_die( 'activation_hook fired!');
+
        if ( wp_is_collaboration_allowed() ) {
                update_option( 'wp_collaboration_enabled', '1' );
        }
```

- Disable and then enable the Gutenberg plugin.
- Verify that the hook is running.

### Plugin not deactivated on WP version mismatch

- Downgrade your WordPress version to 6.7. This version is not supported by Gutenberg.
- Access http://localhost:8881/wp-admin/plugins.php.
- A warning will appear, and the Gutenberg plugin will be disabled.

<img width="938" height="587" alt="after-deactivate-plugin" src="https://github.com/user-attachments/assets/89c29c8a-7426-4d09-9361-af098ba5fc5b" />

## Use of AI Tools

This pull request was authored with assistance from Claude Code (Anthropic). All changes were reviewed and verified by the author.
