### PR TITLE
Site Editor: Fix admin color scheme bleeding through the mobile content scrollbar gutter

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -185,6 +185,12 @@ function Layout() {
 											/>
 										) }
 										{ areas.mobileContent ? (
+											/*
+											 * ThemeProvider wraps SidebarContent (rather than
+											 * just the content) so the scroll wrapper it renders
+											 * inherits the content background tokens. See
+											 * `.edit-site-sidebar__screen-wrapper` in style.scss.
+											 */
 											<ThemeProvider
 												color={ CONTENT_COLOR }
 											>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -184,10 +184,12 @@ function Layout() {
 												}
 											/>
 										) }
-										<SidebarContent routeKey={ routeKey }>
-											{ areas.mobileContent ? (
-												<ThemeProvider
-													color={ CONTENT_COLOR }
+										{ areas.mobileContent ? (
+											<ThemeProvider
+												color={ CONTENT_COLOR }
+											>
+												<SidebarContent
+													routeKey={ routeKey }
 												>
 													<div className="edit-site-layout__mobile-content">
 														<ErrorBoundary>
@@ -196,13 +198,17 @@ function Layout() {
 															}
 														</ErrorBoundary>
 													</div>
-												</ThemeProvider>
-											) : (
+												</SidebarContent>
+											</ThemeProvider>
+										) : (
+											<SidebarContent
+												routeKey={ routeKey }
+											>
 												<ErrorBoundary>
 													{ areas.mobileSidebar }
 												</ErrorBoundary>
-											) }
-										</SidebarContent>
+											</SidebarContent>
+										) }
 										<SaveHub />
 										<SavePanel />
 									</>

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -84,6 +84,9 @@
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;
+}
+
+.edit-site-sidebar__screen-wrapper:has(.edit-site-layout__mobile-content) {
 	background: var(--wpds-color-bg-surface-neutral);
 }
 

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -86,6 +86,10 @@
 	flex-grow: 1;
 }
 
+// On mobile, the content surface lives on the scroll wrapper
+// (not the inner content element) so it also covers the wrapper's
+// reserved scrollbar gutter, preventing the theme background color from
+// bleeding through.
 .edit-site-sidebar__screen-wrapper:has(.edit-site-layout__mobile-content) {
 	background: var(--wpds-color-bg-surface-neutral);
 }


### PR DESCRIPTION

## What?

Fixes https://github.com/WordPress/gutenberg/pull/78397#discussion_r3344111222

Fixes the admin color scheme background bleeding through the white content panel, at the scrollbar location, in the mobile Site Editor layout (e.g. the Styles panel).

## Why?

In the mobile layout, the content panel (`areas.mobileContent`) is rendered white via a `ThemeProvider`, but its scroll container (`.edit-site-sidebar__screen-wrapper`) is outside that theme and has no background of its own. 

## How?

The content panel's surface should be the scroll viewport, so the gutter is part of it. So, we move `<ThemeProvider color={ CONTENT_COLOR }>` up one level to wrap `<SidebarContent>`. 

## Testing Instructions

1. Go to Appearance -> Editor
2. Click Styles
3. Go to dev tools and set the device viewport to a mobile one
4. Observe the scrollbar gutter is clean (white), free from the color bleeding

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/4cc491f2-ca57-4246-b8d9-e85515094700" />|<img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/e9acf795-6ad4-4f11-b1f3-27802b7ffd1c" />|


## Use of AI Tools

I used Claude Opus 4.8 to help with the idea.