### PR TITLE
Blocks: Add innerContent support for static inner blocks, adopt it in the HTML block

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -751,6 +751,26 @@ supports: {
 }
 ```
 
+## innerContent
+
+-   Type: `boolean`
+-   Default value: `false`
+
+Allows the block to keep static HTML fragments interleaved with inner blocks as the canonical source of its own markup. When enabled:
+
+-   The parser retains the block's `innerContent` (an array of static HTML fragments where `null` entries mark the positions of inner blocks) on the parsed block.
+-   The block is serialized from that inner content instead of a `save` implementation, so the static markup round-trips by construction and `save`-based validation doesn't apply.
+-   In the editor, inner blocks render at their positions within the static markup, where they can be edited in place but not moved, removed, or added to.
+
+This is used by the Custom HTML block to support editable blocks at arbitrary positions inside an otherwise static HTML structure.
+
+```js
+supports: {
+	// Serialize from static HTML fragments interleaved with inner blocks.
+	innerContent: true
+}
+```
+
 ## inserter
 
 -   Type: `boolean`

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -759,7 +759,7 @@ supports: {
 Allows the block to keep static HTML fragments interleaved with inner blocks as the canonical source of its own markup. When enabled:
 
 -   The parser retains the block's `innerContent` (an array of static HTML fragments where `null` entries mark the positions of inner blocks) on the parsed block.
--   The block is serialized from that inner content instead of a `save` implementation, so the static markup round-trips by construction and `save`-based validation doesn't apply.
+-   The block is serialized from that inner content instead of a `save` implementation, so serializing always reproduces the parsed markup and `save`-based validation doesn't apply.
 -   In the editor, inner blocks render at their positions within the static markup, where they can be edited in place but not moved, removed, or added to.
 
 This is used by the Custom HTML block to support editable blocks at arbitrary positions inside an otherwise static HTML structure.

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -751,26 +751,6 @@ supports: {
 }
 ```
 
-## innerContent
-
--   Type: `boolean`
--   Default value: `false`
-
-Allows the block to keep static HTML fragments interleaved with inner blocks as the canonical source of its own markup. When enabled:
-
--   The parser retains the block's `innerContent` (an array of static HTML fragments where `null` entries mark the positions of inner blocks) on the parsed block.
--   The block is serialized from that inner content instead of a `save` implementation, so serializing always reproduces the parsed markup and `save`-based validation doesn't apply.
--   In the editor, inner blocks render at their positions within the static markup, where they can be edited in place but not moved, removed, or added to.
-
-This is used by the Custom HTML block to support editable blocks at arbitrary positions inside an otherwise static HTML structure.
-
-```js
-supports: {
-	// Serialize from static HTML fragments interleaved with inner blocks.
-	innerContent: true
-}
-```
-
 ## inserter
 
 -   Type: `boolean`

--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -436,8 +436,7 @@ Add custom HTML code and preview it as you edit.
 
 -	**Name:** [core/html](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-widgets/core-block-html/)
 -	**Category:** [widgets](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-widgets/)
--	**Supports:** interactivity (clientNavigation), ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~visibility~~
--	**Attributes:** content
+-	**Supports:** innerContent, interactivity (clientNavigation), listView, ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~visibility~~
 
 ## Icon
 

--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -436,7 +436,7 @@ Add custom HTML code and preview it as you edit.
 
 -	**Name:** [core/html](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-widgets/core-block-html/)
 -	**Category:** [widgets](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-widgets/)
--	**Supports:** innerContent, interactivity (clientNavigation), listView, ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~visibility~~
+-	**Supports:** interactivity (clientNavigation), listView, ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~visibility~~
 -	**Attributes:** content
 
 ## Icon

--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -437,6 +437,7 @@ Add custom HTML code and preview it as you edit.
 -	**Name:** [core/html](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-widgets/core-block-html/)
 -	**Category:** [widgets](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-widgets/)
 -	**Supports:** innerContent, interactivity (clientNavigation), listView, ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~visibility~~
+-	**Attributes:** content
 
 ## Icon
 

--- a/packages/block-directory/src/plugins/get-install-missing/index.js
+++ b/packages/block-directory/src/plugins/get-install-missing/index.js
@@ -53,9 +53,7 @@ const ModifiedWarning = ( { originalBlock, ...props } ) => {
 	const convertToHTML = () => {
 		replaceBlock(
 			props.clientId,
-			createBlock( 'core/html', {
-				content: originalUndelimitedContent,
-			} )
+			createBlock( 'core/html', {}, [], [ originalUndelimitedContent ] )
 		);
 	};
 

--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -62,10 +62,3 @@
 		justify-content: center;
 	}
 }
-
-// When rendered within the inspector tabs (e.g. the Custom HTML block's
-// "Edit code" button) rather than above them, the zeroed top margin would
-// press the button against the tab list.
-.block-editor-block-inspector__tabs .block-editor-block-inspector-edit-contents {
-	margin-top: $grid-unit-20;
-}

--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -62,3 +62,10 @@
 		justify-content: center;
 	}
 }
+
+// When rendered within the inspector tabs (e.g. the Custom HTML block's
+// "Edit code" button) rather than above them, the zeroed top margin would
+// press the button against the tab list.
+.block-editor-block-inspector__tabs .block-editor-block-inspector-edit-contents {
+	margin-top: $grid-unit-20;
+}

