### PR TITLE
Dashboard: Replace grid row height controls with size presets.

### DIFF
--- a/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
+++ b/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
@@ -13,6 +13,8 @@ import { store as preferencesStore } from '@wordpress/preferences';
  * Internal dependencies
  */
 import type { WidgetGridSettings } from '../../widget-dashboard/types';
+import { normalizeGridSettings } from '../../widget-dashboard/utils/normalize-grid-settings';
+import { DEFAULT_ROW_HEIGHT } from '../../widget-dashboard/utils/row-height-presets';
 
 const SCOPE = 'core/dashboard';
 const KEY = 'dashboardGridSettings';
@@ -28,7 +30,7 @@ const DEFAULT_GRID_SETTINGS: WidgetGridSettings = {
 	model: 'grid',
 	columns: 12,
 	minColumnWidth: 140,
-	rowHeight: 140,
+	rowHeight: DEFAULT_ROW_HEIGHT,
 };
 
 /**
@@ -48,13 +50,15 @@ export function useDashboardGridSettings(): [
 	( settings: WidgetGridSettings ) => void,
 	() => void,
 ] {
-	const settings = useSelect(
-		( select ) =>
-			( select( preferencesStore ).get( SCOPE, KEY ) as
-				| WidgetGridSettings
-				| undefined ) ?? DEFAULT_GRID_SETTINGS,
-		[]
-	);
+	const settings = useSelect( ( select ) => {
+		const stored = select( preferencesStore ).get( SCOPE, KEY ) as
+			| WidgetGridSettings
+			| undefined;
+		return normalizeGridSettings(
+			stored ?? DEFAULT_GRID_SETTINGS,
+			DEFAULT_ROW_HEIGHT
+		);
+	}, [] );
 
 	const { set } = useDispatch( preferencesStore );
 

--- a/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
+++ b/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
@@ -138,7 +138,7 @@ const fields: Field< WidgetGridSettings >[] = [
 		type: 'text',
 		Edit: 'toggleGroup',
 		label: __( 'Row height' ),
-		description: __( 'Height of each row in the standard grid.' ),
+		description: __( 'Height of each grid row.' ),
 		elements: [
 			{ value: 'small', label: __( 'Small' ) },
 			{ value: 'medium', label: __( 'Medium' ) },

--- a/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
+++ b/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
@@ -13,6 +13,11 @@ import { Button, Drawer } from '@wordpress/ui'; // eslint-disable-line @wordpres
  */
 import { useDashboardInternalContext } from '../../context/dashboard-context';
 import { migrateLayout } from '../../utils/migrate-layout';
