### PR TITLE
Media Editor: Add aspect ratio control to mobile toolbar

### DIFF
--- a/packages/media-editor/src/components/media-editor-transform-controls/index.tsx
+++ b/packages/media-editor/src/components/media-editor-transform-controls/index.tsx
@@ -1,9 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import {
+	Button,
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
+	aspectRatio as aspectRatioIcon,
+	check,
 	rotateLeft,
 	rotateRight,
 	flipHorizontal,
@@ -14,6 +21,7 @@ import {
  * Internal dependencies
  */
 import { useMediaEditor } from '../../state';
+import type { AspectRatioPreset } from '../../image-editor/core/constants';
 
 export interface MediaEditorTransformControlsProps {
 	/**
@@ -23,6 +31,16 @@ export interface MediaEditorTransformControlsProps {
 	 * footer layout used at narrower widths.
 	 */
 	withLabels?: boolean;
+	/**
+	 * Selected aspect-ratio preset value. When provided with
+	 * `onAspectRatioChange` and `aspectRatioOptions`, the flat toolbar
+	 * includes an aspect-ratio dropdown.
+	 */
+	aspectRatioValue?: string;
+	/** Setter for the selected aspect-ratio preset value. */
+	onAspectRatioChange?: ( value: string ) => void;
+	/** Aspect-ratio presets to display in the dropdown. */
+	aspectRatioOptions?: AspectRatioPreset[];
 }
 
 /**
@@ -34,11 +52,22 @@ export interface MediaEditorTransformControlsProps {
  *
  * @param props
  * @param props.withLabels
+ * @param props.aspectRatioValue
+ * @param props.onAspectRatioChange
+ * @param props.aspectRatioOptions
  */
 export default function MediaEditorTransformControls( {
 	withLabels = false,
+	aspectRatioValue,
+	onAspectRatioChange,
+	aspectRatioOptions,
 }: MediaEditorTransformControlsProps ) {
 	const { state, setFlip, snapRotate90 } = useMediaEditor();
+	const hasAspectRatioControl =
+		! withLabels &&
+		aspectRatioValue !== undefined &&
+		onAspectRatioChange !== undefined &&
+		aspectRatioOptions !== undefined;
 
 	const rotateButtons = (
 		<>
@@ -90,6 +119,38 @@ export default function MediaEditorTransformControls( {
 		</>
 	);
 
+	const aspectRatioDropdown = hasAspectRatioControl ? (
+		<DropdownMenu
+			icon={ aspectRatioIcon }
+			label={ __( 'Aspect ratio' ) }
+			popoverProps={ { placement: 'top' } }
+			toggleProps={ { size: 'compact' } }
+		>
+			{ ( { onClose } ) => (
+				<MenuGroup label={ __( 'Aspect ratio' ) }>
+					{ aspectRatioOptions.map( ( preset ) => {
+						const value = preset.value.toString();
+						const isSelected = value === aspectRatioValue;
+						return (
+							<MenuItem
+								key={ value }
+								role="menuitemradio"
+								isSelected={ isSelected }
+								icon={ isSelected ? check : undefined }
+								onClick={ () => {
+									onAspectRatioChange( value );
+									onClose();
+								} }
+							>
+								{ preset.label }
+							</MenuItem>
+						);
+					} ) }
+				</MenuGroup>
+			) }
+		</DropdownMenu>
+	) : null;
+
 	if ( withLabels ) {
 		return (
 			<div className="media-editor-transform-controls is-stacked">
@@ -131,6 +192,7 @@ export default function MediaEditorTransformControls( {
 		<div className="media-editor-transform-controls">
 			{ rotateButtons }
 			{ flipButtons }
+			{ aspectRatioDropdown }
 		</div>
 	);
 }

--- a/packages/media-editor/src/components/media-editor-transform-controls/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-transform-controls/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -53,5 +53,44 @@ describe( 'MediaEditorTransformControls', () => {
 		expect(
 			screen.getByRole( 'button', { name: 'Flip vertical' } )
 		).toBeInTheDocument();
+	} );
+
+	it( 'renders an aspect ratio dropdown in the flat toolbar when aspect ratio props are provided', () => {
+		const onAspectRatioChange = jest.fn();
+		setup( {
+			aspectRatioValue: '1',
+			onAspectRatioChange,
+			aspectRatioOptions: [
+				{ label: 'Free', value: 0 },
+				{ label: 'Original', value: -1 },
+				{ label: 'Square', value: 1 },
+			],
+		} );
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Aspect ratio' } )
+		);
+		fireEvent.click(
+			screen.getByRole( 'menuitemradio', { name: 'Free' } )
+		);
+
+		expect( onAspectRatioChange ).toHaveBeenCalledWith( '0' );
+	} );
+
+	it( 'omits the aspect ratio dropdown from the labelled panel layout', () => {
+		setup( {
+			withLabels: true,
+			aspectRatioValue: '1',
+			onAspectRatioChange: jest.fn(),
+			aspectRatioOptions: [
+				{ label: 'Free', value: 0 },
+				{ label: 'Original', value: -1 },
+				{ label: 'Square', value: 1 },
+			],
+		} );
+
+		expect(
+			screen.queryByRole( 'button', { name: 'Aspect ratio' } )
+		).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -666,7 +666,13 @@ function MediaEditorContent( {
 			onReset={ resetCropOptions }
 		/>
 	) : null;
-	const transform = isImage ? <MediaEditorTransformControls /> : null;
+	const transform = isImage ? (
+		<MediaEditorTransformControls
+			aspectRatioValue={ aspectRatioValue }
+			onAspectRatioChange={ setAspectRatioValue }
+			aspectRatioOptions={ aspectRatioOptions }
+		/>
+	) : null;
 	const actions = (
 		<FooterActions
 			isSaving={ isSaving }


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/78896

Adds the aspect ratio control to the media editor mobile toolbar as an icon dropdown.


https://github.com/user-attachments/assets/193062a0-b013-442b-a8f1-bd636710254b



## Why?
The mobile media editor toolbar should expose aspect ratio changes alongside the existing rotate and flip controls.

## How?
- Extends the flat media editor transform toolbar with an optional aspect ratio dropdown.
- Wires the narrow/mobile footer toolbar to the existing crop options state.
- Keeps the labelled sidebar crop panel behavior unchanged for wider viewports.

## Testing Instructions

1. Open the post editor, add an Image block, and click Crop.
2. Shrink the window below 782px - check that the aspect ratio icon appears in the bottom toolbar. Click on it and make sure it works the same way as the sidebar aspect ratio dropdown.