### PR TITLE
Make playlist waveform an inner block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -625,9 +625,20 @@ Embed a simple playlist. ([Source](https://github.com/WordPress/gutenberg/tree/t
 -	**Name:** core/playlist
 -	**Experimental:** true
 -	**Category:** media
--	**Allowed Blocks:** core/playlist-track
+-	**Allowed Blocks:** core/playlist-waveform, core/playlist-tracklist
 -	**Supports:** align, anchor, color (background, gradients, link, text), interactivity, spacing (margin, padding)
 -	**Attributes:** caption, currentTrack, order, showArtists, showImages, showNumbers, showTrackLength, showTracklist, type
+
+## Playlist tracklist
+
+Playlist tracklist. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/playlist-tracklist))
+
+-	**Name:** core/playlist-tracklist
+-	**Experimental:** true
+-	**Category:** media
+-	**Parent:** core/playlist
+-	**Allowed Blocks:** core/playlist-track
+-	**Supports:** ~~html~~, ~~reusable~~
 
 ## Playlist track
 
@@ -636,9 +647,19 @@ Playlist track. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/pack
 -	**Name:** core/playlist-track
 -	**Experimental:** true
 -	**Category:** media
--	**Parent:** core/playlist
+-	**Parent:** core/playlist-tracklist
 -	**Supports:** interactivity (clientNavigation), ~~html~~, ~~reusable~~
 -	**Attributes:** album, artist, blob, id, image, length, src, title, type, uniqueId
+
+## Playlist waveform
+
+Playlist waveform. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/playlist-waveform))
+
+-	**Name:** core/playlist-waveform
+-	**Experimental:** true
+-	**Category:** media
+-	**Parent:** core/playlist
+-	**Supports:** ~~html~~, ~~reusable~~
 
 ## Author (deprecated)
 

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -95,7 +95,9 @@ import * as pageList from './page-list';
 import * as pageListItem from './page-list-item';
 import * as paragraph from './paragraph';
 import * as playlist from './playlist';
+import * as playlistTracklist from './playlist-tracklist';
 import * as playlistTrack from './playlist-track';
+import * as playlistWaveform from './playlist-waveform';
 import * as postAuthor from './post-author';
 import * as postAuthorName from './post-author-name';
 import * as postAuthorBiography from './post-author-biography';
@@ -293,6 +295,8 @@ const getAllBlocks = () => {
 		blocks.push( tabPanel );
 		blocks.push( tabPanels );
 		blocks.push( playlist );
+		blocks.push( playlistWaveform );
+		blocks.push( playlistTracklist );
 		blocks.push( playlistTrack );
 	}
 

--- a/packages/block-library/src/playlist-track/block.json
+++ b/packages/block-library/src/playlist-track/block.json
@@ -5,7 +5,7 @@
 	"name": "core/playlist-track",
 	"title": "Playlist track",
 	"category": "media",
-	"parent": [ "core/playlist" ],
+	"parent": [ "core/playlist-tracklist" ],
 	"description": "Playlist track.",
 	"keywords": [ "music", "sound" ],
 	"textdomain": "default",

--- a/packages/block-library/src/playlist-tracklist/block.json
+++ b/packages/block-library/src/playlist-tracklist/block.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"__experimental": true,
+	"name": "core/playlist-tracklist",
+	"title": "Playlist tracklist",
+	"category": "media",
+	"parent": [ "core/playlist" ],
+	"description": "Playlist tracklist.",
+	"keywords": [ "music", "sound" ],
+	"textdomain": "default",
+	"allowedBlocks": [ "core/playlist-track" ],
+	"usesContext": [
+		"showTracklist",
+		"showArtists",
+		"showNumbers",
+		"showTrackLength"
+	],
+	"supports": {
+		"html": false,
+		"reusable": false
+	},
+	"style": "wp-block-playlist"
+}

--- a/packages/block-library/src/playlist-tracklist/edit.js
+++ b/packages/block-library/src/playlist-tracklist/edit.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	InnerBlocks,
+} from '@wordpress/block-editor';
+
+const PlaylistTracklistEdit = ( { context } ) => {
+	const {
+		showTracklist = true,
+		showArtists = true,
+		showNumbers = true,
+		showTrackLength = true,
+	} = context;
+	const blockProps = useBlockProps( {
+		className: clsx( 'wp-block-playlist__tracklist', {
+			'wp-block-playlist__tracklist-is-hidden': ! showTracklist,
+			'wp-block-playlist__tracklist-artist-is-hidden': ! showArtists,
+			'wp-block-playlist__tracklist-length-is-hidden':
+				! showTrackLength,
+			'wp-block-playlist__tracklist-show-numbers': showNumbers,
+		} ),
+	} );
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		allowedBlocks: [ 'core/playlist-track' ],
+		__experimentalAppenderTagName: 'li',
+		renderAppender: InnerBlocks.ButtonBlockAppender,
+	} );
+
+	return <ol { ...innerBlocksProps } />;
+};
+
+export default PlaylistTracklistEdit;

