### PR TITLE
Media Library: Add Dataviews media library in Site Editor

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -18,6 +18,9 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-dataviews-media-modal' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalDataViewsMediaModal = true', 'before' );
 	}
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-dataviews-media-library' ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalDataViewsMediaLibrary = true', 'before' );
+	}
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-content-only-inspector-fields' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalContentOnlyInspectorFields = true', 'before' );
 	}

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -55,6 +55,11 @@ function gutenberg_initialize_experiments_settings() {
 					'label'       => __( 'Media Upload Modal', 'gutenberg' ),
 					'description' => __( 'Replaces the existing WordPress media modal with a new modal powered by Data Views, supporting browsing, selecting, and uploading media.', 'gutenberg' ),
 				),
+				array(
+					'id'          => 'gutenberg-dataviews-media-library',
+					'label'       => __( 'Media Library (DataViews)', 'gutenberg' ),
+					'description' => __( 'Enables a DataViews-powered media library view in the Site Editor, supporting browsing, searching, and managing media.', 'gutenberg' ),
+				),
 			),
 		),
 		array(

--- a/lib/experimental/pages/site-editor.php
+++ b/lib/experimental/pages/site-editor.php
@@ -33,3 +33,14 @@ function gutenberg_site_editor_register_default_menu_items() {
 	gutenberg_register_site_editor_v2_menu_item( 'patterns', __( 'Patterns', 'gutenberg' ), '/patterns', '' );
 }
 add_action( 'site-editor-v2_init', 'gutenberg_site_editor_register_default_menu_items', 5 );
+
+/**
+ * Register media library menu item and route for the site editor page.
+ */
+function gutenberg_site_editor_register_media_menu_item_and_route() {
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-dataviews-media-library' ) ) {
+		gutenberg_register_site_editor_v2_menu_item( 'media', __( 'Media', 'gutenberg' ), '/media', '' );
+		gutenberg_register_site_editor_v2_route( '/media' );
+	}
+}
+add_action( 'site-editor-v2_init', 'gutenberg_site_editor_register_media_menu_item_and_route', 5 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -61203,6 +61203,7 @@
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 				"@wordpress/keycodes": "file:../keycodes",
+				"@wordpress/media-fields": "file:../media-fields",
 				"@wordpress/media-utils": "file:../media-utils",
 				"@wordpress/notices": "file:../notices",
 				"@wordpress/patterns": "file:../patterns",

--- a/packages/edit-site-init/src/index.ts
+++ b/packages/edit-site-init/src/index.ts
@@ -9,6 +9,7 @@ import {
 	symbol,
 	symbolFilled,
 	layout,
+	media as mediaIcon,
 } from '@wordpress/icons';
 import { dispatch } from '@wordpress/data';
 import { store as bootStore } from '@wordpress/boot';
@@ -27,6 +28,7 @@ export async function init() {
 		templateParts: { icon: symbolFilled },
 		patterns: { icon: symbol },
 		templates: { icon: layout },
+		media: { icon: mediaIcon },
 	};
 
 	// Update each menu item with its icon

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -77,6 +77,7 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",
+		"@wordpress/media-fields": "file:../media-fields",
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/patterns": "file:../patterns",

--- a/packages/edit-site/src/components/media-list/index.js
+++ b/packages/edit-site/src/components/media-list/index.js
@@ -1,0 +1,342 @@
+/**
+ * WordPress dependencies
+ */
+import { Page } from '@wordpress/admin-ui';
+import { Button } from '@wordpress/components';
+import {
+	store as coreStore,
+	privateApis as coreDataPrivateApis,
+} from '@wordpress/core-data';
+import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { useSelect } from '@wordpress/data';
+import { DataViews } from '@wordpress/dataviews';
+import { useEvent, usePrevious } from '@wordpress/compose';
+import { addQueryArgs } from '@wordpress/url';
+import { useView } from '@wordpress/views';
+import { __ } from '@wordpress/i18n';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import {
+	altTextField,
+	attachedToField,
+	authorField,
+	captionField,
+	dateAddedField,
+	dateModifiedField,
+	descriptionField,
+	filesizeField,
+	mediaDimensionsField,
+	mimeTypeField,
+} from '@wordpress/media-fields';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { useLocation, useHistory } = unlock( routerPrivateApis );
+const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
+const { usePostActions } = unlock( editorPrivateApis );
+
+const EMPTY_ARRAY = [];
+
+const LAYOUT_TABLE = 'table';
+const LAYOUT_GRID = 'grid';
+const LAYOUT_LIST = 'list';
+
+function getItemId( item ) {
+	return String( item.id );
+}
+
+const STATIC_FIELDS = [
+	{
+		id: 'title',
+		type: 'text',
+		label: __( 'Title' ),
+		getValue( { item } ) {
+			return (
+				item.title?.raw || item.title?.rendered || __( '(no title)' )
+			);
+		},
+		render( { item } ) {
+			return (
+				<div className="edit-site-media-list__title-cell">
+					{ item.mime_type?.startsWith( 'image/' ) &&
+					item.source_url ? (
+						<img
+							src={ item.source_url }
+							alt=""
+							width={ 25 }
+							height={ 25 }
+							className="edit-site-media-list__inline-thumb"
+						/>
+					) : null }
+					<span>
+						{ item.title?.raw ||
+							item.title?.rendered ||
+							__( '(no title)' ) }
+					</span>
+				</div>
+			);
+		},
+	},
+	{
+		...authorField,
+		type: 'text',
+	},
+	attachedToField,
+	{
+		id: 'comment_count',
+		type: 'text',
+		label: __( 'Comments' ),
+		getValue( { item } ) {
+			return item.comment_count ?? 0;
+		},
+	},
+	dateAddedField,
+	dateModifiedField,
+	altTextField,
+	captionField,
+	descriptionField,
+	filesizeField,
+	mediaDimensionsField,
+	mimeTypeField,
+];
+
+const defaultView = {
+	type: LAYOUT_TABLE,
+	fields: [ 'author', 'attached_to', 'comment_count', 'date' ],
+	showTitle: true,
+	titleField: 'title',
+	mediaField: 'media_thumbnail',
+	perPage: 20,
+	sort: {
+		field: 'date',
+		direction: 'desc',
+	},
+	filters: [],
+};
+
+const defaultLayouts = {
+	[ LAYOUT_TABLE ]: {
+		fields: [ 'title', 'author', 'attached_to', 'comment_count', 'date' ],
+		showTitle: true,
+	},
+	[ LAYOUT_GRID ]: {
+		fields: [ 'media_thumbnail' ],
+		showTitle: true,
+		layout: {
+			previewSize: 170,
+			density: 'compact',
+		},
+	},
+	[ LAYOUT_LIST ]: {
+		fields: [],
+		showTitle: true,
+	},
+};
+
+export default function MediaList() {
+	const { path, query } = useLocation();
+	const history = useHistory();
+
+	const userId = useSelect(
+		( select ) => select( coreStore ).getCurrentUser()?.id,
+		[]
+	);
+
+	const { view, updateView, isModified, resetToDefault } = useView( {
+		kind: 'postType',
+		name: 'attachment',
+		slug: 'default',
+		defaultView,
+		queryParams: {
+			page: query.pageNumber,
+			search: query.search,
+		},
+		onChangeQueryParams( newQueryParams ) {
+			history.navigate(
+				addQueryArgs( path, {
+					...query,
+					pageNumber: newQueryParams.page,
+					search: newQueryParams.search || undefined,
+				} )
+			);
+		},
+	} );
+
+	const onChangeView = useEvent( ( newView ) => {
+		updateView( newView );
+		if ( newView.type !== view.type ) {
+			history.invalidate();
+		}
+	} );
+
+	const [ selection, setSelection ] = useState( [] );
+	const onChangeSelection = useCallback( ( items ) => {
+		setSelection( items );
+	}, [] );
+
+	const fields = STATIC_FIELDS;
+
+	const queryArgs = useMemo( () => {
+		const filters = {};
+
+		if ( query.sidebarFilter === 'my-files' ) {
+			filters.author = userId;
+		} else if ( query.sidebarFilter && query.sidebarFilter !== 'all' ) {
+			filters.media_type = query.sidebarFilter;
+		}
+
+		if ( view.filters ) {
+			for ( const filter of view.filters ) {
+				if ( filter.field === 'media_type' ) {
+					filters.media_type = filter.value;
+				} else if ( filter.field === 'author' ) {
+					if ( filter.operator === 'isAny' ) {
+						filters.author = filter.value;
+					} else if ( filter.operator === 'isNone' ) {
+						filters.author_exclude = filter.value;
+					}
+				} else if (
+					filter.field === 'date' ||
+					filter.field === 'modified'
+				) {
+					if ( filter.operator === 'before' ) {
+						filters.before = filter.value;
+					} else if ( filter.operator === 'after' ) {
+						filters.after = filter.value;
+					}
+				} else if ( filter.field === 'mime_type' ) {
+					filters.mime_type = filter.value;
+				}
+			}
+		}
+
+		return {
+			per_page: view.perPage || 20,
+			page: view.page || 1,
+			status: 'inherit',
+			order: view.sort?.direction,
+			orderby: view.sort?.field,
+			search: view.search,
+			_embed: 'author,wp:attached-to',
+			...filters,
+		};
+	}, [ view, query.sidebarFilter, userId ] );
+
+	const {
+		records,
+		isResolving: isLoadingData,
+		totalItems,
+		totalPages,
+		hasResolved,
+	} = useEntityRecordsWithPermissions( 'postType', 'attachment', queryArgs );
+
+	const data = records;
+
+	const ids = data?.map( getItemId ) ?? [];
+	const prevIds = usePrevious( ids ) ?? [];
+	const deletedIds = prevIds.filter( ( id ) => ! ids.includes( id ) );
+	const postIdWasDeleted =
+		query.postId && deletedIds.includes( query.postId );
+
+	useEffect( () => {
+		if ( postIdWasDeleted ) {
+			history.navigate( addQueryArgs( path, { postId: undefined } ) );
+		}
+	}, [ history, postIdWasDeleted, path ] );
+
+	const paginationInfo = useMemo(
+		() => ( { totalItems, totalPages } ),
+		[ totalItems, totalPages ]
+	);
+
+	const labels = useSelect(
+		( select ) => select( coreStore ).getPostType( 'attachment' )?.labels,
+		[]
+	);
+
+	const canCreateRecord = useSelect(
+		( select ) =>
+			select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: 'attachment',
+			} ),
+		[]
+	);
+
+	const attachmentActions = usePostActions( {
+		postType: 'attachment',
+		context: 'list',
+	} );
+
+	const actions = useMemo( () => {
+		return [
+			{
+				id: 'download',
+				label: __( 'Download' ),
+				isPrimary: false,
+				supportsBulk: false,
+				callback( [ item ] ) {
+					if ( item?.source_url ) {
+						window.open( item.source_url, '_blank' );
+					}
+				},
+			},
+			...attachmentActions,
+		];
+	}, [ attachmentActions ] );
+
+	const handleOnClickItem = useEvent( ( { id } ) => {
+		history.navigate( addQueryArgs( path, { postId: id } ) );
+	} );
+
+	return (
+		<Page
+			title={ labels?.name || __( 'Media' ) }
+			headingLevel={ 2 }
+			actions={
+				canCreateRecord && (
+					<Button
+						variant="primary"
+						onClick={ () =>
+							window.open(
+								addQueryArgs( 'upload.php', {} ),
+								'_blank'
+							)
+						}
+						size="compact"
+						__next40pxDefaultSize
+					>
+						{ __( 'Add New Media' ) }
+					</Button>
+				)
+			}
+		>
+			<DataViews
+				paginationInfo={ paginationInfo }
+				fields={ fields }
+				actions={ actions }
+				data={ data || EMPTY_ARRAY }
+				isLoading={ isLoadingData || ! hasResolved }
+				view={ view }
+				onChangeView={ onChangeView }
+				selection={ selection }
+				onChangeSelection={ onChangeSelection }
+				onClickItem={ handleOnClickItem }
+				isItemClickable={ () => true }
+				getItemId={ getItemId }
+				defaultLayouts={ defaultLayouts }
+				onReset={
+					isModified
+						? () => {
+								resetToDefault();
+								history.invalidate();
+						  }
+						: false
+				}
+			/>
+		</Page>
+	);
+}

