### PR TITLE
Build: restore dot:true on fast-glob in transpilePackage

### DIFF
--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1309,12 +1309,14 @@ async function transpilePackage( packageName ) {
 		cwd: packageDir,
 		ignore: IGNORE_PATTERNS,
 		absolute: true,
+		dot: true,
 	} );
 
 	const assetFiles = await glob( `src/**/*.${ ASSET_EXTENSIONS }`, {
 		cwd: packageDir,
 		ignore: IGNORE_PATTERNS,
 		absolute: true,
+		dot: true,
 	} );
 
 	const buildDir = path.join( packageDir, 'build' );


### PR DESCRIPTION
## Summary

Re-applies [#75114](https://github.com/WordPress/gutenberg/pull/75114) — the \`dot: true\` flag on \`fast-glob\` in \`transpilePackage\` was dropped during a subsequent \`packages/wp-build\` refactor.

## Problem

When the repository path contains a dot-prefixed directory (e.g. \`.worktrees/\`, \`.claude/worktrees/\`), \`fast-glob\`'s default dot-filtering skips matches under that path. \`transpilePackage\` then returns empty file lists and the build silently produces no output, which surfaces downstream as missing \`build/*\` files / type errors.

Same root cause as the original report in #75113.

## Fix

Two-line diff: add \`dot: true\` to both \`glob()\` calls in \`transpilePackage\` (source files and asset files), matching the original PR.

## Test plan

- [ ] Create a worktree under a dot-prefixed directory (e.g. \`.worktrees/my-branch\` or \`.claude/worktrees/my-branch\`).
- [ ] From the worktree, run \`npm install && npm run build\`.
- [ ] Verify build completes and produces output under \`packages/*/build\`, \`packages/*/build-module\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)