### PR TITLE
Dynamic Gallery Block: Attempt a dynamic mode of the gallery block

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -400,7 +400,7 @@ Display multiple images in a rich gallery.
 -	**Category:** [media](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-media/)
 -	**Allowed Blocks:** core/image
 -	**Supports:** align, anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), listView, spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
--	**Attributes:** allowResize, aspectRatio, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, navigationButtonType, randomOrder, shortCodeTransforms, sizeSlug
+-	**Attributes:** allowResize, aspectRatio, caption, columns, dynamicContent, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, navigationButtonType, randomOrder, shortCodeTransforms, sizeSlug
 
 ## Group
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   Removed the `@wordpress/block-library/babel-plugin` export. It was an internal transform for stripping experimental blocks from WordPress core builds and is no longer used by Gutenberg's build process ([#79162](https://github.com/WordPress/gutenberg/pull/79162)).
 
+### New Features
+
+-   Gallery: add a dynamic mode that displays images resolved from a source (initially the images attached to the current post) instead of manually-added image blocks, with an editor preview, mode toggles, and server-side rendering. [#78796](https://github.com/WordPress/gutenberg/pull/78796).
+
 ### Enhancements
 
 -   Image and Site Logo blocks: the Crop toolbar button now opens the Media Editor modal instead of an inline cropper. The previous inline experience is removed ([#78654](https://github.com/WordPress/gutenberg/pull/78654)).

--- a/packages/block-library/src/gallery/README.md
+++ b/packages/block-library/src/gallery/README.md
@@ -22,6 +22,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 |-----------|------|---------|-------------|
 | `images` | `array` | `[]` | [Source](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source): `query`. [Selector](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source): `.blocks-gallery-item` |
 | `ids` | `array` | `[]` | — |
+| `dynamicContent` | `object` | — | — |
 | `navigationButtonType` | `string` | `"icon"` | [Enum](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#enum-validation): `icon`, `text`, `both` |
 | `shortCodeTransforms` | `array` | `[]` | — |
 | `columns` | `number` | — | — |
@@ -67,6 +68,8 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 **Uses context:**
 
 - `galleryId`
+- `postId`
+- `postType`
 
 **Provides context:**
 

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -4,7 +4,7 @@
 	"name": "core/gallery",
 	"title": "Gallery",
 	"category": "media",
-	"usesContext": [ "galleryId" ],
+	"usesContext": [ "galleryId", "postId", "postType" ],
 	"allowedBlocks": [ "core/image" ],
 	"description": "Display multiple images in a rich gallery.",
 	"keywords": [ "images", "photos" ],
@@ -60,6 +60,9 @@
 				"type": "number"
 			},
 			"default": []
+		},
+		"dynamicContent": {
+			"type": "object"
 		},
 		"navigationButtonType": {
 			"type": "string",

--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -187,11 +187,10 @@ export function GallerySourcePanel( {
 		);
 	}
 
-	// In static mode the panel only offers a way into dynamic mode, so hide it
-	// where the context has no post type to resolve against. This is stricter
-	// than the placeholder's entry button (see `edit.js`) on purpose: the
-	// placeholder keeps dynamic mode *possible* anywhere editable, while the
-	// inspector keeps it *easy and obvious* where a concrete post is in context.
+	// In static mode this panel is just an entry into dynamic mode, so hide it
+	// when there's no post type to preview against. This is intentionally
+	// stricter than the placeholder's entry button (see `edit.js`), which stays
+	// available anywhere because the source resolves at render time.
 	if ( ! canUseDynamicSource ) {
 		return null;
 	}

--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -338,7 +338,7 @@ export function GalleryDynamicView( {
 						// stays focusable when disabled by default.)
 						disabled={ isResolvingDynamic }
 					>
-						{ __( 'Edit images' ) }
+						{ __( 'Convert to images' ) }
 					</ToolbarButton>
 				</BlockControls>
 			) }

--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -167,12 +167,11 @@ export function GallerySourcePanel( {
 		);
 	}
 
-	// In static mode the panel only offers a way into dynamic mode, which is
-	// meaningful where the block can resolve against a post: a real post, or a
-	// post-bound template whose post is filled in at render time. Elsewhere
-	// (template part, pattern, generic template) the sole source can never
-	// resolve, leaving nothing to show — so hide the panel rather than present a
-	// dead control. Once other sources exist, render whenever ANY is available.
+	// In static mode the panel only offers a way into dynamic mode, so hide it
+	// where the context has no post type to resolve against. This is stricter
+	// than the placeholder's entry button (see `edit.js`) on purpose: the
+	// placeholder keeps dynamic mode *possible* anywhere editable, while the
+	// inspector keeps it *easy and obvious* where a concrete post is in context.
 	if ( ! canUseDynamicSource ) {
 		return null;
 	}

--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -1,0 +1,298 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import {
+	Button,
+	PanelBody,
+	Placeholder,
+	SelectControl,
+	Spinner,
+	ToolbarButton,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
+import {
+	BlockContextProvider,
+	BlockControls,
+	useBlockEditingMode,
+	__experimentalUseBlockPreview as useBlockPreview,
+} from '@wordpress/block-editor';
+import { View } from '@wordpress/primitives';
+
+/**
+ * Internal dependencies
+ */
+import { sharedIcon } from './shared-icon';
+import {
+	getSourceDescription,
+	DEFAULT_ORDERBY,
+	DEFAULT_ORDER,
+} from './dynamic-source';
+
+/**
+ * Ordering options for a dynamic gallery source. Each value is a composite
+ * `"orderby/order"` string mapping to the matching `/wp/v2/media` collection
+ * params. `menu_order` is deliberately omitted — it isn't a valid REST `orderby`
+ * value, so the editor preview couldn't reproduce it (see `dynamic-source.js`).
+ */
+const ORDER_OPTIONS = [
+	{ label: __( 'Newest to oldest' ), value: 'date/desc' },
+	{ label: __( 'Oldest to newest' ), value: 'date/asc' },
+	{
+		/* translators: Label for ordering images by title in ascending order. */
+		label: __( 'A → Z' ),
+		value: 'title/asc',
+	},
+	{
+		/* translators: Label for ordering images by title in descending order. */
+		label: __( 'Z → A' ),
+		value: 'title/desc',
+	},
+];
+
+/**
+ * "Order by" control for a dynamic gallery, mirroring the Query Loop block's
+ * `OrderControl`: a single `SelectControl` whose value composites `orderby` and
+ * `order`, split apart again on change.
+ *
+ * @param {Object}   props
+ * @param {string}   props.orderby  Current `orderby` value.
+ * @param {string}   props.order    Current `order` value (`asc`/`desc`).
+ * @param {Function} props.onChange Called with `{ orderby, order }` on change.
+ */
+function OrderControl( { orderby, order, onChange } ) {
+	return (
+		<SelectControl
+			__next40pxDefaultSize
+			label={ __( 'Order by' ) }
+			value={ `${ orderby }/${ order }` }
+			options={ ORDER_OPTIONS }
+			onChange={ ( value ) => {
+				const [ newOrderby, newOrder ] = value.split( '/' );
+				onChange( { orderby: newOrderby, order: newOrder } );
+			} }
+		/>
+	);
+}
+
+/**
+ * The Gallery block's "Source" inspector panel.
+ *
+ * In dynamic mode it shows the resolved source, a control to convert back to
+ * individual images, and the source ordering. In static mode it offers the
+ * entry point into dynamic mode — and, since switching discards any hand-added
+ * images, owns the confirmation dialog for that one-way change. Rendered inside
+ * the block's `InspectorControls`, alongside the Settings panel.
+ *
+ * @param {Object}  props
+ * @param {Object}  props.dynamic           The `useDynamicGallery` result.
+ * @param {Object}  props.dropdownMenuProps Shared ToolsPanel dropdown menu props.
+ * @param {boolean} props.hasImages         Whether the gallery has manually-added images.
+ */
+export function GallerySourcePanel( {
+	dynamic,
+	dropdownMenuProps,
+	hasImages,
+} ) {
+	const {
+		dynamicContent,
+		sourceOrderby,
+		sourceOrder,
+		setSourceOrder,
+		convertToStatic,
+		enableDynamicMode,
+		resetSource,
+	} = dynamic;
+	const isDynamic = !! dynamicContent;
+
+	const [ isConfirming, setIsConfirming ] = useState( false );
+
+	// Entering dynamic mode discards any hand-added images, so confirm first
+	// when there are images to lose; otherwise switch straight away.
+	function requestEnableDynamicMode() {
+		if ( hasImages ) {
+			setIsConfirming( true );
+		} else {
+			enableDynamicMode();
+		}
+	}
+
+	if ( isDynamic ) {
+		return (
+			<ToolsPanel
+				label={ __( 'Source' ) }
+				resetAll={ resetSource }
+				dropdownMenuProps={ dropdownMenuProps }
+			>
+				<div className="wp-block-gallery__source-settings">
+					<p className="wp-block-gallery__source-description">
+						{ getSourceDescription( dynamicContent ) }
+					</p>
+					<Button
+						__next40pxDefaultSize
+						variant="secondary"
+						onClick={ convertToStatic }
+					>
+						{ __( 'Convert to individual images' ) }
+					</Button>
+				</div>
+				<ToolsPanelItem
+					isShownByDefault
+					label={ __( 'Order by' ) }
+					hasValue={ () =>
+						sourceOrderby !== DEFAULT_ORDERBY ||
+						sourceOrder !== DEFAULT_ORDER
+					}
+					onDeselect={ () => setSourceOrder( undefined, undefined ) }
+				>
+					<OrderControl
+						orderby={ sourceOrderby }
+						order={ sourceOrder }
+						onChange={ ( { orderby, order } ) =>
+							setSourceOrder( orderby, order )
+						}
+					/>
+				</ToolsPanelItem>
+			</ToolsPanel>
+		);
+	}
+
+	return (
+		<>
+			<PanelBody title={ __( 'Source' ) }>
+				<div className="wp-block-gallery__source-settings">
+					<Button
+						__next40pxDefaultSize
+						variant="secondary"
+						onClick={ requestEnableDynamicMode }
+					>
+						{ __( 'Use images attached to the post' ) }
+					</Button>
+				</div>
+			</PanelBody>
+			{ isConfirming && (
+				<ConfirmDialog
+					isOpen
+					title={ __( 'Use images attached to the post?' ) }
+					__experimentalHideHeader={ false }
+					confirmButtonText={ __( 'Use attached images' ) }
+					onConfirm={ () => {
+						enableDynamicMode();
+						setIsConfirming( false );
+					} }
+					onCancel={ () => setIsConfirming( false ) }
+					size="medium"
+				>
+					{ __(
+						'The images in this gallery will be replaced, but will remain in the media library.'
+					) }
+				</ConfirmDialog>
+			) }
+		</>
+	);
+}
+
+/**
+ * Renders the resolved image blocks as a single, non-editable preview.
+ *
+ * `useBlockPreview` is given the gallery's own block props (so the `<figure>`
+ * stays the real block wrapper and the image figures remain direct descendants
+ * for the gallery's flex/crop styles).
+ *
+ * @param {Object}   props
+ * @param {Object[]} props.imageBlocks Non-persisted `core/image` blocks to preview.
+ * @param {Object}   props.blockProps  The gallery's `useBlockProps()` result.
+ */
+function GalleryImagesPreview( { imageBlocks, blockProps } ) {
+	const previewProps = useBlockPreview( {
+		blocks: imageBlocks,
+		props: blockProps,
+	} );
+	return <figure { ...previewProps } />;
+}
+
+/**
+ * Renders a dynamic-mode gallery on the canvas:
+ *
+ * - a block-toolbar control to convert back to individual images;
+ * - a non-editable preview of the resolved media (or a placeholder while
+ *   resolving / when nothing is found), with the gallery's provided context so
+ *   the previewed images inherit gallery-wide settings;
+ * - the (empty) inner blocks kept mounted so the container's `allowedBlocks: []`
+ *   keeps syncing to block list settings (which blocks insertion and hides the
+ *   List View).
+ *
+ * @param {Object} props
+ * @param {Object} props.dynamic          The `useDynamicGallery` result.
+ * @param {Object} props.blockProps       The gallery's `useBlockProps()` result.
+ * @param {Object} props.innerBlocksProps The gallery's `useInnerBlocksProps()` result.
+ */
+export function GalleryDynamicView( {
+	dynamic,
+	blockProps,
+	innerBlocksProps,
+} ) {
+	const {
+		dynamicImageBlocks,
+		galleryContext,
+		isResolvingDynamic,
+		convertToStatic,
+	} = dynamic;
+
+	// Converting to a static gallery materializes editable inner blocks, which
+	// is a structural change. Only offer it when the block is fully editable:
+	// under a content lock (e.g. inside a `contentOnly` group) the editing mode
+	// is `'contentOnly'`/`'disabled'`, where structural toolbar controls are
+	// hidden and the conversion shouldn't be possible.
+	const blockEditingMode = useBlockEditingMode();
+
+	return (
+		<>
+			{ blockEditingMode === 'default' && (
+				<BlockControls group="other">
+					<ToolbarButton onClick={ convertToStatic }>
+						{ __( 'Edit images' ) }
+					</ToolbarButton>
+				</BlockControls>
+			) }
+			{ dynamicImageBlocks.length ? (
+				<BlockContextProvider value={ galleryContext }>
+					<GalleryImagesPreview
+						imageBlocks={ dynamicImageBlocks }
+						blockProps={ blockProps }
+					/>
+				</BlockContextProvider>
+			) : (
+				<View { ...blockProps }>
+					<Placeholder
+						icon={ sharedIcon }
+						label={ __( 'Gallery' ) }
+						instructions={
+							isResolvingDynamic
+								? __( 'Loading attached images…' )
+								: __(
+										'No images are attached to the post yet.'
+								  )
+						}
+					>
+						{ isResolvingDynamic && <Spinner /> }
+					</Placeholder>
+				</View>
+			) }
+			{ /*
+			 * Dynamic mode shows a preview instead of real inner blocks, but the
+			 * empty inner blocks are still rendered here for their side effect:
+			 * the `allowedBlocks: []` passed to `useInnerBlocksProps` only syncs
+			 * to block list settings while the inner blocks are mounted (via
+			 * `useNestedSettingsUpdate`). That setting is what blocks insertion
+			 * (`canInsertBlockType`) and hides the now-unusable List View
+			 * (`shouldRenderBlockListView`). With no inner blocks and no appender,
+			 * this renders no output of its own.
+			 */ }
+			{ innerBlocksProps.children }
+		</>
+	);
+}

--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -27,12 +27,7 @@ import {
  */
 import { sharedIcon } from './shared-icon';
 import { Caption } from '../utils/caption';
-import {
-	getSourceDescription,
-	DEFAULT_ORDERBY,
-	DEFAULT_ORDER,
-	MAX_IMAGES,
-} from './dynamic-source';
+import { DEFAULT_ORDERBY, DEFAULT_ORDER, MAX_IMAGES } from './dynamic-source';
 
 /**
  * Ordering options for a dynamic gallery source. Each value is a composite
@@ -102,6 +97,7 @@ export function GallerySourcePanel( {
 	const {
 		dynamicContent,
 		canUseDynamicSource,
+		sourceDescriptor,
 		sourceOrderby,
 		sourceOrder,
 		setSourceOrder,
@@ -135,7 +131,8 @@ export function GallerySourcePanel( {
 			>
 				<div className="wp-block-gallery__source-settings">
 					<p className="wp-block-gallery__source-description">
-						{ getSourceDescription( dynamicContent ) }
+						{ sourceDescriptor?.description ??
+							__( 'Dynamic images.' ) }
 					</p>
 					<Button
 						__next40pxDefaultSize
@@ -157,9 +154,9 @@ export function GallerySourcePanel( {
 						isDismissible={ false }
 					>
 						{ sprintf(
-							/* translators: 1: number of images shown. 2: total number of attached images. */
+							/* translators: 1: number of images shown. 2: total number of matching images. */
 							__(
-								'Only the first %1$d of %2$d attached images will be displayed.'
+								'Only the first %1$d of %2$d images will be displayed.'
 							),
 							MAX_IMAGES,
 							dynamicMediaTotal
@@ -199,6 +196,13 @@ export function GallerySourcePanel( {
 		<>
 			<PanelBody title={ __( 'Source' ) }>
 				<div className="wp-block-gallery__source-settings">
+					{ /*
+					 * Hardcoded on purpose: this single-source entry button (and
+					 * its confirm dialog below) is temporary. Once more sources
+					 * exist it becomes a "Choose source" select whose options read
+					 * from each source descriptor's `title`, with help text
+					 * carrying the per-source explanation this string does today.
+					 */ }
 					<Button
 						__next40pxDefaultSize
 						variant="secondary"
@@ -296,11 +300,11 @@ export function GalleryDynamicView( {
 	multiGallerySelection,
 } ) {
 	const {
+		sourceDescriptor,
 		dynamicImageBlocks,
 		galleryContext,
 		isResolvingDynamic,
 		convertToStatic,
-		hasCurrentPost,
 	} = dynamic;
 
 	// Converting to a static gallery materializes editable inner blocks, which
@@ -310,20 +314,15 @@ export function GalleryDynamicView( {
 	// hidden and the conversion shouldn't be possible.
 	const blockEditingMode = useBlockEditingMode();
 
-	// Empty-state copy for the preview. With a concrete post, an empty result
-	// genuinely means the post has no attached images. While editing a post-bound
-	// template there's no post to preview yet, so frame the empty preview as
-	// resolving at render time rather than as a missing-images problem.
-	let emptyInstructions;
-	if ( isResolvingDynamic ) {
-		emptyInstructions = __( 'Loading attached images…' );
-	} else if ( hasCurrentPost ) {
-		emptyInstructions = __( 'No images are attached to the post yet.' );
-	} else {
-		emptyInstructions = __(
-			'Images attached to the post will appear here when this template is viewed.'
-		);
-	}
+	// Empty-state copy for the preview. Framed as forward-looking ("… will appear
+	// here") rather than as an error, since the same empty result covers both a
+	// post with no matching images and a template with no post in context yet —
+	// in either case the source simply resolves to nothing right now. The per-
+	// source wording comes from the source descriptor.
+	const emptyInstructions = isResolvingDynamic
+		? __( 'Loading images…' )
+		: sourceDescriptor?.emptyMessage ??
+		  __( 'Dynamic images will appear here.' );
 
 	return (
 		<>

--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -105,6 +105,7 @@ export function GallerySourcePanel( {
 		convertToStatic,
 		enableDynamicMode,
 		resetSource,
+		isResolvingDynamic,
 	} = dynamic;
 	const isDynamic = !! dynamicContent;
 
@@ -135,6 +136,11 @@ export function GallerySourcePanel( {
 						__next40pxDefaultSize
 						variant="secondary"
 						onClick={ convertToStatic }
+						// Guard the race where the media is still resolving:
+						// converting now would map over an incomplete (or empty)
+						// list and produce a gallery missing images.
+						disabled={ isResolvingDynamic }
+						accessibleWhenDisabled
 					>
 						{ __( 'Convert to individual images' ) }
 					</Button>
@@ -278,7 +284,14 @@ export function GalleryDynamicView( {
 		<>
 			{ blockEditingMode === 'default' && (
 				<BlockControls group="other">
-					<ToolbarButton onClick={ convertToStatic }>
+					<ToolbarButton
+						onClick={ convertToStatic }
+						// Same guard as the inspector's "Convert to individual
+						// images": both call `convertToStatic`, which would map over
+						// a still-resolving (or empty) media list. (`ToolbarButton`
+						// stays focusable when disabled by default.)
+						disabled={ isResolvingDynamic }
+					>
 						{ __( 'Edit images' ) }
 					</ToolbarButton>
 				</BlockControls>

--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -1,10 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import {
 	Button,
+	Notice,
 	PanelBody,
 	Placeholder,
 	SelectControl,
@@ -30,6 +31,7 @@ import {
 	getSourceDescription,
 	DEFAULT_ORDERBY,
 	DEFAULT_ORDER,
+	MAX_IMAGES,
 } from './dynamic-source';
 
 /**
@@ -107,6 +109,8 @@ export function GallerySourcePanel( {
 		enableDynamicMode,
 		resetSource,
 		isResolvingDynamic,
+		hasMoreImagesThanCap,
+		dynamicMediaTotal,
 	} = dynamic;
 	const isDynamic = !! dynamicContent;
 
@@ -146,6 +150,22 @@ export function GallerySourcePanel( {
 						{ __( 'Convert to individual images' ) }
 					</Button>
 				</div>
+				{ hasMoreImagesThanCap && (
+					<Notice
+						className="wp-block-gallery__source-notice"
+						status="warning"
+						isDismissible={ false }
+					>
+						{ sprintf(
+							/* translators: 1: number of images shown. 2: total number of attached images. */
+							__(
+								'Only the first %1$d of %2$d attached images will be displayed.'
+							),
+							MAX_IMAGES,
+							dynamicMediaTotal
+						) }
+					</Notice>
+				) }
 				<ToolsPanelItem
 					isShownByDefault
 					label={ __( 'Order by' ) }

--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -20,12 +20,12 @@ import {
 	useBlockEditingMode,
 	__experimentalUseBlockPreview as useBlockPreview,
 } from '@wordpress/block-editor';
-import { View } from '@wordpress/primitives';
 
 /**
  * Internal dependencies
  */
 import { sharedIcon } from './shared-icon';
+import { Caption } from '../utils/caption';
 import {
 	getSourceDescription,
 	DEFAULT_ORDERBY,
@@ -196,44 +196,69 @@ export function GallerySourcePanel( {
 }
 
 /**
- * Renders the resolved image blocks as a single, non-editable preview.
+ * Renders the resolved image blocks as a read-only preview.
  *
- * `useBlockPreview` is given the gallery's own block props (so the `<figure>`
- * stays the real block wrapper and the image figures remain direct descendants
- * for the gallery's flex/crop styles).
+ * `useBlockPreview` returns a `useDisabled` ref that makes its subtree inert, so
+ * previewed images (including any links) aren't interactive in the editor. The
+ * ref needs a real element, yet the images must stay flex children of the gallery
+ * `<figure>` and sit beside an editable caption. `display: contents` resolves
+ * this: the wrapper carries the ref but generates no box, so the image figures
+ * remain the figure's flex items and only they are disabled — the caption sibling
+ * stays editable. This relies on the gallery's image styles using descendant
+ * (not direct-child) selectors, which the box-less wrapper leaves intact.
  *
  * @param {Object}   props
  * @param {Object[]} props.imageBlocks Non-persisted `core/image` blocks to preview.
- * @param {Object}   props.blockProps  The gallery's `useBlockProps()` result.
  */
-function GalleryImagesPreview( { imageBlocks, blockProps } ) {
-	const previewProps = useBlockPreview( {
+function GalleryImagesPreview( { imageBlocks } ) {
+	const { children, ref, className } = useBlockPreview( {
 		blocks: imageBlocks,
-		props: blockProps,
 	} );
-	return <figure { ...previewProps } />;
+	return (
+		<div
+			ref={ ref }
+			className={ className }
+			style={ { display: 'contents' } }
+		>
+			{ children }
+		</div>
+	);
 }
 
 /**
  * Renders a dynamic-mode gallery on the canvas:
  *
  * - a block-toolbar control to convert back to individual images;
- * - a non-editable preview of the resolved media (or a placeholder while
- *   resolving / when nothing is found), with the gallery's provided context so
- *   the previewed images inherit gallery-wide settings;
+ * - the gallery `<figure>` wrapper holding a non-editable preview of the
+ *   resolved media (or a placeholder while resolving / when nothing is found),
+ *   with the gallery's provided context so the previewed images inherit
+ *   gallery-wide settings;
+ * - an editable gallery-level caption, alongside the read-only preview;
  * - the (empty) inner blocks kept mounted so the container's `allowedBlocks: []`
  *   keeps syncing to block list settings (which blocks insertion and hides the
  *   List View).
  *
- * @param {Object} props
- * @param {Object} props.dynamic          The `useDynamicGallery` result.
- * @param {Object} props.blockProps       The gallery's `useBlockProps()` result.
- * @param {Object} props.innerBlocksProps The gallery's `useInnerBlocksProps()` result.
+ * @param {Object}   props
+ * @param {Object}   props.dynamic               The `useDynamicGallery` result.
+ * @param {Object}   props.blockProps            The gallery's `useBlockProps()` result.
+ * @param {Object}   props.innerBlocksProps      The gallery's `useInnerBlocksProps()` result.
+ * @param {Object}   props.attributes            The gallery block attributes.
+ * @param {Function} props.setAttributes         The block's `setAttributes`.
+ * @param {boolean}  props.isSelected            Whether the gallery block is selected.
+ * @param {Function} props.insertBlocksAfter     Inserts blocks after the gallery.
+ * @param {boolean}  props.isContentLocked       Whether the gallery is content-locked.
+ * @param {boolean}  props.multiGallerySelection Whether multiple galleries are selected.
  */
 export function GalleryDynamicView( {
 	dynamic,
 	blockProps,
 	innerBlocksProps,
+	attributes,
+	setAttributes,
+	isSelected,
+	insertBlocksAfter,
+	isContentLocked,
+	multiGallerySelection,
 } ) {
 	const {
 		dynamicImageBlocks,
@@ -258,15 +283,14 @@ export function GalleryDynamicView( {
 					</ToolbarButton>
 				</BlockControls>
 			) }
-			{ dynamicImageBlocks.length ? (
-				<BlockContextProvider value={ galleryContext }>
-					<GalleryImagesPreview
-						imageBlocks={ dynamicImageBlocks }
-						blockProps={ blockProps }
-					/>
-				</BlockContextProvider>
-			) : (
-				<View { ...blockProps }>
+			<figure { ...blockProps }>
+				{ dynamicImageBlocks.length ? (
+					<BlockContextProvider value={ galleryContext }>
+						<GalleryImagesPreview
+							imageBlocks={ dynamicImageBlocks }
+						/>
+					</BlockContextProvider>
+				) : (
 					<Placeholder
 						icon={ sharedIcon }
 						label={ __( 'Gallery' ) }
@@ -280,8 +304,20 @@ export function GalleryDynamicView( {
 					>
 						{ isResolvingDynamic && <Spinner /> }
 					</Placeholder>
-				</View>
-			) }
+				) }
+				<Caption
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+					isSelected={ isSelected }
+					insertBlocksAfter={ insertBlocksAfter }
+					showToolbarButton={
+						! multiGallerySelection && ! isContentLocked
+					}
+					className="blocks-gallery-caption"
+					label={ __( 'Gallery caption text' ) }
+					placeholder={ __( 'Add gallery caption' ) }
+				/>
+			</figure>
 			{ /*
 			 * Dynamic mode shows a preview instead of real inner blocks, but the
 			 * empty inner blocks are still rendered here for their side effect:

--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -99,6 +99,7 @@ export function GallerySourcePanel( {
 } ) {
 	const {
 		dynamicContent,
+		canUseDynamicSource,
 		sourceOrderby,
 		sourceOrder,
 		setSourceOrder,
@@ -164,6 +165,16 @@ export function GallerySourcePanel( {
 				</ToolsPanelItem>
 			</ToolsPanel>
 		);
+	}
+
+	// In static mode the panel only offers a way into dynamic mode, which is
+	// meaningful where the block can resolve against a post: a real post, or a
+	// post-bound template whose post is filled in at render time. Elsewhere
+	// (template part, pattern, generic template) the sole source can never
+	// resolve, leaving nothing to show — so hide the panel rather than present a
+	// dead control. Once other sources exist, render whenever ANY is available.
+	if ( ! canUseDynamicSource ) {
+		return null;
 	}
 
 	return (
@@ -271,6 +282,7 @@ export function GalleryDynamicView( {
 		galleryContext,
 		isResolvingDynamic,
 		convertToStatic,
+		hasCurrentPost,
 	} = dynamic;
 
 	// Converting to a static gallery materializes editable inner blocks, which
@@ -279,6 +291,21 @@ export function GalleryDynamicView( {
 	// is `'contentOnly'`/`'disabled'`, where structural toolbar controls are
 	// hidden and the conversion shouldn't be possible.
 	const blockEditingMode = useBlockEditingMode();
+
+	// Empty-state copy for the preview. With a concrete post, an empty result
+	// genuinely means the post has no attached images. While editing a post-bound
+	// template there's no post to preview yet, so frame the empty preview as
+	// resolving at render time rather than as a missing-images problem.
+	let emptyInstructions;
+	if ( isResolvingDynamic ) {
+		emptyInstructions = __( 'Loading attached images…' );
+	} else if ( hasCurrentPost ) {
+		emptyInstructions = __( 'No images are attached to the post yet.' );
+	} else {
+		emptyInstructions = __(
+			'Images attached to the post will appear here when this template is viewed.'
+		);
+	}
 
 	return (
 		<>
@@ -307,13 +334,7 @@ export function GalleryDynamicView( {
 					<Placeholder
 						icon={ sharedIcon }
 						label={ __( 'Gallery' ) }
-						instructions={
-							isResolvingDynamic
-								? __( 'Loading attached images…' )
-								: __(
-										'No images are attached to the post yet.'
-								  )
-						}
+						instructions={ emptyInstructions }
 					>
 						{ isResolvingDynamic && <Spinner /> }
 					</Placeholder>

--- a/packages/block-library/src/gallery/dynamic-source.js
+++ b/packages/block-library/src/gallery/dynamic-source.js
@@ -33,7 +33,7 @@ const DYNAMIC_SOURCES = {
 	[ ATTACHED_MEDIA ]: {
 		// Short label for the entry affordance / future source chooser. Mirrors
 		// the "Attached images" media inserter category name.
-		title: __( 'Attached images' ),
+		title: __( 'Use attached images' ),
 		// Help text shown beneath the Source controls.
 		description: __( 'Images attached to the post.' ),
 		// Empty-state copy for the canvas preview.

--- a/packages/block-library/src/gallery/dynamic-source.js
+++ b/packages/block-library/src/gallery/dynamic-source.js
@@ -4,6 +4,14 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Source discriminator for "images attached to the post" — the only dynamic
+ * source implemented so far. Kept as a named constant since it's referenced from
+ * several call sites (the query builder, the descriptor, and the entry points
+ * that switch a gallery into dynamic mode).
+ */
+export const ATTACHED_MEDIA = 'core/attached-media';
+
+/**
  * Default ordering for a dynamic source. `menu_order` (the manual media-library
  * order) is intentionally not used: it isn't a valid `orderby` value on the
  * media REST endpoint, so the editor preview couldn't reproduce it. Both the
@@ -12,6 +20,37 @@ import { __ } from '@wordpress/i18n';
  */
 export const DEFAULT_ORDERBY = 'date';
 export const DEFAULT_ORDER = 'desc';
+
+/**
+ * Per-source copy, keyed by the `source` discriminator in a gallery's
+ * `dynamicContent`. Adding a dynamic source means adding an entry here; the
+ * editor components read these strings instead of hardcoding source-specific
+ * wording. The fields also map onto a future "Choose source" control: `title`
+ * becomes an option label, `description` its help text, and `emptyMessage` the
+ * canvas preview when the source resolves to nothing.
+ */
+const DYNAMIC_SOURCES = {
+	[ ATTACHED_MEDIA ]: {
+		// Short label for the entry affordance / future source chooser. Mirrors
+		// the "Attached images" media inserter category name.
+		title: __( 'Attached images' ),
+		// Help text shown beneath the Source controls.
+		description: __( 'Images attached to the post.' ),
+		// Empty-state copy for the canvas preview.
+		emptyMessage: __( 'Images attached to the post will appear here.' ),
+	},
+};
+
+/**
+ * Returns the descriptor for a dynamic source, or `undefined` for an unknown or
+ * not-yet-implemented source.
+ *
+ * @param {?string} source The `dynamicContent.source` discriminator.
+ * @return {?Object} The source descriptor (`title`, `description`, `emptyMessage`).
+ */
+export function getDynamicSource( source ) {
+	return DYNAMIC_SOURCES[ source ];
+}
 
 /**
  * Upper bound on the number of images a dynamic source resolves, so the editor
@@ -45,7 +84,7 @@ export function getSourceQuery( dynamicContent, { postId } ) {
 	const { source, args = {} } = dynamicContent ?? {};
 
 	switch ( source ) {
-		case 'core/attached-media':
+		case ATTACHED_MEDIA:
 			if ( ! postId ) {
 				return null;
 			}
@@ -66,20 +105,4 @@ export function getSourceQuery( dynamicContent, { postId } ) {
 
 	// Unknown or not-yet-implemented source.
 	return null;
-}
-
-/**
- * Returns a sentence describing a `dynamicContent`, for use as help text beneath
- * the Source controls.
- *
- * @param {Object} dynamicContent The gallery's `dynamicContent` attribute.
- * @return {string} A translated description.
- */
-export function getSourceDescription( dynamicContent ) {
-	switch ( dynamicContent?.source ) {
-		case 'core/attached-media':
-			return __( 'Images attached to the post.' );
-	}
-
-	return __( 'Dynamic images.' );
 }

--- a/packages/block-library/src/gallery/dynamic-source.js
+++ b/packages/block-library/src/gallery/dynamic-source.js
@@ -53,9 +53,9 @@ export function getDynamicSource( source ) {
 }
 
 /**
- * Upper bound on the number of images a dynamic source resolves, so the editor
- * query and the server render stay bounded. Kept in sync with the
- * `posts_per_page` cap in `block_core_gallery_resolve_dynamic_source()`.
+ * Upper bound on the number of images a dynamic source resolves, until the
+ * gallery supports pagination. Kept in sync with the `posts_per_page` cap in
+ * `block_core_gallery_resolve_dynamic_source()`.
  */
 export const MAX_IMAGES = 100;
 

--- a/packages/block-library/src/gallery/dynamic-source.js
+++ b/packages/block-library/src/gallery/dynamic-source.js
@@ -18,7 +18,7 @@ export const DEFAULT_ORDER = 'desc';
  * query and the server render stay bounded. Kept in sync with the
  * `posts_per_page` cap in `block_core_gallery_resolve_dynamic_source()`.
  */
-const MAX_IMAGES = 100;
+export const MAX_IMAGES = 100;
 
 /**
  * Maps a gallery's `dynamicContent` attribute to a query for the `attachment`

--- a/packages/block-library/src/gallery/dynamic-source.js
+++ b/packages/block-library/src/gallery/dynamic-source.js
@@ -1,0 +1,85 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Default ordering for a dynamic source. `menu_order` (the manual media-library
+ * order) is intentionally not used: it isn't a valid `orderby` value on the
+ * media REST endpoint, so the editor preview couldn't reproduce it. Both the
+ * editor query and the server resolver default to the same REST-supported order
+ * so the preview matches the frontend.
+ */
+export const DEFAULT_ORDERBY = 'date';
+export const DEFAULT_ORDER = 'desc';
+
+/**
+ * Upper bound on the number of images a dynamic source resolves, so the editor
+ * query and the server render stay bounded. Kept in sync with the
+ * `posts_per_page` cap in `block_core_gallery_resolve_dynamic_source()`.
+ */
+const MAX_IMAGES = 100;
+
+/**
+ * Maps a gallery's `dynamicContent` attribute to a query for the `attachment`
+ * entity (i.e. `/wp/v2/media` collection params), used to resolve the source to
+ * a list of media in the editor.
+ *
+ * The `source` key is the dispatch discriminator and `args` holds the
+ * source's parameters. This `{ source, args }` shape mirrors the Block
+ * Bindings metadata shape (`metadata.bindings.<key> = { source, args }`) so
+ * dynamic mode can migrate to an `innerBlocks` binding with minimal change.
+ * `args` keys are camelCase (the block-attribute convention, as used by the
+ * Query block's `query` attribute); each source's resolver maps them to the
+ * REST/transport names it needs. `core/attached-media` is a context-relative anchor
+ * resolved here to the REST `parent` param. The server-side counterpart is
+ * `block_core_gallery_resolve_dynamic_source()` in `index.php`.
+ *
+ * @param {Object} dynamicContent The gallery's `dynamicContent` attribute.
+ * @param {Object} context        Resolution context.
+ * @param {number} context.postId The current post ID.
+ * @return {Object|null} A `getEntityRecords` query, or `null` when the source
+ *                       cannot be resolved (unknown source or missing context).
+ */
+export function getSourceQuery( dynamicContent, { postId } ) {
+	const { source, args = {} } = dynamicContent ?? {};
+
+	switch ( source ) {
+		case 'core/attached-media':
+			if ( ! postId ) {
+				return null;
+			}
+			return {
+				parent: postId,
+				per_page: MAX_IMAGES,
+				// The gallery only accepts images, so constrain the source to
+				// image media (matching the server resolver). This keeps the
+				// editor preview in step with the rendered output for posts
+				// that also have non-image attachments.
+				media_type: 'image',
+				// Map the camelCase `args` to the REST-named media collection
+				// params, falling back to the shared defaults.
+				orderby: args.orderBy ?? DEFAULT_ORDERBY,
+				order: args.order ?? DEFAULT_ORDER,
+			};
+	}
+
+	// Unknown or not-yet-implemented source.
+	return null;
+}
+
+/**
+ * Returns a sentence describing a `dynamicContent`, for use as help text beneath
+ * the Source controls.
+ *
+ * @param {Object} dynamicContent The gallery's `dynamicContent` attribute.
+ * @return {string} A translated description.
+ */
+export function getSourceDescription( dynamicContent ) {
+	switch ( dynamicContent?.source ) {
+		case 'core/attached-media':
+			return __( 'Images attached to the post.' );
+	}
+
+	return __( 'Dynamic images.' );
+}

--- a/packages/block-library/src/gallery/dynamic-source.js
+++ b/packages/block-library/src/gallery/dynamic-source.js
@@ -97,9 +97,18 @@ export function getSourceQuery( dynamicContent, { postId } ) {
 				// that also have non-image attachments.
 				media_type: 'image',
 				// Map the camelCase `args` to the REST-named media collection
-				// params, falling back to the shared defaults.
-				orderby: args.orderBy ?? DEFAULT_ORDERBY,
-				order: args.order ?? DEFAULT_ORDER,
+				// params. Unexpected values (only reachable via hand-edited
+				// markup) are coerced back to the defaults — mirroring the server
+				// resolver's allow list — so the editor preview stays in step with
+				// the frontend instead of issuing an invalid REST query.
+				orderby:
+					args.orderBy === 'date' || args.orderBy === 'title'
+						? args.orderBy
+						: DEFAULT_ORDERBY,
+				order:
+					args.order === 'asc' || args.order === 'desc'
+						? args.order
+						: DEFAULT_ORDER,
 			};
 	}
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -69,6 +69,7 @@ import useGetMedia from './use-get-media';
 import GapStyles from './gap-styles';
 import useDynamicGallery from './use-dynamic-gallery';
 import { GallerySourcePanel, GalleryDynamicView } from './dynamic-gallery';
+import { getDynamicSource, ATTACHED_MEDIA } from './dynamic-source';
 
 const MAX_COLUMNS = 8;
 const LINK_OPTIONS = [
@@ -713,7 +714,7 @@ export default function GalleryEdit( props ) {
 							variant="secondary"
 							onClick={ dynamic.enableDynamicMode }
 						>
-							{ __( 'Attached images' ) }
+							{ getDynamicSource( ATTACHED_MEDIA ).title }
 						</Button>
 					) }
 				</MediaPlaceholder>

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -17,6 +17,7 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	ToolbarDropdownMenu,
+	Button,
 } from '@wordpress/components';
 import {
 	store as blockEditorStore,
@@ -65,6 +66,8 @@ import useImageSizes from './use-image-sizes';
 import useGetNewImages from './use-get-new-images';
 import useGetMedia from './use-get-media';
 import GapStyles from './gap-styles';
+import useDynamicGallery from './use-dynamic-gallery';
+import { GallerySourcePanel, GalleryDynamicView } from './dynamic-gallery';
 
 const MAX_COLUMNS = 8;
 const LINK_OPTIONS = [
@@ -126,7 +129,11 @@ export default function GalleryEdit( props ) {
 		isSelected,
 		insertBlocksAfter,
 		isContentLocked,
+		context,
+		__unstableLayoutClassNames: layoutClassNames,
 	} = props;
+
+	const postId = context?.postId;
 
 	const [ lightboxSetting, defaultRatios, themeRatios, showDefaultRatios ] =
 		useSettings(
@@ -143,6 +150,7 @@ export default function GalleryEdit( props ) {
 		: LINK_OPTIONS;
 
 	const {
+		align,
 		navigationButtonType,
 		columns,
 		imageCrop,
@@ -205,15 +213,43 @@ export default function GalleryEdit( props ) {
 
 	const newImages = useGetNewImages( images, imageData );
 
-	// Check if there is at least one image with lightbox enabled
-	const hasLightboxImages = lightboxSetting?.enabled
-		? images.filter(
+	const hasImages = !! images.length;
+	const isDynamic = !! attributes.dynamicContent;
+
+	// Dynamic mode (resolving images from a source instead of inner blocks):
+	// source resolution, the editor-preview blocks, and the mode/ordering
+	// actions.
+	const dynamic = useDynamicGallery( {
+		attributes,
+		setAttributes,
+		clientId,
+		postId,
+	} );
+
+	// State that drives counts/size options should reflect the dynamic media
+	// when the gallery is in dynamic mode.
+	const displayedImageCount = isDynamic
+		? dynamic.dynamicMedia.length
+		: images.length;
+
+	// Check if there is at least one image with lightbox enabled. In dynamic
+	// mode the images inherit the gallery's link setting, so the lightbox is on
+	// when the gallery links images to the lightbox.
+	let hasLightboxImages;
+	if ( isDynamic ) {
+		hasLightboxImages = linkTo === LINK_DESTINATION_LIGHTBOX;
+	} else if ( lightboxSetting?.enabled ) {
+		hasLightboxImages =
+			images.filter(
 				( image ) =>
 					image.attributes?.lightbox?.enabled === undefined ||
 					image.attributes?.lightbox?.enabled === true
-		  ).length > 0
-		: images.filter( ( image ) => image.attributes.lightbox?.enabled )
+			).length > 0;
+	} else {
+		hasLightboxImages =
+			images.filter( ( image ) => image.attributes.lightbox?.enabled )
 				.length > 0;
+	}
 
 	const themeOptions = themeRatios?.map( ( { name, ratio } ) => ( {
 		label: name,
@@ -248,7 +284,7 @@ export default function GalleryEdit( props ) {
 	}, [ newImages ] );
 
 	const imageSizeOptions = useImageSizes(
-		imageData,
+		isDynamic ? dynamic.dynamicMedia : imageData,
 		isSelected,
 		getSettings
 	);
@@ -566,7 +602,6 @@ export default function GalleryEdit( props ) {
 		}
 	}, [ linkTo ] );
 
-	const hasImages = !! images.length;
 	const hasImageIds = hasImages && images.some( ( image ) => !! image.id );
 	const imagesUploading = images.some(
 		( img ) => ! img.id && img.url?.indexOf( 'blob:' ) === 0
@@ -594,7 +629,25 @@ export default function GalleryEdit( props ) {
 	);
 
 	const blockProps = useBlockProps( {
-		className: clsx( className, 'has-nested-images' ),
+		className: clsx(
+			className,
+			'has-nested-images',
+			// In dynamic mode there are no inner blocks and the gallery isn't
+			// rendered through the `Gallery` component, so the classes that
+			// component normally composes onto the `<figure>` (see `gallery.js`)
+			// must be added here to keep the preview's flex/crop layout matching
+			// the static gallery and the frontend.
+			isDynamic && [
+				layoutClassNames,
+				'blocks-gallery-grid',
+				{
+					[ `align${ align }` ]: align,
+					[ `columns-${ columns }` ]: columns !== undefined,
+					'columns-default': columns === undefined,
+					'is-cropped': imageCrop,
+				},
+			]
+		),
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
@@ -602,15 +655,46 @@ export default function GalleryEdit( props ) {
 		directInsert: true,
 		orientation: 'horizontal',
 		renderAppender: false,
+		// In dynamic mode nothing may be inserted: the images are resolved from
+		// the source, not authored as inner blocks. `allowedBlocks: []` enforces
+		// this in every context — unlike `templateLock: 'all'`, it isn't relaxed
+		// to `contentOnly` by a content-locked ancestor — so it blocks insertion
+		// and drag-and-drop (via `canInsertBlockType`). It's also what opts the
+		// gallery out of the List View: a block that can't be inserted into and
+		// has no inner blocks has nothing to navigate or add (see
+		// `shouldRenderBlockListView`). This reaches the block's list settings
+		// only while the inner blocks are mounted, which is why the dynamic view
+		// still renders the (empty) inner blocks.
+		allowedBlocks: isDynamic ? EMPTY_ARRAY : undefined,
 	} );
 
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
-	if ( ! hasImages ) {
+	if ( ! hasImages && ! isDynamic ) {
 		return (
 			<div { ...innerBlocksProps }>
 				{ innerBlocksProps.children }
-				{ mediaPlaceholder }
+				<MediaPlaceholder
+					handleUpload={ false }
+					icon={ sharedIcon }
+					labels={ {
+						title: __( 'Gallery' ),
+						instructions: PLACEHOLDER_TEXT,
+					} }
+					onSelect={ updateImages }
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					multiple
+					onError={ onUploadError }
+					{ ...mediaPlaceholderProps }
+				>
+					<Button
+						__next40pxDefaultSize
+						variant="secondary"
+						onClick={ dynamic.enableDynamicMode }
+					>
+						{ __( 'Use images attached to the post' ) }
+					</Button>
+				</MediaPlaceholder>
 			</div>
 		);
 	}
@@ -620,6 +704,11 @@ export default function GalleryEdit( props ) {
 	return (
 		<>
 			<InspectorControls>
+				<GallerySourcePanel
+					dynamic={ dynamic }
+					dropdownMenuProps={ dropdownMenuProps }
+					hasImages={ hasImages }
+				/>
 				<ToolsPanel
 					label={ __( 'Settings' ) }
 					resetAll={ () => {
@@ -642,12 +731,12 @@ export default function GalleryEdit( props ) {
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
-					{ images.length > 1 && (
+					{ displayedImageCount > 1 && (
 						<ToolsPanelItem
 							isShownByDefault
 							label={ __( 'Columns' ) }
 							hasValue={ () =>
-								!! columns && columns !== images.length
+								!! columns && columns !== displayedImageCount
 							}
 							onDeselect={ () => setColumnsNumber( undefined ) }
 						>
@@ -656,11 +745,16 @@ export default function GalleryEdit( props ) {
 								value={
 									columns
 										? columns
-										: defaultColumnsNumber( images.length )
+										: defaultColumnsNumber(
+												displayedImageCount
+										  )
 								}
 								onChange={ setColumnsNumber }
 								min={ 1 }
-								max={ Math.min( MAX_COLUMNS, images.length ) }
+								max={ Math.min(
+									MAX_COLUMNS,
+									displayedImageCount
+								) }
 								required
 							/>
 						</ToolsPanelItem>
@@ -825,7 +919,7 @@ export default function GalleryEdit( props ) {
 				</ToolbarDropdownMenu>
 			</BlockControls>
 			<>
-				{ ! multiGallerySelection && (
+				{ ! multiGallerySelection && ! isDynamic && (
 					<BlockControls group="other">
 						<MediaReplaceFlow
 							allowedTypes={ ALLOWED_MEDIA_TYPES }
@@ -846,15 +940,25 @@ export default function GalleryEdit( props ) {
 					clientId={ clientId }
 				/>
 			</>
-			<Gallery
-				{ ...props }
-				isContentLocked={ isContentLocked }
-				images={ images }
-				mediaPlaceholder={ ! hasImages ? mediaPlaceholder : undefined }
-				blockProps={ innerBlocksProps }
-				insertBlocksAfter={ insertBlocksAfter }
-				multiGallerySelection={ multiGallerySelection }
-			/>
+			{ isDynamic ? (
+				<GalleryDynamicView
+					dynamic={ dynamic }
+					blockProps={ blockProps }
+					innerBlocksProps={ innerBlocksProps }
+				/>
+			) : (
+				<Gallery
+					{ ...props }
+					isContentLocked={ isContentLocked }
+					images={ images }
+					mediaPlaceholder={
+						! hasImages ? mediaPlaceholder : undefined
+					}
+					blockProps={ innerBlocksProps }
+					insertBlocksAfter={ insertBlocksAfter }
+					multiGallerySelection={ multiGallerySelection }
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -942,9 +942,11 @@ export default function GalleryEdit( props ) {
 			</>
 			{ isDynamic ? (
 				<GalleryDynamicView
+					{ ...props }
 					dynamic={ dynamic }
 					blockProps={ blockProps }
 					innerBlocksProps={ innerBlocksProps }
+					multiGallerySelection={ multiGallerySelection }
 				/>
 			) : (
 				<Gallery

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -134,6 +134,7 @@ export default function GalleryEdit( props ) {
 	} = props;
 
 	const postId = context?.postId;
+	const postType = context?.postType;
 
 	const [ lightboxSetting, defaultRatios, themeRatios, showDefaultRatios ] =
 		useSettings(
@@ -224,6 +225,7 @@ export default function GalleryEdit( props ) {
 		setAttributes,
 		clientId,
 		postId,
+		postType,
 	} );
 
 	// State that drives counts/size options should reflect the dynamic media

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -703,7 +703,7 @@ export default function GalleryEdit( props ) {
 							variant="secondary"
 							onClick={ dynamic.enableDynamicMode }
 						>
-							{ __( 'Use images attached to the post' ) }
+							{ __( 'Attached images' ) }
 						</Button>
 					) }
 				</MediaPlaceholder>

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -697,6 +697,16 @@ export default function GalleryEdit( props ) {
 					onError={ onUploadError }
 					{ ...mediaPlaceholderProps }
 				>
+					{ /*
+					 * Entry into dynamic mode. Gated on the editing mode so it's
+					 * hidden in content-only editing (where this structural change
+					 * isn't allowed), but intentionally not hidden by
+					 * `canUseDynamicSource` the way the inspector is (see
+					 * `dynamic-gallery.js`): even with no
+					 * post type to preview against, the source still resolves at
+					 * render time via `get_the_ID()` (see `index.php`) — e.g. in a
+					 * template part or pattern shown on a singular page.
+					 */ }
 					{ blockEditingMode === 'default' && (
 						<Button
 							__next40pxDefaultSize

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -623,21 +623,6 @@ export default function GalleryEdit( props ) {
 		disableMediaButtons: imagesUploading,
 		value: {},
 	};
-	const mediaPlaceholder = (
-		<MediaPlaceholder
-			handleUpload={ false }
-			icon={ sharedIcon }
-			labels={ {
-				title: __( 'Gallery' ),
-				instructions: PLACEHOLDER_TEXT,
-			} }
-			onSelect={ updateImages }
-			allowedTypes={ ALLOWED_MEDIA_TYPES }
-			multiple
-			onError={ onUploadError }
-			{ ...mediaPlaceholderProps }
-		/>
-	);
 
 	const blockProps = useBlockProps( {
 		className: clsx(
@@ -976,9 +961,6 @@ export default function GalleryEdit( props ) {
 					{ ...props }
 					isContentLocked={ isContentLocked }
 					images={ images }
-					mediaPlaceholder={
-						! hasImages ? mediaPlaceholder : undefined
-					}
 					blockProps={ innerBlocksProps }
 					insertBlocksAfter={ insertBlocksAfter }
 					multiGallerySelection={ multiGallerySelection }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -25,6 +25,7 @@ import {
 	InspectorControls,
 	useBlockProps,
 	useInnerBlocksProps,
+	useBlockEditingMode,
 	BlockControls,
 	MediaReplaceFlow,
 	useSettings,
@@ -135,6 +136,13 @@ export default function GalleryEdit( props ) {
 
 	const postId = context?.postId;
 	const postType = context?.postType;
+
+	// Entering dynamic mode is a structural change (it discards inner blocks and
+	// switches the block's mode), so the entry point is only offered when the
+	// block is fully editable — mirroring the dynamic view's "Edit images"
+	// toolbar control. Under a content lock the mode is `'contentOnly'`/
+	// `'disabled'`, where structural affordances are hidden.
+	const blockEditingMode = useBlockEditingMode();
 
 	const [ lightboxSetting, defaultRatios, themeRatios, showDefaultRatios ] =
 		useSettings(
@@ -689,13 +697,15 @@ export default function GalleryEdit( props ) {
 					onError={ onUploadError }
 					{ ...mediaPlaceholderProps }
 				>
-					<Button
-						__next40pxDefaultSize
-						variant="secondary"
-						onClick={ dynamic.enableDynamicMode }
-					>
-						{ __( 'Use images attached to the post' ) }
-					</Button>
+					{ blockEditingMode === 'default' && (
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							onClick={ dynamic.enableDynamicMode }
+						>
+							{ __( 'Use images attached to the post' ) }
+						</Button>
+					) }
 				</MediaPlaceholder>
 			</div>
 		);

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -17,10 +17,6 @@
 		flex: 0 0 100%;
 	}
 
-	> .blocks-gallery-media-placeholder-wrapper {
-		flex-basis: 100%;
-	}
-
 	// @todo this deserves a refactor, by being moved to the toolbar.
 	.block-editor-media-placeholder.is-appender {
 		.components-placeholder__label {

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -143,3 +143,10 @@
 		width: 100%;
 	}
 }
+
+// The "showing the first N" notice is a plain (non-ToolsPanelItem) child of the
+// Source ToolsPanel, so span both grid columns rather than defaulting to one.
+.wp-block-gallery__source-notice {
+	grid-column: 1 / -1;
+	margin: 0;
+}

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -118,3 +118,28 @@
 	justify-content: flex-end;
 	gap: $grid-unit-15;
 }
+
+// The Source controls are a plain (non-ToolsPanelItem) child of the Source
+// ToolsPanel, so they span both grid columns. The description sits above the
+// button so the button is the last element, keeping the same vertical rhythm to
+// the next control (control -> grid row-gap -> next label) as the other rows.
+.wp-block-gallery__source-settings {
+	grid-column: 1 / -1;
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-10;
+
+	// Muted help-text styling for the source description.
+	.wp-block-gallery__source-description {
+		margin: 0;
+		color: $gray-700;
+		font-size: $helptext-font-size;
+	}
+
+	// Full-width action button, matching other inspector buttons (e.g. the
+	// "Apply globally" control).
+	.components-button {
+		justify-content: center;
+		width: 100%;
+	}
+}

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -18,7 +18,6 @@ export default function Gallery( props ) {
 		attributes,
 		isSelected,
 		setAttributes,
-		mediaPlaceholder,
 		insertBlocksAfter,
 		blockProps,
 		__unstableLayoutClassNames: layoutClassNames,
@@ -44,11 +43,6 @@ export default function Gallery( props ) {
 			) }
 		>
 			{ blockProps.children }
-			{ isSelected && ! blockProps.children && (
-				<div className="blocks-gallery-media-placeholder-wrapper">
-					{ mediaPlaceholder }
-				</div>
-			) }
 			<Caption
 				attributes={ attributes }
 				setAttributes={ setAttributes }

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -12,6 +12,7 @@ import edit from './edit';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
+import variations from './variations';
 
 const { name } = metadata;
 
@@ -39,6 +40,7 @@ export const settings = {
 		],
 	},
 	transforms,
+	variations,
 	edit,
 	save,
 	deprecated,

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -101,6 +101,12 @@ function block_core_gallery_resolve_dynamic_source( $source, $block ) {
 			}
 			$order = strtoupper( $args['order'] ?? 'desc' ) === 'ASC' ? 'ASC' : 'DESC';
 
+			// Bound the number of resolved images until the gallery supports
+			// pagination. Kept in sync with the editor query's `per_page` cap; a
+			// case-insensitive grep for `max_images` finds both this and
+			// `MAX_IMAGES` in `dynamic-source.js`.
+			$max_images = 100;
+
 			$query = new WP_Query(
 				array(
 					'post_parent'    => $post_id,
@@ -109,9 +115,7 @@ function block_core_gallery_resolve_dynamic_source( $source, $block ) {
 					'post_mime_type' => 'image',
 					'orderby'        => $orderby,
 					'order'          => $order,
-					// Bounded to match the editor query's `per_page` cap (see
-					// `MAX_IMAGES` in `dynamic-source.js`).
-					'posts_per_page' => 100,
+					'posts_per_page' => $max_images,
 					'fields'         => 'ids',
 					'no_found_rows'  => true,
 				)

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -254,13 +254,22 @@ function block_core_gallery_render_dynamic_image( $attachment_id, $attributes, $
  * @return string The content of the block being rendered.
  */
 function block_core_gallery_render( $attributes, $content, $block ) {
-	// In dynamic mode the gallery persists no markup (`save.js` returns null);
-	// resolve the configured source to a list of attachments, render an image
-	// block for each, and build the gallery `<figure>` wrapper from scratch. The
-	// existing gap/randomOrder/lightbox post-processing below then runs over the
+	// In dynamic mode the gallery's images are resolved at render time instead of
+	// being authored as inner blocks, so `save.js` persists at most the
+	// gallery-level caption — a bare `<figcaption>`, or nothing when there is no
+	// caption. Resolve the configured source to a list of attachments, render an
+	// image block for each, and build the gallery `<figure>` wrapper from scratch.
+	// The gap/randomOrder/lightbox post-processing below then runs over the
 	// constructed markup unchanged.
 	if ( ! empty( $attributes['dynamicContent'] ) ) {
 		$attachment_ids = block_core_gallery_resolve_dynamic_source( $attributes['dynamicContent'], $block );
+
+		// Nothing resolved — no attachments, or an unrecognized source. Render
+		// nothing rather than an empty gallery wrapper; a saved caption is
+		// meaningless without images, so it is intentionally dropped too.
+		if ( empty( $attachment_ids ) ) {
+			return '';
+		}
 
 		// Expose the gallery's provided context (plus galleryId/postId/postType)
 		// to each image block, since these images are rendered outside the

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -213,8 +213,13 @@ function block_core_gallery_render_dynamic_image( $attachment_id, $attributes, $
 		);
 	}
 
-	$caption = wp_get_attachment_caption( $attachment_id );
-	if ( $caption ) {
+	// Use the raw caption (`post_excerpt`) so the frontend mirrors the editor
+	// preview, which builds the caption from the REST `caption.raw` value. Gap:
+	// the REST API exposes no caption run through `wp_get_attachment_caption`, so
+	// that filter isn't applied here either.
+	$attachment = get_post( $attachment_id );
+	$caption    = $attachment ? $attachment->post_excerpt : '';
+	if ( '' !== $caption ) {
 		$image_markup .= sprintf(
 			'<figcaption class="wp-element-caption">%s</figcaption>',
 			wp_kses_post( $caption )

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -281,6 +281,16 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 			return '';
 		}
 
+		// The source query only fetched IDs (`fields => ids`), which skips
+		// WP_Query's cache priming. Each image rendered below reads the
+		// attachment post and its meta (via `wp_get_attachment_image()`,
+		// `get_post()`, etc.), so warm the post and meta caches in a single pair
+		// of queries up front instead of paying ~two queries per attachment.
+		// Term cache is left cold: the render path doesn't read attachment terms.
+		if ( count( $attachment_ids ) > 1 ) {
+			_prime_post_caches( $attachment_ids, false, true );
+		}
+
 		// Expose the gallery's provided context (plus galleryId/postId/postType)
 		// to each image block, since these images are rendered outside the
 		// gallery's real inner-block tree.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -185,7 +185,12 @@ function block_core_gallery_render_dynamic_image( $attachment_id, $attributes, $
 
 	$img_attr = array( 'class' => 'wp-image-' . $attachment_id );
 	if ( $aspect_ratio && 'auto' !== $aspect_ratio ) {
-		$img_attr['style'] = sprintf( 'aspect-ratio:%s;object-fit:cover;', $aspect_ratio );
+		// Run the aspect ratio through the same sanitization used for every other
+		// block inline style, so an unsafe value can't break out of the style
+		// attribute or inject additional markup.
+		$img_attr['style'] = safecss_filter_attr(
+			sprintf( 'aspect-ratio:%s;object-fit:cover;', $aspect_ratio )
+		);
 	}
 
 	$image_markup = wp_get_attachment_image( $attachment_id, $size_slug, false, $img_attr );

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -53,6 +53,192 @@ function block_core_gallery_render_context( $context, $parsed_block ) {
 add_filter( 'render_block_context', 'block_core_gallery_render_context', 10, 2 );
 
 /**
+ * Resolves a Gallery block's `dynamicContent` to an ordered list of image
+ * attachment IDs.
+ *
+ * The `source` key is the dispatch discriminator and `args` holds the source's
+ * parameters. This `{ source, args }` shape mirrors the Block Bindings metadata
+ * shape so dynamic mode can migrate to an `innerBlocks` binding with minimal
+ * change. `core/attached-media` is a context-relative anchor (the post the gallery is
+ * rendered within); future sources translate their REST-named `args` (`author`,
+ * `categories`, `after`/`before`, `media_type`, etc.) into `WP_Query` arguments
+ * here.
+ *
+ * @since 7.0.0
+ *
+ * @param array    $source The gallery's `dynamicContent` attribute.
+ * @param WP_Block $block  The gallery block instance being rendered.
+ * @return int[] Ordered list of image attachment IDs.
+ */
+function block_core_gallery_resolve_dynamic_source( $source, $block ) {
+	$source_name = $source['source'] ?? null;
+	$args        = $source['args'] ?? array();
+
+	switch ( $source_name ) {
+		case 'core/attached-media':
+			$post_id = $block->context['postId'] ?? get_the_ID();
+			if ( ! $post_id ) {
+				return array();
+			}
+
+			// Map the camelCase `args` (block-attribute convention) to WP_Query
+			// names, defaulting to the same order as the editor preview (see
+			// `dynamic-source.js`). Only REST-supported orderby values are
+			// allowed; `menu_order` is intentionally unsupported (it isn't a
+			// valid media REST `orderby`).
+			$orderby = $args['orderBy'] ?? 'date';
+			if ( ! in_array( $orderby, array( 'date', 'title' ), true ) ) {
+				$orderby = 'date';
+			}
+			$order = strtoupper( $args['order'] ?? 'desc' ) === 'ASC' ? 'ASC' : 'DESC';
+
+			$query = new WP_Query(
+				array(
+					'post_parent'    => $post_id,
+					'post_type'      => 'attachment',
+					'post_status'    => 'inherit',
+					'post_mime_type' => 'image',
+					'orderby'        => $orderby,
+					'order'          => $order,
+					// Bounded to match the editor query's `per_page` cap (see
+					// `MAX_IMAGES` in `dynamic-source.js`).
+					'posts_per_page' => 100,
+					'fields'         => 'ids',
+					'no_found_rows'  => true,
+				)
+			);
+
+			return array_map( 'intval', $query->posts );
+	}
+
+	// Unknown or not-yet-implemented source type.
+	return array();
+}
+
+/**
+ * Builds the link-related image block attributes for a dynamically rendered
+ * gallery image, mapping the gallery-wide `linkTo` setting onto a single image.
+ *
+ * Mirrors the editor's `getHrefAndDestination()` (see `gallery/utils.js`).
+ *
+ * @since 7.0.0
+ *
+ * @param int   $attachment_id The image attachment ID.
+ * @param array $attributes    The gallery block attributes.
+ * @return array Partial image block attributes (`href`, `linkDestination`,
+ *               `linkTarget`, `rel`, `lightbox`).
+ */
+function block_core_gallery_dynamic_image_link_attributes( $attachment_id, $attributes ) {
+	$link_to = $attributes['linkTo'] ?? 'none';
+	$attrs   = array();
+
+	switch ( $link_to ) {
+		// Gutenberg uses 'media'/'attachment'; WP Core uses 'file'/'post'.
+		case 'media':
+		case 'file':
+			$attrs['href']            = wp_get_attachment_url( $attachment_id );
+			$attrs['linkDestination'] = 'media';
+			break;
+		case 'attachment':
+		case 'post':
+			$attrs['href']            = get_attachment_link( $attachment_id );
+			$attrs['linkDestination'] = 'attachment';
+			break;
+		case 'lightbox':
+			$attrs['linkDestination'] = 'none';
+			$attrs['lightbox']        = array( 'enabled' => true );
+			break;
+	}
+
+	if ( ! empty( $attrs['href'] ) && '_blank' === ( $attributes['linkTarget'] ?? '' ) ) {
+		$attrs['linkTarget'] = '_blank';
+		$attrs['rel']        = 'noreferrer noopener';
+	}
+
+	return $attrs;
+}
+
+/**
+ * Renders a single `core/image` block for a Gallery block running in dynamic
+ * mode, applying the gallery-wide settings that affect how an image renders.
+ *
+ * The image markup is generated here (via `wp_get_attachment_image()`) and
+ * rendered through a real `core/image` block instance so that the image block's
+ * own render callback and lightbox behavior run, and so the gallery's existing
+ * lightbox/interactivity post-processing can pick it up.
+ *
+ * @since 7.0.0
+ *
+ * @param int   $attachment_id The image attachment ID.
+ * @param array $attributes    The gallery block attributes.
+ * @param array $context       Context to expose to the inner image block.
+ * @return string The rendered image block HTML, or an empty string on failure.
+ */
+function block_core_gallery_render_dynamic_image( $attachment_id, $attributes, $context ) {
+	$size_slug    = $attributes['sizeSlug'] ?? 'large';
+	$aspect_ratio = $attributes['aspectRatio'] ?? 'auto';
+
+	$img_attr = array( 'class' => 'wp-image-' . $attachment_id );
+	if ( $aspect_ratio && 'auto' !== $aspect_ratio ) {
+		$img_attr['style'] = sprintf( 'aspect-ratio:%s;object-fit:cover;', $aspect_ratio );
+	}
+
+	$image_markup = wp_get_attachment_image( $attachment_id, $size_slug, false, $img_attr );
+	if ( ! $image_markup ) {
+		return '';
+	}
+
+	$image_attributes = array_merge(
+		array(
+			'id'       => $attachment_id,
+			'data-id'  => (string) $attachment_id,
+			'sizeSlug' => $size_slug,
+		),
+		block_core_gallery_dynamic_image_link_attributes( $attachment_id, $attributes )
+	);
+
+	if ( $aspect_ratio && 'auto' !== $aspect_ratio ) {
+		$image_attributes['aspectRatio'] = $aspect_ratio;
+		$image_attributes['scale']       = 'cover';
+	}
+
+	// Wrap in a link when the gallery links images somewhere.
+	if ( ! empty( $image_attributes['href'] ) ) {
+		$image_markup = sprintf(
+			'<a href="%1$s"%2$s%3$s>%4$s</a>',
+			esc_url( $image_attributes['href'] ),
+			isset( $image_attributes['linkTarget'] ) ? ' target="' . esc_attr( $image_attributes['linkTarget'] ) . '"' : '',
+			isset( $image_attributes['rel'] ) ? ' rel="' . esc_attr( $image_attributes['rel'] ) . '"' : '',
+			$image_markup
+		);
+	}
+
+	$caption = wp_get_attachment_caption( $attachment_id );
+	if ( $caption ) {
+		$image_markup .= sprintf(
+			'<figcaption class="wp-element-caption">%s</figcaption>',
+			wp_kses_post( $caption )
+		);
+	}
+
+	$figure = sprintf(
+		'<figure class="wp-block-image size-%1$s">%2$s</figure>',
+		esc_attr( $size_slug ),
+		$image_markup
+	);
+
+	$image_block = array(
+		'blockName'    => 'core/image',
+		'attrs'        => $image_attributes,
+		'innerBlocks'  => array(),
+		'innerHTML'    => $figure,
+		'innerContent' => array( $figure ),
+	);
+
+	return ( new WP_Block( $image_block, $context ) )->render();
+}
+
+/**
  * Renders the `core/gallery` block on the server.
  *
  * @since 6.0.0
@@ -63,6 +249,43 @@ add_filter( 'render_block_context', 'block_core_gallery_render_context', 10, 2 )
  * @return string The content of the block being rendered.
  */
 function block_core_gallery_render( $attributes, $content, $block ) {
+	// In dynamic mode the gallery has no inner image blocks; resolve the
+	// configured source to a list of attachments and render an image block for
+	// each, injecting them into the (otherwise empty) gallery wrapper. The
+	// existing gap/randomOrder/lightbox post-processing below then runs over the
+	// generated markup unchanged.
+	if ( ! empty( $attributes['dynamicContent'] ) ) {
+		$attachment_ids = block_core_gallery_resolve_dynamic_source( $attributes['dynamicContent'], $block );
+
+		// Expose the gallery's provided context (plus galleryId/postId/postType)
+		// to each image block, since these images are rendered outside the
+		// gallery's real inner-block tree.
+		$image_context = array_merge(
+			is_array( $block->context ) ? $block->context : array(),
+			array(
+				'allowResize'          => $attributes['allowResize'] ?? false,
+				'imageCrop'            => $attributes['imageCrop'] ?? true,
+				'fixedHeight'          => $attributes['fixedHeight'] ?? true,
+				'navigationButtonType' => $attributes['navigationButtonType'] ?? 'icon',
+			)
+		);
+
+		$images_markup = '';
+		foreach ( $attachment_ids as $attachment_id ) {
+			$images_markup .= block_core_gallery_render_dynamic_image( $attachment_id, $attributes, $image_context );
+		}
+
+		// Inject the generated images directly after the opening wrapper tag.
+		// The saved content for a dynamic gallery is the bare `<figure>` wrapper
+		// (optionally followed by a gallery `<figcaption>`); attributes on the
+		// wrapper are class/style/id/data-* only, so the first `>` reliably ends
+		// the opening tag.
+		$opening_tag_end = strpos( $content, '>' );
+		if ( false !== $opening_tag_end ) {
+			$content = substr( $content, 0, $opening_tag_end + 1 ) . $images_markup . substr( $content, $opening_tag_end + 1 );
+		}
+	}
+
 	// Adds a style tag for the --wp--style--unstable-gallery-gap var.
 	// The Gallery block needs to recalculate Image block width based on
 	// the current gap setting in order to maintain the number of flex columns

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -152,7 +152,7 @@ function block_core_gallery_dynamic_image_link_attributes( $attachment_id, $attr
 
 	if ( ! empty( $attrs['href'] ) && '_blank' === ( $attributes['linkTarget'] ?? '' ) ) {
 		$attrs['linkTarget'] = '_blank';
-		$attrs['rel']        = 'noreferrer noopener';
+		$attrs['rel']        = 'noopener';
 	}
 
 	return $attrs;

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -76,6 +76,11 @@ function block_core_gallery_resolve_dynamic_source( $source, $block ) {
 
 	switch ( $source_name ) {
 		case 'core/attached-media':
+			// Prefer the post supplied via block context, falling back to the post
+			// being rendered. The fallback is what lets a post-bound template (e.g.
+			// `single`/`page`) resolve against the actual post at render time even
+			// though the editor has no concrete post to preview — the editor gates
+			// the dynamic-mode UI on that same context (see `use-dynamic-gallery.js`).
 			$post_id = $block->context['postId'] ?? get_the_ID();
 			if ( ! $post_id ) {
 				return array();

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -254,11 +254,11 @@ function block_core_gallery_render_dynamic_image( $attachment_id, $attributes, $
  * @return string The content of the block being rendered.
  */
 function block_core_gallery_render( $attributes, $content, $block ) {
-	// In dynamic mode the gallery has no inner image blocks; resolve the
-	// configured source to a list of attachments and render an image block for
-	// each, injecting them into the (otherwise empty) gallery wrapper. The
+	// In dynamic mode the gallery persists no markup (`save.js` returns null);
+	// resolve the configured source to a list of attachments, render an image
+	// block for each, and build the gallery `<figure>` wrapper from scratch. The
 	// existing gap/randomOrder/lightbox post-processing below then runs over the
-	// generated markup unchanged.
+	// constructed markup unchanged.
 	if ( ! empty( $attributes['dynamicContent'] ) ) {
 		$attachment_ids = block_core_gallery_resolve_dynamic_source( $attributes['dynamicContent'], $block );
 
@@ -280,15 +280,27 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 			$images_markup .= block_core_gallery_render_dynamic_image( $attachment_id, $attributes, $image_context );
 		}
 
-		// Inject the generated images directly after the opening wrapper tag.
-		// The saved content for a dynamic gallery is the bare `<figure>` wrapper
-		// (optionally followed by a gallery `<figcaption>`); attributes on the
-		// wrapper are class/style/id/data-* only, so the first `>` reliably ends
-		// the opening tag.
-		$opening_tag_end = strpos( $content, '>' );
-		if ( false !== $opening_tag_end ) {
-			$content = substr( $content, 0, $opening_tag_end + 1 ) . $images_markup . substr( $content, $opening_tag_end + 1 );
+		// Build the wrapper rather than parsing/splicing saved markup.
+		// `get_block_wrapper_attributes()` supplies the block-support
+		// classes/styles (align, color, border, spacing, anchor id); the layout
+		// render filter adds the flex layout classes downstream — the same way a
+		// static gallery's wrapper is composed (`useBlockProps.save()` plus that
+		// filter). Only the gallery-specific classes are added explicitly, and
+		// they mirror `save.js` (kept in sync deliberately — see that file).
+		$gallery_classes  = 'wp-block-gallery has-nested-images';
+		$gallery_classes .= isset( $attributes['columns'] )
+			? ' columns-' . (int) $attributes['columns']
+			: ' columns-default';
+		if ( $attributes['imageCrop'] ?? true ) {
+			$gallery_classes .= ' is-cropped';
 		}
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $gallery_classes ) );
+
+		// In dynamic mode `save.js` persists only the gallery-level caption, so
+		// `$content` is the saved `<figcaption>` (or empty). Append it after the
+		// resolved images — matching the static gallery's `{images}{caption}`
+		// order — without parsing it.
+		$content = sprintf( '<figure %s>%s%s</figure>', $wrapper_attributes, $images_markup, $content );
 	}
 
 	// Adds a style tag for the --wp--style--unstable-gallery-gap var.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -71,8 +71,12 @@ add_filter( 'render_block_context', 'block_core_gallery_render_context', 10, 2 )
  * @return int[] Ordered list of image attachment IDs.
  */
 function block_core_gallery_resolve_dynamic_source( $source, $block ) {
+	if ( ! is_array( $source ) ) {
+		return array();
+	}
+
 	$source_name = $source['source'] ?? null;
-	$args        = $source['args'] ?? array();
+	$args        = isset( $source['args'] ) && is_array( $source['args'] ) ? $source['args'] : array();
 
 	switch ( $source_name ) {
 		case 'core/attached-media':

--- a/packages/block-library/src/gallery/save.js
+++ b/packages/block-library/src/gallery/save.js
@@ -14,7 +14,27 @@ import {
 } from '@wordpress/block-editor';
 
 export default function saveWithInnerBlocks( { attributes } ) {
-	const { caption, columns, imageCrop } = attributes;
+	const { caption, columns, imageCrop, dynamicContent } = attributes;
+
+	const captionElement = ! RichText.isEmpty( caption ) && (
+		<RichText.Content
+			tagName="figcaption"
+			className={ clsx(
+				'blocks-gallery-caption',
+				__experimentalGetElementClassName( 'caption' )
+			) }
+			value={ caption }
+		/>
+	);
+
+	// In dynamic mode the images are resolved at render time and the `<figure>`
+	// wrapper is built by the server render callback (`block_core_gallery_render()`),
+	// so persist only the gallery-level caption. It still sources from
+	// `.blocks-gallery-caption`, so it round-trips; the render callback drops it in
+	// after the resolved images. Nothing is saved when there's no caption.
+	if ( dynamicContent ) {
+		return captionElement || null;
+	}
 
 	const className = clsx( 'has-nested-images', {
 		[ `columns-${ columns }` ]: columns !== undefined,
@@ -27,16 +47,7 @@ export default function saveWithInnerBlocks( { attributes } ) {
 	return (
 		<figure { ...innerBlocksProps }>
 			{ innerBlocksProps.children }
-			{ ! RichText.isEmpty( caption ) && (
-				<RichText.Content
-					tagName="figcaption"
-					className={ clsx(
-						'blocks-gallery-caption',
-						__experimentalGetElementClassName( 'caption' )
-					) }
-					value={ caption }
-				/>
-			) }
+			{ captionElement }
 		</figure>
 	);
 }

--- a/packages/block-library/src/gallery/test/dynamic-source.js
+++ b/packages/block-library/src/gallery/test/dynamic-source.js
@@ -49,6 +49,26 @@ describe( 'getSourceQuery', () => {
 		} );
 	} );
 
+	it( 'coerces unexpected ordering values back to the defaults', () => {
+		// Only reachable via hand-edited markup; mirrors the server resolver's
+		// allow list so the preview never issues an invalid REST query.
+		expect(
+			getSourceQuery(
+				{
+					source: 'core/attached-media',
+					args: { orderBy: 'menu_order', order: 'sideways' },
+				},
+				{ postId: 7 }
+			)
+		).toEqual( {
+			parent: 7,
+			per_page: 100,
+			media_type: 'image',
+			orderby: 'date',
+			order: 'desc',
+		} );
+	} );
+
 	it( 'returns null when there is no post to anchor to', () => {
 		expect(
 			getSourceQuery(

--- a/packages/block-library/src/gallery/test/dynamic-source.js
+++ b/packages/block-library/src/gallery/test/dynamic-source.js
@@ -1,0 +1,70 @@
+/**
+ * Internal dependencies
+ */
+import { getSourceQuery } from '../dynamic-source';
+
+describe( 'getSourceQuery', () => {
+	it( 'resolves the core/attached-media anchor to the REST `parent` param with default ordering', () => {
+		expect(
+			getSourceQuery( { source: 'core/attached-media' }, { postId: 42 } )
+		).toEqual( {
+			parent: 42,
+			per_page: 100,
+			media_type: 'image',
+			orderby: 'date',
+			order: 'desc',
+		} );
+	} );
+
+	it( 'maps the camelCase `args` ordering to the REST params', () => {
+		expect(
+			getSourceQuery(
+				{
+					source: 'core/attached-media',
+					args: { orderBy: 'title', order: 'asc' },
+				},
+				{ postId: 7 }
+			)
+		).toEqual( {
+			parent: 7,
+			per_page: 100,
+			media_type: 'image',
+			orderby: 'title',
+			order: 'asc',
+		} );
+	} );
+
+	it( 'ignores args it does not explicitly map', () => {
+		expect(
+			getSourceQuery(
+				{ source: 'core/attached-media', args: { author: 5 } },
+				{ postId: 7 }
+			)
+		).toEqual( {
+			parent: 7,
+			per_page: 100,
+			media_type: 'image',
+			orderby: 'date',
+			order: 'desc',
+		} );
+	} );
+
+	it( 'returns null when there is no post to anchor to', () => {
+		expect(
+			getSourceQuery(
+				{ source: 'core/attached-media' },
+				{ postId: undefined }
+			)
+		).toBeNull();
+	} );
+
+	it( 'returns null for an unknown source', () => {
+		expect(
+			getSourceQuery( { source: 'notARealSource' }, { postId: 1 } )
+		).toBeNull();
+	} );
+
+	it( 'returns null for an empty/absent source', () => {
+		expect( getSourceQuery( undefined, { postId: 1 } ) ).toBeNull();
+	} );
+} );

--- a/packages/block-library/src/gallery/use-dynamic-gallery.js
+++ b/packages/block-library/src/gallery/use-dynamic-gallery.js
@@ -43,6 +43,9 @@ function buildImageBlockAttributes( media, galleryAttributes ) {
 		...getHrefAndDestination( media, linkTo ),
 		...getUpdatedLinkTargetSettings( linkTarget, galleryAttributes ),
 		sizeSlug,
+		// Raw caption, mirroring the frontend (`index.php`). Gap: the REST API
+		// exposes no caption run through `wp_get_attachment_caption`, so neither
+		// side applies that filter.
 		caption: media.caption?.raw || '',
 		alt: media.alt_text || '',
 		aspectRatio: aspectRatio === 'auto' ? undefined : aspectRatio,

--- a/packages/block-library/src/gallery/use-dynamic-gallery.js
+++ b/packages/block-library/src/gallery/use-dynamic-gallery.js
@@ -113,17 +113,27 @@ export default function useDynamicGallery( {
 		[ query ]
 	);
 
+	// The only gallery settings that affect how an image renders, and so the
+	// only ones `buildImageBlockAttributes` reads. Depending on this narrowed
+	// set (rather than the whole `attributes` object) keeps the preview from
+	// rebuilding on unrelated edits, e.g. typing in the gallery caption.
+	const { sizeSlug, linkTo, linkTarget, aspectRatio } = attributes;
+	const imageAttributes = useMemo(
+		() => ( { sizeSlug, linkTo, linkTarget, aspectRatio } ),
+		[ sizeSlug, linkTo, linkTarget, aspectRatio ]
+	);
+
 	// The (non-persisted) `core/image` blocks used for the editor preview.
-	// Rebuilt when the resolved media or any gallery setting changes.
+	// Rebuilt when the resolved media or an image-relevant setting changes.
 	const dynamicImageBlocks = useMemo(
 		() =>
 			dynamicMedia.map( ( mediaItem ) =>
 				createBlock(
 					'core/image',
-					buildImageBlockAttributes( mediaItem, attributes )
+					buildImageBlockAttributes( mediaItem, imageAttributes )
 				)
 			),
-		[ dynamicMedia, attributes ]
+		[ dynamicMedia, imageAttributes ]
 	);
 
 	// Context the gallery provides to its (previewed) image blocks.
@@ -155,7 +165,7 @@ export default function useDynamicGallery( {
 		const blocks = dynamicMedia.map( ( mediaItem ) =>
 			createBlock(
 				'core/image',
-				buildImageBlockAttributes( mediaItem, attributes )
+				buildImageBlockAttributes( mediaItem, imageAttributes )
 			)
 		);
 		replaceInnerBlocks( clientId, blocks );

--- a/packages/block-library/src/gallery/use-dynamic-gallery.js
+++ b/packages/block-library/src/gallery/use-dynamic-gallery.js
@@ -202,7 +202,11 @@ export default function useDynamicGallery( {
 	);
 
 	// Switches the gallery into dynamic mode, displaying images attached to the
-	// current post. Any manually-added image blocks are removed.
+	// current post. Clearing the inner blocks removes the manually-added images:
+	// they're the gallery's image data, so there's nothing else to reset. The
+	// legacy `images`/`ids` attributes aren't touched — they're back-compat shims
+	// for the pre-innerBlocks format (see `deprecated.js`/`transforms.js`), empty
+	// on any gallery reachable here.
 	function enableDynamicMode() {
 		setAttributes( { dynamicContent: { source: ATTACHED_MEDIA } } );
 		replaceInnerBlocks( clientId, [] );

--- a/packages/block-library/src/gallery/use-dynamic-gallery.js
+++ b/packages/block-library/src/gallery/use-dynamic-gallery.js
@@ -36,6 +36,7 @@ const EMPTY_ARRAY = [];
  */
 function buildImageBlockAttributes( media, galleryAttributes ) {
 	const { sizeSlug, linkTo, linkTarget, aspectRatio } = galleryAttributes;
+	const hasAspectRatio = !! aspectRatio && aspectRatio !== 'auto';
 
 	return {
 		id: media.id,
@@ -48,7 +49,10 @@ function buildImageBlockAttributes( media, galleryAttributes ) {
 		// side applies that filter.
 		caption: media.caption?.raw || '',
 		alt: media.alt_text || '',
-		aspectRatio: aspectRatio === 'auto' ? undefined : aspectRatio,
+		aspectRatio: hasAspectRatio ? aspectRatio : undefined,
+		// Pair `scale` with `aspectRatio` so the image crops rather than stretches,
+		// matching the image block's UI and the frontend (`index.php`).
+		scale: hasAspectRatio ? 'cover' : undefined,
 	};
 }
 

--- a/packages/block-library/src/gallery/use-dynamic-gallery.js
+++ b/packages/block-library/src/gallery/use-dynamic-gallery.js
@@ -17,6 +17,7 @@ import {
 	getSourceQuery,
 	DEFAULT_ORDERBY,
 	DEFAULT_ORDER,
+	MAX_IMAGES,
 } from './dynamic-source';
 
 const EMPTY_ARRAY = [];
@@ -131,16 +132,27 @@ export default function useDynamicGallery( {
 		[ dynamicContent, postId ]
 	);
 
-	const { dynamicMedia, isResolvingDynamic } = useSelect(
+	const { dynamicMedia, dynamicMediaTotal, isResolvingDynamic } = useSelect(
 		( select ) => {
 			if ( ! query ) {
-				return { dynamicMedia: EMPTY_ARRAY, isResolvingDynamic: false };
+				return {
+					dynamicMedia: EMPTY_ARRAY,
+					dynamicMediaTotal: 0,
+					isResolvingDynamic: false,
+				};
 			}
 			const selectorArgs = [ 'postType', 'attachment', query ];
 			return {
 				dynamicMedia:
 					select( coreStore ).getEntityRecords( ...selectorArgs ) ??
 					EMPTY_ARRAY,
+				// Total matching attachments (the `X-WP-Total` header), which the
+				// query's `per_page` cap doesn't bound — so it reveals when the
+				// post has more attached images than are shown.
+				dynamicMediaTotal:
+					select( coreStore ).getEntityRecordsTotalItems(
+						...selectorArgs
+					) ?? 0,
 				isResolvingDynamic: ! select( coreStore ).hasFinishedResolution(
 					'getEntityRecords',
 					selectorArgs
@@ -149,6 +161,10 @@ export default function useDynamicGallery( {
 		},
 		[ query ]
 	);
+
+	// The source caps results at `MAX_IMAGES` (matching the frontend), so flag
+	// when the post has more attached images than the gallery can show.
+	const hasMoreImagesThanCap = dynamicMediaTotal > MAX_IMAGES;
 
 	// The only gallery settings that affect how an image renders, and so the
 	// only ones `buildImageBlockAttributes` reads. Depending on this narrowed
@@ -237,6 +253,8 @@ export default function useDynamicGallery( {
 		dynamicContent,
 		canUseDynamicSource,
 		hasCurrentPost,
+		hasMoreImagesThanCap,
+		dynamicMediaTotal,
 		sourceOrderby,
 		sourceOrder,
 		dynamicMedia,

--- a/packages/block-library/src/gallery/use-dynamic-gallery.js
+++ b/packages/block-library/src/gallery/use-dynamic-gallery.js
@@ -90,6 +90,7 @@ function buildImageBlocks( media, galleryAttributes ) {
  * @param {Function} options.setAttributes The block's `setAttributes`.
  * @param {string}   options.clientId      The block client ID.
  * @param {?number}  options.postId        The current post ID (from block context).
+ * @param {?string}  options.postType      The current post type (from block context).
  * @return {Object} Dynamic-mode source data and actions.
  */
 export default function useDynamicGallery( {
@@ -97,8 +98,22 @@ export default function useDynamicGallery( {
 	setAttributes,
 	clientId,
 	postId,
+	postType,
 } ) {
 	const { dynamicContent } = attributes;
+
+	// Whether dynamic mode makes sense in the current editing context. A
+	// `postType` means the block will resolve against some post at render time —
+	// either a concrete post (post/page editor, Query Loop item) or a post-bound
+	// template (`single`, `page`) whose post is filled in by `get_the_ID()` on the
+	// frontend (see `index.php`). Without it (template part, pattern, generic
+	// template) there's no post to attach to, so the source can never resolve.
+	const canUseDynamicSource = !! postType;
+
+	// Whether there's a concrete post to preview against right now. False while
+	// editing a post-bound template, where images only resolve once the template
+	// renders a real post.
+	const hasCurrentPost = !! postId;
 
 	// Current source ordering, falling back to the shared defaults when unset.
 	const sourceOrderby = dynamicContent?.args?.orderBy ?? DEFAULT_ORDERBY;
@@ -220,6 +235,8 @@ export default function useDynamicGallery( {
 
 	return {
 		dynamicContent,
+		canUseDynamicSource,
+		hasCurrentPost,
 		sourceOrderby,
 		sourceOrder,
 		dynamicMedia,

--- a/packages/block-library/src/gallery/use-dynamic-gallery.js
+++ b/packages/block-library/src/gallery/use-dynamic-gallery.js
@@ -1,0 +1,205 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { pickRelevantMediaFiles } from './shared';
+import { getHrefAndDestination } from './utils';
+import { getUpdatedLinkTargetSettings } from '../image/utils';
+import {
+	getSourceQuery,
+	DEFAULT_ORDERBY,
+	DEFAULT_ORDER,
+} from './dynamic-source';
+
+const EMPTY_ARRAY = [];
+
+/**
+ * Builds the attributes for a `core/image` block from a media (attachment)
+ * record, applying the gallery-wide settings that affect how the image renders.
+ *
+ * Used to construct the (non-persisted) image blocks previewed in dynamic mode,
+ * and the real image blocks created when a dynamic gallery is converted
+ * ("pinned") back to individual images. The frontend equivalent is
+ * `block_core_gallery_render_dynamic_image()` in `index.php`.
+ *
+ * @param {Object} media             A media object as returned by the REST API.
+ * @param {Object} galleryAttributes The gallery block's attributes.
+ * @return {Object} Attributes to pass to `createBlock( 'core/image', ... )`.
+ */
+function buildImageBlockAttributes( media, galleryAttributes ) {
+	const { sizeSlug, linkTo, linkTarget, aspectRatio } = galleryAttributes;
+
+	return {
+		id: media.id,
+		...pickRelevantMediaFiles( media, sizeSlug ),
+		...getHrefAndDestination( media, linkTo ),
+		...getUpdatedLinkTargetSettings( linkTarget, galleryAttributes ),
+		sizeSlug,
+		caption: media.caption?.raw || '',
+		alt: media.alt_text || '',
+		aspectRatio: aspectRatio === 'auto' ? undefined : aspectRatio,
+	};
+}
+
+/**
+ * Bundles the Gallery block's "dynamic mode" source resolution and actions.
+ *
+ * Dynamic mode resolves the gallery's images from a configured source
+ * (`attributes.dynamicContent`) instead of from manually-added inner image
+ * blocks. This hook centralizes the shared, single-instance pieces — the source
+ * resolution (one `getEntityRecords`), the editor-preview blocks, and the
+ * mode/ordering actions — out of the block's `edit` component. Transient UI
+ * concerns (e.g. the convert-to-dynamic confirmation) live in the components
+ * that own them.
+ *
+ * @param {Object}   options
+ * @param {Object}   options.attributes    The gallery block attributes.
+ * @param {Function} options.setAttributes The block's `setAttributes`.
+ * @param {string}   options.clientId      The block client ID.
+ * @param {?number}  options.postId        The current post ID (from block context).
+ * @return {Object} Dynamic-mode source data and actions.
+ */
+export default function useDynamicGallery( {
+	attributes,
+	setAttributes,
+	clientId,
+	postId,
+} ) {
+	const { dynamicContent } = attributes;
+
+	// Current source ordering, falling back to the shared defaults when unset.
+	const sourceOrderby = dynamicContent?.args?.orderBy ?? DEFAULT_ORDERBY;
+	const sourceOrder = dynamicContent?.args?.order ?? DEFAULT_ORDER;
+
+	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
+
+	// Resolve the configured source to a media query. `null` (static mode, or an
+	// unresolvable source) short-circuits the select below so no request fires.
+	const query = useMemo(
+		() =>
+			dynamicContent
+				? getSourceQuery( dynamicContent, { postId } )
+				: null,
+		[ dynamicContent, postId ]
+	);
+
+	const { dynamicMedia, isResolvingDynamic } = useSelect(
+		( select ) => {
+			if ( ! query ) {
+				return { dynamicMedia: EMPTY_ARRAY, isResolvingDynamic: false };
+			}
+			const selectorArgs = [ 'postType', 'attachment', query ];
+			return {
+				dynamicMedia:
+					select( coreStore ).getEntityRecords( ...selectorArgs ) ??
+					EMPTY_ARRAY,
+				isResolvingDynamic: ! select( coreStore ).hasFinishedResolution(
+					'getEntityRecords',
+					selectorArgs
+				),
+			};
+		},
+		[ query ]
+	);
+
+	// The (non-persisted) `core/image` blocks used for the editor preview.
+	// Rebuilt when the resolved media or any gallery setting changes.
+	const dynamicImageBlocks = useMemo(
+		() =>
+			dynamicMedia.map( ( mediaItem ) =>
+				createBlock(
+					'core/image',
+					buildImageBlockAttributes( mediaItem, attributes )
+				)
+			),
+		[ dynamicMedia, attributes ]
+	);
+
+	// Context the gallery provides to its (previewed) image blocks.
+	const galleryContext = useMemo(
+		() => ( {
+			allowResize: attributes.allowResize ?? false,
+			imageCrop: attributes.imageCrop,
+			fixedHeight: attributes.fixedHeight,
+			navigationButtonType: attributes.navigationButtonType,
+		} ),
+		[
+			attributes.allowResize,
+			attributes.imageCrop,
+			attributes.fixedHeight,
+			attributes.navigationButtonType,
+		]
+	);
+
+	// Switches the gallery into dynamic mode, displaying images attached to the
+	// current post. Any manually-added image blocks are removed.
+	function enableDynamicMode() {
+		setAttributes( { dynamicContent: { source: 'core/attached-media' } } );
+		replaceInnerBlocks( clientId, [] );
+	}
+
+	// "Pins" a dynamic gallery: materializes the currently-resolved media as
+	// real, editable image blocks and leaves dynamic mode.
+	function convertToStatic() {
+		const blocks = dynamicMedia.map( ( mediaItem ) =>
+			createBlock(
+				'core/image',
+				buildImageBlockAttributes( mediaItem, attributes )
+			)
+		);
+		replaceInnerBlocks( clientId, blocks );
+		setAttributes( { dynamicContent: undefined } );
+	}
+
+	// Updates the source ordering within `dynamicContent.args`. Passing
+	// `undefined` (or the default order) strips the keys so they aren't
+	// persisted redundantly and the ToolsPanel item reads as unset.
+	function setSourceOrder( nextOrderby, nextOrder ) {
+		const nextArgs = { ...dynamicContent?.args };
+		delete nextArgs.orderBy;
+		delete nextArgs.order;
+		if (
+			nextOrderby !== undefined &&
+			( nextOrderby !== DEFAULT_ORDERBY || nextOrder !== DEFAULT_ORDER )
+		) {
+			nextArgs.orderBy = nextOrderby;
+			nextArgs.order = nextOrder;
+		}
+		const nextSource = { ...dynamicContent };
+		if ( Object.keys( nextArgs ).length ) {
+			nextSource.args = nextArgs;
+		} else {
+			delete nextSource.args;
+		}
+		setAttributes( { dynamicContent: nextSource } );
+	}
+
+	// Resets the source to its bare form: keeps the source kind, drops its args.
+	function resetSource() {
+		setAttributes( {
+			dynamicContent: { source: dynamicContent.source },
+		} );
+	}
+
+	return {
+		dynamicContent,
+		sourceOrderby,
+		sourceOrder,
+		dynamicMedia,
+		dynamicImageBlocks,
+		isResolvingDynamic,
+		galleryContext,
+		enableDynamicMode,
+		convertToStatic,
+		setSourceOrder,
+		resetSource,
+	};
+}

--- a/packages/block-library/src/gallery/use-dynamic-gallery.js
+++ b/packages/block-library/src/gallery/use-dynamic-gallery.js
@@ -15,6 +15,8 @@ import { getHrefAndDestination } from './utils';
 import { getUpdatedLinkTargetSettings } from '../image/utils';
 import {
 	getSourceQuery,
+	getDynamicSource,
+	ATTACHED_MEDIA,
 	DEFAULT_ORDERBY,
 	DEFAULT_ORDER,
 	MAX_IMAGES,
@@ -111,10 +113,10 @@ export default function useDynamicGallery( {
 	// template) there's no post to attach to, so the source can never resolve.
 	const canUseDynamicSource = !! postType;
 
-	// Whether there's a concrete post to preview against right now. False while
-	// editing a post-bound template, where images only resolve once the template
-	// renders a real post.
-	const hasCurrentPost = !! postId;
+	// The descriptor for the configured source (its `title`/`description`/
+	// `emptyMessage`), resolved once here so consumers read the copy without
+	// re-deriving it from `dynamicContent`. `undefined` for an unknown source.
+	const sourceDescriptor = getDynamicSource( dynamicContent?.source );
 
 	// Current source ordering, falling back to the shared defaults when unset.
 	const sourceOrderby = dynamicContent?.args?.orderBy ?? DEFAULT_ORDERBY;
@@ -202,7 +204,7 @@ export default function useDynamicGallery( {
 	// Switches the gallery into dynamic mode, displaying images attached to the
 	// current post. Any manually-added image blocks are removed.
 	function enableDynamicMode() {
-		setAttributes( { dynamicContent: { source: 'core/attached-media' } } );
+		setAttributes( { dynamicContent: { source: ATTACHED_MEDIA } } );
 		replaceInnerBlocks( clientId, [] );
 	}
 
@@ -252,7 +254,7 @@ export default function useDynamicGallery( {
 	return {
 		dynamicContent,
 		canUseDynamicSource,
-		hasCurrentPost,
+		sourceDescriptor,
 		hasMoreImagesThanCap,
 		dynamicMediaTotal,
 		sourceOrderby,

--- a/packages/block-library/src/gallery/use-dynamic-gallery.js
+++ b/packages/block-library/src/gallery/use-dynamic-gallery.js
@@ -57,6 +57,24 @@ function buildImageBlockAttributes( media, galleryAttributes ) {
 }
 
 /**
+ * Builds a set of `core/image` blocks from the resolved media, applying the
+ * gallery-wide settings. Each call mints fresh client IDs, so it can produce
+ * both the editor preview and the materialized inner blocks on convert.
+ *
+ * @param {Object[]} media             Media records from the REST API.
+ * @param {Object}   galleryAttributes The image-relevant gallery attributes.
+ * @return {Object[]} New `core/image` block instances.
+ */
+function buildImageBlocks( media, galleryAttributes ) {
+	return media.map( ( mediaItem ) =>
+		createBlock(
+			'core/image',
+			buildImageBlockAttributes( mediaItem, galleryAttributes )
+		)
+	);
+}
+
+/**
  * Bundles the Gallery block's "dynamic mode" source resolution and actions.
  *
  * Dynamic mode resolves the gallery's images from a configured source
@@ -130,13 +148,7 @@ export default function useDynamicGallery( {
 	// The (non-persisted) `core/image` blocks used for the editor preview.
 	// Rebuilt when the resolved media or an image-relevant setting changes.
 	const dynamicImageBlocks = useMemo(
-		() =>
-			dynamicMedia.map( ( mediaItem ) =>
-				createBlock(
-					'core/image',
-					buildImageBlockAttributes( mediaItem, imageAttributes )
-				)
-			),
+		() => buildImageBlocks( dynamicMedia, imageAttributes ),
 		[ dynamicMedia, imageAttributes ]
 	);
 
@@ -166,13 +178,13 @@ export default function useDynamicGallery( {
 	// "Pins" a dynamic gallery: materializes the currently-resolved media as
 	// real, editable image blocks and leaves dynamic mode.
 	function convertToStatic() {
-		const blocks = dynamicMedia.map( ( mediaItem ) =>
-			createBlock(
-				'core/image',
-				buildImageBlockAttributes( mediaItem, imageAttributes )
-			)
+		// Build fresh blocks rather than reusing the preview's `dynamicImageBlocks`
+		// so the materialized inner blocks get their own client IDs, distinct from
+		// the (disabled) preview instances.
+		replaceInnerBlocks(
+			clientId,
+			buildImageBlocks( dynamicMedia, imageAttributes )
 		);
-		replaceInnerBlocks( clientId, blocks );
 		setAttributes( { dynamicContent: undefined } );
 	}
 

--- a/packages/block-library/src/gallery/variations.js
+++ b/packages/block-library/src/gallery/variations.js
@@ -3,6 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { ATTACHED_MEDIA } from './dynamic-source';
+
 const variations = [
 	{
 		name: 'dynamic-gallery',
@@ -11,7 +16,7 @@ const variations = [
 			'Display images from a source, such as those attached to the current post.'
 		),
 		attributes: {
-			dynamicContent: { source: 'core/attached-media' },
+			dynamicContent: { source: ATTACHED_MEDIA },
 		},
 		// Match any gallery that has a dynamic source configured, regardless of
 		// the specific source or options, so the variation's title and

--- a/packages/block-library/src/gallery/variations.js
+++ b/packages/block-library/src/gallery/variations.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const variations = [
+	{
+		name: 'dynamic-gallery',
+		title: __( 'Dynamic Gallery' ),
+		description: __(
+			'Display images from a source, such as those attached to the current post.'
+		),
+		attributes: {
+			dynamicContent: { source: 'core/attached-media' },
+		},
+		// Match any gallery that has a dynamic source configured, regardless of
+		// the specific source or options, so the variation's title and
+		// description describe the block whenever it runs in dynamic mode.
+		isActive: ( blockAttributes ) => !! blockAttributes.dynamicContent,
+		// `inserter` only: the variation appears as its own inserter entry, but
+		// is deliberately omitted from `transform` so the block toolbar's
+		// "Transform to variation" switcher isn't exposed (the inspector toggle
+		// is the intended way to switch modes). `isActive` still drives the
+		// block card's title/description regardless of scope.
+		scope: [ 'inserter' ],
+	},
+];
+
+export default variations;

--- a/packages/block-library/src/gallery/variations.js
+++ b/packages/block-library/src/gallery/variations.js
@@ -17,12 +17,15 @@ const variations = [
 		// the specific source or options, so the variation's title and
 		// description describe the block whenever it runs in dynamic mode.
 		isActive: ( blockAttributes ) => !! blockAttributes.dynamicContent,
-		// `inserter` only: the variation appears as its own inserter entry, but
-		// is deliberately omitted from `transform` so the block toolbar's
-		// "Transform to variation" switcher isn't exposed (the inspector toggle
-		// is the intended way to switch modes). `isActive` still drives the
-		// block card's title/description regardless of scope.
-		scope: [ 'inserter' ],
+		// No scopes for now. While dynamic mode only supports the "attached to the
+		// current post" source, `'inserter'` is intentionally omitted: a dedicated
+		// inserter entry would surface in post-less contexts (templates, template
+		// parts, synced patterns) where there's no post to resolve images from. The
+		// entry point is instead the inspector toggle on a regular Gallery.
+		// `isActive` still relabels the block card to "Dynamic Gallery" regardless
+		// of scope. Revisit adding `'inserter'` in a follow-up as the feature grows
+		// beyond the post-attached source.
+		scope: [],
 	},
 ];
 

--- a/phpunit/blocks/render-block-gallery-test.php
+++ b/phpunit/blocks/render-block-gallery-test.php
@@ -159,6 +159,36 @@ class Tests_Blocks_Render_Gallery extends WP_UnitTestCase {
 		$this->assertSame( '', trim( $output ) );
 	}
 
+	public function test_dynamic_gallery_sanitizes_image_aspect_ratio_style() {
+		$valid_output = $this->render_in_loop(
+			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"},"aspectRatio":"16/9"} /-->'
+		);
+
+		$this->assertStringContainsString(
+			'style="aspect-ratio:16/9;object-fit:cover"',
+			$valid_output,
+			'A valid aspect ratio should be rendered as an image style.'
+		);
+
+		// A value that tries to break out of the style attribute is run through
+		// `safecss_filter_attr` and escaped on output, so it cannot introduce an
+		// event handler or extra markup.
+		$malicious_output = $this->render_in_loop(
+			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"},"aspectRatio":"16/9\" onload=\"alert(1)"} /-->'
+		);
+
+		$this->assertStringNotContainsString(
+			'onload="alert(1)',
+			$malicious_output,
+			'A malicious aspect ratio must not break out of the style attribute.'
+		);
+		$this->assertStringNotContainsString(
+			'<script',
+			$malicious_output,
+			'A malicious aspect ratio must not inject markup.'
+		);
+	}
+
 	public function test_dynamic_gallery_renders_saved_caption_after_images() {
 		// In dynamic mode `save.js` persists only the gallery-level caption, so the
 		// saved content is a bare `<figcaption>`. The render callback builds the

--- a/phpunit/blocks/render-block-gallery-test.php
+++ b/phpunit/blocks/render-block-gallery-test.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Gallery block rendering tests.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests for the Gallery block, in particular its dynamic mode where images are
+ * resolved from a source (`dynamicContent`) rather than from inner image blocks.
+ *
+ * @group blocks
+ */
+class Tests_Blocks_Render_Gallery extends WP_UnitTestCase {
+
+	/**
+	 * Post that the attachments are attached to.
+	 *
+	 * @var int
+	 */
+	private static $post_id;
+
+	/**
+	 * Image attachment IDs attached to self::$post_id.
+	 *
+	 * @var int[]
+	 */
+	private static $attachment_ids = array();
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$post_id = $factory->post->create(
+			array( 'post_title' => 'Gallery dynamic mode test post' )
+		);
+
+		$file = DIR_TESTDATA . '/images/canola.jpg';
+		// Two images attached to the post.
+		self::$attachment_ids[] = $factory->attachment->create_upload_object( $file, self::$post_id );
+		self::$attachment_ids[] = $factory->attachment->create_upload_object( $file, self::$post_id );
+
+		// Give the attachments distinct dates so `orderby=date` is deterministic
+		// and actually reverses between asc and desc. Created back-to-back from
+		// the same file they would otherwise share a `post_date`, which MySQL
+		// tie-breaks by ID regardless of order direction.
+		wp_update_post(
+			array(
+				'ID'            => self::$attachment_ids[0],
+				'post_date'     => '2020-01-01 00:00:00',
+				'post_date_gmt' => '2020-01-01 00:00:00',
+			)
+		);
+		wp_update_post(
+			array(
+				'ID'            => self::$attachment_ids[1],
+				'post_date'     => '2020-01-02 00:00:00',
+				'post_date_gmt' => '2020-01-02 00:00:00',
+			)
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$attachment_ids as $attachment_id ) {
+			wp_delete_attachment( $attachment_id, true );
+		}
+		wp_delete_post( self::$post_id, true );
+	}
+
+	/**
+	 * Renders a gallery block within the loop for self::$post_id so that the
+	 * `core/attached-media` source resolves against it (via the `get_the_ID()`
+	 * fallback).
+	 *
+	 * @param string $block_markup Serialized gallery block.
+	 * @return string Rendered HTML.
+	 */
+	private function render_in_loop( $block_markup ) {
+		global $post;
+		$post = get_post( self::$post_id );
+		setup_postdata( $post );
+		$output = do_blocks( $block_markup );
+		wp_reset_postdata();
+		return $output;
+	}
+
+	public function test_dynamic_attached_to_post_renders_attached_images() {
+		$output = $this->render_in_loop(
+			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"}} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure><!-- /wp:gallery -->'
+		);
+
+		// One image figure per attached image.
+		$this->assertSame(
+			count( self::$attachment_ids ),
+			substr_count( $output, 'wp-block-image' ),
+			'Should render one image block per attached image.'
+		);
+
+		foreach ( self::$attachment_ids as $attachment_id ) {
+			$this->assertStringContainsString(
+				'wp-image-' . $attachment_id,
+				$output,
+				"Rendered gallery should contain attachment $attachment_id."
+			);
+		}
+	}
+
+	public function test_dynamic_attached_to_post_honours_order() {
+		$asc  = $this->render_in_loop(
+			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media","args":{"orderBy":"date","order":"asc"}}} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure><!-- /wp:gallery -->'
+		);
+		$desc = $this->render_in_loop(
+			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media","args":{"orderBy":"date","order":"desc"}}} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure><!-- /wp:gallery -->'
+		);
+
+		$first  = self::$attachment_ids[0];
+		$second = self::$attachment_ids[1];
+
+		// Oldest to newest: the first-created attachment renders before the second.
+		$this->assertLessThan(
+			strpos( $asc, 'wp-image-' . $second ),
+			strpos( $asc, 'wp-image-' . $first ),
+			'With order=asc the earlier attachment should render first.'
+		);
+
+		// Newest to oldest reverses that order.
+		$this->assertLessThan(
+			strpos( $desc, 'wp-image-' . $first ),
+			strpos( $desc, 'wp-image-' . $second ),
+			'With order=desc the later attachment should render first.'
+		);
+	}
+
+	public function test_dynamic_unknown_source_renders_no_images() {
+		$output = $this->render_in_loop(
+			'<!-- wp:gallery {"dynamicContent":{"source":"notARealSource"}} --><figure class="wp-block-gallery has-nested-images columns-default"></figure><!-- /wp:gallery -->'
+		);
+
+		$this->assertStringNotContainsString( 'wp-block-image', $output );
+	}
+
+	public function test_static_gallery_without_dynamic_source_is_unaffected() {
+		$attachment_id = self::$attachment_ids[0];
+		$image_url     = wp_get_attachment_image_url( $attachment_id, 'large' );
+		$markup        = sprintf(
+			'<!-- wp:gallery {"linkTo":"none"} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":%1$d,"sizeSlug":"large"} --><figure class="wp-block-image size-large"><img src="%2$s" alt="" class="wp-image-%1$d"/></figure><!-- /wp:image --></figure><!-- /wp:gallery -->',
+			$attachment_id,
+			$image_url
+		);
+
+		$output = $this->render_in_loop( $markup );
+
+		// The single, manually-added image renders; the dynamic source path is
+		// not engaged, so no extra attached images are injected.
+		$this->assertSame( 1, substr_count( $output, 'wp-block-image' ) );
+		$this->assertStringContainsString( 'wp-image-' . $attachment_id, $output );
+	}
+
+	public function test_dynamic_lightbox_link_adds_interactivity_directives() {
+		$output = $this->render_in_loop(
+			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"},"linkTo":"lightbox"} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure><!-- /wp:gallery -->'
+		);
+
+		// Lightbox-enabled images go through the image block's lightbox render,
+		// which the gallery then wires up for navigation.
+		$this->assertStringContainsString( 'data-wp-interactive="core/gallery"', $output );
+		$this->assertStringContainsString( 'lightbox-trigger', $output );
+	}
+}

--- a/phpunit/blocks/render-block-gallery-test.php
+++ b/phpunit/blocks/render-block-gallery-test.php
@@ -147,12 +147,16 @@ class Tests_Blocks_Render_Gallery extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_dynamic_unknown_source_renders_no_images() {
+	public function test_dynamic_source_with_no_images_renders_nothing() {
+		// An unrecognized source (like a valid source that resolves to no images)
+		// should render nothing at all — not an empty gallery wrapper.
 		$output = $this->render_in_loop(
 			'<!-- wp:gallery {"dynamicContent":{"source":"notARealSource"}} /-->'
 		);
 
 		$this->assertStringNotContainsString( 'wp-block-image', $output );
+		$this->assertStringNotContainsString( 'wp-block-gallery', $output );
+		$this->assertSame( '', trim( $output ) );
 	}
 
 	public function test_dynamic_gallery_renders_saved_caption_after_images() {

--- a/phpunit/blocks/render-block-gallery-test.php
+++ b/phpunit/blocks/render-block-gallery-test.php
@@ -154,6 +154,58 @@ class Tests_Blocks_Render_Gallery extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'wp-image-' . $attachment_id, $output );
 	}
 
+	public function test_dynamic_caption_mirrors_raw_excerpt_and_ignores_filter() {
+		$attachment_id = self::$attachment_ids[0];
+
+		// Give the attachment a raw caption (`post_excerpt`).
+		wp_update_post(
+			array(
+				'ID'           => $attachment_id,
+				'post_excerpt' => 'Raw caption text',
+			)
+		);
+
+		// The editor preview builds the image caption from the REST `caption.raw`
+		// value and cannot see PHP filters, so a `wp_get_attachment_caption` filter
+		// must NOT influence the rendered figcaption — otherwise the frontend would
+		// diverge from the preview.
+		$filter = static function () {
+			return 'Filtered caption text';
+		};
+		add_filter( 'wp_get_attachment_caption', $filter );
+
+		try {
+			$output = $this->render_in_loop(
+				'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"}} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure><!-- /wp:gallery -->'
+			);
+		} finally {
+			remove_filter( 'wp_get_attachment_caption', $filter );
+			// Reset so the shared fixture doesn't leak into other tests.
+			wp_update_post(
+				array(
+					'ID'           => $attachment_id,
+					'post_excerpt' => '',
+				)
+			);
+		}
+
+		$this->assertStringContainsString(
+			'wp-element-caption',
+			$output,
+			'Dynamic render should output a caption element.'
+		);
+		$this->assertStringContainsString(
+			'Raw caption text',
+			$output,
+			'Dynamic render should use the raw attachment caption, mirroring the editor preview.'
+		);
+		$this->assertStringNotContainsString(
+			'Filtered caption text',
+			$output,
+			'The wp_get_attachment_caption filter must not affect the dynamic render; it cannot be mirrored in the editor preview.'
+		);
+	}
+
 	public function test_dynamic_lightbox_link_adds_interactivity_directives() {
 		$output = $this->render_in_loop(
 			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"},"linkTo":"lightbox"} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure><!-- /wp:gallery -->'

--- a/phpunit/blocks/render-block-gallery-test.php
+++ b/phpunit/blocks/render-block-gallery-test.php
@@ -159,6 +159,32 @@ class Tests_Blocks_Render_Gallery extends WP_UnitTestCase {
 		$this->assertSame( '', trim( $output ) );
 	}
 
+	public function test_dynamic_gallery_ignores_malformed_dynamic_content() {
+		// A `dynamicContent` that isn't the expected `{ source, args }` object
+		// (e.g. corrupted or hand-edited markup) resolves to no source and renders
+		// nothing, without reading array offsets off a non-array value.
+		$non_object = $this->render_in_loop(
+			'<!-- wp:gallery {"dynamicContent":"not-an-object"} /-->'
+		);
+		$this->assertSame(
+			'',
+			trim( $non_object ),
+			'A non-object dynamicContent should resolve to no source and render nothing.'
+		);
+
+		// A valid source with a malformed (non-array) `args` falls back to the
+		// default ordering and still renders the attached images, again without
+		// indexing a non-array.
+		$malformed_args = $this->render_in_loop(
+			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media","args":"oops"}} /-->'
+		);
+		$this->assertSame(
+			count( self::$attachment_ids ),
+			substr_count( $malformed_args, 'wp-block-image' ),
+			'A gallery with malformed args should still render the attached images using the default ordering.'
+		);
+	}
+
 	public function test_dynamic_gallery_sanitizes_image_aspect_ratio_style() {
 		$valid_output = $this->render_in_loop(
 			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"},"aspectRatio":"16/9"} /-->'

--- a/phpunit/blocks/render-block-gallery-test.php
+++ b/phpunit/blocks/render-block-gallery-test.php
@@ -84,8 +84,26 @@ class Tests_Blocks_Render_Gallery extends WP_UnitTestCase {
 
 	public function test_dynamic_attached_to_post_renders_attached_images() {
 		$output = $this->render_in_loop(
-			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"}} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure><!-- /wp:gallery -->'
+			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"}} /-->'
 		);
+
+		// The gallery wrapper is built from scratch (no markup is persisted in
+		// dynamic mode), so assert it carries the gallery-specific classes plus
+		// the flex layout class added by the layout render filter — i.e. the same
+		// wrapper a static gallery would produce.
+		foreach ( array(
+			'wp-block-gallery',
+			'has-nested-images',
+			'columns-default',
+			'is-cropped',
+			'is-layout-flex',
+		) as $expected_class ) {
+			$this->assertStringContainsString(
+				$expected_class,
+				$output,
+				"Constructed gallery wrapper should include the `$expected_class` class."
+			);
+		}
 
 		// One image figure per attached image.
 		$this->assertSame(
@@ -105,10 +123,10 @@ class Tests_Blocks_Render_Gallery extends WP_UnitTestCase {
 
 	public function test_dynamic_attached_to_post_honours_order() {
 		$asc  = $this->render_in_loop(
-			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media","args":{"orderBy":"date","order":"asc"}}} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure><!-- /wp:gallery -->'
+			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media","args":{"orderBy":"date","order":"asc"}}} /-->'
 		);
 		$desc = $this->render_in_loop(
-			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media","args":{"orderBy":"date","order":"desc"}}} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure><!-- /wp:gallery -->'
+			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media","args":{"orderBy":"date","order":"desc"}}} /-->'
 		);
 
 		$first  = self::$attachment_ids[0];
@@ -131,10 +149,35 @@ class Tests_Blocks_Render_Gallery extends WP_UnitTestCase {
 
 	public function test_dynamic_unknown_source_renders_no_images() {
 		$output = $this->render_in_loop(
-			'<!-- wp:gallery {"dynamicContent":{"source":"notARealSource"}} --><figure class="wp-block-gallery has-nested-images columns-default"></figure><!-- /wp:gallery -->'
+			'<!-- wp:gallery {"dynamicContent":{"source":"notARealSource"}} /-->'
 		);
 
 		$this->assertStringNotContainsString( 'wp-block-image', $output );
+	}
+
+	public function test_dynamic_gallery_renders_saved_caption_after_images() {
+		// In dynamic mode `save.js` persists only the gallery-level caption, so the
+		// saved content is a bare `<figcaption>`. The render callback builds the
+		// wrapper, injects the resolved images, then appends the caption.
+		$output = $this->render_in_loop(
+			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"}} --><figcaption class="blocks-gallery-caption wp-element-caption">My gallery caption</figcaption><!-- /wp:gallery -->'
+		);
+
+		$this->assertStringContainsString(
+			'<figcaption class="blocks-gallery-caption wp-element-caption">My gallery caption</figcaption>',
+			$output,
+			'The saved gallery caption should be rendered.'
+		);
+
+		// The caption is appended after the images (mirroring a static gallery).
+		$this->assertGreaterThan(
+			strpos( $output, 'wp-image-' . self::$attachment_ids[0] ),
+			strpos( $output, 'blocks-gallery-caption' ),
+			'The gallery caption should render after the images.'
+		);
+
+		// It sits inside the gallery figure, not loose after it.
+		$this->assertStringEndsWith( '</figure>', trim( $output ) );
 	}
 
 	public function test_static_gallery_without_dynamic_source_is_unaffected() {
@@ -176,7 +219,7 @@ class Tests_Blocks_Render_Gallery extends WP_UnitTestCase {
 
 		try {
 			$output = $this->render_in_loop(
-				'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"}} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure><!-- /wp:gallery -->'
+				'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"}} /-->'
 			);
 		} finally {
 			remove_filter( 'wp_get_attachment_caption', $filter );
@@ -208,7 +251,7 @@ class Tests_Blocks_Render_Gallery extends WP_UnitTestCase {
 
 	public function test_dynamic_lightbox_link_adds_interactivity_directives() {
 		$output = $this->render_in_loop(
-			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"},"linkTo":"lightbox"} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure><!-- /wp:gallery -->'
+			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"},"linkTo":"lightbox"} /-->'
 		);
 
 		// Lightbox-enabled images go through the image block's lightbox render,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of:

* #76955 
* #77117

Add a dynamic mode of the gallery block. While eventually this will be a good entry point for adding media via folders or tags, this MVP focuses on one part of existing core media behaviour: media that is "attached to" the post.

The Dynamic Gallery block variation displays all the media items currently attached to the post, both in the editor and on the site frontend. This matches how the gallery shortcode used to work in the classic editor when no media items are selected.

This is a prototype, all decisions are up for debate! I came to the below decisions through trial and error and a desire to re-use what I could and avoid duplication where possible. I also want to set things up to allow more complex dynamic behaviour further down the track (e.g. query by date range, author, or one day, folders & tags).

<img width="1049" height="599" alt="image" src="https://github.com/user-attachments/assets/61b03073-5fe2-49f9-8df1-830007c2e067" />

### Decisions made

* A block variation not a separate block (this allows the dynamic mode to re-use block attributes, reduces duplication and allows smooth handoff between modes)
* A block variation also allows for a different title and description to provide clarity to the mode
* The Dynamic Gallery is available from the placeholder by clicking a button in the placeholder state
* The Dynamic Gallery can be converted to a static gallery so users can edit the list of images shown
* There is a button to convert back to a Dynamic Gallery, and it presents a warning dialog as it's a destructive action
* When in Dynamic Gallery mode, hide the list view tab as in this state, inner image blocks are displayed dynamically

### Why not block bindings?

* There currently isn't support for innerBlocks / generating a list of inner blocks from a block bindings source
* The `images` and `ids` attributes in the Gallery block are from the legacy v1 version of the Gallery block where the images were baked into the post content markup of the Gallery block
* So, for this prototype/proposal the idea is to go with a block attribute shape that matches an eventual shape for block bindings using inner blocks — the goal here is to make it easy (or easier) to migrate to block bindings further down the track

## Why?

* Being able to display images attached to a post via a gallery is core behaviour supported by the classic editor / gallery shortcode. This is a gap that the Gallery block currently doesn't cover.
* Adding dynamic behaviour opens up lots of powerful features further down the track (query by author, date range, or one day, folders & tags)

## How?

* Add a `dynamicContent` attribute that allows a Gallery block to be identified as dynamic, as well as query arguments like sort order
* Add a Source panel to the settings tab to allow users to configure the query or swap between dynamic and static modes of the block
* Add a block variation for Dynamic Gallery for clearer title / descriptions (and to allow it to be added to the inserter further down the track)
* Add a button to the block placeholder to make it easy to access the Dynamic Gallery mode
* Add a dialog to warn users when switching from static mode to dynamic (we might also want a warning the other way around)

## Testing Instructions

* Create a draft post or page and save it
* Go to the media library directly (e.g. `/wp-admin/upload.php`) and add some media items, using the "Uploaded to" column to attach media items to the post you created
* Go back to the post you created and add a gallery block
* Click the button in the placeholder to try out the dynamic mode
* Using the settings tab, try different ordering, try the different settings, and compare the editor and site frontend states.
* Convert to a static gallery block and test how it works
* Bonus points: test the gallery block within an unsynced pattern, e.g. in the site editor.
    * For a static gallery block, the list view tab should be available
    * In dynamic mode, the list view tab should not be available

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/c45770ca-d8bc-4e38-bc37-940e1c3bd552

### States of the Dynamic Gallery

This is a quick reference of the different areas to help review the language (and UI patterns) used.

#### Empty placeholder state after inserting a Gallery block

<img width="1334" height="508" alt="image" src="https://github.com/user-attachments/assets/bdd0eaa2-9626-486e-a8e1-926e4d62ba24" />

#### Loading state when resolving images attached to the post

<img width="2272" height="592" alt="image" src="https://github.com/user-attachments/assets/9f9af864-a988-4efd-9b5c-b0af7d3d0b67" />

#### Placeholder state when in dynamic mode and no images are available

<img width="1922" height="836" alt="image" src="https://github.com/user-attachments/assets/a2dc245b-0080-4db6-ba34-3fbf1fb212a1" />

#### Modal when converting from static images to images attached to the post

<img width="1094" height="686" alt="image" src="https://github.com/user-attachments/assets/553eaecd-5840-4d4f-b77c-a83c055af102" />

## Use of AI Tools

Some Claude Code and some Codex
