### PR TITLE
Image Editor: focus return after closing image crop modal

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -383,10 +383,14 @@ export default function Image( {
 	);
 	const { getBlock, getSettings } = useSelect( blockEditorStore );
 	const cropButtonRef = useRef();
+	const handleMediaEditorModalClose = useCallback(
+		() => cropButtonRef.current?.focus(),
+		[]
+	);
 	const openImageMediaEditorModal = useOpenImageMediaEditorModal( {
 		attributes,
 		setAttributes,
-		onClose: () => cropButtonRef.current?.focus(),
+		onClose: handleMediaEditorModalClose,
 	} );
 
 	const {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -45,6 +45,7 @@ import {
 	useCallback,
 	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from '@wordpress/element';
 import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
@@ -381,9 +382,11 @@ export default function Image( {
 		[ clientId ]
 	);
 	const { getBlock, getSettings } = useSelect( blockEditorStore );
+	const cropButtonRef = useRef();
 	const openImageMediaEditorModal = useOpenImageMediaEditorModal( {
 		attributes,
 		setAttributes,
+		onClose: () => cropButtonRef.current?.focus(),
 	} );
 
 	const {
@@ -868,6 +871,7 @@ export default function Image( {
 					) }
 					{ allowCrop && (
 						<ToolbarButton
+							ref={ cropButtonRef }
 							onClick={
 								openImageMediaEditorModal
 									? openImageMediaEditorModal

--- a/packages/block-library/src/image/test/use-open-image-media-editor-modal.js
+++ b/packages/block-library/src/image/test/use-open-image-media-editor-modal.js
@@ -111,6 +111,45 @@ describe( 'useOpenImageMediaEditorModal', () => {
 		jest.clearAllMocks();
 	} );
 
+	it( 'passes an onClose handler for returning focus when the media editor closes', async () => {
+		const cropButton = document.createElement( 'button' );
+		const otherButton = document.createElement( 'button' );
+		document.body.append( cropButton, otherButton );
+		const registry = createRegistry();
+		useRegistry.mockReturnValue( registry );
+		const setAttributes = jest.fn();
+		const openMediaEditorModal = jest.fn();
+		mockMediaEditorModalSetting( openMediaEditorModal );
+		const onClose = () => cropButton.focus();
+		const { result } = renderHook( () =>
+			useOpenImageMediaEditorModal( {
+				attributes: {
+					id: 1,
+					url: 'original.jpg',
+					alt: '',
+					caption: '',
+				},
+				setAttributes,
+				onClose,
+			} )
+		);
+
+		try {
+			await act( async () => {
+				await result.current();
+			} );
+			otherButton.focus();
+			expect( otherButton ).toHaveFocus();
+
+			openMediaEditorModal.mock.calls[ 0 ][ 0 ].onClose();
+
+			expect( cropButton ).toHaveFocus();
+		} finally {
+			cropButton.remove();
+			otherButton.remove();
+		}
+	} );
+
 	it( 'resolves fresh attachment metadata when the same attachment id has a stale cache', async () => {
 		const originalAttachment = {
 			id: 1,
@@ -187,6 +226,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 		expect( openMediaEditorModal ).toHaveBeenCalledWith( {
 			id: 1,
 			onUpdate: expect.any( Function ),
+			onClose: undefined,
 		} );
 		expect( setAttributes ).toHaveBeenCalledWith( {
 			alt: 'Updated alt',
@@ -229,6 +269,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 		expect( openMediaEditorModal ).toHaveBeenCalledWith( {
 			id: 1,
 			onUpdate: expect.any( Function ),
+			onClose: undefined,
 		} );
 		expect( setAttributes ).toHaveBeenCalledWith( {
 			caption: 'Updated attachment caption',

--- a/packages/block-library/src/image/use-open-image-media-editor-modal.js
+++ b/packages/block-library/src/image/use-open-image-media-editor-modal.js
@@ -136,7 +136,11 @@ function hasKnownAttachmentMetadata( attachment ) {
 	return hasKnownAlt && hasKnownCaption;
 }
 
-export function useOpenImageMediaEditorModal( { attributes, setAttributes } ) {
+export function useOpenImageMediaEditorModal( {
+	attributes,
+	setAttributes,
+	onClose,
+} ) {
 	// Keep this hook private to the Image block and pass the block attributes
 	// object so the callsite stays compact. Destructure only the attributes
 	// currently used for metadata sync; add more here if the sync policy grows.
@@ -342,11 +346,13 @@ export function useOpenImageMediaEditorModal( { attributes, setAttributes } ) {
 		openMediaEditorModal( {
 			id,
 			onUpdate: handleMediaUpdate,
+			onClose,
 		} );
 	}, [
 		getCachedAttachmentRecord,
 		handleMediaUpdate,
 		id,
+		onClose,
 		openMediaEditorModal,
 		resolveAttachmentRecord,
 	] );

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -10,6 +10,7 @@ import { isBlobURL } from '@wordpress/blob';
 import {
 	createInterpolateElement,
 	useEffect,
+	useRef,
 	useState,
 } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
@@ -73,6 +74,7 @@ const SiteLogo = ( {
 	const isResizable = ! isWideAligned && isLargeViewport;
 	const [ { naturalWidth, naturalHeight }, setNaturalSize ] = useState( {} );
 	const [ isEditingImage, setIsEditingImage ] = useState( false );
+	const cropButtonRef = useRef();
 	const { toggleSelection } = useDispatch( blockEditorStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
@@ -401,12 +403,15 @@ const SiteLogo = ( {
 				shouldShowCropAndDimensions && (
 					<BlockControls group="block">
 						<ToolbarButton
+							ref={ cropButtonRef }
 							onClick={
 								openMediaEditorModal && logoId
 									? () =>
 											openMediaEditorModal( {
 												id: logoId,
 												onUpdate: handleMediaUpdate,
+												onClose: () =>
+													cropButtonRef.current?.focus(),
 											} )
 									: () => setIsEditingImage( true )
 							}

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -351,8 +351,8 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			[ mediaEditKey ]: hasUploadPermissions
 				? editMediaEntity
 				: undefined,
-			[ openMediaEditorModalKey ]: ( { id, onUpdate } ) =>
-				openMediaEditorModal( { id, onUpdate } ),
+			[ openMediaEditorModalKey ]: ( { id, onUpdate, onClose } ) =>
+				openMediaEditorModal( { id, onUpdate, onClose } ),
 			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,
 			[ mediaUploadOnSuccessKey ]: hasUploadPermissions
 				? mediaUploadOnSuccess

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -68,7 +68,7 @@ export function MediaEditorModal( {
 		event.stopPropagation();
 	};
 
-	const closeAndRestoreFocus = () => {
+	const handleClose = () => {
 		closeMediaEditorModal();
 		onClose?.();
 	};
@@ -82,7 +82,7 @@ export function MediaEditorModal( {
 			shouldCloseOnEsc
 			noticesClassName="media-editor-modal__snackbar"
 			noticesPortalElement={ portalElement }
-			onClose={ closeAndRestoreFocus }
+			onClose={ handleClose }
 			onSaved={ ( { id: savedId, url, previous } ) => {
 				if ( savedId && onUpdate ) {
 					const update: MediaEditorModalUpdate = {
@@ -91,7 +91,7 @@ export function MediaEditorModal( {
 					};
 					onUpdate( update );
 				}
-				closeAndRestoreFocus();
+				handleClose();
 				if ( previous && savedId !== previous.id && onUpdate ) {
 					// Intentionally unscoped: the modal is closing, so the
 					// snackbar surfaces in the host editor (not the media

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -37,12 +37,14 @@ export function MediaEditorModal( {
 	fields = [],
 	aspectRatioPresets,
 }: MediaEditorModalProps ) {
-	const { isModalOpen, id, onUpdate } = useSelect( ( select ) => {
-		const { isOpen, getId, getOnUpdate } = select( mediaEditorStore );
+	const { isModalOpen, id, onUpdate, onClose } = useSelect( ( select ) => {
+		const { isOpen, getId, getOnUpdate, getOnClose } =
+			select( mediaEditorStore );
 		return {
 			isModalOpen: isOpen(),
 			id: getId(),
 			onUpdate: getOnUpdate(),
+			onClose: getOnClose(),
 		};
 	}, [] );
 
@@ -66,6 +68,11 @@ export function MediaEditorModal( {
 		event.stopPropagation();
 	};
 
+	const closeAndRestoreFocus = () => {
+		closeMediaEditorModal();
+		onClose?.();
+	};
+
 	return (
 		<MediaEditor
 			id={ id }
@@ -75,7 +82,7 @@ export function MediaEditorModal( {
 			shouldCloseOnEsc
 			noticesClassName="media-editor-modal__snackbar"
 			noticesPortalElement={ portalElement }
-			onClose={ closeMediaEditorModal }
+			onClose={ closeAndRestoreFocus }
 			onSaved={ ( { id: savedId, url, previous } ) => {
 				if ( savedId && onUpdate ) {
 					const update: MediaEditorModalUpdate = {
@@ -84,7 +91,7 @@ export function MediaEditorModal( {
 					};
 					onUpdate( update );
 				}
-				closeMediaEditorModal();
+				closeAndRestoreFocus();
 				if ( previous && savedId !== previous.id && onUpdate ) {
 					// Intentionally unscoped: the modal is closing, so the
 					// snackbar surfaces in the host editor (not the media

--- a/packages/media-editor/src/components/media-editor-modal/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/test/index.tsx
@@ -24,6 +24,7 @@ let mockSaveResult = {
 	},
 };
 const mockOnUpdate = jest.fn();
+const mockOnClose = jest.fn();
 const mockCloseMediaEditorModal = jest.fn();
 const mockCreateSuccessNotice = jest.fn();
 
@@ -81,6 +82,7 @@ describe( 'MediaEditorModal', () => {
 				isOpen: () => true,
 				getId: () => 10,
 				getOnUpdate: () => mockOnUpdate,
+				getOnClose: () => mockOnClose,
 			} ) )
 		);
 		( useDispatch as jest.Mock ).mockImplementation( ( store ) =>
@@ -102,6 +104,7 @@ describe( 'MediaEditorModal', () => {
 			url: 'edited.jpg',
 		} );
 		expect( mockCloseMediaEditorModal ).toHaveBeenCalled();
+		expect( mockOnClose ).toHaveBeenCalled();
 		expect( mockCreateSuccessNotice ).toHaveBeenCalledWith(
 			'Image edited.',
 			expect.objectContaining( {

--- a/packages/media-editor/src/store/actions.ts
+++ b/packages/media-editor/src/store/actions.ts
@@ -15,16 +15,19 @@ export interface MediaEditorModalUpdate {
 interface OpenMediaEditorModalArgs {
 	id: number;
 	onUpdate?: ( updated: MediaEditorModalUpdate ) => void;
+	onClose?: () => void;
 }
 
 export function openMediaEditorModal( {
 	id,
 	onUpdate,
+	onClose,
 }: OpenMediaEditorModalArgs ) {
 	return {
 		type: 'OPEN_MEDIA_EDITOR_MODAL' as const,
 		id,
 		onUpdate: onUpdate ?? null,
+		onClose: onClose ?? null,
 	};
 }
 

--- a/packages/media-editor/src/store/reducer.ts
+++ b/packages/media-editor/src/store/reducer.ts
@@ -4,17 +4,20 @@
 import type { MediaEditorModalUpdate } from './actions';
 
 type OnUpdateCallback = ( updated: MediaEditorModalUpdate ) => void;
+type OnCloseCallback = () => void;
 
 export interface State {
 	isOpen: boolean;
 	id: number | null;
 	onUpdate: OnUpdateCallback | null;
+	onClose: OnCloseCallback | null;
 }
 
 export const DEFAULT_STATE: State = {
 	isOpen: false,
 	id: null,
 	onUpdate: null,
+	onClose: null,
 };
 
 type Action =
@@ -22,6 +25,7 @@ type Action =
 			type: 'OPEN_MEDIA_EDITOR_MODAL';
 			id: number;
 			onUpdate: OnUpdateCallback | null;
+			onClose: OnCloseCallback | null;
 	  }
 	| { type: 'CLOSE_MEDIA_EDITOR_MODAL' };
 
@@ -31,7 +35,7 @@ export default function reducer(
 ): State {
 	switch ( action.type ) {
 		case 'OPEN_MEDIA_EDITOR_MODAL': {
-			const { id, onUpdate } = action as Extract<
+			const { id, onUpdate, onClose } = action as Extract<
 				Action,
 				{ type: 'OPEN_MEDIA_EDITOR_MODAL' }
 			>;
@@ -39,6 +43,7 @@ export default function reducer(
 				isOpen: true,
 				id,
 				onUpdate,
+				onClose,
 			};
 		}
 		case 'CLOSE_MEDIA_EDITOR_MODAL':

--- a/packages/media-editor/src/store/selectors.ts
+++ b/packages/media-editor/src/store/selectors.ts
@@ -14,3 +14,7 @@ export function getId( state: State ): number | null {
 export function getOnUpdate( state: State ) {
 	return state.onUpdate;
 }
+
+export function getOnClose( state: State ) {
+	return state.onClose;
+}

--- a/packages/media-editor/src/store/test/reducer.ts
+++ b/packages/media-editor/src/store/test/reducer.ts
@@ -11,35 +11,43 @@ describe( 'core/media-editor reducer', () => {
 
 	it( 'opens the modal with id and onUpdate', () => {
 		const onUpdate = jest.fn();
+		const onClose = jest.fn();
 		const state = reducer( undefined, {
 			type: 'OPEN_MEDIA_EDITOR_MODAL',
 			id: 42,
 			onUpdate,
+			onClose,
 		} );
 		expect( state ).toEqual( {
 			isOpen: true,
 			id: 42,
 			onUpdate,
+			onClose,
 		} );
 	} );
 
 	it( 'replaces state on a subsequent open (new onUpdate)', () => {
 		const firstOnUpdate = jest.fn();
+		const firstOnClose = jest.fn();
 		const secondOnUpdate = jest.fn();
+		const secondOnClose = jest.fn();
 		const first = reducer( undefined, {
 			type: 'OPEN_MEDIA_EDITOR_MODAL',
 			id: 42,
 			onUpdate: firstOnUpdate,
+			onClose: firstOnClose,
 		} );
 		const second = reducer( first, {
 			type: 'OPEN_MEDIA_EDITOR_MODAL',
 			id: 99,
 			onUpdate: secondOnUpdate,
+			onClose: secondOnClose,
 		} );
 		expect( second ).toEqual( {
 			isOpen: true,
 			id: 99,
 			onUpdate: secondOnUpdate,
+			onClose: secondOnClose,
 		} );
 	} );
 
@@ -48,6 +56,7 @@ describe( 'core/media-editor reducer', () => {
 			type: 'OPEN_MEDIA_EDITOR_MODAL',
 			id: 42,
 			onUpdate: jest.fn(),
+			onClose: jest.fn(),
 		} );
 		const closed = reducer( opened, {
 			type: 'CLOSE_MEDIA_EDITOR_MODAL',


### PR DESCRIPTION
## What?

Restores focus to the Crop toolbar button after closing the media editor modal launched from:

- the Image block (including from within a Gallery)
- the Site Logo block

## Why?

When the cropper is opened from the block toolbar via keyboard, closing the modal currently leaves focus lost instead of returning it to the control that opened the dialog.

The expected modal behavior is to return focus to the launcher when it still exists.

## How?

- Adds an optional `onClose` callback to the media editor modal open payload.
- Calls that callback when the media editor modal closes, including after save.
- Passes a simple focus-return callback from Image and Site Logo:
  `() => cropButtonRef.current?.focus()`

## Testing Instructions

1. Add an Image block with an image.
2. Select the Image block.
3. Use keyboard navigation to focus the Crop button in the block toolbar.
4. Press Enter or Space to open the media editor modal.
5. Close the modal with Cancel, Escape, or Save.
6. Confirm focus returns to the Image block Crop toolbar button.
7. Repeat with a Site Logo and Gallery blocks


https://github.com/user-attachments/assets/89e3613f-066e-4cd0-838e-f2d45cd5d621

