### PR TITLE
React: add ReactCurrentOwner polyfill

### DIFF
--- a/tools/build-scripts/packages/build-vendors.mjs
+++ b/tools/build-scripts/packages/build-vendors.mjs
@@ -16,6 +16,13 @@ const VENDOR_SCRIPTS = [
 		global: 'React',
 		handle: 'react',
 		dependencies: [ 'wp-polyfill' ],
+		contents: [
+			'module.exports = {',
+			'  ...require("react"),',
+			// Polyfill React 18 internals for older versions of `framer-motion`.
+			'  __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: { ReactCurrentOwner: { current: null } },',
+			'};',
+		].join( '\n' ),
 	},
 	{
 		name: 'react-dom',
@@ -94,7 +101,7 @@ async function generateAssetFile( config ) {
  * @return {Promise<void>} Promise that resolves when all builds are finished.
  */
 async function bundleVendorScript( config ) {
-	const { name, global, handle, contents } = config;
+	const { name, global, handle, contents, dependencies } = config;
 
 	// Plugin that externalizes the `react` package.
 	const reactExternalPlugin = {
@@ -126,7 +133,9 @@ async function bundleVendorScript( config ) {
 		globalName: global,
 		target: 'esnext',
 		platform: 'browser',
-		plugins: [ reactExternalPlugin ],
+		plugins: dependencies?.includes( 'react' )
+			? [ reactExternalPlugin ]
+			: [],
 	};
 
 	if ( contents ) {


### PR DESCRIPTION
Plugins that bundle `framer-motion`, for example WooCommerce, currently crash with this error:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')
```
It's because `framer-motion`, for some reason, bundles its own version of `jsx-runtime`:

https://github.com/motiondivision/motion/blob/main/dev/inc/jsxRuntimeShim.js#L15

and that runtime, copy&pasted from React 18, references the `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` global.

This PR adds a polyfill for that to the `react` package. It's simple, the value is not really used: it's assigned to the `_owner` field of the created element, but React 19 ignores that, it doesn't use the field any more.