### PR TITLE
Refactor workspace configuration for Babel dependencies

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,16 +1,6 @@
-module.exports = ( api ) => {
-	api.cache( true );
-
-	return {
-		presets: [ '@wordpress/babel-preset-default' ],
-		plugins: [ '@emotion/babel-plugin', 'babel-plugin-inline-json-import' ],
-		overrides: [
-			{
-				test: 'packages/block-library/src/index.js',
-				plugins: [
-					require.resolve( '@wordpress/block-library/babel-plugin' ),
-				],
-			},
-		],
-	};
-};
+/*
+ * Root babel config delegates to `tools/build-scripts/babel.config.cjs` so
+ * that babel-related dependencies and resolution context live in a workspace
+ * rather than at the repo root.
+ */
+module.exports = require( './tools/build-scripts/babel.config.cjs' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,6 @@
 				"widgets/*"
 			],
 			"devDependencies": {
-				"@babel/core": "7.25.7",
-				"@emotion/babel-plugin": "11.13.5",
 				"@eslint/eslintrc": "^3.0.0",
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
@@ -32,8 +30,6 @@
 				"@wordpress/eslint-tools": "file:./tools/eslint",
 				"@wordpress/release-tools": "file:./tools/release",
 				"@wordpress/vips": "file:./packages/vips",
-				"babel-loader": "9.2.1",
-				"babel-plugin-inline-json-import": "0.3.2",
 				"concurrently": "3.5.0",
 				"cross-env": "7.0.3",
 				"eslint": "^10.0.0",
@@ -25403,7 +25399,6 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-inline-json-import/-/babel-plugin-inline-json-import-0.3.2.tgz",
 			"integrity": "sha512-QNNJx08KjmMT25Cw7rAPQ6dlREDPiZGDyApHL8KQ9vrQHbrr4PTi7W8g1tMMZPz0jEMd39nx/eH7xjnDNxq5sA==",
-			"dev": true,
 			"dependencies": {
 				"decache": "^4.5.1"
 			}
@@ -26640,7 +26635,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
 			"integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
-			"dev": true,
 			"engines": {
 				"node": "*"
 			}
@@ -29680,7 +29674,6 @@
 			"version": "4.5.1",
 			"resolved": "https://registry.npmjs.org/decache/-/decache-4.5.1.tgz",
 			"integrity": "sha512-5J37nATc6FmOTLbcsr9qx7Nm28qQyg1SK4xyEHqM0IBkNhWFp0Sm+vKoWYHD8wq+OUEb9jLyaKFfzzd1A9hcoA==",
-			"dev": true,
 			"dependencies": {
 				"callsite": "^1.0.0"
 			}
@@ -59618,6 +59611,7 @@
 				"uuid": "^14.0.0"
 			},
 			"devDependencies": {
+				"@babel/core": "^7.25.7",
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
@@ -59828,6 +59822,9 @@
 			"name": "@wordpress/browserslist-config",
 			"version": "6.47.0",
 			"license": "GPL-2.0-or-later",
+			"devDependencies": {
+				"browserslist": "^4.21.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -65908,6 +65905,9 @@
 			"name": "@wordpress/warning",
 			"version": "3.47.0",
 			"license": "GPL-2.0-or-later",
+			"devDependencies": {
+				"@babel/core": "^7.25.7"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -66782,6 +66782,7 @@
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
+				"@wordpress/babel-preset-default": "file:../../packages/babel-preset-default",
 				"@wordpress/jest-preset-default": "file:../../packages/jest-preset-default",
 				"@wordpress/scripts": "file:../../packages/scripts",
 				"babel-jest": "^29.7.0",
@@ -66802,9 +66803,12 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@emotion/babel-plugin": "^11.13.5",
 				"@typescript/native-preview": "7.0.0-dev.20260423.1",
+				"@wordpress/babel-preset-default": "file:../../packages/babel-preset-default",
 				"@wordpress/build": "file:../../packages/wp-build",
 				"@wordpress/scripts": "file:../../packages/scripts",
+				"babel-plugin-inline-json-import": "^0.3.2",
 				"chalk": "^4.1.1",
 				"cross-spawn": "^7.0.6",
 				"esbuild": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,6 @@
 		"IS_GUTENBERG_PLUGIN": true
 	},
 	"devDependencies": {
-		"@babel/core": "7.25.7",
-		"@emotion/babel-plugin": "11.13.5",
 		"@eslint/eslintrc": "^3.0.0",
 		"@types/react": "^18.3.27",
 		"@types/react-dom": "^18.3.1",
@@ -71,8 +69,6 @@
 		"@wordpress/eslint-tools": "file:./tools/eslint",
 		"@wordpress/release-tools": "file:./tools/release",
 		"@wordpress/vips": "file:./packages/vips",
-		"babel-loader": "9.2.1",
-		"babel-plugin-inline-json-import": "0.3.2",
 		"concurrently": "3.5.0",
 		"cross-env": "7.0.3",
 		"eslint": "^10.0.0",

--- a/packages/babel-plugin-import-jsx-pragma/test/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/test/index.js
@@ -159,7 +159,10 @@ describe( 'babel-plugin-import-jsx-pragma', () => {
 function getTransformedCode( source, options = {} ) {
 	const { code } = transformSync( source, {
 		configFile: false,
-		plugins: [ [ plugin, options ], '@babel/plugin-syntax-jsx' ],
+		plugins: [
+			[ plugin, options ],
+			require.resolve( '@babel/plugin-syntax-jsx' ),
+		],
 	} );
 
 	return code;

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -145,6 +145,7 @@
 		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
+		"@babel/core": "^7.25.7",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -31,6 +31,9 @@
 		".": "./index.js",
 		"./package.json": "./package.json"
 	},
+	"devDependencies": {
+		"browserslist": "^4.21.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/browserslist-config/test/index.test.js
+++ b/packages/browserslist-config/test/index.test.js
@@ -13,7 +13,7 @@ it( 'should export an array', () => {
 } );
 
 it( 'should not contain invalid queries', () => {
-	const result = browserslist( [ 'extends @wordpress/browserslist-config' ] );
+	const result = browserslist( config );
 
 	expect( result ).toBeTruthy();
 } );

--- a/packages/warning/package.json
+++ b/packages/warning/package.json
@@ -46,6 +46,9 @@
 	"wpScriptDefaultExport": true,
 	"types": "build-types",
 	"sideEffects": false,
+	"devDependencies": {
+		"@babel/core": "^7.25.7"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1311,7 +1311,7 @@ async function transpilePackage( packageName ) {
 	const emotionPlugin = babel( {
 		filter: /\.[jt]sx?$/,
 		config: {
-			plugins: [ '@emotion/babel-plugin' ],
+			plugins: [ styleRuntimeRequire.resolve( '@emotion/babel-plugin' ) ],
 		},
 	} );
 	const externalizeAllExceptCssPlugin = {

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -24,6 +24,7 @@
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
+		"@wordpress/babel-preset-default": "file:../../packages/babel-preset-default",
 		"@wordpress/jest-preset-default": "file:../../packages/jest-preset-default",
 		"@wordpress/scripts": "file:../../packages/scripts",
 		"babel-jest": "^29.7.0",

--- a/test/unit/scripts/babel-transformer.js
+++ b/test/unit/scripts/babel-transformer.js
@@ -8,7 +8,7 @@ const babelJest = require( 'babel-jest' );
 const babelJestInterop = babelJest.__esModule ? babelJest.default : babelJest;
 
 const babelJestTransformer = babelJestInterop.createTransformer( {
-	presets: [ '@wordpress/babel-preset-default' ],
+	presets: [ require.resolve( '@wordpress/babel-preset-default' ) ],
 } );
 
 module.exports = {

--- a/tools/build-scripts/babel.config.cjs
+++ b/tools/build-scripts/babel.config.cjs
@@ -1,0 +1,32 @@
+/*
+ * Babel project-wide config for the monorepo. Owned by this workspace so all
+ * babel-related dependencies live here rather than at the repo root.
+ */
+const path = require( 'node:path' );
+
+const ROOT_DIR = path.resolve( __dirname, '../..' );
+
+module.exports = ( api ) => {
+	api.cache( true );
+
+	return {
+		presets: [ require.resolve( '@wordpress/babel-preset-default' ) ],
+		plugins: [
+			require.resolve( '@emotion/babel-plugin' ),
+			require.resolve( 'babel-plugin-inline-json-import' ),
+		],
+		overrides: [
+			{
+				test: path.join(
+					ROOT_DIR,
+					'packages/block-library/src/index.js'
+				),
+				plugins: [
+					require.resolve(
+						'../../packages/block-library/babel-plugin.cjs'
+					),
+				],
+			},
+		],
+	};
+};

--- a/tools/build-scripts/package.json
+++ b/tools/build-scripts/package.json
@@ -21,9 +21,12 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"@emotion/babel-plugin": "^11.13.5",
 		"@typescript/native-preview": "7.0.0-dev.20260423.1",
+		"@wordpress/babel-preset-default": "file:../../packages/babel-preset-default",
 		"@wordpress/build": "file:../../packages/wp-build",
 		"@wordpress/scripts": "file:../../packages/scripts",
+		"babel-plugin-inline-json-import": "^0.3.2",
 		"chalk": "^4.1.1",
 		"cross-spawn": "^7.0.6",
 		"esbuild": "^0.27.2",


### PR DESCRIPTION
## What?

Related to #75041

## Why? & How?

This implements the "Move babel deps out of root" task from the Phase 7.1 cleanup, adapting the diff from the issue description to the current state of trunk.