### PR TITLE
Audio block: Add transcript field for accessibility

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -65,7 +65,7 @@ Embed a simple audio player. ([Source](https://github.com/WordPress/gutenberg/tr
 -	**Name:** core/audio
 -	**Category:** media
 -	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding)
--	**Attributes:** autoplay, blob, caption, id, loop, preload, src
+-	**Attributes:** autoplay, blob, caption, id, loop, preload, src, transcript
 
 ## Avatar
 

--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -46,6 +46,10 @@
 			"source": "attribute",
 			"selector": "audio",
 			"attribute": "preload"
+		},
+		"transcript": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -21,6 +21,7 @@ import {
 	InspectorControls,
 	MediaPlaceholder,
 	MediaReplaceFlow,
+	RichText,
 	useBlockProps,
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
@@ -50,7 +51,7 @@ function AudioEdit( {
 	isSelected: isSingleSelected,
 	insertBlocksAfter,
 } ) {
-	const { id, autoplay, loop, preload, src } = attributes;
+	const { id, autoplay, loop, preload, src, transcript } = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
 	const blockEditingMode = useBlockEditingMode();
 	const hasNonContentControls = blockEditingMode === 'default';
@@ -269,6 +270,20 @@ function AudioEdit( {
 						isSingleSelected && hasNonContentControls
 					}
 				/>
+				{ ( ! RichText.isEmpty( transcript ) || isSingleSelected ) && (
+					<RichText
+						tagName="p"
+						className="wp-block-audio__transcript-text"
+						value={ transcript }
+						onChange={ ( value ) =>
+							setAttributes( { transcript: value } )
+						}
+						placeholder={ __(
+							'Add a transcript to make your audio accessible to a wider range of users.'
+						) }
+						identifier="transcript"
+					/>
+				) }
 			</figure>
 		</>
 	);

--- a/packages/block-library/src/audio/save.js
+++ b/packages/block-library/src/audio/save.js
@@ -8,11 +8,13 @@ import {
 } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { autoplay, caption, loop, preload, src } = attributes;
+	const { autoplay, caption, loop, preload, src, transcript } = attributes;
+
+	const displayCaption = ! RichText.isEmpty( caption );
 
 	return (
-		src && (
-			<figure { ...useBlockProps.save() }>
+		<figure { ...useBlockProps.save() }>
+			{ src && (
 				<audio
 					controls="controls"
 					src={ src }
@@ -20,16 +22,21 @@ export default function save( { attributes } ) {
 					loop={ loop }
 					preload={ preload }
 				/>
-				{ ! RichText.isEmpty( caption ) && (
-					<RichText.Content
-						tagName="figcaption"
-						value={ caption }
-						className={ __experimentalGetElementClassName(
-							'caption'
-						) }
-					/>
-				) }
-			</figure>
-		)
+			) }
+			{ displayCaption && (
+				<RichText.Content
+					tagName="figcaption"
+					value={ caption }
+					className={ __experimentalGetElementClassName( 'caption' ) }
+				/>
+			) }
+			{ ! RichText.isEmpty( transcript ) && (
+				<RichText.Content
+					tagName="p"
+					className="wp-block-audio__transcript-text"
+					value={ transcript }
+				/>
+			) }
+		</figure>
 	);
 }

--- a/packages/block-library/src/audio/style.scss
+++ b/packages/block-library/src/audio/style.scss
@@ -18,4 +18,11 @@
 		// We restore this as a min-width instead, for alignments.
 		min-width: 300px;
 	}
+
+	// Transcript styling. Always visible to satisfy WCAG 1.2.1 (text
+	// alternative for prerecorded audio-only content).
+	.wp-block-audio__transcript-text {
+		@include caption-style();
+		margin-top: 0.5em;
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Closes #75789
- Adds an inline transcript field to the Audio block.

## Why?
WCAG 1.2.1 (Level A) requires a text alternative for prerecorded audio-only content. The Audio block had no way to provide one.

## How?
- Added a `transcript` string attribute to `core/audio` block.json
- Rendered as a `RichText` paragraph inside the `<figure>` (only when content exists or block is selected)
- Styled with `caption-style()` so it's visually consistent with the existing figcaption

## Testing Instructions
1. Open a post or page in the editor
2. Insert an Audio block and upload an audio file
3. Click below the audio player
4. Type or paste a transcript
5. Save and view the post
6. Verify the transcript appears as a paragraph below the audio player
7. With a screen reader (e.g. VoiceOver ⌘F5), navigate to the audio — the transcript is reachable and read in the linear reading order

## Use of AI Tools
- Use of minimax-m3:cloud model provided by Ollama was utilized to research and provide a11y insights.
- This PR was authored with the help of AI tooling.
