### PR TITLE
Abilities: Add validation tests pinning behavior for WP-specific schema keywords

### DIFF
--- a/packages/abilities/src/tests/validation.test.ts
+++ b/packages/abilities/src/tests/validation.test.ts
@@ -531,11 +531,52 @@ describe( 'validateValueFromSchema', () => {
 	} );
 
 	describe( 'WordPress-specific schema keywords', () => {
-		// AJV's strict mode rejects keywords it doesn't recognize at
-		// compile time, so any WordPress-specific keyword leaking into a
-		// client schema fails the whole validation rather than being
-		// ignored.
-		it( 'should fail compilation when schema contains sanitize_callback', () => {
+		// All of these keywords are valid on WordPress REST API schemas
+		// (sanitize_callback / validate_callback / arg_options from
+		// register_meta and route args, context / readonly from REST
+		// response shaping, example / examples from OpenAPI-style docs,
+		// and boolean `required` from per-arg flags) but are not part of
+		// JSON Schema draft-04. AJV rejects them at compile time (either
+		// strict mode or meta-schema), so the catch block surfaces a
+		// generic "Invalid schema" error rather than ignoring them.
+		it.each( [
+			[ 'sanitize_callback', 'sanitize_text_field' ],
+			[ 'validate_callback', 'rest_validate_request_arg' ],
+			[ 'arg_options', { sanitize_callback: 'sanitize_key' } ],
+			[ 'example', 'an example value' ],
+			[ 'examples', [ 'first', 'second' ] ],
+			[ 'context', [ 'view', 'edit', 'embed' ] ],
+			[ 'readonly', true ],
+			[ 'required', true ],
+		] )(
+			'should fail compilation when a property uses `%s`',
+			( keyword, value ) => {
+				const schema = {
+					type: 'object',
+					properties: {
+						name: {
+							type: 'string',
+							[ keyword ]: value,
+						},
+					},
+				};
+				const consoleErrorSpy = jest
+					.spyOn( console, 'error' )
+					.mockImplementation();
+
+				expect(
+					validateValueFromSchema( { name: 'hello' }, schema )
+				).toBe( 'Invalid schema provided for validation.' );
+				expect( consoleErrorSpy ).toHaveBeenCalledWith(
+					'Schema compilation error:',
+					expect.any( Error )
+				);
+
+				consoleErrorSpy.mockRestore();
+			}
+		);
+
+		it( 'should fail compilation when a WP-specific keyword sits at the top level of the schema', () => {
 			const schema = {
 				type: 'string',
 				sanitize_callback: 'sanitize_text_field',
@@ -545,216 +586,6 @@ describe( 'validateValueFromSchema', () => {
 				.mockImplementation();
 
 			expect( validateValueFromSchema( 'hello', schema ) ).toBe(
-				'Invalid schema provided for validation.'
-			);
-			expect( consoleErrorSpy ).toHaveBeenCalledWith(
-				'Schema compilation error:',
-				expect.any( Error )
-			);
-
-			consoleErrorSpy.mockRestore();
-		} );
-
-		it( 'should fail compilation when schema contains validate_callback', () => {
-			const schema = {
-				type: 'string',
-				validate_callback: 'rest_validate_request_arg',
-			};
-			const consoleErrorSpy = jest
-				.spyOn( console, 'error' )
-				.mockImplementation();
-
-			expect( validateValueFromSchema( 'hello', schema ) ).toBe(
-				'Invalid schema provided for validation.'
-			);
-			expect( consoleErrorSpy ).toHaveBeenCalledWith(
-				'Schema compilation error:',
-				expect.any( Error )
-			);
-
-			consoleErrorSpy.mockRestore();
-		} );
-
-		it( 'should fail compilation when schema contains arg_options', () => {
-			const schema = {
-				type: 'string',
-				arg_options: { sanitize_callback: 'sanitize_key' },
-			};
-			const consoleErrorSpy = jest
-				.spyOn( console, 'error' )
-				.mockImplementation();
-
-			expect( validateValueFromSchema( 'hello', schema ) ).toBe(
-				'Invalid schema provided for validation.'
-			);
-			expect( consoleErrorSpy ).toHaveBeenCalledWith(
-				'Schema compilation error:',
-				expect.any( Error )
-			);
-
-			consoleErrorSpy.mockRestore();
-		} );
-
-		it( 'should fail compilation when a nested property uses sanitize_callback', () => {
-			const schema = {
-				type: 'object',
-				properties: {
-					name: {
-						type: 'string',
-						sanitize_callback: 'sanitize_text_field',
-					},
-				},
-			};
-			const consoleErrorSpy = jest
-				.spyOn( console, 'error' )
-				.mockImplementation();
-
-			expect( validateValueFromSchema( { name: 'hello' }, schema ) ).toBe(
-				'Invalid schema provided for validation.'
-			);
-			expect( consoleErrorSpy ).toHaveBeenCalledWith(
-				'Schema compilation error:',
-				expect.any( Error )
-			);
-
-			consoleErrorSpy.mockRestore();
-		} );
-
-		// `example` (OpenAPI / WordPress REST docs) and `examples`
-		// (JSON Schema draft-06+) are not part of draft-04.
-		it( 'should fail compilation when schema contains `example`', () => {
-			const schema = {
-				type: 'string',
-				example: 'an example value',
-			};
-			const consoleErrorSpy = jest
-				.spyOn( console, 'error' )
-				.mockImplementation();
-
-			expect( validateValueFromSchema( 'hello', schema ) ).toBe(
-				'Invalid schema provided for validation.'
-			);
-			expect( consoleErrorSpy ).toHaveBeenCalledWith(
-				'Schema compilation error:',
-				expect.any( Error )
-			);
-
-			consoleErrorSpy.mockRestore();
-		} );
-
-		it( 'should fail compilation when schema contains `examples`', () => {
-			const schema = {
-				type: 'string',
-				examples: [ 'first', 'second' ],
-			};
-			const consoleErrorSpy = jest
-				.spyOn( console, 'error' )
-				.mockImplementation();
-
-			expect( validateValueFromSchema( 'hello', schema ) ).toBe(
-				'Invalid schema provided for validation.'
-			);
-			expect( consoleErrorSpy ).toHaveBeenCalledWith(
-				'Schema compilation error:',
-				expect.any( Error )
-			);
-
-			consoleErrorSpy.mockRestore();
-		} );
-
-		// WordPress REST argument definitions mark a per-arg `required`
-		// flag as a boolean, whereas JSON Schema expects `required` to be
-		// an array of property names on the parent object.
-		it( 'should fail compilation when `required` is a boolean', () => {
-			const schema = {
-				type: 'string',
-				required: true,
-			};
-			const consoleErrorSpy = jest
-				.spyOn( console, 'error' )
-				.mockImplementation();
-
-			expect( validateValueFromSchema( 'hello', schema ) ).toBe(
-				'Invalid schema provided for validation.'
-			);
-			expect( consoleErrorSpy ).toHaveBeenCalledWith(
-				'Schema compilation error:',
-				expect.any( Error )
-			);
-
-			consoleErrorSpy.mockRestore();
-		} );
-
-		it( 'should fail compilation when a nested property has `required: true`', () => {
-			const schema = {
-				type: 'object',
-				properties: {
-					name: {
-						type: 'string',
-						required: true,
-					},
-				},
-			};
-			const consoleErrorSpy = jest
-				.spyOn( console, 'error' )
-				.mockImplementation();
-
-			expect( validateValueFromSchema( { name: 'hello' }, schema ) ).toBe(
-				'Invalid schema provided for validation.'
-			);
-			expect( consoleErrorSpy ).toHaveBeenCalledWith(
-				'Schema compilation error:',
-				expect.any( Error )
-			);
-
-			consoleErrorSpy.mockRestore();
-		} );
-
-		// `context` (e.g. `[ 'view', 'edit', 'embed' ]`) controls when a
-		// field is returned by the REST API and is the most common
-		// WP-only keyword on response schemas.
-		it( 'should fail compilation when a property uses `context`', () => {
-			const schema = {
-				type: 'object',
-				properties: {
-					name: {
-						type: 'string',
-						context: [ 'view', 'edit', 'embed' ],
-					},
-				},
-			};
-			const consoleErrorSpy = jest
-				.spyOn( console, 'error' )
-				.mockImplementation();
-
-			expect( validateValueFromSchema( { name: 'hello' }, schema ) ).toBe(
-				'Invalid schema provided for validation.'
-			);
-			expect( consoleErrorSpy ).toHaveBeenCalledWith(
-				'Schema compilation error:',
-				expect.any( Error )
-			);
-
-			consoleErrorSpy.mockRestore();
-		} );
-
-		// `readonly` (lowercase) marks server-computed fields and is
-		// common on output schemas.
-		it( 'should fail compilation when a property uses `readonly`', () => {
-			const schema = {
-				type: 'object',
-				properties: {
-					id: {
-						type: 'integer',
-						readonly: true,
-					},
-				},
-			};
-			const consoleErrorSpy = jest
-				.spyOn( console, 'error' )
-				.mockImplementation();
-
-			expect( validateValueFromSchema( { id: 1 }, schema ) ).toBe(
 				'Invalid schema provided for validation.'
 			);
 			expect( consoleErrorSpy ).toHaveBeenCalledWith(

--- a/packages/abilities/src/tests/validation.test.ts
+++ b/packages/abilities/src/tests/validation.test.ts
@@ -709,5 +709,60 @@ describe( 'validateValueFromSchema', () => {
 
 			consoleErrorSpy.mockRestore();
 		} );
+
+		// `context` (e.g. `[ 'view', 'edit', 'embed' ]`) controls when a
+		// field is returned by the REST API and is the most common
+		// WP-only keyword on response schemas.
+		it( 'should fail compilation when a property uses `context`', () => {
+			const schema = {
+				type: 'object',
+				properties: {
+					name: {
+						type: 'string',
+						context: [ 'view', 'edit', 'embed' ],
+					},
+				},
+			};
+			const consoleErrorSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation();
+
+			expect( validateValueFromSchema( { name: 'hello' }, schema ) ).toBe(
+				'Invalid schema provided for validation.'
+			);
+			expect( consoleErrorSpy ).toHaveBeenCalledWith(
+				'Schema compilation error:',
+				expect.any( Error )
+			);
+
+			consoleErrorSpy.mockRestore();
+		} );
+
+		// `readonly` (lowercase) marks server-computed fields and is
+		// common on output schemas.
+		it( 'should fail compilation when a property uses `readonly`', () => {
+			const schema = {
+				type: 'object',
+				properties: {
+					id: {
+						type: 'integer',
+						readonly: true,
+					},
+				},
+			};
+			const consoleErrorSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation();
+
+			expect( validateValueFromSchema( { id: 1 }, schema ) ).toBe(
+				'Invalid schema provided for validation.'
+			);
+			expect( consoleErrorSpy ).toHaveBeenCalledWith(
+				'Schema compilation error:',
+				expect.any( Error )
+			);
+
+			consoleErrorSpy.mockRestore();
+		} );
 	} );
 } );

--- a/packages/abilities/src/tests/validation.test.ts
+++ b/packages/abilities/src/tests/validation.test.ts
@@ -529,4 +529,185 @@ describe( 'validateValueFromSchema', () => {
 			);
 		} );
 	} );
+
+	describe( 'WordPress-specific schema keywords', () => {
+		// AJV's strict mode rejects keywords it doesn't recognize at
+		// compile time, so any WordPress-specific keyword leaking into a
+		// client schema fails the whole validation rather than being
+		// ignored.
+		it( 'should fail compilation when schema contains sanitize_callback', () => {
+			const schema = {
+				type: 'string',
+				sanitize_callback: 'sanitize_text_field',
+			};
+			const consoleErrorSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation();
+
+			expect( validateValueFromSchema( 'hello', schema ) ).toBe(
+				'Invalid schema provided for validation.'
+			);
+			expect( consoleErrorSpy ).toHaveBeenCalledWith(
+				'Schema compilation error:',
+				expect.any( Error )
+			);
+
+			consoleErrorSpy.mockRestore();
+		} );
+
+		it( 'should fail compilation when schema contains validate_callback', () => {
+			const schema = {
+				type: 'string',
+				validate_callback: 'rest_validate_request_arg',
+			};
+			const consoleErrorSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation();
+
+			expect( validateValueFromSchema( 'hello', schema ) ).toBe(
+				'Invalid schema provided for validation.'
+			);
+			expect( consoleErrorSpy ).toHaveBeenCalledWith(
+				'Schema compilation error:',
+				expect.any( Error )
+			);
+
+			consoleErrorSpy.mockRestore();
+		} );
+
+		it( 'should fail compilation when schema contains arg_options', () => {
+			const schema = {
+				type: 'string',
+				arg_options: { sanitize_callback: 'sanitize_key' },
+			};
+			const consoleErrorSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation();
+
+			expect( validateValueFromSchema( 'hello', schema ) ).toBe(
+				'Invalid schema provided for validation.'
+			);
+			expect( consoleErrorSpy ).toHaveBeenCalledWith(
+				'Schema compilation error:',
+				expect.any( Error )
+			);
+
+			consoleErrorSpy.mockRestore();
+		} );
+
+		it( 'should fail compilation when a nested property uses sanitize_callback', () => {
+			const schema = {
+				type: 'object',
+				properties: {
+					name: {
+						type: 'string',
+						sanitize_callback: 'sanitize_text_field',
+					},
+				},
+			};
+			const consoleErrorSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation();
+
+			expect( validateValueFromSchema( { name: 'hello' }, schema ) ).toBe(
+				'Invalid schema provided for validation.'
+			);
+			expect( consoleErrorSpy ).toHaveBeenCalledWith(
+				'Schema compilation error:',
+				expect.any( Error )
+			);
+
+			consoleErrorSpy.mockRestore();
+		} );
+
+		// `example` (OpenAPI / WordPress REST docs) and `examples`
+		// (JSON Schema draft-06+) are not part of draft-04.
+		it( 'should fail compilation when schema contains `example`', () => {
+			const schema = {
+				type: 'string',
+				example: 'an example value',
+			};
+			const consoleErrorSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation();
+
+			expect( validateValueFromSchema( 'hello', schema ) ).toBe(
+				'Invalid schema provided for validation.'
+			);
+			expect( consoleErrorSpy ).toHaveBeenCalledWith(
+				'Schema compilation error:',
+				expect.any( Error )
+			);
+
+			consoleErrorSpy.mockRestore();
+		} );
+
+		it( 'should fail compilation when schema contains `examples`', () => {
+			const schema = {
+				type: 'string',
+				examples: [ 'first', 'second' ],
+			};
+			const consoleErrorSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation();
+
+			expect( validateValueFromSchema( 'hello', schema ) ).toBe(
+				'Invalid schema provided for validation.'
+			);
+			expect( consoleErrorSpy ).toHaveBeenCalledWith(
+				'Schema compilation error:',
+				expect.any( Error )
+			);
+
+			consoleErrorSpy.mockRestore();
+		} );
+
+		// WordPress REST argument definitions mark a per-arg `required`
+		// flag as a boolean, whereas JSON Schema expects `required` to be
+		// an array of property names on the parent object.
+		it( 'should fail compilation when `required` is a boolean', () => {
+			const schema = {
+				type: 'string',
+				required: true,
+			};
+			const consoleErrorSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation();
+
+			expect( validateValueFromSchema( 'hello', schema ) ).toBe(
+				'Invalid schema provided for validation.'
+			);
+			expect( consoleErrorSpy ).toHaveBeenCalledWith(
+				'Schema compilation error:',
+				expect.any( Error )
+			);
+
+			consoleErrorSpy.mockRestore();
+		} );
+
+		it( 'should fail compilation when a nested property has `required: true`', () => {
+			const schema = {
+				type: 'object',
+				properties: {
+					name: {
+						type: 'string',
+						required: true,
+					},
+				},
+			};
+			const consoleErrorSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation();
+
+			expect( validateValueFromSchema( { name: 'hello' }, schema ) ).toBe(
+				'Invalid schema provided for validation.'
+			);
+			expect( consoleErrorSpy ).toHaveBeenCalledWith(
+				'Schema compilation error:',
+				expect.any( Error )
+			);
+
+			consoleErrorSpy.mockRestore();
+		} );
+	} );
 } );


### PR DESCRIPTION
## Summary

Extend [`packages/abilities/src/tests/validation.test.ts`](packages/abilities/src/tests/validation.test.ts) with a new `WordPress-specific schema keywords` group that pins how the client-side validator currently behaves when an `input_schema` / `output_schema` contains keywords that are valid on WordPress REST API schemas but not on JSON Schema draft-04 (which the AJV instance in [`packages/abilities/src/validation.ts`](packages/abilities/src/validation.ts) targets):

- `sanitize_callback`, `validate_callback`, `arg_options` — server-only WordPress keywords (the last one comes from `register_meta()`)
- `context` — REST response-shaping keyword (`['view', 'edit', 'embed']`)
- `readonly` (lowercase, WordPress style) — marks server-computed fields, common on output schemas
- `example` / `examples` — OpenAPI / draft-06+ documentation fields
- `required: true` — the boolean per-arg form used by WordPress REST argument definitions (JSON Schema expects an array of property names)

In every case the validator currently returns `'Invalid schema provided for validation.'` and logs to `console.error`, because AJV strict mode rejects the keyword at compile time (or, for boolean `required`, fails the meta-schema check). The tests are driven from a single `it.each` table so the eight keywords share one body, matching the parameterised-test convention used elsewhere in the codebase (`wp-compat-overlay-slot.test.ts`, `global-styles-engine/utils.test.ts`, etc.).

## Goal: unify handling with WordPress core

This PR is the client-side counterpart to https://github.com/WordPress/wordpress-develop/pull/11997, which hardens the Abilities REST controller by switching to an allow-list of schema keywords — stripping the same WordPress-internal keys (`sanitize_callback`, `validate_callback`, `arg_options`, `examples`, …) before they leave the server.

Together the two PRs converge on a single rule for what client validation sees:

- **Server**: only ship draft-04-compatible keywords in REST responses (core PR).
- **Client**: pin the current failure mode for the keywords the server is about to stop sending, so once the core PR ships, the absence of regressions is visible — and any future change that strips the keywords client-side (instead of, or in addition to, server-side) shows up as a clear test diff.

No production code changes here.

## Test plan

- [x] `npm run test:unit -- --testPathPattern="packages/abilities/src/tests/validation"` — 48 tests pass
- [x] `npm run lint:js -- packages/abilities/src/tests/validation.test.ts` — clean
- [x] `npm run format -- packages/abilities/src/tests/validation.test.ts` — no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