--- a/packages/block-editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/block-editor/src/components/block-list/block-invalid-warning.js
@@ -55,9 +55,12 @@ export default function BlockInvalidWarning( { clientId } ) {
 				return replaceBlock( block.clientId, classicBlock );
 			},
 			toHTML() {
-				const htmlBlock = createBlock( 'core/html', {
-					content: block.originalContent,
-				} );
+				const htmlBlock = createBlock(
+					'core/html',
+					{},
+					[],
+					[ block.originalContent ]
+				);
 				return replaceBlock( block.clientId, htmlBlock );
 			},
 			toBlocks() {

--- a/packages/block-editor/src/components/inner-content/index.js
+++ b/packages/block-editor/src/components/inner-content/index.js
@@ -9,6 +9,7 @@ import {
 	useState,
 } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { safeHTML } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -31,10 +32,11 @@ const LAYOUT = { type: 'default', alignments: [] };
  *
  * Unlike `InnerBlocks`, the rendered blocks are not a contiguous list: they
  * live at arbitrary positions inside markup the block editor doesn't manage.
- * The static fragments are rendered as inert DOM (scripts don't execute and
- * inline event handlers are stripped), and the inner blocks are portalled
- * into placeholder elements. Inner blocks are locked: they can be edited in
- * place but not moved, removed, or added to.
+ * The static fragments are sanitized with `safeHTML` before being injected
+ * into the canvas — the same treatment block save content receives elsewhere
+ * in the editor — and the inner blocks are portalled into placeholder
+ * elements. Inner blocks are locked: they can be edited in place but not
+ * moved, removed, or added to.
  *
  * @param {Object} props          Component props.
  * @param {string} props.clientId Client ID of the block whose inner content
@@ -67,18 +69,11 @@ export default function InnerContent( { clientId } ) {
 
 	useLayoutEffect( () => {
 		const container = containerRef.current;
-		container.innerHTML = html;
 
-		// The static markup is rendered inert: assigning `innerHTML` never
-		// executes `<script>` elements, and inline event handlers are
-		// stripped here so they can't fire inside the editor canvas.
-		container.querySelectorAll( '*' ).forEach( ( element ) => {
-			for ( const attribute of [ ...element.attributes ] ) {
-				if ( attribute.name.startsWith( 'on' ) ) {
-					element.removeAttribute( attribute.name );
-				}
-			}
-		} );
+		// Sanitize before injecting into the canvas: `safeHTML` removes
+		// `<script>` elements and inline event handlers, matching how block
+		// save content is rendered elsewhere in the editor.
+		container.innerHTML = safeHTML( html );
 
 		setSlots(
 			Array.from( container.querySelectorAll( SLOT_TAG_NAME ) ).sort(

--- a/packages/block-editor/src/components/inner-content/index.js
+++ b/packages/block-editor/src/components/inner-content/index.js
@@ -3,13 +3,12 @@
  */
 import {
 	createPortal,
-	useEffect,
 	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -52,14 +51,6 @@ export default function InnerContent( { clientId } ) {
 		},
 		[ clientId ]
 	);
-	const { updateBlockListSettings } = useDispatch( blockEditorStore );
-
-	// Lock the inner blocks: editable in place, but not movable, removable,
-	// or insertable.
-	useEffect( () => {
-		updateBlockListSettings( clientId, { templateLock: 'all' } );
-	}, [ clientId, updateBlockListSettings ] );
-
 	const html = useMemo( () => {
 		let slotIndex = 0;
 		return ( innerContent ?? [] )

--- a/packages/block-editor/src/components/inner-content/index.js
+++ b/packages/block-editor/src/components/inner-content/index.js
@@ -1,0 +1,122 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createPortal,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import BlockListBlock from '../block-list/block';
+import { LayoutProvider } from '../block-list/layout';
+
+const SLOT_TAG_NAME = 'wp-inner-block-slot';
+
+// The static markup surrounding the inner blocks is arbitrary HTML the block
+// editor doesn't manage, so it provides no layout context: no alignments are
+// available to the inner blocks.
+const LAYOUT = { type: 'default', alignments: [] };
+
+/**
+ * Renders the static HTML fragments of a block with the `innerContent`
+ * support, mounting each inner block at the position of its `null`
+ * placeholder within the static markup.
+ *
+ * Unlike `InnerBlocks`, the rendered blocks are not a contiguous list: they
+ * live at arbitrary positions inside markup the block editor doesn't manage.
+ * The static fragments are rendered as inert DOM (scripts don't execute and
+ * inline event handlers are stripped), and the inner blocks are portalled
+ * into placeholder elements. Inner blocks are locked: they can be edited in
+ * place but not moved, removed, or added to.
+ *
+ * @param {Object} props          Component props.
+ * @param {string} props.clientId Client ID of the block whose inner content
+ *                                should be rendered.
+ */
+export default function InnerContent( { clientId } ) {
+	const { innerContent, order } = useSelect(
+		( select ) => {
+			const { getBlock, getBlockOrder } = select( blockEditorStore );
+			return {
+				innerContent: getBlock( clientId )?.innerContent,
+				order: getBlockOrder( clientId ),
+			};
+		},
+		[ clientId ]
+	);
+	const { updateBlockListSettings } = useDispatch( blockEditorStore );
+
+	// Lock the inner blocks: editable in place, but not movable, removable,
+	// or insertable.
+	useEffect( () => {
+		updateBlockListSettings( clientId, { templateLock: 'all' } );
+	}, [ clientId, updateBlockListSettings ] );
+
+	const html = useMemo( () => {
+		let slotIndex = 0;
+		return ( innerContent ?? [] )
+			.map( ( item ) =>
+				item === null
+					? `<${ SLOT_TAG_NAME } data-slot-index="${ slotIndex++ }" style="display: contents"></${ SLOT_TAG_NAME }>`
+					: item
+			)
+			.join( '' );
+	}, [ innerContent ] );
+
+	const containerRef = useRef();
+	const [ slots, setSlots ] = useState( [] );
+
+	useLayoutEffect( () => {
+		const container = containerRef.current;
+		container.innerHTML = html;
+
+		// The static markup is rendered inert: assigning `innerHTML` never
+		// executes `<script>` elements, and inline event handlers are
+		// stripped here so they can't fire inside the editor canvas.
+		container.querySelectorAll( '*' ).forEach( ( element ) => {
+			for ( const attribute of [ ...element.attributes ] ) {
+				if ( attribute.name.startsWith( 'on' ) ) {
+					element.removeAttribute( attribute.name );
+				}
+			}
+		} );
+
+		setSlots(
+			Array.from( container.querySelectorAll( SLOT_TAG_NAME ) ).sort(
+				( a, b ) =>
+					Number( a.dataset.slotIndex ) -
+					Number( b.dataset.slotIndex )
+			)
+		);
+	}, [ html ] );
+
+	return (
+		<LayoutProvider value={ LAYOUT }>
+			<div
+				ref={ containerRef }
+				className="block-editor-inner-content"
+				style={ { display: 'contents' } }
+			/>
+			{ order.map( ( childClientId, index ) =>
+				slots[ index ]
+					? createPortal(
+							<BlockListBlock
+								rootClientId={ clientId }
+								clientId={ childClientId }
+							/>,
+							slots[ index ],
+							childClientId
+					  )
+					: null
+			) }
+		</LayoutProvider>
+	);
+}

--- a/packages/block-editor/src/components/inner-content/test/index.js
+++ b/packages/block-editor/src/components/inner-content/test/index.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	createBlock,
+	registerBlockType,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import InnerContent from '../';
+import { BlockEditorProvider } from '../../provider';
+
+const BLOCK_NAME = 'core/test-inner-content';
+
+// These tests inspect the raw injected DOM to verify the static markup is
+// sanitized before being added to the editor canvas, so direct node access is
+// intentional.
+/* eslint-disable testing-library/no-node-access, testing-library/no-container, testing-library/render-result-naming-convention */
+
+function renderWithInnerContent( innerContent ) {
+	const block = createBlock( BLOCK_NAME, {}, [], innerContent );
+	const { container } = render(
+		<BlockEditorProvider value={ [ block ] }>
+			<InnerContent clientId={ block.clientId } />
+		</BlockEditorProvider>
+	);
+	return container.querySelector( '.block-editor-inner-content' );
+}
+
+describe( 'InnerContent', () => {
+	beforeAll( () => {
+		registerBlockType( BLOCK_NAME, {
+			apiVersion: 3,
+			title: 'Test Inner Content',
+			category: 'text',
+			supports: { innerContent: true },
+			save: () => null,
+		} );
+	} );
+
+	afterAll( () => {
+		unregisterBlockType( BLOCK_NAME );
+	} );
+
+	it( 'renders the static fragments into the canvas', () => {
+		const root = renderWithInnerContent( [
+			'<div class="banner"><h1>Static heading</h1></div>',
+		] );
+
+		expect( root.querySelector( 'h1' ) ).toHaveTextContent(
+			'Static heading'
+		);
+	} );
+
+	it( 'strips script elements from the static fragments', () => {
+		const root = renderWithInnerContent( [
+			'<div><script>window.__innerContentRan = true;</script>Safe</div>',
+		] );
+
+		expect( root.querySelector( 'script' ) ).toBeNull();
+		expect( root ).toHaveTextContent( 'Safe' );
+	} );
+
+	it( 'strips inline event handlers from the static fragments', () => {
+		const root = renderWithInnerContent( [
+			'<button onclick="alert(1)">Click</button>',
+		] );
+
+		expect( root.querySelector( '[onclick]' ) ).toBeNull();
+		expect( root.querySelector( 'button' ) ).toHaveTextContent( 'Click' );
+	} );
+} );
+
+/* eslint-enable testing-library/no-node-access, testing-library/no-container, testing-library/render-result-naming-convention */

--- a/packages/block-editor/src/components/inner-content/test/index.js
+++ b/packages/block-editor/src/components/inner-content/test/index.js
@@ -18,7 +18,7 @@ import {
 import InnerContent from '../';
 import { BlockEditorProvider } from '../../provider';
 
-const BLOCK_NAME = 'core/test-inner-content';
+const BLOCK_NAME = 'core/html';
 
 // These tests inspect the raw injected DOM to verify the static markup is
 // sanitized before being added to the editor canvas, so direct node access is
@@ -39,9 +39,8 @@ describe( 'InnerContent', () => {
 	beforeAll( () => {
 		registerBlockType( BLOCK_NAME, {
 			apiVersion: 3,
-			title: 'Test Inner Content',
+			title: 'Custom HTML',
 			category: 'text',
-			supports: { innerContent: true },
 			save: () => null,
 		} );
 	} );

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -73,6 +73,7 @@ import { LinkPicker } from './components/link-picker';
 import useRemoteUrlData from './components/link-control/use-rich-url-data';
 import { PrivateBlockContext } from './components/block-list/private-block-context';
 import useListViewPanelState from './components/use-list-view-panel-state';
+import InnerContent from './components/inner-content';
 import {
 	isHashLink,
 	isRelativePath,
@@ -147,4 +148,5 @@ lock( privateApis, {
 	useListViewPanelState,
 	isHashLink,
 	isRelativePath,
+	InnerContent,
 } );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1692,6 +1692,12 @@ const canInsertBlockTypeUnmemoized = (
 		return false;
 	}
 
+	// No insertion within static inner content: the inner blocks are fixed
+	// at their placeholder positions within the static markup.
+	if ( isInnerContentRoot( state, rootClientId ) ) {
+		return false;
+	}
+
 	const blockEditingMode = getBlockEditingMode( state, rootClientId ?? '' );
 
 	// Compute section context early so the disabled check below can use it.
@@ -1900,6 +1906,26 @@ export function canInsertBlocks( state, clientIds, rootClientId = null ) {
 }
 
 /**
+ * Returns whether the given root block keeps its markup as static inner
+ * content (`innerContent` block support). Its inner blocks are fixed at
+ * their positions within the static markup: they can be edited in place,
+ * but not moved or removed, and no blocks can be inserted alongside them.
+ * This only applies to the direct children; deeper descendants are
+ * unaffected.
+ *
+ * @param {Object}  state        Editor state.
+ * @param {?string} rootClientId Root block client ID.
+ *
+ * @return {boolean} Whether the root block uses static inner content.
+ */
+function isInnerContentRoot( state, rootClientId ) {
+	return (
+		!! rootClientId &&
+		hasBlockSupport( getBlockName( state, rootClientId ), 'innerContent' )
+	);
+}
+
+/**
  * Determines if the given block is allowed to be deleted.
  *
  * @param {Object} state    Editor state.
@@ -1910,6 +1936,14 @@ export function canInsertBlocks( state, clientIds, rootClientId = null ) {
 export function canRemoveBlock( state, clientId ) {
 	// Disable removal in preview mode.
 	if ( state.settings.isPreviewMode ) {
+		return false;
+	}
+
+	// Blocks within static inner content are fixed in place; a `lock`
+	// attribute can't override the structural constraint.
+	if (
+		isInnerContentRoot( state, getBlockRootClientId( state, clientId ) )
+	) {
 		return false;
 	}
 
@@ -2011,6 +2045,14 @@ export function canRemoveBlocks( state, clientIds ) {
 export function canMoveBlock( state, clientId ) {
 	// Disable moving in preview mode.
 	if ( state.settings.isPreviewMode ) {
+		return false;
+	}
+
+	// Blocks within static inner content are fixed in place; a `lock`
+	// attribute can't override the structural constraint.
+	if (
+		isInnerContentRoot( state, getBlockRootClientId( state, clientId ) )
+	) {
 		return false;
 	}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1907,11 +1907,10 @@ export function canInsertBlocks( state, clientIds, rootClientId = null ) {
 
 /**
  * Returns whether the given root block keeps its markup as static inner
- * content (`innerContent` block support). Its inner blocks are fixed at
- * their positions within the static markup: they can be edited in place,
- * but not moved or removed, and no blocks can be inserted alongside them.
- * This only applies to the direct children; deeper descendants are
- * unaffected.
+ * content (the Custom HTML block). Its inner blocks are fixed at their
+ * positions within the static markup: they can be edited in place, but not
+ * moved or removed, and no blocks can be inserted alongside them. This only
+ * applies to the direct children; deeper descendants are unaffected.
  *
  * @param {Object}  state        Editor state.
  * @param {?string} rootClientId Root block client ID.
@@ -1920,8 +1919,7 @@ export function canInsertBlocks( state, clientIds, rootClientId = null ) {
  */
 function isInnerContentRoot( state, rootClientId ) {
 	return (
-		!! rootClientId &&
-		hasBlockSupport( getBlockName( state, rootClientId ), 'innerContent' )
+		!! rootClientId && getBlockName( state, rootClientId ) === 'core/html'
 	);
 }
 

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -4802,6 +4802,92 @@ describe( 'selectors', () => {
 		} );
 	} );
 
+	describe( 'static inner content (innerContent support)', () => {
+		beforeEach( () => {
+			registerBlockType( 'core/test-inner-content-block', {
+				apiVersion: 3,
+				save: () => null,
+				category: 'text',
+				title: 'Test Inner Content Block',
+				icon: 'test',
+				supports: {
+					innerContent: true,
+				},
+			} );
+		} );
+
+		afterEach( () => {
+			unregisterBlockType( 'core/test-inner-content-block' );
+		} );
+
+		// An innerContent parent with a child container, which has a child
+		// of its own. The direct child is fixed in place; the grandchild
+		// is regular, fully editable content.
+		const buildState = () => ( {
+			blocks: {
+				byClientId: new Map(
+					Object.entries( {
+						parent: { name: 'core/test-inner-content-block' },
+						child: { name: 'core/test-block-b' },
+						grandchild: { name: 'core/test-block-b' },
+					} )
+				),
+				attributes: new Map(
+					Object.entries( {
+						parent: {},
+						child: {},
+						grandchild: {},
+					} )
+				),
+				parents: new Map(
+					Object.entries( {
+						parent: '',
+						child: 'parent',
+						grandchild: 'child',
+					} )
+				),
+				order: new Map( [
+					[ '', [ 'parent' ] ],
+					[ 'parent', [ 'child' ] ],
+					[ 'child', [ 'grandchild' ] ],
+				] ),
+				blockEditingModes: new Map(),
+			},
+			blockListSettings: new Map( [
+				[ 'parent', {} ],
+				[ 'child', {} ],
+			] ),
+			settings: {},
+			derivedBlockEditingModes: new Map(),
+		} );
+
+		it( 'prevents removing a direct child', () => {
+			expect( canRemoveBlock( buildState(), 'child' ) ).toBe( false );
+		} );
+
+		it( 'prevents moving a direct child', () => {
+			expect( canMoveBlock( buildState(), 'child' ) ).toBe( false );
+		} );
+
+		it( 'prevents insertion into the inner content root', () => {
+			expect(
+				canInsertBlockType(
+					buildState(),
+					'core/test-block-b',
+					'parent'
+				)
+			).toBe( false );
+		} );
+
+		it( 'does not cascade to deeper descendants', () => {
+			expect( canRemoveBlock( buildState(), 'grandchild' ) ).toBe( true );
+			expect( canMoveBlock( buildState(), 'grandchild' ) ).toBe( true );
+			expect(
+				canInsertBlockType( buildState(), 'core/test-block-b', 'child' )
+			).toBe( true );
+		} );
+	} );
+
 	describe( 'canMoveBlock', () => {
 		it( 'allows moving within a non-section contentOnly container', () => {
 			// When the parent has contentOnly editing mode but is NOT

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -4802,32 +4802,29 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'static inner content (innerContent support)', () => {
+	describe( 'static inner content (Custom HTML block)', () => {
 		beforeEach( () => {
-			registerBlockType( 'core/test-inner-content-block', {
+			registerBlockType( 'core/html', {
 				apiVersion: 3,
 				save: () => null,
 				category: 'text',
-				title: 'Test Inner Content Block',
+				title: 'Custom HTML',
 				icon: 'test',
-				supports: {
-					innerContent: true,
-				},
 			} );
 		} );
 
 		afterEach( () => {
-			unregisterBlockType( 'core/test-inner-content-block' );
+			unregisterBlockType( 'core/html' );
 		} );
 
-		// An innerContent parent with a child container, which has a child
-		// of its own. The direct child is fixed in place; the grandchild
+		// The Custom HTML block parent with a child container, which has a
+		// child of its own. The direct child is fixed in place; the grandchild
 		// is regular, fully editable content.
 		const buildState = () => ( {
 			blocks: {
 				byClientId: new Map(
 					Object.entries( {
-						parent: { name: 'core/test-inner-content-block' },
+						parent: { name: 'core/html' },
 						child: { name: 'core/test-block-b' },
 						grandchild: { name: 'core/test-block-b' },
 					} )

--- a/packages/block-library/src/code/transforms.js
+++ b/packages/block-library/src/code/transforms.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getBlockContent } from '@wordpress/blocks';
 import { create, toHTMLString } from '@wordpress/rich-text';
 
 /**
@@ -31,14 +31,16 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/html' ],
-			transform: ( attributes ) => {
-				const { content: text } = attributes;
+			__experimentalConvert( block ) {
+				const { attributes } = block;
 				return createBlock( 'core/code', {
 					...attributes,
 					...getTransformedAttributes( attributes, 'core/code' ),
 					// The HTML is plain text (with plain line breaks), so
 					// convert it to rich text.
-					content: toHTMLString( { value: create( { text } ) } ),
+					content: toHTMLString( {
+						value: create( { text: getBlockContent( block ) } ),
+					} ),
 				} );
 			},
 		},

--- a/packages/block-library/src/freeform/migration-notice.js
+++ b/packages/block-library/src/freeform/migration-notice.js
@@ -34,7 +34,7 @@ export default function MigrationNotice( { content, onReplace } ) {
 			key="convert-to-html"
 			variant="secondary"
 			onClick={ () =>
-				onReplace( createBlock( 'core/html', { content } ) )
+				onReplace( createBlock( 'core/html', {}, [], [ content ] ) )
 			}
 		>
 			{ __( 'Convert to HTML' ) }

--- a/packages/block-library/src/html/README.md
+++ b/packages/block-library/src/html/README.md
@@ -13,7 +13,9 @@ Add custom HTML code and preview it as you edit.
 
 _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/) property in block.json._
 
-_This block has no custom attributes._
+| Attribute | [Type](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#type-validation) | [Default](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#default-value) | Description |
+|-----------|------|---------|-------------|
+| `content` | `string` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `local` |
 
 ## Supports
 

--- a/packages/block-library/src/html/README.md
+++ b/packages/block-library/src/html/README.md
@@ -13,9 +13,7 @@ Add custom HTML code and preview it as you edit.
 
 _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/) property in block.json._
 
-| Attribute | [Type](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#type-validation) | [Default](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#default-value) | Description |
-|-----------|------|---------|-------------|
-| `content` | `string` | — | [Source](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source): `raw`. [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
+_This block has no custom attributes._
 
 ## Supports
 
@@ -24,8 +22,10 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`customClassName`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#customclassname): `false`
 - [`className`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#classname): `false`
 - [`html`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#html): `false`
+- [`innerContent`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#innercontent): `true`
 - [`interactivity`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#interactivity):
   - `clientNavigation`: `true`
+- [`listView`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#listview): `true`
 - `customCSS`: `false`
 - [`visibility`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#visibility): `false`
 

--- a/packages/block-library/src/html/README.md
+++ b/packages/block-library/src/html/README.md
@@ -24,7 +24,6 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`customClassName`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#customclassname): `false`
 - [`className`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#classname): `false`
 - [`html`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#html): `false`
-- [`innerContent`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#innercontent): `true`
 - [`interactivity`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#interactivity):
   - `clientNavigation`: `true`
 - [`listView`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#listview): `true`

--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -17,7 +17,6 @@
 		"customClassName": false,
 		"className": false,
 		"html": false,
-		"innerContent": true,
 		"interactivity": {
 			"clientNavigation": true
 		},

--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -7,6 +7,12 @@
 	"description": "Add custom HTML code and preview it as you edit.",
 	"keywords": [ "embed" ],
 	"textdomain": "default",
+	"attributes": {
+		"content": {
+			"type": "string",
+			"role": "local"
+		}
+	},
 	"supports": {
 		"customClassName": false,
 		"className": false,

--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -7,20 +7,15 @@
 	"description": "Add custom HTML code and preview it as you edit.",
 	"keywords": [ "embed" ],
 	"textdomain": "default",
-	"attributes": {
-		"content": {
-			"type": "string",
-			"source": "raw",
-			"role": "content"
-		}
-	},
 	"supports": {
 		"customClassName": false,
 		"className": false,
 		"html": false,
+		"innerContent": true,
 		"interactivity": {
 			"clientNavigation": true
 		},
+		"listView": true,
 		"customCSS": false,
 		"visibility": false
 	},

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -8,7 +8,11 @@ import {
 	BlockIcon,
 	InspectorControls,
 	useBlockProps,
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
+import { parse, getBlockContent } from '@wordpress/blocks';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import {
 	ToolbarButton,
 	ToolbarGroup,
@@ -21,17 +25,49 @@ import { code } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import Preview from './preview';
+import { unlock } from '../lock-unlock';
 import HTMLEditModal from './modal';
 
-export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
+const { InnerContent } = unlock( blockEditorPrivateApis );
+
+export default function HTMLEdit( { clientId } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const registry = useRegistry();
+	const { updateBlock, replaceInnerBlocks } = useDispatch( blockEditorStore );
+	const content = useSelect(
+		( select ) => {
+			const block = select( blockEditorStore ).getBlock( clientId );
+			return block ? getBlockContent( block ) : '';
+		},
+		[ clientId ]
+	);
 	const blockProps = useBlockProps( {
 		className: 'block-library-html__edit',
 	} );
 
+	// Re-parse the edited content: static HTML becomes the block's
+	// `innerContent` fragments and `<!-- wp:* -->` delimited segments become
+	// inner blocks mounted at their positions within the static markup.
+	const onUpdate = ( nextContent ) => {
+		const [ parsedBlock ] = parse(
+			`<!-- wp:html -->\n${ nextContent }\n<!-- /wp:html -->`
+		);
+		registry.batch( () => {
+			updateBlock( clientId, {
+				innerContent:
+					parsedBlock?.innerContent ??
+					( nextContent ? [ nextContent ] : [] ),
+			} );
+			replaceInnerBlocks(
+				clientId,
+				parsedBlock?.innerBlocks ?? [],
+				false
+			);
+		} );
+	};
+
 	// Show placeholder when content is empty
-	if ( ! attributes.content?.trim() ) {
+	if ( ! content?.trim() ) {
 		return (
 			<div { ...blockProps }>
 				<Placeholder
@@ -52,8 +88,8 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 				{ isModalOpen && (
 					<HTMLEditModal
 						onRequestClose={ () => setIsModalOpen( false ) }
-						content={ attributes.content }
-						setAttributes={ setAttributes }
+						content={ content }
+						onUpdate={ onUpdate }
 					/>
 				) }
 			</div>
@@ -84,12 +120,12 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 					</Button>
 				</VStack>
 			</InspectorControls>
-			<Preview content={ attributes.content } isSelected={ isSelected } />
+			<InnerContent clientId={ clientId } />
 			{ isModalOpen && (
 				<HTMLEditModal
 					onRequestClose={ () => setIsModalOpen( false ) }
-					content={ attributes.content }
-					setAttributes={ setAttributes }
+					content={ content }
+					onUpdate={ onUpdate }
 				/>
 			) }
 		</div>

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -11,7 +11,7 @@ import {
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { parse, getBlockContent } from '@wordpress/blocks';
+import { parse, serialize, getBlockContent } from '@wordpress/blocks';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import {
 	ToolbarButton,
@@ -49,20 +49,36 @@ export default function HTMLEdit( { clientId } ) {
 	// `innerContent` fragments and `<!-- wp:* -->` delimited segments become
 	// inner blocks mounted at their positions within the static markup.
 	const onUpdate = ( nextContent ) => {
+		if ( nextContent === content ) {
+			return;
+		}
+
 		const [ parsedBlock ] = parse(
 			`<!-- wp:html -->\n${ nextContent }\n<!-- /wp:html -->`
 		);
+		const nextInnerBlocks = parsedBlock?.innerBlocks ?? [];
+		const prevInnerBlocks = registry
+			.select( blockEditorStore )
+			.getBlocks( clientId );
+		// Keep the existing inner blocks, and thereby their client IDs and
+		// selection, when their markup is unchanged — e.g. when only the
+		// surrounding static HTML was edited.
+		const innerBlocksUnchanged =
+			prevInnerBlocks.length === nextInnerBlocks.length &&
+			prevInnerBlocks.every(
+				( block, index ) =>
+					serialize( block ) === serialize( nextInnerBlocks[ index ] )
+			);
+
 		registry.batch( () => {
 			updateBlock( clientId, {
 				innerContent:
 					parsedBlock?.innerContent ??
 					( nextContent ? [ nextContent ] : [] ),
 			} );
-			replaceInnerBlocks(
-				clientId,
-				parsedBlock?.innerBlocks ?? [],
-				false
-			);
+			if ( ! innerBlocksUnchanged ) {
+				replaceInnerBlocks( clientId, nextInnerBlocks, false );
+			}
 		} );
 	};
 

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -106,12 +106,9 @@ export default function HTMLEdit( { clientId } ) {
 				</ToolbarGroup>
 			</BlockControls>
 			<InspectorControls>
-				<VStack
-					className="block-editor-block-inspector-edit-contents"
-					expanded
-				>
+				<VStack className="block-library-html__edit-code" expanded>
 					<Button
-						className="block-editor-block-inspector-edit-contents__button"
+						className="block-library-html__edit-code-button"
 						__next40pxDefaultSize
 						variant="secondary"
 						onClick={ () => setIsModalOpen( true ) }

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -98,22 +98,9 @@ export default function HTMLEdit( { clientId, attributes } ) {
 			alternative: 'inner content',
 		} );
 
-		const [ parsedBlock ] = parse(
-			`<!-- wp:html -->\n${ attributes.content }\n<!-- /wp:html -->`
-		);
-
-		registry.batch( () => {
-			updateBlock( clientId, {
-				attributes: { content: undefined },
-				innerContent: parsedBlock?.innerContent ?? [
-					attributes.content,
-				],
-			} );
-			replaceInnerBlocks(
-				clientId,
-				parsedBlock?.innerBlocks ?? [],
-				false
-			);
+		updateBlock( clientId, {
+			attributes: { content: undefined },
+			innerContent: [ attributes.content ],
 		} );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ attributes.content ] );

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import {
 	BlockControls,
 	BlockIcon,
@@ -13,6 +13,7 @@ import {
 } from '@wordpress/block-editor';
 import { parse, serialize, getBlockContent } from '@wordpress/blocks';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 import {
 	ToolbarButton,
 	ToolbarGroup,
@@ -30,7 +31,7 @@ import HTMLEditModal from './modal';
 
 const { InnerContent } = unlock( blockEditorPrivateApis );
 
-export default function HTMLEdit( { clientId } ) {
+export default function HTMLEdit( { clientId, attributes } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const registry = useRegistry();
 	const { updateBlock, replaceInnerBlocks } = useDispatch( blockEditorStore );
@@ -81,6 +82,41 @@ export default function HTMLEdit( { clientId } ) {
 			}
 		} );
 	};
+
+	// Migrate the deprecated `content` attribute. The block's markup now lives
+	// in its inner content, but a block created via `createBlock( 'core/html',
+	// { content } )` still arrives with a `content` attribute. As soon as it
+	// loads, move that markup into the block's inner content and clear the
+	// attribute.
+	useEffect( () => {
+		if ( ! attributes.content ) {
+			return;
+		}
+
+		deprecated( 'The content attribute on the Custom HTML block', {
+			since: '7.1',
+			alternative: 'inner content',
+		} );
+
+		const [ parsedBlock ] = parse(
+			`<!-- wp:html -->\n${ attributes.content }\n<!-- /wp:html -->`
+		);
+
+		registry.batch( () => {
+			updateBlock( clientId, {
+				attributes: { content: undefined },
+				innerContent: parsedBlock?.innerContent ?? [
+					attributes.content,
+				],
+			} );
+			replaceInnerBlocks(
+				clientId,
+				parsedBlock?.innerBlocks ?? [],
+				false
+			);
+		} );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ attributes.content ] );
 
 	// Show placeholder when content is empty
 	if ( ! content?.trim() ) {

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -12,6 +12,16 @@
 	}
 }
 
+// The "Edit code" button in the inspector renders inside the tabs panel, so
+// it needs spacing on all sides, including against the tab list above it.
+.block-library-html__edit-code {
+	margin: $grid-unit-20;
+
+	.block-library-html__edit-code-button {
+		justify-content: center;
+	}
+}
+
 // Modal styles
 .block-library-html__modal {
 

--- a/packages/block-library/src/html/index.js
+++ b/packages/block-library/src/html/index.js
@@ -20,12 +20,11 @@ export { metadata, name };
 export const settings = {
 	icon,
 	example: {
-		attributes: {
-			content:
-				'<marquee>' +
+		innerContent: [
+			'<marquee>' +
 				__( 'Welcome to the wonderful world of blocks…' ) +
 				'</marquee>',
-		},
+		],
 	},
 	edit,
 	save,

--- a/packages/block-library/src/html/modal.js
+++ b/packages/block-library/src/html/modal.js
@@ -26,11 +26,7 @@ import { parseContent, serializeContent } from './utils';
 
 const { Tabs } = unlock( componentsPrivateApis );
 
-export default function HTMLEditModal( {
-	onRequestClose,
-	content,
-	setAttributes,
-} ) {
+export default function HTMLEditModal( { onRequestClose, content, onUpdate } ) {
 	// Parse content into separate sections and use as initial state
 	const { html, css, js } = parseContent( content );
 	const [ editedHtml, setEditedHtml ] = useState( html );
@@ -56,13 +52,13 @@ export default function HTMLEditModal( {
 	const handleUpdate = () => {
 		// For users without unfiltered_html capability, strip CSS and JS content
 		// to prevent kses from leaving broken content
-		setAttributes( {
-			content: serializeContent( {
+		onUpdate(
+			serializeContent( {
 				html: editedHtml,
 				css: canUserUseUnfilteredHTML ? editedCss : '',
 				js: canUserUseUnfilteredHTML ? editedJs : '',
-			} ),
-		} );
+			} )
+		);
 	};
 	const handleUpdateAndClose = () => {
 		handleUpdate();

--- a/packages/block-library/src/html/save.js
+++ b/packages/block-library/src/html/save.js
@@ -1,8 +1,5 @@
-/**
- * WordPress dependencies
- */
-import { RawHTML } from '@wordpress/element';
-
-export default function save( { attributes } ) {
-	return <RawHTML>{ attributes.content }</RawHTML>;
+// The block's markup is serialized from its `innerContent` (static HTML
+// fragments interleaved with inner blocks), not from a save implementation.
+export default function save() {
+	return null;
 }

--- a/packages/block-library/src/html/save.js
+++ b/packages/block-library/src/html/save.js
@@ -1,5 +1,15 @@
-// The block's markup is serialized from its `innerContent` (static HTML
-// fragments interleaved with inner blocks), not from a save implementation.
-export default function save() {
-	return null;
+/**
+ * WordPress dependencies
+ */
+import { RawHTML } from '@wordpress/element';
+
+// The block's markup is normally serialized from its `innerContent` (static
+// HTML fragments interleaved with inner blocks), so this `save` output is
+// unused for parsed blocks. It only matters as a fallback for the deprecated
+// `content` attribute: a block created via `createBlock( 'core/html', {
+// content } )` and serialized without ever entering the editor (where it would
+// otherwise be migrated to inner content) has no `innerContent`, so the
+// serializer falls through to this `save` to avoid losing the content.
+export default function save( { attributes } ) {
+	return <RawHTML>{ attributes.content }</RawHTML>;
 }

--- a/packages/block-library/src/html/save.js
+++ b/packages/block-library/src/html/save.js
@@ -1,15 +1,5 @@
-/**
- * WordPress dependencies
- */
-import { RawHTML } from '@wordpress/element';
-
-// The block's markup is normally serialized from its `innerContent` (static
-// HTML fragments interleaved with inner blocks), so this `save` output is
-// unused for parsed blocks. It only matters as a fallback for the deprecated
-// `content` attribute: a block created via `createBlock( 'core/html', {
-// content } )` and serialized without ever entering the editor (where it would
-// otherwise be migrated to inner content) has no `innerContent`, so the
-// serializer falls through to this `save` to avoid losing the content.
-export default function save( { attributes } ) {
-	return <RawHTML>{ attributes.content }</RawHTML>;
+// The block's markup is serialized from its `innerContent` (static HTML
+// fragments interleaved with inner blocks), not from a save implementation.
+export default function save() {
+	return null;
 }

--- a/packages/block-library/src/html/test/index.js
+++ b/packages/block-library/src/html/test/index.js
@@ -1,0 +1,97 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createBlock,
+	getBlockContent,
+	registerBlockType,
+	serialize,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import * as html from '../';
+
+describe( 'core/html', () => {
+	beforeAll( () => {
+		registerBlockType(
+			{ name: html.name, ...html.metadata },
+			html.settings
+		);
+	} );
+
+	afterAll( () => {
+		unregisterBlockType( html.name );
+	} );
+
+	describe( 'deprecated content attribute', () => {
+		it( 'preserves content passed to createBlock', () => {
+			const block = createBlock( 'core/html', {
+				content: '<marquee>Hello</marquee>',
+			} );
+
+			// The attribute is kept so it can be migrated rather than dropped.
+			expect( block.attributes.content ).toBe(
+				'<marquee>Hello</marquee>'
+			);
+		} );
+
+		it( 'serializes content via the save fallback when not migrated', () => {
+			// Mirrors a headless `createBlock` + `serialize` with no editor to
+			// migrate the content into inner content.
+			const block = createBlock( 'core/html', {
+				content: '<marquee>Hello</marquee>',
+			} );
+
+			expect( getBlockContent( block ) ).toBe(
+				'<marquee>Hello</marquee>'
+			);
+			expect( serialize( block ) ).toBe(
+				'<!-- wp:html -->\n<marquee>Hello</marquee>\n<!-- /wp:html -->'
+			);
+		} );
+
+		it( 'keeps the content attribute out of the block delimiter', () => {
+			const block = createBlock( 'core/html', {
+				content: '<marquee>Hello</marquee>',
+			} );
+
+			// `role: 'local'` prevents the attribute from being written into
+			// the comment delimiter as JSON.
+			expect( serialize( block ) ).not.toContain( '{"content"' );
+		} );
+	} );
+
+	describe( 'inner content', () => {
+		it( 'serializes from inner content interleaved with inner blocks', () => {
+			registerBlockType( 'core/paragraph', {
+				apiVersion: 3,
+				category: 'text',
+				title: 'Paragraph',
+				attributes: {
+					content: { type: 'string', source: 'html' },
+				},
+				save: ( { attributes } ) => attributes.content || null,
+			} );
+
+			const block = createBlock(
+				'core/html',
+				{},
+				[ createBlock( 'core/paragraph', { content: 'Editable' } ) ],
+				[ '<div>', null, '</div>' ]
+			);
+
+			expect( serialize( block ) ).toBe(
+				'<!-- wp:html -->\n' +
+					'<div><!-- wp:paragraph -->\n' +
+					'Editable\n' +
+					'<!-- /wp:paragraph --></div>\n' +
+					'<!-- /wp:html -->'
+			);
+
+			unregisterBlockType( 'core/paragraph' );
+		} );
+	} );
+} );

--- a/packages/block-library/src/html/test/index.js
+++ b/packages/block-library/src/html/test/index.js
@@ -5,8 +5,10 @@ import {
 	createBlock,
 	registerBlockType,
 	serialize,
+	switchToBlockType,
 	unregisterBlockType,
 } from '@wordpress/blocks';
+import { create, toHTMLString } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -76,6 +78,66 @@ describe( 'core/html', () => {
 			);
 
 			unregisterBlockType( 'core/paragraph' );
+		} );
+	} );
+
+	describe( 'transform from core/code', () => {
+		beforeEach( () => {
+			registerBlockType( 'core/paragraph', {
+				apiVersion: 3,
+				category: 'text',
+				title: 'Paragraph',
+				attributes: {
+					content: { type: 'string', source: 'html' },
+				},
+				save: ( { attributes } ) => attributes.content || null,
+			} );
+			// A minimal stand-in: the transform only reads `attributes.content`.
+			registerBlockType( 'core/code', {
+				apiVersion: 3,
+				category: 'text',
+				title: 'Code',
+				attributes: {
+					content: { type: 'string', source: 'html' },
+				},
+				save: ( { attributes } ) => attributes.content || null,
+			} );
+		} );
+
+		afterEach( () => {
+			unregisterBlockType( 'core/code' );
+			unregisterBlockType( 'core/paragraph' );
+		} );
+
+		// Mirrors how the code block stores HTML-block source: as escaped,
+		// plain-text rich text.
+		const asCodeContent = ( source ) =>
+			toHTMLString( { value: create( { text: source } ) } );
+
+		it( 'restores block delimiters as editable inner blocks', () => {
+			const codeBlock = createBlock( 'core/code', {
+				content: asCodeContent(
+					'<div><!-- wp:paragraph -->\nEditable\n<!-- /wp:paragraph --></div>'
+				),
+			} );
+
+			const [ htmlBlock ] = switchToBlockType( codeBlock, 'core/html' );
+
+			expect( htmlBlock.name ).toBe( 'core/html' );
+			expect( htmlBlock.innerBlocks ).toHaveLength( 1 );
+			expect( htmlBlock.innerBlocks[ 0 ].name ).toBe( 'core/paragraph' );
+			expect( htmlBlock.innerContent ).toContain( null );
+		} );
+
+		it( 'keeps plain code (no delimiters) as a single static fragment', () => {
+			const codeBlock = createBlock( 'core/code', {
+				content: asCodeContent( '<div>Just static HTML</div>' ),
+			} );
+
+			const [ htmlBlock ] = switchToBlockType( codeBlock, 'core/html' );
+
+			expect( htmlBlock.innerBlocks ).toHaveLength( 0 );
+			expect( htmlBlock.innerContent ).not.toContain( null );
 		} );
 	} );
 } );

--- a/packages/block-library/src/html/test/index.js
+++ b/packages/block-library/src/html/test/index.js
@@ -3,7 +3,6 @@
  */
 import {
 	createBlock,
-	getBlockContent,
 	registerBlockType,
 	serialize,
 	unregisterBlockType,
@@ -35,21 +34,6 @@ describe( 'core/html', () => {
 			// The attribute is kept so it can be migrated rather than dropped.
 			expect( block.attributes.content ).toBe(
 				'<marquee>Hello</marquee>'
-			);
-		} );
-
-		it( 'serializes content via the save fallback when not migrated', () => {
-			// Mirrors a headless `createBlock` + `serialize` with no editor to
-			// migrate the content into inner content.
-			const block = createBlock( 'core/html', {
-				content: '<marquee>Hello</marquee>',
-			} );
-
-			expect( getBlockContent( block ) ).toBe(
-				'<marquee>Hello</marquee>'
-			);
-			expect( serialize( block ) ).toBe(
-				'<!-- wp:html -->\n<marquee>Hello</marquee>\n<!-- /wp:html -->'
 			);
 		} );
 

--- a/packages/block-library/src/html/transforms.js
+++ b/packages/block-library/src/html/transforms.js
@@ -11,22 +11,15 @@ const transforms = {
 			blocks: [ 'core/code' ],
 			transform: ( { content: html } ) => {
 				// The code block may output HTML formatting, so convert it
-				// to plain text.
+				// to plain text, then parse it so any block delimiters become
+				// editable inner blocks at their positions within the static
+				// HTML, rather than inert comment text.
 				const text = create( { html } ).text;
-
-				// Re-parse the markup so any block delimiters become editable
-				// inner blocks at their positions within the static HTML,
-				// rather than inert comment text.
 				const [ block ] = parse(
 					`<!-- wp:html -->\n${ text }\n<!-- /wp:html -->`
 				);
 
-				return createBlock(
-					'core/html',
-					{},
-					block?.innerBlocks ?? [],
-					block?.innerContent ?? [ text ]
-				);
+				return block ?? createBlock( 'core/html', {}, [], [ text ] );
 			},
 		},
 	],

--- a/packages/block-library/src/html/transforms.js
+++ b/packages/block-library/src/html/transforms.js
@@ -10,11 +10,14 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'core/code' ],
 			transform: ( { content: html } ) => {
-				return createBlock( 'core/html', {
-					// The code block may output HTML formatting, so convert it
-					// to plain text.
-					content: create( { html } ).text,
-				} );
+				// The code block may output HTML formatting, so convert it
+				// to plain text.
+				return createBlock(
+					'core/html',
+					{},
+					[],
+					[ create( { html } ).text ]
+				);
 			},
 		},
 	],

--- a/packages/block-library/src/html/transforms.js
+++ b/packages/block-library/src/html/transforms.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, parse } from '@wordpress/blocks';
 import { create } from '@wordpress/rich-text';
 
 const transforms = {
@@ -12,11 +12,20 @@ const transforms = {
 			transform: ( { content: html } ) => {
 				// The code block may output HTML formatting, so convert it
 				// to plain text.
+				const text = create( { html } ).text;
+
+				// Re-parse the markup so any block delimiters become editable
+				// inner blocks at their positions within the static HTML,
+				// rather than inert comment text.
+				const [ block ] = parse(
+					`<!-- wp:html -->\n${ text }\n<!-- /wp:html -->`
+				);
+
 				return createBlock(
 					'core/html',
 					{},
-					[],
-					[ create( { html } ).text ]
+					block?.innerBlocks ?? [],
+					block?.innerContent ?? [ text ]
 				);
 			},
 		},

--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -39,9 +39,7 @@ export default function MissingEdit( { attributes, clientId } ) {
 	function convertToHTML() {
 		replaceBlock(
 			clientId,
-			createBlock( 'core/html', {
-				content: originalUndelimitedContent,
-			} )
+			createBlock( 'core/html', {}, [], [ originalUndelimitedContent ] )
 		);
 	}
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -45,6 +45,7 @@ _Parameters_
 -   _name_ `string`: Block name.
 -   _attributes_ `Record< string, unknown >`: Block attributes.
 -   _innerBlocks_ `Block[]`: Nested blocks.
+-   _innerContent_ `Array< string | null >`: Static HTML fragments interleaved with inner blocks, where `null` entries mark inner block positions. Only applies to blocks with the `innerContent` support.
 
 _Returns_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -45,7 +45,7 @@ _Parameters_
 -   _name_ `string`: Block name.
 -   _attributes_ `Record< string, unknown >`: Block attributes.
 -   _innerBlocks_ `Block[]`: Nested blocks.
--   _innerContent_ `Array< string | null >`: Static HTML fragments interleaved with inner blocks, where `null` entries mark inner block positions. Only applies to blocks with the `innerContent` support.
+-   _innerContent_ `Array< string | null >`: Static HTML fragments interleaved with inner blocks, where `null` entries mark inner block positions. Only applies to the Custom HTML block.
 
 _Returns_
 

--- a/packages/blocks/src/api/factory.ts
+++ b/packages/blocks/src/api/factory.ts
@@ -16,7 +16,6 @@ import {
 	getBlockType,
 	getBlockTypes,
 	getGroupingBlockName,
-	hasBlockSupport,
 } from './registration';
 import {
 	isBlockRegistered,
@@ -45,7 +44,7 @@ const getBlockTypeWithTransformMetadata = (
  * @param innerBlocks  Nested blocks.
  * @param innerContent Static HTML fragments interleaved with inner blocks,
  *                     where `null` entries mark inner block positions. Only
- *                     applies to blocks with the `innerContent` support.
+ *                     applies to the Custom HTML block.
  *
  * @return Block object.
  */
@@ -81,11 +80,13 @@ export function createBlock(
 	};
 
 	if ( innerContent ) {
-		if ( hasBlockSupport( name, 'innerContent' ) ) {
+		// Static inner content is currently a Custom HTML block mechanism
+		// only; it isn't exposed as a block support.
+		if ( name === 'core/html' ) {
 			block.innerContent = innerContent;
 		} else {
 			warning(
-				`The "${ name }" block does not support inner content, so the innerContent argument passed to createBlock was ignored. Add the "innerContent" block support to use it.`
+				`The innerContent argument passed to createBlock for the "${ name }" block was ignored. Only the Custom HTML block stores static inner content.`
 			);
 		}
 	}

--- a/packages/blocks/src/api/factory.ts
+++ b/packages/blocks/src/api/factory.ts
@@ -15,6 +15,7 @@ import {
 	getBlockType,
 	getBlockTypes,
 	getGroupingBlockName,
+	hasBlockSupport,
 } from './registration';
 import {
 	isBlockRegistered,
@@ -38,16 +39,20 @@ const getBlockTypeWithTransformMetadata = (
 /**
  * Returns a block object given its type and attributes.
  *
- * @param name        Block name.
- * @param attributes  Block attributes.
- * @param innerBlocks Nested blocks.
+ * @param name         Block name.
+ * @param attributes   Block attributes.
+ * @param innerBlocks  Nested blocks.
+ * @param innerContent Static HTML fragments interleaved with inner blocks,
+ *                     where `null` entries mark inner block positions. Only
+ *                     applies to blocks with the `innerContent` support.
  *
  * @return Block object.
  */
 export function createBlock(
 	name: string,
 	attributes: Record< string, unknown > = {},
-	innerBlocks: Block[] = []
+	innerBlocks: Block[] = [],
+	innerContent?: Array< string | null >
 ): Block {
 	if ( ! isBlockRegistered( name ) ) {
 		return createBlock( 'core/missing', {
@@ -66,13 +71,19 @@ export function createBlock(
 
 	// Blocks are stored with a unique ID, the assigned type name, the block
 	// attributes, and their inner blocks.
-	return {
+	const block: Block = {
 		clientId,
 		name,
 		isValid: true,
 		attributes: sanitizedAttributes,
 		innerBlocks,
 	};
+
+	if ( innerContent && hasBlockSupport( name, 'innerContent' ) ) {
+		block.innerContent = innerContent;
+	}
+
+	return block;
 }
 
 /**
@@ -684,6 +695,7 @@ type BlockExample = {
 		attributes?: Record< string, unknown >;
 		innerBlocks?: BlockExample[ 'innerBlocks' ];
 	} >;
+	innerContent?: Array< string | null >;
 };
 
 export const getBlockFromExample = (
@@ -695,5 +707,6 @@ export const getBlockFromExample = (
 		example.attributes,
 		( example.innerBlocks ?? [] ).map( ( innerBlock ) =>
 			getBlockFromExample( innerBlock.name, innerBlock )
-		)
+		),
+		example.innerContent
 	);

--- a/packages/blocks/src/api/factory.ts
+++ b/packages/blocks/src/api/factory.ts
@@ -7,6 +7,7 @@ import { v4 as uuid } from 'uuid';
  * WordPress dependencies
  */
 import { createHooks, applyFilters } from '@wordpress/hooks';
+import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -79,8 +80,14 @@ export function createBlock(
 		innerBlocks,
 	};
 
-	if ( innerContent && hasBlockSupport( name, 'innerContent' ) ) {
-		block.innerContent = innerContent;
+	if ( innerContent ) {
+		if ( hasBlockSupport( name, 'innerContent' ) ) {
+			block.innerContent = innerContent;
+		} else {
+			warning(
+				`The "${ name }" block does not support inner content, so the innerContent argument passed to createBlock was ignored. Add the "innerContent" block support to use it.`
+			);
+		}
 	}
 
 	return block;

--- a/packages/blocks/src/api/parser/index.ts
+++ b/packages/blocks/src/api/parser/index.ts
@@ -11,7 +11,6 @@ import {
 	getFreeformContentHandlerName,
 	getUnregisteredTypeHandlerName,
 	getBlockType,
-	hasBlockSupport,
 } from '../registration';
 import { getSaveContent } from '../serializer';
 import { validateBlock } from '../validation';
@@ -216,11 +215,11 @@ export function parseRawBlock(
 	);
 	parsedBlock.originalContent = normalizedBlock.innerHTML;
 
-	// Blocks with the `innerContent` support keep the interleaved static
-	// HTML fragments as the canonical source of their own markup, so the
-	// `save`-based validation and deprecation flows don't apply: serializing
-	// the parsed content reproduces the input by construction.
-	if ( hasBlockSupport( blockType, 'innerContent' ) ) {
+	// The Custom HTML block keeps the interleaved static HTML fragments as
+	// the canonical source of its own markup, so the `save`-based validation
+	// and deprecation flows don't apply: serializing the parsed content
+	// reproduces the input by construction.
+	if ( blockType.name === 'core/html' ) {
 		parsedBlock.innerContent = normalizedBlock.innerContent ?? [
 			normalizedBlock.innerHTML,
 		];

--- a/packages/blocks/src/api/parser/index.ts
+++ b/packages/blocks/src/api/parser/index.ts
@@ -218,8 +218,8 @@ export function parseRawBlock(
 
 	// Blocks with the `innerContent` support keep the interleaved static
 	// HTML fragments as the canonical source of their own markup, so the
-	// `save`-based validation and deprecation flows don't apply: the parsed
-	// content round-trips by construction.
+	// `save`-based validation and deprecation flows don't apply: serializing
+	// the parsed content reproduces the input by construction.
 	if ( hasBlockSupport( blockType, 'innerContent' ) ) {
 		parsedBlock.innerContent = normalizedBlock.innerContent ?? [
 			normalizedBlock.innerHTML,

--- a/packages/blocks/src/api/parser/index.ts
+++ b/packages/blocks/src/api/parser/index.ts
@@ -11,6 +11,7 @@ import {
 	getFreeformContentHandlerName,
 	getUnregisteredTypeHandlerName,
 	getBlockType,
+	hasBlockSupport,
 } from '../registration';
 import { getSaveContent } from '../serializer';
 import { validateBlock } from '../validation';
@@ -214,6 +215,19 @@ export function parseRawBlock(
 		parsedInnerBlocks
 	);
 	parsedBlock.originalContent = normalizedBlock.innerHTML;
+
+	// Blocks with the `innerContent` support keep the interleaved static
+	// HTML fragments as the canonical source of their own markup, so the
+	// `save`-based validation and deprecation flows don't apply: the parsed
+	// content round-trips by construction.
+	if ( hasBlockSupport( blockType, 'innerContent' ) ) {
+		parsedBlock.innerContent = normalizedBlock.innerContent ?? [
+			normalizedBlock.innerHTML,
+		];
+		parsedBlock.isValid = true;
+		parsedBlock.validationIssues = [];
+		return parsedBlock;
+	}
 
 	const validatedBlock = applyBlockValidation( parsedBlock, blockType );
 	const { validationIssues } = validatedBlock;

--- a/packages/blocks/src/api/parser/test/index.js
+++ b/packages/blocks/src/api/parser/test/index.js
@@ -536,7 +536,7 @@ describe( 'block parser', () => {
 			);
 		} );
 
-		it( 'should round-trip static HTML interleaved with inner blocks', () => {
+		it( 'should serialize parsed static HTML interleaved with inner blocks back to identical markup', () => {
 			registerBlockType( 'core/static-html', staticHtmlBlockSettings );
 			registerBlockType( 'core/inner', innerBlockSettings );
 
@@ -550,7 +550,7 @@ describe( 'block parser', () => {
 			expect( serialize( parse( content ) ) ).toBe( content );
 		} );
 
-		it( 'should round-trip static HTML without inner blocks', () => {
+		it( 'should serialize parsed static HTML without inner blocks back to identical markup', () => {
 			registerBlockType( 'core/static-html', staticHtmlBlockSettings );
 
 			const content =

--- a/packages/blocks/src/api/parser/test/index.js
+++ b/packages/blocks/src/api/parser/test/index.js
@@ -488,14 +488,11 @@ describe( 'block parser', () => {
 		} );
 	} );
 
-	describe( 'blocks with innerContent support', () => {
-		const staticHtmlBlockSettings = {
+	describe( 'Custom HTML block static inner content', () => {
+		const htmlBlockSettings = {
 			apiVersion: 3,
 			category: 'text',
-			title: 'static html block',
-			supports: {
-				innerContent: true,
-			},
+			title: 'Custom HTML',
 			save: () => null,
 		};
 
@@ -513,16 +510,16 @@ describe( 'block parser', () => {
 		};
 
 		it( 'should retain innerContent and mark the block valid', () => {
-			registerBlockType( 'core/static-html', staticHtmlBlockSettings );
+			registerBlockType( 'core/html', htmlBlockSettings );
 			registerBlockType( 'core/inner', innerBlockSettings );
 
 			const [ block ] = parse(
-				'<!-- wp:static-html -->\n' +
+				'<!-- wp:html -->\n' +
 					'<div><!-- wp:inner -->\nBananas\n<!-- /wp:inner --></div>\n' +
-					'<!-- /wp:static-html -->'
+					'<!-- /wp:html -->'
 			);
 
-			expect( block.name ).toBe( 'core/static-html' );
+			expect( block.name ).toBe( 'core/html' );
 			expect( block.isValid ).toBe( true );
 			expect( block.innerContent ).toEqual( [
 				'\n<div>',
@@ -537,27 +534,27 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'should serialize parsed static HTML interleaved with inner blocks back to identical markup', () => {
-			registerBlockType( 'core/static-html', staticHtmlBlockSettings );
+			registerBlockType( 'core/html', htmlBlockSettings );
 			registerBlockType( 'core/inner', innerBlockSettings );
 
 			const content =
-				'<!-- wp:static-html -->\n' +
+				'<!-- wp:html -->\n' +
 				'<div class="banner"><h1>Static</h1><!-- wp:inner -->\n' +
 				'Editable\n' +
 				'<!-- /wp:inner --><footer>Footer</footer></div>\n' +
-				'<!-- /wp:static-html -->';
+				'<!-- /wp:html -->';
 
 			expect( serialize( parse( content ) ) ).toBe( content );
 		} );
 
 		it( 'should serialize parsed static HTML without inner blocks back to identical markup', () => {
-			registerBlockType( 'core/static-html', staticHtmlBlockSettings );
+			registerBlockType( 'core/html', htmlBlockSettings );
 
 			const content =
-				'<!-- wp:static-html -->\n' +
+				'<!-- wp:html -->\n' +
 				'<h1>Some HTML code</h1>\n' +
 				'<div>This is a div</div>\n' +
-				'<!-- /wp:static-html -->';
+				'<!-- /wp:html -->';
 
 			expect( serialize( parse( content ) ) ).toBe( content );
 		} );

--- a/packages/blocks/src/api/parser/test/index.js
+++ b/packages/blocks/src/api/parser/test/index.js
@@ -487,4 +487,79 @@ describe( 'block parser', () => {
 			expect( parsed[ 0 ].attributes.content ).toBe( content );
 		} );
 	} );
+
+	describe( 'blocks with innerContent support', () => {
+		const staticHtmlBlockSettings = {
+			apiVersion: 3,
+			category: 'text',
+			title: 'static html block',
+			supports: {
+				innerContent: true,
+			},
+			save: () => null,
+		};
+
+		const innerBlockSettings = {
+			apiVersion: 3,
+			category: 'text',
+			title: 'inner block',
+			attributes: {
+				content: {
+					type: 'string',
+					source: 'html',
+				},
+			},
+			save: ( { attributes } ) => attributes.content || null,
+		};
+
+		it( 'should retain innerContent and mark the block valid', () => {
+			registerBlockType( 'core/static-html', staticHtmlBlockSettings );
+			registerBlockType( 'core/inner', innerBlockSettings );
+
+			const [ block ] = parse(
+				'<!-- wp:static-html -->\n' +
+					'<div><!-- wp:inner -->\nBananas\n<!-- /wp:inner --></div>\n' +
+					'<!-- /wp:static-html -->'
+			);
+
+			expect( block.name ).toBe( 'core/static-html' );
+			expect( block.isValid ).toBe( true );
+			expect( block.innerContent ).toEqual( [
+				'\n<div>',
+				null,
+				'</div>\n',
+			] );
+			expect( block.innerBlocks ).toHaveLength( 1 );
+			expect( block.innerBlocks[ 0 ].name ).toBe( 'core/inner' );
+			expect( block.innerBlocks[ 0 ].attributes.content ).toBe(
+				'Bananas'
+			);
+		} );
+
+		it( 'should round-trip static HTML interleaved with inner blocks', () => {
+			registerBlockType( 'core/static-html', staticHtmlBlockSettings );
+			registerBlockType( 'core/inner', innerBlockSettings );
+
+			const content =
+				'<!-- wp:static-html -->\n' +
+				'<div class="banner"><h1>Static</h1><!-- wp:inner -->\n' +
+				'Editable\n' +
+				'<!-- /wp:inner --><footer>Footer</footer></div>\n' +
+				'<!-- /wp:static-html -->';
+
+			expect( serialize( parse( content ) ) ).toBe( content );
+		} );
+
+		it( 'should round-trip static HTML without inner blocks', () => {
+			registerBlockType( 'core/static-html', staticHtmlBlockSettings );
+
+			const content =
+				'<!-- wp:static-html -->\n' +
+				'<h1>Some HTML code</h1>\n' +
+				'<div>This is a div</div>\n' +
+				'<!-- /wp:static-html -->';
+
+			expect( serialize( parse( content ) ) ).toBe( content );
+		} );
+	} );
 } );

--- a/packages/blocks/src/api/raw-handling/html-to-blocks.ts
+++ b/packages/blocks/src/api/raw-handling/html-to-blocks.ts
@@ -39,7 +39,9 @@ export function htmlToBlocks(
 			return createBlock(
 				// Should not be hardcoded.
 				'core/html',
-				getBlockAttributes( 'core/html', node.outerHTML )
+				{},
+				[],
+				[ node.outerHTML ]
 			);
 		}
 

--- a/packages/blocks/src/api/serializer.tsx
+++ b/packages/blocks/src/api/serializer.tsx
@@ -24,6 +24,7 @@ import {
 	getBlockType,
 	getFreeformContentHandlerName,
 	getUnregisteredTypeHandlerName,
+	hasBlockSupport,
 } from './registration';
 import { serializeRawBlock } from './parser/serialize-raw-block';
 import { isUnmodifiedDefaultBlock, normalizeBlockType } from './utils';
@@ -331,6 +332,42 @@ export function serializeAttributes(
 }
 
 /**
+ * Given the static HTML fragments of a block with the `innerContent` support
+ * and its inner blocks, returns the block's inner HTML markup by interleaving
+ * the fragments with the serialized inner blocks.
+ *
+ * @param innerContent Static HTML fragments, `null` marking inner block positions.
+ * @param innerBlocks  Inner blocks.
+ *
+ * @return HTML.
+ */
+function serializeInnerContent(
+	innerContent: Array< string | null >,
+	innerBlocks: Block[]
+): string {
+	let childIndex = 0;
+	const parts = innerContent.map( ( item ) => {
+		if ( item !== null ) {
+			return item;
+		}
+		const innerBlock = innerBlocks[ childIndex++ ];
+		return innerBlock
+			? serializeBlock( innerBlock, { isInnerBlocks: true } )
+			: '';
+	} );
+
+	// Defensively append inner blocks without a matching placeholder so that
+	// content is never lost when the two arrays fall out of sync.
+	for ( ; childIndex < innerBlocks.length; childIndex++ ) {
+		parts.push(
+			serializeBlock( innerBlocks[ childIndex ], { isInnerBlocks: true } )
+		);
+	}
+
+	return parts.join( '' ).trim();
+}
+
+/**
  * Given a block object, returns the Block's Inner HTML markup.
  *
  * @param block Block instance.
@@ -338,6 +375,12 @@ export function serializeAttributes(
  * @return HTML.
  */
 export function getBlockInnerHTML( block: Block ): string {
+	// Blocks with the `innerContent` support serialize from their static
+	// HTML fragments rather than from a `save` implementation.
+	if ( block.innerContent && hasBlockSupport( block.name, 'innerContent' ) ) {
+		return serializeInnerContent( block.innerContent, block.innerBlocks );
+	}
+
 	// If block was parsed as invalid or encounters an error while generating
 	// save content, use original content instead to avoid content loss. If a
 	// block contains nested content, exempt it from this condition because we

--- a/packages/blocks/src/api/serializer.tsx
+++ b/packages/blocks/src/api/serializer.tsx
@@ -24,7 +24,6 @@ import {
 	getBlockType,
 	getFreeformContentHandlerName,
 	getUnregisteredTypeHandlerName,
-	hasBlockSupport,
 } from './registration';
 import { serializeRawBlock } from './parser/serialize-raw-block';
 import { isUnmodifiedDefaultBlock, normalizeBlockType } from './utils';
@@ -332,9 +331,9 @@ export function serializeAttributes(
 }
 
 /**
- * Given the static HTML fragments of a block with the `innerContent` support
- * and its inner blocks, returns the block's inner HTML markup by interleaving
- * the fragments with the serialized inner blocks.
+ * Given the static HTML fragments of the Custom HTML block and its inner
+ * blocks, returns the block's inner HTML markup by interleaving the fragments
+ * with the serialized inner blocks.
  *
  * @param innerContent Static HTML fragments, `null` marking inner block positions.
  * @param innerBlocks  Inner blocks.
@@ -375,9 +374,9 @@ function serializeInnerContent(
  * @return HTML.
  */
 export function getBlockInnerHTML( block: Block ): string {
-	// Blocks with the `innerContent` support serialize from their static
-	// HTML fragments rather than from a `save` implementation.
-	if ( block.innerContent && hasBlockSupport( block.name, 'innerContent' ) ) {
+	// The Custom HTML block serializes from its static HTML fragments rather
+	// than from a `save` implementation.
+	if ( block.innerContent && block.name === 'core/html' ) {
 		return serializeInnerContent( block.innerContent, block.innerBlocks );
 	}
 

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -26,6 +26,7 @@ import {
 	unregisterBlockType,
 	setGroupingBlockName,
 } from '../registration';
+import { logged as warningLoggedSet } from '../../../../warning/src/utils';
 
 const noop = () => {};
 
@@ -45,6 +46,11 @@ describe( 'block factory', () => {
 	beforeAll( () => {
 		// Load blocks store.
 		require( '../../store' );
+	} );
+
+	beforeEach( () => {
+		// Reset warning logging so deduped warnings fire within each test.
+		warningLoggedSet.clear();
 	} );
 
 	afterEach( () => {
@@ -200,7 +206,7 @@ describe( 'block factory', () => {
 			expect( block.innerContent ).toEqual( [ '<div></div>' ] );
 		} );
 
-		it( 'should ignore innerContent when the block type lacks support', () => {
+		it( 'should ignore innerContent and warn when the block type lacks support', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 
 			const block = createBlock(
@@ -211,6 +217,7 @@ describe( 'block factory', () => {
 			);
 
 			expect( block.innerContent ).toBeUndefined();
+			expect( console ).toHaveWarned();
 		} );
 	} );
 

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -188,25 +188,15 @@ describe( 'block factory', () => {
 			expect( block.attributes ).toEqual( {} );
 		} );
 
-		it( 'should attach innerContent when the block type supports it', () => {
-			registerBlockType( 'core/test-block', {
-				...defaultBlockSettings,
-				supports: {
-					innerContent: true,
-				},
-			} );
+		it( 'should attach innerContent for the Custom HTML block', () => {
+			registerBlockType( 'core/html', defaultBlockSettings );
 
-			const block = createBlock(
-				'core/test-block',
-				{},
-				[],
-				[ '<div></div>' ]
-			);
+			const block = createBlock( 'core/html', {}, [], [ '<div></div>' ] );
 
 			expect( block.innerContent ).toEqual( [ '<div></div>' ] );
 		} );
 
-		it( 'should ignore innerContent and warn when the block type lacks support', () => {
+		it( 'should ignore innerContent and warn for other blocks', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 
 			const block = createBlock(

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -181,6 +181,37 @@ describe( 'block factory', () => {
 
 			expect( block.attributes ).toEqual( {} );
 		} );
+
+		it( 'should attach innerContent when the block type supports it', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				supports: {
+					innerContent: true,
+				},
+			} );
+
+			const block = createBlock(
+				'core/test-block',
+				{},
+				[],
+				[ '<div></div>' ]
+			);
+
+			expect( block.innerContent ).toEqual( [ '<div></div>' ] );
+		} );
+
+		it( 'should ignore innerContent when the block type lacks support', () => {
+			registerBlockType( 'core/test-block', defaultBlockSettings );
+
+			const block = createBlock(
+				'core/test-block',
+				{},
+				[],
+				[ '<div></div>' ]
+			);
+
+			expect( block.innerContent ).toBeUndefined();
+		} );
 	} );
 
 	describe( 'createBlocksFromInnerBlocksTemplate', () => {

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -391,6 +391,80 @@ describe( 'block serializer', () => {
 
 			expect( serializeBlock( block ) ).toBe( '<!-- wp:quote /-->' );
 		} );
+		it( 'serializes blocks with innerContent support from their static fragments', () => {
+			registerBlockType( 'core/static-html', {
+				apiVersion: 3,
+				category: 'text',
+				title: 'static html block',
+				supports: {
+					innerContent: true,
+				},
+				save: () => null,
+			} );
+			registerBlockType( 'core/fruit', {
+				apiVersion: 3,
+				category: 'text',
+				title: 'fruit block',
+				attributes: {
+					fruit: {
+						type: 'string',
+					},
+				},
+				save: ( { attributes } ) => attributes.fruit,
+			} );
+
+			const block = createBlock(
+				'core/static-html',
+				{},
+				[ createBlock( 'core/fruit', { fruit: 'Bananas' } ) ],
+				[ '<div>', null, '</div>' ]
+			);
+
+			expect( serializeBlock( block ) ).toBe(
+				'<!-- wp:static-html -->\n' +
+					'<div><!-- wp:fruit {"fruit":"Bananas"} -->\n' +
+					'Bananas\n' +
+					'<!-- /wp:fruit --></div>\n' +
+					'<!-- /wp:static-html -->'
+			);
+		} );
+		it( 'appends inner blocks missing an innerContent placeholder', () => {
+			registerBlockType( 'core/static-html', {
+				apiVersion: 3,
+				category: 'text',
+				title: 'static html block',
+				supports: {
+					innerContent: true,
+				},
+				save: () => null,
+			} );
+			registerBlockType( 'core/fruit', {
+				apiVersion: 3,
+				category: 'text',
+				title: 'fruit block',
+				attributes: {
+					fruit: {
+						type: 'string',
+					},
+				},
+				save: ( { attributes } ) => attributes.fruit,
+			} );
+
+			const block = createBlock(
+				'core/static-html',
+				{},
+				[ createBlock( 'core/fruit', { fruit: 'Bananas' } ) ],
+				[ '<div></div>' ]
+			);
+
+			expect( serializeBlock( block ) ).toBe(
+				'<!-- wp:static-html -->\n' +
+					'<div></div><!-- wp:fruit {"fruit":"Bananas"} -->\n' +
+					'Bananas\n' +
+					'<!-- /wp:fruit -->\n' +
+					'<!-- /wp:static-html -->'
+			);
+		} );
 	} );
 
 	describe( 'serialize()', () => {

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -391,14 +391,11 @@ describe( 'block serializer', () => {
 
 			expect( serializeBlock( block ) ).toBe( '<!-- wp:quote /-->' );
 		} );
-		it( 'serializes blocks with innerContent support from their static fragments', () => {
-			registerBlockType( 'core/static-html', {
+		it( 'serializes the Custom HTML block from its static fragments', () => {
+			registerBlockType( 'core/html', {
 				apiVersion: 3,
 				category: 'text',
-				title: 'static html block',
-				supports: {
-					innerContent: true,
-				},
+				title: 'Custom HTML',
 				save: () => null,
 			} );
 			registerBlockType( 'core/fruit', {
@@ -414,28 +411,25 @@ describe( 'block serializer', () => {
 			} );
 
 			const block = createBlock(
-				'core/static-html',
+				'core/html',
 				{},
 				[ createBlock( 'core/fruit', { fruit: 'Bananas' } ) ],
 				[ '<div>', null, '</div>' ]
 			);
 
 			expect( serializeBlock( block ) ).toBe(
-				'<!-- wp:static-html -->\n' +
+				'<!-- wp:html -->\n' +
 					'<div><!-- wp:fruit {"fruit":"Bananas"} -->\n' +
 					'Bananas\n' +
 					'<!-- /wp:fruit --></div>\n' +
-					'<!-- /wp:static-html -->'
+					'<!-- /wp:html -->'
 			);
 		} );
 		it( 'appends inner blocks missing an innerContent placeholder', () => {
-			registerBlockType( 'core/static-html', {
+			registerBlockType( 'core/html', {
 				apiVersion: 3,
 				category: 'text',
-				title: 'static html block',
-				supports: {
-					innerContent: true,
-				},
+				title: 'Custom HTML',
 				save: () => null,
 			} );
 			registerBlockType( 'core/fruit', {
@@ -451,18 +445,18 @@ describe( 'block serializer', () => {
 			} );
 
 			const block = createBlock(
-				'core/static-html',
+				'core/html',
 				{},
 				[ createBlock( 'core/fruit', { fruit: 'Bananas' } ) ],
 				[ '<div></div>' ]
 			);
 
 			expect( serializeBlock( block ) ).toBe(
-				'<!-- wp:static-html -->\n' +
+				'<!-- wp:html -->\n' +
 					'<div></div><!-- wp:fruit {"fruit":"Bananas"} -->\n' +
 					'Bananas\n' +
 					'<!-- /wp:fruit -->\n' +
-					'<!-- /wp:static-html -->'
+					'<!-- /wp:html -->'
 			);
 		} );
 	} );

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -488,6 +488,14 @@ export interface Block<
 	 */
 	innerBlocks: Block[];
 	/**
+	 * Static HTML fragments interleaved with inner blocks, for blocks with
+	 * the `innerContent` support. `null` entries mark the positions of the
+	 * inner blocks within the static markup. When present, this is the
+	 * canonical source of the block's own markup and is used for
+	 * serialization instead of the `save` implementation.
+	 */
+	innerContent?: Array< string | null >;
+	/**
 	 * Original content of the block before validation fixes.
 	 */
 	originalContent?: string;
@@ -872,6 +880,16 @@ export interface BlockSupports {
 	 * (default) false
 	 */
 	allowedBlocks?: boolean;
+
+	/**
+	 * Allows the block to keep static HTML fragments interleaved with inner
+	 * blocks as the canonical source of its own markup. When enabled, the
+	 * block is serialized from its parsed inner content instead of a `save`
+	 * implementation.
+	 *
+	 * (default) false
+	 */
+	innerContent?: boolean;
 
 	/**
 	 * Anchors let you link directly to a specific block on a page.

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -488,11 +488,11 @@ export interface Block<
 	 */
 	innerBlocks: Block[];
 	/**
-	 * Static HTML fragments interleaved with inner blocks, for blocks with
-	 * the `innerContent` support. `null` entries mark the positions of the
-	 * inner blocks within the static markup. When present, this is the
-	 * canonical source of the block's own markup and is used for
-	 * serialization instead of the `save` implementation.
+	 * Static HTML fragments interleaved with inner blocks, for the Custom HTML
+	 * block. `null` entries mark the positions of the inner blocks within the
+	 * static markup. When present, this is the canonical source of the block's
+	 * own markup and is used for serialization instead of the `save`
+	 * implementation.
 	 */
 	innerContent?: Array< string | null >;
 	/**
@@ -880,16 +880,6 @@ export interface BlockSupports {
 	 * (default) false
 	 */
 	allowedBlocks?: boolean;
-
-	/**
-	 * Allows the block to keep static HTML fragments interleaved with inner
-	 * blocks as the canonical source of its own markup. When enabled, the
-	 * block is serialized from its parsed inner content instead of a `save`
-	 * implementation.
-	 *
-	 * (default) false
-	 */
-	innerContent?: boolean;
 
 	/**
 	 * Anchors let you link directly to a specific block on a page.

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -46,6 +46,7 @@ export interface Block {
 	attributes: BlockAttributes;
 	clientId?: string;
 	innerBlocks: Block[];
+	innerContent?: Array< string | null >;
 	isValid?: boolean;
 	name: string;
 	originalContent?: string;

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -165,6 +165,64 @@ describe( 'crdt-blocks', () => {
 			expect( content.toString() ).toBe( 'Hello World' );
 		} );
 
+		it( 'syncs innerContent of static inner-content blocks into the Y.Doc', () => {
+			const incomingBlocks: Block[] = [
+				{
+					name: 'core/html',
+					attributes: {},
+					innerBlocks: [
+						{
+							name: 'core/paragraph',
+							attributes: { content: 'Editable' },
+							innerBlocks: [],
+							clientId: 'inner-1',
+						},
+					],
+					innerContent: [ '<div class="banner">', null, '</div>' ],
+					clientId: 'html-1',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, incomingBlocks, null );
+
+			const block = yblocks.get( 0 );
+			expect( block.get( 'innerContent' ) ).toEqual( [
+				'<div class="banner">',
+				null,
+				'</div>',
+			] );
+		} );
+
+		it( 'updates innerContent when the static markup changes', () => {
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/html',
+					attributes: {},
+					innerBlocks: [],
+					innerContent: [ '<p>one</p>' ],
+					clientId: 'html-1',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/html',
+					attributes: {},
+					innerBlocks: [],
+					innerContent: [ '<p>two</p>' ],
+					clientId: 'html-1',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			expect( yblocks.get( 0 ).get( 'innerContent' ) ).toEqual( [
+				'<p>two</p>',
+			] );
+		} );
+
 		it( 'updates existing blocks when content changes', () => {
 			const initialBlocks: Block[] = [
 				{

--- a/packages/widgets/src/blocks/legacy-widget/transforms.js
+++ b/packages/widgets/src/blocks/legacy-widget/transforms.js
@@ -15,9 +15,8 @@ const legacyWidgetTransforms = [
 	{
 		block: 'core/html',
 		widget: 'custom_html',
-		transform: ( { content } ) => ( {
-			content,
-		} ),
+		transformBlock: ( { content } ) =>
+			createBlock( 'core/html', {}, [], [ content ] ),
 	},
 	{
 		block: 'core/archives',
@@ -160,7 +159,7 @@ const legacyWidgetTransforms = [
 			};
 		},
 	},
-].map( ( { block, widget, transform } ) => {
+].map( ( { block, widget, transform, transformBlock } ) => {
 	return {
 		type: 'block',
 		blocks: [ block ],
@@ -168,10 +167,12 @@ const legacyWidgetTransforms = [
 			return idBase === widget && !! instance?.raw;
 		},
 		transform: ( { instance } ) => {
-			const transformedBlock = createBlock(
-				block,
-				transform ? transform( instance.raw ) : undefined
-			);
+			const transformedBlock = transformBlock
+				? transformBlock( instance.raw )
+				: createBlock(
+						block,
+						transform ? transform( instance.raw ) : undefined
+				  );
 			if ( ! instance.raw?.title ) {
 				return transformedBlock;
 			}

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -394,6 +394,11 @@
 					"type": "boolean",
 					"default": true
 				},
+				"innerContent": {
+					"description": "Allows the block to keep static HTML fragments interleaved with inner blocks as the canonical source of its own markup. When enabled, the block is serialized from its parsed inner content instead of a save implementation, and inner blocks are rendered at their positions within the static markup, where they can be edited in place but not moved, removed, or added to.",
+					"type": "boolean",
+					"default": false
+				},
 				"inserter": {
 					"description": "By default, all blocks will appear in the inserter, block transforms menu, Style Book, etc. To hide a block from all parts of the user interface so that it can only be inserted programmatically, set inserter to false.",
 					"type": "boolean",

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -394,11 +394,6 @@
 					"type": "boolean",
 					"default": true
 				},
-				"innerContent": {
-					"description": "Allows the block to keep static HTML fragments interleaved with inner blocks as the canonical source of its own markup. When enabled, the block is serialized from its parsed inner content instead of a save implementation, and inner blocks are rendered at their positions within the static markup, where they can be edited in place but not moved, removed, or added to.",
-					"type": "boolean",
-					"default": false
-				},
 				"inserter": {
 					"description": "By default, all blocks will appear in the inserter, block transforms menu, Style Book, etc. To hide a block from all parts of the user interface so that it can only be inserted programmatically, set inserter to false.",
 					"type": "boolean",

--- a/test/e2e/specs/editor/blocks/code.spec.js
+++ b/test/e2e/specs/editor/blocks/code.spec.js
@@ -90,12 +90,14 @@ test.describe( 'Code', () => {
 
 		test.describe( 'FROM HTML', () => {
 			test( 'should preserve the content', async ( { editor } ) => {
-				await editor.insertBlock( {
-					name: 'core/html',
-					attributes: {
-						content: 'initial content',
-					},
-				} );
+				// The HTML block's markup lives in its inner content, not in
+				// an attribute, so it can't be seeded via `insertBlock`.
+				await editor.setContent(
+					`<!-- wp:html -->\ninitial content\n<!-- /wp:html -->`
+				);
+				await editor.canvas
+					.locator( '[data-type="core/html"]' )
+					.click();
 				await editor.transformBlockTo( 'core/code' );
 				const codeBlock = ( await editor.getBlocks() )[ 0 ];
 				expect( codeBlock.name ).toBe( 'core/code' );
@@ -110,7 +112,6 @@ test.describe( 'Code', () => {
 				await editor.insertBlock( {
 					name: 'core/html',
 					attributes: {
-						content: 'initial content',
 						metadata: {
 							name: 'Custom name',
 						},

--- a/test/e2e/specs/editor/blocks/html.spec.js
+++ b/test/e2e/specs/editor/blocks/html.spec.js
@@ -63,7 +63,44 @@ test.describe( 'HTML block', () => {
 		await editor.publishPost();
 		await page.reload();
 		await expect(
-			editor.canvas.locator( '[data-type="core/html"] iframe' )
-		).toBeVisible();
+			editor.canvas.locator( '[data-type="core/html"]' )
+		).toContainText( '1 < 2' );
+	} );
+
+	test( 'supports editable inner blocks within static HTML', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.setContent(
+			`<!-- wp:html -->
+<div class="banner"><h1>Static heading</h1><!-- wp:paragraph -->
+<p>Editable paragraph</p>
+<!-- /wp:paragraph --><footer>Static footer</footer></div>
+<!-- /wp:html -->`
+		);
+
+		// The inner paragraph renders at its position within the static
+		// markup and is editable in place.
+		const paragraph = editor.canvas.locator(
+			'role=document[name="Block: Paragraph"i]'
+		);
+		await expect( paragraph ).toBeVisible();
+		await paragraph.click();
+		await page.keyboard.press( 'End' );
+		await page.keyboard.type( ' updated' );
+
+		expect( await editor.getEditedPostContent() ).toBe(
+			`<!-- wp:html -->
+<div class="banner"><h1>Static heading</h1><!-- wp:paragraph -->
+<p>Editable paragraph updated</p>
+<!-- /wp:paragraph --><footer>Static footer</footer></div>
+<!-- /wp:html -->`
+		);
+
+		// The inner block is locked: it cannot be removed or moved.
+		await editor.clickBlockOptionsMenuItem( 'Delete' ).catch( () => {} );
+		expect( await editor.getEditedPostContent() ).toContain(
+			'<p>Editable paragraph updated</p>'
+		);
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/html.spec.js
+++ b/test/e2e/specs/editor/blocks/html.spec.js
@@ -86,6 +86,7 @@ test.describe( 'HTML block', () => {
 		);
 		await expect( paragraph ).toBeVisible();
 		await paragraph.click();
+		await expect( paragraph ).toBeFocused();
 		await page.keyboard.press( 'End' );
 		await page.keyboard.type( ' updated' );
 
@@ -97,10 +98,19 @@ test.describe( 'HTML block', () => {
 <!-- /wp:html -->`
 		);
 
-		// The inner block is locked: it cannot be removed or moved.
-		await editor.clickBlockOptionsMenuItem( 'Delete' ).catch( () => {} );
-		expect( await editor.getEditedPostContent() ).toContain(
-			'<p>Editable paragraph updated</p>'
-		);
+		// The inner block is locked: the options menu offers no removal and
+		// the toolbar offers no movers.
+		await editor.clickBlockToolbarButton( 'Options' );
+		const optionsMenu = page.getByRole( 'menu', { name: 'Options' } );
+		await expect( optionsMenu ).toBeVisible();
+		await expect(
+			optionsMenu.getByRole( 'menuitem', { name: 'Delete' } )
+		).toBeHidden();
+		await page.keyboard.press( 'Escape' );
+		await expect(
+			page.locator(
+				'role=toolbar[name="Block tools"i] >> role=button[name="Move up"i]'
+			)
+		).toBeHidden();
 	} );
 } );

--- a/test/e2e/specs/editor/collaboration/collaboration-block-gauntlet.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-block-gauntlet.spec.ts
@@ -624,9 +624,17 @@ test.describe( 'Collaboration - Block Gauntlet', () => {
 			name: 'core/embed',
 			attributes: { caption: 'Embed A' },
 		} );
-		await editor.insertBlock( {
-			name: 'core/html',
-			attributes: { content: '<p>Hello HTML</p>' },
+		// The HTML block stores its markup as inner content, which
+		// `insertBlock` (attributes/innerBlocks only) can't express, so insert
+		// it directly via the data API.
+		await editor.page.evaluate( () => {
+			const block = window.wp.blocks.createBlock(
+				'core/html',
+				{},
+				[],
+				[ '<p>Hello HTML</p>' ]
+			);
+			window.wp.data.dispatch( 'core/block-editor' ).insertBlock( block );
 		} );
 		await editor.insertBlock( {
 			name: 'core/shortcode',
@@ -757,7 +765,7 @@ test.describe( 'Collaboration - Block Gauntlet', () => {
 				} );
 		} );
 
-		// HTML: edit via data API
+		// HTML: edit the static markup (stored as inner content) via data API.
 		await page2.evaluate( () => {
 			const blocks = window.wp.data
 				.select( 'core/block-editor' )
@@ -770,8 +778,8 @@ test.describe( 'Collaboration - Block Gauntlet', () => {
 			}
 			window.wp.data
 				.dispatch( 'core/block-editor' )
-				.updateBlockAttributes( html.clientId, {
-					content: '<div>Edited HTML</div>',
+				.updateBlock( html.clientId, {
+					innerContent: [ '<div>Edited HTML</div>' ],
 				} );
 		} );
 
@@ -832,8 +840,10 @@ test.describe( 'Collaboration - Block Gauntlet', () => {
 					attributes: { caption: 'Embed edited by B' },
 				},
 				{
+					// The HTML block's markup lives in inner content, which the
+					// default `getBlocks()` doesn't surface; it's asserted
+					// separately below.
 					name: 'core/html',
-					attributes: { content: '<div>Edited HTML</div>' },
 				},
 				{
 					name: 'core/shortcode',
@@ -848,6 +858,22 @@ test.describe( 'Collaboration - Block Gauntlet', () => {
 					attributes: { customText: 'Read more B' },
 				},
 			] );
+
+		// The HTML block's edited markup is stored as inner content (not an
+		// attribute), so assert it synced to both users via the full blocks.
+		const getHtmlInnerContent = async ( ed: typeof editor ) => {
+			const blocks = ( await ed.getBlocks( { full: true } ) ) as Array< {
+				name: string;
+				innerContent?: Array< string | null >;
+			} >;
+			return blocks.find( ( b ) => b.name === 'core/html' )?.innerContent;
+		};
+		await expect
+			.poll( () => getHtmlInnerContent( editor ), { timeout: 10_000 } )
+			.toEqual( [ '<div>Edited HTML</div>' ] );
+		await expect
+			.poll( () => getHtmlInnerContent( editor2 ), { timeout: 10_000 } )
+			.toEqual( [ '<div>Edited HTML</div>' ] );
 
 		// Verify both users have identical final block state.
 		const blocksA = await editor.getBlocks();

--- a/test/integration/fixtures/blocks/core__html.json
+++ b/test/integration/fixtures/blocks/core__html.json
@@ -2,9 +2,10 @@
 	{
 		"name": "core/html",
 		"isValid": true,
-		"attributes": {
-			"content": "<h1>Some HTML code</h1>\n<div>This is a div</div>"
-		},
-		"innerBlocks": []
+		"attributes": {},
+		"innerBlocks": [],
+		"innerContent": [
+			"\n<h1>Some HTML code</h1>\n<div>This is a div</div>\n"
+		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__html__inner-blocks.html
+++ b/test/integration/fixtures/blocks/core__html__inner-blocks.html
@@ -1,0 +1,5 @@
+<!-- wp:html -->
+<div class="banner"><h1>Static heading</h1><!-- wp:paragraph -->
+<p>Editable paragraph</p>
+<!-- /wp:paragraph --><footer>Static footer</footer></div>
+<!-- /wp:html -->

--- a/test/integration/fixtures/blocks/core__html__inner-blocks.json
+++ b/test/integration/fixtures/blocks/core__html__inner-blocks.json
@@ -1,0 +1,23 @@
+[
+	{
+		"name": "core/html",
+		"isValid": true,
+		"attributes": {},
+		"innerBlocks": [
+			{
+				"name": "core/paragraph",
+				"isValid": true,
+				"attributes": {
+					"content": "Editable paragraph",
+					"dropCap": false
+				},
+				"innerBlocks": []
+			}
+		],
+		"innerContent": [
+			"\n<div class=\"banner\"><h1>Static heading</h1>",
+			null,
+			"<footer>Static footer</footer></div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__html__inner-blocks.parsed.json
+++ b/test/integration/fixtures/blocks/core__html__inner-blocks.parsed.json
@@ -1,0 +1,21 @@
+[
+	{
+		"blockName": "core/html",
+		"attrs": {},
+		"innerBlocks": [
+			{
+				"blockName": "core/paragraph",
+				"attrs": {},
+				"innerBlocks": [],
+				"innerHTML": "\n<p>Editable paragraph</p>\n",
+				"innerContent": [ "\n<p>Editable paragraph</p>\n" ]
+			}
+		],
+		"innerHTML": "\n<div class=\"banner\"><h1>Static heading</h1><footer>Static footer</footer></div>\n",
+		"innerContent": [
+			"\n<div class=\"banner\"><h1>Static heading</h1>",
+			null,
+			"<footer>Static footer</footer></div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__html__inner-blocks.serialized.html
+++ b/test/integration/fixtures/blocks/core__html__inner-blocks.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:html -->
+<div class="banner"><h1>Static heading</h1><!-- wp:paragraph -->
+<p>Editable paragraph</p>
+<!-- /wp:paragraph --><footer>Static footer</footer></div>
+<!-- /wp:html -->

--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -49,6 +49,7 @@ const normalizeParsedBlocks = ( blocks ) =>
 		isValid: block.isValid,
 		attributes: JSON.parse( JSON.stringify( block.attributes ) ),
 		innerBlocks: normalizeParsedBlocks( block.innerBlocks ),
+		...( block.innerContent ? { innerContent: block.innerContent } : {} ),
 	} ) );
 
 describe( 'full post content fixture', () => {


### PR DESCRIPTION
## What?

Introduces a new block support, `innerContent`, that lets a block keep static HTML fragments interleaved with inner blocks as the canonical source of its own markup — and adopts it unconditionally in the Custom HTML block. This makes it possible to have editable blocks (a paragraph, an image…) at arbitrary positions deep inside an otherwise static HTML structure, without them being movable or removable like regular inner blocks.

```html
<!-- wp:html -->
<div class="banner"><h1>Static heading</h1><!-- wp:paragraph -->
<p>Editable paragraph</p>
<!-- /wp:paragraph --><footer>Static footer</footer></div>
<!-- /wp:html -->
```

## Why?

Complex hand-written HTML structures currently force a choice: either everything is static (HTML block) or everything is blocks. There's no way to mark just *parts* of an HTML structure as editable. The block grammar has always supported interleaved HTML and blocks (`innerContent` with `null` placeholders), but the in-memory model, serializer, and editor never exposed it for valid registered blocks.

## How?

**`@wordpress/blocks`** — the data layer:
- The parser retains the grammar's `innerContent` array on parsed blocks with the `innerContent` support and skips `save`-based validation: serializing the parsed content reproduces the input by construction.
- The serializer emits these blocks by interleaving the static fragments with their serialized inner blocks instead of calling `save` (inner blocks without a matching placeholder are defensively appended so content is never lost).
- `createBlock()` accepts an optional fourth `innerContent` argument; `getBlockFromExample()` passes it through.
- On the front end, `WP_Block::render()` already interleaves `inner_content` with rendered inner blocks, so no PHP changes are needed.

**`@wordpress/block-editor`** — a new private `InnerContent` component:
- Renders the static markup inert (assigning `innerHTML` never executes scripts; inline `on*` handlers are stripped) and portals each inner block's `BlockListBlock` into a `<wp-inner-block-slot>` placeholder at its position within the static markup.
- Inner blocks are editable in place but locked (`templateLock: 'all'`): no moving, removing, or inserting.
- Provides a layout context with no alignments — arbitrary static markup offers no layout to align against, so alignment controls are unavailable on the inner blocks.

**Custom HTML block**:
- Always runs in `innerContent` mode. The `content` attribute (`source: raw`) is removed — serialized output is byte-identical for existing content, so no deprecation or migration is needed.
- The canvas `SandBox` iframe is replaced by `InnerContent`. Note: scripts no longer execute in the canvas preview (styles still apply); the modal's preview keeps the `SandBox`.
- The code modal re-parses on update: `<!-- wp:* -->` delimited segments in the HTML tab become editable inner blocks.
- `listView` support is enabled so the inner blocks tree shows in the inspector, acting as a navigation aid for the editable parts (appender/reorder/delete stay disabled via the locking).
- All `core/html` creation sites updated (paste handler, the various convert-to-HTML flows, legacy widget transform); the widget editors' freeform-handler path parses and serializes back unchanged.

## Testing Instructions

1. `npm run dev` and start wp-env.
2. Insert a Custom HTML block, click "Edit HTML", and enter static HTML with a block delimited inside it, e.g.:
   ```html
   <div class="banner"><h1>Static</h1><!-- wp:paragraph --><p>Editable</p><!-- /wp:paragraph --><footer>Footer</footer></div>
   ```
3. Click Update. The paragraph should render at its position inside the static markup and be editable in place.
4. Verify the paragraph cannot be moved or removed (no movers, no Delete in its options menu) and offers no alignment controls.
5. Verify the inspector shows the inner blocks list, with spacing between the tabs and the "Edit code" button.
6. Save the post and reload: the saved markup is identical to what was entered; the paragraph edit persists at its position. Check the front end renders the full structure.
7. Regression-check existing HTML blocks (plain static content): create, edit, save — markup should be unchanged (note the canvas preview is no longer sandboxed, so scripts don't run there).

### Testing Instructions for Keyboard

1. Insert a Custom HTML block, then use Tab/Enter to activate "Edit HTML", type content including a paragraph block delimiter, Tab to "Update", press Enter.
2. Use arrow keys/Tab in the canvas writing flow to reach the inner paragraph and type — editing should work without a pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

