### PR TITLE
Packages: Fix the published dependency surface of npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46772,7 +46772,6 @@
 			"version": "2.3.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/components": "file:../components",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
@@ -46791,7 +46790,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/admin-ui/node_modules/@testing-library/dom": {
@@ -47285,7 +47290,6 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@react-spring/web": "^9.4.5",
-				"@types/react": "^18.3.27",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/blob": "file:../blob",
@@ -47350,8 +47354,14 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/block-editor/node_modules/@testing-library/dom": {
@@ -47452,7 +47462,6 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@arraypress/waveform-player": "^1.2.1",
-				"@types/react": "^18.3.27",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/autop": "file:../autop",
@@ -47513,8 +47522,14 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/block-library/node_modules/@arraypress/waveform-player": {
@@ -47625,7 +47640,6 @@
 			"version": "15.21.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/autop": "file:../autop",
 				"@wordpress/blob": "file:../blob",
 				"@wordpress/block-serialization-default-parser": "file:../block-serialization-default-parser",
@@ -47661,7 +47675,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/blocks/node_modules/react-is": {
@@ -47674,7 +47694,6 @@
 			"version": "0.15.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/admin-ui": "file:../admin-ui",
 				"@wordpress/base-styles": "file:../base-styles",
@@ -47705,8 +47724,14 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/browserslist-config": {
@@ -47764,7 +47789,6 @@
 				"@floating-ui/react-dom": "^2.0.8",
 				"@types/gradient-parser": "^1.1.0",
 				"@types/highlight-words-core": "^1.2.1",
-				"@types/react": "^18.3.27",
 				"@use-gesture/react": "^10.3.1",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/base-styles": "file:../base-styles",
@@ -47825,8 +47849,14 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/components/node_modules/@emotion/css": {
@@ -47955,7 +47985,6 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/mousetrap": "^1.6.8",
-				"@types/react": "^18.3.27",
 				"@wordpress/deprecated": "file:../deprecated",
 				"@wordpress/dom": "file:../dom",
 				"@wordpress/element": "file:../element",
@@ -47980,7 +48009,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/compose/node_modules/@testing-library/dom": {
@@ -48053,13 +48088,21 @@
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/components": "file:../components",
 				"@wordpress/data": "file:../data",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/private-apis": "file:../private-apis"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/content-types": {
@@ -48067,7 +48110,6 @@
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/admin-ui": "file:../admin-ui",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
@@ -48085,6 +48127,15 @@
 				"@wordpress/ui": "file:../ui",
 				"@wordpress/url": "file:../url",
 				"@wordpress/views": "file:../views"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/core-abilities": {
@@ -48134,7 +48185,6 @@
 			"version": "7.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/block-editor": "file:../block-editor",
 				"@wordpress/blocks": "file:../blocks",
@@ -48170,8 +48220,14 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/core-data/node_modules/@babel/core": {
@@ -49077,7 +49133,6 @@
 			"version": "10.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/deprecated": "file:../deprecated",
 				"@wordpress/element": "file:../element",
@@ -49104,7 +49159,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/data-controls": {
@@ -49195,7 +49256,6 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.29",
-				"@types/react": "^18.3.27",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
 				"@wordpress/compose": "file:../compose",
@@ -49233,8 +49293,14 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/dataviews/node_modules/@testing-library/dom": {
@@ -49836,7 +49902,6 @@
 			"version": "14.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
@@ -49890,6 +49955,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
+				"redux": "^5.0.1",
 				"remove-accents": "^0.5.0",
 				"uuid": "^14.0.0"
 			},
@@ -49904,8 +49970,14 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/editor/node_modules/@testing-library/dom": {
@@ -50304,7 +50376,6 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@react-spring/web": "^9.4.5",
-				"@types/react": "^18.3.27",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/blob": "file:../blob",
@@ -50340,7 +50411,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/format-library": {
@@ -50472,7 +50549,6 @@
 			"version": "1.15.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
@@ -50503,8 +50579,14 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/global-styles-ui/node_modules/@testing-library/dom": {
@@ -50580,7 +50662,6 @@
 				"@dnd-kit/core": "^6.3.1",
 				"@dnd-kit/sortable": "^10.0.0",
 				"@dnd-kit/utilities": "^3.2.2",
-				"@types/react": "^18.3.27",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/element": "file:../element",
 				"@wordpress/style-runtime": "file:../style-runtime",
