### PR TITLE
Dashboard: Fix Add widget error on non-secure HTTP origins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64392,7 +64392,8 @@
 				"@wordpress/viewport": "file:../../packages/viewport",
 				"@wordpress/warning": "file:../../packages/warning",
 				"clsx": "^2.1.1",
-				"fast-deep-equal": "^3.1.3"
+				"fast-deep-equal": "^3.1.3",
+				"uuid": "^14.0.0"
 			}
 		},
 		"routes/experiments-home": {

--- a/routes/dashboard/package.json
+++ b/routes/dashboard/package.json
@@ -31,6 +31,7 @@
 		"@wordpress/viewport": "file:../../packages/viewport",
 		"@wordpress/warning": "file:../../packages/warning",
 		"clsx": "^2.1.1",
-		"fast-deep-equal": "^3.1.3"
+		"fast-deep-equal": "^3.1.3",
+		"uuid": "^14.0.0"
 	}
 }

--- a/routes/dashboard/widget-dashboard/utils/create-dashboard-widget/create-dashboard-widget.ts
+++ b/routes/dashboard/widget-dashboard/utils/create-dashboard-widget/create-dashboard-widget.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { v4 as uuid } from 'uuid';
+
+/**
  * Internal dependencies
  */
 import type { DashboardWidget, GridTilePlacement } from '../../types';
@@ -24,7 +29,7 @@ export function createDashboardWidget< T >(
 	initialAttributes?: T
 ): DashboardWidget< T > {
 	return {
-		uuid: crypto.randomUUID(),
+		uuid: uuid(),
 		type: widgetType.name,
 		attributes:
 			initialAttributes ?? ( widgetType.example?.attributes as T ),


### PR DESCRIPTION
## What

- Replaces `crypto.randomUUID()` with `uuid` v4 in `createDashboardWidget()` when stamping new widget instance IDs.
- Adds `uuid` (`^14.0.0`) as a dependency of `routes/dashboard`, matching other Gutenberg packages.

## Why

`crypto.randomUUID()` is only available in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS, `localhost`, etc.). On plain `http://` origins—common in local development—clicking **Add widget** throws and the inserter fails.

## How

- Import `v4 as uuid` from the `uuid` package in `create-dashboard-widget.ts`.
- Call `uuid()` instead of `crypto.randomUUID()` when creating a new `DashboardWidget` instance.
- Declare the dependency in `routes/dashboard/package.json` and update `package-lock.json`.

## Test plan

- [ ] On an `http://` (non-localhost) site, open the dashboard and add a widget via the inserter — no console error, widget appears in the layout.
- [ ] On HTTPS or `localhost`, confirm adding widgets still works.
- [ ] Run `npm run test:unit routes/dashboard/widget-dashboard/test/create-dashboard-widget.test.ts`
- [ ] Confirm new widgets still receive unique UUIDs (`stamps the type name and a unique uuid`).