### PR TITLE
Editor: Remove dead native guard in block removal warnings

### DIFF
--- a/packages/editor/src/components/block-removal-warnings/index.js
+++ b/packages/editor/src/components/block-removal-warnings/index.js
@@ -95,13 +95,6 @@ export default function BlockRemovalWarnings() {
 		[ currentPostType ]
 	);
 
-	// `BlockRemovalWarnings` is rendered in the editor provider, a shared component
-	// across react native and web. However, `BlockRemovalWarningModal` is web only.
-	// Check it exists before trying to render it.
-	if ( ! BlockRemovalWarningModal ) {
-		return null;
-	}
-
 	if ( ! removalRulesForPostType ) {
 		return null;
 	}


### PR DESCRIPTION
## What?

Removes the `if ( ! BlockRemovalWarningModal ) return null;` guard (and its stale comment) in `BlockRemovalWarnings`.

## Why?

The guard existed because `BlockRemovalWarningModal` was a **web-only** private API of `block-editor`, absent in the React Native build where this provider-level component was shared across native and web. With native support removed in #78747, the modal is now unconditionally registered in `block-editor`'s private APIs (`private-apis.js`), so the check can never be falsy — it's dead code, and the comment referencing "react native" is inaccurate.

## Testing Instructions

- Trigger a block-removal warning (e.g. delete a Query/Post Template block, or a navigation-bound block) and confirm the warning modal still appears.
- Confirm post types without removal rules still render nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)