### PR TITLE
Inserter: don't scroll the category tab list when changing category

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-paging.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-paging.js
@@ -3,7 +3,6 @@
  */
 import { useMemo, useState, useEffect } from '@wordpress/element';
 import { usePrevious } from '@wordpress/compose';
-import { getScrollContainer } from '@wordpress/dom';
 
 const PAGE_SIZE = 20;
 
@@ -43,20 +42,14 @@ export default function usePatternsPaging(
 	}, [ pageIndex, currentCategoryPatterns ] );
 	const numPages = Math.ceil( currentCategoryPatterns.length / PAGE_SIZE );
 	const changePage = ( page ) => {
-		const scrollContainer = getScrollContainer(
-			scrollContainerRef?.current
-		);
-		scrollContainer?.scrollTo( 0, 0 );
+		scrollContainerRef?.current?.scrollTo( 0, 0 );
 
 		setCurrentPage( page );
 	};
 
 	useEffect(
 		function scrollToTopOnCategoryChange() {
-			const scrollContainer = getScrollContainer(
-				scrollContainerRef?.current
-			);
-			scrollContainer?.scrollTo( 0, 0 );
+			scrollContainerRef?.current?.scrollTo( 0, 0 );
 		},
 		[ currentCategory, scrollContainerRef ]
 	);


### PR DESCRIPTION
## What?

In the patterns inserter, clicking a category in the left tab list previously scrolled both sidebars to the top, making the user lose their place. After this change, only the right patterns previewer resets to the top; the left tab list stays exactly where the user scrolled it.

## Why?

`usePatternsPaging` reset the scroll position by calling `getScrollContainer( scrollContainerRef?.current )` and then `scrollTo( 0, 0 )` on the result. `getScrollContainer` returns the node itself if it is currently overflowing, otherwise walks up the DOM until it finds a scrollable ancestor.

When a category is changed, the patterns list it points at is freshly mounted and not necessarily overflowing yet. `getScrollContainer` then traversed up to an ancestor that wraps both the left category tab list and the right previewer panel. Scrolling that ancestor reset both sidebars.

## How?

Scroll the ref'd element directly: `scrollContainerRef?.current?.scrollTo( 0, 0 )`.

The ref is attached to `BlockPatternsList`'s root via `forwardRef`, and that root has `overflow-y: auto` in `style.scss`, so it is a valid scroll container in its own right. When it isn't currently overflowing, `scrollTo` is a harmless no-op. The same change is applied to `changePage`. The `getScrollContainer` import is no longer needed and has been removed.

## Testing Instructions

1. In a site with a block theme that has many pattern categories (e.g. Twenty Twenty-Four), open a new post in the block editor.
2. Open the inserter (`+` toolbar button) and switch to the Patterns tab.
3. In the left tab list, scroll down enough that the first few categories are out of view.
4. Click a different category further down the list.

Expected before: both sidebars jump to the top, the category you just clicked may slide out of view.
Expected after: the left tab list stays at the position you scrolled to; the right previewer resets to the top so the newly selected category's patterns are visible from the start.

Also verify pagination still resets the previewer:

5. Pick a category with more than 20 patterns.
6. Use the next-page control. The right previewer should scroll back to the top.

### Screenshots or screencast

Before: _to attach_
After: _to attach_

## Types of changes

Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code is tested (verified manually in the block editor with Twenty Twenty-Four).
- [x] My code follows the WordPress Coding Standards.
- [x] My code has proper inline documentation.