### PR TITLE
Global Styles: Fix CSS not applying to Custom CSS textarea in Advanced panel

### DIFF
--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -85,7 +85,11 @@ export default function AdvancedPanel( {
 	}
 
 	return (
-		<Stack direction="column" gap="md">
+		<Stack
+			direction="column"
+			gap="md"
+			className="block-editor-global-styles-advanced-panel"
+		>
 			{ cssError && (
 				<Notice status="error" onRemove={ () => setCSSError( null ) }>
 					{ cssError }

--- a/packages/global-styles-ui/src/style.scss
+++ b/packages/global-styles-ui/src/style.scss
@@ -205,9 +205,6 @@
 
 		textarea {
 			flex: 1 1 auto;
-			// CSS input is always LTR regardless of language.
-			/*rtl:ignore*/
-			direction: ltr;
 		}
 	}
 }

--- a/packages/global-styles-ui/src/style.scss
+++ b/packages/global-styles-ui/src/style.scss
@@ -188,27 +188,26 @@
 	flex-direction: column;
 	margin: 16px;
 
-	.components-v-stack {
+	.block-editor-global-styles-advanced-panel {
 		flex: 1 1 auto;
+	}
 
-		.block-editor-global-styles-advanced-panel__custom-css-input {
+	.block-editor-global-styles-advanced-panel__custom-css-input {
+		flex: 1 1 auto;
+		display: flex;
+		flex-direction: column;
+
+		.components-base-control__field {
 			flex: 1 1 auto;
 			display: flex;
 			flex-direction: column;
+		}
 
-			.components-base-control__field {
-				flex: 1 1 auto;
-				display: flex;
-				flex-direction: column;
-
-				.components-textarea-control__input {
-					flex: 1 1 auto;
-					// CSS input is always LTR regardless of language.
-
-					/*rtl:ignore*/
-					direction: ltr;
-				}
-			}
+		textarea {
+			flex: 1 1 auto;
+			// CSS input is always LTR regardless of language.
+			/*rtl:ignore*/
+			direction: ltr;
 		}
 	}
 }


### PR DESCRIPTION
## What?

Follow up to #78682.

Restores the styles that stretch the Custom CSS textarea in the Global Styles Advanced panel to fill the available space.

## Why?

#78682 migrated the Advanced panel wrapper to the `Stack` component. The existing CSS targeted `.components-v-stack` to size the textarea, but that selector is no longer unique to this panel, so the styles stopped applying and the textarea collapsed.

## How?

Add a dedicated `block-editor-global-styles-advanced-panel` class to the `Stack` and scope the styles to it. Furthermore, avoid using the `.components-` prefix as a CSS selector as much as possible.

## Testing Instructions

1. Open the Site Editor and open Styles → Additional CSS (Advanced).
2. Confirm the Custom CSS textarea stretches to fill the available height of the panel.

## Screenshots or screencast

| Before | After |
|--------|--------|
| <img width="716" height="742" alt="image" src="https://github.com/user-attachments/assets/81c83521-94e0-4fb6-adf3-e640a15da394" /> | <img width="709" height="746" alt="image" src="https://github.com/user-attachments/assets/6702adb6-9145-4e64-b221-631958d064eb" /> |

## Use of AI Tools

Claude Code was used to assist with drafting the commit message and PR description. All code changes were authored and reviewed by the contributor.
