### PR TITLE
[WIP] Content Types: Add more fields in post type

### DIFF
--- a/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
+++ b/lib/experimental/content-types/class-wp-rest-user-post-types-controller-gutenberg.php
@@ -112,12 +112,33 @@ class WP_REST_User_Post_Types_Controller_Gutenberg extends WP_REST_Posts_Control
 			'type'                 => 'object',
 			'additionalProperties' => false,
 			'properties'           => array(
-				'public'       => array( 'type' => 'boolean' ),
-				'hierarchical' => array( 'type' => 'boolean' ),
-				'has_archive'  => array( 'type' => 'boolean' ),
-				'show_in_rest' => array( 'type' => 'boolean' ),
+				'public'              => array( 'type' => 'boolean' ),
+				'hierarchical'        => array( 'type' => 'boolean' ),
+				'has_archive'         => array( 'type' => 'boolean' ),
+				'show_in_rest'        => array( 'type' => 'boolean' ),
+				'exclude_from_search' => array( 'type' => 'boolean' ),
+				'show_in_nav_menus'   => array( 'type' => 'boolean' ),
+				'show_ui'             => array( 'type' => 'boolean' ),
+				'show_in_menu'        => array( 'type' => 'boolean' ),
+				'show_in_admin_bar'   => array( 'type' => 'boolean' ),
+				'can_export'          => array( 'type' => 'boolean' ),
+				'query_var'           => array( 'type' => 'boolean' ),
+				'rewrite'             => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'slug'       => array(
+							'type'      => 'string',
+							'maxLength' => 200,
+						),
+						'with_front' => array( 'type' => 'boolean' ),
+						'feeds'      => array( 'type' => 'boolean' ),
+						'pages'      => array( 'type' => 'boolean' ),
+						'ep_mask'    => array( 'type' => 'integer' ),
+					),
+				),
 				// Caps payload size; well above any reasonable description.
