### PR TITLE
Element: add polyfills for render, hydrate, unmountComponentAtNode

### DIFF
--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Added polyfills for the `render`, `hydrate` and `unmountComponentAtNode` APIs that React 19 no longer ships.
+
 ## 7.0.0 (2026-05-27)
 
 ### Breaking Changes

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -134,12 +134,7 @@ Creates a portal into which a component can be rendered.
 
 _Related_
 
--   <https://github.com/facebook/react/issues/10309#issuecomment-318433235>
-
-_Parameters_
-
--   _child_ `React.ReactElement`: Any renderable child, such as an element, string, or fragment.
--   _container_ `HTMLElement`: DOM node into which element should be rendered.
+-   <https://react.dev/reference/react-dom/createPortal>
 
 ### createRef
 
@@ -179,9 +174,9 @@ _Parameters_
 
 Forces React to flush any updates inside the provided callback synchronously.
 
-_Parameters_
+_Related_
 
--   _callback_ `Function`: Callback to run synchronously.
+-   <https://react.dev/reference/react-dom/flushSync>
 
 ### forwardRef
 
@@ -198,6 +193,22 @@ _Returns_
 ### Fragment
 
 A component which renders its children without any wrapping element.
+
+### hydrate
+
+> **Deprecated** since WordPress 6.2.0. Use `hydrateRoot` instead.
+
+Hydrates a given element into the target DOM node.
+
+_Related_
+
+-   <https://react.dev/reference/react-dom/hydrate>
+
+_Parameters_
+
+-   _element_ `React.ReactNode`: Element to hydrate.
+-   _container_ `Element`: DOM node to hydrate.
+-   _callback_ `() => void`: Optional callback called after hydration.
 
 ### hydrateRoot
 
@@ -376,6 +387,22 @@ _Returns_
 
 -   Dangerously-rendering component.
 
+### render
+
+> **Deprecated** since WordPress 6.2.0. Use `createRoot` instead.
+
+Renders a given element into the target DOM node.
+
+_Related_
+
+-   <https://react.dev/reference/react-dom/render>
+
+_Parameters_
+
+-   _element_ `React.ReactNode`: Element to render.
+-   _container_ `Element`: DOM node into which to render.
+-   _callback_ `() => void`: Optional callback called after render.
+
 ### renderToString
 
 Serializes a React element to string.
@@ -414,6 +441,24 @@ _Parameters_
 _Returns_
 
 -   `ReactNode`: The updated children object.
+
+### unmountComponentAtNode
+
+> **Deprecated** since WordPress 6.2.0. Use `root.unmount()` instead.
+
+Removes any mounted element from the target DOM node.
+
+_Related_
+
+-   <https://react.dev/reference/react-dom/unmountComponentAtNode>
+
+_Parameters_
+
+-   _container_ `Element`: DOM node in which to unmount.
+
+_Returns_
+
+-   `boolean`: Whether the node was unmounted.
 
 ### use
 

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -38,6 +38,7 @@
 			"import": "./build-module/index.mjs",
 			"require": "./build/index.cjs"
 		},
+		"./react-polyfill": "./src/react-polyfill-base.ts",
 		"./package.json": "./package.json"
 	},
 	"react-native": "src/index",

--- a/packages/element/src/index.ts
+++ b/packages/element/src/index.ts
@@ -5,4 +5,9 @@ export * from './utils';
 export { default as Platform } from './platform';
 export { default as renderToString } from './serialize';
 export { default as RawHTML } from './raw-html';
-export { default as findDOMNode } from './find-dom-node';
+export {
+	findDOMNode,
+	render,
+	hydrate,
+	unmountComponentAtNode,
+} from './react-polyfill';

--- a/packages/element/src/react-platform.ts
+++ b/packages/element/src/react-platform.ts
@@ -17,18 +17,14 @@ import { createRoot, hydrateRoot } from 'react-dom/client';
 /**
  * Creates a portal into which a component can be rendered.
  *
- * @see https://github.com/facebook/react/issues/10309#issuecomment-318433235
- *
- * @param {React.ReactElement} child     Any renderable child, such as an element,
- *                                       string, or fragment.
- * @param {HTMLElement}        container DOM node into which element should be rendered.
+ * @see https://react.dev/reference/react-dom/createPortal
  */
 export { createPortal };
 
 /**
  * Forces React to flush any updates inside the provided callback synchronously.
  *
- * @param {Function} callback Callback to run synchronously.
+ * @see https://react.dev/reference/react-dom/flushSync
  */
 export { flushSync };
 

