### PR TITLE
DataViews: Add DataViews components to components manifest

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
 
+### Documentation
+
+-   Include DataViews components in [WordPress Design System MCP Server](https://github.com/WordPress/gutenberg/tree/trunk/packages/design-system-mcp) documented components ([#78960](https://github.com/WordPress/gutenberg/pull/78960)).
+
 ## 15.0.0 (2026-05-27)
 
 ### Breaking Changes

--- a/packages/dataviews/src/dataform/stories/content.story.tsx
+++ b/packages/dataviews/src/dataform/stories/content.story.tsx
@@ -18,7 +18,7 @@ const meta: Meta< typeof DataForm > = {
 	parameters: {
 		controls: { disable: true },
 	},
-	tags: [ '!dev' /* Hide individual story pages from sidebar */ ],
+	tags: [ '!dev' /* Hide individual story pages from sidebar */, 'manifest' ],
 };
 export default meta;
 

--- a/packages/dataviews/src/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/dataform/stories/index.story.tsx
@@ -13,6 +13,7 @@ import ValidationComponent from './validation';
 import VisibilityComponent from './visibility';
 
 const meta = {
+	tags: [ 'manifest' ],
 	title: 'DataViews/DataForm',
 	component: DataForm,
 };

--- a/packages/dataviews/src/dataviews-picker/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews-picker/stories/index.story.tsx
@@ -20,6 +20,7 @@ import type { ActionButton, View } from '../../types';
 import { data, fields, type SpaceObject } from './fixtures';
 
 const meta = {
+	tags: [ 'manifest' ],
 	title: 'DataViews/DataViewsPicker',
 	component: DataViewsPicker,
 } as Meta< typeof DataViewsPicker >;

--- a/packages/dataviews/src/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews/stories/index.story.tsx
@@ -21,6 +21,7 @@ import EmptyComponent from './empty';
 import './style.css';
 
 const meta = {
+	tags: [ 'manifest' ],
 	title: 'DataViews/DataViews',
 	component: DataViews,
 	args: {


### PR DESCRIPTION
## What?

Updates DataViews component Storybook stories to add the `'manifest'` tags so that the components are included in the [output manifest](https://storybook.js.org/docs/ai/manifests) on the [hosted `components.json`](https://wordpress.github.io/gutenberg/manifests/components.json).

## Why?

The components manifest is used as the record of "recommended design system components", and is [used by the `@wordpress/design-system-mcp` package](https://github.com/WordPress/gutenberg/blob/d46d47cda4d37846c7e88176b1625f9e7239dde8/packages/design-system-mcp/src/data.ts#L27-L61) for providing a list and details about design system components. Because [DataViews is a package of the design system](https://wordpress.github.io/gutenberg/?path=/docs/design-system-introduction--docs#compositional-packages) and its components are recommended for use, it should be included in the manifest so that the MCP server includes information about the components.

## Testing Instructions

Verify that DataViews components are included in the manifest:

1. Run `npm run storybook:build`
2. Run `grep -q "dataviews" storybook/build/manifests/components.json && echo "Found" || echo "Not Found"`
3. Alternatively: `open storybook/build/manifests/components.html` and observe DataViews in list

Verify that MCP server provides details about the components, using [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector):

1. Run `npm run storybook:build`
2. In a separate terminal process, host the built Storybook: `cd storybook/build && php -S 127.0.0.1:8000`
3. Run `npx @modelcontextprotocol/inspector node packages/design-system-mcp/bin/design-system-mcp.mjs`
4. In the launched browser window, expand "Environment Variables" and add `COMPONENTS_MANIFEST_URL` with value `http://localhost:8000/manifests/components.json`
5. Click "Connect"
6. Under Tools, click "List Tools"
7. Click "Get Components"
8. Click "Run Tool"
9. Observe in tool result that the list of components includes "DataViews", "DataForm", and "DataViewsPicker"
10. Under Tools, click "Get Component Details"
11. In Name, enter `"DataViews"` (including quotes)
12. Click "Run Tool"
13. Observe tool result shows detailed information about DataViews, including props and story examples
   - Note that descriptions aren't being extracted properly. This may be improved in #77382 

## Screenshots or screencast <!-- if applicable -->

<img width="1695" height="1327" alt="image" src="https://github.com/user-attachments/assets/bdbcfce4-dbeb-4ca4-9f3a-f1b65cbbe397" />

## Use of AI Tools

Used Cursor + Claude Opus 4.8 to investigate applicability of components to include from design system packages and add tags.