### PR TITLE
Storybook: Enhance Theme Provider example with admin-ui Page.

### DIFF
--- a/packages/private-apis/CHANGELOG.md
+++ b/packages/private-apis/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Allow `@wordpress/storybook` to opt in to private APIs. ([#78814](https://github.com/WordPress/gutenberg/pull/78814))
+
 ## 1.47.0 (2026-05-27)
 
 ## 1.46.0 (2026-05-14)

--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -40,6 +40,7 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/route',
 	'@wordpress/router',
 	'@wordpress/routes',
+	'@wordpress/storybook',
 	'@wordpress/sync',
 	'@wordpress/theme',
 	'@wordpress/dataviews',

--- a/storybook/decorators/with-router.tsx
+++ b/storybook/decorators/with-router.tsx
@@ -1,0 +1,27 @@
+import { privateApis as routePrivateApis } from '@wordpress/route';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/route'
+);
+
+const { createMemoryHistory, createRootRoute, createRouter, RouterProvider } =
+	unlock( routePrivateApis );
+
+/**
+ * Storybook decorator that provides a router context.
+ *
+ * Wraps stories in a minimal tanstack router (via @wordpress/route private
+ * APIs) so that components consuming `Link` from `@wordpress/route` can
+ * render without errors.
+ */
+export function withRouter( Story: React.ComponentType ) {
+	const rootRoute = createRootRoute( { component: Story } );
+	const router = createRouter( {
+		routeTree: rootRoute,
+		history: createMemoryHistory( { initialEntries: [ '/' ] } ),
+		defaultNotFoundComponent: () => null,
+	} );
+	return <RouterProvider router={ router } />;
+}

--- a/storybook/decorators/with-router.tsx
+++ b/storybook/decorators/with-router.tsx
@@ -3,7 +3,7 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
-	'@wordpress/route'
+	'@wordpress/storybook'
 );
 
 const { createMemoryHistory, createRootRoute, createRouter, RouterProvider } =

--- a/storybook/stories/design-system/theme-example-application.story.tsx
+++ b/storybook/stories/design-system/theme-example-application.story.tsx
@@ -155,6 +155,7 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 						</div>
 
 						<Page
+							ariaLabel="Level 1 breadcrumb"
 							visual={ <Icon icon={ wordpress } size={ 24 } /> }
 							subTitle="All of the subtitle text you need goes here."
 							breadcrumbs={

--- a/storybook/stories/design-system/theme-example-application.story.tsx
+++ b/storybook/stories/design-system/theme-example-application.story.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Breadcrumbs, Page } from '@wordpress/admin-ui';
 import { useState } from '@wordpress/element';
-import { Icon, wordpress } from '@wordpress/icons';
+import { wordpress } from '@wordpress/icons';
 import { privateApis as themeApis } from '@wordpress/theme';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import {
 	Badge,
 	Button,
 	Card,
+	Icon,
 	Link,
 	Notice,
 	Stack,

--- a/storybook/stories/design-system/theme-example-application.story.tsx
+++ b/storybook/stories/design-system/theme-example-application.story.tsx
@@ -248,54 +248,70 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 												</Tabs.Tab>
 											</Tabs.List>
 											<Tabs.Panel value="appearance">
-												<Text
+												<Stack
+													direction="column"
+													gap="md"
 													style={ {
 														paddingBlockStart:
-															'var(--wpds-dimension-padding-lg)',
+															'var(--wpds-dimension-padding-md)',
 													} }
 												>
-													Control how your site looks
-													to visitors. Adjust{ ' ' }
-													<Link href="#">
-														typography
-													</Link>
-													,{ ' ' }
-													<Link href="#">colors</Link>
-													, and spacing to match your
-													brand.
-												</Text>
+													<Text>
+														Control how your site
+														looks to visitors.
+														Adjust{ ' ' }
+														<Link href="#">
+															typography
+														</Link>
+														,{ ' ' }
+														<Link href="#">
+															colors
+														</Link>
+														, and spacing to match
+														your brand.
+													</Text>
+												</Stack>
 											</Tabs.Panel>
 											<Tabs.Panel value="layout">
-												<Text
+												<Stack
+													direction="column"
+													gap="md"
 													style={ {
 														paddingBlockStart:
-															'var(--wpds-dimension-padding-lg)',
+															'var(--wpds-dimension-padding-md)',
 													} }
 												>
-													Choose a layout structure
-													for your pages. Options
-													include full-width, boxed,
-													and{ ' ' }
-													<Link href="#">
-														custom layouts
-													</Link>
-													.
-												</Text>
+													<Text>
+														Choose a layout
+														structure for your
+														pages. Options include
+														full-width, boxed, and{ ' ' }
+														<Link href="#">
+															custom layouts
+														</Link>
+														.
+													</Text>
+												</Stack>
 											</Tabs.Panel>
 											<Tabs.Panel value="accessibility">
-												<Text
+												<Stack
+													direction="column"
+													gap="md"
 													style={ {
 														paddingBlockStart:
-															'var(--wpds-dimension-padding-lg)',
+															'var(--wpds-dimension-padding-md)',
 													} }
 												>
-													Review your site&apos;s{ ' ' }
-													<Link href="#">
-														accessibility settings
-													</Link>{ ' ' }
-													to ensure it meets WCAG
-													guidelines.
-												</Text>
+													<Text>
+														Review your site&apos;s{ ' ' }
+														<Link href="#">
+															accessibility
+															settings
+														</Link>{ ' ' }
+														to ensure it meets WCAG
+														guidelines.
+													</Text>
+												</Stack>
 											</Tabs.Panel>
 										</Tabs.Root>
 									</Card.Content>

--- a/storybook/stories/design-system/theme-example-application.story.tsx
+++ b/storybook/stories/design-system/theme-example-application.story.tsx
@@ -120,6 +120,8 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 									'var(--wpds-color-bg-surface-neutral-weak)',
 								padding:
 									'var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-lg)',
+								borderInlineEnd:
+									'var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak)',
 							} }
 						>
 							<Text