@@ -50598,8 +50679,14 @@
 				"npm": ">=10.2.3"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/grid/node_modules/@testing-library/dom": {
@@ -50715,7 +50802,6 @@
 			"version": "14.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/element": "file:../element",
 				"@wordpress/primitives": "file:../primitives",
 				"change-case": "^4.1.2"
@@ -50725,7 +50811,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/image-cropper": {
@@ -50733,7 +50825,6 @@
 			"version": "1.12.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/components": "file:../components",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
@@ -50746,8 +50837,14 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/interactivity": {
@@ -50756,6 +50853,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@preact/signals": "^1.3.0",
+				"@preact/signals-core": "^1.7.0",
 				"preact": "^10.29.1"
 			},
 			"devDependencies": {
@@ -50953,7 +51051,6 @@
 			"version": "5.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/data": "file:../data",
 				"@wordpress/element": "file:../element",
 				"@wordpress/keycodes": "file:../keycodes"
@@ -50963,7 +51060,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/keycodes": {
@@ -50971,12 +51074,19 @@
 			"version": "4.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/i18n": "file:../i18n"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/latex-to-mathml": {
@@ -50996,7 +51106,6 @@
 			"version": "1.14.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/asset-loader": "file:../asset-loader",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/block-editor": "file:../block-editor",
@@ -51013,6 +51122,15 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/lazy-import": {
@@ -51039,7 +51157,6 @@
 			"version": "5.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/blob": "file:../blob",
@@ -51055,8 +51172,14 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/media-editor": {
@@ -51064,7 +51187,6 @@
 			"version": "0.11.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
@@ -51095,7 +51217,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/media-editor/node_modules/@testing-library/dom": {
@@ -51168,7 +51296,6 @@
 			"version": "0.13.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
 				"@wordpress/compose": "file:../compose",
@@ -51195,7 +51322,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/media-fields/node_modules/@testing-library/dom": {
@@ -51268,7 +51401,6 @@
 			"version": "5.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/blob": "file:../blob",
@@ -51296,7 +51428,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/media-utils/node_modules/@testing-library/dom": {
@@ -51369,7 +51507,6 @@
 			"version": "5.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/components": "file:../components",
 				"@wordpress/data": "file:../data",
@@ -51385,7 +51522,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/notices/node_modules/@testing-library/dom": {
@@ -51587,7 +51730,6 @@
 			"version": "7.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/components": "file:../components",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/deprecated": "file:../deprecated",
@@ -51606,8 +51748,14 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/plugins/node_modules/@testing-library/dom": {
@@ -51710,7 +51858,6 @@
 			"version": "4.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
@@ -51728,8 +51875,14 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/preferences-persistence": {
@@ -51765,7 +51918,6 @@
 			"version": "4.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/element": "file:../element",
 				"clsx": "^2.1.1"
 			},
@@ -51774,7 +51926,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/priority-queue": {
@@ -51841,7 +51999,6 @@
 			"version": "4.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
 				"utility-types": "^3.10.0"
@@ -51849,6 +52006,15 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/readable-js-assets-webpack-plugin": {
@@ -51937,7 +52103,6 @@
 			"version": "7.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/data": "file:../data",
@@ -51959,7 +52124,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/route": {
@@ -51984,7 +52155,6 @@
 			"version": "1.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/element": "file:../element",
 				"@wordpress/private-apis": "file:../private-apis",
@@ -51997,7 +52167,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/scripts": {
@@ -52052,6 +52228,7 @@
 				"react-refresh": "^0.14.0",
 				"read-pkg-up": "^7.0.1",
 				"resolve-bin": "^0.4.0",
+				"rimraf": "^5.0.10",
 				"rtlcss": "^4.3.0",
 				"sass": "^1.54.0",
 				"sass-loader": "^16.0.3",
@@ -52120,7 +52297,6 @@
 			"version": "6.24.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/blocks": "file:../blocks",
 				"@wordpress/components": "file:../components",
@@ -52136,8 +52312,14 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/shortcode": {
@@ -52157,12 +52339,19 @@
 			"version": "2.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"change-case": "^4.1.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/style-runtime": {
@@ -53009,7 +53198,6 @@
 			"version": "0.15.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/element": "file:../element",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/style-runtime": "file:../style-runtime",
@@ -53028,19 +53216,36 @@
 				"@types/node": "^20.19.39",
 				"esbuild": "^0.27.2",
 				"esbuild-esm-loader": "^0.3.3",
