### PR TITLE
Add Preformatted block bindings support

### DIFF
--- a/backport-changelog/7.1/12040.md
+++ b/backport-changelog/7.1/12040.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12040
+
+* https://github.com/WordPress/gutenberg/pull/78859

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -24,6 +24,9 @@ add_filter(
 		) {
 			$attributes[] = 'url';
 		}
+		if ( 'core/preformatted' === $block_type && ! in_array( 'content', $attributes, true ) ) {
+			$attributes[] = 'content';
+		}
 		return $attributes;
 	},
 	10,

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -24,9 +24,6 @@ add_filter(
 		) {
 			$attributes[] = 'url';
 		}
-		if ( 'core/preformatted' === $block_type && ! in_array( 'content', $attributes, true ) ) {
-			$attributes[] = 'content';
-		}
 		return $attributes;
 	},
 	10,

--- a/lib/compat/wordpress-7.1/block-bindings.php
+++ b/lib/compat/wordpress-7.1/block-bindings.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Block Bindings API additions for WordPress 7.1.
+ *
+ * @since 7.1.0
+ * @package gutenberg
+ * @subpackage Block Bindings
+ */
+
+// The following filter can be removed once the minimum required WordPress version is 7.1 or newer.
+add_filter(
+	'block_bindings_supported_attributes',
+	function ( $attributes, $block_type ) {
+		if ( 'core/preformatted' === $block_type && ! in_array( 'content', $attributes, true ) ) {
+			$attributes[] = 'content';
+		}
+		return $attributes;
+	},
+	10,
+	2
+);

--- a/lib/load.php
+++ b/lib/load.php
@@ -78,6 +78,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 	// WordPress 7.1 compat.
 	require __DIR__ . '/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php';
+	require __DIR__ . '/compat/wordpress-7.1/block-bindings.php';
 	require __DIR__ . '/compat/wordpress-7.1/rest-api.php';
 	require __DIR__ . '/compat/wordpress-7.1/collaboration.php';
 

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -77,7 +77,7 @@ class Tests_Block_Bindings extends WP_UnitTestCase {
 
 	public function data_update_block_with_value_from_source() {
 		return array(
-			'paragraph block' => array(
+			'paragraph block'    => array(
 				'content',
 				<<<HTML
 <!-- wp:paragraph -->
@@ -87,7 +87,17 @@ HTML
 				,
 				'<p class="wp-block-paragraph">test source value</p>',
 			),
-			'button block'    => array(
+			'preformatted block' => array(
+				'content',
+				<<<HTML
+<!-- wp:preformatted -->
+<pre class="wp-block-preformatted">This should not appear</pre>
+<!-- /wp:preformatted -->
+HTML
+				,
+				'<pre class="wp-block-preformatted">test source value</pre>',
+			),
+			'button block'       => array(
 				'text',
 				<<<HTML
 <!-- wp:button -->
@@ -97,7 +107,7 @@ HTML
 				,
 				'<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">test source value</a></div>',
 			),
-			'test block'      => array(
+			'test block'         => array(
 				'myAttribute',
 				<<<HTML
 <!-- wp:test/block -->
@@ -348,6 +358,50 @@ HTML;
 			$expected_bindings_metadata,
 			$block->attributes['metadata']['bindings'],
 			'The __default binding should be updated with the individual binding attributes in the block metadata.'
+		);
+	}
+
+	/**
+	 * Tests that the Preformatted block supports the default binding for pattern
+	 * overrides.
+	 *
+	 * @covers WP_Block::process_block_bindings
+	 */
+	public function test_default_binding_for_pattern_overrides_preformatted() {
+		$block_content = <<<HTML
+<!-- wp:preformatted {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Test preformatted"}} -->
+<pre class="wp-block-preformatted">This should not appear</pre>
+<!-- /wp:preformatted -->
+HTML;
+
+		$expected_content = 'This is the preformatted content value';
+		$parsed_blocks    = parse_blocks( $block_content );
+		$block            = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'pattern/overrides' => array(
+					'Test preformatted' => array(
+						'content' => $expected_content,
+					),
+				),
+			)
+		);
+
+		$result = $block->render();
+
+		$this->assertSame(
+			"<pre class=\"wp-block-preformatted\">$expected_content</pre>",
+			trim( $result ),
+			'The `__default` attribute should be replaced with the preformatted content binding.'
+		);
+
+		$expected_bindings_metadata = array(
+			'content' => array( 'source' => 'core/pattern-overrides' ),
+		);
+		$this->assertSame(
+			$expected_bindings_metadata,
+			$block->attributes['metadata']['bindings'],
+			'The __default binding should be updated with the Preformatted content binding.'
 		);
 	}
 

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -883,6 +883,20 @@ test.describe( 'Registered sources', () => {
 			await expect( contentAttribute ).toBeVisible();
 		} );
 
+		test( 'should be possible to connect the preformatted content', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/preformatted',
+			} );
+			await page.getByLabel( 'Attributes options' ).click();
+			const contentAttribute = page.getByRole( 'menuitemcheckbox', {
+				name: 'Show content',
+			} );
+			await expect( contentAttribute ).toBeVisible();
+		} );
+
 		test( 'should be possible to connect the button supported attributes', async ( {
 			editor,
 			page,


### PR DESCRIPTION
## What?

Adds block bindings support for the Preformatted block `content` attribute.

Part of #78851.

Core backport PR: https://github.com/WordPress/wordpress-develop/pull/12040

## Why?

`core/preformatted` has a single top-level rich text content attribute, so it can use the existing generic rich-text block bindings replacement path without media, URL, or navigation-specific coupling.

This is scoped as a WordPress 7.1 compat addition in the Gutenberg plugin. It is not added to the 6.9 compat bucket.

## How?

- Adds `content` to the supported block binding attributes for `core/preformatted` in `lib/compat/wordpress-7.1/block-bindings.php`.
- Adds server-side render coverage for bound Preformatted content.
- Adds pattern override coverage for Preformatted `content`.
- Adds E2E coverage that the editor bindings UI exposes `Show content` for Preformatted.

## Testing Instructions

- `docker exec 23f0d96e0dd1 bash -lc 'cd /var/www/html/wp-content/plugins/gutenberg && vendor/bin/phpunit --filter Tests_Block_Bindings'`
- `vendor/bin/phpcs lib/compat/wordpress-6.9/block-bindings.php lib/compat/wordpress-7.1/block-bindings.php lib/load.php phpunit/block-bindings-test.php`
- `npm run lint:js -- test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js`
- `git diff --check`

I also ran a local wp-admin smoke check against `localhost:8889` with the active `custom-acf-blocks` source plugin and verified the Preformatted block Attributes menu exposes `Show content`.