### PR TITLE
Media Editor: Replace the zoom slider with +/- buttons

### DIFF
--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -1,33 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { RangeControl, SelectControl } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
 import { Stack, VisuallyHidden } from '@wordpress/ui';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { useMediaEditor } from '../../state';
-import {
-	useCropGestureHandlers,
-	CROP_CONTROL_ATTR,
-} from '../../hooks/use-crop-gesture-handlers';
+import { CROP_CONTROL_ATTR } from '../../hooks/use-crop-gesture-handlers';
 import MediaEditorImageControls from '../media-editor-image-controls';
-import { MAX_ZOOM } from '../../image-editor/core/constants';
-import { getMinZoom } from '../../image-editor/core/containment';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
-
-const ZOOM_PERCENTAGE_SCALE = 100;
-const MAX_ZOOM_PERCENTAGE = MAX_ZOOM * ZOOM_PERCENTAGE_SCALE;
-
-function getZoomPercentageForDisplay( zoom: number ): number {
-	return Math.round( zoom * ZOOM_PERCENTAGE_SCALE );
-}
-
-function getMinZoomPercentageForDisplay( zoom: number ): number {
-	return Math.ceil( zoom * ZOOM_PERCENTAGE_SCALE );
-}
 
 export interface MediaEditorCropPanelProps {
 	/**
@@ -38,12 +21,10 @@ export interface MediaEditorCropPanelProps {
 	aspectRatioValue: string;
 	/** Setter for the aspect-ratio preset value. */
 	onAspectRatioChange: ( value: string ) => void;
-	/** Signal that a placement-oriented control is being adjusted. */
-	onPlacementControlInteraction?: () => void;
 	/** Aspect-ratio presets to display in the selector. */
 	aspectRatioOptions: AspectRatioPreset[];
 	/**
-	 * When `true`, render the rotate/flip transform controls at the top of
+	 * When `true`, render the rotate/flip/zoom image controls at the top of
 	 * the panel. Used on wide viewports where the footer no longer carries
 	 * them.
 	 */
@@ -51,28 +32,21 @@ export interface MediaEditorCropPanelProps {
 }
 
 /**
- * Sidebar panel for crop-shape controls. The tactile verbs (rotate, flip)
- * live in the bottom toolbar instead.
+ * Sidebar panel for crop controls. Renders the aspect-ratio selector, plus the
+ * rotate/flip and zoom controls on wide viewports (these move to the footer
+ * toolbar when the sidebar collapses).
  * @param props
  * @param props.aspectRatioValue
  * @param props.onAspectRatioChange
- * @param props.onPlacementControlInteraction
  * @param props.aspectRatioOptions
  * @param props.showTransformControls
  */
 export default function MediaEditorCropPanel( {
 	aspectRatioValue,
 	onAspectRatioChange,
-	onPlacementControlInteraction,
 	aspectRatioOptions,
 	showTransformControls = false,
 }: MediaEditorCropPanelProps ) {
-	const { state, setZoom } = useMediaEditor();
-	const zoomGestureHandlers = useCropGestureHandlers();
-	const minZoom = getMinZoom( state );
-	const zoomPercentage = getZoomPercentageForDisplay( state.zoom );
-	const minZoomPercentage = getMinZoomPercentageForDisplay( minZoom );
-
 	return (
 		// Tag the whole panel as a crop-control region so the modal's
 		// Cmd+Z handler doesn't mistake the SelectControl input for a
@@ -96,36 +70,6 @@ export default function MediaEditorCropPanel( {
 					value: preset.value.toString(),
 				} ) ) }
 			/>
-			<div role="presentation" { ...zoomGestureHandlers }>
-				<RangeControl
-					__next40pxDefaultSize
-					label={ __( 'Zoom (%)' ) }
-					min={ minZoomPercentage }
-					max={ MAX_ZOOM_PERCENTAGE }
-					step={ 1 }
-					shiftStep={ 10 }
-					value={ zoomPercentage }
-					onChange={ ( value ) => {
-						onPlacementControlInteraction?.();
-						setZoom(
-							typeof value === 'number'
-								? value / ZOOM_PERCENTAGE_SCALE
-								: minZoom
-						);
-					} }
-					renderTooltipContent={ ( value ) => {
-						const percentage =
-							typeof value === 'number'
-								? value
-								: minZoomPercentage;
-						return sprintf(
-							/* translators: %d: zoom level as a percentage. */
-							__( '%d%%' ),
-							Math.round( percentage )
-						);
-					} }
-				/>
-			</div>
 		</Stack>
 	);
 }

