### PR TITLE
Add xl border radius token for page shell surfaces.

### DIFF
--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -111,7 +111,7 @@
 		position: static;
 		width: auto;
 		height: auto;
-		border-radius: 8px;
+		border-radius: var(--wpds-border-radius-xl);
 		margin: 0;
 
 		.boot-layout--single-page & {
@@ -167,7 +167,7 @@
 		position: static;
 		width: auto;
 		height: auto;
-		border-radius: 8px;
+		border-radius: var(--wpds-border-radius-xl);
 		z-index: auto;
 
 		.boot-layout--single-page & {

--- a/packages/boot/src/view-transitions.scss
+++ b/packages/boot/src/view-transitions.scss
@@ -106,7 +106,7 @@
 ::view-transition-new(boot--inspector),
 ::view-transition-old(boot--inspector) {
 	background: colors.$white;
-	border-radius: 8px;
+	border-radius: var(--wpds-border-radius-xl);
 	width: 100%;
 	height: 100%;
 	object-fit: none;

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -135,7 +135,7 @@
 			}
 
 			.edit-site-layout:not(.is-full-canvas) & {
-				border-radius: $radius-large;
+				border-radius: var(--wpds-border-radius-xl);
 			}
 
 			&:hover {
@@ -271,7 +271,7 @@ html.canvas-mode-edit-transition::view-transition-group(toggle) {
 	overflow: hidden;
 	box-shadow: $elevation-x-small;
 	@include break-medium() {
-		border-radius: 8px;
+		border-radius: var(--wpds-border-radius-xl);
 		margin: $canvas-padding $canvas-padding $canvas-padding 0;
 	}
 }

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### New Features
 
 -   Add `--wpds-dimension-size-*` design tokens for element sizing ([#76545](https://github.com/WordPress/gutenberg/pull/76545)).
--   Add `--wpds-border-radius-xl` for page and app shell surfaces so nested cards and notices can stay on `--wpds-border-radius-lg` without matching the parent radius.
+-   Add `--wpds-border-radius-xl` for page and app shell surfaces so nested cards and notices can stay on `--wpds-border-radius-lg` without matching the parent radius ([#78913](https://github.com/WordPress/gutenberg/pull/78913)).
 
 ### Code Quality
 

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add `--wpds-border-radius-xl` for page and app shell surfaces so nested cards and notices can stay on `--wpds-border-radius-lg` without matching the parent radius ([#78913](https://github.com/WordPress/gutenberg/pull/78913)).
+
 ## 0.15.0 (2026-06-10)
 
 ### New Features
 
 -   Add `--wpds-dimension-size-*` design tokens for element sizing ([#76545](https://github.com/WordPress/gutenberg/pull/76545)).
--   Add `--wpds-border-radius-xl` for page and app shell surfaces so nested cards and notices can stay on `--wpds-border-radius-lg` without matching the parent radius ([#78913](https://github.com/WordPress/gutenberg/pull/78913)).
 
 ### Code Quality
 

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New Features
 
 -   Add `--wpds-dimension-size-*` design tokens for element sizing ([#76545](https://github.com/WordPress/gutenberg/pull/76545)).
+-   Add `--wpds-border-radius-xl` for page and app shell surfaces so nested cards and notices can stay on `--wpds-border-radius-lg` without matching the parent radius.
 
 ### Code Quality
 

--- a/packages/theme/docs/tokens.md
+++ b/packages/theme/docs/tokens.md
@@ -125,17 +125,18 @@ The interactive state of the element. The default (no modifier) is the idle stat
 
 ### Border
 
-| Variable name               | Description                 |
-| --------------------------- | --------------------------- |
-| `--wpds-border-radius-xs`   | Extra small radius          |
-| `--wpds-border-radius-sm`   | Small radius                |
-| `--wpds-border-radius-md`   | Medium radius               |
-| `--wpds-border-radius-lg`   | Large radius                |
-| `--wpds-border-width-xs`    | Extra small width           |
-| `--wpds-border-width-sm`    | Small width                 |
-| `--wpds-border-width-md`    | Medium width                |
-| `--wpds-border-width-lg`    | Large width                 |
-| `--wpds-border-width-focus` | Border width for focus ring |
+| Variable name               | Description                                        |
+| --------------------------- | -------------------------------------------------- |
+| `--wpds-border-radius-xs`   | Extra small radius                                 |
+| `--wpds-border-radius-sm`   | Small radius                                       |
+| `--wpds-border-radius-md`   | Medium radius                                      |
+| `--wpds-border-radius-lg`   | Large radius                                       |
+| `--wpds-border-radius-xl`   | Extra large radius for page and app shell surfaces |
+| `--wpds-border-width-xs`    | Extra small width                                  |
+| `--wpds-border-width-sm`    | Small width                                        |
+| `--wpds-border-width-md`    | Medium width                                       |
+| `--wpds-border-width-lg`    | Large width                                        |
+| `--wpds-border-width-focus` | Border width for focus ring                        |
 
 ### Color
 

--- a/packages/theme/docs/tokens.md
+++ b/packages/theme/docs/tokens.md
@@ -125,18 +125,18 @@ The interactive state of the element. The default (no modifier) is the idle stat
 
 ### Border
 
-| Variable name               | Description                                        |
-| --------------------------- | -------------------------------------------------- |
-| `--wpds-border-radius-xs`   | Extra small radius                                 |
-| `--wpds-border-radius-sm`   | Small radius                                       |
-| `--wpds-border-radius-md`   | Medium radius                                      |
-| `--wpds-border-radius-lg`   | Large radius                                       |
-| `--wpds-border-radius-xl`   | Extra large radius for page and app shell surfaces |
-| `--wpds-border-width-xs`    | Extra small width                                  |
-| `--wpds-border-width-sm`    | Small width                                        |
-| `--wpds-border-width-md`    | Medium width                                       |
-| `--wpds-border-width-lg`    | Large width                                        |
-| `--wpds-border-width-focus` | Border width for focus ring                        |
+| Variable name               | Description                 |
+| --------------------------- | --------------------------- |
+| `--wpds-border-radius-xs`   | Extra small radius          |
+| `--wpds-border-radius-sm`   | Small radius                |
+| `--wpds-border-radius-md`   | Medium radius               |
+| `--wpds-border-radius-lg`   | Large radius                |
+| `--wpds-border-radius-xl`   | Extra large radius          |
+| `--wpds-border-width-xs`    | Extra small width           |
+| `--wpds-border-width-sm`    | Small width                 |
+| `--wpds-border-width-md`    | Medium width                |
+| `--wpds-border-width-lg`    | Large width                 |
+| `--wpds-border-width-focus` | Border width for focus ring |
 
 ### Color
 

--- a/packages/theme/docs/tokens.md
+++ b/packages/theme/docs/tokens.md
@@ -125,18 +125,18 @@ The interactive state of the element. The default (no modifier) is the idle stat
 
 ### Border
 
-| Variable name               | Description                 |
-| --------------------------- | --------------------------- |
-| `--wpds-border-radius-xs`   | Extra small radius          |
-| `--wpds-border-radius-sm`   | Small radius                |
-| `--wpds-border-radius-md`   | Medium radius               |
-| `--wpds-border-radius-lg`   | Large radius                |
-| `--wpds-border-radius-xl`   | Extra large radius          |
-| `--wpds-border-width-xs`    | Extra small width           |
-| `--wpds-border-width-sm`    | Small width                 |
-| `--wpds-border-width-md`    | Medium width                |
-| `--wpds-border-width-lg`    | Large width                 |
-| `--wpds-border-width-focus` | Border width for focus ring |
+| Variable name               | Description                                                   |
+| --------------------------- | ------------------------------------------------------------- |
+| `--wpds-border-radius-xs`   | Buttons and other elements nested inside controls.            |
+| `--wpds-border-radius-sm`   | Standalone buttons, inputs, and compact controls.             |
+| `--wpds-border-radius-md`   | Menus, popovers, and other small portaled overlays.           |
+| `--wpds-border-radius-lg`   | Cards, dialogs, notices, and other larger content containers. |
+| `--wpds-border-radius-xl`   | Page and app shell surfaces.                                  |
+| `--wpds-border-width-xs`    | Extra small width                                             |
+| `--wpds-border-width-sm`    | Small width                                                   |
+| `--wpds-border-width-md`    | Medium width                                                  |
+| `--wpds-border-width-lg`    | Large width                                                   |
+| `--wpds-border-width-focus` | Border width for focus ring                                   |
 
 ### Color
 

--- a/packages/theme/src/prebuilt/css/design-tokens.css
+++ b/packages/theme/src/prebuilt/css/design-tokens.css
@@ -11,7 +11,7 @@
 	--wpds-border-radius-md: 4px;
 	/* Large radius */
 	--wpds-border-radius-lg: 8px;
-	/* Extra large radius for page and app shell surfaces */
+	/* Extra large radius */
 	--wpds-border-radius-xl: 12px;
 	/* Extra small width */
 	--wpds-border-width-xs: 1px;

--- a/packages/theme/src/prebuilt/css/design-tokens.css
+++ b/packages/theme/src/prebuilt/css/design-tokens.css
@@ -3,15 +3,15 @@
  * ------------------------------------------- */
 
 :root {
-	/* Extra small radius */
+	/* Buttons and other elements nested inside controls. */
 	--wpds-border-radius-xs: 1px;
-	/* Small radius */
+	/* Standalone buttons, inputs, and compact controls. */
 	--wpds-border-radius-sm: 2px;
-	/* Medium radius */
+	/* Menus, popovers, and other small portaled overlays. */
 	--wpds-border-radius-md: 4px;
-	/* Large radius */
+	/* Cards, dialogs, notices, and other larger content containers. */
 	--wpds-border-radius-lg: 8px;
-	/* Extra large radius */
+	/* Page and app shell surfaces. */
 	--wpds-border-radius-xl: 12px;
 	/* Extra small width */
 	--wpds-border-width-xs: 1px;

--- a/packages/theme/src/prebuilt/css/design-tokens.css
+++ b/packages/theme/src/prebuilt/css/design-tokens.css
@@ -11,6 +11,8 @@
 	--wpds-border-radius-md: 4px;
 	/* Large radius */
 	--wpds-border-radius-lg: 8px;
+	/* Extra large radius for page and app shell surfaces */
+	--wpds-border-radius-xl: 12px;
 	/* Extra small width */
 	--wpds-border-width-xs: 1px;
 	/* Small width */

--- a/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
+++ b/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
@@ -7,6 +7,7 @@ export default {
 	'--wpds-border-radius-lg': '8px',
 	'--wpds-border-radius-md': '4px',
 	'--wpds-border-radius-sm': '2px',
+	'--wpds-border-radius-xl': '12px',
 	'--wpds-border-radius-xs': '1px',
 	'--wpds-border-width-focus': 'var(--wp-admin-border-width-focus, 2px)',
 	'--wpds-border-width-lg': '8px',

--- a/packages/theme/src/prebuilt/js/design-tokens.mjs
+++ b/packages/theme/src/prebuilt/js/design-tokens.mjs
@@ -8,6 +8,7 @@ export default [
 	'--wpds-border-radius-sm',
 	'--wpds-border-radius-md',
 	'--wpds-border-radius-lg',
+	'--wpds-border-radius-xl',
 	'--wpds-border-width-xs',
 	'--wpds-border-width-sm',
 	'--wpds-border-width-md',

--- a/packages/theme/src/prebuilt/ts/token-types.ts
+++ b/packages/theme/src/prebuilt/ts/token-types.ts
@@ -44,7 +44,7 @@ export type Easing = 'subtle' | 'balanced' | 'expressive';
 /**
  * Size scale for border radius tokens.
  */
-export type BorderRadiusSize = 'xs' | 'sm' | 'md' | 'lg';
+export type BorderRadiusSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 /**
  * Size scale for border width tokens.

--- a/packages/theme/tokens/border.json
+++ b/packages/theme/tokens/border.json
@@ -18,6 +18,10 @@
 				"$value": { "value": 8, "unit": "px" },
 				"$description": "Large radius"
 			},
+			"xl": {
+				"$value": { "value": 12, "unit": "px" },
+				"$description": "Extra large radius for page and app shell surfaces"
+			},
 			"$extensions": {
 				"com.figma.scopes": [ "CORNER_RADIUS" ]
 			}

--- a/packages/theme/tokens/border.json
+++ b/packages/theme/tokens/border.json
@@ -20,7 +20,7 @@
 			},
 			"xl": {
 				"$value": { "value": 12, "unit": "px" },
-				"$description": "Extra large radius for page and app shell surfaces"
+				"$description": "Extra large radius"
 			},
 			"$extensions": {
 				"com.figma.scopes": [ "CORNER_RADIUS" ]

--- a/packages/theme/tokens/border.json
+++ b/packages/theme/tokens/border.json
@@ -2,6 +2,7 @@
 	"wpds-border": {
 		"$type": "dimension",
 		"radius": {
+			"$description": "Border radius scale for elegant hierarchical nesting. Outer surfaces use larger steps; nested elements use smaller ones so concentric corners stay visually harmonious.",
 			"xs": {
 				"$value": { "value": 1, "unit": "px" },
 				"$description": "Extra small radius"

--- a/packages/theme/tokens/border.json
+++ b/packages/theme/tokens/border.json
@@ -5,23 +5,23 @@
 			"$description": "Border radius scale for elegant hierarchical nesting. Outer surfaces use larger steps; nested elements use smaller ones so concentric corners stay visually harmonious.",
 			"xs": {
 				"$value": { "value": 1, "unit": "px" },
-				"$description": "Extra small radius"
+				"$description": "Buttons and other elements nested inside controls."
 			},
 			"sm": {
 				"$value": { "value": 2, "unit": "px" },
-				"$description": "Small radius"
+				"$description": "Standalone buttons, inputs, and compact controls."
 			},
 			"md": {
 				"$value": { "value": 4, "unit": "px" },
-				"$description": "Medium radius"
+				"$description": "Menus, popovers, and other small portaled overlays."
 			},
 			"lg": {
 				"$value": { "value": 8, "unit": "px" },
-				"$description": "Large radius"
+				"$description": "Cards, dialogs, notices, and other larger content containers."
 			},
 			"xl": {
 				"$value": { "value": 12, "unit": "px" },
-				"$description": "Extra large radius"
+				"$description": "Page and app shell surfaces."
 			},
 			"$extensions": {
 				"com.figma.scopes": [ "CORNER_RADIUS" ]

--- a/storybook/stories/design-system/theme-example-application.story.tsx
+++ b/storybook/stories/design-system/theme-example-application.story.tsx
@@ -110,7 +110,7 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 							gridTemplateColumns: '200px 1fr',
 							minHeight: '500px',
 							color: 'var(--wpds-color-fg-content-neutral)',
-							borderRadius: 'var(--wpds-border-radius-lg)',
+							borderRadius: 'var(--wpds-border-radius-xl)',
 							border: 'var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak)',
 							overflow: 'hidden',
 						} }


### PR DESCRIPTION
## What

Adds `--wpds-border-radius-xl` to the WPDS border radius scale and uses it on outer admin **page shell** surfaces.

**Token & docs**
- New `xl` step in `packages/theme/tokens/border.json` and regenerated prebuild artifacts
- Documented in `packages/theme/docs/tokens.md` and `packages/theme/CHANGELOG.md`

**Consumers**
- **Boot:** `boot-layout__stage`, `boot-layout__inspector`, and `boot-layout__canvas` (desktop); view-transition pseudo-elements
- **Site editor:** `.edit-site-layout__area` and `.edit-site-layout:not(.is-full-canvas) .edit-site-layout__canvas .edit-site-resizable-frame__inner-content`
- **Storybook:** theme example application mock page chrome

## Why

The WPDS design language calls for radius to scale with container size. However, page shells and contained surfaces (Card, Notice) share an 8px radius, so when the latter are nested within the former, the hierarchy is broken. See the Gutenberg Experiments page as an example.

Extending the scale upward (rather than shrinking cards/notices) keeps `lg` aligned with the existing guidance for cards and modals.

## How

1. **Token:** `xs` → `sm` → `md` → `lg` → **`xl`** via Terrazzo; run `npm run build:tokens` in `@wordpress/theme`.
2. **Shells:** Replace hardcoded `8px` / `$radius-large` on outer layout chrome with `var(--wpds-border-radius-xl)`.
3. **Nested surfaces:** No changes to `@wordpress/ui` Card/Notice (still `lg`).

## Screenshots

| Before | After |
| --- | --- |
| <img width="812" height="818" alt="Screenshot 2026-06-03 at 15 44 37" src="https://github.com/user-attachments/assets/db6c4369-cf3c-41d0-8562-90eee7c5e6b3" /> | <img width="811" height="817" alt="Screenshot 2026-06-03 at 15 43 18" src="https://github.com/user-attachments/assets/70328aa4-9490-463f-9a53-1f752f567882" /> |

Note the radius of the shell is now one step larger than the radius of the nested cards.

## Test plan

- [ ] Storybook → **Design System/Theme/Theme Provider/Example Application** — page chrome is more rounded than inner Card
- [ ] Storybook or local app → **boot** routes with Card/Notice inside stage — parent radius visibly larger than card
- [ ] **Site editor** (non–full-canvas) — preview frame and layout area use 12px corners; full-canvas mode unchanged
- [ ] Confirm dashboard widget tiles still match Card `lg` (8px)
- [ ] `npm run build` / theme token build if CI requires fresh prebuild