### PR TITLE
Fix: skip empty block markup in navigation to prevent split UL elements

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -240,13 +240,12 @@ class WP_Navigation_Block_Renderer {
 
 		foreach ( $inner_blocks as $inner_block ) {
 			$inner_block_markup = static::get_markup_for_inner_block( $inner_block );
-			    // Skip hidden blocks that render as empty strings.
-   				// Without this, empty markup triggers the list-close logic
-    			// and splits the navigation into multiple <ul> elements.
-    			if ( '' === $inner_block_markup ) {
-       				 continue;
-    			}
-				
+			// Skip hidden blocks (e.g. hidden via block visibility) that render
+			// as an empty string. Without this check, empty markup is mistaken
+			// for a non-list-item and incorrectly closes the open <ul>.
+			if ( '' === $inner_block_markup ) {
+				continue;
+			}
 			$p                  = new WP_HTML_Tag_Processor( $inner_block_markup );
 			$is_list_item       = $p->next_tag( 'LI' );
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -240,6 +240,13 @@ class WP_Navigation_Block_Renderer {
 
 		foreach ( $inner_blocks as $inner_block ) {
 			$inner_block_markup = static::get_markup_for_inner_block( $inner_block );
+			    // Skip hidden blocks that render as empty strings.
+   				// Without this, empty markup triggers the list-close logic
+    			// and splits the navigation into multiple <ul> elements.
+    			if ( '' === $inner_block_markup ) {
+       				 continue;
+    			}
+				
 			$p                  = new WP_HTML_Tag_Processor( $inner_block_markup );
 			$is_list_item       = $p->next_tag( 'LI' );
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -246,8 +246,8 @@ class WP_Navigation_Block_Renderer {
 			if ( '' === $inner_block_markup ) {
 				continue;
 			}
-			$p                  = new WP_HTML_Tag_Processor( $inner_block_markup );
-			$is_list_item       = $p->next_tag( 'LI' );
+			$p            = new WP_HTML_Tag_Processor( $inner_block_markup );
+			$is_list_item = $p->next_tag( 'LI' );
 
 			if ( $is_list_item && ! $is_list_open ) {
 				$is_list_open       = true;


### PR DESCRIPTION
## What?
Closes #78784

When a navigation block item is hidden using block visibility, the 
frontend renders two separate `<ul>` elements instead of one, splitting 
the navigation list at the position of the hidden item.

## Why?
In `WP_Navigation_Block_Renderer::get_inner_blocks_html()`, the loop 
tracks list state using an `$is_list_open` flag. When a block is hidden, 
`$inner_block->render()` returns an empty string `''`. 
`WP_HTML_Tag_Processor` finds no `<li>` in the empty string, so 
`$is_list_item` evaluates to `false`. This satisfies the close condition 
(`! $is_list_item && $is_list_open`), closing the `<ul>` prematurely. 
The next visible item then opens a brand new `<ul>`, producing two 
separate lists instead of one.

## How?
Added an early `continue` at the top of the `foreach` loop in 
`get_inner_blocks_html()` to skip blocks that render as empty strings. 
This preserves the `$is_list_open` state across hidden blocks, keeping 
all visible items inside a single `<ul>` container.

```php
if ( '' === $inner_block_markup ) {
    continue;
}
```

## Testing Instructions
1. Create a post or page with a Navigation block.
2. Add at least 3 navigation links.
3. Select a middle link → open block settings → hide it using 
   block visibility.
4. Save and view the post/page on the frontend.
5. Right click → Inspect the HTML.
6. Confirm only **one** `<ul class="wp-block-navigation__container">` 
   exists and all visible links are inside it.

### Testing Instructions for Keyboard
No UI changes — this is a server-side PHP rendering fix only. 
No keyboard testing required.

## Screenshots

|Before|After|
|-|-|
|[<img width="1151" height="802" alt="image" src="https://github.com/user-attachments/assets/0fe74880-bd8b-4aff-a91c-9eb6baffaeae" />]|[<img width="1148" height="833" alt="Screenshot 2026-05-29 at 8 59 52 AM" src="https://github.com/user-attachments/assets/191c27e5-8126-40c9-b84f-536954659174" />]|

## Use of AI Tools
Used Claude (claude.ai) as a learning aid to trace through the PHP 
rendering loop logic and understand the root cause. The bug 
investigation, reproduction, fix, and testing were done manually.