### PR TITLE
Notes list view indicator

### DIFF
--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -27,8 +27,12 @@ const ListViewBlockContents = forwardRef(
 		ref
 	) => {
 		const { clientId } = block;
-		const { AdditionalBlockContent, insertedBlock, setInsertedBlock } =
-			useListViewContext();
+		const {
+			AdditionalBlockContent,
+			AdditionalBlockIndicators,
+			insertedBlock,
+			setInsertedBlock,
+		} = useListViewContext();
 
 		// Only include all selected blocks if the currently clicked on block
 		// is one of the selected blocks. This ensures that if a user attempts
@@ -67,6 +71,13 @@ const ListViewBlockContents = forwardRef(
 							onDragStart={ onDragStart }
 							onDragEnd={ onDragEnd }
 							isExpanded={ isExpanded }
+							additionalIndicators={
+								AdditionalBlockIndicators && (
+									<AdditionalBlockIndicators
+										block={ block }
+									/>
+								)
+							}
 							{ ...props }
 						/>
 					) }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -55,6 +55,7 @@ function ListViewBlockSelectButton(
 		isExpanded,
 		ariaDescribedBy,
 		visibilityLabel,
+		additionalIndicators,
 	},
 	ref
 ) {
@@ -158,6 +159,7 @@ function ListViewBlockSelectButton(
 						) ) }
 					</span>
 				) : null }
