### PR TITLE
Dashboard: Use Howdy greeting for page title

### DIFF
--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -35,13 +35,26 @@ function Dashboard() {
 		[]
 	);
 
-	const customizeDashboardLabel = __( 'Customize Dashboard' );
-	const dashboardLabel = __( 'Dashboard' );
+	const greetingName = useSelect( ( select ) => {
+		const user = select( coreStore ).getCurrentUser();
+		if ( ! user ) {
+			return undefined;
+		}
 
-	const displayName = useSelect(
-		( select ) => select( coreStore ).getCurrentUser()?.name,
-		[]
-	);
+		const displayName = user.name?.trim();
+		if ( displayName ) {
+			return displayName;
+		}
+
+		if ( 'username' in user && typeof user.username === 'string' ) {
+			const username = user.username.trim();
+			if ( username ) {
+				return username;
+			}
+		}
+
+		return user.slug;
+	}, [] );
 
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
@@ -52,14 +65,14 @@ function Dashboard() {
 		} );
 	};
 
-	let pageTitle = dashboardLabel;
+	let pageTitle: string = __( 'Dashboard' );
 	if ( editMode ) {
-		pageTitle = customizeDashboardLabel;
-	} else if ( displayName ) {
+		pageTitle = __( 'Customize Dashboard' );
+	} else if ( greetingName ) {
 		pageTitle = sprintf(
 			/* translators: %s: current user's display name. */
 			__( 'Howdy, %s' ),
-			displayName
+			greetingName
 		);
 	}
 

--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -2,9 +2,10 @@
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
+import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as viewportStore } from '@wordpress/viewport';
 
@@ -37,6 +38,11 @@ function Dashboard() {
 	const customizeDashboardLabel = __( 'Customize Dashboard' );
 	const dashboardLabel = __( 'Dashboard' );
 
+	const displayName = useSelect(
+		( select ) => select( coreStore ).getCurrentUser()?.name,
+		[]
+	);
+
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	const handleLayoutChange = ( next: DashboardWidget[] ) => {
@@ -46,7 +52,16 @@ function Dashboard() {
 		} );
 	};
 
-	const pageTitle = editMode ? customizeDashboardLabel : dashboardLabel;
+	let pageTitle = dashboardLabel;
+	if ( editMode ) {
+		pageTitle = customizeDashboardLabel;
+	} else if ( displayName ) {
+		pageTitle = sprintf(
+			/* translators: %s: current user's display name. */
+			__( 'Howdy, %s' ),
+			displayName
+		);
+	}
 
 	return (
 		<WidgetDashboard


### PR DESCRIPTION
## What

- Replaces the default dashboard page title **"Dashboard"** with **"Howdy, {name}"** when not in customize mode.
- Resolves the greeting name from `core-data` (`getCurrentUser()`): display name first, then username (if present on the user record), then slug.
- Keeps **"Customize Dashboard"** as the title while customize/edit mode is active (unchanged).
- Falls back to **"Dashboard"** only while the current user record is still loading.

## Why

[Trac #65083](https://core.trac.wordpress.org/ticket/65083) proposes removing the **"Howdy"** greeting from the WordPress admin bar. That proposal drew pushback from folks who felt it removed a bit of warmth and personality from the admin experience.

The new dashboard is a natural home for a personal welcome: it’s the first screen many users see, and a friendly greeting fits that moment better than a generic **"Dashboard"** label. This doesn’t put **Howdy** back in the admin bar; it restores the sentiment in a place that matches the dashboard’s role—as a greeting at the top of the page, not buried in chrome.

## How

- In [`routes/dashboard/stage.tsx`](routes/dashboard/stage.tsx), `useSelect` reads `getCurrentUser()` from `@wordpress/core-data` and derives `greetingName` with fallbacks: trimmed `name` → `username` (when available) → `slug`.
- Page title logic:
  - **Customize mode** → `Customize Dashboard`
  - **Otherwise, with greeting name** → `sprintf( __( 'Howdy, %s' ), greetingName )`
  - **Otherwise** → `Dashboard` (loading fallback)
- `pageTitle` is typed as `string` so reassignment across translated strings type-checks correctly.
- No changes to the admin bar or other routes.

## Test plan

- [ ] Open the dashboard while logged in — page title shows **Howdy, {your display name}**.
- [ ] With an empty display name, confirm the title falls back to **Howdy, {username or slug}**.
- [ ] Click **Customize** — title switches to **Customize Dashboard**.
- [ ] Exit customize mode — greeting returns.
- [ ] Confirm title is still correct on small viewports (customize mode may hide the title per existing behavior).
- [ ] With user data unavailable, confirm fallback to **Dashboard** does not break the page.

## Related

- [WordPress Trac #65083 — Remove "Howdy" welcome from admin bar](https://core.trac.wordpress.org/ticket/65083)

## Screenshots

| Before | After |
| --- | --- |
| <img width="577" height="345" alt="Screenshot 2026-05-27 at 15 42 29" src="https://github.com/user-attachments/assets/faf00644-5177-4d2b-9403-0881cbe4dd47" /> | <img width="555" height="330" alt="Screenshot 2026-05-27 at 15 42 19" src="https://github.com/user-attachments/assets/5d8dae5b-bfae-4f95-b9b7-4f1faf1943f9" /> |