### PR TITLE
Add display depth attribute to the Navigation block

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -549,7 +549,7 @@ A collection of blocks that allow visitors to get around your site.
 -	**Category:** [theme](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/)
 -	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/icon, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
 -	**Supports:** align (full, wide), anchor, ariaLabel, contentRole, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, overlay, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, submenuVisibility, templateLock, textColor
+-	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, depth, hasIcon, icon, maxNestingLevel, overlay, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, submenuVisibility, templateLock, textColor
 
 ## Custom Link
 

--- a/packages/block-library/src/navigation-submenu/README.md
+++ b/packages/block-library/src/navigation-submenu/README.md
@@ -65,6 +65,7 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 - `openSubmenusOnClick`
 - `submenuVisibility`
 - `style`
+- `depth`
 
 **Provides context:**
 

--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -64,7 +64,8 @@
 		"maxNestingLevel",
 		"openSubmenusOnClick",
 		"submenuVisibility",
-		"style"
+		"style",
+		"depth"
 	],
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -85,7 +85,12 @@ export default function NavigationSubmenuEdit( {
 } ) {
 	const { label, url, description, kind, type, id } = attributes;
 
-	const { showSubmenuIcon, maxNestingLevel, submenuVisibility } = context;
+	const {
+		showSubmenuIcon,
+		maxNestingLevel,
+		submenuVisibility,
+		depth: displayDepth,
+	} = context;
 	const blockEditingMode = useBlockEditingMode();
 
 	// Force click-only behavior in contentOnly mode to prevent hover dropdowns
@@ -263,12 +268,14 @@ export default function NavigationSubmenuEdit( {
 	// Always use overlay colors for submenus.
 	const innerBlocksColors = getColors( context, true );
 
-	const allowedBlocks =
-		parentCount >= maxNestingLevel
-			? ALLOWED_BLOCKS.filter(
-					( blockName ) => blockName !== 'core/navigation-submenu'
-			  )
-			: ALLOWED_BLOCKS;
+	const isSubmenuAllowed =
+		parentCount < maxNestingLevel && parentCount < displayDepth;
+
+	const allowedBlocks = isSubmenuAllowed
+		? ALLOWED_BLOCKS
+		: ALLOWED_BLOCKS.filter(
+				( blockName ) => blockName !== 'core/navigation-submenu'
+		  );
 
 	const navigationChildBlockProps =
 		getNavigationChildBlockProps( innerBlocksColors );

--- a/packages/block-library/src/navigation/README.md
+++ b/packages/block-library/src/navigation/README.md
@@ -63,6 +63,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | `overlayTextColor` | `string` | — | — |
 | `customOverlayTextColor` | `string` | — | — |
 | `maxNestingLevel` | `number` | `5` | — |
+| `depth` | `number` | `5` | — |
 | `templateLock` | `string \| boolean` | — | [Enum](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#enum-validation): `all`, `insert`, `contentOnly`, `false` |
 
 ## Supports
@@ -111,6 +112,7 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 - `openSubmenusOnClick` → attribute `openSubmenusOnClick`
 - `style` → attribute `style`
 - `maxNestingLevel` → attribute `maxNestingLevel`
+- `depth` → attribute `depth`
 
 ## Block Markup
 

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -86,6 +86,10 @@
 			"type": "number",
 			"default": 5
 		},
+		"depth": {
+			"type": "number",
+			"default": 5
+		},
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", "contentOnly", false ]
@@ -106,7 +110,8 @@
 		"submenuVisibility": "submenuVisibility",
 		"openSubmenusOnClick": "openSubmenusOnClick",
 		"style": "style",
-		"maxNestingLevel": "maxNestingLevel"
+		"maxNestingLevel": "maxNestingLevel",
+		"depth": "depth"
 	},
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -32,6 +32,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	RangeControl,
 	ToggleControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
@@ -277,6 +278,7 @@ function Navigation( {
 		} = {},
 		hasIcon,
 		icon = 'handle',
+		depth,
 	} = attributes;
 
 	const ref = attributes.ref;
@@ -789,6 +791,7 @@ function Navigation( {
 								overlayMenu: 'mobile',
 								hasIcon: true,
 								icon: 'handle',
+								depth: 0,
 							} );
 						} }
 						dropdownMenuProps={ dropdownMenuProps }
