### PR TITLE
design-system-mcp: Remove Storybook dependency in TypeScript types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49667,8 +49667,7 @@
 				"design-system-mcp": "bin/design-system-mcp.mjs"
 			},
 			"devDependencies": {
-				"@types/jest": "^29.5.14",
-				"storybook": "^10.2.8"
+				"@types/jest": "^29.5.14"
 			},
 			"engines": {
 				"node": ">=20.10.0",

--- a/packages/design-system-mcp/CHANGELOG.md
+++ b/packages/design-system-mcp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Remove implicit dependency on `storybook` in TypeScript types.
+
 ## 0.5.0 (2026-06-10)
 
 ## 0.4.0 (2026-05-27)

--- a/packages/design-system-mcp/CHANGELOG.md
+++ b/packages/design-system-mcp/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Remove implicit dependency on `storybook` in TypeScript types.
+-   Remove implicit dependency on `storybook` in TypeScript types ([#79132](https://github.com/WordPress/gutenberg/pull/79132)).
 
 ## 0.5.0 (2026-06-10)
 
@@ -12,8 +12,8 @@
 
 ### Enhancements
 
--   `get_component_details` now optionally accepts an array of component names so multiple components can be fetched in a single call. ([#78185](https://github.com/WordPress/gutenberg/pull/78185))
--   The server now provides instructions on how AI agents should be expected to use it, improving discoverability and tool call efficiency. ([#78186](https://github.com/WordPress/gutenberg/pull/78186))
+-   `get_component_details` now optionally accepts an array of component names so multiple components can be fetched in a single call ([#78185](https://github.com/WordPress/gutenberg/pull/78185)).
+-   The server now provides instructions on how AI agents should be expected to use it, improving discoverability and tool call efficiency ([#78186](https://github.com/WordPress/gutenberg/pull/78186)).
 
 ## 0.3.0 (2026-05-14)
 

--- a/packages/design-system-mcp/package.json
+++ b/packages/design-system-mcp/package.json
@@ -46,8 +46,7 @@
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {
-		"@types/jest": "^29.5.14",
-		"storybook": "^10.2.8"
+		"@types/jest": "^29.5.14"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/design-system-mcp/src/test/parse-components.ts
+++ b/packages/design-system-mcp/src/test/parse-components.ts
@@ -154,7 +154,6 @@ function createComponents(
 				value.path ??
 				`../packages/ui/src/${ key }/stories/index.story.tsx`,
 			stories: [],
-			jsDocTags: {},
 			...value,
 		};
 	}

--- a/packages/design-system-mcp/src/types.ts
+++ b/packages/design-system-mcp/src/types.ts
@@ -1,6 +1,13 @@
-import type { ComponentManifest } from 'storybook/internal/types';
-
-export interface ManifestComponent extends ComponentManifest {
+export interface ManifestComponent {
+	id: string;
+	name: string;
+	path: string;
+	description?: string;
+	stories?: Array< {
+		name: string;
+		snippet?: string;
+		description?: string;
+	} >;
 	reactDocgen?: {
 		description?: string;
 		displayName?: string;


### PR DESCRIPTION
## What?

Related: https://github.com/WordPress/gutenberg/pull/79095#discussion_r3398607235

Updates `@wordpress/design-system-mcp` to remove `storybook` as a dependency.

## Why?

Fixes an issue where built TypeScript types have an implicit dependency on `storybook`, but it isn't defined as a dependency by the package. Defining `storybook` as a dependency of the MCP server is not acceptable because [it is a large dependency tree](https://npmgraph.js.org/?q=storybook), and the MCP server relies on recurring updates / installs to keep itself up to date ([via npx](https://github.com/WordPress/gutenberg/blob/trunk/packages/design-system-mcp/README.md#other-claude-desktop-vs-code)).

## How?

Replaces the TypeScript type sourced from `storybook` package internals with a duplicate copy.

The motivation for using the internal types is explained in https://github.com/WordPress/gutenberg/pull/78185#discussion_r3227505056, essentially as a way to provide some awareness when the internal shape changes, since the MCP relies on the shape of the component manifest. However, as explained later in the same thread, we have additional assurances for this through a separate validation step added in https://github.com/WordPress/gutenberg/commit/8f53c4194b150a7c11fa5205db61c803121b3b0f. Maintaining a duplicate type is some additional overhead for us, but it's much better than making `storybook` a dependency.

## Testing Instructions

Verify `npm run build` passes, which includes TypeScript type-checking.

Observe there are no references to `storybook` package in `packages/design-system-mcp/build-types` after build.

Observe that the "Validate manifest matches design-system-mcp contract" CI check on this pull request passes.

## Use of AI Tools

No AI was used.