### PR TITLE
BaseControl: add text-wrap: pretty

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `BaseControl`: Apply `text-wrap: pretty` to help text to avoid typographic widows.
+
 ### Bug Fixes
 
 -   `SandBox`: Fix the viewport-unit (`vh`, `vw`, etc.) stripping so user-supplied HTML using these units in `width`/`height` no longer triggers a runaway resize loop in the preview ([#78677](https://github.com/WordPress/gutenberg/pull/78677)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   `BaseControl`: Apply `text-wrap: pretty` to help text to avoid typographic widows.
+-   `BaseControl`: Apply `text-wrap: pretty` to help text to avoid typographic widows ([#79112](https://github.com/WordPress/gutenberg/pull/79112)).
 
 ### Bug Fixes
 

--- a/packages/components/src/base-control/styles/base-control-styles.ts
+++ b/packages/components/src/base-control/styles/base-control-styles.ts
@@ -45,6 +45,7 @@ export const StyledHelp = styled.p`
 	font-size: ${ font( 'helpText.fontSize' ) };
 	font-style: normal;
 	color: ${ COLORS.gray[ 700 ] };
+	text-wrap: pretty;
 `;
 
 export const StyledVisualLabel = styled.span`


### PR DESCRIPTION
## What?

Pretty tiny PR to address an issue with BaseControl. The icon block revealed that there is a potential for typographic widows in the help text:
<img width="316" height="463" alt="Skærmbillede 2026-06-11 kl  14 04 41" src="https://github.com/user-attachments/assets/d0219f83-1484-41f2-80ac-389602b390be" />

This PR adds `text-wrap: pretty;` to address that:

<img width="285" height="481" alt="Skærmbillede 2026-06-11 kl  14 05 27" src="https://github.com/user-attachments/assets/b4856bf3-8327-48f6-91bb-46645dc207bd" />

## Why?

This improves legibility.

## Testing Instructions

Insert the Icon block, pick an icon, and observe the help text in the inspector, it should not have a typographic widow.

## Use of AI Tools

I used search, little else.