### PR TITLE
Fix @wordpress/data README fragment links

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -613,9 +613,9 @@ _Returns_
 
 ### RegistryConsumer
 
-A custom react Context consumer exposing the provided `registry` to children components. Used along with the RegistryProvider.
+A custom React context consumer exposing the provided `registry` to children components. Used along with the RegistryProvider.
 
-You can read more about the react context api here: <https://react.dev/learn/passing-data-deeply-with-context#step-3-provide-the-context>
+You can read more about the React context API here: <https://react.dev/learn/passing-data-deeply-with-context#step-3-provide-the-context>
 
 _Usage_
 
@@ -646,7 +646,7 @@ const App = ( { props } ) => {
 
 A custom Context provider for exposing the provided `registry` to children components via a consumer.
 
-See <a name="#RegistryConsumer">RegistryConsumer</a> documentation for example.
+See <a href="#registryconsumer">RegistryConsumer</a> documentation for example.
 
 ### resolveSelect
 
@@ -790,11 +790,11 @@ _Returns_
 
 ### useRegistry
 
-A custom react hook exposing the registry context for use.
+A custom React hook exposing the registry context for use.
 
-This exposes the `registry` value provided via the <a href="#RegistryProvider">Registry Provider</a> to a component implementing this hook.
+This exposes the `registry` value provided via the <a href="#registryprovider">Registry Provider</a> to a component implementing this hook.
 
-It acts similarly to the `useContext` react hook.
+It acts similarly to the `useContext` React hook.
 
 Note: Generally speaking, `useRegistry` is a low level hook that in most cases won't be needed for implementation. Most interactions with the `@wordpress/data` API can be performed via the `useSelect` hook, or the `withSelect` and `withDispatch` higher order components.
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -821,7 +821,7 @@ const ParentProvidingRegistry = ( props ) => {
 
 _Returns_
 
--   `DataRegistry`: A custom react hook exposing the registry context value.
+-   `DataRegistry`: A custom React hook exposing the registry context value.
 
 ### useSelect
 

--- a/packages/data/src/components/registry-provider/context.ts
+++ b/packages/data/src/components/registry-provider/context.ts
@@ -14,10 +14,10 @@ Context.displayName = 'RegistryProviderContext';
 const { Consumer, Provider } = Context;
 
 /**
- * A custom react Context consumer exposing the provided `registry` to
+ * A custom React context consumer exposing the provided `registry` to
  * children components. Used along with the RegistryProvider.
  *
- * You can read more about the react context api here:
+ * You can read more about the React context API here:
  * https://react.dev/learn/passing-data-deeply-with-context#step-3-provide-the-context
  *
  * @example
@@ -50,7 +50,7 @@ export const RegistryConsumer = Consumer;
  * A custom Context provider for exposing the provided `registry` to children
  * components via a consumer.
  *
- * See <a name="#RegistryConsumer">RegistryConsumer</a> documentation for
+ * See <a href="#registryconsumer">RegistryConsumer</a> documentation for
  * example.
  */
 export default Provider;

--- a/packages/data/src/components/registry-provider/use-registry.ts
+++ b/packages/data/src/components/registry-provider/use-registry.ts
@@ -10,17 +10,17 @@ import { Context } from './context';
 import type { DataRegistry } from '../../types';
 
 /**
- * A custom react hook exposing the registry context for use.
+ * A custom React hook exposing the registry context for use.
  *
  * This exposes the `registry` value provided via the
- * <a href="#RegistryProvider">Registry Provider</a> to a component implementing
+ * <a href="#registryprovider">Registry Provider</a> to a component implementing
  * this hook.
  *
- * It acts similarly to the `useContext` react hook.
+ * It acts similarly to the `useContext` React hook.
  *
  * Note: Generally speaking, `useRegistry` is a low level hook that in most cases
  * won't be needed for implementation. Most interactions with the `@wordpress/data`
- * API can be performed via the `useSelect` hook,  or the `withSelect` and
+ * API can be performed via the `useSelect` hook, or the `withSelect` and
  * `withDispatch` higher order components.
  *
  * @example
@@ -46,7 +46,7 @@ import type { DataRegistry } from '../../types';
  * };
  * ```
  *
- * @return A custom react hook exposing the registry context value.
+ * @return A custom React hook exposing the registry context value.
  */
 export default function useRegistry(): DataRegistry {
 	return useContext( Context );


### PR DESCRIPTION
## What?
Fixes broken fragment links in the generated `@wordpress/data` README documentation for `RegistryProvider` and `RegistryConsumer`.

## Why?
The generated package docs linked to uppercase fragment IDs, but the rendered headings use lowercase IDs. This meant the links did not jump to the intended sections.

## How?
- Updates the source JSDoc comments used for the generated API docs.
- Updates the generated `packages/data/README.md` output to match.
- Cleans up nearby React wording in the same comments.

Fixes WordPress/Documentation-Issue-Tracker#2000.

## Testing Instructions
- Confirmed `#registryprovider` and `#registryconsumer` match the generated README headings.
- Ran `git diff --check`.