### PR TITLE
Inserter: Fix error being thrown for spoken message when inserting default/direct block

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -10,8 +10,16 @@ import { speak } from '@wordpress/a11y';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { Dropdown, Button } from '@wordpress/components';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
+<<<<<<< HEAD
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
 import { forwardRef } from '@wordpress/element';
+=======
+import {
+	createBlock,
+	store as blocksStore,
+	__experimentalGetBlockLabel as getBlockLabel,
+} from '@wordpress/blocks';
+>>>>>>> 260a3f99dd0 (Fix `null` `allowedBlockType` causing error to be thrown when accessing `title` property)
 import { plus } from '@wordpress/icons';
 
 /**
@@ -110,6 +118,7 @@ const UnforwardedInserter = (
 		hasSingleBlockType,
 		blockTitle,
 		allowedBlockType,
+		blockTypeToInsert,
 		blockToInsert,
 		appenderLabel,
 		targetRootClientId,
@@ -156,12 +165,16 @@ const UnforwardedInserter = (
 			const defaultBlockType = directInsertBlock
 				? getBlockType( directInsertBlock.name )
 				: null;
+			const _blockTypeToInsert = _blockToInsert
+				? getBlockType( _blockToInsert.name )
+				: _allowedBlockType;
 
 			return {
 				hasItems: hasInserterItems( _targetRootClientId ),
 				hasSingleBlockType: _hasSingleBlockType,
 				blockTitle: _allowedBlockType ? _allowedBlockType.title : '',
 				allowedBlockType: _allowedBlockType,
+				blockTypeToInsert: _blockTypeToInsert,
 				blockToInsert: _blockToInsert,
 				appenderLabel: getAppenderLabel(
 					directInsertBlock,
@@ -272,12 +285,17 @@ const UnforwardedInserter = (
 
 		onSelectOrClose?.( newBlock );
 
-		const message = sprintf(
-			// translators: %s: the name of the block that has been added
-			__( '%s block added' ),
-			allowedBlockType.title
-		);
-		speak( message );
+		const blockLabel = blockTypeToInsert
+			? getBlockLabel( blockTypeToInsert, newBlock.attributes )
+			: allowedBlockType?.title;
+		if ( blockLabel ) {
+			const message = sprintf(
+				// translators: %s: the name of the block that has been added
+				__( '%s block added' ),
+				blockLabel
+			);
+			speak( message );
+		}
 	}
 
 	function renderToggle( { onToggle: dropdownOnToggle, isOpen } ) {

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -273,7 +273,7 @@ const UnforwardedInserter = (
 
 		onSelectOrClose?.( newBlock );
 
-		const blockTypeToInsert = getBlockType( blockName ) || allowedBlockType;
+		const blockTypeToInsert = getBlockType( blockName );
 		let blockLabelToInsert;
 		if ( blockTypeToInsert ) {
 			blockLabelToInsert = getBlockLabel(

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -175,15 +175,18 @@ const UnforwardedInserter = (
 			let _blockLabelToInsert;
 			if ( _blockTypeToInsert ) {
 				const attributes = _blockToInsert?.attributes ?? {};
-				const label = getBlockLabel( _blockTypeToInsert, attributes );
-				const variation =
-					label === _blockTypeToInsert.title
-						? getActiveBlockVariation(
-								_blockTypeToInsert.name,
-								attributes
-						  )
-						: null;
-				_blockLabelToInsert = variation?.title || label;
+				_blockLabelToInsert = getBlockLabel(
+					_blockTypeToInsert,
+					attributes
+				);
+
+				if ( _blockLabelToInsert === _blockTypeToInsert.title ) {
+					_blockLabelToInsert =
+						getActiveBlockVariation(
+							_blockTypeToInsert.name,
+							attributes
+						)?.title || _blockLabelToInsert;
+				}
 			}
 
 			return {

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -118,7 +118,7 @@ const UnforwardedInserter = (
 		hasSingleBlockType,
 		blockTitle,
 		allowedBlockType,
-		blockTypeToInsert,
+		blockLabelToInsert,
 		blockToInsert,
 		appenderLabel,
 		targetRootClientId,
@@ -131,7 +131,11 @@ const UnforwardedInserter = (
 				getDirectInsertBlock,
 				getBlockListSettings,
 			} = select( blockEditorStore );
-			const { getBlockVariations, getBlockType } = select( blocksStore );
+			const {
+				getActiveBlockVariation,
+				getBlockVariations,
+				getBlockType,
+			} = select( blocksStore );
 
 			const _targetRootClientId =
 				rootClientId || getBlockRootClientId( clientId ) || undefined;
@@ -168,13 +172,26 @@ const UnforwardedInserter = (
 			const _blockTypeToInsert = _blockToInsert
 				? getBlockType( _blockToInsert.name )
 				: _allowedBlockType;
+			let _blockLabelToInsert;
+			if ( _blockTypeToInsert ) {
+				const attributes = _blockToInsert?.attributes ?? {};
+				const label = getBlockLabel( _blockTypeToInsert, attributes );
+				const variation =
+					label === _blockTypeToInsert.title
+						? getActiveBlockVariation(
+								_blockTypeToInsert.name,
+								attributes
+						  )
+						: null;
+				_blockLabelToInsert = variation?.title || label;
+			}
 
 			return {
 				hasItems: hasInserterItems( _targetRootClientId ),
 				hasSingleBlockType: _hasSingleBlockType,
 				blockTitle: _allowedBlockType ? _allowedBlockType.title : '',
 				allowedBlockType: _allowedBlockType,
-				blockTypeToInsert: _blockTypeToInsert,
+				blockLabelToInsert: _blockLabelToInsert,
 				blockToInsert: _blockToInsert,
 				appenderLabel: getAppenderLabel(
 					directInsertBlock,
@@ -285,14 +302,11 @@ const UnforwardedInserter = (
 
 		onSelectOrClose?.( newBlock );
 
-		const blockLabel = blockTypeToInsert
-			? getBlockLabel( blockTypeToInsert, newBlock.attributes )
-			: allowedBlockType?.title;
-		if ( blockLabel ) {
+		if ( blockLabelToInsert ) {
 			const message = sprintf(
 				// translators: %s: the name of the block that has been added
 				__( '%s block added' ),
-				blockLabel
+				blockLabelToInsert
 			);
 			speak( message );
 		}

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -9,17 +9,13 @@ import clsx from 'clsx';
 import { speak } from '@wordpress/a11y';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { Dropdown, Button } from '@wordpress/components';
-import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
-<<<<<<< HEAD
-import { createBlock, store as blocksStore } from '@wordpress/blocks';
-import { forwardRef } from '@wordpress/element';
-=======
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	createBlock,
 	store as blocksStore,
 	__experimentalGetBlockLabel as getBlockLabel,
 } from '@wordpress/blocks';
->>>>>>> 260a3f99dd0 (Fix `null` `allowedBlockType` causing error to be thrown when accessing `title` property)
+import { forwardRef } from '@wordpress/element';
 import { plus } from '@wordpress/icons';
 
 /**
@@ -118,7 +114,6 @@ const UnforwardedInserter = (
 		hasSingleBlockType,
 		blockTitle,
 		allowedBlockType,
-		blockLabelToInsert,
 		blockToInsert,
 		appenderLabel,
 		targetRootClientId,
@@ -131,11 +126,7 @@ const UnforwardedInserter = (
 				getDirectInsertBlock,
 				getBlockListSettings,
 			} = select( blockEditorStore );
-			const {
-				getActiveBlockVariation,
-				getBlockVariations,
-				getBlockType,
-			} = select( blocksStore );
+			const { getBlockVariations, getBlockType } = select( blocksStore );
 
 			const _targetRootClientId =
 				rootClientId || getBlockRootClientId( clientId ) || undefined;
@@ -169,32 +160,11 @@ const UnforwardedInserter = (
 			const defaultBlockType = directInsertBlock
 				? getBlockType( directInsertBlock.name )
 				: null;
-			const _blockTypeToInsert = _blockToInsert
-				? getBlockType( _blockToInsert.name )
-				: _allowedBlockType;
-			let _blockLabelToInsert;
-			if ( _blockTypeToInsert ) {
-				const attributes = _blockToInsert?.attributes ?? {};
-				_blockLabelToInsert = getBlockLabel(
-					_blockTypeToInsert,
-					attributes
-				);
-
-				if ( _blockLabelToInsert === _blockTypeToInsert.title ) {
-					_blockLabelToInsert =
-						getActiveBlockVariation(
-							_blockTypeToInsert.name,
-							attributes
-						)?.title || _blockLabelToInsert;
-				}
-			}
-
 			return {
 				hasItems: hasInserterItems( _targetRootClientId ),
 				hasSingleBlockType: _hasSingleBlockType,
 				blockTitle: _allowedBlockType ? _allowedBlockType.title : '',
 				allowedBlockType: _allowedBlockType,
-				blockLabelToInsert: _blockLabelToInsert,
 				blockToInsert: _blockToInsert,
 				appenderLabel: getAppenderLabel(
 					directInsertBlock,
@@ -206,8 +176,16 @@ const UnforwardedInserter = (
 		[ rootClientId, clientId, shouldDirectInsert ]
 	);
 
-	const registry = useRegistry();
 	const { insertBlock } = useDispatch( blockEditorStore );
+	const {
+		getBlock,
+		getBlockIndex,
+		getBlockOrder,
+		getBlockRootClientId,
+		getBlockSelectionEnd,
+		getPreviousBlockClientId,
+	} = useSelect( blockEditorStore );
+	const { getActiveBlockVariation, getBlockType } = useSelect( blocksStore );
 
 	// The global inserter (no isAppender, no rootClientId, no clientId) should
 	// always render, even with no items.
@@ -222,9 +200,6 @@ const UnforwardedInserter = (
 			if ( ! attributesToCopy?.length ) {
 				return {};
 			}
-
-			const { getBlock, getPreviousBlockClientId } =
-				registry.select( blockEditorStore );
 
 			// Find the adjacent block of the same type whose attributes
 			// should be copied: previous sibling when inserting next to
@@ -258,13 +233,6 @@ const UnforwardedInserter = (
 		}
 
 		function getInsertionIndex() {
-			const {
-				getBlockIndex,
-				getBlockSelectionEnd,
-				getBlockOrder,
-				getBlockRootClientId,
-			} = registry.select( blockEditorStore );
-
 			// If the clientId is defined, we insert at the position of the block.
 			if ( clientId ) {
 				return getBlockIndex( clientId );
@@ -304,6 +272,21 @@ const UnforwardedInserter = (
 		);
 
 		onSelectOrClose?.( newBlock );
+
+		const blockTypeToInsert = getBlockType( blockName ) || allowedBlockType;
+		let blockLabelToInsert;
+		if ( blockTypeToInsert ) {
+			blockLabelToInsert = getBlockLabel(
+				blockTypeToInsert,
+				newBlock.attributes
+			);
+
+			if ( blockLabelToInsert === blockTypeToInsert.title ) {
+				blockLabelToInsert =
+					getActiveBlockVariation( blockName, newBlock.attributes )
+						?.title || blockLabelToInsert;
+			}
+		}
 
 		if ( blockLabelToInsert ) {
 			const message = sprintf(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Currently the inserter can thrown an error on the navigation block.

## Why?
#77877 seems to have unearthed a bug that was present long before that.

Before #77877, `allowedBlockType` could unusually be set to `false`, attempting to access `allowedBlockType.title` would be ok, but the `title` would be `undefined`, so users of assistive technologies would hear something like "undefined block added".

After #77877, `allowedBlockType` can be set to `null`, attempting to access `allowedBlockType.title` throws an error. I think the upstream code is better in using more expected types, attempting to access `title` throws.

## How?
The new fix uses `getBlockLabel` to determine the label of the inserted block, which should be better. To take variations into account, the code also has to replicate what `useBlockDisplayTitle` does, using `getActiveBlockVariation` to fall back to the correct variation name. 

## Testing Instructions
The block I reproduced this on is navigation (inserting a navigation link when clicking the appender). You can't really hear the spoken message using voiceover because there are lots of other announcements at the same time. But I used a breakpoint in the browser dev tools to determine that the message is now "Page link block added".

1. Add a navigation block
2. Stick a breakpoint on the `speak( message )` line

In this PR: `message` is "Page link block added".
In trunk: the code throws an error.

## Use of AI Tools
OpenCode / Codex