--- a/storybook/stories/design-system/theme-example-application.story.tsx
+++ b/storybook/stories/design-system/theme-example-application.story.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Breadcrumbs, Page } from '@wordpress/admin-ui';
 import { useState } from '@wordpress/element';
+import { Icon, wordpress } from '@wordpress/icons';
 import { privateApis as themeApis } from '@wordpress/theme';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import {
@@ -12,6 +14,8 @@ import {
 	Tabs,
 	Text,
 } from '@wordpress/ui';
+
+import { withRouter } from '../../decorators/with-router';
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
@@ -40,8 +44,8 @@ const meta: Meta< typeof ThemeProvider > = {
 export default meta;
 
 /**
- * A mock application page demonstrating how `ThemeProvider` affects multiple
- * `@wordpress/ui` components in concert. Use the inline controls to adjust
+ * A mock application page demonstrating how `ThemeProvider` affects
+ * `@wordpress/ui` and `@wordpress/admin-ui` components in concert. Use the inline controls to adjust
  * the `primary` and `bg` seed colors, and observe how every surface, text
  * element, and interactive control adapts accordingly.
  */
@@ -103,6 +107,9 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 							gridTemplateColumns: '200px 1fr',
 							minHeight: '500px',
 							color: 'var(--wpds-color-fg-content-neutral)',
+							borderRadius: 'var(--wpds-border-radius-lg)',
+							border: 'var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak)',
+							overflow: 'hidden',
 						} }
 					>
 						{ /* Sidebar */ }
@@ -146,219 +153,159 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 							</nav>
 						</div>
 
-						{ /* Page content (header + content area) */ }
-						<div
-							style={ {
-								backgroundColor:
-									'var(--wpds-color-bg-surface-neutral-weak)',
-								padding: 'var(--wpds-dimension-padding-lg)',
-							} }
+						<Page
+							visual={ <Icon icon={ wordpress } size={ 24 } /> }
+							subTitle="All of the subtitle text you need goes here."
+							breadcrumbs={
+								<Breadcrumbs
+									items={ [
+										{
+											label: 'Root breadcrumb',
+											to: '/connectors',
+										},
+										{ label: 'Level 1 breadcrumb' },
+									] }
+								/>
+							}
+							badges={
+								<Badge intent="informational">Status</Badge>
+							}
+							actions={
+								<>
+									<Button size="compact" variant="solid">
+										Save
+									</Button>
+								</>
+							}
+							showSidebarToggle={ false }
+							hasPadding
 						>
-							<div
+							<Stack
+								direction="column"
+								gap="lg"
 								style={ {
-									display: 'flex',
-									flexDirection: 'column',
-									borderRadius:
-										'var(--wpds-border-radius-lg)',
-									border: '1px solid var(--wpds-color-stroke-surface-neutral-weak)',
-									overflow: 'hidden',
-									height: '100%',
+									maxWidth: '640px',
+									marginInline: 'auto',
 								} }
 							>
