### PR TITLE
Omnipresent toolbar: show site icon instead of dashicon if set

### DIFF
--- a/lib/experimental/omnibar/load.php
+++ b/lib/experimental/omnibar/load.php
@@ -92,3 +92,86 @@ function gutenberg_enable_omnibar_in_site_editor_v2() {
 }
 
 add_action( 'site-editor-v2_init', 'gutenberg_enable_omnibar_in_site_editor_v2' );
+
+/**
+ * Replaces the home/odometer dashicon in the admin bar site menu with the
+ * actual site icon, if one is set.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+ */
+function gutenberg_omnibar_site_icon( $wp_admin_bar ) {
+	if (
+		! is_admin_bar_showing() ||
+		! gutenberg_is_experiment_enabled( 'gutenberg-omnibar' )
+	) {
+		return;
+	}
+
+	$node = $wp_admin_bar->get_node( 'site-name' );
+	if ( ! $node ) {
+		return;
+	}
+
+	$site_icon_url = get_site_icon_url( 64 );
+	if ( ! $site_icon_url ) {
+		return;
+	}
+
+	$meta          = (array) $node->meta;
+	$meta['class'] = isset( $meta['class'] ) ? trim( $meta['class'] . ' has-site-icon' ) : 'has-site-icon';
+
+	$wp_admin_bar->add_node(
+		array(
+			'id'    => 'site-name',
+			'title' => '<img class="site-icon" src="' . esc_url( $site_icon_url ) . '" alt="" />' . $node->title,
+			'meta'  => $meta,
+		)
+	);
+}
+
+add_action( 'admin_bar_menu', 'gutenberg_omnibar_site_icon', 31 );
+
+/**
+ * Adds the styles for the admin bar site icon.
+ */
+function gutenberg_omnibar_site_icon_styles() {
+	if (
+		! is_admin_bar_showing() ||
+		! gutenberg_is_experiment_enabled( 'gutenberg-omnibar' )
+	) {
+		return;
+	}
+
+	$css = <<<CSS
+#wpadminbar #wp-admin-bar-site-name.has-site-icon > .ab-item:before {
+	content: none;
+}
+
+#wpadminbar #wp-admin-bar-site-name > .ab-item .site-icon {
+	width: 20px;
+	height: 20px;
+	margin: 0;
+	margin-inline-end: 6px;
+	vertical-align: -5px;
+	background: #f0f0f1;
+	border-radius: 2px;
+}
+
+@media screen and (max-width: 782px) {
+	#wpadminbar #wp-admin-bar-site-name > .ab-item .site-icon {
+		position: absolute;
+		top: 9px;
+		inset-inline-start: 12px;
+		width: 28px;
+		height: 28px;
+		margin: 0;
+		border-radius: 4px;
+	}
+}
+CSS;
+
+	wp_add_inline_style( 'admin-bar', $css );
+}
+
+add_action( 'wp_enqueue_scripts', 'gutenberg_omnibar_site_icon_styles' );
+add_action( 'admin_enqueue_scripts', 'gutenberg_omnibar_site_icon_styles' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of https://github.com/WordPress/gutenberg/issues/79036

This PR replaces the home / odometer dashicon, with the actual site icon, if set, in the admin bar. The icon will be 20x20px, with border-radius of 2px and background-color of `#f0f0f1`. If the site has not set site icon, then the default dashicons (home / odometer) is NOT changed.

This will be gated in the existing "Omnipresent Toolbar" Gutenberg experiment. Original Core PR: https://github.com/WordPress/wordpress-develop/pull/11781

## Why?

There are three main reasons:

1. Currently, the icon is odometer on site frontend, and house in wp-admin. This feels confusing as the icon changes between screens, but the label (site name) is not. With this, the site name node appearance is fixed.
2. This helps users in mobile viewport to identify the site. Instead of generic icon, we now see the site icon.
3. In the "Toolbar in editor" experiment, the site icon at the top-left corner is replaced by a back button. With this change, this acts as the replacement. This is useful especially on mobile resolutions to identify the site. See the following screenshots

### Post Editor

|Before|After|
|-|-|
|<img width="262" height="160" alt="image" src="https://github.com/user-attachments/assets/5e10c984-8d2c-4d31-a405-d8b05355221c" />|<img width="262" height="160" alt="image" src="https://github.com/user-attachments/assets/40e97524-72a9-4e48-8518-4497039b4269" />
|<img width="262" height="160" alt="image" src="https://github.com/user-attachments/assets/4386d841-ccc6-4b3e-a338-9366ff8a77f2" />|<img width="262" height="160" alt="image" src="https://github.com/user-attachments/assets/e2c1aebd-e588-49dc-bbcc-498c404a51b3" />

### Site Editor

|Before|After|
|-|-|
|<img width="382" height="162" alt="image" src="https://github.com/user-attachments/assets/8c82a704-f731-4f9b-8948-ccee5a36fea5" />|<img width="382" height="162" alt="image" src="https://github.com/user-attachments/assets/ede9122f-b9c8-4aac-bd93-316777acc01e" />
|<img width="262" height="160" alt="image" src="https://github.com/user-attachments/assets/2edfab45-9e9d-4404-981e-f0ed4348689a" />|<img width="262" height="160" alt="image" src="https://github.com/user-attachments/assets/e6b2f06d-a91e-4ef2-9a21-c5f31f7e55d6" />


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Go to Gutenberg -> Experiments, scroll all the way down, then enable the following experiment:

<img width="611" height="105" alt="image" src="https://github.com/user-attachments/assets/141cfa89-5099-4199-8272-bcb52c16d324" />


Then, go to Settings -> General, upload a site icon, then verify it appears in the admin bar as shown in the below screenshots.

## Screenshots or screencast <!-- if applicable -->


### Before

<img width="350" height="32" alt="image" src="https://github.com/user-attachments/assets/123f6b2d-a5fa-45d3-b3f8-2196b93e5948" />

<img width="350" height="32" alt="image" src="https://github.com/user-attachments/assets/560ab716-22c4-494e-a7ec-cc3fd0d66143" />


### After

<img width="350" alt="fresh" src="https://github.com/user-attachments/assets/0096af12-b457-4a5e-b62e-021947cef433" />
<img width="350" alt="modern" src="https://github.com/user-attachments/assets/045cdb0b-b1e0-4a0e-8a61-ec783b983e0f" />
<img width="350" alt="blue" src="https://github.com/user-attachments/assets/da95bee7-318e-407b-9d0d-6b3bc993a4db" />
<img width="350" alt="coffee" src="https://github.com/user-attachments/assets/237ee40a-b075-4c97-a484-73ec3c07e33e" />
<img width="350" alt="ectoplasm" src="https://github.com/user-attachments/assets/f41f8459-9021-4e7b-a2a6-404d1626c173" />
<img width="350" alt="light" src="https://github.com/user-attachments/assets/c911d875-cce1-4f82-b4d0-f523fa4181d5" />
<img width="350" alt="midnight" src="https://github.com/user-attachments/assets/cec833d0-257b-44b2-b71d-bb53c3694142" />
<img width="350" alt="ocean" src="https://github.com/user-attachments/assets/e4f786db-e006-4818-8315-521270efb1bd" />
<img width="350" alt="sunrise" src="https://github.com/user-attachments/assets/1aa79a1f-ef36-49fc-8e95-621420606810" />


### Before (mobile)

<img width="511" height="46" alt="image" src="https://github.com/user-attachments/assets/a9a39acf-00e2-494a-b948-ba56fa0f0fb6" />

<img width="511" height="46" alt="image" src="https://github.com/user-attachments/assets/e347dc60-7f9c-4d4d-9833-d40bc6adb90b" />


### After (mobile)

<img width="511" height="46" alt="image" src="https://github.com/user-attachments/assets/33384a31-3e02-49f1-a3c1-edd4f7703739" />

<img width="511" height="46" alt="image" src="https://github.com/user-attachments/assets/94343b23-7fb6-4eec-8b87-5f31bbf1f814" />


## Use of AI Tools

I used Codex with GPT-5.5 to help with the CSS implementation, with my supervision.