### PR TITLE
Hide Cover overlay controls for viewport states

### DIFF
--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -200,6 +200,9 @@ export default function CoverInspectorControls( {
 
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 
+	const showOverlayControls =
+		colorGradientSettings.hasColorsOrGradients && ! hasSelectedStyleState;
+
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	return (
@@ -343,7 +346,7 @@ export default function CoverInspectorControls( {
 					</ToolsPanel>
 				</InspectorControls>
 			) }
-			{ colorGradientSettings.hasColorsOrGradients && (
+			{ showOverlayControls && (
 				<InspectorControls group="color">
 					<ColorGradientSettingsDropdown
 						__experimentalIsRenderedInSidebar

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -64,6 +64,19 @@ async function openStylesTabIfAvailable() {
 	}
 }
 
+async function selectViewportState( name ) {
+	await userEvent.click(
+		screen.getByRole( 'button', {
+			name: 'State: Default',
+		} )
+	);
+	await userEvent.click(
+		screen.getByRole( 'menuitem', {
+			name,
+		} )
+	);
+}
+
 describe( 'Cover block', () => {
 	describe( 'Editor canvas', () => {
 		test( 'shows placeholder if background image and color not set', async () => {
@@ -368,6 +381,31 @@ describe( 'Cover block', () => {
 
 					expect( opacityControl ).not.toBeInTheDocument();
 				} );
+			} );
+
+			test( 'does not render overlay controls when a viewport state is selected', async () => {
+				await setup();
+				await createAndSelectBlock();
+				await openStylesTabIfAvailable();
+
+				expect(
+					screen.getByRole( 'button', {
+						name: 'Overlay',
+					} )
+				).toBeInTheDocument();
+
+				await selectViewportState( 'Tablet' );
+
+				expect(
+					screen.queryByRole( 'button', {
+						name: 'Overlay',
+					} )
+				).not.toBeInTheDocument();
+				expect(
+					screen.queryByRole( 'slider', {
+						name: 'Overlay opacity',
+					} )
+				).not.toBeInTheDocument();
 			} );
 		} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->


Part of #77817. Until cover overlay controls are made to work with viewport states, it's better to hide them when a state is enabled.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Cover block to a post and set its overlay color and opacity.
2. Set a viewport state and check the overlay controls no longer show.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


<img width="277" height="519" alt="Screenshot 2026-05-28 at 4 17 44 pm" src="https://github.com/user-attachments/assets/6362c1b5-c56d-429d-860d-c2b641e1b6e6" />
