### PR TITLE
[WIP] Block Supports: Remove global border style fallbacks

### DIFF
--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -373,20 +373,33 @@ function gutenberg_render_block_border_fallback( $block_content, $block ) {
 		return $block_content;
 	}
 
+	$attrs = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array();
+
+	// Quick exit when the block has no border-related attribute at all. This
+	// is the common case and short-circuits the registry / theme-json
+	// resolver work below.
+	$has_any_border_attr =
+		! empty( $attrs['borderColor'] ) ||
+		! empty( $attrs['style']['border'] );
+	if ( ! $has_any_border_attr ) {
+		return $block_content;
+	}
+
 	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
-	if ( ! $block_type instanceof WP_Block_Type ) {
+
+	// Respect explicit opt-out of border `style` serialization. The fallback
+	// is intentionally NOT gated on whether the block opts into the `style`
+	// border feature: opting out of `style` means the user cannot pick a
+	// style via UI; it does not mean a block whose attributes carry a
+	// `color` or `width` should be rendered invisibly. The legacy CSS rule
+	// this replaces did not gate on `style` support either.
+	if (
+		$block_type instanceof WP_Block_Type &&
+		wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'style' )
+	) {
 		return $block_content;
 	}
 
-	if ( ! gutenberg_has_border_feature_support( $block_type, 'style' ) ) {
-		return $block_content;
-	}
-
-	if ( wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'style' ) ) {
-		return $block_content;
-	}
-
-	$attrs        = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array();
 	$inherited    = gutenberg_get_inherited_border_styles( $block_type, $attrs );
 	$declarations = gutenberg_get_border_style_fallbacks( $attrs, $inherited );
 

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -47,6 +47,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	$border_block_styles      = array();
 	$has_border_color_support = gutenberg_has_border_feature_support( $block_type, 'color' );
 	$has_border_width_support = gutenberg_has_border_feature_support( $block_type, 'width' );
+	$has_border_style_support = gutenberg_has_border_feature_support( $block_type, 'style' );
 
 	// Border radius.
 	if (
@@ -65,7 +66,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 
 	// Border style.
 	if (
-		gutenberg_has_border_feature_support( $block_type, 'style' ) &&
+		$has_border_style_support &&
 		isset( $block_attributes['style']['border']['style'] ) &&
 		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'style' )
 	) {
@@ -127,6 +128,132 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 }
 
 /**
+ * Determines whether a border style is inherited from the resolved global
+ * styles for a given block instance.
+ *
+ * Mirrors the JS helper `getInheritedBorderStyles` in
+ * `packages/block-editor/src/hooks/border.js`. Checks two cascade levels:
+ * the block type's global styles, and the active block style variation
+ * (derived from the block instance's class name). At each level it considers
+ * the `border.style` shorthand and per-side `border.{side}.style` values.
+ *
+ * Root-level `styles.border.style` is intentionally excluded: theme.json's
+ * root border styles compile to a `body` selector, and `border-style` is not
+ * a CSS-inherited property, so a root border style does not cascade to inner
+ * block borders. Treating it as inherited would suppress the fallback even
+ * when no border style actually applies to the block.
+ *
+ * @param WP_Block_Type $block_type       Block type.
+ * @param array         $block_attributes Block attributes.
+ *
+ * @return array {
+ *     @type bool $shorthand Whether an inherited shorthand style applies.
+ *     @type bool $top       Whether an inherited style applies to the top side.
+ *     @type bool $right     Whether an inherited style applies to the right side.
+ *     @type bool $bottom    Whether an inherited style applies to the bottom side.
+ *     @type bool $left      Whether an inherited style applies to the left side.
+ * }
+ */
+function gutenberg_get_inherited_border_styles( $block_type, $block_attributes ) {
+	$result = array(
+		'shorthand' => false,
+		'top'       => false,
+		'right'     => false,
+		'bottom'    => false,
+		'left'      => false,
+	);
+
+	if ( ! class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' ) ) {
+		return $result;
+	}
+
+	$block_name = $block_type instanceof WP_Block_Type ? $block_type->name : null;
+	if ( ! $block_name ) {
+		return $result;
+	}
+
+	$tree     = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+	$raw_data = method_exists( $tree, 'get_raw_data' ) ? $tree->get_raw_data() : array();
+	$styles   = $raw_data['styles'] ?? array();
+
+	$block_border     = $styles['blocks'][ $block_name ]['border'] ?? array();
+	$variation_border = array();
+
+	// Resolve the active block style variation from the block instance's
+	// class names against the registered variations for the block type.
+	$class_name = $block_attributes['className'] ?? '';
+	if ( $class_name ) {
+		$registered = wp_get_block_styles( $block_name );
+		$variation  = gutenberg_get_variation_name_from_class( $class_name, $registered );
+		if ( $variation ) {
+			$variation_border =
+				$styles['blocks'][ $block_name ]['variations'][ $variation ]['border']
+				?? array();
+		}
+	}
+
+	// `none` and `hidden` are non-rendering border styles. Treating them as
+	// inherited would suppress the fallback when a user adds a color/width
+	// on a block whose theme cascade sets `style: 'none'`, leaving the
+	// user's change invisible. Exclude them so the fallback can emit
+	// `solid` and keep the user's action visible.
+	$is_rendering_style = static function ( $value ) {
+		return ! empty( $value ) && 'none' !== $value && 'hidden' !== $value;
+	};
+
+	$shorthand =
+		$is_rendering_style( $block_border['style'] ?? null ) ||
+		$is_rendering_style( $variation_border['style'] ?? null );
+
+	$result['shorthand'] = $shorthand;
+	foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
+		$result[ $side ] =
+			$shorthand ||
+			$is_rendering_style( $block_border[ $side ]['style'] ?? null ) ||
+			$is_rendering_style( $variation_border[ $side ]['style'] ?? null );
+	}
+
+	return $result;
+}
+
+/**
+ * Returns the first registered block style variation name found in a class
+ * string. Mirrors the JS `getVariationNameFromClass` helper.
+ *
+ * @param string $class_name        Block class string.
+ * @param array  $registered_styles Registered styles for the block type.
+ *
+ * @return string|null Variation name or null if none matched.
+ */
+function gutenberg_get_variation_name_from_class( $class_name, $registered_styles ) {
+	if ( ! $class_name || empty( $registered_styles ) ) {
+		return null;
+	}
+
+	$prefix     = 'is-style-';
+	$prefix_len = strlen( $prefix );
+	$names      = array();
+	foreach ( preg_split( '/\s+/', $class_name ) as $name ) {
+		if ( strpos( $name, $prefix ) === 0 ) {
+			$candidate = substr( $name, $prefix_len );
+			if ( 'default' !== $candidate ) {
+				$names[] = $candidate;
+			}
+		}
+	}
+
+	foreach ( $names as $candidate ) {
+		foreach ( $registered_styles as $style ) {
+			if ( isset( $style['name'] ) && $style['name'] === $candidate ) {
+				return $candidate;
+			}
+		}
+	}
+
+	return null;
+}
+
+/**
  * Checks whether the current block type supports the border feature requested.
  *
  * If the `__experimentalBorder` support flag is a boolean `true` all border
@@ -162,3 +289,127 @@ WP_Block_Supports::get_instance()->register(
 		'apply'              => 'gutenberg_apply_border_support',
 	)
 );
+
+/**
+ * Computes the per-side border-style fallback styles for a block instance.
+ *
+ * Mirrors the JS helper `getBorderStyleFallbacks` in
+ * `packages/block-editor/src/hooks/border.js`. Keep the two implementations
+ * in sync.
+ *
+ * @param array $block_attributes Block attributes (typically `$block['attrs']`).
+ * @param array $inherited        Inheritance flags returned by
+ *                                {@see gutenberg_get_inherited_border_styles()}.
+ *
+ * @return string[] Inline CSS declarations such as `border-top-style:solid` for
+ *                  sides that need a fallback style.
+ */
+function gutenberg_get_border_style_fallbacks( $block_attributes, $inherited ) {
+	$border              = $block_attributes['style']['border'] ?? array();
+	$border_color_preset = $block_attributes['borderColor'] ?? '';
+
+	$has_shorthand_value =
+		! empty( $border_color_preset ) ||
+		! empty( $border['color'] ) ||
+		! empty( $border['width'] );
+	$has_shorthand_style = ! empty( $border['style'] );
+
+	$declarations = array();
+	foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
+		if ( ! empty( $inherited[ $side ] ) ) {
+			continue;
+		}
+
+		$side_border = $border[ $side ] ?? array();
+
+		// If the cascade already provides a visible style for this side —
+		// either an explicit per-side style or a shorthand style which
+		// applies to every side via CSS — no fallback is needed.
+		if ( ! empty( $side_border['style'] ) || $has_shorthand_style ) {
+			continue;
+		}
+
+		$side_has_value = ! empty( $side_border['color'] ) || ! empty( $side_border['width'] );
+
+		// A fallback is needed if the side has its own color/width without
+		// a style, or if the shorthand provides color/width but no style
+		// (which would otherwise leave this side invisible).
+		if ( ! $side_has_value && ! $has_shorthand_value ) {
+			continue;
+		}
+
+		$declarations[] = "border-{$side}-style:solid";
+	}
+
+	return $declarations;
+}
+
+/**
+ * Backward-compatibility fallback for border block support. Historically a
+ * CSS `:where()` rule in `common.scss` ensured that any block with a border
+ * color or width but no `border-style` would still render as a `solid`
+ * border. That rule has been removed in favour of intelligent defaults
+ * applied at edit time. For content saved before that change — or for any
+ * other path that does not pass through the edit-time helper — this filter
+ * injects `border-{side}-style: solid` directly into the rendered block
+ * wrapper so the border remains visible without requiring a re-save.
+ *
+ * Hooked into `render_block` rather than the `apply` callback of the
+ * border block support because `WP_Block_Supports::apply_block_supports()`
+ * is only invoked via `get_block_wrapper_attributes()` from inside a
+ * dynamic block's `render_callback`. Static blocks (Group, Paragraph,
+ * Heading, etc.) bake their wrapper attributes in at save time and never
+ * reach that path, so a `render_block` filter is needed to cover them.
+ * Mirrors the JS render-time fallback in `useBlockProps` at
+ * `packages/block-editor/src/hooks/border.js`.
+ *
+ * @param string $block_content Rendered block HTML.
+ * @param array  $block         Parsed block array.
+ *
+ * @return string Block HTML with the fallback styles injected when needed.
+ */
+function gutenberg_render_block_border_fallback( $block_content, $block ) {
+	if ( ! $block_content || empty( $block['blockName'] ) ) {
+		return $block_content;
+	}
+
+	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	if ( ! $block_type instanceof WP_Block_Type ) {
+		return $block_content;
+	}
+
+	if ( ! gutenberg_has_border_feature_support( $block_type, 'style' ) ) {
+		return $block_content;
+	}
+
+	if ( wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'style' ) ) {
+		return $block_content;
+	}
+
+	$attrs        = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array();
+	$inherited    = gutenberg_get_inherited_border_styles( $block_type, $attrs );
+	$declarations = gutenberg_get_border_style_fallbacks( $attrs, $inherited );
+
+	if ( empty( $declarations ) ) {
+		return $block_content;
+	}
+
+	$processor = new WP_HTML_Tag_Processor( $block_content );
+	if ( ! $processor->next_tag() ) {
+		return $block_content;
+	}
+
+	$existing_style = $processor->get_attribute( 'style' );
+	$existing_style = is_string( $existing_style ) ? rtrim( trim( $existing_style ), ';' ) : '';
+
+	$new_style = $existing_style;
+	if ( '' !== $new_style ) {
+		$new_style .= ';';
+	}
+	$new_style .= implode( ';', $declarations ) . ';';
+
+	$processor->set_attribute( 'style', $new_style );
+
+	return $processor->get_updated_html();
+}
+add_filter( 'render_block', 'gutenberg_render_block_border_fallback', 10, 2 );

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -13,13 +13,13 @@ import {
 } from '@wordpress/blocks';
 import { __experimentalHasSplitBorders as hasSplitBorders } from '@wordpress/components';
 import { Platform, useCallback, useMemo } from '@wordpress/element';
