### PR TITLE
Add Verse block bindings support

### DIFF
--- a/backport-changelog/7.1/12041.md
+++ b/backport-changelog/7.1/12041.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12041
+
+* https://github.com/WordPress/gutenberg/pull/78860

--- a/lib/compat/wordpress-7.1/block-bindings.php
+++ b/lib/compat/wordpress-7.1/block-bindings.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Block Bindings API additions for WordPress 7.1.
+ *
+ * @since 7.1.0
+ * @package gutenberg
+ * @subpackage Block Bindings
+ */
+
+// The following filter can be removed once the minimum required WordPress version is 7.1 or newer.
+add_filter(
+	'block_bindings_supported_attributes',
+	function ( $attributes, $block_type ) {
+		if ( 'core/verse' === $block_type && ! in_array( 'content', $attributes, true ) ) {
+			$attributes[] = 'content';
+		}
+		return $attributes;
+	},
+	10,
+	2
+);

--- a/lib/load.php
+++ b/lib/load.php
@@ -78,6 +78,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 	// WordPress 7.1 compat.
 	require __DIR__ . '/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php';
+	require __DIR__ . '/compat/wordpress-7.1/block-bindings.php';
 	require __DIR__ . '/compat/wordpress-7.1/rest-api.php';
 	require __DIR__ . '/compat/wordpress-7.1/collaboration.php';
 

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -87,6 +87,16 @@ HTML
 				,
 				'<p class="wp-block-paragraph">test source value</p>',
 			),
+			'verse block'     => array(
+				'content',
+				<<<HTML
+<!-- wp:verse -->
+<pre class="wp-block-verse">This should not appear</pre>
+<!-- /wp:verse -->
+HTML
+				,
+				'<pre class="wp-block-verse">test source value</pre>',
+			),
 			'button block'    => array(
 				'text',
 				<<<HTML
@@ -348,6 +358,50 @@ HTML;
 			$expected_bindings_metadata,
 			$block->attributes['metadata']['bindings'],
 			'The __default binding should be updated with the individual binding attributes in the block metadata.'
+		);
+	}
+
+	/**
+	 * Tests that the Verse block supports the default binding for pattern
+	 * overrides.
+	 *
+	 * @covers WP_Block::process_block_bindings
+	 */
+	public function test_default_binding_for_pattern_overrides_verse() {
+		$block_content = <<<HTML
+<!-- wp:verse {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Test verse"}} -->
+<pre class="wp-block-verse">This should not appear</pre>
+<!-- /wp:verse -->
+HTML;
+
+		$expected_content = 'This is the verse content value';
+		$parsed_blocks    = parse_blocks( $block_content );
+		$block            = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'pattern/overrides' => array(
+					'Test verse' => array(
+						'content' => $expected_content,
+					),
+				),
+			)
+		);
+
+		$result = $block->render();
+
+		$this->assertSame(
+			"<pre class=\"wp-block-verse\">$expected_content</pre>",
+			trim( $result ),
+			'The `__default` attribute should be replaced with the verse content binding.'
+		);
+
+		$expected_bindings_metadata = array(
+			'content' => array( 'source' => 'core/pattern-overrides' ),
+		);
+		$this->assertSame(
+			$expected_bindings_metadata,
+			$block->attributes['metadata']['bindings'],
+			'The __default binding should be updated with the Verse content binding.'
 		);
 	}
 

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -883,6 +883,20 @@ test.describe( 'Registered sources', () => {
 			await expect( contentAttribute ).toBeVisible();
 		} );
 
+		test( 'should be possible to connect the verse content', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/verse',
+			} );
+			await page.getByLabel( 'Attributes options' ).click();
+			const contentAttribute = page.getByRole( 'menuitemcheckbox', {
+				name: 'Show content',
+			} );
+			await expect( contentAttribute ).toBeVisible();
+		} );
+
 		test( 'should be possible to connect the button supported attributes', async ( {
 			editor,
 			page,


### PR DESCRIPTION
## What?

Adds block bindings support for the Verse block `content` attribute.

Part of #78851.

Core backport PR: https://github.com/WordPress/wordpress-develop/pull/12041

## Why?

`core/verse` has a single top-level rich text content attribute, so it can use the existing generic rich-text block bindings replacement path without media, URL, or navigation-specific coupling.

This is scoped as a WordPress 7.1 compat addition in the Gutenberg plugin.

## How?

- Adds `content` to the supported block binding attributes for `core/verse` in `lib/compat/wordpress-7.1/block-bindings.php`.
- Adds server-side render coverage for bound Verse content.
- Adds pattern override coverage for Verse `content`.
- Adds E2E coverage that the editor bindings UI exposes `Show content` for Verse.

## Testing Instructions

- `docker exec 23f0d96e0dd1 bash -lc 'cd /var/www/html/wp-content/plugins/gutenberg && vendor/bin/phpunit --filter Tests_Block_Bindings'`
- `vendor/bin/phpcs lib/compat/wordpress-7.1/block-bindings.php lib/load.php phpunit/block-bindings-test.php`
- `npm run lint:js -- test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js`
- `git diff --check`

I also ran a local wp-admin smoke check against `localhost:8889` with the active `custom-acf-blocks` source plugin and verified the Verse block Attributes menu exposes `Show content`.