### PR TITLE
Notes: Show default avatar in the indicator when user avatars are disabled

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Collab Sidebar: Fall back to the discussion default avatar in the note indicator toolbar when a thread participant's avatar URL is unavailable ([#78849](https://github.com/WordPress/gutenberg/pull/78849)).
+
 ## 14.47.0 (2026-05-27)
 
 ### Enhancements

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Bug Fixes
-
--   Collab Sidebar: Fall back to the discussion default avatar in the note indicator toolbar when a thread participant's avatar URL is unavailable ([#78849](https://github.com/WordPress/gutenberg/pull/78849)).
-
 ## 14.47.0 (2026-05-27)
 
 ### Enhancements

--- a/packages/editor/src/components/collab-sidebar/note-indicator-toolbar.js
+++ b/packages/editor/src/components/collab-sidebar/note-indicator-toolbar.js
@@ -19,58 +19,24 @@ import { getAvatarBorderColor } from './utils';
 
 const { NoteIconToolbarSlotFill } = unlock( blockEditorPrivateApis );
 
-export function NoteAvatarIndicator( { onClick, note } ) {
+function ThreadParticipants( { participants } ) {
 	const defaultAvatar = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		const { __experimentalDiscussionSettings } = getSettings();
 		return __experimentalDiscussionSettings?.avatarURL;
 	}, [] );
 
-	const threadParticipants = useMemo( () => {
-		if ( ! note ) {
-			return [];
-		}
-
-		const participantsMap = new Map();
-		const allNotes = [ note, ...note.reply ];
-
-		// Sort by date to show participants in chronological order.
-		allNotes.sort( ( a, b ) => new Date( a.date ) - new Date( b.date ) );
-
-		allNotes.forEach( ( entry ) => {
-			// Track thread participants (original author + repliers).
-			if ( entry.author_name ) {
-				if ( ! participantsMap.has( entry.author ) ) {
-					participantsMap.set( entry.author, {
-						name: entry.author_name,
-						avatar:
-							entry.author_avatar_urls?.[ '48' ] ||
-							entry.author_avatar_urls?.[ '96' ],
-						id: entry.author,
-						date: entry.date,
-					} );
-				}
-			}
-		} );
-
-		return Array.from( participantsMap.values() );
-	}, [ note ] );
-
-	if ( ! threadParticipants.length ) {
-		return null;
-	}
-
 	// If there are more than 3 participants, show 2 avatars and a "+n" number.
 	const maxAvatars = 3;
-	const isOverflow = threadParticipants.length > maxAvatars;
+	const isOverflow = participants.length > maxAvatars;
 	const visibleParticipants = isOverflow
-		? threadParticipants.slice( 0, maxAvatars - 1 )
-		: threadParticipants;
+		? participants.slice( 0, maxAvatars - 1 )
+		: participants;
 	const overflowCount = Math.max(
 		0,
-		threadParticipants.length - visibleParticipants.length
+		participants.length - visibleParticipants.length
 	);
-	const threadHasMoreParticipants = threadParticipants.length > 100;
+	const threadHasMoreParticipants = participants.length > 100;
 
 	// If we hit the note limit, show "100+" instead of exact overflow count.
 	const overflowText =
