### PR TITLE
Tooltip: Use md border radius for portaled popups.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Enhancements
 
--   `Tooltip`: Use `--wpds-border-radius-md` for portaled popup surfaces, aligning with menus and popovers.
+-   `Tooltip`: Use `--wpds-border-radius-md` for portaled popup surfaces, aligning with menus and popovers ([#78983](https://github.com/WordPress/gutenberg/pull/78983)).
 
 ## 34.0.0 (2026-05-27)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   Fix documentation typos and grammar ([#78686](https://github.com/WordPress/gutenberg/pull/78686)).
 
+### Enhancements
+
+-   `Tooltip`: Use `--wpds-border-radius-md` for portaled popup surfaces, aligning with menus and popovers.
+
 ## 34.0.0 (2026-05-27)
 
 ### Breaking Changes

--- a/packages/components/src/tooltip/style.scss
+++ b/packages/components/src/tooltip/style.scss
@@ -5,7 +5,7 @@
 .components-tooltip {
 	background: $black;
 	font-family: $default-font;
-	border-radius: $radius-small;
+	border-radius: var(--wpds-border-radius-md);
 	color: $gray-100;
 	text-align: center;
 	line-height: 1.4;

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Enhancements
 
+-   `Tooltip`: Use `--wpds-border-radius-md` for portaled popup surfaces, aligning with menus and popovers.
 -   `Tooltip.Provider`: Widen the types to accept all props of the equivalent `Tooltip.Provider` from `@base-ui/react` (types-only change) ([#78642](https://github.com/WordPress/gutenberg/pull/78642)).
 
 ## 0.14.0 (2026-05-27)

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Enhancements
 
--   `Tooltip`: Use `--wpds-border-radius-md` for portaled popup surfaces, aligning with menus and popovers.
+-   `Tooltip`: Use `--wpds-border-radius-md` for portaled popup surfaces, aligning with menus and popovers ([#78983](https://github.com/WordPress/gutenberg/pull/78983)).
 -   `Tooltip.Provider`: Widen the types to accept all props of the equivalent `Tooltip.Provider` from `@base-ui/react` (types-only change) ([#78642](https://github.com/WordPress/gutenberg/pull/78642)).
 
 ## 0.14.0 (2026-05-27)

--- a/packages/ui/src/tooltip/style.module.css
+++ b/packages/ui/src/tooltip/style.module.css
@@ -10,7 +10,7 @@
 		padding:
 			var(--wpds-dimension-padding-xs)
 			var(--wpds-dimension-padding-sm);
-		border-radius: var(--wpds-border-radius-sm);
+		border-radius: var(--wpds-border-radius-md);
 		font-family: var(--wpds-typography-font-family-body);
 		font-size: var(--wpds-typography-font-size-sm);
 		line-height: 1.4; /* TODO: use DS token for line height */


### PR DESCRIPTION
## What

Updates tooltip border radius from `sm` (2px) to `md` (4px) in both `@wordpress/ui` and `@wordpress/components`.

- **`@wordpress/ui`:** `packages/ui/src/tooltip/style.module.css`
- **`@wordpress/components`:** `packages/components/src/tooltip/style.scss` — replaces legacy `$radius-small` with `var(--wpds-border-radius-md)`

## Why

Tooltips are portaled overlay surfaces, like menus and popovers. As discussed in https://github.com/WordPress/gutenberg/pull/78913 that role maps to `md`, not `sm` radius. Using `sm` put tooltips on the same step as compact controls (buttons, inputs), which breaks the intended hierarchy between triggers and floating UI.

## How

1. Switch tooltip popup styles to `--wpds-border-radius-md` in both packages.
2. Leave trigger/control styling unchanged — buttons and icon buttons stay on `sm`.
3. Native tooltip styling is unchanged; it already uses 4px, which matches `md`.

## Screenshots

| Before | After |
| --- | --- |
| <img width="73" height="42" alt="Screenshot 2026-06-05 at 15 44 24" src="https://github.com/user-attachments/assets/a91dde85-db12-4d84-af31-40658e12dcc5" /> | <img width="74" height="40" alt="Screenshot 2026-06-05 at 15 44 35" src="https://github.com/user-attachments/assets/60bff9b3-4fac-4443-aac2-d673123c7e81" /> |


## Test plan

- [ ] Storybook → **Design System/Components/Tooltip** — popup corners use 4px radius
- [ ] Block editor / admin — legacy `@wordpress/components` tooltips match the updated radius
- [ ] Confirm tooltip triggers (buttons, icon buttons) are unchanged at `sm`