### PR TITLE
Enhancements: Use theme supports for disabling Font Library

### DIFF
--- a/lib/block-editor-settings.php
+++ b/lib/block-editor-settings.php
@@ -121,6 +121,10 @@ function gutenberg_get_block_editor_settings( $settings ) {
 
 	$settings['canEditCSS'] = current_user_can( 'edit_css' );
 
+	if ( ! isset( $settings['fontLibraryEnabled'] ) ) {
+		$settings['fontLibraryEnabled'] = current_theme_supports( 'font-library' );
+	}
+
 	return $settings;
 }
 add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings', 0 );

--- a/lib/compat/wordpress-7.0/fonts.php
+++ b/lib/compat/wordpress-7.0/fonts.php
@@ -7,21 +7,47 @@
 
 // Priority 11 to run after Core's menu.php sets up the fonts menu.
 add_action( 'admin_menu', 'gutenberg_register_fonts_menu_item', 11 );
+add_action( 'setup_theme', 'gutenberg_setup_font_library_theme_support' );
+
+/**
+ * Adds default theme support for the font library.
+ */
+function gutenberg_setup_font_library_theme_support() {
+	add_theme_support( 'font-library' );
+}
 
 /**
  * Registers the Fonts menu item under Appearance using the font-library page.
  * Removes Core's fonts menu item first to prevent duplication.
  */
 function gutenberg_register_fonts_menu_item() {
+	$has_font_library_support = current_theme_supports( 'font-library' );
+
 	// Remove Core's fonts menu item if it exists.
 	remove_submenu_page( 'themes.php', 'font-library.php' );
 
-	add_submenu_page(
-		'themes.php',
-		__( 'Fonts', 'gutenberg' ),
-		__( 'Fonts', 'gutenberg' ),
-		'edit_theme_options',
-		'font-library-wp-admin',
-		'gutenberg_font_library_wp_admin_render_page'
-	);
+	if ( $has_font_library_support ) {
+		add_submenu_page(
+			'themes.php',
+			__( 'Fonts', 'gutenberg' ),
+			__( 'Fonts', 'gutenberg' ),
+			'edit_theme_options',
+			'font-library-wp-admin',
+			'gutenberg_font_library_wp_admin_render_page'
+		);
+	} else {
+		// Prevent direct access to the Font Library pages.
+		$die_if_disabled = static function () {
+			wp_die(
+				__( 'This feature has been disabled.', 'gutenberg' ),
+				__( 'Disabled', 'gutenberg' ),
+				array(
+					'response'  => 403,
+					'back_link' => true,
+				)
+			);
+		};
+		add_action( 'load-appearance_page_font-library', $die_if_disabled );
+		add_action( 'load-appearance_page_font-library-wp-admin', $die_if_disabled );
+	}
 }


### PR DESCRIPTION
## What?

Closes #79019

Introduce a `font-library` theme support that provides a single mechanism for enabling or disabling the Font Library across both the Block Editor and the WP Admin interface.

When the Font Library is disabled using `remove_theme_support( 'font-library' )`, the Font Library UI is no longer available in the editor and the Fonts admin screen is removed and cannot be accessed directly.

## Why?

Prior to this change, developers could disable the Font Library in the editor by setting `fontLibraryEnabled` to `false` via the `block_editor_settings_all` filter.

However, after the introduction of the dedicated Fonts admin screen, this approach no longer fully disabled the feature. The editor UI could be hidden while the Fonts screen under Appearance remained accessible through both the menu and direct URLs.

This creates an inconsistent experience and requires developers to implement multiple custom solutions to fully disable the feature.

Providing a dedicated `font-library` theme support aligns with existing WordPress patterns and offers a single, centralized way to control Font Library availability.

## How?

This PR introduces a new `font-library` theme support and uses it as the source of truth for Font Library availability.

### Font Library Admin Screen

* Core's Fonts submenu registration is removed to avoid duplicate menu items.
* The Gutenberg Fonts screen is only registered when the active theme supports `font-library`.
* When the feature is disabled, direct access to:

  * `themes.php?page=font-library.php`
  * `themes.php?page=font-library-wp-admin`

  is blocked and returns an error response.

### Block Editor Settings

* `gutenberg_get_block_editor_settings()` now derives `fontLibraryEnabled` from `current_theme_supports( 'font-library' )`.
* This ensures the editor UI automatically reflects the enabled/disabled state of the feature.
* Existing customizations using `block_editor_settings_all` continue to work because they can still override the setting through the existing filter.

## Testing Instructions

### Default Behavior

1. Activate Gutenberg.
2. Open the Site Editor.
3. Verify the Font Library is available from the Typography tools.
4. Navigate to **Appearance → Fonts**.
5. Verify the Fonts screen is accessible.

### Disable the Font Library

1. Add the following to the active theme:

```php
add_action(
	'after_setup_theme',
	function() {
		remove_theme_support( 'font-library' );
	}
);
```

2. Refresh the WP Admin.
3. Verify the **Fonts** submenu is no longer visible under **Appearance**.
4. Open the Site Editor.
5. Verify Font Library controls are no longer available.

### Direct URL Access

1. With the theme support removed, visit:

```
/wp-admin/themes.php?page=font-library.php
```

2. Verify access is denied.

3. Visit:

```
/wp-admin/themes.php?page=font-library-wp-admin
```

4. Verify access is denied.

### Backward Compatibility

1. Add the following filter:

```php
add_filter(
	'block_editor_settings_all',
	function( $settings ) {
		$settings['fontLibraryEnabled'] = false;
		return $settings;
	}
);
```

2. Verify the Font Library is still disabled in the editor.
3. Verify no regressions are introduced to existing customization workflows.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

