### PR TITLE
Media Editor: Keep crop handles operable on large images

### DIFF
--- a/packages/media-editor/src/image-editor/core/constants.ts
+++ b/packages/media-editor/src/image-editor/core/constants.ts
@@ -31,6 +31,17 @@ export const MAX_ZOOM = 10;
 export const MIN_CROP_PIXELS = 24;
 
 /**
+ * Minimum on-screen crop rect dimension in CSS pixels. The source-pixel
+ * floor (`MIN_CROP_PIXELS`) keeps crops from going sub-pixel, but on a large
+ * image fit into a small canvas it can render only a few CSS pixels wide —
+ * too small to grab the resize handles. This floor keeps the crop operable
+ * regardless of display scale; it binds when zoomed out and yields to the
+ * source-pixel floor once the image is shown large enough. Sized to one
+ * handle touch target (`$handle-touch-target-size` in `cropper.scss`).
+ */
+export const MIN_CROP_SCREEN_PX = 44;
+
+/**
  * Wheel zoom sensitivity. A deltaY of 100 changes zoom by 0.25.
  * This could be made configurable as a prop to the Cropper component.
  */

--- a/packages/media-editor/src/image-editor/core/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/stencil-math.ts
@@ -1,9 +1,32 @@
 /**
  * Internal dependencies
  */
+import { MIN_CROP_PIXELS, MIN_CROP_SCREEN_PX } from './constants';
 import type { HandlePosition, NormalizedRect, Size } from './types';
 
 export type { HandlePosition };
