### PR TITLE
Omnipresent Toolbar: increase top padding in sidebar nav title

### DIFF
--- a/packages/edit-site/src/experimental-omnibar.scss
+++ b/packages/edit-site/src/experimental-omnibar.scss
@@ -22,7 +22,7 @@ body.has-admin-bar-in-editor {
 	}
 
 	.edit-site-sidebar-navigation-screen__title-icon {
-		padding-top: 16px;
+		padding-top: 32px;
 	}
 
 	.edit-site-layout__content,

--- a/packages/edit-site/src/experimental-omnibar.scss
+++ b/packages/edit-site/src/experimental-omnibar.scss
@@ -1,5 +1,7 @@
 // Styles for the experimental admin bar in editor.
 
+@use "@wordpress/base-styles/variables" as *;
+
 body.has-admin-bar-in-editor {
 	margin-top: 0;
 	height: 100%;
@@ -22,7 +24,7 @@ body.has-admin-bar-in-editor {
 	}
 
 	.edit-site-sidebar-navigation-screen__title-icon {
-		padding-top: 32px;
+		padding-top: $grid-unit-40;
 	}
 
 	.edit-site-layout__content,


### PR DESCRIPTION
## What?

Fixes part of https://github.com/WordPress/gutenberg/pull/77964#issuecomment-4533172321

Increase the padding between the sidebar title and the admin bar. Check the space on top of the `< Design` title:

|Before|After|
|-|-|
|<img width="654" height="434" alt="image" src="https://github.com/user-attachments/assets/9397b9bd-8d7d-4917-8b0c-20a6f214d6c9" />|<img width="654" height="434" alt="image" src="https://github.com/user-attachments/assets/a946a552-a956-4f9d-9bfd-78048c8c7047" />

<!-- In a few words, what is the PR actually doing? -->

## Why?

Fixing visual imbalance.

## Testing Instructions

1. Go to Gutenberg -> Experiments
2. Enable the Omnipresent Toolbar experiment
3. Go to Appearance -> Design
4. Verify the sidebar looks better as above

## Use of AI Tools

This PR is hand-written.