### PR TITLE
Term Template: Add flex layout option for content items

### DIFF
--- a/packages/block-library/src/term-template/edit.js
+++ b/packages/block-library/src/term-template/edit.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { ToolbarGroup } from '@wordpress/components';
-import { list, grid } from '@wordpress/icons';
+import { list, grid, stretchWide } from '@wordpress/icons';
 import { memo, useMemo, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
@@ -184,6 +184,18 @@ export default function TermTemplateEdit( {
 									columnCount,
 								} ),
 							isActive: layoutType === 'grid',
+						},
+						{
+							icon: stretchWide,
+							title: _x(
+								'Flex view',
+								'Term template block display setting'
+							),
+							onClick: () =>
+								setDisplayLayout( {
+									type: 'flex',
+								} ),
+							isActive: layoutType === 'flex',
 						},
 					] }
 				/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #73185 

<!-- In a few words, what is the PR actually doing? -->
Adds a third layout option ("Flex view") to the Term Template block toolbar, alongside the existing List and Grid options.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently the Term Template block only supports list and grid layouts, both of which force each term item to span full width or a fixed grid column width. This makes it impossible to render terms as inline tags where each item is only as wide as its content.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a new toolbar button that sets `layout.type` to `'flex'` on the block's attributes. It has `display: flex` in the styles making term items flow inline and wrap naturally based on their content width.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Go to Posts > Tags and create several tags with varied name lengths.
3. Open site editor and add a Terms Query block
4. Select Tags taxonomy and enable 'Show empty terms' to display list of newly created Tags
4. Inside Term Query block, locate the Term Template block.
5. In the toolbar, you should now see three layout icons: List, Grid, and Flex.
6. Click the Flex option and verify that term items render inline, each only as wide as their content, wrapping onto new lines when the container is full.
7. Switch back to List and Grid and verify those still behave as before.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
<img width="738" height="353" alt="Screenshot 2026-06-11 at 12 47 21 PM" src="https://github.com/user-attachments/assets/99c1a6b9-978a-4629-8e2c-5b7fd265e64b" />

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
ChatGPT for refining the PR description.