-								{ /* Header */ }
-								<div
-									style={ {
-										backgroundColor:
-											'var(--wpds-color-bg-surface-neutral-strong)',
-										padding:
-											'var(--wpds-dimension-padding-xl)',
-										display: 'flex',
-										alignItems: 'center',
-										justifyContent: 'space-between',
-										gap: 'var(--wpds-dimension-gap-lg)',
-										borderBlockEnd:
-											'1px solid var(--wpds-color-stroke-surface-neutral-weak)',
-									} }
-								>
-									<div
-										style={ {
-											display: 'flex',
-											alignItems: 'center',
-											gap: 'var(--wpds-dimension-gap-md)',
-										} }
-									>
-										<Text
-											variant="heading-lg"
-											render={ <h1 /> }
-											style={ {
-												margin: 0,
-											} }
-										>
-											Settings
-										</Text>
-										<Badge intent="informational">
-											Beta
-										</Badge>
-									</div>
-									<Button
-										variant="solid"
-										tone="brand"
-										size="compact"
-									>
-										Save changes
-									</Button>
-								</div>
+								<Notice.Root intent="info">
+									<Notice.Title>
+										Welcome to your new site
+									</Notice.Title>
+									<Notice.Description>
+										Complete the steps below to finish
+										setting up.
+									</Notice.Description>
+								</Notice.Root>
 
-								{ /* Content area */ }
-								<div
-									style={ {
-										backgroundColor:
-											'var(--wpds-color-bg-surface-neutral)',
-										padding:
-											'var(--wpds-dimension-padding-xl)',
-										flexGrow: 1,
-									} }
-								>
-									<Stack
-										direction="column"
-										gap="xl"
-										style={ {
-											maxWidth: '640px',
-											marginInline: 'auto',
-										} }
-									>
-										<Notice.Root intent="info">
-											<Notice.Title>
-												Welcome to your new site
-											</Notice.Title>
-											<Notice.Description>
-												Complete the steps below to
-												finish setting up.
-											</Notice.Description>
-										</Notice.Root>
+								{ /* Card 1: General */ }
+								<Card.Root>
+									<Card.Header>
+										<Card.Title>General</Card.Title>
+									</Card.Header>
+									<Card.Content>
+										<Stack direction="column" gap="md">
+											<Text>
+												Configure the basic settings for
+												your site. You can update your{ ' ' }
+												<Link href="#">site title</Link>
+												, tagline, and{ ' ' }
+												<Link href="#">
+													admin email address
+												</Link>{ ' ' }
+												at any time.
+											</Text>
+											<Text>
+												For more advanced options, visit
+												the{ ' ' }
+												<Link href="#">
+													developer documentation
+												</Link>
+												.
+											</Text>
+										</Stack>
+									</Card.Content>
+								</Card.Root>
 
-										{ /* Card 1: General */ }
-										<Card.Root>
-											<Card.Header>
-												<Card.Title>General</Card.Title>
-											</Card.Header>
-											<Card.Content>
-												<Stack
-													direction="column"
-													gap="md"
+								{ /* Card 2: Display */ }
+								<Card.Root>
+									<Card.Header>
+										<Card.Title>Display</Card.Title>
+									</Card.Header>
+									<Card.Content>
+										<Tabs.Root defaultValue="appearance">
+											<Tabs.List variant="minimal">
+												<Tabs.Tab value="appearance">
+													Appearance
+												</Tabs.Tab>
+												<Tabs.Tab value="layout">
+													Layout
+												</Tabs.Tab>
+												<Tabs.Tab value="accessibility">
+													Accessibility
+												</Tabs.Tab>
+											</Tabs.List>
+											<Tabs.Panel value="appearance">
+												<Text
+													style={ {
+														paddingBlockStart:
+															'var(--wpds-dimension-padding-lg)',
+													} }
 												>
