### PR TITLE
Packages: Declare missing `@types/react` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59012,6 +59012,7 @@
 			"version": "2.2.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/components": "file:../components",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
@@ -59039,6 +59040,9 @@
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/rich-text": "file:../rich-text",
 				"uuid": "^14.0.0"
+			},
+			"devDependencies": {
+				"@types/react": "^19.2.13"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -59384,6 +59388,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@react-spring/web": "^9.4.5",
+				"@types/react": "^19.2.13",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/blob": "file:../blob",
@@ -59473,6 +59478,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@arraypress/waveform-player": "1.2.1",
+				"@types/react": "^19.2.13",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/autop": "file:../autop",
@@ -59576,6 +59582,7 @@
 			"version": "15.20.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/autop": "file:../autop",
 				"@wordpress/blob": "file:../blob",
 				"@wordpress/block-serialization-default-parser": "file:../block-serialization-default-parser",
@@ -59624,6 +59631,7 @@
 			"version": "0.14.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/admin-ui": "file:../admin-ui",
 				"@wordpress/base-styles": "file:../base-styles",
@@ -59758,6 +59766,7 @@
 				"@storybook/react-vite": "^10.2.8",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@types/jest": "^29.5.14",
+				"@types/react-dom": "^19.2.3",
 				"@wordpress/jest-console": "file:../jest-console",
 				"snapshot-diff": "^0.10.0",
 				"storybook": "^10.2.8",
@@ -59865,6 +59874,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/mousetrap": "^1.6.8",
+				"@types/react": "^19.2.13",
 				"@wordpress/deprecated": "file:../deprecated",
 				"@wordpress/dom": "file:../dom",
 				"@wordpress/element": "file:../element",
@@ -59893,6 +59903,7 @@
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/components": "file:../components",
 				"@wordpress/data": "file:../data",
 				"@wordpress/element": "file:../element",
@@ -59906,6 +59917,7 @@
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/admin-ui": "file:../admin-ui",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
@@ -59972,6 +59984,7 @@
 			"version": "7.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/block-editor": "file:../block-editor",
 				"@wordpress/blocks": "file:../blocks",
@@ -60818,6 +60831,7 @@
 			"version": "10.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/deprecated": "file:../deprecated",
 				"@wordpress/element": "file:../element",
@@ -60867,6 +60881,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.21",
+				"@types/react": "^19.2.13",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
 				"@wordpress/compose": "file:../compose",
@@ -61301,6 +61316,7 @@
 			"version": "14.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
@@ -61656,6 +61672,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@react-spring/web": "^9.4.5",
+				"@types/react": "^19.2.13",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/blob": "file:../blob",
@@ -61753,6 +61770,7 @@
 			"version": "1.14.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
@@ -61791,6 +61809,7 @@
 				"@dnd-kit/core": "^6.3.1",
 				"@dnd-kit/sortable": "^10.0.0",
 				"@dnd-kit/utilities": "^3.2.2",
+				"@types/react": "^19.2.13",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/element": "file:../element",
 				"@wordpress/style-runtime": "file:../style-runtime",
@@ -61858,6 +61877,7 @@
 			"version": "13.2.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/element": "file:../element",
 				"@wordpress/primitives": "file:../primitives",
 				"change-case": "4.1.2"
@@ -61875,6 +61895,7 @@
 			"version": "1.11.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/components": "file:../components",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
@@ -62025,6 +62046,7 @@
 			"version": "5.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/data": "file:../data",
 				"@wordpress/element": "file:../element",
 				"@wordpress/keycodes": "file:../keycodes"
@@ -62042,6 +62064,7 @@
 			"version": "4.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/i18n": "file:../i18n"
 			},
 			"engines": {
@@ -62066,6 +62089,7 @@
 			"version": "1.13.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/asset-loader": "file:../asset-loader",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/block-editor": "file:../block-editor",
@@ -62108,6 +62132,7 @@
 			"version": "5.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/blob": "file:../blob",
@@ -62132,6 +62157,7 @@
 			"version": "0.10.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
@@ -62165,6 +62191,7 @@
 			"version": "0.12.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
 				"@wordpress/compose": "file:../compose",
@@ -62197,6 +62224,7 @@
 			"version": "5.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/blob": "file:../blob",
@@ -62227,6 +62255,7 @@
 			"version": "5.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/components": "file:../components",
 				"@wordpress/data": "file:../data",
@@ -62307,6 +62336,7 @@
 			"version": "7.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/components": "file:../components",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/deprecated": "file:../deprecated",
@@ -62359,6 +62389,7 @@
 			"version": "4.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
@@ -62412,6 +62443,7 @@
 			"version": "4.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/element": "file:../element",
 				"clsx": "^2.1.1"
 			},
