### PR TITLE
Fix: DataViews - CompactItemActions not rendered when action list equals 1.

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- DataViews: Fix CompactItemActions not rendered when action list equals 1 ([#78845](https://github.com/WordPress/gutenberg/pull/78845)).
+- DataViews: Fix `CompactItemActions` (kebab menu) not rendering when all eligible actions are primary. When only primary actions exist, they are now accessible exclusively via the kebab menu rather than as unreachable inline buttons. ([#78845](https://github.com/WordPress/gutenberg/pull/78845)).
 
 ## 15.0.0 (2026-05-27)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- DataViews: Fix CompactItemActions not rendered when action list equals 1 ([#78845](https://github.com/WordPress/gutenberg/pull/78845)).
+
 ## 15.0.0 (2026-05-27)
 
 ### Breaking Changes

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -197,8 +197,6 @@ export default function ItemActions< Item >( {
 		};
 	}, [ actions, item ] );
 
-	const isMobileViewport = useViewportMatch( 'medium', '<' );
-
 	if ( isCompact ) {
 		return (
 			<CompactItemActions
@@ -220,15 +218,14 @@ export default function ItemActions< Item >( {
 				width: 'auto',
 			} }
 		>
-			<PrimaryActions
-				item={ item }
-				actions={ primaryActions }
-				registry={ registry }
-			/>
-			{ ( primaryActions.length < eligibleActions.length ||
-				// Since we hide primary actions on mobile, we need to show the menu
-				// there if there are any actions at all.
-				isMobileViewport ) && (
+			{ primaryActions.length < eligibleActions.length && (
+				<PrimaryActions
+					item={ item }
+					actions={ primaryActions }
+					registry={ registry }
+				/>
+			) }
+			{ eligibleActions.length > 0 && (
 				<CompactItemActions
 					item={ item }
 					actions={ eligibleActions }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/78842

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR resolves the issue in DataViews when there is only one action button and it is primary. This is because the action is not discovered until it's hovered.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- PR fixes by adjusting the conditionals when showing primary action and eligible actions.
- Primary are shown when primary actions are less then eligible actions, else it's shown in kebab.
- The mobile view port condition is now also removed as the case already covered the edge cases.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a dataviews with only one action and make it primary.
2. Check the action, it should be visible in kebab.
3. Previously it was'nt visible and only discovered on hover.
4. See more here - https://github.com/WordPress/gutenberg/issues/78842#issue-4560276347

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
https://github.com/user-attachments/assets/fbde3a14-c6df-4ef7-b45e-b5ee0f3aaab2

### After


https://github.com/user-attachments/assets/a4a0f462-29a5-4758-8636-eb5abb50e24f



## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

- Yes, GitHub Copilot, Claude Sonnet 4.6
- Used for debugging and checking the issue. Also to provide some fixes on the issue.



