### PR TITLE
Post list: Remove close button from Quick Edit drawer

### DIFF
--- a/packages/edit-site/src/components/post-list/quick-edit-modal.js
+++ b/packages/edit-site/src/components/post-list/quick-edit-modal.js
@@ -167,7 +167,6 @@ export function QuickEditModal( {
 				<PostCardPanel
 					postType={ postType }
 					postId={ postId }
-					onClose={ closeModal }
 					hideActions
 				/>
 			</div>

--- a/routes/post-list/quick-edit-modal.tsx
+++ b/routes/post-list/quick-edit-modal.tsx
@@ -213,7 +213,6 @@ export function QuickEditModal( {
 				<PostCardPanel
 					postType={ postType }
 					postId={ postId }
-					onClose={ closeModal }
 					hideActions
 				/>
 			</div>


### PR DESCRIPTION
## What?
Closes #78726

Removes the header close button from the Quick Edit drawer in the Pages DataView.

## Why?
The Quick Edit drawer had two affordances for dismissal: an X close button in the header and an explicit **Cancel** action in the footer. This created ambiguity — it was unclear whether closing via the X would save, discard, or prompt the user. Having two controls that appear similar but may imply different intent increases cognitive load.

This pattern has precedent in `AlertDialog`, which intentionally omits a close button to force an explicit decision through the provided actions.

## How?
The close button in `PostCardPanel` is conditionally rendered only when an `onClose` prop is passed. The fix removes the `onClose={ closeModal }` prop from `PostCardPanel` in both Quick Edit modal files:

- `packages/edit-site/src/components/post-list/quick-edit-modal.js`
- `routes/post-list/quick-edit-modal.tsx`

The interaction model is now unambiguous:
- **Done** → save changes
- **Cancel** → discard changes and exit

## Testing Instructions
1. Go to the Site Editor → Pages.
2. Switch to **Table** layout using the layout switcher in the toolbar.
3. Hover over any page row and click **Quick Edit**.
4. Verify the drawer opens with the page title in the header but **no X close button**.
5. Verify **Cancel** and **Done** buttons are present in the footer.
6. Click **Cancel** and confirm the drawer closes without saving.
7. Re-open Quick Edit, make a change (e.g. toggle status), click **Done**, and confirm the change is saved.

### Testing Instructions for Keyboard
1. Navigate to Site Editor → Pages → Table layout using `Tab`.
2. Focus a row's **Quick Edit** button and press `Enter`.
3. Confirm focus moves into the drawer and there is no focusable X close button in the header.
4. `Tab` through the form fields and footer buttons — only **Cancel** and **Done** should be reachable.
5. Press `Enter` on **Cancel** to close, confirm drawer closes.

## Screenshots or screencast

|Before|After|
|-|-|
| <img width="312" height="796" alt="image" src="https://github.com/user-attachments/assets/41b264c4-3448-4c9b-936c-970dee2a3360" /> | <img width="312" height="796" alt="image" src="https://github.com/user-attachments/assets/a2861b0d-5e38-4328-b142-2b40b5060abb" /> |