### PR TITLE
Media editor: Snap crop handles to source pixels

### DIFF
--- a/packages/media-editor/src/image-editor/core/constants.ts
+++ b/packages/media-editor/src/image-editor/core/constants.ts
@@ -28,7 +28,7 @@ export const MAX_ZOOM = 10;
  * enough to allow tight crops (favicons, icons). Adjust here to tune the
  * floor globally.
  */
-export const MIN_CROP_PIXELS = 4;
+export const MIN_CROP_PIXELS = 16;
 
 /**
  * Minimum on-screen crop rect dimension in CSS pixels. The source-pixel

--- a/packages/media-editor/src/image-editor/core/constants.ts
+++ b/packages/media-editor/src/image-editor/core/constants.ts
@@ -28,7 +28,7 @@ export const MAX_ZOOM = 10;
  * enough to allow tight crops (favicons, icons). Adjust here to tune the
  * floor globally.
  */
-export const MIN_CROP_PIXELS = 24;
+export const MIN_CROP_PIXELS = 4;
 
 /**
  * Minimum on-screen crop rect dimension in CSS pixels. The source-pixel

--- a/packages/media-editor/src/image-editor/core/constants.ts
+++ b/packages/media-editor/src/image-editor/core/constants.ts
@@ -57,6 +57,13 @@ export const SETTLE_TARGET_CANVAS_FILL = 0.8;
 export const MAX_VIEW_SCALE = 8;
 
 /**
+ * CSS pixels per source pixel required before resize handles snap the selected
+ * source region to whole-pixel edges. Below 1:1, a source pixel is sub-pixel on
+ * screen, so snapping would feel notchy without a visible pixel boundary.
+ */
+export const PIXEL_SNAP_DISPLAY_SCALE = 1;
+
+/**
  * Wheel zoom sensitivity. A deltaY of 100 changes zoom by 0.25.
  * This could be made configurable as a prop to the Cropper component.
  */

--- a/packages/media-editor/src/image-editor/core/source-region.ts
+++ b/packages/media-editor/src/image-editor/core/source-region.ts
@@ -202,6 +202,13 @@ function getCropRectFromSourceRegion(
 	};
 }
 
