### PR TITLE
Sync editor settings in layout effect (fixes autosave e2e)

### DIFF
--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -3,7 +3,7 @@
  */
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { ifCondition, usePrevious } from '@wordpress/compose';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { parse } from '@wordpress/blocks';
 import { store as noticesStore } from '@wordpress/notices';
@@ -53,19 +53,14 @@ const hasSessionStorageSupport = () => {
  * restore a local autosave, if one exists.
  */
 function useAutosaveNotice() {
-	const { postId, isEditedPostNew, hasRemoteAutosave } = useSelect(
+	const registry = useRegistry();
+	const { postId, isEditedPostNew } = useSelect(
 		( select ) => ( {
 			postId: select( editorStore ).getCurrentPostId(),
 			isEditedPostNew: select( editorStore ).isEditedPostNew(),
-			hasRemoteAutosave:
-				!! select( editorStore ).getEditorSettings().autosave,
 		} ),
 		[]
 	);
-	const { getEditedPostAttribute } = useSelect( editorStore );
-
-	const { createWarningNotice, removeNotice } = useDispatch( noticesStore );
-	const { editPost, resetEditorBlocks } = useDispatch( editorStore );
 
 	useEffect( () => {
 		let localAutosave = localAutosaveGet( postId, isEditedPostNew );
@@ -83,23 +78,30 @@ function useAutosaveNotice() {
 		const { post_title: title, content, excerpt } = localAutosave;
 		const edits = { title, content, excerpt };
 
-		{
-			// Only display a notice if there is a difference between what has been
-			// saved and that which is stored in sessionStorage.
-			const hasDifference = Object.keys( edits ).some( ( key ) => {
-				return edits[ key ] !== getEditedPostAttribute( key );
-			} );
+		const { getEditedPostAttribute, getEditorSettings } =
+			registry.select( editorStore );
 
-			if ( ! hasDifference ) {
-				// If there is no difference, it can be safely ejected from storage.
-				localAutosaveClear( postId, isEditedPostNew );
-				return;
-			}
+		// Only display a notice if there is a difference between what has been
+		// saved and that which is stored in sessionStorage.
+		const hasDifference = Object.keys( edits ).some( ( key ) => {
+			return edits[ key ] !== getEditedPostAttribute( key );
+		} );
+
+		if ( ! hasDifference ) {
+			// If there is no difference, it can be safely ejected from storage.
+			localAutosaveClear( postId, isEditedPostNew );
+			return;
 		}
 
+		const hasRemoteAutosave = !! getEditorSettings().autosave;
 		if ( hasRemoteAutosave ) {
 			return;
 		}
+
+		const { createWarningNotice, removeNotice } =
+			registry.dispatch( noticesStore );
+		const { editPost, resetEditorBlocks } =
+			registry.dispatch( editorStore );
 
 		const id = 'wpEditorAutosaveRestore';
 
@@ -125,7 +127,7 @@ function useAutosaveNotice() {
 				],
 			}
 		);
-	}, [ isEditedPostNew, postId ] );
+	}, [ registry, postId, isEditedPostNew ] );
 }
 
 /**

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -380,7 +380,8 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		}, [ post.type, post.id, setEditedPost, removeNotice ] );
 
 		// Synchronize the editor settings as they change.
-		useEffect( () => {
+		// Do it as a layout effect so that rendered UI with outdated settings is not painted.
+		useLayoutEffect( () => {
 			updateEditorSettings( settings );
 		}, [ settings, updateEditorSettings ] );
 

--- a/test/e2e/specs/editor/various/autosave.spec.js
+++ b/test/e2e/specs/editor/various/autosave.spec.js
@@ -328,21 +328,6 @@ test.describe( 'Autosave', () => {
 		await page.reload();
 		await page.waitForFunction( () => window?.wp?.data );
 
-		// FIXME: Occasionally, upon reload, there is no server-provided
-		// autosave value available, despite our having previously explicitly
-		// autosaved. The reasons for this are still unknown. Since this is
-		// unrelated to *local* autosave, until we can understand them, we'll
-		// drop this test's expectations if we don't have an autosave object
-		// available.
-		const stillHasRemoteAutosave = await page.evaluate(
-			() =>
-				window.wp.data.select( 'core/editor' ).getEditorSettings()
-					.autosave
-		);
-		if ( ! stillHasRemoteAutosave ) {
-			return;
-		}
-
 		// Only remote autosave notice should be applied.
 		await expect(
 			page.locator( '.components-notice__content' )

--- a/test/e2e/specs/editor/various/autosave.spec.js
+++ b/test/e2e/specs/editor/various/autosave.spec.js
@@ -293,7 +293,8 @@ test.describe( 'Autosave', () => {
 			name: 'Block: Paragraph',
 		} );
 		await paragraph.click();
-		await page.keyboard.type( ' after save' );
+		// Type slowly to ensure that autosave happens more than 1s after publish.
+		await page.keyboard.type( ' after save', { delay: 100 } );
 
 		// Trigger remote autosave.
 		await page.evaluate( () =>


### PR DESCRIPTION
Closes #58959.
Supersedes and closes #77829.

Attempt to fix #78706, a flaky autosave test that started failing 2 days ago. The most likely suspect is the React 19 migration which changed the precise scheduling of effects, state updates and similar things.

The problem is that when we have both remote (server) and local (storage) autosaves, we show notices about both of them:
```
Locator: locator('.components-notice__content')
Expected substring: "There is an autosave of this post that is more recent than the version below."
Error: strict mode violation: locator('.components-notice__content') resolved to 2 elements:
    1) <div class="components-notice__content">The backup of this post in your browser is differ…</div> aka getByText('The backup of this post in')
    2) <div class="components-notice__content">There is an autosave of this post that is more re…</div> aka getByLabel('Editor content').getByText('There is an autosave of this')
```
although we have explicit code (added 7 years ago in #17501) that disables the local notice when the remote one is shown:

https://github.com/WordPress/gutenberg/blob/86c513917e9e268a4ff8dec6538f9f15fcdc447f/packages/editor/src/components/local-autosave-monitor/index.js#L100-L102

But this doesn't work because of the following combination of reasons:
- the `hasRemoteAutosave` value is read in `useEffect`, on mount, from `select( editorStore ).getEditorSettings().autosave`, i.e., the editor settings stored in data store
- at the moment of the mount, the data store doesn't contain the real settings yet, it only has the default values. The real settings are saved in another `useEffect`, in `ExperimentalEditorProvider`. And because effects on parent components run only after effects on child components, the sync happens too late.

The result is that the effect in `LocalAutosaveMonitor` always sees a false value of the `autosave` setting, the check doesn't work.

I'm fixing this by doing the `updateEditorSettings` call in a layout effect instead. Then it happens early enough. Doing this is generally a good idea, it's not a mere hack. Because the initial render doesn't yet have the real settings, only the default ones, we shouldn't paint the result. We should trigger a second render as soon as possible, and paint only after the second, correct render finishes.

In this PR I'm also removing the `stillHasRemoteAutosave` check, because it hides another bug. This check was added by @mcsf in #17679, also 7 years ago. The problem was that sometimes the autosave is not there after reload, although it was reliably saved. I don't know why this was happening in 2019, but today it's happening because of RTC 🙂 

There is this POST request that saves the `crdtDocument` to post meta, triggered by a supposedly read-only `getEntityRecord`. This request happens _after_ the autosave. And the very bad thing about it is that it updates the "modified" timestamp of the post. When the `edit-form-blocks.php` page decides whether to send the autosave, it checks the timestamps:

https://github.com/WordPress/wordpress-develop/blob/75fc4e9f0eb6ec211b1d95e2bd80683fc36c5090/src/wp-admin/edit-form-blocks.php#L291-L300

In my testing, the autosave and meta-save happen either in the same second, and then the test succeeds. Or the meta-save happens in the next second, and then the modified timestamp is bigger, the remote autosave is deleted and the test fails.

For this reason, the e2e test will still fail. What can we do about it? The meta-save request probably shouldn't update any timestamps at all. FYI @alecgeatches 