### PR TITLE
Block Visibility: Keep hide-everywhere working after a block opts out of visibility support

### DIFF
--- a/backport-changelog/7.1/12053.md
+++ b/backport-changelog/7.1/12053.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12053
+
+* https://github.com/WordPress/gutenberg/pull/78780

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -15,14 +15,22 @@
 function gutenberg_render_block_visibility_support( $block_content, $block ) {
 	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 
-	if ( ! $block_type || ! block_has_support( $block_type, 'visibility', true ) ) {
+	if ( ! $block_type ) {
 		return $block_content;
 	}
 
 	$block_visibility = $block['attrs']['metadata']['blockVisibility'] ?? null;
 
+	// Hide the block whenever the value is boolean false, regardless of the
+	// block's current visibility support. This prevents blocks that previously
+	// supported visibility from unintentionally appearing on the front end
+	// after their support was disabled.
 	if ( false === $block_visibility ) {
 		return '';
+	}
+
+	if ( ! block_has_support( $block_type, 'visibility', true ) ) {
+		return $block_content;
 	}
 
 	if ( is_array( $block_visibility ) && ! empty( $block_visibility ) ) {

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -93,7 +93,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$this->assertSame( '', $result, 'Block content should be empty when blockVisibility is false and support is opted in.' );
 	}
 
-	public function test_block_visibility_support_shows_block_when_support_not_opted_in() {
+	public function test_block_visibility_support_hides_block_when_visibility_false_even_without_support() {
 		$this->register_visibility_block_with_support(
 			'test/visibility-block',
 			array( 'visibility' => false )
@@ -111,7 +111,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 
 		$result = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when blockVisibility support is not opted in.' );
+		$this->assertSame( '', $result, 'Block content should be empty when blockVisibility is false, even without visibility support.' );
 	}
 
 	public function test_block_visibility_support_no_visibility_attribute() {


### PR DESCRIPTION
## What?
Closes #78701

Honor `metadata.blockVisibility: false` on the front end even after a block opts out of `visibility` block support, so HTML and Shortcode blocks saved while their support was enabled stay hidden.

## Why?

Visibility support was disabled for the Shortcode block and the HTML block in #76138. This caused an unintended display of content on the front end.

## How?

When metadata.visibility is false, block rendering is always prevented on the frontend.

As another issue, custom HTML blocks and shortcode blocks with `metadata.visibility` set to `false` lack a UI in the editor to make them visible again. Users must delete these blocks once. It might be possible to adjust the visibility UI display logic in the editor, but this seems a bit complex, so this PR focuses solely on frontend fixes.

## Testing Instructions

Input the following code using the  code editor:

```html
<!-- wp:html {"metadata":{"blockVisibility":false}} -->
This HTML should not be displayed on the frontend.
<!-- /wp:html -->

<!-- wp:shortcode {"metadata":{"blockVisibility":false}} -->
[shortcode]
<!-- /wp:shortcode -->
```

The content should not be displayed on the front end.

## Use of AI Tools
Drafted with Claude Code (Opus 4.7). All output reviewed and validated by the author.
