### PR TITLE
Theme: Add design tokens maintainer's guide documentation

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Rename the `bg` and `fg` design token groups to `background` and `foreground`. All `--wpds-color-bg-*` custom properties are now `--wpds-color-background-*`, and all `--wpds-color-fg-*` custom properties are now `--wpds-color-foreground-*` ([#79098](https://github.com/WordPress/gutenberg/pull/79098)).
+
 ### New Features
 
 -   Add `--wpds-color-stroke-surface-caution` and `--wpds-color-stroke-surface-caution-strong` so the `caution` tone has the same stroke-surface coverage as the other status tones ([#79198](https://github.com/WordPress/gutenberg/pull/79198)).
@@ -13,10 +17,11 @@
 
 -   `ThemeProvider`: forward the `cornerRadius` preset to the document element when `isRoot` is set, matching `color` and `cursor`. [#79153](https://github.com/WordPress/gutenberg/pull/79153).
 
-### Breaking Changes
+### Documentation
 
 -   Rename the `bg` and `fg` design token groups to `background` and `foreground`. All `--wpds-color-bg-*` custom properties are now `--wpds-color-background-*`, and all `--wpds-color-fg-*` custom properties are now `--wpds-color-foreground-*` ([#79098](https://github.com/WordPress/gutenberg/pull/79098)).
 -   Rename the `--wpds-color-stroke-focus-brand` design token to `--wpds-color-stroke-focus` ([#79125](https://github.com/WordPress/gutenberg/pull/79125)).
+-   Added [Design Tokens Maintainer's Guide](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/tokens/README.md) and trimmed maintainer-facing content from package README ([#79157](https://github.com/WordPress/gutenberg/pull/79157)).
 
 ### Enhancements
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -67,7 +67,7 @@ Design tokens are the visual design atoms of a design system. They are named ent
 
 Rather than hardcoding values like `#3858e9` or `16px` throughout your code, tokens provide semantic names like `--wpds-color-background-interactive-brand-strong` or `--wpds-dimension-padding-2xl` that describe the purpose and context of the value. This makes code more maintainable and allows the design system to evolve. When a token's value changes, all components using that token automatically reflect the update.
 
-For more information about how design tokens are implemented, you'll find additional documentation in [`tokens/README.md`](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/tokens/README.md).
+For more information about how design tokens are implemented, see [`tokens/README.md`](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/tokens/README.md).
 
 ## Theme Provider
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -11,7 +11,13 @@ A theming package that's part of the WordPress Design System. It has two parts:
 
 ## Design Tokens
 
-In the **[Design Tokens Reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md)** document there is a complete reference of all available design tokens including colors, spacing, typography, and more.
+Design tokens are the visual design atoms of a design system. They are named entities that store visual design attributes like colors, spacing, typography, and shadows. They serve as a single source of truth that bridges design and development, ensuring consistency across platforms and making it easy to maintain and evolve the visual language of an application.
+
+Rather than hardcoding values like `#3858e9` or `16px` throughout your code, tokens provide semantic names like `--wpds-color-background-interactive-brand-strong` or `--wpds-dimension-padding-2xl` that describe the purpose and context of the value. This makes code more maintainable and allows the design system to evolve. When a token's value changes, all components using that token automatically reflect the update.
+
+The **[Design Tokens Reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md)** contains a complete reference of all available design tokens including colors, spacing, typography, and more.
+
+For more information about how design tokens are implemented, see [`tokens/README.md`](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/tokens/README.md).
 
 ### Using Design Tokens
 
@@ -51,14 +57,6 @@ If your application renders React content into additional documents (an iframe, 
 For the best development experience, we recommend configuring the [build plugins](#build-plugins) and [Stylelint rules](#stylelint-plugins) provided by this package. The build plugins automatically inject fallback values into `var(--wpds-*)` references so components render correctly even when the tokens stylesheet is not yet loaded, and will raise an error if a reference does not match a known token. The Stylelint rules catch typos, unknown tokens, and other discouraged patterns during development.
 
 If you use `@wordpress/build` to build your scripts, the build plugins are already enabled by default.
-
-### Design Tokens
-
-Design tokens are the visual design atoms of a design system. They are named entities that store visual design attributes like colors, spacing, typography, and shadows. They serve as a single source of truth that bridges design and development, ensuring consistency across platforms and making it easy to maintain and evolve the visual language of an application.
-
-Rather than hardcoding values like `#3858e9` or `16px` throughout your code, tokens provide semantic names like `--wpds-color-background-interactive-brand-strong` or `--wpds-dimension-padding-2xl` that describe the purpose and context of the value. This makes code more maintainable and allows the design system to evolve. When a token's value changes, all components using that token automatically reflect the update.
-
-For more information about how design tokens are implemented, see [`tokens/README.md`](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/tokens/README.md).
 
 ## Theme Provider
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -52,15 +52,6 @@ For the best development experience, we recommend configuring the [build plugins
 
 If you use `@wordpress/build` to build your scripts, the build plugins are already enabled by default.
 
-### Architecture
-
-Internally, the design system uses a tiered token architecture:
-
--   **Primitive tokens**: Raw values like hex colors or pixel dimensions which are what the browsers eventually interpret. These live in the `/tokens` directory as JSON source files and are an internal implementation detail.
--   **Semantic tokens**: Purpose-driven tokens with meaningful names that reference primitives and describe their intended use. These are what get exported as CSS custom properties.
-
-This separation allows the design system to maintain consistency while providing flexibility, since primitive values can be updated without changing the semantic token names that developers use in their code.
-
 ### Design Tokens
 
 Design tokens are the visual design atoms of a design system. They are named entities that store visual design attributes like colors, spacing, typography, and shadows. They serve as a single source of truth that bridges design and development, ensuring consistency across platforms and making it easy to maintain and evolve the visual language of an application.

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -67,24 +67,7 @@ Design tokens are the visual design atoms of a design system. They are named ent
 
 Rather than hardcoding values like `#3858e9` or `16px` throughout your code, tokens provide semantic names like `--wpds-color-background-interactive-brand-strong` or `--wpds-dimension-padding-2xl` that describe the purpose and context of the value. This makes code more maintainable and allows the design system to evolve. When a token's value changes, all components using that token automatically reflect the update.
 
-#### Structure
-
-The design system follows the [Design Tokens Community Group (DTCG)](https://design-tokens.github.io/community-group/format/) specification and organizes tokens into distinct types based on what kind of visual property they represent. Token definitions are stored as JSON files in the `/tokens` directory:
-
-| File              | Description                                                                                                                      |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `color.json`      | Color palettes including primitive color ramps and semantic color tokens for backgrounds, foregrounds, strokes, and focus states |
-| `dimension.json`  | Spacing scale and semantic spacing tokens for padding, margins, and sizing                                                       |
-| `typography.json` | Font family stacks, font sizes, and line heights                                                                                 |
-| `border.json`     | Border radius and width values                                                                                                   |
-| `elevation.json`  | Shadow definitions for creating depth and layering                                                                               |
-| `motion.json`     | Animation durations and easing curves                                                                                            |
-
-Each JSON file contains both primitive and semantic token definitions in a hierarchical structure. These files are the source of truth for the design system and are processed during the build step to generate CSS custom properties and other output formats in `/src/prebuilt`.
-
-#### Token Naming
-
-Semantic tokens follow a consistent naming pattern that encodes the token's purpose. See the [Design Tokens Reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md) for the naming pattern, the meaning of each segment (type, property, target, tone, emphasis, state), and guidance on how to pick the right token.
+For more information about how design tokens are implemented, you'll find additional documentation in [`tokens/README.md`](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/tokens/README.md).
 
 ## Theme Provider
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -17,7 +17,7 @@ Rather than hardcoding values like `#3858e9` or `16px` throughout your code, tok
 
 The **[Design Tokens Reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md)** contains a complete reference of all available design tokens including colors, spacing, typography, and more.
 
-For more information about how design tokens are implemented, see [`tokens/README.md`](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/tokens/README.md).
+The **[Design Tokens Maintainer's Guide](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/tokens/README.md)** describes how design tokens are implemented in the design system.
 
 ### Using Design Tokens
 

--- a/packages/theme/tokens/README.md
+++ b/packages/theme/tokens/README.md
@@ -29,7 +29,7 @@ Semantic tokens follow a consistent naming pattern that encodes the token's purp
 
 **Semantic tokens** are the public API of the design system's tokens. They map to primitive token values, but the values are incidental, and a consumer is expected to choose a semantic token based on their specific use-case. The design system provides semantic tokens to cover a breadth of use-cases that are standardized at a design systems level.
 
-This structure is meant to shift the emphasis away from the values themselves and toward the meaning and purpose that the tokens represent. Ultimately, the tokens still map to raw values that affect how a component is styled and those values should be internally consistent, but the primitive layer is an incidental concern of the theming internals and not a consideration of the end-user of the design system.
+This structure is meant to **shift the emphasis away from the values themselves and toward the meaning and purpose that the tokens represent**. Ultimately, the tokens still map to raw values that affect how a component is styled and those values should be internally consistent, but the primitive layer is an incidental concern of the theming internals and not a consideration of the end-user of the design system.
 
 Example:
 

--- a/packages/theme/tokens/README.md
+++ b/packages/theme/tokens/README.md
@@ -1,0 +1,76 @@
+# Design Tokens Mantainer's Guide
+
+Design tokens are the visual design atoms of a design system. They are named entities that store visual design attributes like colors, spacing, typography, and shadows. They serve as a single source of truth that bridges design and development, ensuring consistency across platforms and making it easy to maintain and evolve the visual language of an application.
+
+This document includes information about how the design system maintains its tokens implementation. For information about how to use design tokens, refer to the [`@wordpress/theme` package README](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/README.md) and [Design Tokens Reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md).
+
+## Structure
+
+The design system follows the [Design Tokens Community Group (DTCG)](https://design-tokens.github.io/community-group/format/) specification and organizes tokens into distinct types based on what kind of visual property they represent. Token definitions are stored as JSON files in the `/tokens` directory:
+
+| File              | Description                                                                                                                      |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `color.json`      | Color palettes including primitive color ramps and semantic color tokens for backgrounds, foregrounds, strokes, and focus states |
+| `dimension.json`  | Spacing scale and semantic spacing tokens for padding, margins, and sizing                                                       |
+| `typography.json` | Font family stacks, font sizes, and line heights                                                                                 |
+| `border.json`     | Border radius and width values                                                                                                   |
+| `elevation.json`  | Shadow definitions for creating depth and layering                                                                               |
+| `motion.json`     | Animation durations and easing curves                                                                                            |
+
+Each JSON file contains both primitive and semantic token definitions in a hierarchical structure. These files are the source of truth for the design system and are processed during the build step to generate CSS custom properties and other output formats in `/src/prebuilt`.
+
+## Token Naming
+
+Semantic tokens follow a consistent naming pattern that encodes the token's purpose. See the [Design Tokens Reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md) for the naming pattern, the meaning of each segment (type, property, target, tone, emphasis, state), and guidance on how to pick the right token.
+
+## Primitive and Semantic Tokens
+
+**Primitive tokens** are internal, reusable, raw values emitted by the design system's theming. They are not part of the public API, but instead are referenced by semantic tokens, which use the underlying values and provide purpose and meaning to how those values are used.
+
+**Semantic tokens** are the public API of the design system's tokens. They map to primitive token values, but the values are incidental, and a consumer is expected to choose a semantic token based on their specific use-case. The design system provides semantic tokens to cover a breadth of use-cases that are standardized at a design systems level.
+
+This structure is meant to shift the emphasis away from the values themselves and toward the meaning and purpose that the tokens represent. Ultimately, the tokens still map to raw values that affect how a component is styled and those values should be internally consistent, but the primitive layer is an incidental concern of the theming internals and not a consideration of the end-user of the design system.
+
+Example:
+
+```jsonc
+{
+	"wpds-dimension": {
+		"$type": "dimension",
+		"primitive": {
+			"space": {
+				"10": {
+					"$value": { "value": 4, "unit": "px" }
+				}
+            },
+            // ...
+        }
+		"padding": {
+			"xs": {
+				"$value": "{wpds-dimension.primitive.space.10}"
+			},
+            // ...
+        }
+    }
+}
+```
+
+In the example above, the CSS properties generated from these tokens would include:
+
+```css
+--wpds-dimension-padding-xs: 4px;
+```
+
+Someone using the design system should never see or concern themselves with either the `primitive.space.10` token or the underlying 4 pixel base unit. This also enables the design system to alter these values based on factors like density, which could affect the value of the primitive token and cascade automatically to the CSS properties.
+
+## Custom Extensions
+
+The design tokens use [the `$extensions` feature](https://www.designtokens.org/tr/drafts/format/#extensions-0) of the DTCG Tokens specification to add additional, optional support for proprietary data.
+
+### Figma Support
+
+The tokens are implemented so that they can be imported directly into Figma variables, using [Figma's built-in support for importing design tokens](https://help.figma.com/hc/en-us/articles/15343816063383-Modes-for-variables#h_01KAGYPSFC984XDB4YWBCNRZJ7).
+
+This also includes support for [variable modes](https://help.figma.com/hc/en-us/articles/15343816063383-Modes-for-variables), which can be found under [the `modes/` directory](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/tokens/modes/).
+
+Token definitions will also include relevant Figma scopes, which are useful to ensure that token values are only shown in relevant fields in the Figma interface (e.g. border radius tokens only shown in the radius selection fields). These are implemented through the `$extensions['com.figma.scopes']` extension, and a full list of supported scopes is available in [Figma's `VariableScope` developer documentation](https://developers.figma.com/docs/plugins/api/VariableScope/).

--- a/packages/theme/tokens/README.md
+++ b/packages/theme/tokens/README.md
@@ -41,15 +41,18 @@ Example:
 		"$type": "dimension",
 		"primitive": {
 			"space": {
-				"10": {
-					"$value": { "value": 4, "unit": "px" }
+				// ...
+				"80": {
+					"$value": { "value": 40, "unit": "px" }
 				}
 				// ...
 			}
 		},
-		"padding": {
-			"xs": {
-				"$value": "{wpds-dimension.primitive.space.10}"
+		"size": {
+			// ...
+			"lg": {
+				"$value": "{wpds-dimension.primitive.space.80}",
+				"$description": "Default size for buttons and inputs"
 			}
 			// ...
 		}
@@ -60,10 +63,10 @@ Example:
 In the example above, the CSS properties generated from these tokens would include:
 
 ```css
---wpds-dimension-padding-xs: 4px;
+--wpds-dimension-size-lg: 40px;
 ```
 
-Someone using the design system should never see or concern themselves with either the `primitive.space.10` token or the underlying 4 pixel base unit.
+Someone using the design system should never see or concern themselves with either the `primitive.space.80` token or the underlying 4 pixel base unit, and instead focus on the semantics of how element size tokens apply to their component. In this example, a large token being used for a component that follows the size of buttons and inputs in the system.
 
 ## Custom Extensions
 

--- a/packages/theme/tokens/README.md
+++ b/packages/theme/tokens/README.md
@@ -1,4 +1,4 @@
-# Design Tokens Mantainer's Guide
+# Design Tokens Maintainer's Guide
 
 Design tokens are the visual design atoms of a design system. They are named entities that store visual design attributes like colors, spacing, typography, and shadows. They serve as a single source of truth that bridges design and development, ensuring consistency across platforms and making it easy to maintain and evolve the visual language of an application.
 

--- a/packages/theme/tokens/README.md
+++ b/packages/theme/tokens/README.md
@@ -42,16 +42,16 @@ Example:
 				"10": {
 					"$value": { "value": 4, "unit": "px" }
 				}
-            },
-            // ...
-        }
+				// ...
+			}
+		},
 		"padding": {
 			"xs": {
 				"$value": "{wpds-dimension.primitive.space.10}"
-			},
-            // ...
-        }
-    }
+			}
+			// ...
+		}
+	}
 }
 ```
 

--- a/packages/theme/tokens/README.md
+++ b/packages/theme/tokens/README.md
@@ -2,6 +2,8 @@
 
 Design tokens are the visual design atoms of a design system. They are named entities that store visual design attributes like colors, spacing, typography, and shadows. They serve as a single source of truth that bridges design and development, ensuring consistency across platforms and making it easy to maintain and evolve the visual language of an application.
 
+Components that use these design tokens benefit from the consistency they guarantee with other components that extend from the same system. Future theming improvements or configurations like color theming (or "dark mode"), density, or roundness will cascade automatically to these components without any additional effort on the part of the component maintainer.
+
 This document includes information about how the design system maintains its tokens implementation. For information about how to use design tokens, refer to the [`@wordpress/theme` package README](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/README.md) and [Design Tokens Reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md).
 
 ## Structure

--- a/packages/theme/tokens/README.md
+++ b/packages/theme/tokens/README.md
@@ -2,7 +2,7 @@
 
 Design tokens are the visual design atoms of a design system. They are named entities that store visual design attributes like colors, spacing, typography, and shadows. They serve as a single source of truth that bridges design and development, ensuring consistency across platforms and making it easy to maintain and evolve the visual language of an application.
 
-Components that use these design tokens benefit from the consistency they guarantee with other components that extend from the same system. Future theming improvements or configurations like color theming (or "dark mode"), density, or roundness will cascade automatically to these components without any additional effort on the part of the component maintainer.
+Components that use these design tokens benefit from the consistency they guarantee with other components that extend from the same system. Future theming improvements or configurations like color theming (or "dark mode") or roundness will cascade automatically to these components without any additional effort on the part of the component maintainer.
 
 This document includes information about how the design system maintains its tokens implementation. For information about how to use design tokens, refer to the [`@wordpress/theme` package README](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/README.md) and [Design Tokens Reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md).
 
@@ -63,7 +63,7 @@ In the example above, the CSS properties generated from these tokens would inclu
 --wpds-dimension-padding-xs: 4px;
 ```
 
-Someone using the design system should never see or concern themselves with either the `primitive.space.10` token or the underlying 4 pixel base unit. This also enables the design system to alter these values based on factors like density, which could affect the value of the primitive token and cascade automatically to the CSS properties.
+Someone using the design system should never see or concern themselves with either the `primitive.space.10` token or the underlying 4 pixel base unit.
 
 ## Custom Extensions
 


### PR DESCRIPTION
## What?

Related: https://github.com/WordPress/gutenberg/pull/79032#issuecomment-4672707439

Adds a new `README.md` within the `tokens/` directory of the `@wordpress/theme` package to serve as a maintainer's guide for the WordPress Design System design tokens.

## Why?

- Adds additional context for how tokens are maintained which has been undocumented until now:
   - The difference between primitive and semantic tokens and why they exist the way they do
   - Explicit support for Figma variables import, including `$extensions['com.figma.scopes']` and where to find information about maintaining those values
- Improves the relevance of the package's root `README.md` to include information about how to use the theme package. Most people shouldn't care about the existence of `tokens/color.json` and how these files are structured, for example.
- Avoids a confusing dead-end if someone were to link to [the `packages/themes/tokens` directory](https://github.com/WordPress/gutenberg/tree/trunk/packages/theme/tokens). This would be reasonable to do as it is the source of truth for the design system's design tokens, but currently it lacks any documentation context around what that directory is for if someone arrives there directly.

## How?

- Adds new `packages/theme/tokens/README.md`
- Shifts "Structure" and "Token Naming" sub-sections of the root README.md into this new file
- Maintains existing "Design Tokens" section of the root README.md and adds a link to this new document for more information

## Testing Instructions

Review updated documentation for relevance and accuracy.

## Use of AI Tools

No AI was used.