### PR TITLE
Fix type of `$block_instance` parameter in `block_core_image_render_lightbox()`

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -177,7 +177,7 @@ function block_core_image_get_lightbox_settings( $block ) {
  *
  * @return string Filtered block content.
  */
-function block_core_image_render_lightbox( $block_content, $block, $block_instance ) {
+function block_core_image_render_lightbox( $block_content, array $block, WP_Block $block_instance ) {
 	/*
 	 * If there's no IMG tag in the block then return the given block content
 	 * as-is. There's nothing that this code can knowingly modify to add the

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -171,9 +171,9 @@ function block_core_image_get_lightbox_settings( $block ) {
  *
  * @since 6.4.0
  *
- * @param string $block_content  Rendered block content.
- * @param array  $block          Block object.
- * @param array  $block_instance Block instance.
+ * @param string   $block_content  Rendered block content.
+ * @param array    $block          Block object.
+ * @param WP_Block $block_instance Block instance.
  *
  * @return string Filtered block content.
  */


### PR DESCRIPTION
This is a follow-up to https://github.com/WordPress/gutenberg/pull/62906, and specifically to https://github.com/WordPress/gutenberg/commit/1077e73ccc93e06b13bbf8254a9fd8968d6c361b. When the `$block_instance` parameter was added to the `block_core_image_render_lightbox()` function, it was incorrectly typed as an `array` when it is actually a `WP_Block`.