-				"storybook": "^10.2.8"
+				"storybook": "^10.2.8",
+				"stylelint": "^16.8.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"esbuild": "^0.27.2",
+				"postcss": "^8.0.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0",
-				"stylelint": "^16.8.2"
+				"stylelint": "^16.8.2",
+				"vite": "^7.3.2"
 			},
 			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				},
 				"stylelint": {
+					"optional": true
+				},
+				"vite": {
 					"optional": true
 				}
 			}
@@ -53173,7 +53378,6 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@base-ui/react": "^1.5.0",
-				"@types/react": "^18.3.27",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/element": "file:../element",
@@ -53203,8 +53407,14 @@
 				"npm": ">=10.2.3"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/ui/node_modules/@testing-library/dom": {
@@ -53292,7 +53502,6 @@
 			"version": "0.33.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/blob": "file:../blob",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/data": "file:../data",
@@ -53309,8 +53518,14 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/url": {
@@ -53330,7 +53545,6 @@
 			"version": "6.48.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/data": "file:../data",
 				"@wordpress/element": "file:../element"
@@ -53345,7 +53559,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/viewport/node_modules/@testing-library/dom": {

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -44,7 +44,6 @@
 		"src/**/*.module.css"
 	],
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/components": "file:../components",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
@@ -59,7 +58,13 @@
 		"@testing-library/react": "^16.3.2"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -60,7 +60,6 @@
 	],
 	"dependencies": {
 		"@react-spring/web": "^9.4.5",
-		"@types/react": "^18.3.27",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/blob": "file:../blob",
@@ -121,8 +120,14 @@
 		"deep-freeze": "^0.0.1"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -94,7 +94,6 @@
 	],
 	"dependencies": {
 		"@arraypress/waveform-player": "^1.2.1",
-		"@types/react": "^18.3.27",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/autop": "file:../autop",
@@ -151,8 +150,14 @@
 		"deep-freeze": "^0.0.1"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -50,7 +50,6 @@
 		"build-module/store/index.mjs"
 	],
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/autop": "file:../autop",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/block-serialization-default-parser": "file:../block-serialization-default-parser",
@@ -82,7 +81,13 @@
 		"deep-freeze": "^0.0.1"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -40,7 +40,6 @@
 	"wpScriptModuleExports": "./build-module/index.mjs",
 	"types": "build-types",
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/admin-ui": "file:../admin-ui",
 		"@wordpress/base-styles": "file:../base-styles",
