### PR TITLE
Unset grid span defaults with viewport states enabled

### DIFF
--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -40,13 +40,14 @@ function helpText( selfStretch, parentLayout ) {
 /**
  * Form to edit the child layout value.
  *
- * @param {Object}   props                  Props.
- * @param {Object}   props.value            The child layout value.
- * @param {Function} props.onChange         Function to update the child layout value.
- * @param {Object}   props.parentLayout     The parent layout value.
+ * @param {Object}   props                      Props.
+ * @param {Object}   props.value                The child layout value.
+ * @param {Function} props.onChange             Function to update the child layout value.
+ * @param {Object}   props.parentLayout         The parent layout value.
  *
- * @param {boolean}  props.isShownByDefault
- * @param {string}   props.panelId
+ * @param {boolean}  props.isShownByDefault     Whether the control is shown by default.
+ * @param {string}   props.panelId              The panel ID.
+ * @param {boolean}  props.showGridSpanDefaults Whether unset grid span controls should show default values.
  * @return {Element} child layout edit element.
  */
 export default function ChildLayoutControl( {
@@ -55,6 +56,7 @@ export default function ChildLayoutControl( {
 	parentLayout,
 	isShownByDefault,
 	panelId,
+	showGridSpanDefaults = true,
 } ) {
 	const {
 		type: parentType,
@@ -80,6 +82,7 @@ export default function ChildLayoutControl( {
 				parentLayout={ parentLayout }
 				isShownByDefault={ isShownByDefault }
 				panelId={ panelId }
+				showGridSpanDefaults={ showGridSpanDefaults }
 			/>
 		);
 	}
@@ -206,6 +209,7 @@ function GridControls( {
 	parentLayout,
 	isShownByDefault,
 	panelId,
+	showGridSpanDefaults,
 } ) {
 	const { columnStart, rowStart, columnSpan, rowSpan } = childLayout;
 	const { columnCount, rowCount } = parentLayout ?? {};
@@ -243,6 +247,9 @@ function GridControls( {
 		window.__experimentalEnableGridInteractivity && rowCount
 			? rowCount - ( rowStart ?? 1 ) + 1
 			: undefined;
+	const columnSpanValue =
+		columnSpan ?? ( showGridSpanDefaults ? 1 : undefined );
+	const rowSpanValue = rowSpan ?? ( showGridSpanDefaults ? 1 : undefined );
 
 	return (
 		<>
@@ -274,7 +281,7 @@ function GridControls( {
 								columnSpan: constrainedValue,
 							} );
 						} }
-						value={ columnSpan ?? 1 }
+						value={ columnSpanValue }
 						min={ 1 }
 						max={ maxColumnSpan }
 					/>
@@ -298,7 +305,7 @@ function GridControls( {
 								rowSpan: constrainedValue,
 							} );
 						} }
-						value={ rowSpan ?? 1 }
+						value={ rowSpanValue }
 						min={ 1 }
 						max={ maxRowSpan }
 					/>

--- a/packages/block-editor/src/components/child-layout-control/test/index.js
+++ b/packages/block-editor/src/components/child-layout-control/test/index.js
@@ -1,0 +1,126 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import ChildLayoutControl from '../';
+
+jest.mock( '@wordpress/data/src/components/use-select', () =>
+	jest.fn( ( mapSelect ) => {
+		if ( typeof mapSelect === 'function' ) {
+			return mapSelect( () => ( {
+				getBlockRootClientId: () => 'root-client-id',
+			} ) );
+		}
+
+		return {
+			getBlockAttributes: () => ( {} ),
+			getBlockOrder: () => [],
+		};
+	} )
+);
+
+jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
+	useDispatch: () => ( {
+		__unstableMarkNextChangeAsNotPersistent: jest.fn(),
+		moveBlocksToPosition: jest.fn(),
+	} ),
+} ) );
+
+describe( 'ChildLayoutControl', () => {
+	const baseProps = {
+		onChange: jest.fn(),
+		parentLayout: {
+			type: 'grid',
+		},
+		isShownByDefault: true,
+		panelId: 'client-id',
+	};
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	function renderControl( props ) {
+		return render(
+			<ToolsPanel
+				label="Dimensions"
+				resetAll={ jest.fn() }
+				panelId="client-id"
+			>
+				<ChildLayoutControl { ...baseProps } { ...props } />
+			</ToolsPanel>
+		);
+	}
+
+	it( 'shows default grid span values for unset span controls by default', () => {
+		renderControl( { value: {} } );
+
+		expect(
+			screen.getByRole( 'spinbutton', { name: 'Column span' } )
+		).toHaveValue( 1 );
+		expect(
+			screen.getByRole( 'spinbutton', { name: 'Row span' } )
+		).toHaveValue( 1 );
+	} );
+
+	it( 'shows empty grid span values when defaults are hidden', () => {
+		renderControl( { value: {}, showGridSpanDefaults: false } );
+
+		expect(
+			screen.getByRole( 'spinbutton', { name: 'Column span' } )
+		).toHaveValue( null );
+		expect(
+			screen.getByRole( 'spinbutton', { name: 'Row span' } )
+		).toHaveValue( null );
+	} );
+
+	it( 'shows explicitly set grid span values when defaults are hidden', () => {
+		renderControl( {
+			value: {
+				columnSpan: 1,
+				rowSpan: 2,
+			},
+			showGridSpanDefaults: false,
+		} );
+
+		expect(
+			screen.getByRole( 'spinbutton', { name: 'Column span' } )
+		).toHaveValue( 1 );
+		expect(
+			screen.getByRole( 'spinbutton', { name: 'Row span' } )
+		).toHaveValue( 2 );
+	} );
+
+	it( 'sets a numeric span when entering 1 into an empty span control', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		renderControl( {
+			value: {},
+			onChange,
+			showGridSpanDefaults: false,
+		} );
+
+		await user.type(
+			screen.getByRole( 'spinbutton', { name: 'Column span' } ),
+			'1'
+		);
+
+		expect( onChange ).toHaveBeenCalledWith( {
+			columnStart: undefined,
+			rowStart: undefined,
+			rowSpan: undefined,
+			columnSpan: 1,
+		} );
+	} );
+} );

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -33,6 +33,7 @@ import {
 	DEFAULT_BLOCK_STYLE_STATE,
 	hasPseudoBlockStyleState,
 	isDefaultBlockStyleState,
+	hasViewportBlockStyleState,
 } from '../../hooks/block-style-state';
 
 const AXIAL_SIDES = [ 'horizontal', 'vertical' ];
@@ -741,6 +742,9 @@ export default function DimensionsPanel( {
 					onChange={ setChildLayout }
 					parentLayout={ settings?.parentLayout }
 					panelId={ panelId }
+					showGridSpanDefaults={
+						! hasViewportBlockStyleState( styleState )
+					}
 					isShownByDefault={
 						defaultControls.childLayout ??
 						DEFAULT_CONTROLS.childLayout


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Follow-up from #78543.

When a column or row span is set on a grid child, and then a non-default viewport state is toggled, the span controls appear with their default value of "1", when in fact they have no viewport value set. If we want to set that value explicitly to 1, we're forced to change the value to something else and then back to 1 for it to apply.

This PR fixes the issue by removing those inaccurate defaults when viewport states are enabled.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Grid block to a post and some child blocks in it.
2. Set a column span of 3 on a child block.
3. Go to the states dropdown and enable a non-default viewport state:

<img width="552" height="191" alt="Screenshot 2026-05-27 at 3 12 55 pm" src="https://github.com/user-attachments/assets/636a425c-92f0-4d83-b2cc-40592d26e25d" />

4. Check that the span controls are empty and you can set them to 1 (or any other value).

