### PR TITLE
Add gallery lightbox default experiment

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -39,6 +39,9 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-classic-block-deprecation' ) ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalClassicBlockDeprecation = true', 'before' );
 	}
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-gallery-lightbox-default' ) ) {
+		wp_add_inline_script( 'wp-block-library', 'window.__experimentalGalleryLightboxDefault = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -55,6 +55,11 @@ function gutenberg_initialize_experiments_settings() {
 					'label'       => __( 'Media Upload Modal', 'gutenberg' ),
 					'description' => __( 'Replaces the existing WordPress media modal with a new modal powered by Data Views, supporting browsing, selecting, and uploading media.', 'gutenberg' ),
 				),
+				array(
+					'id'          => 'gutenberg-gallery-lightbox-default',
+					'label'       => __( 'Gallery lightbox default', 'gutenberg' ),
+					'description' => __( 'Sets newly created Gallery blocks to use the lightbox by default.', 'gutenberg' ),
+				),
 			),
 		),
 		array(

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -49,7 +49,7 @@ import {
  */
 import { sharedIcon } from './shared-icon';
 import { defaultColumnsNumber, pickRelevantMediaFiles } from './shared';
-import { getHrefAndDestination } from './utils';
+import { getDefaultLinkDestination, getHrefAndDestination } from './utils';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import {
 	getUpdatedLinkTargetSettings,
@@ -142,6 +142,10 @@ export default function GalleryEdit( props ) {
 			'dimensions.aspectRatios.theme',
 			'dimensions.defaultAspectRatios'
 		);
+	const defaultLinkDestination = getDefaultLinkDestination(
+		window?.wp?.media?.view?.settings?.defaultProps?.link,
+		lightboxSetting
+	);
 
 	const linkOptions = ! lightboxSetting?.allowEditing
 		? LINK_OPTIONS.filter(
@@ -311,8 +315,10 @@ export default function GalleryEdit( props ) {
 			...pickRelevantMediaFiles( image, sizeSlug ),
 			...getHrefAndDestination(
 				image,
-				linkTo,
-				imageAttributes?.linkDestination
+				linkTo || defaultLinkDestination,
+				imageAttributes?.linkDestination,
+				imageAttributes,
+				lightboxSetting
 			),
 			...newLinkTarget,
 			className: newClassName,
@@ -584,12 +590,10 @@ export default function GalleryEdit( props ) {
 		if ( ! linkTo ) {
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {
-				linkTo:
-					window?.wp?.media?.view?.settings?.defaultProps?.link ||
-					LINK_DESTINATION_NONE,
+				linkTo: defaultLinkDestination,
 			} );
 		}
-	}, [ linkTo ] );
+	}, [ linkTo, defaultLinkDestination ] );
 
 	const hasImages = !! images.length;
 	const hasImageIds = hasImages && images.some( ( image ) => !! image.id );

--- a/packages/block-library/src/gallery/test/utils.js
+++ b/packages/block-library/src/gallery/test/utils.js
@@ -1,0 +1,89 @@
+/**
+ * Internal dependencies
+ */
+import { getDefaultLinkDestination, getHrefAndDestination } from '../utils';
+import {
+	LINK_DESTINATION_LIGHTBOX,
+	LINK_DESTINATION_MEDIA,
+	LINK_DESTINATION_NONE,
+} from '../constants';
+
+describe( 'gallery block utils', () => {
+	describe( 'getDefaultLinkDestination', () => {
+		const originalGalleryLightboxDefault =
+			window.__experimentalGalleryLightboxDefault;
+
+		afterEach( () => {
+			if ( originalGalleryLightboxDefault === undefined ) {
+				delete window.__experimentalGalleryLightboxDefault;
+				return;
+			}
+
+			window.__experimentalGalleryLightboxDefault =
+				originalGalleryLightboxDefault;
+		} );
+
+		it( 'uses the media default link destination when the experiment is disabled', () => {
+			window.__experimentalGalleryLightboxDefault = false;
+
+			expect(
+				getDefaultLinkDestination( LINK_DESTINATION_MEDIA, {
+					allowEditing: true,
+				} )
+			).toBe( LINK_DESTINATION_MEDIA );
+		} );
+
+		it( 'falls back to no link destination when the experiment is disabled and there is no media default', () => {
+			window.__experimentalGalleryLightboxDefault = false;
+
+			expect(
+				getDefaultLinkDestination( undefined, { allowEditing: true } )
+			).toBe( LINK_DESTINATION_NONE );
+		} );
+
+		it( 'uses lightbox when the experiment is enabled', () => {
+			window.__experimentalGalleryLightboxDefault = true;
+
+			expect(
+				getDefaultLinkDestination( LINK_DESTINATION_MEDIA, {
+					allowEditing: true,
+				} )
+			).toBe( LINK_DESTINATION_LIGHTBOX );
+		} );
+
+		it( 'uses lightbox when the experiment is enabled before lightbox settings load', () => {
+			window.__experimentalGalleryLightboxDefault = true;
+
+			expect(
+				getDefaultLinkDestination( LINK_DESTINATION_MEDIA, undefined )
+			).toBe( LINK_DESTINATION_LIGHTBOX );
+		} );
+
+		it( 'respects disabled lightbox editing', () => {
+			window.__experimentalGalleryLightboxDefault = true;
+
+			expect(
+				getDefaultLinkDestination( LINK_DESTINATION_MEDIA, {
+					allowEditing: false,
+				} )
+			).toBe( LINK_DESTINATION_MEDIA );
+		} );
+	} );
+
+	describe( 'getHrefAndDestination', () => {
+		it( 'enables lightbox when the gallery link destination is lightbox', () => {
+			expect(
+				getHrefAndDestination(
+					{ source_url: 'https://example.com/image.jpg' },
+					LINK_DESTINATION_LIGHTBOX,
+					false,
+					{},
+					{ enabled: false }
+				)
+			).toMatchObject( {
+				href: undefined,
+				lightbox: { enabled: true },
+			} );
+		} );
+	} );
+} );

--- a/packages/block-library/src/gallery/utils.js
+++ b/packages/block-library/src/gallery/utils.js
@@ -16,6 +16,26 @@ import {
 } from '../image/constants';
 
 /**
+ * Returns the link destination to use when a Gallery block has no saved
+ * `linkTo` attribute yet.
+ *
+ * @param {string} mediaDefaultLink Media modal default link destination.
+ * @param {Object} lightboxSetting  Lightbox setting.
+ *
+ * @return {string} Default gallery link destination.
+ */
+export function getDefaultLinkDestination( mediaDefaultLink, lightboxSetting ) {
+	if (
+		window.__experimentalGalleryLightboxDefault &&
+		lightboxSetting?.allowEditing !== false
+	) {
+		return LINK_DESTINATION_LIGHTBOX;
+	}
+
+	return mediaDefaultLink || LINK_DESTINATION_NONE;
+}
+
+/**
  * Determines new href and linkDestination values for an Image block from the
  * supplied Gallery link destination, or falls back to the Image blocks link.
  *


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
No issue.

Adds a Media experiment that makes newly created Gallery blocks use the lightbox by default.

## Why?
This lets us test the Gallery lightbox default behind an experiment flag before enabling or refining the behavior more broadly.

## How?
The experiment registers `gutenberg-gallery-lightbox-default`, exposes `window.__experimentalGalleryLightboxDefault`, and uses that flag when initializing Gallery `linkTo` and new inner Image block attributes. Focused Gallery utility tests cover the default-link behavior and lightbox attribute mapping.

## Testing Instructions
1. Go to Gutenberg > Experiments and enable Gallery lightbox default.
2. Open a post or page and insert a new Gallery block.
3. Add images and confirm the Gallery link setting defaults to Enlarge on click.
4. Save and view the post, then confirm clicking gallery images opens the lightbox.
5. Disable the experiment and confirm new Gallery blocks follow the existing media default link setting instead.

### Testing Instructions for Keyboard
1. Enable the experiment from Gutenberg > Experiments using keyboard navigation.
2. Create a Gallery block, add images, and tab to the block toolbar/settings.
3. Confirm the link setting is Enlarge on click and activate an image on the frontend with the keyboard to open the lightbox.

## Screenshots or screencast
N/A

## Use of AI Tools
This PR was authored with assistance from OpenAI Codex. I reviewed the generated changes and test coverage.