### PR TITLE
Style: Update color to use CSS variable in global-styles-ui

### DIFF
--- a/packages/global-styles-ui/src/font-library/style.scss
+++ b/packages/global-styles-ui/src/font-library/style.scss
@@ -70,7 +70,7 @@ $footer-height: 90px;
 	position: absolute;
 	width: 100%;
 	bottom: 0;
-	border-top: 1px solid colors.$gray-300;
+	border-top: 1px solid var(--wpds-color-stroke-surface-neutral);
 	padding: variables.$grid-unit-30;
 	background-color: colors.$white;
 	box-sizing: border-box;
@@ -123,7 +123,7 @@ $footer-height: 90px;
 
 .font-library__font-card {
 	box-sizing: border-box;
-	border: variables.$border-width solid colors.$gray-300;
+	border: variables.$border-width solid var(--wpds-color-stroke-surface-neutral);
 	width: 100%;
 
 	// Override the default 40px height set by the Button component.
@@ -188,7 +188,7 @@ $footer-height: 90px;
 .font-library-modal__tablist-container {
 	position: sticky;
 	top: 0;
-	border-bottom: 1px solid colors.$gray-300;
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral);
 	background: colors.$white;
 	z-index: 1;
 }

--- a/packages/global-styles-ui/src/screen-revisions/style.scss
+++ b/packages/global-styles-ui/src/screen-revisions/style.scss
@@ -80,7 +80,7 @@
 		left: $grid-unit-20;
 		top: 0;
 		width: 0;
-		border: 0.5px solid $gray-300;
+		border: 0.5px solid var(--wpds-color-stroke-surface-neutral);
 	}
 
 	&:first-child::after {
@@ -188,6 +188,6 @@
 	bottom: 0;
 	background: $white;
 	padding: $grid-unit-15;
-	border-top: $border-width solid $gray-300;
+	border-top: $border-width solid var(--wpds-color-stroke-surface-neutral);
 	box-sizing: border-box;
 }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/79001

## What

Replace hardcoded `colors.$gray-300` border values with the `--wpds-color-stroke-surface-neutral` design token in `global-styles-ui` SCSS files.

## Changes

- `font-library/style.scss`: Updated 3 border declarations (footer border-top, font card border, tablist border-bottom)
- `screen-revisions/style.scss`: Updated 2 border declarations (timeline connector line, footer border-top)


| Before `$gray-300` | After `var(--wpds-color-stroke-surface-neutral)` |
|-------|-------|
| <img width="1691" height="844" alt="Screenshot 2026-06-09 at 7 01 41 PM" src="https://github.com/user-attachments/assets/4853f1ca-07e7-45ea-a299-594dc82694f3" /> | <img width="1698" height="854" alt="Screenshot 2026-06-09 at 7 01 08 PM" src="https://github.com/user-attachments/assets/cba430fb-2a17-48fd-957c-9c132aebfb06" /> | 