+interface SourcePixelSnapEdges {
+	left: boolean;
+	top: boolean;
+	right: boolean;
+	bottom: boolean;
+}
+
 /**
  * Snap a crop rect so the selected source-region edges land on whole pixels.
  *
@@ -220,24 +227,55 @@ export function snapCropRectToSourcePixels(
 	cropRect: NormalizedRect,
 	handle: HandlePosition
 ): NormalizedRect {
+	return snapCropRectEdgesToSourcePixels( state, imageSize, cropRect, {
+		left: handle.includes( 'w' ),
+		top: handle.includes( 'n' ),
+		right: handle.includes( 'e' ),
+		bottom: handle.includes( 's' ),
+	} );
+}
+
+/**
+ * Snap all source-region edges for a crop rect to the nearest whole pixels.
+ *
+ * @param state     The current cropper state.
+ * @param imageSize The natural dimensions of the source image.
+ * @param cropRect  The crop rect to align to the source-pixel grid.
+ * @return A crop rect whose source-region edges are whole pixels.
+ */
+export function snapCropRectToSourcePixelGrid(
+	state: CropperState,
+	imageSize: Size,
+	cropRect: NormalizedRect
+): NormalizedRect {
+	return snapCropRectEdgesToSourcePixels( state, imageSize, cropRect, {
+		left: true,
+		top: true,
+		right: true,
+		bottom: true,
+	} );
+}
+
+function snapCropRectEdgesToSourcePixels(
+	state: CropperState,
+	imageSize: Size,
+	cropRect: NormalizedRect,
+	edges: SourcePixelSnapEdges
+): NormalizedRect {
 	if ( ! isValidSize( imageSize ) ) {
 		return cropRect;
 	}
 
 	const stateWithCrop = sanitizeCropperState( { ...state, cropRect } );
 	const region = getSourceRegion( stateWithCrop, imageSize );
-	const snapLeft = handle.includes( 'w' );
-	const snapRight = handle.includes( 'e' );
-	const snapTop = handle.includes( 'n' );
-	const snapBottom = handle.includes( 's' );
-	const shouldSnapX = snapLeft || snapRight;
-	const shouldSnapY = snapTop || snapBottom;
-	const left = snapLeft ? Math.round( region.x ) : region.x;
-	const top = snapTop ? Math.round( region.y ) : region.y;
-	const right = snapRight
+	const shouldSnapX = edges.left || edges.right;
+	const shouldSnapY = edges.top || edges.bottom;
+	const left = edges.left ? Math.round( region.x ) : region.x;
+	const top = edges.top ? Math.round( region.y ) : region.y;
+	const right = edges.right
 		? Math.round( region.x + region.width )
 		: region.x + region.width;
-	const bottom = snapBottom
+	const bottom = edges.bottom
 		? Math.round( region.y + region.height )
 		: region.y + region.height;
 	if ( right <= left || bottom <= top ) {

--- a/packages/media-editor/src/image-editor/core/source-region.ts
+++ b/packages/media-editor/src/image-editor/core/source-region.ts
@@ -14,6 +14,7 @@ import type {
 } from './types';
 import { createCamera, getRotatedBBox, getVisibleBounds } from './camera';
 import { isValidSize, sanitizeCropperState } from './math/sanitize';
+import { normalizeRotation } from './math/rotation';
 
 /**
  * The selected image region in source-pixel coordinates.
@@ -209,6 +210,23 @@ interface SourcePixelSnapEdges {
 	bottom: boolean;
 }
 
+const CARDINAL_ROTATION_EPSILON = 1e-6;
+
+/**
+ * Check whether a rotation is effectively at a 90-degree stop.
+ *
+ * @param rotation The rotation angle in degrees.
+ * @return Whether the rotation is close enough to a cardinal angle.
+ */
+function isCardinalRotation( rotation: number ): boolean {
+	const normalizedRotation = normalizeRotation( rotation );
+	const nearestCardinal = Math.round( normalizedRotation / 90 ) * 90;
+	return (
+		Math.abs( normalizedRotation - nearestCardinal ) <
+		CARDINAL_ROTATION_EPSILON
+	);
+}
+
 /**
  * Snap a crop rect so the selected source-region edges land on whole pixels.
  *
@@ -227,7 +245,12 @@ export function snapCropRectToSourcePixels(
 	cropRect: NormalizedRect,
 	handle: HandlePosition
 ): NormalizedRect {
-	return snapCropRectEdgesToSourcePixels( state, imageSize, cropRect, {
+	const safeState = sanitizeCropperState( state );
+	if ( ! isCardinalRotation( safeState.rotation ) ) {
+		return cropRect;
+	}
+
+	return snapCropRectEdgesToSourcePixels( safeState, imageSize, cropRect, {
 		left: handle.includes( 'w' ),
 		top: handle.includes( 'n' ),
 		right: handle.includes( 'e' ),

--- a/packages/media-editor/src/image-editor/core/source-region.ts
+++ b/packages/media-editor/src/image-editor/core/source-region.ts
@@ -6,7 +6,12 @@ import { mat2d, vec2 } from 'gl-matrix';
 /**
  * Internal dependencies
  */
-import type { CropperState, Size } from './types';
+import type {
+	CropperState,
+	HandlePosition,
+	NormalizedRect,
+	Size,
+} from './types';
 import { createCamera, getRotatedBBox, getVisibleBounds } from './camera';
 import { isValidSize, sanitizeCropperState } from './math/sanitize';
 
@@ -124,6 +129,141 @@ export function getSourceRegion(
 		rotation: safeState.rotation,
 		flip: { ...safeState.flip },
 		zoom: safeState.zoom,
+	};
+}
+
+/**
+ * Convert a source-pixel region back to the cropper's normalized crop rect.
+ *
+ * The math intentionally mirrors `getSourceRegion`: map the requested source
+ * center through the current camera, then express that screen point inside the
+ * same base visible bounds used to position crop overlays.
+ *
+ * @param state     The current cropper state.
+ * @param imageSize The natural dimensions of the source image.
+ * @param region    The source-pixel region to represent as a crop rect.
+ * @return The normalized crop rect, or null when inputs cannot be mapped.
+ */
+function getCropRectFromSourceRegion(
+	state: CropperState,
+	imageSize: Size,
+	region: SourceRegion
+): NormalizedRect | null {
+	if (
+		! isValidSize( imageSize ) ||
+		region.width <= 0 ||
+		region.height <= 0
+	) {
+		return null;
+	}
+
+	const safeState = sanitizeCropperState( state );
+	const syntheticContainer: Size = { width: 1000, height: 1000 };
+	const baseCamera = createCamera(
+		{ ...safeState, pan: { x: 0, y: 0 }, zoom: 1 },
+		syntheticContainer,
+		imageSize
+	);
+	const visibleBounds = getVisibleBounds( baseCamera );
+	if ( visibleBounds.width <= 0 || visibleBounds.height <= 0 ) {
+		return null;
+	}
+
+	const sourceCenter = vec2.fromValues(
+		( region.x + region.width / 2 ) / imageSize.width,
+		( region.y + region.height / 2 ) / imageSize.height
+	);
+	const screenCenter = vec2.create();
+	const camera = createCamera( safeState, syntheticContainer, imageSize );
+	vec2.transformMat2d( screenCenter, sourceCenter, camera );
+
+	const snapRotation = Math.round( safeState.rotation / 90 ) * 90;
+	const { width: rotW, height: rotH } = getRotatedBBox(
+		imageSize.width,
+		imageSize.height,
+		snapRotation
+	);
+	if ( rotW <= 0 || rotH <= 0 ) {
+		return null;
+	}
+
+	const width = ( region.width * safeState.zoom ) / rotW;
+	const height = ( region.height * safeState.zoom ) / rotH;
+	const centerX =
+		( screenCenter[ 0 ] - visibleBounds.left ) / visibleBounds.width;
+	const centerY =
+		( screenCenter[ 1 ] - visibleBounds.top ) / visibleBounds.height;
+
+	return {
+		x: centerX - width / 2,
+		y: centerY - height / 2,
+		width,
+		height,
+	};
+}
+
+/**
+ * Snap a crop rect so the selected source-region edges land on whole pixels.
+ *
+ * This is a display-time affordance for visible pixel grids; it does not alter
+ * pan/zoom/rotation. Callers decide when snapping is appropriate.
+ *
+ * @param state     The current cropper state.
+ * @param imageSize The natural dimensions of the source image.
+ * @param cropRect  The candidate crop rect from resize math.
+ * @param handle    The active resize handle. Only edges moved by the handle snap.
+ * @return A crop rect whose selected source-region edges are whole pixels.
+ */
+export function snapCropRectToSourcePixels(
+	state: CropperState,
+	imageSize: Size,
+	cropRect: NormalizedRect,
+	handle: HandlePosition
+): NormalizedRect {
+	if ( ! isValidSize( imageSize ) ) {
+		return cropRect;
+	}
+
+	const stateWithCrop = sanitizeCropperState( { ...state, cropRect } );
+	const region = getSourceRegion( stateWithCrop, imageSize );
+	const snapLeft = handle.includes( 'w' );
+	const snapRight = handle.includes( 'e' );
+	const snapTop = handle.includes( 'n' );
+	const snapBottom = handle.includes( 's' );
+	const shouldSnapX = snapLeft || snapRight;
+	const shouldSnapY = snapTop || snapBottom;
+	const left = snapLeft ? Math.round( region.x ) : region.x;
+	const top = snapTop ? Math.round( region.y ) : region.y;
+	const right = snapRight
+		? Math.round( region.x + region.width )
+		: region.x + region.width;
+	const bottom = snapBottom
+		? Math.round( region.y + region.height )
+		: region.y + region.height;
+	if ( right <= left || bottom <= top ) {
+		return cropRect;
+	}
+
+	const snappedCropRect = getCropRectFromSourceRegion(
+		stateWithCrop,
+		imageSize,
+		{
+			...region,
+			x: left,
+			y: top,
+			width: right - left,
+			height: bottom - top,
+		}
+	);
+	if ( ! snappedCropRect ) {
+		return cropRect;
+	}
+
+	return {
+		x: shouldSnapX ? snappedCropRect.x : cropRect.x,
+		y: shouldSnapY ? snappedCropRect.y : cropRect.y,
+		width: shouldSnapX ? snappedCropRect.width : cropRect.width,
+		height: shouldSnapY ? snappedCropRect.height : cropRect.height,
 	};
 }
 

--- a/packages/media-editor/src/image-editor/core/test/camera.ts
+++ b/packages/media-editor/src/image-editor/core/test/camera.ts
@@ -17,6 +17,7 @@ import {
 import {
 	getSourceRegion,
 	getSourceRegionPercent,
+	snapCropRectToSourcePixelGrid,
 	snapCropRectToSourcePixels,
 } from '../source-region';
 import { computeTransformStyle } from '../transform-style';
@@ -632,6 +633,30 @@ describe( 'snapCropRectToSourcePixels', () => {
 		} );
 		expect( snapped.left ).toBeCloseTo( unsnapped.x, 3 );
 		expect( snapped.top ).toBeCloseTo( unsnapped.y, 3 );
+		expect( snapped.right ).toBeCloseTo( Math.round( snapped.right ), 3 );
+		expect( snapped.bottom ).toBeCloseTo( Math.round( snapped.bottom ), 3 );
+	} );
+
+	it( 'snaps all source-region edges to whole pixels', () => {
+		const state = makeState( {
+			zoom: 2.25,
+			pan: { x: 0.013, y: -0.017 },
+			cropRect: { x: 0.12, y: 0.18, width: 0.33, height: 0.41 },
+		} );
+		const candidate = { x: 0.123, y: 0.187, width: 0.337, height: 0.419 };
+
+		const snappedCropRect = snapCropRectToSourcePixelGrid(
+			state,
+			IMAGE,
+			candidate
+		);
+		const snapped = getSourceEdges( {
+			...state,
+			cropRect: snappedCropRect,
+		} );
+
+		expect( snapped.left ).toBeCloseTo( Math.round( snapped.left ), 3 );
+		expect( snapped.top ).toBeCloseTo( Math.round( snapped.top ), 3 );
 		expect( snapped.right ).toBeCloseTo( Math.round( snapped.right ), 3 );
 		expect( snapped.bottom ).toBeCloseTo( Math.round( snapped.bottom ), 3 );
 	} );

