### PR TITLE
Add a grid variation to the Columns block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -157,7 +157,7 @@ Display content in multiple columns, with blocks added to each column. ([Source]
 -	**Name:** core/columns
 -	**Category:** design
 -	**Allowed Blocks:** core/column
--	**Supports:** align (full, wide), anchor, color (background, button, gradients, heading, link, text), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, color (background, button, gradients, heading, link, text), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowJustification~~, ~~allowOrientation~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~, ~~allowWrap~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** isStackedOnMobile, templateLock, verticalAlignment
 
 ## Comment Author Avatar (deprecated)

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -75,21 +75,27 @@ function ColumnEdit( {
 	const classes = clsx( 'block-core-columns', {
 		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 	} );
-	const { columnsIds, hasChildBlocks, rootClientId } = useSelect(
-		( select ) => {
-			const { getBlockOrder, getBlockRootClientId } =
-				select( blockEditorStore );
+	const { columnsIds, hasChildBlocks, isParentGridLayout, rootClientId } =
+		useSelect(
+			( select ) => {
+				const {
+					getBlockAttributes,
+					getBlockOrder,
+					getBlockRootClientId,
+				} = select( blockEditorStore );
 
-			const rootId = getBlockRootClientId( clientId );
+				const rootId = getBlockRootClientId( clientId );
+				const rootAttributes = getBlockAttributes( rootId );
 
-			return {
-				hasChildBlocks: getBlockOrder( clientId ).length > 0,
-				rootClientId: rootId,
-				columnsIds: getBlockOrder( rootId ),
-			};
-		},
-		[ clientId ]
-	);
+				return {
+					hasChildBlocks: getBlockOrder( clientId ).length > 0,
+					rootClientId: rootId,
+					columnsIds: getBlockOrder( rootId ),
+					isParentGridLayout: rootAttributes?.layout?.type === 'grid',
+				};
+			},
+			[ clientId ]
+		);
 
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
@@ -105,7 +111,10 @@ function ColumnEdit( {
 	const widthWithUnit = Number.isFinite( width ) ? width + '%' : width;
 	const blockProps = useBlockProps( {
 		className: classes,
-		style: widthWithUnit ? { flexBasis: widthWithUnit } : undefined,
+		style:
+			widthWithUnit && ! isParentGridLayout
+				? { flexBasis: widthWithUnit }
+				: undefined,
 	} );
 
 	const columnsCount = columnsIds.length;
@@ -139,12 +148,14 @@ function ColumnEdit( {
 					controls={ [ 'top', 'center', 'bottom', 'stretch' ] }
 				/>
 			</BlockControls>
-			<InspectorControls>
-				<ColumnInspectorControls
-					width={ width }
-					setAttributes={ setAttributes }
-				/>
-			</InspectorControls>
+			{ ! isParentGridLayout && (
+				<InspectorControls>
+					<ColumnInspectorControls
+						width={ width }
+						setAttributes={ setAttributes }
+					/>
+				</InspectorControls>
+			) }
 			<div { ...innerBlocksProps } />
 		</>
 	);

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -49,7 +49,10 @@
 		"layout": {
 			"allowSwitching": false,
 			"allowInheriting": false,
-			"allowEditing": false,
+			"allowOrientation": false,
+			"allowJustification": false,
+			"allowVerticalAlignment": false,
+			"allowWrap": false,
 			"default": {
 				"type": "flex",
 				"flexWrap": "nowrap"

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -31,6 +31,7 @@ import {
 	createBlocksFromInnerBlocksTemplate,
 	store as blocksStore,
 } from '@wordpress/blocks';
+import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -205,26 +206,71 @@ function ColumnInspectorControls( {
 }
 
 function ColumnsEditContainer( { attributes, setAttributes, clientId } ) {
-	const { isStackedOnMobile, verticalAlignment, templateLock } = attributes;
+	const { isStackedOnMobile, layout, verticalAlignment, templateLock } =
+		attributes;
+	const layoutType = layout?.type ?? 'flex';
+	const isGridLayout = layoutType === 'grid';
+	const previousLayoutTypeRef = useRef( layoutType );
 	const registry = useRegistry();
 	const { getBlockOrder } = useSelect( blockEditorStore );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const columnCount = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockOrder( clientId ).length,
+		[ clientId ]
+	);
+
+	// Seed the grid with the current number of Column children only when
+	// switching from the default flex layout.
+	useEffect( () => {
+		const didSwitchToGrid =
+			previousLayoutTypeRef.current !== 'grid' && isGridLayout;
+		previousLayoutTypeRef.current = layoutType;
+
+		if (
+			! didSwitchToGrid ||
+			layout?.columnCount !== undefined ||
+			columnCount < 1
+		) {
+			return;
+		}
+
+		setAttributes( {
+			layout: {
+				...layout,
+				columnCount,
+			},
+		} );
+	}, [ columnCount, isGridLayout, layout, layoutType, setAttributes ] );
 
 	const classes = clsx( {
 		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
-		[ `is-not-stacked-on-mobile` ]: ! isStackedOnMobile,
+		[ `is-not-stacked-on-mobile` ]: ! isStackedOnMobile && ! isGridLayout,
 	} );
 
 	const blockProps = useBlockProps( {
 		className: classes,
 	} );
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+	const innerBlocksOptions = {
 		defaultBlock: DEFAULT_BLOCK,
 		directInsert: true,
-		orientation: 'horizontal',
-		renderAppender: false,
+		renderAppender: isGridLayout ? undefined : false,
 		templateLock,
-	} );
+		...( isGridLayout
+			? {
+					layout: {
+						...layout,
+						allowSizingOnChildren: true,
+					},
+			  }
+			: {
+					orientation: 'horizontal',
+			  } ),
+	};
+	const innerBlocksProps = useInnerBlocksProps(
+		blockProps,
+		innerBlocksOptions
+	);
 
 	/**
 	 * Update all child Column blocks with a new vertical alignment setting
@@ -254,13 +300,15 @@ function ColumnsEditContainer( { attributes, setAttributes, clientId } ) {
 					value={ verticalAlignment }
 				/>
 			</BlockControls>
-			<InspectorControls>
-				<ColumnInspectorControls
-					clientId={ clientId }
-					setAttributes={ setAttributes }
-					isStackedOnMobile={ isStackedOnMobile }
-				/>
-			</InspectorControls>
+			{ ! isGridLayout && (
+				<InspectorControls>
+					<ColumnInspectorControls
+						clientId={ clientId }
+						setAttributes={ setAttributes }
+						isStackedOnMobile={ isStackedOnMobile }
+					/>
+				</InspectorControls>
+			) }
 			<div { ...innerBlocksProps } />
 		</>
 	);

--- a/packages/block-library/src/columns/save.js
+++ b/packages/block-library/src/columns/save.js
@@ -9,11 +9,12 @@ import clsx from 'clsx';
 import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { isStackedOnMobile, verticalAlignment } = attributes;
+	const { isStackedOnMobile, layout, verticalAlignment } = attributes;
+	const isGridLayout = layout?.type === 'grid';
 
 	const className = clsx( {
 		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
-		[ `is-not-stacked-on-mobile` ]: ! isStackedOnMobile,
+		[ `is-not-stacked-on-mobile` ]: ! isStackedOnMobile && ! isGridLayout,
 	} );
 
 	const blockProps = useBlockProps.save( { className } );

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -3,15 +3,19 @@
 @use "@wordpress/base-styles/variables" as *;
 
 .wp-block-columns {
-	display: flex;
 	box-sizing: border-box;
 
-	// Responsiveness: Allow wrapping on mobile.
-	flex-wrap: wrap !important;
+	&:not(.is-layout-grid) {
+		display: flex;
 
-	@include break-medium() {
-		flex-wrap: nowrap !important;
+		// Responsiveness: Allow wrapping on mobile.
+		flex-wrap: wrap !important;
+
+		@include break-medium() {
+			flex-wrap: nowrap !important;
+		}
 	}
+
 
 	// Ensure full vertical column stretch when alignment is not set.
 	// This overrides the Layout block support's default align-items setting of `center`.
@@ -32,7 +36,7 @@
 		align-items: flex-end;
 	}
 
-	&:not(.is-not-stacked-on-mobile) > .wp-block-column {
+	&:not(.is-layout-grid):not(.is-not-stacked-on-mobile) > .wp-block-column {
 		@media (max-width: #{ ($break-medium - 1) }) {
 			// Responsiveness: Show at most one columns on mobile. This must be
 			// important since the Column assigns its own width as an inline style.
@@ -59,7 +63,7 @@
 		}
 	}
 
-	&.is-not-stacked-on-mobile {
+	&.is-not-stacked-on-mobile:not(.is-layout-grid) {
 		flex-wrap: nowrap !important;
 
 		> .wp-block-column {
@@ -86,7 +90,6 @@
 	// Matches paragraph block padding.
 	padding: $block-bg-padding--v $block-bg-padding--h;
 }
-
 
 .wp-block-column {
 	flex-grow: 1;

--- a/packages/block-library/src/columns/test/variations.js
+++ b/packages/block-library/src/columns/test/variations.js
@@ -1,0 +1,112 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createBlock,
+	registerBlockType,
+	serialize,
+	store as blocksStore,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+import { select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import {
+	metadata as columnsMetadata,
+	name as columnsName,
+	settings as columnsSettings,
+} from '../index';
+import {
+	metadata as columnMetadata,
+	name as columnName,
+	settings as columnSettings,
+} from '../../column';
+
+describe( 'Columns variations', () => {
+	beforeAll( () => {
+		registerBlockType( columnsMetadata, columnsSettings );
+		registerBlockType( columnMetadata, columnSettings );
+	} );
+
+	afterAll( () => {
+		unregisterBlockType( columnsName );
+		unregisterBlockType( columnName );
+	} );
+
+	it( 'provides transform variations for columns and grid layouts', () => {
+		const variations = select( blocksStore ).getBlockVariations(
+			columnsName,
+			'transform'
+		);
+
+		expect( variations ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					name: 'columns',
+					attributes: {
+						layout: { type: 'flex', flexWrap: 'nowrap' },
+					},
+				} ),
+				expect.objectContaining( {
+					name: 'columns-grid',
+					attributes: { layout: { type: 'grid' } },
+				} ),
+			] )
+		);
+	} );
+
+	it( 'detects the active transform variation from the layout type', () => {
+		expect(
+			select( blocksStore ).getActiveBlockVariation(
+				columnsName,
+				{},
+				'transform'
+			)?.name
+		).toBe( 'columns' );
+
+		expect(
+			select( blocksStore ).getActiveBlockVariation(
+				columnsName,
+				{ layout: { type: 'grid' } },
+				'transform'
+			)?.name
+		).toBe( 'columns-grid' );
+	} );
+
+	it( 'allows grid layout controls without enabling layout type switching', () => {
+		const blockType = select( blocksStore ).getBlockType( columnsName );
+
+		expect( blockType.supports.layout ).toEqual(
+			expect.objectContaining( {
+				allowSwitching: false,
+				allowInheriting: false,
+				allowOrientation: false,
+				allowJustification: false,
+				allowVerticalAlignment: false,
+				allowWrap: false,
+			} )
+		);
+		expect( blockType.supports.layout.allowEditing ).not.toBe( false );
+		expect(
+			blockType.supports.layout.allowSizingOnChildren
+		).toBeUndefined();
+	} );
+
+	it( 'does not serialize mobile stacking classes for grid layout', () => {
+		const serialized = serialize(
+			createBlock(
+				columnsName,
+				{
+					isStackedOnMobile: false,
+					layout: { type: 'grid' },
+				},
+				[ createBlock( columnName ) ]
+			)
+		);
+
+		expect( serialized ).toContain( '"layout":{"type":"grid"}' );
+		expect( serialized ).not.toContain( 'is-not-stacked-on-mobile' );
+	} );
+} );

--- a/packages/block-library/src/columns/variations.js
+++ b/packages/block-library/src/columns/variations.js
@@ -3,6 +3,7 @@
  */
 import { Path, SVG } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { columns as columnsIcon, grid } from '@wordpress/icons';
 
 /** @typedef {import('@wordpress/blocks').WPBlockVariation} WPBlockVariation */
 
@@ -128,6 +129,26 @@ const variations = [
 			[ 'core/column', { width: '25%' } ],
 		],
 		scope: [ 'block' ],
+	},
+	{
+		name: 'columns',
+		title: __( 'Columns' ),
+		description: __( 'Arrange blocks in columns.' ),
+		attributes: { layout: { type: 'flex', flexWrap: 'nowrap' } },
+		scope: [ 'transform' ],
+		isActive: ( blockAttributes ) =>
+			blockAttributes.layout?.type !== 'grid',
+		icon: columnsIcon,
+	},
+	{
+		name: 'columns-grid',
+		title: __( 'Columns grid' ),
+		description: __( 'Arrange columns in a grid.' ),
+		attributes: { layout: { type: 'grid' } },
+		scope: [ 'transform' ],
+		isActive: ( blockAttributes ) =>
+			blockAttributes.layout?.type === 'grid',
+		icon: grid,
 	},
 ];
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes #70355; alternative to #78713.

Tries adding a block variation to Columns which switches it to a grid layout with a column count of whatever number of columns the Columns block has set. 

With the recently added support for responsive layout styles (see #78543), this will allow fine-tuning the responsive behaviour of the Columns block.

When Columns is set to grid, its "columns" and "stack on mobile" settings are hidden, and it's possible to configure its grid layout. The "width" setting in its child Column blocks is also hidden, but it becomes possible to set grid spans on them.


WIP - written with codex/gpt 5.5. I haven't properly human-reviewed it yet!


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Columns block to a post and populate it with content
2. Switch it to Columns grid variation and play around with the controls!
3. Switch it back to Columns

Note that when switching between variations, similarly to what happens with Group variations, all layout-specific settings are lost. This means that stuff like custom Column widths will disappear too. Make use of the undo button as needed 😅 

## Screenshots or screencast <!-- if applicable -->

<img width="1238" height="419" alt="Screenshot 2026-05-27 at 5 52 14 pm" src="https://github.com/user-attachments/assets/5bab14d6-6a56-42c3-98f5-9a4c05fac877" />

<img width="1215" height="909" alt="Screenshot 2026-05-27 at 5 51 46 pm" src="https://github.com/user-attachments/assets/f2fb9e0f-397f-430d-ad44-fcbb7266c310" />


lol I just realised we're exposing an empty layout panel when no controls are available:

<img width="290" height="84" alt="Screenshot 2026-05-27 at 6 00 06 pm" src="https://github.com/user-attachments/assets/3ccf6e75-a9bd-4bc0-bf82-323fb98244d5" />

might fix that separately as it's a bug that can appear in other contexts.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
