### PR TITLE
Border Panel: Fix incorrect panel label

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -49,13 +49,12 @@ import {
 import { onViewportStateChangeKey } from '../../store/private-keys';
 
 function StyleInspectorSlots( {
-	blockName,
 	clientId,
 	showAdvancedControls = true,
 	showPositionControls = true,
 	showBindingsControls = true,
 } ) {
-	const borderPanelLabel = useBorderPanelLabel( { blockName, clientId } );
+	const borderPanelLabel = useBorderPanelLabel( { clientId } );
 	return (
 		<>
 			<InspectorControls.Slot />
@@ -93,12 +92,8 @@ function StyleInspectorSlots( {
 	);
 }
 
-function StyleStateInspectorSlots( {
-	blockName,
-	clientId,
-	selectedBlockStyleState,
-} ) {
-	const borderPanelLabel = useBorderPanelLabel( { blockName, clientId } );
+function StyleStateInspectorSlots( { clientId, selectedBlockStyleState } ) {
+	const borderPanelLabel = useBorderPanelLabel( { clientId } );
 	const showLayoutControls =
 		hasViewportBlockStyleState( selectedBlockStyleState ) &&
 		! hasPseudoBlockStyleState( selectedBlockStyleState );
@@ -281,7 +276,6 @@ function BlockInspector() {
 					<InspectorControlsTabs tabs={ availableTabs } />
 				) : (
 					<StyleInspectorSlots
-						blockName={ renderedBlockName }
 						showAdvancedControls={ false }
 						showPositionControls={ false }
 						showBindingsControls={ false }
@@ -496,7 +490,6 @@ const BlockInspectorSingleBlock = ( {
 			<BlockInspectorPreTabsSlot />
 			{ isBlockStyleStateSelected && ! isSectionBlock && (
 				<StyleStateInspectorSlots
-					blockName={ blockName }
 					clientId={ renderedBlockClientId }
 					selectedBlockStyleState={ selectedBlockStyleState }
 				/>
@@ -524,7 +517,6 @@ const BlockInspectorSingleBlock = ( {
 					<ListViewContentPopover listViewRef={ listViewRef } />
 					{ ! isSectionBlock && (
 						<StyleInspectorSlots
-							blockName={ blockName }
 							clientId={ renderedBlockClientId }
 						/>
 					) }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -50,11 +50,12 @@ import { onViewportStateChangeKey } from '../../store/private-keys';
 
 function StyleInspectorSlots( {
 	blockName,
+	clientId,
 	showAdvancedControls = true,
 	showPositionControls = true,
 	showBindingsControls = true,
 } ) {
-	const borderPanelLabel = useBorderPanelLabel( { blockName } );
+	const borderPanelLabel = useBorderPanelLabel( { blockName, clientId } );
 	return (
 		<>
 			<InspectorControls.Slot />
@@ -92,8 +93,12 @@ function StyleInspectorSlots( {
 	);
 }
 
-function StyleStateInspectorSlots( { blockName, selectedBlockStyleState } ) {
-	const borderPanelLabel = useBorderPanelLabel( { blockName } );
+function StyleStateInspectorSlots( {
+	blockName,
+	clientId,
+	selectedBlockStyleState,
+} ) {
+	const borderPanelLabel = useBorderPanelLabel( { blockName, clientId } );
 	const showLayoutControls =
 		hasViewportBlockStyleState( selectedBlockStyleState ) &&
 		! hasPseudoBlockStyleState( selectedBlockStyleState );
@@ -492,6 +497,7 @@ const BlockInspectorSingleBlock = ( {
 			{ isBlockStyleStateSelected && ! isSectionBlock && (
 				<StyleStateInspectorSlots
 					blockName={ blockName }
+					clientId={ renderedBlockClientId }
 					selectedBlockStyleState={ selectedBlockStyleState }
 				/>
 			) }
@@ -517,7 +523,10 @@ const BlockInspectorSingleBlock = ( {
 					<InspectorControls.Slot group="list" ref={ listViewRef } />
 					<ListViewContentPopover listViewRef={ listViewRef } />
 					{ ! isSectionBlock && (
-						<StyleInspectorSlots blockName={ blockName } />
+						<StyleInspectorSlots
+							blockName={ blockName }
+							clientId={ renderedBlockClientId }
+						/>
 					) }
 				</>
 			) }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -42,13 +42,12 @@ import {
 } from '../../hooks/block-style-state';
 
 function StyleInspectorSlots( {
-	blockName,
 	clientId,
 	showAdvancedControls = true,
 	showPositionControls = true,
 	showBindingsControls = true,
 } ) {
-	const borderPanelLabel = useBorderPanelLabel( { blockName, clientId } );
+	const borderPanelLabel = useBorderPanelLabel( { clientId } );
 	return (
 		<>
 			<InspectorControls.Slot />
@@ -98,7 +97,7 @@ function StyleStateInspectorSlots( {
 	isSectionBlock,
 	selectedBlockStyleState,
 } ) {
-	const borderPanelLabel = useBorderPanelLabel( { blockName, clientId } );
+	const borderPanelLabel = useBorderPanelLabel( { clientId } );
 	const showLayoutControls =
 		hasViewportBlockStyleState( selectedBlockStyleState ) &&
 		! hasPseudoBlockStyleState( selectedBlockStyleState );
@@ -299,7 +298,6 @@ function BlockInspector() {
 					<InspectorControlsTabs tabs={ availableTabs } />
 				) : (
 					<StyleInspectorSlots
-						blockName={ renderedBlockName }
 						showAdvancedControls={ false }
 						showPositionControls={ false }
 						showBindingsControls={ false }
@@ -502,7 +500,6 @@ const BlockInspectorSingleBlock = ( {
 			<BlockInspectorPreTabsSlot />
 			{ isEditingStyleState && (
 				<StyleStateInspectorSlots
-					blockName={ blockName }
 					clientId={ renderedBlockClientId }
 					contentClientIds={ contentClientIds }
 					isSectionBlock={ isSectionBlock }
@@ -532,7 +529,6 @@ const BlockInspectorSingleBlock = ( {
 					<ListViewContentPopover listViewRef={ listViewRef } />
 					{ ! isSectionBlock && (
 						<StyleInspectorSlots
-							blockName={ blockName }
 							clientId={ renderedBlockClientId }
 						/>
 					) }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -43,11 +43,12 @@ import {
 
 function StyleInspectorSlots( {
 	blockName,
+	clientId,
 	showAdvancedControls = true,
 	showPositionControls = true,
 	showBindingsControls = true,
 } ) {
-	const borderPanelLabel = useBorderPanelLabel( { blockName } );
+	const borderPanelLabel = useBorderPanelLabel( { blockName, clientId } );
 	return (
 		<>
 			<InspectorControls.Slot />
@@ -97,7 +98,7 @@ function StyleStateInspectorSlots( {
 	isSectionBlock,
 	selectedBlockStyleState,
 } ) {
-	const borderPanelLabel = useBorderPanelLabel( { blockName } );
+	const borderPanelLabel = useBorderPanelLabel( { blockName, clientId } );
 	const showLayoutControls =
 		hasViewportBlockStyleState( selectedBlockStyleState ) &&
 		! hasPseudoBlockStyleState( selectedBlockStyleState );
@@ -530,7 +531,10 @@ const BlockInspectorSingleBlock = ( {
 					<InspectorControls.Slot group="list" ref={ listViewRef } />
 					<ListViewContentPopover listViewRef={ listViewRef } />
 					{ ! isSectionBlock && (
-						<StyleInspectorSlots blockName={ blockName } />
+						<StyleInspectorSlots
+							blockName={ blockName }
+							clientId={ renderedBlockClientId }
+						/>
 					) }
 				</>
 			) }

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -98,7 +98,6 @@ export default function BorderPanel( {
 	inheritedValue = value,
 	settings,
 	panelId,
-	name,
 	defaultControls = DEFAULT_CONTROLS,
 	showInheritanceLabelIndicators = isGlobalStylesInheritanceEnabled(),
 } ) {
@@ -373,7 +372,6 @@ export default function BorderPanel( {
 		showBorderRadius;
 
 	const label = useBorderPanelLabel( {
-		blockName: name,
 		hasShadowControl,
 		hasBorderControl,
 	} );

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -101,7 +101,6 @@ export default function BorderPanel( {
 	inheritedValue = value,
 	settings,
 	panelId,
-	name,
 	defaultControls = DEFAULT_CONTROLS,
 } ) {
 	const colors = useColorsPerOrigin( settings );
@@ -247,7 +246,6 @@ export default function BorderPanel( {
 		showBorderRadius;
 
 	const label = useBorderPanelLabel( {
-		blockName: name,
 		hasShadowControl,
 		hasBorderControl,
 	} );

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -67,7 +67,7 @@ const StylesTab = ( {
 	isSectionBlock,
 	contentClientIds,
 } ) => {
-	const borderPanelLabel = useBorderPanelLabel( { blockName, clientId } );
+	const borderPanelLabel = useBorderPanelLabel( { clientId } );
 
 	return (
 		<>

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -67,7 +67,7 @@ const StylesTab = ( {
 	isSectionBlock,
 	contentClientIds,
 } ) => {
-	const borderPanelLabel = useBorderPanelLabel( { blockName } );
+	const borderPanelLabel = useBorderPanelLabel( { blockName, clientId } );
 
 	return (
 		<>

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -103,7 +103,7 @@ const StylesTab = ( {
 	isSectionBlock,
 	contentClientIds,
 } ) => {
-	const borderPanelLabel = useBorderPanelLabel( { blockName, clientId } );
+	const borderPanelLabel = useBorderPanelLabel( { clientId } );
 
 	return (
 		<>

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -103,7 +103,7 @@ const StylesTab = ( {
 	isSectionBlock,
 	contentClientIds,
 } ) => {
-	const borderPanelLabel = useBorderPanelLabel( { blockName } );
+	const borderPanelLabel = useBorderPanelLabel( { blockName, clientId } );
 
 	return (
 		<>

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -19,11 +19,7 @@ import { __ } from '@wordpress/i18n';
 import { getColorClassName } from '../components/colors';
 import InspectorControls from '../components/inspector-controls';
 import useMultipleOriginColorsAndGradients from '../components/colors-gradients/use-multiple-origin-colors-and-gradients';
-import {
-	cleanEmptyObject,
-	shouldSkipSerialization,
-	useBlockSettings,
-} from './utils';
+import { cleanEmptyObject, shouldSkipSerialization } from './utils';
 import {
 	useHasBorderPanel,
 	useHasBorderPanelControls,
@@ -36,6 +32,7 @@ import {
 	setStyleForState,
 	useBlockStyleState,
 } from './block-style-state';
+import { unlock } from '../lock-unlock';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
 export const SHADOW_SUPPORT_KEY = 'shadow';
@@ -252,10 +249,28 @@ export function hasShadowSupport( blockName ) {
 
 export function useBorderPanelLabel( {
 	blockName,
+	clientId,
 	hasBorderControl,
 	hasShadowControl,
 } = {} ) {
-	const settings = useBlockSettings( blockName );
+	const settings = useSelect(
+		( select ) => {
+			if ( ! clientId ) {
+				return null;
+			}
+			const { getBlockSettings } = unlock( select( blockEditorStore ) );
+			const [ color, radius, style, width, shadow ] = getBlockSettings(
+				clientId,
+				'border.color',
+				'border.radius',
+				'border.style',
+				'border.width',
+				'shadow'
+			);
+			return { border: { color, radius, style, width }, shadow };
+		},
+		[ clientId ]
+	);
 	const controls = useHasBorderPanelControls( settings );
 
 	if ( ! hasBorderControl && ! hasShadowControl && blockName ) {

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -250,7 +250,6 @@ export function hasShadowSupport( blockName ) {
 }
 
 export function useBorderPanelLabel( {
-	blockName,
 	clientId,
 	hasBorderControl,
 	hasShadowControl,
@@ -275,7 +274,7 @@ export function useBorderPanelLabel( {
 	const settings = { border: { color, radius, style, width }, shadow };
 	const controls = useHasBorderPanelControls( settings );
 
-	if ( ! hasBorderControl && ! hasShadowControl && blockName ) {
+	if ( ! hasBorderControl && ! hasShadowControl && clientId ) {
 		hasBorderControl =
 			controls?.hasBorderColor ||
 			controls?.hasBorderStyle ||

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -37,6 +37,8 @@ import { unlock } from '../lock-unlock';
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
 export const SHADOW_SUPPORT_KEY = 'shadow';
 
+const EMPTY_ARRAY = [];
+
 const getColorByProperty = ( colors, property, value ) => {
 	let matchedColor;
 
@@ -253,13 +255,13 @@ export function useBorderPanelLabel( {
 	hasBorderControl,
 	hasShadowControl,
 } = {} ) {
-	const settings = useSelect(
+	const [ color, radius, style, width, shadow ] = useSelect(
 		( select ) => {
 			if ( ! clientId ) {
-				return null;
+				return EMPTY_ARRAY;
 			}
 			const { getBlockSettings } = unlock( select( blockEditorStore ) );
-			const [ color, radius, style, width, shadow ] = getBlockSettings(
+			return getBlockSettings(
 				clientId,
 				'border.color',
 				'border.radius',
@@ -267,10 +269,10 @@ export function useBorderPanelLabel( {
 				'border.width',
 				'shadow'
 			);
-			return { border: { color, radius, style, width }, shadow };
 		},
 		[ clientId ]
 	);
+	const settings = { border: { color, radius, style, width }, shadow };
 	const controls = useHasBorderPanelControls( settings );
 
 	if ( ! hasBorderControl && ! hasShadowControl && blockName ) {

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -271,7 +271,10 @@ export function useBorderPanelLabel( {
 		},
 		[ clientId ]
 	);
-	const settings = { border: { color, radius, style, width }, shadow };
+	const settings = useMemo(
+		() => ( { border: { color, radius, style, width }, shadow } ),
+		[ color, radius, style, width, shadow ]
+	);
 	const controls = useHasBorderPanelControls( settings );
 
 	if ( ! hasBorderControl && ! hasShadowControl && clientId ) {

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -8,11 +8,7 @@ import { __ } from '@wordpress/i18n';
 import { getColorClassName } from '../components/colors';
 import InspectorControls from '../components/inspector-controls';
 import useMultipleOriginColorsAndGradients from '../components/colors-gradients/use-multiple-origin-colors-and-gradients';
-import {
-	cleanEmptyObject,
-	shouldSkipSerialization,
-	useBlockSettings,
-} from './utils';
+import { cleanEmptyObject, shouldSkipSerialization } from './utils';
 import {
 	useHasBorderPanel,
 	useHasBorderPanelControls,
@@ -26,6 +22,7 @@ import {
 	setStyleForState,
 	useBlockStyleState,
 } from './block-style-state';
+import { unlock } from '../lock-unlock';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
 export const SHADOW_SUPPORT_KEY = 'shadow';
@@ -252,10 +249,28 @@ export function hasShadowSupport( blockName ) {
 
 export function useBorderPanelLabel( {
 	blockName,
+	clientId,
 	hasBorderControl,
 	hasShadowControl,
 } = {} ) {
-	const settings = useBlockSettings( blockName );
+	const settings = useSelect(
+		( select ) => {
+			if ( ! clientId ) {
+				return null;
+			}
+			const { getBlockSettings } = unlock( select( blockEditorStore ) );
+			const [ color, radius, style, width, shadow ] = getBlockSettings(
+				clientId,
+				'border.color',
+				'border.radius',
+				'border.style',
+				'border.width',
+				'shadow'
+			);
+			return { border: { color, radius, style, width }, shadow };
+		},
+		[ clientId ]
+	);
 	const controls = useHasBorderPanelControls( settings );
 
 	if ( ! hasBorderControl && ! hasShadowControl && blockName ) {

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -27,6 +27,8 @@ import { unlock } from '../lock-unlock';
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
 export const SHADOW_SUPPORT_KEY = 'shadow';
 
+const EMPTY_ARRAY = [];
+
 const getColorByProperty = ( colors, property, value ) => {
 	let matchedColor;
 
@@ -253,13 +255,13 @@ export function useBorderPanelLabel( {
 	hasBorderControl,
 	hasShadowControl,
 } = {} ) {
-	const settings = useSelect(
+	const [ color, radius, style, width, shadow ] = useSelect(
 		( select ) => {
 			if ( ! clientId ) {
-				return null;
+				return EMPTY_ARRAY;
 			}
 			const { getBlockSettings } = unlock( select( blockEditorStore ) );
-			const [ color, radius, style, width, shadow ] = getBlockSettings(
+			return getBlockSettings(
 				clientId,
 				'border.color',
 				'border.radius',
@@ -267,10 +269,10 @@ export function useBorderPanelLabel( {
 				'border.width',
 				'shadow'
 			);
-			return { border: { color, radius, style, width }, shadow };
 		},
 		[ clientId ]
 	);
+	const settings = { border: { color, radius, style, width }, shadow };
 	const controls = useHasBorderPanelControls( settings );
 
 	if ( ! hasBorderControl && ! hasShadowControl && blockName ) {


### PR DESCRIPTION
## What?

Closes #60192

Fixes an issue where the Border panel label incorrectly displays as "Shadow" instead of "Border & Shadow" in specific scenarios.

## Why?

The panel label is decided by which controls are shown. However, the place that computes the label did not receive the selected block's client ID. As a result, it could not read per-block setting overrides  and only looked at the global, site-wide settings.

When the `border` support is disabled globally but enabled per block, the label computation wrongly concluded "no border controls", so it showed "Shadow" whenever only shadow was enabled.

## How?

The label computation now receives the client ID and reads the selected block's settings directly. This makes the label match the controls the panel actually renders.

## Testing Instructions

1. Activate `emptytheme`.
2. In `test/emptytheme/theme.json`, remove the `"appearanceTools": true,` line.
3. Insert a Button block and select it.
4. Check the Border panel label in the right sidebar.
5. Confirm the label reads "Border & Shadow".

## Screenshots or screencast

|Before|After|
|-|-|
| <img width="783" height="319" alt="before" src="https://github.com/user-attachments/assets/8f27bdb8-ed7b-447b-9fa5-9ec2fd1eb915" /> | <img width="786" height="317" alt="after" src="https://github.com/user-attachments/assets/0754072d-6854-4046-832e-4023f135dd76" /> |

## Use of AI Tools

This PR was investigated, implemented, and drafted with the help of Claude Code (Claude Opus 4.8). The contents have been reviewed and are owned by the author.
