### PR TITLE
Theme: differentiate `--wpds-color-fg-interactive-{brand,error}-active` vs resting state tokens

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -18,6 +18,10 @@
 -   Rename the `bg` and `fg` design token groups to `background` and `foreground`. All `--wpds-color-bg-*` custom properties are now `--wpds-color-background-*`, and all `--wpds-color-fg-*` custom properties are now `--wpds-color-foreground-*` ([#79098](https://github.com/WordPress/gutenberg/pull/79098)).
 -   Rename the `--wpds-color-stroke-focus-brand` design token to `--wpds-color-stroke-focus` ([#79125](https://github.com/WordPress/gutenberg/pull/79125)).
 
+### Enhancements
+
+-   Tweak `--wpds-color-fg-interactive-brand-active` and `--wpds-color-fg-interactive-error-active` to differentiate them from the non-`active` counterparts ([#79151](https://github.com/WordPress/gutenberg/pull/79151)).
+
 ### Bug Fixes
 
 -   `ThemeProvider`: Strictly enforce the documented seed-color input contract for `color.primary` / `color.background`. Inputs outside sRGB (e.g. `oklch()`), previously accepted incidentally, now throw a clear error ([#79148](https://github.com/WordPress/gutenberg/pull/79148)).
@@ -47,7 +51,8 @@
 -   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
 
 ### Breaking Changes
-- Revert React back to v18 [#78940](https://github.com/WordPress/gutenberg/pull/78940).
+
+-   Revert React back to v18 [#78940](https://github.com/WordPress/gutenberg/pull/78940).
 -   Drop the experimental `density` support from `ThemeProvider`. The `density` prop has been removed, along with the related `data-wpds-density` attribute and the per-density overrides on `--wpds-dimension-padding-*` / `--wpds-dimension-gap-*` tokens ([#78741](https://github.com/WordPress/gutenberg/pull/78741)).
 -   Rename the `color.bg` prop on `ThemeProvider` to `color.background` ([#79007](https://github.com/WordPress/gutenberg/pull/79007)).
 

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Enhancements
 
--   Tweak `--wpds-color-fg-interactive-brand-active` and `--wpds-color-fg-interactive-error-active` to differentiate them from the non-`active` counterparts ([#79151](https://github.com/WordPress/gutenberg/pull/79151)).
+-   Tweak `--wpds-color-foreground-interactive-brand-active` and `--wpds-color-foreground-interactive-error-active` to differentiate them from the non-`active` counterparts ([#79151](https://github.com/WordPress/gutenberg/pull/79151)).
 
 ### Bug Fixes
 

--- a/packages/theme/src/prebuilt/css/design-tokens.css
+++ b/packages/theme/src/prebuilt/css/design-tokens.css
@@ -150,7 +150,7 @@
 	/* Foreground color for interactive elements with brand tone and normal emphasis. */
 	--wpds-color-foreground-interactive-brand: #3858e9;
 	/* Foreground color for interactive elements with brand tone and normal emphasis that are hovered, focused, or active. */
-	--wpds-color-foreground-interactive-brand-active: #3858e9;
+	--wpds-color-foreground-interactive-brand-active: #0b0070;
 	/* Foreground color for interactive elements with brand tone and normal emphasis, in their disabled state. */
 	--wpds-color-foreground-interactive-brand-disabled: #8d8d8d;
 	/* Foreground color for interactive elements with brand tone and strong emphasis. */
@@ -162,7 +162,7 @@
 	/* Foreground color for interactive elements with error tone and normal emphasis. */
 	--wpds-color-foreground-interactive-error: #cc1818;
 	/* Foreground color for interactive elements with error tone and normal emphasis that are hovered, focused, or active. */
-	--wpds-color-foreground-interactive-error-active: #cc1818;
+	--wpds-color-foreground-interactive-error-active: #470000;
 	/* Foreground color for interactive elements with error tone and normal emphasis, in their disabled state. */
 	--wpds-color-foreground-interactive-error-disabled: #8d8d8d;
 	/* Foreground color for interactive elements with error tone and strong emphasis. */

--- a/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
+++ b/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
@@ -77,13 +77,13 @@ export default {
 	'--wpds-color-foreground-interactive-brand':
 		'var(--wp-admin-theme-color, #3858e9)',
 	'--wpds-color-foreground-interactive-brand-active':
-		'var(--wp-admin-theme-color, #3858e9)',
+		'color-mix(in oklch, var(--wp-admin-theme-color, #3858e9) 52%, black)',
 	'--wpds-color-foreground-interactive-brand-disabled': '#8d8d8d',
 	'--wpds-color-foreground-interactive-brand-strong': '#fff',
 	'--wpds-color-foreground-interactive-brand-strong-active': '#fff',
 	'--wpds-color-foreground-interactive-brand-strong-disabled': '#8d8d8d',
 	'--wpds-color-foreground-interactive-error': '#cc1818',
-	'--wpds-color-foreground-interactive-error-active': '#cc1818',
+	'--wpds-color-foreground-interactive-error-active': '#470000',
 	'--wpds-color-foreground-interactive-error-disabled': '#8d8d8d',
 	'--wpds-color-foreground-interactive-error-strong': '#f2efef',
 	'--wpds-color-foreground-interactive-error-strong-active': '#f2efef',

--- a/packages/theme/src/prebuilt/ts/color-tokens.ts
+++ b/packages/theme/src/prebuilt/ts/color-tokens.ts
@@ -21,10 +21,8 @@ export default {
 	],
 	'primary-bgFill2': [ 'background-interactive-brand-strong-active' ],
 	'primary-surface4': [ 'background-interactive-brand-weak-active' ],
-	'primary-fgSurface3': [
-		'foreground-interactive-brand',
-		'foreground-interactive-brand-active',
-	],
+	'primary-fgSurface4': [ 'foreground-interactive-brand-active' ],
+	'primary-fgSurface3': [ 'foreground-interactive-brand' ],
 	'primary-stroke3': [
 		'background-thumb-brand',
 		'background-thumb-brand-active',
@@ -67,11 +65,13 @@ export default {
 		'background-interactive-error-weak-active',
 		'background-surface-error',
 	],
-	'error-fgSurface4': [ 'foreground-content-error' ],
+	'error-fgSurface4': [
+		'foreground-content-error',
+		'foreground-interactive-error-active',
+	],
 	'error-fgSurface3': [
 		'foreground-content-error-weak',
 		'foreground-interactive-error',
-		'foreground-interactive-error-active',
 	],
 	'error-stroke3': [
 		'stroke-interactive-error',

--- a/packages/theme/tokens/color.json
+++ b/packages/theme/tokens/color.json
@@ -1372,7 +1372,7 @@
 					"$description": "Foreground color for interactive elements with brand tone and normal emphasis."
 				},
 				"brand-active": {
-					"$value": "{wpds-color.primitive.primary.fgSurface3}",
+					"$value": "{wpds-color.primitive.primary.fgSurface4}",
 					"$description": "Foreground color for interactive elements with brand tone and normal emphasis that are hovered, focused, or active."
 				},
 				"brand-disabled": {
@@ -1396,7 +1396,7 @@
 					"$description": "Foreground color for interactive elements with error tone and normal emphasis."
 				},
 				"error-active": {
-					"$value": "{wpds-color.primitive.error.fgSurface3}",
+					"$value": "{wpds-color.primitive.error.fgSurface4}",
 					"$description": "Foreground color for interactive elements with error tone and normal emphasis that are hovered, focused, or active."
 				},
 				"error-disabled": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Partially addresses https://github.com/WordPress/gutenberg/issues/77153

Remaps `--wpds-color-foreground-interactive-brand-active` and `--wpds-color-foreground-interactive-error-active` tokens from `fgSurface3` to `fgSurface4`

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As explained in https://github.com/WordPress/gutenberg/issues/77153, currently, resting state and active (used for hover/focus) share the same value.

Changing the value will increase visual discernibility between the two states.

This change was made in collaboration with @jameskoster during a pairing session

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Changing internal mapping, rebuilding tokens

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check hover/focus styles on the DS `Button` story (brand tone, minimal and outline variants), observe text color changes.

The `--wpds-color-foreground-interactive-error-active` token is not currently in use.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="202" height="138" alt="Screenshot 2026-06-12 at 14 28 46" src="https://github.com/user-attachments/assets/1cdce229-61d2-4916-94b8-fae119a0d94e" /> | <img width="208" height="140" alt="Screenshot 2026-06-12 at 14 28 57" src="https://github.com/user-attachments/assets/248497c4-30ab-4e82-a200-987a4003e3d5" /> |

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Cursor + Claude Opus 4.8