### PR TITLE
RSS Block: Add support for displaying featured images from feed items

### DIFF
--- a/packages/block-library/src/rss/block.json
+++ b/packages/block-library/src/rss/block.json
@@ -47,6 +47,10 @@
 		},
 		"rel": {
 			"type": "string"
+		},
+		"displayFeaturedImage": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -44,6 +44,7 @@ export default function RSSEdit( { attributes, setAttributes, name } ) {
 		displayAuthor,
 		displayDate,
 		displayExcerpt,
+		displayFeaturedImage,
 		excerptLength,
 		feedURL,
 		itemsToShow,
@@ -154,6 +155,7 @@ export default function RSSEdit( { attributes, setAttributes, name } ) {
 							displayAuthor: false,
 							displayDate: false,
 							displayExcerpt: false,
+							displayFeaturedImage: false,
 							excerptLength: 55,
 							columns: 2,
 							openInNewTab: false,
@@ -181,6 +183,24 @@ export default function RSSEdit( { attributes, setAttributes, name } ) {
 					</ToolsPanelItem>
 
 					<ToolsPanelItem
+						label={ __( 'Display featured image' ) }
+						hasValue={ () => !! displayFeaturedImage }
+						onDeselect={ () =>
+							setAttributes( { displayFeaturedImage: false } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							__next40pxDefaultSize
+							label={ __( 'Display featured image' ) }
+							checked={ displayFeaturedImage }
+							onChange={ toggleAttribute(
+								'displayFeaturedImage'
+							) }
+						/>
+					</ToolsPanelItem>
+
+					<ToolsPanelItem
 						label={ __( 'Display author' ) }
 						hasValue={ () => !! displayAuthor }
 						onDeselect={ () =>
@@ -189,6 +209,7 @@ export default function RSSEdit( { attributes, setAttributes, name } ) {
 						isShownByDefault
 					>
 						<ToggleControl
+							__next40pxDefaultSize
 							label={ __( 'Display author' ) }
 							checked={ displayAuthor }
 							onChange={ toggleAttribute( 'displayAuthor' ) }
@@ -204,6 +225,7 @@ export default function RSSEdit( { attributes, setAttributes, name } ) {
 						isShownByDefault
 					>
 						<ToggleControl
+							__next40pxDefaultSize
 							label={ __( 'Display date' ) }
 							checked={ displayDate }
 							onChange={ toggleAttribute( 'displayDate' ) }
@@ -219,6 +241,7 @@ export default function RSSEdit( { attributes, setAttributes, name } ) {
 						isShownByDefault
 					>
 						<ToggleControl
+							__next40pxDefaultSize
 							label={ __( 'Display excerpt' ) }
 							checked={ displayExcerpt }
 							onChange={ toggleAttribute( 'displayExcerpt' ) }
@@ -278,6 +301,7 @@ export default function RSSEdit( { attributes, setAttributes, name } ) {
 						isShownByDefault
 					>
 						<ToggleControl
+							__next40pxDefaultSize
 							label={ __( 'Open links in new tab' ) }
 							checked={ openInNewTab }
 							onChange={ ( value ) =>

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -191,7 +191,6 @@ export default function RSSEdit( { attributes, setAttributes, name } ) {
 						isShownByDefault
 					>
 						<ToggleControl
-							__next40pxDefaultSize
 							label={ __( 'Display featured image' ) }
 							checked={ displayFeaturedImage }
 							onChange={ toggleAttribute(
@@ -209,7 +208,6 @@ export default function RSSEdit( { attributes, setAttributes, name } ) {
 						isShownByDefault
 					>
 						<ToggleControl
-							__next40pxDefaultSize
 							label={ __( 'Display author' ) }
 							checked={ displayAuthor }
 							onChange={ toggleAttribute( 'displayAuthor' ) }
@@ -225,7 +223,6 @@ export default function RSSEdit( { attributes, setAttributes, name } ) {
 						isShownByDefault
 					>
 						<ToggleControl
-							__next40pxDefaultSize
 							label={ __( 'Display date' ) }
 							checked={ displayDate }
 							onChange={ toggleAttribute( 'displayDate' ) }
@@ -241,7 +238,6 @@ export default function RSSEdit( { attributes, setAttributes, name } ) {
 						isShownByDefault
 					>
 						<ToggleControl
-							__next40pxDefaultSize
 							label={ __( 'Display excerpt' ) }
 							checked={ displayExcerpt }
 							onChange={ toggleAttribute( 'displayExcerpt' ) }
@@ -301,7 +297,6 @@ export default function RSSEdit( { attributes, setAttributes, name } ) {
 						isShownByDefault
 					>
 						<ToggleControl
-							__next40pxDefaultSize
 							label={ __( 'Open links in new tab' ) }
 							checked={ openInNewTab }
 							onChange={ ( value ) =>

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -16,7 +16,7 @@
  */
 function render_block_core_rss( $attributes ) {
 	if ( in_array( untrailingslashit( $attributes['feedURL'] ), array( site_url(), home_url() ), true ) ) {
-		return '<div class="components-placeholder"><div class="notice notice-error">' . __( 'Adding an RSS feed to this site’s homepage is not supported, as it could lead to a loop that slows down your site. Try using another block, like the <strong>Latest Posts</strong> block, to list posts from the site.' ) . '</div></div>';
+		return '<div class="components-placeholder"><div class="notice notice-error">' . __( 'Adding an RSS feed to this site\'s homepage is not supported, as it could lead to a loop that slows down your site. Try using another block, like the <strong>Latest Posts</strong> block, to list posts from the site.' ) . '</div></div>';
 	}
 
 	$rss = fetch_feed( $attributes['feedURL'] );
@@ -104,7 +104,45 @@ function render_block_core_rss( $attributes ) {
 			$excerpt = '<div class="wp-block-rss__item-excerpt">' . esc_html( $excerpt ) . '</div>';
 		}
 
-		$list_items .= "<li class='wp-block-rss__item'>{$title}{$date_markup}{$author}{$excerpt}</li>";
+		// Build featured image markup if the attribute is enabled.
+		$featured_image = '';
+		if ( ! empty( $attributes['displayFeaturedImage'] ) ) {
+			$image_url = '';
+
+			$enclosure = $item->get_enclosure();
+			if ( $enclosure ) {
+				$mime_type = (string) $enclosure->get_type();
+				$medium    = (string) $enclosure->get_medium();
+				if ( 'image' === $medium || str_starts_with( $mime_type, 'image/' ) ) {
+					$image_url = $enclosure->get_link();
+				}
+			}
+
+			if ( empty( $image_url ) ) {
+				$thumbnail = $item->get_thumbnail();
+				if ( ! empty( $thumbnail ) ) {
+					$image_url = $thumbnail;
+				}
+			}
+
+			if ( empty( $image_url ) ) {
+				$content = $item->get_content();
+				if ( ! empty( $content ) ) {
+					if ( preg_match( '/<img[^>]+src=[\'"]([^\'"]+)[\'"][^>]*>/i', $content, $matches ) ) {
+						$image_url = $matches[1];
+					}
+				}
+			}
+
+			if ( ! empty( $image_url ) ) {
+				$featured_image = sprintf(
+					'<div class="wp-block-rss__item-featured-image"><img src="%s" alt="" /></div>',
+					esc_url( $image_url )
+				);
+			}
+		}
+
+		$list_items .= "<li class='wp-block-rss__item'>{$featured_image}{$title}{$date_markup}{$author}{$excerpt}</li>";
 	}
 
 	$classnames = array();
@@ -122,6 +160,9 @@ function render_block_core_rss( $attributes ) {
 	}
 	if ( $attributes['displayExcerpt'] ) {
 		$classnames[] = 'has-excerpts';
+	}
+	if ( ! empty( $attributes['displayFeaturedImage'] ) ) {
+		$classnames[] = 'has-images';
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classnames ) ) );

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -120,24 +120,49 @@ function render_block_core_rss( $attributes ) {
 
 			if ( empty( $image_url ) ) {
 				$thumbnail = $item->get_thumbnail();
-				if ( ! empty( $thumbnail ) ) {
-					$image_url = $thumbnail;
+				if ( ! empty( $thumbnail['url'] ) ) {
+					$image_url = $thumbnail['url'];
 				}
 			}
 
 			if ( empty( $image_url ) ) {
 				$content = $item->get_content();
 				if ( ! empty( $content ) ) {
-					if ( preg_match( '/<img[^>]+src=[\'"]([^\'"]+)[\'"][^>]*>/i', $content, $matches ) ) {
-						$image_url = $matches[1];
+					if ( preg_match_all(
+						'/<img[^>]+src=[\'"]([^\'"]+)[\'"][^>]*>/i',
+						$content,
+						$matches,
+						PREG_SET_ORDER
+					) ) {
+						foreach ( $matches as $match ) {
+							$img_tag = $match[0];
+							$src     = $match[1];
+
+							$width  = 0;
+							$height = 0;
+							if ( preg_match( '/\bwidth=[\'"]?(\d+)[\'"]?/i', $img_tag, $w ) ) {
+								$width = (int) $w[1];
+							}
+							if ( preg_match( '/\bheight=[\'"]?(\d+)[\'"]?/i', $img_tag, $h ) ) {
+								$height = (int) $h[1];
+							}
+
+							if ( ( $width > 0 && $width <= 1 ) || ( $height > 0 && $height <= 1 ) ) {
+								continue;
+							}
+
+							$image_url = $src;
+							break;
+						}
 					}
 				}
 			}
 
 			if ( ! empty( $image_url ) ) {
 				$featured_image = sprintf(
-					'<div class="wp-block-rss__item-featured-image"><img src="%s" alt="" /></div>',
-					esc_url( $image_url )
+					'<div class="wp-block-rss__item-featured-image"><img src="%s" alt="%s" /></div>',
+					esc_url( $image_url ),
+					esc_attr( $title )
 				);
 			}
 		}

--- a/packages/block-library/src/rss/style.scss
+++ b/packages/block-library/src/rss/style.scss
@@ -41,3 +41,15 @@ ul.wp-block-rss { // The ul is needed for specificity to override the reset styl
 	list-style: none;
 	padding: 0;
 }
+
+.wp-block-rss__item-featured-image {
+	display: block;
+	margin-bottom: 0.5em;
+
+	img {
+		display: block;
+		width: 100%;
+		height: auto;
+		max-width: 100%;
+	}
+}

--- a/packages/components/src/form-file-upload/README.md
+++ b/packages/components/src/form-file-upload/README.md
@@ -65,7 +65,7 @@ Whether to allow multiple selection of files or not.
 
 ### `onChange`
 
- - Type: `ChangeEventHandler<HTMLInputElement> | undefined`
+ - Type: `ChangeEventHandler<HTMLInputElement, HTMLInputElement> | undefined`
  - Required: Yes
 
 Callback function passed directly to the `input` file element.

--- a/packages/components/src/menu/README.md
+++ b/packages/components/src/menu/README.md
@@ -120,7 +120,7 @@ make disabled elements still accessible via keyboard.
 
 ##### `render`
 
- - Type: `ReactElement<any, string | JSXElementConstructor<any>> | RenderProp<HTMLAttributes<any> & { ref?: Ref<any>; }>`
+ - Type: `ReactElement<unknown, string | JSXElementConstructor<any>> | RenderProp<HTMLAttributes<any> & { ref?: Ref<any>; }>`
  - Required: No
 
 Allows the component to be rendered as a different HTML element or React
@@ -245,7 +245,7 @@ The contents of the menu item's prefix, such as an icon.
 
 ##### `render`
 
- - Type: `ReactElement<any, string | JSXElementConstructor<any>> | RenderProp<HTMLAttributes<any> & { ref?: Ref<any>; }>`
+ - Type: `ReactElement<unknown, string | JSXElementConstructor<any>> | RenderProp<HTMLAttributes<any> & { ref?: Ref<any>; }>`
  - Required: No
 
 Allows the component to be rendered as a different HTML element or React
@@ -329,14 +329,14 @@ The radio item's name.
 
 ##### `onChange`
 
- - Type: `BivariantCallback<(event: ChangeEvent<HTMLInputElement>) => void>`
+ - Type: `BivariantCallback<(event: ChangeEvent<HTMLInputElement, Element>) => void>`
  - Required: No
 
 A function that is called when the checkbox's checked state changes.
 
 ##### `render`
 
- - Type: `ReactElement<any, string | JSXElementConstructor<any>> | RenderProp<HTMLAttributes<any> & { ref?: Ref<any>; }>`
+ - Type: `ReactElement<unknown, string | JSXElementConstructor<any>> | RenderProp<HTMLAttributes<any> & { ref?: Ref<any>; }>`
  - Required: No
 
 Allows the component to be rendered as a different HTML element or React
@@ -427,14 +427,14 @@ The checkbox menu item's name.
 
 ##### `onChange`
 
- - Type: `ChangeEventHandler<HTMLInputElement>`
+ - Type: `ChangeEventHandler<HTMLInputElement, HTMLInputElement>`
  - Required: No
 
 A function that is called when the checkbox's checked state changes.
 
 ##### `render`
 
- - Type: `ReactElement<any, string | JSXElementConstructor<any>> | RenderProp<HTMLAttributes<any> & { ref?: Ref<any>; }>`
+ - Type: `ReactElement<unknown, string | JSXElementConstructor<any>> | RenderProp<HTMLAttributes<any> & { ref?: Ref<any>; }>`
  - Required: No
 
 Allows the component to be rendered as a different HTML element or React
@@ -575,7 +575,7 @@ The contents of the menu item's prefix, such as an icon.
 
 ##### `render`
 
- - Type: `ReactElement<any, string | JSXElementConstructor<any>> | RenderProp<HTMLAttributes<any> & { ref?: Ref<any>; }>`
+ - Type: `ReactElement<unknown, string | JSXElementConstructor<any>> | RenderProp<HTMLAttributes<any> & { ref?: Ref<any>; }>`
  - Required: No
 
 Allows the component to be rendered as a different HTML element or React

--- a/packages/components/src/tabs/README.md
+++ b/packages/components/src/tabs/README.md
@@ -164,7 +164,7 @@ still be accessed via the keyboard when navigating through the tablist.
 
 ##### `render`
 
- - Type: `RenderProp<HTMLAttributes<any> & { ref?: Ref<any>; }> | ReactElement<any, string | JSXElementConstructor<any>>`
+ - Type: `RenderProp<HTMLAttributes<any> & { ref?: Ref<any>; }> | ReactElement<unknown, string | JSXElementConstructor<any>>`
  - Required: No
 
 Allows the component to be rendered as a different HTML element or React

--- a/packages/components/src/tree-select/README.md
+++ b/packages/components/src/tree-select/README.md
@@ -118,7 +118,7 @@ If this property is added, an option will be added with this label to represent 
 
 ### `onChange`
 
- - Type: `((value: string, extra?: { event?: ChangeEvent<HTMLSelectElement>; }) => void) | undefined`
+ - Type: `((value: string, extra?: { event?: ChangeEvent<HTMLSelectElement, Element>; }) => void) | undefined`
  - Required: No
 
 A function that receives the value of the new option that is being selected as input.

--- a/test/integration/fixtures/blocks/core__rss.json
+++ b/test/integration/fixtures/blocks/core__rss.json
@@ -11,7 +11,8 @@
 			"displayAuthor": true,
 			"displayDate": true,
 			"excerptLength": 20,
-			"openInNewTab": false
+			"openInNewTab": false,
+			"displayFeaturedImage": false
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
Closes #42827

## What?
This PR adds a new **Display featured image** toggle to the RSS block's inspector controls, allowing images from RSS/Atom feed items to appear alongside each entry in the block output.

## Why?
The RSS block currently renders only the title, date, author, and excerpt for each feed item, there is no way to display accompanying images. Users reported that images from incoming RSS feeds were silently dropped, with no option to surface them. This is a commonly requested feature and a natural complement to the existing display toggles (`displayDate`, `displayAuthor`, `displayExcerpt`).

## Testing Instructions
1. Open a post or page in the block editor.
2. Insert an **RSS** block.
3. Enter a valid RSS feed URL that includes images (e.g. a feed from a news site, a YouTube channel feed, or any feed using `<enclosure>` or `<media:thumbnail>`). Apply the URL.
4. In the **Settings** sidebar, locate the **Display featured image** toggle and enable it.
5. Verify that images appear above each feed item's title in the block preview.
6. Disable the toggle and verify images disappear.
7. Switch the block layout to **Grid view** and verify images are responsive within grid columns.
8. Save the post and view it on the frontend, confirm images render correctly there too.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/1e440720-6808-4a37-908d-ca48ef055a76

