### PR TITLE
Dashboard: Opinionated grid columns with container breakpoints

### DIFF
--- a/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
+++ b/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
@@ -13,6 +13,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
  * Internal dependencies
  */
 import type { WidgetGridSettings } from '../../widget-dashboard/types';
+import { WIDGET_DASHBOARD_COLUMN_COUNT } from '../../widget-dashboard/types';
 import { normalizeGridSettings } from '../../widget-dashboard/utils/normalize-grid-settings';
 import { DEFAULT_ROW_HEIGHT } from '../../widget-dashboard/utils/row-height-presets';
 
@@ -28,7 +29,7 @@ const KEY = 'dashboardGridSettings';
  */
 const DEFAULT_GRID_SETTINGS: WidgetGridSettings = {
 	model: 'grid',
-	columns: 12,
+	columns: WIDGET_DASHBOARD_COLUMN_COUNT,
 	minColumnWidth: 140,
 	rowHeight: DEFAULT_ROW_HEIGHT,
 };

--- a/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
+++ b/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
@@ -30,7 +30,6 @@ const KEY = 'dashboardGridSettings';
 const DEFAULT_GRID_SETTINGS: WidgetGridSettings = {
 	model: 'grid',
 	columns: WIDGET_DASHBOARD_COLUMN_COUNT,
-	minColumnWidth: 140,
 	rowHeight: DEFAULT_ROW_HEIGHT,
 };
 

--- a/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
+++ b/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
@@ -18,14 +18,14 @@ import {
 	rowHeightToPreset,
 	type RowHeightPreset,
 } from '../../utils/row-height-presets';
