### PR TITLE
Media Editor: Fix sidebar overflowing the modal between the small and medium breakpoints

### DIFF
--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Media Editor: Stop the details/crop sidebar overflowing the modal between the small and medium breakpoints.
+
 ### Code Quality
 
 -   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -1,3 +1,4 @@
+@use "@wordpress/base-styles/breakpoints" as breakpoints;
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables" as *;
@@ -71,6 +72,34 @@
 			@include break-medium() {
 				display: flex;
 			}
+		}
+	}
+
+	// Below the medium breakpoint the `ComplementaryArea` switches to its
+	// full-screen "mobile" mode and stretches the panel to `100vw`, set
+	// inline on both the animated fill wrapper and the panel itself. The
+	// media editor runs inside a modal that, between the small and medium
+	// breakpoints, is inset from the viewport edges — so `100vw` is wider
+	// than the dialog, spilling the sidebar past its right edge and over the
+	// canvas. Pin the sidebar to the modal by filling its container instead
+	// of the viewport, and override the two inline `100vw` declarations
+	// (`!important` is the only way to beat an inline style). The whole
+	// override is scoped to this breakpoint so the desktop sidebar width is
+	// untouched.
+	@media (max-width: #{ (breakpoints.$break-medium - 1) }) {
+		// The skeleton sidebar wrapper is always present — it's just empty
+		// when the panel is closed (the default at this breakpoint). Only
+		// give it a definite width while the panel is open (`__fill` is
+		// rendered), otherwise the empty, white, absolutely-positioned
+		// wrapper would cover the canvas. When the panel is open it would
+		// otherwise shrink-wrap to nothing, since `__fill` below is `100%`.
+		.interface-interface-skeleton__sidebar:has(.interface-complementary-area__fill) {
+			width: 100%;
+		}
+
+		.interface-complementary-area__fill,
+		.interface-complementary-area {
+			width: 100% !important;
 		}
 	}
 }


### PR DESCRIPTION
## What?

See #78896, where this was reported.

Fixes the media editor's details/crop sidebar overflowing the modal (and painting over the canvas) at viewport widths between roughly 600px and 782px.

## Why?

`@wordpress/interface`'s `ComplementaryArea` was built for the full-screen editor, where the interface skeleton spans the whole viewport. Below the `medium` breakpoint (782px) it switches to a full-screen "mobile" mode and sets an inline `width: 100vw` on the panel and its animated wrapper — which, at the viewport root, equals the available width.

The media editor is the first consumer to host that same skeleton inside a constrained `<Modal>`. Between the `small` (600px) and `medium` (782px) breakpoints the `size="fill"` modal is inset from the viewport edges (`width: calc(100% - 40px)`, centered), so `100vw` is wider than the dialog. The absolutely-positioned skeleton sidebar (`left: 0`) then spills past the modal's right edge and covers the canvas.

The range is bounded on both sides:

- **< 600px** — the modal is genuinely full-screen (`width: 100%`), so `100vw` equals the modal. No overflow.
- **≥ 782px** — `ComplementaryArea` leaves mobile mode and uses its fixed `280px` width. No `100vw`.

## How?

A CSS override scoped to the media editor (no changes to `@wordpress/interface`, so other consumers — edit-post, edit-site — are untouched). Below the medium breakpoint, within `.media-editor`:

- Fill the modal (`100%`) instead of the viewport, overriding the two inline `100vw` declarations. `!important` is required to beat an inline style.
- Only give the always-present skeleton sidebar wrapper a definite width while the panel is open (`:has(.interface-complementary-area__fill)`), so the empty, white wrapper doesn't cover the canvas when the panel is closed.

This preserves the existing mobile pattern — at this width the sidebar overlays the canvas at full modal width and can be toggled closed to reveal it again.

## Testing Instructions

1. Open the media editor on an image attachment (e.g. via a block that uses it).
2. Resize the browser window into the 600–782px range (or use device emulation at ~700px).
3. Confirm the sidebar does not overflow the modal's right edge.
4. With the panel **closed**, confirm the canvas is fully visible (no white overlay).
5. Toggle the panel **open** and confirm it overlays the canvas at full modal width without spilling.
6. Check both the **Crop** and **Details** tabs (Details has the widest form fields).
7. Verify no regression ≥782px (sidebar docked at its usual width) and <600px (full-screen modal).

### Testing Instructions for Keyboard

1. With the media editor open in the 600–782px range, use the sidebar toggle button to open and close the panel.
2. Confirm focus and the panel's open/close behaviour are unchanged.

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="747" height="478" alt="Screenshot 2026-06-04 at 4 06 11 pm" src="https://github.com/user-attachments/assets/55aa956a-85e1-4803-8801-e5e7a559f7ef" />|<img width="716" height="580" alt="Screenshot 2026-06-04 at 4 37 58 pm" src="https://github.com/user-attachments/assets/cac4af35-6450-47e6-98e7-83e4d42af2b9" />|
|<img width="746" height="490" alt="Screenshot 2026-06-04 at 4 06 06 pm" src="https://github.com/user-attachments/assets/83a77068-b0dc-4859-9499-1ed40f81e723" />|<img width="711" height="575" alt="Screenshot 2026-06-04 at 4 37 51 pm" src="https://github.com/user-attachments/assets/1ea3f54a-4c3b-4843-8669-149612d91b9f" />|







## Use of AI Tools

For the PR description, GPT.

For the solution @andrewserong GPT

