### PR TITLE
Spacer block: Allow height controls inside Row blocks

### DIFF
--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -90,8 +90,34 @@ export default function SpacerControls( {
 	height,
 	width,
 	isResizing,
+	isFlexLayout,
+	blockStyle,
+	layout,
 } ) {
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const isHorizontal = orientation === 'horizontal';
+
+	const handleWidthChange = ( nextWidth ) => {
+		if ( isFlexLayout ) {
+			setAttributes( {
+				width: nextWidth,
+				style: {
+					...blockStyle,
+					layout: {
+						...layout,
+						flexSize: nextWidth,
+						selfStretch: 'fixed',
+					},
+				},
+			} );
+		} else {
+			setAttributes( { width: nextWidth } );
+		}
+	};
+
+	const handleHeightChange = ( nextHeight ) => {
+		setAttributes( { height: nextHeight } );
+	};
 
 	return (
 		<InspectorControls>
@@ -105,7 +131,7 @@ export default function SpacerControls( {
 				} }
 				dropdownMenuProps={ dropdownMenuProps }
 			>
-				{ orientation === 'horizontal' && (
+				{ isHorizontal && (
 					<ToolsPanelItem
 						label={ __( 'Width' ) }
 						isShownByDefault
@@ -117,14 +143,18 @@ export default function SpacerControls( {
 						<DimensionInput
 							label={ __( 'Width' ) }
 							value={ width }
-							onChange={ ( nextWidth ) =>
-								setAttributes( { width: nextWidth } )
-							}
+							onChange={ handleWidthChange }
 							isResizing={ isResizing }
 						/>
 					</ToolsPanelItem>
 				) }
-				{ orientation !== 'horizontal' && (
+				{ /*
+				 * Height is always shown, including when the Spacer is a direct
+				 * descendant of a Row block (horizontal flex layout). A spacer
+				 * inside a wrapping Row still needs height control — e.g. to add
+				 * extra vertical space on mobile when the row's flex items stack.
+				 */ }
+				{ ( ! isHorizontal || isFlexLayout ) && (
 					<ToolsPanelItem
 						label={ __( 'Height' ) }
 						isShownByDefault
@@ -136,9 +166,7 @@ export default function SpacerControls( {
 						<DimensionInput
 							label={ __( 'Height' ) }
 							value={ height }
-							onChange={ ( nextHeight ) =>
-								setAttributes( { height: nextHeight } )
-							}
+							onChange={ handleHeightChange }
 							isResizing={ isResizing }
 						/>
 					</ToolsPanelItem>

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -190,7 +190,14 @@ const SpacerEdit = ( {
 	const style = {
 		height:
 			inheritedOrientation === 'horizontal'
-				? 24
+				? /*
+				   * When horizontal (inside a Row), the flex axis controls width
+				   * via flexBasis. Height must be set independently from the
+				   * `height` attribute so the user can control it from the
+				   * inspector — fall back to a visible minimum so the block
+				   * remains selectable when no height is set.
+				   */
+				  getSpacingPresetCssVar( temporaryHeight || height ) || 24
 				: getHeightForVerticalBlocks(),
 		width:
 			inheritedOrientation === 'horizontal'
@@ -362,15 +369,16 @@ const SpacerEdit = ( {
 				{ blockEditingMode === 'default' &&
 					resizableBoxWithOrientation( inheritedOrientation ) }
 			</View>
-			{ ! isFlexLayout && (
-				<SpacerControls
-					setAttributes={ setAttributes }
-					height={ temporaryHeight || height }
-					width={ temporaryWidth || width }
-					orientation={ inheritedOrientation }
-					isResizing={ isResizing }
-				/>
-			) }
+			<SpacerControls
+				setAttributes={ setAttributes }
+				height={ temporaryHeight || height }
+				width={ temporaryWidth || width }
+				orientation={ inheritedOrientation }
+				isResizing={ isResizing }
+				isFlexLayout={ isFlexLayout }
+				blockStyle={ blockStyle }
+				layout={ layout }
+			/>
 		</>
 	);
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #60985

This PR fixes an issue where the Spacer block could not adjust its height when used as a direct descendant of a Row block.

Currently, when a Spacer block is placed inside a Row block, only the Width control is available because the block inherits a horizontal orientation from the parent flex layout. Additionally, the Spacer controls were entirely hidden inside flex layouts due to a rendering condition in edit.js.

This PR updates the Spacer block behavior so both Width and Height controls are available inside Row blocks, and both dimensions work correctly.

## Testing Instructions

1. Open the Gutenberg editor.
2. Insert a Row block.
3. Insert a Spacer block directly inside the Row block.
4. Select the Spacer block.
5. Verify both Width and Height controls appear in the sidebar.
6. Change the Width value and confirm the Spacer width updates correctly.
7. Change the Height value and confirm the Spacer height updates correctly.
8. Verify changing Height does not affect Width.
9. Verify changing Width does not affect Height.
10. Insert a standalone Spacer block outside a Row block.
11. Confirm only the Height control is shown (existing behavior remains unchanged).
12. Save the post and verify the Spacer dimensions render correctly on the frontend.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/3c8d82fc-cb75-4a77-93ae-bbe1df3ab0db

## Use of AI Tools

Claude AI was used during debugging and code exploration to help analyze the existing Spacer block
