### PR TITLE
Block Bindings: shared compatible-fields hook + panel relocation (split 2/3 of #75022)

### DIFF
--- a/packages/block-editor/src/components/block-bindings/attribute-control.js
+++ b/packages/block-editor/src/components/block-bindings/attribute-control.js
@@ -7,10 +7,7 @@ import fastDeepEqual from 'fast-deep-equal/es6/index.js';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	getBlockBindingsSource,
-	store as blocksStore,
-} from '@wordpress/blocks';
+import { getBlockBindingsSource } from '@wordpress/blocks';
 import {
 	__experimentalItem as Item,
 	__experimentalText as WCText,
@@ -28,6 +25,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import BlockContext from '../block-context';
 import BlockBindingsSourceFieldsList from './source-fields-list';
 import useBlockBindingsUtils from './use-block-bindings-utils';
+import useBlockBindingsCompatibleFields from './use-block-bindings-compatible-fields';
 import { unlock } from '../../lock-unlock';
 import { store as blockEditorStore } from '../../store';
 
@@ -42,45 +40,17 @@ export default function BlockBindingsAttributeControl( {
 	const isMobile = useViewportMatch( 'medium', '<' );
 
 	const blockContext = useContext( BlockContext );
-	const compatibleFields = useSelect(
-		( select ) => {
-			const {
-				getAllBlockBindingsSources,
-				getBlockBindingsSourceFieldsList,
-				getBlockType,
-			} = unlock( select( blocksStore ) );
-
-			const _attribute =
-				getBlockType( blockName ).attributes?.[ attribute ];
-
-			if ( _attribute?.enum ) {
-				return {};
-			}
-
-			const attributeType =
-				_attribute?.type === 'rich-text' ? 'string' : _attribute?.type;
-
-			const sourceFields = {};
-			Object.entries( getAllBlockBindingsSources() ).forEach(
-				( [ sourceName, source ] ) => {
-					const fieldsList = getBlockBindingsSourceFieldsList(
-						source,
-						blockContext
-					);
-					if ( ! fieldsList?.length ) {
-						return;
-					}
-					const compatibleFieldsList = fieldsList.filter(
-						( field ) => field.type === attributeType
-					);
-					if ( compatibleFieldsList.length ) {
-						sourceFields[ sourceName ] = compatibleFieldsList;
-					}
-				}
-			);
-			return sourceFields;
-		},
-		[ attribute, blockName, blockContext ]
+	// Reuse the shared hook (spec req 10). The legacy panel only needs the
+	// `compatibleFields` map here; the broader `isBindable` gate is enforced
+	// elsewhere (`bindableAttributes` in `block-bindings.js`). The duplicate
+	// `canUpdateBlockBindings` read below is intentional accepted tech debt —
+	// collapsing into the hook would entangle the hook's return shape with
+	// legacy-panel-specific gate granularity (the panel renders the item but
+	// disables the menu rather than hiding it).
+	const { compatibleFields } = useBlockBindingsCompatibleFields(
+		attribute,
+		blockName,
+		blockContext
 	);
 
 	const { canUpdateBlockBindings } = useSelect( ( select ) => ( {

--- a/packages/block-editor/src/components/block-bindings/excluded-blocks.js
+++ b/packages/block-editor/src/components/block-bindings/excluded-blocks.js
@@ -1,0 +1,15 @@
+/**
+ * Block names for which the Block Bindings UI (both the legacy "Attributes"
+ * panel and the new inline picker) is not rendered.
+ *
+ * Lives in its own module so the constant can be imported from
+ * `hooks/block-bindings.js` (legacy panel) and from
+ * `components/block-bindings/use-block-bindings-compatible-fields.js`
+ * (shared gate predicate) without creating a circular dependency through
+ * the `components/block-bindings` barrel.
+ */
+export const BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS = [
+	'core/post-date',
+	'core/navigation-link',
+	'core/navigation-submenu',
+];

--- a/packages/block-editor/src/components/block-bindings/index.js
+++ b/packages/block-editor/src/components/block-bindings/index.js
@@ -4,3 +4,4 @@
 export { default as BlockBindingsAttributeControl } from './attribute-control';
 export { default as BlockBindingsSourceFieldsList } from './source-fields-list';
 export { default as useBlockBindingsUtils } from './use-block-bindings-utils';
+export { default as useBlockBindingsCompatibleFields } from './use-block-bindings-compatible-fields';

--- a/packages/block-editor/src/components/block-bindings/test/use-block-bindings-compatible-fields.js
+++ b/packages/block-editor/src/components/block-bindings/test/use-block-bindings-compatible-fields.js
@@ -1,0 +1,226 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	registerBlockType,
+	unregisterBlockType,
+	registerBlockBindingsSource,
+	unregisterBlockBindingsSource,
+} from '@wordpress/blocks';
+import { dispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { useBlockBindingsCompatibleFields } from '../';
+
+const BLOCK_NAME = 'core/test-bindable';
+const ENUM_BLOCK_NAME = 'core/test-enum';
+const SOURCE_STRING = 'test/string-source';
+const SOURCE_NUMBER = 'test/number-source';
+
+const STRING_FIELDS = [
+	{ key: 'one', label: 'One', type: 'string' },
+	{ key: 'two', label: 'Two', type: 'string' },
+];
+const MIXED_FIELDS = [
+	{ key: 'num', label: 'Num', type: 'integer' },
+	{ key: 'str', label: 'Str', type: 'string' },
+];
+
+function registerSources() {
+	registerBlockBindingsSource( {
+		name: SOURCE_STRING,
+		label: 'String source',
+		getFieldsList: () => STRING_FIELDS,
+	} );
+	registerBlockBindingsSource( {
+		name: SOURCE_NUMBER,
+		label: 'Number source',
+		getFieldsList: () => MIXED_FIELDS,
+	} );
+}
+
+function unregisterSources() {
+	unregisterBlockBindingsSource( SOURCE_STRING );
+	unregisterBlockBindingsSource( SOURCE_NUMBER );
+}
+
+function registerBindableBlock() {
+	registerBlockType( BLOCK_NAME, {
+		apiVersion: 3,
+		title: 'Test bindable',
+		category: 'text',
+		attributes: {
+			content: { type: 'rich-text' },
+			label: { type: 'string' },
+		},
+		save: () => null,
+	} );
+}
+
+function registerEnumBlock() {
+	registerBlockType( ENUM_BLOCK_NAME, {
+		apiVersion: 3,
+		title: 'Test enum',
+		category: 'text',
+		attributes: {
+			level: { type: 'string', enum: [ 'a', 'b' ] },
+		},
+		save: () => null,
+	} );
+}
+
+describe( 'useBlockBindingsCompatibleFields', () => {
+	// Track all hooks rendered in a test so we can unmount them in afterEach.
+	// `useSelect` subscribes to the data registry; if a hook stays mounted,
+	// subsequent dispatches in afterEach fire state updates outside any act()
+	// scope, which Jest's strict-console plugin flags as unwrapped errors.
+	let activeHooks;
+
+	function renderTrackedHook( callback ) {
+		const utils = renderHook( callback );
+		activeHooks.push( utils );
+		return utils;
+	}
+
+	beforeEach( () => {
+		activeHooks = [];
+		registerSources();
+		registerBindableBlock();
+		registerEnumBlock();
+		dispatch( blockEditorStore ).updateSettings( {
+			__experimentalBlockBindingsSupportedAttributes: {
+				[ BLOCK_NAME ]: [ 'content', 'label' ],
+				[ ENUM_BLOCK_NAME ]: [ 'level' ],
+				'core/post-date': [ 'date' ],
+			},
+			canUpdateBlockBindings: true,
+		} );
+	} );
+
+	afterEach( () => {
+		// Unmount all subscribed hooks BEFORE we dispatch unwind updates so
+		// the data store does not trigger renders on an unmounted tree.
+		activeHooks.forEach( ( handle ) => handle.unmount() );
+		activeHooks = [];
+
+		unregisterBlockType( BLOCK_NAME );
+		unregisterBlockType( ENUM_BLOCK_NAME );
+		unregisterSources();
+		dispatch( blockEditorStore ).updateSettings( {
+			__experimentalBlockBindingsSupportedAttributes: undefined,
+			canUpdateBlockBindings: undefined,
+		} );
+	} );
+
+	it( 'returns isBindable=false when attribute is enum-typed', () => {
+		const { result } = renderTrackedHook( () =>
+			useBlockBindingsCompatibleFields( 'level', ENUM_BLOCK_NAME, {} )
+		);
+		expect( result.current ).toEqual( {
+			isBindable: false,
+			compatibleFields: {},
+		} );
+	} );
+
+	it( 'coerces rich-text attribute type to string when matching field types', () => {
+		// `content` is `rich-text` so it should match string-typed fields.
+		const { result } = renderTrackedHook( () =>
+			useBlockBindingsCompatibleFields( 'content', BLOCK_NAME, {} )
+		);
+		expect( result.current.isBindable ).toBe( true );
+		expect( result.current.compatibleFields[ SOURCE_STRING ] ).toEqual(
+			STRING_FIELDS
+		);
+	} );
+
+	it( 'filters fields by attribute type and omits sources with zero compatible fields', () => {
+		// `label` is `string`. SOURCE_STRING contributes 2 string fields.
+		// SOURCE_NUMBER has one integer + one string field; only the string
+		// field should be kept.
+		const { result } = renderTrackedHook( () =>
+			useBlockBindingsCompatibleFields( 'label', BLOCK_NAME, {} )
+		);
+		expect( result.current.isBindable ).toBe( true );
+		expect( Object.keys( result.current.compatibleFields ) ).toEqual( [
+			SOURCE_STRING,
+			SOURCE_NUMBER,
+		] );
+		expect( result.current.compatibleFields[ SOURCE_NUMBER ] ).toEqual( [
+			{ key: 'str', label: 'Str', type: 'string' },
+		] );
+	} );
+
+	it( 'returns isBindable=false when attribute is not in __experimentalBlockBindingsSupportedAttributes', () => {
+		act( () => {
+			dispatch( blockEditorStore ).updateSettings( {
+				__experimentalBlockBindingsSupportedAttributes: {},
+			} );
+		} );
+		const { result } = renderTrackedHook( () =>
+			useBlockBindingsCompatibleFields( 'content', BLOCK_NAME, {} )
+		);
+		expect( result.current.isBindable ).toBe( false );
+	} );
+
+	it( 'returns isBindable=false for blocks in BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS', () => {
+		// Register a faux core/post-date so getBlockType resolves it.
+		// The unregister happens in afterAll below (see end of file) so the
+		// state change does not fire on a still-mounted subscribed hook.
+		registerBlockType( 'core/post-date', {
+			apiVersion: 3,
+			title: 'Post date',
+			category: 'text',
+			attributes: { date: { type: 'string' } },
+			save: () => null,
+		} );
+
+		const { result } = renderTrackedHook( () =>
+			useBlockBindingsCompatibleFields( 'date', 'core/post-date', {} )
+		);
+		expect( result.current.isBindable ).toBe( false );
+	} );
+
+	afterAll( () => {
+		// Defensive: ensure the excluded-block test's registration is cleaned
+		// up even though the test itself does not unregister.
+		try {
+			unregisterBlockType( 'core/post-date' );
+		} catch {
+			// Not registered — nothing to do.
+		}
+	} );
+
+	it( 'returns isBindable=false when canUpdateBlockBindings is false', () => {
+		act( () => {
+			dispatch( blockEditorStore ).updateSettings( {
+				canUpdateBlockBindings: false,
+			} );
+		} );
+		const { result } = renderTrackedHook( () =>
+			useBlockBindingsCompatibleFields( 'content', BLOCK_NAME, {} )
+		);
+		expect( result.current.isBindable ).toBe( false );
+		// `compatibleFields` is still computed (used by the legacy panel UI).
+		expect( result.current.compatibleFields[ SOURCE_STRING ] ).toEqual(
+			STRING_FIELDS
+		);
+	} );
+
+	it( 'returns isBindable=true with the compatible-fields map when all gates pass', () => {
+		const { result } = renderTrackedHook( () =>
+			useBlockBindingsCompatibleFields( 'content', BLOCK_NAME, {} )
+		);
+		expect( result.current.isBindable ).toBe( true );
+		expect( Object.keys( result.current.compatibleFields ) ).toContain(
+			SOURCE_STRING
+		);
+	} );
+} );

--- a/packages/block-editor/src/components/block-bindings/use-block-bindings-compatible-fields.js
+++ b/packages/block-editor/src/components/block-bindings/use-block-bindings-compatible-fields.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import { store as blocksStore } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useRegistry } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -39,60 +40,86 @@ export default function useBlockBindingsCompatibleFields(
 	blockName,
 	blockContext
 ) {
-	return useSelect(
+	const registry = useRegistry();
+
+	// Subscribe to a small set of stable primitives so `useSelect`'s dev
+	// reference-stability check stays happy. The actual compatible-fields
+	// computation runs inside `useMemo` below (it would otherwise build a
+	// fresh object on every render, tripping `useSelect`'s warning).
+	const {
+		blockTypeAttribute,
+		sources,
+		supportedAttributes,
+		canUpdateBlockBindings,
+	} = useSelect(
 		( select ) => {
-			const {
-				__experimentalBlockBindingsSupportedAttributes,
-				canUpdateBlockBindings,
-			} = select( blockEditorStore ).getSettings();
+			const settings = select( blockEditorStore ).getSettings();
 			const { getBlockType } = select( blocksStore );
-			const {
-				getAllBlockBindingsSources,
-				getBlockBindingsSourceFieldsList,
-			} = unlock( select( blocksStore ) );
-
-			const _attribute =
-				getBlockType( blockName )?.attributes?.[ attribute ];
-
-			// Enum-typed attributes have a closed set of values and are
-			// therefore not bindable to external sources.
-			if ( _attribute?.enum ) {
-				return { isBindable: false, compatibleFields: {} };
-			}
-
-			const attributeType =
-				_attribute?.type === 'rich-text' ? 'string' : _attribute?.type;
-
-			const compatibleFields = {};
-			Object.entries( getAllBlockBindingsSources() ).forEach(
-				( [ sourceName, source ] ) => {
-					const fieldsList = getBlockBindingsSourceFieldsList(
-						source,
-						blockContext
-					);
-					if ( ! fieldsList?.length ) {
-						return;
-					}
-					const compatibleFieldsList = fieldsList.filter(
-						( field ) => field.type === attributeType
-					);
-					if ( compatibleFieldsList.length ) {
-						compatibleFields[ sourceName ] = compatibleFieldsList;
-					}
-				}
+			const { getAllBlockBindingsSources } = unlock(
+				select( blocksStore )
 			);
-
-			const supportedAttributes =
-				__experimentalBlockBindingsSupportedAttributes?.[ blockName ];
-
-			const isBindable =
-				!! canUpdateBlockBindings &&
-				!! supportedAttributes?.includes( attribute ) &&
-				! BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS.includes( blockName ) &&
-				Object.keys( compatibleFields ).length > 0;
-
-			return { isBindable, compatibleFields };
+			return {
+				blockTypeAttribute:
+					getBlockType( blockName )?.attributes?.[ attribute ],
+				sources: getAllBlockBindingsSources(),
+				supportedAttributes:
+					settings.__experimentalBlockBindingsSupportedAttributes?.[
+						blockName
+					],
+				canUpdateBlockBindings: settings.canUpdateBlockBindings,
+			};
 		},
-		[ attribute, blockName, blockContext ]
+		[ attribute, blockName ]
 	);
+
+	return useMemo( () => {
+		// Enum-typed attributes have a closed set of values and are therefore
+		// not bindable to external sources.
+		if ( blockTypeAttribute?.enum ) {
+			return { isBindable: false, compatibleFields: {} };
+		}
+
+		const attributeType =
+			blockTypeAttribute?.type === 'rich-text'
+				? 'string'
+				: blockTypeAttribute?.type;
+
+		const { getBlockBindingsSourceFieldsList } = unlock(
+			registry.select( blocksStore )
+		);
+
+		const compatibleFields = {};
+		Object.entries( sources ).forEach( ( [ sourceName, source ] ) => {
+			const fieldsList = getBlockBindingsSourceFieldsList(
+				source,
+				blockContext
+			);
+			if ( ! fieldsList?.length ) {
+				return;
+			}
+			const compatibleFieldsList = fieldsList.filter(
+				( field ) => field.type === attributeType
+			);
+			if ( compatibleFieldsList.length ) {
+				compatibleFields[ sourceName ] = compatibleFieldsList;
+			}
+		} );
+
+		const isBindable =
+			!! canUpdateBlockBindings &&
+			!! supportedAttributes?.includes( attribute ) &&
+			! BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS.includes( blockName ) &&
+			Object.keys( compatibleFields ).length > 0;
+
+		return { isBindable, compatibleFields };
+	}, [
+		attribute,
+		blockName,
+		blockTypeAttribute,
+		sources,
+		blockContext,
+		supportedAttributes,
+		canUpdateBlockBindings,
+		registry,
+	] );
 }

--- a/packages/block-editor/src/components/block-bindings/use-block-bindings-compatible-fields.js
+++ b/packages/block-editor/src/components/block-bindings/use-block-bindings-compatible-fields.js
@@ -2,31 +2,34 @@
  * WordPress dependencies
  */
 import { store as blocksStore } from '@wordpress/blocks';
-import { useSelect, useRegistry } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
-import { BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS } from '../../hooks/block-bindings';
+import { BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS } from './excluded-blocks';
 import { unlock } from '../../lock-unlock';
 
 /**
  * Computes the Block Bindings sources/fields that are compatible with a given
  * block attribute, plus whether the inline picker should render for it.
  *
- * This is the single source of truth for the picker gate (spec req 10/11):
- * - Reads `getBlockType` from the PUBLIC blocks store selector (spec req 9).
- * - Reads `getAllBlockBindingsSources` / `getBlockBindingsSourceFieldsList`
- *   via the already-unlocked private selectors (no new unlock surfaces — spec
- *   §6).
- * - Honors the `enum` short-circuit and the `rich-text` -> `string` coercion
- *   from `BlockBindingsAttributeControl`.
- * - Folds in all four gates from spec req 11 (a-d) into `isBindable`.
+ * Single source of truth for the picker gate (spec req 10/11). Consumers are
+ * `BlockBindingsAttributeControl` (legacy panel) and `GatedConnectedButton`
+ * (inline picker), so the gating logic exists once.
  *
- * Consumers: `BlockBindingsAttributeControl` (legacy panel) and the new
- * `GatedConnectedButton` (inline picker), so the gating logic exists once.
+ * The per-source `getBlockBindingsSourceFieldsList` calls run INSIDE
+ * `useSelect`: the underlying registry selectors transparently subscribe to
+ * any other stores read by each `source.getFieldsList({ select, context })`
+ * (typically `core/editor` / `core-data` for post-meta), so sources whose
+ * field lists arrive asynchronously trigger a re-render. The returned
+ * `fieldsBySource` map preserves the selector's memoized array refs, keeping
+ * `useSelect`'s shallow-equal check happy across renders.
+ *
+ * Filtering and the final shape live in `useMemo` so the per-render filter
+ * arrays don't trip the same shallow-equal check inside `useSelect`.
  *
  * @param {string} attribute    The block attribute name (e.g. 'content').
  * @param {string} blockName    The block name (e.g. 'core/paragraph').
@@ -40,41 +43,50 @@ export default function useBlockBindingsCompatibleFields(
 	blockName,
 	blockContext
 ) {
-	const registry = useRegistry();
-
-	// Subscribe to a small set of stable primitives so `useSelect`'s dev
-	// reference-stability check stays happy. The actual compatible-fields
-	// computation runs inside `useMemo` below (it would otherwise build a
-	// fresh object on every render, tripping `useSelect`'s warning).
-	const {
-		blockTypeAttribute,
-		sources,
-		supportedAttributes,
-		canUpdateBlockBindings,
-	} = useSelect(
+	const subscribed = useSelect(
 		( select ) => {
 			const settings = select( blockEditorStore ).getSettings();
 			const { getBlockType } = select( blocksStore );
-			const { getAllBlockBindingsSources } = unlock(
-				select( blocksStore )
+			const {
+				getAllBlockBindingsSources,
+				getBlockBindingsSourceFieldsList,
+			} = unlock( select( blocksStore ) );
+
+			const fieldsBySource = {};
+			Object.entries( getAllBlockBindingsSources() ).forEach(
+				( [ sourceName, source ] ) => {
+					// `getBlockBindingsSourceFieldsList` is memoized via
+					// `createSelector`, so unchanged inputs yield the same
+					// array reference across calls.
+					const fieldsList = getBlockBindingsSourceFieldsList(
+						source,
+						blockContext
+					);
+					if ( fieldsList?.length ) {
+						fieldsBySource[ sourceName ] = fieldsList;
+					}
+				}
 			);
+
 			return {
 				blockTypeAttribute:
 					getBlockType( blockName )?.attributes?.[ attribute ],
-				sources: getAllBlockBindingsSources(),
 				supportedAttributes:
 					settings.__experimentalBlockBindingsSupportedAttributes?.[
 						blockName
 					],
 				canUpdateBlockBindings: settings.canUpdateBlockBindings,
+				fieldsBySource,
 			};
 		},
-		[ attribute, blockName ]
+		[ attribute, blockName, blockContext ]
 	);
 
 	return useMemo( () => {
-		// Enum-typed attributes have a closed set of values and are therefore
-		// not bindable to external sources.
+		const { blockTypeAttribute, fieldsBySource } = subscribed;
+
+		// Enum-typed attributes have a closed set of values and are
+		// therefore not bindable to external sources.
 		if ( blockTypeAttribute?.enum ) {
 			return { isBindable: false, compatibleFields: {} };
 		}
@@ -84,42 +96,24 @@ export default function useBlockBindingsCompatibleFields(
 				? 'string'
 				: blockTypeAttribute?.type;
 
-		const { getBlockBindingsSourceFieldsList } = unlock(
-			registry.select( blocksStore )
+		const compatibleFields = {};
+		Object.entries( fieldsBySource ).forEach(
+			( [ sourceName, fieldsList ] ) => {
+				const compatibleFieldsList = fieldsList.filter(
+					( field ) => field.type === attributeType
+				);
+				if ( compatibleFieldsList.length ) {
+					compatibleFields[ sourceName ] = compatibleFieldsList;
+				}
+			}
 		);
 
-		const compatibleFields = {};
-		Object.entries( sources ).forEach( ( [ sourceName, source ] ) => {
-			const fieldsList = getBlockBindingsSourceFieldsList(
-				source,
-				blockContext
-			);
-			if ( ! fieldsList?.length ) {
-				return;
-			}
-			const compatibleFieldsList = fieldsList.filter(
-				( field ) => field.type === attributeType
-			);
-			if ( compatibleFieldsList.length ) {
-				compatibleFields[ sourceName ] = compatibleFieldsList;
-			}
-		} );
-
 		const isBindable =
-			!! canUpdateBlockBindings &&
-			!! supportedAttributes?.includes( attribute ) &&
+			!! subscribed.canUpdateBlockBindings &&
+			!! subscribed.supportedAttributes?.includes( attribute ) &&
 			! BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS.includes( blockName ) &&
 			Object.keys( compatibleFields ).length > 0;
 
 		return { isBindable, compatibleFields };
-	}, [
-		attribute,
-		blockName,
-		blockTypeAttribute,
-		sources,
-		blockContext,
-		supportedAttributes,
-		canUpdateBlockBindings,
-		registry,
-	] );
+	}, [ attribute, blockName, subscribed ] );
 }

--- a/packages/block-editor/src/components/block-bindings/use-block-bindings-compatible-fields.js
+++ b/packages/block-editor/src/components/block-bindings/use-block-bindings-compatible-fields.js
@@ -1,0 +1,98 @@
+/**
+ * WordPress dependencies
+ */
+import { store as blocksStore } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import { BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS } from '../../hooks/block-bindings';
+import { unlock } from '../../lock-unlock';
+
+/**
+ * Computes the Block Bindings sources/fields that are compatible with a given
+ * block attribute, plus whether the inline picker should render for it.
+ *
+ * This is the single source of truth for the picker gate (spec req 10/11):
+ * - Reads `getBlockType` from the PUBLIC blocks store selector (spec req 9).
+ * - Reads `getAllBlockBindingsSources` / `getBlockBindingsSourceFieldsList`
+ *   via the already-unlocked private selectors (no new unlock surfaces — spec
+ *   §6).
+ * - Honors the `enum` short-circuit and the `rich-text` -> `string` coercion
+ *   from `BlockBindingsAttributeControl`.
+ * - Folds in all four gates from spec req 11 (a-d) into `isBindable`.
+ *
+ * Consumers: `BlockBindingsAttributeControl` (legacy panel) and the new
+ * `GatedConnectedButton` (inline picker), so the gating logic exists once.
+ *
+ * @param {string} attribute    The block attribute name (e.g. 'content').
+ * @param {string} blockName    The block name (e.g. 'core/paragraph').
+ * @param {Object} blockContext The block context object (from `BlockContext`).
+ *
+ * @return {{ isBindable: boolean, compatibleFields: Object }} Gate predicate
+ *   plus map of `sourceKey -> Field[]` (filtered to compatible fields only).
+ */
+export default function useBlockBindingsCompatibleFields(
+	attribute,
+	blockName,
+	blockContext
+) {
+	return useSelect(
+		( select ) => {
+			const {
+				__experimentalBlockBindingsSupportedAttributes,
+				canUpdateBlockBindings,
+			} = select( blockEditorStore ).getSettings();
+			const { getBlockType } = select( blocksStore );
+			const {
+				getAllBlockBindingsSources,
+				getBlockBindingsSourceFieldsList,
+			} = unlock( select( blocksStore ) );
+
+			const _attribute =
+				getBlockType( blockName )?.attributes?.[ attribute ];
+
+			// Enum-typed attributes have a closed set of values and are
+			// therefore not bindable to external sources.
+			if ( _attribute?.enum ) {
+				return { isBindable: false, compatibleFields: {} };
+			}
+
+			const attributeType =
+				_attribute?.type === 'rich-text' ? 'string' : _attribute?.type;
+
+			const compatibleFields = {};
+			Object.entries( getAllBlockBindingsSources() ).forEach(
+				( [ sourceName, source ] ) => {
+					const fieldsList = getBlockBindingsSourceFieldsList(
+						source,
+						blockContext
+					);
+					if ( ! fieldsList?.length ) {
+						return;
+					}
+					const compatibleFieldsList = fieldsList.filter(
+						( field ) => field.type === attributeType
+					);
+					if ( compatibleFieldsList.length ) {
+						compatibleFields[ sourceName ] = compatibleFieldsList;
+					}
+				}
+			);
+
+			const supportedAttributes =
+				__experimentalBlockBindingsSupportedAttributes?.[ blockName ];
+
+			const isBindable =
+				!! canUpdateBlockBindings &&
+				!! supportedAttributes?.includes( attribute ) &&
+				! BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS.includes( blockName ) &&
+				Object.keys( compatibleFields ).length > 0;
+
+			return { isBindable, compatibleFields };
+		},
+		[ attribute, blockName, blockContext ]
+	);
+}

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -92,7 +92,13 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 	}
 
 	return (
-		<InspectorControls group="bindings">
+		<InspectorControls
+			group={
+				window?.__experimentalContentOnlyInspectorFields
+					? 'content'
+					: 'bindings'
+			}
+		>
 			<ToolsPanel
 				label={ __( 'Attributes' ) }
 				resetAll={ () => {

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -19,22 +19,11 @@ import {
 	BlockBindingsAttributeControl,
 	useBlockBindingsUtils,
 } from '../components/block-bindings';
+import { BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS } from '../components/block-bindings/excluded-blocks';
 import { unlock } from '../lock-unlock';
 import InspectorControls from '../components/inspector-controls';
 import BlockContext from '../components/block-context';
 import { store as blockEditorStore } from '../store';
-
-/**
- * Block names for which the legacy "Attributes" Block Bindings panel is not
- * rendered. The new inline picker also uses this list (via
- * `useBlockBindingsCompatibleFields`) so the gating logic is a single source
- * of truth — see spec req 17.
- */
-export const BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS = [
-	'core/post-date',
-	'core/navigation-link',
-	'core/navigation-submenu',
-];
 
 const useToolsPanelDropdownMenuProps = () => {
 	const isMobile = useViewportMatch( 'medium', '<' );

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -24,6 +24,18 @@ import InspectorControls from '../components/inspector-controls';
 import BlockContext from '../components/block-context';
 import { store as blockEditorStore } from '../store';
 
+/**
+ * Block names for which the legacy "Attributes" Block Bindings panel is not
+ * rendered. The new inline picker also uses this list (via
+ * `useBlockBindingsCompatibleFields`) so the gating logic is a single source
+ * of truth — see spec req 17.
+ */
+export const BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS = [
+	'core/post-date',
+	'core/navigation-link',
+	'core/navigation-submenu',
+];
+
 const useToolsPanelDropdownMenuProps = () => {
 	const isMobile = useViewportMatch( 'medium', '<' );
 	return ! isMobile
@@ -119,10 +131,6 @@ export default {
 	edit: BlockBindingsPanel,
 	attributeKeys: [ 'metadata' ],
 	hasSupport( name ) {
-		return ! [
-			'core/post-date',
-			'core/navigation-link',
-			'core/navigation-submenu',
-		].includes( name );
+		return ! BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS.includes( name );
 	},
 };


### PR DESCRIPTION
> **Status: NOT FOR REVIEW** — opened to check the changes and CI. May be closed in the future.

Split 2 of 3 carved out of #75022 (Block Bindings into Block Fields). See the umbrella issue for the full scope.

## Scope

Pure refactor + tests. Extracts the picker gate into a single source of truth shared by the legacy `BlockBindingsAttributeControl` panel and (later) the inline picker.

- `refactor(block-editor)`: extract `BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS`
- `refactor(block-editor)`: relocate `BlockBindingsPanel` to the Content tab when the flag is on
- `feat(block-editor)`: add `useBlockBindingsCompatibleFields` hook
- `refactor(block-editor)`: use shared compatible-fields hook in `BlockBindingsAttributeControl`
- `test(block-editor)`: unit tests for `useBlockBindingsCompatibleFields`
- `refactor(block-editor)`: tighten compatible-fields hook and extract excluded-blocks module

## Diff size

6 files / +383 / -49 (≈300 of which are unit tests)

## Stack

- A — visual indicator on DataForm (`try/75022-A-visual-indicator`)
- B (this) — shared hook + panel relocation
- C — inline picker on RichText, depends on A + B (`try/75022-C-inline-picker`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)