### PR TITLE
Table block: Keep table actions enabled after deleting a row or column

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -56,6 +56,7 @@ import {
 	createTable,
 	updateSelectedCell,
 	getCellAttribute,
+	getFirstRow,
 	insertRow,
 	deleteRow,
 	insertColumn,
@@ -292,10 +293,26 @@ function TableEdit( {
 			return;
 		}
 
-		const { sectionName, rowIndex } = selectedCell;
+		const { sectionName, rowIndex, columnIndex } = selectedCell;
+		const newAttributes = deleteRow( attributes, {
+			sectionName,
+			rowIndex,
+		} );
+		setAttributes( newAttributes );
 
-		setSelectedCell();
-		setAttributes( deleteRow( attributes, { sectionName, rowIndex } ) );
+		// Keep a cell selected so the table actions remain available without
+		// having to refocus a cell first.
+		const remainingRowCount = newAttributes[ sectionName ]?.length ?? 0;
+		if ( remainingRowCount === 0 ) {
+			setSelectedCell();
+			return;
+		}
+		setSelectedCell( {
+			sectionName,
+			rowIndex: Math.min( rowIndex, remainingRowCount - 1 ),
+			columnIndex: columnIndex ?? 0,
+			type: 'cell',
+		} );
 	}
 
 	/**
@@ -346,12 +363,24 @@ function TableEdit( {
 			return;
 		}
 
-		const { sectionName, columnIndex } = selectedCell;
+		const { sectionName, rowIndex, columnIndex } = selectedCell;
+		const newAttributes = deleteColumn( attributes, { columnIndex } );
+		setAttributes( newAttributes );
 
-		setSelectedCell();
-		setAttributes(
-			deleteColumn( attributes, { sectionName, columnIndex } )
-		);
+		// Keep a cell selected so the table actions remain available without
+		// having to refocus a cell first.
+		const remainingColumnCount =
+			getFirstRow( newAttributes )?.cells?.length ?? 0;
+		if ( remainingColumnCount === 0 ) {
+			setSelectedCell();
+			return;
+		}
+		setSelectedCell( {
+			sectionName: sectionName ?? 'body',
+			rowIndex: rowIndex ?? 0,
+			columnIndex: Math.min( columnIndex, remainingColumnCount - 1 ),
+			type: 'cell',
+		} );
 	}
 
 	useEffect( () => {

--- a/test/e2e/specs/editor/blocks/table.spec.js
+++ b/test/e2e/specs/editor/blocks/table.spec.js
@@ -184,6 +184,39 @@ test.describe( 'Table', () => {
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	test( 'keeps table actions available after deleting a row or column', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/table' } );
+
+		// Create the default table.
+		await editor.canvas
+			.locator( 'role=button[name="Create Table"i]' )
+			.click();
+
+		// Focus a body cell so the table actions become available.
+		await editor.canvas
+			.locator( 'role=textbox[name="Body cell text"i] >> nth=0' )
+			.click();
+
+		// Delete a row, then reopen the menu. The actions should remain
+		// enabled without having to refocus a cell first (see #28714).
+		await editor.clickBlockToolbarButton( 'Edit table' );
+		await page.click( 'role=menuitem[name="Delete row"i]' );
+		await editor.clickBlockToolbarButton( 'Edit table' );
+		await expect(
+			page.locator( 'role=menuitem[name="Delete row"i]' )
+		).toBeEnabled();
+
+		// Same expectation after deleting a column.
+		await page.click( 'role=menuitem[name="Delete column"i]' );
+		await editor.clickBlockToolbarButton( 'Edit table' );
+		await expect(
+			page.locator( 'role=menuitem[name="Delete column"i]' )
+		).toBeEnabled();
+	} );
+
 	test( 'allows columns to be aligned', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'core/table' } );
 


### PR DESCRIPTION
## What?
Closes #28714 - independent Testing required, Please do not merge.

After deleting a row or column in the Table block, the "Edit table" menu actions (Insert/Delete row/column) became disabled until the user clicked a cell again to refocus. This PR keeps a sensible cell selected after the deletion, so the actions stay usable.

## Why?
`onDeleteRow` and `onDeleteColumn` were calling `setSelectedCell()` (clearing the selection) and then setting the new attributes. Every item in `tableControls` uses `isDisabled: ! selectedCell`, so the whole menu greyed out until focus returned to a cell. The reporter (and several follow-up confirmations across multiple WP/Gutenberg versions) all had to click a cell to perform a second edit.

## How?
Mirrors the pattern already used by `onInsertRow` / `onInsertColumn`: after mutating the attributes, select a cell that still exists.

- **Row delete:** select the cell at the same `columnIndex`, with `rowIndex` clamped to the new section length. If the section is empty after the delete, clear the selection.
- **Column delete:** select the cell at the same `sectionName` / `rowIndex`, with `columnIndex` clamped to the new column count (using `getFirstRow` to read it). If no columns remain, clear.

## Testing Instructions
1. Add a Table block, set rows ≥ 2 and columns ≥ 2, click "Create Table".
2. Click a body cell once.
3. Block toolbar → "Edit table" → "Delete row".
4. Open "Edit table" again — the actions should still be enabled (before this PR they were greyed out until you refocused a cell).
5. Same for "Delete column".

E2E coverage is added in `test/e2e/specs/editor/blocks/table.spec.js` as a regression test.

### Testing Instructions for Keyboard
No keyboard-interaction changes. The same regression test exercises the menu after both row and column deletion.

## Ai Usage?
- Yes, Claude