### PR TITLE
Revert "Icons: maintain absolute stroke-width regardless of icon-size (#78774)"

### DIFF
--- a/packages/icons/src/library/square.svg
+++ b/packages/icons/src/library/square.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-	<path d="M5.75 12.75V18.25H11.25M12.75 5.75H18.25V11.25" stroke-linecap="square" vector-effect="non-scaling-stroke" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+	<path fill="none" d="M5.75 12.75V18.25H11.25M12.75 5.75H18.25V11.25" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" />
 </svg>


### PR DESCRIPTION
## What?

This reverts commit 86c513917e9e268a4ff8dec6538f9f15fcdc447f (#78774).

## Why?

We applied an approach that maintains an absolute stroke width regardless of icon size to the `square` icon. However, this icon caused unintended changes in the editor. The cause is the following CSS.

```css
.components-button svg {
    fill: currentColor;
}
```

Let's revert #78774 and explore a more ideal approach in #78808.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Check the Zoom out button.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="298" height="63" alt="image" src="https://github.com/user-attachments/assets/8affb03e-3ec5-46d4-974d-8e9ff4f867da" />| <img width="293" height="66" alt="image" src="https://github.com/user-attachments/assets/093a6434-cf66-486c-be9d-e05c6f937b8a" /> |

## Use of AI Tools

None