### PR TITLE
Add playlist track length setting

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -627,7 +627,7 @@ Embed a simple playlist. ([Source](https://github.com/WordPress/gutenberg/tree/t
 -	**Category:** media
 -	**Allowed Blocks:** core/playlist-track
 -	**Supports:** align, anchor, color (background, gradients, link, text), interactivity, spacing (margin, padding)
--	**Attributes:** caption, currentTrack, order, showArtists, showImages, showNumbers, showTracklist, type
+-	**Attributes:** caption, currentTrack, order, showArtists, showImages, showNumbers, showTrackLength, showTracklist, type
 
 ## Playlist track
 

--- a/packages/block-library/src/playlist/block.json
+++ b/packages/block-library/src/playlist/block.json
@@ -37,6 +37,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"showTrackLength": {
+			"type": "boolean",
+			"default": true
+		},
 		"caption": {
 			"type": "string"
 		}

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -55,6 +55,7 @@ const PlaylistEdit = ( {
 		showNumbers,
 		showImages,
 		showArtists,
+		showTrackLength,
 		currentTrack,
 	} = attributes;
 
@@ -280,6 +281,7 @@ const PlaylistEdit = ( {
 							showTracklist: true,
 							showArtists: true,
 							showNumbers: true,
+							showTrackLength: true,
 							showImages: true,
 							order: 'asc',
 						} );
@@ -336,6 +338,24 @@ const PlaylistEdit = ( {
 									checked={ showNumbers }
 								/>
 							</ToolsPanelItem>
+							<ToolsPanelItem
+								label={ __( 'Show track length in Tracklist' ) }
+								isShownByDefault
+								hasValue={ () => showTrackLength !== true }
+								onDeselect={ () =>
+									setAttributes( { showTrackLength: true } )
+								}
+							>
+								<ToggleControl
+									label={ __(
+										'Show track length in Tracklist'
+									) }
+									onChange={ toggleAttribute(
+										'showTrackLength'
+									) }
+									checked={ showTrackLength }
+								/>
+							</ToolsPanelItem>
 						</>
 					) }
 					<ToolsPanelItem
@@ -387,6 +407,8 @@ const PlaylistEdit = ( {
 						className={ clsx( 'wp-block-playlist__tracklist', {
 							'wp-block-playlist__tracklist-show-numbers':
 								showNumbers,
+							'wp-block-playlist__tracklist-length-is-hidden':
+								! showTrackLength,
 						} ) }
 					>
 						{ innerBlocksProps.children }

--- a/packages/block-library/src/playlist/save.js
+++ b/packages/block-library/src/playlist/save.js
@@ -14,7 +14,13 @@ import {
 } from '@wordpress/block-editor';
 
 export default function saveWithInnerBlocks( { attributes } ) {
-	const { caption, showNumbers, showTracklist, showArtists } = attributes;
+	const {
+		caption,
+		showNumbers,
+		showTracklist,
+		showArtists,
+		showTrackLength,
+	} = attributes;
 
 	const blockProps = useBlockProps.save();
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
@@ -25,6 +31,8 @@ export default function saveWithInnerBlocks( { attributes } ) {
 					'wp-block-playlist__tracklist-is-hidden': ! showTracklist,
 					'wp-block-playlist__tracklist-artist-is-hidden':
 						! showArtists,
+					'wp-block-playlist__tracklist-length-is-hidden':
+						! showTrackLength,
 					'wp-block-playlist__tracklist-show-numbers': showNumbers,
 				} ) }
 			>

--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -62,6 +62,13 @@ $waveform-player-height: 100px;
 			}
 		}
 
+		&.wp-block-playlist__tracklist-length-is-hidden {
+			// Hide the track length, which is in the playlist-track block.
+			.wp-block-playlist-track__length {
+				display: none;
+			}
+		}
+
 		&.wp-block-playlist__tracklist-show-numbers {
 			counter-reset: playlist-track;
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Extracted from #75060.

Adds a `showTrackLength` setting to the Playlist block so track lengths can be hidden in the tracklist.

## Why?
This extracts the independent track length visibility change from the larger playlist waveform work so it can be reviewed separately.

## How?
The PR adds a `showTrackLength` boolean attribute, exposes it in the Playlist settings panel, applies hidden-length classes in editor and saved markup, and adds CSS to hide `.wp-block-playlist-track__length` when disabled.

## Testing Instructions
1. Open the editor and insert a Playlist block with audio tracks.
2. Open the Playlist block settings.
3. Toggle "Show track length in Tracklist" off and confirm track lengths are hidden.
4. Toggle it back on and confirm track lengths are shown again.

### Testing Instructions for Keyboard
1. Use the keyboard to focus the Playlist block.
2. Open block settings and tab to "Show track length in Tracklist".
3. Toggle it with the keyboard and confirm the track length visibility changes.

## Screenshots or screencast
<img width="1072" height="696" alt="Jun-04-2026 16-18-30" src="https://github.com/user-attachments/assets/c5bf6402-ae0c-4bdb-abfe-074ac83f7f57" />


## Use of AI Tools
This PR was prepared with assistance from OpenAI Codex. I reviewed the diff and am responsible for the changes.