+				{ additionalIndicators }
 				{ !! visibilityLabel && (
 					// The tooltip below is a sighted-hover affordance for
 					// the (decorative) visibility icon. The same

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -81,6 +81,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 32;
  * @param {string}         props.description            Optional accessible description for the tree grid component.
  * @param {?Function}      props.onSelect               Optional callback to be invoked when a block is selected. Receives the block object that was selected.
  * @param {?ComponentType} props.additionalBlockContent Component that renders additional block content UI.
+ * @param {?ComponentType} props.additionalBlockIndicators Component that renders additional indicators beside the block title.
  * @param {Ref}            ref                          Forwarded ref
  */
 function ListViewComponent(
@@ -96,6 +97,7 @@ function ListViewComponent(
 		description,
 		onSelect,
 		additionalBlockContent: AdditionalBlockContent,
+		additionalBlockIndicators: AdditionalBlockIndicators,
 	},
 	ref
 ) {
@@ -298,6 +300,7 @@ function ListViewComponent(
 			BlockSettingsMenu,
 			listViewInstanceId: instanceId,
 			AdditionalBlockContent,
+			AdditionalBlockIndicators,
 			insertedBlock,
 			setInsertedBlock,
 			treeGridElementRef: elementRef,
@@ -316,6 +319,7 @@ function ListViewComponent(
 			BlockSettingsMenu,
 			instanceId,
 			AdditionalBlockContent,
+			AdditionalBlockIndicators,
 			insertedBlock,
 			setInsertedBlock,
 			rootClientId,
@@ -417,6 +421,7 @@ export default forwardRef( ( props, ref ) => {
 			rootClientId={ null }
 			onSelect={ null }
 			additionalBlockContent={ null }
+			additionalBlockIndicators={ null }
 			blockSettingsMenu={ undefined }
 		/>
 	);

--- a/packages/editor/src/components/collab-sidebar/README.md
+++ b/packages/editor/src/components/collab-sidebar/README.md
@@ -2,8 +2,9 @@
 
 The Notes sidebar (a.k.a. collab sidebar) lets users attach threaded notes to individual blocks. It renders in two modes:
 
-- **All notes** - a full sidebar (opened from the editor's More menu) listing every note thread on the current post.
-- **Floating notes** - on larger viewports, unresolved notes also float next to their associated blocks in the canvas, positioned to track scroll and avoid overlap.
+-   **All notes** - a full sidebar (opened from the editor's More menu) listing every note thread on the current post.
+-   **Floating notes** - on larger viewports, unresolved notes also float next to their associated blocks in the canvas, positioned to track scroll and avoid overlap.
+-   **List View indicators** - blocks with unresolved notes show a compact note icon in List View, giving long documents a passive discovery path before the block is selected.
 
 Notes are stored as WordPress comments (`type: 'note'`) attached to the post. A block references its thread via `metadata.noteId` on block attributes. Each thread has a top-level note plus replies; threads can be resolved (stored as status `approved`) or reopened.
 
@@ -25,7 +26,7 @@ collab-sidebar/
 ├── floating-container.js           FloatingContainer - stack wrapper that applies `top` in floating mode
 │
 ├── hooks.js                        useNoteThreads, useNoteActions, useFloatingBoard, useEnableFloatingSidebar
-├── utils.js                        focusNoteThread, getNoteExcerpt, sanitizeNoteContent, calculateNotePositions, getAvatarBorderColor
+├── utils.js                        focusNoteThread, getNoteExcerpt, sanitizeNoteContent, calculateNotePositions, getAvatarBorderColor, getUnresolvedNoteCountsByBlock
 ├── board-store.js                  createBoardStore - ResizeObserver + ref registry for floating layout
 ├── constants.js                    sidebar identifier strings
 ├── style.scss
@@ -66,20 +67,21 @@ Three layers cooperate:
 
 A plain JS module returning a store created via `createBoardStore()` (one per mounted `Notes`). Holds:
 
-- `blockRefs: Map<noteId, HTMLElement>` - each note's associated block element.
-- `floatingRefs: Map<noteId, HTMLElement>` - each note's floating DOM node.
-- `idByElement: WeakMap<HTMLElement, noteId>` - reverse lookup for the `ResizeObserver`.
-- `heights: { [noteId]: number }` - observed heights of floating elements.
-- `snapshot: { ... }` - frozen shallow copy of `heights` (for `useSyncExternalStore`).
+-   `blockRefs: Map<noteId, HTMLElement>` - each note's associated block element.
+-   `floatingRefs: Map<noteId, HTMLElement>` - each note's floating DOM node.
+-   `idByElement: WeakMap<HTMLElement, noteId>` - reverse lookup for the `ResizeObserver`.
+-   `heights: { [noteId]: number }` - observed heights of floating elements.
+-   `snapshot: { ... }` - frozen shallow copy of `heights` (for `useSyncExternalStore`).
 
 A single shared `ResizeObserver` watches every registered floating element; when a floating note changes height, it updates `heights`, snapshots, and calls every `listener` in the store's `Set`.
 
 API:
-- `subscribe(listener)` / `getSnapshot()` - wired to React via `useSyncExternalStore`. Disconnects the observer when the last subscriber leaves.
-- `registerThread(id, blockEl, floatingEl)` - called by each `NoteThread` once mounted. Adds the block ref, swaps the floating ref (unobserving the previous one), starts observing the new one, emits.
-- `unregisterThread(id)` - inverse; called on unmount.
-- `getBlockRects()` - returns a batched snapshot of block `getBoundingClientRect()` values. Batches reads so subsequent CSS writes don't trigger layout thrash.
-- `getFirstBlockElement()` - the first registered block, used to locate the canvas scroll container.
+
+-   `subscribe(listener)` / `getSnapshot()` - wired to React via `useSyncExternalStore`. Disconnects the observer when the last subscriber leaves.
+-   `registerThread(id, blockEl, floatingEl)` - called by each `NoteThread` once mounted. Adds the block ref, swaps the floating ref (unobserving the previous one), starts observing the new one, emits.
+-   `unregisterThread(id)` - inverse; called on unmount.
+-   `getBlockRects()` - returns a batched snapshot of block `getBoundingClientRect()` values. Batches reads so subsequent CSS writes don't trigger layout thrash.
+-   `getFirstBlockElement()` - the first registered block, used to locate the canvas scroll container.
 
 The store owns DOM references directly, not through React - floating note height changes must update layout without re-rendering the thread list.
 
@@ -89,9 +91,9 @@ Lives inside `Notes`. Holds one store instance (`useState(createBoardStore)`) an
 
 1. Subscribes to `heights` via `useSyncExternalStore(store.subscribe, store.getSnapshot)`.
 2. In a `useEffect` keyed on `threads + heights + selectedNoteId + isFloating + sidebarRef`:
-   - Resolves the canvas scroll container by climbing from the first registered block to `.is-root-container` and calling `getScrollContainer()` on it.
-   - Schedules a single `requestAnimationFrame` that calls `calculateNotePositions({ threads, selectedNoteId, blockRects: store.getBlockRects(), heights, scrollTop })` (pure function in `utils.js`) and stores the result in React state (`notePositions`).
-   - Attaches a capture-phase `scroll` listener on the canvas's `defaultView` that writes a CSS variable `--canvas-scroll` to the sidebar panel. (`window` capture catches scrolls on the document root, which don't bubble.)
+    - Resolves the canvas scroll container by climbing from the first registered block to `.is-root-container` and calling `getScrollContainer()` on it.
+    - Schedules a single `requestAnimationFrame` that calls `calculateNotePositions({ threads, selectedNoteId, blockRects: store.getBlockRects(), heights, scrollTop })` (pure function in `utils.js`) and stores the result in React state (`notePositions`).
+    - Attaches a capture-phase `scroll` listener on the canvas's `defaultView` that writes a CSS variable `--canvas-scroll` to the sidebar panel. (`window` capture catches scrolls on the document root, which don't bubble.)
 3. Returns `{ notePositions, registerThread, unregisterThread }` - the positions flow down as props; the two register callbacks flow to each `NoteThread`.
 
 ### 3. `calculateNotePositions` - pure layout math (in `utils.js`)
@@ -111,7 +113,7 @@ Renders a `Stack` with `top: floating.y` when in floating mode. CSS uses the `--
 
 ### Why this shape
 
-- `ResizeObserver` is canonical for height changes that must drive layout without polling.
-- `useSyncExternalStore` is the right React 18 primitive for "external mutable source with snapshot" - gives concurrent-mode-safe subscriptions without a provider.
-- The scroll listener updates a CSS variable rather than React state, so scrolling doesn't re-render. Per-note `top` only recomputes when threads, heights, selection, or structural inputs change.
-- Batching `getBoundingClientRect` reads inside the `rAF` and separating them from style writes avoids forced layout.
+-   `ResizeObserver` is canonical for height changes that must drive layout without polling.
+-   `useSyncExternalStore` is the right React 18 primitive for "external mutable source with snapshot" - gives concurrent-mode-safe subscriptions without a provider.
+-   The scroll listener updates a CSS variable rather than React state, so scrolling doesn't re-render. Per-note `top` only recomputes when threads, heights, selection, or structural inputs change.
+-   Batching `getBoundingClientRect` reads inside the `rAF` and separating them from style writes avoids forced layout.

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -35,7 +35,8 @@ import {
 
 const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
 
-export function useNoteThreads( postId ) {
+export function useNoteThreads( postId, options = {} ) {
+	const { enabled = true } = options;
 	const queryArgs = {
 		post: postId,
 		type: 'note',
@@ -47,7 +48,7 @@ export function useNoteThreads( postId ) {
 		'root',
 		'comment',
 		queryArgs,
-		{ enabled: !! postId && typeof postId === 'number' }
+		{ enabled: enabled && !! postId && typeof postId === 'number' }
 	);
 
 	const { getBlockAttributes } = useSelect( blockEditorStore );

--- a/packages/editor/src/components/collab-sidebar/test/utils.js
+++ b/packages/editor/src/components/collab-sidebar/test/utils.js
@@ -7,6 +7,7 @@ import {
 	removeNoteIdFromMetadata,
 	calculateNotePositions,
 	pickPrimaryNote,
+	getUnresolvedNoteCountsByBlock,
 } from '../utils';
 
 function makeRect( top ) {
@@ -313,6 +314,34 @@ describe( 'pickPrimaryNote', () => {
 			{ id: 2, status: 'approved' },
 		];
 		expect( pickPrimaryNote( threads ) ).toBe( threads[ 0 ] );
+	} );
+} );
+
+describe( 'getUnresolvedNoteCountsByBlock', () => {
+	it( 'counts unresolved notes by block client ID', () => {
+		expect(
+			getUnresolvedNoteCountsByBlock( [
+				{ id: 1, blockClientId: 'block-1', status: 'hold' },
+				{ id: 2, blockClientId: 'block-1', status: 'hold' },
+				{ id: 3, blockClientId: 'block-2', status: 'hold' },
+			] )
+		).toEqual( {
+			'block-1': 2,
+			'block-2': 1,
+		} );
+	} );
+
+	it( 'ignores resolved notes and notes without a block client ID', () => {
+		expect(
+			getUnresolvedNoteCountsByBlock( [
+				{ id: 1, blockClientId: 'block-1', status: 'approved' },
+				{ id: 2, blockClientId: 'block-1', status: 'hold' },
+				{ id: 3, blockClientId: null, status: 'hold' },
+				{ id: 4, status: 'hold' },
+			] )
+		).toEqual( {
+			'block-1': 1,
+		} );
 	} );
 } );
 

--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -144,6 +144,23 @@ export function pickPrimaryNote( threads ) {
 }
 
 /**
+ * Counts unresolved note threads by their associated block client ID.
+ *
+ * @param {Array} threads Ordered list of thread objects.
+ * @return {Object<string, number>} Unresolved note counts keyed by client ID.
+ */
+export function getUnresolvedNoteCountsByBlock( threads ) {
+	return threads.reduce( ( counts, thread ) => {
+		if ( thread.status !== 'hold' || ! thread.blockClientId ) {
+			return counts;
+		}
+		counts[ thread.blockClientId ] =
+			( counts[ thread.blockClientId ] ?? 0 ) + 1;
+		return counts;
+	}, {} );
+}
+
+/**
  * Removes a note ID from the metadata.
  *
  * @param {Object} metadata Existing block metadata

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -1,14 +1,12 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalListView as ListView,
-	privateApis as blockEditorPrivateApis,
-} from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
 import { useFocusOnMount, useMergeRefs } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { focus } from '@wordpress/dom';
-import { useCallback, useRef, useState } from '@wordpress/element';
+import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { ESCAPE } from '@wordpress/keycodes';
@@ -17,14 +15,52 @@ import { ESCAPE } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import ListViewOutline from './list-view-outline';
+import ListViewNoteIndicator from './list-view-note-indicator';
 import { unlock } from '../../lock-unlock';
 import { store as editorStore } from '../../store';
+import { useNoteThreads } from '../collab-sidebar/hooks';
+import { getUnresolvedNoteCountsByBlock } from '../collab-sidebar/utils';
+import { checkSupport } from '../post-type-support-check';
 
-const { TabbedSidebar } = unlock( blockEditorPrivateApis );
+const { PrivateListView, TabbedSidebar } = unlock( blockEditorPrivateApis );
 
 export default function ListViewSidebar() {
 	const { setIsListViewOpened } = useDispatch( editorStore );
-	const { getListViewToggleRef } = unlock( useSelect( editorStore ) );
+	const { getListViewToggleRef, postId, supportsNotes } = useSelect(
+		( select ) => {
+			const {
+				getCurrentPostId,
+				getListViewToggleRef: getListViewToggleRefSelector,
+			} = unlock( select( editorStore ) );
+			const postType = select( coreStore ).getPostType(
+				select( editorStore ).getEditedPostAttribute( 'type' )
+			);
+
+			return {
+				getListViewToggleRef: getListViewToggleRefSelector,
+				postId: getCurrentPostId(),
+				supportsNotes: !! postType?.supports
+					? checkSupport( postType.supports, 'editor.notes' )
+					: false,
+			};
+		},
+		[]
+	);
+	const { unresolvedNotes } = useNoteThreads( postId, {
+		enabled: supportsNotes,
+	} );
+	const unresolvedNoteCountsByBlock = useMemo(
+		() => getUnresolvedNoteCountsByBlock( unresolvedNotes ),
+		[ unresolvedNotes ]
+	);
+	const NoteIndicator = useCallback(
+		( { block } ) => (
+			<ListViewNoteIndicator
+				count={ unresolvedNoteCountsByBlock[ block.clientId ] }
+			/>
+		),
+		[ unresolvedNoteCountsByBlock ]
+	);
 
 	// This hook handles focus when the sidebar first renders.
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
@@ -126,8 +162,11 @@ export default function ListViewSidebar() {
 						panel: (
 							<div className="editor-list-view-sidebar__list-view-container">
 								<div className="editor-list-view-sidebar__list-view-panel-content">
-									<ListView
+									<PrivateListView
 										dropZoneElement={ dropZoneElement }
+										additionalBlockIndicators={
+											supportsNotes ? NoteIndicator : null
+										}
 									/>
 								</div>
 							</div>

--- a/packages/editor/src/components/list-view-sidebar/list-view-note-indicator.js
+++ b/packages/editor/src/components/list-view-sidebar/list-view-note-indicator.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { Icon, comment } from '@wordpress/icons';
+import { sprintf, _n } from '@wordpress/i18n';
+import { VisuallyHidden, Tooltip } from '@wordpress/ui';
+
+export default function ListViewNoteIndicator( { count } ) {
+	if ( ! count ) {
+		return null;
+	}
+
+	const label = sprintf(
+		/* translators: %d: Number of unresolved notes. */
+		_n( '%d unresolved note', '%d unresolved notes', count ),
+		count
+	);
+
+	return (
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				render={
+					<span className="editor-list-view-sidebar__note-indicator">
+						<Icon icon={ comment } />
+						<VisuallyHidden>{ label }</VisuallyHidden>
+					</span>
+				}
+			/>
+			<Tooltip.Popup>{ label }</Tooltip.Popup>
+		</Tooltip.Root>
+	);
+}

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -1,6 +1,6 @@
-@use "@wordpress/base-styles/colors" as *;
-@use "@wordpress/base-styles/mixins" as *;
-@use "@wordpress/base-styles/variables" as *;
+@use '@wordpress/base-styles/colors' as *;
+@use '@wordpress/base-styles/mixins' as *;
+@use '@wordpress/base-styles/variables' as *;
 
 .editor-list-view-sidebar {
 	height: 100%;
@@ -15,7 +15,7 @@
 	height: 100%;
 
 	// Include custom scrollbars, invisible until hovered.
-	@include custom-scrollbars-on-hover(transparent, $gray-600);
+	@include custom-scrollbars-on-hover( transparent, $gray-600 );
 	overflow: auto;
 
 	// Only reserve space for scrollbars when there is content to scroll.
@@ -41,6 +41,10 @@
 
 .editor-list-view-sidebar__tab-panel {
 	height: 100%;
+}
+
+.editor-list-view-sidebar__note-indicator {
+	line-height: 0;
 }
 
 .editor-list-view-sidebar__outline {

--- a/packages/editor/src/components/post-type-support-check/index.js
+++ b/packages/editor/src/components/post-type-support-check/index.js
@@ -9,7 +9,7 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import { store as editorStore } from '../../store';
 
-function checkSupport( supports = {}, key ) {
+export function checkSupport( supports = {}, key ) {
 	// Check for top-level support keys.
 	if ( supports[ key ] !== undefined ) {
 		return !! supports[ key ];

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -188,6 +188,49 @@ test.describe( 'Block Notes', () => {
 		).toBeVisible();
 	} );
 
+	test( 'shows an unresolved note indicator in List View', async ( {
+		editor,
+		page,
+		pageUtils,
+		blockNoteUtils,
+	} ) => {
+		await blockNoteUtils.addBlockWithNote( {
+			type: 'core/paragraph',
+			attributes: { content: 'Paragraph with a note' },
+			comment: 'List View note indicator',
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Paragraph without a note' },
+		} );
+
+		await pageUtils.pressKeys( 'access+o' );
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+		await expect(
+			listView.locator( '.editor-list-view-sidebar__note-indicator' )
+		).toHaveCount( 1 );
+		await expect(
+			listView.getByText( '1 unresolved note' )
+		).toBeAttached();
+
+		await blockNoteUtils.openBlockNoteSidebar();
+		await page
+			.getByRole( 'treeitem', {
+				name: 'Note: List View note indicator',
+			} )
+			.click();
+		await page.getByRole( 'button', { name: 'Resolve' } ).click();
+
+		await expect(
+			listView.locator( '.editor-list-view-sidebar__note-indicator' )
+		).toHaveCount( 0 );
+		await expect(
+			listView.getByText( '1 unresolved note' )
+		).not.toBeAttached();
+	} );
+
 	test( 'can reopen a resolved note when adding a reply', async ( {
 		page,
 		blockNoteUtils,


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/78603

Adds a small List View indicator for blocks with unresolved Notes.

## Why?

Notes are currently hard to discover in long documents unless a block is selected or the Notes sidebar is already open. This gives authors a passive way to see where unresolved Notes exist.

## How?

Adds a private List View block indicator extension point, then uses it from the editor List View to render a compact note icon for blocks with unresolved note threads.

## Testing Instructions

1. Open a post or page.
2. Add a block and create a Note on it.
3. Open List View.
4. Confirm the block with the unresolved Note shows a note icon.
5. Resolve the Note.
6. Confirm the List View icon disappears.

### Testing Instructions for Keyboard

1. Open a post or page.
2. Use the keyboard to add a Note to a block.
3. Open List View with the keyboard shortcut.
4. Navigate the List View and confirm the unresolved Note indicator is announced.
5. Resolve the Note and confirm the indicator is removed.

## Use of AI Tools

Used ChatGPT/Codex to help draft and implement the changes.