### PR TITLE
Scripts: Remove obsolete bin/setup-local-env.sh

### DIFF
--- a/bin/setup-local-env.sh
+++ b/bin/setup-local-env.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Exit if any command fails.
-set -e
-
-echo "Hi there! It looks like you're trying to use the old local environment setup script. This script has been retired, running \`npm run wp-env start\` will setup a local environment for you, instead.
-
-Check out the documentation for more information: https://developer.wordpress.org/block-editor/contributors/develop/getting-started/"


### PR DESCRIPTION
## What?

Removes the obsolete `bin/setup-local-env.sh` script. It's a part of the clean up of the `bin/` directory in #75041.

## Why?

This script was retired roughly 7 years ago in [#17004](https://github.com/WordPress/gutenberg/pull/17004) ("Switch to using the Core local environment"), when the project moved to `wp-env` / the Core local environment. Since then its only content has been a notice telling users it has been retired and to run `npm run wp-env start` instead.

Nothing in the codebase references the script anymore (no `package.json` scripts, docs, or other tooling point to it), so the stub serves no purpose and can be safely removed.

## How?

Deletes `bin/setup-local-env.sh`. No other files reference it, so no further changes are needed.

## Testing Instructions

1. Confirm `bin/setup-local-env.sh` no longer exists.
2. Run `git grep setup-local-env` and verify there are no remaining references.
3. Verify the documented local-environment workflow is unaffected: `npm run wp-env start` still sets up a local environment as expected.

### Testing Instructions for Keyboard

N/A — no user interface changes.

## Screenshots or screencast

N/A

## Use of AI Tools

This pull request was authored with the assistance of Claude Code. All changes were reviewed by the author.
