### PR TITLE
Theme: Enforce sRGB seed-color input contract for ThemeProvider

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Add `--wpds-border-radius-xl` for page and app shell surfaces so nested cards and notices can stay on `--wpds-border-radius-lg` without matching the parent radius ([#78913](https://github.com/WordPress/gutenberg/pull/78913)).
 
+### Bug Fix
+
+-   `ThemeProvider`: Strictly enforce the documented seed-color input contract for `color.primary` / `color.background`. Inputs outside sRGB (e.g. `oklch()`), previously accepted incidentally, now throw a clear error ([#NNNNN](https://github.com/WordPress/gutenberg/pull/NNNNN)).
+
 ## 0.15.0 (2026-06-10)
 
 ### New Features

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   Add `--wpds-border-radius-xl` for page and app shell surfaces so nested cards and notices can stay on `--wpds-border-radius-lg` without matching the parent radius ([#78913](https://github.com/WordPress/gutenberg/pull/78913)).
 
-### Bug Fix
+### Bug Fixes
 
 -   `ThemeProvider`: Strictly enforce the documented seed-color input contract for `color.primary` / `color.background`. Inputs outside sRGB (e.g. `oklch()`), previously accepted incidentally, now throw a clear error ([#79148](https://github.com/WordPress/gutenberg/pull/79148)).
 

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fix
 
--   `ThemeProvider`: Strictly enforce the documented seed-color input contract for `color.primary` / `color.background`. Inputs outside sRGB (e.g. `oklch()`), previously accepted incidentally, now throw a clear error ([#NNNNN](https://github.com/WordPress/gutenberg/pull/NNNNN)).
+-   `ThemeProvider`: Strictly enforce the documented seed-color input contract for `color.primary` / `color.background`. Inputs outside sRGB (e.g. `oklch()`), previously accepted incidentally, now throw a clear error ([#79148](https://github.com/WordPress/gutenberg/pull/79148)).
 
 ## 0.15.0 (2026-06-10)
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -98,7 +98,7 @@ The `color` prop accepts an object with the following optional properties:
 -   `primary`: The primary/accent seed color (default: `'#3858e9'`).
 -   `background`: The background seed color (default: `'#f8f8f8'`).
 
-Both properties accept a hex string (e.g. `#3858e9`), an `rgb(...)` string, or a CSS color keyword (e.g. `'blue'`). The theme system automatically generates appropriate color ramps and determines light/dark mode based on these seed colors.
+Both properties accept an sRGB-parseable string: a hex value (e.g. `#3858e9`), an `rgb()`/`rgba()` string, or a CSS named color (e.g. `'blue'`). Other CSS color spaces (e.g. `hsl()`, `oklch()`, `lab()`) are not accepted and will throw an error. The theme system automatically generates appropriate color ramps and determines light/dark mode based on these seed colors.
 
 The `cursor` prop accepts an object with the following optional properties:
 

--- a/packages/theme/src/color-ramps/lib/color-utils.ts
+++ b/packages/theme/src/color-ramps/lib/color-utils.ts
@@ -10,7 +10,7 @@ import {
 	type PlainColorObject,
 } from 'colorjs.io/fn';
 
-const ALLOWED_SEED_SPACE_IDS = new Set( [ 'srgb' ] );
+const ALLOWED_SEED_COLOR_SPACES = [ sRGB ];
 
 /**
  * Get string representation of a color.
@@ -51,7 +51,9 @@ export function getContrast(
  * @throws If `seed` is not an sRGB-parseable string.
  */
 export function assertValidSeedColor( seed: string ): void {
-	ColorSpace.register( sRGB );
+	ALLOWED_SEED_COLOR_SPACES.forEach( ( space ) =>
+		ColorSpace.register( space )
+	);
 
 	let spaceId: string;
 	try {
@@ -62,7 +64,9 @@ export function assertValidSeedColor( seed: string ): void {
 		);
 	}
 
-	if ( ! ALLOWED_SEED_SPACE_IDS.has( spaceId ) ) {
+	if (
+		! ALLOWED_SEED_COLOR_SPACES.some( ( space ) => space.id === spaceId )
+	) {
 		throw new Error(
 			`Unsupported seed color "${ seed }": expected a hex value, an \`rgb()\`/\`rgba()\` string, or a CSS named color, but received a \`${ spaceId }\` color.`
 		);

--- a/packages/theme/src/color-ramps/lib/color-utils.ts
+++ b/packages/theme/src/color-ramps/lib/color-utils.ts
@@ -10,10 +10,6 @@ import {
 	type PlainColorObject,
 } from 'colorjs.io/fn';
 
-/**
- * The color space ids that are accepted as seed-color input. Seeds must be
- * sRGB-parseable strings (hex, `rgb()`/`rgba()`, or a CSS named color).
- */
 const ALLOWED_SEED_SPACE_IDS = new Set( [ 'srgb' ] );
 
 /**
@@ -43,16 +39,13 @@ export function getContrast(
 }
 
 /**
- * Assert that a seed-color string conforms to the documented input contract:
- * an sRGB-parseable string (hex, `rgb()`/`rgba()`, or a CSS named color).
+ * Assert that a seed-color string is sRGB-parseable (hex, `rgb()`/`rgba()`, or
+ * a CSS named color), throwing otherwise.
  *
- * This is deliberately strict and deterministic: it rejects any other color
- * space (`oklch()`, `hsl()`, `lab()`, `hwb()`, `color()`, …) REGARDLESS of
- * which `ColorSpace`s happen to be globally registered. For example, the
- * `OKLCH` registration that `clampToGamut` requires would otherwise make
- * `oklch()` strings parseable; here, a successfully parsed `oklch()` color
- * still reports a space id of `oklch`, which is not in the allowlist and so is
- * rejected.
+ * Rejection is deterministic regardless of which `ColorSpace`s are globally
+ * registered: `clampToGamut` registers `OKLCH`, which would otherwise make
+ * `oklch()` strings parse, but their space id is `oklch` (not `srgb`) so they
+ * are still rejected.
  *
  * @param seed The seed-color string to validate.
  * @throws If `seed` is not an sRGB-parseable string.

--- a/packages/theme/src/color-ramps/lib/color-utils.ts
+++ b/packages/theme/src/color-ramps/lib/color-utils.ts
@@ -1,5 +1,6 @@
 import {
 	ColorSpace,
+	parse,
 	to,
 	toGamut,
 	serialize,
@@ -8,6 +9,12 @@ import {
 	OKLCH,
 	type PlainColorObject,
 } from 'colorjs.io/fn';
+
+/**
+ * The color space ids that are accepted as seed-color input. Seeds must be
+ * sRGB-parseable strings (hex, `rgb()`/`rgba()`, or a CSS named color).
+ */
+const ALLOWED_SEED_SPACE_IDS = new Set( [ 'srgb' ] );
 
 /**
  * Get string representation of a color.
@@ -33,6 +40,40 @@ export function getContrast(
 ): number {
 	ColorSpace.register( sRGB );
 	return contrastWCAG21( colorA, colorB );
+}
+
+/**
+ * Assert that a seed-color string conforms to the documented input contract:
+ * an sRGB-parseable string (hex, `rgb()`/`rgba()`, or a CSS named color).
+ *
+ * This is deliberately strict and deterministic: it rejects any other color
+ * space (`oklch()`, `hsl()`, `lab()`, `hwb()`, `color()`, …) REGARDLESS of
+ * which `ColorSpace`s happen to be globally registered. For example, the
+ * `OKLCH` registration that `clampToGamut` requires would otherwise make
+ * `oklch()` strings parseable; here, a successfully parsed `oklch()` color
+ * still reports a space id of `oklch`, which is not in the allowlist and so is
+ * rejected.
+ *
+ * @param seed The seed-color string to validate.
+ * @throws If `seed` is not an sRGB-parseable string.
+ */
+export function assertValidSeedColor( seed: string ): void {
+	ColorSpace.register( sRGB );
+
+	let spaceId: string;
+	try {
+		( { spaceId } = parse( seed ) );
+	} catch {
+		throw new Error(
+			`Unsupported seed color "${ seed }": expected a hex value, an \`rgb()\`/\`rgba()\` string, or a CSS named color.`
+		);
+	}
+
+	if ( ! ALLOWED_SEED_SPACE_IDS.has( spaceId ) ) {
+		throw new Error(
+			`Unsupported seed color "${ seed }": expected a hex value, an \`rgb()\`/\`rgba()\` string, or a CSS named color, but received a \`${ spaceId }\` color.`
+		);
+	}
 }
 
 /**

--- a/packages/theme/src/color-ramps/lib/index.ts
+++ b/packages/theme/src/color-ramps/lib/index.ts
@@ -1,5 +1,10 @@
 import { clone, get, OKLCH, set, type PlainColorObject } from 'colorjs.io/fn';
-import { clampToGamut, getContrast, getColorString } from './color-utils';
+import {
+	assertValidSeedColor,
+	clampToGamut,
+	getContrast,
+	getColorString,
+} from './color-utils';
 import { findColorMeetingRequirements } from './find-color-with-constraints';
 import {
 	sortByDependency,
@@ -203,6 +208,12 @@ export function buildRamp(
 		rescaleToFitContrastTargets?: boolean;
 	} = {}
 ): RampResult {
+	// Enforce the documented seed-color input contract at the single
+	// user-input chokepoint. Internal recursive callers pass
+	// `PlainColorObject`s to `clampToGamut`, not strings to `buildRamp`, so
+	// this is the right boundary for string validation.
+	assertValidSeedColor( seedArg );
+
 	let seed: PlainColorObject;
 	try {
 		seed = clampToGamut( seedArg );

--- a/packages/theme/src/color-ramps/lib/index.ts
+++ b/packages/theme/src/color-ramps/lib/index.ts
@@ -208,10 +208,8 @@ export function buildRamp(
 		rescaleToFitContrastTargets?: boolean;
 	} = {}
 ): RampResult {
-	// Enforce the documented seed-color input contract at the single
-	// user-input chokepoint. Internal recursive callers pass
-	// `PlainColorObject`s to `clampToGamut`, not strings to `buildRamp`, so
-	// this is the right boundary for string validation.
+	// Validate here: the single point where user-supplied color strings enter.
+	// Internal recursive callers pass color objects to `clampToGamut` instead.
 	assertValidSeedColor( seedArg );
 
 	let seed: PlainColorObject;

--- a/packages/theme/src/color-ramps/test/seed-input.test.ts
+++ b/packages/theme/src/color-ramps/test/seed-input.test.ts
@@ -3,63 +3,52 @@ import { buildBgRamp, buildAccentRamp } from '../index';
 import { buildRamp } from '../lib';
 import { BG_RAMP_CONFIG } from '../lib/ramp-configs';
 
-describe( 'seed color input contract', () => {
-	const accepted = [
-		'#3858e9',
-		'#3858e94d',
-		'rgb(56,88,233)',
-		'rgb(56 88 233 / 0.3)',
-		'rgba(56,88,233,0.3)',
-		'blue',
-		'transparent',
-	];
+const ACCEPTED_SEEDS = [
+	'#3858e9',
+	'#3858e94d',
+	'rgb(56,88,233)',
+	'rgb(56 88 233 / 0.3)',
+	'rgba(56,88,233,0.3)',
+	'blue',
+	'transparent',
+];
 
-	const rejected = [
-		'oklch(0.7 0.15 250)',
-		'hsl(230 80% 56%)',
-		'lab(50% 40 59)',
-		'hwb(230 10% 20%)',
-		'color(display-p3 1 0 0)',
-		'',
-		'not-a-color',
-	];
+const REJECTED_SEEDS = [
+	'oklch(0.7 0.15 250)',
+	'hsl(230 80% 56%)',
+	'lab(50% 40 59)',
+	'hwb(230 10% 20%)',
+	'color(display-p3 1 0 0)',
+	'',
+	'not-a-color',
+];
 
-	describe.each( accepted )( 'accepts sRGB-parseable seed %p', ( seed ) => {
-		it( 'buildBgRamp does not throw', () => {
-			expect( () => buildBgRamp( seed ) ).not.toThrow();
-		} );
-
-		it( 'buildAccentRamp does not throw', () => {
-			expect( () => buildAccentRamp( seed ) ).not.toThrow();
-		} );
-
-		it( 'buildRamp does not throw', () => {
-			expect( () => buildRamp( seed, BG_RAMP_CONFIG ) ).not.toThrow();
-		} );
+// Each public entry point shares the same seed-color input contract, so the
+// same assertions run against all of them.
+function testSeedColorContract( build: ( seed: string ) => unknown ) {
+	it.each( ACCEPTED_SEEDS )( 'accepts sRGB-parseable seed %p', ( seed ) => {
+		expect( () => build( seed ) ).not.toThrow();
 	} );
 
-	describe.each( rejected )( 'rejects non-sRGB seed %p', ( seed ) => {
-		it( 'buildBgRamp throws', () => {
-			expect( () => buildBgRamp( seed ) ).toThrow();
-		} );
-
-		it( 'buildAccentRamp throws', () => {
-			expect( () => buildAccentRamp( seed ) ).toThrow();
-		} );
-
-		it( 'buildRamp throws', () => {
-			expect( () => buildRamp( seed, BG_RAMP_CONFIG ) ).toThrow();
-		} );
+	it.each( REJECTED_SEEDS )( 'rejects non-sRGB seed %p', ( seed ) => {
+		expect( () => build( seed ) ).toThrow();
 	} );
 
-	it( 'rejects oklch() even when the OKLCH color space is globally registered', () => {
+	it( 'rejects oklch() even when the OKLCH color space is registered', () => {
 		// Registering OKLCH would otherwise make `oklch(...)` strings parse.
 		ColorSpace.register( OKLCH );
-
-		expect( () =>
-			buildRamp( 'oklch(0.7 0.15 250)', BG_RAMP_CONFIG )
-		).toThrow();
-		expect( () => buildBgRamp( 'oklch(0.7 0.15 250)' ) ).toThrow();
-		expect( () => buildAccentRamp( 'oklch(0.7 0.15 250)' ) ).toThrow();
+		expect( () => build( 'oklch(0.7 0.15 250)' ) ).toThrow();
 	} );
+}
+
+describe( 'buildBgRamp', () => {
+	testSeedColorContract( buildBgRamp );
+} );
+
+describe( 'buildAccentRamp', () => {
+	testSeedColorContract( ( seed ) => buildAccentRamp( seed ) );
+} );
+
+describe( 'buildRamp', () => {
+	testSeedColorContract( ( seed ) => buildRamp( seed, BG_RAMP_CONFIG ) );
 } );

--- a/packages/theme/src/color-ramps/test/seed-input.test.ts
+++ b/packages/theme/src/color-ramps/test/seed-input.test.ts
@@ -1,0 +1,66 @@
+import { ColorSpace, OKLCH } from 'colorjs.io/fn';
+import { buildBgRamp, buildAccentRamp } from '../index';
+import { buildRamp } from '../lib';
+import { BG_RAMP_CONFIG } from '../lib/ramp-configs';
+
+describe( 'seed color input contract', () => {
+	const accepted = [
+		'#3858e9',
+		'#3858e94d',
+		'rgb(56,88,233)',
+		'rgb(56 88 233 / 0.3)',
+		'rgba(56,88,233,0.3)',
+		'blue',
+		'transparent',
+	];
+
+	const rejected = [
+		'oklch(0.7 0.15 250)',
+		'hsl(230 80% 56%)',
+		'lab(50% 40 59)',
+		'hwb(230 10% 20%)',
+		'color(display-p3 1 0 0)',
+		'',
+		'not-a-color',
+	];
+
+	describe.each( accepted )( 'accepts sRGB-parseable seed %p', ( seed ) => {
+		it( 'buildBgRamp does not throw', () => {
+			expect( () => buildBgRamp( seed ) ).not.toThrow();
+		} );
+
+		it( 'buildAccentRamp does not throw', () => {
+			expect( () => buildAccentRamp( seed ) ).not.toThrow();
+		} );
+
+		it( 'buildRamp does not throw', () => {
+			expect( () => buildRamp( seed, BG_RAMP_CONFIG ) ).not.toThrow();
+		} );
+	} );
+
+	describe.each( rejected )( 'rejects non-sRGB seed %p', ( seed ) => {
+		it( 'buildBgRamp throws', () => {
+			expect( () => buildBgRamp( seed ) ).toThrow();
+		} );
+
+		it( 'buildAccentRamp throws', () => {
+			expect( () => buildAccentRamp( seed ) ).toThrow();
+		} );
+
+		it( 'buildRamp throws', () => {
+			expect( () => buildRamp( seed, BG_RAMP_CONFIG ) ).toThrow();
+		} );
+	} );
+
+	it( 'rejects oklch() even when the OKLCH color space is globally registered', () => {
+		// Registering OKLCH would otherwise make `oklch(...)` strings parseable.
+		// The contract must stay deterministic regardless of global registration.
+		ColorSpace.register( OKLCH );
+
+		expect( () =>
+			buildRamp( 'oklch(0.7 0.15 250)', BG_RAMP_CONFIG )
+		).toThrow();
+		expect( () => buildBgRamp( 'oklch(0.7 0.15 250)' ) ).toThrow();
+		expect( () => buildAccentRamp( 'oklch(0.7 0.15 250)' ) ).toThrow();
+	} );
+} );

--- a/packages/theme/src/color-ramps/test/seed-input.test.ts
+++ b/packages/theme/src/color-ramps/test/seed-input.test.ts
@@ -53,8 +53,7 @@ describe( 'seed color input contract', () => {
 	} );
 
 	it( 'rejects oklch() even when the OKLCH color space is globally registered', () => {
-		// Registering OKLCH would otherwise make `oklch(...)` strings parseable.
-		// The contract must stay deterministic regardless of global registration.
+		// Registering OKLCH would otherwise make `oklch(...)` strings parse.
 		ColorSpace.register( OKLCH );
 
 		expect( () =>

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -6,16 +6,22 @@ export interface ThemeProviderSettings {
 	 */
 	color?: {
 		/**
-		 * The primary seed color to use for the theme. Accepts a hex string
-		 * (e.g. `#3858e9`), an `rgb(...)` string, or a CSS color keyword.
+		 * The primary seed color to use for the theme. Accepts an
+		 * sRGB-parseable string: a hex value (e.g. `#3858e9`), an
+		 * `rgb()`/`rgba()` string, or a CSS named color (e.g. `'blue'`). Other
+		 * CSS color spaces (e.g. `hsl()`, `oklch()`, `lab()`) are not accepted
+		 * and throw an error.
 		 *
 		 * By default, it inherits from parent `ThemeProvider`,
 		 * and fallbacks to statically built CSS.
 		 */
 		primary?: string;
 		/**
-		 * The background seed color to use for the theme. Accepts a hex string
-		 * (e.g. `#f8f8f8`), an `rgb(...)` string, or a CSS color keyword.
+		 * The background seed color to use for the theme. Accepts an
+		 * sRGB-parseable string: a hex value (e.g. `#f8f8f8`), an
+		 * `rgb()`/`rgba()` string, or a CSS named color (e.g. `'blue'`). Other
+		 * CSS color spaces (e.g. `hsl()`, `oklch()`, `lab()`) are not accepted
+		 * and throw an error.
 		 *
 		 * By default, it inherits from parent `ThemeProvider`,
 		 * and fallbacks to statically built CSS.


### PR DESCRIPTION
## What?

See #77462 (point A6).

`ThemeProvider`'s `color.primary` / `color.background` seed colors are documented as sRGB strings (hex, `rgb()`/`rgba()`, CSS named colors). This makes the runtime match the docs: colors outside sRGB (e.g. `oklch()`) now throw a clear error instead of being accepted by accident.

## Why?

The accepted input set was an accidental side effect of which color spaces happened to be registered internally — not a deliberate contract.

<details>
<summary>Background</summary>

`clampToGamut` registers the `OKLCH` color space as a required workaround for an open upstream gamut-mapping limitation ([color-js/color.js#734](https://github.com/color-js/color.js/pull/734)). That registration is what incidentally made `oklch()` seed strings parse. So whether an input was accepted depended on registration order rather than a documented rule.

</details>

## How?

Validate the seed string at the single user-input chokepoint (`buildRamp`) and reject any color whose space isn't sRGB — deterministically, regardless of what's globally registered. `clampToGamut` and its `OKLCH` registration are left untouched.

<details>
<summary>Implementation notes</summary>

- New `assertValidSeedColor` helper parses the seed with the registered `sRGB` space and throws unless the parsed color's space id is in the allowlist `{ 'srgb' }`.
- This rejects `oklch()` either way: if `OKLCH` is registered, the parsed space id is `oklch` (≠ `srgb`); if not, parsing throws.
- Internal recursive callers pass color objects (not strings) to `clampToGamut`, so `buildRamp` is the correct boundary for string validation.
- Docs (`types.ts`, `README.md`) and a CHANGELOG entry updated accordingly.

</details>

## Testing Instructions

```
npm run test:unit packages/theme
```

<details>
<summary>What the new tests cover</summary>

`packages/theme/src/color-ramps/test/seed-input.test.ts`, exercised through the public `buildBgRamp` / `buildAccentRamp` / `buildRamp` entry points:

- **Accepted**: `#3858e9`, `#3858e94d`, `rgb(56,88,233)`, `rgb(56 88 233 / 0.3)`, `rgba(56,88,233,0.3)`, `blue`, `transparent`.
- **Rejected**: `oklch(0.7 0.15 250)`, `hsl(230 80% 56%)`, `lab(50% 40 59)`, `hwb(230 10% 20%)`, `color(display-p3 1 0 0)`, `''`, `not-a-color`.
- **Determinism regression**: with `OKLCH` explicitly registered in the test, `oklch(...)` is still rejected.

Existing snapshot tests still pass.

</details>

## Use of AI Tools

This PR was authored with AI assistance (Cursor). All changes were reviewed by a human.