### PR TITLE
Fix responsive element styles front end output

### DIFF
--- a/backport-changelog/7.1/12159.md
+++ b/backport-changelog/7.1/12159.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12159
+
+* https://github.com/WordPress/gutenberg/pull/79135

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -245,6 +245,89 @@ function gutenberg_get_root_state_style( $state_style, $nested_keys ) {
 }
 
 /**
+ * Generates all element selectors for a block root selector.
+ *
+ * @param string $root_selector The block root CSS selector.
+ * @return string[] Element selectors keyed by element name.
+ */
+function gutenberg_get_block_state_element_selectors( $root_selector ) {
+	if ( ! is_string( $root_selector ) || '' === trim( $root_selector ) ) {
+		return array();
+	}
+
+	$block_selectors   = gutenberg_split_selector_list( $root_selector );
+	$element_selectors = array();
+
+	foreach ( WP_Theme_JSON_Gutenberg::ELEMENTS as $element_name => $element_selector ) {
+		$selectors = array();
+
+		foreach ( $block_selectors as $block_selector ) {
+			$block_selector = trim( $block_selector );
+			if ( '' === $block_selector ) {
+				continue;
+			}
+
+			if ( $block_selector === $element_selector ) {
+				$selectors = array( $element_selector );
+				break;
+			}
+
+			$selector_prefix = "$block_selector ";
+			if ( ! str_contains( $element_selector, ',' ) ) {
+				$selectors[] = $selector_prefix . $element_selector;
+				continue;
+			}
+
+			$prepended_selectors = array();
+			foreach ( gutenberg_split_selector_list( $element_selector ) as $selector ) {
+				$prepended_selectors[] = $selector_prefix . $selector;
+			}
+			$selectors[] = implode( ',', $prepended_selectors );
+		}
+
+		if ( ! empty( $selectors ) ) {
+			$element_selectors[ $element_name ] = implode( ',', $selectors );
+		}
+	}
+
+	return $element_selectors;
+}
+
+/**
+ * Adds a compiled state style rule to a rule list.
+ *
+ * @param array       $css_rules   Style rules.
+ * @param string      $state       Pseudo-state selector.
+ * @param string|null $selector    Block, feature, or element selector.
+ * @param array       $style       Style object.
+ * @param string|null $rules_group Optional CSS grouping rule, e.g. a media query.
+ */
+function gutenberg_add_block_state_style_rule( &$css_rules, $state, $selector, $style, $rules_group = null ) {
+	if ( empty( $style ) || ! is_array( $style ) ) {
+		return;
+	}
+
+	$style = gutenberg_get_state_style_with_fallback_dimension_styles( $style );
+
+	$compiled = gutenberg_style_engine_get_styles(
+		gutenberg_normalize_state_style_for_css_output( $style )
+	);
+
+	if ( empty( $compiled['declarations'] ) ) {
+		return;
+	}
+
+	$css_rules[] = array(
+		'state'        => $state,
+		'selector'     => $selector,
+		'declarations' => $compiled['declarations'],
+	);
+	if ( ! empty( $rules_group ) ) {
+		$css_rules[ count( $css_rules ) - 1 ]['rules_group'] = $rules_group;
+	}
+}
+
+/**
  * Builds compiled state style rules, preserving the selector each rule targets.
  *
  * @param array         $state_styles Map of state to style array.
@@ -264,21 +347,13 @@ function gutenberg_get_block_state_style_rules( $state_styles, $block_type, $rul
 		}
 
 		foreach ( gutenberg_get_state_style_groups( $state_style, $block_selectors ) as $group ) {
-			$style    = gutenberg_get_state_style_with_fallback_dimension_styles( $group['style'] );
-			$compiled = gutenberg_style_engine_get_styles(
-				gutenberg_normalize_state_style_for_css_output( $style )
+			gutenberg_add_block_state_style_rule(
+				$css_rules,
+				$state,
+				$group['selector'],
+				$group['style'],
+				$rules_group
 			);
-
-			if ( ! empty( $compiled['declarations'] ) ) {
-				$css_rules[] = array(
-					'state'        => $state,
-					'selector'     => $group['selector'],
-					'declarations' => $compiled['declarations'],
-				);
-				if ( ! empty( $rules_group ) ) {
-					$css_rules[ count( $css_rules ) - 1 ]['rules_group'] = $rules_group;
-				}
-			}
 		}
 	}
 
@@ -440,6 +515,59 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 					$media_query
 				)
 			);
+		}
+
+		if (
+			! empty( $style[ $breakpoint ]['elements'] ) &&
+			is_array( $style[ $breakpoint ]['elements'] )
+		) {
+			$element_selectors = gutenberg_get_block_state_element_selectors(
+				wp_get_block_css_selector( $block_type )
+			);
+
+			foreach (
+				$style[ $breakpoint ]['elements'] as $element_name => $element_style
+			) {
+				if (
+					empty( $element_style ) ||
+					! is_array( $element_style ) ||
+					empty( $element_selectors[ $element_name ] )
+				) {
+					continue;
+				}
+
+				$element_pseudo_states = WP_Theme_JSON_Gutenberg::VALID_ELEMENT_PSEUDO_SELECTORS[ $element_name ]
+					?? array();
+				$root_element_style    = gutenberg_get_root_state_style(
+					$element_style,
+					$element_pseudo_states
+				);
+
+				gutenberg_add_block_state_style_rule(
+					$css_rules,
+					'',
+					$element_selectors[ $element_name ],
+					$root_element_style,
+					$media_query
+				);
+
+				foreach ( $element_pseudo_states as $pseudo_state ) {
+					if (
+						empty( $element_style[ $pseudo_state ] ) ||
+						! is_array( $element_style[ $pseudo_state ] )
+					) {
+						continue;
+					}
+
+					gutenberg_add_block_state_style_rule(
+						$css_rules,
+						$pseudo_state,
+						$element_selectors[ $element_name ],
+						$element_style[ $pseudo_state ],
+						$media_query
+					);
+				}
+			}
 		}
 
 		foreach ( $supported_pseudo_states as $pseudo_state ) {

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -816,6 +816,47 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a responsive element color generates media-query scoped CSS.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_responsive_element_color_generates_media_query_scoped_css() {
+		$this->ensure_block_registered( 'core/group' );
+
+		$block_content = '<div class="wp-block-group"><p><a href="#">Link</a></p></div>';
+		$block         = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'style' => array(
+					'mobile' => array(
+						'elements' => array(
+							'link' => array(
+								'color' => array(
+									'text' => '#00ff00',
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertMatchesRegularExpression(
+			'/^<div class="wp-block-group (wp-states-[a-f0-9]{8})"><p><a href="#">Link<\/a><\/p><\/div>$/',
+			$actual
+		);
+		preg_match( '/wp-states-[a-f0-9]{8}/', $actual, $matches );
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertStringContainsString(
+			'@media (width <= 480px){.' . $matches[0] . ' a:where(:not(.wp-element-button)){color:#00ff00 !important;}}',
+			$actual_stylesheet
+		);
+	}
+
+	/**
 	 * Tests that a responsive pseudo-state generates media-query scoped CSS.
 	 *
 	 * @covers ::gutenberg_render_block_states_support


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Part of #77817.

Viewport-specific state styles for elements such as Link or Heading were not being output on the front end. This PR fixes that.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Paragraph with a link in it to a post.
2. Style the link colour, then go into states > tablet and states > mobile and pick different colours for the link element there.
3. Save and view the front end: the colours should be correct at different viewport sizes.


<img width="703" height="214" alt="Screenshot 2026-06-12 at 11 54 12 am" src="https://github.com/user-attachments/assets/c7f4523c-2d64-471e-88de-741b26e585d2" />
