### PR TITLE
Block Editor: Refactor Inserter to a function component

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -9,8 +9,7 @@ import clsx from 'clsx';
 import { speak } from '@wordpress/a11y';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { Dropdown, Button } from '@wordpress/components';
-import { withDispatch, withSelect } from '@wordpress/data';
-import { compose, ifCondition } from '@wordpress/compose';
+import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
 import { plus } from '@wordpress/icons';
 
@@ -80,27 +79,197 @@ function InserterToggle( {
 }
 
 function Inserter( {
+	clientId,
+	rootClientId,
+	disabled,
+	isAppender,
 	position,
-	hasSingleBlockType,
-	blockToInsert,
-	insertOnlyAllowedBlock,
+	selectBlockOnInsert,
+	shouldDirectInsert = true,
+	showInserterHelpPanel,
 	// This prop is experimental to give some time for the quick inserter to mature
 	// Feel free to make them stable after a few releases.
 	__experimentalIsQuick: isQuick,
 	onSelectOrClose,
 	onToggle,
-	disabled,
-	blockTitle,
-	appenderLabel,
-	toggleProps,
-	hasItems,
 	renderToggle: renderToggleProp,
-	rootClientId,
-	clientId,
-	isAppender,
-	showInserterHelpPanel,
-	selectBlockOnInsert,
+	toggleProps,
 } ) {
+	const {
+		hasItems,
+		hasSingleBlockType,
+		blockTitle,
+		allowedBlockType,
+		blockToInsert,
+		appenderLabel,
+		targetRootClientId,
+	} = useSelect(
+		( select ) => {
+			const {
+				getBlockRootClientId,
+				hasInserterItems,
+				getAllowedBlocks,
+				getDirectInsertBlock,
+				getBlockListSettings,
+			} = select( blockEditorStore );
+			const { getBlockVariations, getBlockType } = select( blocksStore );
+
+			const _targetRootClientId =
+				rootClientId || getBlockRootClientId( clientId ) || undefined;
+
+			const allowedBlocks = getAllowedBlocks( _targetRootClientId );
+			const directInsertBlock =
+				shouldDirectInsert &&
+				getDirectInsertBlock( _targetRootClientId );
+			const { defaultBlock } =
+				getBlockListSettings( _targetRootClientId ) ?? {};
+
+			const _hasSingleBlockType =
+				allowedBlocks?.length === 1 &&
+				getBlockVariations( allowedBlocks[ 0 ].name, 'inserter' )
+					?.length === 0;
+			const _allowedBlockType = _hasSingleBlockType
+				? allowedBlocks[ 0 ]
+				: null;
+
+			// Single-block-type parents get adjacent-attribute copying
+			// without needing to set `directInsert: true`.
+			let _blockToInsert = directInsertBlock || null;
+			if (
+				! _blockToInsert &&
+				_hasSingleBlockType &&
+				defaultBlock?.name === _allowedBlockType.name
+			) {
+				_blockToInsert = defaultBlock;
+			}
+
+			const defaultBlockType = directInsertBlock
+				? getBlockType( directInsertBlock.name )
+				: null;
+
+			return {
+				hasItems: hasInserterItems( _targetRootClientId ),
+				hasSingleBlockType: _hasSingleBlockType,
+				blockTitle: _allowedBlockType ? _allowedBlockType.title : '',
+				allowedBlockType: _allowedBlockType,
+				blockToInsert: _blockToInsert,
+				appenderLabel: getAppenderLabel(
+					directInsertBlock,
+					defaultBlockType
+				),
+				targetRootClientId: _targetRootClientId,
+			};
+		},
+		[ rootClientId, clientId, shouldDirectInsert ]
+	);
+
+	const registry = useRegistry();
+	const { insertBlock } = useDispatch( blockEditorStore );
+
+	// The global inserter (no isAppender, no rootClientId, no clientId) should
+	// always render, even with no items.
+	if ( ! hasItems && ( isAppender || targetRootClientId || clientId ) ) {
+		return null;
+	}
+
+	function insertOnlyAllowedBlock() {
+		const blockName = blockToInsert?.name ?? allowedBlockType.name;
+
+		function getAdjacentBlockAttributes( attributesToCopy ) {
+			if ( ! attributesToCopy?.length ) {
+				return {};
+			}
+
+			const { getBlock, getPreviousBlockClientId } =
+				registry.select( blockEditorStore );
+
+			// Find the adjacent block of the same type whose attributes
+			// should be copied: previous sibling when inserting next to
+			// an existing block, otherwise the last child of the root.
+			let adjacentAttributes;
+			if ( clientId ) {
+				const currentBlock = getBlock( clientId );
+				const previousBlock = getBlock(
+					getPreviousBlockClientId( clientId )
+				);
+				if ( currentBlock?.name === previousBlock?.name ) {
+					adjacentAttributes = previousBlock?.attributes;
+				}
+			} else if ( targetRootClientId ) {
+				const lastInnerBlock =
+					getBlock( targetRootClientId )?.innerBlocks?.at( -1 );
+				if ( lastInnerBlock?.name === blockName ) {
+					adjacentAttributes = lastInnerBlock.attributes;
+				}
+			}
+
+			if ( ! adjacentAttributes ) {
+				return {};
+			}
+
+			return Object.fromEntries(
+				attributesToCopy
+					.filter( ( attr ) => attr in adjacentAttributes )
+					.map( ( attr ) => [ attr, adjacentAttributes[ attr ] ] )
+			);
+		}
+
+		function getInsertionIndex() {
+			const {
+				getBlockIndex,
+				getBlockSelectionEnd,
+				getBlockOrder,
+				getBlockRootClientId,
+			} = registry.select( blockEditorStore );
+
+			// If the clientId is defined, we insert at the position of the block.
+			if ( clientId ) {
+				return getBlockIndex( clientId );
+			}
+
+			// If there a selected block, we insert after the selected block.
+			const end = getBlockSelectionEnd();
+			if (
+				! isAppender &&
+				end &&
+				getBlockRootClientId( end ) === targetRootClientId
+			) {
+				return getBlockIndex( end ) + 1;
+			}
+
+			// Otherwise, we insert at the end of the current rootClientId.
+			return getBlockOrder( targetRootClientId ).length;
+		}
+
+		// Attempt to augment the inserted block with attributes from an adjacent block.
+		// This ensures styling from nearby blocks is preserved in the newly inserted block.
+		// See: https://github.com/WordPress/gutenberg/issues/37904
+		const newAttributes = getAdjacentBlockAttributes(
+			blockToInsert?.attributesToCopy
+		);
+
+		const newBlock = createBlock( blockName, {
+			...blockToInsert?.attributes,
+			...newAttributes,
+		} );
+
+		insertBlock(
+			newBlock,
+			getInsertionIndex(),
+			targetRootClientId,
+			selectBlockOnInsert
+		);
+
+		onSelectOrClose?.( newBlock );
+
+		const message = sprintf(
+			// translators: %s: the name of the block that has been added
+			__( '%s block added' ),
+			allowedBlockType.title
+		);
+		speak( message );
+	}
+
 	function renderToggle( { onToggle: dropdownOnToggle, isOpen } ) {
 		const toggleArgs = {
 			onToggle: dropdownOnToggle,
@@ -136,7 +305,7 @@ function Inserter( {
 						}
 						onClose();
 					} }
-					rootClientId={ rootClientId }
+					rootClientId={ targetRootClientId }
 					clientId={ clientId }
 					isAppender={ isAppender }
 					selectBlockOnInsert={ selectBlockOnInsert }
@@ -150,7 +319,7 @@ function Inserter( {
 					onClose();
 				} }
 				onClose={ onClose }
-				rootClientId={ rootClientId }
+				rootClientId={ targetRootClientId }
 				clientId={ clientId }
 				isAppender={ isAppender }
 				showInserterHelpPanel={ showInserterHelpPanel }
@@ -179,191 +348,4 @@ function Inserter( {
 	);
 }
 
-export default compose( [
-	withSelect(
-		( select, { clientId, rootClientId, shouldDirectInsert = true } ) => {
-			const {
-				getBlockRootClientId,
-				hasInserterItems,
-				getAllowedBlocks,
-				getDirectInsertBlock,
-				getBlockListSettings,
-			} = select( blockEditorStore );
-			const { getBlockVariations, getBlockType } = select( blocksStore );
-
-			rootClientId =
-				rootClientId || getBlockRootClientId( clientId ) || undefined;
-
-			const allowedBlocks = getAllowedBlocks( rootClientId );
-			const directInsertBlock =
-				shouldDirectInsert && getDirectInsertBlock( rootClientId );
-			const { defaultBlock } = getBlockListSettings( rootClientId ) ?? {};
-
-			const hasSingleBlockType =
-				allowedBlocks?.length === 1 &&
-				getBlockVariations( allowedBlocks[ 0 ].name, 'inserter' )
-					?.length === 0;
-			const allowedBlockType = hasSingleBlockType
-				? allowedBlocks[ 0 ]
-				: null;
-
-			// Single-block-type parents get adjacent-attribute copying
-			// without needing to set `directInsert: true`.
-			let blockToInsert = directInsertBlock || null;
-			if (
-				! blockToInsert &&
-				hasSingleBlockType &&
-				defaultBlock?.name === allowedBlockType.name
-			) {
-				blockToInsert = defaultBlock;
-			}
-
-			const defaultBlockType = directInsertBlock
-				? getBlockType( directInsertBlock.name )
-				: null;
-			const appenderLabel = getAppenderLabel(
-				directInsertBlock,
-				defaultBlockType
-			);
-
-			return {
-				hasItems: hasInserterItems( rootClientId ),
-				hasSingleBlockType,
-				blockTitle: allowedBlockType ? allowedBlockType.title : '',
-				allowedBlockType,
-				blockToInsert,
-				appenderLabel,
-				rootClientId,
-			};
-		}
-	),
-	withDispatch( ( dispatch, ownProps, { select } ) => {
-		return {
-			insertOnlyAllowedBlock() {
-				const {
-					rootClientId,
-					clientId,
-					isAppender,
-					hasSingleBlockType,
-					allowedBlockType,
-					blockToInsert,
-					onSelectOrClose,
-					selectBlockOnInsert,
-				} = ownProps;
-
-				if ( ! hasSingleBlockType && ! blockToInsert ) {
-					return;
-				}
-
-				const blockName = blockToInsert?.name ?? allowedBlockType.name;
-
-				function getAdjacentBlockAttributes( attributesToCopy ) {
-					if ( ! attributesToCopy?.length ) {
-						return {};
-					}
-
-					const { getBlock, getPreviousBlockClientId } =
-						select( blockEditorStore );
-
-					// Find the adjacent block of the same type whose attributes
-					// should be copied: previous sibling when inserting next to
-					// an existing block, otherwise the last child of the root.
-					let adjacentAttributes;
-					if ( clientId ) {
-						const currentBlock = getBlock( clientId );
-						const previousBlock = getBlock(
-							getPreviousBlockClientId( clientId )
-						);
-						if ( currentBlock?.name === previousBlock?.name ) {
-							adjacentAttributes = previousBlock?.attributes;
-						}
-					} else if ( rootClientId ) {
-						const lastInnerBlock =
-							getBlock( rootClientId )?.innerBlocks?.at( -1 );
-						if ( lastInnerBlock?.name === blockName ) {
-							adjacentAttributes = lastInnerBlock.attributes;
-						}
-					}
-
-					if ( ! adjacentAttributes ) {
-						return {};
-					}
-
-					return Object.fromEntries(
-						attributesToCopy
-							.filter( ( attr ) => attr in adjacentAttributes )
-							.map( ( attr ) => [
-								attr,
-								adjacentAttributes[ attr ],
-							] )
-					);
-				}
-
-				function getInsertionIndex() {
-					const {
-						getBlockIndex,
-						getBlockSelectionEnd,
-						getBlockOrder,
-						getBlockRootClientId,
-					} = select( blockEditorStore );
-
-					// If the clientId is defined, we insert at the position of the block.
-					if ( clientId ) {
-						return getBlockIndex( clientId );
-					}
-
-					// If there a selected block, we insert after the selected block.
-					const end = getBlockSelectionEnd();
-					if (
-						! isAppender &&
-						end &&
-						getBlockRootClientId( end ) === rootClientId
-					) {
-						return getBlockIndex( end ) + 1;
-					}
-
-					// Otherwise, we insert at the end of the current rootClientId.
-					return getBlockOrder( rootClientId ).length;
-				}
-
-				const { insertBlock } = dispatch( blockEditorStore );
-
-				// Attempt to augment the inserted block with attributes from an adjacent block.
-				// This ensures styling from nearby blocks is preserved in the newly inserted block.
-				// See: https://github.com/WordPress/gutenberg/issues/37904
-				const newAttributes = getAdjacentBlockAttributes(
-					blockToInsert?.attributesToCopy
-				);
-
-				const newBlock = createBlock( blockName, {
-					...( blockToInsert?.attributes || {} ),
-					...newAttributes,
-				} );
-
-				insertBlock(
-					newBlock,
-					getInsertionIndex(),
-					rootClientId,
-					selectBlockOnInsert
-				);
-
-				if ( onSelectOrClose ) {
-					onSelectOrClose( newBlock );
-				}
-
-				const message = sprintf(
-					// translators: %s: the name of the block that has been added
-					__( '%s block added' ),
-					allowedBlockType.title
-				);
-				speak( message );
-			},
-		};
-	} ),
-	// The global inserter should always be visible, we are using ( ! isAppender && ! rootClientId && ! clientId ) as
-	// a way to detect the global Inserter.
-	ifCondition(
-		( { hasItems, isAppender, rootClientId, clientId } ) =>
-			hasItems || ( ! isAppender && ! rootClientId && ! clientId )
-	),
-] )( Inserter );
+export default Inserter;

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -29,6 +29,7 @@ function InserterToggle( {
 	hasSingleBlockType,
 	appenderLabel,
 	toggleProps = {},
+	ref,
 } ) {
 	const {
 		as: Wrapper = Button,
@@ -63,6 +64,7 @@ function InserterToggle( {
 
 	return (
 		<Wrapper
+			ref={ ref }
 			__next40pxDefaultSize={ toggleProps.as ? undefined : true }
 			icon={ plus }
 			label={ label }
@@ -94,6 +96,7 @@ function Inserter( {
 	onToggle,
 	renderToggle: renderToggleProp,
 	toggleProps,
+	ref,
 } ) {
 	const {
 		hasItems,
@@ -285,7 +288,7 @@ function Inserter( {
 			return renderToggleProp( toggleArgs );
 		}
 
-		return <InserterToggle { ...toggleArgs } />;
+		return <InserterToggle ref={ ref } { ...toggleArgs } />;
 	}
 
 	function renderContent( { onClose } ) {

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -9,7 +9,6 @@ import clsx from 'clsx';
 import { speak } from '@wordpress/a11y';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { Dropdown, Button } from '@wordpress/components';
-import { Component } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose, ifCondition } from '@wordpress/compose';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
@@ -23,7 +22,7 @@ import QuickInserter from './quick-inserter';
 import { store as blockEditorStore } from '../../store';
 import { getAppenderLabel } from './get-appender-label';
 
-const defaultRenderToggle = ( {
+function InserterToggle( {
 	onToggle,
 	disabled,
 	isOpen,
@@ -31,7 +30,7 @@ const defaultRenderToggle = ( {
 	hasSingleBlockType,
 	appenderLabel,
 	toggleProps = {},
-} ) => {
+} ) {
 	const {
 		as: Wrapper = Button,
 		label: labelProp,
@@ -78,80 +77,49 @@ const defaultRenderToggle = ( {
 			{ ...rest }
 		/>
 	);
-};
+}
 
-class Inserter extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.onToggle = this.onToggle.bind( this );
-		this.renderToggle = this.renderToggle.bind( this );
-		this.renderContent = this.renderContent.bind( this );
-	}
-
-	onToggle( isOpen ) {
-		const { onToggle } = this.props;
-
-		// Surface toggle callback to parent component.
-		if ( onToggle ) {
-			onToggle( isOpen );
-		}
-	}
-
-	/**
-	 * Render callback to display Dropdown toggle element.
-	 *
-	 * @param {Object}   options
-	 * @param {Function} options.onToggle Callback to invoke when toggle is
-	 *                                    pressed.
-	 * @param {boolean}  options.isOpen   Whether dropdown is currently open.
-	 *
-	 * @return {Element} Dropdown toggle element.
-	 */
-	renderToggle( { onToggle, isOpen } ) {
-		const {
-			disabled,
-			blockTitle,
-			hasSingleBlockType,
-			appenderLabel,
-			toggleProps,
-			hasItems,
-			renderToggle = defaultRenderToggle,
-		} = this.props;
-
-		return renderToggle( {
-			onToggle,
+function Inserter( {
+	position,
+	hasSingleBlockType,
+	blockToInsert,
+	insertOnlyAllowedBlock,
+	// This prop is experimental to give some time for the quick inserter to mature
+	// Feel free to make them stable after a few releases.
+	__experimentalIsQuick: isQuick,
+	onSelectOrClose,
+	onToggle,
+	disabled,
+	blockTitle,
+	appenderLabel,
+	toggleProps,
+	hasItems,
+	renderToggle: renderToggleProp,
+	rootClientId,
+	clientId,
+	isAppender,
+	showInserterHelpPanel,
+	selectBlockOnInsert,
+} ) {
+	function renderToggle( { onToggle: dropdownOnToggle, isOpen } ) {
+		const toggleArgs = {
+			onToggle: dropdownOnToggle,
 			isOpen,
 			disabled: disabled || ! hasItems,
 			blockTitle,
 			hasSingleBlockType,
 			appenderLabel,
 			toggleProps,
-		} );
+		};
+
+		if ( renderToggleProp ) {
+			return renderToggleProp( toggleArgs );
+		}
+
+		return <InserterToggle { ...toggleArgs } />;
 	}
 
-	/**
-	 * Render callback to display Dropdown content element.
-	 *
-	 * @param {Object}   options
-	 * @param {Function} options.onClose Callback to invoke when dropdown is
-	 *                                   closed.
-	 *
-	 * @return {Element} Dropdown content element.
-	 */
-	renderContent( { onClose } ) {
-		const {
-			rootClientId,
-			clientId,
-			isAppender,
-			showInserterHelpPanel,
-			// This prop is experimental to give some time for the quick inserter to mature
-			// Feel free to make them stable after a few releases.
-			__experimentalIsQuick: isQuick,
-			onSelectOrClose,
-			selectBlockOnInsert,
-		} = this.props;
-
+	function renderContent( { onClose } ) {
 		if ( isQuick ) {
 			return (
 				<QuickInserter
@@ -190,36 +158,25 @@ class Inserter extends Component {
 		);
 	}
 
-	render() {
-		const {
-			position,
-			hasSingleBlockType,
-			blockToInsert,
-			insertOnlyAllowedBlock,
-			__experimentalIsQuick: isQuick,
-			onSelectOrClose,
-		} = this.props;
-
-		if ( hasSingleBlockType || blockToInsert ) {
-			return this.renderToggle( { onToggle: insertOnlyAllowedBlock } );
-		}
-
-		return (
-			<Dropdown
-				className="block-editor-inserter"
-				contentClassName={ clsx( 'block-editor-inserter__popover', {
-					'is-quick': isQuick,
-				} ) }
-				popoverProps={ { position, shift: true } }
-				onToggle={ this.onToggle }
-				expandOnMobile
-				headerTitle={ __( 'Add a block' ) }
-				renderToggle={ this.renderToggle }
-				renderContent={ this.renderContent }
-				onClose={ onSelectOrClose }
-			/>
-		);
+	if ( hasSingleBlockType || blockToInsert ) {
+		return renderToggle( { onToggle: insertOnlyAllowedBlock } );
 	}
+
+	return (
+		<Dropdown
+			className="block-editor-inserter"
+			contentClassName={ clsx( 'block-editor-inserter__popover', {
+				'is-quick': isQuick,
+			} ) }
+			popoverProps={ { position, shift: true } }
+			onToggle={ onToggle }
+			expandOnMobile
+			headerTitle={ __( 'Add a block' ) }
+			renderToggle={ renderToggle }
+			renderContent={ renderContent }
+			onClose={ onSelectOrClose }
+		/>
+	);
 }
 
 export default compose( [


### PR DESCRIPTION
## What?
Modernizes the `Inserter` component in `@wordpress/block-editor` with no public API or behavior changes.

* The `defaultRenderToggle` factory function is promoted to a real `InserterToggle` component. The `renderToggle` prop is preserved; when absent, `<InserterToggle>` renders directly.
* I've also done minor cleanup and unreachable guard removals as part of refactoring.

## Testing Instructions
1. Smoke test Inserter in posts and site editor. It should work as before.
2. Component should also have good e2e test coverage from various specs.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
