### PR TITLE
Media Editor: Remove resize handles toggle from crop panel

### DIFF
--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -44,7 +44,7 @@ export default function MediaEditorCanvas( {
 }: MediaEditorCanvasProps ) {
 	const { media } = useMediaEditorContext();
 	const controller = useMediaEditor();
-	const { aspectRatioValue, freeformCrop } = controller.cropOptions;
+	const { aspectRatioValue } = controller.cropOptions;
 	const cropperImage = controller.state.image;
 	const { beginGesture, endGesture, setImage } = controller;
 
@@ -100,7 +100,7 @@ export default function MediaEditorCanvas( {
 				src={ mediaUrl }
 				controller={ controller }
 				aspectRatio={ aspectRatio }
-				freeformCrop={ freeformCrop }
+				freeformCrop
 				focusOnMount={ focusOnMount }
 				showGrid="interactive"
 				isPlacementActive={ isPlacementActive }

--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -1,11 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	RangeControl,
-	SelectControl,
-	ToggleControl,
-} from '@wordpress/components';
+import { RangeControl, SelectControl } from '@wordpress/components';
 import { Stack, VisuallyHidden } from '@wordpress/ui';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -41,10 +37,6 @@ export interface MediaEditorCropPanelProps {
 	aspectRatioValue: string;
 	/** Setter for the aspect-ratio preset value. */
 	onAspectRatioChange: ( value: string ) => void;
-	/** Whether the cropper is in freeform (resize-handle) mode. */
-	freeformCrop: boolean;
-	/** Setter for freeform mode. */
-	onFreeformChange: ( value: boolean ) => void;
 	/** Signal that a placement-oriented control is being adjusted. */
 	onPlacementControlInteraction?: () => void;
 	/** Aspect-ratio presets to display in the selector. */
@@ -52,22 +44,17 @@ export interface MediaEditorCropPanelProps {
 }
 
 /**
- * Sidebar panel for crop-shape controls — aspect-ratio presets and
- * freeform toggle. The tactile verbs (rotate, flip) live in the
- * bottom toolbar instead.
+ * Sidebar panel for crop-shape controls. The tactile verbs (rotate, flip)
+ * live in the bottom toolbar instead.
  * @param props
  * @param props.aspectRatioValue
  * @param props.onAspectRatioChange
- * @param props.freeformCrop
- * @param props.onFreeformChange
  * @param props.onPlacementControlInteraction
  * @param props.aspectRatioOptions
  */
 export default function MediaEditorCropPanel( {
 	aspectRatioValue,
 	onAspectRatioChange,
-	freeformCrop,
-	onFreeformChange,
 	onPlacementControlInteraction,
 	aspectRatioOptions,
 }: MediaEditorCropPanelProps ) {
@@ -79,11 +66,11 @@ export default function MediaEditorCropPanel( {
 
 	return (
 		// Tag the whole panel as a crop-control region so the modal's
-		// Cmd+Z handler doesn't mistake the SelectControl / ToggleControl
-		// inputs for metadata fields (which would suppress undo).
+		// Cmd+Z handler doesn't mistake the SelectControl input for a
+		// metadata field (which would suppress undo).
 		<Stack
 			direction="column"
-			gap="md"
+			gap="xl"
 			{ ...{ [ CROP_CONTROL_ATTR ]: true } }
 		>
 			<VisuallyHidden render={ <h2 /> }>
@@ -98,11 +85,6 @@ export default function MediaEditorCropPanel( {
 					label: preset.label,
 					value: preset.value.toString(),
 				} ) ) }
-			/>
-			<ToggleControl
-				label={ __( 'Show resize handles' ) }
-				checked={ freeformCrop }
-				onChange={ onFreeformChange }
 			/>
 			<div role="presentation" { ...zoomGestureHandlers }>
 				<RangeControl

--- a/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
@@ -18,8 +18,6 @@ function setupCropPanel(
 	const props: MediaEditorCropPanelProps = {
 		aspectRatioValue: '1',
 		onAspectRatioChange: jest.fn(),
-		freeformCrop: false,
-		onFreeformChange: jest.fn(),
 		aspectRatioOptions: [
 			{ label: 'Free', value: 0 },
 			{ label: 'Original', value: -1 },
@@ -49,13 +47,9 @@ describe( 'MediaEditorCropPanel', () => {
 		setupCropPanel();
 
 		const aspectRatio = screen.getByLabelText( 'Aspect ratio' );
-		const resizeCropArea = screen.getByLabelText( 'Show resize handles' );
 		const zoom = screen.getByRole( 'slider', { name: 'Zoom (%)' } );
 
-		expect( aspectRatio.compareDocumentPosition( resizeCropArea ) ).toBe(
-			Node.DOCUMENT_POSITION_FOLLOWING
-		);
-		expect( resizeCropArea.compareDocumentPosition( zoom ) ).toBe(
+		expect( aspectRatio.compareDocumentPosition( zoom ) ).toBe(
 			Node.DOCUMENT_POSITION_FOLLOWING
 		);
 	} );
@@ -63,7 +57,6 @@ describe( 'MediaEditorCropPanel', () => {
 	it( 'passes selected aspect ratio changes to the caller', () => {
 		const controls = setupCropPanel( {
 			aspectRatioValue: '1',
-			freeformCrop: false,
 		} );
 
 		fireEvent.change( screen.getByLabelText( 'Aspect ratio' ), {
@@ -74,18 +67,6 @@ describe( 'MediaEditorCropPanel', () => {
 		expect(
 			( controls.onAspectRatioChange as jest.Mock ).mock.calls[ 0 ][ 0 ]
 		).toBe( '0' );
-		expect( controls.onFreeformChange ).not.toHaveBeenCalled();
-	} );
-
-	it( 'passes resize-handle changes to the caller', () => {
-		const controls = setupCropPanel( {
-			aspectRatioValue: '0',
-			freeformCrop: true,
-		} );
-
-		fireEvent.click( screen.getByLabelText( 'Show resize handles' ) );
-
-		expect( controls.onFreeformChange ).toHaveBeenCalledWith( false );
 	} );
 
 	it( 'displays zoom as a percentage without changing cropper state', () => {

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -452,8 +452,6 @@ function MediaEditorContent( {
 		aspectRatioValue,
 		setAspectRatioValue,
 		aspectRatioOptions,
-		freeformCrop,
-		setFreeformCrop,
 		resetCropOptions,
 	} = useCropOptions( {
 		aspectRatioPresets,
@@ -496,8 +494,6 @@ function MediaEditorContent( {
 						<MediaEditorCropPanel
 							aspectRatioValue={ aspectRatioValue }
 							onAspectRatioChange={ setAspectRatioValue }
-							freeformCrop={ freeformCrop }
-							onFreeformChange={ setFreeformCrop }
 							onPlacementControlInteraction={
 								signalPlacementControlInteraction
 							}
@@ -512,8 +508,6 @@ function MediaEditorContent( {
 		isImage,
 		aspectRatioValue,
 		setAspectRatioValue,
-		freeformCrop,
-		setFreeformCrop,
 		aspectRatioOptions,
 		signalPlacementControlInteraction,
 	] );

--- a/packages/media-editor/src/components/media-editor/test/use-crop-options.tsx
+++ b/packages/media-editor/src/components/media-editor/test/use-crop-options.tsx
@@ -23,9 +23,6 @@ function CropOptionsHarness() {
 			<div data-testid="aspect-ratio-value">
 				{ cropOptions.aspectRatioValue }
 			</div>
-			<div data-testid="freeform-crop">
-				{ cropOptions.freeformCrop ? 'true' : 'false' }
-			</div>
 			<div data-testid="resolved-aspect-ratio">
 				{ cropOptions.resolvedAspectRatio ?? 'undefined' }
 			</div>
@@ -48,9 +45,6 @@ function CropOptionsHarness() {
 			</button>
 			<button onClick={ () => cropOptions.setAspectRatioValue( '0' ) }>
 				Free
-			</button>
-			<button onClick={ () => cropOptions.setFreeformCrop( false ) }>
-				Disable handles
 			</button>
 			<button onClick={ cropOptions.resetCropOptions }>Reset</button>
 		</div>
@@ -103,62 +97,14 @@ describe( 'useCropOptions', () => {
 		).toHaveTextContent( 'undefined' );
 	} );
 
-	it( 'picking Free auto-enables freeform when it was off', () => {
-		renderHarness();
-
-		// Pick a non-Free preset and turn freeform off.
-		fireEvent.click( screen.getByRole( 'button', { name: 'Square' } ) );
-		fireEvent.click(
-			screen.getByRole( 'button', { name: 'Disable handles' } )
-		);
-
-		expect( screen.getByTestId( 'freeform-crop' ) ).toHaveTextContent(
-			'false'
-		);
-		expect( screen.getByTestId( 'aspect-ratio-value' ) ).toHaveTextContent(
-			'1'
-		);
-
-		// Picking Free re-enables freeform — picking Free implies the
-		// user wants to freeform-edit and there'd otherwise be no
-		// visible affordance.
-		fireEvent.click( screen.getByRole( 'button', { name: 'Free' } ) );
-
-		expect( screen.getByTestId( 'aspect-ratio-value' ) ).toHaveTextContent(
-			'0'
-		);
-		expect( screen.getByTestId( 'freeform-crop' ) ).toHaveTextContent(
-			'true'
-		);
-	} );
-
-	it( 'picking Free leaves freeform alone if it was already on', () => {
-		renderHarness();
-
-		// Start clean: freeform is true by default.
-		fireEvent.click( screen.getByRole( 'button', { name: 'Square' } ) );
-		// Don't turn freeform off — pick Free directly.
-		fireEvent.click( screen.getByRole( 'button', { name: 'Free' } ) );
-
-		expect( screen.getByTestId( 'freeform-crop' ) ).toHaveTextContent(
-			'true'
-		);
-	} );
-
-	it( 'reset returns cropOptions to defaults (Free + freeform on)', () => {
+	it( 'reset returns cropOptions to defaults', () => {
 		renderHarness();
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Square' } ) );
-		fireEvent.click(
-			screen.getByRole( 'button', { name: 'Disable handles' } )
-		);
 		fireEvent.click( screen.getByRole( 'button', { name: 'Reset' } ) );
 
 		expect( screen.getByTestId( 'aspect-ratio-value' ) ).toHaveTextContent(
 			'0'
-		);
-		expect( screen.getByTestId( 'freeform-crop' ) ).toHaveTextContent(
-			'true'
 		);
 	} );
 } );

--- a/packages/media-editor/src/components/media-editor/use-crop-options.ts
+++ b/packages/media-editor/src/components/media-editor/use-crop-options.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -9,9 +9,6 @@ import { useCallback, useMemo } from '@wordpress/element';
 import { DEFAULT_ASPECT_RATIOS } from '../../image-editor/core/constants';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
 import { useMediaEditor, resolveAspectRatio } from '../../state';
-
-/** Preset key for "Free" — no aspect lock. Round-trips through SelectControl. */
-const FREE_ASPECT_RATIO_VALUE = '0';
 
 interface UseCropOptionsArgs {
 	aspectRatioPresets?: AspectRatioPreset[];
@@ -21,8 +18,6 @@ interface UseCropOptionsReturn {
 	aspectRatioValue: string;
 	setAspectRatioValue: ( value: string ) => void;
 	aspectRatioOptions: AspectRatioPreset[];
-	freeformCrop: boolean;
-	setFreeformCrop: ( value: boolean ) => void;
 	resolvedAspectRatio: number | undefined;
 	resetCropOptions: () => void;
 }
@@ -47,9 +42,9 @@ export function getAspectRatioOptions(
 
 /**
  * Thin selector over the composite media-editor store for the Crop
- * sidebar tab. Reads the cropOptions slice (preset key, freeform) and
- * exposes the corresponding setters plus a render-time
- * `resolvedAspectRatio` derivation.
+ * sidebar tab. Reads the cropOptions slice (preset key) and exposes
+ * the corresponding setters plus a render-time `resolvedAspectRatio`
+ * derivation.
  *
  * No local React state, no refs, no synchronization effects — the
  * composite store is the single source of truth.
@@ -61,7 +56,7 @@ export function useCropOptions( {
 	aspectRatioPresets,
 }: UseCropOptionsArgs = {} ): UseCropOptionsReturn {
 	const controller = useMediaEditor();
-	const { aspectRatioValue, freeformCrop } = controller.cropOptions;
+	const { aspectRatioValue } = controller.cropOptions;
 	const cropperImage = controller.state.image;
 
 	const aspectRatioOptions = useMemo(
@@ -74,41 +69,10 @@ export function useCropOptions( {
 		[ aspectRatioValue, cropperImage ]
 	);
 
-	// Sidebar UX rule: picking Free auto-enables Resize-crop (freeform)
-	// when it's currently off — picking Free implies the user wants to
-	// freeform-edit, and there'd otherwise be no visible affordance for
-	// it. Wrapped in a gesture so the two dispatches collapse into a
-	// single undo step.
-	const { beginGesture, endGesture, setAspectRatioValue, setFreeformCrop } =
-		controller;
-	const setAspectRatioValueWithFreeformSync = useCallback(
-		( value: string ) => {
-			const shouldReenableFreeform =
-				value === FREE_ASPECT_RATIO_VALUE && ! freeformCrop;
-			if ( ! shouldReenableFreeform ) {
-				setAspectRatioValue( value );
-				return;
-			}
-			beginGesture();
-			setAspectRatioValue( value );
-			setFreeformCrop( true );
-			endGesture();
-		},
-		[
-			freeformCrop,
-			beginGesture,
-			endGesture,
-			setAspectRatioValue,
-			setFreeformCrop,
-		]
-	);
-
 	return {
 		aspectRatioValue,
-		setAspectRatioValue: setAspectRatioValueWithFreeformSync,
+		setAspectRatioValue: controller.setAspectRatioValue,
 		aspectRatioOptions,
-		freeformCrop,
-		setFreeformCrop: controller.setFreeformCrop,
 		resolvedAspectRatio,
 		resetCropOptions: controller.resetCropOptions,
 	};

--- a/packages/media-editor/src/image-editor/docs/recipes.md
+++ b/packages/media-editor/src/image-editor/docs/recipes.md
@@ -78,7 +78,7 @@ function CropperPanel( { src }: { src: string } ) {
 
 ## Use the Media Editor Composite Controller
 
-Use the media editor controller when cropper state must share history with controls such as aspect ratio and freeform crop.
+Use the media editor controller when cropper state must share history with controls such as aspect ratio.
 
 ```tsx
 import { resolveAspectRatio, useMediaEditor } from '../../state';
@@ -96,7 +96,7 @@ function MediaEditorCanvas( { src }: { src: string } ) {
 			src={ src }
 			controller={ controller }
 			aspectRatio={ aspectRatio }
-			freeformCrop={ controller.cropOptions.freeformCrop }
+			freeformCrop
 			onGestureStart={ controller.beginGesture }
 			onGestureEnd={ controller.endGesture }
 		/>

--- a/packages/media-editor/src/state/composite-reducer.ts
+++ b/packages/media-editor/src/state/composite-reducer.ts
@@ -71,24 +71,10 @@ export function mediaEditorReducer(
 				cropOptions: nextCropOptions,
 			};
 		}
-		case 'SET_FREEFORM_CROP': {
-			if ( state.cropOptions.freeformCrop === action.payload ) {
-				return state;
-			}
-			return {
-				...state,
-				cropOptions: {
-					...state.cropOptions,
-					freeformCrop: action.payload,
-				},
-			};
-		}
 		case 'RESET_CROP_OPTIONS': {
 			if (
 				state.cropOptions.aspectRatioValue ===
-					DEFAULT_CROP_OPTIONS.aspectRatioValue &&
-				state.cropOptions.freeformCrop ===
-					DEFAULT_CROP_OPTIONS.freeformCrop
+				DEFAULT_CROP_OPTIONS.aspectRatioValue
 			) {
 				return state;
 			}
@@ -129,8 +115,7 @@ export function areMediaEditorStatesEqual(
 	}
 	return (
 		areCropperStatesEqual( a.cropper, b.cropper ) &&
-		a.cropOptions.aspectRatioValue === b.cropOptions.aspectRatioValue &&
-		a.cropOptions.freeformCrop === b.cropOptions.freeformCrop
+		a.cropOptions.aspectRatioValue === b.cropOptions.aspectRatioValue
 	);
 }
 

--- a/packages/media-editor/src/state/test/use-media-editor-state.ts
+++ b/packages/media-editor/src/state/test/use-media-editor-state.ts
@@ -26,25 +26,23 @@ function setupHook( visualSize = { width: 600, height: 400 } ) {
 
 describe( 'useMediaEditorState', () => {
 	describe( 'initial state', () => {
-		it( 'starts with default cropOptions (Free + freeform on)', () => {
+		it( 'starts with default cropOptions', () => {
 			const { result } = renderHook( () => useMediaEditorState() );
 
 			expect( result.current.cropOptions.aspectRatioValue ).toBe( '0' );
-			expect( result.current.cropOptions.freeformCrop ).toBe( true );
 		} );
 
 		it( 'merges initial cropper and cropOptions overrides', () => {
 			const { result } = renderHook( () =>
 				useMediaEditorState( {
 					cropper: { image: IMAGE },
-					cropOptions: { aspectRatioValue: '1', freeformCrop: false },
+					cropOptions: { aspectRatioValue: '1' },
 				} )
 			);
 
 			expect( result.current.state.image ).toEqual( IMAGE );
 			expect( result.current.cropOptions ).toEqual( {
 				aspectRatioValue: '1',
-				freeformCrop: false,
 			} );
 		} );
 
@@ -94,23 +92,10 @@ describe( 'useMediaEditorState', () => {
 			expect( result.current.hasRedo ).toBe( false );
 		} );
 
-		it( 'undo restores cropOptions changes (freeform toggle)', () => {
-			const { result } = setupHook();
-
-			act( () => result.current.setFreeformCrop( false ) );
-			expect( result.current.cropOptions.freeformCrop ).toBe( false );
-			expect( result.current.isDirty ).toBe( true );
-			expect( result.current.isCropperDirty ).toBe( false );
-
-			act( () => result.current.undo() );
-			expect( result.current.cropOptions.freeformCrop ).toBe( true );
-		} );
-
 		it( 'no-op actions do not record history entries', () => {
 			const { result } = setupHook();
 
-			// Setting freeformCrop to its current value should be a no-op.
-			act( () => result.current.setFreeformCrop( true ) );
+			act( () => result.current.setAspectRatioValue( '0' ) );
 
 			expect( result.current.hasUndo ).toBe( false );
 		} );
@@ -210,37 +195,6 @@ describe( 'useMediaEditorState', () => {
 			expect( result.current.state.rotation ).toBe( 0 );
 			expect( result.current.hasUndo ).toBe( false );
 		} );
-
-		it( 'groups a Free preset change and freeform re-enable in one undo step', () => {
-			const { result } = renderHook( () =>
-				useMediaEditorState( {
-					cropper: { image: IMAGE },
-					cropOptions: {
-						aspectRatioValue: '1',
-						freeformCrop: false,
-					},
-				} )
-			);
-
-			act( () => {
-				result.current.beginGesture();
-				result.current.setAspectRatioValue( '0' );
-				result.current.setFreeformCrop( true );
-				result.current.endGesture();
-			} );
-
-			expect( result.current.cropOptions ).toEqual( {
-				aspectRatioValue: '0',
-				freeformCrop: true,
-			} );
-
-			act( () => result.current.undo() );
-
-			expect( result.current.cropOptions ).toEqual( {
-				aspectRatioValue: '1',
-				freeformCrop: false,
-			} );
-		} );
 	} );
 
 	describe( 'SET_ASPECT_RATIO_VALUE atomicity', () => {
@@ -295,34 +249,10 @@ describe( 'useMediaEditorState', () => {
 			);
 		} );
 
-		it( 'records exactly ONE history entry for an aspect-ratio change followed by a freeform toggle', () => {
-			const { result } = setupHook();
-			const original = result.current.state.cropRect;
-			const originalPreset = result.current.cropOptions.aspectRatioValue;
-			const originalFreeform = result.current.cropOptions.freeformCrop;
-
-			act( () => result.current.setAspectRatioValue( '1' ) ); // Square
-			act( () => result.current.setFreeformCrop( false ) );
-
-			// Two discrete actions → two undo entries.
-			act( () => result.current.undo() );
-			expect( result.current.cropOptions.freeformCrop ).toBe(
-				originalFreeform
-			);
-			expect( result.current.cropOptions.aspectRatioValue ).toBe( '1' );
-
-			act( () => result.current.undo() );
-			expect( result.current.cropOptions.aspectRatioValue ).toBe(
-				originalPreset
-			);
-			expect( result.current.state.cropRect ).toEqual( original );
-		} );
-
 		it( 'groups cropper reset and cropOptions reset in one undo step', () => {
 			const { result } = setupHook();
 
 			act( () => result.current.setAspectRatioValue( '1' ) );
-			act( () => result.current.setFreeformCrop( false ) );
 			act( () => result.current.setRotation( 45 ) );
 
 			act( () => {
@@ -335,7 +265,6 @@ describe( 'useMediaEditorState', () => {
 			expect( result.current.state.rotation ).toBe( 0 );
 			expect( result.current.cropOptions ).toEqual( {
 				aspectRatioValue: '0',
-				freeformCrop: true,
 			} );
 
 			act( () => result.current.undo() );
@@ -343,7 +272,6 @@ describe( 'useMediaEditorState', () => {
 			expect( result.current.state.rotation ).toBe( 45 );
 			expect( result.current.cropOptions ).toEqual( {
 				aspectRatioValue: '1',
-				freeformCrop: false,
 			} );
 		} );
 	} );

--- a/packages/media-editor/src/state/types.ts
+++ b/packages/media-editor/src/state/types.ts
@@ -9,9 +9,8 @@ import type {
 } from '../image-editor';
 
 /**
- * Sidebar control state for the cropper — preset selection and
- * resize-handle visibility. Lives in the composite store so it
- * participates in the same undo history as cropper geometry.
+ * Sidebar control state for the cropper. Lives in the composite store
+ * so it participates in the same undo history as cropper geometry.
  */
 export interface CropOptionsSlice {
 	/**
@@ -20,8 +19,6 @@ export interface CropOptionsSlice {
 	 * decimal = fixed ratio.
 	 */
 	aspectRatioValue: string;
-	/** Whether the cropper exposes resize handles. */
-	freeformCrop: boolean;
 }
 
 /**
@@ -30,7 +27,6 @@ export interface CropOptionsSlice {
  */
 export const DEFAULT_CROP_OPTIONS: CropOptionsSlice = {
 	aspectRatioValue: '0',
-	freeformCrop: true,
 };
 
 /**
@@ -86,9 +82,7 @@ export type MediaEditorAction =
 				visualSize: Size;
 			};
 	  }
-	/** Toggle the resize-handle (freeform) mode. */
-	| { type: 'SET_FREEFORM_CROP'; payload: boolean }
-	/** Reset both cropOptions fields to defaults. */
+	/** Reset cropOptions to defaults. */
 	| { type: 'RESET_CROP_OPTIONS' }
 	/**
 	 * Replace the entire composite state with `payload`. Used by

--- a/packages/media-editor/src/state/use-media-editor-state.ts
+++ b/packages/media-editor/src/state/use-media-editor-state.ts
@@ -95,17 +95,14 @@ function areCropperImagesEqual(
  * setters, undo/redo, gesture boundaries, and viewport reporting.
  */
 export interface MediaEditorController extends CropperController {
-	/** The cropOptions slice (preset key + freeform toggle). */
+	/** The cropOptions slice. */
 	cropOptions: CropOptionsSlice;
 	/** Set the aspect-ratio preset. Atomic with the cropRect reshape. */
 	setAspectRatioValue: ( presetKey: string ) => void;
-	/** Toggle the resize-handle (freeform) mode. */
-	setFreeformCrop: ( value: boolean ) => void;
-	/** Reset cropOptions to defaults (Free + freeform on). */
+	/** Reset cropOptions to defaults. */
 	resetCropOptions: () => void;
 	/**
 	 * Whether the cropper geometry differs from the initial baseline.
-	 * This excludes UI-only cropOptions such as the resize-handle toggle.
 	 */
 	isCropperDirty: boolean;
 	/** Whether there's an undoable change in history. */
@@ -224,8 +221,7 @@ export function useMediaEditorState(
 
 	// Core dispatch wrapper. Synchronously computes the post-state via
 	// the pure reducer so we can skip history pushes for no-op actions
-	// (e.g., setting a freeform toggle to its current value) and keep
-	// `stateRef` in lockstep with React's pending state.
+	// and keep `stateRef` in lockstep with React's pending state.
 	const dispatchWithHistory = useCallback(
 		( action: MediaEditorAction, recordHistory = true ) => {
 			const preState = stateRef.current;
@@ -346,16 +342,6 @@ export function useMediaEditorState(
 		[ dispatchWithHistory ]
 	);
 
-	const setFreeformCrop = useCallback(
-		( value: boolean ) => {
-			dispatchWithHistory( {
-				type: 'SET_FREEFORM_CROP',
-				payload: value,
-			} );
-		},
-		[ dispatchWithHistory ]
-	);
-
 	const resetCropOptions = useCallback( () => {
 		dispatchWithHistory( { type: 'RESET_CROP_OPTIONS' } );
 	}, [ dispatchWithHistory ] );
@@ -450,7 +436,6 @@ export function useMediaEditorState(
 			// Composite extensions
 			cropOptions: state.cropOptions,
 			setAspectRatioValue,
-			setFreeformCrop,
 			resetCropOptions,
 			isCropperDirty,
 			hasUndo,
@@ -471,7 +456,6 @@ export function useMediaEditorState(
 			getCroppedImage,
 			state.cropOptions,
 			setAspectRatioValue,
-			setFreeformCrop,
 			resetCropOptions,
 			isCropperDirty,
 			hasUndo,


### PR DESCRIPTION
## What?

Removes the user-facing “Show resize handles” toggle from the media editor crop panel. 

The media modal now always enables crop resize handles, while the lower-level cropper `freeformCrop` prop remains available for internal/custom cropper use.

## Why?

The toggle exposed an implementation detail rather than a clear user goal. Props to @jasmussen for pointing it out. 

Disabling it made the crop UI harder to understand, especially for free-form crops where it removed the main affordance for resizing the crop area.



## Testing Instructions

1. Open the editor and insert or select an image through the media modal.
2. Open the image editor/crop UI.
3. Confirm the Crop panel shows `Aspect ratio` and `Zoom`, and no longer shows `Show resize handles`.
4. Confirm resize handles are visible on the crop box by default.
5. Change the aspect ratio to `Free` and confirm the crop box can be resized freely.
6. Change the aspect ratio to a fixed option, such as `Square`, and confirm dragging a handle resizes the crop box while preserving that ratio.
7. Use the zoom slider and confirm the image zooms as expected.
8. Click Reset and confirm the crop options return to their default state with resize handles still visible.


## Screenshots

### Before

<img width="277" height="292" alt="Screenshot 2026-05-28 at 1 33 58 pm" src="https://github.com/user-attachments/assets/cc178a62-001a-4076-b173-57b25f25d93f" />

### After

<img width="291" height="397" alt="Screenshot 2026-05-28 at 1 46 58 pm" src="https://github.com/user-attachments/assets/cd8b9f2c-b124-4449-83b1-4362ec0ec34d" />


