### PR TITLE
Format Library: Migrate to recommended `@wordpress/ui` components

### DIFF
--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -6,12 +6,10 @@ import {
 	SVG,
 	Popover,
 	Button,
-	ExternalLink,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	__experimentalNumberControl as NumberControl,
 	TextareaControl,
 } from '@wordpress/components';
+import { Link, Stack } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { insertObject, useAnchor } from '@wordpress/rich-text';
@@ -100,7 +98,7 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 					event.preventDefault();
 				} }
 			>
-				<VStack spacing={ 4 }>
+				<Stack direction="column" gap="lg">
 					<NumberControl
 						__next40pxDefaultSize
 						label={ __( 'Width' ) }
@@ -118,7 +116,8 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 						} }
 						help={
 							<>
-								<ExternalLink
+								<Link
+									openInNewTab
 									href={
 										// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
 										__(
@@ -129,13 +128,13 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 									{ __(
 										'Describe the purpose of the image.'
 									) }
-								</ExternalLink>
+								</Link>
 								<br />
 								{ __( 'Leave empty if decorative.' ) }
 							</>
 						}
 					/>
-					<HStack justify="right">
+					<Stack justify="right">
 						<Button
 							disabled={ ! hasChanged }
 							accessibleWhenDisabled
@@ -145,8 +144,8 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 						>
 							{ __( 'Apply' ) }
 						</Button>
-					</HStack>
-				</VStack>
+					</Stack>
+				</Stack>
 			</form>
 		</Popover>
 	);

--- a/packages/format-library/src/language/index.js
+++ b/packages/format-library/src/language/index.js
@@ -12,9 +12,8 @@ import {
 	SelectControl,
 	Button,
 	Popover,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useState } from '@wordpress/element';
 import { applyFormat, removeFormat, useAnchor } from '@wordpress/rich-text';
 import { language as languageIcon } from '@wordpress/icons';
@@ -83,9 +82,10 @@ function InlineLanguageUI( { value, contentRef, onChange, onClose } ) {
 			anchor={ popoverAnchor }
 			onClose={ onClose }
 		>
-			<VStack
-				as="form"
-				spacing={ 4 }
+			<Stack
+				render={ <form /> }
+				direction="column"
+				gap="lg"
 				className="block-editor-format-toolbar__language-container-content"
 				onSubmit={ ( event ) => {
 					event.preventDefault();
@@ -126,15 +126,15 @@ function InlineLanguageUI( { value, contentRef, onChange, onClose } ) {
 					] }
 					onChange={ ( val ) => setDir( val ) }
 				/>
-				<HStack alignment="right">
+				<Stack justify="right">
 					<Button
 						__next40pxDefaultSize
 						variant="primary"
 						type="submit"
 						text={ __( 'Apply' ) }
 					/>
-				</HStack>
-			</VStack>
+				</Stack>
+			</Stack>
 		</Popover>
 	);
 }

--- a/packages/format-library/src/link/css-classes-setting.js
+++ b/packages/format-library/src/link/css-classes-setting.js
@@ -7,9 +7,8 @@ import { __ } from '@wordpress/i18n';
 import {
 	__experimentalInputControl as InputControl,
 	CheckboxControl,
-	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { VisuallyHidden } from '@wordpress/ui';
+import { Stack, VisuallyHidden } from '@wordpress/ui';
 
 /**
  * CSSClassesSettingComponent
@@ -58,7 +57,7 @@ const CSSClassesSettingComponent = ( { setting, value, onChange } ) => {
 			<VisuallyHidden render={ <legend /> }>
 				{ setting.title }
 			</VisuallyHidden>
-			<VStack spacing={ 3 }>
+			<Stack direction="column" gap="md">
 				<CheckboxControl
 					label={ setting.title }
 					onChange={ handleCheckboxChange }
@@ -82,7 +81,7 @@ const CSSClassesSettingComponent = ( { setting, value, onChange } ) => {
 						/>
 					</div>
 				) }
-			</VStack>
+			</Stack>
 		</fieldset>
 	);
 };

--- a/packages/format-library/src/math/index.js
+++ b/packages/format-library/src/math/index.js
@@ -8,9 +8,9 @@ import { RichTextToolbarButton } from '@wordpress/block-editor';
 import {
 	Popover,
 	TextControl,
-	__experimentalVStack as VStack,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { math as icon } from '@wordpress/icons';
 import { speak } from '@wordpress/a11y';
 
@@ -88,7 +88,7 @@ function InlineUI( {
 			className="block-editor-format-toolbar__math-popover"
 		>
 			<div style={ { minWidth: '300px', padding: '4px' } }>
-				<VStack spacing={ 1 }>
+				<Stack direction="column" gap="xs">
 					<TextControl
 						__next40pxDefaultSize
 						hideLabelFromVision
@@ -114,7 +114,7 @@ function InlineUI( {
 							<style children=".wp-block-math__error .components-badge__content{white-space:normal}" />
 						</>
 					) }
-				</VStack>
+				</Stack>
 			</div>
 		</Popover>
 	);

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -16,19 +16,14 @@ import {
 	getColorObjectByAttributeValues,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import {
-	Popover,
-	privateApis as componentsPrivateApis,
-} from '@wordpress/components';
+import { Popover } from '@wordpress/components';
+import { Tabs } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { textColor as settings, transparentValue } from './index';
-import { unlock } from '../lock-unlock';
-
-const { Tabs } = unlock( componentsPrivateApis );
 
 const TABS = [
 	{ name: 'color', title: __( 'Text' ) },
@@ -168,18 +163,18 @@ export default function InlineColorUI( {
 			className="format-library__inline-color-popover"
 			anchor={ popoverAnchor }
 		>
-			<Tabs>
-				<Tabs.TabList>
+			<Tabs.Root defaultValue={ TABS[ 0 ].name }>
+				<Tabs.List>
 					{ TABS.map( ( tab ) => (
-						<Tabs.Tab tabId={ tab.name } key={ tab.name }>
+						<Tabs.Tab value={ tab.name } key={ tab.name }>
 							{ tab.title }
 						</Tabs.Tab>
 					) ) }
-				</Tabs.TabList>
+				</Tabs.List>
 				{ TABS.map( ( tab ) => (
-					<Tabs.TabPanel
-						tabId={ tab.name }
-						focusable={ false }
+					<Tabs.Panel
+						value={ tab.name }
+						tabIndex={ -1 }
 						key={ tab.name }
 					>
 						<ColorPicker
@@ -188,9 +183,9 @@ export default function InlineColorUI( {
 							value={ value }
 							onChange={ onChange }
 						/>
-					</Tabs.TabPanel>
+					</Tabs.Panel>
 				) ) }
-			</Tabs>
+			</Tabs.Root>
 		</Popover>
 	);
 }

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1265,24 +1265,13 @@
 		}
 	},
 	"packages/format-library/src/image/index.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 3
-		},
 		"react-hooks/refs": {
 			"count": 2
 		}
 	},
 	"packages/format-library/src/language/index.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 2
-		},
 		"react-hooks/refs": {
 			"count": 2
-		}
-	},
-	"packages/format-library/src/link/css-classes-setting.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
 		}
 	},
 	"packages/format-library/src/link/inline.js": {
@@ -1291,17 +1280,11 @@
 		}
 	},
 	"packages/format-library/src/math/index.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		},
 		"react-hooks/refs": {
 			"count": 2
 		}
 	},
 	"packages/format-library/src/text-color/inline.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		},
 		"react-hooks/refs": {
 			"count": 2
 		}


### PR DESCRIPTION
## What?
PR resolves all `@wordpress/use-recommended-components` lint warnings in `packages/format-library/src` by migrating flagged `@wordpress/components` imports to their recommended `@wordpress/ui` equivalents.

Was reviewing PRs in this area and decided to proceed with the migration.

P.S. The Math format still uses the old badge, but it's not marked by recommended error yet.

## Testing Instructions
1. Open a post or page.
2. Add a paragraph.
3. Smoke test the affected formats.
4. They should be rendered as before.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.