### PR TITLE
Add .vscode/settings.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Thumbs.db
 junit.xml
 
 # Local overrides
+/.vscode/settings.json
 .wp-env.override.json
 .wp-env.test.override.json
 playwright.config.override.ts


### PR DESCRIPTION
## What?

See #77913

Adds `/.vscode/settings.json` to `.gitignore`.

## Why?

#77913 proposes a managed VS Code workspace config, but it still needs consensus before it can move forward. In the meantime, contributors who keep personal settings in `.vscode/settings.json` risk accidentally committing them, since the file is currently untracked but not ignored. Ignoring it keeps personal editor settings out of accidental commits without taking a position on the managed-config proposal.

## How?

Adds a `/.vscode/settings.json` entry to the "Local overrides" section of `.gitignore`. The leading slash scopes the rule to the repository root, and only `settings.json` is ignored so that tracked files like `.vscode/launch-example.json` remain unaffected.

## Testing Instructions

1. Create a `.vscode/settings.json` file at the repository root with any content.
2. Run `git status` and confirm the file does not show up as untracked.
3. Run `git status --ignored -- .vscode` and confirm `.vscode/settings.json` is listed as ignored.
4. Confirm `.vscode/launch-example.json` is still tracked: `git ls-files .vscode/`.

## Use of AI Tools

This PR was created with the assistance of Claude Code; the change and description were reviewed by the author.
