### PR TITLE
List View block support: Hide list tab when allowedBlocks is empty, with no children

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   List View: a block that supports `listView` is now excluded from the List View when it has no inner blocks and disallows insertion (`allowedBlocks: []`), since there is nothing to show, rearrange, or add. ([#78932](https://github.com/WordPress/gutenberg/pull/78932))
+-   List View: a block that supports `listView` is now excluded from the List View when it has no inner blocks and disallows insertion (`allowedBlocks` is `[]` or `false`), since there is nothing to show, rearrange, or add. ([#78932](https://github.com/WordPress/gutenberg/pull/78932))
 
 ## 15.21.1 (2026-06-16)
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   List View: a block that supports `listView` is now excluded from the List View when its inner blocks are fully managed — locked with `templateLock: 'all'` and currently empty — since there is nothing to select or navigate. ([#78932](https://github.com/WordPress/gutenberg/pull/78932))
+-   List View: a block that supports `listView` is now excluded from the List View when its inner blocks are fully managed — it has no inner blocks and disallows insertion (`allowedBlocks: []`) — since there is nothing to select, navigate, or add. Unlike `templateLock`, `allowedBlocks` is not relaxed by a content-locked (`contentOnly`) ancestor, so the exclusion holds in every context. ([#78932](https://github.com/WordPress/gutenberg/pull/78932))
 
 ## 15.21.1 (2026-06-16)
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   List View: a block that supports `listView` is now excluded from the List View when its inner blocks are fully managed — locked with `templateLock: 'all'` and currently empty — since there is nothing to select or navigate. ([#78932](https://github.com/WordPress/gutenberg/pull/78932))
+
 ## 15.21.1 (2026-06-16)
 
 ## 15.21.0 (2026-06-10)

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   List View: a block that supports `listView` is now excluded from the List View when its inner blocks are fully managed — it has no inner blocks and disallows insertion (`allowedBlocks: []`) — since there is nothing to select, navigate, or add. Unlike `templateLock`, `allowedBlocks` is not relaxed by a content-locked (`contentOnly`) ancestor, so the exclusion holds in every context. ([#78932](https://github.com/WordPress/gutenberg/pull/78932))
+-   List View: a block that supports `listView` is now excluded from the List View when it has no inner blocks and disallows insertion (`allowedBlocks: []`), since there is nothing to show, rearrange, or add. ([#78932](https://github.com/WordPress/gutenberg/pull/78932))
 
 ## 15.21.1 (2026-06-16)
 

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -21,7 +21,7 @@ import {
 	arrowRight,
 	arrowLeft,
 } from '@wordpress/icons';
-import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
+import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -110,20 +110,14 @@ function BlockCard( {
 			if ( parentClientId || isChild || ! allowParentNavigation ) {
 				return {};
 			}
-			const { getBlockParents, getBlockName } =
-				select( blockEditorStore );
+			const { getBlockParents, getBlockName, hasBlockListViewSupport } =
+				unlock( select( blockEditorStore ) );
 
-			// Find the top-most parent block that is either:
-			// 1. A navigation block (special case for ad-hoc list view support)
-			// 2. Any block with listView support
+			// Find the top-most parent block that participates in List View.
 			const parents = getBlockParents( clientId, false );
-			const foundParentId = parents.find( ( parentId ) => {
-				const parentName = getBlockName( parentId );
-				return (
-					parentName === 'core/navigation' ||
-					hasBlockSupport( parentName, 'listView' )
-				);
-			} );
+			const foundParentId = parents.find( ( parentId ) =>
+				hasBlockListViewSupport( parentId )
+			);
 
 			return {
 				parentBlockClientId: foundParentId,

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -110,13 +110,13 @@ function BlockCard( {
 			if ( parentClientId || isChild || ! allowParentNavigation ) {
 				return {};
 			}
-			const { getBlockParents, getBlockName, hasBlockListViewSupport } =
+			const { getBlockParents, getBlockName, shouldRenderBlockListView } =
 				unlock( select( blockEditorStore ) );
 
 			// Find the top-most parent block that participates in List View.
 			const parents = getBlockParents( clientId, false );
 			const foundParentId = parents.find( ( parentId ) =>
-				hasBlockListViewSupport( parentId )
+				shouldRenderBlockListView( parentId )
 			);
 
 			return {

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -3,12 +3,10 @@
  */
 import { useMemo, useContext } from '@wordpress/element';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { store as blockEditorStore } from '../../store';
 import Edit from './edit';
 import {
 	BlockEditContextProvider,
@@ -23,7 +21,6 @@ import {
 } from './context';
 import { MultipleUsageWarning } from './multiple-usage-warning';
 import { PrivateBlockContext } from '../block-list/private-block-context';
-import { unlock } from '../../lock-unlock';
 
 /**
  * The `useBlockEditContext` hook provides information about the block this hook is being used in.
@@ -58,20 +55,10 @@ export default function BlockEdit( {
 		hasBlockSupport( name, 'layout', false ) ||
 		hasBlockSupport( name, '__experimentalLayout', false );
 	const parentBlockEditContext = useBlockEditContext();
-	const typeHasListViewSupport =
-		hasBlockSupport( name, 'listView' ) || name === 'core/navigation';
-	const participatesInListView = useSelect(
-		( select ) =>
-			typeHasListViewSupport
-				? unlock( select( blockEditorStore ) ).hasBlockListViewSupport(
-						clientId
-				  )
-				: false,
-		[ clientId, typeHasListViewSupport ]
-	);
 	const isInListViewBlockSupportTree =
 		!! parentBlockEditContext[ isInListViewBlockSupportTreeKey ] ||
-		participatesInListView;
+		hasBlockSupport( name, 'listView' ) ||
+		name === 'core/navigation';
 	const { originalBlockClientId } = useContext( PrivateBlockContext );
 
 	return (

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -3,10 +3,12 @@
  */
 import { useMemo, useContext } from '@wordpress/element';
 import { hasBlockSupport } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
+import { store as blockEditorStore } from '../../store';
 import Edit from './edit';
 import {
 	BlockEditContextProvider,
@@ -21,6 +23,7 @@ import {
 } from './context';
 import { MultipleUsageWarning } from './multiple-usage-warning';
 import { PrivateBlockContext } from '../block-list/private-block-context';
+import { unlock } from '../../lock-unlock';
 
 /**
  * The `useBlockEditContext` hook provides information about the block this hook is being used in.
@@ -55,10 +58,20 @@ export default function BlockEdit( {
 		hasBlockSupport( name, 'layout', false ) ||
 		hasBlockSupport( name, '__experimentalLayout', false );
 	const parentBlockEditContext = useBlockEditContext();
+	const typeHasListViewSupport =
+		hasBlockSupport( name, 'listView' ) || name === 'core/navigation';
+	const participatesInListView = useSelect(
+		( select ) =>
+			typeHasListViewSupport
+				? unlock( select( blockEditorStore ) ).hasBlockListViewSupport(
+						clientId
+				  )
+				: false,
+		[ clientId, typeHasListViewSupport ]
+	);
 	const isInListViewBlockSupportTree =
 		!! parentBlockEditContext[ isInListViewBlockSupportTreeKey ] ||
-		hasBlockSupport( name, 'listView' ) ||
-		name === 'core/navigation';
+		participatesInListView;
 	const { originalBlockClientId } = useContext( PrivateBlockContext );
 
 	return (

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -208,7 +208,7 @@ function BlockInspector() {
 			const {
 				getClientIdsOfDescendants,
 				getBlockEditingMode,
-				hasBlockListViewSupport,
+				shouldRenderBlockListView,
 			} = unlock( select( blockEditorStore ) );
 
 			const descendants = getClientIdsOfDescendants(
@@ -219,7 +219,7 @@ function BlockInspector() {
 			// List View tab.
 			const listViewDescendants = new Set();
 			descendants.forEach( ( clientId ) => {
-				if ( hasBlockListViewSupport( clientId ) ) {
+				if ( shouldRenderBlockListView( clientId ) ) {
 					const listViewChildren =
 						getClientIdsOfDescendants( clientId );
 					listViewChildren.forEach( ( childId ) =>

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	getBlockType,
 	getUnregisteredTypeHandlerName,
-	hasBlockSupport,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import {
@@ -208,8 +207,8 @@ function BlockInspector() {
 
 			const {
 				getClientIdsOfDescendants,
-				getBlockName,
 				getBlockEditingMode,
+				hasBlockListViewSupport,
 			} = unlock( select( blockEditorStore ) );
 
 			const descendants = getClientIdsOfDescendants(
@@ -220,14 +219,7 @@ function BlockInspector() {
 			// List View tab.
 			const listViewDescendants = new Set();
 			descendants.forEach( ( clientId ) => {
-				const blockName = getBlockName( clientId );
-				// Navigation block doesn't have List View block support, but
-				// it does have a custom implementation that is shown within
-				// patterns, so it's included in this condition.
-				if (
-					blockName === 'core/navigation' ||
-					hasBlockSupport( blockName, 'listView' )
-				) {
+				if ( hasBlockListViewSupport( clientId ) ) {
 					const listViewChildren =
 						getClientIdsOfDescendants( clientId );
 					listViewChildren.forEach( ( childId ) =>

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { hasBlockSupport, getBlockType } from '@wordpress/blocks';
+import { getBlockType } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	Button,
@@ -20,6 +20,7 @@ import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
 import useBlockDisplayInformation from '../use-block-display-information';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
+import { unlock } from '../../lock-unlock';
 
 export default function BlockQuickNavigation( {
 	clientIds,
@@ -60,7 +61,8 @@ function BlockQuickNavigationItem( {
 					hasSelectedInnerBlock,
 					getBlockOrder,
 					getBlockName,
-				} = select( blockEditorStore );
+					hasBlockListViewSupport,
+				} = unlock( select( blockEditorStore ) );
 
 				const _blockName = getBlockName( clientId );
 
@@ -69,9 +71,7 @@ function BlockQuickNavigationItem( {
 						isBlockSelected( clientId ) ||
 						hasSelectedInnerBlock( clientId, /* deep: */ true ),
 					childBlocks: getBlockOrder( clientId ),
-					hasListViewSupport:
-						_blockName === 'core/navigation' ||
-						hasBlockSupport( _blockName, 'listView' ),
+					hasListViewSupport: hasBlockListViewSupport( clientId ),
 					blockName: _blockName,
 				};
 			},

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -53,7 +53,7 @@ function BlockQuickNavigationItem( {
 	hasListViewTab,
 } ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const { isSelected, childBlocks, hasListViewSupport, blockName } =
+	const { isSelected, childBlocks, shouldRenderListView, blockName } =
 		useSelect(
 			( select ) => {
 				const {
@@ -61,7 +61,7 @@ function BlockQuickNavigationItem( {
 					hasSelectedInnerBlock,
 					getBlockOrder,
 					getBlockName,
-					hasBlockListViewSupport,
+					shouldRenderBlockListView,
 				} = unlock( select( blockEditorStore ) );
 
 				const _blockName = getBlockName( clientId );
@@ -71,7 +71,7 @@ function BlockQuickNavigationItem( {
 						isBlockSelected( clientId ) ||
 						hasSelectedInnerBlock( clientId, /* deep: */ true ),
 					childBlocks: getBlockOrder( clientId ),
-					hasListViewSupport: hasBlockListViewSupport( clientId ),
+					shouldRenderListView: shouldRenderBlockListView( clientId ),
 					blockName: _blockName,
 				};
 			},
@@ -88,7 +88,7 @@ function BlockQuickNavigationItem( {
 
 	const hasChildren = childBlocks && childBlocks.length > 0;
 	const canNavigateToListView =
-		hasChildren && hasListViewTab && hasListViewSupport;
+		hasChildren && hasListViewTab && shouldRenderListView;
 
 	return (
 		<Button

--- a/packages/block-editor/src/hooks/list-view.js
+++ b/packages/block-editor/src/hooks/list-view.js
@@ -52,8 +52,11 @@ export function ListViewPanel( { clientId, name } ) {
 
 	const { isEnabled, hasChildren, isNestedListView } = useSelect(
 		( select ) => {
-			const { getBlockCount, getBlockParents, hasBlockListViewSupport } =
-				unlock( select( blockEditorStore ) );
+			const {
+				getBlockCount,
+				getBlockParents,
+				shouldRenderBlockListView,
+			} = unlock( select( blockEditorStore ) );
 
 			// Avoid showing List Views for both parent and child blocks that have support.
 			// In this situation the parent will show the child in its list already.
@@ -61,11 +64,11 @@ export function ListViewPanel( { clientId, name } ) {
 			// This matches closely the logic in the `BlockCard` component.
 			const parents = getBlockParents( clientId, false );
 			const _isNestedListView = parents.find( ( parentId ) =>
-				hasBlockListViewSupport( parentId )
+				shouldRenderBlockListView( parentId )
 			);
 
 			return {
-				isEnabled: hasBlockListViewSupport( clientId ),
+				isEnabled: shouldRenderBlockListView( clientId ),
 				hasChildren: !! getBlockCount( clientId ),
 				isNestedListView: _isNestedListView,
 			};

--- a/packages/block-editor/src/hooks/list-view.js
+++ b/packages/block-editor/src/hooks/list-view.js
@@ -50,26 +50,22 @@ export function ListViewPanel( { clientId, name } ) {
 		useDispatch( blockEditorStore )
 	);
 
-	const isEnabled = hasListViewSupport( name );
-	const { hasChildren, isNestedListView } = useSelect(
+	const { isEnabled, hasChildren, isNestedListView } = useSelect(
 		( select ) => {
-			const { getBlockCount, getBlockParents, getBlockName } =
-				select( blockEditorStore );
+			const { getBlockCount, getBlockParents, hasBlockListViewSupport } =
+				unlock( select( blockEditorStore ) );
 
 			// Avoid showing List Views for both parent and child blocks that have support.
 			// In this situation the parent will show the child in its list already.
 			// Search parents to see if there's one that also has support, and if so skip rendering.
 			// This matches closely the logic in the `BlockCard` component.
 			const parents = getBlockParents( clientId, false );
-			const _isNestedListView = parents.find( ( parentId ) => {
-				const parentName = getBlockName( parentId );
-				return (
-					parentName === 'core/navigation' ||
-					hasBlockSupport( parentName, 'listView' )
-				);
-			} );
+			const _isNestedListView = parents.find( ( parentId ) =>
+				hasBlockListViewSupport( parentId )
+			);
 
 			return {
+				isEnabled: hasBlockListViewSupport( clientId ),
 				hasChildren: !! getBlockCount( clientId ),
 				isNestedListView: _isNestedListView,
 			};

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -1097,7 +1097,7 @@ export function getListViewExpandRevision( state ) {
  *
  * @return {boolean} Whether the block participates in List View-specific UI.
  */
-export function hasBlockListViewSupport( state, clientId ) {
+export function shouldRenderBlockListView( state, clientId ) {
 	const blockName = getBlockName( state, clientId );
 
 	// The navigation block always participates; its List View is core to how it

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -1086,9 +1086,9 @@ export function getListViewExpandRevision( state ) {
  * `listView` support and the `core/navigation` special case) shared by the List
  * View consumers. A `listView`-supporting block drops out when its List View
  * would be completely unusable — it has no inner blocks and disallows insertion
- * (`allowedBlocks: []`), so there is nothing to show, rearrange, or add — to
- * avoid bloating the UI. Keeping the read internal lets this computation evolve
- * without a back-compat commitment.
+ * (`allowedBlocks` is `[]` or `false`), so there is nothing to show, rearrange,
+ * or add — to avoid bloating the UI. Keeping the read internal lets this
+ * computation evolve without a back-compat commitment.
  *
  * @param {Object} state    Global application state.
  * @param {string} clientId Client ID of the block.
@@ -1109,9 +1109,12 @@ export function hasBlockListViewSupport( state, clientId ) {
 	}
 
 	// Hide the List View only when it would be completely unusable: the block
-	// has no inner blocks to view or rearrange, and disallows insertion
-	// (`allowedBlocks: []`), so it has no appender either. When insertion is
-	// allowed the List View still shows an appender, so it stays.
+	// has no inner blocks to view or rearrange, and disallows insertion, so it
+	// has no appender either. When insertion is allowed the List View still
+	// shows an appender, so it stays.
+	//
+	// Insertion is disallowed when `allowedBlocks` permits nothing — either an
+	// empty array (`allowedBlocks: []`) or the boolean `false`.
 	//
 	// `allowedBlocks` is used rather than inferring this from `templateLock`,
 	// because a content-locked ancestor relaxes a child's own
@@ -1121,10 +1124,11 @@ export function hasBlockListViewSupport( state, clientId ) {
 		state,
 		clientId
 	)?.allowedBlocks;
+	const disallowsInsertion =
+		allowedBlocks === false ||
+		( Array.isArray( allowedBlocks ) && allowedBlocks.length === 0 );
 	const isListViewUnusable =
-		getBlockOrder( state, clientId ).length === 0 &&
-		Array.isArray( allowedBlocks ) &&
-		allowedBlocks.length === 0;
+		getBlockOrder( state, clientId ).length === 0 && disallowsInsertion;
 
 	return ! isListViewUnusable;
 }

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -1078,6 +1078,45 @@ export function getListViewExpandRevision( state ) {
 }
 
 /**
+ * Returns whether a block instance participates in List View-specific UI for
+ * its inner blocks.
+ *
+ * Intentionally private: this is the derived participation logic (block type
+ * `listView` support, the `core/navigation` special case, and the
+ * "managed inner blocks" inference) shared by the List View consumers. A block
+ * opts out implicitly by entering a managed state — `templateLock: 'all'` with
+ * no inner blocks — so there is no dedicated public flag. Keeping the read
+ * internal lets this computation evolve without a back-compat commitment.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId Client ID of the block.
+ *
+ * @return {boolean} Whether the block participates in List View-specific UI.
+ */
+export function hasBlockListViewSupport( state, clientId ) {
+	const blockName = getBlockName( state, clientId );
+	const hasTypeSupport =
+		blockName === 'core/navigation' ||
+		hasBlockSupport( blockName, 'listView' );
+
+	if ( ! hasTypeSupport ) {
+		return false;
+	}
+
+	// A block whose inner blocks are fully managed — the template is locked
+	// (`templateLock: 'all'`) and there are currently no inner blocks — has
+	// nothing to select or navigate, so it doesn't participate in the List
+	// View. This lets blocks that enter a "managed inner blocks" mode (e.g. a
+	// gallery resolving its images dynamically) opt out without a dedicated
+	// flag.
+	const hasManagedInnerBlocks =
+		getTemplateLock( state, clientId ) === 'all' &&
+		getBlockOrder( state, clientId ).length === 0;
+
+	return ! hasManagedInnerBlocks;
+}
+
+/**
  * Returns the client IDs for the viewport modal, or null if
  * the modal is not open.
  *

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -14,6 +14,7 @@ import {
 	getBlockOrder,
 	getBlockParents,
 	getBlockEditingMode,
+	getBlockListSettings,
 	getSettings,
 	canInsertBlockType,
 	getBlockName,
@@ -1084,9 +1085,10 @@ export function getListViewExpandRevision( state ) {
  * Intentionally private: this is the derived participation logic (block type
  * `listView` support, the `core/navigation` special case, and the
  * "managed inner blocks" inference) shared by the List View consumers. A block
- * opts out implicitly by entering a managed state — `templateLock: 'all'` with
- * no inner blocks — so there is no dedicated public flag. Keeping the read
- * internal lets this computation evolve without a back-compat commitment.
+ * opts out implicitly by entering a managed state — it has no inner blocks and
+ * disallows insertion (`allowedBlocks: []`) — so there is no dedicated public
+ * flag. Keeping the read internal lets this computation evolve without a
+ * back-compat commitment.
  *
  * @param {Object} state    Global application state.
  * @param {string} clientId Client ID of the block.
@@ -1095,23 +1097,39 @@ export function getListViewExpandRevision( state ) {
  */
 export function hasBlockListViewSupport( state, clientId ) {
 	const blockName = getBlockName( state, clientId );
-	const hasTypeSupport =
-		blockName === 'core/navigation' ||
-		hasBlockSupport( blockName, 'listView' );
 
-	if ( ! hasTypeSupport ) {
+	// The navigation block always participates; its List View is core to how it
+	// is edited, regardless of how its menu is locked or populated.
+	if ( blockName === 'core/navigation' ) {
+		return true;
+	}
+
+	if ( ! hasBlockSupport( blockName, 'listView' ) ) {
 		return false;
 	}
 
-	// A block whose inner blocks are fully managed — the template is locked
-	// (`templateLock: 'all'`) and there are currently no inner blocks — has
-	// nothing to select or navigate, so it doesn't participate in the List
-	// View. This lets blocks that enter a "managed inner blocks" mode (e.g. a
-	// gallery resolving its images dynamically) opt out without a dedicated
-	// flag.
+	// A block with inner blocks always participates — there are real children to
+	// view and navigate.
+	if ( getBlockOrder( state, clientId ).length !== 0 ) {
+		return true;
+	}
+
+	// The block is empty and has "managed inner blocks" — so opts out of the
+	// List View — when nothing can be inserted into it. This lets a block that
+	// resolves its own children (e.g. a gallery in a dynamic mode) opt out
+	// without a dedicated flag, by declaring `allowedBlocks: []` while it has no
+	// inner blocks: there is nothing to navigate and nothing to add.
+	//
+	// `allowedBlocks` is read from block list settings rather than inferred from
+	// `templateLock` because a content-locked ancestor relaxes a child's own
+	// `templateLock: 'all'` to `contentOnly` (see `useNestedSettingsUpdate`),
+	// whereas `allowedBlocks` is carried through unchanged.
+	const allowedBlocks = getBlockListSettings(
+		state,
+		clientId
+	)?.allowedBlocks;
 	const hasManagedInnerBlocks =
-		getTemplateLock( state, clientId ) === 'all' &&
-		getBlockOrder( state, clientId ).length === 0;
+		Array.isArray( allowedBlocks ) && allowedBlocks.length === 0;
 
 	return ! hasManagedInnerBlocks;
 }

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -1085,10 +1085,12 @@ export function getListViewExpandRevision( state ) {
  * Intentionally private: this is the derived participation logic (block type
  * `listView` support and the `core/navigation` special case) shared by the List
  * View consumers. A `listView`-supporting block drops out when it has no inner
- * blocks and disallows inserting any (`allowedBlocks` is `[]` or `false`): the
- * nested List View panel would then render no block rows and no appender, so it
- * is hidden rather than shown empty. Keeping the read internal lets this
- * computation evolve without a back-compat commitment.
+ * blocks and its `allowedBlocks` (`[]` or `false`) permits no block: the nested
+ * List View panel would render no rows and no appender, so it is hidden rather
+ * than shown empty. This is a signal, not a guarantee — a child naming this
+ * block as its `parent` stays insertable regardless (see `canInsertBlockType`);
+ * that edge case is accepted to keep the check cheap. Keeping the read internal
+ * lets this computation evolve without a back-compat commitment.
  *
  * @param {Object} state    Global application state.
  * @param {string} clientId Client ID of the block.
@@ -1108,29 +1110,18 @@ export function hasBlockListViewSupport( state, clientId ) {
 		return false;
 	}
 
-	// When a block has no inner blocks and explicitly disallows inserting any,
-	// the nested List View panel would render no block rows and no appender, so
-	// hide it. When insertion is allowed the panel still shows an appender, so
-	// it stays.
-	//
-	// Insertion is disallowed when `allowedBlocks` permits nothing — either an
-	// empty array (`[]`) or the boolean `false`.
-	//
-	// `allowedBlocks` is used rather than inferring this from `templateLock`,
-	// because a content-locked ancestor relaxes a child's own
-	// `templateLock: 'all'` to `contentOnly` (see `useNestedSettingsUpdate`),
-	// whereas `allowedBlocks` is carried through unchanged.
+	// `allowedBlocks` permits no block when it is `[]` or `false`; an unset value
+	// is unrestricted and is intentionally not matched.
 	const allowedBlocks = getBlockListSettings(
 		state,
 		clientId
 	)?.allowedBlocks;
-	const insertionDisallowed =
-		allowedBlocks === false ||
-		( Array.isArray( allowedBlocks ) && allowedBlocks.length === 0 );
-	const isEmptyAndInsertionDisallowed =
-		getBlockOrder( state, clientId ).length === 0 && insertionDisallowed;
+	const isEmptyAndNoAllowedBlocks =
+		getBlockOrder( state, clientId ).length === 0 &&
+		( allowedBlocks === false ||
+			( Array.isArray( allowedBlocks ) && allowedBlocks.length === 0 ) );
 
-	return ! isEmptyAndInsertionDisallowed;
+	return ! isEmptyAndNoAllowedBlocks;
 }
 
 /**

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -1083,12 +1083,12 @@ export function getListViewExpandRevision( state ) {
  * its inner blocks.
  *
  * Intentionally private: this is the derived participation logic (block type
- * `listView` support, the `core/navigation` special case, and the
- * "managed inner blocks" inference) shared by the List View consumers. A block
- * opts out implicitly by entering a managed state — it has no inner blocks and
- * disallows insertion (`allowedBlocks: []`) — so there is no dedicated public
- * flag. Keeping the read internal lets this computation evolve without a
- * back-compat commitment.
+ * `listView` support and the `core/navigation` special case) shared by the List
+ * View consumers. A `listView`-supporting block drops out when its List View
+ * would be completely unusable — it has no inner blocks and disallows insertion
+ * (`allowedBlocks: []`), so there is nothing to show, rearrange, or add — to
+ * avoid bloating the UI. Keeping the read internal lets this computation evolve
+ * without a back-compat commitment.
  *
  * @param {Object} state    Global application state.
  * @param {string} clientId Client ID of the block.
@@ -1108,30 +1108,25 @@ export function hasBlockListViewSupport( state, clientId ) {
 		return false;
 	}
 
-	// A block with inner blocks always participates — there are real children to
-	// view and navigate.
-	if ( getBlockOrder( state, clientId ).length !== 0 ) {
-		return true;
-	}
-
-	// The block is empty and has "managed inner blocks" — so opts out of the
-	// List View — when nothing can be inserted into it. This lets a block that
-	// resolves its own children (e.g. a gallery in a dynamic mode) opt out
-	// without a dedicated flag, by declaring `allowedBlocks: []` while it has no
-	// inner blocks: there is nothing to navigate and nothing to add.
+	// Hide the List View only when it would be completely unusable: the block
+	// has no inner blocks to view or rearrange, and disallows insertion
+	// (`allowedBlocks: []`), so it has no appender either. When insertion is
+	// allowed the List View still shows an appender, so it stays.
 	//
-	// `allowedBlocks` is read from block list settings rather than inferred from
-	// `templateLock` because a content-locked ancestor relaxes a child's own
+	// `allowedBlocks` is used rather than inferring this from `templateLock`,
+	// because a content-locked ancestor relaxes a child's own
 	// `templateLock: 'all'` to `contentOnly` (see `useNestedSettingsUpdate`),
 	// whereas `allowedBlocks` is carried through unchanged.
 	const allowedBlocks = getBlockListSettings(
 		state,
 		clientId
 	)?.allowedBlocks;
-	const hasManagedInnerBlocks =
-		Array.isArray( allowedBlocks ) && allowedBlocks.length === 0;
+	const isListViewUnusable =
+		getBlockOrder( state, clientId ).length === 0 &&
+		Array.isArray( allowedBlocks ) &&
+		allowedBlocks.length === 0;
 
-	return ! hasManagedInnerBlocks;
+	return ! isListViewUnusable;
 }
 
 /**

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -1084,10 +1084,10 @@ export function getListViewExpandRevision( state ) {
  *
  * Intentionally private: this is the derived participation logic (block type
  * `listView` support and the `core/navigation` special case) shared by the List
- * View consumers. A `listView`-supporting block drops out when its List View
- * would be completely unusable — it has no inner blocks and disallows insertion
- * (`allowedBlocks` is `[]` or `false`), so there is nothing to show, rearrange,
- * or add — to avoid bloating the UI. Keeping the read internal lets this
+ * View consumers. A `listView`-supporting block drops out when it has no inner
+ * blocks and disallows inserting any (`allowedBlocks` is `[]` or `false`): the
+ * nested List View panel would then render no block rows and no appender, so it
+ * is hidden rather than shown empty. Keeping the read internal lets this
  * computation evolve without a back-compat commitment.
  *
  * @param {Object} state    Global application state.
@@ -1108,13 +1108,13 @@ export function hasBlockListViewSupport( state, clientId ) {
 		return false;
 	}
 
-	// Hide the List View only when it would be completely unusable: the block
-	// has no inner blocks to view or rearrange, and disallows insertion, so it
-	// has no appender either. When insertion is allowed the List View still
-	// shows an appender, so it stays.
+	// When a block has no inner blocks and explicitly disallows inserting any,
+	// the nested List View panel would render no block rows and no appender, so
+	// hide it. When insertion is allowed the panel still shows an appender, so
+	// it stays.
 	//
 	// Insertion is disallowed when `allowedBlocks` permits nothing — either an
-	// empty array (`allowedBlocks: []`) or the boolean `false`.
+	// empty array (`[]`) or the boolean `false`.
 	//
 	// `allowedBlocks` is used rather than inferring this from `templateLock`,
 	// because a content-locked ancestor relaxes a child's own
@@ -1124,13 +1124,13 @@ export function hasBlockListViewSupport( state, clientId ) {
 		state,
 		clientId
 	)?.allowedBlocks;
-	const disallowsInsertion =
+	const insertionDisallowed =
 		allowedBlocks === false ||
 		( Array.isArray( allowedBlocks ) && allowedBlocks.length === 0 );
-	const isListViewUnusable =
-		getBlockOrder( state, clientId ).length === 0 && disallowsInsertion;
+	const isEmptyAndInsertionDisallowed =
+		getBlockOrder( state, clientId ).length === 0 && insertionDisallowed;
 
-	return ! isListViewUnusable;
+	return ! isEmptyAndInsertionDisallowed;
 }
 
 /**

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -138,6 +138,16 @@ describe( 'private selectors', () => {
 			);
 		} );
 
+		it( 'returns false when empty and insertion is disallowed via `allowedBlocks: false`', () => {
+			const state = createState( blockWithListViewSupport, {
+				allowedBlocks: false,
+			} );
+
+			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe(
+				false
+			);
+		} );
+
 		it( 'returns true when empty but insertion is allowed', () => {
 			// e.g. a static, still-empty gallery: nothing yet, but the user can
 			// start inserting, so its List View stays available.

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -128,7 +128,7 @@ describe( 'private selectors', () => {
 			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe( true );
 		} );
 
-		it( 'returns false when empty and insertion is disallowed (List View would be unusable)', () => {
+		it( 'returns false when empty and insertion is disallowed via `allowedBlocks: []`', () => {
 			const state = createState( blockWithListViewSupport, {
 				allowedBlocks: [],
 			} );

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -128,7 +128,7 @@ describe( 'private selectors', () => {
 			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe( true );
 		} );
 
-		it( 'returns false when the inner blocks are managed (empty and insertion disallowed)', () => {
+		it( 'returns false when empty and insertion is disallowed (List View would be unusable)', () => {
 			const state = createState( blockWithListViewSupport, {
 				allowedBlocks: [],
 			} );

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -27,7 +27,7 @@ import {
 	getSelectedBlockStyleState,
 	hasSelectedStyleState,
 	isSelectedBlockStyleStateShownOnCanvas,
-	hasBlockListViewSupport,
+	shouldRenderBlockListView,
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
 import { deviceTypeKey } from '../private-keys';
@@ -76,7 +76,7 @@ describe( 'private selectors', () => {
 		} );
 	} );
 
-	describe( 'hasBlockListViewSupport', () => {
+	describe( 'shouldRenderBlockListView', () => {
 		const blockWithListViewSupport = 'core/test-list-view-support';
 		const blockWithoutListViewSupport = 'core/test-no-list-view-support';
 
@@ -125,7 +125,9 @@ describe( 'private selectors', () => {
 		it( 'returns true for blocks with list view support', () => {
 			const state = createState( blockWithListViewSupport );
 
-			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe( true );
+			expect( shouldRenderBlockListView( state, 'client-1' ) ).toBe(
+				true
+			);
 		} );
 
 		it( 'returns false when empty and insertion is disallowed via `allowedBlocks: []`', () => {
@@ -133,7 +135,7 @@ describe( 'private selectors', () => {
 				allowedBlocks: [],
 			} );
 
-			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe(
+			expect( shouldRenderBlockListView( state, 'client-1' ) ).toBe(
 				false
 			);
 		} );
@@ -143,7 +145,7 @@ describe( 'private selectors', () => {
 				allowedBlocks: false,
 			} );
 
-			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe(
+			expect( shouldRenderBlockListView( state, 'client-1' ) ).toBe(
 				false
 			);
 		} );
@@ -155,13 +157,17 @@ describe( 'private selectors', () => {
 				allowedBlocks: [ 'core/image' ],
 			} );
 
-			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe( true );
+			expect( shouldRenderBlockListView( state, 'client-1' ) ).toBe(
+				true
+			);
 		} );
 
 		it( 'returns true when empty with no allowedBlocks restriction', () => {
 			const state = createState( blockWithListViewSupport );
 
-			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe( true );
+			expect( shouldRenderBlockListView( state, 'client-1' ) ).toBe(
+				true
+			);
 		} );
 
 		it( 'returns true when insertion is disallowed but the block still has inner blocks', () => {
@@ -170,7 +176,9 @@ describe( 'private selectors', () => {
 				innerBlocks: [ 'child-1' ],
 			} );
 
-			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe( true );
+			expect( shouldRenderBlockListView( state, 'client-1' ) ).toBe(
+				true
+			);
 		} );
 
 		it( 'does not grant list view support to unsupported block types', () => {
@@ -178,7 +186,7 @@ describe( 'private selectors', () => {
 				allowedBlocks: [],
 			} );
 
-			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe(
+			expect( shouldRenderBlockListView( state, 'client-1' ) ).toBe(
 				false
 			);
 		} );
@@ -186,7 +194,22 @@ describe( 'private selectors', () => {
 		it( 'preserves the navigation block special case', () => {
 			const state = createState( 'core/navigation' );
 
-			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe( true );
+			expect( shouldRenderBlockListView( state, 'client-1' ) ).toBe(
+				true
+			);
+		} );
+
+		it( 'keeps navigation in list view even when empty and insertion is disallowed', () => {
+			// The navigation special case takes precedence over the
+			// `allowedBlocks` exclusion: even with nothing to show and no
+			// insertion allowed, navigation still participates in List View.
+			const state = createState( 'core/navigation', {
+				allowedBlocks: [],
+			} );
+
+			expect( shouldRenderBlockListView( state, 'client-1' ) ).toBe(
+				true
+			);
 		} );
 	} );
 

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -82,16 +82,24 @@ describe( 'private selectors', () => {
 
 		const createState = (
 			blockName,
-			{ templateLock, innerBlocks = [] } = {}
-		) => ( {
-			blocks: {
-				byClientId: new Map( [ [ 'client-1', { name: blockName } ] ] ),
-				order: new Map( [ [ 'client-1', innerBlocks ] ] ),
-			},
-			blockListSettings: templateLock
-				? new Map( [ [ 'client-1', { templateLock } ] ] )
-				: new Map(),
-		} );
+			{ allowedBlocks, innerBlocks = [] } = {}
+		) => {
+			const blockListSettings = new Map();
+			if ( allowedBlocks !== undefined ) {
+				blockListSettings.set( 'client-1', { allowedBlocks } );
+			}
+
+			return {
+				blocks: {
+					byClientId: new Map( [
+						[ 'client-1', { name: blockName } ],
+					] ),
+					order: new Map( [ [ 'client-1', innerBlocks ] ] ),
+					parents: new Map(),
+				},
+				blockListSettings,
+			};
+		};
 
 		beforeAll( () => {
 			registerBlockType( blockWithListViewSupport, {
@@ -120,9 +128,9 @@ describe( 'private selectors', () => {
 			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe( true );
 		} );
 
-		it( 'returns false when the inner blocks are managed (locked and empty)', () => {
+		it( 'returns false when the inner blocks are managed (empty and insertion disallowed)', () => {
 			const state = createState( blockWithListViewSupport, {
-				templateLock: 'all',
+				allowedBlocks: [],
 			} );
 
 			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe(
@@ -130,9 +138,25 @@ describe( 'private selectors', () => {
 			);
 		} );
 
-		it( 'returns true when locked but the block still has inner blocks', () => {
+		it( 'returns true when empty but insertion is allowed', () => {
+			// e.g. a static, still-empty gallery: nothing yet, but the user can
+			// start inserting, so its List View stays available.
 			const state = createState( blockWithListViewSupport, {
-				templateLock: 'all',
+				allowedBlocks: [ 'core/image' ],
+			} );
+
+			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe( true );
+		} );
+
+		it( 'returns true when empty with no allowedBlocks restriction', () => {
+			const state = createState( blockWithListViewSupport );
+
+			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe( true );
+		} );
+
+		it( 'returns true when insertion is disallowed but the block still has inner blocks', () => {
+			const state = createState( blockWithListViewSupport, {
+				allowedBlocks: [],
 				innerBlocks: [ 'child-1' ],
 			} );
 
@@ -141,7 +165,7 @@ describe( 'private selectors', () => {
 
 		it( 'does not grant list view support to unsupported block types', () => {
 			const state = createState( blockWithoutListViewSupport, {
-				templateLock: 'all',
+				allowedBlocks: [],
 			} );
 
 			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe(

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -27,6 +27,7 @@ import {
 	getSelectedBlockStyleState,
 	hasSelectedStyleState,
 	isSelectedBlockStyleStateShownOnCanvas,
+	hasBlockListViewSupport,
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
 import { deviceTypeKey } from '../private-keys';
@@ -72,6 +73,86 @@ describe( 'private selectors', () => {
 				'123456',
 				'78910',
 			] );
+		} );
+	} );
+
+	describe( 'hasBlockListViewSupport', () => {
+		const blockWithListViewSupport = 'core/test-list-view-support';
+		const blockWithoutListViewSupport = 'core/test-no-list-view-support';
+
+		const createState = (
+			blockName,
+			{ templateLock, innerBlocks = [] } = {}
+		) => ( {
+			blocks: {
+				byClientId: new Map( [ [ 'client-1', { name: blockName } ] ] ),
+				order: new Map( [ [ 'client-1', innerBlocks ] ] ),
+			},
+			blockListSettings: templateLock
+				? new Map( [ [ 'client-1', { templateLock } ] ] )
+				: new Map(),
+		} );
+
+		beforeAll( () => {
+			registerBlockType( blockWithListViewSupport, {
+				apiVersion: 3,
+				title: 'List View support',
+				category: 'text',
+				supports: {
+					listView: true,
+				},
+			} );
+			registerBlockType( blockWithoutListViewSupport, {
+				apiVersion: 3,
+				title: 'No List View support',
+				category: 'text',
+			} );
+		} );
+
+		afterAll( () => {
+			unregisterBlockType( blockWithListViewSupport );
+			unregisterBlockType( blockWithoutListViewSupport );
+		} );
+
+		it( 'returns true for blocks with list view support', () => {
+			const state = createState( blockWithListViewSupport );
+
+			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe( true );
+		} );
+
+		it( 'returns false when the inner blocks are managed (locked and empty)', () => {
+			const state = createState( blockWithListViewSupport, {
+				templateLock: 'all',
+			} );
+
+			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe(
+				false
+			);
+		} );
+
+		it( 'returns true when locked but the block still has inner blocks', () => {
+			const state = createState( blockWithListViewSupport, {
+				templateLock: 'all',
+				innerBlocks: [ 'child-1' ],
+			} );
+
+			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe( true );
+		} );
+
+		it( 'does not grant list view support to unsupported block types', () => {
+			const state = createState( blockWithoutListViewSupport, {
+				templateLock: 'all',
+			} );
+
+			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe(
+				false
+			);
+		} );
+
+		it( 'preserves the navigation block special case', () => {
+			const state = createState( 'core/navigation' );
+
+			expect( hasBlockListViewSupport( state, 'client-1' ) ).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
## What?

Add a per-instance way for a block to disable the List View block support when it's template locked and has no children. The idea is that consumers may want/need to be able to disable the list view tab programmatically rather than just the boolean in `block.json`.

<!--
I've tried an idea here, but I'm not sure of this approach myself, so would love to hear ideas for how we could achieve this! -->

## Why?

It's possible to have blocks that only want to allow the list tab or view to be available based on a certain set of conditions (or a mode). The primary use case I have in mind is that of a Dynamic Gallery block that has two modes: a dynamic one where the inner images are fetched via a query, and a static mode where individual blocks are set within the block. I.e what I'm exploring in https://github.com/WordPress/gutenberg/pull/78796

That's just one use case, though. There could be many cases where a block wants or needs to hide its internals based on a condition. So this PR is proposing a general way to do that.

## How?

<!--
* Add an optional `listView` flag to the `useInnerBlockProps` object (similar to specifying an orientation)
* In `useNestedSettingsUpdate` ensure the `listView` value is saved when block list settings are updated
-->

* Previously this PR tried to add a `listView` flag, but it turns out we can infer a desired state for hiding the list view tab via `allowedBlock: []` or `allowedBlocks: false` (and the absence of any inner blocks). This state can effectively become a "managed inner blocks" mode.
* Add a `shouldRenderBlockListView` selector to return whether or not the list view support is available — this way we're not just checking if the block type allows it, we're also checking if the block _currently_ supports it

For an example of how a consumer might use this in practice, take a look at #78796 which adds a dynamic gallery block variation (effectively a mode).

## Testing Instructions

We can simulate the behaviour in #78796 by updating a block locally to set `allowedBlocks: []`. This is quite artificial, the real use case is in the other PR. Here's a diff to apply it to the Gallery block in this branch.

In this case, to demo the behaviour, I've wired up switching `allowedBlocks: []` to the `randomOrder` value so that you can see it hiding the list tab in the editor:

```diff
diff --git a/packages/block-library/src/gallery/edit.js b/packages/block-library/src/gallery/edit.js
index 12aeb5432b3..02ea6636798 100644
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -603,6 +603,12 @@ export default function GalleryEdit( props ) {
 		directInsert: true,
 		orientation: 'horizontal',
 		renderAppender: false,
+		// TESTING ONLY — do not merge. Toggle the gallery's "Randomize order"
+		// setting to declare `allowedBlocks: []`, turning it into an empty,
+		// insertion-disallowed container so the List View exclusion and the
+		// drag-and-drop/insert block can be exercised without the dynamic
+		// gallery feature.
+		allowedBlocks: randomOrder ? EMPTY_ARRAY : undefined,
 	} );
 
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
```

With the above diff applied, if you add the following block markup, you'll see the Gallery block with no list tab:

```html
<!-- wp:gallery {"randomOrder":true,"linkTo":"none"} -->
<figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure>
<!-- /wp:gallery -->
```

Note again: this is a very artificial example to help test this branch. The above state is effectively useless on this branch, but it will become useful in the dynamic gallery PR (#78796)

<!--
Note that in the other PR I'm also setting `templateLock: 'all'` when in dynamic mode to completely disable nesting inside the gallery block. That's how consumers can achieve a full "managed inner blocks mode". This PR is just about the `listView` support slice of that. -->

## Screenshots or screencast <!-- if applicable -->

With the above diff applied for example, the List tab would be hidden if you have randomOrder toggled on with a gallery block that has no children:

<img width="1268" height="729" alt="image" src="https://github.com/user-attachments/assets/8f867ed7-5ffe-456d-9ee1-6cb02fabb7c6" />

## Use of AI Tools

Claude Code and Codex