### PR TITLE
Fix playlist metadata edits recreating player

### DIFF
--- a/packages/block-library/src/utils/test/waveform-player.js
+++ b/packages/block-library/src/utils/test/waveform-player.js
@@ -193,4 +193,52 @@ describe( 'WaveformPlayer', () => {
 		const secondPlayer = initWaveformPlayer.mock.results[ 1 ].value;
 		expect( secondPlayer.instance.artworkEl ).toBeNull();
 	} );
+
+	it( 'recreates the player to show an artist added to a track that had none', () => {
+		const { rerender } = render(
+			<WaveformPlayer { ...baseProps } artist="" />
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+
+		const firstPlayer = initWaveformPlayer.mock.results[ 0 ].value;
+		// No subtitle element exists when the track started without an artist.
+		expect( firstPlayer.instance.subtitleEl ).toBeNull();
+
+		rerender( <WaveformPlayer { ...baseProps } artist="New Artist" /> );
+
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+
+		expect( firstPlayer.destroy ).toHaveBeenCalledTimes( 1 );
+		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 2 );
+		const secondPlayer = initWaveformPlayer.mock.results[ 1 ].value;
+		expect( secondPlayer.instance.subtitleEl ).toHaveTextContent(
+			'New Artist'
+		);
+	} );
+
+	it( 'recreates the player when the artist is removed', () => {
+		const { rerender } = render( <WaveformPlayer { ...baseProps } /> );
+
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+
+		const player = initWaveformPlayer.mock.results[ 0 ].value;
+
+		rerender( <WaveformPlayer { ...baseProps } artist="" /> );
+
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+
+		expect( player.destroy ).toHaveBeenCalledTimes( 1 );
+		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 2 );
+		const secondPlayer = initWaveformPlayer.mock.results[ 1 ].value;
+		expect( secondPlayer.instance.subtitleEl ).toBeNull();
+	} );
 } );

