### PR TITLE
RTC: Return forbidden rooms together

### DIFF
--- a/lib/compat/wordpress-7.1/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.1/class-wp-http-polling-sync-server.php
@@ -210,8 +210,9 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 				);
 			}
 
-			$rooms      = $request['rooms'];
-			$wp_user_id = get_current_user_id();
+			$rooms           = $request['rooms'];
+			$wp_user_id      = get_current_user_id();
+			$forbidden_rooms = array();
 
 			foreach ( $rooms as $room ) {
 				$client_id = $room['client_id'];
@@ -237,16 +238,19 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 				$object_id   = $object_parts[1] ?? null;
 
 				if ( ! $this->can_user_sync_entity_type( $entity_kind, $entity_name, $object_id ) ) {
-					return new WP_Error(
-						'rest_cannot_edit',
-						sprintf(
-							/* translators: %s: The room name encodes the current entity being synced. */
-							__( 'You do not have permission to sync this entity: %s.', 'gutenberg' ),
-							$room
-						),
-						array( 'status' => rest_authorization_required_code() )
-					);
+					$forbidden_rooms[] = $room;
 				}
+			}
+
+			if ( ! empty( $forbidden_rooms ) ) {
+				return new WP_Error(
+					'rest_cannot_edit',
+					__( 'You do not have permission to sync one or more entities.', 'gutenberg' ),
+					array(
+						'status' => rest_authorization_required_code(),
+						'rooms'  => $forbidden_rooms,
+					)
+				);
 			}
 
 			return true;