--- a/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
@@ -8,7 +8,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
  */
 import MediaEditorCropPanel from '..';
 import type { MediaEditorCropPanelProps } from '..';
-import { MediaEditorStateProvider, useMediaEditor } from '../../../state';
+import { MediaEditorStateProvider } from '../../../state';
 import type { CropperState } from '../../../image-editor';
 
 function setupCropPanel(
@@ -29,31 +29,13 @@ function setupCropPanel(
 	render(
 		<MediaEditorStateProvider initialCropperState={ initialCropperState }>
 			<MediaEditorCropPanel { ...props } />
-			<CurrentZoomValue />
 		</MediaEditorStateProvider>
 	);
 
 	return props;
 }
 
-function CurrentZoomValue() {
-	const { state } = useMediaEditor();
-
-	return <output data-testid="current-zoom">{ state.zoom }</output>;
-}
-
 describe( 'MediaEditorCropPanel', () => {
-	it( 'renders crop shape controls before zoom controls', () => {
-		setupCropPanel();
-
-		const aspectRatio = screen.getByLabelText( 'Aspect ratio' );
-		const zoom = screen.getByRole( 'slider', { name: 'Zoom (%)' } );
-
-		expect( aspectRatio.compareDocumentPosition( zoom ) ).toBe(
-			Node.DOCUMENT_POSITION_FOLLOWING
-		);
-	} );
-
 	it( 'passes selected aspect ratio changes to the caller', () => {
 		const controls = setupCropPanel( {
 			aspectRatioValue: '1',
@@ -69,54 +51,36 @@ describe( 'MediaEditorCropPanel', () => {
 		).toBe( '0' );
 	} );
 
-	it( 'displays zoom as a percentage without changing cropper state', () => {
-		setupCropPanel( {}, { zoom: 3.749999999999999 } );
-
-		const zoomInput = screen.getByRole( 'spinbutton', {
-			name: 'Zoom (%)',
-		} );
-
-		expect( zoomInput ).toHaveValue( 375 );
-		expect( screen.getByTestId( 'current-zoom' ) ).toHaveTextContent(
-			'3.749999999999999'
-		);
-	} );
-
-	it( 'converts percentage input back to the cropper zoom multiplier', () => {
-		const controls = setupCropPanel( {
-			onPlacementControlInteraction: jest.fn(),
-		} );
-
-		fireEvent.change(
-			screen.getByRole( 'spinbutton', { name: 'Zoom (%)' } ),
-			{
-				target: { value: '250' },
-			}
-		);
-
-		expect( screen.getByTestId( 'current-zoom' ) ).toHaveTextContent(
-			'2.5'
-		);
-		expect( controls.onPlacementControlInteraction ).toHaveBeenCalled();
-	} );
-
-	it( 'omits transform controls by default', () => {
+	it( 'omits the image controls by default', () => {
 		setupCropPanel();
 
 		expect( screen.queryByText( 'Rotate' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Flip' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Zoom' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders rotate and flip controls when showTransformControls is set', () => {
+	it( 'renders rotate, flip and zoom controls when showTransformControls is set', () => {
 		setupCropPanel( { showTransformControls: true } );
 
 		expect( screen.getByText( 'Rotate' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Flip' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Zoom' ) ).toBeInTheDocument();
 		expect(
 			screen.getByRole( 'button', { name: 'Rotate 90° clockwise' } )
 		).toBeInTheDocument();
 		expect(
-			screen.getByRole( 'button', { name: 'Flip horizontal' } )
+			screen.getByRole( 'button', { name: 'Zoom in' } )
 		).toBeInTheDocument();
+	} );
+
+	it( 'renders the image controls above the aspect-ratio selector', () => {
+		setupCropPanel( { showTransformControls: true } );
+
+		const rotate = screen.getByText( 'Rotate' );
+		const aspectRatio = screen.getByLabelText( 'Aspect ratio' );
+
+		expect( rotate.compareDocumentPosition( aspectRatio ) ).toBe(
+			Node.DOCUMENT_POSITION_FOLLOWING
+		);
 	} );
 } );

--- a/packages/media-editor/src/components/media-editor-image-controls/index.tsx
+++ b/packages/media-editor/src/components/media-editor-image-controls/index.tsx
@@ -15,21 +15,36 @@ import {
 	rotateRight,
 	flipHorizontal,
 	flipVertical,
+	lineSolid,
+	plus,
 } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { useMediaEditor } from '../../state';
-import type { AspectRatioPreset } from '../../image-editor/core/constants';
+import {
+	MAX_ZOOM,
+	type AspectRatioPreset,
+} from '../../image-editor/core/constants';
+import { getMinZoom } from '../../image-editor/core/containment';
 import { useCropOptions } from '../media-editor/use-crop-options';
+
+/**
+ * Default zoom factor per +/- click. Zooming is geometric, so a fixed
+ * multiplier — rather than an additive step — makes each click feel like the
+ * same amount of zoom at any level (an additive `+0.1` is a 10% jump at 1× but
+ * a ~1% nudge at 10×). `1.2` is ~+20% per click. Overridable via the
+ * `zoomFactor` prop.
+ */
+export const DEFAULT_ZOOM_FACTOR = 1.2;
 
 export interface MediaEditorImageControlsProps {
 	/**
-	 * When `true`, render rotate and flip as two labelled groups stacked
-	 * vertically — the Crop panel layout used on wide viewports. When
-	 * `false` (default), render a single flat row of icon buttons — the
-	 * footer layout used at narrower widths.
+	 * When `true`, render rotate, flip and zoom as labelled groups — the Crop
+	 * panel layout used on wide viewports. When `false` (default), render a
+	 * single flat row of icon buttons — the footer layout used at narrower
+	 * widths.
 	 */
 	withLabels?: boolean;
 	/**
@@ -40,28 +55,42 @@ export interface MediaEditorImageControlsProps {
 	showAspectRatioControl?: boolean;
 	/** Optional caller-supplied aspect-ratio presets. */
 	aspectRatioPresets?: AspectRatioPreset[];
+	/**
+	 * Multiplier applied to the zoom per +/- click — zoom in multiplies by it,
+	 * zoom out divides by it. Must be greater than 1. Defaults to
+	 * `DEFAULT_ZOOM_FACTOR` (1.2).
+	 */
+	zoomFactor?: number;
 }
 
 /**
- * Image editing controls that can be placed independently per viewport: on
- * wide viewports rotate/flip render inside the Crop panel (`withLabels`), and
- * at narrower widths they fall back into the footer toolbar (flat row), where
- * the aspect-ratio dropdown can also be shown.
+ * Image editing controls placed independently per viewport: on wide viewports
+ * rotate/flip/zoom render inside the Crop panel (`withLabels`), and at narrower
+ * widths they fall back into the footer toolbar (flat row), where the
+ * aspect-ratio dropdown can also be shown.
  *
  * @param props
  * @param props.withLabels
  * @param props.showAspectRatioControl
  * @param props.aspectRatioPresets
+ * @param props.zoomFactor
  */
 export default function MediaEditorImageControls( {
 	withLabels = false,
 	showAspectRatioControl = false,
 	aspectRatioPresets,
+	zoomFactor = DEFAULT_ZOOM_FACTOR,
 }: MediaEditorImageControlsProps ) {
-	const { state, setFlip, snapRotate90 } = useMediaEditor();
+	const { state, setFlip, snapRotate90, setZoom } = useMediaEditor();
 	const { aspectRatioValue, setAspectRatioValue, aspectRatioOptions } =
 		useCropOptions( { aspectRatioPresets } );
 	const hasAspectRatioControl = ! withLabels && showAspectRatioControl;
+	const minZoom = getMinZoom( state );
+	const zoomByFactor = ( factor: number ) => {
+		setZoom(
+			Math.min( MAX_ZOOM, Math.max( minZoom, state.zoom * factor ) )
+		);
+	};
 
 	const rotateButtons = (
 		<>
@@ -113,6 +142,29 @@ export default function MediaEditorImageControls( {
 		</>
 	);
 
+	const zoomButtons = (
+		<>
+			<Button
+				size="compact"
+				icon={ plus }
+				label={ __( 'Zoom in' ) }
+				showTooltip
+				disabled={ state.zoom >= MAX_ZOOM }
+				accessibleWhenDisabled
+				onClick={ () => zoomByFactor( zoomFactor ) }
+			/>
+			<Button
+				size="compact"
+				icon={ lineSolid }
+				label={ __( 'Zoom out' ) }
+				showTooltip
+				disabled={ state.zoom <= minZoom }
+				accessibleWhenDisabled
+				onClick={ () => zoomByFactor( 1 / zoomFactor ) }
+			/>
+		</>
+	);
+
 	const aspectRatioDropdown = hasAspectRatioControl ? (
 		<DropdownMenu
 			icon={ aspectRatioIcon }
@@ -148,34 +200,51 @@ export default function MediaEditorImageControls( {
 	if ( withLabels ) {
 		return (
 			<div className="media-editor-image-controls is-stacked">
-				<div
-					className="media-editor-image-controls__group"
-					role="group"
-					aria-label={ __( 'Rotate' ) }
-				>
-					<span
-						className="media-editor-image-controls__label"
-						aria-hidden="true"
+				<div className="media-editor-image-controls__transforms">
+					<div
+						className="media-editor-image-controls__group"
+						role="group"
+						aria-label={ __( 'Rotate' ) }
 					>
-						{ __( 'Rotate' ) }
-					</span>
-					<div className="media-editor-image-controls__buttons">
-						{ rotateButtons }
+						<span
+							className="media-editor-image-controls__label"
+							aria-hidden="true"
+						>
+							{ __( 'Rotate' ) }
+						</span>
+						<div className="media-editor-image-controls__buttons">
+							{ rotateButtons }
+						</div>
+					</div>
+					<div
+						className="media-editor-image-controls__group"
+						role="group"
+						aria-label={ __( 'Flip' ) }
+					>
+						<span
+							className="media-editor-image-controls__label"
+							aria-hidden="true"
+						>
+							{ __( 'Flip' ) }
+						</span>
+						<div className="media-editor-image-controls__buttons">
+							{ flipButtons }
+						</div>
 					</div>
 				</div>
 				<div
 					className="media-editor-image-controls__group"
 					role="group"
-					aria-label={ __( 'Flip' ) }
+					aria-label={ __( 'Zoom' ) }
 				>
 					<span
 						className="media-editor-image-controls__label"
 						aria-hidden="true"
 					>
-						{ __( 'Flip' ) }
+						{ __( 'Zoom' ) }
 					</span>
 					<div className="media-editor-image-controls__buttons">
-						{ flipButtons }
+						{ zoomButtons }
 					</div>
 				</div>
 			</div>
@@ -186,6 +255,7 @@ export default function MediaEditorImageControls( {
 		<div className="media-editor-image-controls">
 			{ rotateButtons }
 			{ flipButtons }
+			{ zoomButtons }
 			{ aspectRatioDropdown }
 		</div>
 	);

--- a/packages/media-editor/src/components/media-editor-image-controls/style.scss
+++ b/packages/media-editor/src/components/media-editor-image-controls/style.scss
@@ -7,13 +7,19 @@
 	align-items: center;
 	gap: $grid-unit-10;
 
-	// Stacked layout used inside the Crop panel on wide viewports: the
-	// Rotate and Flip groups sit side by side (rotate left, flip right)
-	// above the zoom and aspect-ratio controls.
+	// Stacked layout used inside the Crop panel on wide viewports: the Rotate
+	// and Flip groups sit side by side (rotate left, flip right) in a row, with
+	// the Zoom group beneath them. The aspect-ratio select renders separately
+	// below in the Crop panel.
 	&.is-stacked {
-		flex-direction: row;
+		flex-direction: column;
 		align-items: flex-start;
 		gap: $grid-unit-30;
+	}
+
+	&__transforms {
+		display: flex;
+		gap: $grid-unit-60;
 	}
 
 	&__group {

--- a/packages/media-editor/src/components/media-editor-image-controls/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-image-controls/test/index.tsx
@@ -9,28 +9,36 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import MediaEditorImageControls from '..';
 import type { MediaEditorImageControlsProps } from '..';
 import { MediaEditorStateProvider, useMediaEditor } from '../../../state';
+import type { CropperState } from '../../../image-editor';
+import { MAX_ZOOM } from '../../../image-editor/core/constants';
 
-function setup( props: MediaEditorImageControlsProps = {} ) {
+function setup(
+	props: MediaEditorImageControlsProps = {},
+	initialCropperState?: Partial< CropperState >
+) {
 	render(
-		<MediaEditorStateProvider>
+		<MediaEditorStateProvider initialCropperState={ initialCropperState }>
 			<MediaEditorImageControls { ...props } />
-			<CurrentAspectRatioValue />
+			<CurrentState />
 		</MediaEditorStateProvider>
 	);
 }
 
-function CurrentAspectRatioValue() {
-	const { cropOptions } = useMediaEditor();
+function CurrentState() {
+	const { state, cropOptions } = useMediaEditor();
 
 	return (
-		<output data-testid="current-aspect-ratio">
-			{ cropOptions.aspectRatioValue }
-		</output>
+		<>
+			<output data-testid="current-aspect-ratio">
+				{ cropOptions.aspectRatioValue }
+			</output>
+			<output data-testid="current-zoom">{ state.zoom }</output>
+		</>
 	);
 }
 
 describe( 'MediaEditorImageControls', () => {
-	it( 'renders a flat row of rotate and flip buttons by default', () => {
+	it( 'renders a flat row of rotate, flip and zoom buttons by default', () => {
 		setup();
 
 		expect(
@@ -39,31 +47,75 @@ describe( 'MediaEditorImageControls', () => {
 			} )
 		).toBeInTheDocument();
 		expect(
-			screen.getByRole( 'button', { name: 'Rotate 90° clockwise' } )
-		).toBeInTheDocument();
-		expect(
 			screen.getByRole( 'button', { name: 'Flip horizontal' } )
 		).toBeInTheDocument();
 		expect(
-			screen.getByRole( 'button', { name: 'Flip vertical' } )
+			screen.getByRole( 'button', { name: 'Zoom in' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'button', { name: 'Zoom out' } )
 		).toBeInTheDocument();
 
 		// No visible group labels in the flat (footer) layout.
 		expect( screen.queryByText( 'Rotate' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Flip' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Zoom' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders labelled rotate and flip groups when withLabels is set', () => {
+	it( 'renders labelled rotate, flip and zoom groups when withLabels is set', () => {
 		setup( { withLabels: true } );
 
 		expect( screen.getByText( 'Rotate' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Flip' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Zoom' ) ).toBeInTheDocument();
 		expect(
 			screen.getByRole( 'button', { name: 'Rotate 90° clockwise' } )
 		).toBeInTheDocument();
 		expect(
-			screen.getByRole( 'button', { name: 'Flip vertical' } )
+			screen.getByRole( 'button', { name: 'Zoom in' } )
 		).toBeInTheDocument();
+	} );
+
+	it( 'zoom in multiplies the zoom and zoom out divides it', () => {
+		setup( {}, { zoom: 2 } );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Zoom in' } ) );
+		const zoomedIn = Number(
+			screen.getByTestId( 'current-zoom' ).textContent
+		);
+		expect( zoomedIn ).toBeGreaterThan( 2 );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Zoom out' } ) );
+		expect(
+			Number( screen.getByTestId( 'current-zoom' ).textContent )
+		).toBeLessThan( zoomedIn );
+	} );
+
+	it( 'honors a custom zoomFactor', () => {
+		setup( { zoomFactor: 2 }, { zoom: 2 } );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Zoom in' } ) );
+
+		// A factor of 2 from zoom 2 lands at 4 (within [minZoom, MAX_ZOOM]).
+		expect(
+			Number( screen.getByTestId( 'current-zoom' ).textContent )
+		).toBe( 4 );
+	} );
+
+	it( 'disables Zoom in at the maximum zoom', () => {
+		setup( {}, { zoom: MAX_ZOOM } );
+		// Buttons use `accessibleWhenDisabled`, so the disabled state is
+		// expressed via aria-disabled, not the `disabled` attribute.
+		expect(
+			screen.getByRole( 'button', { name: 'Zoom in' } )
+		).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'disables Zoom out at the minimum zoom', () => {
+		setup();
+		expect(
+			screen.getByRole( 'button', { name: 'Zoom out' } )
+		).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 
 	it( 'renders an aspect ratio dropdown in the flat toolbar when enabled', async () => {

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -343,12 +343,14 @@ function MediaEditorContent( {
 	shouldCloseOnEsc = false,
 }: MediaEditorProps ) {
 	const cropper = useMediaEditor();
-	// The sidebar is a side column from the `medium` breakpoint up and
-	// collapses below it. Track that single breakpoint: in "panel mode"
-	// (≥ medium) the rotate/flip controls live in the Crop panel and the
-	// footer is just History + Cancel/Save; below it the controls drop into
-	// the footer. (The fine-rotation ruler always sits under the canvas.)
-	const isPanelLayout = useViewportMatch( 'medium' );
+	// The sidebar is a side column from the `small` breakpoint up and collapses
+	// to an overlay below it — mirroring InterfaceSkeleton's behaviour, shifted
+	// from `medium` to `small` (see the matching CSS overrides in style.scss).
+	// Track that single breakpoint: in "panel mode" (≥ small) the
+	// rotate/flip/zoom controls live in the Crop panel and the footer is just
+	// History + Cancel/Save; below it the controls drop into the footer. (The
+	// fine-rotation ruler always sits under the canvas.)
+	const isPanelLayout = useViewportMatch( 'small' );
 	const footerLayout: 'wide' | 'narrow' = isPanelLayout ? 'wide' : 'narrow';
 
 	const { media, hasEdits } = useSelect(
@@ -483,9 +485,6 @@ function MediaEditorContent( {
 						<MediaEditorCropPanel
 							aspectRatioValue={ aspectRatioValue }
 							onAspectRatioChange={ setAspectRatioValue }
-							onPlacementControlInteraction={
-								signalPlacementControlInteraction
-							}
 							aspectRatioOptions={ aspectRatioOptions }
 							showTransformControls={ isPanelLayout }
 						/>
@@ -499,7 +498,6 @@ function MediaEditorContent( {
 		aspectRatioValue,
 		setAspectRatioValue,
 		aspectRatioOptions,
-		signalPlacementControlInteraction,
 		isPanelLayout,
 	] );
 

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -91,9 +91,9 @@
 
 		// Small left gutter so the tabs and panel content (and the zoom
 		// slider's thumb at its minimum) sit off the sidebar edge. Only in the
-		// column layout; below `medium` the sidebar is a full-width overlay and
+		// column layout; below `small` the sidebar is a full-width overlay and
 		// uses the panel's own gutter instead.
-		@include break-medium() {
+		@include break-small() {
 			padding-left: $grid-unit-10;
 		}
 	}
@@ -110,13 +110,13 @@
 		outline: 1px solid transparent;
 	}
 
-	// Below `medium` the sidebar is a full-width overlay, so the panel carries
-	// its own all-around gutter. From `medium` up it's the right-hand column
-	// and drops its left/bottom padding (the sidebar supplies the left gutter).
+	// Below `small` the sidebar is a full-width overlay, so the panel carries
+	// its own all-around gutter. From `small` up it's the right-hand column and
+	// drops its left/bottom padding (the sidebar supplies the left gutter).
 	.media-editor__panel {
 		padding: $grid-unit-20;
 
-		@include break-medium() {
+		@include break-small() {
 			padding: $grid-unit-20 $grid-unit-30 0 0;
 		}
 	}
@@ -131,30 +131,38 @@
 		.components-button.has-icon {
 			padding: 0;
 
-			@include break-medium() {
+			@include break-small() {
 				display: flex;
 			}
 		}
 	}
 
-	// Below the medium breakpoint the `ComplementaryArea` switches to its
-	// full-screen "mobile" mode and stretches the panel to `100vw`, set
-	// inline on both the animated fill wrapper and the panel itself. The
-	// media editor runs inside a modal that, between the small and medium
-	// breakpoints, is inset from the viewport edges — so `100vw` is wider
-	// than the dialog, spilling the sidebar past its right edge and over the
-	// canvas. Pin the sidebar to the modal by filling its container instead
-	// of the viewport, and override the two inline `100vw` declarations
-	// (`!important` is the only way to beat an inline style). The whole
-	// override is scoped to this breakpoint so the desktop sidebar width is
-	// untouched.
-	@media (max-width: #{ (breakpoints.$break-medium - 1) }) {
-		// The skeleton sidebar wrapper is always present — it's just empty
-		// when the panel is closed (the default at this breakpoint). Only
-		// give it a definite width while the panel is open (`__fill` is
-		// rendered), otherwise the empty, white, absolutely-positioned
-		// wrapper would cover the canvas. When the panel is open it would
-		// otherwise shrink-wrap to nothing, since `__fill` below is `100%`.
+	// `ComplementaryArea`'s "mobile" mode is hard-coded to the `medium`
+	// breakpoint: below 782px it renders an animated fill wrapper and writes
+	// `width: 100vw` inline on both it and the inner panel. We want the sidebar
+	// to mirror InterfaceSkeleton's column/overlay collapse but shifted to
+	// `small`, so we override that inline width by breakpoint (`!important` is
+	// the only way to beat an inline style). `:has(__fill)` scopes the changes
+	// to when the panel is actually open: the skeleton sidebar wrapper is always
+	// present (empty when closed), so touching it unconditionally would paint an
+	// empty box over the canvas.
+
+	// Column (>= small): pull the open panel back in-flow at the sidebar width,
+	// so the controls sit beside the canvas down to 600px.
+	@include break-small() {
+		.interface-interface-skeleton__sidebar:has(.interface-complementary-area__fill) {
+			position: relative !important;
+		}
+
+		.interface-complementary-area__fill,
+		.interface-complementary-area {
+			width: $sidebar-width !important;
+		}
+	}
+
+	// Overlay (< small): the open panel fills the modal width (it would
+	// otherwise shrink-wrap, since the inline `100vw` is overridden below).
+	@media (max-width: #{ (breakpoints.$break-small - 1) }) {
 		.interface-interface-skeleton__sidebar:has(.interface-complementary-area__fill) {
 			width: 100%;
 		}


### PR DESCRIPTION
## What

Replaces the media editor's zoom slider with a +/− button pair, folded into the shared `MediaEditorImageControls` component alongside rotate/flip and the aspect-ratio control.

https://github.com/user-attachments/assets/0684e407-b83a-4474-aae5-f1633b43ef59


## Why

Follow-up to the crop modal layout (#78896) and the image-controls toolbar (#78935). The slider's `%` value is unanchored and confusing — it's relative to an internal base-fit pose, not 1:1 pixels, and its floor shifts with rotation and crop. A +/− pair reads more clearly; pinch and wheel still handle large jumps.

Keeping zoom in its own component left the mobile footer with mismatched gaps between tool groups (raised in review). Consolidating every control into `MediaEditorImageControls` makes the footer a single toolbar with one consistent gap.

## Notes

Built on trunk (#78935 merged). `ComplementaryArea`'s mobile mode is hard-coded to the `medium` breakpoint, so the column-down-to-600 behaviour is achieved with scoped CSS overrides of its inline `100vw` width and position.

## Manual testing

1. Add an Image block and click Crop.
2. **Wide:** the Crop panel shows Rotate/Flip, then Zoom (+ / −), then Aspect ratio — no slider, no number. Click + / − to zoom; − disables when fully out, + when fully in. Each click is the same perceived zoom step at any level.
3. **600–782px:** the sidebar stays a column with the tools; the footer is just History + Cancel/Save (no duplicated tools, no overflow).
4. **Below 600px:** the tools drop into the footer toolbar as a single row.
5. Zoom with + / −, then press Cmd/Ctrl+Z — the zoom step undoes.

## Follow-ups (not this PR)

- Refine the 600–782px sidebar UX (e.g. footer-everywhere with a Details-only tab, or toggle the footer with the drawer).
- Optional slight zoom animation on +/− click.

