### PR TITLE
Scripts: Use require.resolve for SVG webpack loaders to fix pnpm compatibility

### DIFF
--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -1,17 +1,17 @@
 /**
  * External dependencies
  */
+const { basename, dirname, relative, resolve, sep } = require( 'path' );
+const { realpathSync } = require( 'fs' );
+const { exec } = require( 'child_process' );
 const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const webpack = require( 'webpack' );
 const browserslist = require( 'browserslist' );
 const MiniCSSExtractPlugin = require( 'mini-css-extract-plugin' );
-const { basename, dirname, relative, resolve, sep } = require( 'path' );
 const ReactRefreshWebpackPlugin = require( '@pmmmwh/react-refresh-webpack-plugin' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
-const { realpathSync } = require( 'fs' );
 const { sync: glob } = require( 'fast-glob' );
-const { exec } = require( 'child_process' );
 
 /**
  * WordPress dependencies
@@ -220,7 +220,10 @@ const baseConfig = {
 			{
 				test: /\.svg$/,
 				issuer: /\.(j|t)sx?$/,
-				use: [ '@svgr/webpack', 'url-loader' ],
+				use: [
+					require.resolve( '@svgr/webpack' ),
+					require.resolve( 'url-loader' ),
+				],
 				type: 'javascript/auto',
 			},
 			{


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/78750

Use `require.resolve()` for SVG webpack loaders to fix pnpm compatibility. Props to @t-hamano for the diagnosis.

## Why?

pnpm doesn't hoist transitive dependencies. 

Bare strings `'@svgr/webpack'` and `'url-loader'` make webpack search the project root's `node_modules`, which fails. 

Every other loader already uses `require.resolve()`.

## How?

```js
// Before
use: [ '@svgr/webpack', 'url-loader' ],
// After
use: [ require.resolve( '@svgr/webpack' ), require.resolve( 'url-loader' ) ],
```

`require.resolve()` returns absolute paths from the config file's location inside `@wordpress/scripts`, bypassing pnpm's non-hoisted structure.

## Testing Instructions

1. Create a pnpm project, add `@wordpress/scripts` and `react`.
2. Create a block with `src/my-block/explode.svg` and import it:
   ```js
   import { ReactComponent as Explode } from './explode.svg';
   ```
3. Run `npx wp-scripts build`: should compile without `url-loader` resolution errors.

