### PR TITLE
Compose: Fix SSR crash in useMediaQuery and useViewportMatch

### DIFF
--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 -   `useCopyToClipboard`: Call the `onSuccess` callback even when the trigger node unmounts before the copy resolves ([#78387](https://github.com/WordPress/gutenberg/pull/78387)).
 -   `useDialog`: Handle Escape via React `onKeyDown` so portaled descendants can stop propagation to prevent the dialog from closing ([#78433](https://github.com/WordPress/gutenberg/pull/78433)).
+-   `useMediaQuery`, `useViewportMatch`: Resolve the `view` default lazily so the hooks no longer throw `ReferenceError: window is not defined` during server-side rendering. Regression from [#76446](https://github.com/WordPress/gutenberg/pull/76446).
 
 ### Deprecations
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -597,7 +597,7 @@ _Parameters_
 
 -   _breakpoint_ `WPBreakpoint`: Breakpoint size name.
 -   _operator_ `[WPViewportOperator]`: Viewport operator.
--   _view_ `[Window]`: Window instance in which to perform viewport matching.
+-   _view_ `[Window|undefined]`: Window instance in which to perform viewport matching.
 
 _Returns_
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -435,7 +435,7 @@ Runs a media query and returns its value when it changes.
 _Parameters_
 
 -   _query_ `[string]`: Media Query.
--   _view_ `[Window]`: Window instance, else default to global window
+-   _view_ `[Window | undefined]`: Window instance, else default to global window
 
 _Returns_
 

--- a/packages/compose/src/hooks/use-media-query/index.ts
+++ b/packages/compose/src/hooks/use-media-query/index.ts
@@ -19,8 +19,11 @@ const EMPTY_SUBSCRIBER: MQLSubscriber = {
 	getValue: () => false,
 };
 
-function getMQLSubscriber( view: Window, query?: string ): MQLSubscriber {
-	if ( ! query || typeof view?.matchMedia !== 'function' ) {
+function getMQLSubscriber(
+	view: Window | undefined,
+	query?: string
+): MQLSubscriber {
+	if ( ! view || ! query || typeof view.matchMedia !== 'function' ) {
 		return EMPTY_SUBSCRIBER;
 	}
 
@@ -75,7 +78,11 @@ function getMQLSubscriber( view: Window, query?: string ): MQLSubscriber {
  */
 export default function useMediaQuery(
 	query?: string,
-	view: Window = window
+	// Resolve the default lazily so SSR (where `window` is undeclared) does not
+	// throw a ReferenceError when this default expression is evaluated.
+	view: Window | undefined = typeof window !== 'undefined'
+		? window
+		: undefined
 ): boolean {
 	const source = getMQLSubscriber( view, query );
 

--- a/packages/compose/src/hooks/use-media-query/test/ssr.js
+++ b/packages/compose/src/hooks/use-media-query/test/ssr.js
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * External dependencies
+ */
+import { renderToString } from 'react-dom/server';
+
+/**
+ * Internal dependencies
+ */
+import useMediaQuery from '../';
+import useViewportMatch from '../../use-viewport-match';
+
+const MediaQueryComponent = ( { query } ) => {
+	const result = useMediaQuery( query );
+	return `useMediaQuery: ${ result }`;
+};
+
+const ViewportMatchComponent = ( { breakpoint, operator } ) => {
+	const result = useViewportMatch( breakpoint, operator );
+	return `useViewportMatch: ${ result }`;
+};
+
+describe( 'compose hooks in a server (no-window) environment', () => {
+	it( 'useMediaQuery renders to false without throwing when window is undefined', () => {
+		expect( typeof window ).toBe( 'undefined' );
+		expect(
+			renderToString( <MediaQueryComponent query="(min-width: 782px)" /> )
+		).toBe( 'useMediaQuery: false' );
+	} );
+
+	it( 'useMediaQuery renders to false when no query is provided', () => {
+		expect( renderToString( <MediaQueryComponent /> ) ).toBe(
+			'useMediaQuery: false'
+		);
+	} );
+
+	it( 'useViewportMatch renders to false without throwing when window is undefined', () => {
+		expect(
+			renderToString(
+				<ViewportMatchComponent breakpoint="small" operator=">=" />
+			)
+		).toBe( 'useViewportMatch: false' );
+	} );
+} );

--- a/packages/compose/src/hooks/use-viewport-match/index.js
+++ b/packages/compose/src/hooks/use-viewport-match/index.js
@@ -75,7 +75,13 @@ ViewportMatchWidthContext.displayName = 'ViewportMatchWidthContext';
  *
  * @return {boolean} Whether viewport matches query.
  */
-const useViewportMatch = ( breakpoint, operator = '>=', view = window ) => {
+const useViewportMatch = (
+	breakpoint,
+	operator = '>=',
+	// Resolve the default lazily so SSR (where `window` is undeclared) does not
+	// throw a ReferenceError when this default expression is evaluated.
+	view = typeof window !== 'undefined' ? window : undefined
+) => {
 	const simulatedWidth = useContext( ViewportMatchWidthContext );
 	const mediaQuery =
 		! simulatedWidth &&

--- a/packages/compose/src/hooks/use-viewport-match/index.js
+++ b/packages/compose/src/hooks/use-viewport-match/index.js
@@ -64,7 +64,7 @@ ViewportMatchWidthContext.displayName = 'ViewportMatchWidthContext';
  *
  * @param {WPBreakpoint}       breakpoint      Breakpoint size name.
  * @param {WPViewportOperator} [operator=">="] Viewport operator.
- * @param {Window}             [view=window]   Window instance in which to perform viewport matching.
+ * @param {Window|undefined}   [view=window]   Window instance in which to perform viewport matching.
  *
  * @example
  *

--- a/packages/jest-preset-default/scripts/setup-globals.js
+++ b/packages/jest-preset-default/scripts/setup-globals.js
@@ -2,42 +2,50 @@
 // eslint-disable-next-line @wordpress/wp-global-usage
 globalThis.SCRIPT_DEBUG = true;
 
-// These are necessary to load TinyMCE successfully.
-global.window.tinyMCEPreInit = {
-	// Without this, TinyMCE tries to determine its URL by looking at the
-	// <script> tag where it was loaded from, which of course fails here.
-	baseURL: 'about:blank',
-};
+// The remaining globals all hang off `window`, which only exists when the test
+// is using a DOM environment (jsdom). Skip them when running under
+// `@jest-environment node`.
+if ( typeof global.window !== 'undefined' ) {
+	// These are necessary to load TinyMCE successfully.
+	global.window.tinyMCEPreInit = {
+		// Without this, TinyMCE tries to determine its URL by looking at the
+		// <script> tag where it was loaded from, which of course fails here.
+		baseURL: 'about:blank',
+	};
 
-global.window.setImmediate = function ( callback ) {
-	return setTimeout( callback, 0 );
-};
+	global.window.setImmediate = function ( callback ) {
+		return setTimeout( callback, 0 );
+	};
 
-// Ignoring `options` argument since we unconditionally schedule this ASAP.
-global.window.requestIdleCallback = function requestIdleCallback( callback ) {
-	const start = Date.now();
+	// Ignoring `options` argument since we unconditionally schedule this ASAP.
+	global.window.requestIdleCallback = function requestIdleCallback(
+		callback
+	) {
+		const start = Date.now();
 
-	return setTimeout(
-		() =>
-			callback( {
-				didTimeout: false,
-				timeRemaining: () => Math.max( 0, 50 - ( Date.now() - start ) ),
-			} ),
-		0
-	);
-};
+		return setTimeout(
+			() =>
+				callback( {
+					didTimeout: false,
+					timeRemaining: () =>
+						Math.max( 0, 50 - ( Date.now() - start ) ),
+				} ),
+			0
+		);
+	};
 
-global.window.cancelIdleCallback = function cancelIdleCallback( handle ) {
-	return clearTimeout( handle );
-};
+	global.window.cancelIdleCallback = function cancelIdleCallback( handle ) {
+		return clearTimeout( handle );
+	};
 
-global.window.matchMedia = () => ( {
-	matches: false,
-	addListener: () => {},
-	addEventListener: () => {},
-	removeListener: () => {},
-	removeEventListener: () => {},
-} );
+	global.window.matchMedia = () => ( {
+		matches: false,
+		addListener: () => {},
+		addEventListener: () => {},
+		removeListener: () => {},
+		removeEventListener: () => {},
+	} );
 
-// UserSettings global.
-global.window.userSettings = { uid: 1 };
+	// UserSettings global.
+	global.window.userSettings = { uid: 1 };
+}

--- a/test/unit/config/global-mocks.js
+++ b/test/unit/config/global-mocks.js
@@ -65,27 +65,31 @@ jest.mock( 'client-zip', () => ( {
 
 global.ResizeObserver = require( 'resize-observer-polyfill' );
 
-// jsdom lacks Element.getAnimations (needed by Base UI ScrollArea ≥1.3)
-if ( ! global.HTMLElement.prototype.getAnimations ) {
-	global.HTMLElement.prototype.getAnimations = () => [];
-}
+// The following jsdom-targeted setup is skipped when a test opts into
+// `@jest-environment node` so SSR-style tests can run under this config.
+if ( typeof window !== 'undefined' ) {
+	// jsdom lacks Element.getAnimations (needed by Base UI ScrollArea ≥1.3)
+	if ( ! global.HTMLElement.prototype.getAnimations ) {
+		global.HTMLElement.prototype.getAnimations = () => [];
+	}
 
-/**
- * The following mock is for block integration tests that might render
- * components leveraging DOMRect. For example, the Cover block which now renders
- * its ResizableBox control via the BlockPopover component.
- */
-if ( ! window.DOMRect ) {
-	window.DOMRect = class DOMRect {};
-}
+	/**
+	 * The following mock is for block integration tests that might render
+	 * components leveraging DOMRect. For example, the Cover block which now renders
+	 * its ResizableBox control via the BlockPopover component.
+	 */
+	if ( ! window.DOMRect ) {
+		window.DOMRect = class DOMRect {};
+	}
 
-/**
- * Polyfill for Element.scrollIntoView().
- * Necessary because it's not implemented in jsdom, and likely will never be.
- *
- * @see https://github.com/jsdom/jsdom/issues/1695
- */
-global.Element.prototype.scrollIntoView = jest.fn();
+	/**
+	 * Polyfill for Element.scrollIntoView().
+	 * Necessary because it's not implemented in jsdom, and likely will never be.
+	 *
+	 * @see https://github.com/jsdom/jsdom/issues/1695
+	 */
+	global.Element.prototype.scrollIntoView = jest.fn();
+}
 
 if ( ! global.TextDecoder ) {
 	global.TextDecoder = TextDecoder;
@@ -103,8 +107,16 @@ global.File = FilePolyfill;
  * that `@testing-library/user-event` makes non-writable, which breaks
  * `@ariakit/test` and other code that tries to override `focus` and `blur`.
  * @see https://github.com/testing-library/user-event/pull/1265
+ *
+ * Kept at the module top-level so babel-jest hoists it above imports. The
+ * factory falls back to a passthrough when there is no DOM (`@jest-environment
+ * node`), since the real `@testing-library/user-event` requires a browser-like
+ * global and the prototype patching would also fail.
  */
 jest.mock( '@testing-library/user-event', () => {
+	if ( typeof globalThis.window === 'undefined' ) {
+		return { __esModule: true };
+	}
 	const actual = jest.requireActual( '@testing-library/user-event' );
 	const patchedUserEvent = {
 		...actual.userEvent,

--- a/test/unit/mocks/match-media.js
+++ b/test/unit/mocks/match-media.js
@@ -1,22 +1,27 @@
 // Mock `matchMedia` so that all animations are skipped,
 // since js-dom does not fully support CSS animations.
 // Example: https://github.com/jsdom/jsdom/issues/3239
-const originalMatchMedia = window.matchMedia;
-const mockedMatchMedia = jest.fn( ( query ) => {
-	if ( /prefers-reduced-motion/.test( query ) ) {
-		return {
-			...originalMatchMedia( query ),
-			matches: true,
-		};
-	}
+//
+// Skip entirely when there is no `window` (tests opting into
+// `@jest-environment node` for SSR-style assertions).
+if ( typeof window !== 'undefined' ) {
+	const originalMatchMedia = window.matchMedia;
+	const mockedMatchMedia = jest.fn( ( query ) => {
+		if ( /prefers-reduced-motion/.test( query ) ) {
+			return {
+				...originalMatchMedia( query ),
+				matches: true,
+			};
+		}
 
-	return originalMatchMedia( query );
-} );
+		return originalMatchMedia( query );
+	} );
 
-beforeAll( () => {
-	window.matchMedia = jest.fn( mockedMatchMedia );
-} );
+	beforeAll( () => {
+		window.matchMedia = jest.fn( mockedMatchMedia );
+	} );
 
-afterAll( () => {
-	window.matchMedia = originalMatchMedia;
-} );
+	afterAll( () => {
+		window.matchMedia = originalMatchMedia;
+	} );
+}


### PR DESCRIPTION
## What?

Follow up to #76446.

Make `useMediaQuery` and `useViewportMatch` safe to call during server-side rendering. Today they throw `ReferenceError: window is not defined` the moment they're invoked under Node SSR or a `jest-environment node` test, unmounting the whole React tree.

## Why?

#76446 added an optional `view: Window` argument to both hooks, defaulting to the global `window`:

```js
const useViewportMatch = ( breakpoint, operator = '>=', view = window ) => { … }

export default function useMediaQuery(
    query?: string,
    view: Window = window
): boolean { … }
```

Default parameter expressions are evaluated unconditionally at every call. In a non-DOM environment, `window` is an unbound identifier, so the bare reference throws a `ReferenceError` before the function body ever runs — and the existing SSR-safe machinery inside the body (`useSyncExternalStore(subscribe, getValue, () => false)`, with
`() => false` as the server snapshot) never gets a chance to execute.

## How?

- Resolve the `view` default lazily inside the parameter list with `typeof window !== 'undefined' ? window : undefined`. The default expression itself is now safe, and consumers passing an explicit `view` are unaffected.
- Widen `getMQLSubscriber`'s signature to accept `Window | undefined` and short-circuit to `EMPTY_SUBSCRIBER` when `view` is falsy, so the type matches the new reality and `WeakMap.get(undefined)` is impossible.

With these changes, SSR renders fall through to the `useSyncExternalStore` server snapshot and produce `false`; the real match is computed on the client after mount, as before.

## Test coverage

Adds a regression test under `@jest-environment node` that renders both hooks via `react-dom/server`'s `renderToString`. Without the fix, all three cases throw the original `ReferenceError`.

To make a Node-environment test runnable under the shared Jest config, the jsdom-only setup in `packages/jest-preset-default/scripts/setup-globals.js` and `test/unit/{config,mocks}` is guarded with `typeof window !== 'undefined'`. The `@testing-library/user-event` mock stays at the module top level (needed for `babel-jest` hoisting) and falls back to a passthrough when there is no DOM.

## Use of AI Tools

Authored with assistance from Claude Code (Opus 4.7). All changes were reviewed and tested by the author.
