### PR TITLE
Navigable Container: Hoist getFocusableContext out of the component

### DIFF
--- a/packages/components/src/navigable-container/container.tsx
+++ b/packages/components/src/navigable-container/container.tsx
@@ -6,7 +6,7 @@ import type { ForwardedRef } from 'react';
 /**
  * WordPress dependencies
  */
-import { forwardRef, useRef, useEffect, useCallback } from '@wordpress/element';
+import { forwardRef, useRef, useEffect } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 import { focus } from '@wordpress/dom';
 
@@ -29,6 +29,25 @@ function cycleValue( value: number, total: number, offset: number ) {
 	return nextValue;
 }
 
+function getFocusableContext(
+	container: HTMLElement | null,
+	target: Element,
+	tabbableOnly: boolean
+) {
+	if ( ! container ) {
+		return null;
+	}
+
+	const finder = tabbableOnly ? focus.tabbable : focus.focusable;
+	const focusables = finder.find( container );
+
+	const index = focusables.indexOf( target as HTMLElement );
+	if ( index > -1 && target ) {
+		return { index, target, focusables };
+	}
+	return null;
+}
+
 function UnforwardedNavigableContainer(
 	{
 		children,
@@ -43,33 +62,6 @@ function UnforwardedNavigableContainer(
 	ref: ForwardedRef< HTMLDivElement >
 ) {
 	const containerRef = useRef< HTMLDivElement | null >( null );
-
-	const getFocusableIndex = useCallback(
-		( focusables: Element[], target: Element ) => {
-			return focusables.indexOf( target );
-		},
-		[]
-	);
-
-	const getFocusableContext = useCallback(
-		( target: Element ) => {
-			if ( ! containerRef.current ) {
-				return null;
-			}
-
-			const finder = onlyBrowserTabstops
-				? focus.tabbable
-				: focus.focusable;
-			const focusables = finder.find( containerRef.current );
-
-			const index = getFocusableIndex( focusables, target );
-			if ( index > -1 && target ) {
-				return { index, target, focusables };
-			}
-			return null;
-		},
-		[ onlyBrowserTabstops, getFocusableIndex ]
-	);
 
 	useEffect( () => {
 		const container = containerRef.current;
@@ -114,7 +106,11 @@ function UnforwardedNavigableContainer(
 				return;
 			}
 
-			const context = getFocusableContext( activeElement );
+			const context = getFocusableContext(
+				container,
+				activeElement,
+				!! onlyBrowserTabstops
+			);
 			if ( ! context ) {
 				return;
 			}
@@ -151,7 +147,7 @@ function UnforwardedNavigableContainer(
 		stopNavigationEvents,
 		cycle,
 		onNavigate,
-		getFocusableContext,
+		onlyBrowserTabstops,
 	] );
 
 	const mergedRef = useMergeRefs( [ containerRef, ref ] );

--- a/packages/components/src/navigable-container/container.tsx
+++ b/packages/components/src/navigable-container/container.tsx
@@ -30,19 +30,15 @@ function cycleValue( value: number, total: number, offset: number ) {
 }
 
 function getFocusableContext(
-	container: HTMLElement | null,
+	container: HTMLElement,
 	target: Element,
 	tabbableOnly: boolean
 ) {
-	if ( ! container ) {
-		return null;
-	}
-
 	const finder = tabbableOnly ? focus.tabbable : focus.focusable;
 	const focusables = finder.find( container );
 
 	const index = focusables.indexOf( target as HTMLElement );
-	if ( index > -1 && target ) {
+	if ( index > -1 ) {
 		return { index, target, focusables };
 	}
 	return null;
@@ -107,7 +103,7 @@ function UnforwardedNavigableContainer(
 			}
 
 			const context = getFocusableContext(
-				container,
+				container!,
 				activeElement,
 				!! onlyBrowserTabstops
 			);


### PR DESCRIPTION
## What?
A minor follow-up to #77171.

Moves `getFocusableContext` to a module-level function and inlines the trivial `getFocusableIndex` helper into a plain `indexOf` call. Removes the now-unneeded `useCallback` wrappers and import.

## Why?
The helpers didn't depend on component render state, so wrapping them in `useCallback` added memoization overhead and dependency-array bookkeeping for no benefit. Hoisting them simplifies the effect's dependencies (`onlyBrowserTabstops` instead of a memoized callback) and makes the logic easier to read and test. No behavior change.

## Testing Instructions
CI checks are green.

## Use of AI Tools

Assisted by Claude.