--- a/packages/edit-site/src/components/media-list/inspector.js
+++ b/packages/edit-site/src/components/media-list/inspector.js
@@ -1,0 +1,258 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { __, sprintf, _n } from '@wordpress/i18n';
+import {
+	Icon,
+	image as imageIcon,
+	audio as audioIcon,
+	video as videoIcon,
+	file as fileIcon,
+} from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { useLocation } = unlock( routerPrivateApis );
+
+function getMediaTypeIcon( mimeType ) {
+	if ( ! mimeType ) {
+		return fileIcon;
+	}
+	if ( mimeType.startsWith( 'image/' ) ) {
+		return imageIcon;
+	}
+	if ( mimeType.startsWith( 'audio/' ) ) {
+		return audioIcon;
+	}
+	if ( mimeType.startsWith( 'video/' ) ) {
+		return videoIcon;
+	}
+	return fileIcon;
+}
+
+function formatFileSize( bytes ) {
+	if ( ! bytes ) {
+		return '';
+	}
+	const sizes = [ 'B', 'KB', 'MB', 'GB' ];
+	const i = Math.floor( Math.log( bytes ) / Math.log( 1024 ) );
+	return (
+		parseFloat( ( bytes / Math.pow( 1024, i ) ).toFixed( 1 ) ) +
+		' ' +
+		sizes[ i ]
+	);
+}
+
+function formatHumanTime( dateString ) {
+	if ( ! dateString ) {
+		return '';
+	}
+	const date = new Date( dateString );
+	const now = new Date();
+	const diffMs = now - date;
+	const diffSec = Math.floor( diffMs / 1000 );
+	const diffMin = Math.floor( diffSec / 60 );
+	const diffHour = Math.floor( diffMin / 60 );
+	const diffDay = Math.floor( diffHour / 24 );
+
+	if ( Math.floor( diffDay / 365 ) > 0 ) {
+		const y = Math.floor( diffDay / 365 );
+		return sprintf(
+			/* translators: %d: number of years */
+			_n( '%d year ago', '%d years ago', y ),
+			y
+		);
+	}
+	if ( Math.floor( diffDay / 30 ) > 0 ) {
+		const m = Math.floor( diffDay / 30 );
+		return sprintf(
+			/* translators: %d: number of months */
+			_n( '%d month ago', '%d months ago', m ),
+			m
+		);
+	}
+	if ( diffDay > 0 ) {
+		return sprintf(
+			/* translators: %d: number of days */
+			_n( '%d day ago', '%d days ago', diffDay ),
+			diffDay
+		);
+	}
+	if ( diffHour > 0 ) {
+		return sprintf(
+			/* translators: %d: number of hours */
+			_n( '%d hour ago', '%d hours ago', diffHour ),
+			diffHour
+		);
+	}
+	if ( diffMin > 0 ) {
+		return sprintf(
+			/* translators: %d: number of minutes */
+			_n( '%d minute ago', '%d minutes ago', diffMin ),
+			diffMin
+		);
+	}
+	return __( 'Just now' );
+}
+
+function MetaRow( { label, children } ) {
+	return (
+		<div className="edit-site-media-inspector__meta-row">
+			<span className="edit-site-media-inspector__meta-label">
+				{ label }
+			</span>
+			<span className="edit-site-media-inspector__meta-value">
+				{ children }
+			</span>
+		</div>
+	);
+}
+
+function MetaSection( { title, children } ) {
+	return (
+		<div className="edit-site-media-inspector__section">
+			<h3 className="edit-site-media-inspector__section-title">
+				{ title }
+			</h3>
+			{ children }
+		</div>
+	);
+}
+
+export default function MediaInspector() {
+	const { query } = useLocation();
+	const { postId } = query;
+
+	const attachment = useSelect(
+		( select ) => {
+			if ( ! postId ) {
+				return null;
+			}
+			const { getEntityRecord } = select( coreStore );
+			return getEntityRecord( 'postType', 'attachment', postId );
+		},
+		[ postId ]
+	);
+
+	if ( ! postId || ! attachment ) {
+		return null;
+	}
+
+	const titleValue =
+		attachment.title?.raw ||
+		attachment.title?.rendered ||
+		__( '(no title)' );
+	const mimeType = attachment.mime_type || '';
+	const mediaTypeIcon = getMediaTypeIcon( mimeType );
+	const authorName =
+		attachment._embedded?.author?.[ 0 ]?.name || __( 'Unknown' );
+	const fileSize = formatFileSize(
+		attachment.media_details?.filesize || attachment.filesize_raw
+	);
+	const dimensions = attachment.media_details?.width
+		? `${ attachment.media_details.width } × ${ attachment.media_details.height }`
+		: '';
+
+	return (
+		<div className="edit-site-media-inspector">
+			<div className="edit-site-media-inspector__header">
+				<Icon icon={ mediaTypeIcon } size={ 24 } />
+				<h2 className="edit-site-media-inspector__title">
+					{ titleValue }
+				</h2>
+			</div>
+
+			<div className="edit-site-media-inspector__preview">
+				{ mimeType.startsWith( 'image/' ) && attachment.source_url && (
+					<img
+						src={ attachment.source_url }
+						alt={ attachment.alt_text || '' }
+						className="edit-site-media-inspector__image"
+					/>
+				) }
+				{ ! mimeType.startsWith( 'image/' ) && (
+					<div className="edit-site-media-inspector__file-icon">
+						<Icon icon={ mediaTypeIcon } size={ 48 } />
+					</div>
+				) }
+			</div>
+
+			<div className="edit-site-media-inspector__body">
+				<div className="edit-site-media-inspector__description-field">
+					<span className="edit-site-media-inspector__description-label">
+						{ __( 'Description' ) }
+					</span>
+					<p className="edit-site-media-inspector__description-text">
+						{ attachment.description?.raw ||
+							__( 'Add a description\u2026' ) }
+					</p>
+				</div>
+
+				<div className="edit-site-media-inspector__audit">
+					<span>
+						{ sprintf(
+							/* translators: %s: author name */
+							__( 'Uploaded by %s' ),
+							authorName
+						) }
+					</span>
+					<span>
+						{ attachment.date
+							? sprintf(
+									/* translators: %s: relative time */
+									__( 'Uploaded %s' ),
+									formatHumanTime( attachment.date )
+							  )
+							: '' }
+					</span>
+					<span>
+						{ attachment.modified
+							? sprintf(
+									/* translators: %s: relative time */
+									__( 'Last modified %s' ),
+									formatHumanTime( attachment.modified )
+							  )
+							: '' }
+					</span>
+				</div>
+
+				<MetaSection title={ __( 'Metadata' ) }>
+					<MetaRow label={ __( 'Attached To' ) }>
+						{ attachment.post
+							? String( attachment.post )
+							: __( 'Unattached' ) }
+					</MetaRow>
+					<MetaRow label={ __( 'Comments' ) }>
+						{ String( attachment.comment_count ?? 0 ) }
+					</MetaRow>
+					<MetaRow label={ __( 'Alt Text' ) }>
+						{ attachment.alt_text || '—' }
+					</MetaRow>
+					<MetaRow label={ __( 'Caption' ) }>
+						{ attachment.caption?.raw || '—' }
+					</MetaRow>
+					<MetaRow label={ __( 'File Name' ) }>
+						{ attachment.filename_raw || '—' }
+					</MetaRow>
+					<MetaRow label={ __( 'Format' ) }>
+						{ mimeType.split( '/' )[ 1 ]?.toUpperCase() || '—' }
+					</MetaRow>
+					<MetaRow label={ __( 'File Size' ) }>
+						{ fileSize || '—' }
+					</MetaRow>
+					{ dimensions && (
+						<MetaRow label={ __( 'Dimensions' ) }>
+							{ dimensions }
+						</MetaRow>
+					) }
+				</MetaSection>
+			</div>
+		</div>
+	);
+}

