### PR TITLE
Block Bindings: inline picker on RichText block field (split 3/3 of #75022)

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Block Bindings: Surface a connect/disconnect picker inline next to RichText and plain-text Block Fields, gated behind `window.__experimentalContentOnlyInspectorFields`. Relocates the legacy "Attributes" panel to the Content tab when the flag is on; behavior is unchanged when the flag is off ([#75022](https://github.com/WordPress/gutenberg/issues/75022)).
+
 ### Bug Fixes
 
 -   `ColorPanel`: Theme CSS custom-property gradients are now decoded to their preset slug and persisted as a `gradient` block attribute rather than as a raw `style.color.gradient` value ([#78328](https://github.com/WordPress/gutenberg/pull/78328)).

--- a/packages/block-editor/src/hooks/block-fields/connected-button.js
+++ b/packages/block-editor/src/hooks/block-fields/connected-button.js
@@ -7,7 +7,7 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useContext } from '@wordpress/element';
+import { forwardRef, useContext } from '@wordpress/element';
 import { connection, linkOff } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
@@ -41,19 +41,22 @@ const { Menu } = unlock( componentsPrivateApis );
  * @param {Object}  props
  * @param {boolean} props.isConnected Whether the field is currently bound.
  */
-export function ConnectedButton( { isConnected, ...props } ) {
-	const label = isConnected ? __( 'Disconnect' ) : __( 'Connect' );
+export const ConnectedButton = forwardRef(
+	( { isConnected, ...props }, ref ) => {
+		const label = isConnected ? __( 'Disconnect' ) : __( 'Connect' );
 
-	return (
-		<Button
-			{ ...props }
-			size="small"
-			icon={ isConnected ? connection : linkOff }
-			iconSize={ 24 }
-			label={ label }
-		/>
-	);
-}
+		return (
+			<Button
+				ref={ ref }
+				{ ...props }
+				size="small"
+				icon={ isConnected ? connection : linkOff }
+				iconSize={ 24 }
+				label={ label }
+			/>
+		);
+	}
+);
 
 export default ConnectedButton;
 

--- a/packages/block-editor/src/hooks/block-fields/connected-button.js
+++ b/packages/block-editor/src/hooks/block-fields/connected-button.js
@@ -4,22 +4,150 @@
 import {
 	Button,
 	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useContext } from '@wordpress/element';
 import { connection, linkOff } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+import { useViewportMatch } from '@wordpress/compose';
 
-export default function ConnectedButton( { isConnected, ...props } ) {
+/**
+ * Internal dependencies
+ */
+import BlockContext from '../../components/block-context';
+import { useBlockEditContext } from '../../components/block-edit';
+import {
+	BlockBindingsSourceFieldsList,
+	useBlockBindingsCompatibleFields,
+} from '../../components/block-bindings';
+import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { Menu } = unlock( componentsPrivateApis );
+
+/**
+ * Bare `<Button>` rendered as the Block Bindings indicator/trigger. Kept
+ * deliberately free of wrappers so it can be passed to
+ * `Menu.TriggerButton render={ <ConnectedButton ... /> }`: Ariakit places
+ * `aria-expanded`, `aria-haspopup`, ref, and keyboard handlers on this
+ * `<button>` directly. The same element is rendered in both bound and
+ * unbound states (only `icon` and `label` change), preserving the
+ * no-remount guarantee from spec req 4 / AC2.
+ *
+ * Exported as both named and default for backwards compatibility with the
+ * cherry-pick's `import ConnectedButton from './connected-button';`.
+ *
+ * @param {Object}  props
+ * @param {boolean} props.isConnected Whether the field is currently bound.
+ */
+export function ConnectedButton( { isConnected, ...props } ) {
 	const label = isConnected ? __( 'Disconnect' ) : __( 'Connect' );
 
 	return (
+		<Button
+			{ ...props }
+			size="small"
+			icon={ isConnected ? connection : linkOff }
+			iconSize={ 24 }
+			label={ label }
+		/>
+	);
+}
+
+export default ConnectedButton;
+
+/**
+ * Suffix-wrapped variant of `ConnectedButton` for DataForm controls that
+ * render inside an `InputControl`-aware container (the auto-suffix path in
+ * `block-fields/index.js`). The wrapper sits OUTSIDE the Ariakit trigger
+ * boundary so it does not collect `aria-expanded`.
+ *
+ * @param {Object} props Same props as `ConnectedButton`.
+ */
+export function ConnectedButtonSuffix( props ) {
+	return (
 		<InputControlSuffixWrapper variant="control">
-			<Button
-				{ ...props }
-				size="small"
-				icon={ isConnected ? connection : linkOff }
-				iconSize={ 24 }
-				label={ label }
-			/>
+			<ConnectedButton { ...props } />
 		</InputControlSuffixWrapper>
+	);
+}
+
+/**
+ * Interactive Block Bindings picker mounted next to a Block Field.
+ *
+ * Consumes `useBlockBindingsCompatibleFields` (the single gate predicate)
+ * and returns `null` when the field is not bindable. Otherwise it renders
+ * a `Menu` whose trigger is the bare `ConnectedButton` and whose popover
+ * reuses `BlockBindingsSourceFieldsList` verbatim (spec req 6).
+ *
+ * The disconnect interaction is delegated to `BlockBindingsSourceFieldsList`'s
+ * existing `Menu.CheckboxItem` semantics (re-select the checked item to
+ * disconnect — spec req 8, AC5).
+ *
+ * @param {Object}  props
+ * @param {string}  props.attribute   The block attribute name.
+ * @param {string}  props.blockName   The block name (e.g. 'core/paragraph').
+ * @param {boolean} props.isConnected Whether the attribute is bound.
+ * @param {boolean} [props.asSuffix]  When true, wrap the trigger in
+ *                                    `InputControlSuffixWrapper` for the
+ *                                    DataForm auto-suffix path.
+ */
+export function GatedConnectedButton( {
+	attribute,
+	blockName,
+	isConnected,
+	asSuffix = false,
+} ) {
+	const { clientId } = useBlockEditContext();
+	const blockContext = useContext( BlockContext );
+	const isMobile = useViewportMatch( 'medium', '<' );
+	const { isBindable, compatibleFields } = useBlockBindingsCompatibleFields(
+		attribute,
+		blockName,
+		blockContext
+	);
+	const binding = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockAttributes( clientId )?.metadata
+				?.bindings?.[ attribute ],
+		[ clientId, attribute ]
+	);
+
+	if ( ! isBindable ) {
+		return null;
+	}
+
+	const trigger = (
+		<Menu.TriggerButton
+			render={ <ConnectedButton isConnected={ isConnected } /> }
+		/>
+	);
+
+	return (
+		<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>
+			{ asSuffix ? (
+				<InputControlSuffixWrapper variant="control">
+					{ trigger }
+				</InputControlSuffixWrapper>
+			) : (
+				trigger
+			) }
+			<Menu.Popover gutter={ isMobile ? 8 : 36 }>
+				<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>
+					{ Object.entries( compatibleFields ).map(
+						( [ sourceKey, fields ] ) => (
+							<BlockBindingsSourceFieldsList
+								key={ sourceKey }
+								args={ binding?.args }
+								attribute={ attribute }
+								sourceKey={ sourceKey }
+								fields={ fields }
+							/>
+						)
+					) }
+				</Menu>
+			</Menu.Popover>
+		</Menu>
 	);
 }

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -22,7 +22,7 @@ const { fieldsKey, formKey } = unlock( blocksPrivateApis );
 import FieldsDropdownMenu from './fields-dropdown-menu';
 import { PrivateBlockContext } from '../../components/block-list/private-block-context';
 import InspectorControls from '../../components/inspector-controls/fill';
-import ConnectedButton from './connected-button';
+import { GatedConnectedButton } from './connected-button';
 
 // controls
 import RichText from './rich-text';
@@ -160,13 +160,28 @@ function BlockFields( {
 			} else if ( ! fieldDef.Edit ) {
 				field.Edit = {
 					control: fieldDef.type,
-					suffix: ConnectedButton,
+					// Closure captures attribute (fieldDef.id) + blockName
+					// at field-construction time. `blockContext` is read
+					// from React context inside the picker (spec req 10:
+					// no DataForm restructuring, no field.connectionMeta).
+					// When `isBindable` is false the picker returns null;
+					// the wrapped `ConnectedButtonSuffix` variant is used
+					// to retain the InputControl suffix slot for the
+					// `asSuffix` branch (preserving cherry-pick layout).
+					suffix: ( { isConnected } ) => (
+						<GatedConnectedButton
+							attribute={ fieldDef.id }
+							blockName={ blockType.name }
+							isConnected={ isConnected }
+							asSuffix
+						/>
+					),
 				};
 			}
 
 			return field;
 		} );
-	}, [ blockTypeFields, clientId ] );
+	}, [ blockTypeFields, blockType?.name, clientId ] );
 
 	if ( ! blockTypeFields?.length ) {
 		// TODO - we might still want to show a placeholder for blocks with no fields.

--- a/packages/block-editor/src/hooks/block-fields/rich-text/index.js
+++ b/packages/block-editor/src/hooks/block-fields/rich-text/index.js
@@ -22,6 +22,8 @@ import {
 	keyboardShortcutContext,
 	inputEventContext,
 } from '../../../components/rich-text';
+import { useBlockEditContext } from '../../../components/block-edit';
+import { GatedConnectedButton } from '../connected-button';
 import { unlock } from '../../../lock-unlock';
 
 const { useRichText } = unlock( richTextPrivateApis );
@@ -34,6 +36,7 @@ export default function RichTextControl( {
 	config = {},
 } ) {
 	const registry = useRegistry();
+	const { name: blockName } = useBlockEditContext();
 	const isBound = field.id in ( data?.metadata?.bindings || {} );
 	const attrValue = field.getValue( { item: data } );
 	const fieldConfig = field.config || {};
@@ -135,6 +138,11 @@ export default function RichTextControl( {
 					onBlur={ () => setIsSelected( false ) }
 					contentEditable
 					{ ...controlProps }
+				/>
+				<GatedConnectedButton
+					attribute={ field.id }
+					blockName={ blockName }
+					isConnected={ isBound }
 				/>
 			</BaseControl>
 		</>

--- a/test/e2e/specs/editor/various/block-bindings/block-fields-inline-picker.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/block-fields-inline-picker.spec.js
@@ -6,7 +6,31 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 /**
  * Inline Block Bindings picker — Block Fields integration.
  *
- * Covers AC1-AC15 from spec.md §4. The new picker is gated behind
+ * Covers AC1-AC15 from spec.md §4 with the following allocations:
+ * - AC1 (RichText half): integration test below ("renders is-connected
+ *   border on bound RichText fields"). The Text DataForm `is-connected`
+ *   half of AC1 is verified via manual checklist in spec §5 alongside
+ *   the Media border (the cherry-pick already ships both; no production
+ *   change in this pipeline alters either DOM path).
+ * - AC2-AC5, AC9-AC13, AC15: integration tests below.
+ * - AC6 (req 11a "attribute not in supported list"): unit test #4 in
+ *   `use-block-bindings-compatible-fields.js`
+ *   (`returns isBindable=false when attribute is not in
+ *   __experimentalBlockBindingsSupportedAttributes`). The e2e is
+ *   `test.skip`ped — see comment on the skipped test for the
+ *   no-naturally-occurring-block rationale.
+ * - AC7 (req 11b/17 exclusion list): unit test #5
+ *   (`returns isBindable=false for blocks in
+ *   BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS`). Same `test.skip` rationale.
+ * - AC8 (req 11c "no compatible source for any source"): spec §5
+ *   manual verification checklist. No real registered source + real
+ *   block combination naturally yields zero compatible fields without
+ *   also tripping a different gate (11a or 11d), and adding a dedicated
+ *   typed source to the e2e plugin fixture is outside the iteration-2
+ *   fix scope.
+ * - AC14 (backport changelog): file presence, not an e2e.
+ *
+ * The new picker is gated behind
  * `window.__experimentalContentOnlyInspectorFields`, so each test that opts
  * into the flag MUST set it BEFORE inserting blocks / opening the inspector
  * (the flag is read once at first render of the relevant subtree per the
@@ -45,10 +69,15 @@ test.describe( 'Block Fields inline picker', () => {
 			await admin.createNewPost( { title: 'Inline picker tests' } );
 		} );
 
-		test( 'renders is-connected border on bound RichText and Text fields (AC1)', async ( {
+		test( 'renders is-connected border on bound RichText fields (AC1 — RichText half)', async ( {
 			editor,
 			page,
 		} ) => {
+			// Scope: only the RichText `is-connected` border. The Text
+			// DataForm `is-connected` half and the Media `is-connected`
+			// half of AC1 are both ship-from-cherry-pick paths that no
+			// production code in this pipeline touches; they are verified
+			// per the spec §5 manual checklist instead of an e2e here.
 			await editor.insertBlock( {
 				name: 'core/paragraph',
 				attributes: {
@@ -192,62 +221,51 @@ test.describe( 'Block Fields inline picker', () => {
 			).toBeVisible();
 		} );
 
-		test( 'attribute not in supported list hides ConnectedButton (AC6)', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( {
-				name: 'core/heading',
-				attributes: { content: 'heading content', level: 2 },
-			} );
-
-			// `level` is enum-typed and not in supported attrs; no picker.
-			// Heading's `content` IS bindable, so we should still see one
-			// Connect button, but not multiple (one per non-bindable field).
-			const connectButtons = page.getByRole( 'button', {
-				name: 'Connect',
-			} );
-			await expect( connectButtons ).toHaveCount( 1 );
-		} );
+		// AC6 verification deferred to the `useBlockBindingsCompatibleFields`
+		// unit test #4 (`returns isBindable=false when attribute is not in
+		// __experimentalBlockBindingsSupportedAttributes`). Iteration-1 e2e
+		// inserted `core/heading` to test this gate, but Heading's only
+		// registered Block Field is `content` — which IS in the supported
+		// attribute list — so the assertion "exactly one Connect button"
+		// passed trivially without ever triggering gate 11a. No real block
+		// in trunk registers a Block Field whose `id` is absent from
+		// `__experimentalBlockBindingsSupportedAttributes[blockName]` AND
+		// whose type is one a registered source actually fulfills (so
+		// isolating gate 11a from gates 11c/11d at the e2e level would
+		// require a dedicated test block / source pair — added value over
+		// the unit test is nil per spec §5 Unit fallback).
+		// eslint-disable-next-line playwright/no-skipped-test, playwright/expect-expect
+		test.skip( 'attribute not in supported list hides ConnectedButton (AC6) — covered by unit test #4', () => {} );
 
 		// AC7 verification deferred to the `useBlockBindingsCompatibleFields`
-		// unit test (Task 8) — `core/post-date`, `core/navigation-link`,
+		// unit test #5 — `core/post-date`, `core/navigation-link`,
 		// `core/navigation-submenu` do not register `fieldsKey` arrays today,
 		// so the Content tab is empty for them and an integration assertion
 		// would be vacuous. The unit test exercises the gate predicate for
 		// blocks in `BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS` directly per spec
 		// §5 Unit fallback.
+		// eslint-disable-next-line playwright/no-skipped-test, playwright/expect-expect
+		test.skip( 'block in BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS hides ConnectedButton (AC7) — covered by unit test #5', () => {} );
 
-		test( 'no compatible source hides ConnectedButton; passive border still renders for already-bound (AC8)', async ( {
-			editor,
-			page,
-		} ) => {
-			// Insert a paragraph already bound to a source whose key is no
-			// longer available (simulated by binding to a non-existent
-			// fieldsList key). The cherry-pick's `is-connected` border MUST
-			// still render even though `ConnectedButton` should not.
-			await editor.insertBlock( {
-				name: 'core/paragraph',
-				attributes: {
-					content: 'bound paragraph',
-					metadata: {
-						bindings: {
-							content: {
-								source: 'testing/server-only-source',
-								args: { key: 'nonexistent' },
-							},
-						},
-					},
-				},
-			} );
-
-			// Passive border still rendered (cherry-pick behavior).
-			await expect(
-				page.locator(
-					'.block-editor-content-only-controls__rich-text.is-connected'
-				)
-			).toBeVisible();
-		} );
+		// AC8 verification deferred to spec §5 Manual checklist
+		// ("Toggling `window.__experimentalContentOnlyInspectorFields`
+		// between true/false ..." plus the inspect-without-console-errors
+		// rows for blocks bound to sources without compatible fields).
+		// Iteration-1 e2e inserted a paragraph bound to
+		// `testing/server-only-source` (no client `getFieldsList`) and
+		// asserted only the passive border, never the picker absence. Worse,
+		// `testing/complete-source` (also registered by the test plugin)
+		// exposes string-typed fields compatible with paragraph `content`
+		// (rich-text → string), so gate 11c never actually triggered. No
+		// realistic combination of the registered test sources + blocks
+		// yields zero compatible fields for a Block-Fields-bearing
+		// attribute without also tripping a different gate (11a/11d).
+		// Adding a dedicated test source whose `getFieldsList` returns
+		// only types no Block Field exposes would require touching the
+		// `gutenberg-test-block-bindings` plugin fixture, which is
+		// outside the iteration-2 fix scope (test file only).
+		// eslint-disable-next-line playwright/no-skipped-test, playwright/expect-expect
+		test.skip( 'no compatible source hides ConnectedButton (AC8) — covered by spec §5 manual checklist', () => {} );
 
 		test( 'canUpdateBlockBindings=false hides ConnectedButton; border still renders (AC9)', async ( {
 			editor,

--- a/test/e2e/specs/editor/various/block-bindings/block-fields-inline-picker.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/block-fields-inline-picker.spec.js
@@ -1,0 +1,429 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/**
+ * Inline Block Bindings picker — Block Fields integration.
+ *
+ * Covers AC1-AC15 from spec.md §4. The new picker is gated behind
+ * `window.__experimentalContentOnlyInspectorFields`, so each test that opts
+ * into the flag MUST set it BEFORE inserting blocks / opening the inspector
+ * (the flag is read once at first render of the relevant subtree per the
+ * dual-gating decision in plan §A5).
+ */
+
+/**
+ * Enables the experimental Block Fields Content tab. Must be called in
+ * `addInitScript` so the flag is set on every page load before any block
+ * renders.
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+async function enableContentOnlyInspectorFields( page ) {
+	await page.addInitScript( () => {
+		window.__experimentalContentOnlyInspectorFields = true;
+	} );
+}
+
+test.describe( 'Block Fields inline picker', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin( 'gutenberg-test-block-bindings' );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin( 'gutenberg-test-block-bindings' );
+	} );
+
+	test.describe( 'flag on', () => {
+		test.beforeEach( async ( { admin, page } ) => {
+			await enableContentOnlyInspectorFields( page );
+			await admin.createNewPost( { title: 'Inline picker tests' } );
+		} );
+
+		test( 'renders is-connected border on bound RichText and Text fields (AC1)', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'bound paragraph',
+					metadata: {
+						bindings: {
+							content: {
+								source: 'testing/complete-source',
+								args: { key: 'text_field' },
+							},
+						},
+					},
+				},
+			} );
+
+			// The Content tab is the default for Block Fields-supporting blocks.
+			const richTextField = page.locator(
+				'.block-editor-content-only-controls__rich-text.is-connected'
+			);
+			await expect( richTextField ).toBeVisible();
+		} );
+
+		test( 'ConnectedButton swaps icon and label across bound state without remount (AC2)', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'unbound paragraph' },
+			} );
+
+			const connectButton = page.getByRole( 'button', {
+				name: 'Connect',
+			} );
+			await expect( connectButton ).toBeVisible();
+
+			// Tag the live <button> DOM node so we can verify it is the SAME
+			// node after the bound/unbound transition (spec req 4, AC2).
+			await connectButton.evaluate( ( el ) => {
+				el.dataset.noRemountMarker = 'inline-picker';
+			} );
+
+			// Bind via the picker.
+			await connectButton.click();
+			await page
+				.getByRole( 'menuitem', { name: 'Complete Source' } )
+				.click();
+			await page
+				.getByRole( 'menuitemcheckbox', { name: 'Text Field Label' } )
+				.click();
+
+			// Same DOM node, new accessible name + icon.
+			const disconnectButton = page.getByRole( 'button', {
+				name: 'Disconnect',
+			} );
+			await expect( disconnectButton ).toBeVisible();
+			await expect( disconnectButton ).toHaveAttribute(
+				'data-no-remount-marker',
+				'inline-picker'
+			);
+		} );
+
+		test( 'click ConnectedButton opens picker listing compatible sources (AC3, AC4)', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'unbound paragraph' },
+			} );
+
+			await page.getByRole( 'button', { name: 'Connect' } ).click();
+			await expect(
+				page.getByRole( 'menuitem', { name: 'Complete Source' } )
+			).toBeVisible();
+
+			// Drill into the source, select the first compatible field.
+			await page
+				.getByRole( 'menuitem', { name: 'Complete Source' } )
+				.click();
+			await page
+				.getByRole( 'menuitemcheckbox', { name: 'Text Field Label' } )
+				.click();
+
+			// `is-connected` border applied; ConnectedButton flipped to
+			// "Disconnect".
+			await expect(
+				page.locator(
+					'.block-editor-content-only-controls__rich-text.is-connected'
+				)
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'button', { name: 'Disconnect' } )
+			).toBeVisible();
+		} );
+
+		test( 're-selecting the checked item in the picker disconnects (AC5)', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'bound paragraph',
+					metadata: {
+						bindings: {
+							content: {
+								source: 'testing/complete-source',
+								args: { key: 'text_field' },
+							},
+						},
+					},
+				},
+			} );
+
+			const disconnectButton = page.getByRole( 'button', {
+				name: 'Disconnect',
+			} );
+			await disconnectButton.click();
+
+			// Picker opens with the active item checked. Drill in and toggle
+			// it off.
+			await page
+				.getByRole( 'menuitem', { name: 'Complete Source' } )
+				.click();
+			const checkedItem = page.getByRole( 'menuitemcheckbox', {
+				name: 'Text Field Label',
+				checked: true,
+			} );
+			await expect( checkedItem ).toBeVisible();
+			await checkedItem.click();
+
+			// Border removed, ConnectedButton flipped back to "Connect".
+			await expect(
+				page.locator(
+					'.block-editor-content-only-controls__rich-text.is-connected'
+				)
+			).toHaveCount( 0 );
+			await expect(
+				page.getByRole( 'button', { name: 'Connect' } )
+			).toBeVisible();
+		} );
+
+		test( 'attribute not in supported list hides ConnectedButton (AC6)', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/heading',
+				attributes: { content: 'heading content', level: 2 },
+			} );
+
+			// `level` is enum-typed and not in supported attrs; no picker.
+			// Heading's `content` IS bindable, so we should still see one
+			// Connect button, but not multiple (one per non-bindable field).
+			const connectButtons = page.getByRole( 'button', {
+				name: 'Connect',
+			} );
+			await expect( connectButtons ).toHaveCount( 1 );
+		} );
+
+		// AC7 verification deferred to the `useBlockBindingsCompatibleFields`
+		// unit test (Task 8) — `core/post-date`, `core/navigation-link`,
+		// `core/navigation-submenu` do not register `fieldsKey` arrays today,
+		// so the Content tab is empty for them and an integration assertion
+		// would be vacuous. The unit test exercises the gate predicate for
+		// blocks in `BLOCK_BINDINGS_PANEL_EXCLUDED_BLOCKS` directly per spec
+		// §5 Unit fallback.
+
+		test( 'no compatible source hides ConnectedButton; passive border still renders for already-bound (AC8)', async ( {
+			editor,
+			page,
+		} ) => {
+			// Insert a paragraph already bound to a source whose key is no
+			// longer available (simulated by binding to a non-existent
+			// fieldsList key). The cherry-pick's `is-connected` border MUST
+			// still render even though `ConnectedButton` should not.
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'bound paragraph',
+					metadata: {
+						bindings: {
+							content: {
+								source: 'testing/server-only-source',
+								args: { key: 'nonexistent' },
+							},
+						},
+					},
+				},
+			} );
+
+			// Passive border still rendered (cherry-pick behavior).
+			await expect(
+				page.locator(
+					'.block-editor-content-only-controls__rich-text.is-connected'
+				)
+			).toBeVisible();
+		} );
+
+		test( 'canUpdateBlockBindings=false hides ConnectedButton; border still renders (AC9)', async ( {
+			editor,
+			page,
+		} ) => {
+			// Lock down bindings via editor settings BEFORE inserting the
+			// block so the gate observes the false value on first render.
+			await page.evaluate( () => {
+				window.wp.data
+					.dispatch( 'core/block-editor' )
+					.updateSettings( { canUpdateBlockBindings: false } );
+			} );
+
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'bound paragraph',
+					metadata: {
+						bindings: {
+							content: {
+								source: 'testing/complete-source',
+								args: { key: 'text_field' },
+							},
+						},
+					},
+				},
+			} );
+
+			// ConnectedButton absent in both bound and unbound states.
+			await expect(
+				page.getByRole( 'button', { name: 'Connect' } )
+			).toHaveCount( 0 );
+			await expect(
+				page.getByRole( 'button', { name: 'Disconnect' } )
+			).toHaveCount( 0 );
+
+			// Passive border still rendered.
+			await expect(
+				page.locator(
+					'.block-editor-content-only-controls__rich-text.is-connected'
+				)
+			).toBeVisible();
+		} );
+
+		test( 'legacy Attributes panel appears in Content tab, not Settings (AC10)', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'paragraph for legacy panel' },
+			} );
+
+			// Content tab is the default with the experimental flag on.
+			await expect(
+				page
+					.getByRole( 'tabpanel', { name: 'Content' } )
+					.getByLabel( 'Attributes options' )
+			).toBeVisible();
+
+			// Settings tab MUST NOT host the Attributes panel anymore.
+			await page.getByRole( 'tab', { name: 'Settings' } ).click();
+			await expect(
+				page
+					.getByRole( 'tabpanel', { name: 'Settings' } )
+					.getByLabel( 'Attributes options' )
+			).toBeHidden();
+		} );
+
+		test( 'inline picker and legacy panel reflect each others edits (AC12)', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'paragraph' },
+			} );
+
+			// Bind via the inline picker.
+			await page.getByRole( 'button', { name: 'Connect' } ).click();
+			await page
+				.getByRole( 'menuitem', { name: 'Complete Source' } )
+				.click();
+			await page
+				.getByRole( 'menuitemcheckbox', { name: 'Text Field Label' } )
+				.click();
+
+			// Legacy panel (same Content tab) shows the new binding text on
+			// the `content` attribute row.
+			const legacyContentRow = page
+				.getByRole( 'tabpanel', { name: 'Content' } )
+				.getByRole( 'button', { name: /^content/ } );
+			await expect( legacyContentRow ).toContainText(
+				'Text Field Label'
+			);
+		} );
+
+		test( 'reset-all in legacy panel clears inline-picker bindings (AC15)', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'paragraph' },
+			} );
+
+			// Bind via the inline picker first.
+			await page.getByRole( 'button', { name: 'Connect' } ).click();
+			await page
+				.getByRole( 'menuitem', { name: 'Complete Source' } )
+				.click();
+			await page
+				.getByRole( 'menuitemcheckbox', { name: 'Text Field Label' } )
+				.click();
+
+			// Confirm bound state via the inline ConnectedButton.
+			await expect(
+				page.getByRole( 'button', { name: 'Disconnect' } )
+			).toBeVisible();
+
+			// Reset all bindings via the legacy panel's ToolsPanel menu.
+			await page.getByLabel( 'Attributes options' ).click();
+			await page.getByRole( 'menuitem', { name: 'Reset all' } ).click();
+
+			// Inline UI flipped back to unbound; passive border gone.
+			await expect(
+				page.getByRole( 'button', { name: 'Connect' } )
+			).toBeVisible();
+			await expect(
+				page.locator(
+					'.block-editor-content-only-controls__rich-text.is-connected'
+				)
+			).toHaveCount( 0 );
+		} );
+	} );
+
+	test.describe( 'flag off', () => {
+		test.beforeEach( async ( { admin } ) => {
+			// Do NOT set `__experimentalContentOnlyInspectorFields`.
+			await admin.createNewPost( { title: 'Inline picker tests' } );
+		} );
+
+		test( 'legacy Attributes panel remains in Settings tab (AC11)', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'paragraph' },
+			} );
+
+			await page.getByRole( 'tab', { name: 'Settings' } ).click();
+			await expect(
+				page
+					.getByRole( 'tabpanel', { name: 'Settings' } )
+					.getByLabel( 'Attributes options' )
+			).toBeVisible();
+		} );
+
+		test( 'ConnectedButton is absent for all fields (AC13)', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'paragraph' },
+			} );
+
+			// The new picker UI is gated on the experimental flag — absent
+			// means no Connect/Disconnect buttons anywhere in the inspector.
+			await expect(
+				page.getByRole( 'button', { name: 'Connect' } )
+			).toHaveCount( 0 );
+			await expect(
+				page.getByRole( 'button', { name: 'Disconnect' } )
+			).toHaveCount( 0 );
+		} );
+	} );
+} );


### PR DESCRIPTION
> **Status: NOT FOR REVIEW** — opened to check the changes and CI. May be closed in the future.

Split 3 of 3 carved out of #75022 (Block Bindings into Block Fields). See the umbrella issue for the full scope.

> ⚠️ **Base branch is `try/75022-AB-base`** — a helper integration branch that includes splits A and B so this PR's diff stays small (5 files). When A (#78722) and B (#78723) merge to trunk, this PR will be rebased onto trunk.

## Scope

Adds the interactive inline picker on top of the static visual indicator (PR A) using the shared gate hook (PR B). End-user-visible new UX.

- `feat(block-editor)`: split `ConnectedButton` and add interactive picker wrapper
- `feat(block-editor)`: gate text DataForm `ConnectedButton` via shared hook
- `feat(block-editor)`: mount interactive `ConnectedButton` on RichText block field
- `test(block-editor)`: e2e coverage for inline Block Bindings picker (+ tightening)
- `docs(block-editor)`: changelog entry
- `fix(block-editor)`: wrap `ConnectedButton` in `forwardRef`

## Diff size

5 files / +612 / -7 vs `try/75022-AB-base` (≈500 of which are e2e tests).
19 files / +1080 / -64 vs `trunk` (= the full umbrella scope).

## Stack

- A — visual indicator on DataForm (#78722)
- B — shared hook + panel relocation (#78723)
- C (this) — depends on A + B

🤖 Generated with [Claude Code](https://claude.com/claude-code)