### PR TITLE
Media Editor: Remove lag when toggling the sidebar

### DIFF
--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Media Editor: Stop the details/crop sidebar overflowing the modal between the small and medium breakpoints.
+-   Media Editor: Remove the lag when toggling the details/crop sidebar open or closed.
 
 ### Code Quality
 

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -147,9 +147,20 @@
 	// present (empty when closed), so touching it unconditionally would paint an
 	// empty box over the canvas.
 
-	// Column (>= small): pull the open panel back in-flow at the sidebar width,
-	// so the controls sit beside the canvas down to 600px.
-	@include break-small() {
+	// Column (small–medium): between 600px and 782px `ComplementaryArea` is
+	// still in its mobile mode (inline `100vw`, see above) and the skeleton
+	// sidebar is absolutely positioned, so pull the open panel back in-flow at
+	// the sidebar width to sit it beside the canvas as a column.
+	//
+	// Bounded *below* the medium breakpoint on purpose. From 782px up,
+	// `InterfaceSkeleton` already makes the sidebar a `position: relative`,
+	// `width: auto` column and `ComplementaryArea` animates its width to
+	// `$sidebar-width` — exactly like the main editor. Pinning the width with
+	// `!important` there would freeze that open/close tween (the panel would
+	// sit mounted and unchanged for the animation's duration, then pop in or
+	// out), so we leave it to the skeleton. Below 782px there's nothing to
+	// freeze: `ComplementaryArea` zeroes the animation duration in mobile mode.
+	@media (min-width: #{ breakpoints.$break-small }) and (max-width: #{ (breakpoints.$break-medium - 1) }) {
 		.interface-interface-skeleton__sidebar:has(.interface-complementary-area__fill) {
 			position: relative !important;
 		}


### PR DESCRIPTION
## What

Follow up to https://github.com/WordPress/gutenberg/pull/78931

Removes the visible lag when toggling the media editor's details/crop sidebar open or closed.

Props to @talldan for the eagle eyes.

## Why

The sidebar open/close is animated by `ComplementaryAreaFill`, which tweens the panel's `width` (an inline style) over 300ms and keeps the panel mounted via `AnimatePresence` until that tween finishes.

Since https://github.com/WordPress/gutenberg/pull/78931, the media editor pins the sidebar width per breakpoint with `!important`.  The side effect: it clobbers the inline width the animation drives, so the 300ms tween produces no visible motion. The panel just sits mounted and unchanged for 300ms, then pops in or out. 


## Manual testing

1. Open the site or post editor and open the media library, then open an image in the media editor (the modal with the Details/Crop sidebar).
2. With the browser at least 782px wide, click the sidebar toggle in the header to close the sidebar. It should disappear immediately, with no pause.
3. Click it again to reopen. It should appear immediately.
4. Confirm there is no regression in the main editor: open the post editor settings sidebar and toggle it. It should still animate smoothly.
5. Optional: narrow the window below 782px and confirm the sidebar still collapses to a full-width overlay and toggles cleanly.



https://github.com/user-attachments/assets/bd98dc07-464c-49ac-99b8-9262f2c1cf1d