--- a/packages/edit-site/src/components/media-list/sidebar-content.js
+++ b/packages/edit-site/src/components/media-list/sidebar-content.js
@@ -1,0 +1,128 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import {
+	media,
+	image,
+	audio,
+	video,
+	file,
+	table,
+	archive,
+} from '@wordpress/icons';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import SidebarNavigationItem from '../sidebar-navigation-item';
+import { unlock } from '../../lock-unlock';
+
+const { useLocation, useHistory } = unlock( routerPrivateApis );
+
+const FILE_TYPES = [
+	{ slug: 'image', label: __( 'Images' ), icon: image },
+	{ slug: 'audio', label: __( 'Audio' ), icon: audio },
+	{ slug: 'video', label: __( 'Video' ), icon: video },
+	{ slug: 'application', label: __( 'Documents' ), icon: file },
+	{ slug: 'text', label: __( 'Spreadsheets' ), icon: table },
+	{ slug: 'archive', label: __( 'Archives' ), icon: archive },
+];
+
+function SidebarSection( { title, children } ) {
+	return (
+		<div className="edit-site-sidebar-media-library__section">
+			<h3 className="edit-site-sidebar-media-library__section-title">
+				{ title }
+			</h3>
+			{ children }
+		</div>
+	);
+}
+
+export default function MediaSidebarContent() {
+	const { path, query } = useLocation();
+	const history = useHistory();
+	const currentFilter = query.sidebarFilter || 'all';
+
+	const counts = useSelect( ( select ) => {
+		const { getEntityRecordsTotalItems } = select( coreStore );
+		const results = {};
+		for ( const ft of FILE_TYPES ) {
+			results[ ft.slug ] = getEntityRecordsTotalItems(
+				'postType',
+				'attachment',
+				{
+					status: 'inherit',
+					media_type: ft.slug,
+					per_page: 1,
+				}
+			);
+		}
+		return results;
+	}, [] );
+
+	function navigateWithFilter( filter ) {
+		history.navigate(
+			addQueryArgs( path, {
+				...query,
+				sidebarFilter: filter,
+				pageNumber: undefined,
+			} )
+		);
+	}
+
+	return (
+		<div className="edit-site-sidebar-media-library">
+			<ItemGroup>
+				<SidebarNavigationItem
+					icon={ media }
+					aria-current={
+						currentFilter === 'all' ? 'true' : undefined
+					}
+					onClick={ () => navigateWithFilter( 'all' ) }
+				>
+					{ __( 'All Media' ) }
+				</SidebarNavigationItem>
+				<SidebarNavigationItem
+					icon={ media }
+					aria-current={
+						currentFilter === 'my-files' ? 'true' : undefined
+					}
+					onClick={ () => navigateWithFilter( 'my-files' ) }
+				>
+					{ __( 'My Files' ) }
+				</SidebarNavigationItem>
+			</ItemGroup>
+
+			<SidebarSection title={ __( 'File Types' ) }>
+				<ItemGroup>
+					{ FILE_TYPES.map( ( ft ) => (
+						<SidebarNavigationItem
+							key={ ft.slug }
+							icon={ ft.icon }
+							aria-current={
+								currentFilter === ft.slug ? 'true' : undefined
+							}
+							onClick={ () => navigateWithFilter( ft.slug ) }
+							suffix={
+								counts[ ft.slug ] !== undefined ? (
+									<span className="edit-site-sidebar-media-library__count">
+										{ counts[ ft.slug ] }
+									</span>
+								) : undefined
+							}
+						>
+							{ ft.label }
+						</SidebarNavigationItem>
+					) ) }
+				</ItemGroup>
+			</SidebarSection>
+		</div>
+	);
+}

