### PR TITLE
Build: Add GUTENBERG_CHECK_INSTALLED_DEPS env var to opt out of installed-deps check

### DIFF
--- a/tools/build-scripts/build.mjs
+++ b/tools/build-scripts/build.mjs
@@ -85,17 +85,29 @@ async function build() {
 	const startTime = Date.now();
 
 	try {
-		// Step 0: Verify node_modules is in sync with package-lock.json
-		console.log( '🔍 Checking dependencies...' );
-		await exec( 'npm', [
-			'run',
-			'check-installed-deps',
-			'--workspace',
-			'@wordpress/validation-tools',
-			'--silent',
-		] ).catch( () => {
-			throw new Error( 'Run `npm install` to update.' );
-		} );
+		/*
+		 * Step 0: Verify node_modules is in sync with package-lock.json.
+		 *
+		 * GUTENBERG_CHECK_INSTALLED_DEPS controls when this runs:
+		 *   - `BEFORE_BUILD` (default): pre-build gate.
+		 *   - `NEVER`: skip entirely (sticky opt-out for power users).
+		 */
+		if ( process.env.GUTENBERG_CHECK_INSTALLED_DEPS === 'NEVER' ) {
+			console.log(
+				'🔍 Skipping dependency check (GUTENBERG_CHECK_INSTALLED_DEPS=NEVER).'
+			);
+		} else {
+			console.log( '🔍 Checking dependencies...' );
+			await exec( 'npm', [
+				'run',
+				'check-installed-deps',
+				'--workspace',
+				'@wordpress/validation-tools',
+				'--silent',
+			] ).catch( () => {
+				throw new Error( 'Run `npm install` to update.' );
+			} );
+		}
 
 		console.log( '\n🧹 Cleaning packages...' );
 		await exec( 'npm', [ 'run', 'clean:packages' ], { silent: true } );

--- a/tools/build-scripts/dev.mjs
+++ b/tools/build-scripts/dev.mjs
@@ -121,17 +121,29 @@ async function dev() {
 	readyMarkerFile.cleanup();
 
 	try {
-		// Step 0: Verify node_modules is in sync with package-lock.json
-		console.log( '🔍 Checking dependencies...' );
-		await exec( 'npm', [
-			'run',
-			'check-installed-deps',
-			'--workspace',
-			'@wordpress/validation-tools',
-			'--silent',
-		] ).catch( () => {
-			throw new Error( 'Run `npm install` to update.' );
-		} );
+		/*
+		 * Step 0: Verify node_modules is in sync with package-lock.json.
+		 *
+		 * GUTENBERG_CHECK_INSTALLED_DEPS controls when this runs:
+		 *   - `BEFORE_BUILD` (default): pre-build gate.
+		 *   - `NEVER`: skip entirely (sticky opt-out for power users).
+		 */
+		if ( process.env.GUTENBERG_CHECK_INSTALLED_DEPS === 'NEVER' ) {
+			console.log(
+				'🔍 Skipping dependency check (GUTENBERG_CHECK_INSTALLED_DEPS=NEVER).'
+			);
+		} else {
+			console.log( '🔍 Checking dependencies...' );
+			await exec( 'npm', [
+				'run',
+				'check-installed-deps',
+				'--workspace',
+				'@wordpress/validation-tools',
+				'--silent',
+			] ).catch( () => {
+				throw new Error( 'Run `npm install` to update.' );
+			} );
+		}
 
 		console.log( '\n🧹 Cleaning packages...' );
 		await exec( 'npm', [ 'run', 'clean:packages' ], { silent: true } );


### PR DESCRIPTION
## What?

Follow-up to #77995.

Add an enum-style env var, `GUTENBERG_CHECK_INSTALLED_DEPS`, that lets power users opt out of the installed-deps pre-build check from #77995. The build/dev orchestrators (`tools/build-scripts/build.mjs`, `tools/build-scripts/dev.mjs`) read the env var; setting it to `NEVER` skips the dependency check entirely. Default behaviour is unchanged.

## Why?

In [this thread on #77995](https://github.com/WordPress/gutenberg/pull/77995#issuecomment-4656793065), @Mamaduka flagged that the check causes real friction for maintainers who frequently switch between branches while reviewing PRs:

> Already started noticing this. I have to run `npm install` every time I switch between relatively fresh branches, which can get annoying when you're testing a lot of PRs. In most cases, package updates rarely affect them, unless we're intentionally testing them.

[@aduth suggested](https://github.com/WordPress/gutenberg/pull/77995#issuecomment-4663468395) an opt-out for power users that can be made "sticky" via env var. This PR implements that.

The check itself stays on by default — the safety net for "you pulled a branch with new deps and your build is silently using stale `node_modules`" is the whole reason it exists.

## How?

`tools/build-scripts/build.mjs` and `tools/build-scripts/dev.mjs` branch on `process.env.GUTENBERG_CHECK_INSTALLED_DEPS` before invoking the check. When it's `NEVER`, they log a one-line notice and skip the child-process spawn entirely (rather than spawning a Node process just to read the env var and exit).

The env var is treated as an **enum**, not a boolean, on purpose — see [Future improvements](#future-improvements) below. Today the recognised values are:

| Value | Behaviour |
|---|---|
| `BEFORE_BUILD` *(default)* | Run the check as a pre-build gate. Same as today. |
| `NEVER` | Skip the check entirely. |

Unset, or any unknown value, falls through to the default.

## Usage

### Sticky opt-out (recommended for power users)

Add to `~/.zshrc` / `~/.bashrc` / shell profile:

```sh
export GUTENBERG_CHECK_INSTALLED_DEPS=NEVER
```

Then `npm run build` and `npm run dev` skip the dep check until you remove the line (or override per-command — see below). Mamaduka's branch-hopping flow becomes friction-free.

### One-off opt-out (for a single command)

```sh
GUTENBERG_CHECK_INSTALLED_DEPS=NEVER npm run build
```

Or, if you've made it sticky and want to re-enable the check just once:

```sh
GUTENBERG_CHECK_INSTALLED_DEPS=BEFORE_BUILD npm run build
```

### Default

No env var set — the dep check runs as before.

## Future improvements

The enum shape exists so we can add new modes without breaking anyone's existing opt-out. Concrete extensions that have come up:

- **`ON_FAIL`** — defer the check until after a build failure, then run it as a diagnostic to explain *why* the build broke. Closer to [@manzoorwanijk's suggestion](https://github.com/WordPress/gutenberg/pull/77995#issuecomment-4656987345) in the same thread; trades fast-fail for zero friction on the happy path.
- **A relaxed mode (e.g. `MISSING_ONLY`)** — only block when a required package is entirely absent from `node_modules`, ignore integrity drift on otherwise-installed packages. Catches the "this branch genuinely can't run without an install" case while letting through the "patch version drifted" case Mamaduka described.
- **`WARN`** — print the diagnostic but don't fail the build. Soft nudge instead of a gate.

None of these are in scope here; we can pick them up as separate PRs once we see how the opt-out gets used.

## Testing Instructions

All cases run locally; no wp-env required.

### 1. Default behaviour — check still runs

```sh
unset GUTENBERG_CHECK_INSTALLED_DEPS
npm run build
```

Expected: Step 0 prints `🔍 Checking dependencies...` followed by `   ✔ All good.`, then the build runs through to `🎉 Build completed successfully!`. Same as today.

### 2. `NEVER` — check is skipped

```sh
GUTENBERG_CHECK_INSTALLED_DEPS=NEVER npm run build
```

Expected: Step 0 prints a single line:

```
🔍 Skipping dependency check (GUTENBERG_CHECK_INSTALLED_DEPS=NEVER).
```

…then the build proceeds directly to `🧹 Cleaning packages...`. The validation script never runs (no child-process spawn).

### 3. `NEVER` also covers dev mode

```sh
GUTENBERG_CHECK_INSTALLED_DEPS=NEVER npm run dev
# (Ctrl-C once the watch is set up.)
```

Expected: same `🔍 Skipping dependency check…` line, then `npm run dev` proceeds normally.

### 4. `NEVER` does NOT make a real drift go away

Simulate drift, then confirm `NEVER` lets the build proceed *anyway* (this is the intended trade-off — the check is what catches drift; opting out means you accept the risk):

```sh
node -e '
  const fs = require("fs");
  const hidden = JSON.parse(fs.readFileSync("./node_modules/.package-lock.json", "utf8"));
  delete hidden.packages["node_modules/typescript"];
  fs.writeFileSync("./node_modules/.package-lock.json.tampered", JSON.stringify(hidden));
'
mv node_modules/.package-lock.json node_modules/.package-lock.json.bak
mv node_modules/.package-lock.json.tampered node_modules/.package-lock.json

# With opt-out: build proceeds (and will likely fail later with a TS/build error).
GUTENBERG_CHECK_INSTALLED_DEPS=NEVER npm run build

# Restore:
mv node_modules/.package-lock.json.bak node_modules/.package-lock.json
```

Expected: Step 0 prints the skip notice and does NOT abort. The build will likely fail at a later step (this is the whole reason the default check exists), confirming the opt-out genuinely bypasses the safety net.

### 5. Unknown values fall through to default

```sh
GUTENBERG_CHECK_INSTALLED_DEPS=FOOBAR npm run build
```

Expected: same as test 1 — the check runs as if the env var were unset. (Typos in the env var don't silently disable the check.)

### 6. Sticky opt-out via shell rc

Add `export GUTENBERG_CHECK_INSTALLED_DEPS=NEVER` to `~/.zshrc` (or `~/.bashrc`), `source` it (or open a new shell), then run `npm run build` with no inline env var.

Expected: same skip-notice output as test 2.

## Screenshots or screencast

N/A — CLI-only change.

## Use of AI Tools

This PR was authored with assistance from Claude Code (Anthropic). The opt-out logic, comments, and PR description were drafted with AI assistance; all changes were reviewed and tested locally with each of the env-var values described in the testing instructions.