--- a/lib/compat/wordpress-7.1/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.1/class-wp-http-polling-sync-server.php
@@ -245,7 +245,11 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 			if ( ! empty( $forbidden_rooms ) ) {
 				return new WP_Error(
 					'rest_cannot_edit',
-					__( 'You do not have permission to sync one or more entities.', 'gutenberg' ),
+					sprintf(
+						/* translators: %s: Comma-separated list of room names. */
+						__( 'You do not have permission to sync one or more entities: %s.', 'gutenberg' ),
+						implode( ', ', $forbidden_rooms )
+					),
 					array(
 						'status' => rest_authorization_required_code(),
 						'rooms'  => $forbidden_rooms,

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -143,44 +143,12 @@ function isProtocolMismatchError( error: unknown ): error is WPRestError {
 }
 
 /**
- * Try to identify which room caused a forbidden error by checking if any
- * room name from the request appears in the error message. The WordPress
- * REST API includes the room name in per-entity permission errors (e.g.
- * "You do not have permission to sync this entity: postType/post:123.").
- * Room names are never translated, so substring matching is reliable.
- *
- * Returns the room name if found, or null for generic auth failures
- * (e.g. "not logged in") where no specific room is identified.
- *
- * @param error The forbidden error, narrowed via isForbiddenError.
- * @param rooms The room names from the request payload.
- */
-function identifyForbiddenRoom(
-	error: WPRestError,
-	rooms: string[]
-): string | null {
-	const message = typeof error.message === 'string' ? error.message : '';
-
-	// Sort rooms by length descending so the longest match wins. Room names
-	// embed numeric IDs (e.g. "postType/post:1", "postType/post:10"), and a
-	// shorter name can be a substring of a longer one. Without sorting, the
-	// iteration order is the room registration order, so a 403 referencing
-	// "postType/post:10" could incorrectly match "postType/post:1" first.
-	const sortedRooms = [ ...rooms ].sort( ( a, b ) => b.length - a.length );
-
-	for ( const room of sortedRooms ) {
-		if ( message.includes( room ) ) {
-			return room;
-		}
-	}
-
-	return null;
-}
-
-/**
  * Handle a 403 from the sync endpoint. Silently unregisters the affected
- * rooms, and restores pending updates for the remaining rooms so they retry on
- * the next poll cycle.
+ * rooms listed in the error data, and restores pending updates for the
+ * remaining rooms so they retry on the next poll cycle.
+ *
+ * If the error does not include room details, it is treated as a generic auth
+ * failure and all rooms are unregistered.
  *
  * @param error          The forbidden error, narrowed via isForbiddenError.
  * @param requestedRooms The rooms that were in the failing request.
@@ -189,20 +157,12 @@ function handleForbiddenError(
 	error: WPRestError,
 	requestedRooms: SyncPayload[ 'rooms' ]
 ): void {
-	const requestedRoomNames = requestedRooms.map( ( r ) => r.room );
+	const requestedRoomNames = new Set(
+		requestedRooms.map( ( room ) => room.room )
+	);
 	const forbiddenRooms = Array.isArray( error.data.rooms )
-		? error.data.rooms.filter( ( room ) =>
-				requestedRoomNames.includes( room )
-		  )
+		? error.data.rooms.filter( ( room ) => requestedRoomNames.has( room ) )
 		: [];
-	const forbiddenRoom =
-		forbiddenRooms.length === 0
-			? identifyForbiddenRoom( error, requestedRoomNames )
-			: null;
-
-	if ( forbiddenRoom ) {
-		forbiddenRooms.push( forbiddenRoom );
-	}
 
 	if ( forbiddenRooms.length > 0 ) {
 		for ( const room of forbiddenRooms ) {

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -100,7 +100,7 @@ interface RoomState {
 interface WPRestError {
 	code?: string;
 	message?: string;
-	data: { status: number };
+	data: { status: number; rooms?: string[] };
 }
 
 /**
@@ -189,31 +189,42 @@ function handleForbiddenError(
 	error: WPRestError,
 	requestedRooms: SyncPayload[ 'rooms' ]
 ): void {
-	const forbiddenRoom = identifyForbiddenRoom(
-		error,
-		requestedRooms.map( ( r ) => r.room )
-	);
+	const requestedRoomNames = requestedRooms.map( ( r ) => r.room );
+	const forbiddenRooms = Array.isArray( error.data.rooms )
+		? error.data.rooms.filter( ( room ) =>
+				requestedRoomNames.includes( room )
+		  )
+		: [];
+	const forbiddenRoom =
+		forbiddenRooms.length === 0
+			? identifyForbiddenRoom( error, requestedRoomNames )
+			: null;
 
 	if ( forbiddenRoom ) {
-		// A specific room was denied — unregister only that room.
-		const state = roomStates.get( forbiddenRoom );
-		if ( state ) {
-			state.log(
-				'Permission denied, unregistering room',
-				{ error },
-				'error',
-				true // force
-			);
-			unregisterRoom( forbiddenRoom, { sendDisconnectSignal: false } );
+		forbiddenRooms.push( forbiddenRoom );
+	}
+
+	if ( forbiddenRooms.length > 0 ) {
+		for ( const room of forbiddenRooms ) {
+			const state = roomStates.get( room );
+			if ( state ) {
+				state.log(
+					'Permission denied, unregistering room',
+					{ error },
+					'error',
+					true // force
+				);
+				unregisterRoom( room, { sendDisconnectSignal: false } );
+			}
 		}
 
 		// Restore updates for remaining rooms so they can be retried on
 		// the next poll cycle.
 		for ( const room of requestedRooms ) {
-			if (
-				room.room === forbiddenRoom ||
-				! roomStates.has( room.room )
-			) {
+			if ( forbiddenRooms.includes( room.room ) ) {
+				continue;
+			}
+			if ( ! roomStates.has( room.room ) ) {
 				continue;
 			}
 			const remainingState = roomStates.get( room.room )!;

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -1510,6 +1510,95 @@ describe( 'polling-manager', () => {
 			);
 		} );
 
+		it( 'ignores forbidden rooms that were not in the failed request', async () => {
+			mockPostSyncUpdate.mockResolvedValueOnce( {
+				rooms: [
+					{
+						room: 'primary',
+						end_cursor: 1,
+						awareness: { 1: {}, 2: {} },
+						updates: [],
+					},
+				],
+			} );
+
+			const primaryDoc = createMockDoc( 1 );
+			pollingManager.registerRoom( {
+				room: 'primary',
+				doc: primaryDoc,
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+			for ( let i = 1; i <= 10; i++ ) {
+				pollingManager.registerRoom( {
+					room: `overflow-${ i }`,
+					doc: createMockDoc( i + 1 ),
+					awareness: createMockAwareness(),
+					log: jest.fn(),
+					onStatusChange: jest.fn(),
+					onSync: jest.fn(),
+				} );
+			}
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			const onPrimaryDocUpdate = getOnDocUpdate( primaryDoc );
+			onPrimaryDocUpdate( new Uint8Array( [ 1, 2, 3 ] ), 'local-origin' );
+
+			mockPostSyncUpdate.mockRejectedValueOnce( {
+				code: 'rest_cannot_edit',
+				message:
+					'You do not have permission to sync one or more entities: overflow-1, overflow-10.',
+				data: {
+					status: 403,
+					rooms: [ 'overflow-1', 'overflow-10' ],
+				},
+			} );
+			await jest.advanceTimersByTimeAsync( 1000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			const failedPayload = mockPostSyncUpdate.mock.calls[ 1 ][ 0 ] as {
+				rooms: Array< { room: string; updates: unknown[] } >;
+			};
+			expect( failedPayload.rooms.map( ( room ) => room.room ) ).toEqual(
+				[
+					'primary',
+					'overflow-1',
+					'overflow-2',
+					'overflow-3',
+					'overflow-4',
+					'overflow-5',
+					'overflow-6',
+					'overflow-7',
+					'overflow-8',
+					'overflow-9',
+				]
+			);
+			const failedPrimaryRoom = failedPayload.rooms.find(
+				( room ) => room.room === 'primary'
+			);
+			expect( failedPrimaryRoom!.updates.length ).toBeGreaterThan( 0 );
+
+			mockPostSyncUpdate.mockResolvedValueOnce( { rooms: [] } );
+			await jest.advanceTimersByTimeAsync( 1000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			const retryPayload = mockPostSyncUpdate.mock.calls[ 2 ][ 0 ] as {
+				rooms: Array< { room: string; updates: unknown[] } >;
+			};
+			const retryRooms = retryPayload.rooms.map( ( room ) => room.room );
+			expect( retryRooms ).toContain( 'primary' );
+			expect( retryRooms ).toContain( 'overflow-10' );
+			expect( retryRooms ).not.toContain( 'overflow-1' );
+			expect(
+				retryPayload.rooms.find( ( room ) => room.room === 'primary' )!
+					.updates
+			).toEqual( failedPrimaryRoom!.updates );
+		} );
+
 		it( 'retries normally on a 401 (not treated as forbidden)', async () => {
 			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
 

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -1415,6 +1415,101 @@ describe( 'polling-manager', () => {
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 		} );
 
+		it( 'unregisters all rooms listed in a forbidden error response', async () => {
+			mockPostSyncUpdate.mockResolvedValueOnce( {
+				rooms: [
+					{
+						room: 'keep-room',
+						end_cursor: 1,
+						awareness: { 1: {}, 2: {} },
+						updates: [],
+					},
+					{
+						room: 'forbidden-room-a',
+						end_cursor: 1,
+						awareness: {},
+						updates: [],
+					},
+					{
+						room: 'forbidden-room-b',
+						end_cursor: 1,
+						awareness: {},
+						updates: [],
+					},
+				],
+			} );
+
+			const keepDoc = createMockDoc( 1 );
+			pollingManager.registerRoom( {
+				room: 'keep-room',
+				doc: keepDoc,
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+			pollingManager.registerRoom( {
+				room: 'forbidden-room-a',
+				doc: createMockDoc( 2 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+			pollingManager.registerRoom( {
+				room: 'forbidden-room-b',
+				doc: createMockDoc( 3 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			const onDocUpdate = getOnDocUpdate( keepDoc );
+			onDocUpdate( new Uint8Array( [ 1, 2, 3 ] ), 'local-origin' );
+
+			mockPostSyncUpdate.mockRejectedValueOnce( {
+				code: 'rest_cannot_edit',
+				message:
+					'You do not have permission to sync one or more entities.',
+				data: {
+					status: 403,
+					rooms: [ 'forbidden-room-a', 'forbidden-room-b' ],
+				},
+			} );
+			await jest.advanceTimersByTimeAsync( 1000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			const failedPayload = mockPostSyncUpdate.mock.calls[ 1 ][ 0 ];
+			const failedKeepRoom = failedPayload.rooms.find(
+				( room: { room: string } ) => room.room === 'keep-room'
+			);
+			expect( failedKeepRoom!.updates.length ).toBeGreaterThan( 0 );
+
+			mockPostSyncUpdate.mockResolvedValueOnce( {
+				rooms: [
+					{
+						room: 'keep-room',
+						end_cursor: 2,
+						awareness: {},
+						updates: [],
+					},
+				],
+			} );
+			await jest.advanceTimersByTimeAsync( 1000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			const retryPayload = mockPostSyncUpdate.mock.calls[ 2 ][ 0 ];
+			expect( retryPayload.rooms.map( ( room ) => room.room ) ).toEqual( [
+				'keep-room',
+			] );
+			expect( retryPayload.rooms[ 0 ].updates ).toEqual(
+				failedKeepRoom!.updates
+			);
+		} );
+
 		it( 'retries normally on a 401 (not treated as forbidden)', async () => {
 			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
 

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -1376,12 +1376,12 @@ describe( 'polling-manager', () => {
 			await jest.advanceTimersByTimeAsync( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
 
-			// Second poll: 403 referencing only test-room.
+			// Second poll: 403 listing only test-room.
 			mockPostSyncUpdate.mockRejectedValueOnce( {
 				code: 'rest_cannot_edit',
 				message:
-					'You do not have permission to sync this entity: test-room.',
-				data: { status: 403 },
+					'You do not have permission to sync one or more entities: test-room.',
+				data: { status: 403, rooms: [ 'test-room' ] },
 			} );
 			await jest.advanceTimersByTimeAsync( 4000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
@@ -1663,81 +1663,6 @@ describe( 'polling-manager', () => {
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 		} );
 
-		it( 'unregisters the correct room when room names share a prefix', async () => {
-			// Register the shorter-named room first so that, without the
-			// length-descending sort in identifyForbiddenRoom, the iteration
-			// order would match "postType/post:1" as a substring of
-			// "postType/post:10" and unregister the wrong room.
-			const twoRoomResponse = {
-				rooms: [
-					{
-						room: 'postType/post:1',
-						end_cursor: 1,
-						awareness: {},
-						updates: [],
-					},
-					{
-						room: 'postType/post:10',
-						end_cursor: 1,
-						awareness: {},
-						updates: [],
-					},
-				],
-			};
-			mockPostSyncUpdate.mockResolvedValueOnce( twoRoomResponse );
-
-			pollingManager.registerRoom( {
-				room: 'postType/post:1',
-				doc: createMockDoc( 1 ),
-				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
-			} );
-			pollingManager.registerRoom( {
-				room: 'postType/post:10',
-				doc: createMockDoc( 2 ),
-				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
-			} );
-
-			await jest.advanceTimersByTimeAsync( 0 );
-			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
-
-			// Next poll: 403 referencing the longer-named room.
-			mockPostSyncUpdate.mockRejectedValueOnce( {
-				code: 'rest_cannot_edit',
-				message:
-					'You do not have permission to sync this entity: postType/post:10.',
-				data: { status: 403 },
-			} );
-			mockPostSyncUpdate.mockResolvedValueOnce( {
-				rooms: [
-					{
-						room: 'postType/post:1',
-						end_cursor: 2,
-						awareness: {},
-						updates: [],
-					},
-				],
-			} );
-			await jest.advanceTimersByTimeAsync( 4000 );
-			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
-
-			// The next poll's payload should still include the shorter
-			// room and exclude the (correctly identified) longer one.
-			await jest.advanceTimersByTimeAsync( 4000 );
-			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
-			const lastPayload = mockPostSyncUpdate.mock.calls[ 2 ][ 0 ] as {
-				rooms: { room: string }[];
-			};
-			const remainingRoomNames = lastPayload.rooms.map( ( r ) => r.room );
-			expect( remainingRoomNames ).toContain( 'postType/post:1' );
-			expect( remainingRoomNames ).not.toContain( 'postType/post:10' );
-		} );
-
 		it( 'does not send a disconnect signal when unregistering a forbidden room', async () => {
 			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
 
@@ -1753,12 +1678,12 @@ describe( 'polling-manager', () => {
 			await jest.advanceTimersByTimeAsync( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
 
-			// Next poll: 403 referencing the only registered room.
+			// Next poll: 403 listing the only registered room.
 			mockPostSyncUpdate.mockRejectedValueOnce( {
 				code: 'rest_cannot_edit',
 				message:
-					'You do not have permission to sync this entity: test-room.',
-				data: { status: 403 },
+					'You do not have permission to sync one or more entities: test-room.',
+				data: { status: 403, rooms: [ 'test-room' ] },
 			} );
 			await jest.advanceTimersByTimeAsync( 4000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
@@ -1768,7 +1693,7 @@ describe( 'polling-manager', () => {
 			expect( mockPostSyncUpdateNonBlocking ).not.toHaveBeenCalled();
 		} );
 
-		it( 'resumes polling for a newly-registered room after a 403 unregistered all rooms', async () => {
+		it( 'resumes polling for a newly-registered room after a generic 403 unregistered all rooms', async () => {
 			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
 
 			pollingManager.registerRoom( {
@@ -1783,12 +1708,11 @@ describe( 'polling-manager', () => {
 			await jest.advanceTimersByTimeAsync( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
 
-			// Next poll: 403 referencing the only registered room.
+			// Next poll: a generic 403 without room details.
 			// All rooms get unregistered and the poll loop stops.
 			mockPostSyncUpdate.mockRejectedValueOnce( {
 				code: 'rest_cannot_edit',
-				message:
-					'You do not have permission to sync this entity: test-room.',
+				message: 'You do not have permission to perform this action.',
 				data: { status: 403 },
 			} );
 			await jest.advanceTimersByTimeAsync( 4000 );

--- a/phpunit/tests/collaboration/wpHttpPollingSyncServer.php
+++ b/phpunit/tests/collaboration/wpHttpPollingSyncServer.php
@@ -251,18 +251,31 @@ class Tests_Collaboration_WpHttpPollingSyncServer extends WP_Test_REST_Controlle
 		$this->assertErrorResponse( 'rest_cannot_edit', $response, 403 );
 	}
 
+	/**
+	 * @ticket 77243
+	 */
 	public function test_sync_permission_checked_per_room() {
 		wp_set_current_user( self::$editor_id );
 
-		// First room is allowed, second room is forbidden.
+		$forbidden_rooms = array(
+			'unknown/entity',
+			'postType/post:999999',
+		);
+
+		// First room is allowed, remaining rooms are forbidden.
 		$response = $this->dispatch_sync(
 			array(
 				$this->build_room( $this->get_post_room() ),
-				$this->build_room( 'unknown/entity' ),
+				$this->build_room( $forbidden_rooms[0] ),
+				$this->build_room( $forbidden_rooms[1] ),
 			)
 		);
 
 		$this->assertErrorResponse( 'rest_cannot_edit', $response, 403 );
+		$data = $response->get_data();
+		$this->assertSame( $forbidden_rooms, $data['data']['rooms'] );
+		$this->assertStringContainsString( $forbidden_rooms[0], $data['message'] );
+		$this->assertStringContainsString( $forbidden_rooms[1], $data['message'] );
 	}
 
 	/**


### PR DESCRIPTION
## What?
Closes #77243

Updates the HTTP polling sync endpoint and client so a multi-room request can handle all forbidden rooms from a single `403` response.

## Why?
When a poll request includes multiple rooms the user cannot access, the server previously returned a `403` for only the first denied room. The client then had to retry once per forbidden room before reaching a stable working set, causing extra round trips and repeated `403` responses.

## How?
- Collect all rooms that fail the sync permission check and return them in the REST error data as `rooms`.
- Keep the denied room names in the error message so older clients can still fall back to the existing message-matching behavior.
- Update the polling manager to unregister all denied rooms listed in `error.data.rooms`, while restoring pending updates for rooms that remain valid.
- Filter returned room names to the failed request payload so unrelated room names in an error response are ignored.
- Add JS coverage for multi-room forbidden responses and defensive filtering, plus PHP coverage for the REST error payload.

## Testing Instructions
Run the polling-manager unit test:

```bash
npm run test:unit -- packages/sync/src/providers/http-polling/test/polling-manager.test.ts --runInBand
```

With `wp-env-test` running, run the sync server PHPUnit coverage:

```bash
vendor/bin/phpunit phpunit/tests/collaboration/wpHttpPollingSyncServer.php --filter test_sync_permission_checked_per_room
```

Manual two-collaborator check:

1. Start the local environment and enable collaboration:

```bash
npm run wp-env status
npm run wp-env start
npm run wp-env run cli wp option update wp_collaboration_enabled 1
```

2. In `wp-admin`, create a temporary user with the `Editor` role.
3. Make sure the active block theme's page template contains at least two template parts, such as Header and Footer. If it does not, add a second template part to the page template as an administrator.
4. Create or choose a Page that uses that template.
5. Open two separate browser sessions, such as a normal window and a private/incognito window.
6. In the first browser, log in as an administrator and open the Page.
7. In the second browser, log in as the temporary editor and open the same Page so there are two collaborators on the allowed page room.
8. In the temporary editor's browser, open DevTools, switch to the Network tab, and filter requests by `wp-sync/v1/updates`.
9. In the editor sidebar, switch to the Page tab, open the Template panel, click the template name, and toggle Show template on.
10. Confirm the temporary editor sees a single `403` response for `/wp-sync/v1/updates` where:
   - the response code is `rest_cannot_edit`;
   - `data.status` is `403`;
   - `data.rooms` contains all denied template/template-part rooms from that failed request, for example `postType/wp_template_part:*` rooms for Header and Footer;
   - `data.rooms` does not contain the allowed Page room;
   - `message` includes the denied room names for backwards compatibility with older clients.
11. Confirm later `/wp-sync/v1/updates` requests return to `200` responses instead of failing once per forbidden room.
12. Confirm the Connection lost modal does not appear and both browser sessions can keep editing the Page.

### Testing Instructions for Keyboard
Not applicable. This PR does not change UI behavior.

## Screenshots or screencast
Not applicable. This PR does not change UI behavior.

## Use of AI Tools
AI assistance: Yes
Tool(s): OpenClaw, Codex
Used for: OpenClaw helped with writing code and Codex was used for PR description drafting.
