### PR TITLE
RichText: Fix duplicated format wrappers when typing inside an applied format

### DIFF
--- a/packages/e2e-tests/plugins/format-api/index.js
+++ b/packages/e2e-tests/plugins/format-api/index.js
@@ -27,4 +27,34 @@
 			);
 		},
 	} );
+
+	// Format with an unregistered attribute (`data-test` is not listed in
+	// `attributes`), used to test that manually applied formats merge with
+	// their parsed counterparts when typing within them.
+	wp.richText.registerFormatType( 'my-plugin/testing', {
+		title: 'Testing',
+		tagName: 'span',
+		className: 'testing',
+		edit( props ) {
+			return wp.element.createElement(
+				wp.blockEditor.RichTextToolbarButton,
+				{
+					icon: 'editor-code',
+					title: 'Testing',
+					onClick() {
+						props.onChange(
+							wp.richText.toggleFormat( props.value, {
+								type: 'my-plugin/testing',
+								attributes: {
+									'data-test': 'hello',
+								},
+							} )
+						);
+						props.onFocus();
+					},
+					isActive: props.isActive,
+				}
+			);
+		},
+	} );
 } )();

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -89,13 +89,24 @@ function toFormat( { tagName, attributes } ) {
 		delete unregisteredAttributes.contenteditable;
 	}
 
-	return {
+	// Omit empty attribute objects so that parsed formats have the same shape
+	// as manually applied formats (`{ type, attributes? }`), which is required
+	// for format equality checks.
+	const format = {
 		formatType,
 		type: formatType.name,
 		tagName,
-		attributes: registeredAttributes,
-		unregisteredAttributes,
 	};
+
+	if ( Object.keys( registeredAttributes ).length ) {
+		format.attributes = registeredAttributes;
+	}
+
+	if ( Object.keys( unregisteredAttributes ).length ) {
+		format.unregisteredAttributes = unregisteredAttributes;
+	}
+
+	return format;
 }
 
 /**

--- a/packages/rich-text/src/is-format-equal.js
+++ b/packages/rich-text/src/is-format-equal.js
@@ -23,8 +23,17 @@ export function isFormatEqual( format1, format2 ) {
 		return false;
 	}
 
-	const attributes1 = format1.attributes;
-	const attributes2 = format2.attributes;
+	let attributes1 = format1.attributes;
+	let attributes2 = format2.attributes;
+
+	// Manually applied formats hold all attributes in `attributes`, while
+	// formats parsed from HTML split them between `attributes` (registered)
+	// and `unregisteredAttributes`. Compare the merged view so the two shapes
+	// are recognized as equal.
+	if ( format1.unregisteredAttributes || format2.unregisteredAttributes ) {
+		attributes1 = { ...attributes1, ...format1.unregisteredAttributes };
+		attributes2 = { ...attributes2, ...format2.unregisteredAttributes };
+	}
 
 	// Both not defined.
 	if ( attributes1 === attributes2 ) {

--- a/packages/rich-text/src/test/helpers/index.js
+++ b/packages/rich-text/src/test/helpers/index.js
@@ -685,8 +685,6 @@ export const specWithRegistration = [
 					{
 						type: 'my-plugin/link',
 						tagName: 'a',
-						attributes: {},
-						unregisteredAttributes: {},
 					},
 				],
 			],
@@ -710,7 +708,6 @@ export const specWithRegistration = [
 					{
 						type: 'my-plugin/link',
 						tagName: 'a',
-						attributes: {},
 						unregisteredAttributes: {
 							class: 'test',
 						},
@@ -737,7 +734,6 @@ export const specWithRegistration = [
 					{
 						type: 'core/link',
 						tagName: 'a',
-						attributes: {},
 						unregisteredAttributes: {
 							class: 'custom-format',
 						},
@@ -803,8 +799,6 @@ export const specWithRegistration = [
 					{
 						type: 'my-plugin/link',
 						tagName: 'a',
-						attributes: {},
-						unregisteredAttributes: {},
 					},
 				],
 			],
@@ -829,8 +823,6 @@ export const specWithRegistration = [
 				{
 					type: 'my-plugin/non-editable',
 					tagName: 'a',
-					attributes: {},
-					unregisteredAttributes: {},
 					innerHTML: 'a',
 				},
 			],

--- a/packages/rich-text/src/test/is-format-equal.js
+++ b/packages/rich-text/src/test/is-format-equal.js
@@ -62,6 +62,47 @@ describe( 'isFormatEqual', () => {
 			description:
 				'should return true both have same attributes but different order',
 		},
+		{
+			format1: { type: 'bold', attributes: { 'data-test': '1' } },
+			format2: {
+				type: 'bold',
+				unregisteredAttributes: { 'data-test': '1' },
+			},
+			isEqual: true,
+			description:
+				'should return true if one has the same attributes but unregistered',
+		},
+		{
+			format1: { type: 'bold', attributes: { 'data-test': '1' } },
+			format2: {
+				type: 'bold',
+				unregisteredAttributes: { 'data-test': '2' },
+			},
+			isEqual: false,
+			description:
+				'should return false if an unregistered attribute has a different value',
+		},
+		{
+			format1: {
+				type: 'bold',
+				attributes: { a: '1' },
+				unregisteredAttributes: { 'data-test': '1' },
+			},
+			format2: {
+				type: 'bold',
+				attributes: { a: '1', 'data-test': '1' },
+			},
+			isEqual: true,
+			description:
+				'should return true if attributes are split between registered and unregistered',
+		},
+		{
+			format1: { type: 'bold' },
+			format2: { type: 'bold', unregisteredAttributes: { a: '1' } },
+			isEqual: false,
+			description:
+				'should return false if only one has unregistered attributes',
+		},
 	];
 
 	spec.forEach( ( { format1, format2, isEqual, description } ) => {

--- a/packages/rich-text/src/test/update-formats.js
+++ b/packages/rich-text/src/test/update-formats.js
@@ -3,10 +3,19 @@
  */
 
 import { updateFormats } from '../update-formats';
