### PR TITLE
ui/AlertDialog: Fix footer layout style override

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug Fixes
 
+-   `AlertDialog`: Move the footer layout override into the `wp-ui-compositions` layer so it reliably overrides the shared chrome `.footer` regardless of stylesheet injection order.
 -   `Button.Icon`: Preserve icon view boxes so icons with non-standard `viewBox` values are not clipped ([#78614](https://github.com/WordPress/gutenberg/pull/78614)).
 
 ### Enhancements

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Bug Fixes
 
--   `AlertDialog`: Move the footer layout override into the `wp-ui-compositions` layer so it reliably overrides the shared chrome `.footer` regardless of stylesheet injection order.
+-   `AlertDialog`: Fix the footer collapsing to a row depending on stylesheet load order ([#78953](https://github.com/WordPress/gutenberg/pull/78953)).
 -   `Button.Icon`: Preserve icon view boxes so icons with non-standard `viewBox` values are not clipped ([#78614](https://github.com/WordPress/gutenberg/pull/78614)).
 
 ### Enhancements

--- a/packages/ui/CONTRIBUTING.md
+++ b/packages/ui/CONTRIBUTING.md
@@ -274,6 +274,8 @@ Every component stylesheet must include the layer definition at the top and wrap
 -   **`wp-ui-compositions`** - Internal compositions that extend base components
 -   **`wp-ui-overrides`** - Last-resort styles to override default rules
 
+A rule that overrides a primitive defined in another stylesheet (e.g. a shared class from `overlay-chrome.module.css`) must live in a **higher** layer than that primitive — typically `wp-ui-compositions`. Placing both in the same layer leaves the conflict to be resolved by `<style>` injection order, which is not deterministic and can flip when an unrelated component lazy-loads (its own copy of the shared stylesheet re-orders the tags). The layer hierarchy is what guarantees the override wins.
+
 ### Custom Properties and State Styles
 
 When components expose CSS custom properties (variables) for theming or composition, care must be taken to separate **configurable values** from **state handling**. Getting this wrong can silently break styles when components are composed across CSS layers.

--- a/packages/ui/CONTRIBUTING.md
+++ b/packages/ui/CONTRIBUTING.md
@@ -276,6 +276,17 @@ Every component stylesheet must include the layer definition at the top and wrap
 
 A rule that overrides a primitive defined in another stylesheet (e.g. a shared class from `overlay-chrome.module.css`) must live in a **higher** layer than that primitive — typically `wp-ui-compositions`. Placing both in the same layer leaves the conflict to be resolved by `<style>` injection order, which is not deterministic and can flip when an unrelated component lazy-loads (its own copy of the shared stylesheet re-orders the tags). The layer hierarchy is what guarantees the override wins.
 
+When the override also `composes` the primitive it extends, keep the override in `wp-ui-compositions` (the `composes` does not change its layer) and let `composes` bind the two classes together so the base can never be applied without the override:
+
+```css
+@layer wp-ui-compositions {
+	.footer-column {
+		composes: footer from "../utils/css/overlay-chrome.module.css";
+		flex-direction: column;
+	}
+}
+```
+
 ### Custom Properties and State Styles
 
 When components expose CSS custom properties (variables) for theming or composition, care must be taken to separate **configurable values** from **state handling**. Getting this wrong can silently break styles when components are composed across CSS layers.

--- a/packages/ui/src/alert-dialog/popup.tsx
+++ b/packages/ui/src/alert-dialog/popup.tsx
@@ -97,12 +97,7 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >(
 		);
 
 		const footerElement = (
-			<div
-				className={ clsx(
-					overlayChromeStyles.footer,
-					alertDialogStyles[ 'footer-column' ]
-				) }
-			>
+			<div className={ alertDialogStyles[ 'footer-column' ] }>
 				<Stack
 					direction="row"
 					gap="sm"

--- a/packages/ui/src/alert-dialog/style.module.css
+++ b/packages/ui/src/alert-dialog/style.module.css
@@ -5,7 +5,9 @@
 		align-self: flex-end;
 		color: var(--wpds-color-fg-content-error);
 	}
+}
 
+@layer wp-ui-compositions {
 	/*
 	 * AlertDialog stacks an actions row and an optional error message in
 	 * its footer. Override the shared `.footer` row layout to a column so
@@ -18,9 +20,7 @@
 		justify-content: flex-start;
 		gap: var(--wpds-dimension-gap-md);
 	}
-}
 
-@layer wp-ui-compositions {
 	.irreversible-action {
 		--wp-ui-button-background-color: var(--wpds-color-bg-interactive-error-strong);
 		--wp-ui-button-background-color-active: var(--wpds-color-bg-interactive-error-strong-active);

--- a/packages/ui/src/alert-dialog/style.module.css
+++ b/packages/ui/src/alert-dialog/style.module.css
@@ -10,11 +10,18 @@
 @layer wp-ui-compositions {
 	/*
 	 * AlertDialog stacks an actions row and an optional error message in
-	 * its footer. Override the shared `.footer` row layout to a column so
-	 * both children lay out vertically while inheriting the chrome
-	 * padding + separator from `overlay-chrome.module.css`.
+	 * its footer. `composes` the shared `.footer` so the chrome padding +
+	 * separator are inherited, then overrides the row layout to a column.
+	 *
+	 * The override lives in `wp-ui-compositions` (a higher layer than the
+	 * composed `.footer`, which sits in `wp-ui-components`) so it always
+	 * wins regardless of stylesheet injection order. `composes` keeps the
+	 * two classes bound together so the base styles can never be applied
+	 * without this override.
 	 */
 	.footer-column {
+		composes: footer from "../utils/css/overlay-chrome.module.css";
+
 		flex-direction: column;
 		align-items: stretch;
 		justify-content: flex-start;


### PR DESCRIPTION
## What?

Make `AlertDialog`'s `.footer-column` compose the shared `.footer` and place the override in the `wp-ui-compositions` CSS layer.

## Why?

The footer's custom column layout could randomly collapse back to a row:

-   `.footer-column` overrides the shared `.footer` style, but both sat in the same CSS layer.
-   With no layer difference, the winner is decided by the order the stylesheets load.
-   Loading another overlay (e.g. hovering the `Drawer` sidebar item in Storybook) reshuffles that order, so the shared `.footer` wins and the override is lost.
-   Reproducible in Firefox.

Putting the override in a higher layer (`wp-ui-compositions`) makes it win every time, regardless of load order.

## How?

-   The override now lives in the higher `wp-ui-compositions` layer, so it wins by layer precedence independent of injection order.
-   `.footer-column` `composes` the shared `.footer` (instead of pairing the two classes via `clsx` in `popup.tsx`), so the base chrome and the override are always applied together and the relationship is self-documented in CSS.
-   Added a short note in CONTRIBUTING documenting both points.

## Testing Instructions

Use Firefox.

1. In Storybook, open the `AlertDialog` example (with footer actions).
2. Hover the `Drawer` item in the sidebar to trigger its styles loading.
3. The alert dialog footer must keep its column layout (actions + error message stacked) and not collapse to a row.

## Screen recordings

Before:

https://github.com/user-attachments/assets/814d3d06-d976-46b4-ab1d-806090bc369f

After:

https://github.com/user-attachments/assets/c2a61a0c-7d75-4558-bf45-f30e554aa053

## Use of AI Tools

Cursor + Opus 4.8