### PR TITLE
Hide Block Dialog: Add ability to hide elements from logged in or logged out users

### DIFF
--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -26,6 +26,21 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 	}
 
 	if ( is_array( $block_visibility ) && ! empty( $block_visibility ) ) {
+		// Check user authentication visibility.
+		$user_auth_config = $block_visibility['userAuthentication'] ?? null;
+
+		if ( is_array( $user_auth_config ) && ! empty( $user_auth_config ) ) {
+			$is_logged_in = is_user_logged_in();
+
+			if ( ! empty( $user_auth_config['loggedOut'] ) && ! $is_logged_in ) {
+				return '';
+			}
+
+			if ( ! empty( $user_auth_config['loggedIn'] ) && $is_logged_in ) {
+				return '';
+			}
+		}
+
 		// Get viewport configuration from nested structure.
 		$viewport_config = $block_visibility['viewport'] ?? null;
 

--- a/packages/block-editor/src/components/block-visibility/modal.js
+++ b/packages/block-editor/src/components/block-visibility/modal.js
@@ -37,6 +37,7 @@ import { cleanEmptyObject } from '../../hooks/utils';
 import {
 	getViewportCheckboxState,
 	getHideEverywhereCheckboxState,
+	getUserAuthCheckboxState,
 } from './utils';
 
 const DEFAULT_VIEWPORT_CHECKBOX_VALUES = {
@@ -80,6 +81,8 @@ export default function BlockVisibilityModal( { clientIds, onClose } ) {
 			return {
 				hideEverywhere: false,
 				viewportChecked: {},
+				hideFromLoggedOut: false,
+				hideFromLoggedIn: false,
 			};
 		}
 
@@ -92,6 +95,8 @@ export default function BlockVisibilityModal( { clientIds, onClose } ) {
 		return {
 			hideEverywhere: getHideEverywhereCheckboxState( blocks ),
 			viewportChecked: viewportValues,
+			hideFromLoggedOut: getUserAuthCheckboxState( blocks, 'loggedOut' ),
+			hideFromLoggedIn: getUserAuthCheckboxState( blocks, 'loggedIn' ),
 		};
 	}, [ blocks ] );
 
@@ -100,6 +105,12 @@ export default function BlockVisibilityModal( { clientIds, onClose } ) {
 	);
 	const [ hideEverywhere, setHideEverywhere ] = useState(
 		initialViewportValues?.hideEverywhere ?? false
+	);
+	const [ hideFromLoggedOut, setHideFromLoggedOut ] = useState(
+		initialViewportValues?.hideFromLoggedOut ?? false
+	);
+	const [ hideFromLoggedIn, setHideFromLoggedIn ] = useState(
+		initialViewportValues?.hideFromLoggedIn ?? false
 	);
 
 	const handleViewportCheckboxChange = useCallback(
@@ -149,41 +160,77 @@ export default function BlockVisibilityModal( { clientIds, onClose } ) {
 		if ( hideEverywhere !== initialViewportValues.hideEverywhere ) {
 			return true;
 		}
+		if (
+			hideFromLoggedOut !== initialViewportValues.hideFromLoggedOut ||
+			hideFromLoggedIn !== initialViewportValues.hideFromLoggedIn
+		) {
+			return true;
+		}
 		return BLOCK_VISIBILITY_VIEWPORT_ENTRIES.some(
 			( [ , { key } ] ) =>
 				viewportChecked[ key ] !==
 				initialViewportValues.viewportChecked[ key ]
 		);
-	}, [ hideEverywhere, viewportChecked, initialViewportValues ] );
+	}, [
+		hideEverywhere,
+		hideFromLoggedOut,
+		hideFromLoggedIn,
+		viewportChecked,
+		initialViewportValues,
+	] );
 
 	const hasIndeterminateValues = useMemo( () => {
 		if ( hideEverywhere === null ) {
 			return true;
 		}
+		if ( hideFromLoggedOut === null || hideFromLoggedIn === null ) {
+			return true;
+		}
 		return Object.values( viewportChecked ).some(
 			( checked ) => checked === null
 		);
-	}, [ hideEverywhere, viewportChecked ] );
+	}, [
+		hideEverywhere,
+		hideFromLoggedOut,
+		hideFromLoggedIn,
+		viewportChecked,
+	] );
 
 	const handleSubmit = useCallback(
 		( event ) => {
 			event.preventDefault();
-			const newVisibility = hideEverywhere
-				? false
-				: {
-						viewport: BLOCK_VISIBILITY_VIEWPORT_ENTRIES.reduce(
-							( acc, [ , { key } ] ) => {
-								if ( viewportChecked[ key ] ) {
-									// Values are inverted to hide the block on the selected viewport.
-									// In the UI, the checkbox is checked (true) when the block is hidden on the selected viewport,
-									// so 'false' means hide the block on the selected viewport.
-									acc[ key ] = false;
-								}
-								return acc;
-							},
-							{}
-						),
-				  };
+			let newVisibility;
+			if ( hideEverywhere ) {
+				newVisibility = false;
+			} else {
+				const viewport = BLOCK_VISIBILITY_VIEWPORT_ENTRIES.reduce(
+					( acc, [ , { key } ] ) => {
+						if ( viewportChecked[ key ] ) {
+							// Values are inverted to hide the block on the selected viewport.
+							// In the UI, the checkbox is checked (true) when the block is hidden on the selected viewport,
+							// so 'false' means hide the block on the selected viewport.
+							acc[ key ] = false;
+						}
+						return acc;
+					},
+					{}
+				);
+				const userAuthentication = {};
+				if ( hideFromLoggedOut ) {
+					userAuthentication.loggedOut = true;
+				}
+				if ( hideFromLoggedIn ) {
+					userAuthentication.loggedIn = true;
+				}
+				newVisibility = {
+					...( Object.keys( viewport ).length > 0 && {
+						viewport,
+					} ),
+					...( Object.keys( userAuthentication ).length > 0 && {
+						userAuthentication,
+					} ),
+				};
+			}
 			const attributesByClientId = Object.fromEntries(
 				blocks.map( ( { clientId, attributes } ) => [
 					clientId,
@@ -212,6 +259,8 @@ export default function BlockVisibilityModal( { clientIds, onClose } ) {
 			clientIds,
 			createSuccessNotice,
 			hideEverywhere,
+			hideFromLoggedOut,
+			hideFromLoggedIn,
 			noticeMessage,
 			onClose,
 			updateBlockAttributes,
@@ -302,6 +351,30 @@ export default function BlockVisibilityModal( { clientIds, onClose } ) {
 								</ul>
 							) }
 						</li>
+						{ hideEverywhere !== true && (
+							<li className="block-editor-block-visibility-modal__options-item">
+								<CheckboxControl
+									label={ __( 'Hide from logged out users' ) }
+									checked={ hideFromLoggedOut === true }
+									indeterminate={ hideFromLoggedOut === null }
+									onChange={ ( checked ) =>
+										setHideFromLoggedOut( checked )
+									}
+								/>
+							</li>
+						) }
+						{ hideEverywhere !== true && (
+							<li className="block-editor-block-visibility-modal__options-item">
+								<CheckboxControl
+									label={ __( 'Hide from logged in users' ) }
+									checked={ hideFromLoggedIn === true }
+									indeterminate={ hideFromLoggedIn === null }
+									onChange={ ( checked ) =>
+										setHideFromLoggedIn( checked )
+									}
+								/>
+							</li>
+						) }
 					</ul>
 					{ hasMultipleBlocks && hasIndeterminateValues && (
 						<p className="block-editor-block-visibility-modal__description">

--- a/packages/block-editor/src/components/block-visibility/utils.js
+++ b/packages/block-editor/src/components/block-visibility/utils.js
@@ -108,6 +108,37 @@ export function getHideEverywhereCheckboxState( blocks ) {
 }
 
 /**
+ * Gets the checkbox state for a user authentication visibility setting across multiple blocks.
+ * Returns `true` if all blocks are hidden, `null` if some are hidden, `false` if none are hidden.
+ *
+ * @param {Array}  blocks Array of blocks to check.
+ * @param {string} key    The user authentication key to check ('loggedOut' or 'loggedIn').
+ * @return {boolean|null} `true` if all hidden, `null` if some hidden, `false` if none hidden.
+ */
+export function getUserAuthCheckboxState( blocks, key ) {
+	if ( ! blocks?.length ) {
+		return false;
+	}
+
+	const hiddenCount = blocks.filter( ( block ) => {
+		const blockVisibility = block?.attributes?.metadata?.blockVisibility;
+		if ( ! blockVisibility || typeof blockVisibility !== 'object' ) {
+			return false;
+		}
+		return blockVisibility.userAuthentication?.[ key ] === true;
+	} ).length;
+
+	if ( hiddenCount === 0 ) {
+		return false;
+	}
+	if ( hiddenCount === blocks.length ) {
+		return true;
+	}
+
+	return null;
+}
+
+/**
  * Get a human-readable label describing which viewports a block is hidden on.
  *
  * @param {boolean|Object} blockVisibility The block's visibility metadata.
@@ -124,6 +155,8 @@ export function getBlockVisibilityLabel( blockVisibility ) {
 		return __( 'Block is hidden' );
 	}
 
+	const labels = [];
+
 	if ( blockVisibility?.viewport ) {
 		// Hidden on specific viewports - list them
 		const hiddenViewports = BLOCK_VISIBILITY_VIEWPORT_ENTRIES.filter(
@@ -131,12 +164,27 @@ export function getBlockVisibilityLabel( blockVisibility ) {
 		).map( ( [ , viewport ] ) => viewport.label );
 
 		if ( hiddenViewports.length > 0 ) {
-			return sprintf(
-				/* translators: %s: comma-separated list of viewport names (Desktop, Tablet, Mobile) */
-				__( 'Block is hidden on %s' ),
-				hiddenViewports.join( ', ' )
+			labels.push(
+				sprintf(
+					/* translators: %s: comma-separated list of viewport names (Desktop, Tablet, Mobile) */
+					__( 'Hidden on %s' ),
+					hiddenViewports.join( ', ' )
+				)
 			);
 		}
+	}
+
+	if ( blockVisibility?.userAuthentication ) {
+		if ( blockVisibility.userAuthentication.loggedOut ) {
+			labels.push( __( 'Hidden from logged out users' ) );
+		}
+		if ( blockVisibility.userAuthentication.loggedIn ) {
+			labels.push( __( 'Hidden from logged in users' ) );
+		}
+	}
+
+	if ( labels.length > 0 ) {
+		return labels.join( '; ' );
 	}
 
 	return null;


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/78518

## Why?
Add ability to hide elements from logged in or logged out users.

## How?
Add option to hide elements from logged in or logged out users.

## Testing Instructions

- Open a page.
- Add a block.
- Click on the 3 dots in the block toolbar.
- Click on Hide button.
- Here we can see 2 checkboxes, Hide from logged out users and Hide from logged in users

## Screenshots or screencast <!-- if applicable -->
<img width="425" height="461" alt="Screenshot at May 27 11-52-06" src="https://github.com/user-attachments/assets/96597d2e-405f-4f16-887c-010aa7714aa1" />

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Used for: Base code generation and testing.
