### PR TITLE
RTC: Deduplicate collaborators list by WordPress user ID

### DIFF
--- a/packages/editor/src/components/collaborators-presence/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/index.tsx
@@ -23,6 +23,39 @@ interface CollaboratorsPresenceProps {
 }
 
 /**
+ * Groups awareness states by WordPress user ID and returns one entry per user.
+ * Priority: isMe first (preserves "You" label), then connected over disconnected,
+ * then most recently entered tab.
+ *
+ * @param states Awareness states to deduplicate.
+ */
+function deduplicateByUserId(
+	states: PostEditorAwarenessState[]
+): PostEditorAwarenessState[] {
+	const byUserId = new Map< number, PostEditorAwarenessState >();
+	for ( const state of states ) {
+		const userId = state.collaboratorInfo.id;
+		const existing = byUserId.get( userId );
+		if ( ! existing ) {
+			byUserId.set( userId, state );
+			continue;
+		}
+		const pickNew =
+			( state.isMe && ! existing.isMe ) ||
+			( ! state.isMe &&
+				! existing.isMe &&
+				( ( state.isConnected && ! existing.isConnected ) ||
+					( state.isConnected === existing.isConnected &&
+						state.collaboratorInfo.enteredAt >
+							existing.collaboratorInfo.enteredAt ) ) );
+		if ( pickNew ) {
+			byUserId.set( userId, state );
+		}
+	}
+	return Array.from( byUserId.values() );
+}
+
+/**
  * Renders a list of avatars for the active collaborators, with a maximum of 3 visible avatars.
  * Shows a popover with all collaborators on hover.
  *
@@ -39,21 +72,29 @@ export function CollaboratorsPresence( {
 		postType
 	) as PostEditorAwarenessState[];
 
-	const otherActiveCollaborators = activeCollaborators.filter(
-		( c ) => ! c.isMe
+	const me = activeCollaborators.find( ( c ) => c.isMe );
+
+	// Filter by user ID (not just isMe) so the current user's other tabs don't appear as collaborators.
+	const otherActiveCollaborators = deduplicateByUserId(
+		activeCollaborators.filter(
+			( c ) =>
+				! c.isMe && c.collaboratorInfo.id !== me?.collaboratorInfo.id
+		)
 	);
 
-	// Always include self in the list sorted first.
+	// Always include self in the list sorted first, one entry per WP user.
 	const collaboratorsForList = useMemo( () => {
-		return [ ...activeCollaborators ].sort( ( a, b ) => {
-			if ( a.isMe && ! b.isMe ) {
-				return -1;
+		return deduplicateByUserId( [ ...activeCollaborators ] ).sort(
+			( a, b ) => {
+				if ( a.isMe && ! b.isMe ) {
+					return -1;
+				}
+				if ( ! a.isMe && b.isMe ) {
+					return 1;
+				}
+				return 0;
 			}
-			if ( ! a.isMe && b.isMe ) {
-				return 1;
-			}
-			return 0;
-		} );
+		);
 	}, [ activeCollaborators ] );
 
 	const [ cursorRegistry ] = useState( createCursorRegistry );
@@ -69,8 +110,6 @@ export function CollaboratorsPresence( {
 	if ( otherActiveCollaborators.length === 0 ) {
 		return null;
 	}
-
-	const me = activeCollaborators.find( ( c ) => c.isMe );
 
 	return (
 		<>


### PR DESCRIPTION
## What?

Closes #78700 

When the same WordPress user has a post open in multiple browser tabs simultaneously, deduplicate the collaborators header avatars and popover list so they appear only once.

## Why?

Each browser tab registers its own Yjs awareness `clientId`. Because the presence list was keyed and rendered by `clientId`, a single user with two tabs open would appear as two separate entries — each with its own avatar and color. Other collaborators would perceive more concurrent editors than there actually are, and the user themselves would see their own avatar duplicated.

## How?

This is a render-layer change only. The underlying per-`clientId` Yjs awareness state is left completely untouched so cursor and selection rendering in the editor overlay continues to work for each individual session.

A `deduplicateByUserId` helper groups `PostEditorAwarenessState` entries by `collaboratorInfo.id` (the WordPress user ID) and keeps one canonical entry per user, chosen by priority:

1. `isMe: true` entry wins — preserves the "You" label and disabled state in the popover list.
2. Connected session over disconnected.
3. Most recently entered tab (`collaboratorInfo.enteredAt`).

Two call sites are updated in `CollaboratorsPresence`:

- **`otherActiveCollaborators`** — now filters by both `!c.isMe` **and** `c.collaboratorInfo.id !== me?.collaboratorInfo.id`, so the current user's other tabs are excluded entirely from the header avatars.
- **`collaboratorsForList`** — deduplicated before sorting, so the popover list shows one row per user.

`CollaboratorsOverlay` is not affected; it calls `useActiveCollaborators` independently and renders one cursor per `clientId` as before.

## Testing Instructions

**Multi-tab duplicate avatar:**

1. Enable the RTC/collaboration feature.
2. Open a post or page in two separate browser tabs as the same user (e.g. open Tab 1, then duplicate the tab).
3. In each tab, observe the collaborators avatar group in the editor header.
   - **Before:** Two avatars appear for the same user — one "You" avatar and one duplicate with a colored border.
   - **After:** Only one "You" avatar appears in the header. The popover lists the user once, labelled "You".

**Normal multi-user collaboration (regression check):**

1. Open a post as User A (Tab 1) and as User B in a separate browser/incognito window (Tab 2).
2. Both users should see each other's avatars — one each.
3. Clicking a collaborator's name in the popover should scroll to their cursor.
4. Closing a tab should remove the collaborator from the list.

### Testing Instructions for Keyboard

1. Tab to the collaborators avatar button in the toolbar and press **Enter** to open the popover.
2. Verify the collaborator count in the button's `aria-label` ("Collaborators list, N online") matches the number of unique users visible.
3. Tab through the list items in the popover — each collaborator should be focusable, pressing **Enter** on a collaborator should scroll to their cursor.
4. Press **Escape** or Tab to the close button and press **Enter** to dismiss the popover.

## Screenshots or screencast

|Before|After|
|-|-|
|<!-- same user shows two avatars -->|<!-- same user shows one avatar -->|