### PR TITLE
Gallery: Hide Navigation button type when lightbox editing is disabled

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -754,7 +754,7 @@ export default function GalleryEdit( props ) {
 							/>
 						</ToolsPanelItem>
 					) }
-					{ lightboxSetting?.allowEditing && (
+					{ lightboxSetting?.allowEditing && hasLightboxImages && (
 						<ToolsPanelItem
 							label={ __( 'Navigation button type' ) }
 							isShownByDefault
@@ -765,32 +765,30 @@ export default function GalleryEdit( props ) {
 								} )
 							}
 						>
-							{ hasLightboxImages && (
-								<ToggleGroupControl
-									label={ __( 'Navigation button type' ) }
-									value={ navigationButtonType }
-									onChange={ ( value ) =>
-										setAttributes( {
-											navigationButtonType: value,
-										} )
-									}
-									isBlock
-									__next40pxDefaultSize
-									help={ __(
-										'Adjust the appearance of buttons in the lightbox.'
-									) }
-								>
-									{ NAVIGATION_BUTTON_TYPE_OPTIONS.map(
-										( option ) => (
-											<ToggleGroupControlOption
-												key={ option.value }
-												value={ option.value }
-												label={ option.label }
-											/>
-										)
-									) }
-								</ToggleGroupControl>
-							) }
+							<ToggleGroupControl
+								label={ __( 'Navigation button type' ) }
+								value={ navigationButtonType }
+								onChange={ ( value ) =>
+									setAttributes( {
+										navigationButtonType: value,
+									} )
+								}
+								isBlock
+								__next40pxDefaultSize
+								help={ __(
+									'Adjust the appearance of buttons in the lightbox.'
+								) }
+							>
+								{ NAVIGATION_BUTTON_TYPE_OPTIONS.map(
+									( option ) => (
+										<ToggleGroupControlOption
+											key={ option.value }
+											value={ option.value }
+											label={ option.label }
+										/>
+									)
+								) }
+							</ToggleGroupControl>
 						</ToolsPanelItem>
 					) }
 				</ToolsPanel>

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -754,43 +754,45 @@ export default function GalleryEdit( props ) {
 							/>
 						</ToolsPanelItem>
 					) }
-					<ToolsPanelItem
-						label={ __( 'Navigation button type' ) }
-						isShownByDefault
-						hasValue={ () => navigationButtonType !== 'icon' }
-						onDeselect={ () =>
-							setAttributes( {
-								navigationButtonType: 'icon',
-							} )
-						}
-					>
-						{ hasLightboxImages && (
-							<ToggleGroupControl
-								label={ __( 'Navigation button type' ) }
-								value={ navigationButtonType }
-								onChange={ ( value ) =>
-									setAttributes( {
-										navigationButtonType: value,
-									} )
-								}
-								isBlock
-								__next40pxDefaultSize
-								help={ __(
-									'Adjust the appearance of buttons in the lightbox.'
-								) }
-							>
-								{ NAVIGATION_BUTTON_TYPE_OPTIONS.map(
-									( option ) => (
-										<ToggleGroupControlOption
-											key={ option.value }
-											value={ option.value }
-											label={ option.label }
-										/>
-									)
-								) }
-							</ToggleGroupControl>
-						) }
-					</ToolsPanelItem>
+					{ lightboxSetting?.allowEditing && (
+						<ToolsPanelItem
+							label={ __( 'Navigation button type' ) }
+							isShownByDefault
+							hasValue={ () => navigationButtonType !== 'icon' }
+							onDeselect={ () =>
+								setAttributes( {
+									navigationButtonType: 'icon',
+								} )
+							}
+						>
+							{ hasLightboxImages && (
+								<ToggleGroupControl
+									label={ __( 'Navigation button type' ) }
+									value={ navigationButtonType }
+									onChange={ ( value ) =>
+										setAttributes( {
+											navigationButtonType: value,
+										} )
+									}
+									isBlock
+									__next40pxDefaultSize
+									help={ __(
+										'Adjust the appearance of buttons in the lightbox.'
+									) }
+								>
+									{ NAVIGATION_BUTTON_TYPE_OPTIONS.map(
+										( option ) => (
+											<ToggleGroupControlOption
+												key={ option.value }
+												value={ option.value }
+												label={ option.label }
+											/>
+										)
+									) }
+								</ToggleGroupControl>
+							) }
+						</ToolsPanelItem>
+					) }
 				</ToolsPanel>
 			</InspectorControls>
 			<BlockControls group="block">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #79133 

<!-- In a few words, what is the PR actually doing? -->
This PR hides the "Navigation button type" `ToolsPanelItem` for the Gallery block when Image block lightbox editing is disabled via `theme.json`. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
On disabling Image block lightbox functionality using the below code snippet, the Gallery block was still registering the "Navigation button type" panel item in the Settings menu even though there was no way to configure it or interact with it.

```js
{
  "settings": {
    "blocks": {
      "core/image": {
        "lightbox": {
          "allowEditing": false,
          "enabled": false
        }
      }
    }
  }
}
```

So it was exposing a menu item for a control that was not applicable.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The "Navigation button type" is now only registered when `lightboxSetting?.allowEditing` is enabled, so it prevents the item from being added to the ToolsPanel menu when lightbox editing is disabled, while preserving the existing behavior when lightbox editing is available.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Start a Gutenberg development environment.
2. Use a block theme (used Twenty Twenty-Five to reproduce and test).
3. Modify the `theme.json` to include:

```js
{
  "settings": {
    "blocks": {
      "core/image": {
        "lightbox": {
          "allowEditing": false,
          "enabled": false
        }
      }
    }
  }
}
```

4. Refresh the editor.
5. Create a post and insert a Gallery block with images.
6. Open the `⋮` menu next to Settings in the block inspector.
7. Verify that Navigation button type is not listed.
8. To check regression, restore the original `theme.json` or remove the lightbox configuration above.
9. Refresh the editor and open the same Gallery block.
10. Open the `⋮` menu next to Settings.
11. Verify that "Navigation button type" is visible again.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Open a post and insert a Gallery block.
2. Use the keyboard to select the Gallery block.
3. Navigate to the Settings panel and open the `⋮` menu using the keyboard.
4. With lightbox editing disabled via `theme.json`, verify that "Navigation button type" is not present in the menu.
5. Restore the default configuration and verify that the option is present again and remains keyboard accessible.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before | After |
| - | - |
| ![before](https://github.com/user-attachments/assets/aebcd557-284a-4dcf-9c75-86244e6f7a38) | ![after](https://github.com/user-attachments/assets/1f7cc6c4-58a5-43b5-aeba-af524a77a8ca) |

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
AI assistance was used for code analysis, drafting documentation, and implementation review. The implementation, testing, and verification were performed by author.