### PR TITLE
Fix navigation wrapper classname duplication

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -226,14 +226,7 @@ class WP_Navigation_Block_Renderer {
 		$has_submenus   = static::has_submenus( $inner_blocks );
 		$is_interactive = static::is_interactive( $attributes, $inner_blocks );
 
-		$style                = static::get_styles( $attributes );
-		$class                = static::get_classes( $attributes );
-		$container_attributes = get_block_wrapper_attributes(
-			array(
-				'class' => 'wp-block-navigation__container ' . $class,
-				'style' => $style,
-			)
-		);
+		$container_attributes = 'class="wp-block-navigation__container"';
 
 		$inner_blocks_html = '';
 		$is_list_open      = false;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -253,16 +253,15 @@ $navigation-icon-size: 24px;
 	// Show submenus on hover unless they open on click.
 	// Restricted to true-hover devices to prevent sticky touch-hover on mobile.
 	@media (hover: hover) {
-		&:not(.open-on-click):hover>.wp-block-navigation__submenu-container {
+		&:not(.open-on-click):hover > .wp-block-navigation__submenu-container {
 			@include show-submenu;
 			min-width: 200px;
 		}
 	}
 
 	// Keep submenus open when focus is within.
-	&:not(.open-on-click):not(.open-on-hover-click):focus-within>.wp-block-navigation__submenu-container,
-	// Show submenus on click.
-	.wp-block-navigation-submenu__toggle[aria-expanded="true"]~.wp-block-navigation__submenu-container {
+	&:not(.open-on-click):not(.open-on-hover-click):focus-within > .wp-block-navigation__submenu-container,
+	.wp-block-navigation-submenu__toggle[aria-expanded="true"] ~ .wp-block-navigation__submenu-container {
 		@include show-submenu;
 		min-width: 200px;
 	}
@@ -305,7 +304,7 @@ $navigation-icon-size: 24px;
 		}
 
 		>.wp-block-navigation-item__content,
-		.wp-block-navigation__submenu-container>.wp-block-navigation-item>.wp-block-navigation-item__content {
+		.wp-block-navigation__submenu-container > .wp-block-navigation-item > .wp-block-navigation-item__content {
 			flex-grow: 0;
 		}
 
@@ -369,7 +368,7 @@ button.wp-block-navigation-item__content {
 	// Rotate submenu icon when open.
 	&[aria-expanded="true"] {
 
-		+.wp-block-navigation__submenu-icon>svg,
+		+.wp-block-navigation__submenu-icon > svg,
 		>svg {
 			transform: rotate(180deg);
 		}
@@ -442,9 +441,9 @@ button.wp-block-navigation-item__content {
 // When justified space-between, open submenus leftward for last menu item.
 // When justified right, open all submenus leftwards.
 // This needs high specificity.
-.wp-block-navigation.items-justified-space-between .wp-block-page-list>.has-child:last-child,
-.wp-block-navigation.items-justified-space-between>.wp-block-navigation__container>.has-child:last-child,
-.wp-block-navigation.items-justified-right .wp-block-page-list>.has-child,
+.wp-block-navigation.items-justified-space-between .wp-block-page-list > .has-child:last-child,
+.wp-block-navigation.items-justified-space-between > .wp-block-navigation__container > .has-child:last-child,
+.wp-block-navigation.items-justified-right .wp-block-page-list > .has-child,
 .wp-block-navigation.items-justified-right .wp-block-navigation__container .has-child {
 
 	// First submenu.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -172,9 +172,11 @@ $navigation-icon-size: 24px;
 
 		// Hide until hover or focus within.
 		opacity: 0;
+
 		@media not (prefers-reduced-motion) {
 			transition: opacity 0.1s linear;
 		}
+
 		visibility: hidden;
 
 		// Don't take up space when the menu is collapsed.
@@ -183,8 +185,8 @@ $navigation-icon-size: 24px;
 		overflow: hidden; // Overflow is necessary to set, otherwise submenu items will take up space.
 
 		// Submenu items.
-		> .wp-block-navigation-item {
-			> .wp-block-navigation-item__content {
+		>.wp-block-navigation-item {
+			>.wp-block-navigation-item__content {
 				display: flex;
 				flex-grow: 1;
 				padding: 0.5em 1em;
@@ -251,15 +253,16 @@ $navigation-icon-size: 24px;
 	// Show submenus on hover unless they open on click.
 	// Restricted to true-hover devices to prevent sticky touch-hover on mobile.
 	@media (hover: hover) {
-		&:not(.open-on-click):hover > .wp-block-navigation__submenu-container {
+		&:not(.open-on-click):hover>.wp-block-navigation__submenu-container {
 			@include show-submenu;
 			min-width: 200px;
 		}
 	}
+
 	// Keep submenus open when focus is within.
-	&:not(.open-on-click):not(.open-on-hover-click):focus-within > .wp-block-navigation__submenu-container,
+	&:not(.open-on-click):not(.open-on-hover-click):focus-within>.wp-block-navigation__submenu-container,
 	// Show submenus on click.
-	.wp-block-navigation-submenu__toggle[aria-expanded="true"] ~ .wp-block-navigation__submenu-container {
+	.wp-block-navigation-submenu__toggle[aria-expanded="true"]~.wp-block-navigation__submenu-container {
 		@include show-submenu;
 		min-width: 200px;
 	}
@@ -301,12 +304,12 @@ $navigation-icon-size: 24px;
 			}
 		}
 
-		> .wp-block-navigation-item__content,
-		.wp-block-navigation__submenu-container > .wp-block-navigation-item > .wp-block-navigation-item__content {
+		>.wp-block-navigation-item__content,
+		.wp-block-navigation__submenu-container>.wp-block-navigation-item>.wp-block-navigation-item__content {
 			flex-grow: 0;
 		}
 
-		> .wp-block-navigation__submenu-container {
+		>.wp-block-navigation__submenu-container {
 			@include show-submenu;
 			flex-basis: 100%;
 			position: static;
@@ -318,9 +321,7 @@ $navigation-icon-size: 24px;
 }
 
 // Submenu indentation when there's a background.
-.wp-block-navigation.has-background
-.has-child
-.wp-block-navigation__submenu-container {
+.wp-block-navigation.has-background .has-child .wp-block-navigation__submenu-container {
 	left: 0;
 	top: 100%;
 
@@ -367,8 +368,9 @@ button.wp-block-navigation-item__content {
 
 	// Rotate submenu icon when open.
 	&[aria-expanded="true"] {
-		+ .wp-block-navigation__submenu-icon > svg,
-		> svg {
+
+		+.wp-block-navigation__submenu-icon>svg,
+		>svg {
 			transform: rotate(180deg);
 		}
 	}
@@ -382,11 +384,12 @@ button.wp-block-navigation-item__content {
 	padding-left: 0; // Remove the browser default padding.
 	padding-right: 0.6em + 0.25em; // Same size as icon plus margin.
 
-	+ .wp-block-navigation__submenu-icon {
+	+.wp-block-navigation__submenu-icon {
 		margin-left: -0.6em;
 		pointer-events: none; // Make the icon inert to allow click on the button.
 	}
 }
+
 // Remove the browser default padding on the button element used in the navigation link submenu.
 .wp-block-navigation-item.open-on-click button.wp-block-navigation-item__content:not(.wp-block-navigation-submenu__toggle) {
 	padding: 0;
@@ -439,10 +442,11 @@ button.wp-block-navigation-item__content {
 // When justified space-between, open submenus leftward for last menu item.
 // When justified right, open all submenus leftwards.
 // This needs high specificity.
-.wp-block-navigation.items-justified-space-between .wp-block-page-list > .has-child:last-child,
-.wp-block-navigation.items-justified-space-between > .wp-block-navigation__container > .has-child:last-child,
-.wp-block-navigation.items-justified-right .wp-block-page-list > .has-child,
+.wp-block-navigation.items-justified-space-between .wp-block-page-list>.has-child:last-child,
+.wp-block-navigation.items-justified-space-between>.wp-block-navigation__container>.has-child:last-child,
+.wp-block-navigation.items-justified-right .wp-block-page-list>.has-child,
 .wp-block-navigation.items-justified-right .wp-block-navigation__container .has-child {
+
 	// First submenu.
 	.wp-block-navigation__submenu-container {
 		left: auto;
@@ -454,6 +458,7 @@ button.wp-block-navigation-item__content {
 			left: -1px; // Border width.
 			right: -1px;
 		}
+
 		@include break-medium {
 			.wp-block-navigation__submenu-container {
 				left: auto;
@@ -495,6 +500,10 @@ button.wp-block-navigation-item__content {
 	justify-content: var(--navigation-layout-justify, initial);
 	align-items: var(--navigation-layout-align, initial);
 
+	// Inherit colors from the nav block `<nav>` element.
+	color: inherit;
+	background-color: inherit;
+
 	// Reset the default list styles
 	list-style: none;
 	margin: 0;
@@ -522,11 +531,13 @@ button.wp-block-navigation-item__content {
 		opacity: 0;
 		transform: translateY(0.5em);
 	}
+
 	to {
 		opacity: 1;
 		transform: translateY(0);
 	}
 }
+
 .wp-block-navigation__responsive-container {
 	display: none;
 	position: fixed;
@@ -698,7 +709,7 @@ button.wp-block-navigation-item__content {
 		// container so no extra wrapper markup is needed.
 		&.is-menu-open {
 			.wp-block-navigation__responsive-container-content {
-				> *:not(.wp-block-navigation__overlay-container) {
+				>*:not(.wp-block-navigation__overlay-container) {
 					display: none;
 				}
 
@@ -735,6 +746,7 @@ button.wp-block-navigation-item__content {
 		}
 
 		&.is-menu-open {
+
 			// Override breakpoint-inherited submenu rules.
 			.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
 				left: 0;
@@ -745,13 +757,11 @@ button.wp-block-navigation-item__content {
 
 // Default menu background and font color.
 // Don't apply default colors when custom overlay is present.
-.wp-block-navigation:not(.has-background)
-.wp-block-navigation__responsive-container.is-menu-open:not(.disable-default-overlay) {
+.wp-block-navigation:not(.has-background) .wp-block-navigation__responsive-container.is-menu-open:not(.disable-default-overlay) {
 	background-color: #fff;
 }
 
-.wp-block-navigation:not(.has-text-color)
-.wp-block-navigation__responsive-container.is-menu-open:not(.disable-default-overlay) {
+.wp-block-navigation:not(.has-text-color) .wp-block-navigation__responsive-container.is-menu-open:not(.disable-default-overlay) {
 	color: #000;
 }
 

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -9,6 +9,38 @@
 class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 
 	/**
+	 * Test that the inner Navigation list is not treated as a duplicate block wrapper.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers WP_Navigation_Block_Renderer::get_inner_blocks_html
+	 */
+	public function test_inner_list_only_has_container_class() {
+		$output = do_blocks(
+			'<!-- wp:navigation {"fontSize":"x-large","layout":{"orientation":"vertical","justifyContent":"center","flexWrap":"nowrap"}} -->
+			<!-- wp:navigation-link {"label":"Sample Page","url":"/sample-page"} /-->
+			<!-- /wp:navigation -->'
+		);
+
+		$tags = new WP_HTML_Tag_Processor( $output );
+		$this->assertTrue( $tags->next_tag( 'NAV' ) );
+		$this->assertTrue( $tags->has_class( 'wp-block-navigation' ) );
+		$this->assertTrue( $tags->has_class( 'has-x-large-font-size' ) );
+		$this->assertTrue( $tags->has_class( 'items-justified-center' ) );
+		$this->assertTrue( $tags->has_class( 'is-vertical' ) );
+		$this->assertTrue( $tags->has_class( 'no-wrap' ) );
+
+		$this->assertTrue( $tags->next_tag( 'UL' ) );
+		$this->assertSame( 'wp-block-navigation__container', $tags->get_attribute( 'class' ) );
+		$this->assertFalse( $tags->has_class( 'wp-block-navigation' ) );
+		$this->assertFalse( $tags->has_class( 'has-x-large-font-size' ) );
+		$this->assertFalse( $tags->has_class( 'items-justified-center' ) );
+		$this->assertFalse( $tags->has_class( 'is-vertical' ) );
+		$this->assertFalse( $tags->has_class( 'no-wrap' ) );
+		$this->assertNull( $tags->get_attribute( 'style' ) );
+	}
+
+	/**
 	 * Test that navigation links are wrapped in list items to preserve accessible markup
 	 *
 	 * @group navigation-renderer
@@ -37,8 +69,8 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 			// Block markup for WP 6.9 (space before wp-block-navigation-item class)
 			// TODO: Remove the second expected markup after WP 6.9 support is dropped and the old markup is no longer generated.
 			$expected = '<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content"  href="/hello-world"><span class="wp-block-navigation-item__label">Sample Page</span></a></li>';
-			$this->assertEquals( $expected, $result );
 		}
+		$this->assertEquals( $expected, $result );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #62690.

Alternative to #63801 that goes a bit further.

This PR (along with the already merged https://github.com/WordPress/gutenberg/pull/77419) should allow responsive typography to work for the navigation block.

## Why?
In trunk, the navigation block's wrapper class names and styles are incorrectly duplicated on both the top level `<nav>` element and the `<ul>` element that's a child of `<nav>`:
```html
<nav class="wp-block-navigation is-layout-flex wp-block-navigation-is-layout-flex">
  <ul class="wp-block-navigation__container wp-block-navigation">
```

When responsive styles are added, they're done so through a `wp-states` class only on the nav wrapper:
```html
<nav class="wp-block-navigation is-layout-flex wp-block-navigation-is-layout-flex wp-states-2e5ab777">
  <ul class="wp-block-navigation__container wp-block-navigation">
```

The problem is that the `wp-block-navigation` class has a style rule that sets the default font size for the navigation block:
```css
:root :where(.wp-block-navigation) {
    font-size: var(--wp--preset--font-size--medium);
}
```

And it overrules any responsive font size applied via the `wp-states`, preventing responsive font styles from working correctly. This PR should resolve the issue without breaking any nav block styles.

## How?
There are a few options to solve this:
A. Remove the duplicated `wp-block-navigation` from the `ul` (what this PR does)
B. Also duplicate the `wp-states` class to the inner `ul`. (essentially double down on the bug)
C. Make the default font size class only apply to the wrapper (update the selector to `:root :where(nav.wp-block-navigation)`.

I chose A because B & C are essentially doubling down on buggy behavior, introducing more complexity.

The main drawback of A is that it will be more likely to cause back compat issues if a theme relies on those classnames. A dev note is definitely needed.

## Testing Instructions
This will need a lot of general testing to make sure the style features in the nav block still work. I believe they do, but I may be missing something.  I can see that the second bug mentioned in #68350 is still present, it causes inconsistencies for submenus between the editor and frontend, but wasn't introduced in this PR.

1. Add a nav block that has some links and submenus
2. Toggle on the tablet state from dropdown on the block card and select.
3. Set font styles for the tablet state only, check that the styles apply correctly in the editor
4. Switch back to desktop and check that the styles aren't applied
5. Save and view the frontend
6. Resize the viewport between desktop / tablet / mobile, and check that the font styles are applied correctly.

## Screenshots
|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools
Codex / OpenCode