+import {
+	presetToRowHeight,
+	rowHeightToPreset,
+	type RowHeightPreset,
+} from '../../utils/row-height-presets';
 import type {
 	WidgetGridLayoutSettings,
 	WidgetGridModel,
@@ -22,8 +27,6 @@ import { LayoutModelEditField } from './layout-model-edit-field';
 
 const DEFAULT_FIXED_COLUMNS = 6;
 const DEFAULT_MIN_COLUMN_WIDTH = 350;
-const DEFAULT_ROW_HEIGHT = 200;
-const ROW_HEIGHT_AUTO = 'auto' as const;
 
 function getModel( item: WidgetGridSettings ): WidgetGridModel {
 	return item.model ?? 'grid';
@@ -31,19 +34,6 @@ function getModel( item: WidgetGridSettings ): WidgetGridModel {
 
 function isMasonry( item: WidgetGridSettings ): boolean {
 	return getModel( item ) === 'masonry';
-}
-
-function getRowHeight(
-	item: WidgetGridSettings
-): WidgetGridLayoutSettings[ 'rowHeight' ] {
-	if ( isMasonry( item ) ) {
-		return undefined;
-	}
-	return ( item as WidgetGridLayoutSettings ).rowHeight;
-}
-
-function isAutoRowHeight( item: WidgetGridSettings ): boolean {
-	return getRowHeight( item ) === ROW_HEIGHT_AUTO;
 }
 
 function StepperIntegerEdit( {
@@ -144,29 +134,27 @@ const fields: Field< WidgetGridSettings >[] = [
 		isVisible: ( item ) => item.minColumnWidth !== 0,
 	},
 	{
-		id: 'autoRowHeight',
-		type: 'boolean',
-		Edit: 'toggle',
-		label: __( 'Auto-fit row height to content' ),
-		getValue: ( { item } ) => isAutoRowHeight( item ),
+		id: 'rowHeight',
+		type: 'text',
+		Edit: 'toggleGroup',
+		label: __( 'Row height' ),
+		description: __( 'Height of each row in the standard grid.' ),
+		elements: [
+			{ value: 'small', label: __( 'Small' ) },
+			{ value: 'medium', label: __( 'Medium' ) },
+			{ value: 'large', label: __( 'Large' ) },
+		],
+		getValue: ( { item } ) => {
+			const rowHeight = ( item as WidgetGridLayoutSettings ).rowHeight;
+			if ( typeof rowHeight !== 'number' ) {
+				return 'medium';
+			}
+			return rowHeightToPreset( rowHeight );
+		},
 		setValue: ( { value } ) => ( {
-			rowHeight: value ? ROW_HEIGHT_AUTO : DEFAULT_ROW_HEIGHT,
+			rowHeight: presetToRowHeight( value as RowHeightPreset ),
 		} ),
 		isVisible: ( item ) => ! isMasonry( item ),
-	},
-	{
-		id: 'rowHeight',
-		type: 'integer',
-		Edit: StepperIntegerEdit,
-		label: __( 'Row height (px)' ),
-		description: __( 'Height of each row in the standard grid.' ),
-		isValid: { min: 100 },
-		getValue: ( { item } ) => {
-			const rh = getRowHeight( item );
-			return typeof rh === 'number' ? rh : undefined;
-		},
-		isVisible: ( item ) => ! isMasonry( item ),
-		isDisabled: ( { item } ) => isAutoRowHeight( item ),
 	},
 ];
 
@@ -177,7 +165,6 @@ const form: Form = {
 		'columns',
 		'adaptiveColumns',
 		'minColumnWidth',
-		'autoRowHeight',
 		'rowHeight',
 	],
 };

--- a/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
+++ b/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
@@ -20,6 +20,8 @@ import {
  * Internal dependencies
  */
 import { computeGridModelChange } from '../utils/grid-model-change';
+import { normalizeGridSettings } from '../utils/normalize-grid-settings';
+import { DEFAULT_ROW_HEIGHT } from '../utils/row-height-presets';
 import type {
 	WidgetGridModel,
 	WidgetGridSettings,
@@ -41,7 +43,7 @@ const DEFAULT_GRID: WidgetGridSettings = {
 	model: 'grid',
 	columns: 12,
 	minColumnWidth: 140,
-	rowHeight: 140,
+	rowHeight: DEFAULT_ROW_HEIGHT,
 };
 
 type GridSettingsWithColumns = WidgetGridSettings & { columns: number };
@@ -49,9 +51,10 @@ type GridSettingsWithColumns = WidgetGridSettings & { columns: number };
 function resolveGridSettings(
 	settings: WidgetGridSettings
 ): GridSettingsWithColumns {
+	const normalized = normalizeGridSettings( settings, DEFAULT_ROW_HEIGHT );
 	return {
-		...settings,
-		columns: settings.columns ?? DEFAULT_GRID.columns!,
+		...normalized,
+		columns: normalized.columns ?? DEFAULT_GRID.columns!,
 	};
 }
 
@@ -264,11 +267,15 @@ export function WidgetDashboardProvider( {
 	}, [ committedLayout ] );
 
 	const [ stagingGridSettings, setStagingGridSettings ] =
-		useState< WidgetGridSettings >( committedGridSettings );
+		useState< WidgetGridSettings >( () =>
+			normalizeGridSettings( committedGridSettings, DEFAULT_ROW_HEIGHT )
+		);
 
 	// Same external-resync semantics as `stagingLayout`.
 	useEffect( () => {
-		setStagingGridSettings( committedGridSettings );
+		setStagingGridSettings(
+			normalizeGridSettings( committedGridSettings, DEFAULT_ROW_HEIGHT )
+		);
 	}, [ committedGridSettings ] );
 
 	const hasLayoutChanges = useMemo(
@@ -294,7 +301,12 @@ export function WidgetDashboardProvider( {
 			}
 
 			if ( hasGridSettingsChanges ) {
-				onGridSettingsChange?.( stagingGridSettings );
+				onGridSettingsChange?.(
+					normalizeGridSettings(
+						stagingGridSettings,
+						DEFAULT_ROW_HEIGHT
+					)
+				);
 			}
 
 			if ( options?.exitEditMode !== false ) {
@@ -340,7 +352,9 @@ export function WidgetDashboardProvider( {
 			setStagingLayout( next.layout );
 			setStagingGridSettings( next.gridSettings );
 			onLayoutChange( canonicalize( next.layout ) );
-			onGridSettingsChange?.( next.gridSettings );
+			onGridSettingsChange?.(
+				normalizeGridSettings( next.gridSettings, DEFAULT_ROW_HEIGHT )
+			);
 			onEditChange?.( false );
 		},
 		[

--- a/routes/dashboard/widget-dashboard/types.ts
+++ b/routes/dashboard/widget-dashboard/types.ts
@@ -145,16 +145,16 @@ interface BaseWidgetGridSettings {
 
 /**
  * 2D packed grid settings. Items declare explicit width and height
- * spans; rows can be uniform-sized or content-sized via `rowHeight`.
+ * spans; rows use a uniform track height via `rowHeight`.
  */
 export interface WidgetGridLayoutSettings extends BaseWidgetGridSettings {
 	model?: 'grid';
 
 	/**
-	 * Row height in pixels, or `'auto'` to let the tallest item in
-	 * each row size it.
+	 * Row height in pixels (`200` small, `300` medium, `400` large). Every
+	 * tile in a row fills the row vertically.
 	 */
-	rowHeight?: number | 'auto';
+	rowHeight?: number;
 }
 
 /**

--- a/routes/dashboard/widget-dashboard/utils/normalize-grid-settings/index.ts
+++ b/routes/dashboard/widget-dashboard/utils/normalize-grid-settings/index.ts
@@ -1,0 +1,1 @@
+export { normalizeGridSettings } from './normalize-grid-settings';

--- a/routes/dashboard/widget-dashboard/utils/normalize-grid-settings/normalize-grid-settings.ts
+++ b/routes/dashboard/widget-dashboard/utils/normalize-grid-settings/normalize-grid-settings.ts
@@ -1,0 +1,34 @@
+import type { WidgetGridLayoutSettings, WidgetGridSettings } from '../../types';
+import { snapRowHeight } from '../row-height-presets';
+
+/**
+ * Coerces legacy grid row heights to a dashboard preset. Standard grid
+ * rows always use uniform track sizing so tiles align with the masonry
+ * model boundary.
+ *
+ * @param settings         Grid settings to normalize.
+ * @param defaultRowHeight Fallback row height when none is set.
+ */
+export function normalizeGridSettings(
+	settings: WidgetGridSettings,
+	defaultRowHeight: number
+): WidgetGridSettings {
+	if ( ( settings.model ?? 'grid' ) === 'masonry' ) {
+		return settings;
+	}
+
+	const rowHeight = ( settings as WidgetGridLayoutSettings ).rowHeight;
+	const resolved =
+		typeof rowHeight === 'number'
+			? snapRowHeight( rowHeight )
+			: defaultRowHeight;
+
+	if ( rowHeight === resolved ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		rowHeight: resolved,
+	};
+}

--- a/routes/dashboard/widget-dashboard/utils/row-height-presets/index.ts
+++ b/routes/dashboard/widget-dashboard/utils/row-height-presets/index.ts
@@ -1,0 +1,8 @@
+export {
+	DEFAULT_ROW_HEIGHT,
+	ROW_HEIGHT_PRESETS,
+	presetToRowHeight,
+	rowHeightToPreset,
+	snapRowHeight,
+} from './row-height-presets';
+export type { RowHeightPreset } from './row-height-presets';

--- a/routes/dashboard/widget-dashboard/utils/row-height-presets/row-height-presets.ts
+++ b/routes/dashboard/widget-dashboard/utils/row-height-presets/row-height-presets.ts
@@ -1,0 +1,43 @@
+export const ROW_HEIGHT_PRESETS = {
+	small: 200,
+	medium: 300,
+	large: 400,
+} as const;
+
+export type RowHeightPreset = keyof typeof ROW_HEIGHT_PRESETS;
+
+export const DEFAULT_ROW_HEIGHT = ROW_HEIGHT_PRESETS.medium;
+
+const PRESET_ENTRIES = Object.entries( ROW_HEIGHT_PRESETS ) as [
+	RowHeightPreset,
+	number,
+][];
+
+/**
+ * Maps a stored pixel height to the nearest preset so legacy freeform
+ * values still resolve to a valid toggle option.
+ *
+ * @param rowHeight Row height in pixels.
+ */
+export function rowHeightToPreset( rowHeight: number ): RowHeightPreset {
+	let closest: RowHeightPreset = 'medium';
+	let minDistance = Infinity;
+
+	for ( const [ preset, value ] of PRESET_ENTRIES ) {
+		const distance = Math.abs( rowHeight - value );
+		if ( distance < minDistance ) {
+			minDistance = distance;
+			closest = preset;
+		}
+	}
+
+	return closest;
+}
+
+export function presetToRowHeight( preset: RowHeightPreset ): number {
+	return ROW_HEIGHT_PRESETS[ preset ];
+}
+
+export function snapRowHeight( rowHeight: number ): number {
+	return presetToRowHeight( rowHeightToPreset( rowHeight ) );
+}


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/78732 (same direction for columns — simplify layout settings and make opinionated product choices instead of exposing low-level grid geometry).

---

## What

- Removes **Auto-fit row height to content** from the dashboard **Layout settings** drawer.
- Replaces the freeform **Row height (px)** number control with a **Small / Medium / Large** toggle group.
- Standard grid rows always use **uniform track heights**; tiles fill their row vertically.
- Row height presets:
  - **Small** — 200px
  - **Medium** — 300px (default)
  - **Large** — 400px
- Drops `rowHeight: 'auto'` from dashboard grid settings; legacy `'auto'` and non-preset pixel values are normalized to the nearest preset on load and commit.

## Why

Most dashboard users should not need to tune row geometry pixel-by-pixel, and **auto-fit row height** blurs the boundary between **Standard grid** and **Masonry**. Grid tiles should share a consistent row height; Masonry is where content-driven height belongs. Letting rows size to content creates awkward overlap between the two layout models and makes the dashboard harder to scan.

Like the column work in #78732, we should make opinionated decisions and keep layout settings focused on meaningful choices, not low-level grid math.

**Three presets** give enough flexibility (compact vs. comfortable tiles) without inviting configurations that fight the layout system. **300px** as the default balances readable widget chrome with a practical number of rows on typical dashboard surfaces.

## How

- Added `ROW_HEIGHT_PRESETS`, `rowHeightToPreset()`, `presetToRowHeight()`, and `snapRowHeight()` in `utils/row-height-presets/`.
- Added `normalizeGridSettings()` to coerce legacy `'auto'` and freeform heights to preset values.
- Updated the `rowHeight` DataForm field to `type: 'text'` with `Edit: 'toggleGroup'` and `getValue` / `setValue` mapping between preset keys and stored pixel heights.
- Wired normalization through `WidgetDashboardProvider` (staging, resolve, commit) and `useDashboardGridSettings`.
- Updated `WidgetGridLayoutSettings` so `rowHeight` is `number` only.
- Set default row height to `DEFAULT_ROW_HEIGHT` (300px / medium) in provider and preferences hook.

`@wordpress/grid` still supports `rowHeight: 'auto'` for other consumers; the dashboard always passes a numeric height.

## Test plan

- [ ] Open **Layout settings** on a **Standard grid** dashboard and confirm **Auto-fit row height to content** and the freeform **Row height (px)** control are gone.
- [ ] Confirm **Row height** shows **Small**, **Medium**, and **Large** as a toggle group; **Medium** is selected by default on a fresh dashboard.
- [ ] Select each preset and confirm grid tiles resize live behind the drawer (200px / 300px / 400px row tracks).
- [ ] **Save**, reload, and confirm the chosen preset persists.
- [ ] **Cancel** after changing row height and confirm the grid reverts.
- [ ] **Reset** in layout settings and confirm row height returns to **Medium** (300px).
- [ ] Switch to **Masonry** and confirm the row height control is hidden.
- [ ] Switch back to **Standard grid** and confirm layout migrates without errors and row height is available again.
- [ ] If you have older preferences with `rowHeight: 'auto'` or a custom pixel value, reload and confirm a valid preset is selected and the grid renders with uniform rows.
- [ ] With #78732 (or equivalent column changes) applied, confirm layout settings remain focused on model + row height (and any other retained controls), without restored column/auto-row controls.

## Screenshots

| Before | After |
|--------|-------|
| <img width="477" height="777" alt="Screenshot 2026-05-27 at 14 57 20" src="https://github.com/user-attachments/assets/280efdc2-50e2-4c72-83c0-0e58919678e6" /> | <img width="528" height="777" alt="Screenshot 2026-05-27 at 14 56 36" src="https://github.com/user-attachments/assets/96b1371a-ffdc-4ab0-892d-b87232dee210" /> |


