### PR TITLE
Block locking: add "Lock design" action that turns content into a pattern

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add a `BlockLockModalActionsSlotFill` private SlotFill so higher layers can add actions to the block lock modal.
+
 ## 15.21.0 (2026-06-10)
 
 ### Code Quality

--- a/packages/block-editor/src/components/block-lock/modal-actions-slot.js
+++ b/packages/block-editor/src/components/block-lock/modal-actions-slot.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+const BlockLockModalActionsSlotFill = createSlotFill(
+	Symbol( 'BlockLockModalActions' )
+);
+
+export default BlockLockModalActionsSlotFill;

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -22,6 +22,7 @@ import { getBlockType } from '@wordpress/blocks';
 import useBlockLock from './use-block-lock';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { store as blockEditorStore } from '../../store';
+import BlockLockModalActionsSlotFill from './modal-actions-slot';
 
 // Entity based blocks which allow edit locking
 const ALLOWS_EDIT_LOCKING = [ 'core/navigation' ];
@@ -205,7 +206,6 @@ export default function BlockLockModal( { clientId, onClose } ) {
 					{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
 					{ hasTemplateLock && (
 						<ToggleControl
-							className="block-editor-block-lock-modal__template-lock"
 							label={ __( 'Apply to all blocks inside' ) }
 							checked={ applyTemplateLock }
 							disabled={ lock.move && ! lock.remove }
@@ -215,6 +215,9 @@ export default function BlockLockModal( { clientId, onClose } ) {
 						/>
 					) }
 				</fieldset>
+				<BlockLockModalActionsSlotFill.Slot
+					fillProps={ { clientId, onClose } }
+				/>
 				<Flex
 					className="block-editor-block-lock-modal__actions"
 					justify="flex-end"

--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -14,7 +14,7 @@
 }
 
 .block-editor-block-lock-modal__options legend {
-	margin-bottom: $grid-unit-20;
+	margin-bottom: $grid-unit-10;
 	padding: 0;
 }
 
@@ -39,7 +39,7 @@
 	align-items: center;
 	gap: $grid-unit-15;
 	margin-bottom: 0;
-	padding: $grid-unit-15 0 $grid-unit-15 $grid-unit-40;
+	padding: 0 0 $grid-unit-15 $grid-unit-40;
 
 	.block-editor-block-lock-modal__lock-icon {
 		flex-shrink: 0;
@@ -54,9 +54,25 @@
 }
 
 .block-editor-block-lock-modal__template-lock {
+	margin-top: $grid-unit-20;
+	padding-top: $grid-unit-20;
+}
+
+.block-editor-block-lock-modal__extra-actions {
 	border-top: $border-width solid $gray-300;
 	margin-top: $grid-unit-20;
 	padding-top: $grid-unit-20;
+}
+
+.block-editor-block-lock-modal__lock-design-help {
+	margin: 0 0 $grid-unit-15;
+}
+
+// The state classes are chained to outrank the component's own
+// `.components-button.has-icon.has-text { justify-content: start }` rule.
+.block-editor-block-lock-modal__lock-design-button.components-button.has-icon.has-text {
+	width: 100%;
+	justify-content: center;
 }
 
 .block-editor-block-lock-modal__actions {

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -69,6 +69,7 @@ import useBlockDisplayTitle from './components/block-title/use-block-display-tit
 import TabbedSidebar from './components/tabbed-sidebar';
 import NoteIconSlotFill from './components/collab/note-icon-slot';
 import NoteIconToolbarSlotFill from './components/collab/note-icon-toolbar-slot';
+import BlockLockModalActionsSlotFill from './components/block-lock/modal-actions-slot';
 import HTMLElementControl from './components/html-element-control';
 import {
 	useBlockElementRef,
@@ -138,6 +139,7 @@ lock( privateApis, {
 	sectionRootClientIdKey,
 	NoteIconSlotFill,
 	NoteIconToolbarSlotFill,
+	BlockLockModalActionsSlotFill,
 	mediaEditKey,
 	getMediaSelectKey,
 	deviceTypeKey,

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add a "Lock design…" action to the block lock modal that turns the block into an unsynced pattern (content-only), connecting block locking with patterns.
+
 ## 2.48.0 (2026-06-10)
 
 ## 2.47.0 (2026-05-27)

--- a/packages/patterns/src/components/index.js
+++ b/packages/patterns/src/components/index.js
@@ -8,25 +8,29 @@ import { BlockSettingsMenuControls } from '@wordpress/block-editor';
  */
 import PatternConvertButton from './pattern-convert-button';
 import PatternsManageButton from './patterns-manage-button';
+import LockDesignButton from './lock-design-button';
 
 export default function PatternsMenuItems( { rootClientId } ) {
 	return (
-		<BlockSettingsMenuControls>
-			{ ( { selectedClientIds, onClose } ) => (
-				<>
-					<PatternConvertButton
-						clientIds={ selectedClientIds }
-						rootClientId={ rootClientId }
-						closeBlockSettingsMenu={ onClose }
-					/>
-					{ selectedClientIds.length === 1 && (
-						<PatternsManageButton
-							clientId={ selectedClientIds[ 0 ] }
-							onClose={ onClose }
+		<>
+			<BlockSettingsMenuControls>
+				{ ( { selectedClientIds, onClose } ) => (
+					<>
+						<PatternConvertButton
+							clientIds={ selectedClientIds }
+							rootClientId={ rootClientId }
+							closeBlockSettingsMenu={ onClose }
 						/>
-					) }
-				</>
-			) }
-		</BlockSettingsMenuControls>
+						{ selectedClientIds.length === 1 && (
+							<PatternsManageButton
+								clientId={ selectedClientIds[ 0 ] }
+								onClose={ onClose }
+							/>
+						) }
+					</>
+				) }
+			</BlockSettingsMenuControls>
+			<LockDesignButton />
+		</>
 	);
 }

--- a/packages/patterns/src/components/lock-design-button.js
+++ b/packages/patterns/src/components/lock-design-button.js
@@ -1,0 +1,178 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	hasBlockSupport,
+	isReusableBlock,
+	serialize,
+	getBlockType,
+} from '@wordpress/blocks';
+import {
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { lock as lockIcon } from '@wordpress/icons';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import CreatePatternModal from './create-pattern-modal';
+import { PATTERN_SYNC_TYPES } from '../constants';
+import { unlock } from '../lock-unlock';
+
+const { BlockLockModalActionsSlotFill } = unlock( blockEditorPrivateApis );
+
+/**
+ * The control rendered inside the block lock modal. Returns `null` when the
+ * selected block can't be turned into a pattern (e.g. it already is one), which
+ * doubles as the answer to "what if you lock a pattern?" — the affordance
+ * simply isn't offered because the design is already locked.
+ *
+ * @param {Object}   props          Component props.
+ * @param {string}   props.clientId Client id of the block being locked.
+ * @param {()=>void} props.onClick  Invoked when the user opts to lock the design.
+ * @return {React.ComponentType|null} The control, or null.
+ */
+function LockDesignControl( { clientId, onClick } ) {
+	const canConvert = useSelect(
+		( select ) => {
+			const { canUser, getEntityRecord } = select( coreStore );
+			const { getBlock, canInsertBlockType, getBlockRootClientId } =
+				select( blockEditorStore );
+
+			const block = getBlock( clientId );
+
+			// Already a pattern (synced or unsynced): the design is locked
+			// already, so don't offer to lock it again.
+			const isUnsyncedPattern =
+				!! block?.attributes?.metadata?.patternName;
+			const isSyncedPattern =
+				!! block &&
+				isReusableBlock( block ) &&
+				!! getEntityRecord(
+					'postType',
+					'wp_block',
+					block.attributes.ref
+				);
+
+			const blockType = block && getBlockType( block.name );
+			const hasParent = blockType && 'parent' in blockType;
+
+			return (
+				!! block &&
+				block.isValid &&
+				! isUnsyncedPattern &&
+				! isSyncedPattern &&
+				hasBlockSupport( block.name, 'reusable', ! hasParent ) &&
+				canInsertBlockType(
+					'core/block',
+					getBlockRootClientId( clientId )
+				) &&
+				!! canUser( 'create', {
+					kind: 'postType',
+					name: 'wp_block',
+				} )
+			);
+		},
+		[ clientId ]
+	);
+
+	if ( ! canConvert ) {
+		return null;
+	}
+
+	return (
+		<div className="block-editor-block-lock-modal__extra-actions">
+			<p className="block-editor-block-lock-modal__lock-design-help">
+				{ __(
+					'Lock the design and inner layout. This turns the block into a pattern, so styling stays consistent while the content remains editable.'
+				) }
+			</p>
+			<Button
+				className="block-editor-block-lock-modal__lock-design-button"
+				variant="secondary"
+				icon={ lockIcon }
+				onClick={ onClick }
+				__next40pxDefaultSize
+			>
+				{ __( 'Lock design' ) }
+			</Button>
+		</div>
+	);
+}
+
+/**
+ * Fills the block lock modal with a "Lock design" action that converts the
+ * block into an unsynced pattern, which is treated as content-only — design
+ * locked, content editable. Reuses the existing create-pattern flow; the only
+ * deviation is defaulting to unsynced (the variant that yields content-only
+ * editing).
+ *
+ * @return {React.ComponentType} The fill.
+ */
+export default function LockDesignButton() {
+	// The client id of the block whose design is being locked. Held here, at a
+	// persistently-mounted level, so the create-pattern modal survives the lock
+	// modal closing.
+	const [ patternClientId, setPatternClientId ] = useState( null );
+	const { getBlocksByClientId, getBlockAttributes } =
+		useSelect( blockEditorStore );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const { createSuccessNotice } = useDispatch( noticesStore );
+
+	return (
+		<>
+			<BlockLockModalActionsSlotFill.Fill>
+				{ ( { clientId, onClose } ) => (
+					<LockDesignControl
+						clientId={ clientId }
+						onClick={ () => {
+							setPatternClientId( clientId );
+							// Close the lock modal so step 2 takes over.
+							onClose();
+						} }
+					/>
+				) }
+			</BlockLockModalActionsSlotFill.Fill>
+			{ patternClientId && (
+				<CreatePatternModal
+					defaultSyncType={ PATTERN_SYNC_TYPES.unsynced }
+					content={ () =>
+						serialize( getBlocksByClientId( [ patternClientId ] ) )
+					}
+					onSuccess={ ( { pattern } ) => {
+						const existingAttributes =
+							getBlockAttributes( patternClientId );
+						updateBlockAttributes( patternClientId, {
+							metadata: {
+								...( existingAttributes?.metadata ?? {} ),
+								patternName: `core/block/${ pattern.id }`,
+								name: pattern.title.raw,
+							},
+						} );
+						createSuccessNotice(
+							sprintf(
+								// translators: %s: the name the user has given to the pattern.
+								__( 'Design locked: %s' ),
+								pattern.title.raw
+							),
+							{
+								type: 'snackbar',
+								id: 'lock-design-success',
+							}
+						);
+						setPatternClientId( null );
+					} }
+					onError={ () => setPatternClientId( null ) }
+					onClose={ () => setPatternClientId( null ) }
+				/>
+			) }
+		</>
+	);
+}


### PR DESCRIPTION
## What?

Fixes #73599. 

Adds a "Lock design…" action to the block lock modal. Selecting it closes the lock modal and opens the existing create-pattern flow, defaulting to an unsynced pattern. 

<img width="1518" height="872" alt="state" src="https://github.com/user-attachments/assets/1d8ad503-0e1a-47b6-991c-ed6ee5cc7e89" />


## Testing Instructions

Create a design, pick the ellipsis, choose "Lock" and see the "Lock design" button.

## Use of AI Tools

Claude Opus 4.8 and hand-rolled CSS.