### PR TITLE
Templates DataView: Fix status filter options and chip label

### DIFF
--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -157,6 +157,10 @@ export const activeField = {
 	label: __( 'Status' ),
 	id: 'active',
 	type: 'boolean',
+	elements: [
+		{ value: true, label: _x( 'Active', 'template status' ) },
+		{ value: false, label: _x( 'Inactive', 'template status' ) },
+	],
 	getValue: ( { item } ) => item._isActive,
 	render: function Render( { item } ) {
 		const activeLabel = item._isCustom

--- a/routes/template-list/fields/active.tsx
+++ b/routes/template-list/fields/active.tsx
@@ -15,6 +15,10 @@ export const activeField = {
 	label: __( 'Status' ),
 	id: 'active',
 	type: 'boolean',
+	elements: [
+		{ value: true, label: _x( 'Active', 'template status' ) },
+		{ value: false, label: _x( 'Inactive', 'template status' ) },
+	],
 	getValue: ( { item }: { item: any } ) => item._isActive,
 	render: function Render( { item }: { item: any } ) {
 		const activeLabel = item._isCustom


### PR DESCRIPTION


## What?

Closes https://github.com/WordPress/gutenberg/issues/73133

Fixes the broken Status filter in the Templates DataView when the Template Activation experiment is enabled.

## Why?
`activeField` (the "Status" column) was typed as `type: 'boolean'` but had no `elements` array. DataViews requires `elements` to populate the filter dropdown and format the filter chip. Without them:
- The filter showed no selectable options
- The chip displayed "Status is: Status" (the raw boolean formatter's output)

## How?
Added an `elements` array to `activeField`:

```js
elements: [
    { value: true,  label: _x( 'Active',   'template status' ) },
    { value: false, label: _x( 'Inactive', 'template status' ) },
],
```

## Testing Instructions

1. Enable the Template Activation experiment (Gutenberg → Experiments)
2. Site Editor → Templates → Add filter → Status
3. Verify: "Active" and "Inactive" appear as options
4. Select "Active" → chip shows "Status is: Active", all active templates visible
5. Select "Inactive" → chip shows "Status is: Inactive", "No results" 

## Screenshots or screencast 

#### Before

https://github.com/user-attachments/assets/5da94ea8-8ef1-4e52-b89d-e8cd29d31999




#### After




https://github.com/user-attachments/assets/2f0e05e2-2eb7-4028-b5e9-e3f685e2db5a


