### PR TITLE
Github workflows: extend package changelog nudge to bundled packages

### DIFF
--- a/.github/workflows/check-package-changelogs.yml
+++ b/.github/workflows/check-package-changelogs.yml
@@ -19,6 +19,8 @@ on:
             - 'packages/ui/**'
             - 'packages/undo-manager/**'
             - 'packages/views/**'
+            - 'packages/widget-dashboard/**'
+            - 'packages/widget-primitives/**'
             - 'packages/wp-build/**'
             - '!packages/*/src/**/stories/**'
             - '!packages/*/src/**/test/**'
@@ -53,6 +55,8 @@ jobs:
                     - theme
                     - components
                     - private-apis
+                    - widget-dashboard
+                    - widget-primitives
                     - wp-build
         steps:
             - name: 'Get PR commit count'

--- a/.github/workflows/check-package-changelogs.yml
+++ b/.github/workflows/check-package-changelogs.yml
@@ -37,19 +37,22 @@ jobs:
             fail-fast: false
             matrix:
                 package:
+                    # Bundled packages
+                    # Keep in sync with dependency-extraction-webpack-plugin
                     - admin-ui
-                    - components
                     - dataviews
                     - fields
                     - grid
                     - icons
                     - interface
-                    - private-apis
                     - style-runtime
                     - theme
                     - ui
                     - undo-manager
                     - views
+                    # Other packages
+                    - components
+                    - private-apis
                     - wp-build
         steps:
             - name: 'Get PR commit count'

--- a/.github/workflows/check-package-changelogs.yml
+++ b/.github/workflows/check-package-changelogs.yml
@@ -6,10 +6,20 @@ on:
         branches:
             - trunk
         paths:
+            - 'packages/admin-ui/**'
             - 'packages/components/**'
             - 'packages/dataviews/**'
-            - 'packages/ui/**'
+            - 'packages/fields/**'
+            - 'packages/grid/**'
+            - 'packages/icons/**'
+            - 'packages/interface/**'
+            - 'packages/private-apis/**'
+            - 'packages/style-runtime/**'
             - 'packages/theme/**'
+            - 'packages/ui/**'
+            - 'packages/undo-manager/**'
+            - 'packages/views/**'
+            - 'packages/wp-build/**'
             - '!packages/*/src/**/stories/**'
             - '!packages/*/src/**/test/**'
 
@@ -27,10 +37,20 @@ jobs:
             fail-fast: false
             matrix:
                 package:
+                    - admin-ui
                     - components
                     - dataviews
-                    - ui
+                    - fields
+                    - grid
+                    - icons
+                    - interface
+                    - private-apis
+                    - style-runtime
                     - theme
+                    - ui
+                    - undo-manager
+                    - views
+                    - wp-build
         steps:
             - name: 'Get PR commit count'
               env:

--- a/.github/workflows/check-package-changelogs.yml
+++ b/.github/workflows/check-package-changelogs.yml
@@ -46,11 +46,11 @@ jobs:
                     - icons
                     - interface
                     - style-runtime
-                    - theme
                     - ui
                     - undo-manager
                     - views
                     # Other packages
+                    - theme
                     - components
                     - private-apis
                     - wp-build


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Extends the changelog nudge GitHub action to include all bundled packages, plus private-apis and wp-build packages. 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Follow-up to the previous config consolidation done in https://github.com/WordPress/gutenberg/pull/78169

#### Bundled packages

These packages are bundled and referenced as `window.wp` globals, and follow [Semantic Versioning](https://semver.org/). It's important that downstream consumers are kept informed about changes that might impact their usage of the package. The likelihood of breaking changes is greater since bundled packages are often experimental, and we don't need to be as careful with backwards compatibility; consumers update versions at will at their own pace.

#### WP Build and Private APIs

Extending with WP Build came up in https://github.com/WordPress/gutenberg/pull/78807#issuecomment-4578091661 after updating some missing changelog entries from wp-build package.

Consumers are starting to use WP Build, and can control when they update the version; it's not a runtime library externalised, but a command-line tool instead. The tool is at a fairly early stage, so it's important to communicate well about any changes within it.

Additions in private APIs, particularly when used in bundled packages, can cause mismatched version expectations when used with WP Build: bundled packages can try to depend on unlocking an API in externalised `window.wp.*` packages with a version of private APIs that doesn't yet list the permissions for the unlock. (See https://github.com/WordPress/gutenberg/pull/75987)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Just extends the existing list.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Github actions pass.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
