### PR TITLE
Editor: Refactor 'PostPublishButton' into function component

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1236,7 +1236,7 @@ _Returns_
 
 ### PostPublishButton
 
-Renders the publish button.
+Undocumented declaration.
 
 ### PostPublishButtonLabel
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1236,7 +1236,7 @@ _Returns_
 
 ### PostPublishButton
 
-Undocumented declaration.
+Renders the publish button.
 
 ### PostPublishButtonLabel
 

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -2,9 +2,7 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { Component } from '@wordpress/element';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,220 +12,168 @@ import { store as editorStore } from '../../store';
 
 const noop = () => {};
 
-export class PostPublishButton extends Component {
-	constructor( props ) {
-		super( props );
-
-		this.createOnClick = this.createOnClick.bind( this );
-		this.closeEntitiesSavedStates =
-			this.closeEntitiesSavedStates.bind( this );
-
-		this.state = {
-			entitiesSavedStatesCallback: false,
+export default function PostPublishButton( {
+	forceIsDirty,
+	isOpen,
+	isToggle,
+	onSubmit = noop,
+	onToggle,
+	setEntitiesSavedStatesCallback,
+} ) {
+	const {
+		hasPublishAction,
+		isBeingScheduled,
+		isPostSavingLocked,
+		isPublishable,
+		isPublished,
+		isSaveable,
+		isSaving,
+		isAutoSaving,
+		visibility,
+		hasNonPostEntityChanges,
+		isSavingNonPostEntityChanges,
+		postStatus,
+		postStatusHasChanged,
+		postType,
+		postId,
+	} = useSelect( ( select ) => {
+		const store = select( editorStore );
+		return {
+			isSaving: store.isSavingPost(),
+			isAutoSaving: store.isAutosavingPost(),
+			isBeingScheduled: store.isEditedPostBeingScheduled(),
+			visibility: store.getEditedPostVisibility(),
+			isSaveable: store.isEditedPostSaveable(),
+			isPostSavingLocked: store.isPostSavingLocked(),
+			isPublishable: store.isEditedPostPublishable(),
+			isPublished: store.isCurrentPostPublished(),
+			hasPublishAction:
+				store.getCurrentPost()._links?.[ 'wp:action-publish' ] ?? false,
+			postType: store.getCurrentPostType(),
+			postId: store.getCurrentPostId(),
+			postStatus: store.getEditedPostAttribute( 'status' ),
+			postStatusHasChanged: store.getPostEdits()?.status,
+			hasNonPostEntityChanges: store.hasNonPostEntityChanges(),
+			isSavingNonPostEntityChanges: store.isSavingNonPostEntityChanges(),
 		};
-	}
+	}, [] );
 
-	createOnClick( callback ) {
-		return ( ...args ) => {
-			const { hasNonPostEntityChanges, setEntitiesSavedStatesCallback } =
-				this.props;
+	const { editPost, savePost } = useDispatch( editorStore );
+
+	const savePostStatus = ( status ) => {
+		editPost( { status }, { undoIgnore: true } );
+		savePost();
+	};
+
+	const createOnClick =
+		( callback ) =>
+		( ...args ) => {
 			// If a post with non-post entities is published, but the user
 			// elects to not save changes to the non-post entities, those
 			// entities will still be dirty when the Publish button is clicked.
 			// We also need to check that the `setEntitiesSavedStatesCallback`
 			// prop was passed. See https://github.com/WordPress/gutenberg/pull/37383
 			if ( hasNonPostEntityChanges && setEntitiesSavedStatesCallback ) {
-				// The modal for multiple entity saving will open,
-				// hold the callback for saving/publishing the post
-				// so that we can call it if the post entity is checked.
-				this.setState( {
-					entitiesSavedStatesCallback: () => callback( ...args ),
-				} );
+				// The modal for multiple entity saving will open. If the post
+				// entity is checked when it closes, run the held callback.
+				const onClose = ( savedEntities ) => {
+					if (
+						savedEntities &&
+						savedEntities.some(
+							( elt ) =>
+								elt.kind === 'postType' &&
+								elt.name === postType &&
+								elt.key === postId
+						)
+					) {
+						callback( ...args );
+					}
+				};
 
 				// Open the save panel by setting its callback.
 				// To set a function on the useState hook, we must set it
 				// with another function (() => myFunction). Passing the
 				// function on its own will cause an error when called.
-				setEntitiesSavedStatesCallback(
-					() => this.closeEntitiesSavedStates
-				);
+				setEntitiesSavedStatesCallback( () => onClose );
 				return noop;
 			}
 
 			return callback( ...args );
 		};
+
+	const isButtonDisabled =
+		isPostSavingLocked ||
+		( ( isSaving ||
+			! isSaveable ||
+			( ! isPublishable && ! forceIsDirty ) ) &&
+			( ! hasNonPostEntityChanges || isSavingNonPostEntityChanges ) );
+
+	const isToggleDisabled =
+		isPostSavingLocked ||
+		( ( isPublished ||
+			isSaving ||
+			! isSaveable ||
+			( ! isPublishable && ! forceIsDirty ) ) &&
+			( ! hasNonPostEntityChanges || isSavingNonPostEntityChanges ) );
+
+	// If the new status has not changed explicitly, we derive it from
+	// other factors, like having a publish action, etc.. We need to preserve
+	// this because it affects when to show the pre and post publish panels.
+	// If it has changed though explicitly, we need to respect that.
+	let publishStatus = 'publish';
+	if ( postStatusHasChanged ) {
+		publishStatus = postStatus;
+	} else if ( ! hasPublishAction ) {
+		publishStatus = 'pending';
+	} else if ( visibility === 'private' ) {
+		publishStatus = 'private';
+	} else if ( isBeingScheduled ) {
+		publishStatus = 'future';
 	}
 
-	closeEntitiesSavedStates( savedEntities ) {
-		const { postType, postId } = this.props;
-		const { entitiesSavedStatesCallback } = this.state;
-		this.setState( { entitiesSavedStatesCallback: false }, () => {
-			if (
-				savedEntities &&
-				savedEntities.some(
-					( elt ) =>
-						elt.kind === 'postType' &&
-						elt.name === postType &&
-						elt.key === postId
-				)
-			) {
-				// The post entity was checked, call the held callback from `createOnClick`.
-				entitiesSavedStatesCallback();
-			}
-		} );
-	}
-
-	render() {
-		const {
-			forceIsDirty,
-			hasPublishAction,
-			isBeingScheduled,
-			isOpen,
-			isPostSavingLocked,
-			isPublishable,
-			isPublished,
-			isSaveable,
-			isSaving,
-			isAutoSaving,
-			isToggle,
-			savePostStatus,
-			onSubmit = noop,
-			onToggle,
-			visibility,
-			hasNonPostEntityChanges,
-			isSavingNonPostEntityChanges,
-			postStatus,
-			postStatusHasChanged,
-		} = this.props;
-
-		const isButtonDisabled =
-			isPostSavingLocked ||
-			( ( isSaving ||
-				! isSaveable ||
-				( ! isPublishable && ! forceIsDirty ) ) &&
-				( ! hasNonPostEntityChanges || isSavingNonPostEntityChanges ) );
-
-		const isToggleDisabled =
-			isPostSavingLocked ||
-			( ( isPublished ||
-				isSaving ||
-				! isSaveable ||
-				( ! isPublishable && ! forceIsDirty ) ) &&
-				( ! hasNonPostEntityChanges || isSavingNonPostEntityChanges ) );
-
-		// If the new status has not changed explicitly, we derive it from
-		// other factors, like having a publish action, etc.. We need to preserve
-		// this because it affects when to show the pre and post publish panels.
-		// If it has changed though explicitly, we need to respect that.
-		let publishStatus = 'publish';
-		if ( postStatusHasChanged ) {
-			publishStatus = postStatus;
-		} else if ( ! hasPublishAction ) {
-			publishStatus = 'pending';
-		} else if ( visibility === 'private' ) {
-			publishStatus = 'private';
-		} else if ( isBeingScheduled ) {
-			publishStatus = 'future';
+	const onClickButton = () => {
+		if ( isButtonDisabled ) {
+			return;
 		}
+		onSubmit();
+		savePostStatus( publishStatus );
+	};
 
-		const onClickButton = () => {
-			if ( isButtonDisabled ) {
-				return;
-			}
-			onSubmit();
-			savePostStatus( publishStatus );
-		};
+	// Callback to open the publish panel.
+	const onClickToggle = () => {
+		if ( isToggleDisabled ) {
+			return;
+		}
+		onToggle();
+	};
 
-		// Callback to open the publish panel.
-		const onClickToggle = () => {
-			if ( isToggleDisabled ) {
-				return;
-			}
-			onToggle();
-		};
+	const buttonProps = {
+		'aria-disabled': isButtonDisabled,
+		className: 'editor-post-publish-button',
+		isBusy: ! isAutoSaving && isSaving,
+		variant: 'primary',
+		onClick: createOnClick( onClickButton ),
+		'aria-haspopup': hasNonPostEntityChanges ? 'dialog' : undefined,
+	};
 
-		const buttonProps = {
-			'aria-disabled': isButtonDisabled,
-			className: 'editor-post-publish-button',
-			isBusy: ! isAutoSaving && isSaving,
-			variant: 'primary',
-			onClick: this.createOnClick( onClickButton ),
-			'aria-haspopup': hasNonPostEntityChanges ? 'dialog' : undefined,
-		};
-
-		const toggleProps = {
-			'aria-disabled': isToggleDisabled,
-			'aria-expanded': isOpen,
-			className: 'editor-post-publish-panel__toggle',
-			isBusy: isSaving && isPublished,
-			variant: 'primary',
-			size: 'compact',
-			onClick: this.createOnClick( onClickToggle ),
-			'aria-haspopup': hasNonPostEntityChanges ? 'dialog' : undefined,
-		};
-		const componentProps = isToggle ? toggleProps : buttonProps;
-		return (
-			<>
-				<Button
-					{ ...componentProps }
-					className={ `${ componentProps.className } editor-post-publish-button__button` }
-					size="compact"
-				>
-					<PublishButtonLabel />
-				</Button>
-			</>
-		);
-	}
+	const toggleProps = {
+		'aria-disabled': isToggleDisabled,
+		'aria-expanded': isOpen,
+		className: 'editor-post-publish-panel__toggle',
+		isBusy: isSaving && isPublished,
+		variant: 'primary',
+		size: 'compact',
+		onClick: createOnClick( onClickToggle ),
+		'aria-haspopup': hasNonPostEntityChanges ? 'dialog' : undefined,
+	};
+	const componentProps = isToggle ? toggleProps : buttonProps;
+	return (
+		<Button
+			{ ...componentProps }
+			className={ `${ componentProps.className } editor-post-publish-button__button` }
+			size="compact"
+		>
+			<PublishButtonLabel />
+		</Button>
+	);
 }
-
-/**
- * Renders the publish button.
- */
-export default compose( [
-	withSelect( ( select ) => {
-		const {
-			isSavingPost,
-			isAutosavingPost,
-			isEditedPostBeingScheduled,
-			getEditedPostVisibility,
-			isCurrentPostPublished,
-			isEditedPostSaveable,
-			isEditedPostPublishable,
-			isPostSavingLocked,
-			getCurrentPost,
-			getCurrentPostType,
-			getCurrentPostId,
-			hasNonPostEntityChanges,
-			isSavingNonPostEntityChanges,
-			getEditedPostAttribute,
-			getPostEdits,
-		} = select( editorStore );
-		return {
-			isSaving: isSavingPost(),
-			isAutoSaving: isAutosavingPost(),
-			isBeingScheduled: isEditedPostBeingScheduled(),
-			visibility: getEditedPostVisibility(),
-			isSaveable: isEditedPostSaveable(),
-			isPostSavingLocked: isPostSavingLocked(),
-			isPublishable: isEditedPostPublishable(),
-			isPublished: isCurrentPostPublished(),
-			hasPublishAction:
-				getCurrentPost()._links?.[ 'wp:action-publish' ] ?? false,
-			postType: getCurrentPostType(),
-			postId: getCurrentPostId(),
-			postStatus: getEditedPostAttribute( 'status' ),
-			postStatusHasChanged: getPostEdits()?.status,
-			hasNonPostEntityChanges: hasNonPostEntityChanges(),
-			isSavingNonPostEntityChanges: isSavingNonPostEntityChanges(),
-		};
-	} ),
-	withDispatch( ( dispatch ) => {
-		const { editPost, savePost } = dispatch( editorStore );
-		return {
-			savePostStatus: ( status ) => {
-				editPost( { status }, { undoIgnore: true } );
-				savePost();
-			},
-		};
-	} ),
-] )( PostPublishButton );

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -12,7 +12,7 @@ import { store as editorStore } from '../../store';
 
 const noop = () => {};
 
-export default function PostPublishButton( {
+export function PostPublishButton( {
 	forceIsDirty,
 	isOpen,
 	isToggle,
@@ -177,3 +177,8 @@ export default function PostPublishButton( {
 		</Button>
 	);
 }
+
+/**
+ * Renders the publish button.
+ */
+export default PostPublishButton;

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -15,10 +15,6 @@ import { dispatch, select } from '@wordpress/data';
 import PostPublishButton from '../';
 import { store as editorStore } from '../../../store';
 
-// The label component runs its own selectors. Stub it so each test can
-// assert on a stable button name without coupling to the label's logic.
-jest.mock( '../label', () => () => 'Submit for Review' );
-
 describe( 'PostPublishButton', () => {
 	beforeEach( () => {
 		jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
@@ -50,9 +46,10 @@ describe( 'PostPublishButton', () => {
 
 			render( <PostPublishButton /> );
 
-			expect(
-				screen.getByRole( 'button', { name: 'Submit for Review' } )
-			).toHaveAttribute( 'aria-disabled', 'true' );
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
+			);
 		} );
 
 		it( 'should be true if post is not publishable and not forceIsDirty', () => {
@@ -61,9 +58,10 @@ describe( 'PostPublishButton', () => {
 
 			render( <PostPublishButton forceIsDirty={ false } /> );
 
-			expect(
-				screen.getByRole( 'button', { name: 'Submit for Review' } )
-			).toHaveAttribute( 'aria-disabled', 'true' );
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
+			);
 		} );
 
 		it( 'should be true if post is not saveable', () => {
@@ -72,9 +70,10 @@ describe( 'PostPublishButton', () => {
 
 			render( <PostPublishButton /> );
 
-			expect(
-				screen.getByRole( 'button', { name: 'Submit for Review' } )
-			).toHaveAttribute( 'aria-disabled', 'true' );
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
+			);
 		} );
 
 		it( 'should be true if post saving is locked', () => {
@@ -84,9 +83,10 @@ describe( 'PostPublishButton', () => {
 
 			render( <PostPublishButton /> );
 
-			expect(
-				screen.getByRole( 'button', { name: 'Submit for Review' } )
-			).toHaveAttribute( 'aria-disabled', 'true' );
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
+			);
 		} );
 
 		it( 'should be false if post is saveable but not publishable and forceIsDirty is true', () => {
@@ -95,9 +95,10 @@ describe( 'PostPublishButton', () => {
 
 			render( <PostPublishButton forceIsDirty /> );
 
-			expect(
-				screen.getByRole( 'button', { name: 'Submit for Review' } )
-			).toHaveAttribute( 'aria-disabled', 'false' );
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-disabled',
+				'false'
+			);
 		} );
 
 		it( 'should be false if post is publishave and saveable', () => {
@@ -106,9 +107,10 @@ describe( 'PostPublishButton', () => {
 
 			render( <PostPublishButton /> );
 
-			expect(
-				screen.getByRole( 'button', { name: 'Submit for Review' } )
-			).toHaveAttribute( 'aria-disabled', 'false' );
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-disabled',
+				'false'
+			);
 		} );
 	} );
 
@@ -121,9 +123,7 @@ describe( 'PostPublishButton', () => {
 
 			render( <PostPublishButton /> );
 
-			await user.click(
-				screen.getByRole( 'button', { name: 'Submit for Review' } )
-			);
+			await user.click( screen.getByRole( 'button' ) );
 
 			expect( dispatch( editorStore ).editPost ).toHaveBeenCalledWith(
 				{ status: 'pending' },
@@ -140,9 +140,7 @@ describe( 'PostPublishButton', () => {
 
 			render( <PostPublishButton /> );
 
-			await user.click(
-				screen.getByRole( 'button', { name: 'Submit for Review' } )
-			);
+			await user.click( screen.getByRole( 'button' ) );
 
 			expect( dispatch( editorStore ).editPost ).toHaveBeenCalledWith(
 				{ status: 'future' },
@@ -159,9 +157,7 @@ describe( 'PostPublishButton', () => {
 
 			render( <PostPublishButton /> );
 
-			await user.click(
-				screen.getByRole( 'button', { name: 'Submit for Review' } )
-			);
+			await user.click( screen.getByRole( 'button' ) );
 
 			expect( dispatch( editorStore ).editPost ).toHaveBeenCalledWith(
 				{ status: 'private' },
@@ -177,9 +173,7 @@ describe( 'PostPublishButton', () => {
 
 			render( <PostPublishButton /> );
 
-			await user.click(
-				screen.getByRole( 'button', { name: 'Submit for Review' } )
-			);
+			await user.click( screen.getByRole( 'button' ) );
 
 			expect( dispatch( editorStore ).editPost ).toHaveBeenCalledWith(
 				{ status: 'publish' },
@@ -197,9 +191,7 @@ describe( 'PostPublishButton', () => {
 
 			render( <PostPublishButton /> );
 
-			await user.click(
-				screen.getByRole( 'button', { name: 'Submit for Review' } )
-			);
+			await user.click( screen.getByRole( 'button' ) );
 
 			expect( dispatch( editorStore ).editPost ).toHaveBeenCalledWith(
 				{ status: 'publish' },
@@ -215,8 +207,6 @@ describe( 'PostPublishButton', () => {
 
 		render( <PostPublishButton /> );
 
-		expect(
-			screen.getByRole( 'button', { name: 'Submit for Review' } )
-		).toHaveClass( 'is-busy' );
+		expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-busy' );
 	} );
 } );

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -5,14 +5,50 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
+ * WordPress dependencies
+ */
+import { dispatch, select } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
-import { PostPublishButton } from '../';
+import PostPublishButton from '../';
+import { store as editorStore } from '../../../store';
+
+// The label component runs its own selectors. Stub it so each test can
+// assert on a stable button name without coupling to the label's logic.
+jest.mock( '../label', () => () => 'Submit for Review' );
 
 describe( 'PostPublishButton', () => {
+	beforeEach( () => {
+		jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
+			_links: {},
+		} );
+		jest.spyOn( dispatch( editorStore ), 'editPost' ).mockReturnValue();
+		jest.spyOn( dispatch( editorStore ), 'savePost' ).mockReturnValue();
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	function mockSelector( name, value ) {
+		jest.spyOn( select( editorStore ), name ).mockReturnValue( value );
+	}
+
+	function mockHasPublishAction( hasPublishAction ) {
+		jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
+			_links: hasPublishAction ? { 'wp:action-publish': true } : {},
+		} );
+	}
+
 	describe( 'aria-disabled', () => {
 		it( 'should be true if post is currently saving', () => {
-			render( <PostPublishButton isPublishable isSaveable isSaving /> );
+			mockSelector( 'isEditedPostPublishable', true );
+			mockSelector( 'isEditedPostSaveable', true );
+			mockSelector( 'isSavingPost', true );
+
+			render( <PostPublishButton /> );
 
 			expect(
 				screen.getByRole( 'button', { name: 'Submit for Review' } )
@@ -20,13 +56,10 @@ describe( 'PostPublishButton', () => {
 		} );
 
 		it( 'should be true if post is not publishable and not forceIsDirty', () => {
-			render(
-				<PostPublishButton
-					isSaveable
-					isPublishable={ false }
-					forceIsDirty={ false }
-				/>
-			);
+			mockSelector( 'isEditedPostSaveable', true );
+			mockSelector( 'isEditedPostPublishable', false );
+
+			render( <PostPublishButton forceIsDirty={ false } /> );
 
 			expect(
 				screen.getByRole( 'button', { name: 'Submit for Review' } )
@@ -34,7 +67,10 @@ describe( 'PostPublishButton', () => {
 		} );
 
 		it( 'should be true if post is not saveable', () => {
-			render( <PostPublishButton isPublishable isSaveable={ false } /> );
+			mockSelector( 'isEditedPostPublishable', true );
+			mockSelector( 'isEditedPostSaveable', false );
+
+			render( <PostPublishButton /> );
 
 			expect(
 				screen.getByRole( 'button', { name: 'Submit for Review' } )
@@ -42,13 +78,11 @@ describe( 'PostPublishButton', () => {
 		} );
 
 		it( 'should be true if post saving is locked', () => {
-			render(
-				<PostPublishButton
-					isPublishable
-					isSaveable
-					isPostSavingLocked
-				/>
-			);
+			mockSelector( 'isEditedPostPublishable', true );
+			mockSelector( 'isEditedPostSaveable', true );
+			mockSelector( 'isPostSavingLocked', true );
+
+			render( <PostPublishButton /> );
 
 			expect(
 				screen.getByRole( 'button', { name: 'Submit for Review' } )
@@ -56,13 +90,10 @@ describe( 'PostPublishButton', () => {
 		} );
 
 		it( 'should be false if post is saveable but not publishable and forceIsDirty is true', () => {
-			render(
-				<PostPublishButton
-					isSaveable
-					isPublishable={ false }
-					forceIsDirty
-				/>
-			);
+			mockSelector( 'isEditedPostSaveable', true );
+			mockSelector( 'isEditedPostPublishable', false );
+
+			render( <PostPublishButton forceIsDirty /> );
 
 			expect(
 				screen.getByRole( 'button', { name: 'Submit for Review' } )
@@ -70,7 +101,10 @@ describe( 'PostPublishButton', () => {
 		} );
 
 		it( 'should be false if post is publishave and saveable', () => {
-			render( <PostPublishButton isPublishable isSaveable /> );
+			mockSelector( 'isEditedPostPublishable', true );
+			mockSelector( 'isEditedPostSaveable', true );
+
+			render( <PostPublishButton /> );
 
 			expect(
 				screen.getByRole( 'button', { name: 'Submit for Review' } )
@@ -81,106 +115,105 @@ describe( 'PostPublishButton', () => {
 	describe( 'publish status', () => {
 		it( 'should be pending for contributor', async () => {
 			const user = userEvent.setup();
-			const savePostStatus = jest.fn();
-			render(
-				<PostPublishButton
-					hasPublishAction={ false }
-					savePostStatus={ savePostStatus }
-					isSaveable
-					isPublishable
-				/>
-			);
+			mockHasPublishAction( false );
+			mockSelector( 'isEditedPostSaveable', true );
+			mockSelector( 'isEditedPostPublishable', true );
+
+			render( <PostPublishButton /> );
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Submit for Review' } )
 			);
 
-			expect( savePostStatus ).toHaveBeenCalledWith( 'pending' );
+			expect( dispatch( editorStore ).editPost ).toHaveBeenCalledWith(
+				{ status: 'pending' },
+				{ undoIgnore: true }
+			);
 		} );
 
 		it( 'should be future for scheduled post', async () => {
 			const user = userEvent.setup();
-			const savePostStatus = jest.fn();
-			render(
-				<PostPublishButton
-					hasPublishAction
-					savePostStatus={ savePostStatus }
-					isBeingScheduled
-					isSaveable
-					isPublishable
-				/>
-			);
+			mockHasPublishAction( true );
+			mockSelector( 'isEditedPostBeingScheduled', true );
+			mockSelector( 'isEditedPostSaveable', true );
+			mockSelector( 'isEditedPostPublishable', true );
+
+			render( <PostPublishButton /> );
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Submit for Review' } )
 			);
 
-			expect( savePostStatus ).toHaveBeenCalledWith( 'future' );
+			expect( dispatch( editorStore ).editPost ).toHaveBeenCalledWith(
+				{ status: 'future' },
+				{ undoIgnore: true }
+			);
 		} );
 
 		it( 'should be private for private visibility', async () => {
 			const user = userEvent.setup();
-			const savePostStatus = jest.fn();
-			render(
-				<PostPublishButton
-					hasPublishAction
-					savePostStatus={ savePostStatus }
-					visibility="private"
-					isSaveable
-					isPublishable
-				/>
-			);
+			mockHasPublishAction( true );
+			mockSelector( 'getEditedPostVisibility', 'private' );
+			mockSelector( 'isEditedPostSaveable', true );
+			mockSelector( 'isEditedPostPublishable', true );
+
+			render( <PostPublishButton /> );
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Submit for Review' } )
 			);
 
-			expect( savePostStatus ).toHaveBeenCalledWith( 'private' );
+			expect( dispatch( editorStore ).editPost ).toHaveBeenCalledWith(
+				{ status: 'private' },
+				{ undoIgnore: true }
+			);
 		} );
 
 		it( 'should be publish otherwise', async () => {
 			const user = userEvent.setup();
-			const savePostStatus = jest.fn();
-			render(
-				<PostPublishButton
-					hasPublishAction
-					savePostStatus={ savePostStatus }
-					isSaveable
-					isPublishable
-				/>
-			);
+			mockHasPublishAction( true );
+			mockSelector( 'isEditedPostSaveable', true );
+			mockSelector( 'isEditedPostPublishable', true );
+
+			render( <PostPublishButton /> );
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Submit for Review' } )
 			);
 
-			expect( savePostStatus ).toHaveBeenCalledWith( 'publish' );
+			expect( dispatch( editorStore ).editPost ).toHaveBeenCalledWith(
+				{ status: 'publish' },
+				{ undoIgnore: true }
+			);
 		} );
 	} );
 
 	describe( 'click', () => {
 		it( 'should save with status', async () => {
 			const user = userEvent.setup();
-			const savePostStatus = jest.fn();
-			render(
-				<PostPublishButton
-					hasPublishAction
-					savePostStatus={ savePostStatus }
-					isSaveable
-					isPublishable
-				/>
-			);
+			mockHasPublishAction( true );
+			mockSelector( 'isEditedPostSaveable', true );
+			mockSelector( 'isEditedPostPublishable', true );
+
+			render( <PostPublishButton /> );
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Submit for Review' } )
 			);
 
-			expect( savePostStatus ).toHaveBeenCalledWith( 'publish' );
+			expect( dispatch( editorStore ).editPost ).toHaveBeenCalledWith(
+				{ status: 'publish' },
+				{ undoIgnore: true }
+			);
+			expect( dispatch( editorStore ).savePost ).toHaveBeenCalled();
 		} );
 	} );
 
 	it( 'should have save modifier class', () => {
-		render( <PostPublishButton isSaving isPublished /> );
+		mockSelector( 'isSavingPost', true );
+		mockSelector( 'isCurrentPostPublished', true );
+
+		render( <PostPublishButton /> );
 
 		expect(
 			screen.getByRole( 'button', { name: 'Submit for Review' } )


### PR DESCRIPTION
## What?
Supersedes #73992.
Decided to clean this up while working on #78659.

PR refacators 'PostPublishButton' into a function component, replacing HoC with appropriate hooks.

The `entitiesSavedStates` callback bookkeeping (previously held in component state) is gone; each click now builds its own closure that's handed to the parent, so no state or ref is needed.

## Testing Instructions
1. Smoke test publish button.
2. CI checks should be green.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
