### PR TITLE
Media Editor: Keep the modal skeleton pinned in the editor flow

### DIFF
--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -29,17 +29,17 @@
 		flex-direction: column;
 	}
 
-	// The "Toolbar in editor" experiment (`gutenberg-admin-bar-in-editor`)
+	// The skeleton must always sit in the modal's flow (`top: auto`). The reset
+	// above sets that, but external rules can outrank its low specificity — e.g.
+	// the "Toolbar in editor" experiment (`gutenberg-admin-bar-in-editor`)
 	// offsets every `.interface-interface-skeleton` below the admin bar via a
-	// global `body.has-admin-bar-in-editor.is-fullscreen-mode` rule in
-	// edit-post (>= 782px). Our skeleton renders inside a full-screen modal
-	// that's portaled to `<body>` and already overlays the admin bar, so that
-	// offset shifts the whole editor down and clips the fine-rotation ruler
-	// beneath the canvas. Out-specify it (`&` adds `.media-editor`) and pin the
-	// skeleton back to the flow.
-	body.has-admin-bar-in-editor.is-fullscreen-mode
-	&
-	.interface-interface-skeleton {
+	// `body.has-admin-bar-in-editor.is-fullscreen-mode` rule, which would push
+	// the editor (and the fine-rotation ruler under the canvas) down inside our
+	// full-screen modal that already overlays the admin bar. Re-assert `top` at a
+	// specificity that beats such rules, anchored on the modal frame
+	// (`.media-editor` only ever renders inside `.media-editor-modal`) rather
+	// than on the experiment's class, which may change if it ever graduates.
+	.components-modal__frame.media-editor-modal & .interface-interface-skeleton {
 		top: auto;
 	}
 

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -39,7 +39,7 @@
 	// specificity that beats such rules, anchored on the modal frame
 	// (`.media-editor` only ever renders inside `.media-editor-modal`) rather
 	// than on the experiment's class, which may change if it ever graduates.
-	.components-modal__frame.media-editor-modal & .interface-interface-skeleton {
+	.media-editor-modal & .interface-interface-skeleton.interface-interface-skeleton {
 		top: auto;
 	}
 

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -29,6 +29,20 @@
 		flex-direction: column;
 	}
 
+	// The "Toolbar in editor" experiment (`gutenberg-admin-bar-in-editor`)
+	// offsets every `.interface-interface-skeleton` below the admin bar via a
+	// global `body.has-admin-bar-in-editor.is-fullscreen-mode` rule in
+	// edit-post (>= 782px). Our skeleton renders inside a full-screen modal
+	// that's portaled to `<body>` and already overlays the admin bar, so that
+	// offset shifts the whole editor down and clips the fine-rotation ruler
+	// beneath the canvas. Out-specify it (`&` adds `.media-editor`) and pin the
+	// skeleton back to the flow.
+	body.has-admin-bar-in-editor.is-fullscreen-mode
+	&
+	.interface-interface-skeleton {
+		top: auto;
+	}
+
 	.interface-interface-skeleton__editor {
 		min-width: 0;
 		flex: 1;


### PR DESCRIPTION

## What

Pins the media editor's in-modal `InterfaceSkeleton` to `top: auto` at a specificity that external rules can't override, so the editor and the fine-rotation ruler aren't pushed down inside the modal. Surfaced by the "Toolbar in editor" experiment (`gutenberg-admin-bar-in-editor`).

Props to @andrewserong for tracking down the culprit!

## Why

With that experiment on, edit-post applies a global rule offsetting every `.interface-interface-skeleton` below the admin bar (`body.has-admin-bar-in-editor.is-fullscreen-mode .interface-interface-skeleton { top: admin-bar-height }`, at >= 782px). The media editor renders its own `InterfaceSkeleton` inside a full-screen modal that's portaled to `<body>` and already overlays the admin bar, so that offset shifted the whole editor down by the admin-bar height and clipped the fine-rotation ruler beneath the canvas. The modal's existing `top: auto` reset lost on specificity.

## How

Raised the specificity of the in-modal skeleton's `top: auto` reset by anchoring it on the modal frame (`.media-editor-modal & .interface-interface-skeleton.interface-interface-skeleton`), so it always wins. 

## Manual testing

1. In Gutenberg experiments, enable "Toolbar in editor".
2. Open the post editor (fullscreen mode, viewport >= 782px) and edit an image to open the media editor modal.
3. Confirm the modal fills the screen and the fine-rotation ruler under the canvas is fully visible, not pushed down or clipped.
4. Disable the experiment and confirm the modal still looks correct (no change).
5. Narrow the viewport below 782px with the experiment on and confirm the modal is unaffected.


## Screenshots

| Before | After |
|--------|--------|
| <img width="1466" height="742" alt="Screenshot 2026-06-10 at 2 55 12 pm" src="https://github.com/user-attachments/assets/4cf5547f-23bf-40e9-bc08-c68f0affddc6" /> | <img width="1413" height="717" alt="Screenshot 2026-06-10 at 2 54 40 pm" src="https://github.com/user-attachments/assets/61501cd1-4e4d-4457-9b57-93d08ea3b74a" /> | 



