### PR TITLE
Dashboard: layout settings simplified prototype

### DIFF
--- a/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
+++ b/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
@@ -28,7 +28,7 @@ const DEFAULT_GRID_SETTINGS: WidgetGridSettings = {
 	model: 'grid',
 	columns: 12,
 	minColumnWidth: 350,
-	rowHeight: 300,
+	rowHeight: 200,
 };
 
 /**

--- a/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
+++ b/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
@@ -27,8 +27,8 @@ const KEY = 'dashboardGridSettings';
 const DEFAULT_GRID_SETTINGS: WidgetGridSettings = {
 	model: 'grid',
 	columns: 12,
-	minColumnWidth: 140,
-	rowHeight: 140,
+	minColumnWidth: 350,
+	rowHeight: 300,
 };
 
 /**

--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -21,7 +21,8 @@ function Dashboard() {
 		'gutenberg_dashboard'
 	);
 
-	const [ gridSettings, setGridSettings ] = useDashboardGridSettings();
+	const [ gridSettings, setGridSettings, resetGridSettings ] =
+		useDashboardGridSettings();
 
 	const widgetTypes = useWidgetTypes();
 
@@ -46,6 +47,11 @@ function Dashboard() {
 		} );
 	};
 
+	const handleReset = async () => {
+		await resetLayout();
+		resetGridSettings();
+	};
+
 	const pageTitle = editMode ? customizeDashboardLabel : dashboardLabel;
 
 	return (
@@ -53,7 +59,7 @@ function Dashboard() {
 			widgetTypes={ widgetTypes }
 			layout={ layout }
 			onLayoutChange={ handleLayoutChange }
-			onLayoutReset={ resetLayout }
+			onLayoutReset={ handleReset }
 			gridSettings={ gridSettings }
 			onGridSettingsChange={ setGridSettings }
 			editMode={ editMode }

--- a/routes/dashboard/widget-dashboard/components/actions/actions.tsx
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.tsx
@@ -15,7 +15,7 @@ import { AlertDialog, Button, Stack } from '@wordpress/ui';
 import styles from './actions.module.css';
 import { useDashboardInternalContext } from '../../context/dashboard-context';
 import { useDashboardUIContext } from '../../context/ui-context';
-import { LayoutSettings } from '../layout-settings';
+import { LayoutModeDropdown } from '../layout-mode-dropdown';
 import { MoreActionsDropdown } from '../more-actions-dropdown';
 import type { MoreActionsDropdownItem } from '../more-actions-dropdown';
 
@@ -23,15 +23,11 @@ import type { MoreActionsDropdownItem } from '../more-actions-dropdown';
  * Header chrome for the dashboard. Two independent flows are exposed:
  *
  * - **Customize** (layout edits): toggles edit mode, surfaces the Add
- *   widgets / Cancel / Done toolbar. Commits the layout staging buffer
- *   on Done.
- * - **Layout settings** (more-actions dropdown entry): opens a side
- *   drawer with model, column behavior, and row height. Commits the
- *   settings staging buffer on Save inside the drawer.
- *
- * The two flows are mutually exclusive: the Layout settings entry is
- * disabled while edit mode is on so the settings drawer cannot
- * accumulate changes on top of pending layout edits, and vice versa.
+ *   widgets / Layout / Cancel / Done toolbar. Commits the layout staging
+ *   buffer on Done.
+ * - **Layout** (dropdown next to Add widget): switches between Grid and
+ *   Masonry immediately via `commitGridModelChange` while staying in edit
+ *   mode.
  *
  * Returns `null` when the dashboard is mounted without `onEditChange`
  * so surfaces that don't expose edit mode can keep `Actions` in their
@@ -74,13 +70,8 @@ export function Actions(): React.ReactNode {
 		return () => clearTimeout( exitTimeout );
 	}, [ editMode, isEditActionsMounted ] );
 
-	const {
-		setInserterOpen,
-		layoutSettingsOpen,
-		setLayoutSettingsOpen,
-		resetDialogOpen,
-		setResetDialogOpen,
-	} = useDashboardUIContext();
+	const { setInserterOpen, resetDialogOpen, setResetDialogOpen } =
+		useDashboardUIContext();
 	// @TODO: switch to using Admin UI declaratively for mobile viewport support once available.
 	// https://github.com/WordPress/gutenberg/issues/77628
 	const isMobileViewport = useSelect(
@@ -104,10 +95,6 @@ export function Actions(): React.ReactNode {
 		commit();
 	}, [ commit ] );
 
-	const openLayoutSettings = useCallback( () => {
-		setLayoutSettingsOpen( true );
-	}, [ setLayoutSettingsOpen ] );
-
 	const moreActionsItems: MoreActionsDropdownItem[] = [
 		{
 			label: __( 'Reset to default' ),
@@ -115,15 +102,6 @@ export function Actions(): React.ReactNode {
 			disabled: ! onLayoutReset,
 		},
 	];
-
-	if ( canEditGridSettings ) {
-		moreActionsItems.unshift( {
-			label: __( 'Layout settings' ),
-			onClick: openLayoutSettings,
-			disabled: editMode,
-			disabledTooltip: __( 'Disabled while editing widgets' ),
-		} );
-	}
 
 	if ( ! onEditChange ) {
 		return null;
@@ -150,6 +128,8 @@ export function Actions(): React.ReactNode {
 						{ ! isMobileViewport && <Button.Icon icon={ plus } /> }
 						{ __( 'Add widget' ) }
 					</Button>
+
+					{ canEditGridSettings && <LayoutModeDropdown /> }
 
 					<div
 						className={ styles.editActionsDivider }
@@ -206,13 +186,6 @@ export function Actions(): React.ReactNode {
 					confirmButtonText={ __( 'Reset' ) }
 				/>
 			</AlertDialog.Root>
-
-			{ canEditGridSettings && (
-				<LayoutSettings
-					open={ layoutSettingsOpen }
-					onOpenChange={ setLayoutSettingsOpen }
-				/>
-			) }
 		</Stack>
 	);
 }

--- a/routes/dashboard/widget-dashboard/components/actions/actions.tsx
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.tsx
@@ -15,6 +15,7 @@ import { AlertDialog, Button, Stack } from '@wordpress/ui';
 import styles from './actions.module.css';
 import { useDashboardInternalContext } from '../../context/dashboard-context';
 import { useDashboardUIContext } from '../../context/ui-context';
+import { usePendingWhenEditMode } from '../dashboard-commands/use-pending-when-edit-mode';
 import { LayoutModeDropdown } from '../layout-mode-dropdown';
 import { MoreActionsDropdown } from '../more-actions-dropdown';
 import type { MoreActionsDropdownItem } from '../more-actions-dropdown';
@@ -22,9 +23,11 @@ import type { MoreActionsDropdownItem } from '../more-actions-dropdown';
 /**
  * Header chrome for the dashboard. Two independent flows are exposed:
  *
- * - **Customize** (layout edits): toggles edit mode, surfaces the Add
- *   widgets / Layout / Cancel / Done toolbar. Commits the layout staging
- *   buffer on Done.
+ * - **Customize** (layout edits): toggles edit mode and surfaces Layout /
+ *   Cancel / Done. Commits the layout staging buffer on Done.
+ * - **Add widget**: to the right of Customize (or to the right of the edit
+ *   toolbar while customizing); opens the inserter (enters customize mode
+ *   first when not already editing).
  * - **Layout** (dropdown next to Add widget): switches between Grid and
  *   Masonry immediately via `commitGridModelChange` while staying in edit
  *   mode.
@@ -83,9 +86,14 @@ export function Actions(): React.ReactNode {
 		onEditChange?.( ! editMode );
 	}, [ editMode, onEditChange ] );
 
+	const runWhenInEditMode = usePendingWhenEditMode( {
+		editMode,
+		onEditChange,
+	} );
+
 	const insert = useCallback( () => {
-		setInserterOpen( true );
-	}, [ setInserterOpen ] );
+		runWhenInEditMode( () => setInserterOpen( true ) );
+	}, [ runWhenInEditMode, setInserterOpen ] );
 
 	const cancel = useCallback( () => {
 		cancelStaging();
@@ -119,16 +127,6 @@ export function Actions(): React.ReactNode {
 							: styles.editActionsEnter
 					}
 				>
-					<Button
-						variant="minimal"
-						tone="brand"
-						size="compact"
-						onClick={ insert }
-					>
-						{ ! isMobileViewport && <Button.Icon icon={ plus } /> }
-						{ __( 'Add widget' ) }
-					</Button>
-
 					{ canEditGridSettings && <LayoutModeDropdown /> }
 
 					<div
@@ -165,6 +163,16 @@ export function Actions(): React.ReactNode {
 					{ __( 'Customize' ) }
 				</Button>
 			) }
+
+			<Button
+				variant="minimal"
+				tone="brand"
+				size="compact"
+				onClick={ insert }
+			>
+				{ ! isMobileViewport && <Button.Icon icon={ plus } /> }
+				{ __( 'Add widget' ) }
+			</Button>
 
 			<MoreActionsDropdown items={ moreActionsItems } />
 

--- a/routes/dashboard/widget-dashboard/components/layout-mode-dropdown/index.ts
+++ b/routes/dashboard/widget-dashboard/components/layout-mode-dropdown/index.ts
@@ -1,0 +1,1 @@
+export { LayoutModeDropdown } from './layout-mode-dropdown';

--- a/routes/dashboard/widget-dashboard/components/layout-mode-dropdown/layout-mode-dropdown.tsx
+++ b/routes/dashboard/widget-dashboard/components/layout-mode-dropdown/layout-mode-dropdown.tsx
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import type { ChangeEvent } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { chevronDown, layout as layoutIcon } from '@wordpress/icons';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Button, Tooltip } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../../lock-unlock';
+import { useDashboardInternalContext } from '../../context/dashboard-context';
+import type { WidgetGridModel } from '../../types';
+import { getGridModel } from '../../utils/grid-model-change';
+
+const { Menu } = unlock( componentsPrivateApis );
+
+/**
+ * Layout model picker shown beside "Add widget" while customizing. Choosing
+ * Grid or Masonry publishes immediately and keeps edit mode active.
+ *
+ * @return {React.ReactNode} The layout mode dropdown.
+ */
+export function LayoutModeDropdown(): React.ReactNode {
+	const { gridSettings, commitGridModelChange } =
+		useDashboardInternalContext();
+	const model = getGridModel( gridSettings );
+
+	const onModelChange = useCallback(
+		( event: ChangeEvent< HTMLInputElement > ) => {
+			const next = event.target.value as WidgetGridModel;
+			commitGridModelChange( next, { preserveEditMode: true } );
+		},
+		[ commitGridModelChange ]
+	);
+
+	return (
+		<Menu>
+			<Menu.TriggerButton
+				render={
+					<Button variant="minimal" tone="brand" size="compact" />
+				}
+			>
+				<Button.Icon icon={ layoutIcon } />
+				{ __( 'Layout' ) }
+				<Button.Icon icon={ chevronDown } />
+			</Menu.TriggerButton>
+			<Menu.Popover>
+				<Tooltip.Provider delay={ 0 }>
+					<Menu.Group>
+						<Menu.GroupLabel>{ __( 'Layout' ) }</Menu.GroupLabel>
+						<Menu.RadioItem
+							name="dashboard-layout-mode"
+							value="grid"
+							checked={ model === 'grid' }
+							onChange={ onModelChange }
+						>
+							<Menu.ItemLabel>{ __( 'Grid' ) }</Menu.ItemLabel>
+							<Menu.ItemHelpText>
+								{ __(
+									'Widgets align into even rows and columns for a consistent layout.'
+								) }
+							</Menu.ItemHelpText>
+						</Menu.RadioItem>
+						<Menu.RadioItem
+							name="dashboard-layout-mode"
+							value="masonry"
+							checked={ model === 'masonry' }
+							onChange={ onModelChange }
+						>
+							<Menu.ItemLabel>{ __( 'Masonry' ) }</Menu.ItemLabel>
+							<Menu.ItemHelpText>
+								{ __(
+									'Widgets stack to fill available space, allowing different item heights without leaving gaps.'
+								) }
+							</Menu.ItemHelpText>
+						</Menu.RadioItem>
+					</Menu.Group>
+				</Tooltip.Provider>
+			</Menu.Popover>
+		</Menu>
+	);
+}

