### PR TITLE
Interface: Prevent white flash when navigating into the editor

### DIFF
--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `FullscreenMode`: Keep the admin bar and admin menu painted while the editor is loading so a cross-document view transition into the editor no longer flashes a blank white screen ([#65294](https://core.trac.wordpress.org/ticket/65294)).
+
 ## 9.32.0 (2026-05-27)
 
 ## 9.31.0 (2026-05-14)

--- a/packages/interface/src/components/fullscreen-mode/style.scss
+++ b/packages/interface/src/components/fullscreen-mode/style.scss
@@ -20,3 +20,29 @@ body.js.is-fullscreen-mode {
 		}
 	}
 }
+
+// The `is-fullscreen-mode` body class is printed server-side, before the editor
+// has loaded, to avoid a layout jump once it mounts. Until the editor renders
+// its skeleton, however, hiding the admin bar and admin menu (and pulling the
+// content up over the toolbar gap) means a cross-document view transition into
+// the editor captures a fully blank page, producing a white flash.
+//
+// While the editor is still loading -- i.e. before the skeleton adds
+// `interface-interface-skeleton__html-container` to the `html` element -- keep
+// the admin bar and admin menu painted so only the empty content area appears
+// blank. This selector is mutually exclusive with the loaded state above, so it
+// does not affect the cascade once the editor is ready.
+//
+// See: https://core.trac.wordpress.org/ticket/65294
+html:not(.interface-interface-skeleton__html-container) body.js.is-fullscreen-mode {
+
+	@include break-medium {
+		margin-top: 0;
+		height: auto;
+
+		#adminmenumain,
+		#wpadminbar {
+			display: block;
+		}
+	}
+}


### PR DESCRIPTION
## What?
Fixes a temporary blank white screen that appears when navigating into the block editor (e.g. **Posts → Add New**) on WordPress 7.0+, where admin cross-document view transitions are enabled.

Trac: https://core.trac.wordpress.org/ticket/65294

## Why?
Core prints the `is-fullscreen-mode` body class server-side, before the editor JS loads, to avoid a layout jump once the editor mounts. That class immediately hides `#wpadminbar` and `#adminmenumain`. With `@view-transition { navigation: auto }` active across wp-admin, a cross-document navigation into the editor captures the new page *before* React renders, so the snapshot is a fully blank page — the admin bar and menu flash white along with the empty content area.

As noted by @westonruter on the Trac ticket, only the content area should appear blank during load; the admin bar and menu should stay painted.

## How?
Add a loading-state rule, scoped to `html:not(.interface-interface-skeleton__html-container)`, that keeps the admin bar and admin menu displayed (and preserves the toolbar gap) until the editor skeleton mounts and adds that class to `<html>`. The selector is mutually exclusive with the existing fullscreen rule, so the loaded-state cascade — including the off-by-default `has-admin-bar-in-editor` experiment — is unaffected.

## Testing Instructions
- [ ] On WordPress trunk (7.x), ensure your OS/browser does **not** have "reduce motion" enabled (view transitions require `prefers-reduced-motion: no-preference`).
- [ ] Go to **Posts → Add New** by clicking through the admin menu.
- [ ] Before: the whole screen (incl. admin bar and menu) briefly flashes white.
- [ ] After: the admin bar and admin menu remain visible during the transition; only the editor content area is blank until the editor renders.
- [ ] Confirm no layout regression once the editor has fully loaded (it should enter fullscreen mode exactly as before).
- [ ] Repeat at a viewport ≥ 782px (the rule is gated to `break-medium`).

## Screenshots or screencast
BEFORE
<img width="2400" height="1414" alt="trac-65294-BEFORE-unfixed-chrome-hidden" src="https://github.com/user-attachments/assets/9cbef890-0768-4b04-a3a7-9ffee0ab3c9a" />

AFTER
<img width="2400" height="1414" alt="trac-65294-AFTER-built-fix-chrome-painted" src="https://github.com/user-attachments/assets/28f2869e-2398-4ae2-9009-cc6e61d9e651" />

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude
Used for: Initial code skeleton and final implementation and all changes were reviewed, tested and edited by me.

You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.



