### PR TITLE
Image block: don't show crop icon while image is uploading

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -644,7 +644,8 @@ export default function Image( {
 		isSingleSelected &&
 		canEditImage &&
 		! isEditingImage &&
-		! isContentOnlyMode;
+		! isContentOnlyMode &&
+		! isUploading;
 
 	function switchToCover() {
 		replaceBlocks(


### PR DESCRIPTION

## What?

Don't show crop icon while image is uploading in the image block.

Site logo already handles this.

## Why?

If you're quick, you can press crop while an image is uploading and the cropper loads the previous attachment.



## How?

Don't show crop icon while image is uploading

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. With an Image block that has an existing image, replace image by uploading a large sized image
2. Quickly hit crop
3. You can't!

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/5480576a-c914-403f-811e-27266b255220



## Use of AI Tools

None