### PR TITLE
Core Data: Surface and prioritize matched results in fetchLinkSuggestions

### DIFF
--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.ts
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.ts
@@ -58,6 +58,13 @@ type MediaAPIResult = {
 	type: string;
 };
 
+type PostAPIResult = {
+	id: number;
+	title: { rendered: string };
+	link: string;
+	type: string;
+};
+
 export type SearchResult = {
 	/**
 	 * Post or term id.
@@ -80,6 +87,21 @@ export type SearchResult = {
 	 */
 	kind?: string;
 };
+
+/**
+ * Maps a post subtype slug to its WP REST API base path.
+ * Falls back to appending 's' for custom post types.
+ *
+ * @param subtype
+ */
+function getRestBase( subtype: string ): string {
+	const map: Record< string, string > = {
+		post: 'posts',
+		page: 'pages',
+		attachment: 'media',
+	};
+	return map[ subtype ] ?? `${ subtype }s`;
+}
 
 /**
  * Fetches link suggestions from the WordPress API.
@@ -156,6 +178,38 @@ export default async function fetchLinkSuggestions(
 				} )
 				.catch( () => [] ) // Fail by returning no results.
 		);
+	}
+
+	// Slug-based post search. Query the individual REST endpoints
+	// by slug to surface those results, then deduplicate below.
+	if ( ( ! type || type === 'post' ) && search ) {
+		const slugEndpoints = subtype
+			? [ getRestBase( subtype ) ]
+			: [ 'posts', 'pages' ];
+
+		for ( const endpoint of slugEndpoints ) {
+			queries.push(
+				apiFetch< PostAPIResult[] >( {
+					path: addQueryArgs( `/wp/v2/${ endpoint }`, {
+						slug: search,
+						per_page: perPage,
+					} ),
+				} )
+					.then( ( results ) => {
+						return results.map( ( result ) => ( {
+							id: result.id,
+							url: result.link,
+							title:
+								decodeEntities(
+									result.title?.rendered || ''
+								) || __( '(no title)' ),
+							type: result.type,
+							kind: 'post-type' as const,
+						} ) );
+					} )
+					.catch( () => [] )
+			);
+		}
 	}
 
 	if ( ! type || type === 'term' ) {
@@ -244,6 +298,16 @@ export default async function fetchLinkSuggestions(
 
 	let results = responses.flat();
 	results = results.filter( ( result ) => !! result.id );
+	// Deduplicate by id: slug search and title search can return the same post.
+	// Keep the first occurrence (title-search results come first in `queries`).
+	const seen = new Set< number | string >();
+	results = results.filter( ( result ) => {
+		if ( seen.has( result.id ) ) {
+			return false;
+		}
+		seen.add( result.id );
+		return true;
+	} );
 	results = sortResults( results, search );
 	results = results.slice( 0, perPage );
 	return results;
@@ -265,9 +329,12 @@ export default async function fetchLinkSuggestions(
  */
 export function sortResults( results: SearchResult[], search: string ) {
 	const searchTokens = tokenize( search );
+	const scores: Record< string | number, number > = {};
 
-	const scores = {};
 	for ( const result of results ) {
+		let score = 0;
+
+		// Title-based scoring (exact match weight: 10, sub-match weight: ~1).
 		if ( result.title ) {
 			const titleTokens = tokenize( result.title );
 			const exactMatchingTokens = titleTokens.filter( ( titleToken ) =>
@@ -282,23 +349,50 @@ export function sortResults( results: SearchResult[], search: string ) {
 						titleToken.includes( searchToken )
 				)
 			);
-
-			// The score is a combination of exact matches and sub-matches.
-			// More weight is given to exact matches, as they are more relevant (e.g. "cat" vs "caterpillar").
-			// Diving by the total number of tokens in the title normalizes the score and skews
-			// the results towards shorter titles.
-			const exactMatchScore =
-				( exactMatchingTokens.length / titleTokens.length ) * 10;
-
-			const subMatchScore = subMatchingTokens.length / titleTokens.length;
-
-			scores[ result.id ] = exactMatchScore + subMatchScore;
-		} else {
-			scores[ result.id ] = 0;
+			score +=
+				( exactMatchingTokens.length / titleTokens.length ) * 10 +
+				subMatchingTokens.length / titleTokens.length;
 		}
+
+		// Slug-based scoring (exact match weight: 8, sub-match weight: ~0.5).
+		// Sits between exact-title (≤10) and fuzzy-title (<1) so the final order is:
+		//   1. exact title  2. exact slug  3. fuzzy title  4. fuzzy slug
+		if ( result.url ) {
+			const slug = extractSlug( result.url );
+			if ( slug ) {
+				const slugTokens = tokenize( slug );
+				const exactSlugTokens = slugTokens.filter( ( slugToken ) =>
+					searchTokens.some(
+						( searchToken ) => slugToken === searchToken
+					)
+				);
+				const subSlugTokens = slugTokens.filter( ( slugToken ) =>
+					searchTokens.some(
+						( searchToken ) =>
+							slugToken !== searchToken &&
+							slugToken.includes( searchToken )
+					)
+				);
+				score +=
+					( exactSlugTokens.length / slugTokens.length ) * 8 +
+					( subSlugTokens.length / slugTokens.length ) * 0.5;
+			}
+		}
+
+		scores[ result.id ] = score;
 	}
 
 	return results.sort( ( a, b ) => scores[ b.id ] - scores[ a.id ] );
+}
+
+export function extractSlug( url: string ): string {
+	try {
+		const { pathname } = new URL( url );
+		const parts = pathname.replace( /\/$/, '' ).split( '/' );
+		return parts[ parts.length - 1 ] || '';
+	} catch {
+		return '';
+	}
 }
 
 /**

--- a/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
@@ -5,10 +5,28 @@ import {
 	default as fetchLinkSuggestions,
 	sortResults,
 	tokenize,
+	extractSlug,
 } from '../__experimental-fetch-link-suggestions';
 
 jest.mock( '@wordpress/api-fetch', () =>
 	jest.fn( ( { path } ) => {
+		// Slug-based queries (/wp/v2/{type}?slug=...) are handled generically.
+		// Unknown slugs return empty, only add cases for slugs under active test.
+		if ( path.includes( 'slug=' ) ) {
+			if ( path.includes( 'slug=kurse' ) ) {
+				return Promise.resolve( [
+					{
+						id: 42,
+						title: { rendered: 'Kursübersicht' },
+						link: 'http://wordpress.local/kurse/',
+						type: 'page',
+					},
+				] );
+			}
+			// All other slug lookups return no match.
+			return Promise.resolve( [] );
+		}
+
 		switch ( path ) {
 			case '/wp/v2/search?search=&per_page=20&type=post':
 			case '/wp/v2/search?search=Contact&per_page=20&type=post&subtype=page':
@@ -84,6 +102,15 @@ jest.mock( '@wordpress/api-fetch', () =>
 						type: 'attachment',
 						source_url:
 							'http://localhost:8888/wp-content/uploads/2022/03/test-pdf.pdf',
+					},
+				] );
+			case '/wp/v2/pages?slug=kurse&per_page=20':
+				return Promise.resolve( [
+					{
+						id: 42,
+						title: { rendered: 'Kursübersicht' },
+						link: 'http://wordpress.local/kurse/',
+						type: 'page',
 					},
 				] );
 			default:
@@ -320,6 +347,20 @@ describe( 'fetchLinkSuggestions', () => {
 			] )
 		);
 	} );
+	it( 'finds pages by slug when title does not match the search query', () => {
+		return fetchLinkSuggestions( 'kurse', {
+			type: 'post',
+			subtype: 'page',
+		} ).then( ( suggestions ) => {
+			expect( suggestions[ 0 ] ).toEqual( {
+				id: 42,
+				title: 'Kursübersicht',
+				url: 'http://wordpress.local/kurse/',
+				type: 'page',
+				kind: 'post-type',
+			} );
+		} );
+	} );
 } );
 
 describe( 'sortResults', () => {
@@ -446,5 +487,24 @@ describe( 'tokenize', () => {
 			'こんにちは',
 			'世界',
 		] );
+	} );
+} );
+
+describe( 'extractSlug', () => {
+	it( 'returns empty string for invalid URL', () => {
+		expect( extractSlug( 'not-a-url' ) ).toBe( '' );
+	} );
+	it( 'extracts slug from URL with trailing slash', () => {
+		expect( extractSlug( 'http://wordpress.local/kurse/' ) ).toBe(
+			'kurse'
+		);
+	} );
+	it( 'extracts slug from URL without trailing slash', () => {
+		expect( extractSlug( 'http://wordpress.local/kurse' ) ).toBe( 'kurse' );
+	} );
+	it( 'extracts slug from nested URL', () => {
+		expect(
+			extractSlug( 'http://wordpress.local/kurse/freies-training/' )
+		).toBe( 'freies-training' );
 	} );
 } );


### PR DESCRIPTION
## What?
Closes #76805

This PR introduces a parallel slug-based lookup to `__experimentalFetchLinkSuggestions` when a user searches for content. It bypasses the limitation where the core `/wp/v2/search` endpoint strictly screens text matches against titles and excerpts, entirely leaving out valid matches containing different URL slugs.

## Why?
When managing slugs & special character routing (e.g., changing a slug from `kursuebersicht` to `kurse` while maintaining the presentation title as `Kursübersicht`), users inevitably search for pages by their URL paths/slugs inside the Link UI popover. 

Because `/wp/v2/search` completely disregards slug criteria, it yields empty payloads for those keywords. There are zero client-side results available to filter or sort.

## How?

- Implemented sub-queries inside the main link search queue to query content types directly by the exact slug keyword.
- Introduced targeted fallback requests directly to the content type routes (`/wp/v2/posts` or `/wp/v2/pages`) via the `slug=` argument, extract hidden records & deduplicate them against title matches.
- Refactored the `sortResults` calculator by parsing slugs with a clean `extractSlug` helper and assigning a specialized exact slug scale coefficient (`8`). This slots slug matching elegantly right beneath an exact title match (`10`) but completely above fuzzy or string-token fraction overlaps (`<1`).

## Scenario Setup
Create three separate pages in your WordPress dashboard with distinct titles and slugs to test both exact slug matches and fuzzy title matches:
- Page 1 (Target Page): Title: Kursübersicht | Slug: kurse (The word "kurse" is only in the slug and completely absent from the title).
- Page 2 (Distractor Page): Title: Advanced Course Material | Slug: advanced-training (The title contains a partial semantic match for the query).
- Page 3 (Noise Page): Title: Contact Us | Slug: contact | Body Content: "If you have questions about our Kurse, let us know!"

## Testing Instructions

1. Open any post or page for editing, highlight some text, open the link selection wrapper.
2. Input the exact string `kurse` into the search field.
3. Observe the resulting dropdown options.
4. The page titled `Kursübersicht` must be successfully pulled into the results list via the new parallel slug lookup path and float to the absolute top of the list due to its exact slug score modifier. It should be followed secondarily by content match (Contact Us), proving that the exact slug match successfully outranks standard fuzzy content matches.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="696" height="324" alt="image" src="https://github.com/user-attachments/assets/a834ce90-a37e-45fb-8df2-732fbd285be8" />|<img width="704" height="416" alt="image" src="https://github.com/user-attachments/assets/9d97d2bd-9913-4e38-82b7-7b1f718f8464" />|
