### PR TITLE
RichText: Remove dead native-only prop filtering

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -51,36 +51,6 @@ inputEventContext.displayName = 'inputEventContext';
 
 const instanceIdKey = Symbol( 'instanceId' );
 
-/**
- * Removes props used for the native version of RichText so that they are not
- * passed to the DOM element and log warnings.
- *
- * @param {Object} props Props to filter.
- *
- * @return {Object} Filtered props.
- */
-function removeNativeProps( props ) {
-	const {
-		__unstableMobileNoFocusOnMount,
-		deleteEnter,
-		placeholderTextColor,
-		textAlign,
-		selectionColor,
-		tagsToEliminate,
-		disableEditingMenu,
-		fontSize,
-		fontFamily,
-		fontWeight,
-		fontStyle,
-		minWidth,
-		maxWidth,
-		disableSuggestions,
-		disableAutocorrection,
-		...restProps
-	} = props;
-	return restProps;
-}
-
 export function RichTextWrapper(
 	{
 		children,
@@ -113,8 +83,6 @@ export function RichTextWrapper(
 	},
 	forwardedRef
 ) {
-	props = removeNativeProps( props );
-
 	if ( onSplit ) {
 		deprecated( 'wp.blockEditor.RichText onSplit prop', {
 			since: '6.4',
@@ -532,7 +500,7 @@ const PublicForwardedRichTextContainer = forwardRef( ( props, ref ) => {
 			__unstableAllowPrefixTransformations,
 			readOnly,
 			...contentProps
-		} = removeNativeProps( props );
+		} = props;
 		return (
 			<Tag
 				ref={ ref }

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -61,7 +61,6 @@ function PullQuoteEdit( {
 							// translators: placeholder text used for the quote
 							__( 'Add quote' )
 						}
-						textAlign="center"
 					/>
 					{ shouldShowCitation && (
 						<RichText
@@ -80,8 +79,6 @@ function PullQuoteEdit( {
 								} )
 							}
 							className="wp-block-pullquote__citation"
-							__unstableMobileNoFocusOnMount
-							textAlign="center"
 							__unstableOnSplitAtEnd={ () =>
 								insertBlocksAfter(
 									createBlock( getDefaultBlockName() )

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -108,7 +108,6 @@ export default function QuoteEdit( {
 					isSelected={ isSelected }
 					attributes={ attributes }
 					setAttributes={ setAttributes }
-					__unstableMobileNoFocusOnMount
 					icon={ verse }
 					label={ __( 'Quote citation' ) }
 					placeholder={


### PR DESCRIPTION
## What?

Removes `removeNativeProps()` from `RichText` and the now-unused native-only props still passed at its call sites.

## Why?

`removeNativeProps()` stripped props that only ever existed for the React Native version of `RichText` (`placeholderTextColor`, `selectionColor`, `__unstableMobileNoFocusOnMount`, native `textAlign`, etc.) so they wouldn't leak onto the DOM element and log warnings. With native support removed in #78747, nothing passes these props anymore — the filter is dead code.

The only call sites still passing such props were:

- **Pullquote**: `textAlign="center"` (×2) and `__unstableMobileNoFocusOnMount`
- **Quote**: `__unstableMobileNoFocusOnMount` (forwarded through the `Caption` util to `RichText`)

`disableSuggestions` is a legitimate web prop on `URLInput` and is left untouched. Pullquote centering is handled via CSS (`wp-block-pullquote` styles), not the stripped native `textAlign` prop.

## Testing Instructions

- Edit Pullquote (text + citation) and Quote (citation) blocks — focus, typing, splitting, and centering all behave identically.
- Confirm no new React DOM "unknown prop" warnings appear in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)