### PR TITLE
RTC: Fix Yjs undo manager to update UI state when undo stack changes

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -91,7 +91,9 @@ export default function useInnerBlockTemplateSync(
 			);
 
 			if ( ! fastDeepEqual( nextBlocks, currentInnerBlocks ) ) {
-				__unstableMarkNextChangeAsNotPersistent();
+				__unstableMarkNextChangeAsNotPersistent( {
+					history: 'ignore',
+				} );
 				replaceInnerBlocks(
 					clientId,
 					nextBlocks,

--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -277,6 +277,46 @@ describe( 'useBlockSync hook', () => {
 		expect( onChange ).not.toHaveBeenCalled();
 	} );
 
+	it( 'passes undoIgnore when a non-persistent block change ignores history', async () => {
+		const onChange = jest.fn();
+		const onInput = jest.fn();
+		const value1 = [
+			{ clientId: 'a', innerBlocks: [], attributes: { foo: 1 } },
+		];
+		let registry;
+		const setRegistry = ( reg ) => {
+			registry = reg;
+		};
+		render(
+			<TestWrapper
+				setRegistry={ setRegistry }
+				value={ value1 }
+				onChange={ onChange }
+				onInput={ onInput }
+			/>
+		);
+		onChange.mockClear();
+		onInput.mockClear();
+
+		registry
+			.dispatch( blockEditorStore )
+			.__unstableMarkNextChangeAsNotPersistent( {
+				history: 'ignore',
+			} );
+		registry
+			.dispatch( blockEditorStore )
+			.updateBlockAttributes( 'a', { foo: 2 } );
+
+		expect( onInput ).toHaveBeenCalledWith(
+			[ { clientId: 'a', innerBlocks: [], attributes: { foo: 2 } } ],
+			expect.objectContaining( {
+				selection: expect.any( Object ),
+				undoIgnore: true,
+			} )
+		);
+		expect( onChange ).not.toHaveBeenCalled();
+	} );
+
 	it( 'calls onChange if a persistent change occurs', async () => {
 		const onChange = jest.fn();
 		const onInput = jest.fn();

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -342,6 +342,7 @@ export default function useBlockSync( {
 		const {
 			getSelectedBlocksInitialCaretPosition,
 			isLastBlockChangePersistent,
+			__unstableGetLastBlockChangeHistoryMode,
 			__unstableIsLastBlockChangeIgnored,
 			areInnerBlocksControlled,
 			getBlockParents,
@@ -349,6 +350,7 @@ export default function useBlockSync( {
 
 		let blocks = getBlocks( clientId );
 		let isPersistent = isLastBlockChangePersistent();
+		let blockHistoryMode = __unstableGetLastBlockChangeHistoryMode();
 		let previousAreBlocksDifferent = false;
 		let prevSelectionStart = getSelectionStart();
 		let prevSelectionEnd = getSelectionEnd();
@@ -367,6 +369,8 @@ export default function useBlockSync( {
 			}
 
 			const newIsPersistent = isLastBlockChangePersistent();
+			const newBlockHistoryMode =
+				__unstableGetLastBlockChangeHistoryMode();
 			const newBlocks = getBlocks( clientId );
 			const areBlocksDifferent = newBlocks !== blocks;
 			blocks = newBlocks;
@@ -377,6 +381,7 @@ export default function useBlockSync( {
 			) {
 				pendingChangesRef.current.incoming = null;
 				isPersistent = newIsPersistent;
+				blockHistoryMode = newBlockHistoryMode;
 				return;
 			}
 
@@ -409,6 +414,7 @@ export default function useBlockSync( {
 				registry.batch( () => {
 					if ( blocksChanged ) {
 						isPersistent = newIsPersistent;
+						blockHistoryMode = newBlockHistoryMode;
 
 						// For inner block controllers (clientId is set), restore external IDs
 						// before passing blocks to the parent.
@@ -438,9 +444,13 @@ export default function useBlockSync( {
 						const updateParent = isPersistent
 							? onChangeRef.current
 							: onInputRef.current;
-						updateParent( blocksForParent, {
+						const updateOptions = {
 							selection: selectionForParent,
-						} );
+						};
+						if ( blockHistoryMode === 'ignore' ) {
+							updateOptions.undoIgnore = true;
+						}
+						updateParent( blocksForParent, updateOptions );
 					}
 
 					if (

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1646,12 +1646,20 @@ export function __unstableMarkLastChangeAsPersistent() {
 }
 
 /**
- * Action that signals that the next block change should be marked explicitly as not persistent.
+ * Action that signals that the next block change should be marked explicitly
+ * as not persistent.
  *
+ * By default, non-persistent changes may still merge into undo history. Use
+ * `history: 'ignore'` for derived changes that should never be captured by undo.
+ *
+ * @param {Object} options         Options object.
+ * @param {string} options.history How the change should interact with history.
  * @return {Object} Action object.
  */
-export function __unstableMarkNextChangeAsNotPersistent() {
-	return { type: 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT' };
+export function __unstableMarkNextChangeAsNotPersistent( {
+	history = 'merge',
+} = {} ) {
+	return { type: 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT', history };
 }
 
 /**

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -419,18 +419,20 @@ const withBlockTree =
  */
 function withPersistentBlockChange( reducer ) {
 	let lastAction;
-	let markNextChangeAsNotPersistent = false;
+	let nextHistoryMode;
 
 	return ( state, action ) => {
 		const nextState = reducer( state, action );
 
-		const wasMarkedAsNotPersistent = markNextChangeAsNotPersistent;
-		markNextChangeAsNotPersistent =
-			action.type === 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT';
+		const pendingHistoryMode = nextHistoryMode;
+		nextHistoryMode =
+			action.type === 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT'
+				? action.history ?? 'merge'
+				: undefined;
 
 		const isExplicitPersistentChange =
 			action.type === 'MARK_LAST_CHANGE_AS_PERSISTENT' ||
-			wasMarkedAsNotPersistent;
+			pendingHistoryMode;
 
 		// Defer to previous state value (or default) unless changing or
 		// explicitly marking as persistent.
@@ -442,7 +444,7 @@ function withPersistentBlockChange( reducer ) {
 		}
 
 		const isPersistentChange = isExplicitPersistentChange
-			? ! wasMarkedAsNotPersistent
+			? ! pendingHistoryMode
 			: ! isUpdatingSameBlockAttribute( action, lastAction );
 
 		// In comparing against the previous action, consider only those which
@@ -450,7 +452,17 @@ function withPersistentBlockChange( reducer ) {
 		// have resulted in a changed state.
 		lastAction = action;
 
-		return { ...nextState, isPersistentChange };
+		if ( pendingHistoryMode === 'ignore' ) {
+			return {
+				...nextState,
+				isPersistentChange,
+				lastBlockChangeHistoryMode: 'ignore',
+			};
+		}
+
+		const { lastBlockChangeHistoryMode, ...blockChange } = nextState;
+
+		return { ...blockChange, isPersistentChange };
 	};
 }
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2931,6 +2931,25 @@ export function isLastBlockChangePersistent( state ) {
 }
 
 /**
+ * Returns how the most recent block change interacts with undo history.
+ *
+ * - `persistent` changes create a new undo level.
+ * - `merge` changes do not create a new undo level, but may merge into the
+ *    prior stack item history.
+ * - `ignore` changes should never be captured by undo history.
+ *
+ * @param {Object} state Block editor state.
+ *
+ * @return {'persistent'|'merge'|'ignore'} Block change history behavior.
+ */
+export function __unstableGetLastBlockChangeHistoryMode( state ) {
+	if ( state.blocks.lastBlockChangeHistoryMode ) {
+		return state.blocks.lastBlockChangeHistoryMode;
+	}
+	return state.blocks.isPersistentChange === false ? 'merge' : 'persistent';
+}
+
+/**
  * Returns the block list settings for an array of blocks, if any exist.
  *
  * @param {Object} state     Editor state.

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -53,6 +53,7 @@ const {
 	updateBlockListSettings,
 	updateSettings,
 	validateBlocksToTemplate,
+	__unstableMarkNextChangeAsNotPersistent,
 	registerInserterMediaCategory,
 	setBlockEditingMode,
 	unsetBlockEditingMode,
@@ -810,6 +811,26 @@ describe( 'actions', () => {
 				time: expect.any( Number ),
 				updateSelection: true,
 				initialPosition: 0,
+			} );
+		} );
+	} );
+
+	describe( '__unstableMarkNextChangeAsNotPersistent', () => {
+		it( 'should use merge history by default', () => {
+			expect( __unstableMarkNextChangeAsNotPersistent() ).toEqual( {
+				type: 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT',
+				history: 'merge',
+			} );
+		} );
+
+		it( 'should allow ignoring history for the next change', () => {
+			expect(
+				__unstableMarkNextChangeAsNotPersistent( {
+					history: 'ignore',
+				} )
+			).toEqual( {
+				type: 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT',
+				history: 'ignore',
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2236,6 +2236,52 @@ describe( 'state', () => {
 					expect( subsequentState.isPersistentChange ).toBe( true );
 				} );
 
+				it( 'should flag ignored history for an explicitly marked not persistent change', () => {
+					let original = deepFreeze(
+						blocks( undefined, {
+							type: 'RESET_BLOCKS',
+							blocks: [
+								{
+									clientId: 'kumquat',
+									attributes: {},
+									innerBlocks: [],
+								},
+							],
+						} )
+					);
+					original = blocks( original, {
+						type: 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT',
+						history: 'ignore',
+					} );
+
+					const nextState = blocks( original, {
+						type: 'UPDATE_BLOCK_ATTRIBUTES',
+						clientIds: [ 'kumquat' ],
+						attributes: {
+							updated: true,
+						},
+					} );
+
+					expect( nextState.isPersistentChange ).toBe( false );
+					expect( nextState.lastBlockChangeHistoryMode ).toBe(
+						'ignore'
+					);
+
+					// A subsequent change should clear the ignored history.
+					const subsequentState = blocks( nextState, {
+						type: 'UPDATE_BLOCK_ATTRIBUTES',
+						clientIds: [ 'kumquat' ],
+						attributes: {
+							other: true,
+						},
+					} );
+
+					expect( subsequentState.isPersistentChange ).toBe( true );
+					expect(
+						subsequentState.lastBlockChangeHistoryMode
+					).toBeUndefined();
+				} );
+
 				it( 'should retain reference for same state, same persistence', () => {
 					const original = deepFreeze(
 						blocks( undefined, {

--- a/packages/core-data/src/private-actions.js
+++ b/packages/core-data/src/private-actions.js
@@ -200,13 +200,18 @@ export function receiveViewConfig( kind, name, config ) {
 /**
  * Returns an action object used to notify core-data that the sync undo manager
  * state changed outside of the core-data reducer, e.g. The Yjs UndoManager
- * captured an undo level and changed the blocks in the CRDT document.
+ * captured an undo level.
+ *
+ * @param {Object}  state         The sync undo stack state.
+ * @param {boolean} state.hasRedo Whether there are changes to redo.
+ * @param {boolean} state.hasUndo Whether there are changes to undo.
  *
  * @return {Object} Action object.
  */
-export function __unstableNotifySyncUndoManagerChange() {
+export function __unstableNotifySyncUndoManagerChange( state ) {
 	return {
 		type: 'SYNC_UNDO_MANAGER_CHANGE',
+		...state,
 	};
 }
 

--- a/packages/core-data/src/private-actions.js
+++ b/packages/core-data/src/private-actions.js
@@ -198,6 +198,19 @@ export function receiveViewConfig( kind, name, config ) {
 }
 
 /**
+ * Returns an action object used to notify core-data that the sync undo manager
+ * state changed outside of the core-data reducer, e.g. The Yjs UndoManager
+ * captured an undo level and changed the blocks in the CRDT document.
+ *
+ * @return {Object} Action object.
+ */
+export function __unstableNotifySyncUndoManagerChange() {
+	return {
+		type: 'SYNC_UNDO_MANAGER_CHANGE',
+	};
+}
+
+/**
  * Returns an action object used to set the sync connection status for an entity or collection.
  *
  * @param {string}             kind   Kind of the entity.

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -21,18 +21,6 @@ const EMPTY_OBJECT = {};
  * Returns the previous edit from the current undo offset
  * for the entity records edits history, if any.
  *
- * Known Issue: Every-time state.undoManager changes, the getUndoManager
- * private selector is called (if used within useSelect and things like that)
- * which ensures the UI is always properly reactive. But, it's not the case with
- * the custom "sync" undo manager.
- *
- * Assumption: When an undo/redo is created, other parts of the core-data state
- * are likely changing simultaneously, which will trigger the selectors again.
- *
- * This issue is acceptable based on the assumption above.
- *
- * @see https://github.com/WordPress/gutenberg/pull/72407/files#r2580214235 for more details.
- *
  * @param state State tree.
  *
  * @return The undo manager.

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -460,21 +460,27 @@ export function undoManager( state = createUndoManager() ) {
 	return state;
 }
 
+// Stores a snapshot of the sync undo manager's undo/redo availability so
+// core-data selectors can react to undo stack changes.
+export function syncUndoManagerState(
+	state = { hasRedo: false, hasUndo: false },
+	action
+) {
+	switch ( action.type ) {
+		case 'SYNC_UNDO_MANAGER_CHANGE':
+			return {
+				hasRedo: action.hasRedo,
+				hasUndo: action.hasUndo,
+			};
+	}
+	return state;
+}
+
 export function editsReference( state = {}, action ) {
 	switch ( action.type ) {
 		case 'EDIT_ENTITY_RECORD':
 		case 'UNDO':
 		case 'REDO':
-			return {};
-	}
-	return state;
-}
-
-// This reducer intentionally stores no data. It only changes reference so the
-// registry notifies core-data subscribers to refresh sync undo manager state.
-export function syncUndoManagerChangeReference( state = {}, action ) {
-	switch ( action.type ) {
-		case 'SYNC_UNDO_MANAGER_CHANGE':
 			return {};
 	}
 	return state;
@@ -760,7 +766,7 @@ export default combineReducers( {
 	themeGlobalStyleRevisions,
 	entities,
 	editsReference,
-	syncUndoManagerChangeReference,
+	syncUndoManagerState,
 	undoManager,
 	embedPreviews,
 	userPermissions,

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -470,6 +470,16 @@ export function editsReference( state = {}, action ) {
 	return state;
 }
 
+// This reducer intentionally stores no data. It only changes reference so the
+// registry notifies core-data subscribers to refresh sync undo manager state.
+export function syncUndoManagerChangeReference( state = {}, action ) {
+	switch ( action.type ) {
+		case 'SYNC_UNDO_MANAGER_CHANGE':
+			return {};
+	}
+	return state;
+}
+
 /**
  * Reducer managing embed preview data.
  *
@@ -750,6 +760,7 @@ export default combineReducers( {
 	themeGlobalStyleRevisions,
 	entities,
 	editsReference,
+	syncUndoManagerChangeReference,
 	undoManager,
 	embedPreviews,
 	userPermissions,

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -287,8 +287,10 @@ export const getEntityRecord =
 								);
 							}
 						},
-						onUndoStackChange: () => {
-							dispatch.__unstableNotifySyncUndoManagerChange();
+						onUndoStackChange: ( undoState ) => {
+							dispatch.__unstableNotifySyncUndoManagerChange(
+								undoState
+							);
 						},
 						restoreUndoMeta: ( ydoc, meta ) => {
 							const selectionHistory =

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -287,6 +287,9 @@ export const getEntityRecord =
 								);
 							}
 						},
+						onUndoStackChange: () => {
+							dispatch.__unstableNotifySyncUndoManagerChange();
+						},
 						restoreUndoMeta: ( ydoc, meta ) => {
 							const selectionHistory =
 								meta.get( 'selectionHistory' );

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -44,6 +44,7 @@ export interface State {
 	themeGlobalStyleVariations: Record< string, string >;
 	themeGlobalStyleRevisions: Record< number, Object >;
 	undoManager: UndoManager;
+	syncUndoManagerChangeReference: object;
 	userPermissions: Record< string, boolean >;
 	users: UserState;
 	navigationFallbackId: EntityRecordKey;

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -24,6 +24,7 @@ import {
 	isNumericID,
 	getUserPermissionCacheKey,
 } from './utils';
+import { getSyncManager } from './sync';
 import type * as ET from './entity-types';
 import logEntityDeprecation from './utils/log-entity-deprecation';
 
@@ -44,7 +45,10 @@ export interface State {
 	themeGlobalStyleVariations: Record< string, string >;
 	themeGlobalStyleRevisions: Record< number, Object >;
 	undoManager: UndoManager;
-	syncUndoManagerChangeReference: object;
+	syncUndoManagerState: {
+		hasRedo: boolean;
+		hasUndo: boolean;
+	};
 	userPermissions: Record< string, boolean >;
 	users: UserState;
 	navigationFallbackId: EntityRecordKey;
@@ -1149,6 +1153,9 @@ export function getRedoEdit( state: State ): Optional< any > {
  * @return Whether there is a previous edit or not.
  */
 export function hasUndo( state: State ): boolean {
+	if ( getSyncManager()?.undoManager ) {
+		return state.syncUndoManagerState.hasUndo;
+	}
 	return getUndoManager( state ).hasUndo();
 }
 
@@ -1161,6 +1168,9 @@ export function hasUndo( state: State ): boolean {
  * @return Whether there is a next edit or not.
  */
 export function hasRedo( state: State ): boolean {
+	if ( getSyncManager()?.undoManager ) {
+		return state.syncUndoManagerState.hasRedo;
+	}
 	return getUndoManager( state ).hasRedo();
 }
 

--- a/packages/core-data/src/test/private-selectors.js
+++ b/packages/core-data/src/test/private-selectors.js
@@ -1,0 +1,66 @@
+/**
+ * Internal dependencies
+ */
+import { getUndoManager } from '../private-selectors';
+import { getSyncManager } from '../sync';
+
+jest.mock( '../sync', () => ( {
+	getSyncManager: jest.fn(),
+} ) );
+
+describe( 'getUndoManager', () => {
+	afterEach( () => {
+		getSyncManager.mockReset();
+	} );
+
+	it( 'returns the sync undo manager when one is available', () => {
+		const syncUndoManager = {
+			addRecord: jest.fn(),
+			hasRedo: jest.fn(),
+			hasUndo: jest.fn(),
+			redo: jest.fn(),
+			undo: jest.fn(),
+		};
+		const fallbackUndoManager = {
+			addRecord: jest.fn(),
+			hasRedo: jest.fn(),
+			hasUndo: jest.fn(),
+			redo: jest.fn(),
+			undo: jest.fn(),
+		};
+		getSyncManager.mockReturnValue( {
+			undoManager: syncUndoManager,
+		} );
+
+		const state = {
+			undoManager: fallbackUndoManager,
+			syncUndoManagerState: {
+				hasRedo: false,
+				hasUndo: false,
+			},
+		};
+
+		expect( getUndoManager( state ) ).toBe( syncUndoManager );
+	} );
+
+	it( 'returns the default undo manager when there is no sync undo manager', () => {
+		const fallbackUndoManager = {
+			addRecord: jest.fn(),
+			hasRedo: jest.fn(),
+			hasUndo: jest.fn(),
+			redo: jest.fn(),
+			undo: jest.fn(),
+		};
+		getSyncManager.mockReturnValue( undefined );
+
+		expect(
+			getUndoManager( {
+				undoManager: fallbackUndoManager,
+				syncUndoManagerState: {
+					hasRedo: false,
+					hasUndo: false,
+				},
+			} )
+		).toBe( fallbackUndoManager );
+	} );
+} );

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -12,7 +12,8 @@ import {
 	userPermissions,
 	autosaves,
 	currentUser,
-	syncUndoManagerChangeReference,
+	syncUndoManagerState,
+	undoManager,
 } from '../reducer';
 
 describe( 'entities', () => {
@@ -533,22 +534,44 @@ describe( 'currentUser', () => {
 	} );
 } );
 
-describe( 'syncUndoManagerChangeReference', () => {
-	it( 'returns a new reference when the sync undo manager changes', () => {
-		const originalState = {};
-		const state = syncUndoManagerChangeReference( originalState, {
-			type: 'SYNC_UNDO_MANAGER_CHANGE',
-		} );
-
-		expect( state ).not.toBe( originalState );
-	} );
-
+describe( 'undoManager', () => {
 	it( 'returns the same reference for unrelated actions', () => {
-		const originalState = {};
-		const state = syncUndoManagerChangeReference( originalState, {
+		const originalState = undoManager( undefined, {} );
+		const state = undoManager( originalState, {
 			type: 'UNRELATED',
 		} );
 
 		expect( state ).toBe( originalState );
+	} );
+} );
+
+describe( 'syncUndoManagerState', () => {
+	it( 'stores sync undo manager availability', () => {
+		const state = syncUndoManagerState( undefined, {
+			type: 'SYNC_UNDO_MANAGER_CHANGE',
+			hasRedo: false,
+			hasUndo: true,
+		} );
+
+		expect( state ).toEqual( {
+			hasRedo: false,
+			hasUndo: true,
+		} );
+	} );
+
+	it( 'updates sync undo manager availability', () => {
+		const state = syncUndoManagerState(
+			{ hasRedo: false, hasUndo: true },
+			{
+				type: 'SYNC_UNDO_MANAGER_CHANGE',
+				hasRedo: true,
+				hasUndo: false,
+			}
+		);
+
+		expect( state ).toEqual( {
+			hasRedo: true,
+			hasUndo: false,
+		} );
 	} );
 } );

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -12,6 +12,7 @@ import {
 	userPermissions,
 	autosaves,
 	currentUser,
+	syncUndoManagerChangeReference,
 } from '../reducer';
 
 describe( 'entities', () => {
@@ -529,5 +530,25 @@ describe( 'currentUser', () => {
 		);
 
 		expect( state ).toEqual( currentUserData );
+	} );
+} );
+
+describe( 'syncUndoManagerChangeReference', () => {
+	it( 'returns a new reference when the sync undo manager changes', () => {
+		const originalState = {};
+		const state = syncUndoManagerChangeReference( originalState, {
+			type: 'SYNC_UNDO_MANAGER_CHANGE',
+		} );
+
+		expect( state ).not.toBe( originalState );
+	} );
+
+	it( 'returns the same reference for unrelated actions', () => {
+		const originalState = {};
+		const state = syncUndoManagerChangeReference( originalState, {
+			type: 'UNRELATED',
+		} );
+
+		expect( state ).toBe( originalState );
 	} );
 } );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -50,6 +50,7 @@ describe( 'getEntityRecord', () => {
 			receiveEntityRecords: jest.fn(),
 			__unstableAcquireStoreLock: jest.fn(),
 			__unstableReleaseStoreLock: jest.fn(),
+			__unstableNotifySyncUndoManagerChange: jest.fn(),
 			receiveUserPermissions: jest.fn(),
 			finishResolutions: jest.fn(),
 		} );
@@ -173,12 +174,54 @@ describe( 'getEntityRecord', () => {
 				addUndoMeta: expect.any( Function ),
 				editRecord: expect.any( Function ),
 				getEditedRecord: expect.any( Function ),
+				onUndoStackChange: expect.any( Function ),
 				onStatusChange: expect.any( Function ),
 				persistCRDTDoc: expect.any( Function ),
 				refetchRecord: expect.any( Function ),
 				restoreUndoMeta: expect.any( Function ),
 			}
 		);
+	} );
+
+	it( 'notifies core-data when the sync undo manager stack changes', async () => {
+		const POST_RECORD = { id: 1, title: 'Test Post' };
+		const POST_RESPONSE = {
+			json: () => Promise.resolve( POST_RECORD ),
+		};
+		const ENTITIES_WITH_SYNC = [
+			{
+				name: 'post',
+				kind: 'postType',
+				baseURL: '/wp/v2/posts',
+				baseURLParams: { context: 'edit' },
+				syncConfig: {},
+			},
+		];
+
+		const resolveSelectWithSync = {
+			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
+			getEditedEntityRecord: jest.fn(),
+		};
+
+		triggerFetch.mockImplementation( () => POST_RESPONSE );
+
+		await getEntityRecord(
+			'postType',
+			'post',
+			1
+		)( {
+			dispatch,
+			registry,
+			resolveSelect: resolveSelectWithSync,
+		} );
+
+		const handlers = syncManager.load.mock.calls[ 0 ][ 4 ];
+
+		handlers.onUndoStackChange();
+
+		expect(
+			dispatch.__unstableNotifySyncUndoManagerChange
+		).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'persistCRDTDoc fetches edited record and does not save full entity record when the entity does not support meta', async () => {
@@ -507,6 +550,7 @@ describe( 'getEntityRecord', () => {
 				addUndoMeta: expect.any( Function ),
 				editRecord: expect.any( Function ),
 				getEditedRecord: expect.any( Function ),
+				onUndoStackChange: expect.any( Function ),
 				onStatusChange: expect.any( Function ),
 				persistCRDTDoc: expect.any( Function ),
 				refetchRecord: expect.any( Function ),

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -217,11 +217,11 @@ describe( 'getEntityRecord', () => {
 
 		const handlers = syncManager.load.mock.calls[ 0 ][ 4 ];
 
-		handlers.onUndoStackChange();
+		handlers.onUndoStackChange( { hasRedo: false, hasUndo: true } );
 
 		expect(
 			dispatch.__unstableNotifySyncUndoManagerChange
-		).toHaveBeenCalledTimes( 1 );
+		).toHaveBeenCalledWith( { hasRedo: false, hasUndo: true } );
 	} );
 
 	it( 'persistCRDTDoc fetches edited record and does not save full entity record when the entity does not support meta', async () => {

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -24,7 +24,55 @@ import {
 	getRevisions,
 	getRevision,
 	hasRevision,
+	hasUndo,
+	hasRedo,
 } from '../selectors';
+import { getSyncManager } from '../sync';
+
+jest.mock( '../sync', () => ( {
+	getSyncManager: jest.fn(),
+} ) );
+
+describe( 'hasUndo/hasRedo', () => {
+	afterEach( () => {
+		getSyncManager.mockReset();
+	} );
+
+	it( 'reads undo availability from core-data state when a sync undo manager is available', () => {
+		const undoManager = {
+			hasUndo: jest.fn( () => false ),
+			hasRedo: jest.fn( () => false ),
+		};
+		getSyncManager.mockReturnValue( { undoManager } );
+
+		const state = deepFreeze( {
+			syncUndoManagerState: {
+				hasRedo: true,
+				hasUndo: true,
+			},
+		} );
+
+		expect( hasUndo( state ) ).toBe( true );
+		expect( hasRedo( state ) ).toBe( true );
+		expect( undoManager.hasUndo ).not.toHaveBeenCalled();
+		expect( undoManager.hasRedo ).not.toHaveBeenCalled();
+	} );
+
+	it( 'falls back to the default undo manager when no sync undo manager is available', () => {
+		const undoManager = {
+			hasUndo: jest.fn( () => true ),
+			hasRedo: jest.fn( () => false ),
+		};
+		getSyncManager.mockReturnValue( undefined );
+
+		const state = { undoManager };
+
+		expect( hasUndo( state ) ).toBe( true );
+		expect( hasRedo( state ) ).toBe( false );
+		expect( undoManager.hasUndo ).toHaveBeenCalled();
+		expect( undoManager.hasRedo ).toHaveBeenCalled();
+	} );
+} );
 
 describe( 'getEntityRecord', () => {
 	describe( 'normalizing Post ID passed as recordKey', () => {

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -186,6 +186,10 @@ export function createSyncManager( debug = false ): SyncManager {
 			persistCRDTDoc: debugWrap( handlers.persistCRDTDoc ),
 			refetchRecord: debugWrap( handlers.refetchRecord ),
 			restoreUndoMeta: debugWrap( handlers.restoreUndoMeta ),
+
+			onUndoStackChange: handlers.onUndoStackChange
+				? debugWrap( handlers.onUndoStackChange )
+				: undefined,
 		};
 
 		const ydoc = createYjsDoc( { objectType } );
@@ -261,10 +265,11 @@ export function createSyncManager( debug = false ): SyncManager {
 			undoManager = createUndoManager();
 		}
 
-		const { addUndoMeta, restoreUndoMeta } = handlers;
+		const { addUndoMeta, onUndoStackChange, restoreUndoMeta } = handlers;
 		undoManager.addToScope( recordMap, {
 			addUndoMeta,
 			restoreUndoMeta,
+			onUndoStackChange,
 		} );
 
 		// Declare with let before using it in unload closure.

--- a/packages/sync/src/test/undo-manager.test.ts
+++ b/packages/sync/src/test/undo-manager.test.ts
@@ -25,10 +25,41 @@ describe( 'SyncUndoManager', () => {
 			map: doc.getMap( 'record' ),
 			handlers: {
 				addUndoMeta: jest.fn(),
+				onUndoStackChange: jest.fn(),
 				restoreUndoMeta: jest.fn(),
 			},
 		};
 	}
+
+	it( 'notifies scoped handlers when the Yjs undo stack changes', () => {
+		const undoManager = createUndoManager();
+		const first = createScopedMap();
+		const second = createScopedMap();
+
+		undoManager.addToScope( first.map, first.handlers );
+		undoManager.addToScope( second.map, second.handlers );
+
+		first.doc.transact( () => {
+			first.map.set( 'title', 'First changed' );
+		}, LOCAL_EDITOR_ORIGIN );
+
+		expect( first.handlers.onUndoStackChange ).toHaveBeenCalled();
+		expect( second.handlers.onUndoStackChange ).not.toHaveBeenCalled();
+
+		first.handlers.onUndoStackChange.mockClear();
+
+		undoManager.undo();
+
+		expect( first.handlers.onUndoStackChange ).toHaveBeenCalled();
+		expect( second.handlers.onUndoStackChange ).not.toHaveBeenCalled();
+
+		first.handlers.onUndoStackChange.mockClear();
+
+		undoManager.redo();
+
+		expect( first.handlers.onUndoStackChange ).toHaveBeenCalled();
+		expect( second.handlers.onUndoStackChange ).not.toHaveBeenCalled();
+	} );
 
 	it( 'only runs metadata handlers for the document that created the stack item', () => {
 		const undoManager = createUndoManager();

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -134,6 +134,7 @@ export interface RecordHandlers {
 	persistCRDTDoc: () => void;
 	refetchRecord: () => Promise< void >;
 	restoreUndoMeta: ( ydoc: Y.Doc, meta: Map< string, any > ) => void;
+	onUndoStackChange?: () => void;
 }
 
 export interface SyncConfig {
@@ -193,7 +194,10 @@ export interface SyncManager {
 export interface SyncUndoManager extends WPUndoManager< ObjectData > {
 	addToScope: (
 		ymap: Y.Map< any >,
-		handlers: Pick< RecordHandlers, 'addUndoMeta' | 'restoreUndoMeta' >
+		handlers: Pick<
+			RecordHandlers,
+			'addUndoMeta' | 'restoreUndoMeta' | 'onUndoStackChange'
+		>
 	) => void;
 	stopCapturing: () => void;
 }

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -123,6 +123,11 @@ export interface SyncManagerUpdateOptions {
 	isNewUndoLevel?: boolean;
 }
 
+export interface SyncUndoStackState {
+	hasRedo: boolean;
+	hasUndo: boolean;
+}
+
 export interface RecordHandlers {
 	addUndoMeta: ( ydoc: Y.Doc, meta: Map< string, any > ) => void;
 	editRecord: (
@@ -134,7 +139,7 @@ export interface RecordHandlers {
 	persistCRDTDoc: () => void;
 	refetchRecord: () => Promise< void >;
 	restoreUndoMeta: ( ydoc: Y.Doc, meta: Map< string, any > ) => void;
-	onUndoStackChange?: () => void;
+	onUndoStackChange?: ( state: SyncUndoStackState ) => void;
 }
 
 export interface SyncConfig {

--- a/packages/sync/src/undo-manager.ts
+++ b/packages/sync/src/undo-manager.ts
@@ -13,7 +13,12 @@ import type { HistoryRecord } from '@wordpress/undo-manager';
  */
 import { LOCAL_EDITOR_ORIGIN } from './config';
 import { YMultiDocUndoManager } from './y-utilities/y-multidoc-undomanager';
-import type { ObjectData, RecordHandlers, SyncUndoManager } from './types';
+import type {
+	ObjectData,
+	RecordHandlers,
+	SyncUndoManager,
+	SyncUndoStackState,
+} from './types';
 
 type UndoMetaHandlers = Pick<
 	RecordHandlers,
@@ -46,8 +51,15 @@ export function createUndoManager(): SyncUndoManager {
 		trackedOrigins: new Set( [ LOCAL_EDITOR_ORIGIN ] ),
 	} );
 
+	const getUndoStackState = (): SyncUndoStackState => ( {
+		hasRedo: yUndoManager.canRedo(),
+		hasUndo: yUndoManager.canUndo(),
+	} );
+
 	const notifyUndoStackChange = ( ydoc: Y.Doc ): void => {
-		undoMetaHandlers.get( ydoc )?.onUndoStackChange?.();
+		undoMetaHandlers
+			.get( ydoc )
+			?.onUndoStackChange?.( getUndoStackState() );
 	};
 
 	yUndoManager.on( 'stack-item-added', ( event: StackItemEvent ) => {
@@ -76,7 +88,7 @@ export function createUndoManager(): SyncUndoManager {
 
 	yUndoManager.on( 'stack-cleared', () => {
 		undoMetaHandlers.forEach( ( handlers ) => {
-			handlers.onUndoStackChange?.();
+			handlers.onUndoStackChange?.( getUndoStackState() );
 		} );
 	} );
 

--- a/packages/sync/src/undo-manager.ts
+++ b/packages/sync/src/undo-manager.ts
@@ -17,7 +17,7 @@ import type { ObjectData, RecordHandlers, SyncUndoManager } from './types';
 
 type UndoMetaHandlers = Pick<
 	RecordHandlers,
-	'addUndoMeta' | 'restoreUndoMeta'
+	'addUndoMeta' | 'onUndoStackChange' | 'restoreUndoMeta'
 >;
 
 interface StackItemEvent {
@@ -46,6 +46,10 @@ export function createUndoManager(): SyncUndoManager {
 		trackedOrigins: new Set( [ LOCAL_EDITOR_ORIGIN ] ),
 	} );
 
+	const notifyUndoStackChange = ( ydoc: Y.Doc ): void => {
+		undoMetaHandlers.get( ydoc )?.onUndoStackChange?.();
+	};
+
 	yUndoManager.on( 'stack-item-added', ( event: StackItemEvent ) => {
 		const handlers = undoMetaHandlers.get( event.ydoc );
 		if ( ! handlers ) {
@@ -53,6 +57,11 @@ export function createUndoManager(): SyncUndoManager {
 		}
 
 		handlers.addUndoMeta( event.ydoc, event.stackItem.meta );
+		notifyUndoStackChange( event.ydoc );
+	} );
+
+	yUndoManager.on( 'stack-item-updated', ( event: StackItemEvent ) => {
+		notifyUndoStackChange( event.ydoc );
 	} );
 
 	yUndoManager.on( 'stack-item-popped', ( event: StackItemEvent ) => {
@@ -62,6 +71,13 @@ export function createUndoManager(): SyncUndoManager {
 		}
 
 		handlers.restoreUndoMeta( event.ydoc, event.stackItem.meta );
+		notifyUndoStackChange( event.ydoc );
+	} );
+
+	yUndoManager.on( 'stack-cleared', () => {
+		undoMetaHandlers.forEach( ( handlers ) => {
+			handlers.onUndoStackChange?.();
+		} );
 	} );
 
 	return {
@@ -84,10 +100,11 @@ export function createUndoManager(): SyncUndoManager {
 		/**
 		 * Add a Yjs map to the scope of the undo manager.
 		 *
-		 * @param {Y.Map< any >} ymap                     The Yjs map to add to the scope.
-		 * @param                handlers
-		 * @param                handlers.addUndoMeta
-		 * @param                handlers.restoreUndoMeta
+		 * @param {Y.Map< any >} ymap                       The Yjs map to add to the scope.
+		 * @param                handlers                   Handlers for the scoped document.
+		 * @param                handlers.addUndoMeta       Handler to add metadata to undo items.
+		 * @param                handlers.onUndoStackChange Handler for undo stack changes.
+		 * @param                handlers.restoreUndoMeta   Handler to restore metadata from undo items.
 		 */
 		addToScope( ymap: Y.Map< any >, handlers: UndoMetaHandlers ): void {
 			if ( ymap.doc === null ) {


### PR DESCRIPTION
## What?

This is a human-written PR description. Two main changes:

1. Add `onUndoStackChange()` callback to sync manager handlers so that Yjs undo stack operations necessarily communicate with the core-data store and update editor UI when Yjs adds an undo item or changes the undo stack. This was added in https://github.com/WordPress/gutenberg/pull/78864/commits/7985ed0e0b996b1c32a966287736ccb99ce8eb30, which caused the `inner-blocks-templates.spec.js` test to fail correctly below in https://github.com/WordPress/gutenberg/actions/runs/26774227868/job/78921451086.

2. Add a flag to `__unstableMarkNextChangeAsNotPersistent()` to indicate whether history should be merged with a prior undo stack item (`history = 'merge'`) or should be completely ignored (`history = 'ignore'`).

    Typically `__unstableMarkNextChangeAsNotPersistent()` calls are proceeded by [an `onChange()` call](https://github.com/WordPress/gutenberg/blob/0069b18f6438487f87efa903f38a14c2be1c86cd/packages/block-editor/src/components/child-layout-control/index.js#L371-L386), and the flag is used to mark "merge the next operation into the existing undo stack". However in `useInnerBlockTemplateSync()` the non-persistent call [is NOT paired with an existing change](https://github.com/WordPress/gutenberg/blob/62088e26b0cecf29fdabfc6da1992793b186ba81/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js#L94). On a fresh page load, which happens in the test, there is no prior undo item to roll changes into, and so the Yjs undo manager creates a fresh undo for the entity change anyway.
    
3. Change `hasUndo()` / `hasRedo()` in core-data to react to sync undo manager updates.

## Why?

This change is necessary to merge another PR which changes CRDT timing in https://github.com/WordPress/gutenberg/pull/78756. The change in CRDT timing caused the `inner-blocks-templates.spec.js` test to fail for legitimate reasons related to a now-visible dirty undo stack and uncovered the [original bug discussion](https://github.com/WordPress/gutenberg/pull/72407/changes#r2580214235).

## How?

See this original called shot from @youknowriad in https://github.com/WordPress/gutenberg/pull/72407/changes#r2580214235:

> One subtle issue here is that every-time `state.undoManager` changes, the `getUndoManager` private selector is called ... which ensures the UI is always properly reactive.
>
> But, it's not the case with the custom "sync" undo manager.

In short, when the Yjs undo manager adds a new item to the stack, it doesn't notify the UI that something has changed so it can re-render the undo/redo UI toolbar actions. We relied on the fact that typically other things are also changing in core data, so UI state will probably get updated anyway. This seemed to work okay, but a timing change in an unrelated PR https://github.com/WordPress/gutenberg/pull/78756 uncovered this problem again and caused the `inner-blocks-templates.spec.js` test to fail.

Previously the `inner-blocks-templates.spec.js` test was passing because of the deferred CRDT update, so even though **Yjs is incorrectly adding an undo level** from an async template addition, **it wasn't registered in the UI** because the Yjs UndoManager stack add operation fires *after* the UI finishes rendering. So an undo is still available (incorrectly), but it wasn't reflected in the UI which is [what the test checks for](https://github.com/WordPress/gutenberg/blob/ca0c24dac4d8d33530c774eaf8c998799ac19b19/test/e2e/specs/editor/various/inner-blocks-templates.spec.js#L55).

The second `__unstableMarkNextChangeAsNotPersistent()` allows Yjs to understand when an item should be merged with a prior stack item (the typical case) or should always be ignored (the inner template sync case). Nearly all existing calls are implicitly `history = 'merge'`, with the exception of async template loading. The Yjs undo manager doesn't have the concept of a "staged" but not-yet-committed undo item like the built-in manager, and this gives us enough context to know if a cached edit should be committed to storage. 

## Testing Instructions

The main failure and fix can be verified in CI:

1. First, we ensured undo manager updates correctly update the undo/redo UI in https://github.com/WordPress/gutenberg/pull/78864/commits/7985ed0e0b996b1c32a966287736ccb99ce8eb30. This caused the `inner-blocks-templates.spec.js` test to correctly start failing in https://github.com/WordPress/gutenberg/actions/runs/26774227868/job/78921451086.
2. The next set of commits added the `history` flag to `__unstableMarkNextChangeAsNotPersistent()` which Yjs can use to drop async template edits in undo history (https://github.com/WordPress/gutenberg/pull/78864/commits/a065a762ed016b3fdecd3ea168e0dbc0e01836d5, tests in https://github.com/WordPress/gutenberg/pull/78864/commits/0069b18f6438487f87efa903f38a14c2be1c86cd). `inner-blocks-templates.spec.js` and all other tests now succeed.

## Use of AI Tools

AI assistance: Yes
Tool(s): Codex + Claude Code
Used for: Drilling deep into the problem, writing a fix