### PR TITLE
Build: Fix is-shallow-equal default script export

### DIFF
--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -43,6 +43,7 @@
 	},
 	"react-native": "src/index",
 	"wpScript": true,
+	"wpScriptDefaultExport": true,
 	"types": "build-types",
 	"sideEffects": false,
 	"devDependencies": {

--- a/packages/is-shallow-equal/src/index.ts
+++ b/packages/is-shallow-equal/src/index.ts
@@ -15,7 +15,10 @@ export type ComparableObject = Record< string, any >;
  *
  * @return Whether the two values are shallow equal.
  */
-export default function isShallowEqual( a: unknown, b: unknown ): boolean {
+const isShallowEqualBase = function isShallowEqual(
+	a: unknown,
+	b: unknown
+): boolean {
 	if ( a && b ) {
 		if ( a.constructor === Object && b.constructor === Object ) {
 			return isShallowEqualObjects( a, b );
@@ -25,8 +28,15 @@ export default function isShallowEqual( a: unknown, b: unknown ): boolean {
 	}
 
 	return a === b;
-}
+};
 
-// `isShallowEqual` is exported also as a named export because esbuild cannot
-// expose the default export from the `window.wp.isShallowEqual` global.
+// `wpScriptDefaultExport` exposes `window.wp.isShallowEqual` as the callable
+// default export. Attach the named helpers to preserve the existing global API.
+const isShallowEqual = Object.assign( isShallowEqualBase, {
+	isShallowEqual: isShallowEqualBase,
+	isShallowEqualObjects,
+	isShallowEqualArrays,
+} );
+
+export default isShallowEqual;
 export { isShallowEqual, isShallowEqualObjects, isShallowEqualArrays };

--- a/packages/is-shallow-equal/test/index.ts
+++ b/packages/is-shallow-equal/test/index.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import {
+	default as defaultIsShallowEqual,
 	isShallowEqual,
 	isShallowEqualArrays,
 	isShallowEqualObjects,
@@ -153,6 +154,18 @@ describe( 'isShallowEqual', () => {
 		const b = a;
 
 		expect( isShallowEqual( a, b ) ).toBe( true );
+	} );
+
+	it( 'exposes named helpers on the default export', () => {
+		expect( defaultIsShallowEqual.isShallowEqual ).toBe(
+			defaultIsShallowEqual
+		);
+		expect( defaultIsShallowEqual.isShallowEqualArrays ).toBe(
+			isShallowEqualArrays
+		);
+		expect( defaultIsShallowEqual.isShallowEqualObjects ).toBe(
+			isShallowEqualObjects
+		);
 	} );
 } );
 


### PR DESCRIPTION
## What?

Fixes the `@wordpress/is-shallow-equal` script global by enabling `wpScriptDefaultExport`.

This makes `window.wp.isShallowEqual` resolve directly to the package's default function instead of the full module namespace object.

Alternative of #78699

## Why?

After the esbuild migration, packages exposed through `window.wp.*` can be consumed by external webpack builds as externals. For `@wordpress/is-shallow-equal`, default imports such as:

```js
import isShallowEqual from '@wordpress/is-shallow-equal';
```

could resolve to the namespace object instead of the default function, causing runtime errors like:

```text
TypeError: isShallowEqual is not a function
```

`is-shallow-equal` is primarily used as a callable default export, so it should opt into `wpScriptDefaultExport` like other packages that expose their default export directly on `window.wp.*`.

## How?

- Adds `"wpScriptDefaultExport": true` to `@wordpress/is-shallow-equal`.
- Keeps the default export callable.
- Attaches the named helpers to the default function so the existing global API remains available:

```js
window.wp.isShallowEqual( a, b );
window.wp.isShallowEqual.isShallowEqualObjects( a, b );
window.wp.isShallowEqual.isShallowEqualArrays( a, b );
```

This preserves compatibility for consumers using the `window.wp.isShallowEqual.*` helper properties while fixing default-import interop.

## Testing Instructions

Run:

```bash
npm run test:unit packages/is-shallow-equal/test/index.ts
npm run lint:js -- packages/is-shallow-equal/src/index.ts packages/is-shallow-equal/test/index.ts
./node_modules/.bin/tsgo --noEmit -p packages/is-shallow-equal/tsconfig.json
```

Optionally build the package and confirm in the browser console:

```js
typeof window.wp.isShallowEqual;
// "function"

typeof window.wp.isShallowEqual.isShallowEqualObjects;
// "function"

typeof window.wp.isShallowEqual.isShallowEqualArrays;
// "function"
```

## Testing Instructions for Keyboard

Not applicable. This is a build/export compatibility fix with no UI changes.