### PR TITLE
Add image lightbox comments

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -391,6 +391,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 7.0.0 Added type markers to the schema for boolean values.
 	 * @since 7.0.0 Added `dimensions.width`, `dimensions.height`. and
 	 *              `typography.textIndent` properties.
+	 * @since 7.0.0 Added `lightboxComments`.
 	 * @var array
 	 */
 	const VALID_SETTINGS = array(
@@ -444,6 +445,10 @@ class WP_Theme_JSON_Gutenberg {
 		),
 		'lightbox'                      => array(
 			'enabled'      => true,
+			'allowEditing' => true,
+		),
+		'lightboxComments'              => array(
+			'enabled'      => false,
 			'allowEditing' => true,
 		),
 		'position'                      => array(

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -39,6 +39,9 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-classic-block-deprecation' ) ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalClassicBlockDeprecation = true', 'before' );
 	}
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-gallery-lightbox-default' ) ) {
+		wp_add_inline_script( 'wp-block-library', 'window.__experimentalGalleryLightboxDefault = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );
@@ -65,11 +68,6 @@ function gutenberg_enable_block_experiments() {
 	// General experimental blocks that are not in the default block library.
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-block-experiments' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableBlockExperiments = true', 'before' );
-	}
-
-	// Image lightbox comments.
-	if ( gutenberg_is_experiment_enabled( 'gutenberg-lightbox-comments' ) ) {
-		wp_add_inline_script( 'wp-block-library', 'window.__experimentalLightboxComments = true', 'before' );
 	}
 }
 

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -66,6 +66,11 @@ function gutenberg_enable_block_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-block-experiments' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableBlockExperiments = true', 'before' );
 	}
+
+	// Image lightbox comments.
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-lightbox-comments' ) ) {
+		wp_add_inline_script( 'wp-block-library', 'window.__experimentalLightboxComments = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_block_experiments' );

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -55,6 +55,11 @@ function gutenberg_initialize_experiments_settings() {
 					'label'       => __( 'Media Upload Modal', 'gutenberg' ),
 					'description' => __( 'Replaces the existing WordPress media modal with a new modal powered by Data Views, supporting browsing, selecting, and uploading media.', 'gutenberg' ),
 				),
+				array(
+					'id'          => 'gutenberg-lightbox-comments',
+					'label'       => __( 'Image lightbox comments', 'gutenberg' ),
+					'description' => __( 'Enables an opt-in comments panel in the image lightbox, letting visitors read comments on an image and (when logged in) post new ones.', 'gutenberg' ),
+				),
 			),
 		),
 		array(

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -56,9 +56,9 @@ function gutenberg_initialize_experiments_settings() {
 					'description' => __( 'Replaces the existing WordPress media modal with a new modal powered by Data Views, supporting browsing, selecting, and uploading media.', 'gutenberg' ),
 				),
 				array(
-					'id'          => 'gutenberg-lightbox-comments',
-					'label'       => __( 'Image lightbox comments', 'gutenberg' ),
-					'description' => __( 'Enables an opt-in comments panel in the image lightbox, letting visitors read comments on an image and (when logged in) post new ones.', 'gutenberg' ),
+					'id'          => 'gutenberg-gallery-lightbox-default',
+					'label'       => __( 'Gallery lightbox default', 'gutenberg' ),
+					'description' => __( 'Sets newly created Gallery blocks to use the lightbox by default.', 'gutenberg' ),
 				),
 			),
 		),

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -346,6 +346,9 @@
 			"core/image": {
 				"lightbox": {
 					"allowEditing": true
+				},
+				"lightboxComments": {
+					"allowEditing": true
 				}
 			},
 			"core/icon": {

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Image: Add a comments panel to the lightbox, letting visitors read comments on the image's attachment and (when logged in) post new ones.
+
 ### Code Quality
 
 -   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Image: Add an opt-in comments panel to the lightbox, letting visitors read comments on the image's attachment and (when logged in) post new ones. Gated behind the `gutenberg-lightbox-comments` experiment, and controlled by the `lightboxComments` setting (theme.json default + `allowEditing`) and a per-block "Show comments" toggle, mirroring the lightbox setting.
+-   Image: Add an opt-in comments panel to the lightbox, letting visitors read comments on the image's attachment and (when logged in) post new ones. Gated behind the `gutenberg-gallery-lightbox-default` experiment, and controlled by the `lightboxComments` setting (theme.json default + `allowEditing`) and a per-block "Show comments" toggle, mirroring the lightbox setting.
 
 ### Code Quality
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Image: Add an opt-in comments panel to the lightbox, letting visitors read comments on the image's attachment and (when logged in) post new ones. Controlled by the `lightboxComments` setting (theme.json default + `allowEditing`) and a per-block "Show comments" toggle, mirroring the lightbox setting.
+-   Image: Add an opt-in comments panel to the lightbox, letting visitors read comments on the image's attachment and (when logged in) post new ones. Gated behind the `gutenberg-lightbox-comments` experiment, and controlled by the `lightboxComments` setting (theme.json default + `allowEditing`) and a per-block "Show comments" toggle, mirroring the lightbox setting.
 
 ### Code Quality
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Image: Add a comments panel to the lightbox, letting visitors read comments on the image's attachment and (when logged in) post new ones.
+-   Image: Add an opt-in comments panel to the lightbox, letting visitors read comments on the image's attachment and (when logged in) post new ones. Controlled by the `lightboxComments` setting (theme.json default + `allowEditing`) and a per-block "Show comments" toggle, mirroring the lightbox setting.
 
 ### Code Quality
 

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -49,6 +49,12 @@
 				"type": "boolean"
 			}
 		},