--- a/packages/block-library/src/playlist-tracklist/index.js
+++ b/packages/block-library/src/playlist-tracklist/index.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { audio as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	icon,
+	edit,
+	save,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/playlist-tracklist/index.php
+++ b/packages/block-library/src/playlist-tracklist/index.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Server-side registration of the `core/playlist-tracklist` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Registers the `core/playlist-tracklist` block on server.
+ *
+ * @since 6.9.0
+ */
+function register_block_core_playlist_tracklist() {
+	register_block_type_from_metadata( __DIR__ . '/playlist-tracklist' );
+}
+add_action( 'init', 'register_block_core_playlist_tracklist' );

--- a/packages/block-library/src/playlist-tracklist/save.js
+++ b/packages/block-library/src/playlist-tracklist/save.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+export default function save() {
+	const blockProps = useBlockProps.save( {
+		className: 'wp-block-playlist__tracklist',
+	} );
+	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+
+	return <ol { ...innerBlocksProps } />;
+}

--- a/packages/block-library/src/playlist-waveform/block.json
+++ b/packages/block-library/src/playlist-waveform/block.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"__experimental": true,
+	"name": "core/playlist-waveform",
+	"title": "Playlist waveform",
+	"category": "media",
+	"parent": [ "core/playlist" ],
+	"description": "Playlist waveform.",
+	"keywords": [ "music", "sound" ],
+	"textdomain": "default",
+	"usesContext": [ "currentTrack" ],
+	"supports": {
+		"html": false,
+		"reusable": false
+	},
+	"styles": [
+		{ "name": "bars", "label": "Bars", "isDefault": true },
+		{ "name": "mirror", "label": "Mirror" },
+		{ "name": "line", "label": "Line" },
+		{ "name": "blocks", "label": "Blocks" },
+		{ "name": "dots", "label": "Dots" },
+		{ "name": "seekbar", "label": "Seekbar" }
+	],
+	"style": "wp-block-playlist"
+}

