### PR TITLE
e2e-test-utils-playwright: start transpiling again, but faster

### DIFF
--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -25,13 +25,13 @@
 		"npm": ">=8.19.2"
 	},
 	"files": [
-		"src",
+		"build",
 		"build-types"
 	],
 	"exports": {
 		".": {
 			"types": "./build-types/index.d.ts",
-			"default": "./src/index.ts"
+			"default": "./build/index.js"
 		},
 		"./package.json": "./package.json"
 	},
@@ -53,5 +53,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json"
 	}
 }

--- a/packages/e2e-test-utils-playwright/tsconfig.json
+++ b/packages/e2e-test-utils-playwright/tsconfig.json
@@ -6,6 +6,10 @@
 		"composite": false,
 		"module": "Node16",
 		"moduleResolution": "node16",
+		"noEmit": false,
+		"outDir": "build",
+		"sourceMap": true,
+		"emitDeclarationOnly": false,
 		"allowJs": true,
 		"checkJs": false
 	}

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -360,7 +360,7 @@ async function runPerformanceTests( branches, options ) {
 
 	logAtIndent( 2, 'Installing dependencies and building' );
 	await runShellScript(
-		`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm ci && npx playwright install chromium --with-deps"`,
+		`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm ci && npm run build --workspace @wordpress/e2e-test-utils-playwright && npx playwright install chromium --with-deps"`,
 		testRunnerDir
 	);
 


### PR DESCRIPTION
Fixes #79018 and also the issue with published `e2e-test-utils-playwright` package described in https://github.com/WordPress/gutenberg/pull/78847#issuecomment-4626980411

We need to start transpiling the package files again. But this time not as part of the monorepo-wide `npm run build`, but only a targeted build of this single package. Using `tsc` for the transpilation, unlike esbuild for everything else. It turns out that the `tsconfig.json` was already configured for emitting transpiled files for this one package. Before I deleted that in #78847.