### PR TITLE
Fix cross-block text selection delete across nested blocks

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -362,9 +362,17 @@ export default function useSelectionObserver() {
 					];
 					const depth = findDepth( startPath, endPath );
 
+					// One block is an ancestor of the other. Treat as a
+					// rich-text selection across the nesting boundary
+					// instead of promoting to a block-level multiSelect.
+					const isAncestorDescendant =
+						endPath.slice( 0, -1 ).includes( startClientId ) ||
+						startPath.slice( 0, -1 ).includes( endClientId );
+
 					if (
-						startPath[ depth ] !== startClientId ||
-						endPath[ depth ] !== endClientId
+						! isAncestorDescendant &&
+						( startPath[ depth ] !== startClientId ||
+							endPath[ depth ] !== endClientId )
 					) {
 						multiSelect( startPath[ depth ], endPath[ depth ] );
 						return;

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -713,35 +713,53 @@ export const __unstableDeleteSelection =
 			return false;
 		}
 
-		const anchorRootClientId = select.getBlockRootClientId(
+		// Determine document order. Cross-parent selections are allowed
+		// when one block is an ancestor of the other; the descendant
+		// chain between them is cascade-removed by `replaceBlocks`.
+		const anchorParents = select.getBlockParents(
 			selectionAnchor.clientId
 		);
-		const focusRootClientId = select.getBlockRootClientId(
-			selectionFocus.clientId
-		);
+		const focusParents = select.getBlockParents( selectionFocus.clientId );
+		const sameParent =
+			select.getBlockRootClientId( selectionAnchor.clientId ) ===
+			select.getBlockRootClientId( selectionFocus.clientId );
 
-		// It's not mergeable if the selection doesn't start and end in the same
-		// block list. Maybe in the future it should be allowed.
-		if ( anchorRootClientId !== focusRootClientId ) {
-			return;
-		}
-
-		const blockOrder = select.getBlockOrder( anchorRootClientId );
-		const anchorIndex = blockOrder.indexOf( selectionAnchor.clientId );
-		const focusIndex = blockOrder.indexOf( selectionFocus.clientId );
-
-		// Reassign selection start and end based on order.
 		let selectionStart, selectionEnd;
-
-		if ( anchorIndex > focusIndex ) {
+		if ( sameParent ) {
+			const blockOrder = select.getBlockOrder(
+				select.getBlockRootClientId( selectionAnchor.clientId )
+			);
+			if (
+				blockOrder.indexOf( selectionAnchor.clientId ) >
+				blockOrder.indexOf( selectionFocus.clientId )
+			) {
+				selectionStart = selectionFocus;
+				selectionEnd = selectionAnchor;
+			} else {
+				selectionStart = selectionAnchor;
+				selectionEnd = selectionFocus;
+			}
+		} else if ( focusParents.includes( selectionAnchor.clientId ) ) {
+			selectionStart = selectionAnchor;
+			selectionEnd = selectionFocus;
+		} else if ( anchorParents.includes( selectionFocus.clientId ) ) {
 			selectionStart = selectionFocus;
 			selectionEnd = selectionAnchor;
 		} else {
-			selectionStart = selectionAnchor;
-			selectionEnd = selectionFocus;
+			// Cross-parent without an ancestor relationship is not yet
+			// supported here.
+			return;
 		}
 
-		const targetSelection = isForward ? selectionEnd : selectionStart;
+		// For an ancestor/descendant selection the ancestor is always
+		// `selectionStart` in document order, and the merged content
+		// must land there (with the descendant chain removed) no matter
+		// which key was pressed. Forward delete would otherwise target
+		// the descendant and orphan the ancestor, so force a
+		// backward-style merge whenever the endpoints aren't siblings.
+		const isForwardMerge = isForward && sameParent;
+
+		const targetSelection = isForwardMerge ? selectionEnd : selectionStart;
 		const targetBlock = select.getBlock( targetSelection.clientId );
 		const targetBlockType = getBlockType( targetBlock.name );
 
@@ -772,7 +790,7 @@ export const __unstableDeleteSelection =
 			[ selectionB.attributeKey ]: toHTMLString( { value: valueB } ),
 		} );
 
-		const followingBlock = isForward ? cloneA : cloneB;
+		const followingBlock = isForwardMerge ? cloneA : cloneB;
 
 		// We can only merge blocks with similar types
 		// thus, we transform the block to merge first
@@ -788,7 +806,7 @@ export const __unstableDeleteSelection =
 
 		let updatedAttributes;
 
