### PR TITLE
Add 'summary' element to theme.json API for independent styling

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -658,6 +658,7 @@ class WP_Theme_JSON_Gutenberg {
 		'cite'      => 'cite',
 		'select'    => 'select',
 		'textInput' => 'textarea, input:where([type=email],[type=number],[type=password],[type=search],[type=text],[type=tel],[type=url])',
+		'summary'   => 'summary',
 	);
 
 	const __EXPERIMENTAL_ELEMENT_CLASS_NAMES = array(

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -302,6 +302,7 @@ export const __EXPERIMENTAL_ELEMENTS = {
 	select: 'select',
 	textInput:
 		'textarea, input:where([type=email],[type=number],[type=password],[type=search],[type=tel],[type=text],[type=url])',
+	summary: '.wp-block-details summary',
 };
 
 // These paths may have three origins, custom, theme, and default,

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1982,6 +1982,9 @@
 				},
 				"textInput": {
 					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"summary": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
PoC which can close #76535

This PR registers the `<summary>` HTML tag as a standard element within the `theme.json` Elements API. 

## Why?
Currently, the Details block shares typography and color settings globally across both the `summary` (the label) and the hidden content. By adding `summary` as a native `theme.json` element, we allow theme authors to independently target and style the summary tag. This leans into the existing Global Styles architecture, allowing seamless integration with Style Variations.

## How?
- Added the `summary` property to `schemas/json/theme.json` definitions.
- Mapped the `'summary' => 'summary'` selector in `lib/class-wp-theme-json-gutenberg.php` to compile the correct frontend scoped CSS.
- Mapped the `summary: '.wp-block-details summary'` selector in `packages/blocks/src/api/constants.js` to ensure styling parity on the editor canvas.

## Testing Instructions
1. Open a block theme's `theme.json` file.
2. Add a custom style targeting the new summary element globally:
```json
   "styles": {
     "elements": {
       "summary": {
         "typography": {
           "fontFamily": "var:preset|font-family|heading",
           "fontSize": "28px",
           "fontWeight": "100"
         },
         "color": {
           "background": "red",
           "text": "white"
         }
       }
     }
   }
```
3. Open the Site Editor or create a new Post.
4. Add a Details block and enter some text for the summary and the hidden content.
5. The summary text should have the custom size, typography, and red background, completely independent from the inner content.
6. Save and view the frontend. The styling should match the editor perfectly.