### PR TITLE
Editor: Hide cmd palette shortcut in document bar when admin bar is shown

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -141,6 +141,9 @@ export default function DocumentBar( props ) {
 	const { open: openCommandCenter } = useDispatch( commandsStore );
 	const isReducedMotion = useReducedMotion();
 
+	const hasShortcut = ! window.__experimentalAdminBarInEditor;
+	const CommandWrapper = hasShortcut ? Button : 'div';
+
 	const isTemplate = TEMPLATE_POST_TYPES.includes( postType );
 	const hasBackButton =
 		!! onNavigateToPreviousEntityRecord || !! unlockedPatternInfo;
@@ -175,6 +178,7 @@ export default function DocumentBar( props ) {
 		<div
 			className={ clsx( 'editor-document-bar', {
 				'has-back-button': hasBackButton,
+				'has-shortcut': hasShortcut,
 			} ) }
 		>
 			<AnimatePresence>
@@ -208,10 +212,14 @@ export default function DocumentBar( props ) {
 			{ isNotFound ? (
 				<WCText>{ __( 'Document not found' ) }</WCText>
 			) : (
-				<Button
+				<CommandWrapper
 					className="editor-document-bar__command"
-					onClick={ () => openCommandCenter() }
-					size="compact"
+					{ ...( hasShortcut
+						? {
+								onClick: () => openCommandCenter(),
+								size: 'compact',
+						  }
+						: {} ) }
 				>
 					<motion.div
 						className="editor-document-bar__title"
@@ -267,10 +275,12 @@ export default function DocumentBar( props ) {
 								) }
 						</WCText>
 					</motion.div>
-					<span className="editor-document-bar__shortcut">
-						{ displayShortcut.primary( 'k' ) }
-					</span>
-				</Button>
+					{ hasShortcut && (
+						<span className="editor-document-bar__shortcut">
+							{ displayShortcut.primary( 'k' ) }
+						</span>
+					) }
+				</CommandWrapper>
 			) }
 		</div>
 	);

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -142,7 +142,6 @@ export default function DocumentBar( props ) {
 	const isReducedMotion = useReducedMotion();
 
 	const hasShortcut = ! window.__experimentalAdminBarInEditor;
-	const CommandWrapper = hasShortcut ? Button : 'div';
 
 	const isTemplate = TEMPLATE_POST_TYPES.includes( postType );
 	const hasBackButton =
@@ -212,14 +211,10 @@ export default function DocumentBar( props ) {
 			{ isNotFound ? (
 				<WCText>{ __( 'Document not found' ) }</WCText>
 			) : (
-				<CommandWrapper
+				<Button
 					className="editor-document-bar__command"
-					{ ...( hasShortcut
-						? {
-								onClick: () => openCommandCenter(),
-								size: 'compact',
-						  }
-						: {} ) }
+					onClick={ () => openCommandCenter() }
+					size="compact"
 				>
 					<motion.div
 						className="editor-document-bar__title"
@@ -280,7 +275,7 @@ export default function DocumentBar( props ) {
 							{ displayShortcut.primary( 'k' ) }
 						</span>
 					) }
-				</CommandWrapper>
+				</Button>
 			) }
 		</div>
 	);

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -17,7 +17,7 @@
 	border-radius: $grid-unit-05;
 	width: min(100%, 450px);
 
-	&:hover {
+	&.has-shortcut:hover {
 		background-color: $gray-200;
 	}
 
@@ -43,6 +43,9 @@
 }
 
 .editor-document-bar__command {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	flex-grow: 1;
 	color: var(--wp-block-synced-color);
 	overflow: hidden;
@@ -55,8 +58,10 @@
 	max-width: 70%;
 
 	// Offset the layout based on the width of the ⌘K label. This ensures the title is centrally aligned.
-	@include break-medium() {
-		padding-left: $grid-unit-30;
+	.editor-document-bar.has-shortcut & {
+		@include break-medium() {
+			padding-left: $grid-unit-30;
+		}
 	}
 
 	h1 {

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -17,7 +17,7 @@
 	border-radius: $grid-unit-05;
 	width: min(100%, 450px);
 
-	&.has-shortcut:hover {
+	&:hover {
 		background-color: $gray-200;
 	}
 
@@ -43,9 +43,6 @@
 }
 
 .editor-document-bar__command {
-	display: flex;
-	align-items: center;
-	justify-content: center;
 	flex-grow: 1;
 	color: var(--wp-block-synced-color);
 	overflow: hidden;


### PR DESCRIPTION
## What?

Follow-up to https://github.com/WordPress/gutenberg/pull/77964

When the admin bar is shown in the editor (via the above experiment), the cmd-K icon is no longer necessary.

## Why?

Because it's already present in the admin bar. Otherwise, there will be duplicate buttons with the same functionalities that are close by.

## How?

Hide the cmd-K shortcut icon from the document bar component in such case.

## Testing Instructions

1. Go to Gutenberg -> Experiments, scroll all the way down, enable the "Toolbar in editor" experiment.
2. Go to Appearance -> Editor.
3. Verify that the title no longer shows the cmd-K (/ctrl-K) icon.
4. Disable the experiment; verify that the cmd-K icon is back.

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="1032" height="67" alt="image" src="https://github.com/user-attachments/assets/3ee0b836-22c1-4745-85d6-d1d259f4aa6a" />

<img width="1032" height="67" alt="image" src="https://github.com/user-attachments/assets/bf81a103-81ca-40a3-9b4d-2d922d95a4f1" />

### After

<img width="1032" height="100" alt="image" src="https://github.com/user-attachments/assets/02e30b40-5979-4c38-a454-e989fe4df683" />

<img width="1032" height="100" alt="image" src="https://github.com/user-attachments/assets/e61e2c4f-1bcf-4970-a944-beb1bcab8296" />

## Use of AI Tools

I used Claude Opus 4.8 to help with the implementation.