### PR TITLE
Experiment: Toolbar UI refresh: remove Howdy prefix and make user avatar circular

### DIFF
--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -128,7 +128,7 @@ function gutenberg_initialize_experiments_settings() {
 				array(
 					'id'          => 'gutenberg-omnibar',
 					'label'       => __( 'Toolbar UI refresh', 'gutenberg' ),
-					'description' => __( 'Previews a redesigned toolbar UI that is visually consistent everywhere. For now, it includes replacing home/odometer dashicon with site icon if set.', 'gutenberg' ),
+					'description' => __( 'Previews a redesigned toolbar UI. Includes showing site icon, removing "Howdy, " prefix, and making user avatar circular.', 'gutenberg' ),
 				),
 				array(
 					'id'          => 'gutenberg-react-19',

--- a/lib/experimental/omnibar/load.php
+++ b/lib/experimental/omnibar/load.php
@@ -164,3 +164,40 @@ CSS;
 
 add_action( 'wp_enqueue_scripts', 'gutenberg_omnibar_user_avatar_styles' );
 add_action( 'admin_enqueue_scripts', 'gutenberg_omnibar_user_avatar_styles' );
+
+/**
+ * Removes the "Howdy," prefix from the admin bar my-account item, keeping the
+ * display name visible next to the avatar.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+ */
+function gutenberg_omnibar_remove_howdy( $wp_admin_bar ) {
+	if (
+		! is_admin_bar_showing() ||
+		! gutenberg_is_experiment_enabled( 'gutenberg-omnibar' )
+	) {
+		return;
+	}
+
+	$node = $wp_admin_bar->get_node( 'my-account' );
+	if ( ! $node ) {
+		return;
+	}
+
+	$display_name = wp_get_current_user()->display_name;
+	$display_span = '<span class="display-name">' . $display_name . '</span>';
+	/* translators: %s: Current user's display name. */
+	$howdy = sprintf( __( 'Howdy, %s', 'default' ), $display_span );
+	if ( ! str_contains( $node->title, $howdy ) ) {
+		return;
+	}
+
+	$wp_admin_bar->add_node(
+		array(
+			'id'    => 'my-account',
+			'title' => str_replace( $howdy, $display_span, $node->title ),
+		)
+	);
+}
+
+add_action( 'admin_bar_menu', 'gutenberg_omnibar_remove_howdy', 9992 );

--- a/lib/experimental/omnibar/load.php
+++ b/lib/experimental/omnibar/load.php
@@ -87,3 +87,80 @@ CSS;
 
 add_action( 'wp_enqueue_scripts', 'gutenberg_omnibar_site_icon_styles' );
 add_action( 'admin_enqueue_scripts', 'gutenberg_omnibar_site_icon_styles' );
+
+/**
+ * Replaces the 26px avatar in the admin bar my-account item with a 28px one.
+ *
+ * Backports https://github.com/WordPress/wordpress-develop/pull/11799.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+ */
+function gutenberg_omnibar_user_avatar( $wp_admin_bar ) {
+	if (
+		! is_admin_bar_showing() ||
+		! gutenberg_is_experiment_enabled( 'gutenberg-omnibar' )
+	) {
+		return;
+	}
+
+	$node    = $wp_admin_bar->get_node( 'my-account' );
+	$user_id = get_current_user_id();
+	if ( ! $node || ! $user_id ) {
+		return;
+	}
+
+	$old_avatar = get_avatar( $user_id, 26 );
+	$new_avatar = get_avatar( $user_id, 28 );
+	if ( ! $old_avatar || ! $new_avatar ) {
+		return;
+	}
+
+	$wp_admin_bar->add_node(
+		array(
+			'id'    => 'my-account',
+			'title' => str_replace( $old_avatar, $new_avatar, $node->title ),
+		)
+	);
+}
+
+add_action( 'admin_bar_menu', 'gutenberg_omnibar_user_avatar', 9992 );
+
+/**
+ * Adds the styles that make the admin bar user avatar circular.
+ *
+ * Backports https://github.com/WordPress/wordpress-develop/pull/11799.
+ */
+function gutenberg_omnibar_user_avatar_styles() {
+	if (
+		! is_admin_bar_showing() ||
+		! gutenberg_is_experiment_enabled( 'gutenberg-omnibar' )
+	) {
+		return;
+	}
+
+	$css = <<<CSS
+#wpadminbar #wp-admin-bar-user-info .avatar {
+	border-radius: 50%;
+}
+
+#wpadminbar #wp-admin-bar-my-account.with-avatar > .ab-empty-item img,
+#wpadminbar #wp-admin-bar-my-account.with-avatar > a img {
+	height: 20px;
+	border-radius: 50%;
+}
+
+@media screen and (max-width: 782px) {
+	#wpadminbar .quicklinks li#wp-admin-bar-my-account.with-avatar > a img {
+		top: 12px;
+		width: 28px;
+		height: 28px;
+		border-radius: 50%;
+	}
+}
+CSS;
+
+	wp_add_inline_style( 'admin-bar', $css );
+}
+
+add_action( 'wp_enqueue_scripts', 'gutenberg_omnibar_user_avatar_styles' );
+add_action( 'admin_enqueue_scripts', 'gutenberg_omnibar_user_avatar_styles' );


### PR DESCRIPTION
## What

Add new features to the "Toolbar UI refresh" experiment:

- Remove "Howdy, " prefix from the my account node.
- Enlarge and make user avatar image circular instead of square.

## Testing

Go to Settings -> Gutenberg Experiments, enable the following experiment:

<img width="615" height="82" alt="image" src="https://github.com/user-attachments/assets/d57cb760-fcbc-48de-9066-31ac8043b25a" />

then verify the screenshot below.

## Screenshot

Before

<img width="1566" height="64" alt="image" src="https://github.com/user-attachments/assets/d816cf48-de03-4a90-a4c2-b2e1f16dd60c" />


After

<img width="1566" height="64" alt="image" src="https://github.com/user-attachments/assets/7c4693fb-9b7b-4d31-96f6-93c0722100c1" />
