### PR TITLE
Fix experiments page form layout with box-sizing and width

### DIFF
--- a/routes/experiments-home/style.scss
+++ b/routes/experiments-home/style.scss
@@ -1,6 +1,8 @@
 @use "@wordpress/base-styles/variables" as *;
 
 .experiments-page__form {
+	box-sizing: border-box;
+	width: 100%;
 	padding: $grid-unit-30;
 	max-width: 680px;
 	margin: 0 auto;


### PR DESCRIPTION
## What?
Adds `box-sizing: border-box` and `width: 100%` to the `.experiments-page__form` styles to ensure proper layout and padding calculation.

## Why?
Without `box-sizing: border-box`, the padding is added to the element's width, which can cause layout issues and overflow. Setting `width: 100%` ensures the form respects its container width while the `box-sizing` property ensures padding is included in the width calculation, preventing unintended overflow.

Before | After
--- | ---
<img width="1672" height="1228" alt="Screenshot 2026-06-03 at 14 41 34" src="https://github.com/user-attachments/assets/8b004f10-c740-4290-b680-20a16f2c4da9" /> | <img width="1268" height="1277" alt="Screenshot 2026-06-03 at 15 08 47" src="https://github.com/user-attachments/assets/ce7ea378-c69b-4bdc-b8b5-9beda1baf076" />


## How?
Added two CSS properties to the `.experiments-page__form` class:
- `box-sizing: border-box` - Includes padding and border in the element's total width
- `width: 100%` - Makes the form responsive to its container width

## Testing Instructions
1. Navigate to the experiments page
2. Verify the form displays correctly and doesn't overflow its container
3. Confirm padding is properly applied without causing horizontal scrolling
4. Test on various viewport sizes to ensure responsive behavior

### Testing Instructions for Keyboard
N/A - This is a styling change with no interactive elements affected.

https://claude.ai/code/session_019dQaoqQF27FiojFUgyPM4t