### PR TITLE
Math format: Simplify the onClick handler and use canonical selected-text capture

### DIFF
--- a/packages/format-library/src/math/index.js
+++ b/packages/format-library/src/math/index.js
@@ -3,7 +3,13 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { insert, insertObject, useAnchor } from '@wordpress/rich-text';
+import {
+	insert,
+	insertObject,
+	slice,
+	getTextContent,
+	useAnchor,
+} from '@wordpress/rich-text';
 import { RichTextToolbarButton } from '@wordpress/block-editor';
 import {
 	Popover,
@@ -135,53 +141,51 @@ function Edit( {
 			setLatexToMathML( () => module.default );
 		} );
 	}, [] );
+
+	function onClick() {
+		let newValue;
+
+		if ( isObjectActive ) {
+			// Revert the active math object to its LaTeX source so clicking
+			// the button toggles back to the exact text it was created from.
+			// Keep the restored text selected so it can be edited or
+			// re-marked right away.
+			const latex = activeObjectAttributes?.[ 'data-latex' ] || '';
+			newValue = insert( value, latex );
+			newValue.start = newValue.end - latex.length;
+		} else {
+			// If there's a selection, seed the format with it so you can type
+			// LaTeX inline and then mark it as math.
+			const selectedText = getTextContent( slice( value ) );
+			let innerHTML = '';
+			if ( selectedText && latexToMathML ) {
+				try {
+					innerHTML = latexToMathML( selectedText, {
+						displayMode: false,
+					} );
+				} catch {
+					// Leave unrendered; the popover opens with the text
+					// prefilled so the expression can be corrected.
+				}
+			}
+			newValue = insertObject( value, {
+				type: name,
+				attributes: { 'data-latex': selectedText },
+				innerHTML,
+			} );
+			newValue.start = newValue.end - 1;
+		}
+
+		onChange( newValue );
+		onFocus();
+	}
+
 	return (
 		<>
 			<RichTextToolbarButton
 				icon={ icon }
 				title={ title }
-				onClick={ () => {
-					// If a math object is already active, revert it to its
-					// LaTeX source so clicking the button toggles back to the
-					// exact text it was created from. Keep the restored text
-					// selected so it can be edited or re-marked right away.
-					if ( isObjectActive ) {
-						const latex =
-							activeObjectAttributes?.[ 'data-latex' ] || '';
-						const newValue = insert( value, latex );
-						newValue.start = newValue.end - latex.length;
-						onChange( newValue );
-						onFocus();
-						return;
-					}
-					// If there's a selection, seed the format with it so you
-					// can type LaTeX inline and then mark it as math.
-					const selectedText = value.text.slice(
-						value.start,
-						value.end
-					);
-					let innerHTML = '';
-					if ( selectedText && latexToMathML ) {
-						try {
-							innerHTML = latexToMathML( selectedText, {
-								displayMode: false,
-							} );
-						} catch {
-							// Leave unrendered; the popover opens with the text
-							// prefilled so the expression can be corrected.
-						}
-					}
-					const newValue = insertObject( value, {
-						type: name,
-						attributes: {
-							'data-latex': selectedText,
-						},
-						innerHTML,
-					} );
-					newValue.start = newValue.end - 1;
-					onChange( newValue );
-					onFocus();
-				} }
+				onClick={ onClick }
 				isActive={ isObjectActive }
 			/>
 			{ isObjectActive && (


### PR DESCRIPTION
## What?
A minor follow-up to #79052.

- Merge two click handler branches to a single `newValue`, so the shared `onChange( newValue ); onFocus();` tail isn't duplicated.
- Replaced the manual `value.text.slice( value.start, value.end )` with the canonical rich-text helpers `getTextContent( slice( value ) )`. This strips the object-replacement character (`\uFFFC`), so selecting across an existing inline object no longer leaks placeholder chars into `data-latex` / the LaTeX parser.

## Testing Instructions
1. Use testing instructions from #79052.
2. The original change has e2e test coverage.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.