-		if ( isForward ) {
+		if ( isForwardMerge ) {
 			const blockToMerge = blocksWithTheSameType.pop();
 			updatedAttributes = targetBlockType.merge(
 				blockToMerge.attributes,
@@ -812,9 +830,20 @@ export const __unstableDeleteSelection =
 
 		updatedAttributes[ newAttributeKey ] = newHtml;
 
-		const selectedBlockClientIds = select.getSelectedBlockClientIds();
+		// When one endpoint is a descendant of the other,
+		// `getSelectedBlockClientIds` can't map the range (the endpoints
+		// share no block list), so replace the ancestor; its subtree,
+		// which contains the whole selection, is cascade-removed.
+		const otherBlock = targetBlock === blockA ? blockB : blockA;
+		const targetIsAncestor = select
+			.getBlockParents( otherBlock.clientId )
+			.includes( targetBlock.clientId );
+
+		const selectedBlockClientIds = targetIsAncestor
+			? [ targetBlock.clientId ]
+			: select.getSelectedBlockClientIds();
 		const replacement = [
-			...( isForward ? blocksWithTheSameType : [] ),
+			...( isForwardMerge ? blocksWithTheSameType : [] ),
 			{
 				// Preserve the original client ID.
 				...targetBlock,
@@ -822,10 +851,12 @@ export const __unstableDeleteSelection =
 					...targetBlock.attributes,
 					...updatedAttributes,
 				},
-				// Block A's inner blocks sit inside the selection; only B's survive.
+				// Block A's inner blocks sit inside the selection; only B's
+				// survive. This also holds when A is B's ancestor: B ends
+				// the selection, so B's own children come after it.
 				innerBlocks: blockB.innerBlocks,
 			},
-			...( isForward ? [] : blocksWithTheSameType ),
+			...( isForwardMerge ? [] : blocksWithTheSameType ),
 		];
 
 		registry.batch( () => {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1052,6 +1052,41 @@ export function __unstableSelectionHasUnmergeableBlock( state ) {
 }
 
 /**
+ * Compare two block client IDs in document order.
+ *
+ * Returns `true` when `a` appears before `b`, `false` when after, or `null`
+ * when the order can't be determined (e.g. the blocks are in unrelated
+ * subtrees that don't share a comparable common ancestor).
+ *
+ * @param {Object} state Editor state.
+ * @param {string} a     A client ID.
+ * @param {string} b     Another client ID.
+ * @return {?boolean} Whether `a` is before `b`, or null if undeterminable.
+ */
+function isClientIdBefore( state, a, b ) {
+	if ( a === b ) {
+		return false;
+	}
+	// Same parent: simple index comparison.
+	const aParent = getBlockRootClientId( state, a );
+	const bParent = getBlockRootClientId( state, b );
+	if ( aParent === bParent ) {
+		const order = getBlockOrder( state, aParent );
+		return order.indexOf( a ) < order.indexOf( b );
+	}
+	// Ancestor/descendant: ancestor comes first in document order.
+	const bParents = getBlockParents( state, b );
+	if ( bParents.includes( a ) ) {
+		return true;
+	}
+	const aParents = getBlockParents( state, a );
+	if ( aParents.includes( b ) ) {
+		return false;
+	}
+	return null;
+}
+
+/**
  * Check whether the selection is mergeable.
  *
  * @param {Object}  state     Editor state.
@@ -1078,35 +1113,20 @@ export function __unstableIsSelectionMergeable( state, isForward ) {
 		return false;
 	}
 
-	const anchorRootClientId = getBlockRootClientId(
+	// Determine document order. Cross-parent selections are allowed as long
+	// as the two endpoints have a determinable order (same parent, or one
+	// is an ancestor of the other).
+	const anchorBeforeFocus = isClientIdBefore(
 		state,
-		selectionAnchor.clientId
-	);
-	const focusRootClientId = getBlockRootClientId(
-		state,
+		selectionAnchor.clientId,
 		selectionFocus.clientId
 	);
-
-	// It's not mergeable if the selection doesn't start and end in the same
-	// block list. Maybe in the future it should be allowed.
-	if ( anchorRootClientId !== focusRootClientId ) {
+	if ( anchorBeforeFocus === null ) {
 		return false;
 	}
 
-	const blockOrder = getBlockOrder( state, anchorRootClientId );
-	const anchorIndex = blockOrder.indexOf( selectionAnchor.clientId );
-	const focusIndex = blockOrder.indexOf( selectionFocus.clientId );
-
-	// Reassign selection start and end based on order.
-	let selectionStart, selectionEnd;
-
-	if ( anchorIndex > focusIndex ) {
-		selectionStart = selectionFocus;
-		selectionEnd = selectionAnchor;
-	} else {
-		selectionStart = selectionAnchor;
-		selectionEnd = selectionFocus;
-	}
+	const selectionStart = anchorBeforeFocus ? selectionAnchor : selectionFocus;
+	const selectionEnd = anchorBeforeFocus ? selectionFocus : selectionAnchor;
 
 	const targetBlockClientId = isForward
 		? selectionEnd.clientId

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1738,6 +1738,219 @@ test.describe( 'List (@firefox)', () => {
 		}
 	} );
 
+	test( 'should delete text selected across a nested list item with Backspace', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( '* ab' );
+		await page.keyboard.press( 'Enter' );
+		// Leading space at the start of an empty list item triggers indent.
+		await page.keyboard.type( ' cd' );
+
+		// Verify setup: list[outer "ab"[list[inner "cd"]]], caret at end of "cd".
+		await page.keyboard.type( '‸' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'ab' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'cd‸' },
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		] );
+		await page.keyboard.press( 'Backspace' );
+
+		// Caret at offset 2 of "cd". Move to offset 1 (middle).
+		await page.keyboard.press( 'ArrowLeft' );
+
+		// Extend selection backward to offset 1 (middle) of "ab", then
+		// yield to an idle callback so the multi-block selection can
+		// catch up before deleting.
+		await pageUtils.pressKeys( 'shift+ArrowLeft', { times: 3 } );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+
+		await page.keyboard.press( 'Backspace' );
+
+		// Expected: the selected range across both items is removed
+		// and the remaining content is merged. Caret lands at the
+		// merge boundary.
+		await page.keyboard.type( '‸' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'a‸d' },
+					},
+				],
+			},
+		] );
+	} );
+
+	test( 'should delete text selected across a nested list item with Delete', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( '* ab' );
+		await page.keyboard.press( 'Enter' );
+		// Leading space at the start of an empty list item triggers indent.
+		await page.keyboard.type( ' cd' );
+
+		// Verify setup: list[outer "ab"[list[inner "cd"]]], caret at end of "cd".
+		await page.keyboard.type( '‸' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'ab' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'cd‸' },
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		] );
+		await page.keyboard.press( 'Backspace' );
+
+		// Caret at offset 2 of "cd". Move to offset 1 (middle).
+		await page.keyboard.press( 'ArrowLeft' );
+
+		// Extend selection backward to offset 1 (middle) of "ab", then
+		// yield to an idle callback so the multi-block selection can
+		// catch up before deleting.
+		await pageUtils.pressKeys( 'shift+ArrowLeft', { times: 3 } );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+
+		await page.keyboard.press( 'Delete' );
+
+		// Expected: forward delete of the same range produces the same
+		// merged result as Backspace.
+		await page.keyboard.type( '‸' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'a‸d' },
+					},
+				],
+			},
+		] );
+	} );
+
+	test( 'should delete text selected from level 3 to level 1 with Backspace', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( '* ab' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( ' cd' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( ' ef' );
+
+		// Verify setup: three-level nesting, caret at end of "ef".
+		await page.keyboard.type( '‸' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'ab' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'cd' },
+										innerBlocks: [
+											{
+												name: 'core/list',
+												innerBlocks: [
+													{
+														name: 'core/list-item',
+														attributes: {
+															content: 'ef‸',
+														},
+													},
+												],
+											},
+										],
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		] );
+		await page.keyboard.press( 'Backspace' );
+
+		// Caret at offset 2 of "ef". Move to offset 1 (middle).
+		await page.keyboard.press( 'ArrowLeft' );
+
+		// Extend selection back to offset 1 (middle) of "ab", then yield
+		// to an idle callback so the multi-block selection can catch up
+		// before deleting.
+		await pageUtils.pressKeys( 'shift+ArrowLeft', { times: 6 } );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+
+		await page.keyboard.press( 'Backspace' );
+
+		// Expected: the entire nested chain collapses; "a" from level 1
+		// and "f" from level 3 are merged into a single outer-level item.
+		await page.keyboard.type( '‸' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'a‸f' },
+					},
+				],
+			},
+		] );
+	} );
+
 	test( 'should merge a following paragraph into the outermost list with Delete from a nested item (#77245)', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What?
Closes #76233.

Backspace or Delete on a text selection that spans a nested list item (e.g. from the middle of an outer item to the middle of its own nested item) now deletes the selected range and merges the remaining content, instead of silently doing nothing.

## Why?
The selection observer promoted ancestor/descendant selections to a block-level multi-selection, and the store's merge/delete paths bailed on any selection that did not start and end in the same block list.

## How?
1. **`use-selection-observer.js`:** detect when one selection endpoint is an ancestor of the other and dispatch a rich-text `selectionChange` instead of promoting to `multiSelect`.
2. **`__unstableIsSelectionMergeable`:** drop the same-parent gate; determine document order via parent-chain comparison.
3. **`__unstableDeleteSelection`:** support ancestor/descendant endpoints; the merged content always lands in the ancestor (also for forward Delete, which previously targeted the descendant).

## Notes
- Rebased onto trunk as a single commit (pre-rebase history preserved locally). #78776 landed the sibling-item half of this; the merged block now keeps the selection-end block's inner blocks, matching that PR's behavior, so the descendant's own children survive the merge.
- Known remaining gap (follow-up): unselected following siblings of the selection-end block inside intermediate containers are still dropped (e.g. in `ab[ul[cd, xy]]`, selecting from mid-"ab" to mid-"cd" also removes "xy").
- A conservative alternative for the WP 7.1 cycle (fall back to selecting the ancestor block instead of partially merging) is proposed separately; this PR remains the full cross-level merge.

## Testing Instructions
1. Create a list item "ab" with a nested item "cd".
2. Select from the middle of "ab" to the middle of "cd".
3. Press Backspace (or Delete).
4. Expect a single list item "ad" with the caret at the merge boundary.

Covered by three e2e tests in `list.spec.js` (2-level Backspace, 3-level Backspace, 2-level Delete).

## Use of AI Tools
Authored with Claude Code under direction and review.