--- a/packages/block-library/src/utils/test/waveform-player.js
+++ b/packages/block-library/src/utils/test/waveform-player.js
@@ -1,0 +1,196 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { act, render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { WaveformPlayer } from '../waveform-player';
+import { initWaveformPlayer } from '../waveform-utils';
+
+jest.mock( '../waveform-utils', () => ( {
+	initWaveformPlayer: jest.fn(),
+} ) );
+
+/**
+ * Create a fake player instance that mimics the parts of the waveform
+ * player instance the component manipulates.
+ *
+ * @param {Object} options Options passed to initWaveformPlayer.
+ * @return {Object} The fake player.
+ */
+function createFakePlayer( options ) {
+	const titleEl = document.createElement( 'span' );
+	titleEl.textContent = options.title ?? '';
+	// The subtitle and artwork elements only exist when the track had an
+	// artist/image when the player was created, mirroring the library markup.
+	let subtitleEl = null;
+	if ( options.artist ) {
+		subtitleEl = document.createElement( 'span' );
+		subtitleEl.textContent = options.artist;
+	}
+	let artworkEl = null;
+	if ( options.image ) {
+		artworkEl = document.createElement( 'img' );
+		artworkEl.src = options.image;
+	}
+	return {
+		instance: { titleEl, subtitleEl, artworkEl },
+		destroy: jest.fn(),
+	};
+}
+
+describe( 'WaveformPlayer', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		initWaveformPlayer.mockImplementation( ( element, options ) =>
+			createFakePlayer( options )
+		);
+	} );
+
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+		initWaveformPlayer.mockReset();
+	} );
+
+	const baseProps = {
+		src: 'https://example.com/song.mp3',
+		title: 'Original Title',
+		artist: 'Original Artist',
+		image: 'https://example.com/cover.jpg',
+		onEnded: () => {},
+	};
+
+	it( 'initializes the player once with the provided metadata', () => {
+		render( <WaveformPlayer { ...baseProps } /> );
+
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+
+		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 1 );
+		expect( initWaveformPlayer ).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining( {
+				src: baseProps.src,
+				title: 'Original Title',
+				artist: 'Original Artist',
+				image: 'https://example.com/cover.jpg',
+			} )
+		);
+	} );
+
+	it( 'updates metadata on the live player without recreating it', () => {
+		const { rerender } = render( <WaveformPlayer { ...baseProps } /> );
+
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+
+		const player = initWaveformPlayer.mock.results[ 0 ].value;
+
+		rerender(
+			<WaveformPlayer
+				{ ...baseProps }
+				title="New Title"
+				artist="New Artist"
+				image="https://example.com/new.jpg"
+			/>
+		);
+
+		// The player is updated in place, not destroyed and recreated.
+		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 1 );
+		expect( player.destroy ).not.toHaveBeenCalled();
+		expect( player.instance.titleEl ).toHaveTextContent( 'New Title' );
+		expect( player.instance.subtitleEl ).toHaveTextContent( 'New Artist' );
+		expect( player.instance.artworkEl ).toHaveAttribute(
+			'src',
+			'https://example.com/new.jpg'
+		);
+	} );
+
+	it( 'recreates the player when the src changes', () => {
+		const { rerender } = render( <WaveformPlayer { ...baseProps } /> );
+
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+
+		const player = initWaveformPlayer.mock.results[ 0 ].value;
+
+		rerender(
+			<WaveformPlayer
+				{ ...baseProps }
+				src="https://example.com/other.mp3"
+			/>
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+
+		expect( player.destroy ).toHaveBeenCalledTimes( 1 );
+		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'recreates the player to show an image added to a track that had none', () => {
+		const { rerender } = render(
+			<WaveformPlayer { ...baseProps } image="" />
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+
+		const firstPlayer = initWaveformPlayer.mock.results[ 0 ].value;
+		// No artwork element exists when the track started without an image.
+		expect( firstPlayer.instance.artworkEl ).toBeNull();
+
+		rerender(
+			<WaveformPlayer
+				{ ...baseProps }
+				image="https://example.com/added.jpg"
+			/>
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+
+		expect( firstPlayer.destroy ).toHaveBeenCalledTimes( 1 );
+		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 2 );
+		const secondPlayer = initWaveformPlayer.mock.results[ 1 ].value;
+		expect( secondPlayer.instance.artworkEl ).toHaveAttribute(
+			'src',
+			'https://example.com/added.jpg'
+		);
+	} );
+
+	it( 'recreates the player when the image is removed', () => {
+		const { rerender } = render( <WaveformPlayer { ...baseProps } /> );
+
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+
+		const player = initWaveformPlayer.mock.results[ 0 ].value;
+
+		rerender( <WaveformPlayer { ...baseProps } image="" /> );
+
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+
+		expect( player.destroy ).toHaveBeenCalledTimes( 1 );
+		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 2 );
+		const secondPlayer = initWaveformPlayer.mock.results[ 1 ].value;
+		expect( secondPlayer.instance.artworkEl ).toBeNull();
+	} );
+} );

