### PR TITLE
Playlist Block: Add waveform hover timestamps

### DIFF
--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -398,6 +398,7 @@ const PlaylistEdit = ( {
 						title={ currentTrackData?.title }
 						artist={ currentTrackData?.artist }
 						image={ currentTrackData?.image }
+						duration={ currentTrackData?.length }
 						waveformStyle={ waveformStyle }
 						onEnded={ onTrackEnded }
 					/>

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -45,6 +45,7 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 				$artist     = $track_attributes['artist'] ?? '';
 				$album      = $track_attributes['album'] ?? '';
 				$image      = $track_attributes['image'] ?? '';
+				$length     = $track_attributes['length'] ?? '';
 				$url        = $track_attributes['src'] ?? '';
 				$aria_label = $title;
 
@@ -67,6 +68,7 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 					'artist'    => wp_strip_all_tags( $artist ),
 					'album'     => wp_strip_all_tags( $album ),
 					'image'     => esc_url( $image ),
+					'length'    => wp_strip_all_tags( $length ),
 					'ariaLabel' => wp_strip_all_tags( $aria_label ),
 				);
 

--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -60,49 +60,22 @@ $waveform-player-height: 100px;
 	.wp-block-playlist__time-marker {
 		--wp-playlist-time-marker-label-offset: calc(-100% - 0.35rem);
 
-		position: absolute;
-		inset-block: 0;
-		width: 0;
 		color: currentColor;
-		opacity: 0;
 		pointer-events: none;
-		z-index: 6;
-
-		&.is-visible {
-			opacity: 1;
-		}
-
-		&::before {
-			content: "";
-			position: absolute;
-			inset-block: 0;
-			border-inline-start: 2px solid currentColor;
-			opacity: 0.55;
-		}
 	}
 
-	.wp-block-playlist__time-marker-label {
+	.wp-block-playlist__time-marker-label,
+	.wp-block-playlist__time-marker .waveform-marker-tooltip {
 		position: absolute;
 		inset-block-start: 0.35rem;
 		inset-inline-start: 0;
 		transform: translateX(var(--wp-playlist-time-marker-label-offset));
-		font-size: 0.75em;
-		line-height: 1;
-		white-space: nowrap;
-		text-shadow: 0 0 0.35em Canvas;
-		opacity: 0.75;
-	}
-
-	.wp-block-playlist__time-marker .waveform-marker-tooltip {
-		inset-block: 0 auto;
-		inset-inline-start: 0;
-		transform: translateX(var(--wp-playlist-time-marker-label-offset, calc(-100% - 0.35rem)));
 		padding: 0;
 		border-radius: 0;
 		background: transparent;
-		color: currentColor;
 		font-size: 0.75em;
 		line-height: 1;
+		white-space: nowrap;
 		text-shadow: 0 0 0.35em Canvas;
 		opacity: 0.75;
 	}

--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -62,17 +62,11 @@ $waveform-player-height: 100px;
 
 		color: currentColor;
 		pointer-events: none;
-
-		&.wp-block-playlist__time-marker--hover {
-			opacity: 0;
-		}
-
-		&.wp-block-playlist__time-marker--hover.is-visible {
-			opacity: 1;
-		}
 	}
 
+	.wp-block-playlist__time-marker-label,
 	.wp-block-playlist__time-marker .waveform-marker-tooltip {
+		position: absolute;
 		inset-block-start: 0.35rem;
 		inset-inline-start: 0;
 		transform: translateX(var(--wp-playlist-time-marker-label-offset));

--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -58,7 +58,7 @@ $waveform-player-height: 100px;
 	}
 
 	.wp-block-playlist__time-marker {
-		--wp-playlist-time-marker-label-offset: -50%;
+		--wp-playlist-time-marker-label-offset: calc(-100% - 0.35rem);
 
 		position: absolute;
 		inset-block: 0;
@@ -89,6 +89,20 @@ $waveform-player-height: 100px;
 		font-size: 0.75em;
 		line-height: 1;
 		white-space: nowrap;
+		text-shadow: 0 0 0.35em Canvas;
+		opacity: 0.75;
+	}
+
+	.wp-block-playlist__time-marker .waveform-marker-tooltip {
+		inset-block: 0 auto;
+		inset-inline-start: 0;
+		transform: translateX(var(--wp-playlist-time-marker-label-offset, calc(-100% - 0.35rem)));
+		padding: 0;
+		border-radius: 0;
+		background: transparent;
+		color: currentColor;
+		font-size: 0.75em;
+		line-height: 1;
 		text-shadow: 0 0 0.35em Canvas;
 		opacity: 0.75;
 	}

--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -46,7 +46,7 @@ $waveform-player-height: 100px;
 		position: absolute;
 		inset: 0 auto 0 0;
 		width: 0;
-		background: currentColor;
+		background: transparent;
 		opacity: 0;
 		pointer-events: none;
 		transition: opacity 0.12s ease;
@@ -54,7 +54,7 @@ $waveform-player-height: 100px;
 	}
 
 	.waveform-container.is-hovering .wp-block-playlist__waveform-hover-region {
-		opacity: 0.12;
+		opacity: 0;
 	}
 
 	.wp-block-playlist__time-marker {
@@ -62,6 +62,11 @@ $waveform-player-height: 100px;
 
 		color: currentColor;
 		pointer-events: none;
+
+		&.wp-block-playlist__time-marker--current,
+		&.wp-block-playlist__time-marker--end {
+			background: transparent !important;
+		}
 
 		&.wp-block-playlist__time-marker--hover {
 			opacity: 0;
@@ -81,8 +86,11 @@ $waveform-player-height: 100px;
 		border-radius: 0;
 		background: transparent;
 		color: inherit;
-		font-size: 0.75em;
-		line-height: 1;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+			Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+		font-size: 12px;
+		font-weight: 500;
+		line-height: 1.2;
 		white-space: nowrap;
 		text-shadow: 0 0 0.35em Canvas;
 		opacity: 1;

--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -79,11 +79,11 @@ $waveform-player-height: 100px;
 		padding: 0;
 		border-radius: 0;
 		background: transparent;
+		color: inherit;
 		font-size: 0.75em;
 		line-height: 1;
 		white-space: nowrap;
 		text-shadow: 0 0 0.35em Canvas;
-		opacity: 0.75;
 	}
 
 	.waveform-subtitle {

--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -62,11 +62,17 @@ $waveform-player-height: 100px;
 
 		color: currentColor;
 		pointer-events: none;
+
+		&.wp-block-playlist__time-marker--hover {
+			opacity: 0;
+		}
+
+		&.wp-block-playlist__time-marker--hover.is-visible {
+			opacity: 1;
+		}
 	}
 
-	.wp-block-playlist__time-marker-label,
 	.wp-block-playlist__time-marker .waveform-marker-tooltip {
-		position: absolute;
 		inset-block-start: 0.35rem;
 		inset-inline-start: 0;
 		transform: translateX(var(--wp-playlist-time-marker-label-offset));

--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -42,6 +42,57 @@ $waveform-player-height: 100px;
 		margin-bottom: 0;
 	}
 
+	.wp-block-playlist__waveform-hover-region {
+		position: absolute;
+		inset: 0 auto 0 0;
+		width: 0;
+		background: currentColor;
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 0.12s ease;
+		z-index: 0;
+	}
+
+	.waveform-container.is-hovering .wp-block-playlist__waveform-hover-region {
+		opacity: 0.12;
+	}
+
+	.wp-block-playlist__time-marker {
+		--wp-playlist-time-marker-label-offset: -50%;
+
+		position: absolute;
+		inset-block: 0;
+		width: 0;
+		color: currentColor;
+		opacity: 0;
+		pointer-events: none;
+		z-index: 6;
+
+		&.is-visible {
+			opacity: 1;
+		}
+
+		&::before {
+			content: "";
+			position: absolute;
+			inset-block: 0;
+			border-inline-start: 2px solid currentColor;
+			opacity: 0.55;
+		}
+	}
+
+	.wp-block-playlist__time-marker-label {
+		position: absolute;
+		inset-block-start: 0.35rem;
+		inset-inline-start: 0;
+		transform: translateX(var(--wp-playlist-time-marker-label-offset));
+		font-size: 0.75em;
+		line-height: 1;
+		white-space: nowrap;
+		text-shadow: 0 0 0.35em Canvas;
+		opacity: 0.75;
+	}
+
 	.waveform-subtitle {
 		opacity: 0.7;
 	}

--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -65,6 +65,7 @@ $waveform-player-height: 100px;
 
 		&.wp-block-playlist__time-marker--hover {
 			opacity: 0;
+			transition: opacity 0.12s ease;
 		}
 
 		&.wp-block-playlist__time-marker--hover.is-visible {

--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -84,6 +84,7 @@ $waveform-player-height: 100px;
 		line-height: 1;
 		white-space: nowrap;
 		text-shadow: 0 0 0.35em Canvas;
+		opacity: 1;
 	}
 
 	.waveform-subtitle {

--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -32,6 +32,7 @@ $waveform-player-height: 100px;
 		min-width: $waveform-player-height;
 		background: currentColor;
 		margin: 0;
+		opacity: 1;
 
 		&:hover:not(:disabled) {
 			transform: none;
@@ -42,19 +43,33 @@ $waveform-player-height: 100px;
 		margin-bottom: 0;
 	}
 
+	.wp-block-playlist__waveform-progress-region,
 	.wp-block-playlist__waveform-hover-region {
 		position: absolute;
 		inset: 0 auto 0 0;
 		width: 0;
+		pointer-events: none;
+		z-index: 0;
+	}
+
+	.wp-block-playlist__waveform-hover-region {
 		background: transparent;
 		opacity: 0;
-		pointer-events: none;
 		transition: opacity 0.12s ease;
-		z-index: 0;
 	}
 
 	.waveform-container.is-hovering .wp-block-playlist__waveform-hover-region {
 		opacity: 0;
+	}
+
+	.wp-block-playlist__waveform-hover-canvas {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		clip-path: inset(0 100% 0 0);
+		pointer-events: none;
+		z-index: 2;
 	}
 
 	.wp-block-playlist__time-marker {
@@ -64,7 +79,8 @@ $waveform-player-height: 100px;
 		pointer-events: none;
 
 		&.wp-block-playlist__time-marker--current,
-		&.wp-block-playlist__time-marker--end {
+		&.wp-block-playlist__time-marker--end,
+		&.wp-block-playlist__time-marker--hover {
 			background: transparent !important;
 		}
 
@@ -92,7 +108,6 @@ $waveform-player-height: 100px;
 		font-weight: 500;
 		line-height: 1.2;
 		white-space: nowrap;
-		text-shadow: 0 0 0.35em Canvas;
 		opacity: 1;
 	}
 

--- a/packages/block-library/src/playlist/view.js
+++ b/packages/block-library/src/playlist/view.js
@@ -81,10 +81,13 @@ function initPlayer( ref, track, shouldAutoPlay, context ) {
 
 	// If a player already exists, load the new track without recreating.
 	if ( existing?.instance ) {
+		// Set directly rather than via loadTrack(), whose mergeOptions skips
+		// null values and so would leave a stale fallback when the new track
+		// has no length.
+		existing.instance.options.durationFallback = parseTime( track.length );
 		existing.instance
 			.loadTrack( track.url, track.title, track.artist, {
 				artwork: track.image,
-				durationFallback: parseTime( track.length ),
 			} )
 			.then( () => {
 				existing.url = track.url;

--- a/packages/block-library/src/playlist/view.js
+++ b/packages/block-library/src/playlist/view.js
@@ -6,7 +6,11 @@ import { store, getContext, getElement } from '@wordpress/interactivity';
 /**
  * Internal dependencies
  */
-import { initWaveformPlayer, logPlayError } from '../utils/waveform-utils';
+import {
+	initWaveformPlayer,
+	logPlayError,
+	parseTime,
+} from '../utils/waveform-utils';
 
 /**
  * Store player state for each element.
@@ -80,6 +84,7 @@ function initPlayer( ref, track, shouldAutoPlay, context ) {
 		existing.instance
 			.loadTrack( track.url, track.title, track.artist, {
 				artwork: track.image,
+				durationFallback: parseTime( track.length ),
 			} )
 			.then( () => {
 				existing.url = track.url;
@@ -103,6 +108,7 @@ function initPlayer( ref, track, shouldAutoPlay, context ) {
 		title: track.title,
 		artist: track.artist,
 		image: track.image,
+		duration: track.length,
 		autoPlay: shouldAutoPlay,
 		labels,
 		waveformStyle: context.waveformStyle,

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -256,6 +256,25 @@ describe( 'Waveform utilities', () => {
 	} );
 
 	describe( 'setupWaveformTimeMarkers', () => {
+		let getContextSpy;
+
+		beforeEach( () => {
+			getContextSpy = jest
+				.spyOn( window.HTMLCanvasElement.prototype, 'getContext' )
+				.mockImplementation( () => ( {
+					clearRect: jest.fn(),
+					drawImage: jest.fn(),
+					getImageData: jest.fn( () => ( {
+						data: new Uint8ClampedArray( [ 0, 0, 0, 127 ] ),
+					} ) ),
+					putImageData: jest.fn(),
+				} ) );
+		} );
+
+		afterEach( () => {
+			getContextSpy.mockRestore();
+		} );
+
 		function createMarkerTestContext( {
 			duration = 120,
 			currentTime = 0,
@@ -448,9 +467,9 @@ describe( 'Waveform utilities', () => {
 			} );
 			expect( hoverMarker ).toHaveTextContent( '1:00' );
 			expect( hoverRegion ).toHaveStyle( { width: '50%' } );
-			expect( hoverCanvas.style.clipPath ).toBe(
-				'inset(0 50% 0 0)'
-			);
+			expect( hoverCanvas ).toHaveStyle( {
+				clipPath: 'inset(0 50% 0 0)',
+			} );
 		} );
 
 		it( 'should match the hover timestamp color to played preview bars', () => {
@@ -539,9 +558,9 @@ describe( 'Waveform utilities', () => {
 
 			expect( context.drawImage ).toHaveBeenCalledTimes( 2 );
 			expect( context.putImageData ).toHaveBeenCalledTimes( 2 );
-			expect( hoverCanvas.style.clipPath ).toBe(
-				'inset(0 50% 0 0)'
-			);
+			expect( hoverCanvas ).toHaveStyle( {
+				clipPath: 'inset(0 50% 0 0)',
+			} );
 		} );
 
 		it( 'should use fallback duration for time markers before metadata loads', () => {
@@ -634,9 +653,9 @@ describe( 'Waveform utilities', () => {
 			expect( waveformArea ).not.toHaveClass( 'is-hovering' );
 			expect( hoverMarker ).not.toHaveClass( 'is-visible' );
 			expect( hoverRegion ).toHaveStyle( { width: '0' } );
-			expect( hoverCanvas.style.clipPath ).toBe(
-				'inset(0 100% 0 0)'
-			);
+			expect( hoverCanvas ).toHaveStyle( {
+				clipPath: 'inset(0 100% 0 0)',
+			} );
 		} );
 
 		it( 'should remove marker elements on cleanup', () => {

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -328,13 +328,13 @@ describe( 'Waveform utilities', () => {
 			expect( currentMarker ).toHaveClass( 'is-visible' );
 			expect( currentMarker ).toHaveStyle( { left: '25%' } );
 			expect( currentMarker ).toHaveStyle( {
-				color: 'rgba(0, 0, 0, 0.3)',
+				color: 'rgb(0, 0, 0)',
 			} );
 			expect( currentMarker ).toHaveTextContent( '0:45' );
 			expect( endMarker ).toHaveClass( 'is-visible' );
 			expect( endMarker ).toHaveStyle( { left: '100%' } );
 			expect( endMarker ).toHaveStyle( {
-				color: 'rgba(0, 0, 0, 0.3)',
+				color: 'rgb(0, 0, 0)',
 			} );
 			expect( endMarker ).toHaveTextContent( '3:00' );
 			expect( instance.renderMarkers ).toHaveBeenCalled();
@@ -394,7 +394,7 @@ describe( 'Waveform utilities', () => {
 			expect( hoverMarker ).toHaveClass( 'is-visible' );
 			expect( hoverMarker ).toHaveStyle( { left: '50%' } );
 			expect( hoverMarker ).toHaveStyle( {
-				color: 'rgba(0, 0, 0, 0.3)',
+				color: 'rgb(0, 0, 0)',
 			} );
 			expect( hoverMarker ).toHaveTextContent( '1:00' );
 			expect( hoverRegion ).toHaveStyle( { width: '50%' } );

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -352,6 +352,22 @@ describe( 'Waveform utilities', () => {
 			] );
 		} );
 
+		it( 'should clamp the current marker label to the duration', () => {
+			const { container, instance } = createMarkerTestContext( {
+				duration: 180,
+				currentTime: 181,
+			} );
+
+			setupWaveformTimeMarkers( instance, container );
+
+			const currentMarker = container.querySelector(
+				'.wp-block-playlist__time-marker--current'
+			);
+
+			expect( currentMarker ).toHaveStyle( { left: '100%' } );
+			expect( currentMarker ).toHaveTextContent( '3:00' );
+		} );
+
 		it( 'should update the current marker on player timeupdate', () => {
 			const { audio, container, instance } = createMarkerTestContext();
 

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -348,9 +348,7 @@ describe( 'Waveform utilities', () => {
 				value: 60,
 			} );
 
-			container.dispatchEvent(
-				new CustomEvent( 'waveformplayer:timeupdate' )
-			);
+			instance.options.onTimeUpdate( 60, 120, instance );
 
 			const currentMarker = container.querySelector(
 				'.wp-block-playlist__time-marker--current'
@@ -403,13 +401,14 @@ describe( 'Waveform utilities', () => {
 			const hoverMarker = container.querySelector(
 				'.wp-block-playlist__time-marker--hover'
 			);
-			const endMarker = container.querySelector(
-				'.wp-block-playlist__time-marker--end'
-			);
 
 			expect( hoverMarker ).toHaveClass( 'is-visible' );
 			expect( hoverMarker ).toHaveTextContent( '1:00' );
-			expect( endMarker ).toHaveTextContent( '2:00' );
+			expect(
+				container.querySelector(
+					'.wp-block-playlist__time-marker--end'
+				)
+			).toBeNull();
 		} );
 
 		it( 'should hide the hover marker on mouse leave', () => {

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -332,6 +332,12 @@ describe( 'Waveform utilities', () => {
 			} );
 			expect( currentMarker ).toHaveTextContent( '0:45' );
 			expect( endMarker ).toHaveClass( 'is-visible' );
+			// Decorative markers must stay out of the tab order and hidden
+			// from assistive technology.
+			expect( currentMarker ).toHaveAttribute( 'tabindex', '-1' );
+			expect( currentMarker ).toHaveAttribute( 'aria-hidden', 'true' );
+			expect( endMarker ).toHaveAttribute( 'tabindex', '-1' );
+			expect( endMarker ).toHaveAttribute( 'aria-hidden', 'true' );
 			expect( endMarker ).toHaveStyle( { left: '100%' } );
 			expect( endMarker ).toHaveStyle( {
 				color: 'rgb(0, 0, 0)',

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -13,6 +13,7 @@ import '@testing-library/jest-dom';
 import {
 	createWaveformContainer,
 	formatTime,
+	getWaveformColors,
 	parseTime,
 	styleSvgIcons,
 	setupWaveformTimeMarkers,
@@ -24,7 +25,7 @@ import {
 const basePlayerData = {
 	url: 'https://example.com/song.mp3',
 	waveformColor: 'rgba(0, 0, 0, 0.3)',
-	progressColor: 'rgba(0, 0, 0, 0.6)',
+	progressColor: 'rgba(255, 255, 255, 0.3)',
 	buttonColor: '#000000',
 };
 
@@ -80,7 +81,7 @@ describe( 'Waveform utilities', () => {
 			);
 			expect( container ).toHaveAttribute(
 				'data-progress-color',
-				'rgba(0, 0, 0, 0.6)'
+				'rgba(255, 255, 255, 0.3)'
 			);
 			expect( container ).toHaveAttribute(
 				'data-button-color',
@@ -122,6 +123,26 @@ describe( 'Waveform utilities', () => {
 			} );
 
 			expect( container ).toHaveAttribute( 'data-height', '150' );
+		} );
+	} );
+
+	describe( 'getWaveformColors', () => {
+		it( 'should use an inverted color scheme for progress', () => {
+			const wrapper = document.createElement( 'div' );
+			const element = document.createElement( 'div' );
+
+			wrapper.style.backgroundColor = 'rgb(240, 250, 255)';
+			element.style.color = 'rgb(10, 20, 30)';
+			wrapper.appendChild( element );
+			document.body.appendChild( wrapper );
+
+			expect( getWaveformColors( element ) ).toEqual( {
+				textColor: 'rgb(10, 20, 30)',
+				waveformColor: 'rgba(10, 20, 30, 0.3)',
+				progressColor: 'rgba(240, 250, 255, 0.3)',
+			} );
+
+			wrapper.remove();
 		} );
 	} );
 
@@ -265,11 +286,13 @@ describe( 'Waveform utilities', () => {
 				value: currentTime,
 			} );
 
+			const canvas = container.querySelector( 'canvas' );
 			const instance = {
 				audio,
+				canvas,
 				options: {
 					waveformColor: 'rgba(0, 0, 0, 0.3)',
-					progressColor: 'rgba(0, 0, 0, 0.6)',
+					progressColor: 'rgba(255, 255, 255, 0.3)',
 					buttonColor: '#000000',
 				},
 				renderMarkers: jest.fn( () => {
@@ -324,11 +347,14 @@ describe( 'Waveform utilities', () => {
 			const endMarker = container.querySelector(
 				'.wp-block-playlist__time-marker--end'
 			);
+			const progressRegion = container.querySelector(
+				'.wp-block-playlist__waveform-progress-region'
+			);
 
 			expect( currentMarker ).toHaveClass( 'is-visible' );
 			expect( currentMarker ).toHaveStyle( { left: '25%' } );
 			expect( currentMarker ).toHaveStyle( {
-				color: 'rgb(0, 0, 0)',
+				color: 'rgb(255, 255, 255)',
 			} );
 			expect( currentMarker ).toHaveTextContent( '0:45' );
 			expect( endMarker ).toHaveClass( 'is-visible' );
@@ -343,6 +369,10 @@ describe( 'Waveform utilities', () => {
 				color: 'rgb(0, 0, 0)',
 			} );
 			expect( endMarker ).toHaveTextContent( '3:00' );
+			expect( progressRegion ).toHaveStyle( {
+				backgroundColor: 'rgb(0, 0, 0)',
+				width: '25%',
+			} );
 			expect( instance.renderMarkers ).not.toHaveBeenCalled();
 		} );
 
@@ -376,9 +406,16 @@ describe( 'Waveform utilities', () => {
 			const currentMarker = container.querySelector(
 				'.wp-block-playlist__time-marker--current'
 			);
+			const progressRegion = container.querySelector(
+				'.wp-block-playlist__waveform-progress-region'
+			);
 
 			expect( currentMarker ).toHaveStyle( { left: '50%' } );
+			expect( currentMarker ).toHaveStyle( {
+				color: 'rgb(255, 255, 255)',
+			} );
 			expect( currentMarker ).toHaveTextContent( '1:00' );
+			expect( progressRegion ).toHaveStyle( { width: '50%' } );
 		} );
 
 		it( 'should update the hover marker on mouse move', () => {
@@ -399,6 +436,9 @@ describe( 'Waveform utilities', () => {
 			const hoverRegion = container.querySelector(
 				'.wp-block-playlist__waveform-hover-region'
 			);
+			const hoverCanvas = container.querySelector(
+				'.wp-block-playlist__waveform-hover-canvas'
+			);
 
 			expect( waveformArea ).toHaveClass( 'is-hovering' );
 			expect( hoverMarker ).toHaveClass( 'is-visible' );
@@ -408,6 +448,100 @@ describe( 'Waveform utilities', () => {
 			} );
 			expect( hoverMarker ).toHaveTextContent( '1:00' );
 			expect( hoverRegion ).toHaveStyle( { width: '50%' } );
+			expect( hoverCanvas.style.clipPath ).toBe(
+				'inset(0 50% 0 0)'
+			);
+		} );
+
+		it( 'should match the hover timestamp color to played preview bars', () => {
+			const { container, instance, waveformArea } =
+				createMarkerTestContext( {
+					currentTime: 60,
+				} );
+
+			setupWaveformTimeMarkers( instance, container );
+
+			waveformArea.dispatchEvent(
+				new window.MouseEvent( 'mousemove', {
+					clientX: 60,
+				} )
+			);
+
+			const hoverMarker = container.querySelector(
+				'.wp-block-playlist__time-marker--hover'
+			);
+
+			expect( hoverMarker ).toHaveStyle( {
+				color: 'rgb(255, 255, 255)',
+			} );
+		} );
+
+		it( 'should hide the hover timestamp after seeking with a waveform click', () => {
+			jest.useFakeTimers();
+			try {
+				const { container, instance, waveformArea } =
+					createMarkerTestContext();
+
+				setupWaveformTimeMarkers( instance, container );
+
+				waveformArea.dispatchEvent(
+					new window.MouseEvent( 'mousemove', {
+						clientX: 110,
+					} )
+				);
+
+				const hoverMarker = container.querySelector(
+					'.wp-block-playlist__time-marker--hover'
+				);
+
+				expect( hoverMarker ).toHaveClass( 'is-visible' );
+
+				waveformArea.dispatchEvent( new window.MouseEvent( 'click' ) );
+
+				jest.runOnlyPendingTimers();
+
+				expect( hoverMarker ).not.toHaveClass( 'is-visible' );
+			} finally {
+				jest.useRealTimers();
+			}
+		} );
+
+		it( 'should refresh the hover waveform when playback position changes', () => {
+			const { audio, container, instance, waveformArea } =
+				createMarkerTestContext();
+
+			setupWaveformTimeMarkers( instance, container );
+
+			const hoverCanvas = container.querySelector(
+				'.wp-block-playlist__waveform-hover-canvas'
+			);
+			const context = {
+				clearRect: jest.fn(),
+				drawImage: jest.fn(),
+				getImageData: jest.fn( () => ( {
+					data: new Uint8ClampedArray( [ 0, 0, 0, 127 ] ),
+				} ) ),
+				putImageData: jest.fn(),
+			};
+			hoverCanvas.getContext = jest.fn( () => context );
+
+			waveformArea.dispatchEvent(
+				new window.MouseEvent( 'mousemove', {
+					clientX: 110,
+				} )
+			);
+
+			Object.defineProperty( audio, 'currentTime', {
+				configurable: true,
+				value: 60,
+			} );
+			instance.options.onTimeUpdate( 60, 120, instance );
+
+			expect( context.drawImage ).toHaveBeenCalledTimes( 2 );
+			expect( context.putImageData ).toHaveBeenCalledTimes( 2 );
+			expect( hoverCanvas.style.clipPath ).toBe(
+				'inset(0 50% 0 0)'
+			);
 		} );
 
 		it( 'should use fallback duration for time markers before metadata loads', () => {
@@ -437,11 +571,17 @@ describe( 'Waveform utilities', () => {
 
 			expect( currentMarker ).toHaveClass( 'is-visible' );
 			expect( currentMarker ).toHaveStyle( { left: '0%' } );
+			expect( currentMarker ).toHaveStyle( {
+				color: 'rgb(255, 255, 255)',
+			} );
 			expect( currentMarker ).toHaveTextContent( '0:00' );
 			expect( hoverMarker ).toHaveClass( 'is-visible' );
 			expect( hoverMarker ).toHaveTextContent( '1:00' );
 			expect( endMarker ).toHaveClass( 'is-visible' );
 			expect( endMarker ).toHaveStyle( { left: '100%' } );
+			expect( endMarker ).toHaveStyle( {
+				color: 'rgb(0, 0, 0)',
+			} );
 			expect( endMarker ).toHaveTextContent( '2:00' );
 		} );
 
@@ -461,6 +601,9 @@ describe( 'Waveform utilities', () => {
 
 			expect( currentMarker ).toHaveClass( 'is-visible' );
 			expect( currentMarker ).toHaveStyle( { left: '0%' } );
+			expect( currentMarker ).toHaveStyle( {
+				color: 'rgb(0, 0, 0)',
+			} );
 			expect( currentMarker ).toHaveTextContent( '0:00' );
 			expect( endMarker ).not.toHaveClass( 'is-visible' );
 		} );
@@ -484,10 +627,16 @@ describe( 'Waveform utilities', () => {
 			const hoverRegion = container.querySelector(
 				'.wp-block-playlist__waveform-hover-region'
 			);
+			const hoverCanvas = container.querySelector(
+				'.wp-block-playlist__waveform-hover-canvas'
+			);
 
 			expect( waveformArea ).not.toHaveClass( 'is-hovering' );
 			expect( hoverMarker ).not.toHaveClass( 'is-visible' );
 			expect( hoverRegion ).toHaveStyle( { width: '0' } );
+			expect( hoverCanvas.style.clipPath ).toBe(
+				'inset(0 100% 0 0)'
+			);
 		} );
 
 		it( 'should remove marker elements on cleanup', () => {
@@ -502,6 +651,16 @@ describe( 'Waveform utilities', () => {
 			expect(
 				container.querySelector(
 					'.wp-block-playlist__waveform-hover-region'
+				)
+			).toBeNull();
+			expect(
+				container.querySelector(
+					'.wp-block-playlist__waveform-progress-region'
+				)
+			).toBeNull();
+			expect(
+				container.querySelector(
+					'.wp-block-playlist__waveform-hover-canvas'
 				)
 			).toBeNull();
 		} );

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -421,8 +421,9 @@ describe( 'Waveform utilities', () => {
 				createMarkerTestContext( {
 					duration: Number.NaN,
 				} );
+			instance.options.durationFallback = 120;
 
-			setupWaveformTimeMarkers( instance, container, '2:00' );
+			setupWaveformTimeMarkers( instance, container );
 
 			waveformArea.dispatchEvent(
 				new window.MouseEvent( 'mousemove', {

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -12,7 +12,10 @@ import '@testing-library/jest-dom';
  */
 import {
 	createWaveformContainer,
+	formatTime,
+	parseTime,
 	styleSvgIcons,
+	setupWaveformTimeMarkers,
 	setupPlayButtonAccessibility,
 	logPlayError,
 } from '../waveform-utils';
@@ -26,6 +29,36 @@ const basePlayerData = {
 };
 
 describe( 'Waveform utilities', () => {
+	describe( 'formatTime', () => {
+		it( 'should format seconds as m:ss', () => {
+			expect( formatTime( 0 ) ).toBe( '0:00' );
+			expect( formatTime( 9 ) ).toBe( '0:09' );
+			expect( formatTime( 75 ) ).toBe( '1:15' );
+			expect( formatTime( 600 ) ).toBe( '10:00' );
+		} );
+
+		it( 'should format invalid values as 0:00', () => {
+			expect( formatTime( Number.NaN ) ).toBe( '0:00' );
+			expect( formatTime( Infinity ) ).toBe( '0:00' );
+			expect( formatTime( -1 ) ).toBe( '0:00' );
+		} );
+	} );
+
+	describe( 'parseTime', () => {
+		it( 'should parse formatted time strings to seconds', () => {
+			expect( parseTime( '0:09' ) ).toBe( 9 );
+			expect( parseTime( '1:15' ) ).toBe( 75 );
+			expect( parseTime( '1:02:30' ) ).toBe( 3750 );
+		} );
+
+		it( 'should return null for invalid values', () => {
+			expect( parseTime() ).toBeNull();
+			expect( parseTime( '' ) ).toBeNull();
+			expect( parseTime( '75' ) ).toBeNull();
+			expect( parseTime( '1:bad' ) ).toBeNull();
+		} );
+	} );
+
 	describe( 'createWaveformContainer', () => {
 		it( 'should create a container with required data attributes', () => {
 			const container = createWaveformContainer( basePlayerData );
@@ -198,6 +231,180 @@ describe( 'Waveform utilities', () => {
 			styleSvgIcons( container, '#ffff00' );
 
 			expect( path ).toHaveStyle( { fill: '#000000' } );
+		} );
+	} );
+
+	describe( 'setupWaveformTimeMarkers', () => {
+		function createMarkerTestContext( {
+			duration = 120,
+			currentTime = 0,
+		} = {} ) {
+			const container = document.createElement( 'div' );
+			container.innerHTML = `
+				<div class="waveform-container">
+					<canvas></canvas>
+					<div class="waveform-markers"></div>
+				</div>
+			`;
+
+			const waveformArea = container.querySelector(
+				'.waveform-container'
+			);
+			waveformArea.getBoundingClientRect = jest.fn( () => ( {
+				left: 10,
+				width: 200,
+			} ) );
+
+			const audio = document.createElement( 'audio' );
+			Object.defineProperty( audio, 'duration', {
+				configurable: true,
+				value: duration,
+			} );
+			Object.defineProperty( audio, 'currentTime', {
+				configurable: true,
+				value: currentTime,
+			} );
+
+			const instance = { audio, options: {} };
+
+			return { audio, container, instance, waveformArea };
+		}
+
+		it( 'should show current and end time markers', () => {
+			const { container, instance } = createMarkerTestContext( {
+				duration: 180,
+				currentTime: 45,
+			} );
+
+			setupWaveformTimeMarkers( instance, container );
+
+			const currentMarker = container.querySelector(
+				'.wp-block-playlist__time-marker--current'
+			);
+			const endMarker = container.querySelector(
+				'.wp-block-playlist__time-marker--end'
+			);
+
+			expect( currentMarker ).toHaveClass( 'is-visible' );
+			expect( currentMarker ).toHaveStyle( { left: '25%' } );
+			expect( currentMarker ).toHaveTextContent( '0:45' );
+			expect( endMarker ).toHaveClass( 'is-visible' );
+			expect( endMarker ).toHaveStyle( { left: '100%' } );
+			expect( endMarker ).toHaveTextContent( '3:00' );
+		} );
+
+		it( 'should update the current marker on player timeupdate', () => {
+			const { audio, container, instance } = createMarkerTestContext();
+
+			setupWaveformTimeMarkers( instance, container );
+			Object.defineProperty( audio, 'currentTime', {
+				configurable: true,
+				value: 60,
+			} );
+
+			container.dispatchEvent(
+				new CustomEvent( 'waveformplayer:timeupdate' )
+			);
+
+			const currentMarker = container.querySelector(
+				'.wp-block-playlist__time-marker--current'
+			);
+
+			expect( currentMarker ).toHaveStyle( { left: '50%' } );
+			expect( currentMarker ).toHaveTextContent( '1:00' );
+		} );
+
+		it( 'should update the hover marker on mouse move', () => {
+			const { container, instance, waveformArea } =
+				createMarkerTestContext();
+
+			setupWaveformTimeMarkers( instance, container );
+
+			waveformArea.dispatchEvent(
+				new window.MouseEvent( 'mousemove', {
+					clientX: 110,
+				} )
+			);
+
+			const hoverMarker = container.querySelector(
+				'.wp-block-playlist__time-marker--hover'
+			);
+			const hoverRegion = container.querySelector(
+				'.wp-block-playlist__waveform-hover-region'
+			);
+
+			expect( waveformArea ).toHaveClass( 'is-hovering' );
+			expect( hoverMarker ).toHaveClass( 'is-visible' );
+			expect( hoverMarker ).toHaveStyle( { left: '50%' } );
+			expect( hoverMarker ).toHaveTextContent( '1:00' );
+			expect( hoverRegion ).toHaveStyle( { width: '50%' } );
+		} );
+
+		it( 'should use fallback duration for the hover marker', () => {
+			const { container, instance, waveformArea } =
+				createMarkerTestContext( {
+					duration: Number.NaN,
+				} );
+
+			setupWaveformTimeMarkers( instance, container, '2:00' );
+
+			waveformArea.dispatchEvent(
+				new window.MouseEvent( 'mousemove', {
+					clientX: 110,
+				} )
+			);
+
+			const hoverMarker = container.querySelector(
+				'.wp-block-playlist__time-marker--hover'
+			);
+			const endMarker = container.querySelector(
+				'.wp-block-playlist__time-marker--end'
+			);
+
+			expect( hoverMarker ).toHaveClass( 'is-visible' );
+			expect( hoverMarker ).toHaveTextContent( '1:00' );
+			expect( endMarker ).toHaveTextContent( '2:00' );
+		} );
+
+		it( 'should hide the hover marker on mouse leave', () => {
+			const { container, instance, waveformArea } =
+				createMarkerTestContext();
+
+			setupWaveformTimeMarkers( instance, container );
+
+			waveformArea.dispatchEvent(
+				new window.MouseEvent( 'mousemove', {
+					clientX: 110,
+				} )
+			);
+			waveformArea.dispatchEvent( new window.MouseEvent( 'mouseleave' ) );
+
+			const hoverMarker = container.querySelector(
+				'.wp-block-playlist__time-marker--hover'
+			);
+			const hoverRegion = container.querySelector(
+				'.wp-block-playlist__waveform-hover-region'
+			);
+
+			expect( waveformArea ).not.toHaveClass( 'is-hovering' );
+			expect( hoverMarker ).not.toHaveClass( 'is-visible' );
+			expect( hoverRegion ).toHaveStyle( { width: '0' } );
+		} );
+
+		it( 'should remove marker elements on cleanup', () => {
+			const { container, instance } = createMarkerTestContext();
+
+			const cleanup = setupWaveformTimeMarkers( instance, container );
+			cleanup();
+
+			expect(
+				container.querySelector( '.wp-block-playlist__time-marker' )
+			).toBeNull();
+			expect(
+				container.querySelector(
+					'.wp-block-playlist__waveform-hover-region'
+				)
+			).toBeNull();
 		} );
 	} );
 

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -343,19 +343,7 @@ describe( 'Waveform utilities', () => {
 				color: 'rgb(0, 0, 0)',
 			} );
 			expect( endMarker ).toHaveTextContent( '3:00' );
-			expect( instance.renderMarkers ).toHaveBeenCalled();
-			expect( instance.options.markers ).toEqual( [
-				expect.objectContaining( {
-					time: 45,
-					label: '0:45',
-					color: 'rgba(0, 0, 0, 0.3)',
-				} ),
-				expect.objectContaining( {
-					time: 180,
-					label: '3:00',
-					color: 'rgba(0, 0, 0, 0.3)',
-				} ),
-			] );
+			expect( instance.renderMarkers ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should clamp the current marker label to the duration', () => {
@@ -422,7 +410,7 @@ describe( 'Waveform utilities', () => {
 			expect( hoverRegion ).toHaveStyle( { width: '50%' } );
 		} );
 
-		it( 'should use fallback duration for the hover marker', () => {
+		it( 'should use fallback duration for time markers before metadata loads', () => {
 			const { container, instance, waveformArea } =
 				createMarkerTestContext( {
 					duration: Number.NaN,
@@ -440,14 +428,41 @@ describe( 'Waveform utilities', () => {
 			const hoverMarker = container.querySelector(
 				'.wp-block-playlist__time-marker--hover'
 			);
+			const currentMarker = container.querySelector(
+				'.wp-block-playlist__time-marker--current'
+			);
+			const endMarker = container.querySelector(
+				'.wp-block-playlist__time-marker--end'
+			);
 
+			expect( currentMarker ).toHaveClass( 'is-visible' );
+			expect( currentMarker ).toHaveStyle( { left: '0%' } );
+			expect( currentMarker ).toHaveTextContent( '0:00' );
 			expect( hoverMarker ).toHaveClass( 'is-visible' );
 			expect( hoverMarker ).toHaveTextContent( '1:00' );
-			expect(
-				container.querySelector(
-					'.wp-block-playlist__time-marker--end'
-				)
-			).toBeNull();
+			expect( endMarker ).toHaveClass( 'is-visible' );
+			expect( endMarker ).toHaveStyle( { left: '100%' } );
+			expect( endMarker ).toHaveTextContent( '2:00' );
+		} );
+
+		it( 'should show the current marker when duration is unavailable', () => {
+			const { container, instance } = createMarkerTestContext( {
+				duration: Number.NaN,
+			} );
+
+			setupWaveformTimeMarkers( instance, container );
+
+			const currentMarker = container.querySelector(
+				'.wp-block-playlist__time-marker--current'
+			);
+			const endMarker = container.querySelector(
+				'.wp-block-playlist__time-marker--end'
+			);
+
+			expect( currentMarker ).toHaveClass( 'is-visible' );
+			expect( currentMarker ).toHaveStyle( { left: '0%' } );
+			expect( currentMarker ).toHaveTextContent( '0:00' );
+			expect( endMarker ).not.toHaveClass( 'is-visible' );
 		} );
 
 		it( 'should hide the hover marker on mouse leave', () => {

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -348,7 +348,9 @@ describe( 'Waveform utilities', () => {
 				value: 60,
 			} );
 
-			instance.options.onTimeUpdate( 60, 120, instance );
+			container.dispatchEvent(
+				new CustomEvent( 'waveformplayer:timeupdate' )
+			);
 
 			const currentMarker = container.querySelector(
 				'.wp-block-playlist__time-marker--current'
@@ -401,14 +403,13 @@ describe( 'Waveform utilities', () => {
 			const hoverMarker = container.querySelector(
 				'.wp-block-playlist__time-marker--hover'
 			);
+			const endMarker = container.querySelector(
+				'.wp-block-playlist__time-marker--end'
+			);
 
 			expect( hoverMarker ).toHaveClass( 'is-visible' );
 			expect( hoverMarker ).toHaveTextContent( '1:00' );
-			expect(
-				container.querySelector(
-					'.wp-block-playlist__time-marker--end'
-				)
-			).toBeNull();
+			expect( endMarker ).toHaveTextContent( '2:00' );
 		} );
 
 		it( 'should hide the hover marker on mouse leave', () => {

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -265,7 +265,42 @@ describe( 'Waveform utilities', () => {
 				value: currentTime,
 			} );
 
-			const instance = { audio, options: {} };
+			const instance = {
+				audio,
+				options: {},
+				renderMarkers: jest.fn( () => {
+					const markersContainer =
+						container.querySelector( '.waveform-markers' );
+					markersContainer.innerHTML = '';
+
+					if (
+						! Number.isFinite( audio.duration ) ||
+						audio.duration <= 0
+					) {
+						return;
+					}
+
+					instance.options.markers?.forEach( ( marker ) => {
+						const markerElement =
+							document.createElement( 'button' );
+						markerElement.className = 'waveform-marker';
+						markerElement.style.left = `${
+							( marker.time / audio.duration ) * 100
+						}%`;
+						markerElement.setAttribute(
+							'aria-label',
+							marker.label
+						);
+						markerElement.setAttribute( 'data-time', marker.time );
+
+						const tooltip = document.createElement( 'span' );
+						tooltip.className = 'waveform-marker-tooltip';
+						tooltip.textContent = marker.label;
+						markerElement.appendChild( tooltip );
+						markersContainer.appendChild( markerElement );
+					} );
+				} ),
+			};
 
 			return { audio, container, instance, waveformArea };
 		}
@@ -291,6 +326,17 @@ describe( 'Waveform utilities', () => {
 			expect( endMarker ).toHaveClass( 'is-visible' );
 			expect( endMarker ).toHaveStyle( { left: '100%' } );
 			expect( endMarker ).toHaveTextContent( '3:00' );
+			expect( instance.renderMarkers ).toHaveBeenCalled();
+			expect( instance.options.markers ).toEqual( [
+				expect.objectContaining( {
+					time: 45,
+					label: '0:45',
+				} ),
+				expect.objectContaining( {
+					time: 180,
+					label: '3:00',
+				} ),
+			] );
 		} );
 
 		it( 'should update the current marker on player timeupdate', () => {

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -267,7 +267,11 @@ describe( 'Waveform utilities', () => {
 
 			const instance = {
 				audio,
-				options: {},
+				options: {
+					waveformColor: 'rgba(0, 0, 0, 0.3)',
+					progressColor: 'rgba(0, 0, 0, 0.6)',
+					buttonColor: '#000000',
+				},
 				renderMarkers: jest.fn( () => {
 					const markersContainer =
 						container.querySelector( '.waveform-markers' );
@@ -287,6 +291,7 @@ describe( 'Waveform utilities', () => {
 						markerElement.style.left = `${
 							( marker.time / audio.duration ) * 100
 						}%`;
+						markerElement.style.backgroundColor = marker.color;
 						markerElement.setAttribute(
 							'aria-label',
 							marker.label
@@ -322,19 +327,27 @@ describe( 'Waveform utilities', () => {
 
 			expect( currentMarker ).toHaveClass( 'is-visible' );
 			expect( currentMarker ).toHaveStyle( { left: '25%' } );
+			expect( currentMarker ).toHaveStyle( {
+				color: 'rgba(0, 0, 0, 0.3)',
+			} );
 			expect( currentMarker ).toHaveTextContent( '0:45' );
 			expect( endMarker ).toHaveClass( 'is-visible' );
 			expect( endMarker ).toHaveStyle( { left: '100%' } );
+			expect( endMarker ).toHaveStyle( {
+				color: 'rgba(0, 0, 0, 0.3)',
+			} );
 			expect( endMarker ).toHaveTextContent( '3:00' );
 			expect( instance.renderMarkers ).toHaveBeenCalled();
 			expect( instance.options.markers ).toEqual( [
 				expect.objectContaining( {
 					time: 45,
 					label: '0:45',
+					color: 'rgba(0, 0, 0, 0.3)',
 				} ),
 				expect.objectContaining( {
 					time: 180,
 					label: '3:00',
+					color: 'rgba(0, 0, 0, 0.3)',
 				} ),
 			] );
 		} );
@@ -380,6 +393,9 @@ describe( 'Waveform utilities', () => {
 			expect( waveformArea ).toHaveClass( 'is-hovering' );
 			expect( hoverMarker ).toHaveClass( 'is-visible' );
 			expect( hoverMarker ).toHaveStyle( { left: '50%' } );
+			expect( hoverMarker ).toHaveStyle( {
+				color: 'rgba(0, 0, 0, 0.3)',
+			} );
 			expect( hoverMarker ).toHaveTextContent( '1:00' );
 			expect( hoverRegion ).toHaveStyle( { width: '50%' } );
 		} );

--- a/packages/block-library/src/utils/waveform-player.js
+++ b/packages/block-library/src/utils/waveform-player.js
@@ -58,6 +58,7 @@ function updatePlayerMetadata( instance, { title, artist, image } ) {
  * @param {string}   props.title         - The track title.
  * @param {string}   props.artist        - The artist name.
  * @param {string}   props.image         - The artwork image URL.
+ * @param {string}   props.duration      - The formatted track duration.
  * @param {string}   props.waveformStyle - Waveform style (bars, mirror, line, blocks, dots, seekbar).
  * @param {Function} props.onEnded       - Callback when the track finishes playing.
  * @return {Element} The WaveformPlayer element.
@@ -67,6 +68,7 @@ export function WaveformPlayer( {
 	title,
 	artist,
 	image,
+	duration,
 	waveformStyle,
 	onEnded,
 } ) {
@@ -115,6 +117,7 @@ export function WaveformPlayer( {
 				const player = initWaveformPlayer( element, {
 					src,
 					...metadataRef.current,
+					duration,
 					waveformStyle,
 					artist:
 						metadataRef.current.artist || EMPTY_ARTIST_PLACEHOLDER,
@@ -142,7 +145,7 @@ export function WaveformPlayer( {
 				playerDestroy?.();
 			};
 		},
-		[ onEndedEvent, src, waveformStyle, hasImage ]
+		[ onEndedEvent, src, duration, waveformStyle, hasImage ]
 	);
 
 	return <div ref={ ref } className="wp-block-playlist__waveform-player" />;

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -233,6 +233,7 @@ function createTimeMarker( documentRef, type ) {
 	const marker = documentRef.createElement( 'button' );
 	marker.className = `waveform-marker wp-block-playlist__time-marker wp-block-playlist__time-marker--${ type }`;
 	marker.setAttribute( 'aria-hidden', 'true' );
+	marker.tabIndex = -1;
 
 	const label = documentRef.createElement( 'span' );
 	label.className = 'waveform-marker-tooltip';

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -213,6 +213,16 @@ function clamp( value, min, max ) {
 }
 
 /**
+ * Convert a color to the same RGB color without transparency.
+ *
+ * @param {string} color - The source color.
+ * @return {string} The color with full alpha.
+ */
+function toOpaqueColor( color ) {
+	return colord( color ).alpha( 1 ).toRgbString();
+}
+
+/**
  * Create a positioned timestamp marker for the waveform.
  *
  * @param {Document} documentRef - Document used to create elements.
@@ -296,7 +306,9 @@ function decorateWaveformPlayerMarkers( markersContainer ) {
 			'wp-block-playlist__time-marker--current',
 			'is-visible'
 		);
-		currentMarker.style.color = currentMarker.style.backgroundColor;
+		currentMarker.style.color = toOpaqueColor(
+			currentMarker.style.backgroundColor
+		);
 		currentMarker.style.setProperty(
 			'--wp-playlist-time-marker-label-offset',
 			parseFloat( currentMarker.style.left ) < 5
@@ -311,7 +323,9 @@ function decorateWaveformPlayerMarkers( markersContainer ) {
 			'wp-block-playlist__time-marker--end',
 			'is-visible'
 		);
-		endMarker.style.color = endMarker.style.backgroundColor;
+		endMarker.style.color = toOpaqueColor(
+			endMarker.style.backgroundColor
+		);
 		endMarker.style.setProperty(
 			'--wp-playlist-time-marker-label-offset',
 			'calc(-100% - 0.35rem)'
@@ -414,7 +428,7 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 		waveformArea.classList.add( 'is-hovering' );
 		hoverRegion.style.width = `${ percent * 100 }%`;
 		hoverMarker.style.backgroundColor = markerColor;
-		hoverMarker.style.color = markerColor;
+		hoverMarker.style.color = toOpaqueColor( markerColor );
 		ensureHoverMarker();
 		setTimeMarker(
 			hoverMarker,

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -220,12 +220,12 @@ function clamp( value, min, max ) {
  * @return {Element} The marker element.
  */
 function createTimeMarker( documentRef, type ) {
-	const marker = documentRef.createElement( 'button' );
-	marker.className = `waveform-marker wp-block-playlist__time-marker wp-block-playlist__time-marker--${ type }`;
+	const marker = documentRef.createElement( 'div' );
+	marker.className = `wp-block-playlist__time-marker wp-block-playlist__time-marker--${ type }`;
 	marker.setAttribute( 'aria-hidden', 'true' );
 
 	const label = documentRef.createElement( 'span' );
-	label.className = 'waveform-marker-tooltip';
+	label.className = 'wp-block-playlist__time-marker-label';
 	marker.appendChild( label );
 
 	return marker;
@@ -242,7 +242,9 @@ function setTimeMarker( marker, percent, label ) {
 	const position = clamp( percent, 0, 1 );
 
 	marker.style.left = `${ position * 100 }%`;
-	marker.querySelector( '.waveform-marker-tooltip' ).textContent = label;
+	marker.querySelector(
+		'.wp-block-playlist__time-marker-label'
+	).textContent = label;
 	marker.classList.add( 'is-visible' );
 
 	if ( position < 0.05 ) {
@@ -339,6 +341,8 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 	waveformArea.prepend( hoverRegion );
 
 	const hoverMarker = createTimeMarker( documentRef, 'hover' );
+	const fallbackCurrentMarker = createTimeMarker( documentRef, 'current' );
+	const fallbackEndMarker = createTimeMarker( documentRef, 'end' );
 
 	markersContainer.append( hoverMarker );
 
@@ -363,6 +367,37 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 		return instance.options.progressColor || instance.options.buttonColor;
 	};
 
+	const showFallbackMarkers = () => {
+		const durationSeconds = getDuration();
+
+		if ( ! durationSeconds ) {
+			fallbackCurrentMarker.classList.remove( 'is-visible' );
+			fallbackEndMarker.classList.remove( 'is-visible' );
+			return;
+		}
+
+		if ( ! fallbackCurrentMarker.parentElement ) {
+			markersContainer.append( fallbackCurrentMarker );
+		}
+		if ( ! fallbackEndMarker.parentElement ) {
+			markersContainer.append( fallbackEndMarker );
+		}
+
+		setTimeMarker(
+			fallbackCurrentMarker,
+			instance.audio.currentTime / durationSeconds,
+			formatTime( instance.audio.currentTime )
+		);
+		setTimeMarker( fallbackEndMarker, 1, formatTime( durationSeconds ) );
+	};
+
+	const hideFallbackMarkers = () => {
+		fallbackCurrentMarker.classList.remove( 'is-visible' );
+		fallbackEndMarker.classList.remove( 'is-visible' );
+		fallbackCurrentMarker.remove();
+		fallbackEndMarker.remove();
+	};
+
 	const updateWaveformPlayerMarkers = () => {
 		const durationSeconds = getDuration();
 
@@ -370,6 +405,7 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 			instance.options.markers = [];
 			instance.renderMarkers();
 			ensureHoverMarker();
+			showFallbackMarkers();
 			return;
 		}
 
@@ -377,9 +413,11 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 			instance.options.markers = [];
 			instance.renderMarkers();
 			ensureHoverMarker();
+			showFallbackMarkers();
 			return;
 		}
 
+		hideFallbackMarkers();
 		instance.options.markers = createWaveformPlayerMarkers(
 			instance.audio.currentTime,
 			durationSeconds,
@@ -420,12 +458,6 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 		hoverRegion.style.width = '0';
 	};
 
-	const previousOnTimeUpdate = instance.options.onTimeUpdate;
-	instance.options.onTimeUpdate = ( currentTime, trackDuration, player ) => {
-		previousOnTimeUpdate?.( currentTime, trackDuration, player );
-		updateWaveformPlayerMarkers();
-	};
-
 	waveformArea.addEventListener( 'mousemove', updateHoverMarker );
 	waveformArea.addEventListener( 'mouseleave', hideHoverMarker );
 	instance.audio.addEventListener(
@@ -434,6 +466,14 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 	);
 	instance.audio.addEventListener(
 		'durationchange',
+		updateWaveformPlayerMarkers
+	);
+	instance.audio.addEventListener(
+		'timeupdate',
+		updateWaveformPlayerMarkers
+	);
+	container.addEventListener(
+		'waveformplayer:timeupdate',
 		updateWaveformPlayerMarkers
 	);
 	container.addEventListener(
@@ -454,15 +494,24 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 			'durationchange',
 			updateWaveformPlayerMarkers
 		);
+		instance.audio.removeEventListener(
+			'timeupdate',
+			updateWaveformPlayerMarkers
+		);
+		container.removeEventListener(
+			'waveformplayer:timeupdate',
+			updateWaveformPlayerMarkers
+		);
 		container.removeEventListener(
 			'waveformplayer:ended',
 			updateWaveformPlayerMarkers
 		);
-		instance.options.onTimeUpdate = previousOnTimeUpdate;
 		markersContainer
 			.querySelectorAll( '.wp-block-playlist__time-marker' )
 			.forEach( ( marker ) => marker.remove() );
 		hoverMarker.remove();
+		fallbackCurrentMarker.remove();
+		fallbackEndMarker.remove();
 		hoverRegion.remove();
 	};
 }

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -261,6 +261,65 @@ function setTimeMarker( marker, percent, label ) {
 }
 
 /**
+ * Create marker data for WaveformPlayer's marker API.
+ *
+ * @param {number} currentTime - The current playback position.
+ * @param {number} duration    - The track duration.
+ * @param {string} color       - Marker color.
+ * @return {Array} WaveformPlayer marker objects.
+ */
+function createWaveformPlayerMarkers( currentTime, duration, color ) {
+	return [
+		{
+			time: clamp( currentTime, 0, duration ),
+			label: formatTime( currentTime ),
+			color,
+		},
+		{
+			time: duration,
+			label: formatTime( duration ),
+			color,
+		},
+	];
+}
+
+/**
+ * Add Playlist-specific marker classes after WaveformPlayer renders markers.
+ *
+ * @param {Element} markersContainer - WaveformPlayer markers container.
+ */
+function decorateWaveformPlayerMarkers( markersContainer ) {
+	const [ currentMarker, endMarker ] =
+		markersContainer.querySelectorAll( '.waveform-marker' );
+
+	if ( currentMarker ) {
+		currentMarker.classList.add(
+			'wp-block-playlist__time-marker',
+			'wp-block-playlist__time-marker--current',
+			'is-visible'
+		);
+		currentMarker.style.setProperty(
+			'--wp-playlist-time-marker-label-offset',
+			parseFloat( currentMarker.style.left ) < 5
+				? '0'
+				: 'calc(-100% - 0.35rem)'
+		);
+	}
+
+	if ( endMarker ) {
+		endMarker.classList.add(
+			'wp-block-playlist__time-marker',
+			'wp-block-playlist__time-marker--end',
+			'is-visible'
+		);
+		endMarker.style.setProperty(
+			'--wp-playlist-time-marker-label-offset',
+			'calc(-100% - 0.35rem)'
+		);
+	}
+}
+
+/**
  * Set up current, hover, and duration timestamp markers on the waveform.
  *
  * @param {Object}  instance  - The WaveformPlayer library instance.
@@ -281,11 +340,17 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 	hoverRegion.className = 'wp-block-playlist__waveform-hover-region';
 	waveformArea.prepend( hoverRegion );
 
-	const currentMarker = createTimeMarker( documentRef, 'current' );
 	const hoverMarker = createTimeMarker( documentRef, 'hover' );
-	const endMarker = createTimeMarker( documentRef, 'end' );
+	const fallbackCurrentMarker = createTimeMarker( documentRef, 'current' );
+	const fallbackEndMarker = createTimeMarker( documentRef, 'end' );
 
-	markersContainer.append( currentMarker, hoverMarker, endMarker );
+	markersContainer.append( hoverMarker );
+
+	const ensureHoverMarker = () => {
+		if ( ! hoverMarker.parentElement ) {
+			markersContainer.append( hoverMarker );
+		}
+	};
 
 	const getDuration = () => {
 		if ( hasDuration( instance.audio.duration ) ) {
@@ -298,32 +363,69 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 		return hasDuration( fallbackDuration ) ? fallbackDuration : null;
 	};
 
-	const updateCurrentMarker = () => {
+	const getMarkerColor = () => {
+		return instance.options.progressColor || instance.options.buttonColor;
+	};
+
+	const showFallbackMarkers = () => {
 		const durationSeconds = getDuration();
 
 		if ( ! durationSeconds ) {
-			currentMarker.classList.remove( 'is-visible' );
+			fallbackCurrentMarker.classList.remove( 'is-visible' );
+			fallbackEndMarker.classList.remove( 'is-visible' );
 			return;
+		}
+
+		if ( ! fallbackCurrentMarker.parentElement ) {
+			markersContainer.append( fallbackCurrentMarker );
+		}
+		if ( ! fallbackEndMarker.parentElement ) {
+			markersContainer.append( fallbackEndMarker );
 		}
 
 		setTimeMarker(
-			currentMarker,
+			fallbackCurrentMarker,
 			instance.audio.currentTime / durationSeconds,
 			formatTime( instance.audio.currentTime )
 		);
+		setTimeMarker( fallbackEndMarker, 1, formatTime( durationSeconds ) );
 	};
 
-	const updateDurationMarkers = () => {
+	const hideFallbackMarkers = () => {
+		fallbackCurrentMarker.classList.remove( 'is-visible' );
+		fallbackEndMarker.classList.remove( 'is-visible' );
+		fallbackCurrentMarker.remove();
+		fallbackEndMarker.remove();
+	};
+
+	const updateWaveformPlayerMarkers = () => {
 		const durationSeconds = getDuration();
 
 		if ( ! durationSeconds ) {
-			endMarker.classList.remove( 'is-visible' );
-			updateCurrentMarker();
+			instance.options.markers = [];
+			instance.renderMarkers();
+			ensureHoverMarker();
+			showFallbackMarkers();
 			return;
 		}
 
-		setTimeMarker( endMarker, 1, formatTime( durationSeconds ) );
-		updateCurrentMarker();
+		if ( ! hasDuration( instance.audio.duration ) ) {
+			instance.options.markers = [];
+			instance.renderMarkers();
+			ensureHoverMarker();
+			showFallbackMarkers();
+			return;
+		}
+
+		hideFallbackMarkers();
+		instance.options.markers = createWaveformPlayerMarkers(
+			instance.audio.currentTime,
+			durationSeconds,
+			getMarkerColor()
+		);
+		instance.renderMarkers();
+		ensureHoverMarker();
+		decorateWaveformPlayerMarkers( markersContainer );
 	};
 
 	const updateHoverMarker = ( event ) => {
@@ -342,6 +444,7 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 
 		waveformArea.classList.add( 'is-hovering' );
 		hoverRegion.style.width = `${ percent * 100 }%`;
+		ensureHoverMarker();
 		setTimeMarker(
 			hoverMarker,
 			percent,
@@ -357,40 +460,58 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 
 	waveformArea.addEventListener( 'mousemove', updateHoverMarker );
 	waveformArea.addEventListener( 'mouseleave', hideHoverMarker );
-	instance.audio.addEventListener( 'loadedmetadata', updateDurationMarkers );
-	instance.audio.addEventListener( 'durationchange', updateDurationMarkers );
-	instance.audio.addEventListener( 'timeupdate', updateCurrentMarker );
+	instance.audio.addEventListener(
+		'loadedmetadata',
+		updateWaveformPlayerMarkers
+	);
+	instance.audio.addEventListener(
+		'durationchange',
+		updateWaveformPlayerMarkers
+	);
+	instance.audio.addEventListener(
+		'timeupdate',
+		updateWaveformPlayerMarkers
+	);
 	container.addEventListener(
 		'waveformplayer:timeupdate',
-		updateCurrentMarker
+		updateWaveformPlayerMarkers
 	);
-	container.addEventListener( 'waveformplayer:ended', updateCurrentMarker );
+	container.addEventListener(
+		'waveformplayer:ended',
+		updateWaveformPlayerMarkers
+	);
 
-	updateDurationMarkers();
+	updateWaveformPlayerMarkers();
 
 	return () => {
 		waveformArea.removeEventListener( 'mousemove', updateHoverMarker );
 		waveformArea.removeEventListener( 'mouseleave', hideHoverMarker );
 		instance.audio.removeEventListener(
 			'loadedmetadata',
-			updateDurationMarkers
+			updateWaveformPlayerMarkers
 		);
 		instance.audio.removeEventListener(
 			'durationchange',
-			updateDurationMarkers
+			updateWaveformPlayerMarkers
 		);
-		instance.audio.removeEventListener( 'timeupdate', updateCurrentMarker );
+		instance.audio.removeEventListener(
+			'timeupdate',
+			updateWaveformPlayerMarkers
+		);
 		container.removeEventListener(
 			'waveformplayer:timeupdate',
-			updateCurrentMarker
+			updateWaveformPlayerMarkers
 		);
 		container.removeEventListener(
 			'waveformplayer:ended',
-			updateCurrentMarker
+			updateWaveformPlayerMarkers
 		);
-		currentMarker.remove();
+		markersContainer
+			.querySelectorAll( '.wp-block-playlist__time-marker' )
+			.forEach( ( marker ) => marker.remove() );
 		hoverMarker.remove();
-		endMarker.remove();
+		fallbackCurrentMarker.remove();
+		fallbackEndMarker.remove();
 		hoverRegion.remove();
 	};
 }

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -16,6 +16,42 @@ import WaveformPlayerLib from '@arraypress/waveform-player';
 const DEFAULT_WAVEFORM_HEIGHT = 100;
 
 /**
+ * Format a time in seconds to a "m:ss" string.
+ *
+ * @param {number} seconds - The time in seconds.
+ * @return {string} The formatted time string.
+ */
+export function formatTime( seconds ) {
+	const time = Number.isFinite( seconds ) && seconds > 0 ? seconds : 0;
+	const mins = Math.floor( time / 60 );
+	const secs = Math.floor( time % 60 );
+	return `${ mins }:${ String( secs ).padStart( 2, '0' ) }`;
+}
+
+/**
+ * Parse a formatted time string to seconds.
+ *
+ * @param {string} time - Formatted time string, such as "3:10" or "1:02:30".
+ * @return {number|null} Time in seconds, or null when invalid.
+ */
+export function parseTime( time ) {
+	if ( typeof time !== 'string' || ! time.includes( ':' ) ) {
+		return null;
+	}
+
+	const parts = time.split( ':' ).map( Number );
+	if (
+		parts.length < 2 ||
+		parts.length > 3 ||
+		parts.some( ( part ) => ! Number.isFinite( part ) || part < 0 )
+	) {
+		return null;
+	}
+
+	return parts.reduce( ( total, part ) => total * 60 + part, 0 );
+}
+
+/**
  * Get computed style for an element, using ownerDocument for iframe compatibility.
  *
  * @param {Element} element - The element to get styles from.
@@ -155,6 +191,211 @@ export function logPlayError( error ) {
 }
 
 /**
+ * Check whether an audio duration can be used for marker positioning.
+ *
+ * @param {number} duration - The audio duration.
+ * @return {boolean} Whether the duration is usable.
+ */
+function hasDuration( duration ) {
+	return Number.isFinite( duration ) && duration > 0;
+}
+
+/**
+ * Clamp a number to the supplied range.
+ *
+ * @param {number} value - The value to clamp.
+ * @param {number} min   - The minimum value.
+ * @param {number} max   - The maximum value.
+ * @return {number} The clamped value.
+ */
+function clamp( value, min, max ) {
+	return Math.max( min, Math.min( max, value ) );
+}
+
+/**
+ * Create a positioned timestamp marker for the waveform.
+ *
+ * @param {Document} documentRef - Document used to create elements.
+ * @param {string}   type        - Marker type class suffix.
+ * @return {Element} The marker element.
+ */
+function createTimeMarker( documentRef, type ) {
+	const marker = documentRef.createElement( 'div' );
+	marker.className = `wp-block-playlist__time-marker wp-block-playlist__time-marker--${ type }`;
+	marker.setAttribute( 'aria-hidden', 'true' );
+
+	const label = documentRef.createElement( 'span' );
+	label.className = 'wp-block-playlist__time-marker-label';
+	marker.appendChild( label );
+
+	return marker;
+}
+
+/**
+ * Set a marker's position and label.
+ *
+ * @param {Element} marker  - The marker element.
+ * @param {number}  percent - Marker position between 0 and 1.
+ * @param {string}  label   - Marker label.
+ */
+function setTimeMarker( marker, percent, label ) {
+	const position = clamp( percent, 0, 1 );
+
+	marker.style.left = `${ position * 100 }%`;
+	marker.querySelector(
+		'.wp-block-playlist__time-marker-label'
+	).textContent = label;
+	marker.classList.add( 'is-visible' );
+
+	if ( position < 0.05 ) {
+		marker.style.setProperty(
+			'--wp-playlist-time-marker-label-offset',
+			'0'
+		);
+	} else {
+		marker.style.setProperty(
+			'--wp-playlist-time-marker-label-offset',
+			'calc(-100% - 0.35rem)'
+		);
+	}
+}
+
+/**
+ * Set up current, hover, and duration timestamp markers on the waveform.
+ *
+ * @param {Object}  instance  - The WaveformPlayer library instance.
+ * @param {Element} container - The waveform container element.
+ * @param {string}  duration  - Fallback formatted duration.
+ * @return {Function} Cleanup function to remove listeners and marker elements.
+ */
+export function setupWaveformTimeMarkers( instance, container, duration ) {
+	const waveformArea = container.querySelector( '.waveform-container' );
+	const markersContainer = container.querySelector( '.waveform-markers' );
+
+	if ( ! waveformArea || ! markersContainer || ! instance?.audio ) {
+		return () => {};
+	}
+
+	const documentRef = container.ownerDocument;
+	const hoverRegion = documentRef.createElement( 'div' );
+	hoverRegion.className = 'wp-block-playlist__waveform-hover-region';
+	waveformArea.prepend( hoverRegion );
+
+	const currentMarker = createTimeMarker( documentRef, 'current' );
+	const hoverMarker = createTimeMarker( documentRef, 'hover' );
+	const endMarker = createTimeMarker( documentRef, 'end' );
+
+	markersContainer.append( currentMarker, hoverMarker, endMarker );
+
+	const getDuration = () => {
+		if ( hasDuration( instance.audio.duration ) ) {
+			return instance.audio.duration;
+		}
+
+		const fallbackDuration =
+			instance.options.durationFallback ?? parseTime( duration );
+
+		return hasDuration( fallbackDuration ) ? fallbackDuration : null;
+	};
+
+	const updateCurrentMarker = () => {
+		const durationSeconds = getDuration();
+
+		if ( ! durationSeconds ) {
+			currentMarker.classList.remove( 'is-visible' );
+			return;
+		}
+
+		setTimeMarker(
+			currentMarker,
+			instance.audio.currentTime / durationSeconds,
+			formatTime( instance.audio.currentTime )
+		);
+	};
+
+	const updateDurationMarkers = () => {
+		const durationSeconds = getDuration();
+
+		if ( ! durationSeconds ) {
+			endMarker.classList.remove( 'is-visible' );
+			updateCurrentMarker();
+			return;
+		}
+
+		setTimeMarker( endMarker, 1, formatTime( durationSeconds ) );
+		updateCurrentMarker();
+	};
+
+	const updateHoverMarker = ( event ) => {
+		const durationSeconds = getDuration();
+
+		if ( ! durationSeconds ) {
+			return;
+		}
+
+		const rect = waveformArea.getBoundingClientRect();
+		const percent = clamp(
+			( event.clientX - rect.left ) / rect.width,
+			0,
+			1
+		);
+
+		waveformArea.classList.add( 'is-hovering' );
+		hoverRegion.style.width = `${ percent * 100 }%`;
+		setTimeMarker(
+			hoverMarker,
+			percent,
+			formatTime( durationSeconds * percent )
+		);
+	};
+
+	const hideHoverMarker = () => {
+		waveformArea.classList.remove( 'is-hovering' );
+		hoverMarker.classList.remove( 'is-visible' );
+		hoverRegion.style.width = '0';
+	};
+
+	waveformArea.addEventListener( 'mousemove', updateHoverMarker );
+	waveformArea.addEventListener( 'mouseleave', hideHoverMarker );
+	instance.audio.addEventListener( 'loadedmetadata', updateDurationMarkers );
+	instance.audio.addEventListener( 'durationchange', updateDurationMarkers );
+	instance.audio.addEventListener( 'timeupdate', updateCurrentMarker );
+	container.addEventListener(
+		'waveformplayer:timeupdate',
+		updateCurrentMarker
+	);
+	container.addEventListener( 'waveformplayer:ended', updateCurrentMarker );
+
+	updateDurationMarkers();
+
+	return () => {
+		waveformArea.removeEventListener( 'mousemove', updateHoverMarker );
+		waveformArea.removeEventListener( 'mouseleave', hideHoverMarker );
+		instance.audio.removeEventListener(
+			'loadedmetadata',
+			updateDurationMarkers
+		);
+		instance.audio.removeEventListener(
+			'durationchange',
+			updateDurationMarkers
+		);
+		instance.audio.removeEventListener( 'timeupdate', updateCurrentMarker );
+		container.removeEventListener(
+			'waveformplayer:timeupdate',
+			updateCurrentMarker
+		);
+		container.removeEventListener(
+			'waveformplayer:ended',
+			updateCurrentMarker
+		);
+		currentMarker.remove();
+		hoverMarker.remove();
+		endMarker.remove();
+		hoverRegion.remove();
+	};
+}
+
+/**
  * Initialize a WaveformPlayer instance on an element.
  *
  * This is the shared core logic used by both the React component (editor)
@@ -167,6 +408,7 @@ export function logPlayError( error ) {
  * @param {string}   options.artist        - The artist name.
  * @param {string}   options.image         - The artwork image URL.
  * @param {boolean}  options.autoPlay      - Whether to auto-play when ready.
+ * @param {string}   options.duration      - Fallback formatted duration.
  * @param {Function} options.onEnded       - Callback when track ends.
  * @param {Object}   options.labels        - Translated button labels.
  * @param {string}   options.waveformStyle - Waveform style (bars, mirror, line, blocks, dots, seekbar).
@@ -174,7 +416,17 @@ export function logPlayError( error ) {
  */
 export function initWaveformPlayer(
 	element,
-	{ src, title, artist, image, autoPlay, onEnded, labels, waveformStyle }
+	{
+		src,
+		title,
+		artist,
+		image,
+		duration,
+		autoPlay,
+		onEnded,
+		labels,
+		waveformStyle,
+	}
 ) {
 	// Get colors from computed styles.
 	const { textColor, waveformColor, progressColor } =
@@ -195,6 +447,12 @@ export function initWaveformPlayer(
 
 	// Initialize the WaveformPlayer library.
 	const instance = new WaveformPlayerLib( container );
+	instance.options.durationFallback = parseTime( duration );
+	const cleanupTimeMarkers = setupWaveformTimeMarkers(
+		instance,
+		container,
+		duration
+	);
 
 	// Set up event handlers.
 	let cleanupAccessibility;
@@ -221,6 +479,7 @@ export function initWaveformPlayer(
 		container,
 		destroy: () => {
 			cleanupAccessibility?.();
+			cleanupTimeMarkers();
 			container.removeEventListener(
 				'waveformplayer:ready',
 				handlers.ready

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -69,10 +69,36 @@ function getComputedStyle( element ) {
  */
 export function getWaveformColors( element ) {
 	const textColor = getComputedStyle( element ).color;
+	const backgroundColor = getBackgroundColor( element, textColor );
 	const waveformColor = colord( textColor ).alpha( 0.3 ).toRgbString();
-	const progressColor = colord( textColor ).alpha( 0.6 ).toRgbString();
+	const progressColor = colord( backgroundColor ).alpha( 0.3 ).toRgbString();
 
 	return { textColor, waveformColor, progressColor };
+}
+
+/**
+ * Get the nearest opaque background color for an element.
+ *
+ * @param {Element} element   - The element to inspect.
+ * @param {string}  textColor - The text color used to infer a fallback.
+ * @return {string} The resolved background color.
+ */
+function getBackgroundColor( element, textColor ) {
+	let currentElement = element;
+
+	while ( currentElement ) {
+		const backgroundColor =
+			getComputedStyle( currentElement ).backgroundColor;
+		const parsedBackgroundColor = colord( backgroundColor );
+
+		if ( parsedBackgroundColor.toRgb().a > 0 ) {
+			return parsedBackgroundColor.alpha( 1 ).toRgbString();
+		}
+
+		currentElement = currentElement.parentElement;
+	}
+
+	return colord( textColor ).isDark() ? '#ffffff' : '#000000';
 }
 
 /**
@@ -223,6 +249,20 @@ function toOpaqueColor( color ) {
 }
 
 /**
+ * Get a 2D canvas context when available.
+ *
+ * @param {HTMLCanvasElement} canvas - The canvas element.
+ * @return {CanvasRenderingContext2D|null} The canvas context.
+ */
+function getCanvasContext( canvas ) {
+	try {
+		return canvas.getContext?.( '2d' ) ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Create a positioned timestamp marker for the waveform.
  *
  * @param {Document} documentRef - Document used to create elements.
@@ -285,13 +325,24 @@ export function setupWaveformTimeMarkers( instance, container ) {
 	}
 
 	const documentRef = container.ownerDocument;
+	const progressRegion = documentRef.createElement( 'div' );
+	progressRegion.className = 'wp-block-playlist__waveform-progress-region';
+	waveformArea.prepend( progressRegion );
+
 	const hoverRegion = documentRef.createElement( 'div' );
 	hoverRegion.className = 'wp-block-playlist__waveform-hover-region';
 	waveformArea.prepend( hoverRegion );
 
+	const hoverCanvas = documentRef.createElement( 'canvas' );
+	hoverCanvas.className = 'wp-block-playlist__waveform-hover-canvas';
+	hoverCanvas.setAttribute( 'aria-hidden', 'true' );
+	waveformArea.append( hoverCanvas );
+
 	const currentMarker = createTimeMarker( documentRef, 'current' );
 	const endMarker = createTimeMarker( documentRef, 'end' );
 	const hoverMarker = createTimeMarker( documentRef, 'hover' );
+	let hoverPercent = null;
+	let hideHoverMarkerTimeout;
 
 	markersContainer.append( currentMarker, endMarker, hoverMarker );
 
@@ -315,10 +366,71 @@ export function setupWaveformTimeMarkers( instance, container ) {
 
 	const getMarkerColor = () => {
 		return (
+			instance.options.buttonColor ||
 			instance.options.waveformColor ||
-			instance.options.progressColor ||
-			instance.options.buttonColor
+			instance.options.progressColor
 		);
+	};
+
+	const getSectionMarkerColor = ( percent, progress ) => {
+		const color =
+			percent <= progress
+				? instance.options.progressColor || getMarkerColor()
+				: instance.options.waveformColor || getMarkerColor();
+
+		return toOpaqueColor( color );
+	};
+
+	const clearHoverWaveform = () => {
+		hoverCanvas.style.clipPath = 'inset(0 100% 0 0)';
+
+		const context = getCanvasContext( hoverCanvas );
+		context?.clearRect( 0, 0, hoverCanvas.width, hoverCanvas.height );
+	};
+
+	const updateHoverWaveform = ( percent ) => {
+		const sourceCanvas = instance.canvas;
+
+		hoverCanvas.style.clipPath = `inset(0 ${
+			( 1 - percent ) * 100
+		}% 0 0)`;
+
+		if ( ! sourceCanvas ) {
+			return;
+		}
+
+		const width = sourceCanvas.width;
+		const height = sourceCanvas.height;
+		const context = getCanvasContext( hoverCanvas );
+
+		if ( ! width || ! height || ! context ) {
+			return;
+		}
+
+		if ( hoverCanvas.width !== width ) {
+			hoverCanvas.width = width;
+		}
+		if ( hoverCanvas.height !== height ) {
+			hoverCanvas.height = height;
+		}
+
+		try {
+			context.clearRect( 0, 0, width, height );
+			context.drawImage( sourceCanvas, 0, 0 );
+
+			const imageData = context.getImageData( 0, 0, width, height );
+			const { data } = imageData;
+
+			for ( let index = 3; index < data.length; index += 4 ) {
+				if ( data[ index ] > 0 ) {
+					data[ index ] = 255;
+				}
+			}
+
+			context.putImageData( imageData, 0, 0 );
+		} catch {
+			context.clearRect( 0, 0, width, height );
+		}
 	};
 
 	const updateTimeMarkers = () => {
@@ -326,11 +438,23 @@ export function setupWaveformTimeMarkers( instance, container ) {
 		const currentTime = Number.isFinite( instance.audio.currentTime )
 			? instance.audio.currentTime
 			: 0;
-		const markerColor = toOpaqueColor( getMarkerColor() );
+		const progress = durationSeconds
+			? clamp( currentTime / durationSeconds, 0, 1 )
+			: 0;
 
-		currentMarker.style.color = markerColor;
-		endMarker.style.color = markerColor;
+		currentMarker.style.color = durationSeconds
+			? getSectionMarkerColor( progress, progress )
+			: toOpaqueColor( instance.options.waveformColor );
+		endMarker.style.color = getSectionMarkerColor( 1, progress );
+		progressRegion.style.backgroundColor = toOpaqueColor(
+			instance.options.buttonColor
+		);
+		progressRegion.style.width = `${ progress * 100 }%`;
 		ensureTimeMarkers();
+
+		if ( hoverPercent !== null ) {
+			updateHoverWaveform( hoverPercent );
+		}
 
 		if ( ! durationSeconds ) {
 			setTimeMarker( currentMarker, 0, formatTime( currentTime ) );
@@ -340,7 +464,7 @@ export function setupWaveformTimeMarkers( instance, container ) {
 
 		setTimeMarker(
 			currentMarker,
-			currentTime / durationSeconds,
+			progress,
 			formatTime( clamp( currentTime, 0, durationSeconds ) )
 		);
 		setTimeMarker( endMarker, 1, formatTime( durationSeconds ) );
@@ -359,13 +483,16 @@ export function setupWaveformTimeMarkers( instance, container ) {
 			0,
 			1
 		);
+		const currentTime = Number.isFinite( instance.audio.currentTime )
+			? instance.audio.currentTime
+			: 0;
+		const progress = clamp( currentTime / durationSeconds, 0, 1 );
 
-		const markerColor = getMarkerColor();
-		const opaqueMarkerColor = toOpaqueColor( markerColor );
+		hoverPercent = percent;
 		waveformArea.classList.add( 'is-hovering' );
 		hoverRegion.style.width = `${ percent * 100 }%`;
-		hoverMarker.style.backgroundColor = opaqueMarkerColor;
-		hoverMarker.style.color = opaqueMarkerColor;
+		hoverMarker.style.color = getSectionMarkerColor( percent, progress );
+		updateHoverWaveform( percent );
 		ensureTimeMarkers();
 		setTimeMarker(
 			hoverMarker,
@@ -374,10 +501,19 @@ export function setupWaveformTimeMarkers( instance, container ) {
 		);
 	};
 
+	const hideHoverMarkerAfterSeek = () => {
+		clearTimeout( hideHoverMarkerTimeout );
+		hideHoverMarkerTimeout = setTimeout( () => {
+			hoverMarker.classList.remove( 'is-visible' );
+		}, 0 );
+	};
+
 	const hideHoverMarker = () => {
 		waveformArea.classList.remove( 'is-hovering' );
 		hoverMarker.classList.remove( 'is-visible' );
+		hoverPercent = null;
 		hoverRegion.style.width = '0';
+		clearHoverWaveform();
 	};
 
 	const previousOnTimeUpdate = instance.options.onTimeUpdate;
@@ -387,6 +523,7 @@ export function setupWaveformTimeMarkers( instance, container ) {
 	};
 
 	waveformArea.addEventListener( 'mousemove', updateHoverMarker );
+	waveformArea.addEventListener( 'click', hideHoverMarkerAfterSeek );
 	waveformArea.addEventListener( 'mouseleave', hideHoverMarker );
 	instance.audio.addEventListener( 'loadedmetadata', updateTimeMarkers );
 	instance.audio.addEventListener( 'durationchange', updateTimeMarkers );
@@ -395,7 +532,9 @@ export function setupWaveformTimeMarkers( instance, container ) {
 	updateTimeMarkers();
 
 	return () => {
+		clearTimeout( hideHoverMarkerTimeout );
 		waveformArea.removeEventListener( 'mousemove', updateHoverMarker );
+		waveformArea.removeEventListener( 'click', hideHoverMarkerAfterSeek );
 		waveformArea.removeEventListener( 'mouseleave', hideHoverMarker );
 		instance.audio.removeEventListener(
 			'loadedmetadata',
@@ -409,12 +548,15 @@ export function setupWaveformTimeMarkers( instance, container ) {
 			'waveformplayer:ended',
 			updateTimeMarkers
 		);
+		clearHoverWaveform();
 		instance.options.onTimeUpdate = previousOnTimeUpdate;
 		markersContainer
 			.querySelectorAll( '.wp-block-playlist__time-marker' )
 			.forEach( ( marker ) => marker.remove() );
 		hoverMarker.remove();
 		hoverRegion.remove();
+		hoverCanvas.remove();
+		progressRegion.remove();
 	};
 }
 

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -308,6 +308,10 @@ function decorateWaveformPlayerMarkers( markersContainer ) {
 			'wp-block-playlist__time-marker--current',
 			'is-visible'
 		);
+		// These markers are decorative time labels, so keep them out of the
+		// tab order and hidden from assistive technology.
+		currentMarker.tabIndex = -1;
+		currentMarker.setAttribute( 'aria-hidden', 'true' );
 		currentMarker.style.color = toOpaqueColor(
 			currentMarker.style.backgroundColor
 		);
@@ -325,6 +329,8 @@ function decorateWaveformPlayerMarkers( markersContainer ) {
 			'wp-block-playlist__time-marker--end',
 			'is-visible'
 		);
+		endMarker.tabIndex = -1;
+		endMarker.setAttribute( 'aria-hidden', 'true' );
 		endMarker.style.color = toOpaqueColor(
 			endMarker.style.backgroundColor
 		);

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -220,12 +220,12 @@ function clamp( value, min, max ) {
  * @return {Element} The marker element.
  */
 function createTimeMarker( documentRef, type ) {
-	const marker = documentRef.createElement( 'div' );
-	marker.className = `wp-block-playlist__time-marker wp-block-playlist__time-marker--${ type }`;
+	const marker = documentRef.createElement( 'button' );
+	marker.className = `waveform-marker wp-block-playlist__time-marker wp-block-playlist__time-marker--${ type }`;
 	marker.setAttribute( 'aria-hidden', 'true' );
 
 	const label = documentRef.createElement( 'span' );
-	label.className = 'wp-block-playlist__time-marker-label';
+	label.className = 'waveform-marker-tooltip';
 	marker.appendChild( label );
 
 	return marker;
@@ -242,9 +242,7 @@ function setTimeMarker( marker, percent, label ) {
 	const position = clamp( percent, 0, 1 );
 
 	marker.style.left = `${ position * 100 }%`;
-	marker.querySelector(
-		'.wp-block-playlist__time-marker-label'
-	).textContent = label;
+	marker.querySelector( '.waveform-marker-tooltip' ).textContent = label;
 	marker.classList.add( 'is-visible' );
 
 	if ( position < 0.05 ) {
@@ -341,8 +339,6 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 	waveformArea.prepend( hoverRegion );
 
 	const hoverMarker = createTimeMarker( documentRef, 'hover' );
-	const fallbackCurrentMarker = createTimeMarker( documentRef, 'current' );
-	const fallbackEndMarker = createTimeMarker( documentRef, 'end' );
 
 	markersContainer.append( hoverMarker );
 
@@ -367,37 +363,6 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 		return instance.options.progressColor || instance.options.buttonColor;
 	};
 
-	const showFallbackMarkers = () => {
-		const durationSeconds = getDuration();
-
-		if ( ! durationSeconds ) {
-			fallbackCurrentMarker.classList.remove( 'is-visible' );
-			fallbackEndMarker.classList.remove( 'is-visible' );
-			return;
-		}
-
-		if ( ! fallbackCurrentMarker.parentElement ) {
-			markersContainer.append( fallbackCurrentMarker );
-		}
-		if ( ! fallbackEndMarker.parentElement ) {
-			markersContainer.append( fallbackEndMarker );
-		}
-
-		setTimeMarker(
-			fallbackCurrentMarker,
-			instance.audio.currentTime / durationSeconds,
-			formatTime( instance.audio.currentTime )
-		);
-		setTimeMarker( fallbackEndMarker, 1, formatTime( durationSeconds ) );
-	};
-
-	const hideFallbackMarkers = () => {
-		fallbackCurrentMarker.classList.remove( 'is-visible' );
-		fallbackEndMarker.classList.remove( 'is-visible' );
-		fallbackCurrentMarker.remove();
-		fallbackEndMarker.remove();
-	};
-
 	const updateWaveformPlayerMarkers = () => {
 		const durationSeconds = getDuration();
 
@@ -405,7 +370,6 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 			instance.options.markers = [];
 			instance.renderMarkers();
 			ensureHoverMarker();
-			showFallbackMarkers();
 			return;
 		}
 
@@ -413,11 +377,9 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 			instance.options.markers = [];
 			instance.renderMarkers();
 			ensureHoverMarker();
-			showFallbackMarkers();
 			return;
 		}
 
-		hideFallbackMarkers();
 		instance.options.markers = createWaveformPlayerMarkers(
 			instance.audio.currentTime,
 			durationSeconds,
@@ -458,6 +420,12 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 		hoverRegion.style.width = '0';
 	};
 
+	const previousOnTimeUpdate = instance.options.onTimeUpdate;
+	instance.options.onTimeUpdate = ( currentTime, trackDuration, player ) => {
+		previousOnTimeUpdate?.( currentTime, trackDuration, player );
+		updateWaveformPlayerMarkers();
+	};
+
 	waveformArea.addEventListener( 'mousemove', updateHoverMarker );
 	waveformArea.addEventListener( 'mouseleave', hideHoverMarker );
 	instance.audio.addEventListener(
@@ -466,14 +434,6 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 	);
 	instance.audio.addEventListener(
 		'durationchange',
-		updateWaveformPlayerMarkers
-	);
-	instance.audio.addEventListener(
-		'timeupdate',
-		updateWaveformPlayerMarkers
-	);
-	container.addEventListener(
-		'waveformplayer:timeupdate',
 		updateWaveformPlayerMarkers
 	);
 	container.addEventListener(
@@ -494,24 +454,15 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 			'durationchange',
 			updateWaveformPlayerMarkers
 		);
-		instance.audio.removeEventListener(
-			'timeupdate',
-			updateWaveformPlayerMarkers
-		);
-		container.removeEventListener(
-			'waveformplayer:timeupdate',
-			updateWaveformPlayerMarkers
-		);
 		container.removeEventListener(
 			'waveformplayer:ended',
 			updateWaveformPlayerMarkers
 		);
+		instance.options.onTimeUpdate = previousOnTimeUpdate;
 		markersContainer
 			.querySelectorAll( '.wp-block-playlist__time-marker' )
 			.forEach( ( marker ) => marker.remove() );
 		hoverMarker.remove();
-		fallbackCurrentMarker.remove();
-		fallbackEndMarker.remove();
 		hoverRegion.remove();
 	};
 }

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -391,9 +391,7 @@ export function setupWaveformTimeMarkers( instance, container ) {
 	const updateHoverWaveform = ( percent ) => {
 		const sourceCanvas = instance.canvas;
 
-		hoverCanvas.style.clipPath = `inset(0 ${
-			( 1 - percent ) * 100
-		}% 0 0)`;
+		hoverCanvas.style.clipPath = `inset(0 ${ ( 1 - percent ) * 100 }% 0 0)`;
 
 		if ( ! sourceCanvas ) {
 			return;

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -340,10 +340,9 @@ function decorateWaveformPlayerMarkers( markersContainer ) {
  *
  * @param {Object}  instance  - The WaveformPlayer library instance.
  * @param {Element} container - The waveform container element.
- * @param {string}  duration  - Fallback formatted duration.
  * @return {Function} Cleanup function to remove listeners and marker elements.
  */
-export function setupWaveformTimeMarkers( instance, container, duration ) {
+export function setupWaveformTimeMarkers( instance, container ) {
 	const waveformArea = container.querySelector( '.waveform-container' );
 	const markersContainer = container.querySelector( '.waveform-markers' );
 
@@ -371,8 +370,7 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 			return instance.audio.duration;
 		}
 
-		const fallbackDuration =
-			instance.options.durationFallback ?? parseTime( duration );
+		const fallbackDuration = instance.options.durationFallback;
 
 		return hasDuration( fallbackDuration ) ? fallbackDuration : null;
 	};
@@ -545,11 +543,7 @@ export function initWaveformPlayer(
 	// Initialize the WaveformPlayer library.
 	const instance = new WaveformPlayerLib( container );
 	instance.options.durationFallback = parseTime( duration );
-	const cleanupTimeMarkers = setupWaveformTimeMarkers(
-		instance,
-		container,
-		duration
-	);
+	const cleanupTimeMarkers = setupWaveformTimeMarkers( instance, container );
 
 	// Set up event handlers.
 	let cleanupAccessibility;

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -270,78 +270,6 @@ function setTimeMarker( marker, percent, label ) {
 }
 
 /**
- * Create marker data for WaveformPlayer's marker API.
- *
- * @param {number} currentTime - The current playback position.
- * @param {number} duration    - The track duration.
- * @param {string} color       - Marker color.
- * @return {Array} WaveformPlayer marker objects.
- */
-function createWaveformPlayerMarkers( currentTime, duration, color ) {
-	const clampedCurrentTime = clamp( currentTime, 0, duration );
-	return [
-		{
-			time: clampedCurrentTime,
-			label: formatTime( clampedCurrentTime ),
-			color,
-		},
-		{
-			time: duration,
-			label: formatTime( duration ),
-			color,
-		},
-	];
-}
-
-/**
- * Add Playlist-specific marker classes after WaveformPlayer renders markers.
- *
- * @param {Element} markersContainer - WaveformPlayer markers container.
- */
-function decorateWaveformPlayerMarkers( markersContainer ) {
-	const [ currentMarker, endMarker ] =
-		markersContainer.querySelectorAll( '.waveform-marker' );
-
-	if ( currentMarker ) {
-		currentMarker.classList.add(
-			'wp-block-playlist__time-marker',
-			'wp-block-playlist__time-marker--current',
-			'is-visible'
-		);
-		// These markers are decorative time labels, so keep them out of the
-		// tab order and hidden from assistive technology.
-		currentMarker.tabIndex = -1;
-		currentMarker.setAttribute( 'aria-hidden', 'true' );
-		currentMarker.style.color = toOpaqueColor(
-			currentMarker.style.backgroundColor
-		);
-		currentMarker.style.setProperty(
-			'--wp-playlist-time-marker-label-offset',
-			parseFloat( currentMarker.style.left ) < 5
-				? '0'
-				: 'calc(-100% - 0.35rem)'
-		);
-	}
-
-	if ( endMarker ) {
-		endMarker.classList.add(
-			'wp-block-playlist__time-marker',
-			'wp-block-playlist__time-marker--end',
-			'is-visible'
-		);
-		endMarker.tabIndex = -1;
-		endMarker.setAttribute( 'aria-hidden', 'true' );
-		endMarker.style.color = toOpaqueColor(
-			endMarker.style.backgroundColor
-		);
-		endMarker.style.setProperty(
-			'--wp-playlist-time-marker-label-offset',
-			'calc(-100% - 0.35rem)'
-		);
-	}
-}
-
-/**
  * Set up current, hover, and duration timestamp markers on the waveform.
  *
  * @param {Object}  instance  - The WaveformPlayer library instance.
@@ -361,14 +289,18 @@ export function setupWaveformTimeMarkers( instance, container ) {
 	hoverRegion.className = 'wp-block-playlist__waveform-hover-region';
 	waveformArea.prepend( hoverRegion );
 
+	const currentMarker = createTimeMarker( documentRef, 'current' );
+	const endMarker = createTimeMarker( documentRef, 'end' );
 	const hoverMarker = createTimeMarker( documentRef, 'hover' );
 
-	markersContainer.append( hoverMarker );
+	markersContainer.append( currentMarker, endMarker, hoverMarker );
 
-	const ensureHoverMarker = () => {
-		if ( ! hoverMarker.parentElement ) {
-			markersContainer.append( hoverMarker );
-		}
+	const ensureTimeMarkers = () => {
+		[ currentMarker, endMarker, hoverMarker ].forEach( ( marker ) => {
+			if ( ! marker.parentElement ) {
+				markersContainer.append( marker );
+			}
+		} );
 	};
 
 	const getDuration = () => {
@@ -389,31 +321,29 @@ export function setupWaveformTimeMarkers( instance, container ) {
 		);
 	};
 
-	const updateWaveformPlayerMarkers = () => {
+	const updateTimeMarkers = () => {
 		const durationSeconds = getDuration();
+		const currentTime = Number.isFinite( instance.audio.currentTime )
+			? instance.audio.currentTime
+			: 0;
+		const markerColor = toOpaqueColor( getMarkerColor() );
+
+		currentMarker.style.color = markerColor;
+		endMarker.style.color = markerColor;
+		ensureTimeMarkers();
 
 		if ( ! durationSeconds ) {
-			instance.options.markers = [];
-			instance.renderMarkers();
-			ensureHoverMarker();
+			setTimeMarker( currentMarker, 0, formatTime( currentTime ) );
+			endMarker.classList.remove( 'is-visible' );
 			return;
 		}
 
-		if ( ! hasDuration( instance.audio.duration ) ) {
-			instance.options.markers = [];
-			instance.renderMarkers();
-			ensureHoverMarker();
-			return;
-		}
-
-		instance.options.markers = createWaveformPlayerMarkers(
-			instance.audio.currentTime,
-			durationSeconds,
-			getMarkerColor()
+		setTimeMarker(
+			currentMarker,
+			currentTime / durationSeconds,
+			formatTime( clamp( currentTime, 0, durationSeconds ) )
 		);
-		instance.renderMarkers();
-		ensureHoverMarker();
-		decorateWaveformPlayerMarkers( markersContainer );
+		setTimeMarker( endMarker, 1, formatTime( durationSeconds ) );
 	};
 
 	const updateHoverMarker = ( event ) => {
@@ -431,11 +361,12 @@ export function setupWaveformTimeMarkers( instance, container ) {
 		);
 
 		const markerColor = getMarkerColor();
+		const opaqueMarkerColor = toOpaqueColor( markerColor );
 		waveformArea.classList.add( 'is-hovering' );
 		hoverRegion.style.width = `${ percent * 100 }%`;
-		hoverMarker.style.backgroundColor = markerColor;
-		hoverMarker.style.color = toOpaqueColor( markerColor );
-		ensureHoverMarker();
+		hoverMarker.style.backgroundColor = opaqueMarkerColor;
+		hoverMarker.style.color = opaqueMarkerColor;
+		ensureTimeMarkers();
 		setTimeMarker(
 			hoverMarker,
 			percent,
@@ -452,40 +383,31 @@ export function setupWaveformTimeMarkers( instance, container ) {
 	const previousOnTimeUpdate = instance.options.onTimeUpdate;
 	instance.options.onTimeUpdate = ( currentTime, trackDuration, player ) => {
 		previousOnTimeUpdate?.( currentTime, trackDuration, player );
-		updateWaveformPlayerMarkers();
+		updateTimeMarkers();
 	};
 
 	waveformArea.addEventListener( 'mousemove', updateHoverMarker );
 	waveformArea.addEventListener( 'mouseleave', hideHoverMarker );
-	instance.audio.addEventListener(
-		'loadedmetadata',
-		updateWaveformPlayerMarkers
-	);
-	instance.audio.addEventListener(
-		'durationchange',
-		updateWaveformPlayerMarkers
-	);
-	container.addEventListener(
-		'waveformplayer:ended',
-		updateWaveformPlayerMarkers
-	);
+	instance.audio.addEventListener( 'loadedmetadata', updateTimeMarkers );
+	instance.audio.addEventListener( 'durationchange', updateTimeMarkers );
+	container.addEventListener( 'waveformplayer:ended', updateTimeMarkers );
 
-	updateWaveformPlayerMarkers();
+	updateTimeMarkers();
 
 	return () => {
 		waveformArea.removeEventListener( 'mousemove', updateHoverMarker );
 		waveformArea.removeEventListener( 'mouseleave', hideHoverMarker );
 		instance.audio.removeEventListener(
 			'loadedmetadata',
-			updateWaveformPlayerMarkers
+			updateTimeMarkers
 		);
 		instance.audio.removeEventListener(
 			'durationchange',
-			updateWaveformPlayerMarkers
+			updateTimeMarkers
 		);
 		container.removeEventListener(
 			'waveformplayer:ended',
-			updateWaveformPlayerMarkers
+			updateTimeMarkers
 		);
 		instance.options.onTimeUpdate = previousOnTimeUpdate;
 		markersContainer

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -540,8 +540,9 @@ export function initWaveformPlayer(
 	} );
 	element.appendChild( container );
 
-	// Initialize the WaveformPlayer library.
-	const instance = new WaveformPlayerLib( container );
+	// Initialize the WaveformPlayer library. The played/total time is hidden
+	// because the waveform timestamp markers already show this information.
+	const instance = new WaveformPlayerLib( container, { showTime: false } );
 	instance.options.durationFallback = parseTime( duration );
 	const cleanupTimeMarkers = setupWaveformTimeMarkers( instance, container );
 

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -278,10 +278,11 @@ function setTimeMarker( marker, percent, label ) {
  * @return {Array} WaveformPlayer marker objects.
  */
 function createWaveformPlayerMarkers( currentTime, duration, color ) {
+	const clampedCurrentTime = clamp( currentTime, 0, duration );
 	return [
 		{
-			time: clamp( currentTime, 0, duration ),
-			label: formatTime( currentTime ),
+			time: clampedCurrentTime,
+			label: formatTime( clampedCurrentTime ),
 			color,
 		},
 		{

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -296,6 +296,7 @@ function decorateWaveformPlayerMarkers( markersContainer ) {
 			'wp-block-playlist__time-marker--current',
 			'is-visible'
 		);
+		currentMarker.style.color = currentMarker.style.backgroundColor;
 		currentMarker.style.setProperty(
 			'--wp-playlist-time-marker-label-offset',
 			parseFloat( currentMarker.style.left ) < 5
@@ -310,6 +311,7 @@ function decorateWaveformPlayerMarkers( markersContainer ) {
 			'wp-block-playlist__time-marker--end',
 			'is-visible'
 		);
+		endMarker.style.color = endMarker.style.backgroundColor;
 		endMarker.style.setProperty(
 			'--wp-playlist-time-marker-label-offset',
 			'calc(-100% - 0.35rem)'
@@ -360,7 +362,11 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 	};
 
 	const getMarkerColor = () => {
-		return instance.options.progressColor || instance.options.buttonColor;
+		return (
+			instance.options.waveformColor ||
+			instance.options.progressColor ||
+			instance.options.buttonColor
+		);
 	};
 
 	const updateWaveformPlayerMarkers = () => {
@@ -404,8 +410,11 @@ export function setupWaveformTimeMarkers( instance, container, duration ) {
 			1
 		);
 
+		const markerColor = getMarkerColor();
 		waveformArea.classList.add( 'is-hovering' );
 		hoverRegion.style.width = `${ percent * 100 }%`;
+		hoverMarker.style.backgroundColor = markerColor;
+		hoverMarker.style.color = markerColor;
 		ensureHoverMarker();
 		setTimeMarker(
 			hoverMarker,

--- a/phpunit/blocks/render-block-playlist-test.php
+++ b/phpunit/blocks/render-block-playlist-test.php
@@ -119,6 +119,7 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 					'album'    => 'Album One',
 					'src'      => 'http://example.com/song1.mp3',
 					'image'    => 'http://example.com/image1.jpg',
+					'length'   => '3:10',
 				),
 			)
 		);
@@ -259,6 +260,7 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 		$this->assertSame( 'Artist One', $tracks['track-1']['artist'] );
 		$this->assertSame( 'Album One', $tracks['track-1']['album'] );
 		$this->assertSame( 'http://example.com/image1.jpg', $tracks['track-1']['image'] );
+		$this->assertSame( '3:10', $tracks['track-1']['length'] );
 
 		$this->assertSame( 'http://example.com/song2.mp3', $tracks['track-2']['url'] );
 		$this->assertSame( 'Song Two', $tracks['track-2']['title'] );

--- a/phpunit/blocks/render-block-playlist-test.php
+++ b/phpunit/blocks/render-block-playlist-test.php
@@ -119,7 +119,6 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 					'album'    => 'Album One',
 					'src'      => 'http://example.com/song1.mp3',
 					'image'    => 'http://example.com/image1.jpg',
-					'length'   => '3:10',
 				),
 			)
 		);
@@ -231,6 +230,7 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 					'album'    => 'Album One',
 					'src'      => 'http://example.com/song1.mp3',
 					'image'    => 'http://example.com/image1.jpg',
+					'length'   => '3:10',
 				),
 				array(
 					'id'       => 2,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds hover, current-playhead, and end-duration timestamp markers to the Playlist block waveform player, and removes the now-redundant played/total time readout from the player footer.

## Why?

The waveform previously gave no inline indication of time. These markers make seeking easier by showing the hovered time, the current playhead time, and the track duration directly on the waveform. Because that information now lives on the waveform, the separate played/total time text in the footer is redundant and has been removed.

## How?

-   The current and end-duration markers reuse the WaveformPlayer instance's marker API, positioned against the real decoded `audio.duration` and kept in sync via the player's time-update, `loadedmetadata`, and `durationchange` events.
-   A lightweight hover marker overlay follows the cursor along the waveform. When the native `audio.duration` is not yet available, the hover time falls back to the playlist track's saved `length` metadata; this fallback is updated per track so it never goes stale when switching tracks.
-   The library's built-in played/total time display is disabled (`showTime: false`) since the waveform markers now convey this.
-   The marker elements are decorative time labels (`pointer-events: none`), so they are kept out of the tab order (`tabindex="-1"`) and hidden from assistive technology (`aria-hidden`) to avoid dead keyboard tab stops.
-   The same rendering path is used in both the editor and the front end.

## Testing Instructions

1. Open a post or page and insert a **Playlist** block with one or more audio tracks.
2. Hover over the waveform and confirm a timestamp appears to the left of the hover marker and tracks the cursor.
3. Play or seek within the track and confirm the current-playhead timestamp and the end-duration timestamp are visible on the waveform.
4. Confirm the played/total time text no longer appears in the player footer.
5. Switch between tracks and confirm the markers and timestamps update for the new track. For a track without saved length metadata, confirm the hover timestamp still works once the audio metadata has loaded.
6. Publish and repeat steps 2–5 on the front end to confirm parity with the editor.

### Testing Instructions for Keyboard

1. Insert a Playlist block and select it.
2. Tab through the player and confirm focus lands on the play/pause button (Space/Enter toggles playback) and does **not** stop on the decorative timestamp markers on the waveform.
3. With a screen reader running, confirm the timestamp markers are not announced (they are decorative).

> Note: arrow-key scrubbing of the waveform currently requires clicking the player first (a pre-existing limitation of the underlying player). Making the waveform a fully keyboard-operable slider is tracked as a follow-up and is out of scope for this PR.

## Screenshots or screencast

<img width="690" height="135" alt="Screenshot 2026-06-03 at 17 59 16" src="https://github.com/user-attachments/assets/fb91c47b-d62c-4cfe-959d-f08ee9b1b024" />

## Use of AI Tools

Built with AI assistance from OpenAI Codex and Claude Code (Anthropic). All changes were reviewed and verified by the author, including in-browser verification of the keyboard/focus behaviour.
