### PR TITLE
Build Scripts: Fix Windows path handling in dev script

### DIFF
--- a/tools/build-scripts/dev.mjs
+++ b/tools/build-scripts/dev.mjs
@@ -3,7 +3,8 @@
 /**
  * External dependencies
  */
-import { execSync, spawn } from 'child_process';
+import { execSync } from 'child_process';
+import spawn from 'cross-spawn';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import fs from 'fs';
@@ -28,7 +29,6 @@ function exec( command, args = [], options = {} ) {
 		const childOptions = {
 			cwd: ROOT_DIR,
 			stdio: silent ? 'pipe' : 'inherit',
-			shell: true,
 			...spawnOptions,
 		};
 
@@ -89,7 +89,6 @@ function execAsync( command, args = [], options = {} ) {
 	return spawn( command, args, {
 		cwd: ROOT_DIR,
 		stdio: 'inherit',
-		shell: true,
 		...options,
 	} );
 }
@@ -146,7 +145,7 @@ async function dev() {
 
 		// This must happen before TypeScript compilation because some packages
 		// (like vips) have source files that import from generated worker-code.ts
-		await exec( 'node', [
+		await exec( process.execPath, [
 			path.join( __dirname, 'packages/generate-worker-placeholders.mjs' ),
 		] );
 
@@ -162,7 +161,7 @@ async function dev() {
 		console.log( `   ✔ Built TypeScript types (${ buildTime }ms)` );
 
 		console.log( '\n✅ Checking type declaration files...' );
-		await exec( 'node', [
+		await exec( process.execPath, [
 			path.join(
 				__dirname,
 				'packages/check-build-type-declaration-files.cjs'
@@ -170,7 +169,7 @@ async function dev() {
 		] );
 
 		console.log( '\n📦 Building vendor files...' );
-		await exec( 'node', [
+		await exec( process.execPath, [
 			path.join( __dirname, 'packages/build-vendors.mjs' ),
 		] );
 
@@ -198,7 +197,6 @@ async function dev() {
 		const buildWatch = spawn( 'wp-build', [ '--watch' ], {
 			cwd: ROOT_DIR,
 			stdio: [ 'inherit', 'pipe', 'inherit' ],
-			shell: true,
 			env: { ...process.env, NODE_ENV: 'development' },
 		} );
 

--- a/tools/build-scripts/dev.mjs
+++ b/tools/build-scripts/dev.mjs
@@ -145,7 +145,7 @@ async function dev() {
 
 		// This must happen before TypeScript compilation because some packages
 		// (like vips) have source files that import from generated worker-code.ts
-		await exec( process.execPath, [
+		await exec( 'node', [
 			path.join( __dirname, 'packages/generate-worker-placeholders.mjs' ),
 		] );
 
@@ -161,7 +161,7 @@ async function dev() {
 		console.log( `   ✔ Built TypeScript types (${ buildTime }ms)` );
 
 		console.log( '\n✅ Checking type declaration files...' );
-		await exec( process.execPath, [
+		await exec( 'node', [
 			path.join(
 				__dirname,
 				'packages/check-build-type-declaration-files.cjs'
@@ -169,7 +169,7 @@ async function dev() {
 		] );
 
 		console.log( '\n📦 Building vendor files...' );
-		await exec( process.execPath, [
+		await exec( 'node', [
 			path.join( __dirname, 'packages/build-vendors.mjs' ),
 		] );
 


### PR DESCRIPTION
## What?
Closes #78938

Fixes the development build script so spawned commands receive paths as argv values instead of going through a shell.

## Why?

`npm run dev` can fail on Windows when the Gutenberg checkout path contains spaces. The dev orchestration script was using `shell: true`, which allows `cmd.exe` to reinterpret arguments such as absolute script paths.

## How?

- Switches `tools/build-scripts/dev.mjs` to use `cross-spawn`, matching the build script's command execution approach.
- Removes `shell: true` from the dev script's spawned commands.

## Testing Instructions

1. Run `node --check tools/build-scripts/dev.mjs`.
2. On Windows, check out Gutenberg in a path containing a space.
3. Run `npm run dev`.
4. Verify the development build reaches the placeholder generation and subsequent build steps without failing because of the spaced path.
