### PR TITLE
Configure Flakiness.io reporting

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -25,6 +25,7 @@ jobs:
         runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
+            id-token: write
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             fail-fast: false
@@ -56,7 +57,7 @@ jobs:
               env:
                   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
               run: |
-                  xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run --workspace @wordpress/e2e-tests-playwright test:e2e -- --shard=${{ matrix.part }}/${{ matrix.totalParts }}
+                  xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run --workspace @wordpress/e2e-tests-playwright test:e2e:shard -- --shard=${{ matrix.part }}/${{ matrix.totalParts }}
 
             - name: Archive blob reports (HTML)
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 			],
 			"devDependencies": {
 				"@eslint/eslintrc": "^3.0.0",
-				"@flakiness/jest": "^1.2.0",
+				"@flakiness/jest": "^1.3.0",
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
 				"@typescript/native-preview": "^7.0.0-dev.20260423.1",
@@ -3951,134 +3951,27 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/@flakiness/flakiness-report": {
-			"version": "0.34.0",
-			"resolved": "https://registry.npmjs.org/@flakiness/flakiness-report/-/flakiness-report-0.34.0.tgz",
-			"integrity": "sha512-37SRIky7mnMhV9Go/VO3pwo5r0ZQ5h/rTYmQBWdIyty2ZGylEUdbxZ+Yz2wCJwlmVeK9V8VWm0pInAjxUJ/x5g==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"zod": "^4.1.12"
-			}
-		},
 		"node_modules/@flakiness/jest": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@flakiness/jest/-/jest-1.2.0.tgz",
-			"integrity": "sha512-jgkHnPubQk/NeJeItItYEjo2+rsBsdJ2mimFE7+mRunSvfuO5LakQKHGE7W4nWX6wT8hh8c7oYValaOeDre3sg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@flakiness/jest/-/jest-1.3.0.tgz",
+			"integrity": "sha512-CoDNyQARev5Kx2XGl/a3pQhfFLWM8LDNxQwXl1GbC012R0+PgeNligAKJG+Ceh0mIbtUfH73+366B3go1pEhng==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"@flakiness/flakiness-report": "^0.34.0",
-				"@flakiness/sdk": "^3.2.0",
-				"stack-utils": "^2.0.6"
-			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@flakiness/playwright": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@flakiness/playwright/-/playwright-1.13.0.tgz",
-			"integrity": "sha512-9bT6zkFIcsXwU5OsowIu4HXTPcEe8TVk8I538LJbkZpKIX7RMoUNU3StxK97hYN3P22VONO5yllHJAf3bD13+g==",
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/@flakiness/playwright/-/playwright-1.14.0.tgz",
+			"integrity": "sha512-RaMESoTsmxgfw4aFOfMof02+0SLkr0+/KMMTKU9X6Ontk3XVE/35ARSXfxwjrFlVp8rbHpnYElz7YgkdSKh5Gg==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"@flakiness/flakiness-report": "^0.34.0",
-				"@flakiness/sdk": "^3.3.1"
-			},
 			"bin": {
 				"flakiness-playwright-shard": "lib/flakiness-playwright-shard.js"
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@flakiness/sdk": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@flakiness/sdk/-/sdk-3.3.1.tgz",
-			"integrity": "sha512-LrV+g246Oo9MSpVKU9bY/UHOYglwcqr0e4I6Vz0RGhHtOyrR2xZRCVzsM4crItDvNbIW4/9AJSRwQ5nptCykvw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.4.3",
-				"open": "^10.2.0",
-				"stable-hash": "^0.0.6",
-				"which": "^6.0.1",
-				"zod": "^4.3.5"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			},
-			"peerDependencies": {
-				"@flakiness/flakiness-report": ">=0.26.0 <1.0.0"
-			}
-		},
-		"node_modules/@flakiness/sdk/node_modules/define-lazy-prop": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@flakiness/sdk/node_modules/isexe": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
-			"integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/@flakiness/sdk/node_modules/open": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-			"integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"default-browser": "^5.2.1",
-				"define-lazy-prop": "^3.0.0",
-				"is-inside-container": "^1.0.0",
-				"wsl-utils": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@flakiness/sdk/node_modules/which": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
-			"integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^4.0.0"
-			},
-			"bin": {
-				"node-which": "bin/which.js"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@flakiness/sdk/node_modules/zod": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@floating-ui/core": {
@@ -42204,13 +42097,6 @@
 				"figgy-pudding": "^3.5.1"
 			}
 		},
