### PR TITLE
Auto select first item on Site Editor pages landing dashboard

### DIFF
--- a/packages/edit-site/src/components/editor/use-resolve-edited-entity.js
+++ b/packages/edit-site/src/components/editor/use-resolve-edited-entity.js
@@ -126,8 +126,6 @@ export function useResolveEditedEntity() {
 		if ( postType && postId && authorizedPostTypes.includes( postType ) ) {
 			return { postType, postId };
 		}
-		// TODO: for post types lists we should probably not render the front page, but maybe a placeholder
-		// with a message like "Select a page" or something similar.
 		if ( homePage?.postType === 'page' ) {
 			return { postType: 'page', postId: homePage?.postId };
 		}

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -221,6 +221,17 @@ export default function PostList( { postType } ) {
 		}
 	}, [ history, postIdWasDeleted, path ] );
 
+	// select the first item to preview.
+	useEffect( () => {
+		if ( hasResolved && ! isLoadingData && data?.length > 0 && ! postId ) {
+			history.navigate(
+				addQueryArgs( path, {
+					postId: getItemId( data[ 0 ] ),
+				} )
+			);
+		}
+	}, [ hasResolved, isLoadingData, data, postId, path, history ] );
+
 	const paginationInfo = useMemo(
 		() => ( {
 			totalItems,

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -223,14 +223,26 @@ export default function PostList( { postType } ) {
 
 	// select the first item to preview.
 	useEffect( () => {
-		if ( hasResolved && ! isLoadingData && data?.length > 0 && ! postId ) {
-			history.navigate(
-				addQueryArgs( path, {
-					postId: getItemId( data[ 0 ] ),
-				} )
-			);
+		if (
+			postType === 'page' &&
+			hasResolved &&
+			! isLoadingData &&
+			data?.length > 0 &&
+			! postId
+		) {
+			const firstItemId = getItemId( data[ 0 ] );
+
+			setSelection( [ firstItemId ] );
+
+			const newUrl = addQueryArgs( window.location.href, {
+				postId: firstItemId,
+			} );
+
+			window.history.replaceState( window.history.state, '', newUrl );
+
+			window.dispatchEvent( new Event( 'popstate' ) );
 		}
-	}, [ hasResolved, isLoadingData, data, postId, path, history ] );
+	}, [ postType, hasResolved, isLoadingData, data, postId ] );
 
 	const paginationInfo = useMemo(
 		() => ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73346

This PR updates the Site Editor's Pages landing dashboard to automatically select and preview the first page in the list when no specific page is active, replacing the previous behavior of defaulting to the Home template preview.

## Why?
Previously, navigating to the Pages section showed the Home page in the canvas preview, even though the Home element wasn't selected in the list. This disconnected UI state caused user confusion. By auto-selecting the first available page based on the active DataViews sorting, the preview accurately reflects the active list state. 

## How?
Updated `PostList` to detect empty `postId` queries on load and synchronize local selection with the first item from the DataViews output.

To prevent browser back button traps caused by router race conditions, the URL is mutated using native `window.history.replaceState` combined with a popstate event.

## Testing Instructions
1. Navigate to Appearance > Editor.
2. Click on Pages to open the Pages landing dashboard.
3. Verify that the first page in the list is automatically highlighted and its content is rendered in the right hand canvas preview.
4. Change the sorting (e.g., Z-A or by Date) or search for a specific page. Verify the topmost item in the *new* list is the one automatically selected.
5. Click your browser's native **Back** button. Verify that you cleanly exit the Pages view.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/12f0f481-93dd-4732-97fc-2a81c8a8b050
