### PR TITLE
Navigation Overlay Close: Inherit theme typography

### DIFF
--- a/packages/block-library/src/navigation-overlay-close/style.scss
+++ b/packages/block-library/src/navigation-overlay-close/style.scss
@@ -7,7 +7,14 @@
 	border: none;
 	background: transparent;
 	cursor: pointer;
+	font-family: inherit;
+	font-size: inherit;
+	font-style: inherit;
+	font-weight: inherit;
+	letter-spacing: inherit;
+	line-height: inherit;
 	text-decoration: none;
+	text-transform: inherit;
 
 	&:focus {
 		outline-offset: 2px;
@@ -26,4 +33,3 @@
 		align-items: center;
 	}
 }
-


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the Navigation Overlay Close block so its default typography inherits from the active theme.

## Why?
The block renders as a button, so its default text could use system UI instead of the same theme font used by default Paragraph text.

## How?
Adds inherited typography declarations to the block stylesheet for font family, size, style, weight, line height, letter spacing, and text transform.

## Testing Instructions
1. Use a theme that supplies a default font family.
2. Add a Navigation Overlay Close block and set it to display text or both icon and text.
3. Confirm the default Close text uses the same theme font as a Paragraph block, and that selecting a specific font still applies that selected font.

### Testing Instructions for Keyboard
Use keyboard navigation to select the block, open the typography controls, and confirm the default and selected font behavior matches the mouse testing.

## Screenshots or screencast

Not included.

## Use of AI Tools

Authored with assistance from OpenAI Codex; the diff was reviewed before publishing.