@@ -62484,6 +62516,7 @@
 			"version": "4.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
 				"utility-types": "^3.10.0"
@@ -62857,6 +62890,7 @@
 			"version": "7.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/data": "file:../data",
@@ -62903,6 +62937,7 @@
 			"version": "1.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/element": "file:../element",
 				"@wordpress/private-apis": "file:../private-apis",
@@ -63044,6 +63079,7 @@
 			"version": "6.23.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/blocks": "file:../blocks",
 				"@wordpress/components": "file:../components",
@@ -63080,6 +63116,7 @@
 			"version": "2.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"change-case": "^4.1.2"
 			},
 			"engines": {
@@ -63961,6 +63998,7 @@
 			"version": "0.14.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/element": "file:../element",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/style-runtime": "file:../style-runtime",
@@ -64057,6 +64095,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@base-ui/react": "^1.4.1",
+				"@types/react": "^19.2.13",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/element": "file:../element",
@@ -64107,6 +64146,7 @@
 			"version": "0.32.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/blob": "file:../blob",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/data": "file:../data",
@@ -64144,6 +64184,7 @@
 			"version": "6.47.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@types/react": "^19.2.13",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/data": "file:../data",
 				"@wordpress/element": "file:../element"
@@ -64755,6 +64796,7 @@
 				"@storybook/addon-docs": "^10.2.8",
 				"@storybook/icons": "^2.0.1",
 				"@storybook/react-vite": "^10.2.8",
+				"@types/react": "^19.2.13",
 				"@vitejs/plugin-react": "^5.1.2",
 				"@wordpress/theme": "file:../packages/theme",
 				"storybook": "^10.2.8",
@@ -67136,6 +67178,9 @@
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/ui": "file:../../packages/ui"
+			},
+			"devDependencies": {
+				"@types/react": "^19.2.13"
 			}
 		},
 		"widgets/events": {
@@ -67150,6 +67195,9 @@
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/ui": "file:../../packages/ui"
+			},
+			"devDependencies": {
+				"@types/react": "^19.2.13"
 			}
 		},
 		"widgets/hello-dolly": {
@@ -67160,6 +67208,9 @@
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/ui": "file:../../packages/ui"
+			},
+			"devDependencies": {
+				"@types/react": "^19.2.13"
 			}
 		},
 		"widgets/hello-world": {
@@ -67169,6 +67220,9 @@
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/ui": "file:../../packages/ui",
 				"clsx": "^2.1.1"
+			},
+			"devDependencies": {
+				"@types/react": "^19.2.13"
 			}
 		},
 		"widgets/news": {
@@ -67182,6 +67236,9 @@
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/ui": "file:../../packages/ui"
+			},
+			"devDependencies": {
+				"@types/react": "^19.2.13"
 			}
 		},
 		"widgets/quick-draft": {
@@ -67203,6 +67260,9 @@
 				"@wordpress/ui": "file:../../packages/ui",
 				"@wordpress/url": "file:../../packages/url",
 				"clsx": "^2.1.1"
+			},
+			"devDependencies": {
+				"@types/react": "^19.2.13"
 			}
 		},
 		"widgets/site-health": {
@@ -67216,6 +67276,9 @@
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/primitives": "file:../../packages/primitives",
 				"@wordpress/ui": "file:../../packages/ui"
+			},
+			"devDependencies": {
+				"@types/react": "^19.2.13"
 			}
 		},
 		"widgets/site-preview": {
@@ -67230,6 +67293,9 @@
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/ui": "file:../../packages/ui",
 				"@wordpress/url": "file:../../packages/url"
+			},
+			"devDependencies": {
+				"@types/react": "^19.2.13"
 			}
 		},
 		"widgets/welcome": {
@@ -67245,6 +67311,9 @@
 				"@wordpress/primitives": "file:../../packages/primitives",
 				"@wordpress/ui": "file:../../packages/ui",
 				"clsx": "^2.1.1"
+			},
+			"devDependencies": {
+				"@types/react": "^19.2.13"
 			}
 		}
 	}

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 2.2.0 (2026-05-27)
 
 ## 2.1.0 (2026-05-14)

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -45,6 +45,7 @@
 		"src/**/*.module.css"
 	],
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/components": "file:../components",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -54,5 +54,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"devDependencies": {
+		"@types/react": "^19.2.13"
 	}
 }

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -49,13 +49,13 @@
 		"@wordpress/rich-text": "file:../rich-text",
 		"uuid": "^14.0.0"
 	},
