### PR TITLE
Build: update changelog

### DIFF
--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -4,15 +4,24 @@
 
 ### Bug Fixes
 
--   Remove the incorrect `#wpwrap` background from wp-admin critical CSS to prevent a black flash before hydration; rely on the existing `body` background instead.
+-   Remove the incorrect `#wpwrap` background from wp-admin critical CSS to prevent a black flash before hydration; rely on the existing `body` background instead ([#78493](https://github.com/WordPress/gutenberg/pull/78493)).
 
 ## 0.15.0 (2026-05-27)
 
+### Bug Fixes
+
+-   Defer single-page admin `import( "@wordpress/boot" )` until `DOMContentLoaded` so the boot module evaluates after classic script dependencies have loaded ([#78136](https://github.com/WordPress/gutenberg/pull/78136)).
+
 ## 0.14.0 (2026-05-14)
+
+### Enhancements
+
+-   Replace getter-based `wp.*` exports with data properties for faster property access ([#78303](https://github.com/WordPress/gutenberg/pull/78303)).
 
 ### Bug Fixes
 
 -   Register generated CSS module styles with `@wordpress/style-runtime` so they can be injected into registered documents, such as editor iframes ([#77965](https://github.com/WordPress/gutenberg/pull/77965)).
+-   Guard `require_once` calls in generated PHP files against deployment race conditions ([#78110](https://github.com/WordPress/gutenberg/pull/78110)).
 
 ## 0.13.0 (2026-04-29)
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Adds missing changelog entries to WP Build for past two versions.

Follow-up to PRs:
- https://github.com/WordPress/gutenberg/pull/78493
- https://github.com/WordPress/gutenberg/pull/78136
- https://github.com/WordPress/gutenberg/pull/78303
- https://github.com/WordPress/gutenberg/pull/78110


I'm leaving out any experimental dashboard "widget" additions to build, since those are experimental and not really encouraged yet for use. They're documented here.

<details>
<summary>See changelog for widget PRs just for awareness</summary>

## 0.15.0 (2026-05-27)

### Enhancements

-   Add `presentation` field support to `widget.json` for declarative full-bleed rendering ([#78209](https://github.com/WordPress/gutenberg/pull/78209)).
-   Add `content-bleed` presentation variant for widgets that keep their header but render edge-to-edge content ([#78491](https://github.com/WordPress/gutenberg/pull/78491)).

### Documentation

-   Document that widget icons must be SVGs, not dashicons ([#78440](https://github.com/WordPress/gutenberg/pull/78440)).
-   Document optional widget `package.json` and add `widgets/tsconfig.json` for TypeScript ([#78467](https://github.com/WordPress/gutenberg/pull/78467)).

## 0.14.0 (2026-05-14)

### New Features

-   Add experimental `widgets/` folder support for discovering, bundling, and registering dashboard widget script modules ([#77347](https://github.com/WordPress/gutenberg/pull/77347)).

### Enhancements

-   Bootstrap the widget type registry into generated admin pages and add widget modules to the page import map ([#77917](https://github.com/WordPress/gutenberg/pull/77917)).
-   Decouple generated page templates from widget type registration so pages remain widget-agnostic ([#77958](https://github.com/WordPress/gutenberg/pull/77958)).
-   Expose registered widget types to admin pages via the REST API and `core-data` instead of inline globals ([#77987](https://github.com/WordPress/gutenberg/pull/77987)).

</details>


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

WP Build is harder to version bump in plugins when there isn't a clear changelog. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
AI pulled summaries for merged PRs that didn't add a changelog entry.

## Use of AI Tools
yes
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