--- a/packages/edit-site/src/components/media-list/style.scss
+++ b/packages/edit-site/src/components/media-list/style.scss
@@ -1,0 +1,35 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.edit-site-sidebar-media-library__section {
+	margin-top: $grid-unit-20;
+	padding: 0 $grid-unit-10;
+}
+
+.edit-site-sidebar-media-library__section-title {
+	color: $gray-200;
+	font-size: $helptext-font-size;
+	font-weight: $font-weight-medium;
+	padding: 0 $grid-unit-10;
+	margin-bottom: $grid-unit-05;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+}
+
+.edit-site-sidebar-media-library__count {
+	margin-left: auto;
+	color: $gray-600;
+	font-size: $helptext-font-size;
+}
+
+.edit-site-media-list__title-cell {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.edit-site-media-list__inline-thumb {
+	border-radius: 2px;
+	object-fit: cover;
+	flex-shrink: 0;
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -10,6 +10,7 @@ import {
 	styles,
 	page,
 	siteLogo,
+	media,
 } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -57,6 +58,16 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 					>
 						{ __( 'Pages' ) }
 					</SidebarNavigationItem>
+					{ window.__experimentalDataViewsMediaLibrary && (
+						<SidebarNavigationItem
+							uid="media-navigation-item"
+							to="/media"
+							withChevron
+							icon={ media }
+						>
+							{ __( 'Media' ) }
+						</SidebarNavigationItem>
+					) }
 					<SidebarNavigationItem
 						uid="template-navigation-item"
 						to="/template"

--- a/packages/edit-site/src/components/site-editor-routes/index.js
+++ b/packages/edit-site/src/components/site-editor-routes/index.js
@@ -23,6 +23,7 @@ import { pagesRoute } from './pages';
 import { pageItemRoute } from './page-item';
 import { stylebookRoute } from './stylebook';
 import { notFoundRoute } from './notfound';
+import { mediaRoute } from './media';
 
 const routes = [
 	pageItemRoute,
@@ -40,6 +41,10 @@ const routes = [
 	stylebookRoute,
 	notFoundRoute,
 ];
+
+if ( window.__experimentalDataViewsMediaLibrary ) {
+	routes.push( mediaRoute );
+}
 
 export function useRegisterSiteEditorRoutes() {
 	const registry = useRegistry();

--- a/packages/edit-site/src/components/site-editor-routes/media.js
+++ b/packages/edit-site/src/components/site-editor-routes/media.js
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import MediaList from '../media-list';
+import MediaSidebarContent from '../media-list/sidebar-content';
+import MediaInspector from '../media-list/inspector';
+import { unlock } from '../../lock-unlock';
+import { isThemeDataLoaded } from './utils';
+
+const { useLocation } = unlock( routerPrivateApis );
+
+function MobileMediaView() {
+	const { query } = useLocation();
+	const { postId } = query;
+	return postId ? <MediaInspector /> : <MediaList />;
+}
+
+export const mediaRoute = {
+	name: 'media',
+	path: '/media',
+	areas: {
+		sidebar( { siteData } ) {
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
+			return (
+				<SidebarNavigationScreen
+					title={ __( 'Media' ) }
+					backPath="/"
+					content={ <MediaSidebarContent /> }
+				/>
+			);
+		},
+		content() {
+			return <MediaList />;
+		},
+		async preview( { query: q } ) {
+			if ( q.postId ) {
+				return <MediaInspector />;
+			}
+			return undefined;
+		},
+		mobile( { siteData } ) {
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return <></>;
+			}
+			return <MobileMediaView />;
+		},
+	},
+};

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -26,6 +26,7 @@
 @use "./components/sidebar-navigation-screen-main/style.scss" as *;
 @use "./components/sidebar-navigation-screen-templates-browse/style.scss" as *;
 @use "./components/sidebar-dataviews/style.scss" as *;
+@use "./components/media-list/style.scss" as *;
 @use "./components/site-hub/style.scss" as *;
 @use "./components/site-icon/style.scss" as *;
 @use "./components/post-list/style.scss" as *;

--- a/packages/fields/src/actions/trash-post.tsx
+++ b/packages/fields/src/actions/trash-post.tsx
@@ -92,7 +92,9 @@ const trashPost: Action< PostWithPermissions > = {
 										'postType',
 										item.type,
 										item.id.toString(),
-										{},
+										item.type === 'attachment'
+											? { force: true }
+											: {},
 										{ throwOnError: true }
 									)
 								)


### PR DESCRIPTION
## What?
- Closes https://github.com/WordPress/gutenberg/issues/72735
- Adds a DataViews-powered media library view in the Site Editor, behind the `gutenberg-dataviews-media-library` experiment. Includes a 3-panel layout with a filtered sidebar, DataViews table, and a right inspector panel for media details.

## Why?

The existing Media Library (upload.php) is a standalone admin screen. This brings media management into the Site Editor using the DataViews component, consistent with how Pages, Templates, and Patterns are already handled.

## How?

- **Experiment registration**: Added `gutenberg-dataviews-media-library` experiment flag with PHP bridge to `window.__experimentalDataViewsMediaLibrary`
- **Route (`/media`)**: Registered in the classic Site Editor router (`@wordpress/router`) with `sidebar`/`content`/`preview` areas, plus v2 extensible site editor menu item and route
- **Left sidebar**: All Media, My Files, and File Types filters (Images, Audio, Video, Documents, Spreadsheets, Archives) with count badges, each filtering the DataViews table
- **Data table**: Uses `<DataViews>` with columns for title+thumbnail, author, attached to, comments, and date. Supports table/grid/list layouts, search, sorting, pagination, bulk selection, and download/trash actions
- **Right inspector panel**: Shows image preview, description, audit info (uploaded by, dates), and metadata (alt text, caption, file name, format, size, dimensions)
- **Trash fix**: `fields/src/actions/trash-post.tsx` now passes `force: true` for attachments, which require it to delete

## Testing Instructions

1. Go to **wp-admin > Gutenberg > Experiments** and enable **"Media Library (DataViews)"**
2. Open the **Site Editor** (Appearance > Design)
3. The **Media** nav item appears below Pages in the sidebar
4. Click **Media** to see the DataViews-powered media table
5. Use the left sidebar to filter by **My Files** or **File Types**
6. Click a media item to open the right inspector panel
7. Use **Add New Media** button, search, sort, and paginate

## Preview
<img width="1470" height="810" alt="Screenshot 2026-06-05 at 11 41 55 AM" src="https://github.com/user-attachments/assets/6f34ac43-4125-4f64-85b9-ddd078fa2b01" />

## Use of AI Tools

This PR was implemented using the `deepseek-v4-flash:cloud` model (provided by Ollama) via the opencode agent framework. The PR description was also written by the AI. All code was reviewed and validated before submission.