### PR TITLE
Editor: Refactor AutosaveMonitor to a function component

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -130,27 +130,19 @@ Example:
 
 Monitors the changes made to the edited post and triggers autosave if necessary.
 
-The logic is straightforward: a check is performed every `props.interval` seconds. If any changes are detected, `props.autosave()` is called. The time between the change and the autosave varies but is no larger than `props.interval` seconds. Refer to the code below for more details, such as the specific way of detecting changes.
-
-There are two caveats:
-
--   If `props.isAutosaveable` happens to be false at a time of checking for changes, the check is retried every second.
--   The timer may be disabled by setting `props.disableIntervalChecks` to `true`. In that mode, any change will immediately trigger `props.autosave()`.
+The post is checked every `interval` seconds and autosaved when there is something new to save.
 
 _Usage_
 
 ```jsx
-<AutosaveMonitor interval={ 30000 } />
+<AutosaveMonitor interval={ 30 } />
 ```
 
 _Parameters_
 
--   _props_ `Object`: - The properties passed to the component.
--   _props.autosave_ `Function`: - The function to call when changes need to be saved.
--   _props.interval_ `number`: - The maximum time in seconds between an unsaved change and an autosave.
--   _props.isAutosaveable_ `boolean`: - If false, the check for changes is retried every second.
--   _props.disableIntervalChecks_ `boolean`: - If true, disables the timer and any change will immediately trigger `props.autosave()`.
--   _props.isDirty_ `boolean`: - Indicates if there are unsaved changes.
+-   _props_ `Object`: The component props.
+-   _props.interval_ `[number]`: Time in seconds between checks. Defaults to the editor's `autosaveInterval` setting.
+-   _props.autosave_ `[Function]`: Function to call when changes need to be saved. Defaults to the editor store's `autosave` action.
 
 ### BlockAlignmentToolbar
 

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -81,9 +81,10 @@ export default function AutosaveMonitor( { interval, autosave } ) {
 
 		const editsReference = getReferenceByDistinctEdits();
 		const hasNewEdits = editsReference !== lastEditsReferenceRef.current;
-		lastEditsReferenceRef.current = editsReference;
-
 		if ( hasNewEdits && isEditedPostDirty() && ! isAutosavingPost() ) {
+			// Only consume the edits reference when we autosave,
+			// so edits made during an in-flight autosave aren't skipped.
+			lastEditsReferenceRef.current = editsReference;
 			triggerAutosave();
 		}
 	}, autosaveInterval );

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -11,73 +11,107 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import { store as editorStore } from '../../store';
 
