### PR TITLE
Fix: Respect hidden attribute in Shortcode block render

### DIFF
--- a/packages/block-library/src/shortcode/index.php
+++ b/packages/block-library/src/shortcode/index.php
@@ -16,9 +16,11 @@
  * @return string Returns the block content.
  */
 function render_block_core_shortcode( $attributes, $content ) {
+	if ( ! empty( $attributes['hidden'] ) ) {
+		return '';
+	}
 	return wpautop( $content );
 }
-
 /**
  * Registers the `core/shortcode` block on server.
  *


### PR DESCRIPTION
## What?
Closes #78701

The Shortcode block render callback does not check the `hidden` 
attribute, causing previously hidden shortcode blocks to remain 
visible on the front end even in incognito mode.

## Why?
PR #76138 disabled visibility support for the Shortcode block.
However, users who had previously hidden shortcode blocks still 
have `{"hidden":true}` saved in their database from before that 
change. The render callback was not checking this attribute, 
causing those blocks to render on the front end even when 
marked as hidden.

## How?
Added a check for the `hidden` attribute in the render callback 
in `index.php`. If the block is hidden, the function returns an 
empty string instead of rendering the shortcode content.

```php
function render_block_core_shortcode( $attributes, $content ) {
    if ( ! empty( $attributes['hidden'] ) ) {
        return '';
    }
    return wpautop( $content );
}
```

## Testing Instructions
1. Open a post or page
2. Add a Shortcode block
3. Switch to Code Editor (3 dots → Code Editor)
4. Manually add `{"hidden":true}` to block markup:
   `<!-- wp:shortcode {"hidden":true} -->[your_shortcode]<!-- /wp:shortcode -->`
5. Publish the page
6. Visit the page in incognito mode

**Before fix:** Shortcode renders visibly on front end ✗

**After fix:** Nothing renders — block correctly hidden 