--- a/packages/block-library/src/utils/test/waveform-player.js
+++ b/packages/block-library/src/utils/test/waveform-player.js
@@ -22,10 +22,11 @@ jest.mock( '../waveform-utils', () => ( {
  * Create a fake player instance that mimics the parts of the waveform
  * player instance the component manipulates.
  *
- * @param {Object} options Options passed to initWaveformPlayer.
+ * @param {Object}  options Options passed to initWaveformPlayer.
+ * @param {Element} element The element passed to initWaveformPlayer.
  * @return {Object} The fake player.
  */
-function createFakePlayer( options ) {
+function createFakePlayer( options, element ) {
 	const titleEl = document.createElement( 'span' );
 	titleEl.textContent = options.title ?? '';
 	// The subtitle and artwork elements only exist when the track had an
@@ -40,6 +41,15 @@ function createFakePlayer( options ) {
 		artworkEl = document.createElement( 'img' );
 		artworkEl.src = options.image;
 	}
+
+	element.append( titleEl );
+	if ( subtitleEl ) {
+		element.append( subtitleEl );
+	}
+	if ( artworkEl ) {
+		element.append( artworkEl );
+	}
+
 	return {
 		instance: { titleEl, subtitleEl, artworkEl },
 		destroy: jest.fn(),
@@ -50,7 +60,7 @@ describe( 'WaveformPlayer', () => {
 	beforeEach( () => {
 		jest.useFakeTimers();
 		initWaveformPlayer.mockImplementation( ( element, options ) =>
-			createFakePlayer( options )
+			createFakePlayer( options, element )
 		);
 	} );
 
@@ -194,7 +204,7 @@ describe( 'WaveformPlayer', () => {
 		expect( secondPlayer.instance.artworkEl ).toBeNull();
 	} );
 
-	it( 'recreates the player to show an artist added to a track that had none', () => {
+	it( 'updates the player in place to show an artist added to a track that had none', () => {
 		const { rerender } = render(
 			<WaveformPlayer { ...baseProps } artist="" />
 		);
@@ -204,24 +214,26 @@ describe( 'WaveformPlayer', () => {
 		} );
 
 		const firstPlayer = initWaveformPlayer.mock.results[ 0 ].value;
-		// No subtitle element exists when the track started without an artist.
-		expect( firstPlayer.instance.subtitleEl ).toBeNull();
+		// The editor seeds a hidden subtitle element so artist edits can
+		// update in place.
+		expect( firstPlayer.instance.subtitleEl ).toHaveTextContent( '' );
+		expect( firstPlayer.instance.subtitleEl ).toHaveStyle( {
+			display: 'none',
+		} );
 
 		rerender( <WaveformPlayer { ...baseProps } artist="New Artist" /> );
 
-		act( () => {
-			jest.advanceTimersByTime( 100 );
-		} );
-
-		expect( firstPlayer.destroy ).toHaveBeenCalledTimes( 1 );
-		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 2 );
-		const secondPlayer = initWaveformPlayer.mock.results[ 1 ].value;
-		expect( secondPlayer.instance.subtitleEl ).toHaveTextContent(
+		expect( firstPlayer.destroy ).not.toHaveBeenCalled();
+		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 1 );
+		expect( firstPlayer.instance.subtitleEl ).toHaveTextContent(
 			'New Artist'
 		);
+		expect( firstPlayer.instance.subtitleEl ).not.toHaveStyle( {
+			display: 'none',
+		} );
 	} );
 
-	it( 'recreates the player when the artist is removed', () => {
+	it( 'updates the player in place when the artist is removed', () => {
 		const { rerender } = render( <WaveformPlayer { ...baseProps } /> );
 
 		act( () => {
@@ -232,13 +244,11 @@ describe( 'WaveformPlayer', () => {
 
 		rerender( <WaveformPlayer { ...baseProps } artist="" /> );
 
-		act( () => {
-			jest.advanceTimersByTime( 100 );
+		expect( player.destroy ).not.toHaveBeenCalled();
+		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 1 );
+		expect( player.instance.subtitleEl ).toHaveTextContent( '' );
+		expect( player.instance.subtitleEl ).toHaveStyle( {
+			display: 'none',
 		} );
-
-		expect( player.destroy ).toHaveBeenCalledTimes( 1 );
-		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 2 );
-		const secondPlayer = initWaveformPlayer.mock.results[ 1 ].value;
-		expect( secondPlayer.instance.subtitleEl ).toBeNull();
 	} );
 } );

--- a/packages/block-library/src/utils/waveform-player.js
+++ b/packages/block-library/src/utils/waveform-player.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
-import { useRefEffect } from '@wordpress/compose';
+import { useEffect, useRef } from '@wordpress/element';
+import { useEvent, useRefEffect } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -32,13 +32,18 @@ export function WaveformPlayer( {
 	waveformStyle,
 	onEnded,
 } ) {
-	// Store onEnded in a ref so it doesn't need to be a useRefEffect dependency.
+	// Store onEnded in a stable callback so it doesn't need to be a useRefEffect dependency.
 	// The callback changes reference on every render (its dependency chain
 	// includes an unstable array), which would cause useRefEffect to destroy
 	// and recreate the entire player on every re-render, making it disappear
 	// during editor resizes.
-	const onEndedRef = useRef( onEnded );
-	onEndedRef.current = onEnded;
+	const onEndedEvent = useEvent( onEnded );
+	const metadataRef = useRef( { title, artist, image } );
+	const playerRef = useRef();
+
+	useEffect( () => {
+		metadataRef.current = { title, artist, image };
+	}, [ title, artist, image ] );
 
 	const ref = useRefEffect(
 		( element ) => {
@@ -53,14 +58,14 @@ export function WaveformPlayer( {
 				if ( cancelled ) {
 					return;
 				}
-				const { destroy } = initWaveformPlayer( element, {
+				const player = initWaveformPlayer( element, {
 					src,
-					title,
-					artist,
-					image,
+					...metadataRef.current,
 					waveformStyle,
-					onEnded: () => onEndedRef.current?.(),
+					onEnded: () => onEndedEvent?.(),
 				} );
+				playerRef.current = player;
+				const { destroy } = player;
 				playerDestroy = destroy;
 			}
 
@@ -76,10 +81,11 @@ export function WaveformPlayer( {
 			return () => {
 				cancelled = true;
 				clearTimeout( timeoutId );
+				playerRef.current = undefined;
 				playerDestroy?.();
 			};
 		},
-		[ src, title, artist, image, waveformStyle ]
+		[ onEndedEvent, src, waveformStyle ]
 	);
 
 	return <div ref={ ref } className="wp-block-playlist__waveform-player" />;

--- a/packages/block-library/src/utils/waveform-player.js
+++ b/packages/block-library/src/utils/waveform-player.js
@@ -12,11 +12,18 @@ import { initWaveformPlayer } from './waveform-utils';
 /**
  * Update a live waveform player's metadata elements in place.
  *
- * The title and artist are updated in place. The artwork element only exists
- * when the track had an image when the player was created, so its URL is
- * updated in place here; adding or removing an image (which creates or tears
- * down that element) is instead handled by recreating the player, keyed on
- * the `hasImage` dependency.
+ * The title element always exists, so the title is updated in place. The
+ * subtitle and artwork elements only exist when the track had an artist/image
+ * when the player was created, so their values are updated in place here;
+ * adding or removing an artist or image (which creates or tears down those
+ * elements) is instead handled by recreating the player, keyed on the
+ * `hasArtist` and `hasImage` dependencies.
+ *
+ * The library's only metadata API is `loadTrack()`, which re-fetches and
+ * re-decodes the audio and regenerates the waveform (resetting playback), so
+ * it's unsuitable for live metadata edits. We instead write to the title,
+ * subtitle, and artwork elements directly, which is what `loadTrack()` itself
+ * does internally for these fields.
  *
  * @param {Object} instance        - The waveform player instance.
  * @param {Object} metadata        - The track metadata.
@@ -69,11 +76,12 @@ export function WaveformPlayer( {
 	const metadataRef = useRef( { title, artist, image } );
 	const playerRef = useRef();
 
-	// Whether the player has an artwork element depends on whether an image
-	// was present when it was created. Recreate the player when the image is
-	// added or removed so that element is created or torn down; URL changes
-	// to an existing image are applied in place below.
+	// The artwork and subtitle elements only exist when an image/artist was
+	// present when the player was created. Recreate the player when either is
+	// added or removed so that element is created or torn down; value changes
+	// to an existing element are applied in place below.
 	const hasImage = !! image;
+	const hasArtist = !! artist;
 
 	// Keep the freshest metadata available to init() (which runs on a
 	// deferred timeout) and update the live player in place when metadata
@@ -129,7 +137,7 @@ export function WaveformPlayer( {
 				playerDestroy?.();
 			};
 		},
-		[ onEndedEvent, src, waveformStyle, hasImage ]
+		[ onEndedEvent, src, waveformStyle, hasImage, hasArtist ]
 	);
 
 	return <div ref={ ref } className="wp-block-playlist__waveform-player" />;

--- a/packages/block-library/src/utils/waveform-player.js
+++ b/packages/block-library/src/utils/waveform-player.js
@@ -9,15 +9,18 @@ import { useEvent, useRefEffect } from '@wordpress/compose';
  */
 import { initWaveformPlayer } from './waveform-utils';
 
+const EMPTY_ARTIST_PLACEHOLDER = '\u00a0';
+
 /**
  * Update a live waveform player's metadata elements in place.
  *
  * The title element always exists, so the title is updated in place. The
- * subtitle and artwork elements only exist when the track had an artist/image
- * when the player was created, so their values are updated in place here;
- * adding or removing an artist or image (which creates or tears down those
- * elements) is instead handled by recreating the player, keyed on the
- * `hasArtist` and `hasImage` dependencies.
+ * subtitle element is seeded during editor player creation, so it can be
+ * updated in place and hidden when the track has no artist. The artwork
+ * element only exists when the track had an image when the player was created,
+ * so its value is updated in place here; adding or removing an image (which
+ * creates or tears down that element) is instead handled by recreating the
+ * player, keyed on the `hasImage` dependency.
  *
  * The library's only metadata API is `loadTrack()`, which re-fetches and
  * re-decodes the audio and regenerates the waveform (resetting playback), so
@@ -76,12 +79,11 @@ export function WaveformPlayer( {
 	const metadataRef = useRef( { title, artist, image } );
 	const playerRef = useRef();
 
-	// The artwork and subtitle elements only exist when an image/artist was
-	// present when the player was created. Recreate the player when either is
-	// added or removed so that element is created or torn down; value changes
-	// to an existing element are applied in place below.
+	// The artwork element only exists when an image was present when the
+	// player was created. Recreate the player when one is added or removed so
+	// that element is created or torn down; value changes to an existing
+	// element are applied in place below.
 	const hasImage = !! image;
-	const hasArtist = !! artist;
 
 	// Keep the freshest metadata available to init() (which runs on a
 	// deferred timeout) and update the live player in place when metadata
@@ -114,9 +116,12 @@ export function WaveformPlayer( {
 					src,
 					...metadataRef.current,
 					waveformStyle,
+					artist:
+						metadataRef.current.artist || EMPTY_ARTIST_PLACEHOLDER,
 					onEnded: () => onEndedEvent?.(),
 				} );
 				playerRef.current = player;
+				updatePlayerMetadata( player.instance, metadataRef.current );
 				const { destroy } = player;
 				playerDestroy = destroy;
 			}
@@ -137,7 +142,7 @@ export function WaveformPlayer( {
 				playerDestroy?.();
 			};
 		},
-		[ onEndedEvent, src, waveformStyle, hasImage, hasArtist ]
+		[ onEndedEvent, src, waveformStyle, hasImage ]
 	);
 
 	return <div ref={ ref } className="wp-block-playlist__waveform-player" />;

--- a/packages/block-library/src/utils/waveform-player.js
+++ b/packages/block-library/src/utils/waveform-player.js
@@ -10,6 +10,34 @@ import { useEvent, useRefEffect } from '@wordpress/compose';
 import { initWaveformPlayer } from './waveform-utils';
 
 /**
+ * Update a live waveform player's metadata elements in place.
+ *
+ * The title and artist are updated in place. The artwork element only exists
+ * when the track had an image when the player was created, so its URL is
+ * updated in place here; adding or removing an image (which creates or tears
+ * down that element) is instead handled by recreating the player, keyed on
+ * the `hasImage` dependency.
+ *
+ * @param {Object} instance        - The waveform player instance.
+ * @param {Object} metadata        - The track metadata.
+ * @param {string} metadata.title  - The track title.
+ * @param {string} metadata.artist - The artist name.
+ * @param {string} metadata.image  - The artwork image URL.
+ */
+function updatePlayerMetadata( instance, { title, artist, image } ) {
+	if ( instance.titleEl ) {
+		instance.titleEl.textContent = title ?? '';
+	}
+	if ( instance.subtitleEl ) {
+		instance.subtitleEl.textContent = artist ?? '';
+		instance.subtitleEl.style.display = artist ? '' : 'none';
+	}
+	if ( instance.artworkEl && image ) {
+		instance.artworkEl.src = image;
+	}
+}
+
+/**
  * A reusable WaveformPlayer component for the block editor.
  *
  * Renders an audio waveform visualization with play/pause controls.
@@ -41,8 +69,24 @@ export function WaveformPlayer( {
 	const metadataRef = useRef( { title, artist, image } );
 	const playerRef = useRef();
 
+	// Whether the player has an artwork element depends on whether an image
+	// was present when it was created. Recreate the player when the image is
+	// added or removed so that element is created or torn down; URL changes
+	// to an existing image are applied in place below.
+	const hasImage = !! image;
+
+	// Keep the freshest metadata available to init() (which runs on a
+	// deferred timeout) and update the live player in place when metadata
+	// changes. Updating in place avoids destroying and recreating the
+	// player, which would flash it on every keystroke while editing a
+	// track's title or artist.
 	useEffect( () => {
 		metadataRef.current = { title, artist, image };
+
+		const instance = playerRef.current?.instance;
+		if ( instance ) {
+			updatePlayerMetadata( instance, { title, artist, image } );
+		}
 	}, [ title, artist, image ] );
 
 	const ref = useRefEffect(
@@ -85,7 +129,7 @@ export function WaveformPlayer( {
 				playerDestroy?.();
 			};
 		},
-		[ onEndedEvent, src, waveformStyle ]
+		[ onEndedEvent, src, waveformStyle, hasImage ]
 	);
 
 	return <div ref={ ref } className="wp-block-playlist__waveform-player" />;

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -522,11 +522,6 @@
 			"count": 1
 		}
 	},
-	"packages/block-library/src/utils/waveform-player.js": {
-		"react-hooks/refs": {
-			"count": 1
-		}
-	},
 	"packages/block-library/src/video/tracks-editor.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 2


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes the playlist block's waveform player being recreated while editing the current track title, artist, or artwork metadata.

## Why?
The waveform player effect depended on display metadata, so every keystroke in a track title or artist field destroyed and reinitialized the player.

## How?
The init effect now recreates the player only when `src` changes, or when an artist/image is added or removed (which adds or tears down the subtitle/artwork elements that the library only renders when present at construction time). For plain value edits to the title, artist, or image, the existing player's elements are updated in place via `updatePlayerMetadata`, avoiding a destroy/recreate. `useEvent` keeps the `onEnded` callback current without writing to refs during render, and the related stale ESLint suppression is removed.

## Testing Instructions
1. Open a post or page.
2. Insert a Playlist block and add at least one audio track.
3. Edit the current track title and artist in the track list.
4. Confirm the waveform player does not disappear or reinitialize on each keystroke.
5. Add or remove an artist or artwork image on the current track and confirm the player updates correctly.
6. Run `nvm use 20.19.0 && npm run test:unit packages/block-library/src/utils/test/waveform-player.js`.

### Testing Instructions for Keyboard
1. Use the keyboard to focus a playlist track title or artist field.
2. Type several characters.
3. Confirm focus remains in the field and the waveform player remains visible.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Used ChatGPT/Codex to implement and validate the change; the diff was reviewed before submission.