@@ -67,8 +66,14 @@
 		"clsx": "^2.1.1"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   `SandBox`: Fix the viewport-unit (`vh`, `vw`, etc.) stripping so user-supplied HTML using these units in `width`/`height` no longer triggers a runaway resize loop in the preview ([#78677](https://github.com/WordPress/gutenberg/pull/78677)).
 
+### Code Quality
+
+-   Move `@types/react` from `dependencies` to an optional peer dependency so consumers' React type version is used [#79095](https://github.com/WordPress/gutenberg/pull/79095).
+
 ## 35.0.0 (2026-06-10)
 
 ### Breaking Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -61,7 +61,6 @@
 		"@floating-ui/react-dom": "^2.0.8",
 		"@types/gradient-parser": "^1.1.0",
 		"@types/highlight-words-core": "^1.2.1",
-		"@types/react": "^18.3.27",
 		"@use-gesture/react": "^10.3.1",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/base-styles": "file:../base-styles",
@@ -118,8 +117,14 @@
 		"timezone-mock": "^1.3.6"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/components/src/card/card-divider/hook.ts
+++ b/packages/components/src/card/card-divider/hook.ts
@@ -12,9 +12,13 @@ import * as styles from '../styles';
 import { useCx } from '../../utils/hooks/use-cx';
 import type { DividerProps } from '../../divider';
 
+/*
+ * The explicit return type keeps the emitted declaration from inlining the inferred type,
+ * which references `WrapElement` from @ariakit/react-utils
+ */
 export function useCardDivider(
 	props: WordPressComponentProps< DividerProps, 'hr', false >
-) {
+): WordPressComponentProps< DividerProps, 'hr', false > {
 	const { className, ...otherProps } = useContextSystem(
 		props,
 		'CardDivider'

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -46,7 +46,6 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@types/mousetrap": "^1.6.8",
-		"@types/react": "^18.3.27",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
@@ -67,7 +66,13 @@
 		"react-dom": "^18.3.1"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -30,13 +30,21 @@
 	"wpScriptModuleExports": "./build-module/index.mjs",
 	"types": "build-types",
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/components": "file:../components",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/private-apis": "file:../private-apis"
+	},
+	"peerDependencies": {
+		"@types/react": "^18.3.27",
+		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/content-types/package.json
+++ b/packages/content-types/package.json
@@ -33,7 +33,6 @@
 	"wpScriptModuleExports": "./build-module/index.mjs",
 	"types": "build-types",
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/admin-ui": "file:../admin-ui",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",
@@ -51,6 +50,15 @@
 		"@wordpress/ui": "file:../ui",
 		"@wordpress/url": "file:../url",
 		"@wordpress/views": "file:../views"
+	},
+	"peerDependencies": {
+		"@types/react": "^18.3.27",
+		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -48,7 +48,6 @@
 		"build-module/index.mjs"
 	],
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/blocks": "file:../blocks",
@@ -80,8 +79,14 @@
 		"deep-freeze": "^0.0.1"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -500,9 +500,11 @@ _Returns_
 
 Creates a memoized selector that caches the computed values according to the array of "dependants" and the selector parameters, and recomputes the values only when any of them changes.
 
-_Related_
+See The documentation for the `rememo` package from which the `createSelector` function is reexported.
 
--   The documentation for the `rememo` package from which the `createSelector` function is reexported.
+_Type_
+
+-   `( selector: S, getDependants: GetDependants ) => S & EnhancedSelector`
 
 ### dispatch
 
@@ -528,6 +530,14 @@ _Parameters_
 _Returns_
 
 -   `DispatchReturn< StoreNameOrDescriptor >`: Object containing the action creators.
+
+### EnhancedSelector
+
+Undocumented declaration.
+
+### GetDependants
+
+Undocumented declaration.
 
 ### keyedReducer
 

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -44,7 +44,6 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
@@ -67,7 +66,13 @@
 		"deep-freeze": "^0.0.1"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/data/src/create-selector.ts
+++ b/packages/data/src/create-selector.ts
@@ -1,7 +1,41 @@
 /**
+ * External dependencies
+ */
+import memoize from 'rememo';
+
+/**
+ * Returns the array of immutable references on which a memoized selector
+ * depends for computing its result. The memoize cache is preserved only as
+ * long as those dependant references remain the same.
+ */
+export type GetDependants = ( ...args: any[] ) => any[];
+
+/**
+ * The memoization methods a selector returned by `createSelector` is
+ * enhanced with.
+ */
+export interface EnhancedSelector {
+	getDependants: GetDependants;
+
+	/**
+	 * Clears the memoization cache.
+	 */
+	clear: () => void;
+}
+
+/*
+ * The signature mirrors `rememo`'s, but is declared here so that consumers'
+ * emitted declarations reference `@wordpress/data` rather than `rememo`,
+ * which they do not declare as a dependency.
+ */
+
+/**
  * Creates a memoized selector that caches the computed values according to the array of "dependants"
  * and the selector parameters, and recomputes the values only when any of them changes.
  *
- * @see The documentation for the `rememo` package from which the `createSelector` function is reexported.
+ * See The documentation for the `rememo` package from which the `createSelector` function is reexported.
  */
-export { default as createSelector } from 'rememo';
+export const createSelector: < S extends ( ...args: any[] ) => any >(
+	selector: S,
+	getDependants?: GetDependants
+) => S & EnhancedSelector = memoize;

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -30,6 +30,7 @@ export { AsyncModeProvider } from './components/async-mode-provider';
 export { createRegistry } from './registry';
 export { createRegistrySelector, createRegistryControl } from './factory';
 export { createSelector } from './create-selector';
+export type { EnhancedSelector, GetDependants } from './create-selector';
 export { controls } from './controls';
 export { default as createReduxStore } from './redux-store';
 export { keyedReducer } from './redux-store/keyed-reducer';

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `DataViewsPicker`: `DataViewsPicker.BulkActionToolbar` now renders only the bulk-selection info and action buttons, without pagination, matching `DataViews.BulkActionToolbar`. The full footer it previously rendered (including pagination) is now exposed as `DataViewsPicker.Footer`, matching `DataViews.Footer`. [#79180](https://github.com/WordPress/gutenberg/pull/79180)
 
+### Code Quality
+
+- Move `@types/react` from `dependencies` to an optional peer dependency so consumers' React type version is used [#79095](https://github.com/WordPress/gutenberg/pull/79095).
+
 ## 16.0.0 (2026-06-10)
 
 ### Breaking Changes

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -52,7 +52,6 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@ariakit/react": "^0.4.29",
-		"@types/react": "^18.3.27",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
@@ -86,8 +85,14 @@
 		"storybook": "^10.2.8"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -59,7 +59,6 @@
 		"build-module/bindings/**"
 	],
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",
@@ -113,6 +112,7 @@
 		"fast-deep-equal": "^3.1.3",
 		"memize": "^2.1.0",
 		"react-autosize-textarea": "^7.1.0",
+		"redux": "^5.0.1",
 		"remove-accents": "^0.5.0",
 		"uuid": "^14.0.0"
 	},
@@ -123,8 +123,14 @@
 		"deep-freeze": "^0.0.1"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -47,7 +47,6 @@
 	],
 	"dependencies": {
 		"@react-spring/web": "^9.4.5",
-		"@types/react": "^18.3.27",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/blob": "file:../blob",
@@ -79,7 +78,13 @@
 		"remove-accents": "^0.5.0"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/global-styles-ui/package.json
+++ b/packages/global-styles-ui/package.json
@@ -43,7 +43,6 @@
 		"./build-style/": "./build-style/"
 	},
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",
@@ -70,8 +69,14 @@
 		"@testing-library/react": "^16.3.2"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -50,7 +50,6 @@
 		"@dnd-kit/core": "^6.3.1",
 		"@dnd-kit/sortable": "^10.0.0",
 		"@dnd-kit/utilities": "^3.2.2",
-		"@types/react": "^18.3.27",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/style-runtime": "file:../style-runtime",
@@ -64,8 +63,14 @@
 		"@wordpress/ui": "file:../ui"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -43,13 +43,18 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/element": "file:../element",
 		"@wordpress/primitives": "file:../primitives",
 		"change-case": "^4.1.2"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/image-cropper/package.json
+++ b/packages/image-cropper/package.json
@@ -43,7 +43,6 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/components": "file:../components",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
@@ -52,8 +51,14 @@
 		"react-easy-crop": "^5.4.2"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -34,6 +34,7 @@
 	"types": "build-types",
 	"dependencies": {
 		"@preact/signals": "^1.3.0",
+		"@preact/signals-core": "^1.7.0",
 		"preact": "^10.29.1"
 	},
 	"devDependencies": {

--- a/packages/keyboard-shortcuts/package.json
+++ b/packages/keyboard-shortcuts/package.json
@@ -42,13 +42,18 @@
 	"wpScript": true,
 	"types": "build-types/index.d.ts",
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
 		"@wordpress/keycodes": "file:../keycodes"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -43,8 +43,15 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/i18n": "file:../i18n"
+	},
+	"peerDependencies": {
+		"@types/react": "^18.3.27"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/lazy-editor/package.json
+++ b/packages/lazy-editor/package.json
@@ -44,7 +44,6 @@
 	"wpScriptModuleExports": "./build-module/index.mjs",
 	"types": "build-types",
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/asset-loader": "file:../asset-loader",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/block-editor": "file:../block-editor",
@@ -57,6 +56,15 @@
 		"@wordpress/global-styles-engine": "file:../global-styles-engine",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/private-apis": "file:../private-apis"
+	},
+	"peerDependencies": {
+		"@types/react": "^18.3.27",
+		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -45,7 +45,6 @@
 	"wpScript": true,
 	"types": "build-types",
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/blob": "file:../blob",
@@ -57,8 +56,14 @@
 		"change-case": "^4.1.2"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -43,7 +43,6 @@
 		"build-module/store/index.mjs"
 	],
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",
@@ -70,7 +69,13 @@
 		"@testing-library/user-event": "^14.6.1"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/media-fields/package.json
+++ b/packages/media-fields/package.json
@@ -48,7 +48,6 @@
 		"src/**/*.scss"
 	],
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
@@ -71,7 +70,13 @@
 		"@types/jest": "^29.5.14"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -47,7 +47,6 @@
 		"build-style/**"
 	],
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/blob": "file:../blob",
@@ -71,7 +70,13 @@
 		"@testing-library/user-event": "^14.6.1"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -48,7 +48,6 @@
 		"src/**/*.scss"
 	],
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/components": "file:../components",
 		"@wordpress/data": "file:../data",