-import { addFilter } from '@wordpress/hooks';
 import { useSelect } from '@wordpress/data';
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { getColorClassName } from '../components/colors';
 import InspectorControls from '../components/inspector-controls';
 import useMultipleOriginColorsAndGradients from '../components/colors-gradients/use-multiple-origin-colors-and-gradients';
@@ -605,6 +605,13 @@ function useBlockProps( { name, clientId, borderColor, style } ) {
 		! hasBorderSupport( name, 'color' ) ||
 		shouldSkipSerialization( name, BORDER_SUPPORT_KEY, 'color' )
 	) {
+		return {};
+	}
+
+	// Quick exit when the block has no border-related attribute at all.
+	// Avoids the preset-color resolution and fallback work below for the
+	// common case of border-supporting blocks without border data set.
+	if ( ! borderColor && ! style?.border ) {
 		return {};
 	}
 

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -638,12 +638,14 @@ function useBlockProps( { name, clientId, borderColor, style } ) {
 	} );
 
 	const inherited = getInheritedBorderStyles( blockBorder, variationBorder );
-	// Note: `extraStyles.borderXStyle` values flow into the editor wrapper
-	// via `addSaveProps` but `addSaveProps` only forwards `className` to saved
+	// `extraStyles.borderXStyle` values flow into the editor wrapper via
+	// `addSaveProps`, but `addSaveProps` only forwards `className` to saved
 	// HTML. Render-time fallback for the front end is applied in PHP by
