### PR TITLE
Image cropper: round zoom control values and display as percentages

### DIFF
--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -21,6 +21,19 @@ import { MAX_ZOOM } from '../../image-editor/core/constants';
 import { getMinZoom } from '../../image-editor/core/containment';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
 
+const ZOOM_DISPLAY_PRECISION = 10;
+const ZOOM_DISPLAY_TOLERANCE = 1e-8;
+
+function roundDownZoomForDisplay( value: number ): number {
+	// Keep exact tenths represented slightly below their decimal value
+	// from dropping by another tenth in the visible control.
+	return (
+		Math.floor(
+			( value + ZOOM_DISPLAY_TOLERANCE ) * ZOOM_DISPLAY_PRECISION
+		) / ZOOM_DISPLAY_PRECISION
+	);
+}
+
 export interface MediaEditorCropPanelProps {
 	/**
 	 * Selected aspect-ratio preset value as a string (so it round-trips
@@ -63,6 +76,8 @@ export default function MediaEditorCropPanel( {
 	const { state, setZoom } = useMediaEditor();
 	const zoomGestureHandlers = useCropGestureHandlers();
 	const minZoom = getMinZoom( state );
+	const displayZoom = roundDownZoomForDisplay( state.zoom );
+	const displayMinZoom = roundDownZoomForDisplay( minZoom );
 
 	return (
 		// Tag the whole panel as a crop-control region so the modal's
@@ -95,10 +110,10 @@ export default function MediaEditorCropPanel( {
 				<RangeControl
 					__next40pxDefaultSize
 					label={ __( 'Zoom' ) }
-					min={ minZoom }
+					min={ displayMinZoom }
 					max={ MAX_ZOOM }
 					step={ 0.1 }
-					value={ state.zoom }
+					value={ displayZoom }
 					onChange={ ( value ) => {
 						onPlacementControlInteraction?.();
 						setZoom( typeof value === 'number' ? value : minZoom );

--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -2,6 +2,11 @@
  * WordPress dependencies
  */
 import {
+	Flex,
+	FlexBlock,
+	FlexItem,
+	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
+	__experimentalNumberControl as NumberControl,
 	RangeControl,
 	SelectControl,
 	ToggleControl,
@@ -21,17 +26,11 @@ import { MAX_ZOOM } from '../../image-editor/core/constants';
 import { getMinZoom } from '../../image-editor/core/containment';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
 
-const ZOOM_DISPLAY_PRECISION = 10;
-const ZOOM_DISPLAY_TOLERANCE = 1e-8;
+const ZOOM_PERCENTAGE_SCALE = 100;
+const MAX_ZOOM_PERCENTAGE = MAX_ZOOM * ZOOM_PERCENTAGE_SCALE;
 
-function roundDownZoomForDisplay( value: number ): number {
-	// Keep exact tenths represented slightly below their decimal value
-	// from dropping by another tenth in the visible control.
-	return (
-		Math.floor(
-			( value + ZOOM_DISPLAY_TOLERANCE ) * ZOOM_DISPLAY_PRECISION
-		) / ZOOM_DISPLAY_PRECISION
-	);
+function getZoomPercentageForDisplay( zoom: number ): number {
+	return Math.round( zoom * ZOOM_PERCENTAGE_SCALE );
 }
 
 export interface MediaEditorCropPanelProps {
@@ -76,8 +75,8 @@ export default function MediaEditorCropPanel( {
 	const { state, setZoom } = useMediaEditor();
 	const zoomGestureHandlers = useCropGestureHandlers();
 	const minZoom = getMinZoom( state );
-	const displayZoom = roundDownZoomForDisplay( state.zoom );
-	const displayMinZoom = roundDownZoomForDisplay( minZoom );
+	const zoomPercentage = getZoomPercentageForDisplay( state.zoom );
+	const minZoomPercentage = getZoomPercentageForDisplay( minZoom );
 
 	return (
 		// Tag the whole panel as a crop-control region so the modal's
@@ -107,27 +106,65 @@ export default function MediaEditorCropPanel( {
 				onChange={ onFreeformChange }
 			/>
 			<div role="presentation" { ...zoomGestureHandlers }>
-				<RangeControl
-					__next40pxDefaultSize
-					label={ __( 'Zoom' ) }
-					min={ displayMinZoom }
-					max={ MAX_ZOOM }
-					step={ 0.1 }
-					value={ displayZoom }
-					onChange={ ( value ) => {
-						onPlacementControlInteraction?.();
-						setZoom( typeof value === 'number' ? value : minZoom );
-					} }
-					renderTooltipContent={ ( value ) => {
-						const zoom =
-							typeof value === 'number' ? value : minZoom;
-						return sprintf(
-							/* translators: %d: zoom level as a percentage. */
-							__( '%d%%' ),
-							Math.round( zoom * 100 )
-						);
-					} }
-				/>
+				<Flex align="flex-end" gap={ 2 }>
+					<FlexBlock>
+						<RangeControl
+							__next40pxDefaultSize
+							label={ __( 'Zoom' ) }
+							min={ minZoom }
+							max={ MAX_ZOOM }
+							step={ 0.1 }
+							value={ state.zoom }
+							onChange={ ( value ) => {
+								onPlacementControlInteraction?.();
+								setZoom(
+									typeof value === 'number' ? value : minZoom
+								);
+							} }
+							renderTooltipContent={ ( value ) => {
+								const zoom =
+									typeof value === 'number' ? value : minZoom;
+								return sprintf(
+									/* translators: %d: zoom level as a percentage. */
+									__( '%d%%' ),
+									getZoomPercentageForDisplay( zoom )
+								);
+							} }
+							withInputField={ false }
+						/>
+					</FlexBlock>
+					<FlexItem>
+						<NumberControl
+							__next40pxDefaultSize
+							__unstableInputWidth="80px"
+							label={ __( 'Zoom percentage' ) }
+							hideLabelFromVision
+							min={ minZoomPercentage }
+							max={ MAX_ZOOM_PERCENTAGE }
+							step={ 1 }
+							shiftStep={ 10 }
+							value={ zoomPercentage }
+							onChange={ ( value ) => {
+								const nextZoomPercentage = parseFloat(
+									value ?? ''
+								);
+								if ( Number.isNaN( nextZoomPercentage ) ) {
+									return;
+								}
+
+								onPlacementControlInteraction?.();
+								setZoom(
+									nextZoomPercentage / ZOOM_PERCENTAGE_SCALE
+								);
+							} }
+							suffix={
+								<InputControlSuffixWrapper>
+									%
+								</InputControlSuffixWrapper>
+							}
+						/>
+					</FlexItem>
+				</Flex>
 			</div>
 		</Stack>
 	);

--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -106,7 +106,7 @@ export default function MediaEditorCropPanel( {
 				onChange={ onFreeformChange }
 			/>
 			<div role="presentation" { ...zoomGestureHandlers }>
-				<Flex align="flex-end" gap={ 2 }>
+				<Flex align="flex-end" gap={ 4 }>
 					<FlexBlock>
 						<RangeControl
 							__next40pxDefaultSize
@@ -136,7 +136,7 @@ export default function MediaEditorCropPanel( {
 					<FlexItem>
 						<NumberControl
 							__next40pxDefaultSize
-							__unstableInputWidth="80px"
+							__unstableInputWidth="96px"
 							label={ __( 'Zoom percentage' ) }
 							hideLabelFromVision
 							min={ minZoomPercentage }

--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -2,11 +2,6 @@
  * WordPress dependencies
  */
 import {
-	Flex,
-	FlexBlock,
-	FlexItem,
-	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
-	__experimentalNumberControl as NumberControl,
 	RangeControl,
 	SelectControl,
 	ToggleControl,
@@ -31,6 +26,10 @@ const MAX_ZOOM_PERCENTAGE = MAX_ZOOM * ZOOM_PERCENTAGE_SCALE;
 
 function getZoomPercentageForDisplay( zoom: number ): number {
 	return Math.round( zoom * ZOOM_PERCENTAGE_SCALE );
+}
+
+function getMinZoomPercentageForDisplay( zoom: number ): number {
+	return Math.ceil( zoom * ZOOM_PERCENTAGE_SCALE );
 }
 
 export interface MediaEditorCropPanelProps {
@@ -76,7 +75,7 @@ export default function MediaEditorCropPanel( {
 	const zoomGestureHandlers = useCropGestureHandlers();
 	const minZoom = getMinZoom( state );
 	const zoomPercentage = getZoomPercentageForDisplay( state.zoom );
-	const minZoomPercentage = getZoomPercentageForDisplay( minZoom );
+	const minZoomPercentage = getMinZoomPercentageForDisplay( minZoom );
 
 	return (
 		// Tag the whole panel as a crop-control region so the modal's
@@ -106,65 +105,34 @@ export default function MediaEditorCropPanel( {
 				onChange={ onFreeformChange }
 			/>
 			<div role="presentation" { ...zoomGestureHandlers }>
-				<Flex align="flex-end" gap={ 4 }>
-					<FlexBlock>
-						<RangeControl
-							__next40pxDefaultSize
-							label={ __( 'Zoom' ) }
-							min={ minZoom }
-							max={ MAX_ZOOM }
-							step={ 0.1 }
-							value={ state.zoom }
-							onChange={ ( value ) => {
-								onPlacementControlInteraction?.();
-								setZoom(
-									typeof value === 'number' ? value : minZoom
-								);
-							} }
-							renderTooltipContent={ ( value ) => {
-								const zoom =
-									typeof value === 'number' ? value : minZoom;
-								return sprintf(
-									/* translators: %d: zoom level as a percentage. */
-									__( '%d%%' ),
-									getZoomPercentageForDisplay( zoom )
-								);
-							} }
-							withInputField={ false }
-						/>
-					</FlexBlock>
-					<FlexItem>
-						<NumberControl
-							__next40pxDefaultSize
-							__unstableInputWidth="96px"
-							label={ __( 'Zoom percentage' ) }
-							hideLabelFromVision
-							min={ minZoomPercentage }
-							max={ MAX_ZOOM_PERCENTAGE }
-							step={ 1 }
-							shiftStep={ 10 }
-							value={ zoomPercentage }
-							onChange={ ( value ) => {
-								const nextZoomPercentage = parseFloat(
-									value ?? ''
-								);
-								if ( Number.isNaN( nextZoomPercentage ) ) {
-									return;
-								}
-
-								onPlacementControlInteraction?.();
-								setZoom(
-									nextZoomPercentage / ZOOM_PERCENTAGE_SCALE
-								);
-							} }
-							suffix={
-								<InputControlSuffixWrapper>
-									%
-								</InputControlSuffixWrapper>
-							}
-						/>
-					</FlexItem>
-				</Flex>
+				<RangeControl
+					__next40pxDefaultSize
+					label={ __( 'Zoom (%)' ) }
+					min={ minZoomPercentage }
+					max={ MAX_ZOOM_PERCENTAGE }
+					step={ 1 }
+					shiftStep={ 10 }
+					value={ zoomPercentage }
+					onChange={ ( value ) => {
+						onPlacementControlInteraction?.();
+						setZoom(
+							typeof value === 'number'
+								? value / ZOOM_PERCENTAGE_SCALE
+								: minZoom
+						);
+					} }
+					renderTooltipContent={ ( value ) => {
+						const percentage =
+							typeof value === 'number'
+								? value
+								: minZoomPercentage;
+						return sprintf(
+							/* translators: %d: zoom level as a percentage. */
+							__( '%d%%' ),
+							Math.round( percentage )
+						);
+					} }
+				/>
 			</div>
 		</Stack>
 	);

--- a/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
@@ -88,22 +88,34 @@ describe( 'MediaEditorCropPanel', () => {
 		expect( controls.onFreeformChange ).toHaveBeenCalledWith( false );
 	} );
 
-	it.each( [
-		[ 3.749999999999999, 3.7 ],
-		[ 3.799999999999999, 3.8 ],
-	] )(
-		'formats displayed zoom value %s as %s without changing cropper state',
-		( zoom, displayZoom ) => {
-			setupCropPanel( {}, { zoom } );
+	it( 'displays zoom as a percentage without changing cropper state', () => {
+		setupCropPanel( {}, { zoom: 3.749999999999999 } );
 
-			const zoomInput = screen.getByRole( 'spinbutton', {
-				name: 'Zoom',
-			} );
+		const zoomInput = screen.getByRole( 'spinbutton', {
+			name: 'Zoom percentage',
+		} );
 
-			expect( zoomInput ).toHaveValue( displayZoom );
-			expect( screen.getByTestId( 'current-zoom' ) ).toHaveTextContent(
-				String( zoom )
-			);
-		}
-	);
+		expect( zoomInput ).toHaveValue( 375 );
+		expect( screen.getByTestId( 'current-zoom' ) ).toHaveTextContent(
+			'3.749999999999999'
+		);
+	} );
+
+	it( 'converts percentage input back to the cropper zoom multiplier', () => {
+		const controls = setupCropPanel( {
+			onPlacementControlInteraction: jest.fn(),
+		} );
+
+		fireEvent.change(
+			screen.getByRole( 'spinbutton', { name: 'Zoom percentage' } ),
+			{
+				target: { value: '250' },
+			}
+		);
+
+		expect( screen.getByTestId( 'current-zoom' ) ).toHaveTextContent(
+			'2.5'
+		);
+		expect( controls.onPlacementControlInteraction ).toHaveBeenCalled();
+	} );
 } );

--- a/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
@@ -8,10 +8,12 @@ import { fireEvent, render, screen } from '@testing-library/react';
  */
 import MediaEditorCropPanel from '..';
 import type { MediaEditorCropPanelProps } from '..';
-import { MediaEditorStateProvider } from '../../../state';
+import { MediaEditorStateProvider, useMediaEditor } from '../../../state';
+import type { CropperState } from '../../../image-editor';
 
 function setupCropPanel(
-	overrides: Partial< MediaEditorCropPanelProps > = {}
+	overrides: Partial< MediaEditorCropPanelProps > = {},
+	initialCropperState?: Partial< CropperState >
 ) {
 	const props: MediaEditorCropPanelProps = {
 		aspectRatioValue: '1',
@@ -27,18 +29,19 @@ function setupCropPanel(
 	};
 
 	render(
-		<MediaEditorStateProvider>
+		<MediaEditorStateProvider initialCropperState={ initialCropperState }>
 			<MediaEditorCropPanel { ...props } />
+			<CurrentZoomValue />
 		</MediaEditorStateProvider>
 	);
 
 	return props;
 }
 
-function expectElementBefore( first: HTMLElement, second: HTMLElement ) {
-	expect( first.compareDocumentPosition( second ) ).toBe(
-		Node.DOCUMENT_POSITION_FOLLOWING
-	);
+function CurrentZoomValue() {
+	const { state } = useMediaEditor();
+
+	return <output data-testid="current-zoom">{ state.zoom }</output>;
 }
 
 describe( 'MediaEditorCropPanel', () => {
@@ -49,8 +52,12 @@ describe( 'MediaEditorCropPanel', () => {
 		const resizeCropArea = screen.getByLabelText( 'Show resize handles' );
 		const zoom = screen.getByRole( 'slider', { name: 'Zoom' } );
 
-		expectElementBefore( aspectRatio, resizeCropArea );
-		expectElementBefore( resizeCropArea, zoom );
+		expect( aspectRatio.compareDocumentPosition( resizeCropArea ) ).toBe(
+			Node.DOCUMENT_POSITION_FOLLOWING
+		);
+		expect( resizeCropArea.compareDocumentPosition( zoom ) ).toBe(
+			Node.DOCUMENT_POSITION_FOLLOWING
+		);
 	} );
 
 	it( 'passes selected aspect ratio changes to the caller', () => {
@@ -80,4 +87,23 @@ describe( 'MediaEditorCropPanel', () => {
 
 		expect( controls.onFreeformChange ).toHaveBeenCalledWith( false );
 	} );
+
+	it.each( [
+		[ 3.749999999999999, 3.7 ],
+		[ 3.799999999999999, 3.8 ],
+	] )(
+		'formats displayed zoom value %s as %s without changing cropper state',
+		( zoom, displayZoom ) => {
+			setupCropPanel( {}, { zoom } );
+
+			const zoomInput = screen.getByRole( 'spinbutton', {
+				name: 'Zoom',
+			} );
+
+			expect( zoomInput ).toHaveValue( displayZoom );
+			expect( screen.getByTestId( 'current-zoom' ) ).toHaveTextContent(
+				String( zoom )
+			);
+		}
+	);
 } );

--- a/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
@@ -50,7 +50,7 @@ describe( 'MediaEditorCropPanel', () => {
 
 		const aspectRatio = screen.getByLabelText( 'Aspect ratio' );
 		const resizeCropArea = screen.getByLabelText( 'Show resize handles' );
-		const zoom = screen.getByRole( 'slider', { name: 'Zoom' } );
+		const zoom = screen.getByRole( 'slider', { name: 'Zoom (%)' } );
 
 		expect( aspectRatio.compareDocumentPosition( resizeCropArea ) ).toBe(
 			Node.DOCUMENT_POSITION_FOLLOWING
@@ -92,7 +92,7 @@ describe( 'MediaEditorCropPanel', () => {
 		setupCropPanel( {}, { zoom: 3.749999999999999 } );
 
 		const zoomInput = screen.getByRole( 'spinbutton', {
-			name: 'Zoom percentage',
+			name: 'Zoom (%)',
 		} );
 
 		expect( zoomInput ).toHaveValue( 375 );
@@ -107,7 +107,7 @@ describe( 'MediaEditorCropPanel', () => {
 		} );
 
 		fireEvent.change(
-			screen.getByRole( 'spinbutton', { name: 'Zoom percentage' } ),
+			screen.getByRole( 'spinbutton', { name: 'Zoom (%)' } ),
 			{
 				target: { value: '250' },
 			}


### PR DESCRIPTION
## What?

Displays the media editor crop panel zoom control in percentage units.

## Why?

The cropper stores zoom as a multiplier, which can expose values like `3.749999999999999` in the UI. Percentages are clearer for users, and the label `Zoom (%)` makes the unit explicit.

## How?

- Uses the existing `RangeControl` with percentage values.
- Converts the cropper zoom multiplier to a percentage for display.
- Converts percentage input back to a multiplier before calling `setZoom`.
- Keeps the underlying cropper state and math unchanged.

## Testing Instructions

1. Open the editor and add/select an Image block.
2. Open the image editor modal for the selected image.
3. Go to the crop controls.
4. Adjust the `Zoom (%)` slider across several values.
5. Confirm the input next to the slider shows percentage values, such as `150`, `375`, or `1000`, instead of multiplier values like `1.5` or long floats.
6. Type a percentage value into the input and confirm the image zoom updates normally.
7. Apply/save the crop and confirm the edited image output still looks correct.

### Before


<img width="282" height="278" alt="Screenshot 2026-05-28 at 10 01 03 am" src="https://github.com/user-attachments/assets/ace836d8-519f-47bf-8ae8-3d1fb6c6566b" />

### After

<img width="285" height="287" alt="Screenshot 2026-05-28 at 1 00 54 pm" src="https://github.com/user-attachments/assets/cb3cf103-80ff-46a1-8f64-8ed14dc44694" />

