### PR TITLE
Dashboard: Promote WidgetRender into widget-primitives

### DIFF
--- a/routes/dashboard/widget-dashboard/README.md
+++ b/routes/dashboard/widget-dashboard/README.md
@@ -142,4 +142,4 @@ interface WidgetRenderProps< Item = unknown > {
 - `ResolveWidgetModule` — module resolver signature.
 - `WidgetGridSettings` — grid configuration.
 
-The widget contract types (`WidgetName`, `WidgetTypeMetadata`, `WidgetType`, `WidgetRenderProps`, `ResolveWidgetModule`) are defined in `widget-primitives` and imported from there directly; this engine does not re-export them.
+The widget contract types (`WidgetName`, `WidgetType`, `WidgetRenderProps`, `ResolveWidgetModule`) are defined in `widget-primitives` and imported from there directly; this engine does not re-export them.

--- a/routes/dashboard/widget-dashboard/components/dashboard-widget-chrome/dashboard-widget-chrome.tsx
+++ b/routes/dashboard/widget-dashboard/components/dashboard-widget-chrome/dashboard-widget-chrome.tsx
@@ -24,7 +24,7 @@ import { Card, Icon, Stack, Notice, Text, VisuallyHidden } from '@wordpress/ui';
  */
 import { useDashboardInternalContext } from '../../context/dashboard-context';
 import { WidgetContextProvider } from '../../context/widget-context';
-import { WidgetRender } from '../widget-render';
+import { DashboardWidgetRender } from '../widget-render';
 import styles from './dashboard-widget-chrome.module.css';
 import type { DashboardWidget } from '../../types';
 import type { WidgetType } from '../../../widget-primitives';
@@ -211,7 +211,10 @@ export const DashboardWidgetChrome = forwardRef<
 	const body = (
 		<WidgetErrorBoundary>
 			<Suspense fallback={ <LoadingOverlay /> }>
-				<WidgetRender widget={ widget } widgetType={ widgetType } />
+				<DashboardWidgetRender
+					widget={ widget }
+					widgetType={ widgetType }
+				/>
 			</Suspense>
 		</WidgetErrorBoundary>
 	);

--- a/routes/dashboard/widget-dashboard/components/widget-picker/widget-picker.tsx
+++ b/routes/dashboard/widget-dashboard/components/widget-picker/widget-picker.tsx
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { useDashboardInternalContext } from '../../context/dashboard-context';
 import { createDashboardWidget } from '../../utils/create-dashboard-widget';
-import { WidgetRender } from '../widget-render';
+import { DashboardWidgetRender } from '../widget-render';
 import styles from './widget-picker.module.css';
 import type { WidgetType } from '../../../widget-primitives';
 
@@ -34,7 +34,10 @@ function WidgetPreview( { item }: { item: WidgetType } ) {
 	return (
 		<div className={ styles.preview } inert>
 			<Suspense fallback={ null }>
-				<WidgetRender widget={ exampleWidget } widgetType={ item } />
+				<DashboardWidgetRender
+					widget={ exampleWidget }
+					widgetType={ item }
+				/>
 			</Suspense>
 		</div>
 	);

--- a/routes/dashboard/widget-dashboard/components/widget-render/index.ts
+++ b/routes/dashboard/widget-dashboard/components/widget-render/index.ts
@@ -1,1 +1,1 @@
-export { WidgetRender } from './widget-render';
+export { DashboardWidgetRender } from './widget-render';

--- a/routes/dashboard/widget-dashboard/components/widget-render/widget-render.tsx
+++ b/routes/dashboard/widget-dashboard/components/widget-render/widget-render.tsx
@@ -7,23 +7,27 @@ import { useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import { useDashboardInternalContext } from '../../context/dashboard-context';
-import { getLazyWidgetComponent } from '../../../widget-primitives';
+import { WidgetRender } from '../../../widget-primitives';
 import type { DashboardWidget } from '../../types';
 import type { WidgetType } from '../../../widget-primitives';
 
-interface WidgetRenderInternalProps {
+interface DashboardWidgetRenderProps {
 	widget: DashboardWidget< unknown >;
 	widgetType: WidgetType;
 }
 
-function WidgetRenderImpl( { widget, widgetType }: WidgetRenderInternalProps ) {
+/*
+ * Dashboard-specific adapter around the host-agnostic `WidgetRender`
+ * primitive. Bridges the dashboard context (`resolveWidgetModule`, layout
+ * state) and turns layout-level attribute updates into the per-instance
+ * `setAttributes` callback the render contract expects.
+ */
+export function DashboardWidgetRender( {
+	widget,
+	widgetType,
+}: DashboardWidgetRenderProps ) {
 	const { layout, onLayoutChange, resolveWidgetModule } =
 		useDashboardInternalContext();
-
-	const WidgetComponent = getLazyWidgetComponent(
-		widgetType.renderModule,
-		resolveWidgetModule
-	);
 
 	const setAttributes = useCallback(
 		( next: Partial< unknown > ) => {
@@ -45,25 +49,11 @@ function WidgetRenderImpl( { widget, widgetType }: WidgetRenderInternalProps ) {
 	);
 
 	return (
-		<>
-			{ /* WidgetComponent is a cached `lazy()` keyed by renderModule, so its identity stays stable across renders. */ }
-			{ /* eslint-disable-next-line react-hooks/static-components */ }
-			<WidgetComponent
-				attributes={ widget.attributes }
-				setAttributes={ setAttributes }
-			/>
-		</>
+		<WidgetRender
+			widgetType={ widgetType }
+			attributes={ widget.attributes }
+			setAttributes={ setAttributes }
+			resolveWidgetModule={ resolveWidgetModule }
+		/>
 	);
 }
-
-/**
- * Resolves a widget's render module via the configured resolver and renders
- * it with the minimal `WidgetRenderProps` contract: `attributes` plus
- * `setAttributes`. Suspense and error handling live one layer up in
- * `DashboardWidgetChrome`, so a failing or pending body does not tear down
- * the surrounding header or controls.
- *
- * Kept internal to the package. Surfaces that want bare widget rendering
- * should compose `DashboardWidgetChrome` instead.
- */
-export const WidgetRender = WidgetRenderImpl;

--- a/routes/dashboard/widget-primitives/README.md
+++ b/routes/dashboard/widget-primitives/README.md
@@ -36,10 +36,6 @@ neither side has to know about the other:
 - Contract types: `WidgetType`, `WidgetName`, `WidgetRenderProps`,
   `ResolveWidgetModule`.
 
-Anything not exported here (for example `WidgetTypeMetadata`,
-`getLazyWidgetComponent`, or the internal `WidgetModule` shape) is an
-implementation detail and should not be imported from outside the kit.
-
 ## How discovery works
 
 The data flow uses `@wordpress/core-data` and dynamic module imports. There is
@@ -74,5 +70,4 @@ when to import; they do not register widgets.
 This module lives inside the dashboard route while its API stabilizes. Because
 both hosts and widget authors consume it, its destination is a top-level,
 private (unpublished) package, `@wordpress/widget-primitives`, in the same vein as
-`@wordpress/grid`. The current layout (`index.ts`, `types.ts`, `hooks/`,
-`tools/`) already matches that future shape.
+`@wordpress/grid`.

--- a/routes/dashboard/widget-primitives/README.md
+++ b/routes/dashboard/widget-primitives/README.md
@@ -26,6 +26,11 @@ neither side has to know about the other:
 
 ## Public API
 
+- `<WidgetRender>`: canonical entry point for any host that mounts a widget.
+  Resolves the widget's render module via a host-provided `resolveWidgetModule`
+  and mounts the resulting component with the standard `attributes` plus
+  `setAttributes` render contract. Suspense, error handling, and chrome are
+  host concerns and live outside the primitive.
 - `useWidgetTypes()` → `[ widgetTypes, isResolvingWidgetTypes ]`: the
   `WidgetType[]` available on the current page, plus a flag that is true while
   they are still resolving.

--- a/routes/dashboard/widget-primitives/README.md
+++ b/routes/dashboard/widget-primitives/README.md
@@ -12,17 +12,16 @@ dashboard today, a sidebar or an inspector tomorrow). `widget-primitives` sits b
 the build pipeline that produces widgets and the hosts that render them, so
 neither side has to know about the other:
 
-- **Contract.** It defines the widget type shape (`WidgetType`,
-  `WidgetTypeMetadata`, `WidgetName`) and the render contract
-  (`WidgetRenderProps`). Authors type their `widget.ts` / `render.tsx` against
-  these, and hosts consume the same types. Nothing re-exports them: every
-  consumer imports from `widget-primitives` directly, so the source of truth stays in
-  one place.
+- **Contract.** It defines the widget type shape (`WidgetType`, `WidgetName`)
+  and the render contract (`WidgetRenderProps`). Authors type their
+  `widget.ts` / `render.tsx` against these, and hosts consume the same types.
+  Nothing re-exports them: every consumer imports from `widget-primitives`
+  directly, so the source of truth stays in one place.
 - **Discovery.** `useWidgetTypes()` returns the `WidgetType[]` registered on the
   current page.
-- **Resolution.** `getLazyWidgetComponent()` resolves a widget's render module
-  to a cached `lazy()` component, so any host can mount a widget body under
-  Suspense.
+- **Rendering.** `<WidgetRender>` resolves a widget's render module via a
+  host-provided resolver and mounts the resulting component under the host's
+  Suspense boundary.
 
 ## Public API
 
@@ -34,12 +33,11 @@ neither side has to know about the other:
 - `useWidgetTypes()` → `[ widgetTypes, isResolvingWidgetTypes ]`: the
   `WidgetType[]` available on the current page, plus a flag that is true while
   they are still resolving.
-- `getLazyWidgetComponent( renderModule, resolveWidgetModule )`: a cached
-  `lazy()` React component for a widget's render module.
-- Contract types: `WidgetType`, `WidgetTypeMetadata`, `WidgetName`,
-  `WidgetRenderProps`, `ResolveWidgetModule`.
+- Contract types: `WidgetType`, `WidgetName`, `WidgetRenderProps`,
+  `ResolveWidgetModule`.
 
-Anything not exported here (for example the internal `WidgetModule` shape) is an
+Anything not exported here (for example `WidgetTypeMetadata`,
+`getLazyWidgetComponent`, or the internal `WidgetModule` shape) is an
 implementation detail and should not be imported from outside the kit.
 
 ## How discovery works

--- a/routes/dashboard/widget-primitives/components/widget-render/index.ts
+++ b/routes/dashboard/widget-primitives/components/widget-render/index.ts
@@ -1,0 +1,1 @@
+export { WidgetRender } from './widget-render';

--- a/routes/dashboard/widget-primitives/components/widget-render/widget-render.tsx
+++ b/routes/dashboard/widget-primitives/components/widget-render/widget-render.tsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getLazyWidgetComponent } from '../../tools/get-lazy-widget-component';
+import type { ResolveWidgetModule, WidgetType } from '../../types';
+
+interface WidgetRenderProps< Item = unknown > {
+	/**
+	 * The widget type to render.
+	 */
+	widgetType: WidgetType< Item >;
+
+	/**
+	 * Attributes the widget renders with.
+	 */
+	attributes?: Item;
+
+	/**
+	 * Callback to update the widget's attributes.
+	 */
+	setAttributes?: ( next: Partial< Item > ) => void;
+
+	/*
+	 * Host-provided resolver for the `renderModule` script. Required
+	 * because `getLazyWidgetComponent` does not default it; hosts that
+	 * want the standard dynamic-import behavior can pass it directly.
+	 */
+	resolveWidgetModule: ResolveWidgetModule;
+}
+
+/*
+ * Host-agnostic render entry point for any widget type. Resolves the
+ * widget's `renderModule` through the host-provided
+ * `resolveWidgetModule` and mounts the resulting component with the
+ * standard `attributes` plus `setAttributes` render contract.
+ */
+export function WidgetRender< Item = unknown >( {
+	widgetType,
+	attributes,
+	setAttributes,
+	resolveWidgetModule,
+}: WidgetRenderProps< Item > ) {
+	const WidgetComponent = getLazyWidgetComponent(
+		widgetType.renderModule,
+		resolveWidgetModule
+	);
+
+	return (
+		<>
+			{ /* WidgetComponent is a cached `lazy()` keyed by renderModule, so its identity stays stable across renders. */ }
+			{ /* eslint-disable-next-line react-hooks/static-components */ }
+			<WidgetComponent
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
+		</>
+	);
+}

--- a/routes/dashboard/widget-primitives/components/widget-render/widget-render.tsx
+++ b/routes/dashboard/widget-primitives/components/widget-render/widget-render.tsx
@@ -9,26 +9,9 @@ import { getLazyWidgetComponent } from '../../tools/get-lazy-widget-component';
 import type { ResolveWidgetModule, WidgetType } from '../../types';
 
 interface WidgetRenderProps< Item = unknown > {
-	/**
-	 * The widget type to render.
-	 */
 	widgetType: WidgetType< Item >;
-
-	/**
-	 * Attributes the widget renders with.
-	 */
 	attributes?: Item;
-
-	/**
-	 * Callback to update the widget's attributes.
-	 */
 	setAttributes?: ( next: Partial< Item > ) => void;
-
-	/*
-	 * Host-provided resolver for the `renderModule` script. Required
-	 * because `getLazyWidgetComponent` does not default it; hosts that
-	 * want the standard dynamic-import behavior can pass it directly.
-	 */
 	resolveWidgetModule: ResolveWidgetModule;
 }
 

--- a/routes/dashboard/widget-primitives/hooks/use-widget-types.ts
+++ b/routes/dashboard/widget-primitives/hooks/use-widget-types.ts
@@ -43,11 +43,9 @@ interface WidgetModuleRecord {
 }
 
 /**
- * Tuple of `[ widgetTypes, isResolvingWidgetTypes ]`.
- *
- * The boolean is true while widget-module records or their metadata imports
- * have not finished resolving. Layout instances must not be treated as missing
- * until it is false.
+ * `isResolvingWidgetTypes` is true while widget-module records or their
+ * metadata imports have not finished resolving. Layout instances must not
+ * be treated as missing until it is false.
  */
 export type UseWidgetTypesResult = readonly [ WidgetType[], boolean ];
 

--- a/routes/dashboard/widget-primitives/index.ts
+++ b/routes/dashboard/widget-primitives/index.ts
@@ -1,4 +1,9 @@
 /**
+ * Components
+ */
+export { WidgetRender } from './components/widget-render';
+
+/**
  * Hooks
  */
 export { useWidgetTypes } from './hooks';

--- a/routes/dashboard/widget-primitives/index.ts
+++ b/routes/dashboard/widget-primitives/index.ts
@@ -9,16 +9,10 @@ export { WidgetRender } from './components/widget-render';
 export { useWidgetTypes } from './hooks';
 
 /**
- * Tools
- */
-export { getLazyWidgetComponent } from './tools/get-lazy-widget-component';
-
-/**
  * Types
  */
 export type {
 	WidgetName,
-	WidgetTypeMetadata,
 	WidgetType,
 	WidgetRenderProps,
 	ResolveWidgetModule,

--- a/routes/dashboard/widget-primitives/tools/get-lazy-widget-component/get-lazy-widget-component.ts
+++ b/routes/dashboard/widget-primitives/tools/get-lazy-widget-component/get-lazy-widget-component.ts
@@ -36,13 +36,11 @@ function isValidWidgetModule( module: unknown ): module is WidgetModule {
  */
 const componentCache = new Map< string, LazyWidgetComponent >();
 
-/**
+/*
  * Resolve a widget render module to a `lazy()` React component, cached by
  * `renderModule` id. The first call for a given id builds the lazy wrapper
  * around the resolver; subsequent calls return the same instance so that
  * hosts and Suspense boundaries can rely on a stable component identity.
- * @param renderModule
- * @param resolveWidgetModule
  */
 export function getLazyWidgetComponent(
 	renderModule: string,

--- a/routes/dashboard/widget-primitives/types.ts
+++ b/routes/dashboard/widget-primitives/types.ts
@@ -1,9 +1,8 @@
 /**
  * Widget type definitions.
  *
- * Canonical home for widget identity types consumed by the registry,
- * hosts that render widgets, and tools that author them
- * (`@wordpress/build`, schema validators, IDE autocomplete).
+ * Canonical home for widget identity types consumed by the registry and
+ * hosts that render widgets.
  *
  * Each type is generic over the widget's attribute object (`Item`) so a
  * widget binds its own attribute shape once and gets typed `attributes`,
@@ -21,9 +20,7 @@ type IconProps = ComponentProps< typeof Icon >;
 
 /**
  * Widget type identifier, structured as `<widget-namespace>/<widget-name>`.
- * Both segments are lowercase, kebab-case; the full character pattern is
- * enforced by the `widget.json` schema at authoring time and validated at
- * registration time by `WIDGET_NAME_REGEXP` in `registerWidgetType`.
+ * Both segments are lowercase, kebab-case.
  */
 export type WidgetName = `${ string }/${ string }`;
 
@@ -34,7 +31,6 @@ export type WidgetName = `${ string }/${ string }`;
  * assets are discovered by convention from the widget directory
  * (`render.*`, `widget.*`, `render.scss`), not declared here.
  *
- * Consumed by tooling (IDE autocomplete, validation, the build pipeline).
  * Hosts that render widgets consume the richer `WidgetType` below,
  * which extends this shape with runtime-only fields produced by the
  * build manifest.
@@ -130,7 +126,7 @@ export interface WidgetTypeMetadata< Item = unknown > {
  * entry point.
  *
  * The PHP layer (`widget-types.php`) emits this data in snake_case
- * (`render_module`). The `getWidgetTypes` resolver is the single boundary
+ * (`render_module`). The `useWidgetTypes` hook is the single boundary
  * that maps it to the camelCase shape consumed throughout JS/TS.
  */
 export interface WidgetType< Item = unknown >
@@ -138,7 +134,7 @@ export interface WidgetType< Item = unknown >
 	/**
 	 * Script-module identifier resolved to a React component at render
 	 * time. Produced by the build pipeline from the conventional
-	 * `render.*` / `widget.*` entry points; not declared in `widget.json`.
+	 * `render.*` entry point; not declared in `widget.json`.
 	 */
 	renderModule: string;
 }
@@ -171,9 +167,9 @@ export interface WidgetModule {
 }
 
 /**
- * Resolver hook: maps a `WidgetType.renderModule` id to a React component.
- * Defaults to a dynamic `import()`; override for tests, Storybook, or to load
- * from a non-URL source.
+ * Resolver function: maps a `WidgetType.renderModule` id to a React
+ * component. Override for tests, Storybook, or to load from a non-URL
+ * source.
  */
 export type ResolveWidgetModule = (
 	moduleId: string


### PR DESCRIPTION
## What?

Makes a host-agnostic `<WidgetRender>` available from `widget-primitives` and reduces the dashboard's existing `WidgetRender` to a thin adapter (`DashboardWidgetRender`) that supplies the dashboard-specific bits.

Same change also narrows the `widget-primitives` public API to the symbols its consumers actually use, and trims stale or speculative documentation across the kit.

Pure refactor: no behavior change in the dashboard.

## Why?

`widget-primitives` is positioned as the host-agnostic toolkit for dashboard widgets, but until this PR the code that mounts a widget lived inside the dashboard route. Any future host (a sidebar, an inserter, a future digest area) had to copy the dashboard wrapper to reuse the host-agnostic part.

Promoting the host-agnostic render path into `widget-primitives` gives any host a single, canonical entry point. The dashboard wrapper keeps only its host-specific concerns: pulling state from `useDashboardInternalContext()` and dispatching attribute updates against the dashboard layout.

In the same pass, the kit's public API is trimmed back to what its consumers (the dashboard host today, and any future host tomorrow) actually need; and a small cluster of doc references that pointed at non-existent symbols or speculated about future tooling is cleaned up.

## How?

1. **New host-agnostic component.** `<WidgetRender>` lives at `routes/dashboard/widget-primitives/components/widget-render/` and exposes the standard render contract: `widgetType`, `attributes`, `setAttributes`, `resolveWidgetModule`. Suspense, error handling, and chrome stay host concerns and are not part of the primitive.
2. **Dashboard adapter.** `routes/dashboard/widget-dashboard/components/widget-render/` renames its export to `DashboardWidgetRender`. The wrapper now does two things only: bridge the dashboard context and build the per-instance `setAttributes` callback. Consumers `dashboard-widget-chrome` and `widget-picker` are updated to the new name.
3. **Public API narrowed.** `widget-primitives` stops exporting `getLazyWidgetComponent` (now only consumed by the kit's own `WidgetRender`) and `WidgetTypeMetadata` (no external consumer; widget authors do not annotate `widget.ts` with it under the current convention). The package surface is now: `<WidgetRender>`, `useWidgetTypes()`, and the contract types `WidgetType`, `WidgetName`, `WidgetRenderProps`, `ResolveWidgetModule`.
4. **Doc trim.** Across `README.md`, `types.ts`, the hook, the tool, and the new component:
    - Broken symbol references are fixed (`WIDGET_NAME_REGEXP in registerWidgetType`, `getWidgetTypes` resolver, neither exists; the actual mechanisms are `WP_Widget_Type_Registry::register()` and the `useWidgetTypes` hook).
    - Speculative tooling-consumer lists are dropped (no tooling imports those TS types today).
    - Restatement-style JSDoc is removed.
    - An out-of-date folder enumeration in the README is removed.

## Testing Instructions

1. Build the dashboard route and load it.
2. Confirm widgets render exactly as before. No console warnings.
3. Open the widget picker (inserter) and confirm widget previews still render.
4. Edit a widget setting and confirm the attribute update flows through.

Automated coverage: existing JS unit tests in `routes/dashboard/widget-dashboard/test/{widget-dashboard,widget-settings,inserter}.test.tsx` pass without code changes, because they consume the contract types from `widget-primitives` and those are unchanged.

### Testing Instructions for Keyboard

No UI changes. Existing keyboard behavior in the dashboard and the widget picker is unaffected.