### PR TITLE
Patterns: fix focus loss when closing the Create pattern dialog from the block toolbar

### DIFF
--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -186,7 +186,6 @@ export default function PatternConvertButton( {
 					} }
 					onClose={ () => {
 						setIsModalOpen( false );
-						closeBlockSettingsMenu();
 					} }
 				/>
 			) }


### PR DESCRIPTION
## What?

Fixes a focus management regression in the "Create pattern" dialog opened from the block toolbar Options menu.

Closes #78952.

## Why?

When pressing Escape (or otherwise dismissing the dialog without saving), focus was lost because the `onClose` handler for `CreatePatternModal` called `closeBlockSettingsMenu()`, which closed the entire parent dropdown menu. This left no visible focused element in the page.

Other dialogs in the same Options menu — **Lock**, **Rename**, and **Hide** — all follow the correct pattern: they only close the modal on dismiss, keeping the dropdown open so focus can return to the triggering menu item.

## How?

Removed `closeBlockSettingsMenu()` from the `onClose` handler in `PatternConvertButton`. 

`closeBlockSettingsMenu()` is still called correctly in `handleSuccess()` after the user successfully creates a pattern, ensuring the dropdown closes after a committed action.

```diff
 onClose={ () => {
     setIsModalOpen( false );
-    closeBlockSettingsMenu();
 } }
```

## Testing Instructions

1. Create a post, add a Paragraph block.
2. Click the block toolbar **Options** (⋮) menu.
3. Click **"Create pattern"** — the dialog opens.
4. Press **Escape** — the dialog should close, focus should return to the **"Create pattern"** menu item in the still-open Options menu.
5. Verify the same behavior still works correctly for **Lock**, **Rename**, and **Hide** (they should be unchanged).
6. Also verify: creating a pattern successfully still closes both the modal AND the Options dropdown.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:

https://github.com/user-attachments/assets/d7964473-d382-4196-9b2f-1f901257f5e1

After:

https://github.com/user-attachments/assets/56d962f1-b544-44d5-b5ef-a50e4e680a2b

