### PR TITLE
LinkControl: Suggest same-page anchors when typing #

### DIFF
--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -49,6 +49,7 @@ function getExpectedVisualTypeName( type ) {
  * when we are testing the "rich previews" to we update this value with a true mock.
  */
 let mockFetchRichUrlData;
+let mockBlocks;
 
 jest.mock( '@wordpress/data/src/components/use-select', () => {
 	// This allows us to tweak the returned value on each test.
@@ -58,6 +59,7 @@ jest.mock( '@wordpress/data/src/components/use-select', () => {
 useSelect.mockImplementation( () => ( {
 	fetchSearchSuggestions: mockFetchSearchSuggestions,
 	fetchRichUrlData: mockFetchRichUrlData,
+	blocks: mockBlocks,
 } ) );
 
 jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
@@ -72,6 +74,7 @@ jest.mock( '@wordpress/compose', () => ( {
 beforeEach( () => {
 	// Setup a DOM element as a render target.
 	mockFetchSearchSuggestions.mockImplementation( fetchFauxEntitySuggestions );
+	mockBlocks = [];
 } );
 
 afterEach( () => {
@@ -942,6 +945,49 @@ describe( 'Manual link entry', () => {
 	} );
 
 	describe( 'Alternative link protocols and formats', () => {
+		it( 'should suggest matching anchor ids from the current page when typing a hash link', async () => {
+			const user = userEvent.setup();
+			mockBlocks = [
+				{
+					attributes: { anchor: 'intro' },
+					innerBlocks: [],
+				},
+				{
+					attributes: { anchor: 'section-two' },
+					innerBlocks: [
+						{
+							attributes: { anchor: 'nested-section' },
+							innerBlocks: [],
+						},
+					],
+				},
+			];
+
+			render( <LinkControl /> );
+
+			const searchInput = screen.getByRole( 'combobox', {
+				name: 'Search or type URL',
+			} );
+
+			await user.type( searchInput, '#' );
+
+			const searchResults = await screen.findByRole( 'listbox', {
+				name: /Search results for.*/,
+			} );
+
+			const searchResultElements =
+				within( searchResults ).getAllByRole( 'option' );
+
+			expect( searchResultElements ).toHaveLength( 3 );
+			expect( searchResultElements[ 0 ] ).toHaveTextContent( '#intro' );
+			expect( searchResultElements[ 1 ] ).toHaveTextContent(
+				'#nested-section'
+			);
+			expect( searchResultElements[ 2 ] ).toHaveTextContent(
+				'#section-two'
+			);
+		} );
+
 		it.each( [
 			[ 'mailto:example123456@wordpress.org', 'mailto' ],
 			[ 'tel:example123456@wordpress.org', 'tel' ],

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -7,9 +7,9 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import isURLLike from './is-url-like';
+import isURLLike, { isHashLink } from './is-url-like';
 import normalizeUrl from './normalize-url';
-import { CREATE_TYPE } from './constants';
+import { CREATE_TYPE, INTERNAL_TYPE } from './constants';
 import { store as blockEditorStore } from '../../store';
 
 export const handleNoop = () => Promise.resolve( [] );
@@ -25,6 +25,38 @@ export const handleDirectEntry = ( val ) => {
 			type,
 		},
 	] );
+};
+
+const getAnchorSuggestions = ( blocks, val ) => {
+	const search = val.slice( 1 ).toLowerCase();
+	const anchors = new Set();
+	const stack = [ ...( Array.isArray( blocks ) ? blocks : [] ) ];
+
+	while ( stack.length ) {
+		const block = stack.shift();
+		const anchor = block?.attributes?.anchor?.trim();
+
+		if ( anchor && anchor.toLowerCase().includes( search ) ) {
+			anchors.add( anchor );
+		}
+
+		if ( Array.isArray( block?.innerBlocks ) && block.innerBlocks.length ) {
+			stack.push( ...block.innerBlocks );
+		}
+	}
+
+	return Array.from( anchors )
+		.sort( ( a, b ) => a.localeCompare( b ) )
+		.map( ( anchor ) => {
+			const hashLink = `#${ anchor }`;
+
+			return {
+				id: hashLink,
+				title: hashLink,
+				url: hashLink,
+				type: INTERNAL_TYPE,
+			};
+		} );
 };
 
 const handleEntitySearch = async (
@@ -88,19 +120,22 @@ export default function useSearchHandler(
 	allowDirectEntry,
 	withCreateSuggestion
 ) {
-	const { fetchSearchSuggestions, pageOnFront, pageForPosts } = useSelect(
-		( select ) => {
-			const { getSettings } = select( blockEditorStore );
+	const {
+		fetchSearchSuggestions,
+		pageOnFront,
+		pageForPosts,
+		blocks = [],
+	} = useSelect( ( select ) => {
+		const { getSettings, getBlocks } = select( blockEditorStore );
 
-			return {
-				pageOnFront: getSettings().pageOnFront,
-				pageForPosts: getSettings().pageForPosts,
-				fetchSearchSuggestions:
-					getSettings().__experimentalFetchLinkSuggestions,
-			};
-		},
-		[]
-	);
+		return {
+			pageOnFront: getSettings().pageOnFront,
+			pageForPosts: getSettings().pageForPosts,
+			fetchSearchSuggestions:
+				getSettings().__experimentalFetchLinkSuggestions,
+			blocks: getBlocks(),
+		};
+	}, [] );
 
 	const directEntryHandler = allowDirectEntry
 		? handleDirectEntry
@@ -108,6 +143,16 @@ export default function useSearchHandler(
 
 	return useCallback(
 		( val, { isInitialSuggestions } ) => {
+			if ( isHashLink( val ) ) {
+				const anchorSuggestions = getAnchorSuggestions( blocks, val );
+
+				if ( anchorSuggestions.length ) {
+					return Promise.resolve( anchorSuggestions );
+				}
+
+				return directEntryHandler( val, { isInitialSuggestions } );
+			}
+
 			return isURLLike( val )
 				? directEntryHandler( val, { isInitialSuggestions } )
 				: handleEntitySearch(
@@ -120,6 +165,7 @@ export default function useSearchHandler(
 				  );
 		},
 		[
+			blocks,
 			directEntryHandler,
 			fetchSearchSuggestions,
 			pageOnFront,

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -155,9 +155,13 @@ class URLInput extends Component {
 		// - there are at least 2 characters in the search input (except manual searches where
 		//   search input length is not required to trigger a fetch)
 		// - this is a direct entry (eg: a URL)
+		const shouldAllowHashOnlySuggestions =
+			handleURLSuggestions && value === '#';
+
 		if (
 			! isInitialSuggestions &&
-			( value.length < 2 || ( ! handleURLSuggestions && isURL( value ) ) )
+			( ( value.length < 2 && ! shouldAllowHashOnlySuggestions ) ||
+				( ! handleURLSuggestions && isURL( value ) ) )
 		) {
 			this.suggestionsRequest?.cancel?.();
 			this.suggestionsRequest = null;


### PR DESCRIPTION
## What?
Closes #53134

This PR adds same-page anchor suggestions in LinkControl when creating internal links with hash input.

- Typing `#` now shows available anchor IDs from blocks on the current page.
- Typing a partial hash query like #sec filters matching anchor IDs.
- Existing direct-entry behavior is preserved for hash links.

## Why?
When users create in-page links, they often need to target existing section anchors such as heading anchors. Previously:

- by itself did not show suggestions.
- Users had to manually remember and type anchor IDs.

This made internal linking slower and more error-prone. The change improves discoverability and authoring speed for same-page links.

## Testing Instructions

1. Open a post or page in the editor.
2. Add multiple blocks with anchors, for example:
3. Add a Heading block with HTML anchor intro.
4. Add another Heading block with HTML anchor section-two.
5. Add a nested block with HTML anchor nested-section (optional, to validate nested blocks).
6. Add a Paragraph block and select text.
7. Open the link UI.
8. Type `#` in the link input.
9. Confirm suggestions list includes available anchors such as #intro, #nested-section, #section-two.
10. Type `#sec`.
11. Confirm suggestions are filtered to matching anchors.
12. Select one anchor suggestion.
13. Confirm the link URL is set to the selected hash anchor.
14. Save and preview the post.
15. Confirm clicking the link jumps to the correct section.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/d493c1f7-517d-4217-ac14-60e23fd2c96b

## Use of AI Tools
I used claude AI to assist with implementation and drafting.