-		"node_modules/stable-hash": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.6.tgz",
-			"integrity": "sha512-0afH4mobqTybYZsXImQRLOjHV4gvOW+92HdUIax9t7a8d9v54KWykEuMVIcXhD9BCi+w3kS4x7O6fmZQ3JlG/g==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/stable-hash-x": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
@@ -54502,7 +54388,7 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@flakiness/playwright": "^1.13.0",
+				"@flakiness/playwright": "^1.14.0",
 				"@playwright/test": "^1.58.2",
 				"@types/node": "^20.19.39",
 				"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 			],
 			"devDependencies": {
 				"@eslint/eslintrc": "^3.0.0",
+				"@flakiness/playwright": "^1.13.0",
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
 				"@typescript/native-preview": "^7.0.0-dev.20260423.1",
@@ -3948,6 +3949,121 @@
 			"integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/@flakiness/flakiness-report": {
+			"version": "0.34.0",
+			"resolved": "https://registry.npmjs.org/@flakiness/flakiness-report/-/flakiness-report-0.34.0.tgz",
+			"integrity": "sha512-37SRIky7mnMhV9Go/VO3pwo5r0ZQ5h/rTYmQBWdIyty2ZGylEUdbxZ+Yz2wCJwlmVeK9V8VWm0pInAjxUJ/x5g==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"zod": "^4.1.12"
+			}
+		},
+		"node_modules/@flakiness/playwright": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@flakiness/playwright/-/playwright-1.13.0.tgz",
+			"integrity": "sha512-9bT6zkFIcsXwU5OsowIu4HXTPcEe8TVk8I538LJbkZpKIX7RMoUNU3StxK97hYN3P22VONO5yllHJAf3bD13+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@flakiness/flakiness-report": "^0.34.0",
+				"@flakiness/sdk": "^3.3.1"
+			},
+			"bin": {
+				"flakiness-playwright-shard": "lib/flakiness-playwright-shard.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@flakiness/sdk": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@flakiness/sdk/-/sdk-3.3.1.tgz",
+			"integrity": "sha512-LrV+g246Oo9MSpVKU9bY/UHOYglwcqr0e4I6Vz0RGhHtOyrR2xZRCVzsM4crItDvNbIW4/9AJSRwQ5nptCykvw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"open": "^10.2.0",
+				"stable-hash": "^0.0.6",
+				"which": "^6.0.1",
+				"zod": "^4.3.5"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			},
+			"peerDependencies": {
+				"@flakiness/flakiness-report": ">=0.26.0 <1.0.0"
+			}
+		},
+		"node_modules/@flakiness/sdk/node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@flakiness/sdk/node_modules/isexe": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+			"integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@flakiness/sdk/node_modules/open": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+			"integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"default-browser": "^5.2.1",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"wsl-utils": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@flakiness/sdk/node_modules/which": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+			"integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^4.0.0"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@flakiness/sdk/node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@floating-ui/core": {
@@ -20233,6 +20349,22 @@
 			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
 			"integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ=="
 		},
+		"node_modules/bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"run-applescript": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/byte-size": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/byte-size/-/byte-size-8.1.1.tgz",
@@ -23157,6 +23289,36 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/default-browser": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+			"integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+			"integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/default-gateway": {
@@ -39987,6 +40149,19 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/run-applescript": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+			"integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/run-async": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
@@ -42014,6 +42189,13 @@
 				"figgy-pudding": "^3.5.1"
 			}
 		},
+		"node_modules/stable-hash": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.6.tgz",
+			"integrity": "sha512-0afH4mobqTybYZsXImQRLOjHV4gvOW+92HdUIax9t7a8d9v54KWykEuMVIcXhD9BCi+w3kS4x7O6fmZQ3JlG/g==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/stable-hash-x": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
@@ -42151,52 +42333,6 @@
 				"storybook": "^10.0.0"
 			}
 		},
