### PR TITLE
Global styles revisions: replace active text with badge

### DIFF
--- a/packages/global-styles-ui/src/screen-revisions/revisions-buttons.tsx
+++ b/packages/global-styles-ui/src/screen-revisions/revisions-buttons.tsx
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button, Composite } from '@wordpress/components';
+import {
+	Button,
+	Composite,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { dateI18n, getDate, humanTimeDiff, getSettings } from '@wordpress/date';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
@@ -13,6 +17,9 @@ import { ENTER, SPACE } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import type { Revision } from './types';
+import { unlock } from '../lock-unlock';
+
+const { Badge: WCBadge } = unlock( componentsPrivateApis );
 
 const DAY_IN_MILLISECONDS = 60 * 60 * 1000 * 24;
 
@@ -229,11 +236,12 @@ function RevisionsButtons( {
 						</span>
 						{ isSelected &&
 							( areStylesEqual ? (
-								<p className="global-styles-ui-screen-revisions__applied-text">
-									{ __(
-										'These styles are already applied to your site.'
-									) }
-								</p>
+								<WCBadge
+									className="global-styles-ui-screen-revisions__active-badge"
+									intent="info"
+								>
+									{ __( 'Active' ) }
+								</WCBadge>
 							) : (
 								<Button
 									size="compact"

--- a/packages/global-styles-ui/src/screen-revisions/style.scss
+++ b/packages/global-styles-ui/src/screen-revisions/style.scss
@@ -70,8 +70,7 @@
 		}
 
 		.global-styles-ui-screen-revisions__changes > li,
-		.global-styles-ui-screen-revisions__meta,
-		.global-styles-ui-screen-revisions__applied-text {
+		.global-styles-ui-screen-revisions__meta {
 			color: $gray-900;
 		}
 	}
@@ -98,15 +97,14 @@
 }
 
 .global-styles-ui-screen-revisions__apply-button.is-primary,
-.global-styles-ui-screen-revisions__applied-text {
+.global-styles-ui-screen-revisions__active-badge {
 	align-self: flex-start;
 	// Left margin = left padding of .global-styles-ui-screen-revisions__revision-item-wrapper.
-	margin: $grid-unit-05 $grid-unit-15 $grid-unit-15 $grid-unit-50;
+	margin: 0 $grid-unit-15 $grid-unit-15 $grid-unit-50;
 }
 
 .global-styles-ui-screen-revisions__changes,
-.global-styles-ui-screen-revisions__meta,
-.global-styles-ui-screen-revisions__applied-text {
+.global-styles-ui-screen-revisions__meta {
 	color: $gray-700;
 	font-size: 12px;
 }


### PR DESCRIPTION


## What?
Replace the text  - _"These styles are already applied to your site."_ -  with a single `<Active intent="info" />` in the global styles revision rows.

According to the [components library](https://wordpress.github.io/gutenberg/?path=/docs/components-badge--docs&args=intent:info) the current `<Badge />` 

> will be superseded by `Badge` in `@wordpress/ui`, but continue using for now.

Should be fine.

Props to @talldan for the [idea](https://github.com/WordPress/gutenberg/pull/77333#discussion_r3400519439).

## Why?

Save space. Less to read, fewer words to parse. Neater. Zen.

## How?

Replaced text with component.



## Testing Instructions

1. Open the site editor make a change to global styles, e.g. change the background color or apply a style variation. Save it.
2. Make a couple of other changes so the global styles revisions button appears.
3. For every revision that matches the currently-saved global styles, an **Active** badge should appear.



## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="272" height="552" alt="Screenshot 2026-06-12 at 2 38 29 pm" src="https://github.com/user-attachments/assets/36c541e7-bd16-447b-b6f9-0263a2ba52d2" />|<img width="271" height="502" alt="Screenshot 2026-06-12 at 2 38 52 pm" src="https://github.com/user-attachments/assets/a4b2182d-c5fc-48be-a616-752981911a63" />|



## Use of AI Tools

None. 