+		"lightboxComments": {
+			"type": "object",
+			"enabled": {
+				"type": "boolean"
+			}
+		},
 		"title": {
 			"type": "string",
 			"source": "attribute",

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -10,6 +10,7 @@ import {
 	TextareaControl,
 	TextControl,
 	CheckboxControl,
+	ToggleControl,
 	ToolbarButton,
 	ToolbarGroup,
 	__experimentalToolsPanel as ToolsPanel,
@@ -296,6 +297,7 @@ export default function Image( {
 		linkTarget,
 		sizeSlug,
 		lightbox,
+		lightboxComments,
 		metadata,
 		isDecorative,
 	} = attributes;
@@ -551,6 +553,22 @@ export default function Image( {
 		}
 	}
 
+	function onSetLightboxComments( enable ) {
+		if ( enable && ! lightboxCommentsSetting?.enabled ) {
+			setAttributes( {
+				lightboxComments: { enabled: true },
+			} );
+		} else if ( ! enable && lightboxCommentsSetting?.enabled ) {
+			setAttributes( {
+				lightboxComments: { enabled: false },
+			} );
+		} else {
+			setAttributes( {
+				lightboxComments: undefined,
+			} );
+		}
+	}
+
 	function onSetTitle( value ) {
 		// This is the HTML title attribute, separate from the media object
 		// title.
@@ -671,6 +689,22 @@ export default function Image( {
 	const lightboxChecked =
 		!! lightbox?.enabled || ( ! lightbox && !! lightboxSetting?.enabled );
 
+	const [ lightboxCommentsSetting ] = useSettings( 'lightboxComments' );
+
+	const showCommentsSetting =
+		// Comments only apply to the lightbox, so the toggle is only relevant
+		// when the lightbox is enabled for this image.
+		lightboxChecked &&
+		// If a block-level override is set, give users the option to remove it
+		// even when the comments UI is disabled in the settings.
+		( ( !! lightboxComments &&
+			lightboxComments?.enabled !== lightboxCommentsSetting?.enabled ) ||
+			lightboxCommentsSetting?.allowEditing );
+
+	const commentsChecked =
+		!! lightboxComments?.enabled ||
+		( ! lightboxComments && !! lightboxCommentsSetting?.enabled );
+
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const dimensionsControl =
@@ -727,6 +761,7 @@ export default function Image( {
 	const resetSettings = () => {
 		setAttributes( {
 			lightbox: undefined,
+			lightboxComments: undefined,
 		} );
 		updateImage( DEFAULT_MEDIA_SIZE_SLUG );
 	};
@@ -1059,19 +1094,44 @@ export default function Image( {
 					) }
 				</InspectorControls>
 			) }
-			{ !! imageSizeOptions.length && (
+			{ ( !! imageSizeOptions.length || showCommentsSetting ) && (
 				<InspectorControls>
 					<ToolsPanel
 						label={ __( 'Settings' ) }
 						resetAll={ resetSettings }
 						dropdownMenuProps={ dropdownMenuProps }
 					>
-						<ResolutionTool
-							value={ sizeSlug }
-							defaultValue={ DEFAULT_MEDIA_SIZE_SLUG }
-							onChange={ updateImage }
-							options={ imageSizeOptions }
-						/>
+						{ !! imageSizeOptions.length && (
+							<ResolutionTool
+								value={ sizeSlug }
+								defaultValue={ DEFAULT_MEDIA_SIZE_SLUG }
+								onChange={ updateImage }
+								options={ imageSizeOptions }
+							/>
+						) }
+						{ showCommentsSetting && (
+							<ToolsPanelItem
+								label={ __( 'Comments' ) }
+								isShownByDefault
+								hasValue={ () => !! lightboxComments }
+								onDeselect={ () =>
+									setAttributes( {
+										lightboxComments: undefined,
+									} )
+								}
+								panelId={ clientId }
+							>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Show comments' ) }
+									checked={ commentsChecked }
+									onChange={ onSetLightboxComments }
+									help={ __(
+										'Allow visitors to read and post comments on this image in the lightbox.'
+									) }
+								/>
+							</ToolsPanelItem>
+						) }
 					</ToolsPanel>
 				</InspectorControls>
 			) }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -692,6 +692,9 @@ export default function Image( {
 	const [ lightboxCommentsSetting ] = useSettings( 'lightboxComments' );
 
 	const showCommentsSetting =
+		// Lightbox comments are gated behind the `gutenberg-lightbox-comments`
+		// experiment.
+		!! window.__experimentalLightboxComments &&
 		// Comments only apply to the lightbox, so the toggle is only relevant
 		// when the lightbox is enabled for this image.
 		lightboxChecked &&

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -692,9 +692,9 @@ export default function Image( {
 	const [ lightboxCommentsSetting ] = useSettings( 'lightboxComments' );
 
 	const showCommentsSetting =
-		// Lightbox comments are gated behind the `gutenberg-lightbox-comments`
+		// Lightbox comments are gated behind the `gutenberg-gallery-lightbox-default`
 		// experiment.
-		!! window.__experimentalLightboxComments &&
+		!! window.__experimentalGalleryLightboxDefault &&
 		// Comments only apply to the lightbox, so the toggle is only relevant
 		// when the lightbox is enabled for this image.
 		lightboxChecked &&

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -1125,7 +1125,6 @@ export default function Image( {
 								panelId={ clientId }
 							>
 								<ToggleControl
-									__nextHasNoMarginBottom
 									label={ __( 'Show comments' ) }
 									checked={ commentsChecked }
 									onChange={ onSetLightboxComments }

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -340,7 +340,8 @@ function block_core_image_print_lightbox_overlay() {
 	$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z"></path></svg>';
 	$prev_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" aria-hidden="true" focusable="false"><path d="M14.6 7l-1.2-1L8 12l5.4 6 1.2-1-4.6-5z"></path></svg>';
 	$next_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" aria-hidden="true" focusable="false"><path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"></path></svg>';
-	$login_url         = esc_url( wp_login_url( get_permalink() ) );
+	global $wp;
+	$login_url         = esc_url( wp_login_url( home_url( $wp->request ) ) );
 	$login_message     = sprintf(
 		/* translators: %s: Login URL. */
 		wp_kses( __( 'You must be <a href="%s">logged in</a> to comment.' ), array( 'a' => array( 'href' => array() ) ) ),

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -199,14 +199,21 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 	$img_width        = 'none';
 	$img_height       = 'none';
 	$img_srcset       = false;
+	$attachment_id    = $block['attrs']['id'] ?? null;
 
 	wp_interactivity_config(
 		'core/image',
 		array(
-			'defaultAriaLabel' => __( 'Enlarged image' ),
-			'closeButtonText'  => esc_html__( 'Close' ),
-			'prevButtonText'   => esc_html_x( 'Previous', 'previous image in lightbox' ),
-			'nextButtonText'   => esc_html_x( 'Next', 'next image in lightbox' ),
+			'defaultAriaLabel'            => __( 'Enlarged image' ),
+			'closeButtonText'             => esc_html__( 'Close' ),
+			'prevButtonText'              => esc_html_x( 'Previous', 'previous image in lightbox' ),
+			'nextButtonText'              => esc_html_x( 'Next', 'next image in lightbox' ),
+			'commentEndpoint'             => rest_url( 'wp/v2/comments' ),
+			'commentNonce'                => wp_create_nonce( 'wp_rest' ),
+			'commentRegistrationRequired' => get_option( 'comment_registration' ) && ! is_user_logged_in(),
+			'commentSubmittedText'        => __( 'Comment submitted.' ),
+			'commentSubmittingText'       => __( 'Submitting comment...' ),
+			'commentErrorText'            => __( 'Could not submit the comment. Please try again.' ),
 		)
 	);
 
@@ -215,12 +222,12 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 		$custom_aria_label = sprintf( __( 'Enlarged image: %s' ), $alt );
 	}
 
-	if ( isset( $block['attrs']['id'] ) ) {
-		$img_uploaded_src = wp_get_attachment_url( $block['attrs']['id'] );
-		$img_metadata     = wp_get_attachment_metadata( $block['attrs']['id'] );
+	if ( isset( $attachment_id ) ) {
+		$img_uploaded_src = wp_get_attachment_url( $attachment_id );
+		$img_metadata     = wp_get_attachment_metadata( $attachment_id );
 		$has_dimensions   = ( $img_metadata['width'] ?? '' ) && ( $img_metadata['height'] ?? '' );
 		$srcset_size      = $has_dimensions ? array( $img_metadata['width'], $img_metadata['height'] ) : 'large';
-		$img_srcset       = wp_get_attachment_image_srcset( $block['attrs']['id'], $srcset_size );
+		$img_srcset       = wp_get_attachment_image_srcset( $attachment_id, $srcset_size );
 		$img_width        = $img_metadata['width'] ?? 'none';
 		$img_height       = $img_metadata['height'] ?? 'none';
 	}
@@ -247,6 +254,8 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 					'targetHeight'           => $img_height,
 					'scaleAttr'              => $block['attrs']['scale'] ?? false,
 					'alt'                    => $alt,
+					'attachmentId'           => $attachment_id,
+					'commentsOpen'           => isset( $attachment_id ) && comments_open( $attachment_id ),
 					'galleryId'              => $block_instance->context['galleryId'] ?? null,
 					'customAriaLabel'        => $custom_aria_label ?? null,
 					'navigationButtonType'   => $block_instance->context['navigationButtonType'] ?? 'icon',
@@ -325,9 +334,23 @@ function block_core_image_print_lightbox_overlay() {
 	$close_button_text = esc_attr__( 'Close' );
 	$prev_button_text  = esc_attr_x( 'Previous', 'previous image in lightbox' );
 	$next_button_text  = esc_attr_x( 'Next', 'next image in lightbox' );
+	$comment_label     = esc_attr__( 'Comment' );
+	$name_label        = esc_attr__( 'Name' );
+	$email_label       = esc_attr__( 'Email' );
+	$url_label         = esc_attr__( 'Website' );
+	$submit_label      = esc_html__( 'Post Comment' );
+	$comment_icon      = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3h11A2.5 2.5 0 0 1 20 5.5v7A2.5 2.5 0 0 1 17.5 15H9.44L5.3 18.53A.75.75 0 0 1 4 17.96V5.5Zm2.5-1A1 1 0 0 0 5.5 5.5v11.33l3.18-2.71a.75.75 0 0 1 .49-.18h8.33a1 1 0 0 0 1-1v-7.44a1 1 0 0 0-1-1h-11Z"></path></svg>';
 	$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z"></path></svg>';
 	$prev_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" aria-hidden="true" focusable="false"><path d="M14.6 7l-1.2-1L8 12l5.4 6 1.2-1-4.6-5z"></path></svg>';
 	$next_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" aria-hidden="true" focusable="false"><path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"></path></svg>';
+	$required          = get_option( 'require_name_email' ) ? 'required' : '';
+	$login_url         = esc_url( wp_login_url( get_permalink() ) );
+	$login_message     = sprintf(
+		/* translators: %s: Login URL. */
+		wp_kses( __( 'You must be <a href="%s">logged in</a> to comment.' ), array( 'a' => array( 'href' => array() ) ) ),
+		$login_url
+	);
+	$commenter         = wp_get_current_commenter();
 
 	// If the current theme does NOT have a `theme.json`, or the colors are not
 	// defined, it needs to set the background color & close button color to some
@@ -357,6 +380,7 @@ function block_core_image_print_lightbox_overlay() {
 			data-wp-bind--aria-modal="state.ariaModal"
 			data-wp-class--active="state.overlayEnabled"
 			data-wp-class--show-closing-animation="state.overlayOpened"
+			data-wp-class--show-comments="state.commentFormVisible"
 			data-wp-watch---focus="callbacks.setOverlayFocus"
 			data-wp-watch---inert="callbacks.setInertElements"
 			data-wp-on--keydown="actions.handleKeydown"
@@ -395,10 +419,49 @@ function block_core_image_print_lightbox_overlay() {
 						>
 					</figure>
 				</div>
+				<button type="button" class="wp-lightbox-comment-button" data-wp-bind--hidden="!state.selectedImageCommentsOpen" data-wp-bind--aria-expanded="state.commentFormVisible" data-wp-on--click="actions.toggleCommentForm" aria-label="{$comment_label}">
+					{$comment_icon}
+				</button>
 				<button type="button" style="fill:{$close_button_color}" class="wp-lightbox-navigation-button wp-lightbox-navigation-button-next" data-wp-bind--hidden="!state.hasNavigation" data-wp-on--click="actions.showNextImage" data-wp-bind--aria-label="state.nextButtonAriaLabel">
 					<span class="wp-lightbox-navigation-text" data-wp-bind--hidden="!state.hasNavigationText">{$next_button_text}</span>
 					<span class="wp-lightbox-navigation-icon" data-wp-bind--hidden="!state.hasNavigationIcon">{$next_button_icon}</span>
 				</button>
+				<section class="wp-lightbox-comments" data-wp-bind--hidden="!state.commentFormVisible" data-wp-on--click="actions.stopPropagation">
+					<div class="wp-lightbox-comments-list" hidden></div>
+					<p class="wp-lightbox-comments-login" data-wp-bind--hidden="!state.commentLoginRequired">{$login_message}</p>
+					<form data-wp-bind--hidden="state.commentLoginRequired" data-wp-on--submit="actions.submitComment">
+HTML;
+
+	if ( ! is_user_logged_in() ) {
+		$author = esc_attr( $commenter['comment_author'] );
+		$email  = esc_attr( $commenter['comment_author_email'] );
+		$url    = esc_attr( $commenter['comment_author_url'] );
+
+		echo <<<HTML
+						<label>
+							<span>{$name_label}</span>
+							<input name="author" type="text" autocomplete="name" value="{$author}" {$required}>
+						</label>
+						<label>
+							<span>{$email_label}</span>
+							<input name="email" type="email" autocomplete="email" value="{$email}" {$required}>
+						</label>
+						<label>
+							<span>{$url_label}</span>
+							<input name="url" type="url" autocomplete="url" value="{$url}">
+						</label>
+HTML;
+	}
+
+	echo <<<HTML
+						<label>
+							<span>{$comment_label}</span>
+							<textarea name="comment" required></textarea>
+						</label>
+						<button type="submit" data-wp-bind--disabled="state.commentFormIsSubmitting">{$submit_label}</button>
+						<p class="wp-lightbox-comments-message" aria-live="polite" data-wp-text="state.commentFormMessage"></p>
+					</form>
+				</section>
 				<div data-wp-text="state.ariaLabel" aria-live="polite" aria-atomic="true" class="screen-reader-text"></div>
 				<div class="scrim" style="background-color: {$background_color}" aria-hidden="true"></div>
 		</div>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -232,27 +232,31 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 	$img_srcset       = false;
 	$attachment_id    = $block['attrs']['id'] ?? null;
 
-	// Comments are only shown when enabled via the per-block attribute or the
-	// `lightboxComments` theme.json setting, in addition to the attachment
-	// itself having comments open.
-	$comments_settings = block_core_image_get_lightbox_comments_settings( $block );
-	$comments_enabled  = isset( $comments_settings['enabled'] ) && true === $comments_settings['enabled'];
-
-	wp_interactivity_config(
-		'core/image',
-		array(
-			'defaultAriaLabel'            => __( 'Enlarged image' ),
-			'closeButtonText'             => esc_html__( 'Close' ),
-			'prevButtonText'              => esc_html_x( 'Previous', 'previous image in lightbox' ),
-			'nextButtonText'              => esc_html_x( 'Next', 'next image in lightbox' ),
-			'commentEndpoint'             => rest_url( 'wp/v2/comments' ),
-			'commentNonce'                => wp_create_nonce( 'wp_rest' ),
-			'commentLoginRequired'        => ! is_user_logged_in(),
-			'commentSubmittedText'        => __( 'Comment submitted.' ),
-			'commentSubmittingText'       => __( 'Submitting comment...' ),
-			'commentErrorText'            => __( 'Could not submit the comment. Please try again.' ),
-		)
+	$lightbox_config = array(
+		'defaultAriaLabel' => __( 'Enlarged image' ),
+		'closeButtonText'  => esc_html__( 'Close' ),
+		'prevButtonText'   => esc_html_x( 'Previous', 'previous image in lightbox' ),
+		'nextButtonText'   => esc_html_x( 'Next', 'next image in lightbox' ),
 	);
+
+	// Lightbox comments are gated behind the `gutenberg-lightbox-comments`
+	// experiment. When enabled, comments are only shown for an image that also
+	// turns them on via the per-block attribute or the `lightboxComments`
+	// theme.json setting, and whose attachment has comments open.
+	$comments_enabled = false;
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-lightbox-comments' ) ) {
+		$comments_settings = block_core_image_get_lightbox_comments_settings( $block );
+		$comments_enabled  = isset( $comments_settings['enabled'] ) && true === $comments_settings['enabled'];
+
+		$lightbox_config['commentEndpoint']       = rest_url( 'wp/v2/comments' );
+		$lightbox_config['commentNonce']          = wp_create_nonce( 'wp_rest' );
+		$lightbox_config['commentLoginRequired']  = ! is_user_logged_in();
+		$lightbox_config['commentSubmittedText']  = __( 'Comment submitted.' );
+		$lightbox_config['commentSubmittingText'] = __( 'Submitting comment...' );
+		$lightbox_config['commentErrorText']      = __( 'Could not submit the comment. Please try again.' );
+	}
+
+	wp_interactivity_config( 'core/image', $lightbox_config );
 
 	if ( $alt ) {
 		/* translators: %s: Image alt text. */
@@ -371,19 +375,9 @@ function block_core_image_print_lightbox_overlay() {
 	$close_button_text = esc_attr__( 'Close' );
 	$prev_button_text  = esc_attr_x( 'Previous', 'previous image in lightbox' );
 	$next_button_text  = esc_attr_x( 'Next', 'next image in lightbox' );
-	$comment_label     = esc_attr__( 'Comment' );
-	$submit_label      = esc_html__( 'Post Comment' );
-	$comment_icon      = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3h11A2.5 2.5 0 0 1 20 5.5v7A2.5 2.5 0 0 1 17.5 15H9.44L5.3 18.53A.75.75 0 0 1 4 17.96V5.5Zm2.5-1A1 1 0 0 0 5.5 5.5v11.33l3.18-2.71a.75.75 0 0 1 .49-.18h8.33a1 1 0 0 0 1-1v-7.44a1 1 0 0 0-1-1h-11Z"></path></svg>';
 	$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z"></path></svg>';
 	$prev_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" aria-hidden="true" focusable="false"><path d="M14.6 7l-1.2-1L8 12l5.4 6 1.2-1-4.6-5z"></path></svg>';
 	$next_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" aria-hidden="true" focusable="false"><path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"></path></svg>';
-	global $wp;
-	$login_url         = esc_url( wp_login_url( home_url( $wp->request ) ) );
-	$login_message     = sprintf(
-		/* translators: %s: Login URL. */
-		wp_kses( __( 'You must be <a href="%s">logged in</a> to comment.' ), array( 'a' => array( 'href' => array() ) ) ),
-		$login_url
-	);
 
 	// If the current theme does NOT have a `theme.json`, or the colors are not
 	// defined, it needs to set the background color & close button color to some
@@ -398,6 +392,45 @@ function block_core_image_print_lightbox_overlay() {
 		if ( ! empty( $global_styles_color['text'] ) ) {
 			$close_button_color = esc_attr( $global_styles_color['text'] );
 		}
+	}
+
+	// Lightbox comments markup is only output when the
+	// `gutenberg-lightbox-comments` experiment is enabled.
+	$comment_button   = '';
+	$comments_section = '';
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-lightbox-comments' ) ) {
+		$comment_label = esc_attr__( 'Comment' );
+		$submit_label  = esc_html__( 'Post Comment' );
+		$comment_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3h11A2.5 2.5 0 0 1 20 5.5v7A2.5 2.5 0 0 1 17.5 15H9.44L5.3 18.53A.75.75 0 0 1 4 17.96V5.5Zm2.5-1A1 1 0 0 0 5.5 5.5v11.33l3.18-2.71a.75.75 0 0 1 .49-.18h8.33a1 1 0 0 0 1-1v-7.44a1 1 0 0 0-1-1h-11Z"></path></svg>';
+
+		global $wp;
+		$login_url     = esc_url( wp_login_url( home_url( $wp->request ) ) );
+		$login_message = sprintf(
+			/* translators: %s: Login URL. */
+			wp_kses( __( 'You must be <a href="%s">logged in</a> to comment.' ), array( 'a' => array( 'href' => array() ) ) ),
+			$login_url
+		);
+
+		$comment_button = <<<HTML
+				<button type="button" class="wp-lightbox-comment-button" data-wp-bind--hidden="!state.selectedImageCommentsOpen" data-wp-bind--aria-expanded="state.commentFormVisible" data-wp-on--click="actions.toggleCommentForm" aria-label="{$comment_label}">
+					{$comment_icon}
+				</button>
+HTML;
+
+		$comments_section = <<<HTML
+				<section class="wp-lightbox-comments" data-wp-bind--hidden="!state.commentFormVisible" data-wp-on--click="actions.stopPropagation">
+					<div class="wp-lightbox-comments-list" hidden></div>
+					<p class="wp-lightbox-comments-login" data-wp-bind--hidden="!state.commentLoginRequired">{$login_message}</p>
+					<form data-wp-bind--hidden="state.commentLoginRequired" data-wp-on--submit="actions.submitComment">
+						<label>
+							<span>{$comment_label}</span>
+							<textarea name="comment" required></textarea>
+						</label>
+						<button type="submit" data-wp-bind--disabled="state.commentFormIsSubmitting">{$submit_label}</button>
+						<p class="wp-lightbox-comments-message" aria-live="polite" data-wp-text="state.commentFormMessage"></p>
+					</form>
+				</section>
+HTML;
 	}
 
 	echo <<<HTML
@@ -452,25 +485,12 @@ function block_core_image_print_lightbox_overlay() {
 						>
 					</figure>
 				</div>
-				<button type="button" class="wp-lightbox-comment-button" data-wp-bind--hidden="!state.selectedImageCommentsOpen" data-wp-bind--aria-expanded="state.commentFormVisible" data-wp-on--click="actions.toggleCommentForm" aria-label="{$comment_label}">
-					{$comment_icon}
-				</button>
+				{$comment_button}
 				<button type="button" style="fill:{$close_button_color}" class="wp-lightbox-navigation-button wp-lightbox-navigation-button-next" data-wp-bind--hidden="!state.hasNavigation" data-wp-on--click="actions.showNextImage" data-wp-bind--aria-label="state.nextButtonAriaLabel">
 					<span class="wp-lightbox-navigation-text" data-wp-bind--hidden="!state.hasNavigationText">{$next_button_text}</span>
 					<span class="wp-lightbox-navigation-icon" data-wp-bind--hidden="!state.hasNavigationIcon">{$next_button_icon}</span>
 				</button>
-				<section class="wp-lightbox-comments" data-wp-bind--hidden="!state.commentFormVisible" data-wp-on--click="actions.stopPropagation">
-					<div class="wp-lightbox-comments-list" hidden></div>
-					<p class="wp-lightbox-comments-login" data-wp-bind--hidden="!state.commentLoginRequired">{$login_message}</p>
-					<form data-wp-bind--hidden="state.commentLoginRequired" data-wp-on--submit="actions.submitComment">
-						<label>
-							<span>{$comment_label}</span>
-							<textarea name="comment" required></textarea>
-						</label>
-						<button type="submit" data-wp-bind--disabled="state.commentFormIsSubmitting">{$submit_label}</button>
-						<p class="wp-lightbox-comments-message" aria-live="polite" data-wp-text="state.commentFormMessage"></p>
-					</form>
-				</section>
+				{$comments_section}
 				<div data-wp-text="state.ariaLabel" aria-live="polite" aria-atomic="true" class="screen-reader-text"></div>
 				<div class="scrim" style="background-color: {$background_color}" aria-hidden="true"></div>
 		</div>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -198,6 +198,23 @@ function block_core_image_get_lightbox_comments_settings( $block ) {
 }
 
 /**
+ * Checks whether the lightbox comments experiment is enabled.
+ *
+ * The image block also ships in WordPress Core, where the Gutenberg
+ * experiments option does not exist and the `gutenberg_is_experiment_enabled()`
+ * helper is unavailable. Reading the option directly keeps this core-safe: the
+ * option is absent in Core, so the feature stays disabled there.
+ *
+ * @since 7.0.0
+ *
+ * @return bool Whether the lightbox comments experiment is enabled.
+ */
+function block_core_image_is_lightbox_comments_experiment_enabled() {
+	$experiments = get_option( 'gutenberg-experiments', array() );
+	return is_array( $experiments ) && ! empty( $experiments['gutenberg-gallery-lightbox-default'] );
+}
+
+/**
  * Adds the directives and layout needed for the lightbox behavior.
  *
  * @since 6.4.0
@@ -244,7 +261,7 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 	// turns them on via the per-block attribute or the `lightboxComments`
 	// theme.json setting, and whose attachment has comments open.
 	$comments_enabled = false;
-	if ( gutenberg_is_experiment_enabled( 'gutenberg-gallery-lightbox-default' ) ) {
+	if ( block_core_image_is_lightbox_comments_experiment_enabled() ) {
 		$comments_settings = block_core_image_get_lightbox_comments_settings( $block );
 		$comments_enabled  = isset( $comments_settings['enabled'] ) && true === $comments_settings['enabled'];
 
@@ -398,7 +415,7 @@ function block_core_image_print_lightbox_overlay() {
 	// `gutenberg-gallery-lightbox-default` experiment is enabled.
 	$comment_button   = '';
 	$comments_section = '';
-	if ( gutenberg_is_experiment_enabled( 'gutenberg-gallery-lightbox-default' ) ) {
+	if ( block_core_image_is_lightbox_comments_experiment_enabled() ) {
 		$comment_label = esc_attr__( 'Comment' );
 		$submit_label  = esc_html__( 'Post Comment' );
 		$comment_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3h11A2.5 2.5 0 0 1 20 5.5v7A2.5 2.5 0 0 1 17.5 15H9.44L5.3 18.53A.75.75 0 0 1 4 17.96V5.5Zm2.5-1A1 1 0 0 0 5.5 5.5v11.33l3.18-2.71a.75.75 0 0 1 .49-.18h8.33a1 1 0 0 0 1-1v-7.44a1 1 0 0 0-1-1h-11Z"></path></svg>';

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -167,6 +167,37 @@ function block_core_image_get_lightbox_settings( $block ) {
 }
 
 /**
+ * Gets the lightbox comments settings for the block.
+ *
+ * Resolves the per-block attribute first, then the block-level and top-level
+ * `theme.json` settings, mirroring how the lightbox setting is resolved.
+ *
+ * @since 7.0.0
+ *
+ * @param array $block Block data.
+ *
+ * @return array|null Filtered lightbox comments settings.
+ */
+function block_core_image_get_lightbox_comments_settings( $block ) {
+	// Gets the lightbox comments setting from the block attributes.
+	if ( isset( $block['attrs']['lightboxComments'] ) ) {
+		$comments_settings = $block['attrs']['lightboxComments'];
+	}
+
+	if ( ! isset( $comments_settings ) ) {
+		$comments_settings = wp_get_global_settings( array( 'lightboxComments' ), array( 'block_name' => 'core/image' ) );
+
+		// If not present in block-level settings, the previous call returns the
+		// whole `theme.json` structure, so check for a top-level value instead.
+		if ( isset( $comments_settings['lightboxComments'] ) ) {
+			$comments_settings = wp_get_global_settings( array( 'lightboxComments' ) );
+		}
+	}
+
+	return $comments_settings ?? null;
+}
+
+/**
  * Adds the directives and layout needed for the lightbox behavior.
  *
  * @since 6.4.0
@@ -200,6 +231,12 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 	$img_height       = 'none';
 	$img_srcset       = false;
 	$attachment_id    = $block['attrs']['id'] ?? null;
+
+	// Comments are only shown when enabled via the per-block attribute or the
+	// `lightboxComments` theme.json setting, in addition to the attachment
+	// itself having comments open.
+	$comments_settings = block_core_image_get_lightbox_comments_settings( $block );
+	$comments_enabled  = isset( $comments_settings['enabled'] ) && true === $comments_settings['enabled'];
 
 	wp_interactivity_config(
 		'core/image',
@@ -255,7 +292,7 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 					'scaleAttr'              => $block['attrs']['scale'] ?? false,
 					'alt'                    => $alt,
 					'attachmentId'           => $attachment_id,
-					'commentsOpen'           => isset( $attachment_id ) && comments_open( $attachment_id ),
+					'commentsOpen'           => $comments_enabled && isset( $attachment_id ) && comments_open( $attachment_id ),
 					'galleryId'              => $block_instance->context['galleryId'] ?? null,
 					'customAriaLabel'        => $custom_aria_label ?? null,
 					'navigationButtonType'   => $block_instance->context['navigationButtonType'] ?? 'icon',

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -210,7 +210,7 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 			'nextButtonText'              => esc_html_x( 'Next', 'next image in lightbox' ),
 			'commentEndpoint'             => rest_url( 'wp/v2/comments' ),
 			'commentNonce'                => wp_create_nonce( 'wp_rest' ),
-			'commentRegistrationRequired' => get_option( 'comment_registration' ) && ! is_user_logged_in(),
+			'commentLoginRequired'        => ! is_user_logged_in(),
 			'commentSubmittedText'        => __( 'Comment submitted.' ),
 			'commentSubmittingText'       => __( 'Submitting comment...' ),
 			'commentErrorText'            => __( 'Could not submit the comment. Please try again.' ),
@@ -335,22 +335,17 @@ function block_core_image_print_lightbox_overlay() {
 	$prev_button_text  = esc_attr_x( 'Previous', 'previous image in lightbox' );
 	$next_button_text  = esc_attr_x( 'Next', 'next image in lightbox' );
 	$comment_label     = esc_attr__( 'Comment' );
-	$name_label        = esc_attr__( 'Name' );
-	$email_label       = esc_attr__( 'Email' );
-	$url_label         = esc_attr__( 'Website' );
 	$submit_label      = esc_html__( 'Post Comment' );
 	$comment_icon      = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3h11A2.5 2.5 0 0 1 20 5.5v7A2.5 2.5 0 0 1 17.5 15H9.44L5.3 18.53A.75.75 0 0 1 4 17.96V5.5Zm2.5-1A1 1 0 0 0 5.5 5.5v11.33l3.18-2.71a.75.75 0 0 1 .49-.18h8.33a1 1 0 0 0 1-1v-7.44a1 1 0 0 0-1-1h-11Z"></path></svg>';
 	$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z"></path></svg>';
 	$prev_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" aria-hidden="true" focusable="false"><path d="M14.6 7l-1.2-1L8 12l5.4 6 1.2-1-4.6-5z"></path></svg>';
 	$next_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" aria-hidden="true" focusable="false"><path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"></path></svg>';
-	$required          = get_option( 'require_name_email' ) ? 'required' : '';
 	$login_url         = esc_url( wp_login_url( get_permalink() ) );
 	$login_message     = sprintf(
 		/* translators: %s: Login URL. */
 		wp_kses( __( 'You must be <a href="%s">logged in</a> to comment.' ), array( 'a' => array( 'href' => array() ) ) ),
 		$login_url
 	);
-	$commenter         = wp_get_current_commenter();
 
 	// If the current theme does NOT have a `theme.json`, or the colors are not
 	// defined, it needs to set the background color & close button color to some
@@ -430,30 +425,6 @@ function block_core_image_print_lightbox_overlay() {
 					<div class="wp-lightbox-comments-list" hidden></div>
 					<p class="wp-lightbox-comments-login" data-wp-bind--hidden="!state.commentLoginRequired">{$login_message}</p>
 					<form data-wp-bind--hidden="state.commentLoginRequired" data-wp-on--submit="actions.submitComment">
-HTML;
-
-	if ( ! is_user_logged_in() ) {
-		$author = esc_attr( $commenter['comment_author'] );
-		$email  = esc_attr( $commenter['comment_author_email'] );
-		$url    = esc_attr( $commenter['comment_author_url'] );
-
-		echo <<<HTML
-						<label>
-							<span>{$name_label}</span>
-							<input name="author" type="text" autocomplete="name" value="{$author}" {$required}>
-						</label>
-						<label>
-							<span>{$email_label}</span>
-							<input name="email" type="email" autocomplete="email" value="{$email}" {$required}>
-						</label>
-						<label>
-							<span>{$url_label}</span>
-							<input name="url" type="url" autocomplete="url" value="{$url}">
-						</label>
-HTML;
-	}
-
-	echo <<<HTML
 						<label>
 							<span>{$comment_label}</span>
 							<textarea name="comment" required></textarea>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -239,12 +239,12 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 		'nextButtonText'   => esc_html_x( 'Next', 'next image in lightbox' ),
 	);
 
-	// Lightbox comments are gated behind the `gutenberg-lightbox-comments`
+	// Lightbox comments are gated behind the `gutenberg-gallery-lightbox-default`
 	// experiment. When enabled, comments are only shown for an image that also
 	// turns them on via the per-block attribute or the `lightboxComments`
 	// theme.json setting, and whose attachment has comments open.
 	$comments_enabled = false;
-	if ( gutenberg_is_experiment_enabled( 'gutenberg-lightbox-comments' ) ) {
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-gallery-lightbox-default' ) ) {
 		$comments_settings = block_core_image_get_lightbox_comments_settings( $block );
 		$comments_enabled  = isset( $comments_settings['enabled'] ) && true === $comments_settings['enabled'];
 
@@ -395,10 +395,10 @@ function block_core_image_print_lightbox_overlay() {
 	}
 
 	// Lightbox comments markup is only output when the
-	// `gutenberg-lightbox-comments` experiment is enabled.
+	// `gutenberg-gallery-lightbox-default` experiment is enabled.
 	$comment_button   = '';
 	$comments_section = '';
-	if ( gutenberg_is_experiment_enabled( 'gutenberg-lightbox-comments' ) ) {
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-gallery-lightbox-default' ) ) {
 		$comment_label = esc_attr__( 'Comment' );
 		$submit_label  = esc_html__( 'Post Comment' );
 		$comment_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3h11A2.5 2.5 0 0 1 20 5.5v7A2.5 2.5 0 0 1 17.5 15H9.44L5.3 18.53A.75.75 0 0 1 4 17.96V5.5Zm2.5-1A1 1 0 0 0 5.5 5.5v11.33l3.18-2.71a.75.75 0 0 1 .49-.18h8.33a1 1 0 0 0 1-1v-7.44a1 1 0 0 0-1-1h-11Z"></path></svg>';

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -210,6 +210,11 @@
 	visibility: hidden;
 	cursor: zoom-out;
 
+	&.show-comments {
+		overflow-x: hidden;
+		overflow-y: auto;
+	}
+
 	.wp-lightbox-close-button {
 		font-family: inherit;
 		position: absolute;
@@ -295,6 +300,146 @@
 		vertical-align: middle;
 	}
 
+	.wp-lightbox-comment-button {
+		position: absolute;
+		top: calc((100vh + var(--wp--lightbox-container-height)) / 2 - 48px);
+		left: calc((100vw + var(--wp--lightbox-container-width)) / 2 - 48px);
+		z-index: 3000001;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 40px;
+		height: 40px;
+		padding: 0;
+		color: #1e1e1e;
+		background: rgb(255 255 255 / 92%);
+		border: 1px solid rgb(0 0 0 / 12%);
+		border-radius: 4px;
+		box-shadow: 0 2px 8px rgb(0 0 0 / 16%);
+		cursor: pointer;
+		opacity: 0;
+		visibility: hidden;
+		transition: opacity 0.2s ease;
+
+		&[hidden] {
+			display: none;
+		}
+
+		&:hover,
+		&:focus {
+			background: #fff;
+		}
+
+		svg {
+			fill: currentColor;
+		}
+	}
+
+	.lightbox-image-container:hover + .wp-lightbox-comment-button,
+	.wp-lightbox-comment-button:hover,
+	.wp-lightbox-comment-button:focus {
+		opacity: 1;
+		visibility: visible;
+	}
+
+	.wp-lightbox-comments {
+		position: absolute;
+		top: calc((100vh + var(--wp--lightbox-container-height)) / 2 + 16px);
+		left: 50%;
+		transform: translateX(-50%);
+		z-index: 3000001;
+		width: var(--wp--lightbox-container-width);
+		color: #1e1e1e;
+		cursor: auto;
+
+		&[hidden] {
+			display: none;
+		}
+
+		.wp-lightbox-comments-list {
+			display: grid;
+			gap: 16px;
+			margin: 0 0 16px;
+		}
+
+		.wp-lightbox-comment {
+			display: grid;
+			gap: 4px;
+			margin: 0;
+		}
+
+		.wp-lightbox-comment-meta {
+			font-size: 13px;
+			font-weight: 600;
+			line-height: 1.4;
+		}
+
+		.wp-lightbox-comment-content {
+			font-size: 13px;
+			line-height: 1.5;
+
+			> :first-child {
+				margin-top: 0;
+			}
+
+			> :last-child {
+				margin-bottom: 0;
+			}
+		}
+
+		form {
+			display: grid;
+			gap: 12px;
+			margin: 0;
+		}
+
+		label {
+			display: grid;
+			gap: 4px;
+			margin: 0;
+			font-size: 13px;
+			line-height: 1.4;
+		}
+
+		input,
+		textarea {
+			width: 100%;
+			padding: 8px;
+			box-sizing: border-box;
+			font: inherit;
+			color: #1e1e1e;
+			background: #fff;
+			border: 1px solid rgb(0 0 0 / 24%);
+			border-radius: 2px;
+		}
+
+		textarea {
+			min-height: 96px;
+			resize: vertical;
+		}
+
+		button[type="submit"] {
+			justify-self: start;
+			padding: 8px 12px;
+			color: #fff;
+			background: #1e1e1e;
+			border-radius: 2px;
+			cursor: pointer;
+
+			&:disabled {
+				opacity: 0.6;
+				cursor: default;
+			}
+		}
+
+		.wp-lightbox-comments-login,
+		.wp-lightbox-comments-message {
+			margin: 0;
+			font-size: 13px;
+			line-height: 1.4;
+		}
+	}
+
 	.lightbox-image-container {
 		position: absolute;
 		overflow: hidden;
@@ -331,7 +476,7 @@
 		}
 	}
 
-	button {
+	button:not(.wp-lightbox-comment-button):not([type="submit"]) {
 		border: none;
 		background: none;
 	}
@@ -339,7 +484,9 @@
 	.scrim {
 		width: 100%;
 		height: 100%;
-		position: absolute;
+		position: fixed;
+		top: 0;
+		left: 0;
 		z-index: 2000000;
 		background-color: rgb(255, 255, 255);
 		opacity: 0.9;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -302,8 +302,9 @@
 
 	.wp-lightbox-comment-button {
 		position: absolute;
-		top: calc((100vh + var(--wp--lightbox-container-height)) / 2 - 48px);
-		left: calc((100vw + var(--wp--lightbox-container-width)) / 2 - 48px);
+		top: calc((100vh + var(--wp--lightbox-container-height)) / 2 + 8px);
+		left: 50%;
+		transform: translateX(-50%);
 		z-index: 3000001;
 		display: flex;
 		align-items: center;
@@ -317,9 +318,6 @@
 		border-radius: 4px;
 		box-shadow: 0 2px 8px rgb(0 0 0 / 16%);
 		cursor: pointer;
-		opacity: 0;
-		visibility: hidden;
-		transition: opacity 0.2s ease;
 
 		&[hidden] {
 			display: none;
@@ -335,16 +333,9 @@
 		}
 	}
 
-	.lightbox-image-container:hover + .wp-lightbox-comment-button,
-	.wp-lightbox-comment-button:hover,
-	.wp-lightbox-comment-button:focus {
-		opacity: 1;
-		visibility: visible;
-	}
-
 	.wp-lightbox-comments {
 		position: absolute;
-		top: calc((100vh + var(--wp--lightbox-container-height)) / 2 + 16px);
+		top: calc((100vh + var(--wp--lightbox-container-height)) / 2 + 64px);
 		left: 50%;
 		transform: translateX(-50%);
 		z-index: 3000001;

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -598,6 +598,21 @@ const { state, actions, callbacks } = store(
 					withScope( () => callbacks.scrollOverlayTo( comments ) )
 				);
 			},
+			createCommentElement( comment ) {
+				const article = document.createElement( 'article' );
+				article.className = 'wp-lightbox-comment';
+
+				const meta = document.createElement( 'div' );
+				meta.className = 'wp-lightbox-comment-meta';
+				meta.textContent = comment.author_name || '';
+
+				const content = document.createElement( 'div' );
+				content.className = 'wp-lightbox-comment-content';
+				content.innerHTML = comment.content?.rendered || '';
+
+				article.append( meta, content );
+				return article;
+			},
 			renderComments( comments ) {
 				const list = document.querySelector(
 					'.wp-lightbox-comments-list'
@@ -611,20 +626,22 @@ const { state, actions, callbacks } = store(
 				list.hidden = comments.length === 0;
 
 				for ( const comment of comments ) {
-					const article = document.createElement( 'article' );
-					article.className = 'wp-lightbox-comment';
-
-					const meta = document.createElement( 'div' );
-					meta.className = 'wp-lightbox-comment-meta';
-					meta.textContent = comment.author_name || '';
-
-					const content = document.createElement( 'div' );
-					content.className = 'wp-lightbox-comment-content';
-					content.innerHTML = comment.content?.rendered || '';
-
-					article.append( meta, content );
-					list.append( article );
+					list.append( callbacks.createCommentElement( comment ) );
 				}
+			},
+			appendComment( comment ) {
+				const list = document.querySelector(
+					'.wp-lightbox-comments-list'
+				);
+
+				if ( ! list ) {
+					return;
+				}
+
+				const article = callbacks.createCommentElement( comment );
+				list.append( article );
+				list.hidden = false;
+				article.scrollIntoView( { block: 'nearest' } );
 			},
 			async loadComments( force = false ) {
 				const attachmentId = state.selectedImage?.attachmentId;
@@ -705,7 +722,12 @@ const { state, actions, callbacks } = store(
 
 					form.reset();
 					state.commentForm.message = getConfig().commentSubmittedText;
-					callbacks.loadComments( true );
+
+					// Render the newly created comment from the response rather
+					// than re-fetching: the REST list endpoint only returns
+					// approved comments, so a comment held for moderation would
+					// otherwise disappear from view for the author who posted it.
+					callbacks.appendComment( responseBody );
 				} catch ( error ) {
 					state.commentForm.message =
 						error.message || getConfig().commentErrorText;

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -40,6 +40,11 @@ const touchStartEvent = {
 const focusableSelectors = [
 	'.wp-lightbox-close-button',
 	'.wp-lightbox-navigation-button',
+	'.wp-lightbox-comment-button',
+	'.wp-lightbox-comments a',
+	'.wp-lightbox-comments input',
+	'.wp-lightbox-comments textarea',
+	'.wp-lightbox-comments button',
 ];
 
 /**
@@ -71,6 +76,15 @@ const { state, actions, callbacks } = store(
 		state: {
 			selectedImageId: null,
 			selectedGalleryId: null,
+			commentForm: {
+				isVisible: false,
+				isSubmitting: false,
+				message: '',
+			},
+			comments: {
+				attachmentId: null,
+				isLoading: false,
+			},
 			preloadTimers: new Map(),
 			preloadedImageIds: new Set(),
 			get galleryImages() {
@@ -116,6 +130,27 @@ const { state, actions, callbacks } = store(
 			get thisImage() {
 				const { imageId } = getContext();
 				return state.metadata[ imageId ];
+			},
+			get selectedImageCommentsOpen() {
+				return !! state.selectedImage?.commentsOpen;
+			},
+			get commentLoginRequired() {
+				return (
+					state.selectedImageCommentsOpen &&
+					!! getConfig().commentRegistrationRequired
+				);
+			},
+			get commentFormVisible() {
+				return (
+					state.selectedImageCommentsOpen &&
+					state.commentForm.isVisible
+				);
+			},
+			get commentFormIsSubmitting() {
+				return state.commentForm.isSubmitting;
+			},
+			get commentFormMessage() {
+				return state.commentForm.message;
 			},
 			get hasNavigation() {
 				return state.galleryImages.length > 1;
@@ -216,6 +251,7 @@ const { state, actions, callbacks } = store(
 				const { galleryId } = getContext( 'core/gallery' ) || {};
 				state.selectedGalleryId = galleryId || null;
 				state.overlayEnabled = true;
+				callbacks.resetCommentForm();
 
 				// Computes the styles of the overlay for the animation.
 				callbacks.setOverlayStyles();
@@ -240,6 +276,7 @@ const { state, actions, callbacks } = store(
 						// Resets the selected image and gallery ids.
 						state.selectedImageId = null;
 						state.selectedGalleryId = null;
+						callbacks.resetCommentForm();
 					}, 450 );
 				}
 			},
@@ -249,6 +286,7 @@ const { state, actions, callbacks } = store(
 					? state.selectedImageIndex - 1
 					: state.galleryImages.length - 1;
 				state.selectedImageId = state.galleryImages[ nextIndex ];
+				callbacks.resetCommentForm();
 				callbacks.setOverlayStyles();
 			} ),
 			showNextImage: withSyncEvent( ( event ) => {
@@ -257,7 +295,59 @@ const { state, actions, callbacks } = store(
 					? state.selectedImageIndex + 1
 					: 0;
 				state.selectedImageId = state.galleryImages[ nextIndex ];
+				callbacks.resetCommentForm();
 				callbacks.setOverlayStyles();
+			} ),
+			stopPropagation: withSyncEvent( ( event ) => {
+				event.stopPropagation();
+			} ),
+			toggleCommentForm: withSyncEvent( ( event ) => {
+				event.preventDefault();
+				event.stopPropagation();
+				callbacks.toggleCommentForm();
+			} ),
+			submitComment: withSyncEvent( ( event ) => {
+				event.preventDefault();
+				event.stopPropagation();
+
+				if (
+					state.commentForm.isSubmitting ||
+					! state.selectedImage?.attachmentId
+				) {
+					return;
+				}
+
+				const form = event.currentTarget;
+				const formData = new window.FormData( form );
+				const content = String(
+					formData.get( 'comment' ) || ''
+				).trim();
+
+				if ( ! content ) {
+					return;
+				}
+
+				const payload = {
+					post: state.selectedImage.attachmentId,
+					content,
+				};
+				const author = String(
+					formData.get( 'author' ) || ''
+				).trim();
+				const email = String( formData.get( 'email' ) || '' ).trim();
+				const url = String( formData.get( 'url' ) || '' ).trim();
+
+				if ( author ) {
+					payload.author_name = author;
+				}
+				if ( email ) {
+					payload.author_email = email;
+				}
+				if ( url ) {
+					payload.author_url = url;
+				}
+
+				callbacks.submitComment( payload, form );
 			} ),
 			handleKeydown: withSyncEvent( ( event ) => {
 				if ( state.overlayEnabled ) {
@@ -271,7 +361,14 @@ const { state, actions, callbacks } = store(
 						// Traps focus within the overlay.
 						const focusableElements = Array.from(
 							document.querySelectorAll( focusableSelectors )
+						).filter(
+							( element ) =>
+								! element.disabled &&
+								! element.closest( '[hidden]' )
 						);
+						if ( focusableElements.length === 0 ) {
+							return;
+						}
 						const firstFocusableElement = focusableElements[ 0 ];
 						const lastFocusableElement =
 							focusableElements[ focusableElements.length - 1 ];
@@ -292,6 +389,12 @@ const { state, actions, callbacks } = store(
 				}
 			} ),
 			handleTouchMove: withSyncEvent( ( event ) => {
+				if (
+					state.commentFormVisible &&
+					event.target?.closest?.( '.wp-lightbox-comments' )
+				) {
+					return;
+				}
 				// On mobile devices, prevents triggering the scroll event because
 				// otherwise the page jumps around when it resets the scroll position.
 				// This also means that closing the lightbox requires that a user
@@ -420,6 +523,211 @@ const { state, actions, callbacks } = store(
 			},
 		},
 		callbacks: {
+			resetCommentForm() {
+				state.commentForm.isVisible = false;
+				state.commentForm.message = '';
+				state.commentForm.isSubmitting = false;
+				state.comments.attachmentId = null;
+				state.comments.isLoading = false;
+				callbacks.renderComments( [] );
+				const overlay = document.querySelector( '.wp-lightbox-overlay' );
+				if ( overlay ) {
+					overlay.scrollTop = 0;
+				}
+			},
+			scrollOverlayTo( target, onComplete ) {
+				const overlay = document.querySelector( '.wp-lightbox-overlay' );
+				if ( ! overlay || ! target ) {
+					onComplete?.();
+					return;
+				}
+
+				const startTime = Date.now();
+				const duration = 300;
+				const originalPosition = overlay.scrollTop;
+				const targetPosition = Math.min(
+					Math.max(
+						0,
+						target.offsetTop -
+							Math.max(
+								0,
+								window.innerHeight -
+									target.getBoundingClientRect().height -
+									32
+							)
+					),
+					overlay.scrollHeight - overlay.clientHeight
+				);
+				const distance = targetPosition - originalPosition;
+				let isScrolling = true;
+
+				function stopScroll() {
+					isScrolling = false;
+				}
+
+				function runScroll() {
+					const now = Date.now();
+					const progress = Math.min(
+						( now - startTime ) / duration,
+						1
+					);
+					const easedProgress =
+						progress < 0.5
+							? 2 * progress * progress
+							: 1 - Math.pow( -2 * progress + 2, 2 ) / 2;
+
+					overlay.scrollTop =
+						originalPosition + easedProgress * distance;
+
+					if ( progress < 1 && isScrolling ) {
+						window.requestAnimationFrame( runScroll );
+						return;
+					}
+
+					overlay.removeEventListener( 'wheel', stopScroll );
+					onComplete?.();
+				}
+
+				overlay.addEventListener( 'wheel', stopScroll );
+				runScroll();
+			},
+			toggleCommentForm() {
+				const overlay = document.querySelector( '.wp-lightbox-overlay' );
+				const comments = document.querySelector(
+					'.wp-lightbox-comments'
+				);
+
+				if ( state.commentForm.isVisible ) {
+					callbacks.scrollOverlayTo(
+						overlay,
+						withScope( () => {
+							state.commentForm.isVisible = false;
+						} )
+					);
+					return;
+				}
+
+				state.commentForm.isVisible = true;
+				callbacks.loadComments();
+				window.requestAnimationFrame(
+					withScope( () => callbacks.scrollOverlayTo( comments ) )
+				);
+			},
+			renderComments( comments ) {
+				const list = document.querySelector(
+					'.wp-lightbox-comments-list'
+				);
+
+				if ( ! list ) {
+					return;
+				}
+
+				list.replaceChildren();
+				list.hidden = comments.length === 0;
+
+				for ( const comment of comments ) {
+					const article = document.createElement( 'article' );
+					article.className = 'wp-lightbox-comment';
+
+					const meta = document.createElement( 'div' );
+					meta.className = 'wp-lightbox-comment-meta';
+					meta.textContent = comment.author_name || '';
+
+					const content = document.createElement( 'div' );
+					content.className = 'wp-lightbox-comment-content';
+					content.innerHTML = comment.content?.rendered || '';
+
+					article.append( meta, content );
+					list.append( article );
+				}
+			},
+			async loadComments( force = false ) {
+				const attachmentId = state.selectedImage?.attachmentId;
+
+				if (
+					! attachmentId ||
+					state.comments.isLoading ||
+					( ! force && state.comments.attachmentId === attachmentId )
+				) {
+					return;
+				}
+
+				state.comments.isLoading = true;
+
+				try {
+					const url = new URL( getConfig().commentEndpoint );
+					url.searchParams.set( 'post', attachmentId );
+					url.searchParams.set( 'orderby', 'date' );
+					url.searchParams.set( 'order', 'asc' );
+					url.searchParams.set( 'per_page', '100' );
+
+					const response = await window.fetch( url, {
+						credentials: 'same-origin',
+					} );
+
+					if ( ! response.ok ) {
+						throw new Error();
+					}
+
+					const comments = await response.json();
+					callbacks.renderComments( comments );
+					state.comments.attachmentId = attachmentId;
+					if ( state.commentForm.isVisible ) {
+						window.requestAnimationFrame(
+							withScope( () =>
+								callbacks.scrollOverlayTo(
+									document.querySelector(
+										'.wp-lightbox-comments'
+									)
+								)
+							)
+						);
+					}
+				} catch {
+					callbacks.renderComments( [] );
+				} finally {
+					state.comments.isLoading = false;
+				}
+			},
+			async submitComment( payload, form ) {
+				const headers = {
+					'Content-Type': 'application/json',
+				};
+				const { commentNonce } = getConfig();
+
+				if ( commentNonce ) {
+					headers[ 'X-WP-Nonce' ] = commentNonce;
+				}
+
+				state.commentForm.isSubmitting = true;
+				state.commentForm.message = getConfig().commentSubmittingText;
+
+				try {
+					const response = await window.fetch(
+						getConfig().commentEndpoint,
+						{
+							method: 'POST',
+							credentials: 'same-origin',
+							headers,
+							body: JSON.stringify( payload ),
+						}
+					);
+					const responseBody = await response.json();
+
+					if ( ! response.ok ) {
+						throw new Error( responseBody.message );
+					}
+
+					form.reset();
+					state.commentForm.message = getConfig().commentSubmittedText;
+					callbacks.loadComments( true );
+				} catch ( error ) {
+					state.commentForm.message =
+						error.message || getConfig().commentErrorText;
+				} finally {
+					state.commentForm.isSubmitting = false;
+				}
+			},
 			setOverlayStyles() {
 				if ( ! state.overlayEnabled ) {
 					return;
@@ -549,7 +857,6 @@ const { state, actions, callbacks } = store(
 					horizontalPadding = state.hasNavigation ? 320 : 80;
 					verticalPadding = 80;
 				}
-
 				const targetMaxWidth = Math.min(
 					window.innerWidth - horizontalPadding,
 					containerWidth

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -515,13 +515,17 @@ const { state, actions, callbacks } = store(
 				state.comments.attachmentId = null;
 				state.comments.isLoading = false;
 				callbacks.renderComments( [] );
-				const overlay = document.querySelector( '.wp-lightbox-overlay' );
+				const overlay = document.querySelector(
+					'.wp-lightbox-overlay'
+				);
 				if ( overlay ) {
 					overlay.scrollTop = 0;
 				}
 			},
 			scrollOverlayTo( target, onComplete ) {
-				const overlay = document.querySelector( '.wp-lightbox-overlay' );
+				const overlay = document.querySelector(
+					'.wp-lightbox-overlay'
+				);
 				if ( ! overlay || ! target ) {
 					onComplete?.();
 					return;
@@ -577,9 +581,8 @@ const { state, actions, callbacks } = store(
 				runScroll();
 			},
 			toggleCommentForm() {
-				const overlay = document.querySelector( '.wp-lightbox-overlay' );
-				const comments = document.querySelector(
-					'.wp-lightbox-comments'
+				const overlay = document.querySelector(
+					'.wp-lightbox-overlay'
 				);
 
 				if ( state.commentForm.isVisible ) {
@@ -591,6 +594,10 @@ const { state, actions, callbacks } = store(
 					);
 					return;
 				}
+
+				const comments = document.querySelector(
+					'.wp-lightbox-comments'
+				);
 
 				state.commentForm.isVisible = true;
 				callbacks.loadComments();

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -137,7 +137,7 @@ const { state, actions, callbacks } = store(
 			get commentLoginRequired() {
 				return (
 					state.selectedImageCommentsOpen &&
-					!! getConfig().commentRegistrationRequired
+					!! getConfig().commentLoginRequired
 				);
 			},
 			get commentFormVisible() {
@@ -331,21 +331,6 @@ const { state, actions, callbacks } = store(
 					post: state.selectedImage.attachmentId,
 					content,
 				};
-				const author = String(
-					formData.get( 'author' ) || ''
-				).trim();
-				const email = String( formData.get( 'email' ) || '' ).trim();
-				const url = String( formData.get( 'url' ) || '' ).trim();
-
-				if ( author ) {
-					payload.author_name = author;
-				}
-				if ( email ) {
-					payload.author_email = email;
-				}
-				if ( url ) {
-					payload.author_url = url;
-				}
 
 				callbacks.submitComment( payload, form );
 			} ),

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -692,40 +692,47 @@ const { state, actions, callbacks } = store(
 				}
 			},
 			async submitComment( payload, form ) {
+				// Read all config synchronously: `getConfig()` relies on the
+				// interactivity scope, which is lost after the first `await`
+				// below, so calling it afterwards would return an empty config.
+				const {
+					commentNonce,
+					commentEndpoint,
+					commentSubmittingText,
+					commentSubmittedText,
+					commentErrorText,
+				} = getConfig();
+
 				const headers = {
 					'Content-Type': 'application/json',
 				};
-				const { commentNonce } = getConfig();
 
 				if ( commentNonce ) {
 					headers[ 'X-WP-Nonce' ] = commentNonce;
 				}
 
 				state.commentForm.isSubmitting = true;
-				state.commentForm.message = getConfig().commentSubmittingText;
+				state.commentForm.message = commentSubmittingText;
 
 				try {
-					const response = await window.fetch(
-						getConfig().commentEndpoint,
-						{
-							method: 'POST',
-							credentials: 'same-origin',
-							headers,
-							body: JSON.stringify( payload ),
-						}
-					);
+					const response = await window.fetch( commentEndpoint, {
+						method: 'POST',
+						credentials: 'same-origin',
+						headers,
+						body: JSON.stringify( payload ),
+					} );
 					const responseBody = await response.json();
 
 					if ( ! response.ok ) {
 						// Surface the server's validation message when present,
 						// e.g. "Comment content cannot be empty".
 						state.commentForm.message =
-							responseBody.message || getConfig().commentErrorText;
+							responseBody.message || commentErrorText;
 						return;
 					}
 
 					form.reset();
-					state.commentForm.message = getConfig().commentSubmittedText;
+					state.commentForm.message = commentSubmittedText;
 
 					// Render the newly created comment from the response rather
 					// than re-fetching: the REST list endpoint only returns
@@ -735,7 +742,7 @@ const { state, actions, callbacks } = store(
 				} catch {
 					// Network failures or non-JSON responses fall back to the
 					// localized error text rather than a raw browser message.
-					state.commentForm.message = getConfig().commentErrorText;
+					state.commentForm.message = commentErrorText;
 				} finally {
 					state.commentForm.isSubmitting = false;
 				}

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -717,7 +717,11 @@ const { state, actions, callbacks } = store(
 					const responseBody = await response.json();
 
 					if ( ! response.ok ) {
-						throw new Error( responseBody.message );
+						// Surface the server's validation message when present,
+						// e.g. "Comment content cannot be empty".
+						state.commentForm.message =
+							responseBody.message || getConfig().commentErrorText;
+						return;
 					}
 
 					form.reset();
@@ -728,9 +732,10 @@ const { state, actions, callbacks } = store(
 					// approved comments, so a comment held for moderation would
 					// otherwise disappear from view for the author who posted it.
 					callbacks.appendComment( responseBody );
-				} catch ( error ) {
-					state.commentForm.message =
-						error.message || getConfig().commentErrorText;
+				} catch {
+					// Network failures or non-JSON responses fall back to the
+					// localized error text rather than a raw browser message.
+					state.commentForm.message = getConfig().commentErrorText;
 				} finally {
 					state.commentForm.isSubmitting = false;
 				}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -7942,6 +7942,38 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 * @covers WP_Theme_JSON_Gutenberg::sanitize
 	 * @covers WP_Theme_JSON_Gutenberg::remove_keys_not_in_schema
 	 */
+	public function test_sanitize_preserves_lightbox_comments_boolean_values() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'lightboxComments' => array(
+						'enabled'      => true,
+						'allowEditing' => false,
+					),
+					'blocks'           => array(
+						'core/image' => array(
+							'lightboxComments' => array(
+								'enabled'      => true,
+								'allowEditing' => false,
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$settings = $theme_json->get_settings();
+		$this->assertTrue( $settings['lightboxComments']['enabled'] );
+		$this->assertFalse( $settings['lightboxComments']['allowEditing'] );
+		$this->assertTrue( $settings['blocks']['core/image']['lightboxComments']['enabled'] );
+		$this->assertFalse( $settings['blocks']['core/image']['lightboxComments']['allowEditing'] );
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Gutenberg::sanitize
+	 * @covers WP_Theme_JSON_Gutenberg::remove_keys_not_in_schema
+	 */
 	public function test_sanitize_removes_non_boolean_values_in_block_settings() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -385,6 +385,21 @@
 						}
 					},
 					"additionalProperties": false
+				},
+				"lightboxComments": {
+					"description": "Settings related to comments in the lightbox.",
+					"type": "object",
+					"properties": {
+						"enabled": {
+							"description": "Defines whether lightbox comments are enabled or not.",
+							"type": "boolean"
+						},
+						"allowEditing": {
+							"description": "Defines whether to show the lightbox comments UI in the block editor. If set to `false`, the user won't be able to change the lightbox comments settings in the block editor.",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
 				}
 			}
 		},
@@ -892,6 +907,7 @@
 				"dimensions",
 				"layout",
 				"lightbox",
+				"lightboxComments",
 				"position",
 				"shadow",
 				"spacing",

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -959,6 +959,109 @@ test.describe( 'Image - lightbox', () => {
 	} );
 } );
 
+test.describe( 'Image - lightbox comments', () => {
+	let uploadedMedia;
+
+	const lightboxImageBlock = ( media ) =>
+		`<!-- wp:image {"id":${ media.id },"sizeSlug":"full","linkDestination":"none","lightbox":{"enabled":true}} -->
+		<figure class="wp-block-image size-full"><img src="${ media.source_url }" alt="" class="wp-image-${ media.id }"/></figure>
+		<!-- /wp:image -->`;
+
+	async function setAttachmentCommentStatus( requestUtils, status ) {
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/media/${ uploadedMedia.id }`,
+			data: { comment_status: status },
+		} );
+	}
+
+	async function openLightbox( editor, page ) {
+		await editor.setContent( lightboxImageBlock( uploadedMedia ) );
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+		await page.locator( '.wp-lightbox-container img' ).click();
+		await expect(
+			page.locator( '.wp-lightbox-overlay.active' )
+		).toBeVisible();
+	}
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
+		uploadedMedia = await requestUtils.uploadMedia(
+			'./assets/10x10_e2e_test_image_z9T8jK.png'
+		);
+	} );
+
+	test.beforeEach( async ( { admin, requestUtils } ) => {
+		await requestUtils.deleteAllComments();
+		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllComments();
+		await requestUtils.deleteAllMedia();
+	} );
+
+	test( 'hides the comment button when the attachment has comments closed', async ( {
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		await setAttachmentCommentStatus( requestUtils, 'closed' );
+		await openLightbox( editor, page );
+
+		await expect(
+			page.locator( '.wp-lightbox-comment-button' )
+		).toBeHidden();
+	} );
+
+	test( 'shows existing comments when the attachment has comments open', async ( {
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		await setAttachmentCommentStatus( requestUtils, 'open' );
+		await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/comments',
+			data: {
+				post: uploadedMedia.id,
+				content: 'A wonderful photograph.',
+				status: 'approved',
+			},
+		} );
+
+		await openLightbox( editor, page );
+
+		const commentButton = page.locator( '.wp-lightbox-comment-button' );
+		await expect( commentButton ).toBeVisible();
+		await commentButton.click();
+
+		await expect(
+			page.locator( '.wp-lightbox-comment-content' )
+		).toContainText( 'A wonderful photograph.' );
+	} );
+
+	test( 'lets a logged-in visitor submit a comment', async ( {
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		await setAttachmentCommentStatus( requestUtils, 'open' );
+		await openLightbox( editor, page );
+
+		await page.locator( '.wp-lightbox-comment-button' ).click();
+
+		const form = page.locator( '.wp-lightbox-comments form' );
+		await form.locator( 'textarea[name="comment"]' ).fill( 'Great shot!' );
+		await form.getByRole( 'button', { name: 'Post Comment' } ).click();
+
+		await expect(
+			page.locator( '.wp-lightbox-comments-message' )
+		).toHaveText( 'Comment submitted.' );
+	} );
+} );
+
 // Added to prevent regressions of https://github.com/WordPress/gutenberg/pull/57040.
 test.describe( 'Image - Site editor', () => {
 	test.beforeAll( async ( { requestUtils } ) => {

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -1059,6 +1059,12 @@ test.describe( 'Image - lightbox comments', () => {
 		await expect(
 			page.locator( '.wp-lightbox-comments-message' )
 		).toHaveText( 'Comment submitted.' );
+
+		// The submitted comment is rendered from the response, so it appears
+		// immediately for the author even if it is held for moderation.
+		await expect(
+			page.locator( '.wp-lightbox-comment-content' )
+		).toContainText( 'Great shot!' );
 	} );
 } );
 

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -963,10 +963,14 @@ test.describe( 'Image - lightbox comments', () => {
 	let uploadedMedia;
 
 	const lightboxImageBlock = ( media, { comments = true } = {} ) =>
-		`<!-- wp:image {"id":${ media.id },"sizeSlug":"full","linkDestination":"none","lightbox":{"enabled":true}${
+		`<!-- wp:image {"id":${
+			media.id
+		},"sizeSlug":"full","linkDestination":"none","lightbox":{"enabled":true}${
 			comments ? ',"lightboxComments":{"enabled":true}' : ''
 		}} -->
-		<figure class="wp-block-image size-full"><img src="${ media.source_url }" alt="" class="wp-image-${ media.id }"/></figure>
+		<figure class="wp-block-image size-full"><img src="${
+			media.source_url
+		}" alt="" class="wp-image-${ media.id }"/></figure>
 		<!-- /wp:image -->`;
 
 	async function setAttachmentCommentStatus( requestUtils, status ) {

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -993,7 +993,7 @@ test.describe( 'Image - lightbox comments', () => {
 
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.setGutenbergExperiments( [
-			'gutenberg-lightbox-comments',
+			'gutenberg-gallery-lightbox-default',
 		] );
 		await requestUtils.deleteAllMedia();
 		uploadedMedia = await requestUtils.uploadMedia(

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -962,8 +962,10 @@ test.describe( 'Image - lightbox', () => {
 test.describe( 'Image - lightbox comments', () => {
 	let uploadedMedia;
 
-	const lightboxImageBlock = ( media ) =>
-		`<!-- wp:image {"id":${ media.id },"sizeSlug":"full","linkDestination":"none","lightbox":{"enabled":true}} -->
+	const lightboxImageBlock = ( media, { comments = true } = {} ) =>
+		`<!-- wp:image {"id":${ media.id },"sizeSlug":"full","linkDestination":"none","lightbox":{"enabled":true}${
+			comments ? ',"lightboxComments":{"enabled":true}' : ''
+		}} -->
 		<figure class="wp-block-image size-full"><img src="${ media.source_url }" alt="" class="wp-image-${ media.id }"/></figure>
 		<!-- /wp:image -->`;
 
@@ -975,8 +977,12 @@ test.describe( 'Image - lightbox comments', () => {
 		} );
 	}
 
-	async function openLightbox( editor, page ) {
-		await editor.setContent( lightboxImageBlock( uploadedMedia ) );
+	async function openLightbox(
+		editor,
+		page,
+		content = lightboxImageBlock( uploadedMedia )
+	) {
+		await editor.setContent( content );
 		const postId = await editor.publishPost();
 		await page.goto( `/?p=${ postId }` );
 		await page.locator( '.wp-lightbox-container img' ).click();
@@ -1009,6 +1015,23 @@ test.describe( 'Image - lightbox comments', () => {
 	} ) => {
 		await setAttachmentCommentStatus( requestUtils, 'closed' );
 		await openLightbox( editor, page );
+
+		await expect(
+			page.locator( '.wp-lightbox-comment-button' )
+		).toBeHidden();
+	} );
+
+	test( 'hides the comment button when lightbox comments are not enabled', async ( {
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		await setAttachmentCommentStatus( requestUtils, 'open' );
+		await openLightbox(
+			editor,
+			page,
+			lightboxImageBlock( uploadedMedia, { comments: false } )
+		);
 
 		await expect(
 			page.locator( '.wp-lightbox-comment-button' )

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -992,6 +992,9 @@ test.describe( 'Image - lightbox comments', () => {
 	}
 
 	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-lightbox-comments',
+		] );
 		await requestUtils.deleteAllMedia();
 		uploadedMedia = await requestUtils.uploadMedia(
 			'./assets/10x10_e2e_test_image_z9T8jK.png'
@@ -1006,6 +1009,7 @@ test.describe( 'Image - lightbox comments', () => {
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllComments();
 		await requestUtils.deleteAllMedia();
+		await requestUtils.setGutenbergExperiments( [] );
 	} );
 
 	test( 'hides the comment button when the attachment has comments closed', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds support for viewing and submitting comments from image block lightboxes when the underlying attachment has comments open.

## Why?
Attachments can receive comments, but the image lightbox currently offers no way to see or add them from the enlarged image experience.

## How?
The image lightbox now passes attachment comment metadata to the frontend, shows a hover/focus comment icon, scrolls to a comments area, fetches existing comments from the comments REST endpoint, and submits new comments through the same endpoint.

## Testing Instructions
1. Ensure an image attachment has `comment_status` set to `open`.
2. Add that image to a post and enable the image lightbox.
3. View the post, open the image lightbox, hover the enlarged image, and click the comment icon.
4. Confirm existing comments display and that submitting a comment shows feedback.

### Testing Instructions for Keyboard
Open the lightbox, tab to the comment button, press Enter, confirm focus can move through the comment form, and submit a comment with the keyboard.

## Screenshots or screencast
<img width="1728" height="997" alt="Screenshot 2026-06-02 at 20 59 42" src="https://github.com/user-attachments/assets/d2a6c8ab-d1bd-40cf-8ed4-49e3cf28d2f7" />
<img width="1728" height="995" alt="Screenshot 2026-06-02 at 20 54 19" src="https://github.com/user-attachments/assets/1df51356-9440-4d8b-a619-a26ea2de3e80" />
<img width="1728" height="995" alt="Screenshot 2026-06-02 at 20 50 08" src="https://github.com/user-attachments/assets/ff1ebf3b-f059-4c15-b40c-d9e4da61a9c7" />
<img width="1728" height="996" alt="Screenshot 2026-06-02 at 20 49 55" src="https://github.com/user-attachments/assets/bb0b7d0c-3280-425f-8d5d-c9ccf04173f6" />
<img width="1728" height="995" alt="Screenshot 2026-06-02 at 20 49 42" src="https://github.com/user-attachments/assets/d8b4b0aa-4c4e-4f3e-a7f0-c992202c7700" />

