### PR TITLE
Fix: block auto-complete for AI API Keys in Connectors

### DIFF
--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -208,6 +208,7 @@ export function DefaultConnectorSettings( {
 				} }
 				placeholder={ __( 'Enter your API key' ) }
 				disabled={ readOnly || isSaving }
+				autoComplete="off"
 				help={ getHelp() }
 			/>
 			{ readOnly ? (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #78945

Closes https://core.trac.wordpress.org/ticket/65303

Fix: block auto-complete for AI API Keys in Connectors

@justlevine please review

