### PR TITLE
Media Editor Modal: Add a loading and simple error state

### DIFF
--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -136,7 +136,7 @@ export default function MediaEditorCanvas( {
 	if ( status === 'error' ) {
 		return (
 			<div className="media-editor-canvas">
-				<div className="media-editor-canvas__error">
+				<div className="media-editor-canvas__error" role="alert">
 					<p>{ __( 'Failed to load image.' ) }</p>
 				</div>
 			</div>
@@ -150,6 +150,15 @@ export default function MediaEditorCanvas( {
 					<Spinner />
 				</div>
 			) }
+			{ /*
+			 * The cropper stays mounted while loading (hidden behind the
+			 * spinner) so the image decodes off-screen and reveals in one paint
+			 * instead of streaming in top-to-bottom. Until it's revealed it's
+			 * non-interactive (`pointer-events: none` in CSS), and focus is
+			 * withheld by gating `focusOnMount` on the loaded state — the
+			 * cropper's focus effect keys off that prop, so focus lands on the
+			 * crop area only once it's visible.
+			 */ }
 			<div
 				className={ clsx( 'media-editor-canvas__cropper', {
 					'is-loaded': status === 'loaded',
@@ -160,7 +169,7 @@ export default function MediaEditorCanvas( {
 					controller={ controller }
 					aspectRatio={ aspectRatio }
 					freeformCrop
-					focusOnMount={ focusOnMount }
+					focusOnMount={ focusOnMount && status === 'loaded' }
 					showGrid="interactive"
 					isPlacementActive={ isPlacementActive }
 					onGestureStart={ handleGestureStart }

--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -1,7 +1,14 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useMemo } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -48,6 +55,13 @@ export default function MediaEditorCanvas( {
 	const cropperImage = controller.state.image;
 	const { beginGesture, endGesture, setImage } = controller;
 
+	// Tracks whether the image pixels have actually loaded. The cropper's
+	// geometry is driven by the known media dimensions, so its handles and
+	// overlays would otherwise appear before the image finishes streaming in.
+	const [ status, setStatus ] = useState< 'loading' | 'loaded' | 'error' >(
+		'loading'
+	);
+
 	// Resolved aspect ratio is derived from the preset key + the
 	// loaded image (for the "Original" preset). The reducer doesn't
 	// store this number — only the preset key — so it's a render-time
@@ -90,23 +104,69 @@ export default function MediaEditorCanvas( {
 		} );
 	}, [ cropperImage, mediaUrl, mediaWidth, mediaHeight, setImage ] );
 
-	if ( ! mediaUrl || mediaType.type !== 'image' ) {
+	const isImage = mediaType.type === 'image';
+
+	// Probe the image to know when its pixels have loaded (or failed),
+	// independent of the cropper. The browser shares one fetch/cache with the
+	// cropper's own `<img>`, so this adds no network cost. The cropper stays
+	// framework-pure — load/error handling lives here in the wrapper layer.
+	useEffect( () => {
+		if ( ! mediaUrl || ! isImage ) {
+			return;
+		}
+		setStatus( 'loading' );
+		const probe = new window.Image();
+		probe.onload = () => setStatus( 'loaded' );
+		probe.onerror = () => setStatus( 'error' );
+		probe.src = mediaUrl;
+		// Cached images may already be complete before listeners attach.
+		if ( probe.complete ) {
+			setStatus( probe.naturalWidth > 0 ? 'loaded' : 'error' );
+		}
+		return () => {
+			probe.onload = null;
+			probe.onerror = null;
+		};
+	}, [ mediaUrl, isImage ] );
+
+	if ( ! mediaUrl || ! isImage ) {
 		return null;
+	}
+
+	if ( status === 'error' ) {
+		return (
+			<div className="media-editor-canvas">
+				<div className="media-editor-canvas__error">
+					<p>{ __( 'Failed to load image.' ) }</p>
+				</div>
+			</div>
+		);
 	}
 
 	return (
 		<div className="media-editor-canvas">
-			<Cropper
-				src={ mediaUrl }
-				controller={ controller }
-				aspectRatio={ aspectRatio }
-				freeformCrop
-				focusOnMount={ focusOnMount }
-				showGrid="interactive"
-				isPlacementActive={ isPlacementActive }
-				onGestureStart={ handleGestureStart }
-				onGestureEnd={ handleGestureEnd }
-			/>
+			{ status === 'loading' && (
+				<div className="media-editor-canvas__spinner">
+					<Spinner />
+				</div>
+			) }
+			<div
+				className={ clsx( 'media-editor-canvas__cropper', {
+					'is-loaded': status === 'loaded',
+				} ) }
+			>
+				<Cropper
+					src={ mediaUrl }
+					controller={ controller }
+					aspectRatio={ aspectRatio }
+					freeformCrop
+					focusOnMount={ focusOnMount }
+					showGrid="interactive"
+					isPlacementActive={ isPlacementActive }
+					onGestureStart={ handleGestureStart }
+					onGestureEnd={ handleGestureEnd }
+				/>
+			</div>
 		</div>
 	);
 }

--- a/packages/media-editor/src/components/media-editor-canvas/style.scss
+++ b/packages/media-editor/src/components/media-editor-canvas/style.scss
@@ -1,3 +1,6 @@
+@use "@wordpress/base-styles/animations" as *;
+@use "@wordpress/base-styles/colors" as *;
+
 // The canvas wrapper fills the modal's canvas area so the cropper has a
 // sized parent (the cropper uses 100% width/height of its container).
 // `position: relative` establishes a stacking context for any future
@@ -6,4 +9,39 @@
 	position: relative;
 	width: 100%;
 	height: 100%;
+
+	// Holds the cropper, hidden until the image pixels have loaded so the
+	// crop handles and overlays don't appear over a half-loaded image.
+	&__cropper {
+		width: 100%;
+		height: 100%;
+		opacity: 0;
+
+		// Explicit `opacity: 1` (not just the animation's fill mode) keeps the
+		// cropper visible for reduced-motion users, since `animation__fade-in`
+		// is gated behind `@media not (prefers-reduced-motion)`.
+		&.is-loaded {
+			opacity: 1;
+			@include animation__fade-in( 0.2s );
+		}
+	}
+
+	&__spinner {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+	}
+
+	// Centered fallback shown in place of the cropper when the image
+	// fails to load.
+	&__error {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 100%;
+		height: 100%;
+		color: $gray-700;
+		text-align: center;
+	}
 }

--- a/packages/media-editor/src/components/media-editor-canvas/style.scss
+++ b/packages/media-editor/src/components/media-editor-canvas/style.scss
@@ -10,18 +10,21 @@
 	width: 100%;
 	height: 100%;
 
-	// Holds the cropper, hidden until the image pixels have loaded so the
-	// crop handles and overlays don't appear over a half-loaded image.
+	// The cropper stays mounted while loading so the image decodes behind the
+	// spinner and reveals in one paint. It's hidden and non-interactive until
+	// the image has loaded, then fades in.
 	&__cropper {
 		width: 100%;
 		height: 100%;
 		opacity: 0;
+		pointer-events: none;
 
 		// Explicit `opacity: 1` (not just the animation's fill mode) keeps the
 		// cropper visible for reduced-motion users, since `animation__fade-in`
 		// is gated behind `@media not (prefers-reduced-motion)`.
 		&.is-loaded {
 			opacity: 1;
+			pointer-events: auto;
 			@include animation__fade-in( 0.2s );
 		}
 	}


### PR DESCRIPTION
## What?

Add a simple loading state + fade in and error state to the Media Editor Modal.

## Why?

While most of the time the full image will be cached in the browser, I noticed this isn't always the case. And on slower or flaky connections (my internet is flaky today, which I think is why I noticed it!) the loading of the image can look clunky as it loads in from top to bottom with the drag handles already present.

So, this PR proposes adding a spinner, a simple fade-in when the image is loaded, and a simple error state when it fails.

These can all be expanded further in follow-ups (I know @ramonjd was previously looking at a more detailed approach to error handling), but the idea here is to try to make things feel a little smoother in a smaller iterative step.

## How?

* Add a state to capture loading state
* Use an Image object as a probe to determine loading from within the media editor canvas (it's done here so that we don't pollute the `image-editor` directory with WP components, etc)
* Once loaded, hide the spinner and fade in
* In the error state, display a simple paragraph (again, could be expanded further in follow-ups)

## Testing Instructions

To reproduce, I used Chrome Dev Tools with "Disable cache" switched on to simulate when an image hasn't already loaded. I did encounter this in real world usage, but it was intermittent, so this makes it easier to test consistently.

Switch to "Slow 4G" to test slow loading images.

* Add an image to a post or page
* Click the Crop tool in the image block toolbar to open the cropper
* You should (hopefully) see the image load and fade in smoothly with no weird jumps
* If you switch to Offline before opening the modal, you should get an error message instead

## Screenshots or screencast <!-- if applicable -->

### Before (simulating a very slow connection)

https://github.com/user-attachments/assets/9882c8b4-6421-46ac-a081-09139b182bde

### After (when quickly loading)

Even when quickly loading, hopefully it should feel smoother with this PR:

https://github.com/user-attachments/assets/8d255aea-4352-45e6-a1b3-c9c036d19901

### Error state

<img width="2526" height="1636" alt="image" src="https://github.com/user-attachments/assets/c52a370c-19d2-4987-b611-95c4df2103be" />


## Use of AI Tools

Claude Code