### PR TITLE
RTC: Prevent slower polling filters

### DIFF
--- a/packages/sync/CHANGELOG.md
+++ b/packages/sync/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Prevent RTC polling interval filters from slowing active HTTP polling.
+
 ## 1.47.0 (2026-05-27)
 
 ## 1.46.0 (2026-05-14)

--- a/packages/sync/CODE.md
+++ b/packages/sync/CODE.md
@@ -64,8 +64,9 @@ A provider is a transport layer that syncs Yjs document updates between peers. T
 
 The default provider (`src/providers/http-polling/`) uses HTTP polling to exchange updates with a central sync server. A shared polling manager batches updates for all rooms (entities) into a single request per poll cycle. See [the HTTP polling README](./src/providers/http-polling/README.md) for full details including the REST API format, sync protocol, and compaction.
 
--   Poll interval: 1 second when editing alone, 250ms when collaborators are detected.
--   On errors, the interval backs off exponentially (up to 30 seconds).
+-   Poll interval: 4 seconds when editing alone, 1 second when collaborators are detected.
+-   The `sync.pollingManager.pollingInterval` and `sync.pollingManager.pollingIntervalWithCollaborators` filters can make active-tab polling faster, but slower values are clamped to the defaults.
+-   On errors, the interval backs off according to the retry schedule before continuing at 30-second automatic retries.
 -   Awareness state is sent and received alongside document updates in the same poll request.
 
 ### Custom providers

