### PR TITLE
Style Book: Fix crash when previewing variations for blocks without examples

### DIFF
--- a/packages/editor/src/components/style-book/index.js
+++ b/packages/editor/src/components/style-book/index.js
@@ -216,7 +216,7 @@ export function getExamplesForSinglePageUse( examples ) {
  * @return {Array} Updated examples with variation applied.
  */
 function applyBlockVariationsToExamples( examples, variation ) {
-	if ( ! variation || ! examples ) {
+	if ( ! variation ) {
 		return examples;
 	}
 	return examples.map( ( example ) => {
@@ -500,7 +500,7 @@ export const StyleBookPreview = ( {
 			return { examples: examplesForSinglePageUse };
 		}
 
-		if ( blockVariation ) {
+		if ( blockVariation && filteredExamples?.examples?.length ) {
 			return {
 				examples: applyBlockVariationsToExamples(
 					filteredExamples.examples,

--- a/packages/editor/src/components/style-book/index.js
+++ b/packages/editor/src/components/style-book/index.js
@@ -216,7 +216,7 @@ export function getExamplesForSinglePageUse( examples ) {
  * @return {Array} Updated examples with variation applied.
  */
 function applyBlockVariationsToExamples( examples, variation ) {
-	if ( ! variation ) {
+	if ( ! variation || ! examples ) {
 		return examples;
 	}
 	return examples.map( ( example ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #79130

Adds a protective guard to `applyBlockVariationsToExamples` to prevent a `TypeError` crash when attempting to apply style variations to an undefined list of examples.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When opening the style variation detail screen for a block that does not have standalone Style Book examples (like `core/column`), the editor crashes. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added an early return inside `applyBlockVariationsToExamples` (in `packages/editor/src/components/style-book/index.js`) to check `if ( ! variation || ! examples )`. If `examples` evaluates to `undefined`, it safely returns early without calling `.map()`. This prevents the crash and allows the UI to gracefully render an empty/fallback preview state instead.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Go to Appearance > Editor to open the Site Editor.
2. Open the **Styles** panel (the half-black/half-white circle icon).
3. Click the **Eye icon** at the top right of the Styles sidebar to toggle the Style Book ON.
4. Go to **Blocks** and search for the **Column** block.
5. Click on the Column block, then click on any of its listed style variations (e.g., "Style 1").
6. Verify that the editor does not crash and the console is free of `TypeError: Cannot read properties of undefined (reading 'map')` errors.



## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="3818" height="1946" alt="image" src="https://github.com/user-attachments/assets/590a0ad5-7c43-40f8-a2a5-095a9b671088" />|<img width="1470" height="835" alt="image" src="https://github.com/user-attachments/assets/4ada2ab4-34fe-400c-9cbe-fd9d52018480" />|