-		"node_modules/storybook/node_modules/bundle-name": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"run-applescript": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/storybook/node_modules/default-browser": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
-			"integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bundle-name": "^4.1.0",
-				"default-browser-id": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/storybook/node_modules/default-browser-id": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-			"integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/storybook/node_modules/define-lazy-prop": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -42244,19 +42380,6 @@
 			},
 			"engines": {
 				"node": ">= 4"
-			}
-		},
-		"node_modules/storybook/node_modules/run-applescript": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-			"integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/storybook/node_modules/ws": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 			],
 			"devDependencies": {
 				"@eslint/eslintrc": "^3.0.0",
+				"@flakiness/jest": "^1.2.0",
 				"@flakiness/playwright": "^1.13.0",
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
@@ -3959,6 +3960,21 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"zod": "^4.1.12"
+			}
+		},
+		"node_modules/@flakiness/jest": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@flakiness/jest/-/jest-1.2.0.tgz",
+			"integrity": "sha512-jgkHnPubQk/NeJeItItYEjo2+rsBsdJ2mimFE7+mRunSvfuO5LakQKHGE7W4nWX6wT8hh8c7oYValaOeDre3sg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@flakiness/flakiness-report": "^0.34.0",
+				"@flakiness/sdk": "^3.2.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@flakiness/playwright": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
 			"devDependencies": {
 				"@eslint/eslintrc": "^3.0.0",
 				"@flakiness/jest": "^1.2.0",
-				"@flakiness/playwright": "^1.13.0",
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
 				"@typescript/native-preview": "^7.0.0-dev.20260423.1",
@@ -54503,6 +54502,7 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
+				"@flakiness/playwright": "^1.13.0",
 				"@playwright/test": "^1.58.2",
 				"@types/node": "^20.19.39",
 				"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54511,7 +54511,8 @@
 				"esbuild": "^0.27.2",
 				"filenamify": "^4.2.0",
 				"ws": "^8.18.3",
-				"y-websocket": "^3.0.0"
+				"y-websocket": "^3.0.0",
+				"zod": "^4.1.12"
 			}
 		},
 		"test/e2e/node_modules/ws": {
@@ -54534,6 +54535,16 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"test/e2e/node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"test/integration": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.0.0",
 		"@flakiness/jest": "^1.2.0",
-		"@flakiness/playwright": "^1.13.0",
 		"@types/react": "^18.3.27",
 		"@types/react-dom": "^18.3.1",
 		"@typescript/native-preview": "^7.0.0-dev.20260423.1",
@@ -89,10 +88,7 @@
 		"wait-on": "^8.0.1"
 	},
 	"overrides": {
-		"jsdom": "26.1.0",
-		"@flakiness/flakiness-report": {
-			"zod": "^4.1.12"
-		}
+		"jsdom": "26.1.0"
 	},
 	"scripts": {
 		"build": "npm run --workspace @wordpress/build-scripts build:all --",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,10 @@
 		"wait-on": "^8.0.1"
 	},
 	"overrides": {
-		"jsdom": "26.1.0"
+		"jsdom": "26.1.0",
+		"@flakiness/flakiness-report": {
+			"zod": "^4.1.12"
+		}
 	},
 	"scripts": {
 		"build": "npm run --workspace @wordpress/build-scripts build:all --",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 	},
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.0.0",
-		"@flakiness/jest": "^1.2.0",
+		"@flakiness/jest": "^1.3.0",
 		"@types/react": "^18.3.27",
 		"@types/react-dom": "^18.3.1",
 		"@typescript/native-preview": "^7.0.0-dev.20260423.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,10 @@
 		"wait-on": "^8.0.1"
 	},
 	"overrides": {
-		"jsdom": "26.1.0"
+		"jsdom": "26.1.0",
+		"@flakiness/flakiness-report": {
+			"zod": "^4.1.12"
+		}
 	},
 	"scripts": {
 		"build": "npm run --workspace @wordpress/build-scripts build:all --",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
 	},
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.0.0",
+		"@flakiness/jest": "^1.2.0",
 		"@flakiness/playwright": "^1.13.0",
 		"@types/react": "^18.3.27",
 		"@types/react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
 	},
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.0.0",
+		"@flakiness/playwright": "^1.13.0",
 		"@types/react": "^18.3.27",
 		"@types/react-dom": "^18.3.1",
 		"@typescript/native-preview": "^7.0.0-dev.20260423.1",

