### PR TITLE
Image: Fix pasted images stretching when dimensions are preserved

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -422,6 +422,11 @@ export function ImageEdit( {
 		},
 		[ context, isSingleSelected, metadata?.bindings?.url ]
 	);
+	// `height: 'auto'` is not a pinned dimension (it lets the height follow the
+	// aspect ratio, e.g. for an image pasted with both width and height). Treat
+	// it as absent so the placeholder box keeps its aspect ratio and pinned
+	// width instead of collapsing to a 100%×100% fill.
+	const pinnedHeight = height === 'auto' ? undefined : height;
 	const placeholder = ( content ) => {
 		return (
 			<Placeholder
@@ -444,11 +449,11 @@ export function ImageEdit( {
 				}
 				style={ {
 					aspectRatio:
-						! ( width && height ) && aspectRatio
+						! ( width && pinnedHeight ) && aspectRatio
 							? aspectRatio
 							: undefined,
-					width: height && aspectRatio ? '100%' : width,
-					height: width && aspectRatio ? '100%' : height,
+					width: pinnedHeight && aspectRatio ? '100%' : width,
+					height: width && aspectRatio ? '100%' : pinnedHeight,
 					objectFit: scale,
 					...borderProps.style,
 					...shadowProps.style,

--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -52,10 +52,10 @@ const imageSchema = {
 	},
 };
 
-// Read a pixel dimension from an `<img>` HTML attribute and normalise it to
-// the `<value>px` form the Image block stores in its `width` / `height`
-// attributes. Non-integer values (e.g. `50%`) are dropped because the block
-// attribute round-trips through inline styles that expect pixel units.
+// Normalise an `<img>` pixel dimension attribute to the `<value>px` form the
+// Image block stores in its `width`/`height` attributes. Non-integer values
+// (e.g. `50%`) are dropped because the attribute round-trips through inline
+// styles that expect pixel units.
 function parsePixelDimension( value ) {
 	return value && /^\d+$/.test( value ) ? `${ value }px` : undefined;
 }
@@ -114,14 +114,20 @@ const transforms = {
 					anchorElement && anchorElement.className
 						? anchorElement.className
 						: undefined;
-				// Preserve explicit pixel dimensions set on the source `<img>`
-				// (e.g. legacy "Add Media" output: `<img width="77" height="77">`).
-				const width = parsePixelDimension(
+				// Pin only one dimension and let the other follow the natural
+				// ratio via `auto`. Pinning both as fixed pixels stretches the
+				// image when a theme caps the width while the height stays
+				// fixed. So width sources use `height: 'auto'`; height-only
+				// sources use `width: 'auto'`.
+				const widthValue = parsePixelDimension(
 					img.getAttribute( 'width' )
 				);
-				const height = parsePixelDimension(
+				const heightValue = parsePixelDimension(
 					img.getAttribute( 'height' )
 				);
+				const width =
+					widthValue || ( heightValue ? 'auto' : undefined );
+				const height = widthValue ? 'auto' : heightValue;
 				const attributes = getBlockAttributes(
 					'core/image',
 					node.outerHTML,

--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -114,7 +114,7 @@ const transforms = {
 					anchorElement && anchorElement.className
 						? anchorElement.className
 						: undefined;
-				// Pin only one dimension and let the other follow the natural
+				// Pin only one dimension and let the other follow the aspect
 				// ratio via `auto`. Pinning both as fixed pixels stretches the
 				// image when a theme caps the width while the height stays
 				// fixed. So width sources use `height: 'auto'`; height-only
@@ -125,6 +125,25 @@ const transforms = {
 				const heightValue = parsePixelDimension(
 					img.getAttribute( 'height' )
 				);
+				// When both dimensions are declared, preserve the source's
+				// shape via `aspectRatio` (mirroring the resize handle). CSS
+				// `aspect-ratio` needs no fixed dimensions, so the image keeps
+				// its proportions even when the `src` can't resolve to natural
+				// dimensions (e.g. an empty or blob `src`) — without it the
+				// `height: 'auto'` would collapse to `0`.
+				// `parseInt` is `NaN` for an absent dimension and `0` for a
+				// zero one (both falsy), so a bogus ratio is never stored.
+				const widthNumber = parseInt( widthValue, 10 );
+				const heightNumber = parseInt( heightValue, 10 );
+				const aspectRatio =
+					widthNumber && heightNumber
+						? String( widthNumber / heightNumber )
+						: undefined;
+				// A height-only source declares a single dimension, so it can't
+				// carry an aspect ratio: `width: 'auto'` is capped by
+				// `max-width: 100%` while the fixed height can still stretch a
+				// wide source. This is a known edge case (a panoramic image
+				// pinned by height only) left unsolved here.
 				const width =
 					widthValue || ( heightValue ? 'auto' : undefined );
 				const height = widthValue ? 'auto' : heightValue;
@@ -141,6 +160,7 @@ const transforms = {
 						anchor,
 						width,
 						height,
+						aspectRatio,
 					}
 				);
 

--- a/packages/blocks/src/api/raw-handling/test/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/test/paste-handler.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { pasteHandler } from '@wordpress/blocks';
+import { pasteHandler, serialize } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
@@ -338,6 +338,13 @@ describe( 'pasteHandler — core/image', () => {
 		// Height is pinned to `auto` rather than the literal pixel value so the
 		// image scales proportionally when the content width constrains it.
 		expect( result.attributes.height ).toBe( 'auto' );
+		expect( result.attributes.aspectRatio ).toBe( '1' );
+		// The serialized style must keep `height:auto` plus the declared
+		// aspect ratio so a capped width never stretches the image.
+		const serialized = serialize( result );
+		expect( serialized ).toContain( 'width:77px' );
+		expect( serialized ).toContain( 'height:auto' );
+		expect( serialized ).toContain( 'aspect-ratio:1' );
 	} );
 
 	it( 'pins the width and lets the height follow the aspect ratio for an <img> inside a <figure>', () => {
@@ -351,6 +358,32 @@ describe( 'pasteHandler — core/image', () => {
 		expect( result.name ).toBe( 'core/image' );
 		expect( result.attributes.width ).toBe( '120px' );
 		expect( result.attributes.height ).toBe( 'auto' );
+		expect( result.attributes.aspectRatio ).toBe( '1.5' );
+	} );
+
+	it( 'pins the width, sets the aspect ratio, and lifts the anchor for an anchor-wrapped <img> (e.g. a Flickr embed)', () => {
+		const [ result ] = pasteHandler( {
+			HTML: '<a data-flickr-embed="true" href="https://www.flickr.com/photos/x/123/"><img src="https://live.staticflickr.com/65535/123_b.jpg" width="1024" height="683" alt="pexels" /></a>',
+			mode: 'BLOCKS',
+		} );
+
+		expect( console ).toHaveLogged();
+
+		expect( result.name ).toBe( 'core/image' );
+		expect( result.attributes.url ).toBe(
+			'https://live.staticflickr.com/65535/123_b.jpg'
+		);
+		expect( result.attributes.width ).toBe( '1024px' );
+		expect( result.attributes.height ).toBe( 'auto' );
+		expect( result.attributes.aspectRatio ).toBe( String( 1024 / 683 ) );
+		expect( result.attributes.linkDestination ).toBe( 'custom' );
+		expect( result.attributes.href ).toBe(
+			'https://www.flickr.com/photos/x/123/'
+		);
+		const serialized = serialize( result );
+		expect( serialized ).toContain( 'width:1024px' );
+		expect( serialized ).toContain( 'height:auto' );
+		expect( serialized ).toContain( `aspect-ratio:${ 1024 / 683 }` );
 	} );
 
 	it( 'pins the width and lets the height follow when only a width is present', () => {
@@ -364,6 +397,8 @@ describe( 'pasteHandler — core/image', () => {
 		expect( result.name ).toBe( 'core/image' );
 		expect( result.attributes.width ).toBe( '120px' );
 		expect( result.attributes.height ).toBe( 'auto' );
+		// A single declared dimension can't carry an aspect ratio.
+		expect( result.attributes.aspectRatio ).toBeUndefined();
 	} );
 
 	it( 'pins the height and lets the width follow when only a height is present', () => {
@@ -378,6 +413,20 @@ describe( 'pasteHandler — core/image', () => {
 		// A height-only source keeps its height; the width follows via `auto`.
 		expect( result.attributes.width ).toBe( 'auto' );
 		expect( result.attributes.height ).toBe( '80px' );
+		expect( result.attributes.aspectRatio ).toBeUndefined();
+	} );
+
+	it( 'omits the aspect ratio when a dimension is zero', () => {
+		const [ result ] = pasteHandler( {
+			HTML: '<img src="https://example.com/i.jpg" width="100" height="0" />',
+			mode: 'BLOCKS',
+		} );
+
+		expect( console ).toHaveLogged();
+
+		expect( result.name ).toBe( 'core/image' );
+		// A zero dimension would divide to `Infinity`/`NaN`, so no ratio is set.
+		expect( result.attributes.aspectRatio ).toBeUndefined();
 	} );
 
 	it( 'drops non-pixel width/height (e.g. percentages)', () => {

--- a/packages/blocks/src/api/raw-handling/test/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/test/paste-handler.js
@@ -324,7 +324,7 @@ describe( 'pasteHandler — core/image', () => {
 		initAndRegisterImageBlock();
 	} );
 
-	it( 'preserves explicit pixel width and height from a bare <img>', () => {
+	it( 'pins the width and lets the height follow the aspect ratio for a bare <img>', () => {
 		const [ result ] = pasteHandler( {
 			HTML: '<img src="https://example.com/i.jpg" width="77" height="77" />',
 			mode: 'BLOCKS',
@@ -335,10 +335,12 @@ describe( 'pasteHandler — core/image', () => {
 		expect( result.name ).toBe( 'core/image' );
 		expect( result.attributes.url ).toBe( 'https://example.com/i.jpg' );
 		expect( result.attributes.width ).toBe( '77px' );
-		expect( result.attributes.height ).toBe( '77px' );
+		// Height is pinned to `auto` rather than the literal pixel value so the
+		// image scales proportionally when the content width constrains it.
+		expect( result.attributes.height ).toBe( 'auto' );
 	} );
 
-	it( 'preserves explicit pixel width and height from an <img> inside a <figure>', () => {
+	it( 'pins the width and lets the height follow the aspect ratio for an <img> inside a <figure>', () => {
 		const [ result ] = pasteHandler( {
 			HTML: '<figure><img src="https://example.com/i.jpg" width="120" height="80" /></figure>',
 			mode: 'BLOCKS',
@@ -348,6 +350,33 @@ describe( 'pasteHandler — core/image', () => {
 
 		expect( result.name ).toBe( 'core/image' );
 		expect( result.attributes.width ).toBe( '120px' );
+		expect( result.attributes.height ).toBe( 'auto' );
+	} );
+
+	it( 'pins the width and lets the height follow when only a width is present', () => {
+		const [ result ] = pasteHandler( {
+			HTML: '<img src="https://example.com/i.jpg" width="120" />',
+			mode: 'BLOCKS',
+		} );
+
+		expect( console ).toHaveLogged();
+
+		expect( result.name ).toBe( 'core/image' );
+		expect( result.attributes.width ).toBe( '120px' );
+		expect( result.attributes.height ).toBe( 'auto' );
+	} );
+
+	it( 'pins the height and lets the width follow when only a height is present', () => {
+		const [ result ] = pasteHandler( {
+			HTML: '<img src="https://example.com/i.jpg" height="80" />',
+			mode: 'BLOCKS',
+		} );
+
+		expect( console ).toHaveLogged();
+
+		expect( result.name ).toBe( 'core/image' );
+		// A height-only source keeps its height; the width follows via `auto`.
+		expect( result.attributes.width ).toBe( 'auto' );
 		expect( result.attributes.height ).toBe( '80px' );
 	} );
 

--- a/test/integration/fixtures/documents/google-docs-out.html
+++ b/test/integration/fixtures/documents/google-docs-out.html
@@ -54,6 +54,6 @@
 <p>An image:</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"width":"544px","height":"184px"} -->
-<figure class="wp-block-image is-resized"><img src="https://lh4.googleusercontent.com/ID" alt="" style="width:544px;height:184px"/></figure>
+<!-- wp:image {"width":"544px","height":"auto"} -->
+<figure class="wp-block-image is-resized"><img src="https://lh4.googleusercontent.com/ID" alt="" style="width:544px;height:auto"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/google-docs-out.html
+++ b/test/integration/fixtures/documents/google-docs-out.html
@@ -54,6 +54,6 @@
 <p>An image:</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"width":"544px","height":"auto"} -->
-<figure class="wp-block-image is-resized"><img src="https://lh4.googleusercontent.com/ID" alt="" style="width:544px;height:auto"/></figure>
+<!-- wp:image {"width":"544px","height":"auto","aspectRatio":"2.9565217391304346"} -->
+<figure class="wp-block-image is-resized"><img src="https://lh4.googleusercontent.com/ID" alt="" style="aspect-ratio:2.9565217391304346;width:544px;height:auto"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/google-docs-with-comments-out.html
+++ b/test/integration/fixtures/documents/google-docs-with-comments-out.html
@@ -54,6 +54,6 @@
 <p>An image:</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"width":"544px","height":"184px"} -->
-<figure class="wp-block-image is-resized"><img src="https://lh4.googleusercontent.com/ID" alt="" style="width:544px;height:184px"/></figure>
+<!-- wp:image {"width":"544px","height":"auto"} -->
+<figure class="wp-block-image is-resized"><img src="https://lh4.googleusercontent.com/ID" alt="" style="width:544px;height:auto"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/google-docs-with-comments-out.html
+++ b/test/integration/fixtures/documents/google-docs-with-comments-out.html
@@ -54,6 +54,6 @@
 <p>An image:</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"width":"544px","height":"auto"} -->
-<figure class="wp-block-image is-resized"><img src="https://lh4.googleusercontent.com/ID" alt="" style="width:544px;height:auto"/></figure>
+<!-- wp:image {"width":"544px","height":"auto","aspectRatio":"2.9565217391304346"} -->
+<figure class="wp-block-image is-resized"><img src="https://lh4.googleusercontent.com/ID" alt="" style="aspect-ratio:2.9565217391304346;width:544px;height:auto"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/ms-word-out.html
+++ b/test/integration/fixtures/documents/ms-word-out.html
@@ -58,8 +58,8 @@
 <p>An image:</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"width":"451px","height":"338px"} -->
-<figure class="wp-block-image is-resized"><img src="" alt="" style="width:451px;height:338px"/></figure>
+<!-- wp:image {"width":"451px","height":"auto"} -->
+<figure class="wp-block-image is-resized"><img src="" alt="" style="width:451px;height:auto"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->

--- a/test/integration/fixtures/documents/ms-word-out.html
+++ b/test/integration/fixtures/documents/ms-word-out.html
@@ -58,8 +58,8 @@
 <p>An image:</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"width":"451px","height":"auto"} -->
-<figure class="wp-block-image is-resized"><img src="" alt="" style="width:451px;height:auto"/></figure>
+<!-- wp:image {"width":"451px","height":"auto","aspectRatio":"1.334319526627219"} -->
+<figure class="wp-block-image is-resized"><img src="" alt="" style="aspect-ratio:1.334319526627219;width:451px;height:auto"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->

--- a/test/integration/fixtures/documents/one-image-out.html
+++ b/test/integration/fixtures/documents/one-image-out.html
@@ -1,3 +1,3 @@
-<!-- wp:image {"id":5114,"width":"300px","height":"auto"} -->
-<figure class="wp-block-image is-resized"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114" style="width:300px;height:auto"/></figure>
+<!-- wp:image {"id":5114,"width":"300px","height":"auto","aspectRatio":"2.18978102189781"} -->
+<figure class="wp-block-image is-resized"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114" style="aspect-ratio:2.18978102189781;width:300px;height:auto"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/one-image-out.html
+++ b/test/integration/fixtures/documents/one-image-out.html
@@ -1,3 +1,3 @@
-<!-- wp:image {"id":5114,"width":"300px","height":"137px"} -->
-<figure class="wp-block-image is-resized"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114" style="width:300px;height:137px"/></figure>
+<!-- wp:image {"id":5114,"width":"300px","height":"auto"} -->
+<figure class="wp-block-image is-resized"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114" style="width:300px;height:auto"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/two-images-out.html
+++ b/test/integration/fixtures/documents/two-images-out.html
@@ -1,7 +1,7 @@
-<!-- wp:image {"id":5114,"width":"300px","height":"auto"} -->
-<figure class="wp-block-image is-resized"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114" style="width:300px;height:auto"/></figure>
+<!-- wp:image {"id":5114,"width":"300px","height":"auto","aspectRatio":"2.18978102189781"} -->
+<figure class="wp-block-image is-resized"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114" style="aspect-ratio:2.18978102189781;width:300px;height:auto"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"id":5109,"width":"300px","height":"auto"} -->
-<figure class="wp-block-image is-resized"><img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" class="wp-image-5109" style="width:300px;height:auto"/></figure>
+<!-- wp:image {"id":5109,"width":"300px","height":"auto","aspectRatio":"1.2096774193548387"} -->
+<figure class="wp-block-image is-resized"><img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" class="wp-image-5109" style="aspect-ratio:1.2096774193548387;width:300px;height:auto"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/two-images-out.html
+++ b/test/integration/fixtures/documents/two-images-out.html
@@ -1,7 +1,7 @@
-<!-- wp:image {"id":5114,"width":"300px","height":"137px"} -->
-<figure class="wp-block-image is-resized"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114" style="width:300px;height:137px"/></figure>
+<!-- wp:image {"id":5114,"width":"300px","height":"auto"} -->
+<figure class="wp-block-image is-resized"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114" style="width:300px;height:auto"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"id":5109,"width":"300px","height":"248px"} -->
-<figure class="wp-block-image is-resized"><img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" class="wp-image-5109" style="width:300px;height:248px"/></figure>
+<!-- wp:image {"id":5109,"width":"300px","height":"auto"} -->
+<figure class="wp-block-image is-resized"><img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" class="wp-image-5109" style="width:300px;height:auto"/></figure>
 <!-- /wp:image -->


### PR DESCRIPTION
## What?

Follow up to #78610

Fixes pasted images rendering vertically stretched when the source `<img>` carries explicit `width`/`height` attributes (e.g. a Flickr embed code, or a Google Docs / Word paste).

## Why?

Since #78610 the Image block's raw-paste transform preserved both `width` and `height` as fixed pixel values. When a theme's content width caps the width, the height stays pinned at its literal value, forcing the image out of proportion. That commit's goal was to stop converted images from going full-width (#35050); this preserves that while restoring proportional scaling.

## How?

The transform now pins only one dimension and lets the other follow the image's natural aspect ratio via `auto`, mirroring how the block's own resize handle stores dimensions. This preserves the source's display size without pinning both dimensions, which is what caused the stretching.

## Testing Instructions

1. Add an Image block to a post.
2. On Flickr, open a photo, choose Share → Embed, and copy the embed code (one whose `<img>` has large dimensions, e.g. 3648×2736). Or try 

```
<a data-flickr-embed="true" href="https://www.flickr.com/photos/204695550@N06/55326271880/in/dateposted-public/" title="pexels-photo-9881154"><img src="https://live.staticflickr.com/65535/55326271880_8a6a2d4f93_b.jpg" width="1024" height="683" alt="pexels-photo-9881154"/></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
```

4. Paste the embed code into the Image block.
5. Confirm the image scales proportionally to the content width on the canvas, and publish/preview to confirm the same on the front end (previously the height stayed pinned and the image was stretched).

### Testing Instructions for Keyboard

No UI/keyboard surface changes — this only affects the attributes produced when pasting into an Image block.

## Screenshots or screencast

<img width="2800" height="1800" alt="editor-before-after" src="https://github.com/user-attachments/assets/ee523ca7-ebb0-4859-8a8f-5dea3e22a259" />



## Use of AI Tools

This PR was authored with the assistance of Claude Code (Claude Opus). The author reviewed and takes responsibility for all changes.
