### PR TITLE
Fix Latest Posts full content embeds

### DIFF
--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -31,6 +31,38 @@ function block_core_latest_posts_get_excerpt_length() {
 }
 
 /**
+ * Renders the full content for a post listed in the Latest Posts block.
+ *
+ * @since 6.9.0
+ *
+ * @param WP_Post $post The post object.
+ *
+ * @return string The rendered post content.
+ */
+function block_core_latest_posts_get_full_post_content( $post ) {
+	static $seen_posts = array();
+
+	if ( post_password_required( $post ) ) {
+		return __( 'This content is password protected.' );
+	}
+
+	if ( isset( $seen_posts[ $post->ID ] ) ) {
+		return '';
+	}
+
+	$seen_posts[ $post->ID ] = true;
+
+	$post_content = html_entity_decode( $post->post_content, ENT_QUOTES, get_option( 'blog_charset' ) );
+
+	/** This filter is documented in wp-includes/post-template.php */
+	$post_content = apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', $post_content ) );
+
+	unset( $seen_posts[ $post->ID ] );
+
+	return $post_content;
+}
+
+/**
  * Renders the `core/latest-posts` block on server.
  *
  * @since 5.0.0
@@ -72,6 +104,7 @@ function render_block_core_latest_posts( $attributes ) {
 	}
 
 	$list_items_markup = '';
+	$previous_post     = $post;
 
 	foreach ( $recent_posts as $post ) {
 		$post_link = esc_url( get_permalink( $post ) );
@@ -183,20 +216,16 @@ function render_block_core_latest_posts( $attributes ) {
 		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']
 			&& isset( $attributes['displayPostContentRadio'] ) && 'full_post' === $attributes['displayPostContentRadio'] ) {
 
-			$post_content = html_entity_decode( $post->post_content, ENT_QUOTES, get_option( 'blog_charset' ) );
-
-			if ( post_password_required( $post ) ) {
-				$post_content = __( 'This content is password protected.' );
-			}
-
 			$list_items_markup .= sprintf(
 				'<div class="wp-block-latest-posts__post-full-content">%1$s</div>',
-				wp_kses_post( $post_content )
+				block_core_latest_posts_get_full_post_content( $post )
 			);
 		}
 
 		$list_items_markup .= "</li>\n";
 	}
+
+	$post = $previous_post;
 
 	remove_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 20 );
 

--- a/phpunit/blocks/render-last-posts-test.php
+++ b/phpunit/blocks/render-last-posts-test.php
@@ -112,4 +112,141 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 		$this->assertContains( self::$posts[0]->ID, $last_args[1], 'Ensure that post is in array of post ids that are primed' );
 		$this->assertNotContains( self::$sticky_post->ID, $last_args[1], 'Ensure that sticky post is not in array of post ids that are primed' );
 	}
+
+	/**
+	 * @covers ::render_block_core_latest_posts
+	 * @covers ::block_core_latest_posts_get_full_post_content
+	 */
+	public function test_render_block_core_latest_posts_renders_full_post_content_blocks() {
+		$category_id = $this->factory()->category->create();
+		$embed_url   = 'https://example.com/watch/latest-posts-embed';
+
+		$this->factory()->post->create(
+			array(
+				'post_category' => array( $category_id ),
+				'post_content'  => '<!-- wp:embed {"url":"' . $embed_url . '","type":"video","providerNameSlug":"youtube","responsive":true} -->' . "\n" .
+					'<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube"><div class="wp-block-embed__wrapper">' . "\n" .
+					$embed_url . "\n" .
+					'</div></figure>' . "\n" .
+					'<!-- /wp:embed -->',
+				'post_status'   => 'publish',
+				'post_title'    => 'Post with rendered embed',
+			)
+		);
+
+		wp_embed_register_handler(
+			'gutenberg_test_latest_posts_embed',
+			'#https://example\.com/watch/([^\s<]+)#i',
+			static function ( $matches ) {
+				return sprintf(
+					'<iframe title="Embedded test" src="https://example.com/embed/%s"></iframe>',
+					esc_attr( $matches[1] )
+				);
+			},
+			1
+		);
+
+		$attributes = array(
+			'addLinkToFeaturedImage'  => false,
+			'categories'              => array(
+				array(
+					'id' => $category_id,
+				),
+			),
+			'displayFeaturedImage'    => false,
+			'displayPostContent'      => true,
+			'displayPostContentRadio' => 'full_post',
+			'excerptLength'           => 0,
+			'featuredImageSizeSlug'   => '',
+			'order'                   => 'DESC',
+			'orderBy'                 => 'date',
+			'postsToShow'             => 1,
+		);
+
+		$markup = gutenberg_render_block_core_latest_posts( $attributes );
+
+		wp_embed_unregister_handler( 'gutenberg_test_latest_posts_embed', 1 );
+
+		$this->assertStringContainsString( '<iframe title="Embedded test"', $markup );
+		$this->assertStringNotContainsString( $embed_url, $markup );
+	}
+
+	/**
+	 * @covers ::render_block_core_latest_posts
+	 * @covers ::block_core_latest_posts_get_full_post_content
+	 */
+	public function test_render_block_core_latest_posts_keeps_password_protected_full_content_hidden() {
+		$category_id = $this->factory()->category->create();
+
+		$this->factory()->post->create(
+			array(
+				'post_category' => array( $category_id ),
+				'post_content'  => 'Protected latest posts content.',
+				'post_password' => 'password',
+				'post_status'   => 'publish',
+				'post_title'    => 'Password protected post',
+			)
+		);
+
+		$attributes = array(
+			'addLinkToFeaturedImage'  => false,
+			'categories'              => array(
+				array(
+					'id' => $category_id,
+				),
+			),
+			'displayFeaturedImage'    => false,
+			'displayPostContent'      => true,
+			'displayPostContentRadio' => 'full_post',
+			'excerptLength'           => 0,
+			'featuredImageSizeSlug'   => '',
+			'order'                   => 'DESC',
+			'orderBy'                 => 'date',
+			'postsToShow'             => 1,
+		);
+
+		$markup = gutenberg_render_block_core_latest_posts( $attributes );
+
+		$this->assertStringContainsString( 'This content is password protected.', $markup );
+		$this->assertStringNotContainsString( 'Protected latest posts content.', $markup );
+	}
+
+	/**
+	 * @covers ::render_block_core_latest_posts
+	 */
+	public function test_render_block_core_latest_posts_restores_global_post() {
+		$category_id      = $this->factory()->category->create();
+		$original_post_id = $this->factory()->post->create();
+		$GLOBALS['post']  = get_post( $original_post_id );
+
+		$this->factory()->post->create(
+			array(
+				'post_category' => array( $category_id ),
+				'post_content'  => 'Latest post content.',
+				'post_status'   => 'publish',
+				'post_title'    => 'Latest post',
+			)
+		);
+
+		$attributes = array(
+			'addLinkToFeaturedImage'  => false,
+			'categories'              => array(
+				array(
+					'id' => $category_id,
+				),
+			),
+			'displayFeaturedImage'    => false,
+			'displayPostContent'      => true,
+			'displayPostContentRadio' => 'full_post',
+			'excerptLength'           => 0,
+			'featuredImageSizeSlug'   => '',
+			'order'                   => 'DESC',
+			'orderBy'                 => 'date',
+			'postsToShow'             => 1,
+		);
+
+		gutenberg_render_block_core_latest_posts( $attributes );
+
+		$this->assertSame( $original_post_id, $GLOBALS['post']->ID );
+	}
 }


