### PR TITLE
Dashboard: Move layout settings to customize toolbar

### DIFF
--- a/routes/dashboard/widget-dashboard/README.md
+++ b/routes/dashboard/widget-dashboard/README.md
@@ -88,7 +88,7 @@ Renders its children only when `layout` is empty. Pair it with `<WidgetDashboard
 
 #### `<WidgetDashboard.Actions />`
 
-Edit-mode toggle: a "Customize" button while `editMode` is off, and "Add widget", "Cancel", "Done" while it is on. Clicking "Customize" or "Done" fires `onEditChange` with the toggled value. Clicking "Add widget" opens the inserter (see below). Returns `null` when the dashboard is mounted without `onEditChange`, so hosts that don't expose edit mode can keep `Actions` in their tree unconditionally.
+Edit-mode toggle: a "Customize" button while `editMode` is off, and "Add widget", "Layout settings" (when `onGridSettingsChange` is provided), "Cancel", "Done" while it is on. Layout settings is only available in customize mode. Clicking "Customize" or "Done" fires `onEditChange` with the toggled value. Clicking "Add widget" opens the inserter (see below). Returns `null` when the dashboard is mounted without `onEditChange`, so surfaces that don't expose edit mode can keep `Actions` in their tree unconditionally.
 
 `<Page>` from `@wordpress/admin-ui` exposes an `actions` slot used across admin screens (DataViews, WidgetDashboard, …). Plug `Actions` straight into it:
 

--- a/routes/dashboard/widget-dashboard/components/actions/actions.tsx
+++ b/routes/dashboard/widget-dashboard/components/actions/actions.tsx
@@ -4,7 +4,7 @@
 import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { plus } from '@wordpress/icons';
+import { layout as layoutIcon, plus } from '@wordpress/icons';
 import { store as viewportStore } from '@wordpress/viewport';
 // eslint-disable-next-line @wordpress/use-recommended-components
 import { AlertDialog, Button, Stack } from '@wordpress/ui';
@@ -20,18 +20,13 @@ import { MoreActionsDropdown } from '../more-actions-dropdown';
 import type { MoreActionsDropdownItem } from '../more-actions-dropdown';
 
 /**
- * Header chrome for the dashboard. Two independent flows are exposed:
- *
- * - **Customize** (layout edits): toggles edit mode, surfaces the Add
- *   widgets / Cancel / Done toolbar. Commits the layout staging buffer
- *   on Done.
- * - **Layout settings** (more-actions dropdown entry): opens a side
- *   drawer with model, column behavior, and row height. Commits the
- *   settings staging buffer on Save inside the drawer.
- *
- * The two flows are mutually exclusive: the Layout settings entry is
- * disabled while edit mode is on so the settings drawer cannot
- * accumulate changes on top of pending layout edits, and vice versa.
+ * Header chrome for the dashboard. Customize mode surfaces an edit
+ * toolbar with Add widget, Layout settings (when grid settings are
+ * editable), Cancel, and Done. Layout settings opens a side drawer
+ * for model, column behavior, and row height; Save inside the drawer
+ * commits the settings staging buffer without leaving customize mode.
+ * Widget layout edits and grid settings share the same staging layer
+ * while customize mode is active.
  *
  * Returns `null` when the dashboard is mounted without `onEditChange`
  * so hosts that don't expose edit mode can keep `Actions` in their
@@ -108,6 +103,12 @@ export function Actions(): React.ReactNode {
 		setLayoutSettingsOpen( true );
 	}, [ setLayoutSettingsOpen ] );
 
+	useEffect( () => {
+		if ( ! editMode && layoutSettingsOpen ) {
+			setLayoutSettingsOpen( false );
+		}
+	}, [ editMode, layoutSettingsOpen, setLayoutSettingsOpen ] );
+
 	const moreActionsItems: MoreActionsDropdownItem[] = [
 		{
 			label: __( 'Reset to default' ),
@@ -115,15 +116,6 @@ export function Actions(): React.ReactNode {
 			disabled: ! onLayoutReset,
 		},
 	];
-
-	if ( canEditGridSettings ) {
-		moreActionsItems.unshift( {
-			label: __( 'Layout settings' ),
-			onClick: openLayoutSettings,
-			disabled: editMode,
-			disabledTooltip: __( 'Disabled while editing widgets' ),
-		} );
-	}
 
 	if ( ! onEditChange ) {
 		return null;
@@ -150,6 +142,20 @@ export function Actions(): React.ReactNode {
 						{ ! isMobileViewport && <Button.Icon icon={ plus } /> }
 						{ __( 'Add widget' ) }
 					</Button>
+
+					{ canEditGridSettings && (
+						<Button
+							variant="minimal"
+							tone="brand"
+							size="compact"
+							onClick={ openLayoutSettings }
+						>
+							{ ! isMobileViewport && (
+								<Button.Icon icon={ layoutIcon } />
+							) }
+							{ __( 'Layout settings' ) }
+						</Button>
+					) }
 
 					<div
 						className={ styles.editActionsDivider }

--- a/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
+++ b/routes/dashboard/widget-dashboard/components/layout-settings/layout-settings.tsx
@@ -195,11 +195,11 @@ interface LayoutSettingsProps {
 }
 
 /**
- * Non-modal side drawer for grid-level settings (model, column
- * behavior, row height). Reads from and writes to the staging copy
- * in `useDashboardInternalContext`, so every edit shows up live
- * behind the drawer and is committed or rolled back by the drawer's
- * Save / Cancel buttons.
+ * Modal side drawer for grid-level settings (model, column behavior,
+ * row height). Reads from and writes to the staging copy in
+ * `useDashboardInternalContext`; edits preview through the backdrop
+ * and are committed or rolled back by the drawer's Save / Cancel
+ * buttons.
  *
  * Gap is intentionally absent: the spacing between tiles is a
  * design-system concern (theme / density / viewport tokens) and
@@ -211,11 +211,9 @@ interface LayoutSettingsProps {
  * an Escape press, or any path other than the explicit Cancel/Save
  * buttons is treated as Cancel. None of these exit customize mode.
  *
- * Settings and layout-editing are kept as separate flows on the
- * dashboard (the Layout settings entry that opens this drawer is
- * disabled while edit mode is on), so the drawer's commit never
- * publishes layout edits that the user is in the middle of staging
- * through the toolbar.
+ * Opened from the customize toolbar beside Add widget. Cancel and
+ * dismiss revert only grid settings so in-progress widget layout
+ * edits in the same customize session are preserved.
  *
  * @param {LayoutSettingsProps} props Layout settings props.
  * @return {React.ReactNode} The layout settings component.
@@ -259,7 +257,7 @@ export function LayoutSettings( {
 	);
 
 	const handleCancel = useCallback( () => {
-		cancelStaging( { exitEditMode: false } );
+		cancelStaging( { exitEditMode: false, revertLayout: false } );
 		onOpenChange( false );
 	}, [ cancelStaging, onOpenChange ] );
 
@@ -271,7 +269,7 @@ export function LayoutSettings( {
 	const handleOpenChange = useCallback(
 		( nextOpen: boolean ) => {
 			if ( ! nextOpen && open ) {
-				cancelStaging( { exitEditMode: false } );
+				cancelStaging( { exitEditMode: false, revertLayout: false } );
 			}
 			onOpenChange( nextOpen );
 		},
@@ -283,8 +281,6 @@ export function LayoutSettings( {
 			open={ open }
 			onOpenChange={ handleOpenChange }
 			swipeDirection="right"
-			modal={ false }
-			disablePointerDismissal
 		>
 			<Drawer.Popup size="medium" style={ { marginTop: '32px' } }>
 				<Drawer.Header>

--- a/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
+++ b/routes/dashboard/widget-dashboard/context/dashboard-context.tsx
@@ -134,10 +134,16 @@ interface InternalDashboardContextValue {
 	commitGridModelChange: ( targetModel: WidgetGridModel ) => void;
 
 	/**
-	 * Reverts both staging slices. By default also exits edit mode; pass
-	 * `{ exitEditMode: false }` when dismissing the layout settings drawer.
+	 * Reverts staging slices. By default reverts both layout and grid
+	 * settings and exits edit mode. Pass `{ exitEditMode: false }` when
+	 * dismissing the layout settings drawer. Pass `{ revertLayout: false }`
+	 * to revert only grid settings (preserves in-progress widget layout
+	 * edits while customize mode is active).
 	 */
-	cancel: ( options?: { exitEditMode?: boolean } ) => void;
+	cancel: ( options?: {
+		exitEditMode?: boolean;
+		revertLayout?: boolean;
+	} ) => void;
 
 	hasUncommittedChanges: boolean;
 	editMode: boolean;
@@ -226,18 +232,10 @@ interface ProviderProps {
  * `layout` and `gridSettings`; `commit` publishes whichever slice
  * differs from its committed prop, `cancel` reverts both.
  *
- * Two invariants the provider does not enforce on its own:
- *
- * - The shared commit assumes the two slices are not edited
- *   simultaneously. The bundled `Actions` keeps the layout-edit and
- *   settings-drawer flows mutually exclusive; consumers that compose
- *   a different host must uphold the same invariant or accept the
- *   cross-publish.
- * - Staging re-syncs from the committed props on prop change.
- *   In-flight edits are dropped silently when an external update
- *   (cross-tab commit, reset, websocket push) lands. Consumers that
- *   cannot tolerate this loss should mediate the prop updates before
- *   forwarding them here.
+ * Staging re-syncs from the committed props on prop change. In-flight
+ * edits are dropped silently when an external update (cross-tab commit,
+ * reset, websocket push) lands. Consumers that cannot tolerate this
+ * loss should mediate the prop updates before forwarding them here.
  *
  * @param {ProviderProps} props Provider props
  * @return {React.ReactNode} The provider component.
@@ -315,8 +313,10 @@ export function WidgetDashboardProvider( {
 	);
 
 	const cancel = useCallback(
-		( options?: { exitEditMode?: boolean } ) => {
-			setStagingLayout( committedLayout );
+		( options?: { exitEditMode?: boolean; revertLayout?: boolean } ) => {
+			if ( options?.revertLayout !== false ) {
+				setStagingLayout( committedLayout );
+			}
 			setStagingGridSettings( committedGridSettings );
 			if ( options?.exitEditMode !== false ) {
 				onEditChange?.( false );

--- a/routes/dashboard/widget-dashboard/context/ui-context.tsx
+++ b/routes/dashboard/widget-dashboard/context/ui-context.tsx
@@ -16,6 +16,8 @@ import {
 interface DashboardUIContextValue {
 	inserterOpen: boolean;
 	setInserterOpen: ( next: boolean ) => void;
+
+	/** Opened by the Layout settings button in the customize toolbar. */
 	layoutSettingsOpen: boolean;
 	setLayoutSettingsOpen: ( next: boolean ) => void;
 	resetDialogOpen: boolean;
@@ -52,7 +54,8 @@ const Context = createContext< DashboardUIContextValue | null >( null );
 
 /**
  * UI-state hook used by the inserter modal and any compound that needs to
- * open or close it (today: the "Add widget" trigger in `Actions`).
+ * open or close it (today: the "Add widget" and "Layout settings"
+ * triggers in `Actions`).
  *
  * Throws when called outside `WidgetDashboard` so misuse fails loudly during
  * development.

--- a/routes/dashboard/widget-dashboard/test/actions.test.tsx
+++ b/routes/dashboard/widget-dashboard/test/actions.test.tsx
@@ -14,7 +14,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { WidgetDashboard } from '../widget-dashboard';
-import type { DashboardWidget } from '../types';
+import type { DashboardWidget, WidgetGridSettings } from '../types';
 import type { WidgetType } from '../../widget-primitives';
 
 const widgetTypes: WidgetType[] = [];
@@ -25,16 +25,24 @@ const layout: DashboardWidget[] = [
 	{ uuid: 'a', type: 'core/test', placement: { width: 1, height: 1 } },
 ];
 
+const gridSettings: WidgetGridSettings = {
+	model: 'grid',
+	minColumnWidth: 350,
+	rowHeight: 200,
+};
+
 interface HarnessProps {
 	initialEditMode?: boolean;
 	onEditChange?: ( next: boolean ) => void;
 	onLayoutChange?: ( next: DashboardWidget[] ) => void;
+	onGridSettingsChange?: ( next: WidgetGridSettings ) => void;
 }
 
 function Harness( {
 	initialEditMode = false,
 	onEditChange,
 	onLayoutChange = () => {},
+	onGridSettingsChange,
 }: HarnessProps ) {
 	const [ editMode, setEditMode ] = useState( initialEditMode );
 
@@ -42,6 +50,8 @@ function Harness( {
 		<WidgetDashboard
 			layout={ layout }
 			onLayoutChange={ onLayoutChange }
+			gridSettings={ gridSettings }
+			onGridSettingsChange={ onGridSettingsChange }
 			widgetTypes={ widgetTypes }
 			editMode={ editMode }
 			onEditChange={ ( next ) => {
@@ -132,6 +142,74 @@ describe( 'WidgetDashboard.Actions', () => {
 		expect(
 			screen.queryByRole( 'button', { name: 'Done' } )
 		).not.toBeInTheDocument();
+	} );
+
+	describe( 'Layout settings', () => {
+		it( 'is hidden when editMode is false', () => {
+			render( <Harness onGridSettingsChange={ () => {} } /> );
+
+			expect(
+				screen.queryByRole( 'button', { name: 'Layout settings' } )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'is visible in the edit toolbar when grid settings are editable', () => {
+			render(
+				<Harness initialEditMode onGridSettingsChange={ () => {} } />
+			);
+
+			expect(
+				screen.getByRole( 'button', { name: 'Layout settings' } )
+			).toBeInTheDocument();
+		} );
+
+		it( 'is hidden when onGridSettingsChange is not provided', () => {
+			render( <Harness initialEditMode /> );
+
+			expect(
+				screen.queryByRole( 'button', { name: 'Layout settings' } )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'opens the layout settings drawer when clicked', async () => {
+			render(
+				<Harness initialEditMode onGridSettingsChange={ () => {} } />
+			);
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'Layout settings' } )
+			);
+
+			expect(
+				await screen.findByRole( 'dialog', { name: 'Layout settings' } )
+			).toBeInTheDocument();
+		} );
+
+		it( 'is not in the more-actions menu', async () => {
+			const onLayoutReset = jest.fn();
+			render(
+				<WidgetDashboard
+					layout={ layout }
+					onLayoutChange={ () => {} }
+					onLayoutReset={ onLayoutReset }
+					gridSettings={ gridSettings }
+					onGridSettingsChange={ () => {} }
+					widgetTypes={ widgetTypes }
+					editMode
+					onEditChange={ () => {} }
+				>
+					<WidgetDashboard.Actions />
+				</WidgetDashboard>
+			);
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'More options' } )
+			);
+
+			expect(
+				screen.queryByRole( 'menuitem', { name: 'Layout settings' } )
+			).not.toBeInTheDocument();
+		} );
 	} );
 
 	it( 'throws when used outside a WidgetDashboard subtree', () => {

--- a/routes/dashboard/widget-dashboard/test/staging.test.tsx
+++ b/routes/dashboard/widget-dashboard/test/staging.test.tsx
@@ -32,7 +32,10 @@ interface ProbeApi {
 	mutate: ( next: DashboardWidget[] ) => void;
 	mutateGridSettings: ( next: WidgetGridSettings ) => void;
 	commit: ( options?: { exitEditMode?: boolean } ) => void;
-	cancel: ( options?: { exitEditMode?: boolean } ) => void;
+	cancel: ( options?: {
+		exitEditMode?: boolean;
+		revertLayout?: boolean;
+	} ) => void;
 }
 
 const probeRef: { current: ProbeApi | null } = { current: null };
@@ -400,6 +403,45 @@ describe( 'WidgetDashboard staging layer', () => {
 			expect( onLayoutChange ).toHaveBeenCalledTimes( 1 );
 			expect( onGridSettingsChange ).not.toHaveBeenCalled();
 		} );
+	} );
+
+	it( 'reverts only grid settings when cancel passes revertLayout: false', () => {
+		const onLayoutChange = jest.fn();
+		const onGridSettingsChange = jest.fn();
+		const initialSettings: WidgetGridSettings = {
+			model: 'grid',
+			minColumnWidth: 350,
+			rowHeight: 200,
+		};
+		render(
+			<Harness
+				layout={ initialLayout }
+				onLayoutChange={ onLayoutChange }
+				gridSettings={ initialSettings }
+				onGridSettingsChange={ onGridSettingsChange }
+			/>
+		);
+
+		act( () => {
+			readProbe().mutate( [ initialLayout[ 0 ] ] );
+			readProbe().mutateGridSettings( {
+				...initialSettings,
+				minColumnWidth: 420,
+			} );
+		} );
+
+		expect( readProbe().hasUncommittedChanges ).toBe( true );
+
+		act( () => {
+			readProbe().cancel( {
+				exitEditMode: false,
+				revertLayout: false,
+			} );
+		} );
+
+		expect( readProbe().hasUncommittedChanges ).toBe( true );
+		expect( readProbe().layout ).toHaveLength( 1 );
+		expect( readProbe().gridSettings.minColumnWidth ).toBe( 350 );
 	} );
 
 	it( 'stays in edit mode when commit or cancel passes exitEditMode: false', () => {

--- a/routes/dashboard/widget-dashboard/types.ts
+++ b/routes/dashboard/widget-dashboard/types.ts
@@ -248,7 +248,7 @@ export interface WidgetDashboardProps {
 	 * Called when the user commits in-progress grid-settings edits via
 	 * the Done action. The dashboard maintains a staging copy of
 	 * settings internally; mutations stay local until commit. When
-	 * omitted, the `Layout settings` entry in the more-actions menu is
+	 * omitted, the `Layout settings` button in the customize toolbar is
 	 * hidden, since there is nowhere to persist the change.
 	 */
 	onGridSettingsChange?: ( gridSettings: WidgetGridSettings ) => void;


### PR DESCRIPTION
## What

- Moves **Layout settings** from the more-actions (⋯) menu into the **customize toolbar**, beside **Add widget** (visible only while customize/edit mode is on).
- Makes the layout settings drawer **modal** (backdrop, focus trap; backdrop dismiss cancels grid settings).
- Adds `cancel({ revertLayout: false })` so dismissing or canceling the layout settings drawer reverts **only grid settings**, not in-progress widget layout edits in the same customize session.
- Closes the layout settings drawer automatically when exiting customize mode.
- Updates README, types JSDoc, and unit tests for the new placement and scoped cancel behavior.

<img width="1526" height="430" alt="image" src="https://github.com/user-attachments/assets/46b0260d-4227-4d2d-9416-18858b985a2f" />


## Why

- Layout settings is part of customizing the dashboard; placing it next to **Add widget** keeps related Dashboard customization actions together and easier to discover.
- The old more-menu entry was disabled during edit mode, which blocked access when users were already customizing—exactly when grid settings are most relevant.
- With layout settings available during customize, cancel/dismiss must not wipe widget moves the user made in the same session.
- A modal drawer reduces accidental interaction with the grid behind the panel and matches the focused, task-oriented nature of changing layout model and grid options.

## How

- **`actions.tsx`**: Removes the more-menu item; renders a **Layout settings** button in the edit toolbar (with layout icon on non-mobile viewports); closes the drawer when `editMode` becomes false.
- **`dashboard-context.tsx`**: Extends `cancel()` with optional `revertLayout` (default `true`); layout-settings passes `revertLayout: false` on Cancel and dismiss.
- **`layout-settings.tsx`**: Drops `modal={ false }` and `disablePointerDismissal` so the drawer uses default modal behavior.
- **Tests**: `actions.test.tsx` covers toolbar visibility, drawer open, and absence from the more menu; `staging.test.tsx` covers grid-only revert.

## Test plan

- [ ] Open the dashboard, click **Customize** — **Layout settings** appears beside **Add widget** (when `onGridSettingsChange` is wired).
- [ ] Confirm **Layout settings** is not in the more-actions menu.
- [ ] Open layout settings, change a grid option, click **Save** — settings persist; customize mode stays on.
- [ ] In customize mode, move a widget, open layout settings, change a setting, click **Cancel** or dismiss via backdrop/X — grid change is discarded; widget position is unchanged.
- [ ] Click **Done** on the toolbar with both widget and unsaved drawer changes — both commit as expected.
- [ ] Exit customize mode while the drawer is open — drawer closes.
- [ ] Run `npm run test:unit -- routes/dashboard/widget-dashboard/test/actions.test.tsx routes/dashboard/widget-dashboard/test/staging.test.tsx`