### PR TITLE
Refactor to move 'glob' dependency to appropriate workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
 				"cross-env": "^7.0.3",
 				"eslint": "^10.0.0",
 				"eslint-formatter-compact": "^9.0.1",
-				"glob": "^7.1.2",
 				"husky": "^7.0.0",
 				"lerna": "^9.0.7",
 				"lint-staged": "^16.4.0",
@@ -49630,6 +49629,7 @@
 			"devDependencies": {
 				"atob": "^2.1.2",
 				"css-loader": "^6.2.0",
+				"glob": "^7.1.2",
 				"lodash": "^4.17.21",
 				"mini-css-extract-plugin": "^2.9.2",
 				"mkdirp": "^3.0.1"
@@ -52117,6 +52117,7 @@
 			"version": "3.48.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
+				"glob": "^7.1.2",
 				"mkdirp": "^3.0.1",
 				"terser-webpack-plugin": "^5.3.10"
 			},

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
 		"cross-env": "^7.0.3",
 		"eslint": "^10.0.0",
 		"eslint-formatter-compact": "^9.0.1",
-		"glob": "^7.1.2",
 		"husky": "^7.0.0",
 		"lerna": "^9.0.7",
 		"lint-staged": "^16.4.0",

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -43,6 +43,7 @@
 	"devDependencies": {
 		"atob": "^2.1.2",
 		"css-loader": "^6.2.0",
+		"glob": "^7.1.2",
 		"lodash": "^4.17.21",
 		"mini-css-extract-plugin": "^2.9.2",
 		"mkdirp": "^3.0.1"

--- a/packages/readable-js-assets-webpack-plugin/package.json
+++ b/packages/readable-js-assets-webpack-plugin/package.json
@@ -33,6 +33,7 @@
 		"./package.json": "./package.json"
 	},
 	"devDependencies": {
+		"glob": "^7.1.2",
 		"mkdirp": "^3.0.1",
 		"terser-webpack-plugin": "^5.3.10"
 	},


### PR DESCRIPTION
## What?

Part of #75041

## Handles - 

Move glob out of root - 
* Remove glob from root package.json
* Add "glob": "^7.1.2" to packages/dependency-extraction-webpack-plugin/ and packages/readable-js-assets-webpack-plugin/package.json