--- a/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
+++ b/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
@@ -22,7 +22,7 @@ import { LayoutModelEditField } from './layout-model-edit-field';
 
 const DEFAULT_FIXED_COLUMNS = 12;
 const DEFAULT_MIN_COLUMN_WIDTH = 350;
-const DEFAULT_ROW_HEIGHT = 300;
+const DEFAULT_ROW_HEIGHT = 200;
 const ROW_HEIGHT_AUTO = 'auto' as const;
 
 function getModel( item: WidgetGridSettings ): WidgetGridModel {

--- a/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
+++ b/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
@@ -20,9 +20,9 @@ import type {
 } from '../../types';
 import { LayoutModelEditField } from './layout-model-edit-field';
 
-const DEFAULT_FIXED_COLUMNS = 6;
+const DEFAULT_FIXED_COLUMNS = 12;
 const DEFAULT_MIN_COLUMN_WIDTH = 350;
-const DEFAULT_ROW_HEIGHT = 200;
+const DEFAULT_ROW_HEIGHT = 300;
 const ROW_HEIGHT_AUTO = 'auto' as const;
 
 function getModel( item: WidgetGridSettings ): WidgetGridModel {
@@ -153,6 +153,7 @@ const fields: Field< WidgetGridSettings >[] = [
 			rowHeight: value ? ROW_HEIGHT_AUTO : DEFAULT_ROW_HEIGHT,
 		} ),
 		isVisible: ( item ) => ! isMasonry( item ),
+		isDisabled: () => true,
 	},
 	{
 		id: 'rowHeight',
@@ -172,14 +173,9 @@ const fields: Field< WidgetGridSettings >[] = [
 
 const form: Form = {
 	layout: { type: 'regular', labelPosition: 'top' },
-	fields: [
-		'model',
-		'columns',
-		'adaptiveColumns',
-		'minColumnWidth',
-		'autoRowHeight',
-		'rowHeight',
-	],
+	// Column count, adaptive width, and row-height controls stay defined in
+	// `fields` above; only the layout model is exposed in the UI for now.
+	fields: [ 'model' ],
 };
 
 interface LayoutSettingsProps {
@@ -212,10 +208,10 @@ interface LayoutSettingsProps {
  * buttons is treated as Cancel. None of these exit customize mode.
  *
  * Settings and layout-editing are kept as separate flows on the
- * dashboard surface (the Layout settings entry that opens this
- * drawer is disabled while edit mode is on), so the drawer's
- * commit never publishes layout edits that the user is in the
- * middle of staging through the toolbar.
+ * dashboard surface (grid settings mutations are not mixed with
+ * in-flight layout edits without an explicit commit). None of these exit
+ * customize mode except `commit` / `cancel` defaults and `commitGridModelChange`
+ * when `preserveEditMode` is not set.
  *
  * @param {LayoutSettingsProps} props Layout settings props.
  * @return {React.ReactNode} The layout settings component.

--- a/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
+++ b/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
@@ -42,7 +42,7 @@ const DEFAULT_GRID: WidgetGridSettings = {
 	model: 'grid',
 	columns: 12,
 	minColumnWidth: 350,
-	rowHeight: 300,
+	rowHeight: 200,
 };
 
 type GridSettingsWithColumns = WidgetGridSettings & { columns: number };

--- a/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
+++ b/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
@@ -41,8 +41,8 @@ import type {
 const DEFAULT_GRID: WidgetGridSettings = {
 	model: 'grid',
 	columns: 12,
-	minColumnWidth: 140,
-	rowHeight: 140,
+	minColumnWidth: 350,
+	rowHeight: 300,
 };
 
 type GridSettingsWithColumns = WidgetGridSettings & { columns: number };
@@ -130,8 +130,14 @@ interface InternalDashboardContextValue {
 	 * Switches the layout model, updates staging, and publishes
 	 * immediately — equivalent to changing the model in layout
 	 * settings and clicking Save.
+	 *
+	 * Pass `{ preserveEditMode: true }` when switching from the customize
+	 * toolbar so the user stays in edit mode.
 	 */
-	commitGridModelChange: ( targetModel: WidgetGridModel ) => void;
+	commitGridModelChange: (
+		targetModel: WidgetGridModel,
+		options?: { preserveEditMode?: boolean }
+	) => void;
 
 	/**
 	 * Reverts both staging slices. By default also exits edit mode; pass
@@ -224,10 +230,10 @@ interface ProviderProps {
  * Two invariants the provider does not enforce on its own:
  *
  * - The shared commit assumes the two slices are not edited
- *   simultaneously. The bundled `Actions` keeps the layout-edit and
- *   settings-drawer flows mutually exclusive; consumers that compose
- *   a different surface must uphold the same invariant or accept the
- *   cross-publish.
+ *   simultaneously. The bundled `Actions` keeps layout edits and
+ *   immediate layout-model switches from overlapping with incompatible
+ *   flows; consumers that compose a different surface must uphold the
+ *   same invariant or accept the cross-publish.
  * - Staging re-syncs from the committed props on prop change.
  *   In-flight edits are dropped silently when an external update
  *   (cross-tab commit, reset, websocket push) lands. Consumers that
@@ -320,7 +326,10 @@ export function WidgetDashboardProvider( {
 	);
 
 	const commitGridModelChange = useCallback(
-		( targetModel: WidgetGridModel ) => {
+		(
+			targetModel: WidgetGridModel,
+			options?: { preserveEditMode?: boolean }
+		) => {
 			const next = computeGridModelChange( {
 				layout: stagingLayout,
 				gridSettings: stagingGridSettings,
@@ -335,7 +344,9 @@ export function WidgetDashboardProvider( {
 			setStagingGridSettings( next.gridSettings );
 			onLayoutChange( canonicalize( next.layout ) );
 			onGridSettingsChange?.( next.gridSettings );
-			onEditChange?.( false );
+			if ( options?.preserveEditMode !== true ) {
+				onEditChange?.( false );
+			}
 		},
 		[
 			stagingLayout,

--- a/routes/dashboard/widget-dashboard/context/ui-context.tsx
+++ b/routes/dashboard/widget-dashboard/context/ui-context.tsx
@@ -16,8 +16,6 @@ import {
 interface DashboardUIContextValue {
 	inserterOpen: boolean;
 	setInserterOpen: ( next: boolean ) => void;
-	layoutSettingsOpen: boolean;
-	setLayoutSettingsOpen: ( next: boolean ) => void;
 	resetDialogOpen: boolean;
 	setResetDialogOpen: ( next: boolean ) => void;
 
@@ -73,14 +71,14 @@ interface ProviderProps {
 
 /**
  * Holds transient UI state shared across compounds (the inserter modal and
- * the per-instance settings drawer). Kept separate from the data context so
+ * the per-instance settings drawer). Layout mode is changed from the
+ * customize toolbar, not this context. Kept separate from the data context so
  * that data mutations don't churn the UI state and vice-versa.
  * @param root0
  * @param root0.children
  */
 export function WidgetDashboardUIProvider( { children }: ProviderProps ) {
 	const [ inserterOpen, setInserterOpen ] = useState( false );
-	const [ layoutSettingsOpen, setLayoutSettingsOpen ] = useState( false );
 	const [ resetDialogOpen, setResetDialogOpen ] = useState( false );
 	const [ settingsWidgetUuid, setSettingsWidgetUuid ] = useState<
 		string | null
@@ -94,8 +92,6 @@ export function WidgetDashboardUIProvider( { children }: ProviderProps ) {
 		() => ( {
 			inserterOpen,
 			setInserterOpen,
-			layoutSettingsOpen,
-			setLayoutSettingsOpen,
 			resetDialogOpen,
 			setResetDialogOpen,
 			settingsWidgetUuid,
@@ -107,7 +103,6 @@ export function WidgetDashboardUIProvider( { children }: ProviderProps ) {
 		} ),
 		[
 			inserterOpen,
-			layoutSettingsOpen,
 			resetDialogOpen,
 			settingsWidgetUuid,
 			settingsDrawerSide,

--- a/routes/dashboard/widget-dashboard/test/actions.test.tsx
+++ b/routes/dashboard/widget-dashboard/test/actions.test.tsx
@@ -54,9 +54,12 @@ function Harness( {
 }
 
 describe( 'WidgetDashboard.Actions', () => {
-	it( 'renders the Customize button when editMode is false', () => {
+	it( 'renders Add widget and Customize when editMode is false', () => {
 		render( <Harness /> );
 
+		expect(
+			screen.getByRole( 'button', { name: 'Add widget' } )
+		).toBeInTheDocument();
 		expect(
 			screen.getByRole( 'button', { name: 'Customize' } )
 		).toBeInTheDocument();
@@ -74,6 +77,17 @@ describe( 'WidgetDashboard.Actions', () => {
 		expect(
 			screen.queryByRole( 'button', { name: 'Customize' } )
 		).not.toBeInTheDocument();
+	} );
+
+	it( 'enters edit mode when Add widget is clicked outside customize', async () => {
+		const onEditChange = jest.fn();
+		render( <Harness onEditChange={ onEditChange } /> );
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Add widget' } )
+		);
+
+		expect( onEditChange ).toHaveBeenLastCalledWith( true );
 	} );
 
 	it( 'fires onEditChange with true when Customize is clicked', async () => {

--- a/routes/dashboard/widget-dashboard/types.ts
+++ b/routes/dashboard/widget-dashboard/types.ts
@@ -167,7 +167,7 @@ export type WidgetGridModel = 'grid' | 'masonry';
 interface BaseWidgetGridSettings {
 	/**
 	 * Target column count (cap). When omitted alongside
-	 * `minColumnWidth`, the grid renders six columns.
+	 * `minColumnWidth`, the grid uses the dashboard default column cap.
 	 */
 	columns?: number;
 

--- a/routes/dashboard/widget-dashboard/utils/grid-model-change/grid-model-change.ts
+++ b/routes/dashboard/widget-dashboard/utils/grid-model-change/grid-model-change.ts
@@ -8,7 +8,7 @@ import type {
 	WidgetGridSettings,
 } from '../../types';
 
-const DEFAULT_FIXED_COLUMNS = 6;
+const DEFAULT_FIXED_COLUMNS = 12;
 
 export function getGridModel( settings: WidgetGridSettings ): WidgetGridModel {
 	return settings.model ?? 'grid';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Part of https://github.com/WordPress/gutenberg/issues/77616

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

Prototype for simplified layout settings in experimental dashboard.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Enable "dashboard" experiment
- Try new customize mode in the experimental dashboard

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


https://github.com/user-attachments/assets/a14eea66-29e9-451a-a22f-d322428887c3


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
