### PR TITLE
fix: improve color contrast for inactive collab sidebar notes

### DIFF
--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -57,13 +57,12 @@
 		overflow-y: auto;
 	}
 
-	&:not(.is-selected) {
-		.editor-collab-sidebar-panel__user-name,
-		.editor-collab-sidebar-panel__user-time {
-			color: $gray-800;
-		}
+	.editor-collab-sidebar-panel__user-name,
+	.editor-collab-sidebar-panel__user-time {
+		color: $gray-800;
 	}
 }
+
 
 .editor-collab-sidebar-panel__user-name {
 	font-size: 12px;
@@ -129,7 +128,7 @@
 
 .editor-collab-sidebar-panel__deleted-block-notice {
 	font-weight: $font-weight-medium;
-	color: $gray-700;
+	color: $gray-800;
 }
 
 .editor-collab-sidebar-panel__resolution-text {

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -60,7 +60,7 @@
 	&:not(.is-selected) {
 		.editor-collab-sidebar-panel__user-name,
 		.editor-collab-sidebar-panel__user-time {
-			color: #666666;
+			color: #666;
 		}
 	}
 }

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -56,6 +56,13 @@
 		max-height: calc(100dvh - var(--wp-admin--admin-bar--height, 0px) - #{$header-height + $grid-unit-80});
 		overflow-y: auto;
 	}
+
+	&:not(.is-selected) {
+		.editor-collab-sidebar-panel__user-name,
+		.editor-collab-sidebar-panel__user-time {
+			color: #666666;
+		}
+	}
 }
 
 .editor-collab-sidebar-panel__user-name {

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -60,7 +60,7 @@
 	&:not(.is-selected) {
 		.editor-collab-sidebar-panel__user-name,
 		.editor-collab-sidebar-panel__user-time {
-			color: #666;
+			color: $gray-800;
 		}
 	}
 }


### PR DESCRIPTION
## What?
Closes #78843
Improves color contrast for inactive note text in the collab sidebar.
## Why?
Inactive notes use $gray-700 (#757575) on a $gray-100 (#f0f0f0) background, resulting in a contrast ratio of 4.04:1 which fails WCAG AA (minimum 4.5:1).
## How?
Scoped the text color for __user-name and __user-time elements to #666666 when the thread is not selected, giving a contrast ratio of 5.03:1. Selected threads use a white background where $gray-700 already passes, so those are unaffected.
## Testing Instructions

Open the block editor
Add two or more notes in the collab sidebar
Click away so one note is inactive
Use browser devtools or WAVE to confirm contrast ratio is now above 4.5:1

### Testing Instructions for Keyboard
No keyboard interaction changes in this PR.
## Screenshots
Before: #757575 on #f0f0f0 = 4.04:1 (fails WCAG AA)
After: #666666 on #f0f0f0 = 5.03:1 (passes WCAG AA) — verified via WebAIM contrast checker.
## Use of AI Tools
Used AI assistance for guidance on WCAG contrast requirements and identifying the correct SCSS file to modify.