### PR TITLE
Fix titleless post snippets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63287,6 +63287,7 @@
 				"@wordpress/dataviews": "file:../dataviews",
 				"@wordpress/date": "file:../date",
 				"@wordpress/element": "file:../element",
+				"@wordpress/html-entities": "file:../html-entities",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/interface": "file:../interface",

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -33,9 +33,59 @@ import { buildTermsTree } from '../../utils/terms';
 import { store as editorStore } from '../../store';
 
 function getTitle( post ) {
-	return post?.title?.rendered
-		? decodeEntities( post.title.rendered )
-		: `#${ post.id } (${ __( 'no title' ) })`;
+	const title = getPlainText( post?.title );
+	if ( title ) {
+		return title;
+	}
+
+	const snippet = getSnippet( post?.excerpt ) || getSnippet( post?.content );
+	if ( ! snippet ) {
+		return __( '(no title)' );
+	}
+
+	return sprintf(
+		/* translators: 1: title fallback for an untitled post, 2: excerpt or content snippet. */
+		__( '%1$s %2$s' ),
+		__( '(no title)' ),
+		snippet
+	);
+}
+
+function getRenderedContent( content ) {
+	if ( ! content ) {
+		return '';
+	}
+
+	if ( typeof content === 'string' ) {
+		return content;
+	}
+
+	return content.rendered || content.raw || '';
+}
+
+function stripHTML( html ) {
+	if ( typeof document !== 'undefined' ) {
+		const element = document.createElement( 'div' );
+		element.innerHTML = html;
+		return element.textContent || '';
+	}
+
+	return html.replace( /<!--[\s\S]*?-->/g, '' ).replace( /<[^>]*>/g, '' );
+}
+
+function getPlainText( content ) {
+	return decodeEntities( stripHTML( getRenderedContent( content ) ) )
+		.replace( /\s+/g, ' ' )
+		.trim();
+}
+
+function getSnippet( content ) {
+	const text = getPlainText( content );
+	if ( text.length <= 80 ) {
+		return text;
+	}
+
+	return `${ text.slice( 0, 80 ).trimEnd() }...`;
 }
 
 export const getItemPriority = ( name, searchValue ) => {
@@ -88,7 +138,7 @@ export function PageAttributesParent() {
 				parent_exclude: postId,
 				orderby: 'menu_order',
 				order: 'asc',
-				_fields: 'id,title,parent',
+				_fields: 'id,title,parent,excerpt,content',
 			};
 
 			// Perform a search by relevance when the field is changed.

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Show excerpt or content snippets for titleless post and page records. [#78897](https://github.com/WordPress/gutenberg/issues/78897).
+
 ### Code Quality
 
 -   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
@@ -46,7 +50,7 @@
 
 ### Enhancements
 
-- Update the base `titleField` to enable hiding. [#71369](https://github.com/WordPress/gutenberg/pull/71369)
+-   Update the base `titleField` to enable hiding. [#71369](https://github.com/WordPress/gutenberg/pull/71369)
 
 ## 0.21.0 (2025-08-20)
 

--- a/packages/fields/src/actions/test/utils.ts
+++ b/packages/fields/src/actions/test/utils.ts
@@ -1,0 +1,97 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getItemExcerptOrContentSnippet,
+	getItemTitle,
+	getItemTitleWithFallbackSnippet,
+} from '../utils';
+
+describe( 'post action utils', () => {
+	describe( 'getItemTitle', () => {
+		it( 'returns a decoded plain-text title', () => {
+			expect(
+				getItemTitle( {
+					title: { rendered: 'A <strong>bold</strong> title' },
+				} )
+			).toBe( 'A bold title' );
+		} );
+	} );
+
+	describe( 'getItemExcerptOrContentSnippet', () => {
+		it( 'uses the excerpt before the content', () => {
+			expect(
+				getItemExcerptOrContentSnippet( {
+					title: { rendered: '' },
+					excerpt: { rendered: '<p>Excerpt text</p>' },
+					content: { rendered: '<p>Content text</p>' },
+				} )
+			).toBe( 'Excerpt text' );
+		} );
+
+		it( 'falls back to the content when the excerpt is empty', () => {
+			expect(
+				getItemExcerptOrContentSnippet( {
+					title: { rendered: '' },
+					excerpt: { rendered: '' },
+					content: { rendered: '<p>Content &amp; more</p>' },
+				} )
+			).toBe( 'Content & more' );
+		} );
+
+		it( 'trims long snippets', () => {
+			expect(
+				getItemExcerptOrContentSnippet(
+					{
+						title: { rendered: '' },
+						content: {
+							rendered:
+								'<p>This content is longer than expected.</p>',
+						},
+					},
+					12
+				)
+			).toBe( 'This content...' );
+		} );
+	} );
+
+	describe( 'getItemTitleWithFallbackSnippet', () => {
+		it( 'returns the title when one exists', () => {
+			expect(
+				getItemTitleWithFallbackSnippet( {
+					title: { rendered: 'A title' },
+					excerpt: { rendered: 'Excerpt text' },
+				} )
+			).toBe( 'A title' );
+		} );
+
+		it( 'adds an excerpt snippet to the fallback title', () => {
+			expect(
+				getItemTitleWithFallbackSnippet( {
+					title: { rendered: '' },
+					excerpt: { rendered: '<p>Identifying excerpt</p>' },
+				} )
+			).toBe( '(no title) Identifying excerpt' );
+		} );
+
+		it( 'uses content when title and excerpt are empty', () => {
+			expect(
+				getItemTitleWithFallbackSnippet( {
+					title: { rendered: '' },
+					excerpt: { rendered: '' },
+					content: { rendered: '<p>Identifying content</p>' },
+				} )
+			).toBe( '(no title) Identifying content' );
+		} );
+
+		it( 'returns only the fallback when no snippet is available', () => {
+			expect(
+				getItemTitleWithFallbackSnippet( {
+					title: { rendered: '' },
+					excerpt: { rendered: '' },
+					content: { rendered: '' },
+				} )
+			).toBe( '(no title)' );
+		} );
+	} );
+} );

--- a/packages/fields/src/actions/utils.ts
+++ b/packages/fields/src/actions/utils.ts
@@ -2,12 +2,50 @@
  * WordPress dependencies
  */
 import { decodeEntities } from '@wordpress/html-entities';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import type { Post, TemplatePart, Template } from '../types';
+
+const TITLE_FALLBACK_SNIPPET_LENGTH = 80;
+
+type RenderedContent = string | { raw?: string; rendered?: string };
+
+type ItemWithTitleAndContent = {
+	title?: RenderedContent;
+	excerpt?: RenderedContent;
+	content?: RenderedContent;
+};
+
+function getRenderedContent( content?: RenderedContent ) {
+	if ( ! content ) {
+		return '';
+	}
+
+	if ( typeof content === 'string' ) {
+		return content;
+	}
+
+	return content.rendered || content.raw || '';
+}
+
+function stripHTML( html: string ) {
+	if ( typeof document !== 'undefined' ) {
+		const element = document.createElement( 'div' );
+		element.innerHTML = html;
+		return element.textContent || '';
+	}
+
+	return html.replace( /<!--[\s\S]*?-->/g, '' ).replace( /<[^>]*>/g, '' );
+}
+
+function getPlainText( content?: RenderedContent ) {
+	return decodeEntities( stripHTML( getRenderedContent( content ) ) )
+		.replace( /\s+/g, ' ' )
+		.trim();
+}
 
 export function isTemplate( post: Post ): post is Template {
 	return post.type === 'wp_template';
@@ -25,19 +63,47 @@ export function isTemplateOrTemplatePart(
 
 export function getItemTitle(
 	item: {
-		title: string | { rendered: string } | { raw: string };
+		title?: string | { rendered: string } | { raw: string };
 	},
 	fallback: string = __( '(no title)' )
 ) {
-	let title = '';
-	if ( typeof item.title === 'string' ) {
-		title = decodeEntities( item.title );
-	} else if ( item.title && 'rendered' in item.title ) {
-		title = decodeEntities( item.title.rendered );
-	} else if ( item.title && 'raw' in item.title ) {
-		title = decodeEntities( item.title.raw );
-	}
+	const title = getPlainText( item.title );
 	return title || fallback;
+}
+
+export function getItemExcerptOrContentSnippet(
+	item: ItemWithTitleAndContent,
+	length: number = TITLE_FALLBACK_SNIPPET_LENGTH
+) {
+	const text = getPlainText( item.excerpt ) || getPlainText( item.content );
+
+	if ( text.length <= length ) {
+		return text;
+	}
+
+	return `${ text.slice( 0, length ).trimEnd() }...`;
+}
+
+export function getItemTitleWithFallbackSnippet(
+	item: ItemWithTitleAndContent,
+	fallback: string = __( '(no title)' )
+) {
+	const title = getItemTitle( item, '' );
+	if ( title ) {
+		return title;
+	}
+
+	const snippet = getItemExcerptOrContentSnippet( item );
+	if ( ! snippet ) {
+		return fallback;
+	}
+
+	return sprintf(
+		/* translators: 1: title fallback for an untitled post, 2: excerpt or content snippet. */
+		__( '%1$s %2$s' ),
+		fallback,
+		snippet
+	);
 }
 
 /**

--- a/packages/fields/src/fields/page-title/index.ts
+++ b/packages/fields/src/fields/page-title/index.ts
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { BasePost } from '../../types';
-import { getItemTitle } from '../../actions/utils';
+import { getItemTitleWithFallbackSnippet } from '../../actions/utils';
 import PageTitleView from './view';
 
 const pageTitleField: Field< BasePost > = {
@@ -16,7 +16,7 @@ const pageTitleField: Field< BasePost > = {
 	id: 'title',
 	label: __( 'Title' ),
 	placeholder: __( 'No title' ),
-	getValue: ( { item } ) => getItemTitle( item ),
+	getValue: ( { item } ) => getItemTitleWithFallbackSnippet( item ),
 	render: PageTitleView,
 	enableHiding: false,
 	enableGlobalSearch: true,

--- a/packages/fields/src/fields/parent/parent-edit.tsx
+++ b/packages/fields/src/fields/parent/parent-edit.tsx
@@ -144,7 +144,7 @@ export function PageAttributesParent( {
 				parent_exclude: postId,
 				orderby: 'menu_order',
 				order: 'asc',
-				_fields: 'id,title,parent',
+				_fields: 'id,title,parent,excerpt,content',
 				...( !! fieldValue && {
 					// Perform a search by relevance when the field is changed.
 					search: fieldValue,

--- a/packages/fields/src/fields/parent/test/utils.ts
+++ b/packages/fields/src/fields/parent/test/utils.ts
@@ -1,0 +1,41 @@
+/**
+ * Internal dependencies
+ */
+import type { BasePost } from '../../../types';
+import { getTitleWithFallbackName } from '../utils';
+
+describe( 'getTitleWithFallbackName', () => {
+	it( 'returns the decoded post title when present', () => {
+		expect(
+			getTitleWithFallbackName( {
+				id: 1,
+				type: 'page',
+				title: { rendered: 'Parent &amp; page' },
+				content: { rendered: '' },
+			} as BasePost )
+		).toBe( 'Parent & page' );
+	} );
+
+	it( 'uses an excerpt snippet for titleless posts', () => {
+		expect(
+			getTitleWithFallbackName( {
+				id: 1,
+				type: 'page',
+				title: { rendered: '' },
+				excerpt: { rendered: '<p>A recognizable parent page</p>' },
+				content: { rendered: '' },
+			} as BasePost )
+		).toBe( '(no title) A recognizable parent page' );
+	} );
+
+	it( 'uses the fallback when the post has no identifying text', () => {
+		expect(
+			getTitleWithFallbackName( {
+				id: 1,
+				type: 'page',
+				title: { rendered: '' },
+				content: { rendered: '' },
+			} as BasePost )
+		).toBe( '(no title)' );
+	} );
+} );

--- a/packages/fields/src/fields/parent/utils.ts
+++ b/packages/fields/src/fields/parent/utils.ts
@@ -1,18 +1,9 @@
 /**
- * WordPress dependencies
- */
-import { decodeEntities } from '@wordpress/html-entities';
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import type { BasePost } from '../../types';
+import { getItemTitleWithFallbackSnippet } from '../../actions/utils';
 
 export function getTitleWithFallbackName( post: BasePost ) {
-	return typeof post.title === 'object' &&
-		'rendered' in post.title &&
-		post.title.rendered
-		? decodeEntities( post.title.rendered )
-		: `#${ post?.id } (${ __( 'no title' ) })`;
+	return getItemTitleWithFallbackSnippet( post );
 }

--- a/packages/fields/src/fields/title/index.ts
+++ b/packages/fields/src/fields/title/index.ts
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { CommonPost } from '../../types';
-import { getItemTitle } from '../../actions/utils';
+import { getItemTitleWithFallbackSnippet } from '../../actions/utils';
 import TitleView from './view';
 
 const titleField: Field< CommonPost > = {
@@ -16,7 +16,7 @@ const titleField: Field< CommonPost > = {
 	id: 'title',
 	label: __( 'Title' ),
 	placeholder: __( 'No title' ),
-	getValue: ( { item } ) => getItemTitle( item ),
+	getValue: ( { item } ) => getItemTitleWithFallbackSnippet( item ),
 	render: TitleView,
 	enableHiding: true,
 	enableGlobalSearch: true,

--- a/packages/fields/src/fields/title/view.tsx
+++ b/packages/fields/src/fields/title/view.tsx
@@ -8,13 +8,12 @@ import type { ReactNode } from 'react';
  * WordPress dependencies
  */
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import type { CommonPost } from '../../types';
-import { getItemTitle } from '../../actions/utils';
+import { getItemTitleWithFallbackSnippet } from '../../actions/utils';
 
 export function BaseTitleView( {
 	item,
@@ -25,14 +24,14 @@ export function BaseTitleView( {
 	className?: string;
 	children?: ReactNode;
 } ) {
-	const renderedTitle = getItemTitle( item );
+	const renderedTitle = getItemTitleWithFallbackSnippet( item );
 	return (
 		<HStack
 			className={ clsx( 'fields-field__title', className ) }
 			alignment="center"
 			justify="flex-start"
 		>
-			<span>{ renderedTitle || __( '(no title)' ) }</span>
+			<span>{ renderedTitle }</span>
 			{ children }
 		</HStack>
 	);

--- a/packages/media-fields/CHANGELOG.md
+++ b/packages/media-fields/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Show excerpt or content snippets when attached media points to titleless posts. [#78897](https://github.com/WordPress/gutenberg/issues/78897).
+
 ### Code Quality
 
 -   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).

--- a/packages/media-fields/package.json
+++ b/packages/media-fields/package.json
@@ -58,6 +58,7 @@
 		"@wordpress/dataviews": "file:../dataviews",
 		"@wordpress/date": "file:../date",
 		"@wordpress/element": "file:../element",
+		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/primitives": "file:../primitives",

--- a/packages/media-fields/src/attached_to/edit.tsx
+++ b/packages/media-fields/src/attached_to/edit.tsx
@@ -16,7 +16,7 @@ import type { DataFormControlProps } from '@wordpress/dataviews';
  * Internal dependencies
  */
 import type { MediaItem } from '../types';
-import { getRenderedContent } from '../utils/get-rendered-content';
+import { getPostTitleWithFallbackSnippet } from '../utils/get-post-title-with-fallback-snippet';
 
 export type SearchResult = {
 	/**
@@ -45,13 +45,12 @@ export default function MediaAttachedToEdit( {
 	data,
 	onChange,
 }: DataFormControlProps< MediaItem > ) {
+	const embeddedPost = data._embedded?.[ 'wp:attached-to' ]?.[ 0 ];
 	const defaultPost =
-		!! data.post && !! data?._embedded?.[ 'wp:attached-to' ]?.[ 0 ]
+		!! data.post && !! embeddedPost
 			? [
 					{
-						label: getRenderedContent(
-							data._embedded?.[ 'wp:attached-to' ]?.[ 0 ]?.title
-						),
+						label: getPostTitleWithFallbackSnippet( embeddedPost ),
 						value: data.post.toString(),
 					},
 			  ]

--- a/packages/media-fields/src/attached_to/test/view.test.tsx
+++ b/packages/media-fields/src/attached_to/test/view.test.tsx
@@ -40,7 +40,7 @@ describe( 'MediaAttachedToView', () => {
 		expect( screen.getByText( 'Hello world' ) ).toBeInTheDocument();
 	} );
 
-	it( 'falls back to "(no title)" when the embedded post is loaded but has an empty title', () => {
+	it( 'falls back to an excerpt snippet when the embedded post has an empty title', () => {
 		const item: Partial< MediaItem > = {
 			post: 42,
 			_embedded: {
@@ -48,6 +48,35 @@ describe( 'MediaAttachedToView', () => {
 					{
 						id: 42,
 						title: { raw: '', rendered: '' },
+						excerpt: {
+							raw: 'Identifying excerpt',
+							rendered: '<p>Identifying excerpt</p>',
+						},
+					},
+				],
+			},
+		};
+
+		render(
+			<MediaAttachedToView item={ item as MediaItem } field={ field } />
+		);
+
+		expect(
+			screen.getByText( '(no title) Identifying excerpt' )
+		).toBeInTheDocument();
+		expect( screen.queryByText( '42' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'falls back to "(no title)" when the embedded post has no identifying text', () => {
+		const item: Partial< MediaItem > = {
+			post: 42,
+			_embedded: {
+				'wp:attached-to': [
+					{
+						id: 42,
+						title: { raw: '', rendered: '' },
+						excerpt: { raw: '', rendered: '' },
+						content: { raw: '', rendered: '' },
 					},
 				],
 			},

--- a/packages/media-fields/src/attached_to/view.tsx
+++ b/packages/media-fields/src/attached_to/view.tsx
@@ -8,7 +8,7 @@ import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
  * Internal dependencies
  */
 import type { MediaItem } from '../types';
-import { getRenderedContent } from '../utils/get-rendered-content';
+import { getPostTitleWithFallbackSnippet } from '../utils/get-post-title-with-fallback-snippet';
 
 export default function MediaAttachedToView( {
 	item,
@@ -21,21 +21,20 @@ export default function MediaAttachedToView( {
 	>( null );
 
 	const parentId = item.post;
-	const embeddedPostId = item._embedded?.[ 'wp:attached-to' ]?.[ 0 ]?.id;
-	const embeddedPostTitle =
-		item._embedded?.[ 'wp:attached-to' ]?.[ 0 ]?.title;
+	const embeddedPost = item._embedded?.[ 'wp:attached-to' ]?.[ 0 ];
+	const embeddedPostId = embeddedPost?.id;
 
 	useEffect( () => {
-		if ( !! parentId && parentId === embeddedPostId ) {
+		if ( !! parentId && embeddedPost && parentId === embeddedPostId ) {
 			setAttachedPostTitle(
-				getRenderedContent( embeddedPostTitle ) || __( '(no title)' )
+				getPostTitleWithFallbackSnippet( embeddedPost )
 			);
 		}
 
 		if ( ! parentId ) {
 			setAttachedPostTitle( __( '(Unattached)' ) );
 		}
-	}, [ parentId, embeddedPostId, embeddedPostTitle ] );
+	}, [ parentId, embeddedPostId, embeddedPost ] );
 
 	return <>{ attachedPostTitle }</>;
 }

--- a/packages/media-fields/src/utils/get-post-title-with-fallback-snippet.ts
+++ b/packages/media-fields/src/utils/get-post-title-with-fallback-snippet.ts
@@ -1,0 +1,64 @@
+/**
+ * WordPress dependencies
+ */
+import { decodeEntities } from '@wordpress/html-entities';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getRenderedContent } from './get-rendered-content';
+
+const TITLE_FALLBACK_SNIPPET_LENGTH = 80;
+
+type RenderedContent = string | { raw: string; rendered: string };
+
+type PostLike = {
+	title?: RenderedContent;
+	excerpt?: RenderedContent;
+	content?: RenderedContent;
+};
+
+function stripHTML( html: string ) {
+	if ( typeof document !== 'undefined' ) {
+		const element = document.createElement( 'div' );
+		element.innerHTML = html;
+		return element.textContent || '';
+	}
+
+	return html.replace( /<!--[\s\S]*?-->/g, '' ).replace( /<[^>]*>/g, '' );
+}
+
+function getPlainText( content?: RenderedContent ) {
+	return decodeEntities( stripHTML( getRenderedContent( content ) ) )
+		.replace( /\s+/g, ' ' )
+		.trim();
+}
+
+function getSnippet( content?: RenderedContent ) {
+	const text = getPlainText( content );
+	if ( text.length <= TITLE_FALLBACK_SNIPPET_LENGTH ) {
+		return text;
+	}
+
+	return `${ text.slice( 0, TITLE_FALLBACK_SNIPPET_LENGTH ).trimEnd() }...`;
+}
+
+export function getPostTitleWithFallbackSnippet( post: PostLike ) {
+	const title = getPlainText( post.title );
+	if ( title ) {
+		return title;
+	}
+
+	const snippet = getSnippet( post.excerpt ) || getSnippet( post.content );
+	if ( ! snippet ) {
+		return __( '(no title)' );
+	}
+
+	return sprintf(
+		/* translators: 1: title fallback for an untitled post, 2: excerpt or content snippet. */
+		__( '%1$s %2$s' ),
+		__( '(no title)' ),
+		snippet
+	);
+}

--- a/packages/media-fields/src/utils/test/get-post-title-with-fallback-snippet.test.ts
+++ b/packages/media-fields/src/utils/test/get-post-title-with-fallback-snippet.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Internal dependencies
+ */
+import { getPostTitleWithFallbackSnippet } from '../get-post-title-with-fallback-snippet';
+
+describe( 'getPostTitleWithFallbackSnippet', () => {
+	it( 'returns a decoded plain-text title when present', () => {
+		expect(
+			getPostTitleWithFallbackSnippet( {
+				title: { raw: '', rendered: '<strong>Attached</strong> post' },
+				excerpt: { raw: 'Excerpt', rendered: 'Excerpt' },
+			} )
+		).toBe( 'Attached post' );
+	} );
+
+	it( 'uses the excerpt for a titleless post', () => {
+		expect(
+			getPostTitleWithFallbackSnippet( {
+				title: { raw: '', rendered: '' },
+				excerpt: {
+					raw: 'Attached excerpt',
+					rendered: '<p>Attached excerpt</p>',
+				},
+			} )
+		).toBe( '(no title) Attached excerpt' );
+	} );
+
+	it( 'uses the content when the title and excerpt are empty', () => {
+		expect(
+			getPostTitleWithFallbackSnippet( {
+				title: { raw: '', rendered: '' },
+				excerpt: { raw: '', rendered: '' },
+				content: {
+					raw: 'Attached content',
+					rendered: '<p>Attached content</p>',
+				},
+			} )
+		).toBe( '(no title) Attached content' );
+	} );
+
+	it( 'returns only the fallback when no snippet is available', () => {
+		expect(
+			getPostTitleWithFallbackSnippet( {
+				title: { raw: '', rendered: '' },
+				excerpt: { raw: '', rendered: '' },
+				content: { raw: '', rendered: '' },
+			} )
+		).toBe( '(no title)' );
+	} );
+} );


### PR DESCRIPTION
## What?

Shows an excerpt or content snippet alongside `(no title)` for titleless post records in post/page DataViews, parent selectors, and media “Attached to” fields.

## Why?

Titleless posts currently appear only as `(no title)`, or sometimes with an ID, which makes them hard to identify. A short excerpt/content snippet gives users a more human-friendly way to distinguish records.

## How?

Adds shared post title fallback helpers in `@wordpress/fields`, updates post/page title fields and parent selectors to use them, and expands parent selector queries to request excerpt/content. Adds matching media-field fallback logic for embedded attached posts.

## Testing Instructions

1. Create or edit a post/page with no title and an excerpt or content.
2. Open a posts/pages DataViews list and confirm it shows `(no title)` followed by the snippet.
3. Open a page parent selector and confirm titleless parent options show the snippet.
4. Attach media to a titleless post/page and confirm the “Attached to” field shows the snippet.

### Testing Instructions for Keyboard

1. Use `Tab` to navigate to the parent selector or media “Attached to” combobox.
2. Open and move through options with the keyboard.
3. Confirm titleless records are identifiable by the `(no title)` snippet text.

## Use of AI Tools

Used ChatGPT/Codex to help implement, test, and draft this PR. All changes were reviewed by the contributor.