@@ -892,6 +895,28 @@ function Navigation( {
 										{ submenuAccessibilityNotice }
 									</Notice>
 								) }
+								<ToolsPanelItem
+									hasValue={ () => !! depth && depth > 0 }
+									label={ __( 'Display depth' ) }
+									onDeselect={ () =>
+										setAttributes( { depth: 0 } )
+									}
+									isShownByDefault={ false }
+								>
+									<RangeControl
+										__next40pxDefaultSize
+										label={ __( 'Display depth' ) }
+										help={ __(
+											'Limit the number of submenu levels shown on the front end. Does not affect the editor.'
+										) }
+										value={ depth > 0 ? depth : 1 }
+										onChange={ ( value ) =>
+											setAttributes( { depth: value } )
+										}
+										min={ 1 }
+										max={ 6 }
+									/>
+								</ToolsPanelItem>
 							</>
 						) }
 					</ToolsPanel>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -32,7 +32,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
-	RangeControl,
 	ToggleControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
@@ -278,7 +277,6 @@ function Navigation( {
 		} = {},
 		hasIcon,
 		icon = 'handle',
-		depth,
 	} = attributes;
 
 	const ref = attributes.ref;
@@ -791,7 +789,6 @@ function Navigation( {
 								overlayMenu: 'mobile',
 								hasIcon: true,
 								icon: 'handle',
-								depth: 0,
 							} );
 						} }
 						dropdownMenuProps={ dropdownMenuProps }
@@ -895,28 +892,6 @@ function Navigation( {
 										{ submenuAccessibilityNotice }
 									</Notice>
 								) }
-								<ToolsPanelItem
-									hasValue={ () => !! depth && depth > 0 }
-									label={ __( 'Display depth' ) }
-									onDeselect={ () =>
-										setAttributes( { depth: 0 } )
-									}
-									isShownByDefault={ false }
-								>
-									<RangeControl
-										__next40pxDefaultSize
-										label={ __( 'Display depth' ) }
-										help={ __(
-											'Limit the number of submenu levels shown on the front end. Does not affect the editor.'
-										) }
-										value={ depth > 0 ? depth : 1 }
-										onChange={ ( value ) =>
-											setAttributes( { depth: value } )
-										}
-										min={ 1 }
-										max={ 6 }
-									/>
-								</ToolsPanelItem>
 							</>
 						) }
 					</ToolsPanel>

