### PR TITLE
Tools: Ban `classnames` via Syncpack

### DIFF
--- a/syncpack.config.mjs
+++ b/syncpack.config.mjs
@@ -8,6 +8,12 @@ export default {
 			isIgnored: true,
 		},
 		{
+			label: 'Banned dependencies that should not be reintroduced.',
+			dependencies: [ 'classnames' ],
+			packages: [ '**' ],
+			isBanned: true,
+		},
+		{
 			label: 'peerDependencies use intentionally wide ranges; only enforce that the ranges are mutually satisfiable.',
 			dependencyTypes: [ 'peer' ],
 			policy: 'sameRange',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds a `Banned` version group to [`syncpack.config.mjs`](https://github.com/WordPress/gutenberg/blob/trunk/syncpack.config.mjs) so that any package.json declaring `classnames` causes `npm run lint:deps` (and CI) to fail.

Follow-up to #77950 — picks up the [`isBanned classnames` suggestion](https://github.com/WordPress/gutenberg/pull/77950#discussion_r4459327291) from @ciampo's review.

## Why?

Gutenberg standardised on `clsx` in [#61138](https://github.com/WordPress/gutenberg/pull/61138) and removed every `classnames` declaration across the monorepo. There is currently no guardrail preventing it from being re-added later — an `npm install classnames --workspace @wordpress/<some-pkg>` in any workspace would land silently and bloat bundles with both libraries side by side.

ESLint's `no-restricted-imports` already catches `import classnames from 'classnames'` at the source level, but **not** a stray `package.json` declaration with no matching `import` — which is exactly what would happen if someone re-adds the dep ahead of refactoring code. Syncpack catches the declaration; ESLint catches the import. Both layers complement each other.

## How?

Single addition to [`syncpack.config.mjs`](https://github.com/WordPress/gutenberg/blob/trunk/syncpack.config.mjs):

```js
{
    label: 'Banned dependencies that should not be reintroduced.',
    dependencies: [ 'classnames' ],
    packages: [ '**' ],
    isBanned: true,
},
```

The rule is purely preventive — no current declarations match, so this PR's diff in actual `package.json` files is empty.

## Testing Instructions

```sh
# 1. Confirm lint passes on this branch as-is (no current `classnames` declarations):
npm run lint:deps          # exits 0, "✓ No issues found"

# 2. Add `classnames` to any workspace and verify the rule fires:
npm install classnames --workspace @wordpress/components
npm run lint:deps          # exits non-zero; reports `IsBanned`

# 3. `lint:deps:fix` removes the banned declaration:
npm run lint:deps:fix
npm run lint:deps          # exits 0 again
```

### Testing Instructions for Keyboard

N/A — tooling/config only.

## Screenshots or screencast

N/A — no UI changes.

## Use of AI Tools

Drafted with assistance from Claude Code. The change and PR description were reviewed and edited by hand.

<img width="682" height="206" alt="Screenshot 2026-06-09 at 10 03 36 PM" src="https://github.com/user-attachments/assets/572579c3-3cd7-4b04-ace7-ef8fb66eda45" />
