### PR TITLE
Fix: Set list-item rich-text wrapper to inline

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -25,6 +25,7 @@
 @use "./icon/editor.scss" as *;
 @use "./image/editor.scss" as *;
 @use "./latest-posts/editor.scss" as *;
+@use "./list-item/editor.scss" as *;
 @use "./math/editor.scss" as *;
 @use "./media-text/editor.scss" as *;
 @use "./more/editor.scss" as *;

--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -66,5 +66,6 @@
 	"selectors": {
 		"root": ".wp-block-list > li",
 		"border": ".wp-block-list:not(.wp-block-list .wp-block-list) > li"
-	}
+	},
+	"editorStyle": "wp-block-list-item-editor"
 }

--- a/packages/block-library/src/list-item/editor.scss
+++ b/packages/block-library/src/list-item/editor.scss
@@ -1,0 +1,4 @@
+// Prevent the RichText wrapper from behaving as a block element.
+.wp-block-list-item > .block-editor-rich-text__editable.rich-text {
+	display: inline;
+}


### PR DESCRIPTION
## What?
Closes #78499

## Why?
When a theme applies `list-style-position: inside` to `<ul>` or `<ol>` elements, the editor preview breaks visual parity with the frontend. The bullet point renders on a separate line above the list item text. 

This happens because the editor injects a `<div class="block-editor-rich-text__editable">` to make the text editable. Because `<div>` is a block-level element, it forces the text to drop below the "inside" bullet point. 

## How?
Added `packages/block-library/src/list-item/editor.scss` to force the direct `.block-editor-rich-text__editable` child of a list item to `display: inline`. This prevents the block-level break and allows the text to flow naturally next to the bullet, perfectly mirroring the frontend DOM behavior.

## Testing Instructions
1. Add the following CSS to the site (via Appearance > Customize > Additional CSS, or theme styles):
   ```css
   ul { list-style-position: inside; }
   ```
2. Open the Block Editor and add a List block with a few items.
3. The text correctly aligns inline with the bullet point, matching the frontend.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="2938" height="1302" alt="image" src="https://github.com/user-attachments/assets/6cb1c2c1-b68a-4a86-abc6-46b00ea0aacd" />|<img width="2922" height="1274" alt="image" src="https://github.com/user-attachments/assets/caf5f7db-c55f-40d3-ab6d-d43a31c223fb" />|