--- a/packages/block-library/src/navigation/edit/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/edit/leaf-more-menu.js
@@ -38,18 +38,34 @@ function AddSubmenuItem( {
 	expandedState,
 	expand,
 	setInsertedBlock,
+	displayDepth,
+	currentLevel,
 } ) {
 	const { insertBlock, replaceBlock, replaceInnerBlocks } =
 		useDispatch( blockEditorStore );
 
 	const clientId = block.clientId;
-	const isDisabled = ! BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU.includes(
-		block.name
-	);
+	const isUnsupportedBlock =
+		! BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU.includes( block.name );
+	const isHiddenByDepth = displayDepth > 0 && currentLevel >= displayDepth;
+
+	const isDisabled = isUnsupportedBlock || isHiddenByDepth;
+
 	return (
 		<MenuItem
 			icon={ addSubmenu }
 			disabled={ isDisabled }
+			info={
+				isHiddenByDepth
+					? sprintf(
+							/* translators: %d: the maximum number of submenu levels shown on the front end */
+							__(
+								'Display depth is limited to %d level(s). This submenu will not appear on the front end.'
+							),
+							displayDepth
+					  )
+					: undefined
+			}
 			onClick={ () => {
 				const updateSelectionOnInsert = false;
 				const newLink = createBlock(
@@ -122,45 +138,70 @@ export default function LeafMoreMenu( props ) {
 		BlockTitle( { clientId, maximumLength: 25 } )
 	);
 
-	const { rootClientId, canDuplicate, canInsertBlock, isFirst, isLast } =
-		useSelect(
-			( select ) => {
-				const {
-					getBlockRootClientId,
-					canInsertBlockType,
-					getDirectInsertBlock,
-					getBlockIndex,
-					getBlockCount,
-				} = select( blockEditorStore );
-				const { getDefaultBlockName } = select( blocksStore );
+	const {
+		rootClientId,
+		canDuplicate,
+		canInsertBlock,
+		isFirst,
+		isLast,
+		displayDepth,
+		currentLevel,
+	} = useSelect(
+		( select ) => {
+			const {
+				getBlockRootClientId,
+				canInsertBlockType,
+				getDirectInsertBlock,
+				getBlockIndex,
+				getBlockCount,
+				getBlockParents,
+				getBlockName,
+				getBlock,
+			} = select( blockEditorStore );
+			const { getDefaultBlockName } = select( blocksStore );
 
-				const _rootClientId = getBlockRootClientId( clientId );
-				const canInsertDefaultBlock = canInsertBlockType(
-					getDefaultBlockName(),
-					_rootClientId
-				);
-				const directInsertBlock = _rootClientId
-					? getDirectInsertBlock( _rootClientId )
-					: null;
+			const _rootClientId = getBlockRootClientId( clientId );
+			const canInsertDefaultBlock = canInsertBlockType(
+				getDefaultBlockName(),
+				_rootClientId
+			);
+			const directInsertBlock = _rootClientId
+				? getDirectInsertBlock( _rootClientId )
+				: null;
 
-				return {
-					rootClientId: _rootClientId,
-					canDuplicate:
-						!! block &&
-						hasBlockSupport( block.name, 'multiple', true ) &&
-						canInsertBlockType( block.name, _rootClientId ),
-					canInsertBlock:
-						( canInsertDefaultBlock || !! directInsertBlock ) &&
-						!! block &&
-						canInsertBlockType( block.name, _rootClientId ),
-					isFirst: getBlockIndex( clientId ) === 0,
-					isLast:
-						getBlockIndex( clientId ) ===
-						getBlockCount( _rootClientId ) - 1,
-				};
-			},
-			[ clientId, block ]
-		);
+			const parents = getBlockParents( clientId ) || [];
+			const navClientId = parents.find(
+				( id ) => getBlockName( id ) === 'core/navigation'
+			);
+			const navBlock = navClientId ? getBlock( navClientId ) : null;
+
+			const computedDisplayDepth = navBlock?.attributes?.depth ?? 0;
+
+			const computedCurrentLevel =
+				parents.filter(
+					( id ) => getBlockName( id ) === 'core/navigation-submenu'
+				).length + 1;
+
+			return {
+				rootClientId: _rootClientId,
+				canDuplicate:
+					!! block &&
+					hasBlockSupport( block.name, 'multiple', true ) &&
+					canInsertBlockType( block.name, _rootClientId ),
+				canInsertBlock:
+					( canInsertDefaultBlock || !! directInsertBlock ) &&
+					!! block &&
+					canInsertBlockType( block.name, _rootClientId ),
+				isFirst: getBlockIndex( clientId ) === 0,
+				isLast:
+					getBlockIndex( clientId ) ===
+					getBlockCount( _rootClientId ) - 1,
+				displayDepth: computedDisplayDepth,
+				currentLevel: computedCurrentLevel,
+			};
+		},
+		[ clientId, block ]
+	);
 
 	return (
 		<DropdownMenu
@@ -202,6 +243,8 @@ export default function LeafMoreMenu( props ) {
 							expandedState={ props.expandedState }
 							expand={ props.expand }
 							setInsertedBlock={ props.setInsertedBlock }
+							displayDepth={ displayDepth }
+							currentLevel={ currentLevel }
 						/>
 						{ canDuplicate && (
 							<MenuItem

--- a/packages/block-library/src/navigation/edit/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/edit/leaf-more-menu.js
@@ -47,7 +47,7 @@ function AddSubmenuItem( {
 	const clientId = block.clientId;
 	const isUnsupportedBlock =
 		! BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU.includes( block.name );
-	const isHiddenByDepth = displayDepth > 0 && currentLevel >= displayDepth;
+	const isHiddenByDepth = displayDepth >= 0 && currentLevel > displayDepth;
 
 	const isDisabled = isUnsupportedBlock || isHiddenByDepth;
 
@@ -59,9 +59,7 @@ function AddSubmenuItem( {
 				isHiddenByDepth
 					? sprintf(
 							/* translators: %d: the maximum number of submenu levels shown on the front end */
-							__(
-								'Display depth is limited to %d level(s). This submenu will not appear on the front end.'
-							),
+							__( 'Display depth is limited to %d level(s).' ),
 							displayDepth
 					  )
 					: undefined

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -294,9 +294,9 @@ class WP_Navigation_Block_Renderer {
 
 		foreach ( $blocks as $block ) {
 			if ( 'core/navigation-submenu' === ( $block['blockName'] ?? null ) ) {
-				if ( $current_depth >= $max_depth ) {
-					$block['blockName']   = 'core/navigation-link';
-					$block['innerBlocks'] = array();
+				if ( $current_depth > $max_depth ) {
+					$block['blockName']    = 'core/navigation-link';
+					$block['innerBlocks']  = array();
 					$block['innerContent'] = array_values(
 						array_filter(
 							$block['innerContent'] ?? array(),
@@ -351,8 +351,8 @@ class WP_Navigation_Block_Renderer {
 			$blocks = parse_blocks( $markup );
 
 			// Apply display depth limit if set.
-			$depth = isset( $attributes['depth'] ) ? (int) $attributes['depth'] : 0;
-			if ( $depth > 0 ) {
+			$depth = isset( $attributes['depth'] ) ? (int) $attributes['depth'] : 5;
+			if ( $depth >= 0 ) {
 				$blocks = static::filter_parsed_blocks_by_depth( $blocks, $depth );
 			}
 
@@ -377,8 +377,8 @@ class WP_Navigation_Block_Renderer {
 		}
 
 		// Apply display depth limit if set.
-		$depth = isset( $attributes['depth'] ) ? (int) $attributes['depth'] : 0;
-		if ( $depth > 0 ) {
+		$depth = isset( $attributes['depth'] ) ? (int) $attributes['depth'] : 5;
+		if ( $depth >= 0 ) {
 			$fallback_blocks = static::filter_parsed_blocks_by_depth( $fallback_blocks, $depth );
 		}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -273,6 +273,54 @@ class WP_Navigation_Block_Renderer {
 	}
 
 	/**
+	 * Recursively filters parsed blocks to limit rendering depth.
+	 * Navigation submenu blocks beyond the specified depth are converted
+	 * to navigation-link blocks, dropping their children.
+	 *
+	 * @since 23.1.0
+	 *
+	 * @param array $blocks        Array of parsed block arrays.
+	 * @param int   $max_depth     Maximum nesting depth to render.
+	 *                             1 = top-level only (no submenus rendered).
+	 * @param int   $current_depth Current depth level (1-indexed). Default 1.
+	 * @return array Filtered array of parsed blocks.
+	 */
+	private static function filter_parsed_blocks_by_depth( $blocks, $max_depth, $current_depth = 1 ) {
+		if ( empty( $blocks ) || ! is_array( $blocks ) ) {
+			return $blocks;
+		}
+
+		$filtered = array();
+
+		foreach ( $blocks as $block ) {
+			if ( 'core/navigation-submenu' === ( $block['blockName'] ?? null ) ) {
+				if ( $current_depth >= $max_depth ) {
+					$block['blockName']   = 'core/navigation-link';
+					$block['innerBlocks'] = array();
+					$block['innerContent'] = array_values(
+						array_filter(
+							$block['innerContent'] ?? array(),
+							static function ( $content ) {
+								return null !== $content;
+							}
+						)
+					);
+				} else {
+					$block['innerBlocks'] = static::filter_parsed_blocks_by_depth(
+						$block['innerBlocks'] ?? array(),
+						$max_depth,
+						$current_depth + 1
+					);
+				}
+			}
+
+			$filtered[] = $block;
+		}
+
+		return $filtered;
+	}
+
+	/**
 	 * Gets the inner blocks for the navigation block from the navigation post.
 	 *
 	 * @since 6.5.0
@@ -302,8 +350,12 @@ class WP_Navigation_Block_Renderer {
 			$markup = apply_block_hooks_to_content_from_post_object( $markup, $navigation_post );
 			$blocks = parse_blocks( $markup );
 
-			// TODO - this uses the full navigation block attributes for the
-			// context which could be refined.
+			// Apply display depth limit if set.
+			$depth = isset( $attributes['depth'] ) ? (int) $attributes['depth'] : 0;
+			if ( $depth > 0 ) {
+				$blocks = static::filter_parsed_blocks_by_depth( $blocks, $depth );
+			}
+
 			return new WP_Block_List( $blocks, $attributes );
 		}
 	}
@@ -322,6 +374,12 @@ class WP_Navigation_Block_Renderer {
 		// Fallback my have been filtered so do basic test for validity.
 		if ( empty( $fallback_blocks ) || ! is_array( $fallback_blocks ) ) {
 			return new WP_Block_List( array(), $attributes );
+		}
+
+		// Apply display depth limit if set.
+		$depth = isset( $attributes['depth'] ) ? (int) $attributes['depth'] : 0;
+		if ( $depth > 0 ) {
+			$fallback_blocks = static::filter_parsed_blocks_by_depth( $fallback_blocks, $depth );
 		}
 
 		return new WP_Block_List( $fallback_blocks, $attributes );

--- a/test/integration/fixtures/blocks/core__navigation.json
+++ b/test/integration/fixtures/blocks/core__navigation.json
@@ -8,7 +8,8 @@
 			"overlayMenu": "mobile",
 			"icon": "handle",
 			"hasIcon": true,
-			"maxNestingLevel": 5
+			"maxNestingLevel": 5,
+			"depth": 5
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
## What?
Closes #72975

This PR introduces a `depth` attribute to the `core/navigation` block, restoring feature parity with the classic `wp_nav_menu()` depth argument. It ensures deeply nested menus can be visually restricted to a specific level on the frontend, while restricting the editor UI from adding submenus beyond that limit.

## Why?
Currently, if a user places a deeply nested Navigation block in a restricted layout (like a footer), the entire nested tree renders on the frontend and breaks the layout. Site builders need a reliable way to truncate multi-level menus to a specific depth without permanently deleting the child links from the database. 

## How?
1. Added a `depth` attribute (default `5`) to the `core/navigation` block and passed it down to child blocks via `usesContext`.
2. Implemented a filter (`filter_parsed_blocks_by_depth`) which recursively evaluates block depth during rendering. If a `core/navigation-submenu` exceeds the root block's defined depth, its `blockName` is converted to `core/navigation-link` and its children/innerBlocks are safely discarded before hitting the frontend.
3. **Editor Restrictions**: 
   - `core/navigation-submenu` is dynamically removed from `allowedBlocks` when the current depth exceeds the limit, hiding it from the slash inserter and block appender.
   - The "Add submenu link" option calculates its position in the block tree. If adding a submenu would exceed the depth limit, the button is disabled and displays an explanatory tooltip/info label.

## Testing Instructions
2. Open the Site Editor and insert a Navigation block.
3. Populate the block with a deeply nested menu (e.g., Parent > Child > Grandchild).
4. Select the Navigation block and manually set `"depth": 1` in the Code Editor.
5. Save the post and view the frontend. Only the top-level links should render. Any block that was previously a submenu now correctly renders as a standard clickable link.
6. Select a top-level link. Verify that you cannot insert a submenu block via the block appender or slash inserter.
7. Open the options dropdown (three dots) for a navigation link & verify that "Add submenu link" is disabled and displays a warning that the depth limit is reached.
## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After ("depth":1)|
|-|-|
|<img width="2938" height="1300" alt="image" src="https://github.com/user-attachments/assets/85056d11-2288-4779-ac64-0db0ea36b5d4" />|<img width="2940" height="1300" alt="image" src="https://github.com/user-attachments/assets/1b1f5671-a812-4651-bb3d-5488cbdcef68" />|
|<img width="564" height="1296" alt="image" src="https://github.com/user-attachments/assets/5b9ab4fa-ea3e-4e94-b12b-7f0436230b6c" />|<img width="558" height="1294" alt="image" src="https://github.com/user-attachments/assets/a8b37a51-ee70-4511-a2bb-10bd43b06bf3" />|
|<img width="974" height="646" alt="image" src="https://github.com/user-attachments/assets/2e308c38-2682-4042-acea-7bae08fc4e33" />|<img width="816" height="618" alt="image" src="https://github.com/user-attachments/assets/5929081b-a519-4138-8a52-f23dcac906f8" />|
