### PR TITLE
Remove Spotlight mode when selecting block notes

### DIFF
--- a/packages/editor/src/components/collab-sidebar/note-thread.js
+++ b/packages/editor/src/components/collab-sidebar/note-thread.js
@@ -47,7 +47,7 @@ export function NoteThread( {
 	onKeyDown,
 } ) {
 	const isFloating = !! floating;
-	const { toggleBlockHighlight, selectBlock, toggleBlockSpotlight } = unlock(
+	const { toggleBlockHighlight, selectBlock } = unlock(
 		useDispatch( blockEditorStore )
 	);
 	const { selectNote } = unlock( useDispatch( editorStore ) );
@@ -136,7 +136,6 @@ export function NoteThread( {
 
 		selectNote( note.id );
 		focusNoteThread( note.id, sidebarRef.current );
-		toggleBlockSpotlight( note.blockClientId, true );
 		if ( !! note.blockClientId ) {
 			// Pass `null` as the second parameter to prevent focusing the block.
 			selectBlock( note.blockClientId, null );
@@ -145,7 +144,6 @@ export function NoteThread( {
 
 	const onDeselectNote = () => {
 		selectNote( undefined );
-		toggleBlockSpotlight( note.blockClientId, false );
 	};
 
 	const handleResolve = () => {


### PR DESCRIPTION
## What?
Closes #72860

This PR removes the global Spotlight mode from triggering when a user selects a block note in the sidebar.

## Why?
As discussed in the issue triggering the global Spotlight mode when selecting a note destroys the surrounding reading context. This makes it exceptionally difficult to understand structural change requests, as the surrounding blocks are faded out. We needed a less destructive visual indicator that maintains full canvas visibility.

## How?
Removed the `toggleBlockSpotlight` dispatches from the sidebar components (`comments.js` and `add-comment.js`). 

By falling back purely on the existing `selectBlock` and `toggleBlockHighlight` state handlers, the canvas opacity remains at 100%. Targeted blocks now safely inherit the standard blue outline indicator (identical to the List View hover interaction), preserving reading context while maintaining a clear visual anchor to the active note.

## Testing Instructions
1. Open a post or page in the Block Editor.
2. Add a few blocks (e.g., Paragraphs, Headings) to create some document context.
3. Open the Notes sidebar and add a note to a few blocks.
4. Click away into the canvas to deselect the note.
5. Click the note again in the right-hand sidebar. 
6. The targeted block receives a blue outline highlight, but the rest of the document remains at 100% opacity (Spotlight mode does not activate).

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/3e72afb4-7163-4a75-97ab-3d85faeff8a0