### PR TITLE
Inherit styles for custom overlays in navigation

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -563,7 +563,7 @@ function Navigation( {
 	);
 
 	// Configure navigation blocks in overlay templates.
-	const hasSetOverlayDefault = useRef( false );
+	const hasSetOverlayDefaultRef = useRef( false );
 	useEffect( () => {
 		if ( ! isWithinOverlay ) {
 			return;
@@ -575,8 +575,8 @@ function Navigation( {
 		}
 
 		// Set vertical orientation and always-open submenus for new blocks.
-		if ( ! hasSetOverlayDefault.current && ! ref ) {
-			hasSetOverlayDefault.current = true;
+		if ( ! hasSetOverlayDefaultRef.current && ! ref ) {
+			hasSetOverlayDefaultRef.current = true;
 			setAttributes( {
 				submenuVisibility: 'always',
 				layout: {
@@ -761,12 +761,12 @@ function Navigation( {
 			  )
 			: '';
 
-	const isFirstRender = useRef( true ); // Don't speak on first render.
+	const isFirstRenderRef = useRef( true ); // Don't speak on first render.
 	useEffect( () => {
-		if ( ! isFirstRender.current && submenuAccessibilityNotice ) {
+		if ( ! isFirstRenderRef.current && submenuAccessibilityNotice ) {
 			speak( submenuAccessibilityNotice );
 		}
-		isFirstRender.current = false;
+		isFirstRenderRef.current = false;
 	}, [ submenuAccessibilityNotice ] );
 
 	const overlayMenuPreviewId = useInstanceId(
@@ -913,6 +913,7 @@ function Navigation( {
 						isResponsive={ isResponsive }
 						currentTheme={ currentTheme }
 						hasOverlays={ hasOverlays }
+						navigationAttributes={ attributes }
 					/>
 				</InspectorControls>
 			) }

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -1,12 +1,10 @@
 /**
  * WordPress dependencies
  */
-import {
-	PanelBody,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -33,6 +31,7 @@ import OverlayPreview from './overlay-preview';
  * @param {boolean}  props.isResponsive              Whether overlay menu is responsive.
  * @param {string}   props.currentTheme              Current theme stylesheet name.
  * @param {boolean}  props.hasOverlays               Whether any overlay template parts exist.
+ * @param {Object}   props.navigationAttributes      Parent Navigation block attributes.
  * @return {React.JSX.Element}                       The overlay panel component or null if overlay is disabled.
  */
 export default function OverlayPanel( {
@@ -49,12 +48,13 @@ export default function OverlayPanel( {
 	isResponsive,
 	currentTheme,
 	hasOverlays,
+	navigationAttributes,
 } ) {
 	const [ isCreatingOverlay, setIsCreatingOverlay ] = useState( false );
 
 	return (
 		<PanelBody title={ __( 'Overlay' ) } initialOpen>
-			<VStack spacing={ 4 }>
+			<Stack direction="column" gap="md">
 				<OverlayVisibilityControl
 					overlayMenu={ overlayMenu }
 					setAttributes={ setAttributes }
@@ -81,6 +81,7 @@ export default function OverlayPanel( {
 						onNavigateToEntityRecord={ onNavigateToEntityRecord }
 						isCreatingOverlay={ isCreatingOverlay }
 						setIsCreatingOverlay={ setIsCreatingOverlay }
+						navigationAttributes={ navigationAttributes }
 					/>
 				) }
 
@@ -93,7 +94,7 @@ export default function OverlayPanel( {
 							currentTheme={ currentTheme }
 						/>
 					) }
-			</VStack>
+			</Stack>
 		</PanelBody>
 	);
 }

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -10,13 +10,12 @@ import {
 	Button,
 	FlexBlock,
 	FlexItem,
-	__experimentalHStack as HStack,
-	__experimentalText as WCText,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as noticesStore } from '@wordpress/notices';
 import { plus } from '@wordpress/icons';
+import { Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -36,6 +35,7 @@ import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from '../constants';
  * @param {Function} props.onNavigateToEntityRecord Function to navigate to template part editor.
  * @param {boolean}  props.isCreatingOverlay        Whether an overlay is being created (lifted state).
  * @param {Function} props.setIsCreatingOverlay     Function to set creating overlay state (lifted state).
+ * @param {Object}   props.navigationAttributes     Parent Navigation block attributes.
  * @return {React.JSX.Element} The overlay template part selector component.
  */
 export default function OverlayTemplatePartSelector( {
@@ -45,6 +45,7 @@ export default function OverlayTemplatePartSelector( {
 	onNavigateToEntityRecord,
 	isCreatingOverlay,
 	setIsCreatingOverlay,
+	navigationAttributes,
 } ) {
 	const headingId = useInstanceId(
 		OverlayTemplatePartSelector,
@@ -87,8 +88,10 @@ export default function OverlayTemplatePartSelector( {
 	}, [ templateParts ] );
 
 	// Hook to create overlay template part
-	const createOverlayTemplatePart =
-		useCreateOverlayTemplatePart( overlayTemplateParts );
+	const createOverlayTemplatePart = useCreateOverlayTemplatePart(
+		overlayTemplateParts,
+		navigationAttributes
+	);
 
 	// Find the selected template part to get its title
 	const selectedTemplatePart = useMemo( () => {
@@ -303,8 +306,9 @@ export default function OverlayTemplatePartSelector( {
 						showTooltip
 						className="wp-block-navigation__overlay-create-button"
 					/>
-					<HStack
-						alignment="flex-start"
+					<Stack
+						direction="row"
+						align="flex-start"
 						className="wp-block-navigation__overlay-selector-controls"
 					>
 						<FlexBlock>
@@ -337,7 +341,7 @@ export default function OverlayTemplatePartSelector( {
 								</Button>
 							</FlexItem>
 						) }
-					</HStack>
+					</Stack>
 					{ isOverlayMissing && (
 						<DeletedOverlayWarning
 							onClear={ handleClearOverlay }
@@ -347,20 +351,21 @@ export default function OverlayTemplatePartSelector( {
 					) }
 				</>
 			) }
-			<HStack
-				alignment="flex-start"
+			<Stack
+				direction="row"
+				align="flex-start"
 				className="wp-block-navigation__overlay-help-text-wrapper"
 			>
-				<WCText
-					variant="muted"
-					isBlock
+				<Text
+					variant="body-sm"
+					render={ <p /> }
 					className="wp-block-navigation__overlay-help-text"
 				>
 					{ __(
 						'An overlay template allows you to customize the appearance of the dialog that opens when the menu button is pressed.'
 					) }
-				</WCText>
-			</HStack>
+				</Text>
+			</Stack>
 		</div>
 	);
 }

--- a/packages/block-library/src/navigation/edit/test/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/test/use-create-overlay.js
@@ -30,18 +30,31 @@ jest.mock( '@wordpress/block-editor', () => ( {
 } ) );
 
 // Mock @wordpress/blocks
+const mockGetOverlayBlocks = () => [
+	{
+		name: 'core/group',
+		attributes: {},
+		innerBlocks: [
+			{
+				name: 'core/navigation',
+				attributes: {
+					layout: {
+						type: 'flex',
+						orientation: 'vertical',
+					},
+				},
+				innerBlocks: [],
+			},
+		],
+	},
+];
+
 jest.mock( '@wordpress/blocks', () => ( {
 	serialize: jest.fn( ( blocks ) => JSON.stringify( blocks ) ),
 	parse: jest.fn( ( content ) => {
 		// Return mock blocks when parsing pattern content
 		if ( content && typeof content === 'string' ) {
-			return [
-				{
-					name: 'core/group',
-					attributes: {},
-					innerBlocks: [],
-				},
-			];
+			return mockGetOverlayBlocks();
 		}
 		return [];
 	} ),
@@ -275,5 +288,159 @@ describe( 'useCreateOverlayTemplatePart', () => {
 			expect.any( Object ),
 			{ throwOnError: true }
 		);
+	} );
+
+	it( 'should seed overlay navigation blocks with inherited parent navigation styles', async () => {
+		const overlayTemplateParts = [];
+		const createdOverlay = {
+			id: 'twentytwentyfive//navigation-overlay',
+			theme: 'twentytwentyfive',
+			slug: 'navigation-overlay',
+			title: {
+				rendered: 'Navigation Overlay',
+			},
+			area: 'navigation-overlay',
+		};
+		const navigationAttributes = {
+			textColor: 'primary',
+			fontSize: 'large',
+			fontFamily: 'heading',
+			style: {
+				typography: {
+					fontStyle: 'italic',
+					fontWeight: '700',
+					lineHeight: '1.2',
+					textTransform: 'uppercase',
+					letterSpacing: '0.08em',
+					textDecoration: 'underline',
+				},
+			},
+		};
+
+		mockSaveEntityRecord.mockResolvedValue( createdOverlay );
+
+		const blocksModule = require( '@wordpress/blocks' );
+		const { serialize } = blocksModule;
+
+		const { result: createOverlayTemplatePart } = renderHook( () =>
+			useCreateOverlayTemplatePart(
+				overlayTemplateParts,
+				navigationAttributes
+			)
+		);
+
+		await act( async () => {
+			await createOverlayTemplatePart.current();
+		} );
+
+		const savedBlocks = serialize.mock.calls[ 0 ][ 0 ];
+		const navigationBlock = savedBlocks[ 0 ].innerBlocks[ 0 ];
+
+		expect( navigationBlock.attributes ).toEqual(
+			expect.objectContaining( {
+				textColor: 'primary',
+				fontSize: 'large',
+				fontFamily: 'heading',
+				layout: {
+					type: 'flex',
+					orientation: 'vertical',
+				},
+				style: {
+					typography: {
+						fontStyle: 'italic',
+						fontWeight: '700',
+						lineHeight: '1.2',
+						textTransform: 'uppercase',
+						letterSpacing: '0.08em',
+						textDecoration: 'underline',
+					},
+				},
+			} )
+		);
+	} );
+
+	it( 'should not overwrite explicit overlay navigation styles', async () => {
+		const overlayTemplateParts = [];
+		const createdOverlay = {
+			id: 'twentytwentyfive//navigation-overlay',
+			theme: 'twentytwentyfive',
+			slug: 'navigation-overlay',
+			title: {
+				rendered: 'Navigation Overlay',
+			},
+			area: 'navigation-overlay',
+		};
+		const navigationAttributes = {
+			textColor: 'primary',
+			fontSize: 'large',
+			fontFamily: 'heading',
+			style: {
+				typography: {
+					fontWeight: '700',
+					textTransform: 'uppercase',
+				},
+			},
+		};
+
+		mockSaveEntityRecord.mockResolvedValue( createdOverlay );
+
+		const blocksModule = require( '@wordpress/blocks' );
+		const { parse, serialize } = blocksModule;
+		parse.mockImplementationOnce( () => [
+			{
+				name: 'core/group',
+				attributes: {},
+				innerBlocks: [
+					{
+						name: 'core/navigation',
+						attributes: {
+							fontFamily: 'body',
+							style: {
+								color: {
+									text: '#654321',
+								},
+								typography: {
+									fontSize: '20px',
+									fontWeight: '400',
+								},
+							},
+						},
+						innerBlocks: [],
+					},
+				],
+			},
+		] );
+
+		const { result: createOverlayTemplatePart } = renderHook( () =>
+			useCreateOverlayTemplatePart(
+				overlayTemplateParts,
+				navigationAttributes
+			)
+		);
+
+		await act( async () => {
+			await createOverlayTemplatePart.current();
+		} );
+
+		const savedBlocks = serialize.mock.calls[ 0 ][ 0 ];
+		const navigationBlock = savedBlocks[ 0 ].innerBlocks[ 0 ];
+
+		expect( navigationBlock.attributes ).toEqual(
+			expect.objectContaining( {
+				fontFamily: 'body',
+				style: {
+					color: {
+						text: '#654321',
+					},
+					typography: {
+						fontSize: '20px',
+						fontWeight: '400',
+						textTransform: 'uppercase',
+					},
+				},
+			} )
+		);
+		expect( navigationBlock.attributes ).not.toHaveProperty( 'textColor' );
+		expect( navigationBlock.attributes ).not.toHaveProperty( 'fontSize' );
 	} );
 } );

--- a/packages/block-library/src/navigation/edit/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/use-create-overlay.js
@@ -15,14 +15,167 @@ import { getUniqueTemplatePartTitle, getCleanTemplatePartSlug } from './utils';
 import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from '../constants';
 import { unlock } from '../../lock-unlock';
 
+const TEXT_COLOR_ATTRIBUTES = [ 'textColor', 'customTextColor' ];
+const FONT_SIZE_ATTRIBUTES = [ 'fontSize', 'customFontSize' ];
+const TYPOGRAPHY_ATTRIBUTES = [
+	'fontStyle',
+	'fontWeight',
+	'lineHeight',
+	'textTransform',
+	'letterSpacing',
+	'textDecoration',
+];
+
+const hasOwn = ( object, key ) =>
+	!! object && Object.prototype.hasOwnProperty.call( object, key );
+
+function getInheritedNavigationAttributes( attributes = {} ) {
+	const inheritedAttributes = {};
+
+	for ( const attribute of [
+		...TEXT_COLOR_ATTRIBUTES,
+		...FONT_SIZE_ATTRIBUTES,
+		'fontFamily',
+	] ) {
+		if ( hasOwn( attributes, attribute ) ) {
+			inheritedAttributes[ attribute ] = attributes[ attribute ];
+		}
+	}
+
+	const typography = attributes.style?.typography;
+	const inheritedTypography = {};
+	for ( const attribute of [
+		'fontFamily',
+		'fontSize',
+		...TYPOGRAPHY_ATTRIBUTES,
+	] ) {
+		if ( hasOwn( typography, attribute ) ) {
+			inheritedTypography[ attribute ] = typography[ attribute ];
+		}
+	}
+
+	if ( Object.keys( inheritedTypography ).length ) {
+		inheritedAttributes.style = {
+			typography: inheritedTypography,
+		};
+	}
+
+	return inheritedAttributes;
+}
+
+function inheritNavigationBlockAttributes(
+	blockAttributes = {},
+	inheritedAttributes
+) {
+	const nextAttributes = { ...blockAttributes };
+
+	const hasTextColor =
+		TEXT_COLOR_ATTRIBUTES.some( ( attribute ) =>
+			hasOwn( nextAttributes, attribute )
+		) || hasOwn( nextAttributes.style?.color, 'text' );
+
+	if ( ! hasTextColor ) {
+		for ( const attribute of TEXT_COLOR_ATTRIBUTES ) {
+			if ( hasOwn( inheritedAttributes, attribute ) ) {
+				nextAttributes[ attribute ] = inheritedAttributes[ attribute ];
+			}
+		}
+	}
+
+	const hasFontSize =
+		FONT_SIZE_ATTRIBUTES.some( ( attribute ) =>
+			hasOwn( nextAttributes, attribute )
+		) || hasOwn( nextAttributes.style?.typography, 'fontSize' );
+
+	if ( ! hasFontSize ) {
+		for ( const attribute of FONT_SIZE_ATTRIBUTES ) {
+			if ( hasOwn( inheritedAttributes, attribute ) ) {
+				nextAttributes[ attribute ] = inheritedAttributes[ attribute ];
+			}
+		}
+
+		const inheritedTypography = inheritedAttributes.style?.typography;
+		if ( hasOwn( inheritedTypography, 'fontSize' ) ) {
+			nextAttributes.style = {
+				...nextAttributes.style,
+				typography: {
+					...nextAttributes.style?.typography,
+					fontSize: inheritedTypography.fontSize,
+				},
+			};
+		}
+	}
+
+	const hasFontFamily =
+		hasOwn( nextAttributes, 'fontFamily' ) ||
+		hasOwn( nextAttributes.style?.typography, 'fontFamily' );
+
+	if ( ! hasFontFamily ) {
+		if ( hasOwn( inheritedAttributes, 'fontFamily' ) ) {
+			nextAttributes.fontFamily = inheritedAttributes.fontFamily;
+		} else if (
+			hasOwn( inheritedAttributes.style?.typography, 'fontFamily' )
+		) {
+			nextAttributes.style = {
+				...nextAttributes.style,
+				typography: {
+					...nextAttributes.style?.typography,
+					fontFamily: inheritedAttributes.style.typography.fontFamily,
+				},
+			};
+		}
+	}
+
+	for ( const attribute of TYPOGRAPHY_ATTRIBUTES ) {
+		if (
+			hasOwn( inheritedAttributes.style?.typography, attribute ) &&
+			! hasOwn( nextAttributes.style?.typography, attribute )
+		) {
+			nextAttributes.style = {
+				...nextAttributes.style,
+				typography: {
+					...nextAttributes.style?.typography,
+					[ attribute ]:
+						inheritedAttributes.style.typography[ attribute ],
+				},
+			};
+		}
+	}
+
+	return nextAttributes;
+}
+
+function inheritNavigationStyles( blocks, inheritedAttributes ) {
+	if ( ! Object.keys( inheritedAttributes ).length ) {
+		return blocks;
+	}
+
+	return blocks.map( ( block ) => ( {
+		...block,
+		attributes:
+			block.name === 'core/navigation'
+				? inheritNavigationBlockAttributes(
+						block.attributes,
+						inheritedAttributes
+				  )
+				: block.attributes,
+		innerBlocks: block.innerBlocks
+			? inheritNavigationStyles( block.innerBlocks, inheritedAttributes )
+			: block.innerBlocks,
+	} ) );
+}
+
 /**
  * Hook to create a new overlay template part.
  *
- * @param {Array} overlayTemplateParts Array of existing overlay template parts.
- * @return {function(): Promise<Object>} Function to create a new overlay template part.
- *                                      The function returns a Promise that resolves to the created template part object.
+ * @param {Array}  overlayTemplateParts Array of existing overlay template parts.
+ * @param {Object} navigationAttributes Parent Navigation block attributes.
+ * @return {Function} Function that creates a new overlay template part.
  */
-export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
+export default function useCreateOverlayTemplatePart(
+	overlayTemplateParts,
+	navigationAttributes = {}
+) {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const pattern = useSelect(
 		( select ) =>
@@ -51,7 +204,12 @@ export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
 			const blocks = parse( pattern.content, {
 				__unstableSkipMigrationLogs: true,
 			} );
-			initialContent = serialize( blocks );
+			initialContent = serialize(
+				inheritNavigationStyles(
+					blocks,
+					getInheritedNavigationAttributes( navigationAttributes )
+				)
+			);
 		} else {
 			// Fallback to empty paragraph if pattern is not found
 			initialContent = serialize( [ createBlock( 'core/paragraph' ) ] );
@@ -71,7 +229,12 @@ export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
 		);
 
 		return templatePart;
-	}, [ overlayTemplateParts, saveEntityRecord, pattern ] );
+	}, [
+		overlayTemplateParts,
+		saveEntityRecord,
+		pattern,
+		navigationAttributes,
+	] );
 
 	return createOverlayTemplatePart;
 }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -336,7 +336,7 @@ class WP_Navigation_Block_Renderer {
 	 * @param array $blocks Array of parsed block arrays.
 	 * @return array Modified blocks with overlayMenu set to 'never' for navigation blocks.
 	 */
-	private static function disable_overlay_menu_for_nested_navigation_blocks( $blocks ) {
+	private static function disable_overlay_menu_for_nested_navigation_blocks( $blocks, $parent_navigation_attributes = array() ) {
 		if ( empty( $blocks ) || ! is_array( $blocks ) ) {
 			return $blocks;
 		}
@@ -351,6 +351,7 @@ class WP_Navigation_Block_Renderer {
 				if ( ! isset( $block['attrs'] ) ) {
 					$block['attrs'] = array();
 				}
+				$block['attrs']                = static::inherit_navigation_styles_for_overlay_block( $block['attrs'], $parent_navigation_attributes );
 				$block['attrs']['overlayMenu'] = 'never';
 				// Mark this as a nested navigation within an overlay template part
 				// so we can handle its rendering differently.
@@ -359,11 +360,85 @@ class WP_Navigation_Block_Renderer {
 
 			// Recursively process inner blocks.
 			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
-				$block['innerBlocks'] = static::disable_overlay_menu_for_nested_navigation_blocks( $block['innerBlocks'] );
+				$block['innerBlocks'] = static::disable_overlay_menu_for_nested_navigation_blocks( $block['innerBlocks'], $parent_navigation_attributes );
 			}
 		}
 
 		return $blocks;
+	}
+
+	/**
+	 * Inherits parent Navigation text and typography styles for a Navigation block
+	 * rendered inside a custom navigation overlay.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param array $block_attributes             Nested Navigation block attributes.
+	 * @param array $parent_navigation_attributes Parent Navigation block attributes.
+	 * @return array Modified nested Navigation block attributes.
+	 */
+	private static function inherit_navigation_styles_for_overlay_block( $block_attributes, $parent_navigation_attributes ) {
+		$block_color       = isset( $block_attributes['style']['color'] ) && is_array( $block_attributes['style']['color'] ) ? $block_attributes['style']['color'] : array();
+		$block_typography  = isset( $block_attributes['style']['typography'] ) && is_array( $block_attributes['style']['typography'] ) ? $block_attributes['style']['typography'] : array();
+		$parent_typography = isset( $parent_navigation_attributes['style']['typography'] ) && is_array( $parent_navigation_attributes['style']['typography'] ) ? $parent_navigation_attributes['style']['typography'] : array();
+
+		$has_text_color = array_key_exists( 'textColor', $block_attributes ) ||
+			array_key_exists( 'customTextColor', $block_attributes ) ||
+			array_key_exists( 'text', $block_color );
+
+		if ( ! $has_text_color ) {
+			foreach ( array( 'textColor', 'customTextColor' ) as $color_attribute ) {
+				if ( array_key_exists( $color_attribute, $parent_navigation_attributes ) ) {
+					$block_attributes[ $color_attribute ] = $parent_navigation_attributes[ $color_attribute ];
+				}
+			}
+		}
+
+		$has_font_size = array_key_exists( 'fontSize', $block_attributes ) ||
+			array_key_exists( 'customFontSize', $block_attributes ) ||
+			array_key_exists( 'fontSize', $block_typography );
+
+		if ( ! $has_font_size ) {
+			foreach ( array( 'fontSize', 'customFontSize' ) as $font_size_attribute ) {
+				if ( array_key_exists( $font_size_attribute, $parent_navigation_attributes ) ) {
+					$block_attributes[ $font_size_attribute ] = $parent_navigation_attributes[ $font_size_attribute ];
+				}
+			}
+			if ( array_key_exists( 'fontSize', $parent_typography ) ) {
+				$block_attributes['style']['typography']['fontSize'] = $parent_typography['fontSize'];
+			}
+		}
+
+		$has_font_family = array_key_exists( 'fontFamily', $block_attributes ) ||
+			array_key_exists( 'fontFamily', $block_typography );
+
+		if ( ! $has_font_family ) {
+			if ( array_key_exists( 'fontFamily', $parent_navigation_attributes ) ) {
+				$block_attributes['fontFamily'] = $parent_navigation_attributes['fontFamily'];
+			} elseif ( array_key_exists( 'fontFamily', $parent_typography ) ) {
+				$block_attributes['style']['typography']['fontFamily'] = $parent_typography['fontFamily'];
+			}
+		}
+
+		$typography_attributes = array(
+			'fontStyle',
+			'fontWeight',
+			'lineHeight',
+			'textTransform',
+			'letterSpacing',
+			'textDecoration',
+		);
+
+		foreach ( $typography_attributes as $typography_attribute ) {
+			if (
+				array_key_exists( $typography_attribute, $parent_typography ) &&
+				! array_key_exists( $typography_attribute, $block_typography )
+			) {
+				$block_attributes['style']['typography'][ $typography_attribute ] = $parent_typography[ $typography_attribute ];
+			}
+		}
+
+		return $block_attributes;
 	}
 
 	/**
@@ -432,7 +507,7 @@ class WP_Navigation_Block_Renderer {
 				$parsed_blocks = parse_blocks( $content );
 				$blocks        = block_core_navigation_filter_out_empty_blocks( $parsed_blocks );
 				// Disable overlay menu for any navigation blocks within the overlay to prevent nested overlays.
-				$blocks = static::disable_overlay_menu_for_nested_navigation_blocks( $blocks );
+				$blocks = static::disable_overlay_menu_for_nested_navigation_blocks( $blocks, $attributes );
 				return new WP_Block_List( $blocks, $attributes );
 			}
 			return new WP_Block_List( array(), $attributes );
@@ -462,7 +537,7 @@ class WP_Navigation_Block_Renderer {
 		$blocks = parse_blocks( $markup );
 
 		// Disable overlay menu for any navigation blocks within the overlay to prevent nested overlays.
-		$blocks = static::disable_overlay_menu_for_nested_navigation_blocks( $blocks );
+		$blocks = static::disable_overlay_menu_for_nested_navigation_blocks( $blocks, $attributes );
 
 		return new WP_Block_List( $blocks, $attributes );
 	}

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -421,4 +421,118 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Hello, World!', $output, 'Shortcode inside the navigation overlay should be expanded.' );
 		$this->assertStringNotContainsString( '[gb_test_overlay_shortcode]', $output, 'Raw shortcode token should not appear in the overlay output.' );
 	}
+
+	/**
+	 * Test that a Navigation block inside a custom overlay inherits text and
+	 * typography styles from the parent Navigation block when it does not set
+	 * its own values.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers WP_Navigation_Block_Renderer::get_responsive_container_markup
+	 */
+	public function test_navigation_block_in_custom_overlay_inherits_parent_text_and_typography_styles() {
+		$current_theme = get_stylesheet();
+		$slug          = 'test-overlay-with-navigation-styles';
+
+		$template_part_id = wp_insert_post(
+			array(
+				'post_type'    => 'wp_template_part',
+				'post_status'  => 'publish',
+				'post_title'   => 'Test Overlay With Navigation Styles',
+				'post_name'    => $slug,
+				'post_content' => '<!-- wp:group --><div class="wp-block-group"><!-- wp:navigation {"layout":{"type":"flex","orientation":"vertical"}} --><!-- wp:navigation-link {"label":"About","url":"/about"} /--><!-- /wp:navigation --></div><!-- /wp:group -->',
+			),
+			true
+		);
+		$this->assertNotWPError( $template_part_id );
+
+		wp_set_post_terms( $template_part_id, array( $current_theme ), 'wp_theme' );
+		wp_set_post_terms( $template_part_id, array( 'navigation-overlay' ), 'wp_template_part_area' );
+
+		$output = do_blocks(
+			'<!-- wp:navigation {"overlay":"' . $slug . '","overlayMenu":"always","customTextColor":"#123456","customFontSize":32,"fontFamily":"heading","style":{"typography":{"fontStyle":"italic","fontWeight":"700","lineHeight":"1.2","textTransform":"uppercase","letterSpacing":"0.08em","textDecoration":"underline"}}} /-->'
+		);
+
+		$tags = new WP_HTML_Tag_Processor( $output );
+		$this->assertTrue(
+			$tags->next_tag(
+				array(
+					'tag_name'   => 'DIV',
+					'class_name' => 'wp-block-navigation',
+				)
+			),
+			'Nested Navigation block should render as a div inside the custom overlay.'
+		);
+
+		$style = $tags->get_attribute( 'style' );
+		$class = $tags->get_attribute( 'class' );
+
+		$this->assertStringContainsString( 'has-text-color', $class );
+		$this->assertStringContainsString( 'has-heading-font-family', $class );
+		$this->assertStringContainsString( 'has-text-decoration-underline', $class );
+		$this->assertStringContainsString( 'color: #123456;', $style );
+		$this->assertStringContainsString( 'font-size: 32px', $style );
+		$this->assertStringContainsString( 'font-style:italic', $style );
+		$this->assertStringContainsString( 'font-weight:700', $style );
+		$this->assertStringContainsString( 'line-height:1.2', $style );
+		$this->assertStringContainsString( 'text-transform:uppercase', $style );
+		$this->assertStringContainsString( 'letter-spacing:0.08em', $style );
+	}
+
+	/**
+	 * Test that explicit styles on a Navigation block inside a custom overlay
+	 * are preserved instead of being replaced by parent Navigation styles.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers WP_Navigation_Block_Renderer::get_responsive_container_markup
+	 */
+	public function test_navigation_block_in_custom_overlay_preserves_explicit_text_and_typography_styles() {
+		$current_theme = get_stylesheet();
+		$slug          = 'test-overlay-with-explicit-navigation-styles';
+
+		$template_part_id = wp_insert_post(
+			array(
+				'post_type'    => 'wp_template_part',
+				'post_status'  => 'publish',
+				'post_title'   => 'Test Overlay With Explicit Navigation Styles',
+				'post_name'    => $slug,
+				'post_content' => '<!-- wp:group --><div class="wp-block-group"><!-- wp:navigation {"customTextColor":"#654321","customFontSize":20,"fontFamily":"body","style":{"typography":{"fontWeight":"400"}},"layout":{"type":"flex","orientation":"vertical"}} --><!-- wp:navigation-link {"label":"About","url":"/about"} /--><!-- /wp:navigation --></div><!-- /wp:group -->',
+			),
+			true
+		);
+		$this->assertNotWPError( $template_part_id );
+
+		wp_set_post_terms( $template_part_id, array( $current_theme ), 'wp_theme' );
+		wp_set_post_terms( $template_part_id, array( 'navigation-overlay' ), 'wp_template_part_area' );
+
+		$output = do_blocks(
+			'<!-- wp:navigation {"overlay":"' . $slug . '","overlayMenu":"always","customTextColor":"#123456","customFontSize":32,"fontFamily":"heading","style":{"typography":{"fontWeight":"700","textTransform":"uppercase"}}} /-->'
+		);
+
+		$tags = new WP_HTML_Tag_Processor( $output );
+		$this->assertTrue(
+			$tags->next_tag(
+				array(
+					'tag_name'   => 'DIV',
+					'class_name' => 'wp-block-navigation',
+				)
+			),
+			'Nested Navigation block should render as a div inside the custom overlay.'
+		);
+
+		$style = $tags->get_attribute( 'style' );
+		$class = $tags->get_attribute( 'class' );
+
+		$this->assertStringContainsString( 'has-body-font-family', $class );
+		$this->assertStringNotContainsString( 'has-heading-font-family', $class );
+		$this->assertStringContainsString( 'color: #654321;', $style );
+		$this->assertStringContainsString( 'font-size: 20px', $style );
+		$this->assertStringContainsString( 'font-weight:400', $style );
+		$this->assertStringContainsString( 'text-transform:uppercase', $style );
+		$this->assertStringNotContainsString( 'color: #123456;', $style );
+		$this->assertStringNotContainsString( 'font-size: 32px', $style );
+		$this->assertStringNotContainsString( 'font-weight:700', $style );
+	}
 }

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -407,11 +407,6 @@
 			"count": 2
 		}
 	},
-	"packages/block-library/src/navigation/edit/index.js": {
-		"react-hooks/immutability": {
-			"count": 3
-		}
-	},
 	"packages/block-library/src/navigation/edit/navigation-list-view-header.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 2
@@ -430,16 +425,6 @@
 	"packages/block-library/src/navigation/edit/overlay-menu-preview-controls.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
-		}
-	},
-	"packages/block-library/src/navigation/edit/overlay-panel.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
-	"packages/block-library/src/navigation/edit/overlay-template-part-selector.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 2
 		}
 	},
 	"packages/block-library/src/navigation/edit/unsaved-inner-blocks.js": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes #79078

Updates custom Navigation overlays so Navigation blocks inside the overlay template part inherit the parent Navigation block's text color and typography styles when they do not define their own values.

## Why?

When creating a custom overlay from a styled Navigation block, the nested menu in the generated overlay template part could appear visually plain in the editor. On the frontend, inheritance was inconsistent: some styles, such as color and font appearance, could carry through, while font size did not.

This makes the custom overlay start from the same visual baseline as the Navigation block that created it, while still allowing the overlay template part to be customized independently afterward.

## How?

- Passes the parent Navigation block attributes into the overlay template part creation flow.
- Seeds generated overlay Navigation blocks with inherited text color and typography attributes.
- Applies the same inheritance on the server when rendering existing custom overlay template parts.
- Preserves explicit styles already set on the overlay template part's own Navigation block.
- Keeps the menu open icon controlled by the parent Navigation block, since that icon belongs to the outer Navigation instance rather than the overlay template part.

## Testing Instructions

1. Open the Site Editor.
2. Edit a template part that contains a Navigation block, such as the Header.
3. Select or insert a Navigation block.
4. Set the Navigation block's overlay menu to **Always**.
5. Apply visible styles to the parent Navigation block:
   - Text color, for example red.
   - Font size, for example large or x-large.
   - Font appearance or weight, for example italic or bold.
   - Optional: font family, text transform, or letter spacing.
6. In the Navigation block sidebar, click **Create overlay**.
7. Confirm that the Navigation block inside the new **Navigation Overlay** template part shows the inherited color and typography styles.
8. Save the overlay template part.
9. Return to the template or page where the parent Navigation block is used and save changes.
10. View the frontend and open the menu overlay.
11. Confirm that the overlay menu items use the inherited text color and typography styles.
12. Edit the overlay template part's inner Navigation block and set a different text color or typography value.
13. Save and confirm on the frontend that the explicit overlay style is preserved and overrides the inherited parent style.

### Testing Instructions for Keyboard

1. Open the Site Editor.
2. Use keyboard navigation to select the Navigation block.
3. Open the block settings sidebar.
4. Use the keyboard to set the overlay menu to **Always**.
5. Use the keyboard to apply a text color and typography settings to the Navigation block.
6. Tab to the **Create overlay** button and activate it with `Enter` or `Space`.
7. Confirm focus moves to the Navigation Overlay template part editor.
8. Use keyboard navigation to select the inner Navigation block and verify its inherited style settings.
9. Save using the keyboard.
10. Open the frontend, tab to the menu button, activate it with `Enter` or `Space`, and confirm the overlay menu opens with the inherited styles.

## Screencast

### Before Fix

https://github.com/user-attachments/assets/ef8d80aa-9e38-49c2-b462-001c6f4fcf10

### After Fix

https://github.com/user-attachments/assets/5413a176-e4dd-42c6-a7a1-a528d42faa5c

## Use of AI Tools

This PR was authored with assistance from OpenAI Codex. I reviewed the changes and manually verified the behaviour.