@@ -60,7 +59,13 @@
 		"deep-freeze": "^0.0.1"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -42,7 +42,6 @@
 	"wpScript": true,
 	"types": "build-types",
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/deprecated": "file:../deprecated",
@@ -57,8 +56,14 @@
 		"@testing-library/react": "^16.3.2"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -50,7 +50,6 @@
 	],
 	"sideEffects": false,
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",
@@ -64,8 +63,14 @@
 		"clsx": "^2.1.1"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -46,12 +46,17 @@
 		"src/**/*.scss"
 	],
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/element": "file:../element",
 		"clsx": "^2.1.1"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -43,10 +43,18 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"utility-types": "^3.10.0"
+	},
+	"peerDependencies": {
+		"@types/react": "^18.3.27",
+		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -51,7 +51,6 @@
 		"build-module/store/index.mjs"
 	],
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
@@ -69,7 +68,13 @@
 		"deep-freeze": "^0.0.1"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -42,7 +42,6 @@
 	"wpScript": true,
 	"types": "build-types",
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/private-apis": "file:../private-apis",
@@ -51,7 +50,13 @@
 		"route-recognizer": "^0.3.4"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -80,6 +80,7 @@
 		"react-refresh": "^0.14.0",
 		"read-pkg-up": "^7.0.1",
 		"resolve-bin": "^0.4.0",
