### PR TITLE
Rich text: derive event handler relevance from the selection

### DIFF
--- a/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
@@ -33,9 +33,14 @@ export default ( props ) => ( element ) => {
 			registry,
 		} = props.current;
 
-		// The event listener is attached to the window, so we need to check if
-		// the target is the element or inside the element.
-		if ( ! element.contains( event.target ) ) {
+		// The event listener is attached to the window, so we need to check
+		// that the selection is within the element, rather than relying on the
+		// event target (which is the editing host, not necessarily this
+		// element).
+		const { anchorNode, focusNode } = defaultView.getSelection();
+		const containsSelection =
+			element.contains( anchorNode ) && element.contains( focusNode );
+		if ( ! containsSelection ) {
 			return;
 		}
 

--- a/packages/rich-text/src/hook/event-listeners/copy-handler.js
+++ b/packages/rich-text/src/hook/event-listeners/copy-handler.js
@@ -7,7 +7,6 @@ import { privateApis as composePrivateApis } from '@wordpress/compose';
  * Internal dependencies
  */
 import { toHTMLString } from '../../to-html-string';
-import { isCollapsed } from '../../is-collapsed';
 import { slice } from '../../slice';
 import { getTextContent } from '../../get-text-content';
 import { unlock } from '../../lock-unlock';
@@ -18,10 +17,13 @@ export default ( props ) => ( element ) => {
 	function onCopy( event ) {
 		const { record } = props.current;
 		const { ownerDocument } = element;
-		if (
-			isCollapsed( record.current ) ||
-			! element.contains( ownerDocument.activeElement )
-		) {
+		// Determine relevance from the selection, not the active element, so
+		// the handler works regardless of which editing host is focused.
+		const selection = ownerDocument.defaultView.getSelection();
+		const { anchorNode, focusNode } = selection;
+		const containsSelection =
+			element.contains( anchorNode ) && element.contains( focusNode );
+		if ( selection.isCollapsed || ! containsSelection ) {
 			return;
 		}
 

--- a/packages/rich-text/src/hook/event-listeners/input-and-selection.js
+++ b/packages/rich-text/src/hook/event-listeners/input-and-selection.js
@@ -129,14 +129,16 @@ export default ( props ) => ( element ) => {
 			return;
 		}
 
-		// Ensure the active element is the rich text element.
-		if ( ownerDocument.activeElement !== element ) {
-			// If it is not, we can stop listening for selection changes. We
-			// resume listening when the element is focused.
-			ownerDocument.removeEventListener(
-				'selectionchange',
-				handleSelectionChange
-			);
+		// Determine relevance from the selection rather than the active
+		// element, so the handler still works when the editing host is an
+		// ancestor (e.g. the writing flow wrapper) rather than this element.
+		const { anchorNode, focusNode } = defaultView.getSelection();
+		const containsSelection =
+			element.contains( anchorNode ) &&
+			element.contains( focusNode ) &&
+			!! ownerDocument.activeElement?.contains( element );
+
+		if ( ! containsSelection ) {
 			return;
 		}
 
@@ -308,5 +310,9 @@ export default ( props ) => ( element ) => {
 		unsubscribeCompositionStart();
 		unsubscribeCompositionEnd();
 		unsubscribeFocus();
+		ownerDocument.removeEventListener(
+			'selectionchange',
+			handleSelectionChange
+		);
 	};
 };


### PR DESCRIPTION
## What?

Make the rich text copy, cut, paste, and selection sync handlers decide whether an event is theirs based on the current selection, instead of the focused element or the event target.

## Why?

Extracted from #63671 (the reverted iOS multi-select PR): this is the behaviour-neutral, selection-driven relevance part of that change, split out on its own.

Preparation for re-enabling multi-block selection on iOS/touch. That requires the writing flow wrapper to be the editing host during selection, in which case events target the wrapper rather than the individual rich text element, so handlers keyed off `event.target` / `activeElement` would not fire. Keying off the selection is robust to which element is focused. No behaviour change today, since the element holding the selection is also the focused/target element.

## How?

1. **Paste**: check that the selection (anchor and focus nodes) is within the element, instead of `element.contains( event.target )`.
2. **Copy/cut**: check selection containment and the native selection collapsed state, instead of `activeElement` containment and the record collapsed state.
3. **Selection sync** (`selectionchange`): gate on selection containment instead of `activeElement === element`, and remove the listener on cleanup rather than inline.

The clipboard listeners are already attached at the window level, so only the relevance check changes.

## Testing Instructions

1. Select text within a paragraph, copy, and paste elsewhere. Formatting is preserved.
2. Select text and cut. The text is removed and placed on the clipboard.
3. Paste plain and rich content into a block.
4. Move the caret and select text with the mouse and keyboard; the formatting toolbar and selection behave as before.

Everything should behave exactly as before.

### Testing Instructions for Keyboard

As above, using Shift+Arrows to select and Ctrl/Cmd+C / X / V.

## Use of AI Tools

Drafted with Claude Code (Claude Opus 4.8) and reviewed before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

