### PR TITLE
CI: Suppress lint:js warnings on static checks

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -81,7 +81,8 @@ jobs:
 
             - name: Lint JavaScript
               if: ${{ matrix.annotations }}
-              run: npm run lint:js -- --format compact
+              # `--quiet` reports only errors so they aren't buried under warnings in the CI log.
+              run: npm run lint:js -- --format compact --quiet
 
             - name: Lint Styles
               if: ${{ matrix.annotations }}

--- a/packages/base-styles/temp-lint-check.js
+++ b/packages/base-styles/temp-lint-check.js
@@ -1,4 +1,0 @@
-/**
- * Temporary file to verify CI lint error visibility. Remove before merge.
- */
-const unusedVariable = 42;

--- a/packages/base-styles/temp-lint-check.js
+++ b/packages/base-styles/temp-lint-check.js
@@ -1,0 +1,4 @@
+/**
+ * Temporary file to verify CI lint error visibility. Remove before merge.
+ */
+const unusedVariable = 42;


### PR DESCRIPTION
## What?

Add `--quiet` to the `Lint JavaScript` step of the static checks workflow so `lint:js` reports only errors on CI.

## Why?

`actions/setup-node` registers the `eslint-compact` problem matcher, so every ESLint warning is emitted as a `##[warning]` line. Hundreds of `react-hooks/exhaustive-deps` warnings on pre-existing files bury the actual error in the log. These warnings are not useful as PR annotations either, since GitHub only annotates lines in the diff and caps annotations at 10 per step.

## How?

`--quiet` makes ESLint drop warnings before output, so only errors are reported and a real error stands out. Error annotations on the diff are unaffected, and local `npm run lint:js` still shows warnings.

This PR includes a temporary commit introducing a lint error to demonstrate the result. See [the resulting run](https://github.com/WordPress/gutenberg/actions/runs/27188981942/job/80264399084?pr=79025): the error is reported cleanly without warning noise. That commit will be removed before merge.

<img width="1043" height="174" alt="image" src="https://github.com/user-attachments/assets/a2a5e996-c439-4f06-8c68-eecc2ac5ddd0" />


## Testing Instructions

1. Check the `Static Analysis` → `Lint JavaScript` step logs and confirm no `react-hooks/exhaustive-deps` warning lines appear.
2. Confirm genuine lint errors are still reported and still fail the job.
3. Run `npm run lint:js` locally and confirm warnings are still shown (the change is CI-only).

## Use of AI Tools

I used Claude Code to investigate the problem-matcher behavior and draft this change. I reviewed and take responsibility for the result.
