### PR TITLE
Docs: Remove stale mobile references from tooling and primitives docs

### DIFF
--- a/packages/primitives/src/block-quotation/README.md
+++ b/packages/primitives/src/block-quotation/README.md
@@ -1,6 +1,6 @@
 # Block Quotation
 
-A drop-in replacement for the HTML [blockquote](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote) element that works both on the web and in the mobile apps. It indicates that the enclosed text is an extended quotation.
+A drop-in replacement for the HTML [blockquote](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote) element. It indicates that the enclosed text is an extended quotation.
 
 ## Usage
 

--- a/packages/primitives/src/horizontal-rule/README.md
+++ b/packages/primitives/src/horizontal-rule/README.md
@@ -1,6 +1,6 @@
 # HorizontalRule
 
-A drop-in replacement for the HTML [hr](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr) element that works both on the web and in the mobile apps. It represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section.
+A drop-in replacement for the HTML [hr](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr) element. It represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section.
 
 ## Usage
 

--- a/tools/docs/manifest.cjs
+++ b/tools/docs/manifest.cjs
@@ -20,9 +20,8 @@ const blockCategoryPaths = glob(
 );
 const componentPaths = glob( 'packages/components/src/*/**/README.md', {
 	cwd: ROOT_DIR,
-	// Don't expose documentation for mobile only and private components just yet.
+	// Don't expose documentation for private components just yet.
 	ignore: [
-		'**/src/mobile/**/README.md',
 		'packages/components/src/theme/README.md',
 		'packages/components/src/view/README.md',
 		'packages/components/src/menu/README.md',


### PR DESCRIPTION
## What?

Cleans up leftover mobile references in docs tooling and primitive component docs after the React Native removal (#78747):

- `tools/docs/manifest.cjs` — removes the `'**/src/mobile/**/README.md'` ignore glob (no mobile component READMEs remain) and rewords the adjacent comment.
- `packages/primitives/src/block-quotation/README.md` & `horizontal-rule/README.md` — drops the "works both on the web and in the mobile apps" phrasing.

## Why?

The mobile glob now matches nothing, and the primitives docs describe a mobile target that no longer exists.

## Testing Instructions

- `npm run docs:gen` produces no changes to `docs/manifest.json` (verified — these edits are no-ops on generated output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)