+	"devDependencies": {
+		"@types/react": "^19.2.13"
+	},
 	"peerDependencies": {
 		"react": "^19.2.4"
 	},
 	"publishConfig": {
 		"access": "public"
-	},
-	"devDependencies": {
-		"@types/react": "^19.2.13"
 	}
 }

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ### Documentation
 
 -   Fix documentation typos and grammar ([#78686](https://github.com/WordPress/gutenberg/pull/78686)).

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -61,6 +61,7 @@
 	],
 	"dependencies": {
 		"@react-spring/web": "^9.4.5",
+		"@types/react": "^19.2.13",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/blob": "file:../blob",

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 9.47.0 (2026-05-27)
 
 ### Internal

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -95,6 +95,7 @@
 	],
 	"dependencies": {
 		"@arraypress/waveform-player": "1.2.1",
+		"@types/react": "^19.2.13",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/autop": "file:../autop",

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 15.20.0 (2026-05-27)
 
 ### Bug Fix

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -51,6 +51,7 @@
 		"build-module/store/index.mjs"
 	],
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/autop": "file:../autop",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/block-serialization-default-parser": "file:../block-serialization-default-parser",

--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -1,0 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -41,6 +41,7 @@
 	"wpScriptModuleExports": "./build-module/index.mjs",
 	"types": "build-types",
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/admin-ui": "file:../admin-ui",
 		"@wordpress/base-styles": "file:../base-styles",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -110,6 +110,7 @@
 		"@storybook/react-vite": "^10.2.8",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@types/jest": "^29.5.14",
+		"@types/react-dom": "^19.2.3",
 		"@wordpress/jest-console": "file:../jest-console",
 		"snapshot-diff": "^0.10.0",
 		"storybook": "^10.2.8",

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ### Documentation
 
 -   Fix documentation typos ([#78686](https://github.com/WordPress/gutenberg/pull/78686)).

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -47,6 +47,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@types/mousetrap": "^1.6.8",
+		"@types/react": "^19.2.13",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",

--- a/packages/connectors/CHANGELOG.md
+++ b/packages/connectors/CHANGELOG.md
@@ -1,0 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -30,6 +30,7 @@
 	"wpScriptModuleExports": "./build-module/index.mjs",
 	"types": "build-types",
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/components": "file:../components",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",

--- a/packages/content-types/CHANGELOG.md
+++ b/packages/content-types/CHANGELOG.md
@@ -1,0 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).

--- a/packages/content-types/package.json
+++ b/packages/content-types/package.json
@@ -33,6 +33,7 @@
 	"wpScriptModuleExports": "./build-module/index.mjs",
 	"types": "build-types",
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/admin-ui": "file:../admin-ui",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 7.47.0 (2026-05-27)
 
 ## 7.46.0 (2026-05-14)

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -49,6 +49,7 @@
 		"build-module/index.mjs"
 	],
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/blocks": "file:../blocks",

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 10.47.0 (2026-05-27)
 
 ## 10.46.0 (2026-05-14)

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -45,6 +45,7 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 15.0.0 (2026-05-27)
 
 ### Breaking Changes

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -53,6 +53,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@ariakit/react": "^0.4.21",
+		"@types/react": "^19.2.13",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ### Documentation
 
 -   Fix documentation grammar ([#78686](https://github.com/WordPress/gutenberg/pull/78686)).

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -60,6 +60,7 @@
 		"build-module/bindings/**"
 	],
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ### Internal
 
 -   Migrate `Tooltip` consumers from `@wordpress/components` to the new compositional `Tooltip` in `@wordpress/ui` ([#78691](https://github.com/WordPress/gutenberg/pull/78691)).

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -48,6 +48,7 @@
 	],
 	"dependencies": {
 		"@react-spring/web": "^9.4.5",
+		"@types/react": "^19.2.13",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/blob": "file:../blob",

--- a/packages/global-styles-ui/CHANGELOG.md
+++ b/packages/global-styles-ui/CHANGELOG.md
@@ -1,0 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).

--- a/packages/global-styles-ui/package.json
+++ b/packages/global-styles-ui/package.json
@@ -44,6 +44,7 @@
 	},
 	"react-native": "src/index",
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",

--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ### Enhancements
 
 -   Clamp tile resize so width cannot shrink below a single column

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -50,6 +50,7 @@
 		"@dnd-kit/core": "^6.3.1",
 		"@dnd-kit/sortable": "^10.0.0",
 		"@dnd-kit/utilities": "^3.2.2",
+		"@types/react": "^19.2.13",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/style-runtime": "file:../style-runtime",

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ### Breaking Changes
 
 -   Rename `timeToRead` icon to `time`. ([#78804](https://github.com/WordPress/gutenberg/pull/78804))

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -44,6 +44,7 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/element": "file:../element",
 		"@wordpress/primitives": "file:../primitives",
 		"change-case": "4.1.2"

--- a/packages/image-cropper/CHANGELOG.md
+++ b/packages/image-cropper/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 1.11.0 (2026-05-27)
 
 ## 1.10.0 (2026-05-14)

--- a/packages/image-cropper/package.json
+++ b/packages/image-cropper/package.json
@@ -44,6 +44,7 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/components": "file:../components",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/keyboard-shortcuts/CHANGELOG.md
+++ b/packages/keyboard-shortcuts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 5.47.0 (2026-05-27)
 
 ## 5.46.0 (2026-05-14)

--- a/packages/keyboard-shortcuts/package.json
+++ b/packages/keyboard-shortcuts/package.json
@@ -43,6 +43,7 @@
 	"wpScript": true,
 	"types": "build-types/index.d.ts",
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
 		"@wordpress/keycodes": "file:../keycodes"

--- a/packages/keycodes/CHANGELOG.md
+++ b/packages/keycodes/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ### Documentation
 
 -   Fix documentation typos ([#78686](https://github.com/WordPress/gutenberg/pull/78686)).

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -44,6 +44,7 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/i18n": "file:../i18n"
 	},
 	"publishConfig": {

--- a/packages/lazy-editor/CHANGELOG.md
+++ b/packages/lazy-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 1.13.0 (2026-05-27)
 
 ## 1.12.0 (2026-05-14)

--- a/packages/lazy-editor/package.json
+++ b/packages/lazy-editor/package.json
@@ -45,6 +45,7 @@
 	"wpScriptModuleExports": "./build-module/index.mjs",
 	"types": "build-types",
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/asset-loader": "file:../asset-loader",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/block-editor": "file:../block-editor",

--- a/packages/list-reusable-blocks/CHANGELOG.md
+++ b/packages/list-reusable-blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 5.47.0 (2026-05-27)
 
 ### Internal

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -45,6 +45,7 @@
 	"wpScript": true,
 	"types": "build-types",
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/blob": "file:../blob",

--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -1,0 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -44,6 +44,7 @@
 		"build-module/store/index.mjs"
 	],
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",

--- a/packages/media-fields/CHANGELOG.md
+++ b/packages/media-fields/CHANGELOG.md
@@ -1,0 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).

--- a/packages/media-fields/package.json
+++ b/packages/media-fields/package.json
@@ -49,6 +49,7 @@
 		"src/**/*.scss"
 	],
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",

--- a/packages/media-utils/CHANGELOG.md
+++ b/packages/media-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 5.47.0 (2026-05-27)
 
 ## 5.46.0 (2026-05-14)

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -47,6 +47,7 @@
 		"build-style/**"
 	],
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/blob": "file:../blob",

--- a/packages/notices/CHANGELOG.md
+++ b/packages/notices/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 5.47.0 (2026-05-27)
 
 ### Enhancements

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -49,6 +49,7 @@
 		"src/**/*.scss"
 	],
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/components": "file:../components",
 		"@wordpress/data": "file:../data",

--- a/packages/plugins/CHANGELOG.md
+++ b/packages/plugins/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 7.47.0 (2026-05-27)
 
 ## 7.46.0 (2026-05-14)

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -43,6 +43,7 @@
 	"wpScript": true,
 	"types": "build-types",
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/deprecated": "file:../deprecated",

--- a/packages/preferences/CHANGELOG.md
+++ b/packages/preferences/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ### Documentation
 
 -   Fix documentation typos ([#78686](https://github.com/WordPress/gutenberg/pull/78686)).

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -51,6 +51,7 @@
 	],
 	"sideEffects": false,
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",

--- a/packages/primitives/CHANGELOG.md
+++ b/packages/primitives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 4.47.0 (2026-05-27)
 
 ## 4.46.0 (2026-05-14)

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -47,6 +47,7 @@
 		"src/**/*.scss"
 	],
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/element": "file:../element",
 		"clsx": "^2.1.1"
 	},

