### PR TITLE
Writing flow: Delete at end of nested list item should merge into next block

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1184,6 +1184,22 @@ export const mergeBlocks =
 			! blockAType.merge &&
 			getBlockSupport( blockA.name, '__experimentalOnMerge' )
 		) {
+			// Short-circuit if the blocks are the same type.
+			if ( blockA.name === blockB.name ) {
+				registry.batch( () => {
+					dispatch.moveBlocksToPosition(
+						select.getBlockOrder( clientIdB ),
+						clientIdB,
+						clientIdA
+					);
+					if ( select.getSelectionStart()?.clientId === clientIdB ) {
+						dispatch.selectBlock( clientIdA );
+					}
+					dispatch.removeBlock( clientIdB, false );
+				} );
+				return;
+			}
+
 			// If there's no merge function defined, attempt merging inner
 			// blocks.
 			const blocksWithTheSameType = switchToBlockType(
@@ -1201,27 +1217,18 @@ export const mergeBlocks =
 				return;
 			}
 
-			// If the caret was inside the block being removed, it has
-			// nowhere to go after the merge — move it to the newly
-			// inserted block. Otherwise keep the caller's selection
-			// (e.g. Delete from a deeper block inside `clientIdA`).
-			const selectionClientId = select.getSelectionStart()?.clientId;
-			const selectionInsideB =
-				!! selectionClientId &&
-				( selectionClientId === clientIdB ||
-					select
-						.getBlockParents( selectionClientId )
-						.includes( clientIdB ) );
+			const selectionOnB =
+				select.getSelectionStart()?.clientId === clientIdB;
 
 			registry.batch( () => {
 				dispatch.insertBlocks(
 					blockWithSameType.innerBlocks,
 					undefined,
 					clientIdA,
-					selectionInsideB
+					selectionOnB
 				);
-				dispatch.removeBlock( clientIdB, selectionInsideB );
-				if ( selectionInsideB ) {
+				dispatch.removeBlock( clientIdB, selectionOnB );
+				if ( selectionOnB ) {
 					dispatch.selectBlock(
 						blockWithSameType.innerBlocks[ 0 ].clientId
 					);

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1184,22 +1184,6 @@ export const mergeBlocks =
 			! blockAType.merge &&
 			getBlockSupport( blockA.name, '__experimentalOnMerge' )
 		) {
-			// Short-circuit if the blocks are the same type.
-			if ( blockA.name === blockB.name ) {
-				registry.batch( () => {
-					dispatch.moveBlocksToPosition(
-						select.getBlockOrder( clientIdB ),
-						clientIdB,
-						clientIdA
-					);
-					if ( select.getSelectionStart()?.clientId === clientIdB ) {
-						dispatch.selectBlock( clientIdA );
-					}
-					dispatch.removeBlock( clientIdB, false );
-				} );
-				return;
-			}
-
 			// If there's no merge function defined, attempt merging inner
 			// blocks.
 			const blocksWithTheSameType = switchToBlockType(
@@ -1217,22 +1201,16 @@ export const mergeBlocks =
 				return;
 			}
 
-			const selectionOnB =
-				select.getSelectionStart()?.clientId === clientIdB;
-
 			registry.batch( () => {
 				dispatch.insertBlocks(
 					blockWithSameType.innerBlocks,
 					undefined,
-					clientIdA,
-					selectionOnB
+					clientIdA
 				);
-				dispatch.removeBlock( clientIdB, selectionOnB );
-				if ( selectionOnB ) {
-					dispatch.selectBlock(
-						blockWithSameType.innerBlocks[ 0 ].clientId
-					);
-				}
+				dispatch.removeBlock( clientIdB );
+				dispatch.selectBlock(
+					blockWithSameType.innerBlocks[ 0 ].clientId
+				);
 
 				// Attempt to merge the next block if it's the same type and
 				// same attributes. This is useful when merging a paragraph into

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1201,16 +1201,31 @@ export const mergeBlocks =
 				return;
 			}
 
+			// If the caret was inside the block being removed, it has
+			// nowhere to go after the merge — move it to the newly
+			// inserted block. Otherwise keep the caller's selection
+			// (e.g. Delete from a deeper block inside `clientIdA`).
+			const selectionClientId = select.getSelectionStart()?.clientId;
+			const selectionInsideB =
+				!! selectionClientId &&
+				( selectionClientId === clientIdB ||
+					select
+						.getBlockParents( selectionClientId )
+						.includes( clientIdB ) );
+
 			registry.batch( () => {
 				dispatch.insertBlocks(
 					blockWithSameType.innerBlocks,
 					undefined,
-					clientIdA
+					clientIdA,
+					selectionInsideB
 				);
-				dispatch.removeBlock( clientIdB );
-				dispatch.selectBlock(
-					blockWithSameType.innerBlocks[ 0 ].clientId
-				);
+				dispatch.removeBlock( clientIdB, selectionInsideB );
+				if ( selectionInsideB ) {
+					dispatch.selectBlock(
+						blockWithSameType.innerBlocks[ 0 ].clientId
+					);
+				}
 
 				// Attempt to merge the next block if it's the same type and
 				// same attributes. This is useful when merging a paragraph into

--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -101,21 +101,14 @@ export default function useMerge( clientId, onMerge ) {
 			}
 
 			if ( ! nextBlockClientId ) {
-				// Walk past the outermost list. The fallback `onMerge` only walks one level up.
 				const outermostListId = getBlockRootClientId( listItemId );
 				const followingBlockId =
 					getNextBlockClientId( outermostListId );
 
 				if ( followingBlockId ) {
 					mergeBlocks( outermostListId, followingBlockId );
-					return;
 				}
-
-				onMerge( forward );
-				return;
-			}
-
-			if ( getParentListItemId( nextBlockClientId ) ) {
+			} else if ( getParentListItemId( nextBlockClientId ) ) {
 				outdentListItem( nextBlockClientId );
 			} else {
 				mergeWithNested( clientId, nextBlockClientId );

--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -122,14 +122,6 @@ export default function useMerge( clientId, onMerge ) {
 			const nextBlockClientId = getNextId( clientId );
 
 			if ( ! nextBlockClientId ) {
-				// No further list items exist in this list tree. Look past
-				// the outermost containing list for a block to merge into
-				// it. Without this, deleting forward at the end of a
-				// deeply-nested item would silently do nothing — the
-				// block-editor's fallback `onMerge` operates on the
-				// currently selected block and only walks one parent
-				// level up, so it can't reach the next block after the
-				// outer list.
 				let topmostListItemId = clientId;
 				for (
 					let parentLi = getParentListItemId( topmostListItemId );

--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -122,6 +122,32 @@ export default function useMerge( clientId, onMerge ) {
 			const nextBlockClientId = getNextId( clientId );
 
 			if ( ! nextBlockClientId ) {
+				// No further list items exist in this list tree. Look past
+				// the outermost containing list for a block to merge into
+				// it. Without this, deleting forward at the end of a
+				// deeply-nested item would silently do nothing — the
+				// block-editor's fallback `onMerge` operates on the
+				// currently selected block and only walks one parent
+				// level up, so it can't reach the next block after the
+				// outer list.
+				let topmostListItemId = clientId;
+				for (
+					let parentLi = getParentListItemId( topmostListItemId );
+					parentLi;
+					parentLi = getParentListItemId( topmostListItemId )
+				) {
+					topmostListItemId = parentLi;
+				}
+				const outermostListId =
+					getBlockRootClientId( topmostListItemId );
+				const followingBlockId =
+					getNextBlockClientId( outermostListId );
+
+				if ( followingBlockId ) {
+					mergeBlocks( outermostListId, followingBlockId );
+					return;
+				}
+
 				onMerge( forward );
 				return;
 			}

--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -3,7 +3,7 @@
  */
 import { useRegistry, useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { isUnmodifiedBlock } from '@wordpress/blocks';
+import { isUnmodifiedBlock, switchToBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -20,7 +20,7 @@ export default function useMerge( clientId, onMerge ) {
 		getBlockName,
 		getBlock,
 	} = useSelect( blockEditorStore );
-	const { mergeBlocks, moveBlocksToPosition, removeBlock } =
+	const { mergeBlocks, moveBlocksToPosition, removeBlock, insertBlocks } =
 		useDispatch( blockEditorStore );
 	const outdentListItem = useOutdentListItem();
 
@@ -101,12 +101,37 @@ export default function useMerge( clientId, onMerge ) {
 			}
 
 			if ( ! nextBlockClientId ) {
-				const outermostListId = getBlockRootClientId( listItemId );
-				const followingBlockId =
-					getNextBlockClientId( outermostListId );
+				const outerListId = getBlockRootClientId( listItemId );
+				const followingBlockId = getNextBlockClientId( outerListId );
 
 				if ( followingBlockId ) {
-					mergeBlocks( outermostListId, followingBlockId );
+					if ( getBlockName( followingBlockId ) === 'core/list' ) {
+						registry.batch( () => {
+							moveBlocksToPosition(
+								getBlockOrder( followingBlockId ),
+								followingBlockId,
+								outerListId
+							);
+							removeBlock( followingBlockId, false );
+						} );
+					} else {
+						const transformed = switchToBlockType(
+							getBlock( followingBlockId ),
+							'core/list'
+						);
+						const newInnerBlocks = transformed?.[ 0 ]?.innerBlocks;
+						if ( newInnerBlocks?.length ) {
+							registry.batch( () => {
+								insertBlocks(
+									newInnerBlocks,
+									undefined,
+									outerListId,
+									false
+								);
+								removeBlock( followingBlockId, false );
+							} );
+						}
+					}
 				}
 			} else if ( getParentListItemId( nextBlockClientId ) ) {
 				outdentListItem( nextBlockClientId );

--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -46,45 +46,6 @@ export default function useMerge( clientId, onMerge ) {
 		return parentListItemId;
 	}
 
-	/**
-	 * Return the next list item with respect to the given list item. If none,
-	 * return the next list item of the parent list item if it exists.
-	 *
-	 * @param {string} id A list item client ID.
-	 * @return {?string} The client ID of the next list item.
-	 */
-	function _getNextId( id ) {
-		const next = getNextBlockClientId( id );
-		if ( next ) {
-			return next;
-		}
-		const parentListItemId = getParentListItemId( id );
-		if ( ! parentListItemId ) {
-			return;
-		}
-		return _getNextId( parentListItemId );
-	}
-
-	/**
-	 * Given a client ID, return the client ID of the list item on the next
-	 * line, regardless of indentation level.
-	 *
-	 * @param {string} id The client ID of the current list item.
-	 * @return {?string} The client ID of the next list item.
-	 */
-	function getNextId( id ) {
-		const order = getBlockOrder( id );
-
-		// If the list item does not have a nested list, return the next list
-		// item.
-		if ( ! order.length ) {
-			return _getNextId( id );
-		}
-
-		// Get the first list item in the nested list.
-		return getBlockOrder( order[ 0 ] )[ 0 ];
-	}
-
 	return ( forward ) => {
 		function mergeWithNested( clientIdA, clientIdB ) {
 			registry.batch( () => {
@@ -119,19 +80,29 @@ export default function useMerge( clientId, onMerge ) {
 		}
 
 		if ( forward ) {
-			const nextBlockClientId = getNextId( clientId );
+			// Start by diving into the nested list (if any); otherwise walk up
+			// parent list items for a next sibling. `listItemId` ends on the
+			// topmost list item if none is found.
+			const innerListId = getBlockOrder( clientId )[ 0 ];
+			let nextBlockClientId;
+			let listItemId = clientId;
+			if ( innerListId ) {
+				nextBlockClientId = getBlockOrder( innerListId )[ 0 ];
+			} else {
+				while (
+					! ( nextBlockClientId = getNextBlockClientId( listItemId ) )
+				) {
+					const parentLi = getParentListItemId( listItemId );
+					if ( ! parentLi ) {
+						break;
+					}
+					listItemId = parentLi;
+				}
+			}
 
 			if ( ! nextBlockClientId ) {
-				let topmostListItemId = clientId;
-				for (
-					let parentLi = getParentListItemId( topmostListItemId );
-					parentLi;
-					parentLi = getParentListItemId( topmostListItemId )
-				) {
-					topmostListItemId = parentLi;
-				}
-				const outermostListId =
-					getBlockRootClientId( topmostListItemId );
+				// Walk past the outermost list. The fallback `onMerge` only walks one level up.
+				const outermostListId = getBlockRootClientId( listItemId );
 				const followingBlockId =
 					getNextBlockClientId( outermostListId );
 

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1541,6 +1541,79 @@ test.describe( 'List (@firefox)', () => {
 		} );
 	} );
 
+	test( 'should merge a following paragraph into the outermost list with Delete from a nested item (#77245)', async ( {
+		editor,
+		page,
+	} ) => {
+		const startingContent = [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'outer' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'inner' },
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'text' },
+			},
+		];
+		for ( const block of startingContent ) {
+			await editor.insertBlock( block );
+		}
+
+		// Place the cursor at the end of "inner" by stepping back from
+		// the start of the paragraph.
+		await page.keyboard.press( 'Home' );
+		await page.keyboard.press( 'ArrowLeft' );
+
+		await page.keyboard.press( 'Delete' );
+
+		// The caret stays at the end of "inner" — Delete shouldn't
+		// move the cursor away from the block the user pressed it in.
+		await page.keyboard.type( '‸' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'outer' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'inner‸' },
+									},
+								],
+							},
+						],
+					},
+					{
+						name: 'core/list-item',
+						attributes: { content: 'text' },
+					},
+				],
+			},
+		] );
+	} );
+
 	test( 'should leave nested list intact when deleting the parent item', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1624,14 +1624,14 @@ test.describe( 'List (@firefox)', () => {
 				innerBlocks: [
 					{
 						name: 'core/list-item',
-						attributes: { content: 'test' },
+						attributes: { content: 'a' },
 						innerBlocks: [
 							{
 								name: 'core/list',
 								innerBlocks: [
 									{
 										name: 'core/list-item',
-										attributes: { content: 'test' },
+										attributes: { content: 'b' },
 									},
 								],
 							},
@@ -1644,7 +1644,18 @@ test.describe( 'List (@firefox)', () => {
 				innerBlocks: [
 					{
 						name: 'core/list-item',
-						attributes: { content: 'one' },
+						attributes: { content: '1' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: '2' },
+									},
+								],
+							},
+						],
 					},
 				],
 			},
@@ -1653,15 +1664,12 @@ test.describe( 'List (@firefox)', () => {
 			await editor.insertBlock( block );
 		}
 
-		// Place the cursor at the end of the inner "test" in the
-		// first list. After insertion the caret is at the end of
-		// "one" (the only item of the second, flat list); stepping
-		// back one block boundary lands at the end of inner "test".
-		await page.keyboard.press( 'Home' );
-		await page.keyboard.press( 'ArrowLeft' );
+		// Click directly on "b" (the inner item of list 1) to place
+		// the caret there.
+		await editor.canvas.getByText( 'b', { exact: true } ).click();
 
-		// Verify the setup: caret should land at end of the first
-		// list's inner "test".
+		// Verify the setup: caret lands at end of the first list's
+		// inner "b".
 		await page.keyboard.type( '‸' );
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
@@ -1669,14 +1677,14 @@ test.describe( 'List (@firefox)', () => {
 				innerBlocks: [
 					{
 						name: 'core/list-item',
-						attributes: { content: 'test' },
+						attributes: { content: 'a' },
 						innerBlocks: [
 							{
 								name: 'core/list',
 								innerBlocks: [
 									{
 										name: 'core/list-item',
-										attributes: { content: 'test‸' },
+										attributes: { content: 'b‸' },
 									},
 								],
 							},
@@ -1689,7 +1697,18 @@ test.describe( 'List (@firefox)', () => {
 				innerBlocks: [
 					{
 						name: 'core/list-item',
-						attributes: { content: 'one' },
+						attributes: { content: '1' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: '2' },
+									},
+								],
+							},
+						],
 					},
 				],
 			},
@@ -1699,8 +1718,8 @@ test.describe( 'List (@firefox)', () => {
 		// Action under test.
 		await page.keyboard.press( 'Delete' );
 
-		// Caret should stay at the end of the inner "test"; the
-		// second list's items are absorbed as outer-level siblings.
+		// Caret stays at end of "b"; the second list's items are
+		// absorbed as outer-level siblings of "a".
 		await page.keyboard.type( '‸' );
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
@@ -1708,14 +1727,14 @@ test.describe( 'List (@firefox)', () => {
 				innerBlocks: [
 					{
 						name: 'core/list-item',
-						attributes: { content: 'test' },
+						attributes: { content: 'a' },
 						innerBlocks: [
 							{
 								name: 'core/list',
 								innerBlocks: [
 									{
 										name: 'core/list-item',
-										attributes: { content: 'test‸' },
+										attributes: { content: 'b‸' },
 									},
 								],
 							},
@@ -1723,7 +1742,18 @@ test.describe( 'List (@firefox)', () => {
 					},
 					{
 						name: 'core/list-item',
-						attributes: { content: 'one' },
+						attributes: { content: '1' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: '2' },
+									},
+								],
+							},
+						],
 					},
 				],
 			},

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1645,17 +1645,6 @@ test.describe( 'List (@firefox)', () => {
 					{
 						name: 'core/list-item',
 						attributes: { content: 'one' },
-						innerBlocks: [
-							{
-								name: 'core/list',
-								innerBlocks: [
-									{
-										name: 'core/list-item',
-										attributes: { content: 'two' },
-									},
-								],
-							},
-						],
 					},
 				],
 			},
@@ -1664,18 +1653,12 @@ test.describe( 'List (@firefox)', () => {
 			await editor.insertBlock( block );
 		}
 
-		// Place the cursor at the end of the inner "test" in the first
-		// list. After insertion the caret is at the end of "two"
-		// (deepest leaf of the second list); step back across two
-		// block boundaries (start of "two" → end of "one", start of
-		// "one" → into inner "test"), then `End` to snap to the
-		// actual end of the block since the cross-block jump
-		// preserves column rather than landing at end.
+		// Place the cursor at the end of the inner "test" in the
+		// first list. After insertion the caret is at the end of
+		// "one" (the only item of the second, flat list); stepping
+		// back one block boundary lands at the end of inner "test".
 		await page.keyboard.press( 'Home' );
 		await page.keyboard.press( 'ArrowLeft' );
-		await page.keyboard.press( 'Home' );
-		await page.keyboard.press( 'ArrowLeft' );
-		await page.keyboard.press( 'ArrowRight' );
 
 		// Verify the setup: caret should land at end of the first
 		// list's inner "test".
@@ -1707,17 +1690,6 @@ test.describe( 'List (@firefox)', () => {
 					{
 						name: 'core/list-item',
 						attributes: { content: 'one' },
-						innerBlocks: [
-							{
-								name: 'core/list',
-								innerBlocks: [
-									{
-										name: 'core/list-item',
-										attributes: { content: 'two' },
-									},
-								],
-							},
-						],
 					},
 				],
 			},
@@ -1752,17 +1724,6 @@ test.describe( 'List (@firefox)', () => {
 					{
 						name: 'core/list-item',
 						attributes: { content: 'one' },
-						innerBlocks: [
-							{
-								name: 'core/list',
-								innerBlocks: [
-									{
-										name: 'core/list-item',
-										attributes: { content: 'two' },
-									},
-								],
-							},
-						],
 					},
 				],
 			},

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1664,9 +1664,8 @@ test.describe( 'List (@firefox)', () => {
 			await editor.insertBlock( block );
 		}
 
-		// Click directly on "b" (the inner item of list 1) to place
-		// the caret there.
-		await editor.canvas.getByText( 'b', { exact: true } ).click();
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowRight' );
 
 		// Verify the setup: caret lands at end of the first list's
 		// inner "b".

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1614,6 +1614,161 @@ test.describe( 'List (@firefox)', () => {
 		] );
 	} );
 
+	test( 'should merge a following sibling list into the outermost list with Delete from a nested item (#77245)', async ( {
+		editor,
+		page,
+	} ) => {
+		const startingContent = [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'test' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'test' },
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'one' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'two' },
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		];
+		for ( const block of startingContent ) {
+			await editor.insertBlock( block );
+		}
+
+		// Place the cursor at the end of the inner "test" in the first
+		// list. After insertion the caret is at the end of "two"
+		// (deepest leaf of the second list); step back across two
+		// block boundaries (start of "two" → end of "one", start of
+		// "one" → into inner "test"), then `End` to snap to the
+		// actual end of the block since the cross-block jump
+		// preserves column rather than landing at end.
+		await page.keyboard.press( 'Home' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'Home' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowRight' );
+
+		// Verify the setup: caret should land at end of the first
+		// list's inner "test".
+		await page.keyboard.type( '‸' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'test' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'test‸' },
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'one' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'two' },
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		] );
+		await page.keyboard.press( 'Backspace' );
+
+		// Action under test.
+		await page.keyboard.press( 'Delete' );
+
+		// Caret should stay at the end of the inner "test"; the
+		// second list's items are absorbed as outer-level siblings.
+		await page.keyboard.type( '‸' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'test' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'test‸' },
+									},
+								],
+							},
+						],
+					},
+					{
+						name: 'core/list-item',
+						attributes: { content: 'one' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'two' },
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		] );
+	} );
+
 	test( 'should leave nested list intact when deleting the parent item', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What?
Closes #77245.

Pressing Delete at the end of a deeply-nested list item now absorbs the following block (a paragraph or another list) into the outermost containing list, instead of silently doing nothing.

## Why?
The block-editor's fallback `onMerge` only walks one parent level up, so it can't see past the outer `<ul>`/`<ol>` that wraps the nested item. The cursor was effectively stuck at the end of a nested list.

## How?
All logic is scoped to `list-item`'s `useMerge`; the generic `mergeBlocks` action is untouched.

1. **Walk past the outermost list.** When no next list item exists in the tree, walk up the parent list-item chain to the topmost list item, then look for the block that follows its containing list.
2. **Same-name lists:** if that following block is another `core/list`, move its items into the outermost list with `moveBlocksToPosition` and remove the now-empty container.
3. **Other block types:** convert via the list's existing `from:[paragraph, heading, ...]` transform with `switchToBlockType`, then `insertBlocks` the resulting list items with `updateSelection: false` so the caret stays at the end of the inner item.

## Testing Instructions
1. Insert a list with a nested item, e.g. `ul[outer[ul[inner]]]`.
2. Add a paragraph or another list after it.
3. Place the cursor at the end of `inner`, press Delete.
4. The following block is absorbed into the outermost list (paragraph becomes a new outer-level item; another list contributes its items as outer-level siblings). The caret stays at the end of `inner`.

### Testing Instructions for Keyboard
Same as above. The change is keyboard-only behavior.

## Use of AI Tools
Authored with Claude Code (Opus 4.7) under direction and review.