### PR TITLE
Reset preview device to Desktop when entering focus mode for template parts and patterns

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -17,7 +17,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { privateApis as blockLibraryPrivateApis } from '@wordpress/block-library';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -148,7 +148,22 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 	const editorSettings = useSpecificEditorSettings();
 	const { resetZoomLevel } = unlock( useDispatch( blockEditorStore ) );
 	const { setCurrentRevisionId } = unlock( useDispatch( editorStore ) );
+	const { setDeviceType } = useDispatch( editorStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
+
+	useEffect( () => {
+		if ( isLoading || ! isEditMode ) {
+			return;
+		}
+
+		const isFocusModeEditor =
+			postType === 'wp_template_part' || postType === 'wp_block';
+
+		if ( isFocusModeEditor ) {
+			setDeviceType( 'Desktop' );
+		}
+	}, [ isLoading, isEditMode, postType, postId, setDeviceType ] );
+
 	const onActionPerformed = useCallback(
 		( actionId, items ) => {
 			switch ( actionId ) {


### PR DESCRIPTION
## What?
Closes #73769

This PR ensures that when a user navigates to edit a Template Part or Synced Pattern (`wp_block`), the preview device type is automatically reset to `Desktop`.

## Why?
Currently, if a user sets the Site Editor preview mode to `Mobile` or `Tablet`, that state persists when drilling down into a Template Part. Because the focus mode utilizes a canvas with draggable resize handles, inheriting the strict CSS `max-width` constraints of the Mobile/Tablet device type overrides the JavaScript resizer. 

This leads to the canvas becoming locked, the resize handles becoming unresponsive, and the bottom of the template part becoming un-editable due to clipped scroll containers.

## How?
Added a `useEffect` hook, it checks if the user is editing a `wp_template_part` or `wp_block`. If so, it dispatches `setDeviceType( 'Desktop' )`.

## Testing Instructions
1. Navigate to the Site Editor (Appearance > Editor).
2. Change the preview mode to **Mobile** or **Tablet** using the top toolbar.
3. Click on the Footer (or Header) template part, and click the **"Edit"** button.
4. The editor should automatically reset to the Desktop view.
5. The responsive canvas resize handles on the sides should be fully functional.
6. Click **Back** to return to the main Site Editor.
7. Switch to **Mobile** again, and click **Edit** on the template part a second time to ensure the reset fires reliably on subsequent visits.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/6bdaa7c6-0e45-477e-bd4e-7290402020a2