@@ -83,6 +49,62 @@ export function NoteAvatarIndicator( { onClick, note } ) {
 			  );
 
 	return (
+		<Stack direction="row" align="center" gap="xs">
+			{ visibleParticipants.map( ( participant ) => (
+				<img
+					key={ participant.id }
+					src={ participant.avatar || defaultAvatar }
+					alt={ participant.name }
+					className="editor-note-indicator__avatar"
+					style={ {
+						borderColor: getAvatarBorderColor( participant.id ),
+					} }
+				/>
+			) ) }
+			{ overflowCount > 0 && (
+				<span className="editor-note-indicator__overflow">
+					{ overflowText }
+				</span>
+			) }
+		</Stack>
+	);
+}
+
+export function NoteAvatarIndicator( { onClick, note } ) {
+	const threadParticipants = useMemo( () => {
+		if ( ! note ) {
+			return [];
+		}
+
+		// Track thread participants (original author + repliers), sorted by
+		// date so they appear in chronological order.
+		const participantsMap = new Map();
+		const allNotes = [ note, ...note.reply ].sort(
+			( a, b ) => new Date( a.date ) - new Date( b.date )
+		);
+
+		for ( const entry of allNotes ) {
+			if ( ! entry.author_name || participantsMap.has( entry.author ) ) {
+				continue;
+			}
+
+			participantsMap.set( entry.author, {
+				id: entry.author,
+				name: entry.author_name,
+				avatar:
+					entry.author_avatar_urls?.[ '48' ] ||
+					entry.author_avatar_urls?.[ '96' ],
+			} );
+		}
+
+		return Array.from( participantsMap.values() );
+	}, [ note ] );
+
+	if ( ! threadParticipants.length ) {
+		return null;
+	}
+
+	return (
 		<NoteIconToolbarSlotFill.Fill>
 			<ToolbarButton
 				className="editor-note-indicator"
@@ -90,26 +112,7 @@ export function NoteAvatarIndicator( { onClick, note } ) {
 				onClick={ () => onClick() }
 				showTooltip
 			>
-				<Stack direction="row" align="center" gap="xs">
-					{ visibleParticipants.map( ( participant ) => (
-						<img
-							key={ participant.id }
-							src={ participant.avatar || defaultAvatar }
-							alt={ participant.name }
-							className="editor-note-indicator__avatar"
-							style={ {
-								borderColor: getAvatarBorderColor(
-									participant.id
-								),
-							} }
-						/>
-					) ) }
-					{ overflowCount > 0 && (
-						<span className="editor-note-indicator__overflow">
-							{ overflowText }
-						</span>
-					) }
-				</Stack>
+				<ThreadParticipants participants={ threadParticipants } />
 			</ToolbarButton>
 		</NoteIconToolbarSlotFill.Fill>
 	);

--- a/packages/editor/src/components/collab-sidebar/note-indicator-toolbar.js
+++ b/packages/editor/src/components/collab-sidebar/note-indicator-toolbar.js
@@ -5,7 +5,11 @@ import { ToolbarButton } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import {
+	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -16,6 +20,12 @@ import { getAvatarBorderColor } from './utils';
 const { NoteIconToolbarSlotFill } = unlock( blockEditorPrivateApis );
 
 export function NoteAvatarIndicator( { onClick, note } ) {
+	const defaultAvatar = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		const { __experimentalDiscussionSettings } = getSettings();
+		return __experimentalDiscussionSettings?.avatarURL;
+	}, [] );
+
 	const threadParticipants = useMemo( () => {
 		if ( ! note ) {
 			return [];
@@ -29,7 +39,7 @@ export function NoteAvatarIndicator( { onClick, note } ) {
 
 		allNotes.forEach( ( entry ) => {
 			// Track thread participants (original author + repliers).
-			if ( entry.author_name && entry.author_avatar_urls ) {
+			if ( entry.author_name ) {
 				if ( ! participantsMap.has( entry.author ) ) {
 					participantsMap.set( entry.author, {
 						name: entry.author_name,
@@ -84,7 +94,7 @@ export function NoteAvatarIndicator( { onClick, note } ) {
 					{ visibleParticipants.map( ( participant ) => (
 						<img
 							key={ participant.id }
-							src={ participant.avatar }
+							src={ participant.avatar || defaultAvatar }
 							alt={ participant.name }
 							className="editor-note-indicator__avatar"
 							style={ {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/78838

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR resolves the issue if no avataar is selected, the notes in block toolbar were not added, so a quick refrence to all notes for the block was not visible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Use default avtaar as used in all notes with similar logic.
- Remove condition that checks for author avataar to show the notes quick ref.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open post/page.
2. Add a paragraph and add note.
3. From settings --> discussion, uncheck the avataar.
4. Check the block again, the default avataar should be visible.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1440" height="443" alt="Screenshot 2026-06-01 at 3 02 53 PM" src="https://github.com/user-attachments/assets/6b93a0db-c41d-4516-a0db-f1359f103d5e" /> | <img width="1440" height="443" alt="Screenshot 2026-06-01 at 3 01 39 PM" src="https://github.com/user-attachments/assets/bbb0fbbb-50c2-46b5-94e6-18004bd80160" /> |

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
- None