### PR TITLE
Breadcrumbs: Add setting to show trailing separator

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -92,7 +92,7 @@ Display a breadcrumb trail showing the path to the current page. ([Source](https
 -	**Name:** core/breadcrumbs
 -	**Category:** theme
 -	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** prefersTaxonomy, separator, showCurrentItem, showHomeItem, showOnHomePage
+-	**Attributes:** prefersTaxonomy, separator, showCurrentItem, showHomeItem, showOnHomePage, showTrailingSeparator
 
 ## Button
 

--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -26,6 +26,10 @@
 		"showOnHomePage": {
 			"type": "boolean",
 			"default": false
+		},
+		"showTrailingSeparator": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"usesContext": [ "postId", "postType", "templateSlug" ],

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -37,6 +37,7 @@ export default function BreadcrumbEdit( {
 		showCurrentItem,
 		prefersTaxonomy,
 		showOnHomePage,
+		showTrailingSeparator,
 	} = attributes;
 	const {
 		post,
@@ -129,7 +130,10 @@ export default function BreadcrumbEdit( {
 		};
 	}, [ status ] );
 	const disabledRef = useDisabled();
-	const blockProps = useBlockProps( { ref: disabledRef } );
+	const blockProps = useBlockProps( {
+		ref: disabledRef,
+		className: showTrailingSeparator ? 'has-trailing-separator' : undefined,
+	} );
 
 	if ( isLoading ) {
 		return (
@@ -278,6 +282,26 @@ export default function BreadcrumbEdit( {
 									} );
 								}
 							} }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Show trailing separator' ) }
+						isShownByDefault
+						hasValue={ () => showTrailingSeparator }
+						onDeselect={ () =>
+							setAttributes( {
+								showTrailingSeparator: false,
+							} )
+						}
+					>
+						<ToggleControl
+							label={ __( 'Show trailing separator' ) }
+							onChange={ ( value ) =>
+								setAttributes( {
+									showTrailingSeparator: value,
+								} )
+							}
+							checked={ showTrailingSeparator }
 						/>
 					</ToolsPanelItem>
 				</ToolsPanel>

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -183,8 +183,10 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		return '';
 	}
 
+	$wrapper_classes = $attributes['showTrailingSeparator'] ? 'has-trailing-separator' : '';
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
+			'class'      => $wrapper_classes,
 			'style'      => '--separator: "' . addcslashes( $attributes['separator'], '\\"' ) . '";',
 			'aria-label' => __( 'Breadcrumbs' ),
 		)

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -183,7 +183,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$wrapper_classes = $attributes['showTrailingSeparator'] ? 'has-trailing-separator' : '';
+	$wrapper_classes    = $attributes['showTrailingSeparator'] ? 'has-trailing-separator' : '';
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
 			'class'      => $wrapper_classes,

--- a/packages/block-library/src/breadcrumbs/style.scss
+++ b/packages/block-library/src/breadcrumbs/style.scss
@@ -27,4 +27,10 @@
 	span {
 		color: inherit;
 	}
+
+	&.has-trailing-separator li:last-child::after {
+		content: var(--separator, "/") / "";
+		margin: 0 0.5em;
+		opacity: 0.7;
+	}
 }

--- a/test/integration/fixtures/blocks/core__breadcrumbs.json
+++ b/test/integration/fixtures/blocks/core__breadcrumbs.json
@@ -7,7 +7,8 @@
 			"separator": "/",
 			"showHomeItem": true,
 			"showCurrentItem": true,
-			"showOnHomePage": false
+			"showOnHomePage": false,
+			"showTrailingSeparator": false
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION

## What?

Closes https://github.com/WordPress/gutenberg/issues/78926

This PR introduces a new block attribute, `showTrailingSeparator`, for the Breadcrumbs block. When enabled, it applies a `has-trailing-separator` CSS class to the block wrapper, forcing the CSS `::after` separator to render on the `:last-child` item.


## Why?

This resolves an issue where users hiding the "current item" could not append a trailing separator to the end of the remaining breadcrumb trail. 



## Testing Instructions

1. Insert a Breadcrumbs block into a post.
2. Under the block settings, toggle ON the new **Show trailing separator** option.
3. Verify that a trailing separator appears at the end of the breadcrumb trail.
4. Toggle OFF the **Show current breadcrumb** option.
5. Verify that the current item disappears, but the trailing separator remains correctly attached to the preceding item.
6. Publish the post and verify the changes reflect correctly on the frontend.


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/3828b4b7-6896-4056-a56b-7fb758f7ddb4


