### PR TITLE
Scripts: Lint tools package.json files in lint:pkg-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
 		"lint:md:docs": "wp-scripts lint-md-docs",
 		"prelint:php": "npm run other:update-packages:php",
 		"lint:php": "wp-env run --env-cwd='wp-content/plugins/gutenberg' cli composer run-script lint",
-		"lint:pkg-json": "wp-scripts lint-pkg-json . 'packages/*/package.json'",
+		"lint:pkg-json": "wp-scripts lint-pkg-json . 'packages/*/package.json' 'tools/*/package.json'",
 		"other:changelog": "npm exec --no release-cli -- changelog",
 		"other:check-licenses": "concurrently \"npm run --workspace @wordpress/validation-tools check-licenses --\" \"wp-scripts check-licenses --dev\"",
 		"preother:check-local-changes": "npm run docs:build && npm run --workspace @wordpress/theme build",


### PR DESCRIPTION
## What?

Updates the `lint:pkg-json` npm script to also lint `package.json` files in the `tools/` directory.

## Why?

The script currently only lints the root `package.json` and `packages/*/package.json`, so the `package.json` files of workspaces under `tools/` (`build-scripts`, `docs`, `eslint`, `react-19`, `release`, `validation`) are never checked.

## How?

Adds the `'tools/*/package.json'` glob to the `lint:pkg-json` script in the root `package.json`.

## Testing Instructions

1. Run `npm run lint:pkg-json` and confirm it passes.
2. Optionally, introduce a violation in one of the `tools/*/package.json` files (e.g. remove the ending period from a `description`) and confirm the linter now flags it.

## Use of AI Tools

This PR was authored with the assistance of Claude Code; the change was reviewed and verified by a human.