--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 4.47.0 (2026-05-27)
 
 ## 4.46.0 (2026-05-14)

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -44,6 +44,7 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"utility-types": "^3.10.0"

--- a/packages/rich-text/CHANGELOG.md
+++ b/packages/rich-text/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 7.47.0 (2026-05-27)
 
 ## 7.46.0 (2026-05-14)

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -52,6 +52,7 @@
 		"build-module/store/index.mjs"
 	],
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 1.47.0 (2026-05-27)
 
 ## 1.46.0 (2026-05-14)

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -43,6 +43,7 @@
 	"wpScript": true,
 	"types": "build-types",
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/private-apis": "file:../private-apis",

--- a/packages/server-side-render/CHANGELOG.md
+++ b/packages/server-side-render/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 6.23.0 (2026-05-27)
 
 ## 6.22.0 (2026-05-14)

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -45,6 +45,7 @@
 	"wpScriptDefaultExport": true,
 	"types": "build-types/index.d.ts",
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",

--- a/packages/style-engine/CHANGELOG.md
+++ b/packages/style-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 2.47.0 (2026-05-27)
 
 ## 2.46.0 (2026-05-14)

--- a/packages/style-engine/package.json
+++ b/packages/style-engine/package.json
@@ -65,6 +65,7 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"change-case": "^4.1.2"
 	},
 	"publishConfig": {

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ### Breaking Changes
 
 -   Drop the experimental `density` support from `ThemeProvider`. The `density` prop has been removed, along with the related `data-wpds-density` attribute and the per-density overrides on `--wpds-dimension-padding-*` / `--wpds-dimension-gap-*` tokens ([#78741](https://github.com/WordPress/gutenberg/pull/78741)).

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -80,6 +80,7 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/element": "file:../element",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/style-runtime": "file:../style-runtime",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ### Bug Fixes
 
 -   `Button.Icon`: Preserve icon view boxes so icons with non-standard `viewBox` values are not clipped ([#78614](https://github.com/WordPress/gutenberg/pull/78614)).

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,6 +44,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@base-ui/react": "^1.4.1",
+		"@types/react": "^19.2.13",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",

--- a/packages/upload-media/CHANGELOG.md
+++ b/packages/upload-media/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 0.32.0 (2026-05-27)
 
 ### Bug Fix

--- a/packages/upload-media/package.json
+++ b/packages/upload-media/package.json
@@ -49,6 +49,7 @@
 		"build-module/store/index.mjs"
 	],
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",

--- a/packages/viewport/CHANGELOG.md
+++ b/packages/viewport/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
 ## 6.47.0 (2026-05-27)
 
 ## 6.46.0 (2026-05-14)

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -43,6 +43,7 @@
 	"wpScript": true,
 	"types": "build-types",
 	"dependencies": {
+		"@types/react": "^19.2.13",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element"

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -31,6 +31,7 @@
 		"@storybook/addon-docs": "^10.2.8",
 		"@storybook/icons": "^2.0.1",
 		"@storybook/react-vite": "^10.2.8",
+		"@types/react": "^19.2.13",
 		"@vitejs/plugin-react": "^5.1.2",
 		"@wordpress/theme": "file:../packages/theme",
 		"storybook": "^10.2.8",

--- a/widgets/activity/package.json
+++ b/widgets/activity/package.json
@@ -13,5 +13,8 @@
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/ui": "file:../../packages/ui"
+	},
+	"devDependencies": {
+		"@types/react": "^19.2.13"
 	}
 }

--- a/widgets/events/package.json
+++ b/widgets/events/package.json
@@ -11,5 +11,8 @@
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/ui": "file:../../packages/ui"
+	},
+	"devDependencies": {
+		"@types/react": "^19.2.13"
 	}
 }

--- a/widgets/hello-dolly/package.json
+++ b/widgets/hello-dolly/package.json
@@ -7,5 +7,8 @@
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/ui": "file:../../packages/ui"
+	},
+	"devDependencies": {
+		"@types/react": "^19.2.13"
 	}
 }