### PR DESCRIPTION
## What?

Closes #26123.

Fixes the Latest Posts block so posts displayed with the "Full post" content option render embedded/block content instead of outputting the stored embed URL markup.

## Why?

The Latest Posts block's full-content path was reading `post_content` directly and escaping it with `wp_kses_post()`. That bypassed WordPress's normal `the_content` rendering pipeline, so embeds such as YouTube were not transformed into their rendered iframe output inside Latest Posts, even though they rendered correctly on the source post.

## How?

Adds a helper for rendering full post content in Latest Posts through the standard `the_content` filters, while preserving password-protected post behavior. The helper includes a recursion guard so a Latest Posts block inside a listed post cannot recursively render itself.

The render loop also restores the previous global `$post` after rendering the queried latest posts.

## Testing Instructions

1. Create a post containing a YouTube embed block.
2. Create a page containing a Latest Posts block.
3. Configure the Latest Posts block to display post content, with the content mode set to "Full post".
4. View the page on the frontend.
5. Confirm the Latest Posts block renders the YouTube embed iframe instead of displaying the raw YouTube URL/block markup.

Automated testing run locally:

```sh
npm run test:unit:php:base -- --filter Tests_Blocks_RenderLastPosts
```

Result:

```text
OK (5 tests, 10 assertions)
```

Also run locally:

```sh
php -l packages/block-library/src/latest-posts/index.php
php -l phpunit/blocks/render-last-posts-test.php
composer run-script lint packages/block-library/src/latest-posts/index.php phpunit/blocks/render-last-posts-test.php
git diff --check upstream/trunk
```

## Testing Instructions for Keyboard

Not applicable. This change only affects server-side frontend rendering for Latest Posts full-content output and does not change keyboard interaction or editor UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

OpenAI Codex was used to help investigate the issue, implement the fix, run local verification, and draft this PR description. The generated changes and test results were reviewed locally before submission.