--- a/packages/block-library/src/playlist-waveform/edit.js
+++ b/packages/block-library/src/playlist-waveform/edit.js
@@ -1,0 +1,96 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import {
+	store as blockEditorStore,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import { Disabled } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { WaveformPlayer } from '../utils/waveform-player';
+
+const getPlaylistTracks = ( innerBlocks ) => {
+	const tracklist = innerBlocks.find(
+		( block ) => block.name === 'core/playlist-tracklist'
+	);
+	return (
+		tracklist?.innerBlocks ??
+		innerBlocks.filter( ( block ) => block.name === 'core/playlist-track' )
+	);
+};
+
+const PlaylistWaveformEdit = ( {
+	attributes,
+	clientId,
+	context,
+	isSelected,
+} ) => {
+	const waveformStyle =
+		attributes.className?.match( /is-style-([\w-]+)/ )?.[ 1 ] || 'bars';
+	const blockProps = useBlockProps();
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const { isParentSelected, parentPlaylistId, tracks } = useSelect(
+		( select ) => {
+			const { getBlock, getBlockParentsByBlockName, isBlockSelected } =
+				select( blockEditorStore );
+			const [ playlistId ] = getBlockParentsByBlockName(
+				clientId,
+				'core/playlist'
+			);
+			const playlist = playlistId ? getBlock( playlistId ) : undefined;
+
+			return {
+				isParentSelected: playlistId
+					? isBlockSelected( playlistId )
+					: false,
+				parentPlaylistId: playlistId,
+				tracks: playlist
+					? getPlaylistTracks( playlist.innerBlocks )
+							.filter( ( block ) => !! block.attributes.uniqueId )
+							.map( ( block ) => block.attributes )
+					: [],
+			};
+		},
+		[ clientId ]
+	);
+
+	const currentTrack = context?.currentTrack;
+	const currentTrackData = tracks.find(
+		( track ) => track.uniqueId === currentTrack
+	);
+
+	const onTrackEnded = useCallback( () => {
+		const currentIndex = tracks.findIndex(
+			( track ) => track.uniqueId === currentTrack
+		);
+		const nextTrack = tracks[ currentIndex + 1 ] || tracks[ 0 ];
+		if ( nextTrack?.uniqueId && parentPlaylistId ) {
+			updateBlockAttributes( parentPlaylistId, {
+				currentTrack: nextTrack.uniqueId,
+			} );
+		}
+	}, [ currentTrack, parentPlaylistId, tracks, updateBlockAttributes ] );
+
+	return (
+		<div { ...blockProps }>
+			<Disabled isDisabled={ ! ( isSelected || isParentSelected ) }>
+				<WaveformPlayer
+					src={ currentTrackData?.src }
+					title={ currentTrackData?.title }
+					artist={ currentTrackData?.artist }
+					image={ currentTrackData?.image }
+					waveformStyle={ waveformStyle }
+					onEnded={ onTrackEnded }
+				/>
+			</Disabled>
+		</div>
+	);
+};
+
+export default PlaylistWaveformEdit;

--- a/packages/block-library/src/playlist-waveform/index.js
+++ b/packages/block-library/src/playlist-waveform/index.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { audio as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	icon,
+	edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/playlist-waveform/index.php
+++ b/packages/block-library/src/playlist-waveform/index.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Server-side registration of the `core/playlist-waveform` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Registers the `core/playlist-waveform` block on server.
+ *
+ * @since 6.9.0
+ */
+function register_block_core_playlist_waveform() {
+	register_block_type_from_metadata(
+		__DIR__ . '/playlist-waveform',
+		array(
+			'render_callback' => '__return_empty_string',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_playlist_waveform' );

--- a/packages/block-library/src/playlist/block.json
+++ b/packages/block-library/src/playlist/block.json
@@ -8,7 +8,7 @@
 	"description": "Embed a simple playlist.",
 	"keywords": [ "music", "sound" ],
 	"textdomain": "default",
-	"allowedBlocks": [ "core/playlist-track" ],
+	"allowedBlocks": [ "core/playlist-waveform", "core/playlist-tracklist" ],
 	"attributes": {
 		"currentTrack": {
 			"type": "string"
@@ -46,7 +46,10 @@
 		}
 	},
 	"providesContext": {
+		"showTracklist": "showTracklist",
 		"showArtists": "showArtists",
+		"showNumbers": "showNumbers",
+		"showTrackLength": "showTrackLength",
 		"currentTrack": "currentTrack"
 	},
 	"supports": {
@@ -78,14 +81,6 @@
 			"padding": true
 		}
 	},
-	"styles": [
-		{ "name": "bars", "label": "Bars", "isDefault": true },
-		{ "name": "mirror", "label": "Mirror" },
-		{ "name": "line", "label": "Line" },
-		{ "name": "blocks", "label": "Blocks" },
-		{ "name": "dots", "label": "Dots" },
-		{ "name": "seekbar", "label": "Seekbar" }
-	],
 	"editorStyle": "wp-block-playlist-editor",
 	"style": "wp-block-playlist"
 }

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -98,6 +98,20 @@ const PlaylistEdit = ( {
 		[ clientId ]
 	);
 
+	// Reuse an existing waveform block when present so its style variation is
+	// preserved; otherwise create one, migrating any is-style-* class from the
+	// playlist (older markup stored the waveform style on the playlist itself).
+	const resolveWaveformBlock = useCallback(
+		( existingWaveform ) =>
+			existingWaveform ??
+			createBlock( 'core/playlist-waveform', {
+				className: attributes.className?.match(
+					/is-style-[\w-]+/
+				)?.[ 0 ],
+			} ),
+		[ attributes.className ]
+	);
+
 	// Keep the playlist structure normalized. Older playlist markup had track
 	// blocks directly inside the playlist; new markup stores them in a
 	// dedicated tracklist child so the waveform can be styled independently.
@@ -130,14 +144,14 @@ const PlaylistEdit = ( {
 		];
 
 		replaceInnerBlocks( clientId, [
-			waveformBlock ?? createBlock( 'core/playlist-waveform' ),
+			resolveWaveformBlock( waveformBlock ),
 			createBlock(
 				'core/playlist-tracklist',
 				tracklistBlock?.attributes ?? {},
 				normalizedTrackBlocks
 			),
 		] );
-	}, [ clientId, innerBlocks, replaceInnerBlocks ] );
+	}, [ clientId, innerBlocks, replaceInnerBlocks, resolveWaveformBlock ] );
 
 	// Ensure that each inner block has a unique ID,
 	// even if a track is duplicated.
@@ -220,8 +234,11 @@ const PlaylistEdit = ( {
 			const newBlocks = trackList.map( ( track ) =>
 				createBlock( 'core/playlist-track', track )
 			);
+			const existingWaveform = innerBlocks.find(
+				( block ) => block.name === 'core/playlist-waveform'
+			);
 			replaceInnerBlocks( clientId, [
-				createBlock( 'core/playlist-waveform' ),
+				resolveWaveformBlock( existingWaveform ),
 				createBlock( 'core/playlist-tracklist', {}, newBlocks ),
 			] );
 		},
@@ -230,6 +247,8 @@ const PlaylistEdit = ( {
 			setAttributes,
 			replaceInnerBlocks,
 			clientId,
+			innerBlocks,
+			resolveWaveformBlock,
 		]
 	);
 

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -17,11 +17,9 @@ import {
 	useInnerBlocksProps,
 	BlockControls,
 	InspectorControls,
-	InnerBlocks,
 } from '@wordpress/block-editor';
 import {
 	ToggleControl,
-	Disabled,
 	SelectControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
@@ -37,10 +35,23 @@ import { createBlock } from '@wordpress/blocks';
  */
 import { Caption } from '../utils/caption';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
-import { WaveformPlayer } from '../utils/waveform-player';
 import { getTrackAttributes } from './utils';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
+const PLAYLIST_TEMPLATE = [
+	[ 'core/playlist-waveform' ],
+	[ 'core/playlist-tracklist' ],
+];
+
+const getTrackBlocks = ( innerBlocks ) => {
+	const tracklist = innerBlocks.find(
+		( block ) => block.name === 'core/playlist-tracklist'
+	);
+	return (
+		tracklist?.innerBlocks ??
+		innerBlocks.filter( ( block ) => block.name === 'core/playlist-track' )
+	);
+};
 
 const PlaylistEdit = ( {
 	attributes,
@@ -59,9 +70,6 @@ const PlaylistEdit = ( {
 		currentTrack,
 	} = attributes;
 
-	// Extract the waveform style from the block style variation class.
-	const waveformStyle =
-		attributes.className?.match( /is-style-([\w-]+)/ )?.[ 1 ] || 'bars';
 	const blockProps = useBlockProps();
 	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
@@ -72,15 +80,64 @@ const PlaylistEdit = ( {
 	}
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
-	const { innerBlockTracks } = useSelect(
+	const { innerBlocks, innerBlockTracks, tracklistClientId } = useSelect(
 		( select ) => {
 			const { getBlock: _getBlock } = select( blockEditorStore );
+			const block = _getBlock( clientId );
+			const playlistInnerBlocks = block?.innerBlocks ?? [];
+			const tracklistBlock = playlistInnerBlocks.find(
+				( innerBlock ) =>
+					innerBlock.name === 'core/playlist-tracklist'
+			);
 			return {
-				innerBlockTracks: _getBlock( clientId )?.innerBlocks ?? [],
+				innerBlocks: playlistInnerBlocks,
+				innerBlockTracks: getTrackBlocks( playlistInnerBlocks ),
+				tracklistClientId: tracklistBlock?.clientId,
 			};
 		},
 		[ clientId ]
 	);
+
+	// Keep the playlist structure normalized. Older playlist markup had track
+	// blocks directly inside the playlist; new markup stores them in a
+	// dedicated tracklist child so the waveform can be styled independently.
+	useEffect( () => {
+		if ( innerBlocks.length === 0 ) {
+			return;
+		}
+
+		const waveformBlock = innerBlocks.find(
+			( block ) => block.name === 'core/playlist-waveform'
+		);
+		const tracklistBlock = innerBlocks.find(
+			( block ) => block.name === 'core/playlist-tracklist'
+		);
+		const directTrackBlocks = innerBlocks.filter(
+			( block ) => block.name === 'core/playlist-track'
+		);
+
+		if (
+			waveformBlock &&
+			tracklistBlock &&
+			directTrackBlocks.length === 0
+		) {
+			return;
+		}
+
+		const normalizedTrackBlocks = [
+			...( tracklistBlock?.innerBlocks ?? [] ),
+			...directTrackBlocks,
+		];
+
+		replaceInnerBlocks( clientId, [
+			waveformBlock ?? createBlock( 'core/playlist-waveform' ),
+			createBlock(
+				'core/playlist-tracklist',
+				tracklistBlock?.attributes ?? {},
+				normalizedTrackBlocks
+			),
+		] );
+	}, [ clientId, innerBlocks, replaceInnerBlocks ] );
 
 	// Ensure that each inner block has a unique ID,
 	// even if a track is duplicated.
@@ -102,9 +159,14 @@ const PlaylistEdit = ( {
 			return block;
 		} );
 		if ( hasDuplicates ) {
-			replaceInnerBlocks( clientId, updatedBlocks );
+			replaceInnerBlocks( tracklistClientId ?? clientId, updatedBlocks );
 		}
-	}, [ innerBlockTracks, clientId, replaceInnerBlocks ] );
+	}, [
+		innerBlockTracks,
+		clientId,
+		replaceInnerBlocks,
+		tracklistClientId,
+	] );
 
 	// Create a list of tracks from the inner blocks,
 	// but skip blocks that do not have a uniqueId attribute, such as the media placeholder.
@@ -158,8 +220,10 @@ const PlaylistEdit = ( {
 			const newBlocks = trackList.map( ( track ) =>
 				createBlock( 'core/playlist-track', track )
 			);
-			// Replace the inner blocks with the new tracks.
-			replaceInnerBlocks( clientId, newBlocks );
+			replaceInnerBlocks( clientId, [
+				createBlock( 'core/playlist-waveform' ),
+				createBlock( 'core/playlist-tracklist', {}, newBlocks ),
+			] );
 		},
 		[
 			__unstableMarkNextChangeAsNotPersistent,
@@ -168,22 +232,6 @@ const PlaylistEdit = ( {
 			clientId,
 		]
 	);
-
-	// Get current track data by finding the track with matching uniqueId.
-	const currentTrackData = tracks.find(
-		( track ) => track.uniqueId === currentTrack
-	);
-
-	// Handle track end - advance to next track or loop to first.
-	const onTrackEnded = useCallback( () => {
-		const currentIndex = tracks.findIndex(
-			( track ) => track.uniqueId === currentTrack
-		);
-		const nextTrack = tracks[ currentIndex + 1 ] || tracks[ 0 ];
-		if ( nextTrack?.uniqueId ) {
-			setAttributes( { currentTrack: nextTrack.uniqueId } );
-		}
-	}, [ currentTrack, tracks, setAttributes ] );
 
 	const onChangeOrder = useCallback(
 		( trackOrder ) => {
@@ -197,7 +245,7 @@ const PlaylistEdit = ( {
 				return titleB.localeCompare( titleA );
 			} );
 			const firstUniqueId = sortedBlocks[ 0 ]?.attributes?.uniqueId;
-			replaceInnerBlocks( clientId, sortedBlocks );
+			replaceInnerBlocks( tracklistClientId ?? clientId, sortedBlocks );
 			setAttributes( {
 				order: trackOrder,
 				currentTrack:
@@ -212,6 +260,7 @@ const PlaylistEdit = ( {
 			innerBlockTracks,
 			replaceInnerBlocks,
 			setAttributes,
+			tracklistClientId,
 		]
 	);
 
@@ -221,18 +270,17 @@ const PlaylistEdit = ( {
 		};
 	}
 
-	const hasSelectedChild = useSelect(
-		( select ) =>
-			select( blockEditorStore ).hasSelectedInnerBlock( clientId ),
-		[ clientId ]
+	const innerBlocksProps = useInnerBlocksProps(
+		{},
+		{
+			allowedBlocks: [
+				'core/playlist-waveform',
+				'core/playlist-tracklist',
+			],
+			template: PLAYLIST_TEMPLATE,
+			templateLock: 'all',
+		}
 	);
-
-	const hasAnySelected = isSelected || hasSelectedChild;
-
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		__experimentalAppenderTagName: 'li',
-		renderAppender: hasAnySelected && InnerBlocks.ButtonBlockAppender,
-	} );
 
 	if ( tracks.length === 0 ) {
 		return (
@@ -392,28 +440,7 @@ const PlaylistEdit = ( {
 				</ToolsPanel>
 			</InspectorControls>
 			<figure { ...blockProps }>
-				<Disabled isDisabled={ ! isSelected }>
-					<WaveformPlayer
-						src={ currentTrackData?.src }
-						title={ currentTrackData?.title }
-						artist={ currentTrackData?.artist }
-						image={ currentTrackData?.image }
-						waveformStyle={ waveformStyle }
-						onEnded={ onTrackEnded }
-					/>
-				</Disabled>
-				{ showTracklist && (
-					<ol
-						className={ clsx( 'wp-block-playlist__tracklist', {
-							'wp-block-playlist__tracklist-show-numbers':
-								showNumbers,
-							'wp-block-playlist__tracklist-length-is-hidden':
-								! showTrackLength,
-						} ) }
-					>
-						{ innerBlocksProps.children }
-					</ol>
-				) }
+				<div { ...innerBlocksProps } />
 				<Caption
 					attributes={ attributes }
 					setAttributes={ setAttributes }

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -6,6 +6,95 @@
  */
 
 /**
+ * Returns the playlist track blocks for a playlist block.
+ *
+ * @param WP_Block[] $inner_blocks Playlist inner blocks.
+ * @return WP_Block[] Playlist track blocks.
+ */
+function block_core_playlist_get_track_blocks( $inner_blocks ) {
+	$track_blocks = array();
+
+	foreach ( $inner_blocks as $inner_block ) {
+		if ( 'core/playlist-track' === $inner_block->name ) {
+			$track_blocks[] = $inner_block;
+			continue;
+		}
+
+		if ( 'core/playlist-tracklist' === $inner_block->name ) {
+			foreach ( $inner_block->inner_blocks as $track_block ) {
+				if ( 'core/playlist-track' === $track_block->name ) {
+					$track_blocks[] = $track_block;
+				}
+			}
+		}
+	}
+
+	return $track_blocks;
+}
+
+/**
+ * Returns playlist waveform block attributes.
+ *
+ * @param WP_Block[] $inner_blocks Playlist inner blocks.
+ * @return array|null Waveform block attributes.
+ */
+function block_core_playlist_get_waveform_attributes( $inner_blocks ) {
+	foreach ( $inner_blocks as $inner_block ) {
+		if ( 'core/playlist-waveform' === $inner_block->name ) {
+			return $inner_block->attributes;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Returns the style slug from a block style class name.
+ *
+ * @param string $class_name Block class name.
+ * @return string|null Style slug.
+ */
+function block_core_playlist_get_style_from_class_name( $class_name ) {
+	if ( preg_match( '/is-style-([\w-]+)/', $class_name, $matches ) ) {
+		return $matches[1];
+	}
+
+	return null;
+}
+
+/**
+ * Adds playlist tracklist classes based on playlist attributes.
+ *
+ * @param string $content    Playlist content.
+ * @param array  $attributes Playlist attributes.
+ * @return string Playlist content.
+ */
+function block_core_playlist_update_tracklist_classes( $content, $attributes ) {
+	$processor = new WP_HTML_Tag_Processor( $content );
+	if ( ! $processor->next_tag( 'ol' ) ) {
+		return $content;
+	}
+
+	if ( isset( $attributes['showTracklist'] ) && ! $attributes['showTracklist'] ) {
+		$processor->add_class( 'wp-block-playlist__tracklist-is-hidden' );
+	}
+
+	if ( isset( $attributes['showArtists'] ) && ! $attributes['showArtists'] ) {
+		$processor->add_class( 'wp-block-playlist__tracklist-artist-is-hidden' );
+	}
+
+	if ( isset( $attributes['showTrackLength'] ) && ! $attributes['showTrackLength'] ) {
+		$processor->add_class( 'wp-block-playlist__tracklist-length-is-hidden' );
+	}
+
+	if ( ! isset( $attributes['showNumbers'] ) || $attributes['showNumbers'] ) {
+		$processor->add_class( 'wp-block-playlist__tracklist-show-numbers' );
+	}
+
+	return $processor->get_updated_html();
+}
+
+/**
  * Renders the `core/playlist` block on server.
  *
  * @since 6.9.0
@@ -27,52 +116,61 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 	$tracks_data       = array();
 	$current_unique_id = null;
 
-	// Parse inner blocks to extract track data.
+	$track_blocks         = block_core_playlist_get_track_blocks( $block->inner_blocks );
+	$waveform_attributes  = block_core_playlist_get_waveform_attributes( $block->inner_blocks );
+	$waveform_class_names = 'wp-block-playlist-waveform';
+	if ( ! empty( $waveform_attributes['className'] ) ) {
+		$waveform_class_names .= ' ' . $waveform_attributes['className'];
+	}
+
+	// Parse track blocks to extract track data.
 	// This approach avoids duplicating track data in the HTML output.
-	if ( ! empty( $block->inner_blocks ) ) {
-		foreach ( $block->inner_blocks as $inner_block ) {
-			if ( 'core/playlist-track' === $inner_block->name ) {
-				$inner_block->context['playlistId'] = $playlist_id;
+	if ( ! empty( $track_blocks ) ) {
+		foreach ( $track_blocks as $inner_block ) {
+			$inner_block->context['playlistId'] = $playlist_id;
 
-				$track_attributes  = $inner_block->attributes;
-				$unique_id         = $track_attributes['uniqueId'] ?? wp_unique_id( 'playlist-track-' );
-				$playlist_tracks[] = $unique_id;
+			$track_attributes  = $inner_block->attributes;
+			$unique_id         = $track_attributes['uniqueId'] ?? wp_unique_id( 'playlist-track-' );
+			$playlist_tracks[] = $unique_id;
 
-				$inner_block->attributes['uniqueId'] = $unique_id;
+			$inner_block->attributes['uniqueId'] = $unique_id;
 
-				// Extract track metadata from block attributes.
-				$title      = isset( $track_attributes['title'] ) && ! empty( $track_attributes['title'] ) ? $track_attributes['title'] : __( 'Unknown title' );
-				$artist     = $track_attributes['artist'] ?? '';
-				$album      = $track_attributes['album'] ?? '';
-				$image      = $track_attributes['image'] ?? '';
-				$url        = $track_attributes['src'] ?? '';
-				$aria_label = $title;
+			// Extract track metadata from block attributes.
+			$title = __( 'Unknown title' );
+			if ( isset( $track_attributes['title'] ) && ! empty( $track_attributes['title'] ) ) {
+				$title = $track_attributes['title'];
+			}
 
-				if ( $title && $artist && $album ) {
-					$aria_label = sprintf(
-						/* translators: %1$s: track title, %2$s artist name, %3$s: album name. */
-						_x( '%1$s by %2$s from the album %3$s', 'track title, artist name, album name' ),
-						$title,
-						$artist,
-						$album
-					);
-				}
+			$artist     = $track_attributes['artist'] ?? '';
+			$album      = $track_attributes['album'] ?? '';
+			$image      = $track_attributes['image'] ?? '';
+			$url        = $track_attributes['src'] ?? '';
+			$aria_label = $title;
 
-				// Data is passed to wp_interactivity_state() which JSON-encodes it,
-				// so we use wp_strip_all_tags() instead of esc_html() to prevent
-				// HTML injection without double-encoding. URLs still use esc_url().
-				$tracks_data[ $unique_id ] = array(
-					'url'       => esc_url( $url ),
-					'title'     => wp_strip_all_tags( $title ),
-					'artist'    => wp_strip_all_tags( $artist ),
-					'album'     => wp_strip_all_tags( $album ),
-					'image'     => esc_url( $image ),
-					'ariaLabel' => wp_strip_all_tags( $aria_label ),
+			if ( $title && $artist && $album ) {
+				$aria_label = sprintf(
+					/* translators: %1$s: track title, %2$s artist name, %3$s: album name. */
+					_x( '%1$s by %2$s from the album %3$s', 'track title, artist name, album name' ),
+					$title,
+					$artist,
+					$album
 				);
+			}
 
-				if ( $unique_id === $current_media_id ) {
-					$current_unique_id = $unique_id;
-				}
+			// Data is passed to wp_interactivity_state() which JSON-encodes it,
+			// so we use wp_strip_all_tags() instead of esc_html() to prevent
+			// HTML injection without double-encoding. URLs still use esc_url().
+			$tracks_data[ $unique_id ] = array(
+				'url'       => esc_url( $url ),
+				'title'     => wp_strip_all_tags( $title ),
+				'artist'    => wp_strip_all_tags( $artist ),
+				'album'     => wp_strip_all_tags( $album ),
+				'image'     => esc_url( $image ),
+				'ariaLabel' => wp_strip_all_tags( $aria_label ),
+			);
+
+			if ( $unique_id === $current_media_id ) {
+				$current_unique_id = $unique_id;
 			}
 		}
 	}
@@ -102,11 +200,11 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 	// Add waveform player container with translated button labels.
 	$label_play  = esc_attr__( 'Play' );
 	$label_pause = esc_attr__( 'Pause' );
-	$html        = '<div class="wp-block-playlist__waveform-player"
-		data-wp-watch="callbacks.initWaveformPlayer"
-		data-label-play="' . $label_play . '"
-		data-label-pause="' . $label_pause . '"
-	></div>';
+	$html        = '<div class="' . esc_attr( $waveform_class_names ) . '"><div class="wp-block-playlist__waveform-player"
+			data-wp-watch="callbacks.initWaveformPlayer"
+			data-label-play="' . $label_play . '"
+			data-label-pause="' . $label_pause . '"
+		></div></div>';
 
 	// Add the HTML for the current track inside the figure.
 	$figure = null;
@@ -115,13 +213,23 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 		$content = preg_replace( '/(<figure[^>]*>)/', '$1' . $html, $content, 1 );
 	}
 
+	$content = block_core_playlist_update_tracklist_classes( $content, $attributes );
+
 	$processor = new WP_HTML_Tag_Processor( $content );
 	$processor->next_tag( 'figure' );
 	$processor->set_attribute( 'data-wp-interactive', 'core/playlist' );
-	// Extract the waveform style from the block style variation class.
+	// Extract the waveform style from the waveform block style variation class.
 	$waveform_style = 'bars';
-	if ( ! empty( $attributes['className'] ) && preg_match( '/is-style-([\w-]+)/', $attributes['className'], $matches ) ) {
-		$waveform_style = $matches[1];
+	if ( ! empty( $waveform_attributes['className'] ) ) {
+		$waveform_style = block_core_playlist_get_style_from_class_name(
+			$waveform_attributes['className']
+		) ?? $waveform_style;
+	} elseif ( null === $waveform_attributes && ! empty( $attributes['className'] ) ) {
+		// Backward compatibility for playlists saved before the waveform was
+		// represented by its own inner block.
+		$waveform_style = block_core_playlist_get_style_from_class_name(
+			$attributes['className']
+		) ?? $waveform_style;
 	}
 
 	$processor->set_attribute(

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -206,11 +206,13 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 			data-label-pause="' . $label_pause . '"
 		></div></div>';
 
-	// Add the HTML for the current track inside the figure.
+	// Add the HTML for the current track inside the figure. The opening tag is
+	// matched and used as a literal search string so that user-provided class
+	// names containing characters such as `$` are not treated as backreferences.
 	$figure = null;
 	preg_match( '/<figure[^>]*>/', $content, $figure );
 	if ( ! empty( $figure[0] ) ) {
-		$content = preg_replace( '/(<figure[^>]*>)/', '$1' . $html, $content, 1 );
+		$content = str_replace( $figure[0], $figure[0] . $html, $content );
 	}
 
 	$content = block_core_playlist_update_tracklist_classes( $content, $attributes );

--- a/packages/block-library/src/playlist/save.js
+++ b/packages/block-library/src/playlist/save.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -14,30 +9,13 @@ import {
 } from '@wordpress/block-editor';
 
 export default function saveWithInnerBlocks( { attributes } ) {
-	const {
-		caption,
-		showNumbers,
-		showTracklist,
-		showArtists,
-		showTrackLength,
-	} = attributes;
+	const { caption } = attributes;
 
 	const blockProps = useBlockProps.save();
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 	return (
 		<figure { ...innerBlocksProps }>
-			<ol
-				className={ clsx( 'wp-block-playlist__tracklist', {
-					'wp-block-playlist__tracklist-is-hidden': ! showTracklist,
-					'wp-block-playlist__tracklist-artist-is-hidden':
-						! showArtists,
-					'wp-block-playlist__tracklist-length-is-hidden':
-						! showTrackLength,
-					'wp-block-playlist__tracklist-show-numbers': showNumbers,
-				} ) }
-			>
-				{ innerBlocksProps.children }
-			</ol>
+			{ innerBlocksProps.children }
 			{ ! RichText.isEmpty( caption ) && (
 				<RichText.Content
 					tagName="figcaption"

--- a/phpunit/blocks/render-block-playlist-test.php
+++ b/phpunit/blocks/render-block-playlist-test.php
@@ -33,14 +33,30 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	 *
 	 * @param array  $playlist_attrs Attributes for the playlist block.
 	 * @param array  $tracks         Array of track attribute arrays.
+	 * @param array  $waveform_attrs Optional attributes for the waveform block.
 	 * @return string Block markup.
 	 */
-	private function build_playlist_markup( $playlist_attrs, $tracks = array() ) {
+	private function build_playlist_markup( $playlist_attrs, $tracks = array(), $waveform_attrs = null ) {
 		$attrs_json   = wp_json_encode( (object) $playlist_attrs );
 		$track_markup = '';
 		foreach ( $tracks as $track ) {
 			$track_json    = wp_json_encode( $track );
 			$track_markup .= '<!-- wp:playlist-track ' . $track_json . ' /-->';
+		}
+
+		if ( is_array( $waveform_attrs ) ) {
+			$waveform_json = wp_json_encode( (object) $waveform_attrs );
+
+			return '<!-- wp:playlist ' . $attrs_json . ' -->'
+				. '<figure class="wp-block-playlist">'
+				. '<!-- wp:playlist-waveform ' . $waveform_json . ' /-->'
+				. '<!-- wp:playlist-tracklist -->'
+				. '<ol class="wp-block-playlist__tracklist">'
+				. $track_markup
+				. '</ol>'
+				. '<!-- /wp:playlist-tracklist -->'
+				. '</figure>'
+				. '<!-- /wp:playlist -->';
 		}
 
 		return '<!-- wp:playlist ' . $attrs_json . ' -->'
@@ -160,11 +176,11 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	/**
 	 * @covers ::render_block_core_playlist
 	 */
-	public function test_waveform_style_extracted_from_single_word_style_class() {
+	public function test_waveform_style_extracted_from_waveform_inner_block() {
 		$markup = $this->build_playlist_markup(
 			array(
 				'currentTrack' => 'track-1',
-				'className'    => 'is-style-mirror',
+				'className'    => 'is-style-playlist-compact',
 			),
 			array(
 				array(
@@ -173,7 +189,8 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 					'title'    => 'Song One',
 					'src'      => 'http://example.com/song1.mp3',
 				),
-			)
+			),
+			array( 'className' => 'is-style-mirror' )
 		);
 
 		$output = do_blocks( $markup );
@@ -195,7 +212,34 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 		$markup = $this->build_playlist_markup(
 			array(
 				'currentTrack' => 'track-1',
-				'className'    => 'is-style-thin-line',
+			),
+			array(
+				array(
+					'id'       => 1,
+					'uniqueId' => 'track-1',
+					'title'    => 'Song One',
+					'src'      => 'http://example.com/song1.mp3',
+				),
+			),
+			array( 'className' => 'is-style-thin-line' )
+		);
+
+		$output = do_blocks( $markup );
+		$p      = new WP_HTML_Tag_Processor( $output );
+		$p->next_tag( 'figure' );
+
+		$context = json_decode( $p->get_attribute( 'data-wp-context' ), true );
+		$this->assertSame( 'thin-line', $context['waveformStyle'] );
+	}
+
+	/**
+	 * @covers ::render_block_core_playlist
+	 */
+	public function test_waveform_style_falls_back_to_parent_style_for_legacy_markup() {
+		$markup = $this->build_playlist_markup(
+			array(
+				'currentTrack' => 'track-1',
+				'className'    => 'is-style-mirror',
 			),
 			array(
 				array(
@@ -212,7 +256,7 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 		$p->next_tag( 'figure' );
 
 		$context = json_decode( $p->get_attribute( 'data-wp-context' ), true );
-		$this->assertSame( 'thin-line', $context['waveformStyle'] );
+		$this->assertSame( 'mirror', $context['waveformStyle'] );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
No linked issue.

Makes the playlist waveform a dedicated inner block so waveform block styles no longer occupy the playlist block's own style variations.

## Why?
This allows the playlist block itself to support other block styles while the waveform visualization keeps its Bars, Mirror, Line, Blocks, Dots, and Seekbar styles.

## How?
Adds `core/playlist-waveform` and `core/playlist-tracklist`, normalizes older direct track children in the editor, and keeps server rendering compatible with legacy playlist markup while reading waveform styles from the waveform child when present.

## Testing Instructions
1. Open a post or page with block experiments enabled.
2. Insert a Playlist block and choose multiple audio tracks.
3. Select the waveform inner block and verify the waveform style variations change the player visualization.
4. Select the Playlist block and verify playlist-level block styles can be applied independently.
5. Save and reload the post, then verify the selected track list and waveform still render.

### Testing Instructions for Keyboard
1. Use the keyboard to insert and select a Playlist block.
2. Use List View to move focus between the Playlist, Playlist waveform, Playlist tracklist, and Playlist track blocks.
3. Verify the block style controls are reachable for both the Playlist block and Playlist waveform block.

## Screenshots or screencast
Not included.

## Use of AI Tools
Drafted with OpenAI Codex and reviewed by the contributor.

## Validation
`git diff --check`, PHP syntax checks for touched PHP files, and `node --check` for touched JS files passed; PHPUnit, PHPCS, full JS lint, and wp-env testing could not run in this workspace because dependencies/Docker were unavailable.
