### PR TITLE
Validation: Add a published-dependency audit script

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -94,6 +94,10 @@ jobs:
             - name: Type checking
               run: npm run build
 
+            - name: Audit published dependencies
+              if: ${{ matrix.annotations }}
+              run: npm run lint:published-deps -- --fail-unused-ignores
+
             - name: Check local changes
               run: npm run other:check-local-changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5054,6 +5054,387 @@
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
 			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
 		},
+		"node_modules/@mawesome/dependency-audit": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/@mawesome/dependency-audit/-/dependency-audit-0.4.4.tgz",
+			"integrity": "sha512-fnnhA/DItR4N3JAKkpAd2j/JZWXGH+h/ypSE2ClKTKKzm+t/8qJ2yLyc3t3PBieiBef+eMtVpObjk46P7sxRmg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"npm-packlist": "^10.0.4",
+				"pacote": "^21.5.0",
+				"resolve.exports": "^2.0.3",
+				"tar": "^7.5.16",
+				"tinyglobby": "^0.2.17",
+				"typescript": "^6.0.3"
+			},
+			"bin": {
+				"dependency-audit": "dist/cli.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/@npmcli/fs": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+			"integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/@npmcli/installed-package-contents": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
+			"integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-bundled": "^5.0.0",
+				"npm-normalize-package-bin": "^5.0.0"
+			},
+			"bin": {
+				"installed-package-contents": "bin/index.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/cacache": {
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+			"integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/fs": "^5.0.0",
+				"fs-minipass": "^3.0.0",
+				"glob": "^13.0.0",
+				"lru-cache": "^11.1.0",
+				"minipass": "^7.0.3",
+				"minipass-collect": "^2.0.1",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"p-map": "^7.0.2",
+				"ssri": "^13.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/chownr": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/hosted-git-info": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+			"integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/ignore-walk": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
+			"integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"minimatch": "^10.0.3"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/lru-cache": {
+			"version": "11.5.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/npm-bundled": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
+			"integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-normalize-package-bin": "^5.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/npm-normalize-package-bin": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+			"integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/npm-package-arg": {
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+			"integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"hosted-git-info": "^9.0.0",
+				"proc-log": "^6.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-name": "^7.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/npm-packlist": {
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
+			"integrity": "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"ignore-walk": "^8.0.0",
+				"proc-log": "^6.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/p-map": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+			"integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/pacote": {
+			"version": "21.5.1",
+			"resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.1.tgz",
+			"integrity": "sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@gar/promise-retry": "^1.0.0",
+				"@npmcli/git": "^7.0.0",
+				"@npmcli/installed-package-contents": "^4.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/promise-spawn": "^9.0.0",
+				"@npmcli/run-script": "^10.0.0",
+				"cacache": "^20.0.0",
+				"fs-minipass": "^3.0.0",
+				"minipass": "^7.0.2",
+				"npm-package-arg": "^13.0.0",
+				"npm-packlist": "^10.0.1",
+				"npm-pick-manifest": "^11.0.1",
+				"npm-registry-fetch": "^19.0.0",
+				"proc-log": "^6.0.0",
+				"sigstore": "^4.0.0",
+				"ssri": "^13.0.0",
+				"tar": "^7.4.3"
+			},
+			"bin": {
+				"pacote": "bin/index.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/ssri": {
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+			"integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/tar": {
+			"version": "7.5.16",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+			"integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/tinyglobby": {
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/validate-npm-package-name": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+			"integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/yallist": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@mdx-js/react": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.0.tgz",
@@ -26010,6 +26391,23 @@
 				"pend": "~1.2.0"
 			}
 		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/figgy-pudding": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -31020,24 +31418,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
-			}
-		},
-		"node_modules/lerna/node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/lerna/node_modules/fs-extra": {
@@ -43787,23 +44167,6 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
-		"node_modules/tinyglobby/node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tinyglobby/node_modules/picomatch": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
@@ -44307,9 +44670,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-			"integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -45188,24 +45551,6 @@
 					"optional": true
 				},
 				"yaml": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vite/node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
 					"optional": true
 				}
 			}
@@ -54987,6 +55332,7 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
+				"@mawesome/dependency-audit": "^0.4.4",
 				"@wordpress/create-block": "file:../../packages/create-block",
 				"@wordpress/scripts": "file:../../packages/scripts",
 				"chalk": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
 		"prelint:php": "npm run other:update-packages:php",
 		"lint:php": "wp-env run --env-cwd='wp-content/plugins/gutenberg' cli composer run-script lint",
 		"lint:pkg-json": "wp-scripts lint-pkg-json . 'packages/*/package.json'",
+		"lint:published-deps": "npm run --workspace @wordpress/validation-tools dependency-audit --",
 		"other:changelog": "npm exec --no release-cli -- changelog",
 		"other:check-licenses": "concurrently \"npm run --workspace @wordpress/validation-tools check-licenses --\" \"wp-scripts check-licenses --dev\"",
 		"preother:check-local-changes": "npm run docs:build && npm run --workspace @wordpress/theme build",

--- a/packages/editor/src/components/post-text-editor/utils.js
+++ b/packages/editor/src/components/post-text-editor/utils.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { diffChars } from 'diff/lib/diff/character';
-import { diffLines } from 'diff/lib/diff/line';
+import { diffChars } from 'diff/lib/diff/character.js';
+import { diffLines } from 'diff/lib/diff/line.js';
 
 // Character diffing (Myers) is cheap when the edit distance is small but
 // degrades toward O(n^2) as the two strings diverge: a full replacement of

--- a/tools/validation/dependency-audit.config.json
+++ b/tools/validation/dependency-audit.config.json
@@ -1,0 +1,41 @@
+{
+	"ignore": [
+		{
+			"comment": "equivalent-key-map ships no type declarations and has no @types/* package. Referenced only in @wordpress/data's emitted .d.ts.",
+			"package": "equivalent-key-map"
+		},
+		{
+			"comment": "moment-timezone's deep import (moment-timezone/moment-timezone.js) has no resolvable declarations and there is no @types/moment-timezone for it. Referenced in @wordpress/date's emitted .d.ts.",
+			"package": "moment-timezone"
+		},
+		{
+			"comment": "@wordpress/edit-site-init's build/index.cjs require()s @wordpress/boot, which exposes only an ESM `import` condition (no CJS entry). A real packaging mismatch to resolve separately.",
+			"specifier": "@wordpress/boot",
+			"surface": "runtime",
+			"kind": "unresolved"
+		},
+		{
+			"comment": "@wordpress/interactivity-router's build/index.cjs require()s @wordpress/interactivity, which exposes only an ESM `import` condition (no CJS entry). A real packaging mismatch to resolve separately.",
+			"specifier": "@wordpress/interactivity",
+			"surface": "runtime",
+			"kind": "unresolved"
+		},
+		{
+			"comment": "@wordpress/e2e-tests ships test-fixture plugins under plugins/ (imports of @wordpress/connectors as test data and sibling `test/*` script-modules registered by the harness, not real npm packages). Scoped to that package and path so it can never mask a real finding elsewhere.",
+			"target": "@wordpress/e2e-tests",
+			"path": "plugins/**"
+		},
+		{
+			"comment": "@wordpress/scripts intentionally deep-imports puppeteer-core/install (its install entrypoint), which puppeteer-core does not expose via exports.",
+			"specifier": "puppeteer-core/install",
+			"surface": "runtime",
+			"kind": "unresolved"
+		},
+		{
+			"comment": "@wordpress/scripts references puppeteer-firefox conditionally in its puppeteer jest environment; it is an optional, environment-gated import rather than a hard dependency.",
+			"specifier": "puppeteer-firefox",
+			"surface": "runtime",
+			"kind": "undeclared"
+		}
+	]
+}

--- a/tools/validation/package.json
+++ b/tools/validation/package.json
@@ -21,6 +21,7 @@
 	},
 	"type": "module",
 	"devDependencies": {
+		"@mawesome/dependency-audit": "^0.4.4",
 		"@wordpress/create-block": "file:../../packages/create-block",
 		"@wordpress/scripts": "file:../../packages/scripts",
 		"chalk": "^4.1.1",
@@ -34,6 +35,7 @@
 	"scripts": {
 		"check-installed-deps": "node ./check-installed-deps.mjs",
 		"check-licenses": "node ./check-licenses.mjs",
+		"dependency-audit": "dependency-audit --collapse-root-cause ../../packages/*",
 		"check-local-changes": "node ./check-local-changes.cjs",
 		"test-create-block": "node ./test-create-block.mjs",
 		"validate-package-lock": "node ./validate-package-lock.cjs",

--- a/tools/validation/package.json
+++ b/tools/validation/package.json
@@ -35,7 +35,7 @@
 	"scripts": {
 		"check-installed-deps": "node ./check-installed-deps.mjs",
 		"check-licenses": "node ./check-licenses.mjs",
-		"dependency-audit": "dependency-audit --collapse-root-cause ../../packages/*",
+		"dependency-audit": "dependency-audit --collapse-root-cause \"../../packages/*\"",
 		"check-local-changes": "node ./check-local-changes.cjs",
 		"test-create-block": "node ./test-create-block.mjs",
 		"validate-package-lock": "node ./validate-package-lock.cjs",


### PR DESCRIPTION
## What?

Follow up to [#78882 (comment)](https://github.com/WordPress/gutenberg/pull/78882#issuecomment-4650348761), where integrating a check against undeclared published dependencies was suggested.

Adds [`@mawesome/dependency-audit`](https://www.npmjs.com/package/@mawesome/dependency-audit) to `tools/validation` and exposes it as `npm run lint:published-deps`. The audit verifies that every bare import reachable in each package's **published artifact** — runtime JS and emitted `.d.ts` — is declared and resolvable from that package's own dependency ranges, never via root hoisting, a `devDependency`, or a workspace link.

This PR adds a script and its ignore config so the check can be run locally and evaluated; it also adds a CI gate. A companion PR (#79095) fixes everything the audit currently reports — until it lands, this PR doubles as a live demonstration of what the tool catches.

## Why?

Missing published dependencies have been a recurring, hard-to-catch bug class (#74310, #74655, #78882): a module resolves at build time in the monorepo, but consumers installing the package from npm cannot resolve it. For type-surface gaps the failure is silent — with `skipLibCheck: true` the affected exports degrade to `any`. We had no protection against regressions, and as #78882 showed, new gaps keep being introduced.

On current `trunk`, `npm run lint:published-deps` reports **21 real findings across 12 packages** (all fixed by #79095), for example:

```
@wordpress/components@34.0.0
  ✗ types      [undeclared]     @ariakit/react-core/utils/types  (build-types/card/card-divider/hook.d.ts)
@wordpress/react-i18n@4.47.0
  ✗ runtime    [undeclared]     react/jsx-runtime  (build/index.cjs)
@wordpress/editor@14.47.0
  ✗ types      [undeclared]     redux  (build-types/store/index.d.ts)
  ✗ types      [undeclared]     rememo  (build-types/store/selectors.d.ts)
@wordpress/interactivity@6.47.0
  ✗ types      [undeclared]     @preact/signals-core  (build-types/scopes.d.ts)
```

With #79095 merged (and this branch rebased), the audit runs clean and deterministically: `126 packages, 0 findings, 1 collapsed, 12 ignored, 8 notices` (exit 0).

## How?

-   `@mawesome/dependency-audit` is added as a devDependency of the private `@wordpress/validation-tools` workspace (keeping it out of the root, per workspace conventions), with a `dependency-audit` script that audits `packages/*`.
-   A root `lint:published-deps` script delegates to it, mirroring `lint:lockfile`/`lint:tsconfig`.
-   `tools/validation/dependency-audit.config.json` documents every intentional suppression with the reason and the follow-up needed. The remaining ignores are: test-fixture imports in `e2e-tests` (scoped to that package's `plugins/**` path), the optional `puppeteer-core/install` / `puppeteer-firefox` imports in `scripts`, two libraries that ship no types and have no `@types/*` package (`equivalent-key-map`, `moment-timezone`'s deep import), two ESM/CJS packaging mismatches to fix separately (`edit-site-init`→`boot`, `interactivity-router`→`interactivity`), and one temporary rule for `@tannin/sprintf` pending a tool release that resolves ESM-only types.
-   `--collapse-root-cause` makes findings whose root cause is another audited package's packaging notice (currently: `editor` cannot resolve `@wordpress/block-editor`'s types because `block-editor` does not expose them) report against the producer instead of failing every consumer.

Exit codes: `0` clean, `1` findings, `2` a package could not be audited — so the script is CI-ready once we decide to gate (intended follow-up, possibly after evaluating it on a few real PRs).

## Testing Instructions

1. `npm ci`
2. `npm run build` (the audit reads the built artifacts)
3. `npm run lint:published-deps` — on this branch (current trunk) expect exit 1 with `21 findings`, each carrying a remediation suggestion; after #79095 merges and this branch rebases, expect exit 0 with `126 packages, 0 findings, 1 collapsed, 12 ignored, 8 notices, 3 skipped.`
4. To see it catch a fresh regression once green: remove e.g. `"redux"` from `packages/editor/package.json` dependencies, run `npm install && npm run lint:published-deps`, and observe the `undeclared` finding reappear.

### Testing Instructions for Keyboard

N/A — tooling only, no UI.

## Screenshots or screencast

N/A.

## Use of AI Tools

Used Claude Code to wire up the tool, run the audits, and author the ignore config. The diff was reviewed before submission.
