### PR TITLE
e2e-test-utils-playwright: add src to published NPM files

### DIFF
--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -25,7 +25,7 @@
 		"npm": ">=8.19.2"
 	},
 	"files": [
-		"build",
+		"src",
 		"build-types"
 	],
 	"exports": {

--- a/packages/e2e-test-utils-playwright/tsconfig.json
+++ b/packages/e2e-test-utils-playwright/tsconfig.json
@@ -6,12 +6,6 @@
 		"composite": false,
 		"module": "Node16",
 		"moduleResolution": "node16",
-		"noEmit": false,
-		"outDir": "build",
-		"sourceMap": true,
-		"declaration": true,
-		"declarationMap": true,
-		"emitDeclarationOnly": false,
 		"allowJs": true,
 		"checkJs": false
 	}


### PR DESCRIPTION
Fixes #78832 (reported by @Menrath), a regression introduced by #78237. In that PR I stopped building the `e2e-test-utils-playwright` packages, because Playwright can consume the source files, too, and the change allowed us to completely skip a build step when running e2e tests.

But I forgot to add `src` to `files` in `package.json`. The change worked locally, but the `src` files are missing in the published NPM package.