-				'description'  => array(
+				'description'         => array(
 					'type'      => 'string',
 					'maxLength' => 1000,
 				),

--- a/lib/experimental/content-types/post-types.php
+++ b/lib/experimental/content-types/post-types.php
@@ -251,6 +251,34 @@ function gutenberg_build_user_post_type_args( WP_Post $record ) {
 		$args['description'] = (string) $config['description'];
 	}
 
+	// Optional visibility overrides — when absent WordPress derives each from
+	// `public` (or `show_ui` for `show_in_menu`), so only pass them when the
+	// stored config explicitly sets a value.
+	foreach ( array( 'exclude_from_search', 'show_in_nav_menus', 'show_ui', 'show_in_menu', 'show_in_admin_bar', 'can_export', 'query_var' ) as $flag ) {
+		if ( isset( $config[ $flag ] ) ) {
+			$args[ $flag ] = (bool) $config[ $flag ];
+		}
+	}
+
+	// Rewrite options — only pass the keys the caller explicitly stored.
+	if ( isset( $config['rewrite'] ) && is_array( $config['rewrite'] ) ) {
+		$rewrite = array();
+		if ( isset( $config['rewrite']['slug'] ) && '' !== (string) $config['rewrite']['slug'] ) {
+			$rewrite['slug'] = (string) $config['rewrite']['slug'];
+		}
+		foreach ( array( 'with_front', 'feeds', 'pages' ) as $bool_key ) {
+			if ( isset( $config['rewrite'][ $bool_key ] ) ) {
+				$rewrite[ $bool_key ] = (bool) $config['rewrite'][ $bool_key ];
+			}
+		}
+		if ( isset( $config['rewrite']['ep_mask'] ) ) {
+			$rewrite['ep_mask'] = (int) $config['rewrite']['ep_mask'];
+		}
+		if ( ! empty( $rewrite ) ) {
+			$args['rewrite'] = $rewrite;
+		}
+	}
+
 	// `taxonomies` here is the inverse of the taxonomy record's `object_type`:
 	// it lists the taxonomies attached to this post type. Only existing
 	// taxonomies are passed through so we never reference unregistered slugs.

--- a/packages/content-types/src/post-types/edit.tsx
+++ b/packages/content-types/src/post-types/edit.tsx
@@ -27,8 +27,10 @@ import {
 	allItemsField,
 	archivesField,
 	attributesField,
+	canExportField,
 	descriptionField,
 	editItemField,
+	excludeFromSearchField,
 	featuredImageField,
 	filterItemsListField,
 	generalForm,
@@ -45,10 +47,21 @@ import {
 	notFoundInTrashField,
 	parentItemColonField,
 	publicField,
+	queryVarField,
+	rewriteEpMaskField,
+	rewriteFeedsField,
+	rewritePagesField,
+	rewriteSlugField,
+	rewriteWithFrontField,
+	rewriteFormFields,
 	removeFeaturedImageField,
 	searchItemsField,
 	setFeaturedImageField,
 	showInRestField,
+	showInAdminBarField,
+	showInMenuField,
+	showInNavMenusField,
+	showUiField,
 	supportsField,
 	uploadedToThisItemField,
 	useFeaturedImageField,
@@ -56,6 +69,7 @@ import {
 	useTaxonomiesField,
 	viewItemField,
 	viewItemsField,
+	visibilityFormFields,
 } from './fields';
 import {
 	pluralLabelField,
@@ -158,7 +172,21 @@ function PostTypePage( {
 				hierarchicalField,
 				hasArchiveField,
 				showInRestField,
+				excludeFromSearchField,
+				canExportField,
+				queryVarField,
 				statusField,
+				// Visibility
+				showInNavMenusField,
+				showUiField,
+				showInMenuField,
+				showInAdminBarField,
+				// Rewrite
+				rewriteSlugField,
+				rewriteWithFrontField,
+				rewriteFeedsField,
+				rewritePagesField,
+				rewriteEpMaskField,
 				// Labels
 				labelsActionsField,
 				menuNameField,
@@ -204,6 +232,32 @@ function PostTypePage( {
 						isOpened: true,
 					},
 					children: generalForm.fields,
+				},
+				{
+					id: 'visibility',
+					label: __( 'Visibility' ),
+					description: __(
+						'Controls which areas of the admin and front end this post type appears in.'
+					),
+					layout: {
+						type: 'card',
+						isCollapsible: true,
+						isOpened: false,
+					},
+					children: visibilityFormFields,
+				},
+				{
+					id: 'rewrite',
+					label: __( 'Rewrite' ),
+					description: __(
+						'Customize the permalink structure for this post type.'
+					),
+					layout: {
+						type: 'card',
+						isCollapsible: true,
+						isOpened: false,
+					},
+					children: rewriteFormFields,
 				},
 				{
 					id: 'labels',

--- a/packages/content-types/src/post-types/fields/general.tsx
+++ b/packages/content-types/src/post-types/fields/general.tsx
@@ -262,6 +262,36 @@ export function useTaxonomiesField(): Field< PostTypeFormData > {
 	}, [ publicTaxonomies ] );
 }
 
+export const excludeFromSearchField = createBooleanField(
+	'exclude_from_search',
+	__( 'Exclude from search' ),
+	{
+		description: __(
+			'Whether to exclude posts of this type from front-end search results.'
+		),
+	}
+);
+
+export const canExportField = createBooleanField(
+	'can_export',
+	__( 'Can export' ),
+	{
+		description: __(
+			'Whether to allow this post type to be exported via the WordPress built-in export tool.'
+		),
+	}
+);
+
+export const queryVarField = createBooleanField(
+	'query_var',
+	__( 'Query var' ),
+	{
+		description: __(
+			'Whether front-end queries using ?post_type=… can return posts of this type.'
+		),
+	}
+);
+
 // The minimal form used by the quick-edit modal.
 export const defaultForm: Form = {
 	layout: { type: 'regular' },
@@ -290,6 +320,9 @@ export const generalForm: Form = {
 		'hierarchical',
 		'has_archive',
 		'show_in_rest',
+		'exclude_from_search',
+		'can_export',
+		'query_var',
 		'status',
 	],
 };

--- a/packages/content-types/src/post-types/fields/index.ts
+++ b/packages/content-types/src/post-types/fields/index.ts
@@ -1,2 +1,4 @@
 export * from './general';
 export * from './labels';
+export * from './visibility';
+export * from './rewrite';

--- a/packages/content-types/src/post-types/fields/rewrite.tsx
+++ b/packages/content-types/src/post-types/fields/rewrite.tsx
@@ -1,0 +1,121 @@
+/**
+ * WordPress dependencies
+ */
+import type { Field, Form } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { PostTypeFormData } from '../types';
+
+export const rewriteSlugField: Field< PostTypeFormData > = {
+	id: 'rewrite_slug',
+	label: __( 'Slug' ),
+	type: 'text',
+	description: __(
+		'Custom permalink slug for this post type. Defaults to the post type key.'
+	),
+	getValue: ( { item } ) => item.config.rewrite.slug,
+	setValue: ( { item, value } ) => ( {
+		config: {
+			...item.config,
+			rewrite: {
+				...item.config.rewrite,
+				slug: String( value ?? '' ),
+			},
+		},
+	} ),
+	isValid: { maxLength: 200 },
+	enableSorting: false,
+	filterBy: false,
+};
+
+export const rewriteWithFrontField: Field< PostTypeFormData > = {
+	id: 'rewrite_with_front',
+	label: __( 'With front' ),
+	type: 'boolean',
+	Edit: 'toggle',
+	description: __(
+		'Whether the permalink should be prepended with the WP_Rewrite front base (e.g. /blog/ in /blog/my-post-type/).'
+	),
+	getValue: ( { item } ) => item.config.rewrite.with_front,
+	setValue: ( { item, value } ) => ( {
+		config: {
+			...item.config,
+			rewrite: { ...item.config.rewrite, with_front: !! value },
+		},
+	} ),
+	enableSorting: false,
+	filterBy: false,
+};
+
+export const rewriteFeedsField: Field< PostTypeFormData > = {
+	id: 'rewrite_feeds',
+	label: __( 'Feeds' ),
+	type: 'boolean',
+	Edit: 'toggle',
+	description: __(
+		'Whether a feed permalink structure should be built for this post type.'
+	),
+	getValue: ( { item } ) => item.config.rewrite.feeds,
+	setValue: ( { item, value } ) => ( {
+		config: {
+			...item.config,
+			rewrite: { ...item.config.rewrite, feeds: !! value },
+		},
+	} ),
+	enableSorting: false,
+	filterBy: false,
+};
+
+export const rewritePagesField: Field< PostTypeFormData > = {
+	id: 'rewrite_pages',
+	label: __( 'Pages' ),
+	type: 'boolean',
+	Edit: 'toggle',
+	description: __(
+		'Whether the permalink structure should provide for pagination (e.g. /my-post-type/page/2/).'
+	),
+	getValue: ( { item } ) => item.config.rewrite.pages,
+	setValue: ( { item, value } ) => ( {
+		config: {
+			...item.config,
+			rewrite: { ...item.config.rewrite, pages: !! value },
+		},
+	} ),
+	enableSorting: false,
+	filterBy: false,
+};
+
+export const rewriteEpMaskField: Field< PostTypeFormData > = {
+	id: 'rewrite_ep_mask',
+	label: __( 'Endpoint mask' ),
+	type: 'integer',
+	description: __(
+		'Endpoint mask to assign to this post type. Accepts EP_* constants. Defaults to EP_PERMALINK.'
+	),
+	getValue: ( { item } ) => item.config.rewrite.ep_mask,
+	setValue: ( { item, value } ) => ( {
+		config: {
+			...item.config,
+			rewrite: {
+				...item.config.rewrite,
+				ep_mask:
+					value !== undefined && value !== ''
+						? Number( value )
+						: undefined,
+			},
+		},
+	} ),
+	enableSorting: false,
+	filterBy: false,
+};
+
+export const rewriteFormFields: Form[ 'fields' ] = [
+	'rewrite_slug',
+	'rewrite_with_front',
+	'rewrite_feeds',
+	'rewrite_pages',
+	'rewrite_ep_mask',
+];

--- a/packages/content-types/src/post-types/fields/visibility.tsx
+++ b/packages/content-types/src/post-types/fields/visibility.tsx
@@ -1,0 +1,61 @@
+/**
+ * WordPress dependencies
+ */
+import type { Form } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { createBooleanField } from '../../utils/fields';
+
+export const showInNavMenusField = createBooleanField(
+	'show_in_nav_menus',
+	__( 'Available in nav menus' ),
+	{
+		description: __(
+			'Whether posts of this type are available for selection in navigation menus.'
+		),
+	}
+);
+
+export const showUiField = createBooleanField(
+	'show_ui',
+	__( 'Show admin UI' ),
+	{
+		description: __(
+			'Whether to generate a default UI for managing posts of this type in the admin.'
+		),
+	}
+);
+
+export const showInMenuField = createBooleanField(
+	'show_in_menu',
+	__( 'Show in admin menu' ),
+	{
+		description: __(
+			'Whether to show the post type in the WordPress admin menu. Has no effect when Show admin UI is off; the value is preserved either way.'
+		),
+		// Hidden when `show_ui` is off — `show_in_menu` is silently ignored
+		// by register_post_type() in that case, so showing the toggle would
+		// be misleading. The stored value is preserved across the toggle.
+		isVisible: ( item ) => !! item.config.show_ui,
+	}
+);
+
+export const showInAdminBarField = createBooleanField(
+	'show_in_admin_bar',
+	__( 'Show in admin bar' ),
+	{
+		description: __(
+			'Whether to include this post type in the "New" menu of the WordPress admin toolbar.'
+		),
+	}
+);
+
+export const visibilityFormFields: Form[ 'fields' ] = [
+	'show_in_nav_menus',
+	'show_ui',
+	'show_in_menu',
+	'show_in_admin_bar',
+];

--- a/packages/content-types/src/post-types/types.ts
+++ b/packages/content-types/src/post-types/types.ts
@@ -69,6 +69,20 @@ export interface StoredConfig {
 	hierarchical?: boolean;
 	has_archive?: boolean;
 	show_in_rest?: boolean;
+	exclude_from_search?: boolean;
+	show_in_nav_menus?: boolean;
+	show_ui?: boolean;
+	show_in_menu?: boolean;
+	show_in_admin_bar?: boolean;
+	can_export?: boolean;
+	query_var?: boolean;
+	rewrite?: {
+		slug?: string;
+		with_front?: boolean;
+		feeds?: boolean;
+		pages?: boolean;
+		ep_mask?: number;
+	};
 }
 
 import type { ContentType } from '../types';
@@ -85,6 +99,20 @@ export interface PostTypeFormData extends ContentType {
 		taxonomies: string[];
 		supports: SupportFeature[];
 		has_archive: boolean;
+		exclude_from_search: boolean;
+		show_in_nav_menus: boolean;
+		show_ui: boolean;
+		show_in_menu: boolean;
+		show_in_admin_bar: boolean;
+		can_export: boolean;
+		query_var: boolean;
+		rewrite: {
+			slug: string;
+			with_front: boolean;
+			feeds: boolean;
+			pages: boolean;
+			ep_mask?: number;
+		};
 	};
 	count?: number;
 }

--- a/packages/content-types/src/post-types/utils.ts
+++ b/packages/content-types/src/post-types/utils.ts
@@ -32,6 +32,19 @@ export const BLANK_RECORD: PostTypeFormData = {
 		hierarchical: false,
 		has_archive: false,
 		show_in_rest: true,
+		exclude_from_search: false,
+		show_in_nav_menus: true,
+		show_ui: true,
+		show_in_menu: true,
+		show_in_admin_bar: true,
+		can_export: true,
+		query_var: true,
+		rewrite: {
+			slug: '',
+			with_front: true,
+			feeds: false,
+			pages: true,
+		},
 	},
 };
 
@@ -204,6 +217,22 @@ export function toFormData( row: PostTypeRecord ): PostTypeFormData {
 			hierarchical: config.hierarchical ?? false,
 			has_archive: config.has_archive ?? false,
 			show_in_rest: config.show_in_rest ?? true,
+			exclude_from_search: config.exclude_from_search ?? false,
+			show_in_nav_menus: config.show_in_nav_menus ?? true,
+			show_ui: config.show_ui ?? true,
+			show_in_menu: config.show_in_menu ?? true,
+			show_in_admin_bar: config.show_in_admin_bar ?? true,
+			can_export: config.can_export ?? true,
+			query_var: config.query_var ?? true,
+			rewrite: {
+				slug: config.rewrite?.slug ?? '',
+				with_front: config.rewrite?.with_front ?? true,
+				feeds: config.rewrite?.feeds ?? false,
+				pages: config.rewrite?.pages ?? true,
+				...( config.rewrite?.ep_mask !== undefined
+					? { ep_mask: config.rewrite.ep_mask }
+					: {} ),
+			},
 		},
 		count: row.count,
 	};
@@ -220,6 +249,17 @@ export function serializeForSave( data: PostTypeFormData ) {
 	);
 
 	const description = config.description.trim();
+	const rewrite: Record< string, unknown > = {};
+	if ( config.rewrite.slug.trim() !== '' ) {
+		rewrite.slug = config.rewrite.slug.trim();
+	}
+	rewrite.with_front = config.rewrite.with_front;
+	rewrite.feeds = config.rewrite.feeds;
+	rewrite.pages = config.rewrite.pages;
+	if ( config.rewrite.ep_mask !== undefined ) {
+		rewrite.ep_mask = config.rewrite.ep_mask;
+	}
+
 	return {
 		...( data.id !== undefined ? { id: data.id } : {} ),
 		slug: data.slug,
@@ -233,6 +273,14 @@ export function serializeForSave( data: PostTypeFormData ) {
 			hierarchical: config.hierarchical,
 			has_archive: config.has_archive,
 			show_in_rest: config.show_in_rest,
+			exclude_from_search: config.exclude_from_search,
+			show_in_nav_menus: config.show_in_nav_menus,
+			show_ui: config.show_ui,
+			show_in_menu: config.show_in_menu,
+			show_in_admin_bar: config.show_in_admin_bar,
+			can_export: config.can_export,
+			query_var: config.query_var,
+			rewrite,
 			...( description !== '' ? { description } : {} ),
 		},
 	};


### PR DESCRIPTION

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/77600

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