+		"rimraf": "^5.0.10",
 		"rtlcss": "^4.3.0",
 		"sass": "^1.54.0",
 		"sass-loader": "^16.0.3",

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -44,7 +44,6 @@
 	"wpScriptDefaultExport": true,
 	"types": "build-types/index.d.ts",
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",
@@ -56,8 +55,14 @@
 		"@wordpress/url": "file:../url"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/style-engine/package.json
+++ b/packages/style-engine/package.json
@@ -64,8 +64,15 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"change-case": "^4.1.2"
+	},
+	"peerDependencies": {
+		"@types/react": "^18.3.27"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 -   Add unit tests for `ThemeProvider` and `useThemeProviderStyles` ([#79126](https://github.com/WordPress/gutenberg/pull/79126)).
 
+### Code Quality
+
+-   Declare `postcss`, `esbuild`, and `vite` as optional peer dependencies for the bundler plugins, and move `@types/react` from `dependencies` to an optional peer dependency ([#79095](https://github.com/WordPress/gutenberg/pull/79095)).
+
 ## 0.15.0 (2026-06-10)
 
 ### New Features

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -79,7 +79,6 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/element": "file:../element",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/style-runtime": "file:../style-runtime",
@@ -98,15 +97,32 @@
 		"@types/node": "^20.19.39",
 		"esbuild": "^0.27.2",
 		"esbuild-esm-loader": "^0.3.3",
-		"storybook": "^10.2.8"
-	},
-	"peerDependencies": {
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0",
+		"storybook": "^10.2.8",
 		"stylelint": "^16.8.2"
 	},
+	"peerDependencies": {
+		"@types/react": "^18.3.27",
+		"esbuild": "^0.27.2",
+		"postcss": "^8.0.0",
+		"react": "^18.0.0",
+		"react-dom": "^18.0.0",
+		"stylelint": "^16.8.2",
+		"vite": "^7.3.2"
+	},
 	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		},
+		"esbuild": {
+			"optional": true
+		},
+		"postcss": {
+			"optional": true
+		},
 		"stylelint": {
+			"optional": true
+		},
+		"vite": {
 			"optional": true
 		}
 	},

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `Field.Description`: Apply `text-wrap: pretty` to description text to avoid typographic widows ([#79143](https://github.com/WordPress/gutenberg/pull/79143)).
 
+### Code Quality
+
+-   Move `@types/react` from `dependencies` to an optional peer dependency so consumers' React type version is used ([#79095](https://github.com/WordPress/gutenberg/pull/79095)).
+
 ## 0.15.0 (2026-06-10)
 
 ### Breaking Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,7 +44,6 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@base-ui/react": "^1.5.0",
-		"@types/react": "^18.3.27",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
@@ -70,8 +69,14 @@
 		"storybook": "^10.2.8"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/upload-media/package.json
+++ b/packages/upload-media/package.json
@@ -49,7 +49,6 @@
 		"build-module/store/index.mjs"
 	],
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
@@ -62,8 +61,14 @@
 		"uuid": "^14.0.0"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -42,7 +42,6 @@
 	"wpScript": true,
 	"types": "build-types",
 	"dependencies": {
-		"@types/react": "^18.3.27",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element"
@@ -53,7 +52,13 @@
 		"deep-freeze": "^0.0.1"
 	},
 	"peerDependencies": {
+		"@types/react": "^18.3.27",
 		"react": "^18.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## What?

Follow up to #78882 ([discussion](https://github.com/WordPress/gutenberg/pull/78882#issuecomment-4650348761)).

Fixes every remaining case where a package's **published artifact** — its runtime JS or emitted `build-types/*.d.ts` — references a module that consumers installing from npm cannot resolve, as surfaced by auditing all packages with [`@mawesome/dependency-audit`](https://www.npmjs.com/package/@mawesome/dependency-audit) (wired into the repo as `npm run lint:published-deps` in #79094, so regressions are caught going forward).

## Why?

#78882 declared `@types/react` where packages' emitted declarations reference React types, but a full audit of the published artifacts showed more gaps, and one placement issue in #78882 itself:

-   **`@types/react` as a hard `dependency` while `react` is a peer is the wrong placement.** When `react` is supplied by the consumer, the React *type* version must match the consumer's React too. A hard dependency drags in our own copy, which can collide with the consumer's `@types/react` (two structurally-incompatible JSX namespaces) and defeats the decoupling that made `react` a peer in the first place. The type surface should mirror the runtime surface: an optional `peerDependency` (optional so pure-JS consumers see no install warning). This is the established pattern in the React ecosystem.
-   **Some packages import `react/jsx-runtime` at runtime without declaring `react` at all.**
-   **Some packages reference modules in their published files that resolve today only via root hoisting or a workspace link** — the exact bug class of #74310 and #74655.
-   **`@wordpress/data` leaked `rememo`'s types into six consumers' declarations.** `createSelector` was a bare re-export, so consumers' inferred selector types were emitted as `... & import("rememo").EnhancedSelector` in *their* `.d.ts`, and they do not declare `rememo`. With `skipLibCheck: true` those exports silently degrade to `any` for npm consumers.

## How?

-   `@types/react` moves from `dependencies` to an optional `peerDependency` in the 38 packages where `react` is a peer (or where only the types are referenced). `@wordpress/element` keeps it as a dependency since it depends on `react` directly.
-   `react` (`^18.0.0`) is added as a peer to the four packages that import `react/jsx-runtime` at runtime but never declared it: `connectors`, `content-types`, `lazy-editor`, `react-i18n`.
-   Genuinely missing dependencies are declared: `@ariakit/react-core` (components), `redux` (editor), `@preact/signals-core` (interactivity), `rimraf` (scripts); <s>`storybook` moves from dev to prod dependencies in `design-system-mcp` (its emitted types reference it)</s>.
-   `@wordpress/theme` declares its bundler plugins' host tools — `postcss`, `esbuild`, `vite` — as optional peers, following its existing `stylelint` plugin pattern.
-   `@wordpress/data` now owns the `createSelector` types: `create-selector.ts` declares `EnhancedSelector`/`GetDependants` and annotates the export explicitly (same runtime function, zero behavior change), so consumers' emitted declarations reference `import("@wordpress/data")` instead of `rememo`. The two types are re-exported from the package index because TypeScript requires the type to be nameable through the package's public entry to emit a portable reference (TS2883 otherwise).

No runtime changes anywhere; `npm run build` type-checks clean and the regenerated `packages/data/README.md` API docs are included.

## Testing Instructions

1. `npm ci`
2. `npm run build` — confirm the build and type checks pass.
3. `grep -r 'import("rememo")' packages/*/build-types/` — confirm zero hits (on trunk, 6 packages emit such references).
4. Optionally audit any package's published surface: `npx @mawesome/dependency-audit packages/<name>`.

### Testing Instructions for Keyboard

N/A — dependency declaration and type-only changes, no UI.

## Screenshots or screencast

N/A.

## Use of AI Tools

Used Claude Code (with the dependency-audit tool) to identify the affected packages, apply the dependency moves, and validate the results; the Codex CLI reviewed the `createSelector` type-ownership approach. The diff was reviewed before submission.
