### PR TITLE
Shortcode block: Fix editor crash when selecting transform menu

### DIFF
--- a/packages/block-library/src/shortcode/transforms.js
+++ b/packages/block-library/src/shortcode/transforms.js
@@ -53,12 +53,12 @@ const transforms = {
 		return getShortcodeFromTransforms().map( ( fromTransform ) => ( {
 			type: 'block',
 			blocks: [ fromTransform.blockName ],
-			isMatch: ( { text } ) => {
+			isMatch: ( { text = '' } ) => {
 				return []
 					.concat( fromTransform.tag )
 					.some( ( tag ) => isSingleShortcode( text, tag ) );
 			},
-			transform: ( { text } ) => {
+			transform: ( { text = '' } ) => {
 				return rawHandler( { HTML: `<p>${ text.trim() }</p>` } );
 			},
 		} ) );


### PR DESCRIPTION
## What?
If a user inserts a shortcode block and then without typing anything selects the transform menu, it causes an editor crash.

## Why?
Some code in the shortcode transform handling tries to execute `text.trim()` when `text` is `undefined`. It looks like this is recent, from #77944.

## How?
Fixed by defaulting the string to an empty param.

## Testing Instructions
1. Insert a shortcode block
2. Without typing any text, select the block transform menu

Expected: The menu opens
In trunk: The editor crashes

## Use of AI Tools
None, fixed it the ol' fashioned way