### PR TITLE
Tests: Make PHPUnit tests independent of test config flags and theme root

### DIFF
--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -155,7 +155,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'wp-block-hidden-mobile', $result, 'Block should have the visibility class for the mobile viewport size.' );
 
-		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
 
 		$this->assertSame(
 			'@media (width <= 480px){.wp-block-hidden-mobile{display:none !important;}}',
@@ -188,7 +188,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'class="existing-class wp-block-hidden-tablet"', $result, 'Block should have the existing class and the visibility class for the tablet viewport size in the class attribute.' );
 
-		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
 
 		$this->assertSame(
 			'@media (480px < width <= 782px){.wp-block-hidden-tablet{display:none !important;}}',
@@ -222,7 +222,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'class="wp-block-hidden-desktop"', $result, 'Block should have the visibility class for the desktop viewport size in the class attribute.' );
 
-		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
 
 		$this->assertSame(
 			'@media (width > 782px){.wp-block-hidden-desktop{display:none !important;}}',
@@ -260,7 +260,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 			'Block should have both visibility classes in the class attribute'
 		);
 
-		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
 
 		$this->assertSame(
 			'@media (width > 782px){.wp-block-hidden-desktop{display:none !important;}}@media (width <= 480px){.wp-block-hidden-mobile{display:none !important;}}',

--- a/phpunit/block-supports/elements-test.php
+++ b/phpunit/block-supports/elements-test.php
@@ -253,7 +253,7 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 		);
 
 		gutenberg_render_elements_support_styles( $block );
-		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
 
 		$this->assertMatchesRegularExpression(
 			$expected_styles,

--- a/phpunit/block-supports/position-test.php
+++ b/phpunit/block-supports/position-test.php
@@ -107,7 +107,7 @@ class WP_Block_Supports_Position_Test extends WP_UnitTestCase {
 			'Position block wrapper markup should be correct'
 		);
 
-		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
 
 		$this->assertMatchesRegularExpression(
 			$expected_styles,

--- a/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
+++ b/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
@@ -39,6 +39,13 @@ class WP_REST_Global_Styles_Controller_Gutenberg_Test extends WP_Test_REST_Contr
 
 	public function set_up() {
 		parent::set_up();
+		// When the tests run outside of wp-env, the emptytheme fixture is not
+		// mounted in the WordPress theme root, so register the plugin's test
+		// theme directory to make it discoverable.
+		if ( ! wp_get_theme( 'emptytheme' )->exists() ) {
+			register_theme_directory( dirname( __DIR__ ) . '/test' );
+			wp_clean_themes_cache();
+		}
 		switch_theme( 'emptytheme' );
 	}
 
@@ -166,7 +173,7 @@ class WP_REST_Global_Styles_Controller_Gutenberg_Test extends WP_Test_REST_Contr
 					),
 					'wp:theme-file' => array(
 						array(
-							'href'   => home_url( '/wp-content/themes/emptytheme/img/1024x768_emptytheme_test_image.jpg' ),
+							'href'   => get_theme_file_uri( 'img/1024x768_emptytheme_test_image.jpg' ),
 							'name'   => 'file:./img/1024x768_emptytheme_test_image.jpg',
 							'target' => 'styles.background.backgroundImage.url',
 							'type'   => 'image/jpeg',


### PR DESCRIPTION
## What?

Makes some PHPUnit tests pass regardless of the local test config (`SCRIPT_DEBUG`) and of where the test suite's theme root lives, so the suite is green both inside wp-env and when run directly against a local `wordpress-develop` checkout.

## Why?

When running the suite with a `wp-tests-config.php` that sets `SCRIPT_DEBUG` to `true`, the Style Engine pretty-prints its output (newlines and indentation), and the block supports tests that assert against minified CSS fail (9 failures across block visibility, elements, and position tests).

Additionally, `WP_REST_Global_Styles_Controller_Gutenberg_Test::test_get_theme_items` fails outside wp-env because the `emptytheme` fixture lives in `test/emptytheme` and is only mounted into the WordPress theme root by `.wp-env.json`, so the variations endpoint returns an empty array.

## How?

- Pass `array( 'prettify' => false )` to `gutenberg_style_engine_get_stylesheet_from_context()` in the block visibility, elements, and position block supports tests, making the output deterministic regardless of `SCRIPT_DEBUG`.
- In the global styles controller test, register the plugin's `test/` directory as an additional theme directory when `emptytheme` is not found in the theme root, and compute the expected theme file URL with `get_theme_file_uri()` (the same function used by `WP_Theme_JSON_Resolver_Gutenberg::get_resolved_theme_uris()`) instead of hardcoding `/wp-content/themes/...`. Behavior in wp-env/CI is unchanged.

## Testing Instructions

1. Point `WP_TESTS_DIR` at a local `wordpress-develop` checkout whose `wp-tests-config.php` defines `SCRIPT_DEBUG` as `true`.
2. Run `composer run test`.
3. Verify the suite passes; before this change there were 10 failures (block-visibility, elements, position, and global styles controller tests).
4. Verify the tests still pass in the standard wp-env setup.
