### PR TITLE
Connectors: Mask API Key input field to prevent plain text browser exposure

### DIFF
--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -6,13 +6,15 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalItem as Item,
 	__experimentalText as WCText,
+	__experimentalInputControl as InputControl,
+	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
 	ExternalLink,
 	FlexBlock,
 	Button,
-	TextControl,
 } from '@wordpress/components';
 import { createInterpolateElement, useId, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { seen, unseen } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -102,6 +104,7 @@ export function DefaultConnectorSettings( {
 	const [ apiKey, setApiKey ] = useState( initialValue );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ saveError, setSaveError ] = useState< string | null >( null );
+	const [ isKeyVisible, setIsKeyVisible ] = useState( false );
 
 	const helpLinkLabel = helpLabel || helpUrl?.replace( /^https?:\/\//, '' );
 
@@ -196,21 +199,37 @@ export function DefaultConnectorSettings( {
 					: undefined
 			}
 		>
-			<TextControl
+			<InputControl
 				__next40pxDefaultSize
 				label={ __( 'API Key' ) }
-				type="password"
+				type={ isKeyVisible ? 'text' : 'password' }
 				value={ apiKey }
 				onChange={ ( value ) => {
 					if ( ! readOnly ) {
 						setSaveError( null );
-						setApiKey( value );
+						setApiKey( value ?? '' );
 					}
 				} }
 				placeholder={ __( 'Enter your API key' ) }
 				disabled={ readOnly || isSaving }
 				autoComplete="off"
 				help={ getHelp() }
+				suffix={
+					<InputControlSuffixWrapper variant="control">
+						<Button
+							size="small"
+							icon={ isKeyVisible ? unseen : seen }
+							onClick={ () => setIsKeyVisible( ( v ) => ! v ) }
+							label={
+								isKeyVisible
+									? __( 'Hide API key' )
+									: __( 'Show API key' )
+							}
+							disabled={ readOnly || isSaving }
+							accessibleWhenDisabled
+						/>
+					</InputControlSuffixWrapper>
+				}
 			/>
 			{ readOnly ? (
 				onRemove && (

--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -199,6 +199,7 @@ export function DefaultConnectorSettings( {
 			<TextControl
 				__next40pxDefaultSize
 				label={ __( 'API Key' ) }
+				type="password"
 				value={ apiKey }
 				onChange={ ( value ) => {
 					if ( ! readOnly ) {


### PR DESCRIPTION

## What?

Closes https://github.com/WordPress/gutenberg/issues/78965


This PR updates the API Key input field in the Connectors settings page to use `type="password"`, ensuring sensitive credentials are automatically masked and preventing browsers from storing them in plain text autocomplete suggestions.

## Why?

Previously, the API Key field in the AI integration setup form (like the Anthropic provider) used a standard text input component. Although the component had `autoComplete="off"` set, most modern browsers intentionally ignore this directive on standard text fields. As a result, previously entered API keys were stored in standard browser form history and displayed in plain text as autocomplete suggestions whenever a user clicked on the field. This created a visual security exposure and ran the risk of credential leakage. 

## How?

Added `type="password"` to the existing `<TextControl />` component

## Testing Instructions

1. Navigate to the WP Admin Dashboard and go to **Settings > Connectors**.
2. Under any AI provider (e.g., Anthropic or OpenAI), click the **Set up** (or **Install** then **Set up**) button.
3. Click inside the **API Key** input field and type a test key (e.g., `sk-test-key-12345`).
4. Verify that the characters are visually masked.
5. Save the configuration or click elsewhere to lose focus, and then click the field again. Verify that the browser does not display a dropdown containing previously typed, plain-text autocomplete suggestions.


## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/57cb62cf-34e6-4f8b-aeb9-3de7776bb7f3

### After



https://github.com/user-attachments/assets/13e7c3b8-626c-46b7-a9e4-02386a2e7c2d



