### PR TITLE
Try omit-unchanged for compressed-size-action

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -64,6 +64,7 @@ jobs:
 
             - uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v2.9.1
               with:
+                  omit-unchanged: true
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   pattern: '{build/scripts/**/*.min.js,build/styles/**/*.css,build/modules/**/*.min.js}'
                   clean-script: 'distclean'


### PR DESCRIPTION
## What?
If you use email notifications at all, the compressed-size-action notification is incredibly noisy. It emails a huge list of unchanged files, which I expect nobody ever looks at.

In this PR I'm testing the `omit-unchanged` option to reduce the amount of spam:
https://github.com/preactjs/compressed-size-action/blob/f38486648b00a34e8854dd44e21ba901f51d7454/src/index.js#L151

## Use of AI Tools
None