### PR TITLE
Elements: Guard against non-string className in render filter

### DIFF
--- a/backport-changelog/7.1/12028.md
+++ b/backport-changelog/7.1/12028.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12028
+
+* https://github.com/WordPress/gutenberg/pull/78841

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -239,6 +239,11 @@ function gutenberg_render_elements_support_styles( $parsed_block ) {
  */
 function gutenberg_render_elements_class_name( $block_content, $block ) {
 	$class_string = $block['attrs']['className'] ?? '';
+
+	if ( ! is_string( $class_string ) ) {
+		return $block_content;
+	}
+
 	preg_match( '/\bwp-elements-\S+\b/', $class_string, $matches );
 
 	if ( empty( $matches ) ) {

--- a/phpunit/block-supports/elements-test.php
+++ b/phpunit/block-supports/elements-test.php
@@ -89,6 +89,34 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a non-string `className` attribute does not cause a fatal
+	 * error and the block content is returned unmodified.
+	 *
+	 * Block attributes such as `className` are always expected to be strings,
+	 * however invalid stored data can result in other types being present. The
+	 * render filter should fail gracefully rather than passing an array to
+	 * `preg_match()`.
+	 *
+	 * @covers ::gutenberg_render_elements_class_name
+	 */
+	public function test_elements_block_support_class_with_non_string_class_name() {
+		$block = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(
+				'className' => array( '0', '1' ),
+			),
+		);
+
+		$block_content = "<p class=\"0 1\">Test</p>\n";
+
+		$this->assertSame(
+			$block_content,
+			gutenberg_render_elements_class_name( $block_content, $block ),
+			'Block content should be returned unchanged when className is not a string'
+		);
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array


### PR DESCRIPTION
## What?

Adds a type check so the elements block support's `render_block` filter bails out gracefully when a block's `className` attribute isn't a string, rather than passing it straight to `preg_match()`.


## Why?

We had a report of a fatal error coming from `gutenberg_render_elements_class_name()`:

```bash
PHP Fatal error: Uncaught TypeError: preg_match(): Argument #2 ($subject) must be of type string, array given in .../lib/block-supports/elements.php:242
```

The `className` attribute is registered everywhere as `type: 'string'`, and the editor only ever writes a string or undefined, so this comes from invalid stored block data (the trace shows a block serialised with `class="0 1 …"`). It surfaced via an Elasticsearch re-index walking over old posts rather than normal rendering.

It's not something this code produces, but there's no reason to fatal on it. The sibling supports (block-style-variations.php and custom-css.php) already guard against this, so this just brings elements.php in line.

## How?

Adds an early `is_string()` return before the `preg_match()` call, matching the existing pattern in `gutenberg_get_block_style_variation_name_from_class()`.


## Testing Instructions

This is hard to hit through the editor since `className` is always a string there, so it's covered with a unit test:

```bash
npm run test:unit:php -- --filter test_elements_block_support_class_with_non_string_class_name
```

The test passes a block with an array `className` and asserts the content is returned unchanged. You can also confirm the whole `WP_Block_Supports_Elements_Test` class still passes.