--- a/package.json
+++ b/package.json
@@ -88,10 +88,7 @@
 		"wait-on": "^8.0.1"
 	},
 	"overrides": {
-		"jsdom": "26.1.0",
-		"@flakiness/flakiness-report": {
-			"zod": "^4.1.12"
-		}
+		"jsdom": "26.1.0"
 	},
 	"scripts": {
 		"build": "npm run --workspace @wordpress/build-scripts build:all --",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -21,7 +21,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"devDependencies": {
-		"@flakiness/playwright": "^1.13.0",
+		"@flakiness/playwright": "^1.14.0",
 		"@playwright/test": "^1.58.2",
 		"@types/node": "^20.19.39",
 		"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -36,6 +36,7 @@
 	},
 	"scripts": {
 		"test:e2e": "wp-scripts test-playwright --config playwright.config.ts",
+		"test:e2e:shard": "flakiness-playwright-shard --config playwright.config.ts",
 		"test:e2e:debug": "wp-scripts test-playwright --config playwright.config.ts --ui",
 		"test:e2e:rtc-websocket": "wp-scripts test-playwright --config playwright.rtc-websocket.config.ts",
 		"test:e2e:rtc-websocket:debug": "wp-scripts test-playwright --config playwright.rtc-websocket.config.ts --ui"

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -32,11 +32,6 @@
 		"ws": "^8.18.3",
 		"y-websocket": "^3.0.0"
 	},
-	"overrides": {
-		"@flakiness/flakiness-report": {
-			"zod": "^4.1.12"
-		}
-	},
 	"publishConfig": {
 		"access": "public"
 	},

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -21,6 +21,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"devDependencies": {
+		"@flakiness/playwright": "^1.13.0",
 		"@playwright/test": "^1.58.2",
 		"@types/node": "^20.19.39",
 		"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
@@ -30,6 +31,11 @@
 		"filenamify": "^4.2.0",
 		"ws": "^8.18.3",
 		"y-websocket": "^3.0.0"
+	},
+	"overrides": {
+		"@flakiness/flakiness-report": {
+			"zod": "^4.1.12"
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -30,7 +30,8 @@
 		"esbuild": "^0.27.2",
 		"filenamify": "^4.2.0",
 		"ws": "^8.18.3",
-		"y-websocket": "^3.0.0"
+		"y-websocket": "^3.0.0",
+		"zod": "^4.1.12"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -24,7 +24,15 @@ const config = defineConfig( {
 		command: 'npm run --prefix ../.. wp-env-test -- start',
 	},
 	reporter: process.env.CI
-		? [ [ 'github' ], [ './config/flaky-tests-reporter.ts' ], [ 'blob' ] ]
+		? [
+				[ 'github' ],
+				[ './config/flaky-tests-reporter.ts' ],
+				[ 'blob' ],
+				[
+					'@flakiness/playwright',
+					{ flakinessProject: 'WordPress/gutenberg' },
+				],
+		  ]
 		: 'list',
 	workers: 1,
 	globalSetup: fileURLToPath(

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -58,6 +58,7 @@ module.exports = {
 	testEnvironmentOptions: {
 		url: 'http://localhost/',
 	},
+	testLocationInResults: true,
 	testPathIgnorePatterns: [
 		'/.git/',
 		'/node_modules/',
@@ -91,5 +92,6 @@ module.exports = {
 	reporters: [
 		'default',
 		'<rootDir>packages/scripts/config/jest-github-actions-reporter/index.js',
+		[ '@flakiness/jest', { flakinessProject: 'WordPress/gutenberg' } ],
 	],
 };


### PR DESCRIPTION
## What?
This configures Flakiness.io test reporting to track the reliability of the project's E2E tests.

From #78605:

> Flakiness.io is a GitHub-native test analytics dashboard that tracks flaky tests and detects regressions in pull requests....Flakiness.io uses historical test timings to produce better-balanced shards.

Closes #78605.

<!-- In a few words, what is the PR actually doing? -->

## Why?
Deeper insight into tests is never a bad thing. If there's agreement to implement, this service will be tested for ~90 days to see how it works for the WordPress project.

## Use of AI Tools

None.