### PR TITLE
Content Types: Hide Quick Edit action when quick edit is false

### DIFF
--- a/packages/content-types/src/taxonomies/actions/quick-edit.tsx
+++ b/packages/content-types/src/taxonomies/actions/quick-edit.tsx
@@ -177,6 +177,7 @@ const quickEditTaxonomyAction: Action< TaxonomyFormData > = {
 	icon: pencil,
 	isPrimary: true,
 	hideModalHeader: true,
+	isEligible: ( item ) => item.config.show_in_quick_edit,
 	RenderModal: QuickEditTaxonomyModal,
 };
 


### PR DESCRIPTION

## What?
Part of https://github.com/WordPress/gutenberg/issues/77600

## Why?

The Quick Edit button was shown for all taxonomies regardless of the `show_in_quick_edit` setting.


## How?

Added `isEligible` prop to the Quick Edit modal  


## Testing Instructions

1. Go to Content Types → Taxonomies.
2. Edit a taxonomy and set Show in Quick Edit to off.
3. Confirm the Quick Edit button no longer appears for that taxonomy in the list.
4. Re-enable it and confirm the button returns.

## Screenshots or screencast 

### Before

https://github.com/user-attachments/assets/3065fca9-a071-4f84-ac34-f116adfd4617



### After


https://github.com/user-attachments/assets/00f0ff66-a7ba-42eb-9014-f40938bf4cd0