--- a/packages/sync/src/providers/http-polling/README.md
+++ b/packages/sync/src/providers/http-polling/README.md
@@ -81,8 +81,8 @@ const provider = new HttpPollingProvider( {
 
 The polling manager runs continuously:
 
-- **Solo editing**: 1000ms interval, queue paused (no updates sent)
-- **With collaborators**: 250ms interval, queue active
+- **Solo editing**: 4000ms interval, queue paused (no updates sent)
+- **With collaborators**: 1000ms interval, queue active
 
 Each poll cycle:
 
@@ -93,6 +93,10 @@ Each poll cycle:
 5. **Process updates** and generate any required responses (e.g., sync_step2)
 6. **Apply to Y.Doc** using the appropriate Yjs method
 7. **Handle compaction request** if server nominates this client
+
+### Polling Interval Filters
+
+Hosts can use `sync.pollingManager.pollingInterval` and `sync.pollingManager.pollingIntervalWithCollaborators` to make active-tab polling more frequent than the defaults. Returned values greater than the defaults are ignored so hosts cannot slow collaboration below the standard user experience. Faster polling increases request volume, so only lower these intervals when the environment can absorb the extra traffic.
 
 ### 3. Sync Protocol
 
@@ -247,7 +251,7 @@ All CRDT operations happen in the browser via Yjs.
 
 ### Polling Latency
 
-Updates are not instant; there's inherent latency from the polling interval (250ms with collaborators). This is acceptable for document editing but may not suit real-time cursor tracking at high fidelity.
+Updates are not instant; there's inherent latency from the polling interval (1000ms with collaborators by default). This is acceptable for document editing but may not suit real-time cursor tracking at high fidelity.
 
 ### Single Compactor
 

--- a/packages/sync/src/providers/http-polling/config.ts
+++ b/packages/sync/src/providers/http-polling/config.ts
@@ -45,15 +45,36 @@ export const MAX_SYNC_REQUEST_BODY_SIZE_IN_BYTES = 15 * 1024 * 1024;
 // request-body-too-large response forces the client to shrink its retry budget.
 export const MIN_SYNC_REQUEST_BODY_SIZE_LIMIT_IN_BYTES = 2 * 1024 * 1024;
 
-export const POLLING_INTERVAL_IN_MS = applyFilters(
-	'sync.pollingManager.pollingInterval',
-	4000 // 4 seconds
-) as number;
+const DEFAULT_POLLING_INTERVAL_IN_MS = 4000; // 4 seconds
+const DEFAULT_POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS = 1000; // 1 second
 
-export const POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS = applyFilters(
-	'sync.pollingManager.pollingIntervalWithCollaborators',
-	1000 // 1 second
-) as number;
+function getFilteredPollingInterval(
+	hookName: string,
+	defaultInterval: number
+): number {
+	const filteredInterval = applyFilters( hookName, defaultInterval );
+
+	if (
+		typeof filteredInterval !== 'number' ||
+		! Number.isFinite( filteredInterval ) ||
+		filteredInterval <= 0
+	) {
+		return defaultInterval;
+	}
+
+	return Math.min( filteredInterval, defaultInterval );
+}
+
+export const POLLING_INTERVAL_IN_MS = getFilteredPollingInterval(
+	'sync.pollingManager.pollingInterval',
+	DEFAULT_POLLING_INTERVAL_IN_MS
+);
+
+export const POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS =
+	getFilteredPollingInterval(
+		'sync.pollingManager.pollingIntervalWithCollaborators',
+		DEFAULT_POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS
+	);
 
 // Must be less than the server-side AWARENESS_TIMEOUT (30 s) to avoid
 // false disconnects when the tab is in the background.

--- a/packages/sync/src/providers/http-polling/test/config.test.ts
+++ b/packages/sync/src/providers/http-polling/test/config.test.ts
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+
+type SyncConfig = typeof import('../config');
+
+function loadConfigWithFilteredIntervals(
+	filteredIntervals: Record< string, unknown >
+): SyncConfig {
+	jest.resetModules();
+	jest.doMock( '@wordpress/hooks', () => ( {
+		applyFilters: jest.fn( ( hookName: string, defaultValue: unknown ) => {
+			if (
+				Object.prototype.hasOwnProperty.call(
+					filteredIntervals,
+					hookName
+				)
+			) {
+				return filteredIntervals[ hookName ];
+			}
+
+			return defaultValue;
+		} ),
+	} ) );
+
+	return require( '../config' ) as SyncConfig;
+}
+
+describe( 'http-polling config', () => {
+	it( 'uses default polling intervals when filters do not change them', () => {
+		const config = loadConfigWithFilteredIntervals( {} );
+
+		expect( config.POLLING_INTERVAL_IN_MS ).toBe( 4000 );
+		expect( config.POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS ).toBe( 1000 );
+	} );
+
+	it( 'allows filters to make active polling intervals faster', () => {
+		const config = loadConfigWithFilteredIntervals( {
+			'sync.pollingManager.pollingInterval': 1000,
+			'sync.pollingManager.pollingIntervalWithCollaborators': 250,
+		} );
+
+		expect( config.POLLING_INTERVAL_IN_MS ).toBe( 1000 );
+		expect( config.POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS ).toBe( 250 );
+	} );
+
+	it( 'caps filters that would make active polling intervals slower', () => {
+		const config = loadConfigWithFilteredIntervals( {
+			'sync.pollingManager.pollingInterval': 10000,
+			'sync.pollingManager.pollingIntervalWithCollaborators': 2500,
+		} );
+
+		expect( config.POLLING_INTERVAL_IN_MS ).toBe( 4000 );
+		expect( config.POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS ).toBe( 1000 );
+	} );
+
+	it.each( [
+		[ 'zero', 0 ],
+		[ 'negative', -1 ],
+		[ 'non-finite', Infinity ],
+		[ 'non-number', '100' ],
+	] )(
+		'uses default intervals when filters return %s values',
+		( _label, filteredValue ) => {
+			const config = loadConfigWithFilteredIntervals( {
+				'sync.pollingManager.pollingInterval': filteredValue,
+				'sync.pollingManager.pollingIntervalWithCollaborators':
+					filteredValue,
+			} );
+
+			expect( config.POLLING_INTERVAL_IN_MS ).toBe( 4000 );
+			expect( config.POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS ).toBe(
+				1000
+			);
+		}
+	);
+} );


### PR DESCRIPTION
## What?
Closes #77500

Prevents the RTC HTTP polling interval filters from slowing active polling below the default intervals.

## Why?
Hosts can currently use the polling interval filters to slow RTC polling enough that collaboration can feel broken or unresponsive. This keeps the default collaboration experience from being degraded while still allowing hosts to opt into more aggressive polling.

## How?
- Routes the active polling interval filters through a small helper that accepts only positive finite numbers.
- Allows faster filtered values, but clamps slower values to the defaults.
- Adds focused unit coverage for default, faster, slower, and invalid filtered values.
- Updates the sync docs to reflect the current `4000ms` solo and `1000ms` collaborator defaults and faster-only filter behavior.

## Testing Instructions
1. Run `npm run test:unit -- packages/sync/src/providers/http-polling/test`
2. Run `npm run lint:js -- packages/sync/src/providers/http-polling/config.ts packages/sync/src/providers/http-polling/test/config.test.ts`
3. Optional manual check: add filters returning slower values such as `10000` and `2500`, open the editor with RTC enabled, and verify `/wp-sync/v1/updates` still polls at roughly `4000ms` solo and `1000ms` with collaborators.
4. Optional manual check: add filters returning faster values such as `1000` and `250`, then verify those faster intervals are used.
