### PR TITLE
Code Quality: Pass boolean values to the `inert` attribute

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -185,7 +185,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		'data-block': clientId,
 		'data-type': name,
 		'data-title': blockTitle,
-		inert: isSubtreeDisabled ? true : undefined,
+		inert: isSubtreeDisabled,
 		className: clsx(
 			'block-editor-block-list__block',
 			{

--- a/packages/boot/src/components/canvas/index.tsx
+++ b/packages/boot/src/components/canvas/index.tsx
@@ -66,11 +66,7 @@ export default function Canvas( { canvas }: CanvasProps ) {
 	// Render the editor with canvas data
 	return (
 		<div style={ { height: '100%', position: 'relative' } }>
-			<div
-				style={ { height: '100%' } }
-				// @ts-expect-error inert not typed properly
-				inert={ canvas.isPreview ? 'true' : undefined }
-			>
+			<div style={ { height: '100%' } } inert={ canvas.isPreview }>
 				<Editor
 					postType={ canvas.postType }
 					postId={ canvas.postId }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `Disabled`: Pass a boolean to the `inert` attribute instead of the string `'true'` to avoid a React 19 warning ([#78798](https://github.com/WordPress/gutenberg/pull/78798)).
+
 ## 34.0.0 (2026-05-27)
 
 ### Breaking Changes

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Bug Fixes
+### Internal
 
 -   `Disabled`: Pass a boolean to the `inert` attribute instead of the string `'true'` to avoid a React 19 warning ([#78798](https://github.com/WordPress/gutenberg/pull/78798)).
 

--- a/packages/components/src/disabled/index.tsx
+++ b/packages/components/src/disabled/index.tsx
@@ -60,8 +60,7 @@ function Disabled( {
 	return (
 		<Provider value={ isDisabled }>
 			<div
-				// @ts-ignore Reason: inert is a recent HTML attribute
-				inert={ isDisabled ? true : undefined }
+				inert={ isDisabled }
 				className={
 					isDisabled
 						? cx( disabledStyles, className, 'components-disabled' )

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Bug Fixes
+### Internal
 
 - DataViews: Pass boolean values to the `inert` attribute instead of the string `'true'` to avoid a React 19 warning. [#78798](https://github.com/WordPress/gutenberg/pull/78798)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- DataViews: Pass boolean values to the `inert` attribute instead of the string `'true'` to avoid a React 19 warning. [#78798](https://github.com/WordPress/gutenberg/pull/78798)
+
 ## 15.0.0 (2026-05-27)
 
 ### Breaking Changes

--- a/packages/dataviews/src/components/dataviews-footer/index.tsx
+++ b/packages/dataviews/src/components/dataviews-footer/index.tsx
@@ -51,11 +51,7 @@ export default function DataViewsFooter() {
 	}
 	return (
 		( !! totalItems || isRefreshing ) && (
-			<div
-				className="dataviews-footer"
-				// @ts-ignore
-				inert={ isRefreshing ? 'true' : undefined }
-			>
+			<div className="dataviews-footer" inert={ isRefreshing }>
 				<Stack
 					direction="row"
 					justify="end"

--- a/packages/dataviews/src/components/dataviews-layouts/activity/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/activity/index.tsx
@@ -63,8 +63,7 @@ export default function ViewActivity< Item >(
 				direction="column"
 				gap="sm"
 				className={ wrapperClassName }
-				// @ts-ignore
-				inert={ isInert ? 'true' : undefined }
+				inert={ isInert }
 			>
 				{ groupedEntries.map(
 					( [ groupName, groupData ]: [ string, Item[] ] ) => (
@@ -92,8 +91,7 @@ export default function ViewActivity< Item >(
 			<div
 				className={ wrapperClassName }
 				role={ view.infiniteScrollEnabled ? 'feed' : undefined }
-				// @ts-ignore
-				inert={ isInert ? 'true' : undefined }
+				inert={ isInert }
 			>
 				<ActivityItems< Item > { ...props } />
 			</div>

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -344,7 +344,7 @@ interface CompositeGridProps< Item > {
 	data: Item[];
 	isInfiniteScroll: boolean;
 	className?: string;
-	inert?: string;
+	inert?: boolean;
 	isLoading?: boolean;
 	view: ViewGridType;
 	fields: NormalizedField< Item >[];

--- a/packages/dataviews/src/components/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/index.tsx
@@ -55,7 +55,7 @@ function ViewGrid< Item >( {
 		className: clsx( className, {
 			'is-refreshing': ! isInfiniteScroll && isDelayedLoading,
 		} ),
-		inert: ! isInfiniteScroll && !! isLoading ? 'true' : undefined,
+		inert: ! isInfiniteScroll && !! isLoading,
 		isLoading,
 		view,
 		fields,

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -631,10 +631,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 				role={ view.infiniteScrollEnabled ? 'feed' : 'grid' }
 				activeId={ activeCompositeId }
 				setActiveId={ setActiveCompositeId }
-				// @ts-ignore
-				inert={
-					! isInfiniteScroll && !! isLoading ? 'true' : undefined
-				}
+				inert={ ! isInfiniteScroll && !! isLoading }
 			>
 				{ data.map( ( item, index ) => {
 					const id = generateCompositeItemIdPrefix( item );

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -426,8 +426,7 @@ function ViewTable< Item >( {
 				aria-busy={ isLoading }
 				aria-describedby={ tableNoticeId }
 				role={ isInfiniteScroll ? 'feed' : undefined }
-				// @ts-ignore Reason: inert is a recent HTML attribute
-				inert={ ! isInfiniteScroll && isLoading ? 'true' : undefined }
+				inert={ ! isInfiniteScroll && !! isLoading }
 			>
 				<colgroup>
 					{ hasBulkActions && (


### PR DESCRIPTION
See https://make.wordpress.org/core/2026/05/27/react-19-upgrade-in-wordpress/#:~:text=The%20inert%20attribute%20is%20now%20a%20boolean

## What?

Pass boolean values to the `inert` attribute instead of the string `'true'`.

## Why?

Since React 19, `inert` is treated as a real boolean attribute. Passing the string `'true'` now triggers a runtime warning:

> Received the string `true` for the boolean attribute `inert`. Although this works, it will not work as expected if you pass the string "false". Did you mean inert={true}?

<img width="1439" height="650" alt="image" src="https://github.com/user-attachments/assets/c1f9a0dc-ecbf-42a7-bb6e-776d5d6c349c" />

## How?

- Replaced the `? 'true' : undefined` string workarounds with plain boolean expressions.
- Removed the `@ts-ignore` / `@ts-expect-error` directives that are no longer needed,

## Testing Instructions

Ensure the `inert` attribute continues to function. The following are key areas to test:

### Site Editor v2

- Enable the "Extensible Site Editor" experiments
- Access http://localhost:8888/wp-admin/admin.php?page=site-editor-v2
- Confirm that blocks within the canvas cannot be clicked and that the canvas cannot be scrolled. Canvas scrolling should be allowed, but this issue is not caused by this PR.

### Disabled component

Launch Storybook and toggle the `isDisabled` prop.

