### PR TITLE
Block Library: commonize media placeholder wrappers across configurable media blocks

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -13,7 +13,7 @@ import {
 	useMemo,
 	useRef,
 } from '@wordpress/element';
-import { Placeholder, SandBox, Spinner } from '@wordpress/components';
+import { SandBox, Spinner } from '@wordpress/components';
 import { compose, useResizeObserver } from '@wordpress/compose';
 import {
 	withColors,
@@ -43,6 +43,7 @@ import {
 	getPositionClassName,
 	mediaPosition,
 } from '../shared';
+import BlockMediaPlaceholder from '../../utils/media-placeholder';
 import CoverInspectorControls from './inspector-controls';
 import CoverBlockControls from './block-controls';
 import CoverPlaceholder from './cover-placeholder';
@@ -663,7 +664,7 @@ function CoverEdit( {
 				{ resizeListener }
 
 				{ ! url && useFeaturedImage && (
-					<Placeholder
+					<BlockMediaPlaceholder
 						className="wp-block-cover__image--placeholder-image"
 						withIllustration
 					/>

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -8,7 +8,6 @@ import clsx from 'clsx';
  */
 import { isBlobURL, createBlobURL } from '@wordpress/blob';
 import { createBlock, getBlockBindingsSource } from '@wordpress/blocks';
-import { Placeholder } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	BlockIcon,
@@ -31,6 +30,7 @@ import { store as uploadStore } from '@wordpress/upload-media';
  * Internal dependencies
  */
 import { useUploadMediaFromBlobURL } from '../utils/hooks';
+import BlockMediaPlaceholder from '../utils/media-placeholder';
 import Image from './image';
 import { isValidFileType } from './utils';
 import { useMaxWidthObserver } from './use-max-width-observer';
@@ -424,8 +424,8 @@ export function ImageEdit( {
 	);
 	const placeholder = ( content ) => {
 		return (
-			<Placeholder
-				className={ clsx( 'block-editor-media-placeholder', {
+			<BlockMediaPlaceholder
+				className={ clsx( {
 					[ borderProps.className ]:
 						!! borderProps.className && ! isSingleSelected,
 				} ) }
@@ -460,7 +460,7 @@ export function ImageEdit( {
 
 				{ ! lockUrlControls && ! isSmallContainer && content }
 				{ placeholderResizeListener }
-			</Placeholder>
+			</BlockMediaPlaceholder>
 		);
 	};
 

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -11,7 +11,6 @@ import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	ToggleControl,
-	Placeholder,
 	Button,
 	Spinner,
 	TextControl,
@@ -47,6 +46,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import DimensionControls from './dimension-controls';
 import OverlayControls from './overlay-controls';
 import Overlay from './overlay';
+import BlockMediaPlaceholder from '../utils/media-placeholder';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import { unlock } from '../lock-unlock';
 
@@ -174,11 +174,8 @@ export default function PostFeaturedImageEdit( {
 
 	const placeholder = ( content ) => {
 		return (
-			<Placeholder
-				className={ clsx(
-					'block-editor-media-placeholder',
-					borderProps.className
-				) }
+			<BlockMediaPlaceholder
+				className={ clsx( borderProps.className ) }
 				withIllustration
 				style={ {
 					height: !! aspectRatio && '100%',
@@ -188,7 +185,7 @@ export default function PostFeaturedImageEdit( {
 				} }
 			>
 				{ content }
-			</Placeholder>
+			</BlockMediaPlaceholder>
 		);
 	};
 

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -2,7 +2,6 @@
 @use "@wordpress/base-styles/variables" as *;
 
 // Provide special styling for the placeholder.
-// @todo this particular minimal style of placeholder could be componentized further.
 .wp-block-post-featured-image {
 	.block-editor-media-placeholder {
 		z-index: 1; // Need to put it above the overlay so the upload button works.

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -19,7 +19,6 @@ import {
 	Spinner,
 	ToggleControl,
 	ToolbarButton,
-	Placeholder,
 	Button,
 	DropZone,
 	__experimentalToolsPanel as ToolsPanel,
@@ -47,6 +46,7 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { MIN_SIZE } from '../image/constants';
 import { MediaControl, MediaControlPreview } from '../utils/media-control';
+import BlockMediaPlaceholder from '../utils/media-placeholder';
 import { unlock } from '../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
@@ -618,13 +618,10 @@ export default function LogoEdit( {
 		);
 	}
 	const placeholder = ( content ) => {
-		const placeholderClassName = clsx(
-			'block-editor-media-placeholder',
-			className
-		);
+		const placeholderClassName = clsx( className );
 
 		return (
-			<Placeholder
+			<BlockMediaPlaceholder
 				className={ placeholderClassName }
 				preview={ logoImage }
 				withIllustration
@@ -633,7 +630,7 @@ export default function LogoEdit( {
 				} }
 			>
 				{ content }
-			</Placeholder>
+			</BlockMediaPlaceholder>
 		);
 	};
 
@@ -702,13 +699,16 @@ export default function LogoEdit( {
 			{ ( !! logoUrl || !! temporaryURL ) && logoImage }
 			{ ( isLoading ||
 				( ! temporaryURL && ! logoUrl && ! canUserEdit ) ) && (
-				<Placeholder className="site-logo_placeholder" withIllustration>
+				<BlockMediaPlaceholder
+					className="site-logo_placeholder"
+					withIllustration
+				>
 					{ isLoading && (
 						<span className="components-placeholder__preview">
 							<Spinner />
 						</span>
 					) }
-				</Placeholder>
+				</BlockMediaPlaceholder>
 			) }
 			{ ! isLoading && ! temporaryURL && ! logoUrl && canUserEdit && (
 				<MediaPlaceholder

--- a/packages/block-library/src/utils/media-placeholder.js
+++ b/packages/block-library/src/utils/media-placeholder.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { Placeholder } from '@wordpress/components';
+
+export default function BlockMediaPlaceholder( {
+	className,
+	children,
+	...props
+} ) {
+	return (
+		<Placeholder
+			className={ clsx( 'block-editor-media-placeholder', className ) }
+			{ ...props }
+		>
+			{ children }
+		</Placeholder>
+	);
+}

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -10,7 +10,6 @@ import { isBlobURL } from '@wordpress/blob';
 import {
 	Disabled,
 	Spinner,
-	Placeholder,
 	__experimentalToolsPanel as ToolsPanel,
 } from '@wordpress/components';
 import {
@@ -41,6 +40,7 @@ import VideoCommonSettings from './edit-common-settings';
 import TracksEditor from './tracks-editor';
 import Tracks from './tracks';
 import { Caption } from '../utils/caption';
+import BlockMediaPlaceholder from '../utils/media-placeholder';
 import PosterImage from '../utils/poster-image';
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
@@ -138,8 +138,7 @@ function VideoEdit( {
 	// Much of this description is duplicated from MediaPlaceholder.
 	const placeholder = ( content ) => {
 		return (
-			<Placeholder
-				className="block-editor-media-placeholder"
+			<BlockMediaPlaceholder
 				withIllustration={ ! isSingleSelected }
 				icon={ icon }
 				label={ __( 'Video' ) }
@@ -148,7 +147,7 @@ function VideoEdit( {
 				) }
 			>
 				{ content }
-			</Placeholder>
+			</BlockMediaPlaceholder>
 		);
 	};
 


### PR DESCRIPTION
## What?
Closes #56249

Introduces a shared media placeholder wrapper for block editor media placeholders and migrates duplicated placeholder wrapper implementations in common media-configurable blocks to use the shared component.

Blocks updated:
Cover
Image
Post Featured Image
Site Logo
Video

## Why?
Several blocks implemented very similar custom placeholder wrapper markup. This duplication makes maintenance harder and increases the chance of inconsistent behavior when placeholder structure evolves.

This change starts commonization by extracting the shared wrapper behavior while preserving each block’s existing block-specific labels, instructions, preview, and styles.

## Testing Instructions

1. Open the post or page editor.
2. Insert each of the following blocks one by one with no media selected:
  - Cover
  - Image
  - Post Featured Image
  - Site Logo
  - Video
3. Verify each block shows its expected placeholder UI and messaging.
4. For each block, upload/select media from the placeholder and verify normal replacement flow works.
5. Remove/reset media (where supported) and verify placeholder appears again as expected.
6. Check placeholder behavior in selected and unselected states (especially Image/Video).
7. For Site Logo and Post Featured Image, verify custom preview/placeholder states still render correctly when loading and when media is unavailable.
8. Confirm no regressions in drag/drop, media library button, and upload error behaviors.

## Screenshots or screencast
https://github.com/user-attachments/assets/43041042-e2c8-41b1-b4b1-26f42852a053


## Use of AI Tools
Used Claude AI to help draft/refine code changes and PR text.