### PR TITLE
DataViews: Wrap row content in gridcell for valid ARIA grid semantics

### DIFF
--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -329,6 +329,7 @@ function ListItem< Item >( {
 					>
 						<Stack direction="row" align="center">
 							<div
+								role="gridcell"
 								className="dataviews-title-field dataviews-view-list__title-field"
 								id={ labelId }
 							>
@@ -337,7 +338,10 @@ function ListItem< Item >( {
 							{ usedActions }
 						</Stack>
 						{ renderDescription && (
-							<div className="dataviews-view-list__field">
+							<div
+								role="gridcell"
+								className="dataviews-view-list__field"
+							>
 								<descriptionField.render
 									item={ item }
 									field={ descriptionField }
@@ -351,6 +355,7 @@ function ListItem< Item >( {
 							{ otherFields.map( ( field ) => (
 								<div
 									key={ field.id }
+									role="gridcell"
 									className="dataviews-view-list__field"
 								>
 									<VisuallyHidden


### PR DESCRIPTION
## What?
 
Closes #78982
 
This PR fixes a structural ARIA violation in the DataViews list layout. Each row (`role="row"`) contained interactive elements (title link, inline action buttons) as direct accessibility-tree children, which violates the ARIA grid pattern requirement that row children must be `gridcell`, `rowheader`, or `columnheader`.
 
The fix wraps the title field, description, and per-field cells in `<div role="gridcell">`, consistent with the existing treatment of the selectable item button and the actions menu.
 
## Why?
 
Without proper `gridcell` wrappers, assistive technologies cannot convey the row's cell structure, and the markup fails the `aria-required-children` ARIA check (WCAG 1.3.1, Info and Relationships).
 
This affects multiple Site Editor surfaces using the shared DataViews list layout (Pages, Templates, Template Parts, Patterns).
 
## How?
 
Added `role="gridcell"` to three existing wrappers inside `<Composite.Row>` in `packages/dataviews/src/components/dataviews-layouts/list/index.tsx`:
 
1. Title field div (which contains the title link)
2. Description field div
3. Each per-field div inside `otherFields.map(...)`
 
No DOM structure or styling was modified purely an ARIA attribute addition.
 
## Testing Instructions
 
1. Open **Site Editor → Pages** (`admin.php?page=site-editor-v2&p=%2Ftypes%2Fpage`).
2. Switch to **List** layout.
3. Inspect any row in DevTools.
4. Confirm the `<div role="row">` node's interactive descendants (title link, action button) are now contained inside `<div role="gridcell">` wrappers.
 
### Testing Instructions for Keyboard
 
1. Open **Site Editor → Pages** in **List** layout.
2. Use `Tab` to navigate into the list, then arrow keys to move between rows.
3. Confirm keyboard navigation works as before focus moves correctly between rows and interactive elements (title links, action menus) remain reachable.
 
## Screenshots or screencast
 
|Before|After|
|-|-|
|<img width="1457" height="729" alt="image" src="https://github.com/user-attachments/assets/ddc6ee9b-5409-4412-a7e2-51b7b7bc7c58" />|<img width="1455" height="731" alt="image" src="https://github.com/user-attachments/assets/7a81219a-6a14-4d8b-860c-ba29f4569ab1" />|
 
## Use of AI Tools
 
Yes investigation and drafting assisted by AI. Final implementation, testing (lint, unit tests, TypeScript check, manual axe verification), and code review were performed personally.