### PR TITLE
Editor: Derive post title tag from active template's core/post-title block level

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -32,7 +32,7 @@ import { unlock } from '../../lock-unlock';
 
 const { useRichText } = unlock( richTextPrivateApis );
 
-const PostTitle = forwardRef( ( _, forwardedRef ) => {
+const PostTitle = forwardRef( ( { tagName = 'h1' }, forwardedRef ) => {
 	const { placeholder, isEditingContentOnlySection, isPreview } = useSelect(
 		( select ) => {
 			const { getSettings, getEditedContentOnlySection } = unlock(
@@ -180,9 +180,10 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 	// Instead use an inline style to dim the block when it's disabled.
 	const style = isEditingContentOnlySection ? { opacity: 0.2 } : undefined;
 
+	const TagName = tagName;
+
 	return (
-		/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
-		<h1
+		<TagName
 			ref={ useMergeRefs( [ richTextRef, focusRef ] ) }
 			contentEditable={ ! isEditingContentOnlySection && ! isPreview }
 			className={ className }
@@ -195,7 +196,6 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 			onPaste={ onPaste }
 			style={ style }
 		/>
-		/* eslint-enable jsx-a11y/no-noninteractive-element-to-interactive-role */
 	);
 } );
 
@@ -207,8 +207,8 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
  *
  * @return {React.ReactNode} The rendered PostTitle component.
  */
-export default forwardRef( ( _, forwardedRef ) => (
+export default forwardRef( ( props, forwardedRef ) => (
 	<PostTypeSupportCheck supportKeys="title">
-		<PostTitle ref={ forwardedRef } />
+		<PostTitle { ...props } ref={ forwardedRef } />
 	</PostTypeSupportCheck>
 ) );

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -82,6 +82,23 @@ function getPostContentAttributes( blocks ) {
 	}
 }
 
+function getPostTitleAttributes( blocks ) {
+	for ( let i = 0; i < blocks.length; i++ ) {
+		if ( blocks[ i ].name === 'core/post-title' ) {
+			return blocks[ i ].attributes;
+		}
+		if ( blocks[ i ].innerBlocks.length ) {
+			const nestedPostTitle = getPostTitleAttributes(
+				blocks[ i ].innerBlocks
+			);
+
+			if ( nestedPostTitle ) {
+				return nestedPostTitle;
+			}
+		}
+	}
+}
+
 function checkForPostContentAtRootLevel( blocks ) {
 	for ( let i = 0; i < blocks.length; i++ ) {
 		if ( blocks[ i ].name === 'core/post-content' ) {
@@ -256,6 +273,24 @@ function VisualEditor( {
 	}, [ editedPostTemplate?.content, editedPostTemplate?.blocks ] );
 
 	const { layout = {}, align = '' } = newestPostContentAttributes || {};
+	const postTitleTagName = useMemo( () => {
+		if ( ! editedPostTemplate?.content && ! editedPostTemplate?.blocks ) {
+			return 'h1';
+		}
+
+		const postTitleAttributes = editedPostTemplate?.blocks
+			? getPostTitleAttributes( editedPostTemplate.blocks )
+			: getPostTitleAttributes(
+					parse(
+						typeof editedPostTemplate?.content === 'string'
+							? editedPostTemplate.content
+							: ''
+					)
+			  );
+		const level = postTitleAttributes?.level ?? 2;
+
+		return level === 0 ? 'p' : `h${ level }`;
+	}, [ editedPostTemplate?.content, editedPostTemplate?.blocks ] );
 
 	const postContentLayoutClasses = useLayoutClasses(
 		newestPostContentAttributes,
@@ -457,7 +492,10 @@ function VisualEditor( {
 								marginTop: '4rem',
 							} }
 						>
-							<PostTitle ref={ titleRef } />
+							<PostTitle
+								ref={ titleRef }
+								tagName={ postTitleTagName }
+							/>
 						</div>
 					) }
 					<RecursionProvider


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/42441

## What?
The standalone post title element in the post editor always rendered as `<h1>` regardless of the heading level configured on the `core/post-title` block in the active template. This PR makes the post editor title chrome derive its tag name from the template block's `level` attribute instead of hardcoding `<h1>`.

## Why?
The `core/post-title` block already supports a configurable `level` attribute (default: `2`, per `block.json`). In the template editor and on the front end the correct tag is rendered. However the standalone title element used in the post editor (`packages/editor/src/components/post-title`) hardcoded `<h1>`, so the post editor chrome was always visually and semantically inconsistent with both the template setting and the front-end output. This matters for accessibility (heading hierarchy) and for authors who intentionally configure a different level in their template.

## Testing Instructions
1. Open the Site Editor and edit your active theme template (e.g. Single Post or Index).
2. Select the **Title** (`core/post-title`) block and change its heading level, for example, set it to **H2** or **H3** using the toolbar or block settings panel.
3. Save the template.
4. Open any post or page in the post editor (`/wp-admin/post.php`).
5. Verify that the post title input field renders using the heading level you set in step 2 (inspect the DOM, the element should be `<h2>` or `<h3>`, not `<h1>`).
6. Edit the title text and confirm it saves correctly.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/fe301aea-04ee-4bf7-a8fd-08e1efb1f132