+
+/**
+ * Resolve the minimum crop dimension, in source-image pixels, for the current
+ * display scale.
+ *
+ * Two floors compete: a fixed source-pixel floor (`MIN_CROP_PIXELS`) that
+ * avoids sub-pixel crops, and an on-screen floor (`MIN_CROP_SCREEN_PX`) that
+ * keeps the crop large enough to grab. The on-screen floor converted to source
+ * pixels is `MIN_CROP_SCREEN_PX / displayScale`; the binding constraint is the
+ * larger of the two. When zoomed out (small `displayScale`) the on-screen floor
+ * dominates; once the image is shown large enough the source-pixel floor takes
+ * over.
+ *
+ * @param displayScale CSS pixels rendered per source pixel (fit scale × zoom).
+ * @return Minimum crop dimension in source-image pixels.
+ */
+export function getMinCropPixels( displayScale: number ): number {
+	if ( displayScale <= 0 ) {
+		return MIN_CROP_PIXELS;
+	}
+	return Math.max( MIN_CROP_PIXELS, MIN_CROP_SCREEN_PX / displayScale );
+}
 
 /**
  * Default minimum crop rect dimension in normalized space, used when no

--- a/packages/media-editor/src/image-editor/core/test/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/test/stencil-math.ts
@@ -5,10 +5,43 @@ import {
 	computeFreeResizeRect,
 	computeLockedResizeRect,
 	computeShiftLockedResizeRect,
+	getMinCropPixels,
 	type CropBounds,
 	type ResizeDragState,
 } from '../stencil-math';
+import { MIN_CROP_PIXELS, MIN_CROP_SCREEN_PX } from '../constants';
 import type { Size } from '../types';
+
+describe( 'getMinCropPixels — operable on-screen floor', () => {
+	it( 'returns the source-pixel hard floor when the image is shown large enough', () => {
+		// displayScale = 2 CSS px per source px (zoomed in). The usability
+		// term is 44 / 2 = 22 px, below the 24-source-px hard floor, so the
+		// hard floor wins.
+		expect( getMinCropPixels( 2 ) ).toBe( MIN_CROP_PIXELS );
+	} );
+
+	it( 'raises the floor so the crop stays operable when the image is shown small', () => {
+		// A large image fit into a small window: ~0.2 CSS px per source px.
+		// 24 source px would render as ~4.8 px on screen — unusable. The
+		// usability term (44 / 0.2 = 220 source px) must win.
+		expect( getMinCropPixels( 0.2 ) ).toBe( MIN_CROP_SCREEN_PX / 0.2 );
+		expect( getMinCropPixels( 0.2 ) ).toBeGreaterThan( MIN_CROP_PIXELS );
+	} );
+
+	it( 'crosses over from usability floor to hard floor at displayScale = MIN_CROP_SCREEN_PX / MIN_CROP_PIXELS', () => {
+		const crossover = MIN_CROP_SCREEN_PX / MIN_CROP_PIXELS;
+		expect( getMinCropPixels( crossover ) ).toBe( MIN_CROP_PIXELS );
+		// Just below the crossover, the usability term exceeds the hard floor.
+		expect( getMinCropPixels( crossover * 0.99 ) ).toBeGreaterThan(
+			MIN_CROP_PIXELS
+		);
+	} );
+
+	it( 'falls back to the hard floor for a non-positive display scale', () => {
+		expect( getMinCropPixels( 0 ) ).toBe( MIN_CROP_PIXELS );
+		expect( getMinCropPixels( -1 ) ).toBe( MIN_CROP_PIXELS );
+	} );
+} );
 
 const FULL_BOUNDS: CropBounds = { minX: 0, minY: 0, maxX: 1, maxY: 1 };
 

--- a/packages/media-editor/src/image-editor/core/test/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/test/stencil-math.ts
@@ -24,13 +24,16 @@ describe( 'getMinCropPixels — operable on-screen floor', () => {
 		// A large image fit into a small window: ~0.2 CSS px per source px.
 		// 24 source px would render as ~4.8 px on screen — unusable. The
 		// usability term (44 / 0.2 = 220 source px) must win.
-		expect( getMinCropPixels( 0.2 ) ).toBe( MIN_CROP_SCREEN_PX / 0.2 );
+		expect( getMinCropPixels( 0.2 ) ).toBeCloseTo(
+			MIN_CROP_SCREEN_PX / 0.2,
+			5
+		);
 		expect( getMinCropPixels( 0.2 ) ).toBeGreaterThan( MIN_CROP_PIXELS );
 	} );
 
 	it( 'crosses over from usability floor to hard floor at displayScale = MIN_CROP_SCREEN_PX / MIN_CROP_PIXELS', () => {
 		const crossover = MIN_CROP_SCREEN_PX / MIN_CROP_PIXELS;
-		expect( getMinCropPixels( crossover ) ).toBe( MIN_CROP_PIXELS );
+		expect( getMinCropPixels( crossover ) ).toBeCloseTo( MIN_CROP_PIXELS, 5 );
 		// Just below the crossover, the usability term exceeds the hard floor.
 		expect( getMinCropPixels( crossover * 0.99 ) ).toBeGreaterThan(
 			MIN_CROP_PIXELS

--- a/packages/media-editor/src/image-editor/core/test/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/test/stencil-math.ts
@@ -33,7 +33,10 @@ describe( 'getMinCropPixels — operable on-screen floor', () => {
 
 	it( 'crosses over from usability floor to hard floor at displayScale = MIN_CROP_SCREEN_PX / MIN_CROP_PIXELS', () => {
 		const crossover = MIN_CROP_SCREEN_PX / MIN_CROP_PIXELS;
-		expect( getMinCropPixels( crossover ) ).toBeCloseTo( MIN_CROP_PIXELS, 5 );
+		expect( getMinCropPixels( crossover ) ).toBeCloseTo(
+			MIN_CROP_PIXELS,
+			5
+		);
 		// Just below the crossover, the usability term exceeds the hard floor.
 		expect( getMinCropPixels( crossover * 0.99 ) ).toBeGreaterThan(
 			MIN_CROP_PIXELS

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -32,7 +32,7 @@ import type {
 import type { CropperController } from '../hooks/use-cropper-reducer';
 import { getImageFit, getRotatedBBox } from '../../core/camera';
 import { getImageCropBounds, getMinZoom } from '../../core/containment';
-import { MIN_CROP_PIXELS } from '../../core/constants';
+import { getMinCropPixels } from '../../core/stencil-math';
 import { computeInscribedRect } from '../../core/crop-rect';
 import { useInteraction } from '../hooks/use-interaction';
 import { useTransformStyle } from '../hooks/use-transform-style';
@@ -275,6 +275,11 @@ function CropperInner(
 	// floor scales with `zoom` to keep the source-pixel floor constant.
 	// Without this, SETTLE_CROP zooms in proportional to the shrink and
 	// successive drags can crop arbitrarily small.
+	//
+	// The source-pixel floor is resolved per display scale so the crop
+	// stays grabbable: a large image fit into a small canvas would render
+	// the 24px floor only a few CSS pixels wide. `elementSize.width /
+	// naturalWidth` is the fit scale; × zoom gives CSS px per source px.
 	const minCropSize: Size | undefined = useMemo( () => {
 		if ( naturalWidth <= 0 || naturalHeight <= 0 ) {
 			return undefined;
@@ -285,14 +290,19 @@ function CropperInner(
 			naturalHeight,
 			snapRotation
 		);
+		const displayScale = ( elementSize.width / naturalWidth ) * state.zoom;
+		const minPixels = getMinCropPixels( displayScale );
 		return {
-			width: Math.min( 1, ( MIN_CROP_PIXELS * state.zoom ) / bbox.width ),
-			height: Math.min(
-				1,
-				( MIN_CROP_PIXELS * state.zoom ) / bbox.height
-			),
+			width: Math.min( 1, ( minPixels * state.zoom ) / bbox.width ),
+			height: Math.min( 1, ( minPixels * state.zoom ) / bbox.height ),
 		};
-	}, [ naturalWidth, naturalHeight, state.rotation, state.zoom ] );
+	}, [
+		naturalWidth,
+		naturalHeight,
+		state.rotation,
+		state.zoom,
+		elementSize.width,
+	] );
 
 	// Report the rendered image size to the controller. Composite
 	// controllers need it to compute aspect-ratio reshapes from the


### PR DESCRIPTION


## What

The crop area minimum is enforced as a fixed 24 source-image pixels. 

On a large image fit into a small canvas, that renders only a few CSS pixels wide, so the resize handles overlap and the crop becomes impossible to operate. 

This makes the floor adapt to the current display scale while keeping the 24px hard floor once the image is zoomed in enough.

## Why

With a 1400x2500 image in a roughly 1000x500 window, dragging the crop handles to the minimum produces a crop only about 5px wide on screen. The four 44px handle touch targets sit on top of each other and you cannot grab a specific edge.


https://github.com/user-attachments/assets/b986c9e6-28d6-457e-9876-72c99d361334



## Manual testing

1. Open the media editor on an image whose dimensions are much larger than the editor canvas (for example 1400x2500).
2. Resize the browser window small enough that the image is scaled well below 1:1.
3. Drag a corner crop handle inward as far as it will go.
4. Confirm the crop area stays large enough on screen to grab and re-drag the handles, rather than collapsing to a few pixels.
5. Zoom in on the image, then drag a handle inward again, and confirm you can now crop down to a tighter (roughly 24px source) selection.
6. Repeat on a small image (for example 200x200) and confirm crop behaviour is unchanged.


https://github.com/user-attachments/assets/f675106d-8450-43ea-a56a-d4470b762105

## AI usage

Writing tests and reasoning. 
