### PR TITLE
Add link support to Icon block with URL, target, and rel attributes

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -446,7 +446,7 @@ Insert an SVG icon.
 -	**Name:** [core/icon](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-media/core-block-icon/)
 -	**Category:** [media](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-media/)
 -	**Supports:** align (center, left, right), anchor, ariaLabel, color (background, text), dimensions (width), interactivity (clientNavigation), spacing (margin, padding), ~~html~~
--	**Attributes:** icon
+-	**Attributes:** icon, linkTarget, rel, url
 
 ## Image
 

--- a/packages/block-library/src/icon/README.md
+++ b/packages/block-library/src/icon/README.md
@@ -16,6 +16,9 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | Attribute | [Type](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#type-validation) | [Default](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#default-value) | Description |
 |-----------|------|---------|-------------|
 | `icon` | `string` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
+| `url` | `string` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
+| `linkTarget` | `string` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
+| `rel` | `string` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
 
 ## Supports
 

--- a/packages/block-library/src/icon/block.json
+++ b/packages/block-library/src/icon/block.json
@@ -11,6 +11,18 @@
 		"icon": {
 			"type": "string",
 			"role": "content"
+		},
+		"url": {
+			"type": "string",
+			"role": "content"
+		},
+		"linkTarget": {
+			"type": "string",
+			"role": "content"
+		},
+		"rel": {
+			"type": "string",
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/icon/constants.js
+++ b/packages/block-library/src/icon/constants.js
@@ -1,0 +1,3 @@
+export const NEW_TAB_REL = 'noopener';
+export const NEW_TAB_TARGET = '_blank';
+export const NOFOLLOW_REL = 'nofollow';

--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -9,6 +9,7 @@ import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import {
 	DropdownMenu,
+	Popover,
 	TextControl,
 	ToolbarButton,
 	ToolbarGroup,
@@ -20,15 +21,18 @@ import {
 	InspectorControls,
 	useBlockProps,
 	useBlockEditingMode,
+	LinkControl,
 	__experimentalUseColorProps as useColorProps,
 	__experimentalUseBorderProps as useBorderProps,
 	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
 	getDimensionsClassesAndStyles as useDimensionsProps,
 } from '@wordpress/block-editor';
-import { useState } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { SVG, Rect, Path } from '@wordpress/primitives';
 import { useSelect } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
+import { link, linkOff } from '@wordpress/icons';
+import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -36,6 +40,16 @@ import { store as coreDataStore } from '@wordpress/core-data';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import HtmlRenderer from '../utils/html-renderer';
 import { CustomInserterModal } from './components';
+import { NEW_TAB_TARGET, NOFOLLOW_REL } from './constants';
+import { getUpdatedLinkAttributes } from './get-updated-link-attributes';
+
+const LINK_SETTINGS = [
+	...LinkControl.DEFAULT_LINK_SETTINGS,
+	{
+		id: 'nofollow',
+		title: __( 'Mark as nofollow' ),
+	},
+];
 
 const IconPlaceholder = ( { className, style } ) => (
 	<SVG
@@ -57,10 +71,12 @@ const IconPlaceholder = ( { className, style } ) => (
 	</SVG>
 );
 
-export function Edit( { attributes, setAttributes } ) {
-	const { icon, ariaLabel } = attributes;
+export function Edit( { attributes, setAttributes, isSelected } ) {
+	const { icon, ariaLabel, url, linkTarget, rel } = attributes;
 
 	const [ isInserterOpen, setInserterOpen ] = useState( false );
+	const [ isEditingURL, setIsEditingURL ] = useState( false );
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
 
 	const isContentOnlyMode = useBlockEditingMode() === 'contentOnly';
 
@@ -68,6 +84,43 @@ export function Edit( { attributes, setAttributes } ) {
 	const spacingProps = useSpacingProps( attributes );
 	const borderProps = useBorderProps( attributes );
 	const dimensionsProps = useDimensionsProps( attributes );
+
+	const isURLSet = !! url;
+	const opensInNewTab = linkTarget === NEW_TAB_TARGET;
+	const nofollow = !! rel?.includes( NOFOLLOW_REL );
+
+	const linkValue = useMemo(
+		() => ( { url, opensInNewTab, nofollow } ),
+		[ url, opensInNewTab, nofollow ]
+	);
+
+	function onKeyDown( event ) {
+		if ( isKeyboardEvent.primary( event, 'k' ) ) {
+			startEditing( event );
+		} else if ( isKeyboardEvent.primaryShift( event, 'k' ) ) {
+			unlink();
+		}
+	}
+
+	function startEditing( event ) {
+		event.preventDefault();
+		setIsEditingURL( true );
+	}
+
+	function unlink() {
+		setAttributes( {
+			url: undefined,
+			linkTarget: undefined,
+			rel: undefined,
+		} );
+		setIsEditingURL( false );
+	}
+
+	useEffect( () => {
+		if ( ! isSelected ) {
+			setIsEditingURL( false );
+		}
+	}, [ isSelected ] );
 
 	const { selectedIcon, allIcons = [] } = useSelect(
 		( select ) => {
@@ -87,6 +140,8 @@ export function Edit( { attributes, setAttributes } ) {
 
 	const iconToDisplay = selectedIcon?.content || '';
 
+	const blockProps = useBlockProps( { ref: setPopoverAnchor, onKeyDown } );
+
 	const blockControls = (
 		<>
 			<BlockControls group={ isContentOnlyMode ? 'inline' : 'other' }>
@@ -97,6 +152,20 @@ export function Edit( { attributes, setAttributes } ) {
 				>
 					{ icon ? __( 'Replace' ) : __( 'Choose icon' ) }
 				</ToolbarButton>
+			</BlockControls>
+			<BlockControls group="block">
+				<ToolbarButton
+					name="link"
+					icon={ isURLSet ? linkOff : link }
+					title={ isURLSet ? __( 'Unlink' ) : __( 'Link' ) }
+					shortcut={
+						isURLSet
+							? displayShortcut.primaryShift( 'k' )
+							: displayShortcut.primary( 'k' )
+					}
+					onClick={ isURLSet ? unlink : startEditing }
+					isActive={ isURLSet }
+				/>
 			</BlockControls>
 			{ isContentOnlyMode && icon && (
 				// Add some extra controls for content attributes when content only mode is active.
@@ -173,7 +242,7 @@ export function Edit( { attributes, setAttributes } ) {
 		<>
 			{ blockControls }
 			{ inspectorControls }
-			<div { ...useBlockProps() }>
+			<div { ...blockProps }>
 				{ icon ? (
 					<HtmlRenderer
 						html={ iconToDisplay }
@@ -208,6 +277,37 @@ export function Edit( { attributes, setAttributes } ) {
 					/>
 				) }
 			</div>
+			{ isSelected && ( isEditingURL || isURLSet ) && (
+				<Popover
+					placement="bottom"
+					onClose={ () => setIsEditingURL( false ) }
+					anchor={ popoverAnchor }
+					focusOnMount={ isEditingURL ? 'firstElement' : false }
+					__unstableSlotName="__unstable-block-tools-after"
+					shift
+				>
+					<LinkControl
+						value={ linkValue }
+						onChange={ ( {
+							url: newURL,
+							opensInNewTab: newOpensInNewTab,
+							nofollow: newNofollow,
+						} ) =>
+							setAttributes(
+								getUpdatedLinkAttributes( {
+									rel,
+									url: newURL,
+									opensInNewTab: newOpensInNewTab,
+									nofollow: newNofollow,
+								} )
+							)
+						}
+						onRemove={ unlink }
+						forceIsEditingLink={ isEditingURL }
+						settings={ LINK_SETTINGS }
+					/>
+				</Popover>
+			) }
 			{ isInserterOpen && (
 				<CustomInserterModal
 					icons={ allIcons }

--- a/packages/block-library/src/icon/get-updated-link-attributes.js
+++ b/packages/block-library/src/icon/get-updated-link-attributes.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { prependHTTPS } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { NEW_TAB_REL, NEW_TAB_TARGET, NOFOLLOW_REL } from './constants';
+
+/**
+ * Updates the link attributes.
+ *
+ * @param {Object}  attributes               The current block attributes.
+ * @param {string}  attributes.rel           The current link rel attribute.
+ * @param {string}  attributes.url           The current link url.
+ * @param {boolean} attributes.opensInNewTab Whether the link should open in a new window.
+ * @param {boolean} attributes.nofollow      Whether the link should be marked as nofollow.
+ */
+export function getUpdatedLinkAttributes( {
+	rel = '',
+	url = '',
+	opensInNewTab,
+	nofollow,
+} ) {
+	let newLinkTarget;
+	// Since `rel` is editable attribute, we need to check for existing values and proceed accordingly.
+	let updatedRel = rel;
+
+	if ( opensInNewTab ) {
+		newLinkTarget = NEW_TAB_TARGET;
+		updatedRel = updatedRel?.includes( NEW_TAB_REL )
+			? updatedRel
+			: updatedRel + ` ${ NEW_TAB_REL }`;
+	} else {
+		const relRegex = new RegExp( `\\b${ NEW_TAB_REL }\\s*`, 'g' );
+		updatedRel = updatedRel?.replace( relRegex, '' ).trim();
+	}
+
+	if ( nofollow ) {
+		updatedRel = updatedRel?.includes( NOFOLLOW_REL )
+			? updatedRel
+			: ( updatedRel + ` ${ NOFOLLOW_REL }` ).trim();
+	} else {
+		const relRegex = new RegExp( `\\b${ NOFOLLOW_REL }\\s*`, 'g' );
+		updatedRel = updatedRel?.replace( relRegex, '' ).trim();
+	}
+
+	return {
+		url: prependHTTPS( url ),
+		linkTarget: newLinkTarget,
+		rel: updatedRel || undefined,
+	};
+}

--- a/packages/block-library/src/icon/index.php
+++ b/packages/block-library/src/icon/index.php
@@ -108,7 +108,27 @@ function render_block_core_icon( $attributes ) {
 	}
 
 	// Return the updated SVG markup.
-	$svg        = $processor->get_updated_html();
+	$svg = $processor->get_updated_html();
+
+	// Wrap in anchor if URL is set.
+	if ( ! empty( $attributes['url'] ) ) {
+		$link_attrs = 'href="' . esc_url( $attributes['url'] ) . '"';
+
+		if ( ! empty( $attributes['linkTarget'] ) ) {
+			$link_attrs .= ' target="' . esc_attr( $attributes['linkTarget'] ) . '"';
+		}
+
+		if ( ! empty( $attributes['rel'] ) ) {
+			$link_attrs .= ' rel="' . esc_attr( $attributes['rel'] ) . '"';
+		}
+
+		if ( ! empty( $attributes['ariaLabel'] ) ) {
+			$link_attrs .= ' aria-label="' . esc_attr( $attributes['ariaLabel'] ) . '"';
+		}
+
+		$svg = sprintf( '<a %s>%s</a>', $link_attrs, $svg );
+	}
+
 	$attributes = get_block_wrapper_attributes();
 	return sprintf( '<div %s>%s</div>', $attributes, $svg );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #79057

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Icon block allows users to insert and style an SVG icon, but it currently does not provide a way to add a link to the icon.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Yes - Claude Code