-													<Text>
-														Configure the basic
-														settings for your site.
-														You can update your{ ' ' }
-														<Link href="#">
-															site title
-														</Link>
-														, tagline, and{ ' ' }
-														<Link href="#">
-															admin email address
-														</Link>{ ' ' }
-														at any time.
-													</Text>
-													<Text>
-														For more advanced
-														options, visit the{ ' ' }
-														<Link href="#">
-															developer
-															documentation
-														</Link>
-														.
-													</Text>
-												</Stack>
-											</Card.Content>
-										</Card.Root>
-
-										{ /* Card 2: Display */ }
-										<Card.Root>
-											<Card.Header>
-												<Card.Title>Display</Card.Title>
-											</Card.Header>
-											<Card.Content>
-												<Tabs.Root defaultValue="appearance">
-													<Tabs.List variant="minimal">
-														<Tabs.Tab value="appearance">
-															Appearance
-														</Tabs.Tab>
-														<Tabs.Tab value="layout">
-															Layout
-														</Tabs.Tab>
-														<Tabs.Tab value="accessibility">
-															Accessibility
-														</Tabs.Tab>
-													</Tabs.List>
-													<Tabs.Panel value="appearance">
-														<Text
-															style={ {
-																paddingBlockStart:
-																	'var(--wpds-dimension-padding-lg)',
-															} }
-														>
-															Control how your
-															site looks to
-															visitors. Adjust{ ' ' }
-															<Link href="#">
-																typography
-															</Link>
-															,{ ' ' }
-															<Link href="#">
-																colors
-															</Link>
-															, and spacing to
-															match your brand.
-														</Text>
-													</Tabs.Panel>
-													<Tabs.Panel value="layout">
-														<Text
-															style={ {
-																paddingBlockStart:
-																	'var(--wpds-dimension-padding-lg)',
-															} }
-														>
-															Choose a layout
-															structure for your
-															pages. Options
-															include full-width,
-															boxed, and{ ' ' }
-															<Link href="#">
-																custom layouts
-															</Link>
-															.
-														</Text>
-													</Tabs.Panel>
-													<Tabs.Panel value="accessibility">
-														<Text
-															style={ {
-																paddingBlockStart:
-																	'var(--wpds-dimension-padding-lg)',
-															} }
-														>
-															Review your
-															site&apos;s{ ' ' }
-															<Link href="#">
-																accessibility
-																settings
-															</Link>{ ' ' }
-															to ensure it meets
-															WCAG guidelines.
-														</Text>
-													</Tabs.Panel>
-												</Tabs.Root>
-											</Card.Content>
-										</Card.Root>
-									</Stack>
-								</div>
-							</div>
-						</div>
+													Control how your site looks
+													to visitors. Adjust{ ' ' }
+													<Link href="#">
+														typography
+													</Link>
+													,{ ' ' }
+													<Link href="#">colors</Link>
+													, and spacing to match your
+													brand.
+												</Text>
+											</Tabs.Panel>
+											<Tabs.Panel value="layout">
+												<Text
+													style={ {
+														paddingBlockStart:
+															'var(--wpds-dimension-padding-lg)',
+													} }
+												>
+													Choose a layout structure
+													for your pages. Options
+													include full-width, boxed,
+													and{ ' ' }
+													<Link href="#">
+														custom layouts
+													</Link>
+													.
+												</Text>
+											</Tabs.Panel>
+											<Tabs.Panel value="accessibility">
+												<Text
+													style={ {
+														paddingBlockStart:
+															'var(--wpds-dimension-padding-lg)',
+													} }
+												>
+													Review your site&apos;s{ ' ' }
+													<Link href="#">
+														accessibility settings
+													</Link>{ ' ' }
+													to ensure it meets WCAG
+													guidelines.
+												</Text>
+											</Tabs.Panel>
+										</Tabs.Root>
+									</Card.Content>
+								</Card.Root>
+							</Stack>
+						</Page>
 					</div>
 				</ThemeProvider>
 			</div>
 		);
 	},
+	decorators: [ withRouter ],
 	parameters: {
 		controls: { disable: true },
 	},


### PR DESCRIPTION
## Summary

Updates the **Theme Provider → Example Application** Storybook story to better reflect a real WordPress admin screen.

- Replaces the hand-rolled page header and content layout with `Page` from `@wordpress/admin-ui`, using the full header API: visual, breadcrumbs, subtitle, badges, and actions
- Adds a `withRouter` Storybook decorator so breadcrumb links render correctly
- Applies a bordered, large-radius frame around the full app mock (sidebar + page) using design tokens

The story now demonstrates how `ThemeProvider` seed colors affect both `@wordpress/ui` and `@wordpress/admin-ui` components together.

## Test plan

- [ ] Open Storybook → **Design System / Theme / Theme Provider / Example Application**
- [ ] Confirm the app mock renders with a bordered, rounded frame
- [ ] Confirm the `Page` header shows the WordPress icon, breadcrumbs, subtitle, status badge, and Save action
- [ ] Adjust the Primary and Background color pickers and verify header, sidebar, cards, notice, tabs, and buttons all update with the theme
- [ ] Confirm breadcrumb links render without router errors

## Screenshots

### Before
<img width="881" height="641" alt="Screenshot 2026-05-29 at 13 46 54" src="https://github.com/user-attachments/assets/6ab00677-c679-4a31-9530-e4b67f66c668" />


### After
<img width="1003" height="601" alt="Screenshot 2026-05-29 at 13 47 22" src="https://github.com/user-attachments/assets/9fdde670-5ec8-4856-9b48-b700ae4a7fa2" />
