### PR TITLE
Block Bindings: visual indicator on DataForm fields (split 1/3 of #75022)

### DIFF
--- a/packages/block-editor/src/components/block-bindings/attribute-control.js
+++ b/packages/block-editor/src/components/block-bindings/attribute-control.js
@@ -125,12 +125,12 @@ export default function BlockBindingsAttributeControl( {
 			hasValue={ () => !! binding }
 			label={ attribute }
 			onDeselect={
-				!! hasCompatibleFields &&
-				( () => {
-					updateBlockBindings( {
-						[ attribute ]: undefined,
-					} );
-				} )
+				hasCompatibleFields
+					? () =>
+							updateBlockBindings( {
+								[ attribute ]: undefined,
+							} )
+					: undefined
 			}
 		>
 			<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>

--- a/packages/block-editor/src/hooks/block-fields/connected-button.js
+++ b/packages/block-editor/src/hooks/block-fields/connected-button.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
+} from '@wordpress/components';
+import { connection, linkOff } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+export default function ConnectedButton( { isConnected, ...props } ) {
+	const label = isConnected ? __( 'Disconnect' ) : __( 'Connect' );
+
+	return (
+		<InputControlSuffixWrapper variant="control">
+			<Button
+				{ ...props }
+				size="small"
+				icon={ isConnected ? connection : linkOff }
+				iconSize={ 24 }
+				label={ label }
+			/>
+		</InputControlSuffixWrapper>
+	);
+}

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -22,6 +22,7 @@ const { fieldsKey, formKey } = unlock( blocksPrivateApis );
 import FieldsDropdownMenu from './fields-dropdown-menu';
 import { PrivateBlockContext } from '../../components/block-list/private-block-context';
 import InspectorControls from '../../components/inspector-controls/fill';
+import ConnectedButton from './connected-button';
 
 // controls
 import RichText from './rich-text';
@@ -156,6 +157,11 @@ function BlockFields( {
 				field.Edit = createConfiguredControl( Media, {
 					...fieldDef.Edit,
 				} );
+			} else if ( ! fieldDef.Edit ) {
+				field.Edit = {
+					control: fieldDef.type,
+					suffix: ConnectedButton,
+				};
 			}
 
 			return field;

--- a/packages/block-editor/src/hooks/block-fields/media/index.js
+++ b/packages/block-editor/src/hooks/block-fields/media/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -113,6 +118,8 @@ export default function Media( { data, field, onChange, config = {} } ) {
 	const id = value?.id;
 	const url = value?.url;
 
+	const isBound = 'id' in ( data?.metadata?.bindings || {} );
+
 	const attachment = useSelect(
 		( select ) => {
 			if ( ! id ) {
@@ -206,7 +213,10 @@ export default function Media( { data, field, onChange, config = {} } ) {
 					renderToggle={ ( buttonProps ) => (
 						<Button
 							__next40pxDefaultSize
-							className="block-editor-content-only-controls__media"
+							className={ clsx(
+								'block-editor-content-only-controls__media',
+								{ 'is-connected': isBound }
+							) }
 							{ ...buttonProps }
 						>
 							<Grid

--- a/packages/block-editor/src/hooks/block-fields/media/styles.scss
+++ b/packages/block-editor/src/hooks/block-fields/media/styles.scss
@@ -6,6 +6,10 @@
 	box-shadow: inset 0 0 0 $border-width $gray-400;
 	padding-right: $grid-unit-40;
 
+	&.is-connected {
+		box-shadow: inset 0 0 0 $border-width var(--wp-block-synced-color);
+	}
+
 	&:focus:not(:disabled) {
 		// Allow smooth transition between focused and unfocused box-shadow states.
 		box-shadow: 0 0 0 currentColor inset, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);

--- a/packages/block-editor/src/hooks/block-fields/rich-text/index.js
+++ b/packages/block-editor/src/hooks/block-fields/rich-text/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { BaseControl, useBaseControlProps } from '@wordpress/components';
@@ -29,6 +34,7 @@ export default function RichTextControl( {
 	config = {},
 } ) {
 	const registry = useRegistry();
+	const isBound = field.id in ( data?.metadata?.bindings || {} );
 	const attrValue = field.getValue( { item: data } );
 	const fieldConfig = field.config || {};
 	const { clientId } = config;
@@ -101,7 +107,10 @@ export default function RichTextControl( {
 			) }
 			<BaseControl { ...baseControlProps }>
 				<div
-					className="block-editor-content-only-controls__rich-text"
+					className={ clsx(
+						'block-editor-content-only-controls__rich-text',
+						{ 'is-connected': isBound }
+					) }
 					role="textbox"
 					aria-multiline={ ! fieldConfig?.disableLineBreaks }
 					ref={ useMergeRefs( [

--- a/packages/block-editor/src/hooks/block-fields/rich-text/styles.scss
+++ b/packages/block-editor/src/hooks/block-fields/rich-text/styles.scss
@@ -21,4 +21,8 @@
 	// on newer components like InputControl, SelectControl, etc.
 	// These values should be shared with the `controlPaddingX` in ./utils/config-values.js
 	padding: $grid-unit-15;
+
+	&.is-connected {
+		border-color: var(--wp-block-synced-color);
+	}
 }

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -11,6 +11,7 @@
 - DataViews: Lower the sticky footer z-index and isolate grid card stacking contexts. [#78315](https://github.com/WordPress/gutenberg/pull/78315)
 - DataViews: Refresh filter chip styling to align with `Button`. [#75204](https://github.com/WordPress/gutenberg/pull/75204)
 - DataForms: Increase the minimum width of the panel layout popover from 256px to 320px so option labels have more room. [#75204](https://github.com/WordPress/gutenberg/pull/75204)
+- DataForm: Surface a "connected" visual indicator on `text` controls whose `data.metadata.bindings[field.id]` is set; the `ValidatedText` control gains the `.is-connected` class (purple `--wp-block-synced-color` border) and consumer-supplied `prefix`/`suffix` components receive an `isConnected` boolean prop. [#75022](https://github.com/WordPress/gutenberg/issues/75022)
 
 ### Bug Fixes
 

--- a/packages/dataviews/src/components/dataform-controls/style.scss
+++ b/packages/dataviews/src/components/dataform-controls/style.scss
@@ -32,3 +32,8 @@
 		background-color: var(--wpds-color-bg-interactive-neutral-strong-active);
 	}
 }
+
+// TODO: Make selector/classes consistent with this file/directory!
+.components-validated-control .components-input-control.is-connected .components-input-control__backdrop {
+	border-color: var(--wp-block-synced-color);
+}

--- a/packages/dataviews/src/components/dataform-controls/text.tsx
+++ b/packages/dataviews/src/components/dataform-controls/text.tsx
@@ -19,7 +19,10 @@ export default function Text< Item >( {
 	validity,
 }: DataFormControlProps< Item > ) {
 	const { prefix, suffix } = config || {};
-	const isConnected = field.id in ( data?.metadata?.bindings || {} );
+	const isConnected =
+		field.id in
+		( ( data as { metadata?: { bindings?: object } } )?.metadata
+			?.bindings || {} );
 
 	return (
 		<ValidatedText

--- a/packages/dataviews/src/components/dataform-controls/text.tsx
+++ b/packages/dataviews/src/components/dataform-controls/text.tsx
@@ -19,6 +19,7 @@ export default function Text< Item >( {
 	validity,
 }: DataFormControlProps< Item > ) {
 	const { prefix, suffix } = config || {};
+	const isConnected = field.id in ( data?.metadata?.bindings || {} );
 
 	return (
 		<ValidatedText
@@ -29,8 +30,12 @@ export default function Text< Item >( {
 				hideLabelFromVision,
 				markWhenOptional,
 				validity,
-				prefix: prefix ? createElement( prefix ) : undefined,
-				suffix: suffix ? createElement( suffix ) : undefined,
+				prefix: prefix
+					? createElement( prefix, { isConnected } )
+					: undefined,
+				suffix: suffix
+					? createElement( suffix, { isConnected } )
+					: undefined,
 			} }
 		/>
 	);

--- a/packages/dataviews/src/components/dataform-controls/utils/validated-input.tsx
+++ b/packages/dataviews/src/components/dataform-controls/utils/validated-input.tsx
@@ -42,6 +42,7 @@ export default function ValidatedText< Item >( {
 }: DataFormValidatedTextControlProps< Item > ) {
 	const { label, placeholder, description, getValue, setValue, isValid } =
 		field;
+	const isBound = field.id in ( data?.metadata?.bindings || {} );
 	const value = getValue( { item: data } );
 	const disabled = field.isDisabled( { item: data, field } );
 
@@ -58,6 +59,7 @@ export default function ValidatedText< Item >( {
 
 	return (
 		<ValidatedInputControl
+			className={ isBound ? 'is-connected' : undefined }
 			required={ !! isValid.required }
 			markWhenOptional={ markWhenOptional }
 			customValidity={ getCustomValidity( isValid, validity ) }

--- a/packages/dataviews/src/components/dataform-controls/utils/validated-input.tsx
+++ b/packages/dataviews/src/components/dataform-controls/utils/validated-input.tsx
@@ -42,7 +42,10 @@ export default function ValidatedText< Item >( {
 }: DataFormValidatedTextControlProps< Item > ) {
 	const { label, placeholder, description, getValue, setValue, isValid } =
 		field;
-	const isBound = field.id in ( data?.metadata?.bindings || {} );
+	const isBound =
+		field.id in
+		( ( data as { metadata?: { bindings?: object } } )?.metadata
+			?.bindings || {} );
 	const value = getValue( { item: data } );
 	const disabled = field.isDisabled( { item: data, field } );
 

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -149,11 +149,11 @@ export type EditConfigText = {
 	/**
 	 * Prefix component to display before the input.
 	 */
-	prefix?: React.ComponentType;
+	prefix?: React.ComponentType< { isConnected?: boolean } >;
 	/**
 	 * Suffix component to display after the input.
 	 */
-	suffix?: React.ComponentType;
+	suffix?: React.ComponentType< { isConnected?: boolean } >;
 };
 
 /**
@@ -476,8 +476,8 @@ export type DataFormControlProps< Item > = {
 	 * Configuration object for the control.
 	 */
 	config?: {
-		prefix?: React.ComponentType;
-		suffix?: React.ComponentType;
+		prefix?: React.ComponentType< { isConnected?: boolean } >;
+		suffix?: React.ComponentType< { isConnected?: boolean } >;
 		rows?: number;
 		compact?: boolean;
 	};


### PR DESCRIPTION
> **Status: NOT FOR REVIEW** — opened to check the changes and CI. May be closed in the future.

Split 1 of 3 carved out of #75022 (Block Bindings into Block Fields). See the umbrella issue for the full scope.

## Scope

Cherry-pick of the upstream Block Bindings visual indicator WIP onto the DataForm controls, plus follow-up typecheck/docs/onDeselect-guard fixes.

- `feat(block-editor)`: cherry-pick Block Bindings visual indicator WIP
- `docs(dataviews)`: note Block Bindings visual indicator props in DataForm controls
- `fix(dataviews)`: typecheck Block Bindings indicator additions
- `fix(block-editor)`: guard `ToolsPanelItem` `onDeselect` against falsy

## Diff size

12 files / +91 / -14

## Stack

- A (this) — visual indicator on DataForm
- B — shared compatible-fields hook + panel relocation (`try/75022-B-shared-gate-hook`)
- C — inline picker on RichText, depends on A + B (`try/75022-C-inline-picker`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)