### PR TITLE
Add EXIF metadata to image lightbox

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -445,7 +445,7 @@ Insert an image to make a visual statement. ([Source](https://github.com/WordPre
 -	**Name:** core/image
 -	**Category:** media
 -	**Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity, shadow, spacing (margin)
--	**Attributes:** alt, aspectRatio, blob, caption, focalPoint, height, href, id, isDecorative, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
+-	**Attributes:** alt, aspectRatio, blob, caption, exif, focalPoint, height, href, id, isDecorative, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
 
 ## Latest Comments
 

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -144,6 +144,17 @@ Settings related to the lightbox.
 
 ---
 
+### exif
+
+Settings related to displaying EXIF metadata in the image lightbox.
+
+| Property | Description | Type | Default |
+| -------- | ----------- | ---- | ------- |
+| enabled | Defines whether EXIF metadata is shown in the lightbox. | `boolean` |  |
+| allowEditing | Defines whether to show the EXIF metadata UI in the block editor. If set to `false`, the user won't be able to change the EXIF setting in the block editor. | `boolean` |  |
+
+---
+
 ### position
 
 Settings related to position.

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -446,6 +446,10 @@ class WP_Theme_JSON_Gutenberg {
 			'enabled'      => true,
 			'allowEditing' => true,
 		),
+		'exif'                          => array(
+			'enabled'      => true,
+			'allowEditing' => true,
+		),
 		'position'                      => array(
 			'fixed'  => null,
 			'sticky' => null,

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -39,6 +39,9 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-classic-block-deprecation' ) ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalClassicBlockDeprecation = true', 'before' );
 	}
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-gallery-lightbox-default' ) ) {
+		wp_add_inline_script( 'wp-block-library', 'window.__experimentalGalleryLightboxDefault = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -55,6 +55,11 @@ function gutenberg_initialize_experiments_settings() {
 					'label'       => __( 'Media Upload Modal', 'gutenberg' ),
 					'description' => __( 'Replaces the existing WordPress media modal with a new modal powered by Data Views, supporting browsing, selecting, and uploading media.', 'gutenberg' ),
 				),
+				array(
+					'id'          => 'gutenberg-gallery-lightbox-default',
+					'label'       => __( 'Gallery lightbox default', 'gutenberg' ),
+					'description' => __( 'Sets newly created Gallery blocks to use the lightbox by default.', 'gutenberg' ),
+				),
 			),
 		),
 		array(

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -346,6 +346,9 @@
 			"core/image": {
 				"lightbox": {
 					"allowEditing": true
+				},
+				"exif": {
+					"allowEditing": true
 				}
 			},
 			"core/icon": {

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Image: show EXIF metadata (camera, aperture, shutter speed, focal length, copyright) in the lightbox via a toggle ([#78892](https://github.com/WordPress/gutenberg/pull/78892)).
+
 ### Code Quality
 
 -   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Image: show EXIF metadata (camera, aperture, shutter speed, focal length, copyright) in the lightbox via a toggle ([#78892](https://github.com/WordPress/gutenberg/pull/78892)).
+-   Image: optionally show EXIF metadata (camera, aperture, shutter speed, focal length, copyright) in the lightbox, opt-in per image or site-wide via a `core/image.exif` theme.json setting ([#78892](https://github.com/WordPress/gutenberg/pull/78892)).
 
 ### Code Quality
 

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -49,6 +49,12 @@
 				"type": "boolean"
 			}
 		},
+		"exif": {
+			"type": "object",
+			"enabled": {
+				"type": "boolean"
+			}
+		},
 		"title": {
 			"type": "string",
 			"source": "attribute",

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -698,10 +698,12 @@ export default function Image( {
 	const [ exifSetting ] = useSettings( 'exif' );
 
 	const showExifSetting =
+		// The EXIF metadata UI is gated behind the lightbox experiment for now.
+		!! window.__experimentalGalleryLightboxDefault &&
 		// If a block-level override is set, give users the option to remove it
 		// even if the EXIF UI is disabled in the settings.
-		( !! exif && exif?.enabled !== exifSetting?.enabled ) ||
-		exifSetting?.allowEditing;
+		( ( !! exif && exif?.enabled !== exifSetting?.enabled ) ||
+			exifSetting?.allowEditing );
 
 	const exifChecked =
 		!! exif?.enabled || ( ! exif && !! exifSetting?.enabled );

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -10,6 +10,7 @@ import {
 	TextareaControl,
 	TextControl,
 	CheckboxControl,
+	ToggleControl,
 	ToolbarButton,
 	ToolbarGroup,
 	__experimentalToolsPanel as ToolsPanel,
@@ -296,6 +297,7 @@ export default function Image( {
 		linkTarget,
 		sizeSlug,
 		lightbox,
+		exif,
 		metadata,
 		isDecorative,
 	} = attributes;
@@ -551,6 +553,28 @@ export default function Image( {
 		}
 	}
 
+	function onSetExif( enable ) {
+		if ( enable && ! exifSetting?.enabled ) {
+			setAttributes( {
+				exif: { enabled: true },
+			} );
+		} else if ( ! enable && exifSetting?.enabled ) {
+			setAttributes( {
+				exif: { enabled: false },
+			} );
+		} else {
+			setAttributes( {
+				exif: undefined,
+			} );
+		}
+	}
+
+	function resetExif() {
+		setAttributes( {
+			exif: undefined,
+		} );
+	}
+
 	function onSetTitle( value ) {
 		// This is the HTML title attribute, separate from the media object
 		// title.
@@ -670,6 +694,17 @@ export default function Image( {
 
 	const lightboxChecked =
 		!! lightbox?.enabled || ( ! lightbox && !! lightboxSetting?.enabled );
+
+	const [ exifSetting ] = useSettings( 'exif' );
+
+	const showExifSetting =
+		// If a block-level override is set, give users the option to remove it
+		// even if the EXIF UI is disabled in the settings.
+		( !! exif && exif?.enabled !== exifSetting?.enabled ) ||
+		exifSetting?.allowEditing;
+
+	const exifChecked =
+		!! exif?.enabled || ( ! exif && !! exifSetting?.enabled );
 
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
@@ -1011,6 +1046,24 @@ export default function Image( {
 									onChange={ updateIsDecorative }
 									help={ __(
 										'Hidden from assistive technologies.'
+									) }
+								/>
+							</ToolsPanelItem>
+						) }
+						{ lightboxChecked && showExifSetting && (
+							<ToolsPanelItem
+								label={ __( 'Show photo metadata' ) }
+								isShownByDefault
+								hasValue={ () => !! exif }
+								onDeselect={ resetExif }
+							>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Show photo metadata' ) }
+									checked={ exifChecked }
+									onChange={ onSetExif }
+									help={ __(
+										'Display available EXIF data, such as camera and exposure, in the lightbox.'
 									) }
 								/>
 							</ToolsPanelItem>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -1060,7 +1060,6 @@ export default function Image( {
 								onDeselect={ resetExif }
 							>
 								<ToggleControl
-									__nextHasNoMarginBottom
 									label={ __( 'Show photo metadata' ) }
 									checked={ exifChecked }
 									onChange={ onSetExif }

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -167,6 +167,39 @@ function block_core_image_get_lightbox_settings( $block ) {
 }
 
 /**
+ * Returns the EXIF metadata display settings for the block.
+ *
+ * Mirrors the lightbox settings resolution: a per-block `exif` attribute
+ * overrides the `core/image` global settings, which fall back to the top-level
+ * global settings. EXIF metadata is only shown when this resolves to enabled
+ * and the lightbox itself is enabled.
+ *
+ * @since 6.9.0
+ *
+ * @param array $block Block data.
+ *
+ * @return array|null Filtered EXIF display settings.
+ */
+function block_core_image_get_exif_display_settings( $block ) {
+	// Gets the EXIF setting from the block attributes.
+	if ( isset( $block['attrs']['exif'] ) ) {
+		$exif_settings = $block['attrs']['exif'];
+	}
+
+	if ( ! isset( $exif_settings ) ) {
+		$exif_settings = wp_get_global_settings( array( 'exif' ), array( 'block_name' => 'core/image' ) );
+
+		// If not present in block-level settings, check the top-level global
+		// settings (see the matching note in the lightbox settings helper).
+		if ( isset( $exif_settings['exif'] ) ) {
+			$exif_settings = wp_get_global_settings( array( 'exif' ) );
+		}
+	}
+
+	return $exif_settings ?? null;
+}
+
+/**
  * Formats the shutter speed value for display.
  *
  * @since 6.9.0
@@ -317,7 +350,13 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 		$img_srcset       = wp_get_attachment_image_srcset( $block['attrs']['id'], $srcset_size );
 		$img_width        = $img_metadata['width'] ?? 'none';
 		$img_height       = $img_metadata['height'] ?? 'none';
-		$img_exif         = block_core_image_get_lightbox_exif_data( $block['attrs']['id'] );
+
+		// Only expose EXIF metadata (and therefore the toggle button) when it is
+		// enabled via the block attribute or global settings.
+		$exif_settings = block_core_image_get_exif_display_settings( $block );
+		if ( isset( $exif_settings['enabled'] ) && true === $exif_settings['enabled'] ) {
+			$img_exif = block_core_image_get_lightbox_exif_data( $block['attrs']['id'] );
+		}
 	}
 
 	// Figure.

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -248,7 +248,7 @@ function block_core_image_get_lightbox_exif_data( $attachment_id ) {
 		is_numeric( $image_meta['focal_length'] ) &&
 		(float) $image_meta['focal_length'] > 0
 	) {
-		$exif['focalLength'] = (string) (float) $image_meta['focal_length'] . 'mm';
+		$exif['focalLength'] = (string) round( (float) $image_meta['focal_length'], 1 ) . 'mm';
 	}
 
 	if ( ! empty( $image_meta['copyright'] ) && is_scalar( $image_meta['copyright'] ) ) {

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -496,28 +496,28 @@ function block_core_image_print_lightbox_overlay() {
 					</figure>
 				</div>
 				<div class="wp-lightbox-exif" style="color:{$close_button_color}" data-wp-bind--hidden="!state.hasExif" hidden>
-					<dl>
-						<div data-wp-bind--hidden="!state.exifCamera" hidden>
-							<dt>{$camera_label}</dt>
-							<dd data-wp-text="state.exifCamera"></dd>
-						</div>
-						<div data-wp-bind--hidden="!state.exifAperture" hidden>
-							<dt>{$aperture_label}</dt>
-							<dd data-wp-text="state.exifAperture"></dd>
-						</div>
-						<div data-wp-bind--hidden="!state.exifShutterSpeed" hidden>
-							<dt>{$shutter_label}</dt>
-							<dd data-wp-text="state.exifShutterSpeed"></dd>
-						</div>
-						<div data-wp-bind--hidden="!state.exifFocalLength" hidden>
-							<dt>{$focal_label}</dt>
-							<dd data-wp-text="state.exifFocalLength"></dd>
-						</div>
-						<div data-wp-bind--hidden="!state.exifCopyright" hidden>
-							<dt>{$copyright_label}</dt>
-							<dd data-wp-text="state.exifCopyright"></dd>
-						</div>
-					</dl>
+					<ul>
+						<li data-wp-bind--hidden="!state.exifCamera" hidden>
+							<h5>{$camera_label}</h5>
+							<span data-wp-text="state.exifCamera"></span>
+						</li>
+						<li data-wp-bind--hidden="!state.exifAperture" hidden>
+							<h5>{$aperture_label}</h5>
+							<span data-wp-text="state.exifAperture"></span>
+						</li>
+						<li data-wp-bind--hidden="!state.exifShutterSpeed" hidden>
+							<h5>{$shutter_label}</h5>
+							<span data-wp-text="state.exifShutterSpeed"></span>
+						</li>
+						<li data-wp-bind--hidden="!state.exifFocalLength" hidden>
+							<h5>{$focal_label}</h5>
+							<span data-wp-text="state.exifFocalLength"></span>
+						</li>
+						<li data-wp-bind--hidden="!state.exifCopyright" hidden>
+							<h5>{$copyright_label}</h5>
+							<span data-wp-text="state.exifCopyright"></span>
+						</li>
+					</ul>
 				</div>
 				<button type="button" style="fill:{$close_button_color}" class="wp-lightbox-navigation-button wp-lightbox-navigation-button-next" data-wp-bind--hidden="!state.hasNavigation" data-wp-on--click="actions.showNextImage" data-wp-bind--aria-label="state.nextButtonAriaLabel">
 					<span class="wp-lightbox-navigation-text" data-wp-bind--hidden="!state.hasNavigationText">{$next_button_text}</span>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -554,7 +554,7 @@ function block_core_image_print_lightbox_overlay() {
 						<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12.5 2C7.007 2 2.549 6.48 2.549 12S7.007 22 12.5 22s9.951-4.48 9.951-10S17.993 2 12.5 2ZM4.539 12c0-4.41 3.572-8 7.961-8s7.961 3.59 7.961 8-3.572 8-7.961 8-7.961-3.59-7.961-8ZM11.505 7v2h1.99V7h-1.99Zm0 4v6h1.99v-6h-1.99Z"/>
 					</svg>
 				</button>
-				<div id="wp-lightbox-exif" class="wp-lightbox-exif" style="color:{$close_button_color}" role="group" aria-label="{$exif_region_label}" data-wp-bind--hidden="!state.isExifVisible" hidden>
+				<div id="wp-lightbox-exif" class="wp-lightbox-exif" style="color:{$close_button_color}" role="group" aria-label="{$exif_region_label}" data-wp-bind--hidden="!state.isExifVisible" data-wp-on--click="actions.handleExifClick" hidden>
 					<ul>
 						<li data-wp-bind--hidden="!state.exifCamera" hidden>
 							<h5>{$camera_label}</h5>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -420,6 +420,7 @@ function block_core_image_print_lightbox_overlay() {
 	$close_button_text = esc_attr__( 'Close' );
 	$prev_button_text  = esc_attr_x( 'Previous', 'previous image in lightbox' );
 	$next_button_text  = esc_attr_x( 'Next', 'next image in lightbox' );
+	$exif_button_label = esc_attr__( 'Toggle photo metadata visibility' );
 	$camera_label      = esc_html__( 'Camera' );
 	$aperture_label    = esc_html__( 'Aperture' );
 	$shutter_label     = esc_html__( 'Shutter Speed' );
@@ -495,7 +496,22 @@ function block_core_image_print_lightbox_overlay() {
 						>
 					</figure>
 				</div>
-				<div class="wp-lightbox-exif" style="color:{$close_button_color}" data-wp-bind--hidden="!state.hasExif" hidden>
+				<button
+					type="button"
+					style="color:{$close_button_color}"
+					class="wp-lightbox-exif-button"
+					aria-label="{$exif_button_label}"
+					data-wp-bind--aria-expanded="state.exifExpanded"
+					data-wp-bind--hidden="!state.hasExif"
+					data-wp-class--active="state.isExifVisible"
+					data-wp-on--click="actions.toggleExif"
+					hidden
+				>
+					<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+						<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12.5 2C7.007 2 2.549 6.48 2.549 12S7.007 22 12.5 22s9.951-4.48 9.951-10S17.993 2 12.5 2ZM4.539 12c0-4.41 3.572-8 7.961-8s7.961 3.59 7.961 8-3.572 8-7.961 8-7.961-3.59-7.961-8ZM11.505 7v2h1.99V7h-1.99Zm0 4v6h1.99v-6h-1.99Z"/>
+					</svg>
+				</button>
+				<div class="wp-lightbox-exif" style="color:{$close_button_color}" data-wp-bind--hidden="!state.isExifVisible" hidden>
 					<ul>
 						<li data-wp-bind--hidden="!state.exifCamera" hidden>
 							<h5>{$camera_label}</h5>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -167,6 +167,98 @@ function block_core_image_get_lightbox_settings( $block ) {
 }
 
 /**
+ * Formats the shutter speed value for display.
+ *
+ * @since 6.9.0
+ *
+ * @param string|int|float $speed Shutter speed value.
+ *
+ * @return string Formatted shutter speed value.
+ */
+function block_core_image_format_lightbox_exif_shutter_speed( $speed ) {
+	if ( is_string( $speed ) && str_contains( $speed, '/' ) ) {
+		$parts = array_map( 'trim', explode( '/', $speed, 2 ) );
+		if (
+			2 === count( $parts ) &&
+			is_numeric( $parts[0] ) &&
+			is_numeric( $parts[1] ) &&
+			(float) $parts[1] > 0
+		) {
+			$speed = (float) $parts[0] / (float) $parts[1];
+		}
+	}
+
+	if ( ! is_numeric( $speed ) ) {
+		return '';
+	}
+
+	$speed = (float) $speed;
+	if ( $speed <= 0 ) {
+		return '';
+	}
+
+	if ( $speed >= 1 ) {
+		$rounded  = round( $speed, 1 );
+		$decimals = floor( $rounded ) === $rounded ? 0 : 1;
+		return number_format_i18n( $rounded, $decimals ) . 's';
+	}
+
+	return '1/' . (string) round( 1 / $speed ) . 's';
+}
+
+/**
+ * Returns formatted EXIF data for display in the lightbox.
+ *
+ * @since 6.9.0
+ *
+ * @param int $attachment_id Attachment ID.
+ *
+ * @return array Formatted EXIF data.
+ */
+function block_core_image_get_lightbox_exif_data( $attachment_id ) {
+	$metadata = wp_get_attachment_metadata( $attachment_id );
+	if ( empty( $metadata['image_meta'] ) || ! is_array( $metadata['image_meta'] ) ) {
+		return array();
+	}
+
+	$image_meta = $metadata['image_meta'];
+	$exif       = array();
+
+	if ( ! empty( $image_meta['camera'] ) && is_scalar( $image_meta['camera'] ) ) {
+		$exif['camera'] = trim( wp_strip_all_tags( (string) $image_meta['camera'] ) );
+	}
+
+	if (
+		! empty( $image_meta['aperture'] ) &&
+		is_numeric( $image_meta['aperture'] ) &&
+		(float) $image_meta['aperture'] > 0
+	) {
+		$exif['aperture'] = 'f/' . (string) (float) $image_meta['aperture'];
+	}
+
+	if ( ! empty( $image_meta['shutter_speed'] ) ) {
+		$shutter_speed = block_core_image_format_lightbox_exif_shutter_speed( $image_meta['shutter_speed'] );
+		if ( $shutter_speed ) {
+			$exif['shutterSpeed'] = $shutter_speed;
+		}
+	}
+
+	if (
+		! empty( $image_meta['focal_length'] ) &&
+		is_numeric( $image_meta['focal_length'] ) &&
+		(float) $image_meta['focal_length'] > 0
+	) {
+		$exif['focalLength'] = (string) (float) $image_meta['focal_length'] . 'mm';
+	}
+
+	if ( ! empty( $image_meta['copyright'] ) && is_scalar( $image_meta['copyright'] ) ) {
+		$exif['copyright'] = trim( wp_strip_all_tags( (string) $image_meta['copyright'] ) );
+	}
+
+	return array_filter( $exif, 'strlen' );
+}
+
+/**
  * Adds the directives and layout needed for the lightbox behavior.
  *
  * @since 6.4.0
@@ -199,6 +291,7 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 	$img_width        = 'none';
 	$img_height       = 'none';
 	$img_srcset       = false;
+	$img_exif         = array();
 
 	wp_interactivity_config(
 		'core/image',
@@ -223,6 +316,7 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 		$img_srcset       = wp_get_attachment_image_srcset( $block['attrs']['id'], $srcset_size );
 		$img_width        = $img_metadata['width'] ?? 'none';
 		$img_height       = $img_metadata['height'] ?? 'none';
+		$img_exif         = block_core_image_get_lightbox_exif_data( $block['attrs']['id'] );
 	}
 
 	// Figure.
@@ -247,6 +341,7 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 					'targetHeight'           => $img_height,
 					'scaleAttr'              => $block['attrs']['scale'] ?? false,
 					'alt'                    => $alt,
+					'exif'                   => $img_exif,
 					'galleryId'              => $block_instance->context['galleryId'] ?? null,
 					'customAriaLabel'        => $custom_aria_label ?? null,
 					'navigationButtonType'   => $block_instance->context['navigationButtonType'] ?? 'icon',
@@ -325,6 +420,11 @@ function block_core_image_print_lightbox_overlay() {
 	$close_button_text = esc_attr__( 'Close' );
 	$prev_button_text  = esc_attr_x( 'Previous', 'previous image in lightbox' );
 	$next_button_text  = esc_attr_x( 'Next', 'next image in lightbox' );
+	$camera_label      = esc_html__( 'Camera' );
+	$aperture_label    = esc_html__( 'Aperture' );
+	$shutter_label     = esc_html__( 'Shutter Speed' );
+	$focal_label       = esc_html__( 'Focal Length' );
+	$copyright_label   = esc_html__( 'Copyright' );
 	$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z"></path></svg>';
 	$prev_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" aria-hidden="true" focusable="false"><path d="M14.6 7l-1.2-1L8 12l5.4 6 1.2-1-4.6-5z"></path></svg>';
 	$next_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" aria-hidden="true" focusable="false"><path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"></path></svg>';
@@ -394,6 +494,30 @@ function block_core_image_print_lightbox_overlay() {
 							sizes="100vw"
 						>
 					</figure>
+				</div>
+				<div class="wp-lightbox-exif" style="color:{$close_button_color}" data-wp-bind--hidden="!state.hasExif" hidden>
+					<dl>
+						<div data-wp-bind--hidden="!state.exifCamera" hidden>
+							<dt>{$camera_label}</dt>
+							<dd data-wp-text="state.exifCamera"></dd>
+						</div>
+						<div data-wp-bind--hidden="!state.exifAperture" hidden>
+							<dt>{$aperture_label}</dt>
+							<dd data-wp-text="state.exifAperture"></dd>
+						</div>
+						<div data-wp-bind--hidden="!state.exifShutterSpeed" hidden>
+							<dt>{$shutter_label}</dt>
+							<dd data-wp-text="state.exifShutterSpeed"></dd>
+						</div>
+						<div data-wp-bind--hidden="!state.exifFocalLength" hidden>
+							<dt>{$focal_label}</dt>
+							<dd data-wp-text="state.exifFocalLength"></dd>
+						</div>
+						<div data-wp-bind--hidden="!state.exifCopyright" hidden>
+							<dt>{$copyright_label}</dt>
+							<dd data-wp-text="state.exifCopyright"></dd>
+						</div>
+					</dl>
 				</div>
 				<button type="button" style="fill:{$close_button_color}" class="wp-lightbox-navigation-button wp-lightbox-navigation-button-next" data-wp-bind--hidden="!state.hasNavigation" data-wp-on--click="actions.showNextImage" data-wp-bind--aria-label="state.nextButtonAriaLabel">
 					<span class="wp-lightbox-navigation-text" data-wp-bind--hidden="!state.hasNavigationText">{$next_button_text}</span>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -167,6 +167,23 @@ function block_core_image_get_lightbox_settings( $block ) {
 }
 
 /**
+ * Checks whether the experimental image lightbox EXIF metadata feature is enabled.
+ *
+ * The feature is currently behind a Gutenberg experiment. The experiments option
+ * is read directly so this (Core-synced) block file does not depend on the
+ * plugin-only `gutenberg_is_experiment_enabled()` helper; outside the plugin the
+ * option is absent and the feature stays disabled.
+ *
+ * @since 6.9.0
+ *
+ * @return bool True when the experiment is enabled.
+ */
+function block_core_image_is_lightbox_exif_enabled() {
+	$experiments = get_option( 'gutenberg-experiments' );
+	return is_array( $experiments ) && ! empty( $experiments['gutenberg-gallery-lightbox-default'] );
+}
+
+/**
  * Returns the EXIF metadata display settings for the block.
  *
  * Mirrors the lightbox settings resolution: a per-block `exif` attribute
@@ -351,11 +368,14 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 		$img_width        = $img_metadata['width'] ?? 'none';
 		$img_height       = $img_metadata['height'] ?? 'none';
 
-		// Only expose EXIF metadata (and therefore the toggle button) when it is
-		// enabled via the block attribute or global settings.
-		$exif_settings = block_core_image_get_exif_display_settings( $block );
-		if ( isset( $exif_settings['enabled'] ) && true === $exif_settings['enabled'] ) {
-			$img_exif = block_core_image_get_lightbox_exif_data( $block['attrs']['id'] );
+		// Only expose EXIF metadata (and therefore the toggle button) when the
+		// experiment is enabled and it is turned on via the block attribute or
+		// global settings.
+		if ( block_core_image_is_lightbox_exif_enabled() ) {
+			$exif_settings = block_core_image_get_exif_display_settings( $block );
+			if ( isset( $exif_settings['enabled'] ) && true === $exif_settings['enabled'] ) {
+				$img_exif = block_core_image_get_lightbox_exif_data( $block['attrs']['id'] );
+			}
 		}
 	}
 
@@ -460,13 +480,6 @@ function block_core_image_print_lightbox_overlay() {
 	$close_button_text = esc_attr__( 'Close' );
 	$prev_button_text  = esc_attr_x( 'Previous', 'previous image in lightbox' );
 	$next_button_text  = esc_attr_x( 'Next', 'next image in lightbox' );
-	$exif_button_label = esc_attr__( 'Toggle photo metadata visibility' );
-	$exif_region_label = esc_attr__( 'Photo metadata' );
-	$camera_label      = esc_html__( 'Camera' );
-	$aperture_label    = esc_html__( 'Aperture' );
-	$shutter_label     = esc_html__( 'Shutter Speed' );
-	$focal_label       = esc_html__( 'Focal Length' );
-	$copyright_label   = esc_html__( 'Copyright' );
 	$close_button_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z"></path></svg>';
 	$prev_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" aria-hidden="true" focusable="false"><path d="M14.6 7l-1.2-1L8 12l5.4 6 1.2-1-4.6-5z"></path></svg>';
 	$next_button_icon  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" aria-hidden="true" focusable="false"><path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"></path></svg>';
@@ -484,6 +497,62 @@ function block_core_image_print_lightbox_overlay() {
 		if ( ! empty( $global_styles_color['text'] ) ) {
 			$close_button_color = esc_attr( $global_styles_color['text'] );
 		}
+	}
+
+	// The EXIF metadata toggle and panel are only rendered while the feature is
+	// behind an experiment. When disabled, no extra markup is emitted.
+	$exif_markup = '';
+	if ( block_core_image_is_lightbox_exif_enabled() ) {
+		$exif_button_label = esc_attr__( 'Toggle photo metadata visibility' );
+		$exif_region_label = esc_attr__( 'Photo metadata' );
+		$camera_label      = esc_html__( 'Camera' );
+		$aperture_label    = esc_html__( 'Aperture' );
+		$shutter_label     = esc_html__( 'Shutter Speed' );
+		$focal_label       = esc_html__( 'Focal Length' );
+		$copyright_label   = esc_html__( 'Copyright' );
+
+		$exif_markup = <<<HTML
+				<button
+					type="button"
+					style="color:{$close_button_color}"
+					class="wp-lightbox-exif-button"
+					aria-label="{$exif_button_label}"
+					aria-controls="wp-lightbox-exif"
+					data-wp-bind--aria-expanded="state.exifExpanded"
+					data-wp-bind--hidden="!state.hasExif"
+					data-wp-class--active="state.isExifVisible"
+					data-wp-on--click="actions.toggleExif"
+					hidden
+				>
+					<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+						<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12.5 2C7.007 2 2.549 6.48 2.549 12S7.007 22 12.5 22s9.951-4.48 9.951-10S17.993 2 12.5 2ZM4.539 12c0-4.41 3.572-8 7.961-8s7.961 3.59 7.961 8-3.572 8-7.961 8-7.961-3.59-7.961-8ZM11.505 7v2h1.99V7h-1.99Zm0 4v6h1.99v-6h-1.99Z"/>
+					</svg>
+				</button>
+				<div id="wp-lightbox-exif" class="wp-lightbox-exif" style="color:{$close_button_color}" role="group" aria-label="{$exif_region_label}" data-wp-bind--hidden="!state.isExifVisible" data-wp-on--click="actions.handleExifClick" hidden>
+					<ul>
+						<li data-wp-bind--hidden="!state.exifCamera" hidden>
+							<h5>{$camera_label}</h5>
+							<span data-wp-text="state.exifCamera"></span>
+						</li>
+						<li data-wp-bind--hidden="!state.exifAperture" hidden>
+							<h5>{$aperture_label}</h5>
+							<span data-wp-text="state.exifAperture"></span>
+						</li>
+						<li data-wp-bind--hidden="!state.exifShutterSpeed" hidden>
+							<h5>{$shutter_label}</h5>
+							<span data-wp-text="state.exifShutterSpeed"></span>
+						</li>
+						<li data-wp-bind--hidden="!state.exifFocalLength" hidden>
+							<h5>{$focal_label}</h5>
+							<span data-wp-text="state.exifFocalLength"></span>
+						</li>
+						<li data-wp-bind--hidden="!state.exifCopyright" hidden>
+							<h5>{$copyright_label}</h5>
+							<span data-wp-text="state.exifCopyright"></span>
+						</li>
+					</ul>
+				</div>
+	HTML;
 	}
 
 	echo <<<HTML
@@ -538,46 +607,7 @@ function block_core_image_print_lightbox_overlay() {
 						>
 					</figure>
 				</div>
-				<button
-					type="button"
-					style="color:{$close_button_color}"
-					class="wp-lightbox-exif-button"
-					aria-label="{$exif_button_label}"
-					aria-controls="wp-lightbox-exif"
-					data-wp-bind--aria-expanded="state.exifExpanded"
-					data-wp-bind--hidden="!state.hasExif"
-					data-wp-class--active="state.isExifVisible"
-					data-wp-on--click="actions.toggleExif"
-					hidden
-				>
-					<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-						<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12.5 2C7.007 2 2.549 6.48 2.549 12S7.007 22 12.5 22s9.951-4.48 9.951-10S17.993 2 12.5 2ZM4.539 12c0-4.41 3.572-8 7.961-8s7.961 3.59 7.961 8-3.572 8-7.961 8-7.961-3.59-7.961-8ZM11.505 7v2h1.99V7h-1.99Zm0 4v6h1.99v-6h-1.99Z"/>
-					</svg>
-				</button>
-				<div id="wp-lightbox-exif" class="wp-lightbox-exif" style="color:{$close_button_color}" role="group" aria-label="{$exif_region_label}" data-wp-bind--hidden="!state.isExifVisible" data-wp-on--click="actions.handleExifClick" hidden>
-					<ul>
-						<li data-wp-bind--hidden="!state.exifCamera" hidden>
-							<h5>{$camera_label}</h5>
-							<span data-wp-text="state.exifCamera"></span>
-						</li>
-						<li data-wp-bind--hidden="!state.exifAperture" hidden>
-							<h5>{$aperture_label}</h5>
-							<span data-wp-text="state.exifAperture"></span>
-						</li>
-						<li data-wp-bind--hidden="!state.exifShutterSpeed" hidden>
-							<h5>{$shutter_label}</h5>
-							<span data-wp-text="state.exifShutterSpeed"></span>
-						</li>
-						<li data-wp-bind--hidden="!state.exifFocalLength" hidden>
-							<h5>{$focal_label}</h5>
-							<span data-wp-text="state.exifFocalLength"></span>
-						</li>
-						<li data-wp-bind--hidden="!state.exifCopyright" hidden>
-							<h5>{$copyright_label}</h5>
-							<span data-wp-text="state.exifCopyright"></span>
-						</li>
-					</ul>
-				</div>
+				{$exif_markup}
 				<button type="button" style="fill:{$close_button_color}" class="wp-lightbox-navigation-button wp-lightbox-navigation-button-next" data-wp-bind--hidden="!state.hasNavigation" data-wp-on--click="actions.showNextImage" data-wp-bind--aria-label="state.nextButtonAriaLabel">
 					<span class="wp-lightbox-navigation-text" data-wp-bind--hidden="!state.hasNavigationText">{$next_button_text}</span>
 					<span class="wp-lightbox-navigation-icon" data-wp-bind--hidden="!state.hasNavigationIcon">{$next_button_icon}</span>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -457,6 +457,7 @@ function block_core_image_print_lightbox_overlay() {
 			data-wp-bind--aria-label="state.ariaLabel"
 			data-wp-bind--aria-modal="state.ariaModal"
 			data-wp-class--active="state.overlayEnabled"
+			data-wp-class--has-visible-exif="state.isExifVisible"
 			data-wp-class--show-closing-animation="state.overlayOpened"
 			data-wp-watch---focus="callbacks.setOverlayFocus"
 			data-wp-watch---inert="callbacks.setInertElements"

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -197,10 +197,11 @@ function block_core_image_format_lightbox_exif_shutter_speed( $speed ) {
 		return '';
 	}
 
+	// Formats all numeric EXIF values with plain casting (rather than
+	// `number_format_i18n`) so the standard photographic notation is consistent
+	// across aperture, shutter speed, and focal length regardless of locale.
 	if ( $speed >= 1 ) {
-		$rounded  = round( $speed, 1 );
-		$decimals = floor( $rounded ) === $rounded ? 0 : 1;
-		return number_format_i18n( $rounded, $decimals ) . 's';
+		return (string) round( $speed, 1 ) . 's';
 	}
 
 	return '1/' . (string) round( 1 / $speed ) . 's';
@@ -421,6 +422,7 @@ function block_core_image_print_lightbox_overlay() {
 	$prev_button_text  = esc_attr_x( 'Previous', 'previous image in lightbox' );
 	$next_button_text  = esc_attr_x( 'Next', 'next image in lightbox' );
 	$exif_button_label = esc_attr__( 'Toggle photo metadata visibility' );
+	$exif_region_label = esc_attr__( 'Photo metadata' );
 	$camera_label      = esc_html__( 'Camera' );
 	$aperture_label    = esc_html__( 'Aperture' );
 	$shutter_label     = esc_html__( 'Shutter Speed' );
@@ -502,6 +504,7 @@ function block_core_image_print_lightbox_overlay() {
 					style="color:{$close_button_color}"
 					class="wp-lightbox-exif-button"
 					aria-label="{$exif_button_label}"
+					aria-controls="wp-lightbox-exif"
 					data-wp-bind--aria-expanded="state.exifExpanded"
 					data-wp-bind--hidden="!state.hasExif"
 					data-wp-class--active="state.isExifVisible"
@@ -512,7 +515,7 @@ function block_core_image_print_lightbox_overlay() {
 						<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12.5 2C7.007 2 2.549 6.48 2.549 12S7.007 22 12.5 22s9.951-4.48 9.951-10S17.993 2 12.5 2ZM4.539 12c0-4.41 3.572-8 7.961-8s7.961 3.59 7.961 8-3.572 8-7.961 8-7.961-3.59-7.961-8ZM11.505 7v2h1.99V7h-1.99Zm0 4v6h1.99v-6h-1.99Z"/>
 					</svg>
 				</button>
-				<div class="wp-lightbox-exif" style="color:{$close_button_color}" data-wp-bind--hidden="!state.isExifVisible" hidden>
+				<div id="wp-lightbox-exif" class="wp-lightbox-exif" style="color:{$close_button_color}" role="group" aria-label="{$exif_region_label}" data-wp-bind--hidden="!state.isExifVisible" hidden>
 					<ul>
 						<li data-wp-bind--hidden="!state.exifCamera" hidden>
 							<h5>{$camera_label}</h5>

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -416,15 +416,15 @@
 		overflow-x: hidden;
 		overflow-y: auto;
 
-		// Anchors the panel below the image and its toggle button, matching the
-		// image's width so the data lines up with the photo. `(100vh +
-		// container-height) / 2` is the image's bottom edge; the +72px clears the
-		// 40px toggle button (which sits 16px below the image) plus spacing.
+		// Anchors the panel below the image on the same row as the toggle button,
+		// matching the image's width so the data lines up with the photo. `(100vh
+		// + container-height) / 2` is the image's bottom edge.
 		.wp-lightbox-exif {
-			top: calc((100vh + var(--wp--lightbox-container-height)) / 2 + 72px);
+			top: calc((100vh + var(--wp--lightbox-container-height)) / 2 + 16px);
 			bottom: auto;
 			width: var(--wp--lightbox-container-width);
 			max-width: 100%;
+			padding-inline-end: 48px;
 			padding-bottom: calc(env(safe-area-inset-bottom) + 32px);
 		}
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -310,15 +310,22 @@
 	.wp-lightbox-exif-button {
 		position: absolute;
 		z-index: 3000002;
-		left: 50%;
-		bottom: calc(env(safe-area-inset-bottom) + 16px);
-		transform: translateX(-50%);
+		right: calc(env(safe-area-inset-right) + 16px);
+		// On small screens the navigation buttons sit in the bottom corners, so
+		// the toggle is stacked above the next button to avoid overlapping it.
+		bottom: calc(env(safe-area-inset-bottom) + 64px);
 		box-sizing: border-box;
 		width: 40px;
 		height: 40px;
 		padding: 4px;
 		cursor: pointer;
 		line-height: 0;
+
+		// The navigation buttons move to the vertical center, freeing the
+		// bottom-right corner for the toggle.
+		@include break-large() {
+			bottom: calc(env(safe-area-inset-bottom) + 16px);
+		}
 
 		&[hidden] {
 			display: none;
@@ -402,6 +409,48 @@
 
 		span {
 			line-height: 1.3;
+		}
+	}
+
+	// When the EXIF metadata panel is open, the image keeps its size and the
+	// panel is laid out below it. The overlay scrolls vertically instead of
+	// shrinking the image to fit both in the viewport.
+	&.has-visible-exif {
+		--wp--lightbox-exif-image-top: 80px;
+		overflow-x: hidden;
+		overflow-y: auto;
+
+		// Anchors the image toward the top so the panel can sit below it.
+		.lightbox-image-container {
+			top: var(--wp--lightbox-exif-image-top);
+			transform: translateX(-50%);
+		}
+
+		// Pins the toggle button to the viewport so the panel can be dismissed
+		// without scrolling back to it.
+		.wp-lightbox-exif-button {
+			position: fixed;
+		}
+
+		// Lays the panel out in normal flow below the image so its height
+		// contributes to the overlay's scrollable area. `relative` (rather than
+		// `static`) keeps it in flow while preserving its z-index, so it paints
+		// above the scrim instead of behind it.
+		.wp-lightbox-exif {
+			position: relative;
+			left: auto;
+			bottom: auto;
+			transform: none;
+			margin: calc(var(--wp--lightbox-exif-image-top) + var(--wp--lightbox-container-height) + 24px) auto 0;
+			padding-bottom: calc(env(safe-area-inset-bottom) + 88px);
+		}
+
+		// Pins the background to the viewport so it covers the full scroll range
+		// rather than only the first viewport height.
+		.scrim {
+			position: fixed;
+			top: 0;
+			left: 0;
 		}
 	}
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -315,7 +315,9 @@
 		transform: translateX(-50%);
 		box-sizing: border-box;
 		max-width: min(90vw, 720px);
-		font-size: 13px;
+		width: 100%;
+		font-family: "Helvetica Neue", sans-serif;
+		font-size: 12px;
 		line-height: 1.4;
 		text-align: center;
 		cursor: default;
@@ -325,29 +327,43 @@
 			display: none;
 		}
 
-		dl {
+		ul {
 			display: flex;
 			flex-wrap: wrap;
 			justify-content: center;
-			gap: 8px 16px;
 			margin: 0;
+			padding: 0;
+			list-style: none;
 		}
 
-		div {
-			display: flex;
-			gap: 4px;
+		li {
+			display: inline-block;
+			box-sizing: border-box;
+			width: 48%;
+			max-width: 160px;
+			margin: 0 1% 15px;
+			font-size: 13px;
+			line-height: 1.3;
+			vertical-align: top;
 		}
 
-		div[hidden] {
+		li[hidden] {
 			display: none;
 		}
 
-		dt {
-			font-weight: 600;
+		h5 {
+			margin: 0 0 2px;
+			font-family: "Helvetica Neue", sans-serif;
+			font-size: 10px;
+			font-weight: 400;
+			line-height: 1.3;
+			letter-spacing: 0.1em;
+			text-transform: uppercase;
+			opacity: 0.65;
 		}
 
-		dd {
-			margin: 0;
+		span {
+			line-height: 1.3;
 		}
 	}
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -310,22 +310,19 @@
 	.wp-lightbox-exif-button {
 		position: absolute;
 		z-index: 3000002;
-		right: calc(env(safe-area-inset-right) + 16px);
-		// On small screens the navigation buttons sit in the bottom corners, so
-		// the toggle is stacked above the next button to avoid overlapping it.
-		bottom: calc(env(safe-area-inset-bottom) + 64px);
+		// Sits directly below the centered image, with its right edge aligned to
+		// the image's right edge. `(100vh + container-height) / 2` is the image's
+		// bottom edge; the horizontal translate aligns the button's right edge
+		// with the image's right edge (`100%` is the button's own width).
+		top: calc((100vh + var(--wp--lightbox-container-height)) / 2 + 16px);
+		left: 50%;
+		transform: translateX(calc(var(--wp--lightbox-container-width) / 2 - 100%));
 		box-sizing: border-box;
 		width: 40px;
 		height: 40px;
 		padding: 4px;
 		cursor: pointer;
 		line-height: 0;
-
-		// The navigation buttons move to the vertical center, freeing the
-		// bottom-right corner for the toggle.
-		@include break-large() {
-			bottom: calc(env(safe-area-inset-bottom) + 16px);
-		}
 
 		&[hidden] {
 			display: none;
@@ -364,7 +361,7 @@
 		font-family: "Helvetica Neue", sans-serif;
 		font-size: 12px;
 		line-height: 1.4;
-		text-align: center;
+		text-align: left;
 		cursor: default;
 		pointer-events: none;
 
@@ -375,7 +372,7 @@
 		ul {
 			display: flex;
 			flex-wrap: wrap;
-			justify-content: center;
+			justify-content: flex-start;
 			margin: 0;
 			padding: 0;
 			list-style: none;
@@ -412,37 +409,23 @@
 		}
 	}
 
-	// When the EXIF metadata panel is open, the image keeps its size and the
-	// panel is laid out below it. The overlay scrolls vertically instead of
-	// shrinking the image to fit both in the viewport.
+	// When the EXIF metadata panel is open, the image keeps its size and stays
+	// centered; the panel is positioned just below it and the overlay scrolls
+	// vertically to reveal it. This works for any image aspect ratio.
 	&.has-visible-exif {
-		--wp--lightbox-exif-image-top: 80px;
 		overflow-x: hidden;
 		overflow-y: auto;
 
-		// Anchors the image toward the top so the panel can sit below it.
-		.lightbox-image-container {
-			top: var(--wp--lightbox-exif-image-top);
-			transform: translateX(-50%);
-		}
-
-		// Pins the toggle button to the viewport so the panel can be dismissed
-		// without scrolling back to it.
-		.wp-lightbox-exif-button {
-			position: fixed;
-		}
-
-		// Lays the panel out in normal flow below the image so its height
-		// contributes to the overlay's scrollable area. `relative` (rather than
-		// `static`) keeps it in flow while preserving its z-index, so it paints
-		// above the scrim instead of behind it.
+		// Anchors the panel below the image and its toggle button, matching the
+		// image's width so the data lines up with the photo. `(100vh +
+		// container-height) / 2` is the image's bottom edge; the +72px clears the
+		// 40px toggle button (which sits 16px below the image) plus spacing.
 		.wp-lightbox-exif {
-			position: relative;
-			left: auto;
+			top: calc((100vh + var(--wp--lightbox-container-height)) / 2 + 72px);
 			bottom: auto;
-			transform: none;
-			margin: calc(var(--wp--lightbox-exif-image-top) + var(--wp--lightbox-container-height) + 24px) auto 0;
-			padding-bottom: calc(env(safe-area-inset-bottom) + 88px);
+			width: var(--wp--lightbox-container-width);
+			max-width: 100%;
+			padding-bottom: calc(env(safe-area-inset-bottom) + 32px);
 		}
 
 		// Pins the background to the viewport so it covers the full scroll range

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -363,7 +363,6 @@
 		line-height: 1.4;
 		text-align: left;
 		cursor: default;
-		pointer-events: none;
 
 		&[hidden] {
 			display: none;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -307,6 +307,50 @@
 		z-index: 2000001;
 	}
 
+	.wp-lightbox-exif {
+		position: absolute;
+		z-index: 3000001;
+		left: 50%;
+		bottom: calc(env(safe-area-inset-bottom) + 24px);
+		transform: translateX(-50%);
+		box-sizing: border-box;
+		max-width: min(90vw, 720px);
+		font-size: 13px;
+		line-height: 1.4;
+		text-align: center;
+		cursor: default;
+		pointer-events: none;
+
+		&[hidden] {
+			display: none;
+		}
+
+		dl {
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: center;
+			gap: 8px 16px;
+			margin: 0;
+		}
+
+		div {
+			display: flex;
+			gap: 4px;
+		}
+
+		div[hidden] {
+			display: none;
+		}
+
+		dt {
+			font-weight: 600;
+		}
+
+		dd {
+			margin: 0;
+		}
+	}
+
 	.wp-block-image {
 		position: relative;
 		transform-origin: 0 0;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -307,11 +307,49 @@
 		z-index: 2000001;
 	}
 
+	.wp-lightbox-exif-button {
+		position: absolute;
+		z-index: 3000002;
+		left: 50%;
+		bottom: calc(env(safe-area-inset-bottom) + 16px);
+		transform: translateX(-50%);
+		box-sizing: border-box;
+		width: 40px;
+		height: 40px;
+		padding: 4px;
+		cursor: pointer;
+		line-height: 0;
+
+		&[hidden] {
+			display: none;
+		}
+
+		&:hover,
+		&:focus,
+		&.active,
+		&:not(:hover):not(:active):not(.has-background) {
+			background: none;
+			border: none;
+		}
+
+		&:focus-visible {
+			outline: 3px auto currentColor;
+			outline-offset: 3px;
+		}
+
+		svg {
+			display: block;
+			width: 25px;
+			height: 24px;
+			margin: auto;
+		}
+	}
+
 	.wp-lightbox-exif {
 		position: absolute;
 		z-index: 3000001;
 		left: 50%;
-		bottom: calc(env(safe-area-inset-bottom) + 24px);
+		bottom: calc(env(safe-area-inset-bottom) + 72px);
 		transform: translateX(-50%);
 		box-sizing: border-box;
 		max-width: min(90vw, 720px);

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -306,6 +306,11 @@ const { state, actions, callbacks } = store(
 					)
 				);
 			} ),
+			// Keeps clicks (and text selection) within the metadata panel from
+			// bubbling to the overlay, which would otherwise close the lightbox.
+			handleExifClick: withSyncEvent( ( event ) => {
+				event.stopPropagation();
+			} ),
 			showPreviousImage: withSyncEvent( ( event ) => {
 				event.stopPropagation();
 				const nextIndex = state.hasPreviousImage

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -280,8 +280,31 @@ const { state, actions, callbacks } = store(
 			toggleExif: withSyncEvent( ( event ) => {
 				event.preventDefault();
 				event.stopPropagation();
-				state.exifVisible = ! state.exifVisible;
-				callbacks.setOverlayStyles();
+
+				// Closing: scroll back to the top before hiding the panel so the
+				// overlay returns to its non-scrolling state cleanly.
+				if ( state.isExifVisible ) {
+					const overlay =
+						document.querySelector( '.wp-lightbox-overlay' );
+					callbacks.scrollOverlayTo(
+						overlay,
+						withScope( () => {
+							state.exifVisible = false;
+						} )
+					);
+					return;
+				}
+
+				// Opening: reveal the panel, then smoothly scroll it into view on
+				// the next frame, once it has rendered below the image.
+				state.exifVisible = true;
+				window.requestAnimationFrame(
+					withScope( () =>
+						callbacks.scrollOverlayTo(
+							document.querySelector( '.wp-lightbox-exif' )
+						)
+					)
+				);
 			} ),
 			showPreviousImage: withSyncEvent( ( event ) => {
 				event.stopPropagation();
@@ -465,6 +488,78 @@ const { state, actions, callbacks } = store(
 			},
 		},
 		callbacks: {
+			// Smoothly scrolls the overlay so `target` is brought into view.
+			// Passing the overlay itself scrolls back to the top.
+			scrollOverlayTo( target, onComplete ) {
+				const overlay =
+					document.querySelector( '.wp-lightbox-overlay' );
+				if ( ! overlay || ! target ) {
+					onComplete?.();
+					return;
+				}
+
+				const targetPosition = Math.min(
+					Math.max(
+						0,
+						target.offsetTop -
+							Math.max(
+								0,
+								window.innerHeight -
+									target.getBoundingClientRect().height -
+									32
+							)
+					),
+					overlay.scrollHeight - overlay.clientHeight
+				);
+
+				// Honors the user's reduced-motion preference by jumping straight
+				// to the target instead of animating, matching how the rest of the
+				// lightbox guards its motion.
+				if (
+					window.matchMedia( '(prefers-reduced-motion: reduce)' )
+						.matches
+				) {
+					overlay.scrollTop = targetPosition;
+					onComplete?.();
+					return;
+				}
+
+				const startTime = Date.now();
+				const duration = 300;
+				const originalPosition = overlay.scrollTop;
+				const distance = targetPosition - originalPosition;
+				let isScrolling = true;
+
+				function stopScroll() {
+					isScrolling = false;
+				}
+
+				function runScroll() {
+					const now = Date.now();
+					const progress = Math.min(
+						( now - startTime ) / duration,
+						1
+					);
+					const easedProgress =
+						progress < 0.5
+							? 2 * progress * progress
+							: 1 - Math.pow( -2 * progress + 2, 2 ) / 2;
+
+					overlay.scrollTop =
+						originalPosition + easedProgress * distance;
+
+					if ( progress < 1 && isScrolling ) {
+						window.requestAnimationFrame( runScroll );
+						return;
+					}
+
+					overlay.removeEventListener( 'wheel', stopScroll );
+					onComplete?.();
+				}
+
+				overlay.addEventListener( 'wheel', stopScroll );
+				runScroll();
+			},
 			setOverlayStyles() {
 				if ( ! state.overlayEnabled ) {
 					return;

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -164,6 +164,27 @@ const { state, actions, callbacks } = store(
 			get enlargedSrcset() {
 				return getImageSrcset( state.selectedImage );
 			},
+			get selectedImageExif() {
+				return state.selectedImage?.exif || {};
+			},
+			get hasExif() {
+				return Object.values( state.selectedImageExif ).some( Boolean );
+			},
+			get exifCamera() {
+				return state.selectedImageExif.camera;
+			},
+			get exifAperture() {
+				return state.selectedImageExif.aperture;
+			},
+			get exifShutterSpeed() {
+				return state.selectedImageExif.shutterSpeed;
+			},
+			get exifFocalLength() {
+				return state.selectedImageExif.focalLength;
+			},
+			get exifCopyright() {
+				return state.selectedImageExif.copyright;
+			},
 			get figureStyles() {
 				return (
 					state.overlayOpened &&
@@ -548,6 +569,9 @@ const { state, actions, callbacks } = store(
 				if ( 960 < window.innerWidth ) {
 					horizontalPadding = state.hasNavigation ? 320 : 80;
 					verticalPadding = 80;
+				}
+				if ( state.hasExif ) {
+					verticalPadding = Math.max( verticalPadding, 160 );
 				}
 
 				const targetMaxWidth = Math.min(

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -284,8 +284,9 @@ const { state, actions, callbacks } = store(
 				// Closing: scroll back to the top before hiding the panel so the
 				// overlay returns to its non-scrolling state cleanly.
 				if ( state.isExifVisible ) {
-					const overlay =
-						document.querySelector( '.wp-lightbox-overlay' );
+					const overlay = document.querySelector(
+						'.wp-lightbox-overlay'
+					);
 					callbacks.scrollOverlayTo(
 						overlay,
 						withScope( () => {
@@ -496,8 +497,9 @@ const { state, actions, callbacks } = store(
 			// Smoothly scrolls the overlay so `target` is brought into view.
 			// Passing the overlay itself scrolls back to the top.
 			scrollOverlayTo( target, onComplete ) {
-				const overlay =
-					document.querySelector( '.wp-lightbox-overlay' );
+				const overlay = document.querySelector(
+					'.wp-lightbox-overlay'
+				);
 				if ( ! overlay || ! target ) {
 					onComplete?.();
 					return;

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -38,8 +38,9 @@ const touchStartEvent = {
 };
 
 const focusableSelectors = [
-	'.wp-lightbox-close-button',
-	'.wp-lightbox-navigation-button',
+	'.wp-lightbox-close-button:not([hidden])',
+	'.wp-lightbox-navigation-button:not([hidden])',
+	'.wp-lightbox-exif-button:not([hidden])',
 ];
 
 /**
@@ -71,6 +72,7 @@ const { state, actions, callbacks } = store(
 		state: {
 			selectedImageId: null,
 			selectedGalleryId: null,
+			exifVisible: false,
 			preloadTimers: new Map(),
 			preloadedImageIds: new Set(),
 			get galleryImages() {
@@ -170,6 +172,12 @@ const { state, actions, callbacks } = store(
 			get hasExif() {
 				return Object.values( state.selectedImageExif ).some( Boolean );
 			},
+			get isExifVisible() {
+				return state.hasExif && state.exifVisible;
+			},
+			get exifExpanded() {
+				return state.isExifVisible ? 'true' : 'false';
+			},
 			get exifCamera() {
 				return state.selectedImageExif.camera;
 			},
@@ -236,6 +244,7 @@ const { state, actions, callbacks } = store(
 				state.selectedImageId = imageId;
 				const { galleryId } = getContext( 'core/gallery' ) || {};
 				state.selectedGalleryId = galleryId || null;
+				state.exifVisible = false;
 				state.overlayEnabled = true;
 
 				// Computes the styles of the overlay for the animation.
@@ -261,15 +270,23 @@ const { state, actions, callbacks } = store(
 						// Resets the selected image and gallery ids.
 						state.selectedImageId = null;
 						state.selectedGalleryId = null;
+						state.exifVisible = false;
 					}, 450 );
 				}
 			},
+			toggleExif: withSyncEvent( ( event ) => {
+				event.preventDefault();
+				event.stopPropagation();
+				state.exifVisible = ! state.exifVisible;
+				callbacks.setOverlayStyles();
+			} ),
 			showPreviousImage: withSyncEvent( ( event ) => {
 				event.stopPropagation();
 				const nextIndex = state.hasPreviousImage
 					? state.selectedImageIndex - 1
 					: state.galleryImages.length - 1;
 				state.selectedImageId = state.galleryImages[ nextIndex ];
+				state.exifVisible = false;
 				callbacks.setOverlayStyles();
 			} ),
 			showNextImage: withSyncEvent( ( event ) => {
@@ -278,6 +295,7 @@ const { state, actions, callbacks } = store(
 					? state.selectedImageIndex + 1
 					: 0;
 				state.selectedImageId = state.galleryImages[ nextIndex ];
+				state.exifVisible = false;
 				callbacks.setOverlayStyles();
 			} ),
 			handleKeydown: withSyncEvent( ( event ) => {
@@ -570,8 +588,8 @@ const { state, actions, callbacks } = store(
 					horizontalPadding = state.hasNavigation ? 320 : 80;
 					verticalPadding = 80;
 				}
-				if ( state.hasExif ) {
-					verticalPadding = Math.max( verticalPadding, 160 );
+				if ( state.isExifVisible ) {
+					verticalPadding = Math.max( verticalPadding, 220 );
 				}
 
 				const targetMaxWidth = Math.min(

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -253,6 +253,9 @@ const { state, actions, callbacks } = store(
 			hideLightbox() {
 				if ( state.overlayEnabled ) {
 					state.overlayEnabled = false;
+					// Re-centers the image before the closing animation runs so it
+					// zooms out from the center rather than its scrolled position.
+					state.exifVisible = false;
 
 					// Waits until the close animation has completed before allowing a
 					// user to scroll again. The duration of this animation is defined in
@@ -337,7 +340,10 @@ const { state, actions, callbacks } = store(
 				// perform a simple tap. This may be changed in the future if there is a
 				// better alternative to override or reset the scroll position during
 				// swipe actions.
-				if ( state.overlayEnabled ) {
+				//
+				// When the EXIF metadata panel is open the overlay scrolls
+				// vertically, so scrolling is allowed in that case.
+				if ( state.overlayEnabled && ! state.isExifVisible ) {
 					event.preventDefault();
 				}
 			} ),
@@ -587,9 +593,6 @@ const { state, actions, callbacks } = store(
 				if ( 960 < window.innerWidth ) {
 					horizontalPadding = state.hasNavigation ? 320 : 80;
 					verticalPadding = 80;
-				}
-				if ( state.isExifVisible ) {
-					verticalPadding = Math.max( verticalPadding, 220 );
 				}
 
 				const targetMaxWidth = Math.min(

--- a/packages/e2e-tests/plugins/lightbox-exif-metadata.php
+++ b/packages/e2e-tests/plugins/lightbox-exif-metadata.php
@@ -31,3 +31,21 @@ function gutenberg_test_lightbox_exif_metadata( $data ) {
 	return $data;
 }
 add_filter( 'wp_get_attachment_metadata', 'gutenberg_test_lightbox_exif_metadata' );
+
+/**
+ * Enables the EXIF lightbox experiment while this test plugin is active, so the
+ * feature (which is otherwise behind a flag) is rendered on the front end and
+ * exposed in the editor.
+ *
+ * @param mixed $experiments The stored experiments option value.
+ * @return array Experiments with the EXIF lightbox flag enabled.
+ */
+function gutenberg_test_enable_lightbox_exif_experiment( $experiments ) {
+	if ( ! is_array( $experiments ) ) {
+		$experiments = array();
+	}
+	$experiments['gutenberg-gallery-lightbox-default'] = 1;
+	return $experiments;
+}
+add_filter( 'option_gutenberg-experiments', 'gutenberg_test_enable_lightbox_exif_experiment' );
+add_filter( 'default_option_gutenberg-experiments', 'gutenberg_test_enable_lightbox_exif_experiment' );

--- a/packages/e2e-tests/plugins/lightbox-exif-metadata.php
+++ b/packages/e2e-tests/plugins/lightbox-exif-metadata.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Plugin Name: Lightbox EXIF Metadata
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-lightbox-exif-metadata
+ */
+
+/**
+ * Injects predictable EXIF metadata into attachment metadata so the image
+ * lightbox's metadata panel can be exercised on the front end, without
+ * depending on a binary fixture that carries real EXIF data.
+ *
+ * @param array|false $data Attachment metadata, or false if none.
+ * @return array|false Filtered metadata.
+ */
+function gutenberg_test_lightbox_exif_metadata( $data ) {
+	if ( ! is_array( $data ) ) {
+		return $data;
+	}
+
+	$data['image_meta'] = array(
+		'camera'        => 'Test Camera',
+		'aperture'      => '2.8',
+		'shutter_speed' => '0.004',
+		'focal_length'  => '23',
+		'copyright'     => 'Test Photographer',
+	);
+
+	return $data;
+}
+add_filter( 'wp_get_attachment_metadata', 'gutenberg_test_lightbox_exif_metadata' );

--- a/phpunit/blocks/render-block-image-test.php
+++ b/phpunit/blocks/render-block-image-test.php
@@ -207,11 +207,15 @@ class Tests_Blocks_Render_Image extends WP_UnitTestCase {
 					'lightbox'        => array(
 						'enabled' => true,
 					),
+					// EXIF display is opt-in, so it must be enabled explicitly.
+					'exif'            => array(
+						'enabled' => true,
+					),
 					'linkDestination' => 'none',
 				),
 			);
-			$block        = new WP_Block( $parsed_block );
-			$content      = sprintf(
+			$block   = new WP_Block( $parsed_block );
+			$content = sprintf(
 				'<figure class="wp-block-image"><img class="wp-image-%d" src="%s" alt="A camera"/></figure>',
 				$attachment_id,
 				esc_url( wp_get_attachment_url( $attachment_id ) )
@@ -235,6 +239,64 @@ class Tests_Blocks_Render_Image extends WP_UnitTestCase {
 				),
 				$state['metadata'][ $matches[1] ]['exif']
 			);
+		} finally {
+			wp_delete_attachment( $attachment_id, true );
+		}
+	}
+
+	public function test_should_not_add_exif_data_to_lightbox_state_when_not_enabled() {
+		$file          = DIR_TESTDATA . '/images/canola.jpg';
+		$attachment_id = self::factory()->attachment->create_upload_object(
+			$file,
+			0,
+			array(
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		try {
+			wp_update_attachment_metadata(
+				$attachment_id,
+				array(
+					'width'      => 1024,
+					'height'     => 768,
+					'image_meta' => array(
+						'camera'        => 'Nikon D70',
+						'aperture'      => '2.8',
+						'shutter_speed' => '0.004',
+						'focal_length'  => '50',
+					),
+				)
+			);
+
+			// The lightbox is enabled, but EXIF display is not, so no metadata
+			// should be exposed (and therefore no toggle on the front end).
+			$parsed_block = array(
+				'blockName' => 'core/image',
+				'attrs'     => array(
+					'id'              => $attachment_id,
+					'lightbox'        => array(
+						'enabled' => true,
+					),
+					'linkDestination' => 'none',
+				),
+			);
+			$block        = new WP_Block( $parsed_block );
+			$content      = sprintf(
+				'<figure class="wp-block-image"><img class="wp-image-%d" src="%s" alt="A camera"/></figure>',
+				$attachment_id,
+				esc_url( wp_get_attachment_url( $attachment_id ) )
+			);
+
+			$render_lightbox = function_exists( 'gutenberg_block_core_image_render_lightbox' )
+				? 'gutenberg_block_core_image_render_lightbox'
+				: 'block_core_image_render_lightbox';
+
+			$rendered_block = $render_lightbox( $content, $parsed_block, $block );
+			$this->assertSame( 1, preg_match( '/data-wp-key="([^"]+)"/', $rendered_block, $matches ) );
+
+			$state = wp_interactivity_state( 'core/image' );
+			$this->assertSame( array(), $state['metadata'][ $matches[1] ]['exif'] );
 		} finally {
 			wp_delete_attachment( $attachment_id, true );
 		}

--- a/phpunit/blocks/render-block-image-test.php
+++ b/phpunit/blocks/render-block-image-test.php
@@ -147,7 +147,8 @@ class Tests_Blocks_Render_Image extends WP_UnitTestCase {
 						'camera'        => 'Nikon D70',
 						'aperture'      => '2.80',
 						'shutter_speed' => '0.004',
-						'focal_length'  => '50.0',
+						// A long fractional focal length is rounded to one decimal.
+						'focal_length'  => '57.019002375297',
 						'copyright'     => 'Example Photographer',
 						'keywords'      => array( 'ignored' ),
 					),
@@ -164,7 +165,7 @@ class Tests_Blocks_Render_Image extends WP_UnitTestCase {
 					'camera'       => 'Nikon D70',
 					'aperture'     => 'f/2.8',
 					'shutterSpeed' => '1/250s',
-					'focalLength'  => '50mm',
+					'focalLength'  => '57mm',
 					'copyright'    => 'Example Photographer',
 				),
 				$get_exif( $attachment_id )

--- a/phpunit/blocks/render-block-image-test.php
+++ b/phpunit/blocks/render-block-image-test.php
@@ -176,6 +176,9 @@ class Tests_Blocks_Render_Image extends WP_UnitTestCase {
 	}
 
 	public function test_should_add_exif_data_to_lightbox_interactivity_state() {
+		// The feature is behind an experiment, so enable it for this test.
+		update_option( 'gutenberg-experiments', array( 'gutenberg-gallery-lightbox-default' => 1 ) );
+
 		$file          = DIR_TESTDATA . '/images/canola.jpg';
 		$attachment_id = self::factory()->attachment->create_upload_object(
 			$file,
@@ -244,7 +247,74 @@ class Tests_Blocks_Render_Image extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_should_not_add_exif_data_to_lightbox_state_when_experiment_disabled() {
+		// The experiment is off, so EXIF data must not be exposed even though
+		// the lightbox and the EXIF setting are both enabled on the block.
+		update_option( 'gutenberg-experiments', array() );
+
+		$file          = DIR_TESTDATA . '/images/canola.jpg';
+		$attachment_id = self::factory()->attachment->create_upload_object(
+			$file,
+			0,
+			array(
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		try {
+			wp_update_attachment_metadata(
+				$attachment_id,
+				array(
+					'width'      => 1024,
+					'height'     => 768,
+					'image_meta' => array(
+						'camera'        => 'Nikon D70',
+						'aperture'      => '2.8',
+						'shutter_speed' => '0.004',
+						'focal_length'  => '50',
+					),
+				)
+			);
+
+			$parsed_block = array(
+				'blockName' => 'core/image',
+				'attrs'     => array(
+					'id'              => $attachment_id,
+					'lightbox'        => array(
+						'enabled' => true,
+					),
+					'exif'            => array(
+						'enabled' => true,
+					),
+					'linkDestination' => 'none',
+				),
+			);
+			$block        = new WP_Block( $parsed_block );
+			$content      = sprintf(
+				'<figure class="wp-block-image"><img class="wp-image-%d" src="%s" alt="A camera"/></figure>',
+				$attachment_id,
+				esc_url( wp_get_attachment_url( $attachment_id ) )
+			);
+
+			$render_lightbox = function_exists( 'gutenberg_block_core_image_render_lightbox' )
+				? 'gutenberg_block_core_image_render_lightbox'
+				: 'block_core_image_render_lightbox';
+
+			$rendered_block = $render_lightbox( $content, $parsed_block, $block );
+			$this->assertSame( 1, preg_match( '/data-wp-key="([^"]+)"/', $rendered_block, $matches ) );
+
+			$state = wp_interactivity_state( 'core/image' );
+			$this->assertSame( array(), $state['metadata'][ $matches[1] ]['exif'] );
+		} finally {
+			wp_delete_attachment( $attachment_id, true );
+		}
+	}
+
 	public function test_should_not_add_exif_data_to_lightbox_state_when_not_enabled() {
+		// Enable the experiment so this verifies the opt-in setting gate rather
+		// than the experiment gate.
+		update_option( 'gutenberg-experiments', array( 'gutenberg-gallery-lightbox-default' => 1 ) );
+
 		$file          = DIR_TESTDATA . '/images/canola.jpg';
 		$attachment_id = self::factory()->attachment->create_upload_object(
 			$file,

--- a/phpunit/blocks/render-block-image-test.php
+++ b/phpunit/blocks/render-block-image-test.php
@@ -126,4 +126,116 @@ class Tests_Blocks_Render_Image extends WP_UnitTestCase {
 		$rendered_block = gutenberg_render_block_core_image( $attributes, $content, $block );
 		$this->assertSame( '<figure class="wp-block-image"><img src="canola.jpg"/></figure>', $rendered_block );
 	}
+
+	public function test_should_format_lightbox_exif_data_from_attachment_metadata() {
+		$file          = DIR_TESTDATA . '/images/canola.jpg';
+		$attachment_id = self::factory()->attachment->create_upload_object(
+			$file,
+			0,
+			array(
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		try {
+			wp_update_attachment_metadata(
+				$attachment_id,
+				array(
+					'width'      => 1024,
+					'height'     => 768,
+					'image_meta' => array(
+						'camera'        => 'Nikon D70',
+						'aperture'      => '2.80',
+						'shutter_speed' => '0.004',
+						'focal_length'  => '50.0',
+						'copyright'     => 'Example Photographer',
+						'keywords'      => array( 'ignored' ),
+					),
+				)
+			);
+
+			$get_exif = function_exists( 'gutenberg_block_core_image_get_lightbox_exif_data' )
+				? 'gutenberg_block_core_image_get_lightbox_exif_data'
+				: 'block_core_image_get_lightbox_exif_data';
+
+			$this->assertTrue( function_exists( $get_exif ) );
+			$this->assertSame(
+				array(
+					'camera'       => 'Nikon D70',
+					'aperture'     => 'f/2.8',
+					'shutterSpeed' => '1/250s',
+					'focalLength'  => '50mm',
+					'copyright'    => 'Example Photographer',
+				),
+				$get_exif( $attachment_id )
+			);
+		} finally {
+			wp_delete_attachment( $attachment_id, true );
+		}
+	}
+
+	public function test_should_add_exif_data_to_lightbox_interactivity_state() {
+		$file          = DIR_TESTDATA . '/images/canola.jpg';
+		$attachment_id = self::factory()->attachment->create_upload_object(
+			$file,
+			0,
+			array(
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		try {
+			wp_update_attachment_metadata(
+				$attachment_id,
+				array(
+					'width'      => 1024,
+					'height'     => 768,
+					'image_meta' => array(
+						'camera'        => 'Nikon D70',
+						'aperture'      => '2.8',
+						'shutter_speed' => '0.004',
+						'focal_length'  => '50',
+					),
+				)
+			);
+
+			$parsed_block = array(
+				'blockName' => 'core/image',
+				'attrs'     => array(
+					'id'              => $attachment_id,
+					'lightbox'        => array(
+						'enabled' => true,
+					),
+					'linkDestination' => 'none',
+				),
+			);
+			$block        = new WP_Block( $parsed_block );
+			$content      = sprintf(
+				'<figure class="wp-block-image"><img class="wp-image-%d" src="%s" alt="A camera"/></figure>',
+				$attachment_id,
+				esc_url( wp_get_attachment_url( $attachment_id ) )
+			);
+
+			$render_lightbox = function_exists( 'gutenberg_block_core_image_render_lightbox' )
+				? 'gutenberg_block_core_image_render_lightbox'
+				: 'block_core_image_render_lightbox';
+
+			$this->assertTrue( function_exists( $render_lightbox ) );
+			$rendered_block = $render_lightbox( $content, $parsed_block, $block );
+			$this->assertSame( 1, preg_match( '/data-wp-key="([^"]+)"/', $rendered_block, $matches ) );
+
+			$state = wp_interactivity_state( 'core/image' );
+			$this->assertSame(
+				array(
+					'camera'       => 'Nikon D70',
+					'aperture'     => 'f/2.8',
+					'shutterSpeed' => '1/250s',
+					'focalLength'  => '50mm',
+				),
+				$state['metadata'][ $matches[1] ]['exif']
+			);
+		} finally {
+			wp_delete_attachment( $attachment_id, true );
+		}
+	}
 }

--- a/phpunit/blocks/render-block-image-test.php
+++ b/phpunit/blocks/render-block-image-test.php
@@ -12,12 +12,41 @@
  * @group blocks
  */
 class Tests_Blocks_Render_Image extends WP_UnitTestCase {
+	/**
+	 * Holds the `pre_option_gutenberg-experiments` override callback, if set.
+	 *
+	 * @var callable|null
+	 */
+	private $experiments_filter = null;
+
 	public function tear_down() {
+		if ( null !== $this->experiments_filter ) {
+			remove_filter( 'pre_option_gutenberg-experiments', $this->experiments_filter );
+			$this->experiments_filter = null;
+		}
+
 		if ( get_block_bindings_source( 'test/source' ) ) {
 			unregister_block_bindings_source( 'test/source' );
 		}
 
 		parent::tear_down();
+	}
+
+	/**
+	 * Overrides the `gutenberg-experiments` option for the current test.
+	 *
+	 * The PHPUnit bootstrap registers a `pre_option_gutenberg-experiments`
+	 * filter (via `$GLOBALS['wp_tests_options']`) that short-circuits
+	 * `get_option()`, so `update_option()` has no effect. This adds a
+	 * later-running filter that returns the desired value instead.
+	 *
+	 * @param array $experiments Experiments option value.
+	 */
+	private function set_gutenberg_experiments( $experiments ) {
+		$this->experiments_filter = static function () use ( $experiments ) {
+			return $experiments;
+		};
+		add_filter( 'pre_option_gutenberg-experiments', $this->experiments_filter );
 	}
 
 	/**
@@ -177,7 +206,7 @@ class Tests_Blocks_Render_Image extends WP_UnitTestCase {
 
 	public function test_should_add_exif_data_to_lightbox_interactivity_state() {
 		// The feature is behind an experiment, so enable it for this test.
-		update_option( 'gutenberg-experiments', array( 'gutenberg-gallery-lightbox-default' => 1 ) );
+		$this->set_gutenberg_experiments( array( 'gutenberg-gallery-lightbox-default' => 1 ) );
 
 		$file          = DIR_TESTDATA . '/images/canola.jpg';
 		$attachment_id = self::factory()->attachment->create_upload_object(
@@ -250,7 +279,7 @@ class Tests_Blocks_Render_Image extends WP_UnitTestCase {
 	public function test_should_not_add_exif_data_to_lightbox_state_when_experiment_disabled() {
 		// The experiment is off, so EXIF data must not be exposed even though
 		// the lightbox and the EXIF setting are both enabled on the block.
-		update_option( 'gutenberg-experiments', array() );
+		$this->set_gutenberg_experiments( array() );
 
 		$file          = DIR_TESTDATA . '/images/canola.jpg';
 		$attachment_id = self::factory()->attachment->create_upload_object(
@@ -313,7 +342,7 @@ class Tests_Blocks_Render_Image extends WP_UnitTestCase {
 	public function test_should_not_add_exif_data_to_lightbox_state_when_not_enabled() {
 		// Enable the experiment so this verifies the opt-in setting gate rather
 		// than the experiment gate.
-		update_option( 'gutenberg-experiments', array( 'gutenberg-gallery-lightbox-default' => 1 ) );
+		$this->set_gutenberg_experiments( array( 'gutenberg-gallery-lightbox-default' => 1 ) );
 
 		$file          = DIR_TESTDATA . '/images/canola.jpg';
 		$attachment_id = self::factory()->attachment->create_upload_object(

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -388,6 +388,26 @@
 				}
 			}
 		},
+		"settingsExifProperties": {
+			"type": "object",
+			"properties": {
+				"exif": {
+					"description": "Settings related to displaying EXIF metadata in the image lightbox.",
+					"type": "object",
+					"properties": {
+						"enabled": {
+							"description": "Defines whether EXIF metadata is shown in the lightbox.",
+							"type": "boolean"
+						},
+						"allowEditing": {
+							"description": "Defines whether to show the EXIF metadata UI in the block editor. If set to `false`, the user won't be able to change the EXIF setting in the block editor.",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
 		"settingsPositionProperties": {
 			"type": "object",
 			"properties": {
@@ -876,6 +896,7 @@
 				{ "$ref": "#/definitions/settingsDimensionsProperties" },
 				{ "$ref": "#/definitions/settingsLayoutProperties" },
 				{ "$ref": "#/definitions/settingsLightboxProperties" },
+				{ "$ref": "#/definitions/settingsExifProperties" },
 				{ "$ref": "#/definitions/settingsPositionProperties" },
 				{ "$ref": "#/definitions/settingsShadowProperties" },
 				{ "$ref": "#/definitions/settingsSpacingProperties" },
@@ -890,6 +911,7 @@
 				"border",
 				"color",
 				"dimensions",
+				"exif",
 				"layout",
 				"lightbox",
 				"position",

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -998,10 +998,14 @@ test.describe( 'Image - lightbox', () => {
 			await expect( panel ).toContainText( '23mm' );
 			await expect( panel ).toContainText( 'Test Photographer' );
 
-			// Clicking within the panel must not close the lightbox, so the
-			// metadata stays readable (and selectable). The first item is used
-			// because it sits clear of the toggle button in the top corner.
-			await panel.getByText( 'Test Camera' ).click();
+			// Clicking within the panel must not close the lightbox; the panel
+			// stops click propagation so the metadata stays readable and
+			// selectable. A dispatched click is used instead of a pointer click
+			// because the toggle button overlaps the panel in some viewport
+			// sizes, which would block a real click. The bubbling click still
+			// reaches the overlay's close handler unless propagation is stopped,
+			// so this verifies that behavior.
+			await panel.getByText( 'Test Camera' ).dispatchEvent( 'click' );
 			await expect( panel ).toBeVisible();
 			await expect( toggle ).toHaveAttribute( 'aria-expanded', 'true' );
 

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -967,11 +967,11 @@ test.describe( 'Image - lightbox', () => {
 			await requestUtils.deactivatePlugin( 'lightbox-exif-metadata' );
 		} );
 
-		test( 'toggle reveals the photo metadata in the lightbox', async ( {
+		test( 'toggle reveals the photo metadata in the lightbox when enabled', async ( {
 			editor,
 			page,
 		} ) => {
-			await editor.setContent( `<!-- wp:image {"id":${ uploadedMedia.id },"sizeSlug":"full","linkDestination":"none","lightbox":{"enabled":true}} -->
+			await editor.setContent( `<!-- wp:image {"id":${ uploadedMedia.id },"sizeSlug":"full","linkDestination":"none","lightbox":{"enabled":true},"exif":{"enabled":true}} -->
 			<figure class="wp-block-image size-full"><img src="${ uploadedMedia.source_url }" alt="" class="wp-image-${ uploadedMedia.id }"/></figure>
 			<!-- /wp:image -->` );
 
@@ -1002,6 +1002,29 @@ test.describe( 'Image - lightbox', () => {
 			await toggle.click();
 			await expect( toggle ).toHaveAttribute( 'aria-expanded', 'false' );
 			await expect( panel ).toBeHidden();
+		} );
+
+		test( 'no metadata toggle appears when the option is off', async ( {
+			editor,
+			page,
+		} ) => {
+			// The image has EXIF metadata, but the display option is not enabled.
+			await editor.setContent( `<!-- wp:image {"id":${ uploadedMedia.id },"sizeSlug":"full","linkDestination":"none","lightbox":{"enabled":true}} -->
+			<figure class="wp-block-image size-full"><img src="${ uploadedMedia.source_url }" alt="" class="wp-image-${ uploadedMedia.id }"/></figure>
+			<!-- /wp:image -->` );
+
+			const postId = await editor.publishPost();
+			await page.goto( `/?p=${ postId }` );
+
+			await page.locator( '.wp-lightbox-container img' ).click();
+
+			// The lightbox opens, but the metadata toggle stays hidden.
+			await expect(
+				page.locator( '.wp-lightbox-overlay .wp-block-image' ).first()
+			).toBeVisible();
+			await expect(
+				page.locator( '.wp-lightbox-exif-button' )
+			).toBeHidden();
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -998,6 +998,12 @@ test.describe( 'Image - lightbox', () => {
 			await expect( panel ).toContainText( '23mm' );
 			await expect( panel ).toContainText( 'Test Photographer' );
 
+			// Clicking within the panel must not close the lightbox, so the
+			// metadata stays readable (and selectable).
+			await panel.getByText( 'Test Photographer' ).click();
+			await expect( panel ).toBeVisible();
+			await expect( toggle ).toHaveAttribute( 'aria-expanded', 'true' );
+
 			// Toggling again collapses the panel.
 			await toggle.click();
 			await expect( toggle ).toHaveAttribute( 'aria-expanded', 'false' );

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -957,6 +957,53 @@ test.describe( 'Image - lightbox', () => {
 			expect( margin ).toBe( '0px' );
 		} );
 	} );
+
+	test.describe( 'EXIF metadata', () => {
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activatePlugin( 'lightbox-exif-metadata' );
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deactivatePlugin( 'lightbox-exif-metadata' );
+		} );
+
+		test( 'toggle reveals the photo metadata in the lightbox', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.setContent( `<!-- wp:image {"id":${ uploadedMedia.id },"sizeSlug":"full","linkDestination":"none","lightbox":{"enabled":true}} -->
+			<figure class="wp-block-image size-full"><img src="${ uploadedMedia.source_url }" alt="" class="wp-image-${ uploadedMedia.id }"/></figure>
+			<!-- /wp:image -->` );
+
+			const postId = await editor.publishPost();
+			await page.goto( `/?p=${ postId }` );
+
+			await page.locator( '.wp-lightbox-container img' ).click();
+
+			const toggle = page.locator( '.wp-lightbox-exif-button' );
+			const panel = page.locator( '#wp-lightbox-exif' );
+
+			// The toggle is exposed and the panel starts collapsed.
+			await expect( toggle ).toBeVisible();
+			await expect( toggle ).toHaveAttribute( 'aria-expanded', 'false' );
+			await expect( panel ).toBeHidden();
+
+			// Opening the panel reveals the formatted metadata.
+			await toggle.click();
+			await expect( toggle ).toHaveAttribute( 'aria-expanded', 'true' );
+			await expect( panel ).toBeVisible();
+			await expect( panel ).toContainText( 'Test Camera' );
+			await expect( panel ).toContainText( 'f/2.8' );
+			await expect( panel ).toContainText( '1/250s' );
+			await expect( panel ).toContainText( '23mm' );
+			await expect( panel ).toContainText( 'Test Photographer' );
+
+			// Toggling again collapses the panel.
+			await toggle.click();
+			await expect( toggle ).toHaveAttribute( 'aria-expanded', 'false' );
+			await expect( panel ).toBeHidden();
+		} );
+	} );
 } );
 
 // Added to prevent regressions of https://github.com/WordPress/gutenberg/pull/57040.

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -999,8 +999,9 @@ test.describe( 'Image - lightbox', () => {
 			await expect( panel ).toContainText( 'Test Photographer' );
 
 			// Clicking within the panel must not close the lightbox, so the
-			// metadata stays readable (and selectable).
-			await panel.getByText( 'Test Photographer' ).click();
+			// metadata stays readable (and selectable). The first item is used
+			// because it sits clear of the toggle button in the top corner.
+			await panel.getByText( 'Test Camera' ).click();
 			await expect( panel ).toBeVisible();
 			await expect( toggle ).toHaveAttribute( 'aria-expanded', 'true' );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds EXIF metadata (camera, aperture, shutter speed, focal length, copyright) to the Image block lightbox, revealed via a toggle.

## Why?
Images opened in the Gutenberg lightbox can now reveal the available photo metadata instead of only showing the enlarged image.

## How?
- The Image block render path formats selected attachment `image_meta` fields and stores them in the lightbox interactivity state. The overlay shows an info toggle only when metadata exists, and renders only the labels whose values are present.
- When the panel is opened, the image stays centered at full size and the overlay scrolls to reveal a metadata panel positioned directly below the image and matched to the image's width. This works for any aspect ratio (portrait and landscape) and respects `prefers-reduced-motion` (the reveal jumps instantly rather than animating).
- The info toggle sits beneath the image, right-aligned to it; the metadata is left-aligned on the same row.
- Numeric values use consistent photographic notation regardless of locale (`f/2.8`, `1/250s`, `57mm`); focal length is rounded to one decimal.
- Accessibility: the toggle exposes `aria-expanded` and `aria-controls`, the panel is a labelled `group` region, and the focus trap accounts for the toggle.

## Testing Instructions
1. Add an Image block using an uploaded image with EXIF metadata for camera, aperture, shutter speed, focal length, or copyright.
2. Enable the lightbox for the image.
3. Open the post on the front end and click the image.
4. Confirm the metadata is hidden by default and an info toggle appears beneath the image (right-aligned).
5. Click the toggle and confirm the overlay scrolls to reveal only the available EXIF fields below the photo, and that you can scroll between the photo and the data.
6. Try both a portrait and a landscape image and confirm the panel sits below the photo at the image's width in each case.
7. Repeat with an image that has no EXIF metadata and confirm no toggle (and no empty labels) appear.

### Testing Instructions for Keyboard
1. Tab to the lightbox trigger for an image with EXIF metadata.
2. Press Enter or Space to open the lightbox.
3. Tab to the info toggle and press Enter or Space.
4. Confirm the EXIF metadata appears, `aria-expanded` reflects the state, and keyboard focus remains trapped in the lightbox controls.
5. Press Escape to close the lightbox.

### Automated tests
- PHPUnit: `phpunit/blocks/render-block-image-test.php` covers the EXIF formatting (including focal-length rounding) and the interactivity state.
- E2E: `test/e2e/specs/editor/blocks/image.spec.js` ("Image - lightbox › EXIF metadata") covers the toggle showing, opening, and hiding the panel.

## Screenshots or screencast
<img width="1728" height="996" alt="Screenshot 2026-06-02 at 21 07 43" src="https://github.com/user-attachments/assets/8655368d-d359-40df-a7c9-254f9e44ab91" />

_Note: layout has since been refined (panel below the image, scroll-to-reveal, portrait support) — updated screenshots to follow._

## Use of AI Tools
OpenAI Codex was used for the initial implementation; Claude Code was used for the layout, scroll, formatting, accessibility, and test refinements.
