### PR TITLE
Revert "wp-build: Replace getter-based exports with data properties"

### DIFF
--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Remove the incorrect `#wpwrap` background from wp-admin critical CSS to prevent a black flash before hydration; rely on the existing `body` background instead ([#78493](https://github.com/WordPress/gutenberg/pull/78493)).
+-   Revert the getter-based export replacement in `@wordpress/build` to restore compatibility for affected Gutenberg 23.0 builds ([#78917](https://github.com/WordPress/gutenberg/pull/78917)).
 
 ## 0.15.0 (2026-05-27)
 

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -564,35 +564,11 @@ async function bundlePackage( packageName, options = {} ) {
 			globalName,
 		};
 
-		// Compose the footer in pieces:
-		//   1. If the package has a default export, unwrap the namespace so
-		//      `globalName` IS the default value.
-		//   2. For every package that exposes a global namespace, replace
-		//      esbuild's getter-based re-exports with direct data properties.
-		//      esbuild emits each export as `Object.defineProperty(ns, k,
-		//      { get: () => binding })` to preserve ESM live-binding semantics
-		//      across hoisting; consumers then pay a getter call on every
-		//      property access. Across the editor mount that's hundreds of
-		//      thousands of getter invocations (every hook, every selector).
-		//      Once the IIFE has finished, the bindings are stable, so we can
-		//      read each getter once and replace it with a plain data
-		//      property — same value, ~2x cheaper per access in V8.
-		const footerParts = [];
+		// For packages with default exports, add a footer to properly expose the default
 		if ( packageJson.wpScriptDefaultExport && globalName ) {
-			footerParts.push(
-				`if (typeof ${ globalName } === 'object' && ${ globalName }.default) { ${ globalName } = ${ globalName }.default; }`
-			);
-		}
-		if ( globalName ) {
-			// esbuild marks the getters non-configurable, so we can't rewrite
-			// them in place; replacing the whole namespace with a shallow
-			// copy is the simplest way to materialize each value once.
-			footerParts.push(
-				`if(${ globalName }&&typeof ${ globalName }==='object'){${ globalName }=Object.assign({},${ globalName });}`
-			);
-		}
-		if ( footerParts.length ) {
-			baseConfig.footer = { js: footerParts.join( '' ) };
+			baseConfig.footer = {
+				js: `if (typeof ${ globalName } === 'object' && ${ globalName }.default) { ${ globalName } = ${ globalName }.default; }`,
+			};
 		}
 
 		const baseBundlePlugins = [


### PR DESCRIPTION
## What?

Follow up to #78303.

This PR reverts the patch introduced in #78303, which replaced getter-based exports in `@wordpress/build` with data properties.

## Why?

Gutenberg 23.0 introduced regressions tracked in https://github.com/WordPress/gutenberg/issues/78697. For additional context, see:

- https://wordpress.org/support/topic/known-issue-on-sites-with-gutenberg-23-3-0-active/

Reverting the change restores the previous behavior while we prepare a patch release. After the patch release is shipped, we can revisit the approach from #78303 and explore an alternative solution.

## How?

This reverts the changes from #78303 in `packages/wp-build/lib/build.mjs`, restoring the previous getter-based export behavior.

## Testing Instructions

1. Check out this PR.
2. Run `npm run build`.
3. Confirm the build completes successfully.
4. Visit the WordPress Admin
5. Open the console
6. Ensure that `window.wp.isShallowEqual.__esModule` isn't undefined.

### Testing Instructions for Keyboard

This PR does not change the user interface.

## Screenshots or screencast

Not applicable.
