### PR TITLE
Notices: Use site background colour behind pinned notices

### DIFF
--- a/packages/block-editor/src/components/editor-styles/index.js
+++ b/packages/block-editor/src/components/editor-styles/index.js
@@ -62,6 +62,22 @@ function useDarkThemeBodyClassName( styles, scope ) {
 			} else {
 				body.classList.add( 'is-dark-theme' );
 			}
+
+			// Expose the resolved body background color to the host document as a
+			// CSS custom property. This allows elements that live outside the
+			// iframe (e.g. pinned editor notices) to adopt the same background and
+			// appear visually integrated with the canvas.
+			const hostDocument =
+				defaultView?.frameElement?.ownerDocument ?? ownerDocument;
+			const editorEl = hostDocument?.querySelector(
+				'.editor-editor-interface'
+			);
+			if ( editorEl ) {
+				editorEl.style.setProperty(
+					'--wp-editor-body-background',
+					backgroundColor
+				);
+			}
 		},
 		[ styles, scope ]
 	);

--- a/packages/editor/src/components/editor-interface/style.scss
+++ b/packages/editor/src/components/editor-interface/style.scss
@@ -11,6 +11,7 @@
 
 .editor-editor-interface .editor-notices {
 	padding: var(--wpds-dimension-padding-md);
+	background-color: var(--wp-editor-body-background, transparent);
 }
 
 .editor-visual-editor {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/79010

<!-- In a few words, what is the PR actually doing? -->
This PR updates the pinned editor notices to visually integrate with the editor canvas by adopting the active theme's background color.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When a site uses a non-white background colour, the pinned notices strip at the top of the editor content area shows a mismatched background. This creates a visual disconnect, particularly noticeable with colourful or dark themes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR:
1. Updates `useDarkThemeBodyClassName` in `EditorStyles` to expose the canvas's computed `background-color` as a CSS custom property (`--wp-editor-body-background`) on the host document's `.editor-editor-interface` wrapper.
2. Applies this dynamic CSS custom property to the `.editor-notices` container via `style.scss` (with a `transparent` fallback).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post or page in the Editor.
2. Ensure you are using a theme with a non-white background color (or set a custom background color via Global Styles).
3. Trigger a pinned notice. You can do this by Broswer DevTools -> **Network** tab -> set **throttling** to **offline** and attempt to **Publish** a post.
4. Observe that the background color of the notice container.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="1470" height="800" alt="Screenshot 2026-06-08 at 6 24 36 PM" src="https://github.com/user-attachments/assets/6d9175a6-ab36-4eb8-b619-599a16a4cf0f" />

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini and Claude
Used for: Reviewing the existing implementation and suggesting the changes. Final decisions and edits were made by me.