### PR TITLE
[codex] Allow guideline type slugs in REST API

### DIFF
--- a/lib/experimental/guidelines/class-gutenberg-guidelines-rest-controller.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-rest-controller.php
@@ -15,6 +15,57 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Gutenberg_Guidelines_REST_Controller extends WP_REST_Posts_Controller {
 
 	/**
+	 * Retrieves the item schema, allowing guideline type terms to be provided
+	 * by ID or slug in create/update requests.
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+		$base   = $this->get_guideline_type_rest_base();
+
+		if ( isset( $schema['properties'][ $base ]['items']['type'] ) ) {
+			$schema['properties'][ $base ]['description']   = __(
+				'The term IDs or slugs assigned to the post in the wp_guideline_type taxonomy.',
+				'gutenberg'
+			);
+			$schema['properties'][ $base ]['items']['type'] = array( 'integer', 'string' );
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Retrieves the query params for the guidelines collection.
+	 *
+	 * @return array Collection parameters.
+	 */
+	public function get_collection_params() {
+		$query_params = parent::get_collection_params();
+		$base         = $this->get_guideline_type_rest_base();
+
+		foreach ( array( $base, $base . '_exclude' ) as $param ) {
+			if ( isset( $query_params[ $param ] ) ) {
+				$query_params[ $param ] = $this->allow_guideline_type_slugs_in_taxonomy_limit_schema( $query_params[ $param ] );
+			}
+		}
+
+		return $query_params;
+	}
+
+	/**
+	 * Retrieves a collection of guidelines.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+		$this->normalize_guideline_type_query_terms( $request );
+
+		return parent::get_items( $request );
+	}
+
+	/**
 	 * Gate the guidelines collection on the post-type read capability.
 	 *
 	 * The default `WP_REST_Posts_Controller` allows unauthenticated reads of
@@ -75,6 +126,56 @@ class Gutenberg_Guidelines_REST_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
+	 * Checks whether current user can assign the provided terms.
+	 *
+	 * Slugs need a custom pass because the parent implementation checks term
+	 * permissions by ID and skips values it cannot resolve with get_term().
+	 *
+	 * @param WP_REST_Request $request The request object with post and terms data.
+	 * @return bool Whether the current user can assign the provided terms.
+	 */
+	protected function check_assign_terms_permission( $request ) {
+		$taxonomy = get_taxonomy( Gutenberg_Guidelines_Post_Type::TAXONOMY );
+		if ( ! $taxonomy ) {
+			return parent::check_assign_terms_permission( $request );
+		}
+
+		$base = $this->get_guideline_type_rest_base();
+		if ( isset( $request[ $base ] ) ) {
+			foreach ( (array) $request[ $base ] as $term ) {
+				if ( ! is_string( $term ) || rest_is_integer( $term ) ) {
+					continue;
+				}
+
+				$term_id = $this->get_guideline_type_term_id( $term );
+				if ( is_wp_error( $term_id ) ) {
+					$slug  = sanitize_title( $term );
+					$types = wp_guideline_types();
+
+					if (
+						'' !== $slug &&
+						isset( $types[ $slug ] ) &&
+						(
+							! current_user_can( $taxonomy->cap->edit_terms ) ||
+							! current_user_can( $taxonomy->cap->assign_terms )
+						)
+					) {
+						return false;
+					}
+
+					continue;
+				}
+
+				if ( ! current_user_can( 'assign_term', $term_id ) ) {
+					return false;
+				}
+			}
+		}
+
+		return parent::check_assign_terms_permission( $request );
+	}
+
+	/**
 	 * Restrict the status surface for callers without publish capability
 	 * to `private`. Administrators retain the parent's full status surface.
 	 *
@@ -112,6 +213,173 @@ class Gutenberg_Guidelines_REST_Controller extends WP_REST_Posts_Controller {
 		if ( ! isset( $request['id'] ) && null === $request['status'] ) {
 			$request->set_param( 'status', 'private' );
 		}
+
+		$terms_update = $this->normalize_guideline_type_terms( $request );
+		if ( is_wp_error( $terms_update ) ) {
+			return $terms_update;
+		}
+
 		return parent::prepare_item_for_database( $request );
+	}
+
+	/**
+	 * Resolves guideline type slugs to term IDs before the parent controller
+	 * assigns taxonomy terms.
+	 *
+	 * @param WP_REST_Request $request The request object with post and terms data.
+	 * @return true|WP_Error True on success, WP_Error when a slug is invalid.
+	 */
+	private function normalize_guideline_type_terms( WP_REST_Request $request ) {
+		$base = $this->get_guideline_type_rest_base();
+		if ( ! isset( $request[ $base ] ) ) {
+			return true;
+		}
+
+		$term_ids = array();
+		foreach ( (array) $request[ $base ] as $term ) {
+			if ( rest_is_integer( $term ) ) {
+				$term_ids[] = (int) $term;
+				continue;
+			}
+
+			$term_id = $this->get_guideline_type_term_id( $term, true );
+			if ( is_wp_error( $term_id ) ) {
+				return $term_id;
+			}
+
+			$term_ids[] = $term_id;
+		}
+
+		$request->set_param( $base, $term_ids );
+
+		return true;
+	}
+
+	/**
+	 * Resolves guideline type slugs in collection filters to term IDs.
+	 *
+	 * Unlike create/update requests, reads do not create missing registered
+	 * terms. Unknown include slugs resolve to no matches, mirroring an unknown
+	 * term ID.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 */
+	private function normalize_guideline_type_query_terms( WP_REST_Request $request ): void {
+		$base = $this->get_guideline_type_rest_base();
+
+		foreach ( array( $base, $base . '_exclude' ) as $param ) {
+			if ( ! isset( $request[ $param ] ) ) {
+				continue;
+			}
+
+			$value = $request[ $param ];
+			if ( rest_is_array( $value ) ) {
+				$request->set_param( $param, $this->get_guideline_type_query_term_ids( (array) $value ) );
+				continue;
+			}
+
+			if ( rest_is_object( $value ) && isset( $value['terms'] ) ) {
+				$value['terms'] = $this->get_guideline_type_query_term_ids( (array) $value['terms'] );
+				$request->set_param( $param, $value );
+			}
+		}
+	}
+
+	/**
+	 * Resolves collection filter terms to IDs.
+	 *
+	 * @param array $terms Term IDs or slugs.
+	 * @return array Term IDs.
+	 */
+	private function get_guideline_type_query_term_ids( array $terms ): array {
+		$term_ids = array();
+		foreach ( $terms as $term ) {
+			if ( rest_is_integer( $term ) ) {
+				$term_ids[] = (int) $term;
+				continue;
+			}
+
+			$term_id    = is_string( $term ) ? $this->get_guideline_type_term_id( $term ) : null;
+			$term_ids[] = is_wp_error( $term_id ) || null === $term_id ? 0 : $term_id;
+		}
+
+		return $term_ids;
+	}
+
+	/**
+	 * Resolves a guideline type term by slug, optionally creating registered
+	 * guideline types on first use.
+	 *
+	 * @param string $slug   Term slug.
+	 * @param bool   $create Optional. Whether to create registered types when missing.
+	 * @return int|WP_Error Term ID on success, WP_Error on failure.
+	 */
+	private function get_guideline_type_term_id( string $slug, bool $create = false ) {
+		$slug = sanitize_title( $slug );
+		if ( '' === $slug ) {
+			return new WP_Error(
+				'rest_invalid_guideline_type',
+				__( 'Invalid guideline type slug.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$term = get_term_by( 'slug', $slug, Gutenberg_Guidelines_Post_Type::TAXONOMY );
+		if ( $term ) {
+			return (int) $term->term_id;
+		}
+
+		$types = wp_guideline_types();
+		if ( ! $create || ! isset( $types[ $slug ] ) ) {
+			return new WP_Error(
+				'rest_invalid_guideline_type',
+				__( 'Invalid guideline type slug.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$inserted = wp_insert_term(
+			$types[ $slug ]['title'],
+			Gutenberg_Guidelines_Post_Type::TAXONOMY,
+			array( 'slug' => $slug )
+		);
+
+		if ( is_wp_error( $inserted ) ) {
+			return $inserted;
+		}
+
+		return (int) $inserted['term_id'];
+	}
+
+	/**
+	 * Allows guideline type collection filters to accept IDs or slugs.
+	 *
+	 * @param array $schema Taxonomy limit schema.
+	 * @return array Updated schema.
+	 */
+	private function allow_guideline_type_slugs_in_taxonomy_limit_schema( array $schema ): array {
+		if ( isset( $schema['oneOf'][0]['items']['type'] ) ) {
+			$schema['oneOf'][0]['items']['type'] = array( 'integer', 'string' );
+		}
+
+		if ( isset( $schema['oneOf'][1]['properties']['terms']['items']['type'] ) ) {
+			$schema['oneOf'][1]['properties']['terms']['items']['type'] = array( 'integer', 'string' );
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Gets the REST field name for guideline type terms.
+	 *
+	 * @return string REST field name.
+	 */
+	private function get_guideline_type_rest_base(): string {
+		$taxonomy = get_taxonomy( Gutenberg_Guidelines_Post_Type::TAXONOMY );
+		if ( ! $taxonomy ) {
+			return Gutenberg_Guidelines_Post_Type::TAXONOMY;
+		}
+
+		return ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 	}
 }

--- a/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
+++ b/phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php
@@ -64,6 +64,35 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
+	 * Creates a guideline fixture and assigns the given guideline type slug.
+	 *
+	 * @param string $owner_role Role key from the self::$users fixture map.
+	 * @param string $status     Post status for the guideline fixture.
+	 * @param string $type_slug  Guideline type slug.
+	 * @return int Inserted guideline post ID.
+	 */
+	private function create_guideline_with_type( string $owner_role, string $status, string $type_slug ): int {
+		$term = get_term_by( 'slug', $type_slug, Gutenberg_Guidelines_Post_Type::TAXONOMY );
+		if ( ! $term ) {
+			$term_id = self::factory()->term->create(
+				array(
+					'taxonomy' => Gutenberg_Guidelines_Post_Type::TAXONOMY,
+					'name'     => ucfirst( $type_slug ),
+					'slug'     => $type_slug,
+				)
+			);
+		} else {
+			$term_id = $term->term_id;
+		}
+
+		$post_id = $this->create_guideline( $owner_role, $status );
+
+		wp_set_object_terms( $post_id, array( (int) $term_id ), Gutenberg_Guidelines_Post_Type::TAXONOMY );
+
+		return $post_id;
+	}
+
+	/**
 	 * Switches the current user to a fixture user with the named role.
 	 *
 	 * @param string $role Role key from the self::$users fixture map.
@@ -145,6 +174,101 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
+	 * A POST may supply a registered `wp_guideline_type` slug without first
+	 * looking up the term ID. The controller creates the backing term on demand.
+	 */
+	public function test_create_guideline_accepts_registered_type_slug(): void {
+		$this->switch_to_user_role( 'administrator' );
+
+		$request = new WP_REST_Request( 'POST', self::REST_BASE );
+		$request->set_param( 'status', 'private' );
+		$request->set_param( 'title', 'Memory guideline' );
+		$request->set_param( Gutenberg_Guidelines_Post_Type::TAXONOMY, array( 'memory' ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$terms = wp_get_object_terms(
+			$response->get_data()['id'],
+			Gutenberg_Guidelines_Post_Type::TAXONOMY,
+			array( 'fields' => 'slugs' )
+		);
+
+		$this->assertSame( array( 'memory' ), $terms );
+	}
+
+	/**
+	 * Contributor+ users can use registered slugs when creating private
+	 * guidelines.
+	 */
+	public function test_create_private_guideline_accepts_registered_type_slug_for_contributor(): void {
+		$this->switch_to_user_role( 'contributor' );
+
+		$request = new WP_REST_Request( 'POST', self::REST_BASE );
+		$request->set_param( 'title', 'Contributor memory guideline' );
+		$request->set_param( Gutenberg_Guidelines_Post_Type::TAXONOMY, array( 'memory' ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( 'private', $response->get_data()['status'] );
+
+		$terms = wp_get_object_terms(
+			$response->get_data()['id'],
+			Gutenberg_Guidelines_Post_Type::TAXONOMY,
+			array( 'fields' => 'slugs' )
+		);
+
+		$this->assertSame( array( 'memory' ), $terms );
+	}
+
+	/**
+	 * Existing custom terms can also be assigned by slug.
+	 */
+	public function test_create_guideline_accepts_existing_custom_type_slug(): void {
+		self::factory()->term->create(
+			array(
+				'taxonomy' => Gutenberg_Guidelines_Post_Type::TAXONOMY,
+				'name'     => 'Project',
+				'slug'     => 'project',
+			)
+		);
+
+		$this->switch_to_user_role( 'administrator' );
+
+		$request = new WP_REST_Request( 'POST', self::REST_BASE );
+		$request->set_param( 'status', 'private' );
+		$request->set_param( 'title', 'Project guideline' );
+		$request->set_param( Gutenberg_Guidelines_Post_Type::TAXONOMY, array( 'project' ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$terms = wp_get_object_terms(
+			$response->get_data()['id'],
+			Gutenberg_Guidelines_Post_Type::TAXONOMY,
+			array( 'fields' => 'slugs' )
+		);
+
+		$this->assertSame( array( 'project' ), $terms );
+	}
+
+	/**
+	 * Unknown slugs are rejected instead of creating arbitrary guideline types.
+	 */
+	public function test_create_guideline_rejects_unknown_type_slug(): void {
+		$this->switch_to_user_role( 'administrator' );
+
+		$request = new WP_REST_Request( 'POST', self::REST_BASE );
+		$request->set_param( 'status', 'private' );
+		$request->set_param( 'title', 'Unknown type guideline' );
+		$request->set_param( Gutenberg_Guidelines_Post_Type::TAXONOMY, array( 'not-a-guideline-type' ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_guideline_type', $response->get_data()['code'] );
+	}
+
+	/**
 	 * The collection route returns matching guidelines and totals.
 	 */
 	public function test_get_items_lists_guidelines(): void {
@@ -165,6 +289,50 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 		$this->assertContains( $first_post_id, $ids );
 		$this->assertContains( $second_post_id, $ids );
 		$this->assertSame( 2, (int) $headers['X-WP-Total'] );
+	}
+
+	/**
+	 * Collection queries may include guidelines by type slug.
+	 */
+	public function test_get_items_accepts_type_slug_filter(): void {
+		$memory_post_id   = $this->create_guideline_with_type( 'administrator', 'draft', 'memory' );
+		$artifact_post_id = $this->create_guideline_with_type( 'administrator', 'draft', 'artifact' );
+
+		$this->switch_to_user_role( 'administrator' );
+
+		$request = new WP_REST_Request( 'GET', self::REST_BASE );
+		$request->set_param( 'status', 'draft' );
+		$request->set_param( Gutenberg_Guidelines_Post_Type::TAXONOMY, array( 'memory' ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$ids = wp_list_pluck( $response->get_data(), 'id' );
+
+		$this->assertContains( $memory_post_id, $ids );
+		$this->assertNotContains( $artifact_post_id, $ids );
+	}
+
+	/**
+	 * Collection queries may exclude guidelines by type slug.
+	 */
+	public function test_get_items_accepts_type_slug_exclude_filter(): void {
+		$memory_post_id   = $this->create_guideline_with_type( 'administrator', 'draft', 'memory' );
+		$artifact_post_id = $this->create_guideline_with_type( 'administrator', 'draft', 'artifact' );
+
+		$this->switch_to_user_role( 'administrator' );
+
+		$request = new WP_REST_Request( 'GET', self::REST_BASE );
+		$request->set_param( 'status', 'draft' );
+		$request->set_param( Gutenberg_Guidelines_Post_Type::TAXONOMY . '_exclude', array( 'memory' ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$ids = wp_list_pluck( $response->get_data(), 'id' );
+
+		$this->assertNotContains( $memory_post_id, $ids );
+		$this->assertContains( $artifact_post_id, $ids );
 	}
 
 	/**
@@ -260,6 +428,25 @@ class Gutenberg_Standard_Guidelines_REST_Controller_Test extends WP_UnitTestCase
 		$terms = wp_get_object_terms( $post_id, Gutenberg_Guidelines_Post_Type::TAXONOMY, array( 'fields' => 'slugs' ) );
 
 		$this->assertSame( array( 'artifact' ), $terms );
+	}
+
+	/**
+	 * A PATCH may update the assigned guideline type by slug.
+	 */
+	public function test_update_guideline_accepts_type_slug(): void {
+		$post_id = $this->create_guideline( 'administrator', 'draft' );
+
+		$this->switch_to_user_role( 'administrator' );
+
+		$request = new WP_REST_Request( 'PATCH', self::REST_BASE . '/' . $post_id );
+		$request->set_param( Gutenberg_Guidelines_Post_Type::TAXONOMY, array( 'memory' ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$terms = wp_get_object_terms( $post_id, Gutenberg_Guidelines_Post_Type::TAXONOMY, array( 'fields' => 'slugs' ) );
+
+		$this->assertSame( array( 'memory' ), $terms );
 	}
 
 	/**


### PR DESCRIPTION
## What?
Allows the `/wp/v2/guidelines` CPT REST controller to accept `wp_guideline_type` slugs wherever term IDs were previously required.

## Why?
Clients currently need to discover term IDs before creating, updating, or filtering guidelines by type. Slugs are the public shape exposed by `wp_guideline_types()`, so accepting them makes agent and API flows simpler.

## How?
- Widens guideline type REST schemas for create/update and collection filters to accept integer IDs or strings.
- Resolves existing slugs to term IDs and creates registered guideline type terms on write when needed.
- Keeps permission checks aligned with assign/create term caps before core handles taxonomy assignment.
- Normalizes collection include/exclude filters to term IDs without creating terms on read.

## Testing
- `vendor/bin/phpcs lib/experimental/guidelines/class-gutenberg-guidelines-rest-controller.php phpunit/experimental/guidelines/class-gutenberg-standard-guidelines-rest-controller-test.php`
- `npm run wp-env-test start -- --auto-port`
- `npm run test:unit:php:base -- --group guidelines`