### PR TITLE
Cover Block: fix position push out by preceding floated blocks

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -96,6 +96,12 @@
 		display: flex;
 	}
 
+	// Clear floats to not push the block out of its position.
+	&.alignwide,
+	&.alignfull {
+		clear: both;
+	}
+
 	.wp-block-cover__inner-container {
 		position: relative; // Needed for the inner container to be positioned above other elements with absolute positioning.
 		width: 100%;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73691 

<!-- In a few words, what is the PR actually doing? -->
This PR fixes an issue where a Cover block can be pushed out of position by a preceding floated block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Blocks aligned left or right (`alignleft` / `alignright`) use CSS floats. When a Cover block is aligned as `alignwide` or `alignfull`, it does not currently clear preceding floats. As a result, the Cover block may be rendered alongside the floated element instead of starting below it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds `clear: both` to `.wp-block-cover` when combined with `.alignwide` or `.alignfull`. This ensures the Cover block is rendered below any preceding floated block and maintains its intended alignment.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new post.
2. Insert an Image block and set its alignment to **Align left**.
3. Insert a second Image block and set its alignment to **Wide width**.
4. Verify that the second image renders below the first image.
5. Transform the second Image block into a Cover block.
6. Verify that the Cover block is also below the floated image rather than beside it.

<!-- ### Testing Instructions for Keyboard -->
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1150" height="517" alt="Screenshot 2026-06-10 at 12 41 23 PM" src="https://github.com/user-attachments/assets/0a11f787-c466-4e68-97f0-931a976562ab" />|<img width="1126" height="655" alt="Screenshot 2026-06-10 at 12 41 48 PM" src="https://github.com/user-attachments/assets/a44fa446-8ef6-41e5-85a4-9abad4abfb62" />|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
ChatGPT for refining the PR description