### PR TITLE
Block Fields: enable Cmd/Ctrl-K link shortcut in rich text fields

### DIFF
--- a/packages/block-editor/src/hooks/block-fields/rich-text/index.js
+++ b/packages/block-editor/src/hooks/block-fields/rich-text/index.js
@@ -123,7 +123,17 @@ export default function RichTextControl( {
 						anchorRef,
 					] ) }
 					onFocus={ () => setIsSelected( true ) }
-					onBlur={ () => setIsSelected( false ) }
+					onBlur={ ( event ) => {
+						// Don't unmount if focus is going to a popover.
+						if (
+							event.relatedTarget?.closest(
+								'.components-popover'
+							)
+						) {
+							return;
+						}
+						setIsSelected( false );
+					} }
 					contentEditable
 					{ ...controlProps }
 				/>

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -202,7 +202,7 @@ function Edit( {
 					aria-expanded={ addingLink }
 				/>
 			) }
-			{ isVisible && addingLink && (
+			{ addingLink && (
 				<InlineLinkUI
 					stopAddingLink={ stopAddingLink }
 					onFocusOutside={ onFocusOutside }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73270 

<!-- In a few words, what is the PR actually doing? -->
Ensures the Cmd/Ctrl-K keyboard shortcut to insert links works correctly in contentOnly pattern rich text fields.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When editing a pattern in the Site Editor, the sidebar shows rich text fields for editable content blocks. Pressing Cmd/Ctrl-K to insert a link had no effect. The shortcut was being registered correctly, but the link UI never appeared.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This fixes two issues affecting link insertion in Block Fields:
- The link popover in was tied to toolbar visibility. The popover now renders whenever `addingLink` is active, even when the formatting toolbar is hidden in contentOnly mode.
- The `RichTextControl` blur handler in `block-editor` was unmounting the component when focus moved into the link popover. The blur logic now ignores focus transitions into popovers, allowing the link UI to remain mounted and behave consistently with the main editor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Go to Gutenberg Experiments setting page and enable the “Block Fields” experiment.
2. Open the Site Editor (Appearance > Editor).
3. Create or open a pattern containing a Paragraph block.
4. Select some text from the rich text field from the sidebar for that block in the pattern.
5. Press Cmd+K (Mac) or Ctrl+K (Windows/Linux).
6. Verify the link insertion popover opens and focus moves to the URL input.
7. Add a URL or select a search result and verify the link is applied.

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/c14bd652-dc12-4f87-b515-e092fed2406e

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
- ChatGPT for refining PR description
- GitHub copilot for code assistance