### PR TITLE
Core Abilities: Restore the ready promise and lazy-load via dynamic import

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -489,11 +489,3 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 function gutenberg_enqueue_video_conversion_loader() {
 	wp_enqueue_script_module( '@wordpress/video-conversion/loader' );
 }
-
-/**
- * Enqueues the core abilities script module in the admin screens.
- */
-add_action( 'admin_enqueue_scripts', 'gutenberg_enqueue_core_abilities' );
-function gutenberg_enqueue_core_abilities() {
-	wp_enqueue_script_module( '@wordpress/core-abilities' );
-}

--- a/packages/core-abilities/README.md
+++ b/packages/core-abilities/README.md
@@ -16,21 +16,35 @@ _This package assumes that your code will run in an ES2015+ environment. If you'
 
 ## Usage
 
-This package is designed to be loaded as a script module on WordPress admin pages. It exposes an `initialize()` function that, on first call:
+This package is designed to be loaded as a script module on WordPress admin pages. When loaded, it automatically:
 
-1. Fetches all ability categories from `/wp-abilities/v1/categories` and registers them with `@wordpress/abilities`
-2. Fetches all abilities from `/wp-abilities/v1/abilities` and registers them with a `callback` that handles execution via REST API
+1. Fetches all ability categories from `/wp-abilities/v1/categories`
+2. Registers them with `@wordpress/abilities`
+3. Fetches all abilities from `/wp-abilities/v1/abilities`
+4. Registers them with a `callback` that handles execution via REST API
 
-Initialization is lazy: importing the package does not trigger network requests. Call `initialize()` from the feature that needs abilities — for example, when the workflow palette opens. Repeated calls return the same in-flight or resolved promise, so the requests fire at most once.
+Simply import the package to initialize the WordPress abilities:
 
 ```js
-import { initialize } from '@wordpress/core-abilities';
+import '@wordpress/core-abilities';
+```
+
+Initialization is asynchronous because categories and abilities are fetched from the REST API. To wait for registration to finish before calling `getAbilities()` or `executeAbility()`, await the exported `ready` promise:
+
+```js
+import { ready } from '@wordpress/core-abilities';
 import { getAbilities, executeAbility } from '@wordpress/abilities';
 
-await initialize();
+await ready;
 
 console.log( getAbilities() );
 console.log( await executeAbility( 'core/get-site-info' ) );
+```
+
+To defer the network requests until a feature actually needs abilities, import the package dynamically from that feature — the module (and therefore its requests) only loads when the `import()` call runs:
+
+```js
+await import( '@wordpress/core-abilities' );
 ```
 
 ## Contributing to this package

--- a/packages/core-abilities/src/index.ts
+++ b/packages/core-abilities/src/index.ts
@@ -133,21 +133,14 @@ async function initializeAbilities(): Promise< void > {
 	}
 }
 
-let initializePromise: Promise< void > | null = null;
-
 /**
- * Fetches and registers core abilities and their categories.
- *
- * Memoized: repeated calls return the same in-flight or resolved promise, so
- * callers can invoke it from multiple entry points without triggering duplicate
- * REST requests.
+ * Initialize WordPress abilities integration.
  */
-export function initialize(): Promise< void > {
-	if ( ! initializePromise ) {
-		initializePromise = ( async () => {
-			await initializeCategories();
-			await initializeAbilities();
-		} )();
-	}
-	return initializePromise;
+async function initialize(): Promise< void > {
+	// Fetch and register categories, then abilities
+	await initializeCategories();
+	await initializeAbilities();
 }
+
+// Auto-initialize on import.
+export const ready: Promise< void > = initialize();

--- a/packages/workflow/src/components/workflow-menu.js
+++ b/packages/workflow/src/components/workflow-menu.js
@@ -21,7 +21,6 @@ import {
 } from '@wordpress/keyboard-shortcuts';
 import { Icon, search as inputIcon } from '@wordpress/icons';
 import { executeAbility, store as abilitiesStore } from '@wordpress/abilities';
-import { initialize as initializeCoreAbilities } from '@wordpress/core-abilities';
 
 /**
  * Internal dependencies
@@ -128,7 +127,9 @@ export function WorkflowMenu() {
 
 	useEffect( () => {
 		if ( isOpen ) {
-			initializeCoreAbilities();
+			// Load @wordpress/core-abilities on demand. Importing it fetches
+			// and registers all server abilities and categories.
+			import( '@wordpress/core-abilities' );
 		}
 	}, [ isOpen ] );
 


### PR DESCRIPTION
## What?

Restores the `@wordpress/core-abilities` public API that was removed in #78316, while keeping the performance improvement that PR introduced.

- Importing `@wordpress/core-abilities` auto-initializes again, and the exported `ready` promise resolves once all server abilities and categories are registered.
- The `initialize()` export introduced in #78316 is removed — consumers no longer need to call anything.

## Why?

#78316 broke backward compatibility: it removed the exported `ready` promise and forced consumers to call a new `initialize()` function. This restores the previous contract without losing the deferred fetching.

## How?

The laziness moves from the API surface to the module graph:

- `packages/workflow/src/components/workflow-menu.js` now dynamically `import( '@wordpress/core-abilities' )` when the palette opens. Since both packages are script modules, the dependency is emitted as `array( 'id' => '@wordpress/core-abilities', 'import' => 'dynamic' )` in the asset file, so WordPress puts it in the import map without preloading it — the module (and its two REST requests) only loads on first open. This follows the existing `@wordpress/vips/loader` pattern. The ESM module cache guarantees the fetches run at most once.
- The unconditional `wp_enqueue_script_module( '@wordpress/core-abilities' )` on every admin page is removed from `lib/client-assets.php`; with auto-init restored it would have re-introduced the requests-on-every-admin-page issue. The module remains registered via the generated module registry.
- The package README is restored to document `ready` and now mentions dynamic `import()` as the way to defer the requests.

## Testing Instructions

1. Enable the `gutenberg-workflow-palette` experiment.
2. Load any wp-admin page and confirm no `/wp-abilities/v1/*` requests fire on page load.
3. Press <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>J</kbd> — the categories and abilities requests fire, and registered abilities appear in the palette.
4. Close and reopen the palette — no refetch.

Covered by the existing e2e test:

```
npm run test:e2e -- test/e2e/specs/admin/workflow-palette.spec.js
```

The preload specs (`test/e2e/specs/preload/`) also pass.