### PR TITLE
UI: Widen Pick'd upstream prop types to forward all `@base-ui/react` props

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `Tooltip.Provider`: Widen the types to accept all props of the equivalent `Tooltip.Provider` from `@base-ui/react` (types-only change) ([#78642](https://github.com/WordPress/gutenberg/pull/78642)).
+-   `Tooltip.Root`, `Popover.Root`, `Popover.Trigger`, `Popover.Popup`, `Dialog.Root`, `Dialog.Popup`, `Drawer.Root`, `Drawer.Popup`, `AlertDialog.Popup`: Widen the types to forward all upstream props from the equivalent `@base-ui/react` subcomponents instead of `Pick`-ing a subset (types-only change).
 
 ## 0.14.0 (2026-05-27)
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 -   `Tooltip.Provider`: Widen the types to accept all props of the equivalent `Tooltip.Provider` from `@base-ui/react` (types-only change) ([#78642](https://github.com/WordPress/gutenberg/pull/78642)).
--   `Tooltip.Root`, `Popover.Root`, `Popover.Trigger`, `Popover.Popup`, `Dialog.Root`, `Dialog.Popup`, `Drawer.Root`, `Drawer.Popup`, `AlertDialog.Popup`: Widen the types to forward all upstream props from the equivalent `@base-ui/react` subcomponents instead of `Pick`-ing a subset (types-only change).
+-   `Tooltip.Root`, `Popover.Root`, `Popover.Trigger`, `Popover.Popup`, `Dialog.Root`, `Dialog.Popup`, `Drawer.Root`, `Drawer.Popup`, `AlertDialog.Popup`: Widen the types to forward all upstream props from the equivalent `@base-ui/react` subcomponents instead of `Pick`-ing a subset (types-only change) ([#78744](https://github.com/WordPress/gutenberg/pull/78744)).
 
 ## 0.14.0 (2026-05-27)
 

--- a/packages/ui/src/alert-dialog/types.ts
+++ b/packages/ui/src/alert-dialog/types.ts
@@ -61,9 +61,7 @@ export interface TriggerProps extends ComponentProps< 'button' > {
 	children?: ReactNode;
 }
 
-export interface PopupProps
-	extends ComponentProps< 'div' >,
-		Pick< _AlertDialog.Popup.Props, 'initialFocus' | 'finalFocus' > {
+export interface PopupProps extends ComponentProps< typeof _AlertDialog.Popup > {
 	/**
 	 * Optional portal element, typically `<AlertDialog.Portal />` with
 	 * custom `container`, `className`, or `style`. Overlay content is

--- a/packages/ui/src/alert-dialog/types.ts
+++ b/packages/ui/src/alert-dialog/types.ts
@@ -61,7 +61,8 @@ export interface TriggerProps extends ComponentProps< 'button' > {
 	children?: ReactNode;
 }
 
-export interface PopupProps extends ComponentProps< typeof _AlertDialog.Popup > {
+export interface PopupProps
+	extends ComponentProps< typeof _AlertDialog.Popup > {
 	/**
 	 * Optional portal element, typically `<AlertDialog.Portal />` with
 	 * custom `container`, `className`, or `style`. Overlay content is

--- a/packages/ui/src/dialog/types.ts
+++ b/packages/ui/src/dialog/types.ts
@@ -7,18 +7,13 @@ import type { ComponentProps } from '../utils/types';
 
 export type PortalProps = ComponentProps< typeof _Dialog.Portal >;
 
-export interface RootProps
-	extends Pick<
-		_Dialog.Root.Props,
-		| 'open'
-		| 'onOpenChange'
-		| 'onOpenChangeComplete'
-		| 'defaultOpen'
-		| 'modal'
-		| 'disablePointerDismissal'
-	> {
+export interface RootProps extends Omit< _Dialog.Root.Props, 'children' > {
 	/**
-	 * The content to be rendered inside the component.
+	 * The dialog sub-components (`Dialog.Trigger`, `Dialog.Popup`, etc.).
+	 *
+	 * The wrapper consumes `children` directly to set up the dialog's modal
+	 * context, so the render-function form of `children` supported by the
+	 * underlying `Dialog.Root` from `@base-ui/react` is not exposed.
 	 */
 	children?: ReactNode;
 }
@@ -30,9 +25,7 @@ export interface TriggerProps extends ComponentProps< 'button' > {
 	children?: ReactNode;
 }
 
-export interface PopupProps
-	extends ComponentProps< 'div' >,
-		Pick< _Dialog.Popup.Props, 'initialFocus' | 'finalFocus' > {
+export interface PopupProps extends ComponentProps< typeof _Dialog.Popup > {
 	/**
 	 * The content to be rendered inside the component.
 	 */

--- a/packages/ui/src/drawer/types.ts
+++ b/packages/ui/src/drawer/types.ts
@@ -6,30 +6,13 @@ import type { ComponentProps } from '../utils/types';
 
 export type PortalProps = ComponentProps< typeof _Drawer.Portal >;
 
-export interface RootProps
-	extends Pick<
-		_Drawer.Root.Props,
-		| 'open'
-		| 'onOpenChange'
-		| 'onOpenChangeComplete'
-		| 'defaultOpen'
-		| 'modal'
-		| 'disablePointerDismissal'
-	> {
+export interface RootProps extends Omit< _Drawer.Root.Props, 'children' > {
 	/**
-	 * The edge the drawer slides in from, and the direction used to dismiss it
-	 * via swipe gesture.
+	 * The drawer sub-components (`Drawer.Trigger`, `Drawer.Popup`, etc.).
 	 *
-	 * - `'left'` / `'right'`: side drawers; swipe horizontally to dismiss.
-	 * - `'down'`: bottom sheet; swipe down to dismiss.
-	 * - `'up'`: top drawer; swipe up to dismiss.
-	 *
-	 * @default 'left'
-	 */
-	swipeDirection?: _Drawer.Root.Props[ 'swipeDirection' ];
-
-	/**
-	 * The content to be rendered inside the component.
+	 * The wrapper consumes `children` directly to set up the drawer's modal
+	 * context, so the render-function form of `children` supported by the
+	 * underlying `Drawer.Root` from `@base-ui/react` is not exposed.
 	 */
 	children?: ReactNode;
 }
@@ -41,9 +24,7 @@ export interface TriggerProps extends ComponentProps< 'button' > {
 	children?: ReactNode;
 }
 
-export interface PopupProps
-	extends ComponentProps< 'div' >,
-		Pick< _Drawer.Popup.Props, 'initialFocus' | 'finalFocus' > {
+export interface PopupProps extends ComponentProps< typeof _Drawer.Popup > {
 	/**
 	 * The content to be rendered inside the component.
 	 */

--- a/packages/ui/src/popover/types.ts
+++ b/packages/ui/src/popover/types.ts
@@ -9,7 +9,8 @@ export type PositionerProps = ComponentProps< typeof _Popover.Positioner >;
 
 export type RootProps = _Popover.Root.Props;
 
-export interface TriggerProps extends ComponentProps< typeof _Popover.Trigger > {
+export interface TriggerProps
+	extends ComponentProps< typeof _Popover.Trigger > {
 	/**
 	 * The content to be rendered inside the component.
 	 */

--- a/packages/ui/src/popover/types.ts
+++ b/packages/ui/src/popover/types.ts
@@ -7,29 +7,16 @@ export type PortalProps = ComponentProps< typeof _Popover.Portal >;
 
 export type PositionerProps = ComponentProps< typeof _Popover.Positioner >;
 
-export interface RootProps
-	extends Pick<
-		_Popover.Root.Props,
-		'open' | 'onOpenChange' | 'defaultOpen' | 'modal'
-	> {
-	/**
-	 * The popover sub-components (`Popover.Trigger`, `Popover.Popup`, etc.).
-	 */
-	children?: ReactNode;
-}
+export type RootProps = _Popover.Root.Props;
 
-export interface TriggerProps
-	extends ComponentProps< 'button' >,
-		Pick< _Popover.Trigger.Props, 'openOnHover' | 'delay' | 'closeDelay' > {
+export interface TriggerProps extends ComponentProps< typeof _Popover.Trigger > {
 	/**
 	 * The content to be rendered inside the component.
 	 */
 	children?: ReactNode;
 }
 
-export interface PopupProps
-	extends ComponentProps< 'div' >,
-		Pick< _Popover.Popup.Props, 'initialFocus' | 'finalFocus' > {
+export interface PopupProps extends ComponentProps< typeof _Popover.Popup > {
 	/**
 	 * Whether to render a backdrop overlay behind the popover.
 	 *

--- a/packages/ui/src/tooltip/types.ts
+++ b/packages/ui/src/tooltip/types.ts
@@ -7,7 +7,7 @@ export type PortalProps = ComponentProps< typeof _Tooltip.Portal >;
 
 export type PositionerProps = ComponentProps< typeof _Tooltip.Positioner >;
 
-export type RootProps = Pick< _Tooltip.Root.Props, 'disabled' | 'children' >;
+export type RootProps = _Tooltip.Root.Props;
 
 export type ProviderProps = _Tooltip.Provider.Props;
 


### PR DESCRIPTION
## What

Follow-up to #78642 (`Tooltip.Provider` widening). That PR replaced
`Pick< _Tooltip.Provider.Props, 'delay' | 'children' >` with the full
`_Tooltip.Provider.Props`. The follow-up [discussion](https://github.com/WordPress/gutenberg/pull/78642#discussion_r3311126074) generalized the principle: wherever the runtime wrapper already spreads upstream props straight through to base-ui, the public type should reflect the full upstream surface rather than a hand-picked subset.

This PR applies that pattern to every remaining Pick'd upstream prop type in `@wordpress/ui` where the runtime is in fact forwarding the rest.

## Scope

Widened to the full upstream prop type:

| Subcomponent | Before | After |
|---|---|---|
| `Tooltip.Root` | `Pick< _Tooltip.Root.Props, 'disabled' \| 'children' >` | `_Tooltip.Root.Props` |
| `Popover.Root` | `Pick< _Popover.Root.Props, 'open' \| 'onOpenChange' \| 'defaultOpen' \| 'modal' >` + local `children` | `_Popover.Root.Props` |
| `Popover.Trigger` | `ComponentProps< 'button' > & Pick< _Popover.Trigger.Props, 'openOnHover' \| 'delay' \| 'closeDelay' >` | `ComponentProps< typeof _Popover.Trigger >` |
| `Popover.Popup` | `ComponentProps< 'div' > & Pick< _Popover.Popup.Props, 'initialFocus' \| 'finalFocus' >` + local props | `ComponentProps< typeof _Popover.Popup >` + local props |
| `Dialog.Root` | `Pick< _Dialog.Root.Props, 'open' \| 'onOpenChange' \| 'onOpenChangeComplete' \| 'defaultOpen' \| 'modal' \| 'disablePointerDismissal' >` | `Omit< _Dialog.Root.Props, 'children' >` + narrowed `children: ReactNode` (see below) |
| `Dialog.Popup` | `ComponentProps< 'div' > & Pick< _Dialog.Popup.Props, 'initialFocus' \| 'finalFocus' >` + local props | `ComponentProps< typeof _Dialog.Popup >` + local props |
| `Drawer.Root` | `Pick< _Drawer.Root.Props, 'open' \| 'onOpenChange' \| 'onOpenChangeComplete' \| 'defaultOpen' \| 'modal' \| 'disablePointerDismissal' >` + locally-redeclared `swipeDirection` | `Omit< _Drawer.Root.Props, 'children' >` + narrowed `children: ReactNode` (see below). Drops the now-redundant local `swipeDirection` re-declaration. |
| `Drawer.Popup` | `ComponentProps< 'div' > & Pick< _Drawer.Popup.Props, 'initialFocus' \| 'finalFocus' >` + local props | `ComponentProps< typeof _Drawer.Popup >` + local props |
| `AlertDialog.Popup` | `ComponentProps< 'div' > & Pick< _AlertDialog.Popup.Props, 'initialFocus' \| 'finalFocus' >` + local props | `ComponentProps< typeof _AlertDialog.Popup >` + local props |

Intentionally **not** widened:

- **`AlertDialog.Root`** — the wrapper owns the confirm-state machine and overrides `onOpenChange`, `onOpenChangeComplete`, and `actionsRef` on the underlying `_AlertDialog.Root`. Forwarding those upstream props would be a footgun, so the existing `Pick< _AlertDialog.Root.Props, 'open' \| 'onOpenChange' \| 'defaultOpen' >` stays.

### Note on `Dialog.Root` and `Drawer.Root` children

For these two, the wrapper consumes `children` directly to wrap them in a WP-specific modal context provider (`DialogModalProvider` / `DrawerModalProvider`). The upstream `_Dialog.Root.Props['children']` / `_Drawer.Root.Props['children']` accepts a render-function form (base-ui's render-prop pattern), but the wrapper can't honor it — it just renders whatever is passed as plain React children. To prevent that footgun, both keep `children` narrowed to `ReactNode`, with a JSDoc comment explaining the trade-off.

## Testing

- `tsgo --build` is clean on this branch (the only remaining error, `packages/vips/src/vips-worker.ts: Cannot find module './worker-code'`, is pre-existing on `trunk` and unrelated).
- No runtime changes — every wrapper already spreads the wider set of props onto the underlying base-ui component, so existing tests/stories continue to work as-is.

## Notes for reviewers

- This is a types-only widening. Existing call sites that compiled before will continue to compile (Pick'd-subset is a subset of the full type), and consumers gain access to the rest of the upstream API (`actionsRef`, `keepMounted`, `nativeButton`, etc., depending on the subcomponent).
- The `Drawer.Root` change drops the locally-redeclared `swipeDirection` with WP JSDoc. The upstream prop is still there (now via inheritance), with base-ui's own JSDoc. If we want to preserve the WP-flavored doc, happy to re-add it as an explicit interface override — let me know.