### PR TITLE
Add Code block bindings support

### DIFF
--- a/backport-changelog/7.1/12042.md
+++ b/backport-changelog/7.1/12042.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12042
+
+* https://github.com/WordPress/gutenberg/pull/78862

--- a/lib/compat/wordpress-7.1/code-block-bindings.php
+++ b/lib/compat/wordpress-7.1/code-block-bindings.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Code block bindings additions for WordPress 7.1.
+ *
+ * @since 7.1.0
+ * @package gutenberg
+ * @subpackage Block Bindings
+ */
+
+// The following filter can be removed once the minimum required WordPress version is 7.1 or newer.
+add_filter(
+	'block_bindings_supported_attributes',
+	function ( $attributes, $block_type ) {
+		if ( 'core/code' === $block_type && ! in_array( 'content', $attributes, true ) ) {
+			$attributes[] = 'content';
+		}
+		return $attributes;
+	},
+	10,
+	2
+);

--- a/lib/load.php
+++ b/lib/load.php
@@ -78,6 +78,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 	// WordPress 7.1 compat.
 	require __DIR__ . '/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php';
+	require __DIR__ . '/compat/wordpress-7.1/code-block-bindings.php';
 	require __DIR__ . '/compat/wordpress-7.1/rest-api.php';
 	require __DIR__ . '/compat/wordpress-7.1/collaboration.php';
 

--- a/packages/block-library/src/code/transforms.js
+++ b/packages/block-library/src/code/transforms.js
@@ -67,10 +67,23 @@ const transforms = {
 			blocks: [ 'core/paragraph' ],
 			transform: ( attributes ) => {
 				const { content } = attributes;
-				return createBlock( 'core/paragraph', {
-					...getTransformedAttributes( attributes, 'core/paragraph' ),
+				const transformedAttributes = getTransformedAttributes(
+					attributes,
+					'core/paragraph',
+					( { content: contentBinding } ) => ( {
+						content: contentBinding,
+					} )
+				);
+				const paragraphBlock = createBlock( 'core/paragraph', {
+					...attributes,
+					...transformedAttributes,
 					content,
 				} );
+				if ( transformedAttributes?.metadata ) {
+					paragraphBlock.attributes.metadata =
+						transformedAttributes.metadata;
+				}
+				return paragraphBlock;
 			},
 		},
 	],

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -87,6 +87,16 @@ HTML
 				,
 				'<p class="wp-block-paragraph">test source value</p>',
 			),
+			'code block'      => array(
+				'content',
+				<<<HTML
+<!-- wp:code -->
+<pre class="wp-block-code"><code>This should not appear</code></pre>
+<!-- /wp:code -->
+HTML
+				,
+				'<pre class="wp-block-code"><code>test source value</code></pre>',
+			),
 			'button block'    => array(
 				'text',
 				<<<HTML
@@ -348,6 +358,50 @@ HTML;
 			$expected_bindings_metadata,
 			$block->attributes['metadata']['bindings'],
 			'The __default binding should be updated with the individual binding attributes in the block metadata.'
+		);
+	}
+
+	/**
+	 * Tests that the Code block supports the default binding for pattern
+	 * overrides.
+	 *
+	 * @covers WP_Block::process_block_bindings
+	 */
+	public function test_default_binding_for_pattern_overrides_code() {
+		$block_content = <<<HTML
+<!-- wp:code {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Test code"}} -->
+<pre class="wp-block-code"><code>This should not appear</code></pre>
+<!-- /wp:code -->
+HTML;
+
+		$expected_content = 'This is the code content value';
+		$parsed_blocks    = parse_blocks( $block_content );
+		$block            = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'pattern/overrides' => array(
+					'Test code' => array(
+						'content' => $expected_content,
+					),
+				),
+			)
+		);
+
+		$result = $block->render();
+
+		$this->assertSame(
+			"<pre class=\"wp-block-code\"><code>$expected_content</code></pre>",
+			trim( $result ),
+			'The `__default` attribute should be replaced with the code content binding.'
+		);
+
+		$expected_bindings_metadata = array(
+			'content' => array( 'source' => 'core/pattern-overrides' ),
+		);
+		$this->assertSame(
+			$expected_bindings_metadata,
+			$block->attributes['metadata']['bindings'],
+			'The __default binding should be updated with the Code content binding.'
 		);
 	}
 

--- a/test/e2e/specs/editor/blocks/code.spec.js
+++ b/test/e2e/specs/editor/blocks/code.spec.js
@@ -86,6 +86,41 @@ test.describe( 'Code', () => {
 					name: 'Custom name',
 				} );
 			} );
