### PR TITLE
Build: Document the hooks generated by the wp-build page templates

### DIFF
--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -134,7 +134,9 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suf
 	// Load build constants
 	$build_constants = require __DIR__ . '/../../constants.php';
 
-	// Fire init action for extensions to register routes and menu items
+	/**
+	 * Fires when the {{PAGE_SLUG}} admin page is initialized so extensions can register routes and menu items.
+	 */
 	do_action( '{{PAGE_SLUG}}-wp-admin_init' );
 
 	// Preload REST API data

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -134,7 +134,9 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
 		wp_dequeue_style( $style );
 	}
 
-	// Fire init action for extensions to register routes and menu items
+	/**
+	 * Fires when the {{PAGE_SLUG}} page is initialized so extensions can register routes and menu items.
+	 */
 	do_action( '{{PAGE_SLUG}}_init' );
 
 	// Enqueue command palette assets for boot-based pages
@@ -267,18 +269,10 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
 	print_admin_styles();
 	print_head_scripts();
 
-	/**
-	 * Fires in head section for a specific admin page.
-	 *
-	 * @since 2.1.0
-	 */
+	/** This action is documented in wp-admin/admin-header.php */
 	do_action( "admin_head-{$hook_suffix}" ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 
-	/**
-	 * Fires in head section for all admin pages.
-	 *
-	 * @since 2.1.0
-	 */
+	/** This action is documented in wp-admin/admin-header.php */
 	do_action( 'admin_head' );
 	// END see wp-admin/admin-header.php
 	?>
@@ -288,11 +282,7 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
 	<?php
 	// BEGIN see wp-admin/admin-footer.php
 
-	/**
-	 * Prints scripts or data before the default footer scripts.
-	 *
-	 * @since 1.2.0
-	 */
+	/** This action is documented in wp-admin/admin-footer.php */
 	do_action( 'admin_footer', '' );
 
 	// Print import map first so it's available for inline scripts
@@ -302,11 +292,7 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
 	wp_script_modules()->print_script_module_preloads();
 	wp_script_modules()->print_script_module_data();
 
-	/**
-	 * Prints scripts or data after the default footer scripts.
-	 *
-	 * @since 2.8.0
-	 */
+	/** This action is documented in wp-admin/admin-footer.php */
 	do_action( "admin_footer-{$hook_suffix}" ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 	// END see wp-admin/admin-footer.php
 	?>


### PR DESCRIPTION
## What?

Follow up to #73120 and #73137.

The `@wordpress/build` page templates generate PHP files (output under `wp-includes/build/pages/…`) that invoke action hooks. This PR brings those hooks in line with the [WordPress PHP documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#4-hooks-actions-and-filters):

- Add a DocBlock for the per-page init action (`{page_slug}_init` in `page.php.template`, `{page_slug}-wp-admin_init` in `page-wp-admin.php.template`), which previously had only a `//` line comment.
- Replace the duplicated copies of core hook DocBlocks (`admin_head`, `admin_head-{$hook_suffix}`, `admin_footer`, `admin_footer-{$hook_suffix}`) in `page.php.template` with the standard `/** This action is documented in … */` reference comments.

No behavior changes — documentation only.

## Why?

Every action and filter should be documented, either with an inline DocBlock or, when the hook is documented elsewhere, with a `This action/filter is documented in <file>` reference comment. The page templates currently fall short in two ways:

1. **The init actions are undocumented.** `{page_slug}_init` / `{page_slug}-wp-admin_init` carry only a `// Fire init action…` line comment, so every generated page ships an undocumented hook.
2. **Core hook DocBlocks are duplicated.** The admin-header/admin-footer emulation region copies core's DocBlocks for `admin_head`, `admin_footer`, and their `-{$hook_suffix}` variants verbatim. These hooks are defined and documented in `wp-admin/admin-header.php` and `wp-admin/admin-footer.php`; core itself never duplicates a hook's DocBlock and instead uses the "documented in" reference. Duplicating risks the copies drifting from the canonical documentation and misrepresents where the hooks are defined.

(For context, a PHPStan rule being added on the WordPress core side flags exactly these two patterns, which is how they surfaced.)

## How?

- Added a DocBlock above the init `do_action()` in both page templates. **No `@since` is included**: a single shared template generates pages introduced in different versions, so no single version would be correct for the substituted hook name.
- Replaced the four duplicated core DocBlocks in `page.php.template` with `/** This action is documented in wp-admin/admin-header.php */` and `/** This action is documented in wp-admin/admin-footer.php */` as appropriate.
- Left the `{page_slug}_boot_dependencies` filter's DocBlock untouched — it is a genuinely new, page-specific filter (not a re-fire of a core hook), so its inline DocBlock is the canonical documentation and is correct as-is.

## Testing Instructions

This is a documentation-only change to the build templates; there is no runtime behavior change.

1. Run a production build: `npm run build`.
2. Inspect a generated page, e.g. `build/pages/font-library/page.php`:
   - The init `do_action( 'font-library_init' )` is now preceded by a `/** … */` DocBlock.
   - The `admin_head`, `admin_head-{$hook_suffix}`, `admin_footer`, and `admin_footer-{$hook_suffix}` calls are now preceded by `/** This action is documented in … */` reference comments instead of copied DocBlocks.
3. Inspect a wp-admin page, e.g. `build/pages/.../page-wp-admin.php`, and confirm the `…-wp-admin_init` action now has a DocBlock.

### Testing Instructions for Keyboard

N/A — no UI changes.

## Screenshots or screencast

N/A — documentation-only change to generated PHP.

## Use of AI Tools

This pull request was authored with the assistance of Claude Code (Claude Opus). All changes were reviewed by the contributor, who takes responsibility for them.