### PR TITLE
Block Style States: Add @current custom state for Nav Link

### DIFF
--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -237,33 +237,6 @@ function gutenberg_get_block_state_style_rules( $state_styles, $block_type, $rul
 }
 
 /**
- * Returns the CSS selector suffix for a custom (class-based) state, by
- * extracting the trailing class/pseudo segment from the block type's
- * `selectors.states[ $state ]` entry.
- *
- * Example: for `@current` on `core/navigation-link` where
- * `selectors.states['@current'] = ".wp-block-navigation .current-menu-item"`,
- * this returns `.current-menu-item`. The leading scoping portion is dropped
- * because state styles are already scoped by the per-instance `.wp-states-X`
- * class.
- *
- * @param WP_Block_Type $block_type The registered block type.
- * @param string        $state      The custom state key, e.g. `'@current'`.
- * @return string|null The CSS suffix (e.g. `.current-menu-item`), or null if
- *                     no selector is declared for this state.
- */
-function gutenberg_get_custom_state_suffix( $block_type, $state ) {
-	$state_selector = $block_type->selectors['states'][ $state ] ?? null;
-	if ( ! is_string( $state_selector ) || '' === trim( $state_selector ) ) {
-		return null;
-	}
-	if ( preg_match( '/(\.[a-zA-Z0-9_-]+(?:\:[a-zA-Z0-9_-]+)?)\s*$/', $state_selector, $matches ) ) {
-		return $matches[1];
-	}
-	return null;
-}
-
-/**
  * Generates rule descriptors for a custom state's styles, including any nested
  * pseudo-state compound (e.g. `@current` + `:hover`).
  *
@@ -434,10 +407,17 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 
 	$supported_pseudo_states = WP_Theme_JSON_Gutenberg::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] ?? array();
 	$supported_custom_states = WP_Theme_JSON_Gutenberg::VALID_BLOCK_CUSTOM_STATES[ $block_name ] ?? array();
-	$custom_state_suffixes   = array();
+	/*
+	 * `selectors.states[<state>]` declares a CSS suffix that is appended to the
+	 * per-instance scope class to produce the state selector. For example,
+	 * '@current' on the navigation-link block declares '.current-menu-item',
+	 * so the final selector is `.wp-states-XXXX.current-menu-item`. The block
+	 * must declare a non-empty string for the state to be honored.
+	 */
+	$custom_state_suffixes = array();
 	foreach ( $supported_custom_states as $custom_state ) {
-		$suffix = gutenberg_get_custom_state_suffix( $block_type, $custom_state );
-		if ( $suffix ) {
+		$suffix = $block_type->selectors['states'][ $custom_state ] ?? null;
+		if ( is_string( $suffix ) && '' !== trim( $suffix ) ) {
 			$custom_state_suffixes[ $custom_state ] = $suffix;
 		}
 	}

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -237,6 +237,84 @@ function gutenberg_get_block_state_style_rules( $state_styles, $block_type, $rul
 }
 
 /**
+ * Returns the CSS selector suffix for a custom (class-based) state, by
+ * extracting the trailing class/pseudo segment from the block type's
+ * `selectors.states[ $state ]` entry.
+ *
+ * Example: for `@current` on `core/navigation-link` where
+ * `selectors.states['@current'] = ".wp-block-navigation .current-menu-item"`,
+ * this returns `.current-menu-item`. The leading scoping portion is dropped
+ * because state styles are already scoped by the per-instance `.wp-states-X`
+ * class.
+ *
+ * @param WP_Block_Type $block_type The registered block type.
+ * @param string        $state      The custom state key, e.g. `'@current'`.
+ * @return string|null The CSS suffix (e.g. `.current-menu-item`), or null if
+ *                     no selector is declared for this state.
+ */
+function gutenberg_get_custom_state_suffix( $block_type, $state ) {
+	$state_selector = $block_type->selectors['states'][ $state ] ?? null;
+	if ( ! is_string( $state_selector ) || '' === trim( $state_selector ) ) {
+		return null;
+	}
+	if ( preg_match( '/(\.[a-zA-Z0-9_-]+(?:\:[a-zA-Z0-9_-]+)?)\s*$/', $state_selector, $matches ) ) {
+		return $matches[1];
+	}
+	return null;
+}
+
+/**
+ * Generates rule descriptors for a custom state's styles, including any nested
+ * pseudo-state compound (e.g. `@current` + `:hover`).
+ *
+ * @param string        $custom_suffix           CSS suffix for the custom state, e.g. `.current-menu-item`.
+ * @param array         $custom_state_data       The style object stored at `style[ $custom_state ]`.
+ * @param array         $supported_pseudo_states Pseudo-states the block supports.
+ * @param WP_Block_Type $block_type              The registered block type.
+ * @param string|null   $rules_group             Optional CSS grouping rule, e.g. a media query.
+ * @return array[] Rule descriptors.
+ */
+function gutenberg_get_custom_state_css_rules( $custom_suffix, $custom_state_data, $supported_pseudo_states, $block_type, $rules_group = null ) {
+	$rules = array();
+	if ( ! is_array( $custom_state_data ) ) {
+		return $rules;
+	}
+
+	$root_style = gutenberg_get_root_state_style(
+		$custom_state_data,
+		array_merge( array( 'elements' ), $supported_pseudo_states )
+	);
+
+	if ( ! empty( $root_style ) ) {
+		$rules = array_merge(
+			$rules,
+			gutenberg_get_block_state_style_rules(
+				array( $custom_suffix => $root_style ),
+				$block_type,
+				$rules_group
+			)
+		);
+	}
+
+	foreach ( $supported_pseudo_states as $pseudo_state ) {
+		if ( empty( $custom_state_data[ $pseudo_state ] ) || ! is_array( $custom_state_data[ $pseudo_state ] ) ) {
+			continue;
+		}
+
+		$rules = array_merge(
+			$rules,
+			gutenberg_get_block_state_style_rules(
+				array( $custom_suffix . $pseudo_state => $custom_state_data[ $pseudo_state ] ),
+				$block_type,
+				$rules_group
+			)
+		);
+	}
+
+	return $rules;
+}
+
+/**
  * Returns a unique class for a set of state style rules.
  *
  * @param string $block_name Block name.
@@ -355,8 +433,17 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 	}
 
 	$supported_pseudo_states = WP_Theme_JSON_Gutenberg::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] ?? array();
-	$style                   = $block['attrs']['style'] ?? array();
-	$css_rules               = array();
+	$supported_custom_states = WP_Theme_JSON_Gutenberg::VALID_BLOCK_CUSTOM_STATES[ $block_name ] ?? array();
+	$custom_state_suffixes   = array();
+	foreach ( $supported_custom_states as $custom_state ) {
+		$suffix = gutenberg_get_custom_state_suffix( $block_type, $custom_state );
+		if ( $suffix ) {
+			$custom_state_suffixes[ $custom_state ] = $suffix;
+		}
+	}
+
+	$style     = $block['attrs']['style'] ?? array();
+	$css_rules = array();
 
 	foreach ( $supported_pseudo_states as $pseudo_state ) {
 		if ( empty( $style[ $pseudo_state ] ) || ! is_array( $style[ $pseudo_state ] ) ) {
@@ -372,6 +459,22 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		);
 	}
 
+	foreach ( $custom_state_suffixes as $custom_state => $custom_suffix ) {
+		if ( empty( $style[ $custom_state ] ) || ! is_array( $style[ $custom_state ] ) ) {
+			continue;
+		}
+
+		$css_rules = array_merge(
+			$css_rules,
+			gutenberg_get_custom_state_css_rules(
+				$custom_suffix,
+				$style[ $custom_state ],
+				$supported_pseudo_states,
+				$block_type
+			)
+		);
+	}
+
 	foreach ( WP_Theme_JSON_Gutenberg::RESPONSIVE_BREAKPOINTS as $breakpoint => $media_query ) {
 		if ( empty( $style[ $breakpoint ] ) || ! is_array( $style[ $breakpoint ] ) ) {
 			continue;
@@ -379,7 +482,11 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 
 		$root_state_style = gutenberg_get_root_state_style(
 			$style[ $breakpoint ],
-			array_merge( array( 'elements' ), $supported_pseudo_states )
+			array_merge(
+				array( 'elements' ),
+				$supported_pseudo_states,
+				array_keys( $custom_state_suffixes )
+			)
 		);
 
 		if ( ! empty( $root_state_style ) ) {
@@ -402,6 +509,23 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 				$css_rules,
 				gutenberg_get_block_state_style_rules(
 					array( $pseudo_state => $style[ $breakpoint ][ $pseudo_state ] ),
+					$block_type,
+					$media_query
+				)
+			);
+		}
+
+		foreach ( $custom_state_suffixes as $custom_state => $custom_suffix ) {
+			if ( empty( $style[ $breakpoint ][ $custom_state ] ) || ! is_array( $style[ $breakpoint ][ $custom_state ] ) ) {
+				continue;
+			}
+
+			$css_rules = array_merge(
+				$css_rules,
+				gutenberg_get_custom_state_css_rules(
+					$custom_suffix,
+					$style[ $breakpoint ][ $custom_state ],
+					$supported_pseudo_states,
 					$block_type,
 					$media_query
 				)

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3307,14 +3307,22 @@ class WP_Theme_JSON_Gutenberg {
 					}
 				}
 
-				// Handle custom states (e.g. '@current' for navigation).
+				/*
+				 * Handle custom states (e.g. '@current' for navigation).
+				 * The block.json `selectors.states[<state>]` value is a CSS suffix
+				 * appended to the block's root selector (e.g. ".current-menu-item"
+				 * appended to ".wp-block-navigation-link" yields
+				 * ".wp-block-navigation-link.current-menu-item"). Compound states
+				 * append a pseudo-selector after the suffix.
+				 */
 				if ( isset( static::VALID_BLOCK_CUSTOM_STATES[ $name ] ) ) {
 					foreach ( static::VALID_BLOCK_CUSTOM_STATES[ $name ] as $custom_state ) {
 						if (
 							isset( $theme_json['styles']['blocks'][ $name ][ $custom_state ] ) &&
 							isset( $selectors[ $name ]['states'][ $custom_state ] )
 						) {
-							$custom_css_selector = $selectors[ $name ]['states'][ $custom_state ];
+							$custom_state_suffix = $selectors[ $name ]['states'][ $custom_state ];
+							$custom_css_selector = static::append_to_selector( $selector, $custom_state_suffix );
 							$nodes[]             = array(
 								'name'       => $name,
 								'path'       => array( 'styles', 'blocks', $name, $custom_state ),

--- a/packages/block-editor/src/components/global-styles/state-control-badges.js
+++ b/packages/block-editor/src/components/global-styles/state-control-badges.js
@@ -13,14 +13,19 @@ const { Badge: WCBadge } = unlock( componentsPrivateApis );
 
 export default function StateControlBadges( {
 	viewportStates = [],
+	customStates = [],
 	pseudoStates = [],
 	viewportValue = 'default',
+	customStateValue = 'default',
 	pseudoStateValue = 'default',
 	className = 'block-editor-global-styles-state-control__badges',
 } ) {
 	const activeStates = [];
 	const selectedViewport = viewportStates.find(
 		( state ) => state.value === viewportValue
+	);
+	const selectedCustomState = customStates.find(
+		( state ) => state.value === customStateValue
 	);
 	const selectedPseudoState = pseudoStates.find(
 		( state ) => state.value === pseudoStateValue
@@ -30,6 +35,13 @@ export default function StateControlBadges( {
 		activeStates.push( {
 			key: `viewport-${ selectedViewport.value }`,
 			label: selectedViewport.label,
+		} );
+	}
+
+	if ( selectedCustomState ) {
+		activeStates.push( {
+			key: `custom-${ selectedCustomState.value }`,
+			label: selectedCustomState.label,
 		} );
 	}
 

--- a/packages/block-editor/src/components/global-styles/state-control-badges.js
+++ b/packages/block-editor/src/components/global-styles/state-control-badges.js
@@ -20,37 +20,33 @@ export default function StateControlBadges( {
 	pseudoStateValue = 'default',
 	className = 'block-editor-global-styles-state-control__badges',
 } ) {
-	const activeStates = [];
-	const selectedViewport = viewportStates.find(
-		( state ) => state.value === viewportValue
-	);
-	const selectedCustomState = customStates.find(
-		( state ) => state.value === customStateValue
-	);
-	const selectedPseudoState = pseudoStates.find(
-		( state ) => state.value === pseudoStateValue
-	);
-
-	if ( selectedViewport ) {
-		activeStates.push( {
-			key: `viewport-${ selectedViewport.value }`,
-			label: selectedViewport.label,
-		} );
-	}
-
-	if ( selectedCustomState ) {
-		activeStates.push( {
-			key: `custom-${ selectedCustomState.value }`,
-			label: selectedCustomState.label,
-		} );
-	}
-
-	if ( selectedPseudoState ) {
-		activeStates.push( {
-			key: `pseudo-${ selectedPseudoState.value }`,
-			label: selectedPseudoState.label,
-		} );
-	}
+	const activeStates = [
+		{
+			states: viewportStates,
+			value: viewportValue,
+			keyPrefix: 'viewport',
+		},
+		{
+			states: customStates,
+			value: customStateValue,
+			keyPrefix: 'custom',
+		},
+		{
+			states: pseudoStates,
+			value: pseudoStateValue,
+			keyPrefix: 'pseudo',
+		},
+	].flatMap( ( { states, value, keyPrefix } ) => {
+		const selected = states.find( ( state ) => state.value === value );
+		return selected
+			? [
+					{
+						key: `${ keyPrefix }-${ selected.value }`,
+						label: selected.label,
+					},
+			  ]
+			: [];
+	} );
 
 	return (
 		<Stack

--- a/packages/block-editor/src/components/global-styles/state-control.js
+++ b/packages/block-editor/src/components/global-styles/state-control.js
@@ -1,10 +1,21 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { check, chevronDown, moreVertical } from '@wordpress/icons';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
+
+function buildOptions( states ) {
+	return [
+		{ label: __( 'Default' ), value: 'default' },
+		...states.map( ( state ) => ( {
+			label: state.label,
+			value: state.value,
+		} ) ),
+	];
+}
 
 /**
  * State control for managing viewport, custom (class-based), and pseudo-state styles.
@@ -37,6 +48,19 @@ export default function StateControl( {
 	showText = true,
 	popoverProps = {},
 } ) {
+	const viewportOptions = useMemo(
+		() => buildOptions( viewportStates ),
+		[ viewportStates ]
+	);
+	const customStateOptions = useMemo(
+		() => buildOptions( customStates ),
+		[ customStates ]
+	);
+	const pseudoStateOptions = useMemo(
+		() => buildOptions( pseudoStates ),
+		[ pseudoStates ]
+	);
+
 	if (
 		! viewportStates.length &&
 		! customStates.length &&
@@ -44,28 +68,6 @@ export default function StateControl( {
 	) {
 		return null;
 	}
-
-	const viewportOptions = [
-		{ label: __( 'Default' ), value: 'default' },
-		...viewportStates.map( ( state ) => ( {
-			label: state.label,
-			value: state.value,
-		} ) ),
-	];
-	const customStateOptions = [
-		{ label: __( 'Default' ), value: 'default' },
-		...customStates.map( ( state ) => ( {
-			label: state.label,
-			value: state.value,
-		} ) ),
-	];
-	const pseudoStateOptions = [
-		{ label: __( 'Default' ), value: 'default' },
-		...pseudoStates.map( ( state ) => ( {
-			label: state.label,
-			value: state.value,
-		} ) ),
-	];
 
 	const hasViewportOptions = viewportStates.length > 0;
 	const hasCustomStateOptions = customStates.length > 0;
@@ -179,7 +181,12 @@ export default function StateControl( {
 								</MenuGroup>
 							) }
 							{ hasCustomStateOptions && (
-								<MenuGroup label={ __( 'Item' ) }>
+								<MenuGroup
+									label={ _x(
+										'Item',
+										'block style state group for per-item states'
+									) }
+								>
 									{ customStateOptions.map( ( option ) => (
 										<MenuItem
 											key={ `custom-${ option.value }` }

--- a/packages/block-editor/src/components/global-styles/state-control.js
+++ b/packages/block-editor/src/components/global-styles/state-control.js
@@ -7,15 +7,18 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 
 /**
- * State control for managing viewport and pseudo-state styles.
+ * State control for managing viewport, custom (class-based), and pseudo-state styles.
  * Displays a dropdown menu with separate groups for each selector.
  *
  * @param {Object}   props                     Component props.
  * @param {Array}    props.viewportStates      Array of available viewport states.
+ * @param {Array}    props.customStates        Array of available custom (class-based) states (e.g. `@current`).
  * @param {Array}    props.pseudoStates        Array of available pseudo states.
  * @param {string}   props.viewportValue       Currently selected viewport value.
+ * @param {string}   props.customStateValue    Currently selected custom state value.
  * @param {string}   props.pseudoStateValue    Currently selected pseudo state value.
  * @param {Function} props.onChangeViewport    Callback when viewport selection changes.
+ * @param {Function} props.onChangeCustomState Callback when custom state selection changes.
  * @param {Function} props.onChangePseudoState Callback when pseudo state selection changes.
  * @param {boolean}  props.showText            Whether to show text label on the toggle. Default true.
  * @param {Object}   props.popoverProps        Popover props for the dropdown menu.
@@ -23,21 +26,35 @@ import { Stack } from '@wordpress/ui';
  */
 export default function StateControl( {
 	viewportStates = [],
+	customStates = [],
 	pseudoStates = [],
 	viewportValue = 'default',
+	customStateValue = 'default',
 	pseudoStateValue = 'default',
 	onChangeViewport,
+	onChangeCustomState,
 	onChangePseudoState,
 	showText = true,
 	popoverProps = {},
 } ) {
-	if ( ! viewportStates.length && ! pseudoStates.length ) {
+	if (
+		! viewportStates.length &&
+		! customStates.length &&
+		! pseudoStates.length
+	) {
 		return null;
 	}
 
 	const viewportOptions = [
 		{ label: __( 'Default' ), value: 'default' },
 		...viewportStates.map( ( state ) => ( {
+			label: state.label,
+			value: state.value,
+		} ) ),
+	];
+	const customStateOptions = [
+		{ label: __( 'Default' ), value: 'default' },
+		...customStates.map( ( state ) => ( {
 			label: state.label,
 			value: state.value,
 		} ) ),
@@ -51,6 +68,7 @@ export default function StateControl( {
 	];
 
 	const hasViewportOptions = viewportStates.length > 0;
+	const hasCustomStateOptions = customStates.length > 0;
 	const hasPseudoStateOptions = pseudoStates.length > 0;
 	const triggerLabel = __( 'States' );
 	const activeStates = [];
@@ -64,6 +82,19 @@ export default function StateControl( {
 			activeStates.push( {
 				key: `viewport-${ selectedViewport.value }`,
 				label: selectedViewport.label,
+			} );
+		}
+	}
+
+	if ( hasCustomStateOptions && customStateValue !== 'default' ) {
+		const selectedCustomState = customStateOptions.find(
+			( option ) => option.value === customStateValue
+		);
+
+		if ( selectedCustomState ) {
+			activeStates.push( {
+				key: `custom-${ selectedCustomState.value }`,
+				label: selectedCustomState.label,
 			} );
 		}
 	}
@@ -114,56 +145,92 @@ export default function StateControl( {
 				text={ showText ? triggerLabel : undefined }
 				toggleProps={ toggleProps }
 			>
-				{ ( { onClose } ) => (
-					<>
-						{ hasViewportOptions && (
-							<MenuGroup label={ __( 'Viewport' ) }>
-								{ viewportOptions.map( ( option ) => (
-									<MenuItem
-										key={ `viewport-${ option.value }` }
-										onClick={ () => {
-											onChangeViewport?.( option.value );
-											if ( ! hasPseudoStateOptions ) {
-												onClose();
+				{ ( { onClose } ) => {
+					const hasMultipleGroups =
+						[
+							hasViewportOptions,
+							hasCustomStateOptions,
+							hasPseudoStateOptions,
+						].filter( Boolean ).length > 1;
+					return (
+						<>
+							{ hasViewportOptions && (
+								<MenuGroup label={ __( 'Viewport' ) }>
+									{ viewportOptions.map( ( option ) => (
+										<MenuItem
+											key={ `viewport-${ option.value }` }
+											onClick={ () => {
+												onChangeViewport?.(
+													option.value
+												);
+												if ( ! hasMultipleGroups ) {
+													onClose();
+												}
+											} }
+											icon={
+												viewportValue === option.value
+													? check
+													: null
 											}
-										} }
-										icon={
-											viewportValue === option.value
-												? check
-												: null
-										}
-									>
-										{ option.label }
-									</MenuItem>
-								) ) }
-							</MenuGroup>
-						) }
-						{ hasPseudoStateOptions && (
-							<MenuGroup label={ __( 'Pseudo state' ) }>
-								{ pseudoStateOptions.map( ( option ) => (
-									<MenuItem
-										key={ `pseudo-${ option.value }` }
-										onClick={ () => {
-											onChangePseudoState?.(
+										>
+											{ option.label }
+										</MenuItem>
+									) ) }
+								</MenuGroup>
+							) }
+							{ hasCustomStateOptions && (
+								<MenuGroup label={ __( 'Item' ) }>
+									{ customStateOptions.map( ( option ) => (
+										<MenuItem
+											key={ `custom-${ option.value }` }
+											onClick={ () => {
+												onChangeCustomState?.(
+													option.value
+												);
+												if ( ! hasMultipleGroups ) {
+													onClose();
+												}
+											} }
+											icon={
+												customStateValue ===
 												option.value
-											);
-											if ( ! hasViewportOptions ) {
-												onClose();
+													? check
+													: null
 											}
-										} }
-										icon={
-											pseudoStateValue === option.value
-												? check
-												: null
-										}
-									>
-										{ option.label }
-									</MenuItem>
-								) ) }
-							</MenuGroup>
-						) }
-					</>
-				) }
+										>
+											{ option.label }
+										</MenuItem>
+									) ) }
+								</MenuGroup>
+							) }
+							{ hasPseudoStateOptions && (
+								<MenuGroup label={ __( 'Pseudo state' ) }>
+									{ pseudoStateOptions.map( ( option ) => (
+										<MenuItem
+											key={ `pseudo-${ option.value }` }
+											onClick={ () => {
+												onChangePseudoState?.(
+													option.value
+												);
+												if ( ! hasMultipleGroups ) {
+													onClose();
+												}
+											} }
+											icon={
+												pseudoStateValue ===
+												option.value
+													? check
+													: null
+											}
+										>
+											{ option.label }
+										</MenuItem>
+									) ) }
+								</MenuGroup>
+							) }
+						</>
+					);
+				} }
 			</DropdownMenu>
 		</Stack>
 	);

--- a/packages/block-editor/src/components/global-styles/state-control.js
+++ b/packages/block-editor/src/components/global-styles/state-control.js
@@ -18,6 +18,50 @@ function buildOptions( states ) {
 }
 
 /**
+ * Renders one group of state options (Viewport, Item, or Pseudo state) inside
+ * the parent DropdownMenu. Extracted so the three groups share a single
+ * source of truth for menu-item rendering, selected-icon, and close-on-select
+ * behavior.
+ *
+ * @param {Object}   props               Component props.
+ * @param {string}   props.label         Visible group label.
+ * @param {string}   props.keyPrefix     React-key namespace for the group's items.
+ * @param {Array}    props.options       Items to render (each with `value` and `label`).
+ * @param {string}   props.selectedValue Currently-selected value within this group.
+ * @param {Function} props.onChange      Called with the chosen option value.
+ * @param {Function} props.onClose       Closes the parent DropdownMenu.
+ * @param {boolean}  props.closeOnSelect Close the menu after a selection.
+ */
+function StateMenuGroup( {
+	label,
+	keyPrefix,
+	options,
+	selectedValue,
+	onChange,
+	onClose,
+	closeOnSelect,
+} ) {
+	return (
+		<MenuGroup label={ label }>
+			{ options.map( ( option ) => (
+				<MenuItem
+					key={ `${ keyPrefix }-${ option.value }` }
+					onClick={ () => {
+						onChange?.( option.value );
+						if ( closeOnSelect ) {
+							onClose();
+						}
+					} }
+					icon={ selectedValue === option.value ? check : null }
+				>
+					{ option.label }
+				</MenuItem>
+			) ) }
+		</MenuGroup>
+	);
+}
+
+/**
  * State control for managing viewport, custom (class-based), and pseudo-state styles.
  * Displays a dropdown menu with separate groups for each selector.
  *
@@ -69,50 +113,54 @@ export default function StateControl( {
 		return null;
 	}
 
-	const hasViewportOptions = viewportStates.length > 0;
-	const hasCustomStateOptions = customStates.length > 0;
-	const hasPseudoStateOptions = pseudoStates.length > 0;
 	const triggerLabel = __( 'States' );
-	const activeStates = [];
-
-	if ( hasViewportOptions && viewportValue !== 'default' ) {
-		const selectedViewport = viewportOptions.find(
-			( option ) => option.value === viewportValue
-		);
-
-		if ( selectedViewport ) {
-			activeStates.push( {
-				key: `viewport-${ selectedViewport.value }`,
-				label: selectedViewport.label,
-			} );
+	const groups = [
+		{
+			keyPrefix: 'viewport',
+			label: __( 'Viewport' ),
+			options: viewportOptions,
+			rawOptions: viewportStates,
+			selectedValue: viewportValue,
+			onChange: onChangeViewport,
+		},
+		{
+			keyPrefix: 'custom',
+			label: _x( 'Item', 'block style state group for per-item states' ),
+			options: customStateOptions,
+			rawOptions: customStates,
+			selectedValue: customStateValue,
+			onChange: onChangeCustomState,
+		},
+		{
+			keyPrefix: 'pseudo',
+			label: __( 'Pseudo state' ),
+			options: pseudoStateOptions,
+			rawOptions: pseudoStates,
+			selectedValue: pseudoStateValue,
+			onChange: onChangePseudoState,
+		},
+	];
+	const visibleGroups = groups.filter(
+		( { rawOptions } ) => rawOptions.length > 0
+	);
+	const activeStates = visibleGroups.flatMap(
+		( { keyPrefix, options, selectedValue } ) => {
+			if ( selectedValue === 'default' ) {
+				return [];
+			}
+			const selected = options.find(
+				( option ) => option.value === selectedValue
+			);
+			return selected
+				? [
+						{
+							key: `${ keyPrefix }-${ selected.value }`,
+							label: selected.label,
+						},
+				  ]
+				: [];
 		}
-	}
-
-	if ( hasCustomStateOptions && customStateValue !== 'default' ) {
-		const selectedCustomState = customStateOptions.find(
-			( option ) => option.value === customStateValue
-		);
-
-		if ( selectedCustomState ) {
-			activeStates.push( {
-				key: `custom-${ selectedCustomState.value }`,
-				label: selectedCustomState.label,
-			} );
-		}
-	}
-
-	if ( hasPseudoStateOptions && pseudoStateValue !== 'default' ) {
-		const selectedPseudoState = pseudoStateOptions.find(
-			( option ) => option.value === pseudoStateValue
-		);
-
-		if ( selectedPseudoState ) {
-			activeStates.push( {
-				key: `pseudo-${ selectedPseudoState.value }`,
-				label: selectedPseudoState.label,
-			} );
-		}
-	}
+	);
 
 	const currentStateLabel = activeStates.length
 		? activeStates.map( ( state ) => state.label ).join( ', ' )
@@ -148,93 +196,21 @@ export default function StateControl( {
 				toggleProps={ toggleProps }
 			>
 				{ ( { onClose } ) => {
-					const hasMultipleGroups =
-						[
-							hasViewportOptions,
-							hasCustomStateOptions,
-							hasPseudoStateOptions,
-						].filter( Boolean ).length > 1;
+					const closeOnSelect = visibleGroups.length <= 1;
 					return (
 						<>
-							{ hasViewportOptions && (
-								<MenuGroup label={ __( 'Viewport' ) }>
-									{ viewportOptions.map( ( option ) => (
-										<MenuItem
-											key={ `viewport-${ option.value }` }
-											onClick={ () => {
-												onChangeViewport?.(
-													option.value
-												);
-												if ( ! hasMultipleGroups ) {
-													onClose();
-												}
-											} }
-											icon={
-												viewportValue === option.value
-													? check
-													: null
-											}
-										>
-											{ option.label }
-										</MenuItem>
-									) ) }
-								</MenuGroup>
-							) }
-							{ hasCustomStateOptions && (
-								<MenuGroup
-									label={ _x(
-										'Item',
-										'block style state group for per-item states'
-									) }
-								>
-									{ customStateOptions.map( ( option ) => (
-										<MenuItem
-											key={ `custom-${ option.value }` }
-											onClick={ () => {
-												onChangeCustomState?.(
-													option.value
-												);
-												if ( ! hasMultipleGroups ) {
-													onClose();
-												}
-											} }
-											icon={
-												customStateValue ===
-												option.value
-													? check
-													: null
-											}
-										>
-											{ option.label }
-										</MenuItem>
-									) ) }
-								</MenuGroup>
-							) }
-							{ hasPseudoStateOptions && (
-								<MenuGroup label={ __( 'Pseudo state' ) }>
-									{ pseudoStateOptions.map( ( option ) => (
-										<MenuItem
-											key={ `pseudo-${ option.value }` }
-											onClick={ () => {
-												onChangePseudoState?.(
-													option.value
-												);
-												if ( ! hasMultipleGroups ) {
-													onClose();
-												}
-											} }
-											icon={
-												pseudoStateValue ===
-												option.value
-													? check
-													: null
-											}
-										>
-											{ option.label }
-										</MenuItem>
-									) ) }
-								</MenuGroup>
-							) }
+							{ visibleGroups.map( ( group ) => (
+								<StateMenuGroup
+									key={ group.keyPrefix }
+									label={ group.label }
+									keyPrefix={ group.keyPrefix }
+									options={ group.options }
+									selectedValue={ group.selectedValue }
+									onChange={ group.onChange }
+									onClose={ onClose }
+									closeOnSelect={ closeOnSelect }
+								/>
+							) ) }
 						</>
 					);
 				} }

--- a/packages/block-editor/src/hooks/block-style-state.js
+++ b/packages/block-editor/src/hooks/block-style-state.js
@@ -13,6 +13,7 @@ const DEFAULT_STATE_VALUE = 'default';
 
 export const DEFAULT_BLOCK_STYLE_STATE = {
 	viewport: DEFAULT_STATE_VALUE,
+	custom: DEFAULT_STATE_VALUE,
 	pseudo: DEFAULT_STATE_VALUE,
 };
 
@@ -50,6 +51,19 @@ export function hasPseudoBlockStyleState( selectedState ) {
 }
 
 /**
+ * Returns true when a custom (class-based) style state is selected, e.g.
+ * `@current` for the navigation-link block.
+ *
+ * @param {Object} selectedState Selected block style state.
+ * @return {boolean} Whether a custom state is selected.
+ */
+export function hasCustomBlockStyleState( selectedState ) {
+	return (
+		!! selectedState?.custom && selectedState.custom !== DEFAULT_STATE_VALUE
+	);
+}
+
+/**
  * Returns true when the default style state is selected.
  *
  * @param {Object} selectedState Selected block style state.
@@ -58,12 +72,20 @@ export function hasPseudoBlockStyleState( selectedState ) {
 export function isDefaultBlockStyleState( selectedState ) {
 	return (
 		! hasViewportBlockStyleState( selectedState ) &&
+		! hasCustomBlockStyleState( selectedState ) &&
 		! hasPseudoBlockStyleState( selectedState )
 	);
 }
 
 /**
  * Returns the style object path for the selected block style state.
+ *
+ * Path order is `[ viewport, custom, pseudo ]` — viewport is outermost
+ * because it represents a media-query wrapper, while custom (class-based)
+ * and pseudo states both modify the block-instance selector. With this
+ * ordering, e.g. selecting mobile + @current + :hover stores at
+ * `style.mobile['@current'][':hover']` and renders as
+ * `@media(...) { .wp-states-X.current-menu-item:hover { ... } }`.
  *
  * @param {Object} selectedState Selected block style state.
  * @return {string[]} Object path for the selected state styles.
@@ -73,9 +95,11 @@ function getStyleStatePath( selectedState ) {
 		return [];
 	}
 
-	return [ selectedState.viewport, selectedState.pseudo ].filter(
-		( state ) => state && state !== DEFAULT_STATE_VALUE
-	);
+	return [
+		selectedState.viewport,
+		selectedState.custom,
+		selectedState.pseudo,
+	].filter( ( state ) => state && state !== DEFAULT_STATE_VALUE );
 }
 
 export function getStyleForState( style, selectedState ) {

--- a/packages/block-editor/src/hooks/state-utils.js
+++ b/packages/block-editor/src/hooks/state-utils.js
@@ -137,30 +137,21 @@ export function buildStateSelector( baseSelector, name, state ) {
 }
 
 /**
- * Returns the CSS selector suffix for a custom (class-based) state declared
- * on a block via `selectors.states`, extracting the trailing class/pseudo
- * segment so it can be appended to the block-instance selector.
+ * Returns the CSS suffix declared for a custom (class-based) state on the
+ * block type via `selectors.states[ state ]`, e.g. `'.current-menu-item'` for
+ * `@current` on `core/navigation-link`. The value is appended verbatim to the
+ * block-instance scope selector to produce the per-instance state selector.
  *
- * Example: for `@current` on `core/navigation-link`, where
- * `selectors.states['@current'] = ".wp-block-navigation .current-menu-item"`,
- * this returns `.current-menu-item`.
- *
- * Keep in sync with gutenberg_get_custom_state_suffix() in
- * lib/block-supports/states.php.
+ * Keep in sync with the equivalent lookup in
+ * `gutenberg_render_block_states_support()` (lib/block-supports/states.php).
  *
  * @param {string} name  Block name.
  * @param {string} state Custom state key, e.g. `'@current'`.
- * @return {string|null} CSS suffix, or null if not declared.
+ * @return {string|null} CSS suffix, or null if not declared on the block type.
  */
 export function getCustomStateSuffix( name, state ) {
-	const stateSelector = getBlockType( name )?.selectors?.states?.[ state ];
-	if ( typeof stateSelector !== 'string' || ! stateSelector.trim() ) {
-		return null;
-	}
-	const match = stateSelector.match(
-		/(\.[a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)\s*$/
-	);
-	return match ? match[ 1 ] : null;
+	const suffix = getBlockType( name )?.selectors?.states?.[ state ];
+	return typeof suffix === 'string' && suffix.trim() ? suffix : null;
 }
 
 /**

--- a/packages/block-editor/src/hooks/state-utils.js
+++ b/packages/block-editor/src/hooks/state-utils.js
@@ -137,6 +137,33 @@ export function buildStateSelector( baseSelector, name, state ) {
 }
 
 /**
+ * Returns the CSS selector suffix for a custom (class-based) state declared
+ * on a block via `selectors.states`, extracting the trailing class/pseudo
+ * segment so it can be appended to the block-instance selector.
+ *
+ * Example: for `@current` on `core/navigation-link`, where
+ * `selectors.states['@current'] = ".wp-block-navigation .current-menu-item"`,
+ * this returns `.current-menu-item`.
+ *
+ * Keep in sync with gutenberg_get_custom_state_suffix() in
+ * lib/block-supports/states.php.
+ *
+ * @param {string} name  Block name.
+ * @param {string} state Custom state key, e.g. `'@current'`.
+ * @return {string|null} CSS suffix, or null if not declared.
+ */
+export function getCustomStateSuffix( name, state ) {
+	const stateSelector = getBlockType( name )?.selectors?.states?.[ state ];
+	if ( typeof stateSelector !== 'string' || ! stateSelector.trim() ) {
+		return null;
+	}
+	const match = stateSelector.match(
+		/(\.[a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)\s*$/
+	);
+	return match ? match[ 1 ] : null;
+}
+
+/**
  * Builds the CSS selector used to preview a state on the editor canvas,
  * scoped to a specific block instance via its `data-block` attribute.
  *

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { getBlockType } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,7 +24,7 @@ export const RESPONSIVE_STATE_LABELS = {
 };
 
 export const CUSTOM_STATE_LABELS = {
-	'@current': __( 'Current' ),
+	'@current': _x( 'Current', 'block style state for the active menu item' ),
 };
 
 // Keep in sync with WP_Theme_JSON_Gutenberg::VALID_BLOCK_PSEUDO_SELECTORS

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -23,11 +23,23 @@ export const RESPONSIVE_STATE_LABELS = {
 	mobile: __( 'Mobile' ),
 };
 
+export const CUSTOM_STATE_LABELS = {
+	'@current': __( 'Current' ),
+};
+
 // Keep in sync with WP_Theme_JSON_Gutenberg::VALID_BLOCK_PSEUDO_SELECTORS
 // and packages/global-styles-engine/src/core/render.tsx.
 export const VALID_BLOCK_PSEUDO_STATES = {
 	'core/button': [ ':hover', ':focus', ':focus-visible', ':active' ],
 	'core/navigation-link': [ ':hover', ':focus', ':focus-visible', ':active' ],
+};
+
+// Keep in sync with WP_Theme_JSON_Gutenberg::VALID_BLOCK_CUSTOM_STATES.
+// Custom states are class-based (e.g. `.current-menu-item`) rather than CSS
+// pseudo-selectors; the actual CSS selector is declared on the block type via
+// `selectors.states` in block.json.
+export const VALID_BLOCK_CUSTOM_STATES = {
+	'core/navigation-link': [ '@current' ],
 };
 
 function getPseudoStateOptions( name ) {
@@ -38,6 +50,20 @@ function getPseudoStateOptions( name ) {
 		.map( ( state ) => ( {
 			value: state,
 			label: PSEUDO_STATE_LABELS[ state ],
+		} ) );
+}
+
+function getCustomStateOptions( name ) {
+	const validStates = VALID_BLOCK_CUSTOM_STATES[ name ] ?? [];
+	const blockSelectors = getBlockType( name )?.selectors?.states ?? {};
+
+	return validStates
+		.filter(
+			( state ) => CUSTOM_STATE_LABELS[ state ] && blockSelectors[ state ]
+		)
+		.map( ( state ) => ( {
+			value: state,
+			label: CUSTOM_STATE_LABELS[ state ],
 		} ) );
 }
 
@@ -69,20 +95,28 @@ function getViewportStateOptions( name ) {
  */
 export function BlockStatesControl( { name, value, onChange } ) {
 	const viewportStateOptions = getViewportStateOptions( name );
+	const customStateOptions = getCustomStateOptions( name );
 	const pseudoStateOptions = getPseudoStateOptions( name );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
-	if ( ! viewportStateOptions.length && ! pseudoStateOptions.length ) {
+	if (
+		! viewportStateOptions.length &&
+		! customStateOptions.length &&
+		! pseudoStateOptions.length
+	) {
 		return null;
 	}
 
 	return (
 		<StateControl
 			viewportStates={ viewportStateOptions }
+			customStates={ customStateOptions }
 			pseudoStates={ pseudoStateOptions }
 			viewportValue={ value?.viewport ?? DEFAULT_STATE_VALUE }
+			customStateValue={ value?.custom ?? DEFAULT_STATE_VALUE }
 			pseudoStateValue={ value?.pseudo ?? DEFAULT_STATE_VALUE }
 			onChangeViewport={ ( viewport ) => onChange( { viewport } ) }
+			onChangeCustomState={ ( custom ) => onChange( { custom } ) }
 			onChangePseudoState={ ( pseudo ) => onChange( { pseudo } ) }
 			popoverProps={ dropdownMenuProps.popoverProps }
 			showText={ false }
@@ -92,17 +126,24 @@ export function BlockStatesControl( { name, value, onChange } ) {
 
 export function BlockStateBadges( { name, value } ) {
 	const viewportStateOptions = getViewportStateOptions( name );
+	const customStateOptions = getCustomStateOptions( name );
 	const pseudoStateOptions = getPseudoStateOptions( name );
 
-	if ( ! viewportStateOptions.length && ! pseudoStateOptions.length ) {
+	if (
+		! viewportStateOptions.length &&
+		! customStateOptions.length &&
+		! pseudoStateOptions.length
+	) {
 		return null;
 	}
 
 	return (
 		<StateControlBadges
 			viewportStates={ viewportStateOptions }
+			customStates={ customStateOptions }
 			pseudoStates={ pseudoStateOptions }
 			viewportValue={ value?.viewport ?? DEFAULT_STATE_VALUE }
+			customStateValue={ value?.custom ?? DEFAULT_STATE_VALUE }
 			pseudoStateValue={ value?.pseudo ?? DEFAULT_STATE_VALUE }
 		/>
 	);

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -42,9 +42,10 @@ import {
 	getStyleForState,
 	hasViewportBlockStyleState,
 	hasPseudoBlockStyleState,
+	hasCustomBlockStyleState,
 } from './block-style-state';
-import { VALID_BLOCK_PSEUDO_STATES } from './states';
-import { buildScopedBlockSelector } from './state-utils';
+import { VALID_BLOCK_PSEUDO_STATES, VALID_BLOCK_CUSTOM_STATES } from './states';
+import { buildScopedBlockSelector, getCustomStateSuffix } from './state-utils';
 import { scopeSelector } from '../components/global-styles/utils';
 import { useBlockEditingMode } from '../components/block-editing-mode';
 import { store as blockEditorStore } from '../store';
@@ -323,11 +324,75 @@ function getPseudoStateCSSRules( style, name, baseSelector ) {
 }
 
 /**
+ * Generates CSS rules for custom (class-based) state styles such as `@current`.
+ *
+ * Each custom state can contain root styles plus nested pseudo-state styles
+ * (e.g. `@current` + `:hover` stored at `style['@current'][':hover']`).
+ *
+ * @param {Object} style        Block style object containing custom states.
+ * @param {string} name         Block name.
+ * @param {string} baseSelector Base selector used to scope generated CSS.
+ * @return {string[]} Generated CSS rule strings.
+ */
+function getCustomStateCSSRules( style, name, baseSelector ) {
+	const validCustomStates = VALID_BLOCK_CUSTOM_STATES[ name ];
+	if ( ! validCustomStates ) {
+		return [];
+	}
+
+	const validPseudoStates = VALID_BLOCK_PSEUDO_STATES[ name ] ?? [];
+	const cssRules = [];
+
+	validCustomStates.forEach( ( customState ) => {
+		const customStyles = style?.[ customState ];
+		if ( ! customStyles ) {
+			return;
+		}
+		const customSuffix = getCustomStateSuffix( name, customState );
+		if ( ! customSuffix ) {
+			return;
+		}
+
+		const rootStyles = getRootStateStyles(
+			customStyles,
+			validPseudoStates
+		);
+		if ( rootStyles && Object.keys( rootStyles ).length ) {
+			const css = getBlockStateStylesCSS( rootStyles, {
+				name,
+				baseSelector,
+				state: customSuffix,
+			} );
+			if ( css ) {
+				cssRules.push( css );
+			}
+		}
+
+		validPseudoStates.forEach( ( pseudoState ) => {
+			const compoundStyles = customStyles[ pseudoState ];
+			if ( ! compoundStyles ) {
+				return;
+			}
+			const css = getBlockStateStylesCSS( compoundStyles, {
+				name,
+				baseSelector,
+				state: `${ customSuffix }${ pseudoState }`,
+			} );
+			if ( css ) {
+				cssRules.push( css );
+			}
+		} );
+	} );
+
+	return cssRules;
+}
+
+/**
  * Generates CSS rules for responsive block instance style states.
  *
  * Each responsive state can contain root styles, element styles, and nested
- * pseudo-state styles. Generated rules are wrapped in the matching breakpoint
- * media query.
+ * pseudo-state and custom-state styles. Generated rules are wrapped in the
+ * matching breakpoint media query.
  *
  * @param {Object} style        Block style object containing responsive states.
  * @param {string} name         Block name.
@@ -337,7 +402,12 @@ function getPseudoStateCSSRules( style, name, baseSelector ) {
 export function getResponsiveStateCSSRules( style, name, baseSelector ) {
 	const cssRules = [];
 	const validPseudoStates = VALID_BLOCK_PSEUDO_STATES[ name ] ?? [];
-	const nestedStateKeys = [ 'elements', ...validPseudoStates ];
+	const validCustomStates = VALID_BLOCK_CUSTOM_STATES[ name ] ?? [];
+	const nestedStateKeys = [
+		'elements',
+		...validPseudoStates,
+		...validCustomStates,
+	];
 
 	Object.entries( RESPONSIVE_BREAKPOINTS ).forEach(
 		( [ viewport, mediaQuery ] ) => {
@@ -369,6 +439,10 @@ export function getResponsiveStateCSSRules( style, name, baseSelector ) {
 
 			viewportCSSRules.push(
 				...getPseudoStateCSSRules( viewportStyles, name, baseSelector )
+			);
+
+			viewportCSSRules.push(
+				...getCustomStateCSSRules( viewportStyles, name, baseSelector )
 			);
 
 			if ( viewportCSSRules.length ) {
@@ -699,13 +773,17 @@ function BlockStyleControls( {
 		[ clientId, name ]
 	);
 	const isPseudoSelectorState = hasPseudoBlockStyleState( selectedState );
+	const isCustomSelectorState = hasCustomBlockStyleState( selectedState );
 
 	// Inject state styles onto the editor canvas so the selected state is
 	// visible while editing. Scoped to this block instance via data-block so
 	// other blocks of the same type are not affected. Must be called before
 	// any early returns because it is a hook.
 	const canvasStateCSS = useMemo( () => {
-		if ( ! showStateOnCanvas || ! isPseudoSelectorState ) {
+		if (
+			! showStateOnCanvas ||
+			( ! isPseudoSelectorState && ! isCustomSelectorState )
+		) {
 			return undefined;
 		}
 
@@ -739,6 +817,7 @@ function BlockStyleControls( {
 	}, [
 		showStateOnCanvas,
 		isPseudoSelectorState,
+		isCustomSelectorState,
 		globalBlockStyles,
 		style,
 		selectedState,
@@ -903,6 +982,10 @@ function useBlockProps( { name, style } ) {
 
 		cssRules.push(
 			...getPseudoStateCSSRules( style, name, baseElementSelector )
+		);
+
+		cssRules.push(
+			...getCustomStateCSSRules( style, name, baseElementSelector )
 		);
 
 		cssRules.push(

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -754,7 +754,13 @@ function BlockStyleControls( {
 } ) {
 	const settings = useBlockSettings( name, __unstableParentLayout );
 	const blockEditingMode = useBlockEditingMode();
-	const { globalBlockStyles, selectedState, showStateOnCanvas } = useSelect(
+	const {
+		globalBlockStyles,
+		selectedState,
+		showStateOnCanvas,
+		isPseudoSelectorState,
+		isCustomSelectorState,
+	} = useSelect(
 		( select ) => {
 			const blockEditorSelect = select( blockEditorStore );
 			const {
@@ -762,18 +768,19 @@ function BlockStyleControls( {
 				isSelectedBlockStyleStateShownOnCanvas,
 			} = unlock( blockEditorSelect );
 			const editorSettings = blockEditorSelect.getSettings();
+			const currentState = getSelectedBlockStyleState( clientId );
 			return {
 				globalBlockStyles:
 					editorSettings?.[ globalStylesDataKey ]?.blocks?.[ name ],
-				selectedState: getSelectedBlockStyleState( clientId ),
+				selectedState: currentState,
 				showStateOnCanvas:
 					isSelectedBlockStyleStateShownOnCanvas( clientId ),
+				isPseudoSelectorState: hasPseudoBlockStyleState( currentState ),
+				isCustomSelectorState: hasCustomBlockStyleState( currentState ),
 			};
 		},
 		[ clientId, name ]
 	);
-	const isPseudoSelectorState = hasPseudoBlockStyleState( selectedState );
-	const isCustomSelectorState = hasCustomBlockStyleState( selectedState );
 
 	// Inject state styles onto the editor canvas so the selected state is
 	// visible while editing. Scoped to this block instance via data-block so

--- a/packages/block-editor/src/hooks/test/block-style-state.js
+++ b/packages/block-editor/src/hooks/test/block-style-state.js
@@ -67,6 +67,61 @@ describe( 'getStyleForState', () => {
 			color: { text: '#ff0000' },
 		} );
 	} );
+
+	it( 'returns the selected custom state style', () => {
+		const style = {
+			color: { text: '#000000' },
+			'@current': { color: { text: '#ff0000' } },
+		};
+
+		expect(
+			getStyleForState( style, {
+				viewport: 'default',
+				custom: '@current',
+				pseudo: 'default',
+			} )
+		).toEqual( {
+			color: { text: '#ff0000' },
+		} );
+	} );
+
+	it( 'returns the selected custom pseudo state style', () => {
+		const style = {
+			'@current': {
+				':hover': { color: { text: '#ff0000' } },
+			},
+		};
+
+		expect(
+			getStyleForState( style, {
+				viewport: 'default',
+				custom: '@current',
+				pseudo: ':hover',
+			} )
+		).toEqual( {
+			color: { text: '#ff0000' },
+		} );
+	} );
+
+	it( 'returns the selected viewport custom pseudo state style', () => {
+		const style = {
+			mobile: {
+				'@current': {
+					':hover': { color: { text: '#ff0000' } },
+				},
+			},
+		};
+
+		expect(
+			getStyleForState( style, {
+				viewport: 'mobile',
+				custom: '@current',
+				pseudo: ':hover',
+			} )
+		).toEqual( {
+			color: { text: '#ff0000' },
+		} );
+	} );
 } );
 
 describe( 'setStyleForState', () => {
@@ -150,6 +205,42 @@ describe( 'setStyleForState', () => {
 			)
 		).toEqual( {
 			color: { text: '#000000' },
+		} );
+	} );
+
+	it( 'updates only the selected custom state style', () => {
+		expect(
+			setStyleForState(
+				{
+					color: { text: '#000000' },
+					'@current': { color: { text: '#ff0000' } },
+				},
+				{ viewport: 'default', custom: '@current', pseudo: 'default' },
+				{ typography: { fontSize: '32px' } }
+			)
+		).toEqual( {
+			color: { text: '#000000' },
+			'@current': { typography: { fontSize: '32px' } },
+		} );
+	} );
+
+	it( 'updates only the selected custom pseudo state style', () => {
+		expect(
+			setStyleForState(
+				{
+					'@current': {
+						color: { text: '#ff0000' },
+						':hover': { color: { text: '#00ff00' } },
+					},
+				},
+				{ viewport: 'default', custom: '@current', pseudo: ':hover' },
+				{ typography: { fontSize: '32px' } }
+			)
+		).toEqual( {
+			'@current': {
+				color: { text: '#ff0000' },
+				':hover': { typography: { fontSize: '32px' } },
+			},
 		} );
 	} );
 } );
@@ -266,5 +357,27 @@ describe( 'scopeResetAllFilterToState', () => {
 				innerReset
 			)
 		).toBe( innerReset );
+	} );
+
+	it( 'passes only the selected custom state style to the reset filter', () => {
+		const innerReset = jest.fn( () => ( { style: undefined } ) );
+		const attributes = {
+			style: {
+				color: { text: '#000000' },
+				'@current': { color: { text: '#ff0000' } },
+			},
+		};
+
+		const result = scopeResetAllFilterToState(
+			{ viewport: 'default', custom: '@current', pseudo: 'default' },
+			innerReset
+		)( attributes );
+
+		expect( innerReset ).toHaveBeenCalledWith( {
+			style: attributes.style[ '@current' ],
+		} );
+		expect( result ).toEqual( {
+			style: { color: { text: '#000000' } },
+		} );
 	} );
 } );

--- a/packages/block-editor/src/hooks/test/state-utils.js
+++ b/packages/block-editor/src/hooks/test/state-utils.js
@@ -217,20 +217,11 @@ describe( 'getCustomStateSuffix', () => {
 				states: { '@current': '   ' },
 			},
 		} );
-		registerBlockType( 'test/no-states', {
-			apiVersion: 3,
-			title: 'No States',
-			category: 'text',
-			attributes: {},
-			edit: () => null,
-			save: () => null,
-		} );
 	} );
 
 	afterEach( () => {
 		unregisterBlockType( 'test/with-current' );
 		unregisterBlockType( 'test/empty-state' );
-		unregisterBlockType( 'test/no-states' );
 	} );
 
 	it( 'returns the declared suffix for a registered custom state', () => {
@@ -245,21 +236,9 @@ describe( 'getCustomStateSuffix', () => {
 		).toBeNull();
 	} );
 
-	it( 'returns null when the block does not declare selectors.states at all', () => {
-		expect(
-			getCustomStateSuffix( 'test/no-states', '@current' )
-		).toBeNull();
-	} );
-
 	it( 'returns null when the declared value is empty or whitespace', () => {
 		expect(
 			getCustomStateSuffix( 'test/empty-state', '@current' )
-		).toBeNull();
-	} );
-
-	it( 'returns null for an unregistered block name', () => {
-		expect(
-			getCustomStateSuffix( 'test/unregistered', '@current' )
 		).toBeNull();
 	} );
 } );

--- a/packages/block-editor/src/hooks/test/state-utils.js
+++ b/packages/block-editor/src/hooks/test/state-utils.js
@@ -11,6 +11,7 @@ import {
 	buildScopedBlockSelector,
 	buildRootStyleStateSelector,
 	buildPseudoStyleStateSelector,
+	getCustomStateSuffix,
 } from '../state-utils';
 
 describe( 'getRelativeRootSelector', () => {
@@ -189,5 +190,76 @@ describe( 'state selector builders', () => {
 		expect(
 			buildPseudoStyleStateSelector( BASE, 'test/unknown', ':hover' )
 		).toBe( `${ BASE }:hover` );
+	} );
+} );
+
+describe( 'getCustomStateSuffix', () => {
+	beforeEach( () => {
+		registerBlockType( 'test/with-current', {
+			apiVersion: 3,
+			title: 'With Current',
+			category: 'text',
+			attributes: {},
+			edit: () => null,
+			save: () => null,
+			selectors: {
+				states: { '@current': '.current-menu-item' },
+			},
+		} );
+		registerBlockType( 'test/empty-state', {
+			apiVersion: 3,
+			title: 'Empty State',
+			category: 'text',
+			attributes: {},
+			edit: () => null,
+			save: () => null,
+			selectors: {
+				states: { '@current': '   ' },
+			},
+		} );
+		registerBlockType( 'test/no-states', {
+			apiVersion: 3,
+			title: 'No States',
+			category: 'text',
+			attributes: {},
+			edit: () => null,
+			save: () => null,
+		} );
+	} );
+
+	afterEach( () => {
+		unregisterBlockType( 'test/with-current' );
+		unregisterBlockType( 'test/empty-state' );
+		unregisterBlockType( 'test/no-states' );
+	} );
+
+	it( 'returns the declared suffix for a registered custom state', () => {
+		expect( getCustomStateSuffix( 'test/with-current', '@current' ) ).toBe(
+			'.current-menu-item'
+		);
+	} );
+
+	it( 'returns null when the block does not declare the requested state', () => {
+		expect(
+			getCustomStateSuffix( 'test/with-current', '@unknown' )
+		).toBeNull();
+	} );
+
+	it( 'returns null when the block does not declare selectors.states at all', () => {
+		expect(
+			getCustomStateSuffix( 'test/no-states', '@current' )
+		).toBeNull();
+	} );
+
+	it( 'returns null when the declared value is empty or whitespace', () => {
+		expect(
+			getCustomStateSuffix( 'test/empty-state', '@current' )
+		).toBeNull();
+	} );
+
+	it( 'returns null for an unregistered block name', () => {
+		expect(
+			getCustomStateSuffix( 'test/unregistered', '@current' )
+		).toBeNull();
 	} );
 } );

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -362,6 +362,39 @@ describe( 'getResponsiveStateCSSRules', () => {
 			'@media (width <= 480px){.wp-elements-1 a:where(:not(.wp-element-button)) { color: blue; }}',
 		] );
 	} );
+
+	it( 'generates media-query scoped custom-state styles for viewport states', () => {
+		registerBlockType( 'core/navigation-link', {
+			apiVersion: 3,
+			title: 'Custom Link',
+			category: 'design',
+			attributes: {},
+			edit: () => null,
+			save: () => null,
+			selectors: {
+				states: { '@current': '.current-menu-item' },
+			},
+		} );
+
+		expect(
+			getResponsiveStateCSSRules(
+				{
+					mobile: {
+						'@current': {
+							color: { text: 'red' },
+							':hover': { color: { text: 'blue' } },
+						},
+					},
+				},
+				'core/navigation-link',
+				'.wp-elements-1'
+			)
+		).toEqual( [
+			'@media (width <= 480px){.wp-elements-1.current-menu-item { color: red !important; }.wp-elements-1.current-menu-item:hover { color: blue !important; }}',
+		] );
+
+		unregisterBlockType( 'core/navigation-link' );
+	} );
 } );
 
 describe( 'getCanvasStateStyleValue', () => {

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -1060,6 +1060,7 @@ export function getRequestedInspectorTab( state ) {
 
 const DEFAULT_BLOCK_STYLE_STATE = {
 	viewport: 'default',
+	custom: 'default',
 	pseudo: 'default',
 };
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2301,6 +2301,7 @@ export function selectedBlockStyleState( state = undefined, action ) {
 				showStateOnCanvas,
 				value: {
 					viewport: 'default',
+					custom: 'default',
 					pseudo: 'default',
 					...previousValue,
 					...action.value,
@@ -2321,6 +2322,7 @@ export function selectedBlockStyleState( state = undefined, action ) {
 				showStateOnCanvas: action.value,
 				value: {
 					viewport: 'default',
+					custom: 'default',
 					pseudo: 'default',
 					...previousValue,
 				},

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -80,6 +80,7 @@ describe( 'private selectors', () => {
 
 			expect( getSelectedBlockStyleState( state, 'client-1' ) ).toEqual( {
 				viewport: 'default',
+				custom: 'default',
 				pseudo: 'default',
 			} );
 		} );
@@ -107,6 +108,7 @@ describe( 'private selectors', () => {
 
 			expect( getSelectedBlockStyleState( state, 'client-1' ) ).toEqual( {
 				viewport: 'default',
+				custom: 'default',
 				pseudo: 'default',
 			} );
 		} );
@@ -121,6 +123,7 @@ describe( 'private selectors', () => {
 
 			expect( getSelectedBlockStyleState( state, 'client-1' ) ).toEqual( {
 				viewport: 'default',
+				custom: 'default',
 				pseudo: 'default',
 			} );
 		} );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -5835,6 +5835,7 @@ describe( 'state', () => {
 				showStateOnCanvas: true,
 				value: {
 					viewport: 'mobile',
+					custom: 'default',
 					pseudo: 'default',
 				},
 			} );
@@ -5852,7 +5853,26 @@ describe( 'state', () => {
 				showStateOnCanvas: true,
 				value: {
 					viewport: 'default',
+					custom: 'default',
 					pseudo: ':hover',
+				},
+			} );
+		} );
+
+		it( 'stores a selected custom state for a block', () => {
+			const state = selectedBlockStyleState( undefined, {
+				type: 'SET_SELECTED_BLOCK_STYLE_STATE',
+				clientId: 'client-1',
+				value: { custom: '@current' },
+			} );
+
+			expect( state ).toEqual( {
+				clientId: 'client-1',
+				showStateOnCanvas: true,
+				value: {
+					viewport: 'default',
+					custom: '@current',
+					pseudo: 'default',
 				},
 			} );
 		} );
@@ -5875,6 +5895,7 @@ describe( 'state', () => {
 				showStateOnCanvas: true,
 				value: {
 					viewport: 'mobile',
+					custom: 'default',
 					pseudo: ':hover',
 				},
 			} );
@@ -5898,6 +5919,7 @@ describe( 'state', () => {
 				showStateOnCanvas: true,
 				value: {
 					viewport: 'default',
+					custom: 'default',
 					pseudo: ':focus',
 				},
 			} );
@@ -5921,6 +5943,7 @@ describe( 'state', () => {
 				showStateOnCanvas: true,
 				value: {
 					viewport: 'default',
+					custom: 'default',
 					pseudo: 'default',
 				},
 			} );
@@ -6152,7 +6175,11 @@ describe( 'state', () => {
 			expect( state ).toEqual( {
 				clientId: 'client-1',
 				showStateOnCanvas: false,
-				value: { viewport: 'mobile', pseudo: ':hover' },
+				value: {
+					viewport: 'mobile',
+					custom: 'default',
+					pseudo: ':hover',
+				},
 			} );
 		} );
 
@@ -6173,7 +6200,11 @@ describe( 'state', () => {
 			expect( state ).toEqual( {
 				clientId: 'client-1',
 				showStateOnCanvas: false,
-				value: { viewport: 'mobile', pseudo: ':hover' },
+				value: {
+					viewport: 'mobile',
+					custom: 'default',
+					pseudo: ':hover',
+				},
 			} );
 		} );
 	} );

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -87,7 +87,7 @@
 	},
 	"selectors": {
 		"states": {
-			"@current": ".wp-block-navigation .current-menu-item"
+			"@current": ".current-menu-item"
 		}
 	},
 	"editorStyle": "wp-block-navigation-link-editor",

--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -32,7 +32,11 @@ import {
 import { useStyle, useSetting } from './hooks';
 import { GlobalStylesContext } from './context';
 import { unlock } from './lock-unlock';
-import { getValidPseudoStates, getValidViewportStates } from './utils';
+import {
+	getValidCustomStates,
+	getValidPseudoStates,
+	getValidViewportStates,
+} from './utils';
 
 // Initial control values.
 const BACKGROUND_BLOCK_DEFAULT_VALUES = {
@@ -112,15 +116,28 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 	// State selector state
 	const [ selectedViewport, setSelectedViewport ] =
 		useState< string >( 'default' );
+	const [ selectedCustomState, setSelectedCustomState ] =
+		useState< string >( 'default' );
 	const [ selectedPseudoState, setSelectedPseudoState ] =
 		useState< string >( 'default' );
 	const validViewportStates = useMemo( () => getValidViewportStates(), [] );
+	const validCustomStates = useMemo(
+		() => getValidCustomStates( name ),
+		[ name ]
+	);
 	const validPseudoStates = useMemo(
 		() => getValidPseudoStates( name ),
 		[ name ]
 	);
 
-	const stateParam = [ selectedViewport, selectedPseudoState ]
+	// Path order is viewport.custom.pseudo, matching getStyleStatePath in
+	// packages/block-editor/src/hooks/block-style-state.js: viewport wraps the
+	// rule in a media query, custom and pseudo both modify the block selector.
+	const stateParam = [
+		selectedViewport,
+		selectedCustomState,
+		selectedPseudoState,
+	]
 		.filter( ( value ) => value !== 'default' )
 		.join( '.' );
 	const hasSelectedState = stateParam.length > 0;
@@ -343,10 +360,13 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 					variation ? currentBlockStyle?.label! : blockType?.title!
 				}
 				viewportStates={ validViewportStates }
+				customStates={ validCustomStates }
 				pseudoStates={ validPseudoStates }
 				selectedViewport={ selectedViewport }
+				selectedCustomState={ selectedCustomState }
 				selectedPseudoState={ selectedPseudoState }
 				onChangeViewport={ setSelectedViewport }
+				onChangeCustomState={ setSelectedCustomState }
 				onChangePseudoState={ setSelectedPseudoState }
 			/>
 			<BlockPreviewPanel

--- a/packages/global-styles-ui/src/screen-header.tsx
+++ b/packages/global-styles-ui/src/screen-header.tsx
@@ -28,10 +28,13 @@ interface ScreenHeaderProps {
 	description?: string | React.ReactElement;
 	onBack?: () => void;
 	viewportStates?: StateDefinition[];
+	customStates?: StateDefinition[];
 	pseudoStates?: StateDefinition[];
 	selectedViewport?: string;
+	selectedCustomState?: string;
 	selectedPseudoState?: string;
 	onChangeViewport?: ( value: string ) => void;
+	onChangeCustomState?: ( value: string ) => void;
 	onChangePseudoState?: ( value: string ) => void;
 }
 
@@ -40,10 +43,13 @@ export function ScreenHeader( {
 	description,
 	onBack,
 	viewportStates,
+	customStates,
 	pseudoStates,
 	selectedViewport = 'default',
+	selectedCustomState = 'default',
 	selectedPseudoState = 'default',
 	onChangeViewport,
+	onChangeCustomState,
 	onChangePseudoState,
 }: ScreenHeaderProps ) {
 	return (
@@ -70,13 +76,20 @@ export function ScreenHeader( {
 									<VStack spacing={ 2 } alignment="right">
 										<StateControl
 											viewportStates={ viewportStates }
+											customStates={ customStates }
 											pseudoStates={ pseudoStates }
 											viewportValue={ selectedViewport }
+											customStateValue={
+												selectedCustomState
+											}
 											pseudoStateValue={
 												selectedPseudoState
 											}
 											onChangeViewport={
 												onChangeViewport
+											}
+											onChangeCustomState={
+												onChangeCustomState
 											}
 											onChangePseudoState={
 												onChangePseudoState
@@ -84,8 +97,12 @@ export function ScreenHeader( {
 										/>
 										<StateControlBadges
 											viewportStates={ viewportStates }
+											customStates={ customStates }
 											pseudoStates={ pseudoStates }
 											viewportValue={ selectedViewport }
+											customStateValue={
+												selectedCustomState
+											}
 											pseudoStateValue={
 												selectedPseudoState
 											}

--- a/packages/global-styles-ui/src/utils.ts
+++ b/packages/global-styles-ui/src/utils.ts
@@ -3,7 +3,7 @@
  */
 import { areGlobalStylesEqual } from '@wordpress/global-styles-engine';
 import type { GlobalStylesConfig } from '@wordpress/global-styles-engine';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * State definition with value and label.
@@ -61,6 +61,26 @@ export const RESPONSIVE_STATES: StateDefinition[] = [
 ];
 
 /**
+ * Valid custom (class-based) states for blocks. Each value is a `@`-prefixed
+ * key (e.g. `@current`) that resolves to a CSS class suffix declared on the
+ * block type via `selectors.states`.
+ *
+ * Mirrors `WP_Theme_JSON_Gutenberg::VALID_BLOCK_CUSTOM_STATES` and
+ * `VALID_BLOCK_CUSTOM_STATES` in `packages/block-editor/src/hooks/states.js`.
+ */
+export const VALID_BLOCK_CUSTOM_STATES: Record< string, StateDefinition[] > = {
+	'core/navigation-link': [
+		{
+			value: '@current',
+			label: _x(
+				'Current',
+				'block style state for the active menu item'
+			),
+		},
+	],
+};
+
+/**
  * Get the valid pseudo states for a given block or element.
  *
  * @param name The block name (e.g., 'core/button') or element name (e.g., 'button')
@@ -87,6 +107,16 @@ export function getValidPseudoStates( name: string ): StateDefinition[] {
  */
 export function getValidViewportStates(): StateDefinition[] {
 	return RESPONSIVE_STATES;
+}
+
+/**
+ * Get the valid custom (class-based) state definitions for a given block.
+ *
+ * @param name The block name (e.g., 'core/navigation-link').
+ * @return Array of valid custom state definitions, or empty array if none.
+ */
+export function getValidCustomStates( name: string ): StateDefinition[] {
+	return VALID_BLOCK_CUSTOM_STATES[ name ] ?? [];
 }
 
 /**

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -27,7 +27,13 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Registers a block for tests when the block is not already registered.
+	 * Registers a block for tests.
+	 *
+	 * If `$selectors` or `$supports` are provided, the block is force-registered
+	 * with those overrides (unregistering any existing registration first) so
+	 * tests get a deterministic block-type shape regardless of what the
+	 * production block.json declares. Without overrides, an existing
+	 * registration is left in place.
 	 *
 	 * @param string $block_name Block name.
 	 * @param array  $selectors  Optional block selectors (e.g. `['root' => '.foo .bar']`).
@@ -35,9 +41,13 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * @return WP_Block_Type
 	 */
 	private function ensure_block_registered( $block_name, $selectors = array(), $supports = array() ) {
+		$has_overrides    = ! empty( $selectors ) || ! empty( $supports );
 		$registered_block = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
-		if ( $registered_block ) {
+		if ( $registered_block && ! $has_overrides ) {
 			return $registered_block;
+		}
+		if ( $registered_block ) {
+			unregister_block_type( $block_name );
 		}
 
 		$this->test_block_name = $block_name;
@@ -1554,14 +1564,13 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * class declared on the block type's `selectors.states`.
 	 *
 	 * @covers ::gutenberg_render_block_states_support
-	 * @covers ::gutenberg_get_custom_state_suffix
 	 */
 	public function test_custom_state_generates_class_scoped_css() {
 		$this->ensure_block_registered(
 			'core/navigation-link',
 			array(
 				'states' => array(
-					'@current' => '.wp-block-navigation .current-menu-item',
+					'@current' => '.current-menu-item',
 				),
 			)
 		);
@@ -1600,7 +1609,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 			'core/navigation-link',
 			array(
 				'states' => array(
-					'@current' => '.wp-block-navigation .current-menu-item',
+					'@current' => '.current-menu-item',
 				),
 			)
 		);
@@ -1642,7 +1651,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 			'core/navigation-link',
 			array(
 				'states' => array(
-					'@current' => '.wp-block-navigation .current-menu-item',
+					'@current' => '.current-menu-item',
 				),
 			)
 		);

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -1548,4 +1548,150 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 			$actual_stylesheet
 		);
 	}
+
+	/**
+	 * Tests that a custom (`@`-prefixed) state generates CSS scoped via the
+	 * class declared on the block type's `selectors.states`.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 * @covers ::gutenberg_get_custom_state_suffix
+	 */
+	public function test_custom_state_generates_class_scoped_css() {
+		$this->ensure_block_registered(
+			'core/navigation-link',
+			array(
+				'states' => array(
+					'@current' => '.wp-block-navigation .current-menu-item',
+				),
+			)
+		);
+
+		$block_content = '<li class="wp-block-navigation-item">Item</li>';
+		$style         = array(
+			'@current' => array(
+				'color' => array( 'text' => '#ff0000' ),
+			),
+		);
+		$block         = array(
+			'blockName' => 'core/navigation-link',
+			'attrs'     => array( 'style' => $style ),
+		);
+
+		gutenberg_render_block_states_support( $block_content, $block );
+
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertMatchesRegularExpression(
+			'/\.wp-states-[a-f0-9]{8}\.current-menu-item\{color:#ff0000 !important;\}/',
+			$actual_stylesheet
+		);
+		$this->assertStringNotContainsString( '@current', $actual_stylesheet );
+	}
+
+	/**
+	 * Tests that a custom-state + pseudo-state compound (e.g. `@current` + `:hover`)
+	 * generates a single rule with both selectors combined.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 * @covers ::gutenberg_get_custom_state_css_rules
+	 */
+	public function test_custom_state_compound_with_pseudo_generates_combined_selector() {
+		$this->ensure_block_registered(
+			'core/navigation-link',
+			array(
+				'states' => array(
+					'@current' => '.wp-block-navigation .current-menu-item',
+				),
+			)
+		);
+
+		$block_content = '<li class="wp-block-navigation-item">Item</li>';
+		$style         = array(
+			'@current' => array(
+				'color'  => array( 'text' => '#ff0000' ),
+				':hover' => array( 'color' => array( 'text' => '#0000ff' ) ),
+			),
+		);
+		$block         = array(
+			'blockName' => 'core/navigation-link',
+			'attrs'     => array( 'style' => $style ),
+		);
+
+		gutenberg_render_block_states_support( $block_content, $block );
+
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertMatchesRegularExpression(
+			'/\.wp-states-[a-f0-9]{8}\.current-menu-item\{color:#ff0000 !important;\}/',
+			$actual_stylesheet
+		);
+		$this->assertMatchesRegularExpression(
+			'/\.wp-states-[a-f0-9]{8}\.current-menu-item:hover\{color:#0000ff !important;\}/',
+			$actual_stylesheet
+		);
+	}
+
+	/**
+	 * Tests that a custom-state inside a responsive breakpoint is wrapped in
+	 * the matching media query.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_custom_state_inside_breakpoint_wrapped_in_media_query() {
+		$this->ensure_block_registered(
+			'core/navigation-link',
+			array(
+				'states' => array(
+					'@current' => '.wp-block-navigation .current-menu-item',
+				),
+			)
+		);
+
+		$block_content = '<li class="wp-block-navigation-item">Item</li>';
+		$style         = array(
+			'mobile' => array(
+				'@current' => array(
+					'color' => array( 'text' => '#ff0000' ),
+				),
+			),
+		);
+		$block         = array(
+			'blockName' => 'core/navigation-link',
+			'attrs'     => array( 'style' => $style ),
+		);
+
+		gutenberg_render_block_states_support( $block_content, $block );
+
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertMatchesRegularExpression(
+			'/@media \(width <= 480px\)\{\.wp-states-[a-f0-9]{8}\.current-menu-item\{color:#ff0000 !important;\}\}/',
+			$actual_stylesheet
+		);
+	}
+
+	/**
+	 * Tests that a custom-state on a block that does not declare it is silently
+	 * skipped (no CSS emitted).
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_unrecognized_custom_state_is_skipped() {
+		$this->ensure_block_registered( 'core/navigation-link' );
+
+		$block_content = '<li class="wp-block-navigation-item">Item</li>';
+		$style         = array(
+			'@unknown' => array(
+				'color' => array( 'text' => '#ff0000' ),
+			),
+		);
+		$block         = array(
+			'blockName' => 'core/navigation-link',
+			'attrs'     => array( 'style' => $style ),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $block_content, $actual );
+	}
 }

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -1586,12 +1586,17 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 			'attrs'     => array( 'style' => $style ),
 		);
 
-		gutenberg_render_block_states_support( $block_content, $block );
-
-		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertMatchesRegularExpression(
-			'/\.wp-states-[a-f0-9]{8}\.current-menu-item\{color:#ff0000 !important;\}/',
+			'/^<li class="wp-block-navigation-item wp-states-[a-f0-9]{8}">Item<\/li>$/',
+			$actual
+		);
+		preg_match( '/wp-states-[a-f0-9]{8}/', $actual, $matches );
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertStringContainsString(
+			'.' . $matches[0] . '.current-menu-item{color:#ff0000 !important;}',
 			$actual_stylesheet
 		);
 		$this->assertStringNotContainsString( '@current', $actual_stylesheet );
@@ -1626,16 +1631,17 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 			'attrs'     => array( 'style' => $style ),
 		);
 
-		gutenberg_render_block_states_support( $block_content, $block );
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
 
+		preg_match( '/wp-states-[a-f0-9]{8}/', $actual, $matches );
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
 
-		$this->assertMatchesRegularExpression(
-			'/\.wp-states-[a-f0-9]{8}\.current-menu-item\{color:#ff0000 !important;\}/',
+		$this->assertStringContainsString(
+			'.' . $matches[0] . '.current-menu-item{color:#ff0000 !important;}',
 			$actual_stylesheet
 		);
-		$this->assertMatchesRegularExpression(
-			'/\.wp-states-[a-f0-9]{8}\.current-menu-item:hover\{color:#0000ff !important;\}/',
+		$this->assertStringContainsString(
+			'.' . $matches[0] . '.current-menu-item:hover{color:#0000ff !important;}',
 			$actual_stylesheet
 		);
 	}
@@ -1669,12 +1675,13 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 			'attrs'     => array( 'style' => $style ),
 		);
 
-		gutenberg_render_block_states_support( $block_content, $block );
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
 
+		preg_match( '/wp-states-[a-f0-9]{8}/', $actual, $matches );
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
 
-		$this->assertMatchesRegularExpression(
-			'/@media \(width <= 480px\)\{\.wp-states-[a-f0-9]{8}\.current-menu-item\{color:#ff0000 !important;\}\}/',
+		$this->assertStringContainsString(
+			'@media (width <= 480px){.' . $matches[0] . '.current-menu-item{color:#ff0000 !important;}}',
 			$actual_stylesheet
 		);
 	}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -7573,7 +7573,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
-		$expected   = ':root :where(.wp-block-navigation .current-menu-item){background-color: blue;color: red;}';
+		// The selectors.states[@current] value (".current-menu-item") is composed
+		// onto the block's root selector, producing a same-element class compound.
+		$expected   = ':root :where(.wp-block-navigation-link.current-menu-item){background-color: blue;color: red;}';
 		$this->assertSameCSS( $expected, $stylesheet );
 	}
 
@@ -7611,7 +7613,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = ':root :where(.wp-block-navigation .current-menu-item){background-color: blue;color: red;}:root :where(.wp-block-navigation .current-menu-item:hover){background-color: white;color: blue;}:root :where(.wp-block-navigation .current-menu-item:focus){background-color: yellow;color: green;}';
+		$expected = ':root :where(.wp-block-navigation-link.current-menu-item){background-color: blue;color: red;}:root :where(.wp-block-navigation-link.current-menu-item:hover){background-color: white;color: blue;}:root :where(.wp-block-navigation-link.current-menu-item:focus){background-color: yellow;color: green;}';
 		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
 	}
 

--- a/test/e2e/specs/site-editor/global-styles-custom-states.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-custom-states.spec.js
@@ -1,0 +1,133 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Global Styles - Block custom states', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.beforeEach( async ( { admin, requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+		await requestUtils.deleteAllPages();
+		await requestUtils.deleteAllMenus();
+		// Reset the user-saved global styles so tests are hermetic — the
+		// `wp_global_styles` post persists across runs and would mask the
+		// "Save enabled after change" check on re-runs.
+		const globalStylesId =
+			await requestUtils.getCurrentThemeGlobalStylesPostId();
+		if ( globalStylesId ) {
+			await requestUtils.rest( {
+				method: 'PUT',
+				path: `/wp/v2/global-styles/${ globalStylesId }`,
+				data: { styles: {}, settings: {} },
+			} );
+		}
+		await admin.visitSiteEditor( {
+			postId: 'emptytheme//index',
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.deleteAllPages(),
+			requestUtils.deleteAllMenus(),
+		] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'As a user I can style the @current state for Custom Link in Global Styles and see it applied on the current menu item on the frontend', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		// Configure the @current style via Global Styles.
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Styles' } )
+			.click();
+
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Blocks' } )
+			.click();
+
+		await page
+			.getByRole( 'button', { name: 'Custom Link', exact: true } )
+			.click();
+
+		const stateDropdown = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'States' } );
+
+		await expect( stateDropdown ).toBeVisible();
+
+		await stateDropdown.click();
+
+		await page
+			.getByRole( 'menuitem', { name: 'Current', exact: true } )
+			.click();
+
+		await page.getByRole( 'button', { name: 'Typography' } ).click();
+
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'group', { name: 'Font size' } )
+			.getByRole( 'radio', { name: 'Large', exact: true } )
+			.click();
+
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Save' } )
+			.click();
+
+		await page
+			.getByRole( 'region', { name: 'Editor publish' } )
+			.getByRole( 'button', { name: 'Save', exact: true } )
+			.click();
+
+		await expect(
+			page.getByRole( 'button', { name: 'Dismiss this notice' } )
+		).toBeVisible();
+
+		// Create a page, point a navigation menu's Custom Link at that page,
+		// then put the navigation block in the page itself. Visiting the page
+		// makes its own URL the current request, so WP adds .current-menu-item
+		// to the matching nav item.
+		const { id: pageId, link: pageUrl } = await requestUtils.createPage( {
+			title: 'Custom states test page',
+			status: 'publish',
+		} );
+
+		const { id: menuId } = await requestUtils.createNavigationMenu( {
+			title: 'Custom states test menu',
+			content: `<!-- wp:navigation-link {"label":"Self Link","type":"page","id":${ pageId },"url":"${ pageUrl }","kind":"post-type"} /-->`,
+		} );
+
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/pages/${ pageId }`,
+			data: {
+				content: `<!-- wp:navigation {"ref":${ menuId }} /-->`,
+			},
+		} );
+
+		await page.goto( pageUrl );
+
+		const currentItem = page.locator(
+			'.wp-block-navigation .current-menu-item'
+		);
+		await expect( currentItem ).toBeVisible();
+
+		// The composed Global Styles rule lands on `.wp-block-navigation-link
+		// .current-menu-item` (same-element class compound — talldan's preferred
+		// form from #75736), so the current `<li>` should resolve to the Large
+		// preset's value. WP core's default "Large" preset is 36px.
+		await expect( currentItem ).toHaveCSS( 'font-size', '36px' );
+	} );
+} );


### PR DESCRIPTION

## What?

Closes #38277. Part of #77817.

Adds the `@current` state to Block Style States so a user can style the active menu item for `core/navigation-link`, in the block inspector and in Global Styles. Third state axis after pseudo (#76491) and responsive (#78384), and the first **custom** (class-based) state to ship.

## Why?

Until now, theming the current menu item meant hand-writing theme.json or custom CSS. `@current` is the canonical use case for a class-based state, WordPress applies `.current-menu-item` at render time when a link's URL matches the request.

## How?

- `selectors.states["@current"]` on `navigation-link/block.json` is a **class fragment** (`.current-menu-item`), not a full selector. Both consumers compose it under the block's root selector via `append_to_selector()`.
- Adds an "Item" group to the State dropdown alongside Viewport and Pseudo state; wires the new field end-to-end through the store, path-builder, block inspector, and Global Styles screen.
- Extracts `StateMenuGroup` so the three dropdown groups share one source of truth.

## Selector shape (kept-on-purpose tradeoff, #75736)

The team split on `@current`'s CSS shape: @scruffian preferred the broad `.wp-block-navigation .current-menu-item`; @talldan preferred the narrow `.wp-block-navigation-link.current-menu-item`. This PR lands on talldan's form. Side effect: the Global Styles output shape for `@current` changes. Needs Dev Note.

## Not in this PR

- **Nav Link color/border/spacing supports** — separate branch `add/nav-link-style-supports`. Until that lands, only typography is visible under `@current` in the block inspector. Global Styles is unaffected (it exposes the full panel).
- **JSON schema docs** for `selectors.states` — follow-up.
- **Public `block.json` opt-in** for third-party blocks — still deferred per #78088.

## Testing Instructions

1. Open the site editor → **Styles → Blocks → Custom Link**.
2. Open the **States** dropdown in the header → **Item → Current**.
3. Set any supported style (e.g. Typography → Font size → Large).
4. Save Global Styles.
5. Publish a Page with a Navigation block whose Custom Link points to the Page itself; visit the Page. The current menu item renders the styled rule.

## Screenshots

States dropdown on Global Styles:

<img width="1280" height="720" alt="01-global-styles-state-dropdown" src="https://github.com/user-attachments/assets/c19a8ee6-97ee-48f8-938a-323b35df59eb" />
<img width="1280" height="720" alt="02-global-styles-current-selected" src="https://github.com/user-attachments/assets/bf54e1d2-5294-44ec-b457-4d9bb675189f" />
<img width="1280" height="720" alt="03-global-styles-typography-set" src="https://github.com/user-attachments/assets/873c5543-4f0b-4117-b4c6-c8b62dba7b40" />

Frontend:

<img width="1280" height="720" alt="04-frontend-current-menu-item" src="https://github.com/user-attachments/assets/d0f24a0d-c0f5-4e50-9bbe-b61cc7c65f01" />


## Use of AI Tools

Authored with Claude Code (Opus 4.7). All output reviewed and validated by the author.



