### PR TITLE
Icon block: Add CSS to preserve stroke-scaling

### DIFF
--- a/packages/block-library/src/icon/style.scss
+++ b/packages/block-library/src/icon/style.scss
@@ -23,3 +23,10 @@
 	width: 100%;
 	height: 100%;
 }
+
+// Maintain stroke-width: neutralize `vector-effect="non-scaling-stroke"` on
+// shape elements so stroked icons continue to scale their strokes with the
+// icon size, preserving existing visual behavior.
+:where(.wp-block-icon) svg :where(path, rect, circle, ellipse, line, polygon, polyline) {
+	vector-effect: none;
+}


### PR DESCRIPTION
## What?

Related to https://github.com/WordPress/gutenberg/pull/78808#issuecomment-4679386637

This PR explicitly sets the stroke-scaling effect of icons in the Icon block to be default, that strokes are maintained. 

There is no visual effect of applying this at the moment, but it adds a safeguard so that if/when #78808 lands, icons in the icon block retain their same visual effect. Without this, icons could look like this:

<img width="398" height="426" alt="image" src="https://github.com/user-attachments/assets/9cf01900-da64-4a57-97ca-b95505714ea7" />

With this CSS in place, they would instead look like this

<img width="882" height="1082" alt="image" src="https://github.com/user-attachments/assets/fd2bc15e-291e-464b-b649-ac32865db707" />

## Why?

Converting the icon library to be stroke-based would still be beneficial for the icon block. We could add a togglecontrol on whether to maintain the stroke-width or not, and even a slider to define the thickness of the stroke.

But for now, it would keep the visuals identical.

## Testing Instructions

Test the icon block with icons at various sizes. There should be no visual changes.
