### PR TITLE
Fix media editor sidebar close button label

### DIFF
--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -132,6 +132,7 @@ function MediaEditorSidebar( { tabs }: { tabs: EditorTab[] } ) {
 			className="media-editor__sidebar"
 			panelClassName="media-editor__sidebar-panel"
 			headerClassName="media-editor__sidebar-header"
+			closeLabel={ __( 'Close media panel' ) }
 			header={
 				<Tabs.Context.Provider value={ tabsContextValue }>
 					<Tabs.TabList>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? How?

Updates the media image editor sidebar `ComplementaryArea` to provide a media-specific `closeLabel` instead of falling back to the default “Close plugin” label.


## Why?


The close button now uses “Close media panel,” which better describes the action for screen reader users.



## Testing Instructions
1. From an image or site logo block, open the media editor modal
2. Hover over the side panel close button


| Then | Now |
|--------|--------|
|  <img width="274" height="179" alt="Screenshot 2026-06-03 at 1 22 47 pm" src="https://github.com/user-attachments/assets/1074fe34-fba7-476d-95a5-2e3a5c85bf23" /> |  <img width="338" height="177" alt="Screenshot 2026-06-03 at 1 21 47 pm" src="https://github.com/user-attachments/assets/900cdabd-a545-438c-83e1-ec8395a5253a" /> | 


