### PR TITLE
Theme: Add Figma scopes to element size tokens

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -18,6 +18,10 @@
 
 -   Increase the contrast target of `stroke1` from `2.6` to `2.9` so that, on the default scale, it lands between `gray100` and `gray200`. This regenerates `stroke1` for every ramp and updates the values of `--wpds-color-stroke-surface-{brand,error,info,success,warning,neutral-weak}` and `--wpds-color-bg-track-neutral-weak` ([#77599](https://github.com/WordPress/gutenberg/pull/77599)).
 
+### Internal
+
+-   Add Figma `WIDTH_HEIGHT` scopes to `--wpds-dimension-size-*` design tokens ([#79032](https://github.com/WordPress/gutenberg/pull/79032)).
+
 ## 0.14.0 (2026-05-27)
 
 ### Breaking Changes

--- a/packages/theme/tokens/dimension.json
+++ b/packages/theme/tokens/dimension.json
@@ -154,35 +154,59 @@
 		"size": {
 			"5xs": {
 				"$value": "{wpds-dimension.primitive.space.10}",
-				"$description": "Notification indicators"
+				"$description": "Notification indicators",
+				"$extensions": {
+					"com.figma.scopes": [ "WIDTH_HEIGHT" ]
+				}
 			},
 			"4xs": {
 				"$value": "{wpds-dimension.primitive.space.20}",
-				"$description": "Visual size for small interactive elements like resize handles"
+				"$description": "Visual size for small interactive elements like resize handles",
+				"$extensions": {
+					"com.figma.scopes": [ "WIDTH_HEIGHT" ]
+				}
 			},
 			"3xs": {
 				"$value": "{wpds-dimension.primitive.space.30}",
-				"$description": "Small markers"
+				"$description": "Small markers",
+				"$extensions": {
+					"com.figma.scopes": [ "WIDTH_HEIGHT" ]
+				}
 			},
 			"2xs": {
 				"$value": "{wpds-dimension.primitive.space.40}",
-				"$description": "For small controls like checkboxes and radios, or small decorative icons"
+				"$description": "For small controls like checkboxes and radios, or small decorative icons",
+				"$extensions": {
+					"com.figma.scopes": [ "WIDTH_HEIGHT" ]
+				}
 			},
 			"xs": {
 				"$value": "{wpds-dimension.primitive.space.50}",
-				"$description": "For medium sized icons"
+				"$description": "For medium sized icons",
+				"$extensions": {
+					"com.figma.scopes": [ "WIDTH_HEIGHT" ]
+				}
 			},
 			"sm": {
 				"$value": "{wpds-dimension.primitive.space.60}",
-				"$description": "For icons and small buttons"
+				"$description": "For icons and small buttons",
+				"$extensions": {
+					"com.figma.scopes": [ "WIDTH_HEIGHT" ]
+				}
 			},
 			"md": {
 				"$value": "{wpds-dimension.primitive.space.70}",
-				"$description": "For medium-sized buttons and inputs"
+				"$description": "For medium-sized buttons and inputs",
+				"$extensions": {
+					"com.figma.scopes": [ "WIDTH_HEIGHT" ]
+				}
 			},
 			"lg": {
 				"$value": "{wpds-dimension.primitive.space.80}",
-				"$description": "Default size for buttons and inputs"
+				"$description": "Default size for buttons and inputs",
+				"$extensions": {
+					"com.figma.scopes": [ "WIDTH_HEIGHT" ]
+				}
 			}
 		},
 		"surface-width": {


### PR DESCRIPTION

<img width="1094" height="754" alt="Screenshot 2026-06-09 at 09 19 40" src="https://github.com/user-attachments/assets/a60f19a3-da46-42a6-80ed-2eaceb7a0e2f" />


Follow up to https://github.com/WordPress/gutenberg/pull/76545.

## What

Adds `com.figma.scopes` of `WIDTH_HEIGHT` to the `wpds-dimension.size.*` element size tokens (`5xs` through `lg`) in `packages/theme/tokens/dimension.json`.

## Why

Without a Figma scope defined as an `$extensions` entry, these tokens aren't surfaced as size options in Figma's variable pickers when designers are sizing layers.

Adding the `WIDTH_HEIGHT` scope makes them importable and selectable in the appropriate context, consistent with how the existing `surface-width` tokens are scoped.

## How

- Added an `$extensions` block with `"com.figma.scopes": [ "WIDTH_HEIGHT" ]` to each of the eight `size` tokens, mirroring the established pattern already used by `surface-width`.
- No value or naming changes — purely additive metadata, so there is no impact on the generated CSS custom properties or any consuming code.

### Testing Instructions

1. Import `packages/theme/tokens/dimension.json` into Figma.
2. Confirm the `wpds-dimension/size/*` variables import with the `WIDTH_HEIGHT` scope applied.
3. When sizing a layer (width/height), confirm the `size` tokens are offered in the variable picker.

> [!NOTE]
> Unfortunately Figma's scoping system doesn't support targeting height or width individually, only both together, so despite it not matching their intended purpose it will be possible to assign size tokens to widths in Figma.