+import { create } from '../create';
+import { toHTMLString } from '../to-html-string';
+import { registerFormatType } from '../register-format-type';
+import { unregisterFormatType } from '../unregister-format-type';
 import { getSparseArrayLength } from './helpers';
 
 describe( 'updateFormats', () => {
 	const em = { type: 'em' };
+
+	beforeAll( () => {
+		// Initialize the rich-text store.
+		require( '../store' );
+	} );
 
 	it( 'should update formats with empty array', () => {
 		const value = {
@@ -51,5 +60,34 @@ describe( 'updateFormats', () => {
 		expect( result ).toBe( value );
 		expect( result.formats[ 1 ][ 0 ] ).toBe( em );
 		expect( getSparseArrayLength( result.formats ) ).toBe( 2 );
+	} );
+
+	it( 'should update references for manually applied formats', () => {
+		const formatName = 'my-plugin/highlight';
+
+		registerFormatType( formatName, {
+			title: 'Highlight',
+			tagName: 'mark',
+			className: 'highlight',
+			edit() {},
+		} );
+
+		// Simulates typing the last character: the value is parsed from the
+		// DOM while the active format was applied manually, so the two format
+		// objects must be recognized as equal for the reference to be reused.
+		const value = create( { html: '<mark class="highlight">test</mark>' } );
+		const result = updateFormats( {
+			value,
+			start: 3,
+			end: 4,
+			formats: [ { type: formatName } ],
+		} );
+
+		expect( result.formats[ 3 ][ 0 ] ).toBe( result.formats[ 2 ][ 0 ] );
+		expect( toHTMLString( { value: result } ) ).toBe(
+			'<mark class="highlight">test</mark>'
+		);
+
+		unregisterFormatType( formatName );
 	} );
 } );

--- a/test/e2e/specs/editor/plugins/format-api.spec.js
+++ b/test/e2e/specs/editor/plugins/format-api.spec.js
@@ -29,7 +29,7 @@ test.describe( 'Using Format API', () => {
 		await editor.clickBlockToolbarButton( 'More' );
 
 		// Used a regex to tackle the  in name of menuitem.(Custom Link).
-		await page.click( 'role=menuitem[name=/Custom Link/i]' );
+		await page.getByRole( 'menuitem', { name: 'Custom Link' } ).click();
 
 		// Check the content.
 		const content = await editor.getEditedPostContent();
@@ -58,6 +58,34 @@ test.describe( 'Using Format API', () => {
 		expect( await editor.getEditedPostContent() ).toBe(
 			`<!-- wp:paragraph -->
 <p>test</p>
+<!-- /wp:paragraph -->`
+		);
+	} );
+
+	test( 'should not create duplicated wrappers when typing inside an applied format', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( 'First paragraph' );
+		await pageUtils.pressKeys( 'shiftAlt+ArrowLeft' );
+		await editor.clickBlockToolbarButton( 'More' );
+		await page.getByRole( 'menuitem', { name: 'Testing' } ).click();
+
+		// Collapse the selection and move the caret inside the formatted
+		// text, then type. The typed characters must be merged into the
+		// existing format wrapper instead of creating new ones.
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.type( 'xy' );
+
+		expect( await editor.getEditedPostContent() ).toBe(
+			`<!-- wp:paragraph -->
+<p>First <span data-test="hello" class="testing">pxyaragraph</span></p>
 <!-- /wp:paragraph -->`
 		);
 	} );


### PR DESCRIPTION
## What?
Closes #38703

PR fixes each typed character, getting its own format wrapper (e.g., `<span>p</span><span>x</span><span>y</span>`) when typing inside a manually applied format without attribute definition.

## Why?
Manually applied formats and formats parsed from HTML have inconsistent shapes, breaking format equality checks:

- Manual: all attributes live in `attributes`; no `unregisteredAttributes` key.
- Parsed: attributes are split between `attributes` (registered) and `unregisteredAttributes`, and both are emitted even when empty.

When typing, `updateFormats()` relies on `isFormatEqual()` to reuse the parsed format reference for the active format. The shape mismatch makes the check fail, so `toTree()`'s reference-based comparison creates a new wrapper element per character.

## How?
- `create()` no longer emits empty `attributes`/`unregisteredAttributes` objects, so parsed formats match the manual shape.
- `isFormatEqual()` compares the merged `attributes` + `unregisteredAttributes` view, so a manual format with an unregistered attribute (e.g., `data-test`) matches its parsed counterpart. This also fixes a false positive in which a format with only unregistered attributes was considered equal to one without them.

## Testing Instructions
PR has e2e and unit tests. 

## Use of AI Tools

Assisted by Claude.