--- a/packages/element/src/react-polyfill-base.ts
+++ b/packages/element/src/react-polyfill-base.ts
@@ -1,4 +1,6 @@
-import deprecated from '@wordpress/deprecated';
+import { flushSync } from 'react-dom';
+import { createRoot, hydrateRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
 
 const internalsKey = '_reactInternals';
 
@@ -53,21 +55,7 @@ function findHostFiberImpl( fiber: any ): any {
 	return null;
 }
 
-/**
- * Finds the DOM node of a React component instance.
- *
- * @deprecated since WordPress 7.1.0. Use DOM refs instead.
- * @see https://react.dev/reference/react-dom/findDOMNode
- *
- * @param      instance Component's instance.
- */
-export default function findDOMNode( instance: any ): Element | Text | null {
-	deprecated( 'wp.element.findDOMNode', {
-		since: '7.1',
-		alternative: 'DOM refs',
-		link: 'https://react.dev/reference/react-dom/findDOMNode',
-	} );
-
+export function findDOMNode( instance: any ): Element | Text | null {
 	if ( instance === null || instance === undefined ) {
 		return null;
 	}
@@ -89,4 +77,57 @@ export default function findDOMNode( instance: any ): Element | Text | null {
 
 	const hostFiber = findHostFiber( fiber );
 	return hostFiber?.stateNode ?? null;
+}
+
+const roots = new WeakMap< Element, Root >();
+
+export function render(
+	element: React.ReactNode,
+	container: Element,
+	callback?: () => void
+): void {
+	let root = roots.get( container );
+	if ( ! root ) {
+		root = createRoot( container );
+		roots.set( container, root );
+	}
+
+	flushSync( () => {
+		root.render( element );
+	} );
+
+	if ( typeof callback === 'function' ) {
+		callback();
+	}
+}
+
+export function hydrate(
+	element: React.ReactNode,
+	container: Element,
+	callback?: () => void
+): void {
+	let root = roots.get( container );
+	if ( ! root ) {
+		root = hydrateRoot( container, element );
+		roots.set( container, root );
+	} else {
+		root.render( element );
+	}
+
+	if ( typeof callback === 'function' ) {
+		callback();
+	}
+}
+
+export function unmountComponentAtNode( container: Element ): boolean {
+	const root = roots.get( container );
+	if ( ! root ) {
+		return false;
+	}
+
+	flushSync( () => {
+		root.unmount();
+	} );
+	roots.delete( container );
+	return true;
 }

--- a/packages/element/src/react-polyfill.ts
+++ b/packages/element/src/react-polyfill.ts
@@ -1,0 +1,99 @@
+/**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
+ * Internal dependencies
+ */
+import {
+	findDOMNode as findDOMNodeBase,
+	render as renderBase,
+	hydrate as hydrateBase,
+	unmountComponentAtNode as unmountComponentAtNodeBase,
+} from './react-polyfill-base';
+
+/**
+ * Finds the DOM node of a React component instance.
+ *
+ * @deprecated since WordPress 7.1.0. Use DOM refs instead.
+ * @see https://react.dev/reference/react-dom/findDOMNode
+ *
+ * @param      instance Component's instance.
+ */
+export function findDOMNode( instance: any ): Element | Text | null {
+	deprecated( 'wp.element.findDOMNode', {
+		since: '7.1',
+		alternative: 'DOM refs',
+		link: 'https://react.dev/reference/react-dom/findDOMNode',
+	} );
+
+	return findDOMNodeBase( instance );
+}
+
+/**
+ * Renders a given element into the target DOM node.
+ *
+ * @deprecated since WordPress 6.2.0. Use `createRoot` instead.
+ * @see https://react.dev/reference/react-dom/render
+ *
+ * @param      element   Element to render.
+ * @param      container DOM node into which to render.
+ * @param      callback  Optional callback called after render.
+ */
+export function render(
+	element: React.ReactNode,
+	container: Element,
+	callback?: () => void
+): void {
+	deprecated( 'wp.element.render', {
+		since: '6.2',
+		alternative: 'wp.element.createRoot',
+		link: 'https://react.dev/reference/react-dom/client/createRoot',
+	} );
+
+	renderBase( element, container, callback );
+}
+
+/**
+ * Hydrates a given element into the target DOM node.
+ *
+ * @deprecated since WordPress 6.2.0. Use `hydrateRoot` instead.
+ * @see https://react.dev/reference/react-dom/hydrate
+ *
+ * @param      element   Element to hydrate.
+ * @param      container DOM node to hydrate.
+ * @param      callback  Optional callback called after hydration.
+ */
+export function hydrate(
+	element: React.ReactNode,
+	container: Element,
+	callback?: () => void
+): void {
+	deprecated( 'wp.element.hydrate', {
+		since: '6.2',
+		alternative: 'wp.element.hydrateRoot',
+		link: 'https://react.dev/reference/react-dom/client/hydrateRoot',
+	} );
+
+	hydrateBase( element, container, callback );
+}
+
+/**
+ * Removes any mounted element from the target DOM node.
+ *
+ * @deprecated since WordPress 6.2.0. Use `root.unmount()` instead.
+ * @see https://react.dev/reference/react-dom/unmountComponentAtNode
+ *
+ * @param      container DOM node in which to unmount.
+ * @return Whether the node was unmounted.
+ */
+export function unmountComponentAtNode( container: Element ): boolean {
+	deprecated( 'wp.element.unmountComponentAtNode', {
+		since: '6.2',
+		alternative: 'root.unmount()',
+		link: 'https://react.dev/reference/react-dom/client/createRoot#root-unmount',
+	} );
+
+	return unmountComponentAtNodeBase( container );
+}

--- a/packages/element/src/test/find-dom-node.js
+++ b/packages/element/src/test/find-dom-node.js
@@ -1,6 +1,6 @@
 import { act, render } from '@testing-library/react';
 import { Component } from '..';
-import findDOMNodePolyfill from '../find-dom-node';
+import { findDOMNode as findDOMNodePolyfill } from '../react-polyfill';
 
 describe( 'findDOMNode', () => {
 	it( 'should return null when passed null', () => {

--- a/packages/element/src/test/react-polyfill.js
+++ b/packages/element/src/test/react-polyfill.js
@@ -2,17 +2,13 @@
  * Internal dependencies
  */
 import { createElement } from '..';
-import {
-	render as renderPolyfill,
-	hydrate,
-	unmountComponentAtNode,
-} from '../react-polyfill';
+import { render, hydrate, unmountComponentAtNode } from '../react-polyfill';
 
-describe( 'render polyfill', () => {
+describe( 'render', () => {
 	it( 'should render into a container', () => {
 		const container = document.createElement( 'div' );
 
-		renderPolyfill( createElement( 'p', null, 'hello' ), container );
+		render( createElement( 'p', null, 'hello' ), container );
 
 		expect( container ).toHaveTextContent( 'hello' );
 		expect( console ).toHaveWarned();
@@ -21,8 +17,8 @@ describe( 'render polyfill', () => {
 	it( 'should update the container on subsequent renders', () => {
 		const container = document.createElement( 'div' );
 
-		renderPolyfill( createElement( 'p', null, 'hello' ), container );
-		renderPolyfill( createElement( 'p', null, 'world' ), container );
+		render( createElement( 'p', null, 'hello' ), container );
+		render( createElement( 'p', null, 'world' ), container );
 
 		expect( container ).toHaveTextContent( 'world' );
 	} );
@@ -31,25 +27,21 @@ describe( 'render polyfill', () => {
 		const container = document.createElement( 'div' );
 		const callback = jest.fn();
 
-		renderPolyfill(
-			createElement( 'p', null, 'hello' ),
-			container,
-			callback
-		);
+		render( createElement( 'p', null, 'hello' ), container, callback );
 
 		expect( callback ).toHaveBeenCalledTimes( 1 );
 		expect( container ).toHaveTextContent( 'hello' );
 	} );
 } );
 
-describe( 'hydrate polyfill', () => {
+describe( 'hydrate', () => {
 	it( 'should hydrate into a container with matching markup', () => {
 		const container = document.createElement( 'div' );
 		container.innerHTML = '<p>hello</p>';
 
 		hydrate( createElement( 'p', null, 'hello' ), container );
 
-		expect( container.querySelector( 'p' ) ).toHaveTextContent( 'hello' );
+		expect( container ).toHaveTextContent( 'hello' );
 		expect( console ).toHaveWarned();
 	} );
 
@@ -64,7 +56,7 @@ describe( 'hydrate polyfill', () => {
 	} );
 } );
 
-describe( 'unmountComponentAtNode polyfill', () => {
+describe( 'unmountComponentAtNode', () => {
 	it( 'should return false when the container has no root', () => {
 		const container = document.createElement( 'div' );
 
@@ -75,7 +67,7 @@ describe( 'unmountComponentAtNode polyfill', () => {
 	it( 'should unmount and return true when a root exists', () => {
 		const container = document.createElement( 'div' );
 
-		renderPolyfill( createElement( 'p', null, 'hello' ), container );
+		render( createElement( 'p', null, 'hello' ), container );
 		expect( container ).toHaveTextContent( 'hello' );
 
 		expect( unmountComponentAtNode( container ) ).toBe( true );

--- a/packages/element/src/test/render-polyfill.js
+++ b/packages/element/src/test/render-polyfill.js
@@ -1,0 +1,85 @@
+/**
+ * Internal dependencies
+ */
+import { createElement } from '..';
+import {
+	render as renderPolyfill,
+	hydrate,
+	unmountComponentAtNode,
+} from '../react-polyfill';
+
+describe( 'render polyfill', () => {
+	it( 'should render into a container', () => {
+		const container = document.createElement( 'div' );
+
+		renderPolyfill( createElement( 'p', null, 'hello' ), container );
+
+		expect( container ).toHaveTextContent( 'hello' );
+		expect( console ).toHaveWarned();
+	} );
+
+	it( 'should update the container on subsequent renders', () => {
+		const container = document.createElement( 'div' );
+
+		renderPolyfill( createElement( 'p', null, 'hello' ), container );
+		renderPolyfill( createElement( 'p', null, 'world' ), container );
+
+		expect( container ).toHaveTextContent( 'world' );
+	} );
+
+	it( 'should call the callback after rendering', () => {
+		const container = document.createElement( 'div' );
+		const callback = jest.fn();
+
+		renderPolyfill(
+			createElement( 'p', null, 'hello' ),
+			container,
+			callback
+		);
+
+		expect( callback ).toHaveBeenCalledTimes( 1 );
+		expect( container ).toHaveTextContent( 'hello' );
+	} );
+} );
+
+describe( 'hydrate polyfill', () => {
+	it( 'should hydrate into a container with matching markup', () => {
+		const container = document.createElement( 'div' );
+		container.innerHTML = '<p>hello</p>';
+
+		hydrate( createElement( 'p', null, 'hello' ), container );
+
+		expect( container.querySelector( 'p' ) ).toHaveTextContent( 'hello' );
+		expect( console ).toHaveWarned();
+	} );
+
+	it( 'should call the callback after hydrating', () => {
+		const container = document.createElement( 'div' );
+		container.innerHTML = '<p>hello</p>';
+		const callback = jest.fn();
+
+		hydrate( createElement( 'p', null, 'hello' ), container, callback );
+
+		expect( callback ).toHaveBeenCalledTimes( 1 );
+	} );
+} );
+
+describe( 'unmountComponentAtNode polyfill', () => {
+	it( 'should return false when the container has no root', () => {
+		const container = document.createElement( 'div' );
+
+		expect( unmountComponentAtNode( container ) ).toBe( false );
+		expect( console ).toHaveWarned();
+	} );
+
+	it( 'should unmount and return true when a root exists', () => {
+		const container = document.createElement( 'div' );
+
+		renderPolyfill( createElement( 'p', null, 'hello' ), container );
+		expect( container ).toHaveTextContent( 'hello' );
+
+		expect( unmountComponentAtNode( container ) ).toBe( true );
+		expect( container ).toHaveTextContent( '' );
+		expect( unmountComponentAtNode( container ) ).toBe( false );
+	} );
+} );

--- a/tools/build-scripts/packages/build-vendors.mjs
+++ b/tools/build-scripts/packages/build-vendors.mjs
@@ -26,6 +26,7 @@ const VENDOR_SCRIPTS = [
 			'module.exports = {',
 			'  ...require("react-dom"),',
 			'  ...require("react-dom/client"),',
+			'  ...require("@wordpress/element/react-polyfill"),',
 			'};',
 		].join( '\n' ),
 	},


### PR DESCRIPTION
Fixes #78827. Adds polyfills for `render`, `hydrate` and `unmountComponentAtNode` to `@wordpress/element` and also to the `react-dom` script itself.

For the polyfill to be really effective, it needs to be also in `react-dom`, because that's where plugins like Elementor commonly import it from. `react-dom` ships a version of the polyfill without the `deprecated` warnings, because we don't want the `react-dom` script to depend on `wp-deprecated`. This is an issue that we should solve somehow: currently the polyfills in `react-dom` won't issue any warning at all! But it must be done without `wp-deprecated`.

The polyfills are implemented inside `@wordpress/element`, and exported as a new special-purpose `/react-polyfill` export.
