### PR TITLE
Added Missing Global Documentation

### DIFF
--- a/lib/experimental/dashboard-widgets/dashboard-layout.php
+++ b/lib/experimental/dashboard-widgets/dashboard-layout.php
@@ -41,6 +41,8 @@ const GUTENBERG_DASHBOARD_NAME = 'gutenberg_dashboard';
  * The JS side stays oblivious: a default and a user-saved layout
  * look identical at the preferences-store boundary.
  *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
  * @param mixed  $value    The pre-fetched value, or null to let the
  *                         meta API resolve normally.
  * @param int    $user_id  User ID.

--- a/lib/experimental/media-editor/load.php
+++ b/lib/experimental/media-editor/load.php
@@ -31,6 +31,8 @@ function gutenberg_register_media_editor_admin_page() {
 
 /**
  * Sets the admin page title before wp-admin/admin-header.php renders.
+ *
+ * @global string $title The admin page title.
  */
 function gutenberg_media_editor_wp_admin_set_title() {
 	global $title;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? Why?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
-  Global documentation is missing in `dashboard-layout.php` and `media-editor/load.php`

<!-- In a few words, what is the PR actually doing? -->
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added missing global documentation in  `dashboard-layout.php` and `media-editor/load.php` files

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open `dashboard-layout.php` and  `media-editor/load.php` files
2. See Global documentation

## Use of AI Tools
- None

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