-export class AutosaveMonitor extends Component {
-	constructor( props ) {
-		super( props );
-		this.needsAutosave = !! ( props.isDirty && props.isAutosaveable );
-	}
+export function AutosaveMonitor( props ) {
+	const {
+		autosave,
+		isAutosaveable,
+		isAutosaving,
+		isDirty,
+		interval,
+		editsReference,
+		disableIntervalChecks,
+	} = props;
 
-	componentDidMount() {
-		if ( ! this.props.disableIntervalChecks ) {
-			this.setAutosaveTimer();
+	const needsAutosaveRef = useRef( !! ( isDirty && isAutosaveable ) );
+	const timerIdRef = useRef();
+
+	// Keep the latest props and timer handler accessible to the scheduled
+	// timer, which runs outside of React's render cycle.
+	const propsRef = useRef( props );
+	const autosaveTimerHandlerRef = useRef();
+
+	const setAutosaveTimer = useCallback(
+		( timeout = propsRef.current.interval * 1000 ) => {
+			timerIdRef.current = setTimeout( () => {
+				autosaveTimerHandlerRef.current();
+			}, timeout );
+		},
+		[]
+	);
+
+	// Sync the refs after every render so the timer callback always reads the
+	// latest props when it eventually fires.
+	useEffect( () => {
+		propsRef.current = props;
+		autosaveTimerHandlerRef.current = () => {
+			if ( ! propsRef.current.isAutosaveable ) {
+				setAutosaveTimer( 1000 );
+				return;
+			}
+
+			if ( needsAutosaveRef.current ) {
+				needsAutosaveRef.current = false;
+				propsRef.current.autosave();
+			}
+
+			setAutosaveTimer();
+		};
+	} );
+
+	// Equivalent to `componentDidMount` / `componentWillUnmount`.
+	useEffect( () => {
+		if ( ! disableIntervalChecks ) {
+			setAutosaveTimer();
 		}
-	}
 
-	componentDidUpdate( prevProps ) {
-		if ( this.props.disableIntervalChecks ) {
-			if ( this.props.editsReference !== prevProps.editsReference ) {
-				this.props.autosave();
+		return () => {
+			clearTimeout( timerIdRef.current );
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	// Equivalent to `componentDidUpdate`. A single effect preserves the exact
+	// branch ordering of the original class component.
+	const isMountedRef = useRef( false );
+	const prevPropsRef = useRef( props );
+	useEffect( () => {
+		if ( ! isMountedRef.current ) {
+			isMountedRef.current = true;
+			prevPropsRef.current = props;
+			return;
+		}
+
+		const prevProps = prevPropsRef.current;
+		prevPropsRef.current = props;
+
+		if ( disableIntervalChecks ) {
+			if ( editsReference !== prevProps.editsReference ) {
+				autosave();
 			}
 			return;
 		}
 
-		if ( this.props.interval !== prevProps.interval ) {
-			clearTimeout( this.timerId );
-			this.setAutosaveTimer();
+		if ( interval !== prevProps.interval ) {
+			clearTimeout( timerIdRef.current );
+			setAutosaveTimer();
 		}
 
-		if ( ! this.props.isDirty ) {
-			this.needsAutosave = false;
+		if ( ! isDirty ) {
+			needsAutosaveRef.current = false;
 			return;
 		}
 
-		if ( this.props.isAutosaving && ! prevProps.isAutosaving ) {
-			this.needsAutosave = false;
+		if ( isAutosaving && ! prevProps.isAutosaving ) {
+			needsAutosaveRef.current = false;
 			return;
 		}
 
-		if ( this.props.editsReference !== prevProps.editsReference ) {
-			this.needsAutosave = true;
+		if ( editsReference !== prevProps.editsReference ) {
+			needsAutosaveRef.current = true;
 		}
-	}
+	} );
 
-	componentWillUnmount() {
-		clearTimeout( this.timerId );
-	}
-
-	setAutosaveTimer( timeout = this.props.interval * 1000 ) {
-		this.timerId = setTimeout( () => {
-			this.autosaveTimerHandler();
-		}, timeout );
-	}
-
-	autosaveTimerHandler() {
-		if ( ! this.props.isAutosaveable ) {
-			this.setAutosaveTimer( 1000 );
-			return;
-		}
-
-		if ( this.needsAutosave ) {
-			this.needsAutosave = false;
-			this.props.autosave();
-		}
-
-		this.setAutosaveTimer();
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
 /**

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -25,6 +25,11 @@ function useInterval( callback, intervalInSeconds ) {
 	}, [ callback ] );
 
 	useEffect( () => {
+		// Interval can be undefined before editor settings are populated.
+		if ( ! intervalInSeconds ) {
+			return;
+		}
+
 		const id = setInterval(
 			() => callbackRef.current(),
 			intervalInSeconds * 1000

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -1,9 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useRef } from '@wordpress/element';
-import { compose } from '@wordpress/compose';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -11,157 +10,83 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import { store as editorStore } from '../../store';
 
-export function AutosaveMonitor( props ) {
-	const {
-		autosave,
-		isAutosaveable,
-		isAutosaving,
-		isDirty,
-		interval,
-		editsReference,
-		disableIntervalChecks,
-	} = props;
+/**
+ * Calls `callback` every `intervalInSeconds`. The latest `callback` is always
+ * invoked without resetting the timer.
+ *
+ * @param {Function} callback          Function to call on each tick.
+ * @param {number}   intervalInSeconds Seconds between ticks.
+ */
+function useInterval( callback, intervalInSeconds ) {
+	const callbackRef = useRef( callback );
 
-	const needsAutosaveRef = useRef( !! ( isDirty && isAutosaveable ) );
-	const timerIdRef = useRef();
-
-	// Keep the latest props and timer handler accessible to the scheduled
-	// timer, which runs outside of React's render cycle.
-	const propsRef = useRef( props );
-	const autosaveTimerHandlerRef = useRef();
-
-	const setAutosaveTimer = useCallback(
-		( timeout = propsRef.current.interval * 1000 ) => {
-			timerIdRef.current = setTimeout( () => {
-				autosaveTimerHandlerRef.current();
-			}, timeout );
-		},
-		[]
-	);
-
-	// Sync the refs after every render so the timer callback always reads the
-	// latest props when it eventually fires.
 	useEffect( () => {
-		propsRef.current = props;
-		autosaveTimerHandlerRef.current = () => {
-			if ( ! propsRef.current.isAutosaveable ) {
-				setAutosaveTimer( 1000 );
-				return;
-			}
+		callbackRef.current = callback;
+	}, [ callback ] );
 
-			if ( needsAutosaveRef.current ) {
-				needsAutosaveRef.current = false;
-				propsRef.current.autosave();
-			}
-
-			setAutosaveTimer();
-		};
-	} );
-
-	// Equivalent to `componentDidMount` / `componentWillUnmount`.
 	useEffect( () => {
-		if ( ! disableIntervalChecks ) {
-			setAutosaveTimer();
-		}
-
-		return () => {
-			clearTimeout( timerIdRef.current );
-		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
-
-	// Equivalent to `componentDidUpdate`. A single effect preserves the exact
-	// branch ordering of the original class component.
-	const isMountedRef = useRef( false );
-	const prevPropsRef = useRef( props );
-	useEffect( () => {
-		if ( ! isMountedRef.current ) {
-			isMountedRef.current = true;
-			prevPropsRef.current = props;
-			return;
-		}
-
-		const prevProps = prevPropsRef.current;
-		prevPropsRef.current = props;
-
-		if ( disableIntervalChecks ) {
-			if ( editsReference !== prevProps.editsReference ) {
-				autosave();
-			}
-			return;
-		}
-
-		if ( interval !== prevProps.interval ) {
-			clearTimeout( timerIdRef.current );
-			setAutosaveTimer();
-		}
-
-		if ( ! isDirty ) {
-			needsAutosaveRef.current = false;
-			return;
-		}
-
-		if ( isAutosaving && ! prevProps.isAutosaving ) {
-			needsAutosaveRef.current = false;
-			return;
-		}
-
-		if ( editsReference !== prevProps.editsReference ) {
-			needsAutosaveRef.current = true;
-		}
-	} );
-
-	return null;
+		const id = setInterval(
+			() => callbackRef.current(),
+			intervalInSeconds * 1000
+		);
+		return () => clearInterval( id );
+	}, [ intervalInSeconds ] );
 }
 
 /**
  * Monitors the changes made to the edited post and triggers autosave if necessary.
  *
- * The logic is straightforward: a check is performed every `props.interval` seconds. If any changes are detected, `props.autosave()` is called.
- * The time between the change and the autosave varies but is no larger than `props.interval` seconds. Refer to the code below for more details, such as
- * the specific way of detecting changes.
+ * The post is checked every `interval` seconds and autosaved when there is something new to save.
  *
- * There are two caveats:
- * * If `props.isAutosaveable` happens to be false at a time of checking for changes, the check is retried every second.
- * * The timer may be disabled by setting `props.disableIntervalChecks` to `true`. In that mode, any change will immediately trigger `props.autosave()`.
- *
- * @param {Object}   props                       - The properties passed to the component.
- * @param {Function} props.autosave              - The function to call when changes need to be saved.
- * @param {number}   props.interval              - The maximum time in seconds between an unsaved change and an autosave.
- * @param {boolean}  props.isAutosaveable        - If false, the check for changes is retried every second.
- * @param {boolean}  props.disableIntervalChecks - If true, disables the timer and any change will immediately trigger `props.autosave()`.
- * @param {boolean}  props.isDirty               - Indicates if there are unsaved changes.
+ * @param {Object}   props            The component props.
+ * @param {number}   [props.interval] Time in seconds between checks. Defaults to the editor's
+ *                                    `autosaveInterval` setting.
+ * @param {Function} [props.autosave] Function to call when changes need to be saved. Defaults to the
+ *                                    editor store's `autosave` action.
  *
  * @example
  * ```jsx
- * <AutosaveMonitor interval={30000} />
+ * <AutosaveMonitor interval={ 30 } />
  * ```
  */
-export default compose( [
-	withSelect( ( select, ownProps ) => {
-		const { getReferenceByDistinctEdits } = select( coreStore );
+export default function AutosaveMonitor( { interval, autosave } ) {
+	const { autosave: autosaveAction } = useDispatch( editorStore );
+	const triggerAutosave = autosave ?? autosaveAction;
 
-		const {
-			isEditedPostDirty,
-			isEditedPostAutosaveable,
-			isAutosavingPost,
-			getEditorSettings,
-		} = select( editorStore );
+	const { getReferenceByDistinctEdits } = useSelect( coreStore );
+	const { isEditedPostDirty, isEditedPostAutosaveable, isAutosavingPost } =
+		useSelect( editorStore );
 
-		const { interval = getEditorSettings().autosaveInterval } = ownProps;
+	const autosaveInterval = useSelect(
+		( select ) => {
+			if ( interval !== undefined ) {
+				return interval;
+			}
 
-		return {
-			editsReference: getReferenceByDistinctEdits(),
-			isDirty: isEditedPostDirty(),
-			isAutosaveable: isEditedPostAutosaveable(),
-			isAutosaving: isAutosavingPost(),
-			interval,
-		};
-	} ),
-	withDispatch( ( dispatch, ownProps ) => ( {
-		autosave() {
-			const { autosave = dispatch( editorStore ).autosave } = ownProps;
-			autosave();
+			return select( editorStore ).getEditorSettings().autosaveInterval;
 		},
-	} ) ),
-] )( AutosaveMonitor );
+		[ interval ]
+	);
+
+	// Reference of the edits last considered for autosaving. Mutable state that
+	// must not trigger a re-render, hence a ref.
+	const lastEditsReferenceRef = useRef();
+
+	useInterval( () => {
+		// The post can't be autosaved yet (e.g. its existing autosave is still
+		// loading). Keep any pending edits and try again on the next tick.
+		if ( ! isEditedPostAutosaveable() ) {
+			return;
+		}
+
+		const editsReference = getReferenceByDistinctEdits();
+		const hasNewEdits = editsReference !== lastEditsReferenceRef.current;
+		lastEditsReferenceRef.current = editsReference;
+
+		if ( hasNewEdits && isEditedPostDirty() && ! isAutosavingPost() ) {
+			triggerAutosave();
+		}
+	}, autosaveInterval );
+
+	return null;
+}

--- a/packages/editor/src/components/autosave-monitor/test/index.js
+++ b/packages/editor/src/components/autosave-monitor/test/index.js
@@ -146,6 +146,28 @@ describe( 'AutosaveMonitor', () => {
 		expect( autosave ).not.toHaveBeenCalled();
 	} );
 
+	it( 'should autosave edits made during an in-progress autosave once it finishes', () => {
+		const autosave = jest.fn();
+		setState( { isDirty: true, isAutosaveable: true } );
+		render( <AutosaveMonitor autosave={ autosave } interval={ 5 } /> );
+
+		// New edit arrives while an autosave is already in progress: the tick
+		// should not consume the edits reference nor trigger an autosave.
+		setState( {
+			isDirty: true,
+			isAutosaveable: true,
+			isAutosaving: true,
+			editsReference: 2,
+		} );
+		jest.advanceTimersByTime( 5000 );
+		expect( autosave ).not.toHaveBeenCalled();
+
+		// Once the autosave finishes, the pending edit must still be autosaved.
+		setState( { isDirty: true, isAutosaveable: true, editsReference: 2 } );
+		jest.advanceTimersByTime( 5000 );
+		expect( autosave ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'should not autosave again until there are new edits', () => {
 		const autosave = jest.fn();
 		setState( { isDirty: true, isAutosaveable: true } );

--- a/packages/editor/src/components/autosave-monitor/test/index.js
+++ b/packages/editor/src/components/autosave-monitor/test/index.js
@@ -4,251 +4,187 @@
 import { render } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
-import { AutosaveMonitor } from '../';
+import AutosaveMonitor from '../';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
+	useDispatch: jest.fn(),
+} ) );
 
 jest.useFakeTimers();
-jest.spyOn( global, 'clearTimeout' );
-jest.spyOn( global, 'setTimeout' );
+jest.spyOn( global, 'clearInterval' );
+jest.spyOn( global, 'setInterval' );
+
+// The current edited-post state, read live by the mocked selectors so it can be
+// changed between timer ticks without re-rendering the component.
+let state;
+
+function setState( overrides = {} ) {
+	state = {
+		editsReference: 1,
+		isDirty: false,
+		isAutosaveable: false,
+		isAutosaving: false,
+		autosaveInterval: 10,
+		...overrides,
+	};
+}
 
 describe( 'AutosaveMonitor', () => {
 	beforeEach( () => {
-		setTimeout.mockClear();
-		clearTimeout.mockClear();
+		setState();
+		// `useSelect( store )` (static mode) returns bound selectors; the
+		// component destructures the ones it needs from each call. The mapping
+		// form `useSelect( mapSelect )` receives a `select` that resolves to the
+		// same selectors.
+		useSelect.mockImplementation( ( mapSelectOrStore ) => {
+			const selectors = {
+				getReferenceByDistinctEdits: () => state.editsReference,
+				isEditedPostDirty: () => state.isDirty,
+				isEditedPostAutosaveable: () => state.isAutosaveable,
+				isAutosavingPost: () => state.isAutosaving,
+				getEditorSettings: () => ( {
+					autosaveInterval: state.autosaveInterval,
+				} ),
+			};
+			if ( typeof mapSelectOrStore === 'function' ) {
+				return mapSelectOrStore( () => selectors );
+			}
+			return selectors;
+		} );
+		useDispatch.mockReturnValue( { autosave: jest.fn() } );
+		setInterval.mockClear();
+		clearInterval.mockClear();
 	} );
 
 	it( 'should render nothing', () => {
-		const { container } = render( <AutosaveMonitor isDirty /> );
+		const { container } = render( <AutosaveMonitor /> );
 
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
-	it( 'should start autosave timer after being mounted', () => {
-		render( <AutosaveMonitor isDirty /> );
+	it( 'should start the autosave timer after being mounted', () => {
+		render( <AutosaveMonitor /> );
 
-		expect( setTimeout ).toHaveBeenCalled();
+		expect( setInterval ).toHaveBeenCalled();
 	} );
 
 	it( 'should clear the autosave timer after being unmounted', () => {
-		const { rerender } = render( <AutosaveMonitor isDirty /> );
+		const { rerender } = render( <AutosaveMonitor /> );
 
 		rerender( <div /> );
 
-		expect( clearTimeout ).toHaveBeenCalled();
+		expect( clearInterval ).toHaveBeenCalled();
 	} );
 
-	it( 'should clear and restart autosave timer when the interval changes', () => {
-		const { rerender } = render( <AutosaveMonitor isDirty /> );
+	it( 'should restart the autosave timer when the interval changes', () => {
+		const { rerender } = render( <AutosaveMonitor interval={ 10 } /> );
 
-		setTimeout.mockClear();
-		rerender( <AutosaveMonitor isDirty interval={ 999 } /> );
+		setInterval.mockClear();
+		clearInterval.mockClear();
+		rerender( <AutosaveMonitor interval={ 999 } /> );
 
-		expect( clearTimeout ).toHaveBeenCalled();
-		expect( setTimeout ).toHaveBeenCalledTimes( 1 );
+		expect( clearInterval ).toHaveBeenCalled();
+		expect( setInterval ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'should autosave when `editReference` changes', () => {
-		const autosave = jest.fn();
-		const { rerender } = render(
-			<AutosaveMonitor isDirty isAutosaveable autosave={ autosave } />
-		);
+	it( 'should schedule the timer using the interval in seconds', () => {
+		render( <AutosaveMonitor interval={ 5 } /> );
 
-		expect( autosave ).not.toHaveBeenCalled();
-
-		rerender(
-			<AutosaveMonitor
-				isDirty
-				isAutosaveable
-				autosave={ autosave }
-				editsReference={ [] }
-			/>
-		);
-
-		jest.runOnlyPendingTimers();
-
-		expect( autosave ).toHaveBeenCalledTimes( 1 );
-	} );
-
-	it( 'should autosave when `editReference` changes and the post becomes dirty', () => {
-		const autosave = jest.fn();
-		const { rerender } = render(
-			<AutosaveMonitor isAutosaveable autosave={ autosave } />
-		);
-
-		expect( autosave ).not.toHaveBeenCalled();
-
-		rerender(
-			<AutosaveMonitor
-				isDirty
-				isAutosaveable
-				autosave={ autosave }
-				editsReference={ [] }
-			/>
-		);
-
-		jest.runOnlyPendingTimers();
-
-		expect( autosave ).toHaveBeenCalledTimes( 1 );
-	} );
-
-	it( 'should not autosave when `editReference` changes and the post is not dirty anymore', () => {
-		const autosave = jest.fn();
-		const { rerender } = render(
-			<AutosaveMonitor isDirty isAutosaveable autosave={ autosave } />
-		);
-
-		expect( autosave ).not.toHaveBeenCalled();
-
-		rerender(
-			<AutosaveMonitor
-				isAutosaveable
-				autosave={ autosave }
-				editsReference={ [] }
-			/>
-		);
-
-		jest.runOnlyPendingTimers();
-
-		expect( autosave ).not.toHaveBeenCalled();
-	} );
-
-	it( 'should not autosave when `editReference` changes and the post is not autosaving', () => {
-		const autosave = jest.fn();
-		const { rerender } = render(
-			<AutosaveMonitor isAutosaveable autosave={ autosave } />
-		);
-
-		expect( autosave ).not.toHaveBeenCalled();
-
-		rerender(
-			<AutosaveMonitor
-				isAutosaveable
-				autosave={ autosave }
-				isAutosaving={ false }
-				editsReference={ [] }
-			/>
-		);
-
-		jest.runOnlyPendingTimers();
-
-		expect( autosave ).not.toHaveBeenCalled();
-	} );
-
-	it( 'should not autosave when `editReference` changes and the post started autosaving', () => {
-		const autosave = jest.fn();
-		const { rerender } = render(
-			<AutosaveMonitor
-				isAutosaveable
-				autosave={ autosave }
-				isAutosaving={ false }
-			/>
-		);
-
-		expect( autosave ).not.toHaveBeenCalled();
-
-		rerender(
-			<AutosaveMonitor
-				isAutosaveable
-				autosave={ autosave }
-				isAutosaving
-				editsReference={ [] }
-			/>
-		);
-
-		jest.runOnlyPendingTimers();
-
-		expect( autosave ).not.toHaveBeenCalled();
-	} );
-
-	it( 'should schedule itself in another {interval} ms', () => {
-		const { rerender } = render( <AutosaveMonitor isDirty /> );
-
-		rerender( <AutosaveMonitor isDirty isAutosaveable interval={ 5 } /> );
-
-		jest.runOnlyPendingTimers();
-
-		expect( setTimeout ).toHaveBeenLastCalledWith(
+		expect( setInterval ).toHaveBeenLastCalledWith(
 			expect.any( Function ),
 			5000
 		);
 	} );
 
-	it( 'should schedule itself in 1000 ms if the post is not autosaveable at a time', () => {
-		const { rerender } = render( <AutosaveMonitor isDirty /> );
+	it( 'should fall back to the editor autosaveInterval setting', () => {
+		setState( { autosaveInterval: 7 } );
+		render( <AutosaveMonitor /> );
 
-		rerender(
-			<AutosaveMonitor isDirty isAutosaveable={ false } interval={ 5 } />
-		);
-
-		jest.runOnlyPendingTimers();
-
-		expect( setTimeout ).toHaveBeenLastCalledWith(
+		expect( setInterval ).toHaveBeenLastCalledWith(
 			expect.any( Function ),
-			1000
+			7000
 		);
 	} );
 
-	it( 'should autosave on the first timer tick when mounted dirty and autosaveable', () => {
+	it( 'should autosave a dirty, autosaveable post on the timer tick', () => {
 		const autosave = jest.fn();
-		render(
-			<AutosaveMonitor
-				isDirty
-				isAutosaveable
-				autosave={ autosave }
-				interval={ 5 }
-			/>
-		);
+		setState( { isDirty: true, isAutosaveable: true } );
+		render( <AutosaveMonitor autosave={ autosave } interval={ 5 } /> );
 
-		jest.runOnlyPendingTimers();
+		expect( autosave ).not.toHaveBeenCalled();
+
+		jest.advanceTimersByTime( 5000 );
 
 		expect( autosave ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'should not start a timer when `disableIntervalChecks` is true', () => {
-		render( <AutosaveMonitor isDirty disableIntervalChecks /> );
-
-		expect( setTimeout ).not.toHaveBeenCalled();
-	} );
-
-	it( 'should autosave immediately when `editsReference` changes and `disableIntervalChecks` is true', () => {
+	it( 'should not autosave when the post is not dirty', () => {
 		const autosave = jest.fn();
-		const { rerender } = render(
-			<AutosaveMonitor disableIntervalChecks autosave={ autosave } />
-		);
+		setState( { isDirty: false, isAutosaveable: true } );
+		render( <AutosaveMonitor autosave={ autosave } interval={ 5 } /> );
+
+		jest.advanceTimersByTime( 5000 );
 
 		expect( autosave ).not.toHaveBeenCalled();
+	} );
 
-		rerender(
-			<AutosaveMonitor
-				disableIntervalChecks
-				autosave={ autosave }
-				editsReference={ [] }
-			/>
-		);
+	it( 'should not autosave while an autosave is already in progress', () => {
+		const autosave = jest.fn();
+		setState( { isDirty: true, isAutosaveable: true, isAutosaving: true } );
+		render( <AutosaveMonitor autosave={ autosave } interval={ 5 } /> );
 
+		jest.advanceTimersByTime( 5000 );
+
+		expect( autosave ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not autosave again until there are new edits', () => {
+		const autosave = jest.fn();
+		setState( { isDirty: true, isAutosaveable: true } );
+		render( <AutosaveMonitor autosave={ autosave } interval={ 5 } /> );
+
+		jest.advanceTimersByTime( 5000 );
+		expect( autosave ).toHaveBeenCalledTimes( 1 );
+
+		// No new edits: a subsequent tick should not autosave again.
+		jest.advanceTimersByTime( 5000 );
+		expect( autosave ).toHaveBeenCalledTimes( 1 );
+
+		// A new distinct edit triggers another autosave.
+		setState( { isDirty: true, isAutosaveable: true, editsReference: 2 } );
+		jest.advanceTimersByTime( 5000 );
+		expect( autosave ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'should keep pending edits and retry once the post becomes autosaveable', () => {
+		const autosave = jest.fn();
+		setState( { isDirty: true, isAutosaveable: false, editsReference: 2 } );
+		render( <AutosaveMonitor autosave={ autosave } interval={ 5 } /> );
+
+		jest.advanceTimersByTime( 5000 );
+		expect( autosave ).not.toHaveBeenCalled();
+
+		setState( { isDirty: true, isAutosaveable: true, editsReference: 2 } );
+		jest.advanceTimersByTime( 5000 );
 		expect( autosave ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'should not autosave when `editsReference` is unchanged and `disableIntervalChecks` is true', () => {
+	it( 'should fall back to the editor store autosave action', () => {
 		const autosave = jest.fn();
-		const { rerender } = render(
-			<AutosaveMonitor
-				isDirty
-				disableIntervalChecks
-				autosave={ autosave }
-			/>
-		);
+		useDispatch.mockReturnValue( { autosave } );
+		setState( { isDirty: true, isAutosaveable: true } );
+		render( <AutosaveMonitor interval={ 5 } /> );
 
-		rerender(
-			<AutosaveMonitor
-				isDirty
-				disableIntervalChecks
-				autosave={ autosave }
-				interval={ 5 }
-			/>
-		);
+		jest.advanceTimersByTime( 5000 );
 
-		expect( autosave ).not.toHaveBeenCalled();
+		expect( autosave ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/packages/editor/src/components/autosave-monitor/test/index.js
+++ b/packages/editor/src/components/autosave-monitor/test/index.js
@@ -13,16 +13,9 @@ jest.spyOn( global, 'clearTimeout' );
 jest.spyOn( global, 'setTimeout' );
 
 describe( 'AutosaveMonitor', () => {
-	let setAutosaveTimerSpy;
 	beforeEach( () => {
-		setAutosaveTimerSpy = jest.spyOn(
-			AutosaveMonitor.prototype,
-			'setAutosaveTimer'
-		);
-	} );
-
-	afterEach( () => {
-		setAutosaveTimerSpy.mockClear();
+		setTimeout.mockClear();
+		clearTimeout.mockClear();
 	} );
 
 	it( 'should render nothing', () => {
@@ -34,7 +27,7 @@ describe( 'AutosaveMonitor', () => {
 	it( 'should start autosave timer after being mounted', () => {
 		render( <AutosaveMonitor isDirty /> );
 
-		expect( setAutosaveTimerSpy ).toHaveBeenCalled();
+		expect( setTimeout ).toHaveBeenCalled();
 	} );
 
 	it( 'should clear the autosave timer after being unmounted', () => {
@@ -48,10 +41,11 @@ describe( 'AutosaveMonitor', () => {
 	it( 'should clear and restart autosave timer when the interval changes', () => {
 		const { rerender } = render( <AutosaveMonitor isDirty /> );
 
+		setTimeout.mockClear();
 		rerender( <AutosaveMonitor isDirty interval={ 999 } /> );
 
 		expect( clearTimeout ).toHaveBeenCalled();
-		expect( setAutosaveTimerSpy ).toHaveBeenCalledTimes( 2 );
+		expect( setTimeout ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'should autosave when `editReference` changes', () => {
@@ -193,5 +187,68 @@ describe( 'AutosaveMonitor', () => {
 			expect.any( Function ),
 			1000
 		);
+	} );
+
+	it( 'should autosave on the first timer tick when mounted dirty and autosaveable', () => {
+		const autosave = jest.fn();
+		render(
+			<AutosaveMonitor
+				isDirty
+				isAutosaveable
+				autosave={ autosave }
+				interval={ 5 }
+			/>
+		);
+
+		jest.runOnlyPendingTimers();
+
+		expect( autosave ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should not start a timer when `disableIntervalChecks` is true', () => {
+		render( <AutosaveMonitor isDirty disableIntervalChecks /> );
+
+		expect( setTimeout ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should autosave immediately when `editsReference` changes and `disableIntervalChecks` is true', () => {
+		const autosave = jest.fn();
+		const { rerender } = render(
+			<AutosaveMonitor disableIntervalChecks autosave={ autosave } />
+		);
+
+		expect( autosave ).not.toHaveBeenCalled();
+
+		rerender(
+			<AutosaveMonitor
+				disableIntervalChecks
+				autosave={ autosave }
+				editsReference={ [] }
+			/>
+		);
+
+		expect( autosave ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should not autosave when `editsReference` is unchanged and `disableIntervalChecks` is true', () => {
+		const autosave = jest.fn();
+		const { rerender } = render(
+			<AutosaveMonitor
+				isDirty
+				disableIntervalChecks
+				autosave={ autosave }
+			/>
+		);
+
+		rerender(
+			<AutosaveMonitor
+				isDirty
+				disableIntervalChecks
+				autosave={ autosave }
+				interval={ 5 }
+			/>
+		);
+
+		expect( autosave ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
## What?
Part of #22890.
Supersedes #78630. This is a full refactoring, instead of a 1-to-1 mapping of Class to Function component, which AIs often do.

PR refactors `AutosaveMonitor` into a function component with data hooks. Here's what's changed:

- Converts `AutosaveMonitor` from a class + `compose`/`withSelect`/`withDispatch` HoC to a function component using hooks.
- Reads editor state with on-demand `useSelect( store )` getters inside the timer tick instead of subscribing to it.
- Narrows the public API to `interval` and `autosave`; the rest (`isDirty`, `isAutosaveable`, `editsReference`, `isAutosaving`) are now internal.
- Removes the `disableIntervalChecks` prop.
- Collapses the timer logic into a small `useInterval` helper and a single ref.

## Why?
- The HoC subscribed to `editsReference`, which changes on every edit — so the component re-rendered on essentially every keystroke. Reading the state on demand at each check removes those re-renders.
- `disableIntervalChecks` was only ever used by the native mobile layout, removed with the rest of React Native (#78747); this was dead code.
- The injected `isDirty`/`isAutosaveable`/etc. Props were implementation details of the old HoC, not the real API.

## Testing Instructions
1. CI checks should be green.
2. Smoke tests autosaving feature.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.