+
+			test( 'should preserve the block bindings', async ( {
+				editor,
+			} ) => {
+				await editor.insertBlock( {
+					name: 'core/paragraph',
+					attributes: {
+						content: 'initial content',
+						metadata: {
+							bindings: {
+								content: {
+									source: 'core/post-meta',
+									args: {
+										key: 'custom_field',
+									},
+								},
+							},
+						},
+					},
+				} );
+
+				await editor.transformBlockTo( 'core/code' );
+				const codeBlock = ( await editor.getBlocks() )[ 0 ];
+				expect( codeBlock.name ).toBe( 'core/code' );
+				expect( codeBlock.attributes.metadata.bindings ).toMatchObject(
+					{
+						content: {
+							source: 'core/post-meta',
+							args: {
+								key: 'custom_field',
+							},
+						},
+					}
+				);
+			} );
 		} );
 
 		test.describe( 'FROM HTML', () => {
@@ -160,6 +195,60 @@ test.describe( 'Code', () => {
 				expect( codeBlock.name ).toBe( 'core/paragraph' );
 				expect( codeBlock.attributes.metadata ).toMatchObject( {
 					name: 'Custom name',
+				} );
+			} );
+
+			test( 'should preserve the block bindings', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( {
+					name: 'core/code',
+					attributes: {
+						content: 'initial content',
+					},
+				} );
+
+				const codeBlockClientId = await page.evaluate( () =>
+					window.wp.data
+						.select( 'core/block-editor' )
+						.getSelectedBlockClientId()
+				);
+				await page.evaluate( ( clientId ) => {
+					window.wp.data
+						.dispatch( 'core/block-editor' )
+						.updateBlockAttributes( clientId, {
+							metadata: {
+								bindings: {
+									content: {
+										source: 'core/post-meta',
+										args: {
+											key: 'custom_field',
+										},
+									},
+								},
+							},
+						} );
+				}, codeBlockClientId );
+				await page.waitForFunction( ( clientId ) => {
+					return window.wp.data
+						.select( 'core/block-editor' )
+						.getBlock( clientId )?.attributes?.metadata?.bindings
+						?.content;
+				}, codeBlockClientId );
+
+				await editor.transformBlockTo( 'core/paragraph' );
+				const paragraphBlock = ( await editor.getBlocks() )[ 0 ];
+				expect( paragraphBlock.name ).toBe( 'core/paragraph' );
+				expect(
+					paragraphBlock.attributes.metadata.bindings
+				).toMatchObject( {
+					content: {
+						source: 'core/post-meta',
+						args: {
+							key: 'custom_field',
+						},
+					},
 				} );
 			} );
 		} );

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -883,6 +883,20 @@ test.describe( 'Registered sources', () => {
 			await expect( contentAttribute ).toBeVisible();
 		} );
 
+		test( 'should be possible to connect the code content', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/code',
+			} );
+			await page.getByLabel( 'Attributes options' ).click();
+			const contentAttribute = page.getByRole( 'menuitemcheckbox', {
+				name: 'Show content',
+			} );
+			await expect( contentAttribute ).toBeVisible();
+		} );
+
 		test( 'should be possible to connect the button supported attributes', async ( {
 			editor,
 			page,


### PR DESCRIPTION
## What?
Adds block bindings support for the Code block `content` attribute.

Part of #78851.

Core backport: https://github.com/WordPress/wordpress-develop/pull/12042
Backport changelog: `backport-changelog/7.1/12042.md`

## Why?
The Code block has a single text-like `content` attribute rendered inside the block markup, which makes it a low-risk candidate for block bindings compatibility and pattern overrides.

## How?
- Adds a WordPress 7.1 compatibility filter entry for `core/code` -> `content`.
- Adds PHPUnit coverage for source rendering and pattern overrides.
- Adds editor UI coverage to ensure the `content` attribute can be exposed for binding.

## Testing Instructions
- `docker exec -w /var/www/html/wp-content/plugins/gutenberg 23f0d96e0dd1 vendor/bin/phpunit --filter Tests_Block_Bindings`
- `vendor/bin/phpcs lib/compat/wordpress-7.1/code-block-bindings.php lib/load.php phpunit/block-bindings-test.php`
- `npm run lint:js -- test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js`
- `git diff --check`
- Smoke tested on `localhost:8889`:
  - `gutenberg_get_block_bindings_supported_attributes( 'core/code' )` returns `content`.
  - Frontend render replaces fallback code content with the bound source value.
  - Editor UI shows `Show content` in the Attributes options menu for Code.