### PR TITLE
Block Editor: Reduce pattern preview asset fan-out

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -75,6 +75,8 @@ function ScaledBlockPreview( {
 			} }
 		>
 			<Iframe
+				inlineStyles
+				skipScripts
 				contentRef={ useRefEffect( ( bodyElement ) => {
 					const {
 						ownerDocument: { documentElement },

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -89,15 +89,25 @@ function useBubbleEvents( iframeDocument ) {
 	} );
 }
 
-const iframeSrcCache = new WeakMap();
+const iframeSrcCaches = new Map();
 const iframeSrcCleanup = globalThis.FinalizationRegistry
 	? new globalThis.FinalizationRegistry( ( url ) =>
 			URL.revokeObjectURL( url )
 	  )
 	: undefined;
+const inlineStylesheetCache = new Map();
 
-function getIframeSrc( resolvedAssets ) {
-	let src = iframeSrcCache.get( resolvedAssets );
+function getIframeSrc( resolvedAssets, inlineStyles, skipScripts ) {
+	const cacheKey = `${ inlineStyles ? 'inline-styles' : 'linked-styles' }:${
+		skipScripts ? 'no-scripts' : 'scripts'
+	}`;
+	let cache = iframeSrcCaches.get( cacheKey );
+	if ( ! cache ) {
+		cache = new WeakMap();
+		iframeSrcCaches.set( cacheKey, cache );
+	}
+
+	let src = cache.get( resolvedAssets );
 	if ( src ) {
 		return src;
 	}
@@ -122,8 +132,8 @@ function getIframeSrc( resolvedAssets ) {
 				background-color: white;
 			}
 		</style>
-		${ resolvedAssets.styles ?? '' }
-		${ resolvedAssets.scripts ?? '' }
+		${ inlineStyles ? '' : resolvedAssets.styles ?? '' }
+		${ skipScripts ? '' : resolvedAssets.scripts ?? '' }
 	</head>
 	<body>
 		<script>document.currentScript.parentElement.remove()</script>
@@ -131,9 +141,66 @@ function getIframeSrc( resolvedAssets ) {
 </html>`;
 
 	src = URL.createObjectURL( new Blob( [ html ], { type: 'text/html' } ) );
-	iframeSrcCache.set( resolvedAssets, src );
+	cache.set( resolvedAssets, src );
 	iframeSrcCleanup?.register( resolvedAssets, src );
 	return src;
+}
+
+function getInlineStylesheet( href ) {
+	let stylesheet = inlineStylesheetCache.get( href );
+	if ( stylesheet ) {
+		return stylesheet;
+	}
+
+	stylesheet = fetch( href ).then( ( response ) => {
+		if ( ! response.ok ) {
+			throw new Error( `Unable to fetch stylesheet: ${ href }` );
+		}
+		return response.text();
+	} );
+	inlineStylesheetCache.set( href, stylesheet );
+	return stylesheet;
+}
+
+function appendInlineStyles( iframeDocument, styles ) {
+	if ( ! styles ) {
+		return;
+	}
+
+	const container = iframeDocument.createElement( 'div' );
+	container.innerHTML = styles;
+
+	for ( const node of container.children ) {
+		if ( node.tagName === 'STYLE' ) {
+			iframeDocument.head.appendChild( node.cloneNode( true ) );
+			continue;
+		}
+
+		const href = node.getAttribute( 'href' );
+		if ( node.tagName !== 'LINK' || ! href ) {
+			iframeDocument.head.appendChild( node.cloneNode( true ) );
+			continue;
+		}
+
+		getInlineStylesheet( href )
+			.then( ( css ) => {
+				const style = iframeDocument.createElement( 'style' );
+				style.textContent = css;
+				style.setAttribute( 'data-wp-inline-stylesheet', href );
+				for ( const attribute of node.attributes ) {
+					if (
+						attribute.name !== 'href' &&
+						attribute.name !== 'rel'
+					) {
+						style.setAttribute( attribute.name, attribute.value );
+					}
+				}
+				iframeDocument.head.appendChild( style );
+			} )
+			.catch( () => {
+				iframeDocument.head.appendChild( node.cloneNode( true ) );
+			} );
+	}
 }
 
 function Iframe( {
@@ -143,6 +210,8 @@ function Iframe( {
 	scale = 1,
 	frameSize = 0,
 	readonly,
+	inlineStyles = false,
+	skipScripts = false,
 	forwardedRef: ref,
 	title = __( 'Editor canvas' ),
 	...props
@@ -208,6 +277,9 @@ function Iframe( {
 			const { documentElement } = contentDocument;
 			iFrameDocument = contentDocument;
 			setIframeDocument( contentDocument );
+			if ( inlineStyles ) {
+				appendInlineStyles( contentDocument, resolvedAssets.styles );
+			}
 
 			documentElement.classList.add( 'block-editor-iframe__html' );
 
@@ -215,6 +287,14 @@ function Iframe( {
 
 			for ( const compatStyle of getCompatibilityStyles() ) {
 				if ( contentDocument.getElementById( compatStyle.id ) ) {
+					continue;
+				}
+
+				if ( inlineStyles && compatStyle.tagName === 'LINK' ) {
+					appendInlineStyles(
+						contentDocument,
+						compatStyle.outerHTML
+					);
 					continue;
 				}
 
@@ -296,7 +376,7 @@ function Iframe( {
 		[ unguardedBodyRef ]
 	);
 
-	const src = getIframeSrc( resolvedAssets );
+	const src = getIframeSrc( resolvedAssets, inlineStyles, skipScripts );
 
 	// Make sure to not render the before and after focusable div elements in view
 	// mode. They're only needed to capture focus in edit mode.


### PR DESCRIPTION
## What?
Reduces duplicate asset loading in block pattern previews by letting preview iframes inline shared editor styles and skip resolved editor scripts.

Fixes #68979.
Related to #71547.

## Why?
Pattern previews render many isolated iframes. Each preview iframe currently loads the same resolved block/editor stylesheets again, and compatibility styles clone parent stylesheet links into every preview iframe. For blocks/plugins with several editor assets, that multiplies browser requests and host-side asset/program execution work across visible previews.

## How?
- Adds preview-only `inlineStyles` and `skipScripts` options to `Iframe`.
- Uses the preview path in `AutoBlockPreview` to skip resolved scripts and inline resolved/compatibility stylesheet links.
- Caches fetched stylesheet text by URL so preview iframes reuse the same stylesheet response instead of issuing duplicate `<link>` requests.
- Leaves normal editor iframe behavior unchanged unless these preview-only options are passed.

## Evidence
A reproducible Homeboy rig was added in https://github.com/chubes4/homeboy-rigs/pull/198.

Baseline/candidate runs were executed on `homeboy-lab` with a synthetic fixture plugin that registers blocks with unique editor assets and patterns using those blocks.

### Static fixture request fan-out
| Scenario | Baseline fixture responses | Candidate fixture responses | Page errors |
|---|---:|---:|---:|
| `6 blocks x 12 patterns` | 90 | 30 | 0 |
| `12 blocks x 12 patterns` | 180 | 60 | 0 |
| `24 blocks x 12 patterns` | 360 | 98 | 0 |
| `40 blocks x 12 patterns` | 600 | 141 | 0 |

### Serialized asset-delay speed proof
The rig can serve fixture assets through PHP with a `50ms` serialized delay, modeling constrained PHP worker/program-execution capacity from repeated asset requests.

| Scenario | Baseline ready avg | Candidate ready avg | Speedup | Fixture responses | Page errors |
|---|---:|---:|---:|---:|---:|
| `6 blocks x 12 patterns` | 5119.7ms | 2225.0ms | 2.3x faster | 90 -> 30 | 0 |
| `12 blocks x 12 patterns` | 9100.7ms | 2516.7ms | 3.6x faster | 180 -> 60 | 0 |

## Testing Instructions
1. Open the block inserter in the post editor.
2. Browse pattern categories with multiple pattern previews.
3. Confirm pattern previews render normally.
4. Use the linked Homeboy rig for request/timing reproduction if needed.

## Testing
- `npm run lint:js -- packages/block-editor/src/components/iframe/index.js packages/block-editor/src/components/block-preview/auto.js`
- `npm run build -- --skip-types`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, built the Homeboy/WP Codebox reproduction rig, ran lab verification, and summarized the evidence for Chris to review.