### PR TITLE
Navigation Link: fix duplicate block html attributes in editor

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -338,7 +338,6 @@ export default function NavigationLinkEdit( {
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{
-			...blockProps,
 			className: 'remove-outline', // Remove the outline from the inner blocks container.
 		},
 		{

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -450,7 +450,7 @@ test.describe( 'Navigation block', () => {
 			await test.step( 'focus returns to the submenu appender when exiting the submenu link creation without creating a link', async () => {
 				// Move focus to the submenu navigation appender
 				await pageUtils.pressKeys( 'ArrowDown' );
-				await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
+				await pageUtils.pressKeys( 'ArrowRight' );
 
 				await pageUtils.pressKeys( 'ArrowDown' );
 
@@ -571,7 +571,7 @@ test.describe( 'Navigation block', () => {
 			 */
 			// Add a link back so we can delete the first submenu link.
 			await pageUtils.pressKeys( 'ArrowDown' );
-			await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
+			await pageUtils.pressKeys( 'ArrowRight' );
 			await navigation.useBlockInserter();
 			await navigation.addCustomURL( 'https://wordpress.org' );
 			await navigation.expectToHaveTextSelected( 'wordpress.org' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The Navigation link block's editor implementation applies `blockProps` to two separate elements, meaning lots of html attributes end up duplicated, including the block's `id`. See the following example markup, the `<div>` after the `<a>` has the same attributes as the wrapper `<div>`:
```html
<div tabindex="0" class="block-editor-block-list__block wp-block is-selected wp-block-navigation-item is-editing has-link wp-block-navigation-link" aria-invalid="false" id="block-52b530a8-6b10-4c51-a218-0f1089c13fe5" role="document" aria-label="Block: Page link" data-block="52b530a8-6b10-4c51-a218-0f1089c13fe5" data-type="core/navigation-link" data-title="Page link" style="--wp-admin-theme-color: var(--wp-block-synced-color); --wp-admin-theme-color--rgb: var(--wp-block-synced-color--rgb);" data-draggable="true">
  <a class="wp-block-navigation-item__content">
    <div role="textbox" aria-multiline="true" aria-readonly="false" class="block-editor-rich-text__editable wp-block-navigation-item__label rich-text" aria-label="Navigation link text" contenteditable="true" data-wp-block-attribute-key="label" style="white-space: pre-wrap;">
      Sample Page
    </div>
  </a>
  <div tabindex="0" draggable="true" class="remove-outline block-editor-block-list__layout" aria-invalid="false" id="block-52b530a8-6b10-4c51-a218-0f1089c13fe5" role="document" aria-label="Block: Page link" data-block="52b530a8-6b10-4c51-a218-0f1089c13fe5" data-type="core/navigation-link" data-title="Page link" data-is-drop-zone="true" style="--wp-admin-theme-color: var(--wp-block-synced-color); --wp-admin-theme-color--rgb: var(--wp-block-synced-color--rgb);"></div>
</div>
```

This can have some minor buggy side effects with block selection, accessibility, and obviously it's not great to have duplicate ids in the html document. It seems to have been a mistake that was introduce a long time ago and never caught.

Possibly it might also result in flaky e2e tests if a test tries to select a nav link block wrapper.

## How?
Delete the line of code that applies `blockProps` to the inner blocks element. This shouldn't cause any adverse side effects, my understanding is the inner blocks of navigation link are only there to support drag and drop. As soon as the navigation link has inner blocks it auto-converts itself to a submenu block.

## Testing Instructions
1. Insert a nav block
2. Add multiple links
3. Place the caret in the first nav links
4. Press the right arrow key to move the caret right. 

In trunk: when you get to the last character and press right arrow, the caret disappears. This is the second block wrapper receiving focus, press right arrow again and then next block is selected.
In this PR: when you get to the last character and press right arrow the caret doesn't disappear, it moves straight to the next block.

## Screenshots or screencast <!-- if applicable -->
#### Before
https://github.com/user-attachments/assets/d665eaf7-76fc-4661-82d4-1960e25dd3d9

#### After
https://github.com/user-attachments/assets/3b5f5c00-1900-474f-af60-bcc8be7ef8f9

## Use of AI Tools
None