--- a/widgets/hello-world/package.json
+++ b/widgets/hello-world/package.json
@@ -6,5 +6,8 @@
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/ui": "file:../../packages/ui",
 		"clsx": "^2.1.1"
+	},
+	"devDependencies": {
+		"@types/react": "^19.2.13"
 	}
 }

--- a/widgets/news/package.json
+++ b/widgets/news/package.json
@@ -10,5 +10,8 @@
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/ui": "file:../../packages/ui"
+	},
+	"devDependencies": {
+		"@types/react": "^19.2.13"
 	}
 }

--- a/widgets/quick-draft/package.json
+++ b/widgets/quick-draft/package.json
@@ -18,5 +18,8 @@
 		"@wordpress/url": "file:../../packages/url",
 		"@wordpress/ui": "file:../../packages/ui",
 		"clsx": "^2.1.1"
+	},
+	"devDependencies": {
+		"@types/react": "^19.2.13"
 	}
 }

--- a/widgets/site-health/package.json
+++ b/widgets/site-health/package.json
@@ -10,5 +10,8 @@
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/primitives": "file:../../packages/primitives",
 		"@wordpress/ui": "file:../../packages/ui"
+	},
+	"devDependencies": {
+		"@types/react": "^19.2.13"
 	}
 }

--- a/widgets/site-preview/package.json
+++ b/widgets/site-preview/package.json
@@ -11,5 +11,8 @@
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/ui": "file:../../packages/ui",
 		"@wordpress/url": "file:../../packages/url"