-import type {
-	WidgetGridLayoutSettings,
-	WidgetGridModel,
-	WidgetGridSettings,
+import {
+	WIDGET_DASHBOARD_COLUMN_COUNT,
+	type WidgetGridLayoutSettings,
+	type WidgetGridModel,
+	type WidgetGridSettings,
 } from '../../types';
 import { LayoutModelEditField } from './layout-model-edit-field';
 
-const DEFAULT_FIXED_COLUMNS = 6;
 const DEFAULT_MIN_COLUMN_WIDTH = 350;
 
 function getModel( item: WidgetGridSettings ): WidgetGridModel {
@@ -91,16 +91,6 @@ const fields: Field< WidgetGridSettings >[] = [
 		getValue: ( { item } ) => getModel( item ),
 	},
 	{
-		id: 'columns',
-		type: 'integer',
-		Edit: StepperIntegerEdit,
-		label: __( 'Columns' ),
-		description: __(
-			'How many columns to show when the dashboard has enough space.'
-		),
-		isValid: { min: 1, max: 12 },
-	},
-	{
 		id: 'adaptiveColumns',
 		type: 'boolean',
 		Edit: 'toggle',
@@ -162,7 +152,6 @@ const form: Form = {
 	layout: { type: 'regular', labelPosition: 'top' },
 	fields: [
 		'model',
-		'columns',
 		'adaptiveColumns',
 		'minColumnWidth',
 		'rowHeight',
@@ -230,7 +219,7 @@ export function LayoutSettings( {
 					layout,
 					currentModel,
 					nextModel,
-					{ columns: gridSettings.columns ?? DEFAULT_FIXED_COLUMNS }
+					{ columns: WIDGET_DASHBOARD_COLUMN_COUNT }
 				);
 				onLayoutChange( migrated );
 			}

--- a/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
+++ b/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
@@ -1,9 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalNumberControl as NumberControl } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
-import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
+import type { Field, Form } from '@wordpress/dataviews';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Drawer } from '@wordpress/ui'; // eslint-disable-line @wordpress/use-recommended-components
@@ -26,53 +25,12 @@ import {
 } from '../../types';
 import { LayoutModelEditField } from './layout-model-edit-field';
 
-const DEFAULT_MIN_COLUMN_WIDTH = 350;
-
 function getModel( item: WidgetGridSettings ): WidgetGridModel {
 	return item.model ?? 'grid';
 }
 
 function isMasonry( item: WidgetGridSettings ): boolean {
 	return getModel( item ) === 'masonry';
-}
-
-function StepperIntegerEdit( {
-	data,
-	field,
-	onChange,
-}: DataFormControlProps< WidgetGridSettings > ) {
-	const { label, description, getValue, setValue, isValid } = field;
-	const value = getValue( { item: data } );
-	const disabled = field.isDisabled( { item: data, field } );
-	const min =
-		typeof isValid.min?.constraint === 'number'
-			? isValid.min.constraint
-			: undefined;
-	const max =
-		typeof isValid.max?.constraint === 'number'
-			? isValid.max.constraint
-			: undefined;
-
-	return (
-		<NumberControl
-			__next40pxDefaultSize
-			label={ label }
-			help={ description }
-			value={ value ?? '' }
-			min={ min }
-			max={ max }
-			step={ 1 }
-			spinControls="custom"
-			disabled={ disabled }
-			onChange={ ( next ) => {
-				const parsed =
-					next === '' || next === undefined
-						? undefined
-						: Number( next );
-				onChange( setValue( { item: data, value: parsed } ) );
-			} }
-		/>
-	);
 }
 
 const fields: Field< WidgetGridSettings >[] = [
@@ -89,39 +47,6 @@ const fields: Field< WidgetGridSettings >[] = [
 			{ value: 'masonry', label: __( 'Masonry' ) },
 		],
 		getValue: ( { item } ) => getModel( item ),
-	},
-	{
-		id: 'adaptiveColumns',
-		type: 'boolean',
-		Edit: 'toggle',
-		label: __( 'Adjust on narrow screens' ),
-		description: __(
-			'Show fewer columns when the dashboard gets too narrow to keep tiles readable.'
-		),
-		getValue: ( { item } ) => item.minColumnWidth !== 0,
-		setValue: ( { item, value } ) => {
-			if ( ! value ) {
-				return { minColumnWidth: 0 };
-			}
-			const previous = item.minColumnWidth;
-			return {
-				minColumnWidth:
-					previous && previous > 0
-						? previous
-						: DEFAULT_MIN_COLUMN_WIDTH,
-			};
-		},
-	},
-	{
-		id: 'minColumnWidth',
-		type: 'integer',
-		Edit: StepperIntegerEdit,
-		label: __( 'Minimum tile width' ),
-		description: __(
-			'The smallest tile width before a column is removed.'
-		),
-		isValid: { min: 48, max: 600 },
-		isVisible: ( item ) => item.minColumnWidth !== 0,
 	},
 	{
 		id: 'rowHeight',
@@ -150,12 +75,7 @@ const fields: Field< WidgetGridSettings >[] = [
 
 const form: Form = {
 	layout: { type: 'regular', labelPosition: 'top' },
-	fields: [
-		'model',
-		'adaptiveColumns',
-		'minColumnWidth',
-		'rowHeight',
-	],
+	fields: [ 'model', 'rowHeight' ],
 };
 
 interface LayoutSettingsProps {
@@ -171,8 +91,8 @@ interface LayoutSettingsProps {
 }
 
 /**
- * Modal side drawer for grid-level settings (model, column behavior,
- * row height). Reads from and writes to the staging copy in
+ * Modal side drawer for grid-level settings (model, row height).
+ * Reads from and writes to the staging copy in
  * `useDashboardInternalContext`; edits preview through the backdrop
  * and are committed or rolled back by the drawer's Save / Cancel
  * buttons.

--- a/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
+++ b/routes/dashboard/widget-dashboard/components/widgets/widgets.module.css
@@ -1,4 +1,7 @@
 .grid {
+	/* stylelint-disable-next-line property-no-unknown -- container queries for the dashboard grid surface */
+	container-type: inline-size;
+	container-name: widget-dashboard;
 	width: 100%;
 	/* Placeholder and drag-preview radii: match `.tile` and `@wordpress/ui` Card (`--wpds-border-radius-lg`). */
 	--wp-grid-placeholder-radius: var(--wpds-border-radius-lg);

--- a/routes/dashboard/widget-dashboard/components/widgets/widgets.tsx
+++ b/routes/dashboard/widget-dashboard/components/widgets/widgets.tsx
@@ -19,6 +19,7 @@ import type {
  * Internal dependencies
  */
 import { useDashboardInternalContext } from '../../context/dashboard-context';
+import { useDashboardContainerColumnCount } from '../../hooks/use-dashboard-container-column-count';
 import { DashboardWidgetChrome } from '../dashboard-widget-chrome';
 import { WidgetSettingsToolbar } from '../widget-settings';
 import { WidgetLayoutToolbar } from './widget-layout-toolbar';
@@ -30,13 +31,6 @@ import type {
 	MasonryTilePlacement,
 } from '../../types';
 import type { WidgetName } from '../../../widget-primitives';
-
-// Floor applied as `minColumnWidth` on every surface render. Acts as a
-// safety net for stored settings that predate the layered model (where
-// `minColumnWidth` was XOR with `columns` and could be persisted as
-// `undefined`), and keeps tiles legible on narrow viewports without
-// requiring the consumer to wire the floor up themselves.
-const DASHBOARD_MIN_COLUMN_WIDTH = 350;
 
 function toGridLayout( widgets: DashboardWidget[] ): DashboardGridLayoutItem[] {
 	return widgets.map( ( w ) => ( {
@@ -107,9 +101,9 @@ export const Widgets = forwardRef< HTMLDivElement, WidgetsProps >(
 	function Widgets( { className }, ref ) {
 		const { layout, onLayoutChange, editMode, gridSettings, widgetTypes } =
 			useDashboardInternalContext();
+		const { containerRef, columnCount } =
+			useDashboardContainerColumnCount( ref );
 		const isMasonry = gridSettings.model === 'masonry';
-		const minColumnWidth =
-			gridSettings.minColumnWidth ?? DASHBOARD_MIN_COLUMN_WIDTH;
 
 		const gridLayout = useMemo(
 			() =>
@@ -183,8 +177,7 @@ export const Widgets = forwardRef< HTMLDivElement, WidgetsProps >(
 		const surface: React.ReactNode = isMasonry ? (
 			<DashboardLanes
 				layout={ gridLayout as DashboardLanesLayoutItem[] }
-				columns={ gridSettings.columns }
-				minColumnWidth={ minColumnWidth }
+				columns={ columnCount }
 				flowTolerance={ gridSettings.flowTolerance }
 				onChangeLayout={ handleMasonryChange }
 				{ ...sharedRenderProps }
@@ -194,8 +187,7 @@ export const Widgets = forwardRef< HTMLDivElement, WidgetsProps >(
 		) : (
 			<DashboardGrid
 				layout={ gridLayout as DashboardGridLayoutItem[] }
-				columns={ gridSettings.columns }
-				minColumnWidth={ minColumnWidth }
+				columns={ columnCount }
 				rowHeight={ gridSettings.rowHeight }
 				onChangeLayout={ handleGridChange }
 				{ ...sharedRenderProps }
@@ -205,7 +197,10 @@ export const Widgets = forwardRef< HTMLDivElement, WidgetsProps >(
 		);
 
 		return (
-			<div ref={ ref } className={ clsx( styles.grid, className ) }>
+			<div
+				ref={ containerRef }
+				className={ clsx( styles.grid, className ) }
+			>
 				{ surface }
 			</div>
 		);

--- a/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
+++ b/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
@@ -36,14 +36,10 @@ import type { ResolveWidgetModule, WidgetType } from '../../widget-primitives';
  * shape passes through untouched and missing fields fall back to whatever
  * defaults the grid model itself supplies.
  *
- * `widgets.tsx` also applies a hard-coded floor when `minColumnWidth`
- * resolves to `undefined`, to keep legibility intact for stored settings
- * that predate the layered model.
  */
 const DEFAULT_GRID: WidgetGridSettings = {
 	model: 'grid',
 	columns: WIDGET_DASHBOARD_COLUMN_COUNT,
-	minColumnWidth: 140,
 	rowHeight: DEFAULT_ROW_HEIGHT,
 };
 

--- a/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
+++ b/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
@@ -27,6 +27,7 @@ import type {
 	WidgetGridSettings,
 	DashboardWidget,
 } from '../types';
+import { WIDGET_DASHBOARD_COLUMN_COUNT } from '../types';
 import type { ResolveWidgetModule, WidgetType } from '../../widget-primitives';
 
 /*
@@ -41,7 +42,7 @@ import type { ResolveWidgetModule, WidgetType } from '../../widget-primitives';
  */
 const DEFAULT_GRID: WidgetGridSettings = {
 	model: 'grid',
-	columns: 12,
+	columns: WIDGET_DASHBOARD_COLUMN_COUNT,
 	minColumnWidth: 140,
 	rowHeight: DEFAULT_ROW_HEIGHT,
 };
@@ -54,7 +55,7 @@ function resolveGridSettings(
 	const normalized = normalizeGridSettings( settings, DEFAULT_ROW_HEIGHT );
 	return {
 		...normalized,
-		columns: normalized.columns ?? DEFAULT_GRID.columns!,
+		columns: WIDGET_DASHBOARD_COLUMN_COUNT,
 	};
 }
 

--- a/routes/dashboard/widget-dashboard/hooks/use-dashboard-container-column-count.ts
+++ b/routes/dashboard/widget-dashboard/hooks/use-dashboard-container-column-count.ts
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import { useResizeObserver, useMergeRefs } from '@wordpress/compose';
+import {
+	useLayoutEffect,
+	useMemo,
+	useState,
+	type Ref,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { resolveDashboardColumnCount } from '../utils/resolve-dashboard-column-count/resolve-dashboard-column-count';
+
+/**
+ * Tracks the dashboard grid container width and maps it to an opinionated
+ * column count (4 → 2 → 1). Measurement is container-based via
+ * `ResizeObserver`, not viewport media queries.
+ *
+ * @param forwardedRef Optional ref forwarded from the grid wrapper.
+ * @return Merged ref for the container element and the resolved column count.
+ */
+export function useDashboardContainerColumnCount(
+	forwardedRef?: Ref< HTMLDivElement >
+): {
+	containerRef: Ref< HTMLDivElement >;
+	columnCount: number;
+} {
+	const [ container, setContainer ] = useState< HTMLDivElement | null >(
+		null
+	);
+	const [ containerWidth, setContainerWidth ] = useState( 0 );
+
+	const resizeObserverRef = useResizeObserver( ( [ { contentRect } ] ) => {
+		setContainerWidth( contentRect.width );
+	} );
+
+	const containerRef = useMergeRefs( [
+		setContainer,
+		resizeObserverRef,
+		forwardedRef,
+	] );
+
+	useLayoutEffect( () => {
+		if ( ! container ) {
+			return;
+		}
+		const { width } = container.getBoundingClientRect();
+		if ( width > 0 ) {
+			setContainerWidth( width );
+		}
+	}, [ container ] );
+
+	const columnCount = useMemo(
+		() => resolveDashboardColumnCount( containerWidth ),
+		[ containerWidth ]
+	);
+
+	return { containerRef, columnCount };
+}

--- a/routes/dashboard/widget-dashboard/test/dashboard-commands.test.tsx
+++ b/routes/dashboard/widget-dashboard/test/dashboard-commands.test.tsx
@@ -89,9 +89,7 @@ function Harness( {
 			onEditChange={ setEditMode }
 			onLayoutReset={ withLayoutReset ? async () => {} : undefined }
 			gridSettings={
-				withGridSettings
-					? { model: gridModel, columns: 6, minColumnWidth: 350 }
-					: undefined
+				withGridSettings ? { model: gridModel, columns: 6 } : undefined
 			}
 			onGridSettingsChange={ withGridSettings ? () => {} : undefined }
 		>

--- a/routes/dashboard/widget-dashboard/test/staging.test.tsx
+++ b/routes/dashboard/widget-dashboard/test/staging.test.tsx
@@ -309,13 +309,13 @@ describe( 'WidgetDashboard staging layer', () => {
 			act( () => {
 				readProbe().mutateGridSettings( {
 					...initialSettings,
-					rowHeight: 240,
+					rowHeight: 300,
 				} );
 			} );
 
 			expect( onGridSettingsChange ).not.toHaveBeenCalled();
 			expect( readProbe().hasUncommittedChanges ).toBe( true );
-			expect( readProbe().gridSettings.rowHeight ).toBe( 240 );
+			expect( readProbe().gridSettings.rowHeight ).toBe( 300 );
 		} );
 
 		it( 'publishes both layout and settings on commit', () => {

--- a/routes/dashboard/widget-dashboard/test/staging.test.tsx
+++ b/routes/dashboard/widget-dashboard/test/staging.test.tsx
@@ -289,7 +289,6 @@ describe( 'WidgetDashboard staging layer', () => {
 	describe( 'grid settings staging', () => {
 		const initialSettings: WidgetGridSettings = {
 			model: 'grid',
-			minColumnWidth: 350,
 			rowHeight: 200,
 		};
 
@@ -310,13 +309,13 @@ describe( 'WidgetDashboard staging layer', () => {
 			act( () => {
 				readProbe().mutateGridSettings( {
 					...initialSettings,
-					minColumnWidth: 420,
+					rowHeight: 240,
 				} );
 			} );
 
 			expect( onGridSettingsChange ).not.toHaveBeenCalled();
 			expect( readProbe().hasUncommittedChanges ).toBe( true );
-			expect( readProbe().gridSettings.minColumnWidth ).toBe( 420 );
+			expect( readProbe().gridSettings.rowHeight ).toBe( 240 );
 		} );
 
 		it( 'publishes both layout and settings on commit', () => {

--- a/routes/dashboard/widget-dashboard/types.ts
+++ b/routes/dashboard/widget-dashboard/types.ts
@@ -118,17 +118,18 @@ export interface WidgetContextValue {
 export type WidgetGridModel = 'grid' | 'masonry';
 
 /**
- * Fixed column count for the widget dashboard. Not exposed in layout
- * settings; `minColumnWidth` can still reduce the effective count on
- * narrow viewports.
+ * Maximum column count for the widget dashboard on wide containers.
+ * Not exposed in layout settings; container width steps the count down
+ * to two and one column at fixed breakpoints.
  */
 export const WIDGET_DASHBOARD_COLUMN_COUNT = 4;
 
 /**
- * Settings common to every grid model. `columns` and `minColumnWidth`
- * compose as a layered model at runtime: `columns` caps the count and
- * `minColumnWidth` enforces a per-tile width floor that can reduce the
- * count on narrow containers. See `@wordpress/grid` for the resolution.
+ * Settings common to every grid model. Column count is resolved from
+ * the dashboard container width (see
+ * `utils/resolve-dashboard-column-count`). `columns` and `minColumnWidth`
+ * on this type remain for persisted payloads and `@wordpress/grid`
+ * compatibility; the dashboard ignores user-facing values for both.
  *
  * `spacing` is intentionally absent: the gap between tiles is
  * presentational and lives with the design-system theme/density, not
@@ -143,9 +144,8 @@ interface BaseWidgetGridSettings {
 	columns?: number;
 
 	/**
-	 * Per-tile minimum width in pixels. Acts as a floor that can
-	 * reduce the effective column count below `columns` on narrow
-	 * containers.
+	 * Per-tile minimum width in pixels. Unused by the dashboard; column
+	 * count is derived from container width instead.
 	 */
 	minColumnWidth?: number;
 }

--- a/routes/dashboard/widget-dashboard/types.ts
+++ b/routes/dashboard/widget-dashboard/types.ts
@@ -118,6 +118,13 @@ export interface WidgetContextValue {
 export type WidgetGridModel = 'grid' | 'masonry';
 
 /**
+ * Fixed column count for the widget dashboard. Not exposed in layout
+ * settings; `minColumnWidth` can still reduce the effective count on
+ * narrow viewports.
+ */
+export const WIDGET_DASHBOARD_COLUMN_COUNT = 4;
+
+/**
  * Settings common to every grid model. `columns` and `minColumnWidth`
  * compose as a layered model at runtime: `columns` caps the count and
  * `minColumnWidth` enforces a per-tile width floor that can reduce the
@@ -130,8 +137,8 @@ export type WidgetGridModel = 'grid' | 'masonry';
  */
 interface BaseWidgetGridSettings {
 	/**
-	 * Target column count (cap). When omitted alongside
-	 * `minColumnWidth`, the grid renders six columns.
+	 * Target column count (cap). The dashboard always uses
+	 * {@link WIDGET_DASHBOARD_COLUMN_COUNT}; persisted values are ignored.
 	 */
 	columns?: number;
 

--- a/routes/dashboard/widget-dashboard/utils/grid-model-change/grid-model-change.ts
+++ b/routes/dashboard/widget-dashboard/utils/grid-model-change/grid-model-change.ts
@@ -7,8 +7,7 @@ import type {
 	WidgetGridModel,
 	WidgetGridSettings,
 } from '../../types';
-
-const DEFAULT_FIXED_COLUMNS = 6;
+import { WIDGET_DASHBOARD_COLUMN_COUNT } from '../../types';
 
 export function getGridModel( settings: WidgetGridSettings ): WidgetGridModel {
 	return settings.model ?? 'grid';
@@ -43,7 +42,7 @@ export function computeGridModelChange( {
 
 	return {
 		layout: migrateLayout( layout, currentModel, targetModel, {
-			columns: gridSettings.columns ?? DEFAULT_FIXED_COLUMNS,
+			columns: WIDGET_DASHBOARD_COLUMN_COUNT,
 		} ),
 		gridSettings: {
 			...gridSettings,

--- a/routes/dashboard/widget-dashboard/utils/resolve-dashboard-column-count/resolve-dashboard-column-count.ts
+++ b/routes/dashboard/widget-dashboard/utils/resolve-dashboard-column-count/resolve-dashboard-column-count.ts
@@ -1,0 +1,41 @@
+/**
+ * Internal dependencies
+ */
+import { WIDGET_DASHBOARD_COLUMN_COUNT } from '../../types';
+
+/**
+ * Container width (px) below which the dashboard uses a single column.
+ * Matches `@container widget-dashboard (max-width: …)` in widgets CSS.
+ */
+export const WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_ONE_COLUMN = 600;
+
+/**
+ * Container width (px) below which the dashboard drops from four columns
+ * to two. Above this threshold (and below the four-column cap) the
+ * grid uses {@link WIDGET_DASHBOARD_COLUMN_COUNT}.
+ */
+export const WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_TWO_COLUMNS = 960;
+
+/**
+ * Resolves the dashboard grid column count from the widget surface
+ * container width. Uses discrete steps (4 → 2 → 1), not viewport
+ * media queries.
+ *
+ * @param containerWidth Measured inline size of the dashboard grid container.
+ * @return Column count for {@link @wordpress/grid} surfaces.
+ */
+export function resolveDashboardColumnCount( containerWidth: number ): number {
+	if ( containerWidth <= 0 ) {
+		return WIDGET_DASHBOARD_COLUMN_COUNT;
+	}
+
+	if ( containerWidth < WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_ONE_COLUMN ) {
+		return 1;
+	}
+
+	if ( containerWidth < WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_TWO_COLUMNS ) {
+		return 2;
+	}
+
+	return WIDGET_DASHBOARD_COLUMN_COUNT;
+}

--- a/routes/dashboard/widget-dashboard/utils/resolve-dashboard-column-count/test/resolve-dashboard-column-count.test.ts
+++ b/routes/dashboard/widget-dashboard/utils/resolve-dashboard-column-count/test/resolve-dashboard-column-count.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import {
+	resolveDashboardColumnCount,
+	WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_ONE_COLUMN,
+	WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_TWO_COLUMNS,
+} from '../resolve-dashboard-column-count';
+
+describe( 'resolveDashboardColumnCount', () => {
+	it( 'defaults to four columns before measurement', () => {
+		expect( resolveDashboardColumnCount( 0 ) ).toBe( 4 );
+	} );
+
+	it( 'uses four columns at wide container sizes', () => {
+		expect(
+			resolveDashboardColumnCount(
+				WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_TWO_COLUMNS
+			)
+		).toBe( 4 );
+		expect( resolveDashboardColumnCount( 1200 ) ).toBe( 4 );
+	} );
+
+	it( 'uses two columns between mobile and wide breakpoints', () => {
+		expect(
+			resolveDashboardColumnCount(
+				WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_ONE_COLUMN
+			)
+		).toBe( 2 );
+		expect(
+			resolveDashboardColumnCount(
+				WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_TWO_COLUMNS - 1
+			)
+		).toBe( 2 );
+	} );
+
+	it( 'uses one column below the mobile container breakpoint', () => {
+		expect(
+			resolveDashboardColumnCount(
+				WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_ONE_COLUMN - 1
+			)
+		).toBe( 1 );
+	} );
+} );


### PR DESCRIPTION
## What

- Removes **Columns**, **Adjust on narrow screens**, and **Minimum tile width** from the dashboard **Layout settings** drawer.
- Hard-codes a maximum of **4 columns** on wide dashboard containers via `WIDGET_DASHBOARD_COLUMN_COUNT`.
- Adds **opinionated responsive column steps** based on **dashboard container width** (not viewport width):
  - **4 columns** when the container is ≥ 960px
  - **2 columns** from 600px–959px
  - **1 column** below 600px
- Ignores persisted `columns` and `minColumnWidth` values at runtime; layout settings now focus on choices users actually need.

## Why

Most dashboard users will not want to tune grid geometry. Exposing column count and adaptive behavior adds cognitive load for settings that rarely improve the experience and (with bad config) can often make it worse.

We should make opinionated product decisions and keep layout settings focused on meaningful choices, not low-level grid math.

**Four columns** is a practical maximum on wide containers: enough room for a useful dashboard layout without tiles becoming too small to scan or interact with. Beyond four columns, widgets can be shrunk to sizes that have little practical value. Maybe we could bump this value up to 6 on _really_ wide screens. Let's discuss.

**Responsive steps should follow the dashboard container**, not the browser viewport. Container measurement keeps tiles readable when the *dashboard surface* shrinks, regardless of monitor size.

## How

- Introduced `WIDGET_DASHBOARD_COLUMN_COUNT` (4) and `resolveDashboardColumnCount()` with container breakpoints at **600px** and **960px**.
- Added `useDashboardContainerColumnCount` — measures the `.grid` wrapper with `ResizeObserver` and passes the resolved count to `DashboardGrid` / `DashboardLanes`.
- Set `container-type: inline-size` and `container-name: widget-dashboard` on the grid wrapper for container-query alignment.
- Removed adaptive-column UI and stopped passing `minColumnWidth` to `@wordpress/grid`.
- Updated defaults in `WidgetDashboardProvider` and `useDashboardGridSettings` to match.

## Test plan

- [ ] Open **Layout settings** and confirm **Columns**, **Adjust on narrow screens**, and **Minimum tile width** are gone.
- [ ] On a **wide** dashboard container (≥ 960px), confirm **4 columns**.
- [ ] Resize the **dashboard container** to a medium width (600–959px) and confirm **2 columns** — without narrowing the whole browser window if the dashboard stays wide.
- [ ] Narrow the container below 600px and confirm **1 column**.
- [ ] On a **wide viewport** with a **narrow dashboard panel**, confirm columns step down (validates container-based behavior vs viewport media queries).
- [ ] Switch between **Standard grid** and **Masonry**; confirm layout migrates without errors.
- [ ] Change row height / auto row height settings; confirm they still work and persist.
- [ ] Save, reload, and confirm column behavior is unchanged even if older preferences stored different `columns` or `minColumnWidth` values.
- [ ] Use **Reset** in layout settings and confirm defaults apply without restoring removed controls.

## Screenshots

### Before

https://github.com/user-attachments/assets/93fa77f9-de68-4308-a188-3b57813f5f0d



### After

https://github.com/user-attachments/assets/971867ce-7307-4f0e-8629-f25cabd567b3

