### PR TITLE
Media editor: tweak paddings and margins

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -89,6 +89,7 @@ $z-layers: (
 	".editor-post-template__swap-template-modal": 1000001,
 	".editor-post-template__create-template-modal": 1000001,
 	".editor-sync-connection-error-modal": 1000001,
+	".media-editor-modal__footer": 1000001,
 	".components-snackbar-list.media-editor-modal__snackbar": 1000001,
 
 	// Note: The ConfirmDialog component's z-index is being set to 1000001 in packages/components/src/confirm-dialog/styles.ts

--- a/packages/media-editor/src/components/media-editor-modal/style.scss
+++ b/packages/media-editor/src/components/media-editor-modal/style.scss
@@ -12,6 +12,9 @@
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
+	// This isn't precise. The goal is to get closer to a uniform padding of 24px around the modal.
+	// The .components-modal__header is 72px height. Reducing the position by 10px gets us closer.
+	margin-top: 62px;
 }
 
 .media-editor-modal.components-modal__frame .components-modal__children-container {

--- a/packages/media-editor/src/components/media-editor-modal/style.scss
+++ b/packages/media-editor/src/components/media-editor-modal/style.scss
@@ -12,9 +12,6 @@
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
-	// This isn't precise. The goal is to get closer to a uniform padding of 24px around the modal.
-	// The .components-modal__header is 72px height. Reducing the position by 10px gets us closer.
-	margin-top: 62px;
 }
 
 .media-editor-modal.components-modal__frame .components-modal__children-container {

--- a/packages/media-editor/src/components/media-editor-modal/style.scss
+++ b/packages/media-editor/src/components/media-editor-modal/style.scss
@@ -39,6 +39,8 @@
 	// spacing, not divider lines. 16px top / 32px sides / 24px bottom.
 	padding: $grid-unit-20 $grid-unit-40 $grid-unit-30;
 	background: $white;
+	// Above the `.interface-interface-skeleton__sidebar` which has a z-index of 100000.
+	z-index: z-index(".media-editor-modal__footer");
 
 	&.is-wide {
 		flex-direction: row;

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -48,6 +48,11 @@
 		margin: 0 $grid-unit-30;
 		border-radius: $radius-large;
 		overflow: hidden;
+		@include break-small() {
+			// Compensate for the left gutter in the sidebar panel
+			// so the modal padding is uniform (24px).
+			margin-right: $grid-unit-30 - $grid-unit-10;
+		}
 	}
 
 	.media-editor__canvas-toolbar {
@@ -98,6 +103,10 @@
 		}
 	}
 
+	.media-editor__sidebar-panel {
+		padding-bottom: $grid-unit-30;
+	}
+
 	// Borderless controls panel: clear the InterfaceSkeleton sidebar's
 	// default top border, left box-shadow, and high-contrast outline so the
 	// panel sits flush with no divider lines.
@@ -127,6 +136,7 @@
 	.components-panel__header.media-editor__sidebar-header {
 		padding-left: 0;
 		padding-right: $grid-unit-10;
+		margin-right: $grid-unit-30;
 
 		.components-button.has-icon {
 			padding: 0;

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -27,6 +27,7 @@
 		max-height: none;
 		flex: 1;
 		flex-direction: column;
+		min-height: 200px;
 	}
 
 	.interface-interface-skeleton__editor {

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -27,7 +27,6 @@
 		max-height: none;
 		flex: 1;
 		flex-direction: column;
-		min-height: 200px;
 	}
 
 	.interface-interface-skeleton__editor {

--- a/packages/media-editor/src/image-editor/react/components/cropper.scss
+++ b/packages/media-editor/src/image-editor/react/components/cropper.scss
@@ -25,6 +25,8 @@ $handle-touch-target-size: 44px;
 	&__canvas {
 		position: absolute;
 		inset: $grid-unit-30;
+		min-height: 100px;
+		min-width: 100px;
 
 		// Suppress the browser's default focus ring — the crop rectangle
 		// border provides the custom keyboard-focus indicator instead.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds margin adjustments for the media editor modal to ensure uniform padding.

## Why?

Gets us closer to uniformity and to make sure the focusable element at the bottom of the data form in the details tab isn't cut off.

 Related comment:

https://github.com/WordPress/gutenberg/pull/78896#issuecomment-4647827406



## Testing Instructions

Check in your browsers. Things should look okay.

The tabs underline shouldn't go to the edge.

## Screenshots or screencast <!-- if applicable -->


|Before|After|
|-|-|
|<img width="1271" height="728" alt="Screenshot 2026-06-08 at 8 23 51 pm" src="https://github.com/user-attachments/assets/df0d4276-c055-47a4-bc31-04f670575222" />|<img width="1269" height="733" alt="Screenshot 2026-06-08 at 8 20 52 pm" src="https://github.com/user-attachments/assets/136eaca0-48f8-4420-a3f3-16c365231155" />|



## Use of AI Tools

None. 