### PR TITLE
Editor: Disable saving while a non-post entity is being saved

### DIFF
--- a/packages/editor/src/components/global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/index.js
@@ -41,6 +41,7 @@ export default function EditorKeyboardShortcuts() {
 		isPostSavingLocked,
 		isListViewOpened,
 		getEditorMode,
+		isSavingNonPostEntityChanges,
 	} = useSelect( editorStore );
 
 	useShortcut(
@@ -75,7 +76,7 @@ export default function EditorKeyboardShortcuts() {
 		/**
 		 * Do not save the post if post saving is locked.
 		 */
-		if ( isPostSavingLocked() ) {
+		if ( isPostSavingLocked() || isSavingNonPostEntityChanges() ) {
 			return;
 		}
 

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -48,7 +48,7 @@ export function PostPublishButton( {
 			isPublishable: store.isEditedPostPublishable(),
 			isPublished: store.isCurrentPostPublished(),
 			hasPublishAction:
-				store.getCurrentPost()._links?.[ 'wp:action-publish' ] ?? false,
+				!! store.getCurrentPost()?._links?.[ 'wp:action-publish' ],
 			postType: store.getCurrentPostType(),
 			postId: store.getCurrentPostId(),
 			postStatus: store.getEditedPostAttribute( 'status' ),
@@ -103,18 +103,21 @@ export function PostPublishButton( {
 
 	const isButtonDisabled =
 		isPostSavingLocked ||
+		// Disable while a non-post entity (e.g. a newly created term) is mid-save.
+		isSavingNonPostEntityChanges ||
 		( ( isSaving ||
 			! isSaveable ||
 			( ! isPublishable && ! forceIsDirty ) ) &&
-			( ! hasNonPostEntityChanges || isSavingNonPostEntityChanges ) );
+			! hasNonPostEntityChanges );
 
 	const isToggleDisabled =
 		isPostSavingLocked ||
+		isSavingNonPostEntityChanges ||
 		( ( isPublished ||
 			isSaving ||
 			! isSaveable ||
 			( ! isPublishable && ! forceIsDirty ) ) &&
-			( ! hasNonPostEntityChanges || isSavingNonPostEntityChanges ) );
+			! hasNonPostEntityChanges );
 
 	// If the new status has not changed explicitly, we derive it from
 	// other factors, like having a publish action, etc.. We need to preserve

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -89,6 +89,19 @@ describe( 'PostPublishButton', () => {
 			);
 		} );
 
+		it( 'should be true if a non-post entity is being saved', () => {
+			mockSelector( 'isEditedPostPublishable', true );
+			mockSelector( 'isEditedPostSaveable', true );
+			mockSelector( 'isSavingNonPostEntityChanges', true );
+
+			render( <PostPublishButton /> );
+
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
+			);
+		} );
+
 		it( 'should be false if post is saveable but not publishable and forceIsDirty is true', () => {
 			mockSelector( 'isEditedPostSaveable', true );
 			mockSelector( 'isEditedPostPublishable', false );

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -46,6 +46,7 @@ export default function PostSavedState( { forceIsDirty } ) {
 		isSaveable,
 		isSaving,
 		isSavingLocked,
+		isSavingNonPostEntityChanges,
 		isScheduled,
 		hasPublishAction,
 		showIconLabels,
@@ -54,35 +55,25 @@ export default function PostSavedState( { forceIsDirty } ) {
 		postType,
 	} = useSelect(
 		( select ) => {
-			const {
-				isEditedPostNew,
-				isCurrentPostPublished,
-				isCurrentPostScheduled,
-				isEditedPostDirty,
-				isSavingPost,
-				isEditedPostSaveable,
-				isPostSavingLocked,
-				getCurrentPost,
-				isAutosavingPost,
-				getEditedPostAttribute,
-				getPostEdits,
-			} = select( editorStore );
+			const store = select( editorStore );
 			const { get } = select( preferencesStore );
 			return {
-				isAutosaving: isAutosavingPost(),
-				isDirty: forceIsDirty || isEditedPostDirty(),
-				isNew: isEditedPostNew(),
-				isPublished: isCurrentPostPublished(),
-				isSaving: isSavingPost(),
-				isSaveable: isEditedPostSaveable(),
-				isSavingLocked: isPostSavingLocked(),
-				isScheduled: isCurrentPostScheduled(),
+				isAutosaving: store.isAutosavingPost(),
+				isDirty: forceIsDirty || store.isEditedPostDirty(),
+				isNew: store.isEditedPostNew(),
+				isPublished: store.isCurrentPostPublished(),
+				isSaving: store.isSavingPost(),
+				isSaveable: store.isEditedPostSaveable(),
+				isSavingLocked: store.isPostSavingLocked(),
+				isSavingNonPostEntityChanges:
+					store.isSavingNonPostEntityChanges(),
+				isScheduled: store.isCurrentPostScheduled(),
 				hasPublishAction:
-					getCurrentPost()?._links?.[ 'wp:action-publish' ] ?? false,
+					!! store.getCurrentPost()?._links?.[ 'wp:action-publish' ],
 				showIconLabels: get( 'core', 'showIconLabels' ),
-				postStatus: getEditedPostAttribute( 'status' ),
-				postStatusHasChanged: !! getPostEdits()?.status,
-				postType: select( editorStore ).getCurrentPostType(),
+				postStatus: store.getEditedPostAttribute( 'status' ),
+				postStatusHasChanged: !! store.getPostEdits()?.status,
+				postType: store.getCurrentPostType(),
 			};
 		},
 		[ forceIsDirty ]
@@ -143,7 +134,13 @@ export default function PostSavedState( { forceIsDirty } ) {
 
 	const isSaved = forceSavedMessage || ( ! isNew && ! isDirty );
 	const isSavedState = isSaving || isSaved;
-	const isDisabled = isSaving || isSaved || ! isSaveable || isSavingLocked;
+	const isDisabled =
+		isSaving ||
+		isSaved ||
+		! isSaveable ||
+		isSavingLocked ||
+		// Disable while a non-post entity (e.g. a newly created term) is mid-save.
+		isSavingNonPostEntityChanges;
 	let text;
 
 	if ( isSaving ) {

--- a/packages/editor/src/components/post-saved-state/test/index.js
+++ b/packages/editor/src/components/post-saved-state/test/index.js
@@ -71,6 +71,24 @@ describe( 'PostSavedState', () => {
 		expect( screen.getByRole( 'button' ) ).toMatchSnapshot();
 	} );
 
+	it( 'returns a disabled button while a non-post entity is being saved', () => {
+		useSelect.mockImplementation( () => ( {
+			isDirty: true,
+			isNew: false,
+			isSaveable: true,
+			isSaving: false,
+			isSavingNonPostEntityChanges: true,
+			postStatus: 'draft',
+		} ) );
+
+		render( <PostSavedState /> );
+
+		expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+
 	it( 'should return Saved text if not new and not dirty', () => {
 		useSelect.mockImplementation( () => ( {
 			isDirty: false,


### PR DESCRIPTION
## What?
Closes #78558. Alternative approach to #78659.

Fold `isSavingNonPostEntityChanges` into the disabled state of the Publish (`PostPublishButton`), and Save (`PostSavedState`) buttons directly, so saving is blocked while any non-post entity, e.g., a newly created taxonomy term, is mid-save. No imperative `lockPostSaving` / `lockPostAutosaving` calls in the term selectors.

## Why?
`FlatTermSelector` and `HierarchicalTermSelector` associate a new term with the post only after the `POST /wp/v2/<taxonomy>` request resolves. If the user clicked Publish/Save during that window, the post was saved with the pre-creation term IDs.

`isSavingNonPostEntityChanges` already turns `true` during the create request — the new term is tracked in core-data's `saving` state — but the button logic only consulted it when dirty non-post entity changes already existed (the multi-entity save panel flow from #33140). Hoisting it to a top-level disabled condition covers entity creation as well, keeping the locking declarative rather than sprinkling it across consumer components.

## Testing Instructions
1. Create a page.
2. Throttle network via dev tools.
3. Create a new tag.
4. Confirm that while the tag is being created, the save/publish buttons are disabled.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude. Mostly for review.