--- a/packages/media-editor/src/image-editor/core/test/camera.ts
+++ b/packages/media-editor/src/image-editor/core/test/camera.ts
@@ -639,6 +639,7 @@ describe( 'snapCropRectToSourcePixels', () => {
 
 	it( 'snaps all source-region edges to whole pixels', () => {
 		const state = makeState( {
+			rotation: 30,
 			zoom: 2.25,
 			pan: { x: 0.013, y: -0.017 },
 			cropRect: { x: 0.12, y: 0.18, width: 0.33, height: 0.41 },
@@ -659,6 +660,20 @@ describe( 'snapCropRectToSourcePixels', () => {
 		expect( snapped.top ).toBeCloseTo( Math.round( snapped.top ), 3 );
 		expect( snapped.right ).toBeCloseTo( Math.round( snapped.right ), 3 );
 		expect( snapped.bottom ).toBeCloseTo( Math.round( snapped.bottom ), 3 );
+	} );
+
+	it( 'does not snap selected edges while fine rotation couples source axes', () => {
+		const state = makeState( {
+			rotation: 30,
+			zoom: 2.25,
+			pan: { x: 0.013, y: -0.017 },
+			cropRect: { x: 0.12, y: 0.18, width: 0.33, height: 0.41 },
+		} );
+		const candidate = { x: 0.123, y: 0.187, width: 0.337, height: 0.419 };
+
+		expect(
+			snapCropRectToSourcePixels( state, IMAGE, candidate, 'e' )
+		).toBe( candidate );
 	} );
 
 	it( 'returns the input crop rect when the image dimensions are invalid', () => {

--- a/packages/media-editor/src/image-editor/core/test/camera.ts
+++ b/packages/media-editor/src/image-editor/core/test/camera.ts
@@ -14,7 +14,11 @@ import {
 	getImageCropBounds,
 	getMinZoom,
 } from '../containment';
-import { getSourceRegion, getSourceRegionPercent } from '../source-region';
+import {
+	getSourceRegion,
+	getSourceRegionPercent,
+	snapCropRectToSourcePixels,
+} from '../source-region';
 import { computeTransformStyle } from '../transform-style';
 import { DEFAULT_STATE, MAX_ZOOM, MIN_ZOOM } from '../constants';
 import type { CropperState, Size } from '../types';
@@ -574,6 +578,75 @@ describe( 'getSourceRegion', () => {
 		// Rotated AR should be roughly the inverse of default AR.
 		expect( rotatedAR ).toBeCloseTo( 1 / defaultAR, 1 );
 		expect( region.rotation ).toBe( 90 );
+	} );
+} );
+
+describe( 'snapCropRectToSourcePixels', () => {
+	const getSourceEdges = ( state: CropperState ) => {
+		const region = getSourceRegion( state, IMAGE );
+		return {
+			left: region.x,
+			top: region.y,
+			right: region.x + region.width,
+			bottom: region.y + region.height,
+		};
+	};
+
+	it( 'snaps the selected source-region edges to whole pixels under pan and zoom', () => {
+		const state = makeState( {
+			zoom: 2.25,
+			pan: { x: 0.013, y: -0.017 },
+			cropRect: { x: 0.12, y: 0.18, width: 0.33, height: 0.41 },
+		} );
+		const candidate = { x: 0.123, y: 0.187, width: 0.337, height: 0.419 };
+
+		const unsnapped = getSourceRegion(
+			{ ...state, cropRect: candidate },
+			IMAGE
+		);
+		expect(
+			Math.abs(
+				unsnapped.x +
+					unsnapped.width -
+					Math.round( unsnapped.x + unsnapped.width )
+			)
+		).toBeGreaterThan( 0.01 );
+		expect(
+			Math.abs(
+				unsnapped.y +
+					unsnapped.height -
+					Math.round( unsnapped.y + unsnapped.height )
+			)
+		).toBeGreaterThan( 0.01 );
+
+		const snappedCropRect = snapCropRectToSourcePixels(
+			state,
+			IMAGE,
+			candidate,
+			'se'
+		);
+
+		const snapped = getSourceEdges( {
+			...state,
+			cropRect: snappedCropRect,
+		} );
+		expect( snapped.left ).toBeCloseTo( unsnapped.x, 3 );
+		expect( snapped.top ).toBeCloseTo( unsnapped.y, 3 );
+		expect( snapped.right ).toBeCloseTo( Math.round( snapped.right ), 3 );
+		expect( snapped.bottom ).toBeCloseTo( Math.round( snapped.bottom ), 3 );
+	} );
+
+	it( 'returns the input crop rect when the image dimensions are invalid', () => {
+		const cropRect = { x: 0.1, y: 0.2, width: 0.3, height: 0.4 };
+
+		expect(
+			snapCropRectToSourcePixels(
+				makeState(),
+				{ width: 0, height: 0 },
+				cropRect,
+				'se'
+			)
+		).toBe( cropRect );
 	} );
 } );
 

--- a/packages/media-editor/src/image-editor/core/test/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/test/stencil-math.ts
@@ -14,15 +14,14 @@ import type { Size } from '../types';
 
 describe( 'getMinCropPixels — operable on-screen floor', () => {
 	it( 'returns the source-pixel hard floor when the image is shown large enough', () => {
-		// displayScale = 2 CSS px per source px (zoomed in). The usability
-		// term is 44 / 2 = 22 px, below the 24-source-px hard floor, so the
-		// hard floor wins.
-		expect( getMinCropPixels( 2 ) ).toBe( MIN_CROP_PIXELS );
+		const displayScale = ( MIN_CROP_SCREEN_PX / MIN_CROP_PIXELS ) * 1.1;
+
+		expect( getMinCropPixels( displayScale ) ).toBe( MIN_CROP_PIXELS );
 	} );
 
 	it( 'raises the floor so the crop stays operable when the image is shown small', () => {
 		// A large image fit into a small window: ~0.2 CSS px per source px.
-		// 24 source px would render as ~4.8 px on screen — unusable. The
+		// The source-pixel floor would render too small on screen. The
 		// usability term (44 / 0.2 = 220 source px) must win.
 		expect( getMinCropPixels( 0.2 ) ).toBeCloseTo(
 			MIN_CROP_SCREEN_PX / 0.2,

--- a/packages/media-editor/src/image-editor/core/types.ts
+++ b/packages/media-editor/src/image-editor/core/types.ts
@@ -219,4 +219,10 @@ export interface StencilProps {
 		rect: NormalizedRect,
 		handle: HandlePosition
 	) => NormalizedRect;
+	/**
+	 * Optional keyboard resize step in normalized space, per axis. Hosts use
+	 * this when keyboard resize should follow the rendered image scale instead
+	 * of the default percentage-based step.
+	 */
+	keyboardResizeStep?: Size;
 }

--- a/packages/media-editor/src/image-editor/core/types.ts
+++ b/packages/media-editor/src/image-editor/core/types.ts
@@ -210,4 +210,13 @@ export interface StencilProps {
 	 * the source image dimensions. Omit to use the stencil's default.
 	 */
 	minCropSize?: Size;
+	/**
+	 * Optional post-processor for freeform resize output. Hosts use this for
+	 * display-gated behavior such as snapping visible pixel grids to source
+	 * pixel boundaries.
+	 */
+	snapCropRect?: (
+		rect: NormalizedRect,
+		handle: HandlePosition
+	) => NormalizedRect;
 }

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -48,6 +48,7 @@ import { GridOverlay } from './overlays/grid-overlay';
 import { DimensionsOverlay } from './overlays/dimensions-overlay';
 import {
 	getSourceRegion,
+	snapCropRectToSourcePixelGrid,
 	snapCropRectToSourcePixels,
 } from '../../core/source-region';
 import { ViewportProvider, useViewport } from './viewport-provider';
@@ -475,6 +476,51 @@ function CropperInner(
 		},
 		[ displayScale, naturalWidth, naturalHeight, state ]
 	);
+
+	const wasPixelSnapEnabledRef = useRef( false );
+	useEffect( () => {
+		const isPixelSnapEnabled =
+			freeformCrop &&
+			( ! aspectRatio || aspectRatio <= 0 ) &&
+			displayScale >= PIXEL_SNAP_DISPLAY_SCALE &&
+			naturalWidth > 0 &&
+			naturalHeight > 0;
+		const wasPixelSnapEnabled = wasPixelSnapEnabledRef.current;
+		wasPixelSnapEnabledRef.current = isPixelSnapEnabled;
+
+		if ( ! isPixelSnapEnabled || wasPixelSnapEnabled ) {
+			return;
+		}
+
+		const snappedCropRect = snapCropRectToSourcePixelGrid(
+			state,
+			{ width: naturalWidth, height: naturalHeight },
+			state.cropRect
+		);
+		const currentCropRect = state.cropRect;
+		if (
+			Math.abs( currentCropRect.x - snappedCropRect.x ) <
+				CROP_RECT_EPSILON &&
+			Math.abs( currentCropRect.y - snappedCropRect.y ) <
+				CROP_RECT_EPSILON &&
+			Math.abs( currentCropRect.width - snappedCropRect.width ) <
+				CROP_RECT_EPSILON &&
+			Math.abs( currentCropRect.height - snappedCropRect.height ) <
+				CROP_RECT_EPSILON
+		) {
+			return;
+		}
+
+		setCropRect( snappedCropRect );
+	}, [
+		aspectRatio,
+		displayScale,
+		freeformCrop,
+		naturalWidth,
+		naturalHeight,
+		setCropRect,
+		state,
+	] );
 
 	// Use the interaction hook for mouse, touch, and keyboard events.
 	const {

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -56,6 +56,8 @@ import { VISUALLY_HIDDEN_STYLE } from '../visually-hidden-style';
 
 /** Threshold for comparing normalized crop rect values. */
 const CROP_RECT_EPSILON = 1e-6;
+/** Threshold for deciding whether rotation is at a 90-degree stop. */
+const CARDINAL_ROTATION_EPSILON = 1e-6;
 
 /**
  * Props for the Cropper component.
@@ -425,6 +427,42 @@ function CropperInner(
 		naturalWidth > 0
 			? ( elementSize.width / naturalWidth ) * state.zoom * viewScale
 			: 0;
+	const keyboardResizeStep = useMemo( () => {
+		if (
+			displayScale < PIXEL_SNAP_DISPLAY_SCALE ||
+			( aspectRatio && aspectRatio > 0 ) ||
+			naturalWidth <= 0 ||
+			naturalHeight <= 0
+		) {
+			return undefined;
+		}
+		const snapRotation = Math.round( state.rotation / 90 ) * 90;
+		if (
+			Math.abs( state.rotation - snapRotation ) >=
+			CARDINAL_ROTATION_EPSILON
+		) {
+			return undefined;
+		}
+		const bbox = getRotatedBBox(
+			naturalWidth,
+			naturalHeight,
+			snapRotation
+		);
+		if ( bbox.width <= 0 || bbox.height <= 0 ) {
+			return undefined;
+		}
+		return {
+			width: state.zoom / bbox.width,
+			height: state.zoom / bbox.height,
+		};
+	}, [
+		displayScale,
+		aspectRatio,
+		naturalWidth,
+		naturalHeight,
+		state.rotation,
+		state.zoom,
+	] );
 
 	// Per-axis minimum crop size in normalized space, expressing a pixel floor
 	// on the captured source region. cropRect is normalized in the viewport's
@@ -944,6 +982,7 @@ function CropperInner(
 						cropBounds={ cropBounds }
 						minCropSize={ minCropSize }
 						snapCropRect={ snapCropRect }
+						keyboardResizeStep={ keyboardResizeStep }
 					/>
 
 					{ /* Rule-of-thirds grid */ }

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -451,6 +451,11 @@ function CropperInner(
 		if ( bbox.width <= 0 || bbox.height <= 0 ) {
 			return undefined;
 		}
+		// Keyboard steps are normalized crop-space deltas, but snapping wants
+		// one source pixel per key press. The normalized delta for one source
+		// pixel is different on each axis when the snap-rotation bbox is not
+		// square, so this must be an object with separate width/height steps
+		// instead of a single scalar.
 		return {
 			width: state.zoom / bbox.width,
 			height: state.zoom / bbox.height,

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -34,6 +34,7 @@ import { getImageFit, getRotatedBBox, getViewScale } from '../../core/camera';
 import { getImageCropBounds, getMinZoom } from '../../core/containment';
 import {
 	MAX_VIEW_SCALE,
+	PIXEL_SNAP_DISPLAY_SCALE,
 	SETTLE_TARGET_CANVAS_FILL,
 } from '../../core/constants';
 import { computeInscribedRect } from '../../core/crop-rect';
@@ -45,7 +46,10 @@ import { RectangleStencil } from './stencils/rectangle-stencil';
 import { DimmingOverlay } from './overlays/dimming-overlay';
 import { GridOverlay } from './overlays/grid-overlay';
 import { DimensionsOverlay } from './overlays/dimensions-overlay';
-import { getSourceRegion } from '../../core/source-region';
+import {
+	getSourceRegion,
+	snapCropRectToSourcePixels,
+} from '../../core/source-region';
 import { ViewportProvider, useViewport } from './viewport-provider';
 import { VISUALLY_HIDDEN_STYLE } from '../visually-hidden-style';
 
@@ -414,6 +418,12 @@ function CropperInner(
 		} ),
 		[ visualSize.width, visualSize.height, viewScale ]
 	);
+	// CSS pixels rendered per source pixel: the contain fit
+	// (elementSize / natural), times zoom and the view-scale magnification.
+	const displayScale =
+		naturalWidth > 0
+			? ( elementSize.width / naturalWidth ) * state.zoom * viewScale
+			: 0;
 
 	// Per-axis minimum crop size in normalized space, expressing a pixel floor
 	// on the captured source region. cropRect is normalized in the viewport's
@@ -434,8 +444,6 @@ function CropperInner(
 			naturalHeight,
 			snapRotation
 		);
-		const displayScale =
-			( elementSize.width / naturalWidth ) * state.zoom * viewScale;
 		const minPixels = getMinCropPixels( displayScale );
 		return {
 			width: Math.min( 1, ( minPixels * state.zoom ) / bbox.width ),
@@ -446,9 +454,27 @@ function CropperInner(
 		naturalHeight,
 		state.rotation,
 		state.zoom,
-		elementSize.width,
-		viewScale,
+		displayScale,
 	] );
+
+	const snapCropRect = useCallback(
+		( rect: NormalizedRect, handle: HandlePosition ): NormalizedRect => {
+			if (
+				displayScale < PIXEL_SNAP_DISPLAY_SCALE ||
+				naturalWidth <= 0 ||
+				naturalHeight <= 0
+			) {
+				return rect;
+			}
+			return snapCropRectToSourcePixels(
+				state,
+				{ width: naturalWidth, height: naturalHeight },
+				rect,
+				handle
+			);
+		},
+		[ displayScale, naturalWidth, naturalHeight, state ]
+	);
 
 	// Use the interaction hook for mouse, touch, and keyboard events.
 	const {
@@ -699,15 +725,9 @@ function CropperInner(
 		}
 		const centerX = ( canvasSize.width - elementSize.width ) / 2;
 		const centerY = ( canvasSize.height - elementSize.height ) / 2;
-		// CSS pixels rendered per source pixel: the contain fit
-		// (elementSize / natural), times zoom and the view-scale magnification.
 		// Above 1:1 the image is upscaled, so render nearest-neighbour to keep
 		// pixel boundaries crisp (e.g. small images the cropper magnifies);
 		// below 1:1 leave smoothing on for downscaled large images.
-		const displayScale =
-			naturalWidth > 0
-				? ( elementSize.width / naturalWidth ) * state.zoom * viewScale
-				: 0;
 		return {
 			width: elementSize.width,
 			height: elementSize.height,
@@ -728,10 +748,9 @@ function CropperInner(
 	}, [
 		canvasSize,
 		elementSize,
-		naturalWidth,
-		state.zoom,
 		transformString,
 		imageTransition,
+		displayScale,
 		viewScale,
 	] );
 
@@ -878,6 +897,7 @@ function CropperInner(
 						stencilTransition={ settleStencilTransition }
 						cropBounds={ cropBounds }
 						minCropSize={ minCropSize }
+						snapCropRect={ snapCropRect }
 					/>
 
 					{ /* Rule-of-thirds grid */ }

--- a/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
@@ -91,20 +91,21 @@ type RectangleStencilProps = StencilProps;
  * crop pass through to the container for image panning. The crop
  * auto-centers after resize via SETTLE_CROP.
  *
- * @param props                   Component props implementing StencilProps.
- * @param props.cropRect          The crop rectangle in normalized coordinates.
- * @param props.containerSize     The container element dimensions in pixels.
- * @param props.imageSize         The rendered image dimensions in pixels.
- * @param props.onCropChange      Callback fired when the crop rect changes.
- * @param props.onResizeStart     Callback fired when a resize drag starts.
- * @param props.onResizeEnd       Callback fired when a resize drag ends (mouseup).
- * @param props.aspectRatio       Optional fixed aspect ratio (width / height).
- * @param props.freeformCrop      Whether resize handles are shown.
- * @param props.stencilTransition CSS transition string for settle animation.
- * @param props.cropBounds        Maximum crop rect bounds from camera (zoom/rotation-aware).
- * @param props.onEscape          Called when Escape is pressed on a resize handle.
- * @param props.minCropSize       Minimum crop rect dimension in normalized space, per axis.
- * @param props.snapCropRect      Optional post-processor for freeform resize output.
+ * @param props                    Component props implementing StencilProps.
+ * @param props.cropRect           The crop rectangle in normalized coordinates.
+ * @param props.containerSize      The container element dimensions in pixels.
+ * @param props.imageSize          The rendered image dimensions in pixels.
+ * @param props.onCropChange       Callback fired when the crop rect changes.
+ * @param props.onResizeStart      Callback fired when a resize drag starts.
+ * @param props.onResizeEnd        Callback fired when a resize drag ends (mouseup).
+ * @param props.aspectRatio        Optional fixed aspect ratio (width / height).
+ * @param props.freeformCrop       Whether resize handles are shown.
+ * @param props.stencilTransition  CSS transition string for settle animation.
+ * @param props.cropBounds         Maximum crop rect bounds from camera (zoom/rotation-aware).
+ * @param props.onEscape           Called when Escape is pressed on a resize handle.
+ * @param props.minCropSize        Minimum crop rect dimension in normalized space, per axis.
+ * @param props.snapCropRect       Optional post-processor for freeform resize output.
+ * @param props.keyboardResizeStep Optional keyboard resize step in normalized space, per axis.
  * @return The rectangle stencil element.
  */
 export function RectangleStencil( {
@@ -121,6 +122,7 @@ export function RectangleStencil( {
 	onEscape,
 	minCropSize,
 	snapCropRect,
+	keyboardResizeStep,
 }: RectangleStencilProps ) {
 	// Use cropBounds from the camera if available, otherwise default to [0,1].
 	const boundsMinX = cropBounds?.minX ?? 0;
@@ -423,24 +425,28 @@ export function RectangleStencil( {
 				}, KEYBOARD_SETTLE_DELAY );
 			};
 
-			const step = event.shiftKey
-				? DEFAULT_KEYBOARD_STEP * KEYBOARD_SHIFT_STEP_MULTIPLIER
-				: DEFAULT_KEYBOARD_STEP;
+			const stepMultiplier = event.shiftKey
+				? KEYBOARD_SHIFT_STEP_MULTIPLIER
+				: 1;
+			const stepX = keyboardResizeStep?.width ?? DEFAULT_KEYBOARD_STEP;
+			const stepY = keyboardResizeStep?.height ?? DEFAULT_KEYBOARD_STEP;
+			const adjustedStepX = stepX * stepMultiplier;
+			const adjustedStepY = stepY * stepMultiplier;
 
 			// Determine the normalized delta from the arrow key.
 			let dx = 0;
 			let dy = 0;
 			if ( key === 'ArrowLeft' ) {
-				dx = -step;
+				dx = -adjustedStepX;
 			}
 			if ( key === 'ArrowRight' ) {
-				dx = step;
+				dx = adjustedStepX;
 			}
 			if ( key === 'ArrowUp' ) {
-				dy = -step;
+				dy = -adjustedStepY;
 			}
 			if ( key === 'ArrowDown' ) {
-				dy = step;
+				dy = adjustedStepY;
 			}
 
 			if ( hasLockedRatio ) {
@@ -484,6 +490,7 @@ export function RectangleStencil( {
 			onResizeStart,
 			onResizeEnd,
 			onEscape,
+			keyboardResizeStep,
 			snapCropRect,
 		]
 	);

--- a/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
@@ -104,6 +104,7 @@ type RectangleStencilProps = StencilProps;
  * @param props.cropBounds        Maximum crop rect bounds from camera (zoom/rotation-aware).
  * @param props.onEscape          Called when Escape is pressed on a resize handle.
  * @param props.minCropSize       Minimum crop rect dimension in normalized space, per axis.
+ * @param props.snapCropRect      Optional post-processor for freeform resize output.
  * @return The rectangle stencil element.
  */
 export function RectangleStencil( {
@@ -119,6 +120,7 @@ export function RectangleStencil( {
 	cropBounds,
 	onEscape,
 	minCropSize,
+	snapCropRect,
 }: RectangleStencilProps ) {
 	// Use cropBounds from the camera if available, otherwise default to [0,1].
 	const boundsMinX = cropBounds?.minX ?? 0;
@@ -173,6 +175,10 @@ export function RectangleStencil( {
 		) => NormalizedRect;
 		onCropChange: ( rect: NormalizedRect ) => void;
 		onResizeEnd?: () => void;
+		snapCropRect?: (
+			rect: NormalizedRect,
+			handle: HandlePosition
+		) => NormalizedRect;
 	} | null >( null );
 
 	// The normalized aspect ratio: the w/h ratio in normalized space that
@@ -258,6 +264,8 @@ export function RectangleStencil( {
 						);
 					} else {
 						newRect = h.computeFreeRect( drag, latestX, latestY );
+						newRect =
+							h.snapCropRect?.( newRect, drag.handle ) ?? newRect;
 					}
 					h.onCropChange( newRect );
 				} );
@@ -371,6 +379,7 @@ export function RectangleStencil( {
 		computeShiftLockedRect,
 		onCropChange,
 		onResizeEnd,
+		snapCropRect,
 	};
 
 	/**
@@ -459,9 +468,8 @@ export function RectangleStencil( {
 				};
 				const clientX = dx * imageSize.width;
 				const clientY = dy * imageSize.height;
-				onCropChange(
-					computeFreeRect( syntheticDrag, clientX, clientY )
-				);
+				const rect = computeFreeRect( syntheticDrag, clientX, clientY );
+				onCropChange( snapCropRect?.( rect, handle ) ?? rect );
 				scheduleKeyboardResizeEnd();
 			}
 		},
@@ -476,6 +484,7 @@ export function RectangleStencil( {
 			onResizeStart,
 			onResizeEnd,
 			onEscape,
+			snapCropRect,
 		]
 	);
 

--- a/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.tsx
@@ -212,6 +212,31 @@ describe( 'RectangleStencil', () => {
 			expect( newRect.height ).toBeCloseTo( 0.81, 5 );
 			expect( newRect.y ).toBeCloseTo( 0.1, 5 );
 		} );
+
+		it( 'applies snapCropRect to freeform resize output', () => {
+			const snapCropRect = jest.fn( ( rect: NormalizedRect ) => ( {
+				...rect,
+				width: 0.82,
+			} ) );
+			const { onCropChange } = renderStencil( { snapCropRect } );
+			const eHandle = screen.getAllByRole( 'button' )[ 3 ];
+
+			fireEvent.keyDown( eHandle, {
+				key: 'ArrowRight',
+				shiftKey: false,
+			} );
+
+			expect( snapCropRect ).toHaveBeenCalledTimes( 1 );
+			expect( snapCropRect.mock.calls[ 0 ][ 0 ].width ).toBeCloseTo(
+				0.81,
+				5
+			);
+			expect( snapCropRect.mock.calls[ 0 ][ 1 ] ).toBe( 'e' );
+			expect( onCropChange.mock.calls[ 0 ][ 0 ].width ).toBeCloseTo(
+				0.82,
+				5
+			);
+		} );
 	} );
 
 	describe( 'keyboard — arrow keys (coarse step with Shift)', () => {
@@ -246,6 +271,21 @@ describe( 'RectangleStencil', () => {
 			const coarseDelta = coarseRect.width - DEFAULT_CROP_RECT.width;
 
 			expect( coarseDelta / fineDelta ).toBeCloseTo( 10, 0 );
+		} );
+
+		it( 'does not apply snapCropRect while resizing a locked aspect ratio', () => {
+			const snapCropRect = jest.fn( ( rect: NormalizedRect ) => rect );
+			renderStencil( { aspectRatio: 1, snapCropRect } );
+			const nwHandle = screen.getByRole( 'button', {
+				name: 'Resize top-left corner',
+			} );
+
+			fireEvent.keyDown( nwHandle, {
+				key: 'ArrowRight',
+				shiftKey: false,
+			} );
+
+			expect( snapCropRect ).not.toHaveBeenCalled();
 		} );
 	} );
 

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -421,16 +421,17 @@ describe( 'Cropper', () => {
 		const stage = screen.getByTestId( 'cropper-stage' );
 
 		// cropRect starts at {x:0, y:0, width:1, height:1} (right edge = 1.0).
-		// One ArrowRight step (+0.01 normalized) puts the right edge at 1.01.
+		// Pixel snapping is active at zoom:2, so one ArrowRight step is one
+		// source pixel: zoom / sourceWidth = 2 / 600 normalized.
 		// With canvasSize=600×400 and visualSize=600×400:
-		//   rightOverflow = 1.01 * 600 − 600 = 6 → pan.x = −6
+		//   rightOverflow = (1 + 2/600) * 600 − 600 = 2 → pan.x = −2
 		fireEvent.keyDown( eHandle, { key: 'ArrowRight' } );
 
 		const match = stage.style.transform.match(
 			/^translate\((-?\d+(?:\.\d+)?)px, (-?\d+(?:\.\d+)?)px\)$/
 		);
 		expect( match ).not.toBeNull();
-		expect( Number( match?.[ 1 ] ) ).toBeCloseTo( -6, 5 );
+		expect( Number( match?.[ 1 ] ) ).toBeCloseTo( -2, 4 );
 		expect( Number( match?.[ 2 ] ) ).toBeCloseTo( 0, 5 );
 
 		jest.useRealTimers();
@@ -670,6 +671,45 @@ describe( 'Cropper', () => {
 		expect( rect.x ).toBeCloseTo( cropRect.x, 5 );
 		expect( rect.y ).toBeCloseTo( cropRect.y, 5 );
 		expect( rect.height ).toBeCloseTo( cropRect.height, 5 );
+	} );
+
+	it( 'uses source-pixel keyboard steps for horizontal freeform resize when snapping is active', async () => {
+		const image = {
+			src: 'wide.png',
+			naturalWidth: 200,
+			naturalHeight: 100,
+		};
+		const cropRect = { x: 0.1, y: 0.1, width: 0.6, height: 0.6 };
+		const controller = createController();
+		controller.state = {
+			...controller.state,
+			image,
+			cropRect,
+		};
+		const initialRegion = getSourceRegion(
+			{ ...controller.state, cropRect },
+			{ width: image.naturalWidth, height: image.naturalHeight }
+		);
+		render(
+			<Cropper src="wide.png" controller={ controller } freeformCrop />
+		);
+
+		const handle = await screen.findByRole( 'button', {
+			name: 'Resize right edge',
+		} );
+		( controller.setCropRect as jest.Mock ).mockClear();
+		fireEvent.keyDown( handle, { key: 'ArrowRight' } );
+
+		const rect = ( controller.setCropRect as jest.Mock ).mock
+			.calls[ 0 ][ 0 ];
+		const region = getSourceRegion(
+			{ ...controller.state, cropRect: rect },
+			{ width: image.naturalWidth, height: image.naturalHeight }
+		);
+		expect( region.x + region.width ).toBeCloseTo(
+			initialRegion.x + initialRegion.width + 1,
+			3
+		);
 	} );
 
 	it( 'keeps freeform resize smooth below 1:1 display scale', async () => {

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -636,7 +636,7 @@ describe( 'Cropper', () => {
 
 	it( 'snaps freeform resize output to source pixels when the image is shown at 1:1 or larger', async () => {
 		const image = { src: 'tiny.png', naturalWidth: 50, naturalHeight: 50 };
-		const cropRect = { x: 0.113, y: 0.127, width: 0.6, height: 0.456 };
+		const cropRect = { x: 0.1, y: 0.12, width: 0.6, height: 0.44 };
 		const controller = createController();
 		controller.state = {
 			...controller.state,
@@ -663,7 +663,6 @@ describe( 'Cropper', () => {
 			{ width: image.naturalWidth, height: image.naturalHeight }
 		);
 		expect( region.x ).toBeCloseTo( initialRegion.x, 3 );
-		expect( region.x ).not.toBeCloseTo( Math.round( region.x ), 3 );
 		expect( region.x + region.width ).toBeCloseTo(
 			Math.round( region.x + region.width ),
 			3
@@ -707,6 +706,105 @@ describe( 'Cropper', () => {
 				region.x + region.width - Math.round( region.x + region.width )
 			)
 		).toBeGreaterThan( 0.01 );
+	} );
+
+	it( 'snaps all crop edges once when display scale reaches source-pixel size', async () => {
+		const image = {
+			src: 'crossing.png',
+			naturalWidth: 1000,
+			naturalHeight: 1000,
+		};
+		const cropRect = {
+			x: 0.113,
+			y: 0.127,
+			width: 0.733,
+			height: 0.641,
+		};
+		const controller = createController();
+		controller.state = {
+			...controller.state,
+			image,
+			cropRect,
+			zoom: 0.5,
+		};
+		const { rerender } = render(
+			<Cropper
+				src="crossing.png"
+				controller={ controller }
+				freeformCrop
+			/>
+		);
+
+		await screen.findByTestId( 'cropper-image' );
+		expect( controller.setCropRect ).not.toHaveBeenCalled();
+
+		controller.state = { ...controller.state, zoom: 3 };
+		rerender(
+			<Cropper
+				src="crossing.png"
+				controller={ controller }
+				freeformCrop
+			/>
+		);
+
+		await waitFor( () =>
+			expect( controller.setCropRect ).toHaveBeenCalledTimes( 1 )
+		);
+		const rect = ( controller.setCropRect as jest.Mock ).mock
+			.calls[ 0 ][ 0 ];
+		const region = getSourceRegion(
+			{ ...controller.state, cropRect: rect },
+			{ width: image.naturalWidth, height: image.naturalHeight }
+		);
+		for ( const edge of [
+			region.x,
+			region.y,
+			region.x + region.width,
+			region.y + region.height,
+		] ) {
+			expect( edge ).toBeCloseTo( Math.round( edge ), 3 );
+		}
+	} );
+
+	it( 'does not snap all crop edges for fixed-aspect freeform crops', async () => {
+		const image = {
+			src: 'locked-ratio.png',
+			naturalWidth: 1000,
+			naturalHeight: 1000,
+		};
+		const controller = createController();
+		controller.state = {
+			...controller.state,
+			image,
+			cropRect: {
+				x: 0.113,
+				y: 0.127,
+				width: 0.733,
+				height: 0.641,
+			},
+			zoom: 0.5,
+		};
+		const { rerender } = render(
+			<Cropper
+				src="locked-ratio.png"
+				controller={ controller }
+				freeformCrop
+				aspectRatio={ 1 }
+			/>
+		);
+
+		await screen.findByTestId( 'cropper-image' );
+		controller.state = { ...controller.state, zoom: 3 };
+		rerender(
+			<Cropper
+				src="locked-ratio.png"
+				controller={ controller }
+				freeformCrop
+				aspectRatio={ 1 }
+			/>
+		);
+
+		expect( controller.setCropRect ).not.toHaveBeenCalled();
 	} );
 
 	function imageRendering(): string {

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -15,6 +15,7 @@ import {
 import { Cropper } from '../cropper';
 import type { CropperController } from '../../hooks/use-cropper-reducer';
 import { DEFAULT_STATE } from '../../../core/constants';
+import { getSourceRegion } from '../../../core/source-region';
 
 const GRID_TEST_ID = 'cropper-grid';
 const GRID_INTERACTIVE_CLASS =
@@ -425,7 +426,12 @@ describe( 'Cropper', () => {
 		//   rightOverflow = 1.01 * 600 − 600 = 6 → pan.x = −6
 		fireEvent.keyDown( eHandle, { key: 'ArrowRight' } );
 
-		expect( stage ).toHaveStyle( 'transform: translate(-6px, 0px)' );
+		const match = stage.style.transform.match(
+			/^translate\((-?\d+(?:\.\d+)?)px, (-?\d+(?:\.\d+)?)px\)$/
+		);
+		expect( match ).not.toBeNull();
+		expect( Number( match?.[ 1 ] ) ).toBeCloseTo( -6, 5 );
+		expect( Number( match?.[ 2 ] ) ).toBeCloseTo( 0, 5 );
 
 		jest.useRealTimers();
 	} );
@@ -626,6 +632,81 @@ describe( 'Cropper', () => {
 		expect( imageScale() ).toBeCloseTo( 2.4, 2 );
 
 		fireEvent.pointerUp( handle, { pointerId: 1 } );
+	} );
+
+	it( 'snaps freeform resize output to source pixels when the image is shown at 1:1 or larger', async () => {
+		const image = { src: 'tiny.png', naturalWidth: 50, naturalHeight: 50 };
+		const cropRect = { x: 0.113, y: 0.127, width: 0.6, height: 0.456 };
+		const controller = createController();
+		controller.state = {
+			...controller.state,
+			image,
+			cropRect,
+		};
+		const initialRegion = getSourceRegion(
+			{ ...controller.state, cropRect },
+			{ width: image.naturalWidth, height: image.naturalHeight }
+		);
+		render(
+			<Cropper src="tiny.png" controller={ controller } freeformCrop />
+		);
+
+		const handle = await screen.findByRole( 'button', {
+			name: 'Resize right edge',
+		} );
+		fireEvent.keyDown( handle, { key: 'ArrowRight' } );
+
+		const rect = ( controller.setCropRect as jest.Mock ).mock
+			.calls[ 0 ][ 0 ];
+		const region = getSourceRegion(
+			{ ...controller.state, cropRect: rect },
+			{ width: image.naturalWidth, height: image.naturalHeight }
+		);
+		expect( region.x ).toBeCloseTo( initialRegion.x, 3 );
+		expect( region.x ).not.toBeCloseTo( Math.round( region.x ), 3 );
+		expect( region.x + region.width ).toBeCloseTo(
+			Math.round( region.x + region.width ),
+			3
+		);
+		expect( rect.x ).toBeCloseTo( cropRect.x, 5 );
+		expect( rect.y ).toBeCloseTo( cropRect.y, 5 );
+		expect( rect.height ).toBeCloseTo( cropRect.height, 5 );
+	} );
+
+	it( 'keeps freeform resize smooth below 1:1 display scale', async () => {
+		const image = {
+			src: 'large.png',
+			naturalWidth: 3333,
+			naturalHeight: 3333,
+		};
+		const cropRect = { x: 0.113, y: 0.127, width: 0.6, height: 0.456 };
+		const controller = createController();
+		controller.state = {
+			...controller.state,
+			image,
+			cropRect,
+		};
+		render(
+			<Cropper src="large.png" controller={ controller } freeformCrop />
+		);
+
+		const handle = await screen.findByRole( 'button', {
+			name: 'Resize right edge',
+		} );
+		fireEvent.keyDown( handle, { key: 'ArrowRight' } );
+
+		const rect = ( controller.setCropRect as jest.Mock ).mock
+			.calls[ 0 ][ 0 ];
+		const region = getSourceRegion(
+			{ ...controller.state, cropRect: rect },
+			{ width: image.naturalWidth, height: image.naturalHeight }
+		);
+		expect( rect.width ).toBeCloseTo( 0.61, 5 );
+		expect(
+			Math.abs(
+				region.x + region.width - Math.round( region.x + region.width )
+			)
+		).toBeGreaterThan( 0.01 );
 	} );
 
 	function imageRendering(): string {


### PR DESCRIPTION
## What?

Follow up to 

- https://github.com/WordPress/gutenberg/pull/79044


Adds pixel-snapping for freeform crop resizing when the image is displayed at actual source-pixel size or larger.

This is a follow-up to the crop canvas fill work. The snapping is gated so large/downscaled images keep smooth resizing, while magnified images align crop output to source-pixel boundaries.

## Why?

When the cropper magnifies an image enough that individual source pixels are visible, fractional source-pixel crop edges can make the exported pixels less predictable. Snapping in pixel-visible mode makes precise small-region crops easier to reason about.

## How

- Reduces the hard source-pixel crop minimum to `16px`.
- Keeps the `44px` on-screen minimum for handle usability.
- Snaps all crop edges once when freeform cropping crosses into pixel-visible mode.
- Snaps only the moved edge or edges during freeform handle resize.
- Leaves large/downscaled images smooth below actual source-pixel size.
- Skips full-rect activation snapping for fixed-aspect crops to avoid altering the locked ratio.
- Covers pointer and keyboard resize paths.

## Testing Instructions

1. Open the media editor crop UI with freeform cropping enabled.
2. Use a small image that is magnified in the cropper so individual pixels are visible.
3. Zoom from below actual-size display to actual size or larger and confirm the crop edges settle onto source-pixel boundaries.
4. Drag a crop handle and confirm only the moved edge steps cleanly along source-pixel boundaries.
5. Confirm the opposite edge does not move while resizing a single edge.
6. Repeat with keyboard resizing on a focused handle.
7. Try a large image displayed below actual size and confirm resizing remains smooth without obvious snapping.
8. Try a fixed aspect-ratio crop and confirm resizing still behaves as before.

## Screenshots







https://github.com/user-attachments/assets/ee276ba2-9dca-4c78-8c57-1d05401a1eff



