### PR TITLE
Correct behaviour of flex child fixed width and introduce max width option

### DIFF
--- a/backport-changelog/7.1/12172.md
+++ b/backport-changelog/7.1/12172.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12172
+
+* https://github.com/WordPress/gutenberg/pull/79073

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -834,7 +834,7 @@ For the `flow` layout type only, determines display of the "Inner blocks use con
 -   Type: `boolean`
 -   Default value: `false`
 
-For the `flex` layout type only, determines display of sizing controls (Fit/Fill/Fixed) on all child blocks of the flex block.
+For the `flex` layout type only, determines display of sizing controls (Fit/Grow/Max width/Fixed) on all child blocks of the flex block.
 
 ### layout.allowVerticalAlignment
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -320,27 +320,42 @@ function gutenberg_get_child_layout_style_rules( $selector, $child_layout, $pare
 	$self_stretch      = $child_layout['selfStretch'] ?? null;
 	$base_self_stretch = $base_child_layout['selfStretch'] ?? null;
 
+	/*
+	 * These are the serialized `selfStretch` values. `max` used to be called
+	 * "Fixed" in the UI, but was renamed and replaced by `fixedNoShrink`.
+	 */
+	$flex_child_layout_values = array(
+		'fit'   => 'fit',
+		'grow'  => 'fill',
+		'max'   => 'fixed',
+		'fixed' => 'fixedNoShrink',
+	);
+	$flex_size_values         = array(
+		$flex_child_layout_values['max'],
+		$flex_child_layout_values['fixed'],
+	);
+
 	if ( null === $viewport_overrides || $has_viewport_property_override( 'selfStretch' ) || $has_viewport_property_override( 'flexSize' ) ) {
 		if (
 			null !== $viewport_overrides &&
-			( 'fit' === $self_stretch || 'fill' === $self_stretch ) &&
-			( 'fixed' === $base_self_stretch || 'fixedNoShrink' === $base_self_stretch ) &&
+			( $flex_child_layout_values['fit'] === $self_stretch || $flex_child_layout_values['grow'] === $self_stretch ) &&
+			in_array( $base_self_stretch, $flex_size_values, true ) &&
 			isset( $base_child_layout['flexSize'] )
 		) {
 			$child_layout_declarations['flex-basis'] = 'unset';
-			if ( 'fixedNoShrink' === $base_self_stretch ) {
+			if ( $flex_child_layout_values['fixed'] === $base_self_stretch ) {
 				$child_layout_declarations['flex-shrink'] = 'unset';
 			}
 		}
-		if ( ( 'fixed' === $self_stretch || 'fixedNoShrink' === $self_stretch ) && isset( $child_layout['flexSize'] ) ) {
+		if ( in_array( $self_stretch, $flex_size_values, true ) && isset( $child_layout['flexSize'] ) ) {
 			$child_layout_declarations['flex-basis'] = $child_layout['flexSize'];
-			if ( 'fixedNoShrink' === $self_stretch ) {
+			if ( $flex_child_layout_values['fixed'] === $self_stretch ) {
 				$child_layout_declarations['flex-shrink'] = '0';
-			} elseif ( null !== $viewport_overrides && 'fixedNoShrink' === $base_self_stretch ) {
+			} elseif ( null !== $viewport_overrides && $flex_child_layout_values['fixed'] === $base_self_stretch ) {
 				$child_layout_declarations['flex-shrink'] = 'unset';
 			}
 			$child_layout_declarations['box-sizing'] = 'border-box';
-		} elseif ( 'fill' === $self_stretch ) {
+		} elseif ( $flex_child_layout_values['grow'] === $self_stretch ) {
 			$child_layout_declarations['flex-grow'] = '1';
 		}
 	}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -317,13 +317,27 @@ function gutenberg_get_child_layout_style_rules( $selector, $child_layout, $pare
 		return array_key_exists( $property, $viewport_overrides );
 	};
 
-	$self_stretch = $child_layout['selfStretch'] ?? null;
+	$self_stretch      = $child_layout['selfStretch'] ?? null;
+	$base_self_stretch = $base_child_layout['selfStretch'] ?? null;
 
 	if ( null === $viewport_overrides || $has_viewport_property_override( 'selfStretch' ) || $has_viewport_property_override( 'flexSize' ) ) {
+		if (
+			null !== $viewport_overrides &&
+			( 'fit' === $self_stretch || 'fill' === $self_stretch ) &&
+			( 'fixed' === $base_self_stretch || 'fixedNoShrink' === $base_self_stretch ) &&
+			isset( $base_child_layout['flexSize'] )
+		) {
+			$child_layout_declarations['flex-basis'] = 'unset';
+			if ( 'fixedNoShrink' === $base_self_stretch ) {
+				$child_layout_declarations['flex-shrink'] = 'unset';
+			}
+		}
 		if ( ( 'fixed' === $self_stretch || 'fixedNoShrink' === $self_stretch ) && isset( $child_layout['flexSize'] ) ) {
 			$child_layout_declarations['flex-basis'] = $child_layout['flexSize'];
 			if ( 'fixedNoShrink' === $self_stretch ) {
 				$child_layout_declarations['flex-shrink'] = '0';
+			} elseif ( null !== $viewport_overrides && 'fixedNoShrink' === $base_self_stretch ) {
+				$child_layout_declarations['flex-shrink'] = 'unset';
 			}
 			$child_layout_declarations['box-sizing'] = 'border-box';
 		} elseif ( 'fill' === $self_stretch ) {

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -320,8 +320,11 @@ function gutenberg_get_child_layout_style_rules( $selector, $child_layout, $pare
 	$self_stretch = $child_layout['selfStretch'] ?? null;
 
 	if ( null === $viewport_overrides || $has_viewport_property_override( 'selfStretch' ) || $has_viewport_property_override( 'flexSize' ) ) {
-		if ( 'fixed' === $self_stretch && isset( $child_layout['flexSize'] ) ) {
+		if ( ( 'fixed' === $self_stretch || 'fixedNoShrink' === $self_stretch ) && isset( $child_layout['flexSize'] ) ) {
 			$child_layout_declarations['flex-basis'] = $child_layout['flexSize'];
+			if ( 'fixedNoShrink' === $self_stretch ) {
+				$child_layout_declarations['flex-shrink'] = '0';
+			}
 			$child_layout_declarations['box-sizing'] = 'border-box';
 		} elseif ( 'fill' === $self_stretch ) {
 			$child_layout_declarations['flex-grow'] = '1';

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -23,6 +23,24 @@ import { useGetNumberOfBlocksBeforeCell } from '../grid/use-get-number-of-blocks
 import { store as blockEditorStore } from '../../store';
 import { useSettings } from '../use-settings';
 
+// These are the serialized `selfStretch` values. `max` used to be called
+// "Fixed" in the UI, but was renamed and replaced by `fixedNoShrink`.
+const FLEX_CHILD_LAYOUT_VALUES = {
+	fit: 'fit',
+	grow: 'fill',
+	max: 'fixed',
+	fixed: 'fixedNoShrink',
+};
+
+const FLEX_SIZE_VALUES = [
+	FLEX_CHILD_LAYOUT_VALUES.max,
+	FLEX_CHILD_LAYOUT_VALUES.fixed,
+];
+
+function isFlexSizeValue( value ) {
+	return FLEX_SIZE_VALUES.includes( value );
+}
+
 function maxSizeLabel( parentLayout ) {
 	const { orientation = 'horizontal' } = parentLayout ?? {};
 	return orientation === 'horizontal'
@@ -33,20 +51,23 @@ function maxSizeLabel( parentLayout ) {
 function helpText( flexControlValue, parentLayout ) {
 	const { orientation = 'horizontal' } = parentLayout ?? {};
 
-	if ( flexControlValue === 'fill' ) {
+	if ( flexControlValue === FLEX_CHILD_LAYOUT_VALUES.grow ) {
 		return __( 'Stretch to fill available space.' );
 	}
-	if ( flexControlValue === 'fixed' && orientation === 'horizontal' ) {
+	if (
+		flexControlValue === FLEX_CHILD_LAYOUT_VALUES.max &&
+		orientation === 'horizontal'
+	) {
 		return __( 'Specify a maximum width.' );
-	} else if ( flexControlValue === 'fixed' ) {
+	} else if ( flexControlValue === FLEX_CHILD_LAYOUT_VALUES.max ) {
 		return __( 'Specify a maximum height.' );
 	}
 	if (
-		flexControlValue === 'fixedNoShrink' &&
+		flexControlValue === FLEX_CHILD_LAYOUT_VALUES.fixed &&
 		orientation === 'horizontal'
 	) {
 		return __( 'Specify a fixed width.' );
-	} else if ( flexControlValue === 'fixedNoShrink' ) {
+	} else if ( flexControlValue === FLEX_CHILD_LAYOUT_VALUES.fixed ) {
 		return __( 'Specify a fixed height.' );
 	}
 	return __( 'Fit contents.' );
@@ -114,9 +135,8 @@ function FlexControls( {
 } ) {
 	const { selfStretch, flexSize } = childLayout;
 	const { orientation = 'horizontal' } = parentLayout ?? {};
-	const flexControlValue = selfStretch || 'fit';
-	const hasFlexSizeValue =
-		flexControlValue === 'fixed' || flexControlValue === 'fixedNoShrink';
+	const flexControlValue = selfStretch || FLEX_CHILD_LAYOUT_VALUES.fit;
+	const hasFlexSizeValue = isFlexSizeValue( flexControlValue );
 	const hasFlexValue = () => !! selfStretch;
 	const flexResetLabel =
 		orientation === 'horizontal' ? __( 'Width' ) : __( 'Height' );
@@ -139,13 +159,10 @@ function FlexControls( {
 	};
 
 	useEffect( () => {
-		if (
-			( selfStretch === 'fixed' || selfStretch === 'fixedNoShrink' ) &&
-			! flexSize
-		) {
+		if ( isFlexSizeValue( selfStretch ) && ! flexSize ) {
 			onChange( {
 				...childLayout,
-				selfStretch: 'fit',
+				selfStretch: FLEX_CHILD_LAYOUT_VALUES.fit,
 			} );
 		}
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
@@ -166,9 +183,9 @@ function FlexControls( {
 				value={ flexControlValue }
 				help={ helpText( flexControlValue, parentLayout ) }
 				onChange={ ( value ) => {
-					const isFlexSizeValue =
-						value === 'fixed' || value === 'fixedNoShrink';
-					const newFlexSize = isFlexSizeValue ? flexSize : null;
+					const newFlexSize = isFlexSizeValue( value )
+						? flexSize
+						: null;
 					onChange( {
 						selfStretch: value,
 						flexSize: newFlexSize,
@@ -177,29 +194,29 @@ function FlexControls( {
 				isBlock
 			>
 				<ToggleGroupControlOption
-					key="fit"
-					value="fit"
+					key={ FLEX_CHILD_LAYOUT_VALUES.fit }
+					value={ FLEX_CHILD_LAYOUT_VALUES.fit }
 					label={ _x(
 						'Fit',
 						'Intrinsic block width in flex layout'
 					) }
 				/>
 				<ToggleGroupControlOption
-					key="fill"
-					value="fill"
+					key={ FLEX_CHILD_LAYOUT_VALUES.grow }
+					value={ FLEX_CHILD_LAYOUT_VALUES.grow }
 					label={ _x(
 						'Grow',
 						'Block with expanding width in flex layout'
 					) }
 				/>
 				<ToggleGroupControlOption
-					key="fixed"
-					value="fixed"
+					key={ FLEX_CHILD_LAYOUT_VALUES.max }
+					value={ FLEX_CHILD_LAYOUT_VALUES.max }
 					label={ maxSizeLabel( parentLayout ) }
 				/>
 				<ToggleGroupControlOption
-					key="fixedNoShrink"
-					value="fixedNoShrink"
+					key={ FLEX_CHILD_LAYOUT_VALUES.fixed }
+					value={ FLEX_CHILD_LAYOUT_VALUES.fixed }
 					label={ _x(
 						'Fixed',
 						'Block with fixed width in flex layout'

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -26,8 +26,8 @@ import { useSettings } from '../use-settings';
 function maxSizeLabel( parentLayout ) {
 	const { orientation = 'horizontal' } = parentLayout ?? {};
 	return orientation === 'horizontal'
-		? _x( 'Max width', 'Block with maximum width in flex layout' )
-		: _x( 'Max height', 'Block with maximum height in flex layout' );
+		? _x( 'Max', 'Block with maximum width in flex layout' )
+		: _x( 'Max', 'Block with maximum height in flex layout' );
 }
 
 function helpText( flexControlValue, parentLayout ) {

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -23,15 +23,30 @@ import { useGetNumberOfBlocksBeforeCell } from '../grid/use-get-number-of-blocks
 import { store as blockEditorStore } from '../../store';
 import { useSettings } from '../use-settings';
 
-function helpText( selfStretch, parentLayout ) {
-	const { orientation = 'horizontal' } = parentLayout;
+function maxSizeLabel( parentLayout ) {
+	const { orientation = 'horizontal' } = parentLayout ?? {};
+	return orientation === 'horizontal'
+		? _x( 'Max width', 'Block with maximum width in flex layout' )
+		: _x( 'Max height', 'Block with maximum height in flex layout' );
+}
 
-	if ( selfStretch === 'fill' ) {
+function helpText( flexControlValue, parentLayout ) {
+	const { orientation = 'horizontal' } = parentLayout ?? {};
+
+	if ( flexControlValue === 'fill' ) {
 		return __( 'Stretch to fill available space.' );
 	}
-	if ( selfStretch === 'fixed' && orientation === 'horizontal' ) {
+	if ( flexControlValue === 'fixed' && orientation === 'horizontal' ) {
+		return __( 'Specify a maximum width.' );
+	} else if ( flexControlValue === 'fixed' ) {
+		return __( 'Specify a maximum height.' );
+	}
+	if (
+		flexControlValue === 'fixedNoShrink' &&
+		orientation === 'horizontal'
+	) {
 		return __( 'Specify a fixed width.' );
-	} else if ( selfStretch === 'fixed' ) {
+	} else if ( flexControlValue === 'fixedNoShrink' ) {
 		return __( 'Specify a fixed height.' );
 	}
 	return __( 'Fit contents.' );
@@ -99,6 +114,9 @@ function FlexControls( {
 } ) {
 	const { selfStretch, flexSize } = childLayout;
 	const { orientation = 'horizontal' } = parentLayout ?? {};
+	const flexControlValue = selfStretch || 'fit';
+	const hasFlexSizeValue =
+		flexControlValue === 'fixed' || flexControlValue === 'fixedNoShrink';
 	const hasFlexValue = () => !! selfStretch;
 	const flexResetLabel =
 		orientation === 'horizontal' ? __( 'Width' ) : __( 'Height' );
@@ -121,13 +139,16 @@ function FlexControls( {
 	};
 
 	useEffect( () => {
-		if ( selfStretch === 'fixed' && ! flexSize ) {
+		if (
+			( selfStretch === 'fixed' || selfStretch === 'fixedNoShrink' ) &&
+			! flexSize
+		) {
 			onChange( {
 				...childLayout,
 				selfStretch: 'fit',
 			} );
 		}
-	}, [] );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return (
 		<VStack
@@ -142,10 +163,12 @@ function FlexControls( {
 			<ToggleGroupControl
 				size="__unstable-large"
 				label={ childLayoutOrientation( parentLayout ) }
-				value={ selfStretch || 'fit' }
-				help={ helpText( selfStretch, parentLayout ) }
+				value={ flexControlValue }
+				help={ helpText( flexControlValue, parentLayout ) }
 				onChange={ ( value ) => {
-					const newFlexSize = value !== 'fixed' ? null : flexSize;
+					const isFlexSizeValue =
+						value === 'fixed' || value === 'fixedNoShrink';
+					const newFlexSize = isFlexSizeValue ? flexSize : null;
 					onChange( {
 						selfStretch: value,
 						flexSize: newFlexSize,
@@ -172,19 +195,24 @@ function FlexControls( {
 				<ToggleGroupControlOption
 					key="fixed"
 					value="fixed"
+					label={ maxSizeLabel( parentLayout ) }
+				/>
+				<ToggleGroupControlOption
+					key="fixedNoShrink"
+					value="fixedNoShrink"
 					label={ _x(
 						'Fixed',
 						'Block with fixed width in flex layout'
 					) }
 				/>
 			</ToggleGroupControl>
-			{ selfStretch === 'fixed' && (
+			{ hasFlexSizeValue && (
 				<UnitControl
 					size="__unstable-large"
 					units={ units }
 					onChange={ ( value ) => {
 						onChange( {
-							selfStretch,
+							selfStretch: flexControlValue,
 							flexSize: value,
 						} );
 					} }
@@ -199,7 +227,7 @@ function FlexControls( {
 }
 
 export function childLayoutOrientation( parentLayout ) {
-	const { orientation = 'horizontal' } = parentLayout;
+	const { orientation = 'horizontal' } = parentLayout ?? {};
 	return orientation === 'horizontal' ? __( 'Width' ) : __( 'Height' );
 }
 

--- a/packages/block-editor/src/components/child-layout-control/test/index.js
+++ b/packages/block-editor/src/components/child-layout-control/test/index.js
@@ -14,6 +14,10 @@ import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
  */
 import ChildLayoutControl from '../';
 
+jest.mock( '../../use-settings', () => ( {
+	useSettings: () => [ undefined ],
+} ) );
+
 jest.mock( '@wordpress/data/src/components/use-select', () =>
 	jest.fn( ( mapSelect ) => {
 		if ( typeof mapSelect === 'function' ) {
@@ -121,6 +125,68 @@ describe( 'ChildLayoutControl', () => {
 			rowStart: undefined,
 			rowSpan: undefined,
 			columnSpan: 1,
+		} );
+	} );
+
+	it( 'shows legacy fixed flex sizing as max width', () => {
+		renderControl( {
+			parentLayout: {
+				type: 'flex',
+				orientation: 'horizontal',
+			},
+			value: {
+				selfStretch: 'fixed',
+				flexSize: '320px',
+			},
+		} );
+
+		expect(
+			screen.getByRole( 'radio', { name: 'Max width' } )
+		).toBeChecked();
+	} );
+
+	it( 'sets fixedNoShrink when selecting fixed flex sizing', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		renderControl( {
+			parentLayout: {
+				type: 'flex',
+				orientation: 'horizontal',
+			},
+			value: {},
+			onChange,
+		} );
+
+		await user.click( screen.getByRole( 'radio', { name: 'Fixed' } ) );
+
+		expect( onChange ).toHaveBeenCalledWith( {
+			selfStretch: 'fixedNoShrink',
+			flexSize: undefined,
+		} );
+	} );
+
+	it( 'sets legacy fixed when selecting max width', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		renderControl( {
+			parentLayout: {
+				type: 'flex',
+				orientation: 'horizontal',
+			},
+			value: {
+				selfStretch: 'fixedNoShrink',
+				flexSize: '320px',
+			},
+			onChange,
+		} );
+
+		await user.click( screen.getByRole( 'radio', { name: 'Max width' } ) );
+
+		expect( onChange ).toHaveBeenCalledWith( {
+			selfStretch: 'fixed',
+			flexSize: '320px',
 		} );
 	} );
 } );

--- a/packages/block-editor/src/components/child-layout-control/test/index.js
+++ b/packages/block-editor/src/components/child-layout-control/test/index.js
@@ -128,7 +128,7 @@ describe( 'ChildLayoutControl', () => {
 		} );
 	} );
 
-	it( 'shows legacy fixed flex sizing as max width', () => {
+	it( 'shows legacy fixed flex sizing as max', () => {
 		renderControl( {
 			parentLayout: {
 				type: 'flex',
@@ -140,9 +140,7 @@ describe( 'ChildLayoutControl', () => {
 			},
 		} );
 
-		expect(
-			screen.getByRole( 'radio', { name: 'Max width' } )
-		).toBeChecked();
+		expect( screen.getByRole( 'radio', { name: 'Max' } ) ).toBeChecked();
 	} );
 
 	it( 'sets fixedNoShrink when selecting fixed flex sizing', async () => {
@@ -166,7 +164,7 @@ describe( 'ChildLayoutControl', () => {
 		} );
 	} );
 
-	it( 'sets legacy fixed when selecting max width', async () => {
+	it( 'sets legacy fixed when selecting max sizing', async () => {
 		const user = userEvent.setup();
 		const onChange = jest.fn();
 
@@ -182,7 +180,7 @@ describe( 'ChildLayoutControl', () => {
 			onChange,
 		} );
 
-		await user.click( screen.getByRole( 'radio', { name: 'Max width' } ) );
+		await user.click( screen.getByRole( 'radio', { name: 'Max' } ) );
 
 		expect( onChange ).toHaveBeenCalledWith( {
 			selfStretch: 'fixed',

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -60,6 +60,7 @@ export function getChildLayoutStyleRules( {
 		columnSpan,
 		rowSpan,
 	} = effectiveLayout;
+	const baseSelfStretch = layout.selfStretch;
 	const { columnCount, minimumColumnWidth } = parentLayout;
 	const rules = [];
 
@@ -70,12 +71,29 @@ export function getChildLayoutStyleRules( {
 		hasViewportOverride( 'flexSize' )
 	) {
 		if (
+			hasViewportOverrides &&
+			( selfStretch === 'fit' || selfStretch === 'fill' ) &&
+			( baseSelfStretch === 'fixed' ||
+				baseSelfStretch === 'fixedNoShrink' ) &&
+			layout.flexSize
+		) {
+			declarations[ 'flex-basis' ] = 'unset';
+			if ( baseSelfStretch === 'fixedNoShrink' ) {
+				declarations[ 'flex-shrink' ] = 'unset';
+			}
+		}
+		if (
 			( selfStretch === 'fixed' || selfStretch === 'fixedNoShrink' ) &&
 			flexSize
 		) {
 			declarations[ 'flex-basis' ] = flexSize;
 			if ( selfStretch === 'fixedNoShrink' ) {
 				declarations[ 'flex-shrink' ] = '0';
+			} else if (
+				hasViewportOverrides &&
+				baseSelfStretch === 'fixedNoShrink'
+			) {
+				declarations[ 'flex-shrink' ] = 'unset';
 			}
 			declarations[ 'box-sizing' ] = 'border-box';
 		} else if ( selfStretch === 'fill' ) {

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -28,6 +28,24 @@ const RESPONSIVE_BREAKPOINTS = {
 	tablet: '@media (480px < width <= 782px)',
 };
 
+// These are the serialized `selfStretch` values. `max` used to be called
+// "Fixed" in the UI, but was renamed and replaced by `fixedNoShrink`.
+const FLEX_CHILD_LAYOUT_VALUES = {
+	fit: 'fit',
+	grow: 'fill',
+	max: 'fixed',
+	fixed: 'fixedNoShrink',
+};
+
+const FLEX_SIZE_VALUES = [
+	FLEX_CHILD_LAYOUT_VALUES.max,
+	FLEX_CHILD_LAYOUT_VALUES.fixed,
+];
+
+function isFlexSizeValue( value ) {
+	return FLEX_SIZE_VALUES.includes( value );
+}
+
 function serializeRule( { selector, declarations } ) {
 	return `${ selector } {
 		${ Object.entries( declarations )
@@ -72,31 +90,28 @@ export function getChildLayoutStyleRules( {
 	) {
 		if (
 			hasViewportOverrides &&
-			( selfStretch === 'fit' || selfStretch === 'fill' ) &&
-			( baseSelfStretch === 'fixed' ||
-				baseSelfStretch === 'fixedNoShrink' ) &&
+			( selfStretch === FLEX_CHILD_LAYOUT_VALUES.fit ||
+				selfStretch === FLEX_CHILD_LAYOUT_VALUES.grow ) &&
+			isFlexSizeValue( baseSelfStretch ) &&
 			layout.flexSize
 		) {
 			declarations[ 'flex-basis' ] = 'unset';
-			if ( baseSelfStretch === 'fixedNoShrink' ) {
+			if ( baseSelfStretch === FLEX_CHILD_LAYOUT_VALUES.fixed ) {
 				declarations[ 'flex-shrink' ] = 'unset';
 			}
 		}
-		if (
-			( selfStretch === 'fixed' || selfStretch === 'fixedNoShrink' ) &&
-			flexSize
-		) {
+		if ( isFlexSizeValue( selfStretch ) && flexSize ) {
 			declarations[ 'flex-basis' ] = flexSize;
-			if ( selfStretch === 'fixedNoShrink' ) {
+			if ( selfStretch === FLEX_CHILD_LAYOUT_VALUES.fixed ) {
 				declarations[ 'flex-shrink' ] = '0';
 			} else if (
 				hasViewportOverrides &&
-				baseSelfStretch === 'fixedNoShrink'
+				baseSelfStretch === FLEX_CHILD_LAYOUT_VALUES.fixed
 			) {
 				declarations[ 'flex-shrink' ] = 'unset';
 			}
 			declarations[ 'box-sizing' ] = 'border-box';
-		} else if ( selfStretch === 'fill' ) {
+		} else if ( selfStretch === FLEX_CHILD_LAYOUT_VALUES.grow ) {
 			declarations[ 'flex-grow' ] = '1';
 		}
 	}

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -69,8 +69,14 @@ export function getChildLayoutStyleRules( {
 		hasViewportOverride( 'selfStretch' ) ||
 		hasViewportOverride( 'flexSize' )
 	) {
-		if ( selfStretch === 'fixed' && flexSize ) {
+		if (
+			( selfStretch === 'fixed' || selfStretch === 'fixedNoShrink' ) &&
+			flexSize
+		) {
 			declarations[ 'flex-basis' ] = flexSize;
+			if ( selfStretch === 'fixedNoShrink' ) {
+				declarations[ 'flex-shrink' ] = '0';
+			}
 			declarations[ 'box-sizing' ] = 'border-box';
 		} else if ( selfStretch === 'fill' ) {
 			declarations[ 'flex-grow' ] = '1';

--- a/packages/block-editor/src/hooks/test/layout-child.js
+++ b/packages/block-editor/src/hooks/test/layout-child.js
@@ -1,0 +1,72 @@
+/**
+ * Internal dependencies
+ */
+import { getChildLayoutStyleRules } from '../layout-child';
+
+describe( 'layout child', () => {
+	describe( 'getChildLayoutStyleRules()', () => {
+		it( 'preserves legacy fixed sizing as shrinkable max width', () => {
+			expect(
+				getChildLayoutStyleRules( {
+					selector: '.wp-container-content-test',
+					layout: {
+						selfStretch: 'fixed',
+						flexSize: '320px',
+					},
+				} )
+			).toEqual( [
+				{
+					selector: '.wp-container-content-test',
+					declarations: {
+						'flex-basis': '320px',
+						'box-sizing': 'border-box',
+					},
+				},
+			] );
+		} );
+
+		it( 'adds flex-shrink for fixedNoShrink sizing', () => {
+			expect(
+				getChildLayoutStyleRules( {
+					selector: '.wp-container-content-test',
+					layout: {
+						selfStretch: 'fixedNoShrink',
+						flexSize: '320px',
+					},
+				} )
+			).toEqual( [
+				{
+					selector: '.wp-container-content-test',
+					declarations: {
+						'flex-basis': '320px',
+						'flex-shrink': '0',
+						'box-sizing': 'border-box',
+					},
+				},
+			] );
+		} );
+
+		it( 'allows viewport overrides to switch fixedNoShrink to max width', () => {
+			expect(
+				getChildLayoutStyleRules( {
+					selector: '.wp-container-content-test',
+					layout: {
+						selfStretch: 'fixedNoShrink',
+						flexSize: '320px',
+					},
+					viewportOverrides: {
+						selfStretch: 'fixed',
+					},
+				} )
+			).toEqual( [
+				{
+					selector: '.wp-container-content-test',
+					declarations: {
+						'flex-basis': '320px',
+						'box-sizing': 'border-box',
+					},
+				},
+			] );
+		} );
+	} );
+} );

--- a/packages/block-editor/src/hooks/test/layout-child.js
+++ b/packages/block-editor/src/hooks/test/layout-child.js
@@ -46,7 +46,7 @@ describe( 'layout child', () => {
 			] );
 		} );
 
-		it( 'allows viewport overrides to switch fixedNoShrink to max width', () => {
+		it( 'allows viewport overrides to switch fixedNoShrink to max', () => {
 			expect(
 				getChildLayoutStyleRules( {
 					selector: '.wp-container-content-test',
@@ -63,7 +63,100 @@ describe( 'layout child', () => {
 					selector: '.wp-container-content-test',
 					declarations: {
 						'flex-basis': '320px',
+						'flex-shrink': 'unset',
 						'box-sizing': 'border-box',
+					},
+				},
+			] );
+		} );
+
+		it( 'allows viewport overrides to switch fixedNoShrink to fit', () => {
+			expect(
+				getChildLayoutStyleRules( {
+					selector: '.wp-container-content-test',
+					layout: {
+						selfStretch: 'fixedNoShrink',
+						flexSize: '320px',
+					},
+					viewportOverrides: {
+						selfStretch: 'fit',
+					},
+				} )
+			).toEqual( [
+				{
+					selector: '.wp-container-content-test',
+					declarations: {
+						'flex-basis': 'unset',
+						'flex-shrink': 'unset',
+					},
+				},
+			] );
+		} );
+
+		it( 'allows viewport overrides to switch fixed to fit', () => {
+			expect(
+				getChildLayoutStyleRules( {
+					selector: '.wp-container-content-test',
+					layout: {
+						selfStretch: 'fixed',
+						flexSize: '320px',
+					},
+					viewportOverrides: {
+						selfStretch: 'fit',
+					},
+				} )
+			).toEqual( [
+				{
+					selector: '.wp-container-content-test',
+					declarations: {
+						'flex-basis': 'unset',
+					},
+				},
+			] );
+		} );
+
+		it( 'allows viewport overrides to switch fixedNoShrink to grow', () => {
+			expect(
+				getChildLayoutStyleRules( {
+					selector: '.wp-container-content-test',
+					layout: {
+						selfStretch: 'fixedNoShrink',
+						flexSize: '320px',
+					},
+					viewportOverrides: {
+						selfStretch: 'fill',
+					},
+				} )
+			).toEqual( [
+				{
+					selector: '.wp-container-content-test',
+					declarations: {
+						'flex-basis': 'unset',
+						'flex-shrink': 'unset',
+						'flex-grow': '1',
+					},
+				},
+			] );
+		} );
+
+		it( 'allows viewport overrides to switch fixed to grow', () => {
+			expect(
+				getChildLayoutStyleRules( {
+					selector: '.wp-container-content-test',
+					layout: {
+						selfStretch: 'fixed',
+						flexSize: '320px',
+					},
+					viewportOverrides: {
+						selfStretch: 'fill',
+					},
+				} )
+			).toEqual( [
+				{
+					selector: '.wp-container-content-test',
+					declarations: {
+						'flex-basis': 'unset',
+						'flex-grow': '1',
 					},
 				},
 			] );

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -450,7 +450,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	 */
 	public function data_gutenberg_get_child_layout_style_rules() {
 		return array(
-			'legacy fixed sizing remains shrinkable' => array(
+			'legacy fixed sizing remains shrinkable'      => array(
 				'child_layout'       => array(
 					'selfStretch' => 'fixed',
 					'flexSize'    => '320px',
@@ -466,7 +466,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 					),
 				),
 			),
-			'fixed sizing can opt out of shrinking'  => array(
+			'fixed sizing can opt out of shrinking'       => array(
 				'child_layout'       => array(
 					'selfStretch' => 'fixedNoShrink',
 					'flexSize'    => '320px',
@@ -483,7 +483,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 					),
 				),
 			),
-			'viewport overrides can switch fixedNoShrink to max width' => array(
+			'viewport overrides can switch fixedNoShrink to max' => array(
 				'child_layout'       => array(
 					'selfStretch' => 'fixedNoShrink',
 					'flexSize'    => '320px',
@@ -495,8 +495,81 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 					array(
 						'selector'     => '.wp-container-content-test',
 						'declarations' => array(
-							'flex-basis' => '320px',
-							'box-sizing' => 'border-box',
+							'flex-basis'  => '320px',
+							'flex-shrink' => 'unset',
+							'box-sizing'  => 'border-box',
+						),
+					),
+				),
+			),
+			'viewport overrides can switch fixedNoShrink to fit' => array(
+				'child_layout'       => array(
+					'selfStretch' => 'fixedNoShrink',
+					'flexSize'    => '320px',
+				),
+				'viewport_overrides' => array(
+					'selfStretch' => 'fit',
+				),
+				'expected_output'    => array(
+					array(
+						'selector'     => '.wp-container-content-test',
+						'declarations' => array(
+							'flex-basis'  => 'unset',
+							'flex-shrink' => 'unset',
+						),
+					),
+				),
+			),
+			'viewport overrides can switch fixed to fit'  => array(
+				'child_layout'       => array(
+					'selfStretch' => 'fixed',
+					'flexSize'    => '320px',
+				),
+				'viewport_overrides' => array(
+					'selfStretch' => 'fit',
+				),
+				'expected_output'    => array(
+					array(
+						'selector'     => '.wp-container-content-test',
+						'declarations' => array(
+							'flex-basis' => 'unset',
+						),
+					),
+				),
+			),
+			'viewport overrides can switch fixedNoShrink to grow' => array(
+				'child_layout'       => array(
+					'selfStretch' => 'fixedNoShrink',
+					'flexSize'    => '320px',
+				),
+				'viewport_overrides' => array(
+					'selfStretch' => 'fill',
+				),
+				'expected_output'    => array(
+					array(
+						'selector'     => '.wp-container-content-test',
+						'declarations' => array(
+							'flex-basis'  => 'unset',
+							'flex-shrink' => 'unset',
+							'flex-grow'   => '1',
+						),
+					),
+				),
+			),
+			'viewport overrides can switch fixed to grow' => array(
+				'child_layout'       => array(
+					'selfStretch' => 'fixed',
+					'flexSize'    => '320px',
+				),
+				'viewport_overrides' => array(
+					'selfStretch' => 'fill',
+				),
+				'expected_output'    => array(
+					array(
+						'selector'     => '.wp-container-content-test',
+						'declarations' => array(
+							'flex-basis' => 'unset',
+							'flex-grow'  => '1',
 						),
 					),
 				),

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -422,6 +422,89 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Check that gutenberg_get_child_layout_style_rules() renders flex child sizing styles.
+	 *
+	 * @dataProvider data_gutenberg_get_child_layout_style_rules
+	 *
+	 * @covers ::gutenberg_get_child_layout_style_rules
+	 *
+	 * @param array      $child_layout       Child layout values.
+	 * @param array|null $viewport_overrides Optional child viewport layout overrides.
+	 * @param array      $expected_output    The expected output.
+	 */
+	public function test_gutenberg_get_child_layout_style_rules( $child_layout, $viewport_overrides, $expected_output ) {
+		$actual_output = gutenberg_get_child_layout_style_rules(
+			'.wp-container-content-test',
+			$child_layout,
+			array(),
+			$viewport_overrides
+		);
+
+		$this->assertSame( $expected_output, $actual_output );
+	}
+
+	/**
+	 * Data provider for test_gutenberg_get_child_layout_style_rules().
+	 *
+	 * @return array
+	 */
+	public function data_gutenberg_get_child_layout_style_rules() {
+		return array(
+			'legacy fixed sizing remains shrinkable' => array(
+				'child_layout'       => array(
+					'selfStretch' => 'fixed',
+					'flexSize'    => '320px',
+				),
+				'viewport_overrides' => null,
+				'expected_output'    => array(
+					array(
+						'selector'     => '.wp-container-content-test',
+						'declarations' => array(
+							'flex-basis' => '320px',
+							'box-sizing' => 'border-box',
+						),
+					),
+				),
+			),
+			'fixed sizing can opt out of shrinking'  => array(
+				'child_layout'       => array(
+					'selfStretch' => 'fixedNoShrink',
+					'flexSize'    => '320px',
+				),
+				'viewport_overrides' => null,
+				'expected_output'    => array(
+					array(
+						'selector'     => '.wp-container-content-test',
+						'declarations' => array(
+							'flex-basis'  => '320px',
+							'flex-shrink' => '0',
+							'box-sizing'  => 'border-box',
+						),
+					),
+				),
+			),
+			'viewport overrides can switch fixedNoShrink to max width' => array(
+				'child_layout'       => array(
+					'selfStretch' => 'fixedNoShrink',
+					'flexSize'    => '320px',
+				),
+				'viewport_overrides' => array(
+					'selfStretch' => 'fixed',
+				),
+				'expected_output'    => array(
+					array(
+						'selector'     => '.wp-container-content-test',
+						'declarations' => array(
+							'flex-basis' => '320px',
+							'box-sizing' => 'border-box',
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
 	 * Check that gutenberg_render_layout_support_flag() renders the correct classnames on the wrapper.
 	 *
 	 * @dataProvider data_layout_support_flag_renders_classnames_on_wrapper

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -495,7 +495,7 @@
 									"default": true
 								},
 								"allowSizingOnChildren": {
-									"description": "For the `flex` layout type only, determines display of sizing controls (Fit/Grow/Max width/Fixed) on all child blocks of the flex block.",
+									"description": "For the `flex` layout type only, determines display of sizing controls (Fit/Grow/Max/Fixed) on all child blocks of the flex block.",
 									"type": "boolean",
 									"default": false
 								},

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -495,7 +495,7 @@
 									"default": true
 								},
 								"allowSizingOnChildren": {
-									"description": "For the `flex` layout type only, determines display of sizing controls (Fit/Fill/Fixed) on all child blocks of the flex block.",
+									"description": "For the `flex` layout type only, determines display of sizing controls (Fit/Grow/Max width/Fixed) on all child blocks of the flex block.",
 									"type": "boolean",
 									"default": false
 								},


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #53766.

The existing "fixed" option in flex child layouts in reality works as "max width", because it doesn't prevent shrinkage of the blocks it's applied to. This has caused confusion and there have been multiple requests for a "fixed" option that is actually fixed. 

This PR solves the issue by renaming the existing "fixed" behaviour "max width", and allowing "fixed" to be unshrinkable by adding `flex-shrink: 0` to fixed blocks.

There should be no back compat issues; blocks currently set to "fixed" will automatically become "max width", using the same `fixed` attribute value as before. The new "fixed" behaviour uses a new attribute value `fixedNoShrink` 😄 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create a Row block with children and set one to "fixed" size on trunk;
2. Switch to this PR; the "fixed" block should now be max width and its behaviour unchanged;
3. Try setting another Row child to "fixed" and check that its size doesn't go under the stipulated size when the screen resizes.


## Screenshots or screencast <!-- if applicable -->

<img width="266" height="201" alt="Screenshot 2026-06-10 at 3 52 44 pm" src="https://github.com/user-attachments/assets/4370f362-1533-4f06-b73b-82ce2359a4c7" />

The options are starting to look a little tight, but I'm not sure if there's a better component to use here. Suggestions welcome!

## Use of AI Tools

Used codex/gpt 5.5

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
