### PR TITLE
Elements: Align class name parsing with custom CSS implementation

### DIFF
--- a/backport-changelog/7.1/12028.md
+++ b/backport-changelog/7.1/12028.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/12028
 
 * https://github.com/WordPress/gutenberg/pull/78841
+* https://github.com/WordPress/gutenberg/pull/79023

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -92,32 +92,31 @@ function gutenberg_enqueue_block_custom_css() {
  * } $block
  */
 function gutenberg_render_custom_css_class_name( $block_content, $block ) {
-	$class_name_attr = $block['attrs']['className'] ?? null;
-
-	if ( ! is_string( $class_name_attr ) || ! str_contains( $class_name_attr, 'wp-custom-css-' ) ) {
+	$class_name_attr   = $block['attrs']['className'] ?? null;
+	$class_name_prefix = 'wp-custom-css-';
+	if ( ! is_string( $class_name_attr ) || ! str_contains( $class_name_attr, $class_name_prefix ) ) {
 		return $block_content;
 	}
 
 	// Parse out the 'wp-custom-css-*' class name added by gutenberg_render_custom_css_support_styles().
-	$custom_class_name = null;
-	$token_delimiter   = " \t\f\r\n";
-	$class_token       = strtok( $class_name_attr, $token_delimiter );
+	$matched_class_name = null;
+	$token_delimiter    = " \t\f\r\n";
+	$class_token        = strtok( $class_name_attr, $token_delimiter );
 	while ( false !== $class_token ) {
-		if ( str_starts_with( $class_token, 'wp-custom-css-' ) ) {
-			$custom_class_name = $class_token;
+		if ( str_starts_with( $class_token, $class_name_prefix ) ) {
+			$matched_class_name = $class_token;
 			break;
 		}
 		$class_token = strtok( $token_delimiter );
 	}
-	if ( null === $custom_class_name ) {
+	if ( null === $matched_class_name ) {
 		return $block_content;
 	}
 
 	$tags = new WP_HTML_Tag_Processor( $block_content );
-
 	if ( $tags->next_tag() ) {
 		$tags->add_class( 'has-custom-css' );
-		$tags->add_class( $custom_class_name );
+		$tags->add_class( $matched_class_name );
 	}
 
 	return $tags->get_updated_html();

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -232,28 +232,43 @@ function gutenberg_render_elements_support_styles( $parsed_block ) {
  *
  * @see gutenberg_render_elements_support_styles
  *
- * @param  string $block_content Rendered block content.
- * @param  array  $block         Block object.
+ * @param string $block_content Rendered block content.
+ * @param array  $block         Block object.
+ * @return string               Filtered block content.
  *
- * @return string                Filtered block content.
+ * @phpstan-param array{
+ *     attrs: array{
+ *         className?: string,
+ *         ...
+ *     },
+ *     ...
+ * } $block
  */
 function gutenberg_render_elements_class_name( $block_content, $block ) {
-	$class_string = $block['attrs']['className'] ?? '';
-
-	if ( ! is_string( $class_string ) ) {
+	$class_name_attr   = $block['attrs']['className'] ?? null;
+	$class_name_prefix = 'wp-elements-';
+	if ( ! is_string( $class_name_attr ) || ! str_contains( $class_name_attr, $class_name_prefix ) ) {
 		return $block_content;
 	}
 
-	preg_match( '/\bwp-elements-\S+\b/', $class_string, $matches );
-
-	if ( empty( $matches ) ) {
+	// Parse out the 'wp-elements-*' class name.
+	$matched_class_name = null;
+	$token_delimiter    = " \t\f\r\n";
+	$class_token        = strtok( $class_name_attr, $token_delimiter );
+	while ( false !== $class_token ) {
+		if ( str_starts_with( $class_token, $class_name_prefix ) ) {
+			$matched_class_name = $class_token;
+			break;
+		}
+		$class_token = strtok( $token_delimiter );
+	}
+	if ( null === $matched_class_name ) {
 		return $block_content;
 	}
 
 	$tags = new WP_HTML_Tag_Processor( $block_content );
-
 	if ( $tags->next_tag() ) {
-		$tags->add_class( $matches[0] );
+		$tags->add_class( $matched_class_name );
 	}
 
 	return $tags->get_updated_html();

--- a/phpunit/block-supports/elements-test.php
+++ b/phpunit/block-supports/elements-test.php
@@ -117,6 +117,28 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a 'my-wp-elements-*' class name is skipped from processing.
+	 *
+	 * @covers ::gutenberg_render_elements_class_name
+	 */
+	public function test_elements_block_support_class_with_invalid_elements_prefix() {
+		$block = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(
+				'className' => 'my-wp-elements-foo',
+			),
+		);
+
+		$block_content = "<p>Test</p>\n";
+
+		$this->assertSame(
+			$block_content,
+			gutenberg_render_elements_class_name( $block_content, $block ),
+			'Block content should be returned unchanged when className lacks a class with the expected prefix'
+		);
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array


### PR DESCRIPTION
## What?

Follow-up to #78841 and its core companion https://github.com/WordPress/wordpress-develop/pull/12028 (committed in [r62475](https://core.trac.wordpress.org/changeset/62475)), bringing the additional hardening developed during the core review back to Gutenberg so the two stay in sync.

During the core review of #78841, `wp_render_elements_class_name()` was aligned with `wp_render_custom_css_class_name()` (#78217 / [r62359](https://core.trac.wordpress.org/changeset/62359)). This PR applies the same alignment here.

## Why?

`gutenberg_render_elements_class_name()` matched the `wp-elements-*` class with `\bwp-elements-\S+\b`. Because a hyphen is a `\b` word boundary in regex, a class such as `my-wp-elements-foo` was **erroneously matched**. Parsing the `className` attribute into tokens per the HTML spec and checking each with `str_starts_with()` fixes this, and avoids the regex engine entirely for the common case via an upfront `str_contains()` short-circuit.

## How?

- **`gutenberg_render_elements_class_name()`**: replaced the regex with a `str_contains()` guard followed by a `strtok()` walk over the class tokens; added an `@phpstan-param` array shape for `$block`.
- **`gutenberg_render_custom_css_class_name()`**: refactored to use a shared `$class_name_prefix` variable and `$matched_class_name` so both functions remain structurally identical.
- Added a regression test for the `my-wp-elements-foo` substring-prefix case (the non-string `className` test already existed).

These match the corresponding core changes in [r62475](https://core.trac.wordpress.org/changeset/62475) byte-for-byte (modulo the `gutenberg_`/`wp_` prefixes).

## Testing Instructions

- Run the elements block support PHP tests: `npm run test:unit:php -- --filter WP_Block_Supports_Elements_Test`
- Verify `test_elements_block_support_class_with_invalid_elements_prefix` and `test_elements_block_support_class_with_non_string_class_name` pass, and existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
