### PR TITLE
feat: Migrate the browserlintrc file to `packages/postcss-plugins-preset`

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,1 +1,0 @@
-extends @wordpress/browserslist-config

--- a/package-lock.json
+++ b/package-lock.json
@@ -62333,6 +62333,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
+				"@wordpress/browserslist-config": "file:../browserslist-config",
 				"autoprefixer": "^10.4.20",
 				"postcss-import": "^16.1.1"
 			},

--- a/packages/postcss-plugins-preset/lib/index.js
+++ b/packages/postcss-plugins-preset/lib/index.js
@@ -1,4 +1,7 @@
 module.exports = [
 	require( 'postcss-import' )(),
-	require( 'autoprefixer' )( { grid: true } ),
+	require( 'autoprefixer' )( {
+		grid: true,
+		overrideBrowserslist: require( '@wordpress/browserslist-config' ),
+	} ),
 ];

--- a/packages/postcss-plugins-preset/package.json
+++ b/packages/postcss-plugins-preset/package.json
@@ -35,6 +35,7 @@
 	},
 	"dependencies": {
 		"@wordpress/base-styles": "file:../base-styles",
+		"@wordpress/browserslist-config": "file:../browserslist-config",
 		"autoprefixer": "^10.4.20",
 		"postcss-import": "^16.1.1"
 	},


### PR DESCRIPTION
## What? Why? How?
Related to #75041


> Phase 7: Cleanup & Finalization
> 7.1 Root Package.json Cleanup
> Tasks
> 
> Remove .browserslistrc from root - https://github.com/WordPress/gutenberg/pull/78764
> Delete .browserslistrc
> Add @wordpress/browserslist-config to packages/postcss-plugins-preset/package.json
> Add overrideBrowserslist: require( '@wordpress/browserslist-config' ) to require( 'autoprefixer' )() call after grid: true
> 
> 