+	},
+	"devDependencies": {
+		"@types/react": "^19.2.13"
 	}
 }

--- a/widgets/welcome/package.json
+++ b/widgets/welcome/package.json
@@ -12,5 +12,8 @@
 		"@wordpress/primitives": "file:../../packages/primitives",
 		"@wordpress/ui": "file:../../packages/ui",
 		"clsx": "^2.1.1"
+	},
+	"devDependencies": {
+		"@types/react": "^19.2.13"
 	}
 }


### PR DESCRIPTION
## What?

Related to #75041

Declare `@types/react` (and `@types/react-dom` where applicable) as an explicit dependency in the packages that use React types but do not currently declare it.

## Why?

Many packages reference React types in their generated `build-types/` declarations via inline imports like `import('react').ReactNode`, but do not declare `@types/react` as a dependency. Today this resolves only because `@types/react` happens to be hoisted to the repo root, so the typings are found ambiently. That is fragile:

- Consumers installing these packages from npm don't necessarily get `@types/react`, so those inline type imports fail to resolve. With `skipLibCheck: true` (a common tsconfig setting) TypeScript silently falls back to `any`, effectively disabling type checking for the affected exports.
- Under isolated install layouts (e.g. `node_modules/.store` / `install-strategy=linked`, pnpm-style), packages can only resolve what they declare, so the types stop resolving entirely.

A package should declare every module its published files reference. This is the same class of fix as #74310 ("Fix missing dependencies for packages") and #74655 (which did exactly this for `csstype` in `@wordpress/components`).

## How?

For each affected package:

- `@types/react` is added to `dependencies` when the package's emitted `build-types/*.d.ts` reference React types (so consumers can resolve them).
- `@types/react` is added to `devDependencies` when React types are only used internally (not in the emitted declarations).
- `@types/react-dom` is added where `react-dom` types are used.

No source or runtime changes; this only adds dependency declarations (and the corresponding `package-lock.json` / `CHANGELOG.md` entries).

## Testing Instructions

1. `npm ci`
2. `npm run build` and confirm the type build still passes.
3. Optionally, in an isolated install layout, confirm the affected packages resolve `@types/react` from their own dependency tree rather than relying on root hoisting.

### Testing Instructions for Keyboard

N/A — dependency declaration changes only, no UI.

## Screenshots or screencast

N/A.

## Use of AI Tools

Used Claude Code to identify the packages whose generated types reference React without declaring `@types/react` (by scanning `build-types/`) and to apply the declarations and changelog entries. The diff was reviewed before submission.
