### PR TITLE
Update CODEOWNERS for tooling directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,8 +53,8 @@
 /packages/interactivity                         @luisherranz @darerodz
 
 # Tooling
-/bin                                            @ntwb @nerrad @ajitbohra
-/bin/api-docs                                   @ntwb @nerrad @ajitbohra
+/bin                                            @ntwb @nerrad @ajitbohra @manzoorwanijk
+/tools                                          @manzoorwanijk
 /packages/babel-plugin-import-jsx-pragma        @ntwb @nerrad @ajitbohra
 /packages/babel-plugin-makepot                  @ntwb @nerrad @ajitbohra
 /packages/babel-preset-default                  @ntwb @nerrad @ajitbohra


### PR DESCRIPTION
> Heads up: I'd like to add myself as a code owner for the tooling directories here. Please let me know if you have any concerns with that. And if anyone else would like to keep an eye on this area too, let me know and I'm happy to add you alongside.

## What?

Updates `.github/CODEOWNERS` to:

- Add `@manzoorwanijk` as a code owner of the `/tools` directory.
- Add `@manzoorwanijk` as an additional code owner of the `/bin` directory.
- Remove the obsolete `/bin/api-docs` entry, which no longer exists in the repository.

## Why?

Following the changes we made in #75041, I'd like to keep an eye on the tooling under `/tools` and `/bin`. Being listed as a code owner ensures I'm automatically requested for review on changes to those areas so I can keep track of how they evolve.

The `/bin/api-docs` path was also stale — that directory no longer exists, so its CODEOWNERS entry served no purpose and could only cause confusion.

## How?

Edited `.github/CODEOWNERS` in the **Tooling** section:

- Appended `@manzoorwanijk` to the existing `/bin` rule, keeping the current owners intact.
- Added a new `/tools @manzoorwanijk` rule.
- Deleted the `/bin/api-docs` line.

## Testing Instructions

1. Open `.github/CODEOWNERS`.
2. Confirm the **Tooling** section contains:
   - `/bin @ntwb @nerrad @ajitbohra @manzoorwanijk`
   - `/tools @manzoorwanijk`
3. Confirm there is no longer a `/bin/api-docs` entry.
4. (Optional) On GitHub, open a draft PR touching a file under `/tools` and verify `@manzoorwanijk` is automatically requested for review.

### Testing Instructions for Keyboard

N/A — no user-facing UI changes.

## Screenshots or screencast

N/A

## Use of AI Tools

This pull request was authored with the assistance of AI tooling (Claude Code). All changes were reviewed by a human before submission.
