### PR TITLE
DataViewsPicker: Add a new `pickerActivity` layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
--   DataViewsPicker: Add a new `pickerActivity` layout that renders selectable items as a vertical activity timeline. [#78940](https://github.com/WordPress/gutenberg/pull/78940)
+-   DataViewsPicker: Add a new `pickerActivity` layout that renders selectable items as a vertical activity timeline. [#78941](https://github.com/WordPress/gutenberg/pull/78941)
 
 ### Code Quality
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Revert React back to v18 [#78940](https://github.com/WordPress/gutenberg/pull/78940).
 
+### Enhancements
+
+-   DataViewsPicker: Add a new `pickerActivity` layout that renders selectable items as a vertical activity timeline. [#78940](https://github.com/WordPress/gutenberg/pull/78940)
+
 ### Code Quality
 
 -   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).

--- a/packages/dataviews/src/components/dataviews-layouts/index.ts
+++ b/packages/dataviews/src/components/dataviews-layouts/index.ts
@@ -19,6 +19,7 @@ import ViewList from './list';
 import ViewActivity from './activity';
 import ViewPickerGrid from './picker-grid';
 import ViewPickerTable from './picker-table';
+import ViewPickerActivity from './picker-activity';
 import {
 	LAYOUT_GRID,
 	LAYOUT_LIST,
@@ -26,6 +27,7 @@ import {
 	LAYOUT_ACTIVITY,
 	LAYOUT_PICKER_GRID,
 	LAYOUT_PICKER_TABLE,
+	LAYOUT_PICKER_ACTIVITY,
 } from '../../constants';
 import DensityPicker from './utils/density-picker';
 import GridConfigOptions from './utils/grid-config-options';
@@ -72,6 +74,14 @@ export const VIEW_LAYOUTS = [
 		label: __( 'Table' ),
 		component: ViewPickerTable,
 		icon: blockTable,
+		viewConfigOptions: DensityPicker,
+		isPicker: true,
+	},
+	{
+		type: LAYOUT_PICKER_ACTIVITY,
+		label: __( 'Activity' ),
+		component: ViewPickerActivity,
+		icon: scheduled,
 		viewConfigOptions: DensityPicker,
 		isPicker: true,
 	},

--- a/packages/dataviews/src/components/dataviews-layouts/picker-activity/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-activity/index.tsx
@@ -271,6 +271,7 @@ export default function ViewPickerActivity< Item >( {
 	const setsize = isInfiniteScroll ? paginationInfo?.totalItems : undefined;
 
 	const hasData = !! data?.length;
+	const isGrouped = !! ( groupField && dataByGroup );
 
 	const renderItem = ( item: Item ) => (
 		<PickerActivityItem
@@ -318,12 +319,17 @@ export default function ViewPickerActivity< Item >( {
 				aria-multiselectable={ isMultiselect }
 				aria-label={ itemListLabel }
 				aria-busy={ isLoading }
+				render={
+					isGrouped ? (
+						<Stack direction="column" gap="sm" />
+					) : undefined
+				}
 				className={ clsx(
 					'dataviews-view-picker-activity',
 					className
 				) }
 			>
-				{ groupField && dataByGroup
+				{ isGrouped && dataByGroup
 					? Array.from( dataByGroup.entries() ).map(
 							( [ groupName, groupItems ]: [
 								string,

--- a/packages/dataviews/src/components/dataviews-layouts/picker-activity/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-activity/index.tsx
@@ -1,0 +1,353 @@
+/**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { Spinner, Composite } from '@wordpress/components';
+import { useContext, useMemo, useRef } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
+import { __, sprintf } from '@wordpress/i18n';
+import { Stack, VisuallyHidden } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import DataViewsContext from '../../dataviews-context';
+import { useIsMultiselectPicker } from '../../dataviews-picker-footer';
+import getDataByGroup from '../utils/get-data-by-group';
+import { useIntersectionObserver } from '../utils/use-infinite-scroll';
+import type {
+	NormalizedField,
+	ViewPickerActivity as ViewPickerActivityType,
+	ViewPickerActivityProps,
+} from '../../../types';
+import type { SetSelection } from '../../../types/private';
+
+function isDefined< T >( item: T | undefined ): item is T {
+	return !! item;
+}
+
+interface PickerActivityItemProps< Item > {
+	view: ViewPickerActivityType;
+	multiselect?: boolean;
+	selection: string[];
+	onChangeSelection: SetSelection;
+	getItemId: ( item: Item ) => string;
+	item: Item;
+	titleField?: NormalizedField< Item >;
+	mediaField?: NormalizedField< Item >;
+	descriptionField?: NormalizedField< Item >;
+	otherFields: NormalizedField< Item >[];
+	posinset?: number;
+	setsize?: number;
+}
+
+function PickerActivityItem< Item >( {
+	view,
+	multiselect,
+	selection,
+	onChangeSelection,
+	getItemId,
+	item,
+	titleField,
+	mediaField,
+	descriptionField,
+	otherFields,
+	posinset,
+	setsize,
+}: PickerActivityItemProps< Item > ) {
+	const elementRef = useRef< HTMLButtonElement >( null );
+	useIntersectionObserver( elementRef, posinset );
+	const { showTitle = true, showMedia = true, showDescription = true } = view;
+	const id = getItemId( item );
+	const isSelected = selection.includes( id );
+	const density = view.layout?.density ?? 'balanced';
+
+	const mediaContent =
+		showMedia && density !== 'compact' && mediaField?.render ? (
+			<mediaField.render
+				item={ item }
+				field={ mediaField }
+				config={ {
+					sizes: density === 'comfortable' ? '32px' : '24px',
+				} }
+			/>
+		) : null;
+
+	const renderedMediaField = (
+		<div className="dataviews-view-picker-activity__item-type-icon">
+			{ mediaContent || (
+				<span
+					className="dataviews-view-picker-activity__item-bullet"
+					aria-hidden="true"
+				/>
+			) }
+		</div>
+	);
+
+	const renderedTitleField =
+		showTitle && titleField?.render ? (
+			<titleField.render item={ item } field={ titleField } />
+		) : null;
+
+	const renderedDescriptionField =
+		showDescription && descriptionField?.render ? (
+			<descriptionField.render item={ item } field={ descriptionField } />
+		) : null;
+
+	const verticalGap = useMemo( () => {
+		switch ( density ) {
+			case 'comfortable':
+				return 'md';
+			default:
+				return 'sm';
+		}
+	}, [ density ] );
+
+	return (
+		<Composite.Item
+			ref={ elementRef }
+			role="option"
+			aria-label={
+				titleField
+					? titleField.getValue( { item } ) || undefined
+					: undefined
+			}
+			aria-posinset={ posinset }
+			aria-setsize={ setsize }
+			aria-selected={ isSelected }
+			className={ clsx(
+				'dataviews-view-picker-activity__item',
+				density === 'compact' && 'is-compact',
+				density === 'balanced' && 'is-balanced',
+				density === 'comfortable' && 'is-comfortable',
+				isSelected && 'is-selected'
+			) }
+			onClick={ () => {
+				if ( isSelected ) {
+					onChangeSelection(
+						selection.filter( ( itemId ) => id !== itemId )
+					);
+				} else {
+					const newSelection = multiselect
+						? [ ...selection, id ]
+						: [ id ];
+					onChangeSelection( newSelection );
+				}
+			} }
+			render={ <div /> }
+		>
+			<Stack direction="row" gap="lg" justify="start" align="flex-start">
+				<Stack
+					direction="column"
+					gap="xs"
+					align="center"
+					className="dataviews-view-picker-activity__item-type"
+				>
+					{ renderedMediaField }
+				</Stack>
+				<Stack
+					direction="column"
+					gap={ verticalGap }
+					align="flex-start"
+					className="dataviews-view-picker-activity__item-content"
+				>
+					{ renderedTitleField && (
+						<div className="dataviews-view-picker-activity__item-title">
+							{ renderedTitleField }
+						</div>
+					) }
+					{ renderedDescriptionField && (
+						<div className="dataviews-view-picker-activity__item-description">
+							{ renderedDescriptionField }
+						</div>
+					) }
+					<div className="dataviews-view-picker-activity__item-fields">
+						{ otherFields.map( ( field ) => (
+							<div
+								key={ field.id }
+								className="dataviews-view-picker-activity__item-field"
+							>
+								<VisuallyHidden
+									render={ <span /> }
+									className="dataviews-view-picker-activity__item-field-label"
+								>
+									{ field.label }
+								</VisuallyHidden>
+								<span className="dataviews-view-picker-activity__item-field-value">
+									<field.render
+										item={ item }
+										field={ field }
+									/>
+								</span>
+							</div>
+						) ) }
+					</div>
+				</Stack>
+			</Stack>
+		</Composite.Item>
+	);
+}
+
+function PickerActivityGroup< Item >( {
+	groupName,
+	groupField,
+	showLabel = true,
+	children,
+}: {
+	groupName: string;
+	groupField: NormalizedField< Item >;
+	showLabel?: boolean;
+	children: ReactNode;
+} ) {
+	const headerId = useInstanceId(
+		PickerActivityGroup,
+		'dataviews-view-picker-activity-group__header'
+	);
+	return (
+		<Stack
+			direction="column"
+			role="group"
+			aria-labelledby={ headerId }
+			className="dataviews-view-picker-activity-group"
+		>
+			<h3
+				className="dataviews-view-picker-activity-group__header"
+				id={ headerId }
+			>
+				{ showLabel
+					? sprintf(
+							// translators: 1: The label of the field e.g. "Date". 2: The value of the field, e.g.: "May 2022".
+							__( '%1$s: %2$s' ),
+							groupField.label,
+							groupName
+					  )
+					: groupName }
+			</h3>
+			{ children }
+		</Stack>
+	);
+}
+
+export default function ViewPickerActivity< Item >( {
+	data,
+	fields,
+	getItemId,
+	isLoading,
+	onChangeSelection,
+	selection,
+	view,
+	actions,
+	className,
+	empty,
+}: ViewPickerActivityProps< Item > ) {
+	const { itemListLabel, paginationInfo } = useContext( DataViewsContext );
+	const isMultiselect = useIsMultiselectPicker( actions );
+
+	const titleField = fields.find(
+		( field ) => field.id === view?.titleField
+	);
+	const mediaField = fields.find(
+		( field ) => field.id === view?.mediaField
+	);
+	const descriptionField = fields.find(
+		( field ) => field.id === view?.descriptionField
+	);
+	const otherFields = ( view?.fields ?? [] )
+		.map( ( fieldId ) => fields.find( ( f ) => fieldId === f.id ) )
+		.filter( isDefined );
+
+	const groupField = view.groupBy?.field
+		? fields.find( ( f ) => f.id === view.groupBy?.field )
+		: null;
+	const dataByGroup = groupField ? getDataByGroup( data, groupField ) : null;
+
+	const isInfiniteScroll =
+		( view.infiniteScrollEnabled && ! dataByGroup ) ?? false;
+	const setsize = isInfiniteScroll ? paginationInfo?.totalItems : undefined;
+
+	const hasData = !! data?.length;
+
+	const renderItem = ( item: Item ) => (
+		<PickerActivityItem
+			key={ getItemId( item ) }
+			view={ view }
+			multiselect={ isMultiselect }
+			selection={ selection }
+			onChangeSelection={ onChangeSelection }
+			getItemId={ getItemId }
+			item={ item }
+			titleField={ titleField }
+			mediaField={ mediaField }
+			descriptionField={ descriptionField }
+			otherFields={ otherFields }
+			posinset={ ( item as { position?: number } ).position }
+			setsize={ setsize }
+		/>
+	);
+
+	if ( ! hasData ) {
+		return (
+			<div
+				className={ clsx( {
+					'dataviews-loading': isLoading,
+					'dataviews-no-results': ! isLoading,
+				} ) }
+			>
+				{ isLoading ? (
+					<p>
+						<Spinner />
+					</p>
+				) : (
+					empty
+				) }
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<Composite
+				virtualFocus
+				orientation="vertical"
+				role="listbox"
+				aria-multiselectable={ isMultiselect }
+				aria-label={ itemListLabel }
+				aria-busy={ isLoading }
+				className={ clsx(
+					'dataviews-view-picker-activity',
+					className
+				) }
+			>
+				{ groupField && dataByGroup
+					? Array.from( dataByGroup.entries() ).map(
+							( [ groupName, groupItems ]: [
+								string,
+								Item[],
+							] ) => (
+								<PickerActivityGroup< Item >
+									key={ groupName }
+									groupName={ groupName }
+									groupField={ groupField }
+									showLabel={
+										view.groupBy?.showLabel !== false
+									}
+								>
+									{ groupItems.map( renderItem ) }
+								</PickerActivityGroup>
+							)
+					  )
+					: data.map( renderItem ) }
+			</Composite>
+			{ isLoading && (
+				<p className="dataviews-loading-more">
+					<Spinner />
+				</p>
+			) }
+		</>
+	);
+}

--- a/packages/dataviews/src/components/dataviews-layouts/picker-activity/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-activity/style.scss
@@ -191,8 +191,7 @@
 		font-size: var(--wpds-typography-font-size-lg);
 		font-weight: var(--wpds-typography-font-weight-medium);
 		color: var(--wpds-color-fg-content-neutral-weak);
-		// Align with the timeline column; the first item's top margin gives the gap.
-		margin: 0;
+		margin: 0 0 var(--wpds-dimension-gap-sm) 0;
 		padding: 0;
 		padding-inline-start: var(--wpds-dimension-padding-2xl);
 	}

--- a/packages/dataviews/src/components/dataviews-layouts/picker-activity/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-activity/style.scss
@@ -1,0 +1,228 @@
+.dataviews-view-picker-activity {
+	margin: 0;
+	padding: 0;
+	// Fill the wrapper height so the footer sits at the bottom.
+	flex-grow: 1;
+
+	&:focus-visible {
+		&[aria-activedescendant] {
+			outline: none;
+		}
+
+		.dataviews-view-picker-activity__item[data-active-item="true"] {
+			outline: 2px solid var(--wpds-color-stroke-focus-brand);
+			outline-offset: -2px;
+		}
+	}
+
+	.dataviews-view-picker-activity__item {
+		cursor: var(--wpds-cursor-control);
+		border-radius: var(--wpds-border-radius-sm);
+		// Inset content to the toolbar/footer padding so the timeline aligns with the chrome.
+		padding-inline: var(--wpds-dimension-padding-2xl);
+		transition: background-color 0.1s ease;
+
+		// Selected and hovered rows share the same tint (like the table picker),
+		// keeping selection legible even for bullet-only items.
+		&.is-selected,
+		&:hover {
+			background-color: var(--wpds-color-bg-interactive-brand-weak-active);
+		}
+
+		// Selection outline only renders in Windows High Contrast mode.
+		&.is-selected {
+			outline: 3px solid transparent;
+			outline-offset: -2px;
+		}
+
+		&.is-compact {
+			.dataviews-view-picker-activity__item-type {
+				width: var(--wpds-dimension-padding-md);
+
+				&::before {
+					height: calc(var(--wpds-dimension-base) * 3);
+				}
+			}
+			.dataviews-view-picker-activity__item-type-icon {
+				width: calc(var(--wpds-dimension-base) * 3 - 1px);
+				height: calc(var(--wpds-dimension-base) * 3 - 1px);
+			}
+			.dataviews-view-picker-activity__item-content {
+				margin: var(--wpds-dimension-gap-md) 0;
+			}
+		}
+
+		&.is-balanced {
+			.dataviews-view-picker-activity__item-type {
+				width: calc(var(--wpds-dimension-base) * 6); // TODO: use size token when available
+
+				&::before {
+					height: calc(var(--wpds-dimension-base) * 3);
+				}
+			}
+			.dataviews-view-picker-activity__item-type-icon {
+				width: calc(var(--wpds-dimension-base) * 6 + 1px);
+				height: calc(var(--wpds-dimension-base) * 6 + 1px);
+			}
+			.dataviews-view-picker-activity__item-content {
+				margin: var(--wpds-dimension-gap-md) 0;
+				padding-top: var(--wpds-dimension-padding-sm);
+			}
+		}
+
+		&.is-comfortable {
+			.dataviews-view-picker-activity__item-type {
+				width: calc(var(--wpds-dimension-base) * 8); // TODO: use size token when available
+
+				&::before {
+					height: calc(var(--wpds-dimension-base) * 2);
+				}
+			}
+			.dataviews-view-picker-activity__item-type-icon {
+				width: calc(var(--wpds-dimension-base) * 8 + 1px);
+				height: calc(var(--wpds-dimension-base) * 8 + 1px);
+			}
+			.dataviews-view-picker-activity__item-content {
+				margin: var(--wpds-dimension-gap-sm) 0 var(--wpds-dimension-gap-lg);
+				padding-top: var(--wpds-dimension-padding-md);
+			}
+		}
+
+		&.is-comfortable,
+		&.is-balanced {
+			.dataviews-view-picker-activity__item-bullet {
+				width: calc(var(--wpds-dimension-base) * 2 + 1px);
+				height: calc(var(--wpds-dimension-base) * 2 + 1px);
+				position: relative;
+				top: 50%;
+				transform: translateY(-50%);
+			}
+		}
+	}
+
+	.dataviews-view-picker-activity__item-content {
+		flex-grow: 1;
+
+		.dataviews-view-picker-activity__item-title,
+		.dataviews-view-picker-activity__item-description,
+		.dataviews-view-picker-activity__item-fields {
+			min-height: calc(var(--wpds-dimension-base) * 4); // TODO: use size token when available
+		}
+
+		.dataviews-view-picker-activity__item-title {
+			position: relative;
+			display: flex;
+			align-items: center;
+			flex: 1;
+			overflow: hidden;
+		}
+
+		.dataviews-view-picker-activity__item-description {
+			&:empty {
+				display: none;
+			}
+		}
+
+		.dataviews-view-picker-activity__item-fields {
+			color: var(--wpds-color-fg-content-neutral-weak);
+			display: flex;
+			gap: var(--wpds-dimension-gap-md);
+			row-gap: var(--wpds-dimension-gap-xs);
+			flex-wrap: wrap;
+
+			&:empty {
+				display: none;
+			}
+
+			.dataviews-view-picker-activity__item-field {
+				&:has(.dataviews-view-picker-activity__item-field-value:empty) {
+					display: none;
+				}
+			}
+
+			.dataviews-view-picker-activity__item-field-value {
+				display: flex;
+				align-items: center;
+			}
+		}
+	}
+
+	// Timeline connector line
+	.dataviews-view-picker-activity__item-type {
+		align-self: stretch;
+		flex-shrink: 0;
+
+		&::after {
+			content: "";
+			flex: 1 1 auto;
+			width: 1px;
+			margin: 0 auto;
+			background-color: var(--wpds-color-stroke-surface-neutral);
+		}
+
+		&::before {
+			content: "";
+			flex: 0 0 auto;
+			width: 1px;
+			margin: 0 auto;
+			background-color: var(--wpds-color-stroke-surface-neutral);
+		}
+	}
+
+	// First and last item timeline lines
+	.dataviews-view-picker-activity__item:first-child {
+		.dataviews-view-picker-activity__item-type {
+			&::before {
+				visibility: hidden;
+			}
+		}
+	}
+
+	.dataviews-view-picker-activity-group:last-of-type > .dataviews-view-picker-activity__item:last-of-type,
+	& > .dataviews-view-picker-activity__item:last-child {
+		.dataviews-view-picker-activity__item-type {
+			&::after {
+				background: linear-gradient(to bottom, var(--wpds-color-stroke-surface-neutral) 0%, color-mix(in srgb, var(--wpds-color-stroke-surface-neutral) 20%, transparent) 60%, transparent 100%);
+			}
+		}
+	}
+
+	.dataviews-view-picker-activity-group__header {
+		font-size: var(--wpds-typography-font-size-lg);
+		font-weight: var(--wpds-typography-font-weight-medium);
+		color: var(--wpds-color-fg-content-neutral-weak);
+		// Align with the timeline column; the first item's top margin gives the gap.
+		margin: 0;
+		padding: 0;
+		padding-inline-start: var(--wpds-dimension-padding-2xl);
+	}
+
+	// Bullet/icon styling
+	.dataviews-view-picker-activity__item-type-icon {
+		overflow: hidden;
+		flex-shrink: 0;
+		// Transparent so the row tint shows through the corners around the round media.
+		background-color: transparent;
+
+		img,
+		svg,
+		.dataviews-view-picker-activity__item-bullet {
+			display: block;
+			width: 100%;
+			height: 100%;
+			margin: 0 auto;
+			object-fit: cover;
+			border-radius: 50%;
+			box-sizing: border-box;
+			box-shadow: inset 0 0 0 var(--wpds-border-width-xs) var(--wpds-color-stroke-surface-neutral);
+		}
+
+		svg {
+			padding: var(--wpds-dimension-padding-xs);
+		}
+
+		.dataviews-view-picker-activity__item-bullet {
+			background-color: var(--wpds-color-stroke-surface-neutral);
+		}
+	}
+}

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -85,6 +85,7 @@ export function ViewTypeMenu() {
 									case 'table':
 									case 'pickerGrid':
 									case 'pickerTable':
+									case 'pickerActivity':
 									case 'activity':
 										const viewWithoutLayout = { ...view };
 										if ( 'layout' in viewWithoutLayout ) {

--- a/packages/dataviews/src/constants.ts
+++ b/packages/dataviews/src/constants.ts
@@ -54,5 +54,6 @@ export const LAYOUT_ACTIVITY = 'activity';
 // Picker view layouts.
 export const LAYOUT_PICKER_GRID = 'pickerGrid';
 export const LAYOUT_PICKER_TABLE = 'pickerTable';
+export const LAYOUT_PICKER_ACTIVITY = 'pickerActivity';
 
 export const DAYS_OF_WEEK: DayNumber[] = [ 0, 1, 2, 3, 4, 5, 6 ];

--- a/packages/dataviews/src/dataviews-picker/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews-picker/stories/index.story.tsx
@@ -186,6 +186,11 @@ const DataViewsPickerContent = ( {
 				fields={ fields }
 				onChangeView={ setView }
 				config={ { perPageSizes } }
+				defaultLayouts={ {
+					pickerGrid: true,
+					pickerTable: true,
+					pickerActivity: true,
+				} }
 				itemListLabel="Galactic Bodies"
 			/>
 		</>

--- a/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
+++ b/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
@@ -543,6 +543,11 @@ describe( 'DataViews Picker', () => {
 				screen.getByRole( 'menuitemradio', { name: 'Table' } )
 			).toBeInTheDocument();
 
+			// The Activity layout is opt-in and must not appear by default.
+			expect(
+				screen.queryByRole( 'menuitemradio', { name: 'Activity' } )
+			).not.toBeInTheDocument();
+
 			// The grid layout is active by default.
 			expect(
 				screen.getByRole( 'menuitemradio', { name: 'Grid' } )

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -13,6 +13,7 @@
 @use "./components/dataviews-layouts/picker-grid/style.scss" as *;
 @use "./components/dataviews-layouts/picker-table/style.scss" as *;
 @use "./components/dataviews-layouts/activity/style.scss" as *;
+@use "./components/dataviews-layouts/picker-activity/style.scss" as *;
 @use "./components/dataviews-picker-footer/style.scss" as *;
 
 @use "./components/dataform-controls/style.scss" as *;

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -342,12 +342,24 @@ export interface ViewPickerTable extends ViewBase {
 	};
 }
 
+export interface ViewPickerActivity extends ViewBase {
+	type: 'pickerActivity';
+
+	layout?: {
+		/**
+		 * The density of the view.
+		 */
+		density?: Density;
+	};
+}
+
 export type View =
 	| ViewList
 	| ViewGrid
 	| ViewTable
 	| ViewPickerGrid
 	| ViewPickerTable
+	| ViewPickerActivity
 	| ViewActivity;
 
 interface ActionBase< Item > {
@@ -516,6 +528,11 @@ export interface ViewPickerTableProps< Item >
 	view: ViewPickerTable;
 }
 
+export interface ViewPickerActivityProps< Item >
+	extends Omit< ViewPickerBaseProps< Item >, 'view' > {
+	view: ViewPickerActivity;
+}
+
 export type ViewProps< Item > =
 	| ViewTableProps< Item >
 	| ViewGridProps< Item >
@@ -524,7 +541,8 @@ export type ViewProps< Item > =
 
 export type ViewPickerProps< Item > =
 	| ViewPickerGridProps< Item >
-	| ViewPickerTableProps< Item >;
+	| ViewPickerTableProps< Item >
+	| ViewPickerActivityProps< Item >;
 
 export interface SupportedLayouts {
 	list?: Omit< ViewList, 'type' > | true;
@@ -533,6 +551,7 @@ export interface SupportedLayouts {
 	activity?: Omit< ViewActivity, 'type' > | true;
 	pickerGrid?: Omit< ViewPickerGrid, 'type' > | true;
 	pickerTable?: Omit< ViewPickerTable, 'type' > | true;
+	pickerActivity?: Omit< ViewPickerActivity, 'type' > | true;
 }
 
 export interface NormalizedSupportedLayouts {
@@ -542,4 +561,5 @@ export interface NormalizedSupportedLayouts {
 	activity?: Omit< ViewActivity, 'type' >;
 	pickerGrid?: Omit< ViewPickerGrid, 'type' >;
 	pickerTable?: Omit< ViewPickerTable, 'type' >;
+	pickerActivity?: Omit< ViewPickerActivity, 'type' >;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Extracted from: https://github.com/WordPress/gutenberg/pull/77333

This PR adds a new DataViewsPicker layout similar to the DataViews activity layout. This layout seems a nice fit for use cases like the `revisions` UI and eventually is going to be used by the new revisions screen and GS revisions.

## Testing Instructions
1. In storybook (`npm run storybook:dev`) go to this path: `?path=/story/dataviews-dataviewspicker--default`
2. Select the `Activity` layout and play around with the options and UI/UX



## Screenshots or screencast <!-- if applicable -->
<img width="944" height="699" alt="Screenshot 2026-06-04 at 1 00 22 PM" src="https://github.com/user-attachments/assets/77ab2265-3fd3-4aa1-9944-5442636a996f" />



## Use of AI Tools
Opus 4.8 with direction, changes and review