-	// `gutenberg_apply_border_support`, which runs via
-	// `WP_Block_Supports::apply_block_supports()` for both static and dynamic
-	// blocks. The two paths share the same algorithm; keep them in sync.
+	// `gutenberg_render_block_border_fallback`, hooked into the
+	// `render_block` filter so it covers both static and dynamic blocks
+	// (static blocks bypass `apply_block_supports` because they serialize
+	// their wrapper attributes at save time). The two paths share the same
+	// algorithm; keep them in sync.
 	const styleFallbacks = getBorderStyleFallbacks(
 		{ borderColor, style },
 		inherited

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -6,7 +6,11 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { hasBlockSupport, getBlockSupport } from '@wordpress/blocks';
+import {
+	hasBlockSupport,
+	getBlockSupport,
+	store as blocksStore,
+} from '@wordpress/blocks';
 import { __experimentalHasSplitBorders as hasSplitBorders } from '@wordpress/components';
 import { Platform, useCallback, useMemo } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
@@ -15,6 +19,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { getColorClassName } from '../components/colors';
 import InspectorControls from '../components/inspector-controls';
 import useMultipleOriginColorsAndGradients from '../components/colors-gradients/use-multiple-origin-colors-and-gradients';
@@ -29,10 +34,194 @@ import {
 	BorderPanel as StylesBorderPanel,
 } from '../components/global-styles';
 import { store as blockEditorStore } from '../store';
-import { __ } from '@wordpress/i18n';
+import { globalStylesDataKey } from '../store/private-keys';
+import { getVariationNameFromClass } from './block-style-variation';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
 export const SHADOW_SUPPORT_KEY = 'shadow';
+
+const BORDER_SIDES = [ 'top', 'right', 'bottom', 'left' ];
+
+/**
+ * Map from border side to the camelCased React inline-style key. Used by the
+ * render-time fallback to emit `borderTopStyle`, `borderRightStyle`, etc.
+ */
+const BORDER_SIDE_TO_STYLE_KEY = {
+	top: 'borderTopStyle',
+	right: 'borderRightStyle',
+	bottom: 'borderBottomStyle',
+	left: 'borderLeftStyle',
+};
+
+/**
+ * Border `style` values that are "non-rendering" — they intentionally hide
+ * the border even when `color` and `width` are set. Treating these as
+ * inherited would suppress the fallback when a user adds a color on a block
+ * whose theme cascade sets `style: 'none'`, leaving the user's color
+ * invisible. Excluding them lets the fallback emit `solid` so the user's
+ * action remains visible.
+ */
+const NON_RENDERING_BORDER_STYLES = new Set( [ 'none', 'hidden' ] );
+
+const hasRenderingStyle = ( style ) =>
+	!! style && ! NON_RENDERING_BORDER_STYLES.has( style );
+
+/**
+ * Determines whether a border `style` value is being inherited from the
+ * resolved global styles for a given block instance.
+ *
+ * Inheritance is checked across two cascade levels — the block type's global
+ * styles, and the active block style variation — at two scopes each: the
+ * `border.style` shorthand, and any of the per-side `border.{side}.style`
+ * values. A shorthand inherited style is considered to cover every side.
+ *
+ * Root-level `styles.border.style` is intentionally excluded: theme.json's
+ * root border styles compile to a `body` selector, and `border-style` is not
+ * a CSS-inherited property, so a root border style does not cascade to inner
+ * block borders. Treating it as inherited would suppress the fallback even
+ * when no border style actually applies to the block.
+ *
+ * Mirrors the PHP helper `gutenberg_get_inherited_border_styles` in
+ * `lib/block-supports/border.php`. Keep the two implementations in sync.
+ *
+ * @param {Object} blockBorder     Border subtree from
+ *                                 `globalStyles.styles.blocks[ name ].border`.
+ * @param {Object} variationBorder Border subtree from the active variation,
+ *                                 if any.
+ *
+ * @return {{shorthand: boolean, top: boolean, right: boolean, bottom: boolean, left: boolean}}
+ *         Whether an inherited border style applies to the shorthand and to
+ *         each side.
+ */
+export function getInheritedBorderStyles( blockBorder, variationBorder ) {
+	const shorthand =
+		hasRenderingStyle( blockBorder?.style ) ||
+		hasRenderingStyle( variationBorder?.style );
+
+	const result = { shorthand };
+	BORDER_SIDES.forEach( ( side ) => {
+		result[ side ] =
+			shorthand ||
+			hasRenderingStyle( blockBorder?.[ side ]?.style ) ||
+			hasRenderingStyle( variationBorder?.[ side ]?.style );
+	} );
+	return result;
+}
+
+/**
+ * Returns a new border value with `style: 'solid'` filled in where the user
+ * has set a `color` or `width` without an explicit `style` AND no inherited
+ * global border style applies for that scope.
+ *
+ * Replaces the legacy `:where([style*="border-color"]) { border-style: solid }`
+ * CSS fallback in `common.scss`, which produced false positives on inline
+ * styles whose values merely contained `border-color`/`border-width` (e.g.
+ * custom-property declarations or `background-image: url(…border…)`).
+ *
+ * Handles flat, split, and mixed shapes uniformly: the shorthand and each
+ * per-side subtree are evaluated independently. `BorderBoxControl` does not
+ * currently emit mixed shapes but this helper is exported and may be called
+ * from other contexts; keeping the logic shape-agnostic avoids surprises.
+ *
+ * @param {Object|undefined} newBorder Border object emitted by BorderBoxControl.
+ * @param {Object}           inherited Inheritance flags from
+ *                                     {@link getInheritedBorderStyles}.
+ *
+ * @return {Object|undefined} Border value with style defaults applied.
+ */
+export function applyBorderStyleDefaults( newBorder, inherited ) {
+	if ( ! newBorder ) {
+		return newBorder;
+	}
+
+	const updated = { ...newBorder };
+	const isSplit = hasSplitBorders( newBorder );
+
+	// Per-side defaults. Iterating regardless of shape lets mixed shapes
+	// (a shorthand value alongside per-side overrides) be handled cleanly.
+	BORDER_SIDES.forEach( ( side ) => {
+		const sideBorder = updated[ side ];
+		if (
+			sideBorder &&
+			! sideBorder.style &&
+			( sideBorder.color || sideBorder.width ) &&
+			! inherited?.[ side ]
+		) {
+			updated[ side ] = { ...sideBorder, style: 'solid' };
+		}
+	} );
+
+	// Shorthand default. Skipped for pure split inputs to preserve the
+	// existing convention that split borders never carry a shorthand style.
+	if (
+		! isSplit &&
+		! updated.style &&
+		( updated.color || updated.width ) &&
+		! inherited?.shorthand
+	) {
+		updated.style = 'solid';
+	}
+
+	return updated;
+}
+
+/**
+ * Render-time backward-compatibility fallback. For blocks that already have
+ * saved attributes referencing a border `color` or `width` without a `style`
+ * — e.g. content saved before the editor-time default was introduced — this
+ * returns the per-side inline CSS properties needed to keep borders visible
+ * without re-saving the block.
+ *
+ * Mirrors the PHP fallback in `lib/block-supports/border.php` so editor and
+ * front-end output stay consistent. Keep the two implementations in sync.
+ *
+ * @param {Object} attributes               Subset of block attributes.
+ * @param {string} [attributes.borderColor] Block `borderColor` preset attribute.
+ * @param {Object} [attributes.style]       Block `style` attribute.
+ * @param {Object} inherited                Inheritance flags from
+ *                                          {@link getInheritedBorderStyles}.
+ *
+ * @return {Object} Inline style object containing `borderTopStyle`,
+ *                  `borderRightStyle`, etc. for sides that need a fallback.
+ */
+export function getBorderStyleFallbacks(
+	{ borderColor, style } = {},
+	inherited
+) {
+	const border = style?.border;
+	const fallback = {};
+
+	const hasShorthandValue =
+		!! borderColor || !! border?.color || !! border?.width;
+	const hasShorthandStyle = !! border?.style;
+
+	BORDER_SIDES.forEach( ( side ) => {
+		if ( inherited?.[ side ] ) {
+			return;
+		}
+
+		// If the cascade already provides a visible style for this side —
+		// either an explicit per-side style or a shorthand style which
+		// applies to every side via CSS — no fallback is needed.
+		const sideBorder = border?.[ side ];
+		if ( !! sideBorder?.style || hasShorthandStyle ) {
+			return;
+		}
+
+		const sideHasValue = !! sideBorder?.color || !! sideBorder?.width;
+
+		// A fallback is needed if the side has its own color/width without
+		// a style, or if the shorthand provides color/width but no style
+		// (which would otherwise leave this side invisible).
+		if ( ! sideHasValue && ! hasShorthandValue ) {
+			return;
+		}
+
+		fallback[ BORDER_SIDE_TO_STYLE_KEY[ side ] ] = 'solid';
+	} );
+
+	return fallback;
+}
 
 const getColorByProperty = ( colors, property, value ) => {
 	let matchedColor;
@@ -142,24 +331,52 @@ function BordersInspectorControl( { label, children, resetAllFilter } ) {
 
 export function BorderPanel( { clientId, name, setAttributes, settings } ) {
 	const isEnabled = useHasBorderPanel( settings );
-	const { style, borderColor } = useSelect(
+	const { style, borderColor, blockBorder, variationBorder } = useSelect(
 		( select ) => {
-			// Early return to avoid subscription when disabled
+			// Early return to avoid subscription work when disabled.
 			if ( ! isEnabled ) {
 				return {};
 			}
-			const { style: _style, borderColor: _borderColor } =
-				select( blockEditorStore ).getBlockAttributes( clientId ) || {};
-			return { style: _style, borderColor: _borderColor };
+			const { getBlockAttributes, getSettings } =
+				select( blockEditorStore );
+			const attributes = getBlockAttributes( clientId ) || {};
+			const blockNode =
+				getSettings()?.[ globalStylesDataKey ]?.styles?.blocks?.[
+					name
+				];
+			const registeredStyles =
+				select( blocksStore ).getBlockStyles( name );
+			const variationName = getVariationNameFromClass(
+				attributes.className,
+				registeredStyles
+			);
+			return {
+				style: attributes.style,
+				borderColor: attributes.borderColor,
+				blockBorder: blockNode?.border,
+				variationBorder: variationName
+					? blockNode?.variations?.[ variationName ]?.border
+					: undefined,
+			};
 		},
-		[ clientId, isEnabled ]
+		[ clientId, name, isEnabled ]
+	);
+	const inheritedBorderStyles = useMemo(
+		() => getInheritedBorderStyles( blockBorder, variationBorder ),
+		[ blockBorder, variationBorder ]
 	);
 	const value = useMemo( () => {
 		return attributesToStyle( { style, borderColor } );
 	}, [ style, borderColor ] );
 
 	const onChange = ( newStyle ) => {
-		setAttributes( styleToAttributes( newStyle ) );
+		const updatedBorder = applyBorderStyleDefaults(
+			newStyle?.border,
+			inheritedBorderStyles
+		);
+		setAttributes(
+			styleToAttributes( { ...newStyle, border: updatedBorder } )
+		);
 	};
 
 	if ( ! isEnabled ) {
@@ -353,8 +570,36 @@ export function getBorderClasses( attributes ) {
 	} );
 }
 
-function useBlockProps( { name, borderColor, style } ) {
+function useBlockProps( { name, clientId, borderColor, style } ) {
 	const { colors } = useMultipleOriginColorsAndGradients();
+	// Narrow the selector to only the slices needed to resolve inherited
+	// border styles. Subscribing to the entire global-styles tree or to
+	// `getBlockAttributes( clientId )` here would cause every border-support
+	// block to re-render on any unrelated global-styles or attribute change.
+	const { blockBorder, variationBorder } = useSelect(
+		( select ) => {
+			const { getBlockAttributes, getSettings } =
+				select( blockEditorStore );
+			const attrs = getBlockAttributes( clientId );
+			const blockNode =
+				getSettings()?.[ globalStylesDataKey ]?.styles?.blocks?.[
+					name
+				];
+			const registeredStyles =
+				select( blocksStore ).getBlockStyles( name );
+			const variationName = getVariationNameFromClass(
+				attrs?.className,
+				registeredStyles
+			);
+			return {
+				blockBorder: blockNode?.border,
+				variationBorder: variationName
+					? blockNode?.variations?.[ variationName ]?.border
+					: undefined,
+			};
+		},
+		[ clientId, name ]
+	);
 
 	if (
 		! hasBorderSupport( name, 'color' ) ||
@@ -385,11 +630,24 @@ function useBlockProps( { name, borderColor, style } ) {
 		namedColor: getColorSlugFromVariable( style?.border?.left?.color ),
 	} );
 
+	const inherited = getInheritedBorderStyles( blockBorder, variationBorder );
+	// Note: `extraStyles.borderXStyle` values flow into the editor wrapper
+	// via `addSaveProps` but `addSaveProps` only forwards `className` to saved
+	// HTML. Render-time fallback for the front end is applied in PHP by
+	// `gutenberg_apply_border_support`, which runs via
+	// `WP_Block_Supports::apply_block_supports()` for both static and dynamic
+	// blocks. The two paths share the same algorithm; keep them in sync.
+	const styleFallbacks = getBorderStyleFallbacks(
+		{ borderColor, style },
+		inherited
+	);
+
 	const extraStyles = {
 		borderTopColor: borderTopColor || borderColorValue,
 		borderRightColor: borderRightColor || borderColorValue,
 		borderBottomColor: borderBottomColor || borderColorValue,
 		borderLeftColor: borderLeftColor || borderColorValue,
+		...styleFallbacks,
 	};
 
 	return addSaveProps(

--- a/packages/block-editor/src/hooks/test/border.js
+++ b/packages/block-editor/src/hooks/test/border.js
@@ -1,0 +1,411 @@
+/**
+ * Internal dependencies
+ */
+import {
+	applyBorderStyleDefaults,
+	getBorderStyleFallbacks,
+	getInheritedBorderStyles,
+} from '../border';
+
+describe( 'getInheritedBorderStyles', () => {
+	const NO_INHERITANCE_RESULT = {
+		shorthand: false,
+		top: false,
+		right: false,
+		bottom: false,
+		left: false,
+	};
+	const FULL_INHERITANCE_RESULT = {
+		shorthand: true,
+		top: true,
+		right: true,
+		bottom: true,
+		left: true,
+	};
+
+	it( 'returns all-false when there are no inherited border subtrees', () => {
+		expect( getInheritedBorderStyles( undefined, undefined ) ).toEqual(
+			NO_INHERITANCE_RESULT
+		);
+	} );
+
+	it( 'ignores a root-level border style (does not propagate to inner blocks)', () => {
+		// Root styles compile to a `body` selector and `border-style` is
+		// not a CSS-inherited property. The helper takes only the block
+		// and variation borders; callers should not pass root.
+		expect( getInheritedBorderStyles( undefined, undefined ) ).toEqual(
+			NO_INHERITANCE_RESULT
+		);
+	} );
+
+	it( 'detects a shorthand inherited style at block-type level', () => {
+		expect(
+			getInheritedBorderStyles( { style: 'dotted' }, undefined )
+		).toEqual( FULL_INHERITANCE_RESULT );
+	} );
+
+	it( 'detects a per-side inherited style at block-type level', () => {
+		expect(
+			getInheritedBorderStyles( { top: { style: 'dashed' } }, undefined )
+		).toEqual( {
+			shorthand: false,
+			top: true,
+			right: false,
+			bottom: false,
+			left: false,
+		} );
+	} );
+
+	it( 'detects an inherited style at block style variation level', () => {
+		expect(
+			getInheritedBorderStyles( undefined, { style: 'solid' } )
+		).toEqual( FULL_INHERITANCE_RESULT );
+	} );
+
+	it( 'combines per-side inheritance across block and variation', () => {
+		expect(
+			getInheritedBorderStyles(
+				{ top: { style: 'dashed' } },
+				{ right: { style: 'dotted' } }
+			)
+		).toEqual( {
+			shorthand: false,
+			top: true,
+			right: true,
+			bottom: false,
+			left: false,
+		} );
+	} );
+
+	it( 'treats variation shorthand style as covering all sides', () => {
+		expect(
+			getInheritedBorderStyles(
+				{ top: { style: 'dashed' } },
+				{ style: 'solid' }
+			)
+		).toEqual( FULL_INHERITANCE_RESULT );
+	} );
+
+	describe( "non-rendering styles ('none' / 'hidden')", () => {
+		it( "does not treat shorthand 'none' as inherited", () => {
+			expect(
+				getInheritedBorderStyles( { style: 'none' }, undefined )
+			).toEqual( NO_INHERITANCE_RESULT );
+		} );
+
+		it( "does not treat shorthand 'hidden' as inherited", () => {
+			expect(
+				getInheritedBorderStyles( { style: 'hidden' }, undefined )
+			).toEqual( NO_INHERITANCE_RESULT );
+		} );
+
+		it( "does not treat per-side 'none' as inherited", () => {
+			expect(
+				getInheritedBorderStyles(
+					{ top: { style: 'none' } },
+					undefined
+				)
+			).toEqual( NO_INHERITANCE_RESULT );
+		} );
+
+		it( "treats a rendering style alongside 'none' on another side as inherited only for the rendering side", () => {
+			expect(
+				getInheritedBorderStyles(
+					{
+						top: { style: 'none' },
+						right: { style: 'dashed' },
+					},
+					undefined
+				)
+			).toEqual( {
+				shorthand: false,
+				top: false,
+				right: true,
+				bottom: false,
+				left: false,
+			} );
+		} );
+	} );
+} );
+
+describe( 'applyBorderStyleDefaults', () => {
+	const NO_INHERITANCE = {
+		shorthand: false,
+		top: false,
+		right: false,
+		bottom: false,
+		left: false,
+	};
+
+	it( 'returns undefined input unchanged', () => {
+		expect(
+			applyBorderStyleDefaults( undefined, NO_INHERITANCE )
+		).toBeUndefined();
+	} );
+
+	describe( 'uniform (shorthand) borders', () => {
+		it( 'defaults to solid when color is set without style', () => {
+			expect(
+				applyBorderStyleDefaults( { color: '#000' }, NO_INHERITANCE )
+			).toEqual( { color: '#000', style: 'solid' } );
+		} );
+
+		it( 'defaults to solid when width is set without style', () => {
+			expect(
+				applyBorderStyleDefaults( { width: '2px' }, NO_INHERITANCE )
+			).toEqual( { width: '2px', style: 'solid' } );
+		} );
+
+		it( 'does not override an explicit style', () => {
+			expect(
+				applyBorderStyleDefaults(
+					{ color: '#000', style: 'dashed' },
+					NO_INHERITANCE
+				)
+			).toEqual( { color: '#000', style: 'dashed' } );
+		} );
+
+		it( 'does not add a style when shorthand inheritance exists', () => {
+			expect(
+				applyBorderStyleDefaults(
+					{ color: '#000' },
+					{ ...NO_INHERITANCE, shorthand: true }
+				)
+			).toEqual( { color: '#000' } );
+		} );
+
+		it( 'does not add a style when only radius is present', () => {
+			expect(
+				applyBorderStyleDefaults( { radius: '4px' }, NO_INHERITANCE )
+			).toEqual( { radius: '4px' } );
+		} );
+	} );
+
+	describe( 'split borders', () => {
+		it( 'defaults solid per side when color/width is set without style', () => {
+			expect(
+				applyBorderStyleDefaults(
+					{
+						top: { color: '#000' },
+						right: { width: '2px' },
+						bottom: { color: '#fff', width: '1px' },
+						left: { color: '#ccc', style: 'dashed' },
+					},
+					NO_INHERITANCE
+				)
+			).toEqual( {
+				top: { color: '#000', style: 'solid' },
+				right: { width: '2px', style: 'solid' },
+				bottom: { color: '#fff', width: '1px', style: 'solid' },
+				left: { color: '#ccc', style: 'dashed' },
+			} );
+		} );
+
+		it( 'applies shorthand and per-side defaults on mixed shapes', () => {
+			// `hasSplitBorders` returns true if any per-side key exists, so a
+			// mixed shape used to skip the shorthand-level default entirely.
+			// The unified helper handles both levels in a single pass.
+			expect(
+				applyBorderStyleDefaults(
+					{
+						color: '#000',
+						top: { color: '#fff' },
+					},
+					NO_INHERITANCE
+				)
+			).toEqual( {
+				color: '#000',
+				top: { color: '#fff', style: 'solid' },
+			} );
+		} );
+
+		it( 'skips sides where inheritance exists', () => {
+			expect(
+				applyBorderStyleDefaults(
+					{
+						top: { color: '#000' },
+						right: { color: '#000' },
+						bottom: { color: '#000' },
+						left: { color: '#000' },
+					},
+					{ ...NO_INHERITANCE, top: true, left: true }
+				)
+			).toEqual( {
+				top: { color: '#000' },
+				right: { color: '#000', style: 'solid' },
+				bottom: { color: '#000', style: 'solid' },
+				left: { color: '#000' },
+			} );
+		} );
+
+		it( 'does not mutate the input', () => {
+			const input = {
+				top: { color: '#000' },
+				right: { color: '#111' },
+				bottom: { color: '#222' },
+				left: { color: '#333' },
+			};
+			const snapshot = JSON.parse( JSON.stringify( input ) );
+			applyBorderStyleDefaults( input, NO_INHERITANCE );
+			expect( input ).toEqual( snapshot );
+		} );
+	} );
+} );
+
+describe( 'getBorderStyleFallbacks', () => {
+	const NO_INHERITANCE = {
+		shorthand: false,
+		top: false,
+		right: false,
+		bottom: false,
+		left: false,
+	};
+
+	it( 'returns empty when no border attributes are set', () => {
+		expect( getBorderStyleFallbacks( {}, NO_INHERITANCE ) ).toEqual( {} );
+	} );
+
+	it( 'returns empty when called with no arguments', () => {
+		expect( getBorderStyleFallbacks() ).toEqual( {} );
+	} );
+
+	it( 'returns empty when an explicit shorthand style is already present', () => {
+		expect(
+			getBorderStyleFallbacks(
+				{ style: { border: { color: '#000', style: 'dashed' } } },
+				NO_INHERITANCE
+			)
+		).toEqual( {} );
+	} );
+
+	it( 'emits per-side solid for shorthand color/width without style', () => {
+		expect(
+			getBorderStyleFallbacks(
+				{ style: { border: { color: '#000' } } },
+				NO_INHERITANCE
+			)
+		).toEqual( {
+			borderTopStyle: 'solid',
+			borderRightStyle: 'solid',
+			borderBottomStyle: 'solid',
+			borderLeftStyle: 'solid',
+		} );
+	} );
+
+	it( 'emits per-side solid for borderColor preset attribute', () => {
+		expect(
+			getBorderStyleFallbacks( { borderColor: 'accent' }, NO_INHERITANCE )
+		).toEqual( {
+			borderTopStyle: 'solid',
+			borderRightStyle: 'solid',
+			borderBottomStyle: 'solid',
+			borderLeftStyle: 'solid',
+		} );
+	} );
+
+	it( 'skips sides where inheritance applies', () => {
+		expect(
+			getBorderStyleFallbacks(
+				{ style: { border: { width: '2px' } } },
+				{ ...NO_INHERITANCE, top: true, bottom: true }
+			)
+		).toEqual( {
+			borderRightStyle: 'solid',
+			borderLeftStyle: 'solid',
+		} );
+	} );
+
+	it( 'skips all sides when shorthand inheritance applies', () => {
+		expect(
+			getBorderStyleFallbacks(
+				{ style: { border: { color: '#000' } } },
+				{
+					shorthand: true,
+					top: true,
+					right: true,
+					bottom: true,
+					left: true,
+				}
+			)
+		).toEqual( {} );
+	} );
+
+	it( 'emits per-side solid only for the side that needs it', () => {
+		expect(
+			getBorderStyleFallbacks(
+				{
+					style: {
+						border: {
+							top: { color: '#000', style: 'dashed' },
+							right: { color: '#000' },
+						},
+					},
+				},
+				NO_INHERITANCE
+			)
+		).toEqual( { borderRightStyle: 'solid' } );
+	} );
+
+	describe( 'mixed shorthand + per-side data', () => {
+		it( 'does not clobber a side with an explicit per-side style when shorthand color is set', () => {
+			// Shorthand color but no shorthand style; one side has its
+			// own explicit dashed style. That side must keep dashed; the
+			// other three need fallback solid via the shorthand value.
+			expect(
+				getBorderStyleFallbacks(
+					{
+						style: {
+							border: {
+								color: '#000',
+								top: { color: '#fff', style: 'dashed' },
+							},
+						},
+					},
+					NO_INHERITANCE
+				)
+			).toEqual( {
+				borderRightStyle: 'solid',
+				borderBottomStyle: 'solid',
+				borderLeftStyle: 'solid',
+			} );
+		} );
+
+		it( 'emits nothing when the shorthand provides a style — it covers all sides via the cascade', () => {
+			expect(
+				getBorderStyleFallbacks(
+					{
+						style: {
+							border: {
+								style: 'dashed',
+								top: { color: '#fff' },
+								right: { color: '#fff' },
+							},
+						},
+					},
+					NO_INHERITANCE
+				)
+			).toEqual( {} );
+		} );
+
+		it( 'emits per-side solid for sides covered by shorthand color when no style is set anywhere', () => {
+			expect(
+				getBorderStyleFallbacks(
+					{
+						style: {
+							border: {
+								color: '#000',
+								top: { color: '#fff' },
+							},
+						},
+					},
+					NO_INHERITANCE
+				)
+			).toEqual( {
+				borderTopStyle: 'solid',
+				borderRightStyle: 'solid',
+				borderBottomStyle: 'solid',
+				borderLeftStyle: 'solid',
+			} );
+		} );
+	} );
+} );

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -112,56 +112,6 @@
 }
 
 /**
- * The following provide a simple means of applying a default border style when
- * a user first makes a selection in the border block support panel.
- * This prevents issues such as where the user could set a border width
- * and see no border due there being no border style set.
- *
- * This is intended to be removed once intelligent defaults can be set while
- * making border selections via the block support.
- *
- * See: https://github.com/WordPress/gutenberg/pull/33743
- */
-html :where(.has-border-color) {
-	border-style: solid;
-}
-html :where([style*="border-color"]) {
-	border-style: solid;
-}
-html :where([style*="border-top-color"]) {
-	border-top-style: solid;
-}
-html :where([style*="border-right-color"]) {
-	/*rtl:ignore*/
-	border-right-style: solid;
-}
-html :where([style*="border-bottom-color"]) {
-	border-bottom-style: solid;
-}
-html :where([style*="border-left-color"]) {
-	/*rtl:ignore*/
-	border-left-style: solid;
-}
-
-html :where([style*="border-width"]) {
-	border-style: solid;
-}
-html :where([style*="border-top-width"]) {
-	border-top-style: solid;
-}
-html :where([style*="border-right-width"]) {
-	/*rtl:ignore*/
-	border-right-style: solid;
-}
-html :where([style*="border-bottom-width"]) {
-	border-bottom-style: solid;
-}
-html :where([style*="border-left-width"]) {
-	/*rtl:ignore*/
-	border-left-style: solid;
-}
-
-/**
  * Provide baseline responsiveness for images.
  */
 html :where(img[class*="wp-image-"]) {

--- a/phpunit/block-supports/border-test.php
+++ b/phpunit/block-supports/border-test.php
@@ -779,6 +779,44 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * End-to-end: a block that opts into `color` (and/or `width`) but not
+	 * `style` still receives the visibility fallback. Opting out of `style`
+	 * means the user cannot pick a style via UI; it does not mean a block
+	 * whose attributes carry a color or width should be invisible. This
+	 * matches the legacy CSS `:where()` fallback behaviour.
+	 */
+	public function test_render_block_filter_applies_to_block_without_style_support() {
+		self::register_bordered_block_with_support(
+			'test/fallback-color-only-support',
+			array(
+				'__experimentalBorder' => array(
+					'color' => true,
+					'width' => true,
+				),
+			)
+		);
+
+		$inner_html = '<div style="border-color:#ff0000;border-width:2px">x</div>';
+		$rendered   = $this->render_block_through_filter(
+			'test/fallback-color-only-support',
+			array(
+				'style' => array(
+					'border' => array(
+						'color' => '#ff0000',
+						'width' => '2px',
+					),
+				),
+			),
+			$inner_html
+		);
+
+		$this->assertStringContainsString( 'border-top-style:solid', $rendered );
+		$this->assertStringContainsString( 'border-right-style:solid', $rendered );
+		$this->assertStringContainsString( 'border-bottom-style:solid', $rendered );
+		$this->assertStringContainsString( 'border-left-style:solid', $rendered );
+	}
+
+	/**
 	 * End-to-end: inheritance from the resolved global block-type border
 	 * style suppresses the fallback for all sides.
 	 */

--- a/phpunit/block-supports/border-test.php
+++ b/phpunit/block-supports/border-test.php
@@ -20,6 +20,19 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 	public function tear_down() {
 		unregister_block_type( $this->test_block_name );
 		$this->test_block_name = null;
+		remove_filter(
+			'wp_theme_json_data_theme',
+			array( $this, 'filter_inject_block_type_border_style' )
+		);
+		remove_filter(
+			'wp_theme_json_data_theme',
+			array( $this, 'filter_inject_root_border_style' )
+		);
+		remove_filter(
+			'wp_theme_json_data_theme',
+			array( $this, 'filter_inject_block_type_border_none' )
+		);
+		_gutenberg_clean_theme_json_caches();
 		parent::tear_down();
 	}
 
@@ -458,5 +471,528 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Helper that builds a parsed-block array shape and runs it through the
+	 * `render_block` filter chain so we exercise the wired-up fallback exactly
+	 * as it runs at render time.
+	 *
+	 * @param string $block_name Registered block type name.
+	 * @param array  $attrs      Parsed block attributes.
+	 * @param string $inner_html Inner HTML (block wrapper).
+	 *
+	 * @return string Filtered block HTML.
+	 */
+	private function render_block_through_filter( $block_name, $attrs, $inner_html ) {
+		$block = array(
+			'blockName'    => $block_name,
+			'attrs'        => $attrs,
+			'innerBlocks'  => array(),
+			'innerHTML'    => $inner_html,
+			'innerContent' => array( $inner_html ),
+		);
+		return gutenberg_render_block_border_fallback( $inner_html, $block );
+	}
+
+	/**
+	 * The pure fallback helper handles flat color/width inputs by emitting
+	 * `border-{side}-style:solid` for every side.
+	 */
+	public function test_get_border_style_fallbacks_flat_color() {
+		$attrs = array( 'style' => array( 'border' => array( 'color' => '#72aee6' ) ) );
+		$this->assertSame(
+			array(
+				'border-top-style:solid',
+				'border-right-style:solid',
+				'border-bottom-style:solid',
+				'border-left-style:solid',
+			),
+			gutenberg_get_border_style_fallbacks(
+				$attrs,
+				array(
+					'top'    => false,
+					'right'  => false,
+					'bottom' => false,
+					'left'   => false,
+				)
+			)
+		);
+	}
+
+	public function test_get_border_style_fallbacks_flat_width() {
+		$attrs = array( 'style' => array( 'border' => array( 'width' => '2px' ) ) );
+		$this->assertSame(
+			array(
+				'border-top-style:solid',
+				'border-right-style:solid',
+				'border-bottom-style:solid',
+				'border-left-style:solid',
+			),
+			gutenberg_get_border_style_fallbacks(
+				$attrs,
+				array(
+					'top'    => false,
+					'right'  => false,
+					'bottom' => false,
+					'left'   => false,
+				)
+			)
+		);
+	}
+
+	public function test_get_border_style_fallbacks_border_color_preset_alone() {
+		$attrs = array( 'borderColor' => 'accent' );
+		$this->assertSame(
+			array(
+				'border-top-style:solid',
+				'border-right-style:solid',
+				'border-bottom-style:solid',
+				'border-left-style:solid',
+			),
+			gutenberg_get_border_style_fallbacks(
+				$attrs,
+				array(
+					'top'    => false,
+					'right'  => false,
+					'bottom' => false,
+					'left'   => false,
+				)
+			)
+		);
+	}
+
+	/**
+	 * An explicit shorthand `style` covers every side via CSS, so the
+	 * helper must emit nothing.
+	 */
+	public function test_get_border_style_fallbacks_shorthand_style_covers_sides() {
+		$attrs = array(
+			'style' => array(
+				'border' => array(
+					'style' => 'dashed',
+					'top'   => array( 'color' => '#fff' ),
+					'right' => array( 'color' => '#fff' ),
+				),
+			),
+		);
+		$this->assertSame(
+			array(),
+			gutenberg_get_border_style_fallbacks(
+				$attrs,
+				array(
+					'top'    => false,
+					'right'  => false,
+					'bottom' => false,
+					'left'   => false,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Mixed shape: explicit per-side style on top, shorthand color elsewhere.
+	 * Top is preserved (helper emits nothing for it); right/bottom/left need
+	 * the fallback because the shorthand color leaves them otherwise invisible.
+	 */
+	public function test_get_border_style_fallbacks_mixed_preserves_explicit_side_style() {
+		$attrs = array(
+			'style' => array(
+				'border' => array(
+					'color' => '#000',
+					'top'   => array(
+						'color' => '#fff',
+						'style' => 'dashed',
+					),
+				),
+			),
+		);
+		$this->assertSame(
+			array(
+				'border-right-style:solid',
+				'border-bottom-style:solid',
+				'border-left-style:solid',
+			),
+			gutenberg_get_border_style_fallbacks(
+				$attrs,
+				array(
+					'top'    => false,
+					'right'  => false,
+					'bottom' => false,
+					'left'   => false,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Per-side: only sides that have color/width but no style get the fallback.
+	 */
+	public function test_get_border_style_fallbacks_per_side_mixed() {
+		$attrs = array(
+			'style' => array(
+				'border' => array(
+					'top'   => array(
+						'color' => '#000',
+						'style' => 'dashed',
+					),
+					'right' => array( 'color' => '#000' ),
+				),
+			),
+		);
+		$this->assertSame(
+			array( 'border-right-style:solid' ),
+			gutenberg_get_border_style_fallbacks(
+				$attrs,
+				array(
+					'top'    => false,
+					'right'  => false,
+					'bottom' => false,
+					'left'   => false,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Inherited shorthand style suppresses every side.
+	 */
+	public function test_get_border_style_fallbacks_inherited_shorthand_suppresses_all_sides() {
+		$attrs = array( 'style' => array( 'border' => array( 'color' => '#72aee6' ) ) );
+		$this->assertSame(
+			array(),
+			gutenberg_get_border_style_fallbacks(
+				$attrs,
+				array(
+					'top'    => true,
+					'right'  => true,
+					'bottom' => true,
+					'left'   => true,
+				)
+			)
+		);
+	}
+
+	/**
+	 * End-to-end: the `render_block` filter injects fallback styles into
+	 * the rendered wrapper for a static block that has a saved border color
+	 * but no border style.
+	 */
+	public function test_render_block_filter_injects_fallback_for_legacy_static_content() {
+		self::register_bordered_block_with_support(
+			'test/render-fallback-legacy-static',
+			array(
+				'__experimentalBorder' => array(
+					'color' => true,
+					'width' => true,
+					'style' => true,
+				),
+			)
+		);
+
+		$inner_html = '<div class="wp-block-test has-border-color" style="border-color:#ff0000;border-width:4px">x</div>';
+		$rendered   = $this->render_block_through_filter(
+			'test/render-fallback-legacy-static',
+			array(
+				'style' => array(
+					'border' => array(
+						'color' => '#ff0000',
+						'width' => '4px',
+					),
+				),
+			),
+			$inner_html
+		);
+
+		$this->assertStringContainsString( 'border-top-style:solid', $rendered );
+		$this->assertStringContainsString( 'border-right-style:solid', $rendered );
+		$this->assertStringContainsString( 'border-bottom-style:solid', $rendered );
+		$this->assertStringContainsString( 'border-left-style:solid', $rendered );
+		$this->assertStringContainsString( 'border-color:#ff0000', $rendered );
+	}
+
+	/**
+	 * End-to-end: a block with an explicit `border.style` already in its
+	 * attributes is left untouched by the filter.
+	 */
+	public function test_render_block_filter_is_noop_when_border_style_set() {
+		self::register_bordered_block_with_support(
+			'test/render-fallback-noop-style-set',
+			array(
+				'__experimentalBorder' => array(
+					'color' => true,
+					'width' => true,
+					'style' => true,
+				),
+			)
+		);
+
+		$inner_html = '<div style="border-color:#ff0000;border-style:dotted">x</div>';
+		$rendered   = $this->render_block_through_filter(
+			'test/render-fallback-noop-style-set',
+			array(
+				'style' => array(
+					'border' => array(
+						'color' => '#ff0000',
+						'style' => 'dotted',
+					),
+				),
+			),
+			$inner_html
+		);
+
+		$this->assertSame( $inner_html, $rendered );
+		$this->assertStringNotContainsString( 'solid', $rendered );
+	}
+
+	/**
+	 * End-to-end: the filter respects skipped serialization of the `style`
+	 * feature and leaves the block untouched.
+	 */
+	public function test_render_block_filter_skips_when_style_serialization_skipped() {
+		self::register_bordered_block_with_support(
+			'test/render-fallback-skip-serialization',
+			array(
+				'__experimentalBorder' => array(
+					'color'                           => true,
+					'width'                           => true,
+					'style'                           => true,
+					'__experimentalSkipSerialization' => array( 'style' ),
+				),
+			)
+		);
+
+		$inner_html = '<div style="border-color:#ff0000">x</div>';
+		$rendered   = $this->render_block_through_filter(
+			'test/render-fallback-skip-serialization',
+			array(
+				'style' => array(
+					'border' => array(
+						'color' => '#ff0000',
+					),
+				),
+			),
+			$inner_html
+		);
+
+		$this->assertSame( $inner_html, $rendered );
+	}
+
+	/**
+	 * End-to-end: inheritance from the resolved global block-type border
+	 * style suppresses the fallback for all sides.
+	 */
+	public function test_render_block_filter_suppressed_by_inherited_block_type_border_style() {
+		add_filter(
+			'wp_theme_json_data_theme',
+			array( $this, 'filter_inject_block_type_border_style' )
+		);
+		_gutenberg_clean_theme_json_caches();
+
+		self::register_bordered_block_with_support(
+			'test/fallback-inherited-block-type',
+			array(
+				'__experimentalBorder' => array(
+					'color' => true,
+					'width' => true,
+					'style' => true,
+				),
+			)
+		);
+		$inner_html = '<div style="border-color:#72aee6">x</div>';
+		$rendered   = $this->render_block_through_filter(
+			'test/fallback-inherited-block-type',
+			array(
+				'style' => array( 'border' => array( 'color' => '#72aee6' ) ),
+			),
+			$inner_html
+		);
+
+		remove_filter(
+			'wp_theme_json_data_theme',
+			array( $this, 'filter_inject_block_type_border_style' )
+		);
+		_gutenberg_clean_theme_json_caches();
+
+		$this->assertSame( $inner_html, $rendered );
+	}
+
+	/**
+	 * End-to-end: root-level `styles.border.style` must NOT suppress the
+	 * fallback (root border styles compile to `body` and `border-style`
+	 * does not cascade as an inherited CSS property).
+	 */
+	public function test_render_block_filter_not_suppressed_by_root_border_style() {
+		add_filter(
+			'wp_theme_json_data_theme',
+			array( $this, 'filter_inject_root_border_style' )
+		);
+		_gutenberg_clean_theme_json_caches();
+
+		self::register_bordered_block_with_support(
+			'test/fallback-root-border-noop',
+			array(
+				'__experimentalBorder' => array(
+					'color' => true,
+					'width' => true,
+					'style' => true,
+				),
+			)
+		);
+		$inner_html = '<div style="border-color:#72aee6">x</div>';
+		$rendered   = $this->render_block_through_filter(
+			'test/fallback-root-border-noop',
+			array(
+				'style' => array( 'border' => array( 'color' => '#72aee6' ) ),
+			),
+			$inner_html
+		);
+
+		remove_filter(
+			'wp_theme_json_data_theme',
+			array( $this, 'filter_inject_root_border_style' )
+		);
+		_gutenberg_clean_theme_json_caches();
+
+		$this->assertStringContainsString( 'border-top-style:solid', $rendered );
+	}
+
+	/**
+	 * Filter callback: injects a block-type-level border style for the
+	 * `test/fallback-inherited-block-type` block.
+	 */
+	public function filter_inject_block_type_border_style( $theme_json ) {
+		return $theme_json->update_with(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'test/fallback-inherited-block-type' => array(
+							'border' => array(
+								'style' => 'dashed',
+							),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Filter callback: injects a root-level border style. Used to verify
+	 * that the fallback ignores root border styles.
+	 */
+	public function filter_inject_root_border_style( $theme_json ) {
+		return $theme_json->update_with(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'border' => array(
+						'style' => 'dashed',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * End-to-end: a non-rendering inherited style (`none`/`hidden`) must
+	 * NOT suppress the fallback — otherwise a user adding a `borderColor`
+	 * would see no border at all.
+	 */
+	public function test_render_block_filter_not_suppressed_by_non_rendering_inherited_style() {
+		add_filter(
+			'wp_theme_json_data_theme',
+			array( $this, 'filter_inject_block_type_border_none' )
+		);
+		_gutenberg_clean_theme_json_caches();
+
+		self::register_bordered_block_with_support(
+			'test/fallback-inherited-none',
+			array(
+				'__experimentalBorder' => array(
+					'color' => true,
+					'width' => true,
+					'style' => true,
+				),
+			)
+		);
+		$inner_html = '<div style="border-color:#72aee6">x</div>';
+		$rendered   = $this->render_block_through_filter(
+			'test/fallback-inherited-none',
+			array(
+				'style' => array( 'border' => array( 'color' => '#72aee6' ) ),
+			),
+			$inner_html
+		);
+
+		remove_filter(
+			'wp_theme_json_data_theme',
+			array( $this, 'filter_inject_block_type_border_none' )
+		);
+		_gutenberg_clean_theme_json_caches();
+
+		$this->assertStringContainsString( 'border-top-style:solid', $rendered );
+	}
+
+	/**
+	 * Filter callback: injects a block-type-level `border.style: 'none'`
+	 * to verify it does not suppress the fallback.
+	 */
+	public function filter_inject_block_type_border_none( $theme_json ) {
+		return $theme_json->update_with(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'test/fallback-inherited-none' => array(
+							'border' => array(
+								'style' => 'none',
+							),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	public function test_gutenberg_get_variation_name_from_class_returns_null_for_empty_inputs() {
+		$this->assertNull( gutenberg_get_variation_name_from_class( '', array() ) );
+		$this->assertNull(
+			gutenberg_get_variation_name_from_class(
+				'is-style-outlined',
+				array()
+			)
+		);
+		$this->assertNull(
+			gutenberg_get_variation_name_from_class(
+				'',
+				array( array( 'name' => 'outlined' ) )
+			)
+		);
+	}
+
+	public function test_gutenberg_get_variation_name_from_class_matches_registered_variation() {
+		$registered = array(
+			array( 'name' => 'outlined' ),
+			array( 'name' => 'flush' ),
+		);
+		$this->assertSame(
+			'outlined',
+			gutenberg_get_variation_name_from_class(
+				'wp-block-group is-style-outlined',
+				$registered
+			)
+		);
+	}
+
+	public function test_gutenberg_get_variation_name_from_class_ignores_default_and_unknowns() {
+		$registered = array( array( 'name' => 'outlined' ) );
+		$this->assertNull(
+			gutenberg_get_variation_name_from_class(
+				'is-style-default is-style-unknown',
+				$registered
+			)
+		);
 	}
 }

--- a/test/e2e/specs/editor/blocks/border-block-support.spec.js
+++ b/test/e2e/specs/editor/blocks/border-block-support.spec.js
@@ -1,0 +1,160 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/**
+ * Regression coverage for the border block-support fallback. Verifies two
+ * properties of the editor-time intelligent default + render-time fallback
+ * that replaces the legacy `:where([style*="border-color"])` CSS rule:
+ *
+ *   1. Legacy / unmigrated block content that has a border color or width but
+ *      no border style still renders with a visible solid border on the front
+ *      end (backward-compatibility goal).
+ *   2. Inline `style` attributes whose values merely contain the substring
+ *      `border-color` — e.g. a `background-image: url(...border-color.png)`
+ *      or a CSS custom property named `--border-color` — do NOT receive a
+ *      spurious `border-style: solid` (regression #77476 root-cause goal).
+ */
+test.describe( 'Border block support', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		// emptytheme provides a minimal theme.json so the resolved global
+		// styles cascade does not interfere with the fallback logic.
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'legacy block with border color but no border style still renders a visible border on the front end', async ( {
+		editor,
+		page,
+	} ) => {
+		// Simulate content saved before the editor-time `solid` default was
+		// introduced: a group with `style.border.color` but no `border.style`.
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: {
+				style: {
+					border: {
+						color: '#ff0000',
+						width: '4px',
+					},
+				},
+			},
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Legacy border content.' },
+				},
+			],
+		} );
+
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+
+		const group = page.locator( '.wp-block-group.has-border-color' );
+		await expect( group ).toBeVisible();
+
+		const computed = await group.evaluate( ( el ) => {
+			const style = window.getComputedStyle( el );
+			return {
+				borderTopStyle: style.borderTopStyle,
+				borderRightStyle: style.borderRightStyle,
+				borderBottomStyle: style.borderBottomStyle,
+				borderLeftStyle: style.borderLeftStyle,
+				borderTopColor: style.borderTopColor,
+				borderTopWidth: style.borderTopWidth,
+			};
+		} );
+
+		expect( computed.borderTopStyle ).toBe( 'solid' );
+		expect( computed.borderRightStyle ).toBe( 'solid' );
+		expect( computed.borderBottomStyle ).toBe( 'solid' );
+		expect( computed.borderLeftStyle ).toBe( 'solid' );
+		expect( computed.borderTopColor ).toBe( 'rgb(255, 0, 0)' );
+		expect( computed.borderTopWidth ).toBe( '4px' );
+	} );
+} );
+
+test.describe( 'Border block support — no false positives', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'an element whose inline `style` contains a `background-image: url(...border-color...)` does not get a spurious solid border (regression #77476)', async ( {
+		requestUtils,
+		page,
+	} ) => {
+		const { id: postId } = await requestUtils.createPost( {
+			title: 'Border substring regression',
+			status: 'publish',
+			content:
+				'<div id="false-positive-bg" style="background-image:url(\'/wp-content/border-color-decoration.png\');width:120px;height:120px;">x</div>',
+		} );
+
+		await page.goto( `/?p=${ postId }` );
+
+		const target = page.locator( '#false-positive-bg' );
+		await expect( target ).toBeVisible();
+
+		const computed = await target.evaluate( ( el ) => {
+			const s = window.getComputedStyle( el );
+			return {
+				borderTopStyle: s.borderTopStyle,
+				borderRightStyle: s.borderRightStyle,
+				borderBottomStyle: s.borderBottomStyle,
+				borderLeftStyle: s.borderLeftStyle,
+			};
+		} );
+
+		// `none` is the CSS initial value. The legacy `:where()` rule we
+		// removed would have forced these to `solid` because the inline
+		// style string contains the substring `border-color`.
+		expect( computed.borderTopStyle ).toBe( 'none' );
+		expect( computed.borderRightStyle ).toBe( 'none' );
+		expect( computed.borderBottomStyle ).toBe( 'none' );
+		expect( computed.borderLeftStyle ).toBe( 'none' );
+	} );
+
+	test( 'an element whose inline `style` declares a `--border-color` custom property does not get a spurious solid border (regression #77476)', async ( {
+		requestUtils,
+		page,
+	} ) => {
+		const { id: postId } = await requestUtils.createPost( {
+			title: 'Border custom property regression',
+			status: 'publish',
+			content:
+				'<div id="false-positive-var" style="--border-color:red;width:120px;height:120px;">x</div>',
+		} );
+
+		await page.goto( `/?p=${ postId }` );
+
+		const target = page.locator( '#false-positive-var' );
+		await expect( target ).toBeVisible();
+
+		const computed = await target.evaluate( ( el ) => {
+			const s = window.getComputedStyle( el );
+			return {
+				borderTopStyle: s.borderTopStyle,
+				borderRightStyle: s.borderRightStyle,
+				borderBottomStyle: s.borderBottomStyle,
+				borderLeftStyle: s.borderLeftStyle,
+			};
+		} );
+
+		expect( computed.borderTopStyle ).toBe( 'none' );
+		expect( computed.borderRightStyle ).toBe( 'none' );
+		expect( computed.borderBottomStyle ).toBe( 'none' );
+		expect( computed.borderLeftStyle ).toBe( 'none' );
+	} );
+} );


### PR DESCRIPTION
> [!WARNING]
> **This approach is open for evaluation.** It removes the global CSS fallback from every page render, but it is not yet clear that the JS/PHP replacement is objectively better than simply keeping the recently tightened CSS rule. 

## What?

<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow up to #77476.

Replaces the legacy `:where([style*="border-…"])` CSS visibility fallback for the border block support with a cascade-aware, edit-time intelligent default plus a render-time fallback for legacy content.

## Why?

The legacy CSS rule in `packages/block-library/src/common.scss` forced `border-style: solid` on any element whose inline style attribute contained the substring `border-color`, `border-width`, etc. That substring match produced false positives:

• Any element with a CSS custom property such as `--border-color: red` was matched.
• Any element with a `background-image: url(...border-color...)` URL was matched.
• Any future inline-style declaration containing those substrings would be matched.

#77476 mitigated the symptom by tightening the selectors. This PR removes the root cause: the CSS fallback itself.

The CSS fallback has carried a `// TODO` for a long time noting it should be replaced with "intelligent defaults" once edit-time context made that possible. That context now exists (`useBlockSettings`, the resolved global-styles tree exposed via `globalStylesDataKey`, and block-style variation resolution helpers).


## How?

Three coordinated mechanisms replace the one CSS rule. All are cascade-aware.

1. Edit-time intelligent default (new content)

`packages/block-editor/src/hooks/border.js` the block-instance `BorderPanel.onChange` now calls a new pure helper `applyBorderStyleDefaults`. When the user sets a border color or width and:

• there is no explicit border.style on the value being persisted, AND
• there is no inherited global border style for the affected scope (shorthand vs. per-side),

then `style: 'solid'` is persisted into the block's `attributes.style.border`. Saved HTML becomes self-describing: no runtime fallback is needed to render the border. The shared `StylesBorderPanel` used by the Global Styles UI is intentionally untouched, its merged `inheritedValue` already handles inheritance, so no change is needed there.

Inheritance is resolved across two cascade levels:

• `styles.blocks[ name ].border` (block-type global styles)
• `styles.blocks[ name ].variations[ active ].border` (active block style variation, derived from the block's `className` via the shared `getVariationNameFromClass` helper)

Root `styles.border.style` is intentionally excluded, theme.json compiles it to a `body` selector and `border-style` is not a CSS-inherited property, so it does not cascade to inner blocks. Non-rendering values (none, hidden) are also excluded so that a theme setting border.style: 'none' does not silently suppress the fallback when a user adds a color.

2. Editor render-time fallback (legacy content in the editor)

The same `useBlockProps` hook gains a render-time fallback via `getBorderStyleFallbacks` so that blocks with saved attributes carrying color/width but no style still render visibly in the editor wrapper. The fallback flows through `BlockListBlock` wrapper props; it does not mutate saved HTML.

3. Front-end render-time fallback (legacy content on the front end)

`lib/block-supports/border.php`, new `gutenberg_render_block_border_fallback` hooked into the `render_block` filter, using `WP_HTML_Tag_Processor` to inject per-side `border-{side}-style: solid` into the wrapper's style attribute. Hooked into `render_block` rather than `apply_block_supports` because `WP_Block_Supports::apply_block_supports()` is only invoked via `get_block_wrapper_attributes()` from inside a dynamic block's `render_callback`, static blocks (Group, Paragraph, Heading, …) serialize their wrapper attributes at save time and never reach that path. The `render_block` filter covers both static and dynamic blocks.

The PHP path mirrors the JS algorithm exactly. Both files cross-reference each other in doc comments. The PHP helper has a quick-exit when the block has no border-related attribute and shares the same none/hidden non-rendering style handling.

### Removed

packages/block-library/src/common.scss — the entire :where(.has-border-color, [style*="border-…"]) fallback block (lines 114-162) is removed.

## Testing Instructions

1. Activate Gutenberg trunk + this branch.
2. Insert a Group block, open the Border panel, pick a color and width without explicitly selecting a style. Confirm the border is visible immediately in the editor and after publish.
3. Inspect the saved post content (Code Editor view). Confirm the block markup carries "style":{"border {"color":"…","width":"…","style":"solid"}} — i.e. style: 'solid' is persisted into attributes.
4. Save a block whose attributes have only `style.border.color` (no `style.border.style`) — easiest via the Code Editor. Publish and view on the front end. Confirm the border still renders as solid (backward compatibility).
5. With a theme.json that sets `styles.blocks.core/group.border.style` = 'dashed', edit a Group block, add a `border.color` from the UI. Confirm the editor shows the inherited dashed border (not forced solid), and that style: 'solid' is not persisted into the block's attributes (cascade-aware).
6. Regression coverage for #77476 false-positives:
      ◦ Insert an HTML block with `<div style="background-image: url('/wp-content/uploads/border-color-thing.png');">…</div>`. Publish and inspect the rendered output: the element must have `border-style: none` (computed), not solid.
      ◦ Same with `<div style="--border-color: red;">…</div>`.
7. Run the automated suites locally:
      ◦ `npm run test:unit -- packages/block-editor/src/hooks/test/border.js` (32 tests).
      ◦ `npm run test:unit:php -- --filter WP_Block_Supports_Border_Test` (29 tests).
      ◦ `npm run test:e2e -- test/e2e/specs/editor/blocks/border-block-support.spec.js` (3 tests).


## Screenshots or screencast

TBA